### PR TITLE
tui: add right/left arrows for expand/collapse

### DIFF
--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -22,7 +22,8 @@ func helpSections(km keymap) []helpSection {
 		{"Graph", []helpItem{
 			r(km.Up), r(km.Down), r(km.ScrollUp), r(km.ScrollDown),
 			r(km.PageUp), r(km.PageDown), r(km.Home),
-			r(km.End), r(km.Open), r(km.ExpandCollapse), r(km.NewIssue),
+			r(km.End), r(km.Open), r(km.ExpandCollapse),
+			r(km.Expand), r(km.Collapse), r(km.NewIssue),
 			r(km.SortChildren), r(km.Close), r(km.Reopen),
 		}},
 		{"Detail", []helpItem{

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -12,7 +12,7 @@ type keymap struct {
 	Up, Down, PageUp, PageDown, Home, End          key
 	ScrollUp, ScrollDown                           key
 	Open, NewIssue, NewChild, Search               key
-	ExpandCollapse                                 key
+	ExpandCollapse, Expand, Collapse               key
 	SortChildren                                   key
 	FilterStatus, FilterForm, ClearFilters         key
 	Close, Reopen                                  key
@@ -55,6 +55,8 @@ func newKeymap() keymap {
 		NewIssue:       key{Keys: []string{"n"}, Help: "new issue (form)"},
 		NewChild:       key{Keys: []string{"N"}, Help: "new child"},
 		ExpandCollapse: key{Keys: []string{" "}, Help: "expand/collapse"},
+		Expand:         key{Keys: []string{"right"}, Help: "expand"},
+		Collapse:       key{Keys: []string{"left"}, Help: "collapse"},
 		SortChildren:   key{Keys: []string{"o"}, Help: "toggle graph order"},
 		Search:         key{Keys: []string{"/"}, Help: "search"},
 		FilterStatus:   key{Keys: []string{"s"}, Help: "cycle status filter"},

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -404,10 +404,15 @@ func (lm listModel) applyCursorKey(msg tea.KeyMsg, km keymap) (listModel, bool) 
 }
 
 func (lm listModel) applyExpandKey(msg tea.KeyMsg, km keymap) (listModel, bool) {
-	if !km.ExpandCollapse.matches(msg) {
-		return lm, false
+	switch {
+	case km.ExpandCollapse.matches(msg):
+		return lm.toggleExpanded(), true
+	case km.Expand.matches(msg):
+		return lm.setExpanded(true), true
+	case km.Collapse.matches(msg):
+		return lm.setExpanded(false), true
 	}
-	return lm.toggleExpanded(), true
+	return lm, false
 }
 
 func (lm listModel) toggleExpanded() listModel {
@@ -415,13 +420,29 @@ func (lm listModel) toggleExpanded() listModel {
 	if !ok || !row.hasChildren {
 		return lm
 	}
+	return lm.setExpansion(row, !lm.expanded[row.key])
+}
+
+// setExpanded forces the targeted row to expanded (want=true) or
+// collapsed (want=false). Leaves rows without children untouched and
+// is a no-op when the row is already in the requested state, so the
+// right/left arrow bindings stay idempotent.
+func (lm listModel) setExpanded(want bool) listModel {
+	row, ok := lm.targetQueueRow()
+	if !ok || !row.hasChildren || lm.expanded[row.key] == want {
+		return lm
+	}
+	return lm.setExpansion(row, want)
+}
+
+func (lm listModel) setExpansion(row queueRow, want bool) listModel {
 	if lm.expanded == nil {
 		lm.expanded = expansionSet{}
 	}
-	if lm.expanded[row.key] {
-		delete(lm.expanded, row.key)
-	} else {
+	if want {
 		lm.expanded[row.key] = true
+	} else {
+		delete(lm.expanded, row.key)
 	}
 	return lm
 }

--- a/internal/tui/list_filter_test.go
+++ b/internal/tui/list_filter_test.go
@@ -464,6 +464,64 @@ func TestList_ExpandCollapse_LeafNoOp(t *testing.T) {
 	}
 }
 
+// TestList_ArrowExpandCollapse covers the right/left arrow bindings
+// added alongside the space toggle. Right expands a collapsed parent;
+// left collapses an expanded parent. Repeated presses in the same
+// direction must be no-ops so users can mash arrows without the row
+// flipping back and forth.
+func TestList_ArrowExpandCollapse(t *testing.T) {
+	api, km, sc := newListEnv()
+	parentSID := "p001"
+	lm := listModel{
+		issues: []Issue{
+			{ProjectID: 7, UID: "01TEST-p001", ShortID: parentSID, ChildCounts: &ChildCounts{Open: 1, Total: 1}},
+			{ProjectID: 7, UID: "01TEST-c002", ShortID: "c002", ParentShortID: &parentSID},
+		},
+	}
+
+	lm, cmd := lm.Update(tea.KeyMsg{Type: tea.KeyRight}, km, api, sc)
+	if cmd != nil {
+		t.Fatalf("right should not dispatch a command, got %T", cmd)
+	}
+	if len(lm.visibleRows()) != 2 {
+		t.Fatalf("after right: visible rows = %+v, want parent+child", lm.visibleRows())
+	}
+
+	// Right on an already-expanded row is a no-op (and must not toggle).
+	lm, _ = lm.Update(tea.KeyMsg{Type: tea.KeyRight}, km, api, sc)
+	if len(lm.visibleRows()) != 2 {
+		t.Fatalf("right again: visible rows = %+v, want still expanded", lm.visibleRows())
+	}
+
+	lm, _ = lm.Update(tea.KeyMsg{Type: tea.KeyLeft}, km, api, sc)
+	if len(lm.visibleRows()) != 1 {
+		t.Fatalf("after left: visible rows = %+v, want parent only", lm.visibleRows())
+	}
+
+	// Left on an already-collapsed row is a no-op.
+	lm, _ = lm.Update(tea.KeyMsg{Type: tea.KeyLeft}, km, api, sc)
+	if len(lm.visibleRows()) != 1 {
+		t.Fatalf("left again: visible rows = %+v, want still collapsed", lm.visibleRows())
+	}
+}
+
+// TestList_ArrowExpandCollapse_LeafNoOp mirrors the space-leaf case
+// for the arrow bindings: a row with no children must not get an
+// entry written to the expansion set.
+func TestList_ArrowExpandCollapse_LeafNoOp(t *testing.T) {
+	api, km, sc := newListEnv()
+	lm := listModel{issues: []Issue{{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1"}}}
+
+	next, _ := lm.Update(tea.KeyMsg{Type: tea.KeyRight}, km, api, sc)
+	if len(next.expanded) != 0 {
+		t.Fatalf("right on leaf: expanded = %+v, want empty", next.expanded)
+	}
+	next, _ = lm.Update(tea.KeyMsg{Type: tea.KeyLeft}, km, api, sc)
+	if len(next.expanded) != 0 {
+		t.Fatalf("left on leaf: expanded = %+v, want empty", next.expanded)
+	}
+}
+
 func TestList_SelectionPreservedAcrossRefetchWithParentInsertion(t *testing.T) {
 	parentSID := "p001"
 	lm := listModel{

--- a/internal/tui/testdata/golden/help-narrow.txt
+++ b/internal/tui/testdata/golden/help-narrow.txt
@@ -17,6 +17,8 @@ g       first
 G       last
 enter   open detail
 space   expand/collapse
+right   expand
+left    collapse
 n       new issue (form)
 o       toggle graph order
 x       close

--- a/internal/tui/testdata/golden/help-wide.txt
+++ b/internal/tui/testdata/golden/help-wide.txt
@@ -17,9 +17,11 @@ g       first                 A              clear owner
 G       last                  !              set priority                                            
 enter   open detail                                                                                  
 space   expand/collapse       Children                                                               
-n       new issue (form)      N      new child                                                       
-o       toggle graph order    j/k    move child cursor                                               
-x       close                 ↑↓     scroll detail viewport                                          
-r       reopen                enter  open child                                                      
+right   expand                N      new child                                                       
+left    collapse              j/k    move child cursor                                               
+n       new issue (form)      ↑↓     scroll detail viewport                                          
+o       toggle graph order    enter  open child                                                      
+x       close                                                                                        
+r       reopen                                                                                       
 
 press ? to return


### PR DESCRIPTION
## Summary

- Adds right arrow as expand and left arrow as collapse in the list view, alongside the existing space toggle.
- Both arrow bindings are idempotent: right on an already-expanded row, left on an already-collapsed row, and either key on a leaf row are all no-ops.
- Help overlay shows the new bindings in the Graph section.