### PR TITLE
Warn on trusted-proxy principal overwrite + bearer+proxy test coverage

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -44,6 +45,12 @@ type ServerConfig struct {
 	// InsecureReadonly permits unauthenticated GETs on non-loopback TCP
 	// even when Auth.Token == "". DEV ONLY — not for production.
 	InsecureReadonly bool
+
+	// Logger is the structured logger middleware uses for operator-visible
+	// warnings (currently: trusted-proxy header overwriting an upstream
+	// bearer-derived principal). Nil uses slog.Default(); tests inject a
+	// per-test logger so output is observable and isolated.
+	Logger *slog.Logger
 }
 
 // authPolicy returns the resolved bearer-auth policy in the form the

--- a/internal/daemon/trusted_actor.go
+++ b/internal/daemon/trusted_actor.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -45,6 +46,10 @@ func normalizeListenerEntry(s string) string {
 func withTrustedProxyActor(cfg ServerConfig) func(http.Handler) http.Handler {
 	headerName := strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
 	allowlist := cfg.Auth.Proxy.TrustedProxyListeners
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if headerName == "" {
@@ -56,6 +61,7 @@ func withTrustedProxyActor(cfg ServerConfig) func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
+			warnIfOverwritingUpstreamPrincipal(r.Context(), logger, localAddr, headerName)
 			raw := strings.TrimSpace(r.Header.Get(headerName))
 			var ctx context.Context
 			if raw != "" {
@@ -71,4 +77,30 @@ func withTrustedProxyActor(cfg ServerConfig) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// warnIfOverwritingUpstreamPrincipal logs a warning when bearer auth has
+// already attached a principal and trusted-proxy mode is about to overwrite
+// it. An operator who configured both modes on the same listener gets
+// per-request visibility that the proxy header is silently winning, so they
+// can either accept the topology or split the modes onto separate listeners.
+func warnIfOverwritingUpstreamPrincipal(ctx context.Context, logger *slog.Logger, localAddr net.Addr, headerName string) {
+	existing, ok := PrincipalFromContext(ctx)
+	if !ok {
+		return
+	}
+	switch existing.Kind {
+	case PrincipalDBToken, PrincipalStaticToken, PrincipalBootstrap:
+	default:
+		return
+	}
+	listener := ""
+	if localAddr != nil {
+		listener = localAddr.String()
+	}
+	logger.Warn("trusted-proxy header overwriting upstream principal",
+		"listener", listener,
+		"upstream_kind", string(existing.Kind),
+		"upstream_actor", existing.Actor,
+		"header", headerName)
 }

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -1,6 +1,7 @@
 package daemon_test
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
 )
 
 // startTrustedProxyTestServer pre-binds a loopback TCP listener, then builds a
@@ -45,6 +47,52 @@ func startTrustedProxyTestServer(t *testing.T, headerName string) *httptest.Serv
 	ts.Start()
 	t.Cleanup(ts.Close)
 	return ts
+}
+
+// bearerProxyOpts carries the per-test bearer policy for
+// startBearerProxyTestServer. Token is the static or bootstrap value
+// requireBearer compares the Authorization header against; identity-mode is
+// opt-in (RequireTokenIdentity must be true AND Token must be non-empty since
+// checkAuthStartup enforces that pairing, but Serve uses raw NewServer so the
+// constraint is also relied on by the tests below).
+type bearerProxyOpts struct {
+	Token                string
+	RequireTokenIdentity bool
+}
+
+// startBearerProxyTestServer is the sibling of startTrustedProxyTestServer
+// that also wires bearer auth. The two layers stack in production: requireBearer
+// runs first and admits/refuses; withTrustedProxyActor runs second and
+// overwrites the principal on trusted listeners. None of the original
+// trusted-proxy e2e tests exercise that stacking, so this helper exists to add
+// targeted coverage. Returns the server and the DB so identity-mode tests can
+// mint DB tokens against the same store the daemon resolves through.
+func startBearerProxyTestServer(t *testing.T, headerName string, auth bearerProxyOpts) (*httptest.Server, *db.DB) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	d := openTestDB(t)
+	cfg := daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+		Auth: config.AuthConfig{
+			Token:                auth.Token,
+			RequireTokenIdentity: auth.RequireTokenIdentity,
+			Proxy: config.ProxyConfig{
+				TrustedActorHeader:    headerName,
+				TrustedProxyListeners: []string{l.Addr().String()},
+			},
+		},
+	}
+	srv := daemon.NewServer(cfg)
+	t.Cleanup(func() { _ = srv.Close() })
+	ts := httptest.NewUnstartedServer(srv.Handler())
+	require.NoError(t, ts.Listener.Close())
+	ts.Listener = l
+	ts.Start()
+	t.Cleanup(ts.Close)
+	return ts, d.db
 }
 
 // trustedProxyCreateProject posts to /api/v1/projects with a path-free init
