### PR TITLE
Add --comment flag to mutation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,17 @@ kata edit <issue-ref> [--title TEXT] [--body TEXT] [--owner NAME]
                   [--parent <ref>] [--blocks <ref>] [--blocked-by <ref>] [--related <ref>]
                   [--remove-parent <ref>] [--remove-blocks <ref>]
                   [--remove-blocked-by <ref>] [--remove-related <ref>]
+                  [--comment TEXT]
 kata comment <ref> [--body TEXT | --body-file PATH | --body-stdin]
-kata close <ref> --done --message <text> [--commit|--pr|--test|--reviewed|--evidence]
-kata close <ref> [--wontfix|--duplicate-of <ref>|--superseded-by <ref>|--audit-no-change]
-kata reopen <ref>
+kata close <ref> --done --message <text> [--commit|--pr|--test|--reviewed|--evidence] [--comment TEXT]
+kata close <ref> [--wontfix|--duplicate-of <ref>|--superseded-by <ref>|--audit-no-change] [--comment TEXT]
+kata reopen <ref> [--comment TEXT]
 ```
+
+`--comment TEXT` is available on `close`, `reopen`, `edit`, `assign`,
+`unassign`, and `label add`/`rm`. The mutation lands first; the comment is
+appended in a follow-up call. If the comment call fails, the error names
+the issue so you can retry with `kata comment <ref> --body ...`.
 
 Refs accept a bare short_id (`abc4`), a qualified short_id (`kata#abc4`), or
 a full 26-char ULID. The relationship flags on `create`/`edit` are
@@ -244,11 +250,11 @@ closes can be undone individually with `kata reopen <ref>`.
 Labels, ownership, and relationships:
 
 ```sh
-kata label add <ref> <label>
-kata label rm <ref> <label>
+kata label add <ref> <label> [--comment TEXT]
+kata label rm <ref> <label> [--comment TEXT]
 kata labels
-kata assign <ref> <owner>
-kata unassign <ref>
+kata assign <ref> <owner> [--comment TEXT]
+kata unassign <ref> [--comment TEXT]
 ```
 
 Relationships ride on `kata create` and `kata edit` as repeatable flags,

--- a/cmd/kata/assign.go
+++ b/cmd/kata/assign.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newAssignCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "assign <issue-ref> <owner>",
 		Short: "set the owner of an issue",
 		Args:  cobra.ExactArgs(2),
@@ -19,10 +19,12 @@ func newAssignCmd() *cobra.Command {
 			return runAssign(cmd, args[0], args[1], false)
 		},
 	}
+	addCommentFlag(cmd)
+	return cmd
 }
 
 func newUnassignCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "unassign <issue-ref>",
 		Short: "clear the owner of an issue",
 		Args:  cobra.ExactArgs(1),
@@ -30,9 +32,15 @@ func newUnassignCmd() *cobra.Command {
 			return runAssign(cmd, args[0], "", true)
 		},
 	}
+	addCommentFlag(cmd)
+	return cmd
 }
 
 func runAssign(cmd *cobra.Command, raw, owner string, unassign bool) error {
+	comment, err := commentFromFlag(cmd)
+	if err != nil {
+		return err
+	}
 	ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, raw)
 	if err != nil {
 		return err
@@ -55,6 +63,9 @@ func runAssign(cmd *cobra.Command, raw, owner string, unassign bool) error {
 	}
 	if status >= 400 {
 		return apiErrFromBody(status, bs)
+	}
+	if err := postFollowupComment(ctx, client, baseURL, pid, issue.RefForAPI, actor, comment); err != nil {
+		return err
 	}
 	return printAssignMutation(cmd, bs, unassign)
 }

