### PR TITLE
Fix remote-client resolve regression (#35)

### DIFF
--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -271,26 +272,27 @@ func resolveProjectID(ctx context.Context, baseURL, startPath string) (int64, er
 // name. Used by ref-consuming commands that need the project name to format
 // qualified IDs ("<project>#<short_id>") for display or for the destructive
 // confirmation header.
+//
+// Wire shape is chosen client-side so the daemon never has to stat the
+// client's filesystem (issue #35). Priority order:
+//
+//  1. --project X → {name: X}. Explicit target — alias-first repair
+//     would risk redirecting to a different project.
+//  2. .kata.toml readable → {name, alias?}. Daemon does alias-first
+//     repair; on rename the client rewrites .kata.toml to the
+//     canonical name returned in the response.
+//  3. Git workspace, no .kata.toml → {alias}. Daemon does strict
+//     alias lookup; unknown alias is 404 (init owns create-by-
+//     convention from git remotes — resolve never creates).
+//  4. Neither → {start_path}. Legacy local-only fallback.
 func resolveProjectIDAndName(ctx context.Context, baseURL, startPath string) (int64, string, error) {
-	client, err := httpClientFor(ctx, baseURL)
+	body, repair, err := buildResolveRequest(startPath)
 	if err != nil {
 		return 0, "", err
 	}
-	body := map[string]any{}
-	if project := strings.TrimSpace(flags.Project); project != "" {
-		body["name"] = project
-	} else {
-		_, _, err := config.FindProjectConfig(startPath)
-		switch {
-		case err == nil, errors.Is(err, config.ErrProjectConfigMissing):
-			body["start_path"] = startPath
-		default:
-			return 0, "", &cliError{
-				Message:  "read .kata.toml: " + err.Error(),
-				Kind:     kindValidation,
-				ExitCode: ExitValidation,
-			}
-		}
+	client, err := httpClientFor(ctx, baseURL)
+	if err != nil {
+		return 0, "", err
 	}
 	status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
 		baseURL+"/api/v1/projects/resolve", body)
@@ -309,7 +311,112 @@ func resolveProjectIDAndName(ctx context.Context, baseURL, startPath string) (in
 	if err := json.Unmarshal(bs, &b); err != nil {
 		return 0, "", err
 	}
+	if repair != nil {
+		if err := repair(b.Project.Name); err != nil {
+			return 0, "", err
+		}
+	}
 	return b.Project.ID, b.Project.Name, nil
+}
+
+// buildResolveRequest selects the wire shape for a resolve and returns
+// an optional callback for client-side .kata.toml repair on rename.
+func buildResolveRequest(startPath string) (map[string]any, func(string) error, error) {
+	body := map[string]any{}
+
+	if project := strings.TrimSpace(flags.Project); project != "" {
+		body["name"] = project
+		return body, nil, nil
+	}
+
+	disc, err := config.DiscoverPaths(startPath)
+	if err != nil {
+		// Tolerate "not exist" so a typo in --workspace still surfaces
+		// as a uniform daemon-side error instead of a divergent
+		// client-side stat error. Other stat failures (permission,
+		// etc.) propagate.
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{"start_path": startPath}, nil, nil
+		}
+		return nil, nil, &cliError{
+			Message:  err.Error(),
+			Kind:     kindValidation,
+			ExitCode: ExitValidation,
+		}
+	}
+
+	var tomlCfg *config.ProjectConfig
+	if disc.WorkspaceRoot != "" {
+		cfg, err := config.ReadProjectConfig(disc.WorkspaceRoot)
+		switch {
+		case err == nil:
+			tomlCfg = cfg
+		case errors.Is(err, config.ErrProjectConfigMissing):
+			// no .kata.toml here
+		default:
+			return nil, nil, &cliError{
+				Message:  "read .kata.toml: " + err.Error(),
+				Kind:     kindValidation,
+				ExitCode: ExitValidation,
+			}
+		}
+	}
+
+	// Alias derivation is best-effort: a broken git config shouldn't
+	// block resolve when .kata.toml supplies a name. Without a name to
+	// fall back to, the derivation error must surface so the user can
+	// fix it instead of seeing an opaque daemon stat error.
+	var alias *config.AliasInfo
+	if disc.GitRoot != "" || disc.WorkspaceRoot != "" {
+		info, derr := config.ComputeAliasIdentity(disc)
+		switch {
+		case derr == nil:
+			alias = &info
+		case tomlCfg == nil:
+			return nil, nil, &cliError{
+				Message:  derr.Error(),
+				Kind:     kindValidation,
+				ExitCode: ExitValidation,
+			}
+		}
+	}
+
+	if tomlCfg != nil && tomlCfg.Project.Name != "" {
+		body["name"] = tomlCfg.Project.Name
+		if alias != nil {
+			body["alias"] = aliasInputBody(*alias)
+		}
+		workspaceRoot := disc.WorkspaceRoot
+		current := tomlCfg.Project.Name
+		repair := func(canonical string) error {
+			if canonical == "" || canonical == current {
+				return nil
+			}
+			if err := config.WriteProjectConfig(workspaceRoot, canonical); err != nil {
+				return fmt.Errorf("rewrite .kata.toml: %w", err)
+			}
+			return nil
+		}
+		return body, repair, nil
+	}
+
+	if alias != nil {
+		body["alias"] = aliasInputBody(*alias)
+		return body, nil, nil
+	}
+
+	body["start_path"] = startPath
+	return body, nil, nil
+}
+
+// aliasInputBody marshals an AliasInfo into the wire shape the daemon
+// expects (mirrors api.AliasInput).
+func aliasInputBody(info config.AliasInfo) map[string]any {
+	return map[string]any{
+		"identity":  info.Identity,
+		"kind":      info.Kind,
+		"root_path": info.RootPath,
+	}
 }
 
 // printMutation formats a mutation response (issue create/edit/close/reopen)

--- a/cmd/kata/create_test.go
+++ b/cmd/kata/create_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/config"
+	"github.com/wesm/kata/internal/testfix"
 )
 
 func TestCreate_PrintsIssueShortIDInQuietMode(t *testing.T) {
@@ -221,23 +222,118 @@ func TestResolveProjectID_FallsBackOnMissingConfig(t *testing.T) {
 	assert.False(t, hasName, "no .kata.toml means no project name in the request")
 }
 
-func TestResolveProjectID_UsesStartPathForWorkspaceConfig(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, config.WriteProjectConfig(dir, "stale-name"))
+// TestResolveProjectID_SendsNameAndAliasForWorkspaceConfig is the
+// regression coverage for issue #35: when .kata.toml is readable, the
+// client must derive {name, alias} locally and send a path-free
+// request. The daemon's alias-first repair runs against the supplied
+// alias, not against a daemon-side filesystem walk that fails on
+// remote clients (the bug 12ced3a introduced by collapsing the
+// project_identity branch into the always-start_path fallthrough).
+func TestResolveProjectID_SendsNameAndAliasForWorkspaceConfig(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, config.WriteProjectConfig(dir, "project-name"))
 
 	var got map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bs, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(bs, &got)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"project":{"id":42}}`))
+		_, _ = w.Write([]byte(`{"project":{"id":42,"name":"project-name"}}`))
 	}))
 	t.Cleanup(srv.Close)
 
 	id, err := resolveProjectID(context.Background(), srv.URL, dir)
 	require.NoError(t, err)
 	assert.EqualValues(t, 42, id)
-	assert.Equal(t, dir, got["start_path"])
+	assert.Equal(t, "project-name", got["name"], "name from .kata.toml must be sent")
+	alias, ok := got["alias"].(map[string]any)
+	require.True(t, ok, "alias must be sent alongside name so daemon can do alias-first repair")
+	assert.NotEmpty(t, alias["identity"])
+	assert.NotEmpty(t, alias["kind"])
+	assert.NotEmpty(t, alias["root_path"])
+	_, hasStartPath := got["start_path"]
+	assert.False(t, hasStartPath, "request must be path-free so remote daemons can resolve without stat'ing client paths")
+}
+
+// TestResolveProjectID_SendsAliasOnlyForGitWorkspaceWithoutKataToml
+// covers the case where the workspace has a git root but no
+// .kata.toml: the client sends alias metadata alone. The daemon must
+// not derive a project name from the git remote and create-by-
+// convention (resolve is strict; init owns that path).
+func TestResolveProjectID_SendsAliasOnlyForGitWorkspaceWithoutKataToml(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bs, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(bs, &got)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"project":{"id":42,"name":"x"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := resolveProjectID(context.Background(), srv.URL, dir)
+	require.NoError(t, err)
+	alias, ok := got["alias"].(map[string]any)
+	require.True(t, ok, "git workspace must yield an alias even without .kata.toml")
+	assert.NotEmpty(t, alias["identity"])
 	_, hasName := got["name"]
-	assert.False(t, hasName, "ordinary workspace resolution must let daemon alias repair run")
+	assert.False(t, hasName, "resolve must not derive a project name from git remote (init owns by-convention)")
+	_, hasStartPath := got["start_path"]
+	assert.False(t, hasStartPath)
+}
+
+// TestResolveProjectID_ExplicitProjectFlagSendsNameOnly covers the
+// --project override: when the caller targets a project explicitly,
+// alias-first repair must not run (it could redirect away from the
+// caller's chosen project). Name-only is the strict-target contract.
+func TestResolveProjectID_ExplicitProjectFlagSendsNameOnly(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, config.WriteProjectConfig(dir, "in-toml"))
+
+	prev := flags.Project
+	t.Cleanup(func() { flags.Project = prev })
+	flags.Project = "explicit"
+
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bs, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(bs, &got)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"project":{"id":42,"name":"explicit"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := resolveProjectID(context.Background(), srv.URL, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "explicit", got["name"])
+	_, hasAlias := got["alias"]
+	assert.False(t, hasAlias, "--project must send name only — no alias-first repair")
+	_, hasStartPath := got["start_path"]
+	assert.False(t, hasStartPath)
+}
+
+// TestResolveProjectID_RewritesStaleKataToml mirrors what the daemon
+// used to do in resolveByKataToml: when the canonical project name on
+// the daemon differs from the local .kata.toml (project was renamed
+// daemon-side), the client rewrites the file to the canonical name.
+// In remote-client mode the daemon cannot reach the client's
+// filesystem, so this repair must happen on the client.
+func TestResolveProjectID_RewritesStaleKataToml(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, config.WriteProjectConfig(dir, "stale-name"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"project":{"id":42,"name":"canonical-name"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := resolveProjectID(context.Background(), srv.URL, dir)
+	require.NoError(t, err)
+
+	cfg, _, err := config.FindProjectConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "canonical-name", cfg.Project.Name,
+		"stale .kata.toml must be rewritten to the daemon's canonical project name")
 }

--- a/e2e/remote_client_test.go
+++ b/e2e/remote_client_test.go
@@ -190,6 +190,89 @@ func TestRemoteInit_PathFreeWireShape(t *testing.T) {
 	assert.FileExists(t, filepath.Join(clientWS, ".kata.toml"))
 }
 
+// TestRemoteResolve_PathFreeWireShape is the regression e2e for issue
+// #35. After kata init binds a workspace, every subsequent project-
+// scoped command (list, show, create, …) goes through
+// POST /api/v1/projects/resolve. The wire shape must stay path-free
+// — {name, alias?} when .kata.toml is committed — so a client on host
+// B can resolve against a daemon on host A without the daemon stat'ing
+// a path that doesn't exist on its filesystem.
+func TestRemoteResolve_PathFreeWireShape(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e")
+	}
+	bin := buildKataBinary(t)
+
+	port := freeTCPPort(t)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	serverHome := t.TempDir()
+	daemonStderr := &safeBuffer{}
+	daemon := exec.Command(bin, "daemon", "start", "--listen", addr) //nolint:gosec
+	daemon.Env = append(os.Environ(),
+		"KATA_HOME="+serverHome,
+		"KATA_DB="+filepath.Join(serverHome, "kata.db"),
+	)
+	daemon.Stdout = io.Discard
+	daemon.Stderr = daemonStderr
+	daemon.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, daemon.Start())
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("daemon stderr:\n%s", daemonStderr.String())
+		}
+	})
+	t.Cleanup(func() { stopDaemon(daemon) })
+	waitForPing(t, "http://"+addr, 5*time.Second)
+
+	target, err := url.Parse("http://" + addr)
+	require.NoError(t, err)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	var (
+		mu            sync.Mutex
+		resolveBodies []string
+	)
+	recorder := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects/resolve" && r.Method == http.MethodPost {
+			bs, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			resolveBodies = append(resolveBodies, string(bs))
+			mu.Unlock()
+			r.Body = io.NopCloser(bytes.NewReader(bs))
+			r.ContentLength = int64(len(bs))
+		}
+		proxy.ServeHTTP(w, r) //nolint:gosec // G704: forwards to a fixed-test loopback daemon
+	}))
+	t.Cleanup(recorder.Close)
+
+	clientHome := t.TempDir()
+	clientWS := initRepo(t, "https://github.com/wesm/system.git")
+	clientEnv := append(os.Environ(),
+		"KATA_HOME="+clientHome,
+		"KATA_DB="+filepath.Join(clientHome, "kata.db"),
+		"KATA_SERVER="+recorder.URL,
+		"KATA_AUTHOR=e2e-bot",
+	)
+
+	// Bind the workspace first; init writes .kata.toml.
+	runRemoteCmd(t, bin, clientWS, clientEnv, "init")
+	require.FileExists(t, filepath.Join(clientWS, ".kata.toml"))
+
+	// list goes through resolve. With .kata.toml present, the request
+	// must carry {name, alias} and never start_path.
+	runRemoteCmd(t, bin, clientWS, clientEnv, "list")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, resolveBodies, "kata list must issue POST /api/v1/projects/resolve")
+	body := resolveBodies[0]
+	assert.Contains(t, body, `"name":"system"`,
+		"client must send the locally-derived project name")
+	assert.Contains(t, body, `"alias"`,
+		"client must send alias metadata so the daemon can do alias-first repair")
+	assert.NotContains(t, body, "start_path",
+		"remote resolve must not leak the client filesystem path to the daemon (issue #35)")
+}
+
 // freeTCPPort binds 127.0.0.1:0, captures the bound port, and closes.
 // There is a small race window before the caller binds again; accept it.
 func freeTCPPort(t *testing.T) int {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -60,13 +60,24 @@ type ProjectOut struct {
 	Stats *ProjectStatsOut `json:"stats,omitempty"`
 }
 
-// ResolveProjectRequest is POST /api/v1/projects/resolve. Name performs a
-// path-free strict project-name lookup; StartPath resolves from workspace
-// metadata.
+// ResolveProjectRequest is POST /api/v1/projects/resolve.
+//
+// Inputs are tried in priority order:
+//
+//  1. Alias: path-free alias-first lookup. The daemon resolves by
+//     alias.identity; on miss it falls back to Name (if supplied) and
+//     attaches the alias on first-seen. Resolve is strict — the daemon
+//     never creates a project on alias miss, so a git-only client whose
+//     alias is unregistered gets a 404 (run "kata init").
+//  2. Name (without Alias): strict path-free name lookup.
+//  3. StartPath: legacy local-daemon flow that walks the daemon's
+//     filesystem from the client-supplied path. Only useful when the
+//     client and daemon share a filesystem.
 type ResolveProjectRequest struct {
 	Body struct {
-		Name      string `json:"name,omitempty" doc:"project name; preferred over start_path"`
-		StartPath string `json:"start_path,omitempty" doc:"absolute path to resolve from (daemon-side filesystem)"`
+		Name      string      `json:"name,omitempty" doc:"project name; required for first-seen alias attach"`
+		Alias     *AliasInput `json:"alias,omitempty" doc:"client-derived alias metadata; daemon resolves alias first, then falls back to name"`
+		StartPath string      `json:"start_path,omitempty" doc:"absolute path to resolve from (daemon-side filesystem); legacy local-only fallback"`
 	}
 }
 

--- a/internal/daemon/handlers_projects.go
+++ b/internal/daemon/handlers_projects.go
@@ -372,15 +372,25 @@ func resolveByAliasInput(ctx context.Context, store *db.DB, in *api.AliasInput, 
 	alias, err := store.AliasByIdentity(ctx, info.Identity)
 	switch {
 	case err == nil:
+		// Fetch the project before touching the alias so an alias
+		// pointing at an archived row (theoretically possible via
+		// import or direct DB edits — RemoveProject normally hard-
+		// deletes aliases atomically) doesn't bump last_seen_at on the
+		// stale binding.
+		project, err := store.ProjectByID(ctx, alias.ProjectID)
+		if err != nil {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		if project.DeletedAt != nil {
+			return nil, api.NewError(404, "project_not_initialized",
+				"alias "+info.Identity+" points at an archived project",
+				`run "kata init" to bind this workspace to an active project`, nil)
+		}
 		if err := store.TouchAlias(ctx, alias.ID, info.RootPath); err != nil && !errors.Is(err, db.ErrNotFound) {
 			return nil, api.NewError(500, "internal", err.Error(), "", nil)
 		}
 		if refreshed, err := store.AliasByIdentity(ctx, info.Identity); err == nil {
 			alias = refreshed
-		}
-		project, err := store.ProjectByID(ctx, alias.ProjectID)
-		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
 		}
 		return &api.ProjectResolveBody{
 			Project:       dbProjectToOut(project),

--- a/internal/daemon/handlers_projects.go
+++ b/internal/daemon/handlers_projects.go
@@ -68,7 +68,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      "POST",
 		Path:        "/api/v1/projects/resolve",
 	}, func(ctx context.Context, in *api.ResolveProjectRequest) (*api.ResolveProjectResponse, error) {
-		out, err := resolveProject(ctx, cfg.DB, in.Body.Name, in.Body.StartPath)
+		out, err := resolveProject(ctx, cfg.DB, in.Body.Alias, in.Body.Name, in.Body.StartPath)
 		if err != nil {
 			return nil, err
 		}
@@ -311,14 +311,21 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 	})
 }
 
-// resolveProject implements project resolution.
-func resolveProject(ctx context.Context, store *db.DB, name, startPath string) (*api.ProjectResolveBody, error) {
+// resolveProject implements project resolution. Inputs are tried in
+// priority order: alias (path-free, with optional name fallback +
+// first-seen attach), then bare name (strict path-free lookup), then
+// start_path (legacy local-daemon walk). Resolve never creates
+// projects: alias misses without a name match return 404.
+func resolveProject(ctx context.Context, store *db.DB, alias *api.AliasInput, name, startPath string) (*api.ProjectResolveBody, error) {
+	if alias != nil {
+		return resolveByAliasInput(ctx, store, alias, name)
+	}
 	if name != "" {
 		return resolveByName(ctx, store, name)
 	}
 	if startPath == "" {
 		return nil, api.NewError(400, "validation",
-			"either name or start_path is required", "", nil)
+			"one of alias, name, or start_path is required", "", nil)
 	}
 	abs, err := filepath.Abs(startPath)
 	if err != nil {
@@ -342,6 +349,82 @@ func resolveProject(ctx context.Context, store *db.DB, name, startPath string) (
 	return nil, api.NewError(404, "project_not_initialized",
 		"no .kata.toml ancestor and no git ancestor",
 		`run "kata init" inside a workspace`, nil)
+}
+
+// resolveByAliasInput handles the alias-aware path-free resolve flow.
+// The daemon never touches the client filesystem: alias.identity is the
+// canonical key; alias.root_path is stored as opaque metadata. When the
+// alias is unknown but a name is supplied, the daemon falls back to
+// name lookup and attaches the alias on first-seen — so a remote client
+// resolving against a daemon that was previously only reachable from a
+// different host upgrades to the alias-first path on the next call.
+// Resolve never creates projects: an unknown alias with an unknown (or
+// absent) name returns 404.
+func resolveByAliasInput(ctx context.Context, store *db.DB, in *api.AliasInput, name string) (*api.ProjectResolveBody, error) {
+	info := config.AliasInfo{
+		Identity: in.Identity,
+		Kind:     in.Kind,
+		RootPath: in.RootPath,
+	}
+	if err := config.ValidateAliasInfo(info); err != nil {
+		return nil, api.NewError(400, "validation", err.Error(), "", nil)
+	}
+	alias, err := store.AliasByIdentity(ctx, info.Identity)
+	switch {
+	case err == nil:
+		if err := store.TouchAlias(ctx, alias.ID, info.RootPath); err != nil && !errors.Is(err, db.ErrNotFound) {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		if refreshed, err := store.AliasByIdentity(ctx, info.Identity); err == nil {
+			alias = refreshed
+		}
+		project, err := store.ProjectByID(ctx, alias.ProjectID)
+		if err != nil {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		return &api.ProjectResolveBody{
+			Project:       dbProjectToOut(project),
+			Alias:         alias,
+			WorkspaceRoot: info.RootPath,
+		}, nil
+	case !errors.Is(err, db.ErrNotFound):
+		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+
+	// Alias unknown. Fall back to name lookup if supplied so a fresh
+	// client (new host or fresh checkout) can still resolve when the
+	// project was registered without this alias.
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, api.NewError(404, "project_not_initialized",
+			"alias "+info.Identity+" is not registered",
+			`run "kata init" in this workspace`, nil)
+	}
+	if err := config.ValidateProjectName(name); err != nil {
+		return nil, api.NewError(400, "validation", err.Error(), "", nil)
+	}
+	project, err := store.ProjectByName(ctx, name)
+	if errors.Is(err, db.ErrNotFound) {
+		return nil, api.NewError(404, "project_not_initialized",
+			"project "+name+" is not registered",
+			`run "kata init" in this workspace`, nil)
+	}
+	if err != nil {
+		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	// First-seen attach: bind the supplied alias to the matched project
+	// so subsequent resolves hit the alias path. Reassign=false matches
+	// resolve's strict-lookup contract; an existing alias bound
+	// elsewhere surfaces as 409 rather than silently moving.
+	attached, err := attachAlias(ctx, store, project.ID, info, false)
+	if err != nil {
+		return nil, err
+	}
+	return &api.ProjectResolveBody{
+		Project:       dbProjectToOut(project),
+		Alias:         attached,
+		WorkspaceRoot: info.RootPath,
+	}, nil
 }
 
 func resolveByName(ctx context.Context, store *db.DB, name string) (*api.ProjectResolveBody, error) {

--- a/internal/daemon/handlers_projects_test.go
+++ b/internal/daemon/handlers_projects_test.go
@@ -264,6 +264,52 @@ func TestResolve_AliasHitReturnsCanonicalName(t *testing.T) {
 	assert.Contains(t, string(bs), `"name":"new-name"`)
 }
 
+// TestResolve_ByAliasInput_RejectsArchivedProject guards the
+// archived-but-aliased state: RemoveProject hard-deletes aliases
+// atomically, so this is only reachable via direct DB edits or an
+// import path that doesn't go through the API — but resolve is a
+// surface handler, and archived projects must look gone here.
+// resolveByName and the active-project helper already enforce this;
+// the alias path must too.
+func TestResolve_ByAliasInput_RejectsArchivedProject(t *testing.T) {
+	ts, h := startDefaultTestServer(t)
+
+	resp, bs := postJSON(t, ts, "/api/v1/projects", map[string]any{
+		"name": "kata",
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/kata",
+			"kind":      "git",
+			"root_path": "/client/workspace",
+		},
+	})
+	require.Equal(t, 200, resp.StatusCode, string(bs))
+	var initBody struct {
+		Project struct {
+			ID int64 `json:"id"`
+		} `json:"project"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &initBody))
+
+	// Manually flip deleted_at on the project row, leaving the alias
+	// intact. The API-level RemoveProject would also drop the alias,
+	// so this construction tests the defensive 404 in the alias path
+	// rather than the cleanup path.
+	_, err := h.db.ExecContext(t.Context(),
+		`UPDATE projects SET deleted_at = '2026-05-11T00:00:00.000Z' WHERE id = ?`,
+		initBody.Project.ID)
+	require.NoError(t, err)
+
+	resp2, bs2 := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/kata",
+			"kind":      "git",
+			"root_path": "/client/workspace",
+		},
+	})
+	assertAPIError(t, resp2.StatusCode, bs2, http.StatusNotFound, "project_not_initialized")
+	assert.Contains(t, string(bs2), "archived")
+}
+
 // TestResolve_AliasInput_RejectsInvalidKind enforces the same alias
 // validation init applies, so callers see a uniform 400 instead of an
 // opaque downstream failure.

