### PR TITLE
daemon: retry action mutations on sqlite locks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace github.com/muesli/termenv => ./internal/third_party/termenv
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
 github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=

--- a/internal/daemon/handlers_actions.go
+++ b/internal/daemon/handlers_actions.go
@@ -6,6 +6,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 
 	"github.com/wesm/kata/internal/api"
+	"github.com/wesm/kata/internal/db"
 )
 
 // registerActionsHandlers installs POST /actions/close and /actions/reopen.
@@ -25,7 +26,14 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
-		updated, evt, changed, err := cfg.DB.CloseIssue(ctx, issue.ID, in.Body.Reason, in.Body.Actor)
+		var updated db.Issue
+		var evt *db.Event
+		var changed bool
+		err = db.RetryLockContention(ctx, func() error {
+			var err error
+			updated, evt, changed, err = cfg.DB.CloseIssue(ctx, issue.ID, in.Body.Reason, in.Body.Actor)
+			return err
+		})
 		if err != nil {
 			return nil, api.NewError(500, "internal", err.Error(), "", nil)
 		}
@@ -52,7 +60,14 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
-		updated, evt, changed, err := cfg.DB.ReopenIssue(ctx, issue.ID, in.Body.Actor)
+		var updated db.Issue
+		var evt *db.Event
+		var changed bool
+		err = db.RetryLockContention(ctx, func() error {
+			var err error
+			updated, evt, changed, err = cfg.DB.ReopenIssue(ctx, issue.ID, in.Body.Actor)
+			return err
+		})
 		if err != nil {
 			return nil, api.NewError(500, "internal", err.Error(), "", nil)
 		}

--- a/internal/db/lock_retry.go
+++ b/internal/db/lock_retry.go
@@ -1,0 +1,103 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	backoff "github.com/cenkalti/backoff/v5"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+const (
+	defaultInitialLockBackoff = time.Millisecond
+	defaultMaxLockBackoff     = time.Second
+	defaultMaxLockRetryTime   = 30 * time.Second
+	sqlitePrimaryCodeMask     = 0xff
+)
+
+type sqliteCodeError interface {
+	Code() int
+}
+
+type lockRetryConfig struct {
+	maxElapsed time.Duration
+	newBackOff func() backoff.BackOff
+}
+
+// IsLockContention reports whether err is a SQLite busy/locked condition that
+// may clear if the whole mutation is retried after a short delay.
+func IsLockContention(err error) bool {
+	var coded sqliteCodeError
+	if !errors.As(err, &coded) {
+		return false
+	}
+	switch coded.Code() & sqlitePrimaryCodeMask {
+	case sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED:
+		return true
+	default:
+		return false
+	}
+}
+
+// RetryLockContention retries operation when SQLite reports lock contention.
+// The operation must be safe to re-run as a whole; callers should not wrap only
+// a single statement inside an already-open transaction.
+func RetryLockContention(ctx context.Context, operation func() error) error {
+	return retryLockContention(ctx, lockRetryConfig{
+		maxElapsed: defaultMaxLockRetryTime,
+		newBackOff: newLockBackOff,
+	}, operation)
+}
+
+func retryLockContention(ctx context.Context, cfg lockRetryConfig, operation func() error) error {
+	cfg = normalizedLockRetryConfig(cfg)
+	_, err := backoff.Retry(ctx, func() (struct{}, error) {
+		err := operation()
+		if err == nil {
+			return struct{}{}, nil
+		}
+		if !IsLockContention(err) {
+			return struct{}{}, backoff.Permanent(err)
+		}
+		return struct{}{}, err
+	}, backoff.WithBackOff(cfg.newBackOff()), backoff.WithMaxElapsedTime(cfg.maxElapsed))
+	return err
+}
+
+func normalizedLockRetryConfig(cfg lockRetryConfig) lockRetryConfig {
+	if cfg.maxElapsed <= 0 {
+		cfg.maxElapsed = defaultMaxLockRetryTime
+	}
+	if cfg.newBackOff == nil {
+		cfg.newBackOff = newLockBackOff
+	}
+	return cfg
+}
+
+type lockBackOff struct {
+	inner backoff.BackOff
+	max   time.Duration
+}
+
+func newLockBackOff() backoff.BackOff {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = defaultInitialLockBackoff
+	bo.MaxInterval = defaultMaxLockBackoff
+	bo.Multiplier = 2
+	bo.RandomizationFactor = 0.5
+	bo.Reset()
+	return &lockBackOff{inner: bo, max: defaultMaxLockBackoff}
+}
+
+func (b *lockBackOff) NextBackOff() time.Duration {
+	d := b.inner.NextBackOff()
+	if d > b.max {
+		return b.max
+	}
+	return d
+}
+
+func (b *lockBackOff) Reset() {
+	b.inner.Reset()
+}

