### PR TITLE
tui: KataAPI interface, nilaway pre-push hook, lint baseline + CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@8564da7cb3c6866ed1da648ca8f00a258ef0c802  # v6.5.2
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           version: v2.10.1
           args: --config .golangci.yml --no-fix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -33,16 +35,18 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@8564da7cb3c6866ed1da648ca8f00a258ef0c802  # v6.5.2
         with:
           version: v2.10.1
           args: --config .golangci.yml --no-fix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,23 @@ jobs:
 
       - name: Run tests
         run: go test -p 1 ./...
+
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.10.1
+          args: --config .golangci.yml --no-fix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,4 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           version: v2.10.1
-          args: --config .golangci.yml --no-fix
+          args: --config .golangci.yml

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -6,6 +6,31 @@ We are using the latest production version of Go.
 Be pragmatic — raising theoretical or highly pedantic concerns produces
 unnecessary code churn and wasted review-fix cycles.
 
+## Do not assert external facts you cannot verify
+
+You only see the diff. You do NOT have network access and cannot check
+upstream registries, release pages, or package indexes. Therefore:
+
+- Do NOT claim a pinned version, package name, image tag, or URL "does
+  not exist" or is "invalid". Your training data is bounded; new
+  releases happen constantly. If a maintainer pinned `v2.10.1`, assume
+  it exists. Treat unfamiliar version numbers as "unfamiliar to me",
+  not "nonexistent".
+- Do NOT recommend "fix: change to v1.x" based on a hallucinated belief
+  that the pinned version is wrong. The maintainer pinned a SHA along
+  with the version comment; that SHA pin IS the source of truth, and
+  you can see the version comment matches what the maintainer chose.
+- Do NOT claim a SHA does not match the tagged release. You cannot
+  resolve tags to SHAs without the GitHub API.
+- Do NOT flag third-party action upgrades as "downgrade" or "wrong
+  version" unless you can point to a specific breaking-change finding
+  IN THE DIFF (e.g. an input field that was removed and is still
+  referenced in the workflow).
+
+If you genuinely suspect a version is wrong, phrase it as a question
+("verify this version exists") at LOW severity, not as a Medium/High
+finding with a confident "fix".
+
 ## Trust model — single-user local tool
 
 kata is a single-user local CLI + daemon. The daemon binds to either a

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test test-short lint lint-ci vet clean fmt
+.PHONY: build install test test-short lint lint-ci vet clean fmt nilaway
 
 GOFLAGS_TEST := -shuffle=on
 
@@ -22,6 +22,18 @@ lint-ci:
 
 vet:
 	go vet ./...
+
+nilaway:
+	@if ! command -v nilaway >/dev/null 2>&1; then \
+		echo "nilaway not found. Install with:" >&2; \
+		echo "  go install go.uber.org/nilaway/cmd/nilaway@latest" >&2; \
+		exit 1; \
+	fi
+	@module_path="$$(go list -m)" || { \
+		echo "failed to determine module path" >&2; \
+		exit 1; \
+	}; \
+		nilaway -include-pkgs="$$module_path" -test=false ./...
 
 fmt:
 	gofmt -w .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test test-short lint lint-ci vet clean fmt nilaway
+.PHONY: build install test test-short lint vet clean fmt nilaway
 
 GOFLAGS_TEST := -shuffle=on
 
@@ -16,9 +16,6 @@ test-short:
 
 lint:
 	golangci-lint run --config .golangci.yml
-
-lint-ci:
-	golangci-lint run --config .golangci.yml --no-fix
 
 vet:
 	go vet ./...

--- a/cmd/kata/daemon_logs.go
+++ b/cmd/kata/daemon_logs.go
@@ -149,6 +149,9 @@ func runHookLogOnce(stdout, stderr io.Writer, limit int, f *hookLogFilter) (acti
 			mark = activeMark{set: true, info: info, size: info.Size()}
 		}
 	}
+	if matches == nil {
+		return mark, nil
+	}
 	start := 0
 	if limit > 0 && len(matches) > limit {
 		start = len(matches) - limit

--- a/cmd/kata/export.go
+++ b/cmd/kata/export.go
@@ -42,7 +42,7 @@ func newExportCmd() *cobra.Command {
 				return err
 			}
 			defer func() { _ = d.Close() }()
-			f, err := os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+			f, err := os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600) //nolint:gosec // output path is user-supplied via --output CLI flag
 			if err != nil {
 				return fmt.Errorf("open export output: %w", err)
 			}

