### PR TITLE
Bind 0.0.0.0:$PORT for PaaS hosting (Heroku, Cloud Run, Fly.io)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,29 @@ A daemon can serve clients on other hosts over a private network:
   `kata init` falls back to a path-based request only when none of
   those sources are available, so the daemon (or its absence) emits
   the existing validation error.
+
+## Hosted mode (`$PORT` convention)
+
+When no `--listen` flag and no config `listen` are set, the daemon binds
+`0.0.0.0:$PORT` if `PORT` is in the environment. This is the contract
+Heroku originated and that Cloud Run, Render, Fly.io, Railway, App
+Engine, and other PaaS runtimes all follow: the platform picks a port,
+injects it via `PORT`, and expects the process to bind every interface
+at `0.0.0.0:$PORT`. The auto-start child sets `KATA_AUTOSTART=1` so a
+stray `PORT` on a developer's machine does not flip implicit local
+daemons onto wildcard TCP.
+
+- Required env on the host: `KATA_AUTH_TOKEN=<token>` plus
+  `KATA_TRUST_PRIVATE_NETWORK=1`. Without both, the daemon refuses the
+  non-loopback bind — the platform terminates TLS upstream, so the
+  operator must explicitly assert trust in the container's network path.
+- `KATA_HOME` must point at a writable path (e.g. `/tmp/kata`); the
+  daemon writes runtime files and the SQLite DB under it. Local container
+  disk is ephemeral, so data does not survive instance recycling unless
+  `KATA_HOME` is backed by a mounted volume or shared storage.
+- Health: `GET /api/v1/health` and `GET /api/v1/ping` are unauthenticated
+  and suitable for platform liveness / readiness probes.
+- Shutdown: the daemon handles SIGTERM gracefully (up to 10s for
+  in-flight requests).
+- Single-instance: kata assumes one daemon per DB; deploying multiple
+  hosted instances without shared storage gives each its own state.

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -263,6 +263,11 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	if listen == "" {
 		listen = dcfg.Listen
 	}
