### PR TITLE
Trusted-proxy actor header (refs #58)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ coverage.out
 *~
 .DS_Store
 .kata.local.toml
+# roborev snapshots
+/.roborev/

--- a/docs/superpowers/plans/2026-05-28-trusted-proxy-actor-header.md
+++ b/docs/superpowers/plans/2026-05-28-trusted-proxy-actor-header.md
@@ -1,0 +1,1000 @@
+# Trusted-Proxy Actor Header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Hard dependency:** PR #65 (`fix/simple-token-auth`) must be merged before this plan can be executed. The plan plugs into PR #65's `Principal` type, `WithPrincipal` context helper, `actorFor`, `ensureAttributedWriteAllowed`, and `attributedActor` chokepoint. Tasks reference these symbols directly.
+
+**Goal:** Add a trusted-proxy actor header mode that lets a reverse proxy assert the request actor via a configured header. Coexists with PR #65's token-identity mode at the `attributedActor` chokepoint; both are server-derived attribution modes.
+
+**Architecture:** New `[auth.proxy]` config sub-table plus env overrides. A new `withTrustedProxyActor` middleware (composed inside PR #65's bearer/identity middleware) inspects the request's local addr; on a trusted listener it overwrites the principal with `PrincipalTrustedProxy{Actor: header}` or a `PrincipalTrustedProxyAbsent` sentinel. PR #65's `actorFor` and `ensureAttributedWriteAllowed` are extended to recognize the two new principal kinds — `PrincipalTrustedProxy` returns the proxy-asserted actor (ignoring the body actor); `PrincipalTrustedProxyAbsent` rejects with `400 actor_header_required`. Handler code does not change.
+
+**Tech Stack:** Go, `net/http`, `github.com/danielgtaylor/huma/v2`, `github.com/BurntSushi/toml`, `github.com/stretchr/testify`.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-trusted-proxy-actor-header-design.md`.
+
+---
+
+## File Structure
+
+**Create:**
+- `internal/daemon/trusted_actor.go` — listener matcher + `withTrustedProxyActor` middleware.
+- `internal/daemon/trusted_actor_test.go` — unit tests for the matcher and the middleware matrix.
+- `internal/daemon/trusted_actor_e2e_test.go` — integration tests via `httptest`.
+
+**Modify:**
+- `internal/config/daemon_config.go` — add a `ProxyConfig` struct under `AuthConfig`, parsing the `[auth.proxy]` sub-table; extend `applyDaemonConfigEnv` with the two new env overrides.
+- `internal/config/daemon_config_test.go` — add tests for TOML parse + env overrides for the new keys.
+- `internal/daemon/auth.go` (or wherever PR #65 puts `Principal`/`actorFor`/`ensureAttributedWriteAllowed`):
+  - Add two `PrincipalKind` constants: `PrincipalTrustedProxy`, `PrincipalTrustedProxyAbsent`.
+  - Extend `actorFor` to return the proxy-asserted actor for `PrincipalTrustedProxy`.
+  - Extend `ensureAttributedWriteAllowed` to reject `PrincipalTrustedProxyAbsent` with `400 actor_header_required`.
+- `internal/daemon/auth_test.go` (or the file PR #65 tests `actorFor` in) — add tests for the two new principal-kind branches.
+- `internal/daemon/server.go` — compose `withTrustedProxyActor` into the middleware chain in `NewServer`, inside `requireBearer`/`requireIdentityBearer`.
+
+**Leave alone:**
+- The 26 mutation handlers — PR #65 already swapped them to `attributedActor`. This plan changes nothing in any handler file.
+- Read-only actor-filter handlers (`handlers_events.go`, `handlers_digest.go`, `handlers_audit.go`) — never call `attributedActor`.
+- Every `actor` struct tag in `internal/api/types.go` — schema stays `required:"true"`.
+
+---
+
+## Task 1: Add `[auth.proxy]` config keys
+
+**Files:**
+- Modify: `internal/config/daemon_config.go` (extend `AuthConfig` with a `Proxy ProxyConfig` field; define `ProxyConfig`)
+- Test: `internal/config/daemon_config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/config/daemon_config_test.go`:
+
+```go
+func TestReadDaemonConfig_AuthProxy(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_ACTOR_HEADER", "")
+	t.Setenv("KATA_TRUSTED_PROXY_LISTENERS", "")
+
+	dir := t.TempDir()
+	t.Setenv("KATA_HOME", dir)
+	path := filepath.Join(dir, "config.toml")
+	body := `
+[auth]
+token = "tok"
+
+[auth.proxy]
+trusted_actor_header = "X-Kata-Actor"
+trusted_proxy_listeners = ["unix:///run/kata/proxy.sock", "100.64.0.5:7777"]
+`
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	require.Equal(t, "X-Kata-Actor", cfg.Auth.Proxy.TrustedActorHeader)
+	require.Equal(t,
+		[]string{"unix:///run/kata/proxy.sock", "100.64.0.5:7777"},
+		cfg.Auth.Proxy.TrustedProxyListeners)
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `go test ./internal/config/ -run TestReadDaemonConfig_AuthProxy -v`
+Expected: FAIL — `cfg.Auth.Proxy` undefined or unknown-key TOML error.
+
+- [ ] **Step 3: Add the struct + sub-table parsing**
+
+In `internal/config/daemon_config.go`, extend `AuthConfig` and define `ProxyConfig`:
+
+```go
+type AuthConfig struct {
+	Token               string      `toml:"token"`
+	TrustPrivateNetwork bool        `toml:"trust_private_network"`
+	// ... whatever PR #65 added to AuthConfig (RequireTokenIdentity etc.) stays.
+	Proxy               ProxyConfig `toml:"proxy"`
+}
+
+// ProxyConfig is the [auth.proxy] sub-table. Both keys empty/absent means
+// trusted-proxy actor mode is off; this is the default.
+type ProxyConfig struct {
+	TrustedActorHeader    string   `toml:"trusted_actor_header"`
+	TrustedProxyListeners []string `toml:"trusted_proxy_listeners"`
+}
+```
+
+Extend the trim block in `ReadDaemonConfig`:
+
+```go
+cfg.Listen = strings.TrimSpace(cfg.Listen)
+cfg.Auth.Token = strings.TrimSpace(cfg.Auth.Token)
+cfg.Auth.Proxy.TrustedActorHeader = strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `go test ./internal/config/ -run TestReadDaemonConfig_AuthProxy -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full config package suite**
+
+Run: `go test ./internal/config/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/daemon_config.go internal/config/daemon_config_test.go
+git commit -m "feat: add [auth.proxy] config sub-table for trusted-proxy actor header"
+```
+
+---
+
+## Task 2: Apply env overrides for the two new keys
+
+**Files:**
+- Modify: `internal/config/daemon_config.go` (extend `applyDaemonConfigEnv`)
+- Test: `internal/config/daemon_config_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/config/daemon_config_test.go`:
+
+```go
+func TestApplyDaemonConfigEnv_AuthProxyHeader(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_ACTOR_HEADER", "X-Env-Actor")
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth.proxy]\ntrusted_actor_header = \"X-Toml-Actor\"\n"), 0o600))
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	require.Equal(t, "X-Env-Actor", cfg.Auth.Proxy.TrustedActorHeader,
+		"KATA_TRUSTED_ACTOR_HEADER must override config.toml")
+}
+
+func TestApplyDaemonConfigEnv_AuthProxyListeners(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_PROXY_LISTENERS",
+		"unix:///s1 , 100.64.0.5:7777 ,, ")
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth.proxy]\ntrusted_proxy_listeners = [\"unix:///toml-only\"]\n"), 0o600))
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"unix:///s1", "100.64.0.5:7777"},
+		cfg.Auth.Proxy.TrustedProxyListeners,
+		"KATA_TRUSTED_PROXY_LISTENERS must split on commas, trim, drop empties, override config.toml")
+}
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `go test ./internal/config/ -run TestApplyDaemonConfigEnv_AuthProxy -v`
+Expected: FAIL — env variables not applied yet.
+
+- [ ] **Step 3: Extend `applyDaemonConfigEnv`**
+
+In `internal/config/daemon_config.go`, add inside `applyDaemonConfigEnv` (after the existing token / trust_private_network branches PR #65 left in place):
+
+```go
+if v := strings.TrimSpace(os.Getenv("KATA_TRUSTED_ACTOR_HEADER")); v != "" {
+	cfg.Auth.Proxy.TrustedActorHeader = v
+}
+if raw := os.Getenv("KATA_TRUSTED_PROXY_LISTENERS"); raw != "" {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	cfg.Auth.Proxy.TrustedProxyListeners = out
+}
+```
+
+`os.Getenv` + non-empty matches the existing `KATA_AUTH_TOKEN` pattern (empty string = no override) and keeps Task 1's TOML test compatible.
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `go test ./internal/config/ -run TestApplyDaemonConfigEnv_AuthProxy -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full config package suite**
+
+Run: `go test ./internal/config/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/daemon_config.go internal/config/daemon_config_test.go
+git commit -m "feat: add env overrides for [auth.proxy] keys"
+```
+
+---
+
+## Task 3: Listener-trust matcher
+
+**Files:**
+- Create: `internal/daemon/trusted_actor.go`
+- Create: `internal/daemon/trusted_actor_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/daemon/trusted_actor_test.go`:
+
+```go
+package daemon
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListenerTrusted(t *testing.T) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", "100.64.0.5:7777")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unixAddr := &net.UnixAddr{Name: "/run/kata/proxy.sock", Net: "unix"}
+	otherTCP, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:9999")
+
+	cases := []struct {
+		name      string
+		local     net.Addr
+		allowlist []string
+		want      bool
+	}{
+		{"empty allowlist", tcpAddr, nil, false},
+		{"nil addr", nil, []string{"100.64.0.5:7777"}, false},
+		{"tcp match", tcpAddr, []string{"100.64.0.5:7777"}, true},
+		{"tcp no match", otherTCP, []string{"100.64.0.5:7777"}, false},
+		{"unix match with prefix", unixAddr, []string{"unix:///run/kata/proxy.sock"}, true},
+		{"unix match plain path", unixAddr, []string{"/run/kata/proxy.sock"}, true},
+		{"unix no match", unixAddr, []string{"/different/path"}, false},
+		{"whitespace in entry trimmed", tcpAddr, []string{"  100.64.0.5:7777 "}, true},
+		{"wildcard 0.0.0.0 never matches", tcpAddr, []string{"0.0.0.0:7777"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := listenerTrusted(tc.local, tc.allowlist)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails (compile error)**
+
+Run: `go test ./internal/daemon/ -run TestListenerTrusted -v`
+Expected: FAIL — `undefined: listenerTrusted`.
+
+- [ ] **Step 3: Implement the matcher**
+
+Create `internal/daemon/trusted_actor.go`:
+
+```go
+package daemon
+
+import (
+	"net"
+	"strings"
+)
+
+// listenerTrusted reports whether localAddr matches one of the configured
+// trusted-proxy-listener entries. Entries are normalized by trimming
+// whitespace and any "unix://" prefix; the local addr's String() is
+// compared verbatim (for Unix sockets that's the path; for TCP it's
+// host:port with brackets for IPv6).
+//
+// A wildcard bind ("0.0.0.0:7777", "[::]:7777") reports a specific
+// interface IP per accepted connection, never the wildcard, so a
+// wildcard entry never matches. Operators should list literal bind
+// addresses (a Unix socket or a specific private IP).
+func listenerTrusted(localAddr net.Addr, allowlist []string) bool {
+	if localAddr == nil || len(allowlist) == 0 {
+		return false
+	}
+	local := localAddr.String()
+	for _, entry := range allowlist {
+		if normalizeListenerEntry(entry) == local {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeListenerEntry(s string) string {
+	s = strings.TrimSpace(s)
+	return strings.TrimPrefix(s, "unix://")
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `go test ./internal/daemon/ -run TestListenerTrusted -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/daemon/trusted_actor.go internal/daemon/trusted_actor_test.go
+git commit -m "feat: add listener-trust matcher for trusted-proxy actor mode"
+```
+
+---
+
+## Task 4: Add `PrincipalTrustedProxy` and `PrincipalTrustedProxyAbsent` kinds
+
+**Files:**
+- Modify: wherever PR #65 defines `PrincipalKind` and the existing constants (likely `internal/daemon/auth.go`).
+- Test: wherever PR #65 tests `PrincipalKind`/`Principal`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to PR #65's principal test file (or create `internal/daemon/principal_proxy_test.go` if there's no obvious home):
+
+```go
+func TestPrincipalKind_TrustedProxyConstants(t *testing.T) {
+	// The two new kinds must be distinct values that round-trip through
+	// the existing String() / printable form PR #65 provides on
+	// PrincipalKind (so logs and audit reads don't collapse them).
+	assert.NotEqual(t, PrincipalTrustedProxy, PrincipalTrustedProxyAbsent)
+	assert.NotEqual(t, PrincipalTrustedProxy, PrincipalDBToken)
+	assert.NotEqual(t, PrincipalTrustedProxy, PrincipalStaticToken)
+	assert.NotEqual(t, PrincipalTrustedProxy, PrincipalBootstrap)
+	// If PR #65 added a Stringer on PrincipalKind, lock the names:
+	// assert.Equal(t, "trusted_proxy", PrincipalTrustedProxy.String())
+	// assert.Equal(t, "trusted_proxy_absent", PrincipalTrustedProxyAbsent.String())
+}
+```
+
+(Adjust to whatever surface PR #65 exposes on `PrincipalKind` — the test should at minimum lock the new constants as distinct values.)
+
+- [ ] **Step 2: Run the test and verify it fails (compile error: undefined constants)**
+
+Run: `go test ./internal/daemon/ -run TestPrincipalKind_TrustedProxyConstants -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the new principal kinds**
+
+In the file where PR #65 defines `PrincipalKind`, extend the constant block:
+
+```go
+const (
+	// ... PR #65's existing kinds: PrincipalStaticToken, PrincipalBootstrap, PrincipalDBToken
+	PrincipalTrustedProxy        // set by the trusted-proxy middleware when the header is present.
+	PrincipalTrustedProxyAbsent  // set by the trusted-proxy middleware when the header is missing/empty on a trusted listener.
+)
+```
+
+If PR #65 added a `Stringer` on `PrincipalKind`, extend its switch with the two new cases.
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `go test ./internal/daemon/ -run TestPrincipalKind_TrustedProxyConstants -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/daemon/auth.go internal/daemon/principal_proxy_test.go
+git commit -m "feat: add trusted-proxy principal kinds"
+```
+
+(File names depend on where PR #65 put things.)
+
+---
+
+## Task 5: `withTrustedProxyActor` middleware + matrix test
+
+**Files:**
+- Modify: `internal/daemon/trusted_actor.go`
+- Modify: `internal/daemon/trusted_actor_test.go`
+
+- [ ] **Step 1: Write the failing matrix test**
+
+Append to `internal/daemon/trusted_actor_test.go`. Extend the import block with:
+- `"context"`, `"net/http"`, `"net/http/httptest"`
+- `"github.com/stretchr/testify/require"`
+- `"go.kenn.io/kata/internal/config"`
+
+```go
+func TestWithTrustedProxyActor_Matrix(t *testing.T) {
+	tcpAddr, _ := net.ResolveTCPAddr("tcp", "100.64.0.5:7777")
+	otherTCP, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:9999")
+
+	type want struct {
+		kind  PrincipalKind // zero value = principal unchanged
+		actor string
+	}
+	cases := []struct {
+		name     string
+		header   string
+		local    net.Addr
+		auth     config.AuthConfig
+		// optional "incoming" principal set by PR #65's bearer middleware;
+		// the trusted-proxy middleware should only overwrite it on a trusted listener.
+		incoming Principal
+		want     want
+	}{
+		{
+			name:   "mode off, no header set",
+			header: "", local: tcpAddr,
+			auth:     config.AuthConfig{},
+			incoming: Principal{Kind: PrincipalDBToken, Actor: "alice"},
+			want:     want{kind: PrincipalDBToken, actor: "alice"}, // unchanged
+		},
+		{
+			name:   "mode off, header sent but ignored",
+			header: "alice", local: tcpAddr,
+			auth:     config.AuthConfig{Proxy: config.ProxyConfig{TrustedProxyListeners: []string{"100.64.0.5:7777"}}},
+			incoming: Principal{},
+			want:     want{},
+		},
+		{
+			name:   "mode on, untrusted listener",
+			header: "alice", local: otherTCP,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			incoming: Principal{Kind: PrincipalDBToken, Actor: "alice"},
+			want:     want{kind: PrincipalDBToken, actor: "alice"}, // unchanged
+		},
+		{
+			name:   "mode on, trusted listener, header set -> overwrite",
+			header: "alice", local: tcpAddr,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			incoming: Principal{Kind: PrincipalDBToken, Actor: "token-bob"},
+			want:     want{kind: PrincipalTrustedProxy, actor: "alice"},
+		},
+		{
+			name:   "mode on, trusted listener, header missing -> absent",
+			header: "", local: tcpAddr,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			want: want{kind: PrincipalTrustedProxyAbsent},
+		},
+		{
+			name:   "mode on, trusted listener, whitespace-only header -> absent",
+			header: "   ", local: tcpAddr,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			want: want{kind: PrincipalTrustedProxyAbsent},
+		},
+		{
+			name:   "mode on, trusted listener, header trimmed before storing",
+			header: "  bob  ", local: tcpAddr,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			want: want{kind: PrincipalTrustedProxy, actor: "bob"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got Principal
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if p, ok := PrincipalFromContext(r.Context()); ok {
+					got = p
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+			h := withTrustedProxyActor(ServerConfig{Auth: tc.auth})(next)
+
+			req := httptest.NewRequest("POST", "/x", nil)
+			if tc.header != "" {
+				req.Header.Set("X-Kata-Actor", tc.header)
+			}
+			ctx := context.WithValue(req.Context(), http.LocalAddrContextKey, tc.local)
+			// Simulate the upstream bearer middleware having already set a principal:
+			if tc.incoming.Kind != 0 {
+				ctx = WithPrincipal(ctx, tc.incoming)
+			}
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, tc.want.kind, got.Kind)
+			assert.Equal(t, tc.want.actor, got.Actor)
+		})
+	}
+}
+```
+
+(`PrincipalFromContext` and `WithPrincipal` are PR #65's helpers — confirm exact names after #65 merges.)
+
+- [ ] **Step 2: Run the test and verify it fails (compile error)**
+
+Run: `go test ./internal/daemon/ -run TestWithTrustedProxyActor_Matrix -v`
+Expected: FAIL — `undefined: withTrustedProxyActor`.
+
+- [ ] **Step 3: Implement the middleware**
+
+Append to `internal/daemon/trusted_actor.go`. Extend the import block with `"context"`, `"net/http"`:
+
+```go
+// withTrustedProxyActor inspects each request's local address and, on a
+// trusted listener, overwrites the request principal with a
+// PrincipalTrustedProxy carrying the header value. A missing or empty
+// header on a trusted listener becomes a PrincipalTrustedProxyAbsent
+// sentinel. The middleware never rejects on its own; rejection is left to
+// ensureAttributedWriteAllowed so read-only paths (which never call
+// attributedActor) are not blocked.
+func withTrustedProxyActor(cfg ServerConfig) func(http.Handler) http.Handler {
+	headerName := strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
+	allowlist := cfg.Auth.Proxy.TrustedProxyListeners
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if headerName == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			localAddr, _ := r.Context().Value(http.LocalAddrContextKey).(net.Addr)
+			if !listenerTrusted(localAddr, allowlist) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			raw := strings.TrimSpace(r.Header.Get(headerName))
+			var ctx context.Context
+			if raw != "" {
+				ctx = WithPrincipal(r.Context(), Principal{
+					Kind:  PrincipalTrustedProxy,
+					Actor: raw,
+				})
+			} else {
+				ctx = WithPrincipal(r.Context(), Principal{
+					Kind: PrincipalTrustedProxyAbsent,
+				})
+			}
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `go test ./internal/daemon/ -run TestWithTrustedProxyActor_Matrix -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/daemon/trusted_actor.go internal/daemon/trusted_actor_test.go
+git commit -m "feat: add withTrustedProxyActor middleware"
+```
+
+---
+
+## Task 6: Extend `actorFor` + `ensureAttributedWriteAllowed` for the new kinds
+
+**Files:**
+- Modify: wherever PR #65 defines `actorFor` and `ensureAttributedWriteAllowed` (likely `internal/daemon/auth.go` or `internal/daemon/server.go`).
+- Test: wherever PR #65 tests them.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```go
+func TestActorFor_TrustedProxy(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), Principal{
+		Kind:  PrincipalTrustedProxy,
+		Actor: "proxy-user",
+	})
+	got := actorFor(ctx, "client-claim")
+	assert.Equal(t, "proxy-user", got, "trusted-proxy principal wins over supplied actor")
+}
+
+func TestEnsureAttributedWriteAllowed_TrustedProxyAbsent(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), Principal{
+		Kind: PrincipalTrustedProxyAbsent,
+	})
+	err := ensureAttributedWriteAllowed(ctx)
+	require.Error(t, err)
+
+	var apiErr *api.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, 400, apiErr.Status)
+	assert.Equal(t, "actor_header_required", apiErr.Code)
+}
+
+func TestEnsureAttributedWriteAllowed_TrustedProxyAllowed(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), Principal{
+		Kind:  PrincipalTrustedProxy,
+		Actor: "proxy-user",
+	})
+	require.NoError(t, ensureAttributedWriteAllowed(ctx),
+		"PrincipalTrustedProxy must be allowed to do attributed writes")
+}
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `go test ./internal/daemon/ -run TestActorFor_TrustedProxy -run TestEnsureAttributedWriteAllowed_TrustedProxy -v`
+Expected: FAIL — the existing `actorFor` / `ensureAttributedWriteAllowed` don't recognize the new kinds.
+
+- [ ] **Step 3: Extend the resolvers**
+
+Add the two new branches to PR #65's existing functions:
+
+```go
+func actorFor(ctx context.Context, requestActor string) string {
+	if p, ok := PrincipalFromContext(ctx); ok {
+		switch p.Kind {
+		// ... PR #65's existing cases (PrincipalDBToken returns p.Actor, etc.) ...
+		case PrincipalTrustedProxy:
+			return p.Actor
+		}
+	}
+	return requestActor
+}
+
+func ensureAttributedWriteAllowed(ctx context.Context) error {
+	if p, ok := PrincipalFromContext(ctx); ok {
+		switch p.Kind {
+		// ... PR #65's existing cases (PrincipalBootstrap rejects, etc.) ...
+		case PrincipalTrustedProxyAbsent:
+			return api.NewError(400, "actor_header_required",
+				"actor header required on this listener but was missing or empty",
+				"", nil)
+		}
+	}
+	return nil
+}
+```
+
+(Adjust to match PR #65's exact switch shape; the new branches go alongside the existing ones.)
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `go test ./internal/daemon/ -run TestActorFor_TrustedProxy -run TestEnsureAttributedWriteAllowed_TrustedProxy -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/daemon/auth.go internal/daemon/auth_test.go
+git commit -m "feat: route trusted-proxy principals through attributedActor"
+```
+
+---
+
+## Task 7: Wire `withTrustedProxyActor` into the middleware chain
+
+**Files:**
+- Modify: `internal/daemon/server.go`
+
+- [ ] **Step 1: Update the handler composition**
+
+In `NewServer`, locate the line that builds the handler chain after PR #65 (something like):
+
+```go
+s.handler = withCSRFGuards(requireBearer(cfg.authPolicy())(mux))
+```
+
+or (if PR #65's identity-bearer wraps it):
+
+```go
+s.handler = withCSRFGuards(requireIdentityBearer(...)(mux))
+```
+
+Insert `withTrustedProxyActor(cfg)` just inside the auth middleware so it runs after the principal is initialized:
+
+```go
+s.handler = withCSRFGuards(requireBearer(cfg.authPolicy())(withTrustedProxyActor(cfg)(mux)))
+```
+
+- [ ] **Step 2: Run the full daemon test suite to confirm nothing regressed**
+
+Run: `go test ./internal/daemon/`
+Expected: PASS — with no `Auth.Proxy.TrustedActorHeader` set in existing test configs, `withTrustedProxyActor` is a pass-through.
+
+- [ ] **Step 3: Run the linter**
+
+Run: `nix run 'nixpkgs#golangci-lint' -- run ./internal/daemon/`
+Expected: zero warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/daemon/server.go
+git commit -m "feat: wire withTrustedProxyActor into the middleware chain"
+```
+
+---
+
+## Task 8: Integration test — trusted listener credits the header value
+
+**Files:**
+- Create: `internal/daemon/trusted_actor_e2e_test.go`
+
+This test uses a pre-bound TCP listener so the trusted-listener allowlist can be set before `NewServer` builds the middleware chain.
+
+- [ ] **Step 1: Write the test**
+
+Create `internal/daemon/trusted_actor_e2e_test.go`:
+
+```go
+package daemon_test
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+)
+
+// startTrustedProxyTestServer binds a loopback TCP listener, builds a
+// daemon.Server whose trusted-proxy allowlist contains that listener's
+// address, and swaps the listener into httptest. Pre-binding is necessary
+// because the allowlist is captured at NewServer time and
+// httptest.NewServer would pick its own random port.
+func startTrustedProxyTestServer(t *testing.T, headerName string, database *db.DB) *httptest.Server {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	cfg := daemon.ServerConfig{
+		DB:        database,
+		StartedAt: time.Now(),
+		Auth: config.AuthConfig{
+			Proxy: config.ProxyConfig{
+				TrustedActorHeader:    headerName,
+				TrustedProxyListeners: []string{l.Addr().String()},
+			},
+		},
+	}
+	srv := daemon.NewServer(cfg)
+	ts := httptest.NewUnstartedServer(srv.Handler())
+	require.NoError(t, ts.Listener.Close())
+	ts.Listener = l
+	ts.Start()
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestTrustedProxyHeader_CreditsHeaderActor(t *testing.T) {
+	// Open a test DB the same way other handler tests do — look in
+	// internal/daemon/testhelpers_test.go for the established pattern
+	// (e.g., openTestDB) and call it directly rather than going through
+	// bootstrapProject, which builds its own server we can't swap a
+	// listener into.
+	tdb := openTestDB(t)
+
+	ts := startTrustedProxyTestServer(t, "X-Kata-Actor", tdb)
+
+	// Seed via HTTP setup helpers. Issue creation calls attributedActor
+	// (post-PR-#65), so pass X-Kata-Actor on the issue-create call.
+	// initProject does not call attributedActor; the header is optional
+	// there but harmless.
+	projectID := trustedProxyCreateProject(t, ts, map[string]string{"X-Kata-Actor": "setup"})
+	issueRef := trustedProxyCreateIssue(t, ts, projectID, map[string]string{"X-Kata-Actor": "setup"})
+
+	body := map[string]any{
+		"actor":   "client-claim",
+		"reason":  "done",
+		"message": "verified end-to-end after the fix landed.",
+		"source":  "tui",
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, map[string]string{"X-Kata-Actor": "proxy-user"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
+
+	var payload struct {
+		Event *struct {
+			Actor string `json:"actor"`
+		} `json:"event"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	require.NotNil(t, payload.Event)
+	assert.Equal(t, "proxy-user", payload.Event.Actor,
+		"event.actor must reflect the header value, not the body actor")
+}
+```
+
+`doReq` already exists in `internal/daemon/testhelpers_test.go`. `openTestDB`, `trustedProxyCreateProject`, `trustedProxyCreateIssue` are stand-in names — replace with the actual db-setup helper used by `bootstrapProject` and two small local helpers that POST to `/api/v1/projects` (`initProject`) and `/api/v1/projects/{id}/issues` (`createIssue`) via `postJSON`.
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `go test ./internal/daemon/ -run TestTrustedProxyHeader_CreditsHeaderActor -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/daemon/trusted_actor_e2e_test.go
+git commit -m "test: integration test that trusted header is credited as actor"
+```
+
+---
+
+## Task 9: Integration test — trusted listener, missing header rejects with 400
+
+**Files:**
+- Modify: `internal/daemon/trusted_actor_e2e_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Append:
+
+```go
+func TestTrustedProxyHeader_MissingHeaderRejects(t *testing.T) {
+	tdb := openTestDB(t)
+	ts := startTrustedProxyTestServer(t, "X-Kata-Actor", tdb)
+
+	projectID := trustedProxyCreateProject(t, ts, map[string]string{"X-Kata-Actor": "setup"})
+	issueRef := trustedProxyCreateIssue(t, ts, projectID, map[string]string{"X-Kata-Actor": "setup"})
+
+	body := map[string]any{
+		"actor":   "client-claim",
+		"reason":  "done",
+		"message": "should be rejected because header is missing.",
+		"source":  "tui",
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, nil) // no X-Kata-Actor on the close call
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body: %s", raw)
+
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "actor_header_required", env.Error.Code)
+}
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `go test ./internal/daemon/ -run TestTrustedProxyHeader_MissingHeaderRejects -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/daemon/trusted_actor_e2e_test.go
+git commit -m "test: integration test that missing header on trusted listener rejects"
+```
+
+---
+
+## Task 10: Integration test — reads on a trusted listener are not blocked
+
+**Files:**
+- Modify: `internal/daemon/trusted_actor_e2e_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Append:
+
+```go
+func TestTrustedProxyHeader_ReadsNotBlocked(t *testing.T) {
+	tdb := openTestDB(t)
+	ts := startTrustedProxyTestServer(t, "X-Kata-Actor", tdb)
+
+	// GET /api/v1/health is a read with no actor and no required setup.
+	// On a trusted listener with no header, the middleware stores a
+	// trusted-but-absent principal; the health handler never calls
+	// attributedActor, so it must still return 200.
+	resp, raw := doReq(t, ts, "GET", "/api/v1/health", nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
+}
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `go test ./internal/daemon/ -run TestTrustedProxyHeader_ReadsNotBlocked -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/daemon/trusted_actor_e2e_test.go
+git commit -m "test: integration test that reads on trusted listener are not blocked"
+```
+
+---
+
+## Task 11: Integration test — mode-off path is unchanged
+
+**Files:**
+- Modify: `internal/daemon/trusted_actor_e2e_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Append:
+
+```go
+func TestTrustedProxyHeader_ModeOffUnchanged(t *testing.T) {
+	// Mode off (empty TrustedActorHeader). The header is ignored, and the
+	// body actor (or whatever PR #65's other principal sources produce) is
+	// used as today.
+	tdb := openTestDB(t)
+	ts := startTrustedProxyTestServer(t, "" /* mode off */, tdb)
+
+	projectID := trustedProxyCreateProject(t, ts, nil)
+	issueRef := trustedProxyCreateIssue(t, ts, projectID, nil)
+
+	body := map[string]any{
+		"actor":   "client-claim",
+		"reason":  "done",
+		"message": "mode off; body actor must be used.",
+		"source":  "tui",
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, map[string]string{"X-Kata-Actor": "should-be-ignored"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
+
+	var payload struct {
+		Event *struct {
+			Actor string `json:"actor"`
+		} `json:"event"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	require.NotNil(t, payload.Event)
+	assert.Equal(t, "client-claim", payload.Event.Actor,
+		"mode off: header is ignored, body actor wins")
+}
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `go test ./internal/daemon/ -run TestTrustedProxyHeader_ModeOffUnchanged -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run the entire test + lint pipeline one final time**
+
+Run: `go test ./... && nix run 'nixpkgs#golangci-lint' -- run`
+Expected: full PASS, zero warnings across the whole repo.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/daemon/trusted_actor_e2e_test.go
+git commit -m "test: integration test that mode-off path is byte-for-byte unchanged"
+```
+
+---
+
+## Done
+
+When all 11 tasks are complete:
+
+- `feat/issue-58` carries the design spec (already committed) plus the implementation: `[auth.proxy]` config keys, env overrides, listener matcher, two new principal kinds, the `withTrustedProxyActor` middleware, the chokepoint extensions to `actorFor` and `ensureAttributedWriteAllowed`, the wiring, and four integration tests (header credited, missing header rejects, reads not blocked, mode-off unchanged).
+- Every acceptance criterion from issue #58 is mapped to a task: config + env (Tasks 1-2), trusted listener credits header / conflict ignored (Task 8), missing header rejects (Task 9), non-trusted listener ignores header (Task 5 matrix), mode-off byte-for-byte unchanged (Task 11), middleware matrix + chokepoint unit tests (Tasks 5 + 6).
+- Confirm with the user before pushing or marking the existing draft PR ready for review.

--- a/docs/superpowers/specs/2026-05-27-trusted-proxy-actor-header-design.md
+++ b/docs/superpowers/specs/2026-05-27-trusted-proxy-actor-header-design.md
@@ -67,12 +67,17 @@ env var is more dangerous than the friction of a config edit.
 
 Resolution rules after env + TOML merge:
 
-- `trusted_actor_header` empty → mode **off**. The header (if any) is ignored
-  everywhere; PR #65 behavior is unchanged.
-- `trusted_actor_header` non-empty, `trusted_proxy_listeners` empty → no
-  listener ever matches, so the header is ignored on every request. Observable
-  behavior is identical to off, but it is a misconfiguration worth calling out
-  in operator docs.
+- `trusted_actor_header` empty, `trusted_proxy_listeners` any → mode **off**.
+  The header (if any) is ignored everywhere; PR #65 behavior is unchanged.
+  Listeners-without-header is accepted as dead config (no security impact:
+  with no header name, no overwrite ever happens).
+- `trusted_actor_header` non-empty, `trusted_proxy_listeners` empty →
+  **rejected at config load** with an error naming the missing key. A silent
+  no-op here is dangerous: an operator who typos the listener address (or
+  forgets it) would believe proxy attribution is on while body-supplied actors
+  continue to flow through. Implementers: `ReadDaemonConfig` must return an
+  error in this case after the env+TOML merge so an env-supplied listener can
+  complete a TOML-supplied header (and vice versa).
 - `trusted_actor_header` non-empty, `trusted_proxy_listeners` non-empty → mode
   **on** for the listed listeners; other listeners pass through untouched.
 
@@ -150,9 +155,12 @@ The middleware never rejects on its own; rejection is decided downstream in
 functions) are never blocked.
 
 If the proxy ever sends multiple values for the configured header, the
-middleware reads only the first value (Go's `r.Header.Get` semantics). Operator
-docs should require a single value at the proxy boundary so this never matters
-in practice.
+middleware silently uses the first value (Go's `r.Header.Get` semantics) — no
+log, no rejection. This is intentional: detecting and reacting to malformed
+proxy behavior is the proxy operator's job, not the daemon's, and adding a log
+line per request would just be noise on every well-formed deployment. Operator
+docs must require a single value at the proxy boundary so this case never
+arises in practice.
 
 ### 3.3 Integration with PR #65's `attributedActor` chokepoint
 
@@ -206,11 +214,15 @@ Two consequences of the overwrite-on-trusted-listener rule:
   guidance is to terminate each mode on its own listener (a Unix socket for
   the proxy; a TCP port for direct token-holding clients).
 - Token-admin endpoints (`POST /api/v1/tokens`, `GET /api/v1/tokens`,
-  `POST /api/v1/tokens/{id}/actions/revoke`) reject `PrincipalTrustedProxy`
-  via PR #65's `ensureTokenAdminAllowed`, which admits only
+  `POST /api/v1/tokens/{id}/actions/revoke`) reject **both** trusted-proxy
+  principal kinds — `PrincipalTrustedProxy` and `PrincipalTrustedProxyAbsent` —
+  via PR #65's `ensureTokenAdminAllowed`, which is allow-list and admits only
   `PrincipalBootstrap`, `PrincipalStaticToken`, or no-principal. A
-  trusted-proxy front-end cannot mint or revoke tokens; that capability stays
-  bound to the bootstrap actor.
+  trusted-proxy front-end cannot mint or revoke tokens whether or not it
+  supplies the header; that capability stays bound to the bootstrap actor.
+  Both branches are pinned by tests
+  (`TestTrustedProxyHeader_TokenAdminForbidden` for the header-present case,
+  `TestTrustedProxyHeader_TokenAdminForbiddenWithoutHeader` for absent).
 
 ### 3.5 Schema stays required
 

--- a/docs/superpowers/specs/2026-05-27-trusted-proxy-actor-header-design.md
+++ b/docs/superpowers/specs/2026-05-27-trusted-proxy-actor-header-design.md
@@ -19,8 +19,13 @@ user (SSO, OAuth, mutual-TLS, whatever), and asserts the actor via a configured
 HTTP header over a daemon path only the proxy can reach.
 
 Token identity and trusted-proxy identity are two **server-derived actor
-modes**. Both ignore client-supplied actor fields. Neither falls back to body or
-query actor when enabled. An operator picks one based on their deployment:
+modes**. Both ignore client-supplied actor fields where they apply. Token
+identity applies on every request the daemon accepts (PR #65). Trusted-proxy
+identity applies only to requests that arrive on a configured trusted listener;
+requests on any other listener follow PR #65's existing rules unchanged. Within
+the scope where a mode applies, there is no fallback to a body or query actor.
+An operator picks one mode (or both, on different listeners) based on their
+deployment:
 
 | Mode | Auth boundary | Actor source | Best for |
 |------|---------------|--------------|----------|
@@ -53,12 +58,25 @@ Environment overrides match the existing style (`KATA_AUTH_TOKEN`,
 - `KATA_TRUSTED_ACTOR_HEADER` — string; overrides `trusted_actor_header`.
 - `KATA_TRUSTED_PROXY_LISTENERS` — comma-separated list; overrides
   `trusted_proxy_listeners`. Entries are trimmed; empty entries are dropped.
-  Treats empty/unset env value as "no override" (matches `KATA_AUTH_TOKEN`).
 
-The mode is **on** only when `trusted_actor_header` is non-empty after
-resolution. `trusted_proxy_listeners` with an empty header is inert (header off
-wins). Absent everywhere = off; existing configs parse and behave exactly as
-before.
+Both env vars treat empty/unset as "no override" (matches `KATA_AUTH_TOKEN`):
+an operator cannot disable a TOML-enabled mode by setting the env var to an
+empty string. Disabling the mode requires editing config.toml. This is
+intentional — silently turning off a security-affecting config from an empty
+env var is more dangerous than the friction of a config edit.
+
+Resolution rules after env + TOML merge:
+
+- `trusted_actor_header` empty → mode **off**. The header (if any) is ignored
+  everywhere; PR #65 behavior is unchanged.
+- `trusted_actor_header` non-empty, `trusted_proxy_listeners` empty → no
+  listener ever matches, so the header is ignored on every request. Observable
+  behavior is identical to off, but it is a misconfiguration worth calling out
+  in operator docs.
+- `trusted_actor_header` non-empty, `trusted_proxy_listeners` non-empty → mode
+  **on** for the listed listeners; other listeners pass through untouched.
+
+Absent everywhere = off; existing configs parse and behave exactly as before.
 
 ### 2.1 Listener address forms
 
@@ -131,6 +149,11 @@ The middleware never rejects on its own; rejection is decided downstream in
 `attributedActor` / `actorFor` so read-only requests (which do not call those
 functions) are never blocked.
 
+If the proxy ever sends multiple values for the configured header, the
+middleware reads only the first value (Go's `r.Header.Get` semantics). Operator
+docs should require a single value at the proxy boundary so this never matters
+in practice.
+
 ### 3.3 Integration with PR #65's `attributedActor` chokepoint
 
 PR #65 lands one chokepoint for all attributed writes:
@@ -162,7 +185,34 @@ kind** rather than introducing a parallel resolver:
 All 26 mutation handlers PR #65 swapped to `attributedActor` automatically pick
 up the new attribution source — no further handler edits.
 
-### 3.4 Schema stays required
+### 3.4 Principal precedence
+
+`withTrustedProxyActor` overwrites whichever principal PR #65 already attached
+to the request when the request lands on a trusted listener and the mode is on.
+The full matrix:
+
+| Listener trusted? | Header set? | Mode | Principal on ctx after middleware | Mutation outcome via `attributedActor` |
+|-------------------|-------------|------|------------------------------------|----------------------------------------|
+| n/a | n/a | off | Whatever PR #65 set (`StaticToken` / `Bootstrap` / `DBToken` / none) | PR #65 rules |
+| no | any | on | Whatever PR #65 set | PR #65 rules |
+| yes | non-empty | on | `PrincipalTrustedProxy{Actor: <header>}` (overwrites PR #65) | `actorFor` returns the header value; body actor ignored |
+| yes | empty/absent | on | `PrincipalTrustedProxyAbsent` (overwrites PR #65) | `ensureAttributedWriteAllowed` rejects with `400 actor_header_required` |
+
+Two consequences of the overwrite-on-trusted-listener rule:
+
+- A valid DB-token identity from PR #65 is silently discarded when the same
+  request lands on a trusted listener with this mode on. Operators running
+  both modes on the same listener are choosing this behavior; the deployment
+  guidance is to terminate each mode on its own listener (a Unix socket for
+  the proxy; a TCP port for direct token-holding clients).
+- Token-admin endpoints (`POST /api/v1/tokens`, `GET /api/v1/tokens`,
+  `POST /api/v1/tokens/{id}/actions/revoke`) reject `PrincipalTrustedProxy`
+  via PR #65's `ensureTokenAdminAllowed`, which admits only
+  `PrincipalBootstrap`, `PrincipalStaticToken`, or no-principal. A
+  trusted-proxy front-end cannot mint or revoke tokens; that capability stays
+  bound to the bootstrap actor.
+
+### 3.5 Schema stays required
 
 The `actor` body/query field keeps its `required:"true"` Huma tag. On a trusted
 listener the client still sends some actor value, which is simply ignored in

--- a/docs/superpowers/specs/2026-05-27-trusted-proxy-actor-header-design.md
+++ b/docs/superpowers/specs/2026-05-27-trusted-proxy-actor-header-design.md
@@ -1,0 +1,260 @@
+# kata Trusted-Proxy Actor Header Design
+
+**Status:** Approved design for implementation planning (post-PR-#65)
+**Date:** 2026-05-27 (last revised 2026-05-28)
+**Topic:** Opt-in mode where a trusted front proxy asserts the request actor via a configured header, complementing PR #65's token-identity mode.
+**Issue:** https://github.com/kenn-io/kata/issues/58
+**Depends on:** PR #65 (`fix/simple-token-auth`) — token-identity infrastructure, `Principal` type, `attributedActor` chokepoint.
+
+## 1. Purpose
+
+The daemon credits every mutating action to an actor. PR #65 introduces the
+notion of an **attributed principal** — a server-derived identity that wins over
+any client-supplied actor. In PR #65 the only attributed principal source is a
+DB-registered API token (`PrincipalDBToken`).
+
+This spec adds a second attributed-principal source for the deployment pattern
+PR #65 does not cover: a reverse proxy fronts the daemon, authenticates the
+user (SSO, OAuth, mutual-TLS, whatever), and asserts the actor via a configured
+HTTP header over a daemon path only the proxy can reach.
+
+Token identity and trusted-proxy identity are two **server-derived actor
+modes**. Both ignore client-supplied actor fields. Neither falls back to body or
+query actor when enabled. An operator picks one based on their deployment:
+
+| Mode | Auth boundary | Actor source | Best for |
+|------|---------------|--------------|----------|
+| Token identity (PR #65) | The daemon | DB-stored `api_tokens` row | Direct CLI clients with personal tokens |
+| Trusted-proxy identity (this spec) | A reverse proxy | A configured header set by the proxy | SSO/OAuth deployments behind a proxy |
+
+Off by default. No behavior change unless configured. Coexists with token
+identity at the chokepoint (`attributedActor`).
+
+## 2. Configuration Surface
+
+A new TOML sub-table `[auth.proxy]` carries this mode's keys, mirroring the
+shape Grafana uses for `[auth.proxy]`:
+
+```toml
+[auth.proxy]
+trusted_actor_header = "X-Kata-Actor"
+trusted_proxy_listeners = ["unix:///run/kata/proxy.sock"]
+```
+
+- `trusted_actor_header` (string) — the header name the proxy sets. Empty (or
+  absent) means trusted-proxy mode is **off**.
+- `trusted_proxy_listeners` ([]string) — the literal bind address(es) on which
+  the header is honored. A request that did not arrive on one of these listeners
+  ignores the header entirely.
+
+Environment overrides match the existing style (`KATA_AUTH_TOKEN`,
+`KATA_TRUST_PRIVATE_NETWORK`, `KATA_REQUIRE_TOKEN_IDENTITY`):
+
+- `KATA_TRUSTED_ACTOR_HEADER` — string; overrides `trusted_actor_header`.
+- `KATA_TRUSTED_PROXY_LISTENERS` — comma-separated list; overrides
+  `trusted_proxy_listeners`. Entries are trimmed; empty entries are dropped.
+  Treats empty/unset env value as "no override" (matches `KATA_AUTH_TOKEN`).
+
+The mode is **on** only when `trusted_actor_header` is non-empty after
+resolution. `trusted_proxy_listeners` with an empty header is inert (header off
+wins). Absent everywhere = off; existing configs parse and behave exactly as
+before.
+
+### 2.1 Listener address forms
+
+Allowlist entries must be **literal** bind addresses, matching the daemon's
+`listen` value:
+
+- Unix socket: `unix:///run/kata/proxy.sock` (the `unix://` prefix is stripped
+  before matching).
+- TCP: `host:port`, e.g. `100.64.0.5:7777`.
+
+Wildcard binds (`0.0.0.0:7777`, `:7777`, `::`) are **not** valid allowlist
+entries: an accepted connection reports the specific interface IP it arrived on,
+never the wildcard, so a wildcard entry would never match. This mirrors the
+existing posture in `requireNonPublic` (`internal/daemon/endpoint.go`), which
+already rejects unspecified binds. A trusted proxy listener should be a Unix
+socket or a specific private IP that only the proxy can reach.
+
+## 3. Architecture
+
+### 3.1 Per-request listener trust
+
+The HTTP server roots every request in a base context that carries
+`http.LocalAddrContextKey` — the `net.Addr` of the local end of the accepted
+connection (set automatically by `net/http`). A middleware reads that address,
+normalizes it, and tests membership in the normalized allowlist:
+
+- Unix local addr (`*net.UnixAddr`): compare its path against allowlist entries
+  with any `unix://` prefix stripped.
+- TCP local addr (`*net.TCPAddr`): compare its `host:port` string against
+  allowlist entries.
+
+Resolving trust per request (rather than once at startup from
+`cfg.Endpoint.Address()`) is deliberate: `cfg.Endpoint` is nil when the server
+is mounted via `httptest`, so a startup-resolved boolean would be untestable.
+The per-request check works in both the real daemon and `httptest`, and makes
+the listener-trust matrix unit-testable without binding real sockets.
+
+### 3.2 Middleware: `withTrustedProxyActor`
+
+A new `net/http` middleware composed just inside `requireBearer` (or PR #65's
+`requireIdentityBearer` when identity mode is on) in `NewServer`, so it runs
+only on requests that auth has admitted or passed through. The middleware does
+NOT replace PR #65's principal middleware — it runs after it. On trusted
+listeners with a valid header it overwrites the principal with a
+`PrincipalTrustedProxy`; on trusted listeners with a missing/empty header it
+sets a `PrincipalTrustedProxyAbsent` sentinel.
+
+Composition order (outer → inner):
+
+```
+withCSRFGuards
+  requireBearer / requireIdentityBearer  (sets Principal{StaticToken|Bootstrap|DBToken})
+    withTrustedProxyActor                (overwrites Principal on trusted listeners)
+      mux
+```
+
+Behavior per request:
+
+- Mode off (empty header name) -> pass through untouched. Principal from PR #65
+  (if any) stands.
+- Mode on but local addr not in the allowlist -> pass through untouched
+  (header, if any, is ignored).
+- Mode on and on a trusted listener:
+  - Header present and non-empty -> overwrite principal with
+    `Principal{Kind: PrincipalTrustedProxy, Actor: <trimmed header value>}`.
+  - Header absent or empty -> overwrite principal with
+    `Principal{Kind: PrincipalTrustedProxyAbsent}`.
+
+The middleware never rejects on its own; rejection is decided downstream in
+`attributedActor` / `actorFor` so read-only requests (which do not call those
+functions) are never blocked.
+
+### 3.3 Integration with PR #65's `attributedActor` chokepoint
+
+PR #65 lands one chokepoint for all attributed writes:
+
+```go
+// from PR #65
+func attributedActor(ctx context.Context, requestActor string) (string, error) {
+    if err := ensureAttributedWriteAllowed(ctx); err != nil {
+        return "", err
+    }
+    actor := actorFor(ctx, requestActor)
+    if err := validateActor(actor); err != nil {
+        return "", err
+    }
+    return actor, nil
+}
+```
+
+This spec extends two functions in that package, **adding a third principal
+kind** rather than introducing a parallel resolver:
+
+- `actorFor(ctx, requestActor)` learns to return the proxy-asserted actor when
+  the context carries `Principal{Kind: PrincipalTrustedProxy, Actor: a}` —
+  returning `a`, ignoring `requestActor`.
+- `ensureAttributedWriteAllowed(ctx)` learns to reject when the context carries
+  `Principal{Kind: PrincipalTrustedProxyAbsent}`, returning
+  `400 actor_header_required`.
+
+All 26 mutation handlers PR #65 swapped to `attributedActor` automatically pick
+up the new attribution source — no further handler edits.
+
+### 3.4 Schema stays required
+
+The `actor` body/query field keeps its `required:"true"` Huma tag. On a trusted
+listener the client still sends some actor value, which is simply ignored in
+favor of the header (acceptance criteria: "a conflicting body/query actor is
+ignored"). This keeps the change off every actor struct tag and means a client
+that omits actor entirely still gets the existing required-field validation
+error — no behavior change. The proxy deployment forwards the kata client
+request, which always includes an actor, so this is invisible in practice.
+
+## 4. Data Flow
+
+A mutating request flows through these stages in order:
+
+- Client (or proxy-forwarded client) sends a mutating request.
+- `requireBearer` / `requireIdentityBearer` admits the request; in identity
+  mode PR #65 sets a `Principal{Kind: ...}` from the bearer.
+- `withTrustedProxyActor` inspects the local addr: trusted listener + header
+  set -> overwrites principal with `PrincipalTrustedProxy{Actor: header}`;
+  trusted listener + header missing -> overwrites principal with
+  `PrincipalTrustedProxyAbsent`; otherwise -> principal untouched.
+- Huma routes to the handler; the handler calls
+  `attributedActor(ctx, in.Body.Actor)`.
+- `ensureAttributedWriteAllowed` rejects `PrincipalTrustedProxyAbsent` with
+  `400 actor_header_required`.
+- `actorFor` returns the proxy-asserted actor for `PrincipalTrustedProxy`,
+  ignoring `requestActor`. For any other principal kind, PR #65's existing
+  rules apply.
+- The resolved actor flows on as the change `Author`, exactly as today.
+
+## 5. Error Handling
+
+- Trusted listener, mutation, missing/empty header -> `400 actor_header_required`
+  with a clear message. (Decision: reject rather than fall back. Falling back
+  would let a direct, non-proxied client omit the header and supply any actor,
+  defeating the feature.)
+- Mode off / non-trusted listener -> identical to current behavior (whatever
+  PR #65 establishes for the principal in scope).
+- Reads carry no actor and never reach `attributedActor`, so they are never
+  blocked by this feature.
+
+## 6. Security Notes
+
+- Trust is bound to specific listeners so a client on any other path cannot
+  spoof the actor by setting the header. With a Unix socket or a private IP that
+  only the proxy can reach, the header is meaningful exactly because nothing else
+  can set it on that path.
+- Stripping any client-supplied copy of the header before it reaches kata is the
+  proxy's responsibility and is deployment-side (out of scope). This will be
+  noted in the operator docs.
+- The feature does not change the connection-auth posture (`requireBearer`,
+  `checkAuthStartup`) and does not interact with token admin (token mint/revoke
+  still bootstrap-or-loopback only per PR #65). It layers actor attribution on
+  top.
+- Token-identity mode and trusted-proxy mode are intentionally independent.
+  Operators choosing trusted-proxy mode typically run the daemon on a Unix
+  socket or loopback that only the proxy can reach; the proxy owns user auth
+  and the daemon owns audit attribution. Token-identity mode is for direct
+  clients each holding a DB-registered token.
+
+## 7. Testing
+
+- **Middleware unit tests** (`withTrustedProxyActor`): drive crafted
+  `*http.Request`s with `http.LocalAddrContextKey` set and the header
+  present/absent across the trust matrix — trusted+present, trusted+absent,
+  untrusted+present, untrusted+absent, mode-off — asserting the resulting
+  principal value on the context. No real sockets.
+- **`actorFor` / `ensureAttributedWriteAllowed` unit tests for the new
+  principal kinds:** authoritative-wins (`PrincipalTrustedProxy`),
+  trusted-but-absent -> `400 actor_header_required`
+  (`PrincipalTrustedProxyAbsent`), and the existing principal kinds delegate
+  unchanged.
+- **Config tests:** TOML parse of both keys under `[auth.proxy]`; env overrides
+  incl. comma-split and trimming for the listener list; absent = off; existing
+  `[auth]` configs unchanged.
+- **Listener normalization tests:** `unix://`-prefixed entry matches a unix
+  local addr; `host:port` entry matches a TCP local addr; wildcard entry does
+  not match.
+- **Reads-not-blocked test:** with the mode on and on a trusted listener, a
+  header-less GET still returns its normal 2xx — verifying the middleware
+  defers rejection to `attributedActor` and never blocks read paths.
+- **Integration test (`httptest`):** trusted listener credits the header value
+  and ignores a conflicting body actor; a regression test confirming the
+  mode-off path is byte-for-byte current behavior.
+
+## 8. Out of Scope
+
+- The proxy itself and how it authenticates users; any specific identity
+  provider.
+- Making the `actor` field optional in the request schema.
+- Per-operation or per-actor authorization (the header asserts identity, not
+  permissions).
+- Cross-mode interactions beyond "trusted-proxy principal wins over whatever
+  PR #65 established for this request." If an operator runs both modes at
+  once on the same listener, the trusted-proxy principal overwrites the token
+  principal — documented but not encouraged.

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -119,7 +119,26 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 	cfg.Auth.Token = strings.TrimSpace(cfg.Auth.Token)
 	cfg.Auth.Proxy.TrustedActorHeader = strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
 	applyDaemonConfigEnv(&cfg)
+	if err := validateAuthProxy(cfg.Auth.Proxy); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
 	return &cfg, nil
+}
+
+// validateAuthProxy rejects the dangerous partial-config case where the
+// operator names a trusted-proxy header but forgets to enumerate any trusted
+// listeners. A silent no-op there would look like proxy attribution is enabled
+// while the daemon still trusts whatever body actor a client supplied.
+//
+// The inverse (listeners without a header) is dead config — the mode stays off
+// because the header name is empty — and is accepted silently.
+func validateAuthProxy(p ProxyConfig) error {
+	if p.TrustedActorHeader != "" && len(p.TrustedProxyListeners) == 0 {
+		return errors.New(
+			"auth.proxy: trusted_actor_header is set but trusted_proxy_listeners is empty. " +
+				"Set both to enable proxy attribution, or unset the header to disable")
+	}
+	return nil
 }
 
 func applyDaemonConfigEnv(cfg *DaemonConfig) {

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -94,33 +94,34 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	var cfg DaemonConfig
 	data, err := os.ReadFile(path) //nolint:gosec // path is derived from KATA_HOME, not user input
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			var cfg DaemonConfig
-			applyDaemonConfigEnv(&cfg)
-			return &cfg, nil
+	switch {
+	case err == nil:
+		meta, err := toml.Decode(string(data), &cfg)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
 		}
+		if u := meta.Undecoded(); len(u) > 0 {
+			keys := make([]string, len(u))
+			for i, k := range u {
+				keys[i] = k.String()
+			}
+			return nil, fmt.Errorf("parse %s: unknown key(s): %s", path, strings.Join(keys, ", "))
+		}
+		cfg.Listen = strings.TrimSpace(cfg.Listen)
+		cfg.Auth.Token = strings.TrimSpace(cfg.Auth.Token)
+		cfg.Auth.Proxy.TrustedActorHeader = strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
+	case errors.Is(err, os.ErrNotExist):
+		// Absent file: fall through with zero-value cfg. Env merge and
+		// validation below still apply so an env-only misconfig is
+		// caught the same way a TOML-only one is.
+	default:
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
-	var cfg DaemonConfig
-	meta, err := toml.Decode(string(data), &cfg)
-	if err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
-	}
-	if u := meta.Undecoded(); len(u) > 0 {
-		keys := make([]string, len(u))
-		for i, k := range u {
-			keys[i] = k.String()
-		}
-		return nil, fmt.Errorf("parse %s: unknown key(s): %s", path, strings.Join(keys, ", "))
-	}
-	cfg.Listen = strings.TrimSpace(cfg.Listen)
-	cfg.Auth.Token = strings.TrimSpace(cfg.Auth.Token)
-	cfg.Auth.Proxy.TrustedActorHeader = strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
 	applyDaemonConfigEnv(&cfg)
 	if err := validateAuthProxy(cfg.Auth.Proxy); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
+		return nil, err
 	}
 	return &cfg, nil
 }

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -39,9 +39,17 @@ type DaemonConfig struct {
 // ephemeral or CI-only tokens that should never be persisted to disk.
 // KATA_TRUST_PRIVATE_NETWORK=1 is equivalent to trust_private_network = true.
 type AuthConfig struct {
-	Token                string `toml:"token"`
-	TrustPrivateNetwork  bool   `toml:"trust_private_network"`
-	RequireTokenIdentity bool   `toml:"require_token_identity"`
+	Token                string      `toml:"token"`
+	TrustPrivateNetwork  bool        `toml:"trust_private_network"`
+	RequireTokenIdentity bool        `toml:"require_token_identity"`
+	Proxy                ProxyConfig `toml:"proxy"`
+}
+
+// ProxyConfig is the [auth.proxy] sub-table. Both keys empty/absent means
+// trusted-proxy actor mode is off; this is the default.
+type ProxyConfig struct {
+	TrustedActorHeader    string   `toml:"trusted_actor_header"`
+	TrustedProxyListeners []string `toml:"trusted_proxy_listeners"`
 }
 
 // TUIConfig holds TUI user preferences from <KATA_HOME>/config.toml.
@@ -109,6 +117,7 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 	}
 	cfg.Listen = strings.TrimSpace(cfg.Listen)
 	cfg.Auth.Token = strings.TrimSpace(cfg.Auth.Token)
+	cfg.Auth.Proxy.TrustedActorHeader = strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
 	applyDaemonConfigEnv(&cfg)
 	return &cfg, nil
 }

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -130,6 +130,19 @@ func applyDaemonConfigEnv(cfg *DaemonConfig) {
 	if EnvTruthy("KATA_TRUST_PRIVATE_NETWORK") {
 		cfg.Auth.TrustPrivateNetwork = true
 	}
+	if v := strings.TrimSpace(os.Getenv("KATA_TRUSTED_ACTOR_HEADER")); v != "" {
+		cfg.Auth.Proxy.TrustedActorHeader = v
+	}
+	if raw := os.Getenv("KATA_TRUSTED_PROXY_LISTENERS"); raw != "" {
+		parts := strings.Split(raw, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if t := strings.TrimSpace(p); t != "" {
+				out = append(out, t)
+			}
+		}
+		cfg.Auth.Proxy.TrustedProxyListeners = out
+	}
 }
 
 // EnvTruthy reports whether an environment variable is set to a recognized

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -208,3 +208,36 @@ trusted_proxy_listeners = ["unix:///run/kata/proxy.sock", "100.64.0.5:7777"]
 		[]string{"unix:///run/kata/proxy.sock", "100.64.0.5:7777"},
 		cfg.Auth.Proxy.TrustedProxyListeners)
 }
+
+func TestApplyDaemonConfigEnv_AuthProxyHeader(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_ACTOR_HEADER", "X-Env-Actor")
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth.proxy]\ntrusted_actor_header = \"X-Toml-Actor\"\n"), 0o600))
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	require.Equal(t, "X-Env-Actor", cfg.Auth.Proxy.TrustedActorHeader,
+		"KATA_TRUSTED_ACTOR_HEADER must override config.toml")
+}
+
+func TestApplyDaemonConfigEnv_AuthProxyListeners(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_PROXY_LISTENERS",
+		"unix:///s1 , 100.64.0.5:7777 ,, ")
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth.proxy]\ntrusted_proxy_listeners = [\"unix:///toml-only\"]\n"), 0o600))
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"unix:///s1", "100.64.0.5:7777"},
+		cfg.Auth.Proxy.TrustedProxyListeners,
+		"KATA_TRUSTED_PROXY_LISTENERS must split on commas, trim, drop empties, override config.toml")
+}

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -181,3 +181,30 @@ func TestReadDaemonConfig_AuthTokenAbsent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, cfg.Auth.Token)
 }
