### PR TITLE
Add kata projects restore command (closes #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ kata projects list
 kata projects show <project>
 kata projects rename <project> <name>
 kata projects merge <source> <target> [--rename-target NAME]
+kata projects remove <project> [--force]
+kata projects restore <project>
 kata export [--project NAME] [--output PATH]
 kata import --input PATH --target PATH [--force]
 ```

--- a/cmd/kata/projects.go
+++ b/cmd/kata/projects.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kata/internal/config"
@@ -25,9 +26,10 @@ type projectAliasRef struct {
 }
 
 type projectRef struct {
-	ID      int64             `json:"id"`
-	Name    string            `json:"name"`
-	Aliases []projectAliasRef `json:"aliases,omitempty"`
+	ID        int64             `json:"id"`
+	Name      string            `json:"name"`
+	DeletedAt *time.Time        `json:"deleted_at,omitempty"`
+	Aliases   []projectAliasRef `json:"aliases,omitempty"`
 }
 
 // shortIDExtensionItem mirrors api.MergeShortIDExtension for decoding the
@@ -43,7 +45,7 @@ type shortIDExtensionItem struct {
 func newProjectsCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "projects", Short: "list and inspect kata projects"}
 	cmd.AddCommand(projectsListCmd(), projectsShowCmd(), projectsRenameCmd(),
-		projectsMergeCmd(), projectsRemoveCmd(), projectsDetachCmd())
+		projectsMergeCmd(), projectsRemoveCmd(), projectsRestoreCmd(), projectsDetachCmd())
 	return cmd
 }
 
@@ -343,6 +345,22 @@ func resolveProjectSelector(ctx context.Context, client *http.Client, baseURL, s
 	if err != nil {
 		return projectRef{}, err
 	}
+	return resolveProjectSelectorFromRefs(selector, projects)
+}
+
+func resolveProjectSelectorIncludingArchived(ctx context.Context, client *http.Client, baseURL, selector string) (projectRef, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return projectRef{}, &cliError{Message: "project selector must be non-empty", Kind: kindValidation, ExitCode: ExitValidation}
+	}
+	projects, err := loadProjectRefsIncludingArchived(ctx, client, baseURL)
+	if err != nil {
+		return projectRef{}, err
+	}
+	return resolveProjectSelectorFromRefs(selector, projects)
+}
+
+func resolveProjectSelectorFromRefs(selector string, projects []projectRef) (projectRef, error) {
 	if id, parseErr := strconv.ParseInt(selector, 10, 64); parseErr == nil {
 		for _, project := range projects {
 			if project.ID == id {
@@ -366,7 +384,19 @@ func resolveProjectSelector(ctx context.Context, client *http.Client, baseURL, s
 }
 
 func loadProjectRefs(ctx context.Context, client *http.Client, baseURL string) ([]projectRef, error) {
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/projects", nil)
+	return loadProjectRefsWithArchived(ctx, client, baseURL, false)
+}
+
+func loadProjectRefsIncludingArchived(ctx context.Context, client *http.Client, baseURL string) ([]projectRef, error) {
+	return loadProjectRefsWithArchived(ctx, client, baseURL, true)
+}
+
+func loadProjectRefsWithArchived(ctx context.Context, client *http.Client, baseURL string, includeArchived bool) ([]projectRef, error) {
+	path := baseURL + "/api/v1/projects"
+	if includeArchived {
+		path += "?include=archived"
+	}
+	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -380,6 +410,9 @@ func loadProjectRefs(ctx context.Context, client *http.Client, baseURL string) (
 		return nil, err
 	}
 	for i := range list.Projects {
+		if list.Projects[i].DeletedAt != nil {
+			continue
+		}
 		status, detail, err := httpDoJSON(ctx, client, http.MethodGet,
 			fmt.Sprintf("%s/api/v1/projects/%d", baseURL, list.Projects[i].ID), nil)
 		if err != nil {
@@ -534,6 +567,67 @@ func projectsRemoveCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "archive even when open issues remain")
 	return cmd
+}
+
+func projectsRestoreCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restore <project>",
+		Short: "restore an archived project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			baseURL, err := ensureDaemon(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := httpClientFor(ctx, baseURL)
+			if err != nil {
+				return err
+			}
+			project, err := resolveProjectSelectorIncludingArchived(ctx, client, baseURL, args[0])
+			if err != nil {
+				return err
+			}
+			actor, _ := resolveActor(flags.As, nil)
+			path := fmt.Sprintf("%s/api/v1/projects/%d/restore?actor=%s",
+				baseURL, project.ID, url.QueryEscape(actor))
+			status, bs, err := httpDoJSON(ctx, client, http.MethodPost, path, nil)
+			if err != nil {
+				return err
+			}
+			if status >= 400 {
+				return apiErrFromBody(status, bs)
+			}
+			if flags.JSON {
+				var buf bytes.Buffer
+				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
+					return err
+				}
+				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+				return err
+			}
+			var b struct {
+				Project struct {
+					ID   int64  `json:"id"`
+					Name string `json:"name"`
+				} `json:"project"`
+				Changed bool `json:"changed"`
+			}
+			if err := json.Unmarshal(bs, &b); err != nil {
+				return err
+			}
+			if !b.Changed {
+				_, err = fmt.Fprintf(cmd.OutOrStdout(),
+					"project #%d (%s) is already active\n",
+					b.Project.ID, textsafe.Line(b.Project.Name))
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(),
+				"restored project #%d (%s); run 'kata init' in the workspace to reattach an alias\n",
+				b.Project.ID, textsafe.Line(b.Project.Name))
+			return err
+		},
+	}
 }
 
 // projectsDetachCmd drops a single alias from a project: DELETE

--- a/cmd/kata/projects_test.go
+++ b/cmd/kata/projects_test.go
@@ -32,6 +32,36 @@ func TestProjects_ListJSONHasNoNextIssueNumber(t *testing.T) {
 	}
 }
 
+func TestProjects_RestoreArchivedProjectByName(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	p, err := env.DB.CreateProject(ctx, "retry-import")
+	require.NoError(t, err)
+	_, err = env.DB.AttachAlias(ctx, p.ID, "github.com/wesm/retry-import", "git", "/tmp/retry-import")
+	require.NoError(t, err)
+	_, _, err = env.DB.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: p.ID, Actor: "tester"})
+	require.NoError(t, err)
+
+	out := requireCmdOutput(t, env, "projects", "restore", "retry-import")
+	assert.Contains(t, out, "restored project #"+itoa(p.ID)+" (retry-import)")
+	assert.Contains(t, out, "run 'kata init' in the workspace to reattach an alias")
+
+	got, err := env.DB.ProjectByName(ctx, "retry-import")
+	require.NoError(t, err)
+	assert.Equal(t, p.ID, got.ID)
+	assert.Nil(t, got.DeletedAt)
+}
+
+func TestProjects_RestoreActiveProjectIsNoop(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	p, err := env.DB.CreateProject(ctx, "active")
+	require.NoError(t, err)
+
+	out := requireCmdOutput(t, env, "projects", "restore", "active")
+	assert.Contains(t, out, "project #"+itoa(p.ID)+" (active) is already active")
+}
+
 // TestProjects_ResetCounterCommandIsAbsent guards against the reset-counter
 // command being reintroduced after the v8 cutover removed its underlying
 // next_issue_number column (spec §9.5). The daemon's 404 on the endpoint is

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -556,6 +556,23 @@ type RemoveProjectResponse struct {
 	}
 }
 
+// RestoreProjectRequest is POST /api/v1/projects/{id}/restore. The action is
+// idempotent: already-active projects return changed=false with no event.
+type RestoreProjectRequest struct {
+	ProjectID int64  `path:"project_id" required:"true"`
+	Actor     string `query:"actor" required:"true"`
+}
+
+// RestoreProjectResponse carries the active project, optional project.restored
+// event, and changed=false for retry/no-op restores.
+type RestoreProjectResponse struct {
+	Body struct {
+		Project ProjectOut `json:"project"`
+		Event   *db.Event  `json:"event"`
+		Changed bool       `json:"changed"`
+	}
+}
+
 // DetachProjectAliasRequest is DELETE /api/v1/projects/{id}/aliases/{alias_id}.
 // Force=true overrides the last-alias refusal.
 type DetachProjectAliasRequest struct {

--- a/internal/daemon/handlers_projects.go
+++ b/internal/daemon/handlers_projects.go
@@ -101,7 +101,15 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 	}, func(ctx context.Context, in *struct {
 		Include string `query:"include"`
 	}) (*api.ListProjectsResponse, error) {
-		ps, err := cfg.DB.ListProjects(ctx)
+		var (
+			ps  []db.Project
+			err error
+		)
+		if includeContains(in.Include, "archived") {
+			ps, err = cfg.DB.ListProjectsIncludingArchived(ctx)
+		} else {
+			ps, err = cfg.DB.ListProjects(ctx)
+		}
 		if err != nil {
 			return nil, api.NewError(500, "internal", err.Error(), "", nil)
 		}
@@ -248,6 +256,32 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		out := &api.RemoveProjectResponse{}
 		out.Body.Project = dbProjectToOut(project)
 		out.Body.Event = evt
+		return out, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "restoreProject",
+		Method:      "POST",
+		Path:        "/api/v1/projects/{project_id}/restore",
+	}, func(ctx context.Context, in *api.RestoreProjectRequest) (*api.RestoreProjectResponse, error) {
+		if err := validateActor(in.Actor); err != nil {
+			return nil, err
+		}
+		project, evt, changed, err := cfg.DB.RestoreProject(ctx, in.ProjectID, in.Actor)
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, api.NewError(404, "project_not_found", "project not found", "", nil)
+		}
+		if err != nil {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		if changed && evt != nil {
+			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: project.ID})
+			cfg.Hooks.Enqueue(*evt)
+		}
+		out := &api.RestoreProjectResponse{}
+		out.Body.Project = dbProjectToOut(project)
+		out.Body.Event = evt
+		out.Body.Changed = changed
 		return out, nil
 	})
 
@@ -767,7 +801,7 @@ func upsertProject(ctx context.Context, store *db.DB, name string) (db.Project, 
 	if archived, archErr := store.ProjectByNameIncludingArchived(ctx, name); archErr == nil && archived.DeletedAt != nil {
 		return db.Project{}, false, api.NewError(409, "project_archived",
 			"project with this name was archived via `kata projects remove`",
-			"restore the project (not yet supported) or pick a different name",
+			`run "kata projects restore `+name+`" or pick a different name`,
 			map[string]any{"name": name, "deleted_at": archived.DeletedAt})
 	}
 	created, err := store.CreateProject(ctx, name)

--- a/internal/daemon/handlers_projects_test.go
+++ b/internal/daemon/handlers_projects_test.go
@@ -182,6 +182,80 @@ func TestResolve_ByAliasInput_NotRegistered(t *testing.T) {
 	assertAPIError(t, resp.StatusCode, bs, http.StatusNotFound, "project_not_initialized")
 }
 
+func TestListProjects_IncludeArchived(t *testing.T) {
+	ts, h := startDefaultTestServer(t)
+	active, err := h.db.CreateProject(t.Context(), "active")
+	require.NoError(t, err)
+	archived, err := h.db.CreateProject(t.Context(), "archived")
+	require.NoError(t, err)
+	_, _, err = h.db.RemoveProject(t.Context(), db.RemoveProjectParams{ProjectID: archived.ID, Actor: "tester"})
+	require.NoError(t, err)
+
+	resp, bs := doReq(t, ts, http.MethodGet, "/api/v1/projects?include=archived", nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
+
+	var body struct {
+		Projects []struct {
+			ID        int64   `json:"id"`
+			Name      string  `json:"name"`
+			DeletedAt *string `json:"deleted_at"`
+		} `json:"projects"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &body))
+	require.Len(t, body.Projects, 2)
+	assert.Equal(t, active.ID, body.Projects[0].ID)
+	assert.Nil(t, body.Projects[0].DeletedAt)
+	assert.Equal(t, archived.ID, body.Projects[1].ID)
+	assert.NotNil(t, body.Projects[1].DeletedAt)
+}
+
+func TestRestoreProject_RestoresArchivedProject(t *testing.T) {
+	ts, h := startDefaultTestServer(t)
+	p, err := h.db.CreateProject(t.Context(), "archived")
+	require.NoError(t, err)
+	_, _, err = h.db.RemoveProject(t.Context(), db.RemoveProjectParams{ProjectID: p.ID, Actor: "tester"})
+	require.NoError(t, err)
+
+	resp, bs := postJSON(t, ts, "/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+"/restore?actor=tester", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
+
+	var body struct {
+		Project struct {
+			ID        int64   `json:"id"`
+			DeletedAt *string `json:"deleted_at"`
+		} `json:"project"`
+		Event   *db.Event `json:"event"`
+		Changed bool      `json:"changed"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &body))
+	assert.True(t, body.Changed)
+	assert.Equal(t, p.ID, body.Project.ID)
+	assert.Nil(t, body.Project.DeletedAt)
+	require.NotNil(t, body.Event)
+	assert.Equal(t, "project.restored", body.Event.Type)
+}
+
+func TestRestoreProject_ActiveProjectIsNoop(t *testing.T) {
+	ts, h := startDefaultTestServer(t)
+	p, err := h.db.CreateProject(t.Context(), "active")
+	require.NoError(t, err)
+
+	resp, bs := postJSON(t, ts, "/api/v1/projects/"+strconv.FormatInt(p.ID, 10)+"/restore?actor=tester", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
+
+	var body struct {
+		Project struct {
+			ID int64 `json:"id"`
+		} `json:"project"`
+		Event   *db.Event `json:"event"`
+		Changed bool      `json:"changed"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &body))
+	assert.False(t, body.Changed)
+	assert.Nil(t, body.Event)
+	assert.Equal(t, p.ID, body.Project.ID)
+}
+
 // TestResolve_AliasMissNameHit_FirstSeenAttach handles the case
 // where a client has a .kata.toml (so it sends a name) and a git
 // workspace whose alias is not yet attached on this daemon (e.g. first

