### PR TITLE
cli: add --project selector flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ needed. In a git workspace, the default project identity is derived from the
 remote URL. For a non-git workspace or an explicit shared identity:
 
 ```sh
-kata init --project github.com/example/product --name product
+kata init --identity github.com/example/product --name product
 ```
 
 Create and inspect issues:

--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -149,6 +149,12 @@ func validateCreateLabels(labels []string) error {
 // resolveProjectID resolves the project ID for a given workspace start
 // path by calling POST /api/v1/projects/resolve on the daemon.
 //
+// When --project is set, workspace resolution is bypassed entirely: the
+// selector (numeric id, name, identity, or alias) is matched against
+// the daemon's projects list. This is what lets a user run
+// `kata create --project <name> "title"` without cd'ing — and lets a
+// remote client target a project whose path doesn't exist locally.
+//
 // When the workspace has a readable .kata.toml at startPath or any
 // ancestor directory, the project identity is sent and the daemon
 // skips its filesystem walk. This is what lets a client on host B
@@ -165,6 +171,13 @@ func resolveProjectID(ctx context.Context, baseURL, startPath string) (int64, er
 	client, err := httpClientFor(ctx, baseURL)
 	if err != nil {
 		return 0, err
+	}
+	if selector := strings.TrimSpace(flags.Project); selector != "" {
+		project, err := resolveProjectSelector(ctx, client, baseURL, selector)
+		if err != nil {
+			return 0, err
+		}
+		return project.ID, nil
 	}
 	body := map[string]any{}
 	cfg, _, err := config.FindProjectConfig(startPath)

--- a/cmd/kata/create_test.go
+++ b/cmd/kata/create_test.go
@@ -134,3 +134,95 @@ func TestResolveProjectID_FallsBackOnMissingConfig(t *testing.T) {
 	_, hasIdentity := got["project_identity"]
 	assert.False(t, hasIdentity, "no .kata.toml means no project_identity in the request")
 }
+
+// TestResolveProjectID_WithProjectFlag_ResolvesByName proves that when
+// flags.Project is set, resolveProjectID skips the workspace-based
+// /resolve flow and goes through the projects list selector. This is
+// what enables `kata create --project <name>` to target a project
+// other than the one bound to cwd.
+func TestResolveProjectID_WithProjectFlag_ResolvesByName(t *testing.T) {
+	resetFlags(t)
+	flags.Project = "kata"
+
+	var resolveCalled atomic.Int32
+	srv := httptest.NewServer(projectsListHandler(t, &resolveCalled))
+	t.Cleanup(srv.Close)
+
+	id, err := resolveProjectID(context.Background(), srv.URL, t.TempDir())
+	require.NoError(t, err)
+	assert.EqualValues(t, 7, id)
+	assert.Zero(t, resolveCalled.Load(), "selector path must not call /resolve")
+}
+
+// TestResolveProjectID_WithProjectFlag_AcceptsID confirms numeric
+// selectors work alongside name selectors.
+func TestResolveProjectID_WithProjectFlag_AcceptsID(t *testing.T) {
+	resetFlags(t)
+	flags.Project = "7"
+
+	srv := httptest.NewServer(projectsListHandler(t, nil))
+	t.Cleanup(srv.Close)
+
+	id, err := resolveProjectID(context.Background(), srv.URL, t.TempDir())
+	require.NoError(t, err)
+	assert.EqualValues(t, 7, id)
+}
+
+// TestResolveProjectID_WithProjectFlag_NotFound surfaces a useful
+// error when the selector matches nothing.
+func TestResolveProjectID_WithProjectFlag_NotFound(t *testing.T) {
+	resetFlags(t)
+	flags.Project = "nonexistent"
+
+	srv := httptest.NewServer(projectsListHandler(t, nil))
+	t.Cleanup(srv.Close)
+
+	_, err := resolveProjectID(context.Background(), srv.URL, t.TempDir())
+	require.Error(t, err)
+}
+
+// projectsListHandler stubs the daemon endpoints loadProjectRefs touches:
+// GET /api/v1/projects (the list) and GET /api/v1/projects/{id} (the
+// per-project alias detail loadProjectRefs walks for selector matching).
+// resolveSeen, when non-nil, is incremented if /api/v1/projects/resolve is
+// hit — selector callers must never go through that endpoint.
+func projectsListHandler(t *testing.T, resolveSeen *atomic.Int32) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"projects":[{"id":7,"identity":"github.com/wesm/kata","name":"kata","next_issue_number":1}]}`))
+		case "/api/v1/projects/7":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"project":{"id":7,"identity":"github.com/wesm/kata","name":"kata","next_issue_number":1},"aliases":[]}`))
+		case "/api/v1/projects/resolve":
+			if resolveSeen != nil {
+				resolveSeen.Add(1)
+			}
+			http.Error(w, "selector path must not call /resolve", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+// TestCreate_WithProjectFlag_TargetsNamedProject is the integration
+// proof that --project lets a user create issues in a project other
+// than the one bound to cwd. Without --project, create falls back to
+// workspace resolution and the issue would land in the default
+// project.
+func TestCreate_WithProjectFlag_TargetsNamedProject(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	otherDir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/other.git")
+	defaultPID := resolvePIDViaHTTP(t, env.URL, dir)
+	otherPID := resolvePIDViaHTTP(t, env.URL, otherDir)
+
+	out := runCLI(t, env, dir, "--quiet", "create", "--project", "other", "issue in other")
+	assert.Equal(t, "1", out)
+
+	defaultIssues := listIssueNumbersViaHTTP(t, env.URL, defaultPID)
+	otherIssues := listIssueNumbersViaHTTP(t, env.URL, otherPID)
+	assert.Empty(t, defaultIssues, "issue must not land in the workspace project")
+	assert.Equal(t, []int64{1}, otherIssues, "issue must land in the project named by --project")
+}

--- a/cmd/kata/digest.go
+++ b/cmd/kata/digest.go
@@ -41,6 +41,22 @@ cross-project digest.`,
 					ExitCode: ExitUsage,
 				}
 			}
+			if strings.TrimSpace(flags.Project) != "" {
+				if projectIDArg != 0 {
+					return &cliError{
+						Message:  "--project and --project-id are mutually exclusive",
+						Kind:     kindUsage,
+						ExitCode: ExitUsage,
+					}
+				}
+				if allProjects {
+					return &cliError{
+						Message:  "--project and --all-projects are mutually exclusive",
+						Kind:     kindUsage,
+						ExitCode: ExitUsage,
+					}
+				}
+			}
 			if strings.TrimSpace(sinceStr) == "" {
 				return &cliError{
 					Message:  "--since is required (e.g. --since 24h)",

--- a/cmd/kata/digest_test.go
+++ b/cmd/kata/digest_test.go
@@ -29,6 +29,24 @@ func TestDigest_RejectsBadSince(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid time spec")
 }
 
+// TestDigest_ProjectAndProjectIDConflict pins that --project (selector) and
+// --project-id (numeric, legacy) cannot both be set.
+func TestDigest_ProjectAndProjectIDConflict(t *testing.T) {
+	_, err := runCmdOutput(t, nil, "digest", "--since", "24h", "--project", "kata", "--project-id", "1")
+	ce := requireCLIError(t, err, ExitUsage)
+	assert.Contains(t, ce.Message, "--project")
+	assert.Contains(t, ce.Message, "--project-id")
+}
+
+// TestDigest_ProjectAndAllProjectsConflict mirrors the existing
+// --all-projects/--project-id check for the new selector flag.
+func TestDigest_ProjectAndAllProjectsConflict(t *testing.T) {
+	_, err := runCmdOutput(t, nil, "digest", "--since", "24h", "--project", "kata", "--all-projects")
+	ce := requireCLIError(t, err, ExitUsage)
+	assert.Contains(t, ce.Message, "--project")
+	assert.Contains(t, ce.Message, "--all-projects")
+}
+
 func TestDigest_ParseSinceUntil(t *testing.T) {
 	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 

--- a/cmd/kata/events.go
+++ b/cmd/kata/events.go
@@ -38,6 +38,14 @@ until SIGINT/SIGTERM. Reconnects with exponential backoff on disconnect.`,
 			if allProjects && projectIDArg != 0 {
 				return &cliError{Message: "--all-projects and --project-id are mutually exclusive", Kind: kindUsage, ExitCode: ExitUsage}
 			}
+			if strings.TrimSpace(flags.Project) != "" {
+				if projectIDArg != 0 {
+					return &cliError{Message: "--project and --project-id are mutually exclusive", Kind: kindUsage, ExitCode: ExitUsage}
+				}
+				if allProjects {
+					return &cliError{Message: "--project and --all-projects are mutually exclusive", Kind: kindUsage, ExitCode: ExitUsage}
+				}
+			}
 			if tail {
 				// One-shot-only flags must reject under --tail so users
 				// don't think `--tail --limit 1` will stream just one

--- a/cmd/kata/events_test.go
+++ b/cmd/kata/events_test.go
@@ -114,6 +114,25 @@ func TestEvents_NegativeAfterRejected(t *testing.T) {
 	assert.Contains(t, ce.Message, "non-negative")
 }
 
+// TestEvents_ProjectAndProjectIDConflict pins that --project (selector) and
+// --project-id (numeric, legacy) cannot both be set. Without this check the
+// flags would silently arbitrate; better to fail fast so users notice.
+func TestEvents_ProjectAndProjectIDConflict(t *testing.T) {
+	_, err := runCmdOutput(t, nil, "events", "--project", "kata", "--project-id", "1")
+	ce := requireCLIError(t, err, ExitUsage)
+	assert.Contains(t, ce.Message, "--project")
+	assert.Contains(t, ce.Message, "--project-id")
+}
+
+// TestEvents_ProjectAndAllProjectsConflict mirrors the existing
+// --all-projects/--project-id check for the new selector flag.
+func TestEvents_ProjectAndAllProjectsConflict(t *testing.T) {
+	_, err := runCmdOutput(t, nil, "events", "--project", "kata", "--all-projects")
+	ce := requireCLIError(t, err, ExitUsage)
+	assert.Contains(t, ce.Message, "--project")
+	assert.Contains(t, ce.Message, "--all-projects")
+}
+
 func TestEvents_NegativeLastEventIDRejected(t *testing.T) {
 	_, err := runCmdOutput(t, nil, "events", "--all-projects", "--tail", "--last-event-id=-1")
 	ce := requireCLIError(t, err, ExitUsage)

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -18,7 +18,7 @@ import (
 
 // initOptions holds the flags specific to `kata init`.
 type initOptions struct {
-	Project  string
+	Identity string
 	Name     string
 	Replace  bool
 	Reassign bool
@@ -26,7 +26,7 @@ type initOptions struct {
 
 // callInitOpts is the parameter bag passed to callInit.
 type callInitOpts struct {
-	Project  string
+	Identity string
 	Name     string
 	Replace  bool
 	Reassign bool
@@ -112,13 +112,24 @@ func newInitCmd() *cobra.Command {
 
 Writes a committed .kata.toml that binds the workspace to a project
 identity. The daemon derives the identity from a git remote when one
-is present; pass --project to override, or --name to set the
+is present; pass --identity to override, or --name to set the
 human-readable name.
+
+The global --project selector flag (used by other commands to target
+an existing project) is rejected here: init creates the binding
+rather than selecting one, so the two cannot be combined.
 
 Also adds .kata.local.toml to .gitignore so a developer's per-machine
 overrides (e.g., a remote daemon URL via [server] url = "...") never
 get committed.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(flags.Project) != "" {
+				return &cliError{
+					Message:  "kata init does not accept the --project selector; use --identity to set the project identity",
+					Kind:     kindUsage,
+					ExitCode: ExitUsage,
+				}
+			}
 			baseURL, err := ensureDaemon(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("daemon: %w", err)
@@ -136,7 +147,7 @@ get committed.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.Project, "project", "", "project identity (default: derived from git remote)")
+	cmd.Flags().StringVar(&opts.Identity, "identity", "", "project identity to bind (default: derived from git remote)")
 	cmd.Flags().StringVar(&opts.Name, "name", "", "human name for the project (default: last path segment)")
 	cmd.Flags().BoolVar(&opts.Replace, "replace", false, "overwrite .kata.toml binding when it conflicts")
 	cmd.Flags().BoolVar(&opts.Reassign, "reassign", false, "move an existing alias to this project")
@@ -218,7 +229,7 @@ func localDerive(startPath string, opts callInitOpts) (localInit, error) {
 			return localInit{}, err
 		}
 	}
-	choice, err := config.PickInitIdentity(disc, tomlCfg, opts.Project, opts.Name, opts.Replace)
+	choice, err := config.PickInitIdentity(disc, tomlCfg, opts.Identity, opts.Name, opts.Replace)
 	if err != nil {
 		return localInit{}, err
 	}
@@ -316,8 +327,8 @@ func runIdentityInit(ctx context.Context, baseURL string, in localInit, opts cal
 // places .gitignore beside it.
 func runStartPathInit(ctx context.Context, baseURL, startPath string, opts callInitOpts) (string, error) {
 	reqBody := map[string]any{"start_path": startPath}
-	if opts.Project != "" {
-		reqBody["project_identity"] = opts.Project
+	if opts.Identity != "" {
+		reqBody["project_identity"] = opts.Identity
 	}
 	if opts.Name != "" {
 		reqBody["name"] = opts.Name

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -33,6 +33,43 @@ func TestInit_FreshGitRepoBindsViaRemote(t *testing.T) {
 	assert.FileExists(t, filepath.Join(dir, ".kata.toml"))
 }
 
+// TestInit_RejectsProjectSelectorFlag pins that `kata --project foo init`
+// (and `kata init --project foo`, via persistent-flag inheritance) is a
+// usage error, not a silent no-op. The global --project flag is a
+// selector for existing projects; init creates the binding and uses
+// --identity for the identity-to-set, so the two must not be mixed.
+func TestInit_RejectsProjectSelectorFlag(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	_, err := runCmdOutput(t, nil, "--workspace", dir, "--project", "kata", "init")
+	ce := requireCLIError(t, err, ExitUsage)
+	assert.Contains(t, ce.Message, "--project")
+	assert.Contains(t, ce.Message, "--identity")
+}
+
+// TestInit_AcceptsIdentityFlag confirms the renamed flag still threads
+// the identity through to the daemon request. Locks the wire shape:
+// the daemon receives project_identity from --identity, just as it
+// previously received it from the old --project flag.
+func TestInit_AcceptsIdentityFlag(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	daemonStub := newFakeDaemon(t)
+
+	resetFlags(t)
+	_, err := callInit(context.Background(), daemonStub.srv.URL, dir,
+		callInitOpts{Identity: "github.com/example/foo", Name: "foo"})
+	require.NoError(t, err)
+
+	req := daemonStub.request()
+	require.NotNil(t, req)
+	assert.Equal(t, "github.com/example/foo", req["project_identity"])
+}
+
 func TestInit_AddsLocalToGitignoreWhenAbsent(t *testing.T) {
 	env := testenv.New(t)
 	dir := t.TempDir()
@@ -231,7 +268,7 @@ func TestInit_RemoteClient_FromSubdir(t *testing.T) {
 }
 
 // TestInit_RemoteClient_ConflictDetectedLocally asserts that a
-// client-side .kata.toml conflict with --project (without --replace)
+// client-side .kata.toml conflict with --identity (without --replace)
 // fails before any daemon round-trip, so a remote daemon never sees a
 // stale identity. The error must also carry the structured
 // "project_binding_conflict" code so --json consumers can branch on
@@ -254,7 +291,7 @@ name     = "kata"
 	t.Cleanup(func() { flags.JSON = false })
 
 	_, err := callInit(context.Background(), daemonStub.srv.URL, dir,
-		callInitOpts{Project: "github.com/wesm/other"})
+		callInitOpts{Identity: "github.com/wesm/other"})
 	require.Error(t, err)
 	var ce *cliError
 	require.ErrorAs(t, err, &ce)

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -21,6 +21,7 @@ type globalFlags struct {
 	Quiet     bool
 	As        string
 	Workspace string
+	Project   string
 }
 
 var flags globalFlags
@@ -45,6 +46,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&flags.Quiet, "quiet", "q", false, "suppress non-essential output")
 	cmd.PersistentFlags().StringVar(&flags.As, "as", "", "override actor (default: $KATA_AUTHOR > $USER > git > anonymous)")
 	cmd.PersistentFlags().StringVar(&flags.Workspace, "workspace", "", "path used for project resolution (default: cwd)")
+	cmd.PersistentFlags().StringVar(&flags.Project, "project", "", "target project by id, name, or identity (overrides workspace-based resolution)")
 	// Catch the cobra/pflag pitfall where a positional that looks like
 	// a negative integer (kata show -1, kata delete -1) is parsed as
 	// a flag and produces "unknown shorthand flag: '1' in -1" — useless

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -47,6 +47,18 @@ Use kata as the shared issue ledger for this workspace.
 10. Do not run delete or purge unless the user explicitly asks for that exact
     destructive action and issue number.
 
+11. To target a project other than the one bound to the current workspace,
+    pass --project <selector> on any command. The selector accepts a
+    project id, name, identity, or alias, and bypasses workspace-based
+    resolution. The project must already exist; --project never creates one
+    (kata init is the only path that creates a project row).
+
+       kata create --project <name> "fix invoice rounding"
+       kata list --project 7 --json
+
+    --project is rejected by kata init (which uses --identity for the
+    binding it creates).
+
 For long-running agents, poll events:
 
    kata events --after 0 --limit 100 --json

--- a/cmd/kata/testhelpers_test.go
+++ b/cmd/kata/testhelpers_test.go
@@ -514,3 +514,21 @@ func fetchIssueViaHTTP(t *testing.T, env *testenv.Env, pid int64, issueNum int64
 	t.Helper()
 	return getJSON[IssueResponse](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues/"+itoa(issueNum))
 }
+
+// listIssueNumbersViaHTTP fetches the open+closed issue numbers in a project.
+// Used by --project tests to assert that a created or mutated issue landed in
+// the right project rather than the workspace's default.
+func listIssueNumbersViaHTTP(t *testing.T, baseURL string, pid int64) []int64 {
+	t.Helper()
+	type response struct {
+		Issues []struct {
+			Number int64 `json:"number"`
+		} `json:"issues"`
+	}
+	b := getJSON[response](t, baseURL+"/api/v1/projects/"+itoa(pid)+"/issues?status=&limit=100")
+	out := make([]int64, 0, len(b.Issues))
+	for _, i := range b.Issues {
+		out = append(out, i.Number)
+	}
+	return out
+}

--- a/docs/superpowers/specs/2026-04-29-kata-design.md
+++ b/docs/superpowers/specs/2026-04-29-kata-design.md
@@ -108,7 +108,7 @@ Given a start path:
 2. **Else, alias lookup.** If `G` exists, compute `alias_identity` and look up `project_aliases`. On match, resolve to that project; update `last_seen_at`/`root_path`.
 3. **Else, fail.** Return `project_not_initialized` with hint `run "kata init" in this workspace`.
 
-Outside any git repo and without `.kata.toml`, every command except `kata init --project <X>` fails. kata never silently namespaces issues to "a random cwd."
+Outside any git repo and without `.kata.toml`, every command except `kata init --identity <X>` fails. kata never silently namespaces issues to "a random cwd."
 
 `.kata.toml` parsing and `alias_identity` derivation are performed daemon-side from the `start_path` the CLI sends — there is one source of truth for resolution semantics. The CLI never constructs project identities; it sends paths.
 
@@ -714,7 +714,7 @@ The CLI text path treats `reset_required: true` the same way the TUI does on `sy
 - `kata events --after-id N --json` is the primary agent polling primitive; returns `next_after_id` for the next call. Timestamps (`--since`) are the human path. If the polling response sets `reset_required: true`, the agent must drop any cached state and resume polling from `next_after_id` (= the new baseline). See §4.11.
 - `kata show` and relationship-command issue references accept `#N`, bare number `N`, full issue UID, or a unique UID prefix of at least 8 characters. Numbers remain project-scoped display labels; UIDs are the stable cross-cutover identity. Other lifecycle commands are still number-first until their parsers are moved onto the shared resolver.
 - `kata export` / `kata import` are the supported schema-evolution and backup/restore path. JSONL exports preserve the source schema version exactly; imports into a newer binary apply deterministic fill rules, including UID generation for legacy records, inside a fresh database before validation and swap.
-- **Project binding is workspace-driven, not flag-driven.** Agents do not pass `--project <identity>` on writes. They run from a workspace whose `.kata.toml` declares the binding. If `.kata.toml` is missing, write commands fail with `project_not_initialized` and a hint to run `kata init`. **Do not** auto-create a project — that is exactly how agents end up writing into the wrong namespace.
+- **Project binding is workspace-driven by default.** Agents normally run from a workspace whose `.kata.toml` declares the binding; that is the path that gets validated by alias and resolves predictably. If `.kata.toml` is missing, write commands fail with `project_not_initialized` and a hint to run `kata init`. **Do not** auto-create a project from a flag — that is exactly how agents end up writing into the wrong namespace. The global `--project <selector>` flag exists for cross-project work against an *existing* project; it never creates one. `kata init` remains the only path that creates a `projects` row.
 
 ### 5.2 Identity (actor)
 
@@ -764,7 +764,7 @@ JSON mode:
 $ kata create "fix login bug"
 error: kata project is not bound to this workspace
 hint: run `kata init` (auto-derives identity from git remote) or
-      `kata init --project <identity>` to attach to an existing project
+      `kata init --identity <identity>` to attach to an existing project
 ```
 
 ### 5.5 Confirmation for destructive ops
@@ -812,15 +812,15 @@ Agent skill activation isn't fully deterministic. Two backup commands:
 
 ## 6. CLI Surface
 
-Universal flags on every command: `--json`, `--quiet`/`-q`, `--as <name>`, `--workspace <path>` (overrides cwd as the workspace root used for resolution; the value is a path, not a project identity). `--all-projects` for cross-project reads where applicable.
+Universal flags on every command: `--json`, `--quiet`/`-q`, `--as <name>`, `--workspace <path>` (overrides cwd as the workspace root used for resolution; the value is a path, not a project identity). `--all-projects` for cross-project reads where applicable. `--project <selector>` selects an existing project by id, name, identity, or alias and bypasses workspace-based resolution; rejected by `kata init` (which uses `--identity` to set the binding). The selector is a convenience for cross-project work, not a substitute for `.kata.toml` — it never creates a project.
 
-Note: there is no public `--project-id <N>` flag for agent-facing commands. Agents resolve through `.kata.toml`; the TUI and internal client may carry `project_id` end-to-end after a single `/projects/resolve` call but the value is never exposed as a CLI argument.
+Note: `--project-id <N>` exists on `kata events` and `kata digest` for legacy numeric scoping; new code should prefer `--project <selector>`. Agents resolving through `.kata.toml` need neither flag; the TUI and internal client may carry `project_id` end-to-end after a single `/projects/resolve` call but that internal value is distinct from the user-facing flags.
 
 ### 6.1 Command map
 
 | Group | Command | Notes |
 |---|---|---|
-| Init | `kata init [--project <identity>] [--name <name>] [--replace] [--reassign]` | Fresh-clone flow: with no flags, reads existing `.kata.toml` if present; else derives identity from git remote. Creates/upserts the project, attaches the workspace alias, writes `.kata.toml` if missing. The **only** path that creates project rows. Idempotent. |
+| Init | `kata init [--identity <identity>] [--name <name>] [--replace] [--reassign]` | Fresh-clone flow: with no flags, reads existing `.kata.toml` if present; else derives identity from git remote. Creates/upserts the project, attaches the workspace alias, writes `.kata.toml` if missing. The **only** path that creates project rows. Idempotent. The global `--project` selector is rejected here. |
 | Lifecycle | `kata create <title> [--body* / --idempotency-key K / --force-new / --label L / --owner O / --parent N / --blocks N]` | `--label` repeated only (no CSV). Initial labels/links/owner go into the `issue.created` event payload. Fails with `project_not_initialized` if no `.kata.toml` and no matching alias. |
 | | `kata show <issue-ref> [--include-events] [--include-deleted]` | Default: issue + comments + links + labels. `<issue-ref>` is `#N`, `N`, full UID, or unique UID prefix. |
 | | `kata list [--status / --label / --owner / --author / --workspace / --all-projects / --updated-since / --limit / --search]` | Default: this project, `status=open`, `updated_at DESC`, limit 50. |


### PR DESCRIPTION
## Summary

- Adds a global `--project <selector>` flag that targets a project by id, name, identity, or alias, bypassing workspace-based resolution.
- `events` and `digest` reject `--project` alongside `--project-id` / `--all-projects` so the chosen scope stays unambiguous.

## Why

Today the only way to scope CLI commands to a project is to `cd` into a workspace bound to it, or pass `--workspace <path>`. In remote-client mode that path may not exist on the client. `digest` and `events` already had `--project-id` (numeric only); other read/write commands had no escape hatch at all.

`--project` flows through the existing `resolveProjectSelector` helper used by `kata projects rename/merge/...`, so id/name/identity/alias matching works the same everywhere.

## Behavior

- `kata create --project <name> "title"` — works without cd, without `--workspace`.
- `kata list --project 7`, `kata show --project <name> 12`, `kata edit --project <name> 12 ...` — same shape.
- `kata events --project <name> --project-id 1` — fails fast with usage error.
- Workspace-bound flow is unchanged when `--project` is empty.