### PR TITLE
version: prefix VCS build revisions with g

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -45,6 +45,7 @@ func versionFromVCS() string {
 	if len(rev) > shortHashLen {
 		rev = rev[:shortHashLen]
 	}
+	rev = "g" + rev
 	if dirty {
 		rev += dirtySuffix
 	}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,35 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionFromVCSPrefixesShortRevisionWithG(t *testing.T) {
+	origReadBuildInfo := readBuildInfo
+	defer func() { readBuildInfo = origReadBuildInfo }()
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Settings: []debug.BuildSetting{
+			{Key: settingRevision, Value: "1697674abcdef"},
+		}}, true
+	}
+
+	assert.Equal(t, "g1697674", versionFromVCS())
+}
+
+func TestVersionFromVCSPrefixesDirtyRevisionWithG(t *testing.T) {
+	origReadBuildInfo := readBuildInfo
+	defer func() { readBuildInfo = origReadBuildInfo }()
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Settings: []debug.BuildSetting{
+			{Key: settingRevision, Value: "1697674abcdef"},
+			{Key: settingModified, Value: "true"},
+		}}, true
+	}
+
+	assert.Equal(t, "g1697674-dirty", versionFromVCS())
+}


### PR DESCRIPTION
## Summary
- prefix VCS-derived short revisions with `g` so numeric hashes read as git hashes in the TUI chrome
- preserve stamped release versions and dirty suffix behavior
- add focused coverage for clean and dirty VCS metadata

## Validation
- `go test ./internal/version`
- `go test ./internal/version ./internal/tui ./cmd/kata`