### PR TITLE
Allow trusted private-network bearer auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,16 +33,20 @@ For long-running work, `kata events --tail` streams NDJSON.
 
 A daemon can serve clients on other hosts over a private network:
 
-- Server: `kata daemon start --listen 100.64.0.5:7777`, or set
+- Server: for mutable remote access, set `[auth].token` plus
+  `[auth].trust_private_network = true` in `<KATA_HOME>/config.toml`, or
+  export `KATA_AUTH_TOKEN` plus `KATA_TRUST_PRIVATE_NETWORK=1`, then run
+  `kata daemon start --listen 100.64.0.5:7777`. Set
   `listen = "100.64.0.5:7777"` in `<KATA_HOME>/config.toml` so every
   daemon (including the auto-started one) binds TCP.
 - Client: `export KATA_SERVER=http://100.64.0.5:7777` or commit a
   gitignored `.kata.local.toml` with `[server] url = "..."` next to
   `.kata.toml`. `KATA_SERVER` env wins.
-- Optional bearer auth: set `[auth].token` plus
-  `[auth].trust_private_network = true` in `<KATA_HOME>/config.toml`, or use
-  `KATA_AUTH_TOKEN` plus `KATA_TRUST_PRIVATE_NETWORK=1`. The trust flag is
-  required for non-loopback HTTP because the daemon does not terminate TLS.
+- Unauthenticated private-network mode is `--insecure-readonly`, which permits
+  GET requests only. Mutations and the event stream require bearer auth.
+- Trusted plaintext bearer targets must be literal non-public IPs (loopback,
+  RFC1918, CGNAT, link-local, ULA). Public IPs and DNS hostnames require HTTPS
+  termination or an SSH tunnel.
 - Init and resolution are both path-free whenever the client can
   derive the project name locally (existing `.kata.toml`, `--project`, or a
   git workspace): the client sends `name` and writes `.kata.toml` itself; the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ start of each session for the agent contract; the short version:
 
 For long-running work, `kata events --tail` streams NDJSON.
 
-## Remote-client mode (no auth)
+## Remote-client mode (private network)
 
 A daemon can serve clients on other hosts over a private network:
 
@@ -39,11 +39,14 @@ A daemon can serve clients on other hosts over a private network:
 - Client: `export KATA_SERVER=http://100.64.0.5:7777` or commit a
   gitignored `.kata.local.toml` with `[server] url = "..."` next to
   `.kata.toml`. `KATA_SERVER` env wins.
+- Optional bearer auth: set `[auth].token` plus
+  `[auth].trust_private_network = true` in `<KATA_HOME>/config.toml`, or use
+  `KATA_AUTH_TOKEN` plus `KATA_TRUST_PRIVATE_NETWORK=1`. The trust flag is
+  required for non-loopback HTTP because the daemon does not terminate TLS.
 - Init and resolution are both path-free whenever the client can
   derive the project name locally (existing `.kata.toml`, `--project`, or a
   git workspace): the client sends `name` and writes `.kata.toml` itself; the
   daemon never stats the client's filesystem.
   `kata init` falls back to a path-based request only when none of
   those sources are available, so the daemon (or its absence) emits
-  the existing validation error. No auth yet — network ACLs are the
-  boundary.
+  the existing validation error.

--- a/README.md
+++ b/README.md
@@ -488,13 +488,18 @@ A kata daemon can serve clients on other hosts over a private network
 (loopback, RFC1918, CGNAT, link-local, ULA — public addresses are rejected):
 
 ```sh
-kata daemon start --listen 100.64.0.5:7777
+KATA_AUTH_TOKEN=change-me KATA_TRUST_PRIVATE_NETWORK=1 \
+  kata daemon start --listen 100.64.0.5:7777
 ```
 
-Or set the address persistently in `<KATA_HOME>/config.toml`:
+Or set the address and auth persistently in `<KATA_HOME>/config.toml`:
 
 ```toml
 listen = "100.64.0.5:7777"
+
+[auth]
+token = "change-me"
+trust_private_network = true
 ```
 
 The CLI flag wins over the config file when both are present. Auto-started
@@ -523,23 +528,14 @@ url = "http://100.64.0.5:7777"
 `kata init` adds `.kata.local.toml` to `.gitignore` automatically.
 `KATA_SERVER` wins over the file when both are set.
 
-To require bearer auth on the private-network listener, set a token and
-explicitly assert that the network path already provides confidentiality and
-integrity:
-
-```toml
-listen = "100.64.0.5:7777"
-
-[auth]
-token = "change-me"
-trust_private_network = true
-```
-
-The environment equivalents are `KATA_AUTH_TOKEN` and
+The environment auth equivalents are `KATA_AUTH_TOKEN` and
 `KATA_TRUST_PRIVATE_NETWORK=1`. Clients use the same token sources. Mutable
 non-loopback HTTP requires both `token` and `trust_private_network`; without
 the trust flag, kata refuses the token-protected listener because the daemon