--- a/cmd/kata/export_test.go
+++ b/cmd/kata/export_test.go
@@ -30,7 +30,7 @@ func TestExportWritesJSONLToOutput(t *testing.T) {
 	out, err := runCmdOutput(t, nil, "export", "--output", outPath)
 	require.NoError(t, err)
 
-	bs, err := os.ReadFile(outPath)
+	bs, err := os.ReadFile(outPath) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	assert.Contains(t, string(bs), `"kind":"meta"`)
 	assert.Contains(t, string(bs), "exported issue")

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -480,7 +480,7 @@ func ensureGitignoreEntry(dir, entry string) error {
 		if len(existing) > 0 && existing[len(existing)-1] != '\n' {
 			prefix = "\n"
 		}
-		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644) //nolint:gosec // .gitignore is world-readable by convention; mode is unused by O_APPEND on existing files but golangci-lint flags it
 		if err != nil {
 			return err
 		}

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -45,7 +45,7 @@ func TestInit_AddsLocalToGitignoreWhenAbsent(t *testing.T) {
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
 	require.NoError(t, err)
 
-	content, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	content, err := os.ReadFile(filepath.Join(dir, ".gitignore")) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	assert.Contains(t, string(content), ".kata.local.toml")
 }
@@ -56,7 +56,7 @@ func TestInit_GitignoreIsIdempotent(t *testing.T) {
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"),
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), //nolint:gosec // test fixture mirrors production .gitignore mode
 		[]byte("node_modules/\n.kata.local.toml\n"), 0o644))
 
 	flags.JSON = true
@@ -65,7 +65,7 @@ func TestInit_GitignoreIsIdempotent(t *testing.T) {
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
 	require.NoError(t, err)
 
-	content, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	content, err := os.ReadFile(filepath.Join(dir, ".gitignore")) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	// Exactly one occurrence — no duplication on re-run.
 	assert.Equal(t, 1, strings.Count(string(content), ".kata.local.toml"))
@@ -84,7 +84,7 @@ func TestInit_GitignoreLandsAtWorkspaceRoot(t *testing.T) {
 	runGit(t, root, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
 	sub := filepath.Join(root, "internal", "tui")
-	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.MkdirAll(sub, 0o755)) //nolint:gosec // test fixture under TempDir
 
 	flags.JSON = true
 	t.Cleanup(func() { flags.JSON = false })
@@ -99,7 +99,7 @@ func TestInit_GitignoreLandsAtWorkspaceRoot(t *testing.T) {
 	// .gitignore must follow .kata.toml — at the git root.
 	rootIgnore := filepath.Join(root, ".gitignore")
 	assert.FileExists(t, rootIgnore)
-	content, err := os.ReadFile(rootIgnore)
+	content, err := os.ReadFile(rootIgnore) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	assert.Contains(t, string(content), ".kata.local.toml")
 
@@ -200,7 +200,7 @@ func TestInit_RemoteClient_WritesGitignore(t *testing.T) {
 	_, err := callInit(context.Background(), daemonStub.srv.URL, dir, callInitOpts{})
 	require.NoError(t, err)
 
-	content, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	content, err := os.ReadFile(filepath.Join(dir, ".gitignore")) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	assert.Contains(t, string(content), ".kata.local.toml")
 }
@@ -298,7 +298,7 @@ func TestInit_GitignoreAppendsToExisting(t *testing.T) {
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"),
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), //nolint:gosec // test fixture mirrors production .gitignore mode
 		[]byte("dist/\n"), 0o644))
 
 	flags.JSON = true
@@ -307,7 +307,7 @@ func TestInit_GitignoreAppendsToExisting(t *testing.T) {
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
 	require.NoError(t, err)
 
-	content, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	content, err := os.ReadFile(filepath.Join(dir, ".gitignore")) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "dist/")
 	assert.Contains(t, string(content), ".kata.local.toml")

--- a/cmd/kata/link.go
+++ b/cmd/kata/link.go
@@ -102,15 +102,6 @@ func newUnrelateCmd() *cobra.Command {
 	}
 }
 
