### PR TITLE
Ship signed multi-arch container image + release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the build context to Go sources, manifests, and the embedded schema.
+.git
+.github
+.claude
+docs
+e2e
+dist
+*.md
+LICENSE
+kata
+kata.exe
+coverage.out

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,8 +1,8 @@
 name: Image
 
 # Releases publish to Google Artifact Registry via Workload Identity
-# Federation (no long-lived keys). Set these repo variables under
-# Settings -> Secrets and variables -> Actions -> Variables:
+# Federation (no long-lived keys). Set these repo secrets under
+# Settings -> Secrets and variables -> Actions -> Secrets:
 #   GCP_PROJECT   - Google Cloud project ID
 #   AR_HOST       - Artifact Registry host, e.g. <region>-docker.pkg.dev
 #   AR_REPO       - Artifact Registry Docker repository name
@@ -67,7 +67,7 @@ jobs:
       attestations: write
 
     env:
-      IMAGE: ${{ vars.AR_HOST }}/${{ vars.GCP_PROJECT }}/${{ vars.AR_REPO }}/kata
+      IMAGE: ${{ secrets.AR_HOST }}/${{ secrets.GCP_PROJECT }}/${{ secrets.AR_REPO }}/kata
 
     steps:
       - name: Check out repository
@@ -82,14 +82,14 @@ jobs:
         id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3
         with:
-          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
-          service_account: ${{ vars.PUBLISHER_SA }}
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.PUBLISHER_SA }}
           token_format: access_token
 
       - name: Log in to Artifact Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
-          registry: ${{ vars.AR_HOST }}
+          registry: ${{ secrets.AR_HOST }}
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,142 @@
+name: Image
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - docker-bake.hcl
+      - .github/workflows/image.yml
+      - go.mod
+      - go.sum
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build:
+    name: Build & smoke-test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Build image and load into the engine
+        run: docker buildx bake --file docker-bake.hcl image-local --load
+
+      - name: Smoke-test the binary
+        run: docker run --rm kata:local version
+
+      - name: Assert the image runs as non-root
+        run: |
+          user="$(docker image inspect kata:local --format '{{.Config.User}}')"
+          echo "image user: ${user}"
+          test "${user}" = "65532:65532"
+
+  release:
+    name: Build, push, sign, attest
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Derive image tags and labels
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=auto
+
+      - name: Compute build args
+        id: vars
+        run: |
+          echo "commit=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push the multi-arch image
+        id: bake
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584  # v7.2.0
+        with:
+          files: |
+            ./docker-bake.hcl
+            cwd://${{ steps.meta.outputs.bake-file }}
+          targets: image
+          push: true
+          set: |
+            image.args.VERSION=${{ steps.meta.outputs.version }}
+            image.args.COMMIT=${{ steps.vars.outputs.commit }}
+            image.args.DATE=${{ steps.vars.outputs.date }}
+
+      - name: Extract the pushed digest
+        id: digest
+        env:
+          METADATA: ${{ steps.bake.outputs.metadata }}
+        run: |
+          digest="$(jq -r '.image["containerimage.digest"]' <<< "$METADATA")"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Image digest: ${digest}"
+
+      - name: Sign the digest (cosign keyless)
+        env:
+          DIGEST: ${{ steps.digest.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Attach a build-provenance attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
+          push-to-registry: true
+
+      - name: Verify the signature (gate)
+        env:
+          DIGEST: ${{ steps.digest.outputs.digest }}
+        run: |
+          cosign verify \
+            --certificate-identity "${{ github.server_url }}/${{ github.repository }}/.github/workflows/image.yml@${{ github.ref }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${IMAGE}@${DIGEST}"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -78,6 +78,15 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
+      - name: Validate tag format (strict semver)
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "Tag '$TAG' is not strict semver vX.Y.Z[-prerelease]" >&2
+            exit 1
+          fi
+
       - name: Authenticate to Google Cloud (Workload Identity Federation)
         id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3
@@ -151,8 +160,10 @@ jobs:
       - name: Verify the signature (gate)
         env:
           DIGEST: ${{ steps.digest.outputs.digest }}
+          CERT_ID: ${{ github.server_url }}/${{ github.repository }}/.github/workflows/image.yml@${{ github.ref }}
+          OIDC_ISSUER: https://token.actions.githubusercontent.com
         run: |
           cosign verify \
-            --certificate-identity "${{ github.server_url }}/${{ github.repository }}/.github/workflows/image.yml@${{ github.ref }}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            --certificate-identity "$CERT_ID" \
+            --certificate-oidc-issuer "$OIDC_ISSUER" \
             "${IMAGE}@${DIGEST}"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,5 +1,14 @@
 name: Image
 
+# Releases publish to Google Artifact Registry via Workload Identity
+# Federation (no long-lived keys). Set these repo variables under
+# Settings -> Secrets and variables -> Actions -> Variables:
+#   GCP_PROJECT   - Google Cloud project ID
+#   AR_HOST       - Artifact Registry host, e.g. <region>-docker.pkg.dev
+#   AR_REPO       - Artifact Registry Docker repository name
+#   WIF_PROVIDER  - full Workload Identity provider resource name
+#   PUBLISHER_SA  - publisher service account email
+
 on:
   pull_request:
     paths:
@@ -19,9 +28,6 @@ permissions:
 concurrency:
   group: image-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-env:
-  IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
   build:
@@ -57,9 +63,11 @@ jobs:
 
     permissions:
       contents: read
-      packages: write
       id-token: write
       attestations: write
+
+    env:
+      IMAGE: ${{ vars.AR_HOST }}/${{ vars.GCP_PROJECT }}/${{ vars.AR_REPO }}/kata
 
     steps:
       - name: Check out repository
@@ -70,12 +78,20 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      - name: Log in to GHCR
+      - name: Authenticate to Google Cloud (Workload Identity Federation)
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.PUBLISHER_SA }}
+          token_format: access_token
+
+      - name: Log in to Artifact Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ vars.AR_HOST }}
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -16,6 +16,8 @@ on:
       - .dockerignore
       - docker-bake.hcl
       - .github/workflows/image.yml