--- a/internal/db/queries_projects_remove.go
+++ b/internal/db/queries_projects_remove.go
@@ -117,6 +117,68 @@ func (d *DB) RemoveProject(ctx context.Context, p RemoveProjectParams) (Project,
 	return updated, &evt, nil
 }
 
+// RestoreProject clears projects.deleted_at and emits one project.restored
+// event. Active projects return a retry-safe no-op envelope: the project row,
+// nil event, and changed=false. Unknown projects return ErrNotFound.
+func (d *DB) RestoreProject(ctx context.Context, projectID int64, actor string) (Project, *Event, bool, error) {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return Project{}, nil, false, fmt.Errorf("begin restore project: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	project, err := scanProject(tx.QueryRowContext(ctx, projectSelect+` WHERE id = ?`, projectID))
+	if err != nil {
+		return Project{}, nil, false, err
+	}
+	if project.DeletedAt == nil {
+		if err := tx.Commit(); err != nil {
+			return Project{}, nil, false, fmt.Errorf("commit restore project noop: %w", err)
+		}
+		return project, nil, false, nil
+	}
+
+	res, err := tx.ExecContext(ctx,
+		`UPDATE projects SET deleted_at = NULL WHERE id = ? AND deleted_at IS NOT NULL`,
+		project.ID)
+	if err != nil {
+		return Project{}, nil, false, fmt.Errorf("restore project: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return Project{}, nil, false, fmt.Errorf("restore project rows affected: %w", err)
+	}
+	if n == 0 {
+		if err := tx.Commit(); err != nil {
+			return Project{}, nil, false, fmt.Errorf("commit restore project race noop: %w", err)
+		}
+		updated, err := d.ProjectByID(ctx, project.ID)
+		if err != nil {
+			return Project{}, nil, false, err
+		}
+		return updated, nil, false, nil
+	}
+
+	evt, err := d.insertEventTx(ctx, tx, eventInsert{
+		ProjectID:   project.ID,
+		ProjectName: project.Name,
+		Type:        "project.restored",
+		Actor:       actor,
+		Payload:     "{}",
+	})
+	if err != nil {
+		return Project{}, nil, false, err
+	}
+	updated, err := scanProject(tx.QueryRowContext(ctx, projectSelect+` WHERE id = ?`, project.ID))
+	if err != nil {
+		return Project{}, nil, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Project{}, nil, false, fmt.Errorf("commit restore project: %w", err)
+	}
+	return updated, &evt, true, nil
+}
+
 // DetachAliasParams identifies a single alias to drop. ProjectID scopes the
 // lookup to a specific project so a stale handler preflight cannot resolve
 // to one project_id and then race a reassignment that points alias_id at a

--- a/internal/db/queries_projects_remove_test.go
+++ b/internal/db/queries_projects_remove_test.go
@@ -125,6 +125,42 @@ func TestRemoveProject_ExcludedFromListAndResolve(t *testing.T) {
 	require.NotNil(t, got.DeletedAt)
 }
 
+func TestRestoreProject_ReactivatesArchivedProjectAndEmitsEvent(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	p, err := d.CreateProject(ctx, "restore-me")
+	require.NoError(t, err)
+	_, _, err = d.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: p.ID, Actor: "tester"})
+	require.NoError(t, err)
+
+	got, evt, changed, err := d.RestoreProject(ctx, p.ID, "tester")
+	require.NoError(t, err)
+	assert.True(t, changed)
+	require.Nil(t, got.DeletedAt)
+	require.NotNil(t, evt)
+	assert.Equal(t, "project.restored", evt.Type)
+	assert.Equal(t, p.ID, evt.ProjectID)
+	assert.True(t, uid.Valid(evt.UID))
+
+	active, err := d.ProjectByName(ctx, "restore-me")
+	require.NoError(t, err)
+	assert.Equal(t, p.ID, active.ID)
+}
+
+func TestRestoreProject_ActiveProjectIsNoop(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	p, err := d.CreateProject(ctx, "already-active")
+	require.NoError(t, err)
+
+	got, evt, changed, err := d.RestoreProject(ctx, p.ID, "tester")
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Nil(t, evt)
+	assert.Equal(t, p.ID, got.ID)
+	assert.Nil(t, got.DeletedAt)
+}
+
 // TestDetachProjectAlias_RemovesOneAndEmitsEvent pins the happy path: with
 // two aliases, one detaches cleanly and emits project.alias_removed.
 func TestDetachProjectAlias_RemovesOneAndEmitsEvent(t *testing.T) {


### PR DESCRIPTION
## Summary

- New `kata projects restore <project>` command and matching `POST /api/v1/projects/{id}/restore` endpoint that clears `deleted_at` and emits a `project.restored` event.
- `GET /api/v1/projects?include=archived` returns archived rows so the CLI can resolve archived names; the default list view still hides them.
- `project_archived` error hint now points users at the new command instead of saying restore is unsupported.
- Restore is idempotent: calling it on an active project returns `changed=false` with no event.

Closes #51.