### PR TITLE
tui: unify detail view as one scrolling document

### DIFF
--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -95,7 +95,7 @@ type detailModel struct {
 	err             error
 	gen             int64
 	activeTab       detailTab
-	scroll          int // body scroll offset in lines
+	scroll          int // unified viewport offset in document lines
 	tabCursor       int // active-tab row cursor
 	childCursor     int
 	comments        []CommentEntry
@@ -121,15 +121,15 @@ type detailModel struct {
 	tabExplicit bool
 	// lastTermWidth / lastTermHeight cache the most recent terminal
 	// dimensions seen by Model.routeTopLevel's WindowSizeMsg handler.
-	// scrollBodyDown reads them to clamp dm.scroll against the body's
-	// rendered max start so overscrolling past EOF doesn't let
-	// dm.scroll grow unbounded — without the clamp, a follow-up PgUp
-	// appears stuck until the inflated offset unwinds (roborev #17184).
+	// viewportDims reads them to compute the visible-row count for
+	// page-step sizing and reveal-cursor math, and to clamp dm.scroll
+	// against the document's rendered max start so overscrolling past
+	// EOF can't let the offset grow unbounded.
 	lastTermWidth  int
 	lastTermHeight int
 	// lastDetail* caches the actual detail viewport when the model can compute
 	// it (notably split-pane mode, where the detail pane is narrower/shorter
-	// than the terminal). When unset, body scroll clamping falls back to the
+	// than the terminal). When unset, viewport math falls back to the
 	// stacked full-terminal calculation.
 	lastDetailWidth  int
 	lastDetailHeight int
@@ -284,17 +284,21 @@ func (dm detailModel) handleNavKey(
 ) (detailModel, tea.Cmd, bool) {
 	switch {
 	case km.NextTab.matches(msg):
-		dm = dm.cycleDetailFocus(1)
+		return dm.cycleDetailFocus(1).revealCursor(), nil, true
 	case km.PrevTab.matches(msg):
-		dm = dm.cycleDetailFocus(-1)
+		return dm.cycleDetailFocus(-1).revealCursor(), nil, true
 	case km.PageUp.matches(msg):
-		return dm.scrollBodyUp(), nil, true
+		return dm.pageScrollUp(), nil, true
 	case km.PageDown.matches(msg):
-		return dm.scrollBodyDown(), nil, true
+		return dm.pageScrollDown(), nil, true
+	case km.ScrollUp.matches(msg):
+		return dm.scrollViewportBy(-1), nil, true
+	case km.ScrollDown.matches(msg):
+		return dm.scrollViewportBy(1), nil, true
 	case km.Up.matches(msg):
-		return dm.handleUp(), nil, true
+		return dm.handleUp().revealCursor(), nil, true
 	case km.Down.matches(msg):
-		return dm.handleDown(), nil, true
+		return dm.handleDown().revealCursor(), nil, true
 	case km.Open.matches(msg):
 		next, cmd := dm.handleEnter(api)
 		return next, cmd, true
@@ -304,103 +308,122 @@ func (dm detailModel) handleNavKey(
 	default:
 		return dm, nil, false
 	}
-	return dm, nil, true
 }
 
-// detailBodyScrollStep is the per-keystroke body-scroll delta. Larger
-// than a single line so PageDown feels like an actual page jump,
-// smaller than a full visible window so the user keeps a few rows of
-// context across the seam. The renderer clamps the upper bound, so
-// over-eager scrolling on a short body is harmless.
-const detailBodyScrollStep = 8
-
-func (dm detailModel) scrollBodyUp() detailModel {
-	dm.scroll -= detailBodyScrollStep
+// scrollViewportBy slides the detail viewport `delta` rows. Negative
+// scrolls up, positive down. The result is clamped to [0, maxStart]
+// against the unified document the renderer will draw.
+func (dm detailModel) scrollViewportBy(delta int) detailModel {
+	width, visible, ok := dm.viewportDims()
+	dm.scroll += delta
 	if dm.scroll < 0 {
 		dm.scroll = 0
 	}
-	return dm
-}
-
-// scrollBodyDown advances the body scroll by detailBodyScrollStep
-// lines, clamped at the body's rendered maximum start position.
-// Without the clamp, repeated PgDn past EOF lets dm.scroll grow
-// unbounded; the renderer hides this with its own per-frame clamp,
-// but a follow-up PgUp would then appear stuck until the inflated
-// offset finally unwound (roborev #17184).
-func (dm detailModel) scrollBodyDown() detailModel {
-	dm.scroll += detailBodyScrollStep
-	maxStart := dm.bodyMaxStartEstimate()
-	if maxStart >= 0 && dm.scroll > maxStart {
+	if !ok {
+		return dm
+	}
+	docLines, _ := dm.detailDocumentLines(width, dm.scrollChrome())
+	if maxStart := viewportMaxStart(len(docLines), visible); dm.scroll > maxStart {
 		dm.scroll = maxStart
 	}
 	return dm
 }
 
-// bodyMaxStartEstimate returns the largest valid dm.scroll value, or
-// -1 when the cap can't be computed (no issue, no cached terminal
-// width). It mirrors the renderer's body-budget calculation so it
-// never lets dm.scroll out-run what the renderer will display.
-func (dm detailModel) bodyMaxStartEstimate() int {
-	if dm.issue == nil {
-		return -1
-	}
-	width, height := dm.lastTermWidth, dm.lastTermHeight
-	if dm.lastDetailWidth > 0 && dm.lastDetailHeight > 0 {
-		width, height = dm.lastDetailWidth, dm.lastDetailHeight
-	}
-	if width <= 0 || height <= 0 {
-		return -1
-	}
-	sheetWidth := documentSheetWidth(width)
-	wrapped := renderMarkdownLines(dm.issue.Body, sheetWidth)
-	bodyRows := dm.renderedBodyRows(width, height, sheetWidth)
-	if dm.lastDetailSplit {
-		bodyRows = dm.renderedSplitBodyRows(height, sheetWidth)
-	}
-	maxStart := len(wrapped) - bodyRows
-	if maxStart < 0 {
-		return 0
-	}
-	return maxStart
+// pageScrollUp / pageScrollDown step by one viewport-minus-overlap so
+// PgUp/PgDn jump a page while keeping a couple of rows of context
+// across the seam. Falls back to a fixed step when terminal dimensions
+// haven't been observed yet (cold start before the first WindowSizeMsg).
+func (dm detailModel) pageScrollUp() detailModel {
+	return dm.scrollViewportBy(-dm.pageStep())
 }
 
-func (dm detailModel) renderedBodyRows(termWidth, termHeight, sheetWidth int) int {
-	chrome := viewChrome{}
-	helpRows := detailHelpRows(dm, chrome)
-	footerLines := helpLines(helpRows, termWidth)
-	header := append([]string{renderTitleBar(termWidth, chrome.scope, chrome.version), ""}, dm.documentHeader(sheetWidth, chrome)...)
-	hasChildren := len(dm.children) > 0
-	hasActivity := dm.hasActivity()
-	fixed := len(header) + 1 /* body label */ + 1 /* blank gap before activity */ +
-		1 /* info */ + footerLines
-	if hasChildren {
-		fixed += 2
-	}
-	if hasActivity {
-		fixed += 2
-	}
-	bodyRows, _, _ := detailDocumentBudgets(termHeight-fixed, len(dm.children), hasActivity)
-	return bodyRows
+func (dm detailModel) pageScrollDown() detailModel {
+	return dm.scrollViewportBy(dm.pageStep())
 }
 
-func (dm detailModel) renderedSplitBodyRows(height, sheetWidth int) int {
-	header := dm.documentHeader(sheetWidth, viewChrome{})
-	hasChildren := len(dm.children) > 0
-	hasActivity := dm.hasActivity()
-	fixed := len(header) + 1
-	if hasChildren {
-		fixed += 2
+// detailPageOverlap is the row count kept visible across a page step
+// so the user retains context. Same intent as a "less"-style page key.
+const detailPageOverlap = 2
+
+// detailFallbackPageStep is the page size used when terminal
+// dimensions are unknown (initial dispatch before WindowSizeMsg).
+const detailFallbackPageStep = 8
+
+func (dm detailModel) pageStep() int {
+	_, visible, ok := dm.viewportDims()
+	if !ok || visible <= detailPageOverlap {
+		return detailFallbackPageStep
 	}
-	if hasActivity {
-		fixed += 2
-	}
-	bodyRows, _, _ := detailDocumentBudgets(height-fixed, len(dm.children), hasActivity)
-	return bodyRows
+	return visible - detailPageOverlap
 }
 
-// handleUp moves the tab cursor up when the active tab has rows;
-// otherwise scrolls the body. Both clamp at zero.
+// viewportDims returns the width and visible-row count of the detail
+// document viewport using the most recent terminal dimensions seen by
+// Update. In split mode the cached lastDetailWidth/Height already
+// record the pane's inner area; in stacked mode visible rows equal
+// terminal height minus the title bar, info line, and footer.
+func (dm detailModel) viewportDims() (width, visible int, ok bool) {
+	if dm.lastDetailSplit && dm.lastDetailWidth > 0 && dm.lastDetailHeight > 0 {
+		return dm.lastDetailWidth, dm.lastDetailHeight, true
+	}
+	if dm.lastTermWidth <= 0 || dm.lastTermHeight <= 0 {
+		return 0, 0, false
+	}
+	helpRows := detailHelpRows(dm, dm.scrollChrome())
+	footerLines := helpLines(helpRows, dm.lastTermWidth)
+	visible = dm.lastTermHeight - 2 - 1 - footerLines
+	if visible < 1 {
+		visible = 1
+	}
+	return dm.lastTermWidth, visible, true
+}
+
+// scrollChrome returns the chrome subset that affects document line
+// count (notably the all-projects metadata row). It carries the same
+// scope identity the View call sees so scroll math doesn't drift from
+// the rendered layout.
+func (dm detailModel) scrollChrome() viewChrome {
+	return viewChrome{scope: scope{
+		allProjects: dm.allProjects,
+		projectID:   dm.scopePID,
+	}}
+}
+
+// revealCursor scrolls the viewport so the focused section's cursor
+// (children or active activity tab) is visible. A no-op when the
+// cursor is already in the window or terminal dims aren't known yet.
+// Called after Tab/section-cursor moves so the user always sees the
+// row they're acting on.
+func (dm detailModel) revealCursor() detailModel {
+	width, visible, ok := dm.viewportDims()
+	if !ok {
+		return dm
+	}
+	docLines, anchors := dm.detailDocumentLines(width, dm.scrollChrome())
+	row := -1
+	switch dm.detailFocus {
+	case focusChildren:
+		row = anchors.childCursor
+	case focusActivity:
+		row = anchors.tabCursor
+		// When the active tab has no entries yet (loading / error /
+		// empty placeholder), pin the activity header to the top of
+		// the viewport so the user knows where focus landed.
+		if row < 0 && anchors.activity >= 0 {
+			row = anchors.activity - 1
+		}
+	}
+	if row < 0 {
+		return dm
+	}
+	dm.scroll = scrollToReveal(dm.scroll, row, visible, len(docLines))
+	return dm
+}
+
+// handleUp moves the section cursor (children or active activity tab)
+// up by one. When there is no section cursor — no children and no
+// activity rows — j/k spills to viewport scroll so the binding never
+// feels dead. ↑/↓ have their own scroll handlers wired in handleNavKey.
 func (dm detailModel) handleUp() detailModel {
 	if dm.detailFocus == focusChildren {
 		if dm.childCursor > 0 {
@@ -414,15 +437,12 @@ func (dm detailModel) handleUp() detailModel {
 		}
 		return dm
 	}
-	if dm.scroll > 0 {
-		dm.scroll--
-	}
-	return dm
+	return dm.scrollViewportBy(-1)
 }
 
-// handleDown moves the tab cursor down (clamped to row-count - 1) or
-// scrolls the body when the tab is empty. Body scroll's upper bound
-// is clamped in the renderer.
+// handleDown moves the section cursor down by one. Clamps at the last
+// row; spills to viewport scroll when there is no section cursor —
+// see handleUp for the rationale.
 func (dm detailModel) handleDown() detailModel {
 	if dm.detailFocus == focusChildren {
 		if dm.childCursor < len(dm.children)-1 {
@@ -436,8 +456,7 @@ func (dm detailModel) handleDown() detailModel {
 		}
 		return dm
 	}
-	dm.scroll++
-	return dm
+	return dm.scrollViewportBy(1)
 }
 
 // handleBack pops one level off the nav stack if non-empty, otherwise

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"context"
-	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -296,9 +295,17 @@ func (dm detailModel) handleNavKey(
 	case km.ScrollDown.matches(msg):
 		return dm.scrollViewportBy(1), nil, true
 	case km.Up.matches(msg):
-		return dm.handleUp().revealCursor(), nil, true
+		next, moved := dm.handleUp()
+		if moved {
+			next = next.revealCursor()
+		}
+		return next, nil, true
 	case km.Down.matches(msg):
-		return dm.handleDown().revealCursor(), nil, true
+		next, moved := dm.handleDown()
+		if moved {
+			next = next.revealCursor()
+		}
+		return next, nil, true
 	case km.Open.matches(msg):
 		next, cmd := dm.handleEnter(api)
 		return next, cmd, true
@@ -423,40 +430,45 @@ func (dm detailModel) revealCursor() detailModel {
 // handleUp moves the section cursor (children or active activity tab)
 // up by one. When there is no section cursor — no children and no
 // activity rows — j/k spills to viewport scroll so the binding never
-// feels dead. ↑/↓ have their own scroll handlers wired in handleNavKey.
-func (dm detailModel) handleUp() detailModel {
+// feels dead. The bool return reports whether a section cursor moved
+// (or stayed put on a populated section); false means the call
+// scrolled the viewport instead. handleNavKey uses that signal to
+// skip revealCursor on the scroll path — otherwise revealCursor would
+// pin the activity header back into view and undo the scroll.
+// ↑/↓ have their own scroll handlers wired in handleNavKey.
+func (dm detailModel) handleUp() (detailModel, bool) {
 	if dm.detailFocus == focusChildren {
 		if dm.childCursor > 0 {
 			dm.childCursor--
 		}
-		return dm
+		return dm, true
 	}
 	if dm.activeRowCount() > 0 {
 		if dm.tabCursor > 0 {
 			dm.tabCursor--
 		}
-		return dm
+		return dm, true
 	}
-	return dm.scrollViewportBy(-1)
+	return dm.scrollViewportBy(-1), false
 }
 
 // handleDown moves the section cursor down by one. Clamps at the last
 // row; spills to viewport scroll when there is no section cursor —
-// see handleUp for the rationale.
-func (dm detailModel) handleDown() detailModel {
+// see handleUp for the rationale and the bool return contract.
+func (dm detailModel) handleDown() (detailModel, bool) {
 	if dm.detailFocus == focusChildren {
 		if dm.childCursor < len(dm.children)-1 {
 			dm.childCursor++
 		}
-		return dm
+		return dm, true
 	}
 	if n := dm.activeRowCount(); n > 0 {
 		if dm.tabCursor < n-1 {
 			dm.tabCursor++
 		}
-		return dm
+		return dm, true
 	}
-	return dm.scrollViewportBy(1)
+	return dm.scrollViewportBy(1), false
 }
 
 // handleBack pops one level off the nav stack if non-empty, otherwise
@@ -617,50 +629,26 @@ func (dm detailModel) activeRowCount() int {
 	return 0
 }
 
-// activeChunks builds the entryChunk slice for the active tab using
-// the same per-entry layout the per-tab renderer produces (header +
-// wrapped body + separator for comments; one line for events / links).
-// Used by the detail scroll indicator so the visible-entry window is
-// computed against the renderer's actual chunk shape rather than
-// comparing entry count to a line budget — fixes the multi-line
-// comment indicator gap from roborev #119 finding 2.
+// activeChunks returns the chunk list for the current active tab,
+// dispatching to the per-tab chunk builders so the chunks ARE the
+// renderable content (cursor markers and styled headers included).
+// detailDocumentLines uses these directly — eliminating the second
+// markdown pass that the previous implementation paid via
+// renderActiveTabFull on top of activeChunks.
 //
 // width is the rendered width of the tab pane (the same width passed
-// to the tab renderers from renderActiveTab).
-//
-// The comments path uses renderMarkdownLines with the same width-2
-// budget renderCommentsTab uses (detail_tabs.go:39) so the indicator
-// math matches what's actually drawn — wrapBody used to under-count
-// Markdown-formatted comments and could suppress the indicator when
-// wrapped lines exceeded the visible budget (roborev #17131 finding 3).
+// to the per-tab renderers).
 func (dm detailModel) activeChunks(width int) []entryChunk {
 	switch dm.activeTab {
 	case tabComments:
-		out := make([]entryChunk, 0, len(dm.comments))
-		for _, c := range dm.comments {
-			lines := []string{
-				fmt.Sprintf("[%s] %s",
-					sanitizeForDisplay(c.Author), fmtTime(c.CreatedAt)),
-			}
-			for _, ln := range renderMarkdownLines(c.Body, max(1, width-2)) {
-				lines = append(lines, "  "+ln)
-			}
-			lines = append(lines, "")
-			out = append(out, entryChunk{lines: lines})
-		}
-		return out
+		return commentChunks(dm.comments, width, dm.tabCursor,
+			tabState{loading: dm.commentsLoading, err: dm.commentsErr})
 	case tabEvents:
-		out := make([]entryChunk, 0, len(dm.events))
-		for range dm.events {
-			out = append(out, entryChunk{lines: []string{""}})
-		}
-		return out
+		return eventChunks(dm.events, width, dm.tabCursor,
+			tabState{loading: dm.eventsLoading, err: dm.eventsErr})
 	case tabLinks:
-		out := make([]entryChunk, 0, len(dm.links))
-		for range dm.links {
-			out = append(out, entryChunk{lines: []string{""}})
-		}
-		return out
+		return linkChunks(dm.links, width, dm.tabCursor,
+			tabState{loading: dm.linksLoading, err: dm.linksErr})
 	}
 	return nil
 }

--- a/internal/tui/detail_redesign_test.go
+++ b/internal/tui/detail_redesign_test.go
@@ -201,7 +201,7 @@ func TestDetailRedesign_FooterHintsAreComprehensive(t *testing.T) {
 		}
 	}
 	for _, want := range []string{
-		"↑↓ move", "↹ section", "↵ open",
+		"↑↓ scroll", "j/k row", "↹ section", "↵ open", "pgup/pgdn page",
 		"e edit", "c comment", "+ label", "- unlabel",
 		"a owner", "A unassign",
 		"x close", "r reopen",

--- a/internal/tui/detail_render.go
+++ b/internal/tui/detail_render.go
@@ -10,22 +10,25 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
-// View renders the stacked detail view as a document page. The page
-// reads top-to-bottom:
+// View renders the stacked detail view as a single scrolling document.
+// The layout is:
 //
-//   - line 1: full-width project/title bar (kept in sync with the
-//     list view so the global chrome reads as a single window)
-//   - line 2: blank breather under the chrome
-//   - sheet: issue lead + body + (optional children) + (optional
-//     activity), each row prefixed with documentGutter cells of
-//     space and capped at documentSheetWidth(width) cells of content
-//   - line H-1: info line (chrome row)
+//   - line 1: full-width project/title bar (chrome, never scrolls)
+//   - line 2: blank breather under the chrome (chrome, never scrolls)
+//   - lines 3..H-2: detail document — issue header + body + (optional
+//     children) + (optional activity), windowed by dm.scroll
+//   - line H-1: info line (chrome row, viewport indicator + status)
 //   - line H:   footer help table (chrome row)
 //
-// Content lives inside a 96-cell maximum measure. Spare terminal
-// width to the right is left blank — the redesign avoids stretching
-// section bands across wide terminals so the page reads as a focused
-// document, not a half-empty workspace.
+// Body, children, and activity render in full inside the document; the
+// per-section row budgets that used to split the available height are
+// gone. ↑/↓ scrolls the document one line; PgUp/PgDn pages by the
+// visible window.
+//
+// Content lives inside a 96-cell maximum measure. Spare terminal width
+// to the right is left blank — the redesign avoids stretching section
+// bands across wide terminals so the page reads as a focused document,
+// not a half-empty workspace.
 func (dm detailModel) View(width, height int, chrome viewChrome) string {
 	if dm.loading {
 		return statusStyle.Render("loading…")
@@ -36,67 +39,70 @@ func (dm detailModel) View(width, height int, chrome viewChrome) string {
 	if width <= 0 || height < listMinHeight {
 		return dm.renderTinyFallback(width)
 	}
-	sheetWidth := documentSheetWidth(width)
 	helpRows := detailHelpRows(dm, chrome)
 	footerLines := helpLines(helpRows, width)
 	footer := renderFooterHelpTable(helpRows, width)
 	titleBar := renderTitleBar(width, chrome.scope, chrome.version)
-	header := append([]string{titleBar, ""}, dm.documentHeader(sheetWidth, chrome)...)
-	hasChildren := len(dm.children) > 0
-	hasActivity := dm.hasActivity()
-	fixed := len(header) + 1 /* body label */ + 1 /* blank gap before activity */ +
-		1 /* info */ + footerLines
-	if hasChildren {
-		fixed += 2 /* children label + blank gap */
+	// Top chrome (title + blank) + bottom chrome (info + footer) frame
+	// the viewport. Whatever rows are left belong to the document.
+	visible := height - 2 - 1 - footerLines
+	if visible < 1 {
+		visible = 1
 	}
-	if hasActivity {
-		fixed += 2 /* activity header + blank gap */
-	}
-	bodyA, childA, tabA := detailDocumentBudgets(height-fixed, len(dm.children), hasActivity)
-	bodyArea := withGutter(dm.renderBody(sheetWidth, bodyA))
-	childrenArea := ""
-	if hasChildren {
-		childrenArea = withGutter(dm.renderChildrenSection(sheetWidth, childA))
-	}
-	tabArea := ""
-	if hasActivity {
-		tabArea = withGutter(dm.renderActiveTab(sheetWidth, tabA))
-	}
-	infoLine := dm.renderInfoLine(width, chrome, tabA)
-	parts := append([]string{}, header...)
-	parts = append(parts, "", renderDocumentSectionHeader("Body"), bodyArea)
-	if hasChildren {
-		parts = append(parts, "", renderDocumentSectionHeader("Children"), childrenArea)
-	}
-	if hasActivity {
-		parts = append(parts, "", dm.renderActivityHeader(sheetWidth), tabArea)
-	}
-	content := padDocumentContent(parts, height-1-footerLines, width)
-	return strings.Join([]string{content, infoLine, footer}, "\n")
+	docLines, _ := dm.detailDocumentLines(width, chrome)
+	scroll := clampScroll(dm.scroll, len(docLines), visible)
+	windowed := windowDocLines(docLines, scroll, visible, width)
+	infoLine := dm.renderInfoLine(width, chrome, len(docLines), scroll, visible)
+	parts := append([]string{titleBar, ""}, windowed...)
+	parts = append(parts, infoLine, footer)
+	return strings.Join(parts, "\n")
 }
 
 // renderTinyFallback is the degraded render for terminals below the
-// minimum height. Just dump body content so the user sees something.
+// minimum height. Window the document with whatever space is left so
+// the user still sees something instead of an error or blank screen.
 func (dm detailModel) renderTinyFallback(width int) string {
-	return dm.renderBody(width, detailMinBodyRows)
+	if width <= 0 {
+		width = 1
+	}
+	docLines, _ := dm.detailDocumentLines(width, viewChrome{})
+	scroll := clampScroll(dm.scroll, len(docLines), detailMinBodyRows)
+	return strings.Join(windowDocLines(docLines, scroll, detailMinBodyRows, width), "\n")
 }
 
-func padDocumentContent(parts []string, rows, terminalWidth int) string {
-	if rows < 1 {
-		rows = 1
+// clampScroll keeps dm.scroll within [0, viewportMaxStart) for the
+// given document length and viewport size. View / ViewSplit always
+// pass the user's intended scroll through this so an off-the-end
+// dm.scroll (e.g. after a tab switch trims the document) doesn't
+// produce a window of blanks.
+func clampScroll(scroll, total, visible int) int {
+	if scroll < 0 {
+		return 0
 	}
-	content := strings.Join(parts, "\n")
-	lines := strings.Split(content, "\n")
-	for i, line := range lines {
-		lines[i] = padToWidth(line, terminalWidth)
+	maxStart := viewportMaxStart(total, visible)
+	if scroll > maxStart {
+		return maxStart
 	}
-	for len(lines) < rows {
-		lines = append(lines, blankLine(terminalWidth))
+	return scroll
+}
+
+// windowDocLines slices [scroll, scroll+visible) of the document and
+// pads with blank rows when the document is shorter than the viewport
+// so the chrome below stays anchored on the same screen line. Lines
+// are emitted as-is (already gutter-prefixed during assembly).
+func windowDocLines(lines []string, scroll, visible, width int) []string {
+	out := make([]string, 0, visible)
+	end := scroll + visible
+	if end > len(lines) {
+		end = len(lines)
 	}
-	if len(lines) > rows {
-		lines = lines[:rows]
+	for i := scroll; i < end; i++ {
+		out = append(out, padToWidth(lines[i], width))
 	}
-	return strings.Join(lines, "\n")
+	for len(out) < visible {
+		out = append(out, blankLine(width))
+	}
+	return out
 }
 
 // documentHeader builds the issue-lead block: title row, byline,
@@ -362,41 +368,15 @@ func blankLine(width int) string {
 	return normalRowStyle.Render(strings.Repeat(" ", max(0, width)))
 }
 
-func detailDocumentBudgets(avail, childCount int, hasActivity bool) (
-	bodyRows, childRows, tabRows int,
-) {
-	if avail < 1 {
-		return 1, 0, 0
-	}
-	if childCount > 0 && avail > 1 {
-		childRows = min(childCount, max(1, avail/5))
-		avail -= childRows
-	}
-	if hasActivity && avail >= 6 {
-		tabRows = max(detailMinTabRows, avail/3)
-		if tabRows > avail-1 {
-			tabRows = avail - 1
-		}
-		avail -= tabRows
-	}
-	bodyRows = avail
-	if bodyRows < 1 {
-		bodyRows = 1
-	}
-	return bodyRows, childRows, tabRows
-}
-
 // renderInfoLine renders the info line just above the footer for the
-// detail view. Same priority order as the list view: active panel
-// prompt > flash > SSE-degraded > toast > scroll indicator. Always
-// rendered inside statsLineStyle so the row reads as chrome even
-// when blank.
+// detail view. Priority order: active panel prompt > flash >
+// SSE-degraded > toast > viewport scroll indicator. Always rendered
+// inside statsLineStyle so the row reads as chrome even when blank.
 //
-// tabBudget is the actual tab-content row budget (computed in View
-// from height). When 0 the scroll indicator is suppressed — used by
-// the early View call before bodyA/tabA are resolved; View calls
-// this again with the real budget once it knows tabA.
-func (dm detailModel) renderInfoLine(width int, chrome viewChrome, tabBudget int) string {
+// total is the document line count and scroll/visible are the current
+// window. When the document fits the viewport, the indicator is
+// suppressed.
+func (dm detailModel) renderInfoLine(width int, chrome viewChrome, total, scroll, visible int) string {
 	body := ""
 	switch {
 	case chrome.input.kind.isPanelPrompt():
@@ -408,28 +388,26 @@ func (dm detailModel) renderInfoLine(width int, chrome viewChrome, tabBudget int
 	case chrome.toast != nil:
 		body = chrome.toast.text
 	default:
-		// Compute the visible-entry window from the same chunk-
-		// windowing logic the per-tab renderer uses, so multi-line
-		// chunks (comments) report the right [start-end] range and
-		// don't suppress the indicator when entry count <= line
-		// budget but total wrapped lines exceed it (#119 finding 2).
-		n := dm.activeRowCount()
-		if n > 0 && tabBudget > 0 {
-			// Chunk math uses the same content-width as the per-tab
-			// renderer (sheet, not terminal) so wrapped comment line
-			// counts match what's actually drawn — see roborev #17140
-			// finding 2.
-			chunks := dm.activeChunks(documentSheetWidth(width))
-			start, end := windowChunkBounds(chunks, dm.tabCursor, tabBudget)
-			if end-start < n {
-				body = rightAlignInside(
-					fmt.Sprintf("[%d-%d of %d %s]",
-						start+1, end, n, dm.activeTabLabel()),
-					titleBarInnerWidth(width))
-			}
+		if indicator := documentScrollIndicator(total, scroll, visible); indicator != "" {
+			body = rightAlignInside(indicator, titleBarInnerWidth(width))
 		}
 	}
 	return statsLineStyle.Render(padToWidth(body, titleBarInnerWidth(width)))
+}
+
+// documentScrollIndicator returns the "[lines X-Y of Z]" hint for the
+// detail viewport, or empty string when the document fits the viewport.
+// Lines are 1-indexed for display.
+func documentScrollIndicator(total, scroll, visible int) string {
+	if total <= visible || visible <= 0 || total <= 0 {
+		return ""
+	}
+	start := scroll + 1
+	end := scroll + visible
+	if end > total {
+		end = total
+	}
+	return fmt.Sprintf("[lines %d-%d of %d]", start, end, total)
 }
 
 // renderInfoPrompt renders an active panel-local prompt as a single
@@ -454,6 +432,119 @@ const (
 	detailMinBodyRows = 4
 	detailMinTabRows  = 3
 )
+
+// detailAnchors records the document row index where each section
+// begins, plus the document row of the section cursor. Tab and j/k
+// use these to scroll the unified viewport so the focused section /
+// selected row is visible. -1 means the section or cursor is absent.
+type detailAnchors struct {
+	body        int
+	children    int
+	activity    int
+	childCursor int
+	tabCursor   int
+	total       int
+}
+
+// emptyAnchors returns a detailAnchors with all section / cursor rows
+// marked absent. Callers fill in only the rows that actually exist
+// for the current detail model.
+func emptyAnchors() detailAnchors {
+	return detailAnchors{
+		body:        -1,
+		children:    -1,
+		activity:    -1,
+		childCursor: -1,
+		tabCursor:   -1,
+	}
+}
+
+// detailDocumentLines flattens the entire detail content (issue header,
+// body, children, activity) into one slice of rendered rows. The slice
+// excludes the global title bar and the bottom info+footer chrome —
+// those are owned by the caller (View / ViewSplit) and stay pinned.
+//
+// anchors reports where each section starts in the slice (and where
+// the section cursor sits), so handleNavKey can scroll the viewport
+// to bring focus into view when Tab cycles or j/k advances.
+func (dm detailModel) detailDocumentLines(width int, chrome viewChrome) ([]string, detailAnchors) {
+	sheetWidth := documentSheetWidth(width)
+	lines := make([]string, 0, 32)
+	anchors := emptyAnchors()
+	addBlock := func(block string) {
+		lines = append(lines, strings.Split(block, "\n")...)
+	}
+
+	for _, hdr := range dm.documentHeader(sheetWidth, chrome) {
+		addBlock(hdr)
+	}
+
+	lines = append(lines, "", renderDocumentSectionHeader("Body"))
+	anchors.body = len(lines)
+	addBlock(withGutter(dm.renderBodyFull(sheetWidth)))
+
+	if len(dm.children) > 0 {
+		lines = append(lines, "", renderDocumentSectionHeader("Children"))
+		anchors.children = len(lines)
+		cursor := clampInt(dm.childCursor, 0, len(dm.children)-1)
+		anchors.childCursor = anchors.children + cursor
+		addBlock(withGutter(dm.renderChildrenFull(sheetWidth)))
+	}
+
+	if dm.hasActivity() {
+		lines = append(lines, "", dm.renderActivityHeader(sheetWidth))
+		anchors.activity = len(lines)
+		if chunks := dm.activeChunks(sheetWidth); len(chunks) > 0 {
+			cursor := clampInt(dm.tabCursor, 0, len(chunks)-1)
+			offset := 0
+			for i := 0; i < cursor; i++ {
+				offset += len(chunks[i].lines)
+			}
+			anchors.tabCursor = anchors.activity + offset
+		}
+		addBlock(withGutter(dm.renderActiveTabFull(sheetWidth)))
+	}
+
+	anchors.total = len(lines)
+	return lines, anchors
+}
+
+// viewportMaxStart returns the largest dm.scroll value that still
+// produces a fully-utilized viewport for a document of `total` rows
+// with `visible` rendered rows. When the document fits the viewport,
+// returns 0. Callers clamp dm.scroll against this.
+func viewportMaxStart(total, visible int) int {
+	if total <= visible || visible <= 0 {
+		return 0
+	}
+	return total - visible
+}
+
+// scrollToReveal returns the new scroll offset that keeps `row` inside
+// a `visible`-row window starting at `scroll`. If the row is above the
+// window, the window slides up to land the row at the top; below the
+// window, it slides down so the row is the last visible line.
+//
+// total bounds the result so an off-the-end anchor never lets scroll
+// run past viewportMaxStart.
+func scrollToReveal(scroll, row, visible, total int) int {
+	if row < 0 || visible <= 0 {
+		return scroll
+	}
+	maxStart := viewportMaxStart(total, visible)
+	if row < scroll {
+		scroll = row
+	} else if row >= scroll+visible {
+		scroll = row - visible + 1
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+	if scroll > maxStart {
+		scroll = maxStart
+	}
+	return scroll
+}
 
 func renderHierarchySummary(width int, parent *IssueRef, children []Issue) string {
 	left := "Parent: -"
@@ -480,64 +571,55 @@ func childrenCountSummary(children []Issue) string {
 	return fmt.Sprintf("%d open / %d total", open, len(children))
 }
 
-// activeTabLabel returns the singular noun for the active tab so the
-// scroll indicator reads naturally ("[1-9 of 12 events]" not
-// "[1-9 of 12]").
-func (dm detailModel) activeTabLabel() string {
-	switch dm.activeTab {
-	case tabComments:
-		return "comments"
-	case tabEvents:
-		return "events"
-	case tabLinks:
-		return "links"
-	}
-	return ""
-}
-
-// renderBody splits the issue body on newlines, hard-wraps each line,
-// and returns the dm.scroll-windowed slice. Hard-wrap (truncate) keeps
-// v1 simple; soft word-wrap is deferred. Body is sanitized before
-// wrapping so agent-authored ANSI / control sequences cannot reach
-// the terminal.
-func (dm detailModel) renderBody(width, lines int) string {
+// renderBodyFull returns every wrapped body line as one joined string.
+// Hard-wrap (truncate) keeps v1 simple; soft word-wrap is deferred.
+// Body is sanitized before wrapping so agent-authored ANSI / control
+// sequences cannot reach the terminal. The unified detail-document
+// scroll (dm.scroll) windows this at the document level — the per-
+// section windowing that used to live here was removed when the body /
+// children / activity sections were merged into one scrollable column.
+func (dm detailModel) renderBodyFull(width int) string {
 	wrapped := renderMarkdownLines(dm.issue.Body, width)
 	if len(wrapped) == 0 {
 		return statusStyle.Render("(no description)")
 	}
-	start := dm.scroll
-	if maxStart := len(wrapped) - lines; start > maxStart {
-		if maxStart < 0 {
-			maxStart = 0
-		}
-		start = maxStart
-	}
-	end := start + lines
-	if end > len(wrapped) {
-		end = len(wrapped)
-	}
-	return strings.Join(wrapped[start:end], "\n")
+	return strings.Join(wrapped, "\n")
 }
 
-func (dm detailModel) renderChildrenSection(width, rows int) string {
-	if rows <= 0 || len(dm.children) == 0 {
+// renderChildrenFull returns every child row as one joined string with
+// the cursor highlight applied to the selected child when focus is on
+// the children section. Document-level scroll (dm.scroll) handles
+// visibility — there is no per-section row budget anymore.
+func (dm detailModel) renderChildrenFull(width int) string {
+	if len(dm.children) == 0 {
 		return ""
 	}
 	cursor := clampInt(dm.childCursor, 0, len(dm.children)-1)
-	visible, vCursor := windowChildIssues(dm.children, cursor, rows)
-	lines := []string{}
-	for i, child := range visible {
-		line := renderChildIssueRow(child, i == vCursor && dm.detailFocus == focusChildren, width)
-		if i == vCursor && dm.detailFocus == focusChildren {
+	lines := make([]string, 0, len(dm.children))
+	for i, child := range dm.children {
+		selected := i == cursor && dm.detailFocus == focusChildren
+		line := renderChildIssueRow(child, selected, width)
+		switch {
+		case selected:
 			line = selectedStyle.Render(padToWidth(line, width))
-		} else if i%2 == 1 {
+		case i%2 == 1:
 			line = altRowStyle.Render(padToWidth(line, width))
-		} else {
+		default:
 			line = normalRowStyle.Render(padToWidth(line, width))
 		}
 		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")
+}
+
+// renderActiveTabFull returns the active tab's full content with no
+// per-tab windowing. Effectively-infinite height defeats assembleTab's
+// window+clip step; line-wise width truncation still applies. Used by
+// the unified document renderer where dm.scroll handles visibility at
+// the document level.
+func (dm detailModel) renderActiveTabFull(width int) string {
+	const noLimit = 1 << 30
+	return dm.renderActiveTab(width, noLimit)
 }
 
 func renderChildIssueRow(child Issue, selected bool, width int) string {
@@ -565,15 +647,6 @@ func renderChildIssueRow(child Issue, selected bool, width int) string {
 		padToWidth(humanizeRelative(child.UpdatedAt), updateW),
 	}
 	return strings.Join(parts, "")
-}
-
-func windowChildIssues(issues []Issue, cursor, budget int) ([]Issue, int) {
-	n := len(issues)
-	if n == 0 {
-		return issues, 0
-	}
-	start, end := windowBounds(n, cursor, budget)
-	return issues[start:end], cursor - start
 }
 
 // wrapBody splits s on newlines, then hard-wraps each segment to width.

--- a/internal/tui/detail_render.go
+++ b/internal/tui/detail_render.go
@@ -494,7 +494,11 @@ func (dm detailModel) detailDocumentLines(width int, chrome viewChrome) ([]strin
 	if dm.hasActivity() {
 		lines = append(lines, "", dm.renderActivityHeader(sheetWidth))
 		anchors.activity = len(lines)
-		if chunks := dm.activeChunks(sheetWidth); len(chunks) > 0 {
+		chunks := dm.activeChunks(sheetWidth)
+		// tabCursor anchor only makes sense when the chunks map to real
+		// rows; loading / errored / empty placeholders return a single
+		// pseudo-chunk with no cursor target.
+		if dm.activeRowCount() > 0 && len(chunks) > 0 {
 			cursor := clampInt(dm.tabCursor, 0, len(chunks)-1)
 			offset := 0
 			for i := 0; i < cursor; i++ {
@@ -502,7 +506,11 @@ func (dm detailModel) detailDocumentLines(width int, chrome viewChrome) ([]strin
 			}
 			anchors.tabCursor = anchors.activity + offset
 		}
-		addBlock(withGutter(dm.renderActiveTabFull(sheetWidth)))
+		for _, ch := range chunks {
+			for _, line := range ch.lines {
+				lines = append(lines, withGutter(truncate(line, sheetWidth)))
+			}
+		}
 	}
 
 	anchors.total = len(lines)
@@ -612,16 +620,6 @@ func (dm detailModel) renderChildrenFull(width int) string {
 	return strings.Join(lines, "\n")
 }
 
-// renderActiveTabFull returns the active tab's full content with no
-// per-tab windowing. Effectively-infinite height defeats assembleTab's
-// window+clip step; line-wise width truncation still applies. Used by
-// the unified document renderer where dm.scroll handles visibility at
-// the document level.
-func (dm detailModel) renderActiveTabFull(width int) string {
-	const noLimit = 1 << 30
-	return dm.renderActiveTab(width, noLimit)
-}
-
 func renderChildIssueRow(child Issue, selected bool, width int) string {
 	const (
 		markerW = 2
@@ -686,27 +684,6 @@ func hardWrap(s string, width int) []string {
 		out = append(out, s)
 	}
 	return out
-}
-
-// renderActiveTab dispatches to the per-tab renderer. The header line
-// "Comments (N)" / "Events (N)" / "Links (N)" sits above the entries
-// and is always rendered (even on empty data) so the tab strip + count
-// stays consistent across tab switches. The per-tab loading/err state
-// is forwarded so the renderer can substitute "(loading...)" or an
-// error chip for the entry list.
-func (dm detailModel) renderActiveTab(width, height int) string {
-	switch dm.activeTab {
-	case tabComments:
-		return renderCommentsTab(dm.comments, width, height, dm.tabCursor,
-			tabState{loading: dm.commentsLoading, err: dm.commentsErr})
-	case tabEvents:
-		return renderEventsTab(dm.events, width, height, dm.tabCursor,
-			tabState{loading: dm.eventsLoading, err: dm.eventsErr})
-	case tabLinks:
-		return renderLinksTab(dm.links, width, height, dm.tabCursor,
-			tabState{loading: dm.linksLoading, err: dm.linksErr})
-	}
-	return ""
 }
 
 func (dm detailModel) hasActivity() bool {

--- a/internal/tui/detail_tabs.go
+++ b/internal/tui/detail_tabs.go
@@ -15,20 +15,16 @@ type tabState struct {
 	err     error
 }
 
-// renderCommentsTab formats the comments tab as document activity:
-// cursor marker + bold author + dim timestamp, followed by indented
-// Markdown comment text and a blank separator.
-// The cursor highlights the row under dm.tabCursor; rendered lines
-// are windowed so the cursor entry is always visible even when the
-// entries don't all fit in height.
-//
-// The "Comments (N)" label is shown by renderTabStrip above; this
-// renderer no longer repeats it. Empty / loading / error placeholders
-// still render in place of the entries via tabPlaceholder.
-func renderCommentsTab(cs []CommentEntry, width, height, cursor int, ts tabState) string {
-	placeholder := tabPlaceholder(ts, "comments", "(no comments)", len(cs))
-	if placeholder != nil {
-		return assembleTab(nil, []entryChunk{*placeholder}, width, height, -1)
+// commentChunks builds the chunk slice for the comments tab. Each
+// non-placeholder chunk is one comment: cursor marker + author + dim
+// timestamp, followed by indented Markdown comment body and a blank
+// separator. Empty / loading / errored states return a single
+// placeholder chunk via tabPlaceholder. The chunks ARE the rendered
+// content — detailDocumentLines emits them directly without a second
+// markdown pass.
+func commentChunks(cs []CommentEntry, width, cursor int, ts tabState) []entryChunk {
+	if placeholder := tabPlaceholder(ts, "comments", "(no comments)", len(cs)); placeholder != nil {
+		return []entryChunk{*placeholder}
 	}
 	chunks := make([]entryChunk, 0, len(cs))
 	authorW := commentAuthorWidth(cs)
@@ -42,18 +38,16 @@ func renderCommentsTab(cs []CommentEntry, width, height, cursor int, ts tabState
 		lines = append(lines, "")
 		chunks = append(chunks, entryChunk{lines: lines})
 	}
-	return assembleTab(nil, chunks, width, height, cursor)
+	return chunks
 }
 
-// renderEventsTab formats one line per event:
+// eventChunks builds one single-line chunk per event:
 // "[type] timestamp actor — description". The description is type-
-// specific (e.g., "labeled bug", "linked #7"). Cursor highlights the
-// row under dm.tabCursor; the rendered lines are windowed around the
-// cursor so a tabCursor past the visible height still has its row on
-// screen.
-func renderEventsTab(es []EventLogEntry, width, height, cursor int, ts tabState) string {
+// specific (e.g., "labeled bug", "linked #7").
+func eventChunks(es []EventLogEntry, width, cursor int, ts tabState) []entryChunk {
+	_ = width // single-line entries; width clipping happens at render time
 	if placeholder := tabPlaceholder(ts, "events", "(no events yet)", len(es)); placeholder != nil {
-		return assembleTab(nil, []entryChunk{*placeholder}, width, height, -1)
+		return []entryChunk{*placeholder}
 	}
 	chunks := make([]entryChunk, 0, len(es))
 	for i, e := range es {
@@ -68,20 +62,18 @@ func renderEventsTab(es []EventLogEntry, width, height, cursor int, ts tabState)
 			applyActivityCursor(line, i == cursor),
 		}})
 	}
-	return assembleTab(nil, chunks, width, height, cursor)
+	return chunks
 }
 
-// renderLinksTab formats one line per link:
+// linkChunks builds one single-line chunk per link:
 // "[type] → #ToN ← #FromN  by author @ timestamp". The "(open|closed)"
-// status is not on the LinkEntry projection; pressing Enter on a link
-// jumps to the target so the user can see the title and status there.
-// Lines are windowed around the cursor for the same reason.
-//
-// Type is daemon-defined but Author is agent-supplied; sanitize the
-// latter so a malicious link author can't push the terminal around.
-func renderLinksTab(ls []LinkEntry, width, height, cursor int, ts tabState) string {
+// status isn't on the LinkEntry projection; pressing Enter jumps to the
+// target. Type is daemon-defined; Author is agent-supplied and is
+// sanitized so a malicious link author can't push the terminal around.
+func linkChunks(ls []LinkEntry, width, cursor int, ts tabState) []entryChunk {
+	_ = width
 	if placeholder := tabPlaceholder(ts, "links", "(no links)", len(ls)); placeholder != nil {
-		return assembleTab(nil, []entryChunk{*placeholder}, width, height, -1)
+		return []entryChunk{*placeholder}
 	}
 	chunks := make([]entryChunk, 0, len(ls))
 	for i, l := range ls {
@@ -92,7 +84,56 @@ func renderLinksTab(ls []LinkEntry, width, height, cursor int, ts tabState) stri
 			applyActivityCursor(line, i == cursor),
 		}})
 	}
+	return chunks
+}
+
+// renderCommentsTab / renderEventsTab / renderLinksTab assemble the
+// chunks into a windowed, height-bounded view. The chunk-builders
+// above are also reachable via detailModel.activeChunks for the
+// unified detail document; the per-tab renderers stay for tests that
+// need windowing behaviour at a fixed height.
+func renderCommentsTab(cs []CommentEntry, width, height, cursor int, ts tabState) string {
+	chunks := commentChunks(cs, width, cursor, ts)
+	if len(chunks) == 0 {
+		return ""
+	}
+	if isPlaceholderChunks(chunks, ts, len(cs)) {
+		return assembleTab(nil, chunks, width, height, -1)
+	}
 	return assembleTab(nil, chunks, width, height, cursor)
+}
+
+func renderEventsTab(es []EventLogEntry, width, height, cursor int, ts tabState) string {
+	chunks := eventChunks(es, width, cursor, ts)
+	if len(chunks) == 0 {
+		return ""
+	}
+	if isPlaceholderChunks(chunks, ts, len(es)) {
+		return assembleTab(nil, chunks, width, height, -1)
+	}
+	return assembleTab(nil, chunks, width, height, cursor)
+}
+
+func renderLinksTab(ls []LinkEntry, width, height, cursor int, ts tabState) string {
+	chunks := linkChunks(ls, width, cursor, ts)
+	if len(chunks) == 0 {
+		return ""
+	}
+	if isPlaceholderChunks(chunks, ts, len(ls)) {
+		return assembleTab(nil, chunks, width, height, -1)
+	}
+	return assembleTab(nil, chunks, width, height, cursor)
+}
+
+// isPlaceholderChunks reports whether the chunks slice represents a
+// loading / errored / empty placeholder rather than rendered entries.
+// The per-tab renderers pass cursor=-1 to assembleTab in that case so
+// windowChunkBounds doesn't try to anchor on a fake "row 0".
+func isPlaceholderChunks(chunks []entryChunk, ts tabState, n int) bool {
+	if len(chunks) != 1 {
+		return false
+	}
+	return ts.err != nil || ts.loading || n == 0
 }
 
 // tabPlaceholder returns the chunk to render in lieu of the entry list

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -399,6 +399,47 @@ func TestDetail_Scroll_SplitViewportClamp(t *testing.T) {
 	}
 }
 
+// TestDetail_JK_OnEmptyActivityTab_ScrollsViewport pins the regression
+// in handleNavKey: when the focused activity tab has no rows
+// (placeholder loading / error / empty), j/k must spill to viewport
+// scroll without revealCursor immediately pinning the activity header
+// back into view. Without this, scrolling near the bottom of a long
+// body with focusActivity on an empty tab would snap the viewport
+// back to the activity header on every press.
+func TestDetail_JK_OnEmptyActivityTab_ScrollsViewport(t *testing.T) {
+	dm := detailFixture()
+	dm.issue.Body = strings.Repeat("body line\n", 60) + "tail"
+	dm.links = nil // empty links tab; comments+events keep hasActivity true
+	dm.activeTab = tabLinks
+	dm.detailFocus = focusActivity
+	dm.tabExplicit = true
+	dm.lastTermWidth, dm.lastTermHeight = 100, 24
+
+	// Scroll into the body so the activity header is well above the
+	// viewport. Without the fix, revealCursor will pull scroll back to
+	// the activity header on every j/k press.
+	dm.scroll = 30
+	docTotal, _ := dm.detailDocumentLines(dm.lastTermWidth, dm.scrollChrome())
+	_, visible, ok := dm.viewportDims()
+	if !ok || dm.scroll+visible >= len(docTotal) {
+		t.Fatalf("setup: scroll=%d not deep into the document (visible=%d total=%d)",
+			dm.scroll, visible, len(docTotal))
+	}
+
+	km := newKeymap()
+	before := dm.scroll
+	next, _ := dm.Update(runeKey('j'), km, nil)
+	if next.scroll != before+1 {
+		t.Fatalf("j on empty activity tab: scroll = %d, want %d — revealCursor likely pulled scroll back to the activity header",
+			next.scroll, before+1)
+	}
+	next, _ = next.Update(runeKey('k'), km, nil)
+	if next.scroll != before {
+		t.Fatalf("k on empty activity tab: scroll = %d, want %d (before-1)",
+			next.scroll, before)
+	}
+}
+
 // TestDetail_OpenFromList_SeedsViewportCache pins the regression:
 // the freshly-installed detail model in handleOpenDetail must inherit
 // the terminal dimensions, not start from zero. Without the seed,

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -399,6 +399,65 @@ func TestDetail_Scroll_SplitViewportClamp(t *testing.T) {
 	}
 }
 
+// TestDetail_OpenFromList_SeedsViewportCache pins the regression:
+// the freshly-installed detail model in handleOpenDetail must inherit
+// the terminal dimensions, not start from zero. Without the seed,
+// viewportDims() returns ok=false, pageStep falls back to
+// detailFallbackPageStep (8) regardless of how tall the terminal is,
+// and scrollViewportBy skips its EOF clamp until the next
+// WindowSizeMsg arrives.
+func TestDetail_OpenFromList_SeedsViewportCache(t *testing.T) {
+	m := scenarioModel(t, 200, 40) // split layout breakpoint is 140x36
+	iss := listFixture()[0]
+	out, _ := m.Update(openDetailMsg{issue: iss})
+	m = out.(Model)
+
+	if m.detail.lastTermWidth != 200 || m.detail.lastTermHeight != 40 {
+		t.Fatalf("lastTerm = %dx%d, want 200x40 after open",
+			m.detail.lastTermWidth, m.detail.lastTermHeight)
+	}
+	if !m.detail.lastDetailSplit {
+		t.Fatalf("lastDetailSplit = false at split layout 200x40")
+	}
+	_, visible, ok := m.detail.viewportDims()
+	if !ok {
+		t.Fatalf("viewportDims().ok = false after open; pageStep would be %d",
+			m.detail.pageStep())
+	}
+	if step := m.detail.pageStep(); step != visible-detailPageOverlap {
+		t.Errorf("pageStep = %d, want %d (visible-overlap)",
+			step, visible-detailPageOverlap)
+	}
+}
+
+// TestModel_ToggleLayout_RefreshesViewportCache pins the regression:
+// pressing the layout-toggle key changes the detail pane's effective
+// size (full-width stacked vs boxed split-pane inner area). Without
+// refreshing the cache the next PgUp/PgDn keeps using the pre-toggle
+// dimensions — overshooting after stacked → split (the split pane is
+// smaller) or leaving slack after split → stacked.
+func TestModel_ToggleLayout_RefreshesViewportCache(t *testing.T) {
+	m := scenarioModel(t, 200, 40) // starts in split
+	iss := listFixture()[0]
+	out, _ := m.Update(openDetailMsg{issue: iss})
+	m = out.(Model)
+	if !m.detail.lastDetailSplit {
+		t.Fatalf("setup: expected split layout cached")
+	}
+
+	m = m.toggleLayout() // split → stacked
+	if m.detail.lastDetailSplit {
+		t.Fatalf("after toggle: lastDetailSplit still true; cache is stale")
+	}
+	if m.detail.lastTermWidth != 200 || m.detail.lastTermHeight != 40 {
+		t.Fatalf("after toggle: lastTerm = %dx%d, want preserved 200x40",
+			m.detail.lastTermWidth, m.detail.lastTermHeight)
+	}
+	if _, _, ok := m.detail.viewportDims(); !ok {
+		t.Fatalf("viewportDims().ok = false after toggle")
+	}
+}
+
 // TestDetail_Back_EmitsPopMsg: esc returns a tea.Cmd that emits
 // popDetailMsg when the nav stack is empty.
 func TestDetail_Back_EmitsPopMsg(t *testing.T) {

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -174,7 +174,12 @@ func TestDetail_RenderHierarchySections(t *testing.T) {
 		{Number: 43, Title: "detail hint bars incomplete", Status: "open", Owner: ptrString("alice")},
 		{Number: 44, Title: "new issue form parent field", Status: "closed"},
 	}
-	out := stripANSI(dm.View(100, 28, viewChrome{}))
+	// In the unified-viewport layout the children section sits below the
+	// body in document order. Assert against the assembled document
+	// rather than the viewport so we don't have to size the terminal
+	// large enough to fit everything (or scroll programmatically).
+	docLines, _ := dm.detailDocumentLines(100, viewChrome{})
+	out := stripANSI(strings.Join(docLines, "\n"))
 	assertContainsAll(t, out,
 		"parent: #12 workspace polish parent",
 		"children: 1 open / 2 total",
@@ -212,24 +217,27 @@ func TestDetail_TabCycle_NextPrev(t *testing.T) {
 	}
 }
 
-// TestDetail_TabRender_ActiveContent: after a tab press the events
-// header text appears in the rendered output.
+// TestDetail_TabRender_ActiveContent: after a tab press the active-tab
+// chip changes in the activity strip. Assert against the assembled
+// document rather than the viewport so the activity strip is in scope
+// regardless of body length.
 func TestDetail_TabRender_ActiveContent(t *testing.T) {
 	dm := detailFixture()
 	km := newKeymap()
-	out := dm.View(80, 24, viewChrome{})
-	if !strings.Contains(out, "Comments (2)") {
-		t.Fatalf("comments header missing:\n%s", out)
+	docOut := func(d detailModel) string {
+		lines, _ := d.detailDocumentLines(80, viewChrome{})
+		return stripANSI(strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(docOut(dm), "Comments (2)") {
+		t.Fatalf("comments header missing:\n%s", docOut(dm))
 	}
 	dm, _ = dm.Update(tea.KeyMsg{Type: tea.KeyTab}, km, nil)
-	out = dm.View(80, 24, viewChrome{})
-	if !strings.Contains(out, "Events (2)") {
-		t.Fatalf("events header missing after tab:\n%s", out)
+	if !strings.Contains(docOut(dm), "Events (2)") {
+		t.Fatalf("events header missing after tab:\n%s", docOut(dm))
 	}
 	dm, _ = dm.Update(tea.KeyMsg{Type: tea.KeyTab}, km, nil)
-	out = dm.View(80, 24, viewChrome{})
-	if !strings.Contains(out, "Links (1)") {
-		t.Fatalf("links header missing after second tab:\n%s", out)
+	if !strings.Contains(docOut(dm), "Links (1)") {
+		t.Fatalf("links header missing after second tab:\n%s", docOut(dm))
 	}
 }
 
@@ -336,53 +344,58 @@ func TestDetail_Scroll_PageDownClampsPastEOFAndPageUpResponds(t *testing.T) {
 	}
 }
 
-func TestDetail_Scroll_BodyMaxStartEstimateDoesNotExceedRenderedMax(t *testing.T) {
+// TestDetail_Scroll_PageDownClampsToDocument: a long body + some
+// activity rows yields a document strictly taller than a 30-row
+// terminal. Aggressive PgDn must clamp dm.scroll at the document's
+// max-start so the renderer never windows past EOF — and so a single
+// PgUp produces visible movement, not a no-op while an inflated
+// offset unwinds (regression for roborev #17184, retargeted at the
+// unified viewport).
+func TestDetail_Scroll_PageDownClampsToDocument(t *testing.T) {
 	dm := detailFixture()
-	dm.comments = nil
-	dm.events = nil
-	dm.links = nil
 	dm.issue.Body = strings.Repeat("line\n", 39) + "tail"
 	width, height := 120, 30
 	dm.lastTermWidth, dm.lastTermHeight = width, height
+	docLines, _ := dm.detailDocumentLines(width, dm.scrollChrome())
+	_, visible, _ := dm.viewportDims()
+	maxStart := viewportMaxStart(len(docLines), visible)
 
-	sheetWidth := documentSheetWidth(width)
-	chrome := viewChrome{}
-	helpRows := detailHelpRows(dm, chrome)
-	footerLines := helpLines(helpRows, width)
-	header := append([]string{renderTitleBar(width, chrome.scope, chrome.version), ""}, dm.documentHeader(sheetWidth, chrome)...)
-	fixed := len(header) + 1 /* body label */ + 1 /* blank gap before activity */ +
-		1 /* info */ + footerLines
-	bodyRows, _, _ := detailDocumentBudgets(height-fixed, 0, false)
-	renderedMaxStart := len(renderMarkdownLines(dm.issue.Body, sheetWidth)) - bodyRows
-	if renderedMaxStart < 0 {
-		renderedMaxStart = 0
+	km := newKeymap()
+	for i := 0; i < 12; i++ {
+		dm, _ = dm.Update(tea.KeyMsg{Type: tea.KeyPgDown}, km, nil)
 	}
-
-	if got := dm.bodyMaxStartEstimate(); got > renderedMaxStart {
-		t.Fatalf("bodyMaxStartEstimate=%d exceeds rendered maxStart=%d", got, renderedMaxStart)
+	if dm.scroll > maxStart {
+		t.Fatalf("PgDn past EOF: scroll=%d > maxStart=%d", dm.scroll, maxStart)
+	}
+	prev := dm.scroll
+	dm, _ = dm.Update(tea.KeyMsg{Type: tea.KeyPgUp}, km, nil)
+	if prev > 0 && dm.scroll >= prev {
+		t.Fatalf("PgUp after overscroll did not respond: scroll=%d, prev=%d",
+			dm.scroll, prev)
 	}
 }
 
-func TestDetail_Scroll_SplitBodyMaxStartUsesSplitViewport(t *testing.T) {
+// TestDetail_Scroll_SplitViewportClamp: in split-pane mode the cached
+// lastDetailWidth/Height is the inner pane size. Aggressive PgDn must
+// clamp scroll using that pane height, not the full terminal — split
+// panes are typically much shorter and would otherwise let dm.scroll
+// run far past the rendered EOF.
+func TestDetail_Scroll_SplitViewportClamp(t *testing.T) {
 	dm := detailFixture()
-	dm.comments = nil
-	dm.events = nil
-	dm.links = nil
 	dm.issue.Body = strings.Repeat("line\n", 59) + "tail"
 	width, height := 72, 24
 	dm.lastDetailWidth, dm.lastDetailHeight = width, height
 	dm.lastDetailSplit = true
+	docLines, _ := dm.detailDocumentLines(width, dm.scrollChrome())
+	maxStart := viewportMaxStart(len(docLines), height)
 
-	sheetWidth := documentSheetWidth(width)
-	header := dm.documentHeader(sheetWidth, viewChrome{})
-	bodyRows, _, _ := detailDocumentBudgets(height-(len(header)+1), 0, false)
-	renderedMaxStart := len(renderMarkdownLines(dm.issue.Body, sheetWidth)) - bodyRows
-	if renderedMaxStart < 0 {
-		renderedMaxStart = 0
+	km := newKeymap()
+	for i := 0; i < 30; i++ {
+		dm, _ = dm.Update(tea.KeyMsg{Type: tea.KeyPgDown}, km, nil)
 	}
-
-	if got := dm.bodyMaxStartEstimate(); got != renderedMaxStart {
-		t.Fatalf("split bodyMaxStartEstimate=%d, want rendered maxStart=%d", got, renderedMaxStart)
+	if dm.scroll != maxStart {
+		t.Fatalf("PgDn in split overflowed: scroll=%d, want maxStart=%d",
+			dm.scroll, maxStart)
 	}
 }
 
@@ -520,7 +533,8 @@ func TestDetail_FetchedMsgs_ErrorRecorded(t *testing.T) {
 func TestDetail_TabPlaceholder_LoadingRendered(t *testing.T) {
 	dm := detailFixture()
 	dm.commentsLoading = true
-	out := dm.View(80, 30, viewChrome{})
+	lines, _ := dm.detailDocumentLines(80, viewChrome{})
+	out := stripANSI(strings.Join(lines, "\n"))
 	if !strings.Contains(out, "loading") {
 		t.Fatalf("expected loading placeholder on comments tab, got:\n%s", out)
 	}
@@ -533,7 +547,8 @@ func TestDetail_TabPlaceholder_ErrorRendered(t *testing.T) {
 	dm := detailFixture()
 	dm.commentsLoading = false
 	dm.commentsErr = errors.New("server down")
-	out := dm.View(80, 30, viewChrome{})
+	lines, _ := dm.detailDocumentLines(80, viewChrome{})
+	out := stripANSI(strings.Join(lines, "\n"))
 	if !strings.Contains(out, "comments: server down") {
 		t.Fatalf("expected per-tab error hint, got:\n%s", out)
 	}
@@ -859,33 +874,37 @@ func TestDetail_FetchCommands_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestDetail_BodyScroll_RenderWindow: with scroll=N the rendered body
-// starts at line N+header so the user sees later body content.
-func TestDetail_BodyScroll_RenderWindow(t *testing.T) {
+// TestDetail_Viewport_ScrollAdvancesWindow: with dm.scroll = N the
+// viewport's first visible row is documentLines[N], so the user reads
+// later content as the offset grows.
+func TestDetail_Viewport_ScrollAdvancesWindow(t *testing.T) {
 	dm := detailFixture()
+	docLines, _ := dm.detailDocumentLines(120, viewChrome{})
+	want := stripANSI(docLines[5])
+	dm.lastTermWidth, dm.lastTermHeight = 120, 30
 	dm.scroll = 5
-	out := dm.renderBody(80, 5)
-	lines := strings.Split(out, "\n")
-	if len(lines) != 5 {
-		t.Fatalf("got %d body lines, want 5", len(lines))
+	out := stripANSI(dm.View(120, 30, viewChrome{}))
+	// Title bar + blank are pinned chrome (lines 0-1); the first
+	// document row sits on line 2.
+	rows := strings.Split(out, "\n")
+	if len(rows) < 3 {
+		t.Fatalf("view too short:\n%s", out)
 	}
-	if lines[0] != "line" {
-		t.Fatalf("body[0] = %q, want line", lines[0])
+	if !strings.Contains(rows[2], strings.TrimSpace(want)) {
+		t.Fatalf("first visible row mismatch:\n want %q\n  got %q", want, rows[2])
 	}
 }
 
-// TestDetail_ScrollClampsAtEOF: if scroll is set beyond the body length
-// the renderer clamps at the last line so the window still fills.
-func TestDetail_ScrollClampsAtEOF(t *testing.T) {
+// TestDetail_Viewport_ScrollClampsAtEOF: an out-of-range dm.scroll is
+// clamped against viewportMaxStart so the renderer never produces a
+// window of blanks past the last line.
+func TestDetail_Viewport_ScrollClampsAtEOF(t *testing.T) {
 	dm := detailFixture()
 	dm.scroll = 10000
-	out := dm.renderBody(80, 5)
-	lines := strings.Split(out, "\n")
-	if len(lines) == 0 {
-		t.Fatalf("expected clamped window, got empty output")
-	}
+	dm.lastTermWidth, dm.lastTermHeight = 120, 30
+	out := stripANSI(dm.View(120, 30, viewChrome{}))
 	if !strings.Contains(out, "tail") {
-		t.Fatalf("expected tail near EOF, got:\n%s", out)
+		t.Fatalf("expected tail of body near EOF, got:\n%s", out)
 	}
 }
 

--- a/internal/tui/edge_test.go
+++ b/internal/tui/edge_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -676,35 +677,37 @@ func TestOverlayModal_PadsShortBackground(t *testing.T) {
 	}
 }
 
-// TestDetail_ScrollIndicator_AccountsForMultiLineComments: when
-// comment entries wrap to multiple lines, the per-tab scroll
-// indicator must compute the visible window in entry units using
-// the renderer's actual chunk shape, not by comparing entry
-// count to a line budget. With 6 comments in an 8-line pane and
-// each comment contributing ~4 lines (header + body + blank), only
-// 2 entries fit, so the indicator must fire and report a window
-// shorter than 6. Regression for roborev #119 finding 2.
-func TestDetail_ScrollIndicator_AccountsForMultiLineComments(t *testing.T) {
+// TestDetail_ScrollIndicator_ViewportCoversWholeDocument: the info
+// indicator reports the unified viewport position. With 6 multi-line
+// comments plus body and headers, the document is well over a 16-row
+// terminal, so the indicator must surface and read in document-line
+// units (not per-tab entry units, which the legacy detail view used
+// before the unified-viewport refactor).
+func TestDetail_ScrollIndicator_ViewportCoversWholeDocument(t *testing.T) {
 	cs := make([]CommentEntry, 6)
 	body := "wrapped body content that takes a few lines"
 	for i := range cs {
 		cs[i] = CommentEntry{Author: "actor", Body: body}
 	}
 	dm := detailModel{
-		issue:     &Issue{Number: 1, Title: "x", Status: "open"},
+		issue: &Issue{
+			Number: 1, Title: "x", Status: "open",
+			Body: strings.Repeat("body line\n", 12),
+		},
 		comments:  cs,
 		activeTab: tabComments,
 		tabCursor: 0,
 	}
-	// 8-line tab budget. With multi-line chunks at ~3-4 lines each,
-	// only 2-3 entries fit; the indicator must report fewer than 6.
-	info := dm.renderInfoLine(120, viewChrome{sseStatus: sseConnected}, 8)
-	if !strings.Contains(info, "of 6 comments") {
-		t.Fatalf("indicator missing or wrong total; info = %q", info)
+	docLines, _ := dm.detailDocumentLines(120, viewChrome{})
+	const visible = 16
+	info := dm.renderInfoLine(120,
+		viewChrome{sseStatus: sseConnected}, len(docLines), 0, visible)
+	wantSuffix := fmt.Sprintf("of %d]", len(docLines))
+	if !strings.Contains(info, wantSuffix) {
+		t.Fatalf("indicator missing total; want suffix %q, got info = %q",
+			wantSuffix, info)
 	}
-	// The visible range must be smaller than [1-6] (the bug was that
-	// n=6 <= budget=8 suppressed the indicator entirely).
-	if strings.Contains(info, "[1-6 ") {
-		t.Fatalf("indicator claims all 6 comments fit; info = %q", info)
+	if !strings.Contains(info, "lines 1-16 ") {
+		t.Fatalf("indicator missing visible range; got info = %q", info)
 	}
 }

--- a/internal/tui/footer_hints.go
+++ b/internal/tui/footer_hints.go
@@ -173,18 +173,20 @@ func (dm detailModel) detailHelpRows() [][]helpItem {
 	}
 	if dm.detailFocus == focusChildren && len(dm.children) > 0 {
 		nav := []helpItem{
-			{key: "↑↓", desc: "child"},
+			{key: "↑↓", desc: "scroll"},
+			{key: "j/k", desc: "child"},
 			{key: "↵", desc: "open child"},
 			{key: "↹", desc: "section"},
-			{key: "pgup/pgdn", desc: "scroll body"},
+			{key: "pgup/pgdn", desc: "page"},
 		}
 		return [][]helpItem{append(nav, actions...)}
 	}
 	nav := []helpItem{
-		{key: "↑↓", desc: "move"},
+		{key: "↑↓", desc: "scroll"},
+		{key: "j/k", desc: "row"},
 		{key: "↹", desc: "section"},
 		{key: "↵", desc: "open"},
-		{key: "pgup/pgdn", desc: "scroll body"},
+		{key: "pgup/pgdn", desc: "page"},
 	}
 	return [][]helpItem{append(nav, actions...)}
 }

--- a/internal/tui/footer_hints_test.go
+++ b/internal/tui/footer_hints_test.go
@@ -41,9 +41,11 @@ func TestDetailHelpRows_Contexts(t *testing.T) {
 		activeTab:   tabComments,
 	}}
 	assertHelpItemsPresent(t, activity.detailHelpRows(),
-		helpItem{key: "↑↓", desc: "move"},
+		helpItem{key: "↑↓", desc: "scroll"},
+		helpItem{key: "j/k", desc: "row"},
 		helpItem{key: "↹", desc: "section"},
 		helpItem{key: "↵", desc: "open"},
+		helpItem{key: "pgup/pgdn", desc: "page"},
 		helpItem{key: "e", desc: "edit"},
 		helpItem{key: "c", desc: "comment"},
 		helpItem{key: "+", desc: "label"},
@@ -60,7 +62,8 @@ func TestDetailHelpRows_Contexts(t *testing.T) {
 
 	children := Model{detail: hierarchyDetailModel(focusChildren)}
 	assertHelpItemsPresent(t, children.detailHelpRows(),
-		helpItem{key: "↑↓", desc: "child"},
+		helpItem{key: "↑↓", desc: "scroll"},
+		helpItem{key: "j/k", desc: "child"},
 		helpItem{key: "↵", desc: "open child"},
 		helpItem{key: "N", desc: "child"},
 		helpItem{key: "e", desc: "edit"},
@@ -109,16 +112,19 @@ func TestHelpRows_InputAndModalContexts(t *testing.T) {
 	}
 }
 
+// TestPersistentHelpRowsPreferArrowNotation guards the queue (list)
+// footer's arrow-first convention. The detail footer additionally
+// surfaces j/k as the section-cursor binding, since the unified
+// document refactor split arrows (viewport scroll) from j/k (row
+// cursor) — both must be discoverable from the persistent help row.
 func TestPersistentHelpRowsPreferArrowNotation(t *testing.T) {
 	m := Model{
 		list:   listModel{issues: hierarchyIssues()},
 		detail: hierarchyDetailModel(focusActivity),
 	}
-	for _, rows := range [][][]helpItem{m.queueHelpRows(), m.detailHelpRows()} {
-		for _, item := range flattenHelpRows(rows) {
-			if strings.Contains(item.key, "j/k") {
-				t.Fatalf("persistent footer keys should use arrows, got %+v", item)
-			}
+	for _, item := range flattenHelpRows(m.queueHelpRows()) {
+		if strings.Contains(item.key, "j/k") {
+			t.Fatalf("queue footer keys should use arrows, got %+v", item)
 		}
 	}
 }

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -33,7 +33,8 @@ func helpSections(km keymap) []helpSection {
 		}},
 		{"Children", []helpItem{
 			r(km.NewChild),
-			{key: "↑↓", desc: "move child cursor"},
+			{key: "j/k", desc: "move child cursor"},
+			{key: "↑↓", desc: "scroll detail viewport"},
 			{key: "enter", desc: "open child"},
 		}},
 		{"Forms", []helpItem{

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -20,7 +20,8 @@ func helpSections(km keymap) []helpSection {
 	return []helpSection{
 		{"Global", []helpItem{r(km.Help), r(km.Quit), r(km.Projects), r(km.ToggleLayout)}},
 		{"Graph", []helpItem{
-			r(km.Up), r(km.Down), r(km.PageUp), r(km.PageDown), r(km.Home),
+			r(km.Up), r(km.Down), r(km.ScrollUp), r(km.ScrollDown),
+			r(km.PageUp), r(km.PageDown), r(km.Home),
 			r(km.End), r(km.Open), r(km.ExpandCollapse), r(km.NewIssue),
 			r(km.SortChildren), r(km.Close), r(km.Reopen),
 		}},

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -40,6 +40,21 @@ func TestHelpSections_AllBindingsCovered(t *testing.T) {
 	}
 }
 
+// TestRenderHelp_ChildrenSectionMatchesKeymap pins the Children
+// section of the help overlay against the actual j/k vs ↑↓ split:
+// j/k moves the child cursor, ↑↓ scrolls the detail viewport. The
+// help text used to claim "↑↓ move child cursor" which became stale
+// when the document-viewport keymap split landed.
+func TestRenderHelp_ChildrenSectionMatchesKeymap(t *testing.T) {
+	out := stripANSI(renderHelp(newKeymap(), 80, ListFilter{}))
+	if !strings.Contains(out, "j/k") || !strings.Contains(out, "move child cursor") {
+		t.Errorf("help overlay should describe j/k as the child-cursor key; got:\n%s", out)
+	}
+	if !strings.Contains(out, "↑↓") || !strings.Contains(out, "scroll detail viewport") {
+		t.Errorf("help overlay should describe ↑↓ as the viewport scroll key; got:\n%s", out)
+	}
+}
+
 // TestRenderHelp_NarrowWidth: width 40 picks a 1-column layout. We
 // assert each section title appears on its own line so a future
 // regression that drops Detail (or any other section) is caught.

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -10,6 +10,7 @@ type keymap struct {
 	Projects                                       key
 	ToggleLayout                                   key
 	Up, Down, PageUp, PageDown, Home, End          key
+	ScrollUp, ScrollDown                           key
 	Open, NewIssue, NewChild, Search               key
 	ExpandCollapse                                 key
 	SortChildren                                   key
@@ -31,12 +32,20 @@ type key struct {
 // newKeymap returns the spec §7.3 bindings.
 func newKeymap() keymap {
 	return keymap{
-		Help:           key{Keys: []string{"?"}, Help: "help"},
-		Quit:           key{Keys: []string{"q", "ctrl+c"}, Help: "quit"},
-		Projects:       key{Keys: []string{"P"}, Help: "projects"},
-		ToggleLayout:   key{Keys: []string{"L"}, Help: "toggle layout"},
-		Up:             key{Keys: []string{"k", "up"}, Help: "up"},
-		Down:           key{Keys: []string{"j", "down"}, Help: "down"},
+		Help:         key{Keys: []string{"?"}, Help: "help"},
+		Quit:         key{Keys: []string{"q", "ctrl+c"}, Help: "quit"},
+		Projects:     key{Keys: []string{"P"}, Help: "projects"},
+		ToggleLayout: key{Keys: []string{"L"}, Help: "toggle layout"},
+		// Up/Down are the section-cursor bindings: in the detail view
+		// they move the activity tab cursor or the children cursor.
+		// ScrollUp/ScrollDown are the document-viewport scroll bindings:
+		// in the detail view they slide the whole detail document one
+		// line at a time. The list view binds both pairs to the same
+		// cursor handler so existing j/k + arrow ergonomics survive.
+		Up:             key{Keys: []string{"k"}, Help: "up"},
+		Down:           key{Keys: []string{"j"}, Help: "down"},
+		ScrollUp:       key{Keys: []string{"up"}, Help: "scroll up"},
+		ScrollDown:     key{Keys: []string{"down"}, Help: "scroll down"},
 		PageUp:         key{Keys: []string{"pgup"}, Help: "page up"},
 		PageDown:       key{Keys: []string{"pgdown"}, Help: "page down"},
 		Home:           key{Keys: []string{"g"}, Help: "first"},

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -138,6 +138,12 @@ func (m Model) toggleLayout() Model {
 	if prev != m.layout {
 		m = m.handleLayoutFlip(prev)
 	}
+	// The layout flip changes which footer help-row table is rendered
+	// and whether the detail pane is full-width or boxed in a split
+	// pane, both of which feed the viewport-dim calculation. Refresh
+	// the cache so PgUp/PgDn paging and EOF clamping use the new
+	// dimensions immediately, not the stale ones from before the flip.
+	m.detail = m.applyDetailViewportCache(m.detail)
 	return m
 }
 

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -266,11 +266,11 @@ func (lm listModel) applyCursorKey(msg tea.KeyMsg, km keymap) (listModel, bool) 
 	rows := lm.visibleRows()
 	n := len(rows)
 	switch {
-	case km.Up.matches(msg):
+	case km.Up.matches(msg), km.ScrollUp.matches(msg):
 		if lm.cursor > 0 {
 			lm.cursor--
 		}
-	case km.Down.matches(msg):
+	case km.Down.matches(msg), km.ScrollDown.matches(msg):
 		if lm.cursor < n-1 {
 			lm.cursor++
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -591,9 +591,7 @@ func (m Model) routeTopLevel(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		}
 		// Cache the terminal/detail viewport so PgDn can clamp body
 		// scroll against the same dimensions the renderer will use.
-		m.detail.lastTermWidth = m.width
-		m.detail.lastTermHeight = m.height
-		m.detail = m.cacheDetailViewport(m.detail)
+		m.detail = m.applyDetailViewportCache(m.detail)
 		return m, nil, true
 	case tea.KeyMsg:
 		// Modal owns input when active. Enter the modal-specific
@@ -634,6 +632,19 @@ func (m Model) routeTopLevel(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return m, nil, true
 	}
 	return m, nil, false
+}
+
+// applyDetailViewportCache copies the latest terminal dimensions into
+// dm and recomputes the split-pane cache. Run this after installing a
+// fresh detailModel (open/jump/follow) or after a layout toggle so
+// PgUp/PgDn page-stepping and scrollViewportBy's EOF clamp see correct
+// viewport dimensions on the very first key press, without waiting
+// for the next tea.WindowSizeMsg. Without this seed, viewportDims
+// returns ok=false and pageStep degrades to detailFallbackPageStep.
+func (m Model) applyDetailViewportCache(dm detailModel) detailModel {
+	dm.lastTermWidth = m.width
+	dm.lastTermHeight = m.height
+	return m.cacheDetailViewport(dm)
 }
 
 func (m Model) cacheDetailViewport(dm detailModel) detailModel {
@@ -1975,6 +1986,7 @@ func (m Model) handleOpenDetail(msg openDetailMsg) (tea.Model, tea.Cmd) {
 	m.detail.commentsLoading = true
 	m.detail.eventsLoading = true
 	m.detail.linksLoading = true
+	m.detail = m.applyDetailViewportCache(m.detail)
 	m.view = viewDetail
 	// In M6 split layout, "enter from list → detail" means focus
 	// moves to the detail pane on open. m.view also moves to
@@ -2054,7 +2066,7 @@ func (m Model) handleJumpDetail(msg jumpDetailMsg) (tea.Model, tea.Cmd) {
 		eventsLoading:   true,
 		linksLoading:    true,
 	}
-	m.detail = next
+	m.detail = m.applyDetailViewportCache(next)
 	cmds := []tea.Cmd{
 		fetchIssue(m.api, pid, msg.number, gen),
 		fetchComments(m.api, pid, msg.number, gen),
@@ -2216,6 +2228,7 @@ func (m Model) scheduleDetailFollow() (Model, tea.Cmd) {
 	m.detail.commentsLoading = true
 	m.detail.eventsLoading = true
 	m.detail.linksLoading = true
+	m.detail = m.applyDetailViewportCache(m.detail)
 	m.nextDetailFollowGen++
 	tickGen := m.nextDetailFollowGen
 	return m, tea.Tick(detailFollowDebounce, func(time.Time) tea.Msg {

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -55,13 +55,11 @@ func (m Model) mouseWheelAt(delta, x int) (Model, tea.Cmd) {
 }
 
 func (m Model) mouseDetailWheel(delta int) Model {
-	for i := 0; i < mouseWheelScrollLines; i++ {
-		if delta < 0 {
-			m.detail = m.detail.scrollBodyUp()
-		} else {
-			m.detail = m.detail.scrollBodyDown()
-		}
+	step := mouseWheelScrollLines
+	if delta < 0 {
+		step = -step
 	}
+	m.detail = m.detail.scrollViewportBy(step)
 	return m
 }
 

--- a/internal/tui/scenarios_test.go
+++ b/internal/tui/scenarios_test.go
@@ -177,6 +177,21 @@ func TestScenario_ReadAnIssue_PageUpClampsAtTop(t *testing.T) {
 	}
 }
 
+// TestScenario_ReadAnIssue_ArrowKeysScrollOnShortTerminal pins the
+// fix for the original "↑↓ scrolling doesn't work on short terminals"
+// bug: every issue has a synthetic issue.created event, so the legacy
+// handleUp/handleDown logic kept ↑/↓ on the activity-tab cursor and
+// never reached the body. With the unified-viewport refactor, ↑/↓ is
+// always document scroll — on a short terminal full of body the user
+// can read past the visible window without learning PgUp/PgDn.
+func TestScenario_ReadAnIssue_ArrowKeysScrollOnShortTerminal(t *testing.T) {
+	body := strings.Repeat("scrollable line\n", 80) + "ARROW_TAIL_MARKER"
+	m := setupDetailScenario(t, 120, 24, body)
+	assertViewMissing(t, m, "ARROW_TAIL_MARKER")
+	m = pressN(t, m, tea.KeyMsg{Type: tea.KeyDown}, 80)
+	assertViewContains(t, m, "ARROW_TAIL_MARKER")
+}
+
 // TestScenario_NavigateTabs_TabAdvancesActiveSection drives Tab and
 // asserts the active-tab bracket follows. Catches a class of bug
 // where Tab gets silently swallowed (e.g. eaten by an open modal,

--- a/internal/tui/split_render.go
+++ b/internal/tui/split_render.go
@@ -161,7 +161,50 @@ func splitInfoBody(m Model) string {
 			titleBarInnerWidth(m.width),
 		)
 	}
+	if m.focus == focusDetail {
+		return rightAlignInside(
+			splitDetailScrollIndicator(m), titleBarInnerWidth(m.width),
+		)
+	}
 	return ""
+}
+
+// splitDetailScrollIndicator returns the viewport position hint for
+// the detail pane in split mode. The pane's inner height (after the
+// 2-cell border) is the visible window; the document's total line
+// count is computed against the same width the pane renders at.
+func splitDetailScrollIndicator(m Model) string {
+	if m.detail.issue == nil {
+		return ""
+	}
+	bodyHeight := splitBodyHeight(m)
+	listW := splitListPaneWidth(m.width)
+	detailW := m.width - listW
+	if detailW < 20 {
+		detailW = 20
+	}
+	innerW := detailW - 2
+	innerH := bodyHeight - 2
+	if innerW < 10 {
+		innerW = 10
+	}
+	if innerH < 2 {
+		innerH = 2
+	}
+	docLines, _ := m.detail.detailDocumentLines(innerW, m.chrome())
+	scroll := clampScroll(m.detail.scroll, len(docLines), innerH)
+	return documentScrollIndicator(len(docLines), scroll, innerH)
+}
+
+// splitBodyHeight mirrors the body-height calculation in renderSplit
+// so the indicator math matches what's actually drawn.
+func splitBodyHeight(m Model) int {
+	footerLines := helpLines(m.splitHelpRows(), m.width)
+	bodyHeight := m.height - 2 - footerLines // title + info + footer
+	if bodyHeight < 4 {
+		bodyHeight = 4
+	}
+	return bodyHeight
 }
 
 // renderSplitFooter renders the shared footer help table for the split
@@ -178,6 +221,10 @@ func renderSplitFooter(width int, m Model) string {
 // 1-cell border on every side (lipgloss border), so the content
 // already sits indented from the surrounding chrome — the gutter
 // just adds breathing room inside the panel.
+//
+// Like the stacked View, the pane is one continuous scrolling
+// document: dm.scroll windows the assembled lines and ↑/↓ slide the
+// viewport.
 func (dm detailModel) ViewSplit(width, height int, chrome viewChrome) string {
 	if dm.loading {
 		return statusStyle.Render("loading…")
@@ -188,36 +235,10 @@ func (dm detailModel) ViewSplit(width, height int, chrome viewChrome) string {
 	if width <= 0 || height < 6 {
 		return dm.renderTinyFallback(width)
 	}
-	sheetWidth := documentSheetWidth(width)
-	header := dm.documentHeader(sheetWidth, chrome)
-	hasChildren := len(dm.children) > 0
-	hasActivity := dm.hasActivity()
-	fixed := len(header) + 1 /* body label */
-	if hasChildren {
-		fixed += 2 /* children label + gap */
-	}
-	if hasActivity {
-		fixed += 2 /* activity header + gap */
-	}
-	bodyA, childA, tabA := detailDocumentBudgets(height-fixed, len(dm.children), hasActivity)
-	bodyArea := withGutter(dm.renderBody(sheetWidth, bodyA))
-	childrenArea := ""
-	if hasChildren {
-		childrenArea = withGutter(dm.renderChildrenSection(sheetWidth, childA))
-	}
-	tabArea := ""
-	if hasActivity {
-		tabArea = withGutter(dm.renderActiveTab(sheetWidth, tabA))
-	}
-	parts := append([]string{}, header...)
-	parts = append(parts, renderDocumentSectionHeader("Body"), bodyArea)
-	if hasChildren {
-		parts = append(parts, "", renderDocumentSectionHeader("Children"), childrenArea)
-	}
-	if hasActivity {
-		parts = append(parts, "", dm.renderActivityHeader(sheetWidth), tabArea)
-	}
-	return padDocumentContent(parts, height, width)
+	docLines, _ := dm.detailDocumentLines(width, chrome)
+	scroll := clampScroll(dm.scroll, len(docLines), height)
+	windowed := windowDocLines(docLines, scroll, height, width)
+	return strings.Join(windowed, "\n")
 }
 
 // pickHighlightedIssue returns a copy of the issue currently under

--- a/internal/tui/testdata/golden/detail-children-focus.txt
+++ b/internal/tui/testdata/golden/detail-children-focus.txt
@@ -1,5 +1,5 @@
  Project: —                                                                                                   kata カタ 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: #12 workspace polish parent                                                                     
@@ -17,6 +17,8 @@
   > alice  Apr 30 10:00                                                                                                 
     I can repro on macOS.                                                                                               
                                                                                                                         
+    bob    Apr 30 11:00                                                                                                 
+    Looks like a race in oauth.                                                                                         
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -25,8 +27,6 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
-                                                                                                                        
-                                                                                                                        
-                                                                                                    [1-1 of 2 comments] 
- ↑↓ child▕ ↵ open child▕ ↹ section▕ pgup/pgdn scroll body▕ e edit▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign  
- x close ▕ r reopen    ▕ p parent ▕ b block              ▕ l link▕ N child  ▕ L layout▕ esc back ▕ ? help ▕ q quit      
+ ↑↓ scroll ▕ j/k child▕ ↵ open child▕ ↹ section▕ pgup/pgdn page▕ e edit▕ c comment▕ + label ▕ - unlabel▕ a owner        
+ A unassign▕ x close  ▕ r reopen    ▕ p parent ▕ b block       ▕ l link▕ N child  ▕ L layout▕ esc back ▕ ? help         
+ q quit                                                                                                                 

--- a/internal/tui/testdata/golden/detail-comments-tab.txt
+++ b/internal/tui/testdata/golden/detail-comments-tab.txt
@@ -1,5 +1,5 @@
  Project: —                                                                                                   kata カタ 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            
@@ -26,5 +26,5 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
- ↑↓ move▕ ↹ section▕ ↵ open  ▕ pgup/pgdn scroll body▕ e edit▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign       
- x close▕ r reopen ▕ p parent▕ b block              ▕ l link▕ N child  ▕ L layout▕ esc back ▕ ? help ▕ q quit           
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit ▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign  
+ x close  ▕ r reopen▕ p parent ▕ b block▕ l link        ▕ N child▕ L layout ▕ esc back▕ ? help   ▕ q quit               

--- a/internal/tui/testdata/golden/detail-document-80x50.txt
+++ b/internal/tui/testdata/golden/detail-document-80x50.txt
@@ -1,5 +1,5 @@
  Project: kata                                                  kata カタ · dev 
-                                                                                
+
   #42  fix login bug on Safari                                            [open]
   authored by wesm · created Apr 30 10:00 · updated 3h ago                      
   owner: alice   parent: #12 workspace polish parent                            
@@ -44,7 +44,7 @@
                                                                                 
                                                                                 
                                                                                 
- ↑↓ move ▕ ↹ section▕ ↵ open ▕ pgup/pgdn scroll body▕ e edit  ▕ c comment       
- + label ▕ - unlabel▕ a owner▕ A unassign           ▕ x close ▕ r reopen        
- p parent▕ b block  ▕ l link ▕ N child              ▕ L layout▕ esc back        
- ? help  ▕ q quit                                                               
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit                
+ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign    ▕ x close               
+ r reopen ▕ p parent▕ b block  ▕ l link ▕ N child       ▕ L layout              
+ esc back ▕ ? help  ▕ q quit                                                    

--- a/internal/tui/testdata/golden/detail-document-empty.txt
+++ b/internal/tui/testdata/golden/detail-document-empty.txt
@@ -1,5 +1,5 @@
  Project: —                                                           kata カタ 
-                                                                                
+
   #99  empty issue                                                        [open]
   owner: none   parent: none                                                    
                                                                                 
@@ -26,7 +26,7 @@
                                                                                 
                                                                                 
                                                                                 
- ↑↓ move ▕ ↹ section▕ ↵ open ▕ pgup/pgdn scroll body▕ e edit  ▕ c comment       
- + label ▕ - unlabel▕ a owner▕ A unassign           ▕ x close ▕ r reopen        
- p parent▕ b block  ▕ l link ▕ N child              ▕ L layout▕ esc back        
- ? help  ▕ q quit                                                               
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit                
+ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign    ▕ x close               
+ r reopen ▕ p parent▕ b block  ▕ l link ▕ N child       ▕ L layout              
+ esc back ▕ ? help  ▕ q quit                                                    

--- a/internal/tui/testdata/golden/detail-document-markdown.txt
+++ b/internal/tui/testdata/golden/detail-document-markdown.txt
@@ -1,5 +1,5 @@
  Project: —                                                           kata カタ 
-                                                                                
+
   #55  markdown body                                                      [open]
   owner: none   parent: none                                                    
                                                                                 
@@ -34,7 +34,7 @@
                                                                                 
                                                                                 
                                                                                 
- ↑↓ move ▕ ↹ section▕ ↵ open ▕ pgup/pgdn scroll body▕ e edit  ▕ c comment       
- + label ▕ - unlabel▕ a owner▕ A unassign           ▕ x close ▕ r reopen        
- p parent▕ b block  ▕ l link ▕ N child              ▕ L layout▕ esc back        
- ? help  ▕ q quit                                                               
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit                
+ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign    ▕ x close               
+ r reopen ▕ p parent▕ b block  ▕ l link ▕ N child       ▕ L layout              
+ esc back ▕ ? help  ▕ q quit                                                    

--- a/internal/tui/testdata/golden/detail-document-narrow.txt
+++ b/internal/tui/testdata/golden/detail-document-narrow.txt
@@ -1,5 +1,5 @@
  Project: —                                                   kata カタ 
-                                                                        
+
   #42  fix login bug on Safari                                    [open]
   authored by wesm                                                      
   owner: alice   parent: #12 workspace polish                           
@@ -34,7 +34,7 @@
                                                                         
                                                                         
                                                                         
- ↑↓ move  ▕ ↹ section▕ ↵ open   ▕ pgup/pgdn scroll body▕ e edit         
- c comment▕ + label  ▕ - unlabel▕ a owner              ▕ A unassign     
- x close  ▕ r reopen ▕ p parent ▕ b block              ▕ l link         
- N child  ▕ L layout ▕ esc back ▕ ? help               ▕ q quit         
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit        
+ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign    ▕ x close       
+ r reopen ▕ p parent▕ b block  ▕ l link ▕ N child       ▕ L layout      
+ esc back ▕ ? help  ▕ q quit                                            

--- a/internal/tui/testdata/golden/detail-document-wide-160x32.txt
+++ b/internal/tui/testdata/golden/detail-document-wide-160x32.txt
@@ -1,5 +1,5 @@
  Project: kata                                                                                                                                  kata カタ · dev 
-                                                                                                                                                                
+
   #1  fix the tui to be less shitty                                                         [open]                                                              
   authored by anonymous · created May 2 19:15 · updated 21h ago                                                                                                 
   owner: none   parent: none                                                                                                                                    
@@ -28,5 +28,5 @@
                                                                                                                                                                 
                                                                                                                                                                 
                                                                                                                                                                 
- ↑↓ move▕ ↹ section▕ ↵ open  ▕ pgup/pgdn scroll body▕ e edit▕ c comment▕ + label▕ - unlabel▕ a owner▕ A unassign▕ x close▕ r reopen▕ p parent▕ b block▕ l link  
- N child▕ L layout ▕ esc back▕ ? help               ▕ q quit                                                                                                    
+ ↑↓ scroll▕ j/k row▕ ↹ section▕ ↵ open  ▕ pgup/pgdn page▕ e edit▕ c comment▕ + label▕ - unlabel▕ a owner▕ A unassign▕ x close▕ r reopen▕ p parent▕ b block      
+ l link   ▕ N child▕ L layout ▕ esc back▕ ? help        ▕ q quit                                                                                                

--- a/internal/tui/testdata/golden/detail-events-tab.txt
+++ b/internal/tui/testdata/golden/detail-events-tab.txt
@@ -1,5 +1,5 @@
  Project: —                                                                                                   kata カタ 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            
@@ -26,5 +26,5 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
- ↑↓ move▕ ↹ section▕ ↵ open  ▕ pgup/pgdn scroll body▕ e edit▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign       
- x close▕ r reopen ▕ p parent▕ b block              ▕ l link▕ N child  ▕ L layout▕ esc back ▕ ? help ▕ q quit           
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit ▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign  
+ x close  ▕ r reopen▕ p parent ▕ b block▕ l link        ▕ N child▕ L layout ▕ esc back▕ ? help   ▕ q quit               

--- a/internal/tui/testdata/golden/detail-links-tab.txt
+++ b/internal/tui/testdata/golden/detail-links-tab.txt
@@ -1,5 +1,5 @@
  Project: —                                                                                                   kata カタ 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            
@@ -26,5 +26,5 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
- ↑↓ move▕ ↹ section▕ ↵ open  ▕ pgup/pgdn scroll body▕ e edit▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign       
- x close▕ r reopen ▕ p parent▕ b block              ▕ l link▕ N child  ▕ L layout▕ esc back ▕ ? help ▕ q quit           
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit ▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign  
+ x close  ▕ r reopen▕ p parent ▕ b block▕ l link        ▕ N child▕ L layout ▕ esc back▕ ? help   ▕ q quit               

--- a/internal/tui/testdata/golden/detail-long-comments-list.txt
+++ b/internal/tui/testdata/golden/detail-long-comments-list.txt
@@ -1,5 +1,5 @@
  Project: —                                                                                                   kata カタ 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            
@@ -9,22 +9,22 @@
   Click the login button twice.                                                                                         
                                                                                                                         
   Activity   [ Comments (30) ]   Events (2)   Links (1)                                                                 
-    actor-14  Apr 30 10:13                                                                                              
-    comment body 14                                                                                                     
+    actor-1   Apr 30 10:00                                                                                              
+    comment body 1                                                                                                      
                                                                                                                         
-  > actor-15  Apr 30 10:14                                                                                              
-    comment body 15                                                                                                     
+    actor-2   Apr 30 10:01                                                                                              
+    comment body 2                                                                                                      
                                                                                                                         
+    actor-3   Apr 30 10:02                                                                                              
+    comment body 3                                                                                                      
                                                                                                                         
+    actor-4   Apr 30 10:03                                                                                              
+    comment body 4                                                                                                      
                                                                                                                         
+    actor-5   Apr 30 10:04                                                                                              
+    comment body 5                                                                                                      
                                                                                                                         
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                                        
-                                                                                                 [14-15 of 30 comments] 
- ↑↓ move▕ ↹ section▕ ↵ open  ▕ pgup/pgdn scroll body▕ e edit▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign       
- x close▕ r reopen ▕ p parent▕ b block              ▕ l link▕ N child  ▕ L layout▕ esc back ▕ ? help ▕ q quit           
+    actor-6   Apr 30 10:05                                                                                              
+                                                                                                     [lines 1-25 of 99] 
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit ▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign  
+ x close  ▕ r reopen▕ p parent ▕ b block▕ l link        ▕ N child▕ L layout ▕ esc back▕ ? help   ▕ q quit               

--- a/internal/tui/testdata/golden/detail-with-children.txt
+++ b/internal/tui/testdata/golden/detail-with-children.txt
@@ -1,5 +1,5 @@
  Project: —                                                                                                   kata カタ 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: #12 workspace polish parent                                                                     
@@ -17,6 +17,8 @@
   > alice  Apr 30 10:00                                                                                                 
     I can repro on macOS.                                                                                               
                                                                                                                         
+    bob    Apr 30 11:00                                                                                                 
+    Looks like a race in oauth.                                                                                         
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -26,7 +28,5 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
-                                                                                                                        
-                                                                                                    [1-1 of 2 comments] 
- ↑↓ move▕ ↹ section▕ ↵ open  ▕ pgup/pgdn scroll body▕ e edit▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign       
- x close▕ r reopen ▕ p parent▕ b block              ▕ l link▕ N child  ▕ L layout▕ esc back ▕ ? help ▕ q quit           
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit ▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign  
+ x close  ▕ r reopen▕ p parent ▕ b block▕ l link        ▕ N child▕ L layout ▕ esc back▕ ? help   ▕ q quit               

--- a/internal/tui/testdata/golden/detail-with-label-prompt.txt
+++ b/internal/tui/testdata/golden/detail-with-label-prompt.txt
@@ -1,5 +1,5 @@
  Project: —                                                                                                   kata カタ 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            

--- a/internal/tui/testdata/golden/detail-with-labels.txt
+++ b/internal/tui/testdata/golden/detail-with-labels.txt
@@ -1,5 +1,5 @@
  Project: —                                                                                                   kata カタ 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: alice   parent: none                                                                                           
@@ -13,6 +13,8 @@
   > alice  Apr 30 10:00                                                                                                 
     I can repro on macOS.                                                                                               
                                                                                                                         
+    bob    Apr 30 11:00                                                                                                 
+    Looks like a race in oauth.                                                                                         
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -24,7 +26,5 @@
                                                                                                                         
                                                                                                                         
                                                                                                                         
-                                                                                                                        
-                                                                                                    [1-1 of 2 comments] 
- ↑↓ move▕ ↹ section▕ ↵ open  ▕ pgup/pgdn scroll body▕ e edit▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign       
- x close▕ r reopen ▕ p parent▕ b block              ▕ l link▕ N child  ▕ L layout▕ esc back ▕ ? help ▕ q quit           
+ ↑↓ scroll▕ j/k row ▕ ↹ section▕ ↵ open ▕ pgup/pgdn page▕ e edit ▕ c comment▕ + label ▕ - unlabel▕ a owner▕ A unassign  
+ x close  ▕ r reopen▕ p parent ▕ b block▕ l link        ▕ N child▕ L layout ▕ esc back▕ ? help   ▕ q quit               

--- a/internal/tui/testdata/golden/help-narrow.txt
+++ b/internal/tui/testdata/golden/help-narrow.txt
@@ -39,7 +39,8 @@ A              clear owner
 
 Children
 N      new child
-↑↓     move child cursor
+j/k    move child cursor
+↑↓     scroll detail viewport
 enter  open child
 
 Forms

--- a/internal/tui/testdata/golden/help-narrow.txt
+++ b/internal/tui/testdata/golden/help-narrow.txt
@@ -7,8 +7,10 @@ P         projects
 L         toggle layout
 
 Graph
-k/up    up
-j/down  down
+k       up
+j       down
+up      scroll up
+down    scroll down
 pgup    page up
 pgdown  page down
 g       first

--- a/internal/tui/testdata/golden/help-wide.txt
+++ b/internal/tui/testdata/golden/help-wide.txt
@@ -17,9 +17,9 @@ g       first                 A              clear owner
 G       last                                                                                         
 enter   open detail           Children                                                               
 space   expand/collapse       N      new child                                                       
-n       new issue (form)      ↑↓     move child cursor                                               
-o       toggle graph order    enter  open child                                                      
-x       close                                                                                        
+n       new issue (form)      j/k    move child cursor                                               
+o       toggle graph order    ↑↓     scroll detail viewport                                          
+x       close                 enter  open child                                                      
 r       reopen                                                                                       
 
 press ? to return

--- a/internal/tui/testdata/golden/help-wide.txt
+++ b/internal/tui/testdata/golden/help-wide.txt
@@ -7,17 +7,19 @@ P         projects            enter          jump to referenced issue    tab/shi
 L         toggle layout       esc/backspace  back                        ctrl+e         open editor  
                               e              edit body                   ctrl+u         clear prompt 
 Graph                         c              new comment                                             
-k/up    up                    p              set parent                  Filters                     
-j/down  down                  b              add blocker                 /       search              
-pgup    page up               l              add link                    s       cycle status filter 
-pgdown  page down             +              add label                   f       filter (form)       
-g       first                 -              remove label                c       clear filters       
-G       last                  a              assign owner                ctrl+r  reset filter form   
-enter   open detail           A              clear owner                                             
-space   expand/collapse                                                                              
-n       new issue (form)      Children                                                               
-o       toggle graph order    N      new child                                                       
-x       close                 ↑↓     move child cursor                                               
-r       reopen                enter  open child                                                      
+k       up                    p              set parent                  Filters                     
+j       down                  b              add blocker                 /       search              
+up      scroll up             l              add link                    s       cycle status filter 
+down    scroll down           +              add label                   f       filter (form)       
+pgup    page up               -              remove label                c       clear filters       
+pgdown  page down             a              assign owner                ctrl+r  reset filter form   
+g       first                 A              clear owner                                             
+G       last                                                                                         
+enter   open detail           Children                                                               
+space   expand/collapse       N      new child                                                       
+n       new issue (form)      ↑↓     move child cursor                                               
+o       toggle graph order    enter  open child                                                      
+x       close                                                                                        
+r       reopen                                                                                       
 
 press ? to return

--- a/internal/tui/testdata/golden/label-prompt-empty.txt
+++ b/internal/tui/testdata/golden/label-prompt-empty.txt
@@ -1,5 +1,5 @@
  Project: kata                                                                                          kata カタ · dev 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            

--- a/internal/tui/testdata/golden/label-prompt-error.txt
+++ b/internal/tui/testdata/golden/label-prompt-error.txt
@@ -1,5 +1,5 @@
  Project: kata                                                                                          kata カタ · dev 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            

--- a/internal/tui/testdata/golden/label-prompt-loading.txt
+++ b/internal/tui/testdata/golden/label-prompt-loading.txt
@@ -1,5 +1,5 @@
  Project: kata                                                                                          kata カタ · dev 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            

--- a/internal/tui/testdata/golden/label-prompt-menu-open.txt
+++ b/internal/tui/testdata/golden/label-prompt-menu-open.txt
@@ -1,5 +1,5 @@
  Project: kata                                                                                          kata カタ · dev 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            

--- a/internal/tui/testdata/golden/label-prompt-scroll.txt
+++ b/internal/tui/testdata/golden/label-prompt-scroll.txt
@@ -1,5 +1,5 @@
  Project: kata                                                                                          kata カタ · dev 
-                                                                                                                        
+
   #42  fix login bug on Safari                                                              [open]                      
   authored by wesm                                                                                                      
   owner: none   parent: none                                                                                            

--- a/internal/tui/testdata/golden/list-detail-split-focus-detail.txt
+++ b/internal/tui/testdata/golden/list-detail-split-focus-detail.txt
@@ -3,7 +3,8 @@
 │        #     status    title                   kids    updated   ││  #42  fix login bug on Safari                                                      [open]│
 │        #1    open      fix login bug on Safari         3h ago    ││  authored by wesm                                                                        │
 │▶       #2    closed    rebuild search index            1h ago    ││  owner: none   parent: none                                                              │
-│        #3    [deleted] purge stale tokens              2h ago    ││  Body                                                                                    │
+│        #3    [deleted] purge stale tokens              2h ago    ││                                                                                          │
+│                                                                  ││  Body                                                                                    │
 │                                                                  ││  Reproduces in Safari 17 only.                                                           │
 │                                                                  ││  Click the login button twice.                                                           │
 │                                                                  ││                                                                                          │
@@ -33,8 +34,7 @@
 │                                                                  ││                                                                                          │
 │                                                                  ││                                                                                          │
 │                                                                  ││                                                                                          │
-│                                                                  ││                                                                                          │
 └──────────────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────┘
                                                                                                                                                                 
- ↑↓ move▕ ↹ section▕ ↵ open  ▕ pgup/pgdn scroll body▕ e edit▕ c comment▕ + label▕ - unlabel▕ a owner▕ A unassign▕ x close▕ r reopen▕ p parent▕ b block▕ l link  
- N child▕ L layout ▕ esc back▕ ? help               ▕ q quit                                                                                                    
+ ↑↓ scroll▕ j/k row▕ ↹ section▕ ↵ open  ▕ pgup/pgdn page▕ e edit▕ c comment▕ + label▕ - unlabel▕ a owner▕ A unassign▕ x close▕ r reopen▕ p parent▕ b block      
+ l link   ▕ N child▕ L layout ▕ esc back▕ ? help        ▕ q quit                                                                                                

--- a/internal/tui/testdata/golden/list-detail-split-resize-collapse.txt
+++ b/internal/tui/testdata/golden/list-detail-split-resize-collapse.txt
@@ -3,7 +3,8 @@
 │        #     status    title                   kids    updated   ││  #42  fix login bug on Safari                                  [open]│
 │        #1    open      fix login bug on Safari         3h ago    ││  authored by wesm                                                    │
 │▶       #2    closed    rebuild search index            1h ago    ││  owner: none   parent: none                                          │
-│        #3    [deleted] purge stale tokens              2h ago    ││  Body                                                                │
+│        #3    [deleted] purge stale tokens              2h ago    ││                                                                      │
+│                                                                  ││  Body                                                                │
 │                                                                  ││  Reproduces in Safari 17 only.                                       │
 │                                                                  ││  Click the login button twice.                                       │
 │                                                                  ││                                                                      │
@@ -13,7 +14,6 @@
 │                                                                  ││                                                                      │
 │                                                                  ││    bob    Apr 30 11:00                                               │
 │                                                                  ││    Looks like a race in oauth.                                       │
-│                                                                  ││                                                                      │
 │                                                                  ││                                                                      │
 │                                                                  ││                                                                      │
 │                                                                  ││                                                                      │

--- a/internal/tui/testdata/golden/list-detail-split-wide.txt
+++ b/internal/tui/testdata/golden/list-detail-split-wide.txt
@@ -3,7 +3,8 @@
 │        #     status    title                   kids    updated   ││  #42  fix login bug on Safari                                                      [open]│
 │        #1    open      fix login bug on Safari         3h ago    ││  authored by wesm                                                                        │
 │▶       #2    closed    rebuild search index            1h ago    ││  owner: none   parent: none                                                              │
-│        #3    [deleted] purge stale tokens              2h ago    ││  Body                                                                                    │
+│        #3    [deleted] purge stale tokens              2h ago    ││                                                                                          │
+│                                                                  ││  Body                                                                                    │
 │                                                                  ││  Reproduces in Safari 17 only.                                                           │
 │                                                                  ││  Click the login button twice.                                                           │
 │                                                                  ││                                                                                          │
@@ -13,7 +14,6 @@
 │                                                                  ││                                                                                          │
 │                                                                  ││    bob    Apr 30 11:00                                                                   │
 │                                                                  ││    Looks like a race in oauth.                                                           │
-│                                                                  ││                                                                                          │
 │                                                                  ││                                                                                          │
 │                                                                  ││                                                                                          │
 │                                                                  ││                                                                                          │


### PR DESCRIPTION
## Summary

- ↑/↓ now scroll the entire detail view as one document instead of being trapped on the activity-tab cursor. Fixes the long-standing "arrows feel dead on short terminals" complaint — every issue carries a synthetic `issue.created` event, so the legacy section-cursor routing reached the body-scroll path basically never.
- Renders header / body / children / activity into one flat slice and applies a single viewport offset. `View` and `ViewSplit` share `detailDocumentLines`, so stacked and split-pane modes can't drift.
- Bindings: ↑/↓ scroll one line, PgUp/PgDn page by viewport-minus-overlap (replacing the old fixed-8-line jump), j/k still drive the section cursor for Enter-jumps, Tab cycles section + auto-scrolls so the cursor is visible.
- Info line shows `[lines X-Y of Z]` for document position; per-tab cursor range indicator is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)