+
+func TestReadDaemonConfig_AuthProxy(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_ACTOR_HEADER", "")
+	t.Setenv("KATA_TRUSTED_PROXY_LISTENERS", "")
+
+	dir := t.TempDir()
+	t.Setenv("KATA_HOME", dir)
+	path := filepath.Join(dir, "config.toml")
+	body := `
+[auth]
+token = "tok"
+
+[auth.proxy]
+trusted_actor_header = "X-Kata-Actor"
+trusted_proxy_listeners = ["unix:///run/kata/proxy.sock", "100.64.0.5:7777"]
+`
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	require.Equal(t, "X-Kata-Actor", cfg.Auth.Proxy.TrustedActorHeader)
+	require.Equal(t,
+		[]string{"unix:///run/kata/proxy.sock", "100.64.0.5:7777"},
+		cfg.Auth.Proxy.TrustedProxyListeners)
+}

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -245,6 +245,24 @@ func TestReadDaemonConfig_RejectsHeaderWithoutListeners(t *testing.T) {
 		"error must name the missing key so the operator can fix it")
 }
 
+func TestReadDaemonConfig_RejectsEnvOnlyHeaderWithoutListeners(t *testing.T) {
+	// No config.toml. Env supplies a header but no listeners. The
+	// missing-file path used to short-circuit before validation, so this
+	// would silently start with proxy attribution effectively off — the
+	// exact misconfig the file-present path rejects. Both paths must
+	// agree.
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_ACTOR_HEADER", "X-Kata-Actor")
+	t.Setenv("KATA_TRUSTED_PROXY_LISTENERS", "")
+	t.Setenv("KATA_HOME", t.TempDir())
+
+	_, err := config.ReadDaemonConfig()
+	require.Error(t, err,
+		"env-only header without listeners must reject same as TOML-only")
+	assert.Contains(t, err.Error(), "trusted_proxy_listeners")
+}
+
 func TestReadDaemonConfig_AcceptsListenersWithoutHeader(t *testing.T) {
 	// listeners without a header is dead config: the mode is off (no
 	// principal overwrite ever happens), so it has no security impact.

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -213,15 +213,76 @@ func TestApplyDaemonConfigEnv_AuthProxyHeader(t *testing.T) {
 	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
 	t.Setenv("KATA_TRUSTED_ACTOR_HEADER", "X-Env-Actor")
+	t.Setenv("KATA_TRUSTED_PROXY_LISTENERS", "")
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	// Listeners are set in TOML so the resolved config is complete; this
+	// test asserts only that the env header beats the TOML header.
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
-		[]byte("[auth.proxy]\ntrusted_actor_header = \"X-Toml-Actor\"\n"), 0o600))
+		[]byte("[auth.proxy]\ntrusted_actor_header = \"X-Toml-Actor\"\ntrusted_proxy_listeners = [\"unix:///s\"]\n"), 0o600))
 	cfg, err := config.ReadDaemonConfig()
 	require.NoError(t, err)
 	require.Equal(t, "X-Env-Actor", cfg.Auth.Proxy.TrustedActorHeader,
 		"KATA_TRUSTED_ACTOR_HEADER must override config.toml")
