### PR TITLE
docs: extract hosted-mode detail to docs/hosted-mode.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,26 +99,7 @@ A daemon can serve clients on other hosts over a private network:
 
 ## Hosted mode (`$PORT` convention)
 
-When no `--listen` flag and no config `listen` are set, the daemon binds
-`0.0.0.0:$PORT` if `PORT` is in the environment. This is the contract
-Heroku originated and that Cloud Run, Render, Fly.io, Railway, App
-Engine, and other PaaS runtimes all follow: the platform picks a port,
-injects it via `PORT`, and expects the process to bind every interface
-at `0.0.0.0:$PORT`. The auto-start child sets `KATA_AUTOSTART=1` so a
-stray `PORT` on a developer's machine does not flip implicit local
-daemons onto wildcard TCP.
-
-- Required env on the host: `KATA_AUTH_TOKEN=<token>` plus
-  `KATA_TRUST_PRIVATE_NETWORK=1`. Without both, the daemon refuses the
-  non-loopback bind — the platform terminates TLS upstream, so the
-  operator must explicitly assert trust in the container's network path.
-- `KATA_HOME` must point at a writable path (e.g. `/tmp/kata`); the
-  daemon writes runtime files and the SQLite DB under it. Local container
-  disk is ephemeral, so data does not survive instance recycling unless
-  `KATA_HOME` is backed by a mounted volume or shared storage.
-- Health: `GET /api/v1/health` and `GET /api/v1/ping` are unauthenticated
-  and suitable for platform liveness / readiness probes.
-- Shutdown: the daemon handles SIGTERM gracefully (up to 10s for
-  in-flight requests).
-- Single-instance: kata assumes one daemon per DB; deploying multiple
-  hosted instances without shared storage gives each its own state.
+When hosted on a PaaS that follows the Heroku-style `$PORT` contract
+(Cloud Run, Render, Fly.io, Railway, App Engine, etc.), the daemon
+binds `0.0.0.0:$PORT`. See [`docs/hosted-mode.md`](docs/hosted-mode.md)
+for the required env, health probes, shutdown, and persistence caveats.

--- a/docs/hosted-mode.md
+++ b/docs/hosted-mode.md
@@ -1,0 +1,39 @@
+# Kata hosted mode (`$PORT` convention)
+
+When no `--listen` flag and no config `listen` are set, the daemon binds
+`0.0.0.0:$PORT` if `PORT` is in the environment. This is the contract
+Heroku originated and that Cloud Run, Render, Fly.io, Railway, App
+Engine, and other PaaS runtimes all follow: the platform picks a port,
+injects it via `PORT`, and expects the process to bind every interface
+at `0.0.0.0:$PORT`.
+
+The auto-start child sets `KATA_AUTOSTART=1` so a stray `PORT` on a
+developer's machine does not flip implicit local daemons onto wildcard
+TCP.
+
+## Required environment
+
+- `KATA_AUTH_TOKEN=<token>` plus `KATA_TRUST_PRIVATE_NETWORK=1`. Without
+  both, the daemon refuses the non-loopback bind — the platform
+  terminates TLS upstream, so the operator must explicitly assert trust
+  in the container's network path.
+- `KATA_HOME` must point at a writable path (e.g. `/tmp/kata`); the
+  daemon writes runtime files and the SQLite DB under it. Local
+  container disk is ephemeral, so data does not survive instance
+  recycling unless `KATA_HOME` is backed by a mounted volume or shared
+  storage.
+
+## Health probes
+
+`GET /api/v1/health` and `GET /api/v1/ping` are unauthenticated and
+suitable for platform liveness / readiness probes.
+
+## Shutdown
+
+The daemon handles SIGTERM gracefully (up to 10s for in-flight
+requests).
+
+## Single-instance assumption
+
+kata assumes one daemon per DB; deploying multiple hosted instances
+without shared storage gives each its own state.


### PR DESCRIPTION
Follow-up to #63 addressing review feedback from @mariusvniekerk.

## Summary

`AGENTS.md` is loaded into every session, so per-feature operator detail there is expensive context. Moves the env contract, health probes, shutdown, and persistence / single-instance caveats from `AGENTS.md` into `docs/hosted-mode.md`, leaving a one-paragraph pointer in `AGENTS.md` so an agent still knows hosted mode exists and where to read the details on demand.

## Test plan

- [x] Docs-only change; no Go code or tests touched.