### PR TITLE
Fix init with percent-encoded git remote URLs

### DIFF
--- a/internal/config/project_identity.go
+++ b/internal/config/project_identity.go
@@ -257,29 +257,39 @@ var scpLikeRE = regexp.MustCompile(`^([^@\s]+)@([^:\s]+):(.+)$`)
 
 // NormalizeRemoteURL strips credentials, normalizes SSH↔HTTPS, drops trailing
 // .git, and returns "host/path" form (e.g. "github.com/wesm/kata").
+// Percent-encoded characters are decoded and spaces replaced with hyphens so
+// the result satisfies the identity charset (Azure DevOps remotes commonly
+// contain %20 in org/project names).
 func NormalizeRemoteURL(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", fmt.Errorf("empty remote url")
 	}
+	var result string
 	if m := scpLikeRE.FindStringSubmatch(raw); m != nil {
 		host := m[2]
 		path := strings.TrimSuffix(m[3], ".git")
-		return host + "/" + path, nil
+		result = host + "/" + path
+	} else {
+		u, err := url.Parse(raw)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			return "", fmt.Errorf("parse remote url %q: not a recognized form", raw)
+		}
+		host := u.Host
+		if at := strings.LastIndex(host, "@"); at >= 0 {
+			host = host[at+1:]
+		}
+		path := strings.TrimSuffix(strings.TrimPrefix(u.Path, "/"), ".git")
+		if path == "" {
+			return host, nil
+		}
+		result = host + "/" + path
 	}
-	u, err := url.Parse(raw)
-	if err != nil || u.Scheme == "" || u.Host == "" {
-		return "", fmt.Errorf("parse remote url %q: not a recognized form", raw)
+	if decoded, err := url.PathUnescape(result); err == nil {
+		result = decoded
 	}
-	host := u.Host
-	if at := strings.LastIndex(host, "@"); at >= 0 {
-		host = host[at+1:]
-	}
-	path := strings.TrimSuffix(strings.TrimPrefix(u.Path, "/"), ".git")
-	if path == "" {
-		return host, nil
-	}
-	return host + "/" + path, nil
+	result = strings.ReplaceAll(result, " ", "-")
+	return result, nil
 }
 
 var identityCharsetRE = regexp.MustCompile(`^[A-Za-z0-9._:/\-]+$`)

--- a/internal/config/project_identity_test.go
+++ b/internal/config/project_identity_test.go
@@ -73,6 +73,9 @@ func TestNormalizeRemoteURL(t *testing.T) {
 		{"https://user:pass@github.com/wesm/kata.git", "github.com/wesm/kata"},
 		{"git@github.com:wesm/kata.git", "github.com/wesm/kata"},
 		{"ssh://git@gitlab.com/team/repo.git", "gitlab.com/team/repo"},
+		// Percent-encoded paths (Azure DevOps, spaces in org/project names)
+		{"rtstnz@vs-ssh.visualstudio.com:v3/rtstnz/AI%20Experiments/AI%20Experiments", "vs-ssh.visualstudio.com/v3/rtstnz/AI-Experiments/AI-Experiments"},
+		{"https://dev.azure.com/org/My%20Project/_git/My%20Repo.git", "dev.azure.com/org/My-Project/_git/My-Repo"},
 	}
 	for _, tc := range cases {
 		got, err := config.NormalizeRemoteURL(tc.in)


### PR DESCRIPTION
## Summary

- `kata init --replace --project <name>` fails with "identity contains disallowed characters" when the git remote URL contains percent-encoded characters (e.g. `%20` for spaces in Azure DevOps org/project names)
- `NormalizeRemoteURL` now decodes percent-encoded characters and replaces spaces with hyphens, producing valid identities
- Affects both SCP-style (`user@host:path`) and HTTPS remote URLs

## Reproduction

```sh
# In a git repo with an Azure DevOps remote like:
# rtstnz@vs-ssh.visualstudio.com:v3/rtstnz/AI%20Experiments/AI%20Experiments

kata init --project my-project --name my-project --replace
# Error: alias.identity: identity contains disallowed characters:
#   "vs-ssh.visualstudio.com/v3/rtstnz/AI%20Experiments/AI%20Experiments"
```

## Test plan

- [x] Added test cases for SCP-style and HTTPS URLs with `%20` encoding
- [x] Verified existing `TestNormalizeRemoteURL` cases still pass
- [x] Full `go test ./...` passes (two pre-existing flaky timing tests in `internal/hooks` occasionally fail on both main and this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)