--- a/cmd/kata/assign_test.go
+++ b/cmd/kata/assign_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAssign_RoundTrip(t *testing.T) {
@@ -16,4 +17,25 @@ func TestAssign_RoundTrip(t *testing.T) {
 
 	uOut := runCLI(t, env, dir, "unassign", ref)
 	assert.True(t, strings.Contains(uOut, "unassigned"))
+}
+
+func TestAssign_WithComment_AppendsComment(t *testing.T) {
+	env, dir, pid, ref := setupWorkspaceWithIssue(t, "x")
+
+	runCLI(t, env, dir, "assign", ref, "alice", "--comment", "owns the auth area")
+
+	got := fetchIssueViaHTTPWithComments(t, env, pid, ref)
+	require.Len(t, got.Comments, 1)
+	assert.Equal(t, "owns the auth area", got.Comments[0].Body)
+}
+
+func TestUnassign_WithComment_AppendsComment(t *testing.T) {
+	env, dir, pid, ref := setupWorkspaceWithIssue(t, "x")
+	runCLI(t, env, dir, "assign", ref, "alice")
+
+	runCLI(t, env, dir, "unassign", ref, "--comment", "rolling off")
+
+	got := fetchIssueViaHTTPWithComments(t, env, pid, ref)
+	require.Len(t, got.Comments, 1)
+	assert.Equal(t, "rolling off", got.Comments[0].Body)
 }

--- a/cmd/kata/close.go
+++ b/cmd/kata/close.go
@@ -151,6 +151,7 @@ Instead, label and comment:
 	cmd.Flags().StringVar(&sugarPR, "pr", "", "sugar for --evidence pr:<url>")
 	cmd.Flags().StringVar(&sugarTest, "test", "", "sugar for --evidence test:<command>")
 	cmd.Flags().StringArrayVar(&sugarReviewed, "reviewed", nil, "sugar for --evidence reviewed-paths:<path>, repeatable")
+	addCommentFlag(cmd)
 	return cmd
 }
 
@@ -204,8 +205,13 @@ func parseEvidenceFlags(raw []string) ([]api.Evidence, error) {
 
 // runAction is shared by close and reopen. It resolves the issue reference,
 // resolves the project, merges extra fields into the request body, and calls
-// the daemon action endpoint.
+// the daemon action endpoint. If --comment was passed on the command, the
+// comment is appended in a separate POST after the action succeeds.
 func runAction(cmd *cobra.Command, raw, action string, extra map[string]any) error {
+	comment, err := commentFromFlag(cmd)
+	if err != nil {
+		return err
+	}
 	ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, raw)
 	if err != nil {
 		return err
@@ -227,6 +233,9 @@ func runAction(cmd *cobra.Command, raw, action string, extra map[string]any) err
 	}
 	if status >= 400 {
 		return apiErrFromBody(status, bs)
+	}
+	if err := postFollowupComment(ctx, client, baseURL, pid, issue.RefForAPI, actor, comment); err != nil {
+		return err
 	}
 	return printMutation(cmd, bs)
 }

--- a/cmd/kata/close_reopen_test.go
+++ b/cmd/kata/close_reopen_test.go
@@ -326,3 +326,45 @@ func TestReopen_SingleRefWorks(t *testing.T) {
 	show := runCLI(t, env, dir, "show", ref, "--json")
 	assert.Contains(t, show, `"status":"open"`)
 }
+
+func TestClose_WithComment_AppendsComment(t *testing.T) {
+	env, dir, pid, ref := setupWorkspaceWithIssue(t, "test issue")
+
+	runCLI(t, env, dir, "close", ref,
+		"--done",
+		"--message", "Fixed Safari callback double-submit and ran tests.",
+		"--commit", "abc1234",
+		"--comment", "fixed in abc1234")
+
+	got := fetchIssueViaHTTPWithComments(t, env, pid, ref)
+	require.Len(t, got.Comments, 1, "close --comment must append exactly one comment")
+	assert.Equal(t, "fixed in abc1234", got.Comments[0].Body)
+	assert.Equal(t, "closed", got.Issue.Status)
+}
+
+func TestReopen_WithComment_AppendsComment(t *testing.T) {
+	env, dir, pid, ref := setupWorkspaceWithIssue(t, "test issue")
+	runCLI(t, env, dir, "close", ref,
+		"--done",
+		"--message", "Fixed Safari callback double-submit and ran tests.",
+		"--commit", "abc1234")
+
+	runCLI(t, env, dir, "reopen", ref, "--comment", "regressed")
+
+	got := fetchIssueViaHTTPWithComments(t, env, pid, ref)
+	require.Len(t, got.Comments, 1)
+	assert.Equal(t, "regressed", got.Comments[0].Body)
+	assert.Equal(t, "open", got.Issue.Status)
+}
+
+func TestClose_EmptyComment_Rejected(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	ref := createIssueViaHTTP(t, env, dir, "x")
+
+	_, err := runCLICapture(t, env, dir, "close", ref,
+		"--done",
+		"--message", "Fixed Safari callback double-submit and ran tests.",
+		"--commit", "abc1234",
+		"--comment", "   ")
+	_ = requireCLIError(t, err, ExitValidation)
+}

