### PR TITLE
Raise import body limit; surface list truncation

### DIFF
--- a/cmd/kata/list.go
+++ b/cmd/kata/list.go
@@ -102,11 +102,23 @@ func newListCmd() *cobra.Command {
 					return err
 				}
 			}
+			// Truncation hint: when we got exactly --limit rows back the
+			// daemon may have more. Print to stderr so pipelines stay
+			// clean (kata list | grep ...). Quiet suppresses it. Has a
+			// false positive when the project has exactly --limit issues,
+			// which we accept as a much smaller harm than silent
+			// truncation on projects above the default.
+			if !flags.Quiet && len(b.Issues) == limit {
+				if _, err := fmt.Fprintf(cmd.ErrOrStderr(),
+					"... showing %d (raise --limit to see more)\n", limit); err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&status, "status", "open", "filter by status: open|closed|all")
-	cmd.Flags().IntVar(&limit, "limit", 50, "max rows")
+	cmd.Flags().IntVar(&limit, "limit", 200, "max rows")
 	cmd.Flags().IntVar(&priority, "priority", 0, "exact priority filter (0..4); 0 = highest")
 	cmd.Flags().IntVar(&maxPriority, "max-priority", 0, "include only priority <= this value (0..4)")
 	return cmd

--- a/cmd/kata/list_test.go
+++ b/cmd/kata/list_test.go
@@ -60,3 +60,59 @@ func TestList_SanitizesAnsiAndNewlinesInTitle(t *testing.T) {
 		assert.NotEmpty(t, ln, "list output produced a blank row from injected newline")
 	}
 }
+
+// TestList_HintsWhenTruncated covers the silent-truncation pitfall: when the
+// returned page is exactly --limit rows, the CLI prints a stderr hint so users
+// realize there may be more. Hint goes to stderr so it doesn't pollute pipes
+// (kata list | grep ...) and is suppressed in --json mode.
+func TestList_HintsWhenTruncated(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	for _, title := range []string{"alpha", "beta", "gamma"} {
+		createIssue(t, env, pid, title)
+	}
+
+	stdout, stderr, err := runCLIWithErr(t, env, dir, "list", "--limit", "2")
+	require.NoError(t, err)
+	// Two rows on stdout, no hint on stdout.
+	rows := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	assert.Len(t, rows, 2, "stdout should carry exactly --limit rows")
+	assert.NotContains(t, stdout, "--limit", "hint must go to stderr, not stdout")
+	// Hint on stderr.
+	assert.Contains(t, stderr, "--limit",
+		"stderr should hint that more rows may exist (stderr=%q)", stderr)
+}
+
+// TestList_NoHintWhenAllRowsFit guards the false-negative direction: when the
+// page is shorter than --limit, no hint should fire.
+func TestList_NoHintWhenAllRowsFit(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	for _, title := range []string{"alpha", "beta"} {
+		createIssue(t, env, pid, title)
+	}
+
+	stdout, stderr, err := runCLIWithErr(t, env, dir, "list", "--limit", "10")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "alpha")
+	assert.Contains(t, stdout, "beta")
+	assert.NotContains(t, stderr, "--limit", "no hint expected when rows < limit")
+}
+
+// TestList_JSONOmitsHint pins that the JSON output path stays pure JSON. The
+// hint is human-facing; agents consuming --json must not get extra stderr
+// noise that breaks parsers expecting silent success.
+func TestList_JSONOmitsHint(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	for _, title := range []string{"alpha", "beta", "gamma"} {
+		createIssue(t, env, pid, title)
+	}
+
+	stdout, stderr, err := runCLIWithErr(t, env, dir, "--json", "list", "--limit", "2")
+	require.NoError(t, err)
+	assert.NotContains(t, stderr, "--limit", "JSON mode must suppress the hint")
+	// stdout should still parse as JSON.
+	var got struct {
+		Issues []map[string]any `json:"issues"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.Len(t, got.Issues, 2)
+}

--- a/internal/daemon/handlers_imports.go
+++ b/internal/daemon/handlers_imports.go
@@ -16,6 +16,12 @@ func registerImportsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		OperationID: "importIssues",
 		Method:      "POST",
 		Path:        "/api/v1/projects/{project_id}/imports",
+		// Imports batch many issues (plus comments and links) into a single
+		// POST. Huma's default 1 MiB cap (huma.go:1378) rejects realistic
+		// migrations from beads/JIRA/etc. — a few hundred issues with
+		// comments easily exceeds 1 MiB. 64 MiB covers ~25k issues at
+		// typical enrichment ratios while still bounding a runaway client.
+		MaxBodyBytes: 64 << 20,
 	}, func(ctx context.Context, in *api.ImportRequest) (*api.ImportResponse, error) {
 		if err := validateActor(in.Body.Actor); err != nil {
 			return nil, err

--- a/internal/daemon/handlers_imports_test.go
+++ b/internal/daemon/handlers_imports_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -285,4 +286,32 @@ func createImportTestProject(t *testing.T, env *testenv.Env, _ string, name stri
 	p, err := env.DB.CreateProject(context.Background(), name)
 	require.NoError(t, err)
 	return p
+}
+
+// TestImportEndpoint_AcceptsLargeBody guards against regressing to huma's
+// default 1 MiB MaxBodyBytes — large beads imports (a few hundred issues with
+// comments) easily exceed 1 MiB, and the importer does all of bd export + per-
+// issue bd comments before POSTing, so a 413 wastes minutes of upstream work.
+func TestImportEndpoint_AcceptsLargeBody(t *testing.T) {
+	env := testenv.New(t)
+	pid := createImportTestProject(t, env, "github.com/wesm/kata", "kata").ID
+	// 1.5 MiB body field puts the serialized request comfortably above
+	// huma's 1 MiB default but well under any reasonable per-endpoint cap.
+	largeBody := strings.Repeat("x", 1500000)
+	req := map[string]any{
+		"actor":  "importer",
+		"source": "beads",
+		"items": []map[string]any{{
+			"external_id": "beads-large",
+			"title":       "Imported",
+			"body":        largeBody,
+			"author":      "alice",
+			"status":      "open",
+			"created_at":  "2026-05-01T10:00:00Z",
+			"updated_at":  "2026-05-01T10:00:00Z",
+		}},
+	}
+	resp, raw := envDoRaw(t, env, http.MethodPost, importEndpointPath(pid), req, nil)
+	require.Equalf(t, http.StatusOK, resp.StatusCode,
+		"large import body rejected (status=%d body=%s)", resp.StatusCode, string(raw))
 }


### PR DESCRIPTION
## Summary

- **daemon**: import endpoint accepts bodies up to 64 MiB (was huma's default 1 MiB). A few hundred imported issues with comments serialize past 1 MiB, and the importer does `bd export` + per-issue `bd comments` before POSTing — so a 413 wasted minutes of upstream work. 64 MiB covers ~25k issues at typical enrichment ratios.
- **cli**: `kata list` default `--limit` is 200 (was 50). When the returned page is exactly `--limit` rows, prints `... showing N (raise --limit to see more)` to stderr so users notice the cap. Suppressed under `--quiet` and `--json` so machine-consumed output stays a single document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)