-does not terminate TLS.
+does not terminate TLS. Plain HTTP with trusted bearer auth is limited to
+literal non-public addresses: loopback, RFC1918, CGNAT, link-local, and ULA.
+Public IPs and DNS hostnames are rejected; use HTTPS through a reverse proxy
+or an SSH tunnel for those shapes.
 
 For unauthenticated private-network experiments, `kata daemon start --listen
 100.64.0.5:7777 --insecure-readonly` permits GET requests only; mutations and

--- a/README.md
+++ b/README.md
@@ -536,12 +536,17 @@ trust_private_network = true
 ```
 
 The environment equivalents are `KATA_AUTH_TOKEN` and
-`KATA_TRUST_PRIVATE_NETWORK=1`. Clients use the same token sources. Without
-`trust_private_network`, kata refuses a token-protected non-loopback HTTP
-listener because the daemon does not terminate TLS. Without a token, this mode
-remains unauthenticated and network ACLs (firewall, VPN, tailnet) are the
-access boundary. Default behavior (no flag, no env, no local file) is
-unchanged: a local Unix-socket daemon is auto-started on demand.
+`KATA_TRUST_PRIVATE_NETWORK=1`. Clients use the same token sources. Mutable
+non-loopback HTTP requires both `token` and `trust_private_network`; without
+the trust flag, kata refuses the token-protected listener because the daemon
+does not terminate TLS.
+
+For unauthenticated private-network experiments, `kata daemon start --listen
+100.64.0.5:7777 --insecure-readonly` permits GET requests only; mutations and
+the event stream still require authentication. Network ACLs (firewall, VPN,
+tailnet) are the access boundary in that read-only dev mode. Default behavior
+(no flag, no env, no local file) is unchanged: a local Unix-socket daemon is
+auto-started on demand.
 
 ## Backup and restore
 

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Future shared mode should be a distinct deployment:
 
 The local daemon should not be exposed directly to a LAN or public network.
 
-### Remote daemon (opt-in, no auth)
+### Remote daemon (opt-in private network)
 
 A kata daemon can serve clients on other hosts over a private network
 (loopback, RFC1918, CGNAT, link-local, ULA — public addresses are rejected):
@@ -523,9 +523,25 @@ url = "http://100.64.0.5:7777"
 `kata init` adds `.kata.local.toml` to `.gitignore` automatically.
 `KATA_SERVER` wins over the file when both are set.
 
-There is no authentication in this mode — network ACLs (firewall, VPN,
-tailnet) are the access boundary. Default behavior (no flag, no env, no local
-file) is unchanged: a local Unix-socket daemon is auto-started on demand.
+To require bearer auth on the private-network listener, set a token and
+explicitly assert that the network path already provides confidentiality and
+integrity:
+
+```toml
+listen = "100.64.0.5:7777"
+
+[auth]
+token = "change-me"
+trust_private_network = true
+```
+
+The environment equivalents are `KATA_AUTH_TOKEN` and
+`KATA_TRUST_PRIVATE_NETWORK=1`. Clients use the same token sources. Without
+`trust_private_network`, kata refuses a token-protected non-loopback HTTP
+listener because the daemon does not terminate TLS. Without a token, this mode
+remains unauthenticated and network ACLs (firewall, VPN, tailnet) are the
+access boundary. Default behavior (no flag, no env, no local file) is
+unchanged: a local Unix-socket daemon is auto-started on demand.
 
 ## Backup and restore
 

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -209,6 +209,9 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	if err := daemon.CheckAuthStartup(listen, dcfg.Auth, insecureReadonly); err != nil {
 		return err
 	}
+	if msg, ok := daemon.TrustPrivateNetworkWarning(listen, dcfg.Auth); ok {
+		fmt.Fprintln(os.Stderr, msg)
+	}
 	if err := ns.EnsureDirs(); err != nil {
 		return err
 	}

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -116,12 +116,14 @@ func applyDaemonConfigEnv(cfg *DaemonConfig) {
 	if v := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")); v != "" {
 		cfg.Auth.Token = v
 	}
-	if envTruthy("KATA_TRUST_PRIVATE_NETWORK") {
+	if EnvTruthy("KATA_TRUST_PRIVATE_NETWORK") {
 		cfg.Auth.TrustPrivateNetwork = true
 	}
 }
 
-func envTruthy(name string) bool {
+// EnvTruthy reports whether an environment variable is set to a recognized
+// true value for kata config overlays.
+func EnvTruthy(name string) bool {
 	v := strings.TrimSpace(os.Getenv(name))
 	return v == "1" || strings.EqualFold(v, "true")
 }

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -32,13 +32,15 @@ type DaemonConfig struct {
 
 // AuthConfig is the [auth] block of <KATA_HOME>/config.toml. An empty
 // Token disables bearer auth — appropriate for Unix-socket and loopback-TCP
-// deployments; non-loopback TCP requires a token unless the daemon is
-// started with --insecure-readonly.
+// deployments; non-loopback TCP requires either --insecure-readonly with no
+// token, or a token plus TrustPrivateNetwork.
 //
 // KATA_AUTH_TOKEN, when set, overrides the TOML value. Use it for
 // ephemeral or CI-only tokens that should never be persisted to disk.
+// KATA_TRUST_PRIVATE_NETWORK=1 is equivalent to trust_private_network = true.
 type AuthConfig struct {
-	Token string `toml:"token"`
+	Token               string `toml:"token"`
+	TrustPrivateNetwork bool   `toml:"trust_private_network"`
 }
 
 // TUIConfig holds TUI user preferences from <KATA_HOME>/config.toml.
@@ -86,7 +88,9 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // path is derived from KATA_HOME, not user input
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return &DaemonConfig{}, nil
+			var cfg DaemonConfig
+			applyDaemonConfigEnv(&cfg)
+			return &cfg, nil
 		}
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
@@ -104,8 +108,20 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 	}
 	cfg.Listen = strings.TrimSpace(cfg.Listen)
 	cfg.Auth.Token = strings.TrimSpace(cfg.Auth.Token)
+	applyDaemonConfigEnv(&cfg)
+	return &cfg, nil
+}
+
+func applyDaemonConfigEnv(cfg *DaemonConfig) {
 	if v := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")); v != "" {
 		cfg.Auth.Token = v
 	}
-	return &cfg, nil
+	if envTruthy("KATA_TRUST_PRIVATE_NETWORK") {
+		cfg.Auth.TrustPrivateNetwork = true
+	}
+}
+
+func envTruthy(name string) bool {
+	v := strings.TrimSpace(os.Getenv(name))
+	return v == "1" || strings.EqualFold(v, "true")
 }

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -104,6 +104,30 @@ func TestReadDaemonConfig_ReadsAuthToken(t *testing.T) {
 	assert.Equal(t, "abc-123", cfg.Auth.Token)
 }
 
+func TestReadDaemonConfig_ReadsAuthTrustPrivateNetwork(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth]\ntrust_private_network = true\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.True(t, cfg.Auth.TrustPrivateNetwork)
+}
+
+func TestReadDaemonConfig_AuthTrustPrivateNetworkEnvOverridesTOML(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth]\ntrust_private_network = false\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.True(t, cfg.Auth.TrustPrivateNetwork)
+}
+
 func TestReadDaemonConfig_AuthTokenEnvOverridesTOML(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
@@ -115,6 +139,15 @@ func TestReadDaemonConfig_AuthTokenEnvOverridesTOML(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "from-env", cfg.Auth.Token,
 		"KATA_AUTH_TOKEN must override config.toml")
+}
+
+func TestReadDaemonConfig_AuthTokenEnvWorksWithoutTOML(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_AUTH_TOKEN", "from-env")
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "from-env", cfg.Auth.Token)
 }
 
 func TestReadDaemonConfig_AuthTokenAbsent(t *testing.T) {

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -121,6 +121,8 @@ func CheckAuthStartup(listen string, auth config.AuthConfig, insecureReadonly bo
 	})
 }
 
+// TrustPrivateNetworkWarning returns the startup warning shown when the daemon
+// is configured to send bearer tokens over trusted private-network HTTP.
 func TrustPrivateNetworkWarning(listen string, auth config.AuthConfig) (string, bool) {
 	if !isNonLoopbackTCP(listen) || auth.Token == "" || !auth.TrustPrivateNetwork {
 		return "", false

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -20,13 +20,15 @@ const (
 )
 
 // authPolicy is the resolved auth posture at daemon start. Token == "" disables
-// bearer auth; InsecureReadonly is the dev escape hatch that allows GETs on
-// non-loopback TCP without a token. Both fields are also surfaced through
-// ServerConfig (see Task B3); this struct exists so the middleware itself
-// does not depend on ServerConfig.
+// bearer auth; TrustPrivateNetwork is the explicit operator opt-in that allows
+// token auth on non-loopback private-network TCP; InsecureReadonly is the dev
+// escape hatch that allows GETs on non-loopback TCP without a token. These
+// fields are also surfaced through ServerConfig; this struct exists so the
+// middleware itself does not depend on ServerConfig.
 type authPolicy struct {
-	Token            string
-	InsecureReadonly bool
+	Token               string
+	TrustPrivateNetwork bool
+	InsecureReadonly    bool
 }
 
 // requireBearer returns an HTTP middleware that enforces bearer-token auth
@@ -79,9 +81,10 @@ func requireBearer(p authPolicy) func(http.Handler) http.Handler {
 // convention as runDaemonWithListen: "" means Unix socket; "host:port"
 // means TCP. The matrix on non-loopback TCP is:
 //
-//	Token != ""                       -> REFUSE (token would travel in cleartext)
-//	Token == "" &&  InsecureReadonly  -> permit (dev-only GET access)
-//	Token == "" && !InsecureReadonly  -> REFUSE (would expose mutations to the LAN)
+//	Token != "" && TrustPrivateNetwork -> permit (operator accepts private-network confidentiality)
+//	Token != "" && !TrustPrivateNetwork -> REFUSE (token would travel in cleartext)
+//	Token == "" &&  InsecureReadonly   -> permit (dev-only GET access)
+//	Token == "" && !InsecureReadonly   -> REFUSE (would expose mutations to the LAN)
 //
 // The daemon does not terminate TLS, so a bearer token on plaintext non-
 // loopback HTTP is a passive-capture risk. Operators wanting cross-host
@@ -93,6 +96,9 @@ func checkAuthStartup(listen string, p authPolicy) error {
 		return nil
 	}
 	if p.Token != "" {
+		if p.TrustPrivateNetwork {
+			return nil
+		}
 		return fmt.Errorf("non-loopback TCP listen %q with a bearer token is not "+
 			"supported — the daemon does not terminate TLS, so the token would "+
 			"travel over plaintext HTTP; bind to a Unix socket or 127.0.0.1 and "+
@@ -109,8 +115,18 @@ func checkAuthStartup(listen string, p authPolicy) error {
 // CheckAuthStartup is the exported form used by the CLI entry point.
 func CheckAuthStartup(listen string, auth config.AuthConfig, insecureReadonly bool) error {
 	return checkAuthStartup(listen, authPolicy{
-		Token: auth.Token, InsecureReadonly: insecureReadonly,
+		Token:               auth.Token,
+		TrustPrivateNetwork: auth.TrustPrivateNetwork,
+		InsecureReadonly:    insecureReadonly,
 	})
+}
+
+func TrustPrivateNetworkWarning(listen string, auth config.AuthConfig) (string, bool) {
+	if !isNonLoopbackTCP(listen) || auth.Token == "" || !auth.TrustPrivateNetwork {
+		return "", false
+	}
+	return "kata daemon: WARNING: listening on non-loopback TCP with bearer auth; " +
+		"operator has asserted private-network confidentiality.", true
 }
 
 // isNonLoopbackTCP reports whether listen designates a TCP bind that's

--- a/internal/daemon/auth_startup_test.go
+++ b/internal/daemon/auth_startup_test.go
@@ -57,6 +57,45 @@ func TestAuthStartupGuard_TokenOnNonLoopback_Refuses(t *testing.T) {
 	}
 }
 
+func TestAuthStartupGuard_TokenOnNonLoopback_TrustPrivateNetwork_Permitted(t *testing.T) {
+	p := authPolicy{Token: "tok", TrustPrivateNetwork: true}
+	require.NoError(t, checkAuthStartup("100.64.0.5:7777", p))
+	require.NoError(t, checkAuthStartup("192.168.1.20:7777", p))
+}
+
+func TestAuthStartupGuard_TrustPrivateNetworkWithoutToken_StillRefuses(t *testing.T) {
+	err := checkAuthStartup("100.64.0.5:7777",
+		authPolicy{TrustPrivateNetwork: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-loopback TCP")
+}
+
+func TestTrustPrivateNetworkWarning(t *testing.T) {
+	msg, ok := TrustPrivateNetworkWarning("100.64.0.5:7777",
+		config.AuthConfig{Token: "tok", TrustPrivateNetwork: true})
+	require.True(t, ok)
+	assert.Contains(t, msg, "WARNING")
+	assert.Contains(t, msg, "non-loopback")
+	assert.Contains(t, msg, "private-network confidentiality")
+}
+
+func TestTrustPrivateNetworkWarning_OnlyWhenEffective(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		listen string
+		auth   config.AuthConfig
+	}{
+		{name: "loopback", listen: "127.0.0.1:7777", auth: config.AuthConfig{Token: "tok", TrustPrivateNetwork: true}},
+		{name: "no token", listen: "100.64.0.5:7777", auth: config.AuthConfig{TrustPrivateNetwork: true}},
+		{name: "no trust", listen: "100.64.0.5:7777", auth: config.AuthConfig{Token: "tok"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := TrustPrivateNetworkWarning(tc.listen, tc.auth)
+			assert.False(t, ok)
+		})
+	}
+}
+
 // TestAuthStartupGuard_TokenOnNonLoopback_InsecureReadonly_StillRefuses
 // covers the corner case where the operator combines a token with
 // --insecure-readonly on a non-loopback bind. The token would still leak
@@ -105,10 +144,11 @@ func TestAuthStartupGuard_LocalhostHostname_NoTokenOK(t *testing.T) {
 
 func TestServerConfig_AuthPolicyThreaded(t *testing.T) {
 	cfg := ServerConfig{
-		Auth:             config.AuthConfig{Token: "tok-123"},
+		Auth:             config.AuthConfig{Token: "tok-123", TrustPrivateNetwork: true},
 		InsecureReadonly: false,
 	}
 	got := cfg.authPolicy()
 	assert.Equal(t, "tok-123", got.Token)
+	assert.True(t, got.TrustPrivateNetwork)
 	assert.False(t, got.InsecureReadonly)
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -50,7 +50,11 @@ type ServerConfig struct {
 // middleware consumes. Keeping the conversion here means the middleware
 // stays unaware of ServerConfig and config.AuthConfig.
 func (c ServerConfig) authPolicy() authPolicy {
-	return authPolicy{Token: c.Auth.Token, InsecureReadonly: c.InsecureReadonly}
+	return authPolicy{
+		Token:               c.Auth.Token,
+		TrustPrivateNetwork: c.Auth.TrustPrivateNetwork,
+		InsecureReadonly:    c.InsecureReadonly,
+	}
 }
 
 // CloseThrottlePolicy is the runtime form of [close.throttle] in

--- a/internal/daemonclient/auth.go
+++ b/internal/daemonclient/auth.go
@@ -25,14 +25,20 @@ import (
 // "no token" so the request fails with a clean 401 rather than a noisy
 // client-side decode error.
 func resolveAuthToken() string {
+	return resolveAuthConfig().Token
+}
+
+func resolveAuthConfig() config.AuthConfig {
+	envToken := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
+	envTrust := envTruthy("KATA_TRUST_PRIVATE_NETWORK")
 	if v := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")); v != "" {
-		return v
+		envToken = v
 	}
 	cfg, err := config.ReadDaemonConfig()
 	if err != nil || cfg == nil {
-		return ""
+		return config.AuthConfig{Token: envToken, TrustPrivateNetwork: envTrust}
 	}
-	return cfg.Auth.Token
+	return cfg.Auth
 }
 
 // bearerTransport wraps an http.RoundTripper and injects
@@ -56,9 +62,10 @@ func resolveAuthToken() string {
 // though the redirected request "looks safe" by transport-encryption
 // alone.
 type bearerTransport struct {
-	base   http.RoundTripper
-	token  string
-	origin string
+	base                http.RoundTripper
+	token               string
+	origin              string
+	trustPrivateNetwork bool
 }
 
 func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -71,7 +78,7 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// the same transport, and we would attach the token to the redirected
 	// request. Re-validating req.URL here covers both initial requests and
 	// follow-up redirects without trusting the client redirect policy.
-	if err := checkBearerTargetSafeURL(req.URL); err != nil {
+	if err := checkBearerTargetSafeURL(req.URL, t.trustPrivateNetwork); err != nil {
 		return nil, err
 	}
 	if reqOrigin := req.URL.Scheme + "://" + req.URL.Host; reqOrigin != t.origin {
@@ -90,14 +97,20 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // A nil base falls back to http.DefaultTransport — matching net/http's
 // own zero-value behavior when *http.Client.Transport is nil. origin
 // is the scheme://host the bearer is pinned to (see bearerTransport).
-func withBearer(base http.RoundTripper, token, origin string) http.RoundTripper {
+func withBearer(base http.RoundTripper, token, origin string, trustPrivateNetwork ...bool) http.RoundTripper {
 	if token == "" {
 		return base
 	}
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	return &bearerTransport{base: base, token: token, origin: origin}
+	trust := len(trustPrivateNetwork) > 0 && trustPrivateNetwork[0]
+	return &bearerTransport{
+		base:                base,
+		token:               token,
+		origin:              origin,
+		trustPrivateNetwork: trust,
+	}
 }
 
 // checkBearerTargetSafe refuses to attach a bearer token to a baseURL that
@@ -105,12 +118,13 @@ func withBearer(base http.RoundTripper, token, origin string) http.RoundTripper 
 // origin the bearer should be pinned to for subsequent requests. Thin wrapper
 // over checkBearerTargetSafeURL that accepts a string base URL — used at
 // client construction time to fail fast before any request is built.
-func checkBearerTargetSafe(baseURL string) (string, error) {
+func checkBearerTargetSafe(baseURL string, trustPrivateNetwork ...bool) (string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return "", fmt.Errorf("parse base URL %q for bearer-token safety check: %w", baseURL, err)
 	}
-	if err := checkBearerTargetSafeURL(u); err != nil {
+	trust := len(trustPrivateNetwork) > 0 && trustPrivateNetwork[0]
+	if err := checkBearerTargetSafeURL(u, trust); err != nil {
 		return "", err
 	}
 	return u.Scheme + "://" + u.Host, nil
@@ -122,11 +136,12 @@ func checkBearerTargetSafe(baseURL string) (string, error) {
 const unixSentinelHost = "kata.invalid"
 
 // checkBearerTargetSafeURL is the per-request form of the bearer-safety check.
-// Safe targets are the Unix-socket sentinel host, HTTPS schemes, and HTTP
-// loopback addresses (including "localhost", "127.0.0.1", "[::1]"). Defense
-// in depth on top of checkAuthStartup so a redirect-following client cannot
-// leak the token to a plaintext non-loopback URL.
-func checkBearerTargetSafeURL(u *url.URL) error {
+// Safe targets are the Unix-socket sentinel host, HTTPS schemes, HTTP loopback
+// addresses (including "localhost", "127.0.0.1", "[::1]"), and plaintext
+// non-loopback URLs only when the operator opted into private-network trust.
+// Defense in depth on top of checkAuthStartup ensures a redirect-following
+// client cannot leak the token to an untrusted origin.
+func checkBearerTargetSafeURL(u *url.URL, trustPrivateNetwork bool) error {
 	if u == nil {
 		return fmt.Errorf("nil URL for bearer-token safety check")
 	}
@@ -146,8 +161,16 @@ func checkBearerTargetSafeURL(u *url.URL) error {
 	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
 		return nil
 	}
+	if trustPrivateNetwork {
+		return nil
+	}
 	return fmt.Errorf("refusing to attach bearer token to plaintext non-loopback URL %q — "+
 		"the daemon does not terminate TLS, so the token would travel in cleartext; "+
 		"use a Unix socket or loopback address, tunnel via SSH, or terminate TLS "+
 		"in a reverse proxy", u.Redacted())
+}
+
+func envTruthy(name string) bool {
+	v := strings.TrimSpace(os.Getenv(name))
+	return v == "1" || strings.EqualFold(v, "true")
 }

--- a/internal/daemonclient/auth.go
+++ b/internal/daemonclient/auth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
 )
 
 // resolveAuthToken returns the auth token a client should attach to
@@ -30,10 +31,7 @@ func resolveAuthToken() string {
 
 func resolveAuthConfig() config.AuthConfig {
 	envToken := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
-	envTrust := envTruthy("KATA_TRUST_PRIVATE_NETWORK")
-	if v := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")); v != "" {
-		envToken = v
-	}
+	envTrust := config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
 	cfg, err := config.ReadDaemonConfig()
 	if err != nil || cfg == nil {
 		return config.AuthConfig{Token: envToken, TrustPrivateNetwork: envTrust}
@@ -97,19 +95,18 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // A nil base falls back to http.DefaultTransport — matching net/http's
 // own zero-value behavior when *http.Client.Transport is nil. origin
 // is the scheme://host the bearer is pinned to (see bearerTransport).
-func withBearer(base http.RoundTripper, token, origin string, trustPrivateNetwork ...bool) http.RoundTripper {
+func withBearer(base http.RoundTripper, token, origin string, trustPrivateNetwork bool) http.RoundTripper {
 	if token == "" {
 		return base
 	}
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	trust := len(trustPrivateNetwork) > 0 && trustPrivateNetwork[0]
 	return &bearerTransport{
 		base:                base,
 		token:               token,
 		origin:              origin,
-		trustPrivateNetwork: trust,
+		trustPrivateNetwork: trustPrivateNetwork,
 	}
 }
 
@@ -118,13 +115,12 @@ func withBearer(base http.RoundTripper, token, origin string, trustPrivateNetwor
 // origin the bearer should be pinned to for subsequent requests. Thin wrapper
 // over checkBearerTargetSafeURL that accepts a string base URL — used at
 // client construction time to fail fast before any request is built.
-func checkBearerTargetSafe(baseURL string, trustPrivateNetwork ...bool) (string, error) {
+func checkBearerTargetSafe(baseURL string, trustPrivateNetwork bool) (string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return "", fmt.Errorf("parse base URL %q for bearer-token safety check: %w", baseURL, err)
 	}
-	trust := len(trustPrivateNetwork) > 0 && trustPrivateNetwork[0]
-	if err := checkBearerTargetSafeURL(u, trust); err != nil {
+	if err := checkBearerTargetSafeURL(u, trustPrivateNetwork); err != nil {
 		return "", err
 	}
 	return u.Scheme + "://" + u.Host, nil
@@ -138,7 +134,7 @@ const unixSentinelHost = "kata.invalid"
 // checkBearerTargetSafeURL is the per-request form of the bearer-safety check.
 // Safe targets are the Unix-socket sentinel host, HTTPS schemes, HTTP loopback
 // addresses (including "localhost", "127.0.0.1", "[::1]"), and plaintext
-// non-loopback URLs only when the operator opted into private-network trust.
+// private-IP URLs only when the operator opted into private-network trust.
 // Defense in depth on top of checkAuthStartup ensures a redirect-following
 // client cannot leak the token to an untrusted origin.
 func checkBearerTargetSafeURL(u *url.URL, trustPrivateNetwork bool) error {
@@ -162,15 +158,13 @@ func checkBearerTargetSafeURL(u *url.URL, trustPrivateNetwork bool) error {
 		return nil
 	}
 	if trustPrivateNetwork {
+		if err := daemon.ValidateNonPublicAddress(net.JoinHostPort(host, u.Port())); err != nil {
+			return fmt.Errorf("plaintext trusted-private-network bearer target %q rejected: %w", u.Redacted(), err)
+		}
 		return nil
 	}
 	return fmt.Errorf("refusing to attach bearer token to plaintext non-loopback URL %q — "+
 		"the daemon does not terminate TLS, so the token would travel in cleartext; "+
 		"use a Unix socket or loopback address, tunnel via SSH, or terminate TLS "+
 		"in a reverse proxy", u.Redacted())
-}
-
-func envTruthy(name string) bool {
-	v := strings.TrimSpace(os.Getenv(name))
-	return v == "1" || strings.EqualFold(v, "true")
 }

--- a/internal/daemonclient/auth_test.go
+++ b/internal/daemonclient/auth_test.go
@@ -195,6 +195,16 @@ func TestNewHTTPClient_RefusesBearerOnPlaintextNonLoopback(t *testing.T) {
 	assert.Contains(t, err.Error(), "plaintext")
 }
 
+func TestNewHTTPClient_AllowsBearerOnPlaintextNonLoopbackWhenTrustPrivateNetworkSet(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_AUTH_TOKEN", "secret")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+
+	_, err := NewHTTPClient(context.Background(), "http://100.64.0.5:7373", Opts{})
+	require.NoError(t, err)
+}
+
 // TestNewHTTPClient_AllowsBearerOnLoopback covers the safe-target arm of
 // checkBearerTargetSafe: 127.0.0.1 and [::1] keep the token in-host even
 // over plaintext HTTP.
@@ -276,6 +286,48 @@ func TestBearerTransport_RefusesPlaintextNonLoopbackPerRequest(t *testing.T) {
 	assert.Contains(t, err.Error(), "plaintext")
 }
 
+func TestBearerTransport_AllowsPlaintextNonLoopbackWhenTrustPrivateNetworkSet(t *testing.T) {
+	var got string
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Header.Get("Authorization")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
+	})
+	rt := withBearer(base, "secret", "http://100.64.0.5:7373", true)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"http://100.64.0.5:7373/api/v1/ping", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, "Bearer secret", got)
+}
+
+func TestBearerTransport_TrustPrivateNetworkStillRefusesCrossOrigin(t *testing.T) {
+	called := false
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+	})
+	rt := withBearer(base, "secret", "http://100.64.0.5:7373", true)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"http://100.64.0.6:7373/api/v1/ping", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-origin")
+	assert.False(t, called, "cross-origin request must not reach the base transport")
+}
+
 // TestBearerTransport_BlocksTokenOnRedirectToPlaintextNonLoopback is the
 // concrete regression test for the per-request guard. The test server
 // 302-redirects to a plaintext non-loopback URL; http.Client follows the
@@ -354,4 +406,10 @@ func writeAuthConfig(home, tok string) error {
 // writeRawConfig writes config.toml verbatim under home.
 func writeRawConfig(home, body string) error {
 	return os.WriteFile(filepath.Join(home, "config.toml"), []byte(body), 0o600)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/internal/daemonclient/auth_test.go
+++ b/internal/daemonclient/auth_test.go
@@ -56,7 +56,7 @@ func TestBearerTransportInjectsHeader(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c := &http.Client{Transport: withBearer(http.DefaultTransport, "secret", srv.URL)}
+	c := &http.Client{Transport: withBearer(http.DefaultTransport, "secret", srv.URL, false)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
@@ -74,7 +74,7 @@ func TestBearerTransportNoTokenPassthrough(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	rt := withBearer(http.DefaultTransport, "", srv.URL)
+	rt := withBearer(http.DefaultTransport, "", srv.URL, false)
 	assert.Equal(t, http.DefaultTransport, rt,
 		"empty token must return the base transport unchanged")
 
@@ -96,7 +96,7 @@ func TestBearerTransportPreservesCallerHeader(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c := &http.Client{Transport: withBearer(http.DefaultTransport, "from-transport", srv.URL)}
+	c := &http.Client{Transport: withBearer(http.DefaultTransport, "from-transport", srv.URL, false)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer caller-supplied")
@@ -114,7 +114,7 @@ func TestBearerTransportDoesNotMutateRequest(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c := &http.Client{Transport: withBearer(http.DefaultTransport, "secret", srv.URL)}
+	c := &http.Client{Transport: withBearer(http.DefaultTransport, "secret", srv.URL, false)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
@@ -206,6 +206,28 @@ func TestNewHTTPClient_AllowsBearerOnPlaintextNonLoopbackWhenTrustPrivateNetwork
 	require.NoError(t, err)
 }
 
+func TestNewHTTPClient_TrustPrivateNetworkRejectsPublicPlaintextTarget(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_AUTH_TOKEN", "secret")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+
+	_, err := NewHTTPClient(context.Background(), "http://8.8.8.8:7373", Opts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-public")
+}
+
+func TestNewHTTPClient_TrustPrivateNetworkRejectsPlaintextHostname(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_AUTH_TOKEN", "secret")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+
+	_, err := NewHTTPClient(context.Background(), "http://example.internal:7373", Opts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "literal IP")
+}
+
 // TestNewHTTPClient_AllowsBearerOnLoopback covers the safe-target arm of
 // checkBearerTargetSafe: 127.0.0.1 and [::1] keep the token in-host even
 // over plaintext HTTP.
@@ -248,11 +270,11 @@ func TestNewHTTPClient_AllowsBearerOverHTTPS(t *testing.T) {
 // path-bearing baseURLs must normalize to the same origin so the per-request
 // pin matches regardless of which API path triggered the check.
 func TestCheckBearerTargetSafe_UnixBase(t *testing.T) {
-	origin, err := checkBearerTargetSafe(UnixBase)
+	origin, err := checkBearerTargetSafe(UnixBase, false)
 	require.NoError(t, err)
 	assert.Equal(t, UnixBase, origin)
 
-	origin, err = checkBearerTargetSafe(UnixBase + "/api/v1/ping")
+	origin, err = checkBearerTargetSafe(UnixBase+"/api/v1/ping", false)
 	require.NoError(t, err)
 	assert.Equal(t, UnixBase, origin)
 }
@@ -275,7 +297,7 @@ func TestNewHTTPClient_NoTokenSkipsSafetyCheck(t *testing.T) {
 // pointed at a plaintext non-loopback URL must be refused before the
 // token reaches the wire.
 func TestBearerTransport_RefusesPlaintextNonLoopbackPerRequest(t *testing.T) {
-	rt := withBearer(http.DefaultTransport, "secret", "http://127.0.0.1:7373")
+	rt := withBearer(http.DefaultTransport, "secret", "http://127.0.0.1:7373", false)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		"http://example.invalid:7373/api/v1/ping", nil)
 	require.NoError(t, err)
@@ -340,7 +362,7 @@ func TestBearerTransport_BlocksTokenOnRedirectToPlaintextNonLoopback(t *testing.
 	}))
 	t.Cleanup(srv.Close)
 
-	c := &http.Client{Transport: withBearer(http.DefaultTransport, "secret", srv.URL)}
+	c := &http.Client{Transport: withBearer(http.DefaultTransport, "secret", srv.URL, false)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
@@ -357,7 +379,7 @@ func TestBearerTransport_BlocksTokenOnRedirectToPlaintextNonLoopback(t *testing.
 // passes the HTTPS / loopback safety check on its own) must be refused
 // before the token reaches the wire.
 func TestBearerTransport_RefusesCrossOriginPerRequest(t *testing.T) {
-	rt := withBearer(http.DefaultTransport, "secret", "https://daemon.example")
+	rt := withBearer(http.DefaultTransport, "secret", "https://daemon.example", false)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		"https://attacker.example/api/v1/ping", nil)
 	require.NoError(t, err)
@@ -386,7 +408,7 @@ func TestBearerTransport_BlocksTokenOnCrossOriginHTTPSRedirect(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	base := srv.Client().Transport
-	c := &http.Client{Transport: withBearer(base, "secret", srv.URL)}
+	c := &http.Client{Transport: withBearer(base, "secret", srv.URL, false)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server

--- a/internal/daemonclient/auth_test.go
+++ b/internal/daemonclient/auth_test.go
@@ -189,6 +189,7 @@ func TestNewHTTPClient_RefusesBearerOnPlaintextNonLoopback(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("KATA_HOME", tmp)
 	t.Setenv("KATA_AUTH_TOKEN", "secret")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
 
 	_, err := NewHTTPClient(context.Background(), "http://example.invalid:7373", Opts{})
 	require.Error(t, err)

--- a/internal/daemonclient/client.go
+++ b/internal/daemonclient/client.go
@@ -148,14 +148,14 @@ func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client
 	if err != nil {
 		return nil, err
 	}
-	token := resolveAuthToken()
+	auth := resolveAuthConfig()
 	var origin string
-	if token != "" {
-		if origin, err = checkBearerTargetSafe(baseURL); err != nil {
+	if auth.Token != "" {
+		if origin, err = checkBearerTargetSafe(baseURL, auth.TrustPrivateNetwork); err != nil {
 			return nil, err
 		}
 	}
-	c.Transport = withBearer(c.Transport, token, origin)
+	c.Transport = withBearer(c.Transport, auth.Token, origin, auth.TrustPrivateNetwork)
 	return c, nil
 }
 


### PR DESCRIPTION
## Summary
- Add `[auth].trust_private_network` and `KATA_TRUST_PRIVATE_NETWORK=1` as the explicit opt-in for bearer auth over private-network HTTP.
- Thread the trust setting through daemon startup and client bearer safety checks while preserving same-origin token pinning.
- Document authenticated private-network daemon setup and emit a startup warning when the trust mode is active.

## Test Plan
- [x] `make test`
- [x] `go vet ./...`

Closes #53