--- a/cmd/kata/comment_flag.go
+++ b/cmd/kata/comment_flag.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// addCommentFlag registers --comment on a mutation command. Commands that
+// already have a --body / --comment body for their own payload (e.g. the
+// dedicated `comment` command) must not call this helper.
+func addCommentFlag(cmd *cobra.Command) {
+	var v string
+	cmd.Flags().StringVar(&v, "comment", "",
+		"append this comment to the issue after the mutation succeeds")
+}
+
+// commentFromFlag returns the trimmed --comment value, or empty string when
+// the flag was not set. An explicit whitespace-only --comment is rejected so
+// "kata close 1 --comment ' '" surfaces as a usage error instead of a silent
+// empty comment.
+func commentFromFlag(cmd *cobra.Command) (string, error) {
+	if !cmd.Flags().Changed("comment") {
+		return "", nil
+	}
+	raw, _ := cmd.Flags().GetString("comment")
+	if strings.TrimSpace(raw) == "" {
+		return "", &cliError{
+			Message:  "--comment must not be empty",
+			Kind:     kindValidation,
+			ExitCode: ExitValidation,
+		}
+	}
+	return raw, nil
+}
+
+// postFollowupComment posts a comment after a successful mutation. No-op when
+// body is empty. The mutation already landed on the daemon, so a failure here
+// is surfaced as a separate error pointing the user at the manual retry.
+func postFollowupComment(
+	ctx context.Context,
+	client *http.Client,
+	baseURL string,
+	projectID int64,
+	issueRef, actor, body string,
+) error {
+	if body == "" {
+		return nil
+	}
+	status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/projects/%d/issues/%s/comments", baseURL, projectID, url.PathEscape(issueRef)),
+		map[string]any{"actor": actor, "body": body})
+	if err != nil {
+		return fmt.Errorf("issue mutation succeeded but appending --comment failed: %w "+
+			"(retry with: kata comment %s --body ...)", err, issueRef)
+	}
+	if status >= 400 {
+		base := apiErrFromBody(status, bs)
+		return fmt.Errorf("issue mutation succeeded but appending --comment failed: %w "+
+			"(retry with: kata comment %s --body ...)", base, issueRef)
+	}
+	return nil
+}

--- a/cmd/kata/edit.go
+++ b/cmd/kata/edit.go
@@ -58,9 +58,14 @@ func newEditCmd() *cobra.Command {
 		"remove blocked-by←<ref> (idempotent; repeatable)")
 	cmd.Flags().Var(newRefSliceValue(&removeRelated), "remove-related",
 		"remove related↔<ref> (idempotent; repeatable)")
+	addCommentFlag(cmd)
 
 	// RunE is set after flag registration so we can reference cmd.Flags().Changed.
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		comment, err := commentFromFlag(cmd)
+		if err != nil {
+			return err
+		}
 		payload := map[string]any{}
 		if cmd.Flags().Changed("title") {
 			if strings.TrimSpace(title) == "" {
@@ -157,6 +162,10 @@ func newEditCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			actor, _ := resolveActor(flags.As, nil)
+			if err := postFollowupComment(ctx, client, baseURL, pid, issue.RefForAPI, actor, comment); err != nil {
+				return err
+			}
 			return printMutation(cmd, syntheticNoopFromShow(bs))
 		}
 
@@ -187,6 +196,9 @@ func newEditCmd() *cobra.Command {
 		}
 		if status >= 400 {
 			return apiErrFromBody(status, bs)
+		}
+		if err := postFollowupComment(ctx, client, baseURL, pid, issue.RefForAPI, actor, comment); err != nil {
+			return err
 		}
 		return printMutation(cmd, bs)
 	}

--- a/cmd/kata/edit_test.go
+++ b/cmd/kata/edit_test.go
@@ -291,3 +291,15 @@ func TestEdit_EmptyTitle_ValidatedClientSide(t *testing.T) {
 			"validation message should explain the failure for %q", blank)
 	}
 }