+	if listen == "" {
+		if addr, ok := listenFromPortEnv(); ok {
+			listen = addr
+		}
+	}
 	ns, err := daemon.NewNamespace()
 	if err != nil {
 		return err
@@ -362,6 +367,29 @@ func chooseEndpoint(ns *daemon.Namespace, listen string) (daemon.DaemonEndpoint,
 		return nil, fmt.Errorf("kata daemon: invalid --listen value %q: %v", listen, err)
 	}
 	return daemon.TCPEndpointAny(listen), nil
+}
+
+// listenFromPortEnv reports the bind address to use when the daemon is
+// hosted on a PaaS that follows the Heroku-style $PORT contract. Cloud
+// Run, Render, Fly.io, Railway, and App Engine all work this way: the
+// platform injects PORT into the environment and expects the process to
+// bind every interface at 0.0.0.0:$PORT. Consulted only when neither
+// --listen nor a config value was supplied.
+//
+// The auto-start child inherits the parent environment, so a stray PORT
+// in a developer's shell would otherwise hijack every implicit daemon
+// onto wildcard TCP. We refuse to act on PORT when the auto-start marker
+// (daemon.AutoStartMarkerEnv) is set on the process; daemonclient stamps
+// it on the child to identify itself.
+func listenFromPortEnv() (string, bool) {
+	if os.Getenv(daemon.AutoStartMarkerEnv) == "1" {
+		return "", false
+	}
+	port := strings.TrimSpace(os.Getenv("PORT"))
+	if n, err := strconv.Atoi(port); err != nil || n < 1 || n > 65535 {
+		return "", false
+	}
+	return net.JoinHostPort("0.0.0.0", port), true
 }
 
 // setupHooks loads hooks.toml, materializes $KATA_HOME, and constructs

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -261,11 +261,10 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		return err
 	}
 	if listen == "" {
-		listen = dcfg.Listen
-	}
-	if listen == "" {
-		if addr, ok := listenFromPortEnv(); ok {
-			listen = addr
+		if listen = dcfg.Listen; listen == "" {
+			if addr, ok := listenFromPortEnv(); ok {
+				listen = addr
+			}
 		}
 	}
 	ns, err := daemon.NewNamespace()

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -277,6 +277,56 @@ func TestDaemonStart_ListenFlagRejectsMalformed(t *testing.T) {
 	assert.Contains(t, err.Error(), "--listen")
 }
 
+func TestListenFromPortEnv(t *testing.T) {
+	t.Run("PORT yields wildcard bind", func(t *testing.T) {
+		t.Setenv(daemon.AutoStartMarkerEnv, "")
+		t.Setenv("PORT", "8080")
+		addr, ok := listenFromPortEnv()
+		require.True(t, ok)
+		assert.Equal(t, "0.0.0.0:8080", addr)
+	})
+	t.Run("auto-start marker suppresses PORT reading", func(t *testing.T) {
+		// The implicit auto-start child inherits the parent environment,
+		// so a stray PORT on a developer's shell must not flip it onto
+		// wildcard TCP — the spawner stamps the marker for that reason.
+		t.Setenv(daemon.AutoStartMarkerEnv, "1")
+		t.Setenv("PORT", "8080")
+		_, ok := listenFromPortEnv()
+		assert.False(t, ok)
+	})
+	t.Run("invalid PORT is ignored", func(t *testing.T) {
+		t.Setenv(daemon.AutoStartMarkerEnv, "")
+		t.Setenv("PORT", "not-a-port")
+		_, ok := listenFromPortEnv()
+		assert.False(t, ok)
+	})
+}
+
+// TestDaemonStart_PortEnvBindsWildcard verifies that when the platform
+// injects PORT and the daemon is started explicitly (no auto-start
+// marker), with no --listen flag and no config value, the bind address
+// is derived from PORT as 0.0.0.0:$PORT. With no token configured, the
+// auth-startup guard refuses the non-loopback bind — and the refusal
+// names the derived address, proving the PORT path was taken and the
+// address passed validation.
+func TestDaemonStart_PortEnvBindsWildcard(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_DB", filepath.Join(tmp, "kata.db"))
+	t.Setenv(daemon.AutoStartMarkerEnv, "")
+	t.Setenv("PORT", "8081")
+
+	cmd := newRootCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"daemon", "start"})
+
+	err := cmd.ExecuteContext(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "0.0.0.0:8081")
+}
+
 // TestDaemonStart_ConfigFileListenIsHonored verifies that
 // <KATA_HOME>/config.toml's `listen = ...` value is picked up when the
 // --listen flag is absent. We use an obviously-public address so the