--- a/internal/db/lock_retry_test.go
+++ b/internal/db/lock_retry_test.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	backoff "github.com/cenkalti/backoff/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+type codedSQLiteErr int
+
+func (e codedSQLiteErr) Error() string { return "sqlite error" }
+func (e codedSQLiteErr) Code() int     { return int(e) }
+
+func TestIsLockContentionRecognizesSQLiteBusyAndLocked(t *testing.T) {
+	assert.True(t, IsLockContention(codedSQLiteErr(sqlite3.SQLITE_BUSY)))
+	assert.True(t, IsLockContention(codedSQLiteErr(sqlite3.SQLITE_LOCKED)))
+	assert.True(t, IsLockContention(fmt.Errorf("wrapped: %w",
+		codedSQLiteErr(sqlite3.SQLITE_LOCKED|(1<<8)))))
+	assert.False(t, IsLockContention(codedSQLiteErr(sqlite3.SQLITE_CONSTRAINT)))
+	assert.False(t, IsLockContention(errors.New("database is locked")))
+}
+
+func TestRetryLockContentionRetriesLockContentionUntilSuccess(t *testing.T) {
+	attempts := 0
+
+	err := retryLockContention(context.Background(), lockRetryConfig{
+		maxElapsed: time.Second,
+		newBackOff: func() backoff.BackOff {
+			return &backoff.ZeroBackOff{}
+		},
+	}, func() error {
+		attempts++
+		if attempts < 4 {
+			return fmt.Errorf("reopen: %w", codedSQLiteErr(sqlite3.SQLITE_LOCKED))
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, attempts)
+}
+
+func TestRetryLockContentionDoesNotRetryOtherErrors(t *testing.T) {
+	wantErr := errors.New("constraint failed")
+	attempts := 0
+
+	err := retryLockContention(context.Background(), lockRetryConfig{
+		maxElapsed: time.Second,
+		newBackOff: func() backoff.BackOff {
+			return &backoff.ZeroBackOff{}
+		},
+	}, func() error {
+		attempts++
+		return wantErr
+	})
+
+	assert.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, attempts)
+}
+
+func TestNewLockBackOffUsesSmallJitteredPolicy(t *testing.T) {
+	got, ok := newLockBackOff().(*lockBackOff)
+	require.True(t, ok)
+	inner, ok := got.inner.(*backoff.ExponentialBackOff)
+	require.True(t, ok)
+
+	assert.Equal(t, time.Millisecond, inner.InitialInterval)
+	assert.Equal(t, time.Second, inner.MaxInterval)
+	assert.Equal(t, 2.0, inner.Multiplier)
+	assert.Equal(t, 0.5, inner.RandomizationFactor)
+	assert.Equal(t, time.Second, got.max)
+}
+
+func TestLockBackOffCapsRandomizedDelayAtOneSecond(t *testing.T) {
+	bo := &lockBackOff{
+		inner: &sequenceBackOff{next: []time.Duration{
+			2 * time.Second,
+		}},
+		max: time.Second,
+	}
+
+	assert.Equal(t, time.Second, bo.NextBackOff())
+}
+
+type sequenceBackOff struct {
+	next []time.Duration
+}
+
+func (b *sequenceBackOff) NextBackOff() time.Duration {
+	if len(b.next) == 0 {
+		return backoff.Stop
+	}
+	d := b.next[0]
+	b.next = b.next[1:]
+	return d
+}
+
+func (b *sequenceBackOff) Reset() {}


### PR DESCRIPTION
## Summary
- add a DB retry helper for SQLite BUSY/LOCKED errors using cenkalti/backoff/v5
- configure jittered exponential backoff starting at 1ms, capped at 1s per wait, with a 30s elapsed retry budget
- wrap daemon close/reopen action mutations so rapid CLI calls retry transient lock contention instead of surfacing immediate internal errors

## Validation
- git diff --cached --check
- GOFLAGS=-buildvcs=false go test ./...