### PR TITLE
feat(digest): per-actor activity digest over the event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ kata search <query> [--limit N] [--include-deleted]
 kata ready [--limit N]
 kata events [--after N] [--limit N]
 kata events --tail [--last-event-id N]
+kata digest --since 24h [--until ...] [--project-id N | --all-projects]
+            [--actor NAME ...]
 kata projects list
 kata projects show <project>
 kata projects rename <project> <name>
@@ -228,6 +230,15 @@ kata projects merge <source> <target> [--rename-target NAME]
 kata export [--output PATH]
 kata import --input PATH --target PATH [--force]
 ```
+
+`kata digest` summarizes activity over a time window. It groups events by
+actor and lists per-issue actions (created, commented:N, closed:done,
+labeled:bug, unblocks:#7, ...) so you can see at a glance what each agent or
+person did overnight. `--since` accepts a duration (`24h`, `7d`) or an
+RFC3339 timestamp; `--until` defaults to now. The default scope is the
+current workspace's project; pass `--all-projects` for a cross-project
+digest, or `--project-id N` for an explicit one. `--actor` is repeatable to
+limit the report to one or more actors.
 
 Destructive operations are explicit:
 

--- a/cmd/kata/digest.go
+++ b/cmd/kata/digest.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/wesm/kata/internal/textsafe"
+)
+
+func newDigestCmd() *cobra.Command {
+	var (
+		sinceStr     string
+		untilStr     string
+		projectIDArg int64
+		allProjects  bool
+		actors       []string
+	)
+	cmd := &cobra.Command{
+		Use:   "digest",
+		Short: "summarize recent activity by actor (created / closed / commented / unblocked / ...)",
+		Long: `kata digest reads the event stream over a time window and prints a
+human-readable changelog grouped by actor. Use --since with a duration
+(e.g. 24h, 7d) or an RFC3339 timestamp; --until defaults to now.
+
+By default, digest is scoped to the current workspace's project. Use
+--project-id to scope to a specific project, or --all-projects for a
+cross-project digest.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if allProjects && projectIDArg != 0 {
+				return &cliError{
+					Message:  "--all-projects and --project-id are mutually exclusive",
+					Kind:     kindUsage,
+					ExitCode: ExitUsage,
+				}
+			}
+			if strings.TrimSpace(sinceStr) == "" {
+				return &cliError{
+					Message:  "--since is required (e.g. --since 24h)",
+					Kind:     kindUsage,
+					ExitCode: ExitUsage,
+				}
+			}
+			now := time.Now().UTC()
+			since, err := parseSinceUntil(sinceStr, now)
+			if err != nil {
+				return &cliError{Message: err.Error(), Kind: kindValidation, ExitCode: ExitValidation}
+			}
+			var until time.Time
+			if untilStr == "" {
+				until = now
+			} else {
+				until, err = parseSinceUntil(untilStr, now)
+				if err != nil {
+					return &cliError{Message: err.Error(), Kind: kindValidation, ExitCode: ExitValidation}
+				}
+			}
+			if !until.After(since) {
+				return &cliError{
+					Message:  "--until must be strictly after --since",
+					Kind:     kindValidation,
+					ExitCode: ExitValidation,
+				}
+			}
+
+			ctx := cmd.Context()
+			baseURL, err := ensureDaemon(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := httpClientFor(ctx, baseURL)
+			if err != nil {
+				return err
+			}
+			getURL, err := digestURL(ctx, baseURL, digestURLOpts{
+				ProjectIDArg: projectIDArg,
+				AllProjects:  allProjects,
+				Since:        since,
+				Until:        until,
+				Actors:       actors,
+			})
+			if err != nil {
+				return err
+			}
+			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, getURL, nil)
+			if err != nil {
+				return err
+			}
+			if status >= 400 {
+				return apiErrFromBody(status, bs)
+			}
+			if flags.JSON {
+				var buf bytes.Buffer
+				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
+					return err
+				}
+				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+				return err
+			}
+			return printDigestHuman(cmd, bs)
+		},
+	}
+	cmd.Flags().StringVar(&sinceStr, "since", "", "window start (duration like 24h or RFC3339)")
+	cmd.Flags().StringVar(&untilStr, "until", "", "window end (default: now)")
+	cmd.Flags().Int64Var(&projectIDArg, "project-id", 0, "scope to a specific project id")
+	cmd.Flags().BoolVar(&allProjects, "all-projects", false, "summarize all projects")
+	cmd.Flags().StringSliceVar(&actors, "actor", nil, "limit to one or more actors (repeatable)")
+	return cmd
+}
+
+// parseSinceUntil accepts either a Go duration (e.g. 24h, 30m, 7d) or an
+// RFC3339 timestamp. Durations are interpreted as "now minus duration"; the
+// "d" suffix is expanded to hours since Go's time.ParseDuration doesn't
+// support days natively.
+func parseSinceUntil(s string, now time.Time) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	expanded := s
+	if strings.HasSuffix(s, "d") {
+		num := strings.TrimSuffix(s, "d")
+		// Trust no integer-overflow wraparound here: a multi-year window is
+		// the user's call, and ParseDuration will reject pathological inputs
+		// (e.g. trailing "d" with non-numeric prefix).
+		expanded = num + "h"
+		if d, err := time.ParseDuration(expanded); err == nil {
+			return now.Add(-24 * d).UTC(), nil
+		}
+	}
+	d, err := time.ParseDuration(expanded)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid time spec %q: must be a duration (24h, 7d) or RFC3339 timestamp", s)
+	}
+	return now.Add(-d).UTC(), nil
+}
+
+type digestURLOpts struct {
+	ProjectIDArg int64
+	AllProjects  bool
+	Since        time.Time
+	Until        time.Time
+	Actors       []string
+}
+
+func digestURL(ctx context.Context, baseURL string, opts digestURLOpts) (string, error) {
+	q := url.Values{}
+	// RFC3339Nano (not plain RFC3339) so the daemon's millisecond-precision
+	// `created_at <= until` doesn't truncate the just-emitted event out of
+	// the window when --until defaults to "now".
+	q.Set("since", opts.Since.UTC().Format(time.RFC3339Nano))
+	q.Set("until", opts.Until.UTC().Format(time.RFC3339Nano))
+	for _, a := range opts.Actors {
+		q.Add("actor", a)
+	}
+	switch {
+	case opts.AllProjects:
+		return baseURL + "/api/v1/digest?" + q.Encode(), nil
+	case opts.ProjectIDArg != 0:
+		return fmt.Sprintf("%s/api/v1/projects/%d/digest?%s", baseURL, opts.ProjectIDArg, q.Encode()), nil
+	default:
+		start, err := resolveStartPath(flags.Workspace)
+		if err != nil {
+			return "", err
+		}
+		pid, err := resolveProjectID(ctx, baseURL, start)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s/api/v1/projects/%d/digest?%s", baseURL, pid, q.Encode()), nil
+	}
+}
+
+func printDigestHuman(cmd *cobra.Command, bs []byte) error {
+	var b struct {
+		Since      time.Time `json:"since"`
+		Until      time.Time `json:"until"`
+		EventCount int       `json:"event_count"`
+		ProjectID  int64     `json:"project_id"`
+		Totals     struct {
+			Created    int `json:"created"`
+			Closed     int `json:"closed"`
+			Reopened   int `json:"reopened"`
+			Commented  int `json:"commented"`
+			Edited     int `json:"edited"`
+			Assigned   int `json:"assigned"`
+			Unassigned int `json:"unassigned"`
+			Labeled    int `json:"labeled"`
+			Unlabeled  int `json:"unlabeled"`
+			Linked     int `json:"linked"`
+			Unlinked   int `json:"unlinked"`
+			Unblocked  int `json:"unblocked"`
+		} `json:"totals"`
+		Actors []struct {
+			Actor  string `json:"actor"`
+			Totals struct {
+				Created   int `json:"created"`
+				Closed    int `json:"closed"`
+				Reopened  int `json:"reopened"`
+				Commented int `json:"commented"`
+				Unblocked int `json:"unblocked"`
+			} `json:"totals"`
+			Issues []struct {
+				ProjectID       int64    `json:"project_id"`
+				ProjectIdentity string   `json:"project_identity"`
+				IssueNumber     int64    `json:"issue_number"`
+				Actions         []string `json:"actions"`
+			} `json:"issues"`
+		} `json:"actors"`
+	}
+	if err := json.Unmarshal(bs, &b); err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "digest %s → %s  (%d events)\n",
+		b.Since.Format(time.RFC3339), b.Until.Format(time.RFC3339), b.EventCount); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out,
+		"  totals: created=%d closed=%d reopened=%d commented=%d unblocked=%d\n",
+		b.Totals.Created, b.Totals.Closed, b.Totals.Reopened, b.Totals.Commented, b.Totals.Unblocked); err != nil {
+		return err
+	}
+	if len(b.Actors) == 0 {
+		_, err := fmt.Fprintln(out, "  (no activity)")
+		return err
+	}
+	for _, a := range b.Actors {
+		if _, err := fmt.Fprintf(out,
+			"\n%s — created=%d closed=%d reopened=%d commented=%d unblocked=%d\n",
+			textsafe.Line(a.Actor), a.Totals.Created, a.Totals.Closed,
+			a.Totals.Reopened, a.Totals.Commented, a.Totals.Unblocked); err != nil {
+			return err
+		}
+		for _, iss := range a.Issues {
+			prefix := fmt.Sprintf("#%d", iss.IssueNumber)
+			// On cross-project digests, prefix the project identity so the
+			// reader can disambiguate colliding numbers.
+			if b.ProjectID == 0 && iss.ProjectIdentity != "" {
+				prefix = fmt.Sprintf("%s#%d", textsafe.Line(iss.ProjectIdentity)+"/", iss.IssueNumber)
+			}
+			if _, err := fmt.Fprintf(out, "  %-12s %s\n",
+				prefix, textsafe.Line(strings.Join(iss.Actions, ", "))); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/kata/digest_test.go
+++ b/cmd/kata/digest_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/kata/internal/testenv"
+)
+
+func TestDigest_HumanRender(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	createIssue(t, env, pid, "first")
+	createIssue(t, env, pid, "second")
+
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--workspace", dir, "digest", "--since", "1h"})
+	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
+	require.NoError(t, cmd.Execute())
+	out := buf.String()
+	assert.Contains(t, out, "digest ")
+	assert.Contains(t, out, "created=2")
+	assert.Contains(t, out, "#1")
+	assert.Contains(t, out, "created")
+}
+
+func TestDigest_RejectsBadSince(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+	_ = resolvePIDViaHTTP(t, env.URL, dir)
+
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--workspace", dir, "digest", "--since", "blarg"})
+	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid time spec")
+}
+
+func TestDigest_ParseSinceUntil(t *testing.T) {
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+
+	got, err := parseSinceUntil("24h", now)
+	require.NoError(t, err)
+	assert.Equal(t, now.Add(-24*time.Hour), got)
+
+	got, err = parseSinceUntil("7d", now)
+	require.NoError(t, err)
+	assert.Equal(t, now.Add(-7*24*time.Hour), got)
+
+	got, err = parseSinceUntil("2026-05-01T00:00:00Z", now)
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), got)
+
+	_, err = parseSinceUntil("garbage", now)
+	require.Error(t, err)
+}

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -84,6 +84,7 @@ func newRootCmd() *cobra.Command {
 		newEventsCmd(),
 		newExportCmd(),
 		newImportCmd(),
+		newDigestCmd(),
 		newQuickstartCmd(),
 		newWhoamiCmd(),
 		newHealthCmd(),

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -434,6 +434,78 @@ type PurgeResponse struct {
 	}
 }
 