+}
+
+func TestReadDaemonConfig_RejectsHeaderWithoutListeners(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_ACTOR_HEADER", "")
+	t.Setenv("KATA_TRUSTED_PROXY_LISTENERS", "")
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth.proxy]\ntrusted_actor_header = \"X-Kata-Actor\"\n"), 0o600))
+
+	_, err := config.ReadDaemonConfig()
+	require.Error(t, err,
+		"header set without listeners must reject at config load, not silently no-op")
+	assert.Contains(t, err.Error(), "trusted_proxy_listeners",
+		"error must name the missing key so the operator can fix it")
+}
+
+func TestReadDaemonConfig_AcceptsListenersWithoutHeader(t *testing.T) {
+	// listeners without a header is dead config: the mode is off (no
+	// principal overwrite ever happens), so it has no security impact.
+	// Accept it silently so partial configs in the safe direction don't
+	// block daemon start.
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_ACTOR_HEADER", "")
+	t.Setenv("KATA_TRUSTED_PROXY_LISTENERS", "")
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth.proxy]\ntrusted_proxy_listeners = [\"unix:///s\"]\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Auth.Proxy.TrustedActorHeader)
+	assert.Equal(t, []string{"unix:///s"}, cfg.Auth.Proxy.TrustedProxyListeners)
+}
+
+func TestReadDaemonConfig_EnvCompletesPartialTOMLProxy(t *testing.T) {
+	// TOML supplies only the header (would be rejected alone); env adds
+	// listeners. Validation runs after env merge, so this is valid.
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_TRUSTED_ACTOR_HEADER", "")
+	t.Setenv("KATA_TRUSTED_PROXY_LISTENERS", "unix:///s")
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth.proxy]\ntrusted_actor_header = \"X-Kata-Actor\"\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "X-Kata-Actor", cfg.Auth.Proxy.TrustedActorHeader)
+	assert.Equal(t, []string{"unix:///s"}, cfg.Auth.Proxy.TrustedProxyListeners)
 }
 
 func TestApplyDaemonConfigEnv_AuthProxyListeners(t *testing.T) {

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -19,6 +19,15 @@ const (
 	// identity mode. It is not an attributed actor, but token-admin routes
 	// audit it as bootstrap/admin rather than as the target actor.
 	PrincipalStaticToken PrincipalKind = "static_token"
+	// PrincipalTrustedProxy is set by the trusted-proxy middleware when an
+	// accepted request on a trusted listener carries the configured actor
+	// header. The Principal.Actor field holds the verified header value.
+	PrincipalTrustedProxy PrincipalKind = "trusted_proxy"
+	// PrincipalTrustedProxyAbsent is set by the trusted-proxy middleware
+	// when a request on a trusted listener is missing the configured actor
+	// header (or its value is empty). Writes against this principal are
+	// rejected; reads pass through.
+	PrincipalTrustedProxyAbsent PrincipalKind = "trusted_proxy_absent"
 )
 
 // Principal is the request-local identity derived by auth middleware.

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -71,11 +71,19 @@ func attributedActor(ctx context.Context, requestActor string) (string, error) {
 
 func ensureAttributedWriteAllowed(ctx context.Context) error {
 	p, ok := PrincipalFromContext(ctx)
-	if !ok || p.Kind != PrincipalBootstrap {
+	if !ok {
 		return nil
 	}
-	return api.NewError(403, "bootstrap_token_write_forbidden",
-		"bootstrap token cannot perform attributed writes; use a user token", "", nil)
+	switch p.Kind {
+	case PrincipalBootstrap:
+		return api.NewError(403, "bootstrap_token_write_forbidden",
+			"bootstrap token cannot perform attributed writes; use a user token", "", nil)
+	case PrincipalTrustedProxyAbsent:
+		return api.NewError(400, "actor_header_required",
+			"actor header required on this listener but was missing or empty", "", nil)
+	default:
+		return nil
+	}
 }
 
 func ensureTokenAdminAllowed(ctx context.Context) error {

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -107,8 +107,11 @@ func tuiBypassAllowed(ctx context.Context, source, reason string) bool {
 	if source != "tui" || reason != "done" {
 		return false
 	}
-	if p, ok := PrincipalFromContext(ctx); ok && p.Kind == PrincipalDBToken {
-		return false
+	if p, ok := PrincipalFromContext(ctx); ok {
+		switch p.Kind {
+		case PrincipalDBToken, PrincipalTrustedProxy, PrincipalTrustedProxyAbsent:
+			return false
+		}
 	}
 	return true
 }

--- a/internal/daemon/identity_test.go
+++ b/internal/daemon/identity_test.go
@@ -1,9 +1,13 @@
 package daemon
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/api"
 )
 
 // TestPrincipalKind_TrustedProxyConstants locks the values of the two
@@ -25,4 +29,46 @@ func TestPrincipalKind_TrustedProxyConstants(t *testing.T) {
 	// consumers.
 	assert.Equal(t, PrincipalKind("trusted_proxy"), PrincipalTrustedProxy)
 	assert.Equal(t, PrincipalKind("trusted_proxy_absent"), PrincipalTrustedProxyAbsent)
+}
+
+// TestActorFor_TrustedProxy verifies that a PrincipalTrustedProxy principal's
+// Actor field is honored as the resolved actor, overriding any
+// request-supplied actor string. The trusted-proxy header value is set by
+// the listener-trust middleware and must win over client-claimed actors.
+func TestActorFor_TrustedProxy(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), Principal{
+		Kind:  PrincipalTrustedProxy,
+		Actor: "proxy-user",
+	})
+	got := actorFor(ctx, "client-claim")
+	assert.Equal(t, "proxy-user", got, "trusted-proxy principal wins over supplied actor")
+}
+
+// TestEnsureAttributedWriteAllowed_TrustedProxyAbsent locks the rejection
+// contract for trusted-listener requests that did not carry the configured
+// actor header. The error envelope must be 400 actor_header_required so
+// clients can distinguish "trusted but unattributed" from generic 403s.
+func TestEnsureAttributedWriteAllowed_TrustedProxyAbsent(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), Principal{
+		Kind: PrincipalTrustedProxyAbsent,
+	})
+	err := ensureAttributedWriteAllowed(ctx)
+	require.Error(t, err)
+
+	var apiErr *api.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, 400, apiErr.Status)
+	assert.Equal(t, "actor_header_required", apiErr.Code)
+}
+
+// TestEnsureAttributedWriteAllowed_TrustedProxyAllowed confirms the positive
+// path: when the trusted-proxy middleware sets a PrincipalTrustedProxy with
+// an Actor value, attributed writes proceed.
+func TestEnsureAttributedWriteAllowed_TrustedProxyAllowed(t *testing.T) {
+	ctx := WithPrincipal(context.Background(), Principal{
+		Kind:  PrincipalTrustedProxy,
+		Actor: "proxy-user",
+	})
+	require.NoError(t, ensureAttributedWriteAllowed(ctx),
+		"PrincipalTrustedProxy must be allowed to do attributed writes")
 }

