### PR TITLE
Add agent output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,8 @@ Session setup:
 
 - Run from the project workspace, or pass `--workspace <path>`.
 - Set `KATA_AUTHOR` once at session start.
-- Prefer `--json` for reads and writes when you need to parse output.
+- Use `--agent` for concise action summaries in agent logs.
+- Use `--json` when your script needs complete structured data.
 
 Per-task guidelines:
 

--- a/README.md
+++ b/README.md
@@ -395,8 +395,9 @@ Session setup:
 
 - Run from the project workspace, or pass `--workspace <path>`.
 - Set `KATA_AUTHOR` once at session start.
-- Use `--agent` for concise action summaries in agent logs.
-- Use `--json` when your script needs complete structured data.
+- Default to `--agent` for ordinary kata reads and mutations in agent logs.
+- Use `--json` only when your script needs complete structured data, for
+  example when piping into `jq`.
 
 Per-task guidelines:
 
@@ -417,27 +418,27 @@ Use relationships deliberately. The link types mean:
 | `related` | Useful context, but not ordering. |
 
 Example session (using `abc4` as a placeholder for the issue's actual
-short_id, which `kata create --json` and `kata search --json` both
+short_id, which `kata create --agent` and `kata search --agent` both
 return):
 
 ```sh
 # Search before creating
-kata search "login race" --json
+kata search "login race" --agent
 
 # If no existing issue fits, create with an idempotency key
 kata create "fix login race" \
   --body "Observed double-submit in Safari callback." \
   --idempotency-key "login-race-2026-05-02" \
-  --json
+  --agent
 
 # Update an existing issue rather than open a duplicate
-kata show abc4 --json
-kata comment abc4 --body "Found another reproduction path." --json
-kata label add abc4 safari --json
-kata edit abc4 --blocks d4ex --json
+kata show abc4 --agent
+kata comment abc4 --body "Found another reproduction path." --agent
+kata label add abc4 safari --agent
+kata edit abc4 --blocks d4ex --agent
 
 # Close when done
-kata close abc4 --done --message "Fixed the issue and verified the relevant tests pass." --commit <sha> --json
+kata close abc4 --done --message "Fixed the issue and verified the relevant tests pass." --commit <sha> --agent
 ```
 
 For long-running agents, poll events and remember the returned cursor; resume
@@ -445,13 +446,14 @@ from it on the next call. If a response says `reset_required`, discard cached
 kata state and resume from the reset cursor.
 
 ```sh
-kata events --after 0 --limit 100 --json
+kata events --after 0 --limit 100 --agent
 ```
 
-For live streams, `--tail` emits newline-delimited JSON:
+For live streams, use `--agent` for one line per event in agent logs. Use
+`--json` only when a consumer expects newline-delimited JSON:
 
 ```sh
-kata events --tail
+kata events --tail --agent
 ```
 
 ## Agent Task Claiming
@@ -464,12 +466,12 @@ to the current actor. The claim fails if another actor already claimed the issue
 ISSUE=$(kata ready --unowned --json | jq -r '.issues[0].short_id')
 
 # Claim it (fails if someone else claimed it first)
-kata claim "$ISSUE" || exit 1
+kata claim "$ISSUE" --agent || exit 1
 
 # Do the work...
 
 # Close when done
-kata close "$ISSUE" --done --message "Fixed the issue and verified the relevant tests pass." --commit "$SHA"
+kata close "$ISSUE" --done --message "Fixed the issue and verified the relevant tests pass." --commit "$SHA" --agent
 ```
 
 The `kata ready` command supports filters for finding suitable work:

--- a/cmd/kata/assign.go
+++ b/cmd/kata/assign.go
@@ -89,7 +89,11 @@ func printAssignMutation(cmd *cobra.Command, bs []byte, unassign bool) error {
 		if unassign {
 			verb = "unassign"
 		}
-		return printAgentMutation(cmd, verb, bs, func(w io.Writer, m agentIssueMutation) error {
+		var m agentIssueMutation
+		if err := json.Unmarshal(bs, &m); err != nil {
+			return err
+		}
+		return printAgentMutationDecoded(cmd.OutOrStdout(), verb, m, true, func(w io.Writer, m agentIssueMutation) error {
 			if unassign {
 				return writeAgentField(w, "Owner-Cleared", "true")
 			}

--- a/cmd/kata/assign.go
+++ b/cmd/kata/assign.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -74,13 +75,29 @@ func runAssign(cmd *cobra.Command, raw, owner string, unassign bool) error {
 // nothing; JSON mode emits the daemon body under the kata_api_version
 // envelope; otherwise prints a single human-readable line.
 func printAssignMutation(cmd *cobra.Command, bs []byte, unassign bool) error {
-	if flags.JSON {
+	mode := currentOutputMode()
+	if mode == outputJSON {
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 			return err
 		}
 		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 		return err
+	}
+	if mode == outputAgent {
+		verb := "assign"
+		if unassign {
+			verb = "unassign"
+		}
+		return printAgentMutation(cmd, verb, bs, func(w io.Writer, m agentIssueMutation) error {
+			if unassign {
+				return writeAgentField(w, "Owner-Cleared", "true")
+			}
+			if m.Issue.Owner != nil {
+				return writeAgentField(w, "Owner", agentValue(*m.Issue.Owner))
+			}
+			return nil
+		})
 	}
 	var b struct {
 		Issue struct {

--- a/cmd/kata/assign_test.go
+++ b/cmd/kata/assign_test.go
@@ -24,7 +24,7 @@ func TestAssign_AgentOutput(t *testing.T) {
 
 	out := runCLI(t, env, dir, "--agent", "assign", ref, "wesm")
 
-	assert.Regexp(t, `(?m)^OK assign \S+`, out)
+	assert.Regexp(t, `(?m)^OK assign \S+ changed=true`, out)
 	assert.Contains(t, out, "Owner: wesm")
 }
 
@@ -35,7 +35,7 @@ func TestUnassign_AgentOutput(t *testing.T) {
 	resetFlags(t)
 	out := runCLI(t, env, dir, "--agent", "unassign", ref)
 
-	assert.Regexp(t, `(?m)^OK unassign \S+`, out)
+	assert.Regexp(t, `(?m)^OK unassign \S+ changed=true`, out)
 	assert.Contains(t, out, "Owner-Cleared: true")
 }
 

--- a/cmd/kata/assign_test.go
+++ b/cmd/kata/assign_test.go
@@ -19,6 +19,26 @@ func TestAssign_RoundTrip(t *testing.T) {
 	assert.True(t, strings.Contains(uOut, "unassigned"))
 }
 
+func TestAssign_AgentOutput(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "x")
+
+	out := runCLI(t, env, dir, "--agent", "assign", ref, "wesm")
+
+	assert.Regexp(t, `(?m)^OK assign \S+`, out)
+	assert.Contains(t, out, "Owner: wesm")
+}
+
+func TestUnassign_AgentOutput(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "x")
+	runCLI(t, env, dir, "assign", ref, "wesm")
+
+	resetFlags(t)
+	out := runCLI(t, env, dir, "--agent", "unassign", ref)
+
+	assert.Regexp(t, `(?m)^OK unassign \S+`, out)
+	assert.Contains(t, out, "Owner-Cleared: true")
+}
+
 func TestAssign_WithComment_AppendsComment(t *testing.T) {
 	env, dir, pid, ref := setupWorkspaceWithIssue(t, "x")
 

--- a/cmd/kata/audit_closes.go
+++ b/cmd/kata/audit_closes.go
@@ -79,13 +79,17 @@ analysis. The text output is a wide table; pass --json for tooling.`,
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
-			if flags.JSON {
+			mode := currentOutputMode()
+			if mode == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err
 				}
 				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 				return err
+			}
+			if mode == outputAgent {
+				return printAuditClosesAgent(cmd, bs)
 			}
 			return printAuditClosesTable(cmd, bs)
 		},
@@ -136,6 +140,38 @@ func printAuditClosesTable(cmd *cobra.Command, bs []byte) error {
 			r.Time, r.Actor, r.Issue, parent, r.Reason,
 			strings.Join(r.EvidenceTypes, ","),
 			flagsCol); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printAuditClosesAgent(cmd *cobra.Command, bs []byte) error {
+	var resp struct {
+		Rows []api.AuditCloseRow `json:"rows"`
+	}
+	if err := json.Unmarshal(bs, &resp); err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "OK audit count=%d\n", len(resp.Rows)); err != nil {
+		return err
+	}
+	for _, r := range resp.Rows {
+		fields := []agentField{
+			agentRowField("time", r.Time),
+			agentRowField("actor", r.Actor),
+			agentRowField("issue", r.Issue),
+		}
+		if r.Parent != "" {
+			fields = append(fields, agentRowField("parent", r.Parent))
+		}
+		fields = append(fields,
+			agentRowField("reason", r.Reason),
+			agentRowListField("evidence", r.EvidenceTypes),
+			agentRowListField("flags", r.Flags),
+		)
+		if err := writeAgentKVRow(out, fields...); err != nil {
 			return err
 		}
 	}

--- a/cmd/kata/audit_closes_test.go
+++ b/cmd/kata/audit_closes_test.go
@@ -52,6 +52,24 @@ func TestAuditCloses_TextOutputRendersRows(t *testing.T) {
 		"text output must include the close reason")
 }
 