@@ -300,4 +348,165 @@ func TestTrustedProxyHeader_TUIBypassRequiresCloseValidation(t *testing.T) {
 		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
 		body, map[string]string{"X-Kata-Actor": "proxy-user"})
 	assertAPIError(t, resp.StatusCode, raw, http.StatusBadRequest, "validation")
+}
+
+// TestTrustedProxyHeader_StaticBearerHeaderWins exercises the simplest
+// stacked case: a daemon with both bearer auth (static token) and trusted-
+// proxy mode configured. A request that supplies a valid bearer AND the
+// trusted-proxy header on the trusted listener must succeed, with the header
+// value credited as the actor (not the body actor, and not anything derived
+// from the bearer — static tokens have no associated actor).
+func TestTrustedProxyHeader_StaticBearerHeaderWins(t *testing.T) {
+	ts, _ := startBearerProxyTestServer(t, "X-Kata-Actor",
+		bearerProxyOpts{Token: "static-bearer"})
+	authed := map[string]string{
+		"Authorization": "Bearer static-bearer",
+		"X-Kata-Actor":  "proxy-user",
+	}
+
+	projectID := trustedProxyCreateProject(t, ts, authed)
+	issueRef := trustedProxyCreateIssue(t, ts, projectID, authed)
+
+	body := map[string]any{
+		"actor":    "client-claim",
+		"reason":   "done",
+		"message":  "stacked bearer + proxy must credit the proxy-asserted header value.",
+		"evidence": []map[string]any{{"type": "commit", "sha": "abc1234"}},
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, authed)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "close: %s", raw)
+
+	var payload struct {
+		Event *struct {
+			Actor string `json:"actor"`
+		} `json:"event"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	require.NotNil(t, payload.Event, "close returned no event: %s", raw)
+	assert.Equal(t, "proxy-user", payload.Event.Actor,
+		"bearer auth admits the request; trusted-proxy must still overwrite the actor")
+}
+
+// TestTrustedProxyHeader_StaticBearerMissingHeaderRejects pins the layered
+// error surface: a valid bearer on a trusted listener without the header must
+// fail with 400 actor_header_required (not 401 — bearer was fine — and not a
+// silent body-actor fallback).
+func TestTrustedProxyHeader_StaticBearerMissingHeaderRejects(t *testing.T) {
+	ts, _ := startBearerProxyTestServer(t, "X-Kata-Actor",
+		bearerProxyOpts{Token: "static-bearer"})
+	authed := map[string]string{
+		"Authorization": "Bearer static-bearer",
+		"X-Kata-Actor":  "setup",
+	}
+
+	projectID := trustedProxyCreateProject(t, ts, authed)
+	issueRef := trustedProxyCreateIssue(t, ts, projectID, authed)
+
+	body := map[string]any{
+		"actor":   "client-claim",
+		"reason":  "done",
+		"message": "valid bearer, but no X-Kata-Actor on a trusted listener.",
+		"source":  "tui",
+	}
+	// Same Authorization header, but no X-Kata-Actor.
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, map[string]string{"Authorization": "Bearer static-bearer"})
+	assertAPIError(t, resp.StatusCode, raw, http.StatusBadRequest, "actor_header_required")
+}
+
+// TestTrustedProxyHeader_BadBearerStops401BeforeProxy verifies the middleware
+// ordering at the failure boundary: a request with the trusted-proxy header
+// but a wrong bearer must short-circuit at requireBearer with a token error,
+// never reaching withTrustedProxyActor. Without this test, swapping the
+// middleware order in composition could quietly let the header through on
+// unauthenticated requests.
+func TestTrustedProxyHeader_BadBearerStops401BeforeProxy(t *testing.T) {
+	ts, _ := startBearerProxyTestServer(t, "X-Kata-Actor",
+		bearerProxyOpts{Token: "static-bearer"})
+
+	// Setup uses the right bearer so we have something to close.
+	authed := map[string]string{
+		"Authorization": "Bearer static-bearer",
+		"X-Kata-Actor":  "setup",
+	}
+	projectID := trustedProxyCreateProject(t, ts, authed)
+	issueRef := trustedProxyCreateIssue(t, ts, projectID, authed)
+
+	// The close request supplies a bogus bearer plus the proxy header. The
+	// header should be ignored because requireBearer rejects first.
+	body := map[string]any{
+		"actor":   "client-claim",
+		"reason":  "done",
+		"message": "wrong bearer must reject before the proxy header is considered.",
+		"source":  "tui",
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, map[string]string{
+			"Authorization": "Bearer wrong-bearer",
+			"X-Kata-Actor":  "proxy-user",
+		})
+	assertAPIError(t, resp.StatusCode, raw, http.StatusForbidden, "auth_invalid")
+}
+
+// TestTrustedProxyHeader_DBTokenIdentityHeaderOverwrites exercises the case
+// the spec §3.4 precedence table explicitly calls out: identity-mode bearer
+// admits the request and PR #65's requireIdentityBearer sets
+// PrincipalDBToken{Actor: "bob"}; the trusted-proxy middleware then
+// overwrites that principal with PrincipalTrustedProxy{Actor: "alice"} on the
+// trusted listener. The resulting event must credit "alice" (header), not
+// "bob" (token), not "client-claim" (body). This is the "documented but not
+// encouraged" silent override — pinning it here makes any future drift in
+// either layer fail loudly.
+func TestTrustedProxyHeader_DBTokenIdentityHeaderOverwrites(t *testing.T) {
+	ts, store := startBearerProxyTestServer(t, "X-Kata-Actor",
+		bearerProxyOpts{Token: "bootstrap-token", RequireTokenIdentity: true})
+
+	// Mint a DB-registered token for "bob" so requireIdentityBearer sets
+	// PrincipalDBToken on his requests.
+	bobPlain := "bob-db-token"
+	_, _, err := store.CreateAPIToken(context.Background(), db.CreateAPITokenParams{
+		PlaintextToken: bobPlain,
+		Actor:          "bob",
+		AdminActor:     db.BootstrapActor,
+	})
+	require.NoError(t, err)
+
+	// Setup uses the bootstrap token (allowed in identity mode for admin-
+	// shaped writes) plus the proxy header for actor attribution.
+	setup := map[string]string{
+		"Authorization": "Bearer bootstrap-token",
+		"X-Kata-Actor":  "setup",
+	}
+	projectID := trustedProxyCreateProject(t, ts, setup)
+	issueRef := trustedProxyCreateIssue(t, ts, projectID, setup)
+
+	// The close uses bob's DB token AND a conflicting header value. Header
+	// must win; the DB-token actor "bob" must be silently discarded.
+	body := map[string]any{
+		"actor":    "client-claim",
+		"reason":   "done",
+		"message":  "DB-token identity + proxy header: the header must overwrite the DB identity.",
+		"evidence": []map[string]any{{"type": "commit", "sha": "abc1234"}},
+	}
+	resp, raw := doReq(t, ts, "POST",
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+issueRef+"/actions/close",
+		body, map[string]string{
+			"Authorization": "Bearer " + bobPlain,
+			"X-Kata-Actor":  "alice",
+		})
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "close: %s", raw)
+
+	var payload struct {
+		Event *struct {
+			Actor string `json:"actor"`
+		} `json:"event"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	require.NotNil(t, payload.Event, "close returned no event: %s", raw)
+	assert.Equal(t, "alice", payload.Event.Actor,
+		"trusted-proxy header must overwrite a DB-token identity on a trusted listener")
 }

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -1,12 +1,15 @@
 package daemon_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,22 +63,47 @@ type bearerProxyOpts struct {
 	RequireTokenIdentity bool
 }
 
