### PR TITLE
Cross-platform install docs and top-of-readme quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 .PHONY: build install test test-short lint vet clean fmt nilaway tui tui-demo
 
 GOFLAGS_TEST := -shuffle=on
+GOBIN ?= $(HOME)/.local/bin
 
 build:
 	go build -o kata ./cmd/kata
 
 install:
-	GOBIN=$${HOME}/.local/bin go install ./cmd/kata
+	GOBIN=$(GOBIN) go install ./cmd/kata
 
 test:
 	go test $(GOFLAGS_TEST) ./...

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@
 
 GOFLAGS_TEST := -shuffle=on
 GOBIN ?= $(HOME)/.local/bin
+export GOBIN
 
 build:
 	go build -o kata ./cmd/kata
 
 install:
-	GOBIN=$(GOBIN) go install ./cmd/kata
+	go install ./cmd/kata
 
 test:
 	go test $(GOFLAGS_TEST) ./...

--- a/README.md
+++ b/README.md
@@ -146,8 +146,6 @@ directory to your `PATH`.
 ### Build from a clone (macOS / Linux)
 
 ```sh
-git clone https://github.com/wesm/kata.git
-cd kata
 make install
 ```
 
@@ -159,8 +157,6 @@ isn't already.
 PowerShell or cmd.exe:
 
 ```powershell
-git clone https://github.com/wesm/kata.git
-cd kata
 go build -o kata.exe ./cmd/kata
 # Move kata.exe to a directory on your PATH, e.g. %USERPROFILE%\.local\bin
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ same local daemon and SQLite database.
 Status: early public preview. The CLI, daemon, and TUI are usable, but command
 contracts and UI details may still change before a stable release.
 
+## Quick Start
+
+```sh
+go install github.com/wesm/kata/cmd/kata@latest   # or see Install for other options
+
+cd your-repo
+kata init                                         # bind this workspace to a kata project
+kata create "fix login race"                      # returns the issue's short_id, e.g. abc4
+kata list                                         # list open issues
+kata show abc4                                    # inspect by short_id
+kata close abc4 --done --message "Fixed; tests green." --commit <sha>
+kata tui                                          # browse and triage interactively
+```
+
+See [Install](#install) for `go install`, build-from-source, and Windows
+instructions; see [Working with kata](#working-with-kata) for a longer
+walkthrough.
+
 ## What kata does today
 
 What you can do:
@@ -110,24 +128,53 @@ carries the issue state.
 
 ## Install
 
-kata is built with Go. To build from source you need Go 1.26 or later and a
-clone of this repository:
+kata is a single Go binary with no runtime dependencies and builds on macOS,
+Linux, and Windows. Pre-built release binaries are not published yet; install
+from source using one of the options below. All paths require **Go 1.26 or
+later** (<https://go.dev/dl/>).
+
+### `go install` (any platform)
 
 ```sh
-make build
+go install github.com/wesm/kata/cmd/kata@latest
+```
+
+Go places `kata` in `$(go env GOBIN)`, falling back to `$(go env GOPATH)/bin`
+(typically `~/go/bin` on Unix, `%USERPROFILE%\go\bin` on Windows). Add that
+directory to your `PATH`.
+
+### Build from a clone (macOS / Linux)
+
+```sh
+git clone https://github.com/wesm/kata.git
+cd kata
 make install
 ```
 
-`make install` places `kata` in `~/.local/bin`. Make sure that directory is on
-your `PATH`.
+`make install` places `kata` in `~/.local/bin`; add it to your `PATH` if it
+isn't already.
 
-For development:
+### Build from a clone (Windows)
 
-```sh
-make test
+PowerShell or cmd.exe:
+
+```powershell
+git clone https://github.com/wesm/kata.git
+cd kata
+go build -o kata.exe ./cmd/kata
+# Move kata.exe to a directory on your PATH, e.g. %USERPROFILE%\.local\bin
 ```
 
-## Quick Start
+The `go install` command above also works on Windows and is usually simpler.
+
+### Development
+
+```sh
+make test          # run the test suite
+make lint          # run golangci-lint
+```
+
+## Working with kata
 
 Initialize kata in a workspace:
 

--- a/README.md
+++ b/README.md
@@ -146,11 +146,12 @@ directory to your `PATH`.
 ### Build from a clone (macOS / Linux)
 
 ```sh
-make install
+make install                            # installs to ~/.local/bin
+make install GOBIN=/usr/local/bin       # or set GOBIN to install elsewhere
 ```
 
-`make install` places `kata` in `~/.local/bin`; add it to your `PATH` if it
-isn't already.
+Add the install directory to your `PATH` if it isn't already. `GOBIN` from the
+environment is also honored (`export GOBIN=/opt/bin && make install`).
 
 ### Build from a clone (Windows)
 


### PR DESCRIPTION
## Summary
- Add a short Quick Start near the top of the README; rename the longer existing section to "Working with kata".
- Document three install paths for macOS, Linux, and Windows: `go install github.com/wesm/kata/cmd/kata@latest`, `make install` (Unix clone), and `go build -o kata.exe ./cmd/kata` (Windows clone).
- Make the `make install` target directory overridable via `GOBIN` (default stays `~/.local/bin`). Previously `GOBIN` was hardcoded inline in the recipe so `make install GOBIN=...` had no effect.