--- a/internal/daemon/handlers_projects_test.go
+++ b/internal/daemon/handlers_projects_test.go
@@ -135,6 +135,152 @@ func TestResolve_NeitherFieldSet(t *testing.T) {
 	assert.Contains(t, string(bs), "start_path")
 }
 
+// TestResolve_ByAliasInput_PathFree verifies remote clients can
+// resolve a registered project by sending alias metadata alone — no
+// start_path on the wire. This is the remote-mode counterpart of init's
+// path-free flow: a daemon on host A serves a client on host B without
+// stat'ing host B's workspace.
+func TestResolve_ByAliasInput_PathFree(t *testing.T) {
+	ts := newTestServer(t)
+
+	// Register via path-free init with alias metadata, mimicking what
+	// the new client would do.
+	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{
+		"name": "kata",
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/kata",
+			"kind":      "git",
+			"root_path": "/client/workspace",
+		},
+	})
+
+	// Resolve by alias only — no name, no start_path.
+	resp, bs := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/kata",
+			"kind":      "git",
+			"root_path": "/client/workspace",
+		},
+	})
+	require.Equal(t, 200, resp.StatusCode, string(bs))
+	assert.Contains(t, string(bs), `"name":"kata"`)
+}
+
+// TestResolve_ByAliasInput_NotRegistered returns 404 when neither
+// the alias nor a name match. The daemon must not derive a project
+// name from the alias and create-by-convention — resolve is strict.
+func TestResolve_ByAliasInput_NotRegistered(t *testing.T) {
+	ts := newTestServer(t)
+
+	resp, bs := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/never-seen",
+			"kind":      "git",
+			"root_path": "/client/workspace",
+		},
+	})
+	assertAPIError(t, resp.StatusCode, bs, http.StatusNotFound, "project_not_initialized")
+}
+
+// TestResolve_AliasMissNameHit_FirstSeenAttach handles the case
+// where a client has a .kata.toml (so it sends a name) and a git
+// workspace whose alias is not yet attached on this daemon (e.g. first
+// resolve from a new host). The daemon falls back to name lookup, then
+// attaches the alias on first-seen so subsequent resolves go through
+// the alias path.
+func TestResolve_AliasMissNameHit_FirstSeenAttach(t *testing.T) {
+	ts := newTestServer(t)
+
+	// Register a project by name only (no alias attached).
+	_, _ = postJSON(t, ts, "/api/v1/projects", map[string]any{"name": "kata"})
+
+	// Client has both name (from .kata.toml) and alias (from git remote)
+	// but the alias is not yet attached on the daemon.
+	resp, bs := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{
+		"name": "kata",
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/kata",
+			"kind":      "git",
+			"root_path": "/client/workspace",
+		},
+	})
+	require.Equal(t, 200, resp.StatusCode, string(bs))
+	assert.Contains(t, string(bs), `"name":"kata"`)
+	assert.Contains(t, string(bs), `"alias_identity":"github.com/wesm/kata"`,
+		"alias must be attached on first-seen so subsequent resolves hit the alias path")
+
+	// Second resolve, alias-only, must succeed against the attached alias.
+	resp2, bs2 := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/kata",
+			"kind":      "git",
+			"root_path": "/client/workspace",
+		},
+	})
+	require.Equal(t, 200, resp2.StatusCode, string(bs2))
+	assert.Contains(t, string(bs2), `"name":"kata"`)
+}
+
+// TestResolve_AliasHitReturnsCanonicalName covers the rename-repair
+// case: a project was renamed daemon-side, but the client's .kata.toml
+// still carries the old name. Alias-first lookup must return the
+// canonical name so the client can rewrite .kata.toml.
+func TestResolve_AliasHitReturnsCanonicalName(t *testing.T) {
+	ts := newTestServer(t)
+
+	// Register and capture project id.
+	_, bs := postJSON(t, ts, "/api/v1/projects", map[string]any{
+		"name": "old-name",
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/kata",
+			"kind":      "git",
+			"root_path": "/client/workspace",
+		},
+	})
+	var initBody struct {
+		Project struct {
+			ID int64 `json:"id"`
+		} `json:"project"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &initBody))
+
+	// Rename project daemon-side.
+	rresp, rbs := patchJSON(t, ts, "/api/v1/projects/"+strconv.FormatInt(initBody.Project.ID, 10),
+		map[string]any{"name": "new-name"})
+	require.Equal(t, 200, rresp.StatusCode, string(rbs))
+
+	// Client still claims the old name but its alias is attached to the
+	// renamed project. Alias must win and response must carry the
+	// canonical (new) name.
+	resp, bs := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{
+		"name": "old-name",
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/kata",
+			"kind":      "git",
+			"root_path": "/client/workspace",
+		},
+	})
+	require.Equal(t, 200, resp.StatusCode, string(bs))
+	assert.Contains(t, string(bs), `"name":"new-name"`)
+}
+
+// TestResolve_AliasInput_RejectsInvalidKind enforces the same alias
+// validation init applies, so callers see a uniform 400 instead of an
+// opaque downstream failure.
+func TestResolve_AliasInput_RejectsInvalidKind(t *testing.T) {
+	ts := newTestServer(t)
+
+	resp, bs := postJSON(t, ts, "/api/v1/projects/resolve", map[string]any{
+		"alias": map[string]any{
+			"identity":  "github.com/wesm/kata",
+			"kind":      "bogus",
+			"root_path": "/work",
+		},
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, string(bs))
+	assert.Contains(t, string(bs), "kind")
+}
+
 // TestResolve_NameWinsOverStartPath verifies precedence: when both
 // name and start_path are supplied, name takes priority and the daemon
 // never touches the (potentially nonexistent) path.

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 
 	"github.com/wesm/kata/internal/config"
@@ -185,26 +186,110 @@ func (c *Client) EditBody(
 
 // ResolveProject runs the §4.2 resolution flow against startPath.
 //
-// start_path lets the daemon resolve by alias first and repair stale
-// .kata.toml bindings after project rename/merge. A readable local .kata.toml
-// is still parsed first so malformed config fails with a direct fix-it error.
+// Wire shape is chosen client-side so the daemon never has to stat the
+// client's filesystem (issue #35): {name, alias?} when .kata.toml is
+// readable, {alias} for a git workspace without .kata.toml, and
+// {start_path} as a legacy local-only fallback. When the daemon
+// returns a canonical name that differs from the local .kata.toml, the
+// client rewrites the file in place.
 func (c *Client) ResolveProject(ctx context.Context, startPath string) (*ResolveResp, error) {
-	var resp ResolveResp
-	req := map[string]string{}
-	_, _, err := config.FindProjectConfig(startPath)
-	switch {
-	case err == nil, errors.Is(err, config.ErrProjectConfigMissing):
-		req["start_path"] = startPath
-	default:
-		// Found a .kata.toml but couldn't parse it. Propagate so the
-		// user sees the broken-config error instead of a confusing
-		// daemon-side stat failure under remote-client mode.
-		return nil, fmt.Errorf("read .kata.toml: %w", err)
+	req, repair, err := buildResolveRequest(startPath)
+	if err != nil {
+		return nil, err
 	}
+	var resp ResolveResp
 	if err := c.do(ctx, http.MethodPost, "/api/v1/projects/resolve", req, &resp); err != nil {
 		return nil, err
 	}
+	if repair != nil {
+		if err := repair(resp.Project.Name); err != nil {
+			return nil, err
+		}
+	}
 	return &resp, nil
+}
+
+// buildResolveRequest selects the resolve wire shape and returns an
+// optional callback that rewrites .kata.toml when the daemon's
+// canonical name differs from the local binding.
+func buildResolveRequest(startPath string) (map[string]any, func(string) error, error) {
+	disc, err := config.DiscoverPaths(startPath)
+	if err != nil {
+		// Path doesn't exist locally — pass through to start_path so
+		// the daemon's not-initialized error surfaces uniformly, same
+		// as the pre-12ced3a behavior. Permission and other stat
+		// errors still propagate (they indicate a real problem the
+		// user needs to know about).
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{"start_path": startPath}, nil, nil
+		}
+		return nil, nil, err
+	}
+	var tomlCfg *config.ProjectConfig
+	if disc.WorkspaceRoot != "" {
+		cfg, err := config.ReadProjectConfig(disc.WorkspaceRoot)
+		switch {
+		case err == nil:
+			tomlCfg = cfg
+		case errors.Is(err, config.ErrProjectConfigMissing):
+			// no .kata.toml
+		default:
+			// Surface the parse error directly so the user sees the
+			// fix-it message instead of a confusing daemon-side stat
+			// failure under remote-client mode.
+			return nil, nil, fmt.Errorf("read .kata.toml: %w", err)
+		}
+	}
+
+	var alias *config.AliasInfo
+	if disc.GitRoot != "" || disc.WorkspaceRoot != "" {
+		info, derr := config.ComputeAliasIdentity(disc)
+		switch {
+		case derr == nil:
+			alias = &info
+		case tomlCfg == nil:
+			return nil, nil, derr
+		}
+	}
+
+	body := map[string]any{}
+	if tomlCfg != nil && tomlCfg.Project.Name != "" {
+		body["name"] = tomlCfg.Project.Name
+		if alias != nil {
+			body["alias"] = aliasInputBody(*alias)
+		}
+		workspaceRoot := disc.WorkspaceRoot
+		current := tomlCfg.Project.Name
+		repair := func(canonical string) error {
+			if canonical == "" || canonical == current {
+				return nil
+			}
+			if err := config.WriteProjectConfig(workspaceRoot, canonical); err != nil {
+				return fmt.Errorf("rewrite .kata.toml: %w", err)
+			}
+			return nil
+		}
+		return body, repair, nil
+	}
+
+	if alias != nil {
+		body["alias"] = aliasInputBody(*alias)
+		return body, nil, nil
+	}
+
+	body["start_path"] = startPath
+	return body, nil, nil
+}
+
+// aliasInputBody marshals a config.AliasInfo into the api.AliasInput
+// wire shape (untyped map to keep the daemon-facing JSON local to
+// this file).
+func aliasInputBody(info config.AliasInfo) map[string]any {
+	return map[string]any{
+		"identity":  info.Identity,
+		"kind":      info.Kind,
+		"root_path": info.RootPath,
+	}
 }
 
 // ListLabels returns the per-label aggregate counts for projectID. The

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wesm/kata/internal/config"
+	"github.com/wesm/kata/internal/testfix"
 )
 
 // newTestClient stands up an httptest server with handler, registers
@@ -713,23 +714,83 @@ func TestClient_ResolveProject_FallsBackOnMissingConfig(t *testing.T) {
 	assert.False(t, hasName)
 }
 
-func TestClient_ResolveProject_UsesStartPathForWorkspaceConfig(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, config.WriteProjectConfig(dir, "stale-name"))
+// TestClient_ResolveProject_SendsNameAndAliasForWorkspaceConfig is
+// regression coverage for issue #35: when .kata.toml is readable, the
+// TUI must send {name, alias} so a daemon on another host can resolve
+// without stat'ing the client's filesystem.
+func TestClient_ResolveProject_SendsNameAndAliasForWorkspaceConfig(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, config.WriteProjectConfig(dir, "project-name"))
 
 	var got map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bs, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(bs, &got)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"project":{"id":42}}`))