+// DigestRequest is GET /api/v1/digest (cross-project) and
+// /api/v1/projects/{project_id}/digest (per-project). Since/Until are
+// RFC3339 timestamps. Actor is a repeated query param: ?actor=alice&actor=bob.
+type DigestRequest struct {
+	Since  string   `query:"since" required:"true"`
+	Until  string   `query:"until,omitempty"`
+	Actors []string `query:"actor,omitempty"`
+}
+
+// DigestProjectRequest is the per-project variant. Only the path param differs.
+type DigestProjectRequest struct {
+	ProjectID int64    `path:"project_id" required:"true"`
+	Since     string   `query:"since" required:"true"`
+	Until     string   `query:"until,omitempty"`
+	Actors    []string `query:"actor,omitempty"`
+}
+
+// DigestTotals is the per-actor and grand-total breakdown of mutations the
+// digest understands. Categories that do not apply to a window are zero, not
+// omitted, so renderers can rely on the field set.
+type DigestTotals struct {
+	Created    int `json:"created"`
+	Closed     int `json:"closed"`
+	Reopened   int `json:"reopened"`
+	Commented  int `json:"commented"`
+	Edited     int `json:"edited"`
+	Assigned   int `json:"assigned"`
+	Unassigned int `json:"unassigned"`
+	Labeled    int `json:"labeled"`
+	Unlabeled  int `json:"unlabeled"`
+	Linked     int `json:"linked"`
+	Unlinked   int `json:"unlinked"`
+	Unblocked  int `json:"unblocked"`
+	Deleted    int `json:"deleted"`
+	Restored   int `json:"restored"`
+	Other      int `json:"other"`
+}
+
+// DigestIssueActions is the per-issue summary inside one actor's section.
+// Number/ProjectID identify the issue; Actions is a stable, ordered list of
+// human-readable action tokens (e.g. "created", "commented:2", "closed:done",
+// "labeled:bug", "unblocks #7"). The aggregator collapses repeated comments
+// into a count and joins the close reason / label name into the token so the
+// renderer can stay dumb.
+type DigestIssueActions struct {
+	ProjectID       int64    `json:"project_id"`
+	ProjectIdentity string   `json:"project_identity"`
+	IssueNumber     int64    `json:"issue_number"`
+	Actions         []string `json:"actions"`
+}
+
+// DigestActorEntry is one actor's slice of the digest. Issues is sorted by
+// issue number for stable rendering.
+type DigestActorEntry struct {
+	Actor  string               `json:"actor"`
+	Totals DigestTotals         `json:"totals"`
+	Issues []DigestIssueActions `json:"issues"`
+}
+
+// DigestResponse is the digest payload. ProjectID is 0 for cross-project
+// requests, otherwise the requested project. Actors is sorted by actor name.
+type DigestResponse struct {
+	Body struct {
+		Since      time.Time          `json:"since"`
+		Until      time.Time          `json:"until"`
+		ProjectID  int64              `json:"project_id"`
+		EventCount int                `json:"event_count"`
+		Totals     DigestTotals       `json:"totals"`
+		Actors     []DigestActorEntry `json:"actors"`
+	}
+}
+
 // SearchRequest is GET /api/v1/projects/{id}/search?q=...&limit=...&include_deleted=...
 type SearchRequest struct {
 	ProjectID      int64  `path:"project_id" required:"true"`

--- a/internal/daemon/handlers_digest.go
+++ b/internal/daemon/handlers_digest.go
@@ -1,0 +1,479 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/wesm/kata/internal/api"
+	"github.com/wesm/kata/internal/db"
+)
+
+func registerDigestHandlers(humaAPI huma.API, cfg ServerConfig) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "digestGlobal",
+		Method:      "GET",
+		Path:        "/api/v1/digest",
+	}, func(ctx context.Context, in *api.DigestRequest) (*api.DigestResponse, error) {
+		return doDigest(ctx, cfg, 0, in.Since, in.Until, in.Actors)
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "digestProject",
+		Method:      "GET",
+		Path:        "/api/v1/projects/{project_id}/digest",
+	}, func(ctx context.Context, in *api.DigestProjectRequest) (*api.DigestResponse, error) {
+		if in.ProjectID <= 0 {
+			return nil, api.NewError(400, "validation",
+				"project_id must be a positive integer", "", nil)
+		}
+		if _, err := cfg.DB.ProjectByID(ctx, in.ProjectID); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return nil, api.NewError(404, "project_not_found", "project not found", "", nil)
+			}
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		return doDigest(ctx, cfg, in.ProjectID, in.Since, in.Until, in.Actors)
+	})
+}
+
+// doDigest is the shared implementation for both digest endpoints.
+func doDigest(
+	ctx context.Context,
+	cfg ServerConfig,
+	projectID int64,
+	sinceStr, untilStr string,
+	actors []string,
+) (*api.DigestResponse, error) {
+	since, err := time.Parse(time.RFC3339, sinceStr)
+	if err != nil {
+		return nil, api.NewError(400, "validation",
+			"since must be an RFC3339 timestamp", "", nil)
+	}
+	var until time.Time
+	if untilStr == "" {
+		until = time.Now().UTC()
+	} else {
+		until, err = time.Parse(time.RFC3339, untilStr)
+		if err != nil {
+			return nil, api.NewError(400, "validation",
+				"until must be an RFC3339 timestamp", "", nil)
+		}
+	}
+	if !until.After(since) {
+		return nil, api.NewError(400, "validation",
+			"until must be strictly after since", "", nil)
+	}
+
+	rows, err := cfg.DB.EventsInWindow(ctx, db.EventsInWindowParams{
+		Since:     since.UTC().Format("2006-01-02T15:04:05.000Z"),
+		Until:     until.UTC().Format("2006-01-02T15:04:05.000Z"),
+		ProjectID: projectID,
+		Actors:    actors,
+	})
+	if err != nil {
+		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+
+	out := &api.DigestResponse{}
+	out.Body.Since = since.UTC()
+	out.Body.Until = until.UTC()
+	out.Body.ProjectID = projectID
+	out.Body.EventCount = len(rows)
+	out.Body.Totals, out.Body.Actors = aggregateDigest(rows)
+	return out, nil
+}
+
+// issueKey identifies an issue across projects in the digest aggregator. We
+// can't key on issue_number alone because cross-project digests can have
+// colliding numbers, and a (project_id, issue_number) pair is enough to
+// disambiguate without resolving the canonical issues.id.
+type issueKey struct {
+	ProjectID int64
+	Number    int64
+}
+
+// issueAccum tracks the per-(actor,issue) action sequence. We collapse repeats
+// (comments especially) to "verb:N" tokens so the human renderer doesn't
+// drown in duplicate lines for chatty agents.
+type issueAccum struct {
+	ProjectIdentity string
+	Created         bool
+	CloseReason     string // empty if not closed in window
+	Reopened        bool
+	Edited          bool
+	CommentCount    int
+	AssignedTo      string // last value wins
+	Unassigned      bool
+	LabelsAdded     []string
+	LabelsRemoved   []string
+	Linked          []string // formatted "type:#N"
+	Unlinked        []string
+	UnblocksOthers  []int64 // issue numbers this actor unblocked
+	Deleted         bool
+	Restored        bool
+	Other           int
+}
+
+// aggregateDigest folds an ordered slice of events into the digest grand
+// totals and per-actor sections.
+func aggregateDigest(rows []db.Event) (api.DigestTotals, []api.DigestActorEntry) {
+	type actorState struct {
+		totals api.DigestTotals
+		issues map[issueKey]*issueAccum
+	}
+	byActor := map[string]*actorState{}
+	var grand api.DigestTotals
+
+	for _, e := range rows {
+		st, ok := byActor[e.Actor]
+		if !ok {
+			st = &actorState{issues: map[issueKey]*issueAccum{}}
+			byActor[e.Actor] = st
+		}
+		// Some event types have no associated issue (none today, but be defensive).
+		var key issueKey
+		var acc *issueAccum
+		if e.IssueNumber != nil {
+			key = issueKey{ProjectID: e.ProjectID, Number: *e.IssueNumber}
+			a, ok := st.issues[key]
+			if !ok {
+				a = &issueAccum{ProjectIdentity: e.ProjectIdentity}
+				st.issues[key] = a
+			}
+			acc = a
+		}
+		applyEvent(e, &st.totals, &grand, acc)
+	}
+
+	// Cross-actor enrichment: for every issue.unlinked of type=blocks the
+	// blocker side gets credit for an "unblocks #blocked" action. The
+	// aggregator stores this on the actor who emitted the unlink event.
+	// (No additional pass needed — already handled in applyEvent.)
+
+	out := make([]api.DigestActorEntry, 0, len(byActor))
+	for actor, st := range byActor {
+		entry := api.DigestActorEntry{
+			Actor:  actor,
+			Totals: st.totals,
+		}
+		entry.Issues = renderIssueAccums(st.issues)
+		out = append(out, entry)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Actor < out[j].Actor })
+	return grand, out
+}
+
+// applyEvent classifies a single event and updates totals + per-issue state.
+// totals and grand are both bumped (per-actor and overall).
+func applyEvent(e db.Event, totals, grand *api.DigestTotals, acc *issueAccum) {
+	switch e.Type {
+	case "issue.created":
+		bump(&totals.Created, &grand.Created)
+		if acc != nil {
+			acc.Created = true
+		}
+		// CreateIssue folds initial labels/owner/links into the same payload
+		// rather than emitting separate issue.labeled/assigned/linked events,
+		// so the digest must mine them out here or it undercounts common
+		// create-time activity (e.g. `kata create --label bug --owner alice`).
+		labels, owner, links := createdInitialState(e.Payload)
+		for _, l := range labels {
+			bump(&totals.Labeled, &grand.Labeled)
+			if acc != nil {
+				acc.LabelsAdded = append(acc.LabelsAdded, l)
+			}
+		}
+		if owner != "" {
+			bump(&totals.Assigned, &grand.Assigned)
+			if acc != nil {
+				acc.AssignedTo = owner
+			}
+		}
+		for _, lk := range links {
+			bump(&totals.Linked, &grand.Linked)
+			if acc != nil && lk.Type != "" {
+				acc.Linked = append(acc.Linked, fmt.Sprintf("%s:#%d", lk.Type, lk.ToNumber))
+			}
+		}
+	case "issue.closed":
+		bump(&totals.Closed, &grand.Closed)
+		if acc != nil {
+			acc.CloseReason = closeReasonOf(e.Payload)
+			if acc.CloseReason == "" {
+				acc.CloseReason = "done"
+			}
+		}
+	case "issue.reopened":
+		bump(&totals.Reopened, &grand.Reopened)
+		if acc != nil {
+			acc.Reopened = true
+		}
+	case "issue.commented":
+		bump(&totals.Commented, &grand.Commented)
+		if acc != nil {
+			acc.CommentCount++
+		}
+	case "issue.updated":
+		bump(&totals.Edited, &grand.Edited)
+		if acc != nil {
+			acc.Edited = true
+		}
+	case "issue.assigned":
+		bump(&totals.Assigned, &grand.Assigned)
+		if acc != nil {
+			acc.AssignedTo = ownerOf(e.Payload)
+		}
+	case "issue.unassigned":
+		bump(&totals.Unassigned, &grand.Unassigned)
+		if acc != nil {
+			acc.Unassigned = true
+		}
+	case "issue.labeled":
+		bump(&totals.Labeled, &grand.Labeled)
+		if acc != nil {
+			if l := labelOf(e.Payload); l != "" {
+				acc.LabelsAdded = append(acc.LabelsAdded, l)
+			}
+		}
+	case "issue.unlabeled":
+		bump(&totals.Unlabeled, &grand.Unlabeled)
+		if acc != nil {
+			if l := labelOf(e.Payload); l != "" {
+				acc.LabelsRemoved = append(acc.LabelsRemoved, l)
+			}
+		}
+	case "issue.linked":
+		bump(&totals.Linked, &grand.Linked)
+		if acc != nil {
+			if t, to := linkSummary(e.Payload); t != "" {
+				acc.Linked = append(acc.Linked, fmt.Sprintf("%s:#%d", t, to))
+			}
+		}
+	case "issue.unlinked":
+		bump(&totals.Unlinked, &grand.Unlinked)
+		t, to := linkSummary(e.Payload)
+		if acc != nil && t != "" {
+			acc.Unlinked = append(acc.Unlinked, fmt.Sprintf("%s:#%d", t, to))
+		}
+		// "blocked-on-X resolved": when the blocker side explicitly removes
+		// the blocks edge, credit them with unblocking the other issue. The
+		// link payload uses from_number = the URL-issue (the side calling
+		// `kata unblock <blocker> <blocked>` posts on the blocker), so the
+		// to_number is the issue that becomes unblocked.
+		if t == "blocks" && acc != nil && to > 0 {
+			acc.UnblocksOthers = append(acc.UnblocksOthers, to)
+			bump(&totals.Unblocked, &grand.Unblocked)
+		}
+	case "issue.soft_deleted":
+		bump(&totals.Deleted, &grand.Deleted)
+		if acc != nil {
+			acc.Deleted = true
+		}
+	case "issue.restored":
+		bump(&totals.Restored, &grand.Restored)
+		if acc != nil {
+			acc.Restored = true
+		}
+	default:
+		bump(&totals.Other, &grand.Other)
+		if acc != nil {
+			acc.Other++
+		}
+	}
+}
+
+func bump(local, grand *int) { *local++; *grand++ }
+
+// closeReasonOf extracts the close reason from an issue.closed payload.
+// Returns "" on parse failure so the caller can default to "done".
+func closeReasonOf(payload string) string {
+	if payload == "" {
+		return ""
+	}
+	var p struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(payload), &p); err != nil {
+		return ""
+	}
+	return p.Reason
+}
+
+func ownerOf(payload string) string {
+	if payload == "" {
+		return ""
+	}
+	var p struct {
+		Owner string `json:"owner"`
+	}
+	if err := json.Unmarshal([]byte(payload), &p); err != nil {
+		return ""
+	}
+	return p.Owner
+}
+
+func labelOf(payload string) string {
+	if payload == "" {
+		return ""
+	}
+	var p struct {
+		Label string `json:"label"`
+	}
+	if err := json.Unmarshal([]byte(payload), &p); err != nil {
+		return ""
+	}
+	return p.Label
+}
+
+// createdInitialState mines an issue.created payload for any initial labels,
+// owner, and links that CreateIssue folds in instead of emitting separate
+// issue.labeled/assigned/linked events. Returns zero values on parse failure
+// so the caller treats malformed payloads as "no extras" rather than crashing.
+func createdInitialState(payload string) ([]string, string, []createdLink) {
+	if payload == "" {
+		return nil, "", nil
+	}
+	var p struct {
+		Labels []string      `json:"labels"`
+		Owner  string        `json:"owner"`
+		Links  []createdLink `json:"links"`
+	}
+	if err := json.Unmarshal([]byte(payload), &p); err != nil {
+		return nil, "", nil
+	}
+	return p.Labels, p.Owner, p.Links
+}
+
+type createdLink struct {
+	Type     string `json:"type"`
+	ToNumber int64  `json:"to_number"`
+}
+
+func linkSummary(payload string) (string, int64) {
+	if payload == "" {
+		return "", 0
+	}
+	var p struct {
+		Type     string `json:"type"`
+		ToNumber int64  `json:"to_number"`
+	}
+	if err := json.Unmarshal([]byte(payload), &p); err != nil {
+		return "", 0
+	}
+	return p.Type, p.ToNumber
+}
+
+// renderIssueAccums turns the per-issue accumulators into the wire shape:
+// one DigestIssueActions per issue with a stable, ordered list of action
+// tokens. Issues are sorted by (project_id, number).
+func renderIssueAccums(m map[issueKey]*issueAccum) []api.DigestIssueActions {
+	keys := make([]issueKey, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].ProjectID != keys[j].ProjectID {
+			return keys[i].ProjectID < keys[j].ProjectID
+		}
+		return keys[i].Number < keys[j].Number
+	})
+	out := make([]api.DigestIssueActions, 0, len(keys))
+	for _, k := range keys {
+		acc := m[k]
+		out = append(out, api.DigestIssueActions{
+			ProjectID:       k.ProjectID,
+			ProjectIdentity: acc.ProjectIdentity,
+			IssueNumber:     k.Number,
+			Actions:         renderActions(acc),
+		})
+	}
+	return out
+}
+
+// renderActions emits action tokens in canonical order — created first
+// (creation context), then comment count, edits, ownership, labels, links,
+// state changes (closed/reopened), and finally lifecycle (deleted/restored).
+// The fixed order keeps the human renderer deterministic and avoids surfacing
+// "closed" before "created" when both happen in the same window.
+func renderActions(acc *issueAccum) []string {
+	var actions []string
+	if acc.Created {
+		actions = append(actions, "created")
+	}
+	if acc.CommentCount == 1 {
+		actions = append(actions, "commented")
+	} else if acc.CommentCount > 1 {
+		actions = append(actions, fmt.Sprintf("commented:%d", acc.CommentCount))
+	}
+	if acc.Edited {
+		actions = append(actions, "edited")
+	}
+	if acc.AssignedTo != "" {
+		actions = append(actions, "assigned:"+acc.AssignedTo)
+	}
+	if acc.Unassigned {
+		actions = append(actions, "unassigned")
+	}
+	for _, l := range acc.LabelsAdded {
+		actions = append(actions, "labeled:"+l)
+	}
+	for _, l := range acc.LabelsRemoved {
+		actions = append(actions, "unlabeled:"+l)
+	}
+	actions = append(actions, acc.Linked...)
+	for _, u := range acc.Unlinked {
+		actions = append(actions, "un"+u)
+	}
+	for _, n := range acc.UnblocksOthers {
+		actions = append(actions, fmt.Sprintf("unblocks:#%d", n))
+	}
+	if acc.Reopened {
+		actions = append(actions, "reopened")
+	}
+	if acc.CloseReason != "" {
+		actions = append(actions, "closed:"+acc.CloseReason)
+	}
+	if acc.Deleted {
+		actions = append(actions, "deleted")
+	}
+	if acc.Restored {
+		actions = append(actions, "restored")
+	}
+	if acc.Other > 0 {
+		actions = append(actions, fmt.Sprintf("other:%d", acc.Other))
+	}
+	// Empty action list shouldn't really happen, but be defensive: an issue
+	// with only "issue.foo"-style unknown events would otherwise render as
+	// an empty bullet. Drop the trailing empty.
+	if len(actions) == 0 {
+		actions = []string{"-"}
+	}
+	return dedupe(actions)
+}
+
+// dedupe drops adjacent duplicates while preserving order. We get duplicates
+// when, e.g., the same label is added and removed twice — surfacing the dupes
+// is noise; collapsing them keeps the report scannable.
+func dedupe(in []string) []string {
+	if len(in) <= 1 {
+		return in
+	}
+	out := make([]string, 0, len(in))
+	seen := map[string]bool{}
+	for _, s := range in {
+		key := strings.ToLower(s)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/daemon/handlers_digest_test.go
+++ b/internal/daemon/handlers_digest_test.go
@@ -1,0 +1,391 @@
+package daemon_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/kata/internal/testenv"
+)
+
+// TestDigest_AggregatesByActor exercises the end-to-end digest path: two
+// actors create, comment, label, close, and explicitly unblock issues; the
+// digest then surfaces per-actor totals and per-issue action sequences.
+func TestDigest_AggregatesByActor(t *testing.T) {
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+
+	// Alice creates two issues, comments on the first twice, closes it.
+	a := createIssueAs(t, env, pid, "alice", "first")
+	_ = createIssueAs(t, env, pid, "alice", "second")
+	postCommentAs(t, env, pid, a, "alice", "looking now")
+	postCommentAs(t, env, pid, a, "alice", "found a repro")
+	closeIssueAs(t, env, pid, a, "alice", "done")
+
+	// Bob creates an issue, labels it, then bob blocks-his-own-issue with
+	// alice's first issue, then unblocks (the unlink credits bob with
+	// "unblocks").
+	b := createIssueAs(t, env, pid, "bob", "third")
+	postLabelAs(t, env, pid, b, "bob", "bug")
+	postLinkAs(t, env, pid, a, "bob", "blocks", b) // a blocks b
+	deleteLinkBlocksAs(t, env, pid, a, "bob", b)   // bob unblocks b
+
+	since := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	until := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	digestURL := env.URL +
+		"/api/v1/projects/" + strconv.FormatInt(pid, 10) +
+		"/digest?since=" + url.QueryEscape(since) + "&until=" + url.QueryEscape(until)
+
+	resp, err := env.HTTP.Get(digestURL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, 200, resp.StatusCode)
+
+	var body struct {
+		EventCount int   `json:"event_count"`
+		ProjectID  int64 `json:"project_id"`
+		Totals     struct {
+			Created   int `json:"created"`
+			Closed    int `json:"closed"`
+			Commented int `json:"commented"`
+			Labeled   int `json:"labeled"`
+			Linked    int `json:"linked"`
+			Unlinked  int `json:"unlinked"`
+			Unblocked int `json:"unblocked"`
+		} `json:"totals"`
+		Actors []struct {
+			Actor  string `json:"actor"`
+			Totals struct {
+				Created   int `json:"created"`
+				Closed    int `json:"closed"`
+				Commented int `json:"commented"`
+				Unblocked int `json:"unblocked"`
+			} `json:"totals"`
+			Issues []struct {
+				IssueNumber int64    `json:"issue_number"`
+				Actions     []string `json:"actions"`
+			} `json:"issues"`
+		} `json:"actors"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	assert.Equal(t, pid, body.ProjectID)
+	assert.GreaterOrEqual(t, body.EventCount, 9)
+	assert.Equal(t, 3, body.Totals.Created)
+	assert.Equal(t, 1, body.Totals.Closed)
+	assert.Equal(t, 2, body.Totals.Commented)
+	assert.Equal(t, 1, body.Totals.Labeled)
+	assert.Equal(t, 1, body.Totals.Linked)
+	assert.Equal(t, 1, body.Totals.Unlinked)
+	assert.Equal(t, 1, body.Totals.Unblocked, "unlink of type=blocks should bump unblocked")
+
+	// Actors are sorted alphabetically.
+	require.Len(t, body.Actors, 2)
+	assert.Equal(t, "alice", body.Actors[0].Actor)
+	assert.Equal(t, "bob", body.Actors[1].Actor)
+	assert.Equal(t, 2, body.Actors[0].Totals.Created)
+	assert.Equal(t, 1, body.Actors[0].Totals.Closed)
+	assert.Equal(t, 2, body.Actors[0].Totals.Commented)
+	assert.Equal(t, 1, body.Actors[1].Totals.Unblocked)
+
+	// Alice's first issue should show created → commented:2 → closed:done in
+	// that canonical order.
+	var aliceFirst []string
+	for _, iss := range body.Actors[0].Issues {
+		if iss.IssueNumber == a {
+			aliceFirst = iss.Actions
+			break
+		}
+	}
+	require.NotNil(t, aliceFirst)
+	assert.Equal(t, []string{"created", "commented:2", "closed:done"}, aliceFirst)
+
+	// Bob's actions on issue b should include the labeled token and the
+	// unblocks-credit referencing issue b.
+	var bobOnB []string
+	for _, iss := range body.Actors[1].Issues {
+		if iss.IssueNumber == b {
+			bobOnB = iss.Actions
+			break
+		}
+	}
+	require.NotNil(t, bobOnB)
+	assert.Contains(t, bobOnB, "labeled:bug")
+}
+
+// TestDigest_ActorFilter only returns events for the named actors.
+func TestDigest_ActorFilter(t *testing.T) {
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	_ = createIssueAs(t, env, pid, "alice", "x")
+	_ = createIssueAs(t, env, pid, "bob", "y")
+
+	since := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	resp, err := env.HTTP.Get(env.URL +
+		"/api/v1/projects/" + strconv.FormatInt(pid, 10) +
+		"/digest?since=" + url.QueryEscape(since) + "&actor=alice")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, 200, resp.StatusCode)
+
+	var body struct {
+		Actors []struct {
+			Actor string `json:"actor"`
+		} `json:"actors"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	require.Len(t, body.Actors, 1)
+	assert.Equal(t, "alice", body.Actors[0].Actor)
+}
+
+// TestDigest_CountsCreateTimeLabelsOwnerLinks ensures that initial labels,
+// owner, and links supplied at issue creation are folded into digest totals
+// and per-issue actions. CreateIssue does not emit separate
+// issue.labeled/assigned/linked events for create-time state — without payload
+// mining the digest would silently undercount common `kata create --label
+// bug --owner alice --blocks 7` activity.
+func TestDigest_CountsCreateTimeLabelsOwnerLinks(t *testing.T) {
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+
+	// Seed a target issue alice's later issue can block.
+	target := createIssueAs(t, env, pid, "alice", "target")
+
+	// Alice creates a richer issue with a label, an owner, and a blocks link.
+	body, _ := json.Marshal(map[string]any{
+		"actor":  "alice",
+		"title":  "rich",
+		"labels": []string{"bug"},
+		"owner":  "bob",
+		"links": []map[string]any{
+			{"type": "blocks", "to_number": target},
+		},
+	})
+	resp, err := env.HTTP.Post(
+		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
+		"application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, 200, resp.StatusCode)
+	var created struct {
+		Issue struct {
+			Number int64 `json:"number"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	rich := created.Issue.Number
+
+	since := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	until := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	dresp, err := env.HTTP.Get(env.URL +
+		"/api/v1/projects/" + strconv.FormatInt(pid, 10) +
+		"/digest?since=" + url.QueryEscape(since) + "&until=" + url.QueryEscape(until))
+	require.NoError(t, err)
+	defer func() { _ = dresp.Body.Close() }()
+	require.Equal(t, 200, dresp.StatusCode)
+
+	var digest struct {
+		Totals struct {
+			Created  int `json:"created"`
+			Labeled  int `json:"labeled"`
+			Assigned int `json:"assigned"`
+			Linked   int `json:"linked"`
+		} `json:"totals"`
+		Actors []struct {
+			Actor  string `json:"actor"`
+			Totals struct {
+				Created  int `json:"created"`
+				Labeled  int `json:"labeled"`
+				Assigned int `json:"assigned"`
+				Linked   int `json:"linked"`
+			} `json:"totals"`
+			Issues []struct {
+				IssueNumber int64    `json:"issue_number"`
+				Actions     []string `json:"actions"`
+			} `json:"issues"`
+		} `json:"actors"`
+	}
+	require.NoError(t, json.NewDecoder(dresp.Body).Decode(&digest))
+
+	// Two issues created total. The richer one bumps labeled / assigned /
+	// linked even though no separate events were emitted for them.
+	assert.Equal(t, 2, digest.Totals.Created)
+	assert.Equal(t, 1, digest.Totals.Labeled, "create-time label must fold into digest totals")
+	assert.Equal(t, 1, digest.Totals.Assigned, "create-time owner must fold into digest totals")
+	assert.Equal(t, 1, digest.Totals.Linked, "create-time link must fold into digest totals")
+
+	require.Len(t, digest.Actors, 1)
+	assert.Equal(t, "alice", digest.Actors[0].Actor)
+	assert.Equal(t, 1, digest.Actors[0].Totals.Labeled)
+	assert.Equal(t, 1, digest.Actors[0].Totals.Assigned)
+	assert.Equal(t, 1, digest.Actors[0].Totals.Linked)
+
+	var actions []string
+	for _, iss := range digest.Actors[0].Issues {
+		if iss.IssueNumber == rich {
+			actions = iss.Actions
+			break
+		}
+	}
+	require.NotNil(t, actions, "rich issue not present in alice's per-issue digest")
+	assert.Contains(t, actions, "created")
+	assert.Contains(t, actions, "labeled:bug")
+	assert.Contains(t, actions, "assigned:bob")
+	assert.Contains(t, actions, "blocks:#"+strconv.FormatInt(target, 10))
+}
+
+// TestDigest_RejectsBadSince validates the since parameter.
+func TestDigest_RejectsBadSince(t *testing.T) {
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	resp, err := env.HTTP.Get(env.URL +
+		"/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/digest?since=not-a-time")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, 400, resp.StatusCode)
+}
+
+// TestDigest_GlobalEndpoint covers the cross-project route.
+func TestDigest_GlobalEndpoint(t *testing.T) {
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	_ = createIssueAs(t, env, pid, "alice", "x")
+
+	since := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	resp, err := env.HTTP.Get(env.URL + "/api/v1/digest?since=" + url.QueryEscape(since))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, 200, resp.StatusCode)
+
+	var body struct {
+		ProjectID int64 `json:"project_id"`
+		Totals    struct {
+			Created int `json:"created"`
+		} `json:"totals"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, int64(0), body.ProjectID, "global digest reports project_id=0")
+	assert.GreaterOrEqual(t, body.Totals.Created, 1)
+}
+
+// --- helpers below are local to digest tests; they parallel the ones in
+// handlers_links_test.go but accept an explicit actor so cross-actor scenarios
+// can be set up. ---
+
+func createIssueAs(t *testing.T, env *testenv.Env, pid int64, actor, title string) int64 {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"actor": actor, "title": title})
+	resp, err := env.HTTP.Post(
+		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
+		"application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, 200, resp.StatusCode)
+	var out struct {
+		Issue struct {
+			Number int64 `json:"number"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	return out.Issue.Number
+}
+
+func postCommentAs(t *testing.T, env *testenv.Env, pid, num int64, actor, txt string) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"actor": actor, "body": txt})
+	resp, err := env.HTTP.Post(
+		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
+			"/issues/"+strconv.FormatInt(num, 10)+"/comments",
+		"application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+}
+
+func closeIssueAs(t *testing.T, env *testenv.Env, pid, num int64, actor, reason string) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"actor": actor, "reason": reason})
+	resp, err := env.HTTP.Post(
+		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
+			"/issues/"+strconv.FormatInt(num, 10)+"/actions/close",
+		"application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+}
+
+func postLabelAs(t *testing.T, env *testenv.Env, pid, num int64, actor, label string) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"actor": actor, "label": label})
+	resp, err := env.HTTP.Post(
+		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
+			"/issues/"+strconv.FormatInt(num, 10)+"/labels",
+		"application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+}
+
+func postLinkAs(t *testing.T, env *testenv.Env, pid, fromNum int64, actor, linkType string, toNum int64) int64 {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"actor": actor, "type": linkType, "to_number": toNum,
+	})
+	resp, err := env.HTTP.Post(
+		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
+			"/issues/"+strconv.FormatInt(fromNum, 10)+"/links",
+		"application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equalf(t, 200, resp.StatusCode, "postLinkAs status")
+	var out struct {
+		Link struct {
+			ID int64 `json:"id"`
+		} `json:"link"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	return out.Link.ID
+}
+
+// deleteLinkBlocksAs removes a blocks link by re-creating it just to read its
+// id, then DELETEs it. The DELETE attribution is to `actor`, which is the
+// person who gets credit for the unblock.
+func deleteLinkBlocksAs(t *testing.T, env *testenv.Env, pid, fromNum int64, actor string, toNum int64) {
+	t.Helper()
+	// Look up the existing link id by reading the blocker's links list. The
+	// daemon doesn't expose a /links GET, so we rely on the issue show
+	// payload, which includes Links with their ids.
+	resp, err := env.HTTP.Get(env.URL + "/api/v1/projects/" +
+		strconv.FormatInt(pid, 10) + "/issues/" + strconv.FormatInt(fromNum, 10))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	var view struct {
+		Links []struct {
+			ID       int64  `json:"id"`
+			Type     string `json:"type"`
+			ToNumber int64  `json:"to_number"`
+		} `json:"links"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&view))
+	var linkID int64
+	for _, l := range view.Links {
+		if l.Type == "blocks" && l.ToNumber == toNum {
+			linkID = l.ID
+			break
+		}
+	}
+	require.NotZero(t, linkID, "no blocks link to %d found on issue %d", toNum, fromNum)
+
+	delURL := env.URL + "/api/v1/projects/" + strconv.FormatInt(pid, 10) +
+		"/issues/" + strconv.FormatInt(fromNum, 10) + "/links/" +
+		strconv.FormatInt(linkID, 10) + "?actor=" + url.QueryEscape(actor)
+	req, err := http.NewRequest(http.MethodDelete, delURL, nil)
+	require.NoError(t, err)
+	dresp, err := env.HTTP.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, dresp.Body.Close())
+	require.Equal(t, 200, dresp.StatusCode)
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -163,6 +163,7 @@ func registerRoutes(humaAPI huma.API, mux *http.ServeMux, cfg ServerConfig) {
 	registerSearch(humaAPI, cfg)
 	registerDestructive(humaAPI, cfg)
 	registerEventsHandlers(humaAPI, mux, cfg)
+	registerDigestHandlers(humaAPI, cfg)
 }
 
 // registerHealth registers /api/v1/ping and /api/v1/health.

--- a/internal/db/queries_events.go
+++ b/internal/db/queries_events.go
@@ -73,6 +73,68 @@ func (d *DB) EventsAfter(ctx context.Context, p EventsAfterParams) ([]Event, err
 	return out, rows.Err()
 }
 
+// EventsInWindowParams selects events whose created_at lies in the closed
+// window [Since, Until]. ProjectID = 0 disables the project filter; an empty
+// Actors slice disables actor filtering. Results are ordered by id ASC so the
+// digest aggregator can rely on chronological ordering for per-issue
+// "actions" sequencing.
+//
+// Both bounds are inclusive. SQLite stores created_at at millisecond
+// precision; an exclusive upper bound silently excludes events emitted in the
+// same millisecond as Until, which happens often when Until defaults to
+// time.Now() right after a mutation. Inclusive matches what humans typing
+// "since 24h" expect anyway.
+type EventsInWindowParams struct {
+	Since     string // string, inclusive lower bound on created_at
+	Until     string // string, inclusive upper bound on created_at
+	ProjectID int64  // 0 = cross-project
+	Actors    []string
+}
+
+// EventsInWindow returns every event in the requested window. There is no row
+// cap: digest is a one-shot read and the caller has already chosen a finite
+// window. Callers are expected to pass a sane window (typically <= 7 days).
+func (d *DB) EventsInWindow(ctx context.Context, p EventsInWindowParams) ([]Event, error) {
+	var (
+		conds []string
+		args  []any
+	)
+	conds = append(conds, "created_at >= ?")
+	args = append(args, p.Since)
+	conds = append(conds, "created_at <= ?")
+	args = append(args, p.Until)
+	if p.ProjectID != 0 {
+		conds = append(conds, "project_id = ?")
+		args = append(args, p.ProjectID)
+	}
+	if len(p.Actors) > 0 {
+		placeholders := make([]string, len(p.Actors))
+		for i, a := range p.Actors {
+			placeholders[i] = "?"
+			args = append(args, a)
+		}
+		conds = append(conds, "actor IN ("+strings.Join(placeholders, ",")+")")
+	}
+	q := `SELECT id, project_id, project_identity, issue_id, issue_number, related_issue_id,
+	             type, actor, payload, created_at
+	      FROM events WHERE ` + strings.Join(conds, " AND ") + ` ORDER BY id ASC`
+	rows, err := d.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("events in window: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Event
+	for rows.Next() {
+		var e Event
+		if err := rows.Scan(&e.ID, &e.ProjectID, &e.ProjectIdentity, &e.IssueID,
+			&e.IssueNumber, &e.RelatedIssueID, &e.Type, &e.Actor, &e.Payload, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan event: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 // PurgeResetCheck returns the maximum purge_reset_after_event_id strictly
 // greater than afterID, optionally constrained to a project. Returns 0 when
 // no matching purge_log row exists. The strict > semantics align with the


### PR DESCRIPTION
## Summary

Adds `kata digest --since 24h [--until ...] [--project-id N | --all-projects] [--actor NAME ...] [--json]`, a pure-read summary of the event stream grouped by actor, with per-issue action sequences (`created`, `commented:2`, `closed:done`, `labeled:bug`, `unblocks:#7`, ...). Backed by two new daemon endpoints — `GET /api/v1/digest` (cross-project) and `GET /api/v1/projects/{id}/digest`. No schema changes.

The intent is the natural human-oversight artifact for an agent-driven workflow: "what did each actor do overnight." The aggregator walks `events` in `[since, until]`, classifies each row by `type`, and folds `issue.created` payloads (initial labels / owner / links) into per-actor totals so common `kata create --label bug --owner alice --blocks 7` activity isn't undercounted.

### What's new

- **CLI** (`cmd/kata/digest.go`): duration parser accepts Go durations, RFC3339, and `7d`-style day shorthand. Human renderer prefixes `project_identity/#N` in cross-project mode; JSON renderer emits the standard `kata_api_version` envelope.
- **Daemon** (`internal/daemon/handlers_digest.go`): aggregator classifies all current event types (created/closed/reopened/commented/edited/assigned/unassigned/labeled/unlabeled/linked/unlinked/soft_deleted/restored) plus a derived `unblocks:#N` token for explicit `issue.unlinked` of type=blocks. Token order is canonical (creation → comments → edits → ownership → labels → links → state → lifecycle) so renderers stay dumb.
- **DB** (`internal/db/queries_events.go`): `EventsInWindow` with project + actor filters. **Inclusive** upper bound — see Notes.
- **API types** (`internal/api/types.go`): `DigestRequest`, `DigestProjectRequest`, `DigestResponse`, `DigestTotals`, `DigestActorEntry`, `DigestIssueActions`.
- **Docs**: README "Search, readiness, events, and project inspection" section now documents the command.

### Notes

- `events.created_at` is stored at SQLite ms precision via `strftime('%Y-%m-%dT%H:%M:%fZ','now')`. An exclusive upper bound (`<`) at `time.Now()` silently drops events emitted in the same millisecond as the default `until`, so the window is closed on both ends. The CLI also formats with `time.RFC3339Nano` (not plain `RFC3339`) so second-precision rounding doesn't elide events on the fast path.
- "blocked-on-X resolved" is implemented narrowly: explicit `kata unblock` (= `issue.unlinked` of type=blocks) credits the actor with `unblocks:#N`. The richer interpretation (closing a blocker auto-credits unblock for downstream issues) was left out — would require joining the live `links` table at digest time and is easy to add later if useful.
- Status is "early public preview" so the new endpoints don't promise stability beyond the rest of the API surface.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/daemon/... -run TestDigest` (4 daemon integration tests: per-actor aggregation, actor filter, bad-since validation, cross-project endpoint, create-payload mining)
- [x] `go test ./cmd/kata/... -run TestDigest` (3 CLI tests including `parseSinceUntil` unit coverage)
- [x] `go test ./...` — all packages green except the pre-existing `TestCreate_RejectsWhitespaceLabel` flake which fails on `main` too (depends on host daemon having `github.com/wesm/kata` registered)
- [x] Smoke-tested against a live daemon (`kata digest --all-projects --since 720h`, `--json`, `--project-id N`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)