+      - cmd/**
+      - internal/**
       - go.mod
       - go.sum
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -X go.kenn.io/kata/internal/version.BuildDate=${DATE}" \
     -o /out/kata ./cmd/kata
 
-# Stage an empty data dir so the final COPY can own it as the nonroot uid; a
-# fresh volume mounted at KATA_HOME then inherits writable ownership.
-RUN mkdir -p /data
+# Stage the data dir with a .keep file so the final-stage COPY reliably
+# preserves the directory and its ownership across all BuildKit versions; a
+# fresh volume mounted at KATA_HOME then inherits writable ownership for the
+# nonroot uid.
+RUN mkdir -p /data && touch /data/.keep
 
 # Final stage. Distroless static nonroot: no shell, no package manager, runs
 # as uid 65532. Pinned by digest.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+
+# Build stage. Runs on the native build platform and cross-compiles to the
+# target platform via buildx's TARGETOS/TARGETARCH, so multi-arch builds need
+# no QEMU. CGO is off, yielding a static binary that runs on distroless static.
+FROM --platform=$BUILDPLATFORM golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+
+# -buildvcs=false because .dockerignore omits .git, so there is no VCS metadata
+# to stamp; the version is injected via ldflags instead.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" \
+    go build -trimpath -buildvcs=false \
+    -ldflags="-s -w \
+    -X go.kenn.io/kata/internal/version.Version=${VERSION} \
+    -X go.kenn.io/kata/internal/version.Commit=${COMMIT} \
+    -X go.kenn.io/kata/internal/version.BuildDate=${DATE}" \
+    -o /out/kata ./cmd/kata
+
+# Stage an empty data dir so the final COPY can own it as the nonroot uid; a
+# fresh volume mounted at KATA_HOME then inherits writable ownership.
+RUN mkdir -p /data
+
+# Final stage. Distroless static nonroot: no shell, no package manager, runs
+# as uid 65532. Pinned by digest.
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+
+COPY --from=build /out/kata /kata
+COPY --from=build --chown=65532:65532 /data /data
+
+ENV KATA_HOME=/data
+# Conventional daemon TCP port. Informational only — the daemon binds it only
+# when told to via --listen or config.toml (see README "Container image").
+EXPOSE 7777
+VOLUME ["/data"]
+
+USER 65532:65532
+
+ENTRYPOINT ["/kata"]
+CMD ["daemon", "start"]

--- a/README.md
+++ b/README.md
@@ -579,18 +579,15 @@ auto-started on demand.
 
 ## Container image
 
-A hardened image for running the daemon is published to the GitHub
-Container Registry on each tagged release:
-
-```sh
-docker pull ghcr.io/kenn-io/kata:latest
-```
-
-It is multi-arch (`linux/amd64`, `linux/arm64`), built from
-`gcr.io/distroless/static-debian12:nonroot`, and runs as a non-root user
-(uid 65532) with no shell or package manager. Every published digest is
-cosign-signed (keyless, via GitHub's OIDC identity) and carries a
-build-provenance attestation — see [Verifying](#verifying-signature-and-provenance).
+A hardened, multi-stage image for running the daemon is defined in
+`docker-bake.hcl`. It is built from
+`gcr.io/distroless/static-debian12:nonroot`, runs as a non-root user
+(uid 65532) with no shell or package manager, and is multi-arch
+(`linux/amd64`, `linux/arm64`). Tagged releases publish a cosign-signed
+image, with a build-provenance attestation, to the project's Artifact
+Registry for the maintained deployment — see
+[Verifying](#verifying-signature-and-provenance). To build it yourself, see
+[Building locally](#building-locally) below.
 
 ### Runtime contract
 
@@ -624,7 +621,7 @@ docker network create --subnet 172.20.0.0/24 kata-net
 docker run -d --name kata \
   --network kata-net --ip 172.20.0.10 \
   -v kata-data:/data \
-  ghcr.io/kenn-io/kata:latest
+  kata:local
 ```
 
 Or pass the address and auth on the command line, overriding the default
@@ -635,7 +632,7 @@ docker run -d --name kata \
   --network kata-net --ip 172.20.0.10 \
   -e KATA_AUTH_TOKEN=change-me -e KATA_TRUST_PRIVATE_NETWORK=1 \
   -v kata-data:/data \
-  ghcr.io/kenn-io/kata:latest \
+  kata:local \
   daemon start --listen 172.20.0.10:7777
 ```
 
@@ -657,20 +654,15 @@ args: ["daemon", "start", "--listen", "$(POD_IP):7777"]
 
 ### Verifying signature and provenance
 
-Verify the keyless signature with
-[cosign](https://github.com/sigstore/cosign):
+Each published digest is signed keyless via GitHub's OIDC identity. Verify it
+with [cosign](https://github.com/sigstore/cosign), substituting the published
+image reference:
 
 ```sh
 cosign verify \
   --certificate-identity-regexp '^https://github.com/kenn-io/kata/[.]github/workflows/image[.]yml@refs/tags/.*$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/kenn-io/kata:latest
-```
-
-Inspect the build-provenance attestation with the GitHub CLI:
-
-```sh
-gh attestation verify oci://ghcr.io/kenn-io/kata:latest --repo kenn-io/kata
+  <ar-host>/<project>/<repo>/kata:<tag>
 ```
 
 ### Building locally

--- a/README.md
+++ b/README.md
@@ -577,6 +577,112 @@ tailnet) are the access boundary in that read-only dev mode. Default behavior
 (no flag, no env, no local file) is unchanged: a local Unix-socket daemon is
 auto-started on demand.
 
+## Container image
+
+A hardened image for running the daemon is published to the GitHub
+Container Registry on each tagged release:
+
+```sh
+docker pull ghcr.io/kenn-io/kata:latest
+```
+
+It is multi-arch (`linux/amd64`, `linux/arm64`), built from
+`gcr.io/distroless/static-debian12:nonroot`, and runs as a non-root user
+(uid 65532) with no shell or package manager. Every published digest is
+cosign-signed (keyless, via GitHub's OIDC identity) and carries a
+build-provenance attestation — see [Verifying](#verifying-signature-and-provenance).
+
+### Runtime contract
+
+- **Data lives in `KATA_HOME`, which is `/data` in the image.** Mount a
+  writable volume there to persist the SQLite database, runtime files,
+  and hook state across restarts.
+- **The default entrypoint runs `kata daemon start`**, which binds a Unix
+  socket — reachable only inside the container. To serve clients on other
+  hosts, tell the daemon to bind a TCP address, either with `--listen` or
+  via `listen` in `KATA_HOME/config.toml`.
+- **Bind a concrete private IP, not a wildcard.** kata rejects the
+  unspecified address (`0.0.0.0` / `::`) and any public IP; it binds only
+  literal non-public addresses (loopback, RFC1918, CGNAT, link-local,
+  ULA). Mutating clients additionally need a token and the
+  `trust_private_network` flag, as described under
+  [Remote daemon](#remote-daemon-opt-in-private-network) above.
+
+Mount a `config.toml` and run the default entrypoint:
+
+```toml
+# stored at /data/config.toml inside the mounted volume
+listen = "172.20.0.10:7777"
+
+[auth]
+token = "change-me"
+trust_private_network = true
+```
+
+```sh
+docker network create --subnet 172.20.0.0/24 kata-net
+docker run -d --name kata \
+  --network kata-net --ip 172.20.0.10 \
+  -v kata-data:/data \
+  ghcr.io/kenn-io/kata:latest
+```
+
+Or pass the address and auth on the command line, overriding the default
+arguments:
+
+```sh
+docker run -d --name kata \
+  --network kata-net --ip 172.20.0.10 \
+  -e KATA_AUTH_TOKEN=change-me -e KATA_TRUST_PRIVATE_NETWORK=1 \
+  -v kata-data:/data \
+  ghcr.io/kenn-io/kata:latest \
+  daemon start --listen 172.20.0.10:7777
+```
+
+On Kubernetes, bind the pod IP from the downward API:
+
+```yaml
+env:
+  - name: POD_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.podIP
+  - name: KATA_AUTH_TOKEN
+    valueFrom:
+      secretKeyRef: { name: kata, key: token }
+  - name: KATA_TRUST_PRIVATE_NETWORK
+    value: "1"
+args: ["daemon", "start", "--listen", "$(POD_IP):7777"]
+```
+
+### Verifying signature and provenance
+
+Verify the keyless signature with
+[cosign](https://github.com/sigstore/cosign):
+
+```sh
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/kenn-io/kata/[.]github/workflows/image[.]yml@refs/tags/.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/kenn-io/kata:latest
+```
+
+Inspect the build-provenance attestation with the GitHub CLI:
+
+```sh
+gh attestation verify oci://ghcr.io/kenn-io/kata:latest --repo kenn-io/kata
+```
+
+### Building locally
+
+The build is defined in `docker-bake.hcl`. Build a native single-arch
+image into your local engine and run it:
+
+```sh
+docker buildx bake image-local --load
+docker run --rm kata:local version
+```
+
 ## Backup and restore
 
 `kata export` writes the local database as JSONL; `kata import` rebuilds

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,51 @@
+# Build definition for the kata daemon image.
+#
+#   docker buildx bake image-local --load   # native single-arch, for dev
+#   docker buildx bake image                # multi-arch, used by CI/release
+#
+# Version metadata is injected via build args; override with
+#   VERSION=v1.2.3 COMMIT=abc1234 DATE=2026-05-27T00:00:00Z docker buildx bake image
+
+variable "VERSION" {
+  default = "dev"
+}
+
+variable "COMMIT" {
+  default = "unknown"
+}
+
+variable "DATE" {
+  default = "unknown"
+}
+
+# Populated by docker/metadata-action's generated bake file in CI (tags,
+# labels, annotations). The empty stub keeps local bake runs working.
+target "docker-metadata-action" {}
+
+# Shared build inputs. Hidden (underscore prefix): never built directly.
+target "_common" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  args = {
+    VERSION = VERSION
+    COMMIT  = COMMIT
+    DATE    = DATE
+  }
+}
+
+# Release image: multi-arch, attested, tags/labels from metadata-action.
+target "image" {
+  inherits  = ["_common", "docker-metadata-action"]
+  platforms = ["linux/amd64", "linux/arm64"]
+  attest = [
+    "type=provenance,mode=max",
+    "type=sbom",
+  ]
+}
+
+# Dev/CI smoke build: the host's native platform, no attestations, a fixed
+# local tag so it can be loaded into the engine and run.
+target "image-local" {
+  inherits = ["_common"]
+  tags     = ["kata:local"]
+}


### PR DESCRIPTION
## Summary

Adds the container image and release pipeline for the kata daemon. Closes #59.

- **`Dockerfile`** — multi-stage, distroless. The build stage runs on `$BUILDPLATFORM` and cross-compiles with `$TARGETOS`/`$TARGETARCH` (CGO off → no QEMU). Final stage is `gcr.io/distroless/static-debian12:nonroot`, both base images digest-pinned, runs as uid 65532, `KATA_HOME=/data`, version via `-ldflags -X .../internal/version.*`.
- **`docker-bake.hcl`** (per @mariusvniekerk's suggestion) — `image` target (multi-arch, attested) for release; `image-local` (native, loadable) for dev and the PR smoke test.
- **`.github/workflows/image.yml`** — on a `v*` tag: authenticate to GCP via Workload Identity Federation (no long-lived keys) → buildx-bake build + push to `${{ secrets.AR_HOST }}/${{ secrets.GCP_PROJECT }}/${{ secrets.AR_REPO }}/kata` → cosign keyless sign of the digest → `actions/attest-build-provenance` → `cosign verify` gate (cert-identity = this workflow, issuer = GitHub OIDC). On PRs touching the build, it builds the image and smoke-tests that it runs and is non-root. Actions SHA-pinned to match `test.yml`.
- **`README.md`** — "Container image" section: runtime contract + cosign verification against the AR digest; build locally via `bake image-local`.

## Required repo secrets

Set under **Settings → Secrets and variables → Actions → Secrets**:

- `GCP_PROJECT` — Google Cloud project ID
- `AR_HOST` — Artifact Registry host (e.g. `<region>-docker.pkg.dev`)
- `AR_REPO` — Artifact Registry Docker repository name
- `WIF_PROVIDER` — full Workload Identity provider resource name
- `PUBLISHER_SA` — publisher service account email

They identify the GCP target rather than gate access (WIF + OIDC do that), but storing them as secrets keeps the values out of the public repo's Actions UI and out of workflow logs (auto-masked). The consuming deployment provisions the WIF provider + service account and trusts this repo.

## Acceptance criteria

- [x] `docker build` yields a working image: starts the daemon, non-root, distroless — exercised by the PR `build` job.
- [x] Multi-arch (amd64 + arm64) via the bake `image` target.
- [x] Tagged release authenticates via WIF, publishes to Artifact Registry, cosign-signs keyless, attaches a provenance attestation.
- [x] `cosign verify --certificate-oidc-issuer https://token.actions.githubusercontent.com` with the workflow cert-identity succeeds against the published AR digest (in-workflow gate + documented end-user command).
- [x] Base images digest-pinned; actions SHA-pinned.
- [x] Docs cover `KATA_HOME` volume and TCP `Listen`.

## Notes for reviewers

- **Bind a concrete private IP, not a wildcard.** The daemon rejects `0.0.0.0`/`::` and public IPs, so the container must bind a literal private IP. README uses the Docker static-IP and Kubernetes `status.podIP` patterns.
- WIF auth uses `google-github-actions/auth@v3` with `token_format: access_token`; `docker/login-action` then logs into AR using `oauth2accesstoken` + the access token. No long-lived keys, no Docker passwords.
- SBOM is included via BuildKit `attest type=sbom`; build provenance is attached both in-image (BuildKit, `mode=max`) and as the signed GitHub attestation pushed to AR.

## Test plan

- [x] `go build` cross-compiles static binaries for linux/amd64 and linux/arm64; `version` reports the ldflags-injected values (also with `-s -w`).
- [x] `hadolint Dockerfile`, `actionlint image.yml`, and HCL parse all clean.
- [ ] First `v*` tag (after the repo secrets are set) exercises WIF auth, AR push, cosign sign / attest / verify end-to-end (no GCP creds in the authoring environment).