--- a/internal/daemon/identity_test.go
+++ b/internal/daemon/identity_test.go
@@ -1,0 +1,28 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPrincipalKind_TrustedProxyConstants locks the values of the two
+// trusted-proxy principal kinds. They must be distinct from each other
+// and from the kinds defined by the identity layer so logs and audit
+// reads can tell them apart.
+func TestPrincipalKind_TrustedProxyConstants(t *testing.T) {
+	assert.NotEqual(t, PrincipalTrustedProxy, PrincipalTrustedProxyAbsent)
+	assert.NotEqual(t, PrincipalTrustedProxy, PrincipalDBToken)
+	assert.NotEqual(t, PrincipalTrustedProxy, PrincipalStaticToken)
+	assert.NotEqual(t, PrincipalTrustedProxy, PrincipalBootstrap)
+	assert.NotEqual(t, PrincipalTrustedProxyAbsent, PrincipalDBToken)
+	assert.NotEqual(t, PrincipalTrustedProxyAbsent, PrincipalStaticToken)
+	assert.NotEqual(t, PrincipalTrustedProxyAbsent, PrincipalBootstrap)
+
+	// PrincipalKind is a string named type. Lock the snake_case string
+	// values so they match the existing convention ("db_token",
+	// "bootstrap", "static_token") and stay stable for log/audit
+	// consumers.
+	assert.Equal(t, PrincipalKind("trusted_proxy"), PrincipalTrustedProxy)
+	assert.Equal(t, PrincipalKind("trusted_proxy_absent"), PrincipalTrustedProxyAbsent)
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -96,7 +96,7 @@ func NewServer(cfg ServerConfig) *Server {
 	s := &Server{cfg: cfg, api: humaAPI}
 	registerRoutes(humaAPI, mux, cfg)
 
-	s.handler = withCSRFGuards(requireBearer(cfg.authPolicy(), cfg.DB)(mux))
+	s.handler = withCSRFGuards(requireBearer(cfg.authPolicy(), cfg.DB)(withTrustedProxyActor(cfg)(mux)))
 	return s
 }
 

--- a/internal/daemon/trusted_actor.go
+++ b/internal/daemon/trusted_actor.go
@@ -1,0 +1,34 @@
+package daemon
+
+import (
+	"net"
+	"strings"
+)
+
+// listenerTrusted reports whether localAddr matches one of the configured
+// trusted-proxy-listener entries. Entries are normalized by trimming
+// whitespace and any "unix://" prefix; the local addr's String() is
+// compared verbatim (for Unix sockets that's the path; for TCP it's
+// host:port with brackets for IPv6).
+//
+// A wildcard bind ("0.0.0.0:7777", "[::]:7777") reports a specific
+// interface IP per accepted connection, never the wildcard, so a
+// wildcard entry never matches. Operators should list literal bind
+// addresses (a Unix socket or a specific private IP).
+func listenerTrusted(localAddr net.Addr, allowlist []string) bool {
+	if localAddr == nil || len(allowlist) == 0 {
+		return false
+	}
+	local := localAddr.String()
+	for _, entry := range allowlist {
+		if normalizeListenerEntry(entry) == local {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeListenerEntry(s string) string {
+	s = strings.TrimSpace(s)
+	return strings.TrimPrefix(s, "unix://")
+}

--- a/internal/daemon/trusted_actor.go
+++ b/internal/daemon/trusted_actor.go
@@ -1,7 +1,9 @@
 package daemon
 
 import (
+	"context"
 	"net"
+	"net/http"
 	"strings"
 )
 
@@ -31,4 +33,42 @@ func listenerTrusted(localAddr net.Addr, allowlist []string) bool {
 func normalizeListenerEntry(s string) string {
 	s = strings.TrimSpace(s)
 	return strings.TrimPrefix(s, "unix://")
+}
+
+// withTrustedProxyActor inspects each request's local address and, on a
+// trusted listener, overwrites the request principal with a
+// PrincipalTrustedProxy carrying the header value. A missing or empty
+// header on a trusted listener becomes a PrincipalTrustedProxyAbsent
+// sentinel. The middleware never rejects on its own; rejection is left to
+// ensureAttributedWriteAllowed so read-only paths (which never call
+// attributedActor) are not blocked.
+func withTrustedProxyActor(cfg ServerConfig) func(http.Handler) http.Handler {
+	headerName := strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
+	allowlist := cfg.Auth.Proxy.TrustedProxyListeners
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if headerName == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			localAddr, _ := r.Context().Value(http.LocalAddrContextKey).(net.Addr)
+			if !listenerTrusted(localAddr, allowlist) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			raw := strings.TrimSpace(r.Header.Get(headerName))
+			var ctx context.Context
+			if raw != "" {
+				ctx = WithPrincipal(r.Context(), Principal{
+					Kind:  PrincipalTrustedProxy,
+					Actor: raw,
+				})
+			} else {
+				ctx = WithPrincipal(r.Context(), Principal{
+					Kind: PrincipalTrustedProxyAbsent,
+				})
+			}
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -204,3 +204,43 @@ func TestTrustedProxyHeader_ModeOffUnchanged(t *testing.T) {
 	assert.Equal(t, "client-claim", payload.Event.Actor,
 		"mode off: header is ignored, body actor wins")
 }
+
+// TestTrustedProxyHeader_TokenAdminForbidden locks the cross-mode boundary:
+// even on a trusted listener, the trusted-proxy header cannot mint or list
+// tokens. The middleware overwrites whatever principal upstream set with
+// PrincipalTrustedProxy; ensureTokenAdminAllowed (PR #65) only admits
+// PrincipalBootstrap, PrincipalStaticToken, or no-principal, so the request
+// is rejected with 403 token_admin_forbidden.
+//
+// Without this test, a future change to ensureTokenAdminAllowed could silently
+// promote PrincipalTrustedProxy into the token-admin allowlist and the only
+// signal would be the absence of a test failure.
+func TestTrustedProxyHeader_TokenAdminForbidden(t *testing.T) {
+	ts := startTrustedProxyTestServer(t, "X-Kata-Actor")
+
+	body := map[string]any{
+		"actor": "alice",
+		"name":  "test-token",
+	}
+	resp, raw := doReq(t, ts, "POST", "/api/v1/tokens",
+		body, map[string]string{"X-Kata-Actor": "alice"})
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, "body: %s", raw)
+
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "token_admin_forbidden", env.Error.Code,
+		"trusted-proxy principals must not be allowed to mint or revoke tokens")
+
+	// And the same boundary holds for list and revoke.
+	resp, raw = doReq(t, ts, "GET", "/api/v1/tokens", nil,
+		map[string]string{"X-Kata-Actor": "alice"})
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, "list body: %s", raw)
+
+	resp, raw = doReq(t, ts, "POST", "/api/v1/tokens/42/actions/revoke", nil,
+		map[string]string{"X-Kata-Actor": "alice"})
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, "revoke body: %s", raw)
+}

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -169,3 +169,38 @@ func TestTrustedProxyHeader_ReadsNotBlocked(t *testing.T) {
 	resp, raw := doReq(t, ts, "GET", "/api/v1/health", nil, nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
 }
+
+// TestTrustedProxyHeader_ModeOffUnchanged verifies that with mode off (empty
+// TrustedActorHeader) the header is ignored and the body actor flows through
+// as it did before this feature landed. The middleware short-circuits before
+// checking the allowlist, so even a request that would otherwise look like a
+// trusted-proxy call is attributed to the body actor.
+func TestTrustedProxyHeader_ModeOffUnchanged(t *testing.T) {
+	// Mode off (empty TrustedActorHeader). The header is ignored, and the
+	// body actor is used as today.
+	ts := startTrustedProxyTestServer(t, "" /* mode off */)
+
+	projectID := trustedProxyCreateProject(t, ts, nil)
+	issueRef := trustedProxyCreateIssue(t, ts, projectID, nil)
+
+	body := map[string]any{
+		"actor":   "client-claim",
+		"reason":  "done",
+		"message": "mode off; body actor must be used.",
+		"source":  "tui",
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, map[string]string{"X-Kata-Actor": "should-be-ignored"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
+
+	var payload struct {
+		Event *struct {
+			Actor string `json:"actor"`
+		} `json:"event"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	require.NotNil(t, payload.Event)
+	assert.Equal(t, "client-claim", payload.Event.Actor,
+		"mode off: header is ignored, body actor wins")
+}

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -244,3 +244,38 @@ func TestTrustedProxyHeader_TokenAdminForbidden(t *testing.T) {
 		map[string]string{"X-Kata-Actor": "alice"})
 	require.Equal(t, http.StatusForbidden, resp.StatusCode, "revoke body: %s", raw)
 }
+
+// TestTrustedProxyHeader_TokenAdminForbiddenWithoutHeader covers the absent-
+// header variant of the same boundary. A request on a trusted listener that
+// omits the actor header lands in PrincipalTrustedProxyAbsent, and
+// ensureTokenAdminAllowed must reject it just as firmly as the header-present
+// case. Without this test, a future change that allowed the absent-header
+// principal to bypass token admin (perhaps under the rationale "no actor was
+// claimed, so it's safe") would slip through. The header-present test and this
+// one together pin both trusted-proxy principal variants out of the token-admin
+// allowlist.
+func TestTrustedProxyHeader_TokenAdminForbiddenWithoutHeader(t *testing.T) {
+	ts := startTrustedProxyTestServer(t, "X-Kata-Actor")
+
+	body := map[string]any{
+		"actor": "alice",
+		"name":  "test-token",
+	}
+	resp, raw := doReq(t, ts, "POST", "/api/v1/tokens", body, nil)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, "body: %s", raw)
+
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "token_admin_forbidden", env.Error.Code,
+		"trusted-proxy absent principals must also be rejected from token admin")
+
+	resp, raw = doReq(t, ts, "GET", "/api/v1/tokens", nil, nil)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, "list body: %s", raw)
+
+	resp, raw = doReq(t, ts, "POST", "/api/v1/tokens/42/actions/revoke", nil, nil)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, "revoke body: %s", raw)
+}

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -129,3 +129,28 @@ func TestTrustedProxyHeader_CreditsHeaderActor(t *testing.T) {
 	assert.Equal(t, "proxy-user", payload.Event.Actor,
 		"event.actor must reflect the trusted header value, not the body actor")
 }
+
+// TestTrustedProxyHeader_MissingHeaderRejects verifies the negative path:
+// when the trusted listener is configured but the client omits the actor
+// header, withTrustedProxyActor installs PrincipalTrustedProxyAbsent and
+// ensureAttributedWriteAllowed rejects the write with actor_header_required.
+// Without this guard a misconfigured proxy could silently let body-supplied
+// actor values through on a listener that callers expect to be header-attributed.
+func TestTrustedProxyHeader_MissingHeaderRejects(t *testing.T) {
+	ts := startTrustedProxyTestServer(t, "X-Kata-Actor")
+
+	projectID := trustedProxyCreateProject(t, ts, map[string]string{"X-Kata-Actor": "setup"})
+	issueRef := trustedProxyCreateIssue(t, ts, projectID,
+		map[string]string{"X-Kata-Actor": "setup"})
+
+	body := map[string]any{
+		"actor":   "client-claim",
+		"reason":  "done",
+		"message": "should be rejected because the trusted header is missing.",
+		"source":  "tui",
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, nil) // no X-Kata-Actor on the close call
+	assertAPIError(t, resp.StatusCode, raw, http.StatusBadRequest, "actor_header_required")
+}

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -109,10 +109,10 @@ func TestTrustedProxyHeader_CreditsHeaderActor(t *testing.T) {
 	// "proxy-user". A passing test proves attributedActor preferred the
 	// principal's actor over the body's.
 	body := map[string]any{
-		"actor":   "client-claim",
-		"reason":  "done",
-		"message": "verified end-to-end after the fix landed.",
-		"source":  "tui",
+		"actor":    "client-claim",
+		"reason":   "done",
+		"message":  "verified end-to-end after the trusted proxy actor fix landed.",
+		"evidence": []map[string]any{{"type": "commit", "sha": "abc1234"}},
 	}
 	resp, raw := doReq(t, ts, "POST",
 		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
@@ -278,4 +278,26 @@ func TestTrustedProxyHeader_TokenAdminForbiddenWithoutHeader(t *testing.T) {
 
 	resp, raw = doReq(t, ts, "POST", "/api/v1/tokens/42/actions/revoke", nil, nil)
 	require.Equal(t, http.StatusForbidden, resp.StatusCode, "revoke body: %s", raw)
+}
+
+// TestTrustedProxyHeader_TUIBypassRequiresCloseValidation keeps the trusted-
+// proxy actor mode aligned with PR #65's token-derived identity rules: once the
+// actor is server-derived, a client-controlled source=tui flag must not bypass
+// close message/evidence validation.
+func TestTrustedProxyHeader_TUIBypassRequiresCloseValidation(t *testing.T) {
+	ts := startTrustedProxyTestServer(t, "X-Kata-Actor")
+
+	projectID := trustedProxyCreateProject(t, ts, map[string]string{"X-Kata-Actor": "setup"})
+	issueRef := trustedProxyCreateIssue(t, ts, projectID,
+		map[string]string{"X-Kata-Actor": "setup"})
+
+	body := map[string]any{
+		"actor":  "client-claim",
+		"reason": "done",
+		"source": "tui",
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, map[string]string{"X-Kata-Actor": "proxy-user"})
+	assertAPIError(t, resp.StatusCode, raw, http.StatusBadRequest, "validation")
 }

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -154,3 +154,18 @@ func TestTrustedProxyHeader_MissingHeaderRejects(t *testing.T) {
 		body, nil) // no X-Kata-Actor on the close call
 	assertAPIError(t, resp.StatusCode, raw, http.StatusBadRequest, "actor_header_required")
 }
+
+// TestTrustedProxyHeader_ReadsNotBlocked verifies that a header-less GET on a
+// trusted listener still returns 2xx. The middleware stores PrincipalTrustedProxyAbsent
+// for the read, but read handlers never call attributedActor, so the missing
+// header must not reject the request.
+func TestTrustedProxyHeader_ReadsNotBlocked(t *testing.T) {
+	ts := startTrustedProxyTestServer(t, "X-Kata-Actor")
+
+	// GET /api/v1/health is a read with no actor and no required setup.
+	// On a trusted listener with no header, the middleware stores a
+	// trusted-but-absent principal; the health handler never calls
+	// attributedActor, so it must still return 200.
+	resp, raw := doReq(t, ts, "GET", "/api/v1/health", nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", raw)
+}

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -1,0 +1,131 @@
+package daemon_test
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
+)
+
+// startTrustedProxyTestServer pre-binds a loopback TCP listener, then builds a
+// daemon.Server whose trusted-proxy allowlist names that listener's address,
+// and finally swaps the listener into an httptest.Server. The two-step dance
+// exists because withTrustedProxyActor captures the allowlist at NewServer
+// time; httptest.NewServer would otherwise pick its own random port and the
+// allowlist entry would never match.
+func startTrustedProxyTestServer(t *testing.T, headerName string) *httptest.Server {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	d := openTestDB(t)
+	cfg := daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+		Auth: config.AuthConfig{
+			Proxy: config.ProxyConfig{
+				TrustedActorHeader:    headerName,
+				TrustedProxyListeners: []string{l.Addr().String()},
+			},
+		},
+	}
+	srv := daemon.NewServer(cfg)
+	t.Cleanup(func() { _ = srv.Close() })
+	ts := httptest.NewUnstartedServer(srv.Handler())
+	require.NoError(t, ts.Listener.Close())
+	ts.Listener = l
+	ts.Start()
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// trustedProxyCreateProject posts to /api/v1/projects with a path-free init
+// (name only) so the test does not need a git workspace on disk. Returns the
+// new project's rowid. The headers map is passed through to doReq so callers
+// can carry an X-Kata-Actor header on the setup call when token-identity mode
+// or trusted-proxy mode requires attribution.
+func trustedProxyCreateProject(t *testing.T, ts *httptest.Server, headers map[string]string) int64 {
+	t.Helper()
+	resp, raw := doReq(t, ts, "POST", "/api/v1/projects",
+		map[string]any{"name": "trusted-proxy-e2e"}, headers)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "init project: %s", raw)
+	var body struct {
+		Project struct {
+			ID int64 `json:"id"`
+		} `json:"project"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &body), string(raw))
+	require.NotZero(t, body.Project.ID, "init returned zero project id: %s", raw)
+	return body.Project.ID
+}
+
+// trustedProxyCreateIssue posts to /api/v1/projects/{id}/issues and returns
+// the new issue's short_id, which is the wire-format ref the close action
+// expects. Headers are forwarded to doReq so the call can carry the trusted
+// actor header along with the body actor.
+func trustedProxyCreateIssue(t *testing.T, ts *httptest.Server, projectID int64, headers map[string]string) string {
+	t.Helper()
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues",
+		map[string]any{"actor": "setup", "title": "trusted proxy header e2e"}, headers)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "create issue: %s", raw)
+	var body struct {
+		Issue struct {
+			ShortID string `json:"short_id"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &body), string(raw))
+	require.NotEmpty(t, body.Issue.ShortID, "create returned no short_id: %s", raw)
+	return body.Issue.ShortID
+}
+
+// TestTrustedProxyHeader_CreditsHeaderActor exercises the full pipeline:
+// withTrustedProxyActor turns the X-Kata-Actor header into a PrincipalTrustedProxy
+// on the trusted listener, attributedActor prefers the principal's actor over
+// the request body's actor, and the close event row records the header value
+// rather than the body value.
+func TestTrustedProxyHeader_CreditsHeaderActor(t *testing.T) {
+	ts := startTrustedProxyTestServer(t, "X-Kata-Actor")
+
+	// Seed via the HTTP surface so the trusted-proxy principal is the
+	// only writer in scope. initProject (POST /api/v1/projects) does
+	// not call attributedActor, but the header is still applied by the
+	// middleware so passing it here is harmless and keeps the test
+	// uniform. createIssue does call attributedActor, so the header is
+	// required for the seed issue to materialize.
+	projectID := trustedProxyCreateProject(t, ts, map[string]string{"X-Kata-Actor": "setup"})
+	issueRef := trustedProxyCreateIssue(t, ts, projectID,
+		map[string]string{"X-Kata-Actor": "setup"})
+
+	// The body carries actor="client-claim"; the trusted header carries
+	// "proxy-user". A passing test proves attributedActor preferred the
+	// principal's actor over the body's.
+	body := map[string]any{
+		"actor":   "client-claim",
+		"reason":  "done",
+		"message": "verified end-to-end after the fix landed.",
+		"source":  "tui",
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, map[string]string{"X-Kata-Actor": "proxy-user"})
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "close: %s", raw)
+
+	var payload struct {
+		Event *struct {
+			Actor string `json:"actor"`
+		} `json:"event"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload), string(raw))
+	require.NotNil(t, payload.Event, "close returned no event row: %s", raw)
+	assert.Equal(t, "proxy-user", payload.Event.Actor,
+		"event.actor must reflect the trusted header value, not the body actor")
+}

--- a/internal/daemon/trusted_actor_test.go
+++ b/internal/daemon/trusted_actor_test.go
@@ -1,10 +1,15 @@
 package daemon
 
 import (
+	"context"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
 )
 
 func TestListenerTrusted(t *testing.T) {
@@ -35,6 +40,114 @@ func TestListenerTrusted(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := listenerTrusted(tc.local, tc.allowlist)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWithTrustedProxyActor_Matrix(t *testing.T) {
+	tcpAddr, _ := net.ResolveTCPAddr("tcp", "100.64.0.5:7777")
+	otherTCP, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:9999")
+
+	type want struct {
+		kind  PrincipalKind // zero value = principal unchanged
+		actor string
+	}
+	cases := []struct {
+		name     string
+		header   string
+		local    net.Addr
+		auth     config.AuthConfig
+		incoming Principal
+		want     want
+	}{
+		{
+			name:   "mode off, no header set",
+			header: "", local: tcpAddr,
+			auth:     config.AuthConfig{},
+			incoming: Principal{Kind: PrincipalDBToken, Actor: "alice"},
+			want:     want{kind: PrincipalDBToken, actor: "alice"},
+		},
+		{
+			name:   "mode off, header sent but ignored",
+			header: "alice", local: tcpAddr,
+			auth:     config.AuthConfig{Proxy: config.ProxyConfig{TrustedProxyListeners: []string{"100.64.0.5:7777"}}},
+			incoming: Principal{},
+			want:     want{},
+		},
+		{
+			name:   "mode on, untrusted listener",
+			header: "alice", local: otherTCP,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			incoming: Principal{Kind: PrincipalDBToken, Actor: "alice"},
+			want:     want{kind: PrincipalDBToken, actor: "alice"},
+		},
+		{
+			name:   "mode on, trusted listener, header set -> overwrite",
+			header: "alice", local: tcpAddr,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			incoming: Principal{Kind: PrincipalDBToken, Actor: "token-bob"},
+			want:     want{kind: PrincipalTrustedProxy, actor: "alice"},
+		},
+		{
+			name:   "mode on, trusted listener, header missing -> absent",
+			header: "", local: tcpAddr,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			want: want{kind: PrincipalTrustedProxyAbsent},
+		},
+		{
+			name:   "mode on, trusted listener, whitespace-only header -> absent",
+			header: "   ", local: tcpAddr,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			want: want{kind: PrincipalTrustedProxyAbsent},
+		},
+		{
+			name:   "mode on, trusted listener, header trimmed before storing",
+			header: "  bob  ", local: tcpAddr,
+			auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Kata-Actor",
+				TrustedProxyListeners: []string{"100.64.0.5:7777"},
+			}},
+			want: want{kind: PrincipalTrustedProxy, actor: "bob"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got Principal
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if p, ok := PrincipalFromContext(r.Context()); ok {
+					got = p
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+			h := withTrustedProxyActor(ServerConfig{Auth: tc.auth})(next)
+
+			req := httptest.NewRequest("POST", "/x", nil)
+			if tc.header != "" {
+				req.Header.Set("X-Kata-Actor", tc.header)
+			}
+			ctx := context.WithValue(req.Context(), http.LocalAddrContextKey, tc.local)
+			if tc.incoming.Kind != "" {
+				ctx = WithPrincipal(ctx, tc.incoming)
+			}
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, tc.want.kind, got.Kind)
+			assert.Equal(t, tc.want.actor, got.Actor)
 		})
 	}
 }

--- a/internal/daemon/trusted_actor_test.go
+++ b/internal/daemon/trusted_actor_test.go
@@ -1,0 +1,40 @@
+package daemon
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListenerTrusted(t *testing.T) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", "100.64.0.5:7777")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unixAddr := &net.UnixAddr{Name: "/run/kata/proxy.sock", Net: "unix"}
+	otherTCP, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:9999")
+
+	cases := []struct {
+		name      string
+		local     net.Addr
+		allowlist []string
+		want      bool
+	}{
+		{"empty allowlist", tcpAddr, nil, false},
+		{"nil addr", nil, []string{"100.64.0.5:7777"}, false},
+		{"tcp match", tcpAddr, []string{"100.64.0.5:7777"}, true},
+		{"tcp no match", otherTCP, []string{"100.64.0.5:7777"}, false},
+		{"unix match with prefix", unixAddr, []string{"unix:///run/kata/proxy.sock"}, true},
+		{"unix match plain path", unixAddr, []string{"/run/kata/proxy.sock"}, true},
+		{"unix no match", unixAddr, []string{"/different/path"}, false},
+		{"whitespace in entry trimmed", tcpAddr, []string{"  100.64.0.5:7777 "}, true},
+		{"wildcard 0.0.0.0 never matches", tcpAddr, []string{"0.0.0.0:7777"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := listenerTrusted(tc.local, tc.allowlist)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds opt-in trusted-proxy actor header mode. A reverse proxy fronting the daemon can assert the request actor via a configured HTTP header on a configured listener; the daemon credits that value to the action instead of the body-supplied actor. Layers on PR #65's `attributedActor` chokepoint as a second server-derived attribution mode.

- **Two server-derived actor modes:** PR #65's DB token identity (direct CLI clients with personal tokens) and this PR's trusted-proxy header identity (SSO/OAuth deployments behind a reverse proxy). Both ignore client-supplied actor fields where they apply.
- **Integration:** adds `PrincipalTrustedProxy` and `PrincipalTrustedProxyAbsent` to PR #65's principal kinds, extends `actorFor` / `ensureAttributedWriteAllowed` to handle them, and adds a `withTrustedProxyActor` middleware that overwrites the request principal on trusted listeners. All 26 mutation handlers already routed through `attributedActor` pick up the new attribution automatically — no per-handler edits.
- **Config:** new `[auth.proxy]` sub-table with `trusted_actor_header` and `trusted_proxy_listeners`, plus matching `KATA_TRUSTED_ACTOR_HEADER` and `KATA_TRUSTED_PROXY_LISTENERS` env overrides. Empty/unset env is "no override" (matches `KATA_AUTH_TOKEN`).
- **Token admin stays bootstrap-only:** PR #65's `ensureTokenAdminAllowed` admits only `PrincipalBootstrap`/`PrincipalStaticToken`/no-principal, so a trusted-proxy front-end cannot mint or revoke tokens. Locked by `TestTrustedProxyHeader_TokenAdminForbidden`.

Spec: `docs/superpowers/specs/2026-05-27-trusted-proxy-actor-header-design.md`
Plan: `docs/superpowers/plans/2026-05-28-trusted-proxy-actor-header.md`

## Test plan

- [x] `go test ./internal/config/... ./internal/daemon/...` — all pass locally
- [x] `golangci-lint run` — clean
- [x] Middleware unit tests cover the trust matrix (trusted+present, trusted+absent, untrusted+present, untrusted+absent, mode-off)
- [x] `actorFor` / `ensureAttributedWriteAllowed` unit tests for `PrincipalTrustedProxy` and `PrincipalTrustedProxyAbsent`
- [x] Config tests for TOML parse under `[auth.proxy]` and env-override comma-split/trim
- [x] Listener-normalization tests for `unix://` prefix + `host:port` matching, wildcard rejection
- [x] End-to-end (httptest) tests: header credited as actor, missing header on trusted listener → 400, reads on trusted listener not blocked, mode-off unchanged, token-admin endpoints reject trusted-proxy principal

Refs #58