### PR TITLE
tui: invisible reconnects + plain-http guard for remote URLs

### DIFF
--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -37,8 +37,14 @@ type ProjectBindings struct {
 // http://100.64.0.5:7777). When set on .kata.local.toml it directs
 // the client to a remote daemon; ignored if it appears in committed
 // .kata.toml in v1, but parsed without error.
+//
+// AllowInsecure opts out of the client-side scheme guard that rejects
+// plain http to a non-private host. Required when URL uses a hostname
+// (the client cannot resolve it without DNS access) or a public IP
+// over plain http. Has no effect on https URLs.
 type ServerConfig struct {
-	URL string `toml:"url,omitempty"`
+	URL           string `toml:"url,omitempty"`
+	AllowInsecure bool   `toml:"allow_insecure,omitempty"`
 }
 
 // ReadProjectConfig parses <workspaceRoot>/.kata.toml and validates v1 fields.

--- a/internal/daemonclient/remote.go
+++ b/internal/daemonclient/remote.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/wesm/kata/internal/config"
@@ -90,14 +91,11 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 }
 
 // envAllowInsecure reports whether KATA_ALLOW_INSECURE is set to a
-// truthy value. Anything other than "1" or "true" (case-insensitive)
-// is false.
+// truthy value. Accepts "1" and "true" (case-insensitive) with
+// surrounding whitespace trimmed.
 func envAllowInsecure() bool {
-	switch os.Getenv(allowInsecureEnvVar) {
-	case "1", "true", "TRUE", "True":
-		return true
-	}
-	return false
+	v := strings.TrimSpace(os.Getenv(allowInsecureEnvVar))
+	return v == "1" || strings.EqualFold(v, "true")
 }
 
 // findLocalConfig walks upward from start looking for .kata.local.toml,
