### PR TITLE
test: consolidate test fixtures and helpers across packages

### DIFF
--- a/cmd/kata/assign_test.go
+++ b/cmd/kata/assign_test.go
@@ -1,38 +1,19 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestAssign_RoundTrip(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
-	createIssue(t, env, pid, "x")
+	env, dir, _ := setupWorkspaceWithIssue(t, "x")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "assign", "1", "alice"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.True(t, strings.Contains(buf.String(), "assigned") ||
-		strings.Contains(buf.String(), "alice"))
+	out := runCLI(t, env, dir, "assign", "1", "alice")
+	assert.True(t, strings.Contains(out, "assigned") ||
+		strings.Contains(out, "alice"))
 
-	resetFlags(t)
-	uCmd := newRootCmd()
-	var ubuf bytes.Buffer
-	uCmd.SetOut(&ubuf)
-	uCmd.SetArgs([]string{"--workspace", dir, "unassign", "1"})
-	uCmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, uCmd.Execute())
-	assert.True(t, strings.Contains(ubuf.String(), "unassigned"))
+	uOut := runCLI(t, env, dir, "unassign", "1")
+	assert.True(t, strings.Contains(uOut, "unassigned"))
 }

--- a/cmd/kata/client_test.go
+++ b/cmd/kata/client_test.go
@@ -24,11 +24,7 @@ func TestEnvHTTPTimeout(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("KATA_HTTP_TIMEOUT", tc.env)
-			got := envHTTPTimeout(def)
-			if got != tc.want {
-				t.Fatalf("envHTTPTimeout(%q) = %v, want %v", tc.env, got, tc.want)
-			}
+			assertEnvDurationOverride(t, "KATA_HTTP_TIMEOUT", tc.env, def, tc.want, envHTTPTimeout)
 		})
 	}
 }
@@ -51,5 +47,14 @@ func TestEnsureDaemon_RemoteUnavailableMapsToCLIError(t *testing.T) {
 	}
 	if ce.ExitCode != ExitDaemonUnavail {
 		t.Errorf("expected ExitCode=%d, got %d", ExitDaemonUnavail, ce.ExitCode)
+	}
+}
+
+func assertEnvDurationOverride(t *testing.T, envKey, envVal string, fallback, want time.Duration, parseFn func(time.Duration) time.Duration) {
+	t.Helper()
+	t.Setenv(envKey, envVal)
+	got := parseFn(fallback)
+	if got != want {
+		t.Fatalf("%s=%q override failed: got %v, want %v", envKey, envVal, got, want)
 	}
 }

--- a/cmd/kata/close_reopen_test.go
+++ b/cmd/kata/close_reopen_test.go
@@ -1,40 +1,17 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestCloseReopen_RoundTrip(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
-	resp, err := http.Post(env.URL+"/api/v1/projects/"+itoa(pid)+"/issues",
-		"application/json", bytes.NewReader([]byte(`{"actor":"x","title":"x"}`))) //nolint:noctx // test-only
-	require.NoError(t, err)
-	_ = resp.Body.Close()
+	env, dir, _ := setupWorkspaceWithIssue(t, "test issue")
 
-	closeCmd := newRootCmd()
-	var bclose bytes.Buffer
-	closeCmd.SetOut(&bclose)
-	closeCmd.SetArgs([]string{"--workspace", dir, "close", "1", "--reason", "wontfix"})
-	closeCmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, closeCmd.Execute())
-	assert.True(t, strings.Contains(bclose.String(), "closed"))
+	out := runCLI(t, env, dir, "close", "1", "--reason", "wontfix")
+	assert.Contains(t, out, "closed")
 
-	reopenCmd := newRootCmd()
-	var bo bytes.Buffer
-	reopenCmd.SetOut(&bo)
-	reopenCmd.SetArgs([]string{"--workspace", dir, "reopen", "1"})
-	reopenCmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, reopenCmd.Execute())
-	assert.True(t, strings.Contains(bo.String(), "open"))
+	out = runCLI(t, env, dir, "reopen", "1")
+	assert.Contains(t, out, "open")
 }

--- a/cmd/kata/comment_test.go
+++ b/cmd/kata/comment_test.go
@@ -1,32 +1,16 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestComment_AppendsToIssue(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
-	body := []byte(`{"actor":"x","title":"x"}`)
-	resp, err := http.Post(env.URL+"/api/v1/projects/"+itoa(pid)+"/issues", "application/json", bytes.NewReader(body)) //nolint:noctx // test-only
-	require.NoError(t, err)
-	_ = resp.Body.Close()
+	env, dir := setupCLIEnv(t)
+	createIssueViaHTTP(t, env, dir, "x")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "comment", "1", "--body", "looks good"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.True(t, strings.Contains(buf.String(), "looks good") || strings.Contains(buf.String(), "comment"))
+	out := runCLI(t, env, dir, "comment", "1", "--body", "looks good")
+	assert.True(t, strings.Contains(out, "looks good") || strings.Contains(out, "comment"))
 }

--- a/cmd/kata/create_test.go
+++ b/cmd/kata/create_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -9,73 +8,36 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestCreate_PrintsIssueNumberInQuietMode(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "--quiet", "create", "first issue", "--body", "details"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Equal(t, "1", strings.TrimSpace(buf.String()))
+	env, dir := setupCLIEnv(t)
+	out := runCLI(t, env, dir, "--quiet", "create", "first issue", "--body", "details")
+	assert.Equal(t, "1", out)
 }
 
 func TestCreate_WithInitialLabelsAndParent(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+	env, dir := setupCLIEnv(t)
 	pid := resolvePIDViaHTTP(t, env.URL, dir)
 	createIssue(t, env, pid, "parent-issue") // #1
 	createIssue(t, env, pid, "blocker")      // #2
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{
-		"--workspace", dir, "create", "child",
+	out := runCLI(t, env, dir, "create", "child",
 		"--label", "bug", "--label", "needs-review",
 		"--parent", "1",
 		"--blocks", "2",
 		"--owner", "alice",
-	})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "child")
+	)
+	assert.Contains(t, out, "child")
 
 	// Fetch the created issue (#3) and assert every initial-state flag was
 	// actually persisted, not just echoed back in the create response.
-	resp, err := http.Get(env.URL + "/api/v1/projects/" + itoa(pid) + "/issues/3") //nolint:noctx,gosec // test-only loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-	var b struct {
-		Issue struct {
-			Number int64   `json:"number"`
-			Owner  *string `json:"owner"`
-		} `json:"issue"`
-		Labels []struct {
-			Label string `json:"label"`
-		} `json:"labels"`
-		Links []struct {
-			Type       string `json:"type"`
-			FromNumber int64  `json:"from_number"`
-			ToNumber   int64  `json:"to_number"`
-		} `json:"links"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&b))
+	b := fetchIssueViaHTTP(t, env, pid, 3)
 	require.NotNil(t, b.Issue.Owner)
 	assert.Equal(t, "alice", *b.Issue.Owner)
 
@@ -103,49 +65,28 @@ func TestCreate_WithInitialLabelsAndParent(t *testing.T) {
 }
 
 func TestCreate_WithIdempotencyKeyReusesOnRepeat(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+	env, dir := setupCLIEnv(t)
 
 	// First call.
-	cmd := newRootCmd()
-	var buf1 bytes.Buffer
-	cmd.SetOut(&buf1)
-	cmd.SetArgs([]string{"--workspace", dir, "--quiet", "create",
-		"first issue", "--idempotency-key", "K1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	first := strings.TrimSpace(buf1.String())
+	first := runCLI(t, env, dir, "--quiet", "create",
+		"first issue", "--idempotency-key", "K1")
 	assert.Equal(t, "1", first)
 
 	// Repeat with the same key + same fingerprint → reuse, same number.
 	resetFlags(t)
-	cmd = newRootCmd()
-	var buf2 bytes.Buffer
-	cmd.SetOut(&buf2)
-	cmd.SetArgs([]string{"--workspace", dir, "--quiet", "create",
-		"first issue", "--idempotency-key", "K1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	second := strings.TrimSpace(buf2.String())
+	second := runCLI(t, env, dir, "--quiet", "create",
+		"first issue", "--idempotency-key", "K1")
 	assert.Equal(t, "1", second, "same key + fingerprint must return existing issue number")
 }
 
 func TestCreate_ForceNewBypassesLookalike(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+	env, dir := setupCLIEnv(t)
 	createIssueViaHTTP(t, env, dir, "fix login crash on Safari")
 
 	// Without --force-new the daemon would 409 on look-alike. With it, a new issue lands.
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "--quiet", "create",
-		"fix login crash Safari", "--force-new"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Equal(t, "2", strings.TrimSpace(buf.String()))
+	out := runCLI(t, env, dir, "--quiet", "create",
+		"fix login crash Safari", "--force-new")
+	assert.Equal(t, "2", out)
 }
 
 // TestResolveProjectID_PropagatesParseError guards against a malformed

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -16,24 +16,15 @@ import (
 )
 
 func TestDaemonStatus_NoDaemonReportsAbsent(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	setupKataEnv(t)
 
-	cmd := newDaemonCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"status"})
-	err := cmd.Execute()
-	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "no daemon")
+	out := executeRoot(t, newDaemonCmd(), "status")
+	assert.Contains(t, string(out), "no daemon")
 }
 
 func TestDaemonStatus_JSONReportsDaemonsWithVersion(t *testing.T) {
 	resetFlags(t)
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	tmp := setupKataEnv(t)
 
 	ns, err := daemon.NewNamespace()
 	require.NoError(t, err)
@@ -48,11 +39,7 @@ func TestDaemonStatus_JSONReportsDaemonsWithVersion(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"daemon", "status", "--json"})
-	require.NoError(t, cmd.Execute())
+	out := executeRoot(t, newRootCmd(), "daemon", "status", "--json")
 
 	var got struct {
 		KataAPIVersion int `json:"kata_api_version"`
@@ -64,7 +51,7 @@ func TestDaemonStatus_JSONReportsDaemonsWithVersion(t *testing.T) {
 			StartedAt string `json:"started_at"`
 		} `json:"daemons"`
 	}
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.NoError(t, json.Unmarshal(out, &got))
 	require.Equal(t, 1, got.KataAPIVersion)
 	require.Len(t, got.Daemons, 1)
 	assert.Equal(t, os.Getpid(), got.Daemons[0].PID)
@@ -76,21 +63,15 @@ func TestDaemonStatus_JSONReportsDaemonsWithVersion(t *testing.T) {
 
 func TestDaemonStatus_JSONReportsEmptyDaemonList(t *testing.T) {
 	resetFlags(t)
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	setupKataEnv(t)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"daemon", "status", "--json"})
-	require.NoError(t, cmd.Execute())
+	out := executeRoot(t, newRootCmd(), "daemon", "status", "--json")
 
 	var got struct {
 		KataAPIVersion int             `json:"kata_api_version"`
 		Daemons        json.RawMessage `json:"daemons"`
 	}
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.NoError(t, json.Unmarshal(out, &got))
 	assert.Equal(t, 1, got.KataAPIVersion)
 	assert.JSONEq(t, "[]", string(got.Daemons))
 }
@@ -181,9 +162,7 @@ func TestEnsureDaemon_ReturnsExistingURL(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	tmp := setupKataEnv(t)
 
 	addr, cleanup := pipeServer(t)
 	t.Cleanup(cleanup)

--- a/cmd/kata/daemon_cutover_test.go
+++ b/cmd/kata/daemon_cutover_test.go
@@ -12,10 +12,7 @@ import (
 )
 
 func TestDaemonStartRunsAutoCutoverBeforeOpen(t *testing.T) {
-	home := t.TempDir()
-	dbPath := filepath.Join(home, "kata.db")
-	t.Setenv("KATA_HOME", home)
-	t.Setenv("KATA_DB", dbPath)
+	dbPath := filepath.Join(setupKataEnv(t), "kata.db")
 	d, err := db.Open(context.Background(), dbPath)
 	require.NoError(t, err)
 	_, err = d.ExecContext(context.Background(), `UPDATE meta SET value='0' WHERE key='schema_version'`)

--- a/cmd/kata/daemon_logs_test.go
+++ b/cmd/kata/daemon_logs_test.go
@@ -23,28 +23,71 @@ func writeRuns(t *testing.T, dir string, files map[string][]map[string]any) {
 		t.Fatal(err)
 	}
 	for name, lines := range files {
-		var buf bytes.Buffer
-		for _, l := range lines {
-			b, _ := json.Marshal(l)
-			buf.Write(b)
-			buf.WriteByte('\n')
-		}
-		if err := os.WriteFile(filepath.Join(dir, name), buf.Bytes(), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		writeHookLog(t, dir, name, lines...)
 	}
 }
 
+// writeHookLog writes JSONL entries to dir/filename, creating dir if needed.
+// Each entry is JSON-marshaled and terminated with a newline.
+func writeHookLog(t *testing.T, dir, filename string, entries ...map[string]any) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	for _, e := range entries {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(b)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(filepath.Join(dir, filename), buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// appendHookLogAsync schedules a background goroutine that, after delay,
+// appends JSONL entries to path (creating the file if missing). Used by
+// --tail tests that simulate logs arriving while a command is executing.
+// Errors are silently ignored — the test will fail naturally if the data
+// never lands.
+func appendHookLogAsync(path string, delay time.Duration, entries ...map[string]any) {
+	go func() {
+		time.Sleep(delay)
+		var buf bytes.Buffer
+		for _, e := range entries {
+			b, err := json.Marshal(e)
+			if err != nil {
+				return
+			}
+			buf.Write(b)
+			buf.WriteByte('\n')
+		}
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600) //nolint:gosec // G304: test-controlled temp path
+		if err != nil {
+			return
+		}
+		_, _ = f.Write(buf.Bytes())
+		_ = f.Close()
+	}()
+}
+
+// setupHooksDir initializes a temporary KATA_HOME with an empty kata.db,
+// creates the namespaced hooks directory, and returns home, hooksDir, and
+// the db hash used to derive hooksDir.
 func setupHooksDir(t *testing.T) (home, hooksDir, dbHash string) {
 	t.Helper()
-	home = t.TempDir()
-	t.Setenv("KATA_HOME", home)
-	t.Setenv("KATA_DB", filepath.Join(home, "kata.db"))
+	home = setupKataEnv(t)
 	if err := os.WriteFile(filepath.Join(home, "kata.db"), []byte{0}, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	dbHash = config.DBHash(filepath.Join(home, "kata.db"))
 	hooksDir = filepath.Join(home, "hooks", dbHash)
+	if err := os.MkdirAll(hooksDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	return
 }
 
@@ -56,15 +99,8 @@ func TestDaemonLogs_Hooks_PrintsChronological(t *testing.T) {
 		"runs.jsonl":   {{"event_id": 3, "result": "ok"}, {"event_id": 4, "result": "ok"}},
 	})
 	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"daemon", "logs", "--hooks"})
-	cmd.SetContext(context.Background())
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-	out := buf.String()
+	out, _, err := executeRootCapture(t, context.Background(), "daemon", "logs", "--hooks")
+	require.NoError(t, err)
 	idx1 := strings.Index(out, `"event_id":1`)
 	idx2 := strings.Index(out, `"event_id":2`)
 	idx3 := strings.Index(out, `"event_id":3`)
@@ -84,15 +120,8 @@ func TestDaemonLogs_Hooks_FailedOnly(t *testing.T) {
 		},
 	})
 	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"daemon", "logs", "--hooks", "--failed-only"})
-	cmd.SetContext(context.Background())
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-	out := buf.String()
+	out, _, err := executeRootCapture(t, context.Background(), "daemon", "logs", "--hooks", "--failed-only")
+	require.NoError(t, err)
 	if strings.Contains(out, `"event_id":1`) {
 		t.Fatal("--failed-only should exclude ok exit_code=0")
 	}
@@ -103,28 +132,18 @@ func TestDaemonLogs_Hooks_FailedOnly(t *testing.T) {
 
 func TestDaemonLogs_Hooks_MalformedLineSkippedWithStderrWarning(t *testing.T) {
 	_, dir, _ := setupHooksDir(t)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatal(err)
-	}
 	contents := "{\"event_id\":1,\"result\":\"ok\"}\nnot-json\n{\"event_id\":2,\"result\":\"ok\"}\n"
 	if err := os.WriteFile(filepath.Join(dir, "runs.jsonl"), []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	resetFlags(t)
-	cmd := newRootCmd()
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{"daemon", "logs", "--hooks"})
-	cmd.SetContext(context.Background())
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(stdout.String(), `"event_id":1`) || !strings.Contains(stdout.String(), `"event_id":2`) {
+	stdout, stderr, err := executeRootCapture(t, context.Background(), "daemon", "logs", "--hooks")
+	require.NoError(t, err)
+	if !strings.Contains(stdout, `"event_id":1`) || !strings.Contains(stdout, `"event_id":2`) {
 		t.Fatal("valid lines should still print")
 	}
-	if !strings.Contains(stderr.String(), "skipping malformed line") {
-		t.Fatalf("stderr should warn about malformed line: %q", stderr.String())
+	if !strings.Contains(stderr, "skipping malformed line") {
+		t.Fatalf("stderr should warn about malformed line: %q", stderr)
 	}
 }
 
@@ -135,31 +154,16 @@ func TestDaemonLogs_Hooks_MalformedLineSkippedWithStderrWarning(t *testing.T) {
 // file and never observe future writes to runs.jsonl.
 func TestDaemonLogs_Hooks_Tail_RotatedOnlyWaitsForActive(t *testing.T) {
 	_, dir, _ := setupHooksDir(t)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatal(err)
-	}
 	// Only a rotated file exists at startup.
-	if err := os.WriteFile(filepath.Join(dir, "runs.jsonl.1"),
-		[]byte(`{"event_id":99,"result":"ok"}`+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeHookLog(t, dir, "runs.jsonl.1", map[string]any{"event_id": 99, "result": "ok"})
+
 	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	cmd.SetArgs([]string{"daemon", "logs", "--hooks", "--tail"})
-	cmd.SetContext(ctx)
+	appendHookLogAsync(filepath.Join(dir, "runs.jsonl"), 300*time.Millisecond,
+		map[string]any{"event_id": 7, "result": "ok"})
 
-	go func() {
-		time.Sleep(300 * time.Millisecond)
-		_ = os.WriteFile(filepath.Join(dir, "runs.jsonl"),
-			[]byte(`{"event_id":7,"result":"ok"}`+"\n"), 0o600)
-	}()
-
-	_ = cmd.Execute()
-	out := buf.String()
+	out, _, _ := executeRootCapture(t, ctx, "daemon", "logs", "--hooks", "--tail")
 	if !strings.Contains(out, `"event_id":7`) {
 		t.Fatalf("tail must follow runs.jsonl after it appears: %q", out)
 	}
@@ -271,9 +275,6 @@ func TestFollowActive_MarkAtSize_DoesNotReEmit(t *testing.T) {
 // it was read, so tail can resume at the exact byte offset.
 func TestRunHookLogOnce_Mark_ReportsActiveFileSize(t *testing.T) {
 	_, dir, _ := setupHooksDir(t)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatal(err)
-	}
 	contents := `{"event_id":1,"result":"ok"}` + "\n"
 	path := filepath.Join(dir, "runs.jsonl")
 	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
@@ -297,14 +298,8 @@ func TestRunHookLogOnce_Mark_ReportsActiveFileSize(t *testing.T) {
 // later starts at offset 0 once the file appears.
 func TestRunHookLogOnce_Mark_UnsetWhenActiveAbsent(t *testing.T) {
 	_, dir, _ := setupHooksDir(t)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatal(err)
-	}
 	// Only a rotated file exists.
-	if err := os.WriteFile(filepath.Join(dir, "runs.jsonl.1"),
-		[]byte(`{"event_id":99,"result":"ok"}`+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeHookLog(t, dir, "runs.jsonl.1", map[string]any{"event_id": 99, "result": "ok"})
 	var stdout, stderr bytes.Buffer
 	mark, err := runHookLogOnce(&stdout, &stderr, 100, &hookLogFilter{hookIndex: -1})
 	if err != nil {
@@ -317,31 +312,16 @@ func TestRunHookLogOnce_Mark_UnsetWhenActiveAbsent(t *testing.T) {
 
 func TestDaemonLogs_Hooks_Tail_PicksUpNewLines(t *testing.T) {
 	_, dir, _ := setupHooksDir(t)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatal(err)
-	}
 	path := filepath.Join(dir, "runs.jsonl")
-	if err := os.WriteFile(path, []byte(`{"event_id":1,"result":"ok"}`+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeHookLog(t, dir, "runs.jsonl", map[string]any{"event_id": 1, "result": "ok"})
+
 	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	cmd.SetArgs([]string{"daemon", "logs", "--hooks", "--tail"})
-	cmd.SetContext(ctx)
+	appendHookLogAsync(path, 200*time.Millisecond,
+		map[string]any{"event_id": 2, "result": "ok"})
 
-	go func() {
-		time.Sleep(200 * time.Millisecond)
-		f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // G304: test-controlled temp path
-		_, _ = f.WriteString(`{"event_id":2,"result":"ok"}` + "\n")
-		_ = f.Close()
-	}()
-
-	_ = cmd.Execute()
-	out := buf.String()
+	out, _, _ := executeRootCapture(t, ctx, "daemon", "logs", "--hooks", "--tail")
 	if !strings.Contains(out, `"event_id":1`) || !strings.Contains(out, `"event_id":2`) {
 		t.Fatalf("tail should print initial + appended: %q", out)
 	}
@@ -354,14 +334,8 @@ func TestDaemonLogs_Hooks_Tail_PicksUpNewLines(t *testing.T) {
 func TestDaemonLogs_RejectsNonPositiveLimit(t *testing.T) {
 	for _, lim := range []string{"0", "-1"} {
 		resetFlags(t)
-		cmd := newRootCmd()
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
-		cmd.SetErr(&buf)
-		cmd.SetArgs([]string{"daemon", "logs", "--hooks", "--limit", lim})
-		cmd.SetContext(context.Background())
-
-		err := cmd.Execute()
+		_, _, err := executeRootCapture(t, context.Background(),
+			"daemon", "logs", "--hooks", "--limit", lim)
 		require.Errorf(t, err, "--limit %s should reject", lim)
 		var ce *cliError
 		require.True(t, errors.As(err, &ce))
@@ -375,14 +349,8 @@ func TestDaemonLogs_RejectsNonPositiveLimit(t *testing.T) {
 // -1 is meaningless; reject loudly.
 func TestDaemonLogs_RejectsHookIndexBelowMinusOne(t *testing.T) {
 	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"daemon", "logs", "--hooks", "--hook-index", "-2"})
-	cmd.SetContext(context.Background())
-
-	err := cmd.Execute()
+	_, _, err := executeRootCapture(t, context.Background(),
+		"daemon", "logs", "--hooks", "--hook-index", "-2")
 	require.Error(t, err)
 	var ce *cliError
 	require.True(t, errors.As(err, &ce))

--- a/cmd/kata/daemon_reload_loop_test.go
+++ b/cmd/kata/daemon_reload_loop_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/hooks"
 )
 
@@ -42,47 +43,34 @@ type nopLogger struct{}
 func (nopLogger) Printf(string, ...any) {}
 
 func TestRunReloadLoop_DispatchesOnSignal(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("KATA_HOME", dir)
+	dir := setupKataEnv(t)
 	path := filepath.Join(dir, "hooks.toml")
-	if err := os.WriteFile(path, []byte(`[[hook]]
+	require.NoError(t, os.WriteFile(path, []byte(`[[hook]]
 event = "issue.created"
 command = "/bin/true"
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
+`), 0o600))
 	rec := &recordingDispatcher{}
 	sigs := make(chan os.Signal, 1)
-	logBuf := nopLogger{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	done := make(chan struct{})
 	go func() {
-		runReloadLoop(ctx, sigs, path, rec, logBuf)
+		runReloadLoop(ctx, sigs, path, rec, nopLogger{})
 		close(done)
 	}()
 
 	sigs <- syscall.SIGHUP
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	require.Eventually(t, func() bool {
 		rec.mu.Lock()
-		n := len(rec.reloadCalls)
-		rec.mu.Unlock()
-		if n >= 1 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		defer rec.mu.Unlock()
+		return len(rec.reloadCalls) >= 1
+	}, 2*time.Second, 10*time.Millisecond)
 	cancel()
 	<-done
 
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
-	if len(rec.reloadCalls) != 1 {
-		t.Fatalf("Reload calls = %d, want 1", len(rec.reloadCalls))
-	}
-	if len(rec.reloadCalls[0].Snapshot.Hooks) != 1 {
-		t.Fatal("expected one hook in reloaded snapshot")
-	}
+	require.Len(t, rec.reloadCalls, 1)
+	require.Len(t, rec.reloadCalls[0].Snapshot.Hooks, 1, "expected one hook in reloaded snapshot")
 }

--- a/cmd/kata/daemon_reload_test.go
+++ b/cmd/kata/daemon_reload_test.go
@@ -1,35 +1,23 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDaemonReload_NoRunningDaemon_ExitUsage(t *testing.T) {
 	resetFlags(t)
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	setupKataEnv(t)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"daemon", "reload"})
-	cmd.SetContext(context.Background())
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when no daemon running")
-	}
+	_, _, err := executeRootCapture(t, context.Background(), "daemon", "reload")
+	require.Error(t, err)
 	var ce *cliError
-	if !errors.As(err, &ce) || ce.ExitCode != ExitUsage {
-		t.Fatalf("err = %v, want ExitUsage cliError", err)
-	}
-	if !strings.Contains(strings.ToLower(ce.Message), "no daemon") {
-		t.Fatalf("message should mention no daemon: %q", ce.Message)
-	}
+	require.True(t, errors.As(err, &ce))
+	assert.Equal(t, ExitUsage, ce.ExitCode)
+	assert.Contains(t, strings.ToLower(ce.Message), "no daemon")
 }

--- a/cmd/kata/delete_test.go
+++ b/cmd/kata/delete_test.go
@@ -1,69 +1,36 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestDelete_NoForceIsValidationError(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "to be deleted")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "to be deleted")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "delete", "1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, ExitValidation, ce.ExitCode)
+	err := f.execute("delete", "1")
+	ce := requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "--force")
 }
 
 func TestDelete_ForceWithConfirmSoftDeletes(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "to be deleted")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "to be deleted")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "delete", "1", "--force", "--confirm", "DELETE #1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "deleted")
+	require.NoError(t, f.execute("delete", "1", "--force", "--confirm", "DELETE #1"))
+	assert.Contains(t, f.buf.String(), "deleted")
 }
 
 func TestDelete_ConfirmMismatchIsExit6(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "to be deleted")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "to be deleted")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "delete", "1", "--force", "--confirm", "DELETE #2"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, ExitConfirm, ce.ExitCode)
+	err := f.execute("delete", "1", "--force", "--confirm", "DELETE #2")
+	ce := requireCLIError(t, err, ExitConfirm)
 	assert.True(t, strings.Contains(ce.Code, "confirm_mismatch"))
 }
 
@@ -72,22 +39,11 @@ func TestDelete_ConfirmMismatchIsExit6(t *testing.T) {
 // isTTY (which sees the developer's terminal under `go test`) with a stub
 // that always reports false, so the assertion is deterministic.
 func TestDelete_NoTTYNoConfirmIsConfirmRequired(t *testing.T) {
-	resetFlags(t)
 	stubIsTTY(t, false)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "to be deleted")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "to be deleted")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "delete", "1", "--force"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, ExitConfirm, ce.ExitCode)
+	err := f.execute("delete", "1", "--force")
+	ce := requireCLIError(t, err, ExitConfirm)
 	assert.Equal(t, "confirm_required", ce.Code)
 }

--- a/cmd/kata/diagnostic_test.go
+++ b/cmd/kata/diagnostic_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"strconv"
 	"strings"
@@ -15,137 +14,73 @@ import (
 )
 
 func TestWhoami_FlagOverride(t *testing.T) {
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"whoami", "--as", "claude-4.7"})
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
+	out := requireCmdOutput(t, nil, "whoami", "--as", "claude-4.7")
 	assert.Contains(t, out, "claude-4.7")
 	assert.Contains(t, out, "flag")
 }
 
 func TestHealth_PrintsSchemaVersion(t *testing.T) {
-	resetFlags(t)
 	env := testenv.New(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"health"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "schema_version="+strconv.Itoa(db.CurrentSchemaVersion()))
+	out := requireCmdOutput(t, env, "health")
+	assert.Contains(t, out, "schema_version="+strconv.Itoa(db.CurrentSchemaVersion()))
 }
 
 func TestProjectsList_PrintsKnown(t *testing.T) {
-	resetFlags(t)
 	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	_ = dir
+	_ = initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"projects", "list"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.True(t, strings.Contains(buf.String(), "github.com/wesm/kata"))
+	out := requireCmdOutput(t, env, "projects", "list")
+	assert.True(t, strings.Contains(out, "github.com/wesm/kata"))
 }
 
 func TestProjectsRename_RenamesProject(t *testing.T) {
-	resetFlags(t)
 	env := testenv.New(t)
 	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
 	projectID := resolvePIDViaHTTP(t, env.URL, dir)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"projects", "rename", itoa(projectID), "Kata Tracker"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "renamed project #"+itoa(projectID)+" to Kata Tracker")
+	out := requireCmdOutput(t, env, "projects", "rename", itoa(projectID), "Kata Tracker")
+	assert.Contains(t, out, "renamed project #"+itoa(projectID)+" to Kata Tracker")
 
-	show := newRootCmd()
-	var showBuf bytes.Buffer
-	show.SetOut(&showBuf)
-	show.SetArgs([]string{"projects", "show", itoa(projectID)})
-	show.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, show.Execute())
-	assert.Contains(t, showBuf.String(), "(Kata Tracker, next #")
+	show := requireCmdOutput(t, env, "projects", "show", itoa(projectID))
+	assert.Contains(t, show, "(Kata Tracker, next #")
 }
 
 func TestProjectsRename_AcceptsProjectSelector(t *testing.T) {
-	resetFlags(t)
 	env := testenv.New(t)
 	_ = initBoundWorkspace(t, env.URL, "https://github.com/wesm/kenn.git")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"projects", "rename", "kenn", "steward"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "renamed project #")
-	assert.Contains(t, buf.String(), "to steward")
+	out := requireCmdOutput(t, env, "projects", "rename", "kenn", "steward")
+	assert.Contains(t, out, "renamed project #")
+	assert.Contains(t, out, "to steward")
 }
 
 func TestProjectsMerge_MergesSourceSelectorIntoSurvivingTarget(t *testing.T) {
-	resetFlags(t)
 	env := testenv.New(t)
-	ctx := context.Background()
-	kenn, err := env.DB.CreateProject(ctx, "github.com/wesm/kenn", "steward")
-	require.NoError(t, err)
-	steward, err := env.DB.CreateProject(ctx, "github.com/wesm/steward", "steward")
-	require.NoError(t, err)
-	_, err = env.DB.AttachAlias(ctx, kenn.ID, "github.com/wesm/kenn", "git", "/tmp/kenn")
-	require.NoError(t, err)
-	_, err = env.DB.AttachAlias(ctx, steward.ID, "github.com/wesm/steward", "git", "/tmp/steward")
-	require.NoError(t, err)
-	_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{
+	kenn, steward := setupMergeProjects(t, env)
+	_, _, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
 		ProjectID: kenn.ID, Title: "carry history forward", Author: "tester",
 	})
 	require.NoError(t, err)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"projects", "merge", "kenn", "steward"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "merged project #"+itoa(kenn.ID)+" into #"+itoa(steward.ID))
-	assert.Contains(t, buf.String(), "moved 1 issue")
+	out := requireCmdOutput(t, env, "projects", "merge", "kenn", "steward")
+	assert.Contains(t, out, "merged project #"+itoa(kenn.ID)+" into #"+itoa(steward.ID))
+	assert.Contains(t, out, "moved 1 issue")
 
-	issue, err := env.DB.IssueByNumber(ctx, steward.ID, 1)
+	issue, err := env.DB.IssueByNumber(context.Background(), steward.ID, 1)
 	require.NoError(t, err)
 	assert.Equal(t, "carry history forward", issue.Title)
-	_, err = env.DB.ProjectByID(ctx, kenn.ID)
+	_, err = env.DB.ProjectByID(context.Background(), kenn.ID)
 	assert.ErrorIs(t, err, db.ErrNotFound)
 }
 
 func TestProjectsMerge_RewritesWorkspaceBindingFromSourceToTarget(t *testing.T) {
-	resetFlags(t)
 	env := testenv.New(t)
-	ctx := context.Background()
-	kenn, err := env.DB.CreateProject(ctx, "github.com/wesm/kenn", "steward")
-	require.NoError(t, err)
-	steward, err := env.DB.CreateProject(ctx, "github.com/wesm/steward", "steward")
-	require.NoError(t, err)
-	_, err = env.DB.AttachAlias(ctx, kenn.ID, "github.com/wesm/kenn", "git", "/tmp/kenn")
-	require.NoError(t, err)
-	_, err = env.DB.AttachAlias(ctx, steward.ID, "github.com/wesm/steward", "git", "/tmp/steward")
-	require.NoError(t, err)
+	setupMergeProjects(t, env)
 
 	dir := t.TempDir()
 	require.NoError(t, config.WriteProjectConfig(dir, "github.com/wesm/kenn", "steward"))
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "projects", "merge", "kenn", "steward"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
+	_ = requireCmdOutput(t, env, "--workspace", dir, "projects", "merge", "kenn", "steward")
 
 	cfg, err := config.ReadProjectConfig(dir)
 	require.NoError(t, err)
@@ -154,14 +89,8 @@ func TestProjectsMerge_RewritesWorkspaceBindingFromSourceToTarget(t *testing.T) 
 }
 
 func TestProjectsRename_RejectsBlankName(t *testing.T) {
-	resetFlags(t)
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"projects", "rename", "1", "   "})
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, kindValidation, ce.Kind)
+	_, err := runCmdOutput(t, nil, "projects", "rename", "1", "   ")
+	ce := requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "project name must be non-empty")
 }
 

--- a/cmd/kata/digest_test.go
+++ b/cmd/kata/digest_test.go
@@ -1,31 +1,20 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestDigest_HumanRender(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
-	createIssue(t, env, pid, "first")
-	createIssue(t, env, pid, "second")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "first")
+	createIssueViaHTTP(t, f.env, f.dir, "second")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "digest", "--since", "1h"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
+	require.NoError(t, f.execute("digest", "--since", "1h"))
+	out := f.buf.String()
 	assert.Contains(t, out, "digest ")
 	assert.Contains(t, out, "created=2")
 	assert.Contains(t, out, "#1")
@@ -33,18 +22,9 @@ func TestDigest_HumanRender(t *testing.T) {
 }
 
 func TestDigest_RejectsBadSince(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	_ = resolvePIDViaHTTP(t, env.URL, dir)
+	f := newCLIFixture(t)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "digest", "--since", "blarg"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	err := cmd.Execute()
+	err := f.execute("digest", "--since", "blarg")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid time spec")
 }

--- a/cmd/kata/edit_test.go
+++ b/cmd/kata/edit_test.go
@@ -1,13 +1,9 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestEdit_EmptyTitle_ValidatedClientSide covers hammer-test
@@ -18,21 +14,10 @@ import (
 // flag to keep the existing title).
 func TestEdit_EmptyTitle_ValidatedClientSide(t *testing.T) {
 	for _, blank := range []string{"", "   ", "\t\n"} {
-		resetFlags(t)
-		cmd := newRootCmd()
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
-		cmd.SetErr(&buf)
-		cmd.SetArgs([]string{"edit", "1", "--title", blank})
-		cmd.SetContext(context.Background())
-
-		err := cmd.Execute()
-		require.Error(t, err, "blank title %q should be rejected", blank)
-		var ce *cliError
-		require.True(t, errors.As(err, &ce), "expected *cliError, got %T", err)
-		assert.Equal(t, ExitValidation, ce.ExitCode)
+		_, err := runCmdOutput(t, nil, "edit", "1", "--title", blank)
+		ce := requireCLIError(t, err, ExitValidation)
 		assert.Equal(t, kindValidation, ce.Kind)
 		assert.Contains(t, ce.Message, "must not be empty",
-			"validation message should explain the failure")
+			"validation message should explain the failure for %q", blank)
 	}
 }

--- a/cmd/kata/events_test.go
+++ b/cmd/kata/events_test.go
@@ -1,13 +1,10 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -17,20 +14,13 @@ import (
 )
 
 func TestEvents_OneShotPlainOutput(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "first")
-	createIssueViaHTTP(t, env, dir, "second")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "first")
+	createIssueViaHTTP(t, f.env, f.dir, "second")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "events"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
+	require.NoError(t, f.execute("events"))
 
-	out := buf.String()
+	out := f.buf.String()
 	assert.Contains(t, out, "issue.created")
 	lines := 0
 	for _, l := range strings.Split(out, "\n") {
@@ -42,17 +32,10 @@ func TestEvents_OneShotPlainOutput(t *testing.T) {
 }
 
 func TestEvents_OneShotJSON(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "only")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "only")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "events", "--json"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
+	require.NoError(t, f.execute("events", "--json"))
 
 	var b struct {
 		KataAPIVersion int `json:"kata_api_version"`
@@ -64,7 +47,7 @@ func TestEvents_OneShotJSON(t *testing.T) {
 		} `json:"events"`
 		NextAfterID int64 `json:"next_after_id"`
 	}
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &b))
+	require.NoError(t, json.Unmarshal(f.buf.Bytes(), &b))
 	assert.Equal(t, 1, b.KataAPIVersion)
 	require.Len(t, b.Events, 1)
 	assert.Equal(t, "issue.created", b.Events[0].Type)
@@ -75,84 +58,40 @@ func TestEvents_OneShotJSON(t *testing.T) {
 }
 
 func TestEvents_OneShotAllProjectsHitsCrossProject(t *testing.T) {
-	resetFlags(t)
 	env := testenv.New(t)
 	dirA := initBoundWorkspace(t, env.URL, "https://github.com/wesm/a.git")
 	dirB := initBoundWorkspace(t, env.URL, "https://github.com/wesm/b.git")
 	createIssueViaHTTP(t, env, dirA, "a-issue")
 	createIssueViaHTTP(t, env, dirB, "b-issue")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"events", "--all-projects", "--json"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
+	out := requireCmdOutput(t, env, "events", "--all-projects", "--json")
 
 	var b struct {
 		Events []struct {
 			ProjectID int64 `json:"project_id"`
 		} `json:"events"`
 	}
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &b))
+	require.NoError(t, json.Unmarshal([]byte(out), &b))
 	assert.Len(t, b.Events, 2, "all-projects must include both projects")
 }
 
-// safeBuffer is a mutex-protected bytes.Buffer used by tail tests so that
-// `go test -race` does not flag the goroutine running cmd.Execute writing to
-// the buffer racing with the test goroutine reading it via Snapshot.
-type safeBuffer struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
-}
-
-func (s *safeBuffer) Write(p []byte) (int, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.buf.Write(p)
-}
-
-func (s *safeBuffer) Snapshot() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.buf.String()
-}
-
 func TestEvents_TailEmitsNDJSON(t *testing.T) {
-	resetFlags(t)
 	env := testenv.New(t)
 	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
 
-	cmd := newRootCmd()
-	buf := &safeBuffer{}
-	cmd.SetOut(buf)
 	ctx, cancel := context.WithTimeout(contextWithBaseURL(context.Background(), env.URL), 5*time.Second)
 	defer cancel()
-	cmd.SetArgs([]string{"--workspace", dir, "events", "--tail"})
-	cmd.SetContext(ctx)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		_ = cmd.Execute()
-	}()
+	a := startAsyncCLI(t, ctx, "--workspace", dir, "events", "--tail")
+	defer a.stop()
 
 	time.Sleep(200 * time.Millisecond)
 	createIssueViaHTTP(t, env, dir, "first")
 	createIssueViaHTTP(t, env, dir, "second")
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.Count(buf.Snapshot(), "issue.created") >= 2 {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	cancel()
-	wg.Wait()
+	out := a.awaitOutput(func(s string) bool {
+		return strings.Count(s, "issue.created") >= 2
+	}, 2*time.Second)
 
-	out := buf.Snapshot()
 	lines := []string{}
 	for _, l := range strings.Split(strings.TrimSpace(out), "\n") {
 		if strings.TrimSpace(l) != "" {
@@ -161,41 +100,23 @@ func TestEvents_TailEmitsNDJSON(t *testing.T) {
 	}
 	require.GreaterOrEqual(t, len(lines), 2, "expected at least 2 NDJSON lines, got: %q", out)
 	for _, l := range lines[:2] {
-		var env map[string]any
-		require.NoError(t, json.Unmarshal([]byte(l), &env), "each line must be a JSON object")
-		assert.Equal(t, "issue.created", env["type"])
-		assert.NotEmpty(t, env["project_uid"])
-		assert.NotEmpty(t, env["issue_uid"])
+		var envObj map[string]any
+		require.NoError(t, json.Unmarshal([]byte(l), &envObj), "each line must be a JSON object")
+		assert.Equal(t, "issue.created", envObj["type"])
+		assert.NotEmpty(t, envObj["project_uid"])
+		assert.NotEmpty(t, envObj["issue_uid"])
 	}
 }
 
 func TestEvents_NegativeAfterRejected(t *testing.T) {
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"events", "--all-projects", "--after=-1"})
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, ExitUsage, ce.ExitCode)
+	_, err := runCmdOutput(t, nil, "events", "--all-projects", "--after=-1")
+	ce := requireCLIError(t, err, ExitUsage)
 	assert.Contains(t, ce.Message, "non-negative")
 }
 
 func TestEvents_NegativeLastEventIDRejected(t *testing.T) {
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"events", "--all-projects", "--tail", "--last-event-id=-1"})
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, ExitUsage, ce.ExitCode)
+	_, err := runCmdOutput(t, nil, "events", "--all-projects", "--tail", "--last-event-id=-1")
+	ce := requireCLIError(t, err, ExitUsage)
 	assert.Contains(t, ce.Message, "non-negative")
 }
 
@@ -205,39 +126,22 @@ func TestEvents_NegativeLastEventIDRejected(t *testing.T) {
 func TestEvents_TailFailsFastOn4xx(t *testing.T) {
 	resetFlags(t)
 	env := testenv.New(t)
-	cmd := newRootCmd()
-	buf := &safeBuffer{}
-	cmd.SetOut(buf)
-	cmd.SetErr(buf)
 	ctx, cancel := context.WithTimeout(contextWithBaseURL(context.Background(), env.URL), 5*time.Second)
 	defer cancel()
-	cmd.SetArgs([]string{"events", "--project-id", "99999", "--tail"})
-	cmd.SetContext(ctx)
-	err := cmd.Execute()
+	_, _, err := executeRootCapture(t, ctx, "events", "--project-id", "99999", "--tail")
 	require.Error(t, err, "tail must surface 404 instead of looping")
 	assert.Contains(t, err.Error(), "404")
 }
 
 func TestEvents_TailFollowsResetRequired(t *testing.T) {
-	resetFlags(t)
 	env := testenv.New(t)
 	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
 	createIssueViaHTTP(t, env, dir, "doomed")
 
-	cmd := newRootCmd()
-	buf := &safeBuffer{}
-	cmd.SetOut(buf)
 	ctx, cancel := context.WithTimeout(contextWithBaseURL(context.Background(), env.URL), 5*time.Second)
 	defer cancel()
-	cmd.SetArgs([]string{"--workspace", dir, "events", "--tail"})
-	cmd.SetContext(ctx)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		_ = cmd.Execute()
-	}()
+	a := startAsyncCLI(t, ctx, "--workspace", dir, "events", "--tail")
+	defer a.stop()
 
 	time.Sleep(300 * time.Millisecond)
 	pid := resolvePIDViaHTTP(t, env.URL, dir)
@@ -251,17 +155,10 @@ func TestEvents_TailFollowsResetRequired(t *testing.T) {
 	_ = resp.Body.Close()
 	require.Equal(t, 200, resp.StatusCode)
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.Contains(buf.Snapshot(), `"reset_required":true`) {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	cancel()
-	wg.Wait()
-
-	assert.Contains(t, buf.Snapshot(), `"reset_required":true`,
+	out := a.awaitOutput(func(s string) bool {
+		return strings.Contains(s, `"reset_required":true`)
+	}, 2*time.Second)
+	assert.Contains(t, out, `"reset_required":true`,
 		"--tail must emit a reset envelope when the daemon sends sync.reset_required")
 }
 
@@ -274,19 +171,8 @@ func TestEvents_TailRejectsOneShotFlags(t *testing.T) {
 		{"events", "--tail", "--limit", "1"},
 		{"events", "--tail", "--after", "5"},
 	} {
-		resetFlags(t)
-		cmd := newRootCmd()
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
-		cmd.SetErr(&buf)
-		cmd.SetArgs(args)
-		cmd.SetContext(context.Background())
-
-		err := cmd.Execute()
-		require.Errorf(t, err, "args %v should reject", args)
-		var ce *cliError
-		require.True(t, errors.As(err, &ce), "expected *cliError, got %T", err)
-		assert.Equalf(t, ExitUsage, ce.ExitCode, "args %v: wrong exit code", args)
+		_, err := runCmdOutput(t, nil, args...)
+		ce := requireCLIError(t, err, ExitUsage)
 		assert.Equalf(t, kindUsage, ce.Kind, "args %v: wrong kind", args)
 	}
 }
@@ -295,19 +181,8 @@ func TestEvents_TailRejectsOneShotFlags(t *testing.T) {
 // --last-event-id is documented as --tail-only, so passing it without
 // --tail should reject loudly instead of being silently ignored.
 func TestEvents_OneShotRejectsTailFlag(t *testing.T) {
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"events", "--last-event-id", "5"})
-	cmd.SetContext(context.Background())
-
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.True(t, errors.As(err, &ce))
-	assert.Equal(t, ExitUsage, ce.ExitCode)
+	_, err := runCmdOutput(t, nil, "events", "--last-event-id", "5")
+	_ = requireCLIError(t, err, ExitUsage)
 }
 
 // TestEvents_OneShotRejectsNonPositiveLimit: parallel to list/ready,
@@ -315,18 +190,7 @@ func TestEvents_OneShotRejectsTailFlag(t *testing.T) {
 // has the same check after hammer-test #5.
 func TestEvents_OneShotRejectsNonPositiveLimit(t *testing.T) {
 	for _, lim := range []string{"0", "-1"} {
-		resetFlags(t)
-		cmd := newRootCmd()
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
-		cmd.SetErr(&buf)
-		cmd.SetArgs([]string{"events", "--limit", lim})
-		cmd.SetContext(context.Background())
-
-		err := cmd.Execute()
-		require.Errorf(t, err, "--limit %s should reject", lim)
-		var ce *cliError
-		require.True(t, errors.As(err, &ce))
-		assert.Equal(t, ExitValidation, ce.ExitCode)
+		_, err := runCmdOutput(t, nil, "events", "--limit", lim)
+		_ = requireCLIError(t, err, ExitValidation)
 	}
 }

--- a/cmd/kata/export_test.go
+++ b/cmd/kata/export_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -13,11 +12,8 @@ import (
 )
 
 func TestExportWritesJSONLToOutput(t *testing.T) {
-	resetFlags(t)
-	home := t.TempDir()
+	home := setupKataEnv(t)
 	dbPath := filepath.Join(home, "kata.db")
-	t.Setenv("KATA_HOME", home)
-	t.Setenv("KATA_DB", dbPath)
 	d, err := db.Open(context.Background(), dbPath)
 	require.NoError(t, err)
 	p, err := d.CreateProject(context.Background(), "github.com/wesm/kata", "kata")
@@ -31,25 +27,19 @@ func TestExportWritesJSONLToOutput(t *testing.T) {
 	require.NoError(t, d.Close())
 
 	outPath := filepath.Join(home, "export.jsonl")
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"export", "--output", outPath})
-	require.NoError(t, cmd.Execute())
+	out, err := runCmdOutput(t, nil, "export", "--output", outPath)
+	require.NoError(t, err)
 
 	bs, err := os.ReadFile(outPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(bs), `"kind":"meta"`)
 	assert.Contains(t, string(bs), "exported issue")
-	assert.Contains(t, buf.String(), outPath)
+	assert.Contains(t, out, outPath)
 }
 
 func TestExportRefusesRunningDaemonUnlessAllowed(t *testing.T) {
-	resetFlags(t)
-	home := t.TempDir()
+	home := setupKataEnv(t)
 	dbPath := filepath.Join(home, "kata.db")
-	t.Setenv("KATA_HOME", home)
-	t.Setenv("KATA_DB", dbPath)
 	d, err := db.Open(context.Background(), dbPath)
 	require.NoError(t, err)
 	require.NoError(t, d.Close())
@@ -57,12 +47,7 @@ func TestExportRefusesRunningDaemonUnlessAllowed(t *testing.T) {
 	t.Cleanup(cleanup)
 	require.NoError(t, writeRuntimeFor(home, addr))
 
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"export", "--output", filepath.Join(home, "export.jsonl")})
-	err = cmd.Execute()
-
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
+	_, err = runCmdOutput(t, nil, "export", "--output", filepath.Join(home, "export.jsonl"))
+	ce := requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "daemon is running")
 }

--- a/cmd/kata/helpers_test.go
+++ b/cmd/kata/helpers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -17,46 +18,83 @@ func writeStringFile(t *testing.T, path, body string) {
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
 }
 
-func TestResolveBody_FlagWins(t *testing.T) {
-	got, err := resolveBody(BodySources{Body: "hello", BodySet: true}, nil)
-	require.NoError(t, err)
-	assert.Equal(t, "hello", got)
+// runEmitJSON invokes emitJSON against a fresh buffer and returns its output,
+// removing the var-buf-then-String dance from each test case.
+func runEmitJSON(t *testing.T, payload any) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	err := emitJSON(&buf, payload)
+	return buf.String(), err
 }
 
-func TestResolveBody_ExplicitEmptyIsHonored(t *testing.T) {
-	got, err := resolveBody(BodySources{Body: "", BodySet: true}, nil)
-	require.NoError(t, err)
-	assert.Equal(t, "", got)
-}
-
-func TestResolveBody_FromFile(t *testing.T) {
-	dir := t.TempDir()
-	path := dir + "/b.txt"
-	writeStringFile(t, path, "from file")
-	got, err := resolveBody(BodySources{File: path, FileSet: true}, nil)
-	require.NoError(t, err)
-	assert.Equal(t, "from file", got)
-}
-
-func TestResolveBody_FromStdin(t *testing.T) {
-	in := bytes.NewBufferString("from stdin")
-	got, err := resolveBody(BodySources{Stdin: true}, in)
-	require.NoError(t, err)
-	assert.Equal(t, "from stdin", got)
-}
-
-func TestResolveBody_TwoSourcesIsError(t *testing.T) {
-	_, err := resolveBody(BodySources{Body: "x", BodySet: true, Stdin: true}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "exactly one")
-}
-
-// An explicit `--body ""` together with `--body-stdin` is still a conflict —
-// the previous (count by non-empty value) implementation missed this case.
-func TestResolveBody_TwoSourcesEmptyBodyIsError(t *testing.T) {
-	_, err := resolveBody(BodySources{Body: "", BodySet: true, Stdin: true}, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "exactly one")
+func TestResolveBody(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(t *testing.T) (BodySources, io.Reader)
+		want    string
+		wantErr string
+	}{
+		{
+			name: "flag wins",
+			setup: func(*testing.T) (BodySources, io.Reader) {
+				return BodySources{Body: "hello", BodySet: true}, nil
+			},
+			want: "hello",
+		},
+		{
+			name: "explicit empty is honored",
+			setup: func(*testing.T) (BodySources, io.Reader) {
+				return BodySources{Body: "", BodySet: true}, nil
+			},
+			want: "",
+		},
+		{
+			name: "from file",
+			setup: func(t *testing.T) (BodySources, io.Reader) {
+				path := t.TempDir() + "/b.txt"
+				writeStringFile(t, path, "from file")
+				return BodySources{File: path, FileSet: true}, nil
+			},
+			want: "from file",
+		},
+		{
+			name: "from stdin",
+			setup: func(*testing.T) (BodySources, io.Reader) {
+				return BodySources{Stdin: true}, bytes.NewBufferString("from stdin")
+			},
+			want: "from stdin",
+		},
+		{
+			name: "two sources is error",
+			setup: func(*testing.T) (BodySources, io.Reader) {
+				return BodySources{Body: "x", BodySet: true, Stdin: true}, nil
+			},
+			wantErr: "exactly one",
+		},
+		{
+			// An explicit `--body ""` together with `--body-stdin` is still a
+			// conflict — the previous (count by non-empty value) implementation
+			// missed this case.
+			name: "two sources with empty body is error",
+			setup: func(*testing.T) (BodySources, io.Reader) {
+				return BodySources{Body: "", BodySet: true, Stdin: true}, nil
+			},
+			wantErr: "exactly one",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sources, stdin := tc.setup(t)
+			got, err := resolveBody(sources, stdin)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func TestResolveActor_Precedence(t *testing.T) {
@@ -87,30 +125,30 @@ func TestResolveActor_Precedence(t *testing.T) {
 }
 
 func TestEmitJSON_AddsAPIVersion(t *testing.T) {
-	var buf bytes.Buffer
-	require.NoError(t, emitJSON(&buf, map[string]string{"x": "y"}))
-	out := buf.String()
+	out, err := runEmitJSON(t, map[string]string{"x": "y"})
+	require.NoError(t, err)
 	assert.Contains(t, out, `"kata_api_version":1`)
 	assert.Contains(t, out, `"x":"y"`)
 	assert.True(t, strings.HasSuffix(out, "\n"))
 }
 
 func TestEmitJSON_EmptyObject(t *testing.T) {
-	var buf bytes.Buffer
-	require.NoError(t, emitJSON(&buf, struct{}{}))
-	assert.Equal(t, "{\"kata_api_version\":1}\n", buf.String())
+	out, err := runEmitJSON(t, struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, "{\"kata_api_version\":1}\n", out)
 }
 
 func TestEmitJSON_RejectsNonObject(t *testing.T) {
-	var buf bytes.Buffer
-	require.Error(t, emitJSON(&buf, "scalar"))
-	require.Error(t, emitJSON(&buf, []int{1, 2, 3}))
-	require.Error(t, emitJSON(&buf, nil))
+	_, err := runEmitJSON(t, "scalar")
+	require.Error(t, err)
+	_, err = runEmitJSON(t, []int{1, 2, 3})
+	require.Error(t, err)
+	_, err = runEmitJSON(t, nil)
+	require.Error(t, err)
 }
 
 func TestEmitJSON_RejectsReservedKey(t *testing.T) {
-	var buf bytes.Buffer
-	err := emitJSON(&buf, map[string]any{"kata_api_version": "evil"})
+	_, err := runEmitJSON(t, map[string]any{"kata_api_version": "evil"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kata_api_version")
 }
@@ -122,14 +160,13 @@ func TestEmitJSON_RejectsReservedKey(t *testing.T) {
 // bytes.Contains(`"kata_api_version"`) guard would have let this slip
 // through and produced a duplicate-keyed envelope downstream.
 func TestEmitJSON_RejectsEscapedReservedKey(t *testing.T) {
-	var buf bytes.Buffer
 	// Build the escape sequence explicitly — backtick raw strings interpret
 	// the bytes literally, but writing `k` here avoids any rendering
 	// ambiguity in the source file.
 	payload := json.RawMessage([]byte(`{"\u006bata_api_version":"evil"}`))
 	require.NotContains(t, string(payload), `"kata_api_version"`,
 		"test fixture itself must contain the escape, not the literal key")
-	err := emitJSON(&buf, payload)
+	_, err := runEmitJSON(t, payload)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kata_api_version")
 }

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -13,19 +13,19 @@ import (
 	"github.com/wesm/kata/internal/jsonl"
 )
 
-func TestImportCreatesTargetDB(t *testing.T) {
-	resetFlags(t)
-	home := t.TempDir()
-	t.Setenv("KATA_HOME", home)
-	t.Setenv("KATA_DB", filepath.Join(home, "kata.db"))
-	input := writeExportFixture(t, home)
-	target := filepath.Join(home, "target.db")
+func setupImportTest(t *testing.T) (home, input, target string) {
+	t.Helper()
+	home = setupKataEnv(t)
+	input = writeExportFixture(t, home)
+	target = filepath.Join(home, "target.db")
+	return home, input, target
+}
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"import", "--input", input, "--target", target})
-	require.NoError(t, cmd.Execute())
+func TestImportCreatesTargetDB(t *testing.T) {
+	_, input, target := setupImportTest(t)
+
+	out, err := runCmdOutput(t, nil, "import", "--input", input, "--target", target)
+	require.NoError(t, err)
 
 	d, err := db.Open(context.Background(), target)
 	require.NoError(t, err)
@@ -33,40 +33,25 @@ func TestImportCreatesTargetDB(t *testing.T) {
 	got, err := d.ProjectByIdentity(context.Background(), "github.com/wesm/kata")
 	require.NoError(t, err)
 	assert.Equal(t, "kata", got.Name)
-	assert.Contains(t, buf.String(), target)
+	assert.Contains(t, out, target)
 }
 
 func TestImportRejectsExistingTargetWithoutForce(t *testing.T) {
-	resetFlags(t)
-	home := t.TempDir()
-	t.Setenv("KATA_HOME", home)
-	t.Setenv("KATA_DB", filepath.Join(home, "kata.db"))
-	input := writeExportFixture(t, home)
-	target := filepath.Join(home, "target.db")
+	_, input, target := setupImportTest(t)
 	d, err := db.Open(context.Background(), target)
 	require.NoError(t, err)
 	_, err = d.CreateProject(context.Background(), "github.com/wesm/existing", "existing")
 	require.NoError(t, err)
 	require.NoError(t, d.Close())
 
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"import", "--input", input, "--target", target})
-	err = cmd.Execute()
-
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
+	_, err = runCmdOutput(t, nil, "import", "--input", input, "--target", target)
+	ce := requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "target already exists")
 }
 
 func TestImportRefusesDaemon(t *testing.T) {
-	resetFlags(t)
-	home := t.TempDir()
+	home, input, target := setupImportTest(t)
 	dbPath := filepath.Join(home, "kata.db")
-	t.Setenv("KATA_HOME", home)
-	t.Setenv("KATA_DB", dbPath)
-	input := writeExportFixture(t, home)
-	target := filepath.Join(home, "target.db")
 	d, err := db.Open(context.Background(), dbPath)
 	require.NoError(t, err)
 	require.NoError(t, d.Close())
@@ -74,13 +59,8 @@ func TestImportRefusesDaemon(t *testing.T) {
 	t.Cleanup(cleanup)
 	require.NoError(t, writeRuntimeFor(home, addr))
 
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"import", "--input", input, "--target", target})
-	err = cmd.Execute()
-
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
+	_, err = runCmdOutput(t, nil, "import", "--input", input, "--target", target)
+	ce := requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "daemon is running")
 	assert.NotContains(t, ce.Message, "--allow-running-daemon")
 }

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -24,22 +23,14 @@ func TestInit_FreshGitRepoBindsViaRemote(t *testing.T) {
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
+	resetFlags(t)
 	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
 
 	ctx := context.Background()
 	out, err := callInit(ctx, env.URL, dir, callInitOpts{})
 	require.NoError(t, err)
 	assert.Contains(t, out, `"identity":"github.com/wesm/kata"`)
 	assert.FileExists(t, filepath.Join(dir, ".kata.toml"))
-}
-
-func runGit(t *testing.T, dir string, args ...string) {
-	t.Helper()
-	cmd := exec.Command("git", args...) //nolint:gosec // git binary is trusted; args are test-controlled
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "git %v: %s", args, out)
 }
 
 func TestInit_AddsLocalToGitignoreWhenAbsent(t *testing.T) {

--- a/cmd/kata/issue_ref_commands_test.go
+++ b/cmd/kata/issue_ref_commands_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strings"
@@ -9,34 +8,23 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/db"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestIssueRefCommandsAcceptUIDs(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+	env, dir := setupCLIEnv(t)
 	pid := resolvePIDViaHTTP(t, env.URL, dir)
 
-	nextNumber := int64(0)
 	issue := func(title string) db.Issue {
 		t.Helper()
-		createIssue(t, env, pid, title)
-		nextNumber++
-		iss, err := env.DB.IssueByNumber(context.Background(), pid, nextNumber)
+		num := createIssueViaHTTP(t, env, dir, title)
+		iss, err := env.DB.IssueByNumber(context.Background(), pid, num)
 		require.NoError(t, err)
 		return iss
 	}
 	run := func(args ...string) string {
 		t.Helper()
 		resetFlags(t)
-		cmd := newRootCmd()
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
-		cmd.SetArgs(append([]string{"--workspace", dir}, args...))
-		cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-		require.NoError(t, cmd.Execute(), strings.Join(args, " "))
-		return buf.String()
+		return runCLI(t, env, dir, args...)
 	}
 
 	assign := issue("assign by uid")

--- a/cmd/kata/jsonl_smoke_test.go
+++ b/cmd/kata/jsonl_smoke_test.go
@@ -1,19 +1,10 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"net"
-	"net/http"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/daemon"
-	"github.com/wesm/kata/internal/db"
 	"github.com/wesm/kata/internal/testenv"
 )
 
@@ -21,87 +12,23 @@ func TestSmoke_ExportImport(t *testing.T) {
 	env := testenv.New(t)
 	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
 
-	runSmokeCLI(t, env.URL, []string{"--workspace", dir, "create", "export smoke one", "--body", "orchid body", "--label", "bug"})
-	runSmokeCLI(t, env.URL, []string{"--workspace", dir, "create", "export smoke two", "--body", "blocks first", "--blocks", "1"})
-	runSmokeCLI(t, env.URL, []string{"--workspace", dir, "comment", "1", "--body", "watermelon note"})
-	runSmokeCLI(t, env.URL, []string{"--workspace", dir, "label", "add", "2", "backend"})
+	runCLI(t, env, dir, "create", "export smoke one", "--body", "orchid body", "--label", "bug")
+	runCLI(t, env, dir, "create", "export smoke two", "--body", "blocks first", "--blocks", "1")
+	runCLI(t, env, dir, "comment", "1", "--body", "watermelon note")
+	runCLI(t, env, dir, "label", "add", "2", "backend")
 
-	before := runSmokeCLI(t, env.URL, []string{"--workspace", dir, "--json", "list"})
-	beforeShow := runSmokeCLI(t, env.URL, []string{"--workspace", dir, "--json", "show", "1"})
+	before := runCLI(t, env, dir, "--json", "list")
+	beforeShow := runCLI(t, env, dir, "--json", "show", "1")
 	assert.Contains(t, beforeShow, "watermelon note")
 	exportPath := filepath.Join(env.Home, "smoke.jsonl")
-	runSmokeCLI(t, env.URL, []string{"export", "--output", exportPath})
+	runCLI(t, env, dir, "export", "--output", exportPath)
 	targetPath := filepath.Join(t.TempDir(), "imported.db")
-	runSmokeCLI(t, env.URL, []string{"import", "--input", exportPath, "--target", targetPath})
+	runCLI(t, env, dir, "import", "--input", exportPath, "--target", targetPath)
 
-	importedURL := startSmokeDaemonForDB(t, targetPath)
-	after := runSmokeCLI(t, importedURL, []string{"--workspace", dir, "--json", "list"})
-	afterShow := runSmokeCLI(t, importedURL, []string{"--workspace", dir, "--json", "show", "1"})
+	imported := testenv.NewFromDB(t, targetPath)
+	after := runCLI(t, imported, dir, "--json", "list")
+	afterShow := runCLI(t, imported, dir, "--json", "show", "1")
 
 	assert.JSONEq(t, before, after)
 	assert.JSONEq(t, beforeShow, afterShow)
-}
-
-func runSmokeCLI(t *testing.T, baseURL string, args []string) string {
-	t.Helper()
-	resetFlags(t)
-	cmd := newRootCmd()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs(args)
-	cmd.SetContext(contextWithBaseURL(context.Background(), baseURL))
-	require.NoError(t, cmd.Execute())
-	return out.String()
-}
-
-func startSmokeDaemonForDB(t *testing.T, path string) string {
-	t.Helper()
-	d, err := db.Open(context.Background(), path)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = d.Close() })
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	bcast := daemon.NewEventBroadcaster()
-	srv := daemon.NewServer(daemon.ServerConfig{
-		DB:          d,
-		StartedAt:   time.Now().UTC(),
-		Broadcaster: bcast,
-	})
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		_ = srv.Serve(ctx, l)
-	}()
-	t.Cleanup(func() {
-		cancel()
-		<-done
-	})
-	url := "http://" + l.Addr().String()
-	waitSmokeDaemon(t, url)
-	return url
-}
-
-func waitSmokeDaemon(t *testing.T, url string) {
-	t.Helper()
-	client := &http.Client{Timeout: 2 * time.Second}
-	deadline := time.Now().Add(2 * time.Second)
-	var lastErr error
-	for time.Now().Before(deadline) {
-		resp, err := client.Get(url + "/api/v1/ping") //nolint:noctx // short test readiness poll
-		if err == nil {
-			var body struct {
-				OK bool `json:"ok"`
-			}
-			lastErr = json.NewDecoder(resp.Body).Decode(&body)
-			_ = resp.Body.Close()
-			if resp.StatusCode == http.StatusOK && body.OK && lastErr == nil {
-				return
-			}
-		} else {
-			lastErr = err
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	require.NoError(t, lastErr)
 }

--- a/cmd/kata/label_test.go
+++ b/cmd/kata/label_test.go
@@ -1,76 +1,34 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestLabelAdd_HappyPath(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
-	createIssue(t, env, pid, "a")
+	env, dir, _ := setupWorkspaceWithIssue(t, "a")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "label", "add", "1", "needs-review"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "needs-review")
+	out := runCLI(t, env, dir, "label", "add", "1", "needs-review")
+	assert.Contains(t, out, "needs-review")
 }
 
 func TestLabelRm_HappyPath(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
-	createIssue(t, env, pid, "a")
+	env, dir, _ := setupWorkspaceWithIssue(t, "a")
 
-	addCmd := newRootCmd()
-	addCmd.SetOut(&bytes.Buffer{})
-	addCmd.SetArgs([]string{"--workspace", dir, "label", "add", "1", "bug"})
-	addCmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, addCmd.Execute())
-
-	resetFlags(t)
-	rmCmd := newRootCmd()
-	var buf bytes.Buffer
-	rmCmd.SetOut(&buf)
-	rmCmd.SetArgs([]string{"--workspace", dir, "label", "rm", "1", "bug"})
-	rmCmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, rmCmd.Execute())
-	assert.True(t, strings.Contains(buf.String(), "removed") ||
-		strings.Contains(buf.String(), "unlabeled"))
+	runCLI(t, env, dir, "label", "add", "1", "bug")
+	out := runCLI(t, env, dir, "label", "rm", "1", "bug")
+	assert.True(t, strings.Contains(out, "removed") || strings.Contains(out, "unlabeled"))
 }
 
 func TestLabelsList_PrintsCounts(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
-	createIssue(t, env, pid, "a")
-	addCmd := newRootCmd()
-	addCmd.SetOut(&bytes.Buffer{})
-	addCmd.SetArgs([]string{"--workspace", dir, "label", "add", "1", "bug"})
-	addCmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, addCmd.Execute())
+	env, dir, _ := setupWorkspaceWithIssue(t, "a")
 
-	resetFlags(t)
-	listCmd := newRootCmd()
-	var buf bytes.Buffer
-	listCmd.SetOut(&buf)
-	listCmd.SetArgs([]string{"--workspace", dir, "labels"})
-	listCmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, listCmd.Execute())
-	out := buf.String()
+	runCLI(t, env, dir, "label", "add", "1", "bug")
+	out := runCLI(t, env, dir, "labels")
 	assert.Contains(t, out, "bug")
 	assert.Contains(t, out, "1")
 }
@@ -86,18 +44,9 @@ func TestLabel_RejectsEmptyLabel(t *testing.T) {
 		{"label", "rm", "1", "  "},
 	} {
 		resetFlags(t)
-		cmd := newRootCmd()
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
-		cmd.SetErr(&buf)
-		cmd.SetArgs(args)
-		cmd.SetContext(context.Background())
-
-		err := cmd.Execute()
+		_, _, err := executeRootCapture(t, context.Background(), args...)
 		require.Errorf(t, err, "args %v should reject", args)
-		var ce *cliError
-		require.ErrorAs(t, err, &ce)
-		assert.Equal(t, ExitValidation, ce.ExitCode)
+		ce := requireCLIError(t, err, ExitValidation)
 		assert.Contains(t, ce.Message, "label must not be empty")
 	}
 }
@@ -109,17 +58,7 @@ func TestLabel_RejectsEmptyLabel(t *testing.T) {
 // client-side instead.
 func TestCreate_RejectsWhitespaceLabel(t *testing.T) {
 	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"create", "title", "--label", "   "})
-	cmd.SetContext(context.Background())
-
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, ExitValidation, ce.ExitCode)
+	_, _, err := executeRootCapture(t, context.Background(), "create", "title", "--label", "   ")
+	ce := requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "label must not be empty")
 }

--- a/cmd/kata/link_test.go
+++ b/cmd/kata/link_test.go
@@ -1,40 +1,25 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestLink_GenericRoundTrip(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "a")
 	createIssue(t, env, pid, "b")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "link", "1", "blocks", "2"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
+	out := runCLI(t, env, dir, "link", "1", "blocks", "2")
 	assert.True(t, strings.Contains(out, "linked") || strings.Contains(out, "blocks"))
 }
 
 func TestLink_AcceptsUIDRefs(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "a")
 	createIssue(t, env, pid, "b")
 	a, err := env.DB.IssueByNumber(context.Background(), pid, 1)
@@ -42,13 +27,8 @@ func TestLink_AcceptsUIDRefs(t *testing.T) {
 	b, err := env.DB.IssueByNumber(context.Background(), pid, 2)
 	require.NoError(t, err)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "link", a.UID, "blocks", b.UID})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.True(t, strings.Contains(buf.String(), "linked") || strings.Contains(buf.String(), "blocks"))
+	out := runCLI(t, env, dir, "link", a.UID, "blocks", b.UID)
+	assert.True(t, strings.Contains(out, "linked") || strings.Contains(out, "blocks"))
 
 	link, err := env.DB.LinkByEndpoints(context.Background(), a.ID, b.ID, "blocks")
 	require.NoError(t, err)
@@ -57,10 +37,7 @@ func TestLink_AcceptsUIDRefs(t *testing.T) {
 }
 
 func TestUnlink_AcceptsUIDRefs(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "a")
 	createIssue(t, env, pid, "b")
 	a, err := env.DB.IssueByNumber(context.Background(), pid, 1)
@@ -69,130 +46,59 @@ func TestUnlink_AcceptsUIDRefs(t *testing.T) {
 	require.NoError(t, err)
 	createLinkViaHTTP(t, env, pid, 1, "blocks", 2)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "unlink", a.UID, "blocks", b.UID})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "unlinked")
+	out := runCLI(t, env, dir, "unlink", a.UID, "blocks", b.UID)
+	assert.Contains(t, out, "unlinked")
 }
 
 func TestParent_WithReplace(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "child")
 	createIssue(t, env, pid, "p1")
 	createIssue(t, env, pid, "p2")
 
-	cmd1 := newRootCmd()
-	cmd1.SetOut(&bytes.Buffer{})
-	cmd1.SetArgs([]string{"--workspace", dir, "parent", "1", "2"})
-	cmd1.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd1.Execute())
-
-	resetFlags(t)
-	cmd2 := newRootCmd()
-	var buf bytes.Buffer
-	cmd2.SetOut(&buf)
-	cmd2.SetArgs([]string{"--workspace", dir, "parent", "1", "3", "--replace"})
-	cmd2.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd2.Execute())
-	assert.True(t, strings.Contains(buf.String(), "linked") ||
-		strings.Contains(buf.String(), "parent"))
+	runCLI(t, env, dir, "parent", "1", "2")
+	out := runCLI(t, env, dir, "parent", "1", "3", "--replace")
+	assert.True(t, strings.Contains(out, "linked") || strings.Contains(out, "parent"))
 }
 
 func TestUnlink_RemovesLink(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "a")
 	createIssue(t, env, pid, "b")
-
 	createLinkViaHTTP(t, env, pid, 1, "blocks", 2)
 
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "unlink", "1", "blocks", "2"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.True(t, strings.Contains(buf.String(), "unlinked") ||
-		strings.Contains(buf.String(), "removed"))
+	out := runCLI(t, env, dir, "unlink", "1", "blocks", "2")
+	assert.True(t, strings.Contains(out, "unlinked") || strings.Contains(out, "removed"))
 }
 
 func TestUnparent_RemovesParentLink(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "child")
 	createIssue(t, env, pid, "p")
-
 	createLinkViaHTTP(t, env, pid, 1, "parent", 2)
 
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "unparent", "1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.True(t, strings.Contains(buf.String(), "unlinked") ||
-		strings.Contains(buf.String(), "removed"))
+	out := runCLI(t, env, dir, "unparent", "1")
+	assert.True(t, strings.Contains(out, "unlinked") || strings.Contains(out, "removed"))
 }
 
 func TestRelate_CanonicalOrderingHidesArgOrder(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "a")
 	createIssue(t, env, pid, "b")
 
-	cmd := newRootCmd()
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetArgs([]string{"--workspace", dir, "relate", "2", "1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-
-	resetFlags(t)
-	cmd2 := newRootCmd()
-	var buf bytes.Buffer
-	cmd2.SetOut(&buf)
-	cmd2.SetArgs([]string{"--workspace", dir, "relate", "1", "2"})
-	cmd2.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd2.Execute())
-	assert.Contains(t, buf.String(), "no-op")
+	runCLI(t, env, dir, "relate", "2", "1")
+	out := runCLI(t, env, dir, "relate", "1", "2")
+	assert.Contains(t, out, "no-op")
 }
 
 func TestBlock_RoundTrip(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "blocker")
 	createIssue(t, env, pid, "blocked")
 
-	cmd := newRootCmd()
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetArgs([]string{"--workspace", dir, "block", "1", "2"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-
-	resetFlags(t)
-	cmd2 := newRootCmd()
-	var buf bytes.Buffer
-	cmd2.SetOut(&buf)
-	cmd2.SetArgs([]string{"--workspace", dir, "unblock", "1", "2"})
-	cmd2.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd2.Execute())
-	assert.True(t, strings.Contains(buf.String(), "unlinked") ||
-		strings.Contains(buf.String(), "removed"))
+	runCLI(t, env, dir, "block", "1", "2")
+	out := runCLI(t, env, dir, "unblock", "1", "2")
+	assert.True(t, strings.Contains(out, "unlinked") || strings.Contains(out, "removed"))
 }
 
 // TestUnlink_RelatedReverseOrderStillFinds verifies that `kata unlink 5
@@ -200,50 +106,14 @@ func TestBlock_RoundTrip(t *testing.T) {
 // canonicalizes related storage to (min,max), so order at lookup time must
 // not matter.
 func TestUnlink_RelatedReverseOrderStillFinds(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "a")
 	createIssue(t, env, pid, "b")
 
 	// Daemon stores this canonically as (1,2).
 	createLinkViaHTTP(t, env, pid, 1, "related", 2)
 
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
 	// User passes (2,1) — reverse of the canonical storage order.
-	cmd.SetArgs([]string{"--workspace", dir, "unlink", "2", "related", "1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "unlinked")
-}
-
-// createLinkViaHTTP is a thin test helper duplicated in link_test.go and
-// label_test.go because cmd/kata is a separate package from internal/daemon.
-func createLinkViaHTTP(t *testing.T, env *testenv.Env, projectID, fromNumber int64, linkType string, toNumber int64) {
-	t.Helper()
-	body := []byte(`{"actor":"tester","type":"` + linkType + `","to_number":` + itoa(toNumber) + `}`)
-	resp, err := http.Post(
-		env.URL+"/api/v1/projects/"+itoa(projectID)+
-			"/issues/"+itoa(fromNumber)+"/links",
-		"application/json", bytes.NewReader(body)) //nolint:noctx,gosec // test-only loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-}
-
-// createIssue is a test helper that creates an issue via HTTP and discards
-// the response. Use when you need an issue but not its number (numbers go
-// 1, 2, 3 in order so you can hard-code them).
-func createIssue(t *testing.T, env *testenv.Env, projectID int64, title string) {
-	t.Helper()
-	body := []byte(`{"actor":"tester","title":"` + title + `"}`)
-	resp, err := http.Post(
-		env.URL+"/api/v1/projects/"+itoa(projectID)+"/issues",
-		"application/json", bytes.NewReader(body)) //nolint:noctx,gosec // test-only loopback
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
+	out := runCLI(t, env, dir, "unlink", "2", "related", "1")
+	assert.Contains(t, out, "unlinked")
 }

--- a/cmd/kata/list_test.go
+++ b/cmd/kata/list_test.go
@@ -1,41 +1,21 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestList_DefaultsToOpenIssuesInProject(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	for _, title := range []string{"alpha", "beta"} {
-		body := []byte(`{"actor":"x","title":"` + title + `"}`)
-		resp, err := http.Post(env.URL+"/api/v1/projects/"+itoa(pid)+"/issues", "application/json", bytes.NewReader(body)) //nolint:gosec,noctx // test-only
-		require.NoError(t, err)
-		require.Equal(t, 200, resp.StatusCode)
-		_ = resp.Body.Close()
+		createIssue(t, env, pid, title)
 	}
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "list"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
-	assert.True(t, strings.Contains(out, "alpha"))
-	assert.True(t, strings.Contains(out, "beta"))
+	out := runCLI(t, env, dir, "list")
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "beta")
 }
 
 // TestList_SanitizesAnsiAndNewlinesInTitle covers hammer-test
@@ -45,27 +25,10 @@ func TestList_DefaultsToOpenIssuesInProject(t *testing.T) {
 // at the human-output boundary; the JSON path is exempt (agents need
 // the raw bytes).
 func TestList_SanitizesAnsiAndNewlinesInTitle(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "evil\x1b[2Jtitle\nwith newline")
 
-	hostile := "evil\x1b[2Jtitle\nwith newline"
-	body, err := json.Marshal(map[string]string{"actor": "x", "title": hostile})
-	require.NoError(t, err)
-	resp, err := http.Post(env.URL+"/api/v1/projects/"+itoa(pid)+"/issues", //nolint:gosec,noctx
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	require.Equal(t, 200, resp.StatusCode)
-	_ = resp.Body.Close()
-
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "list"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
+	out := runCLI(t, env, dir, "list")
 	assert.NotContains(t, out, "\x1b", "ESC reached stdout")
 	// The newline in the title must be escaped (\n literal) so the
 	// list row stays on one visual line.

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -3,24 +3,17 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestRoot_HelpListsUniversalFlags(t *testing.T) {
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--help"})
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
+	out := string(executeRoot(t, newRootCmd(), "--help"))
 	assert.Contains(t, out, "--json")
 	assert.Contains(t, out, "--quiet")
 	assert.Contains(t, out, "--as")
@@ -40,13 +33,7 @@ func TestExitCodeFor_PureMapping(t *testing.T) {
 // command before PersistentPreRunE fires.
 func TestRunEEntered_FalseOnUnknownCommand(t *testing.T) {
 	resetRunEEntered(t)
-	cmd := newRootCmd()
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"this-command-does-not-exist"})
-	cmd.SetContext(context.Background())
-
-	err := cmd.Execute()
+	_, _, err := executeRootCapture(t, context.Background(), "this-command-does-not-exist")
 	require.Error(t, err)
 	assert.False(t, runEEntered, "PersistentPreRunE must not fire on unknown command")
 	assert.Equal(t, ExitUsage, exitCodeFor(err, runEEntered))
@@ -56,13 +43,7 @@ func TestRunEEntered_FalseOnUnknownCommand(t *testing.T) {
 // on whoami short-circuits before PersistentPreRunE.
 func TestRunEEntered_FalseOnNoArgsViolation(t *testing.T) {
 	resetRunEEntered(t)
-	cmd := newRootCmd()
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"whoami", "unexpected-positional-arg"})
-	cmd.SetContext(context.Background())
-
-	err := cmd.Execute()
+	_, _, err := executeRootCapture(t, context.Background(), "whoami", "unexpected-positional-arg")
 	require.Error(t, err)
 	assert.False(t, runEEntered, "NoArgs rejection must short-circuit before PersistentPreRunE")
 	assert.Equal(t, ExitUsage, exitCodeFor(err, runEEntered))
@@ -73,13 +54,8 @@ func TestRunEEntered_FalseOnNoArgsViolation(t *testing.T) {
 func TestRunEEntered_TrueOnSuccessfulRunE(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)
-	cmd := newRootCmd()
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"whoami", "--as", "test-actor"})
-	cmd.SetContext(context.Background())
-
-	require.NoError(t, cmd.Execute())
+	_, _, err := executeRootCapture(t, context.Background(), "whoami", "--as", "test-actor")
+	require.NoError(t, err)
 	assert.True(t, runEEntered, "PersistentPreRunE should fire before whoami's RunE")
 }
 
@@ -88,11 +64,7 @@ func TestRunEEntered_TrueOnSuccessfulRunE(t *testing.T) {
 // link/unlink can't mask each other's missing registration. A help-string
 // substring match for "link" passes if only "unlink" is registered.
 func TestRoot_Plan2VerbsAdvertised(t *testing.T) {
-	cmd := newRootCmd()
-	registered := make(map[string]struct{}, len(cmd.Commands()))
-	for _, sub := range cmd.Commands() {
-		registered[sub.Name()] = struct{}{}
-	}
+	registered := rootSubcommands()
 	for _, verb := range []string{
 		"link", "unlink", "parent", "unparent",
 		"block", "unblock", "relate", "unrelate",
@@ -109,11 +81,7 @@ func TestRoot_Plan2VerbsAdvertised(t *testing.T) {
 // search-and-destroy verbs Plan 3 introduces. A future regression that
 // drops a `subs` line will surface here, before it bites a user at the help.
 func TestRoot_Plan3VerbsAdvertised(t *testing.T) {
-	cmd := newRootCmd()
-	registered := make(map[string]struct{}, len(cmd.Commands()))
-	for _, sub := range cmd.Commands() {
-		registered[sub.Name()] = struct{}{}
-	}
+	registered := rootSubcommands()
 	for _, verb := range []string{"delete", "restore", "purge", "search"} {
 		_, ok := registered[verb]
 		assert.Truef(t, ok, "root must register subcommand %q", verb)
@@ -121,11 +89,7 @@ func TestRoot_Plan3VerbsAdvertised(t *testing.T) {
 }
 
 func TestRoot_QuickstartAdvertised(t *testing.T) {
-	cmd := newRootCmd()
-	registered := make(map[string]*cobra.Command, len(cmd.Commands()))
-	for _, sub := range cmd.Commands() {
-		registered[sub.Name()] = sub
-	}
+	registered := rootSubcommands()
 	quickstart, ok := registered["quickstart"]
 	require.True(t, ok, "root must register quickstart")
 	assert.Contains(t, quickstart.Aliases, "agent-instructions")
@@ -154,16 +118,7 @@ func TestEmitError_JSONMode_ProducesParseableEnvelope(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	emitError(&buf, cli, true, true)
-	var got struct {
-		Error struct {
-			Kind     string `json:"kind"`
-			Code     string `json:"code"`
-			Message  string `json:"message"`
-			ExitCode int    `json:"exit_code"`
-		} `json:"error"`
-	}
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &got),
-		"--json error must be parseable JSON; got %q", buf.String())
+	got := parseErrorEnvelope(t, buf.Bytes())
 	assert.Equal(t, "not_found", got.Error.Kind)
 	assert.Equal(t, "issue_not_found", got.Error.Code)
 	assert.Equal(t, "issue not found", got.Error.Message)
@@ -191,14 +146,7 @@ func TestEmitError_NonCliError_SynthesizesEnvelope(t *testing.T) {
 	plain := errors.New("connection refused")
 	var buf bytes.Buffer
 	emitError(&buf, plain, true, true) // runEReached=true → ExitInternal/internal
-	var got struct {
-		Error struct {
-			Kind     string `json:"kind"`
-			Message  string `json:"message"`
-			ExitCode int    `json:"exit_code"`
-		} `json:"error"`
-	}
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	got := parseErrorEnvelope(t, buf.Bytes())
 	assert.Equal(t, "internal", got.Error.Kind)
 	assert.Equal(t, "connection refused", got.Error.Message)
 	assert.Equal(t, ExitInternal, got.Error.ExitCode)
@@ -283,24 +231,15 @@ func TestHealth_HonorsKataServer(t *testing.T) {
 // printing Owner; unowned issues render as "(unowned)" so the cell
 // is never empty.
 func TestList_ShowsOwnerInParens(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	body := []byte(`{"actor":"x","title":"T","owner":"alice"}`)
 	resp, err := http.Post(env.URL+"/api/v1/projects/"+itoa(pid)+"/issues",
-		"application/json", bytes.NewReader(body)) //nolint:gosec,noctx
+		"application/json", bytes.NewReader(body)) //nolint:gosec,noctx // test-only loopback
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 	_ = resp.Body.Close()
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "list"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
+	out := runCLI(t, env, dir, "list")
 	assert.Contains(t, out, "(alice)", "list must show owner in parens")
 	assert.NotContains(t, out, "(x)",
 		"list must not show author in parens (would disagree with ready)")
@@ -317,20 +256,9 @@ func TestNegativePositional_ProducesUsefulError(t *testing.T) {
 		{"delete", "-1"},
 		{"link", "-1", "blocks", "3"},
 	} {
-		resetFlags(t)
-		cmd := newRootCmd()
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
-		cmd.SetErr(&buf)
-		cmd.SetArgs(args)
-		cmd.SetContext(context.Background())
-
-		err := cmd.Execute()
+		_, err := runCmdOutput(t, nil, args...)
 		require.Errorf(t, err, "args %v should error", args)
-		var ce *cliError
-		require.True(t, errors.As(err, &ce),
-			"expected *cliError for args %v, got %T: %v", args, err, err)
-		assert.Equal(t, ExitUsage, ce.ExitCode)
+		ce := requireCLIError(t, err, ExitUsage)
 		assert.Equal(t, kindUsage, ce.Kind)
 		assert.Contains(t, ce.Message, "--",
 			"useful error must mention the `--` separator workaround")

--- a/cmd/kata/purge_test.go
+++ b/cmd/kata/purge_test.go
@@ -1,64 +1,39 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestPurge_NoForceIsValidationError(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "vaporize")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "vaporize")
 
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--workspace", dir, "purge", "1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, ExitValidation, ce.ExitCode)
+	err := f.execute("purge", "1")
+	_ = requireCLIError(t, err, ExitValidation)
 }
 
 func TestPurge_ForceWithConfirmRemovesEverything(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "vaporize")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "vaporize")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "purge", "1", "--force", "--confirm", "PURGE #1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "purged")
+	require.NoError(t, f.execute("purge", "1", "--force", "--confirm", "PURGE #1"))
+	assert.Contains(t, f.buf.String(), "purged")
 }
 
 // TestPurge_NoTTYNoConfirmIsConfirmRequired mirrors the delete coverage:
 // non-terminal stdin + missing --confirm must surface as exit 6
 // confirm_required, not as a confirm_mismatch from an empty TTY read.
 func TestPurge_NoTTYNoConfirmIsConfirmRequired(t *testing.T) {
-	resetFlags(t)
 	stubIsTTY(t, false)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "vaporize")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "vaporize")
 
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--workspace", dir, "purge", "1", "--force"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, ExitConfirm, ce.ExitCode)
+	err := f.execute("purge", "1", "--force")
+	ce := requireCLIError(t, err, ExitConfirm)
 	assert.Equal(t, "confirm_required", ce.Code)
 }
 
@@ -66,20 +41,15 @@ func TestPurge_NoTTYNoConfirmIsConfirmRequired(t *testing.T) {
 // flows through the CLI → HTTP body → daemon → DB so the purge_log.reason
 // column captures the operator's free-text justification.
 func TestPurge_ReasonFlagPersistsToPurgeLog(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "vaporize")
+	f := newCLIFixture(t)
+	createIssueViaHTTP(t, f.env, f.dir, "vaporize")
 
 	const wantReason = "spam test data"
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--workspace", dir, "purge", "1",
-		"--force", "--confirm", "PURGE #1", "--reason", wantReason})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
+	require.NoError(t, f.execute("purge", "1",
+		"--force", "--confirm", "PURGE #1", "--reason", wantReason))
 
 	var got *string
-	err := env.DB.QueryRowContext(context.Background(),
+	err := f.env.DB.QueryRowContext(context.Background(),
 		`SELECT reason FROM purge_log ORDER BY id DESC LIMIT 1`).Scan(&got)
 	require.NoError(t, err)
 	require.NotNil(t, got, "purge_log.reason should not be NULL when --reason was provided")

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -11,31 +10,21 @@ import (
 
 func TestQuickstart_PrintsAgentInstructions(t *testing.T) {
 	resetFlags(t)
-	cmd := newQuickstartCmd()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs(nil)
-
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, out.String(), "kata agent quickstart")
-	assert.Contains(t, out.String(), "Search before creating")
-	assert.Contains(t, out.String(), "Do not run delete or purge")
+	out := string(executeRoot(t, newQuickstartCmd()))
+	assert.Contains(t, out, "kata agent quickstart")
+	assert.Contains(t, out, "Search before creating")
+	assert.Contains(t, out, "Do not run delete or purge")
 }
 
 func TestQuickstart_JSON(t *testing.T) {
 	resetFlags(t)
 	flags.JSON = true
-	cmd := newQuickstartCmd()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetArgs(nil)
-
-	require.NoError(t, cmd.Execute())
+	out := executeRoot(t, newQuickstartCmd())
 	var got struct {
 		APIVersion int    `json:"kata_api_version"`
 		Quickstart string `json:"quickstart"`
 	}
-	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.NoError(t, json.Unmarshal(out, &got))
 	assert.Equal(t, 1, got.APIVersion)
 	assert.Contains(t, got.Quickstart, "kata agent quickstart")
 }

--- a/cmd/kata/ready_test.go
+++ b/cmd/kata/ready_test.go
@@ -1,33 +1,20 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestReady_FiltersBlocked(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "blocker")
 	createIssue(t, env, pid, "blocked")
 	createIssue(t, env, pid, "standalone")
 	createLinkViaHTTP(t, env, pid, 1, "blocks", 2)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "ready"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
+	out := runCLI(t, env, dir, "ready")
 	assert.Contains(t, out, "blocker")
 	assert.Contains(t, out, "standalone")
 	assert.False(t, strings.Contains(out, "blocked"),

--- a/cmd/kata/restore_test.go
+++ b/cmd/kata/restore_test.go
@@ -1,34 +1,16 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestRestore_ClearsDeletedAt(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "delete me")
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "delete me")
 
-	// Soft delete via the CLI first.
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--workspace", dir, "delete", "1", "--force", "--confirm", "DELETE #1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-
-	// Then restore.
-	resetFlags(t)
-	cmd = newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "restore", "1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "restored")
+	runCLI(t, env, dir, "delete", "1", "--force", "--confirm", "DELETE #1")
+	output := runCLI(t, env, dir, "restore", "1")
+	assert.Contains(t, output, "restored")
 }

--- a/cmd/kata/search_test.go
+++ b/cmd/kata/search_test.go
@@ -1,65 +1,37 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestSearch_ReturnsMatchedIssues(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "fix login crash on Safari")
-	createIssueViaHTTP(t, env, dir, "unrelated issue")
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "fix login crash on Safari")
+	createIssue(t, env, pid, "unrelated issue")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "search", "login Safari"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "fix login crash on Safari")
-	assert.NotContains(t, buf.String(), "unrelated issue")
+	out := runCLI(t, env, dir, "search", "login Safari")
+	assert.Contains(t, out, "fix login crash on Safari")
+	assert.NotContains(t, out, "unrelated issue")
 }
 
 func TestSearch_EmptyQueryIsValidationError(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--workspace", dir, "search", "  "})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	err := cmd.Execute()
-	require.Error(t, err)
-	var ce *cliError
-	require.ErrorAs(t, err, &ce)
-	assert.Equal(t, ExitValidation, ce.ExitCode)
+	f := newCLIFixture(t)
+	_ = requireCLIError(t, f.execute("search", "  "), ExitValidation)
 }
 
 // TestSearch_UnquotedMultiTerm verifies that `kata search login Safari`
 // (no quotes) joins the args with spaces and matches the same way as the
 // quoted form. Required by the BM25 implicit-AND contract.
 func TestSearch_UnquotedMultiTerm(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	createIssueViaHTTP(t, env, dir, "fix login crash on Safari")
-	createIssueViaHTTP(t, env, dir, "unrelated issue")
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "fix login crash on Safari")
+	createIssue(t, env, pid, "unrelated issue")
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "search", "login", "Safari"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), "fix login crash on Safari")
-	assert.NotContains(t, buf.String(), "unrelated issue")
+	out := runCLI(t, env, dir, "search", "login", "Safari")
+	assert.Contains(t, out, "fix login crash on Safari")
+	assert.NotContains(t, out, "unrelated issue")
 }
 
 // TestSearch_RejectsNonPositiveLimit covers hammer-test #5: --limit
@@ -68,18 +40,7 @@ func TestSearch_UnquotedMultiTerm(t *testing.T) {
 // list/ready/events/daemon-logs validation.
 func TestSearch_RejectsNonPositiveLimit(t *testing.T) {
 	for _, lim := range []string{"0", "-1"} {
-		resetFlags(t)
-		cmd := newRootCmd()
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
-		cmd.SetErr(&buf)
-		cmd.SetArgs([]string{"search", "x", "--limit", lim})
-		cmd.SetContext(context.Background())
-
-		err := cmd.Execute()
-		require.Errorf(t, err, "--limit %s should reject", lim)
-		var ce *cliError
-		require.ErrorAs(t, err, &ce)
-		assert.Equal(t, ExitValidation, ce.ExitCode)
+		_, err := runCmdOutput(t, nil, "search", "x", "--limit", lim)
+		_ = requireCLIError(t, err, ExitValidation)
 	}
 }

--- a/cmd/kata/show_test.go
+++ b/cmd/kata/show_test.go
@@ -1,41 +1,25 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestShow_RendersLabelsAndLinksSections(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "parent") // #1
 	createIssue(t, env, pid, "child")  // #2
 	// Two labels so we exercise the comma-join.
 	for _, label := range []string{"bug", "priority:high"} {
-		body := []byte(`{"actor":"tester","label":"` + label + `"}`)
-		resp, err := http.Post(env.URL+"/api/v1/projects/"+itoa(pid)+"/issues/2/labels",
-			"application/json", bytes.NewReader(body)) //nolint:noctx,gosec // test-only
-		require.NoError(t, err)
-		require.NoError(t, resp.Body.Close())
+		runCLI(t, env, dir, "label", "add", "2", label)
 	}
 	createLinkViaHTTP(t, env, pid, 2, "parent", 1)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "show", "2"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
+	out := runCLI(t, env, dir, "show", "2")
 	// Exact section headers and comma-joined label rendering.
 	assert.Contains(t, out, "--- labels ---")
 	assert.Contains(t, out, "bug, priority:high")
@@ -49,51 +33,30 @@ func TestShow_RendersLabelsAndLinksSections(t *testing.T) {
 // the link's "to" side, the rendered arrow flips (←) so the line still reads
 // from the perspective of the issue being shown.
 func TestShow_LinkArrowReversesOnToSide(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "parent") // #1
 	createIssue(t, env, pid, "child")  // #2
 	// child → parent stores (from=2, to=1). Showing #1 puts us on the to side.
 	createLinkViaHTTP(t, env, pid, 2, "parent", 1)
 
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--workspace", dir, "show", "1"})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	require.NoError(t, cmd.Execute())
-	out := buf.String()
+	out := runCLI(t, env, dir, "show", "1")
 	assert.Contains(t, out, "parent ← #2", "to-side show must reverse the arrow")
 }
 
 func TestShow_AcceptsHashFullUIDAndUniquePrefix(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "uid target")
 	issue, err := env.DB.IssueByNumber(context.Background(), pid, 1)
 	require.NoError(t, err)
 
 	for _, ref := range []string{"#1", issue.UID, issue.UID[:12]} {
-		resetFlags(t)
-		cmd := newRootCmd()
-		var buf bytes.Buffer
-		cmd.SetOut(&buf)
-		cmd.SetArgs([]string{"--workspace", dir, "show", ref})
-		cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-		require.NoError(t, cmd.Execute(), "ref %s", ref)
-		assert.Contains(t, buf.String(), "uid target")
+		out := runCLI(t, env, dir, "show", ref)
+		assert.Contains(t, out, "uid target", "ref %s", ref)
 	}
 }
 
 func TestShow_UIDPrefixErrors(t *testing.T) {
-	resetFlags(t)
-	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "a")
 	createIssue(t, env, pid, "b")
 	uidA := "01JZ0000000000000000000001"
@@ -107,22 +70,13 @@ func TestShow_UIDPrefixErrors(t *testing.T) {
 	first, err := env.DB.IssueByNumber(context.Background(), pid, 1)
 	require.NoError(t, err)
 
-	cmd := newRootCmd()
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetArgs([]string{"--workspace", dir, "show", first.UID[:4]})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	err = cmd.Execute()
+	_, err = runCLICapture(t, env, dir, "show", first.UID[:4])
 	require.Error(t, err)
 	var ce *cliError
 	require.True(t, errors.As(err, &ce))
 	assert.Equal(t, "prefix_too_short", ce.Code)
 
-	resetFlags(t)
-	cmd = newRootCmd()
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetArgs([]string{"--workspace", dir, "show", first.UID[:8]})
-	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
-	err = cmd.Execute()
+	_, err = runCLICapture(t, env, dir, "show", first.UID[:8])
 	require.Error(t, err)
 	require.True(t, errors.As(err, &ce))
 	assert.Equal(t, "prefix_ambiguous", ce.Code)

--- a/cmd/kata/testhelpers_test.go
+++ b/cmd/kata/testhelpers_test.go
@@ -8,16 +8,62 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/daemon"
 	"github.com/wesm/kata/internal/daemonclient"
+	"github.com/wesm/kata/internal/db"
 	"github.com/wesm/kata/internal/testenv"
 	"github.com/wesm/kata/internal/version"
 )
+
+// setupKataEnv points KATA_HOME and KATA_DB at a fresh temp dir so the test
+// runs in isolation from any developer-local state. Returns the temp dir.
+func setupKataEnv(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	return tmp
+}
+
+// executeRoot runs the given cobra command with args and returns stdout. It
+// fails the test if Execute returns an error. Use for non-workspace tests
+// (daemon, etc.); workspace-bound tests should use runCLI instead.
+func executeRoot(t *testing.T, cmd *cobra.Command, args ...string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute())
+	return buf.Bytes()
+}
+
+// executeRootCapture runs a fresh root cobra command with the given context
+// and args, returning captured stdout, stderr, and any Execute error. Unlike
+// executeRoot it does not fail on error — callers decide how to react (assert
+// success, expect a specific error, or ignore for tail/timeout cases).
+//
+//nolint:revive // test helper: t *testing.T conventionally precedes ctx.
+func executeRootCapture(t *testing.T, ctx context.Context, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := newRootCmd()
+	var so, se bytes.Buffer
+	cmd.SetOut(&so)
+	cmd.SetErr(&se)
+	cmd.SetArgs(args)
+	cmd.SetContext(ctx)
+	err = cmd.Execute()
+	return so.String(), se.String(), err
+}
 
 // pipeServer starts a TCP listener on a random loopback port, registers
 // GET /api/v1/ping, and returns the host:port address and a cleanup function.
@@ -68,25 +114,64 @@ func contextWithBaseURL(ctx context.Context, url string) context.Context {
 	return context.WithValue(ctx, daemonclient.BaseURLKey{}, url)
 }
 
+// runGit executes `git <args>` in dir and fails the test on error. Use for
+// test setup that needs to initialize a workspace, configure remotes, etc.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...) //nolint:gosec // git binary is trusted; args are test-controlled
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v: %s", args, out)
+}
+
+// postJSON marshals reqBody, POSTs to url, asserts a 200 response, and decodes
+// the JSON body into Resp. Use for daemon API helpers that read the response.
+func postJSON[Resp any](t *testing.T, url string, reqBody any) Resp {
+	t.Helper()
+	body, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body)) //nolint:noctx,gosec // test-only loopback
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equalf(t, 200, resp.StatusCode, "POST %s", url)
+	var out Resp
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	return out
+}
+
+// postJSONOK is postJSON without a response body: marshal, POST, assert 200,
+// discard. Use for daemon API helpers that don't care about the response.
+func postJSONOK(t *testing.T, url string, reqBody any) {
+	t.Helper()
+	body, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body)) //nolint:noctx,gosec // test-only loopback
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equalf(t, 200, resp.StatusCode, "POST %s", url)
+}
+
+// getJSON GETs url, asserts a 200 response, and decodes the body into Resp.
+func getJSON[Resp any](t *testing.T, url string) Resp {
+	t.Helper()
+	resp, err := http.Get(url) //nolint:noctx,gosec // test-only loopback
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equalf(t, 200, resp.StatusCode, "GET %s", url)
+	var out Resp
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	return out
+}
+
 // initBoundWorkspace creates a temporary git workspace, adds a git remote, and
 // registers it with the test daemon via POST /api/v1/projects. Returns the
 // workspace directory path.
 func initBoundWorkspace(t *testing.T, baseURL, origin string) string {
 	t.Helper()
 	dir := t.TempDir()
-	cmd := exec.Command("git", "init", "--quiet")
-	cmd.Dir = dir
-	require.NoError(t, cmd.Run())
-	cmd = exec.Command("git", "remote", "add", "origin", origin) //nolint:gosec // G204: git with test-controlled origin
-	cmd.Dir = dir
-	require.NoError(t, cmd.Run())
-
-	body, err := json.Marshal(map[string]string{"start_path": dir})
-	require.NoError(t, err)
-	resp, err := http.Post(baseURL+"/api/v1/projects", "application/json", bytes.NewReader(body)) //nolint:gosec,noctx // test-only
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", origin)
+	postJSONOK(t, baseURL+"/api/v1/projects", map[string]string{"start_path": dir})
 	return dir
 }
 
@@ -94,16 +179,10 @@ func initBoundWorkspace(t *testing.T, baseURL, origin string) string {
 // returns the resolved project ID.
 func resolvePIDViaHTTP(t *testing.T, baseURL, startPath string) int64 {
 	t.Helper()
-	body, err := json.Marshal(map[string]string{"start_path": startPath})
-	require.NoError(t, err)
-	resp, err := http.Post(baseURL+"/api/v1/projects/resolve", "application/json", bytes.NewReader(body)) //nolint:gosec,noctx // test-only
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-	var b struct {
+	type response struct {
 		Project struct{ ID int64 } `json:"project"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&b))
+	b := postJSON[response](t, baseURL+"/api/v1/projects/resolve", map[string]string{"start_path": startPath})
 	return b.Project.ID
 }
 
@@ -115,19 +194,13 @@ func itoa(n int64) string { return strconv.FormatInt(n, 10) }
 func createIssueViaHTTP(t *testing.T, env *testenv.Env, dir, title string) int64 {
 	t.Helper()
 	pid := resolvePIDViaHTTP(t, env.URL, dir)
-	body, err := json.Marshal(map[string]any{"actor": "tester", "title": title})
-	require.NoError(t, err)
-	resp, err := http.Post(env.URL+"/api/v1/projects/"+itoa(pid)+"/issues",
-		"application/json", bytes.NewReader(body)) //nolint:gosec,noctx // test-only loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-	var b struct {
+	type response struct {
 		Issue struct {
 			Number int64 `json:"number"`
 		} `json:"issue"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&b))
+	b := postJSON[response](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues",
+		map[string]any{"actor": "tester", "title": title})
 	return b.Issue.Number
 }
 
@@ -149,4 +222,294 @@ func stubIsTTY(t *testing.T, want bool) {
 	saved := isTTY
 	isTTY = func(*os.File) bool { return want }
 	t.Cleanup(func() { isTTY = saved })
+}
+
+// runCmdOutput executes a fresh root command with args and returns captured
+// stdout plus any Execute error. resetFlags is applied. If env is non-nil the
+// daemon base URL is injected into the context. Use for non-workspace tests
+// that need the daemon URL but not the --workspace flag.
+func runCmdOutput(t *testing.T, env *testenv.Env, args ...string) (string, error) {
+	t.Helper()
+	resetFlags(t)
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs(args)
+	ctx := context.Background()
+	if env != nil {
+		ctx = contextWithBaseURL(ctx, env.URL)
+	}
+	cmd.SetContext(ctx)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// requireCmdOutput is runCmdOutput with require.NoError on the result.
+func requireCmdOutput(t *testing.T, env *testenv.Env, args ...string) string {
+	t.Helper()
+	out, err := runCmdOutput(t, env, args...)
+	require.NoError(t, err)
+	return out
+}
+
+// setupMergeProjects creates the canonical "kenn" and "steward" projects, each
+// with a matching git alias, used by ProjectsMerge tests.
+func setupMergeProjects(t *testing.T, env *testenv.Env) (kenn, steward db.Project) {
+	t.Helper()
+	ctx := context.Background()
+	var err error
+	kenn, err = env.DB.CreateProject(ctx, "github.com/wesm/kenn", "steward")
+	require.NoError(t, err)
+	steward, err = env.DB.CreateProject(ctx, "github.com/wesm/steward", "steward")
+	require.NoError(t, err)
+	_, err = env.DB.AttachAlias(ctx, kenn.ID, "github.com/wesm/kenn", "git", "/tmp/kenn")
+	require.NoError(t, err)
+	_, err = env.DB.AttachAlias(ctx, steward.ID, "github.com/wesm/steward", "git", "/tmp/steward")
+	require.NoError(t, err)
+	return kenn, steward
+}
+
+// runCLI executes a root command and returns the output.
+func runCLI(t *testing.T, env *testenv.Env, dir string, args ...string) string {
+	t.Helper()
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	fullArgs := append([]string{"--workspace", dir}, args...)
+	cmd.SetArgs(fullArgs)
+	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
+	require.NoError(t, cmd.Execute())
+	return strings.TrimSpace(buf.String())
+}
+
+// runCLICapture is the error-tolerant sibling of runCLI: it runs a fresh root
+// command bound to dir under env's daemon URL and returns combined
+// stdout+stderr plus the Execute error. Use when a test needs to assert on a
+// specific failure (cliError code, exit status) instead of just succeeding.
+func runCLICapture(t *testing.T, env *testenv.Env, dir string, args ...string) (string, error) {
+	t.Helper()
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(append([]string{"--workspace", dir}, args...))
+	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// setupWorkspaceWithIssue initializes a test environment and workspace with a single issue.
+func setupWorkspaceWithIssue(t *testing.T, issueTitle string) (*testenv.Env, string, int64) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, issueTitle)
+	return env, dir, pid
+}
+
+// setupCLIWorkspace bundles resetFlags, testenv.New, initBoundWorkspace, and
+// project ID resolution into one call. Use for CLI tests that seed their own
+// issues; setupWorkspaceWithIssue is the one-issue convenience wrapper.
+func setupCLIWorkspace(t *testing.T) (*testenv.Env, string, int64) {
+	t.Helper()
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	return env, dir, pid
+}
+
+// createIssue creates an issue via HTTP and discards the response. Use when
+// you need an issue but not its number — numbers go 1, 2, 3 in order so they
+// can be hard-coded.
+func createIssue(t *testing.T, env *testenv.Env, projectID int64, title string) {
+	t.Helper()
+	postJSONOK(t, env.URL+"/api/v1/projects/"+itoa(projectID)+"/issues",
+		map[string]any{"actor": "tester", "title": title})
+}
+
+// createLinkViaHTTP creates a link between two issues via HTTP. Used by tests
+// that need a pre-existing link to exercise unlink/show/etc.
+func createLinkViaHTTP(t *testing.T, env *testenv.Env, projectID, fromNumber int64, linkType string, toNumber int64) {
+	t.Helper()
+	postJSONOK(t,
+		env.URL+"/api/v1/projects/"+itoa(projectID)+"/issues/"+itoa(fromNumber)+"/links",
+		map[string]any{"actor": "tester", "type": linkType, "to_number": toNumber})
+}
+
+// setupCLIEnv combines the standard workspace initialization and server startup.
+func setupCLIEnv(t *testing.T) (*testenv.Env, string) {
+	t.Helper()
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+	return env, dir
+}
+
+// cliFixture bundles a workspace-bound test environment with a fresh root
+// command whose stdout/stderr write into a single shared buffer and whose
+// context already carries the test daemon's base URL. Use newCLIFixture for
+// CLI tests that need to inspect output or expect specific errors; runCLI is
+// preferable for plain success-path checks.
+type cliFixture struct {
+	env *testenv.Env
+	dir string
+	cmd *cobra.Command
+	buf *bytes.Buffer
+}
+
+// newCLIFixture sets up resetFlags, a fresh testenv, a bound workspace, and a
+// new root command wired to a shared buffer and the daemon base URL context.
+func newCLIFixture(t *testing.T) *cliFixture {
+	t.Helper()
+	env, dir := setupCLIEnv(t)
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
+	return &cliFixture{env: env, dir: dir, cmd: cmd, buf: &buf}
+}
+
+// execute runs the fixture's command with --workspace prepended to args.
+func (f *cliFixture) execute(args ...string) error {
+	f.cmd.SetArgs(append([]string{"--workspace", f.dir}, args...))
+	return f.cmd.Execute()
+}
+
+// rootSubcommands returns the freshly constructed root command's subcommands
+// keyed by name. Use to assert subcommand registration without iterating
+// cmd.Commands() in every advertise test.
+func rootSubcommands() map[string]*cobra.Command {
+	cmd := newRootCmd()
+	out := make(map[string]*cobra.Command, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		out[sub.Name()] = sub
+	}
+	return out
+}
+
+// errorEnvelopeForTest mirrors the JSON envelope emitted by emitError under
+// --json. Tests assert on Kind/Code/Message/ExitCode; fields the test does not
+// care about decode to their zero value.
+type errorEnvelopeForTest struct {
+	Error struct {
+		Kind     string `json:"kind"`
+		Code     string `json:"code"`
+		Message  string `json:"message"`
+		ExitCode int    `json:"exit_code"`
+	} `json:"error"`
+}
+
+// parseErrorEnvelope unmarshals a --json error payload, failing the test with
+// the raw bytes if the payload isn't parseable JSON.
+func parseErrorEnvelope(t *testing.T, data []byte) errorEnvelopeForTest {
+	t.Helper()
+	var got errorEnvelopeForTest
+	require.NoError(t, json.Unmarshal(data, &got),
+		"--json error must be parseable JSON; got %q", string(data))
+	return got
+}
+
+// requireCLIError asserts that err is a *cliError with the given exit code and
+// returns it for further code/message inspection by the caller.
+func requireCLIError(t *testing.T, err error, expectedCode int) *cliError {
+	t.Helper()
+	require.Error(t, err)
+	var ce *cliError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, expectedCode, ce.ExitCode)
+	return ce
+}
+
+type IssueResponse struct {
+	Issue struct {
+		Number int64   `json:"number"`
+		Owner  *string `json:"owner"`
+	} `json:"issue"`
+	Labels []struct {
+		Label string `json:"label"`
+	} `json:"labels"`
+	Links []struct {
+		Type       string `json:"type"`
+		FromNumber int64  `json:"from_number"`
+		ToNumber   int64  `json:"to_number"`
+	} `json:"links"`
+}
+
+// safeBuffer is a mutex-protected bytes.Buffer used by streaming/tail tests so
+// `go test -race` does not flag the goroutine running cmd.Execute writing to
+// the buffer racing with the test goroutine reading it via Snapshot.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *safeBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *safeBuffer) Snapshot() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// asyncCLI wraps a long-running cobra command executing in a background
+// goroutine. Use awaitOutput to poll the captured stdout/stderr for expected
+// substrings and stop to cancel the derived context and wait for completion.
+type asyncCLI struct {
+	buf    *safeBuffer
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// startAsyncCLI builds a fresh root command with args, attaches a safeBuffer to
+// stdout/stderr, and runs Execute in a background goroutine under a context
+// derived from ctx. resetFlags is applied. Callers stop it via stop().
+//
+//nolint:revive // test helper: t *testing.T conventionally precedes ctx.
+func startAsyncCLI(t *testing.T, ctx context.Context, args ...string) *asyncCLI {
+	t.Helper()
+	resetFlags(t)
+	derived, cancel := context.WithCancel(ctx)
+	cmd := newRootCmd()
+	buf := &safeBuffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	cmd.SetContext(derived)
+	a := &asyncCLI{buf: buf, cancel: cancel}
+	a.wg.Add(1)
+	go func() {
+		defer a.wg.Done()
+		_ = cmd.Execute()
+	}()
+	return a
+}
+
+// awaitOutput polls the snapshot until predicate returns true or timeout
+// expires. Returns the final snapshot in either case so callers can assert on
+// the captured output.
+func (a *asyncCLI) awaitOutput(predicate func(string) bool, timeout time.Duration) string {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if predicate(a.buf.Snapshot()) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return a.buf.Snapshot()
+}
+
+// stop cancels the derived context and waits for Execute to return.
+func (a *asyncCLI) stop() {
+	a.cancel()
+	a.wg.Wait()
+}
+
+func fetchIssueViaHTTP(t *testing.T, env *testenv.Env, pid int64, issueNum int64) IssueResponse {
+	t.Helper()
+	return getJSON[IssueResponse](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues/"+itoa(issueNum))
 }

--- a/cmd/kata/tui_cmd_test.go
+++ b/cmd/kata/tui_cmd_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"strings"
 	"testing"
 )
@@ -16,17 +14,10 @@ import (
 // capability the wire cannot deliver. Both gates land at the daemon
 // boundary; re-add when handlers_issues.go grows the routes.
 func TestTUI_CommandRegistered(t *testing.T) {
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"tui", "--help"})
-	cmd.SetContext(context.Background())
-	if err := cmd.Execute(); err != nil {
+	out, err := runCmdOutput(t, nil, "tui", "--help")
+	if err != nil {
 		t.Fatal(err)
 	}
-	out := buf.String()
 	if !strings.Contains(out, "--uid-format") {
 		t.Fatalf("--uid-format missing from help: %s", out)
 	}
@@ -39,14 +30,7 @@ func TestTUI_CommandRegistered(t *testing.T) {
 }
 
 func TestTUI_RejectsInvalidUIDFormatBeforeTTYCheck(t *testing.T) {
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"tui", "--uid-format", "wide"})
-	cmd.SetContext(context.Background())
-	err := cmd.Execute()
+	_, err := runCmdOutput(t, nil, "tui", "--uid-format", "wide")
 	if err == nil {
 		t.Fatal("expected invalid uid format error")
 	}
@@ -60,14 +44,7 @@ func TestTUI_RejectsInvalidUIDFormatBeforeTTYCheck(t *testing.T) {
 // failure (and the TTY check in tui.Run is never reached, which would
 // be inappropriate for an arg-parse failure).
 func TestTUI_RejectsExtraArgs(t *testing.T) {
-	resetFlags(t)
-	cmd := newRootCmd()
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"tui", "extra-positional"})
-	cmd.SetContext(context.Background())
-	err := cmd.Execute()
+	_, err := runCmdOutput(t, nil, "tui", "extra-positional")
 	if err == nil {
 		t.Fatal("expected error for extra positional arg")
 	}

--- a/internal/api/error_format_test.go
+++ b/internal/api/error_format_test.go
@@ -6,12 +6,15 @@ package api
 
 import (
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/stretchr/testify/assert"
 )
+
+func humaErr(loc, msg string) error {
+	return &huma.ErrorDetail{Location: loc, Message: msg}
+}
 
 // TestFoldDetailsIntoMessage covers hammer-test finding #11: a
 // validation failure used to surface "validation failed" with no
@@ -20,52 +23,59 @@ import (
 // "field: reason" form so close --reason banana, list --status
 // nonsense, etc. give the user actionable feedback.
 func TestFoldDetailsIntoMessage(t *testing.T) {
-	t.Run("no details returns base message", func(t *testing.T) {
-		assert.Equal(t, "validation failed",
-			foldDetailsIntoMessage("validation failed", nil))
-	})
-
-	t.Run("ErrorDetailer with location surfaces field name", func(t *testing.T) {
-		errs := []error{
-			&huma.ErrorDetail{
-				Location: "body.reason",
-				Message:  "expected one of done, wontfix, duplicate",
+	tests := []struct {
+		name     string
+		errs     []error
+		expected string   // exact match when non-empty
+		contains []string // substrings that must appear in output
+	}{
+		{
+			name:     "no details returns base message",
+			errs:     nil,
+			expected: "validation failed",
+		},
+		{
+			name:     "ErrorDetailer with location surfaces field name",
+			errs:     []error{humaErr("body.reason", "expected one of done, wontfix, duplicate")},
+			expected: "validation failed: reason: expected one of done, wontfix, duplicate",
+		},
+		{
+			name: "path. and query. prefixes also stripped",
+			errs: []error{
+				humaErr("query.status", "expected enum value"),
+				humaErr("path.id", "must be integer"),
 			},
-		}
-		got := foldDetailsIntoMessage("validation failed", errs)
-		assert.Equal(t,
-			"validation failed: reason: expected one of done, wontfix, duplicate",
-			got)
-	})
+			contains: []string{"status: expected enum value", "id: must be integer"},
+		},
+		{
+			name:     "plain error falls back to .Error()",
+			errs:     []error{errors.New("custom")},
+			expected: "validation failed: custom",
+		},
+		{
+			name: "more than three details gets and-N-more suffix",
+			errs: []error{
+				humaErr("body.a", "x"),
+				humaErr("body.b", "x"),
+				humaErr("body.c", "x"),
+				humaErr("body.d", "x"),
+				humaErr("body.e", "x"),
+			},
+			contains: []string{"(and 2 more)"},
+		},
+	}
 
-	t.Run("path. and query. prefixes also stripped", func(t *testing.T) {
-		errs := []error{
-			&huma.ErrorDetail{Location: "query.status", Message: "expected enum value"},
-			&huma.ErrorDetail{Location: "path.id", Message: "must be integer"},
-		}
-		got := foldDetailsIntoMessage("validation failed", errs)
-		assert.Contains(t, got, "status: expected enum value")
-		assert.Contains(t, got, "id: must be integer")
-	})
-
-	t.Run("plain error falls back to .Error()", func(t *testing.T) {
-		got := foldDetailsIntoMessage("validation failed",
-			[]error{errors.New("custom")})
-		assert.Equal(t, "validation failed: custom", got)
-	})
-
-	t.Run("more than three details gets and-N-more suffix", func(t *testing.T) {
-		errs := []error{
-			&huma.ErrorDetail{Location: "body.a", Message: "x"},
-			&huma.ErrorDetail{Location: "body.b", Message: "x"},
-			&huma.ErrorDetail{Location: "body.c", Message: "x"},
-			&huma.ErrorDetail{Location: "body.d", Message: "x"},
-			&huma.ErrorDetail{Location: "body.e", Message: "x"},
-		}
-		got := foldDetailsIntoMessage("validation failed", errs)
-		assert.True(t, strings.Contains(got, "(and 2 more)"),
-			"expected `(and 2 more)` in message, got %q", got)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := foldDetailsIntoMessage("validation failed", tt.errs)
+			if tt.expected != "" {
+				assert.Equal(t, tt.expected, got)
+			}
+			for _, sub := range tt.contains {
+				assert.Contains(t, got, sub)
+			}
+		})
+	}
 }
 
 // TestInstallErrorFormatter_FoldsDetailsIntoApiError pins that

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -11,13 +11,21 @@ import (
 	"github.com/wesm/kata/internal/config"
 )
 
+// setupTestHome creates an isolated KATA_HOME for the test and returns its
+// path. Using t.TempDir keeps parallel tests from colliding on a shared dir.
+func setupTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	return home
+}
+
 func TestKataHome_PrefersEnvOverDefault(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
+	home := setupTestHome(t)
 
 	got, err := config.KataHome()
 	require.NoError(t, err)
-	assert.Equal(t, tmp, got)
+	assert.Equal(t, home, got)
 }
 
 func TestKataHome_DefaultsToUserHomeDotKata(t *testing.T) {
@@ -31,23 +39,21 @@ func TestKataHome_DefaultsToUserHomeDotKata(t *testing.T) {
 }
 
 func TestKataDB_PrefersEnvOverHomeJoin(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "custom.db"))
+	home := setupTestHome(t)
+	t.Setenv("KATA_DB", filepath.Join(home, "custom.db"))
 
 	got, err := config.KataDB()
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join(tmp, "custom.db"), got)
+	assert.Equal(t, filepath.Join(home, "custom.db"), got)
 }
 
 func TestKataDB_DefaultsToHomeKataDB(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
+	home := setupTestHome(t)
 	t.Setenv("KATA_DB", "")
 
 	got, err := config.KataDB()
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join(tmp, "kata.db"), got)
+	assert.Equal(t, filepath.Join(home, "kata.db"), got)
 }
 
 func TestDBHash_StableTwelveLowerHex(t *testing.T) {
@@ -62,68 +68,55 @@ func TestDBHash_StableTwelveLowerHex(t *testing.T) {
 }
 
 func TestRuntimeDir_NamespaceIsDBHashUnderHome(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	home := setupTestHome(t)
+	t.Setenv("KATA_DB", filepath.Join(home, "kata.db"))
 
 	got, err := config.RuntimeDir()
 	require.NoError(t, err)
-	hash := config.DBHash(filepath.Join(tmp, "kata.db"))
-	assert.Equal(t, filepath.Join(tmp, "runtime", hash), got)
+	hash := config.DBHash(filepath.Join(home, "kata.db"))
+	assert.Equal(t, filepath.Join(home, "runtime", hash), got)
 }
 
+const testDBHash = "abc123def456"
+
 func TestHookConfigPath_HonorsKataHome(t *testing.T) {
-	t.Setenv("KATA_HOME", "/tmp/kata-test")
+	home := setupTestHome(t)
+
 	got, err := config.HookConfigPath()
-	if err != nil {
-		t.Fatalf("HookConfigPath: %v", err)
-	}
-	want := filepath.Join("/tmp/kata-test", "hooks.toml")
-	if got != want {
-		t.Fatalf("HookConfigPath = %q, want %q", got, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "hooks.toml"), got)
 }
 
 func TestHookRootDir_NamespacedByDBHash(t *testing.T) {
-	t.Setenv("KATA_HOME", "/tmp/kata-test")
-	got, err := config.HookRootDir("abc123def456")
-	if err != nil {
-		t.Fatalf("HookRootDir: %v", err)
-	}
-	want := filepath.Join("/tmp/kata-test", "hooks", "abc123def456")
-	if got != want {
-		t.Fatalf("HookRootDir = %q, want %q", got, want)
-	}
+	home := setupTestHome(t)
+
+	got, err := config.HookRootDir(testDBHash)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "hooks", testDBHash), got)
 }
 
 func TestHookOutputDir_UnderHookRoot(t *testing.T) {
-	t.Setenv("KATA_HOME", "/tmp/kata-test")
-	got, err := config.HookOutputDir("abc123def456")
-	if err != nil {
-		t.Fatalf("HookOutputDir: %v", err)
-	}
-	if !strings.HasSuffix(got, filepath.Join("hooks", "abc123def456", "output")) {
-		t.Fatalf("HookOutputDir = %q, want suffix hooks/abc123def456/output", got)
-	}
+	setupTestHome(t)
+
+	got, err := config.HookOutputDir(testDBHash)
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(got, filepath.Join("hooks", testDBHash, "output")),
+		"HookOutputDir = %q, want suffix hooks/%s/output", got, testDBHash)
 }
 
 func TestHookRunsPath_UnderHookRoot(t *testing.T) {
-	t.Setenv("KATA_HOME", "/tmp/kata-test")
-	got, err := config.HookRunsPath("abc123def456")
-	if err != nil {
-		t.Fatalf("HookRunsPath: %v", err)
-	}
-	want := filepath.Join("/tmp/kata-test", "hooks", "abc123def456", "runs.jsonl")
-	if got != want {
-		t.Fatalf("HookRunsPath = %q, want %q", got, want)
-	}
+	home := setupTestHome(t)
+
+	got, err := config.HookRunsPath(testDBHash)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "hooks", testDBHash, "runs.jsonl"), got)
 }
 
 // TestHookRootDir_RejectsNonHash pins that path helpers refuse to join
 // any string that isn't a 12-char lower-hex DBHash, so a corrupted state
 // file or test typo can't escape <KataHome>/hooks via path traversal.
 func TestHookRootDir_RejectsNonHash(t *testing.T) {
-	t.Setenv("KATA_HOME", "/tmp/kata-test")
+	setupTestHome(t)
 	cases := []string{
 		"",                   // empty
 		"../escape",          // traversal
@@ -135,14 +128,11 @@ func TestHookRootDir_RejectsNonHash(t *testing.T) {
 		string([]byte{0, 1}), // control bytes
 	}
 	for _, c := range cases {
-		if _, err := config.HookRootDir(c); err == nil {
-			t.Errorf("HookRootDir(%q) should error", c)
-		}
-		if _, err := config.HookOutputDir(c); err == nil {
-			t.Errorf("HookOutputDir(%q) should error", c)
-		}
-		if _, err := config.HookRunsPath(c); err == nil {
-			t.Errorf("HookRunsPath(%q) should error", c)
-		}
+		_, err := config.HookRootDir(c)
+		assert.Errorf(t, err, "HookRootDir(%q) should error", c)
+		_, err = config.HookOutputDir(c)
+		assert.Errorf(t, err, "HookOutputDir(%q) should error", c)
+		_, err = config.HookRunsPath(c)
+		assert.Errorf(t, err, "HookRunsPath(%q) should error", c)
 	}
 }

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -10,15 +10,25 @@ import (
 	"github.com/wesm/kata/internal/config"
 )
 
-func writeKataTOML(t *testing.T, dir, body string) {
+func setupKataProjectDir(t *testing.T, body string) string {
 	t.Helper()
+	dir := t.TempDir()
 	path := filepath.Join(dir, ".kata.toml")
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o644)) //nolint:gosec // test fixture matches production .kata.toml mode
+	return dir
+}
+
+func writeAndReadConfig(t *testing.T, identity, name string) *config.ProjectConfig {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, config.WriteProjectConfig(dir, identity, name))
+	cfg, err := config.ReadProjectConfig(dir)
+	require.NoError(t, err)
+	return cfg
 }
 
 func TestReadProjectConfig_Roundtrip(t *testing.T) {
-	dir := t.TempDir()
-	writeKataTOML(t, dir, `version = 1
+	dir := setupKataProjectDir(t, `version = 1
 
 [project]
 identity = "github.com/wesm/kata"
@@ -39,8 +49,7 @@ func TestReadProjectConfig_Missing(t *testing.T) {
 }
 
 func TestReadProjectConfig_RejectsBadVersion(t *testing.T) {
-	dir := t.TempDir()
-	writeKataTOML(t, dir, `version = 2
+	dir := setupKataProjectDir(t, `version = 2
 
 [project]
 identity = "x"
@@ -53,8 +62,7 @@ name = "y"
 }
 
 func TestReadProjectConfig_RejectsBlankIdentity(t *testing.T) {
-	dir := t.TempDir()
-	writeKataTOML(t, dir, `version = 1
+	dir := setupKataProjectDir(t, `version = 1
 
 [project]
 identity = "   "
@@ -67,26 +75,17 @@ name = "x"
 }
 
 func TestWriteProjectConfig_DerivesNameFromLastSegment(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, config.WriteProjectConfig(dir, "github.com/wesm/kata", ""))
-
-	cfg, err := config.ReadProjectConfig(dir)
-	require.NoError(t, err)
+	cfg := writeAndReadConfig(t, "github.com/wesm/kata", "")
 	assert.Equal(t, "kata", cfg.Project.Name)
 }
 
 func TestWriteProjectConfig_PreservesExplicitName(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, config.WriteProjectConfig(dir, "github.com/wesm/kata", "Kata Tracker"))
-
-	cfg, err := config.ReadProjectConfig(dir)
-	require.NoError(t, err)
+	cfg := writeAndReadConfig(t, "github.com/wesm/kata", "Kata Tracker")
 	assert.Equal(t, "Kata Tracker", cfg.Project.Name)
 }
 
 func TestReadProjectConfig_AcceptsOptionalServerBlock(t *testing.T) {
-	dir := t.TempDir()
-	writeKataTOML(t, dir, `version = 1
+	dir := setupKataProjectDir(t, `version = 1
 
 [project]
 identity = "github.com/wesm/kata"
@@ -101,8 +100,7 @@ url = "http://127.0.0.1:7777"
 }
 
 func TestReadProjectConfig_NoServerBlockYieldsZeroValue(t *testing.T) {
-	dir := t.TempDir()
-	writeKataTOML(t, dir, `version = 1
+	dir := setupKataProjectDir(t, `version = 1
 
 [project]
 identity = "github.com/wesm/kata"
@@ -114,8 +112,7 @@ name     = "kata"
 }
 
 func TestFindProjectConfig_FromSubdirectory(t *testing.T) {
-	root := t.TempDir()
-	writeKataTOML(t, root, `version = 1
+	root := setupKataProjectDir(t, `version = 1
 
 [project]
 identity = "github.com/wesm/kata"
@@ -131,8 +128,7 @@ name     = "kata"
 }
 
 func TestFindProjectConfig_FromExactDir(t *testing.T) {
-	root := t.TempDir()
-	writeKataTOML(t, root, `version = 1
+	root := setupKataProjectDir(t, `version = 1
 
 [project]
 identity = "github.com/wesm/kata"
@@ -152,8 +148,7 @@ func TestFindProjectConfig_MissingReturnsSentinel(t *testing.T) {
 }
 
 func TestFindProjectConfig_PropagatesParseError(t *testing.T) {
-	root := t.TempDir()
-	writeKataTOML(t, root, "this is not toml = = =")
+	root := setupKataProjectDir(t, "this is not toml = = =")
 	cfg, foundDir, err := config.FindProjectConfig(root)
 	assert.Nil(t, cfg)
 	assert.Empty(t, foundDir)

--- a/internal/config/project_identity_test.go
+++ b/internal/config/project_identity_test.go
@@ -2,24 +2,21 @@ package config_test
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/config"
+	"github.com/wesm/kata/internal/testfix"
 )
 
 func TestDiscoverPaths_FindsKataTomlAndGit(t *testing.T) {
 	root := t.TempDir()
-	//nolint:gosec // test fixture under TempDir; permissive perms are intentional.
-	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
-	//nolint:gosec // test fixture; mirrors how users commit .kata.toml world-readable.
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".kata.toml"), []byte("version = 1\n\n[project]\nidentity = \"x\"\nname = \"x\"\n"), 0o644))
+	testfix.MkDotGit(t, root)
+	testfix.WriteKataToml(t, root, "x", "x")
 	sub := filepath.Join(root, "a", "b")
-	//nolint:gosec // test fixture under TempDir.
-	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.MkdirAll(sub, 0o755)) //nolint:gosec // test fixture under TempDir.
 
 	d, err := config.DiscoverPaths(sub)
 	require.NoError(t, err)
@@ -29,13 +26,10 @@ func TestDiscoverPaths_FindsKataTomlAndGit(t *testing.T) {
 
 func TestDiscoverPaths_KataTomlInSubdirOfGit(t *testing.T) {
 	root := t.TempDir()
-	//nolint:gosec // test fixture under TempDir.
-	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	testfix.MkDotGit(t, root)
 	sub := filepath.Join(root, "subproject")
-	//nolint:gosec // test fixture under TempDir.
-	require.NoError(t, os.MkdirAll(sub, 0o755))
-	//nolint:gosec // test fixture; mirrors how users commit .kata.toml world-readable.
-	require.NoError(t, os.WriteFile(filepath.Join(sub, ".kata.toml"), []byte("version = 1\n\n[project]\nidentity = \"x\"\nname = \"x\"\n"), 0o644))
+	require.NoError(t, os.MkdirAll(sub, 0o755)) //nolint:gosec // test fixture under TempDir.
+	testfix.WriteKataToml(t, sub, "x", "x")
 
 	d, err := config.DiscoverPaths(sub)
 	require.NoError(t, err)
@@ -59,9 +53,8 @@ func TestDiscoverPaths_StartPathMissingErrors(t *testing.T) {
 
 func TestDiscoverPaths_StartPathIsFileWalksFromParent(t *testing.T) {
 	root := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755)) //nolint:gosec // test fixture
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".kata.toml"),  //nolint:gosec // test fixture
-		[]byte("version = 1\n\n[project]\nidentity = \"x\"\nname = \"x\"\n"), 0o644))
+	testfix.MkDotGit(t, root)
+	testfix.WriteKataToml(t, root, "x", "x")
 	filePath := filepath.Join(root, "README.md")
 	require.NoError(t, os.WriteFile(filePath, []byte("hi"), 0o644)) //nolint:gosec // test fixture
 
@@ -89,8 +82,8 @@ func TestNormalizeRemoteURL(t *testing.T) {
 }
 
 func TestComputeAliasIdentity_GitWithRemote(t *testing.T) {
-	dir := initGitRepo(t)
-	requireGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	dir := testfix.InitGitRepo(t)
+	testfix.RunGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
 	a, err := config.ComputeAliasIdentity(config.DiscoveredPaths{GitRoot: dir})
 	require.NoError(t, err)
@@ -100,7 +93,7 @@ func TestComputeAliasIdentity_GitWithRemote(t *testing.T) {
 }
 
 func TestComputeAliasIdentity_GitNoRemote(t *testing.T) {
-	dir := initGitRepo(t)
+	dir := testfix.InitGitRepo(t)
 
 	a, err := config.ComputeAliasIdentity(config.DiscoveredPaths{GitRoot: dir})
 	require.NoError(t, err)
@@ -202,8 +195,8 @@ func TestPickInitIdentity_InputIdentityWithExplicitName(t *testing.T) {
 }
 
 func TestPickInitIdentity_FromGitRoot(t *testing.T) {
-	dir := initGitRepo(t)
-	requireGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	dir := testfix.InitGitRepo(t)
+	testfix.RunGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
 	got, err := config.PickInitIdentity(
 		config.DiscoveredPaths{GitRoot: dir}, nil, "", "", false)
@@ -305,24 +298,4 @@ func TestValidateAliasInfo(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.hint)
 		})
 	}
-}
-
-// helpers
-
-func initGitRepo(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
-	requireGit(t, dir, "init", "--quiet")
-	requireGit(t, dir, "config", "user.email", "x@example.com")
-	requireGit(t, dir, "config", "user.name", "x")
-	return dir
-}
-
-func requireGit(t *testing.T, dir string, args ...string) {
-	t.Helper()
-	//nolint:gosec // git binary is fixed; args are test-supplied subcommand flags.
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "git %v: %s", args, out)
 }

--- a/internal/daemon/broadcaster_race_test.go
+++ b/internal/daemon/broadcaster_race_test.go
@@ -2,7 +2,6 @@ package daemon_test
 
 import (
 	"context"
-	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -21,48 +20,20 @@ import (
 // authority; the broadcaster only signals "something changed at or below N".
 func TestSSE_OutOfOrderBroadcastsEmitInIDOrder(t *testing.T) {
 	env := testenv.New(t)
-	project, err := env.DB.CreateProject(context.Background(), "github.com/test/a", "a")
-	require.NoError(t, err)
-
-	// Sentinel: insert + broadcast a setup event before the test events. We
-	// wait for its frame to confirm the SSE handler has finished its drain
-	// phase and entered the live wakeup loop. Without this anchor, the test
-	// events could land in the drain (which delivers in id order trivially)
-	// instead of exercising the wakeup-and-requery path under test.
-	_, sentinel, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
-		ProjectID: project.ID, Title: "sentinel", Author: "tester",
-	})
-	require.NoError(t, err)
-
-	hwm, err := env.DB.MaxEventID(context.Background())
-	require.NoError(t, err)
-	resp := openSSE(t, env, "after_id="+strconv.FormatInt(hwm-1, 10), nil)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-
-	framer := newSSEFramer(resp.Body)
-	sentinelFrame, ok := framer.Next(t, 2*time.Second)
-	require.True(t, ok, "sentinel drain frame should arrive")
-	require.Equal(t, strconv.FormatInt(sentinel.ID, 10), sentinelFrame.id)
+	pid, _, framer := setupLiveSSE(t, env)
 
 	// Now in live phase. Insert two events directly via DB so the handler-side
 	// broadcast does NOT fire; broadcast manually in inverted order to pin the
 	// wakeup-and-requery ordering claim.
-	_, evt1, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
-		ProjectID: project.ID, Title: "first", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, evt2, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
-		ProjectID: project.ID, Title: "second", Author: "tester",
-	})
-	require.NoError(t, err)
+	_, evt1 := mkIssueWithEvent(t, env, pid, "first")
+	_, evt2 := mkIssueWithEvent(t, env, pid, "second")
 
 	// Inverted: evt2 first, then evt1.
 	env.Broadcaster.Broadcast(daemon.StreamMsg{
-		Kind: "event", Event: &evt2, ProjectID: project.ID,
+		Kind: "event", Event: &evt2, ProjectID: pid,
 	})
 	env.Broadcaster.Broadcast(daemon.StreamMsg{
-		Kind: "event", Event: &evt1, ProjectID: project.ID,
+		Kind: "event", Event: &evt1, ProjectID: pid,
 	})
 
 	first, ok := framer.Next(t, 2*time.Second)
@@ -81,40 +52,19 @@ func TestSSE_OutOfOrderBroadcastsEmitInIDOrder(t *testing.T) {
 // receive a post-purge frame and silently advance past the reset cursor.
 func TestSSE_LivePhaseChecksPurgeResetBeforeReplay(t *testing.T) {
 	env := testenv.New(t)
-	project, err := env.DB.CreateProject(context.Background(), "github.com/test/a", "a")
-	require.NoError(t, err)
-
-	// Create a sentinel event so the SSE handler enters live phase.
-	sentinelIssue, sentinelEvt, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
-		ProjectID: project.ID, Title: "sentinel", Author: "tester",
-	})
-	require.NoError(t, err)
-
-	hwm, err := env.DB.MaxEventID(context.Background())
-	require.NoError(t, err)
-	resp := openSSE(t, env, "after_id="+strconv.FormatInt(hwm-1, 10), nil)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-
-	framer := newSSEFramer(resp.Body)
-	first, ok := framer.Next(t, 2*time.Second)
-	require.True(t, ok)
-	require.Equal(t, strconv.FormatInt(sentinelEvt.ID, 10), first.id)
+	pid, sentinelIssue, framer := setupLiveSSE(t, env)
 
 	// Now create a second issue and purge the sentinel directly via DB so
 	// the handler-side broadcasts do NOT fire. Then broadcast ONLY an
 	// "event" message (simulating the broadcaster reordering: reset lost
 	// the race). The handler must still emit a reset because
 	// PurgeResetCheck sees the purge committed.
-	_, evt2, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
-		ProjectID: project.ID, Title: "post-purge", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = env.DB.PurgeIssue(context.Background(), sentinelIssue.ID, "tester", nil)
+	_, evt2 := mkIssueWithEvent(t, env, pid, "post-purge")
+	_, err := env.DB.PurgeIssue(context.Background(), sentinelIssue.ID, "tester", nil)
 	require.NoError(t, err)
 
 	env.Broadcaster.Broadcast(daemon.StreamMsg{
-		Kind: "event", Event: &evt2, ProjectID: project.ID,
+		Kind: "event", Event: &evt2, ProjectID: pid,
 	})
 
 	frame, ok := framer.Next(t, 2*time.Second)
@@ -126,11 +76,7 @@ func TestSSE_LivePhaseChecksPurgeResetBeforeReplay(t *testing.T) {
 // TestBroadcaster_ConcurrentSubscribeBroadcastUnsub is a -race fuzz of
 // concurrent Subscribe/Broadcast/Unsub. It asserts the broadcaster doesn't
 // deadlock, panic, or leak goroutines.
-func TestBroadcaster_ConcurrentSubscribeBroadcastUnsub(t *testing.T) {
-	d, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "kata.db"))
-	require.NoError(t, err)
-	defer func() { _ = d.Close() }()
-
+func TestBroadcaster_ConcurrentSubscribeBroadcastUnsub(_ *testing.T) {
 	b := daemon.NewEventBroadcaster()
 	var wg sync.WaitGroup
 	const N = 100

--- a/internal/daemon/broadcaster_test.go
+++ b/internal/daemon/broadcaster_test.go
@@ -16,13 +16,7 @@ func TestBroadcaster_SubscribeAndUnsubLifecycle(t *testing.T) {
 	sub.Unsub()
 	// Calling Unsub twice must be safe — closes only once.
 	sub.Unsub()
-	// Channel must be closed.
-	select {
-	case _, ok := <-sub.Ch:
-		assert.False(t, ok, "channel must be closed after Unsub")
-	case <-time.After(time.Second):
-		t.Fatal("channel was not closed within 1s")
-	}
+	assertChannelClosed(t, sub.Ch, time.Second, "sub.Ch after Unsub")
 }
 
 func TestBroadcaster_BroadcastFansToMatchingFiltersOnly(t *testing.T) {
@@ -34,28 +28,16 @@ func TestBroadcaster_BroadcastFansToMatchingFiltersOnly(t *testing.T) {
 	defer a.Unsub()
 	defer other.Unsub()
 
-	evt := &db.Event{ID: 100, ProjectID: 1, Type: "issue.created"}
-	b.Broadcast(daemon.StreamMsg{Kind: "event", Event: evt, ProjectID: 1})
+	broadcastEvent(b, 1, 100)
 
-	select {
-	case got := <-all.Ch:
-		assert.Equal(t, "event", got.Kind)
-		assert.Equal(t, int64(100), got.Event.ID)
-	case <-time.After(time.Second):
-		t.Fatal("cross-project subscriber should have received the event")
-	}
-	select {
-	case got := <-a.Ch:
-		assert.Equal(t, int64(100), got.Event.ID)
-	case <-time.After(time.Second):
-		t.Fatal("project-1 subscriber should have received the event")
-	}
-	select {
-	case got := <-other.Ch:
-		t.Fatalf("project-2 subscriber must not receive a project-1 event, got %+v", got)
-	case <-time.After(50 * time.Millisecond):
-		// expected: no delivery
-	}
+	gotAll := receiveMsg(t, all.Ch, time.Second, "cross-project subscriber")
+	assert.Equal(t, "event", gotAll.Kind)
+	assert.Equal(t, int64(100), gotAll.Event.ID)
+
+	gotA := receiveMsg(t, a.Ch, time.Second, "project-1 subscriber")
+	assert.Equal(t, int64(100), gotA.Event.ID)
+
+	assertNoReceive(t, other.Ch, 50*time.Millisecond, "project-2 subscriber must not receive a project-1 event")
 }
 
 func TestBroadcaster_ResetFansToAllMatchingFilters(t *testing.T) {
@@ -68,13 +50,9 @@ func TestBroadcaster_ResetFansToAllMatchingFilters(t *testing.T) {
 	b.Broadcast(daemon.StreamMsg{Kind: "reset", ResetID: 999, ProjectID: 1})
 
 	for i, ch := range []<-chan daemon.StreamMsg{all.Ch, a.Ch} {
-		select {
-		case got := <-ch:
-			assert.Equal(t, "reset", got.Kind)
-			assert.Equal(t, int64(999), got.ResetID)
-		case <-time.After(time.Second):
-			t.Fatalf("subscriber %d did not receive reset", i)
-		}
+		got := receiveMsg(t, ch, time.Second, "reset subscriber")
+		assert.Equalf(t, "reset", got.Kind, "subscriber %d", i)
+		assert.Equalf(t, int64(999), got.ResetID, "subscriber %d", i)
 	}
 }
 
@@ -87,26 +65,10 @@ func TestBroadcaster_OverflowDisconnectsSlowSubscriberOnly(t *testing.T) {
 	// the broadcaster to close it.
 
 	for i := int64(0); i < 300; i++ {
-		evt := &db.Event{ID: i + 1, ProjectID: 1, Type: "issue.created"}
-		b.Broadcast(daemon.StreamMsg{Kind: "event", Event: evt, ProjectID: 1})
+		broadcastEvent(b, 1, i+1)
 	}
 
-	// slow.Ch must close (overflow disconnect).
-	closed := false
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case _, ok := <-slow.Ch:
-			if !ok {
-				closed = true
-			}
-		case <-time.After(20 * time.Millisecond):
-		}
-		if closed {
-			break
-		}
-	}
-	assert.True(t, closed, "slow subscriber's channel must close on overflow")
+	assertChannelClosed(t, slow.Ch, time.Second, "slow subscriber's channel must close on overflow")
 
 	// fast must still be live: drain it and assert at least one delivery.
 	got := 0

--- a/internal/daemon/endpoint_test.go
+++ b/internal/daemon/endpoint_test.go
@@ -12,6 +12,30 @@ import (
 	"github.com/wesm/kata/internal/daemon"
 )
 
+// assertEndpointRoundTrip verifies that a listener and dialer endpoint
+// can successfully connect and exchange data.
+func assertEndpointRoundTrip(t *testing.T, l net.Listener, dialEP daemon.DaemonEndpoint) {
+	t.Helper()
+	t.Cleanup(func() { _ = l.Close() })
+
+	go func() {
+		c, err := l.Accept()
+		if err == nil && c != nil {
+			_, _ = c.Write([]byte("ok"))
+			_ = c.Close()
+		}
+	}()
+
+	conn, err := dialEP.Dial(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	buf := make([]byte, 2)
+	_, err = conn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", string(buf))
+}
+
 func TestUnixEndpoint_RoundTrip(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix sockets unsupported on windows")
@@ -21,23 +45,8 @@ func TestUnixEndpoint_RoundTrip(t *testing.T) {
 
 	l, err := ep.Listen()
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = l.Close() })
 
-	go func() {
-		c, _ := l.Accept()
-		if c != nil {
-			_, _ = c.Write([]byte("ok"))
-			_ = c.Close()
-		}
-	}()
-
-	conn, err := ep.Dial(context.Background())
-	require.NoError(t, err)
-	defer func() { _ = conn.Close() }()
-	buf := make([]byte, 2)
-	_, err = conn.Read(buf)
-	require.NoError(t, err)
-	assert.Equal(t, "ok", string(buf))
+	assertEndpointRoundTrip(t, l, ep)
 	assert.Equal(t, "unix://"+sock, ep.Address())
 }
 
@@ -45,26 +54,12 @@ func TestTCPEndpoint_RoundTrip(t *testing.T) {
 	ep := daemon.TCPEndpoint("127.0.0.1:0")
 	l, err := ep.Listen()
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = l.Close() })
 
 	// Hand the actually-bound address back into a fresh endpoint for Dial.
 	addr := l.Addr().(*net.TCPAddr).String()
 	dialEP := daemon.TCPEndpoint(addr)
-	go func() {
-		c, _ := l.Accept()
-		if c != nil {
-			_, _ = c.Write([]byte("ok"))
-			_ = c.Close()
-		}
-	}()
 
-	conn, err := dialEP.Dial(context.Background())
-	require.NoError(t, err)
-	defer func() { _ = conn.Close() }()
-	buf := make([]byte, 2)
-	_, err = conn.Read(buf)
-	require.NoError(t, err)
-	assert.Equal(t, "ok", string(buf))
+	assertEndpointRoundTrip(t, l, dialEP)
 }
 
 func TestTCPEndpoint_RejectsNonLoopback(t *testing.T) {

--- a/internal/daemon/envhelpers_test.go
+++ b/internal/daemon/envhelpers_test.go
@@ -1,0 +1,388 @@
+package daemon_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/kata/internal/testenv"
+)
+
+// defaultActor is the actor string used by the un-parameterized helpers
+// (postLink, postLabel, createIssueViaHTTP). Tests that need cross-actor
+// scenarios should use the *As variants.
+const defaultActor = "tester"
+
+// envDoJSON sends a JSON-bodied request against env's daemon. When body is
+// non-nil it is JSON-encoded and Content-Type is set automatically. When out
+// is non-nil and the response is 2xx the body is decoded into out; otherwise
+// the body is drained. The response is returned for status assertions.
+func envDoJSON(t *testing.T, env *testenv.Env, method, path string, body, out any) *http.Response {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != nil {
+		js, err := json.Marshal(body)
+		require.NoError(t, err)
+		bodyReader = bytes.NewReader(js)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, env.URL+path, bodyReader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := env.HTTP.Do(req) //nolint:gosec // test request to loopback URL
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	if out != nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(out))
+	} else {
+		_, _ = io.Copy(io.Discard, resp.Body)
+	}
+	return resp
+}
+
+// envDoRaw is the raw-body counterpart to envDoJSON. It builds an arbitrary
+// request (optional JSON body, optional headers), executes it, and returns the
+// response paired with the buffered body bytes. Use this when the test needs
+// to assert on the raw payload (substring checks, error envelopes) instead of
+// decoding into a typed struct. resp.Body is closed before return.
+func envDoRaw(t *testing.T, env *testenv.Env, method, path string, body any, headers map[string]string) (*http.Response, []byte) {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != nil {
+		js, err := json.Marshal(body)
+		require.NoError(t, err)
+		bodyReader = bytes.NewReader(js)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, env.URL+path, bodyReader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := env.HTTP.Do(req) //nolint:gosec // test request to loopback URL
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	bs, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, bs
+}
+
+// envGetRaw is the GET shorthand for envDoRaw — no body, no extra headers.
+func envGetRaw(t *testing.T, env *testenv.Env, path string) (*http.Response, []byte) {
+	t.Helper()
+	return envDoRaw(t, env, http.MethodGet, path, nil, nil)
+}
+
+// envPostJSON POSTs body and decodes the response into out, asserting 200.
+// For non-2xx assertions, use envDoJSON directly.
+func envPostJSON(t *testing.T, env *testenv.Env, path string, body, out any) {
+	t.Helper()
+	resp := envDoJSON(t, env, http.MethodPost, path, body, out)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "POST %s expected 200, got %d", path, resp.StatusCode)
+}
+
+// envGetJSON GETs path and decodes the response into out, asserting 200.
+func envGetJSON(t *testing.T, env *testenv.Env, path string, out any) {
+	t.Helper()
+	resp := envDoJSON(t, env, http.MethodGet, path, nil, out)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "GET %s expected 200, got %d", path, resp.StatusCode)
+}
+
+// rfc3339Offset returns now+d formatted as RFC3339 in UTC; convenient for
+// digest tests building ?since= / ?until= query params.
+func rfc3339Offset(d time.Duration) string {
+	return time.Now().Add(d).UTC().Format(time.RFC3339)
+}
+
+// projectPath returns the URL prefix for resources scoped to a project rowid.
+func projectPath(projectID int64) string {
+	return "/api/v1/projects/" + strconv.FormatInt(projectID, 10)
+}
+
+// issuePath returns the URL for a specific issue under a project. When suffix
+// is non-empty it is appended after the issue number (e.g. "comments" or
+// "actions/close"); when empty the resource URL itself is returned.
+func issuePath(projectID, issueNumber int64, suffix string) string {
+	base := projectPath(projectID) + "/issues/" + strconv.FormatInt(issueNumber, 10)
+	if suffix == "" {
+		return base
+	}
+	return base + "/" + suffix
+}
+
+// initWorkspaceViaHTTP runs git init in a temp dir, adds origin, posts to
+// /api/v1/projects, and returns the resolved project_id.
+func initWorkspaceViaHTTP(t *testing.T, env *testenv.Env, origin string) int64 {
+	t.Helper()
+	dir := t.TempDir()
+	mustRun(t, dir, "git", "init", "--quiet")
+	mustRun(t, dir, "git", "remote", "add", "origin", origin)
+
+	envPostJSON(t, env, "/api/v1/projects", map[string]string{"start_path": dir}, nil)
+	var out struct {
+		Project struct {
+			ID int64 `json:"id"`
+		} `json:"project"`
+	}
+	envPostJSON(t, env, "/api/v1/projects/resolve", map[string]string{"start_path": dir}, &out)
+	return out.Project.ID
+}
+
+// mustRun runs a command in dir, failing the test on error.
+func mustRun(t *testing.T, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...) //nolint:gosec // G204: test-controlled args
+	cmd.Dir = dir
+	require.NoErrorf(t, cmd.Run(), "%s %v", name, args)
+}
+
+// setupOneIssue creates a workspace + one issue, returns (project_id, issue_number).
+func setupOneIssue(t *testing.T, env *testenv.Env) (int64, int64) {
+	t.Helper()
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	n := createIssueViaHTTP(t, env, pid, "x")
+	return pid, n
+}
+
+// setupTwoIssues creates a workspace + two issues, returns (project_id, a_number, b_number).
+func setupTwoIssues(t *testing.T, env *testenv.Env) (int64, int64, int64) {
+	t.Helper()
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	a := createIssueViaHTTP(t, env, pid, "a")
+	b := createIssueViaHTTP(t, env, pid, "b")
+	return pid, a, b
+}
+
+// createIssueViaHTTP creates an issue with the default actor and returns its number.
+func createIssueViaHTTP(t *testing.T, env *testenv.Env, projectID int64, title string) int64 {
+	t.Helper()
+	return createIssueAs(t, env, projectID, defaultActor, title)
+}
+
+// createIssueAs creates an issue attributed to actor and returns its number.
+func createIssueAs(t *testing.T, env *testenv.Env, projectID int64, actor, title string) int64 {
+	t.Helper()
+	var out struct {
+		Issue struct {
+			Number int64 `json:"number"`
+		} `json:"issue"`
+	}
+	envPostJSON(t, env, projectPath(projectID)+"/issues",
+		map[string]string{"actor": actor, "title": title}, &out)
+	return out.Issue.Number
+}
+
+// postCommentAs posts a comment attributed to actor.
+func postCommentAs(t *testing.T, env *testenv.Env, projectID, issueNumber int64, actor, body string) {
+	t.Helper()
+	envPostJSON(t, env, issuePath(projectID, issueNumber, "comments"),
+		map[string]string{"actor": actor, "body": body}, nil)
+}
+
+// closeIssueAs closes an issue attributed to actor.
+func closeIssueAs(t *testing.T, env *testenv.Env, projectID, issueNumber int64, actor, reason string) {
+	t.Helper()
+	envPostJSON(t, env, issuePath(projectID, issueNumber, "actions/close"),
+		map[string]string{"actor": actor, "reason": reason}, nil)
+}
+
+// labelResp is the decoded shape of an AddLabelResponse body.
+type labelResp struct {
+	Issue struct {
+		Number int64 `json:"number"`
+	} `json:"issue"`
+	Label struct {
+		Label string `json:"label"`
+	} `json:"label"`
+	Event *struct {
+		Type string `json:"type"`
+	} `json:"event"`
+	Changed bool `json:"changed"`
+}
+
+// postLabel calls POST /labels with the default actor and returns the decoded response.
+func postLabel(t *testing.T, env *testenv.Env, projectID, issueNumber int64, label string) labelResp {
+	t.Helper()
+	return postLabelAs(t, env, projectID, issueNumber, defaultActor, label)
+}
+
+// postLabelAs calls POST /labels attributed to actor and returns the decoded response.
+func postLabelAs(t *testing.T, env *testenv.Env, projectID, issueNumber int64, actor, label string) labelResp {
+	t.Helper()
+	var out labelResp
+	envPostJSON(t, env, issuePath(projectID, issueNumber, "labels"),
+		map[string]string{"actor": actor, "label": label}, &out)
+	return out
+}
+
+// deleteLabel calls DELETE /labels/{label} with the default actor and returns
+// the response paired with the decoded labelResp. The decoded body is only
+// populated for 2xx responses; callers asserting on error envelopes should
+// inspect resp.StatusCode and ignore the labelResp.
+func deleteLabel(t *testing.T, env *testenv.Env, projectID, issueNumber int64, label string) (*http.Response, labelResp) {
+	t.Helper()
+	return deleteLabelAs(t, env, projectID, issueNumber, defaultActor, label)
+}
+
+// deleteLabelAs calls DELETE /labels/{label} attributed to actor.
+func deleteLabelAs(t *testing.T, env *testenv.Env, projectID, issueNumber int64, actor, label string) (*http.Response, labelResp) {
+	t.Helper()
+	path := issuePath(projectID, issueNumber, "labels/"+url.PathEscape(label)) +
+		"?actor=" + url.QueryEscape(actor)
+	var out labelResp
+	resp := envDoJSON(t, env, http.MethodDelete, path, nil, &out)
+	return resp, out
+}
+
+// linkResp is the decoded shape of a CreateLinkResponse body. The Event UID
+// fields are populated only by handlers that emit them (e.g. issue.linked);
+// other paths leave them nil.
+type linkResp struct {
+	Issue struct {
+		Number int64 `json:"number"`
+	} `json:"issue"`
+	Link struct {
+		ID           int64  `json:"id"`
+		Type         string `json:"type"`
+		FromNumber   int64  `json:"from_number"`
+		FromIssueUID string `json:"from_issue_uid"`
+		ToNumber     int64  `json:"to_number"`
+		ToIssueUID   string `json:"to_issue_uid"`
+	} `json:"link"`
+	Event *struct {
+		Type            string  `json:"type"`
+		ProjectUID      string  `json:"project_uid"`
+		IssueUID        *string `json:"issue_uid"`
+		RelatedIssueUID *string `json:"related_issue_uid"`
+	} `json:"event"`
+	Changed bool `json:"changed"`
+}
+
+// postLink calls POST /links with the default actor and returns the decoded response.
+func postLink(t *testing.T, env *testenv.Env, projectID, fromNumber int64, linkType string, toNumber int64) linkResp {
+	t.Helper()
+	return postLinkAs(t, env, projectID, fromNumber, defaultActor, linkType, toNumber)
+}
+
+// postLinkAs calls POST /links attributed to actor and returns the decoded response.
+func postLinkAs(t *testing.T, env *testenv.Env, projectID, fromNumber int64, actor, linkType string, toNumber int64) linkResp {
+	t.Helper()
+	var out linkResp
+	envPostJSON(t, env, issuePath(projectID, fromNumber, "links"),
+		map[string]any{"actor": actor, "type": linkType, "to_number": toNumber}, &out)
+	return out
+}
+
+// postLinkRaw calls POST /links with an arbitrary payload (e.g. replace=true,
+// blank actor) and returns the response paired with the decoded body. The
+// decoded body is only populated for 2xx responses; callers asserting on error
+// envelopes should inspect resp.StatusCode and ignore the linkResp.
+func postLinkRaw(t *testing.T, env *testenv.Env, projectID, fromNumber int64, payload map[string]any) (*http.Response, linkResp) {
+	t.Helper()
+	var out linkResp
+	resp := envDoJSON(t, env, http.MethodPost, issuePath(projectID, fromNumber, "links"), payload, &out)
+	return resp, out
+}
+
+// deleteLink calls DELETE /links/{id} with the default actor and returns the
+// response paired with the decoded linkResp.
+func deleteLink(t *testing.T, env *testenv.Env, projectID, issueNumber, linkID int64) (*http.Response, linkResp) {
+	t.Helper()
+	return deleteLinkAs(t, env, projectID, issueNumber, defaultActor, linkID)
+}
+
+// deleteLinkAs calls DELETE /links/{id} attributed to actor.
+func deleteLinkAs(t *testing.T, env *testenv.Env, projectID, issueNumber int64, actor string, linkID int64) (*http.Response, linkResp) {
+	t.Helper()
+	path := issuePath(projectID, issueNumber, "links/"+strconv.FormatInt(linkID, 10)) +
+		"?actor=" + url.QueryEscape(actor)
+	var out linkResp
+	resp := envDoJSON(t, env, http.MethodDelete, path, nil, &out)
+	return resp, out
+}
+
+// ownerResp is the decoded shape of an Assign/Unassign response body.
+type ownerResp struct {
+	Issue struct {
+		Owner *string `json:"owner"`
+	} `json:"issue"`
+	Event *struct {
+		Type string `json:"type"`
+	} `json:"event"`
+	Changed bool `json:"changed"`
+}
+
+// postAssign POSTs to /actions/assign and returns the response paired with the
+// decoded body. The body is only populated for 2xx responses; callers asserting
+// on error envelopes should inspect resp.StatusCode and ignore ownerResp.
+func postAssign(t *testing.T, env *testenv.Env, projectID, issueNumber int64, actor, owner string) (*http.Response, ownerResp) {
+	t.Helper()
+	var out ownerResp
+	resp := envDoJSON(t, env, http.MethodPost, issuePath(projectID, issueNumber, "actions/assign"),
+		map[string]string{"actor": actor, "owner": owner}, &out)
+	return resp, out
+}
+
+// postUnassign POSTs to /actions/unassign and returns the response paired with
+// the decoded body.
+func postUnassign(t *testing.T, env *testenv.Env, projectID, issueNumber int64, actor string) (*http.Response, ownerResp) {
+	t.Helper()
+	var out ownerResp
+	resp := envDoJSON(t, env, http.MethodPost, issuePath(projectID, issueNumber, "actions/unassign"),
+		map[string]string{"actor": actor}, &out)
+	return resp, out
+}
+
+// lastEventPayload returns the JSON payload of the most recently inserted event
+// of eventType for projectID. Used by tests verifying side-effect events that
+// aren't surfaced in the HTTP response (e.g. the trailing unlink emitted by a
+// parent --replace).
+func lastEventPayload(t *testing.T, env *testenv.Env, projectID int64, eventType string) string {
+	t.Helper()
+	var payload string
+	require.NoError(t, env.DB.QueryRowContext(t.Context(),
+		`SELECT payload FROM events
+		 WHERE project_id = ? AND type = ?
+		 ORDER BY id DESC LIMIT 1`, projectID, eventType).Scan(&payload))
+	return payload
+}
+
+// deleteLinkBlocksAs removes a blocks link from fromNumber → toNumber. The
+// daemon doesn't expose a /links GET, so the link id is recovered from the
+// issue show payload before the DELETE. The DELETE attribution is to actor,
+// who gets credit for the unblock event.
+func deleteLinkBlocksAs(t *testing.T, env *testenv.Env, projectID, fromNumber int64, actor string, toNumber int64) {
+	t.Helper()
+	var view struct {
+		Links []struct {
+			ID       int64  `json:"id"`
+			Type     string `json:"type"`
+			ToNumber int64  `json:"to_number"`
+		} `json:"links"`
+	}
+	envGetJSON(t, env, issuePath(projectID, fromNumber, ""), &view)
+	var linkID int64
+	for _, l := range view.Links {
+		if l.Type == "blocks" && l.ToNumber == toNumber {
+			linkID = l.ID
+			break
+		}
+	}
+	require.NotZerof(t, linkID, "no blocks link to %d found on issue %d", toNumber, fromNumber)
+
+	delPath := issuePath(projectID, fromNumber, "links/"+strconv.FormatInt(linkID, 10)) +
+		"?actor=" + url.QueryEscape(actor)
+	resp := envDoJSON(t, env, http.MethodDelete, delPath, nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/internal/daemon/handlers_archived_project_test.go
+++ b/internal/daemon/handlers_archived_project_test.go
@@ -1,8 +1,6 @@
 package daemon_test
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -14,8 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/wesm/kata/internal/db"
 )
 
 // TestArchivedProject_SurfaceHandlersReturn404 covers every project-scoped
@@ -33,10 +29,7 @@ func TestArchivedProject_SurfaceHandlersReturn404(t *testing.T) {
 	// Archive the project directly via the DB layer. The HTTP DELETE path is
 	// covered by handlers_projects_test; here we only need the projects row
 	// in archived state so we can probe each surface endpoint.
-	_, _, err := h.DB().RemoveProject(context.Background(), db.RemoveProjectParams{
-		ProjectID: projectID, Actor: "tester",
-	})
-	require.NoError(t, err)
+	archiveProject(t, h, projectID, false)
 
 	pid := strconv.FormatInt(projectID, 10)
 
@@ -67,24 +60,8 @@ func TestArchivedProject_SurfaceHandlersReturn404(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var bodyReader io.Reader
-			if tc.body != nil {
-				js, err := json.Marshal(tc.body)
-				require.NoError(t, err)
-				bodyReader = bytes.NewReader(js)
-			}
-			r, err := http.NewRequest(tc.method, ts.URL+tc.path, bodyReader)
-			require.NoError(t, err)
-			if tc.body != nil {
-				r.Header.Set("Content-Type", "application/json")
-			}
-			resp, err := http.DefaultClient.Do(r) //nolint:gosec // test loopback
-			require.NoError(t, err)
-			defer func() { _ = resp.Body.Close() }()
-			bs, _ := io.ReadAll(resp.Body)
-
-			assert.Equal(t, http.StatusNotFound, resp.StatusCode, string(bs))
-			assert.Contains(t, string(bs), "project_not_found", string(bs))
+			resp, bs := doReq(t, ts, tc.method, tc.path, tc.body, nil)
+			assertAPIError(t, resp.StatusCode, bs, http.StatusNotFound, "project_not_found")
 		})
 	}
 }
@@ -102,7 +79,6 @@ func TestArchivedProject_SurfaceHandlersReturn404(t *testing.T) {
 func TestArchivedProject_IssueScopedHandlersReturn404(t *testing.T) {
 	h, projectID := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	ctx := context.Background()
 	pid := strconv.FormatInt(projectID, 10)
 
 	// Seed one issue we can target. The issue's number is guaranteed to be
@@ -114,10 +90,7 @@ func TestArchivedProject_IssueScopedHandlersReturn404(t *testing.T) {
 
 	// Force-archive: open issue exists, so plain RemoveProject would be
 	// refused by the open-issues guard.
-	_, _, err := h.DB().RemoveProject(ctx, db.RemoveProjectParams{
-		ProjectID: projectID, Actor: "tester", Force: true,
-	})
-	require.NoError(t, err)
+	archiveProject(t, h, projectID, true)
 
 	num := strconv.Itoa(issueNumber)
 	cases := []struct {
@@ -174,27 +147,8 @@ func TestArchivedProject_IssueScopedHandlersReturn404(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var bodyReader io.Reader
-			if tc.body != nil {
-				js, err := json.Marshal(tc.body)
-				require.NoError(t, err)
-				bodyReader = bytes.NewReader(js)
-			}
-			r, err := http.NewRequest(tc.method, ts.URL+tc.path, bodyReader)
-			require.NoError(t, err)
-			if tc.body != nil {
-				r.Header.Set("Content-Type", "application/json")
-			}
-			for k, v := range tc.headers {
-				r.Header.Set(k, v)
-			}
-			resp, err := http.DefaultClient.Do(r) //nolint:gosec // test loopback
-			require.NoError(t, err)
-			defer func() { _ = resp.Body.Close() }()
-			respBs, _ := io.ReadAll(resp.Body)
-
-			assert.Equal(t, http.StatusNotFound, resp.StatusCode, string(respBs))
-			assert.Contains(t, string(respBs), "project_not_found", string(respBs))
+			resp, bs := doReq(t, ts, tc.method, tc.path, tc.body, tc.headers)
+			assertAPIError(t, resp.StatusCode, bs, http.StatusNotFound, "project_not_found")
 		})
 	}
 }
@@ -205,7 +159,6 @@ func TestArchivedProject_IssueScopedHandlersReturn404(t *testing.T) {
 func TestArchivedProject_ShowIssueByUIDReturns404(t *testing.T) {
 	h, projectID := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	ctx := context.Background()
 
 	pid := strconv.FormatInt(projectID, 10)
 	resp, bs := postJSON(t, ts, "/api/v1/projects/"+pid+"/issues",
@@ -219,17 +172,13 @@ func TestArchivedProject_ShowIssueByUIDReturns404(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bs, &created))
 	require.NotEmpty(t, created.Issue.UID)
 
-	_, _, err := h.DB().RemoveProject(ctx, db.RemoveProjectParams{
-		ProjectID: projectID, Actor: "tester", Force: true,
-	})
-	require.NoError(t, err)
+	archiveProject(t, h, projectID, true)
 
 	resp2, err := http.Get(ts.URL + "/api/v1/issues/" + created.Issue.UID) //nolint:gosec,noctx // test loopback
 	require.NoError(t, err)
 	defer func() { _ = resp2.Body.Close() }()
 	bs2, _ := io.ReadAll(resp2.Body)
-	assert.Equal(t, http.StatusNotFound, resp2.StatusCode, string(bs2))
-	assert.Contains(t, string(bs2), "project_not_found", string(bs2))
+	assertAPIError(t, resp2.StatusCode, bs2, http.StatusNotFound, "project_not_found")
 }
 
 // TestListAllIssues_NegativeProjectIDReturns400 pins that
@@ -245,8 +194,7 @@ func TestListAllIssues_NegativeProjectIDReturns400(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	bs, _ := io.ReadAll(resp.Body)
 
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), "validation", string(bs))
+	assertAPIError(t, resp.StatusCode, bs, http.StatusBadRequest, "validation")
 	assert.Contains(t, string(bs), "project_id", string(bs))
 }
 
@@ -257,20 +205,12 @@ func TestArchivedProject_SSEStreamRejects(t *testing.T) {
 	h, projectID := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
 
-	_, _, err := h.DB().RemoveProject(context.Background(), db.RemoveProjectParams{
-		ProjectID: projectID, Actor: "tester",
-	})
-	require.NoError(t, err)
+	archiveProject(t, h, projectID, false)
 
 	pid := strconv.FormatInt(projectID, 10)
-	r, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/events/stream?project_id="+pid, nil)
-	require.NoError(t, err)
-	r.Header.Set("Accept", "text/event-stream")
-	resp, err := http.DefaultClient.Do(r) //nolint:gosec // test loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, _ := io.ReadAll(resp.Body)
+	resp, bs := doReq(t, ts, http.MethodGet,
+		"/api/v1/events/stream?project_id="+pid, nil,
+		map[string]string{"Accept": "text/event-stream"})
 
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), "project_not_found", string(bs))
+	assertAPIError(t, resp.StatusCode, bs, http.StatusNotFound, "project_not_found")
 }

--- a/internal/daemon/handlers_comments_test.go
+++ b/internal/daemon/handlers_comments_test.go
@@ -1,8 +1,6 @@
 package daemon_test
 
 import (
-	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,14 +8,9 @@ import (
 )
 
 func TestCommentEndpoint_AppendsAndEmitsEvent(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	_, _ = postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		map[string]any{"actor": "x", "title": "x"})
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
 
-	resp, bs := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1/comments",
+	resp, bs := postJSON(t, ts, issueURL(pid, num, "comments"),
 		map[string]any{"actor": "agent", "body": "first comment"})
 	require.Equal(t, 200, resp.StatusCode, string(bs))
 	assert.Contains(t, string(bs), `"body":"first comment"`)
@@ -25,52 +18,34 @@ func TestCommentEndpoint_AppendsAndEmitsEvent(t *testing.T) {
 }
 
 func TestActionsClose_ReopenRoundtrip(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	_, _ = postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		map[string]any{"actor": "x", "title": "x"})
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
 
-	resp, bs := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1/actions/close",
+	resp, bs := postJSON(t, ts, issueURL(pid, num, "actions/close"),
 		map[string]any{"actor": "agent", "reason": "wontfix"})
 	require.Equal(t, 200, resp.StatusCode, string(bs))
 	assert.Contains(t, string(bs), `"status":"closed"`)
 	assert.Contains(t, string(bs), `"closed_reason":"wontfix"`)
 
-	resp2, bs2 := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1/actions/reopen",
+	resp2, bs2 := postJSON(t, ts, issueURL(pid, num, "actions/reopen"),
 		map[string]any{"actor": "agent"})
 	require.Equal(t, 200, resp2.StatusCode, string(bs2))
 	assert.Contains(t, string(bs2), `"status":"open"`)
 }
 
 func TestActionsClose_RejectsUnsupportedReason(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	_, _ = postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		map[string]any{"actor": "x", "title": "x"})
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
 
-	resp, bs := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1/actions/close",
+	resp, bs := postJSON(t, ts, issueURL(pid, num, "actions/close"),
 		map[string]any{"actor": "agent", "reason": "obsolete"})
-	assert.Equal(t, 400, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"code":"validation"`)
+	assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 }
 
 func TestActionsClose_AlreadyClosedIsNoOpEnvelope(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	_, _ = postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		map[string]any{"actor": "x", "title": "x"})
-	_, _ = postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1/actions/close",
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
+	_, _ = postJSON(t, ts, issueURL(pid, num, "actions/close"),
 		map[string]any{"actor": "agent"})
 
-	resp, bs := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1/actions/close",
+	resp, bs := postJSON(t, ts, issueURL(pid, num, "actions/close"),
 		map[string]any{"actor": "agent"})
 	require.Equal(t, 200, resp.StatusCode, string(bs))
 	assert.Contains(t, string(bs), `"changed":false`)
@@ -78,43 +53,25 @@ func TestActionsClose_AlreadyClosedIsNoOpEnvelope(t *testing.T) {
 }
 
 func TestCreateComment_BlankActorIs400(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	_, _ = postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		map[string]any{"actor": "x", "title": "x"})
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
 
-	resp, bs := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1/comments",
+	resp, bs := postJSON(t, ts, issueURL(pid, num, "comments"),
 		map[string]any{"actor": "   ", "body": "hi"})
-	assert.Equal(t, 400, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"code":"validation"`)
+	assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 }
 
 func TestCloseIssue_BlankActorIs400(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	_, _ = postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		map[string]any{"actor": "x", "title": "x"})
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
 
-	resp, bs := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1/actions/close",
+	resp, bs := postJSON(t, ts, issueURL(pid, num, "actions/close"),
 		map[string]any{"actor": "   "})
-	assert.Equal(t, 400, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"code":"validation"`)
+	assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 }
 
 func TestReopenIssue_BlankActorIs400(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	_, _ = postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		map[string]any{"actor": "x", "title": "x"})
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
 
-	resp, bs := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1/actions/reopen",
+	resp, bs := postJSON(t, ts, issueURL(pid, num, "actions/reopen"),
 		map[string]any{"actor": "   "})
-	assert.Equal(t, 400, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"code":"validation"`)
+	assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 }

--- a/internal/daemon/handlers_destructive_test.go
+++ b/internal/daemon/handlers_destructive_test.go
@@ -2,7 +2,6 @@ package daemon_test
 
 import (
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,41 +9,27 @@ import (
 )
 
 func TestDelete_RequiresConfirmHeader(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
-	_, _ = postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues",
-		map[string]any{"actor": "agent", "title": "x"})
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
 
-	resp := postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/delete",
+	resp := postWithHeader(t, ts, issueURL(pid, num, "actions/delete"),
 		nil, // no header
 		map[string]any{"actor": "agent"})
-	require.Equal(t, 412, resp.status, string(resp.body))
-	assert.Contains(t, string(resp.body), `"confirm_required"`)
+	assertAPIError(t, resp.status, resp.body, 412, "confirm_required")
 }
 
 func TestDelete_RejectsWrongConfirmValue(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
-	_, _ = postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues",
-		map[string]any{"actor": "agent", "title": "x"})
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
 
-	resp := postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/delete",
+	resp := postWithHeader(t, ts, issueURL(pid, num, "actions/delete"),
 		map[string]string{"X-Kata-Confirm": "DELETE #2"}, // wrong number
 		map[string]any{"actor": "agent"})
-	require.Equal(t, 412, resp.status, string(resp.body))
-	assert.Contains(t, string(resp.body), `"confirm_mismatch"`)
+	assertAPIError(t, resp.status, resp.body, 412, "confirm_mismatch")
 }
 
 func TestDelete_AcceptsCorrectConfirmAndSoftDeletes(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
-	_, _ = postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues",
-		map[string]any{"actor": "agent", "title": "x"})
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
 
-	resp := postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/delete",
+	resp := postWithHeader(t, ts, issueURL(pid, num, "actions/delete"),
 		map[string]string{"X-Kata-Confirm": "DELETE #1"},
 		map[string]any{"actor": "agent"})
 	require.Equal(t, 200, resp.status, string(resp.body))
@@ -52,21 +37,17 @@ func TestDelete_AcceptsCorrectConfirmAndSoftDeletes(t *testing.T) {
 	assert.Contains(t, string(resp.body), `"issue.soft_deleted"`)
 
 	// show without include_deleted now 404s.
-	respShow, bs := getStatusBody(t, ts, "/api/v1/projects/"+pidStr+"/issues/1")
+	respShow, bs := getStatusBody(t, ts, issueURL(pid, num, ""))
 	require.Equal(t, 404, respShow.StatusCode, string(bs))
 }
 
 func TestDelete_AlreadyDeletedIsNoOp(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
-	_, _ = postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues",
-		map[string]any{"actor": "agent", "title": "x"})
-	requireOK(t, postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/delete",
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
+	requireOK(t, postWithHeader(t, ts, issueURL(pid, num, "actions/delete"),
 		map[string]string{"X-Kata-Confirm": "DELETE #1"},
 		map[string]any{"actor": "agent"}))
 
-	resp := postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/delete",
+	resp := postWithHeader(t, ts, issueURL(pid, num, "actions/delete"),
 		map[string]string{"X-Kata-Confirm": "DELETE #1"},
 		map[string]any{"actor": "agent"})
 	require.Equal(t, 200, resp.status, string(resp.body))
@@ -75,52 +56,42 @@ func TestDelete_AlreadyDeletedIsNoOp(t *testing.T) {
 }
 
 func TestRestore_ClearsDeletedAt(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
-	_, _ = postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues",
-		map[string]any{"actor": "agent", "title": "x"})
-	requireOK(t, postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/delete",
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
+	requireOK(t, postWithHeader(t, ts, issueURL(pid, num, "actions/delete"),
 		map[string]string{"X-Kata-Confirm": "DELETE #1"},
 		map[string]any{"actor": "agent"}))
 
-	resp, bs := postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/restore",
+	resp, bs := postJSON(t, ts, issueURL(pid, num, "actions/restore"),
 		map[string]any{"actor": "agent"})
 	require.Equal(t, 200, resp.StatusCode, string(bs))
 	assert.Contains(t, string(bs), `"changed":true`)
 	assert.Contains(t, string(bs), `"issue.restored"`)
 
 	// show without include_deleted works again.
-	respShow, bsShow := getStatusBody(t, ts, "/api/v1/projects/"+pidStr+"/issues/1")
+	respShow, bsShow := getStatusBody(t, ts, issueURL(pid, num, ""))
 	require.Equal(t, 200, respShow.StatusCode, string(bsShow))
 }
 
 func TestPurge_RequiresConfirmHeaderAndRemovesAllRows(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
-	_, _ = postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues",
-		map[string]any{"actor": "agent", "title": "purge me"})
-	issue, err := h.DB().IssueByNumber(t.Context(), pid, 1)
+	h, ts, pid, num := bootstrapProjectWithIssue(t)
+	issue, err := h.DB().IssueByNumber(t.Context(), pid, num)
 	require.NoError(t, err)
 	project, err := h.DB().ProjectByID(t.Context(), pid)
 	require.NoError(t, err)
 
 	// Missing header → 412.
-	resp := postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/purge",
+	resp := postWithHeader(t, ts, issueURL(pid, num, "actions/purge"),
 		nil, map[string]any{"actor": "agent"})
-	require.Equal(t, 412, resp.status, string(resp.body))
-	assert.Contains(t, string(resp.body), `"confirm_required"`)
+	assertAPIError(t, resp.status, resp.body, 412, "confirm_required")
 
 	// Wrong header → 412 confirm_mismatch.
-	resp = postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/purge",
+	resp = postWithHeader(t, ts, issueURL(pid, num, "actions/purge"),
 		map[string]string{"X-Kata-Confirm": "DELETE #1"},
 		map[string]any{"actor": "agent"})
-	require.Equal(t, 412, resp.status, string(resp.body))
-	assert.Contains(t, string(resp.body), `"confirm_mismatch"`)
+	assertAPIError(t, resp.status, resp.body, 412, "confirm_mismatch")
 
 	// Correct header → 200 with purge_log.
-	resp = postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/1/actions/purge",
+	resp = postWithHeader(t, ts, issueURL(pid, num, "actions/purge"),
 		map[string]string{"X-Kata-Confirm": "PURGE #1"},
 		map[string]any{"actor": "agent"})
 	require.Equal(t, 200, resp.status, string(resp.body))
@@ -130,7 +101,7 @@ func TestPurge_RequiresConfirmHeaderAndRemovesAllRows(t *testing.T) {
 	assert.Contains(t, string(resp.body), `"project_uid":"`+project.UID+`"`)
 
 	// Subsequent show 404s — issue is gone.
-	respShow, _ := getStatusBody(t, ts, "/api/v1/projects/"+pidStr+"/issues/1?include_deleted=true")
+	respShow, _ := getStatusBody(t, ts, issueURL(pid, num, "")+"?include_deleted=true")
 	assert.Equal(t, 404, respShow.StatusCode)
 }
 
@@ -140,13 +111,11 @@ func TestPurge_RequiresConfirmHeaderAndRemovesAllRows(t *testing.T) {
 func TestDelete_UnknownIssueIs404(t *testing.T) {
 	h, pid := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
 
-	resp := postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/9999/actions/delete",
+	resp := postWithHeader(t, ts, issueURL(pid, 9999, "actions/delete"),
 		map[string]string{"X-Kata-Confirm": "DELETE #9999"},
 		map[string]any{"actor": "agent"})
-	require.Equal(t, 404, resp.status, string(resp.body))
-	assert.Contains(t, string(resp.body), `"issue_not_found"`)
+	assertAPIError(t, resp.status, resp.body, 404, "issue_not_found")
 }
 
 // TestRestore_UnknownIssueIs404 mirrors TestDelete_UnknownIssueIs404 for the
@@ -154,23 +123,19 @@ func TestDelete_UnknownIssueIs404(t *testing.T) {
 func TestRestore_UnknownIssueIs404(t *testing.T) {
 	h, pid := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
 
-	resp, bs := postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues/9999/actions/restore",
+	resp, bs := postJSON(t, ts, issueURL(pid, 9999, "actions/restore"),
 		map[string]any{"actor": "agent"})
-	require.Equal(t, 404, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"issue_not_found"`)
+	assertAPIError(t, resp.StatusCode, bs, 404, "issue_not_found")
 }
 
 // TestPurge_UnknownIssueIs404 mirrors the delete/restore 404 pin for purge.
 func TestPurge_UnknownIssueIs404(t *testing.T) {
 	h, pid := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
 
-	resp := postWithHeader(t, ts, "/api/v1/projects/"+pidStr+"/issues/9999/actions/purge",
+	resp := postWithHeader(t, ts, issueURL(pid, 9999, "actions/purge"),
 		map[string]string{"X-Kata-Confirm": "PURGE #9999"},
 		map[string]any{"actor": "agent"})
-	require.Equal(t, 404, resp.status, string(resp.body))
-	assert.Contains(t, string(resp.body), `"issue_not_found"`)
+	assertAPIError(t, resp.status, resp.body, 404, "issue_not_found")
 }

--- a/internal/daemon/handlers_digest_test.go
+++ b/internal/daemon/handlers_digest_test.go
@@ -1,9 +1,6 @@
 package daemon_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
 	"net/url"
 	"strconv"
 	"testing"
@@ -13,6 +10,89 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/testenv"
 )
+
+// digestActor is the per-actor slice in the digest response: totals plus a
+// per-issue action sequence.
+type digestActor struct {
+	Actor  string `json:"actor"`
+	Totals struct {
+		Created   int `json:"created"`
+		Closed    int `json:"closed"`
+		Commented int `json:"commented"`
+		Labeled   int `json:"labeled"`
+		Assigned  int `json:"assigned"`
+		Linked    int `json:"linked"`
+		Unblocked int `json:"unblocked"`
+	} `json:"totals"`
+	Issues []struct {
+		IssueNumber int64    `json:"issue_number"`
+		Actions     []string `json:"actions"`
+	} `json:"issues"`
+}
+
+// digestBody is the decoded shape used by the digest tests. Fields are a
+// superset of what each individual test asserts; missing fields decode as
+// zero values.
+type digestBody struct {
+	EventCount int   `json:"event_count"`
+	ProjectID  int64 `json:"project_id"`
+	Totals     struct {
+		Created   int `json:"created"`
+		Closed    int `json:"closed"`
+		Commented int `json:"commented"`
+		Labeled   int `json:"labeled"`
+		Assigned  int `json:"assigned"`
+		Linked    int `json:"linked"`
+		Unlinked  int `json:"unlinked"`
+		Unblocked int `json:"unblocked"`
+	} `json:"totals"`
+	Actors []digestActor `json:"actors"`
+}
+
+// actionsFor returns the action sequence the digest recorded for actor on
+// issueNumber, or nil when no entry exists for that pair.
+func (d *digestBody) actionsFor(actor string, issueNumber int64) []string {
+	for _, a := range d.Actors {
+		if a.Actor != actor {
+			continue
+		}
+		for _, iss := range a.Issues {
+			if iss.IssueNumber == issueNumber {
+				return iss.Actions
+			}
+		}
+	}
+	return nil
+}
+
+// projectDigestPath builds the per-project digest URL with optional
+// since/until/actor filters. Empty values are omitted.
+func projectDigestPath(projectID int64, since, until, actor string) string {
+	q := url.Values{}
+	if since != "" {
+		q.Set("since", since)
+	}
+	if until != "" {
+		q.Set("until", until)
+	}
+	if actor != "" {
+		q.Set("actor", actor)
+	}
+	path := projectPath(projectID) + "/digest"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	return path
+}
+
+// fetchDigest GETs the per-project digest with the supplied since/until window
+// and returns the decoded body.
+func fetchDigest(t *testing.T, env *testenv.Env, projectID int64, since, until string) digestBody {
+	t.Helper()
+	var out digestBody
+	envGetJSON(t, env, projectDigestPath(projectID, since, until, ""), &out)
+	return out
+}
 
 // TestDigest_AggregatesByActor exercises the end-to-end digest path: two
 // actors create, comment, label, close, and explicitly unblock issues; the
@@ -36,44 +116,7 @@ func TestDigest_AggregatesByActor(t *testing.T) {
 	postLinkAs(t, env, pid, a, "bob", "blocks", b) // a blocks b
 	deleteLinkBlocksAs(t, env, pid, a, "bob", b)   // bob unblocks b
 
-	since := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
-	until := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
-	digestURL := env.URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) +
-		"/digest?since=" + url.QueryEscape(since) + "&until=" + url.QueryEscape(until)
-
-	resp, err := env.HTTP.Get(digestURL)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-
-	var body struct {
-		EventCount int   `json:"event_count"`
-		ProjectID  int64 `json:"project_id"`
-		Totals     struct {
-			Created   int `json:"created"`
-			Closed    int `json:"closed"`
-			Commented int `json:"commented"`
-			Labeled   int `json:"labeled"`
-			Linked    int `json:"linked"`
-			Unlinked  int `json:"unlinked"`
-			Unblocked int `json:"unblocked"`
-		} `json:"totals"`
-		Actors []struct {
-			Actor  string `json:"actor"`
-			Totals struct {
-				Created   int `json:"created"`
-				Closed    int `json:"closed"`
-				Commented int `json:"commented"`
-				Unblocked int `json:"unblocked"`
-			} `json:"totals"`
-			Issues []struct {
-				IssueNumber int64    `json:"issue_number"`
-				Actions     []string `json:"actions"`
-			} `json:"issues"`
-		} `json:"actors"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	body := fetchDigest(t, env, pid, rfc3339Offset(-time.Hour), rfc3339Offset(time.Hour))
 
 	assert.Equal(t, pid, body.ProjectID)
 	assert.GreaterOrEqual(t, body.EventCount, 9)
@@ -96,25 +139,13 @@ func TestDigest_AggregatesByActor(t *testing.T) {
 
 	// Alice's first issue should show created → commented:2 → closed:done in
 	// that canonical order.
-	var aliceFirst []string
-	for _, iss := range body.Actors[0].Issues {
-		if iss.IssueNumber == a {
-			aliceFirst = iss.Actions
-			break
-		}
-	}
+	aliceFirst := body.actionsFor("alice", a)
 	require.NotNil(t, aliceFirst)
 	assert.Equal(t, []string{"created", "commented:2", "closed:done"}, aliceFirst)
 
 	// Bob's actions on issue b should include the labeled token and the
 	// unblocks-credit referencing issue b.
-	var bobOnB []string
-	for _, iss := range body.Actors[1].Issues {
-		if iss.IssueNumber == b {
-			bobOnB = iss.Actions
-			break
-		}
-	}
+	bobOnB := body.actionsFor("bob", b)
 	require.NotNil(t, bobOnB)
 	assert.Contains(t, bobOnB, "labeled:bug")
 }
@@ -126,20 +157,8 @@ func TestDigest_ActorFilter(t *testing.T) {
 	_ = createIssueAs(t, env, pid, "alice", "x")
 	_ = createIssueAs(t, env, pid, "bob", "y")
 
-	since := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
-	resp, err := env.HTTP.Get(env.URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) +
-		"/digest?since=" + url.QueryEscape(since) + "&actor=alice")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-
-	var body struct {
-		Actors []struct {
-			Actor string `json:"actor"`
-		} `json:"actors"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	var body digestBody
+	envGetJSON(t, env, projectDigestPath(pid, rfc3339Offset(-time.Hour), "", "alice"), &body)
 	require.Len(t, body.Actors, 1)
 	assert.Equal(t, "alice", body.Actors[0].Actor)
 }
@@ -158,7 +177,12 @@ func TestDigest_CountsCreateTimeLabelsOwnerLinks(t *testing.T) {
 	target := createIssueAs(t, env, pid, "alice", "target")
 
 	// Alice creates a richer issue with a label, an owner, and a blocks link.
-	body, _ := json.Marshal(map[string]any{
+	var created struct {
+		Issue struct {
+			Number int64 `json:"number"`
+		} `json:"issue"`
+	}
+	envPostJSON(t, env, projectPath(pid)+"/issues", map[string]any{
 		"actor":  "alice",
 		"title":  "rich",
 		"labels": []string{"bug"},
@@ -166,52 +190,10 @@ func TestDigest_CountsCreateTimeLabelsOwnerLinks(t *testing.T) {
 		"links": []map[string]any{
 			{"type": "blocks", "to_number": target},
 		},
-	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-	var created struct {
-		Issue struct {
-			Number int64 `json:"number"`
-		} `json:"issue"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	}, &created)
 	rich := created.Issue.Number
 
-	since := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
-	until := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
-	dresp, err := env.HTTP.Get(env.URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) +
-		"/digest?since=" + url.QueryEscape(since) + "&until=" + url.QueryEscape(until))
-	require.NoError(t, err)
-	defer func() { _ = dresp.Body.Close() }()
-	require.Equal(t, 200, dresp.StatusCode)
-
-	var digest struct {
-		Totals struct {
-			Created  int `json:"created"`
-			Labeled  int `json:"labeled"`
-			Assigned int `json:"assigned"`
-			Linked   int `json:"linked"`
-		} `json:"totals"`
-		Actors []struct {
-			Actor  string `json:"actor"`
-			Totals struct {
-				Created  int `json:"created"`
-				Labeled  int `json:"labeled"`
-				Assigned int `json:"assigned"`
-				Linked   int `json:"linked"`
-			} `json:"totals"`
-			Issues []struct {
-				IssueNumber int64    `json:"issue_number"`
-				Actions     []string `json:"actions"`
-			} `json:"issues"`
-		} `json:"actors"`
-	}
-	require.NoError(t, json.NewDecoder(dresp.Body).Decode(&digest))
+	digest := fetchDigest(t, env, pid, rfc3339Offset(-time.Hour), rfc3339Offset(time.Hour))
 
 	// Two issues created total. The richer one bumps labeled / assigned /
 	// linked even though no separate events were emitted for them.
@@ -226,13 +208,7 @@ func TestDigest_CountsCreateTimeLabelsOwnerLinks(t *testing.T) {
 	assert.Equal(t, 1, digest.Actors[0].Totals.Assigned)
 	assert.Equal(t, 1, digest.Actors[0].Totals.Linked)
 
-	var actions []string
-	for _, iss := range digest.Actors[0].Issues {
-		if iss.IssueNumber == rich {
-			actions = iss.Actions
-			break
-		}
-	}
+	actions := digest.actionsFor("alice", rich)
 	require.NotNil(t, actions, "rich issue not present in alice's per-issue digest")
 	assert.Contains(t, actions, "created")
 	assert.Contains(t, actions, "labeled:bug")
@@ -244,10 +220,7 @@ func TestDigest_CountsCreateTimeLabelsOwnerLinks(t *testing.T) {
 func TestDigest_RejectsBadSince(t *testing.T) {
 	env := testenv.New(t)
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
-	resp, err := env.HTTP.Get(env.URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/digest?since=not-a-time")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp := envDoJSON(t, env, "GET", projectPath(pid)+"/digest?since=not-a-time", nil, nil)
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
@@ -257,135 +230,13 @@ func TestDigest_GlobalEndpoint(t *testing.T) {
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	_ = createIssueAs(t, env, pid, "alice", "x")
 
-	since := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/digest?since=" + url.QueryEscape(since))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-
 	var body struct {
 		ProjectID int64 `json:"project_id"`
 		Totals    struct {
 			Created int `json:"created"`
 		} `json:"totals"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	envGetJSON(t, env, "/api/v1/digest?since="+url.QueryEscape(rfc3339Offset(-time.Hour)), &body)
 	assert.Equal(t, int64(0), body.ProjectID, "global digest reports project_id=0")
 	assert.GreaterOrEqual(t, body.Totals.Created, 1)
-}
-
-// --- helpers below are local to digest tests; they parallel the ones in
-// handlers_links_test.go but accept an explicit actor so cross-actor scenarios
-// can be set up. ---
-
-func createIssueAs(t *testing.T, env *testenv.Env, pid int64, actor, title string) int64 {
-	t.Helper()
-	body, _ := json.Marshal(map[string]string{"actor": actor, "title": title})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Issue struct {
-			Number int64 `json:"number"`
-		} `json:"issue"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
-	return out.Issue.Number
-}
-
-func postCommentAs(t *testing.T, env *testenv.Env, pid, num int64, actor, txt string) {
-	t.Helper()
-	body, _ := json.Marshal(map[string]string{"actor": actor, "body": txt})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(num, 10)+"/comments",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-}
-
-func closeIssueAs(t *testing.T, env *testenv.Env, pid, num int64, actor, reason string) {
-	t.Helper()
-	body, _ := json.Marshal(map[string]string{"actor": actor, "reason": reason})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(num, 10)+"/actions/close",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-}
-
-func postLabelAs(t *testing.T, env *testenv.Env, pid, num int64, actor, label string) {
-	t.Helper()
-	body, _ := json.Marshal(map[string]string{"actor": actor, "label": label})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(num, 10)+"/labels",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-}
-
-func postLinkAs(t *testing.T, env *testenv.Env, pid, fromNum int64, actor, linkType string, toNum int64) int64 {
-	t.Helper()
-	body, _ := json.Marshal(map[string]any{
-		"actor": actor, "type": linkType, "to_number": toNum,
-	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(fromNum, 10)+"/links",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equalf(t, 200, resp.StatusCode, "postLinkAs status")
-	var out struct {
-		Link struct {
-			ID int64 `json:"id"`
-		} `json:"link"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
-	return out.Link.ID
-}
-
-// deleteLinkBlocksAs removes a blocks link by re-creating it just to read its
-// id, then DELETEs it. The DELETE attribution is to `actor`, which is the
-// person who gets credit for the unblock.
-func deleteLinkBlocksAs(t *testing.T, env *testenv.Env, pid, fromNum int64, actor string, toNum int64) {
-	t.Helper()
-	// Look up the existing link id by reading the blocker's links list. The
-	// daemon doesn't expose a /links GET, so we rely on the issue show
-	// payload, which includes Links with their ids.
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/projects/" +
-		strconv.FormatInt(pid, 10) + "/issues/" + strconv.FormatInt(fromNum, 10))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	var view struct {
-		Links []struct {
-			ID       int64  `json:"id"`
-			Type     string `json:"type"`
-			ToNumber int64  `json:"to_number"`
-		} `json:"links"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&view))
-	var linkID int64
-	for _, l := range view.Links {
-		if l.Type == "blocks" && l.ToNumber == toNum {
-			linkID = l.ID
-			break
-		}
-	}
-	require.NotZero(t, linkID, "no blocks link to %d found on issue %d", toNum, fromNum)
-
-	delURL := env.URL + "/api/v1/projects/" + strconv.FormatInt(pid, 10) +
-		"/issues/" + strconv.FormatInt(fromNum, 10) + "/links/" +
-		strconv.FormatInt(linkID, 10) + "?actor=" + url.QueryEscape(actor)
-	req, err := http.NewRequest(http.MethodDelete, delURL, nil)
-	require.NoError(t, err)
-	dresp, err := env.HTTP.Do(req)
-	require.NoError(t, err)
-	require.NoError(t, dresp.Body.Close())
-	require.Equal(t, 200, dresp.StatusCode)
 }

--- a/internal/daemon/handlers_events_test.go
+++ b/internal/daemon/handlers_events_test.go
@@ -3,7 +3,6 @@ package daemon_test
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 	"strconv"
@@ -26,20 +25,47 @@ func mkProject(t *testing.T, env *testenv.Env, identity, name string) int64 {
 
 func mkIssue(t *testing.T, env *testenv.Env, projectID int64, title string) db.Issue {
 	t.Helper()
-	is, _, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
+	is, _ := mkIssueWithEvent(t, env, projectID, title)
+	return is
+}
+
+func mkIssueWithEvent(t *testing.T, env *testenv.Env, projectID int64, title string) (db.Issue, db.Event) {
+	t.Helper()
+	is, evt, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
 		ProjectID: projectID, Title: title, Author: "tester",
 	})
 	require.NoError(t, err)
-	return is
+	return is, evt
+}
+
+// setupLiveSSE creates a project, injects a sentinel issue, opens an SSE
+// stream just before that sentinel, and consumes the sentinel frame so the
+// returned framer is parked in the live wakeup loop. Use this when a test
+// needs to exercise post-drain handler behavior (e.g. broadcaster races,
+// purge-reset rechecks) and must not have the events under test land in the
+// initial drain phase.
+func setupLiveSSE(t *testing.T, env *testenv.Env) (int64, db.Issue, *sseFramer) {
+	t.Helper()
+	pid := mkProject(t, env, "github.com/test/a", "a")
+	sentinelIssue, sentinelEvt := mkIssueWithEvent(t, env, pid, "sentinel")
+
+	hwm, err := env.DB.MaxEventID(context.Background())
+	require.NoError(t, err)
+	resp := openSSE(t, env, "after_id="+strconv.FormatInt(hwm-1, 10), nil)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, 200, resp.StatusCode)
+
+	framer := newSSEFramer(resp.Body)
+	first, ok := framer.Next(t, 2*time.Second)
+	require.True(t, ok, "sentinel drain frame should arrive")
+	require.Equal(t, strconv.FormatInt(sentinelEvt.ID, 10), first.id)
+	return pid, sentinelIssue, framer
 }
 
 func TestPollEvents_EmptyResultIsNonNullArray(t *testing.T) {
 	env := testenv.New(t)
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/events?after_id=0&limit=10")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, bs := envGetRaw(t, env, "/api/v1/events?after_id=0&limit=10")
 	require.Equal(t, 200, resp.StatusCode)
-	bs, _ := io.ReadAll(resp.Body)
 	body := string(bs)
 	assert.Contains(t, body, `"events":[]`, "must be empty array, never null")
 	assert.Contains(t, body, `"reset_required":false`)
@@ -54,10 +80,6 @@ func TestPollEvents_ReturnsEventsAndAdvancesCursor(t *testing.T) {
 	project, err := env.DB.ProjectByID(context.Background(), pid)
 	require.NoError(t, err)
 
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/events?after_id=0&limit=10")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var b struct {
 		ResetRequired bool `json:"reset_required"`
 		Events        []struct {
@@ -68,7 +90,7 @@ func TestPollEvents_ReturnsEventsAndAdvancesCursor(t *testing.T) {
 		} `json:"events"`
 		NextAfterID int64 `json:"next_after_id"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&b))
+	envGetJSON(t, env, "/api/v1/events?after_id=0&limit=10", &b)
 	require.Len(t, b.Events, 2)
 	assert.Equal(t, int64(1), b.Events[0].EventID)
 	assert.Equal(t, int64(2), b.Events[1].EventID)
@@ -95,10 +117,6 @@ func TestPollEvents_UIDsIncludeRelatedIssue(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/events?after_id=2&limit=10")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var b struct {
 		Events []struct {
 			Type            string  `json:"type"`
@@ -107,7 +125,7 @@ func TestPollEvents_UIDsIncludeRelatedIssue(t *testing.T) {
 			RelatedIssueUID *string `json:"related_issue_uid"`
 		} `json:"events"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&b))
+	envGetJSON(t, env, "/api/v1/events?after_id=2&limit=10", &b)
 	require.Len(t, b.Events, 1)
 	assert.Equal(t, "issue.linked", b.Events[0].Type)
 	assert.Equal(t, project.UID, b.Events[0].ProjectUID)
@@ -122,11 +140,8 @@ func TestPollEvents_NextAfterIDEchoesAfterIDOnEmpty(t *testing.T) {
 	pid := mkProject(t, env, "github.com/test/a", "a")
 	mkIssue(t, env, pid, "only")
 
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/events?after_id=99&limit=10")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, bs := envGetRaw(t, env, "/api/v1/events?after_id=99&limit=10")
 	require.Equal(t, 200, resp.StatusCode)
-	bs, _ := io.ReadAll(resp.Body)
 	body := string(bs)
 	assert.Contains(t, body, `"next_after_id":99`)
 	assert.Contains(t, body, `"events":[]`)
@@ -139,16 +154,12 @@ func TestPollEvents_PerProjectFiltersOtherProjects(t *testing.T) {
 	mkIssue(t, env, pa, "a1")
 	mkIssue(t, env, pb, "b1")
 
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/projects/" + strconv.FormatInt(pa, 10) + "/events?after_id=0&limit=10")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var b struct {
 		Events []struct {
 			ProjectID int64 `json:"project_id"`
 		} `json:"events"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&b))
+	envGetJSON(t, env, "/api/v1/projects/"+strconv.FormatInt(pa, 10)+"/events?after_id=0&limit=10", &b)
 	require.Len(t, b.Events, 1)
 	assert.Equal(t, pa, b.Events[0].ProjectID)
 }
@@ -161,10 +172,6 @@ func TestPollEvents_ResetRequiredAfterPurge(t *testing.T) {
 	require.NoError(t, err)
 
 	// Cursor below the reset → reset_required:true
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/events?after_id=0&limit=10")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var b struct {
 		ResetRequired bool  `json:"reset_required"`
 		ResetAfterID  int64 `json:"reset_after_id"`
@@ -173,7 +180,7 @@ func TestPollEvents_ResetRequiredAfterPurge(t *testing.T) {
 		} `json:"events"`
 		NextAfterID int64 `json:"next_after_id"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&b))
+	envGetJSON(t, env, "/api/v1/events?after_id=0&limit=10", &b)
 	assert.True(t, b.ResetRequired)
 	assert.Greater(t, b.ResetAfterID, int64(0))
 	assert.Equal(t, b.ResetAfterID, b.NextAfterID, "next_after_id == reset_after_id when reset")
@@ -186,22 +193,15 @@ func TestPollEvents_LimitClampsAt1000(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		mkIssue(t, env, pid, "x")
 	}
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/events?after_id=0&limit=99999")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := envGetRaw(t, env, "/api/v1/events?after_id=0&limit=99999")
 	assert.Equal(t, 200, resp.StatusCode, "values >1000 must clamp silently, not 400")
 }
 
 func TestPollEvents_LimitNonPositiveIs400(t *testing.T) {
 	env := testenv.New(t)
 	for _, q := range []string{"after_id=0&limit=0", "after_id=0&limit=-5"} {
-		resp, err := env.HTTP.Get(env.URL + "/api/v1/events?" + q)
-		require.NoError(t, err)
-		bs, _ := io.ReadAll(resp.Body)
-		body := string(bs)
-		_ = resp.Body.Close()
-		assert.Equal(t, 400, resp.StatusCode, "limit %s should be 400", q)
-		assert.Contains(t, body, `"code":"validation"`)
+		resp, bs := envGetRaw(t, env, "/api/v1/events?"+q)
+		assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 	}
 }
 
@@ -209,26 +209,19 @@ func TestPollEvents_NegativeAfterIDIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid := mkProject(t, env, "github.com/test/a", "a")
 	pidStr := strconv.FormatInt(pid, 10)
-	urls := []string{
-		env.URL + "/api/v1/events?after_id=-1",
-		env.URL + "/api/v1/projects/" + pidStr + "/events?after_id=-1",
+	paths := []string{
+		"/api/v1/events?after_id=-1",
+		"/api/v1/projects/" + pidStr + "/events?after_id=-1",
 	}
-	for _, u := range urls {
-		resp, err := env.HTTP.Get(u) //nolint:gosec // G107: test server URL, not user-controlled
-		require.NoError(t, err)
-		bs, _ := io.ReadAll(resp.Body)
-		body := string(bs)
-		_ = resp.Body.Close()
-		assert.Equal(t, 400, resp.StatusCode, "url %s should be 400", u)
-		assert.Contains(t, body, `"code":"validation"`)
+	for _, p := range paths {
+		resp, bs := envGetRaw(t, env, p)
+		assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 	}
 }
 
 func TestPollEvents_LimitNonNumericIs400(t *testing.T) {
 	env := testenv.New(t)
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/events?after_id=0&limit=foo")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := envGetRaw(t, env, "/api/v1/events?after_id=0&limit=foo")
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
@@ -239,16 +232,12 @@ func TestPollEvents_LimitAbsentUsesDefault(t *testing.T) {
 	mkIssue(t, env, pid, "second")
 
 	// No limit query param at all — should default to 100 and return both rows.
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/events?after_id=0")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var b struct {
 		Events []struct {
 			EventID int64 `json:"event_id"`
 		} `json:"events"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&b))
+	envGetJSON(t, env, "/api/v1/events?after_id=0", &b)
 	require.Len(t, b.Events, 2, "missing limit should default to pollLimitDefault, not reject the request")
 }
 
@@ -257,12 +246,8 @@ func TestPollEvents_LimitAbsentUsesDefault(t *testing.T) {
 // cross-project sentinel (projectID == 0) and leak every project's events.
 func TestPollEvents_PerProject_NonPositiveProjectIDIs400(t *testing.T) {
 	env := testenv.New(t)
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/projects/0/events?after_id=0&limit=10")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	assert.Equal(t, 400, resp.StatusCode)
-	bs, _ := io.ReadAll(resp.Body)
-	assert.Contains(t, string(bs), `"code":"validation"`)
+	resp, bs := envGetRaw(t, env, "/api/v1/projects/0/events?after_id=0&limit=10")
+	assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 }
 
 // TestPollEvents_PerProject_UnknownProjectIs404 mirrors sibling project-scoped
@@ -270,12 +255,8 @@ func TestPollEvents_PerProject_NonPositiveProjectIDIs400(t *testing.T) {
 // than returning an empty list for a project that does not exist.
 func TestPollEvents_PerProject_UnknownProjectIs404(t *testing.T) {
 	env := testenv.New(t)
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/projects/9999/events?after_id=0&limit=10")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	assert.Equal(t, 404, resp.StatusCode)
-	bs, _ := io.ReadAll(resp.Body)
-	assert.Contains(t, string(bs), `"code":"project_not_found"`)
+	resp, bs := envGetRaw(t, env, "/api/v1/projects/9999/events?after_id=0&limit=10")
+	assertAPIError(t, resp.StatusCode, bs, 404, "project_not_found")
 }
 
 type sseFrame struct {
@@ -384,52 +365,33 @@ func openSSE(t *testing.T, env *testenv.Env, query string, header http.Header) *
 func TestSSE_AcceptNegotiation(t *testing.T) {
 	env := testenv.New(t)
 
-	// Missing Accept → 406
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		env.URL+"/api/v1/events/stream", nil)
-	req.Header.Del("Accept")
-	resp, err := env.HTTP.Do(req) //nolint:gosec // G704: test server URL, not user-controlled
-	require.NoError(t, err)
-	bs, _ := io.ReadAll(resp.Body)
-	body := string(bs)
-	_ = resp.Body.Close()
-	assert.Equal(t, 406, resp.StatusCode)
-	assert.Contains(t, body, `"code":"not_acceptable"`)
+	// Missing Accept → 406. envDoRaw doesn't add an Accept header on its own,
+	// so this exercises the missing-header path.
+	resp, bs := envDoRaw(t, env, http.MethodGet, "/api/v1/events/stream", nil, nil)
+	assertAPIError(t, resp.StatusCode, bs, 406, "not_acceptable")
 
 	// Wrong Accept → 406
-	req, _ = http.NewRequestWithContext(context.Background(), http.MethodGet,
-		env.URL+"/api/v1/events/stream", nil)
-	req.Header.Set("Accept", "application/json")
-	resp, err = env.HTTP.Do(req) //nolint:gosec // G704: test server URL, not user-controlled
-	require.NoError(t, err)
-	_ = resp.Body.Close()
+	resp, _ = envDoRaw(t, env, http.MethodGet, "/api/v1/events/stream", nil,
+		map[string]string{"Accept": "application/json"})
 	assert.Equal(t, 406, resp.StatusCode)
 
 	// Right Accept → 200
-	resp = openSSE(t, env, "", http.Header{"Accept": []string{"text/event-stream"}})
-	defer func() { _ = resp.Body.Close() }()
-	assert.Equal(t, 200, resp.StatusCode)
-	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	sseResp := openSSE(t, env, "", http.Header{"Accept": []string{"text/event-stream"}})
+	defer func() { _ = sseResp.Body.Close() }()
+	assert.Equal(t, 200, sseResp.StatusCode)
+	assert.Equal(t, "text/event-stream", sseResp.Header.Get("Content-Type"))
 
 	// */* → 200
-	resp = openSSE(t, env, "", http.Header{"Accept": []string{"*/*"}})
-	defer func() { _ = resp.Body.Close() }()
-	assert.Equal(t, 200, resp.StatusCode)
+	sseResp2 := openSSE(t, env, "", http.Header{"Accept": []string{"*/*"}})
+	defer func() { _ = sseResp2.Body.Close() }()
+	assert.Equal(t, 200, sseResp2.StatusCode)
 }
 
 func TestSSE_CursorConflict(t *testing.T) {
 	env := testenv.New(t)
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		env.URL+"/api/v1/events/stream?after_id=5", nil)
-	req.Header.Set("Accept", "text/event-stream")
-	req.Header.Set("Last-Event-ID", "10")
-	resp, err := env.HTTP.Do(req) //nolint:gosec // G704: test server URL, not user-controlled
-	require.NoError(t, err)
-	bs, _ := io.ReadAll(resp.Body)
-	body := string(bs)
-	_ = resp.Body.Close()
-	assert.Equal(t, 400, resp.StatusCode)
-	assert.Contains(t, body, `"code":"cursor_conflict"`)
+	resp, bs := envDoRaw(t, env, http.MethodGet, "/api/v1/events/stream?after_id=5", nil,
+		map[string]string{"Accept": "text/event-stream", "Last-Event-ID": "10"})
+	assertAPIError(t, resp.StatusCode, bs, 400, "cursor_conflict")
 }
 
 // TestSSE_CursorConflictPresenceBased pins the rule that detection is on
@@ -438,17 +400,9 @@ func TestSSE_CursorConflict(t *testing.T) {
 // cursor_conflict, not silently win for the header.
 func TestSSE_CursorConflictPresenceBased(t *testing.T) {
 	env := testenv.New(t)
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		env.URL+"/api/v1/events/stream?after_id=", nil)
-	req.Header.Set("Accept", "text/event-stream")
-	req.Header.Set("Last-Event-ID", "5")
-	resp, err := env.HTTP.Do(req) //nolint:gosec // G704: test server URL, not user-controlled
-	require.NoError(t, err)
-	bs, _ := io.ReadAll(resp.Body)
-	body := string(bs)
-	_ = resp.Body.Close()
-	assert.Equal(t, 400, resp.StatusCode)
-	assert.Contains(t, body, `"code":"cursor_conflict"`)
+	resp, bs := envDoRaw(t, env, http.MethodGet, "/api/v1/events/stream?after_id=", nil,
+		map[string]string{"Accept": "text/event-stream", "Last-Event-ID": "5"})
+	assertAPIError(t, resp.StatusCode, bs, 400, "cursor_conflict")
 }
 
 // TestSSE_NonGETReturnsAllowHeader pins that 405 responses include `Allow: GET`
@@ -456,11 +410,7 @@ func TestSSE_CursorConflictPresenceBased(t *testing.T) {
 func TestSSE_NonGETReturnsAllowHeader(t *testing.T) {
 	env := testenv.New(t)
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
-		req, _ := http.NewRequestWithContext(context.Background(), method,
-			env.URL+"/api/v1/events/stream", nil)
-		resp, err := env.HTTP.Do(req) //nolint:gosec // G704: test server URL, not user-controlled
-		require.NoError(t, err)
-		_ = resp.Body.Close()
+		resp, _ := envDoRaw(t, env, method, "/api/v1/events/stream", nil, nil)
 		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "method=%s", method)
 		assert.Equal(t, http.MethodGet, resp.Header.Get("Allow"), "method=%s", method)
 	}
@@ -550,16 +500,8 @@ func TestSSE_DrainFollowedByLiveBroadcast(t *testing.T) {
 	assert.Equal(t, "issue.created", first.event)
 
 	// Now create a second issue via HTTP so the handler fires a live broadcast.
-	pidStr := strconv.FormatInt(pid, 10)
-	issueURL := env.URL + "/api/v1/projects/" + pidStr + "/issues"
-	issueReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, issueURL,
-		strings.NewReader(`{"title":"second","actor":"tester"}`))
-	require.NoError(t, err)
-	issueReq.Header.Set("Content-Type", "application/json")
-	issueResp, err := env.HTTP.Do(issueReq) //nolint:gosec // G704: test server URL, not user-controlled
-	require.NoError(t, err)
-	_ = issueResp.Body.Close()
-	require.Equal(t, 200, issueResp.StatusCode)
+	envPostJSON(t, env, projectPath(pid)+"/issues",
+		map[string]string{"title": "second", "actor": "tester"}, nil)
 
 	second, ok := framer.Next(t, 2*time.Second)
 	require.True(t, ok, "live frame should arrive after the broadcast")
@@ -571,7 +513,6 @@ func TestSSE_LiveResetClosesStream(t *testing.T) {
 	env := testenv.New(t)
 	pid := mkProject(t, env, "github.com/test/a", "a")
 	is := mkIssue(t, env, pid, "doomed")
-	pidStr := strconv.FormatInt(pid, 10)
 
 	resp := openSSE(t, env, "after_id=0", nil)
 	defer func() { _ = resp.Body.Close() }()
@@ -585,15 +526,10 @@ func TestSSE_LiveResetClosesStream(t *testing.T) {
 	require.True(t, ok, "drain frame should arrive")
 	assert.Equal(t, "issue.created", first.event)
 
-	purgeURL := env.URL + "/api/v1/projects/" + pidStr + "/issues/" + strconv.FormatInt(is.Number, 10) + "/actions/purge"
-	purgeReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, purgeURL,
-		strings.NewReader(`{"actor":"tester"}`))
-	require.NoError(t, err)
-	purgeReq.Header.Set("Content-Type", "application/json")
-	purgeReq.Header.Set("X-Kata-Confirm", "PURGE #"+strconv.FormatInt(is.Number, 10))
-	purgeResp, err := env.HTTP.Do(purgeReq) //nolint:gosec // G704: test server URL, not user-controlled
-	require.NoError(t, err)
-	_ = purgeResp.Body.Close()
+	purgeResp, _ := envDoRaw(t, env, http.MethodPost,
+		issuePath(pid, is.Number, "actions/purge"),
+		map[string]string{"actor": "tester"},
+		map[string]string{"X-Kata-Confirm": "PURGE #" + strconv.FormatInt(is.Number, 10)})
 	require.Equal(t, 200, purgeResp.StatusCode)
 
 	reset, ok := framer.Next(t, 2*time.Second)
@@ -616,18 +552,10 @@ func TestSSE_ParentReplaceEmitsTwoFrames(t *testing.T) {
 	mkIssue(t, env, pid, "first")  // #1, will be initial parent
 	mkIssue(t, env, pid, "second") // #2, will be replacement parent
 	mkIssue(t, env, pid, "child")  // #3, the issue we re-parent
-	pidStr := strconv.FormatInt(pid, 10)
 
 	// Initial parent link 3 → 1.
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		env.URL+"/api/v1/projects/"+pidStr+"/issues/3/links",
-		strings.NewReader(`{"actor":"tester","type":"parent","to_number":1}`))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := env.HTTP.Do(req) //nolint:gosec // G704: test server URL, not user-controlled
-	require.NoError(t, err)
-	_ = resp.Body.Close()
-	require.Equal(t, 200, resp.StatusCode)
+	envPostJSON(t, env, issuePath(pid, 3, "links"),
+		map[string]any{"actor": "tester", "type": "parent", "to_number": 1}, nil)
 
 	// Subscribe AFTER the initial link so we don't see its frame in the drain.
 	maxID, err := env.DB.MaxEventID(context.Background())
@@ -636,15 +564,8 @@ func TestSSE_ParentReplaceEmitsTwoFrames(t *testing.T) {
 	defer func() { _ = sseResp.Body.Close() }()
 
 	// Re-parent 3 → 2 with replace.
-	req, err = http.NewRequestWithContext(context.Background(), http.MethodPost,
-		env.URL+"/api/v1/projects/"+pidStr+"/issues/3/links",
-		strings.NewReader(`{"actor":"tester","type":"parent","to_number":2,"replace":true}`))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err = env.HTTP.Do(req) //nolint:gosec // G704: test server URL, not user-controlled
-	require.NoError(t, err)
-	_ = resp.Body.Close()
-	require.Equal(t, 200, resp.StatusCode)
+	envPostJSON(t, env, issuePath(pid, 3, "links"),
+		map[string]any{"actor": "tester", "type": "parent", "to_number": 2, "replace": true}, nil)
 
 	// Live phase delivers two frames in order: issue.unlinked then issue.linked.
 	frames := readSSEFramesUntilN(t, sseResp.Body, 2, 2*time.Second)
@@ -655,16 +576,9 @@ func TestSSE_ParentReplaceEmitsTwoFrames(t *testing.T) {
 
 func TestSSE_UnknownProjectIDReturns404(t *testing.T) {
 	env := testenv.New(t)
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		env.URL+"/api/v1/events/stream?project_id=99999", nil)
-	req.Header.Set("Accept", "text/event-stream")
-	resp, err := env.HTTP.Do(req) //nolint:gosec // G704: test server URL, not user-controlled
-	require.NoError(t, err)
-	bs, _ := io.ReadAll(resp.Body)
-	body := string(bs)
-	_ = resp.Body.Close()
-	assert.Equal(t, 404, resp.StatusCode)
-	assert.Contains(t, body, `"code":"project_not_found"`)
+	resp, bs := envDoRaw(t, env, http.MethodGet, "/api/v1/events/stream?project_id=99999", nil,
+		map[string]string{"Accept": "text/event-stream"})
+	assertAPIError(t, resp.StatusCode, bs, 404, "project_not_found")
 }
 
 func TestSSE_LiveHeartbeatKeepsConnectionAlive(t *testing.T) {

--- a/internal/daemon/handlers_health_test.go
+++ b/internal/daemon/handlers_health_test.go
@@ -1,31 +1,16 @@
 package daemon_test
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	"github.com/wesm/kata/internal/daemon"
 	"github.com/wesm/kata/internal/db"
 )
 
 func TestHealth_ReportsSchemaAndUptime(t *testing.T) {
-	d := openTestDB(t)
-	srv := daemon.NewServer(daemon.ServerConfig{DB: d.db, StartedAt: d.now})
-	t.Cleanup(func() { _ = srv.Close() })
-
-	ts := httptest.NewServer(srv.Handler())
-	t.Cleanup(ts.Close)
-
-	resp, err := http.Get(ts.URL + "/api/v1/health")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	ts, _ := startDefaultTestServer(t)
 
 	var body struct {
 		OK            bool   `json:"ok"`
@@ -33,9 +18,7 @@ func TestHealth_ReportsSchemaAndUptime(t *testing.T) {
 		Uptime        string `json:"uptime"`
 		DBPath        string `json:"db_path"`
 	}
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal(bs, &body))
+	getAndUnmarshal(t, ts, "/api/v1/health", http.StatusOK, &body)
 	assert.True(t, body.OK)
 	assert.Equal(t, db.CurrentSchemaVersion(), body.SchemaVersion)
 	assert.NotEmpty(t, body.Uptime)

--- a/internal/daemon/handlers_hooks_integration_test.go
+++ b/internal/daemon/handlers_hooks_integration_test.go
@@ -1,16 +1,13 @@
 package daemon_test
 
 import (
-	"encoding/json"
 	"net/http/httptest"
-	"strconv"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wesm/kata/internal/daemon"
 	"github.com/wesm/kata/internal/db"
 	"github.com/wesm/kata/internal/hooks"
 )
@@ -38,41 +35,19 @@ func (r *recordingSink) snapshot() []db.Event {
 
 var _ hooks.Sink = (*recordingSink)(nil)
 
-// newServerWithRecordingSink wires a fresh DB+server with the recordingSink
-// installed, plus a git workspace bootstrapped with origin so kata init can
-// derive an alias identity. Returns the test server, its workspace dir, and
-// the sink so assertions can inspect captured events.
-func newServerWithRecordingSink(t *testing.T) (*httptest.Server, string, *recordingSink) {
-	t.Helper()
-	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
-	d := openTestDB(t)
-	sink := &recordingSink{}
-	srv := daemon.NewServer(daemon.ServerConfig{DB: d.db, StartedAt: d.now, Hooks: sink})
-	ts := httptest.NewServer(srv.Handler())
-	t.Cleanup(ts.Close)
-	return ts, dir, sink
-}
-
 // TestHooks_IssueCreate_EnqueuesSibling exercises the create-issue handler
 // end-to-end and asserts the sibling Hooks.Enqueue fires alongside the
 // Broadcaster.Broadcast — proving the integration point exists and matches
 // the persisted event row's Type.
 func TestHooks_IssueCreate_EnqueuesSibling(t *testing.T) {
-	ts, dir, sink := newServerWithRecordingSink(t)
-
-	// Bootstrap the project; project init does not emit events.
-	_, bs := postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": dir})
-	var initResp struct{ Project struct{ ID int64 } }
-	require.NoError(t, json.Unmarshal(bs, &initResp))
-	pid := initResp.Project.ID
+	sink := &recordingSink{}
+	h, pid := bootstrapProject(t, withHooksSink(sink))
+	ts := h.ts.(*httptest.Server)
 
 	// Pre-condition: project init does not enqueue anything.
 	require.Empty(t, sink.snapshot(), "project init should not emit hook events")
 
-	resp, body := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
+	resp, body := postJSON(t, ts, issuesURL(pid),
 		map[string]any{"actor": "agent-1", "title": "first", "body": "details"})
 	require.Equal(t, 200, resp.StatusCode, string(body))
 

--- a/internal/daemon/handlers_instance_test.go
+++ b/internal/daemon/handlers_instance_test.go
@@ -2,10 +2,7 @@ package daemon_test
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
@@ -21,24 +18,12 @@ import (
 // TestInstance_ReturnsLocalUID covers spec §8.8: GET /api/v1/instance returns
 // the value db.Open seeded into meta.instance_uid.
 func TestInstance_ReturnsLocalUID(t *testing.T) {
-	d := openTestDB(t)
-	srv := daemon.NewServer(daemon.ServerConfig{DB: d.db, StartedAt: d.now})
-	t.Cleanup(func() { _ = srv.Close() })
+	ts, d := startDefaultTestServer(t)
 
-	ts := httptest.NewServer(srv.Handler())
-	t.Cleanup(ts.Close)
-
-	resp, err := http.Get(ts.URL + "/api/v1/instance")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
 	var body struct {
 		InstanceUID string `json:"instance_uid"`
 	}
-	require.NoError(t, json.Unmarshal(bs, &body))
+	getAndUnmarshal(t, ts, "/api/v1/instance", http.StatusOK, &body)
 	assert.Equal(t, d.db.InstanceUID(), body.InstanceUID)
 	assert.True(t, uid.Valid(body.InstanceUID), "instance_uid %q invalid", body.InstanceUID)
 }
@@ -50,8 +35,7 @@ func TestInstance_ReturnsLocalUID(t *testing.T) {
 // skips the seed step and yields a *DB with empty cached value.
 func TestInstance_503WhenUIDUnset(t *testing.T) {
 	ctx := context.Background()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kata.db")
+	path := filepath.Join(t.TempDir(), "kata.db")
 
 	// Materialize a real DB file so OpenReadOnly has something to attach to.
 	primary, err := db.Open(ctx, path)
@@ -64,23 +48,8 @@ func TestInstance_503WhenUIDUnset(t *testing.T) {
 	t.Cleanup(func() { _ = ro.Close() })
 	require.Empty(t, ro.InstanceUID(), "OpenReadOnly must yield empty cached InstanceUID")
 
-	srv := daemon.NewServer(daemon.ServerConfig{DB: ro, StartedAt: time.Now().UTC()})
-	t.Cleanup(func() { _ = srv.Close() })
-	ts := httptest.NewServer(srv.Handler())
-	t.Cleanup(ts.Close)
+	ts := startTestServer(t, daemon.ServerConfig{DB: ro, StartedAt: time.Now().UTC()})
 
-	resp, err := http.Get(ts.URL + "/api/v1/instance") //nolint:gosec // test loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
-
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	var env struct {
-		Error struct {
-			Code string `json:"code"`
-		} `json:"error"`
-	}
-	require.NoError(t, json.Unmarshal(bs, &env), string(bs))
-	assert.Equal(t, "instance_uid_unset", env.Error.Code)
+	resp, bs := getStatusBody(t, ts, "/api/v1/instance")
+	assertAPIError(t, resp.StatusCode, bs, http.StatusServiceUnavailable, "instance_uid_unset")
 }

--- a/internal/daemon/handlers_issues_test.go
+++ b/internal/daemon/handlers_issues_test.go
@@ -1,9 +1,7 @@
 package daemon_test
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -16,36 +14,9 @@ import (
 	"github.com/wesm/kata/internal/uid"
 )
 
-// httptestServerHandle bundles a httptest.Server with the on-disk workspace
-// directory the server was bootstrapped against. The ts field is typed as
-// any to keep cross-helper imports loose; tests cast to *httptest.Server.
-type httptestServerHandle struct {
-	ts  any // *httptest.Server, but kept generic to avoid import cycles in helpers
-	dir string
-	db  *db.DB
-}
-
-// DB returns the *db.DB the test server is wired against, so a test can
-// reach below the HTTP surface to set up state (e.g. soft-delete an issue
-// before retrying create-with-idempotency-key).
-func (h *httptestServerHandle) DB() *db.DB { return h.db }
-
-// bootstrapProject spins up a fresh server + git workspace and runs `kata
-// init` against it, returning the handle and the project rowid. Used as a
-// shared setup for every issue handler test.
-func bootstrapProject(t *testing.T) (*httptestServerHandle, int64) {
-	t.Helper()
-	h := newServerWithGitWorkspace(t, "https://github.com/wesm/kata.git")
-	_, bs := postJSON(t, h.ts.(*httptest.Server), "/api/v1/projects", map[string]any{"start_path": h.dir})
-	var resp struct{ Project struct{ ID int64 } }
-	require.NoError(t, json.Unmarshal(bs, &resp))
-	return h, resp.Project.ID
-}
-
 func TestIssues_CreateRoundtrip(t *testing.T) {
 	h, projectID := bootstrapProject(t)
-	resp, bs := postJSON(t, h.ts.(*httptest.Server),
-		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues",
+	resp, bs := postJSON(t, h.ts.(*httptest.Server), issuesURL(projectID),
 		map[string]any{"actor": "agent-1", "title": "first", "body": "details"})
 	require.Equal(t, 200, resp.StatusCode, string(bs))
 
@@ -67,8 +38,7 @@ func TestIssues_CreateRoundtrip(t *testing.T) {
 func TestIssues_UIDWireShapeAndLookup(t *testing.T) {
 	h, projectID := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	resp, bs := postJSON(t, ts,
-		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues",
+	resp, bs := postJSON(t, ts, issuesURL(projectID),
 		map[string]any{"actor": "agent-1", "title": "uid issue"})
 	require.Equal(t, 200, resp.StatusCode, string(bs))
 
@@ -90,76 +60,49 @@ func TestIssues_UIDWireShapeAndLookup(t *testing.T) {
 	require.NotNil(t, created.Event.IssueUID)
 	assert.Equal(t, created.Issue.UID, *created.Event.IssueUID)
 
-	respList, err := http.Get(ts.URL + "/api/v1/projects/" + strconv.FormatInt(projectID, 10) + "/issues")
-	require.NoError(t, err)
-	defer func() { _ = respList.Body.Close() }()
-	listBS, err := io.ReadAll(respList.Body)
-	require.NoError(t, err)
-	assert.Contains(t, string(listBS), `"uid":"`+created.Issue.UID+`"`)
-	assert.Contains(t, string(listBS), `"project_uid":"`+created.Issue.ProjectUID+`"`)
+	listBS := getBody(t, ts, issuesURL(projectID))
+	assert.Contains(t, listBS, `"uid":"`+created.Issue.UID+`"`)
+	assert.Contains(t, listBS, `"project_uid":"`+created.Issue.ProjectUID+`"`)
 
-	respByUID, err := http.Get(ts.URL + "/api/v1/issues/" + created.Issue.UID)
-	require.NoError(t, err)
-	defer func() { _ = respByUID.Body.Close() }()
-	byUIDBS, err := io.ReadAll(respByUID.Body)
-	require.NoError(t, err)
-	require.Equal(t, 200, respByUID.StatusCode, string(byUIDBS))
+	byUIDResp, byUIDBS := getStatusBody(t, ts, "/api/v1/issues/"+created.Issue.UID)
+	require.Equal(t, 200, byUIDResp.StatusCode, string(byUIDBS))
 	assert.Contains(t, string(byUIDBS), `"number":`+strconv.FormatInt(created.Issue.Number, 10))
 	assert.Contains(t, string(byUIDBS), `"uid":"`+created.Issue.UID+`"`)
 
-	respBad, err := http.Get(ts.URL + "/api/v1/issues/not-a-ulid")
-	require.NoError(t, err)
-	defer func() { _ = respBad.Body.Close() }()
-	badBS, err := io.ReadAll(respBad.Body)
-	require.NoError(t, err)
-	assert.Equal(t, 400, respBad.StatusCode, string(badBS))
+	badResp, badBS := getStatusBody(t, ts, "/api/v1/issues/not-a-ulid")
+	assert.Equal(t, 400, badResp.StatusCode, string(badBS))
 	assert.Contains(t, string(badBS), `"code":"validation"`)
 }
 
 func TestIssues_ListAndShow(t *testing.T) {
 	h, pid := bootstrapProject(t)
+	ts := h.ts.(*httptest.Server)
 	for _, title := range []string{"a", "b"} {
-		_, _ = postJSON(t, h.ts.(*httptest.Server),
-			"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
+		_, _ = postJSON(t, ts, issuesURL(pid),
 			map[string]any{"actor": "x", "title": title})
 	}
 
-	resp, err := http.Get(h.ts.(*httptest.Server).URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues?status=open")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, _ := io.ReadAll(resp.Body)
-	assert.Equal(t, 200, resp.StatusCode)
-	assert.Contains(t, string(bs), `"title":"a"`)
-	assert.Contains(t, string(bs), `"title":"b"`)
+	listBS := getBody(t, ts, issuesURL(pid)+"?status=open")
+	assert.Contains(t, listBS, `"title":"a"`)
+	assert.Contains(t, listBS, `"title":"b"`)
 
-	resp2, err := http.Get(h.ts.(*httptest.Server).URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues/1")
-	require.NoError(t, err)
-	defer func() { _ = resp2.Body.Close() }()
-	bs2, _ := io.ReadAll(resp2.Body)
-	assert.Equal(t, 200, resp2.StatusCode)
-	assert.Contains(t, string(bs2), `"comments":`)
+	showBS := getBody(t, ts, issueURL(pid, 1, ""))
+	assert.Contains(t, showBS, `"comments":`)
 }
 
 func TestIssues_ListMissingProjectIs404(t *testing.T) {
 	h, _ := bootstrapProject(t)
-	resp, err := http.Get(h.ts.(*httptest.Server).URL + "/api/v1/projects/9999/issues")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, _ := io.ReadAll(resp.Body)
-	assert.Equal(t, 404, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"code":"project_not_found"`)
+	resp, bs := getStatusBody(t, h.ts.(*httptest.Server), "/api/v1/projects/9999/issues")
+	assertAPIError(t, resp.StatusCode, bs, 404, "project_not_found")
 }
 
 func TestIssues_PatchEditTitleAndBody(t *testing.T) {
 	h, pid := bootstrapProject(t)
-	_, _ = postJSON(t, h.ts.(*httptest.Server),
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
+	ts := h.ts.(*httptest.Server)
+	_, _ = postJSON(t, ts, issuesURL(pid),
 		map[string]any{"actor": "x", "title": "old"})
 
-	resp, bs := patchJSON(t, h.ts.(*httptest.Server),
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1",
+	resp, bs := patchJSON(t, ts, issueURL(pid, 1, ""),
 		map[string]any{"actor": "x", "title": "new"})
 	require.Equal(t, 200, resp.StatusCode, string(bs))
 	assert.Contains(t, string(bs), `"title":"new"`)
@@ -167,43 +110,26 @@ func TestIssues_PatchEditTitleAndBody(t *testing.T) {
 
 func TestCreateIssue_BlankActorIs400(t *testing.T) {
 	h, pid := bootstrapProject(t)
-	resp, bs := postJSON(t, h.ts.(*httptest.Server),
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
+	resp, bs := postJSON(t, h.ts.(*httptest.Server), issuesURL(pid),
 		map[string]any{"actor": "   ", "title": "x"})
-	assert.Equal(t, 400, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"code":"validation"`)
+	assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 }
 
 func TestEditIssue_BlankActorIs400(t *testing.T) {
 	h, pid := bootstrapProject(t)
-	_, _ = postJSON(t, h.ts.(*httptest.Server),
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
+	ts := h.ts.(*httptest.Server)
+	_, _ = postJSON(t, ts, issuesURL(pid),
 		map[string]any{"actor": "x", "title": "old"})
 
-	resp, bs := patchJSON(t, h.ts.(*httptest.Server),
-		"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/1",
+	resp, bs := patchJSON(t, ts, issueURL(pid, 1, ""),
 		map[string]any{"actor": "   ", "title": "new"})
-	assert.Equal(t, 400, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"code":"validation"`)
+	assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 }
 
 func TestCreateIssue_WithInitialState(t *testing.T) {
 	env := testenv.New(t)
 	pid, parent, _ := setupTwoIssues(t, env)
 
-	body, _ := json.Marshal(map[string]any{
-		"actor":  "tester",
-		"title":  "child",
-		"owner":  "alice",
-		"labels": []string{"bug", "needs-review"},
-		"links":  []map[string]any{{"type": "parent", "to_number": parent}},
-	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var out struct {
 		Issue struct {
 			Number int64   `json:"number"`
@@ -214,7 +140,13 @@ func TestCreateIssue_WithInitialState(t *testing.T) {
 			Payload string `json:"payload"`
 		} `json:"event"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envPostJSON(t, env, projectPath(pid)+"/issues", map[string]any{
+		"actor":  "tester",
+		"title":  "child",
+		"owner":  "alice",
+		"labels": []string{"bug", "needs-review"},
+		"links":  []map[string]any{{"type": "parent", "to_number": parent}},
+	}, &out)
 	require.NotNil(t, out.Issue.Owner)
 	assert.Equal(t, "alice", *out.Issue.Owner)
 	assert.Equal(t, "issue.created", out.Event.Type)
@@ -226,15 +158,10 @@ func TestCreateIssue_WithInitialState(t *testing.T) {
 func TestCreateIssue_InitialLinkToMissingTargetIs404(t *testing.T) {
 	env := testenv.New(t)
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
-	body, _ := json.Marshal(map[string]any{
+	resp, _ := envDoRaw(t, env, http.MethodPost, projectPath(pid)+"/issues", map[string]any{
 		"actor": "tester", "title": "child",
 		"links": []map[string]any{{"type": "parent", "to_number": 99}},
-	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	}, nil)
 	assert.Equal(t, 404, resp.StatusCode)
 }
 
@@ -251,25 +178,18 @@ func TestCreateIssue_RejectsArchivedProject(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	resp, bs := postJSON(t, h.ts.(*httptest.Server),
-		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues",
+	resp, bs := postJSON(t, h.ts.(*httptest.Server), issuesURL(projectID),
 		map[string]any{"actor": "agent-1", "title": "should fail", "body": "details"})
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"code":"project_not_found"`)
+	assertAPIError(t, resp.StatusCode, bs, http.StatusNotFound, "project_not_found")
 }
 
 func TestCreateIssue_InvalidLabelIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
-	body, _ := json.Marshal(map[string]any{
+	resp, _ := envDoRaw(t, env, http.MethodPost, projectPath(pid)+"/issues", map[string]any{
 		"actor": "tester", "title": "x",
 		"labels": []string{"BadCase"},
-	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	}, nil)
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
@@ -280,15 +200,10 @@ func TestCreateIssue_InvalidLabelIs400(t *testing.T) {
 func TestCreateIssue_InitialSelfLinkIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
-	body, _ := json.Marshal(map[string]any{
+	resp, _ := envDoRaw(t, env, http.MethodPost, projectPath(pid)+"/issues", map[string]any{
 		"actor": "tester", "title": "self",
 		"links": []map[string]any{{"type": "parent", "to_number": 1}},
-	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	}, nil)
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
@@ -298,7 +213,7 @@ func TestCreateIssue_InitialSelfLinkIs400(t *testing.T) {
 func TestCreate_IdempotencyReuse_SameFingerprint(t *testing.T) {
 	h, pid := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	path := "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues"
+	path := issuesURL(pid)
 	body := map[string]any{"actor": "agent-1", "title": "fix login crash", "body": "stack trace here"}
 
 	first := postWithHeader(t, ts, path, map[string]string{"Idempotency-Key": "K1"}, body)
@@ -350,7 +265,7 @@ func TestCreate_IdempotencyReuse_SameFingerprint(t *testing.T) {
 func TestCreate_IdempotencyMismatch(t *testing.T) {
 	h, pid := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	path := "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues"
+	path := issuesURL(pid)
 
 	first := postWithHeader(t, ts, path, map[string]string{"Idempotency-Key": "K1"},
 		map[string]any{"actor": "agent-1", "title": "first title", "body": "first body"})
@@ -381,7 +296,7 @@ func TestCreate_IdempotencyMismatch(t *testing.T) {
 func TestCreate_IdempotencyDeletedIs409(t *testing.T) {
 	h, pid := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	path := "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues"
+	path := issuesURL(pid)
 
 	first := postWithHeader(t, ts, path, map[string]string{"Idempotency-Key": "K-DEL"},
 		map[string]any{"actor": "agent-1", "title": "soft delete me", "body": "details"})
@@ -411,7 +326,7 @@ func TestCreate_IdempotencyDeletedIs409(t *testing.T) {
 func TestCreate_LookalikeSoftBlock(t *testing.T) {
 	h, pid := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	path := "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues"
+	path := issuesURL(pid)
 	body := map[string]any{"actor": "agent-1", "title": "fix login crash", "body": "stack trace here"}
 
 	first := postWithHeader(t, ts, path, nil, body)
@@ -428,7 +343,7 @@ func TestCreate_LookalikeSoftBlock(t *testing.T) {
 func TestCreate_ForceNewBypassesLookalike(t *testing.T) {
 	h, pid := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	path := "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues"
+	path := issuesURL(pid)
 
 	first := postWithHeader(t, ts, path, nil,
 		map[string]any{"actor": "agent-1", "title": "fix login crash", "body": "stack trace here"})
@@ -449,7 +364,7 @@ func TestCreate_ForceNewBypassesLookalike(t *testing.T) {
 func TestCreate_IdempotencyWinsOverForceNew(t *testing.T) {
 	h, pid := bootstrapProject(t)
 	ts := h.ts.(*httptest.Server)
-	path := "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues"
+	path := issuesURL(pid)
 	body := map[string]any{"actor": "agent-1", "title": "fix login crash", "body": "stack trace here"}
 
 	first := postWithHeader(t, ts, path, map[string]string{"Idempotency-Key": "K1"}, body)
@@ -486,18 +401,13 @@ func TestListIssues_HydratesLabels(t *testing.T) {
 	postLabel(t, env, pid, first, "bug")
 	postLabel(t, env, pid, second, "enhancement")
 
-	resp, err := env.HTTP.Get(env.URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var out struct {
 		Issues []struct {
 			Number int64    `json:"number"`
 			Labels []string `json:"labels"`
 		} `json:"issues"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envGetJSON(t, env, projectPath(pid)+"/issues", &out)
 	require.Len(t, out.Issues, 2)
 	byNumber := map[int64][]string{}
 	for _, iss := range out.Issues {
@@ -514,11 +424,6 @@ func TestListIssues_IncludesHierarchyMetadata(t *testing.T) {
 	child := createIssueViaHTTP(t, env, pid, "child")
 	postLink(t, env, pid, child, "parent", parent)
 
-	resp, err := env.HTTP.Get(env.URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var out struct {
 		Issues []struct {
 			Number       int64  `json:"number"`
@@ -529,7 +434,7 @@ func TestListIssues_IncludesHierarchyMetadata(t *testing.T) {
 			} `json:"child_counts"`
 		} `json:"issues"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envGetJSON(t, env, projectPath(pid)+"/issues", &out)
 	require.Len(t, out.Issues, 2)
 	byNumber := map[int64]struct {
 		ParentNumber *int64
@@ -561,18 +466,13 @@ func TestListIssues_IncludesBlockerMetadata(t *testing.T) {
 	blocked := createIssueViaHTTP(t, env, pid, "blocked")
 	postLink(t, env, pid, blocker, "blocks", blocked)
 
-	resp, err := env.HTTP.Get(env.URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var out struct {
 		Issues []struct {
 			Number int64   `json:"number"`
 			Blocks []int64 `json:"blocks,omitempty"`
 		} `json:"issues"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envGetJSON(t, env, projectPath(pid)+"/issues", &out)
 	byNumber := map[int64][]int64{}
 	for _, iss := range out.Issues {
 		byNumber[iss.Number] = iss.Blocks
@@ -592,18 +492,13 @@ func TestListAllIssues_AcrossProjects(t *testing.T) {
 	createIssueViaHTTP(t, env, pidB, "beta-1")
 	createIssueViaHTTP(t, env, pidA, "alpha-2")
 
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/issues")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-
 	var out struct {
 		Issues []struct {
 			ProjectID int64  `json:"project_id"`
 			Title     string `json:"title"`
 		} `json:"issues"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envGetJSON(t, env, "/api/v1/issues", &out)
 	require.Len(t, out.Issues, 3)
 	projectIDs := map[int64]int{}
 	for _, iss := range out.Issues {
@@ -622,18 +517,13 @@ func TestListAllIssues_ProjectFilter(t *testing.T) {
 	createIssueViaHTTP(t, env, pidA, "alpha-1")
 	createIssueViaHTTP(t, env, pidB, "beta-1")
 
-	resp, err := env.HTTP.Get(env.URL +
-		"/api/v1/issues?project_id=" + strconv.FormatInt(pidB, 10))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var out struct {
 		Issues []struct {
 			ProjectID int64  `json:"project_id"`
 			Title     string `json:"title"`
 		} `json:"issues"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envGetJSON(t, env, "/api/v1/issues?project_id="+strconv.FormatInt(pidB, 10), &out)
 	require.Len(t, out.Issues, 1)
 	assert.Equal(t, pidB, out.Issues[0].ProjectID)
 	assert.Equal(t, "beta-1", out.Issues[0].Title)
@@ -644,19 +534,8 @@ func TestListAllIssues_ProjectFilter(t *testing.T) {
 // endpoint's contract for invalid IDs.
 func TestListAllIssues_ProjectNotFound(t *testing.T) {
 	env := testenv.New(t)
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/issues?project_id=9999")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	var body struct {
-		Error struct {
-			Code string `json:"code"`
-		} `json:"error"`
-	}
-	require.NoError(t, json.Unmarshal(bs, &body), string(bs))
-	assert.Equal(t, "project_not_found", body.Error.Code)
+	resp, bs := envGetRaw(t, env, "/api/v1/issues?project_id=9999")
+	assertAPIError(t, resp.StatusCode, bs, http.StatusNotFound, "project_not_found")
 }
 
 // TestListAllIssues_HydratesLabelsAcrossProjects pins that labels attach
@@ -671,10 +550,6 @@ func TestListAllIssues_HydratesLabelsAcrossProjects(t *testing.T) {
 	postLabel(t, env, pidA, a1, "bug")
 	postLabel(t, env, pidB, b1, "enhancement")
 
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/issues")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var out struct {
 		Issues []struct {
 			ProjectID int64    `json:"project_id"`
@@ -682,7 +557,7 @@ func TestListAllIssues_HydratesLabelsAcrossProjects(t *testing.T) {
 			Labels    []string `json:"labels"`
 		} `json:"issues"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envGetJSON(t, env, "/api/v1/issues", &out)
 	labelsByKey := map[string][]string{}
 	for _, iss := range out.Issues {
 		key := strconv.FormatInt(iss.ProjectID, 10) + "/" + strconv.FormatInt(iss.Number, 10)
@@ -700,12 +575,6 @@ func TestShowIssue_IncludesLinksAndLabels(t *testing.T) {
 	postLabel(t, env, pid, child, "bug")
 	postLink(t, env, pid, child, "parent", parent)
 
-	resp, err := env.HTTP.Get(env.URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) +
-		"/issues/" + strconv.FormatInt(child, 10))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var out struct {
 		Links []struct {
 			Type       string `json:"type"`
@@ -716,7 +585,7 @@ func TestShowIssue_IncludesLinksAndLabels(t *testing.T) {
 			Label string `json:"label"`
 		} `json:"labels"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envGetJSON(t, env, issuePath(pid, child, ""), &out)
 	require.Len(t, out.Links, 1)
 	assert.Equal(t, "parent", out.Links[0].Type)
 	assert.Equal(t, child, out.Links[0].FromNumber)
@@ -737,12 +606,6 @@ func TestShowIssue_IncludesParentAndChildren(t *testing.T) {
 	postLink(t, env, pid, greatGrandchild, "parent", grandchild)
 	postLabel(t, env, pid, grandchild, "bug")
 
-	resp, err := env.HTTP.Get(env.URL +
-		"/api/v1/projects/" + strconv.FormatInt(pid, 10) +
-		"/issues/" + strconv.FormatInt(child, 10))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var out struct {
 		Parent *struct {
 			Number int64  `json:"number"`
@@ -758,7 +621,7 @@ func TestShowIssue_IncludesParentAndChildren(t *testing.T) {
 			} `json:"child_counts"`
 		} `json:"children"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envGetJSON(t, env, issuePath(pid, child, ""), &out)
 	require.NotNil(t, out.Parent)
 	assert.Equal(t, parent, out.Parent.Number)
 	assert.Equal(t, "parent", out.Parent.Title)

--- a/internal/daemon/handlers_labels_test.go
+++ b/internal/daemon/handlers_labels_test.go
@@ -1,10 +1,7 @@
 package daemon_test
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/http"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,12 +33,8 @@ func TestAddLabel_DuplicateIsNoOp(t *testing.T) {
 func TestAddLabel_InvalidIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	body, _ := json.Marshal(map[string]string{"actor": "tester", "label": "Bad-Case"})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/"+strconv.FormatInt(n, 10)+"/labels",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp := envDoJSON(t, env, http.MethodPost, issuePath(pid, n, "labels"),
+		map[string]string{"actor": "tester", "label": "Bad-Case"}, nil)
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
@@ -50,21 +43,8 @@ func TestRemoveLabel_HappyPath(t *testing.T) {
 	pid, n := setupOneIssue(t, env)
 	postLabel(t, env, pid, n, "bug")
 
-	req, err := http.NewRequest("DELETE",
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/labels/bug?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := env.HTTP.Do(req) //nolint:gosec // test-only, loopback URL
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, out := deleteLabel(t, env, pid, n, "bug")
 	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Event *struct {
-			Type string `json:"type"`
-		} `json:"event"`
-		Changed bool `json:"changed"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
 	require.NotNil(t, out.Event)
 	assert.Equal(t, "issue.unlabeled", out.Event.Type)
 	assert.True(t, out.Changed)
@@ -73,21 +53,8 @@ func TestRemoveLabel_HappyPath(t *testing.T) {
 func TestRemoveLabel_AbsentIs200NoOp(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	req, err := http.NewRequest("DELETE",
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/labels/never-attached?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := env.HTTP.Do(req) //nolint:gosec // test-only, loopback URL
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, out := deleteLabel(t, env, pid, n, "never-attached")
 	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Event *struct {
-			Type string `json:"type"`
-		} `json:"event"`
-		Changed bool `json:"changed"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
 	assert.Nil(t, out.Event)
 	assert.False(t, out.Changed)
 }
@@ -95,26 +62,15 @@ func TestRemoveLabel_AbsentIs200NoOp(t *testing.T) {
 func TestAddLabel_BlankActorIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	body, _ := json.Marshal(map[string]string{"actor": "   ", "label": "bug"})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/labels",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp := envDoJSON(t, env, http.MethodPost, issuePath(pid, n, "labels"),
+		map[string]string{"actor": "   ", "label": "bug"}, nil)
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
 func TestRemoveLabel_BlankActorIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	req, err := http.NewRequest("DELETE",
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/labels/bug?actor=%20%20", nil)
-	require.NoError(t, err)
-	resp, err := env.HTTP.Do(req) //nolint:gosec // test-only, loopback URL
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := deleteLabelAs(t, env, pid, n, "  ", "bug")
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
@@ -126,61 +82,17 @@ func TestLabelsList_ReturnsCounts(t *testing.T) {
 	postLabel(t, env, pid, a, "priority:high")
 	postLabel(t, env, pid, b, "bug")
 
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/labels")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
 	var out struct {
 		Labels []struct {
 			Label string `json:"label"`
 			Count int64  `json:"count"`
 		} `json:"labels"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	envGetJSON(t, env, projectPath(pid)+"/labels", &out)
 	got := map[string]int64{}
 	for _, c := range out.Labels {
 		got[c.Label] = c.Count
 	}
 	assert.Equal(t, int64(2), got["bug"])
 	assert.Equal(t, int64(1), got["priority:high"])
-}
-
-// --- helpers ---
-
-// setupOneIssue creates a workspace + one issue, returns (project_id, issue_number).
-func setupOneIssue(t *testing.T, env *testenv.Env) (int64, int64) {
-	t.Helper()
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
-	n := createIssueViaHTTP(t, env, pid, "x")
-	return pid, n
-}
-
-// labelResp is the decoded shape of an AddLabelResponse body.
-type labelResp struct {
-	Issue struct {
-		Number int64 `json:"number"`
-	} `json:"issue"`
-	Label struct {
-		Label string `json:"label"`
-	} `json:"label"`
-	Event *struct {
-		Type string `json:"type"`
-	} `json:"event"`
-	Changed bool `json:"changed"`
-}
-
-// postLabel calls POST /labels and returns the decoded response.
-func postLabel(t *testing.T, env *testenv.Env, projectID, number int64, label string) labelResp {
-	t.Helper()
-	body, _ := json.Marshal(map[string]string{"actor": "tester", "label": label})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+
-			"/issues/"+strconv.FormatInt(number, 10)+"/labels",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equalf(t, 200, resp.StatusCode, "postLabel expected 200, got %d", resp.StatusCode)
-	var out labelResp
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
-	return out
 }

--- a/internal/daemon/handlers_links_test.go
+++ b/internal/daemon/handlers_links_test.go
@@ -1,11 +1,7 @@
 package daemon_test
 
 import (
-	"bytes"
 	"encoding/json"
-	"net/http"
-	"os/exec"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,38 +13,7 @@ func TestCreateLink_HappyPath(t *testing.T) {
 	env := testenv.New(t)
 	pid, a, b := setupTwoIssues(t, env)
 
-	body, _ := json.Marshal(map[string]any{
-		"actor":     "tester",
-		"type":      "blocks",
-		"to_number": b,
-	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/"+strconv.FormatInt(a, 10)+"/links",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Issue struct {
-			Number int64 `json:"number"`
-		} `json:"issue"`
-		Link struct {
-			ID           int64  `json:"id"`
-			Type         string `json:"type"`
-			FromNumber   int64  `json:"from_number"`
-			FromIssueUID string `json:"from_issue_uid"`
-			ToNumber     int64  `json:"to_number"`
-			ToIssueUID   string `json:"to_issue_uid"`
-		} `json:"link"`
-		Event *struct {
-			Type            string  `json:"type"`
-			ProjectUID      string  `json:"project_uid"`
-			IssueUID        *string `json:"issue_uid"`
-			RelatedIssueUID *string `json:"related_issue_uid"`
-		} `json:"event"`
-		Changed bool `json:"changed"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	out := postLink(t, env, pid, a, "blocks", b)
 	assert.Equal(t, "blocks", out.Link.Type)
 	assert.Equal(t, a, out.Link.FromNumber)
 	assert.Equal(t, b, out.Link.ToNumber)
@@ -134,16 +99,11 @@ func TestCreateLink_ParentAlreadySetIs409(t *testing.T) {
 	p2 := createIssueViaHTTP(t, env, pid, "p2")
 	postLink(t, env, pid, child, "parent", p1)
 
-	body, _ := json.Marshal(map[string]any{
+	resp, _ := postLinkRaw(t, env, pid, child, map[string]any{
 		"actor":     "tester",
 		"type":      "parent",
 		"to_number": p2,
 	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/"+strconv.FormatInt(child, 10)+"/links",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, 409, resp.StatusCode)
 }
 
@@ -153,24 +113,13 @@ func TestCreateLink_ParentReplaceSwapsParent(t *testing.T) {
 	p2 := createIssueViaHTTP(t, env, pid, "p2")
 	postLink(t, env, pid, child, "parent", p1)
 
-	body, _ := json.Marshal(map[string]any{
+	resp, out := postLinkRaw(t, env, pid, child, map[string]any{
 		"actor":     "tester",
 		"type":      "parent",
 		"to_number": p2,
 		"replace":   true,
 	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/"+strconv.FormatInt(child, 10)+"/links",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Link struct {
-			ToNumber int64 `json:"to_number"`
-		} `json:"link"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
 	assert.Equal(t, p2, out.Link.ToNumber)
 }
 
@@ -180,32 +129,21 @@ func TestCreateLink_ParentReplaceUnlinkEventPointsToOldParent(t *testing.T) {
 	p2 := createIssueViaHTTP(t, env, pid, "p2")
 	postLink(t, env, pid, child, "parent", p1)
 
-	body, _ := json.Marshal(map[string]any{
+	resp, _ := postLinkRaw(t, env, pid, child, map[string]any{
 		"actor":     "tester",
 		"type":      "parent",
 		"to_number": p2,
 		"replace":   true,
 	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+"/issues/"+strconv.FormatInt(child, 10)+"/links",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
 	require.Equal(t, 200, resp.StatusCode)
 
 	// The unlink event isn't in the response (response carries only the
 	// linked event). Query the events table directly to verify the unlink
 	// event references the OLD parent (p1), not the new (p2).
-	row := env.DB.QueryRowContext(t.Context(),
-		`SELECT payload FROM events
-		 WHERE project_id = ? AND type = 'issue.unlinked'
-		 ORDER BY id DESC LIMIT 1`, pid)
-	var payload string
-	require.NoError(t, row.Scan(&payload))
 	var pl struct {
 		ToNumber int64 `json:"to_number"`
 	}
-	require.NoError(t, json.Unmarshal([]byte(payload), &pl))
+	require.NoError(t, json.Unmarshal([]byte(lastEventPayload(t, env, pid, "issue.unlinked")), &pl))
 	assert.Equal(t, p1, pl.ToNumber, "unlink event must reference the old parent's number")
 }
 
@@ -220,18 +158,12 @@ func TestCreateLink_ParentReplaceSelfLinkLeavesNoMutation(t *testing.T) {
 	pid, child, p1 := setupTwoIssues(t, env)
 	postLink(t, env, pid, child, "parent", p1)
 
-	body, _ := json.Marshal(map[string]any{
+	resp, _ := postLinkRaw(t, env, pid, child, map[string]any{
 		"actor":     "tester",
 		"type":      "parent",
 		"to_number": child,
 		"replace":   true,
 	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(child, 10)+"/links",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
 	require.Equal(t, 400, resp.StatusCode, "self-link must be rejected before mutation")
 
 	// No issue.unlinked event was inserted. The bug's signature was a
@@ -254,17 +186,11 @@ func TestCreateLink_ParentReplaceSelfLinkLeavesNoMutation(t *testing.T) {
 func TestCreateLink_BlankActorIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid, a, b := setupTwoIssues(t, env)
-	body, _ := json.Marshal(map[string]any{
+	resp, _ := postLinkRaw(t, env, pid, a, map[string]any{
 		"actor":     "   ",
 		"type":      "blocks",
 		"to_number": b,
 	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(a, 10)+"/links",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
@@ -272,31 +198,18 @@ func TestDeleteLink_BlankActorIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid, a, b := setupTwoIssues(t, env)
 	created := postLink(t, env, pid, a, "blocks", b)
-	req, err := http.NewRequest("DELETE",
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(a, 10)+
-			"/links/"+strconv.FormatInt(created.Link.ID, 10)+"?actor=%20%20", nil)
-	require.NoError(t, err)
-	resp, err := env.HTTP.Do(req) //nolint:gosec // test-only, loopback URL
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := deleteLinkAs(t, env, pid, a, "  ", created.Link.ID)
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
 func TestCreateLink_SelfLinkIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid, a, _ := setupTwoIssues(t, env)
-	body, _ := json.Marshal(map[string]any{
+	resp, _ := postLinkRaw(t, env, pid, a, map[string]any{
 		"actor":     "tester",
 		"type":      "blocks",
 		"to_number": a,
 	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(a, 10)+"/links",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
@@ -305,22 +218,8 @@ func TestDeleteLink_RemovesAndEmitsUnlink(t *testing.T) {
 	pid, a, b := setupTwoIssues(t, env)
 	created := postLink(t, env, pid, a, "blocks", b)
 
-	req, err := http.NewRequest("DELETE",
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(a, 10)+
-			"/links/"+strconv.FormatInt(created.Link.ID, 10)+"?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := env.HTTP.Do(req) //nolint:gosec // test-only, loopback URL
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, out := deleteLink(t, env, pid, a, created.Link.ID)
 	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Event *struct {
-			Type string `json:"type"`
-		} `json:"event"`
-		Changed bool `json:"changed"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
 	require.NotNil(t, out.Event)
 	assert.Equal(t, "issue.unlinked", out.Event.Type)
 	assert.True(t, out.Changed)
@@ -336,137 +235,15 @@ func TestDeleteLink_NotAttachedToURLIssueIs404(t *testing.T) {
 	c := createIssueViaHTTP(t, env, pid, "c")
 	created := postLink(t, env, pid, a, "blocks", b)
 
-	req, err := http.NewRequest("DELETE",
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(c, 10)+
-			"/links/"+strconv.FormatInt(created.Link.ID, 10)+"?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := env.HTTP.Do(req) //nolint:gosec // test-only, loopback URL
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := deleteLink(t, env, pid, c, created.Link.ID)
 	assert.Equal(t, 404, resp.StatusCode)
 }
 
 func TestDeleteLink_AbsentIs200NoOp(t *testing.T) {
 	env := testenv.New(t)
 	pid, a, _ := setupTwoIssues(t, env)
-	req, err := http.NewRequest("DELETE",
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(a, 10)+
-			"/links/9999?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := env.HTTP.Do(req) //nolint:gosec // test-only, loopback URL
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	assert.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Event *struct {
-			Type string `json:"type"`
-		} `json:"event"`
-		Changed bool `json:"changed"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	resp, out := deleteLink(t, env, pid, a, 9999)
+	require.Equal(t, 200, resp.StatusCode)
 	assert.Nil(t, out.Event)
 	assert.False(t, out.Changed)
-}
-
-// --- helpers used across handlers_links_test.go and handlers_labels_test.go ---
-
-// setupTwoIssues creates a workspace, two issues, and returns (project_id, a_number, b_number).
-func setupTwoIssues(t *testing.T, env *testenv.Env) (int64, int64, int64) {
-	t.Helper()
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
-	a := createIssueViaHTTP(t, env, pid, "a")
-	b := createIssueViaHTTP(t, env, pid, "b")
-	return pid, a, b
-}
-
-// initWorkspaceViaHTTP runs git init in a temp dir, adds origin, posts to
-// /api/v1/projects, and returns the resolved project_id.
-func initWorkspaceViaHTTP(t *testing.T, env *testenv.Env, origin string) int64 {
-	t.Helper()
-	dir := t.TempDir()
-	mustRun(t, dir, "git", "init", "--quiet")
-	mustRun(t, dir, "git", "remote", "add", "origin", origin)
-
-	body, _ := json.Marshal(map[string]string{"start_path": dir})
-	resp, err := env.HTTP.Post(env.URL+"/api/v1/projects", "application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-
-	body, _ = json.Marshal(map[string]string{"start_path": dir})
-	resp, err = env.HTTP.Post(env.URL+"/api/v1/projects/resolve", "application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	var out struct {
-		Project struct {
-			ID int64 `json:"id"`
-		} `json:"project"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
-	return out.Project.ID
-}
-
-// createIssueViaHTTP creates an issue and returns its number.
-func createIssueViaHTTP(t *testing.T, env *testenv.Env, projectID int64, title string) int64 {
-	t.Helper()
-	body, _ := json.Marshal(map[string]string{"actor": "tester", "title": title})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	var out struct {
-		Issue struct {
-			Number int64 `json:"number"`
-		} `json:"issue"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
-	return out.Issue.Number
-}
-
-// linkResp is the decoded shape of a CreateLinkResponse body.
-type linkResp struct {
-	Issue struct {
-		Number int64 `json:"number"`
-	} `json:"issue"`
-	Link struct {
-		ID           int64  `json:"id"`
-		Type         string `json:"type"`
-		FromNumber   int64  `json:"from_number"`
-		FromIssueUID string `json:"from_issue_uid"`
-		ToNumber     int64  `json:"to_number"`
-		ToIssueUID   string `json:"to_issue_uid"`
-	} `json:"link"`
-	Event *struct {
-		Type string `json:"type"`
-	} `json:"event"`
-	Changed bool `json:"changed"`
-}
-
-// postLink is a small wrapper that calls POST /links and returns the decoded
-// CreateLinkResponse-shaped body.
-func postLink(t *testing.T, env *testenv.Env, projectID, fromNumber int64, linkType string, toNumber int64) linkResp {
-	t.Helper()
-	body, _ := json.Marshal(map[string]any{
-		"actor": "tester", "type": linkType, "to_number": toNumber,
-	})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+
-			"/issues/"+strconv.FormatInt(fromNumber, 10)+"/links",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equalf(t, 200, resp.StatusCode, "postLink expected 200, got %d", resp.StatusCode)
-	var out linkResp
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
-	return out
-}
-
-// mustRun runs a command in dir, failing the test on error.
-func mustRun(t *testing.T, dir, name string, args ...string) {
-	t.Helper()
-	cmd := exec.Command(name, args...) //nolint:gosec // G204: test-controlled args
-	cmd.Dir = dir
-	require.NoErrorf(t, cmd.Run(), "%s %v", name, args)
 }

--- a/internal/daemon/handlers_ownership_test.go
+++ b/internal/daemon/handlers_ownership_test.go
@@ -1,9 +1,6 @@
 package daemon_test
 
 import (
-	"bytes"
-	"encoding/json"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,24 +11,8 @@ import (
 func TestAssign_HappyPath(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	body, _ := json.Marshal(map[string]string{"actor": "tester", "owner": "alice"})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/actions/assign",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, out := postAssign(t, env, pid, n, "tester", "alice")
 	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Issue struct {
-			Owner *string `json:"owner"`
-		} `json:"issue"`
-		Event *struct {
-			Type string `json:"type"`
-		} `json:"event"`
-		Changed bool `json:"changed"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
 	require.NotNil(t, out.Issue.Owner)
 	assert.Equal(t, "alice", *out.Issue.Owner)
 	require.NotNil(t, out.Event)
@@ -42,24 +23,11 @@ func TestAssign_HappyPath(t *testing.T) {
 func TestAssign_SameOwnerIsNoOp(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	body, _ := json.Marshal(map[string]string{"actor": "tester", "owner": "alice"})
-	url := env.URL + "/api/v1/projects/" + strconv.FormatInt(pid, 10) +
-		"/issues/" + strconv.FormatInt(n, 10) + "/actions/assign"
-	resp, err := env.HTTP.Post(url, "application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-
-	resp, err = env.HTTP.Post(url, "application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := postAssign(t, env, pid, n, "tester", "alice")
 	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Event *struct {
-			Type string `json:"type"`
-		} `json:"event"`
-		Changed bool `json:"changed"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+
+	resp, out := postAssign(t, env, pid, n, "tester", "alice")
+	require.Equal(t, 200, resp.StatusCode)
 	assert.Nil(t, out.Event)
 	assert.False(t, out.Changed)
 }
@@ -67,71 +35,32 @@ func TestAssign_SameOwnerIsNoOp(t *testing.T) {
 func TestAssign_BlankOwnerIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	body, _ := json.Marshal(map[string]string{"actor": "tester", "owner": "   "})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/actions/assign",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := postAssign(t, env, pid, n, "tester", "   ")
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
 func TestAssign_BlankActorIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	body, _ := json.Marshal(map[string]string{"actor": "   ", "owner": "alice"})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/actions/assign",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := postAssign(t, env, pid, n, "   ", "alice")
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
 func TestUnassign_BlankActorIs400(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	body, _ := json.Marshal(map[string]string{"actor": "   "})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/actions/unassign",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := postUnassign(t, env, pid, n, "   ")
 	assert.Equal(t, 400, resp.StatusCode)
 }
 
 func TestUnassign_HappyPath(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
-	body, _ := json.Marshal(map[string]string{"actor": "tester", "owner": "alice"})
-	resp, err := env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/actions/assign",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-
-	body, _ = json.Marshal(map[string]string{"actor": "tester"})
-	resp, err = env.HTTP.Post(
-		env.URL+"/api/v1/projects/"+strconv.FormatInt(pid, 10)+
-			"/issues/"+strconv.FormatInt(n, 10)+"/actions/unassign",
-		"application/json", bytes.NewReader(body))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := postAssign(t, env, pid, n, "tester", "alice")
 	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Issue struct {
-			Owner *string `json:"owner"`
-		} `json:"issue"`
-		Event *struct {
-			Type string `json:"type"`
-		} `json:"event"`
-		Changed bool `json:"changed"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+
+	resp, out := postUnassign(t, env, pid, n, "tester")
+	require.Equal(t, 200, resp.StatusCode)
 	assert.Nil(t, out.Issue.Owner)
 	require.NotNil(t, out.Event)
 	assert.Equal(t, "issue.unassigned", out.Event.Type)

--- a/internal/daemon/handlers_projects_test.go
+++ b/internal/daemon/handlers_projects_test.go
@@ -1,13 +1,10 @@
 package daemon_test
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -17,54 +14,22 @@ import (
 
 	"github.com/wesm/kata/internal/daemon"
 	"github.com/wesm/kata/internal/db"
+	"github.com/wesm/kata/internal/testfix"
 )
-
-func runGit(t *testing.T, dir string, args ...string) {
-	t.Helper()
-	//nolint:gosec // git binary is fixed; args are test-supplied subcommand flags.
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "git %v: %s", args, out)
-}
-
-func newTestServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	d := openTestDB(t)
-	srv := daemon.NewServer(daemon.ServerConfig{DB: d.db, StartedAt: d.now})
-	ts := httptest.NewServer(srv.Handler())
-	t.Cleanup(ts.Close)
-	return ts
-}
-
-func postJSON(t *testing.T, ts *httptest.Server, path string, body any) (*http.Response, []byte) {
-	t.Helper()
-	js, err := json.Marshal(body)
-	require.NoError(t, err)
-	resp, err := http.Post(ts.URL+path, "application/json", bytes.NewReader(js))
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, _ := io.ReadAll(resp.Body)
-	return resp, bs
-}
 
 func TestResolve_FailsOutsideKataTomlAndWithoutAlias(t *testing.T) {
 	ts := newTestServer(t)
 	resp, bs := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{
 		"start_path": t.TempDir(),
 	})
-	assert.Equal(t, 404, resp.StatusCode)
-	assert.Contains(t, string(bs), "project_not_initialized")
+	assertAPIError(t, resp.StatusCode, bs, 404, "project_not_initialized")
 }
 
 func TestInit_FromGitRemoteCreatesProject(t *testing.T) {
-	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
-
-	ts := newTestServer(t)
+	h := newServerWithGitWorkspace(t, "https://github.com/wesm/kata.git")
+	ts := h.ts.(*httptest.Server)
 	resp, bs := postJSON(t, ts, "/api/v1/projects", map[string]any{
-		"start_path": dir,
+		"start_path": h.dir,
 	})
 	assert.Equal(t, 200, resp.StatusCode, string(bs))
 
@@ -88,25 +53,17 @@ func TestInit_FromGitRemoteCreatesProject(t *testing.T) {
 	assert.Equal(t, "github.com/wesm/kata", body.Alias.AliasIdentity)
 
 	// .kata.toml must have been written
-	_, err := os.Stat(filepath.Join(dir, ".kata.toml"))
+	_, err := os.Stat(filepath.Join(h.dir, ".kata.toml"))
 	assert.NoError(t, err)
 }
 
 func TestInit_FreshCloneFromExistingKataToml(t *testing.T) {
 	// Simulate "git clone, kata init" on a repo that already had .kata.toml.
-	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"), //nolint:gosec // test fixture matches production .kata.toml mode
-		[]byte(`version = 1
+	h := newServerWithGitWorkspace(t, "")
+	testfix.WriteKataToml(t, h.dir, "github.com/wesm/system", "system")
 
-[project]
-identity = "github.com/wesm/system"
-name     = "system"
-`), 0o644))
-
-	ts := newTestServer(t)
-	resp, bs := postJSON(t, ts, "/api/v1/projects", map[string]any{
-		"start_path": dir,
+	resp, bs := postJSON(t, h.ts.(*httptest.Server), "/api/v1/projects", map[string]any{
+		"start_path": h.dir,
 	})
 	assert.Equal(t, 200, resp.StatusCode, string(bs))
 
@@ -122,14 +79,12 @@ name     = "system"
 }
 
 func TestResolve_AfterInitSucceeds(t *testing.T) {
-	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
-	ts := newTestServer(t)
+	h := newServerWithGitWorkspace(t, "https://github.com/wesm/kata.git")
+	ts := h.ts.(*httptest.Server)
 
-	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": dir})
+	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": h.dir})
 
-	resp, bs := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{"start_path": dir})
+	resp, bs := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{"start_path": h.dir})
 	assert.Equal(t, 200, resp.StatusCode, string(bs))
 	assert.Contains(t, string(bs), `"identity":"github.com/wesm/kata"`)
 }
@@ -140,8 +95,8 @@ func TestResolve_AfterInitSucceeds(t *testing.T) {
 // client on host B reach a project registered on host A's daemon.
 func TestResolve_ByProjectIdentity_PathFree(t *testing.T) {
 	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	testfix.RunGit(t, dir, "init", "--quiet")
+	testfix.RunGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 	ts := newTestServer(t)
 
 	// Register the project (local-style init).
@@ -186,8 +141,8 @@ func TestResolve_NeitherFieldSet(t *testing.T) {
 // and the daemon never touches the (potentially nonexistent) path.
 func TestResolve_IdentityWinsOverStartPath(t *testing.T) {
 	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	testfix.RunGit(t, dir, "init", "--quiet")
+	testfix.RunGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 	ts := newTestServer(t)
 
 	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": dir})
@@ -202,33 +157,24 @@ func TestResolve_IdentityWinsOverStartPath(t *testing.T) {
 }
 
 func TestInit_AliasConflictWithoutReassign(t *testing.T) {
-	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
-	ts := newTestServer(t)
+	h := newServerWithGitWorkspace(t, "https://github.com/wesm/kata.git")
+	ts := h.ts.(*httptest.Server)
 
 	// First init binds the alias to "github.com/wesm/kata".
-	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": dir})
+	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": h.dir})
 
 	// .kata.toml now declares a different identity.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"), //nolint:gosec // test fixture matches production .kata.toml mode
-		[]byte(`version = 1
-
-[project]
-identity = "github.com/wesm/other"
-name     = "other"
-`), 0o644))
+	testfix.WriteKataToml(t, h.dir, "github.com/wesm/other", "other")
 
 	// Re-init without --replace must fail.
 	resp, bs := postJSON(t, ts, "/api/v1/projects", map[string]any{
-		"start_path": dir,
+		"start_path": h.dir,
 	})
-	assert.Equal(t, http.StatusConflict, resp.StatusCode)
-	assert.Contains(t, string(bs), "project_alias_conflict")
+	assertAPIError(t, resp.StatusCode, bs, http.StatusConflict, "project_alias_conflict")
 
 	// With --reassign + --replace, succeeds and rewrites alias.
 	resp2, bs2 := postJSON(t, ts, "/api/v1/projects", map[string]any{
-		"start_path": dir,
+		"start_path": h.dir,
 		"replace":    true,
 		"reassign":   true,
 	})
@@ -310,8 +256,8 @@ func TestInit_ByIdentity_RejectsEmptyIdentity(t *testing.T) {
 // must create a new project — not return the alias-bound override.
 func TestInit_ByIdentity_StrictIdentityLookup(t *testing.T) {
 	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/origin.git")
+	testfix.RunGit(t, dir, "init", "--quiet")
+	testfix.RunGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/origin.git")
 	ts := newTestServer(t)
 
 	// Path-based init with --project override: project.identity is
@@ -582,8 +528,7 @@ func TestResetCounter_RefusesWhenIssuesExist(t *testing.T) {
 
 	resp, bs := postJSON(t, ts, "/api/v1/projects/"+pidStr+"/reset-counter",
 		map[string]any{"to": 1})
-	require.Equal(t, http.StatusConflict, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"project_has_issues"`)
+	assertAPIError(t, resp.StatusCode, bs, http.StatusConflict, "project_has_issues")
 	assert.Contains(t, string(bs), `"issue_count":1`)
 }
 
@@ -595,8 +540,7 @@ func TestResetCounter_RejectsZeroOrNegative(t *testing.T) {
 	for _, to := range []int64{0, -5} {
 		resp, bs := postJSON(t, ts, "/api/v1/projects/"+pidStr+"/reset-counter",
 			map[string]any{"to": to})
-		require.Equal(t, http.StatusBadRequest, resp.StatusCode, string(bs))
-		assert.Contains(t, string(bs), `"validation"`)
+		assertAPIError(t, resp.StatusCode, bs, http.StatusBadRequest, "validation")
 	}
 }
 
@@ -604,36 +548,20 @@ func TestResetCounter_ProjectNotFound(t *testing.T) {
 	ts := newTestServer(t)
 	resp, bs := postJSON(t, ts, "/api/v1/projects/9999/reset-counter",
 		map[string]any{"to": 1})
-	require.Equal(t, http.StatusNotFound, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"project_not_found"`)
+	assertAPIError(t, resp.StatusCode, bs, http.StatusNotFound, "project_not_found")
 }
 
 func TestListProjectsAndShow(t *testing.T) {
-	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/x.git")
-	ts := newTestServer(t)
-	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": dir})
+	h := newServerWithGitWorkspace(t, "https://github.com/wesm/x.git")
+	ts := h.ts.(*httptest.Server)
+	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": h.dir})
 
-	resp, err := http.Get(ts.URL + "/api/v1/projects")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, _ := io.ReadAll(resp.Body)
-	require.Equal(t, 200, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"identity":"github.com/wesm/x"`)
+	listBody := getBody(t, ts, "/api/v1/projects")
+	assert.Contains(t, listBody, `"identity":"github.com/wesm/x"`)
 
-	// pull project_id from the resolve flow then GET the show endpoint.
-	_, rb := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{"start_path": dir})
-	var rbody struct {
-		Project struct{ ID int64 }
-	}
-	require.NoError(t, json.Unmarshal(rb, &rbody))
-	resp2, err := http.Get(ts.URL + "/api/v1/projects/" + strconv.FormatInt(rbody.Project.ID, 10))
-	require.NoError(t, err)
-	defer func() { _ = resp2.Body.Close() }()
-	body2, _ := io.ReadAll(resp2.Body)
-	assert.Equal(t, 200, resp2.StatusCode)
-	assert.Contains(t, string(body2), `"aliases":`)
+	pid := resolveProjectID(t, ts, h.dir)
+	showBody := getBody(t, ts, "/api/v1/projects/"+strconv.FormatInt(pid, 10))
+	assert.Contains(t, showBody, `"aliases":`)
 }
 
 // TestListProjects_DefaultShape pins the byte-level wire shape of
@@ -669,19 +597,14 @@ func TestListProjects_DefaultShape(t *testing.T) {
 }
 
 func TestRenameProject_UpdatesNameAndKeepsIdentity(t *testing.T) {
-	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
-	ts := newTestServer(t)
-	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": dir})
+	h := newServerWithGitWorkspace(t, "https://github.com/wesm/kata.git")
+	ts := h.ts.(*httptest.Server)
+	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": h.dir})
 
-	_, rb := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{"start_path": dir})
-	var rbody struct {
-		Project struct{ ID int64 }
-	}
-	require.NoError(t, json.Unmarshal(rb, &rbody))
+	pid := resolveProjectID(t, ts, h.dir)
+	pidStr := strconv.FormatInt(pid, 10)
 
-	resp, bs := patchJSON(t, ts, "/api/v1/projects/"+strconv.FormatInt(rbody.Project.ID, 10), map[string]any{
+	resp, bs := patchJSON(t, ts, "/api/v1/projects/"+pidStr, map[string]any{
 		"name": "Kata Tracker",
 	})
 	require.Equal(t, 200, resp.StatusCode, string(bs))
@@ -689,28 +612,18 @@ func TestRenameProject_UpdatesNameAndKeepsIdentity(t *testing.T) {
 	assert.Contains(t, string(bs), `"name":"Kata Tracker"`)
 	assert.Contains(t, string(bs), `"aliases":`)
 
-	resp2, err := http.Get(ts.URL + "/api/v1/projects/" + strconv.FormatInt(rbody.Project.ID, 10))
-	require.NoError(t, err)
-	defer func() { _ = resp2.Body.Close() }()
-	body2, _ := io.ReadAll(resp2.Body)
-	assert.Equal(t, 200, resp2.StatusCode)
-	assert.Contains(t, string(body2), `"name":"Kata Tracker"`)
+	showBody := getBody(t, ts, "/api/v1/projects/"+pidStr)
+	assert.Contains(t, showBody, `"name":"Kata Tracker"`)
 }
 
 func TestRenameProject_RejectsBlankName(t *testing.T) {
-	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
-	ts := newTestServer(t)
-	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": dir})
+	h := newServerWithGitWorkspace(t, "https://github.com/wesm/kata.git")
+	ts := h.ts.(*httptest.Server)
+	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"start_path": h.dir})
 
-	_, rb := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{"start_path": dir})
-	var rbody struct {
-		Project struct{ ID int64 }
-	}
-	require.NoError(t, json.Unmarshal(rb, &rbody))
+	pid := resolveProjectID(t, ts, h.dir)
 
-	resp, bs := patchJSON(t, ts, "/api/v1/projects/"+strconv.FormatInt(rbody.Project.ID, 10), map[string]any{
+	resp, bs := patchJSON(t, ts, "/api/v1/projects/"+strconv.FormatInt(pid, 10), map[string]any{
 		"name": "   ",
 	})
 	assert.Equal(t, 400, resp.StatusCode)
@@ -722,8 +635,7 @@ func TestRenameProject_MissingIs404(t *testing.T) {
 	resp, bs := patchJSON(t, ts, "/api/v1/projects/9999", map[string]any{
 		"name": "Missing",
 	})
-	assert.Equal(t, 404, resp.StatusCode)
-	assert.Contains(t, string(bs), "project_not_found")
+	assertAPIError(t, resp.StatusCode, bs, 404, "project_not_found")
 }
 
 func TestMergeProject_SourceMovesIntoSurvivingTarget(t *testing.T) {
@@ -764,6 +676,7 @@ func TestMergeProject_SourceMovesIntoSurvivingTarget(t *testing.T) {
 // archived identity returns project_archived (409).
 func TestRemoveProject_ArchivesAndDropsAliases(t *testing.T) {
 	h := newServerWithGitWorkspace(t, "")
+	ts := h.ts.(*httptest.Server)
 	store := h.DB()
 	ctx := t.Context()
 	p, err := store.CreateProject(ctx, "github.com/wesm/proj-rm", "proj-rm")
@@ -771,14 +684,8 @@ func TestRemoveProject_ArchivesAndDropsAliases(t *testing.T) {
 	_, err = store.AttachAlias(ctx, p.ID, "github.com/wesm/proj-rm", "git", h.dir)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodDelete,
-		h.ts.(*httptest.Server).URL+"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+"?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
+	resp, bs := doReq(t, ts, http.MethodDelete,
+		"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+"?actor=tester", nil, nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
 
 	var body struct {
@@ -793,12 +700,8 @@ func TestRemoveProject_ArchivesAndDropsAliases(t *testing.T) {
 	require.NotNil(t, body.Project.DeletedAt)
 	assert.Equal(t, "project.removed", body.Event.Type)
 
-	listResp, err := http.Get(h.ts.(*httptest.Server).URL + "/api/v1/projects") //nolint:gosec // test loopback
-	require.NoError(t, err)
-	defer func() { _ = listResp.Body.Close() }()
-	listBs, err := io.ReadAll(listResp.Body)
-	require.NoError(t, err)
-	assert.NotContains(t, string(listBs), "github.com/wesm/proj-rm",
+	listBody := getBody(t, ts, "/api/v1/projects")
+	assert.NotContains(t, listBody, "github.com/wesm/proj-rm",
 		"archived project must not surface in /projects list")
 }
 
@@ -806,6 +709,7 @@ func TestRemoveProject_ArchivesAndDropsAliases(t *testing.T) {
 // returns 409 project_has_open_issues when force is omitted.
 func TestRemoveProject_RefusesWithOpenIssues(t *testing.T) {
 	h := newServerWithGitWorkspace(t, "")
+	ts := h.ts.(*httptest.Server)
 	store := h.DB()
 	ctx := t.Context()
 	p, err := store.CreateProject(ctx, "github.com/wesm/proj-busy", "proj-busy")
@@ -815,22 +719,16 @@ func TestRemoveProject_RefusesWithOpenIssues(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodDelete,
-		h.ts.(*httptest.Server).URL+"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+"?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusConflict, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), "project_has_open_issues")
+	resp, bs := doReq(t, ts, http.MethodDelete,
+		"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+"?actor=tester", nil, nil)
+	assertAPIError(t, resp.StatusCode, bs, http.StatusConflict, "project_has_open_issues")
 }
 
 // TestRemoveProject_ForceOverridesOpenIssues pins ?force=true: with the
 // flag, archival succeeds even with open issues.
 func TestRemoveProject_ForceOverridesOpenIssues(t *testing.T) {
 	h := newServerWithGitWorkspace(t, "")
+	ts := h.ts.(*httptest.Server)
 	store := h.DB()
 	ctx := t.Context()
 	p, err := store.CreateProject(ctx, "github.com/wesm/proj-force-http", "proj-force-http")
@@ -840,15 +738,8 @@ func TestRemoveProject_ForceOverridesOpenIssues(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodDelete,
-		h.ts.(*httptest.Server).URL+"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+
-			"?actor=tester&force=true", nil)
-	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
+	resp, bs := doReq(t, ts, http.MethodDelete,
+		"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+"?actor=tester&force=true", nil, nil)
 	assert.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
 }
 
@@ -857,6 +748,7 @@ func TestRemoveProject_ForceOverridesOpenIssues(t *testing.T) {
 // emits project.alias_removed.
 func TestDetachProjectAlias_DropsOneAndEmitsEvent(t *testing.T) {
 	h := newServerWithGitWorkspace(t, "")
+	ts := h.ts.(*httptest.Server)
 	store := h.DB()
 	ctx := t.Context()
 	p, err := store.CreateProject(ctx, "github.com/wesm/proj-alias-http", "proj-alias-http")
@@ -866,15 +758,9 @@ func TestDetachProjectAlias_DropsOneAndEmitsEvent(t *testing.T) {
 	a2, err := store.AttachAlias(ctx, p.ID, "local:///tmp/aliased", "local", "/tmp/aliased")
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodDelete,
-		h.ts.(*httptest.Server).URL+"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+
-			"/aliases/"+strconv.FormatInt(a2.ID, 10)+"?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
+	resp, bs := doReq(t, ts, http.MethodDelete,
+		"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+
+			"/aliases/"+strconv.FormatInt(a2.ID, 10)+"?actor=tester", nil, nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
 
 	var body struct {
@@ -899,6 +785,7 @@ func TestDetachProjectAlias_DropsOneAndEmitsEvent(t *testing.T) {
 // the only alias for a project rejects detach without ?force=true.
 func TestDetachProjectAlias_LastRefuses(t *testing.T) {
 	h := newServerWithGitWorkspace(t, "")
+	ts := h.ts.(*httptest.Server)
 	store := h.DB()
 	ctx := t.Context()
 	p, err := store.CreateProject(ctx, "github.com/wesm/proj-only-http", "proj-only-http")
@@ -906,17 +793,10 @@ func TestDetachProjectAlias_LastRefuses(t *testing.T) {
 	a, err := store.AttachAlias(ctx, p.ID, "github.com/wesm/proj-only-http", "git", h.dir)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodDelete,
-		h.ts.(*httptest.Server).URL+"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+
-			"/aliases/"+strconv.FormatInt(a.ID, 10)+"?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusConflict, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), "alias_is_last")
+	resp, bs := doReq(t, ts, http.MethodDelete,
+		"/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+
+			"/aliases/"+strconv.FormatInt(a.ID, 10)+"?actor=tester", nil, nil)
+	assertAPIError(t, resp.StatusCode, bs, http.StatusConflict, "alias_is_last")
 }
 
 // TestDetachProjectAlias_RejectsCrossProject pins that an alias_id from
@@ -924,6 +804,7 @@ func TestDetachProjectAlias_LastRefuses(t *testing.T) {
 // avoid leaking the existence of the cross-project alias.
 func TestDetachProjectAlias_RejectsCrossProject(t *testing.T) {
 	h := newServerWithGitWorkspace(t, "")
+	ts := h.ts.(*httptest.Server)
 	store := h.DB()
 	ctx := t.Context()
 	p1, err := store.CreateProject(ctx, "github.com/wesm/p1", "p1")
@@ -935,17 +816,10 @@ func TestDetachProjectAlias_RejectsCrossProject(t *testing.T) {
 	a2, err := store.AttachAlias(ctx, p2.ID, "github.com/wesm/p2", "git", h.dir)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest(http.MethodDelete,
-		h.ts.(*httptest.Server).URL+"/api/v1/projects/"+strconv.FormatInt(p1.ID, 10)+
-			"/aliases/"+strconv.FormatInt(a2.ID, 10)+"?actor=tester", nil)
-	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test loopback
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), "alias_not_found")
+	resp, bs := doReq(t, ts, http.MethodDelete,
+		"/api/v1/projects/"+strconv.FormatInt(p1.ID, 10)+
+			"/aliases/"+strconv.FormatInt(a2.ID, 10)+"?actor=tester", nil, nil)
+	assertAPIError(t, resp.StatusCode, bs, http.StatusNotFound, "alias_not_found")
 }
 
 // TestRemoveProject_ArchivedIdentityRefusesReinit pins the user's clarifier
@@ -1086,13 +960,7 @@ func TestInit_MergedKataTomlIdentityResolvesToSurvivingProject(t *testing.T) {
 		TargetProjectID: steward.ID,
 	})
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(h.dir, ".kata.toml"), //nolint:gosec // test fixture mirrors production .kata.toml mode
-		[]byte(`version = 1
-
-[project]
-identity = "github.com/wesm/kenn"
-name     = "kenn"
-`), 0o644))
+	testfix.WriteKataToml(t, h.dir, "github.com/wesm/kenn", "kenn")
 
 	resp, bs := postJSON(t, h.ts.(*httptest.Server), "/api/v1/projects", map[string]any{
 		"start_path": h.dir,

--- a/internal/daemon/handlers_ready_test.go
+++ b/internal/daemon/handlers_ready_test.go
@@ -1,14 +1,28 @@
 package daemon_test
 
 import (
-	"encoding/json"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/testenv"
 )
+
+// readyResp is the decoded shape of a /ready response body, narrowed to the
+// fields the tests assert on.
+type readyResp struct {
+	Issues []struct {
+		Number int64 `json:"number"`
+	} `json:"issues"`
+}
+
+// getReady GETs /api/v1/projects/{pid}/ready{query} and decodes the response.
+// query may be empty or a leading-`?` query string (e.g. "?limit=2").
+func getReady(t *testing.T, env *testenv.Env, projectID int64, query string) readyResp {
+	t.Helper()
+	var out readyResp
+	envGetJSON(t, env, projectPath(projectID)+"/ready"+query, &out)
+	return out
+}
 
 func TestReady_FiltersBlocked(t *testing.T) {
 	env := testenv.New(t)
@@ -16,16 +30,7 @@ func TestReady_FiltersBlocked(t *testing.T) {
 	standalone := createIssueViaHTTP(t, env, pid, "standalone")
 	postLink(t, env, pid, blocker, "blocks", blocked)
 
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/ready")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Issues []struct {
-			Number int64 `json:"number"`
-		} `json:"issues"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	out := getReady(t, env, pid, "")
 	got := map[int64]bool{}
 	for _, i := range out.Issues {
 		got[i.Number] = true
@@ -42,15 +47,6 @@ func TestReady_RespectsLimit(t *testing.T) {
 		createIssueViaHTTP(t, env, pid, "x")
 	}
 
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/ready?limit=2")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	require.Equal(t, 200, resp.StatusCode)
-	var out struct {
-		Issues []struct {
-			Number int64 `json:"number"`
-		} `json:"issues"`
-	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	out := getReady(t, env, pid, "?limit=2")
 	assert.Len(t, out.Issues, 2)
 }

--- a/internal/daemon/handlers_search_test.go
+++ b/internal/daemon/handlers_search_test.go
@@ -1,48 +1,42 @@
 package daemon_test
 
 import (
-	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestSearchEndpoint_ReturnsHitsWithScores(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
-	_, _ = postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues",
-		map[string]any{"actor": "agent", "title": "fix login crash on Safari"})
-	_, _ = postJSON(t, ts, "/api/v1/projects/"+pidStr+"/issues",
-		map[string]any{"actor": "agent", "title": "unrelated"})
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	createIssueViaHTTP(t, env, pid, "fix login crash on Safari")
+	createIssueViaHTTP(t, env, pid, "unrelated")
 
-	bs := getBody(t, ts, "/api/v1/projects/"+pidStr+"/search?q="+url.QueryEscape("login Safari"))
-	assert.Contains(t, bs, `"query":"login Safari"`)
-	assert.Contains(t, bs, `"title":"fix login crash on Safari"`)
-	assert.Contains(t, bs, `"matched_in"`)
-	assert.NotContains(t, bs, `"title":"unrelated"`,
+	resp, bs := envGetRaw(t, env, projectPath(pid)+"/search?q="+url.QueryEscape("login Safari"))
+	require.Equal(t, 200, resp.StatusCode)
+	body := string(bs)
+	assert.Contains(t, body, `"query":"login Safari"`)
+	assert.Contains(t, body, `"title":"fix login crash on Safari"`)
+	assert.Contains(t, body, `"matched_in"`)
+	assert.NotContains(t, body, `"title":"unrelated"`,
 		"unrelated issue should not appear in results")
 }
 
 func TestSearchEndpoint_EmptyQueryIsValidationError(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 
-	resp, bs := getStatusBody(t, ts, "/api/v1/projects/"+pidStr+"/search?q=")
-	require.Equal(t, 400, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"validation"`)
+	resp, bs := envGetRaw(t, env, projectPath(pid)+"/search?q=")
+	assertAPIError(t, resp.StatusCode, bs, 400, "validation")
 }
 
 func TestSearchEndpoint_UnknownProjectIs404(t *testing.T) {
-	h, _ := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	resp, bs := getStatusBody(t, ts, "/api/v1/projects/9999/search?q=anything")
-	require.Equal(t, 404, resp.StatusCode, string(bs))
-	assert.Contains(t, string(bs), `"project_not_found"`)
+	env := testenv.New(t)
+	resp, bs := envGetRaw(t, env, "/api/v1/projects/9999/search?q=anything")
+	assertAPIError(t, resp.StatusCode, bs, 404, "project_not_found")
 }
 
 // TestSearchEndpoint_EmptyResultsIsArrayNotNull pins the wire shape: a
@@ -51,12 +45,13 @@ func TestSearchEndpoint_UnknownProjectIs404(t *testing.T) {
 // future regression that flipped to `var hits []SearchHit` would silently
 // emit null and break clients that assume an array.
 func TestSearchEndpoint_EmptyResultsIsArrayNotNull(t *testing.T) {
-	h, pid := bootstrapProject(t)
-	ts := h.ts.(*httptest.Server)
-	pidStr := strconv.FormatInt(pid, 10)
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 
-	bs := getBody(t, ts, "/api/v1/projects/"+pidStr+"/search?q=zxqyq-no-such-token")
-	assert.Contains(t, bs, `"results":[]`,
+	resp, bs := envGetRaw(t, env, projectPath(pid)+"/search?q=zxqyq-no-such-token")
+	require.Equal(t, 200, resp.StatusCode)
+	body := string(bs)
+	assert.Contains(t, body, `"results":[]`,
 		"empty results must serialize as an array, not null")
-	assert.NotContains(t, bs, `"results":null`)
+	assert.NotContains(t, body, `"results":null`)
 }

--- a/internal/daemon/namespace_test.go
+++ b/internal/daemon/namespace_test.go
@@ -10,10 +10,20 @@ import (
 	"github.com/wesm/kata/internal/daemon"
 )
 
-func TestNamespace_DataDirIsKataHomeRuntime(t *testing.T) {
+// setupMockEnv creates a temp dir and points $KATA_HOME and $KATA_DB at it
+// for the test's lifetime. Returns the temp dir so callers can construct
+// dbhash-derived paths or layer additional env vars on top before calling
+// daemon.NewNamespace().
+func setupMockEnv(t *testing.T) string {
+	t.Helper()
 	tmp := t.TempDir()
 	t.Setenv("KATA_HOME", tmp)
 	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	return tmp
+}
+
+func TestNamespace_DataDirIsKataHomeRuntime(t *testing.T) {
+	tmp := setupMockEnv(t)
 
 	ns, err := daemon.NewNamespace()
 	require.NoError(t, err)
@@ -23,10 +33,8 @@ func TestNamespace_DataDirIsKataHomeRuntime(t *testing.T) {
 }
 
 func TestNamespace_SocketDirHonorsXDGRuntimeDir(t *testing.T) {
-	tmp := t.TempDir()
+	setupMockEnv(t)
 	xdg := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
 	t.Setenv("XDG_RUNTIME_DIR", xdg)
 
 	ns, err := daemon.NewNamespace()
@@ -35,9 +43,7 @@ func TestNamespace_SocketDirHonorsXDGRuntimeDir(t *testing.T) {
 }
 
 func TestNamespace_SocketDirFallsBackToTmpDir(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	setupMockEnv(t)
 	t.Setenv("XDG_RUNTIME_DIR", "")
 	t.Setenv("TMPDIR", "/var/folders/xy")
 

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -3,7 +3,6 @@ package daemon_test
 import (
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -33,9 +32,13 @@ func TestRuntimeFile_RoundTripWriteRead(t *testing.T) {
 func TestListRuntimeFiles_FindsAllInDir(t *testing.T) {
 	dir := t.TempDir()
 	for _, pid := range []int{1, 2, 3} {
-		require.NoError(t, os.WriteFile( //nolint:gosec // runtime files are world-readable per §2.3
-			filepath.Join(dir, "daemon."+strconv.Itoa(pid)+".json"),
-			[]byte(`{"pid":`+strconv.Itoa(pid)+`,"address":"x","db_path":"x","started_at":"2026-01-01T00:00:00Z"}`), 0o644))
+		_, err := daemon.WriteRuntimeFile(dir, daemon.RuntimeRecord{
+			PID:       pid,
+			Address:   "x",
+			DBPath:    "x",
+			StartedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
 	}
 
 	got, err := daemon.ListRuntimeFiles(dir)

--- a/internal/daemon/server_internal_test.go
+++ b/internal/daemon/server_internal_test.go
@@ -12,7 +12,7 @@ import (
 func TestServerConfig_NilHooks_FillsNoop(t *testing.T) {
 	cfg := ServerConfig{Hooks: nil}
 	srv := NewServer(cfg)
-	defer func() { _ = srv.Close() }()
+	t.Cleanup(func() { _ = srv.Close() })
 	if srv.cfg.Hooks == nil {
 		t.Fatal("Hooks should default to NewNoop, not stay nil")
 	}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1,60 +1,33 @@
 package daemon_test
 
 import (
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/wesm/kata/internal/daemon"
 )
 
 func TestServer_PingReturnsOK(t *testing.T) {
-	d := openTestDB(t)
-	srv := daemon.NewServer(daemon.ServerConfig{
-		DB:        d.db,
-		StartedAt: d.now,
-	})
-	t.Cleanup(func() { _ = srv.Close() })
+	ts, _ := startDefaultTestServer(t)
 
-	ts := httptest.NewServer(srv.Handler())
-	t.Cleanup(ts.Close)
-
-	resp, err := http.Get(ts.URL + "/api/v1/ping")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, body := getStatusBody(t, ts, "/api/v1/ping")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	body, _ := io.ReadAll(resp.Body)
 	assert.Contains(t, string(body), `"ok":true`)
 }
 
 func TestServer_RejectsNonEmptyOrigin(t *testing.T) {
-	d := openTestDB(t)
-	srv := daemon.NewServer(daemon.ServerConfig{DB: d.db, StartedAt: d.now})
-	t.Cleanup(func() { _ = srv.Close() })
+	ts, _ := startDefaultTestServer(t)
 
-	ts := httptest.NewServer(srv.Handler())
-	t.Cleanup(ts.Close)
-
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/ping", nil)
-	require.NoError(t, err)
-	req.Header.Set("Origin", "https://attacker.example.com")
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test request to httptest server URL
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
+	resp, _ := doReq(t, ts, http.MethodGet, "/api/v1/ping", nil, map[string]string{
+		"Origin": "https://attacker.example.com",
+	})
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
 func TestServer_MutationRequiresJSON(t *testing.T) {
-	d := openTestDB(t)
-	srv := daemon.NewServer(daemon.ServerConfig{DB: d.db, StartedAt: d.now})
-	t.Cleanup(func() { _ = srv.Close() })
-
-	ts := httptest.NewServer(srv.Handler())
-	t.Cleanup(ts.Close)
+	ts, _ := startDefaultTestServer(t)
 
 	resp, err := http.Post(ts.URL+"/api/v1/projects/resolve", "text/plain",
 		strings.NewReader(`{"start_path":"/x"}`))

--- a/internal/daemon/testhelpers_test.go
+++ b/internal/daemon/testhelpers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,11 +12,96 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wesm/kata/internal/daemon"
 	"github.com/wesm/kata/internal/db"
+	"github.com/wesm/kata/internal/hooks"
+	"github.com/wesm/kata/internal/testfix"
 )
+
+// httptestServerHandle bundles a httptest.Server with the on-disk workspace
+// directory the server was bootstrapped against. The ts field is typed as
+// any to keep cross-helper imports loose; tests cast to *httptest.Server.
+type httptestServerHandle struct {
+	ts  any // *httptest.Server, but kept generic to avoid import cycles in helpers
+	dir string
+	db  *db.DB
+}
+
+// DB returns the *db.DB the test server is wired against, so a test can
+// reach below the HTTP surface to set up state (e.g. soft-delete an issue
+// before retrying create-with-idempotency-key).
+func (h *httptestServerHandle) DB() *db.DB { return h.db }
+
+// serverOption mutates a daemon.ServerConfig before the test server starts.
+// Used by helpers that wire a fresh server (e.g. newServerWithGitWorkspace,
+// bootstrapProject) so callers can install non-default plumbing such as a
+// recording hooks sink without having to duplicate the bootstrap dance.
+type serverOption func(*daemon.ServerConfig)
+
+// withHooksSink installs sink as the daemon's hooks.Sink so tests can observe
+// every Enqueue call without spinning up the real dispatcher.
+func withHooksSink(sink hooks.Sink) serverOption {
+	return func(c *daemon.ServerConfig) { c.Hooks = sink }
+}
+
+// issuesURL returns the issues collection URL for the given project rowid.
+func issuesURL(projectID int64) string {
+	return fmt.Sprintf("/api/v1/projects/%d/issues", projectID)
+}
+
+// issueURL returns the URL for a specific issue under a project. When suffix
+// is non-empty it is appended after the issue number (e.g. "comments" or
+// "actions/close"); when empty the resource URL itself is returned.
+func issueURL(projectID int64, issueNumber int64, suffix string) string {
+	if suffix == "" {
+		return fmt.Sprintf("/api/v1/projects/%d/issues/%d", projectID, issueNumber)
+	}
+	return fmt.Sprintf("/api/v1/projects/%d/issues/%d/%s", projectID, issueNumber, suffix)
+}
+
+// bootstrapProject spins up a fresh server + git workspace and runs `kata
+// init` against it, returning the handle and the project rowid. Used as a
+// shared setup for every issue handler test. Optional serverOptions are
+// forwarded to newServerWithGitWorkspace (e.g. to install a hooks sink).
+func bootstrapProject(t *testing.T, opts ...serverOption) (*httptestServerHandle, int64) {
+	t.Helper()
+	h := newServerWithGitWorkspace(t, "https://github.com/wesm/kata.git", opts...)
+	_, bs := postJSON(t, h.ts.(*httptest.Server), "/api/v1/projects", map[string]any{"start_path": h.dir})
+	var resp struct{ Project struct{ ID int64 } }
+	require.NoError(t, json.Unmarshal(bs, &resp))
+	return h, resp.Project.ID
+}
+
+// bootstrapProjectWithIssue runs bootstrapProject and additionally posts a
+// minimal issue so callers can target issue number 1 directly. Returns the
+// handle, the cast *httptest.Server, the project rowid, and the issue number.
+func bootstrapProjectWithIssue(t *testing.T) (*httptestServerHandle, *httptest.Server, int64, int64) {
+	t.Helper()
+	h, pid := bootstrapProject(t)
+	ts := h.ts.(*httptest.Server)
+	resp, bs := postJSON(t, ts, issuesURL(pid),
+		map[string]any{"actor": "x", "title": "x"})
+	require.Equalf(t, 200, resp.StatusCode, "seed issue: %s", string(bs))
+	return h, ts, pid, 1
+}
+
+// assertAPIError asserts the response carries the standard error envelope
+// shape with the given HTTP status and error.code. The raw body is surfaced
+// in failure messages so debugging doesn't require rerunning with -v.
+func assertAPIError(t *testing.T, status int, body []byte, wantStatus int, wantCode string) {
+	t.Helper()
+	require.Equalf(t, wantStatus, status, "status: got %d, body: %s", status, string(body))
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(body, &envelope), string(body))
+	assert.Equal(t, wantCode, envelope.Error.Code, string(body))
+}
 
 // testDBHandle bundles a fresh *db.DB and a started-at timestamp for daemon
 // server tests.
@@ -34,22 +120,83 @@ func openTestDB(t *testing.T) testDBHandle {
 	return testDBHandle{db: d, now: time.Now().UTC()}
 }
 
+// startTestServer wires a daemon server with the given config, mounts it on
+// an httptest.Server, and registers cleanups for both. Tests that need a
+// custom ServerConfig (read-only DB, hooks sink, etc.) use this directly;
+// callers that just need a default server should use startDefaultTestServer.
+func startTestServer(t *testing.T, cfg daemon.ServerConfig) *httptest.Server {
+	t.Helper()
+	srv := daemon.NewServer(cfg)
+	t.Cleanup(func() { _ = srv.Close() })
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// startDefaultTestServer opens a fresh test DB and starts an httptest.Server
+// against it with the default ServerConfig. Returns the server and the DB
+// handle so tests can inspect or mutate state below the HTTP layer.
+func startDefaultTestServer(t *testing.T) (*httptest.Server, testDBHandle) {
+	t.Helper()
+	d := openTestDB(t)
+	return startTestServer(t, daemon.ServerConfig{DB: d.db, StartedAt: d.now}), d
+}
+
 // newServerWithGitWorkspace creates a fresh git repo in t.TempDir(), wires a
 // daemon server against a fresh DB, and returns a handle exposing both. When
 // originURL is non-empty it is added as the "origin" remote so alias
-// derivation has an http(s) URL to chew on.
-func newServerWithGitWorkspace(t *testing.T, originURL string) *httptestServerHandle {
+// derivation has an http(s) URL to chew on. Optional serverOptions tweak the
+// ServerConfig before the http server starts (e.g. installing a hooks sink).
+func newServerWithGitWorkspace(t *testing.T, originURL string, opts ...serverOption) *httptestServerHandle {
 	t.Helper()
 	dir := t.TempDir()
-	runGit(t, dir, "init", "--quiet")
+	testfix.RunGit(t, dir, "init", "--quiet")
 	if originURL != "" {
-		runGit(t, dir, "remote", "add", "origin", originURL)
+		testfix.RunGit(t, dir, "remote", "add", "origin", originURL)
 	}
 	d := openTestDB(t)
-	srv := daemon.NewServer(daemon.ServerConfig{DB: d.db, StartedAt: d.now})
-	ts := httptest.NewServer(srv.Handler())
-	t.Cleanup(ts.Close)
+	cfg := daemon.ServerConfig{DB: d.db, StartedAt: d.now}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	ts := startTestServer(t, cfg)
 	return &httptestServerHandle{ts: ts, dir: dir, db: d.db}
+}
+
+// resolveProjectID posts /api/v1/projects/resolve for the given workspace dir
+// and returns the resolved project rowid. Saves callers from declaring an
+// anonymous struct just to extract the ID.
+func resolveProjectID(t *testing.T, ts *httptest.Server, dir string) int64 {
+	t.Helper()
+	_, bs := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{"start_path": dir})
+	var rbody struct {
+		Project struct {
+			ID int64 `json:"id"`
+		} `json:"project"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &rbody), string(bs))
+	return rbody.Project.ID
+}
+
+// postJSON issues a POST with a JSON body and returns the response plus the
+// fully-drained body. The shared default for POST tests in this package.
+func postJSON(t *testing.T, ts *httptest.Server, path string, body any) (*http.Response, []byte) {
+	t.Helper()
+	js, err := json.Marshal(body)
+	require.NoError(t, err)
+	resp, err := http.Post(ts.URL+path, "application/json", bytes.NewReader(js))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	bs, _ := io.ReadAll(resp.Body)
+	return resp, bs
+}
+
+// newTestServer is a thin convenience wrapper over startDefaultTestServer for
+// tests that don't need access to the underlying *db.DB.
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	ts, _ := startDefaultTestServer(t)
+	return ts
 }
 
 // patchJSON issues a PATCH request with a JSON body and returns the response
@@ -68,6 +215,48 @@ func patchJSON(t *testing.T, ts *httptest.Server, path string, body any) (*http.
 	return resp, bs
 }
 
+// doReq builds and executes an arbitrary-method HTTP request against ts. When
+// body is non-nil it is JSON-encoded and Content-Type is set automatically;
+// extra headers are layered on top. The response body is fully drained and
+// returned, and resp.Body is closed before the function returns.
+func doReq(t *testing.T, ts *httptest.Server, method, path string, body any, headers map[string]string) (*http.Response, []byte) {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != nil {
+		js, err := json.Marshal(body)
+		require.NoError(t, err)
+		bodyReader = bytes.NewReader(js)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, ts.URL+path, bodyReader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test request to httptest server URL
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	bs, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, bs
+}
+
+// archiveProject soft-deletes (archives) a project via the DB layer. Pass
+// force=true to bypass the open-issues guard when the project still has live
+// issues. Tests use this to set up the archived-project state without going
+// through the HTTP DELETE path.
+func archiveProject(t *testing.T, h *httptestServerHandle, projectID int64, force bool) {
+	t.Helper()
+	_, _, err := h.DB().RemoveProject(context.Background(), db.RemoveProjectParams{
+		ProjectID: projectID,
+		Actor:     "tester",
+		Force:     force,
+	})
+	require.NoError(t, err)
+}
+
 // getBody runs a GET against the test server and asserts a 2xx status. Returns
 // the body as a string for easy substring assertions.
 func getBody(t *testing.T, ts *httptest.Server, path string) string {
@@ -81,6 +270,16 @@ func getBody(t *testing.T, ts *httptest.Server, path string) string {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
 	return string(bs)
+}
+
+// getAndUnmarshal performs a GET against ts, asserts the response status
+// matches wantStatus, and decodes the body into target. The raw body is
+// surfaced in failure messages so debugging doesn't require rerunning.
+func getAndUnmarshal(t *testing.T, ts *httptest.Server, path string, wantStatus int, target any) {
+	t.Helper()
+	resp, bs := getStatusBody(t, ts, path)
+	require.Equalf(t, wantStatus, resp.StatusCode, "GET %s: status %d, body: %s", path, resp.StatusCode, string(bs))
+	require.NoError(t, json.Unmarshal(bs, target), string(bs))
 }
 
 // getStatusBody is like getBody but returns the response so callers can assert
@@ -130,4 +329,59 @@ func postWithHeader(t *testing.T, ts *httptest.Server, path string, headers map[
 func requireOK(t *testing.T, r httpResp) {
 	t.Helper()
 	require.Equalf(t, 200, r.status, "expected 200, got %d: %s", r.status, string(r.body))
+}
+
+// receiveMsg blocks until a StreamMsg arrives on ch or timeout fires; on
+// timeout it calls t.Fatalf with the supplied label so failures identify the
+// site without a custom select block.
+func receiveMsg(t *testing.T, ch <-chan daemon.StreamMsg, timeout time.Duration, label string) daemon.StreamMsg {
+	t.Helper()
+	select {
+	case got := <-ch:
+		return got
+	case <-time.After(timeout):
+		t.Fatalf("%s: did not receive within %s", label, timeout)
+		return daemon.StreamMsg{}
+	}
+}
+
+// assertNoReceive asserts that no StreamMsg arrives on ch within the timeout.
+// A delivery is reported via t.Fatalf, surfacing the offending message.
+func assertNoReceive(t *testing.T, ch <-chan daemon.StreamMsg, timeout time.Duration, label string) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		t.Fatalf("%s: unexpected delivery %+v", label, got)
+	case <-time.After(timeout):
+	}
+}
+
+// assertChannelClosed waits up to timeout for ch to be closed, draining any
+// values delivered in the meantime. Any value received before the close is
+// discarded — callers that care about delivered values should drain explicitly.
+func assertChannelClosed(t *testing.T, ch <-chan daemon.StreamMsg, timeout time.Duration, label string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+		case <-time.After(remaining):
+		}
+	}
+	t.Fatalf("%s: channel was not closed within %s", label, timeout)
+}
+
+// broadcastEvent constructs a synthetic issue.created event with the given
+// IDs and broadcasts it through b. Saves callers the StreamMsg{Kind:"event"}
+// boilerplate when the specific event payload doesn't matter.
+func broadcastEvent(b *daemon.EventBroadcaster, projectID, eventID int64) {
+	evt := &db.Event{ID: eventID, ProjectID: projectID, Type: "issue.created"}
+	b.Broadcast(daemon.StreamMsg{Kind: "event", Event: evt, ProjectID: projectID})
 }

--- a/internal/daemonclient/ensure_test.go
+++ b/internal/daemonclient/ensure_test.go
@@ -20,25 +20,16 @@ import (
 
 func TestEnsureRunningRestartsWhenDaemonVersionDiffers(t *testing.T) {
 	t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	tmp := setupKataEnv(t)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/ping" {
-			http.NotFound(w, r)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ok":      true,
-			"service": "kata",
-			"version": "old-version",
-			"pid":     os.Getpid(),
-		})
-	}))
-	t.Cleanup(server.Close)
+	_, addr := startMockDaemonPing(t, map[string]any{
+		"ok":      true,
+		"service": "kata",
+		"version": "old-version",
+		"pid":     os.Getpid(),
+	})
 
-	require.NoError(t, writeRuntimeRecord(t, tmp, strings.TrimPrefix(server.URL, "http://")))
+	require.NoError(t, writeRuntimeRecord(t, tmp, addr))
 	restore := patchEnsureHooks(t, "new-version", "http://new-daemon")
 	url, err := EnsureRunning(context.Background())
 	require.NoError(t, err)
@@ -50,20 +41,11 @@ func TestEnsureRunningRestartsWhenDaemonVersionDiffers(t *testing.T) {
 
 func TestEnsureRunningRestartsWhenDaemonVersionUnknown(t *testing.T) {
 	t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	tmp := setupKataEnv(t)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/ping" {
-			http.NotFound(w, r)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
-	}))
-	t.Cleanup(server.Close)
+	_, addr := startMockDaemonPing(t, map[string]any{"ok": true})
 
-	require.NoError(t, writeRuntimeRecord(t, tmp, strings.TrimPrefix(server.URL, "http://")))
+	require.NoError(t, writeRuntimeRecord(t, tmp, addr))
 	restore := patchEnsureHooks(t, "new-version", "http://new-daemon")
 	url, err := EnsureRunning(context.Background())
 	require.NoError(t, err)
@@ -80,9 +62,7 @@ func TestShouldRefuseAutoStartDaemonFromGoTestBinary(t *testing.T) {
 }
 
 func TestStopRunningDaemonsDoesNotSignalUnverifiedRuntimePID(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	tmp := setupKataEnv(t)
 	cmd := exec.Command("sleep", "30")
 	require.NoError(t, cmd.Start())
 	waitCh := make(chan error, 1)
@@ -108,22 +88,13 @@ func TestStopRunningDaemonsDoesNotSignalUnverifiedRuntimePID(t *testing.T) {
 
 func TestStopRunningDaemonsErrorsOnUnverifiableIncompatibleRuntime(t *testing.T) {
 	t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
-	tmp := t.TempDir()
-	t.Setenv("KATA_HOME", tmp)
-	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/ping" {
-			http.NotFound(w, r)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"ok":      true,
-			"service": "kata",
-			"version": "old-version",
-		})
-	}))
-	t.Cleanup(server.Close)
-	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), strings.TrimPrefix(server.URL, "http://")))
+	tmp := setupKataEnv(t)
+	_, addr := startMockDaemonPing(t, map[string]any{
+		"ok":      true,
+		"service": "kata",
+		"version": "old-version",
+	})
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), addr))
 	ns, err := daemon.NewNamespace()
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
@@ -135,6 +106,32 @@ func TestStopRunningDaemonsErrorsOnUnverifiableIncompatibleRuntime(t *testing.T)
 
 	_, err = os.Stat(filepath.Join(ns.DataDir, fmt.Sprintf("daemon.%d.json", os.Getpid())))
 	assert.NoError(t, err, "unverifiable reachable daemon runtime file should be preserved")
+}
+
+// setupKataEnv points KATA_HOME and KATA_DB at a fresh temp dir so the test
+// runs in isolation from any developer-local state. Returns the temp dir.
+func setupKataEnv(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	return tmp
+}
+
+// startMockDaemonPing starts an httptest.Server that responds to
+// /api/v1/ping with the given JSON payload and 404s every other path.
+// Returns the full URL and the host:port address used in runtime records.
+func startMockDaemonPing(t *testing.T, payload map[string]any) (url, addr string) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ping" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(server.Close)
+	return server.URL, strings.TrimPrefix(server.URL, "http://")
 }
 
 func writeRuntimeRecord(t *testing.T, home, addr string) error {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,10 +15,7 @@ import (
 )
 
 func TestOpen_AppliesPragmasAndMigrations(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "kata.db")
-	d, err := db.Open(context.Background(), path)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = d.Close() })
+	d := openTestDB(t)
 
 	var fk int
 	require.NoError(t, d.QueryRow("PRAGMA foreign_keys").Scan(&fk))
@@ -29,21 +25,13 @@ func TestOpen_AppliesPragmasAndMigrations(t *testing.T) {
 	require.NoError(t, d.QueryRow("PRAGMA journal_mode").Scan(&mode))
 	assert.Equal(t, "wal", mode)
 
-	var version string
-	require.NoError(t, d.QueryRow(`SELECT value FROM meta WHERE key='schema_version'`).Scan(&version))
-	assert.Equal(t, strconv.Itoa(db.CurrentSchemaVersion()), version)
+	assertSchemaVersion(t, d, db.CurrentSchemaVersion())
 }
 
 func TestOpen_RecordsCurrentSchemaVersion(t *testing.T) {
 	assert.Equal(t, 4, db.CurrentSchemaVersion())
-	path := filepath.Join(t.TempDir(), "kata.db")
-	d, err := db.Open(context.Background(), path)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = d.Close() })
-
-	var got string
-	require.NoError(t, d.QueryRow(`SELECT value FROM meta WHERE key='schema_version'`).Scan(&got))
-	assert.Equal(t, strconv.Itoa(db.CurrentSchemaVersion()), got)
+	d := openTestDB(t)
+	assertSchemaVersion(t, d, db.CurrentSchemaVersion())
 }
 
 func TestOpen_IsIdempotent(t *testing.T) {
@@ -56,9 +44,7 @@ func TestOpen_IsIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = d2.Close() })
 
-	var version string
-	require.NoError(t, d2.QueryRow(`SELECT value FROM meta WHERE key='schema_version'`).Scan(&version))
-	assert.Equal(t, strconv.Itoa(db.CurrentSchemaVersion()), version)
+	assertSchemaVersion(t, d2, db.CurrentSchemaVersion())
 }
 
 func TestOpen_RejectsOlderSchemaNeedingJSONLCutover(t *testing.T) {
@@ -77,10 +63,7 @@ func TestOpen_RejectsOlderSchemaNeedingJSONLCutover(t *testing.T) {
 }
 
 func TestOpen_TimestampColumnsScanIntoTime(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "kata.db")
-	d, err := db.Open(context.Background(), path)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = d.Close() })
+	d := openTestDB(t)
 
 	projectUID, err := uid.New()
 	require.NoError(t, err)

--- a/internal/db/instance_uid_test.go
+++ b/internal/db/instance_uid_test.go
@@ -64,12 +64,8 @@ func TestInstanceUIDCachedAcrossDirectSQLMutation(t *testing.T) {
 	assert.Equal(t, original, d.InstanceUID(),
 		"cached InstanceUID must not move when meta.instance_uid is mutated mid-run")
 
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
-	_, evt, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "post-mutation", Author: "tester",
-	})
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
+	_, evt := createTesterIssue(ctx, t, d, p.ID, "post-mutation")
 	assert.Equal(t, original, evt.OriginInstanceUID,
 		"insert path must stamp the cached origin, not the freshly-mutated row value")
 }
@@ -80,14 +76,8 @@ func TestInstanceUIDCachedAcrossDirectSQLMutation(t *testing.T) {
 func TestEventInsertCarriesUIDAndOrigin(t *testing.T) {
 	ctx := context.Background()
 	d := openTestDB(t)
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
-	_, evt, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID,
-		Title:     "uid-stamping",
-		Author:    "tester",
-	})
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
+	_, evt := createTesterIssue(ctx, t, d, p.ID, "uid-stamping")
 	assert.True(t, uid.Valid(evt.UID), "event UID %q invalid", evt.UID)
 	assert.Equal(t, d.InstanceUID(), evt.OriginInstanceUID)
 }
@@ -97,12 +87,8 @@ func TestEventInsertCarriesUIDAndOrigin(t *testing.T) {
 func TestPurgeInsertCarriesUIDAndOrigin(t *testing.T) {
 	ctx := context.Background()
 	d := openTestDB(t)
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "purge me", Author: "tester",
-	})
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
+	issue, _ := createTesterIssue(ctx, t, d, p.ID, "purge me")
 	pl, err := d.PurgeIssue(ctx, issue.ID, "tester", nil)
 	require.NoError(t, err)
 	assert.True(t, uid.Valid(pl.UID), "purge UID %q invalid", pl.UID)
@@ -114,11 +100,10 @@ func TestPurgeInsertCarriesUIDAndOrigin(t *testing.T) {
 func TestEventUIDNotNullRejected(t *testing.T) {
 	ctx := context.Background()
 	d := openTestDB(t)
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
 
 	// uid omitted entirely.
-	_, err = d.ExecContext(ctx, `
+	_, err := d.ExecContext(ctx, `
 		INSERT INTO events(origin_instance_uid, project_id, project_identity, type, actor, payload, created_at)
 		VALUES (?, ?, 'github.com/wesm/kata', 'issue.created', 'tester', '{}', strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
 		d.InstanceUID(), p.ID)

--- a/internal/db/queries_create_initial_test.go
+++ b/internal/db/queries_create_initial_test.go
@@ -1,8 +1,6 @@
 package db_test
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -12,10 +10,7 @@ import (
 )
 
 func TestCreateIssue_WithInitialLabels(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	issue, evt, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: p.ID, Title: "x", Author: "tester",
@@ -33,18 +28,14 @@ func TestCreateIssue_WithInitialLabels(t *testing.T) {
 	assert.ElementsMatch(t, []string{"bug", "priority:high"}, got, "duplicates deduplicated")
 
 	// Payload includes initial labels (sorted, deduplicated).
-	var payload struct {
+	payload := unmarshalPayload[struct {
 		Labels []string `json:"labels"`
-	}
-	require.NoError(t, json.Unmarshal([]byte(evt.Payload), &payload))
+	}](t, evt.Payload)
 	assert.Equal(t, []string{"bug", "priority:high"}, payload.Labels)
 }
 
 func TestCreateIssue_WithInitialOwner(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	owner := "alice"
 	issue, evt, err := d.CreateIssue(ctx, db.CreateIssueParams{
@@ -55,18 +46,14 @@ func TestCreateIssue_WithInitialOwner(t *testing.T) {
 	require.NotNil(t, issue.Owner)
 	assert.Equal(t, "alice", *issue.Owner)
 
-	var payload struct {
+	payload := unmarshalPayload[struct {
 		Owner string `json:"owner"`
-	}
-	require.NoError(t, json.Unmarshal([]byte(evt.Payload), &payload))
+	}](t, evt.Payload)
 	assert.Equal(t, "alice", payload.Owner)
 }
 
 func TestCreateIssue_WithInitialLinks(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	parent := makeIssue(t, ctx, d, p.ID, "parent", "tester")
 	blocker := makeIssue(t, ctx, d, p.ID, "blocker", "tester")
 
@@ -85,23 +72,19 @@ func TestCreateIssue_WithInitialLinks(t *testing.T) {
 	assert.Len(t, links, 2)
 
 	// Payload references to_number, not to_issue_id.
-	var payload struct {
+	payload := unmarshalPayload[struct {
 		Links []struct {
 			Type     string `json:"type"`
 			ToNumber int64  `json:"to_number"`
 		} `json:"links"`
-	}
-	require.NoError(t, json.Unmarshal([]byte(evt.Payload), &payload))
+	}](t, evt.Payload)
 	require.Len(t, payload.Links, 2)
 }
 
 func TestCreateIssue_RejectsInitialLinkToMissingTarget(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
+	_, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: p.ID, Title: "x", Author: "tester",
 		Links: []db.InitialLink{{Type: "parent", ToNumber: 999}},
 	})
@@ -110,13 +93,10 @@ func TestCreateIssue_RejectsInitialLinkToMissingTarget(t *testing.T) {
 }
 
 func TestCreateIssue_RejectsInvalidInitialLinkType(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	target := makeIssue(t, ctx, d, p.ID, "t", "tester")
 
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
+	_, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: p.ID, Title: "x", Author: "tester",
 		Links: []db.InitialLink{{Type: "child", ToNumber: target.Number}},
 	})
@@ -124,12 +104,9 @@ func TestCreateIssue_RejectsInvalidInitialLinkType(t *testing.T) {
 }
 
 func TestCreateIssue_RejectsInvalidLabel(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
+	_, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: p.ID, Title: "x", Author: "tester",
 		Labels: []string{"BadCase"},
 	})
@@ -137,10 +114,7 @@ func TestCreateIssue_RejectsInvalidLabel(t *testing.T) {
 }
 
 func TestCreateIssue_NoInitialStateEmitsEmptyPayload(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	_, evt, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: p.ID, Title: "x", Author: "tester",
@@ -150,10 +124,7 @@ func TestCreateIssue_NoInitialStateEmitsEmptyPayload(t *testing.T) {
 }
 
 func TestCreateIssue_DuplicateInitialLinksAreDeduped(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	parent := makeIssue(t, ctx, d, p.ID, "parent", "tester")
 
 	child, evt, err := d.CreateIssue(ctx, db.CreateIssueParams{
@@ -171,21 +142,17 @@ func TestCreateIssue_DuplicateInitialLinksAreDeduped(t *testing.T) {
 	assert.Len(t, links, 1)
 
 	// Payload reflects the deduped list.
-	var payload struct {
+	payload := unmarshalPayload[struct {
 		Links []struct {
 			Type     string `json:"type"`
 			ToNumber int64  `json:"to_number"`
 		} `json:"links"`
-	}
-	require.NoError(t, json.Unmarshal([]byte(evt.Payload), &payload))
+	}](t, evt.Payload)
 	assert.Len(t, payload.Links, 1)
 }
 
 func TestCreateIssue_EmptyStringOwnerNormalizesToNil(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	empty := ""
 	issue, evt, err := d.CreateIssue(ctx, db.CreateIssueParams{
@@ -198,10 +165,7 @@ func TestCreateIssue_EmptyStringOwnerNormalizesToNil(t *testing.T) {
 }
 
 func TestCreateIssue_WithAllInitialState(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	parent := makeIssue(t, ctx, d, p.ID, "parent", "tester")
 
 	owner := "alice"
@@ -226,15 +190,14 @@ func TestCreateIssue_WithAllInitialState(t *testing.T) {
 	assert.Len(t, links, 1)
 
 	// Payload union: labels, links, and owner all present.
-	var payload struct {
+	payload := unmarshalPayload[struct {
 		Labels []string `json:"labels"`
 		Links  []struct {
 			Type     string `json:"type"`
 			ToNumber int64  `json:"to_number"`
 		} `json:"links"`
 		Owner string `json:"owner"`
-	}
-	require.NoError(t, json.Unmarshal([]byte(evt.Payload), &payload))
+	}](t, evt.Payload)
 	assert.Equal(t, []string{"bug", "priority:high"}, payload.Labels)
 	require.Len(t, payload.Links, 1)
 	assert.Equal(t, "parent", payload.Links[0].Type)

--- a/internal/db/queries_delete_test.go
+++ b/internal/db/queries_delete_test.go
@@ -12,14 +12,7 @@ import (
 )
 
 func TestSoftDeleteIssue_SetsDeletedAtAndEmitsEvent(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, _, issue := setupTestIssue(t)
 
 	updated, evt, changed, err := d.SoftDeleteIssue(ctx, issue.ID, "agent")
 	require.NoError(t, err)
@@ -38,16 +31,7 @@ func TestSoftDeleteIssue_SetsDeletedAtAndEmitsEvent(t *testing.T) {
 }
 
 func TestSoftDeleteIssue_AlreadyDeletedIsNoOp(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, _, err = d.SoftDeleteIssue(ctx, issue.ID, "agent")
-	require.NoError(t, err)
+	d, ctx, _, issue := setupSoftDeletedIssue(t)
 
 	updated, evt, changed, err := d.SoftDeleteIssue(ctx, issue.ID, "agent")
 	require.NoError(t, err)
@@ -64,16 +48,7 @@ func TestSoftDeleteIssue_UnknownIssueIsErrNotFound(t *testing.T) {
 }
 
 func TestRestoreIssue_ClearsDeletedAtAndEmitsEvent(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, _, err = d.SoftDeleteIssue(ctx, issue.ID, "agent")
-	require.NoError(t, err)
+	d, ctx, _, issue := setupSoftDeletedIssue(t)
 
 	updated, evt, changed, err := d.RestoreIssue(ctx, issue.ID, "agent")
 	require.NoError(t, err)
@@ -84,14 +59,7 @@ func TestRestoreIssue_ClearsDeletedAtAndEmitsEvent(t *testing.T) {
 }
 
 func TestRestoreIssue_NotDeletedIsNoOp(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, _, issue := setupTestIssue(t)
 
 	_, evt, changed, err := d.RestoreIssue(ctx, issue.ID, "agent")
 	require.NoError(t, err)
@@ -107,14 +75,8 @@ func TestRestoreIssue_UnknownIssueIsErrNotFound(t *testing.T) {
 }
 
 func TestSoftDeleteRestore_RoundTripVisibility(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "round trip", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	issue, _ := createTesterIssue(ctx, t, d, p.ID, "round trip")
 
 	// Initial: visible in default list.
 	listed, err := d.ListIssues(ctx, db.ListIssuesParams{ProjectID: p.ID})
@@ -139,16 +101,7 @@ func TestSoftDeleteRestore_RoundTripVisibility(t *testing.T) {
 }
 
 func TestRestoreIssue_EmitsEventWithPayloadAndRefs(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, _, err = d.SoftDeleteIssue(ctx, issue.ID, "agent")
-	require.NoError(t, err)
+	d, ctx, _, issue := setupSoftDeletedIssue(t)
 
 	updated, evt, changed, err := d.RestoreIssue(ctx, issue.ID, "agent")
 	require.NoError(t, err)
@@ -192,16 +145,12 @@ func TestSoftDeleteIssue_ScopesByIssueID(t *testing.T) {
 func TestPurgeIssue_RemovesAllDependentsAndAudits(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
 	target, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: p.ID, Title: "delete me", Body: "body", Author: "tester",
 	})
 	require.NoError(t, err)
-	keeper, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "keep me", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
+	keeper, _ := createTesterIssue(ctx, t, d, p.ID, "keep me")
 
 	// Add a comment, a label (with event), and a link from keeper → target so
 	// cascade removes a non-trivial set of dependents.
@@ -244,36 +193,27 @@ func TestPurgeIssue_RemovesAllDependentsAndAudits(t *testing.T) {
 	require.NotNil(t, pl.PurgeResetAfterEventID, "events were deleted, reset cursor must be set")
 
 	// Verify rows actually gone.
-	var n int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM issues WHERE id = ?`, target.ID).Scan(&n))
-	assert.Equal(t, 0, n, "issue row removed")
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM comments WHERE issue_id = ?`, target.ID).Scan(&n))
-	assert.Equal(t, 0, n, "comments removed")
-	require.NoError(t, d.QueryRowContext(ctx,
+	assertRowCount(ctx, t, d, 0, "issue row removed",
+		`SELECT count(*) FROM issues WHERE id = ?`, target.ID)
+	assertRowCount(ctx, t, d, 0, "comments removed",
+		`SELECT count(*) FROM comments WHERE issue_id = ?`, target.ID)
+	assertRowCount(ctx, t, d, 0, "links removed",
 		`SELECT count(*) FROM links WHERE from_issue_id = ? OR to_issue_id = ?`,
-		target.ID, target.ID).Scan(&n))
-	assert.Equal(t, 0, n, "links removed")
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM issue_labels WHERE issue_id = ?`, target.ID).Scan(&n))
-	assert.Equal(t, 0, n, "labels removed")
-	require.NoError(t, d.QueryRowContext(ctx,
+		target.ID, target.ID)
+	assertRowCount(ctx, t, d, 0, "labels removed",
+		`SELECT count(*) FROM issue_labels WHERE issue_id = ?`, target.ID)
+	assertRowCount(ctx, t, d, 0, "events removed",
 		`SELECT count(*) FROM events WHERE issue_id = ? OR related_issue_id = ?`,
-		target.ID, target.ID).Scan(&n))
-	assert.Equal(t, 0, n, "events removed")
-
-	// FTS row gone.
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM issues_fts WHERE rowid = ?`, target.ID).Scan(&n))
-	assert.Equal(t, 0, n, "FTS row removed")
+		target.ID, target.ID)
+	assertRowCount(ctx, t, d, 0, "FTS row removed",
+		`SELECT count(*) FROM issues_fts WHERE rowid = ?`, target.ID)
 
 	// keeper's events.created is the only event attributed to keeper that
 	// survives — keeper's issue.linked was deleted because related_issue_id
 	// pointed to target.
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM events WHERE issue_id = ?`, keeper.ID).Scan(&n))
-	assert.Equal(t, 1, n, "keeper's issue.created survives; its issue.linked was cascade-deleted via related_issue_id")
+	assertRowCount(ctx, t, d, 1,
+		"keeper's issue.created survives; its issue.linked was cascade-deleted via related_issue_id",
+		`SELECT count(*) FROM events WHERE issue_id = ?`, keeper.ID)
 }
 
 func TestPurgeIssue_NoEventsLeavesResetCursorNull(t *testing.T) {
@@ -281,10 +221,7 @@ func TestPurgeIssue_NoEventsLeavesResetCursorNull(t *testing.T) {
 	// bypass CreateIssue's automatic issue.created event. Verify that
 	// PurgeIssue sees zero attached events and leaves PurgeResetAfterEventID
 	// as nil (no SSE cursor reservation needed).
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	issueUID, err := uid.New()
 	require.NoError(t, err)
 	res, err := d.ExecContext(ctx,
@@ -303,14 +240,7 @@ func TestPurgeIssue_NoEventsLeavesResetCursorNull(t *testing.T) {
 }
 
 func TestPurgeIssue_ReservesSqliteSequenceAboveMaxEventID(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	target, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p, target := setupTestIssue(t)
 	// Capture max events.id BEFORE purge.
 	var maxBefore int64
 	require.NoError(t, d.QueryRowContext(ctx,
@@ -341,14 +271,7 @@ func TestPurgeIssue_UnknownIssueIsErrNotFound(t *testing.T) {
 func TestPurgeIssue_PersistsReason(t *testing.T) {
 	// Reason threads through to purge_log.reason and round-trips on the
 	// returned PurgeLog. Catches argument-order regressions in the INSERT.
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	target, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, _, target := setupTestIssue(t)
 
 	reason := "ops cleanup"
 	pl, err := d.PurgeIssue(ctx, target.ID, "agent", &reason)
@@ -362,24 +285,13 @@ func TestPurgeIssue_OnSoftDeletedIssue(t *testing.T) {
 	// ladder is delete → purge, not delete-XOR-purge. lookupIssueIncludingDeleted
 	// is the right primitive; this test pins the contract so a future swap
 	// to a deleted-filtering lookup would fail loudly.
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	target, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "delete-then-purge", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, _, err = d.SoftDeleteIssue(ctx, target.ID, "agent")
-	require.NoError(t, err)
+	d, ctx, _, target := setupSoftDeletedIssue(t)
 
 	pl, err := d.PurgeIssue(ctx, target.ID, "agent", nil)
 	require.NoError(t, err)
 	assert.Equal(t, target.ID, pl.PurgedIssueID)
 
 	// Row is gone from issues.
-	var n int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM issues WHERE id = ?`, target.ID).Scan(&n))
-	assert.Equal(t, 0, n, "issue row removed even though it was soft-deleted first")
+	assertRowCount(ctx, t, d, 0, "issue row removed even though it was soft-deleted first",
+		`SELECT count(*) FROM issues WHERE id = ?`, target.ID)
 }

--- a/internal/db/queries_events_test.go
+++ b/internal/db/queries_events_test.go
@@ -19,14 +19,8 @@ func TestMaxEventID_EmptyTable(t *testing.T) {
 func TestMaxEventID_AfterInserts(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/test/a", "a")
-	require.NoError(t, err)
-	for i := 0; i < 3; i++ {
-		_, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-			ProjectID: p.ID, Title: "t", Body: "", Author: "tester",
-		})
-		require.NoError(t, err)
-	}
+	p := createProject(ctx, t, d, "github.com/test/a", "a")
+	createTesterIssues(ctx, t, d, p.ID, 3)
 	got, err := d.MaxEventID(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), got, "three issue.created events → highest event id is 3")
@@ -35,14 +29,10 @@ func TestMaxEventID_AfterInserts(t *testing.T) {
 func TestEventsAfter_CrossProject(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	pa, err := d.CreateProject(ctx, "github.com/test/a", "a")
-	require.NoError(t, err)
-	pb, err := d.CreateProject(ctx, "github.com/test/b", "b")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: pa.ID, Title: "a1", Author: "tester"})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: pb.ID, Title: "b1", Author: "tester"})
-	require.NoError(t, err)
+	pa := createProject(ctx, t, d, "github.com/test/a", "a")
+	pb := createProject(ctx, t, d, "github.com/test/b", "b")
+	createTesterIssue(ctx, t, d, pa.ID, "a1")
+	createTesterIssue(ctx, t, d, pb.ID, "b1")
 
 	all, err := d.EventsAfter(ctx, db.EventsAfterParams{AfterID: 0, Limit: 100})
 	require.NoError(t, err)
@@ -54,14 +44,10 @@ func TestEventsAfter_CrossProject(t *testing.T) {
 func TestEventsAfter_PerProjectFilter(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	pa, err := d.CreateProject(ctx, "github.com/test/a", "a")
-	require.NoError(t, err)
-	pb, err := d.CreateProject(ctx, "github.com/test/b", "b")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: pa.ID, Title: "a1", Author: "tester"})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: pb.ID, Title: "b1", Author: "tester"})
-	require.NoError(t, err)
+	pa := createProject(ctx, t, d, "github.com/test/a", "a")
+	pb := createProject(ctx, t, d, "github.com/test/b", "b")
+	createTesterIssue(ctx, t, d, pa.ID, "a1")
+	createTesterIssue(ctx, t, d, pb.ID, "b1")
 
 	onlyA, err := d.EventsAfter(ctx, db.EventsAfterParams{AfterID: 0, ProjectID: pa.ID, Limit: 100})
 	require.NoError(t, err)
@@ -72,12 +58,8 @@ func TestEventsAfter_PerProjectFilter(t *testing.T) {
 func TestEventsAfter_RespectsThroughID(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/test/a", "a")
-	require.NoError(t, err)
-	for i := 0; i < 5; i++ {
-		_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "tester"})
-		require.NoError(t, err)
-	}
+	p := createProject(ctx, t, d, "github.com/test/a", "a")
+	createTesterIssues(ctx, t, d, p.ID, 5)
 	got, err := d.EventsAfter(ctx, db.EventsAfterParams{AfterID: 0, ThroughID: 3, Limit: 100})
 	require.NoError(t, err)
 	require.Len(t, got, 3)
@@ -87,12 +69,8 @@ func TestEventsAfter_RespectsThroughID(t *testing.T) {
 func TestEventsAfter_RespectsLimit(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/test/a", "a")
-	require.NoError(t, err)
-	for i := 0; i < 5; i++ {
-		_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "tester"})
-		require.NoError(t, err)
-	}
+	p := createProject(ctx, t, d, "github.com/test/a", "a")
+	createTesterIssues(ctx, t, d, p.ID, 5)
 	got, err := d.EventsAfter(ctx, db.EventsAfterParams{AfterID: 0, Limit: 2})
 	require.NoError(t, err)
 	assert.Len(t, got, 2)
@@ -101,12 +79,8 @@ func TestEventsAfter_RespectsLimit(t *testing.T) {
 func TestEventsAfter_StrictlyAfterNonZeroID(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/test/a", "a")
-	require.NoError(t, err)
-	for i := 0; i < 5; i++ {
-		_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "tester"})
-		require.NoError(t, err)
-	}
+	p := createProject(ctx, t, d, "github.com/test/a", "a")
+	createTesterIssues(ctx, t, d, p.ID, 5)
 	// Five issue.created events with ids 1..5. AfterID=3 must return ids 4, 5
 	// (strict >); AfterID=5 must return zero rows.
 	got, err := d.EventsAfter(ctx, db.EventsAfterParams{AfterID: 3, Limit: 100})
@@ -130,11 +104,9 @@ func TestPurgeResetCheck_NoPurges(t *testing.T) {
 func TestPurgeResetCheck_AfterPurgeWithEvents(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/test/a", "a")
-	require.NoError(t, err)
-	is, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "doomed", Author: "tester"})
-	require.NoError(t, err)
-	_, err = d.PurgeIssue(ctx, is.ID, "tester", nil)
+	p := createProject(ctx, t, d, "github.com/test/a", "a")
+	is, _ := createTesterIssue(ctx, t, d, p.ID, "doomed")
+	_, err := d.PurgeIssue(ctx, is.ID, "tester", nil)
 	require.NoError(t, err)
 
 	// cursor below the reset → returns the reset cursor
@@ -151,13 +123,10 @@ func TestPurgeResetCheck_AfterPurgeWithEvents(t *testing.T) {
 func TestPurgeResetCheck_PerProject(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	pa, err := d.CreateProject(ctx, "github.com/test/a", "a")
-	require.NoError(t, err)
-	pb, err := d.CreateProject(ctx, "github.com/test/b", "b")
-	require.NoError(t, err)
-	is, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: pa.ID, Title: "doomed", Author: "tester"})
-	require.NoError(t, err)
-	_, err = d.PurgeIssue(ctx, is.ID, "tester", nil)
+	pa := createProject(ctx, t, d, "github.com/test/a", "a")
+	pb := createProject(ctx, t, d, "github.com/test/b", "b")
+	is, _ := createTesterIssue(ctx, t, d, pa.ID, "doomed")
+	_, err := d.PurgeIssue(ctx, is.ID, "tester", nil)
 	require.NoError(t, err)
 
 	// per-project filter: a purge in A is invisible to a B-scoped subscriber

--- a/internal/db/queries_idempotency_test.go
+++ b/internal/db/queries_idempotency_test.go
@@ -87,27 +87,13 @@ func TestFingerprint_Vector(t *testing.T) {
 		"filled fingerprint must not drift")
 }
 
-func strPtr(s string) *string { return &s }
-
 func TestLookupIdempotency_ReturnsMatchWithinWindow(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-
 	// Hand-write an issue.created event with idempotency_key + fingerprint
 	// in the payload so we test LookupIdempotency in isolation from the
 	// CreateIssue extension landing in Task 9.
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p, issue := setupTestIssue(t)
 	fp := "abc123"
-	_, err = d.ExecContext(ctx,
-		`UPDATE events
-		 SET payload = json_set(payload, '$.idempotency_key', 'K1', '$.idempotency_fingerprint', ?)
-		 WHERE issue_id = ? AND type = 'issue.created'`, fp, issue.ID)
-	require.NoError(t, err)
+	injectIdempotencyKey(ctx, t, d, issue.ID, "K1", fp)
 
 	since := time.Now().Add(-1 * time.Hour)
 	got, err := d.LookupIdempotency(ctx, p.ID, "K1", since)
@@ -120,19 +106,8 @@ func TestLookupIdempotency_ReturnsMatchWithinWindow(t *testing.T) {
 }
 
 func TestLookupIdempotency_OutsideWindowIsNil(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = d.ExecContext(ctx,
-		`UPDATE events
-		 SET payload = json_set(payload, '$.idempotency_key', 'K1', '$.idempotency_fingerprint', 'fp')
-		 WHERE issue_id = ?`, issue.ID)
-	require.NoError(t, err)
+	d, ctx, p, issue := setupTestIssue(t)
+	injectIdempotencyKey(ctx, t, d, issue.ID, "K1", "fp")
 
 	// Window starts in the future — every existing event is "outside".
 	future := time.Now().Add(1 * time.Hour)
@@ -142,10 +117,7 @@ func TestLookupIdempotency_OutsideWindowIsNil(t *testing.T) {
 }
 
 func TestLookupIdempotency_DifferentKeyIsNil(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	got, err := d.LookupIdempotency(ctx, p.ID, "no-such-key", time.Now().Add(-1*time.Hour))
 	require.NoError(t, err)
 	assert.Nil(t, got)
@@ -154,19 +126,10 @@ func TestLookupIdempotency_DifferentKeyIsNil(t *testing.T) {
 func TestLookupIdempotency_DifferentProjectIsNil(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p1, err := d.CreateProject(ctx, "p1", "p1")
-	require.NoError(t, err)
-	p2, err := d.CreateProject(ctx, "p2", "p2")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p1.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = d.ExecContext(ctx,
-		`UPDATE events
-		 SET payload = json_set(payload, '$.idempotency_key', 'K1', '$.idempotency_fingerprint', 'fp')
-		 WHERE issue_id = ?`, issue.ID)
-	require.NoError(t, err)
+	p1 := createProject(ctx, t, d, "p1", "p1")
+	p2 := createProject(ctx, t, d, "p2", "p2")
+	issue, _ := createTesterIssue(ctx, t, d, p1.ID, "x")
+	injectIdempotencyKey(ctx, t, d, issue.ID, "K1", "fp")
 
 	got, err := d.LookupIdempotency(ctx, p2.ID, "K1", time.Now().Add(-1*time.Hour))
 	require.NoError(t, err)
@@ -178,14 +141,7 @@ func TestLookupIdempotency_DifferentProjectIsNil(t *testing.T) {
 // returned. The partial index already enforces this; the SQL WHERE clause
 // reinforces it. This test locks both layers.
 func TestLookupIdempotency_OnlyIssueCreatedEvents(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "x", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p, issue := setupTestIssue(t)
 	// Stamp the idempotency_key onto a NON-issue.created row by inserting a
 	// fake issue.edited event. The partial index excludes this row by type;
 	// the WHERE e.type = 'issue.created' clause reinforces.

--- a/internal/db/queries_issues_test.go
+++ b/internal/db/queries_issues_test.go
@@ -1,7 +1,6 @@
 package db_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,9 +9,7 @@ import (
 )
 
 func TestCreateIssue_AllocatesNumberAndEmitsEvent(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
+	d, ctx, p := setupTestProject(t)
 
 	issue, evt, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: p.ID,
@@ -40,9 +37,7 @@ func TestCreateIssue_AllocatesNumberAndEmitsEvent(t *testing.T) {
 }
 
 func TestCreateIssue_NumbersAreSequentialPerProject(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
+	d, ctx, p := setupTestProject(t)
 
 	for i := 1; i <= 3; i++ {
 		issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
@@ -54,22 +49,15 @@ func TestCreateIssue_NumbersAreSequentialPerProject(t *testing.T) {
 }
 
 func TestGetIssueByNumber_NotFound(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
+	d, ctx, p := setupTestProject(t)
 	_, err := d.IssueByNumber(ctx, p.ID, 99)
 	assert.ErrorIs(t, err, db.ErrNotFound)
 }
 
 func TestListIssues_DefaultsToOpenOnlyAndExcludesDeleted(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
+	d, ctx, p := setupTestProject(t)
 	for _, title := range []string{"a", "b", "c"} {
-		_, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-			ProjectID: p.ID, Title: title, Author: "x",
-		})
-		require.NoError(t, err)
+		createTesterIssue(ctx, t, d, p.ID, title)
 	}
 
 	got, err := d.ListIssues(ctx, db.ListIssuesParams{ProjectID: p.ID, Status: "open"})
@@ -81,19 +69,12 @@ func TestListIssues_DefaultsToOpenOnlyAndExcludesDeleted(t *testing.T) {
 // ProjectID==0 every project's issues are returned, soft-deleted rows are
 // excluded, and the ordering is created_at DESC, id DESC.
 func TestListAllIssues_CoversAllProjectsAndOrders(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p1, err := d.CreateProject(ctx, "alpha", "alpha")
-	require.NoError(t, err)
-	p2, err := d.CreateProject(ctx, "beta", "beta")
-	require.NoError(t, err)
+	d, ctx, p1 := setupTestProject(t)
+	p2 := createProject(ctx, t, d, "beta", "beta")
 
-	a1, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p1.ID, Title: "alpha-1", Author: "x"})
-	require.NoError(t, err)
-	b1, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p2.ID, Title: "beta-1", Author: "x"})
-	require.NoError(t, err)
-	a2, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p1.ID, Title: "alpha-2", Author: "x"})
-	require.NoError(t, err)
+	a1, _ := createTesterIssue(ctx, t, d, p1.ID, "alpha-1")
+	b1, _ := createTesterIssue(ctx, t, d, p2.ID, "beta-1")
+	a2, _ := createTesterIssue(ctx, t, d, p1.ID, "alpha-2")
 
 	got, err := d.ListAllIssues(ctx, db.ListAllIssuesParams{})
 	require.NoError(t, err)
@@ -109,16 +90,10 @@ func TestListAllIssues_CoversAllProjectsAndOrders(t *testing.T) {
 // TestListAllIssues_ProjectFilterScopes pins the optional project_id query:
 // passing ProjectID>0 returns only that project's issues.
 func TestListAllIssues_ProjectFilterScopes(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p1, err := d.CreateProject(ctx, "alpha", "alpha")
-	require.NoError(t, err)
-	p2, err := d.CreateProject(ctx, "beta", "beta")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p1.ID, Title: "a1", Author: "x"})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p2.ID, Title: "b1", Author: "x"})
-	require.NoError(t, err)
+	d, ctx, p1 := setupTestProject(t)
+	p2 := createProject(ctx, t, d, "beta", "beta")
+	createTesterIssue(ctx, t, d, p1.ID, "a1")
+	createTesterIssue(ctx, t, d, p2.ID, "b1")
 
 	got, err := d.ListAllIssues(ctx, db.ListAllIssuesParams{ProjectID: p2.ID})
 	require.NoError(t, err)
@@ -129,15 +104,10 @@ func TestListAllIssues_ProjectFilterScopes(t *testing.T) {
 // TestListAllIssues_StatusFilterApplies pins the status filter across
 // projects: closed/open are honored.
 func TestListAllIssues_StatusFilterApplies(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	open1, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "open", Author: "x"})
-	require.NoError(t, err)
-	closed1, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "to-close", Author: "x"})
-	require.NoError(t, err)
-	_, _, _, err = d.CloseIssue(ctx, closed1.ID, "done", "x")
+	d, ctx, p := setupTestProject(t)
+	open1, _ := createTesterIssue(ctx, t, d, p.ID, "open")
+	closed1, _ := createTesterIssue(ctx, t, d, p.ID, "to-close")
+	_, _, _, err := d.CloseIssue(ctx, closed1.ID, "done", "x")
 	require.NoError(t, err)
 
 	got, err := d.ListAllIssues(ctx, db.ListAllIssuesParams{Status: "open"})
@@ -149,15 +119,10 @@ func TestListAllIssues_StatusFilterApplies(t *testing.T) {
 // TestListAllIssues_ExcludesSoftDeleted pins that purged/soft-deleted issues
 // don't surface in the cross-project list.
 func TestListAllIssues_ExcludesSoftDeleted(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	live, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "live", Author: "x"})
-	require.NoError(t, err)
-	doomed, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "doomed", Author: "x"})
-	require.NoError(t, err)
-	_, _, _, err = d.SoftDeleteIssue(ctx, doomed.ID, "x")
+	d, ctx, p := setupTestProject(t)
+	live, _ := createTesterIssue(ctx, t, d, p.ID, "live")
+	doomed, _ := createTesterIssue(ctx, t, d, p.ID, "doomed")
+	_, _, _, err := d.SoftDeleteIssue(ctx, doomed.ID, "x")
 	require.NoError(t, err)
 
 	got, err := d.ListAllIssues(ctx, db.ListAllIssuesParams{})
@@ -168,14 +133,8 @@ func TestListAllIssues_ExcludesSoftDeleted(t *testing.T) {
 
 // TestListAllIssues_LimitCaps pins the limit knob on cross-project listing.
 func TestListAllIssues_LimitCaps(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	for i := 0; i < 5; i++ {
-		_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "i", Author: "x"})
-		require.NoError(t, err)
-	}
+	d, ctx, p := setupTestProject(t)
+	createTesterIssues(ctx, t, d, p.ID, 5)
 
 	got, err := d.ListAllIssues(ctx, db.ListAllIssuesParams{Limit: 2})
 	require.NoError(t, err)
@@ -183,10 +142,7 @@ func TestListAllIssues_LimitCaps(t *testing.T) {
 }
 
 func TestCreateComment_EmitsEvent(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
-	issue, _, _ := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "x"})
+	d, ctx, p, issue := setupTestIssue(t)
 
 	cmt, evt, err := d.CreateComment(ctx, db.CreateCommentParams{
 		IssueID: issue.ID, Author: "agent", Body: "hi",
@@ -200,10 +156,7 @@ func TestCreateComment_EmitsEvent(t *testing.T) {
 }
 
 func TestCloseIssue_SetsStatusAndEmitsEvent(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
-	issue, _, _ := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "x"})
+	d, ctx, _, issue := setupTestIssue(t)
 
 	updated, evt, changed, err := d.CloseIssue(ctx, issue.ID, "done", "agent")
 	require.NoError(t, err)
@@ -216,10 +169,7 @@ func TestCloseIssue_SetsStatusAndEmitsEvent(t *testing.T) {
 }
 
 func TestCloseIssue_OnAlreadyClosedIsNoOp(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
-	issue, _, _ := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "x"})
+	d, ctx, _, issue := setupTestIssue(t)
 	_, _, _, err := d.CloseIssue(ctx, issue.ID, "done", "agent")
 	require.NoError(t, err)
 
@@ -230,11 +180,9 @@ func TestCloseIssue_OnAlreadyClosedIsNoOp(t *testing.T) {
 }
 
 func TestReopenIssue_ClearsStatusAndEmitsEvent(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
-	issue, _, _ := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "x"})
-	_, _, _, _ = d.CloseIssue(ctx, issue.ID, "done", "agent")
+	d, ctx, _, issue := setupTestIssue(t)
+	_, _, _, err := d.CloseIssue(ctx, issue.ID, "done", "agent")
+	require.NoError(t, err)
 
 	updated, evt, changed, err := d.ReopenIssue(ctx, issue.ID, "agent")
 	require.NoError(t, err)
@@ -246,10 +194,7 @@ func TestReopenIssue_ClearsStatusAndEmitsEvent(t *testing.T) {
 }
 
 func TestEditIssue_SetsFieldsAndEmitsEvent(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
-	issue, _, _ := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "old", Body: "ob", Author: "x"})
+	d, ctx, _, issue := setupTestIssue(t)
 
 	newTitle := "new"
 	updated, evt, changed, err := d.EditIssue(ctx, db.EditIssueParams{
@@ -263,10 +208,7 @@ func TestEditIssue_SetsFieldsAndEmitsEvent(t *testing.T) {
 }
 
 func TestEditIssue_NoFieldsIsValidationError(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
-	issue, _, _ := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "x"})
+	d, ctx, _, issue := setupTestIssue(t)
 
 	_, _, _, err := d.EditIssue(ctx, db.EditIssueParams{IssueID: issue.ID, Actor: "agent"})
 	assert.ErrorIs(t, err, db.ErrNoFields)

--- a/internal/db/queries_labels_by_issues_test.go
+++ b/internal/db/queries_labels_by_issues_test.go
@@ -1,7 +1,6 @@
 package db_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,10 +12,7 @@ import (
 // map without a SQL roundtrip. The daemon's list handler relies on
 // this so an empty list page doesn't waste a query.
 func TestLabelsByIssues_EmptyInput_ReturnsEmptyMap(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	got, err := d.LabelsByIssues(ctx, p.ID, nil)
 	require.NoError(t, err)
@@ -34,18 +30,10 @@ func TestLabelsByIssues_EmptyInput_ReturnsEmptyMap(t *testing.T) {
 // querying project B returns no labels for that ID. issue_labels has
 // no project_id column, so the constraint runs through the JOIN.
 func TestLabelsByIssues_ConstrainedByProjectID(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	pa, err := d.CreateProject(ctx, "a", "a")
-	require.NoError(t, err)
-	pb, err := d.CreateProject(ctx, "b", "b")
-	require.NoError(t, err)
-	ia := makeIssue(t, ctx, d, pa.ID, "a", "tester")
-	ib := makeIssue(t, ctx, d, pb.ID, "b", "tester")
-	_, err = d.AddLabel(ctx, ia.ID, "bug", "tester")
-	require.NoError(t, err)
-	_, err = d.AddLabel(ctx, ib.ID, "feature", "tester")
-	require.NoError(t, err)
+	d, ctx, pa := setupTestProject(t)
+	pb := createProject(ctx, t, d, "b", "b")
+	ia := makeIssueWithLabels(t, ctx, d, pa.ID, "a", "tester", "bug")
+	ib := makeIssueWithLabels(t, ctx, d, pb.ID, "b", "tester", "feature")
 
 	// Query project A with both issue IDs; only ia's labels return.
 	got, err := d.LabelsByIssues(ctx, pa.ID, []int64{ia.ID, ib.ID})
@@ -58,16 +46,8 @@ func TestLabelsByIssues_ConstrainedByProjectID(t *testing.T) {
 // alphabetical sort. Insertion order is intentionally non-alphabetical
 // so the assertion would fail if ORDER BY were dropped.
 func TestLabelsByIssues_OrdersByIssueThenLabel(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
-
-	for _, lbl := range []string{"prio-1", "bug", "needs-review"} {
-		_, err := d.AddLabel(ctx, i.ID, lbl, "tester")
-		require.NoError(t, err)
-	}
+	d, ctx, p := setupTestProject(t)
+	i := makeIssueWithLabels(t, ctx, d, p.ID, "a", "tester", "prio-1", "bug", "needs-review")
 
 	got, err := d.LabelsByIssues(ctx, p.ID, []int64{i.ID})
 	require.NoError(t, err)
@@ -78,25 +58,10 @@ func TestLabelsByIssues_OrdersByIssueThenLabel(t *testing.T) {
 // across multiple issues with overlapping and disjoint labels: each
 // issue's slice is independently sorted and only contains its own labels.
 func TestLabelsByIssues_MultiIssue_HappyPath(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i1 := makeIssue(t, ctx, d, p.ID, "a", "tester")
-	i2 := makeIssue(t, ctx, d, p.ID, "b", "tester")
-	i3 := makeIssue(t, ctx, d, p.ID, "c", "tester")
-
-	add := func(issueID int64, label string) {
-		_, err := d.AddLabel(ctx, issueID, label, "tester")
-		require.NoError(t, err)
-	}
-	add(i1.ID, "bug")
-	add(i1.ID, "prio-1")
-	add(i2.ID, "feature")
-	add(i2.ID, "needs-review")
-	add(i2.ID, "bug")
-	add(i3.ID, "prio-1")
-	add(i3.ID, "wontfix")
+	d, ctx, p := setupTestProject(t)
+	i1 := makeIssueWithLabels(t, ctx, d, p.ID, "a", "tester", "bug", "prio-1")
+	i2 := makeIssueWithLabels(t, ctx, d, p.ID, "b", "tester", "feature", "needs-review", "bug")
+	i3 := makeIssueWithLabels(t, ctx, d, p.ID, "c", "tester", "prio-1", "wontfix")
 
 	got, err := d.LabelsByIssues(ctx, p.ID, []int64{i1.ID, i2.ID, i3.ID})
 	require.NoError(t, err)
@@ -113,17 +78,12 @@ func TestLabelsByIssues_MultiIssue_HappyPath(t *testing.T) {
 // because the IN clause exceeded the bound-parameter cap. The function
 // now chunks the IN clause into groups of <=500 IDs and merges results.
 func TestLabelsByIssues_LargeBatch_ChunksUnderSQLiteLimit(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	const n = 1500
 	ids := make([]int64, 0, n)
 	for i := 0; i < n; i++ {
-		issue := makeIssue(t, ctx, d, p.ID, "i", "tester")
-		_, err := d.AddLabel(ctx, issue.ID, "bug", "tester")
-		require.NoError(t, err)
+		issue := makeIssueWithLabels(t, ctx, d, p.ID, "i", "tester", "bug")
 		ids = append(ids, issue.ID)
 	}
 
@@ -140,14 +100,9 @@ func TestLabelsByIssues_LargeBatch_ChunksUnderSQLiteLimit(t *testing.T) {
 // missing key as "no labels"; this prevents allocation noise on the
 // common case where most issues are unlabeled.
 func TestLabelsByIssues_IssueWithNoLabelsAbsent(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i1 := makeIssue(t, ctx, d, p.ID, "labeled", "tester")
+	d, ctx, p := setupTestProject(t)
+	i1 := makeIssueWithLabels(t, ctx, d, p.ID, "labeled", "tester", "bug")
 	i2 := makeIssue(t, ctx, d, p.ID, "naked", "tester")
-	_, err = d.AddLabel(ctx, i1.ID, "bug", "tester")
-	require.NoError(t, err)
 
 	got, err := d.LabelsByIssues(ctx, p.ID, []int64{i1.ID, i2.ID})
 	require.NoError(t, err)

--- a/internal/db/queries_labels_test.go
+++ b/internal/db/queries_labels_test.go
@@ -1,7 +1,6 @@
 package db_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -11,11 +10,7 @@ import (
 )
 
 func TestAddLabel_RoundTrips(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
+	d, ctx, _, i := setupTestIssue(t)
 
 	row, err := d.AddLabel(ctx, i.ID, "needs-review", "tester")
 	require.NoError(t, err)
@@ -29,24 +24,16 @@ func TestAddLabel_RoundTrips(t *testing.T) {
 }
 
 func TestAddLabel_DuplicateIsErrLabelExists(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
+	d, ctx, _, i := setupTestIssue(t)
 
-	_, err = d.AddLabel(ctx, i.ID, "bug", "tester")
+	_, err := d.AddLabel(ctx, i.ID, "bug", "tester")
 	require.NoError(t, err)
 	_, err = d.AddLabel(ctx, i.ID, "bug", "tester")
 	assert.True(t, errors.Is(err, db.ErrLabelExists), "got %v", err)
 }
 
 func TestAddLabel_RejectsBadCharset(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
+	d, ctx, _, i := setupTestIssue(t)
 
 	for _, label := range []string{"UPPER", "with space", "emoji😀", "" /* empty */, "exclam!"} {
 		_, err := d.AddLabel(ctx, i.ID, label, "tester")
@@ -56,11 +43,7 @@ func TestAddLabel_RejectsBadCharset(t *testing.T) {
 }
 
 func TestAddLabel_AcceptsAllAllowedChars(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
+	d, ctx, _, i := setupTestIssue(t)
 
 	for _, label := range []string{"bug", "priority:high", "v1.0", "needs-review", "a-z_0-9"} {
 		_, err := d.AddLabel(ctx, i.ID, label, "tester")
@@ -69,12 +52,8 @@ func TestAddLabel_AcceptsAllAllowedChars(t *testing.T) {
 }
 
 func TestRemoveLabel_RoundTrips(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
-	_, err = d.AddLabel(ctx, i.ID, "bug", "tester")
+	d, ctx, _, i := setupTestIssue(t)
+	_, err := d.AddLabel(ctx, i.ID, "bug", "tester")
 	require.NoError(t, err)
 
 	require.NoError(t, d.RemoveLabel(ctx, i.ID, "bug"))
@@ -89,24 +68,16 @@ func TestRemoveLabel_RoundTrips(t *testing.T) {
 }
 
 func TestAddLabel_BlankAuthorIsNotMisreportedAsInvalidLabel(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
+	d, ctx, _, i := setupTestIssue(t)
 
-	_, err = d.AddLabel(ctx, i.ID, "bug", "" /* blank */)
+	_, err := d.AddLabel(ctx, i.ID, "bug", "" /* blank */)
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, db.ErrLabelInvalid),
 		"blank author must not surface as ErrLabelInvalid, got %v", err)
 }
 
 func TestLabelByEndpoints_FindsExisting(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
+	d, ctx, _, i := setupTestIssue(t)
 
 	created, err := d.AddLabel(ctx, i.ID, "bug", "tester")
 	require.NoError(t, err)
@@ -121,18 +92,11 @@ func TestLabelByEndpoints_FindsExisting(t *testing.T) {
 }
 
 func TestLabelCounts_AggregatesPerProject(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	a := makeIssue(t, ctx, d, p.ID, "a", "tester")
 	b := makeIssue(t, ctx, d, p.ID, "b", "tester")
-	for _, lab := range []string{"bug", "priority:high"} {
-		_, err := d.AddLabel(ctx, a.ID, lab, "tester")
-		require.NoError(t, err)
-	}
-	_, err = d.AddLabel(ctx, b.ID, "bug", "tester")
-	require.NoError(t, err)
+	addLabels(ctx, t, d, a.ID, "tester", "bug", "priority:high")
+	addLabels(ctx, t, d, b.ID, "tester", "bug")
 
 	counts, err := d.LabelCounts(ctx, p.ID)
 	require.NoError(t, err)

--- a/internal/db/queries_links_test.go
+++ b/internal/db/queries_links_test.go
@@ -10,35 +10,14 @@ import (
 	"github.com/wesm/kata/internal/db"
 )
 
-// makeIssue is a helper that creates an issue under projectID. It returns the
-// created issue.
-//
-//nolint:revive // test helper: t *testing.T conventionally precedes ctx.
-func makeIssue(t *testing.T, ctx context.Context, d *db.DB, projectID int64, title, author string) db.Issue {
-	t.Helper()
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: projectID, Title: title, Author: author,
-	})
-	require.NoError(t, err)
-	return issue
-}
-
 func TestCreateLink_RoundTrips(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
 	a := makeIssue(t, ctx, d, p.ID, "child", "tester")
 	b := makeIssue(t, ctx, d, p.ID, "parent", "tester")
 
-	link, err := d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID:   p.ID,
-		FromIssueID: a.ID,
-		ToIssueID:   b.ID,
-		Type:        "parent",
-		Author:      "tester",
-	})
-	require.NoError(t, err)
+	link := makeLink(ctx, t, d, p.ID, a.ID, b.ID, "parent")
 	assert.Greater(t, link.ID, int64(0))
 	assert.Equal(t, "parent", link.Type)
 	assert.Equal(t, a.ID, link.FromIssueID)
@@ -54,24 +33,18 @@ func TestCreateLink_RoundTrips(t *testing.T) {
 }
 
 func TestLinksRejectMismatchedUIDCache(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	a := makeIssue(t, ctx, d, p.ID, "a", "tester")
 	b := makeIssue(t, ctx, d, p.ID, "b", "tester")
 
-	_, err = d.ExecContext(ctx,
+	_, err := d.ExecContext(ctx,
 		`INSERT INTO links(project_id, from_issue_id, to_issue_id, from_issue_uid, to_issue_uid, type, author)
 		 VALUES(?, ?, ?, ?, ?, 'blocks', 'tester')`,
 		p.ID, a.ID, b.ID, b.UID, b.UID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "from_issue_uid does not match from_issue_id")
 
-	link, err := d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: a.ID, ToIssueID: b.ID, Type: "blocks", Author: "tester",
-	})
-	require.NoError(t, err)
+	link := makeLink(ctx, t, d, p.ID, a.ID, b.ID, "blocks")
 	_, err = d.ExecContext(ctx,
 		`UPDATE links SET to_issue_uid = ? WHERE id = ?`, a.UID, link.ID)
 	require.Error(t, err)
@@ -81,16 +54,12 @@ func TestLinksRejectMismatchedUIDCache(t *testing.T) {
 func TestCreateLink_DuplicateIsErrLinkExists(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
 	a := makeIssue(t, ctx, d, p.ID, "a", "tester")
 	b := makeIssue(t, ctx, d, p.ID, "b", "tester")
 
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: a.ID, ToIssueID: b.ID, Type: "blocks", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
+	makeLink(ctx, t, d, p.ID, a.ID, b.ID, "blocks")
+	_, err := d.CreateLink(ctx, db.CreateLinkParams{
 		ProjectID: p.ID, FromIssueID: a.ID, ToIssueID: b.ID, Type: "blocks", Author: "tester",
 	})
 	assert.True(t, errors.Is(err, db.ErrLinkExists), "expected ErrLinkExists, got %v", err)
@@ -99,17 +68,13 @@ func TestCreateLink_DuplicateIsErrLinkExists(t *testing.T) {
 func TestCreateLink_SecondParentIsErrParentAlreadySet(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
 	child := makeIssue(t, ctx, d, p.ID, "child", "tester")
 	p1 := makeIssue(t, ctx, d, p.ID, "p1", "tester")
 	p2 := makeIssue(t, ctx, d, p.ID, "p2", "tester")
 
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: child.ID, ToIssueID: p1.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
+	makeLink(ctx, t, d, p.ID, child.ID, p1.ID, "parent")
+	_, err := d.CreateLink(ctx, db.CreateLinkParams{
 		ProjectID: p.ID, FromIssueID: child.ID, ToIssueID: p2.ID, Type: "parent", Author: "tester",
 	})
 	assert.True(t, errors.Is(err, db.ErrParentAlreadySet),
@@ -117,22 +82,16 @@ func TestCreateLink_SecondParentIsErrParentAlreadySet(t *testing.T) {
 }
 
 func TestCreateLink_ExactDuplicateParentIsErrLinkExists(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	child := makeIssue(t, ctx, d, p.ID, "child", "tester")
 	parent := makeIssue(t, ctx, d, p.ID, "parent", "tester")
 
 	// First insert succeeds.
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: child.ID, ToIssueID: parent.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
+	makeLink(ctx, t, d, p.ID, child.ID, parent.ID, "parent")
 
 	// Re-inserting the exact same triple is "already linked" (idempotent
 	// no-op), not "different parent set". Must be ErrLinkExists.
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
+	_, err := d.CreateLink(ctx, db.CreateLinkParams{
 		ProjectID: p.ID, FromIssueID: child.ID, ToIssueID: parent.ID, Type: "parent", Author: "tester",
 	})
 	assert.True(t, errors.Is(err, db.ErrLinkExists),
@@ -142,14 +101,12 @@ func TestCreateLink_ExactDuplicateParentIsErrLinkExists(t *testing.T) {
 func TestCreateLink_CrossProjectIsErrCrossProject(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p1, err := d.CreateProject(ctx, "p1", "p1")
-	require.NoError(t, err)
-	p2, err := d.CreateProject(ctx, "p2", "p2")
-	require.NoError(t, err)
+	p1 := createProject(ctx, t, d, "p1", "p1")
+	p2 := createProject(ctx, t, d, "p2", "p2")
 	a := makeIssue(t, ctx, d, p1.ID, "a", "tester")
 	b := makeIssue(t, ctx, d, p2.ID, "b", "tester")
 
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
+	_, err := d.CreateLink(ctx, db.CreateLinkParams{
 		ProjectID: p1.ID, FromIssueID: a.ID, ToIssueID: b.ID, Type: "blocks", Author: "tester",
 	})
 	require.Error(t, err)
@@ -158,13 +115,10 @@ func TestCreateLink_CrossProjectIsErrCrossProject(t *testing.T) {
 }
 
 func TestCreateLink_SelfLinkIsError(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	a := makeIssue(t, ctx, d, p.ID, "a", "tester")
 
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
+	_, err := d.CreateLink(ctx, db.CreateLinkParams{
 		ProjectID: p.ID, FromIssueID: a.ID, ToIssueID: a.ID, Type: "related", Author: "tester",
 	})
 	assert.True(t, errors.Is(err, db.ErrSelfLink),
@@ -172,16 +126,10 @@ func TestCreateLink_SelfLinkIsError(t *testing.T) {
 }
 
 func TestLinkByEndpoints_FindsExisting(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	a := makeIssue(t, ctx, d, p.ID, "a", "tester")
 	b := makeIssue(t, ctx, d, p.ID, "b", "tester")
-	created, err := d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: a.ID, ToIssueID: b.ID, Type: "related", Author: "tester",
-	})
-	require.NoError(t, err)
+	created := makeLink(ctx, t, d, p.ID, a.ID, b.ID, "related")
 
 	got, err := d.LinkByEndpoints(ctx, a.ID, b.ID, "related")
 	require.NoError(t, err)
@@ -192,22 +140,13 @@ func TestLinkByEndpoints_FindsExisting(t *testing.T) {
 }
 
 func TestLinksByIssue_ReturnsBothDirections(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	a := makeIssue(t, ctx, d, p.ID, "a", "tester")
 	b := makeIssue(t, ctx, d, p.ID, "b", "tester")
 	c := makeIssue(t, ctx, d, p.ID, "c", "tester")
 	// a → blocks → b ; c → parent → a
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: a.ID, ToIssueID: b.ID, Type: "blocks", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: c.ID, ToIssueID: a.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
+	makeLink(ctx, t, d, p.ID, a.ID, b.ID, "blocks")
+	makeLink(ctx, t, d, p.ID, c.ID, a.ID, "parent")
 
 	got, err := d.LinksByIssue(ctx, a.ID)
 	require.NoError(t, err)
@@ -215,21 +154,15 @@ func TestLinksByIssue_ReturnsBothDirections(t *testing.T) {
 }
 
 func TestParentOf_ReturnsErrNotFoundWhenAbsent(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	a := makeIssue(t, ctx, d, p.ID, "a", "tester")
 
-	_, err = d.ParentOf(ctx, a.ID)
+	_, err := d.ParentOf(ctx, a.ID)
 	assert.True(t, errors.Is(err, db.ErrNotFound))
 }
 
 func TestParentNumbersByIssues_EmptyInput(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	got, err := d.ParentNumbersByIssues(ctx, p.ID, nil)
 	require.NoError(t, err)
@@ -243,10 +176,7 @@ func TestParentNumbersByIssues_EmptyInput(t *testing.T) {
 }
 
 func TestChildCountsByParents_EmptyInput(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	got, err := d.ChildCountsByParents(ctx, p.ID, nil)
 	require.NoError(t, err)
@@ -260,23 +190,14 @@ func TestChildCountsByParents_EmptyInput(t *testing.T) {
 }
 
 func TestParentNumbersByIssues_ReturnsImmediateParents(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	parent := makeIssue(t, ctx, d, p.ID, "parent", "tester")
 	child1 := makeIssue(t, ctx, d, p.ID, "child 1", "tester")
 	child2 := makeIssue(t, ctx, d, p.ID, "child 2", "tester")
 	unrelated := makeIssue(t, ctx, d, p.ID, "unrelated", "tester")
 
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: child1.ID, ToIssueID: parent.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: child2.ID, ToIssueID: parent.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
+	makeLink(ctx, t, d, p.ID, child1.ID, parent.ID, "parent")
+	makeLink(ctx, t, d, p.ID, child2.ID, parent.ID, "parent")
 
 	got, err := d.ParentNumbersByIssues(ctx, p.ID, []int64{child1.ID, child2.ID, unrelated.ID})
 	require.NoError(t, err)
@@ -288,23 +209,15 @@ func TestParentNumbersByIssues_ReturnsImmediateParents(t *testing.T) {
 func TestParentNumbersByIssues_ConstrainsProject(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	pa, err := d.CreateProject(ctx, "a", "a")
-	require.NoError(t, err)
-	pb, err := d.CreateProject(ctx, "b", "b")
-	require.NoError(t, err)
+	pa := createProject(ctx, t, d, "a", "a")
+	pb := createProject(ctx, t, d, "b", "b")
 	parentA := makeIssue(t, ctx, d, pa.ID, "parent a", "tester")
 	childA := makeIssue(t, ctx, d, pa.ID, "child a", "tester")
 	parentB := makeIssue(t, ctx, d, pb.ID, "parent b", "tester")
 	childB := makeIssue(t, ctx, d, pb.ID, "child b", "tester")
 
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: pa.ID, FromIssueID: childA.ID, ToIssueID: parentA.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: pb.ID, FromIssueID: childB.ID, ToIssueID: parentB.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
+	makeLink(ctx, t, d, pa.ID, childA.ID, parentA.ID, "parent")
+	makeLink(ctx, t, d, pb.ID, childB.ID, parentB.ID, "parent")
 
 	got, err := d.ParentNumbersByIssues(ctx, pa.ID, []int64{childA.ID, childB.ID})
 	require.NoError(t, err)
@@ -313,21 +226,15 @@ func TestParentNumbersByIssues_ConstrainsProject(t *testing.T) {
 }
 
 func TestChildCountsByParents_ReturnsOpenAndTotalDirectChildren(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	parent := makeIssue(t, ctx, d, p.ID, "parent", "tester")
 	child1 := makeIssue(t, ctx, d, p.ID, "child 1", "tester")
 	child2 := makeIssue(t, ctx, d, p.ID, "child 2", "tester")
 	child3 := makeIssue(t, ctx, d, p.ID, "child 3", "tester")
 	for _, child := range []db.Issue{child1, child2, child3} {
-		_, err = d.CreateLink(ctx, db.CreateLinkParams{
-			ProjectID: p.ID, FromIssueID: child.ID, ToIssueID: parent.ID, Type: "parent", Author: "tester",
-		})
-		require.NoError(t, err)
+		makeLink(ctx, t, d, p.ID, child.ID, parent.ID, "parent")
 	}
-	_, _, _, err = d.CloseIssue(ctx, child2.ID, "done", "tester")
+	_, _, _, err := d.CloseIssue(ctx, child2.ID, "done", "tester")
 	require.NoError(t, err)
 
 	got, err := d.ChildCountsByParents(ctx, p.ID, []int64{parent.ID})
@@ -336,26 +243,14 @@ func TestChildCountsByParents_ReturnsOpenAndTotalDirectChildren(t *testing.T) {
 }
 
 func TestChildrenOfIssue_ReturnsDirectChildrenOnly(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	parent := makeIssue(t, ctx, d, p.ID, "parent", "tester")
 	child1 := makeIssue(t, ctx, d, p.ID, "child 1", "tester")
 	child2 := makeIssue(t, ctx, d, p.ID, "child 2", "tester")
 	grandchild := makeIssue(t, ctx, d, p.ID, "grandchild", "tester")
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: child1.ID, ToIssueID: parent.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: child2.ID, ToIssueID: parent.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: grandchild.ID, ToIssueID: child1.ID, Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
+	makeLink(ctx, t, d, p.ID, child1.ID, parent.ID, "parent")
+	makeLink(ctx, t, d, p.ID, child2.ID, parent.ID, "parent")
+	makeLink(ctx, t, d, p.ID, grandchild.ID, child1.ID, "parent")
 
 	got, err := d.ChildrenOfIssue(ctx, p.ID, parent.ID)
 	require.NoError(t, err)
@@ -365,10 +260,7 @@ func TestChildrenOfIssue_ReturnsDirectChildrenOnly(t *testing.T) {
 }
 
 func TestChildCountsByParents_ChunksLargeInputs(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	const parentCount = 501
 	parentIDs := make([]int64, 0, parentCount)
@@ -377,10 +269,7 @@ func TestChildCountsByParents_ChunksLargeInputs(t *testing.T) {
 		parentIDs = append(parentIDs, parent.ID)
 	}
 	child := makeIssue(t, ctx, d, p.ID, "child", "tester")
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: child.ID, ToIssueID: parentIDs[parentCount-1], Type: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
+	makeLink(ctx, t, d, p.ID, child.ID, parentIDs[parentCount-1], "parent")
 
 	got, err := d.ChildCountsByParents(ctx, p.ID, parentIDs)
 	require.NoError(t, err, "large parent batches must be chunked under SQLite parameter limits")
@@ -389,19 +278,13 @@ func TestChildCountsByParents_ChunksLargeInputs(t *testing.T) {
 }
 
 func TestDeleteLinkByID_RemovesRow(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	a := makeIssue(t, ctx, d, p.ID, "a", "tester")
 	b := makeIssue(t, ctx, d, p.ID, "b", "tester")
-	link, err := d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID: p.ID, FromIssueID: a.ID, ToIssueID: b.ID, Type: "blocks", Author: "tester",
-	})
-	require.NoError(t, err)
+	link := makeLink(ctx, t, d, p.ID, a.ID, b.ID, "blocks")
 
 	require.NoError(t, d.DeleteLinkByID(ctx, link.ID))
-	_, err = d.LinkByID(ctx, link.ID)
+	_, err := d.LinkByID(ctx, link.ID)
 	assert.True(t, errors.Is(err, db.ErrNotFound))
 
 	// Re-deleting returns ErrNotFound (caller decides whether to surface as

--- a/internal/db/queries_owner_test.go
+++ b/internal/db/queries_owner_test.go
@@ -1,7 +1,6 @@
 package db_test
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -10,11 +9,7 @@ import (
 )
 
 func TestUpdateOwner_AssignFromNil(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
+	d, ctx, _, i := setupTestIssue(t)
 
 	owner := "alice"
 	updated, evt, changed, err := d.UpdateOwner(ctx, i.ID, &owner, "tester")
@@ -28,14 +23,7 @@ func TestUpdateOwner_AssignFromNil(t *testing.T) {
 }
 
 func TestUpdateOwner_UnassignFromValue(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
-	owner := "alice"
-	_, _, _, err = d.UpdateOwner(ctx, i.ID, &owner, "tester")
-	require.NoError(t, err)
+	d, ctx, _, i := setupAssignedIssue(t, "alice")
 
 	updated, evt, changed, err := d.UpdateOwner(ctx, i.ID, nil, "tester")
 	require.NoError(t, err)
@@ -47,15 +35,9 @@ func TestUpdateOwner_UnassignFromValue(t *testing.T) {
 }
 
 func TestUpdateOwner_NoOpSameOwner(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
-	owner := "alice"
-	_, _, _, err = d.UpdateOwner(ctx, i.ID, &owner, "tester")
-	require.NoError(t, err)
+	d, ctx, _, i := setupAssignedIssue(t, "alice")
 
+	owner := "alice"
 	_, evt, changed, err := d.UpdateOwner(ctx, i.ID, &owner, "tester")
 	require.NoError(t, err)
 	assert.False(t, changed)
@@ -63,11 +45,7 @@ func TestUpdateOwner_NoOpSameOwner(t *testing.T) {
 }
 
 func TestUpdateOwner_NoOpAlreadyUnassigned(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
+	d, ctx, _, i := setupTestIssue(t)
 
 	_, evt, changed, err := d.UpdateOwner(ctx, i.ID, nil, "tester")
 	require.NoError(t, err)
@@ -80,11 +58,7 @@ func TestUpdateOwner_NoOpAlreadyUnassigned(t *testing.T) {
 // json_valid CHECK and rolling back the assignment. Now built via
 // encoding/json so any schema-accepted owner value round-trips cleanly.
 func TestUpdateOwner_ControlByteOwnerProducesValidJSON(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	i := makeIssue(t, ctx, d, p.ID, "a", "tester")
+	d, ctx, _, i := setupTestIssue(t)
 
 	owner := "alice\x00bob"
 	updated, evt, changed, err := d.UpdateOwner(ctx, i.ID, &owner, "tester")

--- a/internal/db/queries_projects_remove_test.go
+++ b/internal/db/queries_projects_remove_test.go
@@ -33,10 +33,8 @@ func TestRemoveProject_ArchivesAndDropsAliases(t *testing.T) {
 	assert.True(t, uid.Valid(evt.UID))
 	assert.Equal(t, d.InstanceUID(), evt.OriginInstanceUID)
 
-	var aliasCount int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM project_aliases WHERE project_id = ?`, p.ID).Scan(&aliasCount))
-	assert.Equal(t, 0, aliasCount, "aliases must be hard-deleted")
+	assertRowCount(ctx, t, d, 0, "aliases must be hard-deleted",
+		`SELECT COUNT(*) FROM project_aliases WHERE project_id = ?`, p.ID)
 }
 
 // TestRemoveProject_RefusesWhenOpenIssues pins the safety gate: open issues
@@ -80,11 +78,8 @@ func TestRemoveProject_ForceOverridesOpenIssues(t *testing.T) {
 	require.NotNil(t, got.DeletedAt)
 	require.NotNil(t, evt)
 
-	var stillOpen int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM issues WHERE project_id = ? AND status = 'open'`,
-		p.ID).Scan(&stillOpen))
-	assert.Equal(t, 1, stillOpen, "force does not bulk-close issues")
+	assertRowCount(ctx, t, d, 1, "force does not bulk-close issues",
+		`SELECT COUNT(*) FROM issues WHERE project_id = ? AND status = 'open'`, p.ID)
 }
 
 // TestRemoveProject_AlreadyArchived covers the idempotency-rejection: a
@@ -152,10 +147,8 @@ func TestDetachProjectAlias_RemovesOneAndEmitsEvent(t *testing.T) {
 	assert.Equal(t, p.ID, evt.ProjectID)
 	assert.True(t, uid.Valid(evt.UID))
 
-	var remaining int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM project_aliases WHERE project_id = ?`, p.ID).Scan(&remaining))
-	assert.Equal(t, 1, remaining)
+	assertRowCount(ctx, t, d, 1, "one alias remains after detach",
+		`SELECT COUNT(*) FROM project_aliases WHERE project_id = ?`, p.ID)
 
 	// The other alias is still resolvable.
 	resolved, err := d.AliasByIdentity(ctx, a1.AliasIdentity)
@@ -198,10 +191,8 @@ func TestDetachProjectAlias_ForceDropsLast(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, evt)
 
-	var remaining int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM project_aliases WHERE project_id = ?`, p.ID).Scan(&remaining))
-	assert.Equal(t, 0, remaining)
+	assertRowCount(ctx, t, d, 0, "force drops the last alias",
+		`SELECT COUNT(*) FROM project_aliases WHERE project_id = ?`, p.ID)
 }
 
 // TestDetachProjectAlias_RejectsCrossProject pins the atomic
@@ -232,8 +223,6 @@ func TestDetachProjectAlias_RejectsCrossProject(t *testing.T) {
 		"cross-project detach must refuse with ErrNotFound, got %v", err)
 
 	// Both of B's aliases are intact.
-	var remaining int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM project_aliases WHERE project_id = ?`, pB.ID).Scan(&remaining))
-	assert.Equal(t, 2, remaining)
+	assertRowCount(ctx, t, d, 2, "B's aliases unchanged after cross-project refusal",
+		`SELECT COUNT(*) FROM project_aliases WHERE project_id = ?`, pB.ID)
 }

--- a/internal/db/queries_projects_test.go
+++ b/internal/db/queries_projects_test.go
@@ -2,7 +2,6 @@ package db_test
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,14 +10,6 @@ import (
 	"github.com/wesm/kata/internal/db"
 	"github.com/wesm/kata/internal/uid"
 )
-
-func openTestDB(t *testing.T) *db.DB {
-	t.Helper()
-	d, err := db.Open(context.Background(), filepath.Join(t.TempDir(), "kata.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = d.Close() })
-	return d
-}
 
 func TestCreateProject_RoundTrips(t *testing.T) {
 	d := openTestDB(t)
@@ -53,19 +44,16 @@ func TestProjectByIdentity_NotFound(t *testing.T) {
 func TestCreateProject_DuplicateIdentity(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
+	createProject(ctx, t, d, "x", "x")
 	_, err := d.CreateProject(ctx, "x", "x")
-	require.NoError(t, err)
-	_, err = d.CreateProject(ctx, "x", "x")
 	require.Error(t, err)
 }
 
 func TestRenameProject_UpdatesNameOnly(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
-	alias, err := d.AttachAlias(ctx, p.ID, "github.com/wesm/kata", "git", "/tmp/kata")
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
+	alias := attachAlias(ctx, t, d, p.ID, "github.com/wesm/kata", "/tmp/kata")
 
 	renamed, err := d.RenameProject(ctx, p.ID, "Kata Tracker")
 	require.NoError(t, err)
@@ -92,8 +80,7 @@ func TestRenameProject_MissingReturnsErrNotFound(t *testing.T) {
 func TestAttachAlias_AndLookup(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
+	p := createKataProject(ctx, t, d)
 
 	a, err := d.AttachAlias(ctx, p.ID, "github.com/wesm/kata", "git", "/tmp/x")
 	require.NoError(t, err)
@@ -114,10 +101,8 @@ func TestAliasByIdentity_NotFound(t *testing.T) {
 func TestTouchAlias_UpdatesLastSeen(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "x", "x")
-	require.NoError(t, err)
-	a, err := d.AttachAlias(ctx, p.ID, "x", "git", "/tmp/x")
-	require.NoError(t, err)
+	p := createProject(ctx, t, d, "x", "x")
+	a := attachAlias(ctx, t, d, p.ID, "x", "/tmp/x")
 
 	require.NoError(t, d.TouchAlias(ctx, a.ID, "/tmp/y"))
 	got, err := d.AliasByIdentity(ctx, "x")
@@ -142,8 +127,8 @@ func TestListProjects_Empty(t *testing.T) {
 func TestListProjects_OrdersByIDAsc(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	_, _ = d.CreateProject(ctx, "a", "a")
-	_, _ = d.CreateProject(ctx, "b", "b")
+	createProject(ctx, t, d, "a", "a")
+	createProject(ctx, t, d, "b", "b")
 
 	got, err := d.ListProjects(ctx)
 	require.NoError(t, err)
@@ -153,11 +138,9 @@ func TestListProjects_OrdersByIDAsc(t *testing.T) {
 }
 
 func TestProjectAliases_ReturnsAllForProject(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, _ := d.CreateProject(ctx, "p", "p")
-	_, _ = d.AttachAlias(ctx, p.ID, "alias-a", "git", "/tmp/a")
-	_, _ = d.AttachAlias(ctx, p.ID, "alias-b", "git", "/tmp/b")
+	d, ctx, p := setupTestProject(t)
+	attachAlias(ctx, t, d, p.ID, "alias-a", "/tmp/a")
+	attachAlias(ctx, t, d, p.ID, "alias-b", "/tmp/b")
 
 	got, err := d.ProjectAliases(ctx, p.ID)
 	require.NoError(t, err)
@@ -167,23 +150,13 @@ func TestProjectAliases_ReturnsAllForProject(t *testing.T) {
 func TestMergeProjects_MovesSourceIntoSurvivingTarget(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	kenn, err := d.CreateProject(ctx, "github.com/wesm/kenn", "kenn")
-	require.NoError(t, err)
-	steward, err := d.CreateProject(ctx, "github.com/wesm/steward", "steward")
-	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, kenn.ID, "github.com/wesm/kenn", "git", "/tmp/kenn")
-	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, steward.ID, "github.com/wesm/steward", "git", "/tmp/steward")
-	require.NoError(t, err)
-	parent, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: kenn.ID, Title: "parent", Author: "tester",
-	})
-	require.NoError(t, err)
-	child, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: kenn.ID, Title: "child", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
+	kenn := createProject(ctx, t, d, "github.com/wesm/kenn", "kenn")
+	steward := createProject(ctx, t, d, "github.com/wesm/steward", "steward")
+	attachAlias(ctx, t, d, kenn.ID, "github.com/wesm/kenn", "/tmp/kenn")
+	attachAlias(ctx, t, d, steward.ID, "github.com/wesm/steward", "/tmp/steward")
+	parent := makeIssue(t, ctx, d, kenn.ID, "parent", "tester")
+	child := makeIssue(t, ctx, d, kenn.ID, "child", "tester")
+	_, _, err := d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
 		ProjectID: kenn.ID, FromIssueID: child.ID, ToIssueID: parent.ID, Type: "parent", Author: "tester",
 	}, db.LinkEventParams{
 		EventType: "issue.linked", EventIssueID: child.ID, EventIssueNumber: child.Number,
@@ -238,14 +211,11 @@ func TestMergeProjects_MovesSourceIntoSurvivingTarget(t *testing.T) {
 func TestMergeProjects_PreservesSourceIdentityWhenAliasAlreadyTargetsTarget(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	source, err := d.CreateProject(ctx, "github.com/wesm/old", "old")
-	require.NoError(t, err)
-	target, err := d.CreateProject(ctx, "github.com/wesm/new", "new")
-	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, target.ID, "github.com/wesm/old", "git", "/tmp/old")
-	require.NoError(t, err)
+	source := createProject(ctx, t, d, "github.com/wesm/old", "old")
+	target := createProject(ctx, t, d, "github.com/wesm/new", "new")
+	attachAlias(ctx, t, d, target.ID, "github.com/wesm/old", "/tmp/old")
 
-	_, err = d.MergeProjects(ctx, db.MergeProjectsParams{
+	_, err := d.MergeProjects(ctx, db.MergeProjectsParams{
 		SourceProjectID: source.ID,
 		TargetProjectID: target.ID,
 	})
@@ -259,16 +229,12 @@ func TestMergeProjects_PreservesSourceIdentityWhenAliasAlreadyTargetsTarget(t *t
 func TestMergeProjects_RejectsSourceIdentityAliasOwnedByDifferentProject(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	source, err := d.CreateProject(ctx, "github.com/wesm/old", "old")
-	require.NoError(t, err)
-	target, err := d.CreateProject(ctx, "github.com/wesm/new", "new")
-	require.NoError(t, err)
-	other, err := d.CreateProject(ctx, "github.com/wesm/other", "other")
-	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, other.ID, "github.com/wesm/old", "git", "/tmp/old")
-	require.NoError(t, err)
+	source := createProject(ctx, t, d, "github.com/wesm/old", "old")
+	target := createProject(ctx, t, d, "github.com/wesm/new", "new")
+	other := createProject(ctx, t, d, "github.com/wesm/other", "other")
+	attachAlias(ctx, t, d, other.ID, "github.com/wesm/old", "/tmp/old")
 
-	_, err = d.MergeProjects(ctx, db.MergeProjectsParams{
+	_, err := d.MergeProjects(ctx, db.MergeProjectsParams{
 		SourceProjectID: source.ID,
 		TargetProjectID: target.ID,
 	})
@@ -286,11 +252,9 @@ func TestMergeProjects_RejectsSourceIdentityAliasOwnedByDifferentProject(t *test
 func TestMergeProjects_RejectsArchivedSource(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	source, err := d.CreateProject(ctx, "github.com/wesm/archived-src", "src")
-	require.NoError(t, err)
-	target, err := d.CreateProject(ctx, "github.com/wesm/live-tgt", "tgt")
-	require.NoError(t, err)
-	_, _, err = d.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: source.ID, Actor: "tester"})
+	source := createProject(ctx, t, d, "github.com/wesm/archived-src", "src")
+	target := createProject(ctx, t, d, "github.com/wesm/live-tgt", "tgt")
+	_, _, err := d.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: source.ID, Actor: "tester"})
 	require.NoError(t, err)
 
 	_, err = d.MergeProjects(ctx, db.MergeProjectsParams{
@@ -304,11 +268,9 @@ func TestMergeProjects_RejectsArchivedSource(t *testing.T) {
 func TestMergeProjects_RejectsArchivedTarget(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	source, err := d.CreateProject(ctx, "github.com/wesm/live-src", "src")
-	require.NoError(t, err)
-	target, err := d.CreateProject(ctx, "github.com/wesm/archived-tgt", "tgt")
-	require.NoError(t, err)
-	_, _, err = d.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: target.ID, Actor: "tester"})
+	source := createProject(ctx, t, d, "github.com/wesm/live-src", "src")
+	target := createProject(ctx, t, d, "github.com/wesm/archived-tgt", "tgt")
+	_, _, err := d.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: target.ID, Actor: "tester"})
 	require.NoError(t, err)
 
 	_, err = d.MergeProjects(ctx, db.MergeProjectsParams{
@@ -320,20 +282,12 @@ func TestMergeProjects_RejectsArchivedTarget(t *testing.T) {
 func TestMergeProjects_IssueNumberCollisionReturnsError(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	source, err := d.CreateProject(ctx, "github.com/wesm/kenn", "kenn")
-	require.NoError(t, err)
-	target, err := d.CreateProject(ctx, "github.com/wesm/steward", "steward")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: source.ID, Title: "source issue", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: target.ID, Title: "target issue", Author: "tester",
-	})
-	require.NoError(t, err)
+	source := createProject(ctx, t, d, "github.com/wesm/kenn", "kenn")
+	target := createProject(ctx, t, d, "github.com/wesm/steward", "steward")
+	makeIssue(t, ctx, d, source.ID, "source issue", "tester")
+	makeIssue(t, ctx, d, target.ID, "target issue", "tester")
 
-	_, err = d.MergeProjects(ctx, db.MergeProjectsParams{
+	_, err := d.MergeProjects(ctx, db.MergeProjectsParams{
 		SourceProjectID: source.ID,
 		TargetProjectID: target.ID,
 	})
@@ -345,10 +299,7 @@ func TestMergeProjects_IssueNumberCollisionReturnsError(t *testing.T) {
 }
 
 func TestResetIssueCounter_EmptyProjectMovesCounter(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	require.NoError(t, d.ResetIssueCounter(ctx, p.ID, 42))
 
@@ -358,13 +309,9 @@ func TestResetIssueCounter_EmptyProjectMovesCounter(t *testing.T) {
 }
 
 func TestResetIssueCounter_ReturnsTypedErrorWithCount(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	for range 3 {
-		_, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "a"})
-		require.NoError(t, err)
+		makeIssue(t, ctx, d, p.ID, "x", "a")
 	}
 	before, err := d.ProjectByID(ctx, p.ID)
 	require.NoError(t, err)
@@ -386,10 +333,7 @@ func TestResetIssueCounter_ProjectNotFound(t *testing.T) {
 }
 
 func TestResetIssueCounter_RejectsInvalidTo(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	for _, to := range []int64{0, -1, -42} {
 		err := d.ResetIssueCounter(ctx, p.ID, to)
@@ -404,15 +348,11 @@ func TestResetIssueCounter_RejectsInvalidTo(t *testing.T) {
 // Covers the production scenario: project accumulated issues that were all
 // purged, then the user resets the counter to start over at 1.
 func TestResetIssueCounter_SucceedsAfterPurge(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	var issueIDs []int64
 	for range 3 {
-		issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "a"})
-		require.NoError(t, err)
+		issue := makeIssue(t, ctx, d, p.ID, "x", "a")
 		issueIDs = append(issueIDs, issue.ID)
 	}
 	for _, id := range issueIDs {
@@ -431,12 +371,8 @@ func TestResetIssueCounter_SucceedsAfterPurge(t *testing.T) {
 // empty-check must be atomic with the write so a concurrent CreateIssue
 // can't slip between them.
 func TestResetIssueCounter_GateLivesInUpdate(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "x", Author: "a"})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	makeIssue(t, ctx, d, p.ID, "x", "a")
 
 	before, err := d.ProjectByID(ctx, p.ID)
 	require.NoError(t, err)
@@ -453,8 +389,7 @@ func TestResetIssueCounter_GateLivesInUpdate(t *testing.T) {
 func TestBatchProjectStats_EmptyProjectReturnsZeroes(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/empty", "empty")
-	require.NoError(t, err)
+	p := createProject(ctx, t, d, "github.com/wesm/empty", "empty")
 
 	stats, err := d.BatchProjectStats(ctx)
 	require.NoError(t, err)
@@ -473,16 +408,9 @@ func TestBatchProjectStats_EmptyProjectReturnsZeroes(t *testing.T) {
 func TestBatchProjectStats_NoCountInflation(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/proj", "proj")
-	require.NoError(t, err)
-	for i := 0; i < 3; i++ {
-		_, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-			ProjectID: p.ID,
-			Title:     "i",
-			Body:      "",
-			Author:    "tester",
-		})
-		require.NoError(t, err)
+	p := createProject(ctx, t, d, "github.com/wesm/proj", "proj")
+	for range 3 {
+		makeIssue(t, ctx, d, p.ID, "i", "tester")
 	}
 	iss, err := d.IssueByNumber(ctx, p.ID, 1)
 	require.NoError(t, err)
@@ -509,17 +437,10 @@ func TestBatchProjectStats_NoCountInflation(t *testing.T) {
 func TestBatchProjectStats_ExcludesSoftDeletedIssues(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/proj", "proj")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "live", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
-	soft, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "soft", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, _, err = d.SoftDeleteIssue(ctx, soft.ID, "tester")
+	p := createProject(ctx, t, d, "github.com/wesm/proj", "proj")
+	makeIssue(t, ctx, d, p.ID, "live", "tester")
+	soft := makeIssue(t, ctx, d, p.ID, "soft", "tester")
+	_, _, _, err := d.SoftDeleteIssue(ctx, soft.ID, "tester")
 	require.NoError(t, err)
 	// Sanity: the soft-deleted row still exists with deleted_at set, so
 	// the filter is what's actually doing the work.
@@ -537,11 +458,9 @@ func TestBatchProjectStats_ExcludesSoftDeletedIssues(t *testing.T) {
 func TestBatchProjectStats_ExcludesArchivedProjects(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	live, err := d.CreateProject(ctx, "github.com/wesm/live", "live")
-	require.NoError(t, err)
-	arch, err := d.CreateProject(ctx, "github.com/wesm/arch", "arch")
-	require.NoError(t, err)
-	_, _, err = d.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: arch.ID, Actor: "tester"})
+	live := createProject(ctx, t, d, "github.com/wesm/live", "live")
+	arch := createProject(ctx, t, d, "github.com/wesm/arch", "arch")
+	_, _, err := d.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: arch.ID, Actor: "tester"})
 	require.NoError(t, err)
 
 	stats, err := d.BatchProjectStats(ctx)
@@ -556,20 +475,12 @@ func TestBatchProjectStats_ExcludesArchivedProjects(t *testing.T) {
 func TestBatchProjectStats_PartitionsByProject(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	a, err := d.CreateProject(ctx, "github.com/wesm/a", "a")
-	require.NoError(t, err)
-	b, err := d.CreateProject(ctx, "github.com/wesm/b", "b")
-	require.NoError(t, err)
-	for i := 0; i < 2; i++ {
-		_, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-			ProjectID: a.ID, Title: "x", Author: "tester",
-		})
-		require.NoError(t, err)
+	a := createProject(ctx, t, d, "github.com/wesm/a", "a")
+	b := createProject(ctx, t, d, "github.com/wesm/b", "b")
+	for range 2 {
+		makeIssue(t, ctx, d, a.ID, "x", "tester")
 	}
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: b.ID, Title: "y", Author: "tester",
-	})
-	require.NoError(t, err)
+	makeIssue(t, ctx, d, b.ID, "y", "tester")
 
 	stats, err := d.BatchProjectStats(ctx)
 	require.NoError(t, err)
@@ -592,23 +503,13 @@ func TestBatchProjectStats_PartitionsByProject(t *testing.T) {
 func TestBatchProjectStats_ParsesZonedLegacyTimestamp(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/zoned", "zoned")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "live", Author: "tester",
-	})
-	require.NoError(t, err)
+	p := createProject(ctx, t, d, "github.com/wesm/zoned", "zoned")
+	issue := makeIssue(t, ctx, d, p.ID, "live", "tester")
 	// Stamp an event whose created_at uses the zoned legacy layout. The
 	// MAX(created_at) over events for this project will surface this row,
 	// driving parseSQLiteTimestamp through the new layout slot.
-	eventUID, err := uid.New()
-	require.NoError(t, err)
 	const zonedTS = "2099-05-04 12:34:56.789-07:00"
-	_, err = d.ExecContext(ctx, `
-		INSERT INTO events (uid, origin_instance_uid, project_id, project_identity, issue_id, issue_number, type, actor, payload, created_at)
-		VALUES (?, (SELECT value FROM meta WHERE key='instance_uid'), ?, ?, ?, ?, 'issue.edited', 'tester', '{}', ?)`,
-		eventUID, p.ID, p.Identity, issue.ID, issue.Number, zonedTS)
-	require.NoError(t, err)
+	insertLegacyEvent(ctx, t, d, p, issue, "issue.edited", zonedTS)
 
 	stats, err := d.BatchProjectStats(ctx)
 	require.NoError(t, err)
@@ -639,34 +540,18 @@ func TestBatchProjectStats_ParsesZonedLegacyTimestamp(t *testing.T) {
 func TestBatchProjectStats_PicksAbsoluteLatestAcrossMixedFormats(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "github.com/wesm/mixed-ts", "mixed-ts")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "live", Author: "tester",
-	})
-	require.NoError(t, err)
+	p := createProject(ctx, t, d, "github.com/wesm/mixed-ts", "mixed-ts")
+	issue := makeIssue(t, ctx, d, p.ID, "live", "tester")
 
 	// Earlier-in-absolute-time but lex-LATER (T separator > space).
-	earlierUID, err := uid.New()
-	require.NoError(t, err)
 	const earlierTRFC = "2050-01-01T00:00:00.000Z"
-	_, err = d.ExecContext(ctx, `
-		INSERT INTO events (uid, origin_instance_uid, project_id, project_identity, issue_id, issue_number, type, actor, payload, created_at)
-		VALUES (?, (SELECT value FROM meta WHERE key='instance_uid'), ?, ?, ?, ?, 'issue.edited', 'tester', '{}', ?)`,
-		earlierUID, p.ID, p.Identity, issue.ID, issue.Number, earlierTRFC)
-	require.NoError(t, err)
+	insertLegacyEvent(ctx, t, d, p, issue, "issue.edited", earlierTRFC)
 
 	// Later-in-absolute-time but lex-EARLIER (space separator < T).
 	// 2050-01-01 00:00:01-00:00 == 2050-01-01T00:00:01Z which is one
 	// second after earlierTRFC. Lex MAX would pick earlierTRFC.
-	laterUID, err := uid.New()
-	require.NoError(t, err)
 	const laterZoned = "2050-01-01 00:00:01.000-00:00"
-	_, err = d.ExecContext(ctx, `
-		INSERT INTO events (uid, origin_instance_uid, project_id, project_identity, issue_id, issue_number, type, actor, payload, created_at)
-		VALUES (?, (SELECT value FROM meta WHERE key='instance_uid'), ?, ?, ?, ?, 'issue.commented', 'tester', '{}', ?)`,
-		laterUID, p.ID, p.Identity, issue.ID, issue.Number, laterZoned)
-	require.NoError(t, err)
+	insertLegacyEvent(ctx, t, d, p, issue, "issue.commented", laterZoned)
 
 	stats, err := d.BatchProjectStats(ctx)
 	require.NoError(t, err)

--- a/internal/db/queries_ready_test.go
+++ b/internal/db/queries_ready_test.go
@@ -10,73 +10,49 @@ import (
 )
 
 func TestReadyIssues_FiltersOutClosed(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	open := makeIssue(t, ctx, d, p.ID, "open", "tester")
 	closed := makeIssue(t, ctx, d, p.ID, "closed", "tester")
-	_, _, _, err = d.CloseIssue(ctx, closed.ID, "done", "tester")
+	_, _, _, err := d.CloseIssue(ctx, closed.ID, "done", "tester")
 	require.NoError(t, err)
 
-	ready, err := d.ReadyIssues(ctx, p.ID, 0)
-	require.NoError(t, err)
-	got := numbers(ready)
+	got := readyNumbers(t, ctx, d, p.ID)
 	assert.Contains(t, got, open.Number)
 	assert.NotContains(t, got, closed.Number)
 }
 
 func TestReadyIssues_ExcludesIssuesBlockedByOpenBlocker(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	blocker := makeIssue(t, ctx, d, p.ID, "blocker", "tester")
 	blocked := makeIssue(t, ctx, d, p.ID, "blocked", "tester")
 	standalone := makeIssue(t, ctx, d, p.ID, "standalone", "tester")
-	// blocker → blocks → blocked
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID:   p.ID,
-		FromIssueID: blocker.ID,
-		ToIssueID:   blocked.ID,
-		Type:        "blocks",
-		Author:      "tester",
-	})
-	require.NoError(t, err)
+	makeLink(ctx, t, d, p.ID, blocker.ID, blocked.ID, "blocks")
 
-	ready, err := d.ReadyIssues(ctx, p.ID, 0)
-	require.NoError(t, err)
-	got := numbers(ready)
+	got := readyNumbers(t, ctx, d, p.ID)
 	assert.Contains(t, got, blocker.Number, "blocker is ready (not blocked itself)")
 	assert.Contains(t, got, standalone.Number, "standalone is ready")
 	assert.NotContains(t, got, blocked.Number, "blocked is not ready while blocker is open")
 }
 
 func TestReadyIssues_ClosedBlockerUnblocksDownstream(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	blocker := makeIssue(t, ctx, d, p.ID, "blocker", "tester")
 	blocked := makeIssue(t, ctx, d, p.ID, "blocked", "tester")
-	_, err = d.CreateLink(ctx, db.CreateLinkParams{
-		ProjectID:   p.ID,
-		FromIssueID: blocker.ID,
-		ToIssueID:   blocked.ID,
-		Type:        "blocks",
-		Author:      "tester",
-	})
-	require.NoError(t, err)
-	_, _, _, err = d.CloseIssue(ctx, blocker.ID, "done", "tester")
+	makeLink(ctx, t, d, p.ID, blocker.ID, blocked.ID, "blocks")
+	_, _, _, err := d.CloseIssue(ctx, blocker.ID, "done", "tester")
 	require.NoError(t, err)
 
-	ready, err := d.ReadyIssues(ctx, p.ID, 0)
-	require.NoError(t, err)
-	got := numbers(ready)
+	got := readyNumbers(t, ctx, d, p.ID)
 	assert.Contains(t, got, blocked.Number, "blocked is ready once blocker closes")
 }
 
-func numbers(rows []db.Issue) []int64 {
+// readyNumbers fetches ready issues for projectID and returns their numbers.
+//
+//nolint:revive // test helper: t *testing.T conventionally precedes ctx.
+func readyNumbers(t *testing.T, ctx context.Context, d *db.DB, projectID int64) []int64 {
+	t.Helper()
+	rows, err := d.ReadyIssues(ctx, projectID, 0)
+	require.NoError(t, err)
 	out := make([]int64, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, r.Number)

--- a/internal/db/queries_search_test.go
+++ b/internal/db/queries_search_test.go
@@ -1,7 +1,6 @@
 package db_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,96 +9,52 @@ import (
 )
 
 func TestFTS_IssueInsertIsIndexed(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "fix login crash", Body: "stack trace here", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	createTesterIssueWithBody(ctx, t, d, p.ID, "fix login crash", "stack trace here")
 
-	var hits int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'login'`).Scan(&hits))
-	assert.Equal(t, 1, hits, "FTS should index issue.title on insert")
-
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'trace'`).Scan(&hits))
-	assert.Equal(t, 1, hits, "FTS should index issue.body on insert")
+	assertRowCount(ctx, t, d, 1, "FTS should index issue.title on insert",
+		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'login'`)
+	assertRowCount(ctx, t, d, 1, "FTS should index issue.body on insert",
+		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'trace'`)
 }
 
 func TestFTS_IssueUpdateReindexes(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "old title", Body: "initial body content", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	issue := createTesterIssueWithBody(ctx, t, d, p.ID, "old title", "initial body content")
 
 	newTitle := "fresh title"
-	_, _, _, err = d.EditIssue(ctx, db.EditIssueParams{
+	_, _, _, err := d.EditIssue(ctx, db.EditIssueParams{
 		IssueID: issue.ID, Title: &newTitle, Actor: "tester",
 	})
 	require.NoError(t, err)
 
-	var oldHits, newHits int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'old'`).Scan(&oldHits))
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'fresh'`).Scan(&newHits))
-	assert.Equal(t, 0, oldHits, "old title tokens must be gone after edit")
-	assert.Equal(t, 1, newHits, "new title tokens must be searchable after edit")
+	assertRowCount(ctx, t, d, 0, "old title tokens must be gone after edit",
+		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'old'`)
+	assertRowCount(ctx, t, d, 1, "new title tokens must be searchable after edit",
+		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'fresh'`)
 }
 
 func TestFTS_CommentInsertReindexes(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "boring", Body: "body", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	issue := createTesterIssueWithBody(ctx, t, d, p.ID, "boring", "body")
+	addTesterComment(ctx, t, d, issue.ID, "watermelon")
 
-	_, _, err = d.CreateComment(ctx, db.CreateCommentParams{
-		IssueID: issue.ID, Author: "tester", Body: "watermelon",
-	})
-	require.NoError(t, err)
-
-	var hits int
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'watermelon'`).Scan(&hits))
-	assert.Equal(t, 1, hits, "comment body must be searchable after insert")
+	assertRowCount(ctx, t, d, 1, "comment body must be searchable after insert",
+		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'watermelon'`)
 }
 
 func TestSearchFTS_RanksByBM25(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	// Three issues. Only the first two mention "login"; the second has it
 	// many more times. Issue 1's body is padded with unrelated text so token
 	// density makes issue 2's BM25 win unambiguous regardless of column-length
 	// normalization quirks.
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "fix login crash",
-		Body:   "stack trace from a totally unrelated incident with many tokens to dilute density and dominate length normalization here",
-		Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "login is broken on login screen",
-		Body: "login fails twice login login login", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "unrelated issue", Body: "no match here", Author: "tester",
-	})
-	require.NoError(t, err)
+	createTesterIssueWithBody(ctx, t, d, p.ID, "fix login crash",
+		"stack trace from a totally unrelated incident with many tokens to dilute density and dominate length normalization here")
+	createTesterIssueWithBody(ctx, t, d, p.ID, "login is broken on login screen",
+		"login fails twice login login login")
+	createTesterIssueWithBody(ctx, t, d, p.ID, "unrelated issue", "no match here")
 
 	got, err := d.SearchFTS(ctx, p.ID, "login", 20, false)
 	require.NoError(t, err)
@@ -115,20 +70,11 @@ func TestSearchFTS_RanksByBM25(t *testing.T) {
 }
 
 func TestSearchFTS_MatchedIn_Comments(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
 	// Issue body does NOT contain the search term; only the comment does.
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "unrelated", Body: "nothing here", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateComment(ctx, db.CreateCommentParams{
-		IssueID: issue.ID, Author: "tester", Body: "watermelon found",
-	})
-	require.NoError(t, err)
+	issue := createTesterIssueWithBody(ctx, t, d, p.ID, "unrelated", "nothing here")
+	addTesterComment(ctx, t, d, issue.ID, "watermelon found")
 
 	got, err := d.SearchFTS(ctx, p.ID, "watermelon", 20, false)
 	require.NoError(t, err)
@@ -138,19 +84,10 @@ func TestSearchFTS_MatchedIn_Comments(t *testing.T) {
 }
 
 func TestSearchFTS_MatchedIn_AllThreeColumns(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "watermelon title", Body: "watermelon body", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateComment(ctx, db.CreateCommentParams{
-		IssueID: issue.ID, Author: "tester", Body: "watermelon comment",
-	})
-	require.NoError(t, err)
+	issue := createTesterIssueWithBody(ctx, t, d, p.ID, "watermelon title", "watermelon body")
+	addTesterComment(ctx, t, d, issue.ID, "watermelon comment")
 
 	got, err := d.SearchFTS(ctx, p.ID, "watermelon", 20, false)
 	require.NoError(t, err)
@@ -160,21 +97,11 @@ func TestSearchFTS_MatchedIn_AllThreeColumns(t *testing.T) {
 }
 
 func TestSearchFTS_FiltersByProject(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p1, err := d.CreateProject(ctx, "p1", "p1")
-	require.NoError(t, err)
-	p2, err := d.CreateProject(ctx, "p2", "p2")
-	require.NoError(t, err)
+	d, ctx, p1 := setupTestProject(t)
+	p2 := createProject(ctx, t, d, "p2", "p2")
 
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p1.ID, Title: "login bug", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p2.ID, Title: "login bug", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
+	createTesterIssueWithBody(ctx, t, d, p1.ID, "login bug", "")
+	createTesterIssueWithBody(ctx, t, d, p2.ID, "login bug", "")
 
 	got, err := d.SearchFTS(ctx, p1.ID, "login", 20, false)
 	require.NoError(t, err)
@@ -183,22 +110,13 @@ func TestSearchFTS_FiltersByProject(t *testing.T) {
 }
 
 func TestSearchFTS_ExcludesDeletedByDefault(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	keep, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "keep login", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
-	gone, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "deleted login", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	keep := createTesterIssueWithBody(ctx, t, d, p.ID, "keep login", "")
+	gone := createTesterIssueWithBody(ctx, t, d, p.ID, "deleted login", "")
 	// Mark the second issue soft-deleted directly via SQL — Task 5 ships
 	// SoftDeleteIssue but this test runs before that, and the DB-layer
 	// behavior we want to verify is "search query filters deleted_at IS NULL".
-	_, err = d.ExecContext(ctx,
+	_, err := d.ExecContext(ctx,
 		`UPDATE issues SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ?`,
 		gone.ID)
 	require.NoError(t, err)
@@ -215,14 +133,8 @@ func TestSearchFTS_ExcludesDeletedByDefault(t *testing.T) {
 }
 
 func TestSearchFTS_EmptyQueryReturnsEmpty(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "anything", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	createTesterIssueWithBody(ctx, t, d, p.ID, "anything", "")
 
 	got, err := d.SearchFTS(ctx, p.ID, "   ", 20, false)
 	require.NoError(t, err)
@@ -230,18 +142,12 @@ func TestSearchFTS_EmptyQueryReturnsEmpty(t *testing.T) {
 }
 
 func TestSearchFTS_LimitCappedAt200(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 	// Create 250 matching issues. The cap must clamp the result set to 200
 	// regardless of how large a limit the caller passes; without the cap, this
 	// test would return 250 and fail.
 	for i := 0; i < 250; i++ {
-		_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-			ProjectID: p.ID, Title: "login bug", Body: "", Author: "tester",
-		})
-		require.NoError(t, err)
+		createTesterIssueWithBody(ctx, t, d, p.ID, "login bug", "")
 	}
 	got, err := d.SearchFTS(ctx, p.ID, "login", 1_000_000, false)
 	require.NoError(t, err)
@@ -252,23 +158,11 @@ func TestSearchFTS_MultiTermImplicitAND(t *testing.T) {
 	// Multi-term queries split on whitespace and AND the terms. "login Safari"
 	// must match an issue that contains both terms even when they aren't
 	// adjacent — the previous single-phrase wrap missed this.
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
 
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "fix login crash on Safari", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "login bug", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "Safari preferences", Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
+	createTesterIssue(ctx, t, d, p.ID, "fix login crash on Safari")
+	createTesterIssueWithBody(ctx, t, d, p.ID, "login bug", "")
+	createTesterIssueWithBody(ctx, t, d, p.ID, "Safari preferences", "")
 
 	got, err := d.SearchFTS(ctx, p.ID, "login Safari", 20, false)
 	require.NoError(t, err)
@@ -277,14 +171,8 @@ func TestSearchFTS_MultiTermImplicitAND(t *testing.T) {
 }
 
 func TestSearchFTS_QueryEscaping(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: `fix "login" crash`, Body: "", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	createTesterIssueWithBody(ctx, t, d, p.ID, `fix "login" crash`, "")
 
 	// FTS5 syntax characters must not surface as syntax errors.
 	got, err := d.SearchFTS(ctx, p.ID, `"login"`, 20, false)
@@ -298,14 +186,8 @@ func TestSearchFTS_QueryEscaping(t *testing.T) {
 // must use OR semantics so each column reports as matched. With the old
 // AND-based per-column subqueries this returned matched_in=[].
 func TestSearchFTS_MatchedIn_CrossColumn(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "login bug", Body: "Safari issue", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	createTesterIssueWithBody(ctx, t, d, p.ID, "login bug", "Safari issue")
 
 	got, err := d.SearchFTS(ctx, p.ID, "login Safari", 20, false)
 	require.NoError(t, err)
@@ -319,18 +201,9 @@ func TestSearchFTS_MatchedIn_CrossColumn(t *testing.T) {
 // token and doubles embedded quotes, which neutralizes NEAR/OR/AND/NOT and
 // the `*` prefix-match marker.
 func TestSearchFTS_OperatorWordsAsLiterals(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "do NOT merge yet", Body: "blocked OR waiting", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "merge after review", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	createTesterIssueWithBody(ctx, t, d, p.ID, "do NOT merge yet", "blocked OR waiting")
+	createTesterIssue(ctx, t, d, p.ID, "merge after review")
 	// Seeded so AND/NEAR-as-literals can be exercised: each operator-bearing
 	// row pairs with a competitor that has the surrounding tokens but lacks
 	// the operator word itself. Under operator semantics ("build" AND
@@ -338,22 +211,10 @@ func TestSearchFTS_OperatorWordsAsLiterals(t *testing.T) {
 	// the row containing the literal operator word matches. The test asserts
 	// exactly one match, so a regression that lost the FTS5 phrase-quoting
 	// fails here.
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "build AND deploy pipeline", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "build deploy pipeline", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "place item NEAR exit", Author: "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "place item by exit", Author: "tester",
-	})
-	require.NoError(t, err)
+	createTesterIssue(ctx, t, d, p.ID, "build AND deploy pipeline")
+	createTesterIssue(ctx, t, d, p.ID, "build deploy pipeline")
+	createTesterIssue(ctx, t, d, p.ID, "place item NEAR exit")
+	createTesterIssue(ctx, t, d, p.ID, "place item by exit")
 
 	cases := []struct {
 		name, query, wantTitle string
@@ -384,14 +245,8 @@ func TestSearchFTS_OperatorWordsAsLiterals(t *testing.T) {
 // can decide. With AND, "login crash Safari critical" excludes a row that
 // only contains "login crash Safari" (no "critical").
 func TestSearchFTSAny_FindsNearDuplicates(t *testing.T) {
-	d := openTestDB(t)
-	ctx := context.Background()
-	p, err := d.CreateProject(ctx, "p", "p")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID, Title: "login crash on Safari", Body: "stack trace", Author: "tester",
-	})
-	require.NoError(t, err)
+	d, ctx, p := setupTestProject(t)
+	createTesterIssueWithBody(ctx, t, d, p.ID, "login crash on Safari", "stack trace")
 
 	// Implicit-AND: query has an extra token ("critical") that the row lacks
 	// — the row is filtered out before similarity scoring would see it.

--- a/internal/db/schema_completeness_test.go
+++ b/internal/db/schema_completeness_test.go
@@ -2,11 +2,11 @@ package db_test
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/wesm/kata/internal/db"
 )
 
 // TestAllSchemaTablesExist guards against a future migration accidentally
@@ -23,11 +23,7 @@ func TestAllSchemaTablesExist(t *testing.T) {
 		"meta", "issues_fts",
 	}
 	for _, name := range wanted {
-		var n int
-		err := d.QueryRowContext(context.Background(),
-			`SELECT 1 FROM sqlite_master WHERE name = ?`, name).Scan(&n)
-		require.NoErrorf(t, err, "table %q missing from schema", name)
-		assert.Equal(t, 1, n, name)
+		assertSchemaObject(t, d, name)
 	}
 }
 
@@ -64,9 +60,7 @@ func TestSchemaUIDColumnsIndexesAndTriggers(t *testing.T) {
 	}
 }
 
-func assertColumn(t *testing.T, d interface {
-	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
-}, table, column, typ string, notNull bool) {
+func assertColumn(t *testing.T, d *db.DB, table, column, typ string, notNull bool) {
 	t.Helper()
 	rows, err := d.QueryContext(context.Background(), `PRAGMA table_info(`+table+`)`)
 	require.NoError(t, err)
@@ -91,9 +85,7 @@ func assertColumn(t *testing.T, d interface {
 	t.Fatalf("column %s.%s missing", table, column)
 }
 
-func assertSchemaObject(t *testing.T, d interface {
-	QueryRowContext(context.Context, string, ...any) *sql.Row
-}, name string) {
+func assertSchemaObject(t *testing.T, d *db.DB, name string) {
 	t.Helper()
 	var got string
 	err := d.QueryRowContext(context.Background(),

--- a/internal/db/testhelpers_test.go
+++ b/internal/db/testhelpers_test.go
@@ -1,0 +1,255 @@
+package db_test
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wesm/kata/internal/db"
+	"github.com/wesm/kata/internal/uid"
+)
+
+// openTestDB opens a fresh database in a temporary directory and registers
+// cleanup to close it when the test ends.
+func openTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	d, _ := openTestDBWithPath(t)
+	return d
+}
+
+// openTestDBWithPath is like openTestDB but also returns the on-disk path,
+// useful for tests that need to reopen the database or pre-seed it.
+func openTestDBWithPath(t *testing.T) (*db.DB, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kata.db")
+	d, err := db.Open(context.Background(), path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+	return d, path
+}
+
+// assertSchemaVersion checks that the schema_version row in meta matches the
+// expected version.
+func assertSchemaVersion(t *testing.T, d *db.DB, expected int) {
+	t.Helper()
+	var got string
+	require.NoError(t, d.QueryRow(`SELECT value FROM meta WHERE key='schema_version'`).Scan(&got))
+	assert.Equal(t, strconv.Itoa(expected), got)
+}
+
+// createKataProject creates the canonical "github.com/wesm/kata" / "kata"
+// project used by tests that need a project to exist but don't care about its
+// identity.
+func createKataProject(ctx context.Context, t *testing.T, d *db.DB) db.Project {
+	t.Helper()
+	return createProject(ctx, t, d, "github.com/wesm/kata", "kata")
+}
+
+// createProject creates a project with the given url and name, asserting no
+// error. Use when a test needs a specific project identity (e.g. multiple
+// projects to exercise per-project filtering).
+func createProject(ctx context.Context, t *testing.T, d *db.DB, url, name string) db.Project {
+	t.Helper()
+	p, err := d.CreateProject(ctx, url, name)
+	require.NoError(t, err)
+	return p
+}
+
+// setupTestProject opens a fresh database and creates a generic "p"/"p"
+// project. Returns the db, a fresh context, and the project.
+func setupTestProject(t *testing.T) (*db.DB, context.Context, db.Project) {
+	t.Helper()
+	d := openTestDB(t)
+	ctx := context.Background()
+	p, err := d.CreateProject(ctx, "p", "p")
+	require.NoError(t, err)
+	return d, ctx, p
+}
+
+// unmarshalPayload decodes a JSON event payload into T and returns it.
+func unmarshalPayload[T any](t *testing.T, payload string) T {
+	t.Helper()
+	var dest T
+	require.NoError(t, json.Unmarshal([]byte(payload), &dest))
+	return dest
+}
+
+// makeIssue creates an issue under projectID with the given title and author,
+// returning only the issue. Used when the caller doesn't need the create event.
+//
+//nolint:revive // test helper: t *testing.T conventionally precedes ctx.
+func makeIssue(t *testing.T, ctx context.Context, d *db.DB, projectID int64, title, author string) db.Issue {
+	t.Helper()
+	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: projectID, Title: title, Author: author,
+	})
+	require.NoError(t, err)
+	return issue
+}
+
+// addLabels applies the given labels to issueID, asserting no error on each.
+func addLabels(ctx context.Context, t *testing.T, d *db.DB, issueID int64, author string, labels ...string) {
+	t.Helper()
+	for _, lbl := range labels {
+		_, err := d.AddLabel(ctx, issueID, lbl, author)
+		require.NoError(t, err)
+	}
+}
+
+// makeIssueWithLabels creates an issue and applies labels to it in one call.
+//
+//nolint:revive // test helper: t *testing.T conventionally precedes ctx.
+func makeIssueWithLabels(t *testing.T, ctx context.Context, d *db.DB, projectID int64, title, author string, labels ...string) db.Issue {
+	t.Helper()
+	issue := makeIssue(t, ctx, d, projectID, title, author)
+	addLabels(ctx, t, d, issue.ID, author, labels...)
+	return issue
+}
+
+// createTesterIssue creates an issue in projectID authored by "tester" with
+// the given title.
+func createTesterIssue(ctx context.Context, t *testing.T, d *db.DB, projectID int64, title string) (db.Issue, db.Event) {
+	t.Helper()
+	issue, evt, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: projectID,
+		Title:     title,
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	return issue, evt
+}
+
+// createTesterIssueWithBody creates an issue in projectID authored by "tester"
+// with the given title and body. Used by search/FTS tests where the body
+// content matters.
+func createTesterIssueWithBody(ctx context.Context, t *testing.T, d *db.DB, projectID int64, title, body string) db.Issue {
+	t.Helper()
+	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: projectID, Title: title, Body: body, Author: "tester",
+	})
+	require.NoError(t, err)
+	return issue
+}
+
+// addTesterComment adds a comment authored by "tester" to issueID with the
+// given body, asserting no error.
+func addTesterComment(ctx context.Context, t *testing.T, d *db.DB, issueID int64, body string) {
+	t.Helper()
+	_, _, err := d.CreateComment(ctx, db.CreateCommentParams{
+		IssueID: issueID, Author: "tester", Body: body,
+	})
+	require.NoError(t, err)
+}
+
+// createTesterIssues bulk-creates count issues in projectID, all authored by
+// "tester" with title "x". Used to advance event ids when a test cares only
+// about event sequencing, not issue content.
+func createTesterIssues(ctx context.Context, t *testing.T, d *db.DB, projectID int64, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		createTesterIssue(ctx, t, d, projectID, "x")
+	}
+}
+
+// setupTestIssue extends setupTestProject by also creating a single
+// "tester"-authored issue with title "x". Returns db, context, project, and
+// issue — the most common starting state for issue-mutation tests.
+func setupTestIssue(t *testing.T) (*db.DB, context.Context, db.Project, db.Issue) {
+	t.Helper()
+	d, ctx, p := setupTestProject(t)
+	issue, _ := createTesterIssue(ctx, t, d, p.ID, "x")
+	return d, ctx, p, issue
+}
+
+// setupSoftDeletedIssue extends setupTestIssue by soft-deleting the issue,
+// the starting state for tests that exercise restore/purge of an
+// already-deleted issue.
+func setupSoftDeletedIssue(t *testing.T) (*db.DB, context.Context, db.Project, db.Issue) {
+	t.Helper()
+	d, ctx, p, issue := setupTestIssue(t)
+	_, _, _, err := d.SoftDeleteIssue(ctx, issue.ID, "agent")
+	require.NoError(t, err)
+	return d, ctx, p, issue
+}
+
+// setupAssignedIssue extends setupTestIssue by assigning the issue to owner,
+// the starting state for tests that exercise reassignment or unassignment.
+func setupAssignedIssue(t *testing.T, owner string) (*db.DB, context.Context, db.Project, db.Issue) {
+	t.Helper()
+	d, ctx, p, issue := setupTestIssue(t)
+	_, _, _, err := d.UpdateOwner(ctx, issue.ID, &owner, "tester")
+	require.NoError(t, err)
+	return d, ctx, p, issue
+}
+
+// makeLink creates a link of the given type between fromID and toID under
+// projectID, authored by "tester". Used for setup steps that aren't themselves
+// the subject of an error assertion.
+func makeLink(ctx context.Context, t *testing.T, d *db.DB, projectID, fromID, toID int64, linkType string) db.Link {
+	t.Helper()
+	link, err := d.CreateLink(ctx, db.CreateLinkParams{
+		ProjectID:   projectID,
+		FromIssueID: fromID,
+		ToIssueID:   toID,
+		Type:        linkType,
+		Author:      "tester",
+	})
+	require.NoError(t, err)
+	return link
+}
+
+// attachAlias attaches a "git" alias to projectID, asserting no error. Used by
+// tests that need an alias as setup but aren't asserting on AttachAlias's
+// behavior.
+func attachAlias(ctx context.Context, t *testing.T, d *db.DB, projectID int64, identity, path string) db.ProjectAlias {
+	t.Helper()
+	a, err := d.AttachAlias(ctx, projectID, identity, "git", path)
+	require.NoError(t, err)
+	return a
+}
+
+// insertLegacyEvent stamps an event on the events table directly via SQL with
+// a caller-supplied created_at value. Used by stats-parser tests that need to
+// seed timestamps in the legacy zoned/space-separated layouts that
+// CreateIssue won't produce.
+func insertLegacyEvent(ctx context.Context, t *testing.T, d *db.DB, p db.Project, issue db.Issue, eventType, createdAt string) {
+	t.Helper()
+	eventUID, err := uid.New()
+	require.NoError(t, err)
+	_, err = d.ExecContext(ctx, `
+		INSERT INTO events (uid, origin_instance_uid, project_id, project_identity, issue_id, issue_number, type, actor, payload, created_at)
+		VALUES (?, (SELECT value FROM meta WHERE key='instance_uid'), ?, ?, ?, ?, ?, 'tester', '{}', ?)`,
+		eventUID, p.ID, p.Identity, issue.ID, issue.Number, eventType, createdAt)
+	require.NoError(t, err)
+}
+
+// strPtr returns a pointer to s. Used by tests that need to pass an optional
+// string parameter (e.g. issue owner) by address.
+func strPtr(s string) *string { return &s }
+
+// injectIdempotencyKey rewrites the issue.created event payload for issueID
+// to include the given idempotency key and fingerprint. Used by
+// LookupIdempotency tests to seed idempotency state directly, in isolation
+// from the CreateIssue idempotency path.
+func injectIdempotencyKey(ctx context.Context, t *testing.T, d *db.DB, issueID int64, key, fingerprint string) {
+	t.Helper()
+	_, err := d.ExecContext(ctx,
+		`UPDATE events
+		 SET payload = json_set(payload, '$.idempotency_key', ?, '$.idempotency_fingerprint', ?)
+		 WHERE issue_id = ? AND type = 'issue.created'`,
+		key, fingerprint, issueID)
+	require.NoError(t, err)
+}
+
+// assertRowCount runs a count query and asserts the result equals expected.
+// Reduces visual noise in tests that need to verify cascade-delete behavior.
+func assertRowCount(ctx context.Context, t *testing.T, d *db.DB, expected int, msg, query string, args ...any) {
+	t.Helper()
+	var n int
+	require.NoError(t, d.QueryRowContext(ctx, query, args...).Scan(&n))
+	assert.Equal(t, expected, n, msg)
+}

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -40,20 +40,55 @@ func TestLoadedConfig_FieldsExist(t *testing.T) {
 	}
 }
 
-func writeTOML(t *testing.T, body string) string {
+// setupKataHome creates a temp directory and points $KATA_HOME at it.
+func setupKataHome(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	t.Setenv("KATA_HOME", dir)
+	return dir
+}
+
+func writeTOML(t *testing.T, body string) string {
+	t.Helper()
+	dir := setupKataHome(t)
 	path := filepath.Join(dir, "hooks.toml")
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("KATA_HOME", dir)
 	return path
 }
 
+// assertLoadError writes body, calls LoadStartup, and fails the test unless
+// LoadStartup returns a non-nil error. msg describes what should have been
+// rejected.
+func assertLoadError(t *testing.T, body, msg string) {
+	t.Helper()
+	p := writeTOML(t, body)
+	if _, err := LoadStartup(p); err == nil {
+		t.Fatal(msg)
+	}
+}
+
+// assertLoadOK writes body, calls LoadStartup, and fails the test if it
+// returns an error. Returns the parsed LoadedConfig for further assertions.
+func assertLoadOK(t *testing.T, body string) LoadedConfig {
+	t.Helper()
+	p := writeTOML(t, body)
+	lc, err := LoadStartup(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return lc
+}
+
+// defaultTestConfig is the baseline Config used as the "current" state in
+// reload tests.
+func defaultTestConfig() Config {
+	return Config{PoolSize: 4, QueueCap: 1000}
+}
+
 func TestLoadStartup_FileMissing_EmptySnapshotDefaults(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("KATA_HOME", dir)
+	dir := setupKataHome(t)
 	lc, err := LoadStartup(filepath.Join(dir, "hooks.toml"))
 	if err != nil {
 		t.Fatalf("missing file should not be an error: %v", err)
@@ -67,10 +102,7 @@ func TestLoadStartup_FileMissing_EmptySnapshotDefaults(t *testing.T) {
 }
 
 func TestLoadStartup_Malformed_ReturnsError(t *testing.T) {
-	p := writeTOML(t, "[[hook]]\nevent = ")
-	if _, err := LoadStartup(p); err == nil {
-		t.Fatal("malformed TOML should error")
-	}
+	assertLoadError(t, "[[hook]]\nevent = ", "malformed TOML should error")
 }
 
 // TestLoadReload_Malformed_ReturnsError pins spec §4.6: SIGHUP / malformed →
@@ -79,17 +111,14 @@ func TestLoadStartup_Malformed_ReturnsError(t *testing.T) {
 // surfaces.
 func TestLoadReload_Malformed_ReturnsError(t *testing.T) {
 	p := writeTOML(t, "[[hook]]\nevent = ")
-	cur := Config{PoolSize: 4, QueueCap: 1000}
-	if _, err := LoadReload(p, cur); err == nil {
+	if _, err := LoadReload(p, defaultTestConfig()); err == nil {
 		t.Fatal("malformed TOML on reload should error")
 	}
 }
 
 func TestLoadReload_Missing_EmptySnapshotNoError(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("KATA_HOME", dir)
-	cur := Config{PoolSize: 4, QueueCap: 1000}
-	lc, err := LoadReload(filepath.Join(dir, "hooks.toml"), cur)
+	dir := setupKataHome(t)
+	lc, err := LoadReload(filepath.Join(dir, "hooks.toml"), defaultTestConfig())
 	if err != nil {
 		t.Fatalf("missing file on reload: %v", err)
 	}
@@ -135,25 +164,19 @@ ploo_size = 8
 }
 
 func TestLoad_EventStarCreated_Error(t *testing.T) {
-	p := writeTOML(t, `
+	assertLoadError(t, `
 [[hook]]
 event   = "*.created"
 command = "/bin/true"
-`)
-	if _, err := LoadStartup(p); err == nil {
-		t.Fatal("event = *.created must be rejected")
-	}
+`, "event = *.created must be rejected")
 }
 
 func TestLoad_EventSyncResetRequired_Error(t *testing.T) {
-	p := writeTOML(t, `
+	assertLoadError(t, `
 [[hook]]
 event   = "sync.reset_required"
 command = "/bin/true"
-`)
-	if _, err := LoadStartup(p); err == nil {
-		t.Fatal("event = sync.reset_required must be rejected")
-	}
+`, "event = sync.reset_required must be rejected")
 }
 
 func TestLoad_CommandPaths(t *testing.T) {
@@ -175,41 +198,33 @@ func TestLoad_CommandPaths(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			p := writeTOML(t, "[[hook]]\nevent = \"issue.created\"\ncommand = \""+c.cmd+"\"\n")
-			_, err := LoadStartup(p)
-			if c.ok && err != nil {
-				t.Fatalf("command %q should be ok, got %v", c.cmd, err)
-			}
-			if !c.ok && err == nil {
-				t.Fatalf("command %q should be rejected", c.cmd)
+			body := "[[hook]]\nevent = \"issue.created\"\ncommand = \"" + c.cmd + "\"\n"
+			if c.ok {
+				assertLoadOK(t, body)
+			} else {
+				assertLoadError(t, body, "command "+c.cmd+" should be rejected")
 			}
 		})
 	}
 }
 
 func TestLoad_RelativeWorkingDir_Error(t *testing.T) {
-	p := writeTOML(t, `
+	assertLoadError(t, `
 [[hook]]
 event       = "issue.created"
 command     = "/bin/true"
 working_dir = "relative/path"
-`)
-	if _, err := LoadStartup(p); err == nil {
-		t.Fatal("relative working_dir must be rejected")
-	}
+`, "relative working_dir must be rejected")
 }
 
 func TestLoad_KataPrefixedEnv_Error(t *testing.T) {
-	p := writeTOML(t, `
+	assertLoadError(t, `
 [[hook]]
 event   = "issue.created"
 command = "/bin/true"
 [hook.env]
 KATA_FOO = "x"
-`)
-	if _, err := LoadStartup(p); err == nil {
-		t.Fatal("[hook.env] keys matching ^KATA_ must be rejected")
-	}
+`, "[hook.env] keys matching ^KATA_ must be rejected")
 }
 
 func TestLoad_HookCountCap(t *testing.T) {
@@ -217,14 +232,11 @@ func TestLoad_HookCountCap(t *testing.T) {
 	for i := 0; i < 257; i++ {
 		b.WriteString("[[hook]]\nevent = \"issue.created\"\ncommand = \"/bin/true\"\n")
 	}
-	p := writeTOML(t, b.String())
-	if _, err := LoadStartup(p); err == nil {
-		t.Fatal("257 [[hook]] entries must be rejected (cap 256)")
-	}
+	assertLoadError(t, b.String(), "257 [[hook]] entries must be rejected (cap 256)")
 }
 
 func TestLoad_SizeUnitsBinary(t *testing.T) {
-	p := writeTOML(t, `
+	lc := assertLoadOK(t, `
 [hooks]
 output_disk_cap = "100k"
 runs_log_max    = "1MB"
@@ -232,10 +244,6 @@ runs_log_max    = "1MB"
 event   = "issue.created"
 command = "/bin/true"
 `)
-	lc, err := LoadStartup(p)
-	if err != nil {
-		t.Fatal(err)
-	}
 	if lc.Config.OutputDiskCap != 100*1024 {
 		t.Fatalf("100k = %d, want %d", lc.Config.OutputDiskCap, 100*1024)
 	}
@@ -245,7 +253,7 @@ command = "/bin/true"
 }
 
 func TestLoad_UserEnvSorted(t *testing.T) {
-	p := writeTOML(t, `
+	lc := assertLoadOK(t, `
 [[hook]]
 event   = "issue.created"
 command = "/bin/true"
@@ -254,10 +262,6 @@ ZED   = "z"
 ALPHA = "a"
 MID   = "m"
 `)
-	lc, err := LoadStartup(p)
-	if err != nil {
-		t.Fatal(err)
-	}
 	got := lc.Snapshot.Hooks[0].UserEnv
 	want := []string{"ALPHA=a", "MID=m", "ZED=z"}
 	if !reflect.DeepEqual(got, want) {
@@ -266,8 +270,7 @@ MID   = "m"
 }
 
 func TestLoad_DefaultWorkingDir_IsKataHome(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("KATA_HOME", dir)
+	dir := setupKataHome(t)
 	path := filepath.Join(dir, "hooks.toml")
 	if err := os.WriteFile(path, []byte("[[hook]]\nevent = \"issue.created\"\ncommand = \"/bin/true\"\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -295,13 +298,11 @@ func TestLoad_TimeoutBounds(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			p := writeTOML(t, "[[hook]]\nevent=\"issue.created\"\ncommand=\"/bin/true\"\ntimeout=\""+c.v+"\"\n")
-			_, err := LoadStartup(p)
-			if c.ok && err != nil {
-				t.Fatalf("timeout %q should be ok: %v", c.v, err)
-			}
-			if !c.ok && err == nil {
-				t.Fatalf("timeout %q should be rejected", c.v)
+			body := "[[hook]]\nevent=\"issue.created\"\ncommand=\"/bin/true\"\ntimeout=\"" + c.v + "\"\n"
+			if c.ok {
+				assertLoadOK(t, body)
+			} else {
+				assertLoadError(t, body, "timeout "+c.v+" should be rejected")
 			}
 		})
 	}
@@ -309,10 +310,7 @@ func TestLoad_TimeoutBounds(t *testing.T) {
 
 func TestLoad_PoolSizeBounds(t *testing.T) {
 	for _, body := range []string{"[hooks]\npool_size = 0\n", "[hooks]\npool_size = 17\n"} {
-		p := writeTOML(t, body)
-		if _, err := LoadStartup(p); err == nil {
-			t.Fatalf("body %q should be rejected", body)
-		}
+		assertLoadError(t, body, "body "+body+" should be rejected")
 	}
 }
 
@@ -320,15 +318,11 @@ func TestLoad_PoolSizeBounds(t *testing.T) {
 // output_disk_cap = 100) are valid byte values, alongside unit-suffixed
 // strings like "100MB". Spec §4.2 lists both forms.
 func TestLoad_SizeAcceptsBareInteger(t *testing.T) {
-	p := writeTOML(t, `
+	lc := assertLoadOK(t, `
 [hooks]
 output_disk_cap = 12345
 runs_log_max    = 67890
 `)
-	lc, err := LoadStartup(p)
-	if err != nil {
-		t.Fatalf("bare integer sizes should load: %v", err)
-	}
 	if lc.Config.OutputDiskCap != 12345 {
 		t.Fatalf("output_disk_cap = %d, want 12345", lc.Config.OutputDiskCap)
 	}
@@ -342,27 +336,21 @@ runs_log_max    = 67890
 func TestLoad_SizeOverflow(t *testing.T) {
 	// 9223372036854775807 / 1024 / 1024 ≈ 8796093022207 → adding "mb" puts
 	// us above MaxInt64.
-	p := writeTOML(t, `
+	assertLoadError(t, `
 [hooks]
 output_disk_cap = "9999999999999mb"
-`)
-	if _, err := LoadStartup(p); err == nil {
-		t.Fatal("massively oversize size value should be rejected")
-	}
+`, "massively oversize size value should be rejected")
 }
 
 // TestLoad_AbsolutePathWithSpaces pins that command validation accepts
 // internal whitespace inside an absolute path (Windows "Program Files"
 // or Unix custom dirs), while still rejecting bare names with spaces.
 func TestLoad_AbsolutePathWithSpaces(t *testing.T) {
-	p := writeTOML(t, `
+	assertLoadOK(t, `
 [[hook]]
 event   = "issue.created"
 command = "/Applications/Some App/bin/notify"
 `)
-	if _, err := LoadStartup(p); err != nil {
-		t.Fatalf("absolute path with spaces should be accepted: %v", err)
-	}
 }
 
 // TestMatch_IssueStarOnlyKnown pins that the issue.* matcher rejects

--- a/internal/hooks/dispatcher_test.go
+++ b/internal/hooks/dispatcher_test.go
@@ -14,10 +14,13 @@ import (
 	"github.com/wesm/kata/internal/db"
 )
 
+// mustNewDispatcher builds a Dispatcher rooted at a fresh temp KataHome with
+// no-op resolvers and returns the dispatcher, a buffer capturing the daemon
+// log, and the absolute path to the runs.jsonl appender for that DB.
 func mustNewDispatcher(t *testing.T, hooks []ResolvedHook, cfg Config) (*Dispatcher, *strings.Builder, string) {
 	t.Helper()
 	root := t.TempDir()
-	dbHash := "testdbhash01"
+	const dbHash = "testdbhash01"
 	logBuf := &strings.Builder{}
 	deps := DispatcherDeps{
 		DBHash:          dbHash,
@@ -40,7 +43,40 @@ func mustNewDispatcher(t *testing.T, hooks []ResolvedHook, cfg Config) (*Dispatc
 		defer cancel()
 		_ = d.Shutdown(ctx)
 	})
-	return d, logBuf, dbHash
+	return d, logBuf, filepath.Join(root, "hooks", dbHash, "runs.jsonl")
+}
+
+// newTestHook builds a ResolvedHook that runs the hookprobe binary with the
+// given args and a 2s timeout. event "*" matches every event; any other
+// value is matched exactly.
+func newTestHook(t *testing.T, event string, args ...string) ResolvedHook {
+	t.Helper()
+	match := matchExact(event)
+	if event == "*" {
+		match = matchAlways()
+	}
+	return ResolvedHook{
+		Index:      0,
+		Event:      event,
+		Match:      match,
+		Command:    hookprobePath(t),
+		Args:       args,
+		Timeout:    2 * time.Second,
+		WorkingDir: t.TempDir(),
+	}
+}
+
+// enqueueEvents pushes count events of the given type into d, with sequential
+// IDs starting at startID and ProjectID/ProjectIdentity placeholders.
+func enqueueEvents(d *Dispatcher, eventType string, startID, count int) {
+	for i := 0; i < count; i++ {
+		d.Enqueue(db.Event{
+			ID:              int64(startID + i),
+			Type:            eventType,
+			ProjectID:       1,
+			ProjectIdentity: "x",
+		})
+	}
 }
 
 func TestDispatcher_NewNoop_ImplementsSink(t *testing.T) {
@@ -52,38 +88,31 @@ func TestDispatcher_NewNoop_ImplementsSink(t *testing.T) {
 }
 
 func TestDispatcher_Enqueue_RoutesToMatchingHooks(t *testing.T) {
-	bin := hookprobePath(t)
-	dir := t.TempDir()
-	hookA := ResolvedHook{Index: 0, Event: "issue.created", Match: matchExact("issue.created"), Command: bin, Args: []string{"exit", "0"}, Timeout: 2 * time.Second, WorkingDir: dir}
-	hookB := ResolvedHook{Index: 1, Event: "issue.updated", Match: matchExact("issue.updated"), Command: bin, Args: []string{"exit", "0"}, Timeout: 2 * time.Second, WorkingDir: dir}
+	hookA := newTestHook(t, "issue.created", "exit", "0")
+	hookB := newTestHook(t, "issue.updated", "exit", "0")
+	hookB.Index = 1
 	cfg := defaultConfig()
 	cfg.PoolSize = 2
 	cfg.QueueCap = 8
-	d, _, dbHash := mustNewDispatcher(t, []ResolvedHook{hookA, hookB}, cfg)
-	d.Enqueue(db.Event{ID: 100, Type: "issue.created", ProjectID: 1, ProjectIdentity: "x"})
-	// Wait for runs.jsonl to receive a line.
-	runsPath := filepath.Join(d.deps.KataHome, "hooks", dbHash, "runs.jsonl")
+	d, _, runsPath := mustNewDispatcher(t, []ResolvedHook{hookA, hookB}, cfg)
+	enqueueEvents(d, "issue.created", 100, 1)
 	if !waitForLines(t, runsPath, 1, 2*time.Second) {
 		t.Fatal("expected 1 run for hookA")
 	}
-	d.Enqueue(db.Event{ID: 101, Type: "issue.updated", ProjectID: 1, ProjectIdentity: "x"})
+	enqueueEvents(d, "issue.updated", 101, 1)
 	if !waitForLines(t, runsPath, 2, 2*time.Second) {
 		t.Fatal("expected 2 runs after second event")
 	}
 }
 
 func TestDispatcher_Enqueue_QueueFullDropsAndCounts(t *testing.T) {
-	bin := hookprobePath(t)
-	dir := t.TempDir()
-	slow := ResolvedHook{Index: 0, Event: "*", Match: matchAlways(), Command: bin, Args: []string{"sleep", "200ms"}, Timeout: 2 * time.Second, WorkingDir: dir}
+	slow := newTestHook(t, "*", "sleep", "200ms")
 	cfg := defaultConfig()
 	cfg.PoolSize = 1
 	cfg.QueueCap = 1
 	cfg.QueueFullLogInterval = 10 * time.Millisecond
 	d, _, _ := mustNewDispatcher(t, []ResolvedHook{slow}, cfg)
-	for i := 0; i < 10; i++ {
-		d.Enqueue(db.Event{ID: int64(200 + i), Type: "issue.created", ProjectID: 1, ProjectIdentity: "x"})
-	}
+	enqueueEvents(d, "issue.created", 200, 10)
 	// At least N-2 should drop (1 in queue + 1 in flight + N-2 dropped).
 	if got := d.dropped.Load(); got < 5 {
 		t.Fatalf("dropped=%d, want >=5", got)
@@ -115,14 +144,13 @@ func TestDispatcher_Shutdown_Idempotent(t *testing.T) {
 }
 
 func TestDispatcher_Shutdown_Timeout_ReportsInflight(t *testing.T) {
-	bin := hookprobePath(t)
-	dir := t.TempDir()
-	stuck := ResolvedHook{Index: 0, Event: "*", Match: matchAlways(), Command: bin, Args: []string{"term-ignore", "10s"}, Timeout: 5 * time.Second, WorkingDir: dir}
+	stuck := newTestHook(t, "*", "term-ignore", "10s")
+	stuck.Timeout = 5 * time.Second
 	cfg := defaultConfig()
 	cfg.PoolSize = 1
 	cfg.QueueCap = 4
 	d, logBuf, _ := mustNewDispatcher(t, []ResolvedHook{stuck}, cfg)
-	d.Enqueue(db.Event{ID: 300, Type: "issue.created", ProjectID: 1, ProjectIdentity: "x"})
+	enqueueEvents(d, "issue.created", 300, 1)
 	// Give the worker a moment to start.
 	time.Sleep(100 * time.Millisecond)
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -136,23 +164,18 @@ func TestDispatcher_Shutdown_Timeout_ReportsInflight(t *testing.T) {
 }
 
 func TestDispatcher_Shutdown_DropsQueued(t *testing.T) {
-	bin := hookprobePath(t)
-	dir := t.TempDir()
-	hold := ResolvedHook{Index: 0, Event: "*", Match: matchAlways(), Command: bin, Args: []string{"sleep", "500ms"}, Timeout: 2 * time.Second, WorkingDir: dir}
+	hold := newTestHook(t, "*", "sleep", "500ms")
 	cfg := defaultConfig()
 	cfg.PoolSize = 1
 	cfg.QueueCap = 4
-	d, _, dbHash := mustNewDispatcher(t, []ResolvedHook{hold}, cfg)
-	for i := 0; i < 5; i++ {
-		d.Enqueue(db.Event{ID: int64(400 + i), Type: "issue.created", ProjectID: 1, ProjectIdentity: "x"})
-	}
+	d, _, runsPath := mustNewDispatcher(t, []ResolvedHook{hold}, cfg)
+	enqueueEvents(d, "issue.created", 400, 5)
 	time.Sleep(50 * time.Millisecond) // worker has popped one
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	if err := d.Shutdown(ctx); err != nil {
 		t.Fatal(err)
 	}
-	runsPath := filepath.Join(d.deps.KataHome, "hooks", dbHash, "runs.jsonl")
 	lines := countJSONLLines(runsPath)
 	// Only the in-flight job should have produced a line. (4xx all
 	// completing would be > 1.) Allow <=2 to tolerate edge timing.
@@ -162,21 +185,17 @@ func TestDispatcher_Shutdown_DropsQueued(t *testing.T) {
 }
 
 func TestDispatcher_Reload_AtomicWithEnqueue(t *testing.T) {
-	bin := hookprobePath(t)
-	dir := t.TempDir()
-	first := ResolvedHook{Index: 0, Event: "*", Match: matchAlways(), Command: bin, Args: []string{"exit", "0"}, Timeout: 2 * time.Second, WorkingDir: dir}
+	first := newTestHook(t, "*", "exit", "0")
 	cfg := defaultConfig()
 	d, _, _ := mustNewDispatcher(t, []ResolvedHook{first}, cfg)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 200; i++ {
-			d.Enqueue(db.Event{ID: int64(i), Type: "issue.created", ProjectID: 1, ProjectIdentity: "x"})
-		}
+		enqueueEvents(d, "issue.created", 0, 200)
 	}()
 	for i := 0; i < 50; i++ {
-		newHook := ResolvedHook{Index: 0, Event: "issue.created", Match: matchExact("issue.created"), Command: bin, Args: []string{"exit", "0"}, Timeout: 2 * time.Second, WorkingDir: dir}
+		newHook := newTestHook(t, "issue.created", "exit", "0")
 		d.Reload(LoadedConfig{Snapshot: Snapshot{Hooks: []ResolvedHook{newHook}}, Config: cfg})
 		time.Sleep(2 * time.Millisecond)
 	}
@@ -184,9 +203,8 @@ func TestDispatcher_Reload_AtomicWithEnqueue(t *testing.T) {
 }
 
 func TestDispatcher_AliasResolverContext_CancelsOnShutdown(t *testing.T) {
-	bin := hookprobePath(t)
-	dir := t.TempDir()
-	h := ResolvedHook{Index: 0, Event: "*", Match: matchAlways(), Command: bin, Args: []string{"sleep", "5s"}, Timeout: 30 * time.Second, WorkingDir: dir}
+	h := newTestHook(t, "*", "sleep", "5s")
+	h.Timeout = 30 * time.Second
 	cfg := defaultConfig()
 	cfg.PoolSize = 1
 	cfg.QueueCap = 1
@@ -221,7 +239,7 @@ func TestDispatcher_AliasResolverContext_CancelsOnShutdown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d.Enqueue(db.Event{ID: 500, Type: "issue.created", ProjectID: 1, ProjectIdentity: "x"})
+	enqueueEvents(d, "issue.created", 500, 1)
 	// Wait briefly for the worker to invoke the resolver.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {

--- a/internal/hooks/hookprobe_helper_test.go
+++ b/internal/hooks/hookprobe_helper_test.go
@@ -56,58 +56,62 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func TestHookprobe_StdinEcho(t *testing.T) {
-	bin := hookprobePath(t)
-	cmd := exec.Command(bin, "stdin") //nolint:gosec // bin is the test-built helper
-	cmd.Stdin = strings.NewReader("hello\n")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
+// runHookprobe builds an exec.Cmd for the hookprobe binary, optionally wires
+// stdin and extra env vars, runs it, and returns captured stdout/stderr along
+// with the resolved exit code.
+func runHookprobe(t testing.TB, stdin string, env []string, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command(hookprobePath(t), args...) //nolint:gosec // bin is the test-built helper
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
 	}
-	if out.String() != "hello\n" {
-		t.Fatalf("stdin echo = %q, want %q", out.String(), "hello\n")
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	exit := exitCode(t, cmd.Run())
+	return stdout.String(), stderr.String(), exit
+}
+
+func TestHookprobe_StdinEcho(t *testing.T) {
+	stdout, _, exit := runHookprobe(t, "hello\n", nil, "stdin")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if stdout != "hello\n" {
+		t.Fatalf("stdin echo = %q, want %q", stdout, "hello\n")
 	}
 }
 
 func TestHookprobe_ExitCode(t *testing.T) {
-	bin := hookprobePath(t)
-	cmd := exec.Command(bin, "exit", "7") //nolint:gosec // bin is the test-built helper
-	err := cmd.Run()
-	exit := exitCode(t, err)
+	_, _, exit := runHookprobe(t, "", nil, "exit", "7")
 	if exit != 7 {
 		t.Fatalf("exit code = %d, want 7", exit)
 	}
 }
 
 func TestHookprobe_EnvKey(t *testing.T) {
-	bin := hookprobePath(t)
-	cmd := exec.Command(bin, "env", "KATA_TEST_X") //nolint:gosec // bin is the test-built helper
-	cmd.Env = append(os.Environ(), "KATA_TEST_X=hello-world")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
+	stdout, _, exit := runHookprobe(t, "", []string{"KATA_TEST_X=hello-world"}, "env", "KATA_TEST_X")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
 	}
-	if strings.TrimSpace(out.String()) != "hello-world" {
-		t.Fatalf("env value = %q, want %q", out.String(), "hello-world")
+	if strings.TrimSpace(stdout) != "hello-world" {
+		t.Fatalf("env value = %q, want %q", stdout, "hello-world")
 	}
 }
 
 func TestHookprobe_Both(t *testing.T) {
-	bin := hookprobePath(t)
-	cmd := exec.Command(bin, "both", "outline", "errline") //nolint:gosec // bin is the test-built helper
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
+	stdout, stderr, exit := runHookprobe(t, "", nil, "both", "outline", "errline")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
 	}
-	if !strings.Contains(stdout.String(), "outline") {
-		t.Fatalf("stdout = %q, want outline", stdout.String())
+	if !strings.Contains(stdout, "outline") {
+		t.Fatalf("stdout = %q, want outline", stdout)
 	}
-	if !strings.Contains(stderr.String(), "errline") {
-		t.Fatalf("stderr = %q, want errline", stderr.String())
+	if !strings.Contains(stderr, "errline") {
+		t.Fatalf("stderr = %q, want errline", stderr)
 	}
 }
 

--- a/internal/hooks/payload_test.go
+++ b/internal/hooks/payload_test.go
@@ -49,15 +49,45 @@ func okAlias(_ context.Context, _ db.Event) (AliasSnapshot, bool, error) {
 	return AliasSnapshot{Identity: "github.com/wesm/kata", Kind: "git", RootPath: "/Users/wesm/code/kata"}, true, nil
 }
 
-func TestBuildStdin_HappyPath(t *testing.T) {
-	evt := sampleEvent("issue.commented")
-	out, truncated := buildStdinJSON(context.Background(), evt, okProject, okIssue, okComment, okAlias, nopLog())
-	if truncated {
-		t.Fatal("happy path should not truncate")
+// buildOpts captures the resolver/logger inputs to buildStdinJSON; tests
+// override only the fields they care about via withXxx options.
+type buildOpts struct {
+	rp  projectResolver
+	ri  issueResolver
+	rc  commentResolver
+	ra  aliasResolver
+	log logfn
+}
+
+type buildOption func(*buildOpts)
+
+func withProject(r projectResolver) buildOption { return func(o *buildOpts) { o.rp = r } }
+func withIssue(r issueResolver) buildOption     { return func(o *buildOpts) { o.ri = r } }
+func withComment(r commentResolver) buildOption { return func(o *buildOpts) { o.rc = r } }
+func withAlias(r aliasResolver) buildOption     { return func(o *buildOpts) { o.ra = r } }
+func withLog(l logfn) buildOption               { return func(o *buildOpts) { o.log = l } }
+
+// runBuild invokes buildStdinJSON with the okXxx defaults, applies overrides,
+// and unmarshals the result. Returns raw bytes, decoded envelope, and the
+// truncated flag.
+func runBuild(t *testing.T, evt db.Event, opts ...buildOption) ([]byte, map[string]any, bool) {
+	t.Helper()
+	o := buildOpts{rp: okProject, ri: okIssue, rc: okComment, ra: okAlias, log: nopLog()}
+	for _, opt := range opts {
+		opt(&o)
 	}
+	out, truncated := buildStdinJSON(context.Background(), evt, o.rp, o.ri, o.rc, o.ra, o.log)
 	var got map[string]any
 	if err := json.Unmarshal(out, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
+	}
+	return out, got, truncated
+}
+
+func TestBuildStdin_HappyPath(t *testing.T) {
+	_, got, truncated := runBuild(t, sampleEvent("issue.commented"))
+	if truncated {
+		t.Fatal("happy path should not truncate")
 	}
 	if got["kata_hook_version"].(float64) != 1 {
 		t.Fatalf("kata_hook_version: %v", got["kata_hook_version"])
@@ -84,26 +114,20 @@ func TestBuildStdin_HappyPath(t *testing.T) {
 }
 
 func TestBuildStdin_AliasMissing_OmitsBlock(t *testing.T) {
-	evt := sampleEvent("issue.created")
 	noAlias := func(_ context.Context, _ db.Event) (AliasSnapshot, bool, error) { return AliasSnapshot{}, false, nil }
-	out, _ := buildStdinJSON(context.Background(), evt, okProject, okIssue, okComment, noAlias, nopLog())
-	var got map[string]any
-	_ = json.Unmarshal(out, &got)
+	_, got, _ := runBuild(t, sampleEvent("issue.created"), withAlias(noAlias))
 	if _, ok := got["alias"]; ok {
 		t.Fatal("alias block should be omitted")
 	}
 }
 
 func TestBuildStdin_AliasError_OmitsBlockLogs(t *testing.T) {
-	evt := sampleEvent("issue.created")
 	errAlias := func(_ context.Context, _ db.Event) (AliasSnapshot, bool, error) {
 		return AliasSnapshot{}, false, errors.New("boom")
 	}
 	logged := []string{}
 	logger := func(format string, _ ...any) { logged = append(logged, format) }
-	out, _ := buildStdinJSON(context.Background(), evt, okProject, okIssue, okComment, errAlias, logger)
-	var got map[string]any
-	_ = json.Unmarshal(out, &got)
+	_, got, _ := runBuild(t, sampleEvent("issue.created"), withAlias(errAlias), withLog(logger))
 	if _, ok := got["alias"]; ok {
 		t.Fatal("alias block should be omitted on resolver error")
 	}
@@ -113,24 +137,18 @@ func TestBuildStdin_AliasError_OmitsBlockLogs(t *testing.T) {
 }
 
 func TestBuildStdin_IssueResolverError_OmitsIssueBlock(t *testing.T) {
-	evt := sampleEvent("issue.created")
 	bad := func(_ context.Context, _ int64) (IssueSnapshot, error) { return IssueSnapshot{}, errors.New("db down") }
-	out, _ := buildStdinJSON(context.Background(), evt, okProject, bad, okComment, okAlias, nopLog())
-	var got map[string]any
-	_ = json.Unmarshal(out, &got)
+	_, got, _ := runBuild(t, sampleEvent("issue.created"), withIssue(bad))
 	if _, ok := got["issue"]; ok {
 		t.Fatal("issue block should be omitted when IssueResolver errors")
 	}
 }
 
 func TestBuildStdin_ProjectResolverError_KeepsIDAndIdentity(t *testing.T) {
-	evt := sampleEvent("issue.created")
 	bad := func(_ context.Context, _ int64) (ProjectSnapshot, error) {
 		return ProjectSnapshot{}, errors.New("db down")
 	}
-	out, _ := buildStdinJSON(context.Background(), evt, bad, okIssue, okComment, okAlias, nopLog())
-	var got map[string]any
-	_ = json.Unmarshal(out, &got)
+	_, got, _ := runBuild(t, sampleEvent("issue.created"), withProject(bad))
 	proj := got["project"].(map[string]any)
 	if proj["id"].(float64) != 3 {
 		t.Fatalf("project.id should still be present: %v", proj["id"])
@@ -141,27 +159,23 @@ func TestBuildStdin_ProjectResolverError_KeepsIDAndIdentity(t *testing.T) {
 }
 
 func TestBuildStdin_NonCommentEvent_SkipsCommentResolver(t *testing.T) {
-	evt := sampleEvent("issue.created")
 	called := false
 	cr := func(_ context.Context, _ int64) (CommentSnapshot, error) {
 		called = true
 		return CommentSnapshot{}, nil
 	}
-	_, _ = buildStdinJSON(context.Background(), evt, okProject, okIssue, cr, okAlias, nopLog())
+	_, _, _ = runBuild(t, sampleEvent("issue.created"), withComment(cr))
 	if called {
 		t.Fatal("CommentResolver must not be invoked for non-issue.commented events")
 	}
 }
 
 func TestBuildStdin_TitleTruncated(t *testing.T) {
-	evt := sampleEvent("issue.created")
 	bigTitle := strings.Repeat("A", 2*1024)
 	bigIssue := func(_ context.Context, _ int64) (IssueSnapshot, error) {
 		return IssueSnapshot{Number: 1, Title: bigTitle, Status: "open"}, nil
 	}
-	out, _ := buildStdinJSON(context.Background(), evt, okProject, bigIssue, okComment, okAlias, nopLog())
-	var got map[string]any
-	_ = json.Unmarshal(out, &got)
+	_, got, _ := runBuild(t, sampleEvent("issue.created"), withIssue(bigIssue))
 	issue := got["issue"].(map[string]any)
 	if issue["_truncated"] != true {
 		t.Fatal("issue._truncated should be true for 2KB title")
@@ -172,7 +186,6 @@ func TestBuildStdin_TitleTruncated(t *testing.T) {
 }
 
 func TestBuildStdin_TitleTruncation_RuneBoundary(t *testing.T) {
-	evt := sampleEvent("issue.created")
 	// 4-byte rune (😀 = U+1F600) repeated to overflow the 1KB title cap
 	// at a non-aligned offset. 257 runes = 1028 bytes, cap = 1024 means
 	// the cut lands inside the 257th rune.
@@ -180,11 +193,7 @@ func TestBuildStdin_TitleTruncation_RuneBoundary(t *testing.T) {
 	bigIssue := func(_ context.Context, _ int64) (IssueSnapshot, error) {
 		return IssueSnapshot{Number: 1, Title: bigTitle, Status: "open"}, nil
 	}
-	out, _ := buildStdinJSON(context.Background(), evt, okProject, bigIssue, okComment, okAlias, nopLog())
-	var got map[string]any
-	if err := json.Unmarshal(out, &got); err != nil {
-		t.Fatal(err)
-	}
+	_, got, _ := runBuild(t, sampleEvent("issue.created"), withIssue(bigIssue))
 	issue := got["issue"].(map[string]any)
 	title := issue["title"].(string)
 	if !utf8.ValidString(title) {
@@ -208,15 +217,13 @@ func TestBuildStdin_TopLevelTruncation_DropsOptionalFields(t *testing.T) {
 	}
 	bigPayload := strings.Repeat("Y", 250*1024)
 	evt.Payload = `{"comment_id":104,"big":"` + bigPayload + `"}`
-	out, truncated := buildStdinJSON(context.Background(), evt, okProject, bigIssue, bigComment, okAlias, nopLog())
+	out, got, truncated := runBuild(t, evt, withIssue(bigIssue), withComment(bigComment))
 	if !truncated {
 		t.Fatal("oversize payload should set top-level payload_truncated:true")
 	}
 	if len(out) > 256*1024 {
 		t.Fatalf("output size %d exceeds 256KB cap", len(out))
 	}
-	var got map[string]any
-	_ = json.Unmarshal(out, &got)
 	if got["payload_truncated"] != true {
 		t.Fatal("payload_truncated must be true")
 	}

--- a/internal/hooks/prune_test.go
+++ b/internal/hooks/prune_test.go
@@ -12,13 +12,9 @@ import (
 
 func TestPrune_StartupSeed_TotalsBytesInDir(t *testing.T) {
 	dir := t.TempDir()
-	mustWrite(t, filepath.Join(dir, "1.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "1.0.err"), 50)
+	writeHookLogs(t, dir, 1, 0, 100, 50)
 	mustWrite(t, filepath.Join(dir, "2.0.out"), 200)
-	p := newPruner(dir, 1024, log.New(&bytes.Buffer{}, "", 0))
-	if err := p.Seed(); err != nil {
-		t.Fatal(err)
-	}
+	p := setupSeededPruner(t, dir, 1024)
 	if got := p.Total(); got != 350 {
 		t.Fatalf("seed total = %d, want 350", got)
 	}
@@ -26,79 +22,46 @@ func TestPrune_StartupSeed_TotalsBytesInDir(t *testing.T) {
 
 func TestPrune_MaybeSweep_OldestGroupFirst(t *testing.T) {
 	dir := t.TempDir()
-	mustWrite(t, filepath.Join(dir, "10.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "10.0.err"), 50)
-	mustWrite(t, filepath.Join(dir, "20.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "20.0.err"), 50)
-	mustWrite(t, filepath.Join(dir, "30.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "30.0.err"), 50)
-	logBuf := &bytes.Buffer{}
-	p := newPruner(dir, 250, log.New(logBuf, "", 0))
-	if err := p.Seed(); err != nil {
-		t.Fatal(err)
-	}
+	writeHookLogs(t, dir, 10, 0, 100, 50)
+	writeHookLogs(t, dir, 20, 0, 100, 50)
+	writeHookLogs(t, dir, 30, 0, 100, 50)
+	p := setupSeededPruner(t, dir, 250)
 	p.MaybeSweep()
 	// 450 -> cap 250 -> must delete oldest groups (10.0 and 20.0) leaving 150.
-	if _, err := os.Stat(filepath.Join(dir, "10.0.out")); err == nil {
-		t.Fatal("oldest group should have been deleted")
-	}
-	if _, err := os.Stat(filepath.Join(dir, "30.0.out")); err != nil {
-		t.Fatalf("newest group must survive: %v", err)
-	}
+	assertPruned(t, filepath.Join(dir, "10.0.out"))
+	assertRetained(t, filepath.Join(dir, "30.0.out"))
 }
 
 func TestPrune_AtomicGroup_DeletesOutAndErrTogether(t *testing.T) {
 	dir := t.TempDir()
-	mustWrite(t, filepath.Join(dir, "10.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "10.0.err"), 50)
-	mustWrite(t, filepath.Join(dir, "20.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "20.0.err"), 50)
-	p := newPruner(dir, 100, log.New(&bytes.Buffer{}, "", 0))
-	if err := p.Seed(); err != nil {
-		t.Fatal(err)
-	}
+	writeHookLogs(t, dir, 10, 0, 100, 50)
+	writeHookLogs(t, dir, 20, 0, 100, 50)
+	p := setupSeededPruner(t, dir, 100)
 	p.MaybeSweep()
-	if _, err := os.Stat(filepath.Join(dir, "10.0.out")); err == nil {
-		t.Fatal("10.0.out should be gone")
-	}
-	if _, err := os.Stat(filepath.Join(dir, "10.0.err")); err == nil {
-		t.Fatal("10.0.err should also be gone (atomic group delete)")
-	}
+	assertPruned(t, filepath.Join(dir, "10.0.out"))
+	assertPruned(t, filepath.Join(dir, "10.0.err"))
 }
 
 func TestPrune_PartialGroup_NotFatal(t *testing.T) {
 	dir := t.TempDir()
 	// Only .out exists for this group; .err is missing.
 	mustWrite(t, filepath.Join(dir, "10.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "20.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "20.0.err"), 50)
-	p := newPruner(dir, 100, log.New(&bytes.Buffer{}, "", 0))
-	if err := p.Seed(); err != nil {
-		t.Fatal(err)
-	}
+	writeHookLogs(t, dir, 20, 0, 100, 50)
+	p := setupSeededPruner(t, dir, 100)
 	p.MaybeSweep()
-	if _, err := os.Stat(filepath.Join(dir, "10.0.out")); err == nil {
-		t.Fatal("partial group should still be eligible for delete")
-	}
+	assertPruned(t, filepath.Join(dir, "10.0.out"))
 }
 
 func TestPrune_AddAfterRun_TriggersSweep(t *testing.T) {
 	dir := t.TempDir()
-	p := newPruner(dir, 100, log.New(&bytes.Buffer{}, "", 0))
-	if err := p.Seed(); err != nil {
-		t.Fatal(err)
-	}
-	mustWrite(t, filepath.Join(dir, "1.0.out"), 80)
-	mustWrite(t, filepath.Join(dir, "1.0.err"), 0)
+	p := setupSeededPruner(t, dir, 100)
+	writeHookLogs(t, dir, 1, 0, 80, 0)
 	p.AddRun(1, 0, 80, 0)
-	mustWrite(t, filepath.Join(dir, "2.0.out"), 80)
-	mustWrite(t, filepath.Join(dir, "2.0.err"), 0)
+	writeHookLogs(t, dir, 2, 0, 80, 0)
 	p.AddRun(2, 0, 80, 0)
 	// Total now 160 over cap 100 -> after second AddRun, sweep should run
 	// and delete oldest (1.0) leaving 80.
-	if _, err := os.Stat(filepath.Join(dir, "1.0.out")); err == nil {
-		t.Fatal("oldest run should have been pruned by AddRun-triggered sweep")
-	}
+	assertPruned(t, filepath.Join(dir, "1.0.out"))
 }
 
 // TestPrune_SkipsActiveGroup pins the contract that MaybeSweep never
@@ -108,26 +71,16 @@ func TestPrune_AddAfterRun_TriggersSweep(t *testing.T) {
 // ordering.
 func TestPrune_SkipsActiveGroup(t *testing.T) {
 	dir := t.TempDir()
-	mustWrite(t, filepath.Join(dir, "10.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "10.0.err"), 50)
-	mustWrite(t, filepath.Join(dir, "20.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "20.0.err"), 50)
-	mustWrite(t, filepath.Join(dir, "30.0.out"), 100)
-	mustWrite(t, filepath.Join(dir, "30.0.err"), 50)
-	p := newPruner(dir, 200, log.New(&bytes.Buffer{}, "", 0))
-	if err := p.Seed(); err != nil {
-		t.Fatal(err)
-	}
+	writeHookLogs(t, dir, 10, 0, 100, 50)
+	writeHookLogs(t, dir, 20, 0, 100, 50)
+	writeHookLogs(t, dir, 30, 0, 100, 50)
+	p := setupSeededPruner(t, dir, 200)
 	p.SetActiveCheck(func(k groupKey) bool {
 		return k.eventID == 10
 	})
 	p.MaybeSweep()
-	if _, err := os.Stat(filepath.Join(dir, "10.0.out")); err != nil {
-		t.Fatalf("active group 10.0 must be preserved: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, "20.0.out")); err == nil {
-		t.Fatal("inactive next-oldest 20.0 should have been deleted")
-	}
+	assertRetained(t, filepath.Join(dir, "10.0.out"))
+	assertPruned(t, filepath.Join(dir, "20.0.out"))
 }
 
 // TestPrune_StaleScan_NoDoubleDecrement guards the
@@ -137,10 +90,7 @@ func TestPrune_SkipsActiveGroup(t *testing.T) {
 func TestPrune_StaleScan_NoDoubleDecrement(t *testing.T) {
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "1.0.out"), 100)
-	p := newPruner(dir, 1024, log.New(&bytes.Buffer{}, "", 0))
-	if err := p.Seed(); err != nil {
-		t.Fatal(err)
-	}
+	p := setupSeededPruner(t, dir, 1024)
 	startTotal := p.Total()
 	stale := groupInfo{
 		key:     groupKey{eventID: 999, hookIndex: 0},
@@ -164,13 +114,9 @@ func TestPrune_ConcurrentSweep_TotalMatchesDisk(t *testing.T) {
 	const groups = 12
 	const perStream = 100
 	for i := 1; i <= groups; i++ {
-		mustWrite(t, filepath.Join(dir, fmt.Sprintf("%d.0.out", i)), perStream)
-		mustWrite(t, filepath.Join(dir, fmt.Sprintf("%d.0.err", i)), perStream)
+		writeHookLogs(t, dir, i, 0, perStream, perStream)
 	}
-	p := newPruner(dir, 400, log.New(&bytes.Buffer{}, "", 0))
-	if err := p.Seed(); err != nil {
-		t.Fatal(err)
-	}
+	p := setupSeededPruner(t, dir, 400)
 	var wg sync.WaitGroup
 	for w := 0; w < 4; w++ {
 		wg.Add(1)
@@ -202,5 +148,40 @@ func mustWrite(t *testing.T, path string, n int) {
 	t.Helper()
 	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), n), 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// setupSeededPruner builds a pruner with a discarded-log writer and
+// runs Seed, failing the test if seeding errors.
+func setupSeededPruner(t *testing.T, dir string, capBytes int64) *pruner {
+	t.Helper()
+	p := newPruner(dir, capBytes, log.New(&bytes.Buffer{}, "", 0))
+	if err := p.Seed(); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// writeHookLogs writes the .out and .err pair for a (eventID, hookIndex)
+// group with the given byte sizes.
+func writeHookLogs(t *testing.T, dir string, eventID, hookIndex, outSize, errSize int) {
+	t.Helper()
+	mustWrite(t, filepath.Join(dir, fmt.Sprintf("%d.%d.out", eventID, hookIndex)), outSize)
+	mustWrite(t, filepath.Join(dir, fmt.Sprintf("%d.%d.err", eventID, hookIndex)), errSize)
+}
+
+// assertPruned fails the test if path still exists on disk.
+func assertPruned(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("expected %s to be pruned, but it still exists", path)
+	}
+}
+
+// assertRetained fails the test if path does not exist on disk.
+func assertRetained(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to be retained: %v", path, err)
 	}
 }

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -46,42 +46,65 @@ func newRunnerSetup(t *testing.T) *runnerSetup {
 	return &runnerSetup{t: t, deps: deps, dir: root, dbHash: dbHash, logBuf: logBuf}
 }
 
-func TestRunner_OK_HookprobeStdin(t *testing.T) {
-	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
+// runProbe executes hookprobe with default ResolvedHook fields
+// (Command=hookprobe, Timeout=2s, WorkingDir=rs.dir), applying customize
+// to override fields, and returns the captured runRecord. Callers that
+// only need to vary args can pass a one-liner customize.
+func (rs *runnerSetup) runProbe(customize func(*ResolvedHook)) runRecord {
+	rs.t.Helper()
+	return rs.runProbeWithDone(make(chan struct{}), customize)
+}
+
+// runProbeWithDone is the full-control variant taking a caller-supplied
+// shutdown channel; used by daemon-shutdown tests.
+func (rs *runnerSetup) runProbeWithDone(done chan struct{}, customize func(*ResolvedHook)) runRecord {
+	rs.t.Helper()
 	var got runRecord
 	rs.deps.AppendRun = func(r runRecord) { got = r }
+	hook := ResolvedHook{
+		Command:    hookprobePath(rs.t),
+		Timeout:    2 * time.Second,
+		WorkingDir: rs.dir,
+	}
+	if customize != nil {
+		customize(&hook)
+	}
 	job := HookJob{
 		Event:      sampleEvent("issue.created"),
-		Hook:       ResolvedHook{Index: 0, Command: bin, Args: []string{"stdin"}, Timeout: 2 * time.Second, WorkingDir: rs.dir},
+		Hook:       hook,
 		EnqueuedAt: rs.deps.Now(),
 	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	runJob(context.Background(), done, job, rs.deps)
+	return got
+}
+
+func readRecordOut(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // G304: test-controlled path under t.TempDir()
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestRunner_OK_HookprobeStdin(t *testing.T) {
+	rs := newRunnerSetup(t)
+	got := rs.runProbe(func(h *ResolvedHook) { h.Args = []string{"stdin"} })
 	if got.Result != "ok" {
 		t.Fatalf("result = %q, want ok (log=%s)", got.Result, rs.logBuf.String())
 	}
 	if got.ExitCode != 0 {
 		t.Fatalf("exit_code = %d, want 0", got.ExitCode)
 	}
-	stdoutBytes, err := os.ReadFile(got.StdoutPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(stdoutBytes), `"event_id":81237`) {
-		t.Fatalf("stdout missing event_id: %q", stdoutBytes)
+	stdout := readRecordOut(t, got.StdoutPath)
+	if !strings.Contains(stdout, `"event_id":81237`) {
+		t.Fatalf("stdout missing event_id: %q", stdout)
 	}
 }
 
 func TestRunner_NonzeroExit(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 1, Command: bin, Args: []string{"exit", "7"}, Timeout: 2 * time.Second, WorkingDir: rs.dir},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	got := rs.runProbe(func(h *ResolvedHook) { h.Args = []string{"exit", "7"} })
 	if got.Result != "ok" || got.ExitCode != 7 {
 		t.Fatalf("got %+v, want result=ok exit_code=7", got)
 	}
@@ -89,13 +112,7 @@ func TestRunner_NonzeroExit(t *testing.T) {
 
 func TestRunner_SpawnFailed_NonexistentCommand(t *testing.T) {
 	rs := newRunnerSetup(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 2, Command: "/nonexistent/no-such-binary", Timeout: 2 * time.Second, WorkingDir: rs.dir},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	got := rs.runProbe(func(h *ResolvedHook) { h.Command = "/nonexistent/no-such-binary" })
 	if got.Result != "spawn_failed" {
 		t.Fatalf("result = %q, want spawn_failed", got.Result)
 	}
@@ -109,14 +126,10 @@ func TestRunner_SpawnFailed_NonexistentCommand(t *testing.T) {
 
 func TestRunner_WorkingDirMissing(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 3, Command: bin, Args: []string{"exit", "0"}, Timeout: 2 * time.Second, WorkingDir: filepath.Join(rs.dir, "nope")},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	got := rs.runProbe(func(h *ResolvedHook) {
+		h.Args = []string{"exit", "0"}
+		h.WorkingDir = filepath.Join(rs.dir, "nope")
+	})
 	if got.Result != "working_dir_missing" {
 		t.Fatalf("result = %q, want working_dir_missing", got.Result)
 	}
@@ -129,18 +142,12 @@ func TestRunner_WorkingDirMissing(t *testing.T) {
 // DB load.
 func TestRunner_AliasResolverInvokedOnce(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
 	var calls int32
 	rs.deps.Alias = func(_ context.Context, _ db.Event) (AliasSnapshot, bool, error) {
 		atomic.AddInt32(&calls, 1)
 		return AliasSnapshot{Identity: "github.com/wesm/kata", Kind: "git", RootPath: rs.dir}, true, nil
 	}
-	rs.deps.AppendRun = func(_ runRecord) {}
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 0, Command: bin, Args: []string{"exit", "0"}, Timeout: 2 * time.Second, WorkingDir: rs.dir},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	rs.runProbe(func(h *ResolvedHook) { h.Args = []string{"exit", "0"} })
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Fatalf("alias resolver invocations = %d, want 1", got)
 	}
@@ -152,26 +159,16 @@ func TestRunner_AliasResolverInvokedOnce(t *testing.T) {
 // block on err, so env must agree to keep the two views consistent.
 func TestRunner_AliasResolverErr_NoEnvLeak(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
 	rs.deps.Alias = func(_ context.Context, _ db.Event) (AliasSnapshot, bool, error) {
 		return AliasSnapshot{Identity: "github.com/wesm/kata", Kind: "git", RootPath: rs.dir},
 			true, errors.New("resolver boom")
 	}
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 0, Command: bin, Args: []string{"env", "KATA_ALIAS_IDENTITY"}, Timeout: 2 * time.Second, WorkingDir: rs.dir},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	got := rs.runProbe(func(h *ResolvedHook) { h.Args = []string{"env", "KATA_ALIAS_IDENTITY"} })
 	if got.Result != "ok" {
 		t.Fatalf("expected ok, got %q", got.Result)
 	}
-	out, err := os.ReadFile(got.StdoutPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.TrimSpace(string(out)) != "" {
+	out := readRecordOut(t, got.StdoutPath)
+	if strings.TrimSpace(out) != "" {
 		t.Fatalf("KATA_ALIAS_IDENTITY must be empty when resolver returned err: %q", out)
 	}
 }
@@ -182,20 +179,18 @@ func TestRunner_AliasResolverErr_NoEnvLeak(t *testing.T) {
 // once per occurrence).
 func TestRunner_WorkingDirMissing_LogsViaCallback(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
 	var loggedHook ResolvedHook
 	var logged int32
 	rs.deps.LogWorkingDirMissing = func(h ResolvedHook) {
 		atomic.AddInt32(&logged, 1)
 		loggedHook = h
 	}
-	rs.deps.AppendRun = func(_ runRecord) {}
 	missing := filepath.Join(rs.dir, "absent")
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 7, Command: bin, Args: []string{"exit", "0"}, Timeout: 2 * time.Second, WorkingDir: missing},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	rs.runProbe(func(h *ResolvedHook) {
+		h.Index = 7
+		h.Args = []string{"exit", "0"}
+		h.WorkingDir = missing
+	})
 	if atomic.LoadInt32(&logged) != 1 {
 		t.Fatalf("LogWorkingDirMissing should be called exactly once, got %d", logged)
 	}
@@ -206,18 +201,14 @@ func TestRunner_WorkingDirMissing_LogsViaCallback(t *testing.T) {
 
 func TestRunner_WorkingDirIsFile(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
 	wd := filepath.Join(rs.dir, "wd-as-file")
 	if err := os.WriteFile(wd, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 4, Command: bin, Args: []string{"exit", "0"}, Timeout: 2 * time.Second, WorkingDir: wd},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	got := rs.runProbe(func(h *ResolvedHook) {
+		h.Args = []string{"exit", "0"}
+		h.WorkingDir = wd
+	})
 	if got.Result != "spawn_failed" {
 		t.Fatalf("working_dir = file: result = %q, want spawn_failed", got.Result)
 	}
@@ -225,15 +216,11 @@ func TestRunner_WorkingDirIsFile(t *testing.T) {
 
 func TestRunner_TimedOut_TermDelay(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 5, Command: bin, Args: []string{"term-delay", "10ms"}, Timeout: 50 * time.Millisecond, WorkingDir: rs.dir},
-	}
 	rs.deps.GraceWindow = 200 * time.Millisecond
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	got := rs.runProbe(func(h *ResolvedHook) {
+		h.Args = []string{"term-delay", "10ms"}
+		h.Timeout = 50 * time.Millisecond
+	})
 	if got.Result != "timed_out" {
 		t.Fatalf("result = %q, want timed_out", got.Result)
 	}
@@ -241,15 +228,11 @@ func TestRunner_TimedOut_TermDelay(t *testing.T) {
 
 func TestRunner_TimedOut_TermIgnore_Killed(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 6, Command: bin, Args: []string{"term-ignore", "10s"}, Timeout: 50 * time.Millisecond, WorkingDir: rs.dir},
-	}
 	rs.deps.GraceWindow = 50 * time.Millisecond
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	got := rs.runProbe(func(h *ResolvedHook) {
+		h.Args = []string{"term-ignore", "10s"}
+		h.Timeout = 50 * time.Millisecond
+	})
 	if got.Result != "timed_out" {
 		t.Fatalf("result = %q, want timed_out (SIGKILL fallback)", got.Result)
 	}
@@ -257,19 +240,15 @@ func TestRunner_TimedOut_TermIgnore_Killed(t *testing.T) {
 
 func TestRunner_DaemonShutdown_BeforeWait(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 7, Command: bin, Args: []string{"sleep", "1s"}, Timeout: 5 * time.Second, WorkingDir: rs.dir},
-	}
 	done := make(chan struct{})
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		close(done)
 	}()
-	runJob(context.Background(), done, job, rs.deps)
+	got := rs.runProbeWithDone(done, func(h *ResolvedHook) {
+		h.Args = []string{"sleep", "1s"}
+		h.Timeout = 5 * time.Second
+	})
 	if got.Result != "daemon_shutdown" {
 		t.Fatalf("result = %q, want daemon_shutdown", got.Result)
 	}
@@ -277,20 +256,13 @@ func TestRunner_DaemonShutdown_BeforeWait(t *testing.T) {
 
 func TestRunner_OutputCapture_BothStreams(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 8, Command: bin, Args: []string{"both", "OUT", "ERR"}, Timeout: 2 * time.Second, WorkingDir: rs.dir},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
-	out, _ := os.ReadFile(got.StdoutPath)
-	er, _ := os.ReadFile(got.StderrPath)
-	if !strings.Contains(string(out), "OUT") {
+	got := rs.runProbe(func(h *ResolvedHook) { h.Args = []string{"both", "OUT", "ERR"} })
+	out := readRecordOut(t, got.StdoutPath)
+	er := readRecordOut(t, got.StderrPath)
+	if !strings.Contains(out, "OUT") {
 		t.Fatalf(".out missing OUT: %q", out)
 	}
-	if !strings.Contains(string(er), "ERR") {
+	if !strings.Contains(er, "ERR") {
 		t.Fatalf(".err missing ERR: %q", er)
 	}
 	if got.StdoutBytes != int64(len(out)) || got.StderrBytes != int64(len(er)) {
@@ -300,36 +272,21 @@ func TestRunner_OutputCapture_BothStreams(t *testing.T) {
 
 func TestRunner_EnvKataVars(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook:  ResolvedHook{Index: 9, Command: bin, Args: []string{"env", "KATA_EVENT_ID"}, Timeout: 2 * time.Second, WorkingDir: rs.dir},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
-	out, _ := os.ReadFile(got.StdoutPath)
-	if strings.TrimSpace(string(out)) != "81237" {
+	got := rs.runProbe(func(h *ResolvedHook) { h.Args = []string{"env", "KATA_EVENT_ID"} })
+	out := readRecordOut(t, got.StdoutPath)
+	if strings.TrimSpace(out) != "81237" {
 		t.Fatalf("KATA_EVENT_ID = %q, want 81237", out)
 	}
 }
 
 func TestRunner_EnvUserOverridable_NotForKata(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook: ResolvedHook{
-			Index: 10, Command: bin, Args: []string{"env", "EXTRA"},
-			Timeout: 2 * time.Second, WorkingDir: rs.dir,
-			UserEnv: []string{"EXTRA=visible"},
-		},
-	}
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
-	out, _ := os.ReadFile(got.StdoutPath)
-	if strings.TrimSpace(string(out)) != "visible" {
+	got := rs.runProbe(func(h *ResolvedHook) {
+		h.Args = []string{"env", "EXTRA"}
+		h.UserEnv = []string{"EXTRA=visible"}
+	})
+	out := readRecordOut(t, got.StdoutPath)
+	if strings.TrimSpace(out) != "visible" {
 		t.Fatalf("user env not visible: %q", out)
 	}
 }

--- a/internal/hooks/runner_unix_test.go
+++ b/internal/hooks/runner_unix_test.go
@@ -3,7 +3,6 @@
 package hooks
 
 import (
-	"context"
 	"os/exec"
 	"testing"
 	"time"
@@ -19,22 +18,13 @@ import (
 // expires.
 func TestRunner_KillTree_OrphanedChildrenDieToo(t *testing.T) {
 	rs := newRunnerSetup(t)
-	bin := hookprobePath(t)
-	var got runRecord
-	rs.deps.AppendRun = func(r runRecord) { got = r }
-	job := HookJob{
-		Event: sampleEvent("issue.created"),
-		Hook: ResolvedHook{
-			Index:      11,
-			Command:    bin,
-			Args:       []string{"spawn-orphan", "30s"},
-			Timeout:    100 * time.Millisecond,
-			WorkingDir: rs.dir,
-		},
-	}
 	rs.deps.GraceWindow = 100 * time.Millisecond
 	start := time.Now()
-	runJob(context.Background(), make(chan struct{}), job, rs.deps)
+	got := rs.runProbe(func(h *ResolvedHook) {
+		h.Index = 11
+		h.Args = []string{"spawn-orphan", "30s"}
+		h.Timeout = 100 * time.Millisecond
+	})
 	if got.Result != "timed_out" {
 		t.Fatalf("result = %q, want timed_out (rs log: %s)", got.Result, rs.logBuf.String())
 	}

--- a/internal/hooks/runs_test.go
+++ b/internal/hooks/runs_test.go
@@ -11,44 +11,48 @@ import (
 	"testing"
 )
 
-func TestRunsAppender_OneLinePerRun(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "runs.jsonl")
-	app, err := newRunsAppender(path, 1<<20, 5)
+func newTestRunsAppender(t *testing.T, threshold int64, keep int) (*runsAppender, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "runs.jsonl")
+	app, err := newRunsAppender(path, threshold, keep)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("newRunsAppender: %v", err)
 	}
-	defer func() { _ = app.Close() }()
-	app.Append(runRecord{Version: 1, EventID: 1, Result: "ok"})
-	app.Append(runRecord{Version: 1, EventID: 2, Result: "ok"})
-	app.Append(runRecord{Version: 1, EventID: 3, Result: "ok"})
+	t.Cleanup(func() { _ = app.Close() })
+	return app, path
+}
+
+func countValidRunRecords(t *testing.T, path string) int {
+	t.Helper()
 	data, err := os.ReadFile(path) //nolint:gosec // G304: test-controlled path under t.TempDir()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("read %s: %v", path, err)
 	}
-	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	count := 0
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	for scanner.Scan() {
 		var r runRecord
 		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
-			t.Fatalf("line %d not JSON: %v", count, err)
+			t.Fatalf("%s line %d not JSON: %v", path, count, err)
 		}
 		count++
 	}
-	if count != 3 {
+	return count
+}
+
+func TestRunsAppender_OneLinePerRun(t *testing.T) {
+	app, path := newTestRunsAppender(t, 1<<20, 5)
+	app.Append(runRecord{Version: 1, EventID: 1, Result: "ok"})
+	app.Append(runRecord{Version: 1, EventID: 2, Result: "ok"})
+	app.Append(runRecord{Version: 1, EventID: 3, Result: "ok"})
+	if count := countValidRunRecords(t, path); count != 3 {
 		t.Fatalf("got %d lines, want 3", count)
 	}
 }
 
 func TestRunsAppender_RotatesAtThreshold(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "runs.jsonl")
 	// 1KB threshold; each runRecord is well over 100B, so a few writes rotate.
-	app, err := newRunsAppender(path, 1024, 3)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = app.Close() }()
+	app, path := newTestRunsAppender(t, 1024, 3)
 	for i := 0; i < 50; i++ {
 		app.Append(runRecord{Version: 1, EventID: int64(i), Result: "ok",
 			HookCommand: "/usr/local/bin/something/longer"})
@@ -62,13 +66,7 @@ func TestRunsAppender_RotatesAtThreshold(t *testing.T) {
 }
 
 func TestRunsAppender_KeepsAtMostKeepFiles(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "runs.jsonl")
-	app, err := newRunsAppender(path, 256, 2) // keep .1 and .2
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = app.Close() }()
+	app, path := newTestRunsAppender(t, 256, 2) // keep .1 and .2
 	for i := 0; i < 200; i++ {
 		app.Append(runRecord{Version: 1, EventID: int64(i), Result: "ok",
 			HookCommand: "/usr/local/bin/notify"})
@@ -88,18 +86,12 @@ func TestRunsAppender_KeepsAtMostKeepFiles(t *testing.T) {
 }
 
 func TestRunsAppender_ConcurrentAppends_NoInterleave(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "runs.jsonl")
 	// Sized so the workload produces at most `keep` rotations, so every
 	// file the appender created is still on disk for validation. With
 	// each runRecord ~250B serialized, 8 writers * 25 records = ~50KB
 	// of writes against a 16KB threshold yields ~3 rotations < keep=5.
 	const totalRecords = 25
-	app, err := newRunsAppender(path, 16*1024, 5)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = app.Close() }()
+	app, path := newTestRunsAppender(t, 16*1024, 5)
 	var wg sync.WaitGroup
 	for w := 0; w < 8; w++ {
 		wg.Add(1)
@@ -127,20 +119,7 @@ func TestRunsAppender_ConcurrentAppends_NoInterleave(t *testing.T) {
 	// appender wrote was evicted before assertion.
 	totalLines := 0
 	for _, f := range files {
-		data, err := os.ReadFile(f) //nolint:gosec // G304: test-controlled path under t.TempDir()
-		if err != nil {
-			t.Fatal(err)
-		}
-		for i, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
-			if line == "" {
-				continue
-			}
-			var r runRecord
-			if err := json.Unmarshal([]byte(line), &r); err != nil {
-				t.Fatalf("%s line %d invalid JSON: %v (line=%q)", f, i, err, line)
-			}
-			totalLines++
-		}
+		totalLines += countValidRunRecords(t, f)
 	}
 	if want := 8 * totalRecords; totalLines != want {
 		t.Fatalf("validated %d lines across %d files, want %d (no rotated file should have been evicted)",

--- a/internal/jsonl/cutover_test.go
+++ b/internal/jsonl/cutover_test.go
@@ -18,29 +18,19 @@ import (
 )
 
 func TestAutoCutoverNoopsAtCurrentSchema(t *testing.T) {
-	ctx := context.Background()
-	path := filepath.Join(t.TempDir(), "kata.db")
-	d, err := db.Open(ctx, path)
-	require.NoError(t, err)
-	require.NoError(t, d.Close())
+	ctx, path := setupClosedTestDB(t)
 
 	require.NoError(t, jsonl.AutoCutover(ctx, path))
 
-	ver, err := db.PeekSchemaVersion(ctx, path)
-	require.NoError(t, err)
-	assert.Equal(t, db.CurrentSchemaVersion(), ver)
+	assertCurrentSchemaVersion(t, path)
 	assertNoCutoverTemps(t, path)
 }
 
 func TestAutoCutoverRefusesExistingTempFiles(t *testing.T) {
-	ctx := context.Background()
-	path := filepath.Join(t.TempDir(), "kata.db")
-	d, err := db.Open(ctx, path)
-	require.NoError(t, err)
-	require.NoError(t, d.Close())
+	ctx, path := setupClosedTestDB(t)
 	require.NoError(t, os.WriteFile(path+".import.tmp.jsonl", []byte("partial"), 0o600))
 
-	err = jsonl.AutoCutover(ctx, path)
+	err := jsonl.AutoCutover(ctx, path)
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, jsonl.ErrCutoverInProgress))
@@ -72,9 +62,7 @@ func TestAutoCutoverUpgradesLegacyV1DB(t *testing.T) {
 	d, err := db.Open(ctx, path)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = d.Close() })
-	ver, err := db.PeekSchemaVersion(ctx, path)
-	require.NoError(t, err)
-	assert.Equal(t, db.CurrentSchemaVersion(), ver)
+	assertCurrentSchemaVersion(t, path)
 	var projectUID, issueUID, eventIssueUID string
 	require.NoError(t, d.QueryRow(`SELECT uid FROM projects WHERE id = 1`).Scan(&projectUID))
 	require.NoError(t, d.QueryRow(`SELECT uid FROM issues WHERE id = 1`).Scan(&issueUID))
@@ -86,273 +74,17 @@ func TestAutoCutoverUpgradesLegacyV1DB(t *testing.T) {
 }
 
 func TestPeekSchemaVersion(t *testing.T) {
-	ctx := context.Background()
-	path := filepath.Join(t.TempDir(), "kata.db")
-	d, err := db.Open(ctx, path)
-	require.NoError(t, err)
-	require.NoError(t, d.Close())
-
-	ver, err := db.PeekSchemaVersion(ctx, path)
-	require.NoError(t, err)
-	assert.Equal(t, db.CurrentSchemaVersion(), ver)
+	ctx, path := setupClosedTestDB(t)
+	assertCurrentSchemaVersion(t, path)
 
 	noMeta := filepath.Join(t.TempDir(), "empty.db")
 	raw, err := sql.Open("sqlite", noMeta)
 	require.NoError(t, err)
 	require.NoError(t, raw.PingContext(ctx))
 	require.NoError(t, raw.Close())
-	ver, err = db.PeekSchemaVersion(ctx, noMeta)
+	ver, err := db.PeekSchemaVersion(ctx, noMeta)
 	require.NoError(t, err)
 	assert.Equal(t, 0, ver)
-}
-
-func writeLegacyV1DB(t *testing.T, path string) {
-	t.Helper()
-	raw, err := sql.Open("sqlite", path)
-	require.NoError(t, err)
-	schema := `
-CREATE TABLE projects (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  identity TEXT UNIQUE NOT NULL,
-  name TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  next_issue_number INTEGER NOT NULL DEFAULT 2
-);
-CREATE TABLE project_aliases (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER NOT NULL REFERENCES projects(id),
-  alias_identity TEXT UNIQUE NOT NULL,
-  alias_kind TEXT NOT NULL,
-  root_path TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  last_seen_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE TABLE issues (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER NOT NULL REFERENCES projects(id),
-  number INTEGER NOT NULL,
-  title TEXT NOT NULL,
-  body TEXT NOT NULL DEFAULT '',
-  status TEXT NOT NULL DEFAULT 'open',
-  closed_reason TEXT,
-  owner TEXT,
-  author TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  updated_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  closed_at DATETIME,
-  deleted_at DATETIME
-);
-CREATE TABLE comments (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  issue_id INTEGER NOT NULL REFERENCES issues(id),
-  author TEXT NOT NULL,
-  body TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE TABLE links (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER NOT NULL REFERENCES projects(id),
-  from_issue_id INTEGER NOT NULL REFERENCES issues(id),
-  to_issue_id INTEGER NOT NULL REFERENCES issues(id),
-  type TEXT NOT NULL,
-  author TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE TABLE issue_labels (
-  issue_id INTEGER NOT NULL REFERENCES issues(id),
-  label TEXT NOT NULL,
-  author TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  PRIMARY KEY(issue_id, label)
-);
-CREATE TABLE events (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER NOT NULL REFERENCES projects(id),
-  project_identity TEXT NOT NULL,
-  issue_id INTEGER REFERENCES issues(id),
-  issue_number INTEGER,
-  related_issue_id INTEGER REFERENCES issues(id),
-  type TEXT NOT NULL,
-  actor TEXT NOT NULL,
-  payload TEXT NOT NULL DEFAULT '{}',
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE TABLE purge_log (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER NOT NULL,
-  purged_issue_id INTEGER NOT NULL,
-  project_identity TEXT NOT NULL,
-  issue_number INTEGER NOT NULL,
-  issue_title TEXT NOT NULL,
-  issue_author TEXT NOT NULL,
-  comment_count INTEGER NOT NULL,
-  link_count INTEGER NOT NULL,
-  label_count INTEGER NOT NULL,
-  event_count INTEGER NOT NULL,
-  events_deleted_min_id INTEGER,
-  events_deleted_max_id INTEGER,
-  purge_reset_after_event_id INTEGER,
-  actor TEXT NOT NULL,
-  reason TEXT,
-  purged_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-INSERT INTO meta(key, value) VALUES('schema_version', '1');
-INSERT INTO meta(key, value) VALUES('created_by_version', '0.1.0');
-INSERT INTO projects(id, identity, name, created_at, next_issue_number)
-VALUES(1, 'github.com/wesm/kata', 'kata', '2026-05-03T00:00:00.000Z', 2);
-INSERT INTO project_aliases(id, project_id, alias_identity, alias_kind, root_path, created_at, last_seen_at)
-VALUES(1, 1, 'github.com/wesm/kata', 'git', '/tmp/kata', '2026-05-03T00:00:00.000Z', '2026-05-03T00:00:00.000Z');
-INSERT INTO issues(id, project_id, number, title, body, status, closed_reason, owner, author, created_at, updated_at, closed_at, deleted_at)
-VALUES(1, 1, 1, 'legacy issue', '', 'open', NULL, NULL, 'tester', '2026-05-03T00:00:01.000Z', '2026-05-03T00:00:01.000Z', NULL, NULL);
-INSERT INTO comments(id, issue_id, author, body, created_at)
-VALUES(1, 1, 'tester', 'legacy comment', '2026-05-03T00:00:02.000Z');
-INSERT INTO issue_labels(issue_id, label, author, created_at)
-VALUES(1, 'bug', 'tester', '2026-05-03T00:00:02.000Z');
-INSERT INTO events(id, project_id, project_identity, issue_id, issue_number, related_issue_id, type, actor, payload, created_at)
-VALUES(1, 1, 'github.com/wesm/kata', 1, 1, NULL, 'issue.created', 'tester', '{}', '2026-05-03T00:00:01.000Z');
-`
-	_, err = raw.Exec(schema)
-	require.NoError(t, err)
-	require.NoError(t, raw.Close())
-}
-
-func writeLegacyV2DB(t *testing.T, path string) {
-	t.Helper()
-	raw, err := sql.Open("sqlite", path)
-	require.NoError(t, err)
-	schema := `
-CREATE TABLE projects (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  uid TEXT NOT NULL UNIQUE,
-  identity TEXT UNIQUE NOT NULL,
-  name TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  next_issue_number INTEGER NOT NULL DEFAULT 1,
-  CHECK (length(uid) = 26)
-);
-CREATE TABLE project_aliases (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER NOT NULL REFERENCES projects(id),
-  alias_identity TEXT UNIQUE NOT NULL,
-  alias_kind TEXT NOT NULL,
-  root_path TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  last_seen_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE TABLE issues (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  uid TEXT NOT NULL UNIQUE,
-  project_id INTEGER NOT NULL REFERENCES projects(id),
-  number INTEGER NOT NULL,
-  title TEXT NOT NULL,
-  body TEXT NOT NULL DEFAULT '',
-  status TEXT NOT NULL DEFAULT 'open',
-  closed_reason TEXT,
-  owner TEXT,
-  author TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  updated_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  closed_at DATETIME,
-  deleted_at DATETIME,
-  UNIQUE(project_id, number),
-  CHECK (length(uid) = 26)
-);
-CREATE TABLE comments (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  issue_id INTEGER NOT NULL REFERENCES issues(id),
-  author TEXT NOT NULL,
-  body TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE TABLE links (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER NOT NULL REFERENCES projects(id),
-  from_issue_id INTEGER NOT NULL REFERENCES issues(id),
-  to_issue_id INTEGER NOT NULL REFERENCES issues(id),
-  from_issue_uid TEXT NOT NULL,
-  to_issue_uid TEXT NOT NULL,
-  type TEXT NOT NULL,
-  author TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE TABLE issue_labels (
-  issue_id INTEGER NOT NULL REFERENCES issues(id),
-  label TEXT NOT NULL,
-  author TEXT NOT NULL,
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  PRIMARY KEY(issue_id, label)
-);
--- v2 events: no uid, no origin_instance_uid (the v2→v3 cutover backfills them).
-CREATE TABLE events (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER NOT NULL REFERENCES projects(id),
-  project_identity TEXT NOT NULL,
-  issue_id INTEGER REFERENCES issues(id),
-  issue_uid TEXT,
-  issue_number INTEGER,
-  related_issue_id INTEGER REFERENCES issues(id),
-  related_issue_uid TEXT,
-  type TEXT NOT NULL,
-  actor TEXT NOT NULL,
-  payload TEXT NOT NULL DEFAULT '{}',
-  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
--- v2 purge_log: no uid, no origin_instance_uid.
-CREATE TABLE purge_log (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER NOT NULL,
-  purged_issue_id INTEGER NOT NULL,
-  issue_uid TEXT,
-  project_uid TEXT,
-  project_identity TEXT NOT NULL,
-  issue_number INTEGER NOT NULL,
-  issue_title TEXT NOT NULL,
-  issue_author TEXT NOT NULL,
-  comment_count INTEGER NOT NULL,
-  link_count INTEGER NOT NULL,
-  label_count INTEGER NOT NULL,
-  event_count INTEGER NOT NULL,
-  events_deleted_min_id INTEGER,
-  events_deleted_max_id INTEGER,
-  purge_reset_after_event_id INTEGER,
-  actor TEXT NOT NULL,
-  reason TEXT,
-  purged_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-INSERT INTO meta(key, value) VALUES('schema_version', '2');
-INSERT INTO meta(key, value) VALUES('created_by_version', '0.1.0');
-
-INSERT INTO projects(id, uid, identity, name, created_at, next_issue_number)
-VALUES(1, '01HZZZZZZZZZZZZZZZZZZZZZZZ', 'github.com/wesm/kata', 'kata', '2026-05-03T00:00:00.000Z', 2);
-INSERT INTO issues(id, uid, project_id, number, title, body, status, author, created_at, updated_at)
-VALUES(1, '01HZZZZZZZZZZZZZZZZZZZZZZ1', 1, 1, 'v2 issue', '', 'open', 'tester',
-       '2026-05-03T00:00:01.000Z', '2026-05-03T00:00:01.000Z');
--- Two real events on issue #1: created (carrying idempotency_key) + commented.
-INSERT INTO events(id, project_id, project_identity, issue_id, issue_uid, issue_number, type, actor, payload, created_at)
-VALUES(1, 1, 'github.com/wesm/kata', 1, '01HZZZZZZZZZZZZZZZZZZZZZZ1', 1, 'issue.created', 'tester',
-       '{"idempotency_key":"K1","idempotency_fingerprint":"fp"}', '2026-05-03T00:00:01.000Z');
-INSERT INTO events(id, project_id, project_identity, issue_id, issue_uid, issue_number, type, actor, payload, created_at)
-VALUES(2, 1, 'github.com/wesm/kata', 1, '01HZZZZZZZZZZZZZZZZZZZZZZ1', 1, 'issue.commented', 'tester',
-       '{"comment_id":42}', '2026-05-03T00:00:02.000Z');
--- A purge_log row referring to a long-gone issue #99 with the synthetic SSE
--- reset cursor reserved at 99 (a value greater than any current events.id).
-INSERT INTO purge_log(id, project_id, purged_issue_id, issue_uid, project_uid, project_identity,
-                      issue_number, issue_title, issue_author, comment_count, link_count, label_count,
-                      event_count, events_deleted_min_id, events_deleted_max_id,
-                      purge_reset_after_event_id, actor, reason, purged_at)
-VALUES(1, 1, 99, '01HZZZZZZZZZZZZZZZZZZZZZ99', '01HZZZZZZZZZZZZZZZZZZZZZZZ', 'github.com/wesm/kata',
-       99, 'gone', 'tester', 0, 0, 0, 1, 50, 50, 99, 'tester', 'fixture',
-       '2026-05-03T00:00:03.000Z');
-INSERT INTO sqlite_sequence(name, seq) VALUES('events', 99);
-INSERT INTO sqlite_sequence(name, seq) VALUES('issues', 1);
-INSERT INTO sqlite_sequence(name, seq) VALUES('projects', 1);
-INSERT INTO sqlite_sequence(name, seq) VALUES('purge_log', 1);
-`
-	_, err = raw.Exec(schema)
-	require.NoError(t, err)
-	require.NoError(t, raw.Close())
 }
 
 // TestRoundtripV4PreservesDeletedAt covers #24's projects.deleted_at column:

--- a/internal/jsonl/cutover_v4_test.go
+++ b/internal/jsonl/cutover_v4_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	_ "modernc.org/sqlite"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,42 +21,16 @@ func TestV3ToV4CutoverPreservesProjects(t *testing.T) {
 	path := filepath.Join(dir, "test.db")
 	ctx := context.Background()
 
-	// Build a v3-shape DB: open at current schema, then strip deleted_at
-	// and roll meta.schema_version back to 3.
-	d, err := db.Open(ctx, path)
-	require.NoError(t, err)
-	_, err = d.ExecContext(ctx, `INSERT INTO projects(id, uid, identity, name, next_issue_number) VALUES(1,'01HZZZZZZZZZZZZZZZZZZZZ001','proj-a','Proj A',1)`)
-	require.NoError(t, err)
-	require.NoError(t, d.Close())
-
-	raw, err := sql.Open("sqlite", "file:"+path)
-	require.NoError(t, err)
-	for _, s := range []string{
-		`DROP INDEX IF EXISTS idx_projects_active`,
-		`CREATE TABLE projects_v3(id INTEGER PRIMARY KEY, uid TEXT, identity TEXT, name TEXT, created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')), next_issue_number INTEGER NOT NULL DEFAULT 1)`,
-		`INSERT INTO projects_v3 SELECT id,uid,identity,name,created_at,next_issue_number FROM projects`,
-		`DROP TABLE projects`,
-		`ALTER TABLE projects_v3 RENAME TO projects`,
-		`UPDATE meta SET value='3' WHERE key='schema_version'`,
-	} {
-		_, err := raw.ExecContext(ctx, s)
-		require.NoError(t, err, s)
-	}
-	require.NoError(t, raw.Close())
-
-	v, err := db.PeekSchemaVersion(ctx, path)
-	require.NoError(t, err)
-	require.Equal(t, 3, v, "precondition: DB should report v3")
+	writeLegacyV3DB(t, path)
+	assertSchemaVersion(t, path, 3)
 
 	require.NoError(t, jsonl.AutoCutover(ctx, path))
 
-	v2, err := db.PeekSchemaVersion(ctx, path)
-	require.NoError(t, err)
-	assert.Equal(t, 4, v2, "schema should upgrade to v4")
+	assertCurrentSchemaVersion(t, path)
 
 	d2, err := db.Open(ctx, path)
 	require.NoError(t, err)
-	defer d2.Close()
+	t.Cleanup(func() { _ = d2.Close() })
 
 	var id int64
 	var identity string

--- a/internal/jsonl/decoder_test.go
+++ b/internal/jsonl/decoder_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/wesm/kata/internal/jsonl"
 )
 
-func TestDecoderRequiresExportVersionFirst(t *testing.T) {
-	input := strings.NewReader(`{"kind":"project","data":{"id":1}}` + "\n")
+func decodeLines(ctx context.Context, lines ...string) ([]jsonl.Envelope, error) {
+	return jsonl.NewDecoder(strings.NewReader(buildJSONL(lines...))).ReadAll(ctx)
+}
 
-	_, err := jsonl.NewDecoder(input).ReadAll(context.Background())
+func TestDecoderRequiresExportVersionFirst(t *testing.T) {
+	_, err := decodeLines(context.Background(), `{"kind":"project","data":{"id":1}}`)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, jsonl.ErrMissingExportVersion)
@@ -22,12 +24,10 @@ func TestDecoderRequiresExportVersionFirst(t *testing.T) {
 }
 
 func TestDecoderRejectsUnknownKind(t *testing.T) {
-	input := strings.NewReader(
-		`{"kind":"meta","data":{"key":"export_version","value":"1"}}` + "\n" +
-			`{"kind":"bogus","data":{"id":1}}` + "\n",
+	_, err := decodeLines(context.Background(),
+		validExportVersion,
+		`{"kind":"bogus","data":{"id":1}}`,
 	)
-
-	_, err := jsonl.NewDecoder(input).ReadAll(context.Background())
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, jsonl.ErrUnknownKind)
@@ -35,13 +35,11 @@ func TestDecoderRejectsUnknownKind(t *testing.T) {
 }
 
 func TestDecoderRejectsOutOfOrderKind(t *testing.T) {
-	input := strings.NewReader(
-		`{"kind":"meta","data":{"key":"export_version","value":"1"}}` + "\n" +
-			`{"kind":"link","data":{"id":1}}` + "\n" +
-			`{"kind":"issue","data":{"id":1}}` + "\n",
+	_, err := decodeLines(context.Background(),
+		validExportVersion,
+		`{"kind":"link","data":{"id":1}}`,
+		`{"kind":"issue","data":{"id":1}}`,
 	)
-
-	_, err := jsonl.NewDecoder(input).ReadAll(context.Background())
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, jsonl.ErrKindOrderViolation)
@@ -49,25 +47,21 @@ func TestDecoderRejectsOutOfOrderKind(t *testing.T) {
 }
 
 func TestDecoderReportsInvalidJSONLine(t *testing.T) {
-	input := strings.NewReader(
-		`{"kind":"meta","data":{"key":"export_version","value":"1"}}` + "\n" +
-			`{"kind":"project","data":` + "\n",
+	_, err := decodeLines(context.Background(),
+		validExportVersion,
+		`{"kind":"project","data":`,
 	)
-
-	_, err := jsonl.NewDecoder(input).ReadAll(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "line 2")
 }
 
 func TestDecoderReadsOrderedEnvelopes(t *testing.T) {
-	input := strings.NewReader(
-		`{"kind":"meta","data":{"key":"export_version","value":"1"},"ignored":true}` + "\n" +
-			`{"kind":"meta","data":{"key":"schema_version","value":"1"}}` + "\n" +
-			`{"kind":"project","data":{"id":1}}` + "\n",
+	got, err := decodeLines(context.Background(),
+		`{"kind":"meta","data":{"key":"export_version","value":"1"},"ignored":true}`,
+		`{"kind":"meta","data":{"key":"schema_version","value":"1"}}`,
+		`{"kind":"project","data":{"id":1}}`,
 	)
-
-	got, err := jsonl.NewDecoder(input).ReadAll(context.Background())
 
 	require.NoError(t, err)
 	require.Len(t, got, 3)
@@ -85,14 +79,14 @@ func TestEncoderWritesCompactJSONLines(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, `{"kind":"meta","data":{"key":"export_version","value":"1"}}`+"\n", out.String())
+	assert.Equal(t, validExportVersion+"\n", out.String())
 }
 
 func TestDecoderReturnsContextError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := jsonl.NewDecoder(strings.NewReader(`{"kind":"meta","data":{"key":"export_version","value":"1"}}` + "\n")).ReadAll(ctx)
+	_, err := decodeLines(ctx, validExportVersion)
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, context.Canceled))

--- a/internal/jsonl/export_test.go
+++ b/internal/jsonl/export_test.go
@@ -15,29 +15,12 @@ import (
 )
 
 func TestExportWritesOrderedRecordsWithSequenceLast(t *testing.T) {
-	ctx := context.Background()
-	d := openExportTestDB(t)
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, p.ID, "github.com/wesm/kata", "git", "/tmp/kata")
-	require.NoError(t, err)
-	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID,
-		Title:     "export me",
-		Author:    "tester",
-		Labels:    []string{"bug"},
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateComment(ctx, db.CreateCommentParams{
-		IssueID: issue.ID,
-		Author:  "tester",
-		Body:    "jsonl comment",
-	})
-	require.NoError(t, err)
+	ctx, d, p := newExportEnv(t)
+	attachAlias(ctx, t, d, p.ID, "github.com/wesm/kata", "git", "/tmp/kata")
+	issue := createTesterIssue(ctx, t, d, p.ID, "export me", "", "bug")
+	addTesterComment(ctx, t, d, issue.ID, "jsonl comment")
 
-	var out bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, d, &out, jsonl.ExportOptions{IncludeDeleted: true}))
-	records := decodeJSONLLines(t, out.Bytes())
+	records := exportAndDecode(ctx, t, d, jsonl.ExportOptions{IncludeDeleted: true})
 
 	require.NotEmpty(t, records)
 	assert.Equal(t, "meta", records[0]["kind"])
@@ -48,11 +31,8 @@ func TestExportWritesOrderedRecordsWithSequenceLast(t *testing.T) {
 }
 
 func TestExportEmitsEventPayloadAsJSONObject(t *testing.T) {
-	ctx := context.Background()
-	d := openExportTestDB(t)
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
+	ctx, d, p := newExportEnv(t)
+	_, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID:      p.ID,
 		Title:          "payload",
 		Author:         "tester",
@@ -60,9 +40,7 @@ func TestExportEmitsEventPayloadAsJSONObject(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var out bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, d, &out, jsonl.ExportOptions{IncludeDeleted: true}))
-	records := decodeJSONLLines(t, out.Bytes())
+	records := exportAndDecode(ctx, t, d, jsonl.ExportOptions{IncludeDeleted: true})
 
 	var found bool
 	for _, rec := range records {
@@ -86,9 +64,7 @@ func TestExportLegacyV1OmitsUIDFields(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = d.Close() })
 
-	var out bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, d, &out, jsonl.ExportOptions{IncludeDeleted: true}))
-	records := decodeJSONLLines(t, out.Bytes())
+	records := exportAndDecode(ctx, t, d, jsonl.ExportOptions{IncludeDeleted: true})
 
 	assert.Equal(t, map[string]any{"key": "export_version", "value": "1"}, records[0]["data"])
 	for _, rec := range records {
@@ -116,59 +92,26 @@ func TestExportProjectIDFiltersProjectScopedRows(t *testing.T) {
 	require.NoError(t, err)
 	p2, err := d.CreateProject(ctx, "github.com/wesm/other", "other")
 	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, p1.ID, "github.com/wesm/kata", "git", "/tmp/kata")
-	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, p2.ID, "github.com/wesm/other", "git", "/tmp/other")
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p1.ID,
-		Title:     "keep me",
-		Author:    "tester",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p2.ID,
-		Title:     "drop me",
-		Author:    "tester",
-	})
-	require.NoError(t, err)
+	attachAlias(ctx, t, d, p1.ID, "github.com/wesm/kata", "git", "/tmp/kata")
+	attachAlias(ctx, t, d, p2.ID, "github.com/wesm/other", "git", "/tmp/other")
+	createTesterIssue(ctx, t, d, p1.ID, "keep me", "")
+	createTesterIssue(ctx, t, d, p2.ID, "drop me", "")
 
-	var out bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, d, &out, jsonl.ExportOptions{
+	records := exportAndDecode(ctx, t, d, jsonl.ExportOptions{
 		ProjectID:      p1.ID,
 		IncludeDeleted: true,
-	}))
-	records := decodeJSONLLines(t, out.Bytes())
+	})
 
 	assertRecordsDoNotContain(t, records, "drop me")
 	assertProjectIDs(t, records, map[int64]bool{p1.ID: true})
 }
 
 func TestExportNoIncludeDeletedOmitsSoftDeletedIssueDependents(t *testing.T) {
-	ctx := context.Background()
-	d := openExportTestDB(t)
-	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
-	require.NoError(t, err)
-	kept, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID,
-		Title:     "kept issue",
-		Author:    "tester",
-	})
-	require.NoError(t, err)
-	deleted, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p.ID,
-		Title:     "deleted issue",
-		Author:    "tester",
-		Labels:    []string{"gone"},
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateComment(ctx, db.CreateCommentParams{
-		IssueID: deleted.ID,
-		Author:  "tester",
-		Body:    "deleted comment",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
+	ctx, d, p := newExportEnv(t)
+	kept := createTesterIssue(ctx, t, d, p.ID, "kept issue", "")
+	deleted := createTesterIssue(ctx, t, d, p.ID, "deleted issue", "", "gone")
+	addTesterComment(ctx, t, d, deleted.ID, "deleted comment")
+	_, _, err := d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
 		ProjectID:   p.ID,
 		FromIssueID: deleted.ID,
 		ToIssueID:   kept.ID,
@@ -182,9 +125,7 @@ func TestExportNoIncludeDeletedOmitsSoftDeletedIssueDependents(t *testing.T) {
 	_, err = d.ExecContext(ctx, `UPDATE issues SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`, deleted.ID)
 	require.NoError(t, err)
 
-	var out bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, d, &out, jsonl.ExportOptions{IncludeDeleted: false}))
-	records := decodeJSONLLines(t, out.Bytes())
+	records := exportAndDecode(ctx, t, d, jsonl.ExportOptions{IncludeDeleted: false})
 
 	assertRecordsDoNotContain(t, records, "deleted issue")
 	assertRecordsDoNotContain(t, records, "deleted comment")
@@ -208,6 +149,26 @@ func openExportTestDB(t *testing.T) *db.DB {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = d.Close() })
 	return d
+}
+
+// newExportEnv opens a fresh test DB and seeds the canonical "kata" project
+// used by most export tests.
+func newExportEnv(t *testing.T) (context.Context, *db.DB, db.Project) {
+	t.Helper()
+	ctx := context.Background()
+	d := openExportTestDB(t)
+	p, err := d.CreateProject(ctx, "github.com/wesm/kata", "kata")
+	require.NoError(t, err)
+	return ctx, d, p
+}
+
+// exportAndDecode runs jsonl.Export into a buffer and decodes the resulting
+// JSONL stream into records.
+func exportAndDecode(ctx context.Context, t *testing.T, d *db.DB, opts jsonl.ExportOptions) []map[string]any {
+	t.Helper()
+	var out bytes.Buffer
+	require.NoError(t, jsonl.Export(ctx, d, &out, opts))
+	return decodeJSONLLines(t, out.Bytes())
 }
 
 func assertRecordsDoNotContain(t *testing.T, records []map[string]any, needle string) {

--- a/internal/jsonl/failure_test.go
+++ b/internal/jsonl/failure_test.go
@@ -18,21 +18,21 @@ func TestImportPropagatesDecoderFailures(t *testing.T) {
 	}{
 		{
 			name:    "truncated JSON",
-			input:   `{"kind":"meta","data":{"key":"export_version","value":"1"}}` + "\n" + `{"kind":"project","data":`,
+			input:   buildJSONL(validExportVersion, `{"kind":"project","data":`),
 			wantErr: "line 2",
 		},
 		{
 			name:    "missing export version",
-			input:   `{"kind":"project","data":{"id":1}}` + "\n",
+			input:   buildJSONL(`{"kind":"project","data":{"id":1}}`),
 			wantErr: "missing export_version",
 		},
 		{
 			name: "kind order violation",
-			input: strings.Join([]string{
-				`{"kind":"meta","data":{"key":"export_version","value":"1"}}`,
+			input: buildJSONL(
+				validExportVersion,
 				`{"kind":"event","data":{"id":1}}`,
 				`{"kind":"issue","data":{"id":1}}`,
-			}, "\n") + "\n",
+			),
 			wantErr: "kind order violation",
 		},
 	}

--- a/internal/jsonl/fixtures_test.go
+++ b/internal/jsonl/fixtures_test.go
@@ -1,16 +1,168 @@
 package jsonl_test
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/db"
+	"github.com/wesm/kata/internal/jsonl"
 )
+
+// validExportVersion is the standard export_version meta envelope tests
+// prepend to bypass the decoder's initial version check.
+const validExportVersion = `{"kind":"meta","data":{"key":"export_version","value":"1"}}`
+
+// validV1ProjectRow is a canonical v1 project envelope with next_issue_number=1
+// used by import tests that just need a referenceable parent project.
+const validV1ProjectRow = `{"kind":"project","data":{"id":1,"identity":"github.com/wesm/kata","name":"kata","created_at":"2026-05-03T00:00:00.000Z","next_issue_number":1}}`
+
+// buildJSONL joins envelope lines into valid JSONL: newline-separated with a
+// trailing newline. Callers should not include trailing newlines in inputs.
+func buildJSONL(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// importJSONL builds JSONL from lines and runs jsonl.Import against d,
+// returning the import error so callers can assert success or failure.
+func importJSONL(ctx context.Context, d *db.DB, lines ...string) error {
+	return jsonl.Import(ctx, strings.NewReader(buildJSONL(lines...)), d)
+}
+
+// setupClosedTestDB seeds a database file at the current schema version and
+// closes it, returning a context and the on-disk path. Tests that exercise
+// path-based entry points (AutoCutover, PeekSchemaVersion) need a database
+// file with no open handles.
+func setupClosedTestDB(t *testing.T) (context.Context, string) {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "kata.db")
+	d, err := db.Open(ctx, path)
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+	return ctx, path
+}
+
+// assertCurrentSchemaVersion fails the test unless the database at path
+// reports the schema version baked into this binary.
+func assertCurrentSchemaVersion(t *testing.T, path string) {
+	t.Helper()
+	assertSchemaVersion(t, path, db.CurrentSchemaVersion())
+}
+
+// assertSchemaVersion fails the test unless the database at path reports
+// the expected schema version.
+func assertSchemaVersion(t *testing.T, path string, expected int) {
+	t.Helper()
+	ver, err := db.PeekSchemaVersion(context.Background(), path)
+	require.NoError(t, err)
+	assert.Equal(t, expected, ver, "schema version mismatch")
+}
+
+// writeLegacyDBFromFixture creates a SQLite database at path by executing the
+// SQL in testdata/<fixtureName>.
+func writeLegacyDBFromFixture(t *testing.T, path, fixtureName string) {
+	t.Helper()
+	schema, err := os.ReadFile(filepath.Join("testdata", fixtureName))
+	require.NoError(t, err)
+	raw, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer func() { _ = raw.Close() }()
+	_, err = raw.Exec(string(schema))
+	require.NoError(t, err)
+}
+
+func writeLegacyV1DB(t *testing.T, path string) {
+	t.Helper()
+	writeLegacyDBFromFixture(t, path, "legacy_v1.sql")
+}
+
+func writeLegacyV2DB(t *testing.T, path string) {
+	t.Helper()
+	writeLegacyDBFromFixture(t, path, "legacy_v2.sql")
+}
+
+func writeLegacyV3DB(t *testing.T, path string) {
+	t.Helper()
+	writeLegacyDBFromFixture(t, path, "legacy_v3.sql")
+}
+
+// openCutoverDB writes a legacy database at a fresh temp path using seedFn,
+// runs jsonl.AutoCutover, and opens the upgraded database. The opened handle
+// is closed via t.Cleanup.
+func openCutoverDB(ctx context.Context, t *testing.T, seedFn func(*testing.T, string)) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kata.db")
+	seedFn(t, path)
+	require.NoError(t, jsonl.AutoCutover(ctx, path))
+	d, err := db.Open(ctx, path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+// fetchInstanceUID returns the raw meta.instance_uid value stored in d.
+func fetchInstanceUID(ctx context.Context, t *testing.T, d *db.DB) string {
+	t.Helper()
+	var s string
+	require.NoError(t, d.QueryRowContext(ctx,
+		`SELECT value FROM meta WHERE key='instance_uid'`).Scan(&s))
+	return s
+}
+
+// exportToBuffer runs jsonl.Export with IncludeDeleted:true and returns the
+// encoded bytes.
+func exportToBuffer(ctx context.Context, t *testing.T, src *db.DB) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, jsonl.Export(ctx, src, &buf, jsonl.ExportOptions{IncludeDeleted: true}))
+	return &buf
+}
 
 type richJSONLFixture struct {
 	DB      *db.DB
 	Project db.Project
+}
+
+// createTesterIssue creates an issue authored by "tester" with the given title,
+// body, and labels. Used to cut the CreateIssue + require.NoError boilerplate
+// from fixture builders that share the "tester" author convention.
+func createTesterIssue(ctx context.Context, t *testing.T, d *db.DB, projectID int64, title, body string, labels ...string) db.Issue {
+	t.Helper()
+	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: projectID,
+		Title:     title,
+		Body:      body,
+		Author:    "tester",
+		Labels:    labels,
+	})
+	require.NoError(t, err)
+	return issue
+}
+
+// addTesterComment posts a comment on issueID authored by "tester".
+func addTesterComment(ctx context.Context, t *testing.T, d *db.DB, issueID int64, body string) {
+	t.Helper()
+	_, _, err := d.CreateComment(ctx, db.CreateCommentParams{
+		IssueID: issueID,
+		Author:  "tester",
+		Body:    body,
+	})
+	require.NoError(t, err)
+}
+
+// attachAlias attaches an alias to projectID, asserting no error. The kind
+// argument lets callers choose "git", "local", etc.
+func attachAlias(ctx context.Context, t *testing.T, d *db.DB, projectID int64, identity, kind, path string) {
+	t.Helper()
+	_, err := d.AttachAlias(ctx, projectID, identity, kind, path)
+	require.NoError(t, err)
 }
 
 func buildRichJSONLFixture(t *testing.T) richJSONLFixture {
@@ -22,64 +174,19 @@ func buildRichJSONLFixture(t *testing.T) richJSONLFixture {
 	require.NoError(t, err)
 	p2, err := d.CreateProject(ctx, "github.com/wesm/other", "other")
 	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, p1.ID, "github.com/wesm/kata", "git", "/tmp/kata")
-	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, p1.ID, "kata-local", "local", "/work/kata")
-	require.NoError(t, err)
-	_, err = d.AttachAlias(ctx, p2.ID, "github.com/wesm/other", "git", "/tmp/other")
-	require.NoError(t, err)
+	attachAlias(ctx, t, d, p1.ID, "github.com/wesm/kata", "git", "/tmp/kata")
+	attachAlias(ctx, t, d, p1.ID, "kata-local", "local", "/work/kata")
+	attachAlias(ctx, t, d, p2.ID, "github.com/wesm/other", "git", "/tmp/other")
 
-	login, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p1.ID,
-		Title:     "orchid login regression",
-		Body:      "Safari login fails after the orchid rollout",
-		Author:    "tester",
-		Labels:    []string{"bug", "frontend"},
-	})
-	require.NoError(t, err)
-	blocker, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p1.ID,
-		Title:     "api blocker",
-		Body:      "Backend response blocks login",
-		Author:    "tester",
-		Labels:    []string{"backend"},
-	})
-	require.NoError(t, err)
-	softDeleted, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p1.ID,
-		Title:     "soft deleted keeps FTS",
-		Body:      "deleted but still exportable",
-		Author:    "tester",
-	})
-	require.NoError(t, err)
-	purged, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p1.ID,
-		Title:     "purged audit trail",
-		Body:      "purged body should leave purge_log only",
-		Author:    "tester",
-		Labels:    []string{"audit"},
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: p2.ID,
-		Title:     "other project orchid",
-		Body:      "cross project export coverage",
-		Author:    "tester",
-	})
-	require.NoError(t, err)
+	login := createTesterIssue(ctx, t, d, p1.ID, "orchid login regression", "Safari login fails after the orchid rollout", "bug", "frontend")
+	blocker := createTesterIssue(ctx, t, d, p1.ID, "api blocker", "Backend response blocks login", "backend")
+	softDeleted := createTesterIssue(ctx, t, d, p1.ID, "soft deleted keeps FTS", "deleted but still exportable")
+	purged := createTesterIssue(ctx, t, d, p1.ID, "purged audit trail", "purged body should leave purge_log only", "audit")
+	createTesterIssue(ctx, t, d, p2.ID, "other project orchid", "cross project export coverage")
 
-	_, _, err = d.CreateComment(ctx, db.CreateCommentParams{
-		IssueID: login.ID,
-		Author:  "tester",
-		Body:    "watermelon comment text",
-	})
-	require.NoError(t, err)
-	_, _, err = d.CreateComment(ctx, db.CreateCommentParams{
-		IssueID: purged.ID,
-		Author:  "tester",
-		Body:    "purged comment text",
-	})
-	require.NoError(t, err)
+	addTesterComment(ctx, t, d, login.ID, "watermelon comment text")
+	addTesterComment(ctx, t, d, purged.ID, "purged comment text")
+
 	_, _, err = d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
 		ProjectID:   p1.ID,
 		FromIssueID: blocker.ID,

--- a/internal/jsonl/identity_v3_test.go
+++ b/internal/jsonl/identity_v3_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,18 +21,9 @@ import (
 // inherited by v3).
 func TestV2ToV3CutoverFillsIdentity(t *testing.T) {
 	ctx := context.Background()
-	path := filepath.Join(t.TempDir(), "kata.db")
-	writeLegacyV2DB(t, path)
+	d := openCutoverDB(ctx, t, writeLegacyV2DB)
 
-	require.NoError(t, jsonl.AutoCutover(ctx, path))
-
-	d, err := db.Open(ctx, path)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = d.Close() })
-
-	var localUID string
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT value FROM meta WHERE key='instance_uid'`).Scan(&localUID))
+	localUID := fetchInstanceUID(ctx, t, d)
 	assert.True(t, uid.Valid(localUID))
 
 	// Every event has a valid uid + origin == new instance, AND the seeded
@@ -43,9 +33,9 @@ func TestV2ToV3CutoverFillsIdentity(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = rows.Close() }()
 	var (
-		eventCount   int
-		seenCreated  bool
-		seenComment  bool
+		eventCount  int
+		seenCreated bool
+		seenComment bool
 	)
 	for rows.Next() {
 		var u, typ, payload, origin string
@@ -95,12 +85,7 @@ func TestV2ToV3CutoverFillsIdentity(t *testing.T) {
 	// Re-running the cutover on a fresh copy of the same v2 source must yield
 	// identical event/purge_log row UIDs (FromStableSeed determinism), even
 	// though instance_uid/origin are intentionally non-deterministic.
-	pathB := filepath.Join(t.TempDir(), "b.db")
-	writeLegacyV2DB(t, pathB)
-	require.NoError(t, jsonl.AutoCutover(ctx, pathB))
-	b, err := db.Open(ctx, pathB)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = b.Close() })
+	b := openCutoverDB(ctx, t, writeLegacyV2DB)
 
 	for _, q := range []string{
 		`SELECT uid FROM events ORDER BY id ASC`,
@@ -116,18 +101,9 @@ func TestV2ToV3CutoverFillsIdentity(t *testing.T) {
 // matching the new local meta.instance_uid.
 func TestV1ToV3CutoverFillsIdentity(t *testing.T) {
 	ctx := context.Background()
-	path := filepath.Join(t.TempDir(), "kata.db")
-	writeLegacyV1DB(t, path)
+	d := openCutoverDB(ctx, t, writeLegacyV1DB)
 
-	require.NoError(t, jsonl.AutoCutover(ctx, path))
-
-	d, err := db.Open(ctx, path)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = d.Close() })
-
-	var localUID string
-	require.NoError(t, d.QueryRowContext(ctx,
-		`SELECT value FROM meta WHERE key='instance_uid'`).Scan(&localUID))
+	localUID := fetchInstanceUID(ctx, t, d)
 	assert.True(t, uid.Valid(localUID))
 
 	var eventUID, eventOrigin string
@@ -146,20 +122,8 @@ func TestV1ToV3CutoverFillsIdentity(t *testing.T) {
 func TestV1ToV3CutoverDeterministicRowUIDs(t *testing.T) {
 	ctx := context.Background()
 
-	pathA := filepath.Join(t.TempDir(), "a.db")
-	writeLegacyV1DB(t, pathA)
-	require.NoError(t, jsonl.AutoCutover(ctx, pathA))
-
-	pathB := filepath.Join(t.TempDir(), "b.db")
-	writeLegacyV1DB(t, pathB)
-	require.NoError(t, jsonl.AutoCutover(ctx, pathB))
-
-	a, err := db.Open(ctx, pathA)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = a.Close() })
-	b, err := db.Open(ctx, pathB)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = b.Close() })
+	a := openCutoverDB(ctx, t, writeLegacyV1DB)
+	b := openCutoverDB(ctx, t, writeLegacyV1DB)
 
 	for _, q := range []string{
 		`SELECT uid FROM projects ORDER BY id ASC`,
@@ -172,12 +136,7 @@ func TestV1ToV3CutoverDeterministicRowUIDs(t *testing.T) {
 	// Sanity: meta.instance_uid is intentionally NOT deterministic across
 	// reruns — two clones of the same v1 source must become two distinct
 	// installations.
-	var aUID, bUID string
-	require.NoError(t, a.QueryRowContext(ctx,
-		`SELECT value FROM meta WHERE key='instance_uid'`).Scan(&aUID))
-	require.NoError(t, b.QueryRowContext(ctx,
-		`SELECT value FROM meta WHERE key='instance_uid'`).Scan(&bUID))
-	assert.NotEqual(t, aUID, bUID)
+	assert.NotEqual(t, fetchInstanceUID(ctx, t, a), fetchInstanceUID(ctx, t, b))
 }
 
 // TestRoundtripV3PreservesInstanceUID covers spec §8.6: a v3 export → v3
@@ -193,23 +152,13 @@ func TestRoundtripV3PreservesInstanceUID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var srcUID string
-	require.NoError(t, src.QueryRowContext(ctx,
-		`SELECT value FROM meta WHERE key='instance_uid'`).Scan(&srcUID))
+	srcUID := fetchInstanceUID(ctx, t, src)
 
-	var buf bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, src, &buf, jsonl.ExportOptions{IncludeDeleted: true}))
-
-	dstPath := filepath.Join(t.TempDir(), "dst.db")
-	dst, err := db.Open(ctx, dstPath)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = dst.Close() })
+	buf := exportToBuffer(ctx, t, src)
+	dst := openImportTargetDB(t)
 	require.NoError(t, jsonl.Import(ctx, bytes.NewReader(buf.Bytes()), dst))
 
-	var dstUID string
-	require.NoError(t, dst.QueryRowContext(ctx,
-		`SELECT value FROM meta WHERE key='instance_uid'`).Scan(&dstUID))
-	assert.Equal(t, srcUID, dstUID, "default mode preserves source identity")
+	assert.Equal(t, srcUID, fetchInstanceUID(ctx, t, dst), "default mode preserves source identity")
 
 	for _, origin := range scanUIDs(t, dst, `SELECT origin_instance_uid FROM events`) {
 		assert.Equal(t, srcUID, origin)
@@ -227,13 +176,9 @@ func TestImportRefreshesCachedInstanceUID(t *testing.T) {
 	src := openExportTestDB(t)
 	srcUID := src.InstanceUID()
 
-	var buf bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, src, &buf, jsonl.ExportOptions{IncludeDeleted: true}))
+	buf := exportToBuffer(ctx, t, src)
 
-	dstPath := filepath.Join(t.TempDir(), "dst.db")
-	dst, err := db.Open(ctx, dstPath)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = dst.Close() })
+	dst := openImportTargetDB(t)
 	preImport := dst.InstanceUID()
 	require.NotEqual(t, srcUID, preImport, "fresh target must start with its own identity")
 
@@ -266,24 +211,15 @@ func TestImportNewInstanceRegeneratesIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var srcUID string
-	require.NoError(t, src.QueryRowContext(ctx,
-		`SELECT value FROM meta WHERE key='instance_uid'`).Scan(&srcUID))
+	srcUID := fetchInstanceUID(ctx, t, src)
 
-	var buf bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, src, &buf, jsonl.ExportOptions{IncludeDeleted: true}))
-
-	dstPath := filepath.Join(t.TempDir(), "dst.db")
-	dst, err := db.Open(ctx, dstPath)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = dst.Close() })
+	buf := exportToBuffer(ctx, t, src)
+	dst := openImportTargetDB(t)
 	require.NoError(t, jsonl.ImportWithOptions(ctx, bytes.NewReader(buf.Bytes()), dst, jsonl.ImportOptions{
 		NewInstance: true,
 	}))
 
-	var dstUID string
-	require.NoError(t, dst.QueryRowContext(ctx,
-		`SELECT value FROM meta WHERE key='instance_uid'`).Scan(&dstUID))
+	dstUID := fetchInstanceUID(ctx, t, dst)
 	assert.NotEqual(t, srcUID, dstUID, "new-instance keeps target's fresh identity")
 	assert.True(t, uid.Valid(dstUID))
 

--- a/internal/jsonl/import_test.go
+++ b/internal/jsonl/import_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,13 +49,12 @@ func TestImportRoundTripsExportedRows(t *testing.T) {
 func TestImportSQLiteSequenceUsesUpdateOrInsert(t *testing.T) {
 	ctx := context.Background()
 	target := openImportTargetDB(t)
-	input := strings.Join([]string{
-		`{"kind":"meta","data":{"key":"export_version","value":"1"}}`,
-		`{"kind":"sqlite_sequence","data":{"name":"issues","seq":150}}`,
-		`{"kind":"sqlite_sequence","data":{"name":"issues","seq":150}}`,
-	}, "\n") + "\n"
 
-	require.NoError(t, jsonl.Import(ctx, strings.NewReader(input), target))
+	require.NoError(t, importJSONL(ctx, target,
+		validExportVersion,
+		`{"kind":"sqlite_sequence","data":{"name":"issues","seq":150}}`,
+		`{"kind":"sqlite_sequence","data":{"name":"issues","seq":150}}`,
+	))
 
 	var rows int
 	require.NoError(t, target.QueryRowContext(ctx,
@@ -70,17 +68,17 @@ func TestImportSQLiteSequenceUsesUpdateOrInsert(t *testing.T) {
 
 func TestImportV1FillsUIDsDeterministically(t *testing.T) {
 	ctx := context.Background()
-	input := strings.Join([]string{
-		`{"kind":"meta","data":{"key":"export_version","value":"1"}}`,
+	rows := []string{
+		validExportVersion,
 		`{"kind":"project","data":{"id":1,"identity":"github.com/wesm/kata","name":"kata","created_at":"2026-05-03T00:00:00.000Z","next_issue_number":2}}`,
 		`{"kind":"issue","data":{"id":1,"project_id":1,"number":1,"title":"v1 issue","body":"","status":"open","closed_reason":null,"owner":null,"author":"tester","created_at":"2026-05-03T00:00:01.000Z","updated_at":"2026-05-03T00:00:01.000Z","closed_at":null,"deleted_at":null}}`,
 		`{"kind":"event","data":{"id":1,"project_id":1,"project_identity":"github.com/wesm/kata","issue_id":1,"issue_number":1,"related_issue_id":null,"type":"issue.created","actor":"tester","payload":{},"created_at":"2026-05-03T00:00:01.000Z"}}`,
-	}, "\n") + "\n"
+	}
 
 	first := openImportTargetDB(t)
-	require.NoError(t, jsonl.Import(ctx, strings.NewReader(input), first))
+	require.NoError(t, importJSONL(ctx, first, rows...))
 	second := openImportTargetDB(t)
-	require.NoError(t, jsonl.Import(ctx, strings.NewReader(input), second))
+	require.NoError(t, importJSONL(ctx, second, rows...))
 
 	firstUIDs := readFilledUIDs(t, first)
 	secondUIDs := readFilledUIDs(t, second)
@@ -96,13 +94,12 @@ func TestImportV1FillsUIDsDeterministically(t *testing.T) {
 func TestImportV1RejectsCorruptEventFK(t *testing.T) {
 	ctx := context.Background()
 	target := openImportTargetDB(t)
-	input := strings.Join([]string{
-		`{"kind":"meta","data":{"key":"export_version","value":"1"}}`,
-		`{"kind":"project","data":{"id":1,"identity":"github.com/wesm/kata","name":"kata","created_at":"2026-05-03T00:00:00.000Z","next_issue_number":1}}`,
-		`{"kind":"event","data":{"id":7,"project_id":1,"project_identity":"github.com/wesm/kata","issue_id":999,"issue_number":1,"related_issue_id":null,"type":"issue.created","actor":"tester","payload":{},"created_at":"2026-05-03T00:00:01.000Z"}}`,
-	}, "\n") + "\n"
 
-	err := jsonl.Import(ctx, strings.NewReader(input), target)
+	err := importJSONL(ctx, target,
+		validExportVersion,
+		validV1ProjectRow,
+		`{"kind":"event","data":{"id":7,"project_id":1,"project_identity":"github.com/wesm/kata","issue_id":999,"issue_number":1,"related_issue_id":null,"type":"issue.created","actor":"tester","payload":{},"created_at":"2026-05-03T00:00:01.000Z"}}`,
+	)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "corrupt_event_fk")
@@ -112,12 +109,11 @@ func TestImportV1RejectsCorruptEventFK(t *testing.T) {
 func TestImportRejectsInvalidExportVersion(t *testing.T) {
 	ctx := context.Background()
 	target := openImportTargetDB(t)
-	input := strings.Join([]string{
-		`{"kind":"meta","data":{"key":"export_version","value":"not-a-version"}}`,
-		`{"kind":"project","data":{"id":1,"identity":"github.com/wesm/kata","name":"kata","created_at":"2026-05-03T00:00:00.000Z","next_issue_number":1}}`,
-	}, "\n") + "\n"
 
-	err := jsonl.Import(ctx, strings.NewReader(input), target)
+	err := importJSONL(ctx, target,
+		`{"kind":"meta","data":{"key":"export_version","value":"not-a-version"}}`,
+		validV1ProjectRow,
+	)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "export_version")
@@ -127,12 +123,11 @@ func TestImportRejectsInvalidExportVersion(t *testing.T) {
 func TestImportRejectsTooNewExportVersion(t *testing.T) {
 	ctx := context.Background()
 	target := openImportTargetDB(t)
-	input := strings.Join([]string{
-		`{"kind":"meta","data":{"key":"export_version","value":"999"}}`,
-		`{"kind":"project","data":{"id":1,"identity":"github.com/wesm/kata","name":"kata","created_at":"2026-05-03T00:00:00.000Z","next_issue_number":1}}`,
-	}, "\n") + "\n"
 
-	err := jsonl.Import(ctx, strings.NewReader(input), target)
+	err := importJSONL(ctx, target,
+		`{"kind":"meta","data":{"key":"export_version","value":"999"}}`,
+		validV1ProjectRow,
+	)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported export_version")
@@ -142,12 +137,11 @@ func TestImportRejectsTooNewExportVersion(t *testing.T) {
 func TestImportRejectsForeignKeyViolationBeforeCommit(t *testing.T) {
 	ctx := context.Background()
 	target := openImportTargetDB(t)
-	input := strings.Join([]string{
-		`{"kind":"meta","data":{"key":"export_version","value":"1"}}`,
-		`{"kind":"project_alias","data":{"id":1,"project_id":999,"alias_identity":"missing","alias_kind":"git","root_path":"/tmp/missing","created_at":"2026-05-03T00:00:00.000Z","last_seen_at":"2026-05-03T00:00:00.000Z"}}`,
-	}, "\n") + "\n"
 
-	err := jsonl.Import(ctx, strings.NewReader(input), target)
+	err := importJSONL(ctx, target,
+		validExportVersion,
+		`{"kind":"project_alias","data":{"id":1,"project_id":999,"alias_identity":"missing","alias_kind":"git","root_path":"/tmp/missing","created_at":"2026-05-03T00:00:00.000Z","last_seen_at":"2026-05-03T00:00:00.000Z"}}`,
+	)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "foreign_key_check")

--- a/internal/jsonl/roundtrip_test.go
+++ b/internal/jsonl/roundtrip_test.go
@@ -3,7 +3,6 @@ package jsonl_test
 import (
 	"bytes"
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,16 +16,12 @@ func TestRoundtripRichDatabaseIsByteEquivalent(t *testing.T) {
 	fixture := buildRichJSONLFixture(t)
 	src := fixture.DB
 
-	var first bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, src, &first, jsonl.ExportOptions{IncludeDeleted: true}))
+	first := exportToBuffer(ctx, t, src)
 
-	dst, err := db.Open(ctx, filepath.Join(t.TempDir(), "roundtrip.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = dst.Close() })
+	dst := openExportTestDB(t)
 	require.NoError(t, jsonl.Import(ctx, bytes.NewReader(first.Bytes()), dst))
 
-	var second bytes.Buffer
-	require.NoError(t, jsonl.Export(ctx, dst, &second, jsonl.ExportOptions{IncludeDeleted: true}))
+	second := exportToBuffer(ctx, t, dst)
 
 	assert.Equal(t, first.String(), second.String())
 	assertRoundtripTableCounts(t, src, dst)

--- a/internal/jsonl/testdata/legacy_v1.sql
+++ b/internal/jsonl/testdata/legacy_v1.sql
@@ -1,0 +1,100 @@
+CREATE TABLE projects (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  identity TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  next_issue_number INTEGER NOT NULL DEFAULT 2
+);
+CREATE TABLE project_aliases (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  alias_identity TEXT UNIQUE NOT NULL,
+  alias_kind TEXT NOT NULL,
+  root_path TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  last_seen_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE issues (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  number INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'open',
+  closed_reason TEXT,
+  owner TEXT,
+  author TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  closed_at DATETIME,
+  deleted_at DATETIME
+);
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  author TEXT NOT NULL,
+  body TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE links (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  from_issue_id INTEGER NOT NULL REFERENCES issues(id),
+  to_issue_id INTEGER NOT NULL REFERENCES issues(id),
+  type TEXT NOT NULL,
+  author TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE issue_labels (
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  label TEXT NOT NULL,
+  author TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY(issue_id, label)
+);
+CREATE TABLE events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  project_identity TEXT NOT NULL,
+  issue_id INTEGER REFERENCES issues(id),
+  issue_number INTEGER,
+  related_issue_id INTEGER REFERENCES issues(id),
+  type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  payload TEXT NOT NULL DEFAULT '{}',
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE purge_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL,
+  purged_issue_id INTEGER NOT NULL,
+  project_identity TEXT NOT NULL,
+  issue_number INTEGER NOT NULL,
+  issue_title TEXT NOT NULL,
+  issue_author TEXT NOT NULL,
+  comment_count INTEGER NOT NULL,
+  link_count INTEGER NOT NULL,
+  label_count INTEGER NOT NULL,
+  event_count INTEGER NOT NULL,
+  events_deleted_min_id INTEGER,
+  events_deleted_max_id INTEGER,
+  purge_reset_after_event_id INTEGER,
+  actor TEXT NOT NULL,
+  reason TEXT,
+  purged_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+INSERT INTO meta(key, value) VALUES('schema_version', '1');
+INSERT INTO meta(key, value) VALUES('created_by_version', '0.1.0');
+INSERT INTO projects(id, identity, name, created_at, next_issue_number)
+VALUES(1, 'github.com/wesm/kata', 'kata', '2026-05-03T00:00:00.000Z', 2);
+INSERT INTO project_aliases(id, project_id, alias_identity, alias_kind, root_path, created_at, last_seen_at)
+VALUES(1, 1, 'github.com/wesm/kata', 'git', '/tmp/kata', '2026-05-03T00:00:00.000Z', '2026-05-03T00:00:00.000Z');
+INSERT INTO issues(id, project_id, number, title, body, status, closed_reason, owner, author, created_at, updated_at, closed_at, deleted_at)
+VALUES(1, 1, 1, 'legacy issue', '', 'open', NULL, NULL, 'tester', '2026-05-03T00:00:01.000Z', '2026-05-03T00:00:01.000Z', NULL, NULL);
+INSERT INTO comments(id, issue_id, author, body, created_at)
+VALUES(1, 1, 'tester', 'legacy comment', '2026-05-03T00:00:02.000Z');
+INSERT INTO issue_labels(issue_id, label, author, created_at)
+VALUES(1, 'bug', 'tester', '2026-05-03T00:00:02.000Z');
+INSERT INTO events(id, project_id, project_identity, issue_id, issue_number, related_issue_id, type, actor, payload, created_at)
+VALUES(1, 1, 'github.com/wesm/kata', 1, 1, NULL, 'issue.created', 'tester', '{}', '2026-05-03T00:00:01.000Z');

--- a/internal/jsonl/testdata/legacy_v2.sql
+++ b/internal/jsonl/testdata/legacy_v2.sql
@@ -1,0 +1,127 @@
+CREATE TABLE projects (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  uid TEXT NOT NULL UNIQUE,
+  identity TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  next_issue_number INTEGER NOT NULL DEFAULT 1,
+  CHECK (length(uid) = 26)
+);
+CREATE TABLE project_aliases (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  alias_identity TEXT UNIQUE NOT NULL,
+  alias_kind TEXT NOT NULL,
+  root_path TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  last_seen_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE issues (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  uid TEXT NOT NULL UNIQUE,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  number INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'open',
+  closed_reason TEXT,
+  owner TEXT,
+  author TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  closed_at DATETIME,
+  deleted_at DATETIME,
+  UNIQUE(project_id, number),
+  CHECK (length(uid) = 26)
+);
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  author TEXT NOT NULL,
+  body TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE links (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  from_issue_id INTEGER NOT NULL REFERENCES issues(id),
+  to_issue_id INTEGER NOT NULL REFERENCES issues(id),
+  from_issue_uid TEXT NOT NULL,
+  to_issue_uid TEXT NOT NULL,
+  type TEXT NOT NULL,
+  author TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE issue_labels (
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  label TEXT NOT NULL,
+  author TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY(issue_id, label)
+);
+-- v2 events: no uid, no origin_instance_uid (the v2->v3 cutover backfills them).
+CREATE TABLE events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  project_identity TEXT NOT NULL,
+  issue_id INTEGER REFERENCES issues(id),
+  issue_uid TEXT,
+  issue_number INTEGER,
+  related_issue_id INTEGER REFERENCES issues(id),
+  related_issue_uid TEXT,
+  type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  payload TEXT NOT NULL DEFAULT '{}',
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+-- v2 purge_log: no uid, no origin_instance_uid.
+CREATE TABLE purge_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL,
+  purged_issue_id INTEGER NOT NULL,
+  issue_uid TEXT,
+  project_uid TEXT,
+  project_identity TEXT NOT NULL,
+  issue_number INTEGER NOT NULL,
+  issue_title TEXT NOT NULL,
+  issue_author TEXT NOT NULL,
+  comment_count INTEGER NOT NULL,
+  link_count INTEGER NOT NULL,
+  label_count INTEGER NOT NULL,
+  event_count INTEGER NOT NULL,
+  events_deleted_min_id INTEGER,
+  events_deleted_max_id INTEGER,
+  purge_reset_after_event_id INTEGER,
+  actor TEXT NOT NULL,
+  reason TEXT,
+  purged_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+INSERT INTO meta(key, value) VALUES('schema_version', '2');
+INSERT INTO meta(key, value) VALUES('created_by_version', '0.1.0');
+
+INSERT INTO projects(id, uid, identity, name, created_at, next_issue_number)
+VALUES(1, '01HZZZZZZZZZZZZZZZZZZZZZZZ', 'github.com/wesm/kata', 'kata', '2026-05-03T00:00:00.000Z', 2);
+INSERT INTO issues(id, uid, project_id, number, title, body, status, author, created_at, updated_at)
+VALUES(1, '01HZZZZZZZZZZZZZZZZZZZZZZ1', 1, 1, 'v2 issue', '', 'open', 'tester',
+       '2026-05-03T00:00:01.000Z', '2026-05-03T00:00:01.000Z');
+-- Two real events on issue #1: created (carrying idempotency_key) + commented.
+INSERT INTO events(id, project_id, project_identity, issue_id, issue_uid, issue_number, type, actor, payload, created_at)
+VALUES(1, 1, 'github.com/wesm/kata', 1, '01HZZZZZZZZZZZZZZZZZZZZZZ1', 1, 'issue.created', 'tester',
+       '{"idempotency_key":"K1","idempotency_fingerprint":"fp"}', '2026-05-03T00:00:01.000Z');
+INSERT INTO events(id, project_id, project_identity, issue_id, issue_uid, issue_number, type, actor, payload, created_at)
+VALUES(2, 1, 'github.com/wesm/kata', 1, '01HZZZZZZZZZZZZZZZZZZZZZZ1', 1, 'issue.commented', 'tester',
+       '{"comment_id":42}', '2026-05-03T00:00:02.000Z');
+-- A purge_log row referring to a long-gone issue #99 with the synthetic SSE
+-- reset cursor reserved at 99 (a value greater than any current events.id).
+INSERT INTO purge_log(id, project_id, purged_issue_id, issue_uid, project_uid, project_identity,
+                      issue_number, issue_title, issue_author, comment_count, link_count, label_count,
+                      event_count, events_deleted_min_id, events_deleted_max_id,
+                      purge_reset_after_event_id, actor, reason, purged_at)
+VALUES(1, 1, 99, '01HZZZZZZZZZZZZZZZZZZZZZ99', '01HZZZZZZZZZZZZZZZZZZZZZZZ', 'github.com/wesm/kata',
+       99, 'gone', 'tester', 0, 0, 0, 1, 50, 50, 99, 'tester', 'fixture',
+       '2026-05-03T00:00:03.000Z');
+INSERT INTO sqlite_sequence(name, seq) VALUES('events', 99);
+INSERT INTO sqlite_sequence(name, seq) VALUES('issues', 1);
+INSERT INTO sqlite_sequence(name, seq) VALUES('projects', 1);
+INSERT INTO sqlite_sequence(name, seq) VALUES('purge_log', 1);

--- a/internal/jsonl/testdata/legacy_v3.sql
+++ b/internal/jsonl/testdata/legacy_v3.sql
@@ -1,0 +1,112 @@
+CREATE TABLE projects (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  uid TEXT NOT NULL UNIQUE,
+  identity TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  next_issue_number INTEGER NOT NULL DEFAULT 1,
+  CHECK (length(uid) = 26)
+);
+-- v3 projects: no deleted_at column and no idx_projects_active index
+-- (added by the v3->v4 cutover).
+CREATE TABLE project_aliases (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  alias_identity TEXT UNIQUE NOT NULL,
+  alias_kind TEXT NOT NULL,
+  root_path TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  last_seen_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE issues (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  uid TEXT NOT NULL UNIQUE,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  number INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'open',
+  closed_reason TEXT,
+  owner TEXT,
+  author TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  closed_at DATETIME,
+  deleted_at DATETIME,
+  UNIQUE(project_id, number),
+  CHECK (length(uid) = 26)
+);
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  author TEXT NOT NULL,
+  body TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE links (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  from_issue_id INTEGER NOT NULL REFERENCES issues(id),
+  to_issue_id INTEGER NOT NULL REFERENCES issues(id),
+  from_issue_uid TEXT NOT NULL,
+  to_issue_uid TEXT NOT NULL,
+  type TEXT NOT NULL,
+  author TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE issue_labels (
+  issue_id INTEGER NOT NULL REFERENCES issues(id),
+  label TEXT NOT NULL,
+  author TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY(issue_id, label)
+);
+-- v3 events: gain uid + origin_instance_uid (the v2->v3 cutover backfilled them).
+CREATE TABLE events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  uid TEXT NOT NULL UNIQUE,
+  origin_instance_uid TEXT NOT NULL,
+  project_id INTEGER NOT NULL REFERENCES projects(id),
+  project_identity TEXT NOT NULL,
+  issue_id INTEGER REFERENCES issues(id),
+  issue_uid TEXT,
+  issue_number INTEGER,
+  related_issue_id INTEGER REFERENCES issues(id),
+  related_issue_uid TEXT,
+  type TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  payload TEXT NOT NULL DEFAULT '{}',
+  created_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+-- v3 purge_log: gain uid + origin_instance_uid.
+CREATE TABLE purge_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  uid TEXT NOT NULL UNIQUE,
+  origin_instance_uid TEXT NOT NULL,
+  project_id INTEGER NOT NULL,
+  purged_issue_id INTEGER NOT NULL,
+  issue_uid TEXT,
+  project_uid TEXT,
+  project_identity TEXT NOT NULL,
+  issue_number INTEGER NOT NULL,
+  issue_title TEXT NOT NULL,
+  issue_author TEXT NOT NULL,
+  comment_count INTEGER NOT NULL,
+  link_count INTEGER NOT NULL,
+  label_count INTEGER NOT NULL,
+  event_count INTEGER NOT NULL,
+  events_deleted_min_id INTEGER,
+  events_deleted_max_id INTEGER,
+  purge_reset_after_event_id INTEGER,
+  actor TEXT NOT NULL,
+  reason TEXT,
+  purged_at DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+INSERT INTO meta(key, value) VALUES('schema_version', '3');
+INSERT INTO meta(key, value) VALUES('created_by_version', '0.1.0');
+INSERT INTO meta(key, value) VALUES('instance_uid', '01HZZZZZZZZZZZZZZZZZINST01');
+
+INSERT INTO projects(id, uid, identity, name, created_at, next_issue_number)
+VALUES(1, '01HZZZZZZZZZZZZZZZZZZZZ001', 'proj-a', 'Proj A', '2026-05-03T00:00:00.000Z', 1);
+INSERT INTO sqlite_sequence(name, seq) VALUES('projects', 1);

--- a/internal/similarity/similarity_test.go
+++ b/internal/similarity/similarity_test.go
@@ -8,6 +8,29 @@ import (
 	"github.com/wesm/kata/internal/similarity"
 )
 
+const epsilon = 1e-9
+
+type tokenizeTestCase struct {
+	name string
+	in   string
+	want []string
+}
+
+func runTokenizeTests(t *testing.T, cases []tokenizeTestCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, similarity.Tokenize(tc.in))
+		})
+	}
+}
+
+func assertScore(t *testing.T, want float64, titleA, bodyA, titleB, bodyB string, msgAndArgs ...interface{}) {
+	t.Helper()
+	got := similarity.Score(titleA, bodyA, titleB, bodyB)
+	assert.InDelta(t, want, got, epsilon, msgAndArgs...)
+}
+
 func TestCanonical(t *testing.T) {
 	// Decomposed "café" = e + combining acute (U+0065 U+0301).
 	decomposed := string([]rune{'c', 'a', 'f', 'e', '́'})
@@ -24,7 +47,7 @@ func TestCanonical(t *testing.T) {
 		{"preserves_case", "Fix Login Bug", "Fix Login Bug"},
 		{"nfc_normalizes_combining_marks", precomposed, precomposed},
 		{"nfc_normalizes_decomposed_form", decomposed, precomposed},
-		{"non_ascii_whitespace_is_collapsed", "foo bar", "foo bar"},
+		{"non_ascii_whitespace_is_collapsed", "foo\u00a0bar", "foo bar"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -34,11 +57,7 @@ func TestCanonical(t *testing.T) {
 }
 
 func TestTokenize(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want []string
-	}{
+	runTokenizeTests(t, []tokenizeTestCase{
 		{"empty", "", nil},
 		{"single_word", "fix", []string{"fix"}},
 		{"drops_stop_words", "the bug is in login", []string{"bug", "login"}},
@@ -48,12 +67,7 @@ func TestTokenize(t *testing.T) {
 			[]string{"fix", "crash", "test"}},
 		{"drops_short_tokens", "a b is fix", []string{"fix"}},
 		{"splits_on_punctuation", "fix-login: crash!", []string{"fix", "login", "crash"}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, similarity.Tokenize(tc.in))
-		})
-	}
+	})
 }
 
 func TestJaccard(t *testing.T) {
@@ -70,33 +84,31 @@ func TestJaccard(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.InDelta(t, tc.want, similarity.Jaccard(tc.a, tc.b), 1e-9)
+			assert.InDelta(t, tc.want, similarity.Jaccard(tc.a, tc.b), epsilon)
 		})
 	}
 }
 
 func TestScore_WeightedSum(t *testing.T) {
-	got := similarity.Score("fix login crash", "stack trace here",
+	assertScore(t, 1.0,
+		"fix login crash", "stack trace here",
 		"fix login crash", "stack trace here")
-	assert.InDelta(t, 1.0, got, 1e-9)
-
-	got = similarity.Score("fix login crash", "stack trace here",
+	assertScore(t, 0.6,
+		"fix login crash", "stack trace here",
 		"fix login crash", "completely different body")
-	assert.InDelta(t, 0.6, got, 1e-9)
-
-	got = similarity.Score("fix login crash", "shared body text",
+	assertScore(t, 0.4,
+		"fix login crash", "shared body text",
 		"unrelated title", "shared body text")
-	assert.InDelta(t, 0.4, got, 1e-9)
-
-	got = similarity.Score("alpha", "beta", "gamma", "delta")
-	assert.InDelta(t, 0.0, got, 1e-9)
+	assertScore(t, 0.0,
+		"alpha", "beta", "gamma", "delta")
 }
 
 func TestScore_Body500CharLimit(t *testing.T) {
 	prefix := strings.Repeat("x", 500)
-	got := similarity.Score("same", prefix+" alpha-divergent",
-		"same", prefix+" beta-divergent")
-	assert.InDelta(t, 1.0, got, 1e-9, "divergence past 500 chars must not affect the score")
+	assertScore(t, 1.0,
+		"same", prefix+" alpha-divergent",
+		"same", prefix+" beta-divergent",
+		"divergence past 500 chars must not affect the score")
 }
 
 // TestTokenize_AllStopWordsAreFiltered guards against stopword/stem ordering
@@ -120,38 +132,20 @@ func TestTokenize_AllStopWordsAreFiltered(t *testing.T) {
 // phrase containing only stopwords (some of which would stem to nonsense
 // tokens if processed in the wrong order) yields an empty token slice.
 func TestTokenize_StopWordsBeforeStem(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want []string
-	}{
+	runTokenizeTests(t, []tokenizeTestCase{
 		{"this_was_a_bug", "this was a bug", []string{"bug"}},
 		{"all_stopwords_strippable", "this was has", nil},
 		{"mixed_phrase", "this issue has the login crash", []string{"issue", "login", "crash"}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, similarity.Tokenize(tc.in))
-		})
-	}
+	})
 }
 
 // TestTokenize_DropsSingleRuneNonASCII pins the rune-count short-token filter:
 // "é" is one rune (two bytes) and must be dropped per the documented
 // "shorter than 2 runes" rule, not retained because of byte length.
 func TestTokenize_DropsSingleRuneNonASCII(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want []string
-	}{
+	runTokenizeTests(t, []tokenizeTestCase{
 		{"single_nonascii_rune", "é", nil},
 		{"single_ascii_letter", "a", nil},
 		{"two_runes_nonascii_kept", "éé", []string{"éé"}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, similarity.Tokenize(tc.in))
-		})
-	}
+	})
 }

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -5,6 +5,7 @@ package testenv
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -37,6 +38,50 @@ func New(t *testing.T) *Env {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = d.Close() })
 
+	url, client, bcast := serveDaemon(t, d)
+	return &Env{URL: url, HTTP: client, DB: d, Home: home, Broadcaster: bcast}
+}
+
+// NewFromDB launches a daemon backed by an existing SQLite database file. Use
+// this when verifying the contents of a DB produced by import/restore/migration
+// flows. KATA_HOME is not modified — the caller's environment is preserved.
+func NewFromDB(t *testing.T, dbPath string) *Env {
+	t.Helper()
+	d, err := db.Open(context.Background(), dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	url, client, bcast := serveDaemon(t, d)
+	return &Env{URL: url, HTTP: client, DB: d, Home: filepath.Dir(dbPath), Broadcaster: bcast}
+}
+
+// Get issues GET env.URL+path, reads and closes the response body, and returns
+// the status code paired with the body bytes. Errors fail the test.
+func (e *Env) Get(t *testing.T, path string) (int, []byte) {
+	t.Helper()
+	resp, err := e.HTTP.Get(e.URL + path) //nolint:gosec,noctx // test helper against loopback
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, body
+}
+
+// RequireOK GETs path, asserts the response is 200, and returns the body.
+func (e *Env) RequireOK(t *testing.T, path string) []byte {
+	t.Helper()
+	status, body := e.Get(t, path)
+	require.Equalf(t, http.StatusOK, status, "GET %s expected 200, got %d: %s", path, status, body)
+	return body
+}
+
+// serveDaemon binds a loopback listener, runs the daemon against d in a
+// background goroutine, and waits for /ping to return 200. Cleanup (server
+// shutdown wait) is wired via t.Cleanup. Callers are responsible for closing d
+// in a separately registered cleanup so LIFO ordering closes the DB after
+// Serve returns.
+func serveDaemon(t *testing.T, d *db.DB) (string, *http.Client, *daemon.EventBroadcaster) {
+	t.Helper()
 	// Bind the listener once and hand it directly to Server.Serve so no other
 	// process can grab the port between bind and serve (the close-then-reopen
 	// pattern has a TOCTOU race).
@@ -57,9 +102,6 @@ func New(t *testing.T) *Env {
 		defer close(done)
 		_ = srv.Serve(ctx, l)
 	}()
-	// Cleanup must wait for Serve to return (Shutdown drained) before the DB is
-	// closed, otherwise in-flight handlers can race against d.Close. t.Cleanup
-	// is LIFO, so this fires before the d.Close cleanup registered above.
 	t.Cleanup(func() {
 		cancel()
 		<-done
@@ -67,7 +109,7 @@ func New(t *testing.T) *Env {
 
 	// Wait for /ping to answer with 200; if the daemon never becomes ready, or
 	// if some other service won the port and answered with a non-200, fail
-	// loudly at New rather than letting the test report a confusing failure on
+	// loudly here rather than letting the test report a confusing failure on
 	// its first real request.
 	url := "http://" + addr
 	deadline := time.Now().Add(2 * time.Second)
@@ -90,6 +132,5 @@ func New(t *testing.T) *Env {
 		time.Sleep(20 * time.Millisecond)
 	}
 	require.Truef(t, ready, "daemon did not become ready within 2s: %v", lastErr)
-
-	return &Env{URL: url, HTTP: client, DB: d, Home: home, Broadcaster: bcast}
+	return url, client, bcast
 }

--- a/internal/testenv/testenv_test.go
+++ b/internal/testenv/testenv_test.go
@@ -1,21 +1,14 @@
 package testenv_test
 
 import (
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/testenv"
 )
 
 func TestEnv_BootsDaemonAndAnswersPing(t *testing.T) {
 	env := testenv.New(t)
-	resp, err := env.HTTP.Get(env.URL + "/api/v1/ping")
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-	bs, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode)
-	assert.Contains(t, string(bs), `"ok":true`)
+	body := env.RequireOK(t, "/api/v1/ping")
+	assert.Contains(t, string(body), `"ok":true`)
 }

--- a/internal/testfix/testfix.go
+++ b/internal/testfix/testfix.go
@@ -1,0 +1,53 @@
+// Package testfix collects small filesystem and git fixtures shared across
+// test packages: writing a stock .kata.toml, faking a .git directory, and
+// running real git for tests that need a working repository.
+package testfix
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// WriteKataToml writes a minimal v1 .kata.toml under dir with the given
+// identity and name. The world-readable file mode mirrors how users commit
+// .kata.toml in real projects.
+func WriteKataToml(t *testing.T, dir, identity, name string) {
+	t.Helper()
+	body := fmt.Sprintf("version = 1\n\n[project]\nidentity = %q\nname     = %q\n", identity, name)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"), []byte(body), 0o644)) //nolint:gosec // test fixture mirrors production .kata.toml mode
+}
+
+// MkDotGit creates an empty .git directory under dir so that walk-up
+// discovery code can detect a git workspace without a real repository.
+func MkDotGit(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755)) //nolint:gosec // test fixture under TempDir
+}
+
+// InitGitRepo creates a fresh temp directory, runs git init, and configures
+// a deterministic author so commit-producing tests don't depend on the host
+// git config. Returns the repo path.
+func InitGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	RunGit(t, dir, "init", "--quiet")
+	RunGit(t, dir, "config", "user.email", "x@example.com")
+	RunGit(t, dir, "config", "user.name", "x")
+	return dir
+}
+
+// RunGit invokes the system git binary inside dir with args and fails the
+// test, surfacing combined output, if the command errors.
+func RunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	//nolint:gosec // git binary is fixed; args are test-supplied subcommand flags.
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v: %s", args, out)
+}

--- a/internal/textsafe/textsafe_test.go
+++ b/internal/textsafe/textsafe_test.go
@@ -1,111 +1,64 @@
 package textsafe
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
-// TestBlock_StripsAnsi covers the headline malicious case: a string
-// containing a screen-clear escape (ESC [ 2 J) is rendered without
-// the escape so the agent can't blank the user's terminal.
-func TestBlock_StripsAnsi(t *testing.T) {
-	in := "before\x1b[2Jafter"
-	got := Block(in)
-	if strings.Contains(got, "\x1b") {
-		t.Fatalf("ESC survived sanitization: %q", got)
+// TestBlock covers the multi-line sanitizer. Each case names the threat
+// or property under test; exact-string equality implicitly proves the
+// dangerous bytes were stripped.
+func TestBlock(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// CSI escape (ESC [ 2 J) would blank the user's terminal.
+		{"strips_ansi_csi", "before\x1b[2Jafter", "beforeafter"},
+		// OSC family — title sets and OSC-8 hyperlinks can render as
+		// legitimate-looking text linking to an attacker URL.
+		{"strips_ansi_osc", "click \x1b]8;;https://evil.example/\x1b\\here\x1b]8;;\x1b\\!", "click here!"},
+		// U+202E RIGHT-TO-LEFT OVERRIDE visually inverts subsequent
+		// text; Cf runes are stripped alongside C0/C1 controls.
+		{"strips_bidi_override", "safe\u202eevil", "safeevil"},
+		// Block is for multi-line contexts, so legitimate body content
+		// with newlines and tabs survives.
+		{"preserves_newlines_and_tabs", "line one\nline two\tindented", "line one\nline two\tindented"},
+		{"empty_string", "", ""},
 	}
-	if got != "beforeafter" {
-		t.Fatalf("got %q, want %q", got, "beforeafter")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Block(tc.in); got != tc.want {
+				t.Fatalf("Block(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 
-// TestBlock_StripsOSC covers the OSC family — title sets and OSC-8
-// hyperlinks, which can render as legitimate-looking text linking
-// to an attacker URL.
-func TestBlock_StripsOSC(t *testing.T) {
-	in := "click \x1b]8;;https://evil.example/\x1b\\here\x1b]8;;\x1b\\!"
-	got := Block(in)
-	if strings.Contains(got, "\x1b") {
-		t.Fatalf("ESC survived OSC sanitization: %q", got)
+// TestLine covers the single-line sanitizer, which stacks on Block and
+// additionally collapses newlines/tabs that would break row layout.
+func TestLine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Embedded newlines become the literal `\n` so the row stays
+		// one visual line.
+		{"replaces_newline_with_literal_escape", "title with\nembedded newline", `title with\nembedded newline`},
+		// Tabs render at variable widths across terminals and break
+		// column alignment; replace with a single space.
+		{"replaces_tabs_with_space", "title\twith\ttabs", "title with tabs"},
+		// Line inherits ANSI stripping from Block.
+		{"strips_ansi", "title\x1b[31mred\x1b[0mback", "titleredback"},
+		// \r in a single-row context can rewind the cursor and
+		// overwrite the rest of the row.
+		{"strips_carriage_return", "good\rbad", "goodbad"},
+		{"empty_string", "", ""},
 	}
-}
-
-// TestBlock_StripsBidiOverride covers the U+202E (RIGHT-TO-LEFT
-// OVERRIDE) attack: a title can visually invert subsequent text.
-func TestBlock_StripsBidiOverride(t *testing.T) {
-	in := "safe" + string(rune(0x202E)) + "evil"
-	got := Block(in)
-	if strings.ContainsRune(got, 0x202E) {
-		t.Fatalf("U+202E survived sanitization: %q", got)
-	}
-	if got != "safeevil" {
-		t.Fatalf("got %q, want %q", got, "safeevil")
-	}
-}
-
-// TestBlock_PreservesNewlinesAndTabs: Block is for multi-line
-// contexts, so legitimate body content with newlines and tabs
-// survives.
-func TestBlock_PreservesNewlinesAndTabs(t *testing.T) {
-	in := "line one\nline two\tindented"
-	got := Block(in)
-	if got != in {
-		t.Fatalf("Block changed legitimate body content: got %q, want %q", got, in)
-	}
-}
-
-// TestBlock_EmptyString returns empty without allocating.
-func TestBlock_EmptyString(t *testing.T) {
-	if got := Block(""); got != "" {
-		t.Fatalf("Block(\"\") = %q, want empty", got)
-	}
-}
-
-// TestLine_ReplacesNewlinesWithLiteralEscape: a title with embedded
-// newlines breaks single-line list-row layout. Line replaces them
-// with the literal `\n` so the row stays one visual line.
-func TestLine_ReplacesNewlinesWithLiteralEscape(t *testing.T) {
-	in := "title with\nembedded newline"
-	got := Line(in)
-	if strings.Contains(got, "\n") {
-		t.Fatalf("Line preserved a literal newline: %q", got)
-	}
-	if !strings.Contains(got, `\n`) {
-		t.Fatalf("Line did not replace newline with `\\n`: %q", got)
-	}
-}
-
-// TestLine_ReplacesTabsWithSpace: tabs render at variable widths
-// across terminals and break column alignment. Replace with a
-// single space.
-func TestLine_ReplacesTabsWithSpace(t *testing.T) {
-	in := "title\twith\ttabs"
-	got := Line(in)
-	if strings.ContainsRune(got, '\t') {
-		t.Fatalf("Line preserved a literal tab: %q", got)
-	}
-	if got != "title with tabs" {
-		t.Fatalf("got %q, want %q", got, "title with tabs")
-	}
-}
-
-// TestLine_AlsoStripsAnsi: Line stacks on top of Block so ANSI is
-// stripped here too.
-func TestLine_AlsoStripsAnsi(t *testing.T) {
-	in := "title\x1b[31mred\x1b[0mback"
-	got := Line(in)
-	if strings.Contains(got, "\x1b") {
-		t.Fatalf("ESC survived Line sanitization: %q", got)
-	}
-}
-
-// TestLine_StripsCarriageReturn: \r in a single-row context can
-// rewind the cursor and overwrite the rest of the row. Block
-// already strips it; verify here for the single-line context.
-func TestLine_StripsCarriageReturn(t *testing.T) {
-	in := "good\rbad"
-	got := Line(in)
-	if strings.ContainsRune(got, '\r') {
-		t.Fatalf("\\r survived: %q", got)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Line(tc.in); got != tc.want {
+				t.Fatalf("Line(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/tui/cache_test.go
+++ b/internal/tui/cache_test.go
@@ -2,24 +2,32 @@ package tui
 
 import "testing"
 
+// setupSeededCache returns a cache pre-populated with one issue for the
+// canonical test project, plus the key used to seed it.
+func setupSeededCache() (*issueCache, cacheKey) {
+	c := newIssueCache()
+	k := cacheKey{projectID: 7}
+	c.put(k, []Issue{{Number: 1}})
+	return c, k
+}
+
+func assertStale(t *testing.T, c *issueCache, want bool) {
+	t.Helper()
+	if got := c.isStale(); got != want {
+		t.Fatalf("isStale = %v, want %v", got, want)
+	}
+}
+
 // TestCache_PutThenStaleThenRefetch covers the steady-state SSE flow:
 // fetch populates the slot, an event marks it stale, and a fresh fetch
 // clears stale and replaces the data.
 func TestCache_PutThenStaleThenRefetch(t *testing.T) {
-	c := newIssueCache()
-	k := cacheKey{projectID: 7}
-	c.put(k, []Issue{{Number: 1}})
-	if c.isStale() {
-		t.Fatal("freshly put cache must not be stale")
-	}
+	c, k := setupSeededCache()
+	assertStale(t, c, false)
 	c.markStale()
-	if !c.isStale() {
-		t.Fatal("after markStale, isStale must be true")
-	}
+	assertStale(t, c, true)
 	c.put(k, []Issue{{Number: 2}})
-	if c.isStale() {
-		t.Fatal("after re-put, stale must clear")
-	}
+	assertStale(t, c, false)
 	if len(c.data) != 1 || c.data[0].Number != 2 {
 		t.Fatalf("data = %+v, want [{Number:2}]", c.data)
 	}
@@ -29,13 +37,10 @@ func TestCache_PutThenStaleThenRefetch(t *testing.T) {
 // follow-up isStale returns false (no slot, nothing to be stale about).
 // This is the sync.reset_required path.
 func TestCache_DropEmpties(t *testing.T) {
-	c := newIssueCache()
-	c.put(cacheKey{projectID: 7}, []Issue{{Number: 1}})
+	c, _ := setupSeededCache()
 	c.markStale()
 	c.drop()
-	if c.isStale() {
-		t.Fatal("after drop, isStale must be false")
-	}
+	assertStale(t, c, false)
 	if c.set {
 		t.Fatal("after drop, set must be false")
 	}
@@ -47,14 +52,11 @@ func TestCache_DropEmpties(t *testing.T) {
 // TestCache_MarkStaleIdempotent: multiple events in a 150ms window all
 // flip stale; the second markStale on an already-stale cache is a no-op.
 func TestCache_MarkStaleIdempotent(t *testing.T) {
-	c := newIssueCache()
-	c.put(cacheKey{projectID: 7}, []Issue{{Number: 1}})
+	c, _ := setupSeededCache()
 	c.markStale()
 	c.markStale()
 	c.markStale()
-	if !c.isStale() {
-		t.Fatal("triple markStale should leave isStale=true")
-	}
+	assertStale(t, c, true)
 }
 
 func TestCache_RenderFilterDoesNotChangeSlotKey(t *testing.T) {
@@ -74,7 +76,5 @@ func TestCache_RenderFilterDoesNotChangeSlotKey(t *testing.T) {
 // stale=true requires a real slot to be stale about.
 func TestCache_EmptyIsNotStale(t *testing.T) {
 	c := newIssueCache()
-	if c.isStale() {
-		t.Fatal("empty cache must not report stale")
-	}
+	assertStale(t, c, false)
 }

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -17,24 +17,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newTestClient stands up an httptest server with handler, registers
+// cleanup, and returns a daemon Client pointed at it.
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL, srv.Client())
+}
+
+// respondJSON writes body as a JSON response with the right Content-Type.
+func respondJSON(t *testing.T, w http.ResponseWriter, body any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}
+
 func TestClient_ListIssues_BuildsExpectedURLAndDecodes(t *testing.T) {
 	var gotURL string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotURL = r.URL.String()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		respondJSON(t, w, map[string]any{
 			"issues": []map[string]any{
 				{"number": 1, "title": "a", "status": "open"},
 				{"number": 2, "title": "b", "status": "open"},
 			},
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	got, err := c.ListIssues(context.Background(), 7, ListFilter{Status: "open"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(gotURL, "/api/v1/projects/7/issues") {
 		t.Fatalf("unexpected URL: %s", gotURL)
 	}
@@ -48,16 +61,13 @@ func TestClient_ListIssues_BuildsExpectedURLAndDecodes(t *testing.T) {
 
 func TestClient_ListIssues_SendsLimit(t *testing.T) {
 	var gotQuery string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"issues":[]}`))
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
-	if _, err := c.ListIssues(context.Background(), 7, ListFilter{Limit: 2001}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	_, err := c.ListIssues(context.Background(), 7, ListFilter{Limit: 2001})
+	require.NoError(t, err)
 	if !strings.Contains(gotQuery, "limit=2001") {
 		t.Fatalf("limit not sent: %q", gotQuery)
 	}
@@ -68,14 +78,13 @@ func TestClient_ListIssues_SendsLimit(t *testing.T) {
 
 func TestModel_FetchInitialUsesQueueFetchFilter(t *testing.T) {
 	var gotQuery string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"issues":[]}`))
-	}))
-	defer srv.Close()
+	})
 	m := Model{
-		api:   NewClient(srv.URL, srv.Client()),
+		api:   c,
 		scope: scope{projectID: 7},
 		list:  listModel{filter: ListFilter{Status: "closed"}},
 	}
@@ -84,9 +93,7 @@ func TestModel_FetchInitialUsesQueueFetchFilter(t *testing.T) {
 	if !ok {
 		t.Fatalf("fetchInitial msg = %T, want initialFetchMsg", msg)
 	}
-	if fetched.err != nil {
-		t.Fatal(fetched.err)
-	}
+	require.NoError(t, fetched.err)
 	if !strings.Contains(gotQuery, "limit=2001") {
 		t.Fatalf("limit not sent: %q", gotQuery)
 	}
@@ -100,10 +107,9 @@ func TestModel_FetchInitialUsesQueueFetchFilter(t *testing.T) {
 
 func TestClient_GetIssueDetail_DecodesWrappedEnvelope(t *testing.T) {
 	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		respondJSON(t, w, map[string]any{
 			"issue": map[string]any{
 				"uid": "01JZ0000000000000000000001", "project_uid": "01JZ0000000000000000000002",
 				"number": 42, "title": "fix", "status": "open",
@@ -118,13 +124,9 @@ func TestClient_GetIssueDetail_DecodesWrappedEnvelope(t *testing.T) {
 			},
 			"labels": []any{},
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	detail, err := c.GetIssueDetail(context.Background(), 7, 42)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if gotPath != "/api/v1/projects/7/issues/42" {
 		t.Fatalf("unexpected path: %s", gotPath)
 	}
@@ -139,9 +141,7 @@ func TestClient_GetIssueDetail_DecodesWrappedEnvelope(t *testing.T) {
 		t.Fatalf("project UID = %q", got.ProjectUID)
 	}
 	links, err := c.ListLinks(context.Background(), 7, 42)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(links) != 1 || links[0].FromIssueUID != "01JZ0000000000000000000001" ||
 		links[0].ToIssueUID != "01JZ0000000000000000000003" {
 		t.Fatalf("link UIDs not decoded: %+v", links)
@@ -149,9 +149,8 @@ func TestClient_GetIssueDetail_DecodesWrappedEnvelope(t *testing.T) {
 }
 
 func TestClient_ShowIssue_DecodesHierarchy(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(t, w, map[string]any{
 			"issue": map[string]any{"number": 42, "title": "fix", "status": "open"},
 			"parent": map[string]any{
 				"number": 12, "title": "workspace polish", "status": "open",
@@ -172,13 +171,9 @@ func TestClient_ShowIssue_DecodesHierarchy(t *testing.T) {
 				{"issue_id": 1, "label": "bug", "author": "a"},
 			},
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	got, err := c.GetIssueDetail(context.Background(), 7, 42)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if got.Issue == nil || got.Issue.Number != 42 {
 		t.Fatalf("unexpected issue: %+v", got.Issue)
 	}
@@ -201,37 +196,30 @@ func TestClient_ShowIssue_DecodesHierarchy(t *testing.T) {
 
 func TestClient_CreateIssue_SendsIdempotencyHeader(t *testing.T) {
 	var gotKey string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotKey = r.Header.Get("Idempotency-Key")
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		respondJSON(t, w, map[string]any{
 			"issue":   map[string]any{"number": 1, "title": "t", "status": "open"},
 			"changed": true,
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	_, err := c.CreateIssue(context.Background(), 7, CreateIssueBody{
 		Title: "t", Actor: "alice", IdempotencyKey: "my-key",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if gotKey != "my-key" {
 		t.Fatalf("Idempotency-Key not forwarded: %q", gotKey)
 	}
 }
 
 func TestClient_DecodeError_ReturnsAPIError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(
 			`{"status":404,"error":{"code":"project_not_initialized",` +
 				`"message":"no .kata.toml ancestor","hint":"run kata init"}}`))
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	_, err := c.GetIssueDetail(context.Background(), 7, 42)
 	if err == nil {
 		t.Fatal("expected error")
@@ -256,22 +244,17 @@ func TestClient_DecodeError_ReturnsAPIError(t *testing.T) {
 
 func TestClient_RemoveLabel_PathEscapesLabel(t *testing.T) {
 	var gotRawURI, gotMethod, gotActor string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotRawURI = r.RequestURI
 		gotMethod = r.Method
 		gotActor = r.URL.Query().Get("actor")
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		respondJSON(t, w, map[string]any{
 			"issue":   map[string]any{"number": 1, "title": "t", "status": "open"},
 			"changed": true,
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	_, err := c.RemoveLabel(context.Background(), 7, 42, "team/backend", "alice")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if gotMethod != http.MethodDelete {
 		t.Fatalf("method = %s, want DELETE", gotMethod)
 	}
@@ -285,22 +268,17 @@ func TestClient_RemoveLabel_PathEscapesLabel(t *testing.T) {
 
 func TestClient_ListComments_RoutesThroughShowIssue(t *testing.T) {
 	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		respondJSON(t, w, map[string]any{
 			"issue":    map[string]any{"number": 42, "title": "t", "status": "open"},
 			"comments": []map[string]any{{"id": 1, "author": "a", "body": "hi"}},
 			"links":    []any{},
 			"labels":   []any{},
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	got, err := c.ListComments(context.Background(), 7, 42)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if gotPath != "/api/v1/projects/7/issues/42" {
 		t.Fatalf("unexpected path: %s", gotPath)
 	}
@@ -311,32 +289,26 @@ func TestClient_ListComments_RoutesThroughShowIssue(t *testing.T) {
 
 func TestClient_AssignEmptyOwnerRoutesToUnassign(t *testing.T) {
 	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		respondJSON(t, w, map[string]any{
 			"issue":   map[string]any{"number": 1, "title": "t", "status": "open"},
 			"changed": true,
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	_, err := c.Assign(context.Background(), 7, 42, "", "alice")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.HasSuffix(gotPath, "/actions/unassign") {
 		t.Fatalf("expected unassign path, got %s", gotPath)
 	}
 }
 
 func TestClient_ListEvents_FiltersByIssueClientSide(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/projects/7/events" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		respondJSON(t, w, map[string]any{
 			"events": []map[string]any{
 				{
 					"event_id": 1, "type": "issue.commented", "issue_number": 42, "actor": "a",
@@ -355,13 +327,9 @@ func TestClient_ListEvents_FiltersByIssueClientSide(t *testing.T) {
 			"next_after_id":  3,
 			"reset_required": false,
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	got, err := c.ListEvents(context.Background(), 7, 42)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(got) != 2 {
 		t.Fatalf("got %d events for #42, want 2", len(got))
 	}
@@ -383,16 +351,12 @@ func TestClient_ListEvents_FiltersByIssueClientSide(t *testing.T) {
 // returned resp.Issues evaluated *before* c.do filled it (the do call was
 // the second operand of the comma-statement, so resp was nil at capture).
 func TestClient_ListIssues_NotNilOnSuccess(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"issues":[{"number":1,"title":"a","status":"open"}]}`))
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	got, err := c.ListIssues(context.Background(), 7, ListFilter{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(got) != 1 || got[0].Number != 1 {
 		t.Fatalf("got %+v, want one issue with number=1", got)
 	}
@@ -401,16 +365,12 @@ func TestClient_ListIssues_NotNilOnSuccess(t *testing.T) {
 // TestClient_ListAllIssues_NotNilOnSuccess covers the same regression on
 // the cross-project endpoint.
 func TestClient_ListAllIssues_NotNilOnSuccess(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"issues":[{"number":2,"title":"b","status":"open"}]}`))
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	got, err := c.ListAllIssues(context.Background(), ListFilter{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(got) != 1 || got[0].Number != 2 {
 		t.Fatalf("got %+v, want one issue with number=2", got)
 	}
@@ -418,16 +378,12 @@ func TestClient_ListAllIssues_NotNilOnSuccess(t *testing.T) {
 
 // TestClient_ListProjects_NotNilOnSuccess is the analogue for ListProjects.
 func TestClient_ListProjects_NotNilOnSuccess(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"projects":[{"id":7,"identity":"x","name":"k"}]}`))
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	got, err := c.ListProjects(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(got) != 1 || got[0].ID != 7 {
 		t.Fatalf("got %+v, want one project with id=7", got)
 	}
@@ -438,22 +394,19 @@ func TestClient_ListProjects_NotNilOnSuccess(t *testing.T) {
 // the struct for client-side filtering but must not leak as URL params.
 func TestClient_ListIssues_FilterShape(t *testing.T) {
 	var gotURL string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotURL = r.URL.String()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"issues":[]}`))
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
-	if _, err := c.ListIssues(context.Background(), 7, ListFilter{
+	})
+	_, err := c.ListIssues(context.Background(), 7, ListFilter{
 		Status: "open",
 		Owner:  "alice",
 		Author: "bob",
 		Search: "foo",
 		Labels: []string{"x"},
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 	if !strings.Contains(gotURL, "status=open") {
 		t.Fatalf("status not sent: %s", gotURL)
 	}
@@ -471,9 +424,8 @@ func TestClient_ListIssues_FilterShape(t *testing.T) {
 // is automatic — this test pins that promise so a future struct-tag
 // removal doesn't silently drop labels from the list view.
 func TestListIssues_TUIDecodePopulatesLabels(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(t, w, map[string]any{
 			"issues": []map[string]any{
 				{
 					"number": 1, "title": "first", "status": "open",
@@ -489,13 +441,9 @@ func TestListIssues_TUIDecodePopulatesLabels(t *testing.T) {
 				},
 			},
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	got, err := c.ListIssues(context.Background(), 7, ListFilter{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(got) != 3 {
 		t.Fatalf("got %d issues, want 3", len(got))
 	}
@@ -526,9 +474,8 @@ func TestListIssues_TUIDecodePopulatesLabels(t *testing.T) {
 // Issue struct) means a show response with no labels leaves a
 // previously-populated Labels slice empty — covered by other tests.
 func TestShowIssue_PopulatesLabelsFromTopLevel(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(t, w, map[string]any{
 			"issue":    map[string]any{"number": 42, "title": "fix", "status": "open"},
 			"comments": []any{},
 			"links":    []any{},
@@ -538,13 +485,9 @@ func TestShowIssue_PopulatesLabelsFromTopLevel(t *testing.T) {
 				{"issue_id": 1, "label": "needs-design", "author": "a"},
 			},
 		})
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	resp, err := c.showIssue(context.Background(), 7, 42)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	got := resp.Issue.Labels
 	want := []string{"bug", "needs-design", "prio-1"}
 	if len(got) != len(want) {
@@ -561,11 +504,9 @@ func TestShowIssue_PopulatesLabelsFromTopLevel(t *testing.T) {
 // Code and Message are both blank. Without the fallback, Error() would
 // return ": ".
 func TestAPIError_EmptyBodyFallback(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 	_, err := c.GetIssueDetail(context.Background(), 7, 42)
 	if err == nil {
 		t.Fatal("expected error")
@@ -587,7 +528,7 @@ func TestAPIError_EmptyBodyFallback(t *testing.T) {
 // decodes the ?include=stats wire shape into ProjectSummaryWithStats,
 // including the optional Stats field. Spec §7.3.
 func TestClient_ListProjectsWithStats_Decodes(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/v1/projects", r.URL.Path)
 		require.Equal(t, "stats", r.URL.Query().Get("include"))
 		w.Header().Set("Content-Type", "application/json")
@@ -599,9 +540,7 @@ func TestClient_ListProjectsWithStats_Decodes(t *testing.T) {
                  "stats": {"open": 0, "closed": 0, "last_event_at": null}}
             ]
         }`))
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 
 	got, err := c.ListProjectsWithStats(t.Context())
 	require.NoError(t, err)
@@ -622,12 +561,10 @@ func TestClient_ListProjectsWithStats_Decodes(t *testing.T) {
 // array returns []ProjectSummaryWithStats{}, never nil — callers iterate
 // without nil-checks. Spec §7.3.
 func TestClient_ListProjectsWithStats_NotNilOnSuccess(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	c := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"projects": []}`))
-	}))
-	defer srv.Close()
-	c := NewClient(srv.URL, srv.Client())
+	})
 
 	got, err := c.ListProjectsWithStats(t.Context())
 	require.NoError(t, err)

--- a/internal/tui/detail_document_test.go
+++ b/internal/tui/detail_document_test.go
@@ -42,11 +42,7 @@ func TestDetailDocumentPage80x50LayoutSignals(t *testing.T) {
 	} {
 		assertStringContains(t, got, want)
 	}
-	for _, deny := range []string{"Owner:", "Parent:"} {
-		if strings.Contains(got, deny) {
-			t.Fatalf("detail document should use lowercase metadata labels, found %q:\n%s", deny, got)
-		}
-	}
+	assertStringsLack(t, got, "Owner:", "Parent:")
 }
 
 func TestDetailCompactSheet_UsesDenseRhythmAndNoDecorativeRules(t *testing.T) {
@@ -67,34 +63,14 @@ func TestDetailCompactSheet_UsesDenseRhythmAndNoDecorativeRules(t *testing.T) {
 	if strings.Contains(got, "issue #42") {
 		t.Fatalf("compact sheet should not render issue number as a separate lead-in:\n%s", got)
 	}
-	for _, deny := range []string{"Body ─", "Activity ─"} {
-		if strings.Contains(got, deny) {
-			t.Fatalf("compact sheet should not use decorative rule %q:\n%s", deny, got)
-		}
-	}
+	assertStringsLack(t, got, "Body ─", "Activity ─")
 	// The redesign separates metadata and Body with one blank breather
 	// row so the page reads as a quiet document. Body should land
 	// within two rows of the last metadata line — close enough to feel
-	// connected, not far enough to leak dead air.
-	metadataEnd := indexOf(lines, "labels:")
-	body := indexOf(lines, "Body")
-	if metadataEnd < 0 || body < 0 {
-		t.Fatalf("missing metadata/body:\n%s", got)
-	}
-	if body-metadataEnd > 2 {
-		t.Fatalf("Body should follow metadata within one blank row; metadata=%d body=%d:\n%s",
-			metadataEnd, body, got)
-	}
-	bodyText := indexOf(lines, "Click the login button twice.")
-	activity := indexOf(lines, "Activity")
-	if bodyText < 0 || activity < 0 {
-		t.Fatalf("missing body text/activity:\n%s", got)
-	}
-	// Same one-blank-row rhythm between body content and Activity.
-	if activity > bodyText+3 {
-		t.Fatalf("Activity should follow short body within one blank row; body=%d activity=%d:\n%s",
-			bodyText, activity, got)
-	}
+	// connected, not far enough to leak dead air. Same rhythm between
+	// body content and Activity.
+	assertMaxGap(t, got, "labels:", "Body", 2)
+	assertMaxGap(t, got, "Click the login button twice.", "Activity", 3)
 }
 
 // TestDetailCompactSheet_AdaptiveSurfaces locks down the redesigned
@@ -174,15 +150,7 @@ func TestDetailDocument_DoesNotPadBodyBeforeChildren(t *testing.T) {
 	dm := snapDetailHierarchyFixture()
 
 	got := stripANSI(dm.View(80, 50, viewChrome{}))
-	lines := strings.Split(got, "\n")
-	bodyEnd := indexOf(lines, "Click the login button twice.")
-	children := indexOf(lines, "Children")
-	if bodyEnd < 0 || children < 0 {
-		t.Fatalf("missing body or children section:\n%s", got)
-	}
-	if gap := children - bodyEnd; gap > 4 {
-		t.Fatalf("body section absorbed vertical slack; gap=%d:\n%s", gap, got)
-	}
+	assertMaxGap(t, got, "Click the login button twice.", "Children", 4)
 }
 
 // TestDetailDocument_NarrowStacksMetadata verifies that on a narrow
@@ -256,11 +224,7 @@ func TestDetailDocument_MarkdownRenderingDropsSourceFences(t *testing.T) {
 	for _, want := range []string{"Steps", "`Login`", `fmt.Println("ok")`} {
 		assertStringContains(t, got, want)
 	}
-	for _, deny := range []string{"## Steps", "```"} {
-		if strings.Contains(got, deny) {
-			t.Fatalf("markdown source marker %q leaked into detail render:\n%s", deny, got)
-		}
-	}
+	assertStringsLack(t, got, "## Steps", "```")
 }
 
 func TestDetailDocument_CommentAuthorsAlignTimestamps(t *testing.T) {

--- a/internal/tui/detail_mutation_test.go
+++ b/internal/tui/detail_mutation_test.go
@@ -16,6 +16,48 @@ func dmFixture() detailModel {
 	return detailModel{issue: &iss, scopePID: 7, actor: "tester"}
 }
 
+// setupMutationTest builds the (api, dm, km) triplet used by every
+// detail-mutation test: a fakeDetailAPI seeded with a generic
+// successful MutationResp, dmFixture(), and a fresh keymap.
+func setupMutationTest(t *testing.T) (*fakeDetailAPI, detailModel, keymap) {
+	t.Helper()
+	api := &fakeDetailAPI{
+		mutationResult: &MutationResp{Issue: &Issue{Number: 42}},
+	}
+	return api, dmFixture(), newKeymap()
+}
+
+// requireInputPrompt evaluates cmd, asserts it returns an
+// openInputMsg of the given kind, and fails the test otherwise.
+func requireInputPrompt(t *testing.T, cmd tea.Cmd, want inputKind) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected openInputCmd, got nil")
+	}
+	msg, ok := cmd().(openInputMsg)
+	if !ok {
+		t.Fatalf("expected openInputMsg, got %T", cmd())
+	}
+	if msg.kind != want {
+		t.Fatalf("openInputMsg.kind = %v, want %v", msg.kind, want)
+	}
+}
+
+// executePromptCommit invokes dispatchPanelPromptCommit, asserts a
+// non-nil cmd, runs it through runDetailCmd, and returns the
+// post-commit model so callers can inspect status/state.
+func executePromptCommit(
+	t *testing.T, dm detailModel, api *fakeDetailAPI, km keymap,
+	kind inputKind, val string,
+) detailModel {
+	t.Helper()
+	_, cmd := dm.dispatchPanelPromptCommit(api, kind, val)
+	if cmd == nil {
+		t.Fatal("expected dispatch cmd")
+	}
+	return runDetailCmd(t, dm, cmd, km, api)
+}
+
 // runDetailCmd executes the tea.Cmd returned by Update once and feeds
 // the resulting message back into Update so the test sees the post-
 // fetch (or post-mutation-result) state. Returns the second-pass model.
@@ -54,11 +96,7 @@ func typeRunes(
 // TestDetail_Close_DispatchesAPI: pressing 'x' calls api.Close exactly
 // once with the fixture's projectID, number, and actor.
 func TestDetail_Close_DispatchesAPI(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42, Status: "closed"}},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
 	out, cmd := dm.Update(runeKey('x'), km, api)
 	if cmd == nil {
@@ -76,11 +114,7 @@ func TestDetail_Close_DispatchesAPI(t *testing.T) {
 
 // TestDetail_Reopen_DispatchesAPI: pressing 'r' calls api.Reopen.
 func TestDetail_Reopen_DispatchesAPI(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42, Status: "open"}},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
 	out, cmd := dm.Update(runeKey('r'), km, api)
 	if cmd == nil {
@@ -101,21 +135,10 @@ func TestDetail_Reopen_DispatchesAPI(t *testing.T) {
 // Model.routeTopLevel intercepts to construct the inputState; dm
 // itself is unchanged after the keypress.
 func TestDetail_AddLabel_OpensPrompt(t *testing.T) {
-	api := &fakeDetailAPI{}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
 	_, cmd := dm.Update(runeKey('+'), km, api)
-	if cmd == nil {
-		t.Fatal("expected openInputCmd from +")
-	}
-	msg, ok := cmd().(openInputMsg)
-	if !ok {
-		t.Fatalf("expected openInputMsg, got %T", cmd())
-	}
-	if msg.kind != inputLabelPrompt {
-		t.Fatalf("openInputMsg.kind = %v, want inputLabelPrompt", msg.kind)
-	}
+	requireInputPrompt(t, cmd, inputLabelPrompt)
 	if api.addLabelCalls != 0 {
 		t.Fatalf("addLabelCalls = %d, want 0 (no commit yet)", api.addLabelCalls)
 	}
@@ -127,17 +150,9 @@ func TestDetail_AddLabel_OpensPrompt(t *testing.T) {
 // (Model.commitInput → dm.dispatchPanelPromptCommit), and
 // fakeDetailAPI doesn't fit through Model.api (*Client).
 func TestDetail_AddLabel_CommitCallsAPI(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42}},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
-	_, cmd := dm.dispatchPanelPromptCommit(api, inputLabelPrompt, "bug")
-	if cmd == nil {
-		t.Fatal("expected dispatch cmd")
-	}
-	_ = runDetailCmd(t, dm, cmd, km, api)
+	_ = executePromptCommit(t, dm, api, km, inputLabelPrompt, "bug")
 	if api.addLabelCalls != 1 {
 		t.Fatalf("addLabelCalls = %d, want 1", api.addLabelCalls)
 	}
@@ -152,22 +167,11 @@ func TestDetail_AddLabel_CommitCallsAPI(t *testing.T) {
 // TestDetail_RemoveLabel_OpensPromptAndDispatches: '-' opens a
 // remove-label prompt; commit dispatches to api.RemoveLabel.
 func TestDetail_RemoveLabel_OpensPromptAndDispatches(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42}},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
 	_, cmd := dm.Update(runeKey('-'), km, api)
-	msg, ok := cmd().(openInputMsg)
-	if !ok || msg.kind != inputRemoveLabelPrompt {
-		t.Fatalf("expected openInputMsg{inputRemoveLabelPrompt}, got %v", cmd())
-	}
-	_, dispatchCmd := dm.dispatchPanelPromptCommit(api, inputRemoveLabelPrompt, "bug")
-	if dispatchCmd == nil {
-		t.Fatal("expected dispatch cmd")
-	}
-	_ = runDetailCmd(t, dm, dispatchCmd, km, api)
+	requireInputPrompt(t, cmd, inputRemoveLabelPrompt)
+	_ = executePromptCommit(t, dm, api, km, inputRemoveLabelPrompt, "bug")
 	if api.removeLabelCalls != 1 {
 		t.Fatalf("removeLabelCalls = %d, want 1", api.removeLabelCalls)
 	}
@@ -179,22 +183,11 @@ func TestDetail_RemoveLabel_OpensPromptAndDispatches(t *testing.T) {
 // TestDetail_AssignOwner_OpensPromptAndDispatches: 'a' opens an
 // owner-assign prompt; commit dispatches to api.Assign.
 func TestDetail_AssignOwner_OpensPromptAndDispatches(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42}},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
 	_, cmd := dm.Update(runeKey('a'), km, api)
-	msg, ok := cmd().(openInputMsg)
-	if !ok || msg.kind != inputOwnerPrompt {
-		t.Fatalf("expected openInputMsg{inputOwnerPrompt}, got %v", cmd())
-	}
-	_, dispatchCmd := dm.dispatchPanelPromptCommit(api, inputOwnerPrompt, "alice")
-	if dispatchCmd == nil {
-		t.Fatal("expected dispatch cmd")
-	}
-	_ = runDetailCmd(t, dm, dispatchCmd, km, api)
+	requireInputPrompt(t, cmd, inputOwnerPrompt)
+	_ = executePromptCommit(t, dm, api, km, inputOwnerPrompt, "alice")
 	if api.assignCalls != 1 {
 		t.Fatalf("assignCalls = %d, want 1", api.assignCalls)
 	}
@@ -206,11 +199,7 @@ func TestDetail_AssignOwner_OpensPromptAndDispatches(t *testing.T) {
 // TestDetail_ClearOwner_DispatchesAPI: 'A' immediately calls
 // api.Assign("", "tester") with no modal.
 func TestDetail_ClearOwner_DispatchesAPI(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42}},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
 	out, cmd := dm.Update(runeKey('A'), km, api)
 	if cmd == nil {
@@ -228,21 +217,11 @@ func TestDetail_ClearOwner_DispatchesAPI(t *testing.T) {
 // TestDetail_AddLink_Parent: 'p' opens an inputParentPrompt; commit
 // of "42" calls api.AddLink({Type:parent, ToNumber:42}).
 func TestDetail_AddLink_Parent(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42}},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
 	_, cmd := dm.Update(runeKey('p'), km, api)
-	if msg, ok := cmd().(openInputMsg); !ok || msg.kind != inputParentPrompt {
-		t.Fatalf("expected openInputMsg{inputParentPrompt}, got %v", cmd())
-	}
-	_, dispatchCmd := dm.dispatchPanelPromptCommit(api, inputParentPrompt, "42")
-	if dispatchCmd == nil {
-		t.Fatal("expected dispatch cmd")
-	}
-	_ = runDetailCmd(t, dm, dispatchCmd, km, api)
+	requireInputPrompt(t, cmd, inputParentPrompt)
+	_ = executePromptCommit(t, dm, api, km, inputParentPrompt, "42")
 	if api.addLinkCalls != 1 {
 		t.Fatalf("addLinkCalls = %d, want 1", api.addLinkCalls)
 	}
@@ -254,18 +233,11 @@ func TestDetail_AddLink_Parent(t *testing.T) {
 // TestDetail_AddLink_Blocks: 'b' opens an inputBlockerPrompt;
 // commit of "5" calls api.AddLink({Type:blocks, ToNumber:5}).
 func TestDetail_AddLink_Blocks(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42}},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
 	_, cmd := dm.Update(runeKey('b'), km, api)
-	if msg, ok := cmd().(openInputMsg); !ok || msg.kind != inputBlockerPrompt {
-		t.Fatalf("expected openInputMsg{inputBlockerPrompt}, got %v", cmd())
-	}
-	_, dispatchCmd := dm.dispatchPanelPromptCommit(api, inputBlockerPrompt, "5")
-	_ = runDetailCmd(t, dm, dispatchCmd, km, api)
+	requireInputPrompt(t, cmd, inputBlockerPrompt)
+	_ = executePromptCommit(t, dm, api, km, inputBlockerPrompt, "5")
 	if api.addLinkCalls != 1 {
 		t.Fatalf("addLinkCalls = %d, want 1", api.addLinkCalls)
 	}
@@ -282,18 +254,11 @@ func TestDetail_AddLink_Blocks(t *testing.T) {
 // L was rebound to ToggleLayout when the layout-toggle hotkey was
 // added — AddLink moved to lowercase l for ergonomics.)
 func TestDetail_AddLink_Other(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42}},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
 
 	_, cmd := dm.Update(runeKey('l'), km, api)
-	if msg, ok := cmd().(openInputMsg); !ok || msg.kind != inputLinkPrompt {
-		t.Fatalf("expected openInputMsg{inputLinkPrompt}, got %v", cmd())
-	}
-	_, dispatchCmd := dm.dispatchPanelPromptCommit(api, inputLinkPrompt, "related 7")
-	_ = runDetailCmd(t, dm, dispatchCmd, km, api)
+	requireInputPrompt(t, cmd, inputLinkPrompt)
+	_ = executePromptCommit(t, dm, api, km, inputLinkPrompt, "related 7")
 	if api.addLinkCalls != 1 {
 		t.Fatalf("addLinkCalls = %d, want 1", api.addLinkCalls)
 	}
@@ -310,11 +275,7 @@ func TestDetail_AddLink_OtherParseFailure(t *testing.T) {
 	km := newKeymap()
 	dm := dmFixture()
 
-	_, dispatchCmd := dm.dispatchPanelPromptCommit(api, inputLinkPrompt, "noop")
-	if dispatchCmd == nil {
-		t.Fatal("expected synthetic-error cmd")
-	}
-	out := runDetailCmd(t, dm, dispatchCmd, km, api)
+	out := executePromptCommit(t, dm, api, km, inputLinkPrompt, "noop")
 	if api.addLinkCalls != 0 {
 		t.Fatalf("addLinkCalls = %d, want 0 (parse failure path)", api.addLinkCalls)
 	}
@@ -366,12 +327,8 @@ func TestDetail_MutationError_PlainError(t *testing.T) {
 // (issue, comments, events, links). We assert at least the GetIssue
 // call landed by inspecting api.lastGetIssue after running the batch.
 func TestDetail_MutationSuccess_DispatchesRefetch(t *testing.T) {
-	api := &fakeDetailAPI{
-		mutationResult: &MutationResp{Issue: &Issue{Number: 42}},
-		getIssueResult: &Issue{Number: 42, Status: "closed"},
-	}
-	km := newKeymap()
-	dm := dmFixture()
+	api, dm, km := setupMutationTest(t)
+	api.getIssueResult = &Issue{Number: 42, Status: "closed"}
 
 	out, cmd := dm.Update(runeKey('x'), km, api)
 	if cmd == nil {

--- a/internal/tui/detail_redesign_test.go
+++ b/internal/tui/detail_redesign_test.go
@@ -116,19 +116,11 @@ func TestDetailRedesign_NoReplacementGlyphs(t *testing.T) {
 // no signal. Owner and parent stay (those absences are informative).
 func TestDetailRedesign_OmitsEmptyLabelsAndChildren(t *testing.T) {
 	defer snapshotInit(t)()
-	iss := Issue{
-		ProjectID: 7, Number: 1, Title: "blank",
-		Status: "open", Author: "anonymous",
-	}
-	dm := detailModel{issue: &iss}
+	dm := simpleDetailModel()
 	got := stripANSI(dm.View(160, 24, viewChrome{
 		scope: scope{projectID: 7, projectName: "kata"},
 	}))
-	for _, deny := range []string{"labels: none", "children: none"} {
-		if strings.Contains(got, deny) {
-			t.Fatalf("expected %q to be omitted:\n%s", deny, got)
-		}
-	}
+	assertStringsLack(t, got, "labels: none", "children: none")
 }
 
 // TestDetailRedesign_DefaultsToFirstNonEmptyActivityTab covers the
@@ -138,17 +130,11 @@ func TestDetailRedesign_OmitsEmptyLabelsAndChildren(t *testing.T) {
 // has data" failure.
 func TestDetailRedesign_DefaultsToFirstNonEmptyActivityTab(t *testing.T) {
 	defer snapshotInit(t)()
-	iss := Issue{ProjectID: 7, Number: 1, Title: "issue", Status: "open"}
-	dm := detailModel{issue: &iss}
+	dm := simpleDetailModel()
 	when := time.Date(2026, 5, 2, 19, 16, 0, 0, time.UTC)
-	dm = dm.applyFetched(commentsFetchedMsg{gen: dm.gen, comments: nil})
-	dm = dm.applyFetched(eventsFetchedMsg{
-		gen: dm.gen,
-		events: []EventLogEntry{
-			{ID: 1, Type: "issue.created", Actor: "anonymous", CreatedAt: when},
-		},
-	})
-	dm = dm.applyFetched(linksFetchedMsg{gen: dm.gen, links: nil})
+	dm = seedActivity(dm, nil, []EventLogEntry{
+		{ID: 1, Type: "issue.created", Actor: "anonymous", CreatedAt: when},
+	}, nil)
 	if dm.activeTab != tabEvents {
 		t.Fatalf("expected activeTab=%v after fetch with empty comments + 1 event, got %v",
 			tabEvents, dm.activeTab)
@@ -165,11 +151,7 @@ func TestDetailRedesign_DefaultsToFirstNonEmptyActivityTab(t *testing.T) {
 // switch that would jump tabs on initial load before fetches complete.
 func TestDetailRedesign_DefaultStaysWhenAllActivityEmpty(t *testing.T) {
 	defer snapshotInit(t)()
-	iss := Issue{ProjectID: 7, Number: 1, Title: "issue", Status: "open"}
-	dm := detailModel{issue: &iss}
-	dm = dm.applyFetched(commentsFetchedMsg{gen: dm.gen, comments: nil})
-	dm = dm.applyFetched(eventsFetchedMsg{gen: dm.gen, events: nil})
-	dm = dm.applyFetched(linksFetchedMsg{gen: dm.gen, links: nil})
+	dm := seedActivity(simpleDetailModel(), nil, nil, nil)
 	if dm.activeTab != tabComments {
 		t.Fatalf("expected activeTab to stay tabComments when all empty, got %v",
 			dm.activeTab)
@@ -182,8 +164,7 @@ func TestDetailRedesign_DefaultStaysWhenAllActivityEmpty(t *testing.T) {
 // user's chosen tab.
 func TestDetailRedesign_ExplicitTabPickStaysSticky(t *testing.T) {
 	defer snapshotInit(t)()
-	iss := Issue{ProjectID: 7, Number: 1, Title: "issue", Status: "open"}
-	dm := detailModel{issue: &iss}
+	dm := simpleDetailModel()
 	// User explicitly cycles to tabLinks before any fetch arrives.
 	dm.activeTab = tabLinks
 	dm.tabExplicit = true
@@ -248,6 +229,24 @@ func TestDetailRedesign_SectionHeadersHaveNoBackgroundSlab(t *testing.T) {
 	if styleHasBackground(detailMetaStyle) {
 		t.Fatal("detailMetaStyle should not paint a background band")
 	}
+}
+
+// simpleDetailModel returns a minimal detailModel for tab/state tests
+// where issue contents are incidental — only the embedded *Issue
+// pointer is required to drive view and tab logic.
+func simpleDetailModel() detailModel {
+	iss := Issue{ProjectID: 7, Number: 1, Title: "issue", Status: "open"}
+	return detailModel{issue: &iss}
+}
+
+// seedActivity applies the three activity-fetch messages in order so
+// tests can drive the post-fetch state in one line. Pass nil for any
+// tab that should remain empty.
+func seedActivity(dm detailModel, comments []CommentEntry, events []EventLogEntry, links []LinkEntry) detailModel {
+	dm = dm.applyFetched(commentsFetchedMsg{gen: dm.gen, comments: comments})
+	dm = dm.applyFetched(eventsFetchedMsg{gen: dm.gen, events: events})
+	dm = dm.applyFetched(linksFetchedMsg{gen: dm.gen, links: links})
+	return dm
 }
 
 func firstNonEmptyLine(s string) string {

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -12,6 +12,33 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
+// newDetailHostModel builds a Model wired with a stub API client and a
+// single-project scope so detail-level handler tests can drive
+// Model.Update without re-typing the boilerplate.
+func newDetailHostModel(opts Options, projectID int64) Model {
+	m := initialModel(opts)
+	m.api = &Client{}
+	m.scope = scope{projectID: projectID}
+	return m
+}
+
+// assertJumpDetailCmd evaluates cmd, asserts it returns a jumpDetailMsg
+// targeting want, and fails otherwise.
+func assertJumpDetailCmd(t *testing.T, cmd tea.Cmd, want int64) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected jump cmd, got nil")
+	}
+	msg := cmd()
+	jm, ok := msg.(jumpDetailMsg)
+	if !ok {
+		t.Fatalf("expected jumpDetailMsg, got %T", msg)
+	}
+	if jm.number != want {
+		t.Fatalf("jumpDetailMsg.number = %d, want %d", jm.number, want)
+	}
+}
+
 // detailFixture seeds a detailModel with one issue, two comments, two
 // events, and one link so every per-tab renderer has data to render.
 // The body has many lines so j scrolling has somewhere to go.
@@ -148,18 +175,14 @@ func TestDetail_RenderHierarchySections(t *testing.T) {
 		{Number: 44, Title: "new issue form parent field", Status: "closed"},
 	}
 	out := stripANSI(dm.View(100, 28, viewChrome{}))
-	for _, want := range []string{
+	assertContainsAll(t, out,
 		"parent: #12 workspace polish parent",
 		"children: 1 open / 2 total",
 		"Children",
 		"#43",
 		"detail hint bars incomplete",
 		"#44",
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("detail hierarchy render missing %q:\n%s", want, out)
-		}
-	}
+	)
 }
 
 // TestDetail_TabCycle_NextPrev: tab cycles forward, shift+tab cycles
@@ -383,9 +406,7 @@ func TestDetail_Back_EmitsPopMsg(t *testing.T) {
 // a tea.Cmd. (We can't introspect a tea.Batch directly without running
 // it, but we can verify the model state mutated correctly.)
 func TestDetail_OpenFromList_DispatchesBatch(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{} // non-nil so handleOpenDetail dispatches the batch
-	m.scope = scope{projectID: 7}
+	m := newDetailHostModel(Options{}, 7)
 	m.list.loading = false
 	m.list.issues = []Issue{
 		{ProjectID: 7, Number: 1, Title: "first"},
@@ -592,9 +613,7 @@ func TestDetailApplyFetched_PopulatesParentAndChildren(t *testing.T) {
 // model-level handler seeds all three per-tab loading flags so the
 // initial render shows "(loading…)" until the tab fetches return.
 func TestDetail_OpenDetail_SeedsLoadingFlags(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
+	m := newDetailHostModel(Options{}, 7)
 	iss := Issue{ProjectID: 7, Number: 1, Title: "x"}
 	out, _ := m.Update(openDetailMsg{issue: iss})
 	m = out.(Model)
@@ -975,18 +994,13 @@ func TestDetail_RenderEventsTab_FormatsCommonEventTypes(t *testing.T) {
 			Payload: map[string]any{"owner": "wesm"}},
 	}
 	out := renderEventsTab(es, 200, 20, -1, tabState{})
-	checks := []string{
+	assertContainsAll(t, out,
 		"[issue.created] 2025-01-02 15:04 a — created",
 		"[issue.closed] 2025-01-02 15:04 a — closed (wontfix)",
 		"[issue.labeled] 2025-01-02 15:04 b — labeled bug",
 		"[issue.linked] 2025-01-02 15:04 c — linked blocks #11",
 		"[issue.assigned] 2025-01-02 15:04 d — assigned wesm",
-	}
-	for _, want := range checks {
-		if !strings.Contains(out, want) {
-			t.Fatalf("missing %q:\n%s", want, out)
-		}
-	}
+	)
 }
 
 // TestDetail_RenderEventsTab_UnknownTypeFallback: an unrecognized event
@@ -1129,16 +1143,7 @@ func TestDetailChildren_EnterJumpsToChild(t *testing.T) {
 	km := newKeymap()
 
 	_, cmd := dm.Update(tea.KeyMsg{Type: tea.KeyEnter}, km, &fakeDetailAPI{})
-	if cmd == nil {
-		t.Fatal("enter on focused child should emit jump command")
-	}
-	jm, ok := cmd().(jumpDetailMsg)
-	if !ok {
-		t.Fatalf("expected jumpDetailMsg, got %T", cmd())
-	}
-	if jm.number != 44 {
-		t.Fatalf("jumpDetailMsg.number = %d, want 44", jm.number)
-	}
+	assertJumpDetailCmd(t, cmd, 44)
 }
 
 // runBatch unwraps a tea.Batch wrapper and runs every nested cmd in
@@ -1181,16 +1186,7 @@ func TestDetail_EnterOnEventWithIssueRef_JumpsAndStacks(t *testing.T) {
 	dm.tabCursor = 0
 	km := newKeymap()
 	_, cmd := dm.Update(tea.KeyMsg{Type: tea.KeyEnter}, km, api)
-	if cmd == nil {
-		t.Fatal("expected jump cmd from Enter")
-	}
-	jm, ok := cmd().(jumpDetailMsg)
-	if !ok {
-		t.Fatalf("expected jumpDetailMsg, got %T", cmd())
-	}
-	if jm.number != 11 {
-		t.Fatalf("jumpDetailMsg.number = %d, want 11", jm.number)
-	}
+	assertJumpDetailCmd(t, cmd, 11)
 }
 
 // TestDetail_EnterOnLinkEntry_JumpsToTarget: pressing Enter on a link
@@ -1204,16 +1200,7 @@ func TestDetail_EnterOnLinkEntry_JumpsToTarget(t *testing.T) {
 	dm.tabCursor = 0
 	km := newKeymap()
 	_, cmd := dm.Update(tea.KeyMsg{Type: tea.KeyEnter}, km, api)
-	if cmd == nil {
-		t.Fatal("expected jump cmd from Enter on link")
-	}
-	jm, ok := cmd().(jumpDetailMsg)
-	if !ok {
-		t.Fatalf("expected jumpDetailMsg, got %T", cmd())
-	}
-	if jm.number != 7 {
-		t.Fatalf("jumpDetailMsg.number = %d, want 7", jm.number)
-	}
+	assertJumpDetailCmd(t, cmd, 7)
 }
 
 // TestDetail_EnterOnIncomingLink_JumpsToFromNumber: when the cursor is
@@ -1236,17 +1223,7 @@ func TestDetail_EnterOnIncomingLink_JumpsToFromNumber(t *testing.T) {
 	}
 	km := newKeymap()
 	_, cmd := dm.Update(tea.KeyMsg{Type: tea.KeyEnter}, km, api)
-	if cmd == nil {
-		t.Fatal("expected jump cmd from Enter on incoming link")
-	}
-	jm, ok := cmd().(jumpDetailMsg)
-	if !ok {
-		t.Fatalf("expected jumpDetailMsg, got %T", cmd())
-	}
-	if jm.number != 99 {
-		t.Fatalf("jumpDetailMsg.number = %d, want 99 (incoming → FromNumber)",
-			jm.number)
-	}
+	assertJumpDetailCmd(t, cmd, 99)
 }
 
 // TestLinkJumpTarget_OutgoingPicksToNumber: when ToNumber differs from
@@ -1477,9 +1454,7 @@ func TestDetail_ApplyActivityCursor_UsesTextMarker(t *testing.T) {
 // fetch for A lands after the user has popped and reopened B. The B
 // view must not pick up A's comments/events/links/issue.
 func TestDetail_StaleFetch_DroppedAcrossOpen(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
+	m := newDetailHostModel(Options{}, 7)
 	m.list.loading = false
 	m.list.issues = []Issue{
 		{ProjectID: 7, Number: 1, Title: "A"},
@@ -1524,9 +1499,7 @@ func TestDetail_StaleFetch_DroppedAcrossOpen(t *testing.T) {
 // the jump must not seed the post-jump view. The flow is exercised at
 // the Model level so the monotonic m.nextGen counter is the authority.
 func TestDetail_StaleFetch_DroppedAcrossJump(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
+	m := newDetailHostModel(Options{}, 7)
 	m.view = viewDetail
 	m.detail = detailFixture()
 	m.detail.activeTab = tabLinks
@@ -1572,9 +1545,7 @@ func TestDetail_StaleFetch_DroppedAcrossJump(t *testing.T) {
 // asserts C's data survives — the gen on C must be strictly greater
 // than B's gen.
 func TestModel_GenMonotonicAcrossJumpBackOpen(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
+	m := newDetailHostModel(Options{}, 7)
 	// List has issues A (#1) and C (#3); B (#2) is the jump target.
 	m.list.loading = false
 	m.list.issues = []Issue{
@@ -1724,9 +1695,7 @@ func TestList_DetailMutation_Ignored(t *testing.T) {
 // the resolved identity instead of the empty string.
 func TestDetail_Open_SeedsActorFromList(t *testing.T) {
 	t.Setenv("KATA_AUTHOR", "wes")
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
+	m := newDetailHostModel(Options{}, 7)
 	iss := Issue{ProjectID: 7, Number: 1, Title: "x"}
 	out, _ := m.Update(openDetailMsg{issue: iss})
 	m = out.(Model)
@@ -1797,9 +1766,7 @@ func TestDetail_Jump_PreservesActor(t *testing.T) {
 // twice advances the generation each time so any in-flight fetch from
 // the first open is dropped on the second.
 func TestDetail_Open_AdvancesGenAcrossReopens(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
+	m := newDetailHostModel(Options{}, 7)
 	iss := Issue{ProjectID: 7, Number: 1, Title: "x"}
 	out, _ := m.Update(openDetailMsg{issue: iss})
 	m = out.(Model)

--- a/internal/tui/edge_test.go
+++ b/internal/tui/edge_test.go
@@ -29,15 +29,13 @@ func TestEdge_WindowResize_NoPanic(t *testing.T) {
 	m.list.issues = snapListFixture()
 	m.list.issues[0].Title = "fix login bug on Safari with an unusually long regression title"
 
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 30})
 	wide := m.View()
 	if !strings.Contains(wide, "fix login bug on Safari with an unusually long regression title") {
 		t.Fatalf("wide render missing full title:\n%s", wide)
 	}
 
-	out, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 80, Height: 30})
 	if m.width != 80 || m.height != 30 {
 		t.Fatalf("resize not applied: width=%d height=%d", m.width, m.height)
 	}
@@ -69,10 +67,7 @@ func TestEdge_WindowResize_NoPanic(t *testing.T) {
 // refetch — the cursor clamp + filter mirror handle the visual update.
 // Status filter changes still dispatch a refetch (covered separately).
 func TestEdge_SSEDuringSearchPrompt(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
-	m.list.loading = false
+	m := newTestModel()
 	m.list.issues = []Issue{{ProjectID: 7, Number: 1, Title: "x"}}
 
 	// Open the search bar with '/'.
@@ -82,8 +77,7 @@ func TestEdge_SSEDuringSearchPrompt(t *testing.T) {
 	}
 
 	// Type 'a' before the SSE event arrives. Live mirrors into filter.
-	out, cmd := m.Update(runeKey('a'))
-	m = out.(Model)
+	m, cmd := updateModel(m, runeKey('a'))
 	if cmd != nil {
 		t.Fatalf("typing 'a' must not return a cmd, got %T", cmd)
 	}
@@ -93,8 +87,7 @@ func TestEdge_SSEDuringSearchPrompt(t *testing.T) {
 
 	// SSE event lands while the bar is still open. pendingRefetch
 	// flips and a debounce tick is queued; the bar state is untouched.
-	out, sseCmd := m.Update(eventReceivedMsg{projectID: 7, issueNumber: 0})
-	m = out.(Model)
+	m, sseCmd := updateModel(m, eventReceivedMsg{projectID: 7, issueNumber: 0})
 	if m.input.kind != inputSearchBar {
 		t.Fatal("SSE event closed the bar; should be transparent to it")
 	}
@@ -109,8 +102,7 @@ func TestEdge_SSEDuringSearchPrompt(t *testing.T) {
 	}
 
 	// Continue typing 'b' — bar accepts the rune.
-	out, cmd = m.Update(runeKey('b'))
-	m = out.(Model)
+	m, cmd = updateModel(m, runeKey('b'))
 	if cmd != nil {
 		t.Fatalf("typing 'b' after SSE must not return a cmd, got %T", cmd)
 	}
@@ -120,8 +112,7 @@ func TestEdge_SSEDuringSearchPrompt(t *testing.T) {
 
 	// Enter commits — bar closes, filter stays. No refetch (Search is
 	// client-side; the bar already mirrored the value live).
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.input.kind != inputNone {
 		t.Fatal("Enter did not close the bar")
 	}
@@ -135,10 +126,7 @@ func TestEdge_SSEDuringSearchPrompt(t *testing.T) {
 // background mutation can shuffle them). The cursor must stay on the
 // same issue rather than the same index.
 func TestEdge_IdentitySelection_FollowsIssueAcrossReorder(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
-	m.list.loading = false
+	m := newTestModel()
 	m.list.issues = []Issue{
 		{Number: 1, Title: "alpha"},
 		{Number: 2, Title: "beta"},
@@ -151,7 +139,7 @@ func TestEdge_IdentitySelection_FollowsIssueAcrossReorder(t *testing.T) {
 	// because it was just updated. With positional selection the cursor
 	// would still point at index 1 (now "alpha"), silently changing
 	// what the user sees as selected.
-	out, _ := m.Update(refetchedMsg{
+	nm, _ := updateModel(m, refetchedMsg{
 		dispatchKey: m.currentCacheKey(),
 		issues: []Issue{
 			{Number: 2, Title: "beta"},
@@ -159,14 +147,7 @@ func TestEdge_IdentitySelection_FollowsIssueAcrossReorder(t *testing.T) {
 			{Number: 3, Title: "gamma"},
 		},
 	})
-	nm := out.(Model)
-	if nm.list.cursor != 0 {
-		t.Fatalf("cursor = %d, want 0 (#2 moved to row 0)", nm.list.cursor)
-	}
-	if nm.list.selectedNumber != 2 {
-		t.Fatalf("selectedNumber = %d, want 2 (identity preserved)",
-			nm.list.selectedNumber)
-	}
+	assertSelection(t, nm, 0, 2)
 }
 
 // TestEdge_IdentitySelection_FallsBackWhenIssueDisappears: when the
@@ -175,10 +156,7 @@ func TestEdge_IdentitySelection_FollowsIssueAcrossReorder(t *testing.T) {
 // the same index clamped to the new visible range and re-records the
 // issue under it.
 func TestEdge_IdentitySelection_FallsBackWhenIssueDisappears(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
-	m.list.loading = false
+	m := newTestModel()
 	m.list.issues = []Issue{
 		{Number: 1, Title: "alpha"},
 		{Number: 2, Title: "beta"},
@@ -187,7 +165,7 @@ func TestEdge_IdentitySelection_FallsBackWhenIssueDisappears(t *testing.T) {
 	m.list.cursor = 1
 	m.list.selectedNumber = 2
 
-	out, _ := m.Update(refetchedMsg{
+	nm, _ := updateModel(m, refetchedMsg{
 		dispatchKey: m.currentCacheKey(),
 		issues: []Issue{
 			{Number: 1, Title: "alpha"},
@@ -195,14 +173,7 @@ func TestEdge_IdentitySelection_FallsBackWhenIssueDisappears(t *testing.T) {
 			{Number: 3, Title: "gamma"},
 		},
 	})
-	nm := out.(Model)
-	if nm.list.cursor != 1 {
-		t.Fatalf("cursor = %d, want 1 (clamped to new index 1)", nm.list.cursor)
-	}
-	if nm.list.selectedNumber != 3 {
-		t.Fatalf("selectedNumber = %d, want 3 (re-pinned to issue at fallback row)",
-			nm.list.selectedNumber)
-	}
+	assertSelection(t, nm, 1, 3)
 }
 
 // TestEdge_PageUpPageDown_MovesCursorInChunks: pgup/pgdown shift the
@@ -210,28 +181,16 @@ func TestEdge_IdentitySelection_FallsBackWhenIssueDisappears(t *testing.T) {
 // hundreds of j/k presses.
 func TestEdge_PageUpPageDown_MovesCursorInChunks(t *testing.T) {
 	m := initialModel(Options{})
-	issues := make([]Issue, 50)
-	for i := range issues {
-		issues[i] = Issue{Number: int64(i + 1), Title: "row"}
-	}
 	m.list.loading = false
-	m.list.issues = issues
+	m.list.issues = makeTestIssues(50)
 	m.list.cursor = 5
 
 	// pgdown advances by pageStep (10).
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
-	nm := out.(Model)
-	if nm.list.cursor != 15 {
-		t.Fatalf("after pgdown, cursor = %d, want 15", nm.list.cursor)
-	}
-	if nm.list.selectedNumber != 16 {
-		t.Fatalf("selectedNumber = %d, want 16 (issue at cursor 15)",
-			nm.list.selectedNumber)
-	}
+	nm, _ := updateModel(m, tea.KeyMsg{Type: tea.KeyPgDown})
+	assertSelection(t, nm, 15, 16)
 
 	// pgup walks back by pageStep.
-	out, _ = nm.Update(tea.KeyMsg{Type: tea.KeyPgUp})
-	nm = out.(Model)
+	nm, _ = updateModel(nm, tea.KeyMsg{Type: tea.KeyPgUp})
 	if nm.list.cursor != 5 {
 		t.Fatalf("after pgup, cursor = %d, want 5", nm.list.cursor)
 	}
@@ -241,16 +200,11 @@ func TestEdge_PageUpPageDown_MovesCursorInChunks(t *testing.T) {
 // last row rather than walking past the slice.
 func TestEdge_PageDown_ClampsAtEnd(t *testing.T) {
 	m := initialModel(Options{})
-	issues := make([]Issue, 12)
-	for i := range issues {
-		issues[i] = Issue{Number: int64(i + 1), Title: "row"}
-	}
 	m.list.loading = false
-	m.list.issues = issues
+	m.list.issues = makeTestIssues(12)
 	m.list.cursor = 8
 
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
-	nm := out.(Model)
+	nm, _ := updateModel(m, tea.KeyMsg{Type: tea.KeyPgDown})
 	if nm.list.cursor != 11 {
 		t.Fatalf("cursor = %d, want 11 (clamped to last row)", nm.list.cursor)
 	}
@@ -312,10 +266,7 @@ func numToTag(n int) string {
 // before a status/search/owner/labels change should still populate the
 // full list; filteredIssues narrows what renders afterward.
 func TestEdge_RefetchAfterRenderFilterChangeKeepsWorkingSet(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
-	m.list.loading = false
+	m := newTestModel()
 	m.list.issues = []Issue{{Number: 99, Title: "current-filter row"}}
 	m.list.filter = ListFilter{Status: "open"}
 
@@ -326,8 +277,7 @@ func TestEdge_RefetchAfterRenderFilterChangeKeepsWorkingSet(t *testing.T) {
 			{Number: 2, Status: "open", Title: "open row"},
 		},
 	}
-	out, _ := m.Update(fetched)
-	nm := out.(Model)
+	nm, _ := updateModel(m, fetched)
 	if len(nm.list.issues) != 2 {
 		t.Fatalf("working set was not refreshed: %+v", nm.list.issues)
 	}
@@ -354,8 +304,7 @@ func TestEdge_StaleRefetch_DroppedAcrossScopeToggle(t *testing.T) {
 		dispatchKey: cacheKey{projectID: 7}, // single-project at dispatch
 		issues:      []Issue{{Number: 1, Title: "single-project row"}},
 	}
-	out, _ := m.Update(stale)
-	nm := out.(Model)
+	nm, _ := updateModel(m, stale)
 	if len(nm.list.issues) != 1 || nm.list.issues[0].Number != 99 {
 		t.Fatalf("stale single-project refetch leaked into all-projects view: %+v",
 			nm.list.issues)
@@ -368,8 +317,7 @@ func TestEdge_StaleRefetch_DroppedAcrossScopeToggle(t *testing.T) {
 func TestQuit_QPressed_OpensConfirm(t *testing.T) {
 	m := initialModel(Options{})
 	m.list.loading = false
-	out, cmd := m.Update(runeKey('q'))
-	nm := out.(Model)
+	nm, cmd := updateModel(m, runeKey('q'))
 	if cmd != nil {
 		if msg := cmd(); msg != nil {
 			if _, isQuit := msg.(tea.QuitMsg); isQuit {
@@ -387,8 +335,7 @@ func TestQuit_QPressed_OpensConfirm(t *testing.T) {
 func TestQuit_CtrlCFastQuits(t *testing.T) {
 	m := initialModel(Options{})
 	m.list.loading = false
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
-	nm := out.(Model)
+	nm, cmd := updateModel(m, tea.KeyMsg{Type: tea.KeyCtrlC})
 	if nm.modal != modalNone {
 		t.Fatalf("ctrl+c opened a modal: %v", nm.modal)
 	}
@@ -422,8 +369,7 @@ func TestQuit_NCancels(t *testing.T) {
 		m := initialModel(Options{})
 		m.list.loading = false
 		m.modal = modalQuitConfirm
-		out, cmd := m.Update(runeKey(k))
-		nm := out.(Model)
+		nm, cmd := updateModel(m, runeKey(k))
 		if cmd != nil {
 			if msg := cmd(); msg != nil {
 				if _, isQuit := msg.(tea.QuitMsg); isQuit {
@@ -439,8 +385,8 @@ func TestQuit_NCancels(t *testing.T) {
 	m := initialModel(Options{})
 	m.list.loading = false
 	m.modal = modalQuitConfirm
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	if out.(Model).modal != modalNone {
+	nm, _ := updateModel(m, tea.KeyMsg{Type: tea.KeyEsc})
+	if nm.modal != modalNone {
 		t.Fatal("Esc did not close the quit modal")
 	}
 }
@@ -452,8 +398,7 @@ func TestQuit_ModalAbsorbsOtherKeys(t *testing.T) {
 	m := initialModel(Options{})
 	m.list.loading = false
 	m.modal = modalQuitConfirm
-	out, cmd := m.Update(runeKey('j'))
-	nm := out.(Model)
+	nm, cmd := updateModel(m, runeKey('j'))
 	if cmd != nil {
 		t.Fatalf("j during modal returned cmd %T; should be absorbed", cmd)
 	}
@@ -473,9 +418,7 @@ func TestQuit_ModalAbsorbsOtherKeys(t *testing.T) {
 // refetch picks up the change without waiting for SSE. Regression
 // for roborev #89 finding 1.
 func TestEdge_DetailMutation_StaleGen_MarksCacheStale(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
+	m := newTestModel()
 	m.view = viewDetail
 	// Pretend the user is now on issue #99 (gen=10) after jumping
 	// from issue #42 (gen=5).
@@ -488,8 +431,7 @@ func TestEdge_DetailMutation_StaleGen_MarksCacheStale(t *testing.T) {
 		origin: "detail", gen: 5, kind: "close",
 		resp: &MutationResp{Issue: &Issue{Number: 42}},
 	}
-	out, _ := m.Update(mut)
-	nm := out.(Model)
+	nm, _ := updateModel(m, mut)
 	if !nm.cache.isStale() {
 		t.Fatal("stale-gen detail mutation must mark cache stale so next refetch repopulates")
 	}
@@ -505,9 +447,7 @@ func TestEdge_DetailMutation_StaleGen_MarksCacheStale(t *testing.T) {
 // mutate detail state or dispatch fetches. handleJumpDetail gates on
 // view==viewDetail. Regression for roborev #89 finding 2.
 func TestEdge_JumpDetail_ViewGuard(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
+	m := newTestModel()
 	// User left detail view between the keypress and the jump msg.
 	m.view = viewList
 	m.detail.issue = &Issue{ProjectID: 7, Number: 42}
@@ -516,8 +456,7 @@ func TestEdge_JumpDetail_ViewGuard(t *testing.T) {
 	priorGen := m.detail.gen
 	priorIssue := m.detail.issue.Number
 
-	out, cmd := m.Update(jumpDetailMsg{number: 99})
-	nm := out.(Model)
+	nm, cmd := updateModel(m, jumpDetailMsg{number: 99})
 	if cmd != nil {
 		t.Fatalf("jump while not in viewDetail must dispatch no fetches, got %T", cmd)
 	}
@@ -538,10 +477,7 @@ func TestEdge_JumpDetail_ViewGuard(t *testing.T) {
 // issue if it survived the new filter, defeating the explicit "I changed
 // the filter" intent. Regression for roborev #90 finding 1.
 func TestEdge_FilterChange_ClearsSelectedNumber(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
-	m.list.loading = false
+	m := newTestModel()
 	m.list.issues = []Issue{
 		{Number: 1, Title: "alpha", Status: "open"},
 		{Number: 2, Title: "beta", Status: "open"},
@@ -550,8 +486,7 @@ func TestEdge_FilterChange_ClearsSelectedNumber(t *testing.T) {
 	m.list.cursor = 1
 	m.list.selectedNumber = 2 // cursor on #2
 
-	out, cmd := m.Update(runeKey('s'))
-	nm := out.(Model)
+	nm, cmd := updateModel(m, runeKey('s'))
 	if nm.list.selectedNumber != 0 {
 		t.Fatalf("selectedNumber = %d, want 0 (filter change clears identity)",
 			nm.list.selectedNumber)
@@ -564,10 +499,7 @@ func TestEdge_FilterChange_ClearsSelectedNumber(t *testing.T) {
 // TestEdge_ClearFilters_ClearsSelectedNumber: same as above for `c`
 // (clear filters).
 func TestEdge_ClearFilters_ClearsSelectedNumber(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
-	m.list.loading = false
+	m := newTestModel()
 	m.list.filter = ListFilter{Status: "open", Owner: "alice"}
 	m.list.issues = []Issue{
 		{Number: 1, Title: "alpha", Status: "open", Owner: ptrString("alice")},
@@ -575,8 +507,7 @@ func TestEdge_ClearFilters_ClearsSelectedNumber(t *testing.T) {
 	m.list.cursor = 0
 	m.list.selectedNumber = 1
 
-	out, _ := m.Update(runeKey('c'))
-	nm := out.(Model)
+	nm, _ := updateModel(m, runeKey('c'))
 	if nm.list.selectedNumber != 0 {
 		t.Fatalf("selectedNumber = %d, want 0 (clear filters resets identity)",
 			nm.list.selectedNumber)
@@ -592,10 +523,7 @@ func TestEdge_ClearFilters_ClearsSelectedNumber(t *testing.T) {
 // dispatchToView would forward to detail and the result would be
 // silently dropped.
 func TestEdge_ListMutation_CompletesAfterDetailOpen(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
-	m.list.loading = false
+	m := newTestModel()
 	m.list.actor = "tester"
 	m.list.issues = []Issue{{ProjectID: 7, Number: 1, Title: "x"}}
 	// Simulate having opened detail view after dispatching the close.
@@ -604,8 +532,7 @@ func TestEdge_ListMutation_CompletesAfterDetailOpen(t *testing.T) {
 
 	mut := mutationDoneMsg{origin: "list", kind: "close",
 		resp: &MutationResp{Issue: &Issue{Number: 1}}}
-	out, _ := m.Update(mut)
-	nm := out.(Model)
+	nm, _ := updateModel(m, mut)
 	if nm.list.status == "" {
 		t.Fatal("list mutation completion was dropped while detail was active")
 	}
@@ -622,10 +549,7 @@ func TestEdge_ListMutation_CompletesAfterDetailOpen(t *testing.T) {
 // Without top-level routing, dispatchToView would forward to the list
 // and the response would be silently dropped.
 func TestEdge_DetailMutation_CompletesAfterPopToList(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
-	m.list.loading = false
+	m := newTestModel()
 	// Detail is initialized with a current issue and gen=5 from a recent
 	// open; after popping, m.view is viewList but m.detail still holds
 	// the prior state until the next open.
@@ -636,8 +560,7 @@ func TestEdge_DetailMutation_CompletesAfterPopToList(t *testing.T) {
 
 	mut := mutationDoneMsg{origin: "detail", gen: 5, kind: "close",
 		resp: &MutationResp{Issue: &Issue{Number: 42}}}
-	out, _ := m.Update(mut)
-	nm := out.(Model)
+	nm, _ := updateModel(m, mut)
 	if nm.detail.status == "" {
 		t.Fatal("detail mutation completion was dropped while list was active")
 	}
@@ -654,9 +577,7 @@ func TestEdge_DetailMutation_CompletesAfterPopToList(t *testing.T) {
 // Driven through Model.Update so the jumpDetailMsg flow exercises
 // Model.handleJumpDetail end-to-end (gen comes from m.nextGen).
 func TestEdge_DetailJumpBack(t *testing.T) {
-	m := initialModel(Options{})
-	m.api = &Client{}
-	m.scope = scope{projectID: 7}
+	m := newTestModel()
 	m.view = viewDetail
 
 	// Build A with one link to issue #7. We seed activeTab=tabLinks and
@@ -675,8 +596,7 @@ func TestEdge_DetailJumpBack(t *testing.T) {
 	m.nextGen = 1
 
 	// Press Enter on the link → emits jumpDetailMsg(7).
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = out.(Model)
+	m, cmd := updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
 		t.Fatal("expected jump cmd from Enter")
 	}
@@ -687,8 +607,7 @@ func TestEdge_DetailJumpBack(t *testing.T) {
 
 	// Feed the jumpDetailMsg back so Model.handleJumpDetail performs
 	// the navStack push and gen advance.
-	out, _ = m.Update(jm)
-	m = out.(Model)
+	m, _ = updateModel(m, jm)
 	if len(m.detail.navStack) != 1 {
 		t.Fatalf("navStack length = %d, want 1", len(m.detail.navStack))
 	}
@@ -701,17 +620,15 @@ func TestEdge_DetailJumpBack(t *testing.T) {
 	}
 
 	// Apply the in-flight detailFetchedMsg so the stacked view has data.
-	out, _ = m.Update(detailFetchedMsg{
+	m, _ = updateModel(m, detailFetchedMsg{
 		gen: m.detail.gen, issue: &Issue{Number: 7, Title: "linked target"},
 	})
-	m = out.(Model)
 	if m.detail.issue == nil || m.detail.issue.Number != 7 {
 		t.Fatalf("post-fetch dm.issue.Number = %v, want 7", m.detail.issue)
 	}
 
 	// Press Esc → pop to original (handleBack restores from navStack).
-	out, popCmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	m = out.(Model)
+	m, popCmd := updateModel(m, tea.KeyMsg{Type: tea.KeyEsc})
 	if popCmd != nil {
 		t.Fatalf("Esc on stacked detail must not emit a cmd, got %T", popCmd)
 	}

--- a/internal/tui/filter_form_test.go
+++ b/internal/tui/filter_form_test.go
@@ -46,18 +46,50 @@ func filterFormFixture() Model {
 // openNewIssueForm.
 func openFilterForm(t *testing.T, m Model) Model {
 	t.Helper()
-	out, cmd := m.Update(runeKey('f'))
-	m = out.(Model)
+	m, cmd := stepModel(m, runeKey('f'))
 	if cmd == nil {
 		t.Fatalf("press f produced no cmd; expected openInputCmd")
 	}
-	msg := cmd()
-	out, _ = m.Update(msg)
-	m = out.(Model)
-	if m.input.kind != inputFilterForm {
-		t.Fatalf("openInput did not land inputFilterForm; got %v", m.input.kind)
+	m, _ = stepModel(m, cmd())
+	assertInputKind(t, m, inputFilterForm)
+	return m
+}
+
+// typeString feeds each rune of s through the model as a tea.KeyMsg.
+// Mirrors how a user types into the focused field of an input form.
+func typeString(m Model, s string) Model {
+	for _, r := range s {
+		m, _ = stepModel(m, runeKey(r))
 	}
 	return m
+}
+
+// pressTabN sends Tab through Update n times so callers can advance the
+// focused field by a known number of steps in one expression.
+func pressTabN(m Model, n int) Model {
+	for i := 0; i < n; i++ {
+		m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyTab})
+	}
+	return m
+}
+
+// assertInputKind fails the test unless the model's open input matches
+// want — replaces the recurring `if m.input.kind != X { t.Fatalf(...) }`
+// boilerplate.
+func assertInputKind(t *testing.T, m Model, want inputKind) {
+	t.Helper()
+	if m.input.kind != want {
+		t.Fatalf("input.kind = %v, want %v", m.input.kind, want)
+	}
+}
+
+// assertActiveField fails the test unless the focused field index matches
+// want — collapses the recurring active-field check on multi-field forms.
+func assertActiveField(t *testing.T, m Model, want int) {
+	t.Helper()
+	if m.input.active != want {
+		t.Fatalf("input.active = %d, want %d", m.input.active, want)
+	}
 }
 
 // TestFilterForm_OpensOnFKey: pressing f on the list view opens the
@@ -86,16 +118,12 @@ func TestFilterForm_OpensOnFKey(t *testing.T) {
 func TestFilterForm_AllProjectsScopeStillRenders(t *testing.T) {
 	m := filterFormFixture()
 	m.scope = scope{allProjects: true}
-	out, cmd := m.Update(runeKey('f'))
+	m, cmd := stepModel(m, runeKey('f'))
 	if cmd == nil {
 		t.Fatal("press f in all-projects mode must dispatch openInputCmd")
 	}
-	msg := cmd()
-	out, _ = out.(Model).Update(msg)
-	nm := out.(Model)
-	if nm.input.kind != inputFilterForm {
-		t.Fatalf("filter form did not open in all-projects mode: kind=%v", nm.input.kind)
-	}
+	m, _ = stepModel(m, cmd())
+	assertInputKind(t, m, inputFilterForm)
 }
 
 // TestFilterForm_TabCyclesFourFields_WithWrap: tab cycles
@@ -105,8 +133,7 @@ func TestFilterForm_TabCyclesFourFields_WithWrap(t *testing.T) {
 	m := openFilterForm(t, filterFormFixture())
 	wants := []int{1, 2, 3, 0}
 	for i, want := range wants {
-		out, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = out.(Model)
+		m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyTab})
 		if m.input.active != want {
 			t.Fatalf("step %d: active = %d, want %d", i, m.input.active, want)
 		}
@@ -122,20 +149,17 @@ func TestFilterForm_StatusFieldRadioCycle_LeftRightSpace(t *testing.T) {
 		t.Fatalf("initial radio = %q, want all", got)
 	}
 	// → all → open
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight})
-	m = out.(Model)
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyRight})
 	if got := m.input.fields[0].radio.value(); got != "open" {
 		t.Fatalf("after right: %q, want open", got)
 	}
 	// space open → closed
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeySpace})
-	m = out.(Model)
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeySpace})
 	if got := m.input.fields[0].radio.value(); got != "closed" {
 		t.Fatalf("after space: %q, want closed", got)
 	}
 	// ← closed → open
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
-	m = out.(Model)
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyLeft})
 	if got := m.input.fields[0].radio.value(); got != "open" {
 		t.Fatalf("after left: %q, want open", got)
 	}
@@ -152,23 +176,15 @@ func TestFilterForm_StatusFieldRadioCycle_LeftRightSpace(t *testing.T) {
 func TestFilterForm_CommitUsesDedicatedPath(t *testing.T) {
 	m := openFilterForm(t, filterFormFixture())
 	// Set Status=open via a right-arrow cycle.
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight})
-	m = out.(Model)
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyRight})
 	// Tab to Owner; type alice.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
-	for _, r := range "alice" {
-		m, _ = stepModel(m, runeKey(r))
-	}
+	m = pressTabN(m, 1)
+	m = typeString(m, "alice")
 	// Tab to Search; type login.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
-	for _, r := range "login" {
-		m, _ = stepModel(m, runeKey(r))
-	}
+	m = pressTabN(m, 1)
+	m = typeString(m, "login")
 	// ctrl+s commits.
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
-	nm := out.(Model)
+	nm, cmd := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	if cmd != nil {
 		t.Fatalf("commit produced cmd %T; filters should apply client-side", cmd)
 	}
@@ -176,9 +192,7 @@ func TestFilterForm_CommitUsesDedicatedPath(t *testing.T) {
 	if !listFilterEqual(nm.list.filter, want) {
 		t.Fatalf("list.filter = %+v, want %+v", nm.list.filter, want)
 	}
-	if nm.input.kind != inputNone {
-		t.Fatalf("form did not close on commit: kind=%v", nm.input.kind)
-	}
+	assertInputKind(t, nm, inputNone)
 }
 
 // TestFilterForm_CommitZeroesSelectedNumberAndResetsCursor: a filter
@@ -189,8 +203,7 @@ func TestFilterForm_CommitZeroesSelectedNumberAndResetsCursor(t *testing.T) {
 	m := openFilterForm(t, filterFormFixture())
 	m.list.cursor = 5
 	m.list.selectedNumber = 42
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
-	nm := out.(Model)
+	nm, _ := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	if nm.list.cursor != 0 {
 		t.Fatalf("cursor = %d, want 0 after commit", nm.list.cursor)
 	}
@@ -205,8 +218,7 @@ func TestFilterForm_CommitZeroesSelectedNumberAndResetsCursor(t *testing.T) {
 func TestFilterForm_CommitClearsLmStatus(t *testing.T) {
 	m := openFilterForm(t, filterFormFixture())
 	m.list.status = "closed #99"
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
-	nm := out.(Model)
+	nm, _ := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	if nm.list.status != "" {
 		t.Fatalf("list.status = %q, want empty after commit", nm.list.status)
 	}
@@ -216,11 +228,10 @@ func TestFilterForm_CommitClearsLmStatus(t *testing.T) {
 // cached all-status working set and returns no command.
 func TestFilterForm_CommitDoesNotRefetch(t *testing.T) {
 	m := openFilterForm(t, filterFormFixture())
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	_, cmd := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd, got %T", cmd)
 	}
-	_ = out
 }
 
 // TestFilterForm_CommitResetsCursorToZero is a more explicit form of
@@ -229,8 +240,7 @@ func TestFilterForm_CommitDoesNotRefetch(t *testing.T) {
 func TestFilterForm_CommitResetsCursorToZero(t *testing.T) {
 	m := openFilterForm(t, filterFormFixture())
 	m.list.cursor = 17
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
-	nm := out.(Model)
+	nm, _ := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	if nm.list.cursor != 0 {
 		t.Fatalf("cursor not reset: got %d, want 0", nm.list.cursor)
 	}
@@ -256,8 +266,7 @@ func TestFilterForm_CtrlRResetsFieldsOnly_PreFilterIntact(t *testing.T) {
 		t.Fatalf("preFilter = %+v, want %+v", m.input.preFilter, wantPre)
 	}
 	// ctrl+r resets.
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
-	m = out.(Model)
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlR})
 	if got := m.input.fields[0].radio.value(); got != "all" {
 		t.Fatalf("Status not reset: %q, want all", got)
 	}
@@ -285,17 +294,11 @@ func TestFilterForm_EscRestoresPreFilter(t *testing.T) {
 	m.list.filter = ListFilter{Status: "open", Owner: "wesm"}
 	m = openFilterForm(t, m)
 	// Make a change inside the form (just type into Owner via tab+keys).
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
-	for _, r := range "alice" {
-		m, _ = stepModel(m, runeKey(r))
-	}
+	m = pressTabN(m, 1)
+	m = typeString(m, "alice")
 	// Esc cancels.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	nm := out.(Model)
-	if nm.input.kind != inputNone {
-		t.Fatalf("form not closed after esc: kind=%v", nm.input.kind)
-	}
+	nm, _ := stepModel(m, tea.KeyMsg{Type: tea.KeyEsc})
+	assertInputKind(t, nm, inputNone)
 	want := ListFilter{Status: "open", Owner: "wesm"}
 	if !listFilterEqual(nm.list.filter, want) {
 		t.Fatalf("filter not restored: got %+v, want %+v", nm.list.filter, want)
@@ -312,11 +315,8 @@ func TestFilterForm_CtrlSCommitsViaCommitInputBranch_NotCommitFormInput(
 	t *testing.T,
 ) {
 	m := openFilterForm(t, filterFormFixture())
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
-	nm := out.(Model)
-	if nm.input.kind != inputNone {
-		t.Fatalf("filter form did not clear on ctrl+s: kind=%v", nm.input.kind)
-	}
+	nm, _ := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlS})
+	assertInputKind(t, nm, inputNone)
 	if nm.input.saving {
 		t.Fatal("saving=true after ctrl+s; filter form fell into commitFormInput")
 	}
@@ -411,18 +411,12 @@ func TestHelpScreen_NoLongerMentionsO(t *testing.T) {
 func TestFilterForm_LabelsField_AnyOfSemantics_AppliesViaCommit(t *testing.T) {
 	m := openFilterForm(t, filterFormFixture())
 	// Tab three times so Labels (idx 3) is the active field.
-	for i := 0; i < 3; i++ {
-		out, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = out.(Model)
-	}
+	m = pressTabN(m, 3)
 	if m.input.active != 3 {
 		t.Fatalf("active = %d, want 3 (Labels)", m.input.active)
 	}
-	for _, r := range "bug, prio-1" {
-		m, _ = stepModel(m, runeKey(r))
-	}
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
-	nm := out.(Model)
+	m = typeString(m, "bug, prio-1")
+	nm, _ := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	want := []string{"bug", "prio-1"}
 	if len(nm.list.filter.Labels) != len(want) {
 		t.Fatalf("filter.Labels = %v, want %v", nm.list.filter.Labels, want)
@@ -455,25 +449,16 @@ func TestFilterForm_LabelsField_AnyOfSemantics_AppliesViaCommit(t *testing.T) {
 func TestFilterForm_LabelsField_FreeTypedInAllProjectsScope(t *testing.T) {
 	m := filterFormFixture()
 	m.scope = scope{allProjects: true}
-	out, cmd := m.Update(runeKey('f'))
+	m, cmd := stepModel(m, runeKey('f'))
 	if cmd == nil {
 		t.Fatal("press f in all-projects mode must dispatch openInputCmd")
 	}
-	out, _ = out.(Model).Update(cmd())
-	m = out.(Model)
-	if m.input.kind != inputFilterForm {
-		t.Fatalf("filter form did not open in all-projects mode: kind=%v", m.input.kind)
-	}
+	m, _ = stepModel(m, cmd())
+	assertInputKind(t, m, inputFilterForm)
 	// Tab to Labels (idx 3); type free text.
-	for i := 0; i < 3; i++ {
-		out, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = out.(Model)
-	}
-	for _, r := range "ad-hoc-label" {
-		m, _ = stepModel(m, runeKey(r))
-	}
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
-	nm := out.(Model)
+	m = pressTabN(m, 3)
+	m = typeString(m, "ad-hoc-label")
+	nm, _ := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	if len(nm.list.filter.Labels) != 1 || nm.list.filter.Labels[0] != "ad-hoc-label" {
 		t.Fatalf("filter.Labels = %v, want [ad-hoc-label]", nm.list.filter.Labels)
 	}

--- a/internal/tui/footer_hints_test.go
+++ b/internal/tui/footer_hints_test.go
@@ -8,16 +8,10 @@ import (
 )
 
 func TestQueueHelpRows_ConditionalItems(t *testing.T) {
-	parentNum := int64(1)
-	withChildren := Model{list: listModel{issues: []Issue{
-		{ProjectID: 7, Number: parentNum, Title: "parent", Status: "open"},
-		{ProjectID: 7, Number: 2, ParentNumber: &parentNum, Title: "child", Status: "open"},
-	}}}
-	assertHelpItemPresent(t, flattenHelpRows(withChildren.queueHelpRows()),
-		helpItem{key: "space", desc: "expand"})
-	assertHelpItemPresent(t, flattenHelpRows(withChildren.queueHelpRows()),
-		helpItem{key: "N", desc: "child"})
-	assertHelpItemPresent(t, flattenHelpRows(withChildren.queueHelpRows()),
+	withChildren := Model{list: listModel{issues: hierarchyIssues()}}
+	assertHelpItemsPresent(t, withChildren.queueHelpRows(),
+		helpItem{key: "space", desc: "expand"},
+		helpItem{key: "N", desc: "child"},
 		helpItem{key: "o", desc: "order"})
 
 	leaf := Model{list: listModel{issues: []Issue{
@@ -46,43 +40,33 @@ func TestDetailHelpRows_Contexts(t *testing.T) {
 		detailFocus: focusActivity,
 		activeTab:   tabComments,
 	}}
-	for _, want := range []helpItem{
-		{key: "↑↓", desc: "move"},
-		{key: "↹", desc: "section"},
-		{key: "↵", desc: "open"},
-		{key: "e", desc: "edit"},
-		{key: "c", desc: "comment"},
-		{key: "+", desc: "label"},
-		{key: "a", desc: "owner"},
-		{key: "x", desc: "close"},
-		{key: "r", desc: "reopen"},
-		{key: "p", desc: "parent"},
-		{key: "b", desc: "block"},
-		{key: "l", desc: "link"},
-		{key: "L", desc: "layout"},
-		{key: "esc", desc: "back"},
-		{key: "?", desc: "help"},
-		{key: "q", desc: "quit"},
-	} {
-		assertHelpItemPresent(t, flattenHelpRows(activity.detailHelpRows()), want)
-	}
+	assertHelpItemsPresent(t, activity.detailHelpRows(),
+		helpItem{key: "↑↓", desc: "move"},
+		helpItem{key: "↹", desc: "section"},
+		helpItem{key: "↵", desc: "open"},
+		helpItem{key: "e", desc: "edit"},
+		helpItem{key: "c", desc: "comment"},
+		helpItem{key: "+", desc: "label"},
+		helpItem{key: "a", desc: "owner"},
+		helpItem{key: "x", desc: "close"},
+		helpItem{key: "r", desc: "reopen"},
+		helpItem{key: "p", desc: "parent"},
+		helpItem{key: "b", desc: "block"},
+		helpItem{key: "l", desc: "link"},
+		helpItem{key: "L", desc: "layout"},
+		helpItem{key: "esc", desc: "back"},
+		helpItem{key: "?", desc: "help"},
+		helpItem{key: "q", desc: "quit"})
 
-	children := Model{detail: detailModel{
-		issue:       &Issue{Number: 1, Title: "parent", Status: "open"},
-		children:    []Issue{{Number: 2, Title: "child", Status: "open"}},
-		detailFocus: focusChildren,
-	}}
-	for _, want := range []helpItem{
-		{key: "↑↓", desc: "child"},
-		{key: "↵", desc: "open child"},
-		{key: "N", desc: "child"},
-		{key: "e", desc: "edit"},
-		{key: "x", desc: "close"},
-		{key: "?", desc: "help"},
-		{key: "q", desc: "quit"},
-	} {
-		assertHelpItemPresent(t, flattenHelpRows(children.detailHelpRows()), want)
-	}
+	children := Model{detail: hierarchyDetailModel(focusChildren)}
+	assertHelpItemsPresent(t, children.detailHelpRows(),
+		helpItem{key: "↑↓", desc: "child"},
+		helpItem{key: "↵", desc: "open child"},
+		helpItem{key: "N", desc: "child"},
+		helpItem{key: "e", desc: "edit"},
+		helpItem{key: "x", desc: "close"},
+		helpItem{key: "?", desc: "help"},
+		helpItem{key: "q", desc: "quit"})
 }
 
 func TestHelpRows_InputAndModalContexts(t *testing.T) {
@@ -120,25 +104,15 @@ func TestHelpRows_InputAndModalContexts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := flattenHelpRows(tt.m.helpRows())
-			for _, want := range tt.want {
-				assertHelpItemPresent(t, got, want)
-			}
+			assertHelpItemsPresent(t, tt.m.helpRows(), tt.want...)
 		})
 	}
 }
 
 func TestPersistentHelpRowsPreferArrowNotation(t *testing.T) {
-	parentNum := int64(1)
 	m := Model{
-		list: listModel{issues: []Issue{
-			{ProjectID: 7, Number: parentNum, Title: "parent", Status: "open"},
-			{ProjectID: 7, Number: 2, ParentNumber: &parentNum, Title: "child", Status: "open"},
-		}},
-		detail: detailModel{
-			issue:    &Issue{Number: 1, Title: "parent", Status: "open"},
-			children: []Issue{{Number: 2, Title: "child", Status: "open"}},
-		},
+		list:   listModel{issues: hierarchyIssues()},
+		detail: hierarchyDetailModel(focusActivity),
 	}
 	for _, rows := range [][][]helpItem{m.queueHelpRows(), m.detailHelpRows()} {
 		for _, item := range flattenHelpRows(rows) {
@@ -185,11 +159,7 @@ func TestReflowHelpRows_ExtremeNarrowFallsBackToOneItemPerRow(t *testing.T) {
 }
 
 func TestListViewFooterUsesAdaptiveHelpTable(t *testing.T) {
-	parentNum := int64(1)
-	lm := listModel{issues: []Issue{
-		{ProjectID: 7, Number: parentNum, Title: "parent", Status: "open"},
-		{ProjectID: 7, Number: 2, ParentNumber: &parentNum, Title: "child", Status: "open"},
-	}}
+	lm := listModel{issues: hierarchyIssues()}
 	got := stripANSI(lm.View(80, 14, viewChrome{}))
 	assertLineCount(t, got, 14)
 	assertLinesFitWidth(t, got, 80)
@@ -199,16 +169,31 @@ func TestListViewFooterUsesAdaptiveHelpTable(t *testing.T) {
 }
 
 func TestDetailViewFooterUsesAdaptiveChildrenFocusHints(t *testing.T) {
-	dm := detailModel{
-		issue:       &Issue{Number: 1, Title: "parent", Status: "open"},
-		children:    []Issue{{Number: 2, Title: "child", Status: "open"}},
-		detailFocus: focusChildren,
-	}
+	dm := hierarchyDetailModel(focusChildren)
 	got := stripANSI(dm.View(80, 18, viewChrome{}))
 	assertLineCount(t, got, 18)
 	assertLinesFitWidth(t, got, 80)
 	assertStringContains(t, got, "open child")
 	assertStringContains(t, got, "N child")
+}
+
+// hierarchyIssues returns a parent (Number=1) and one child (Number=2)
+// under ProjectID 7, the standard fixture for tests that need a queue
+// or detail view with a parent/child relationship.
+func hierarchyIssues() []Issue {
+	parentNum := int64(1)
+	return []Issue{
+		{ProjectID: 7, Number: parentNum, Title: "parent", Status: "open"},
+		{ProjectID: 7, Number: 2, ParentNumber: &parentNum, Title: "child", Status: "open"},
+	}
+}
+
+func hierarchyDetailModel(focus detailFocus) detailModel {
+	return detailModel{
+		issue:       &Issue{Number: 1, Title: "parent", Status: "open"},
+		children:    []Issue{{Number: 2, Title: "child", Status: "open"}},
+		detailFocus: focus,
+	}
 }
 
 func flattenHelpRows(rows [][]helpItem) []helpItem {
@@ -227,6 +212,14 @@ func assertHelpItemPresent(t *testing.T, rows []helpItem, want helpItem) {
 		}
 	}
 	t.Fatalf("help rows missing %+v in %+v", want, rows)
+}
+
+func assertHelpItemsPresent(t *testing.T, rows [][]helpItem, wants ...helpItem) {
+	t.Helper()
+	flat := flattenHelpRows(rows)
+	for _, want := range wants {
+		assertHelpItemPresent(t, flat, want)
+	}
 }
 
 func assertHelpItemAbsent(t *testing.T, rows []helpItem, deny helpItem) {
@@ -258,5 +251,38 @@ func assertLinesFitWidth(t *testing.T, got string, width int) {
 		if w := runewidth.StringWidth(line); w > width {
 			t.Fatalf("line %d width=%d exceeds %d:\n%s", i+1, w, width, got)
 		}
+	}
+}
+
+func assertStringsLack(t *testing.T, got string, denials ...string) {
+	t.Helper()
+	for _, deny := range denials {
+		if strings.Contains(got, deny) {
+			t.Fatalf("output unexpectedly contains %q:\n%s", deny, got)
+		}
+	}
+}
+
+func assertContainsAll(t *testing.T, got string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// assertMaxGap finds the first lines containing topMarker and bottomMarker
+// and fails if the bottom line trails the top by more than maxGap rows.
+func assertMaxGap(t *testing.T, got, topMarker, bottomMarker string, maxGap int) {
+	t.Helper()
+	lines := strings.Split(got, "\n")
+	top := indexOf(lines, topMarker)
+	bottom := indexOf(lines, bottomMarker)
+	if top < 0 || bottom < 0 {
+		t.Fatalf("missing markers (%q=%d, %q=%d):\n%s", topMarker, top, bottomMarker, bottom, got)
+	}
+	if gap := bottom - top; gap > maxGap {
+		t.Fatalf("%q→%q gap=%d exceeds %d:\n%s", topMarker, bottomMarker, gap, maxGap, got)
 	}
 }

--- a/internal/tui/form_test.go
+++ b/internal/tui/form_test.go
@@ -1,14 +1,45 @@
 package tui
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+// captureCreateIssue stands up a test client whose handler records the
+// request path and replies with a minimal successful CreateIssue
+// payload. Returns the client and a pointer the caller dereferences
+// after the dispatch to inspect the request URL.
+func captureCreateIssue(t *testing.T) (*Client, *string) {
+	t.Helper()
+	var gotPath string
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		respondJSON(t, w, map[string]any{
+			"issue":   map[string]any{"number": 1, "title": "hi", "status": "open"},
+			"changed": true,
+		})
+	})
+	return c, &gotPath
+}
+
+// unwrapMutationCmd evaluates cmd, asserts the result is a
+// mutationDoneMsg with no err, and returns it. Fails the test with a
+// useful message on any mismatch.
+func unwrapMutationCmd(t *testing.T, cmd tea.Cmd) mutationDoneMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected mutation cmd, got nil")
+	}
+	msg := cmd()
+	mut, ok := msg.(mutationDoneMsg)
+	if !ok {
+		t.Fatalf("cmd returned %T, want mutationDoneMsg", msg)
+	}
+	return mut
+}
 
 // errStub is a minimal error type for tests that need a non-nil error
 // of a known string. Re-introduced here after the editor-test cleanup
@@ -439,19 +470,9 @@ func TestOpenCommentForm_UsesDetailScopePID(t *testing.T) {
 // detailIsActive() so split + focusDetail also routes through
 // m.detail.scopePID. Regression for roborev job 17575.
 func TestCommitNewIssueForm_SplitLayoutFocusDetail_UsesDetailScopePID(t *testing.T) {
-	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"issue":   map[string]any{"number": 1, "title": "hi", "status": "open"},
-			"changed": true,
-		})
-	}))
-	defer srv.Close()
-
+	api, gotPath := captureCreateIssue(t)
 	m := Model{
-		api:    NewClient(srv.URL, srv.Client()),
+		api:    api,
 		view:   viewList,
 		layout: layoutSplit,
 		focus:  focusDetail,
@@ -474,21 +495,14 @@ func TestCommitNewIssueForm_SplitLayoutFocusDetail_UsesDetailScopePID(t *testing
 	m.input.fields[0].input.SetValue("hi")
 
 	_, cmd := m.commitNewIssueForm()
-	if cmd == nil {
-		t.Fatal("commitNewIssueForm returned no cmd; want a CreateIssue dispatch")
-	}
-	msg := cmd()
-	mut, ok := msg.(mutationDoneMsg)
-	if !ok {
-		t.Fatalf("dispatch returned %T, want mutationDoneMsg", msg)
-	}
+	mut := unwrapMutationCmd(t, cmd)
 	if mut.err != nil {
-		t.Fatalf("CreateIssue dispatch failed: %v (path=%q)", mut.err, gotPath)
+		t.Fatalf("CreateIssue dispatch failed: %v (path=%q)", mut.err, *gotPath)
 	}
-	if !strings.Contains(gotPath, "/api/v1/projects/42/issues") {
+	if !strings.Contains(*gotPath, "/api/v1/projects/42/issues") {
 		t.Fatalf("URL path = %q, want /api/v1/projects/42/issues "+
 			"(split+focusDetail must use m.detail.scopePID, not m.scope.projectID=0)",
-			gotPath)
+			*gotPath)
 	}
 }
 
@@ -498,19 +512,9 @@ func TestCommitNewIssueForm_SplitLayoutFocusDetail_UsesDetailScopePID(t *testing
 // project (m.detail.scopePID), not m.scope.projectID==0. The
 // detailIsActive() switch must keep this path working.
 func TestCommitNewIssueForm_StackedViewDetail_UsesDetailScopePID(t *testing.T) {
-	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"issue":   map[string]any{"number": 1, "title": "hi", "status": "open"},
-			"changed": true,
-		})
-	}))
-	defer srv.Close()
-
+	api, gotPath := captureCreateIssue(t)
 	m := Model{
-		api:    NewClient(srv.URL, srv.Client()),
+		api:    api,
 		view:   viewDetail,
 		layout: layoutStacked,
 		keymap: newKeymap(),
@@ -526,18 +530,11 @@ func TestCommitNewIssueForm_StackedViewDetail_UsesDetailScopePID(t *testing.T) {
 	m.input.fields[0].input.SetValue("hi")
 
 	_, cmd := m.commitNewIssueForm()
-	if cmd == nil {
-		t.Fatal("commitNewIssueForm returned no cmd")
-	}
-	msg := cmd()
-	mut, ok := msg.(mutationDoneMsg)
-	if !ok {
-		t.Fatalf("dispatch returned %T, want mutationDoneMsg", msg)
-	}
+	mut := unwrapMutationCmd(t, cmd)
 	if mut.err != nil {
-		t.Fatalf("CreateIssue dispatch failed: %v (path=%q)", mut.err, gotPath)
+		t.Fatalf("CreateIssue dispatch failed: %v (path=%q)", mut.err, *gotPath)
 	}
-	if !strings.Contains(gotPath, "/api/v1/projects/42/issues") {
-		t.Fatalf("URL path = %q, want /api/v1/projects/42/issues", gotPath)
+	if !strings.Contains(*gotPath, "/api/v1/projects/42/issues") {
+		t.Fatalf("URL path = %q, want /api/v1/projects/42/issues", *gotPath)
 	}
 }

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -4,8 +4,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	tea "github.com/charmbracelet/bubbletea"
 )
 
 // TestHelpSections_AllBindingsCovered guards against drift between
@@ -47,11 +45,7 @@ func TestHelpSections_AllBindingsCovered(t *testing.T) {
 // regression that drops Detail (or any other section) is caught.
 func TestRenderHelp_NarrowWidth(t *testing.T) {
 	out := renderHelp(newKeymap(), 40, ListFilter{})
-	for _, want := range []string{"Global", "Graph", "Detail", "Children", "Forms", "Filters"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("narrow help missing section %q\n%s", want, out)
-		}
-	}
+	assertContainsAll(t, out, "Global", "Graph", "Detail", "Children", "Forms", "Filters")
 	if helpColumnCount(40) != 1 {
 		t.Fatalf("helpColumnCount(40)=%d, want 1", helpColumnCount(40))
 	}
@@ -65,13 +59,9 @@ func TestRenderHelp_WideWidth(t *testing.T) {
 		t.Fatalf("helpColumnCount(130)=%d, want 3", helpColumnCount(130))
 	}
 	out := renderHelp(newKeymap(), 130, ListFilter{})
-	for _, want := range []string{
+	assertContainsAll(t, out,
 		"Global", "Graph", "Detail", "Children", "Forms", "Filters", "kata — keybindings",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("wide help missing %q\n%s", want, out)
-		}
-	}
+	)
 }
 
 // TestRenderHelp_FilterChips: an active filter renders as a chip strip
@@ -91,13 +81,11 @@ func TestRenderHelp_FilterChips(t *testing.T) {
 func TestHelpToggle_FromList_AndBack(t *testing.T) {
 	m := initialModel(Options{})
 	m.view = viewList
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
-	mh := out.(Model)
+	mh := sendRune(m, '?')
 	if mh.view != viewHelp {
 		t.Fatalf("after ? from list, view = %v, want viewHelp", mh.view)
 	}
-	out, _ = mh.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
-	ml := out.(Model)
+	ml := sendRune(mh, '?')
 	if ml.view != viewList {
 		t.Fatalf("after ? from help, view = %v, want viewList", ml.view)
 	}
@@ -109,13 +97,11 @@ func TestHelpToggle_FromList_AndBack(t *testing.T) {
 func TestHelpToggle_FromDetail(t *testing.T) {
 	m := initialModel(Options{})
 	m.view = viewDetail
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
-	mh := out.(Model)
+	mh := sendRune(m, '?')
 	if mh.view != viewHelp {
 		t.Fatalf("after ? from detail, view = %v, want viewHelp", mh.view)
 	}
-	out, _ = mh.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
-	md := out.(Model)
+	md := sendRune(mh, '?')
 	if md.view != viewDetail {
 		t.Fatalf("after ? from help, view = %v, want viewDetail", md.view)
 	}
@@ -129,9 +115,9 @@ func TestHelpToggle_FromDetail(t *testing.T) {
 func TestHelpToggle_QuitFromHelp(t *testing.T) {
 	m := initialModel(Options{})
 	m.view = viewHelp
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
-	if out.(Model).modal != modalQuitConfirm {
-		t.Fatalf("q from help did not open quit-confirm modal: %v", out.(Model).modal)
+	nm := sendRune(m, 'q')
+	if nm.modal != modalQuitConfirm {
+		t.Fatalf("q from help did not open quit-confirm modal: %v", nm.modal)
 	}
 }
 
@@ -141,8 +127,7 @@ func TestHelpToggle_QuitFromHelp(t *testing.T) {
 func TestHelp_GatedByInputting(t *testing.T) {
 	m := initialModel(Options{})
 	m.input = newSearchBar(ListFilter{})
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
-	nm := out.(Model)
+	nm := sendRune(m, '?')
 	if nm.view == viewHelp {
 		t.Fatal("? opened help while bar was active; should be gated")
 	}
@@ -164,11 +149,10 @@ func TestHelp_RefetchWhileOpen_KeepsListInSync(t *testing.T) {
 	m.list.issues = []Issue{{Number: 1, Title: "old"}}
 	m.prevView = viewList
 	m.view = viewHelp
-	out, _ := m.Update(refetchedMsg{
+	nm, _ := updateModel(m, refetchedMsg{
 		dispatchKey: cacheKey{projectID: 1, limit: queueFetchLimit},
 		issues:      []Issue{{Number: 2, Title: "new"}},
 	})
-	nm := out.(Model)
 	if got := len(nm.list.issues); got != 1 {
 		t.Fatalf("list.issues len = %d, want 1", got)
 	}
@@ -176,11 +160,11 @@ func TestHelp_RefetchWhileOpen_KeepsListInSync(t *testing.T) {
 		t.Fatalf("list.issues = %+v, want [{Number:2 Title:new}]", nm.list.issues)
 	}
 	// Toggling back to the list must surface the refreshed rows.
-	out2, _ := nm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
-	if out2.(Model).view != viewList {
-		t.Fatalf("after ? from help, view = %v, want viewList", out2.(Model).view)
+	back := sendRune(nm, '?')
+	if back.view != viewList {
+		t.Fatalf("after ? from help, view = %v, want viewList", back.view)
 	}
-	if out2.(Model).list.issues[0].Number != 2 {
+	if back.list.issues[0].Number != 2 {
 		t.Fatal("returning to list must show refetched issues, not stale snapshot")
 	}
 }
@@ -198,20 +182,19 @@ func TestHelp_InitialFetchAfterScopeToggle_KeepsListInSync(t *testing.T) {
 	m.prevView = viewList
 	m.view = viewHelp
 	// Simulate an initialFetchMsg from a scope-toggle's fetchInitial.
-	out, _ := m.Update(initialFetchMsg{
+	nm, _ := updateModel(m, initialFetchMsg{
 		dispatchKey: cacheKey{projectID: 1, limit: queueFetchLimit},
 		issues:      []Issue{{Number: 99, Title: "all-projects row"}},
 	})
-	nm := out.(Model)
 	if got := len(nm.list.issues); got != 1 || nm.list.issues[0].Number != 99 {
 		t.Fatalf("list.issues = %+v, want [{Number:99 ...}]", nm.list.issues)
 	}
 	// Closing the overlay must surface the refreshed rows.
-	out2, _ := nm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
-	if out2.(Model).view != viewList {
-		t.Fatalf("after ? from help, view = %v, want viewList", out2.(Model).view)
+	back := sendRune(nm, '?')
+	if back.view != viewList {
+		t.Fatalf("after ? from help, view = %v, want viewList", back.view)
 	}
-	if out2.(Model).list.issues[0].Number != 99 {
+	if back.list.issues[0].Number != 99 {
 		t.Fatal("returning to list must show post-toggle rows, not stale snapshot")
 	}
 }

--- a/internal/tui/helpers_test.go
+++ b/internal/tui/helpers_test.go
@@ -1,0 +1,283 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// int64Ptr returns a pointer to v, the canonical helper for populating
+// optional *int64 fields (e.g. Issue.ParentNumber) in test fixtures.
+func int64Ptr(v int64) *int64 { return &v }
+
+// testIssueProjectID is the ProjectID used by the testIssue builder. It
+// matches the projectID on the scope returned by newTestModel/homedScope so
+// fixtures and model state agree by default.
+const testIssueProjectID int64 = 7
+
+// issueOpt mutates an Issue built by testIssue. Use the with* helpers
+// below rather than constructing issueOpt values directly.
+type issueOpt func(*Issue)
+
+// testIssue builds an Issue with ProjectID=7 and a default title of
+// "issue <number>". Tests that care about the title set it explicitly via
+// withTitle.
+func testIssue(number int64, opts ...issueOpt) Issue {
+	i := Issue{
+		ProjectID: testIssueProjectID,
+		Number:    number,
+		Title:     fmt.Sprintf("issue %d", number),
+	}
+	for _, opt := range opts {
+		opt(&i)
+	}
+	return i
+}
+
+func withTitle(title string) issueOpt {
+	return func(i *Issue) { i.Title = title }
+}
+
+func withParent(parent int64) issueOpt {
+	return func(i *Issue) { i.ParentNumber = &parent }
+}
+
+func withCounts(open, total int) issueOpt {
+	return func(i *Issue) { i.ChildCounts = &ChildCounts{Open: open, Total: total} }
+}
+
+func withBlocks(blocks ...int64) issueOpt {
+	return func(i *Issue) { i.Blocks = blocks }
+}
+
+func withStatus(status string) issueOpt {
+	return func(i *Issue) { i.Status = status }
+}
+
+func withLabels(labels ...string) issueOpt {
+	return func(i *Issue) { i.Labels = labels }
+}
+
+// mockDaemon builds an httptest.Server that dispatches by URL path. The
+// server sets Content-Type: application/json before invoking each handler,
+// so handlers only need to write status + body. Unmapped paths return 404.
+// The server is closed via t.Cleanup.
+func mockDaemon(t *testing.T, routes map[string]http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if h, ok := routes[r.URL.Path]; ok {
+			h(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// projectNotInitializedHandler responds to /api/v1/projects/resolve with
+// the 404 + project_not_initialized envelope used to drive the boot path
+// into the empty-state / projects-view branches.
+func projectNotInitializedHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status": 404,
+		"error":  map[string]any{"code": "project_not_initialized"},
+	})
+}
+
+// useNoColor switches the package-level styles to colorNone for the
+// duration of the test process. Tests that need ANSI-free output call
+// this so assertions can use plain string matching.
+func useNoColor(_ *testing.T) {
+	applyColorMode(colorNone, io.Discard)
+}
+
+// renderBodyNoColor renders lm's body and strips ANSI escapes, the
+// shape every list-render test wants when asserting on plain text.
+func renderBodyNoColor(lm listModel, width, height int, chrome viewChrome) string {
+	return stripANSI(lm.renderBody(width, height, chrome))
+}
+
+// newTestModel returns a Model wired with a stub Client, single-project
+// scope (projectID=7), and list.loading=false — the baseline shared by
+// most state-machine tests in this package.
+func newTestModel() Model {
+	m := initialModel(Options{})
+	m.api = &Client{}
+	m.scope = scope{projectID: 7}
+	m.list.loading = false
+	return m
+}
+
+// updateModel pipes msg through m.Update and unwraps the returned
+// tea.Model interface back to the concrete Model struct.
+func updateModel(m Model, msg tea.Msg) (Model, tea.Cmd) {
+	out, cmd := m.Update(msg)
+	return out.(Model), cmd
+}
+
+// sendRune dispatches a single-rune KeyMsg through m.Update and returns
+// the resulting Model, collapsing the verbose tea.KeyMsg + type-assert
+// boilerplate to one call.
+func sendRune(m Model, r rune) Model {
+	nm, _ := updateModel(m, keyRune(r))
+	return nm
+}
+
+// keyRune builds a single-rune tea.KeyMsg for tests that route keys
+// directly (e.g. routeProjectsViewKey) rather than through m.Update.
+func keyRune(r rune) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+}
+
+// sendKey dispatches a typed-key KeyMsg (e.g. tea.KeyDown, tea.KeyTab,
+// tea.KeyEnter) through m.Update and returns the resulting Model.
+func sendKey(m Model, kt tea.KeyType) Model {
+	nm, _ := updateModel(m, tea.KeyMsg{Type: kt})
+	return nm
+}
+
+// resizeModel sends a WindowSizeMsg through m.Update and returns the
+// resulting Model, collapsing the WindowSizeMsg + type-assert
+// boilerplate that every layout/chrome test repeats.
+func resizeModel(m Model, width, height int) Model {
+	nm, _ := updateModel(m, tea.WindowSizeMsg{Width: width, Height: height})
+	return nm
+}
+
+// makeTestIssues returns count Issues numbered 1..count with a stable
+// "row" title, suitable for pagination and viewport boundary tests.
+func makeTestIssues(count int) []Issue {
+	issues := make([]Issue, count)
+	for i := range issues {
+		issues[i] = Issue{Number: int64(i + 1), Title: "row"}
+	}
+	return issues
+}
+
+// mockProject bundles the three parallel maps the projects view consults
+// (projectsByID, projectIdentByID, projectStats) into one record so test
+// fixtures can list projects without juggling three coordinated literals.
+type mockProject struct {
+	ID    int64
+	Name  string
+	Ident string
+	Stats ProjectStatsSummary
+}
+
+// injectProjects populates the model's three parallel project maps from
+// the given mockProject records.
+func injectProjects(m *Model, projects ...mockProject) {
+	for _, p := range projects {
+		m.projectsByID[p.ID] = p.Name
+		m.projectIdentByID[p.ID] = p.Ident
+		m.projectStats[p.ID] = p.Stats
+	}
+}
+
+// setupProjectsView returns a Model in viewProjects with standard 120×24
+// dimensions, optionally pre-populated with the given mockProject rows.
+func setupProjectsView(projects ...mockProject) Model {
+	m := initialModel(Options{})
+	m.view = viewProjects
+	m.width, m.height = 120, 24
+	injectProjects(&m, projects...)
+	return m
+}
+
+// setupEmptyView returns a Model in viewEmpty with standard 80×24
+// dimensions — the baseline for empty-state rendering and key-handling
+// tests.
+func setupEmptyView() Model {
+	m := initialModel(Options{})
+	m.view = viewEmpty
+	m.width, m.height = 80, 24
+	return m
+}
+
+// assertCmdQuit fails t if cmd is nil or its result is not tea.QuitMsg.
+// The shape every quit-path assertion repeats: a nil cmd means the
+// keystroke didn't trigger Bubble Tea's quit at all.
+func assertCmdQuit(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("cmd = nil, want tea.Quit")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("cmd = %T, want tea.QuitMsg", cmd())
+	}
+}
+
+// homedScope builds a scope where the active project equals the home
+// project — the common shape for tests that need a single-project scope
+// already settled (i.e. came from a list, not a fresh boot).
+func homedScope(id int64, name string) scope {
+	return scope{projectID: id, projectName: name, homeProjectID: id, homeProjectName: name}
+}
+
+// assertContains fails t if subject does not contain substr. failMsg
+// describes the assertion (the helper appends the missing substring and
+// the full subject to keep diagnostics consistent across tests).
+func assertContains(t *testing.T, subject, substr, failMsg string) {
+	t.Helper()
+	if !strings.Contains(subject, substr) {
+		t.Fatalf("%s. Expected to find %q in:\n%s", failMsg, substr, subject)
+	}
+}
+
+// assertNotContains is the inverse of assertContains.
+func assertNotContains(t *testing.T, subject, substr, failMsg string) {
+	t.Helper()
+	if strings.Contains(subject, substr) {
+		t.Fatalf("%s. Did not expect to find %q in:\n%s", failMsg, substr, subject)
+	}
+}
+
+// assertStyleForeground fails t if style's foreground is not a
+// lipgloss.Color whose string value equals want. Collapses the recurring
+// type-assert + string-compare block in style tests.
+func assertStyleForeground(t *testing.T, style lipgloss.Style, label, want string) {
+	t.Helper()
+	fg, ok := style.GetForeground().(lipgloss.Color)
+	if !ok {
+		t.Fatalf("%s foreground = %T, want lipgloss.Color", label, style.GetForeground())
+	}
+	if string(fg) != want {
+		t.Fatalf("%s foreground = %q, want %q", label, string(fg), want)
+	}
+}
+
+// assertTerminalColor fails t if tc is not a lipgloss.Color whose string
+// value equals want. Used for raw lipgloss.TerminalColor vars (e.g.
+// panel border colors) that aren't wrapped in a Style.
+func assertTerminalColor(t *testing.T, tc lipgloss.TerminalColor, label, want string) {
+	t.Helper()
+	c, ok := tc.(lipgloss.Color)
+	if !ok {
+		t.Fatalf("%s = %T, want lipgloss.Color", label, tc)
+	}
+	if string(c) != want {
+		t.Fatalf("%s = %q, want %q", label, string(c), want)
+	}
+}
+
+// assertSelection fails t if either the cursor row or the recorded
+// selectedNumber identity differs from the wants.
+func assertSelection(t *testing.T, m Model, wantCursor int, wantNumber int64) {
+	t.Helper()
+	if m.list.cursor != wantCursor {
+		t.Fatalf("cursor = %d, want %d", m.list.cursor, wantCursor)
+	}
+	if m.list.selectedNumber != wantNumber {
+		t.Fatalf("selectedNumber = %d, want %d", m.list.selectedNumber, wantNumber)
+	}
+}

--- a/internal/tui/label_cache_test.go
+++ b/internal/tui/label_cache_test.go
@@ -17,6 +17,15 @@ func buildModelWithLabelCache(_ *testing.T) Model {
 	}
 }
 
+// setupScopedModel returns a label-cache-initialized Model with the
+// active project scope set to pid — the shared starting state for
+// every dispatch/acceptance test in this file.
+func setupScopedModel(t *testing.T, pid int64) Model {
+	m := buildModelWithLabelCache(t)
+	m.scope = scope{projectID: pid}
+	return m
+}
+
 // fakeLabelLister is a labelLister stub that returns a canned slice
 // without touching the network. Used by the race-fix coverage so the
 // test exercises the rejection path with a real (non-empty) response,
@@ -46,9 +55,8 @@ func (f *fakeLabelLister) ListLabels(_ context.Context, _ int64) ([]LabelCount, 
 // the gen-stamp into the cmd (or dropped the gen check in the
 // handler) would let the stale labels overwrite the cache.
 func TestLabelCache_DispatchStampsGenBeforeResponse(t *testing.T) {
-	m := buildModelWithLabelCache(t)
 	pid := int64(7)
-	m.scope = scope{projectID: pid}
+	m := setupScopedModel(t, pid)
 	fake := &fakeLabelLister{labels: []LabelCount{{Label: "from-first", Count: 1}}}
 	// First dispatch — gen stamped to 1, fetching=true. Capture the
 	// cmd; do NOT run it yet so the second dispatch can bump gen.
@@ -68,8 +76,7 @@ func TestLabelCache_DispatchStampsGenBeforeResponse(t *testing.T) {
 	}
 	// Now run the first cmd — it produces labelsFetchedMsg{gen: 1, ...}.
 	msg := firstCmd()
-	out, _ := m.Update(msg)
-	nm := out.(Model)
+	nm, _ := updateModel(m, msg)
 	entry := nm.projectLabels.byProject[pid]
 	if len(entry.labels) != 0 {
 		t.Fatalf("stale gen=1 response must be rejected because "+
@@ -86,15 +93,14 @@ func TestLabelCache_DispatchStampsGenBeforeResponse(t *testing.T) {
 // are silently discarded so a slow first-dispatch can't overwrite a
 // freshly-invalidated cache entry.
 func TestLabelCache_StaleGenResponseDropped(t *testing.T) {
-	m := buildModelWithLabelCache(t)
 	pid := int64(7)
-	m.scope = scope{projectID: pid}
+	m := setupScopedModel(t, pid)
 	m, _ = m.dispatchLabelFetch(pid) // gen=1
 	m, _ = m.dispatchLabelFetch(pid) // gen=2 (newer)
-	out, _ := m.Update(labelsFetchedMsg{
+	nm, _ := updateModel(m, labelsFetchedMsg{
 		pid: pid, gen: 1, labels: []LabelCount{{Label: "old", Count: 1}},
 	})
-	entry := out.(Model).projectLabels.byProject[pid]
+	entry := nm.projectLabels.byProject[pid]
 	if len(entry.labels) != 0 {
 		t.Fatalf("stale gen=1 response must NOT populate cache "+
 			"(cache.gen=2); got labels=%v", entry.labels)
@@ -115,8 +121,7 @@ func TestLabelCache_StaleGenResponseDropped(t *testing.T) {
 // scope to pid=8, then send the pid=7 response. Assert the pid=7
 // entry IS populated AND fetching=false — that's the new contract.
 func TestLabelCache_InactiveProjectResponseStillPopulatesCache(t *testing.T) {
-	m := buildModelWithLabelCache(t)
-	m.scope = scope{projectID: 7} // active project is 7
+	m := setupScopedModel(t, 7) // active project is 7
 	// Dispatch creates the entry for pid=7 with gen=1, fetching=true.
 	m, _ = m.dispatchLabelFetch(7)
 	// User switches project to pid=8 BEFORE the response lands.
@@ -124,11 +129,11 @@ func TestLabelCache_InactiveProjectResponseStillPopulatesCache(t *testing.T) {
 	// Response for pid=7 arrives from the now-inactive fetch. The
 	// per-project cache must accept it — the entry's pid matches the
 	// message's pid, so the data goes in the right slot.
-	out, _ := m.Update(labelsFetchedMsg{
+	nm, _ := updateModel(m, labelsFetchedMsg{
 		pid: 7, gen: 1,
 		labels: []LabelCount{{Label: "from7", Count: 1}},
 	})
-	entry := out.(Model).projectLabels.byProject[7]
+	entry := nm.projectLabels.byProject[7]
 	if len(entry.labels) != 1 || entry.labels[0].Label != "from7" {
 		t.Fatalf("response for pid=7 must populate the pid=7 cache "+
 			"entry even when target is pid=8 (cache is per-project); "+
@@ -148,8 +153,7 @@ func TestLabelCache_InactiveProjectResponseStillPopulatesCache(t *testing.T) {
 // ListLabels fetch. Mirrors maybeRefetchLabels's SSE gate so the two
 // invalidation paths behave identically.
 func TestBatchLabelRefresh_GatesOnCacheExistence(t *testing.T) {
-	m := buildModelWithLabelCache(t)
-	m.scope = scope{projectID: 7}
+	m := setupScopedModel(t, 7)
 	// No cache entry for pid=7 — the user never opened the menu.
 	mut := mutationDoneMsg{
 		kind: "label.add",
@@ -172,8 +176,7 @@ func TestBatchLabelRefresh_GatesOnCacheExistence(t *testing.T) {
 // against the project at least once), a successful label mutation
 // MUST dispatch a refresh so the menu's count column stays accurate.
 func TestBatchLabelRefresh_DispatchesWhenEntryExists(t *testing.T) {
-	m := buildModelWithLabelCache(t)
-	m.scope = scope{projectID: 7}
+	m := setupScopedModel(t, 7)
 	// Prime an entry as if the user had previously opened the menu.
 	m.projectLabels.byProject[7] = labelCacheEntry{
 		pid: 7, gen: 1,
@@ -224,9 +227,8 @@ func TestMutAffectsLabelCounts_AllRelevantKinds(t *testing.T) {
 // list/detail refetch path is independent — this test asserts the
 // suggestion-cache invalidation specifically.
 func TestLabelCache_SSEEventInvalidatesSuggestionCacheOnly(t *testing.T) {
-	m := buildModelWithLabelCache(t)
 	pid := int64(7)
-	m.scope = scope{projectID: pid}
+	m := setupScopedModel(t, pid)
 	m.cache = newIssueCache()
 	m.sseCh = nil // no SSE bridge to re-arm
 	m.nextLabelsGen = 5
@@ -234,10 +236,9 @@ func TestLabelCache_SSEEventInvalidatesSuggestionCacheOnly(t *testing.T) {
 		labels: []LabelCount{{Label: "stale", Count: 1}},
 		gen:    5, pid: pid,
 	}
-	out, _ := m.Update(eventReceivedMsg{
+	nm, _ := updateModel(m, eventReceivedMsg{
 		eventType: "issue.labeled", projectID: pid, issueNumber: 42,
 	})
-	nm := out.(Model)
 	entry := nm.projectLabels.byProject[pid]
 	if !entry.fetching {
 		t.Fatal("SSE event must trigger refetch (fetching=true)")

--- a/internal/tui/label_prompt_test.go
+++ b/internal/tui/label_prompt_test.go
@@ -36,35 +36,30 @@ func labelPromptFixture() Model {
 	return m
 }
 
+// assertHighlight fails the test unless the suggestion menu's
+// highlight index matches want.
+func assertHighlight(t *testing.T, m Model, want int) {
+	t.Helper()
+	if got := m.input.suggestHighlight; got != want {
+		t.Fatalf("suggestHighlight = %d, want %d", got, want)
+	}
+}
+
 // TestLabelPrompt_ArrowKeys_MoveHighlight_WithWrap: pressing ↓ four
 // times wraps from index 0 → 1 → 2 → 0 (3 entries). Then ↑ wraps
 // 0 → 2.
 func TestLabelPrompt_ArrowKeys_MoveHighlight_WithWrap(t *testing.T) {
 	m := labelPromptFixture()
-	// Down to 1.
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
-	m = out.(Model)
-	if got := m.input.suggestHighlight; got != 1 {
-		t.Fatalf("highlight = %d after 1 down, want 1", got)
-	}
-	// Down to 2.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
-	m = out.(Model)
-	if got := m.input.suggestHighlight; got != 2 {
-		t.Fatalf("highlight = %d after 2 down, want 2", got)
-	}
+	m = sendKey(m, tea.KeyDown)
+	assertHighlight(t, m, 1)
+	m = sendKey(m, tea.KeyDown)
+	assertHighlight(t, m, 2)
 	// Down wraps to 0.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
-	m = out.(Model)
-	if got := m.input.suggestHighlight; got != 0 {
-		t.Fatalf("highlight = %d after wrap-down, want 0", got)
-	}
+	m = sendKey(m, tea.KeyDown)
+	assertHighlight(t, m, 0)
 	// Up wraps from 0 → 2.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
-	m = out.(Model)
-	if got := m.input.suggestHighlight; got != 2 {
-		t.Fatalf("highlight = %d after wrap-up, want 2", got)
-	}
+	m = sendKey(m, tea.KeyUp)
+	assertHighlight(t, m, 2)
 }
 
 // TestLabelPrompt_TabCompletesHighlightedSuggestion: with the
@@ -74,10 +69,8 @@ func TestLabelPrompt_TabCompletesHighlightedSuggestion(t *testing.T) {
 	m := labelPromptFixture()
 	// Move highlight to beta (sorted by count desc: alpha=5, beta=3,
 	// gamma=1, so beta is index 1).
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
-	m = out.(Model)
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
+	m = sendKey(m, tea.KeyDown)
+	m = sendKey(m, tea.KeyTab)
 	if got := m.input.activeField().value(); got != "beta" {
 		t.Fatalf("buffer = %q after tab on beta, want %q", got, "beta")
 	}
@@ -143,22 +136,16 @@ func TestLabelPrompt_EnterCommitsCurrentBuffer(t *testing.T) {
 	m := labelPromptFixture()
 	m.input.activeField().input.SetValue("freshlabel")
 	m.input.fields[0] = *m.input.activeField()
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	nm := out.(Model)
-	if nm.input.kind != inputNone {
-		t.Fatalf("input kind after enter = %v, want inputNone", nm.input.kind)
-	}
+	nm := sendKey(m, tea.KeyEnter)
+	assertInputKind(t, nm, inputNone)
 }
 
 // TestLabelPrompt_EscClosesPromptAndMenu: esc cancels the input,
 // closing both the prompt and the menu.
 func TestLabelPrompt_EscClosesPromptAndMenu(t *testing.T) {
 	m := labelPromptFixture()
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	nm := out.(Model)
-	if nm.input.kind != inputNone {
-		t.Fatalf("input kind after esc = %v, want inputNone", nm.input.kind)
-	}
+	nm := sendKey(m, tea.KeyEsc)
+	assertInputKind(t, nm, inputNone)
 }
 
 // TestSuggestMenu_BodyKeepsFullHeight_AndChromeStaysAtBottom: when

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -70,8 +70,7 @@ func TestLayout_ResizeSplitToStacked_PreservesSelectionFocusDetail(t *testing.T)
 	m, cleanup := layoutTestSetup(t)
 	defer cleanup()
 	// Boot into split layout.
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
 	if m.layout != layoutSplit {
 		t.Fatalf("setup failed: layout=%v want split", m.layout)
 	}
@@ -82,8 +81,7 @@ func TestLayout_ResizeSplitToStacked_PreservesSelectionFocusDetail(t *testing.T)
 	m.focus = focusDetail
 	m.list.selectedNumber = 42
 	// Resize down across the breakpoint.
-	out, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	if m.layout != layoutStacked {
 		t.Errorf("layout=%v after resize, want layoutStacked", m.layout)
 	}
@@ -101,12 +99,10 @@ func TestLayout_ResizeSplitToStacked_PreservesSelectionFocusDetail(t *testing.T)
 func TestLayout_ResizeSplitToStacked_PreservesSelectionFocusList(t *testing.T) {
 	m, cleanup := layoutTestSetup(t)
 	defer cleanup()
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
 	m.focus = focusList
 	m.list.selectedNumber = 99
-	out, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	if m.layout != layoutStacked {
 		t.Errorf("layout=%v after resize, want layoutStacked", m.layout)
 	}
@@ -125,14 +121,12 @@ func TestLayout_ResizeStackedToSplit_PreservesFocusFromList(t *testing.T) {
 	m, cleanup := layoutTestSetup(t)
 	defer cleanup()
 	// Start stacked, viewList.
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	if m.layout != layoutStacked || m.view != viewList {
 		t.Fatalf("setup failed: layout=%v view=%v", m.layout, m.view)
 	}
 	// Resize up across the breakpoint.
-	out, _ = m.Update(tea.WindowSizeMsg{Width: 160, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
 	if m.layout != layoutSplit {
 		t.Errorf("layout=%v after resize, want layoutSplit", m.layout)
 	}
@@ -147,13 +141,11 @@ func TestLayout_ResizeStackedToSplit_PreservesFocusFromList(t *testing.T) {
 func TestLayout_ResizeStackedToSplit_PreservesFocusFromDetail(t *testing.T) {
 	m, cleanup := layoutTestSetup(t)
 	defer cleanup()
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	iss := m.list.issues[0]
 	m.detail.issue = &iss
 	m.view = viewDetail
-	out, _ = m.Update(tea.WindowSizeMsg{Width: 160, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
 	if m.layout != layoutSplit {
 		t.Errorf("layout=%v after resize, want layoutSplit", m.layout)
 	}
@@ -195,16 +187,14 @@ func TestLayout_SplitListPaneWidth_GrowsWithTerminal(t *testing.T) {
 func TestLayout_ToggleLayout_FromSplitToStacked(t *testing.T) {
 	m, cleanup := layoutTestSetup(t)
 	defer cleanup()
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
 	if m.layout != layoutSplit {
 		t.Fatalf("setup failed: layout=%v want split", m.layout)
 	}
 	iss := m.list.issues[0]
 	m.detail.issue = &iss
 	m.focus = focusDetail
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
-	m = out.(Model)
+	m = sendRune(m, 'L')
 	if m.layout != layoutStacked {
 		t.Errorf("layout=%v after L toggle, want layoutStacked", m.layout)
 	}
@@ -214,8 +204,7 @@ func TestLayout_ToggleLayout_FromSplitToStacked(t *testing.T) {
 	if m.view != viewDetail {
 		t.Errorf("view=%v after toggle from focusDetail, want viewDetail", m.view)
 	}
-	out, _ = m.Update(tea.WindowSizeMsg{Width: 200, Height: 50})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 200, Height: 50})
 	if m.layout != layoutStacked {
 		t.Errorf("layout=%v after resize while locked, want layoutStacked", m.layout)
 	}
@@ -227,15 +216,12 @@ func TestLayout_ToggleLayout_FromStackedToSplit(t *testing.T) {
 	m, cleanup := layoutTestSetup(t)
 	defer cleanup()
 	// Boot in a split-eligible terminal but force-stacked first.
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 40})
-	m = out.(Model)
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	m = sendRune(m, 'L')
 	if m.layout != layoutStacked {
 		t.Fatalf("setup failed: layout=%v want stacked after first L", m.layout)
 	}
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
-	m = out.(Model)
+	m = sendRune(m, 'L')
 	if m.layout != layoutSplit {
 		t.Errorf("layout=%v after second L toggle, want layoutSplit", m.layout)
 	}
@@ -251,13 +237,11 @@ func TestLayout_ToggleLayout_FromStackedToSplit(t *testing.T) {
 func TestLayout_ToggleLayout_RefusesSplitOnTooNarrowTerminal(t *testing.T) {
 	m, cleanup := layoutTestSetup(t)
 	defer cleanup()
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	if m.layout != layoutStacked {
 		t.Fatalf("setup failed: layout=%v want stacked", m.layout)
 	}
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
-	m = out.(Model)
+	m = sendRune(m, 'L')
 	if m.layout != layoutStacked {
 		t.Errorf("layout=%v after L on too-narrow term, want layoutStacked", m.layout)
 	}

--- a/internal/tui/list_filter_test.go
+++ b/internal/tui/list_filter_test.go
@@ -95,6 +95,14 @@ func runeKey(r rune) tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
 }
 
+// newListEnv returns the standard test trio for listModel.Update calls:
+// a fresh fakeListAPI, a default keymap, and a single-project scope
+// (projectID: 7). The api is returned by pointer so callers can seed
+// result/error fields before invoking Update.
+func newListEnv() (*fakeListAPI, keymap, scope) {
+	return &fakeListAPI{}, newKeymap(), scope{projectID: 7}
+}
+
 // drainCmd executes the tea.Cmd returned by Update once and feeds the
 // resulting message back into Update so the test sees the post-fetch
 // state. Returns the second-pass model so chains stay one-line.
@@ -113,9 +121,7 @@ func drainCmd(
 // TestList_StatusCycle confirms `s` cycles "" → open → closed → "" without
 // refetching. Status now filters the cached all-status working set.
 func TestList_StatusCycle(t *testing.T) {
-	api := &fakeListAPI{}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
 	lm := listModel{issues: []Issue{
 		{Number: 1, Status: "open"},
 		{Number: 2, Status: "closed"},
@@ -155,9 +161,7 @@ func TestList_StatusCycle(t *testing.T) {
 }
 
 func TestList_StatusOpenDoesNotAutoExpandMatchingChildren(t *testing.T) {
-	api := &fakeListAPI{}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
 	parent := int64(1)
 	lm := listModel{issues: []Issue{
 		{
@@ -187,9 +191,7 @@ func TestList_StatusOpenDoesNotAutoExpandMatchingChildren(t *testing.T) {
 }
 
 func TestList_StatusOpenPromotesChildWhenParentClosed(t *testing.T) {
-	api := &fakeListAPI{}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
 	parent := int64(17)
 	lm := listModel{issues: []Issue{
 		{
@@ -335,10 +337,7 @@ func openBarFromCmd(t *testing.T, m Model, key rune) Model {
 // and does not dispatch a refetch. There is no IncludeDeleted slot today (see
 // ListFilter doc) so the post-state is the zero value.
 func TestList_ClearFilters_ZeroesEveryField(t *testing.T) {
-	api := &fakeListAPI{}
-	km := newKeymap()
-	sc := scope{projectID: 7}
-
+	api, km, sc := newListEnv()
 	lm := listModel{filter: ListFilter{
 		Status: "open", Owner: "wes", Search: "bug",
 		Labels: []string{"prio-1"},
@@ -382,9 +381,7 @@ func TestList_ApplyFetched_SetsTruncatedAboveWorkingSetLimitAndTrims(t *testing.
 // previously j moved through all issues and the marker landed on the
 // wrong (sometimes invisible) row.
 func TestList_Cursor_MovesInFilteredSpace(t *testing.T) {
-	api := &fakeListAPI{}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
 	lm := listModel{
 		filter: ListFilter{Owner: "alice"},
 		issues: []Issue{
@@ -412,9 +409,7 @@ func TestList_Cursor_MovesInFilteredSpace(t *testing.T) {
 }
 
 func TestList_ExpandCollapse(t *testing.T) {
-	api := &fakeListAPI{}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
 	lm := listModel{
 		issues: []Issue{
 			{ProjectID: 7, Number: 1, ChildCounts: &ChildCounts{Open: 1, Total: 1}},
@@ -436,9 +431,7 @@ func TestList_ExpandCollapse(t *testing.T) {
 }
 
 func TestList_ExpandCollapse_LeafNoOp(t *testing.T) {
-	api := &fakeListAPI{}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
 	lm := listModel{issues: []Issue{{ProjectID: 7, Number: 1}}}
 
 	next, cmd := lm.Update(tea.KeyMsg{Type: tea.KeySpace}, km, api, sc)
@@ -617,9 +610,8 @@ func TestList_QuitGate_RoutesQuitToBuffer(t *testing.T) {
 // TestList_RefetchError_PutsErrOnModel ensures fetch failures surface in
 // lm.err so View renders the error state and the user can retry.
 func TestList_RefetchError_PutsErrOnModel(t *testing.T) {
-	api := &fakeListAPI{listIssuesErr: errors.New("boom")}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
+	api.listIssuesErr = errors.New("boom")
 
 	lm := listModel{}
 	cmd := lm.refetchCmd(api, sc)
@@ -803,11 +795,8 @@ func TestList_AuthorFilter_NarrowsDisplay(t *testing.T) {
 // the row 2 issue's number, threading the actor through. The fixture
 // uses two rows so cursor!=0 is observable.
 func TestList_Close_DispatchesAPI(t *testing.T) {
-	api := &fakeListAPI{
-		closeResult: &MutationResp{Issue: &Issue{Number: 2, Status: "closed"}},
-	}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
+	api.closeResult = &MutationResp{Issue: &Issue{Number: 2, Status: "closed"}}
 	lm := listModel{
 		actor: "tester",
 		issues: []Issue{
@@ -840,11 +829,8 @@ func TestList_Close_DispatchesAPI(t *testing.T) {
 // TestList_Reopen_DispatchesAPI mirrors TestList_Close_DispatchesAPI for
 // the 'r' binding.
 func TestList_Reopen_DispatchesAPI(t *testing.T) {
-	api := &fakeListAPI{
-		reopenResult: &MutationResp{Issue: &Issue{Number: 1, Status: "open"}},
-	}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
+	api.reopenResult = &MutationResp{Issue: &Issue{Number: 1, Status: "open"}}
 	lm := listModel{
 		actor: "tester",
 		issues: []Issue{
@@ -869,9 +855,7 @@ func TestList_Reopen_DispatchesAPI(t *testing.T) {
 // TestList_Close_EmptyListNoOp: 'x' on an empty list does not call
 // api.Close and does not panic.
 func TestList_Close_EmptyListNoOp(t *testing.T) {
-	api := &fakeListAPI{}
-	km := newKeymap()
-	sc := scope{projectID: 7}
+	api, km, sc := newListEnv()
 	lm := listModel{actor: "tester"}
 
 	_, cmd := lm.Update(runeKey('x'), km, api, sc)

--- a/internal/tui/list_render_test.go
+++ b/internal/tui/list_render_test.go
@@ -13,7 +13,7 @@ import (
 // rendered alphabetically regardless of caller order. Sort is in-render
 // so callers don't have to pre-sort the daemon's response.
 func TestRenderLabelChips_AlphabeticalSort(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	got := renderLabelChips([]string{"prio-1", "bug", "needs-design"}, 80)
 	bug := strings.Index(got, "[bug]")
 	needs := strings.Index(got, "[needs-design]")
@@ -31,7 +31,7 @@ func TestRenderLabelChips_AlphabeticalSort(t *testing.T) {
 // so not every chip fits; the renderer must drop the tail and append
 // `+N` indicating the count of dropped labels.
 func TestRenderLabelChips_PacksUntilOverflow(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	got := renderLabelChips([]string{"a", "b", "c", "d", "e"}, 12)
 	if !strings.Contains(got, "+") {
 		t.Fatalf("expected +N overflow marker in %q", got)
@@ -46,7 +46,7 @@ func TestRenderLabelChips_PacksUntilOverflow(t *testing.T) {
 // formed correctly (literal +, then a base-10 integer >= 1) when the
 // chip pack drops chips.
 func TestRenderLabelChips_PlusNOverflowFormat(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	got := renderLabelChips([]string{"alpha", "beta", "gamma", "delta"}, 14)
 	idx := strings.Index(got, "+")
 	if idx < 0 {
@@ -63,7 +63,7 @@ func TestRenderLabelChips_PlusNOverflowFormat(t *testing.T) {
 // degraded form when even one chip won't fit. The fallback keeps the
 // header informative on tiny terminals.
 func TestRenderLabelChips_UltraNarrowFallback(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	got := renderLabelChips([]string{"bug", "prio-1"}, 5)
 	if !strings.Contains(got, "[2 labels]") {
 		t.Fatalf("expected ultra-narrow fallback [2 labels] in %q", got)
@@ -73,7 +73,7 @@ func TestRenderLabelChips_UltraNarrowFallback(t *testing.T) {
 // TestRenderLabelChips_EmptyLabels verifies the empty-labels placeholder
 // renders so the header layout doesn't shift when labels are absent.
 func TestRenderLabelChips_EmptyLabels(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	got := renderLabelChips(nil, 80)
 	if !strings.Contains(got, "(no labels)") {
 		t.Fatalf("expected (no labels) placeholder in %q", got)
@@ -95,17 +95,12 @@ func TestRenderLabelChips_EmptyLabels(t *testing.T) {
 // of the sanitized "カタ" (4 cells), or measured byte length instead
 // of cell width, the math would be wrong and the test would fail.
 func TestRenderLabelChips_WidthMeasureUsesRunewidth(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	got := renderLabelChips([]string{"\x1b[31mカタ", "bug"}, 11)
 	if strings.Contains(got, "\x1b") {
 		t.Fatalf("ESC survived width-measure path: %q", got)
 	}
-	if !strings.Contains(got, "[bug]") {
-		t.Fatalf("expected [bug] chip in %q", got)
-	}
-	if !strings.Contains(got, "+1") {
-		t.Fatalf("expected +1 overflow in %q", got)
-	}
+	assertContainsAll(t, got, "[bug]", "+1")
 	if w := runewidth.StringWidth(got); w > 11 {
 		t.Fatalf("rendered width %d exceeds budget 11: %q", w, got)
 	}
@@ -121,7 +116,7 @@ func TestRenderLabelChips_WidthMeasureUsesRunewidth(t *testing.T) {
 // escapes and a U+202E RIGHT-TO-LEFT OVERRIDE must not survive into
 // the rendered output.
 func TestRenderLabelChips_RenderedTextSanitized(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	rlo := rune(0x202E)
 	hostile := "ok" + string(rlo) + "pad"
 	got := renderLabelChips([]string{"bug\x1b[2J", hostile}, 80)
@@ -144,7 +139,7 @@ func TestRenderLabelChips_RenderedTextSanitized(t *testing.T) {
 // `Project: —` rather than the empty `Project: ` form, preserving
 // the "left side never blank" invariant.
 func TestTitleBarLeft_SanitizeEmptyFallsBackToPlaceholder(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	// String of pure control runes — sanitizeForDisplay strips them.
 	got := titleBarLeft(scope{projectName: "\x01\x02\x07"})
 	if got != "Project: —" {
@@ -179,7 +174,7 @@ func TestTitleBarLeft_SanitizeEmptyFallsBackToPlaceholder(t *testing.T) {
 // of this test used budget=30 where both reserves happened to pack
 // the same number of chips, so it would not catch the regression.
 func TestRenderLabelChips_LargeOverflowReservesActualWidth(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	labels := make([]string, 150)
 	for i := range labels {
 		labels[i] = "bug"
@@ -204,7 +199,7 @@ func TestRenderLabelChips_LargeOverflowReservesActualWidth(t *testing.T) {
 // but the TUI is the wrong layer to depend on that; this test guards
 // the renderer-level invariant directly.
 func TestRenderLabelChips_NewlineInLabelDoesNotBreakRow(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	got := renderLabelChips([]string{"bug\nfoo"}, 80)
 	if strings.ContainsRune(got, '\n') {
 		t.Fatalf("literal newline survived in chip strip: %q", got)
@@ -226,7 +221,7 @@ func TestDisclosureGlyph(t *testing.T) {
 		t.Fatalf("expanded glyph = %q, want ▾", got)
 	}
 
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	if got := disclosureGlyph(true, false); got != "+" {
 		t.Fatalf("no-color collapsed glyph = %q, want +", got)
 	}
@@ -236,7 +231,7 @@ func TestDisclosureGlyph(t *testing.T) {
 }
 
 func TestRenderListBody_UsesQueueRowsWithDisclosureAndChildCounts(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	parentNum := int64(1)
 	lm := listModel{issues: []Issue{
 		{
@@ -246,29 +241,17 @@ func TestRenderListBody_UsesQueueRowsWithDisclosureAndChildCounts(t *testing.T) 
 		{ProjectID: 7, Number: 2, ParentNumber: &parentNum, Title: "child", Status: "open"},
 	}}
 
-	collapsed := stripANSI(lm.renderBody(100, 6, viewChrome{}))
-	if !strings.Contains(collapsed, "+") {
-		t.Fatalf("collapsed parent missing disclosure glyph:\n%s", collapsed)
-	}
-	if !strings.Contains(collapsed, "1/2") {
-		t.Fatalf("collapsed parent missing child count:\n%s", collapsed)
-	}
-	if strings.Contains(collapsed, "child") {
-		t.Fatalf("collapsed tree rendered child row:\n%s", collapsed)
-	}
+	collapsed := renderBodyNoColor(lm, 100, 6, viewChrome{})
+	assertContainsAll(t, collapsed, "+", "1/2")
+	assertStringsLack(t, collapsed, "child")
 
 	lm.expanded = expansionSet{{projectID: 7, number: parentNum}: true}
-	expanded := stripANSI(lm.renderBody(100, 6, viewChrome{}))
-	if !strings.Contains(expanded, "-") {
-		t.Fatalf("expanded parent missing disclosure glyph:\n%s", expanded)
-	}
-	if !strings.Contains(expanded, "child") {
-		t.Fatalf("expanded tree missing child row:\n%s", expanded)
-	}
+	expanded := renderBodyNoColor(lm, 100, 6, viewChrome{})
+	assertContainsAll(t, expanded, "-", "child")
 }
 
 func TestRenderListBody_ContextRowHasVisibleMarkerInNoColor(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	parentNum := int64(1)
 	lm := listModel{
 		issues: []Issue{
@@ -278,13 +261,8 @@ func TestRenderListBody_ContextRowHasVisibleMarkerInNoColor(t *testing.T) {
 		filter: ListFilter{Search: "login"},
 	}
 
-	got := stripANSI(lm.renderBody(100, 6, viewChrome{}))
-	if !strings.Contains(got, "~") {
-		t.Fatalf("context row missing no-color marker:\n%s", got)
-	}
-	if !strings.Contains(got, "parent") || !strings.Contains(got, "child login") {
-		t.Fatalf("context render missing ancestor or child:\n%s", got)
-	}
+	got := renderBodyNoColor(lm, 100, 6, viewChrome{})
+	assertContainsAll(t, got, "~", "parent", "child login")
 }
 
 // TestRenderListBody_AllProjectsPrefixesTitle pins the navigation contract
@@ -292,7 +270,7 @@ func TestRenderListBody_ContextRowHasVisibleMarkerInNoColor(t *testing.T) {
 // the owning project's display name from chrome.projectsByID, so the user
 // can tell which project a row belongs to without expanding detail.
 func TestRenderListBody_AllProjectsPrefixesTitle(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	lm := listModel{issues: []Issue{
 		{ProjectID: 7, Number: 1, Title: "alpha bug", Status: "open"},
 		{ProjectID: 9, Number: 1, Title: "beta bug", Status: "open"},
@@ -301,13 +279,8 @@ func TestRenderListBody_AllProjectsPrefixesTitle(t *testing.T) {
 		scope:        scope{allProjects: true},
 		projectsByID: map[int64]string{7: "alpha", 9: "beta"},
 	}
-	got := stripANSI(lm.renderBody(120, 6, chrome))
-	if !strings.Contains(got, "[alpha] alpha bug") {
-		t.Fatalf("all-projects render missing alpha prefix:\n%s", got)
-	}
-	if !strings.Contains(got, "[beta] beta bug") {
-		t.Fatalf("all-projects render missing beta prefix:\n%s", got)
-	}
+	got := renderBodyNoColor(lm, 120, 6, chrome)
+	assertContainsAll(t, got, "[alpha] alpha bug", "[beta] beta bug")
 }
 
 // TestRenderListBody_AllProjectsFallsBackToPID pins the degraded path: a
@@ -315,7 +288,7 @@ func TestRenderListBody_AllProjectsPrefixesTitle(t *testing.T) {
 // project before the next /projects refresh) renders as "[#PID]" rather
 // than appearing nameless.
 func TestRenderListBody_AllProjectsFallsBackToPID(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	lm := listModel{issues: []Issue{
 		{ProjectID: 42, Number: 1, Title: "ghost project", Status: "open"},
 	}}
@@ -323,7 +296,7 @@ func TestRenderListBody_AllProjectsFallsBackToPID(t *testing.T) {
 		scope:        scope{allProjects: true},
 		projectsByID: map[int64]string{},
 	}
-	got := stripANSI(lm.renderBody(120, 6, chrome))
+	got := renderBodyNoColor(lm, 120, 6, chrome)
 	if !strings.Contains(got, "[#42] ghost project") {
 		t.Fatalf("missing-project render must fall back to [#PID]:\n%s", got)
 	}
@@ -333,7 +306,7 @@ func TestRenderListBody_AllProjectsFallsBackToPID(t *testing.T) {
 // single-project scope the prefix is omitted (every row belongs to the
 // same project, so repeating the name is noise).
 func TestRenderListBody_SingleProjectOmitsPrefix(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	lm := listModel{issues: []Issue{
 		{ProjectID: 7, Number: 1, Title: "alpha bug", Status: "open"},
 	}}
@@ -341,17 +314,15 @@ func TestRenderListBody_SingleProjectOmitsPrefix(t *testing.T) {
 		scope:        scope{projectID: 7, projectName: "alpha"},
 		projectsByID: map[int64]string{7: "alpha"},
 	}
-	got := stripANSI(lm.renderBody(120, 6, chrome))
-	if strings.Contains(got, "[alpha]") {
-		t.Fatalf("single-project render must not prefix project name:\n%s", got)
-	}
+	got := renderBodyNoColor(lm, 120, 6, chrome)
+	assertStringsLack(t, got, "[alpha]")
 	if !strings.Contains(got, "alpha bug") {
 		t.Fatalf("title missing in single-project render:\n%s", got)
 	}
 }
 
 func TestRenderListInfoLine_TruncationNotice(t *testing.T) {
-	applyColorMode(colorNone, io.Discard)
+	useNoColor(t)
 	lm := listModel{truncated: true, issues: []Issue{{Number: 1, Status: "open"}}}
 	got := stripANSI(renderListInfoLine(100, viewChrome{}, lm, 10))
 	want := "showing first 2000 issues; refine filters"

--- a/internal/tui/list_test.go
+++ b/internal/tui/list_test.go
@@ -42,24 +42,33 @@ func listFixture() []Issue {
 	}
 }
 
-// TestList_Render_Fixture confirms the seed reaches the screen so the
-// rendering layer can be reviewed independent of the network layer. The
-// [deleted] assertion guards statusChip's soft-delete branch.
-func TestList_Render_Fixture(t *testing.T) {
+// setupListTeatest boots a teatest model at 120x30, seeds the standard
+// listFixture, and registers a ctrl+c fast-quit cleanup. q opens the
+// quit-confirm modal in M3.5b; ctrl+c bypasses the confirm so tests
+// terminate without an extra `y` keystroke + race on the modal.
+func setupListTeatest(t *testing.T) *teatest.TestModel {
+	t.Helper()
 	m := initialModel(Options{})
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 30))
 	tm.Send(tea.WindowSizeMsg{Width: 120, Height: 30})
 	tm.Send(initialFetchMsg{dispatchKey: cacheKey{limit: queueFetchLimit}, issues: listFixture()})
+	t.Cleanup(func() {
+		tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+		tm.WaitFinished(t)
+	})
+	return tm
+}
+
+// TestList_Render_Fixture confirms the seed reaches the screen so the
+// rendering layer can be reviewed independent of the network layer. The
+// [deleted] assertion guards statusChip's soft-delete branch.
+func TestList_Render_Fixture(t *testing.T) {
+	tm := setupListTeatest(t)
 	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
 		s := string(b)
 		return strings.Contains(s, "fix login bug on Safari") &&
 			strings.Contains(s, "[deleted]")
 	}, teatest.WithDuration(2*time.Second))
-	// q opens the quit-confirm modal in M3.5b; ctrl+c is the fast-quit
-	// path that bypasses the confirm. Use ctrl+c here so the test can
-	// terminate without an extra `y` keystroke + race on the modal.
-	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
-	tm.WaitFinished(t)
 }
 
 // TestList_Cursor_DownAndUp drives j/j/k against the three-row fixture
@@ -69,10 +78,7 @@ func TestList_Render_Fixture(t *testing.T) {
 // columns, so we scan output line-by-line for one that contains both the
 // marker and the row's issue number.
 func TestList_Cursor_DownAndUp(t *testing.T) {
-	m := initialModel(Options{})
-	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 30))
-	tm.Send(tea.WindowSizeMsg{Width: 120, Height: 30})
-	tm.Send(initialFetchMsg{dispatchKey: cacheKey{limit: queueFetchLimit}, issues: listFixture()})
+	tm := setupListTeatest(t)
 	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
 		return strings.Contains(string(b), "purge stale tokens")
 	}, teatest.WithDuration(2*time.Second))
@@ -87,9 +93,4 @@ func TestList_Cursor_DownAndUp(t *testing.T) {
 		}
 		return false
 	}, teatest.WithDuration(2*time.Second))
-	// q opens the quit-confirm modal in M3.5b; ctrl+c is the fast-quit
-	// path that bypasses the confirm. Use ctrl+c here so the test can
-	// terminate without an extra `y` keystroke + race on the modal.
-	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
-	tm.WaitFinished(t)
 }

--- a/internal/tui/narrow_terminal_test.go
+++ b/internal/tui/narrow_terminal_test.go
@@ -27,6 +27,22 @@ func narrowTestSetup(t *testing.T) (Model, func()) {
 	return m, cleanup
 }
 
+// assertHintVisible fails t when the rendered View's hint-marker
+// presence doesn't match want. Folds the verbose Contains+Fatalf
+// pattern that the narrow-terminal tests repeat for both polarities.
+func assertHintVisible(t *testing.T, m Model, want bool) {
+	t.Helper()
+	view := m.View()
+	got := strings.Contains(view, narrowHintMarker)
+	if got == want {
+		return
+	}
+	if want {
+		t.Fatalf("view missing hint marker %q; got:\n%s", narrowHintMarker, view)
+	}
+	t.Fatalf("view unexpectedly contains hint marker %q; got:\n%s", narrowHintMarker, view)
+}
+
 // TestNarrowTerminal_NarrowWidthShowsHint verifies that a sub-80-column
 // width trips the M5 short-circuit and renders the centered hint
 // regardless of how tall the terminal is.
@@ -34,13 +50,8 @@ func TestNarrowTerminal_NarrowWidthShowsHint(t *testing.T) {
 	m, cleanup := narrowTestSetup(t)
 	defer cleanup()
 
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 24})
-	m = out.(Model)
-	got := m.View()
-	if !strings.Contains(got, narrowHintMarker) {
-		t.Fatalf("narrow width view missing hint marker %q; got:\n%s",
-			narrowHintMarker, got)
-	}
+	m = resizeModel(m, 60, 24)
+	assertHintVisible(t, m, true)
 }
 
 // TestNarrowTerminal_ShortHeightRendersNormally verifies that a short
@@ -53,13 +64,9 @@ func TestNarrowTerminal_ShortHeightRendersNormally(t *testing.T) {
 	m.list.issues = []Issue{{ProjectID: 7, Number: 1, Title: "short pane", Status: "open"}}
 	m.scope = scope{projectID: 7, projectName: "kata"}
 
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 12})
-	m = out.(Model)
-	got := m.View()
-	if strings.Contains(got, narrowHintMarker) {
-		t.Fatalf("short-height view unexpectedly contains hint marker; got:\n%s", got)
-	}
-	if !strings.Contains(got, "short pane") {
+	m = resizeModel(m, 120, 12)
+	assertHintVisible(t, m, false)
+	if got := m.View(); !strings.Contains(got, "short pane") {
 		t.Fatalf("short-height view missing list content; got:\n%s", got)
 	}
 }
@@ -70,13 +77,8 @@ func TestNarrowTerminal_BothNarrowShowsHint(t *testing.T) {
 	m, cleanup := narrowTestSetup(t)
 	defer cleanup()
 
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 12})
-	m = out.(Model)
-	got := m.View()
-	if !strings.Contains(got, narrowHintMarker) {
-		t.Fatalf("both-narrow view missing hint marker %q; got:\n%s",
-			narrowHintMarker, got)
-	}
+	m = resizeModel(m, 60, 12)
+	assertHintVisible(t, m, true)
 }
 
 // TestNarrowTerminal_NormalSizeRendersNormally verifies the negative
@@ -88,13 +90,8 @@ func TestNarrowTerminal_NormalSizeRendersNormally(t *testing.T) {
 	m, cleanup := narrowTestSetup(t)
 	defer cleanup()
 
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
-	m = out.(Model)
-	got := m.View()
-	if strings.Contains(got, narrowHintMarker) {
-		t.Fatalf("normal-size view unexpectedly contains hint marker; got:\n%s",
-			got)
-	}
+	m = resizeModel(m, 120, 30)
+	assertHintVisible(t, m, false)
 }
 
 // TestNarrowTerminal_QStillRoutesToQuitConfirm proves that the View
@@ -106,10 +103,8 @@ func TestNarrowTerminal_QStillRoutesToQuitConfirm(t *testing.T) {
 	m, cleanup := narrowTestSetup(t)
 	defer cleanup()
 
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 12})
-	m = out.(Model)
-	out, cmd := m.Update(runeKey('q'))
-	nm := out.(Model)
+	m = resizeModel(m, 60, 12)
+	nm, cmd := updateModel(m, runeKey('q'))
 	if cmd != nil {
 		if msg := cmd(); msg != nil {
 			if _, isQuit := msg.(tea.QuitMsg); isQuit {
@@ -129,9 +124,8 @@ func TestNarrowTerminal_CtrlCStillQuits(t *testing.T) {
 	m, cleanup := narrowTestSetup(t)
 	defer cleanup()
 
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 12})
-	m = out.(Model)
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	m = resizeModel(m, 60, 12)
+	_, cmd := updateModel(m, tea.KeyMsg{Type: tea.KeyCtrlC})
 	if cmd == nil {
 		t.Fatal("ctrl+c at narrow size produced no cmd; expected tea.Quit")
 	}
@@ -149,11 +143,7 @@ func TestNarrowTerminal_ZeroWidthBeforeFirstResize_DoesNotShowHint(t *testing.T)
 	m, cleanup := narrowTestSetup(t)
 	defer cleanup()
 	// No WindowSizeMsg; m.width and m.height remain 0.
-	got := m.View()
-	if strings.Contains(got, narrowHintMarker) {
-		t.Fatalf("pre-resize View unexpectedly contains hint marker; got:\n%s",
-			got)
-	}
+	assertHintVisible(t, m, false)
 }
 
 // TestNarrowTerminal_QuitConfirmModalOverlaysHint covers roborev #250:
@@ -173,16 +163,13 @@ func TestNarrowTerminal_QuitConfirmModalOverlaysHint(t *testing.T) {
 	m, cleanup := narrowTestSetup(t)
 	defer cleanup()
 	// Resize to full width and open quit-confirm.
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
-	m = out.(Model)
-	out, _ = m.Update(runeKey('q'))
-	m = out.(Model)
+	m = resizeModel(m, 120, 30)
+	m = sendRune(m, 'q')
 	if m.modal != modalQuitConfirm {
 		t.Fatalf("modal = %v after q at full width, want modalQuitConfirm", m.modal)
 	}
 	// Now resize below threshold while the modal is still open.
-	out, _ = m.Update(tea.WindowSizeMsg{Width: 60, Height: 24})
-	m = out.(Model)
+	m = resizeModel(m, 60, 24)
 	view := m.View()
 	if !strings.Contains(view, "[Y]") {
 		t.Fatalf("quit-confirm modal hidden by narrow short-circuit; got:\n%s", view)

--- a/internal/tui/new_issue_form_test.go
+++ b/internal/tui/new_issue_form_test.go
@@ -55,18 +55,26 @@ func newIssueFormFixture() Model {
 // openInputCmd, returning a model with m.input.kind == inputNewIssueForm.
 func openNewIssueForm(t *testing.T, m Model) Model {
 	t.Helper()
-	out, cmd := m.Update(runeKey('n'))
-	m = out.(Model)
+	m, cmd := stepModel(m, runeKey('n'))
 	if cmd == nil {
 		t.Fatalf("press n produced no cmd; expected openInputCmd")
 	}
-	msg := cmd()
-	out, _ = m.Update(msg)
-	m = out.(Model)
-	if m.input.kind != inputNewIssueForm {
-		t.Fatalf("openInput did not land inputNewIssueForm; got %v", m.input.kind)
-	}
+	m, _ = stepModel(m, cmd())
+	assertInputKind(t, m, inputNewIssueForm)
 	return m
+}
+
+// primeLabelCache seeds m.projectLabels with a known entry for projectID
+// at gen so tests can detect dispatchLabelFetch effects (gen advance,
+// fetching=true) or, conversely, confirm a stale-message path left the
+// entry untouched.
+func primeLabelCache(m *Model, projectID, gen int64) {
+	m.projectLabels = newLabelCache()
+	m.projectLabels.byProject[projectID] = labelCacheEntry{
+		pid: projectID, gen: gen,
+		labels: []LabelCount{{Label: "old", Count: 1}},
+	}
+	m.nextLabelsGen = gen
 }
 
 func focusNewIssueField(s inputState, idx int) inputState {
@@ -102,14 +110,11 @@ func TestNewIssueForm_OpensOnNKey_ListView(t *testing.T) {
 func TestNewIssueForm_AllProjectsScopeIsNoOp(t *testing.T) {
 	m := newIssueFormFixture()
 	m.scope = scope{allProjects: true}
-	out, cmd := m.Update(runeKey('n'))
-	nm := out.(Model)
+	nm, cmd := stepModel(m, runeKey('n'))
 	if cmd != nil {
 		t.Fatalf("expected nil cmd in all-projects mode, got %T", cmd)
 	}
-	if nm.input.kind != inputNone {
-		t.Fatalf("input opened in all-projects mode: kind=%v", nm.input.kind)
-	}
+	assertInputKind(t, nm, inputNone)
 	if nm.list.status == "" {
 		t.Fatal("expected a status hint explaining the no-op")
 	}
@@ -144,13 +149,9 @@ func TestNewIssueForm_ConstructorBlursAllFieldsFocusesField0(t *testing.T) {
 // blurs/focuses the right fields each step.
 func TestNewIssueForm_TabCyclesFieldsWithWrap(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
-	wants := []int{1, 2, 3, 4, 0}
-	for i, want := range wants {
-		out, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = out.(Model)
-		if m.input.active != want {
-			t.Fatalf("step %d: active = %d, want %d", i, m.input.active, want)
-		}
+	for _, want := range []int{1, 2, 3, 4, 0} {
+		m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyTab})
+		assertActiveField(t, m, want)
 	}
 }
 
@@ -158,13 +159,9 @@ func TestNewIssueForm_TabCyclesFieldsWithWrap(t *testing.T) {
 // 0→4→3→2→1→0 with wrap.
 func TestNewIssueForm_ShiftTabReverseCyclesWithWrap(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
-	wants := []int{4, 3, 2, 1, 0}
-	for i, want := range wants {
-		out, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
-		m = out.(Model)
-		if m.input.active != want {
-			t.Fatalf("step %d: active = %d, want %d", i, m.input.active, want)
-		}
+	for _, want := range []int{4, 3, 2, 1, 0} {
+		m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyShiftTab})
+		assertActiveField(t, m, want)
 	}
 }
 
@@ -173,36 +170,21 @@ func TestNewIssueForm_ShiftTabReverseCyclesWithWrap(t *testing.T) {
 // → Body, Labels → Owner, Owner → Parent, Parent → Title (wrap).
 func TestNewIssueForm_EnterInSingleLineAdvancesField(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = out.(Model)
+	m, cmd := stepModel(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd != nil {
 		t.Fatalf("enter on Title dispatched a cmd %T; expected advance only", cmd)
 	}
-	if m.input.active != 1 {
-		t.Fatalf("after enter on Title: active = %d, want 1 (Body)", m.input.active)
-	}
+	assertActiveField(t, m, 1)
 	// Skip Body — enter inserts a newline there. Cycle to Labels (idx 2).
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
-	if m.input.active != 2 {
-		t.Fatalf("after tab from Body: active = %d, want 2 (Labels)", m.input.active)
-	}
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = out.(Model)
-	if m.input.active != 3 {
-		t.Fatalf("after enter on Labels: active = %d, want 3 (Owner)", m.input.active)
-	}
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = out.(Model)
-	if m.input.active != 4 {
-		t.Fatalf("after enter on Owner: active = %d, want 4 (Parent)", m.input.active)
-	}
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyTab})
+	assertActiveField(t, m, 2)
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assertActiveField(t, m, 3)
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assertActiveField(t, m, 4)
 	// Enter on Parent wraps to Title.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = out.(Model)
-	if m.input.active != 0 {
-		t.Fatalf("after enter on Parent: active = %d, want 0 (wrap to Title)", m.input.active)
-	}
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assertActiveField(t, m, 0)
 }
 
 // TestNewIssueForm_EnterInBodyInsertsNewline: enter on the body field
@@ -210,23 +192,13 @@ func TestNewIssueForm_EnterInSingleLineAdvancesField(t *testing.T) {
 func TestNewIssueForm_EnterInBodyInsertsNewline(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
 	// Tab to Body.
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
-	if m.input.active != 1 {
-		t.Fatalf("setup: active = %d, want 1 (Body)", m.input.active)
-	}
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyTab})
+	assertActiveField(t, m, 1)
 	// Type a line then enter then another line.
-	for _, r := range "line1" {
-		m, _ = stepModel(m, runeKey(r))
-	}
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = out.(Model)
-	if m.input.active != 1 {
-		t.Fatalf("enter on Body advanced field: active = %d, want 1", m.input.active)
-	}
-	for _, r := range "line2" {
-		m, _ = stepModel(m, runeKey(r))
-	}
+	m = typeString(m, "line1")
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assertActiveField(t, m, 1)
+	m = typeString(m, "line2")
 	body := m.input.fields[1].area.Value()
 	if !strings.Contains(body, "line1") || !strings.Contains(body, "line2") {
 		t.Fatalf("body missing one of the lines: %q", body)
@@ -240,14 +212,11 @@ func TestNewIssueForm_EnterInBodyInsertsNewline(t *testing.T) {
 // blank Title sets the in-form err and does NOT dispatch.
 func TestNewIssueForm_CtrlSEmptyTitleSetsErrNoDispatch(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
-	nm := out.(Model)
+	nm, cmd := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	if cmd != nil {
 		t.Fatalf("empty-title ctrl+s dispatched cmd %T; want nil", cmd)
 	}
-	if nm.input.kind != inputNewIssueForm {
-		t.Fatalf("form closed on empty commit: kind=%v", nm.input.kind)
-	}
+	assertInputKind(t, nm, inputNewIssueForm)
 	if nm.input.err == "" {
 		t.Fatal("expected err on empty-title commit")
 	}
@@ -262,9 +231,7 @@ func TestNewIssueForm_CtrlSEmptyTitleSetsErrNoDispatch(t *testing.T) {
 func TestNewIssueForm_CtrlSTitleOnly_DispatchesWithMinimalPayload(t *testing.T) {
 	api := &fakeListAPI{createResult: &MutationResp{Issue: &Issue{Number: 99}}}
 	m := openNewIssueForm(t, newIssueFormFixture())
-	for _, r := range "fix bug" {
-		m, _ = stepModel(m, runeKey(r))
-	}
+	m = typeString(m, "fix bug")
 	// Drive dispatchCreateIssue directly to assert the wire shape; the
 	// commit cmd uses Model.api which is *Client and unfittable to
 	// fakeListAPI without major plumbing.
@@ -351,32 +318,22 @@ func TestNewIssueForm_CtrlSAllFields_NormalizedPayload(t *testing.T) {
 func TestNewIssueForm_CtrlEOnlyWhenBodyFocused(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
 	// Title focused — ctrl+e is a no-op.
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
-	m = out.(Model)
+	m, cmd := stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlE})
 	if cmd != nil {
 		t.Fatalf("ctrl+e on Title dispatched cmd %T; want nil (gated)", cmd)
 	}
-	if m.input.kind != inputNewIssueForm {
-		t.Fatalf("ctrl+e on Title closed the form: kind=%v", m.input.kind)
-	}
+	assertInputKind(t, m, inputNewIssueForm)
 	// Tab to Body — ctrl+e fires.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
-	out, cmd = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
-	m = out.(Model)
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, cmd = stepModel(m, tea.KeyMsg{Type: tea.KeyCtrlE})
 	if cmd == nil {
 		t.Fatal("ctrl+e on Body produced no editor handoff cmd")
 	}
-	if m.input.kind != inputNewIssueForm {
-		t.Fatalf("ctrl+e on Body closed the form: kind=%v", m.input.kind)
-	}
+	assertInputKind(t, m, inputNewIssueForm)
 	// Tab through Labels, Owner, and Parent — ctrl+e is a no-op for all three.
 	for _, want := range []int{2, 3, 4} {
-		out, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = out.(Model)
-		if m.input.active != want {
-			t.Fatalf("setup: active = %d, want %d", m.input.active, want)
-		}
+		m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyTab})
+		assertActiveField(t, m, want)
 		_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
 		if cmd != nil {
 			t.Fatalf("ctrl+e on field[%d] dispatched cmd %T; want nil", want, cmd)
@@ -423,29 +380,22 @@ func TestNewIssueForm_ParentInvalidShowsError(t *testing.T) {
 
 func TestList_NewChild_NoSelectionNoOp(t *testing.T) {
 	m := newIssueFormFixture()
-	out, cmd := m.Update(runeKey('N'))
-	nm := out.(Model)
+	nm, cmd := stepModel(m, runeKey('N'))
 	if cmd != nil {
 		t.Fatalf("N with no selected row returned cmd %T, want nil", cmd)
 	}
-	if nm.input.kind != inputNone {
-		t.Fatalf("N with no selected row opened input kind=%v", nm.input.kind)
-	}
+	assertInputKind(t, nm, inputNone)
 }
 
 func TestList_NewChild_PrefillsSelectedParent(t *testing.T) {
 	m := newIssueFormFixture()
 	m.list.issues = []Issue{{ProjectID: 7, Number: 42, Title: "parent", Status: "open"}}
-	out, cmd := m.Update(runeKey('N'))
-	m = out.(Model)
+	m, cmd := stepModel(m, runeKey('N'))
 	if cmd == nil {
 		t.Fatal("N on a selected row produced no open-input command")
 	}
-	out, _ = m.Update(cmd())
-	m = out.(Model)
-	if m.input.kind != inputNewIssueForm {
-		t.Fatalf("input kind = %v, want inputNewIssueForm", m.input.kind)
-	}
+	m, _ = stepModel(m, cmd())
+	assertInputKind(t, m, inputNewIssueForm)
 	if m.input.title != "new child issue" {
 		t.Fatalf("title = %q, want new child issue", m.input.title)
 	}
@@ -489,14 +439,12 @@ func TestNewChildForm_ParentPrefillBackspaceClearsAndUnlocks(t *testing.T) {
 func TestNewIssueForm_StaleEditorReturnDropped(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
 	// Tab to Body and seed it.
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyTab})
 	m.input.fields[1].area.SetValue("user-typed body")
 	staleGen := m.input.formGen + 999 // any non-matching value
-	out, _ = m.Update(editorReturnedMsg{
+	nm, _ := stepModel(m, editorReturnedMsg{
 		kind: "create", content: "stale editor content", formGen: staleGen,
 	})
-	nm := out.(Model)
 	if got := nm.input.fields[1].area.Value(); got != "user-typed body" {
 		t.Fatalf("body = %q, want unchanged (stale return must not write)", got)
 	}
@@ -508,14 +456,11 @@ func TestNewIssueForm_StaleEditorReturnDropped(t *testing.T) {
 func TestNewIssueForm_MutationFailureLeavesFormOpenWithErr(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
 	m.input.saving = true
-	out, _ := m.Update(mutationDoneMsg{
+	nm, _ := stepModel(m, mutationDoneMsg{
 		origin: "form", kind: "create", formGen: m.input.formGen,
 		err: errStub("daemon 500"),
 	})
-	nm := out.(Model)
-	if nm.input.kind != inputNewIssueForm {
-		t.Fatalf("form closed on failure: kind=%v", nm.input.kind)
-	}
+	assertInputKind(t, nm, inputNewIssueForm)
 	if nm.input.saving {
 		t.Fatal("saving stayed true after failure; user can't retry")
 	}
@@ -529,14 +474,9 @@ func TestNewIssueForm_MutationFailureLeavesFormOpenWithErr(t *testing.T) {
 // create chain forced detail open; the multi-field form does not).
 func TestNewIssueForm_EscDiscardsAndReturnsToList(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
-	for _, r := range "draft" {
-		m, _ = stepModel(m, runeKey(r))
-	}
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	nm := out.(Model)
-	if nm.input.kind != inputNone {
-		t.Fatalf("esc did not close form: kind=%v", nm.input.kind)
-	}
+	m = typeString(m, "draft")
+	nm, cmd := stepModel(m, tea.KeyMsg{Type: tea.KeyEsc})
+	assertInputKind(t, nm, inputNone)
 	if nm.view != viewList {
 		t.Fatalf("view = %v, want viewList (no auto-detail)", nm.view)
 	}
@@ -562,11 +502,8 @@ func TestNewIssueForm_MutationSuccessRoutesToList(t *testing.T) {
 		origin: "form", kind: "create", formGen: m.input.formGen,
 		resp: &MutationResp{Issue: &Issue{Number: 99}},
 	}
-	out, _ := m.Update(mut)
-	nm := out.(Model)
-	if nm.input.kind != inputNone {
-		t.Fatalf("form did not close on success: kind=%v", nm.input.kind)
-	}
+	nm, _ := stepModel(m, mut)
+	assertInputKind(t, nm, inputNone)
 	if nm.list.selectedNumber != 99 {
 		t.Fatalf("selectedNumber = %d, want 99 (seeded by lm.applyMutation)",
 			nm.list.selectedNumber)
@@ -625,21 +562,13 @@ func TestNewIssueForm_MutationSuccessRefreshesLabelCache(t *testing.T) {
 	// present, batchLabelRefresh's existence gate would skip the
 	// dispatch — but the test scenario is "user already opened menu,
 	// then created with labels, expects fresh counts on next open".
-	m.projectLabels = newLabelCache()
-	m.projectLabels.byProject[7] = labelCacheEntry{
-		pid: 7, gen: 1,
-		labels: []LabelCount{{Label: "old", Count: 1}},
-	}
-	m.nextLabelsGen = 1
+	primeLabelCache(&m, 7, 1)
 	mut := mutationDoneMsg{
 		origin: "form", kind: "create", formGen: m.input.formGen,
 		resp: &MutationResp{Issue: &Issue{Number: 99, ProjectID: 7}},
 	}
-	out, _ := m.Update(mut)
-	nm := out.(Model)
-	if nm.input.kind != inputNone {
-		t.Fatalf("form did not close on success: kind=%v", nm.input.kind)
-	}
+	nm, _ := stepModel(m, mut)
+	assertInputKind(t, nm, inputNone)
 	entry := nm.projectLabels.byProject[7]
 	if !entry.fetching {
 		t.Fatal("label cache for pid=7 did not enter fetching=true; " +
@@ -668,15 +597,10 @@ func TestNewIssueForm_StaleResponseFromPriorFormDropped(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
 	staleGen := m.input.formGen
 	// Type something into the original form so we have observable state.
-	for _, r := range "draft A" {
-		m, _ = stepModel(m, runeKey(r))
-	}
+	m = typeString(m, "draft A")
 	// User presses esc, closing form A.
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	m = out.(Model)
-	if m.input.kind != inputNone {
-		t.Fatalf("setup: esc did not close form A: kind=%v", m.input.kind)
-	}
+	m, _ = stepModel(m, tea.KeyMsg{Type: tea.KeyEsc})
+	assertInputKind(t, m, inputNone)
 	// User opens form B — fresh formGen should be staleGen+1 (or larger).
 	m = openNewIssueForm(t, m)
 	freshGen := m.input.formGen
@@ -685,31 +609,21 @@ func TestNewIssueForm_StaleResponseFromPriorFormDropped(t *testing.T) {
 			freshGen, staleGen)
 	}
 	// Type something into form B so we can confirm it survives untouched.
-	for _, r := range "draft B" {
-		m, _ = stepModel(m, runeKey(r))
-	}
+	m = typeString(m, "draft B")
 	bBeforeBuf := m.input.fields[0].input.Value()
 	// Prime the label cache so a hypothetical stray batchLabelRefresh
 	// would visibly bump entry.gen — that lets the assertion catch the
 	// "stale response sneaks through and refreshes labels for the
 	// inactive project" failure mode too.
-	m.projectLabels = newLabelCache()
-	m.projectLabels.byProject[7] = labelCacheEntry{
-		pid: 7, gen: 5,
-		labels: []LabelCount{{Label: "old", Count: 1}},
-	}
-	m.nextLabelsGen = 5
+	primeLabelCache(&m, 7, 5)
 	// Stale response from form A finally lands.
 	stale := mutationDoneMsg{
 		origin: "form", kind: "create", formGen: staleGen,
 		resp: &MutationResp{Issue: &Issue{Number: 11, ProjectID: 7}},
 	}
-	out, _ = m.Update(stale)
-	nm := out.(Model)
+	nm, _ := stepModel(m, stale)
 	// Form B must remain open and untouched.
-	if nm.input.kind != inputNewIssueForm {
-		t.Fatalf("form B closed by stale form-A response: kind=%v", nm.input.kind)
-	}
+	assertInputKind(t, nm, inputNewIssueForm)
 	if nm.input.formGen != freshGen {
 		t.Fatalf("form B formGen mutated: got %d, want %d",
 			nm.input.formGen, freshGen)

--- a/internal/tui/projects_view_smoke_test.go
+++ b/internal/tui/projects_view_smoke_test.go
@@ -1,9 +1,7 @@
 package tui
 
 import (
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -17,16 +15,9 @@ import (
 // viewList in all-projects scope, and P from viewList returns to
 // viewProjects.
 func TestSmoke_ProjectsViewLoop(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/api/v1/projects/resolve":
-			w.WriteHeader(http.StatusNotFound)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": 404,
-				"error":  map[string]any{"code": "project_not_initialized"},
-			})
-		case "/api/v1/projects":
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects/resolve": projectNotInitializedHandler,
+		"/api/v1/projects": func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, "stats", r.URL.Query().Get("include"))
 			_, _ = w.Write([]byte(`{"projects":[
                 {"id":1,"identity":"github.com/wesm/proj-a","name":"proj-a",
@@ -36,14 +27,12 @@ func TestSmoke_ProjectsViewLoop(t *testing.T) {
                 {"id":3,"identity":"github.com/wesm/proj-c","name":"proj-c",
                  "stats":{"open":10,"closed":3,"last_event_at":"2026-05-04T11:00:00.000Z"}}
             ]}`))
-		case "/api/v1/issues":
-			// Cross-project list — the all-projects drill-in fetches from here.
+		},
+		// Cross-project list — the all-projects drill-in fetches from here.
+		"/api/v1/issues": func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`{"issues":[]}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer srv.Close()
+		},
+	})
 	c := NewClient(srv.URL, srv.Client())
 
 	// 1. Boot resolves to viewProjects.
@@ -51,22 +40,8 @@ func TestSmoke_ProjectsViewLoop(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, viewProjects, bi.view)
 
-	// 2. Build the model and seed the projects cache from boot's
-	//    pre-fetched rows (matches buildRunModel).
-	m := initialModel(Options{})
-	m.api = c
-	m.scope = bi.scope
-	m.view = bi.view
-	m.projectsByID = map[int64]string{}
-	m.projectIdentByID = map[int64]string{}
-	m.projectStats = map[int64]ProjectStatsSummary{}
-	for _, r := range bi.projects {
-		m.projectsByID[r.ID] = r.Name
-		m.projectIdentByID[r.ID] = r.Identity
-		if r.Stats != nil {
-			m.projectStats[r.ID] = *r.Stats
-		}
-	}
+	// 2. Build the model from boot — same wiring Run uses in production.
+	m := buildRunModel(Options{}, c, bi)
 
 	// 3. Rows ordered by last_event_at desc: proj-b (12:00), proj-c (11:00), proj-a (10:00).
 	rows := projectsRows(m.projectsByID, m.projectIdentByID, m.projectStats)
@@ -84,8 +59,7 @@ func TestSmoke_ProjectsViewLoop(t *testing.T) {
 	require.NotNil(t, cmd, "drill-in must dispatch fetchInitial")
 
 	// 5. P from the resulting viewList returns to viewProjects with scope preserved.
-	out2, cmd2 := nextModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'P'}})
-	nm2 := out2.(Model)
+	nm2, cmd2 := updateModel(nextModel, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'P'}})
 	assert.Equal(t, viewProjects, nm2.view)
 	assert.True(t, nm2.scope.allProjects, "scope preserved on P-back")
 	require.NotNil(t, cmd2, "P must dispatch fetchProjectsWithStats")

--- a/internal/tui/projects_view_test.go
+++ b/internal/tui/projects_view_test.go
@@ -16,10 +16,8 @@ import (
 // projects loaded yet. Required for boot landing where the fetch is
 // still in flight.
 func TestProjectsView_RendersWithoutPanic(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.width = 80
-	m.height = 24
+	m := setupProjectsView()
+	m.width = 80 // narrower than the 120 default
 
 	out := m.View()
 	if out == "" {
@@ -102,16 +100,10 @@ func TestProjectsRows_StableTiebreakerOnEqualNamesAndTimes(t *testing.T) {
 // terminal so all columns fit.
 func TestProjectsView_RendersTable(t *testing.T) {
 	t1 := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.width = 120
-	m.height = 24
-	m.projectsByID = map[int64]string{1: "kata", 2: "roborev"}
-	m.projectIdentByID = map[int64]string{1: "github.com/wesm/kata", 2: "github.com/wesm/roborev"}
-	m.projectStats = map[int64]ProjectStatsSummary{
-		1: {Open: 12, Closed: 3, LastEventAt: &t1},
-		2: {Open: 7, Closed: 2, LastEventAt: &t1},
-	}
+	m := setupProjectsView(
+		mockProject{ID: 1, Name: "kata", Ident: "github.com/wesm/kata", Stats: ProjectStatsSummary{Open: 12, Closed: 3, LastEventAt: &t1}},
+		mockProject{ID: 2, Name: "roborev", Ident: "github.com/wesm/roborev", Stats: ProjectStatsSummary{Open: 7, Closed: 2, LastEventAt: &t1}},
+	)
 
 	out := m.View()
 	for _, want := range []string{
@@ -127,17 +119,14 @@ func TestProjectsView_RendersTable(t *testing.T) {
 // screen. Without clipping, every row renders and the chrome falls
 // off the bottom — the user can't see [↑/↓ k/j] move etc.
 func TestProjectsView_ViewportClipsRowsToHeight(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.width = 120
+	m := setupProjectsView()
 	m.height = 14 // chrome=8 + ~5 row slots
-	m.projectsByID = map[int64]string{}
-	m.projectIdentByID = map[int64]string{}
-	m.projectStats = map[int64]ProjectStatsSummary{}
 	for i := int64(1); i <= 20; i++ {
-		m.projectsByID[i] = "proj" + strconv.FormatInt(i, 10)
-		m.projectIdentByID[i] = "github.com/wesm/proj" + strconv.FormatInt(i, 10)
-		m.projectStats[i] = ProjectStatsSummary{}
+		injectProjects(&m, mockProject{
+			ID:    i,
+			Name:  "proj" + strconv.FormatInt(i, 10),
+			Ident: "github.com/wesm/proj" + strconv.FormatInt(i, 10),
+		})
 	}
 	m.projectsCursor = 10
 
@@ -151,15 +140,9 @@ func TestProjectsView_ViewportClipsRowsToHeight(t *testing.T) {
 // TestProjectsView_DashWhenNoEvents pins spec §6.1: a row with
 // LastEventAt=nil renders "—" in the Updated column.
 func TestProjectsView_DashWhenNoEvents(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.width = 120
-	m.height = 24
-	m.projectsByID = map[int64]string{1: "fresh"}
-	m.projectIdentByID = map[int64]string{1: "github.com/wesm/fresh"}
-	m.projectStats = map[int64]ProjectStatsSummary{
-		1: {Open: 0, Closed: 0, LastEventAt: nil},
-	}
+	m := setupProjectsView(
+		mockProject{ID: 1, Name: "fresh", Ident: "github.com/wesm/fresh"},
+	)
 	out := m.View()
 	assert.Contains(t, out, "—", "nil LastEventAt must render as em-dash")
 }
@@ -168,13 +151,9 @@ func TestProjectsView_DashWhenNoEvents(t *testing.T) {
 // highlighting a real project renders its identity URL beneath the
 // table; highlighting the sentinel renders the description.
 func TestProjectsView_IdentityFooterOnHighlight(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.width = 120
-	m.height = 24
-	m.projectsByID = map[int64]string{1: "kata"}
-	m.projectIdentByID = map[int64]string{1: "github.com/wesm/kata"}
-	m.projectStats = map[int64]ProjectStatsSummary{1: {}}
+	m := setupProjectsView(
+		mockProject{ID: 1, Name: "kata", Ident: "github.com/wesm/kata"},
+	)
 
 	m.projectsCursor = 0 // sentinel row
 	out := m.View()
@@ -188,22 +167,22 @@ func TestProjectsView_IdentityFooterOnHighlight(t *testing.T) {
 // TestProjectsView_JKMoveCursor pins basic vertical navigation. Cursor
 // is clamped at both ends; j moves down, k moves up.
 func TestProjectsView_JKMoveCursor(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.projectsByID = map[int64]string{1: "a", 2: "b", 3: "c"}
-	m.projectIdentByID = map[int64]string{1: "...", 2: "...", 3: "..."}
-	m.projectStats = map[int64]ProjectStatsSummary{1: {}, 2: {}, 3: {}}
+	m := setupProjectsView(
+		mockProject{ID: 1, Name: "a", Ident: "..."},
+		mockProject{ID: 2, Name: "b", Ident: "..."},
+		mockProject{ID: 3, Name: "c", Ident: "..."},
+	)
 	m.projectsCursor = 0
 
-	out, _ := m.routeProjectsViewKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	out, _ := m.routeProjectsViewKey(keyRune('j'))
 	assert.Equal(t, 1, out.projectsCursor, "j → cursor 1")
 
-	out, _ = out.routeProjectsViewKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	out, _ = out.routeProjectsViewKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	out, _ = out.routeProjectsViewKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	out, _ = out.routeProjectsViewKey(keyRune('j'))
+	out, _ = out.routeProjectsViewKey(keyRune('j'))
+	out, _ = out.routeProjectsViewKey(keyRune('j'))
 	assert.Equal(t, 3, out.projectsCursor, "j past end is clamped")
 
-	out, _ = out.routeProjectsViewKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	out, _ = out.routeProjectsViewKey(keyRune('k'))
 	assert.Equal(t, 2, out.projectsCursor, "k → cursor 2")
 }
 
@@ -211,11 +190,10 @@ func TestProjectsView_JKMoveCursor(t *testing.T) {
 // a real project sets scope to that project and transitions to viewList
 // with a fresh fetch dispatched.
 func TestProjectsView_EnterOnProjectTransitions(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.projectsByID = map[int64]string{7: "kata", 9: "roborev"}
-	m.projectIdentByID = map[int64]string{7: "...", 9: "..."}
-	m.projectStats = map[int64]ProjectStatsSummary{7: {}, 9: {}}
+	m := setupProjectsView(
+		mockProject{ID: 7, Name: "kata", Ident: "..."},
+		mockProject{ID: 9, Name: "roborev", Ident: "..."},
+	)
 	// Prime the cache so isStale() can register invalidation
 	// (isStale requires cache.set==true; see cache.go:51-52).
 	m.cache.put(cacheKey{allProjects: true}, []Issue{{Number: 1}})
@@ -237,11 +215,9 @@ func TestProjectsView_EnterOnProjectTransitions(t *testing.T) {
 // TestProjectsView_EnterOnSentinelTransitions pins that Enter on the
 // All-projects row sets allProjects=true and transitions to viewList.
 func TestProjectsView_EnterOnSentinelTransitions(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.projectsByID = map[int64]string{1: "a"}
-	m.projectIdentByID = map[int64]string{1: "..."}
-	m.projectStats = map[int64]ProjectStatsSummary{1: {}}
+	m := setupProjectsView(
+		mockProject{ID: 1, Name: "a", Ident: "..."},
+	)
 	// Prime the cache so isStale() can register invalidation
 	// (isStale requires cache.set==true; see cache.go:51-52).
 	m.cache.put(cacheKey{projectID: 1}, []Issue{{Number: 1}})
@@ -259,12 +235,10 @@ func TestProjectsView_EnterOnSentinelTransitions(t *testing.T) {
 // re-selection contract: re-selecting the row that matches the active
 // scope just returns to viewList — no cache invalidation, no refetch.
 func TestProjectsView_EnterOnCurrentScopeIsIdempotent(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.projectsByID = map[int64]string{7: "kata"}
-	m.projectIdentByID = map[int64]string{7: "..."}
-	m.projectStats = map[int64]ProjectStatsSummary{7: {}}
-	m.scope = scope{projectID: 7, projectName: "kata", homeProjectID: 7, homeProjectName: "kata"}
+	m := setupProjectsView(
+		mockProject{ID: 7, Name: "kata", Ident: "..."},
+	)
+	m.scope = homedScope(7, "kata")
 	m.projectsCursor = 1 // the kata row
 
 	out, cmd := m.routeProjectsViewKey(tea.KeyMsg{Type: tea.KeyEnter})
@@ -277,9 +251,8 @@ func TestProjectsView_EnterOnCurrentScopeIsIdempotent(t *testing.T) {
 // viewProjects returns to viewList without a refetch when scope is set
 // (the user came from a list via P).
 func TestProjectsView_EscReturnsToPriorList(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
-	m.scope = scope{projectID: 7, projectName: "kata", homeProjectID: 7, homeProjectName: "kata"}
+	m := setupProjectsView()
+	m.scope = homedScope(7, "kata")
 
 	out, cmd := m.routeProjectsViewKey(tea.KeyMsg{Type: tea.KeyEsc})
 	assert.Equal(t, viewList, out.view, "Esc → viewList")
@@ -290,8 +263,7 @@ func TestProjectsView_EscReturnsToPriorList(t *testing.T) {
 // TestProjectsView_EscNoOpOnBootEntry pins that Esc with no prior scope
 // (boot landed on viewProjects) leaves the view in place. Spec §1.4.
 func TestProjectsView_EscNoOpOnBootEntry(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
+	m := setupProjectsView()
 	// Default scope is zero (empty=false, projectID=0, allProjects=false)
 	// — this represents the boot landing case.
 
@@ -303,10 +275,9 @@ func TestProjectsView_EscNoOpOnBootEntry(t *testing.T) {
 // TestProjectsView_RRefreshes pins spec §1.4: r dispatches a manual
 // refresh of the projects table. View stays in viewProjects.
 func TestProjectsView_RRefreshes(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewProjects
+	m := setupProjectsView()
 
-	out, cmd := m.routeProjectsViewKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	out, cmd := m.routeProjectsViewKey(keyRune('r'))
 	assert.Equal(t, viewProjects, out.view)
 	require.NotNil(t, cmd, "r must dispatch fetchProjectsWithStats")
 }
@@ -317,13 +288,12 @@ func TestProjectsView_RRefreshes(t *testing.T) {
 func TestProjectsView_PFromListTransitions(t *testing.T) {
 	m := initialModel(Options{})
 	m.view = viewList
-	m.scope = scope{projectID: 7, projectName: "kata", homeProjectID: 7, homeProjectName: "kata"}
+	m.scope = homedScope(7, "kata")
 	// Need a stub api so the cmd can be dispatched without crashing —
 	// the cmd doesn't run to completion in this test.
 	m.api = &Client{}
 
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'P'}})
-	nm := out.(Model)
+	nm, cmd := updateModel(m, keyRune('P'))
 	assert.Equal(t, viewProjects, nm.view)
 	assert.Equal(t, int64(7), nm.scope.projectID, "scope preserved on P transition")
 	require.NotNil(t, cmd, "P must dispatch a stats fetch")
@@ -338,8 +308,7 @@ func TestProjectsView_PWhileInputFocusedRoutesToPrompt(t *testing.T) {
 	m.scope = scope{projectID: 7, projectName: "kata"}
 	m.input = newSearchBar(ListFilter{})
 
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'P'}})
-	nm := out.(Model)
+	nm, _ := updateModel(m, keyRune('P'))
 	assert.Equal(t, viewList, nm.view, "view must not transition while input is focused")
 	if v := nm.input.activeField().value(); v != "P" {
 		t.Fatalf("input buffer = %q, want %q", v, "P")

--- a/internal/tui/queue_rows_test.go
+++ b/internal/tui/queue_rows_test.go
@@ -2,13 +2,11 @@ package tui
 
 import "testing"
 
-func int64Ptr(v int64) *int64 { return &v }
-
 func TestBuildQueueRows_CollapsedShowsTopLevelOnly(t *testing.T) {
 	issues := []Issue{
-		{ProjectID: 7, Number: 1, Title: "parent", ChildCounts: &ChildCounts{Open: 1, Total: 1}},
-		{ProjectID: 7, Number: 2, Title: "child", ParentNumber: int64Ptr(1)},
-		{ProjectID: 7, Number: 3, Title: "unrelated"},
+		testIssue(1, withCounts(1, 1)),
+		testIssue(2, withParent(1)),
+		testIssue(3),
 	}
 
 	rows := buildQueueRows(issues, ListFilter{}, nil)
@@ -20,10 +18,10 @@ func TestBuildQueueRows_CollapsedShowsTopLevelOnly(t *testing.T) {
 
 func TestBuildQueueRows_ExpandedShowsDirectChildren(t *testing.T) {
 	issues := []Issue{
-		{ProjectID: 7, Number: 1, Title: "parent", ChildCounts: &ChildCounts{Open: 2, Total: 2}},
-		{ProjectID: 7, Number: 2, Title: "child 1", ParentNumber: int64Ptr(1), ChildCounts: &ChildCounts{Open: 1, Total: 1}},
-		{ProjectID: 7, Number: 3, Title: "child 2", ParentNumber: int64Ptr(1)},
-		{ProjectID: 7, Number: 4, Title: "grandchild", ParentNumber: int64Ptr(2)},
+		testIssue(1, withCounts(2, 2)),
+		testIssue(2, withParent(1), withCounts(1, 1)),
+		testIssue(3, withParent(1)),
+		testIssue(4, withParent(2)),
 	}
 
 	rows := buildQueueRows(issues, ListFilter{}, expansionSet{{projectID: 7, number: 1}: true})
@@ -44,10 +42,10 @@ func TestBuildQueueRows_ExpandedShowsDirectChildren(t *testing.T) {
 
 func TestBuildQueueRows_DefaultsExpandedChildrenToTopologicalOrder(t *testing.T) {
 	issues := []Issue{
-		{ProjectID: 7, Number: 1, Title: "parent", ChildCounts: &ChildCounts{Open: 3, Total: 3}},
-		{ProjectID: 7, Number: 2, Title: "blocked child", ParentNumber: int64Ptr(1)},
-		{ProjectID: 7, Number: 3, Title: "blocker child", ParentNumber: int64Ptr(1), Blocks: []int64{2}},
-		{ProjectID: 7, Number: 4, Title: "unrelated child", ParentNumber: int64Ptr(1)},
+		testIssue(1, withCounts(3, 3)),
+		testIssue(2, withParent(1)),
+		testIssue(3, withParent(1), withBlocks(2)),
+		testIssue(4, withParent(1)),
 	}
 
 	rows := buildQueueRows(issues, ListFilter{}, expansionSet{{projectID: 7, number: 1}: true})
@@ -56,10 +54,10 @@ func TestBuildQueueRows_DefaultsExpandedChildrenToTopologicalOrder(t *testing.T)
 
 func TestBuildQueueRows_TemporalChildSortPreservesFetchOrder(t *testing.T) {
 	issues := []Issue{
-		{ProjectID: 7, Number: 1, Title: "parent", ChildCounts: &ChildCounts{Open: 3, Total: 3}},
-		{ProjectID: 7, Number: 2, Title: "blocked child", ParentNumber: int64Ptr(1)},
-		{ProjectID: 7, Number: 3, Title: "blocker child", ParentNumber: int64Ptr(1), Blocks: []int64{2}},
-		{ProjectID: 7, Number: 4, Title: "unrelated child", ParentNumber: int64Ptr(1)},
+		testIssue(1, withCounts(3, 3)),
+		testIssue(2, withParent(1)),
+		testIssue(3, withParent(1), withBlocks(2)),
+		testIssue(4, withParent(1)),
 	}
 
 	rows := buildQueueRowsWithSort(
@@ -73,9 +71,9 @@ func TestBuildQueueRows_TemporalChildSortPreservesFetchOrder(t *testing.T) {
 
 func TestBuildQueueRows_FilteredChildAutoShowsAncestorContext(t *testing.T) {
 	issues := []Issue{
-		{ProjectID: 7, Number: 1, Title: "parent"},
-		{ProjectID: 7, Number: 2, Title: "detail hint bars incomplete", ParentNumber: int64Ptr(1)},
-		{ProjectID: 7, Number: 3, Title: "unrelated"},
+		testIssue(1),
+		testIssue(2, withTitle("detail hint bars incomplete"), withParent(1)),
+		testIssue(3),
 	}
 
 	rows := buildQueueRows(issues, ListFilter{Search: "hint bars"}, nil)
@@ -93,8 +91,8 @@ func TestBuildQueueRows_FilteredChildAutoShowsAncestorContext(t *testing.T) {
 
 func TestBuildQueueRows_StatusFilterIsClientSide(t *testing.T) {
 	issues := []Issue{
-		{ProjectID: 7, Number: 1, Status: "open"},
-		{ProjectID: 7, Number: 2, Status: "closed"},
+		testIssue(1, withStatus("open")),
+		testIssue(2, withStatus("closed")),
 	}
 
 	rows := buildQueueRows(issues, ListFilter{Status: "closed"}, nil)
@@ -103,8 +101,8 @@ func TestBuildQueueRows_StatusFilterIsClientSide(t *testing.T) {
 
 func TestBuildQueueRows_LabelsFilterAnyOf(t *testing.T) {
 	issues := []Issue{
-		{ProjectID: 7, Number: 1, Labels: []string{"bug", "ux"}},
-		{ProjectID: 7, Number: 2, Labels: []string{"daemon"}},
+		testIssue(1, withLabels("bug", "ux")),
+		testIssue(2, withLabels("daemon")),
 	}
 
 	rows := buildQueueRows(issues, ListFilter{Labels: []string{"ux", "docs"}}, nil)

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -18,10 +17,8 @@ import (
 // initial list fetch should hit the project-scoped endpoint.
 func TestBoot_ResolvesProject(t *testing.T) {
 	var sawList bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/api/v1/projects/resolve":
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects/resolve": func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"project": map[string]any{
 					"id":       7,
@@ -30,14 +27,12 @@ func TestBoot_ResolvesProject(t *testing.T) {
 				},
 				"workspace_root": "/tmp/x",
 			})
-		case "/api/v1/projects/7/issues":
+		},
+		"/api/v1/projects/7/issues": func(w http.ResponseWriter, _ *http.Request) {
 			sawList = true
 			_ = json.NewEncoder(w).Encode(map[string]any{"issues": []map[string]any{}})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer srv.Close()
+		},
+	})
 	c := NewClient(srv.URL, srv.Client())
 	bi, err := bootResolveScope(t.Context(), c, "/tmp/x")
 	if err != nil {
@@ -75,20 +70,13 @@ func TestBoot_ResolvesProject(t *testing.T) {
 // TestBoot_UnresolvedWithProjects_LandsViewProjects below, which pins
 // the ≥1 project branch.)
 func TestBoot_EmptyState_NoProjectsRegistered(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/api/v1/projects/resolve":
-			w.WriteHeader(http.StatusNotFound)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"error": map[string]any{"code": "project_not_initialized"},
-			})
-		case "/api/v1/projects":
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects/resolve": projectNotInitializedHandler,
+		"/api/v1/projects": func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, "stats", r.URL.Query().Get("include"))
 			_, _ = w.Write([]byte(`{"projects":[]}`))
-		}
-	}))
-	defer srv.Close()
+		},
+	})
 	c := NewClient(srv.URL, srv.Client())
 	bi, err := bootResolveScope(t.Context(), c, "/tmp/empty")
 	if err != nil {
@@ -106,12 +94,12 @@ func TestBoot_EmptyState_NoProjectsRegistered(t *testing.T) {
 // TestBoot_NonResolveErrorPropagates: a 500 from /resolve should fail Run
 // instead of silently downgrading. Black-screen prevention.
 func TestBoot_NonResolveErrorPropagates(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"status":500,"error":{"code":"internal","message":"db down"}}`))
-	}))
-	defer srv.Close()
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects/resolve": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"status":500,"error":{"code":"internal","message":"db down"}}`))
+		},
+	})
 	c := NewClient(srv.URL, srv.Client())
 	if _, err := bootResolveScope(t.Context(), c, "/tmp/x"); err == nil {
 		t.Fatal("expected error to propagate, got nil")
@@ -156,29 +144,16 @@ func TestRun_NonFileStdout_ReturnsNotATTY(t *testing.T) {
 // rule: an unresolved cwd plus ≥1 registered project lands on
 // viewProjects, not viewEmpty. Spec §4.2.
 func TestBoot_UnresolvedWithProjects_LandsViewProjects(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/api/v1/projects/resolve":
-			w.WriteHeader(http.StatusNotFound)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"status": 404,
-				"error": map[string]any{
-					"code":    "project_not_initialized",
-					"message": "no kata.toml",
-				},
-			})
-		case "/api/v1/projects":
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects/resolve": projectNotInitializedHandler,
+		"/api/v1/projects": func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, "stats", r.URL.Query().Get("include"))
 			_, _ = w.Write([]byte(`{"projects":[
 				{"id":7,"identity":"github.com/wesm/kata","name":"kata",
 				 "stats":{"open":3,"closed":1,"last_event_at":"2026-05-04T12:00:00.000Z"}}
 			]}`))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer srv.Close()
+		},
+	})
 	c := NewClient(srv.URL, srv.Client())
 
 	bi, err := bootResolveScope(t.Context(), c, "/tmp/unbound")

--- a/internal/tui/sanitize_test.go
+++ b/internal/tui/sanitize_test.go
@@ -5,149 +5,105 @@ import (
 	"testing"
 )
 
-// TestSanitizeForDisplay_StripsCSI: ANSI Color/cursor sequences must
-// be removed so an agent-authored title can't paint the terminal.
-func TestSanitizeForDisplay_StripsCSI(t *testing.T) {
-	in := "\x1b[31mDANGER\x1b[0m fix login"
-	got := sanitizeForDisplay(in)
+// assertSafeRender fails if rendered output contains raw ESC or CR
+// bytes — both let agent-supplied text attack the terminal (cursor
+// manipulation, column overwrite). Every TUI view that surfaces
+// external content must sanitize before render.
+func assertSafeRender(t testing.TB, got string) {
+	t.Helper()
 	if strings.Contains(got, "\x1b") {
-		t.Fatalf("ESC survived: %q", got)
+		t.Fatalf("ESC survived in render: %q", got)
 	}
-	if got != "DANGER fix login" {
-		t.Fatalf("got %q, want %q", got, "DANGER fix login")
-	}
-}
-
-// TestSanitizeForDisplay_StripsOSCWithBEL: an OSC sequence terminated
-// by BEL (set window title) must be removed entirely.
-func TestSanitizeForDisplay_StripsOSCWithBEL(t *testing.T) {
-	in := "before\x1b]0;evil title\x07after"
-	got := sanitizeForDisplay(in)
-	if strings.Contains(got, "evil title") {
-		t.Fatalf("OSC payload leaked: %q", got)
-	}
-	if got != "beforeafter" {
-		t.Fatalf("got %q, want %q", got, "beforeafter")
-	}
-}
-
-// TestSanitizeForDisplay_StripsOSCWithST: OSC terminated by the
-// String Terminator (ESC \) — the other legal end marker.
-func TestSanitizeForDisplay_StripsOSCWithST(t *testing.T) {
-	in := "x\x1b]8;;file:///etc/passwd\x1b\\link\x1b]8;;\x1b\\y"
-	got := sanitizeForDisplay(in)
-	if strings.Contains(got, "file:///etc/passwd") {
-		t.Fatalf("OSC hyperlink payload leaked: %q", got)
-	}
-	if strings.Contains(got, "\x1b") {
-		t.Fatalf("ESC survived: %q", got)
-	}
-}
-
-// TestSanitizeForDisplay_PreservesNewlineAndTab: bodies legitimately
-// contain newlines and tabs; both must survive so multi-line content
-// renders correctly.
-func TestSanitizeForDisplay_PreservesNewlineAndTab(t *testing.T) {
-	in := "line one\nline two\tindented"
-	got := sanitizeForDisplay(in)
-	if got != in {
-		t.Fatalf("newline/tab dropped: got %q, want %q", got, in)
-	}
-}
-
-// TestSanitizeForDisplay_StripsCarriageReturn: \r is not whitelisted —
-// stripping it prevents an agent from overwriting the prior column on
-// the same row.
-func TestSanitizeForDisplay_StripsCarriageReturn(t *testing.T) {
-	in := "real\rINJECTED"
-	got := sanitizeForDisplay(in)
 	if strings.Contains(got, "\r") {
-		t.Fatalf("CR survived: %q", got)
-	}
-	if got != "realINJECTED" {
-		t.Fatalf("got %q, want realINJECTED", got)
+		t.Fatalf("CR survived in render: %q", got)
 	}
 }
 
-// TestSanitizeForDisplay_StripsBareEsc: a bare ESC (no following
-// CSI/OSC bracket) is dropped via the IsControl pass.
-func TestSanitizeForDisplay_StripsBareEsc(t *testing.T) {
-	in := "be\x1bfore"
-	got := sanitizeForDisplay(in)
-	if strings.Contains(got, "\x1b") {
-		t.Fatalf("ESC survived: %q", got)
-	}
-	if got != "before" {
-		t.Fatalf("got %q, want before", got)
-	}
-}
+// TestSanitizeForDisplay covers every input class sanitizeForDisplay
+// must handle: ANSI/OSC escape sequences (multiple terminator forms),
+// bare control bytes, Cf format runes (bidi override, zero-width
+// joiners), and the legitimate-content cases that must pass through
+// untouched.
+func TestSanitizeForDisplay(t *testing.T) {
+	rlo := string(rune(0x202E))  // RIGHT-TO-LEFT OVERRIDE
+	zwsp := string(rune(0x200B)) // ZERO WIDTH SPACE
+	zwnj := string(rune(0x200C)) // ZERO WIDTH NON-JOINER
+	zwj := string(rune(0x200D))  // ZERO WIDTH JOINER
 
-// TestSanitizeForDisplay_NoOpForPlainText: pure text is returned
-// unchanged and no allocation is forced (the fast path returns s
-// directly when no controls are present).
-func TestSanitizeForDisplay_NoOpForPlainText(t *testing.T) {
-	in := "fix login bug on Safari"
-	if got := sanitizeForDisplay(in); got != in {
-		t.Fatalf("plain text changed: got %q, want %q", got, in)
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "strips CSI color sequences",
+			input: "\x1b[31mDANGER\x1b[0m fix login",
+			want:  "DANGER fix login",
+		},
+		{
+			name:  "strips OSC terminated by BEL (set window title)",
+			input: "before\x1b]0;evil title\x07after",
+			want:  "beforeafter",
+		},
+		{
+			name:  "strips OSC terminated by ST (hyperlink)",
+			input: "x\x1b]8;;file:///etc/passwd\x1b\\link\x1b]8;;\x1b\\y",
+			want:  "xlinky",
+		},
+		{
+			name:  "preserves newline and tab",
+			input: "line one\nline two\tindented",
+			want:  "line one\nline two\tindented",
+		},
+		{
+			name:  "strips bare carriage return",
+			input: "real\rINJECTED",
+			want:  "realINJECTED",
+		},
+		{
+			name:  "strips bare ESC",
+			input: "be\x1bfore",
+			want:  "before",
+		},
+		{
+			name:  "no-op for plain ASCII",
+			input: "fix login bug on Safari",
+			want:  "fix login bug on Safari",
+		},
+		{
+			name:  "preserves unicode (CJK, emoji, accented)",
+			input: "修复 login 🐛 résumé",
+			want:  "修复 login 🐛 résumé",
+		},
+		{
+			// U+202E is category Cf (Format), not C (Control), so
+			// unicode.IsControl alone wouldn't catch it. Constructed
+			// from rune() to avoid embedding a Trojan-Source rune in
+			// this file's literal text.
+			name:  "strips U+202E bidi override",
+			input: "fix " + rlo + "txetnoc lacitirc",
+			want:  "fix txetnoc lacitirc",
+		},
+		{
+			// Zero-width format runes are invisible but interfere
+			// with search and copy-paste; strip them too.
+			name:  "strips zero-width format runes",
+			input: "spo" + zwsp + "of" + zwnj + "er" + zwj + "ed",
+			want:  "spoofered",
+		},
+		{
+			name:  "empty input short-circuits",
+			input: "",
+			want:  "",
+		},
 	}
-}
 
-// TestSanitizeForDisplay_PreservesUnicode: regular printable Unicode
-// (CJK, emoji, accented Latin) must survive — sanitization only
-// targets controls and escapes.
-func TestSanitizeForDisplay_PreservesUnicode(t *testing.T) {
-	in := "修复 login 🐛 résumé"
-	if got := sanitizeForDisplay(in); got != in {
-		t.Fatalf("unicode dropped: got %q, want %q", got, in)
-	}
-}
-
-// TestSanitizeForDisplay_StripsBidiOverride: U+202E RIGHT-TO-LEFT
-// OVERRIDE is in Unicode category Cf (Format), not C (Control), so
-// the older unicode.IsControl-only check let it through. It can
-// reorder text visually — agent-supplied content can use it to spoof
-// safe-looking strings. Sanitize must drop it.
-//
-// The bidi rune is constructed with string(rune(0x202E)) rather than
-// embedded literally so this source file doesn't trip gosec G116
-// (Trojan Source) on its own scan.
-func TestSanitizeForDisplay_StripsBidiOverride(t *testing.T) {
-	rlo := rune(0x202E)
-	in := "fix " + string(rlo) + "txetnoc lacitirc"
-	got := sanitizeForDisplay(in)
-	if strings.ContainsRune(got, rlo) {
-		t.Fatalf("U+202E RIGHT-TO-LEFT OVERRIDE survived: %q", got)
-	}
-	if !strings.Contains(got, "fix") {
-		t.Fatalf("legitimate text dropped: %q", got)
-	}
-}
-
-// TestSanitizeForDisplay_StripsZeroWidthFormatRunes: U+200B/200C/200D
-// (zero-width space / non-joiner / joiner) are also Cf. They can be
-// invisible in rendered output but interfere with searches and
-// terminal copy-paste. Strip them too. Runes constructed from their
-// code points to avoid embedding invisible characters in source.
-func TestSanitizeForDisplay_StripsZeroWidthFormatRunes(t *testing.T) {
-	zwsp := rune(0x200B)
-	zwnj := rune(0x200C)
-	zwj := rune(0x200D)
-	in := "spo" + string(zwsp) + "of" + string(zwnj) + "er" + string(zwj) + "ed"
-	got := sanitizeForDisplay(in)
-	for _, r := range []rune{zwsp, zwnj, zwj} {
-		if strings.ContainsRune(got, r) {
-			t.Fatalf("zero-width format rune %U survived: %q", r, got)
-		}
-	}
-	if got != "spoofered" {
-		t.Fatalf("got %q, want %q", got, "spoofered")
-	}
-}
-
-// TestSanitizeForDisplay_EmptyInput: empty string short-circuits.
-func TestSanitizeForDisplay_EmptyInput(t *testing.T) {
-	if got := sanitizeForDisplay(""); got != "" {
-		t.Fatalf("got %q, want empty", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeForDisplay(tc.input); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -161,9 +117,7 @@ func TestListView_SanitizesMaliciousTitle(t *testing.T) {
 		{Number: 1, Title: "\x1b]0;HIJACK\x07normal title", Status: "open"},
 	}
 	out := lm.View(120, 30, viewChrome{})
-	if strings.Contains(out, "\x1b") {
-		t.Fatalf("ESC reached rendered list: %q", out)
-	}
+	assertSafeRender(t, out)
 	if strings.Contains(out, "HIJACK") {
 		t.Fatalf("OSC payload reached rendered list: %q", out)
 	}
@@ -182,9 +136,7 @@ func TestDetailView_SanitizesMaliciousBody(t *testing.T) {
 		},
 	}
 	out := dm.View(120, 30, viewChrome{})
-	if strings.Contains(out, "\x1b") {
-		t.Fatalf("ESC reached rendered detail body: %q", out)
-	}
+	assertSafeRender(t, out)
 	if !strings.Contains(out, "overwrite-attack") {
 		t.Fatalf("body text dropped (CSI strip should leave the payload): %q", out)
 	}
@@ -198,10 +150,5 @@ func TestCommentsTab_SanitizesMaliciousAuthorAndBody(t *testing.T) {
 		Body: "body line\rOVERWRITE",
 	}}
 	out := renderCommentsTab(cs, 120, 20, 0, tabState{})
-	if strings.Contains(out, "\x1b") {
-		t.Fatalf("ESC in comment author reached render: %q", out)
-	}
-	if strings.Contains(out, "\r") {
-		t.Fatalf("CR in comment body reached render: %q", out)
-	}
+	assertSafeRender(t, out)
 }

--- a/internal/tui/scenarios_test.go
+++ b/internal/tui/scenarios_test.go
@@ -46,6 +46,43 @@ func scenarioModel(t *testing.T, w, h int) Model {
 	return out.(Model)
 }
 
+// setupDetailScenario is the most common opening: build a list-view
+// model at (w, h) and immediately transition to detail for the first
+// fixture issue with the given body.
+func setupDetailScenario(t *testing.T, w, h int, body string) Model {
+	t.Helper()
+	return scenarioOpenDetail(t, scenarioModel(t, w, h), body)
+}
+
+// assertViewState pins the layout/view/focus triple in one assertion
+// so failures print all three values in one message instead of
+// stopping at the first mismatch.
+func assertViewState(t *testing.T, m Model, l layoutMode, v viewID, f focusPane) {
+	t.Helper()
+	if m.layout != l || m.view != v || m.focus != f {
+		t.Fatalf("state mismatch: got layout=%v view=%v focus=%v, want %v/%v/%v",
+			m.layout, m.view, m.focus, l, v, f)
+	}
+}
+
+// assertViewContains fails if the rendered (ANSI-stripped) view does
+// not contain substr. Includes the full view in the failure message
+// so the test output shows what was actually rendered.
+func assertViewContains(t *testing.T, m Model, substr string) {
+	t.Helper()
+	if !strings.Contains(view(m), substr) {
+		t.Fatalf("expected view to contain %q; view:\n%s", substr, view(m))
+	}
+}
+
+// assertViewMissing is the negative counterpart of assertViewContains.
+func assertViewMissing(t *testing.T, m Model, substr string) {
+	t.Helper()
+	if strings.Contains(view(m), substr) {
+		t.Fatalf("expected view to NOT contain %q; view:\n%s", substr, view(m))
+	}
+}
+
 // scenarioOpenDetail puts the model into detail view for the first
 // list issue and seeds the four per-tab fetch responses so the detail
 // is fully populated. body is the issue body — pass a long body when
@@ -119,16 +156,11 @@ func view(m Model) string { return stripANSI(m.View()) }
 // tests didn't catch it because the bug was about an interaction,
 // not a static frame.
 func TestScenario_ReadAnIssue_BodyScrollsOnPageDown(t *testing.T) {
-	m := scenarioModel(t, 120, 30)
 	body := strings.Repeat("scrollable line\n", 60) + "TAIL_MARKER"
-	m = scenarioOpenDetail(t, m, body)
-	if strings.Contains(view(m), "TAIL_MARKER") {
-		t.Fatalf("setup invariant: TAIL_MARKER visible without scrolling:\n%s", view(m))
-	}
+	m := setupDetailScenario(t, 120, 30, body)
+	assertViewMissing(t, m, "TAIL_MARKER")
 	m = pressN(t, m, tea.KeyMsg{Type: tea.KeyPgDown}, 16)
-	if !strings.Contains(view(m), "TAIL_MARKER") {
-		t.Fatalf("PageDown did not scroll body to TAIL_MARKER; final view:\n%s", view(m))
-	}
+	assertViewContains(t, m, "TAIL_MARKER")
 }
 
 // TestScenario_ReadAnIssue_PageUpClampsAtTop ensures the body-scroll
@@ -136,13 +168,10 @@ func TestScenario_ReadAnIssue_BodyScrollsOnPageDown(t *testing.T) {
 // past zero only if the clamp is broken, in which case the renderer
 // would slice an empty window and lose the body's first line.
 func TestScenario_ReadAnIssue_PageUpClampsAtTop(t *testing.T) {
-	m := scenarioModel(t, 120, 30)
 	body := "FIRST_LINE_MARKER\n" + strings.Repeat("filler line\n", 30)
-	m = scenarioOpenDetail(t, m, body)
+	m := setupDetailScenario(t, 120, 30, body)
 	m = pressN(t, m, tea.KeyMsg{Type: tea.KeyPgUp}, 5)
-	if !strings.Contains(view(m), "FIRST_LINE_MARKER") {
-		t.Fatalf("PgUp from the top lost the first line; final view:\n%s", view(m))
-	}
+	assertViewContains(t, m, "FIRST_LINE_MARKER")
 	if m.detail.scroll != 0 {
 		t.Fatalf("dm.scroll = %d after PgUp at top, want 0", m.detail.scroll)
 	}
@@ -154,19 +183,12 @@ func TestScenario_ReadAnIssue_PageUpClampsAtTop(t *testing.T) {
 // double-bound, or clobbered by a global handler), which a snapshot
 // of one focus state can't see.
 func TestScenario_NavigateTabs_TabAdvancesActiveSection(t *testing.T) {
-	m := scenarioModel(t, 120, 30)
-	m = scenarioOpenDetail(t, m, "short body")
-	if !strings.Contains(view(m), "[ Comments (1) ]") {
-		t.Fatalf("setup invariant: Comments tab not active:\n%s", view(m))
-	}
+	m := setupDetailScenario(t, 120, 30, "short body")
+	assertViewContains(t, m, "[ Comments (1) ]")
 	m = pressKey(t, m, tea.KeyMsg{Type: tea.KeyTab})
-	if !strings.Contains(view(m), "[ Events (1) ]") {
-		t.Fatalf("Tab did not advance to Events:\n%s", view(m))
-	}
+	assertViewContains(t, m, "[ Events (1) ]")
 	m = pressKey(t, m, tea.KeyMsg{Type: tea.KeyTab})
-	if !strings.Contains(view(m), "[ Links (0) ]") {
-		t.Fatalf("Tab did not advance to Links:\n%s", view(m))
-	}
+	assertViewContains(t, m, "[ Links (0) ]")
 }
 
 // TestScenario_EscReturnsFromStackedDetailToList drives the same path
@@ -174,18 +196,11 @@ func TestScenario_NavigateTabs_TabAdvancesActiveSection(t *testing.T) {
 // returns a popDetailMsg command, and the command is then fed back into
 // Model.Update. A submodel-only test can miss this parent handoff.
 func TestScenario_EscReturnsFromStackedDetailToList(t *testing.T) {
-	m := scenarioModel(t, 120, 30)
-	m = scenarioOpenDetail(t, m, "short body")
+	m := setupDetailScenario(t, 120, 30, "short body")
 	if m.view != viewDetail {
 		t.Fatalf("setup: view=%v, want viewDetail", m.view)
 	}
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	m = out.(Model)
-	if cmd == nil {
-		t.Fatal("Esc from stacked detail returned nil cmd; want popDetailMsg")
-	}
-	out, _ = m.Update(cmd())
-	m = out.(Model)
+	m = sendKeyAndDrain(t, m, tea.KeyMsg{Type: tea.KeyEsc})
 	if m.view != viewList {
 		t.Fatalf("Esc did not return to list: view=%v, want viewList", m.view)
 	}
@@ -197,12 +212,8 @@ func TestScenario_EscReturnsFromStackedDetailToList(t *testing.T) {
 // overlays, layout flips, and model-level gates agree with what the
 // user just did.
 func TestScenario_EscReturnsFromSplitDetailToList(t *testing.T) {
-	m := scenarioModel(t, 200, 40)
-	m = scenarioOpenDetail(t, m, "short body")
-	if m.layout != layoutSplit || m.view != viewDetail || m.focus != focusDetail {
-		t.Fatalf("setup: layout=%v view=%v focus=%v, want split/detail/detail",
-			m.layout, m.view, m.focus)
-	}
+	m := setupDetailScenario(t, 200, 40, "short body")
+	assertViewState(t, m, layoutSplit, viewDetail, focusDetail)
 	m = pressKey(t, m, tea.KeyMsg{Type: tea.KeyEsc})
 	if m.focus != focusList {
 		t.Fatalf("Esc did not return focus to list: focus=%v", m.focus)
@@ -217,8 +228,7 @@ func TestScenario_EscReturnsFromSplitDetailToList(t *testing.T) {
 // nav stack, matching Backspace and stacked detail behavior; only a
 // second back action should leave the detail pane.
 func TestScenario_EscPopsSplitDetailNavStackBeforeLeavingPane(t *testing.T) {
-	m := scenarioModel(t, 200, 40)
-	m = scenarioOpenDetail(t, m, "parent body")
+	m := setupDetailScenario(t, 200, 40, "parent body")
 	parent := m.detail
 	child := Issue{ProjectID: 7, Number: 2, Title: "child task", Status: "open"}
 	m.detail = detailModel{
@@ -246,19 +256,9 @@ func TestScenario_EscPopsSplitDetailNavStackBeforeLeavingPane(t *testing.T) {
 // detail model first, then emits popDetailMsg; the parent handler must
 // clear split focus as well as view state.
 func TestScenario_BackspaceReturnsFromSplitDetailToList(t *testing.T) {
-	m := scenarioModel(t, 200, 40)
-	m = scenarioOpenDetail(t, m, "short body")
-	if m.layout != layoutSplit || m.view != viewDetail || m.focus != focusDetail {
-		t.Fatalf("setup: layout=%v view=%v focus=%v, want split/detail/detail",
-			m.layout, m.view, m.focus)
-	}
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
-	m = out.(Model)
-	if cmd == nil {
-		t.Fatal("Backspace from split detail returned nil cmd; want popDetailMsg")
-	}
-	out, _ = m.Update(cmd())
-	m = out.(Model)
+	m := setupDetailScenario(t, 200, 40, "short body")
+	assertViewState(t, m, layoutSplit, viewDetail, focusDetail)
+	m = sendKeyAndDrain(t, m, tea.KeyMsg{Type: tea.KeyBackspace})
 	if m.view != viewList {
 		t.Fatalf("Backspace did not return view to list: view=%v", m.view)
 	}
@@ -362,8 +362,7 @@ func TestScenario_LayoutToggle_NarrowThenWidePreservesSplitIntent(t *testing.T) 
 // that flips one but not both must still fail (roborev #17192
 // finding 1).
 func TestScenario_LDoesNotOpenLinkPromptInDetail(t *testing.T) {
-	m := scenarioModel(t, 200, 40)
-	m = scenarioOpenDetail(t, m, "short body")
+	m := setupDetailScenario(t, 200, 40, "short body")
 	prevLayout := m.layout
 	m = pressRune(t, m, 'L')
 	if m.input.kind != inputNone {
@@ -381,8 +380,7 @@ func TestScenario_LDoesNotOpenLinkPromptInDetail(t *testing.T) {
 // positive path — lowercase l should still open the link prompt. If
 // this test fails, AddLink got accidentally rebound or removed.
 func TestScenario_LowercaseLOpensLinkPromptInDetail(t *testing.T) {
-	m := scenarioModel(t, 120, 30)
-	m = scenarioOpenDetail(t, m, "short body")
+	m := setupDetailScenario(t, 120, 30, "short body")
 	m = sendKeyAndDrain(t, m, runeKey('l'))
 	if m.input.kind != inputLinkPrompt {
 		t.Fatalf("lowercase l did not open link prompt; m.input.kind = %v", m.input.kind)
@@ -443,9 +441,8 @@ func TestScenario_ChildCreatedRefetchesParentDetail(t *testing.T) {
 // on the children list, PageDown should still advance the body
 // scroll — the body-scroll keys are intentionally focus-agnostic.
 func TestScenario_BodyScrollWorksWhileChildrenFocused(t *testing.T) {
-	m := scenarioModel(t, 120, 30)
 	body := strings.Repeat("scrollable line\n", 60) + "BODY_TAIL"
-	m = scenarioOpenDetail(t, m, body)
+	m := setupDetailScenario(t, 120, 30, body)
 	// Seed a child so children focus is reachable.
 	m.detail.children = []Issue{{Number: 99, Title: "child", Status: "open"}}
 	// Cycle into children focus via Tab. The detail focus order is
@@ -458,7 +455,5 @@ func TestScenario_BodyScrollWorksWhileChildrenFocused(t *testing.T) {
 		t.Fatalf("setup: focus = %v, want focusChildren", m.detail.detailFocus)
 	}
 	m = pressN(t, m, tea.KeyMsg{Type: tea.KeyPgDown}, 16)
-	if !strings.Contains(view(m), "BODY_TAIL") {
-		t.Fatalf("PgDn on children focus did not scroll body to tail; view:\n%s", view(m))
-	}
+	assertViewContains(t, m, "BODY_TAIL")
 }

--- a/internal/tui/scope_test.go
+++ b/internal/tui/scope_test.go
@@ -1,61 +1,39 @@
 package tui
 
-import (
-	"strings"
-	"testing"
-
-	tea "github.com/charmbracelet/bubbletea"
-)
+import "testing"
 
 // TestEmptyState_RendersHint: viewEmpty renders the onboarding hint
 // containing both the "no kata projects" line and the kata init hint.
 func TestEmptyState_RendersHint(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewEmpty
-	m.width = 80
-	m.height = 24
-	out := m.View()
-	for _, want := range []string{
+	m := setupEmptyView()
+	assertContainsAll(t, m.View(),
 		"no kata projects registered yet",
 		"kata init",
 		"press q to quit",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("empty view missing %q in output\n%s", want, out)
-		}
-	}
+	)
 }
 
 // TestEmptyState_QuitsOnQ: q from viewEmpty opens the M3.5b
 // quit-confirm modal. Y from there commits to quit. ctrl+c remains
 // the immediate-quit escape hatch so the user is never trapped.
 func TestEmptyState_QuitsOnQ(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewEmpty
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
-	if out.(Model).modal != modalQuitConfirm {
-		t.Fatalf("q from viewEmpty did not open quit-confirm: %v", out.(Model).modal)
+	m, _ := updateModel(setupEmptyView(), keyRune('q'))
+	if m.modal != modalQuitConfirm {
+		t.Fatalf("q from viewEmpty did not open quit-confirm: %v", m.modal)
 	}
-	out, cmd := out.(Model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
-	_ = out
-	if cmd == nil {
-		t.Fatal("y in modal produced nil cmd, want tea.Quit")
-	}
-	if _, ok := cmd().(tea.QuitMsg); !ok {
-		t.Fatalf("y in modal cmd = %T, want tea.QuitMsg", cmd())
-	}
+	_, cmd := updateModel(m, keyRune('y'))
+	assertCmdQuit(t, cmd)
 }
 
 // TestEmptyState_OtherKeysIgnored: j, ?, R in viewEmpty are no-ops so an
 // unbound user can't accidentally fall into a partially-functional help
 // or list view from a state with no projects.
 func TestEmptyState_OtherKeysIgnored(t *testing.T) {
-	m := initialModel(Options{})
-	m.view = viewEmpty
+	m := setupEmptyView()
 	for _, k := range []rune{'j', '?', 'R', 'k', 's'} {
-		out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{k}})
-		if out.(Model).view != viewEmpty {
-			t.Fatalf("key %q changed view from empty to %v", k, out.(Model).view)
+		out, cmd := updateModel(m, keyRune(k))
+		if out.view != viewEmpty {
+			t.Fatalf("key %q changed view from empty to %v", k, out.view)
 		}
 		if cmd != nil {
 			t.Fatalf("key %q in viewEmpty returned non-nil cmd", k)
@@ -67,8 +45,5 @@ func TestEmptyState_OtherKeysIgnored(t *testing.T) {
 // without panicking inside lipgloss.Place. Defensive: the model emits
 // width/height from WindowSizeMsg, which can lag on first frame.
 func TestRenderEmpty_ZeroDims(t *testing.T) {
-	out := renderEmpty(0, 0)
-	if !strings.Contains(out, "no kata projects registered yet") {
-		t.Fatalf("zero-dim render missing hint:\n%s", out)
-	}
+	assertContainsAll(t, renderEmpty(0, 0), "no kata projects registered yet")
 }

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -83,6 +83,28 @@ func assertGolden(t *testing.T, name, got string) {
 	}
 }
 
+// snapViewChrome returns the steady-state viewChrome used by every
+// list snapshot: project 7 / "kata" scope, SSE connected, version
+// "v0.1.0". Tests that need to mutate (e.g. add an input bar) assign
+// to a local and modify the field they care about.
+func snapViewChrome() viewChrome {
+	return viewChrome{
+		scope:     scope{projectID: 7, projectName: "kata"},
+		sseStatus: sseConnected,
+		version:   "v0.1.0",
+	}
+}
+
+// snapListModel returns a listModel pre-loaded with the given issues
+// and loading flipped off — the universal starting point for every
+// TestSnapshot_List_* fixture.
+func snapListModel(issues []Issue) listModel {
+	lm := newListModel()
+	lm.loading = false
+	lm.issues = issues
+	return lm
+}
+
 // snapListFixture mirrors listFixture but pegs every UpdatedAt at a
 // known offset from snapshotFixedNow so humanizeRelative renders
 // deterministic deltas. The deleted row also has a fixed DeletedAt.
@@ -194,16 +216,9 @@ func snapDetailHierarchyFixture() detailModel {
 // covers open, closed, and soft-deleted statusChip branches.
 func TestSnapshot_List_DefaultMixedStatus(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = snapListFixture()
+	lm := snapListModel(snapListFixture())
 	lm.cursor = 1
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	got := lm.View(120, 30, chrome)
+	got := lm.View(120, 30, snapViewChrome())
 	assertGolden(t, "list-default-mixed-status", got)
 }
 
@@ -221,16 +236,9 @@ func TestSnapshot_List_DefaultMixedStatus(t *testing.T) {
 // empty-state hint appears.
 func TestSnapshot_List_EmptyAfterFilter(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = snapListFixture()
+	lm := snapListModel(snapListFixture())
 	lm.filter = ListFilter{Search: "no-match-anywhere"}
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	got := lm.View(120, 30, chrome)
+	got := lm.View(120, 30, snapViewChrome())
 	assertGolden(t, "list-empty-after-filter", got)
 }
 
@@ -239,16 +247,9 @@ func TestSnapshot_List_EmptyAfterFilter(t *testing.T) {
 // rendered background; underlying content stays painted around it.
 func TestSnapshot_QuitConfirmModal(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = snapListFixture()
+	lm := snapListModel(snapListFixture())
 	lm.cursor = 1
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	bg := lm.View(120, 30, chrome)
+	bg := lm.View(120, 30, snapViewChrome())
 	got := overlayModal(bg, renderQuitConfirmModal(), 120, 30)
 	assertGolden(t, "quit-confirm-modal", got)
 }
@@ -258,15 +259,9 @@ func TestSnapshot_QuitConfirmModal(t *testing.T) {
 // The footer help row swaps to the bar's enter/esc/ctrl+u keys.
 func TestSnapshot_List_SearchBarActive(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = snapListFixture()
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-		input:     newSearchBar(ListFilter{Search: "login"}),
-	}
+	lm := snapListModel(snapListFixture())
+	chrome := snapViewChrome()
+	chrome.input = newSearchBar(ListFilter{Search: "login"})
 	got := lm.View(120, 30, chrome)
 	assertGolden(t, "list-search-bar-active", got)
 }
@@ -277,8 +272,6 @@ func TestSnapshot_List_SearchBarActive(t *testing.T) {
 // indicator surfaces as `[start-end of N issues]` aligned right.
 func TestSnapshot_List_ScrollIndicator(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
 	issues := make([]Issue, 50)
 	for i := range issues {
 		issues[i] = Issue{
@@ -290,14 +283,9 @@ func TestSnapshot_List_ScrollIndicator(t *testing.T) {
 			),
 		}
 	}
-	lm.issues = issues
+	lm := snapListModel(issues)
 	lm.cursor = 25 // mid-list so the scroll window has both start and end visible
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	got := lm.View(120, 30, chrome)
+	got := lm.View(120, 30, snapViewChrome())
 	assertGolden(t, "list-scroll-indicator", got)
 }
 
@@ -309,95 +297,53 @@ func ptrFormat(n int64) string {
 
 func TestSnapshot_List_WithFilterChips(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = []Issue{{
+	lm := snapListModel([]Issue{{
 		Number: 1, Title: "narrowed by chips", Status: "open",
 		Owner:     ptrString("alice"),
 		UpdatedAt: snapshotFixedNow.Add(-30 * time.Minute),
-	}}
+	}})
 	lm.filter = ListFilter{Status: "open", Owner: "alice"}
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	got := lm.View(120, 30, chrome)
+	got := lm.View(120, 30, snapViewChrome())
 	assertGolden(t, "list-with-filter-chips", got)
 }
 
 func TestSnapshot_List_TreeCollapsed(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = snapTreeFixture()
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	got := lm.View(120, 22, chrome)
+	lm := snapListModel(snapTreeFixture())
+	got := lm.View(120, 22, snapViewChrome())
 	assertGolden(t, "list-tree-collapsed", got)
 }
 
 func TestSnapshot_List_TreeExpanded(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = snapTreeFixture()
+	lm := snapListModel(snapTreeFixture())
 	lm.expanded = expansionSet{{projectID: 7, number: 10}: true}
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	got := lm.View(120, 22, chrome)
+	got := lm.View(120, 22, snapViewChrome())
 	assertGolden(t, "list-tree-expanded", got)
 }
 
 func TestSnapshot_List_TreeAutoExpandedMatch(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = snapTreeFixture()
+	lm := snapListModel(snapTreeFixture())
 	lm.filter = ListFilter{Search: "jump target"}
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	got := lm.View(120, 22, chrome)
+	got := lm.View(120, 22, snapViewChrome())
 	assertGolden(t, "list-tree-auto-expanded-match", got)
 }
 
 func TestSnapshot_List_TreeContextRow(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = snapTreeFixture()
+	lm := snapListModel(snapTreeFixture())
 	lm.filter = ListFilter{Search: "hint bars"}
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	got := lm.View(120, 22, chrome)
+	got := lm.View(120, 22, snapViewChrome())
 	assertGolden(t, "list-tree-context-row", got)
 }
 
 func TestSnapshot_List_TreeNoColor(t *testing.T) {
 	defer snapshotInit(t)()
-	lm := newListModel()
-	lm.loading = false
-	lm.issues = snapTreeFixture()
+	lm := snapListModel(snapTreeFixture())
 	lm.expanded = expansionSet{{projectID: 7, number: 10}: true}
 	lm.filter = ListFilter{Search: "hint bars"}
-	chrome := viewChrome{
-		scope:     scope{projectID: 7, projectName: "kata"},
-		sseStatus: sseConnected,
-		version:   "v0.1.0",
-	}
-	got := lm.View(120, 22, chrome)
+	got := lm.View(120, 22, snapViewChrome())
 	if !strings.Contains(got, "-") || !strings.Contains(got, "~") {
 		t.Fatalf("no-color tree snapshot missing fallback disclosure or context marker:\n%s", got)
 	}
@@ -532,17 +478,12 @@ func TestSnapshot_Detail_DocumentWide160x32(t *testing.T) {
 		UpdatedAt: snapshotFixedNow.Add(-21 * time.Hour),
 	}
 	dm := detailModel{issue: &iss, scopePID: 7}
-	dm = dm.applyFetched(commentsFetchedMsg{gen: dm.gen, comments: nil})
-	dm = dm.applyFetched(eventsFetchedMsg{
-		gen: dm.gen,
-		events: []EventLogEntry{
-			{
-				ID: 1, Type: "issue.created", Actor: "anonymous",
-				CreatedAt: time.Date(2026, 5, 2, 19, 16, 0, 0, time.UTC),
-			},
+	dm = seedActivity(dm, nil, []EventLogEntry{
+		{
+			ID: 1, Type: "issue.created", Actor: "anonymous",
+			CreatedAt: time.Date(2026, 5, 2, 19, 16, 0, 0, time.UTC),
 		},
-	})
-	dm = dm.applyFetched(linksFetchedMsg{gen: dm.gen, links: nil})
+	}, nil)
 	got := dm.View(160, 32, viewChrome{
 		scope:   scope{projectID: 7, projectName: "kata"},
 		version: "dev",

--- a/internal/tui/split_test.go
+++ b/internal/tui/split_test.go
@@ -11,23 +11,46 @@ import (
 // splitTestSetup boots a Model into split layout (160x40) with the
 // listFixture seeded so the split tests have something to render and
 // drive cursor moves against. Returns the model and a cleanup that
-// reverts the rebuilt color mode.
+// reverts the rebuilt color mode. The api field is wired with a stub
+// Client so handlers that gate on a non-nil api don't no-op.
 func splitTestSetup(t *testing.T) (Model, func()) {
 	t.Helper()
 	t.Setenv("KATA_COLOR_MODE", "none")
 	t.Setenv("NO_COLOR", "")
 	applyDefaultColorMode(io.Discard)
 	m := initialModel(Options{})
+	m.api = &Client{}
 	m.scope = scope{projectID: 7, projectName: "kata"}
 	m.list.loading = false
 	m.list.issues = snapListFixture()
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
 	cleanup := func() { applyDefaultColorMode(io.Discard) }
 	if m.layout != layoutSplit {
 		t.Fatalf("split setup failed: layout=%v want layoutSplit", m.layout)
 	}
 	return m, cleanup
+}
+
+// focusFirstIssueDetail seeds the detail pane with m.list.issues[0],
+// pins scopePID to the active project, and switches focus to the
+// detail pane — the standard mutation pattern that drives detail-pane
+// tests in split mode.
+func focusFirstIssueDetail(m *Model) {
+	iss := m.list.issues[0]
+	m.detail.issue = &iss
+	m.detail.scopePID = m.scope.projectID
+	m.focus = focusDetail
+}
+
+// assertSingleOverlayBox verifies that view contains exactly one
+// rounded modal box (╭). Pane borders use the normal border (┌), so a
+// count > 1 means a modal accidentally rendered inside a pane instead
+// of over the whole terminal.
+func assertSingleOverlayBox(t *testing.T, view string) {
+	t.Helper()
+	if c := strings.Count(view, "╭"); c != 1 {
+		t.Errorf("expected exactly 1 modal top-left ╭ corner, got %d", c)
+	}
 }
 
 // TestSplit_CursorMoveRetargetsDetail covers the synchronous detail-
@@ -40,8 +63,7 @@ func TestSplit_CursorMoveRetargetsDetail(t *testing.T) {
 	defer cleanup()
 	// Press j twice — the fixture has 3 rows so cursor lands on row 2.
 	for i := 0; i < 2; i++ {
-		out, _ := m.Update(runeKey('j'))
-		m = out.(Model)
+		m, _ = updateModel(m, runeKey('j'))
 	}
 	if m.detail.issue == nil {
 		t.Fatal("dm.issue stayed nil after cursor moves")
@@ -66,8 +88,7 @@ func TestSplit_DebounceCoalescesBursts(t *testing.T) {
 	defer cleanup()
 	startGen := m.nextDetailFollowGen
 	for i := 0; i < 5; i++ {
-		out, _ := m.Update(runeKey('j'))
-		m = out.(Model)
+		m, _ = updateModel(m, runeKey('j'))
 	}
 	// Cursor caps at len-1 = 2 (3 rows), so two of the five j keys
 	// move and three are no-ops. The gen advances only on actual
@@ -92,8 +113,7 @@ func TestSplit_TabMovesFocusToDetail(t *testing.T) {
 	if m.focus != focusList {
 		t.Fatalf("setup focus=%v want focusList", m.focus)
 	}
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.KeyMsg{Type: tea.KeyTab})
 	if m.focus != focusDetail {
 		t.Errorf("focus=%v after tab, want focusDetail", m.focus)
 	}
@@ -106,8 +126,7 @@ func TestSplit_TabMovesFocusToDetail(t *testing.T) {
 func TestSplit_EnterMovesFocusToDetail(t *testing.T) {
 	m, cleanup := splitTestSetup(t)
 	defer cleanup()
-	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = out.(Model)
+	m, cmd := updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
 		t.Fatal("Enter on list pane produced no cmd; expected openDetailMsg dispatch")
 	}
@@ -115,8 +134,7 @@ func TestSplit_EnterMovesFocusToDetail(t *testing.T) {
 	if _, ok := msg.(openDetailMsg); !ok {
 		t.Fatalf("expected openDetailMsg from Enter, got %T", msg)
 	}
-	out, _ = m.Update(msg)
-	m = out.(Model)
+	m, _ = updateModel(m, msg)
 	if m.focus != focusDetail {
 		t.Errorf("focus=%v after enter+route, want focusDetail", m.focus)
 	}
@@ -128,11 +146,8 @@ func TestSplit_EnterMovesFocusToDetail(t *testing.T) {
 func TestSplit_EscReturnsFocusToList(t *testing.T) {
 	m, cleanup := splitTestSetup(t)
 	defer cleanup()
-	iss := m.list.issues[0]
-	m.detail.issue = &iss
-	m.focus = focusDetail
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	m = out.(Model)
+	focusFirstIssueDetail(&m)
+	m, _ = updateModel(m, tea.KeyMsg{Type: tea.KeyEsc})
 	if m.focus != focusList {
 		t.Errorf("focus=%v after esc, want focusList", m.focus)
 	}
@@ -145,17 +160,13 @@ func TestSplit_EscReturnsFocusToList(t *testing.T) {
 func TestSplit_EscDoesNotEscapeWhilePromptActive(t *testing.T) {
 	m, cleanup := splitTestSetup(t)
 	defer cleanup()
-	iss := m.list.issues[0]
-	m.detail.issue = &iss
-	m.detail.scopePID = 7
-	m.focus = focusDetail
+	focusFirstIssueDetail(&m)
 	// Open a label prompt.
 	m, _ = m.openInput(inputLabelPrompt)
 	if m.input.kind != inputLabelPrompt {
 		t.Fatalf("setup failed: input.kind=%v want inputLabelPrompt", m.input.kind)
 	}
-	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.KeyMsg{Type: tea.KeyEsc})
 	if m.input.kind != inputNone {
 		t.Errorf("input.kind=%v after first esc, want inputNone (prompt closed)", m.input.kind)
 	}
@@ -163,8 +174,7 @@ func TestSplit_EscDoesNotEscapeWhilePromptActive(t *testing.T) {
 		t.Errorf("focus=%v after first esc, want focusDetail (focus stays)", m.focus)
 	}
 	// Second esc moves focus.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.KeyMsg{Type: tea.KeyEsc})
 	if m.focus != focusList {
 		t.Errorf("focus=%v after second esc, want focusList", m.focus)
 	}
@@ -184,12 +194,7 @@ func TestSplit_FilterModalOverlaysWholeTerminal(t *testing.T) {
 	if !strings.Contains(got, "filter") {
 		t.Fatalf("filter modal did not render; output:\n%s", got)
 	}
-	// Modal box uses rounded border ╭ ╮ ╰ ╯; pane borders use the
-	// normal border (┌ ┐ └ ┘). One ╭ means the modal box is the
-	// only rounded panel on screen.
-	if c := strings.Count(got, "╭"); c != 1 {
-		t.Errorf("expected exactly 1 modal top-left ╭ corner, got %d", c)
-	}
+	assertSingleOverlayBox(t, got)
 }
 
 // TestSplit_NewIssueFormOverlaysWholeTerminal: same property for the
@@ -202,9 +207,7 @@ func TestSplit_NewIssueFormOverlaysWholeTerminal(t *testing.T) {
 	if !strings.Contains(got, "new issue") {
 		t.Fatalf("new-issue form did not render; output:\n%s", got)
 	}
-	if c := strings.Count(got, "╭"); c != 1 {
-		t.Errorf("expected exactly 1 modal top-left ╭ corner, got %d", c)
-	}
+	assertSingleOverlayBox(t, got)
 }
 
 // TestSplit_HelpRowSwapsWithFocus: focus=list shows list footer
@@ -243,10 +246,7 @@ func TestSplit_HelpRowSwapsWithFocus(t *testing.T) {
 func TestSplit_SuggestionMenuClampedToDetailPane(t *testing.T) {
 	m, cleanup := splitTestSetup(t)
 	defer cleanup()
-	iss := m.list.issues[0]
-	m.detail.issue = &iss
-	m.detail.scopePID = 7
-	m.focus = focusDetail
+	focusFirstIssueDetail(&m)
 	// Seed the label cache so the menu has a known row to find.
 	m.projectLabels.byProject[7] = labelCacheEntry{
 		pid: 7, gen: 1,
@@ -278,14 +278,12 @@ func TestSplit_LayoutFlip_FromStackedToSplitFromList(t *testing.T) {
 	m, cleanup := splitTestSetup(t)
 	defer cleanup()
 	// Already in split mode from setup — flip back to stacked first.
-	out, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	if m.layout != layoutStacked {
 		t.Fatalf("setup failed: layout=%v want layoutStacked", m.layout)
 	}
 	m.list.selectedNumber = 7
-	out, _ = m.Update(tea.WindowSizeMsg{Width: 160, Height: 40})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
 	if m.layout != layoutSplit {
 		t.Errorf("layout=%v after resize up, want layoutSplit", m.layout)
 	}
@@ -309,11 +307,8 @@ func TestSplit_LayoutFlip_FromStackedToSplitFromList(t *testing.T) {
 func TestSplit_JumpDetail_SurvivesCursorFollowFocusDetail(t *testing.T) {
 	m, cleanup := splitTestSetup(t)
 	defer cleanup()
-	// api must be non-nil for handleJumpDetail to dispatch the fetch.
-	m.api = &Client{}
 	// Press j to retarget detail via cursor-follow; m.view stays viewList.
-	out, _ := m.Update(runeKey('j'))
-	m = out.(Model)
+	m, _ = updateModel(m, runeKey('j'))
 	if m.detail.issue == nil {
 		t.Fatal("setup: cursor-follow did not retarget m.detail.issue")
 	}
@@ -321,8 +316,7 @@ func TestSplit_JumpDetail_SurvivesCursorFollowFocusDetail(t *testing.T) {
 		t.Fatalf("setup: m.view=%v want viewList (cursor-follow must not change m.view)", m.view)
 	}
 	// Tab advances focus to focusDetail; m.view still viewList.
-	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = out.(Model)
+	m, _ = updateModel(m, tea.KeyMsg{Type: tea.KeyTab})
 	if m.focus != focusDetail {
 		t.Fatalf("setup: m.focus=%v want focusDetail after Tab", m.focus)
 	}
@@ -337,63 +331,44 @@ func TestSplit_JumpDetail_SurvivesCursorFollowFocusDetail(t *testing.T) {
 	}
 }
 
-// TestSplit_JumpDetail_DroppedWhenHelpOverlayOpen covers Job 252:
-// when viewHelp is active in split mode (full-screen overlay hides
-// both panes), a queued jumpDetailMsg must NOT silently mutate the
-// hidden detail state. The original M6 fix used detailIsActive() which
+// TestSplit_JumpDetail_DroppedWhenViewObscured covers Job 252: when a
+// full-screen view (viewHelp / viewEmpty) hides both panes in split
+// mode, a queued jumpDetailMsg must NOT silently mutate the hidden
+// detail state. The original M6 fix used detailIsActive() which
 // ignored m.view; this test pins the corrected detailPaneVisible()
-// gate.
-func TestSplit_JumpDetail_DroppedWhenHelpOverlayOpen(t *testing.T) {
-	m, cleanup := splitTestSetup(t)
-	defer cleanup()
-	m.api = &Client{}
-	// Park focus on detail (the racy state: ? opens help while focus
-	// is still focusDetail). detailIsActive() alone returns true here,
-	// so the bare-helper gate would let the jump through.
-	m.focus = focusDetail
-	m.view = viewHelp
-	priorGen := m.detail.gen
-	if !m.detailIsActive() {
-		t.Fatalf("setup: detailIsActive=false with focusDetail, want true (test would not exercise the gate)")
+// gate across both obscuring views.
+func TestSplit_JumpDetail_DroppedWhenViewObscured(t *testing.T) {
+	cases := []struct {
+		name string
+		view viewID
+	}{
+		{"viewHelp", viewHelp},
+		{"viewEmpty", viewEmpty},
 	}
-	if m.detailPaneVisible() {
-		t.Fatalf("setup: detailPaneVisible=true with viewHelp, want false")
-	}
-	out, cmd := m.Update(jumpDetailMsg{number: 99})
-	if cmd != nil {
-		t.Fatal("jumpDetailMsg under viewHelp dispatched a cmd — hidden detail state mutated (Job 252 regression)")
-	}
-	nm := out.(Model)
-	if nm.detail.gen != priorGen {
-		t.Errorf("detail.gen advanced from %d to %d under viewHelp — hidden detail state mutated", priorGen, nm.detail.gen)
-	}
-}
-
-// TestSplit_JumpDetail_DroppedWhenEmptyState is the viewEmpty
-// counterpart of TestSplit_JumpDetail_DroppedWhenHelpOverlayOpen
-// (Job 252). viewEmpty (e.g. no project bound) is a full-screen
-// state that hides both panes; a queued jumpDetailMsg must not
-// mutate the hidden detail state.
-func TestSplit_JumpDetail_DroppedWhenEmptyState(t *testing.T) {
-	m, cleanup := splitTestSetup(t)
-	defer cleanup()
-	m.api = &Client{}
-	m.focus = focusDetail
-	m.view = viewEmpty
-	priorGen := m.detail.gen
-	if !m.detailIsActive() {
-		t.Fatalf("setup: detailIsActive=false with focusDetail, want true (test would not exercise the gate)")
-	}
-	if m.detailPaneVisible() {
-		t.Fatalf("setup: detailPaneVisible=true with viewEmpty, want false")
-	}
-	out, cmd := m.Update(jumpDetailMsg{number: 99})
-	if cmd != nil {
-		t.Fatal("jumpDetailMsg under viewEmpty dispatched a cmd — hidden detail state mutated (Job 252 regression)")
-	}
-	nm := out.(Model)
-	if nm.detail.gen != priorGen {
-		t.Errorf("detail.gen advanced from %d to %d under viewEmpty — hidden detail state mutated", priorGen, nm.detail.gen)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, cleanup := splitTestSetup(t)
+			defer cleanup()
+			// Park focus on detail (the racy state: ? opens help while
+			// focus is still focusDetail). detailIsActive() alone returns
+			// true here, so the bare-helper gate would let the jump through.
+			m.focus = focusDetail
+			m.view = tc.view
+			priorGen := m.detail.gen
+			if !m.detailIsActive() {
+				t.Fatalf("setup: detailIsActive=false with focusDetail, want true (test would not exercise the gate)")
+			}
+			if m.detailPaneVisible() {
+				t.Fatalf("setup: detailPaneVisible=true with %v, want false", tc.name)
+			}
+			nm, cmd := updateModel(m, jumpDetailMsg{number: 99})
+			if cmd != nil {
+				t.Fatalf("jumpDetailMsg under %s dispatched a cmd — hidden detail state mutated (Job 252 regression)", tc.name)
+			}
+			if nm.detail.gen != priorGen {
+				t.Errorf("detail.gen advanced from %d to %d under %s — hidden detail state mutated", priorGen, nm.detail.gen, tc.name)
+			}
+		})
 	}
 }
 
@@ -407,12 +382,8 @@ func TestSplit_JumpDetail_DroppedWhenEmptyState(t *testing.T) {
 func TestSplit_ListMutation_LandsOnListWhileFocusDetail(t *testing.T) {
 	m, cleanup := splitTestSetup(t)
 	defer cleanup()
-	m.api = &Client{}
 	m.list.actor = "tester"
-	iss := m.list.issues[0]
-	m.detail.issue = &iss
-	m.detail.scopePID = 7
-	m.focus = focusDetail
+	focusFirstIssueDetail(&m)
 	if m.listIsActive() {
 		t.Fatalf("setup: listIsActive=true with focusDetail, want false")
 	}
@@ -420,8 +391,7 @@ func TestSplit_ListMutation_LandsOnListWhileFocusDetail(t *testing.T) {
 		origin: "list", kind: "close",
 		resp: &MutationResp{Issue: &Issue{Number: 42, Status: "closed"}},
 	}
-	out, _ := m.Update(mut)
-	nm := out.(Model)
+	nm, _ := updateModel(m, mut)
 	if nm.list.status == "" {
 		t.Fatal("list.status empty — list-origin mutation dropped while focusDetail")
 	}
@@ -439,7 +409,6 @@ func TestSplit_ListMutation_LandsOnListWhileFocusDetail(t *testing.T) {
 func TestSplit_DetailMutation_LandsOnDetailWhileFocusList(t *testing.T) {
 	m, cleanup := splitTestSetup(t)
 	defer cleanup()
-	m.api = &Client{}
 	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Title: "to edit"}
 	m.detail.scopePID = 7
 	m.detail.gen = 5
@@ -451,8 +420,7 @@ func TestSplit_DetailMutation_LandsOnDetailWhileFocusList(t *testing.T) {
 		origin: "detail", gen: 5, kind: "body.edit",
 		resp: &MutationResp{Issue: &Issue{Number: 42, Body: "new"}},
 	}
-	out, _ := m.Update(mut)
-	nm := out.(Model)
+	nm, _ := updateModel(m, mut)
 	if nm.detail.status == "" {
 		t.Fatal("detail.status empty — detail-origin mutation dropped while focusList")
 	}
@@ -537,8 +505,7 @@ func TestSplit_CursorFollow_RetargetsOnSameNumberDifferentProject(t *testing.T) 
 	startGen := m.nextDetailFollowGen
 	// Press j — cursor moves to row 1; selectedNumber stays 1 because
 	// both rows share Number. Pre-fix this was a silent no-op.
-	out, _ := m.Update(runeKey('j'))
-	m = out.(Model)
+	m, _ = updateModel(m, runeKey('j'))
 	if m.list.cursor != 1 {
 		t.Fatalf("setup failed: cursor=%d after j, want 1", m.list.cursor)
 	}

--- a/internal/tui/sse_test.go
+++ b/internal/tui/sse_test.go
@@ -2,7 +2,7 @@ package tui
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -18,11 +18,8 @@ import (
 // not produce a frame; the issue.created frame after it must.
 func TestSSEParser_KeepalivesAreSkipped(t *testing.T) {
 	in := ": keepalive\n\n" +
-		"id: 1\nevent: issue.created\ndata: {\"event_id\":1,\"type\":\"issue.created\"}\n\n"
-	frames, err := parseAllFrames(strings.NewReader(in))
-	if err != nil && !errors.Is(err, io.EOF) {
-		t.Fatal(err)
-	}
+		formatSSEFrame(1, "issue.created", `{"event_id":1,"type":"issue.created"}`)
+	frames := assertParse(t, in)
 	if len(frames) != 1 {
 		t.Fatalf("got %d frames, want 1", len(frames))
 	}
@@ -36,12 +33,9 @@ func TestSSEParser_KeepalivesAreSkipped(t *testing.T) {
 
 // TestSSEParser_MultipleFrames: two consecutive event blocks both arrive.
 func TestSSEParser_MultipleFrames(t *testing.T) {
-	in := "id: 1\nevent: issue.created\ndata: {\"event_id\":1}\n\n" +
-		"id: 2\nevent: issue.commented\ndata: {\"event_id\":2}\n\n"
-	frames, err := parseAllFrames(strings.NewReader(in))
-	if err != nil {
-		t.Fatal(err)
-	}
+	in := formatSSEFrame(1, "issue.created", `{"event_id":1}`) +
+		formatSSEFrame(2, "issue.commented", `{"event_id":2}`)
+	frames := assertParse(t, in)
 	if len(frames) != 2 {
 		t.Fatalf("got %d frames, want 2", len(frames))
 	}
@@ -55,12 +49,9 @@ func TestSSEParser_MultipleFrames(t *testing.T) {
 // per api.EventReset's contract); the JSON payload's reset_after_id is
 // intentionally not lifted onto the frame.
 func TestSSEParser_ResetRequired(t *testing.T) {
-	in := "id: 42\nevent: sync.reset_required\n" +
-		"data: {\"event_id\":42,\"reset_after_id\":42}\n\n"
-	frames, err := parseAllFrames(strings.NewReader(in))
-	if err != nil {
-		t.Fatal(err)
-	}
+	in := formatSSEFrame(42, "sync.reset_required",
+		`{"event_id":42,"reset_after_id":42}`)
+	frames := assertParse(t, in)
 	if len(frames) != 1 {
 		t.Fatalf("got %d frames, want 1", len(frames))
 	}
@@ -76,12 +67,11 @@ func TestSSEParser_ResetRequired(t *testing.T) {
 // dropped, the next well-formed frame still arrives. Regression for
 // "single bad frame wedges the consumer."
 func TestSSEParser_MalformedFrameSkipped(t *testing.T) {
-	in := "id: 1\nevent: issue.created\n\n" + // no data line
-		"id: 2\nevent: issue.commented\ndata: {\"event_id\":2}\n\n"
-	frames, err := parseAllFrames(strings.NewReader(in))
-	if err != nil {
-		t.Fatal(err)
-	}
+	// First frame intentionally omits the data: line — the malformedness
+	// is the subject of the test, so it cannot be built via formatSSEFrame.
+	in := "id: 1\nevent: issue.created\n\n" +
+		formatSSEFrame(2, "issue.commented", `{"event_id":2}`)
+	frames := assertParse(t, in)
 	if len(frames) != 1 {
 		t.Fatalf("got %d frames, want 1 (malformed dropped)", len(frames))
 	}
@@ -93,11 +83,10 @@ func TestSSEParser_MalformedFrameSkipped(t *testing.T) {
 // TestSSEParser_EOFNoTrailingFrame: an in-progress frame at EOF is
 // dropped (no blank-line terminator means no commit).
 func TestSSEParser_EOFNoTrailingFrame(t *testing.T) {
+	// No trailing blank line — the missing terminator is the subject of
+	// the test, so it cannot be built via formatSSEFrame.
 	in := "id: 1\nevent: issue.created\ndata: {\"event_id\":1}\n"
-	frames, err := parseAllFrames(strings.NewReader(in))
-	if err != nil {
-		t.Fatal(err)
-	}
+	frames := assertParse(t, in)
 	if len(frames) != 0 {
 		t.Fatalf("got %d frames, want 0 (no terminator)", len(frames))
 	}
@@ -197,22 +186,16 @@ func TestNextBackoff_Doubles_Caps(t *testing.T) {
 // sseConnected status (deferred until the first frame arrives); the two
 // frames follow. Last-Event-ID is omitted on the first connect.
 func TestSSE_StreamForwardsMessages(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := newSSEMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Last-Event-ID") != "" {
 			t.Errorf("Last-Event-ID set on first connect: %q",
 				r.Header.Get("Last-Event-ID"))
 		}
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.WriteHeader(http.StatusOK)
-		_, _ = io.WriteString(w,
-			"id: 1\nevent: issue.created\ndata: {\"type\":\"issue.created\","+
-				"\"project_id\":7}\n\n")
-		w.(http.Flusher).Flush()
-		_, _ = io.WriteString(w,
-			"id: 2\nevent: sync.reset_required\ndata: {\"reset_after_id\":2}\n\n")
-		w.(http.Flusher).Flush()
-	}))
-	defer srv.Close()
+		writeSSEFrame(t, w, 1, "issue.created",
+			`{"type":"issue.created","project_id":7}`)
+		writeSSEFrame(t, w, 2, "sync.reset_required",
+			`{"reset_after_id":2}`)
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -250,12 +233,9 @@ func TestSSE_StreamForwardsMessages(t *testing.T) {
 // regression-locks Fix I1: a flapping daemon must not flicker
 // connected ↔ reconnecting between frame-less retries.
 func TestSSE_NoConnectedStatusBeforeFirstFrame(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.WriteHeader(http.StatusOK)
+	srv := newSSEMockServer(t, func(_ http.ResponseWriter, _ *http.Request) {
 		// Return immediately — body closes with no frames.
-	}))
-	defer srv.Close()
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -279,7 +259,7 @@ func TestSSE_NoConnectedStatusBeforeFirstFrame(t *testing.T) {
 func TestSSE_ReconnectSendsLastEventID(t *testing.T) {
 	var connects int32
 	var secondHeader atomic.Value
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := newSSEMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		n := atomic.AddInt32(&connects, 1)
 		if n >= 2 {
 			secondHeader.Store(r.Header.Get("Last-Event-ID"))
@@ -287,15 +267,10 @@ func TestSSE_ReconnectSendsLastEventID(t *testing.T) {
 			<-r.Context().Done()
 			return
 		}
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.WriteHeader(http.StatusOK)
-		_, _ = io.WriteString(w,
-			"id: 5\nevent: issue.created\ndata: {\"type\":\"issue.created\","+
-				"\"project_id\":7}\n\n")
-		w.(http.Flusher).Flush()
+		writeSSEFrame(t, w, 5, "issue.created",
+			`{"type":"issue.created","project_id":7}`)
 		// Close the connection by returning.
-	}))
-	defer srv.Close()
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ch := make(chan tea.Msg, 8)
@@ -385,4 +360,47 @@ func TestSSE_BuildRequest_SingleProjectAddsQuery(t *testing.T) {
 	if got := req.Header.Get("Last-Event-ID"); got != "9" {
 		t.Fatalf("Last-Event-ID = %q, want 9", got)
 	}
+}
+
+// formatSSEFrame builds a well-formed SSE frame: id + event + data
+// terminated by a blank line. Parser tests use this instead of raw string
+// concatenation so a missing newline can't masquerade as a real bug.
+func formatSSEFrame(id int64, event, data string) string {
+	return fmt.Sprintf("id: %d\nevent: %s\ndata: %s\n\n", id, event, data)
+}
+
+// writeSSEFrame writes a well-formed SSE frame to w and flushes. Mock SSE
+// handlers compose calls to this rather than juggling io.WriteString plus
+// the http.Flusher cast.
+func writeSSEFrame(t *testing.T, w http.ResponseWriter, id int64, event, data string) {
+	t.Helper()
+	if _, err := io.WriteString(w, formatSSEFrame(id, event, data)); err != nil {
+		t.Fatalf("write sse frame: %v", err)
+	}
+	w.(http.Flusher).Flush()
+}
+
+// newSSEMockServer wraps httptest.NewServer with the boilerplate every SSE
+// test repeats: Content-Type: text/event-stream + 200 OK before delegating
+// to handler. The server is closed via t.Cleanup.
+func newSSEMockServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// assertParse runs parseAllFrames against in and fails t on error,
+// returning only the frames the parser produced.
+func assertParse(t *testing.T, in string) []frame {
+	t.Helper()
+	frames, err := parseAllFrames(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return frames
 }

--- a/internal/tui/sse_update_test.go
+++ b/internal/tui/sse_update_test.go
@@ -34,6 +34,40 @@ func sseUpdateFixtureAt(t time.Time) Model {
 	return m
 }
 
+// sseDetailFixture builds a Model in detail view focused on a specific
+// open issue, with a stub *Client wired so refetch helpers can capture
+// it without hitting the network. detail.gen is seeded non-zero so
+// generation-tagged fetches don't look like the zero-valued initial
+// state.
+func sseDetailFixture(projectID, issueNumber int64) Model {
+	m := sseUpdateFixture()
+	m.scope = scope{projectID: projectID}
+	m.api = NewClient("http://kata.invalid", nil)
+	m.view = viewDetail
+	m.detail.issue = &Issue{ProjectID: projectID, Number: issueNumber, Status: "open"}
+	m.detail.scopePID = projectID
+	m.detail.gen = 5
+	return m
+}
+
+// assertDetailRefetchBatch fails t unless cmd produces a tea.BatchMsg
+// containing exactly four fetches (issue + comments + events + links) —
+// the shape every detail-tab refetch must dispatch.
+func assertDetailRefetchBatch(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd, got nil")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected tea.BatchMsg, got %T", msg)
+	}
+	if got := len(batch); got != 4 {
+		t.Fatalf("expected 4 fetches in batch (issue + 3 tabs), got %d", got)
+	}
+}
+
 // TestEventAffectsView_AllProjects: in all-projects scope, any event
 // with a non-zero projectID affects the view; projectID == 0 does not.
 func TestEventAffectsView_AllProjects(t *testing.T) {
@@ -149,13 +183,7 @@ func TestHandleEventReceived_NoEffect_NoStale(t *testing.T) {
 // directly so we don't have to invoke a 150ms tick to assert on cmd
 // shape.
 func TestHandleEventReceived_DetailViewSingleIssueRefetch(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
-	m.detail.scopePID = 7
-	m.detail.gen = 5
+	m := sseDetailFixture(7, 42)
 	cmd := m.maybeRefetchOpenDetail(eventReceivedMsg{projectID: 7, issueNumber: 42})
 	if cmd == nil {
 		t.Fatal("maybeRefetchOpenDetail must return a fetch cmd for matching issueNumber")
@@ -191,13 +219,7 @@ func TestHandleEventReceived_ParentLinkInvalidatesQueue(t *testing.T) {
 }
 
 func TestHandleEventReceived_ParentLinkRefetchesOpenParentDetail(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
-	m.detail.scopePID = 7
-	m.detail.gen = 5
+	m := sseDetailFixture(7, 42)
 
 	cmd := m.maybeRefetchOpenDetail(eventReceivedMsg{
 		eventType:   "issue.linked",
@@ -211,13 +233,7 @@ func TestHandleEventReceived_ParentLinkRefetchesOpenParentDetail(t *testing.T) {
 }
 
 func TestHandleEventReceived_ParentLinkRefetchesOpenChildDetail(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
-	m.detail.issue = &Issue{ProjectID: 7, Number: 43, Status: "open"}
-	m.detail.scopePID = 7
-	m.detail.gen = 5
+	m := sseDetailFixture(7, 43)
 
 	cmd := m.maybeRefetchOpenDetail(eventReceivedMsg{
 		eventType:   "issue.linked",
@@ -238,13 +254,7 @@ func TestHandleEventReceived_ParentLinkRefetchesOpenChildDetail(t *testing.T) {
 // payload carries a parent link and refetch the open parent's detail
 // — otherwise the parent's children section stays stale until reload.
 func TestHandleEventReceived_IssueCreatedWithParentRefetchesOpenParent(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
-	m.detail.scopePID = 7
-	m.detail.gen = 5
+	m := sseDetailFixture(7, 42)
 
 	cmd := m.maybeRefetchOpenDetail(eventReceivedMsg{
 		eventType:   "issue.created",
@@ -289,13 +299,7 @@ func TestDecodeEventReceived_IssueCreatedExtractsParentLink(t *testing.T) {
 }
 
 func TestHandleEventReceived_NonParentLinkDoesNotRefetchForHierarchy(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
-	m.detail.scopePID = 7
-	m.detail.gen = 5
+	m := sseDetailFixture(7, 42)
 
 	cmd := m.maybeRefetchOpenDetail(eventReceivedMsg{
 		eventType:   "issue.linked",
@@ -318,26 +322,10 @@ func TestHandleEventReceived_NonParentLinkDoesNotRefetchForHierarchy(t *testing.
 // children: maybeRefetchOpenDetail uses m.api (a real *Client), so
 // driving the children would actually hit the network.
 func TestHandleEventReceived_DetailViewRefetchesAllTabs(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
-	m.detail.scopePID = 7
-	m.detail.gen = 5
+	m := sseDetailFixture(7, 42)
 
 	cmd := m.maybeRefetchOpenDetail(eventReceivedMsg{projectID: 7, issueNumber: 42})
-	if cmd == nil {
-		t.Fatal("expected non-nil cmd for matching event")
-	}
-	msg := cmd()
-	batch, ok := msg.(tea.BatchMsg)
-	if !ok {
-		t.Fatalf("expected tea.BatchMsg from refetch cmd, got %T", msg)
-	}
-	if got := len(batch); got != 4 {
-		t.Fatalf("expected 4 fetches in batch (issue + 3 tabs), got %d", got)
-	}
+	assertDetailRefetchBatch(t, cmd)
 }
 
 // TestHandleEventReceived_DetailViewMismatch_NoRefetch: an event with a
@@ -345,12 +333,7 @@ func TestHandleEventReceived_DetailViewRefetchesAllTabs(t *testing.T) {
 // detail refetch — maybeRefetchOpenDetail returns nil. Tested directly
 // to avoid invoking the 150ms debounce tick.
 func TestHandleEventReceived_DetailViewMismatch_NoRefetch(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
-	m.detail.scopePID = 7
+	m := sseDetailFixture(7, 42)
 	cmd := m.maybeRefetchOpenDetail(eventReceivedMsg{projectID: 7, issueNumber: 99})
 	if cmd != nil {
 		t.Fatalf("maybeRefetchOpenDetail must return nil for non-matching issueNumber, got %T",
@@ -365,13 +348,9 @@ func TestHandleEventReceived_DetailViewMismatch_NoRefetch(t *testing.T) {
 // matched on issueNumber only, so a sibling project's event with the
 // same number would churn the wrong detail.
 func TestHandleEventReceived_CrossProjectMismatch_NoRefetch(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{allProjects: true}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
 	// Open detail is project A (#42); event is project B (#42).
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
-	m.detail.scopePID = 7
+	m := sseDetailFixture(7, 42)
+	m.scope = scope{allProjects: true}
 	cmd := m.maybeRefetchOpenDetail(eventReceivedMsg{projectID: 8, issueNumber: 42})
 	if cmd != nil {
 		t.Fatalf("cross-project event with same issueNumber must not refetch, got %T",
@@ -382,11 +361,8 @@ func TestHandleEventReceived_CrossProjectMismatch_NoRefetch(t *testing.T) {
 // TestMaybeRefetchOpenDetail_ListView_NoRefetch: even with a matching
 // issueNumber, list-view (not detail) must not dispatch a refetch.
 func TestMaybeRefetchOpenDetail_ListView_NoRefetch(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
+	m := sseDetailFixture(7, 42)
 	m.view = viewList
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
 	cmd := m.maybeRefetchOpenDetail(eventReceivedMsg{projectID: 7, issueNumber: 42})
 	if cmd != nil {
 		t.Fatalf("list-view must not refetch detail, got %T", cmd)
@@ -399,25 +375,9 @@ func TestMaybeRefetchOpenDetail_ListView_NoRefetch(t *testing.T) {
 // (each calls into m.api with the real *Client and would hit the
 // network).
 func TestRefetchOpenDetail_BatchShape(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
-	m.detail.scopePID = 7
-	m.detail.gen = 5
+	m := sseDetailFixture(7, 42)
 
-	cmd := m.refetchOpenDetail()
-	if cmd == nil {
-		t.Fatal("expected non-nil cmd from refetchOpenDetail in detail view")
-	}
-	batch, ok := cmd().(tea.BatchMsg)
-	if !ok {
-		t.Fatalf("expected tea.BatchMsg, got %T", cmd())
-	}
-	if len(batch) != 4 {
-		t.Fatalf("expected 4 fetches in batch, got %d", len(batch))
-	}
+	assertDetailRefetchBatch(t, m.refetchOpenDetail())
 }
 
 // TestRefetchOpenDetail_NoOpInList: when the active view is the list,
@@ -425,12 +385,8 @@ func TestRefetchOpenDetail_BatchShape(t *testing.T) {
 // stale detail fetches over the wire. A leftover m.detail.issue from
 // a prior open must NOT trigger a refetch.
 func TestRefetchOpenDetail_NoOpInList(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
+	m := sseDetailFixture(7, 42)
 	m.view = viewList
-	m.detail.issue = &Issue{ProjectID: 7, Number: 42, Status: "open"}
-	m.detail.scopePID = 7
 
 	if cmd := m.refetchOpenDetail(); cmd != nil {
 		t.Fatalf("expected nil cmd in viewList, got %T", cmd)
@@ -441,11 +397,9 @@ func TestRefetchOpenDetail_NoOpInList(t *testing.T) {
 // issue seeded) returns nil so the gen-tagged fetches don't fire
 // against a zero-valued projectID/number.
 func TestRefetchOpenDetail_NoOpWithoutIssue(t *testing.T) {
-	m := sseUpdateFixture()
-	m.scope = scope{projectID: 7}
-	m.api = NewClient("http://kata.invalid", nil)
-	m.view = viewDetail
-	// m.detail.issue is nil — view is viewDetail but pre-fetch.
+	m := sseDetailFixture(7, 42)
+	// view is viewDetail but pre-fetch — clear the seeded issue.
+	m.detail.issue = nil
 	if cmd := m.refetchOpenDetail(); cmd != nil {
 		t.Fatalf("expected nil cmd when issue not seeded, got %T", cmd)
 	}

--- a/internal/tui/suggest_render_test.go
+++ b/internal/tui/suggest_render_test.go
@@ -6,57 +6,49 @@ import (
 	"testing"
 )
 
+// defaultTestPrompt builds the inputLabelPrompt panel state shared by
+// every suggest-render test in this file: project 7, issue 1.
+func defaultTestPrompt() inputState {
+	return newPanelPrompt(inputLabelPrompt, formTarget{
+		projectID: 7, issueNumber: 1,
+	})
+}
+
 // TestSuggestMenu_RendersEntries: a populated cache produces a menu
 // with one row per suggestion (top + bottom border + N entry rows).
 func TestSuggestMenu_RendersEntries(t *testing.T) {
 	defer snapshotInit(t)()
-	s := newPanelPrompt(inputLabelPrompt, formTarget{
-		projectID: 7, issueNumber: 1,
-	})
+	s := defaultTestPrompt()
 	suggestions := []LabelCount{
 		{Label: "bug", Count: 5},
 		{Label: "design", Count: 3},
 	}
 	got := renderSuggestMenu(s, suggestions, labelCacheEntry{})
-	if !strings.Contains(got, "bug") {
-		t.Fatalf("menu missing 'bug': %q", got)
-	}
-	if !strings.Contains(got, "design") {
-		t.Fatalf("menu missing 'design': %q", got)
-	}
+	assertContains(t, got, "bug", "menu missing 'bug'")
+	assertContains(t, got, "design", "menu missing 'design'")
 }
 
 // TestSuggestMenu_LoadingPlaceholder: a fetching=true entry with no
 // labels renders the loading placeholder instead of an empty list.
 func TestSuggestMenu_LoadingPlaceholder(t *testing.T) {
 	defer snapshotInit(t)()
-	s := newPanelPrompt(inputLabelPrompt, formTarget{
-		projectID: 7, issueNumber: 1,
-	})
+	s := defaultTestPrompt()
 	got := renderSuggestMenu(s, nil, labelCacheEntry{
 		pid: 7, gen: 1, fetching: true,
 	})
-	if !strings.Contains(got, "loading") {
-		t.Fatalf("menu missing 'loading' placeholder: %q", got)
-	}
+	assertContains(t, got, "loading", "menu missing 'loading' placeholder")
 }
 
 // TestSuggestMenu_ErrorPlaceholder: an entry with a non-nil err
 // surfaces the error message in the menu body.
 func TestSuggestMenu_ErrorPlaceholder(t *testing.T) {
 	defer snapshotInit(t)()
-	s := newPanelPrompt(inputLabelPrompt, formTarget{
-		projectID: 7, issueNumber: 1,
-	})
+	s := defaultTestPrompt()
 	got := renderSuggestMenu(s, nil, labelCacheEntry{
 		pid: 7, gen: 1, err: errors.New("daemon 500"),
 	})
-	if !strings.Contains(got, "daemon 500") {
-		t.Fatalf("menu missing error message: %q", got)
-	}
-	if !strings.Contains(got, "error") {
-		t.Fatalf("menu missing error label: %q", got)
-	}
+	assertContains(t, got, "daemon 500", "menu missing error message")
+	assertContains(t, got, "error", "menu missing error label")
 }
 
 // TestSuggestMenu_EmptyPlaceholder: a fetched entry with zero labels
@@ -64,15 +56,11 @@ func TestSuggestMenu_ErrorPlaceholder(t *testing.T) {
 // no labels yet (rather than a confusingly-empty menu).
 func TestSuggestMenu_EmptyPlaceholder(t *testing.T) {
 	defer snapshotInit(t)()
-	s := newPanelPrompt(inputLabelPrompt, formTarget{
-		projectID: 7, issueNumber: 1,
-	})
+	s := defaultTestPrompt()
 	got := renderSuggestMenu(s, nil, labelCacheEntry{
 		pid: 7, gen: 1, fetching: false,
 	})
-	if !strings.Contains(got, "no labels") {
-		t.Fatalf("menu missing empty placeholder: %q", got)
-	}
+	assertContains(t, got, "no labels", "menu missing empty placeholder")
 }
 
 // TestSuggestMenu_Scrolls_HighlightStaysVisible: with N > maxRows
@@ -81,9 +69,7 @@ func TestSuggestMenu_EmptyPlaceholder(t *testing.T) {
 // without the windowing).
 func TestSuggestMenu_Scrolls_HighlightStaysVisible(t *testing.T) {
 	defer snapshotInit(t)()
-	s := newPanelPrompt(inputLabelPrompt, formTarget{
-		projectID: 7, issueNumber: 1,
-	})
+	s := defaultTestPrompt()
 	s.suggestHighlight = 9 // out past the menu's row budget
 	suggestions := make([]LabelCount, 12)
 	for i := range suggestions {
@@ -93,15 +79,12 @@ func TestSuggestMenu_Scrolls_HighlightStaysVisible(t *testing.T) {
 		}
 	}
 	got := renderSuggestMenu(s, suggestions, labelCacheEntry{})
-	if !strings.Contains(got, "lbl-10") {
-		t.Fatalf("scroll window did not include highlighted row "+
-			"(lbl-10): %q", got)
-	}
+	assertContains(t, got, "lbl-10",
+		"scroll window did not include highlighted row (lbl-10)")
 	// And the first entries (which would render without scroll)
 	// should NOT be present once the window has scrolled past them.
-	if strings.Contains(got, "lbl-1\n") || strings.Contains(got, "lbl-1 ") {
-		t.Fatalf("scroll window did not scroll past lbl-1: %q", got)
-	}
+	assertNotContains(t, got, "lbl-1\n", "scroll window did not scroll past lbl-1")
+	assertNotContains(t, got, "lbl-1 ", "scroll window did not scroll past lbl-1")
 }
 
 // TestFilterSuggestions_PrefixCaseInsensitive: prefix filter matches
@@ -240,9 +223,7 @@ func TestSuggestMenu_InfoLineAndFooterStayAtBottom_WhenMenuOpen(t *testing.T) {
 // placeholder rows).
 func TestSuggestMenuHeight_CountsBordersAndBody(t *testing.T) {
 	defer snapshotInit(t)()
-	s := newPanelPrompt(inputLabelPrompt, formTarget{
-		projectID: 7, issueNumber: 1,
-	})
+	s := defaultTestPrompt()
 	// Empty cache: 1 placeholder row + 2 borders = 3.
 	if got := suggestMenuHeight(s, nil, labelCacheEntry{}); got != 3 {
 		t.Fatalf("empty-cache height = %d, want 3", got)

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -125,13 +125,7 @@ func TestApplyColorMode_RebuildsAllStyles(t *testing.T) {
 // from statusStyle.
 func TestApplyColorMode_DeletedStyleIsRedFaint(t *testing.T) {
 	applyColorMode(colorDark, io.Discard)
-	fg, ok := deletedStyle.GetForeground().(lipgloss.Color)
-	if !ok {
-		t.Fatalf("deletedStyle.GetForeground() = %T, want lipgloss.Color", deletedStyle.GetForeground())
-	}
-	if string(fg) != "196" {
-		t.Fatalf("deletedStyle dark foreground = %q, want %q", string(fg), "196")
-	}
+	assertStyleForeground(t, deletedStyle, "deletedStyle dark", "196")
 	if !deletedStyle.GetFaint() {
 		t.Fatal("deletedStyle must be faint so the red doesn't read as an error chip")
 	}
@@ -139,29 +133,11 @@ func TestApplyColorMode_DeletedStyleIsRedFaint(t *testing.T) {
 
 func TestApplyColorMode_StatusColorsStayDistinctInWarmDisplays(t *testing.T) {
 	applyColorMode(colorDark, io.Discard)
-	openDark, ok := openStyle.GetForeground().(lipgloss.Color)
-	if !ok {
-		t.Fatalf("openStyle dark foreground = %T, want lipgloss.Color", openStyle.GetForeground())
-	}
-	closedDark, ok := closedStyle.GetForeground().(lipgloss.Color)
-	if !ok {
-		t.Fatalf("closedStyle dark foreground = %T, want lipgloss.Color", closedStyle.GetForeground())
-	}
-	if string(openDark) != "46" {
-		t.Fatalf("openStyle dark foreground = %q, want %q", string(openDark), "46")
-	}
-	if string(closedDark) != "245" {
-		t.Fatalf("closedStyle dark foreground = %q, want neutral gray %q", string(closedDark), "245")
-	}
+	assertStyleForeground(t, openStyle, "openStyle dark", "46")
+	assertStyleForeground(t, closedStyle, "closedStyle dark", "245")
 
 	applyColorMode(colorLight, io.Discard)
-	closedLight, ok := closedStyle.GetForeground().(lipgloss.Color)
-	if !ok {
-		t.Fatalf("closedStyle light foreground = %T, want lipgloss.Color", closedStyle.GetForeground())
-	}
-	if string(closedLight) != "240" {
-		t.Fatalf("closedStyle light foreground = %q, want neutral gray %q", string(closedLight), "240")
-	}
+	assertStyleForeground(t, closedStyle, "closedStyle light", "240")
 }
 
 // TestApplyColorMode_PanelBorderColorsBound asserts the M3+ panel
@@ -176,10 +152,6 @@ func TestApplyColorMode_PanelBorderColorsBound(t *testing.T) {
 	if panelInactiveBorder == nil {
 		t.Fatal("panelInactiveBorder must be bound by applyColorMode(colorDark)")
 	}
-	if c, ok := panelActiveBorder.(lipgloss.Color); ok && string(c) != "205" {
-		t.Fatalf("panelActiveBorder dark = %q, want %q", string(c), "205")
-	}
-	if c, ok := panelInactiveBorder.(lipgloss.Color); ok && string(c) != "246" {
-		t.Fatalf("panelInactiveBorder dark = %q, want %q", string(c), "246")
-	}
+	assertTerminalColor(t, panelActiveBorder, "panelActiveBorder dark", "205")
+	assertTerminalColor(t, panelInactiveBorder, "panelInactiveBorder dark", "246")
 }

--- a/internal/uid/uid_test.go
+++ b/internal/uid/uid_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/wesm/kata/internal/uid"
 )
 
+var fixedTestTime = time.Date(2026, 5, 4, 1, 2, 3, 456_000_000, time.UTC)
+
 func TestNewReturnsValidULID(t *testing.T) {
 	got, err := uid.New()
 	require.NoError(t, err)
@@ -34,30 +36,28 @@ func TestNewIsUniqueAndMonotonic(t *testing.T) {
 }
 
 func TestFromTimeEncodesTimestampWithRandomEntropy(t *testing.T) {
-	ts := time.Date(2026, 5, 4, 1, 2, 3, 456_000_000, time.UTC)
-	a, err := uid.FromTime(ts)
+	a, err := uid.FromTime(fixedTestTime)
 	require.NoError(t, err)
-	b, err := uid.FromTime(ts)
+	b, err := uid.FromTime(fixedTestTime)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, a, b)
-	assert.Equal(t, ts.UnixMilli(), uid.MustTime(a).UnixMilli())
-	assert.Equal(t, ts.UnixMilli(), uid.MustTime(b).UnixMilli())
+	assert.Equal(t, fixedTestTime.UnixMilli(), uid.MustTime(a).UnixMilli())
+	assert.Equal(t, fixedTestTime.UnixMilli(), uid.MustTime(b).UnixMilli())
 }
 
 func TestFromStableSeedIsDeterministic(t *testing.T) {
-	ts := time.Date(2026, 5, 4, 1, 2, 3, 456_000_000, time.UTC)
-	a, err := uid.FromStableSeed([]byte("issue:7:42"), ts)
+	a, err := uid.FromStableSeed([]byte("issue:7:42"), fixedTestTime)
 	require.NoError(t, err)
-	b, err := uid.FromStableSeed([]byte("issue:7:42"), ts)
+	b, err := uid.FromStableSeed([]byte("issue:7:42"), fixedTestTime)
 	require.NoError(t, err)
-	c, err := uid.FromStableSeed([]byte("issue:7:43"), ts)
+	c, err := uid.FromStableSeed([]byte("issue:7:43"), fixedTestTime)
 	require.NoError(t, err)
 
 	assert.Equal(t, a, b)
 	assert.NotEqual(t, a, c)
 	assert.True(t, uid.Valid(a))
-	assert.Equal(t, ts.UnixMilli(), uid.MustTime(a).UnixMilli())
+	assert.Equal(t, fixedTestTime.UnixMilli(), uid.MustTime(a).UnixMilli())
 }
 
 func TestValidAndValidPrefixRejectBadInput(t *testing.T) {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -7,29 +7,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVersionFromVCSPrefixesShortRevisionWithG(t *testing.T) {
-	origReadBuildInfo := readBuildInfo
-	defer func() { readBuildInfo = origReadBuildInfo }()
+func mockBuildInfo(t *testing.T, revision string, modified bool) {
+	t.Helper()
+	orig := readBuildInfo
+	t.Cleanup(func() { readBuildInfo = orig })
 
-	readBuildInfo = func() (*debug.BuildInfo, bool) {
-		return &debug.BuildInfo{Settings: []debug.BuildSetting{
-			{Key: settingRevision, Value: "1697674abcdef"},
-		}}, true
+	settings := []debug.BuildSetting{
+		{Key: settingRevision, Value: revision},
 	}
+	if modified {
+		settings = append(settings, debug.BuildSetting{Key: settingModified, Value: "true"})
+	}
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Settings: settings}, true
+	}
+}
 
+func TestVersionFromVCSPrefixesShortRevisionWithG(t *testing.T) {
+	mockBuildInfo(t, "1697674abcdef", false)
 	assert.Equal(t, "g1697674", versionFromVCS())
 }
 
 func TestVersionFromVCSPrefixesDirtyRevisionWithG(t *testing.T) {
-	origReadBuildInfo := readBuildInfo
-	defer func() { readBuildInfo = origReadBuildInfo }()
-
-	readBuildInfo = func() (*debug.BuildInfo, bool) {
-		return &debug.BuildInfo{Settings: []debug.BuildSetting{
-			{Key: settingRevision, Value: "1697674abcdef"},
-			{Key: settingModified, Value: "true"},
-		}}, true
-	}
-
+	mockBuildInfo(t, "1697674abcdef", true)
 	assert.Equal(t, "g1697674-dirty", versionFromVCS())
 }


### PR DESCRIPTION
## Summary

- Extract shared test fixtures into `internal/testfix` (git repo init, `.kata.toml` writer, `.git` stub) and add per-package `testhelpers_test.go` files for CLI, daemon, and DB helpers.
- Replace per-test boilerplate with reusable helpers: `setupCLIWorkspace`/`runCLI` for cmd/kata, `setupKataEnv`/`executeRoot` for daemon orchestration, `postJSON`/`getJSON` for HTTP envelopes, `setupTestIssue`/`setupTestProject` for DB tests, `mockDaemon`/`updateModel`/`assertContainsAll` for TUI tests.
- Convert several scattered table-style assertions into table-driven form (`TestFoldDetailsIntoMessage`, sanitize, textsafe, `resolveBody`).
- Externalize legacy schema SQL into `internal/jsonl/testdata/legacy_v{1,2,3}.sql` instead of inlining downgrade hacks.
- Net result: -2,366 lines across 139 test files with no production code changes.

## Test plan

- [ ] `go vet ./...` clean
- [ ] `go build ./...` clean
- [ ] `go test ./...` passes locally
- [ ] CI green