### PR TITLE
TUI: add opt-in mouse support

### DIFF
--- a/cmd/kata/tui_cmd.go
+++ b/cmd/kata/tui_cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+	"github.com/wesm/kata/internal/config"
 	"github.com/wesm/kata/internal/tui"
 )
 
@@ -16,11 +17,16 @@ import (
 // reads.
 func newTUICmd() *cobra.Command {
 	var uidFormat string
+	var mouse bool
 	cmd := &cobra.Command{
 		Use:   "tui",
 		Short: "open the interactive issue browser",
 		Long: `kata tui opens a Bubble Tea TUI scoped to the current project (per .kata.toml).
-Press ? for help, q to quit.`,
+Press ? for help, q to quit.
+
+Mouse support is opt-in. Set [tui] mouse = true in <KATA_HOME>/config.toml
+or pass --mouse for one run. Hold Option (macOS) or Shift (Linux) for native
+terminal text selection while mouse tracking is enabled.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
@@ -34,15 +40,32 @@ Press ? for help, q to quit.`,
 					ExitCode: ExitValidation,
 				}
 			}
+			mouseEnabled, err := resolveTUIMouseOption(cmd, mouse)
+			if err != nil {
+				return err
+			}
 			return tui.Run(ctx, tui.Options{
 				Stdout:           cmd.OutOrStdout(),
 				Stderr:           cmd.ErrOrStderr(),
 				DisplayUIDFormat: uidFormat,
+				Mouse:            mouseEnabled,
 			})
 		},
 	}
 	cmd.Flags().StringVar(&uidFormat, "uid-format", "none", "show issue UIDs in detail (none|short|full)")
+	cmd.Flags().BoolVar(&mouse, "mouse", false, "enable opt-in mouse support for this run (or set [tui] mouse = true in config.toml)")
 	return cmd
+}
+
+func resolveTUIMouseOption(cmd *cobra.Command, flagValue bool) (bool, error) {
+	cfg, err := config.ReadDaemonConfig()
+	if err != nil {
+		return false, err
+	}
+	if cmd.Flags().Changed("mouse") {
+		return flagValue, nil
+	}
+	return cfg.TUI.Mouse, nil
 }
 
 func validTUIUIDFormat(v string) bool {

--- a/cmd/kata/tui_cmd_test.go
+++ b/cmd/kata/tui_cmd_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -20,6 +22,9 @@ func TestTUI_CommandRegistered(t *testing.T) {
 	}
 	if !strings.Contains(out, "--uid-format") {
 		t.Fatalf("--uid-format missing from help: %s", out)
+	}
+	if !strings.Contains(out, "--mouse") {
+		t.Fatalf("--mouse missing from help: %s", out)
 	}
 	for _, banned := range []string{"--all-projects", "--include-deleted"} {
 		if strings.Contains(out, banned) {
@@ -52,5 +57,40 @@ func TestTUI_RejectsExtraArgs(t *testing.T) {
 	if !strings.Contains(msg, "unknown command") &&
 		!strings.Contains(msg, "accepts no args") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTUI_MouseOptionReadsConfigToml(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte("[tui]\nmouse = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newTUICmd()
+	got, err := resolveTUIMouseOption(cmd, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatal("mouse option = false, want true from [tui] mouse")
+	}
+}
+
+func TestTUI_MouseFlagOverridesConfigToml(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte("[tui]\nmouse = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newTUICmd()
+	if err := cmd.Flags().Set("mouse", "true"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveTUIMouseOption(cmd, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatal("mouse option = false, want true from --mouse")
 	}
 }

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -20,6 +20,17 @@ type DaemonConfig struct {
 	// --listen flag is supplied. Same syntax as the flag (host:port).
 	// An empty value (or a missing file) means "default Unix socket".
 	Listen string `toml:"listen"`
+	// TUI carries client-side interactive UI defaults. Unlike remote
+	// daemon overrides, these are user preferences and belong in
+	// <KATA_HOME>/config.toml.
+	TUI TUIConfig `toml:"tui"`
+}
+
+// TUIConfig holds TUI user preferences from <KATA_HOME>/config.toml.
+type TUIConfig struct {
+	// Mouse enables Bubble Tea mouse cell-motion capture and additive
+	// click/wheel navigation. Default false preserves native selection.
+	Mouse bool `toml:"mouse"`
 }
 
 // ReadDaemonConfig parses <KATA_HOME>/config.toml. Returns a zero-value

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -40,6 +40,17 @@ func TestReadDaemonConfig_TrimsWhitespace(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:7777", cfg.Listen)
 }
 
+func TestReadDaemonConfig_ReadsTUIMouse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[tui]\nmouse = true\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.True(t, cfg.TUI.Mouse)
+}
+
 func TestReadDaemonConfig_RejectsMalformed(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -579,6 +579,9 @@ func projectIDFromMutation(m Model, mut mutationDoneMsg) int64 {
 // open/key. ok=true means the message was handled here.
 func (m Model) routeTopLevel(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg := msg.(type) {
+	case tea.MouseMsg:
+		next, cmd := m.routeMouse(msg)
+		return next, cmd, true
 	case tea.WindowSizeMsg:
 		prevLayout := m.layout
 		m.width, m.height = msg.Width, msg.Height

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -1,0 +1,169 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+const (
+	stackedListDataRowY   = 4
+	projectsFirstRowY     = 4
+	mouseWheelScrollLines = 3
+)
+
+func (m Model) routeMouse(msg tea.MouseMsg) (Model, tea.Cmd) {
+	if !m.opts.Mouse || msg.Action != tea.MouseActionPress || !m.canQuit() {
+		return m, nil
+	}
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		return m.mouseWheelAt(-1, msg.X)
+	case tea.MouseButtonWheelDown:
+		return m.mouseWheelAt(1, msg.X)
+	case tea.MouseButtonLeft:
+		return m.mouseLeftClick(msg.X, msg.Y)
+	}
+	return m, nil
+}
+
+func (m Model) mouseWheelAt(delta, x int) (Model, tea.Cmd) {
+	if m.view == viewProjects {
+		m.moveProjectsCursor(delta)
+		return m, nil
+	}
+	if m.layout == layoutSplit {
+		if x >= splitListPaneWidth(m.width) {
+			m.focus = focusDetail
+			return m.mouseDetailWheel(delta), nil
+		}
+		m.focus = focusList
+		return m.mouseListWheel(delta)
+	}
+	if m.view == viewDetail {
+		return m.mouseDetailWheel(delta), nil
+	}
+	return m.mouseListWheel(delta)
+}
+
+func (m Model) mouseDetailWheel(delta int) Model {
+	for i := 0; i < mouseWheelScrollLines; i++ {
+		if delta < 0 {
+			m.detail = m.detail.scrollBodyUp()
+		} else {
+			m.detail = m.detail.scrollBodyDown()
+		}
+	}
+	return m
+}
+
+func (m Model) mouseListWheel(delta int) (Model, tea.Cmd) {
+	if delta < 0 && m.list.cursor > 0 {
+		m.list.cursor--
+	}
+	if delta > 0 && m.list.cursor < len(m.list.visibleRows())-1 {
+		m.list.cursor++
+	}
+	m.list = m.list.syncSelection(m.list.visibleRows())
+	if m.layout == layoutSplit {
+		return m.scheduleDetailFollow()
+	}
+	return m, nil
+}
+
+func (m Model) mouseLeftClick(x, y int) (Model, tea.Cmd) {
+	if m.view == viewProjects {
+		return m.mouseProjectsClick(y)
+	}
+	if m.layout == layoutSplit {
+		if x < splitListPaneWidth(m.width) {
+			m.focus = focusList
+			return m.mouseListClick(splitListRowY(y))
+		}
+		m.focus = focusDetail
+		return m, nil
+	}
+	if m.view == viewList {
+		return m.mouseListClick(y - stackedListDataRowY)
+	}
+	return m, nil
+}
+
+func splitListRowY(y int) int {
+	return y - 2 // title row + pane top border; list pane data starts at first inner row
+}
+
+func (m Model) mouseListClick(row int) (Model, tea.Cmd) {
+	if row < 0 {
+		return m, nil
+	}
+	rows := m.list.visibleRows()
+	if len(rows) == 0 {
+		return m, nil
+	}
+	budget := m.listDataBudget()
+	start, end := windowBounds(len(rows), m.list.cursor, budget)
+	idx := start + row
+	if idx < start || idx >= end || idx >= len(rows) {
+		return m, nil
+	}
+	m.list.cursor = idx
+	m.list = m.list.syncSelection(rows)
+	if m.layout == layoutSplit {
+		return m.scheduleDetailFollow()
+	}
+	return m, nil
+}
+
+func (m Model) listDataBudget() int {
+	if m.layout == layoutSplit {
+		footerLines := helpLines(m.splitHelpRows(), m.width)
+		bodyHeight := m.height - 2 - footerLines
+		if bodyHeight < 4 {
+			bodyHeight = 4
+		}
+		innerH := bodyHeight - 2
+		if innerH < 2 {
+			innerH = 2
+		}
+		return innerH - 2
+	}
+	footerLines := helpLines(listHelpRows(m.list, m.chrome()), m.width)
+	bodyRows := m.height - 2 - 1 - footerLines
+	if bodyRows < listBodyFloor {
+		bodyRows = listBodyFloor
+	}
+	return bodyRows - 2
+}
+
+func (m Model) mouseProjectsClick(y int) (Model, tea.Cmd) {
+	row := y - projectsFirstRowY
+	if row < 0 {
+		return m, nil
+	}
+	rows := projectsRows(m.projectsByID, m.projectIdentByID, m.projectStats)
+	budget := len(rows)
+	if m.height > 0 {
+		budget = m.height - projectsViewChromeRows
+		if budget < 1 {
+			budget = 1
+		}
+	}
+	visible := clipProjectsRows(rows, m.projectsCursor, budget)
+	if row >= len(visible) {
+		return m, nil
+	}
+	m.projectsCursor = visible[row].index
+	return m, nil
+}
+
+func (m *Model) moveProjectsCursor(delta int) {
+	rows := projectsRows(m.projectsByID, m.projectIdentByID, m.projectStats)
+	if len(rows) == 0 {
+		m.projectsCursor = 0
+		return
+	}
+	m.projectsCursor += delta
+	if m.projectsCursor < 0 {
+		m.projectsCursor = 0
+	}
+	if m.projectsCursor >= len(rows) {
+		m.projectsCursor = len(rows) - 1
+	}
+}

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -4,12 +4,16 @@ import tea "github.com/charmbracelet/bubbletea"
 
 const (
 	stackedListDataRowY   = 4
+	splitListDataRowY     = 4
 	projectsFirstRowY     = 4
 	mouseWheelScrollLines = 3
 )
 
 func (m Model) routeMouse(msg tea.MouseMsg) (Model, tea.Cmd) {
 	if !m.opts.Mouse || msg.Action != tea.MouseActionPress || !m.canQuit() {
+		return m, nil
+	}
+	if !m.mouseVisibleViewAcceptsInput() {
 		return m, nil
 	}
 	switch msg.Button {
@@ -21,6 +25,14 @@ func (m Model) routeMouse(msg tea.MouseMsg) (Model, tea.Cmd) {
 		return m.mouseLeftClick(msg.X, msg.Y)
 	}
 	return m, nil
+}
+
+func (m Model) mouseVisibleViewAcceptsInput() bool {
+	switch m.view {
+	case viewList, viewDetail, viewProjects:
+		return true
+	}
+	return false
 }
 
 func (m Model) mouseWheelAt(delta, x int) (Model, tea.Cmd) {
@@ -86,7 +98,8 @@ func (m Model) mouseLeftClick(x, y int) (Model, tea.Cmd) {
 }
 
 func splitListRowY(y int) int {
-	return y - 2 // title row + pane top border; list pane data starts at first inner row
+	// Title, pane top border, table header, separator, then first data row.
+	return y - splitListDataRowY
 }
 
 func (m Model) mouseListClick(row int) (Model, tea.Cmd) {

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -1,0 +1,86 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func mouseLeftClick(x, y int) tea.MouseMsg {
+	return tea.MouseMsg{X: x, Y: y, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft}
+}
+
+func mouseWheelDown() tea.MouseMsg {
+	return tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown}
+}
+
+func mouseWheelUp() tea.MouseMsg {
+	return tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelUp}
+}
+
+func TestProgramOpts_MouseDisabledByDefault(t *testing.T) {
+	without := programOpts(t.Context(), Options{})
+	with := programOpts(t.Context(), Options{Mouse: true})
+	if len(with) != len(without)+1 {
+		t.Fatalf("programOpts with mouse len=%d, want disabled len %d + 1", len(with), len(without))
+	}
+}
+
+func TestMouseDisabledIgnoresMouseMsg(t *testing.T) {
+	m := resizeModel(newTestModel(), 120, 30)
+	m.list.issues = makeTestIssues(3)
+	m.list.cursor = 0
+
+	nm, cmd := updateModel(m, mouseLeftClick(4, 6))
+	if cmd != nil {
+		t.Fatalf("disabled mouse returned cmd %T, want nil", cmd())
+	}
+	if nm.list.cursor != 0 {
+		t.Fatalf("disabled mouse moved cursor to %d, want 0", nm.list.cursor)
+	}
+}
+
+func TestMouseClickSelectsIssueListRow(t *testing.T) {
+	m := resizeModel(newTestModel(), 120, 30)
+	m.opts.Mouse = true
+	m.list.issues = makeTestIssues(5)
+
+	nm, cmd := updateModel(m, mouseLeftClick(4, 6)) // stacked list row 3: title, stats, header, rule, row0...
+	if cmd != nil {
+		t.Fatalf("single click returned cmd %T, want nil", cmd())
+	}
+	if nm.list.cursor != 2 || nm.list.selectedNumber != 3 {
+		t.Fatalf("cursor=%d selected=%d, want cursor=2 selected #3", nm.list.cursor, nm.list.selectedNumber)
+	}
+}
+
+func TestMouseWheelScrollsIssueDetail(t *testing.T) {
+	m := setupDetailScenario(t, 120, 30, "line\nline\nline\nline\nline\nline\nline\nline\nline\nline\nline\nline\nline\nline\nline\nTAIL")
+	m.opts.Mouse = true
+	m.detail.scroll = 0
+
+	nm, _ := updateModel(m, mouseWheelDown())
+	if nm.detail.scroll == 0 {
+		t.Fatal("wheel down did not scroll detail body")
+	}
+	nm, _ = updateModel(nm, mouseWheelUp())
+	if nm.detail.scroll != 0 {
+		t.Fatalf("wheel up scroll=%d, want 0", nm.detail.scroll)
+	}
+}
+
+func TestMouseClickSelectsProjectsRow(t *testing.T) {
+	m := setupProjectsView(
+		mockProject{ID: 1, Name: "alpha", Ident: "github.com/acme/alpha"},
+		mockProject{ID: 2, Name: "beta", Ident: "github.com/acme/beta"},
+	)
+	m.opts.Mouse = true
+
+	nm, cmd := updateModel(m, mouseLeftClick(2, 5)) // projects row after title/count/blank/header
+	if cmd != nil {
+		t.Fatalf("single click returned cmd %T, want nil", cmd())
+	}
+	if nm.projectsCursor != 1 {
+		t.Fatalf("projectsCursor=%d, want first concrete project row", nm.projectsCursor)
+	}
+}

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -11,7 +11,11 @@ func mouseLeftClick(x, y int) tea.MouseMsg {
 }
 
 func mouseWheelDown() tea.MouseMsg {
-	return tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown}
+	return mouseWheelDownAt(0)
+}
+
+func mouseWheelDownAt(x int) tea.MouseMsg {
+	return tea.MouseMsg{X: x, Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown}
 }
 
 func mouseWheelUp() tea.MouseMsg {
@@ -51,6 +55,33 @@ func TestMouseClickSelectsIssueListRow(t *testing.T) {
 	}
 	if nm.list.cursor != 2 || nm.list.selectedNumber != 3 {
 		t.Fatalf("cursor=%d selected=%d, want cursor=2 selected #3", nm.list.cursor, nm.list.selectedNumber)
+	}
+}
+
+func TestMouseSplitClickFirstIssueRowSelectsFirstVisibleRow(t *testing.T) {
+	m := resizeModel(newTestModel(), 160, 30)
+	m.opts.Mouse = true
+	m.layout = layoutSplit
+	m.list.issues = makeTestIssues(5)
+	m.list.cursor = 0
+
+	nm, _ := updateModel(m, mouseLeftClick(4, 4)) // title, pane border, table header, rule, first row
+	if nm.list.cursor != 0 || nm.list.selectedNumber != 1 {
+		t.Fatalf("cursor=%d selected=%d, want first visible issue", nm.list.cursor, nm.list.selectedNumber)
+	}
+}
+
+func TestMouseFullScreenHelpIgnoresSplitPaneMouse(t *testing.T) {
+	m := resizeModel(newTestModel(), 160, 30)
+	m.opts.Mouse = true
+	m.layout = layoutSplit
+	m.view = viewHelp
+	m.list.issues = makeTestIssues(5)
+	m.list.cursor = 0
+
+	nm, _ := updateModel(m, mouseWheelDownAt(4))
+	if nm.list.cursor != 0 {
+		t.Fatalf("help-view mouse wheel moved list cursor to %d, want no-op", nm.list.cursor)
 	}
 }
 

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -33,6 +33,7 @@ type Options struct {
 	Stdout           io.Writer // typically os.Stdout
 	Stderr           io.Writer // typically os.Stderr
 	DisplayUIDFormat string    // none, short, or full
+	Mouse            bool      // opt-in mouse capture and mouse-driven navigation
 }
 
 // Run starts the TUI. Blocks until the user quits or ctx is cancelled.
@@ -93,14 +94,16 @@ func buildRunModel(opts Options, c *Client, bi bootInit) Model {
 // Splitting this off Run keeps Run's cyclomatic complexity within the
 // project's ≤8 limit.
 func programOpts(ctx context.Context, opts Options) []tea.ProgramOption {
-	// Mouse capture is intentionally NOT enabled (plan §152): the TUI is
-	// keyboard-first, and tea.WithMouseAllMotion would emit mouse-tracking
-	// control sequences that prevent the user from selecting text natively
-	// in the alt-screen. Add it back in a future plan that actually wires
-	// MouseMsg handlers.
 	out := []tea.ProgramOption{
 		tea.WithContext(ctx),
 		tea.WithAltScreen(),
+	}
+	if opts.Mouse {
+		// Opt-in only: mouse tracking blocks native text selection in many
+		// terminals. CellMotion captures clicks/releases/wheel without idle
+		// all-motion churn; users can hold Option (macOS) or Shift (Linux)
+		// to bypass tracking for native selection.
+		out = append(out, tea.WithMouseCellMotion())
 	}
 	if opts.Stdout != nil {
 		out = append(out, tea.WithOutput(opts.Stdout))


### PR DESCRIPTION
## Summary
- add opt-in TUI mouse support via `<KATA_HOME>/config.toml` `[tui] mouse = true` or `kata tui --mouse`
- enable Bubble Tea cell-motion capture only when opted in
- wire click-to-select for issue/project rows and wheel scrolling for list, project, and detail views
- document native text-selection workaround in `kata tui --help`

Closes #13.

## Validation
- `GOFLAGS=-buildvcs=false go test ./...`
- `make lint` still fails on pre-existing gosec findings in `internal/daemon/server.go:101` and `internal/daemonclient/client.go:90`