+
+func TestEdit_WithComment_AppendsComment(t *testing.T) {
+	env, dir, pid, ref := setupWorkspaceWithIssue(t, "subject")
+
+	runCLI(t, env, dir, "edit", ref, "--priority", "1", "--comment", "bumping for incident")
+
+	got := fetchIssueViaHTTPWithComments(t, env, pid, ref)
+	require.Len(t, got.Comments, 1)
+	assert.Equal(t, "bumping for incident", got.Comments[0].Body)
+	require.NotNil(t, got.Issue.Priority)
+	assert.Equal(t, int64(1), *got.Issue.Priority)
+}

--- a/cmd/kata/label.go
+++ b/cmd/kata/label.go
@@ -22,7 +22,7 @@ func newLabelCmd() *cobra.Command {
 }
 
 func labelAddCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "add <issue-ref> <label>",
 		Short: "attach a label to an issue",
 		Args:  cobra.ExactArgs(2),
@@ -30,6 +30,10 @@ func labelAddCmd() *cobra.Command {
 			label := args[1]
 			if strings.TrimSpace(label) == "" {
 				return &cliError{Message: "label must not be empty", Kind: kindValidation, ExitCode: ExitValidation}
+			}
+			comment, err := commentFromFlag(cmd)
+			if err != nil {
+				return err
 			}
 			ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, args[0])
 			if err != nil {
@@ -49,13 +53,18 @@ func labelAddCmd() *cobra.Command {
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
+			if err := postFollowupComment(ctx, client, baseURL, pid, issue.RefForAPI, actor, comment); err != nil {
+				return err
+			}
 			return printLabelMutation(cmd, bs)
 		},
 	}
+	addCommentFlag(cmd)
+	return cmd
 }
 
 func labelRmCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "rm <issue-ref> <label>",
 		Short: "detach a label from an issue",
 		Args:  cobra.ExactArgs(2),
@@ -67,6 +76,10 @@ func labelRmCmd() *cobra.Command {
 			// meaningful message — hammer-test finding #8.
 			if strings.TrimSpace(label) == "" {
 				return &cliError{Message: "label must not be empty", Kind: kindValidation, ExitCode: ExitValidation}
+			}
+			comment, err := commentFromFlag(cmd)
+			if err != nil {
+				return err
 			}
 			ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, args[0])
 			if err != nil {
@@ -86,9 +99,14 @@ func labelRmCmd() *cobra.Command {
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
+			if err := postFollowupComment(ctx, client, baseURL, pid, issue.RefForAPI, actor, comment); err != nil {
+				return err
+			}
 			return printLabelRemoved(cmd, bs, issue.RefForAPI, label)
 		},
 	}
+	addCommentFlag(cmd)
+	return cmd
 }
 
 func newLabelsCmd() *cobra.Command {

--- a/cmd/kata/label_test.go
+++ b/cmd/kata/label_test.go
@@ -51,6 +51,27 @@ func TestLabel_RejectsEmptyLabel(t *testing.T) {
 	}
 }
 
+func TestLabelAdd_WithComment_AppendsComment(t *testing.T) {
+	env, dir, pid, ref := setupWorkspaceWithIssue(t, "a")
+
+	runCLI(t, env, dir, "label", "add", ref, "flaky", "--comment", "intermittent in CI")
+
+	got := fetchIssueViaHTTPWithComments(t, env, pid, ref)
+	require.Len(t, got.Comments, 1)
+	assert.Equal(t, "intermittent in CI", got.Comments[0].Body)
+}
+
+func TestLabelRm_WithComment_AppendsComment(t *testing.T) {
+	env, dir, pid, ref := setupWorkspaceWithIssue(t, "a")
+	runCLI(t, env, dir, "label", "add", ref, "flaky")
+
+	runCLI(t, env, dir, "label", "rm", ref, "flaky", "--comment", "stable since 4.6")
+
+	got := fetchIssueViaHTTPWithComments(t, env, pid, ref)
+	require.Len(t, got.Comments, 1)
+	assert.Equal(t, "stable since 4.6", got.Comments[0].Body)
+}
+
 // TestCreate_RejectsWhitespaceLabel covers the create --label case from
 // hammer #8. Pflag's StringSliceVar drops a literal empty argument (""),
 // but a whitespace-only label like "   " makes it through and used to be

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -90,7 +90,13 @@ Use kata as the shared issue ledger for this workspace.
    fail loudly. Read parent before asserting a removal. The other
    --remove-* flags are idempotent (no-op when the link is already gone).
 