+		_, _ = w.Write([]byte(`{"project":{"id":42,"name":"project-name"}}`))
 	}))
 	defer srv.Close()
 	c := NewClient(srv.URL, srv.Client())
 
 	_, err := c.ResolveProject(t.Context(), dir)
 	require.NoError(t, err)
-	assert.Equal(t, dir, got["start_path"])
+	assert.Equal(t, "project-name", got["name"])
+	alias, ok := got["alias"].(map[string]any)
+	require.True(t, ok, "alias must be sent alongside name so daemon can do alias-first repair")
+	assert.NotEmpty(t, alias["identity"])
+	_, hasStartPath := got["start_path"]
+	assert.False(t, hasStartPath, "request must be path-free")
+}
+
+// TestClient_ResolveProject_SendsAliasOnlyForGitWorkspaceWithoutKataToml
+// covers a git workspace without .kata.toml: client sends alias alone.
+// Resolve must not derive a project name from the git remote (init
+// owns by-convention).
+func TestClient_ResolveProject_SendsAliasOnlyForGitWorkspaceWithoutKataToml(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bs, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(bs, &got)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"project":{"id":42,"name":"x"}}`))
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL, srv.Client())
+
+	_, err := c.ResolveProject(t.Context(), dir)
+	require.NoError(t, err)
+	alias, ok := got["alias"].(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, alias["identity"])
 	_, hasName := got["name"]
-	assert.False(t, hasName, "ordinary workspace resolution must let daemon alias repair run")
+	assert.False(t, hasName)
+	_, hasStartPath := got["start_path"]
+	assert.False(t, hasStartPath)
+}
+
+// TestClient_ResolveProject_RewritesStaleKataToml verifies the
+// rename-repair handoff to the client: when the daemon returns a
+// canonical name that differs from the local .kata.toml, the TUI
+// rewrites the file. Mirrors the CLI behavior so both clients keep
+// .kata.toml fresh.
+func TestClient_ResolveProject_RewritesStaleKataToml(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, config.WriteProjectConfig(dir, "stale-name"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"project":{"id":42,"name":"canonical-name"}}`))
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL, srv.Client())
+
+	_, err := c.ResolveProject(t.Context(), dir)
+	require.NoError(t, err)
+
+	cfg, _, err := config.FindProjectConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "canonical-name", cfg.Project.Name,
+		"stale .kata.toml must be rewritten to the daemon's canonical name")
 }