+// syncBuffer is a goroutine-safe bytes.Buffer wrapper for capturing slog
+// output. The slog handler writes from the request goroutine while the test
+// reads from the test goroutine, so the raw bytes.Buffer's unsynchronized
+// access would race under -race.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 // startBearerProxyTestServer is the sibling of startTrustedProxyTestServer
 // that also wires bearer auth. The two layers stack in production: requireBearer
 // runs first and admits/refuses; withTrustedProxyActor runs second and
 // overwrites the principal on trusted listeners. None of the original
 // trusted-proxy e2e tests exercise that stacking, so this helper exists to add
-// targeted coverage. Returns the server and the DB so identity-mode tests can
-// mint DB tokens against the same store the daemon resolves through.
-func startBearerProxyTestServer(t *testing.T, headerName string, auth bearerProxyOpts) (*httptest.Server, *db.DB) {
+// targeted coverage. Returns the server, the DB (so identity-mode tests can
+// mint DB tokens against the same store the daemon resolves through), and a
+// log capture so tests can assert on the slog warning emitted when a
+// trusted-proxy header overwrites an upstream bearer-derived principal.
+func startBearerProxyTestServer(t *testing.T, headerName string, auth bearerProxyOpts) (*httptest.Server, *db.DB, *syncBuffer) {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	d := openTestDB(t)
+	logs := &syncBuffer{}
 	cfg := daemon.ServerConfig{
 		DB:        d.db,
 		StartedAt: d.now,
+		Logger:    slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
 		Auth: config.AuthConfig{
 			Token:                auth.Token,
 			RequireTokenIdentity: auth.RequireTokenIdentity,
@@ -92,7 +120,7 @@ func startBearerProxyTestServer(t *testing.T, headerName string, auth bearerProx
 	ts.Listener = l
 	ts.Start()
 	t.Cleanup(ts.Close)
-	return ts, d.db
+	return ts, d.db, logs
 }
 
 // trustedProxyCreateProject posts to /api/v1/projects with a path-free init
@@ -357,7 +385,7 @@ func TestTrustedProxyHeader_TUIBypassRequiresCloseValidation(t *testing.T) {
 // value credited as the actor (not the body actor, and not anything derived
 // from the bearer — static tokens have no associated actor).
 func TestTrustedProxyHeader_StaticBearerHeaderWins(t *testing.T) {
-	ts, _ := startBearerProxyTestServer(t, "X-Kata-Actor",
+	ts, _, logs := startBearerProxyTestServer(t, "X-Kata-Actor",
 		bearerProxyOpts{Token: "static-bearer"})
 	authed := map[string]string{
 		"Authorization": "Bearer static-bearer",
@@ -387,6 +415,13 @@ func TestTrustedProxyHeader_StaticBearerHeaderWins(t *testing.T) {
 	require.NotNil(t, payload.Event, "close returned no event: %s", raw)
 	assert.Equal(t, "proxy-user", payload.Event.Actor,
 		"bearer auth admits the request; trusted-proxy must still overwrite the actor")
+
+	// The operator wired both modes on the same listener — daemon should
+	// have warned at least once that the proxy header is silently winning
+	// over the static-token principal.
+	out := logs.String()
+	assert.Contains(t, out, "trusted-proxy header overwriting upstream principal")
+	assert.Contains(t, out, "upstream_kind=static_token")
 }
 
 // TestTrustedProxyHeader_StaticBearerMissingHeaderRejects pins the layered
@@ -394,7 +429,7 @@ func TestTrustedProxyHeader_StaticBearerHeaderWins(t *testing.T) {
 // fail with 400 actor_header_required (not 401 — bearer was fine — and not a
 // silent body-actor fallback).
 func TestTrustedProxyHeader_StaticBearerMissingHeaderRejects(t *testing.T) {
-	ts, _ := startBearerProxyTestServer(t, "X-Kata-Actor",
+	ts, _, _ := startBearerProxyTestServer(t, "X-Kata-Actor",
 		bearerProxyOpts{Token: "static-bearer"})
 	authed := map[string]string{
 		"Authorization": "Bearer static-bearer",
@@ -424,7 +459,7 @@ func TestTrustedProxyHeader_StaticBearerMissingHeaderRejects(t *testing.T) {
 // middleware order in composition could quietly let the header through on
 // unauthenticated requests.
 func TestTrustedProxyHeader_BadBearerStops401BeforeProxy(t *testing.T) {
-	ts, _ := startBearerProxyTestServer(t, "X-Kata-Actor",
+	ts, _, _ := startBearerProxyTestServer(t, "X-Kata-Actor",
 		bearerProxyOpts{Token: "static-bearer"})
 
 	// Setup uses the right bearer so we have something to close.
@@ -461,7 +496,7 @@ func TestTrustedProxyHeader_BadBearerStops401BeforeProxy(t *testing.T) {
 // "bob" (token), not "client-claim" (body). Pin this so a future change that
 // reverses the precedence (or silently merges the two principals) fails here.
 func TestTrustedProxyHeader_DBTokenIdentityHeaderOverwrites(t *testing.T) {
-	ts, store := startBearerProxyTestServer(t, "X-Kata-Actor",
+	ts, store, logs := startBearerProxyTestServer(t, "X-Kata-Actor",
 		bearerProxyOpts{Token: "bootstrap-token", RequireTokenIdentity: true})
 
 	// Mint a DB-registered token for "bob" so requireIdentityBearer sets
@@ -508,4 +543,14 @@ func TestTrustedProxyHeader_DBTokenIdentityHeaderOverwrites(t *testing.T) {
 	require.NotNil(t, payload.Event, "close returned no event: %s", raw)
 	assert.Equal(t, "alice", payload.Event.Actor,
 		"trusted-proxy header must overwrite a DB-token identity on a trusted listener")
+
+	// Bearer identity + proxy attribution stacked → daemon should have
+	// warned about the overwrite so an operator running both modes notices.
+	// The setup calls (project init, issue create) used the bootstrap
+	// token, so the kind in the warning may be either db_token (for the
+	// close) or bootstrap (for setup) — assert on the message and key.
+	out := logs.String()
+	assert.Contains(t, out, "trusted-proxy header overwriting upstream principal")
+	assert.Contains(t, out, "upstream_kind=db_token",
+		"the close request used a DB token; that kind must appear in at least one warning")
 }

--- a/internal/daemon/trusted_actor_e2e_test.go
+++ b/internal/daemon/trusted_actor_e2e_test.go
@@ -452,15 +452,14 @@ func TestTrustedProxyHeader_BadBearerStops401BeforeProxy(t *testing.T) {
 	assertAPIError(t, resp.StatusCode, raw, http.StatusForbidden, "auth_invalid")
 }
 
-// TestTrustedProxyHeader_DBTokenIdentityHeaderOverwrites exercises the case
-// the spec §3.4 precedence table explicitly calls out: identity-mode bearer
-// admits the request and PR #65's requireIdentityBearer sets
+// TestTrustedProxyHeader_DBTokenIdentityHeaderOverwrites exercises the
+// stacked case where bearer identity AND trusted-proxy attribution are both
+// configured. requireIdentityBearer admits the DB token and sets
 // PrincipalDBToken{Actor: "bob"}; the trusted-proxy middleware then
 // overwrites that principal with PrincipalTrustedProxy{Actor: "alice"} on the
 // trusted listener. The resulting event must credit "alice" (header), not
-// "bob" (token), not "client-claim" (body). This is the "documented but not
-// encouraged" silent override — pinning it here makes any future drift in
-// either layer fail loudly.
+// "bob" (token), not "client-claim" (body). Pin this so a future change that
+// reverses the precedence (or silently merges the two principals) fails here.
 func TestTrustedProxyHeader_DBTokenIdentityHeaderOverwrites(t *testing.T) {
 	ts, store := startBearerProxyTestServer(t, "X-Kata-Actor",
 		bearerProxyOpts{Token: "bootstrap-token", RequireTokenIdentity: true})


### PR DESCRIPTION
## Summary

Follow-up to #66. Two related changes:

**Production:** when bearer identity (static token, bootstrap, or DB token) and trusted-proxy mode are both configured and a request lands on a trusted listener, the trusted-proxy middleware silently overwrites the bearer-derived principal. The silent overwrite is documented behavior but invisible to an operator who configured both modes on the same listener. `withTrustedProxyActor` now emits a `slog.Warn` per request with structured fields (`listener`, `upstream_kind`, `upstream_actor`, `header`) so the overwrite is observable in logs. Single-mode deployments stay silent.

`ServerConfig` grows a `Logger *slog.Logger` field defaulting to `slog.Default()`; tests inject a per-test capture without touching the global default.

**Test:** the original trusted-proxy e2e tests built a server with **only** the proxy config — no `Auth.Token`, no `RequireTokenIdentity` — so the `requireBearer → withTrustedProxyActor` chain was never exercised together. Adds a sibling helper (`startBearerProxyTestServer`) that wires both layers and captures the slog output, plus four tests for the four interesting interactions:

- **Static bearer + header on trusted listener** — header wins, body actor ignored. Asserts the overwrite warning fires with `upstream_kind=static_token`.
- **Static bearer + missing header on trusted listener** — `400 actor_header_required` (not 401, since bearer auth succeeds).
- **Wrong bearer + header on trusted listener** — `403 auth_invalid` from `requireBearer` before the proxy middleware can run. Locks the middleware order.
- **Identity-mode DB token + conflicting header** — mints a DB token for `bob`, sends a close with `X-Kata-Actor: alice`. The header wins; the DB-token identity for `bob` is silently discarded. Asserts the warning fires with `upstream_kind=db_token`.

Three commits, total ~290 lines: feat (warning), test (bearer+proxy helper + four tests + warning assertions), small comment cleanup.

## Test plan

- [x] `go test ./internal/daemon/` — all pass
- [x] `go test ./internal/daemon/ -race` — race-clean (the slog capture uses a sync-mutex buffer)
- [x] `golangci-lint run ./internal/daemon/...` — clean