+func TestAuditCloses_AgentOutputShape(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "issue one")
+	runCLIAs(t, env, dir, "tester", "close", ref, "--done",
+		"--message", "Fixed the issue and ran the auth tests thoroughly.",
+		"--commit", "abc1234")
+
+	out := runCLI(t, env, dir, "--agent", "audit", "closes")
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.GreaterOrEqual(t, len(lines), 2, "agent audit should include header and rows: %q", out)
+	assert.Regexp(t, `^OK audit count=\d+`, lines[0])
+	assert.Contains(t, lines[1], "actor=tester")
+	assert.Contains(t, lines[1], "issue="+ref)
+	assert.Contains(t, lines[1], "reason=done")
+	assert.Contains(t, lines[1], "evidence=commit")
+	assert.NotContains(t, out, "\x1b", "agent output must not contain ANSI escape bytes")
+}
+
 // TestAuditCloses_FilterByActor verifies --actor narrows results to a
 // single actor's closes.
 func TestAuditCloses_FilterByActor(t *testing.T) {

--- a/cmd/kata/beads_import.go
+++ b/cmd/kata/beads_import.go
@@ -241,7 +241,7 @@ func beadsInitRequiredError() error {
 }
 
 func isBeadsImportUnattended(cmd *cobra.Command) bool {
-	if flags.JSON || flags.Quiet {
+	if currentOutputMode() != outputHuman || flags.Quiet {
 		return true
 	}
 	in, ok := cmd.InOrStdin().(*os.File)

--- a/cmd/kata/beads_import.go
+++ b/cmd/kata/beads_import.go
@@ -146,7 +146,7 @@ func runBeadsImport(cmd *cobra.Command) error {
 	if status >= 400 {
 		return apiErrFromBody(status, bs)
 	}
-	return printBeadsImportResult(cmd, bs)
+	return printBeadsImportResult(cmd, bs, projectID)
 }
 
 func collectBeadsImportRequest(ctx context.Context, workspace, actor string) (beadsImportRequest, error) {
@@ -252,7 +252,7 @@ func isBeadsImportUnattended(cmd *cobra.Command) bool {
 	return !ok || !isTTY(out)
 }
 
-func printBeadsImportResult(cmd *cobra.Command, bs []byte) error {
+func printBeadsImportResult(cmd *cobra.Command, bs []byte, projectID int64) error {
 	if flags.JSON {
 		_, err := cmd.OutOrStdout().Write(bs)
 		return err
@@ -262,6 +262,12 @@ func printBeadsImportResult(cmd *cobra.Command, bs []byte) error {
 	}
 	var summary beadsImportSummary
 	if err := json.Unmarshal(bs, &summary); err != nil {
+		return err
+	}
+	if currentOutputMode() == outputAgent {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"OK import source_format=beads project=%d created=%d updated=%d unchanged=%d comments=%d links=%d\n",
+			projectID, summary.Created, summary.Updated, summary.Unchanged, summary.Comments, summary.Links)
 		return err
 	}
 	_, err := fmt.Fprintf(cmd.OutOrStdout(),

--- a/cmd/kata/beads_import_test.go
+++ b/cmd/kata/beads_import_test.go
@@ -105,6 +105,17 @@ func TestImportBeadsJSONSummaryFromLiveBD(t *testing.T) {
 	assert.Empty(t, summary.Errors)
 }
 
+func TestImportBeadsAgentSummaryFromLiveBD(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	installFakeBD(t)
+
+	out, err := runCLICapture(t, env, dir, "import", "--source-format", "beads", "--agent", "--as", "importer")
+	require.NoError(t, err)
+
+	assert.Equal(t, "OK import source_format=beads project="+itoa(pid)+" created=1 updated=0 unchanged=0 comments=1 links=0\n", out)
+	assert.NotContains(t, out, "target=")
+}
+
 // TestBeadsImport_AssignsShortIDs pins that imported beads issues pick
 // up a valid kata short_id from the auto-extend path — the importer
 // creates fresh kata ULIDs and the short_id flows through unchanged in

--- a/cmd/kata/beads_import_test.go
+++ b/cmd/kata/beads_import_test.go
@@ -20,21 +20,29 @@ import (
 func TestImportBeadsRejectsInputAndTargetFlags(t *testing.T) {
 	setupKataEnv(t)
 
-	_, err := runCmdOutput(t, nil, "import", "--format", "beads", "--input", "beads.jsonl")
+	_, err := runCmdOutput(t, nil, "import", "--source-format", "beads", "--input", "beads.jsonl")
 	ce := requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "--input")
 
-	_, err = runCmdOutput(t, nil, "import", "--format", "beads", "--target", "target.db")
+	_, err = runCmdOutput(t, nil, "import", "--source-format", "beads", "--target", "target.db")
 	ce = requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "--target")
 }
 
-func TestImportRejectsUnsupportedFormat(t *testing.T) {
+func TestImportRejectsUnsupportedSourceFormat(t *testing.T) {
 	setupKataEnv(t)
 
-	_, err := runCmdOutput(t, nil, "import", "--format", "bogus")
+	_, err := runCmdOutput(t, nil, "import", "--source-format", "bogus")
 	ce := requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "unsupported import format")
+}
+
+func TestImportLegacyFormatBeadsStillSelectsSource(t *testing.T) {
+	setupKataEnv(t)
+
+	_, err := runCmdOutput(t, nil, "import", "--format", "beads", "--input", "beads.jsonl")
+	ce := requireCLIError(t, err, ExitValidation)
+	assert.Contains(t, ce.Message, "--input")
 }
 
 func TestImportBeadsMissingProjectUnattended(t *testing.T) {
@@ -42,7 +50,7 @@ func TestImportBeadsMissingProjectUnattended(t *testing.T) {
 	env := testenv.New(t)
 	dir := t.TempDir()
 
-	_, err := runCLICapture(t, env, dir, "import", "--format", "beads", "--json")
+	_, err := runCLICapture(t, env, dir, "import", "--source-format", "beads", "--json")
 	ce := requireCLIError(t, err, ExitValidation)
 	assert.Contains(t, ce.Message, "run kata init first")
 }
@@ -51,7 +59,7 @@ func TestImportBeadsFromLiveBD(t *testing.T) {
 	env, dir, pid := setupCLIWorkspace(t)
 	installFakeBD(t)
 
-	out, err := runCLICapture(t, env, dir, "import", "--format", "beads", "--as", "importer")
+	out, err := runCLICapture(t, env, dir, "import", "--source-format", "beads", "--as", "importer")
 	require.NoError(t, err)
 	assert.Contains(t, out, "imported beads: created 1, updated 0, unchanged 0, comments 1, links 0")
 
@@ -75,7 +83,7 @@ func TestImportBeadsJSONSummaryFromLiveBD(t *testing.T) {
 	env, dir, _ := setupCLIWorkspace(t)
 	installFakeBD(t)
 
-	out, err := runCLICapture(t, env, dir, "import", "--format", "beads", "--json", "--as", "importer")
+	out, err := runCLICapture(t, env, dir, "import", "--source-format", "beads", "--json", "--as", "importer")
 	require.NoError(t, err)
 
 	var summary struct {
@@ -105,7 +113,7 @@ func TestBeadsImport_AssignsShortIDs(t *testing.T) {
 	env, dir, _ := setupCLIWorkspace(t)
 	installFakeBD(t)
 
-	out, err := runCLICapture(t, env, dir, "import", "--format", "beads", "--json", "--as", "importer")
+	out, err := runCLICapture(t, env, dir, "import", "--source-format", "beads", "--json", "--as", "importer")
 	require.NoError(t, err)
 
 	var result struct {
@@ -170,7 +178,7 @@ func runBeadsImportTTY(t *testing.T, env *testenv.Env, dir, input string, args .
 	cmd.SetIn(stdin)
 	cmd.SetOut(stdout)
 	cmd.SetErr(stdout)
-	cmd.SetArgs(append([]string{"--workspace", dir, "import", "--format", "beads"}, args...))
+	cmd.SetArgs(append([]string{"--workspace", dir, "import", "--source-format", "beads"}, args...))
 	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
 	err = cmd.Execute()
 	require.NoError(t, stdout.Sync())

--- a/cmd/kata/beads_import_test.go
+++ b/cmd/kata/beads_import_test.go
@@ -55,6 +55,19 @@ func TestImportBeadsMissingProjectUnattended(t *testing.T) {
 	assert.Contains(t, ce.Message, "run kata init first")
 }
 
+func TestImportBeadsAgentMissingProjectDoesNotPrompt(t *testing.T) {
+	resetFlags(t)
+	stubIsTTY(t, true)
+	env := testenv.New(t)
+	dir := t.TempDir()
+
+	out, err := runBeadsImportTTY(t, env, dir, "y\n", "--agent")
+
+	ce := requireCLIError(t, err, ExitValidation)
+	assert.Contains(t, ce.Message, "run kata init first")
+	assert.NotContains(t, out, "Run kata init now?")
+}
+
 func TestImportBeadsFromLiveBD(t *testing.T) {
 	env, dir, pid := setupCLIWorkspace(t)
 	installFakeBD(t)

--- a/cmd/kata/claim.go
+++ b/cmd/kata/claim.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -54,17 +55,31 @@ func runClaim(cmd *cobra.Command, raw string, force bool) error {
 	return printClaimMutation(cmd, bs)
 }
 
-// printClaimMutation formats the claim response. Quiet mode prints
-// nothing; JSON mode emits the daemon body under the kata_api_version
-// envelope; otherwise prints a single human-readable line.
+// printClaimMutation formats the claim response for the selected output mode.
+// Quiet human mode prints nothing; JSON mode emits the daemon body under the
+// kata_api_version envelope; agent mode uses the mutation contract.
 func printClaimMutation(cmd *cobra.Command, bs []byte) error {
-	if flags.JSON {
+	mode := currentOutputMode()
+	if mode == outputJSON {
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 			return err
 		}
 		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 		return err
+	}
+	if mode == outputAgent {
+		return printAgentMutation(cmd, "claim", bs, func(w io.Writer, m agentIssueMutation) error {
+			if m.Issue.Owner != nil {
+				if err := writeAgentField(w, "Owner", agentValue(*m.Issue.Owner)); err != nil {
+					return err
+				}
+			}
+			if m.PreviousOwner != nil && *m.PreviousOwner != "" {
+				return writeAgentField(w, "Previous-Owner", agentValue(*m.PreviousOwner))
+			}
+			return nil
+		})
 	}
 	var b struct {
 		Issue struct {

--- a/cmd/kata/claim_test.go
+++ b/cmd/kata/claim_test.go
@@ -109,6 +109,30 @@ func TestClaim_ForceOverrideShowsPreviousOwner(t *testing.T) {
 	require.Contains(t, out, "was: agent1")
 }
 
+func TestClaim_AgentOutputIncludesOwner(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	issue := createIssueViaHTTPFull(t, env, dir, "test claim agent")
+
+	resetFlags(t)
+	out := runCLIAs(t, env, dir, "agent1", "--agent", "claim", issue.ShortID)
+
+	assert.Regexp(t, `(?m)^OK claim \S+`, out)
+	assert.Contains(t, out, "Owner: agent1")
+}
+
+func TestClaim_AgentForceOutputIncludesPreviousOwner(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	issue := createIssueViaHTTPFull(t, env, dir, "test claim agent previous")
+	runCLIAs(t, env, dir, "agent1", "claim", issue.ShortID)
+
+	resetFlags(t)
+	out := runCLIAs(t, env, dir, "agent2", "--agent", "claim", "--force", issue.ShortID)
+
+	assert.Regexp(t, `(?m)^OK claim \S+`, out)
+	assert.Contains(t, out, "Owner: agent2")
+	assert.Contains(t, out, "Previous-Owner: agent1")
+}
+
 func TestClaim_WithComment(t *testing.T) {
 	env, dir := setupCLIEnv(t)
 

--- a/cmd/kata/close.go
+++ b/cmd/kata/close.go
@@ -119,10 +119,9 @@ Instead, label and comment:
 				"evidence": parsed,
 				"dry_run":  dryRun,
 			}
-			// Route the dry-run banner to stderr (and suppress under
-			// --json / --quiet) so machine-parseable stdout isn't polluted
-			// with a non-JSON prefix.
-			if dryRun && !flags.JSON && !flags.Quiet {
+			// Route the dry-run banner to stderr only in human mode so
+			// machine-parseable output modes stay unprefixed.
+			if dryRun && currentOutputMode() == outputHuman && !flags.Quiet {
 				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "close: dry-run (no mutations will occur)")
 			}
 			return runAction(cmd, args[0], "close", extra)

--- a/cmd/kata/close_reopen_test.go
+++ b/cmd/kata/close_reopen_test.go
@@ -35,6 +35,7 @@ func TestClose_AgentOutput(t *testing.T) {
 	assert.Regexp(t, `(?m)^OK close \S+`, out)
 	assert.Contains(t, out, "Status: closed")
 	assert.Contains(t, out, "Reason: done")
+	assert.Contains(t, out, "Evidence: commit:abc1234")
 }
 
 func TestClose_AgentDryRunSuppressesHumanBanner(t *testing.T) {

--- a/cmd/kata/close_reopen_test.go
+++ b/cmd/kata/close_reopen_test.go
@@ -37,6 +37,20 @@ func TestClose_AgentOutput(t *testing.T) {
 	assert.Contains(t, out, "Reason: done")
 }
 
+func TestClose_AgentDryRunSuppressesHumanBanner(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "test issue")
+
+	stdout, stderr, err := runCLIWithErr(t, env, dir, "--agent", "close", ref,
+		"--done",
+		"--message", "Fixed Safari callback double-submit and ran tests.",
+		"--commit", "abc1234",
+		"--dry-run")
+
+	require.NoError(t, err)
+	assert.Regexp(t, `(?m)^OK close \S+`, stdout)
+	assert.Empty(t, stderr)
+}
+
 func TestReopen_AgentOutput(t *testing.T) {
 	env, dir, _, ref := setupWorkspaceWithIssue(t, "test issue")
 	runCLI(t, env, dir, "close", ref,

--- a/cmd/kata/close_reopen_test.go
+++ b/cmd/kata/close_reopen_test.go
@@ -24,6 +24,33 @@ func TestCloseReopen_RoundTrip(t *testing.T) {
 	assert.Contains(t, out, "open")
 }
 
+func TestClose_AgentOutput(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "test issue")
+
+	out := runCLI(t, env, dir, "--agent", "close", ref,
+		"--done",
+		"--message", "Fixed Safari callback double-submit and ran tests.",
+		"--commit", "abc1234")
+
+	assert.Regexp(t, `(?m)^OK close \S+`, out)
+	assert.Contains(t, out, "Status: closed")
+	assert.Contains(t, out, "Reason: done")
+}
+
+func TestReopen_AgentOutput(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "test issue")
+	runCLI(t, env, dir, "close", ref,
+		"--done",
+		"--message", "Fixed Safari callback double-submit and ran tests.",
+		"--commit", "abc1234")
+
+	resetFlags(t)
+	out := runCLI(t, env, dir, "--agent", "reopen", ref)
+
+	assert.Regexp(t, `(?m)^OK reopen \S+`, out)
+	assert.Contains(t, out, "Status: open")
+}
+
 func TestCloseCmd_CanonicalDoneRequiresEvidence(t *testing.T) {
 	env, dir, _, ref := setupWorkspaceWithIssue(t, "test issue")
 

--- a/cmd/kata/comment.go
+++ b/cmd/kata/comment.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -56,13 +57,18 @@ func newCommentCmd() *cobra.Command {
 		if status >= 400 {
 			return apiErrFromBody(status, bs)
 		}
-		if flags.JSON {
+		switch currentOutputMode() {
+		case outputJSON:
 			var buf bytes.Buffer
 			if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 				return err
 			}
 			_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 			return err
+		case outputAgent:
+			return printAgentMutation(cmd, "comment", bs, func(w io.Writer, _ agentIssueMutation) error {
+				return writeAgentField(w, "Comment", "appended")
+			})
 		}
 		if !flags.Quiet {
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), "comment appended")

--- a/cmd/kata/comment_test.go
+++ b/cmd/kata/comment_test.go
@@ -14,3 +14,13 @@ func TestComment_AppendsToIssue(t *testing.T) {
 	out := runCLI(t, env, dir, "comment", short, "--body", "looks good")
 	assert.True(t, strings.Contains(out, "looks good") || strings.Contains(out, "comment"))
 }
+
+func TestComment_AgentOutput(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	short := createIssueViaHTTP(t, env, dir, "x")
+
+	out := runCLI(t, env, dir, "--agent", "comment", short, "--body", "looks good")
+
+	assert.Regexp(t, `(?m)^OK comment \S+`, out)
+	assert.Contains(t, out, "Comment: appended")
+}

--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -439,6 +440,7 @@ func printMutation(cmd *cobra.Command, bs []byte) error {
 // summary. The wire payload (JSON-mode output) is left unchanged —
 // the `applied` argument only seeds the human-mode renderer.
 func printMutationWithApplied(cmd *cobra.Command, bs []byte, applied *mutationChanges) error {
+	mode := currentOutputMode()
 	var b struct {
 		Issue struct {
 			ShortID string `json:"short_id"`
@@ -451,13 +453,23 @@ func printMutationWithApplied(cmd *cobra.Command, bs []byte, applied *mutationCh
 	if err := json.Unmarshal(bs, &b); err != nil {
 		return err
 	}
-	if flags.JSON {
+	if mode == outputJSON {
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 			return err
 		}
 		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 		return err
+	}
+	if mode == outputAgent {
+		return printAgentMutation(cmd, commandLeaf(cmd), bs, func(w io.Writer, m agentIssueMutation) error {
+			if m.Issue.ClosedReason != nil {
+				if err := writeAgentField(w, "Reason", agentValue(*m.Issue.ClosedReason)); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 	}
 	if flags.Quiet {
 		_, err := fmt.Fprintln(cmd.OutOrStdout(), b.Issue.ShortID)

--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -612,12 +612,10 @@ func agentEditChangeNames(cmd *cobra.Command, changes *mutationChanges) []string
 
 func agentHasLinkChanges(cmd *cobra.Command, changes *mutationChanges) bool {
 	if changes != nil {
-		if changes.ParentSet != nil || changes.ParentRemoved != nil ||
+		return changes.ParentSet != nil || changes.ParentRemoved != nil ||
 			len(changes.BlocksAdded) > 0 || len(changes.BlocksRemoved) > 0 ||
 			len(changes.BlockedByAdded) > 0 || len(changes.BlockedByRemoved) > 0 ||
-			len(changes.RelatedAdded) > 0 || len(changes.RelatedRemoved) > 0 {
-			return true
-		}
+			len(changes.RelatedAdded) > 0 || len(changes.RelatedRemoved) > 0
 	}
 	for _, flag := range []string{
 		"parent", "blocks", "blocked-by", "related",

--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -462,10 +462,30 @@ func printMutationWithApplied(cmd *cobra.Command, bs []byte, applied *mutationCh
 		return err
 	}
 	if mode == outputAgent {
-		return printAgentMutation(cmd, commandLeaf(cmd), bs, func(w io.Writer, m agentIssueMutation) error {
+		var m agentIssueMutation
+		if err := json.Unmarshal(bs, &m); err != nil {
+			return err
+		}
+		verb := commandLeaf(cmd)
+		includeChangedTrue := verb == "edit"
+		return printAgentMutationDecoded(cmd.OutOrStdout(), verb, m, includeChangedTrue, func(w io.Writer, m agentIssueMutation) error {
 			if m.Issue.ClosedReason != nil {
 				if err := writeAgentField(w, "Reason", agentValue(*m.Issue.ClosedReason)); err != nil {
 					return err
+				}
+			}
+			if verb == "close" {
+				for _, evidence := range agentEvidenceSummaries(m) {
+					if err := writeAgentField(w, "Evidence", agentValue(evidence)); err != nil {
+						return err
+					}
+				}
+			}
+			if verb == "edit" && m.Changed {
+				if changes := agentEditChangeNames(cmd, b.Changes); len(changes) > 0 {
+					if err := writeAgentField(w, "Changes", strings.Join(changes, ", ")); err != nil {
+						return err
+					}
 				}
 			}
 			return nil
@@ -567,4 +587,85 @@ func summarizeChanges(c *mutationChanges, changed bool) string {
 		return ""
 	}
 	return "links: " + strings.Join(parts, ", ")
+}
+
+func agentEditChangeNames(cmd *cobra.Command, changes *mutationChanges) []string {
+	names := make([]string, 0, 5)
+	for _, item := range []struct {
+		flag string
+		name string
+	}{
+		{"title", "title"},
+		{"body", "body"},
+		{"owner", "owner"},
+		{"priority", "priority"},
+	} {
+		if cmd.Flags().Changed(item.flag) {
+			names = append(names, item.name)
+		}
+	}
+	if agentHasLinkChanges(cmd, changes) {
+		names = append(names, "links")
+	}
+	return names
+}
+
+func agentHasLinkChanges(cmd *cobra.Command, changes *mutationChanges) bool {
+	if changes != nil {
+		if changes.ParentSet != nil || changes.ParentRemoved != nil ||
+			len(changes.BlocksAdded) > 0 || len(changes.BlocksRemoved) > 0 ||
+			len(changes.BlockedByAdded) > 0 || len(changes.BlockedByRemoved) > 0 ||
+			len(changes.RelatedAdded) > 0 || len(changes.RelatedRemoved) > 0 {
+			return true
+		}
+	}
+	for _, flag := range []string{
+		"parent", "blocks", "blocked-by", "related",
+		"remove-parent", "remove-blocks", "remove-blocked-by", "remove-related",
+	} {
+		if cmd.Flags().Changed(flag) {
+			return true
+		}
+	}
+	return false
+}
+
+func agentEvidenceSummaries(m agentIssueMutation) []string {
+	if m.Event == nil || m.Event.Payload == "" {
+		return nil
+	}
+	var payload struct {
+		Evidence []struct {
+			Type      string   `json:"type"`
+			SHA       string   `json:"sha,omitempty"`
+			URL       string   `json:"url,omitempty"`
+			Command   string   `json:"command,omitempty"`
+			Paths     []string `json:"paths,omitempty"`
+			Rationale string   `json:"rationale,omitempty"`
+			IssueRef  string   `json:"issue_ref,omitempty"`
+		} `json:"evidence,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(m.Event.Payload), &payload); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(payload.Evidence))
+	for _, ev := range payload.Evidence {
+		switch ev.Type {
+		case "commit":
+			out = append(out, "commit:"+ev.SHA)
+		case "pr":
+			out = append(out, "pr:"+ev.URL)
+		case "test":
+			out = append(out, "test:"+ev.Command)
+		case "reviewed-paths":
+			out = append(out, "reviewed-paths:"+strings.Join(ev.Paths, ","))
+		case "no-change-audit":
+			out = append(out, "no-change-audit:"+ev.Rationale)
+		case "duplicate-of":
+			out = append(out, "duplicate-of:"+ev.IssueRef)
+		case "superseded-by":
+			out = append(out, "superseded-by:"+ev.IssueRef)
+		}
+	}
+	return out
 }

--- a/cmd/kata/create_test.go
+++ b/cmd/kata/create_test.go
@@ -25,6 +25,16 @@ func TestCreate_PrintsIssueShortIDInQuietMode(t *testing.T) {
 	assert.NotContains(t, out, "\n", "quiet mode must emit a single line")
 }
 
+func TestCreate_AgentOutput(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+
+	out := runCLI(t, env, dir, "--agent", "create", "first issue")
+
+	assert.Regexp(t, `(?m)^OK create \S+`, out)
+	assert.Contains(t, out, `Issue: `)
+	assert.Contains(t, out, `Status: open`)
+}
+
 func TestCreate_WithInitialLabelsAndParent(t *testing.T) {
 	env, dir := setupCLIEnv(t)
 	pid := resolvePIDViaHTTP(t, env.URL, dir)
@@ -137,6 +147,16 @@ func TestCreate_WithIdempotencyKeyReusesOnRepeat(t *testing.T) {
 	second := runCLI(t, env, dir, "--quiet", "create",
 		"first issue", "--idempotency-key", "K1")
 	assert.Equal(t, first, second, "same key + fingerprint must return existing issue short_id")
+}
+
+func TestCreate_AgentOutputIdempotencyReuse(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+
+	runCLI(t, env, dir, "--agent", "create", "first issue", "--idempotency-key", "K")
+	resetFlags(t)
+	second := runCLI(t, env, dir, "--agent", "create", "first issue", "--idempotency-key", "K")
+
+	assert.Contains(t, second, "reused=true changed=false")
 }
 
 // TestCreate_IdempotentReuseHumanModeOmitsLinksSummary pins that a

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -75,7 +75,15 @@ func daemonStatusCmd() *cobra.Command {
 					})
 				}
 			}
-			if flags.JSON {
+			switch currentOutputMode() {
+			case outputAgent:
+				status := "stopped"
+				if len(out.Daemons) > 0 {
+					status = "running"
+				}
+				_, err := fmt.Fprintf(cmd.OutOrStdout(), "OK daemon status=%s\n", status)
+				return err
+			case outputJSON:
 				return emitJSON(cmd.OutOrStdout(), out)
 			}
 			if len(out.Daemons) == 0 {

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -35,6 +37,13 @@ func daemonStartCmd() *cobra.Command {
 		Use:   "start",
 		Short: "start the daemon in foreground",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if currentOutputMode() == outputAgent {
+				return &cliError{
+					Message:  "kata daemon start does not support --agent; run without output formatting",
+					Kind:     kindUsage,
+					ExitCode: ExitUsage,
+				}
+			}
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 			return runDaemonWithListen(ctx, listen, insecureReadonly)
@@ -131,16 +140,53 @@ func daemonStopCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			mode := currentOutputMode()
+			pids := make([]int, 0, len(recs))
 			for _, r := range recs {
 				if daemon.ProcessAlive(r.PID) {
 					p, _ := os.FindProcess(r.PID)
 					_ = p.Signal(syscall.SIGTERM)
-					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "stopped pid=%d\n", r.PID)
+					pids = append(pids, r.PID)
+					if mode == outputHuman {
+						_, _ = fmt.Fprintf(cmd.OutOrStdout(), "stopped pid=%d\n", r.PID)
+					}
 				}
+			}
+			switch mode {
+			case outputAgent:
+				switch len(pids) {
+				case 0:
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "OK daemon action=stop stopped=0")
+				case 1:
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK daemon action=stop pid=%d\n", pids[0])
+				default:
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK daemon action=stop stopped=%d pids=%s\n",
+						len(pids), agentValue(joinInts(pids, ",")))
+				}
+			case outputJSON:
+				return emitJSON(cmd.OutOrStdout(), daemonStopOutput{
+					Action:  "stop",
+					Stopped: len(pids),
+					PIDs:    pids,
+				})
 			}
 			return nil
 		},
 	}
+}
+
+type daemonStopOutput struct {
+	Action  string `json:"action"`
+	Stopped int    `json:"stopped"`
+	PIDs    []int  `json:"pids"`
+}
+
+func joinInts(values []int, sep string) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, strconv.Itoa(value))
+	}
+	return strings.Join(parts, sep)
 }
 
 func daemonReloadCmd() *cobra.Command {
@@ -173,13 +219,28 @@ func daemonReloadCmd() *cobra.Command {
 						Message: fmt.Sprintf("signal pid %d: %v", r.PID, err),
 					}
 				}
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-					"reload signal sent to pid=%d (check daemon log for result)\n", r.PID)
+				switch currentOutputMode() {
+				case outputAgent:
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK daemon action=reload pid=%d\n", r.PID)
+				case outputJSON:
+					return emitJSON(cmd.OutOrStdout(), daemonReloadOutput{
+						Action: "reload",
+						PID:    r.PID,
+					})
+				default:
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+						"reload signal sent to pid=%d (check daemon log for result)\n", r.PID)
+				}
 				return nil
 			}
 			return &cliError{Kind: kindUsage, ExitCode: ExitUsage, Message: "no daemon running"}
 		},
 	}
+}
+
+type daemonReloadOutput struct {
+	Action string `json:"action"`
+	PID    int    `json:"pid"`
 }
 
 // runDaemon is the foreground daemon entry point. Used by `kata daemon start`

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -83,6 +85,154 @@ func TestDaemonStatus_AgentReportsStopped(t *testing.T) {
 
 	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "status")
 	assert.Equal(t, "OK daemon status=stopped\n", string(out))
+}
+
+func TestDaemonStart_RejectsAgentOutputBeforeStartup(t *testing.T) {
+	for _, args := range [][]string{
+		{"--agent", "daemon", "start", "--listen", "8.8.8.8:7777"},
+		{"--format", "agent", "daemon", "start", "--listen", "8.8.8.8:7777"},
+	} {
+		resetFlags(t)
+		setupKataEnv(t)
+
+		stdout, stderr, err := executeRootCapture(t, context.Background(), args...)
+
+		require.Error(t, err, "args %v", args)
+		ce := requireCLIError(t, err, ExitUsage)
+		assert.Equal(t, kindUsage, ce.Kind)
+		assert.Contains(t, ce.Message, "kata daemon start does not support --agent")
+		assert.Empty(t, stdout)
+		assert.Contains(t, stderr, "kata daemon start does not support --agent")
+		assert.NotContains(t, stderr, "non-public")
+	}
+}
+
+func TestDaemonStop_AgentReportsStoppedPID(t *testing.T) {
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	child := startSleepProcess(t)
+	writeRuntimePID(t, tmp, child.Process.Pid)
+
+	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "stop")
+
+	assert.Equal(t, "OK daemon action=stop pid="+strconv.Itoa(child.Process.Pid)+"\n", string(out))
+}
+
+func TestDaemonStop_AgentNoDaemonReportsNoop(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+
+	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "stop")
+
+	assert.Equal(t, "OK daemon action=stop stopped=0\n", string(out))
+}
+
+func TestDaemonStop_JSONReportsStoppedPIDs(t *testing.T) {
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	child := startSleepProcess(t)
+	writeRuntimePID(t, tmp, child.Process.Pid)
+
+	out := executeRoot(t, newRootCmd(), "--json", "daemon", "stop")
+
+	var got struct {
+		KataAPIVersion int    `json:"kata_api_version"`
+		Action         string `json:"action"`
+		Stopped        int    `json:"stopped"`
+		PIDs           []int  `json:"pids"`
+	}
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, 1, got.KataAPIVersion)
+	assert.Equal(t, "stop", got.Action)
+	assert.Equal(t, 1, got.Stopped)
+	assert.Equal(t, []int{child.Process.Pid}, got.PIDs)
+}
+
+func TestDaemonStop_JSONReportsNoop(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+
+	out := executeRoot(t, newRootCmd(), "--json", "daemon", "stop")
+
+	var got struct {
+		KataAPIVersion int    `json:"kata_api_version"`
+		Action         string `json:"action"`
+		Stopped        int    `json:"stopped"`
+		PIDs           []int  `json:"pids"`
+	}
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, 1, got.KataAPIVersion)
+	assert.Equal(t, "stop", got.Action)
+	assert.Equal(t, 0, got.Stopped)
+	assert.Empty(t, got.PIDs)
+}
+
+func TestDaemonStop_AgentReportsMultiplePIDs(t *testing.T) {
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	first := startSleepProcess(t)
+	second := startSleepProcess(t)
+	writeRuntimePID(t, tmp, first.Process.Pid)
+	writeRuntimePID(t, tmp, second.Process.Pid)
+
+	out := string(executeRoot(t, newRootCmd(), "--agent", "daemon", "stop"))
+
+	assert.Contains(t, out, "OK daemon action=stop stopped=2 pids=")
+	assert.Contains(t, out, strconv.Itoa(first.Process.Pid))
+	assert.Contains(t, out, strconv.Itoa(second.Process.Pid))
+}
+
+func TestDaemonStop_JSONReportsMultiplePIDs(t *testing.T) {
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	first := startSleepProcess(t)
+	second := startSleepProcess(t)
+	writeRuntimePID(t, tmp, first.Process.Pid)
+	writeRuntimePID(t, tmp, second.Process.Pid)
+
+	out := executeRoot(t, newRootCmd(), "--json", "daemon", "stop")
+
+	var got struct {
+		KataAPIVersion int    `json:"kata_api_version"`
+		Action         string `json:"action"`
+		Stopped        int    `json:"stopped"`
+		PIDs           []int  `json:"pids"`
+	}
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, 1, got.KataAPIVersion)
+	assert.Equal(t, "stop", got.Action)
+	assert.Equal(t, 2, got.Stopped)
+	assert.ElementsMatch(t, []int{first.Process.Pid, second.Process.Pid}, got.PIDs)
+}
+
+func TestDaemonReload_AgentReportsReloadedPID(t *testing.T) {
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	child := startSleepProcess(t)
+	writeRuntimePID(t, tmp, child.Process.Pid)
+
+	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "reload")
+
+	assert.Equal(t, "OK daemon action=reload pid="+strconv.Itoa(child.Process.Pid)+"\n", string(out))
+}
+
+func TestDaemonReload_JSONReportsReloadedPID(t *testing.T) {
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	child := startSleepProcess(t)
+	writeRuntimePID(t, tmp, child.Process.Pid)
+
+	out := executeRoot(t, newRootCmd(), "--json", "daemon", "reload")
+
+	var got struct {
+		KataAPIVersion int    `json:"kata_api_version"`
+		Action         string `json:"action"`
+		PID            int    `json:"pid"`
+	}
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, 1, got.KataAPIVersion)
+	assert.Equal(t, "reload", got.Action)
+	assert.Equal(t, child.Process.Pid, got.PID)
 }
 
 func TestHealth_AgentReportsOK(t *testing.T) {
@@ -190,4 +340,32 @@ func TestEnsureDaemon_ReturnsExistingURL(t *testing.T) {
 	url, err := ensureDaemon(context.Background())
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(url, "http://"))
+}
+
+func startSleepProcess(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("sleep", "60") //nolint:gosec // test helper starts a controlled local process
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+	return cmd
+}
+
+func writeRuntimePID(t *testing.T, home string, pid int) {
+	t.Helper()
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	require.NoError(t, ns.EnsureDirs())
+	_, err = daemon.WriteRuntimeFile(ns.DataDir, daemon.RuntimeRecord{
+		PID:       pid,
+		Address:   "unix://" + filepath.Join(home, "daemon.sock"),
+		DBPath:    filepath.Join(home, "kata.db"),
+		Version:   "v-test",
+		StartedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
 }

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/testenv"
 )
 
 func TestDaemonStatus_NoDaemonReportsAbsent(t *testing.T) {
@@ -74,6 +75,24 @@ func TestDaemonStatus_JSONReportsEmptyDaemonList(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &got))
 	assert.Equal(t, 1, got.KataAPIVersion)
 	assert.JSONEq(t, "[]", string(got.Daemons))
+}
+
+func TestDaemonStatus_AgentReportsStopped(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+
+	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "status")
+	assert.Equal(t, "OK daemon status=stopped\n", string(out))
+}
+
+func TestHealth_AgentReportsOK(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	cmd := newRootCmd()
+	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
+
+	out := executeRoot(t, cmd, "--agent", "health")
+	assert.Contains(t, string(out), "OK health")
 }
 
 func TestDaemonStart_ListenFlagRejectsPublicAddress(t *testing.T) {

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -242,7 +242,7 @@ func TestHealth_AgentReportsOK(t *testing.T) {
 	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
 
 	out := executeRoot(t, cmd, "--agent", "health")
-	assert.Contains(t, string(out), "OK health")
+	assert.Equal(t, "OK health ok=true daemon=running\n", string(out))
 }
 
 func TestDaemonStart_ListenFlagRejectsPublicAddress(t *testing.T) {

--- a/cmd/kata/daemon_logs.go
+++ b/cmd/kata/daemon_logs.go
@@ -157,7 +157,7 @@ func runHookLogOnce(stdout, stderr io.Writer, limit int, f *hookLogFilter) (acti
 		start = len(matches) - limit
 	}
 	for _, m := range matches[start:] {
-		writeLine(stdout, m)
+		writeHookLogRecord(stdout, []byte(m))
 	}
 	return mark, nil
 }
@@ -169,6 +169,47 @@ func runHookLogOnce(stdout, stderr io.Writer, limit int, f *hookLogFilter) (acti
 func writeLine(w io.Writer, s string) {
 	_, _ = w.Write([]byte(s))
 	_, _ = w.Write([]byte{'\n'})
+}
+
+func writeHookLogRecord(w io.Writer, raw []byte) {
+	if currentOutputMode() != outputAgent {
+		writeLine(w, string(raw))
+		return
+	}
+	var rec map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		return
+	}
+	writeLine(w, formatAgentHookLogRecord(rec))
+}
+
+func formatAgentHookLogRecord(rec map[string]json.RawMessage) string {
+	keys := make([]string, 0, len(rec))
+	for k := range rec {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("OK daemon_log")
+	for _, k := range keys {
+		b.WriteByte(' ')
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(agentLogValue(rec[k]))
+	}
+	return b.String()
+}
+
+func agentLogValue(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return agentValue(s)
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return agentValue(string(raw))
+	}
+	return agentValue(buf.String())
 }
 
 // readMatchesFromFile reads one file and returns its matching records.
@@ -372,7 +413,7 @@ func emitOne(content []byte, lineNo int, path string, stdout, stderr io.Writer, 
 		}
 		return
 	}
-	writeLine(stdout, string(rec))
+	writeHookLogRecord(stdout, rec)
 }
 
 // hookRunsRoot returns $KATA_HOME/hooks/<dbhash> for the active KATA_DB.

--- a/cmd/kata/daemon_logs_test.go
+++ b/cmd/kata/daemon_logs_test.go
@@ -147,6 +147,62 @@ func TestDaemonLogs_Hooks_MalformedLineSkippedWithStderrWarning(t *testing.T) {
 	}
 }
 
+func TestDaemonLogs_Hooks_AgentSkipsMalformedLine(t *testing.T) {
+	_, dir, _ := setupHooksDir(t)
+	contents := "{\"event_id\":1,\"result\":\"ok\"}\nnot-json\n{\"event_id\":2,\"result\":\"ok\"}\n"
+	if err := os.WriteFile(filepath.Join(dir, "runs.jsonl"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resetFlags(t)
+	stdout, stderr, err := executeRootCapture(t, context.Background(), "--agent", "daemon", "logs", "--hooks")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "OK daemon_log event_id=1 result=ok")
+	assert.Contains(t, stdout, "OK daemon_log event_id=2 result=ok")
+	assert.NotContains(t, stdout, "not-json")
+	assert.NotContains(t, stdout, "raw=")
+	assert.Contains(t, stderr, "skipping malformed line")
+}
+
+func TestDaemonLogs_Hooks_AgentOutputOneLinePerRecord(t *testing.T) {
+	_, dir, _ := setupHooksDir(t)
+	writeRuns(t, dir, map[string][]map[string]any{
+		"runs.jsonl": {{
+			"event_id":   1,
+			"event_type": "issue.created",
+			"hook_index": 0,
+			"result":     "failed",
+			"exit_code":  1,
+			"stderr":     "first line\nsecond line",
+		}},
+	})
+	resetFlags(t)
+
+	stdout, _, err := executeRootCapture(t, context.Background(), "--agent", "daemon", "logs", "--hooks")
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	require.Len(t, lines, 1, "agent daemon logs must emit one physical line per record: %q", stdout)
+	assert.Contains(t, lines[0], "OK daemon_log")
+	assert.Contains(t, lines[0], "event_id=1")
+	assert.Contains(t, lines[0], "event_type=issue.created")
+	assert.Contains(t, lines[0], "hook_index=0")
+	assert.Contains(t, lines[0], "result=failed")
+	assert.Contains(t, lines[0], "exit_code=1")
+	assert.Contains(t, lines[0], `stderr="first line\nsecond line"`)
+	assert.NotContains(t, lines[0], "{")
+}
+
+func TestFormatAgentHookLogRecordFormatsDecodedRecord(t *testing.T) {
+	got := formatAgentHookLogRecord(map[string]json.RawMessage{
+		"event_id":   json.RawMessage(`1`),
+		"event_type": json.RawMessage(`"issue.created"`),
+		"stderr":     json.RawMessage(`"first line\nsecond line"`),
+	})
+
+	assert.Equal(t, `OK daemon_log event_id=1 event_type=issue.created stderr="first line\nsecond line"`, got)
+}
+
 // TestDaemonLogs_Hooks_Tail_RotatedOnlyWaitsForActive guards the
 // awaitActiveFile contract that --tail will not latch onto a rotated
 // runs.jsonl.N when the active runs.jsonl is missing. Before the fix,

--- a/cmd/kata/delete.go
+++ b/cmd/kata/delete.go
@@ -160,12 +160,36 @@ func printDestructive(cmd *cobra.Command, ref, verb string, bs []byte) error {
 	}
 	if mode == outputAgent {
 		if verb == "delete" {
-			return printAgentMutation(cmd, "delete", bs, func(w io.Writer, _ agentIssueMutation) error {
-				if err := writeAgentField(w, "Deleted", "true"); err != nil {
+			var m agentIssueMutation
+			if err := json.Unmarshal(bs, &m); err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if !flags.Quiet {
+				if _, err := fmt.Fprintf(out, "OK delete %s", m.Issue.ShortID); err != nil {
 					return err
 				}
-				return writeAgentField(w, "Undo", "kata restore "+shellQuoteArg(ref)+" --agent")
-			})
+				if !m.Changed {
+					if _, err := fmt.Fprint(out, " changed=false"); err != nil {
+						return err
+					}
+				}
+				if _, err := fmt.Fprintln(out); err != nil {
+					return err
+				}
+			}
+			if m.Issue.ShortID != "" && m.Issue.Title != "" {
+				if _, err := fmt.Fprintf(out, "Issue: %s %s\n", m.Issue.ShortID, agentValue(m.Issue.Title)); err != nil {
+					return err
+				}
+			}
+			if err := writeAgentField(out, "Status", "deleted"); err != nil {
+				return err
+			}
+			if err := writeAgentField(out, "Deleted", "true"); err != nil {
+				return err
+			}
+			return writeAgentField(out, "Undo", "kata restore "+shellQuoteArg(ref)+" --agent")
 		}
 		if verb == "purge" {
 			var b struct {

--- a/cmd/kata/delete.go
+++ b/cmd/kata/delete.go
@@ -160,7 +160,7 @@ func printDestructive(cmd *cobra.Command, ref, verb string, bs []byte) error {
 	}
 	if mode == outputAgent {
 		if verb == "delete" {
-			return printAgentMutation(cmd, "delete", bs, func(w io.Writer, m agentIssueMutation) error {
+			return printAgentMutation(cmd, "delete", bs, func(w io.Writer, _ agentIssueMutation) error {
 				if err := writeAgentField(w, "Deleted", "true"); err != nil {
 					return err
 				}

--- a/cmd/kata/delete.go
+++ b/cmd/kata/delete.go
@@ -191,7 +191,7 @@ func printDestructive(cmd *cobra.Command, ref, verb string, bs []byte) error {
 					return err
 				}
 			}
-			return writeAgentField(cmd.OutOrStdout(), "Purged", "true")
+			return writeAgentField(cmd.OutOrStdout(), "Status", "purged")
 		}
 	}
 	if flags.Quiet {

--- a/cmd/kata/delete.go
+++ b/cmd/kata/delete.go
@@ -149,13 +149,50 @@ func runDestructive(cmd *cobra.Command, baseURL string, pid int64, pathRef, disp
 // printDestructive renders the destructive-action response in the active
 // output mode (JSON envelope, quiet, or one-line human).
 func printDestructive(cmd *cobra.Command, ref, verb string, bs []byte) error {
-	if flags.JSON {
+	mode := currentOutputMode()
+	if mode == outputJSON {
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 			return err
 		}
 		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 		return err
+	}
+	if mode == outputAgent {
+		if verb == "delete" {
+			return printAgentMutation(cmd, "delete", bs, func(w io.Writer, m agentIssueMutation) error {
+				if err := writeAgentField(w, "Deleted", "true"); err != nil {
+					return err
+				}
+				return writeAgentField(w, "Undo", "kata restore "+shellQuoteArg(ref)+" --agent")
+			})
+		}
+		if verb == "purge" {
+			var b struct {
+				PurgeLog struct {
+					ShortID    *string `json:"short_id"`
+					IssueTitle string  `json:"issue_title"`
+				} `json:"purge_log"`
+			}
+			if err := json.Unmarshal(bs, &b); err != nil {
+				return err
+			}
+			shortID := ref
+			if b.PurgeLog.ShortID != nil && *b.PurgeLog.ShortID != "" {
+				shortID = *b.PurgeLog.ShortID
+			}
+			if !flags.Quiet {
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "OK purge %s\n", shortID); err != nil {
+					return err
+				}
+			}
+			if b.PurgeLog.IssueTitle != "" {
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Issue: %s %s\n", shortID, agentValue(b.PurgeLog.IssueTitle)); err != nil {
+					return err
+				}
+			}
+			return writeAgentField(cmd.OutOrStdout(), "Purged", "true")
+		}
 	}
 	if flags.Quiet {
 		return nil
@@ -170,6 +207,31 @@ func printDestructive(cmd *cobra.Command, ref, verb string, bs []byte) error {
 		return err
 	}
 	return nil
+}
+
+func shellQuoteArg(s string) string {
+	if isShellSafeArg(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func isShellSafeArg(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case strings.ContainsRune("@%_+=:,./-", r):
+		case r == '#' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // httpDoJSONWithHeader mirrors httpDoJSON but lets callers attach extra

--- a/cmd/kata/delete_test.go
+++ b/cmd/kata/delete_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +25,46 @@ func TestDelete_ForceWithConfirmSoftDeletes(t *testing.T) {
 
 	require.NoError(t, f.execute("delete", short, "--force", "--confirm", "DELETE kata#"+short))
 	assert.Contains(t, f.buf.String(), "deleted")
+}
+
+func TestDelete_AgentOutput(t *testing.T) {
+	env, dir, _ := setupCLIWorkspace(t)
+	short := createIssueViaHTTP(t, env, dir, "to be deleted")
+
+	out := runCLI(t, env, dir, "--agent", "delete", short, "--force", "--confirm", "DELETE kata#"+short)
+
+	assert.Regexp(t, `(?m)^OK delete \S+`, out)
+	assert.Contains(t, out, "Undo: kata restore kata#"+short+" --agent")
+}
+
+func TestDelete_AgentUndoUsesQualifiedRef(t *testing.T) {
+	resetFlags(t)
+	flags.Mode = outputAgent
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	body := []byte(`{"issue":{"short_id":"abc4","qualified_id":"other#abc4","title":"to be deleted","status":"open"},"changed":true}`)
+
+	require.NoError(t, printDestructive(cmd, "other#abc4", "delete", body))
+
+	out := buf.String()
+	assert.Contains(t, out, "Undo: kata restore other#abc4 --agent")
+	assert.NotContains(t, out, "Undo: kata restore abc4 --agent")
+}
+
+func TestDelete_AgentUndoQuotesQualifiedRefForShell(t *testing.T) {
+	resetFlags(t)
+	flags.Mode = outputAgent
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	body := []byte(`{"issue":{"short_id":"abc4","qualified_id":"Kata Tracker#abc4","title":"to be deleted","status":"open"},"changed":true}`)
+
+	require.NoError(t, printDestructive(cmd, "Kata Tracker#abc4", "delete", body))
+
+	out := buf.String()
+	assert.Contains(t, out, "Undo: kata restore 'Kata Tracker#abc4' --agent")
+	assert.NotContains(t, out, "Undo: kata restore Kata Tracker#abc4 --agent")
 }
 
 func TestDelete_ConfirmMismatchIsExit6(t *testing.T) {

--- a/cmd/kata/delete_test.go
+++ b/cmd/kata/delete_test.go
@@ -34,6 +34,8 @@ func TestDelete_AgentOutput(t *testing.T) {
 	out := runCLI(t, env, dir, "--agent", "delete", short, "--force", "--confirm", "DELETE kata#"+short)
 
 	assert.Regexp(t, `(?m)^OK delete \S+`, out)
+	assert.Contains(t, out, "Status: deleted")
+	assert.NotContains(t, out, "Status: open")
 	assert.Contains(t, out, "Undo: kata restore kata#"+short+" --agent")
 }
 

--- a/cmd/kata/diagnostic_test.go
+++ b/cmd/kata/diagnostic_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
@@ -17,6 +18,21 @@ func TestWhoami_FlagOverride(t *testing.T) {
 	out := requireCmdOutput(t, nil, "whoami", "--as", "claude-4.7")
 	assert.Contains(t, out, "claude-4.7")
 	assert.Contains(t, out, "flag")
+}
+
+func TestWhoami_FormatJSONAliasAffectsSuccessfulOutput(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newRootCmd(), "--format", "json", "whoami", "--as", "tester"))
+
+	var got struct {
+		KataAPIVersion int    `json:"kata_api_version"`
+		Actor          string `json:"actor"`
+		Source         string `json:"source"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "output must be JSON: %s", out)
+	assert.Equal(t, 1, got.KataAPIVersion)
+	assert.Equal(t, "tester", got.Actor)
+	assert.Equal(t, "flag", got.Source)
 }
 
 func TestHealth_PrintsSchemaVersion(t *testing.T) {

--- a/cmd/kata/diagnostic_test.go
+++ b/cmd/kata/diagnostic_test.go
@@ -35,6 +35,12 @@ func TestWhoami_FormatJSONAliasAffectsSuccessfulOutput(t *testing.T) {
 	assert.Equal(t, "flag", got.Source)
 }
 
+func TestWhoami_AgentIncludesActorAndSource(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newRootCmd(), "--agent", "whoami", "--as", "tester"))
+	assert.Equal(t, "OK whoami actor=tester source=flag\n", out)
+}
+
 func TestHealth_PrintsSchemaVersion(t *testing.T) {
 	env := testenv.New(t)
 	out := requireCmdOutput(t, env, "health")

--- a/cmd/kata/digest.go
+++ b/cmd/kata/digest.go
@@ -103,13 +103,17 @@ cross-project digest.`,
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
-			if flags.JSON {
+			mode := currentOutputMode()
+			if mode == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err
 				}
 				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 				return err
+			}
+			if mode == outputAgent {
+				return printDigestAgent(cmd, bs)
 			}
 			return printDigestHuman(cmd, bs)
 		},
@@ -255,6 +259,52 @@ func printDigestHuman(cmd *cobra.Command, bs []byte) error {
 			}
 			if _, err := fmt.Fprintf(out, "  %-14s %s\n",
 				prefix, textsafe.Line(strings.Join(iss.Actions, ", "))); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func printDigestAgent(cmd *cobra.Command, bs []byte) error {
+	var b struct {
+		Since      time.Time `json:"since"`
+		Until      time.Time `json:"until"`
+		EventCount int       `json:"event_count"`
+		Actors     []struct {
+			Actor  string `json:"actor"`
+			Issues []struct {
+				ProjectName  string   `json:"project_name"`
+				IssueShortID string   `json:"issue_short_id"`
+				Actions      []string `json:"actions"`
+			} `json:"issues"`
+		} `json:"actors"`
+	}
+	if err := json.Unmarshal(bs, &b); err != nil {
+		return err
+	}
+	count := 0
+	for _, a := range b.Actors {
+		count += len(a.Issues)
+	}
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "OK digest count=%d events=%d since=%s until=%s\n",
+		count, b.EventCount,
+		agentValue(b.Since.Format(time.RFC3339)),
+		agentValue(b.Until.Format(time.RFC3339))); err != nil {
+		return err
+	}
+	for _, a := range b.Actors {
+		for _, iss := range a.Issues {
+			fields := []agentField{
+				agentRowField("actor", a.Actor),
+				agentRowField("issue", iss.IssueShortID),
+				agentRowListField("actions", iss.Actions),
+			}
+			if iss.ProjectName != "" {
+				fields = append(fields, agentRowField("project", iss.ProjectName))
+			}
+			if err := writeAgentKVRow(out, fields...); err != nil {
 				return err
 			}
 		}

--- a/cmd/kata/digest_test.go
+++ b/cmd/kata/digest_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +23,21 @@ func TestDigest_HumanRender(t *testing.T) {
 	assert.Contains(t, out, first)
 	assert.Contains(t, out, second)
 	assert.Contains(t, out, "created")
+}
+
+func TestDigest_AgentOutputShape(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	short := createIssueViaHTTP(t, env, dir, "first")
+
+	out := runCLI(t, env, dir, "--agent", "digest", "--since", "1h")
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.GreaterOrEqual(t, len(lines), 2, "agent digest should include header and rows: %q", out)
+	assert.Regexp(t, `^OK digest count=\d+`, lines[0])
+	assert.Contains(t, lines[1], "actor=tester")
+	assert.Contains(t, lines[1], "issue="+short)
+	assert.Contains(t, lines[1], "actions=created")
+	assert.NotContains(t, out, "\x1b", "agent output must not contain ANSI escape bytes")
 }
 
 // TestDigest_OutputShape pins the JSON wire shape: per-issue rows carry

--- a/cmd/kata/edit_test.go
+++ b/cmd/kata/edit_test.go
@@ -177,6 +177,21 @@ func TestEdit_HumanModePrintsLinkSummary(t *testing.T) {
 		"human-mode no-op edit must say so explicitly: %q", out)
 }
 
+func TestEdit_AgentOutputIncludesChangedAndChanges(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	subject := createIssue(t, env, pid, "subject")
+	target := createIssue(t, env, pid, "target")
+
+	out := runCLI(t, env, dir, "--agent", "edit", subject,
+		"--title", "renamed subject",
+		"--owner", "wesm",
+		"--blocks", target)
+
+	assert.Regexp(t, `(?m)^OK edit \S+ changed=true`, out)
+	assert.Contains(t, out, "Changes: title, owner, links")
+}
+
 // TestEdit_DistinctParentRefsRejected covers the at-most-one parent contract.
 // --parent A --parent B (or --remove-parent) must error rather than
 // silently last-winning so a typo can't mutate the wrong relationship.

--- a/cmd/kata/edit_test.go
+++ b/cmd/kata/edit_test.go
@@ -192,6 +192,21 @@ func TestEdit_AgentOutputIncludesChangedAndChanges(t *testing.T) {
 	assert.Contains(t, out, "Changes: title, owner, links")
 }
 
+func TestEdit_AgentOutputDoesNotReportNoopLinkChanges(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	subject := createIssue(t, env, pid, "subject")
+	target := createIssue(t, env, pid, "target")
+
+	out := runCLI(t, env, dir, "--agent", "edit", subject,
+		"--title", "renamed subject",
+		"--remove-blocks", target)
+
+	assert.Regexp(t, `(?m)^OK edit \S+ changed=true`, out)
+	assert.Contains(t, out, "Changes: title")
+	assert.NotContains(t, out, "Changes: title, links")
+}
+
 // TestEdit_DistinctParentRefsRejected covers the at-most-one parent contract.
 // --parent A --parent B (or --remove-parent) must error rather than
 // silently last-winning so a typo can't mutate the wrong relationship.

--- a/cmd/kata/events.go
+++ b/cmd/kata/events.go
@@ -116,13 +116,17 @@ func runEventsPoll(cmd *cobra.Command, opts eventsPollOptions) error {
 	if status >= 400 {
 		return apiErrFromBody(status, bs)
 	}
-	if flags.JSON {
+	mode := currentOutputMode()
+	if mode == outputJSON {
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 			return err
 		}
 		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 		return err
+	}
+	if mode == outputAgent {
+		return printEventsAgent(cmd, bs)
 	}
 	return printEventsHuman(cmd, bs)
 }
@@ -184,6 +188,43 @@ func printEventsHuman(cmd *cobra.Command, bs []byte) error {
 	return nil
 }
 
+func printEventsAgent(cmd *cobra.Command, bs []byte) error {
+	var b struct {
+		ResetRequired bool  `json:"reset_required"`
+		ResetAfterID  int64 `json:"reset_after_id"`
+		Events        []struct {
+			EventID      int64   `json:"event_id"`
+			Type         string  `json:"type"`
+			IssueShortID *string `json:"issue_short_id"`
+			Actor        string  `json:"actor"`
+		} `json:"events"`
+		NextAfterID int64 `json:"next_after_id"`
+	}
+	if err := json.Unmarshal(bs, &b); err != nil {
+		return err
+	}
+	out := cmd.OutOrStdout()
+	if b.ResetRequired {
+		_, err := fmt.Fprintf(out, "OK events reset_required=true reset_after_id=%d\n", b.ResetAfterID)
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "OK events count=%d next_after_id=%d\n", len(b.Events), b.NextAfterID); err != nil {
+		return err
+	}
+	for _, e := range b.Events {
+		id := fmt.Sprint(e.EventID)
+		if err := writeAgentKVRow(out,
+			agentRowField("id", id),
+			agentRowField("type", e.Type),
+			agentOptionalRowField("issue", e.IssueShortID),
+			agentRowField("actor", e.Actor),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type eventsTailOptions struct {
 	ProjectIDArg int64
 	AllProjects  bool
@@ -235,13 +276,14 @@ func runEventsTail(cmd *cobra.Command, opts eventsTailOptions) error {
 		return err
 	}
 	out := cmd.OutOrStdout()
+	mode := currentOutputMode()
 	cursor := opts.LastEventID
 	backoff := tailBackoffStart
 	for {
 		if ctx.Err() != nil {
 			return nil
 		}
-		res, sErr := streamOnce(ctx, client, url, cursor, out)
+		res, sErr := streamOnce(ctx, client, url, cursor, out, mode)
 		if errors.Is(sErr, errTerminalHTTP) {
 			return sErr
 		}
@@ -315,10 +357,9 @@ func (f *frameState) empty() bool {
 
 // flush writes the frame to out and returns the typed result. Callers
 // must call reset() afterward (deferred by the caller, not here, so the
-// return path is single-purpose). Output is always NDJSON: one envelope
-// per line, plus a synthetic reset envelope on sync.reset_required so
-// consumers can match on reset_required.
-func (f *frameState) flush(out io.Writer) (streamResult, error) {
+// return path is single-purpose). JSON/human tail output stays NDJSON;
+// agent tail output uses compact one-line records.
+func (f *frameState) flush(out io.Writer, mode outputMode) (streamResult, error) {
 	if f.event == "sync.reset_required" {
 		var r struct {
 			ResetAfterID int64 `json:"reset_after_id"`
@@ -326,15 +367,24 @@ func (f *frameState) flush(out io.Writer) (streamResult, error) {
 		if err := json.Unmarshal([]byte(f.data), &r); err != nil {
 			return streamResult{}, fmt.Errorf("parse reset frame: %w", err)
 		}
-		env := resetEnvelope{ResetRequired: true, ResetAfterID: r.ResetAfterID}
-		body, err := json.Marshal(env)
-		if err != nil {
-			return streamResult{}, fmt.Errorf("encode reset envelope: %w", err)
-		}
-		if _, err := fmt.Fprintln(out, string(body)); err != nil {
-			return streamResult{}, err
+		if mode == outputAgent {
+			if _, err := fmt.Fprintf(out, "OK events reset_required=true reset_after_id=%d\n", r.ResetAfterID); err != nil {
+				return streamResult{}, err
+			}
+		} else {
+			env := resetEnvelope{ResetRequired: true, ResetAfterID: r.ResetAfterID}
+			body, err := json.Marshal(env)
+			if err != nil {
+				return streamResult{}, fmt.Errorf("encode reset envelope: %w", err)
+			}
+			if _, err := fmt.Fprintln(out, string(body)); err != nil {
+				return streamResult{}, err
+			}
 		}
 		return streamResult{Reset: &streamResetSignal{newCursor: r.ResetAfterID}}, nil
+	}
+	if mode == outputAgent {
+		return f.flushAgentEvent(out)
 	}
 	if _, err := fmt.Fprintln(out, f.data); err != nil {
 		return streamResult{}, err
@@ -343,7 +393,41 @@ func (f *frameState) flush(out io.Writer) (streamResult, error) {
 	return streamResult{Progress: streamProgress{lastID: n}}, nil
 }
 
-func streamOnce(ctx context.Context, client *http.Client, baseURL string, cursor int64, out io.Writer) (streamResult, error) {
+func (f *frameState) flushAgentEvent(out io.Writer) (streamResult, error) {
+	var e struct {
+		EventID      int64   `json:"event_id"`
+		Type         string  `json:"type"`
+		IssueShortID *string `json:"issue_short_id"`
+		Actor        string  `json:"actor"`
+	}
+	if err := json.Unmarshal([]byte(f.data), &e); err != nil {
+		return streamResult{}, fmt.Errorf("parse event frame: %w", err)
+	}
+	id := e.EventID
+	if id == 0 {
+		id, _ = strconv.ParseInt(f.id, 10, 64)
+	}
+	progressID, _ := strconv.ParseInt(f.id, 10, 64)
+	if _, err := fmt.Fprintf(out, "OK event id=%d type=%s", id, agentValue(e.Type)); err != nil {
+		return streamResult{}, err
+	}
+	if e.IssueShortID != nil && *e.IssueShortID != "" {
+		if _, err := fmt.Fprintf(out, " issue=%s", agentValue(*e.IssueShortID)); err != nil {
+			return streamResult{}, err
+		}
+	}
+	if e.Actor != "" {
+		if _, err := fmt.Fprintf(out, " actor=%s", agentValue(e.Actor)); err != nil {
+			return streamResult{}, err
+		}
+	}
+	if _, err := fmt.Fprintln(out); err != nil {
+		return streamResult{}, err
+	}
+	return streamResult{Progress: streamProgress{lastID: progressID}}, nil
+}
+
+func streamOnce(ctx context.Context, client *http.Client, baseURL string, cursor int64, out io.Writer, mode outputMode) (streamResult, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL, nil)
 	if err != nil {
 		return streamResult{Progress: streamProgress{lastID: cursor}}, err
@@ -370,12 +454,12 @@ func streamOnce(ctx context.Context, client *http.Client, baseURL string, cursor
 		return streamResult{Progress: streamProgress{lastID: cursor}},
 			fmt.Errorf("http %d: %s", resp.StatusCode, string(bs))
 	}
-	return parseSSEStream(bufio.NewReader(resp.Body), cursor, out)
+	return parseSSEStream(bufio.NewReader(resp.Body), cursor, out, mode)
 }
 
 // parseSSEStream pulls SSE frames off rd until EOF or a reset frame and
-// emits each event's data: line as NDJSON via flushFrame on out.
-func parseSSEStream(rd *bufio.Reader, cursor int64, out io.Writer) (streamResult, error) {
+// emits each event in the caller-selected output mode.
+func parseSSEStream(rd *bufio.Reader, cursor int64, out io.Writer, mode outputMode) (streamResult, error) {
 	var f frameState
 	progress := streamProgress{lastID: cursor}
 	for {
@@ -391,7 +475,7 @@ func parseSSEStream(rd *bufio.Reader, cursor int64, out io.Writer) (streamResult
 			if f.empty() {
 				continue
 			}
-			res, ferr := f.flush(out)
+			res, ferr := f.flush(out, mode)
 			f.reset()
 			if ferr != nil {
 				return streamResult{Progress: progress}, ferr

--- a/cmd/kata/events.go
+++ b/cmd/kata/events.go
@@ -195,6 +195,7 @@ func printEventsAgent(cmd *cobra.Command, bs []byte) error {
 		Events        []struct {
 			EventID      int64   `json:"event_id"`
 			Type         string  `json:"type"`
+			ProjectName  string  `json:"project_name"`
 			IssueShortID *string `json:"issue_short_id"`
 			Actor        string  `json:"actor"`
 		} `json:"events"`
@@ -213,9 +214,11 @@ func printEventsAgent(cmd *cobra.Command, bs []byte) error {
 	}
 	for _, e := range b.Events {
 		id := fmt.Sprint(e.EventID)
+		project := e.ProjectName
 		if err := writeAgentKVRow(out,
 			agentRowField("id", id),
 			agentRowField("type", e.Type),
+			agentOptionalRowField("project", &project),
 			agentOptionalRowField("issue", e.IssueShortID),
 			agentRowField("actor", e.Actor),
 		); err != nil {
@@ -397,6 +400,7 @@ func (f *frameState) flushAgentEvent(out io.Writer) (streamResult, error) {
 	var e struct {
 		EventID      int64   `json:"event_id"`
 		Type         string  `json:"type"`
+		ProjectName  string  `json:"project_name"`
 		IssueShortID *string `json:"issue_short_id"`
 		Actor        string  `json:"actor"`
 	}
@@ -413,6 +417,11 @@ func (f *frameState) flushAgentEvent(out io.Writer) (streamResult, error) {
 	}
 	if e.IssueShortID != nil && *e.IssueShortID != "" {
 		if _, err := fmt.Fprintf(out, " issue=%s", agentValue(*e.IssueShortID)); err != nil {
+			return streamResult{}, err
+		}
+	}
+	if e.ProjectName != "" {
+		if _, err := fmt.Fprintf(out, " project=%s", agentValue(e.ProjectName)); err != nil {
 			return streamResult{}, err
 		}
 	}

--- a/cmd/kata/events_test.go
+++ b/cmd/kata/events_test.go
@@ -69,8 +69,8 @@ func TestEvents_OneShotAgentOutput(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	require.Len(t, lines, 3, "agent output should be header plus one row per event: %q", out)
 	assert.Equal(t, "OK events count=2 next_after_id=2", lines[0])
-	assert.Equal(t, "- id=1 type=issue.created issue="+first+" actor=wesm", lines[1])
-	assert.Equal(t, "- id=2 type=issue.created issue="+second+" actor=wesm", lines[2])
+	assert.Equal(t, "- id=1 type=issue.created project=kata issue="+first+" actor=wesm", lines[1])
+	assert.Equal(t, "- id=2 type=issue.created project=kata issue="+second+" actor=wesm", lines[2])
 }
 
 func TestEvents_OneShotAgentResetRequired(t *testing.T) {
@@ -102,6 +102,19 @@ func TestEvents_OneShotAllProjectsHitsCrossProject(t *testing.T) {
 	assert.Len(t, b.Events, 2, "all-projects must include both projects")
 }
 
+func TestEvents_OneShotAllProjectsAgentIncludesProject(t *testing.T) {
+	env := testenv.New(t)
+	dirA := initBoundWorkspace(t, env.URL, "https://github.com/wesm/a.git")
+	dirB := initBoundWorkspace(t, env.URL, "https://github.com/wesm/b.git")
+	createIssueViaHTTP(t, env, dirA, "a-issue")
+	createIssueViaHTTP(t, env, dirB, "b-issue")
+
+	out := requireCmdOutput(t, env, "events", "--all-projects", "--agent")
+
+	assert.Contains(t, out, "project=a")
+	assert.Contains(t, out, "project=b")
+}
+
 func TestEvents_TailAgentEmitsOneLinePerEvent(t *testing.T) {
 	env := testenv.New(t)
 	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
@@ -127,7 +140,7 @@ func TestEvents_TailAgentEmitsOneLinePerEvent(t *testing.T) {
 	}
 	require.GreaterOrEqual(t, len(lines), 2, "expected at least 2 agent event lines, got: %q", out)
 	for _, l := range lines[:2] {
-		assert.Regexp(t, `^OK event id=\d+ type=issue\.created issue=\S+ actor=tester$`, l)
+		assert.Regexp(t, `^OK event id=\d+ type=issue\.created issue=\S+ project=kata actor=tester$`, l)
 		assert.NotContains(t, l, "{", "agent tail output must not be NDJSON")
 	}
 	assert.Contains(t, lines[0], "issue="+first)

--- a/cmd/kata/events_test.go
+++ b/cmd/kata/events_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -57,6 +59,31 @@ func TestEvents_OneShotJSON(t *testing.T) {
 	assert.Equal(t, int64(1), b.NextAfterID)
 }
 
+func TestEvents_OneShotAgentOutput(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	first := runCLI(t, env, dir, "--quiet", "--as", "wesm", "create", "first")
+	second := runCLI(t, env, dir, "--quiet", "--as", "wesm", "create", "second")
+
+	out := runCLI(t, env, dir, "--agent", "events")
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Len(t, lines, 3, "agent output should be header plus one row per event: %q", out)
+	assert.Equal(t, "OK events count=2 next_after_id=2", lines[0])
+	assert.Equal(t, "- id=1 type=issue.created issue="+first+" actor=wesm", lines[1])
+	assert.Equal(t, "- id=2 type=issue.created issue="+second+" actor=wesm", lines[2])
+}
+
+func TestEvents_OneShotAgentResetRequired(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	short := createIssueViaHTTP(t, env, dir, "doomed")
+
+	runCLI(t, env, dir, "purge", short, "--force", "--confirm", "PURGE kata#"+short)
+
+	out := runCLI(t, env, dir, "--agent", "events", "--after", "0")
+
+	assert.Regexp(t, `^OK events reset_required=true reset_after_id=\d+\n?$`, out)
+}
+
 func TestEvents_OneShotAllProjectsHitsCrossProject(t *testing.T) {
 	env := testenv.New(t)
 	dirA := initBoundWorkspace(t, env.URL, "https://github.com/wesm/a.git")
@@ -73,6 +100,73 @@ func TestEvents_OneShotAllProjectsHitsCrossProject(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(out), &b))
 	assert.Len(t, b.Events, 2, "all-projects must include both projects")
+}
+
+func TestEvents_TailAgentEmitsOneLinePerEvent(t *testing.T) {
+	env := testenv.New(t)
+	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+
+	ctx, cancel := context.WithTimeout(contextWithBaseURL(context.Background(), env.URL), 5*time.Second)
+	defer cancel()
+	a := startAsyncCLI(t, ctx, "--workspace", dir, "--agent", "events", "--tail")
+	defer a.stop()
+
+	time.Sleep(200 * time.Millisecond)
+	first := createIssueViaHTTP(t, env, dir, "first")
+	second := createIssueViaHTTP(t, env, dir, "second")
+
+	out := a.awaitOutput(func(s string) bool {
+		return strings.Count(s, "OK event ") >= 2
+	}, 2*time.Second)
+
+	lines := []string{}
+	for _, l := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(l) != "" {
+			lines = append(lines, l)
+		}
+	}
+	require.GreaterOrEqual(t, len(lines), 2, "expected at least 2 agent event lines, got: %q", out)
+	for _, l := range lines[:2] {
+		assert.Regexp(t, `^OK event id=\d+ type=issue\.created issue=\S+ actor=tester$`, l)
+		assert.NotContains(t, l, "{", "agent tail output must not be NDJSON")
+	}
+	assert.Contains(t, lines[0], "issue="+first)
+	assert.Contains(t, lines[1], "issue="+second)
+}
+
+func TestEvents_TailAgentProgressUsesSSEID(t *testing.T) {
+	input := strings.Join([]string{
+		"id: 42",
+		"event: issue.created",
+		`data: {"event_id":7,"type":"issue.created","issue_short_id":"abc4","actor":"wesm"}`,
+		"",
+		"",
+	}, "\n")
+	var out bytes.Buffer
+
+	res, err := parseSSEStream(bufio.NewReader(strings.NewReader(input)), 0, &out, outputAgent)
+
+	require.NoError(t, err)
+	assert.Equal(t, "OK event id=7 type=issue.created issue=abc4 actor=wesm\n", out.String())
+	assert.Equal(t, int64(42), res.Progress.lastID)
+}
+
+func TestEvents_TailAgentResetRequired(t *testing.T) {
+	input := strings.Join([]string{
+		"id: 100",
+		"event: sync.reset_required",
+		`data: {"reset_after_id":100}`,
+		"",
+		"",
+	}, "\n")
+	var out bytes.Buffer
+
+	res, err := parseSSEStream(bufio.NewReader(strings.NewReader(input)), 0, &out, outputAgent)
+
+	require.NoError(t, err)
+	require.NotNil(t, res.Reset)
+	assert.Equal(t, int64(100), res.Reset.newCursor)
+	assert.Equal(t, "OK events reset_required=true reset_after_id=100\n", out.String())
 }
 
 func TestEvents_TailEmitsNDJSON(t *testing.T) {

--- a/cmd/kata/export.go
+++ b/cmd/kata/export.go
@@ -71,11 +71,16 @@ func newExportCmd() *cobra.Command {
 			if err := f.Close(); err != nil {
 				return fmt.Errorf("close export output: %w", err)
 			}
-			if !flags.Quiet && !flags.JSON {
-				_, err = fmt.Fprintf(cmd.OutOrStdout(), "exported %s\n", output)
-				return err
+			if flags.Quiet || flags.JSON {
+				return nil
 			}
-			return nil
+			switch currentOutputMode() {
+			case outputAgent:
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK export output=%s\n", agentValue(output))
+			default:
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "exported %s\n", output)
+			}
+			return err
 		},
 	}
 	cmd.Flags().StringVar(&output, "output", "", "path to write JSONL export")

--- a/cmd/kata/export_test.go
+++ b/cmd/kata/export_test.go
@@ -38,6 +38,28 @@ func TestExportWritesJSONLToOutput(t *testing.T) {
 	assert.Contains(t, out, outPath)
 }
 
+func TestExportAgentOutput(t *testing.T) {
+	home := setupKataEnv(t)
+	dbPath := filepath.Join(home, "kata.db")
+	d, err := db.Open(context.Background(), dbPath)
+	require.NoError(t, err)
+	p, err := d.CreateProject(context.Background(), "kata")
+	require.NoError(t, err)
+	_, _, err = d.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: p.ID,
+		Title:     "agent export",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	outPath := filepath.Join(home, "agent.jsonl")
+	out, err := runCmdOutput(t, nil, "export", "--agent", "--output", outPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "OK export output="+outPath+"\n", out)
+}
+
 func TestExportScopesByProjectName(t *testing.T) {
 	home := setupKataEnv(t)
 	dbPath := filepath.Join(home, "kata.db")

--- a/cmd/kata/health.go
+++ b/cmd/kata/health.go
@@ -34,9 +34,22 @@ func newHealthCmd() *cobra.Command {
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
+			var b struct {
+				OK            bool   `json:"ok"`
+				SchemaVersion int    `json:"schema_version"`
+				Uptime        string `json:"uptime"`
+				DBPath        string `json:"db_path"`
+			}
+			if err := json.Unmarshal(bs, &b); err != nil {
+				return err
+			}
 			mode := currentOutputMode()
 			if mode == outputAgent {
-				_, err := fmt.Fprintln(cmd.OutOrStdout(), "OK health")
+				daemonStatus := "unhealthy"
+				if b.OK {
+					daemonStatus = "running"
+				}
+				_, err := fmt.Fprintf(cmd.OutOrStdout(), "OK health ok=%t daemon=%s\n", b.OK, daemonStatus)
 				return err
 			}
 			if mode == outputJSON {
@@ -45,15 +58,6 @@ func newHealthCmd() *cobra.Command {
 					return err
 				}
 				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
-				return err
-			}
-			var b struct {
-				OK            bool   `json:"ok"`
-				SchemaVersion int    `json:"schema_version"`
-				Uptime        string `json:"uptime"`
-				DBPath        string `json:"db_path"`
-			}
-			if err := json.Unmarshal(bs, &b); err != nil {
 				return err
 			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "ok=%v schema_version=%d uptime=%s db=%s\n",

--- a/cmd/kata/health.go
+++ b/cmd/kata/health.go
@@ -34,7 +34,12 @@ func newHealthCmd() *cobra.Command {
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
-			if flags.JSON {
+			mode := currentOutputMode()
+			if mode == outputAgent {
+				_, err := fmt.Fprintln(cmd.OutOrStdout(), "OK health")
+				return err
+			}
+			if mode == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -15,11 +15,15 @@ func newImportCmd() *cobra.Command {
 	var target string
 	var force bool
 	var newInstance bool
-	var format string
+	var sourceFormat string
 	cmd := &cobra.Command{
 		Use:   "import",
 		Short: "import a kata database export",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			format, err := resolveImportSourceFormat(cmd, sourceFormat)
+			if err != nil {
+				return err
+			}
 			switch strings.TrimSpace(format) {
 			case "", "kata":
 				return runKataJSONLImport(cmd, input, target, force, newInstance)
@@ -37,7 +41,7 @@ func newImportCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVar(&format, "format", "kata", "import format (kata or beads)")
+	cmd.Flags().StringVar(&sourceFormat, "source-format", "kata", "import source format (kata or beads)")
 	cmd.Flags().StringVar(&input, "input", "", "path to JSONL export")
 	cmd.Flags().StringVar(&target, "target", "", "database path to create")
 	cmd.Flags().BoolVar(&force, "force", false, "replace existing target database")
@@ -46,11 +50,30 @@ func newImportCmd() *cobra.Command {
 	return cmd
 }
 
+func resolveImportSourceFormat(cmd *cobra.Command, sourceFormat string) (string, error) {
+	// During the import flag migration, root --format values human|json|agent
+	// select output mode, while kata|beads are temporary legacy import source
+	// values. The sets are intentionally disjoint so this fallback can be
+	// removed after the deprecation window without ambiguity.
+	legacy := strings.TrimSpace(flags.Format)
+	if isImportLegacySourceFormat(legacy) {
+		if cmd.Flags().Changed("source-format") {
+			return "", &cliError{
+				Message:  fmt.Sprintf("--format %s cannot be combined with --source-format; use --source-format only", legacy),
+				Kind:     kindUsage,
+				ExitCode: ExitUsage,
+			}
+		}
+		return legacy, nil
+	}
+	return strings.TrimSpace(sourceFormat), nil
+}
+
 func validateBeadsImportFlags(cmd *cobra.Command) error {
 	for _, name := range []string{"input", "target", "force", "new-instance"} {
 		if cmd.Flags().Changed(name) {
 			return &cliError{
-				Message:  fmt.Sprintf("--%s is not supported with --format beads", name),
+				Message:  fmt.Sprintf("--%s is not supported with --source-format beads", name),
 				Kind:     kindValidation,
 				ExitCode: ExitValidation,
 			}

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -122,9 +122,14 @@ func runKataJSONLImport(cmd *cobra.Command, input, target string, force, newInst
 	}); err != nil {
 		return err
 	}
-	if !flags.Quiet && !flags.JSON {
-		_, err = fmt.Fprintf(cmd.OutOrStdout(), "imported %s\n", target)
-		return err
+	if flags.Quiet || flags.JSON {
+		return nil
 	}
-	return nil
+	switch currentOutputMode() {
+	case outputAgent:
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK import source_format=kata target=%s\n", agentValue(target))
+	default:
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "imported %s\n", target)
+	}
+	return err
 }

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -55,7 +55,7 @@ func resolveImportSourceFormat(cmd *cobra.Command, sourceFormat string) (string,
 	// select output mode, while kata|beads are temporary legacy import source
 	// values. The sets are intentionally disjoint so this fallback can be
 	// removed after the deprecation window without ambiguity.
-	legacy := strings.TrimSpace(flags.Format)
+	legacy := legacyImportSourceFormat()
 	if isImportLegacySourceFormat(legacy) {
 		if cmd.Flags().Changed("source-format") {
 			return "", &cliError{
@@ -67,6 +67,16 @@ func resolveImportSourceFormat(cmd *cobra.Command, sourceFormat string) (string,
 		return legacy, nil
 	}
 	return strings.TrimSpace(sourceFormat), nil
+}
+
+func legacyImportSourceFormat() string {
+	for _, format := range flags.FormatValues {
+		format = strings.TrimSpace(format)
+		if isImportLegacySourceFormat(format) {
+			return format
+		}
+	}
+	return strings.TrimSpace(flags.Format)
 }
 
 func validateBeadsImportFlags(cmd *cobra.Command) error {

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,41 @@ func TestImportCreatesTargetDB(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "kata", got.Name)
 	assert.Contains(t, out, target)
+}
+
+func TestImportFormatAgentSelectsOutputMode(t *testing.T) {
+	_, input, target := setupImportTest(t)
+
+	_, err := runCmdOutput(t, nil, "import", "--format", "agent", "--input", input, "--target", target)
+	require.NoError(t, err)
+
+	d, err := db.Open(context.Background(), target)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+	got, err := d.ProjectByName(context.Background(), "kata")
+	require.NoError(t, err)
+	assert.Equal(t, "kata", got.Name)
+}
+
+func TestImportLegacyFormatConflictsWithSourceFormat(t *testing.T) {
+	setupKataEnv(t)
+
+	_, err := runCmdOutput(t, nil, "import", "--format", "beads", "--source-format", "kata")
+	ce := requireCLIError(t, err, ExitUsage)
+	assert.Contains(t, ce.Message, "--format beads cannot be combined with --source-format")
+}
+
+func TestImportLegacyFormatBeadsAllowsAgentOutputMode(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	setupKataEnv(t)
+
+	_, stderr, err := executeRootCapture(t, context.Background(),
+		"import", "--format", "beads", "--agent", "--input", "beads.jsonl")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "ERR import validation:"),
+		"stderr should use agent mode for legacy beads import, got %q", stderr)
+	assert.Contains(t, stderr, "--input is not supported")
 }
 
 func TestImportRejectsExistingTargetWithoutForce(t *testing.T) {

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -40,7 +40,7 @@ func TestImportCreatesTargetDB(t *testing.T) {
 func TestImportFormatAgentSelectsOutputMode(t *testing.T) {
 	_, input, target := setupImportTest(t)
 
-	_, err := runCmdOutput(t, nil, "import", "--format", "agent", "--input", input, "--target", target)
+	out, err := runCmdOutput(t, nil, "import", "--format", "agent", "--source-format", "kata", "--input", input, "--target", target)
 	require.NoError(t, err)
 
 	d, err := db.Open(context.Background(), target)
@@ -49,6 +49,7 @@ func TestImportFormatAgentSelectsOutputMode(t *testing.T) {
 	got, err := d.ProjectByName(context.Background(), "kata")
 	require.NoError(t, err)
 	assert.Equal(t, "kata", got.Name)
+	assert.Equal(t, "OK import source_format=kata target="+target+"\n", out)
 }
 
 func TestImportLegacyFormatConflictsWithSourceFormat(t *testing.T) {

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -72,6 +72,31 @@ func TestImportLegacyFormatBeadsAllowsAgentOutputMode(t *testing.T) {
 	assert.Contains(t, stderr, "--input is not supported")
 }
 
+func TestImportLegacyFormatBeadsParseErrorPreservesAgentMode(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	setupKataEnv(t)
+
+	_, stderr, err := executeRootCapture(t, context.Background(),
+		"import", "--format", "beads", "--agent", "--bogus")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "ERR import usage:"),
+		"stderr should use agent mode for legacy beads parse error, got %q", stderr)
+}
+
+func TestImportLegacyFormatBeadsParseErrorPreservesJSONMode(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	setupKataEnv(t)
+
+	_, stderr, err := executeRootCapture(t, context.Background(),
+		"import", "--format", "beads", "--json", "--bogus")
+	require.Error(t, err)
+	got := parseErrorEnvelope(t, []byte(stderr))
+	assert.Equal(t, "usage", got.Error.Kind)
+	assert.Contains(t, got.Error.Message, "unknown flag: --bogus")
+}
+
 func TestImportRejectsExistingTargetWithoutForce(t *testing.T) {
 	_, input, target := setupImportTest(t)
 	d, err := db.Open(context.Background(), target)

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -286,16 +286,18 @@ func runNameInit(ctx context.Context, baseURL string, in localInit, opts callIni
 	}
 
 	dest := config.WriteDestination(in.Disc, in.StartPath)
-	if needsTomlWrite(in.ExistingToml, resp.Project.Name) {
+	tomlChanged := needsTomlWrite(in.ExistingToml, resp.Project.Name)
+	if tomlChanged {
 		if err := config.WriteProjectConfig(dest, resp.Project.Name); err != nil {
 			return "", fmt.Errorf("write .kata.toml: %w", err)
 		}
 	}
-	if err := ensureGitignoreEntry(dest, ".kata.local.toml"); err != nil {
-		fmt.Fprintf(os.Stderr, "kata: warning: could not update .gitignore: %v\n", err)
+	gitignoreChanged, err := ensureGitignoreEntry(dest, ".kata.local.toml")
+	if err != nil {
+		warnGitignoreUpdate(err)
 	}
 
-	return formatInitOutput(bs, resp.Project.Name, resp.Created)
+	return formatInitOutput(bs, resp.Project.Name, dest, resp.Created, resp.Created || tomlChanged || gitignoreChanged)
 }
 
 // runStartPathInit is the fallback used when the client cannot derive a name
@@ -334,11 +336,21 @@ func runStartPathInit(ctx context.Context, baseURL, startPath string, opts callI
 	if gitignoreDir == "" {
 		gitignoreDir = startPath
 	}
-	if err := ensureGitignoreEntry(gitignoreDir, ".kata.local.toml"); err != nil {
-		fmt.Fprintf(os.Stderr, "kata: warning: could not update .gitignore: %v\n", err)
+	gitignoreChanged, err := ensureGitignoreEntry(gitignoreDir, ".kata.local.toml")
+	if err != nil {
+		warnGitignoreUpdate(err)
 	}
 
-	return formatInitOutput(bs, resp.Project.Name, resp.Created)
+	// The path-based daemon flow writes workspace files remotely and exposes no
+	// local file-change bit today; project creation is the closest stable signal.
+	return formatInitOutput(bs, resp.Project.Name, gitignoreDir, resp.Created, resp.Created || gitignoreChanged)
+}
+
+func warnGitignoreUpdate(err error) {
+	if currentOutputMode() != outputHuman {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "kata: warning: could not update .gitignore: %v\n", err)
 }
 
 // postProjects POSTs the request and returns the raw response body on
@@ -370,18 +382,22 @@ func needsTomlWrite(existing *config.ProjectConfig, name string) bool {
 	return existing.Project.Name != name
 }
 
-// formatInitOutput renders the human-readable or JSON form of the init
-// result, shared between the path-free and path-based flows.
-func formatInitOutput(bs []byte, name string, created bool) (string, error) {
-	if flags.JSON {
+// formatInitOutput renders the selected output mode for init, shared between
+// the path-free and path-based flows.
+func formatInitOutput(bs []byte, name, workspace string, projectCreated, changed bool) (string, error) {
+	switch currentOutputMode() {
+	case outputJSON:
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 			return "", fmt.Errorf("emit json: %w", err)
 		}
 		return buf.String(), nil
+	case outputAgent:
+		return fmt.Sprintf("OK init project=%s workspace=%s changed=%t\n",
+			agentValue(name), agentValue(workspace), changed), nil
 	}
 	action := "bound"
-	if created {
+	if projectCreated {
 		action = "created and bound"
 	}
 	return fmt.Sprintf("%s project %s\n", action, textsafe.Line(name)), nil
@@ -442,11 +458,10 @@ func mapStatusToExit(status int, _ string) int {
 	}
 }
 
-// ensureGitignoreEntry appends a single line to <dir>/.gitignore if
-// the entry is not already present. Creates the file if absent.
-// Idempotent: re-running on a file that already lists the entry is a
-// no-op.
-func ensureGitignoreEntry(dir, entry string) error {
+// ensureGitignoreEntry appends a single line to <dir>/.gitignore if the entry
+// is not already present. It creates the file if absent and returns whether the
+// file changed. Re-running on a file that already lists the entry is a no-op.
+func ensureGitignoreEntry(dir, entry string) (bool, error) {
 	path := filepath.Join(dir, ".gitignore")
 	existing, err := os.ReadFile(path) //nolint:gosec
 	switch {
@@ -455,7 +470,7 @@ func ensureGitignoreEntry(dir, entry string) error {
 		// pattern (e.g. ".kata.local.toml.bak").
 		for _, line := range strings.Split(string(existing), "\n") {
 			if strings.TrimSpace(line) == entry {
-				return nil
+				return false, nil
 			}
 		}
 		// Preserve trailing-newline convention: if the file ends without
@@ -467,16 +482,19 @@ func ensureGitignoreEntry(dir, entry string) error {
 		}
 		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644) //nolint:gosec // .gitignore is world-readable by convention; mode is unused by O_APPEND on existing files but golangci-lint flags it
 		if err != nil {
-			return err
+			return false, err
 		}
 		defer func() { _ = f.Close() }()
 		if _, err := f.WriteString(prefix + entry + "\n"); err != nil {
-			return err
+			return false, err
 		}
-		return nil
+		return true, nil
 	case errors.Is(err, os.ErrNotExist):
-		return os.WriteFile(path, []byte(entry+"\n"), 0o644) //nolint:gosec
+		if err := os.WriteFile(path, []byte(entry+"\n"), 0o644); err != nil { //nolint:gosec
+			return false, err
+		}
+		return true, nil
 	default:
-		return err
+		return false, err
 	}
 }

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -308,4 +309,149 @@ func TestInit_GitignoreAppendsToExisting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "dist/")
 	assert.Contains(t, string(content), ".kata.local.toml")
+}
+
+func TestInit_AgentOutputReportsProjectWorkspaceAndChanged(t *testing.T) {
+	resetFlags(t)
+	flags.Agent = true
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	daemonStub := newFakeDaemon(t)
+
+	out, err := callInit(context.Background(), daemonStub.srv.URL, dir, callInitOpts{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "OK init project=kata workspace="+agentValue(dir)+" changed=true\n", out)
+}
+
+func TestInit_AgentOutputChangedWhenExistingProjectBindsFreshWorkspace(t *testing.T) {
+	resetFlags(t)
+	flags.Agent = true
+	env := testenv.New(t)
+	_, err := env.DB.CreateProject(context.Background(), "kata")
+	require.NoError(t, err)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	out, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "OK init project=kata workspace="+agentValue(dir)+" changed=true\n", out)
+}
+
+func TestInit_HumanOutputKeepsProjectCreatedSemanticsForFreshWorkspace(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	_, err := env.DB.CreateProject(context.Background(), "kata")
+	require.NoError(t, err)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	out, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "bound project kata\n", out)
+}
+
+func TestInit_AgentOutputChangedWhenOnlyGitignoreUpdated(t *testing.T) {
+	resetFlags(t)
+	flags.Agent = true
+	env := testenv.New(t)
+	_, err := env.DB.CreateProject(context.Background(), "kata")
+	require.NoError(t, err)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"), //nolint:gosec // test fixture matches production .kata.toml mode
+		[]byte(`version = 1
+
+[project]
+identity = "github.com/wesm/kata"
+name     = "kata"
+`), 0o644))
+
+	out, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "OK init project=kata workspace="+agentValue(dir)+" changed=true\n", out)
+}
+
+func TestInit_AgentOutputQuotesProjectName(t *testing.T) {
+	resetFlags(t)
+	flags.Agent = true
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	daemonStub := newFakeDaemon(t)
+
+	out, err := callInit(context.Background(), daemonStub.srv.URL, dir, callInitOpts{Project: "two words"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "OK init project=\"two words\" workspace="+agentValue(dir)+" changed=true\n", out)
+}
+
+func TestInit_MachineOutputSuppressesGitignoreWarning(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func()
+		wantOut   string
+	}{
+		{
+			name: "agent",
+			configure: func() {
+				flags.Agent = true
+			},
+			wantOut: "OK init project=kata workspace=",
+		},
+		{
+			name: "json",
+			configure: func() {
+				flags.JSON = true
+			},
+			wantOut: `"kata_api_version":1`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFlags(t)
+			dir := t.TempDir()
+			runGit(t, dir, "init", "--quiet")
+			runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+			require.NoError(t, os.Mkdir(filepath.Join(dir, ".gitignore"), 0o755)) //nolint:gosec // test fixture under TempDir
+			daemonStub := newFakeDaemon(t)
+			tt.configure()
+
+			var out string
+			var err error
+			stderr := captureProcessStderr(t, func() {
+				out, err = callInit(context.Background(), daemonStub.srv.URL, dir, callInitOpts{})
+			})
+
+			require.NoError(t, err)
+			assert.Contains(t, out, tt.wantOut)
+			assert.Empty(t, stderr)
+		})
+	}
+}
+
+func captureProcessStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = old })
+
+	fn()
+
+	require.NoError(t, w.Close())
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	os.Stderr = old
+	return buf.String()
 }

--- a/cmd/kata/label.go
+++ b/cmd/kata/label.go
@@ -141,7 +141,8 @@ func newLabelsCmd() *cobra.Command {
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
-			if flags.JSON {
+			mode := currentOutputMode()
+			if mode == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err
@@ -157,6 +158,22 @@ func newLabelsCmd() *cobra.Command {
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
 				return err
+			}
+			if mode == outputAgent {
+				out := cmd.OutOrStdout()
+				if _, err := fmt.Fprintf(out, "OK labels count=%d\n", len(b.Labels)); err != nil {
+					return err
+				}
+				for _, c := range b.Labels {
+					count := fmt.Sprint(c.Count)
+					if err := writeAgentKVRow(out,
+						agentRowField("label", c.Label),
+						agentRowField("count", count),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
 			}
 			for _, c := range b.Labels {
 				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%-32s  %d\n", c.Label, c.Count); err != nil {

--- a/cmd/kata/label.go
+++ b/cmd/kata/label.go
@@ -201,7 +201,10 @@ func printLabelMutation(cmd *cobra.Command, bs []byte) error {
 		if err := json.Unmarshal(bs, &m); err != nil {
 			return err
 		}
-		return printAgentMutationDecoded(cmd.OutOrStdout(), "label", m, true, func(w io.Writer, _ agentIssueMutation) error {
+		return printAgentMutationDecoded(cmd.OutOrStdout(), "label", m, true, func(w io.Writer, m agentIssueMutation) error {
+			if err := writeAgentField(w, "Label", agentValue(m.Label.Label)); err != nil {
+				return err
+			}
 			return writeAgentField(w, "Action", "added")
 		})
 	}
@@ -249,6 +252,9 @@ func printLabelRemoved(cmd *cobra.Command, bs []byte, ref, label string) error {
 			return err
 		}
 		return printAgentMutationDecoded(cmd.OutOrStdout(), "label", m, true, func(w io.Writer, _ agentIssueMutation) error {
+			if err := writeAgentField(w, "Label", agentValue(label)); err != nil {
+				return err
+			}
 			return writeAgentField(w, "Action", "removed")
 		})
 	}

--- a/cmd/kata/label.go
+++ b/cmd/kata/label.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -169,13 +170,23 @@ func newLabelsCmd() *cobra.Command {
 
 // printLabelMutation formats AddLabelResponse for the three output modes.
 func printLabelMutation(cmd *cobra.Command, bs []byte) error {
-	if flags.JSON {
+	mode := currentOutputMode()
+	if mode == outputJSON {
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 			return err
 		}
 		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 		return err
+	}
+	if mode == outputAgent {
+		var m agentIssueMutation
+		if err := json.Unmarshal(bs, &m); err != nil {
+			return err
+		}
+		return printAgentMutationDecoded(cmd.OutOrStdout(), "label", m, true, func(w io.Writer, _ agentIssueMutation) error {
+			return writeAgentField(w, "Action", "added")
+		})
 	}
 	var b struct {
 		Issue struct {
@@ -206,13 +217,23 @@ func printLabelMutation(cmd *cobra.Command, bs []byte) error {
 // body carries only {issue, event, changed} so the line is built from the
 // (issue ref, label) the CLI used to call DELETE.
 func printLabelRemoved(cmd *cobra.Command, bs []byte, ref, label string) error {
-	if flags.JSON {
+	mode := currentOutputMode()
+	if mode == outputJSON {
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 			return err
 		}
 		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 		return err
+	}
+	if mode == outputAgent {
+		var m agentIssueMutation
+		if err := json.Unmarshal(bs, &m); err != nil {
+			return err
+		}
+		return printAgentMutationDecoded(cmd.OutOrStdout(), "label", m, true, func(w io.Writer, _ agentIssueMutation) error {
+			return writeAgentField(w, "Action", "removed")
+		})
 	}
 	var b struct {
 		Changed bool `json:"changed"`

--- a/cmd/kata/label_test.go
+++ b/cmd/kata/label_test.go
@@ -16,6 +16,15 @@ func TestLabelAdd_HappyPath(t *testing.T) {
 	assert.Contains(t, out, "needs-review")
 }
 
+func TestLabelAdd_AgentOutput(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "a")
+
+	out := runCLI(t, env, dir, "--agent", "label", "add", ref, "needs-review")
+
+	assert.Regexp(t, `(?m)^OK label \S+ changed=true`, out)
+	assert.Contains(t, out, "Action: added")
+}
+
 func TestLabelRm_HappyPath(t *testing.T) {
 	env, dir, _, ref := setupWorkspaceWithIssue(t, "a")
 

--- a/cmd/kata/label_test.go
+++ b/cmd/kata/label_test.go
@@ -22,6 +22,7 @@ func TestLabelAdd_AgentOutput(t *testing.T) {
 	out := runCLI(t, env, dir, "--agent", "label", "add", ref, "needs-review")
 
 	assert.Regexp(t, `(?m)^OK label \S+ changed=true`, out)
+	assert.Contains(t, out, "Label: needs-review")
 	assert.Contains(t, out, "Action: added")
 }
 
@@ -31,6 +32,18 @@ func TestLabelRm_HappyPath(t *testing.T) {
 	runCLI(t, env, dir, "label", "add", ref, "bug")
 	out := runCLI(t, env, dir, "label", "rm", ref, "bug")
 	assert.True(t, strings.Contains(out, "removed") || strings.Contains(out, "unlabeled"))
+}
+
+func TestLabelRm_AgentOutput(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "a")
+	runCLI(t, env, dir, "label", "add", ref, "bug")
+
+	resetFlags(t)
+	out := runCLI(t, env, dir, "--agent", "label", "rm", ref, "bug")
+
+	assert.Regexp(t, `(?m)^OK label \S+ changed=true`, out)
+	assert.Contains(t, out, "Label: bug")
+	assert.Contains(t, out, "Action: removed")
 }
 
 func TestLabelsList_PrintsCounts(t *testing.T) {

--- a/cmd/kata/label_test.go
+++ b/cmd/kata/label_test.go
@@ -42,6 +42,18 @@ func TestLabelsList_PrintsCounts(t *testing.T) {
 	assert.Contains(t, out, "1")
 }
 
+func TestLabelsList_AgentOutputIncludesCount(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "a")
+
+	runCLI(t, env, dir, "label", "add", ref, "bug")
+	runCLI(t, env, dir, "label", "add", ref, "safari")
+	out := runCLI(t, env, dir, "--agent", "labels")
+
+	assert.Contains(t, out, "OK labels count=2\n")
+	assert.Contains(t, out, "- label=bug count=1\n")
+	assert.Contains(t, out, "- label=safari count=1")
+}
+
 // TestLabel_RejectsEmptyLabel covers hammer-test finding #8: label rm with an
 // empty value used to URL-encode to "" and hit /labels/?actor=... which the
 // daemon answered with a raw 404 page. Now both add and rm reject

--- a/cmd/kata/list.go
+++ b/cmd/kata/list.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kata/internal/textsafe"
@@ -94,7 +96,8 @@ func newListCmd() *cobra.Command {
 			if httpStatus >= 400 {
 				return apiErrFromBody(httpStatus, bs)
 			}
-			if flags.JSON {
+			mode := currentOutputMode()
+			if mode == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err
@@ -104,15 +107,36 @@ func newListCmd() *cobra.Command {
 			}
 			var b struct {
 				Issues []struct {
-					ShortID     string  `json:"short_id"`
-					QualifiedID string  `json:"qualified_id"`
-					Title       string  `json:"title"`
-					Status      string  `json:"status"`
-					Owner       *string `json:"owner"`
+					ShortID     string   `json:"short_id"`
+					QualifiedID string   `json:"qualified_id"`
+					Title       string   `json:"title"`
+					Status      string   `json:"status"`
+					Owner       *string  `json:"owner"`
+					Priority    *int64   `json:"priority"`
+					Labels      []string `json:"labels"`
 				} `json:"issues"`
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
 				return err
+			}
+			if mode == outputAgent {
+				out := cmd.OutOrStdout()
+				if _, err := fmt.Fprintf(out, "OK list count=%d\n", len(b.Issues)); err != nil {
+					return err
+				}
+				for _, i := range b.Issues {
+					if err := writeAgentKVRow(out,
+						agentRowField("issue", i.ShortID),
+						agentRowField("status", i.Status),
+						agentRowIntField("priority", i.Priority),
+						agentOptionalRowField("owner", i.Owner),
+						agentRowListField("labels", i.Labels),
+						agentRowField("title", i.Title),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
 			}
 			// Show owner in parens to match ready's convention. Owner
 			// is the actionable identity ("who's responsible") whereas
@@ -155,4 +179,57 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&labels, "label", nil, "only issues with this label (repeatable, AND logic)")
 	cmd.Flags().StringSliceVar(&noLabels, "no-label", nil, "exclude issues with this label (repeatable)")
 	return cmd
+}
+
+type agentField struct {
+	name  string
+	value *string
+}
+
+func agentRowField(name, value string) agentField {
+	return agentField{name: name, value: &value}
+}
+
+func agentOptionalRowField(name string, value *string) agentField {
+	if value == nil || *value == "" {
+		return agentField{name: name}
+	}
+	return agentField{name: name, value: value}
+}
+
+func agentRowIntField(name string, value *int64) agentField {
+	if value == nil {
+		return agentField{name: name}
+	}
+	s := fmt.Sprint(*value)
+	return agentField{name: name, value: &s}
+}
+
+func agentRowFloatField(name string, value float64) agentField {
+	s := fmt.Sprintf("%.2f", value)
+	return agentField{name: name, value: &s}
+}
+
+func agentRowListField(name string, values []string) agentField {
+	if len(values) == 0 {
+		return agentField{name: name}
+	}
+	s := strings.Join(values, ",")
+	return agentField{name: name, value: &s}
+}
+
+func writeAgentKVRow(w io.Writer, fields ...agentField) error {
+	if _, err := fmt.Fprint(w, "-"); err != nil {
+		return err
+	}
+	for _, f := range fields {
+		if f.value == nil {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, " %s=%s", f.name, agentValue(*f.value)); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(w)
+	return err
 }

--- a/cmd/kata/list_test.go
+++ b/cmd/kata/list_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -39,6 +40,27 @@ func TestList_DefaultsToOpenIssuesInProject(t *testing.T) {
 	out := runCLI(t, env, dir, "list")
 	assert.Contains(t, out, "alpha")
 	assert.Contains(t, out, "beta")
+}
+
+func TestList_AgentOutputRowsOmitAbsentOwner(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "unowned task")
+
+	out := runCLI(t, env, dir, "--agent", "list")
+
+	assert.Contains(t, out, "OK list count=1\n")
+	assert.Contains(t, out, `title="unowned task"`)
+	assert.NotContains(t, out, "owner=")
+}
+
+func TestList_AgentOutputEscapesQuotedTitle(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, `quoted "title"`)
+
+	out := runCLI(t, env, dir, "--agent", "list")
+
+	assert.Contains(t, out, "OK list count=1\n")
+	assert.Contains(t, out, "title="+strconv.Quote(`quoted "title"`))
 }
 
 // TestList_SanitizesAnsiAndNewlinesInTitle covers hammer-test

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -17,14 +17,15 @@ import (
 
 // globalFlags carries the universal flags applied on every command.
 type globalFlags struct {
-	Format    string
-	JSON      bool
-	Agent     bool
-	Mode      outputMode
-	Quiet     bool
-	As        string
-	Workspace string
-	Project   string
+	Format       string
+	FormatValues []string
+	JSON         bool
+	Agent        bool
+	Mode         outputMode
+	Quiet        bool
+	As           string
+	Workspace    string
+	Project      string
 }
 
 var flags globalFlags
@@ -58,7 +59,8 @@ func newRootCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.PersistentFlags().StringVar(&flags.Format, "format", "", "output format: human|json|agent")
+	cmd.PersistentFlags().Var(outputFormatFlag{value: &flags.Format, values: &flags.FormatValues},
+		"format", "output format: human|json|agent")
 	cmd.PersistentFlags().BoolVar(&flags.JSON, "json", false, "emit machine-readable JSON")
 	cmd.PersistentFlags().BoolVar(&flags.Agent, "agent", false, "emit concise agent-readable text")
 	cmd.PersistentFlags().BoolVarP(&flags.Quiet, "quiet", "q", false, "suppress non-essential output")

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -289,7 +289,7 @@ func emitJSONError(w io.Writer, err error, runEReached bool) {
 
 func emitHumanError(w io.Writer, err error, runEReached bool) {
 	cli := cliErrorForErr(err, runEReached)
-	_, _ = fmt.Fprintln(w, "kata:", cli.Message)
+	_, _ = fmt.Fprintln(w, "kata:", cli.Message) //nolint:gosec // G705: CLI stderr error text, not HTML.
 }
 
 func cliErrorForErr(err error, runEReached bool) *cliError {

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -171,7 +171,7 @@ func resolvedOutputModeForError(root *cobra.Command, args []string) (outputMode,
 	if cmd := commandFromArgs(root, args); isImportCommand(cmd) {
 		importLegacy = true
 	}
-	mode, err := resolveOutputModeArgsForCommand(args, flags.Format, flags.JSON, flags.Agent, importLegacy)
+	mode, err := resolveOutputModeArgsForCommand(args, flags.Format, flags.JSON, flags.Agent, importLegacy, root)
 	if err != nil {
 		return outputHuman, err
 	}

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -47,7 +47,7 @@ func newRootCmd() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			runEEntered = true
 			errorCommandName = commandLeaf(cmd)
-			mode, err := resolveOutputModeValues(flags.Format, flags.JSON, flags.Agent)
+			mode, err := resolveOutputModeForCommand(cmd)
 			if err != nil {
 				return err
 			}

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -17,7 +17,10 @@ import (
 
 // globalFlags carries the universal flags applied on every command.
 type globalFlags struct {
+	Format    string
 	JSON      bool
+	Agent     bool
+	Mode      outputMode
 	Quiet     bool
 	As        string
 	Workspace string
@@ -30,19 +33,30 @@ var flags globalFlags
 // It stays false when cobra fails during argument/flag parsing, allowing main()
 // to distinguish a parse error (ExitUsage) from an operational failure (ExitInternal).
 var runEEntered bool
+var errorCommandName string
 
 func newRootCmd() *cobra.Command {
+	flags.Mode = ""
+	errorCommandName = ""
 	cmd := &cobra.Command{
 		Use:           "kata",
 		Short:         "kata — lightweight issue tracker for agents",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			runEEntered = true
+			errorCommandName = commandLeaf(cmd)
+			mode, err := resolveOutputModeValues(flags.Format, flags.JSON, flags.Agent)
+			if err != nil {
+				return err
+			}
+			flags.Mode = mode
 			return nil
 		},
 	}
+	cmd.PersistentFlags().StringVar(&flags.Format, "format", "", "output format: human|json|agent")
 	cmd.PersistentFlags().BoolVar(&flags.JSON, "json", false, "emit machine-readable JSON")
+	cmd.PersistentFlags().BoolVar(&flags.Agent, "agent", false, "emit concise agent-readable text")
 	cmd.PersistentFlags().BoolVarP(&flags.Quiet, "quiet", "q", false, "suppress non-essential output")
 	cmd.PersistentFlags().StringVar(&flags.As, "as", "", "override actor (default: $KATA_AUTHOR > $USER > git > anonymous)")
 	cmd.PersistentFlags().StringVar(&flags.Workspace, "workspace", "", "path used for project resolution (default: cwd)")
@@ -105,23 +119,96 @@ func main() {
 		stop()
 	}()
 	if err := newRootCmd().ExecuteContext(ctx); err != nil {
-		emitError(os.Stderr, err, flags.JSON, runEEntered)
+		emitErrorForMode(os.Stderr, err, resolvedOutputModeForError(os.Args[1:]), runEEntered)
 		os.Exit(exitCodeForErr(err, runEEntered))
 	}
 }
 
-// emitError writes the error to w. When jsonMode is true, the output
-// is a JSON envelope shaped after the daemon's ErrorEnvelope plus a
-// `kind` and `exit_code` for client-side classification — agents can
-// branch on a stable taxonomy without grepping the human message.
-// When jsonMode is false, the human path stays "kata: <message>".
-//
-// The JSON envelope is always emitted to stderr (where the human
-// message also goes) so consumers don't have to reconfigure stream
-// routing per --json. Stdout stays reserved for successful command
-// output, so a partial-success run can emit useful stdout JSON and
-// an error envelope on stderr without the streams being mixed.
+// emitError preserves the legacy bool-shaped test/helper API while main uses
+// the resolved output mode.
 func emitError(w io.Writer, err error, jsonMode bool, runEReached bool) {
+	if jsonMode {
+		emitErrorForMode(w, err, outputJSON, runEReached)
+		return
+	}
+	emitErrorForMode(w, err, outputHuman, runEReached)
+}
+
+func emitErrorForMode(w io.Writer, err error, mode outputMode, runEReached bool) {
+	switch mode {
+	case outputJSON:
+		emitJSONError(w, err, runEReached)
+	case outputAgent:
+		emitAgentError(w, commandNameForError(runEReached), cliErrorForErr(err, runEReached))
+	default:
+		emitHumanError(w, err, runEReached)
+	}
+}
+
+func resolvedOutputModeForError(args []string) outputMode {
+	if flags.Mode != "" {
+		return flags.Mode
+	}
+	mode, err := resolveOutputModeArgs(args, flags.Format, flags.JSON, flags.Agent)
+	if err != nil {
+		return outputHuman
+	}
+	return mode
+}
+
+func commandNameForError(runEReached bool) string {
+	if !runEReached {
+		return "kata"
+	}
+	if errorCommandName != "" {
+		return errorCommandName
+	}
+	return "kata"
+}
+
+func commandLeaf(cmd *cobra.Command) string {
+	if cmd == nil {
+		return "kata"
+	}
+	parts := strings.Fields(cmd.CommandPath())
+	if len(parts) == 0 {
+		return "kata"
+	}
+	return parts[len(parts)-1]
+}
+
+// emitJSONError writes a JSON envelope shaped after the daemon's
+// ErrorEnvelope plus a `kind` and `exit_code` for client-side classification.
+// The JSON envelope is always emitted to stderr in main so stdout stays
+// reserved for successful command output.
+func emitJSONError(w io.Writer, err error, runEReached bool) {
+	cli := cliErrorForErr(err, runEReached)
+	env := struct {
+		Error struct {
+			Kind     errKind `json:"kind"`
+			Code     string  `json:"code,omitempty"`
+			Message  string  `json:"message"`
+			ExitCode int     `json:"exit_code"`
+		} `json:"error"`
+	}{}
+	env.Error.Kind = cli.Kind
+	env.Error.Code = cli.Code
+	env.Error.Message = cli.Message
+	env.Error.ExitCode = cli.ExitCode
+	bs, mErr := json.Marshal(env)
+	if mErr == nil {
+		_, _ = fmt.Fprintln(w, string(bs))
+		return
+	}
+	emitHumanError(w, err, runEReached)
+}
+
+func emitHumanError(w io.Writer, err error, runEReached bool) {
+	cli := cliErrorForErr(err, runEReached)
+	_, _ = fmt.Fprintln(w, "kata:", cli.Message)
+}
+
+func cliErrorForErr(err error, runEReached bool) *cliError {
 	var cli *cliError
 	if !errors.As(err, &cli) {
 		// Non-cliError: synthesize one so the JSON path has uniform
@@ -133,28 +220,7 @@ func emitError(w io.Writer, err error, jsonMode bool, runEReached bool) {
 			ExitCode: exit,
 		}
 	}
-	if jsonMode {
-		env := struct {
-			Error struct {
-				Kind     errKind `json:"kind"`
-				Code     string  `json:"code,omitempty"`
-				Message  string  `json:"message"`
-				ExitCode int     `json:"exit_code"`
-			} `json:"error"`
-		}{}
-		env.Error.Kind = cli.Kind
-		env.Error.Code = cli.Code
-		env.Error.Message = cli.Message
-		env.Error.ExitCode = cli.ExitCode
-		bs, mErr := json.Marshal(env)
-		if mErr == nil {
-			_, _ = fmt.Fprintln(w, string(bs))
-			return
-		}
-		// JSON marshal failed (shouldn't happen on a fixed shape) —
-		// fall through to plain text so the user still gets *something*.
-	}
-	_, _ = fmt.Fprintln(w, "kata:", cli.Message)
+	return cli
 }
 
 // exitCodeForErr returns the exit code an error should produce. When

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -175,9 +175,39 @@ func resolvedOutputModeForError(root *cobra.Command, args []string) (outputMode,
 	}
 	mode, err := resolveOutputModeArgsForCommand(args, flags.Format, flags.JSON, flags.Agent, importLegacy, root)
 	if err != nil {
-		return outputHuman, err
+		return outputModeHintForResolutionError(importLegacy), err
 	}
 	return mode, nil
+}
+
+func outputModeHintForResolutionError(importLegacy bool) outputMode {
+	formats := flags.FormatValues
+	if len(formats) == 0 && flags.Format != "" {
+		formats = []string{flags.Format}
+	}
+	selected := make([]outputMode, 0, len(formats)+2)
+	for _, format := range formats {
+		switch mode := outputMode(outputFormatValue(format, importLegacy)); mode {
+		case outputHuman, outputJSON, outputAgent:
+			selected = append(selected, mode)
+		}
+	}
+	if flags.JSON {
+		selected = append(selected, outputJSON)
+	}
+	if flags.Agent {
+		selected = append(selected, outputAgent)
+	}
+	if len(selected) == 0 {
+		return outputHuman
+	}
+	first := selected[0]
+	for _, mode := range selected[1:] {
+		if mode != first {
+			return outputHuman
+		}
+	}
+	return first
 }
 
 func commandNameForError(root *cobra.Command, args []string, runEReached bool) string {

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -148,7 +148,7 @@ func emitErrorForMode(w io.Writer, err error, mode outputMode, runEReached bool)
 }
 
 func emitRootError(w io.Writer, cmd *cobra.Command, args []string, err error, runEReached bool) {
-	mode := resolvedOutputModeForError(args)
+	mode := resolvedOutputModeForError(cmd, args)
 	switch mode {
 	case outputAgent:
 		emitAgentError(w, commandNameForError(cmd, args, runEReached), cliErrorForErr(err, runEReached))
@@ -157,11 +157,15 @@ func emitRootError(w io.Writer, cmd *cobra.Command, args []string, err error, ru
 	}
 }
 
-func resolvedOutputModeForError(args []string) outputMode {
+func resolvedOutputModeForError(root *cobra.Command, args []string) outputMode {
 	if flags.Mode != "" {
 		return flags.Mode
 	}
-	mode, err := resolveOutputModeArgs(args, flags.Format, flags.JSON, flags.Agent)
+	importLegacy := false
+	if cmd := commandFromArgs(root, args); isImportCommand(cmd) {
+		importLegacy = true
+	}
+	mode, err := resolveOutputModeArgsForCommand(args, flags.Format, flags.JSON, flags.Agent, importLegacy)
 	if err != nil {
 		return outputHuman
 	}

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -36,6 +36,7 @@ var runEEntered bool
 var errorCommandName string
 
 func newRootCmd() *cobra.Command {
+	runEEntered = false
 	flags.Mode = ""
 	errorCommandName = ""
 	cmd := &cobra.Command{
@@ -118,8 +119,9 @@ func main() {
 		<-ctx.Done()
 		stop()
 	}()
-	if err := newRootCmd().ExecuteContext(ctx); err != nil {
-		emitErrorForMode(os.Stderr, err, resolvedOutputModeForError(os.Args[1:]), runEEntered)
+	cmd := newRootCmd()
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		emitRootError(os.Stderr, cmd, os.Args[1:], err, runEEntered)
 		os.Exit(exitCodeForErr(err, runEEntered))
 	}
 }
@@ -139,9 +141,19 @@ func emitErrorForMode(w io.Writer, err error, mode outputMode, runEReached bool)
 	case outputJSON:
 		emitJSONError(w, err, runEReached)
 	case outputAgent:
-		emitAgentError(w, commandNameForError(runEReached), cliErrorForErr(err, runEReached))
+		emitAgentError(w, commandNameForError(nil, nil, runEReached), cliErrorForErr(err, runEReached))
 	default:
 		emitHumanError(w, err, runEReached)
+	}
+}
+
+func emitRootError(w io.Writer, cmd *cobra.Command, args []string, err error, runEReached bool) {
+	mode := resolvedOutputModeForError(args)
+	switch mode {
+	case outputAgent:
+		emitAgentError(w, commandNameForError(cmd, args, runEReached), cliErrorForErr(err, runEReached))
+	default:
+		emitErrorForMode(w, err, mode, runEReached)
 	}
 }
 
@@ -156,14 +168,76 @@ func resolvedOutputModeForError(args []string) outputMode {
 	return mode
 }
 
-func commandNameForError(runEReached bool) string {
-	if !runEReached {
-		return "kata"
-	}
+func commandNameForError(root *cobra.Command, args []string, runEReached bool) string {
 	if errorCommandName != "" {
 		return errorCommandName
 	}
+	if !runEReached {
+		if cmd := commandFromArgs(root, args); cmd != nil && cmd != root {
+			return commandLeaf(cmd)
+		}
+	}
 	return "kata"
+}
+
+func commandFromArgs(root *cobra.Command, args []string) *cobra.Command {
+	if root == nil {
+		return nil
+	}
+	cmd := root
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		if strings.HasPrefix(arg, "-") {
+			if flagArgConsumesValue(cmd, arg) && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		next := childCommandByName(cmd, arg)
+		if next == nil {
+			break
+		}
+		cmd = next
+	}
+	return cmd
+}
+
+func childCommandByName(cmd *cobra.Command, name string) *cobra.Command {
+	if cmd == nil {
+		return nil
+	}
+	for _, child := range cmd.Commands() {
+		if child.Name() == name {
+			return child
+		}
+		for _, alias := range child.Aliases {
+			if alias == name {
+				return child
+			}
+		}
+	}
+	return nil
+}
+
+func flagArgConsumesValue(cmd *cobra.Command, arg string) bool {
+	name := strings.TrimLeft(arg, "-")
+	if eq := strings.IndexByte(name, '='); eq >= 0 {
+		return false
+	}
+	if name == "" {
+		return false
+	}
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
+		flag = cmd.PersistentFlags().Lookup(name)
+	}
+	if flag == nil {
+		flag = cmd.InheritedFlags().Lookup(name)
+	}
+	return flag != nil && flag.Value.Type() != "bool"
 }
 
 func commandLeaf(cmd *cobra.Command) string {

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -52,6 +52,9 @@ func newRootCmd() *cobra.Command {
 				return err
 			}
 			flags.Mode = mode
+			if mode == outputJSON {
+				flags.JSON = true
+			}
 			return nil
 		},
 	}
@@ -148,7 +151,10 @@ func emitErrorForMode(w io.Writer, err error, mode outputMode, runEReached bool)
 }
 
 func emitRootError(w io.Writer, cmd *cobra.Command, args []string, err error, runEReached bool) {
-	mode := resolvedOutputModeForError(cmd, args)
+	mode, modeErr := resolvedOutputModeForError(cmd, args)
+	if modeErr != nil {
+		err = modeErr
+	}
 	switch mode {
 	case outputAgent:
 		emitAgentError(w, commandNameForError(cmd, args, runEReached), cliErrorForErr(err, runEReached))
@@ -157,9 +163,9 @@ func emitRootError(w io.Writer, cmd *cobra.Command, args []string, err error, ru
 	}
 }
 
-func resolvedOutputModeForError(root *cobra.Command, args []string) outputMode {
+func resolvedOutputModeForError(root *cobra.Command, args []string) (outputMode, error) {
 	if flags.Mode != "" {
-		return flags.Mode
+		return flags.Mode, nil
 	}
 	importLegacy := false
 	if cmd := commandFromArgs(root, args); isImportCommand(cmd) {
@@ -167,9 +173,9 @@ func resolvedOutputModeForError(root *cobra.Command, args []string) outputMode {
 	}
 	mode, err := resolveOutputModeArgsForCommand(args, flags.Format, flags.JSON, flags.Agent, importLegacy)
 	if err != nil {
-		return outputHuman
+		return outputHuman, err
 	}
-	return mode
+	return mode, nil
 }
 
 func commandNameForError(root *cobra.Command, args []string, runEReached bool) string {

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -156,22 +156,33 @@ func TestEmitError_HumanMode_StillPrintsKataPrefix(t *testing.T) {
 }
 
 func TestEmitError_AgentMode_CommandError(t *testing.T) {
-	cli := &cliError{Message: "comment body is required", Kind: kindValidation, ExitCode: ExitValidation}
+	cli := &cliError{
+		Message:  "comment body is required",
+		Code:     "comment_body_required",
+		Kind:     kindValidation,
+		ExitCode: ExitValidation,
+	}
 	var buf bytes.Buffer
 	emitAgentError(&buf, "comment", cli)
-	assert.Contains(t, buf.String(), "ERR comment validation: comment body is required\n")
+	assert.Equal(t, "ERR comment validation: comment body is required\n", buf.String())
 }
 
-func TestEmitError_AgentMode_ParseError(t *testing.T) {
+func TestEmitError_AgentMode_UnknownCommandUsesKata(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)
 	_, stderr, err := executeRootCapture(t, context.Background(), "--agent", "cretae")
 	require.Error(t, err)
-	var buf bytes.Buffer
-	buf.WriteString(stderr)
-	emitErrorForMode(&buf, err, resolvedOutputModeForError([]string{"--agent", "cretae"}), runEEntered)
-	assert.Truef(t, strings.HasPrefix(buf.String(), "ERR kata usage:"),
-		"stderr should start with agent usage error, got %q", buf.String())
+	assert.Truef(t, strings.HasPrefix(stderr, "ERR kata usage:"),
+		"stderr should start with agent usage error, got %q", stderr)
+}
+
+func TestEmitError_AgentMode_CommandArgErrorUsesLeafCommand(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--agent", "show")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "ERR show usage:"),
+		"stderr should start with agent usage error for show, got %q", stderr)
 }
 
 // TestEmitError_NonCliError_SynthesizesEnvelope confirms a plain

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -205,6 +205,16 @@ func TestEmitError_OutputModeConflictPrecedesUnknownCommand(t *testing.T) {
 	assert.NotContains(t, stderr, "unknown command")
 }
 
+func TestOutputMode_RepeatedFormatConflicts(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	stdout, stderr, err := executeRootCapture(t, context.Background(),
+		"--format", "human", "--format", "json", "version")
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "conflicting output modes")
+}
+
 func TestEmitError_RawModeScanParsesJSONTrueValue(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -205,6 +205,41 @@ func TestEmitError_OutputModeConflictPrecedesUnknownCommand(t *testing.T) {
 	assert.NotContains(t, stderr, "unknown command")
 }
 
+func TestEmitError_RawModeScanParsesJSONTrueValue(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--json=true", "cretae")
+	require.Error(t, err)
+	got := parseErrorEnvelope(t, []byte(stderr))
+	assert.Equal(t, "usage", got.Error.Kind)
+	assert.Contains(t, got.Error.Message, "unknown command")
+}
+
+func TestEmitError_RawModeScanParsesAgentTrueValue(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--agent=true", "cretae")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "ERR kata usage:"),
+		"stderr should use agent mode, got %q", stderr)
+}
+
+func TestEmitError_RawModeScanParsesJSONFalseValue(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--json=false", "cretae")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "kata:"), "stderr should stay human, got %q", stderr)
+}
+
+func TestEmitError_RawModeScanParsesAgentFalseValue(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--agent=false", "cretae")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "kata:"), "stderr should stay human, got %q", stderr)
+}
+
 func TestEmitError_RawModeScanSkipsWorkspaceFormatValue(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -258,6 +258,24 @@ func TestEmitError_RawModeScanSkipsWorkspaceAgentValue(t *testing.T) {
 	assert.NotContains(t, stderr, "ERR ")
 }
 
+func TestEmitError_RawModeScanSkipsCreateBodyJSONValue(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "create", "--body", "--json")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "kata:"), "stderr should stay human, got %q", stderr)
+	assert.Falsef(t, strings.HasPrefix(stderr, "{"), "stderr should not be JSON, got %q", stderr)
+}
+
+func TestEmitError_RawModeScanSkipsCreateBodyAgentValue(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "create", "--body", "--agent")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "kata:"), "stderr should stay human, got %q", stderr)
+	assert.NotContains(t, stderr, "ERR ")
+}
+
 func TestEmitError_AgentMode_CommandArgErrorUsesLeafCommand(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -287,6 +287,16 @@ func TestEmitError_RawModeScanSkipsCreateBodyJSONValue(t *testing.T) {
 	assert.Falsef(t, strings.HasPrefix(stderr, "{"), "stderr should not be JSON, got %q", stderr)
 }
 
+func TestEmitError_InvalidCommandPathDoesNotSwallowJSON(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "typo", "create", "--body", "--json")
+	require.Error(t, err)
+	got := parseErrorEnvelope(t, []byte(stderr))
+	assert.Equal(t, "usage", got.Error.Kind)
+	assert.Contains(t, got.Error.Message, "unknown command")
+}
+
 func TestEmitError_RawModeScanSkipsCreateBodyAgentValue(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,9 @@ import (
 
 func TestRoot_HelpListsUniversalFlags(t *testing.T) {
 	out := string(executeRoot(t, newRootCmd(), "--help"))
+	assert.Contains(t, out, "--format")
 	assert.Contains(t, out, "--json")
+	assert.Contains(t, out, "--agent")
 	assert.Contains(t, out, "--quiet")
 	assert.Contains(t, out, "--as")
 	assert.Contains(t, out, "--workspace")
@@ -150,6 +153,25 @@ func TestEmitError_HumanMode_StillPrintsKataPrefix(t *testing.T) {
 	var buf bytes.Buffer
 	emitError(&buf, cli, false, true)
 	assert.Contains(t, buf.String(), "kata: title must not be empty")
+}
+
+func TestEmitError_AgentMode_CommandError(t *testing.T) {
+	cli := &cliError{Message: "comment body is required", Kind: kindValidation, ExitCode: ExitValidation}
+	var buf bytes.Buffer
+	emitAgentError(&buf, "comment", cli)
+	assert.Contains(t, buf.String(), "ERR comment validation: comment body is required\n")
+}
+
+func TestEmitError_AgentMode_ParseError(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--agent", "cretae")
+	require.Error(t, err)
+	var buf bytes.Buffer
+	buf.WriteString(stderr)
+	emitErrorForMode(&buf, err, resolvedOutputModeForError([]string{"--agent", "cretae"}), runEEntered)
+	assert.Truef(t, strings.HasPrefix(buf.String(), "ERR kata usage:"),
+		"stderr should start with agent usage error, got %q", buf.String())
 }
 
 // TestEmitError_NonCliError_SynthesizesEnvelope confirms a plain

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -196,6 +196,16 @@ func TestEmitError_OutputModeErrorPrecedesUnknownCommand(t *testing.T) {
 	assert.NotContains(t, stderr, "unknown command")
 }
 
+func TestEmitError_AgentAliasWithInvalidFormatStillUsesAgent(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--agent", "--format", "xml", "version")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "ERR version usage:"),
+		"stderr should use agent mode, got %q", stderr)
+	assert.Contains(t, stderr, "unsupported output format")
+}
+
 func TestEmitError_OutputModeConflictPrecedesUnknownCommand(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -205,6 +205,24 @@ func TestEmitError_OutputModeConflictPrecedesUnknownCommand(t *testing.T) {
 	assert.NotContains(t, stderr, "unknown command")
 }
 
+func TestEmitError_RawModeScanSkipsWorkspaceFormatValue(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--workspace", "--format", "show")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "kata:"), "stderr should stay human, got %q", stderr)
+	assert.NotContains(t, stderr, "unsupported output format")
+}
+
+func TestEmitError_RawModeScanSkipsWorkspaceAgentValue(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--workspace", "--agent", "show")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "kata:"), "stderr should stay human, got %q", stderr)
+	assert.NotContains(t, stderr, "ERR ")
+}
+
 func TestEmitError_AgentMode_CommandArgErrorUsesLeafCommand(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -176,6 +176,35 @@ func TestEmitError_AgentMode_UnknownCommandUsesKata(t *testing.T) {
 		"stderr should start with agent usage error, got %q", stderr)
 }
 
+func TestEmitError_AgentMode_ParseErrorSingleLine(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--agent", "cretae")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "ERR kata usage:"),
+		"stderr should start with agent usage error, got %q", stderr)
+	assert.Equal(t, 1, strings.Count(stderr, "\n"), "agent error must be one physical line: %q", stderr)
+	assert.NotContains(t, stderr, "Did you mean")
+}
+
+func TestEmitError_OutputModeErrorPrecedesUnknownCommand(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--format", "xml", "cretae")
+	require.Error(t, err)
+	assert.Contains(t, stderr, "unsupported output format")
+	assert.NotContains(t, stderr, "unknown command")
+}
+
+func TestEmitError_OutputModeConflictPrecedesUnknownCommand(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--json", "--agent", "cretae")
+	require.Error(t, err)
+	assert.Contains(t, stderr, "conflicting output modes")
+	assert.NotContains(t, stderr, "unknown command")
+}
+
 func TestEmitError_AgentMode_CommandArgErrorUsesLeafCommand(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -70,21 +70,50 @@ func resolveOutputModeArgsForCommand(
 ) (outputMode, error) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		switch {
-		case arg == "--":
+		if arg == "--" {
 			return resolveOutputModeValues(outputFormatValue(format, importLegacy), jsonFlag, agentFlag)
-		case arg == "--json":
-			jsonFlag = true
-		case arg == "--agent":
-			agentFlag = true
-		case arg == "--format" && i+1 < len(args):
-			format = args[i+1]
-			i++
-		case strings.HasPrefix(arg, "--format="):
-			format = strings.TrimPrefix(arg, "--format=")
+		}
+		name, value, hasValue, ok := splitLongFlag(arg)
+		if !ok {
+			continue
+		}
+		switch name {
+		case "json":
+			if !hasValue {
+				jsonFlag = true
+			}
+		case "agent":
+			if !hasValue {
+				agentFlag = true
+			}
+		case "format":
+			if hasValue {
+				format = value
+			} else if i+1 < len(args) {
+				format = args[i+1]
+				i++
+			}
+		case "as", "workspace", "project":
+			if !hasValue && i+1 < len(args) {
+				i++
+			}
 		}
 	}
 	return resolveOutputModeValues(outputFormatValue(format, importLegacy), jsonFlag, agentFlag)
+}
+
+func splitLongFlag(arg string) (name, value string, hasValue bool, ok bool) {
+	if !strings.HasPrefix(arg, "--") || arg == "--" {
+		return "", "", false, false
+	}
+	trimmed := strings.TrimPrefix(arg, "--")
+	if trimmed == "" {
+		return "", "", false, false
+	}
+	if before, after, found := strings.Cut(trimmed, "="); found {
+		return before, after, true, true
+	}
+	return trimmed, "", false, true
 }
 
 func outputFormatValue(format string, importLegacy bool) string {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -121,5 +121,12 @@ func emitAgentError(w io.Writer, command string, err error) {
 	if command == "" {
 		command = "kata"
 	}
-	_, _ = fmt.Fprintf(w, "ERR %s %s: %s\n", command, cli.Kind, cli.Message)
+	_, _ = fmt.Fprintf(w, "ERR %s %s: %s\n", command, cli.Kind, firstLine(cli.Message))
+}
+
+func firstLine(s string) string {
+	if idx := strings.IndexAny(s, "\r\n"); idx >= 0 {
+		return s[:idx]
+	}
+	return s
 }

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+type outputMode string
+
+const (
+	outputHuman outputMode = "human"
+	outputJSON  outputMode = "json"
+	outputAgent outputMode = "agent"
+)
+
+const agentFormatVersion = 1
+
+func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMode, error) {
+	var selected []outputMode
+	if format != "" {
+		switch outputMode(format) {
+		case outputHuman, outputJSON, outputAgent:
+			selected = append(selected, outputMode(format))
+		default:
+			return "", &cliError{
+				Message:  "unsupported output format " + strconv.Quote(format) + " (want human, json, or agent)",
+				Kind:     kindUsage,
+				ExitCode: ExitUsage,
+			}
+		}
+	}
+	if jsonFlag {
+		selected = append(selected, outputJSON)
+	}
+	if agentFlag {
+		selected = append(selected, outputAgent)
+	}
+	if len(selected) == 0 {
+		return outputHuman, nil
+	}
+	first := selected[0]
+	for _, mode := range selected[1:] {
+		if mode != first {
+			return "", &cliError{Message: "conflicting output modes", Kind: kindUsage, ExitCode: ExitUsage}
+		}
+	}
+	return first, nil
+}
+
+func resolveOutputModeArgs(args []string, format string, jsonFlag, agentFlag bool) (outputMode, error) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--":
+			return resolveOutputModeValues(format, jsonFlag, agentFlag)
+		case arg == "--json":
+			jsonFlag = true
+		case arg == "--agent":
+			agentFlag = true
+		case arg == "--format" && i+1 < len(args):
+			format = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--format="):
+			format = strings.TrimPrefix(arg, "--format=")
+		}
+	}
+	return resolveOutputModeValues(format, jsonFlag, agentFlag)
+}
+
+func emitAgentError(w io.Writer, command string, err error) {
+	var cli *cliError
+	if !errors.As(err, &cli) {
+		cli = &cliError{
+			Message:  err.Error(),
+			Kind:     kindInternal,
+			ExitCode: ExitInternal,
+		}
+	}
+	if command == "" {
+		command = "kata"
+	}
+	_, _ = fmt.Fprintf(w, "ERR %s %s: %s\n", command, cli.Kind, cli.Message)
+	if cli.Code != "" {
+		_, _ = fmt.Fprintf(w, "Code: %s\n", cli.Code)
+	}
+}

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type outputMode string
@@ -59,7 +60,7 @@ func resolveOutputModeForCommand(cmd *cobra.Command) (outputMode, error) {
 }
 
 func resolveOutputModeArgs(args []string, format string, jsonFlag, agentFlag bool) (outputMode, error) {
-	return resolveOutputModeArgsForCommand(args, format, jsonFlag, agentFlag, false)
+	return resolveOutputModeArgsForCommand(args, format, jsonFlag, agentFlag, false, nil)
 }
 
 func resolveOutputModeArgsForCommand(
@@ -67,7 +68,9 @@ func resolveOutputModeArgsForCommand(
 	format string,
 	jsonFlag, agentFlag bool,
 	importLegacy bool,
+	root *cobra.Command,
 ) (outputMode, error) {
+	cmd := root
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
@@ -75,10 +78,16 @@ func resolveOutputModeArgsForCommand(
 		}
 		name, value, hasValue, ok := splitLongFlag(arg)
 		if !ok {
+			if next := childCommandByName(cmd, arg); next != nil {
+				cmd = next
+			}
 			continue
 		}
 		switch name {
 		case "json":
+			if !rawFlagKnown(cmd, name) {
+				continue
+			}
 			if hasValue {
 				if parsed, err := strconv.ParseBool(value); err == nil {
 					jsonFlag = parsed
@@ -87,6 +96,9 @@ func resolveOutputModeArgsForCommand(
 				jsonFlag = true
 			}
 		case "agent":
+			if !rawFlagKnown(cmd, name) {
+				continue
+			}
 			if hasValue {
 				if parsed, err := strconv.ParseBool(value); err == nil {
 					agentFlag = parsed
@@ -95,14 +107,17 @@ func resolveOutputModeArgsForCommand(
 				agentFlag = true
 			}
 		case "format":
+			if !rawFlagKnown(cmd, name) {
+				continue
+			}
 			if hasValue {
 				format = value
 			} else if i+1 < len(args) {
 				format = args[i+1]
 				i++
 			}
-		case "as", "workspace", "project":
-			if !hasValue && i+1 < len(args) {
+		default:
+			if rawFlagConsumesValue(cmd, name) && !hasValue && i+1 < len(args) {
 				i++
 			}
 		}
@@ -122,6 +137,58 @@ func splitLongFlag(arg string) (name, value string, hasValue bool, ok bool) {
 		return before, after, true, true
 	}
 	return trimmed, "", false, true
+}
+
+func rawFlagKnown(cmd *cobra.Command, name string) bool {
+	if cmd == nil {
+		return isRootPersistentFlag(name)
+	}
+	return lookupRawFlag(cmd, name) != nil
+}
+
+func rawFlagConsumesValue(cmd *cobra.Command, name string) bool {
+	if cmd == nil {
+		return isRootStringFlag(name)
+	}
+	flag := lookupRawFlag(cmd, name)
+	return flag != nil && flag.Value.Type() != "bool"
+}
+
+func lookupRawFlag(cmd *cobra.Command, name string) *pflag.Flag {
+	if cmd == nil {
+		return nil
+	}
+	if flag := cmd.Flags().Lookup(name); flag != nil {
+		return flag
+	}
+	if flag := cmd.PersistentFlags().Lookup(name); flag != nil {
+		return flag
+	}
+	if flag := cmd.InheritedFlags().Lookup(name); flag != nil {
+		return flag
+	}
+	if root := cmd.Root(); root != nil {
+		return root.PersistentFlags().Lookup(name)
+	}
+	return nil
+}
+
+func isRootPersistentFlag(name string) bool {
+	switch name {
+	case "format", "json", "agent", "quiet", "as", "workspace", "project":
+		return true
+	default:
+		return false
+	}
+}
+
+func isRootStringFlag(name string) bool {
+	switch name {
+	case "format", "as", "workspace", "project":
+		return true
+	default:
+		return false
+	}
 }
 
 func outputFormatValue(format string, importLegacy bool) string {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -191,6 +191,7 @@ func resolveOutputModeArgsForCommand(
 ) (outputMode, error) {
 	cmd := root
 	formats := append([]string(nil), flags.FormatValues...)
+	commandPathStopped := false
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
@@ -198,8 +199,12 @@ func resolveOutputModeArgsForCommand(
 		}
 		name, value, hasValue, ok := splitLongFlag(arg)
 		if !ok {
-			if next := childCommandByName(cmd, arg); next != nil {
-				cmd = next
+			if !commandPathStopped {
+				if next := childCommandByName(cmd, arg); next != nil {
+					cmd = next
+				} else {
+					commandPathStopped = true
+				}
 			}
 			continue
 		}

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -79,11 +79,19 @@ func resolveOutputModeArgsForCommand(
 		}
 		switch name {
 		case "json":
-			if !hasValue {
+			if hasValue {
+				if parsed, err := strconv.ParseBool(value); err == nil {
+					jsonFlag = parsed
+				}
+			} else {
 				jsonFlag = true
 			}
 		case "agent":
-			if !hasValue {
+			if hasValue {
+				if parsed, err := strconv.ParseBool(value); err == nil {
+					agentFlag = parsed
+				}
+			} else {
 				agentFlag = true
 			}
 		case "format":

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -18,8 +18,6 @@ const (
 	outputAgent outputMode = "agent"
 )
 
-const agentFormatVersion = 1
-
 func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMode, error) {
 	var selected []outputMode
 	if format != "" {
@@ -121,7 +119,7 @@ func emitAgentError(w io.Writer, command string, err error) {
 	if command == "" {
 		command = "kata"
 	}
-	_, _ = fmt.Fprintf(w, "ERR %s %s: %s\n", command, cli.Kind, firstLine(cli.Message))
+	_, _ = fmt.Fprintf(w, "ERR %s %s: %s\n", command, cli.Kind, firstLine(cli.Message)) //nolint:gosec // G705: CLI stderr error text, not HTML.
 }
 
 func firstLine(s string) string {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -83,7 +83,4 @@ func emitAgentError(w io.Writer, command string, err error) {
 		command = "kata"
 	}
 	_, _ = fmt.Fprintf(w, "ERR %s %s: %s\n", command, cli.Kind, cli.Message)
-	if cli.Code != "" {
-		_, _ = fmt.Fprintf(w, "Code: %s\n", cli.Code)
-	}
 }

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -34,10 +34,36 @@ type agentIssueMutation struct {
 		Owner        *string `json:"owner"`
 		DeletedAt    *string `json:"deleted_at"`
 	} `json:"issue"`
+	Event *struct {
+		Payload string `json:"payload"`
+	} `json:"event"`
+	Label struct {
+		Label string `json:"label"`
+	} `json:"label"`
 	Changed       bool    `json:"changed"`
 	Reused        bool    `json:"reused,omitempty"`
 	PreviousOwner *string `json:"previous_owner,omitempty"`
 }
+
+type outputFormatFlag struct {
+	value  *string
+	values *[]string
+}
+
+func (f outputFormatFlag) Set(s string) error {
+	*f.value = s
+	*f.values = append(*f.values, s)
+	return nil
+}
+
+func (f outputFormatFlag) String() string {
+	if f.value == nil {
+		return ""
+	}
+	return *f.value
+}
+
+func (f outputFormatFlag) Type() string { return "string" }
 
 func printAgentMutation(cmd *cobra.Command, verb string, bs []byte, extra func(io.Writer, agentIssueMutation) error) error {
 	var m agentIssueMutation
@@ -88,9 +114,16 @@ func printAgentMutationDecoded(
 	return nil
 }
 
-func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMode, error) {
+func resolveOutputModeFormats(formats []string, fallback string, importLegacy bool, jsonFlag, agentFlag bool) (outputMode, error) {
+	if len(formats) == 0 && fallback != "" {
+		formats = []string{fallback}
+	}
 	var selected []outputMode
-	if format != "" {
+	for _, format := range formats {
+		format = outputFormatValue(format, importLegacy)
+		if format == "" {
+			continue
+		}
 		switch outputMode(format) {
 		case outputHuman, outputJSON, outputAgent:
 			selected = append(selected, outputMode(format))
@@ -120,6 +153,10 @@ func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMod
 	return first, nil
 }
 
+func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMode, error) {
+	return resolveOutputModeFormats(nil, format, false, jsonFlag, agentFlag)
+}
+
 func currentOutputMode() outputMode {
 	if flags.Mode != "" {
 		return flags.Mode
@@ -138,7 +175,7 @@ func resolveOutputModeForCommand(cmd *cobra.Command) (outputMode, error) {
 	if isImportCommand(cmd) && isImportLegacySourceFormat(format) {
 		format = ""
 	}
-	return resolveOutputModeValues(format, flags.JSON, flags.Agent)
+	return resolveOutputModeFormats(flags.FormatValues, format, isImportCommand(cmd), flags.JSON, flags.Agent)
 }
 
 func resolveOutputModeArgs(args []string, format string, jsonFlag, agentFlag bool) (outputMode, error) {
@@ -153,10 +190,11 @@ func resolveOutputModeArgsForCommand(
 	root *cobra.Command,
 ) (outputMode, error) {
 	cmd := root
+	formats := append([]string(nil), flags.FormatValues...)
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
-			return resolveOutputModeValues(outputFormatValue(format, importLegacy), jsonFlag, agentFlag)
+			return resolveOutputModeFormats(formats, format, importLegacy, jsonFlag, agentFlag)
 		}
 		name, value, hasValue, ok := splitLongFlag(arg)
 		if !ok {
@@ -194,8 +232,10 @@ func resolveOutputModeArgsForCommand(
 			}
 			if hasValue {
 				format = value
+				formats = append(formats, value)
 			} else if i+1 < len(args) {
 				format = args[i+1]
+				formats = append(formats, args[i+1])
 				i++
 			}
 		default:
@@ -204,7 +244,7 @@ func resolveOutputModeArgsForCommand(
 			}
 		}
 	}
-	return resolveOutputModeValues(outputFormatValue(format, importLegacy), jsonFlag, agentFlag)
+	return resolveOutputModeFormats(formats, format, importLegacy, jsonFlag, agentFlag)
 }
 
 func splitLongFlag(arg string) (name, value string, hasValue bool, ok bool) {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.kenn.io/kata/internal/textsafe"
 )
 
 type outputMode string
@@ -224,6 +226,32 @@ func emitAgentError(w io.Writer, command string, err error) {
 		command = "kata"
 	}
 	_, _ = fmt.Fprintf(w, "ERR %s %s: %s\n", command, cli.Kind, firstLine(cli.Message)) //nolint:gosec // G705: CLI stderr error text, not HTML.
+}
+
+func agentValue(s string) string {
+	clean := textsafe.Block(s)
+	if clean == "" {
+		return `""`
+	}
+	if strings.IndexFunc(clean, func(r rune) bool {
+		return unicode.IsSpace(r) || r == '"' || r == '\\' || unicode.IsControl(r)
+	}) >= 0 {
+		return strconv.Quote(clean)
+	}
+	return clean
+}
+
+func writeAgentField(w io.Writer, name, value string) error {
+	_, err := fmt.Fprintf(w, "%s: %s\n", name, value)
+	return err
+}
+
+func agentFencedText(s string) string {
+	fence := "```"
+	for strings.Contains(s, fence) {
+		fence += "`"
+	}
+	return fence + "text\n" + textsafe.Block(s) + "\n" + fence + "\n"
 }
 
 func firstLine(s string) string {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,69 @@ const (
 
 	agentFormatVersion = 1
 )
+
+type agentIssueMutation struct {
+	Issue struct {
+		ShortID      string  `json:"short_id"`
+		QualifiedID  string  `json:"qualified_id"`
+		Title        string  `json:"title"`
+		Status       string  `json:"status"`
+		ClosedReason *string `json:"closed_reason"`
+		Owner        *string `json:"owner"`
+		DeletedAt    *string `json:"deleted_at"`
+	} `json:"issue"`
+	Changed bool `json:"changed"`
+	Reused  bool `json:"reused,omitempty"`
+}
+
+func printAgentMutation(cmd *cobra.Command, verb string, bs []byte, extra func(io.Writer, agentIssueMutation) error) error {
+	var m agentIssueMutation
+	if err := json.Unmarshal(bs, &m); err != nil {
+		return err
+	}
+	return printAgentMutationDecoded(cmd.OutOrStdout(), verb, m, false, extra)
+}
+
+func printAgentMutationDecoded(
+	w io.Writer,
+	verb string,
+	m agentIssueMutation,
+	includeChangedTrue bool,
+	extra func(io.Writer, agentIssueMutation) error,
+) error {
+	if !flags.Quiet {
+		if _, err := fmt.Fprintf(w, "OK %s %s", verb, m.Issue.ShortID); err != nil {
+			return err
+		}
+		if m.Reused {
+			if _, err := fmt.Fprint(w, " reused=true"); err != nil {
+				return err
+			}
+		}
+		if !m.Changed || includeChangedTrue {
+			if _, err := fmt.Fprintf(w, " changed=%t", m.Changed); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	if m.Issue.ShortID != "" && m.Issue.Title != "" {
+		if _, err := fmt.Fprintf(w, "Issue: %s %s\n", m.Issue.ShortID, agentValue(m.Issue.Title)); err != nil {
+			return err
+		}
+	}
+	if m.Issue.Status != "" {
+		if err := writeAgentField(w, "Status", agentValue(m.Issue.Status)); err != nil {
+			return err
+		}
+	}
+	if extra != nil {
+		return extra(w, m)
+	}
+	return nil
+}
 
 func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMode, error) {
 	var selected []outputMode

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -61,11 +61,20 @@ func resolveOutputModeForCommand(cmd *cobra.Command) (outputMode, error) {
 }
 
 func resolveOutputModeArgs(args []string, format string, jsonFlag, agentFlag bool) (outputMode, error) {
+	return resolveOutputModeArgsForCommand(args, format, jsonFlag, agentFlag, false)
+}
+
+func resolveOutputModeArgsForCommand(
+	args []string,
+	format string,
+	jsonFlag, agentFlag bool,
+	importLegacy bool,
+) (outputMode, error) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
 		case arg == "--":
-			return resolveOutputModeValues(format, jsonFlag, agentFlag)
+			return resolveOutputModeValues(outputFormatValue(format, importLegacy), jsonFlag, agentFlag)
 		case arg == "--json":
 			jsonFlag = true
 		case arg == "--agent":
@@ -77,7 +86,14 @@ func resolveOutputModeArgs(args []string, format string, jsonFlag, agentFlag boo
 			format = strings.TrimPrefix(arg, "--format=")
 		}
 	}
-	return resolveOutputModeValues(format, jsonFlag, agentFlag)
+	return resolveOutputModeValues(outputFormatValue(format, importLegacy), jsonFlag, agentFlag)
+}
+
+func outputFormatValue(format string, importLegacy bool) string {
+	if importLegacy && isImportLegacySourceFormat(format) {
+		return ""
+	}
+	return format
 }
 
 func isImportCommand(cmd *cobra.Command) bool {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -19,6 +19,8 @@ const (
 	outputHuman outputMode = "human"
 	outputJSON  outputMode = "json"
 	outputAgent outputMode = "agent"
+
+	agentFormatVersion = 1
 )
 
 func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMode, error) {
@@ -51,6 +53,19 @@ func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMod
 		}
 	}
 	return first, nil
+}
+
+func currentOutputMode() outputMode {
+	if flags.Mode != "" {
+		return flags.Mode
+	}
+	if flags.Agent {
+		return outputAgent
+	}
+	if flags.JSON {
+		return outputJSON
+	}
+	return outputHuman
 }
 
 func resolveOutputModeForCommand(cmd *cobra.Command) (outputMode, error) {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 type outputMode string
@@ -50,6 +52,14 @@ func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMod
 	return first, nil
 }
 
+func resolveOutputModeForCommand(cmd *cobra.Command) (outputMode, error) {
+	format := flags.Format
+	if isImportCommand(cmd) && isImportLegacySourceFormat(format) {
+		format = ""
+	}
+	return resolveOutputModeValues(format, flags.JSON, flags.Agent)
+}
+
 func resolveOutputModeArgs(args []string, format string, jsonFlag, agentFlag bool) (outputMode, error) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -68,6 +78,19 @@ func resolveOutputModeArgs(args []string, format string, jsonFlag, agentFlag boo
 		}
 	}
 	return resolveOutputModeValues(format, jsonFlag, agentFlag)
+}
+
+func isImportCommand(cmd *cobra.Command) bool {
+	return cmd != nil && cmd.Name() == "import"
+}
+
+func isImportLegacySourceFormat(format string) bool {
+	switch strings.TrimSpace(format) {
+	case "kata", "beads":
+		return true
+	default:
+		return false
+	}
 }
 
 func emitAgentError(w io.Writer, command string, err error) {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -34,8 +34,9 @@ type agentIssueMutation struct {
 		Owner        *string `json:"owner"`
 		DeletedAt    *string `json:"deleted_at"`
 	} `json:"issue"`
-	Changed bool `json:"changed"`
-	Reused  bool `json:"reused,omitempty"`
+	Changed       bool    `json:"changed"`
+	Reused        bool    `json:"reused,omitempty"`
+	PreviousOwner *string `json:"previous_owner,omitempty"`
 }
 
 func printAgentMutation(cmd *cobra.Command, verb string, bs []byte, extra func(io.Writer, agentIssueMutation) error) error {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -367,11 +367,12 @@ func writeAgentField(w io.Writer, name, value string) error {
 }
 
 func agentFencedText(s string) string {
+	clean := textsafe.Block(s)
 	fence := "```"
-	for strings.Contains(s, fence) {
+	for strings.Contains(clean, fence) {
 		fence += "`"
 	}
-	return fence + "text\n" + textsafe.Block(s) + "\n" + fence + "\n"
+	return fence + "text\n" + clean + "\n" + fence + "\n"
 }
 
 func firstLine(s string) string {

--- a/cmd/kata/output_mode_test.go
+++ b/cmd/kata/output_mode_test.go
@@ -58,3 +58,10 @@ func TestAgentFencedText_ExtendsFenceForBackticks(t *testing.T) {
 	assert.Contains(t, got, "````text\n")
 	assert.True(t, strings.HasSuffix(got, "\n````\n"))
 }
+
+func TestAgentFencedText_ChoosesFenceAfterSanitizing(t *testing.T) {
+	got := agentFencedText("``\x00` inside")
+	assert.Contains(t, got, "````text\n")
+	assert.Contains(t, got, "``` inside")
+	assert.True(t, strings.HasSuffix(got, "\n````\n"))
+}

--- a/cmd/kata/output_mode_test.go
+++ b/cmd/kata/output_mode_test.go
@@ -37,3 +37,9 @@ func TestResolveOutputMode(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveOutputModeArgs_BadFormatOutsideImport(t *testing.T) {
+	_, err := resolveOutputModeArgs([]string{"--format", "xml"}, "", false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported output format")
+}

--- a/cmd/kata/output_mode_test.go
+++ b/cmd/kata/output_mode_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveOutputMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		format  string
+		json    bool
+		agent   bool
+		want    outputMode
+		wantErr string
+	}{
+		{name: "default human", want: outputHuman},
+		{name: "format json", format: "json", want: outputJSON},
+		{name: "json alias", json: true, want: outputJSON},
+		{name: "agent alias", agent: true, want: outputAgent},
+		{name: "matching agent flags", format: "agent", agent: true, want: outputAgent},
+		{name: "conflicting modes", format: "human", json: true, wantErr: "conflicting output modes"},
+		{name: "bad format", format: "xml", wantErr: "unsupported output format"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveOutputModeValues(tc.format, tc.json, tc.agent)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cmd/kata/output_mode_test.go
+++ b/cmd/kata/output_mode_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,4 +44,17 @@ func TestResolveOutputModeArgs_BadFormatOutsideImport(t *testing.T) {
 	_, err := resolveOutputModeArgs([]string{"--format", "xml"}, "", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported output format")
+}
+
+func TestAgentValue_Quoting(t *testing.T) {
+	assert.Equal(t, "abc4", agentValue("abc4"))
+	assert.Equal(t, strconv.Quote("Fix login race"), agentValue("Fix login race"))
+	assert.Equal(t, strconv.Quote(`quoted "title"`), agentValue(`quoted "title"`))
+	assert.Equal(t, strconv.Quote("bad\nline"), agentValue("bad\nline"))
+}
+
+func TestAgentFencedText_ExtendsFenceForBackticks(t *testing.T) {
+	got := agentFencedText("``` inside")
+	assert.Contains(t, got, "````text\n")
+	assert.True(t, strings.HasSuffix(got, "\n````\n"))
 }

--- a/cmd/kata/projects.go
+++ b/cmd/kata/projects.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -64,14 +65,19 @@ func projectsListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/projects", nil)
+			mode := currentOutputMode()
+			path := baseURL + "/api/v1/projects"
+			if mode == outputAgent {
+				path += "?include=stats"
+			}
+			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, path, nil)
 			if err != nil {
 				return err
 			}
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
-			if flags.JSON {
+			if mode == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err
@@ -81,12 +87,38 @@ func projectsListCmd() *cobra.Command {
 			}
 			var b struct {
 				Projects []struct {
-					ID   int64  `json:"id"`
-					Name string `json:"name"`
+					ID    int64  `json:"id"`
+					Name  string `json:"name"`
+					Stats *struct {
+						Open   int `json:"open"`
+						Closed int `json:"closed"`
+					} `json:"stats"`
 				} `json:"projects"`
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
 				return err
+			}
+			if mode == outputAgent {
+				out := cmd.OutOrStdout()
+				if _, err := fmt.Fprintf(out, "OK projects count=%d\n", len(b.Projects)); err != nil {
+					return err
+				}
+				for _, p := range b.Projects {
+					open, closed := 0, 0
+					if p.Stats != nil {
+						open = p.Stats.Open
+						closed = p.Stats.Closed
+					}
+					if err := writeAgentKVRow(out,
+						agentRowField("project", p.Name),
+						agentRowField("id", fmt.Sprint(p.ID)),
+						agentRowField("open", fmt.Sprint(open)),
+						agentRowField("closed", fmt.Sprint(closed)),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
 			}
 			for _, p := range b.Projects {
 				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%d  %s\n",
@@ -148,6 +180,12 @@ func projectsRenameCmd() *cobra.Command {
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
 				return err
+			}
+			if currentOutputMode() == outputAgent {
+				return writeAgentProjectAction(cmd.OutOrStdout(), "rename",
+					agentRowField("id", fmt.Sprint(b.Project.ID)),
+					agentRowField("project", b.Project.Name),
+				)
 			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "renamed project #%d to %s\n",
 				b.Project.ID, textsafe.Line(b.Project.Name))
@@ -220,6 +258,28 @@ func projectsMergeCmd() *cobra.Command {
 				}
 				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 				return err
+			}
+			if currentOutputMode() == outputAgent {
+				if err := writeAgentProjectAction(cmd.OutOrStdout(), "merge",
+					agentRowField("source", fmt.Sprint(b.Source.ID)),
+					agentRowField("target", fmt.Sprint(b.Target.ID)),
+					agentRowField("project", b.Target.Name),
+					agentRowField("issues_moved", fmt.Sprint(b.IssuesMoved)),
+					agentRowField("aliases_moved", fmt.Sprint(b.AliasesMoved)),
+					agentRowField("events_moved", fmt.Sprint(b.EventsMoved)),
+				); err != nil {
+					return err
+				}
+				for _, ext := range b.ShortIDExtensions {
+					if err := writeAgentKVRow(cmd.OutOrStdout(),
+						agentRowField("uid", ext.UID),
+						agentRowField("pre_merge_short_id", ext.PreMergeShortID),
+						agentRowField("post_merge_short_id", ext.PostMergeShortID),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
 			}
 			if _, err := fmt.Fprintf(cmd.OutOrStdout(),
 				"merged project #%d into #%d (%s); moved %s, %s, %s\n",
@@ -300,9 +360,15 @@ func projectsShowCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			project, err := resolveProjectSelector(ctx, client, baseURL, args[0])
-			if err != nil {
-				return err
+			project := projectRef{}
+			if id, parseErr := strconv.ParseInt(strings.TrimSpace(args[0]), 10, 64); parseErr == nil {
+				project.ID = id
+			} else {
+				var err error
+				project, err = resolveProjectSelector(ctx, client, baseURL, args[0])
+				if err != nil {
+					return err
+				}
 			}
 			status, bs, err := httpDoJSON(ctx, client, http.MethodGet,
 				fmt.Sprintf("%s/api/v1/projects/%d", baseURL, project.ID), nil)
@@ -328,6 +394,16 @@ func projectsShowCmd() *cobra.Command {
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
 				return err
+			}
+			if currentOutputMode() == outputAgent {
+				out := cmd.OutOrStdout()
+				if _, err := fmt.Fprintln(out, "OK projects count=1"); err != nil {
+					return err
+				}
+				return writeAgentKVRow(out,
+					agentRowField("project", b.Project.Name),
+					agentRowField("id", fmt.Sprint(b.Project.ID)),
+				)
 			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "#%d %s\n",
 				b.Project.ID, textsafe.Line(b.Project.Name))
@@ -559,6 +635,12 @@ func projectsRemoveCmd() *cobra.Command {
 				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 				return err
 			}
+			if currentOutputMode() == outputAgent {
+				return writeAgentProjectAction(cmd.OutOrStdout(), "remove",
+					agentRowField("id", fmt.Sprint(project.ID)),
+					agentRowField("project", project.Name),
+				)
+			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(),
 				"archived project #%d (%s); events preserved, aliases dropped\n",
 				project.ID, textsafe.Line(project.Name))
@@ -615,6 +697,13 @@ func projectsRestoreCmd() *cobra.Command {
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
 				return err
+			}
+			if currentOutputMode() == outputAgent {
+				return writeAgentProjectAction(cmd.OutOrStdout(), "restore",
+					agentRowField("id", fmt.Sprint(b.Project.ID)),
+					agentRowField("project", b.Project.Name),
+					agentRowField("changed", strconv.FormatBool(b.Changed)),
+				)
 			}
 			if !b.Changed {
 				_, err = fmt.Fprintf(cmd.OutOrStdout(),
@@ -684,6 +773,13 @@ func projectsDetachCmd() *cobra.Command {
 				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 				return err
 			}
+			if currentOutputMode() == outputAgent {
+				return writeAgentProjectAction(cmd.OutOrStdout(), "detach",
+					agentRowField("project_id", fmt.Sprint(projectID)),
+					agentRowField("alias_id", fmt.Sprint(aliasID)),
+					agentRowField("alias", selector),
+				)
+			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(),
 				"detached alias %q from project #%d\n", selector, projectID)
 			return err
@@ -691,6 +787,22 @@ func projectsDetachCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "drop the alias even when it's the only one for its project")
 	return cmd
+}
+
+func writeAgentProjectAction(w io.Writer, action string, fields ...agentField) error {
+	if _, err := fmt.Fprintf(w, "OK project action=%s", agentValue(action)); err != nil {
+		return err
+	}
+	for _, f := range fields {
+		if f.value == nil {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, " %s=%s", f.name, agentValue(*f.value)); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(w)
+	return err
 }
 
 // findAliasBySelector matches an alias_identity exactly across every

--- a/cmd/kata/projects_test.go
+++ b/cmd/kata/projects_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +34,90 @@ func TestProjects_ListJSONHasNoNextIssueNumber(t *testing.T) {
 	}
 }
 
+func TestProjects_ListAgentIncludesStats(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	p, err := env.DB.CreateProject(ctx, "kata")
+	require.NoError(t, err)
+	open, _, err := env.DB.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "open", Author: "tester"})
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "closed", Author: "tester"})
+	require.NoError(t, err)
+	_, _, _, err = env.DB.CloseIssue(ctx, open.ID, "done", "tester", "", nil)
+	require.NoError(t, err)
+
+	out := requireCmdOutput(t, env, "--agent", "projects", "list")
+
+	assert.Equal(t, "OK projects count=1\n- project=kata id="+itoa(p.ID)+" open=1 closed=1\n", out)
+}
+
+func TestProjects_ShowAgentUsesReadShape(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	p, err := env.DB.CreateProject(ctx, "kata")
+	require.NoError(t, err)
+	closed, _, err := env.DB.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "closed", Author: "tester"})
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{ProjectID: p.ID, Title: "open", Author: "tester"})
+	require.NoError(t, err)
+	_, _, _, err = env.DB.CloseIssue(ctx, closed.ID, "done", "tester", "", nil)
+	require.NoError(t, err)
+
+	out := requireCmdOutput(t, env, "--agent", "projects", "show", itoa(p.ID))
+
+	assert.Equal(t, "OK projects count=1\n- project=kata id="+itoa(p.ID)+"\n", out)
+}
+
+func TestProjects_ShowAgentDoesNotFetchStats(t *testing.T) {
+	var statsRequests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/projects" && r.URL.Query().Get("include") == "stats":
+			statsRequests++
+			http.Error(w, "unexpected stats request", http.StatusTeapot)
+		case r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"projects":[{"id":1,"name":"kata"}]}`))
+		case r.URL.Path == "/api/v1/projects/1":
+			_, _ = w.Write([]byte(`{"project":{"id":1,"name":"kata"},"aliases":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	resetFlags(t)
+	stdout, _, err := executeRootCapture(t, contextWithBaseURL(context.Background(), srv.URL),
+		"--agent", "projects", "show", "kata")
+	require.NoError(t, err)
+
+	assert.Equal(t, "OK projects count=1\n- project=kata id=1\n", stdout)
+	assert.Equal(t, 0, statsRequests)
+}
+
+func TestProjects_ShowNumericIDDoesNotListProjects(t *testing.T) {
+	var listRequests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			listRequests++
+			http.Error(w, "unexpected list request", http.StatusTeapot)
+		case "/api/v1/projects/1":
+			_, _ = w.Write([]byte(`{"project":{"id":1,"name":"kata"},"aliases":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	resetFlags(t)
+	stdout, _, err := executeRootCapture(t, contextWithBaseURL(context.Background(), srv.URL),
+		"--agent", "projects", "show", "1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "OK projects count=1\n- project=kata id=1\n", stdout)
+	assert.Equal(t, 0, listRequests)
+}
+
 func TestProjects_RestoreArchivedProjectByName(t *testing.T) {
 	env := testenv.New(t)
 	ctx := context.Background()
@@ -50,6 +136,17 @@ func TestProjects_RestoreArchivedProjectByName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, p.ID, got.ID)
 	assert.Nil(t, got.DeletedAt)
+}
+
+func TestProjects_RenameAgentOutput(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	p, err := env.DB.CreateProject(ctx, "old")
+	require.NoError(t, err)
+
+	out := requireCmdOutput(t, env, "--agent", "projects", "rename", itoa(p.ID), "new name")
+
+	assert.Equal(t, "OK project action=rename id="+itoa(p.ID)+" project=\"new name\"\n", out)
 }
 
 func TestProjects_RestoreActiveProjectIsNoop(t *testing.T) {

--- a/cmd/kata/purge_test.go
+++ b/cmd/kata/purge_test.go
@@ -32,7 +32,7 @@ func TestPurge_AgentOutput(t *testing.T) {
 
 	assert.Regexp(t, `(?m)^OK purge `+short, out)
 	assert.Contains(t, out, `Issue: `+short+` vaporize`)
-	assert.Contains(t, out, "Purged: true")
+	assert.Contains(t, out, "Status: purged")
 }
 
 // TestPurge_NoTTYNoConfirmIsConfirmRequired mirrors the delete coverage:

--- a/cmd/kata/purge_test.go
+++ b/cmd/kata/purge_test.go
@@ -24,6 +24,17 @@ func TestPurge_ForceWithConfirmRemovesEverything(t *testing.T) {
 	assert.Contains(t, f.buf.String(), "purged")
 }
 
+func TestPurge_AgentOutput(t *testing.T) {
+	env, dir, _ := setupCLIWorkspace(t)
+	short := createIssueViaHTTP(t, env, dir, "vaporize")
+
+	out := runCLI(t, env, dir, "--agent", "purge", short, "--force", "--confirm", "PURGE kata#"+short)
+
+	assert.Regexp(t, `(?m)^OK purge `+short, out)
+	assert.Contains(t, out, `Issue: `+short+` vaporize`)
+	assert.Contains(t, out, "Purged: true")
+}
+
 // TestPurge_NoTTYNoConfirmIsConfirmRequired mirrors the delete coverage:
 // non-terminal stdin + missing --confirm must surface as exit 6
 // confirm_required, not as a confirm_mismatch from an empty TTY read.

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -12,8 +12,8 @@ const agentQuickstartText = `# kata agent quickstart
 Use kata as the shared issue ledger for this workspace.
 
 1. Run from the workspace (--workspace overrides; --project picks
-   another). Author = $KATA_AUTHOR > $USER > git user.name. --json for
-   parsing. If uninitialized, report that kata init is needed.
+   another). Author = $KATA_AUTHOR > $USER > git user.name.
+   If uninitialized, report that kata init is needed.
    Issue refs are short_ids derived from each issue's ULID (e.g. abc4).
    Cross-project: kata#abc4. Full 26-char ULIDs also resolve. Legacy
    numeric refs (12, kata#12) no longer work.
@@ -49,6 +49,9 @@ Use kata as the shared issue ledger for this workspace.
    The daemon refuses parent-close while open children remain. Reviewers
    can replay activity with kata audit closes and undo a specific lazy
    close with kata reopen <ref>.
+
+   Use --agent for concise action summaries in agent logs.
+   Use --json when your script needs complete structured data.
 
 3. Search before creating:
 

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -148,6 +148,16 @@ spawning a local daemon. The default (no env, no .kata.local.toml) is
 unchanged: a local Unix-socket daemon is auto-started on demand.
 `
 
+const agentQuickstartCompactText = `Use kata as the shared issue ledger for this workspace.
+Search before creating or updating work.
+Use --agent for concise action summaries in agent logs.
+Use --json when your script needs complete structured data.
+If work is incomplete, label needs-review and comment with what remains.
+Close only verified work with substantive prose and typed evidence.
+Do not run delete or purge unless explicitly asked for that exact action and issue ref.
+Poll kata events with a saved cursor; reset cached state on reset_required.
+`
+
 func newQuickstartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "quickstart",
@@ -166,7 +176,7 @@ func newQuickstartCmd() *cobra.Command {
 				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
 				return err
 			case outputAgent:
-				_, err := fmt.Fprint(cmd.OutOrStdout(), "OK quickstart\n"+agentQuickstartText)
+				_, err := fmt.Fprint(cmd.OutOrStdout(), "OK quickstart\n"+agentQuickstartCompactText)
 				return err
 			}
 			_, err := fmt.Fprint(cmd.OutOrStdout(), agentQuickstartText)

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -50,39 +50,40 @@ Use kata as the shared issue ledger for this workspace.
    can replay activity with kata audit closes and undo a specific lazy
    close with kata reopen <ref>.
 
-   Use --agent for concise action summaries in agent logs.
-   Use --json when your script needs complete structured data.
+   Default to --agent for ordinary kata reads and mutations in agent logs.
+   Use --json only when your script needs complete structured data, for
+   example when piping into jq.
 
 3. Search before creating:
 
-   kata search "login race" --json
-   kata search --project foo "login race" --json
+   kata search "login race" --agent
+   kata search --project foo "login race" --agent
 
 4. If no existing issue fits, create with an idempotency key:
 
    kata create "fix login race" \
      --body "Observed double-submit in Safari callback." \
      --idempotency-key "login-race-2026-05-02" \
-     --json
+     --agent
 
    kata create --project foo "fix login race" \
      --body "Observed double-submit in Safari callback." \
      --idempotency-key "foo-login-race-2026-05-02" \
-     --json
+     --agent
 
 5. Prefer updating existing issues over creating duplicates:
 
-   kata show abc4 --json
-   kata show --project foo abc4 --json
-   kata comment abc4 --body "Found another reproduction path." --json
-   kata label add abc4 safari --json
-   kata edit abc4 --blocks d4ex --json
+   kata show abc4 --agent
+   kata show --project foo abc4 --agent
+   kata comment abc4 --body "Found another reproduction path." --agent
+   kata label add abc4 safari --agent
+   kata edit abc4 --blocks d4ex --agent
 
 6. Find and claim available work (multi-agent environments):
 
    # Find unclaimed work
-   kata ready --unowned --json
-   kata ready --unowned --label bug --no-label blocked --json
+   kata ready --unowned --agent
+   kata ready --unowned --label bug --no-label blocked --agent
 
    # Claim it (fails if already claimed by another actor)
    kata claim <ref>
@@ -98,8 +99,8 @@ Use kata as the shared issue ledger for this workspace.
    blocked_by  = the target must be resolved before this issue can proceed
    related     = useful context, but not ordering
 
-   kata create "fix auth flow" --parent abc4 --blocked-by d4ex --related j7m2 --json
-   kata edit abc4 --remove-blocks d4ex --related j7m2 --json
+   kata create "fix auth flow" --parent abc4 --blocked-by d4ex --related j7m2 --agent
+   kata edit abc4 --remove-blocks d4ex --related j7m2 --agent
 
    --remove-parent <ref> is strict: it must equal the current parent or
    fail loudly. Read parent before asserting a removal. The other
@@ -116,16 +117,17 @@ Use kata as the shared issue ledger for this workspace.
 
 For long-running agents, poll events:
 
-   kata events --after 0 --limit 100 --json
+   kata events --after 0 --limit 100 --agent
 
 Remember the returned cursor and resume from it. If a response says
 reset_required, discard cached kata state and resume from the reset cursor.
 
 For live streams:
 
-   kata events --tail
+   kata events --tail --agent
 
-The tail stream emits newline-delimited JSON.
+The agent tail stream emits one OK event line per event. Use --json only
+when a consumer expects newline-delimited JSON.
 
 # Remote daemon (optional)
 
@@ -150,8 +152,8 @@ unchanged: a local Unix-socket daemon is auto-started on demand.
 
 const agentQuickstartCompactText = `Use kata as the shared issue ledger for this workspace.
 Search before creating or updating work.
-Use --agent for concise action summaries in agent logs.
-Use --json when your script needs complete structured data.
+Default to --agent for ordinary kata reads and mutations in agent logs.
+Use --json only when your script needs complete structured data.
 If work is incomplete, label needs-review and comment with what remains.
 Close only verified work with substantive prose and typed evidence.
 Do not run delete or purge unless explicitly asked for that exact action and issue ref.

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -155,7 +155,8 @@ func newQuickstartCmd() *cobra.Command {
 		Short:   "print instructions for agents using kata",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if flags.JSON {
+			switch currentOutputMode() {
+			case outputJSON:
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, map[string]string{
 					"quickstart": agentQuickstartText,
@@ -163,6 +164,9 @@ func newQuickstartCmd() *cobra.Command {
 					return err
 				}
 				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+				return err
+			case outputAgent:
+				_, err := fmt.Fprint(cmd.OutOrStdout(), "OK quickstart\n"+agentQuickstartText)
 				return err
 			}
 			_, err := fmt.Fprint(cmd.OutOrStdout(), agentQuickstartText)

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -47,6 +47,14 @@ func TestQuickstart_JSON(t *testing.T) {
 	assert.Contains(t, got.Quickstart, "kata events --after 0 --limit 100 --json")
 }
 
+func TestQuickstart_AgentOutput(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newRootCmd(), "--agent", "quickstart"))
+	assert.Truef(t, strings.HasPrefix(out, "OK quickstart\n"), "got %q", out)
+	assert.Contains(t, out, "Use --agent for concise action summaries in agent logs.")
+	assert.Contains(t, out, "Use --json when your script needs complete structured data.")
+}
+
 func TestQuickstart_AgentInstructionsAliasMentionsAgentOutput(t *testing.T) {
 	resetFlags(t)
 	out := string(executeRoot(t, newRootCmd(), "agent-instructions"))

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -15,8 +15,10 @@ func TestQuickstart_PrintsAgentInstructions(t *testing.T) {
 	assert.Contains(t, out, "kata agent quickstart")
 	assert.Contains(t, out, "Search before creating")
 	assert.Contains(t, out, "Do not run delete or purge")
-	assert.Contains(t, out, "Use --agent for concise action summaries in agent logs.")
-	assert.Contains(t, out, "Use --json when your script needs complete structured data.")
+	assert.Contains(t, out, "Default to --agent for ordinary kata reads and mutations in agent logs.")
+	assert.Contains(t, out, "Use --json only when your script needs complete structured data")
+	assert.Contains(t, out, `kata search "login race" --agent`)
+	assert.Contains(t, out, `kata events --after 0 --limit 100 --agent`)
 }
 
 func TestQuickstart_PromotesCloseStep(t *testing.T) {
@@ -42,9 +44,9 @@ func TestQuickstart_JSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &got))
 	assert.Equal(t, 1, got.APIVersion)
 	assert.Contains(t, got.Quickstart, "kata agent quickstart")
-	assert.Contains(t, got.Quickstart, "Use --agent for concise action summaries in agent logs.")
-	assert.Contains(t, got.Quickstart, "Use --json when your script needs complete structured data.")
-	assert.Contains(t, got.Quickstart, "kata events --after 0 --limit 100 --json")
+	assert.Contains(t, got.Quickstart, "Default to --agent for ordinary kata reads and mutations in agent logs.")
+	assert.Contains(t, got.Quickstart, "Use --json only when your script needs complete structured data")
+	assert.Contains(t, got.Quickstart, "kata events --after 0 --limit 100 --agent")
 }
 
 func TestQuickstart_AgentOutput(t *testing.T) {
@@ -53,13 +55,13 @@ func TestQuickstart_AgentOutput(t *testing.T) {
 	assert.Truef(t, strings.HasPrefix(out, "OK quickstart\n"), "got %q", out)
 	assert.NotContains(t, out, "# kata agent quickstart")
 	assert.NotContains(t, out, "Remote daemon")
-	assert.Contains(t, out, "Use --agent for concise action summaries in agent logs.")
-	assert.Contains(t, out, "Use --json when your script needs complete structured data.")
+	assert.Contains(t, out, "Default to --agent for ordinary kata reads and mutations in agent logs.")
+	assert.Contains(t, out, "Use --json only when your script needs complete structured data.")
 }
 
 func TestQuickstart_AgentInstructionsAliasMentionsAgentOutput(t *testing.T) {
 	resetFlags(t)
 	out := string(executeRoot(t, newRootCmd(), "agent-instructions"))
-	assert.Contains(t, out, "Use --agent for concise action summaries in agent logs.")
-	assert.Contains(t, out, "Use --json when your script needs complete structured data.")
+	assert.Contains(t, out, "Default to --agent for ordinary kata reads and mutations in agent logs.")
+	assert.Contains(t, out, "Use --json only when your script needs complete structured data")
 }

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -15,6 +15,8 @@ func TestQuickstart_PrintsAgentInstructions(t *testing.T) {
 	assert.Contains(t, out, "kata agent quickstart")
 	assert.Contains(t, out, "Search before creating")
 	assert.Contains(t, out, "Do not run delete or purge")
+	assert.Contains(t, out, "Use --agent for concise action summaries in agent logs.")
+	assert.Contains(t, out, "Use --json when your script needs complete structured data.")
 }
 
 func TestQuickstart_PromotesCloseStep(t *testing.T) {
@@ -40,4 +42,14 @@ func TestQuickstart_JSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &got))
 	assert.Equal(t, 1, got.APIVersion)
 	assert.Contains(t, got.Quickstart, "kata agent quickstart")
+	assert.Contains(t, got.Quickstart, "Use --agent for concise action summaries in agent logs.")
+	assert.Contains(t, got.Quickstart, "Use --json when your script needs complete structured data.")
+	assert.Contains(t, got.Quickstart, "kata events --after 0 --limit 100 --json")
+}
+
+func TestQuickstart_AgentInstructionsAliasMentionsAgentOutput(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newRootCmd(), "agent-instructions"))
+	assert.Contains(t, out, "Use --agent for concise action summaries in agent logs.")
+	assert.Contains(t, out, "Use --json when your script needs complete structured data.")
 }

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -51,6 +51,8 @@ func TestQuickstart_AgentOutput(t *testing.T) {
 	resetFlags(t)
 	out := string(executeRoot(t, newRootCmd(), "--agent", "quickstart"))
 	assert.Truef(t, strings.HasPrefix(out, "OK quickstart\n"), "got %q", out)
+	assert.NotContains(t, out, "# kata agent quickstart")
+	assert.NotContains(t, out, "Remote daemon")
 	assert.Contains(t, out, "Use --agent for concise action summaries in agent logs.")
 	assert.Contains(t, out, "Use --json when your script needs complete structured data.")
 }

--- a/cmd/kata/ready.go
+++ b/cmd/kata/ready.go
@@ -78,7 +78,8 @@ func newReadyCmd() *cobra.Command {
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
-			if flags.JSON {
+			mode := currentOutputMode()
+			if mode == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err
@@ -88,13 +89,31 @@ func newReadyCmd() *cobra.Command {
 			}
 			var b struct {
 				Issues []struct {
-					ShortID string  `json:"short_id"`
-					Title   string  `json:"title"`
-					Owner   *string `json:"owner,omitempty"`
+					ShortID  string  `json:"short_id"`
+					Title    string  `json:"title"`
+					Owner    *string `json:"owner,omitempty"`
+					Priority *int64  `json:"priority"`
 				} `json:"issues"`
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
 				return err
+			}
+			if mode == outputAgent {
+				out := cmd.OutOrStdout()
+				if _, err := fmt.Fprintf(out, "OK ready count=%d\n", len(b.Issues)); err != nil {
+					return err
+				}
+				for _, i := range b.Issues {
+					if err := writeAgentKVRow(out,
+						agentRowField("issue", i.ShortID),
+						agentRowIntField("priority", i.Priority),
+						agentOptionalRowField("owner", i.Owner),
+						agentRowField("title", i.Title),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
 			}
 			for _, i := range b.Issues {
 				ownerStr := "-"

--- a/cmd/kata/ready_test.go
+++ b/cmd/kata/ready_test.go
@@ -43,6 +43,17 @@ func TestReady_FiltersBlocked(t *testing.T) {
 		"blocked is hidden while blocker is open")
 }
 
+func TestReady_AgentOutputRowsOmitAbsentOwner(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "ready unowned")
+
+	out := runCLI(t, env, dir, "--agent", "ready")
+
+	assert.Contains(t, out, "OK ready count=1\n")
+	assert.Contains(t, out, `title="ready unowned"`)
+	assert.NotContains(t, out, "owner=")
+}
+
 func TestReady_UnownedAndOwnerMutualExclusion(t *testing.T) {
 	env, dir := setupCLIEnv(t)
 	resetFlags(t)

--- a/cmd/kata/restore.go
+++ b/cmd/kata/restore.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -38,7 +39,12 @@ func newRestoreCmd() *cobra.Command {
 			if status >= 400 {
 				return apiErrFromBody(status, bs)
 			}
-			if !flags.Quiet && !flags.JSON {
+			if currentOutputMode() == outputAgent {
+				return printAgentMutation(cmd, "restore", bs, func(w io.Writer, _ agentIssueMutation) error {
+					return writeAgentField(w, "Deleted", "false")
+				})
+			}
+			if !flags.Quiet && currentOutputMode() == outputHuman {
 				_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s restored\n", issue.RefForAPI)
 				return err
 			}

--- a/cmd/kata/restore.go
+++ b/cmd/kata/restore.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -40,7 +41,11 @@ func newRestoreCmd() *cobra.Command {
 				return apiErrFromBody(status, bs)
 			}
 			if currentOutputMode() == outputAgent {
-				return printAgentMutation(cmd, "restore", bs, func(w io.Writer, _ agentIssueMutation) error {
+				var m agentIssueMutation
+				if err := json.Unmarshal(bs, &m); err != nil {
+					return err
+				}
+				return printAgentMutationDecoded(cmd.OutOrStdout(), "restore", m, true, func(w io.Writer, _ agentIssueMutation) error {
 					return writeAgentField(w, "Deleted", "false")
 				})
 			}

--- a/cmd/kata/restore_test.go
+++ b/cmd/kata/restore_test.go
@@ -23,6 +23,6 @@ func TestRestore_AgentOutput(t *testing.T) {
 	resetFlags(t)
 	out := runCLI(t, env, dir, "--agent", "restore", short)
 
-	assert.Regexp(t, `(?m)^OK restore \S+`, out)
+	assert.Regexp(t, `(?m)^OK restore \S+ changed=true`, out)
 	assert.Contains(t, out, "Deleted: false")
 }

--- a/cmd/kata/restore_test.go
+++ b/cmd/kata/restore_test.go
@@ -14,3 +14,15 @@ func TestRestore_ClearsDeletedAt(t *testing.T) {
 	output := runCLI(t, env, dir, "restore", short)
 	assert.Contains(t, output, "restored")
 }
+
+func TestRestore_AgentOutput(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	short := createIssue(t, env, pid, "delete me")
+	runCLI(t, env, dir, "delete", short, "--force", "--confirm", "DELETE kata#"+short)
+
+	resetFlags(t)
+	out := runCLI(t, env, dir, "--agent", "restore", short)
+
+	assert.Regexp(t, `(?m)^OK restore \S+`, out)
+	assert.Contains(t, out, "Deleted: false")
+}

--- a/cmd/kata/search.go
+++ b/cmd/kata/search.go
@@ -89,7 +89,8 @@ func buildSearchURL(baseURL string, pid int64, query string, limit int, includeD
 // printSearchResults renders a search response in the active output mode:
 // JSON envelope, human-readable list, or "no matches" when empty.
 func printSearchResults(cmd *cobra.Command, bs []byte) error {
-	if flags.JSON {
+	mode := currentOutputMode()
+	if mode == outputJSON {
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 			return err
@@ -98,6 +99,7 @@ func printSearchResults(cmd *cobra.Command, bs []byte) error {
 		return err
 	}
 	var b struct {
+		Query   string `json:"query"`
 		Results []struct {
 			Issue struct {
 				ShortID string `json:"short_id"`
@@ -110,6 +112,24 @@ func printSearchResults(cmd *cobra.Command, bs []byte) error {
 	}
 	if err := json.Unmarshal(bs, &b); err != nil {
 		return err
+	}
+	if mode == outputAgent {
+		out := cmd.OutOrStdout()
+		if _, err := fmt.Fprintf(out, "OK search count=%d query=%s\n", len(b.Results), agentValue(b.Query)); err != nil {
+			return err
+		}
+		for _, r := range b.Results {
+			if err := writeAgentKVRow(out,
+				agentRowField("issue", r.Issue.ShortID),
+				agentRowFloatField("score", r.Score),
+				agentRowField("status", r.Issue.Status),
+				agentRowListField("matched", r.MatchedIn),
+				agentRowField("title", r.Issue.Title),
+			); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	if len(b.Results) == 0 {
 		if flags.Quiet {

--- a/cmd/kata/search_test.go
+++ b/cmd/kata/search_test.go
@@ -40,6 +40,16 @@ func TestSearch_ReturnsMatchedIssues(t *testing.T) {
 	assert.NotContains(t, out, "unrelated issue")
 }
 
+func TestSearch_AgentOutputEmptyEmitsOnlyHeader(t *testing.T) {
+	env, dir, _ := setupCLIWorkspace(t)
+
+	out, stderr, err := runCLIWithErr(t, env, dir, "--agent", "search", "login race")
+
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.Equal(t, "OK search count=0 query=\"login race\"\n", out)
+}
+
 func TestSearch_EmptyQueryIsValidationError(t *testing.T) {
 	f := newCLIFixture(t)
 	_ = requireCLIError(t, f.execute("search", "  "), ExitValidation)

--- a/cmd/kata/show.go
+++ b/cmd/kata/show.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -34,7 +35,8 @@ func newShowCmd() *cobra.Command {
 			if httpStatus >= 400 {
 				return apiErrFromBody(httpStatus, bs)
 			}
-			if flags.JSON {
+			mode := currentOutputMode()
+			if mode == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err
@@ -44,16 +46,19 @@ func newShowCmd() *cobra.Command {
 			}
 			var b struct {
 				Issue struct {
-					ShortID string `json:"short_id"`
-					UID     string `json:"uid"`
-					Title   string `json:"title"`
-					Body    string `json:"body"`
-					Status  string `json:"status"`
-					Author  string `json:"author"`
+					ShortID  string  `json:"short_id"`
+					UID      string  `json:"uid"`
+					Title    string  `json:"title"`
+					Body     string  `json:"body"`
+					Status   string  `json:"status"`
+					Author   string  `json:"author"`
+					Owner    *string `json:"owner"`
+					Priority *int64  `json:"priority"`
 				} `json:"issue"`
 				Comments []struct {
-					Author string `json:"author"`
-					Body   string `json:"body"`
+					Author    string `json:"author"`
+					Body      string `json:"body"`
+					CreatedAt string `json:"created_at"`
 				} `json:"comments"`
 				Labels []struct {
 					Label string `json:"label"`
@@ -66,6 +71,9 @@ func newShowCmd() *cobra.Command {
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
 				return err
+			}
+			if mode == outputAgent {
+				return printShowAgent(cmd.OutOrStdout(), b)
 			}
 			out := cmd.OutOrStdout()
 			if _, err := fmt.Fprintf(out, "%s  %s  [%s]  by %s\n",
@@ -120,6 +128,97 @@ func newShowCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func printShowAgent(w io.Writer, b struct {
+	Issue struct {
+		ShortID  string  `json:"short_id"`
+		UID      string  `json:"uid"`
+		Title    string  `json:"title"`
+		Body     string  `json:"body"`
+		Status   string  `json:"status"`
+		Author   string  `json:"author"`
+		Owner    *string `json:"owner"`
+		Priority *int64  `json:"priority"`
+	} `json:"issue"`
+	Comments []struct {
+		Author    string `json:"author"`
+		Body      string `json:"body"`
+		CreatedAt string `json:"created_at"`
+	} `json:"comments"`
+	Labels []struct {
+		Label string `json:"label"`
+	} `json:"labels"`
+	Links []struct {
+		Type string         `json:"type"`
+		From linkPeerForCLI `json:"from"`
+		To   linkPeerForCLI `json:"to"`
+	} `json:"links"`
+}) error {
+	if _, err := fmt.Fprintf(w, "OK show %s\n", b.Issue.ShortID); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Issue: %s %s\n", b.Issue.ShortID, agentValue(b.Issue.Title)); err != nil {
+		return err
+	}
+	if b.Issue.Status != "" {
+		if err := writeAgentField(w, "Status", agentValue(b.Issue.Status)); err != nil {
+			return err
+		}
+	}
+	if b.Issue.Owner != nil && *b.Issue.Owner != "" {
+		if err := writeAgentField(w, "Owner", agentValue(*b.Issue.Owner)); err != nil {
+			return err
+		}
+	}
+	if len(b.Labels) > 0 {
+		labels := make([]string, 0, len(b.Labels))
+		for _, l := range b.Labels {
+			labels = append(labels, l.Label)
+		}
+		if err := writeAgentField(w, "Labels", agentValue(strings.Join(labels, ","))); err != nil {
+			return err
+		}
+	}
+	if b.Issue.Priority != nil {
+		if err := writeAgentField(w, "Priority", fmt.Sprint(*b.Issue.Priority)); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprint(w, "Body:\n", agentFencedText(b.Issue.Body)); err != nil {
+		return err
+	}
+	if len(b.Comments) > 0 {
+		if _, err := fmt.Fprintln(w, "Comments:"); err != nil {
+			return err
+		}
+		for _, c := range b.Comments {
+			if err := writeAgentKVRow(w,
+				agentRowField("author", c.Author),
+				agentRowField("created_at", c.CreatedAt),
+			); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(w, agentFencedText(c.Body)); err != nil {
+				return err
+			}
+		}
+	}
+	if len(b.Links) > 0 {
+		if _, err := fmt.Fprintln(w, "Links:"); err != nil {
+			return err
+		}
+		for _, l := range b.Links {
+			_, other := linkLabelFromPOV(l.Type, b.Issue.UID, l.From, l.To)
+			if err := writeAgentKVRow(w,
+				agentRowField("type", l.Type),
+				agentRowField("issue", other),
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // linkPeerForCLI mirrors api.LinkPeer for the show command's decode path. UID

--- a/cmd/kata/show.go
+++ b/cmd/kata/show.go
@@ -209,9 +209,9 @@ func printShowAgent(w io.Writer, b struct {
 			return err
 		}
 		for _, l := range b.Links {
-			_, other := linkLabelFromPOV(l.Type, b.Issue.UID, l.From, l.To)
+			label, other := linkLabelFromPOV(l.Type, b.Issue.UID, l.From, l.To)
 			if err := writeAgentKVRow(w,
-				agentRowField("type", l.Type),
+				agentRowField("type", label),
 				agentRowField("issue", other),
 			); err != nil {
 				return err

--- a/cmd/kata/show_test.go
+++ b/cmd/kata/show_test.go
@@ -71,6 +71,18 @@ func TestShow_AgentOutputLinkRowsUseExistingLinkResponseFields(t *testing.T) {
 	assert.NotContains(t, out, `title="blocked title"`)
 }
 
+func TestShow_AgentOutputLinkRowsUsePOVLabels(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	blocker := createIssue(t, env, pid, "blocker")
+	blocked := createIssue(t, env, pid, "blocked")
+	createLinkViaHTTP(t, env, pid, blocker, "blocks", blocked)
+
+	out := runCLI(t, env, dir, "--agent", "show", blocked)
+
+	assert.Contains(t, out, "- type=blocked-by issue="+blocker)
+	assert.NotContains(t, out, "- type=blocks issue="+blocker)
+}
+
 // TestShow_LinkLabelInvertsOnToSide verifies that when show runs against
 // the link's "to" side, the rendered LABEL inverts to read from the
 // viewer's perspective: the parent slot's "to" end is the parent of

--- a/cmd/kata/show_test.go
+++ b/cmd/kata/show_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,49 @@ func TestShow_RendersLabelsAndLinksSections(t *testing.T) {
 	// so it reads "parent: <parent_short_id>" — its parent is the parent issue.
 	assert.Contains(t, out, "--- links ---")
 	assert.Contains(t, out, "parent: "+parent)
+}
+
+func TestShow_AgentOutputRendersIssueBodyLabelsAndComments(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	type createResp struct {
+		Issue struct {
+			ShortID string `json:"short_id"`
+		} `json:"issue"`
+	}
+	created := postJSON[createResp](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues",
+		map[string]any{
+			"actor":    "tester",
+			"title":    "Safari callback",
+			"body":     "Safari can double-submit the callback.",
+			"priority": int64(2),
+			"labels":   []string{"bug", "safari"},
+		})
+	runCLI(t, env, dir, "--as", "tester", "comment", created.Issue.ShortID, "--body", "Reproduced on macOS.")
+
+	out := runCLI(t, env, dir, "--agent", "show", created.Issue.ShortID)
+
+	assert.Contains(t, out, "OK show "+created.Issue.ShortID+"\n")
+	assert.Contains(t, out, "Issue: "+created.Issue.ShortID+" \"Safari callback\"\n")
+	assert.Contains(t, out, "Status: open\n")
+	assert.Contains(t, out, "Labels: bug,safari\n")
+	assert.Contains(t, out, "Priority: 2\n")
+	assert.Contains(t, out, "Body:\n```text\nSafari can double-submit the callback.\n```\n")
+	assert.Regexp(t, regexp.MustCompile(`(?m)^- author=tester created_at=[^ \n]+$`), out)
+	assert.Contains(t, out, "\n```text\nReproduced on macOS.\n```")
+	assert.NotContains(t, out, "Owner:")
+}
+
+func TestShow_AgentOutputLinkRowsUseExistingLinkResponseFields(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	blocker := createIssue(t, env, pid, "blocker")
+	blocked := createIssue(t, env, pid, "blocked title")
+	createLinkViaHTTP(t, env, pid, blocker, "blocks", blocked)
+
+	out := runCLI(t, env, dir, "--agent", "show", blocker)
+
+	assert.Contains(t, out, "Links:\n")
+	assert.Contains(t, out, "- type=blocks issue="+blocked)
+	assert.NotContains(t, out, `title="blocked title"`)
 }
 
 // TestShow_LinkLabelInvertsOnToSide verifies that when show runs against

--- a/cmd/kata/testhelpers_test.go
+++ b/cmd/kata/testhelpers_test.go
@@ -62,6 +62,9 @@ func executeRootCapture(t *testing.T, ctx context.Context, args ...string) (stdo
 	cmd.SetArgs(args)
 	cmd.SetContext(ctx)
 	err = cmd.Execute()
+	if err != nil {
+		emitRootError(&se, cmd, args, err, runEEntered)
+	}
 	return so.String(), se.String(), err
 }
 

--- a/cmd/kata/tui_cmd.go
+++ b/cmd/kata/tui_cmd.go
@@ -29,6 +29,9 @@ or pass --mouse for one run. Hold Option (macOS) or Shift (Linux) for native
 terminal text selection while mouse tracking is enabled.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if currentOutputMode() == outputAgent {
+				return &cliError{Message: "kata tui does not support --agent; run without output formatting", Kind: kindUsage, ExitCode: ExitUsage}
+			}
 			ctx := cmd.Context()
 			if ctx == nil {
 				ctx = context.Background()

--- a/cmd/kata/tui_cmd_test.go
+++ b/cmd/kata/tui_cmd_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // kata tui needs a TTY, so we exercise the registration via --help;
@@ -41,6 +45,24 @@ func TestTUI_RejectsInvalidUIDFormatBeforeTTYCheck(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "uid format must be one of none, short, full") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTUI_RejectsAgentOutputBeforeLaunch(t *testing.T) {
+	for _, args := range [][]string{
+		{"--agent", "tui"},
+		{"tui", "--agent"},
+		{"--format", "agent", "tui"},
+		{"tui", "--format", "agent"},
+	} {
+		stdout, stderr, err := executeRootCapture(t, context.Background(), args...)
+		require.Error(t, err, "args %v", args)
+		ce := requireCLIError(t, err, ExitUsage)
+		assert.Equal(t, kindUsage, ce.Kind)
+		assert.Contains(t, ce.Message, "kata tui does not support --agent")
+		assert.Empty(t, stdout)
+		assert.Contains(t, stderr, "kata tui does not support --agent")
+		assert.NotContains(t, stderr, "terminal")
 	}
 }
 

--- a/cmd/kata/version.go
+++ b/cmd/kata/version.go
@@ -17,15 +17,21 @@ func newVersionCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
-			if flags.JSON {
+			switch currentOutputMode() {
+			case outputAgent:
+				_, err := fmt.Fprintf(out, "OK version version=%s agent_format=%d\n",
+					agentValue(version.Version), agentFormatVersion)
+				return err
+			case outputJSON:
 				var buf bytes.Buffer
-				payload := map[string]string{
-					"version": version.Version,
-					"commit":  version.Commit,
-					"built":   version.BuildDate,
-					"go":      runtime.Version(),
-					"os":      runtime.GOOS,
-					"arch":    runtime.GOARCH,
+				payload := map[string]any{
+					"version":      version.Version,
+					"commit":       version.Commit,
+					"built":        version.BuildDate,
+					"go":           runtime.Version(),
+					"os":           runtime.GOOS,
+					"arch":         runtime.GOARCH,
+					"agent_format": agentFormatVersion,
 				}
 				if err := emitJSON(&buf, payload); err != nil {
 					return err

--- a/cmd/kata/version_test.go
+++ b/cmd/kata/version_test.go
@@ -65,6 +65,21 @@ func TestVersion_JSONEnvelope(t *testing.T) {
 	assert.Equal(t, runtime.GOARCH, got.Arch)
 }
 
+func TestVersion_AgentIncludesFormatVersion(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newRootCmd(), "--agent", "version"))
+	assert.Contains(t, out, "OK version ")
+	assert.Contains(t, out, "agent_format=1")
+}
+
+func TestVersion_JSONIncludesAgentFormat(t *testing.T) {
+	resetFlags(t)
+	out := executeRoot(t, newRootCmd(), "--json", "version")
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, float64(agentFormatVersion), got["agent_format"])
+}
+
 func TestVersion_IsWiredOnRoot(t *testing.T) {
 	resetFlags(t)
 	root := newRootCmd()

--- a/cmd/kata/whoami.go
+++ b/cmd/kata/whoami.go
@@ -14,7 +14,13 @@ func newWhoamiCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			actor, source := resolveActor(flags.As, nil)
-			if flags.JSON {
+			mode := currentOutputMode()
+			if mode == outputAgent {
+				_, err := fmt.Fprintf(cmd.OutOrStdout(), "OK whoami actor=%s source=%s\n",
+					agentValue(actor), agentValue(source))
+				return err
+			}
+			if mode == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, map[string]string{"actor": actor, "source": source}); err != nil {
 					return err

--- a/docs/superpowers/plans/2026-05-26-agent-output-format-implementation.md
+++ b/docs/superpowers/plans/2026-05-26-agent-output-format-implementation.md
@@ -505,6 +505,11 @@ comment body
 
 Fence starts at column 0.
 
+For links, emit only fields available in the existing show response. Current
+link rows include `type` and `issue`; do not fake `title=` because link peer
+titles are not present in the response and this plan forbids daemon API changes
+or extra per-link fetches for agent formatting.
+
 - [ ] **Step 5: Run focused tests**
 
 Run: `go test ./cmd/kata -run 'Test(List|Search|Ready|Labels|Show)'`

--- a/docs/superpowers/plans/2026-05-26-agent-output-format-implementation.md
+++ b/docs/superpowers/plans/2026-05-26-agent-output-format-implementation.md
@@ -1,0 +1,808 @@
+# Agent Output Format Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the approved `--format agent` CLI output contract for kata while preserving existing human and JSON behavior.
+
+**Architecture:** Add one shared output-mode layer under `cmd/kata` that resolves `--format`, `--json`, and `--agent`, centralizes agent quoting/fencing/error emission, and exposes small render helpers. Convert command printers to dispatch on the resolved mode without changing daemon HTTP requests or response schemas.
+
+**Tech Stack:** Go 1.26, Cobra/pflag, existing kata daemon HTTP API, existing `cmd/kata` test fixtures, `testify`.
+
+---
+
+## File Structure
+
+- Create `cmd/kata/output_mode.go`: output mode enum, flag resolution, conflict validation, agent value quoting, line sanitization, fenced text helper, shared agent error emitter, and generic row helpers.
+- Create `cmd/kata/output_mode_test.go`: focused unit tests for output mode resolution, agent quoting, fences, and agent error emission.
+- Modify `cmd/kata/main.go`: add `--format` and `--agent`, resolve output mode, route errors through agent/json/human emitters, and update help tests.
+- Modify `cmd/kata/helpers.go`: keep `emitJSON`; add version constant `agentFormatVersion = 1` if it is not in `output_mode.go`.
+- Modify command files with existing renderers: `create.go`, `comment.go`, `close.go`, `reopen.go`, `assign.go`, `label.go`, `delete.go`, `restore.go`, `list.go`, `show.go`, `search.go`, `ready.go`, `events.go`, `digest.go`, `audit_closes.go`, `whoami.go`, `version.go`, `health.go`, `daemon_cmd.go`, `daemon_logs.go`, `export.go`, `import.go`, `beads_import.go`, `projects.go`, `quickstart.go`, `tui_cmd.go`.
+- Modify tests adjacent to each changed command, preferring focused additions to existing `*_test.go` files.
+- Modify `README.md` and quickstart text in `cmd/kata/quickstart.go` to recommend `--agent` for transcript-friendly agent use and `--json` for complete structured parsing.
+
+## Implementation Notes
+
+- During the `kata import` deprecation window, route the single root `--format` flag by value:
+  - `human|json|agent` means output mode.
+  - `kata|beads` means legacy import source format only for `kata import`, only when `--source-format` is absent.
+  - The namespaces do not overlap. Add a code comment near this resolver so future cleanup is obvious.
+- Preserve `--json` output exactly except for adding `agent_format` to `kata version --json`.
+- JSON errors stay on stderr as JSON. Agent errors stay on stderr as `ERR ...`. Human errors keep `kata: ...`.
+- Do not change daemon APIs. Any data needed for agent output must come from existing response bodies or already-resolved CLI context.
+- For absent nullable free-form values such as owner, omit the field. Do not print sentinels like `owner=unowned`.
+
+### Task 1: Output Mode Resolution And Agent Error Contract
+
+**Files:**
+- Create: `cmd/kata/output_mode.go`
+- Create: `cmd/kata/output_mode_test.go`
+- Modify: `cmd/kata/main.go`
+- Modify: `cmd/kata/main_test.go`
+
+- [ ] **Step 1: Write failing tests for output mode resolution**
+
+Add table tests in `cmd/kata/output_mode_test.go`:
+
+```go
+func TestResolveOutputMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		format  string
+		json    bool
+		agent   bool
+		want    outputMode
+		wantErr string
+	}{
+		{name: "default human", want: outputHuman},
+		{name: "format json", format: "json", want: outputJSON},
+		{name: "json alias", json: true, want: outputJSON},
+		{name: "agent alias", agent: true, want: outputAgent},
+		{name: "matching agent flags", format: "agent", agent: true, want: outputAgent},
+		{name: "conflicting modes", format: "human", json: true, wantErr: "conflicting output modes"},
+		{name: "bad format", format: "xml", wantErr: "unsupported output format"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveOutputModeValues(tc.format, tc.json, tc.agent)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run: `go test ./cmd/kata -run 'TestResolveOutputMode|TestRoot_HelpListsUniversalFlags'`
+
+Expected: fail because `outputMode`, `resolveOutputModeValues`, `--format`, and `--agent` do not exist.
+
+- [ ] **Step 3: Implement output mode types and flags**
+
+In `cmd/kata/output_mode.go`, add:
+
+```go
+type outputMode string
+
+const (
+	outputHuman outputMode = "human"
+	outputJSON  outputMode = "json"
+	outputAgent outputMode = "agent"
+)
+
+const agentFormatVersion = 1
+
+func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMode, error) {
+	var selected []outputMode
+	if format != "" {
+		switch outputMode(format) {
+		case outputHuman, outputJSON, outputAgent:
+			selected = append(selected, outputMode(format))
+		default:
+			return "", &cliError{
+				Message:  "unsupported output format " + strconv.Quote(format) + " (want human, json, or agent)",
+				Kind:     kindUsage,
+				ExitCode: ExitUsage,
+			}
+		}
+	}
+	if jsonFlag {
+		selected = append(selected, outputJSON)
+	}
+	if agentFlag {
+		selected = append(selected, outputAgent)
+	}
+	if len(selected) == 0 {
+		return outputHuman, nil
+	}
+	first := selected[0]
+	for _, mode := range selected[1:] {
+		if mode != first {
+			return "", &cliError{Message: "conflicting output modes", Kind: kindUsage, ExitCode: ExitUsage}
+		}
+	}
+	return first, nil
+}
+```
+
+Extend `globalFlags` in `main.go` with `Format string`, `Agent bool`, and resolved `Mode outputMode`. Register:
+
+```go
+cmd.PersistentFlags().StringVar(&flags.Format, "format", "", "output format: human|json|agent")
+cmd.PersistentFlags().BoolVar(&flags.Agent, "agent", false, "emit concise agent-readable text")
+```
+
+Update `PersistentPreRunE` to resolve and store `flags.Mode`. During Task 7, extend this resolver so `kata import --format kata|beads` is accepted as a temporary legacy source-format value.
+
+- [ ] **Step 4: Update error routing**
+
+Change `emitError` signature to accept `mode outputMode` or add a small wrapper:
+
+```go
+func emitErrorForMode(w io.Writer, err error, mode outputMode, runEReached bool) {
+	switch mode {
+	case outputJSON:
+		emitJSONError(w, err, runEReached)
+	case outputAgent:
+		emitAgentError(w, err, commandNameForError(runEReached))
+	default:
+		emitHumanError(w, err, runEReached)
+	}
+}
+```
+
+For parse errors before a subcommand dispatches, use `kata` as the second token. For command errors, use the command's `CommandPath()` final component where available.
+
+- [ ] **Step 5: Add tests for agent errors**
+
+In `cmd/kata/main_test.go`, add tests that call the error emitter directly:
+
+```go
+func TestEmitError_AgentMode_CommandError(t *testing.T) {
+	cli := &cliError{Message: "comment body is required", Kind: kindValidation, ExitCode: ExitValidation}
+	var buf bytes.Buffer
+	emitAgentError(&buf, "comment", cli)
+	assert.Contains(t, buf.String(), "ERR comment validation: comment body is required\n")
+}
+```
+
+Also add an integration-style parse error test:
+
+Run command: `executeRootCapture(t, context.Background(), "--agent", "cretae")`
+
+Expected stderr starts with `ERR kata usage:`.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `go test ./cmd/kata -run 'TestResolveOutputMode|TestEmitError|TestRoot_HelpListsUniversalFlags'`
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/kata/main.go cmd/kata/main_test.go cmd/kata/output_mode.go cmd/kata/output_mode_test.go
+git commit -m "Add CLI output mode resolution"
+```
+
+### Task 2: Agent Quoting, Field, And Fence Helpers
+
+**Files:**
+- Modify: `cmd/kata/output_mode.go`
+- Modify: `cmd/kata/output_mode_test.go`
+
+- [ ] **Step 1: Write failing tests for agent value encoding**
+
+Add tests:
+
+```go
+func TestAgentValue_Quoting(t *testing.T) {
+	assert.Equal(t, "abc4", agentValue("abc4"))
+	assert.Equal(t, strconv.Quote("Fix login race"), agentValue("Fix login race"))
+	assert.Equal(t, strconv.Quote(`quoted "title"`), agentValue(`quoted "title"`))
+	assert.Equal(t, strconv.Quote("bad\nline"), agentValue("bad\nline"))
+}
+
+func TestAgentFencedText_ExtendsFenceForBackticks(t *testing.T) {
+	got := agentFencedText("``` inside")
+	assert.Contains(t, got, "````text\n")
+	assert.True(t, strings.HasSuffix(got, "\n````\n"))
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `go test ./cmd/kata -run 'TestAgentValue|TestAgentFencedText'`
+
+Expected: fail because helpers do not exist.
+
+- [ ] **Step 3: Implement helpers**
+
+In `output_mode.go`, add:
+
+```go
+func agentValue(s string) string {
+	clean := textsafe.Line(s)
+	if clean == "" {
+		return `""`
+	}
+	if strings.IndexFunc(clean, func(r rune) bool {
+		return unicode.IsSpace(r) || r == '"' || r == '\\' || unicode.IsControl(r)
+	}) >= 0 {
+		return strconv.Quote(clean)
+	}
+	return clean
+}
+
+func writeAgentField(w io.Writer, name, value string) error {
+	_, err := fmt.Fprintf(w, "%s: %s\n", name, value)
+	return err
+}
+
+func agentFencedText(s string) string {
+	fence := "```"
+	for strings.Contains(s, fence) {
+		fence += "`"
+	}
+	return fence + "text\n" + textsafe.Block(s) + "\n" + fence + "\n"
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `go test ./cmd/kata -run 'TestAgentValue|TestAgentFencedText'`
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/kata/output_mode.go cmd/kata/output_mode_test.go
+git commit -m "Add agent output formatting helpers"
+```
+
+### Task 3: Version, Whoami, And Simple Local Commands
+
+**Files:**
+- Modify: `cmd/kata/version.go`
+- Modify: `cmd/kata/version_test.go`
+- Modify: `cmd/kata/whoami.go`
+- Modify: `cmd/kata/health.go`
+- Modify: `cmd/kata/daemon_cmd.go`
+- Modify: `cmd/kata/daemon_cmd_test.go`
+
+- [ ] **Step 1: Write failing version tests**
+
+In `version_test.go`, add:
+
+```go
+func TestVersion_AgentIncludesFormatVersion(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newRootCmd(), "--agent", "version"))
+	assert.Contains(t, out, "OK version ")
+	assert.Contains(t, out, "agent_format=1")
+}
+
+func TestVersion_JSONIncludesAgentFormat(t *testing.T) {
+	resetFlags(t)
+	out := executeRoot(t, newRootCmd(), "--json", "version")
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, float64(agentFormatVersion), got["agent_format"])
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `go test ./cmd/kata -run 'TestVersion_'`
+
+Expected: fail because version does not support agent mode or JSON `agent_format`.
+
+- [ ] **Step 3: Implement version and whoami agent output**
+
+In `version.go`, branch:
+
+```go
+case flags.Mode == outputAgent:
+	_, err := fmt.Fprintf(out, "OK version version=%s agent_format=%d\n",
+		agentValue(version.Version), agentFormatVersion)
+	return err
+```
+
+Add `agent_format` to JSON payload.
+
+In `whoami.go`, add:
+
+```go
+if flags.Mode == outputAgent {
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "OK whoami actor=%s source=%s\n",
+		agentValue(actor), agentValue(source))
+	return err
+}
+```
+
+- [ ] **Step 4: Add and implement health/daemon status agent tests**
+
+Use existing daemon status test patterns. Assert `--agent` emits `OK daemon status=...` and `health --agent` emits `OK health`.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `go test ./cmd/kata -run 'TestVersion_|TestWhoami|TestHealth|TestDaemon'`
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/kata/version.go cmd/kata/version_test.go cmd/kata/whoami.go cmd/kata/health.go cmd/kata/daemon_cmd.go cmd/kata/daemon_cmd_test.go
+git commit -m "Add agent output for local status commands"
+```
+
+### Task 4: Shared Agent Mutation Renderer
+
+**Files:**
+- Modify: `cmd/kata/output_mode.go`
+- Modify: `cmd/kata/create.go`
+- Modify: `cmd/kata/comment.go`
+- Modify: `cmd/kata/close.go`
+- Modify: `cmd/kata/reopen.go`
+- Modify: `cmd/kata/assign.go`
+- Modify: `cmd/kata/label.go`
+- Modify: `cmd/kata/delete.go`
+- Modify: `cmd/kata/restore.go`
+- Test: `cmd/kata/create_test.go`, `cmd/kata/comment_test.go`, `cmd/kata/close_reopen_test.go`, `cmd/kata/assign_test.go`, `cmd/kata/label_test.go`, `cmd/kata/delete_test.go`, `cmd/kata/restore_test.go`, `cmd/kata/purge_test.go`
+
+- [ ] **Step 1: Write failing tests for representative mutations**
+
+Add tests for:
+
+- `kata create --agent`: starts `OK create <short_id>`, includes `Issue:` and `Status: open`.
+- `kata create --agent --idempotency-key K` twice: second includes `reused=true changed=false`.
+- `kata comment --agent`: `OK comment <short_id>` and `Comment: appended`.
+- `kata close --agent`: `OK close <short_id>`, `Status: closed`, `Reason: done`.
+- `kata reopen --agent`: `OK reopen <short_id>`, `Status: open`.
+- `kata assign --agent`: `Owner: wesm`.
+- `kata unassign --agent`: `Owner-Cleared: true`.
+- `kata label add --agent`: `OK label <short_id> changed=true`.
+- `kata delete --agent`: `Undo: kata restore <short_id> --agent`.
+- `kata restore --agent`: `Deleted: false`.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `go test ./cmd/kata -run 'Test(Create|Comment|Close|Reopen|Assign|Unassign|Label|Delete|Restore).*Agent'`
+
+Expected: fail because commands still render human/JSON only.
+
+- [ ] **Step 3: Implement generic mutation agent output**
+
+In `output_mode.go`, define a small decoded shape:
+
+```go
+type agentIssueMutation struct {
+	Issue struct {
+		ShortID      string  `json:"short_id"`
+		QualifiedID  string  `json:"qualified_id"`
+		Title        string  `json:"title"`
+		Status       string  `json:"status"`
+		ClosedReason *string `json:"closed_reason"`
+		Owner        *string `json:"owner"`
+		DeletedAt    *string `json:"deleted_at"`
+	} `json:"issue"`
+	Changed bool `json:"changed"`
+	Reused  bool `json:"reused,omitempty"`
+}
+```
+
+Add helpers:
+
+```go
+func printAgentMutation(cmd *cobra.Command, verb string, bs []byte, extra func(io.Writer, agentIssueMutation) error) error
+```
+
+The first line shape is:
+
+```go
+OK <verb> <short_id> [reused=true] [changed=false]
+```
+
+Print `Issue: <short_id> "<title>"` and `Status: <status>` when available.
+
+- [ ] **Step 4: Wire lifecycle commands**
+
+Update existing printers:
+
+- `printMutationWithApplied`: when `flags.Mode == outputAgent`, call `printAgentMutation` with verb from `cmd.CommandPath()` final component.
+- `comment.go`: after successful POST, agent mode should decode response and call a comment-specific helper that prints `Comment: appended`.
+- `printAssignMutation`: agent mode emits `Owner:` for assign and `Owner-Cleared: true` for unassign.
+- `printLabelMutation` / `printLabelRemoved`: agent mode emits `Action: added|removed`.
+- `printDestructive`: agent mode emits delete/purge shapes.
+- `restore.go`: remove the current early human-only print path for agent mode and route through mutation renderer with `Deleted: false`.
+
+- [ ] **Step 5: Preserve quiet and JSON behavior**
+
+Run existing non-agent tests after each command group. Ensure `--quiet` still prints exactly what it did before, and `--json` remains parseable.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `go test ./cmd/kata -run 'Test(Create|Comment|Close|Reopen|Assign|Unassign|Label|Delete|Restore|Purge)'`
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/kata/output_mode.go cmd/kata/create.go cmd/kata/comment.go cmd/kata/close.go cmd/kata/reopen.go cmd/kata/assign.go cmd/kata/label.go cmd/kata/delete.go cmd/kata/restore.go cmd/kata/*_test.go
+git commit -m "Add agent output for issue mutations"
+```
+
+### Task 5: Agent Output For List, Search, Ready, Labels, And Show
+
+**Files:**
+- Modify: `cmd/kata/list.go`
+- Modify: `cmd/kata/search.go`
+- Modify: `cmd/kata/ready.go`
+- Modify: `cmd/kata/label.go`
+- Modify: `cmd/kata/show.go`
+- Test: `cmd/kata/list_test.go`, `cmd/kata/search_test.go`, `cmd/kata/ready_test.go`, `cmd/kata/label_test.go`, `cmd/kata/show_test.go`
+
+- [ ] **Step 1: Write failing tests for read outputs**
+
+Add tests:
+
+- `list --agent` emits `OK list count=N`; rows omit owner when absent.
+- `list --agent` with title `quoted "title"` emits an escaped quoted value.
+- empty `search --agent` emits only `OK search count=0 query="..."`.
+- `ready --agent` emits rows without owner when absent.
+- `labels --agent` emits `OK labels count=N`.
+- `show --agent` emits `Labels: bug,safari`, fenced `Body:`, comment row followed by column-0 fenced text, and no `Owner:` when absent.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run: `go test ./cmd/kata -run 'Test(List|Search|Ready|Labels|Show).*Agent'`
+
+Expected: fail because agent read renderers do not exist.
+
+- [ ] **Step 3: Implement list/search/ready row helpers**
+
+Use agent row helpers so row code stays small:
+
+```go
+func writeAgentKVRow(w io.Writer, fields ...agentField) error
+```
+
+Omit fields whose value pointer is nil. For list-valued fields, join with `,` and no spaces.
+
+- [ ] **Step 4: Implement show agent renderer**
+
+Decode the existing show response. Emit:
+
+````text
+OK show abc4
+Issue: abc4 "Title"
+Status: open
+Owner: wesm        # only when non-nil/non-empty
+Labels: bug,safari # only when labels exist
+Priority: 2        # only when set
+Body:
+```text
+...
+```
+````
+
+For each comment:
+
+````text
+- author=<value> created_at=<value>
+```text
+comment body
+```
+````
+
+Fence starts at column 0.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `go test ./cmd/kata -run 'Test(List|Search|Ready|Labels|Show)'`
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/kata/list.go cmd/kata/search.go cmd/kata/ready.go cmd/kata/label.go cmd/kata/show.go cmd/kata/*_test.go
+git commit -m "Add agent output for issue reads"
+```
+
+### Task 6: Agent Output For Events, Digest, And Audit
+
+**Files:**
+- Modify: `cmd/kata/events.go`
+- Modify: `cmd/kata/digest.go`
+- Modify: `cmd/kata/audit_closes.go`
+- Test: `cmd/kata/events_test.go`, `cmd/kata/digest_test.go`, `cmd/kata/audit_closes_test.go`
+
+- [ ] **Step 1: Write failing events tests**
+
+Add tests:
+
+- `events --agent` emits `OK events count=N next_after_id=M` and rows like `- id=42 type=issue.created issue=abc4 actor=wesm`.
+- reset response in one-shot agent mode emits `OK events reset_required=true reset_after_id=N`.
+- `events --tail --agent` emits one line per event: `OK event id=... type=... issue=... actor=...`.
+- `events --tail --json` remains NDJSON.
+
+- [ ] **Step 2: Run events tests and verify failure**
+
+Run: `go test ./cmd/kata -run 'TestEvents.*Agent|TestEvents.*JSON'`
+
+Expected: agent tests fail, JSON tests pass.
+
+- [ ] **Step 3: Implement events agent renderers**
+
+In `runEventsPoll`, branch on `flags.Mode == outputAgent` before human output. In `streamOnce` or the frame write boundary, branch tail output mode:
+
+```go
+if flags.Mode == outputAgent {
+	fmt.Fprintf(out, "OK event id=%d type=%s", id, agentValue(eventType))
+	...
+}
+```
+
+Keep one line per event in tail mode. Do not emit multiline blocks.
+
+- [ ] **Step 4: Add digest and audit agent tests**
+
+For `digest --agent` and `audit closes --agent`, assert only the stable shape:
+
+- Header starts with `OK digest` / `OK audit`.
+- Rows use `key=value`.
+- No ANSI escape bytes.
+
+- [ ] **Step 5: Implement digest/audit agent renderers**
+
+Follow existing human decoders, but use compact key/value rows. Do not include fields that require extra daemon calls.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `go test ./cmd/kata -run 'TestEvents|TestDigest|TestAuditCloses'`
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/kata/events.go cmd/kata/digest.go cmd/kata/audit_closes.go cmd/kata/events_test.go cmd/kata/digest_test.go cmd/kata/audit_closes_test.go
+git commit -m "Add agent output for event and audit reads"
+```
+
+### Task 7: Import, Export, Projects, And Daemon Logs
+
+**Files:**
+- Modify: `cmd/kata/import.go`
+- Modify: `cmd/kata/beads_import.go`
+- Modify: `cmd/kata/export.go`
+- Modify: `cmd/kata/projects.go`
+- Modify: `cmd/kata/daemon_logs.go`
+- Test: `cmd/kata/import_test.go`, `cmd/kata/beads_import_test.go`, `cmd/kata/export_test.go`, `cmd/kata/projects_test.go`, `cmd/kata/daemon_logs_test.go`
+
+- [ ] **Step 1: Write failing import format migration tests**
+
+Add tests:
+
+- `kata import --source-format beads` selects beads import path.
+- During deprecation, `kata import --format beads --agent` is accepted as legacy source format.
+- `kata import --format beads --source-format beads` fails with a usage error.
+- `kata import --format agent --source-format kata` selects agent output and kata JSONL source.
+
+- [ ] **Step 2: Run import tests and verify failure**
+
+Run: `go test ./cmd/kata -run 'TestImport.*Format|TestBeadsImport'`
+
+Expected: fail because `--source-format` and the routing rules do not exist.
+
+- [ ] **Step 3: Implement import source-format migration**
+
+In `import.go`:
+
+- Add local `sourceFormat string`.
+- Remove the import command's local `--format` registration. Root owns `--format`.
+- Update the root output-mode resolver to accept `flags.Format == "kata"` or `"beads"` only when the final command name is `import`; in that case, set `flags.Mode = outputHuman` unless `--json` or `--agent` also selected output mode through their aliases.
+- In `import.go`, consume `flags.Format` as the legacy source-format value only when it is `kata` or `beads` and `--source-format` is absent.
+- Parse by value with a comment:
+
+```go
+// During the deprecation window, kata|beads in the root --format slot
+// means source format. human|json|agent belongs to the root output mode
+// namespace. The value sets are disjoint, so routing is unambiguous.
+```
+
+If both `--source-format` and legacy `--format kata|beads` are set, return a usage `cliError`.
+
+- [ ] **Step 4: Implement import/export agent output**
+
+Kata JSONL import:
+
+```text
+OK import source_format=kata target=<db_path>
+```
+
+Beads import:
+
+```text
+OK import source_format=beads project=<id_or_name> created=<n> updated=<n> unchanged=<n> comments=<n> links=<n>
+```
+
+Export:
+
+```text
+OK export output=<path>
+```
+
+- [ ] **Step 5: Implement projects and daemon logs agent output**
+
+Projects reads use `OK projects count=N`; project mutations use `OK project action=<verb> ...`. `daemon logs --agent` emits one line per log record and no multiline blocks.
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `go test ./cmd/kata -run 'TestImport|TestBeadsImport|TestExport|TestProjects|TestDaemonLogs'`
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/kata/import.go cmd/kata/beads_import.go cmd/kata/export.go cmd/kata/projects.go cmd/kata/daemon_logs.go cmd/kata/*_test.go
+git commit -m "Add agent output for maintenance commands"
+```
+
+### Task 8: TUI Rejection, Quickstart, README, And Help Text
+
+**Files:**
+- Modify: `cmd/kata/tui_cmd.go`
+- Modify: `cmd/kata/tui_cmd_test.go`
+- Modify: `cmd/kata/quickstart.go`
+- Modify: `cmd/kata/quickstart_test.go`
+- Modify: `README.md`
+
+- [ ] **Step 1: Write failing TUI and quickstart tests**
+
+Add tests:
+
+- `kata tui --agent` fails with usage and does not launch TUI.
+- `kata quickstart` mentions `--agent`.
+- `kata agent-instructions` mentions `--agent`.
+- Quickstart still mentions `--json` for complete structured parsing.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run: `go test ./cmd/kata -run 'TestTUI.*Agent|TestQuickstart'`
+
+Expected: fail until TUI rejection and text are updated.
+
+- [ ] **Step 3: Implement TUI rejection**
+
+In `newTUICmd` RunE, before launching:
+
+```go
+if flags.Mode == outputAgent {
+	return &cliError{Message: "kata tui does not support --agent; run without output formatting", Kind: kindUsage, ExitCode: ExitUsage}
+}
+```
+
+- [ ] **Step 4: Update quickstart and README**
+
+Replace agent examples that currently say "prefer `--json` for reads and writes" with:
+
+```text
+Use --agent for concise action summaries in agent logs.
+Use --json when your script needs complete structured data.
+```
+
+Keep any JSON-specific polling examples as JSON where parsing full structure is required.
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `go test ./cmd/kata -run 'TestTUI|TestQuickstart|TestRoot_HelpListsUniversalFlags'`
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/kata/tui_cmd.go cmd/kata/tui_cmd_test.go cmd/kata/quickstart.go cmd/kata/quickstart_test.go README.md
+git commit -m "Document agent output mode"
+```
+
+### Task 9: Contract Sweep And Full Test Run
+
+**Files:**
+- Modify as needed based on failures.
+
+- [ ] **Step 1: Search for missed `flags.JSON` branches**
+
+Run:
+
+```bash
+rg -n "flags\\.JSON|flags\\.Quiet|emitJSON|print[A-Za-z].*\\(cmd.*bs|fmt\\.Fprint" cmd/kata
+```
+
+Expected: every output-producing branch either dispatches through output mode or is intentionally human-only with a test-backed reason.
+
+- [ ] **Step 2: Add missing focused tests**
+
+For any missed command, add the smallest agent-mode test that pins its first line and any critical fields.
+
+- [ ] **Step 3: Run command package tests**
+
+Run: `go test ./cmd/kata`
+
+Expected: pass.
+
+- [ ] **Step 4: Run full repo tests**
+
+Run: `go test ./...`
+
+Expected: pass.
+
+- [ ] **Step 5: Run final formatting/checks**
+
+Run:
+
+```bash
+gofmt -w cmd/kata
+git diff --check
+```
+
+Expected: no diff-check errors.
+
+- [ ] **Step 6: Commit final fixes if any**
+
+```bash
+git add .
+git commit -m "Complete agent output mode coverage"
+```
+
+Skip this commit only if there were no changes after the previous task commits.
+
+### Task 10: Close Kata Issue
+
+**Files:**
+- No source changes.
+
+- [ ] **Step 1: Confirm final commit and clean worktree**
+
+Run:
+
+```bash
+git status --short
+git rev-parse --short HEAD
+```
+
+Expected: clean status and a commit SHA to reference.
+
+- [ ] **Step 2: Close the kata issue with evidence**
+
+Use the issue ref corresponding to GitHub issue #46 in local kata, if present. If the local kata issue does not exist, comment in the final response instead of closing an unrelated local issue.
+
+If present:
+
+```bash
+kata close <ref> --done \
+  --message "Implemented agent output format with --format agent/--agent, stable ERR/OK contract, docs, and tests." \
+  --commit <sha> \
+  --test "go test ./..."
+```
+
+Expected: issue closes only after tests pass.
+
+- [ ] **Step 3: Final response**
+
+Report:
+
+- Final commit SHA.
+- Test commands run.
+- Any intentional compatibility notes, especially the `kata import --format kata|beads` deprecation window.

--- a/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
+++ b/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
@@ -221,7 +221,32 @@ Issue: abc4 "Fix login race"
 Owner: wesm
 ```
 
-Delete and purge:
+Unassign:
+
+```text
+OK unassign abc4 changed=true
+Issue: abc4 "Fix login race"
+Owner-Cleared: true
+```
+
+Reopen:
+
+```text
+OK reopen abc4
+Issue: abc4 "Fix login race"
+Status: open
+```
+
+Restore, delete, and purge:
+
+Restore:
+
+```text
+OK restore abc4 changed=true
+Issue: abc4 "Fix login race"
+Status: open
+Deleted: false
+```
 
 ```text
 OK delete abc4
@@ -246,8 +271,8 @@ List:
 ```text
 OK list count=3
 - issue=abc4 status=open priority=2 owner=wesm labels=bug,safari title="Fix login race"
-- issue=def7 status=open owner=unowned labels=architecture title="Control channel"
-- issue=j9k2 status=closed owner=unowned title="Old task"
+- issue=def7 status=open labels=architecture title="Control channel"
+- issue=j9k2 status=closed title="Old task"
 ```
 
 Search:
@@ -285,7 +310,7 @@ Ready:
 ```text
 OK ready count=2
 - issue=abc4 priority=1 owner=wesm title="Fix login race"
-- issue=def7 owner=unowned title="Control channel"
+- issue=def7 title="Control channel"
 ```
 
 Labels:
@@ -322,6 +347,10 @@ the same rule applies:
 Labels: bug,safari
 ```
 
+Nullable free-form fields are omitted when absent. Do not emit sentinel values
+such as `owner=unowned` or `owner=null`, because users can choose those exact
+strings as real owner names.
+
 ### 5.3 Other Non-Interactive Commands
 
 Every non-interactive command that emits CLI output must support `--format
@@ -339,7 +368,9 @@ Required coverage:
   ...` line.
 - `daemon logs --agent`: stream-safe one-line records, no multiline blocks.
 - `export`: `OK export output=<path>`.
-- `import`: `OK import target=<path> source_format=<kata|beads> ...`.
+- `import --source-format kata`: `OK import source_format=kata target=<db_path>`.
+- `import --source-format beads`: `OK import source_format=beads project=<name_or_id>
+  created=<n> updated=<n> unchanged=<n> comments=<n> links=<n>`.
 - `projects` subcommands: use `OK projects ...` for reads and `OK project
   action=<verb> ...` for mutations such as rename, merge, remove, restore, and
   detach.
@@ -465,8 +496,8 @@ Pin the contract with focused CLI tests:
   - cobra parse error emits `ERR kata usage: ...` on stderr.
   - JSON error mode remains unchanged.
 - Mutations:
-  - create, idempotent create reuse, comment, edit no-op, close, label,
-    assign, delete, restore, purge.
+  - create, idempotent create reuse, comment, edit no-op, close, reopen, label,
+    assign, unassign, delete, restore, purge.
 - Reads:
   - list, show, search, ready, labels, projects, events, digest, audit.
   - empty reads emit `count=0` and no placeholder row.

--- a/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
+++ b/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
@@ -302,7 +302,7 @@ Comments:
 Reproduced on macOS.
 ```
 Links:
-- type=blocks issue=def7 title="Control channel"
+- type=blocks issue=def7
 ````
 
 Ready:
@@ -350,6 +350,10 @@ Labels: bug,safari
 Nullable free-form fields are omitted when absent. Do not emit sentinel values
 such as `owner=unowned` or `owner=null`, because users can choose those exact
 strings as real owner names.
+
+`show --agent` link rows use only fields available in the existing show
+response. They include `type` and `issue`; they do not include peer titles
+unless the show response grows that field in a future agent format version.
 
 ### 5.3 Other Non-Interactive Commands
 

--- a/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
+++ b/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
@@ -1,0 +1,455 @@
+# kata Agent Output Format Design
+
+**Status:** Approved design for implementation planning
+**Date:** 2026-05-26
+**Topic:** Add a concise, stable CLI output mode for coding agents without replacing JSON as the full machine API.
+**Issue:** https://github.com/kenn-io/kata/issues/46
+
+## 1. Purpose
+
+Agents currently reach for `--json` even when they only need a short action
+acknowledgement. That leads to shell pipelines like:
+
+```sh
+kata comment abc4 --body "..." --json |
+  python3 -c 'import json,sys; d=json.load(sys.stdin); print(...)'
+```
+
+JSON should remain the rich, structured API for programs. The new agent format
+is for a different job: compact, stable text that can be pasted into an agent
+transcript, scanned by a human, and pattern-matched by an agent without needing
+a JSON parser.
+
+## 2. Output Mode Surface
+
+Add a universal output mode flag:
+
+```text
+--format human
+--format json
+--format agent
+```
+
+Mode behavior:
+
+- `human` is the default and preserves current text output.
+- `json` is equivalent to today's `--json` output.
+- `agent` emits the stable text contract described in this document.
+
+Compatibility aliases:
+
+- `--json` is an alias for `--format json`.
+- `--agent` is an alias for `--format agent`.
+
+If multiple output mode flags are passed and they resolve to the same mode, the
+invocation is valid. If they resolve to different modes, the CLI returns a
+usage error before running the command.
+
+Examples:
+
+```sh
+kata list --json                 # same as kata list --format json
+kata list --agent                # same as kata list --format agent
+kata list --format agent --agent # valid
+kata list --format human --json  # usage error
+```
+
+`--quiet` stays orthogonal. It is a suppression flag, not an output mode, and
+does not conflict with `--agent`. In agent mode, `--quiet` suppresses
+nonessential success framing such as `OK ...` headers where the command already
+has a quiet behavior. Errors still emit an `ERR ...` line on stderr.
+
+### 2.1 Existing `kata import --format` Collision
+
+`kata import` already uses `--format` to select the import source format
+(`kata` or `beads`). A universal output `--format` cannot share that name.
+
+Resolve this as part of the feature:
+
+- Add `kata import --source-format <kata|beads>` for the import source type.
+- Move import examples and tests to `--source-format`.
+- Reserve `--format` globally for output mode on every command.
+- If a user runs `kata import --format beads`, return a usage error with a
+  hint: `use --source-format beads; --format now controls output mode`.
+
+This is a small compatibility break, but it keeps the universal output flag
+simple and prevents command-specific shadowing.
+
+## 3. Agent Format Contract
+
+Agent output is a stable text contract.
+
+Contract rules:
+
+- In non-quiet agent mode, the first token is always `OK` for success or `ERR`
+  for failure. `--quiet --agent` may suppress success framing, but not errors.
+- Success goes to stdout. Failure goes to stderr and exits nonzero.
+- The second token is the command or record kind: `create`, `comment`, `list`,
+  `show`, `event`, `kata`, and so on.
+- Remaining first-line fields use stable positional fields only where specified
+  by this document; otherwise they are `key=value`.
+- Field order is part of the contract.
+- New fields may be appended to a line or block. Existing field names, first
+  tokens, and meanings do not change without an agent format version bump.
+- Agent output is plain UTF-8 with no ANSI styling.
+- Human-output sanitization rules apply to untrusted single-line values.
+- Values containing whitespace, quotes, or control characters are double-quoted
+  with Go/JSON-style escaping. Simple tokens may remain unquoted.
+- JSON remains the richer and more complete machine API.
+
+The current agent format version is `1`. Breaking changes require bumping this
+integer. Agents can discover it with:
+
+```text
+$ kata version --agent
+OK version version=0.0.0 agent_format=1
+```
+
+The version is also included in `kata version --json` as `agent_format`.
+Ordinary command output does not repeat the version to keep transcripts small.
+
+## 4. Error Format
+
+Agent mode has a parallel error shape so agents can branch on the first token
+without knowing whether a command succeeded.
+
+Command errors:
+
+```text
+ERR comment validation: comment body is required
+Hint: pass --body, --body-file, or --body-stdin
+```
+
+Top-level usage errors where no subcommand ran:
+
+```text
+ERR kata usage: unknown command "cretae"
+```
+
+Daemon and transport failures:
+
+```text
+ERR list daemon_unavailable: kata daemon is unavailable
+Hint: run kata daemon status
+```
+
+Rules:
+
+- First line shape is `ERR <command> <kind>: <message>`.
+- `<kind>` uses the existing CLI error taxonomy where possible: `usage`,
+  `validation`, `not_found`, `conflict`, `confirm`, `daemon_unavailable`,
+  `internal`.
+- Optional follow-up lines use fixed field names such as `Hint:`, `Code:`, and
+  `Exit-Code:`.
+- In `--format json`, error output remains the existing JSON error envelope on
+  stderr.
+- In `--format human`, error output remains the existing human text.
+
+## 5. Success Format
+
+### 5.1 Mutations
+
+Mutation output answers what happened, which issue changed, and whether the
+operation was a no-op.
+
+Create:
+
+```text
+OK create abc4
+Issue: abc4 "Fix login race"
+Status: open
+```
+
+Idempotent create reuse:
+
+```text
+OK create abc4 reused=true changed=false
+Issue: abc4 "Fix login race"
+Status: open
+```
+
+Comment:
+
+```text
+OK comment abc4
+Issue: abc4 "Fix login race"
+Comment: appended
+```
+
+Edit:
+
+```text
+OK edit abc4 changed=true
+Issue: abc4 "Fix login race"
+Status: open
+Changes: title, owner, links
+```
+
+Close:
+
+```text
+OK close abc4
+Issue: abc4 "Fix login race"
+Status: closed
+Reason: done
+Evidence: commit:3a401a8
+```
+
+Label:
+
+```text
+OK label abc4 changed=true
+Issue: abc4 "Fix login race"
+Label: safari
+Action: added
+```
+
+Assign:
+
+```text
+OK assign abc4 changed=true
+Issue: abc4 "Fix login race"
+Owner: wesm
+```
+
+Delete and purge:
+
+```text
+OK delete kata#abc4
+Issue: kata#abc4 "Fix login race"
+Status: deleted
+Undo: kata restore kata#abc4 --agent
+```
+
+```text
+OK purge kata#abc4
+Issue: kata#abc4 "Fix login race"
+Status: purged
+```
+
+`Undo:` is allowed only when the follow-up is factual and mechanically correct.
+Generic `Next:` guidance is intentionally not part of the format.
+
+### 5.2 Reads
+
+List:
+
+```text
+OK list count=3
+- issue=abc4 status=open priority=2 owner=wesm labels=bug,safari title="Fix login race"
+- issue=def7 status=open owner=unowned labels=architecture title="Control channel"
+- issue=j9k2 status=closed owner=unowned title="Old task"
+```
+
+Search:
+
+```text
+OK search count=2 query="login race"
+- issue=abc4 score=0.82 status=open matched=title,body title="Fix login race"
+- issue=d4ex score=0.61 status=closed matched=comments title="Safari callback"
+```
+
+Show:
+
+````text
+OK show abc4
+Issue: abc4 "Fix login race"
+Status: open
+Owner: wesm
+Labels: bug, safari
+Priority: 2
+Body:
+```text
+Safari can double-submit the callback.
+```
+Comments:
+- author=wesm created_at=2026-05-17T17:31:04Z
+```text
+Reproduced on macOS.
+```
+Links:
+- type=blocks issue=def7 title="Control channel"
+````
+
+Ready:
+
+```text
+OK ready count=2
+- issue=abc4 priority=1 owner=wesm title="Fix login race"
+- issue=def7 owner=unowned title="Control channel"
+```
+
+Labels:
+
+```text
+OK labels count=2
+- label=bug count=4
+- label=safari count=1
+```
+
+Projects:
+
+```text
+OK projects count=2
+- project=kata id=1 open=12 closed=8
+- project=docs id=2 open=3 closed=1
+```
+
+Digest and audit commands follow the same pattern: an `OK <command>
+count=<n>` header followed by one line per returned record, using `key=value`
+fields.
+
+### 5.3 Other Non-Interactive Commands
+
+Every non-interactive command that emits CLI output must support `--format
+agent`, either by using one of the lifecycle/read shapes above or by emitting a
+single `OK <command> ...` line with stable `key=value` fields.
+
+Required coverage:
+
+- `init`: `OK init project=<name> workspace=<path> changed=<bool>`.
+- `whoami`: `OK whoami actor=<name> source=<source>`.
+- `version`: `OK version version=<version> agent_format=1`.
+- `health`: `OK health ok=<bool> daemon=<status>`.
+- `daemon status`: `OK daemon status=<status> ...`.
+- `daemon start`, `daemon stop`, `daemon reload`: one `OK daemon action=<verb>
+  ...` line.
+- `daemon logs --agent`: stream-safe one-line records, no multiline blocks.
+- `export`: `OK export output=<path>`.
+- `import`: `OK import target=<path> source_format=<kata|beads> ...`.
+- `projects` subcommands: use `OK projects ...` for reads and `OK project
+  action=<verb> ...` for mutations such as rename, merge, remove, restore, and
+  detach.
+- `quickstart`: `OK quickstart` followed by compact instruction lines. The
+  agent-oriented instructions prefer `--agent` for transcript output and
+  `--json` for complete structured parsing.
+
+`kata tui` is interactive and does not have a meaningful agent transcript
+output. If `--format agent` or `--agent` is passed to `kata tui`, return a usage
+error instead of launching the TUI.
+
+### 5.4 Events
+
+Non-tail event reads use a header plus rows:
+
+```text
+OK events count=2 next_after_id=44
+- id=42 type=issue.created issue=abc4 actor=wesm
+- id=43 type=issue.commented issue=abc4 actor=codex
+```
+
+Tail mode is stream-safe and emits exactly one line per event:
+
+```text
+OK event id=42 type=issue.created issue=abc4 actor=wesm
+OK event id=43 type=issue.commented issue=abc4 actor=codex
+```
+
+`kata events --tail --json` remains NDJSON. `kata events --tail --agent` is not
+NDJSON and does not emit multi-line blocks.
+
+## 6. Multiline Text
+
+Agent mode preserves multiline text in fenced `text` blocks by default.
+
+Rules:
+
+- `show --agent` emits full issue bodies and comments unless the command has an
+  explicit limit flag.
+- No silent truncation is allowed.
+- If truncation is introduced later, it must be marked with fixed fields before
+  the fenced block.
+
+Example:
+
+````text
+Body-Truncated: true
+Body-Bytes: 12000
+Body:
+```text
+First visible bytes...
+```
+````
+
+Fenced text blocks use at least three backticks and `text`. If the body itself
+contains a triple-backtick sequence, the renderer must choose a longer fence so
+the block remains valid Markdown.
+
+## 7. Implementation Shape
+
+Add a shared output layer in `cmd/kata` rather than hand-rolling agent output
+inside every command.
+
+Suggested pieces:
+
+- Extend global flags with an output mode enum: `human`, `json`, `agent`.
+- Resolve `--format`, `--json`, and `--agent` once at the root.
+- Keep `emitJSON` as the JSON helper.
+- Add shared helpers for agent mode:
+  - `emitAgentError`
+  - `emitAgentMutation`
+  - `emitAgentList`
+  - `emitAgentShow`
+  - `emitAgentRows`
+  - `quoteAgentValue` / `sanitizeAgentLine`
+  - `emitFencedText`
+- Convert command printers to dispatch through the resolved output mode.
+
+The HTTP behavior of commands should not change. Commands should continue to
+call the daemon, decode the same response bodies, and then render according to
+the selected mode.
+
+## 8. Quickstart and Agent Instructions
+
+Update `kata quickstart` and its `kata agent-instructions` alias to recommend
+agent mode for transcript-friendly command output:
+
+```text
+Use --agent for concise action summaries in agent logs.
+Use --json when your script needs complete structured data.
+```
+
+Examples in the agent instructions should prefer `--agent` for ordinary reads
+and writes, and reserve `--json` for cases where the instructions explicitly
+tell the agent to parse complete structured data.
+
+## 9. Testing
+
+Pin the contract with focused CLI tests:
+
+- Flag resolution:
+  - `--json` equals `--format json`.
+  - `--agent` equals `--format agent`.
+  - matching aliases are accepted.
+  - conflicting output modes fail with usage.
+  - `kata import --source-format beads` replaces the old source-format flag.
+  - `kata import --format beads` fails with the migration hint.
+  - `kata tui --agent` fails with usage.
+- Agent errors:
+  - validation error emits `ERR <command> validation: ...` on stderr.
+  - cobra parse error emits `ERR kata usage: ...` on stderr.
+  - JSON error mode remains unchanged.
+- Mutations:
+  - create, idempotent create reuse, comment, edit no-op, close, label,
+    assign, delete, restore, purge.
+- Reads:
+  - list, show, search, ready, labels, projects, events, digest, audit.
+- Streaming:
+  - `events --tail --agent` emits one line per event.
+  - `events --tail --json` remains NDJSON.
+- Text safety:
+  - no ANSI/control leakage in agent single-line fields.
+  - multiline bodies are fenced.
+  - embedded backticks do not break fences.
+- Quickstart:
+  - agent instructions mention `--agent`.
+  - JSON is still documented for complete structured parsing.
+
+## 10. Non-Goals
+
+- Do not remove or weaken `--json`.
+- Do not change daemon API responses for this feature.
+- Do not add a new serialization format such as XML.
+- Do not make agent mode the default in this change.
+- Do not add prescriptive workflow hints like `Next:` unless the follow-up is
+  factual and mechanically correct, such as a restore command after delete.

--- a/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
+++ b/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
@@ -69,11 +69,19 @@ Resolve this as part of the feature:
 - Add `kata import --source-format <kata|beads>` for the import source type.
 - Move import examples and tests to `--source-format`.
 - Reserve `--format` globally for output mode on every command.
-- If a user runs `kata import --format beads`, return a usage error with a
-  hint: `use --source-format beads; --format now controls output mode`.
+- For one release, keep legacy `kata import --format kata|beads` as a silent
+  fallback for the source format when `--source-format` is not also set.
+  `--json` and `--agent` aliases may still select output mode during this
+  fallback window.
+- If both legacy `--format kata|beads` and `--source-format` are passed, return
+  a usage error asking the caller to use only `--source-format`.
+- After the deprecation window, remove the legacy source-format use of
+  `--format`. At that point `kata import --format beads` returns a usage error
+  with a hint: `use --source-format beads; --format controls output mode`.
 
-This is a small compatibility break, but it keeps the universal output flag
-simple and prevents command-specific shadowing.
+This keeps the transition graceful while making the final contract simple:
+`--format` is the universal output mode, and `--source-format` is the import
+source selector.
 
 ## 3. Agent Format Contract
 
@@ -85,7 +93,8 @@ Contract rules:
   for failure. `--quiet --agent` may suppress success framing, but not errors.
 - Success goes to stdout. Failure goes to stderr and exits nonzero.
 - The second token is the command or record kind: `create`, `comment`, `list`,
-  `show`, `event`, `kata`, and so on.
+  `show`, `event`, and so on. `kata` is used only for top-level parse errors
+  before a subcommand dispatches.
 - Remaining first-line fields use stable positional fields only where specified
   by this document; otherwise they are `key=value`.
 - Field order is part of the contract.
@@ -215,15 +224,15 @@ Owner: wesm
 Delete and purge:
 
 ```text
-OK delete kata#abc4
-Issue: kata#abc4 "Fix login race"
+OK delete abc4
+Issue: abc4 "Fix login race"
 Status: deleted
-Undo: kata restore kata#abc4 --agent
+Undo: kata restore abc4 --agent
 ```
 
 ```text
-OK purge kata#abc4
-Issue: kata#abc4 "Fix login race"
+OK purge abc4
+Issue: abc4 "Fix login race"
 Status: purged
 ```
 
@@ -256,7 +265,7 @@ OK show abc4
 Issue: abc4 "Fix login race"
 Status: open
 Owner: wesm
-Labels: bug, safari
+Labels: bug,safari
 Priority: 2
 Body:
 ```text
@@ -298,6 +307,20 @@ OK projects count=2
 Digest and audit commands follow the same pattern: an `OK <command>
 count=<n>` header followed by one line per returned record, using `key=value`
 fields.
+
+Empty successful reads emit the normal header with `count=0` and no row lines:
+
+```text
+OK search count=0 query="login race"
+OK list count=0
+```
+
+List-valued fields use comma-separated values with no spaces. In block fields,
+the same rule applies:
+
+```text
+Labels: bug,safari
+```
 
 ### 5.3 Other Non-Interactive Commands
 
@@ -357,8 +380,13 @@ Rules:
 - `show --agent` emits full issue bodies and comments unless the command has an
   explicit limit flag.
 - No silent truncation is allowed.
-- If truncation is introduced later, it must be marked with fixed fields before
-  the fenced block.
+- If truncation is introduced later, the truncation metadata fields immediately
+  precede the `Body:`, `Comment:`, or other text-field line they describe.
+- Truncation metadata is emitted as a pair: `<Field>-Truncated: true` and
+  `<Field>-Bytes: <full-byte-count>`. Do not emit one without the other.
+- List rows may be followed by a fenced text block when the row represents a
+  record with body content, as comments do in `show --agent`. The fence starts
+  at column 0, not indented under the `-` row.
 
 Example:
 
@@ -421,10 +449,17 @@ Pin the contract with focused CLI tests:
   - `--json` equals `--format json`.
   - `--agent` equals `--format agent`.
   - matching aliases are accepted.
+  - equal-mode combinations such as `--format agent --agent` are accepted.
   - conflicting output modes fail with usage.
-  - `kata import --source-format beads` replaces the old source-format flag.
-  - `kata import --format beads` fails with the migration hint.
+  - `kata import --source-format beads` selects the import source format.
+  - during the deprecation window, `kata import --format beads` is accepted as
+    a legacy source-format fallback.
+  - passing both legacy `--format beads` and `--source-format` fails with the
+    migration hint.
   - `kata tui --agent` fails with usage.
+- Version discovery:
+  - `kata version --agent` emits `agent_format=1`.
+  - `kata version --json` includes `agent_format`.
 - Agent errors:
   - validation error emits `ERR <command> validation: ...` on stderr.
   - cobra parse error emits `ERR kata usage: ...` on stderr.
@@ -434,11 +469,14 @@ Pin the contract with focused CLI tests:
     assign, delete, restore, purge.
 - Reads:
   - list, show, search, ready, labels, projects, events, digest, audit.
+  - empty reads emit `count=0` and no placeholder row.
 - Streaming:
   - `events --tail --agent` emits one line per event.
   - `events --tail --json` remains NDJSON.
 - Text safety:
   - no ANSI/control leakage in agent single-line fields.
+  - a title containing an embedded `"` is escaped so the row remains
+    well-formed.
   - multiline bodies are fenced.
   - embedded backticks do not break fences.
 - Quickstart:

--- a/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
+++ b/docs/superpowers/specs/2026-05-26-agent-output-format-design.md
@@ -368,8 +368,9 @@ Required coverage:
 - `version`: `OK version version=<version> agent_format=1`.
 - `health`: `OK health ok=<bool> daemon=<status>`.
 - `daemon status`: `OK daemon status=<status> ...`.
-- `daemon start`, `daemon stop`, `daemon reload`: one `OK daemon action=<verb>
-  ...` line.
+- `daemon stop`, `daemon reload`: one `OK daemon action=<verb> ...` line.
+- `daemon start`: foreground server command; reject agent output mode with a
+  usage error instead of launching because there is no final transcript result.
 - `daemon logs --agent`: stream-safe one-line records, no multiline blocks.
 - `export`: `OK export output=<path>`.
 - `import --source-format kata`: `OK import source_format=kata target=<db_path>`.
@@ -382,9 +383,9 @@ Required coverage:
   agent-oriented instructions prefer `--agent` for transcript output and
   `--json` for complete structured parsing.
 
-`kata tui` is interactive and does not have a meaningful agent transcript
-output. If `--format agent` or `--agent` is passed to `kata tui`, return a usage
-error instead of launching the TUI.
+`kata tui` is interactive and `kata daemon start` is a foreground server; neither
+has a meaningful final agent transcript output. If `--format agent` or `--agent`
+is passed to either command, return a usage error instead of launching.
 
 ### 5.4 Events
 


### PR DESCRIPTION
## Summary
- Add universal `--format human|json|agent` output mode with `--json` and `--agent` aliases, including structured agent `OK`/`ERR` output.
- Roll agent output through CLI mutations, reads, events, imports/exports, project/daemon/status commands, and quickstart docs.
- Document the agent output contract and implementation plan, including stability/versioning and migration behavior for import format flags.

Addresses #46 

## Spec Summary

- `--format human|json|agent` is the universal output selector.
- `--json` is an alias for `--format json`; `--agent` is an alias for `--format agent`.
- Conflicting output selections fail; equal-mode combinations are accepted.
- Agent success output starts with `OK <verb>` and uses stable field names.
- Agent errors start with `ERR <verb> <kind>:` so callers can branch on one token.
- Agent values are single-line and escaped when needed; long bodies/comments use fenced text blocks.
- `kata version --agent` exposes `agent_format=1`; JSON remains the richer structured API.
- `kata import --format kata|beads` is preserved during the deprecation window, while `--source-format` is the new import-source flag.

## Output Examples

All examples below use synthetic sample data.

### Human output

```console
$ kata create "Fix login race"
abc4 Fix login race [open]

$ kata list
abc4      open      Fix login race  (alex)
```

### JSON output

```console
$ kata create "Fix login race" --json
{
  "kata_api_version": 1,
  "issue": {
    "short_id": "abc4",
    "title": "Fix login race",
    "status": "open"
  },
  "changed": true
}

$ kata version --json
{
  "kata_api_version": 1,
  "version": "0.0.0",
  "agent_format": 1
}
```

### Agent output

```console
$ kata create "Fix login race" --agent
OK create abc4
Issue: abc4 "Fix login race"
Status: open

$ kata list --agent
OK list count=1
- issue=abc4 status=open title="Fix login race" owner=alex

$ kata close abc4 --done --message "Fixed duplicate submit and verified tests." --commit 3a401a8 --agent
OK close abc4
Issue: abc4 "Fix login race"
Status: closed
Reason: done
Evidence: commit:3a401a8
```

### Agent errors and streams

```console
$ kata --agent show missing-ref
ERR show not_found: issue not found

$ kata events --tail --agent
OK event id=42 type=issue.created issue=abc4 project=demo actor=alex
```

The agent format is meant to be parseable by the first token (`OK` or `ERR`) while staying cheaper and easier to paste into agent transcripts than full JSON. JSON remains the richer structured API.

## Test Plan
- `go test ./...`
- `make lint`
- `git diff --check`
- roborev-fix pass: addressed/closed failing review jobs; remaining open jobs were passing reviews with no findings.