@@ -221,7 +219,11 @@ func requireSecureOrPrivate(u *url.URL, allowInsecure bool) error {
 // probeRemote does a 1-second /api/v1/ping check against base. We keep
 // the budget tight: a misconfigured remote should fail fast, not stall
 // the user behind the 5-second auto-start deadline.
-func probeRemote(ctx context.Context, base string) bool {
+//
+// Indirected through a package-level var so tests that exercise
+// resolution paths past the probe (e.g. allow_insecure bypass) can
+// stub the network call without dialing TEST-NET addresses.
+var probeRemote = func(ctx context.Context, base string) bool {
 	client := &http.Client{Timeout: 1 * time.Second}
 	return Ping(ctx, client, base)
 }

--- a/internal/daemonclient/remote.go
+++ b/internal/daemonclient/remote.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -11,11 +12,17 @@ import (
 	"time"
 
 	"github.com/wesm/kata/internal/config"
+	"github.com/wesm/kata/internal/daemon"
 )
 
 // remoteServerEnvVar is the environment variable that names a kata
 // daemon URL. When set, it takes precedence over .kata.local.toml.
 const remoteServerEnvVar = "KATA_SERVER"
+
+// allowInsecureEnvVar opts out of the plain-http guard for KATA_SERVER.
+// Truthy values: "1", "true". Has no effect on .kata.local.toml; the
+// equivalent there is `[server].allow_insecure = true`.
+const allowInsecureEnvVar = "KATA_ALLOW_INSECURE"
 
 // ErrRemoteUnavailable wraps probe failures against an explicitly
 // configured remote URL (env or .kata.local.toml). Callers translate
@@ -49,7 +56,7 @@ func ResolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 // would silently miss the workspace's local override.
 func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, error) {
 	if v := os.Getenv(remoteServerEnvVar); v != "" {
-		u, err := normalizeRemoteURL(v)
+		u, err := normalizeRemoteURL(v, envAllowInsecure())
 		if err != nil {
 			return "", false, fmt.Errorf("KATA_SERVER %q: %w", v, err)
 		}
@@ -72,7 +79,7 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 	if cfg.Server.URL == "" {
 		return "", false, nil
 	}
-	u, err := normalizeRemoteURL(cfg.Server.URL)
+	u, err := normalizeRemoteURL(cfg.Server.URL, cfg.Server.AllowInsecure)
 	if err != nil {
 		return "", false, fmt.Errorf("%s server.url %q: %w", path, cfg.Server.URL, err)
 	}
@@ -80,6 +87,17 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 		return "", false, fmt.Errorf("%w: %s (%s)", ErrRemoteUnavailable, u, path)
 	}
 	return u, true, nil
+}
+
+// envAllowInsecure reports whether KATA_ALLOW_INSECURE is set to a
+// truthy value. Anything other than "1" or "true" (case-insensitive)
+// is false.
+func envAllowInsecure() bool {
+	switch os.Getenv(allowInsecureEnvVar) {
+	case "1", "true", "TRUE", "True":
+		return true
+	}
+	return false
 }
 
 // findLocalConfig walks upward from start looking for .kata.local.toml,
@@ -161,7 +179,13 @@ func isWorkspaceBoundary(dir string) bool {
 // normalizeRemoteURL parses a value as an http(s) URL and returns the
 // canonical scheme://host[:port] form (no path, no query). Empty path
 // matches the daemon's expectation: callers append /api/v1/... themselves.
-func normalizeRemoteURL(v string) (string, error) {
+//
+// Enforces a scheme guard: plain http is allowed only for private IP
+// literals (loopback, RFC1918, CGNAT, link-local, ULA — the same set
+// the daemon's listen-address validator accepts). Hostnames over plain
+// http and public IPs over plain http are rejected unless allowInsecure
+// is true. https URLs are unaffected.
+func normalizeRemoteURL(v string, allowInsecure bool) (string, error) {
 	u, err := url.Parse(v)
 	if err != nil {
 		return "", fmt.Errorf("parse url: %w", err)
@@ -172,7 +196,26 @@ func normalizeRemoteURL(v string) (string, error) {
 	if u.Host == "" {
 		return "", errors.New("url must include host")
 	}
+	if err := requireSecureOrPrivate(u, allowInsecure); err != nil {
+		return "", err
+	}
 	return u.Scheme + "://" + u.Host, nil
+}
+
+// requireSecureOrPrivate returns nil when the URL is safe to dial over
+// the given network posture. https is always safe; plain http is only
+// safe for a private IP literal. allowInsecure short-circuits the check
+// for users who know what they're doing (e.g. talking to an internal
+// service over a hostname inside a private overlay).
+func requireSecureOrPrivate(u *url.URL, allowInsecure bool) error {
+	if u.Scheme == "https" || allowInsecure {
+		return nil
+	}
+	host := u.Hostname()
+	if err := daemon.ValidateNonPublicAddress(net.JoinHostPort(host, "1")); err != nil {
+		return fmt.Errorf("plain http to %q is not allowed: %w; use https or set allow_insecure (env KATA_ALLOW_INSECURE=1, or [server].allow_insecure=true in .kata.local.toml)", host, err)
+	}
+	return nil
 }
 
 // probeRemote does a 1-second /api/v1/ping check against base. We keep

--- a/internal/daemonclient/remote_test.go
+++ b/internal/daemonclient/remote_test.go
@@ -313,6 +313,148 @@ url = "`+srv.URL+`"
 	assert.Equal(t, srv.URL, url)
 }
 
+// TestNormalizeRemoteURL_SchemeGuard covers the plain-http guard.
+// Plain http is rejected for public IPs and hostnames; loopback and
+// private IPs are accepted; https and allow_insecure short-circuit.
+func TestNormalizeRemoteURL_SchemeGuard(t *testing.T) {
+	cases := []struct {
+		name           string
+		url            string
+		allowInsecure  bool
+		wantOK         bool
+		wantErrSubstr  string
+		wantNormalized string
+	}{
+		{
+			name: "https public host allowed",
+			url:  "https://example.com:7777", wantOK: true,
+			wantNormalized: "https://example.com:7777",
+		},
+		{
+			name: "http loopback allowed",
+			url:  "http://127.0.0.1:7777", wantOK: true,
+			wantNormalized: "http://127.0.0.1:7777",
+		},
+		{
+			name: "http rfc1918 allowed",
+			url:  "http://10.0.0.5:7777", wantOK: true,
+			wantNormalized: "http://10.0.0.5:7777",
+		},
+		{
+			name: "http cgnat allowed (tailscale range)",
+			url:  "http://100.64.0.5:7777", wantOK: true,
+			wantNormalized: "http://100.64.0.5:7777",
+		},
+		{
+			name: "http public ipv4 rejected",
+			url:  "http://8.8.8.8:7777", wantOK: false,
+			wantErrSubstr: "plain http to \"8.8.8.8\"",
+		},
+		{
+			name: "http hostname rejected (cannot validate without DNS)",
+			url:  "http://kata.example.com:7777", wantOK: false,
+			wantErrSubstr: "plain http to \"kata.example.com\"",
+		},
+		{
+			name: "http localhost hostname rejected (use 127.0.0.1)",
+			url:  "http://localhost:7777", wantOK: false,
+			wantErrSubstr: "plain http to \"localhost\"",
+		},
+		{
+			name: "http public ipv4 allowed when allow_insecure",
+			url:  "http://8.8.8.8:7777", allowInsecure: true, wantOK: true,
+			wantNormalized: "http://8.8.8.8:7777",
+		},
+		{
+			name: "http hostname allowed when allow_insecure",
+			url:  "http://kata.example.com:7777", allowInsecure: true, wantOK: true,
+			wantNormalized: "http://kata.example.com:7777",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeRemoteURL(tc.url, tc.allowInsecure)
+			if tc.wantOK {
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantNormalized, got)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrSubstr)
+		})
+	}
+}
+
+// TestResolveRemote_EnvSchemeGuardRejectsPublicHTTP verifies the guard
+// fires through the env-driven entry point with a clear actionable
+// error mentioning KATA_ALLOW_INSECURE.
+func TestResolveRemote_EnvSchemeGuardRejectsPublicHTTP(t *testing.T) {
+	t.Setenv("KATA_SERVER", "http://8.8.8.8:7777")
+	t.Setenv("KATA_ALLOW_INSECURE", "")
+
+	_, _, err := resolveRemote(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KATA_SERVER")
+	assert.Contains(t, err.Error(), "allow_insecure")
+}
+
+// TestResolveRemote_EnvAllowInsecureBypassesGuard confirms the env
+// opt-out lets a public-http URL through the guard. The probe still
+// fails (the URL points nowhere) so the surface error is
+// ErrRemoteUnavailable, not the guard error.
+func TestResolveRemote_EnvAllowInsecureBypassesGuard(t *testing.T) {
+	t.Setenv("KATA_SERVER", "http://198.51.100.1:1") // TEST-NET-2, unroutable
+	t.Setenv("KATA_ALLOW_INSECURE", "1")
+
+	_, _, err := resolveRemote(context.Background(), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRemoteUnavailable)
+	assert.NotContains(t, err.Error(), "allow_insecure",
+		"guard message must not appear when allow_insecure is set")
+}
+
+// TestResolveRemote_FileSchemeGuardRejectsPublicHTTP exercises the
+// guard via .kata.local.toml. Without allow_insecure the URL is
+// rejected before the probe runs.
+func TestResolveRemote_FileSchemeGuardRejectsPublicHTTP(t *testing.T) {
+	t.Setenv("KATA_SERVER", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeWorkspaceMarker(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "http://8.8.8.8:7777"
+`), 0o600))
+
+	_, _, err := resolveRemote(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".kata.local.toml")
+	assert.Contains(t, err.Error(), "allow_insecure")
+}
+
+// TestResolveRemote_FileAllowInsecureBypassesGuard confirms the file
+// opt-out lets a public-http URL through the guard. The probe still
+// fails (URL is unroutable) so the surface error is ErrRemoteUnavailable.
+func TestResolveRemote_FileAllowInsecureBypassesGuard(t *testing.T) {
+	t.Setenv("KATA_SERVER", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeWorkspaceMarker(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "http://198.51.100.1:1"
+allow_insecure = true
+`), 0o600))
+
+	_, _, err := resolveRemote(context.Background(), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRemoteUnavailable)
+	assert.NotContains(t, err.Error(), "is not allowed",
+		"guard message must not appear when allow_insecure is set")
+}
+
 // writeWorkspaceMarker drops a minimal .kata.toml at dir so the
 // test mimics a real kata workspace, anchoring .kata.local.toml
 // discovery to a legitimate boundary.

--- a/internal/daemonclient/remote_test.go
+++ b/internal/daemonclient/remote_test.go
@@ -3,6 +3,7 @@ package daemonclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -399,11 +400,12 @@ func TestResolveRemote_EnvSchemeGuardRejectsPublicHTTP(t *testing.T) {
 }
 
 // TestResolveRemote_EnvAllowInsecureBypassesGuard confirms the env
-// opt-out lets a public-http URL through the guard. The probe still
-// fails (the URL points nowhere) so the surface error is
-// ErrRemoteUnavailable, not the guard error.
+// opt-out lets a public-http URL through the guard. The probe is
+// stubbed to return false so the surface error is
+// ErrRemoteUnavailable; this avoids any real outbound dial.
 func TestResolveRemote_EnvAllowInsecureBypassesGuard(t *testing.T) {
-	t.Setenv("KATA_SERVER", "http://198.51.100.1:1") // TEST-NET-2, unroutable
+	stubProbe(t, false)
+	t.Setenv("KATA_SERVER", "http://198.51.100.1:7777") // TEST-NET-2, never dialed
 	t.Setenv("KATA_ALLOW_INSECURE", "1")
 
 	_, _, err := resolveRemote(context.Background(), "")
@@ -434,9 +436,11 @@ url = "http://8.8.8.8:7777"
 }
 
 // TestResolveRemote_FileAllowInsecureBypassesGuard confirms the file
-// opt-out lets a public-http URL through the guard. The probe still
-// fails (URL is unroutable) so the surface error is ErrRemoteUnavailable.
+// opt-out lets a public-http URL through the guard. The probe is
+// stubbed to return false so the surface error is
+// ErrRemoteUnavailable; this avoids any real outbound dial.
 func TestResolveRemote_FileAllowInsecureBypassesGuard(t *testing.T) {
+	stubProbe(t, false)
 	t.Setenv("KATA_SERVER", "")
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -444,7 +448,7 @@ func TestResolveRemote_FileAllowInsecureBypassesGuard(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
 		[]byte(`version = 1
 [server]
-url = "http://198.51.100.1:1"
+url = "http://198.51.100.1:7777"
 allow_insecure = true
 `), 0o600))
 
@@ -453,6 +457,44 @@ allow_insecure = true
 	assert.ErrorIs(t, err, ErrRemoteUnavailable)
 	assert.NotContains(t, err.Error(), "is not allowed",
 		"guard message must not appear when allow_insecure is set")
+}
+
+// TestEnvAllowInsecure_Truthiness covers the case-insensitive parsing
+// of KATA_ALLOW_INSECURE. Empty / "0" / "false" must be false; "1" and
+// "true" in any case must be true; surrounding whitespace is trimmed.
+func TestEnvAllowInsecure_Truthiness(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"yes", false},
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"tRuE", true},
+		{" 1 ", true},
+		{"  true\t", true},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("val=%q", tc.val), func(t *testing.T) {
+			t.Setenv("KATA_ALLOW_INSECURE", tc.val)
+			assert.Equal(t, tc.want, envAllowInsecure())
+		})
+	}
+}
+
+// stubProbe replaces probeRemote for the duration of the test so
+// resolution paths past the guard don't issue real outbound dials.
+// Restored via t.Cleanup.
+func stubProbe(t *testing.T, ok bool) {
+	t.Helper()
+	saved := probeRemote
+	probeRemote = func(_ context.Context, _ string) bool { return ok }
+	t.Cleanup(func() { probeRemote = saved })
 }
 
 // writeWorkspaceMarker drops a minimal .kata.toml at dir so the