### PR DESCRIPTION
## Summary

Restores path-free project resolution for project-scoped commands
(`kata list`, `kata tui`, `create`, `close`, …) in remote-client mode.

Issue #35: after 12ced3a collapsed `project_identity` into `project_name`,
the CLI and TUI fell through to `{start_path}` on every resolve when
`.kata.toml` was readable. A daemon on another host then ran
`DiscoverPaths` on a client path on its own filesystem and failed with
`validation: stat /path: no such file or directory`. Only `kata init`
was updated to the path-free wire shape; resolve was missed.

## Change

Mirror `kata init`'s path-free contract on resolve.

- **API** (`internal/api/types.go`): `ResolveProjectRequest.Body` gains
  optional `Alias *AliasInput`. Priority order: alias > name > start_path.
- **Daemon** (`internal/daemon/handlers_projects.go`): new
  `resolveByAliasInput` does alias-first lookup with a name fallback
  that attaches the alias on first-seen. Resolve never creates projects
  — an unknown alias without a matching name returns 404, so a git-only
  workspace whose alias isn't registered cannot resolve-by-convention
  from the git remote (init owns that path). Archived projects are
  rejected with 404 after the lookup so an alias pointing at a
  soft-deleted row doesn't slip through the active surface.
- **CLI + TUI**: derive wire shape locally. `--project` sends `{name}`.
  `.kata.toml` sends `{name, alias?}`. Git workspace without
  `.kata.toml` sends `{alias}`. Bare directory still falls back to
  `{start_path}` for local-daemon mode.
- **Client-side `.kata.toml` repair**: when the daemon returns a
  canonical name that differs from the local binding (project renamed
  daemon-side), the client rewrites `.kata.toml`. The daemon's own
  rewrite worked only in local mode.

The two tests that previously pinned `start_path` with a workspace
`.kata.toml` are inverted. New e2e regression `TestRemoteResolve_PathFreeWireShape`
asserts `kata list` hits `POST /api/v1/projects/resolve` with `{name, alias}`
and no `start_path` under `KATA_SERVER`.

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)