### PR TITLE
Add version subcommand

### DIFF
--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -85,6 +85,7 @@ func newRootCmd() *cobra.Command {
 		newHealthCmd(),
 		newProjectsCmd(),
 		newTUICmd(),
+		newVersionCmd(),
 	}
 	cmd.AddCommand(subs...)
 	return cmd

--- a/cmd/kata/version.go
+++ b/cmd/kata/version.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+
+	"github.com/wesm/kata/internal/version"
+
+	"github.com/spf13/cobra"
+)
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "print version information",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+			if flags.JSON {
+				var buf bytes.Buffer
+				payload := map[string]string{
+					"version": version.Version,
+					"commit":  version.Commit,
+					"built":   version.BuildDate,
+					"go":      runtime.Version(),
+					"os":      runtime.GOOS,
+					"arch":    runtime.GOARCH,
+				}
+				if err := emitJSON(&buf, payload); err != nil {
+					return err
+				}
+				_, err := fmt.Fprint(out, buf.String())
+				return err
+			}
+			_, err := fmt.Fprintf(out,
+				"kata %s\n"+
+					"  commit:  %s\n"+
+					"  built:   %s\n"+
+					"  go:      %s\n"+
+					"  os/arch: %s/%s\n",
+				version.Version, version.Commit, version.BuildDate,
+				runtime.Version(), runtime.GOOS, runtime.GOARCH,
+			)
+			return err
+		},
+	}
+}