--- a/internal/tui/events_sse.go
+++ b/internal/tui/events_sse.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -44,39 +45,72 @@ var reconnectStatusGrace = 1500 * time.Millisecond
 // first disconnect of an outage, fired only if the reconnect hasn't
 // produced a frame within the grace window, and cancelled when the next
 // successful read produces its first frame (or on goroutine exit).
+//
+// publishConnected and the AfterFunc callback share a mutex so the two
+// state transitions cannot interleave: once a callback observes
+// "connected" it returns without sending; once publishConnected sets
+// "connected" any later or in-flight callback observes it and bails.
+// When the callback wins the race it sends sseReconnecting *before*
+// publishConnected sends sseConnected, so the channel ordering keeps
+// the final state correct (connected wins, reconnecting was a brief
+// flash that the consumer overwrites).
 func startSSE(
 	ctx context.Context, hc sseClient, base string, projectID *int64, sseCh chan<- tea.Msg,
 ) {
 	const maxBackoff = 30 * time.Second
 	backoff := time.Second
 	var lastID int64
-	var graceTimer *time.Timer
-	inOutage := false
 
-	stopGrace := func() {
+	var (
+		stateMu      sync.Mutex
+		graceTimer   *time.Timer // nil when no grace window is pending
+		hasConnected bool        // true once sseConnected has been sent for the current outage
+		inOutage     bool
+	)
+
+	publishConnected := func() {
+		stateMu.Lock()
+		defer stateMu.Unlock()
 		if graceTimer != nil {
 			graceTimer.Stop()
 			graceTimer = nil
 		}
 		inOutage = false
+		hasConnected = true
+		notifyStatus(ctx, sseCh, sseConnected)
 	}
-	defer stopGrace()
 	armGrace := func() {
+		stateMu.Lock()
+		defer stateMu.Unlock()
 		if inOutage {
 			return
 		}
 		inOutage = true
+		hasConnected = false
 		graceTimer = time.AfterFunc(reconnectStatusGrace, func() {
+			stateMu.Lock()
+			defer stateMu.Unlock()
+			if hasConnected {
+				return
+			}
 			notifyStatus(ctx, sseCh, sseReconnecting)
 		})
 	}
+	defer func() {
+		stateMu.Lock()
+		if graceTimer != nil {
+			graceTimer.Stop()
+			graceTimer = nil
+		}
+		stateMu.Unlock()
+	}()
 
 	for {
 		if ctx.Err() != nil {
 			return
 		}
 		connected, err := readSSEStream(
-			ctx, hc, base, projectID, lastID, sseCh, &lastID, stopGrace,
+			ctx, hc, base, projectID, lastID, sseCh, &lastID, publishConnected,
 		)
 		if err == nil || ctx.Err() != nil {
 			return
@@ -125,10 +159,11 @@ func notifyStatus(ctx context.Context, sseCh chan<- tea.Msg, st sseConnState) {
 // connection that fails before any frame arrives produces no connected
 // status, only the reconnecting status the caller emits on disconnect.
 //
-// onConnect is invoked on the same first-frame transition that pushes
-// sseConnected. startSSE uses it to cancel a pending reconnect-status
-// grace timer so a fast recovery never surfaces the "reconnecting" badge.
-// nil is acceptable; tests that call readSSEStream directly pass nil.
+// onConnect, when non-nil, is invoked on the first-frame transition and
+// owns the sseConnected publication (it is responsible for serializing
+// the send with any concurrent reconnect-status timer). When onConnect
+// is nil readSSEStream emits sseConnected directly — the path tests
+// take when driving readSSEStream without the startSSE wrapper.
 func readSSEStream(
 	ctx context.Context, hc sseClient, base string, projectID *int64,
 	lastID int64, sseCh chan<- tea.Msg, updateLastID *int64, onConnect func(),
@@ -158,8 +193,9 @@ func readSSEStream(
 		if !connected {
 			if onConnect != nil {
 				onConnect()
+			} else {
+				notifyStatus(ctx, sseCh, sseConnected)
 			}
-			notifyStatus(ctx, sseCh, sseConnected)
 			connected = true
 		}
 		*updateLastID = f.id

--- a/internal/tui/events_sse.go
+++ b/internal/tui/events_sse.go
@@ -19,6 +19,15 @@ type sseClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// reconnectStatusGrace defers surfacing sseReconnecting to the UI for
+// this long after a disconnect. Brief outages (daemon restarts, transient
+// network blips) usually recover inside the window so the user never sees
+// the badge. The grace runs in parallel with the reconnect loop — it does
+// not delay the reconnect attempt itself, only the user-visible signal.
+//
+// var (not const) so tests can shorten it.
+var reconnectStatusGrace = 1500 * time.Millisecond
+
 // startSSE is the long-lived consumer goroutine. Loops over
 // readSSEStream, reconnects with exponential backoff (1s → 30s, capped),
 // and resumes via Last-Event-ID once at least one frame was emitted on
@@ -30,21 +39,49 @@ type sseClient interface {
 // reconnecting on a flapping daemon: the user would see "connected" the
 // moment we issue the request, "reconnecting" on the inevitable error,
 // and so on per loop turn even though no frame ever made it through.
+//
+// sseReconnecting is debounced by reconnectStatusGrace: armed on the
+// first disconnect of an outage, fired only if the reconnect hasn't
+// produced a frame within the grace window, and cancelled when the next
+// successful read produces its first frame (or on goroutine exit).
 func startSSE(
 	ctx context.Context, hc sseClient, base string, projectID *int64, sseCh chan<- tea.Msg,
 ) {
 	const maxBackoff = 30 * time.Second
 	backoff := time.Second
 	var lastID int64
+	var graceTimer *time.Timer
+	inOutage := false
+
+	stopGrace := func() {
+		if graceTimer != nil {
+			graceTimer.Stop()
+			graceTimer = nil
+		}
+		inOutage = false
+	}
+	defer stopGrace()
+	armGrace := func() {
+		if inOutage {
+			return
+		}
+		inOutage = true
+		graceTimer = time.AfterFunc(reconnectStatusGrace, func() {
+			notifyStatus(ctx, sseCh, sseReconnecting)
+		})
+	}
+
 	for {
 		if ctx.Err() != nil {
 			return
 		}
-		connected, err := readSSEStream(ctx, hc, base, projectID, lastID, sseCh, &lastID)
+		connected, err := readSSEStream(
+			ctx, hc, base, projectID, lastID, sseCh, &lastID, stopGrace,
+		)
 		if err == nil || ctx.Err() != nil {
 			return
 		}
-		notifyStatus(ctx, sseCh, sseReconnecting)
+		armGrace()
 		if connected {
 			backoff = time.Second
 		}
@@ -87,9 +124,14 @@ func notifyStatus(ctx context.Context, sseCh chan<- tea.Msg, st sseConnState) {
 // successful frame — never optimistically before a frame lands. A
 // connection that fails before any frame arrives produces no connected
 // status, only the reconnecting status the caller emits on disconnect.
+//
+// onConnect is invoked on the same first-frame transition that pushes
+// sseConnected. startSSE uses it to cancel a pending reconnect-status
+// grace timer so a fast recovery never surfaces the "reconnecting" badge.
+// nil is acceptable; tests that call readSSEStream directly pass nil.
 func readSSEStream(
 	ctx context.Context, hc sseClient, base string, projectID *int64,
-	lastID int64, sseCh chan<- tea.Msg, updateLastID *int64,
+	lastID int64, sseCh chan<- tea.Msg, updateLastID *int64, onConnect func(),
 ) (bool, error) {
 	req, err := buildSSERequest(ctx, base, projectID, lastID)
 	if err != nil {
@@ -114,6 +156,9 @@ func readSSEStream(
 			return connected, perr
 		}
 		if !connected {
+			if onConnect != nil {
+				onConnect()
+			}
 			notifyStatus(ctx, sseCh, sseConnected)
 			connected = true
 		}

--- a/internal/tui/sse_test.go
+++ b/internal/tui/sse_test.go
@@ -201,7 +201,7 @@ func TestSSE_StreamForwardsMessages(t *testing.T) {
 	defer cancel()
 	ch := make(chan tea.Msg, 4)
 	var lastID int64
-	connected, _ := readSSEStream(ctx, srv.Client(), srv.URL, nil, 0, ch, &lastID)
+	connected, _ := readSSEStream(ctx, srv.Client(), srv.URL, nil, 0, ch, &lastID, nil)
 	if !connected {
 		t.Fatal("connected = false, want true")
 	}
@@ -241,7 +241,7 @@ func TestSSE_NoConnectedStatusBeforeFirstFrame(t *testing.T) {
 	defer cancel()
 	ch := make(chan tea.Msg, 4)
 	var lastID int64
-	connected, _ := readSSEStream(ctx, srv.Client(), srv.URL, nil, 0, ch, &lastID)
+	connected, _ := readSSEStream(ctx, srv.Client(), srv.URL, nil, 0, ch, &lastID, nil)
 	if connected {
 		t.Fatal("connected = true, want false (no frames arrived)")
 	}
@@ -315,6 +315,111 @@ Done:
 	if hdr != "5" {
 		t.Fatalf("Last-Event-ID on reconnect = %q, want 5", hdr)
 	}
+}
+
+// TestSSE_GracePeriod_FastReconnect_NoReconnectingBadge verifies that a
+// disconnect followed by a quick recovery (within reconnectStatusGrace)
+// never surfaces sseReconnecting to the channel — fast restarts must be
+// invisible to the UI. The handler returns a frame on the first connect,
+// closes, and returns another frame on the second connect; with the
+// default 1s initial backoff the reconnect lands well inside the 1.5s
+// grace window.
+func TestSSE_GracePeriod_FastReconnect_NoReconnectingBadge(t *testing.T) {
+	var connects int32
+	srv := newSSEMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&connects, 1)
+		writeSSEFrame(t, w, int64(n), "issue.created",
+			`{"type":"issue.created","project_id":7}`)
+		if n == 1 {
+			return // close so reconnect happens
+		}
+		<-r.Context().Done()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan tea.Msg, 16)
+	done := make(chan struct{})
+	go func() {
+		startSSE(ctx, srv.Client(), srv.URL, nil, ch)
+		close(done)
+	}()
+
+	// Wait for two eventReceivedMsg arrivals (one per connect). The
+	// second arrival proves the reconnect succeeded; if no sseReconnecting
+	// crossed the channel by then, the grace timer was correctly cancelled.
+	var sawEvents int
+	var sawReconnecting bool
+	deadline := time.After(5 * time.Second)
+	for sawEvents < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("only saw %d eventReceivedMsg, want 2", sawEvents)
+		case msg := <-ch:
+			switch m := msg.(type) {
+			case eventReceivedMsg:
+				sawEvents++
+			case sseStatusMsg:
+				if m.state == sseReconnecting {
+					sawReconnecting = true
+				}
+			}
+		}
+	}
+	cancel()
+	<-done
+	if sawReconnecting {
+		t.Fatal("sseReconnecting pushed during fast reconnect — grace timer should have suppressed it")
+	}
+}
+
+// TestSSE_GracePeriod_LongOutage_SurfacesBadge verifies that a sustained
+// outage (no productive reconnect within the grace window) does push
+// sseReconnecting to the channel, and that recovery pushes sseConnected.
+// The test shortens reconnectStatusGrace to keep the run fast.
+func TestSSE_GracePeriod_LongOutage_SurfacesBadge(t *testing.T) {
+	saved := reconnectStatusGrace
+	reconnectStatusGrace = 50 * time.Millisecond
+	t.Cleanup(func() { reconnectStatusGrace = saved })
+
+	var ready atomic.Bool
+	srv := newSSEMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if !ready.Load() {
+			return // empty body, close — readSSEStream sees EOF
+		}
+		writeSSEFrame(t, w, 1, "issue.created",
+			`{"type":"issue.created","project_id":7}`)
+		<-r.Context().Done()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan tea.Msg, 16)
+	done := make(chan struct{})
+	go func() {
+		startSSE(ctx, srv.Client(), srv.URL, nil, ch)
+		close(done)
+	}()
+	t.Cleanup(func() { cancel(); <-done })
+
+	waitForState := func(want sseConnState) {
+		t.Helper()
+		deadline := time.After(5 * time.Second)
+		for {
+			select {
+			case <-deadline:
+				t.Fatalf("did not observe sseStatusMsg{%v}", want)
+			case msg := <-ch:
+				if st, ok := msg.(sseStatusMsg); ok && st.state == want {
+					return
+				}
+			}
+		}
+	}
+	// First the badge should surface (grace fires, no productive reconnect yet).
+	waitForState(sseReconnecting)
+	// Flip the server to ready; the next reconnect produces a frame and
+	// pushes sseConnected.
+	ready.Store(true)
+	waitForState(sseConnected)
 }
 
 // drainOne reads the next message off ch with a deadline so a stuck

--- a/internal/tui/sse_test.go
+++ b/internal/tui/sse_test.go
@@ -372,6 +372,91 @@ func TestSSE_GracePeriod_FastReconnect_NoReconnectingBadge(t *testing.T) {
 	}
 }
 
+// TestSSE_GracePeriod_TimerVsConnectIsRaceFree drives startSSE with a
+// very short grace so the timer is forced to fire nearly simultaneously
+// with the recovery on every cycle. The invariant under test: the
+// terminal sseStatusMsg observed for any outage must be sseConnected,
+// never sseReconnecting. Pre-lock the goroutine could send
+// sseReconnecting *after* sseConnected when the timer's check-then-send
+// straddled publishConnected; with the mutex the timer either bails
+// (hasConnected was already set) or sends sseReconnecting before
+// sseConnected and channel ordering preserves the correct final state.
+//
+// Run under -race -count=N for additional confidence.
+func TestSSE_GracePeriod_TimerVsConnectIsRaceFree(t *testing.T) {
+	saved := reconnectStatusGrace
+	reconnectStatusGrace = 1 * time.Millisecond
+	t.Cleanup(func() { reconnectStatusGrace = saved })
+
+	// Server flaps: even-numbered connects send a frame, odd-numbered
+	// close immediately. Two consecutive cycles cover the full
+	// disconnect → grace-fires → reconnect-with-frame path.
+	const cycles = 3
+	var connects int32
+	srv := newSSEMockServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&connects, 1)
+		if n%2 == 1 {
+			return
+		}
+		writeSSEFrame(t, w, int64(n), "issue.created",
+			`{"type":"issue.created","project_id":7}`)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan tea.Msg, 256)
+	done := make(chan struct{})
+	go func() {
+		startSSE(ctx, srv.Client(), srv.URL, nil, ch)
+		close(done)
+	}()
+
+	// Track the last sseStatusMsg observed at any point and the count
+	// of frames so we know when enough cycles have completed.
+	var lastStatus *sseConnState
+	deadline := time.After(20 * time.Second)
+	frames := 0
+	for frames < cycles {
+		select {
+		case <-deadline:
+			t.Fatalf("only saw %d frames, want %d", frames, cycles)
+		case msg := <-ch:
+			switch m := msg.(type) {
+			case eventReceivedMsg:
+				frames++
+			case sseStatusMsg:
+				s := m.state
+				lastStatus = &s
+			}
+		}
+	}
+	cancel()
+	<-done
+
+	// Drain anything still buffered so the last observation is current.
+	for {
+		select {
+		case msg := <-ch:
+			if st, ok := msg.(sseStatusMsg); ok {
+				s := st.state
+				lastStatus = &s
+			}
+		default:
+			goto done
+		}
+	}
+done:
+	if lastStatus == nil {
+		t.Fatal("no sseStatusMsg observed; expected at least one transition")
+	}
+	// The terminal state observed for the run must be sseConnected:
+	// every reconnect completed before the run ended. A pre-lock build
+	// could leave the terminal state at sseReconnecting if the timer's
+	// send raced past publishConnected's send.
+	if *lastStatus != sseConnected {
+		t.Fatalf("terminal sseStatusMsg = %v, want sseConnected (race fix regression)", *lastStatus)
+	}
+}
+
 // TestSSE_GracePeriod_LongOutage_SurfacesBadge verifies that a sustained
 // outage (no productive reconnect within the grace window) does push
 // sseReconnecting to the channel, and that recovery pushes sseConnected.


### PR DESCRIPTION
## Summary

Two related fixes on the path to issue #20 (TUI HTTP-backed remote engine).

**1. SSE reconnect debounce.** `internal/tui/events_sse.go` previously fired `sseReconnecting` immediately on every disconnect, so a sub-second daemon restart or transient network blip flashed the "kata: reconnecting…" badge before the reconnect succeeded. A `time.AfterFunc` grace timer (1.5s) now runs in parallel with the reconnect loop: armed on the first disconnect of an outage, fired only if no frame arrives inside the window, and cancelled when the next successful read produces its first frame (or on goroutine exit). The reconnect attempt itself is unchanged — only the user-visible signal is debounced. Pattern adapted from roborev's invisible-restart behavior.

**2. Plain-http scheme guard.** `normalizeRemoteURL` now rejects plain `http://` to a public IP or hostname. Acceptance mirrors the daemon's `ValidateNonPublicAddress`: literal loopback, RFC1918, CGNAT, link-local, or ULA pass; everything else fails. `https://` is always allowed. Opt-out paths: `KATA_ALLOW_INSECURE=1` env var and `[server].allow_insecure = true` in `.kata.local.toml`. Documented examples (CGNAT IPs, https) work without opt-in.

These move #20 to a working state for non-loopback deployments without further code changes — the existing `*Client` is already HTTP-based and `EnsureRunning` already honors `KATA_SERVER`/`.kata.local.toml`.

## Test plan
- [x] `go test ./...` passes
- [x] `make lint` clean
- [x] Grace tests run with `-count=3` cleanly
- [x] New scheme-guard tests cover loopback/RFC1918/CGNAT/public/hostname × https/http × allow_insecure on/off

🤖 Generated with [Claude Code](https://claude.com/claude-code)