### PR TITLE
tui: make child rows prominent under expanded parents

### DIFF
--- a/internal/tui/list_render.go
+++ b/internal/tui/list_render.go
@@ -434,6 +434,7 @@ func (lm listModel) renderBody(width, height int, chrome viewChrome) string {
 	cols := listColumnWidths(width, narrow)
 	rows := buildRows(visible, vCursor, cols.title, narrow, chrome)
 	headers := listTableHeaders(narrow)
+	bands := groupBanding(visible)
 	t := table.New().
 		Border(lipgloss.HiddenBorder()).
 		BorderTop(false).
@@ -458,7 +459,7 @@ func (lm listModel) renderBody(width, height int, chrome viewChrome) string {
 			if row >= 0 && row < len(visible) && visible[row].context {
 				return s.Inherit(subtleStyle)
 			}
-			if row >= 0 && row%2 == 1 {
+			if row >= 0 && row < len(bands) && bands[row] {
 				return s.Inherit(altRowStyle)
 			}
 			return s.Inherit(normalRowStyle)
@@ -889,9 +890,82 @@ func contextMarker(context bool) string {
 	return ""
 }
 
+// groupBanding returns one boolean per visible row — true means the
+// row renders with altRowStyle, false with normalRowStyle. A "group"
+// is a root plus its expanded descendants; every row in the group
+// shares one banding class so an expanded parent and its children read
+// as one banded block. Without this, the every-other-row stripe slices
+// straight through a single-child group and the parent/child link
+// dissolves visually.
+//
+// The first root in the window is normal (matches the prior renderer's
+// row-0-is-normal invariant); the next root flips to alt; and so on.
+// Children inherit whatever class their root sits on.
+func groupBanding(visible []queueRow) []bool {
+	bands := make([]bool, len(visible))
+	rootAlt := true // first depth==0 row flips this to false (= normalRowStyle)
+	for i, qr := range visible {
+		if qr.depth == 0 {
+			rootAlt = !rootAlt
+		}
+		bands[i] = rootAlt
+	}
+	return bands
+}
+
+// treeCell renders the tree-guide column for one queueRow. Roots get a
+// disclosure glyph (or blank if they have no children); child rows get
+// box-drawing guides (`├─`/`└─`) that connect them to the parent group
+// above. Depth ≥ 2 falls back to an ellipsis prefix because the 4-cell
+// tree column can only fit one level of explicit guides; deeper trees
+// are rare in practice (kata's umbrella → leaves model).
+//
+// Under colorNone the cell returns plain ASCII without going through
+// subtleStyle — explicit short-circuit so the no-color contract isn't
+// dependent on subtleStyle being a no-op (it is today, but a future
+// theme tweak shouldn't be able to leak escapes into NO_COLOR snapshots).
+// In color modes the guides render in subtleStyle so they read as
+// scaffolding rather than competing with the row's content; the
+// disclosure glyph itself is left unstyled so it keeps full weight as
+// the only interactive bit.
 func treeCell(row queueRow) string {
-	indent := strings.Repeat(" ", min(row.depth, 3))
-	return truncate(indent+disclosureGlyph(row.hasChildren, row.expanded), 3)
+	if row.depth == 0 {
+		return disclosureGlyph(row.hasChildren, row.expanded)
+	}
+	guide := childGuide(row.lastChild)
+	if row.depth >= 2 {
+		guide = depthPrefix() + guide
+	}
+	if activeColorMode == colorNone {
+		return guide
+	}
+	return subtleStyle.Render(guide)
+}
+
+// depthPrefix returns the 1-cell prefix used to mark depth ≥ 2 child
+// rows. Plain `.` under colorNone (keeps NO_COLOR strictly ASCII) and
+// `…` (U+2026) in color modes (consistent with truncate's ellipsis).
+func depthPrefix() string {
+	if activeColorMode == colorNone {
+		return "."
+	}
+	return "…"
+}
+
+// childGuide returns the 2-cell box-drawing prefix for a child row. The
+// last child of a parent gets `└─`; earlier siblings get `├─`. ASCII
+// fallbacks (`\\-`, `+-`) keep colorNone snapshots stable.
+func childGuide(lastChild bool) string {
+	if activeColorMode == colorNone {
+		if lastChild {
+			return `\-`
+		}
+		return "+-"
+	}
+	if lastChild {
+		return "└─"
+	}
+	return "├─"
 }
 
 func disclosureGlyph(hasChildren, expanded bool) string {

--- a/internal/tui/list_render_test.go
+++ b/internal/tui/list_render_test.go
@@ -230,6 +230,86 @@ func TestDisclosureGlyph(t *testing.T) {
 	}
 }
 
+// TestTreeCell_ChildGuides verifies that child rows render box-drawing
+// connectors regardless of whether the child has children of its own —
+// the previous renderer left leaf children with only an indent, which
+// made an expanded parent's children visually indistinguishable from
+// unrelated sibling rows below.
+func TestTreeCell_ChildGuides(t *testing.T) {
+	applyColorMode(colorAuto, io.Discard)
+	parent := queueRow{depth: 0, hasChildren: true, expanded: true}
+	got := stripANSI(treeCell(parent))
+	if got != "▾" {
+		t.Fatalf("expanded parent treeCell = %q, want ▾", got)
+	}
+	intermediate := queueRow{depth: 1, lastChild: false}
+	got = stripANSI(treeCell(intermediate))
+	if got != "├─" {
+		t.Fatalf("intermediate child treeCell = %q, want ├─", got)
+	}
+	last := queueRow{depth: 1, lastChild: true}
+	got = stripANSI(treeCell(last))
+	if got != "└─" {
+		t.Fatalf("last child treeCell = %q, want └─", got)
+	}
+
+	deep := queueRow{depth: 2, lastChild: true}
+	got = stripANSI(treeCell(deep))
+	if got != "…└─" {
+		t.Fatalf("depth-2 last child treeCell = %q, want …└─", got)
+	}
+
+	useNoColor(t)
+	got = treeCell(queueRow{depth: 1, lastChild: false})
+	if got != "+-" {
+		t.Fatalf("no-color intermediate child = %q, want +-", got)
+	}
+	got = treeCell(queueRow{depth: 1, lastChild: true})
+	if got != `\-` {
+		t.Fatalf(`no-color last child = %q, want \-`, got)
+	}
+	got = treeCell(queueRow{depth: 2, lastChild: true})
+	if got != `.\-` {
+		t.Fatalf(`no-color depth-2 last child = %q, want .\-`, got)
+	}
+	// no-color must not contain U+2026 (the strict-ASCII contract for
+	// NO_COLOR snapshots; was the looser convention before).
+	if strings.ContainsRune(got, '…') {
+		t.Fatalf("no-color depth-2 contains U+2026: %q", got)
+	}
+}
+
+// TestGroupBanding_ParentChildShareBand verifies that an expanded
+// parent and its expanded children render with the same banding class
+// — without this, the every-other-row stripe slices through the group
+// and the child's connection to the parent dissolves visually.
+func TestGroupBanding_ParentChildShareBand(t *testing.T) {
+	visible := []queueRow{
+		{depth: 0}, // root A
+		{depth: 1}, // child of A
+		{depth: 1}, // child of A
+		{depth: 0}, // root B
+		{depth: 0}, // root C
+		{depth: 1}, // child of C
+	}
+	bands := groupBanding(visible)
+	if len(bands) != len(visible) {
+		t.Fatalf("len = %d, want %d", len(bands), len(visible))
+	}
+	if bands[0] != bands[1] || bands[1] != bands[2] {
+		t.Fatalf("group A rows differ: %v", bands[:3])
+	}
+	if bands[0] == bands[3] {
+		t.Fatalf("root A and root B should flip bands; got %v / %v", bands[0], bands[3])
+	}
+	if bands[3] == bands[4] {
+		t.Fatalf("consecutive roots B/C should flip bands; got %v / %v", bands[3], bands[4])
+	}
+	if bands[4] != bands[5] {
+		t.Fatalf("root C and its child should share band; got %v / %v", bands[4], bands[5])
+	}
+}
+
 func TestRenderListBody_UsesQueueRowsWithDisclosureAndChildCounts(t *testing.T) {
 	useNoColor(t)
 	parentNum := int64(1)

--- a/internal/tui/testdata/golden/list-tree-auto-expanded-match.txt
+++ b/internal/tui/testdata/golden/list-tree-auto-expanded-match.txt
@@ -2,8 +2,8 @@
  open: 4 · closed: 1 · all: 5                                                                      search:"jump target" 
         #     prio status    title                                                       kids    owner         updated  
 ▶ ~ -   #10   —    open      professional workspace polish                               1/2     wesm          30m ago  
-  ~  -  #11   —    open      detail hint bars incomplete                                 1/1     claude        45m ago  
-        #13   —    open      child detail jump target                                                          3h ago   
+  ~ \-  #11   —    open      detail hint bars incomplete                                 1/1     claude        45m ago  
+    .\- #13   —    open      child detail jump target                                                          3h ago   
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/internal/tui/testdata/golden/list-tree-context-row.txt
+++ b/internal/tui/testdata/golden/list-tree-context-row.txt
@@ -2,7 +2,7 @@
  open: 4 · closed: 1 · all: 5                                                                        search:"hint bars" 
         #     prio status    title                                                       kids    owner         updated  
 ▶ ~ -   #10   —    open      professional workspace polish                               1/2     wesm          30m ago  
-     +  #11   —    open      detail hint bars incomplete                                 1/1     claude        45m ago  
+    \-  #11   —    open      detail hint bars incomplete                                 1/1     claude        45m ago  
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/internal/tui/testdata/golden/list-tree-expanded.txt
+++ b/internal/tui/testdata/golden/list-tree-expanded.txt
@@ -2,8 +2,8 @@
  open: 4 · closed: 1 · all: 5                                                                                           
         #     prio status    title                                                       kids    owner         updated  
 ▶   -   #10   —    open      professional workspace polish                               1/2     wesm          30m ago  
-     +  #11   —    open      detail hint bars incomplete                                 1/1     claude        45m ago  
-        #12   —    closed    new issue form parent field                                                       2h ago   
+    +-  #11   —    open      detail hint bars incomplete                                 1/1     claude        45m ago  
+    \-  #12   —    closed    new issue form parent field                                                       2h ago   
         #20   —    open      standalone queue cleanup                                                          4h ago   
                                                                                                                         
                                                                                                                         

--- a/internal/tui/testdata/golden/list-tree-no-color.txt
+++ b/internal/tui/testdata/golden/list-tree-no-color.txt
@@ -2,7 +2,7 @@
  open: 4 · closed: 1 · all: 5                                                                        search:"hint bars" 
         #     prio status    title                                                       kids    owner         updated  
 ▶ ~ -   #10   —    open      professional workspace polish                               1/2     wesm          30m ago  
-     +  #11   —    open      detail hint bars incomplete                                 1/1     claude        45m ago  
+    \-  #11   —    open      detail hint bars incomplete                                 1/1     claude        45m ago  
                                                                                                                         
                                                                                                                         
                                                                                                                         


### PR DESCRIPTION
## Summary

- Children of an expanded parent now render box-drawing connectors (`├─` / `└─`) in the tree column. Previously, leaf children rendered with a blank glyph and only a 1-cell indent, so a single child sandwiched between alternating-stripe rows was visually indistinguishable from unrelated siblings.
- Row banding flips per *root group* instead of per row, so a parent and its expanded children share one band — the every-other-row stripe no longer slices through the parent/child relationship.
- Depth ≥ 2 (rare in kata's umbrella → leaves model) gets a leading `…` (or `.` under colorNone) so the connector still fits the 4-cell tree column.

No data/model changes — `queueRow.depth` and `queueRow.lastChild` already carried the necessary signal. Only `internal/tui/list_render.go` and its tests/goldens were touched.

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `make lint` (golangci-lint) clean
- [x] Direct unit tests for child-guide glyphs (depth 1 + depth ≥ 2, color + colorNone)
- [x] Direct unit test for group-aware banding (parent + children share band; consecutive roots flip)
- [x] 4 golden snapshots regenerated and visually reviewed
- [ ] Visual sanity-check of live TUI before merging out of draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)