--- a/cmd/kata/version_test.go
+++ b/cmd/kata/version_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/wesm/kata/internal/version"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubVersionInfo overrides the exported version.* package variables for
+// the duration of the test so the version command produces a deterministic
+// output regardless of how the test binary was built.
+func stubVersionInfo(t *testing.T, ver, commit, built string) {
+	t.Helper()
+	origVer, origCommit, origBuilt := version.Version, version.Commit, version.BuildDate
+	version.Version, version.Commit, version.BuildDate = ver, commit, built
+	t.Cleanup(func() {
+		version.Version, version.Commit, version.BuildDate = origVer, origCommit, origBuilt
+	})
+}
+
+func TestVersion_HumanFormatMatchesMsgvault(t *testing.T) {
+	resetFlags(t)
+	stubVersionInfo(t, "v0.0.1-test", "abc1234", "2026-05-12T11:17:12Z")
+
+	out := string(executeRoot(t, newVersionCmd()))
+
+	expected := fmt.Sprintf(
+		"kata v0.0.1-test\n"+
+			"  commit:  abc1234\n"+
+			"  built:   2026-05-12T11:17:12Z\n"+
+			"  go:      %s\n"+
+			"  os/arch: %s/%s\n",
+		runtime.Version(), runtime.GOOS, runtime.GOARCH,
+	)
+	assert.Equal(t, expected, out)
+}
+
+func TestVersion_JSONEnvelope(t *testing.T) {
+	resetFlags(t)
+	flags.JSON = true
+	stubVersionInfo(t, "v0.0.1-test", "abc1234", "2026-05-12T11:17:12Z")
+
+	out := executeRoot(t, newVersionCmd())
+
+	var got struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+		Built   string `json:"built"`
+		Go      string `json:"go"`
+		OS      string `json:"os"`
+		Arch    string `json:"arch"`
+	}
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, "v0.0.1-test", got.Version)
+	assert.Equal(t, "abc1234", got.Commit)
+	assert.Equal(t, "2026-05-12T11:17:12Z", got.Built)
+	assert.Equal(t, runtime.Version(), got.Go)
+	assert.Equal(t, runtime.GOOS, got.OS)
+	assert.Equal(t, runtime.GOARCH, got.Arch)
+}
+
+func TestVersion_IsWiredOnRoot(t *testing.T) {
+	resetFlags(t)
+	root := newRootCmd()
+	for _, c := range root.Commands() {
+		if c.Use == "version" {
+			return
+		}
+	}
+	t.Fatal("version subcommand not registered on root")
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,11 +8,13 @@ package version
 import "runtime/debug"
 
 const (
-	defaultVersion  = "dev"
-	shortHashLen    = 7
-	settingRevision = "vcs.revision"
-	settingModified = "vcs.modified"
-	dirtySuffix     = "-dirty"
+	defaultVersion   = "dev"
+	unknown          = "unknown"
+	shortHashLen     = 7
+	settingRevision  = "vcs.revision"
+	settingModified  = "vcs.modified"
+	settingBuildTime = "vcs.time"
+	dirtySuffix      = "-dirty"
 )
 
 var readBuildInfo = debug.ReadBuildInfo
@@ -22,11 +24,26 @@ var readBuildInfo = debug.ReadBuildInfo
 // Go's embedded VCS metadata.
 var Version = defaultVersion
 
+// Commit is the short VCS revision the binary was built from. Release
+// builds can override it with ldflags; otherwise it is derived from
+// debug.BuildInfo's vcs.revision setting.
+var Commit = unknown
+
+// BuildDate is the commit timestamp the binary was built from, formatted
+// as RFC3339. Release builds can override it with ldflags; otherwise it
+// comes from debug.BuildInfo's vcs.time setting.
+var BuildDate = unknown
+
 func init() {
-	if Version != defaultVersion {
-		return
+	if Version == defaultVersion {
+		Version = versionFromVCS()
 	}
-	Version = versionFromVCS()
+	if Commit == unknown {
+		Commit = commitFromVCS()
+	}
+	if BuildDate == unknown {
+		BuildDate = buildDateFromVCS()
+	}
 }
 
 func versionFromVCS() string {
@@ -55,4 +72,33 @@ func versionFromVCS() string {
 		rev += dirtySuffix
 	}
 	return rev
+}
+
+func commitFromVCS() string {
+	info, ok := readBuildInfo()
+	if !ok {
+		return unknown
+	}
+	for _, s := range info.Settings {
+		if s.Key == settingRevision && s.Value != "" {
+			if len(s.Value) > shortHashLen {
+				return s.Value[:shortHashLen]
+			}
+			return s.Value
+		}
+	}
+	return unknown
+}
+
+func buildDateFromVCS() string {
+	info, ok := readBuildInfo()
+	if !ok {
+		return unknown
+	}
+	for _, s := range info.Settings {
+		if s.Key == settingBuildTime && s.Value != "" {
+			return s.Value
+		}
+	}
+	return unknown
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -8,13 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func mockBuildInfo(t *testing.T, revision string, modified bool) {
+func mockBuildInfo(t *testing.T, revision, buildTime string, modified bool) {
 	t.Helper()
 	orig := readBuildInfo
 	t.Cleanup(func() { readBuildInfo = orig })
 
 	settings := []debug.BuildSetting{
 		{Key: settingRevision, Value: revision},
+	}
+	if buildTime != "" {
+		settings = append(settings, debug.BuildSetting{Key: settingBuildTime, Value: buildTime})
 	}
 	if modified {
 		settings = append(settings, debug.BuildSetting{Key: settingModified, Value: "true"})
@@ -25,11 +28,31 @@ func mockBuildInfo(t *testing.T, revision string, modified bool) {
 }
 
 func TestVersionFromVCSPrefixesShortRevisionWithG(t *testing.T) {
-	mockBuildInfo(t, "1697674abcdef", false)
+	mockBuildInfo(t, "1697674abcdef", "", false)
 	assert.Equal(t, "g1697674", versionFromVCS())
 }
 
 func TestVersionFromVCSPrefixesDirtyRevisionWithG(t *testing.T) {
-	mockBuildInfo(t, "1697674abcdef", true)
+	mockBuildInfo(t, "1697674abcdef", "", true)
 	assert.Equal(t, "g1697674-dirty", versionFromVCS())
+}
+
+func TestCommitReturnsShortRevisionFromBuildInfo(t *testing.T) {
+	mockBuildInfo(t, "1697674abcdef0123456789", "", false)
+	assert.Equal(t, "1697674", commitFromVCS())
+}
+
+func TestCommitReturnsUnknownWhenBuildInfoMissingRevision(t *testing.T) {
+	mockBuildInfo(t, "", "", false)
+	assert.Equal(t, "unknown", commitFromVCS())
+}
+
+func TestBuildDateReturnsVCSTime(t *testing.T) {
+	mockBuildInfo(t, "1697674abcdef", "2026-02-10T01:00:19Z", false)
+	assert.Equal(t, "2026-02-10T01:00:19Z", buildDateFromVCS())
+}
+
+func TestBuildDateReturnsUnknownWhenBuildInfoMissingTime(t *testing.T) {
+	mockBuildInfo(t, "1697674abcdef", "", false)
+	assert.Equal(t, "unknown", buildDateFromVCS())
 }


### PR DESCRIPTION
## Summary
- `kata version` prints version, commit, build date, Go toolchain, and os/arch in the same shape as `msgvault version`
- Build metadata is derived from `runtime/debug.BuildInfo` so plain `go install` / `go build` populate the new fields without any ldflags wiring; release builds can still override `version.Commit` / `version.BuildDate` via `-X` if desired
- `--json` is supported for consistency with other kata commands

## Output
```
$ kata version
kata gdeb733e-dirty
  commit:  deb733e
  built:   2026-05-12T15:01:48Z
  go:      go1.26.3
  os/arch: darwin/arm64
```

## Test plan
- [x] `go test ./internal/version/ ./cmd/kata/` passes (new tests cover human format, JSON envelope, root wiring, and the new `commitFromVCS` / `buildDateFromVCS` helpers)
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean
- [x] Built and ran `kata version` and `kata --json version` against a real binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)