--- a/e2e/port_env_test.go
+++ b/e2e/port_env_test.go
@@ -80,7 +80,7 @@ func TestPortEnvBind_ServesAndShutsDownCleanly(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/api/v1/projects", nil) //nolint:noctx
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+token)
-	authResp, err := client.Do(req)
+	authResp, err := client.Do(req) //nolint:gosec // G107: URL is "http://127.0.0.1:<free-port>" composed from freeTCPPort.
 	require.NoError(t, err)
 	_ = authResp.Body.Close()
 	assert.NotEqual(t, http.StatusUnauthorized, authResp.StatusCode,

--- a/e2e/port_env_test.go
+++ b/e2e/port_env_test.go
@@ -1,0 +1,152 @@
+//go:build !windows
+
+package e2e_test
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPortEnvBind_ServesAndShutsDownCleanly walks the platform-$PORT
+// path end-to-end: with PORT set in the environment, the daemon binds
+// 0.0.0.0:$PORT, /api/v1/health returns 200 unauthenticated, the
+// protected /api/v1/projects route gates on the bearer token, and the
+// daemon exits cleanly on SIGTERM.
+func TestPortEnvBind_ServesAndShutsDownCleanly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e")
+	}
+	bin := buildKataBinary(t)
+
+	port := freeTCPPort(t)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	home := t.TempDir()
+	const token = "e2e-token"
+
+	stderr := &safeBuffer{}
+	//nolint:gosec // G204: bin is buildKataBinary's output
+	cmd := exec.Command(bin, "daemon", "start")
+	cmd.Env = append(os.Environ(),
+		"KATA_HOME="+home,
+		"KATA_DB="+filepath.Join(home, "kata.db"),
+		"KATA_AUTH_TOKEN="+token,
+		"KATA_TRUST_PRIVATE_NETWORK=1",
+		// Defensively clear the marker so a polluted parent env can't
+		// turn this into a Unix-socket run.
+		"KATA_AUTOSTART=",
+		fmt.Sprintf("PORT=%d", port),
+	)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("daemon stderr:\n%s", stderr.String())
+		}
+		// Fallback teardown if the test bailed before SIGTERMing itself.
+		if cmd.ProcessState == nil {
+			stopDaemon(cmd)
+		}
+	})
+
+	waitForPing(t, "http://"+addr, 5*time.Second)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	healthResp, err := client.Get("http://" + addr + "/api/v1/health") //nolint:noctx
+	require.NoError(t, err)
+	_ = healthResp.Body.Close()
+	assert.Equal(t, http.StatusOK, healthResp.StatusCode,
+		"unauthenticated /api/v1/health should 200")
+
+	noTokenResp, err := client.Get("http://" + addr + "/api/v1/projects") //nolint:noctx
+	require.NoError(t, err)
+	_ = noTokenResp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, noTokenResp.StatusCode,
+		"protected GET without token should 401")
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/api/v1/projects", nil) //nolint:noctx
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	authResp, err := client.Do(req)
+	require.NoError(t, err)
+	_ = authResp.Body.Close()
+	assert.NotEqual(t, http.StatusUnauthorized, authResp.StatusCode,
+		"protected GET with valid bearer should not 401")
+
+	// Graceful SIGTERM: the daemon's signal.NotifyContext wiring cancels
+	// the root context, which triggers httpSrv.Shutdown. A clean exit is
+	// code 0; we assert no error from cmd.Wait().
+	require.NoError(t, cmd.Process.Signal(syscall.SIGTERM))
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case waitErr := <-done:
+		assert.NoErrorf(t, waitErr,
+			"daemon should exit cleanly on SIGTERM (stderr: %s)", stderr.String())
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+		t.Fatalf("daemon did not exit within 5s of SIGTERM (stderr: %s)", stderr.String())
+	}
+}
+
+// TestPortEnvBind_AutostartMarkerSuppresses verifies the marker
+// honored by daemonclient.autoStart: when KATA_AUTOSTART=1 is set, a
+// stray PORT in the environment must not flip the daemon onto wildcard
+// TCP. The daemon falls back to the default Unix socket path, the
+// runtime file appears under KATA_HOME, and PORT remains unbound.
+func TestPortEnvBind_AutostartMarkerSuppresses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e")
+	}
+	bin := buildKataBinary(t)
+
+	port := freeTCPPort(t)
+	home := t.TempDir()
+
+	env := append(os.Environ(),
+		"KATA_HOME="+home,
+		"KATA_DB="+filepath.Join(home, "kata.db"),
+		"KATA_AUTOSTART=1",
+		fmt.Sprintf("PORT=%d", port),
+	)
+	stderr := startDaemon(t, bin, env)
+
+	// Wait for the daemon to publish its runtime file — proof that it
+	// finished startup. The Unix-socket path writes the file just like
+	// the TCP path; absence here would mean startup failed.
+	runtimeGlob := filepath.Join(home, "runtime", "*", "daemon.*.json")
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		matches, _ := filepath.Glob(runtimeGlob)
+		if len(matches) > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	matches, _ := filepath.Glob(runtimeGlob)
+	require.NotEmptyf(t, matches,
+		"daemon never wrote a runtime file (stderr: %s)", stderr.String())
+
+	// The key assertion: PORT must remain unbound. If suppression had
+	// failed, the daemon would be accepting on this address.
+	conn, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 250*time.Millisecond)
+	if dialErr == nil {
+		_ = conn.Close()
+		t.Fatalf("PORT %d is bound; auto-start marker should have suppressed the PORT-env path (stderr: %s)",
+			port, stderr.String())
+	}
+}