-// canonicalRelated returns (min, max) so callers don't need to remember
-// which direction the schema enforces.
-func canonicalRelated(a, b int64) (int64, int64) {
-	if a < b {
-		return a, b
-	}
-	return b, a
-}
-
 func runLinkCreate(cmd *cobra.Command, fromRef string, linkType string, toRef string, replace bool) error {
 	ctx := cmd.Context()
 	start, err := resolveStartPath(flags.Workspace)

--- a/internal/config/local_config.go
+++ b/internal/config/local_config.go
@@ -60,7 +60,7 @@ func MergeLocalWithStderr(base, local *ProjectConfig, stderr io.Writer) *Project
 		return &merged
 	}
 	if local.Project.Identity != "" && local.Project.Identity != base.Project.Identity {
-		fmt.Fprintf(stderr, "kata: ignoring divergent project.identity %q in .kata.local.toml (canonical is %q in .kata.toml)\n",
+		_, _ = fmt.Fprintf(stderr, "kata: ignoring divergent project.identity %q in .kata.local.toml (canonical is %q in .kata.toml)\n",
 			local.Project.Identity, base.Project.Identity)
 	}
 	if local.Project.Name != "" {

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -119,7 +119,7 @@ identity = "github.com/wesm/kata"
 name     = "kata"
 `)
 	sub := filepath.Join(root, "internal", "tui")
-	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.MkdirAll(sub, 0o755)) //nolint:gosec // test fixture under TempDir
 
 	cfg, foundDir, err := config.FindProjectConfig(sub)
 	require.NoError(t, err)

--- a/internal/daemon/handlers_digest.go
+++ b/internal/daemon/handlers_digest.go
@@ -383,6 +383,9 @@ func renderIssueAccums(m map[issueKey]*issueAccum) []api.DigestIssueActions {
 	out := make([]api.DigestIssueActions, 0, len(keys))
 	for _, k := range keys {
 		acc := m[k]
+		if acc == nil {
+			continue
+		}
 		out = append(out, api.DigestIssueActions{
 			ProjectID:       k.ProjectID,
 			ProjectIdentity: acc.ProjectIdentity,

--- a/internal/daemonclient/remote_test.go
+++ b/internal/daemonclient/remote_test.go
@@ -144,7 +144,7 @@ func TestResolveRemote_FileFoundInParentDirectory(t *testing.T) {
 	t.Setenv("KATA_SERVER", "")
 	parent := t.TempDir()
 	child := filepath.Join(parent, "subdir")
-	require.NoError(t, os.Mkdir(child, 0o755))
+	require.NoError(t, os.Mkdir(child, 0o755)) //nolint:gosec // test fixture under TempDir
 	writeWorkspaceMarker(t, parent)
 	require.NoError(t, os.WriteFile(filepath.Join(parent, ".kata.local.toml"),
 		[]byte(`version = 1
@@ -240,7 +240,7 @@ func TestResolveRemote_FileIgnoredAboveWorkspaceBoundary(t *testing.T) {
 	outer := t.TempDir()
 	workspace := filepath.Join(outer, "workspace")
 	sub := filepath.Join(workspace, "deep", "subdir")
-	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.MkdirAll(sub, 0o755)) //nolint:gosec // test fixture under TempDir
 	writeWorkspaceMarker(t, workspace)
 
 	// Attacker file in the shared ancestor — points at an unreachable
@@ -268,7 +268,7 @@ func TestResolveRemote_FileInsideWorkspaceWinsOverOutsideAncestor(t *testing.T) 
 	t.Setenv("KATA_SERVER", "")
 	outer := t.TempDir()
 	workspace := filepath.Join(outer, "workspace")
-	require.NoError(t, os.MkdirAll(workspace, 0o755))
+	require.NoError(t, os.MkdirAll(workspace, 0o755)) //nolint:gosec // test fixture under TempDir
 	writeWorkspaceMarker(t, workspace)
 
 	// Attacker file higher up — must be ignored.
@@ -299,7 +299,7 @@ func TestResolveRemote_GitMarkerCountsAsWorkspace(t *testing.T) {
 	srv := pingingServer(t)
 	t.Setenv("KATA_SERVER", "")
 	dir := t.TempDir()
-	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755)) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
 		[]byte(`version = 1
 [server]
@@ -318,7 +318,7 @@ url = "`+srv.URL+`"
 // discovery to a legitimate boundary.
 func writeWorkspaceMarker(t *testing.T, dir string) {
 	t.Helper()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"),
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"), //nolint:gosec // test fixture mirrors production .kata.toml mode
 		[]byte("version = 1\n\n[project]\nidentity = \"github.com/wesm/test\"\nname = \"test\"\n"),
 		0o644))
 }

--- a/internal/jsonl/cutover.go
+++ b/internal/jsonl/cutover.go
@@ -77,7 +77,7 @@ func exportCutoverSource(ctx context.Context, sourcePath, tmpJSONL string) error
 		return err
 	}
 	defer func() { _ = source.Close() }()
-	f, err := os.OpenFile(tmpJSONL, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	f, err := os.OpenFile(tmpJSONL, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // tmpJSONL is daemon-controlled state-dir filename
 	if err != nil {
 		return fmt.Errorf("create cutover jsonl: %w", err)
 	}

--- a/internal/jsonl/cutover_test.go
+++ b/internal/jsonl/cutover_test.go
@@ -40,13 +40,13 @@ func TestAutoCutoverFailureLeavesSourceAndRemovesTemps(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "kata.db")
 	writeVersionZeroDB(t, path)
-	before, err := os.ReadFile(path)
+	before, err := os.ReadFile(path) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 
 	err = jsonl.AutoCutover(ctx, path)
 
 	require.Error(t, err)
-	after, readErr := os.ReadFile(path)
+	after, readErr := os.ReadFile(path) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, readErr)
 	assert.Equal(t, before, after)
 	assertNoCutoverTemps(t, path)

--- a/internal/jsonl/fixtures_test.go
+++ b/internal/jsonl/fixtures_test.go
@@ -69,7 +69,7 @@ func assertSchemaVersion(t *testing.T, path string, expected int) {
 // SQL in testdata/<fixtureName>.
 func writeLegacyDBFromFixture(t *testing.T, path, fixtureName string) {
 	t.Helper()
-	schema, err := os.ReadFile(filepath.Join("testdata", fixtureName))
+	schema, err := os.ReadFile(filepath.Join("testdata", fixtureName)) //nolint:gosec // testdata path is constant per call site
 	require.NoError(t, err)
 	raw, err := sql.Open("sqlite", path)
 	require.NoError(t, err)

--- a/internal/jsonl/types.go
+++ b/internal/jsonl/types.go
@@ -9,6 +9,7 @@ import (
 // Kind is the fixed record kind tag in a JSONL envelope.
 type Kind string
 
+// JSONL record kinds. Order matches the export sequence enforced by kindOrder.
 const (
 	KindMeta           Kind = "meta"
 	KindProject        Kind = "project"
@@ -22,6 +23,7 @@ const (
 	KindSQLiteSequence Kind = "sqlite_sequence"
 )
 
+// Sentinel errors returned by the decoder for malformed or out-of-order envelopes.
 var (
 	ErrMissingExportVersion = errors.New("missing export_version")
 	ErrUnknownKind          = errors.New("unknown kind")

--- a/internal/tui/api.go
+++ b/internal/tui/api.go
@@ -1,0 +1,23 @@
+package tui
+
+import "context"
+
+// KataAPI is the daemon surface the TUI consumes. It is owned by this
+// package (the consumer) and covers exactly the methods the TUI calls
+// today — no speculative future-proofing for a remote engine. When that
+// engine lands it will satisfy this interface structurally and the
+// surface can grow alongside concrete need.
+//
+// The narrower listAPI / detailAPI / labelLister interfaces continue to
+// type the call sites that only need a slice of the surface. KataAPI is
+// the union held by Model.api so a single value can be passed to those
+// narrower seams.
+type KataAPI interface {
+	listAPI
+	detailAPI
+
+	ListProjects(ctx context.Context) ([]ProjectSummary, error)
+	ListProjectsWithStats(ctx context.Context) ([]ProjectSummaryWithStats, error)
+	ListLabels(ctx context.Context, projectID int64) ([]LabelCount, error)
+	ResolveProject(ctx context.Context, startPath string) (*ResolveResp, error)
+}

--- a/internal/tui/detail_render.go
+++ b/internal/tui/detail_render.go
@@ -467,7 +467,11 @@ func (dm detailModel) renderInfoLine(width int, chrome viewChrome, tabBudget int
 // keep it intact (don't sanitize — strips the cursor) and width-clip
 // with ansi.Truncate so escape sequences survive.
 func renderInfoPrompt(s inputState, innerWidth int) string {
-	body := s.title + ": " + s.activeField().input.View()
+	field := s.activeField()
+	if field == nil {
+		return ansi.Truncate(s.title+": ", innerWidth, "…")
+	}
+	body := s.title + ": " + field.input.View()
 	return ansi.Truncate(body, innerWidth, "…")
 }
 

--- a/internal/tui/detail_render.go
+++ b/internal/tui/detail_render.go
@@ -386,33 +386,6 @@ func detailDocumentBudgets(avail, childCount int, hasActivity bool) (
 	return bodyRows, childRows, tabRows
 }
 
-func detailSplitBudgets(height, childCount int) (bodyRows, childRows, tabRows int) {
-	return detailBudgets(height-7, childCount)
-}
-
-func detailBudgets(avail, childCount int) (bodyRows, childRows, tabRows int) {
-	if avail < 1 {
-		avail = 1
-	}
-	if childCount > 0 && avail >= detailMinBodyRows+detailMinTabRows+2 {
-		childRows = min(childCount+1, max(2, avail/4))
-		avail -= childRows
-	}
-	bodyRows = avail * 2 / 3
-	if bodyRows < detailMinBodyRows && avail > detailMinBodyRows {
-		bodyRows = detailMinBodyRows
-	}
-	tabRows = avail - bodyRows
-	if tabRows < detailMinTabRows {
-		tabRows = min(detailMinTabRows, max(0, avail-1))
-		bodyRows = avail - tabRows
-	}
-	if bodyRows < 1 {
-		bodyRows = 1
-	}
-	return bodyRows, childRows, tabRows
-}
-
 // renderInfoLine renders the info line just above the footer for the
 // detail view. Same priority order as the list view: active panel
 // prompt > flash > SSE-degraded > toast > scroll indicator. Always
@@ -475,76 +448,12 @@ func renderInfoPrompt(s inputState, innerWidth int) string {
 	return ansi.Truncate(body, innerWidth, "…")
 }
 
-// detailMinSplit is the smallest tab-content + body budget that gets
-// the proportional split. Below it, fall back to the floors.
-const detailMinSplit = 8
-
 // detailMinBodyRows / detailMinTabRows are the floors so neither
 // pane collapses to zero on small terminals.
 const (
 	detailMinBodyRows = 4
 	detailMinTabRows  = 3
 )
-
-// renderHeaderMeta builds the first detail-header row:
-// `#N · status · author · created Xago · updated Yago`. Sanitized
-// agent text only — author flows through sanitizeForDisplay.
-func renderHeaderMeta(iss Issue) string {
-	left := fmt.Sprintf("#%d", iss.Number) + " · " + statusChip(iss)
-	bits := []string{}
-	if iss.Author != "" {
-		bits = append(bits, sanitizeForDisplay(iss.Author))
-	}
-	if !iss.CreatedAt.IsZero() {
-		bits = append(bits, "created "+humanizeRelative(iss.CreatedAt))
-	}
-	if !iss.UpdatedAt.IsZero() {
-		bits = append(bits, "updated "+humanizeRelative(iss.UpdatedAt))
-	}
-	right := strings.Join(bits, " · ")
-	if right == "" {
-		return left
-	}
-	return left + " · " + right
-}
-
-// renderHeaderAssignment builds the second header row: owner on the
-// left, label chips packed on the right. Width-aware so the chip
-// strip surrenders cells to the owner half rather than overflowing.
-// Owner placeholder `Owner: —` keeps the row's visible weight when
-// no owner is set.
-func renderHeaderAssignment(width int, iss Issue) string {
-	left := "Owner: " + ownerDisplay(iss.Owner)
-	leftCells := runewidth.StringWidth(left)
-	// Right side gets whatever remains after the owner half plus a
-	// 1-cell separator. Floor at 1 so renderLabelChips doesn't get a
-	// negative budget on tiny terminals — its own ultra-narrow path
-	// will degrade gracefully.
-	rightBudget := width - leftCells - 1
-	if rightBudget < 1 {
-		rightBudget = 1
-	}
-	right := renderLabelChips(iss.Labels, rightBudget)
-	return padLeftRightInside(left, right, width)
-}
-
-// ownerDisplay returns the rendered owner text, sanitized for display.
-// Nil or empty owner renders as the em-dash placeholder so the row
-// keeps its visible weight (`Owner: —`).
-func ownerDisplay(owner *string) string {
-	if owner == nil || *owner == "" {
-		return "—"
-	}
-	return sanitizeForDisplay(*owner)
-}
-
-// renderHeaderTitle is the bold full-width title row below the
-// assignment row. Sanitized + truncated so the rendered cell never
-// overflows or carries control sequences.
-func renderHeaderTitle(width int, iss Issue) string {
-	t := sanitizeForDisplay(iss.Title)
-	return titleStyle.Render(truncate(t, max(20, width)))
-}
 
 func renderHierarchySummary(width int, parent *IssueRef, children []Issue) string {
 	left := "Parent: -"
@@ -569,22 +478,6 @@ func childrenCountSummary(children []Issue) string {
 		}
 	}
 	return fmt.Sprintf("%d open / %d total", open, len(children))
-}
-
-// renderLabeledRule produces `── <label> ──` padded to width with
-// dashes. Falls back to a plain dash run when the label prefix is
-// wider than the available width — defensive against tiny terminals
-// so we never call strings.Repeat with a negative count.
-func renderLabeledRule(label string, width int) string {
-	if width <= 0 {
-		return ""
-	}
-	prefix := "── " + label + " ──"
-	prefixW := runewidth.StringWidth(prefix)
-	if prefixW > width {
-		return separatorRuleStyle.Render(strings.Repeat("─", width))
-	}
-	return separatorRuleStyle.Render(prefix + strings.Repeat("─", width-prefixW))
 }
 
 // activeTabLabel returns the singular noun for the active tab so the
@@ -720,28 +613,6 @@ func hardWrap(s string, width int) []string {
 		out = append(out, s)
 	}
 	return out
-}
-
-// renderTabStrip renders the three tab titles with their counts. The
-// active tab is wrapped in literal brackets (`[ Comments (4) ]`) plus
-// the bold/underline tabActive style; inactive tabs are plain text.
-// The bracket-and-bold combo gives the active state two redundant
-// signals so it remains visible in `KATA_COLOR_MODE=none`.
-func (dm detailModel) renderTabStrip() string {
-	titles := [detailTabCount]string{
-		fmt.Sprintf("Comments (%d)", len(dm.comments)),
-		fmt.Sprintf("Events (%d)", len(dm.events)),
-		fmt.Sprintf("Links (%d)", len(dm.links)),
-	}
-	parts := make([]string, 0, detailTabCount)
-	for i, t := range titles {
-		if detailTab(i) == dm.activeTab {
-			parts = append(parts, tabActive.Render("[ "+t+" ]"))
-		} else {
-			parts = append(parts, tabInactive.Render(t))
-		}
-	}
-	return strings.Join(parts, "  ")
 }
 
 // renderActiveTab dispatches to the per-tab renderer. The header line