-7. Do not run delete or purge unless the user explicitly asks for that exact
+7. To leave context alongside a mutation, pass --comment TEXT on
+   close, reopen, edit, assign, unassign, or label add/rm. The
+   mutation lands first; the comment is appended in a follow-up call.
+   If the comment call fails, the error names the issue so you can
+   retry with kata comment <ref> --body ...
+
+8. Do not run delete or purge unless the user explicitly asks for that exact
    destructive action and issue ref.
 
 For long-running agents, poll events:

--- a/cmd/kata/reopen.go
+++ b/cmd/kata/reopen.go
@@ -5,7 +5,7 @@ import (
 )
 
 func newReopenCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "reopen <issue-ref>",
 		Short: "reopen a closed issue",
 		Args:  cobra.ExactArgs(1),
@@ -13,4 +13,6 @@ func newReopenCmd() *cobra.Command {
 			return runAction(cmd, args[0], "reopen", nil)
 		},
 	}
+	addCommentFlag(cmd)
+	return cmd
 }

--- a/cmd/kata/testhelpers_test.go
+++ b/cmd/kata/testhelpers_test.go
@@ -490,6 +490,7 @@ type IssueResponse struct {
 		Title    string  `json:"title"`
 		Owner    *string `json:"owner"`
 		Priority *int64  `json:"priority"`
+		Status   string  `json:"status"`
 	} `json:"issue"`
 	Labels []struct {
 		Label string `json:"label"`
@@ -499,6 +500,18 @@ type IssueResponse struct {
 		From linkPeerTest `json:"from"`
 		To   linkPeerTest `json:"to"`
 	} `json:"links"`
+	Comments []struct {
+		Author string `json:"author"`
+		Body   string `json:"body"`
+	} `json:"comments"`
+}
+
+// fetchIssueViaHTTPWithComments is fetchIssueViaHTTP — it already returns the
+// Comments field on IssueResponse — kept as a named alias so tests reading
+// comments document their intent and survive future shape changes.
+func fetchIssueViaHTTPWithComments(t *testing.T, env *testenv.Env, pid int64, ref string) IssueResponse {
+	t.Helper()
+	return fetchIssueViaHTTP(t, env, pid, ref)
 }
 
 // safeBuffer is a mutex-protected bytes.Buffer used by streaming/tail tests so


### PR DESCRIPTION
## Summary

- `kata close 41 --comment 'fixed in abc123'` now appends the comment in one call instead of requiring a separate `kata comment 41 --body ...`. Agents (and humans) consistently forget the follow-up, so closes and edits land without context.
- The same `--comment TEXT` flag works on `close`, `reopen`, `edit`, `assign`, `unassign`, and `label add`/`rm`.
- Implementation is purely client-side: the mutation lands on its existing endpoint, then the CLI POSTs to `/comments`. No daemon changes, no new wire format. On comment failure the error names the issue so the user can retry with `kata comment <N> --body ...`.

## Why

The example use case is the exact prompt I keep seeing:

```
kata close 41 --comment "Fixed in e510319 — role=combobox/listbox/option, ..."
```

Before this PR that flag silently fails (`unknown flag: --comment`). After: it works on every mutation command where leaving a same-call note is useful.

## Test plan

- [x] `go test ./cmd/kata/ ./e2e/ -count=1` — all green
- [x] TDD: `TestClose_WithComment_AppendsComment`, `TestReopen_WithComment_AppendsComment`, `TestClose_EmptyComment_Rejected`, `TestAssign_WithComment_AppendsComment`, `TestUnassign_WithComment_AppendsComment`, `TestLabelAdd_WithComment_AppendsComment`, `TestLabelRm_WithComment_AppendsComment`, `TestEdit_WithComment_AppendsComment` — each watched fail before implementation
- [x] README and `kata quickstart` updated to document the flag