--- a/internal/daemon/endpoint.go
+++ b/internal/daemon/endpoint.go
@@ -22,6 +22,13 @@ type DaemonEndpoint interface {
 
 type unixEndpoint struct{ path string }
 
+// AutoStartMarkerEnv names the environment variable set on the auto-start
+// child daemon process so it can recognize itself as implicitly spawned.
+// The marker lets the child suppress behavior that should only fire when
+// the daemon is started explicitly — currently, the PORT-env listen path
+// (see cmd/kata listenFromPortEnv). Setter: daemonclient.autoStart.
+const AutoStartMarkerEnv = "KATA_AUTOSTART"
+
 // staleSocketProbeTimeout caps how long the pre-bind probe waits
 // before giving up. A short timeout is enough on a healthy host: a
 // running daemon accepts immediately, and a stale socket whose owner
@@ -116,9 +123,11 @@ func (t tcpAnyEndpoint) Address() string { return t.addr }
 func (t tcpAnyEndpoint) Kind() string    { return "tcp" }
 
 // TCPEndpointAny constructs a TCP endpoint that accepts any non-public
-// address (loopback, RFC1918, CGNAT, link-local, ULA). Public IPv4,
-// GUA IPv6, and unspecified (0.0.0.0 / ::) are rejected. Hostnames are
-// rejected — callers must resolve to a literal IP.
+// address (loopback, RFC1918, CGNAT, link-local, ULA) plus the unspecified
+// wildcard (0.0.0.0 / ::), so the daemon can satisfy the Heroku-style
+// $PORT contract used by PaaS hosting platforms (Cloud Run, Render,
+// Fly.io, Railway, App Engine, etc.). Public IPv4 and GUA IPv6 are
+// rejected. Hostnames are rejected — callers must resolve to a literal IP.
 func TCPEndpointAny(addr string) DaemonEndpoint { return tcpAnyEndpoint{addr: addr} }
 
 // cgnatBlock is RFC6598 100.64.0.0/10 — the carrier-grade NAT range
@@ -138,8 +147,15 @@ var cgnatBlock = &net.IPNet{
 func ValidateNonPublicAddress(addr string) error { return requireNonPublic(addr) }
 
 // requireNonPublic accepts loopback, RFC1918 (via IsPrivate), CGNAT,
-// link-local, and ULA. Rejects public IPv4, GUA IPv6, the unspecified
-// address (0.0.0.0 / ::), and any hostname.
+// link-local, ULA, and the unspecified wildcard (0.0.0.0 / ::). Rejects
+// public IPv4, GUA IPv6, and any hostname.
+//
+// The wildcard is permitted so the daemon can bind every interface to
+// satisfy the Heroku-style $PORT contract used by PaaS hosting platforms
+// (Cloud Run, Render, Fly.io, Railway, App Engine, etc.). This does not
+// weaken exposure control: checkAuthStartup still refuses any non-loopback
+// bind (the wildcard included) unless the operator supplies a bearer
+// token plus trust_private_network, or opts into --insecure-readonly.
 func requireNonPublic(addr string) error {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
@@ -150,7 +166,7 @@ func requireNonPublic(addr string) error {
 		return fmt.Errorf("address %q is not a literal IP (resolve hostnames before calling)", addr)
 	}
 	if ip.IsUnspecified() {
-		return fmt.Errorf("address %q is non-public: unspecified bind not allowed; use a private address (loopback, RFC1918, CGNAT, link-local, ULA)", addr)
+		return nil
 	}
 	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || cgnatBlock.Contains(ip) {
 		return nil

--- a/internal/daemon/endpoint_test.go
+++ b/internal/daemon/endpoint_test.go
@@ -298,11 +298,22 @@ func TestTCPEndpointAny_RejectsGUAIPv6(t *testing.T) {
 	assert.Contains(t, err.Error(), "non-public")
 }
 
-func TestTCPEndpointAny_RejectsUnspecified(t *testing.T) {
+func TestTCPEndpointAny_AcceptsUnspecified(t *testing.T) {
+	// The Heroku-style $PORT contract used by PaaS hosting (Cloud Run,
+	// Render, Fly.io, etc.) requires binding every interface
+	// (0.0.0.0:$PORT), so the address validator must permit the
+	// wildcard. Exposure is gated by checkAuthStartup, not by this
+	// layer. Bind may still fail in an IPv6-less environment ([::]:0),
+	// so we only assert the validator itself does not reject the
+	// address.
 	for _, addr := range []string{"0.0.0.0:0", "[::]:0"} {
-		_, err := daemon.TCPEndpointAny(addr).Listen()
-		require.Error(t, err, addr)
-		assert.Contains(t, err.Error(), "non-public", addr)
+		l, err := daemon.TCPEndpointAny(addr).Listen()
+		if err != nil {
+			assert.NotContains(t, err.Error(), "non-public", addr)
+			assert.NotContains(t, err.Error(), "literal IP", addr)
+			continue
+		}
+		_ = l.Close()
 	}
 }
 

--- a/internal/daemonclient/ensure.go
+++ b/internal/daemonclient/ensure.go
@@ -163,6 +163,11 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 	cmd := exec.Command(exe, "daemon", "start")
 	cmd.Stdout = nil
 	cmd.Stderr = os.Stderr
+	// Mark the child as an implicit auto-start so it skips the PORT-env
+	// listen path (see listenFromPortEnv). The child inherits the
+	// parent's environment, so a stray PORT in a developer's shell would
+	// otherwise flip every implicit daemon onto wildcard TCP.
+	cmd.Env = append(os.Environ(), daemon.AutoStartMarkerEnv+"=1")
 	// Detach the child into its own process group so SIGINT delivered to the
 	// foreground caller (e.g. ctrl-C on `kata create` or `kata tui`) is not
 	// propagated to the daemon we just spawned.


### PR DESCRIPTION
## Summary
- Daemon binds `0.0.0.0:$PORT` when `PORT` is in the environment and neither `--listen` nor config `listen` is set — the contract Heroku originated and that Cloud Run, Render, Fly.io, Railway, and App Engine all follow.
- An auto-start marker (`KATA_AUTOSTART=1`, stamped by `daemonclient.autoStart` on the spawned child) keeps a stray `PORT` in a developer's shell from hijacking implicit local daemons.
- `requireNonPublic` now permits the unspecified wildcard (`0.0.0.0` / `::`); exposure stays gated by `checkAuthStartup`, which still refuses non-loopback binds without a token plus `trust_private_network` (or `--insecure-readonly`).
- `AGENTS.md` gains a "Hosted mode" section covering the env contract, health probes, shutdown, and persistence / single-instance caveats.
- New e2e coverage exercises the real serve path, SIGTERM shutdown, and the autostart suppression.

## Test plan
- [x] `go test ./...` green
- [x] `golangci-lint run` clean on touched packages
- [x] `e2e.TestPortEnvBind_ServesAndShutsDownCleanly` — real bind on `0.0.0.0:$PORT`, `/api/v1/health` returns 200 unauthenticated, `/api/v1/projects` returns 401 without token and not-401 with one, daemon exits cleanly on SIGTERM
- [x] `e2e.TestPortEnvBind_AutostartMarkerSuppresses` — `KATA_AUTOSTART=1` + `PORT` keeps the PORT address unbound and the daemon falls back to the Unix socket path