--- a/internal/tui/detail_tabs.go
+++ b/internal/tui/detail_tabs.go
@@ -191,6 +191,9 @@ func windowChunks(chunks []entryChunk, cursor, budget int) []entryChunk {
 // renderer's view) instead of comparing entry count to line budget
 // directly — see roborev #119 finding 2.
 func windowChunkBounds(chunks []entryChunk, cursor, budget int) (int, int) {
+	if chunks == nil {
+		return 0, 0
+	}
 	n := len(chunks)
 	if n == 0 {
 		return 0, 0

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -298,7 +298,9 @@ func (s inputState) Update(msg tea.KeyMsg) (inputState, inputAction) {
 	case tea.KeyEsc:
 		return s, actionCancel
 	case tea.KeyCtrlU:
-		s.activeField().setValue("")
+		if f := s.activeField(); f != nil {
+			f.setValue("")
+		}
 		return s, actionNone
 	}
 	if isLabelPromptKind(s.kind) {

--- a/internal/tui/inputs_render.go
+++ b/internal/tui/inputs_render.go
@@ -21,7 +21,10 @@ func renderInputBar(s inputState, width int) string {
 		BorderForeground(panelActiveBorder).
 		Width(width-2). // -2 for the side borders
 		Padding(0, 1)
-	body := sanitizeForDisplay(s.activeField().input.View())
+	var body string
+	if field := s.activeField(); field != nil {
+		body = sanitizeForDisplay(field.input.View())
+	}
 	rendered := box.Render(body)
 	// Embed the title in the top border via a manual overlay: lipgloss
 	// doesn't expose a "title in border" primitive yet, so prepend a
@@ -46,7 +49,10 @@ func renderPanelPrompt(s inputState, width int) string {
 		BorderForeground(panelActiveBorder).
 		Width(width-2).
 		Padding(0, 1)
-	body := sanitizeForDisplay(s.activeField().input.View())
+	var body string
+	if field := s.activeField(); field != nil {
+		body = sanitizeForDisplay(field.input.View())
+	}
 	rendered := box.Render(body)
 	title := titleStyle.Render(" " + s.title + " ")
 	return title + "\n" + rendered

--- a/internal/tui/label_cache.go
+++ b/internal/tui/label_cache.go
@@ -71,8 +71,6 @@ func (m Model) dispatchLabelFetch(pid int64) (Model, tea.Cmd) {
 	entry.fetching = true
 	entry.err = nil
 	m.projectLabels.byProject[pid] = entry
-	// m.api is *Client — convert to labelLister carefully so a typed-
-	// nil pointer doesn't become a non-nil interface inside the cmd.
 	var api labelLister
 	if m.api != nil {
 		api = m.api

--- a/internal/tui/list_render.go
+++ b/internal/tui/list_render.go
@@ -283,7 +283,10 @@ func renderListInfoLine(width int, chrome viewChrome, lm listModel, dataBudget i
 // Plan 8 commit 5a retired the owner bar; the search bar is the only
 // remaining inline command bar so the prefix is unconditionally "/".
 func renderInfoBar(s inputState, innerWidth int) string {
-	full := "/" + s.activeField().input.View()
+	full := "/"
+	if field := s.activeField(); field != nil {
+		full += field.input.View()
+	}
 	return ansi.Truncate(full, innerWidth, "…")
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -42,7 +42,7 @@ const (
 // replace it to drive deterministic toast expiry.
 type Model struct {
 	opts           Options
-	api            *Client
+	api            KataAPI
 	scope          scope
 	view           viewID
 	prevView       viewID
@@ -1378,7 +1378,7 @@ func normalizeOwner(buf string) *string {
 // Title is sent untrimmed; Labels and Owner have already been
 // normalized by commitNewIssueForm.
 func dispatchFormCreateIssue(
-	api *Client, pid int64, body CreateIssueBody, formGen int64,
+	api listAPI, pid int64, body CreateIssueBody, formGen int64,
 ) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -1395,7 +1395,7 @@ func dispatchFormCreateIssue(
 // with origin="form" + the captured formGen so routeFormMutation can
 // match the response to the still-open form.
 func dispatchFormAddComment(
-	api *Client, target formTarget, body, actor string, formGen int64,
+	api detailAPI, target formTarget, body, actor string, formGen int64,
 ) tea.Cmd {
 	pid, num := target.projectID, target.issueNumber
 	return func() tea.Msg {
@@ -1412,7 +1412,7 @@ func dispatchFormAddComment(
 // dispatchFormEditBody is the form-side EditBody dispatch. Same
 // shape as dispatchFormAddComment.
 func dispatchFormEditBody(
-	api *Client, target formTarget, body, actor string, formGen int64,
+	api detailAPI, target formTarget, body, actor string, formGen int64,
 ) tea.Cmd {
 	pid, num := target.projectID, target.issueNumber
 	return func() tea.Msg {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1136,7 +1136,11 @@ func (m Model) applyLiveBarFilter() Model {
 	if m.input.kind == inputNone {
 		return m
 	}
-	v := m.input.activeField().value()
+	field := m.input.activeField()
+	if field == nil {
+		return m
+	}
+	v := field.value()
 	if m.input.kind == inputSearchBar {
 		m.list.filter.Search = v
 	}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -65,7 +65,12 @@ func Run(ctx context.Context, opts Options) error {
 // frame renders with stats.
 func buildRunModel(opts Options, c *Client, bi bootInit) Model {
 	m := initialModel(opts)
-	m.api = c
+	// Guard against a typed-nil *Client becoming a non-nil KataAPI:
+	// only assign when c carries a value, so m.api stays a true nil
+	// interface otherwise and m.api != nil checks remain correct.
+	if c != nil {
+		m.api = c
+	}
 	m.scope = bi.scope
 	m.view = bi.view
 	if len(bi.projects) > 0 {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,8 @@
+// Package version exposes the kata build's version string, derived from
+// runtime/debug.BuildInfo so a stripped binary still reports a stable
+// identifier.
+//
+//nolint:revive // var-naming flags `version` as stdlib-conflicting but no such stdlib package exists.
 package version
 
 import "runtime/debug"

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,3 +1,4 @@
+//nolint:revive // var-naming flags `version` as stdlib-conflicting but no such stdlib package exists; matches the production package name.
 package version
 
 import (

--- a/prek.toml
+++ b/prek.toml
@@ -1,5 +1,9 @@
-repos = [
-  { repo = "local", hooks = [
-    { id = "make-lint", name = "make lint", entry = "make lint", language = "system", pass_filenames = false, always_run = true },
-  ] },
+default_install_hook_types = ["pre-push"]
+default_stages = ["pre-commit"]
+
+[[repos]]
+repo = "local"
+hooks = [
+  { id = "make-lint", name = "make lint", entry = "make lint", language = "system", pass_filenames = false, always_run = true },
+  { id = "nilaway", name = "nilaway", entry = "make nilaway", language = "system", stages = ["pre-push"], types_or = ["go", "go-mod", "go-sum"], pass_filenames = false },
 ]


### PR DESCRIPTION
## Summary

Bundles four connected changes that emerged from extracting the TUI's daemon abstraction.

### KataAPI interface (closes #19)
- New `internal/tui/api.go` defining `KataAPI` — embeds the existing narrow `listAPI` + `detailAPI` and adds the four methods `Model` itself calls (`ListProjects`, `ListProjectsWithStats`, `ListLabels`, `ResolveProject`).
- `Model.api` switches from `*Client` to `KataAPI`. `*Client` satisfies it structurally; existing tests that assign `&Client{}` or `NewClient(...)` keep working.
- Form-dispatch helpers narrow: `dispatchFormCreateIssue` → `listAPI`, `dispatchFormAddComment`/`EditBody` → `detailAPI`.
- Unblocks #20 (HTTP-backed engine) and #21 (engine resolver) — the remote engine just has to satisfy `KataAPI` structurally.

### Defensive nil guards
Roborev follow-up. With `Model.api` an interface, a typed-nil `*Client` could become a non-nil `KataAPI`; added a guard at the single assignment site so `m.api != nil` checks stay correct. While running nilaway against the codebase, fixed seven additional findings — all defensive guards at locations where the runtime was already correct (slicing nil slices is safe, map keys sourced from the same map's iteration are present, callers ensured `inputState` had fields), but which nilaway can't prove without help.

### nilaway pre-push hook
- `make nilaway` runs `go.uber.org/nilaway/cmd/nilaway` scoped to first-party packages.
- Wired into prek as a pre-push hook. Install with `prek install -t pre-push`.

### Lint baseline + CI guard
- Cleared the 24 pre-existing `make lint` findings: deleted ~138 lines of dead code (orphaned helpers in `internal/tui/detail_render.go` after the document-style detail layout landed; an unused `canonicalRelated` in `cmd/kata/link.go`), added missing docstrings on exported `jsonl.Kind`/`Err*` blocks and the `version` package, fixed an unchecked `fmt.Fprintf`, and annotated gosec/revive false positives with one-line justifications.
- Added a `lint` job to `.github/workflows/test.yml` running `golangci-lint v2.10.1` on every PR and main push so the baseline can't regress.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [x] `make nilaway` clean
- [x] `make lint` clean (zero issues)
- [x] `git push` exercises the pre-push hook end-to-end