### PR TITLE
Harden JSONL export and import safety

### DIFF
--- a/cmd/kata/export.go
+++ b/cmd/kata/export.go
@@ -111,7 +111,7 @@ func writeExportOutput(ctx context.Context, d *db.DB, output string, opts jsonl.
 }
 
 func replaceExportOutput(tmpName, output string) error {
-	if err := os.Rename(tmpName, output); err != nil {
+	if err := os.Rename(tmpName, output); err != nil { //nolint:gosec // output is the user-requested export destination; tmpName comes from os.CreateTemp in the same dir.
 		return fmt.Errorf("replace export output: %w", err)
 	}
 	return nil

--- a/cmd/kata/export.go
+++ b/cmd/kata/export.go
@@ -110,13 +110,6 @@ func writeExportOutput(ctx context.Context, d *db.DB, output string, opts jsonl.
 	return nil
 }
 
-func replaceExportOutput(tmpName, output string) error {
-	if err := os.Rename(tmpName, output); err != nil { //nolint:gosec // output is the user-requested export destination; tmpName comes from os.CreateTemp in the same dir.
-		return fmt.Errorf("replace export output: %w", err)
-	}
-	return nil
-}
-
 // resolveExportProject reconciles the global --project NAME flag with the
 // local --project-id N flag. NAME is looked up against the projects table
 // since export reads the database directly (the daemon must be stopped).

--- a/cmd/kata/export.go
+++ b/cmd/kata/export.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -48,28 +50,11 @@ func newExportCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			f, err := os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600) //nolint:gosec // output path is user-supplied via --output CLI flag
-			if err != nil {
-				return fmt.Errorf("open export output: %w", err)
-			}
-			bw := bufio.NewWriter(f)
-			if err := jsonl.Export(ctx, d, bw, jsonl.ExportOptions{
+			if err := writeExportOutput(ctx, d, output, jsonl.ExportOptions{
 				ProjectID:      projectID,
 				IncludeDeleted: includeDeleted,
 			}); err != nil {
-				_ = f.Close()
 				return err
-			}
-			if err := bw.Flush(); err != nil {
-				_ = f.Close()
-				return fmt.Errorf("flush export output: %w", err)
-			}
-			if err := f.Sync(); err != nil {
-				_ = f.Close()
-				return fmt.Errorf("sync export output: %w", err)
-			}
-			if err := f.Close(); err != nil {
-				return fmt.Errorf("close export output: %w", err)
 			}
 			if flags.Quiet || flags.JSON {
 				return nil
@@ -88,6 +73,57 @@ func newExportCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", true, "include soft-deleted rows")
 	cmd.Flags().BoolVar(&allowRunningDaemon, "allow-running-daemon", false, "export even if a daemon is running")
 	return cmd
+}
+
+func writeExportOutput(ctx context.Context, d *db.DB, output string, opts jsonl.ExportOptions) error {
+	dir := filepath.Dir(output)
+	base := filepath.Base(output)
+	f, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create export output: %w", err)
+	}
+	tmpName := f.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = f.Close()
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	bw := bufio.NewWriter(f)
+	if err := jsonl.Export(ctx, d, bw, opts); err != nil {
+		return err
+	}
+	if err := bw.Flush(); err != nil {
+		return fmt.Errorf("flush export output: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync export output: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close export output: %w", err)
+	}
+	if err := replaceExportOutput(tmpName, output); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func replaceExportOutput(tmpName, output string) error {
+	if err := os.Rename(tmpName, output); err != nil {
+		if runtime.GOOS == "windows" {
+			if rmErr := os.Remove(output); rmErr != nil && !os.IsNotExist(rmErr) {
+				return fmt.Errorf("replace export output: %w", err)
+			}
+			if retryErr := os.Rename(tmpName, output); retryErr == nil {
+				return nil
+			}
+		}
+		return fmt.Errorf("replace export output: %w", err)
+	}
+	return nil
 }
 
 // resolveExportProject reconciles the global --project NAME flag with the

--- a/cmd/kata/export.go
+++ b/cmd/kata/export.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -113,14 +112,6 @@ func writeExportOutput(ctx context.Context, d *db.DB, output string, opts jsonl.
 
 func replaceExportOutput(tmpName, output string) error {
 	if err := os.Rename(tmpName, output); err != nil {
-		if runtime.GOOS == "windows" {
-			if rmErr := os.Remove(output); rmErr != nil && !os.IsNotExist(rmErr) {
-				return fmt.Errorf("replace export output: %w", err)
-			}
-			if retryErr := os.Rename(tmpName, output); retryErr == nil {
-				return nil
-			}
-		}
 		return fmt.Errorf("replace export output: %w", err)
 	}
 	return nil

--- a/cmd/kata/export_replace_unix.go
+++ b/cmd/kata/export_replace_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func replaceExportOutput(tmpName, output string) error {
+	if err := os.Rename(tmpName, output); err != nil { //nolint:gosec // output is the user-requested export destination; tmpName comes from os.CreateTemp in the same dir.
+		return fmt.Errorf("replace export output: %w", err)
+	}
+	return nil
+}

--- a/cmd/kata/export_replace_windows.go
+++ b/cmd/kata/export_replace_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func replaceExportOutput(tmpName, output string) error {
+	from, err := windows.UTF16PtrFromString(tmpName)
+	if err != nil {
+		return fmt.Errorf("encode export temp path: %w", err)
+	}
+	to, err := windows.UTF16PtrFromString(output)
+	if err != nil {
+		return fmt.Errorf("encode export output path: %w", err)
+	}
+	if err := windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH); err != nil {
+		return fmt.Errorf("replace export output: %w", err)
+	}
+	return nil
+}

--- a/cmd/kata/export_test.go
+++ b/cmd/kata/export_test.go
@@ -83,6 +83,30 @@ func TestExportReplaceOutputDoesNotDeleteExistingOutput(t *testing.T) {
 		"export replacement must not delete the existing backup before replacement succeeds")
 }
 
+func TestExportReplaceOutputUsesWindowsReplacePrimitive(t *testing.T) {
+	bs, err := os.ReadFile("export_replace_windows.go")
+	require.NoError(t, err)
+
+	assert.Contains(t, string(bs), "windows.MoveFileEx")
+	assert.Contains(t, string(bs), "windows.MOVEFILE_REPLACE_EXISTING")
+}
+
+func TestReplaceExportOutputReplacesExistingOutput(t *testing.T) {
+	dir := t.TempDir()
+	output := filepath.Join(dir, "export.jsonl")
+	tmp := filepath.Join(dir, ".export.jsonl.tmp")
+	require.NoError(t, os.WriteFile(output, []byte("old\n"), 0o600))
+	require.NoError(t, os.WriteFile(tmp, []byte("new\n"), 0o600))
+
+	require.NoError(t, replaceExportOutput(tmp, output))
+
+	bs, err := os.ReadFile(output) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, "new\n", string(bs))
+	_, err = os.Stat(tmp)
+	assert.True(t, os.IsNotExist(err), "successful replacement must consume the temp file")
+}
+
 func TestExportAgentOutput(t *testing.T) {
 	home := setupKataEnv(t)
 	dbPath := filepath.Join(home, "kata.db")

--- a/cmd/kata/export_test.go
+++ b/cmd/kata/export_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,6 +72,15 @@ func TestExportDoesNotReplaceExistingOutputOnFailure(t *testing.T) {
 	bs, readErr := os.ReadFile(outPath) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, readErr)
 	assert.Equal(t, "previous backup\n", string(bs))
+}
+
+func TestExportReplaceOutputDoesNotDeleteExistingOutput(t *testing.T) {
+	bs, err := os.ReadFile("export.go")
+	require.NoError(t, err)
+
+	re := regexp.MustCompile(`os\.Remove\(\s*output\s*\)`)
+	assert.NotRegexp(t, re, string(bs),
+		"export replacement must not delete the existing backup before replacement succeeds")
 }
 
 func TestExportAgentOutput(t *testing.T) {

--- a/cmd/kata/export_test.go
+++ b/cmd/kata/export_test.go
@@ -38,6 +38,41 @@ func TestExportWritesJSONLToOutput(t *testing.T) {
 	assert.Contains(t, out, outPath)
 }
 
+func TestExportDoesNotReplaceExistingOutputOnFailure(t *testing.T) {
+	home := setupKataEnv(t)
+	dbPath := filepath.Join(home, "kata.db")
+	ctx := context.Background()
+	d, err := db.Open(ctx, dbPath)
+	require.NoError(t, err)
+	p, err := d.CreateProject(ctx, "kata")
+	require.NoError(t, err)
+	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: p.ID,
+		Title:     "invalid metadata",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	conn, err := d.Conn(ctx)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, `PRAGMA ignore_check_constraints = ON`)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, `UPDATE issues SET metadata = '{' WHERE id = ?`, issue.ID)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, `PRAGMA ignore_check_constraints = OFF`)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	require.NoError(t, d.Close())
+
+	outPath := filepath.Join(home, "export.jsonl")
+	require.NoError(t, os.WriteFile(outPath, []byte("previous backup\n"), 0o600))
+	_, err = runCmdOutput(t, nil, "export", "--output", outPath)
+	require.Error(t, err)
+
+	bs, readErr := os.ReadFile(outPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "previous backup\n", string(bs))
+}
+
 func TestExportAgentOutput(t *testing.T) {
 	home := setupKataEnv(t)
 	dbPath := filepath.Join(home, "kata.db")

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -185,15 +185,15 @@ func installImportedTarget(tmpTarget, target string, force bool) error {
 		if targetExists {
 			return fmt.Errorf("target already exists; pass --force to replace it")
 		}
-		if err := os.Rename(tmpTarget, target); err != nil {
+		if _, err := moveSQLiteFileSet(tmpTarget, target); err != nil {
 			return fmt.Errorf("install import target: %w", err)
 		}
 		return nil
 	}
 
-	backupTarget := target + ".replace.tmp"
-	if err := removeSQLiteFileSetMain(backupTarget); err != nil {
-		return fmt.Errorf("clear stale import target backup: %w", err)
+	backupTarget, err := prepareImportBackupTarget(target)
+	if err != nil {
+		return err
 	}
 	backupMade, err := moveSQLiteFileSet(target, backupTarget)
 	if err != nil {
@@ -202,7 +202,7 @@ func installImportedTarget(tmpTarget, target string, force bool) error {
 			restoreImportedTargetBackup(backupTarget, target, backupMade),
 		)
 	}
-	if err := os.Rename(tmpTarget, target); err != nil {
+	if _, err := moveSQLiteFileSet(tmpTarget, target); err != nil {
 		return errors.Join(
 			fmt.Errorf("install import target: %w", err),
 			restoreImportedTargetBackup(backupTarget, target, backupMade),
@@ -212,6 +212,29 @@ func installImportedTarget(tmpTarget, target string, force bool) error {
 		return fmt.Errorf("remove import target backup: %w", err)
 	}
 	return nil
+}
+
+func prepareImportBackupTarget(target string) (string, error) {
+	dir := filepath.Dir(target)
+	base := filepath.Base(target)
+	f, err := os.CreateTemp(dir, "."+base+".replace-*")
+	if err != nil {
+		return "", fmt.Errorf("create import target backup: %w", err)
+	}
+	backupTarget := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(backupTarget) //nolint:gosec // backupTarget comes from os.CreateTemp above.
+		return "", fmt.Errorf("close import target backup placeholder: %w", err)
+	}
+	if err := os.Remove(backupTarget); err != nil { //nolint:gosec // backupTarget comes from os.CreateTemp above.
+		return "", fmt.Errorf("remove import target backup placeholder: %w", err)
+	}
+	if exists, err := sqliteFileSetExists(backupTarget); err != nil {
+		return "", fmt.Errorf("stat import target backup: %w", err)
+	} else if exists {
+		return "", fmt.Errorf("import target backup already exists: %s", backupTarget)
+	}
+	return backupTarget, nil
 }
 
 func restoreImportedTargetBackup(backupTarget, target string, backupMade bool) error {
@@ -234,7 +257,7 @@ func moveSQLiteFileSet(from, to string) (bool, error) {
 		} else if err != nil {
 			return len(moved) > 0, fmt.Errorf("stat %s: %w", src, err)
 		}
-		if err := os.Rename(src, dst); err != nil { //nolint:gosec // src/dst are SQLite sidecars beside an explicit import target or temp DB.
+		if err := os.Rename(src, dst); err != nil { //nolint:gosec // src/dst are SQLite files beside an explicit import target or temp DB.
 			var rollbackErr error
 			for i := len(moved) - 1; i >= 0; i-- {
 				oldSrc := to + moved[i]

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -166,7 +166,7 @@ func prepareImportTempTarget(target string) (string, func(), error) {
 	}
 	tmpTarget := f.Name()
 	if err := f.Close(); err != nil {
-		_ = os.Remove(tmpTarget)
+		_ = os.Remove(tmpTarget) //nolint:gosec // tmpTarget comes from os.CreateTemp above.
 		return "", nil, fmt.Errorf("close import target placeholder: %w", err)
 	}
 	removeSQLiteFileSetMain(tmpTarget)
@@ -213,7 +213,7 @@ func renameIfExists(from, to string) {
 }
 
 func removeSQLiteFileSetMain(path string) {
-	_ = os.Remove(path)
+	_ = os.Remove(path) //nolint:gosec // path is either os.CreateTemp output or a suffix of explicit --target for import replacement.
 	_ = os.Remove(path + "-wal")
 	_ = os.Remove(path + "-shm")
 }

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -169,8 +170,8 @@ func prepareImportTempTarget(target string) (string, func(), error) {
 		_ = os.Remove(tmpTarget) //nolint:gosec // tmpTarget comes from os.CreateTemp above.
 		return "", nil, fmt.Errorf("close import target placeholder: %w", err)
 	}
-	removeSQLiteFileSetMain(tmpTarget)
-	return tmpTarget, func() { removeSQLiteFileSetMain(tmpTarget) }, nil
+	_ = removeSQLiteFileSetMain(tmpTarget)
+	return tmpTarget, func() { _ = removeSQLiteFileSetMain(tmpTarget) }, nil
 }
 
 func installImportedTarget(tmpTarget, target string, force bool) error {
@@ -182,38 +183,81 @@ func installImportedTarget(tmpTarget, target string, force bool) error {
 	}
 
 	backupTarget := target + ".replace.tmp"
-	removeSQLiteFileSetMain(backupTarget)
+	if err := removeSQLiteFileSetMain(backupTarget); err != nil {
+		return fmt.Errorf("clear stale import target backup: %w", err)
+	}
 	backupMade := false
 	if _, err := os.Stat(target); err == nil {
 		if err := os.Rename(target, backupTarget); err != nil {
 			return fmt.Errorf("backup import target before replace: %w", err)
 		}
 		backupMade = true
-		renameIfExists(target+"-wal", backupTarget+"-wal")
-		renameIfExists(target+"-shm", backupTarget+"-shm")
+		if err := moveSQLiteSidecars(target, backupTarget); err != nil {
+			return errors.Join(
+				fmt.Errorf("backup import target sidecars: %w", err),
+				restoreImportedTargetBackup(backupTarget, target, backupMade),
+			)
+		}
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("stat import target before replace: %w", err)
 	}
 	if err := os.Rename(tmpTarget, target); err != nil {
-		if backupMade {
-			_ = os.Rename(backupTarget, target)
-			renameIfExists(backupTarget+"-wal", target+"-wal")
-			renameIfExists(backupTarget+"-shm", target+"-shm")
-		}
-		return fmt.Errorf("install import target: %w", err)
+		return errors.Join(
+			fmt.Errorf("install import target: %w", err),
+			restoreImportedTargetBackup(backupTarget, target, backupMade),
+		)
 	}
-	removeSQLiteFileSetMain(backupTarget)
+	if err := removeSQLiteFileSetMain(backupTarget); err != nil {
+		return fmt.Errorf("remove import target backup: %w", err)
+	}
 	return nil
 }
 
-func renameIfExists(from, to string) {
-	if _, err := os.Stat(from); err == nil {
-		_ = os.Rename(from, to)
+func restoreImportedTargetBackup(backupTarget, target string, backupMade bool) error {
+	if !backupMade {
+		return nil
 	}
+	if err := os.Rename(backupTarget, target); err != nil {
+		return fmt.Errorf("restore import target backup: %w", err)
+	}
+	if err := moveSQLiteSidecars(backupTarget, target); err != nil {
+		return fmt.Errorf("restore import target sidecars: %w", err)
+	}
+	return nil
 }
 
-func removeSQLiteFileSetMain(path string) {
-	_ = os.Remove(path) //nolint:gosec // path is either os.CreateTemp output or a suffix of explicit --target for import replacement.
-	_ = os.Remove(path + "-wal")
-	_ = os.Remove(path + "-shm")
+func moveSQLiteSidecars(from, to string) error {
+	moved := make([]string, 0, 2)
+	for _, suffix := range []string{"-wal", "-shm"} {
+		src := from + suffix
+		dst := to + suffix
+		if _, err := os.Stat(src); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("stat %s: %w", src, err)
+		}
+		if err := os.Rename(src, dst); err != nil { //nolint:gosec // src/dst are SQLite sidecars beside an explicit import target or temp DB.
+			var rollbackErr error
+			for i := len(moved) - 1; i >= 0; i-- {
+				oldSrc := to + moved[i]
+				oldDst := from + moved[i]
+				if err := os.Rename(oldSrc, oldDst); err != nil { //nolint:gosec // rollback of sidecars just moved by this helper.
+					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("rollback %s: %w", moved[i], err))
+				}
+			}
+			return errors.Join(fmt.Errorf("rename %s: %w", suffix, err), rollbackErr)
+		}
+		moved = append(moved, suffix)
+	}
+	return nil
+}
+
+func removeSQLiteFileSetMain(path string) error {
+	var out error
+	for _, name := range []string{path, path + "-wal", path + "-shm"} {
+		if err := os.Remove(name); err != nil && !os.IsNotExist(err) { //nolint:gosec // path is os.CreateTemp output or a suffix of explicit --target for import replacement.
+			out = errors.Join(out, err)
+		}
+	}
+	return out
 }

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -275,7 +275,7 @@ func moveSQLiteFileSet(from, to string) (bool, error) {
 
 func sqliteFileSetExists(path string) (bool, error) {
 	for _, name := range sqliteFileSetPaths(path) {
-		if _, err := os.Stat(name); err == nil {
+		if _, err := os.Stat(name); err == nil { //nolint:gosec // path is an explicit import target or temp/backup path, plus SQLite sidecars.
 			return true, nil
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return false, err

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -105,14 +105,16 @@ func runKataJSONLImport(cmd *cobra.Command, input, target string, force, newInst
 		"daemon is running for this database; stop it before importing"); err != nil {
 		return err
 	}
-	if _, err := os.Stat(target); err == nil && !force {
+	targetExists, err := sqliteFileSetExists(target)
+	if err != nil {
+		return fmt.Errorf("stat import target: %w", err)
+	}
+	if targetExists && !force {
 		return &cliError{
 			Message:  "target already exists; pass --force to replace it",
 			Kind:     kindValidation,
 			ExitCode: ExitValidation,
 		}
-	} else if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("stat import target: %w", err)
 	}
 	in, err := os.Open(input) //nolint:gosec // import path is user-provided CLI input
 	if err != nil {
@@ -176,6 +178,13 @@ func prepareImportTempTarget(target string) (string, func(), error) {
 
 func installImportedTarget(tmpTarget, target string, force bool) error {
 	if !force {
+		targetExists, err := sqliteFileSetExists(target)
+		if err != nil {
+			return fmt.Errorf("stat import target before install: %w", err)
+		}
+		if targetExists {
+			return fmt.Errorf("target already exists; pass --force to replace it")
+		}
 		if err := os.Rename(tmpTarget, target); err != nil {
 			return fmt.Errorf("install import target: %w", err)
 		}
@@ -186,20 +195,12 @@ func installImportedTarget(tmpTarget, target string, force bool) error {
 	if err := removeSQLiteFileSetMain(backupTarget); err != nil {
 		return fmt.Errorf("clear stale import target backup: %w", err)
 	}
-	backupMade := false
-	if _, err := os.Stat(target); err == nil {
-		if err := os.Rename(target, backupTarget); err != nil {
-			return fmt.Errorf("backup import target before replace: %w", err)
-		}
-		backupMade = true
-		if err := moveSQLiteSidecars(target, backupTarget); err != nil {
-			return errors.Join(
-				fmt.Errorf("backup import target sidecars: %w", err),
-				restoreImportedTargetBackup(backupTarget, target, backupMade),
-			)
-		}
-	} else if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("stat import target before replace: %w", err)
+	backupMade, err := moveSQLiteFileSet(target, backupTarget)
+	if err != nil {
+		return errors.Join(
+			fmt.Errorf("backup import target: %w", err),
+			restoreImportedTargetBackup(backupTarget, target, backupMade),
+		)
 	}
 	if err := os.Rename(tmpTarget, target); err != nil {
 		return errors.Join(
@@ -217,47 +218,59 @@ func restoreImportedTargetBackup(backupTarget, target string, backupMade bool) e
 	if !backupMade {
 		return nil
 	}
-	if err := os.Rename(backupTarget, target); err != nil {
+	if _, err := moveSQLiteFileSet(backupTarget, target); err != nil {
 		return fmt.Errorf("restore import target backup: %w", err)
-	}
-	if err := moveSQLiteSidecars(backupTarget, target); err != nil {
-		return fmt.Errorf("restore import target sidecars: %w", err)
 	}
 	return nil
 }
 
-func moveSQLiteSidecars(from, to string) error {
-	moved := make([]string, 0, 2)
-	for _, suffix := range []string{"-wal", "-shm"} {
+func moveSQLiteFileSet(from, to string) (bool, error) {
+	moved := make([]string, 0, 3)
+	for _, suffix := range []string{"", "-wal", "-shm"} {
 		src := from + suffix
 		dst := to + suffix
 		if _, err := os.Stat(src); errors.Is(err, os.ErrNotExist) {
 			continue
 		} else if err != nil {
-			return fmt.Errorf("stat %s: %w", src, err)
+			return len(moved) > 0, fmt.Errorf("stat %s: %w", src, err)
 		}
 		if err := os.Rename(src, dst); err != nil { //nolint:gosec // src/dst are SQLite sidecars beside an explicit import target or temp DB.
 			var rollbackErr error
 			for i := len(moved) - 1; i >= 0; i-- {
 				oldSrc := to + moved[i]
 				oldDst := from + moved[i]
-				if err := os.Rename(oldSrc, oldDst); err != nil { //nolint:gosec // rollback of sidecars just moved by this helper.
+				if err := os.Rename(oldSrc, oldDst); err != nil { //nolint:gosec // rollback of the SQLite files just moved by this helper.
 					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("rollback %s: %w", moved[i], err))
 				}
 			}
-			return errors.Join(fmt.Errorf("rename %s: %w", suffix, err), rollbackErr)
+			return len(moved) > 0, errors.Join(fmt.Errorf("rename %s: %w", suffix, err), rollbackErr)
 		}
 		moved = append(moved, suffix)
 	}
-	return nil
+	return len(moved) > 0, nil
+}
+
+func sqliteFileSetExists(path string) (bool, error) {
+	for _, name := range sqliteFileSetPaths(path) {
+		if _, err := os.Stat(name); err == nil {
+			return true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+	}
+	return false, nil
 }
 
 func removeSQLiteFileSetMain(path string) error {
 	var out error
-	for _, name := range []string{path, path + "-wal", path + "-shm"} {
+	for _, name := range sqliteFileSetPaths(path) {
 		if err := os.Remove(name); err != nil && !os.IsNotExist(err) { //nolint:gosec // path is os.CreateTemp output or a suffix of explicit --target for import replacement.
 			out = errors.Join(out, err)
 		}
 	}
 	return out
+}
+
+func sqliteFileSetPaths(path string) []string {
+	return []string{path, path + "-wal", path + "-shm"}
 }

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -112,26 +113,38 @@ func runKataJSONLImport(cmd *cobra.Command, input, target string, force, newInst
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("stat import target: %w", err)
 	}
-	if force {
-		if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove import target: %w", err)
-		}
-	}
 	in, err := os.Open(input) //nolint:gosec // import path is user-provided CLI input
 	if err != nil {
 		return fmt.Errorf("open import input: %w", err)
 	}
 	defer func() { _ = in.Close() }()
-	d, err := db.Open(cmd.Context(), target)
+	tmpTarget, cleanupTmp, err := prepareImportTempTarget(target)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = d.Close() }()
+	installed := false
+	defer func() {
+		if !installed {
+			cleanupTmp()
+		}
+	}()
+	d, err := db.Open(cmd.Context(), tmpTarget)
+	if err != nil {
+		return err
+	}
 	if err := jsonl.ImportWithOptions(cmd.Context(), in, d, jsonl.ImportOptions{
 		NewInstance: newInstance,
 	}); err != nil {
+		_ = d.Close()
 		return err
 	}
+	if err := d.Close(); err != nil {
+		return fmt.Errorf("close import target: %w", err)
+	}
+	if err := installImportedTarget(tmpTarget, target, force); err != nil {
+		return err
+	}
+	installed = true
 	if flags.Quiet || flags.JSON {
 		return nil
 	}
@@ -142,4 +155,65 @@ func runKataJSONLImport(cmd *cobra.Command, input, target string, force, newInst
 		_, err = fmt.Fprintf(cmd.OutOrStdout(), "imported %s\n", target)
 	}
 	return err
+}
+
+func prepareImportTempTarget(target string) (string, func(), error) {
+	dir := filepath.Dir(target)
+	base := filepath.Base(target)
+	f, err := os.CreateTemp(dir, "."+base+".import-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create import target: %w", err)
+	}
+	tmpTarget := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpTarget)
+		return "", nil, fmt.Errorf("close import target placeholder: %w", err)
+	}
+	removeSQLiteFileSetMain(tmpTarget)
+	return tmpTarget, func() { removeSQLiteFileSetMain(tmpTarget) }, nil
+}
+
+func installImportedTarget(tmpTarget, target string, force bool) error {
+	if !force {
+		if err := os.Rename(tmpTarget, target); err != nil {
+			return fmt.Errorf("install import target: %w", err)
+		}
+		return nil
+	}
+
+	backupTarget := target + ".replace.tmp"
+	removeSQLiteFileSetMain(backupTarget)
+	backupMade := false
+	if _, err := os.Stat(target); err == nil {
+		if err := os.Rename(target, backupTarget); err != nil {
+			return fmt.Errorf("backup import target before replace: %w", err)
+		}
+		backupMade = true
+		renameIfExists(target+"-wal", backupTarget+"-wal")
+		renameIfExists(target+"-shm", backupTarget+"-shm")
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("stat import target before replace: %w", err)
+	}
+	if err := os.Rename(tmpTarget, target); err != nil {
+		if backupMade {
+			_ = os.Rename(backupTarget, target)
+			renameIfExists(backupTarget+"-wal", target+"-wal")
+			renameIfExists(backupTarget+"-shm", target+"-shm")
+		}
+		return fmt.Errorf("install import target: %w", err)
+	}
+	removeSQLiteFileSetMain(backupTarget)
+	return nil
+}
+
+func renameIfExists(from, to string) {
+	if _, err := os.Stat(from); err == nil {
+		_ = os.Rename(from, to)
+	}
+}
+
+func removeSQLiteFileSetMain(path string) {
+	_ = os.Remove(path)
+	_ = os.Remove(path + "-wal")
+	_ = os.Remove(path + "-shm")
 }

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -145,6 +145,50 @@ func TestInstallImportedTargetForceRemovesSidecarsWhenMainTargetIsMissing(t *tes
 	assert.True(t, os.IsNotExist(statErr), "force import must remove stale shm sidecar")
 }
 
+func TestInstallImportedTargetForcePreservesUserFileAtDeterministicBackupPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.db")
+	tmpTarget := filepath.Join(dir, "imported.db")
+	userFile := target + ".replace.tmp"
+	require.NoError(t, os.WriteFile(target, []byte("old-db"), 0o600))
+	require.NoError(t, os.WriteFile(tmpTarget, []byte("new-db"), 0o600))
+	require.NoError(t, os.WriteFile(userFile, []byte("keep-me"), 0o600))
+
+	require.NoError(t, installImportedTarget(tmpTarget, target, true))
+
+	gotTarget, readErr := os.ReadFile(target) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "new-db", string(gotTarget))
+	gotUserFile, readErr := os.ReadFile(userFile) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "keep-me", string(gotUserFile))
+}
+
+func TestInstallImportedTargetMovesTempSidecars(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.db")
+	tmpTarget := filepath.Join(dir, "imported.db")
+	require.NoError(t, os.WriteFile(tmpTarget, []byte("new-db"), 0o600))
+	require.NoError(t, os.WriteFile(tmpTarget+"-wal", []byte("new-wal"), 0o600))
+	require.NoError(t, os.WriteFile(tmpTarget+"-shm", []byte("new-shm"), 0o600))
+
+	require.NoError(t, installImportedTarget(tmpTarget, target, false))
+
+	gotTarget, readErr := os.ReadFile(target) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "new-db", string(gotTarget))
+	gotWAL, readErr := os.ReadFile(target + "-wal") //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "new-wal", string(gotWAL))
+	gotSHM, readErr := os.ReadFile(target + "-shm") //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "new-shm", string(gotSHM))
+	_, statErr := os.Stat(tmpTarget + "-wal")
+	assert.True(t, os.IsNotExist(statErr), "installed import must not leave wal sidecar at temp path")
+	_, statErr = os.Stat(tmpTarget + "-shm")
+	assert.True(t, os.IsNotExist(statErr), "installed import must not leave shm sidecar at temp path")
+}
+
 func TestImportForcePreservesExistingTargetOnFailure(t *testing.T) {
 	home := setupKataEnv(t)
 	input := filepath.Join(home, "bad.jsonl")
@@ -180,7 +224,7 @@ func TestImportFailureRemovesNewPartialTarget(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "failed import must not leave a partial target DB")
 }
 
-func TestInstallImportedTargetForceFailsBeforeReplaceOnStaleSidecarCleanupError(t *testing.T) {
+func TestInstallImportedTargetForcePreservesUserDirectoryAtDeterministicBackupSidecarPath(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target.db")
 	tmpTarget := filepath.Join(dir, "imported.db")
@@ -191,19 +235,16 @@ func TestInstallImportedTargetForceFailsBeforeReplaceOnStaleSidecarCleanupError(
 	require.NoError(t, os.Mkdir(backupWALDir, 0o700))
 	require.NoError(t, os.WriteFile(filepath.Join(backupWALDir, "block"), []byte("x"), 0o600))
 
-	err := installImportedTarget(tmpTarget, target, true)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "clear stale import target backup")
+	require.NoError(t, installImportedTarget(tmpTarget, target, true))
 
 	gotTarget, readErr := os.ReadFile(target) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, readErr)
-	assert.Equal(t, "old-db", string(gotTarget))
-	gotWAL, readErr := os.ReadFile(target + "-wal") //nolint:gosec // test fixture under TempDir
+	assert.Equal(t, "new-db", string(gotTarget))
+	_, statErr := os.Stat(target + "-wal")
+	assert.True(t, os.IsNotExist(statErr), "force import must remove the old target wal")
+	gotBlock, readErr := os.ReadFile(filepath.Join(backupWALDir, "block")) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, readErr)
-	assert.Equal(t, "old-wal", string(gotWAL))
-	gotTmp, readErr := os.ReadFile(tmpTarget) //nolint:gosec // test fixture under TempDir
-	require.NoError(t, readErr)
-	assert.Equal(t, "new-db", string(gotTmp))
+	assert.Equal(t, "x", string(gotBlock))
 }
 
 func TestMoveSQLiteFileSetRollsBackAlreadyMovedSidecarOnError(t *testing.T) {

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -111,6 +111,40 @@ func TestImportRejectsExistingTargetWithoutForce(t *testing.T) {
 	assert.Contains(t, ce.Message, "target already exists")
 }
 
+func TestImportRejectsExistingTargetSidecarWithoutForce(t *testing.T) {
+	_, input, target := setupImportTest(t)
+	require.NoError(t, os.WriteFile(target+"-wal", []byte("stale-wal"), 0o600))
+
+	_, err := runCmdOutput(t, nil, "import", "--input", input, "--target", target)
+	ce := requireCLIError(t, err, ExitValidation)
+	assert.Contains(t, ce.Message, "target already exists")
+
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr), "non-force import must not install beside stale sidecars")
+	gotWAL, readErr := os.ReadFile(target + "-wal") //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "stale-wal", string(gotWAL))
+}
+
+func TestInstallImportedTargetForceRemovesSidecarsWhenMainTargetIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.db")
+	tmpTarget := filepath.Join(dir, "imported.db")
+	require.NoError(t, os.WriteFile(tmpTarget, []byte("new-db"), 0o600))
+	require.NoError(t, os.WriteFile(target+"-wal", []byte("stale-wal"), 0o600))
+	require.NoError(t, os.WriteFile(target+"-shm", []byte("stale-shm"), 0o600))
+
+	require.NoError(t, installImportedTarget(tmpTarget, target, true))
+
+	gotTarget, readErr := os.ReadFile(target) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "new-db", string(gotTarget))
+	_, statErr := os.Stat(target + "-wal")
+	assert.True(t, os.IsNotExist(statErr), "force import must remove stale wal sidecar")
+	_, statErr = os.Stat(target + "-shm")
+	assert.True(t, os.IsNotExist(statErr), "force import must remove stale shm sidecar")
+}
+
 func TestImportForcePreservesExistingTargetOnFailure(t *testing.T) {
 	home := setupKataEnv(t)
 	input := filepath.Join(home, "bad.jsonl")
@@ -172,7 +206,7 @@ func TestInstallImportedTargetForceFailsBeforeReplaceOnStaleSidecarCleanupError(
 	assert.Equal(t, "new-db", string(gotTmp))
 }
 
-func TestMoveSQLiteSidecarsRollsBackAlreadyMovedSidecarOnError(t *testing.T) {
+func TestMoveSQLiteFileSetRollsBackAlreadyMovedSidecarOnError(t *testing.T) {
 	dir := t.TempDir()
 	from := filepath.Join(dir, "from.db")
 	to := filepath.Join(dir, "to.db")
@@ -181,8 +215,9 @@ func TestMoveSQLiteSidecarsRollsBackAlreadyMovedSidecarOnError(t *testing.T) {
 	require.NoError(t, os.Mkdir(to+"-shm", 0o700))
 	require.NoError(t, os.WriteFile(filepath.Join(to+"-shm", "block"), []byte("x"), 0o600))
 
-	err := moveSQLiteSidecars(from, to)
+	moved, err := moveSQLiteFileSet(from, to)
 	require.Error(t, err)
+	assert.True(t, moved)
 
 	gotWAL, readErr := os.ReadFile(from + "-wal") //nolint:gosec // test fixture under TempDir
 	require.NoError(t, readErr)

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -146,6 +146,54 @@ func TestImportFailureRemovesNewPartialTarget(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "failed import must not leave a partial target DB")
 }
 
+func TestInstallImportedTargetForceFailsBeforeReplaceOnStaleSidecarCleanupError(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.db")
+	tmpTarget := filepath.Join(dir, "imported.db")
+	backupWALDir := target + ".replace.tmp-wal"
+	require.NoError(t, os.WriteFile(target, []byte("old-db"), 0o600))
+	require.NoError(t, os.WriteFile(target+"-wal", []byte("old-wal"), 0o600))
+	require.NoError(t, os.WriteFile(tmpTarget, []byte("new-db"), 0o600))
+	require.NoError(t, os.Mkdir(backupWALDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(backupWALDir, "block"), []byte("x"), 0o600))
+
+	err := installImportedTarget(tmpTarget, target, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "clear stale import target backup")
+
+	gotTarget, readErr := os.ReadFile(target) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "old-db", string(gotTarget))
+	gotWAL, readErr := os.ReadFile(target + "-wal") //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "old-wal", string(gotWAL))
+	gotTmp, readErr := os.ReadFile(tmpTarget) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "new-db", string(gotTmp))
+}
+
+func TestMoveSQLiteSidecarsRollsBackAlreadyMovedSidecarOnError(t *testing.T) {
+	dir := t.TempDir()
+	from := filepath.Join(dir, "from.db")
+	to := filepath.Join(dir, "to.db")
+	require.NoError(t, os.WriteFile(from+"-wal", []byte("wal"), 0o600))
+	require.NoError(t, os.WriteFile(from+"-shm", []byte("shm"), 0o600))
+	require.NoError(t, os.Mkdir(to+"-shm", 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(to+"-shm", "block"), []byte("x"), 0o600))
+
+	err := moveSQLiteSidecars(from, to)
+	require.Error(t, err)
+
+	gotWAL, readErr := os.ReadFile(from + "-wal") //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "wal", string(gotWAL))
+	gotSHM, readErr := os.ReadFile(from + "-shm") //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, "shm", string(gotSHM))
+	_, statErr := os.Stat(to + "-wal")
+	assert.True(t, os.IsNotExist(statErr), "rolled back wal sidecar must not remain at destination")
+}
+
 func TestImportRefusesDaemon(t *testing.T) {
 	home, input, target := setupImportTest(t)
 	dbPath := filepath.Join(home, "kata.db")

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -111,6 +111,41 @@ func TestImportRejectsExistingTargetWithoutForce(t *testing.T) {
 	assert.Contains(t, ce.Message, "target already exists")
 }
 
+func TestImportForcePreservesExistingTargetOnFailure(t *testing.T) {
+	home := setupKataEnv(t)
+	input := filepath.Join(home, "bad.jsonl")
+	require.NoError(t, os.WriteFile(input, []byte(`{"kind":"issue","data":{}}`+"\n"), 0o600))
+	target := filepath.Join(home, "target.db")
+	ctx := context.Background()
+	d, err := db.Open(ctx, target)
+	require.NoError(t, err)
+	_, err = d.CreateProject(ctx, "existing")
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	_, err = runCmdOutput(t, nil, "import", "--force", "--input", input, "--target", target)
+	require.Error(t, err)
+
+	d, err = db.Open(ctx, target)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+	_, err = d.ProjectByName(ctx, "existing")
+	require.NoError(t, err)
+}
+
+func TestImportFailureRemovesNewPartialTarget(t *testing.T) {
+	home := setupKataEnv(t)
+	input := filepath.Join(home, "bad.jsonl")
+	require.NoError(t, os.WriteFile(input, []byte(`{"kind":"issue","data":{}}`+"\n"), 0o600))
+	target := filepath.Join(home, "target.db")
+
+	_, err := runCmdOutput(t, nil, "import", "--input", input, "--target", target)
+	require.Error(t, err)
+
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr), "failed import must not leave a partial target DB")
+}
+
 func TestImportRefusesDaemon(t *testing.T) {
 	home, input, target := setupImportTest(t)
 	dbPath := filepath.Join(home, "kata.db")

--- a/internal/db/commit_result_audit_test.go
+++ b/internal/db/commit_result_audit_test.go
@@ -1,0 +1,34 @@
+package db_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMutationHelpersDoNotReturnResultsWithCommitCall(t *testing.T) {
+	root := filepath.Join("..", "..", "internal", "db")
+	riskyReturn := regexp.MustCompile(`return\s+.*,\s*tx\.Commit\(\)`)
+	var offenders []string
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		require.NoError(t, err)
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		bs, err := os.ReadFile(path) //nolint:gosec // test reads checked-in source files.
+		require.NoError(t, err)
+		lines := strings.Split(string(bs), "\n")
+		for i, line := range lines {
+			if riskyReturn.MatchString(line) {
+				offenders = append(offenders, filepath.ToSlash(path)+":"+strconv.Itoa(i+1)+": "+strings.TrimSpace(line))
+			}
+		}
+		return nil
+	}))
+	require.Empty(t, offenders, "commit errors must be checked before returning mutation result values")
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1124,7 +1124,10 @@ func (d *DB) CloseIssueWithEvents(
 		return Issue{}, nil, false, err
 	}
 	if issue.Status == "closed" {
-		return issue, nil, false, tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return Issue{}, nil, false, err
+		}
+		return issue, nil, false, nil
 	}
 	if hasOpen, err := txHasOpenChildren(ctx, tx, issue.ProjectID, issueID); err != nil {
 		return Issue{}, nil, false, err
@@ -1298,7 +1301,10 @@ func (d *DB) ReopenIssue(
 		return Issue{}, nil, false, err
 	}
 	if issue.Status == "open" {
-		return issue, nil, false, tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return Issue{}, nil, false, err
+		}
+		return issue, nil, false, nil
 	}
 	reopenedAt := time.Now().UTC().Format(sqliteTimeFormat)
 	if _, err := tx.ExecContext(ctx,
@@ -1369,7 +1375,10 @@ func (d *DB) EditIssue(ctx context.Context, p EditIssueParams) (Issue, *Event, b
 		return Issue{}, nil, false, err
 	}
 	if !changed {
-		return issue, nil, false, tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return Issue{}, nil, false, err
+		}
+		return issue, nil, false, nil
 	}
 	sets = append([]string{`updated_at = ?`}, sets...)
 	args = append([]any{ts}, args...)
@@ -1545,7 +1554,10 @@ func (d *DB) UpdateOwner(ctx context.Context, issueID int64, newOwner *string, a
 	}
 	// No-op: same owner.
 	if ownerEqual(issue.Owner, newOwner) {
-		return issue, nil, false, tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return Issue{}, nil, false, err
+		}
+		return issue, nil, false, nil
 	}
 
 	ts := nowTimestamp()

--- a/internal/db/queries_priority.go
+++ b/internal/db/queries_priority.go
@@ -29,7 +29,10 @@ func (d *DB) UpdatePriority(ctx context.Context, issueID int64, newPriority *int
 		return Issue{}, nil, false, err
 	}
 	if priorityEqual(issue.Priority, newPriority) {
-		return issue, nil, false, tx.Commit()
+		if err := tx.Commit(); err != nil {
+			return Issue{}, nil, false, err
+		}
+		return issue, nil, false, nil
 	}
 
 	ts := nowTimestamp()

--- a/internal/jsonl/decoder.go
+++ b/internal/jsonl/decoder.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -22,21 +23,30 @@ func NewDecoder(r io.Reader) *Decoder {
 // ReadAll reads every envelope, enforcing the fixed kind order and requiring
 // meta.export_version as the first record.
 func (d *Decoder) ReadAll(ctx context.Context) ([]Envelope, error) {
-	scanner := bufio.NewScanner(d.r)
-	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	reader := bufio.NewReader(d.r)
 
 	var (
 		out      []Envelope
 		lineNo   int
 		lastRank = -1
 	)
-	for scanner.Scan() {
+	for {
+		lineBytes, err := reader.ReadBytes('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("read jsonl: %w", err)
+		}
+		if len(lineBytes) == 0 {
+			break
+		}
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
 		lineNo++
-		line := bytes.TrimSpace(scanner.Bytes())
+		line := bytes.TrimSpace(lineBytes)
 		if len(line) == 0 {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			continue
 		}
 
@@ -58,9 +68,9 @@ func (d *Decoder) ReadAll(ctx context.Context) ([]Envelope, error) {
 		}
 		lastRank = rank
 		out = append(out, env)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan jsonl: %w", err)
+		if errors.Is(err, io.EOF) {
+			break
+		}
 	}
 	if len(out) == 0 {
 		return nil, ErrMissingExportVersion

--- a/internal/jsonl/export.go
+++ b/internal/jsonl/export.go
@@ -18,8 +18,28 @@ type ExportOptions struct {
 	IncludeDeleted bool
 }
 
+type exportQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
 // Export writes a deterministic JSONL export of d to w.
 func Export(ctx context.Context, d *db.DB, w io.Writer, opts ExportOptions) error {
+	tx, err := d.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return fmt.Errorf("begin export snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := exportSnapshot(ctx, tx, w, opts); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit export snapshot: %w", err)
+	}
+	return nil
+}
+
+func exportSnapshot(ctx context.Context, d exportQuerier, w io.Writer, opts ExportOptions) error {
 	enc := NewEncoder(w)
 
 	version, err := schemaVersion(ctx, d)
@@ -109,7 +129,7 @@ type metaRecord struct {
 	Value string `json:"value"`
 }
 
-func schemaVersion(ctx context.Context, d *db.DB) (string, error) {
+func schemaVersion(ctx context.Context, d exportQuerier) (string, error) {
 	var version string
 	if err := d.QueryRowContext(ctx, `SELECT value FROM meta WHERE key='schema_version'`).Scan(&version); err != nil {
 		return "", fmt.Errorf("read schema_version: %w", err)
@@ -117,7 +137,7 @@ func schemaVersion(ctx context.Context, d *db.DB) (string, error) {
 	return version, nil
 }
 
-func exportMeta(ctx context.Context, d *db.DB, enc *Encoder) error {
+func exportMeta(ctx context.Context, d exportQuerier, enc *Encoder) error {
 	rows, err := d.QueryContext(ctx, `SELECT key, value FROM meta ORDER BY key ASC`)
 	if err != nil {
 		return fmt.Errorf("export meta: %w", err)
@@ -135,7 +155,7 @@ func exportMeta(ctx context.Context, d *db.DB, enc *Encoder) error {
 	return rows.Err()
 }
 
-func exportProjects(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
+func exportProjects(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
 	hasIdentity, err := tableHasColumn(ctx, d, "projects", "identity")
 	if err != nil {
 		return err
@@ -202,7 +222,7 @@ func exportProjects(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 // physical schema) does not surface this. The import path defaults
 // metadata to {} and revision to 1 when those fields are absent from a
 // record, so omitting them here produces correct v10 rows downstream.
-func exportProjectsV8(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportProjectsV8(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID        int64   `json:"id"`
 		UID       string  `json:"uid"`
@@ -230,7 +250,7 @@ func exportProjectsV8(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOp
 
 // exportProjectsV7 emits the v7 projects projection (with next_issue_number
 // and without the identity column). Used when cutting over from a v7 source.
-func exportProjectsV7(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportProjectsV7(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID              int64   `json:"id"`
 		UID             string  `json:"uid"`
@@ -259,7 +279,7 @@ func exportProjectsV7(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOp
 	})
 }
 
-func exportProjectsV4(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportProjectsV4(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID              int64   `json:"id"`
 		UID             string  `json:"uid"`
@@ -292,7 +312,7 @@ func exportProjectsV4(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOp
 // exportProjectsV2 covers schema versions 2 and 3 (UID present, deleted_at
 // absent). Kept distinct so cutover from v3→v4 reads the source via the
 // pre-v4 column list and lets the import path default deleted_at to NULL.
-func exportProjectsV2(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportProjectsV2(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID              int64  `json:"id"`
 		UID             string `json:"uid"`
@@ -319,7 +339,7 @@ func exportProjectsV2(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOp
 	})
 }
 
-func exportProjectsV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportProjectsV1(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID              int64  `json:"id"`
 		Identity        string `json:"identity"`
@@ -345,7 +365,7 @@ func exportProjectsV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOp
 	})
 }
 
-func exportProjectAliases(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportProjectAliases(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID            int64  `json:"id"`
 		ProjectID     int64  `json:"project_id"`
@@ -376,7 +396,7 @@ func exportProjectAliases(ctx context.Context, d *db.DB, enc *Encoder, opts Expo
 	})
 }
 
-func exportRecurrences(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportRecurrences(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID                  int64           `json:"id"`
 		UID                 string          `json:"uid"`
@@ -452,7 +472,7 @@ func exportRecurrences(ctx context.Context, d *db.DB, enc *Encoder, opts ExportO
 	})
 }
 
-func exportIssues(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
+func exportIssues(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
 	if sourceSchemaVersion < 2 {
 		return exportIssuesV1(ctx, d, enc, opts)
 	}
@@ -525,7 +545,7 @@ func exportIssues(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOption
 // exist on a real v8/v9 source DB. The import path defaults Metadata to
 // {} and Revision to 1 when those fields are absent from a record, so
 // omitting them here lets v9 rows replay cleanly into the v10 schema.
-func exportIssuesV8(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportIssuesV8(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID           int64   `json:"id"`
 		UID          string  `json:"uid"`
@@ -565,7 +585,7 @@ func exportIssuesV8(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 // exportIssuesV6 emits the schema_version 6..7 issue projection (with priority
 // and the now-dropped number column). Cutover from a pre-short_id source DB
 // lands here; targets at v8+ derive short_ids during replay (Task 9).
-func exportIssuesV6(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportIssuesV6(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID           int64   `json:"id"`
 		UID          string  `json:"uid"`
@@ -605,7 +625,7 @@ func exportIssuesV6(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 // exportIssuesV2 emits the schema_version 2..5 issue projection (no priority
 // column). Cutover from a pre-priority source DB lands here; targets at v6+
 // silently default priority to NULL on import.
-func exportIssuesV2(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportIssuesV2(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID           int64   `json:"id"`
 		UID          string  `json:"uid"`
@@ -641,7 +661,7 @@ func exportIssuesV2(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 	})
 }
 
-func exportIssuesV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportIssuesV1(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID           int64   `json:"id"`
 		ProjectID    int64   `json:"project_id"`
@@ -676,7 +696,7 @@ func exportIssuesV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 	})
 }
 
-func exportComments(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
+func exportComments(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
 	if sourceSchemaVersion < 12 {
 		return exportCommentsV10(ctx, d, enc, opts)
 	}
@@ -704,7 +724,7 @@ func exportComments(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 	})
 }
 
-func exportCommentsV10(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportCommentsV10(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID        int64  `json:"id"`
 		IssueID   int64  `json:"issue_id"`
@@ -728,7 +748,7 @@ func exportCommentsV10(ctx context.Context, d *db.DB, enc *Encoder, opts ExportO
 	})
 }
 
-func exportIssueLabels(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportIssueLabels(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		IssueID   int64  `json:"issue_id"`
 		Label     string `json:"label"`
@@ -751,7 +771,7 @@ func exportIssueLabels(ctx context.Context, d *db.DB, enc *Encoder, opts ExportO
 	})
 }
 
-func exportLinks(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
+func exportLinks(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
 	if sourceSchemaVersion < 2 {
 		return exportLinksV1(ctx, d, enc, opts)
 	}
@@ -786,7 +806,7 @@ func exportLinks(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions
 	})
 }
 
-func exportLinksV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportLinksV1(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID          int64  `json:"id"`
 		ProjectID   int64  `json:"project_id"`
@@ -815,7 +835,7 @@ func exportLinksV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptio
 	})
 }
 
-func exportImportMappings(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportImportMappings(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID              int64   `json:"id"`
 		Source          string  `json:"source"`
@@ -865,7 +885,7 @@ func exportImportMappings(ctx context.Context, d *db.DB, enc *Encoder, opts Expo
 	})
 }
 
-func exportFederationBindings(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportFederationBindings(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ProjectID            int64   `json:"project_id"`
 		Role                 string  `json:"role"`
@@ -910,7 +930,7 @@ func exportFederationBindings(ctx context.Context, d *db.DB, enc *Encoder, opts 
 	})
 }
 
-func exportFederationSyncStatus(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportFederationSyncStatus(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ProjectID         int64   `json:"project_id"`
 		LastPullStartedAt *string `json:"last_pull_started_at,omitempty"`
@@ -945,7 +965,7 @@ func exportFederationSyncStatus(ctx context.Context, d *db.DB, enc *Encoder, opt
 	})
 }
 
-func exportFederationQuarantine(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportFederationQuarantine(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID           int64           `json:"id"`
 		ProjectID    int64           `json:"project_id"`
@@ -990,7 +1010,7 @@ func exportFederationQuarantine(ctx context.Context, d *db.DB, enc *Encoder, opt
 	})
 }
 
-func exportFederationEnrollments(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportFederationEnrollments(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID               int64   `json:"id"`
 		TokenHash        string  `json:"token_hash"`
@@ -1022,7 +1042,7 @@ func exportFederationEnrollments(ctx context.Context, d *db.DB, enc *Encoder, op
 	})
 }
 
-func exportIssueClaims(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions) error {
+func exportIssueClaims(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
 	type record struct {
 		ID                int64   `json:"id"`
 		ClaimUID          string  `json:"claim_uid"`
@@ -1070,7 +1090,7 @@ func exportIssueClaims(ctx context.Context, d *db.DB, enc *Encoder, opts ExportO
 
 func exportPendingClaimRequests(
 	ctx context.Context,
-	d *db.DB,
+	d exportQuerier,
 	enc *Encoder,
 	opts ExportOptions,
 ) error {
@@ -1121,7 +1141,7 @@ func exportPendingClaimRequests(
 	})
 }
 
-func exportEvents(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
+func exportEvents(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
 	projectNameExpr, joinProjects := eventProjectNameExpr(sourceSchemaVersion)
 	if sourceSchemaVersion < 2 {
 		return exportEventsV1(ctx, d, enc, opts, projectNameExpr, joinProjects)
@@ -1227,7 +1247,7 @@ func exportEvents(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOption
 	})
 }
 
-func exportEventsV8(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
+func exportEventsV8(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
 	type record struct {
 		ID                int64           `json:"id"`
 		UID               string          `json:"uid"`
@@ -1281,7 +1301,7 @@ func exportEventsV8(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 
 // exportEventsV3 emits the v3..v7 events projection (with the now-dropped
 // issue_number column). Cutover from a pre-short_id source DB lands here.
-func exportEventsV3(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
+func exportEventsV3(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
 	type record struct {
 		ID                int64           `json:"id"`
 		UID               string          `json:"uid"`
@@ -1334,7 +1354,7 @@ func exportEventsV3(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 	})
 }
 
-func exportEventsV2(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
+func exportEventsV2(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
 	type record struct {
 		ID              int64           `json:"id"`
 		ProjectID       int64           `json:"project_id"`
@@ -1393,7 +1413,7 @@ func exportEventsV2(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 	})
 }
 
-func exportEventsV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
+func exportEventsV1(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
 	type record struct {
 		ID             int64           `json:"id"`
 		ProjectID      int64           `json:"project_id"`
@@ -1443,7 +1463,7 @@ func exportEventsV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 	})
 }
 
-func exportPurgeLog(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
+func exportPurgeLog(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, sourceSchemaVersion int) error {
 	projectNameExpr, joinProjects, err := purgeProjectNameExpr(ctx, d, sourceSchemaVersion)
 	if err != nil {
 		return err
@@ -1509,7 +1529,7 @@ func exportPurgeLog(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOpti
 
 // exportPurgeLogV3 emits the v3..v7 purge_log projection (with the now-dropped
 // issue_number column). Cutover from a pre-short_id source DB lands here.
-func exportPurgeLogV3(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
+func exportPurgeLogV3(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
 	type record struct {
 		ID                     int64   `json:"id"`
 		UID                    string  `json:"uid"`
@@ -1560,7 +1580,7 @@ func exportPurgeLogV3(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOp
 	})
 }
 
-func exportPurgeLogV2(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
+func exportPurgeLogV2(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
 	type record struct {
 		ID                     int64   `json:"id"`
 		ProjectID              int64   `json:"project_id"`
@@ -1609,7 +1629,7 @@ func exportPurgeLogV2(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOp
 	})
 }
 
-func exportPurgeLogV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
+func exportPurgeLogV1(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions, projectNameExpr, joinProjects string) error {
 	type record struct {
 		ID                     int64   `json:"id"`
 		ProjectID              int64   `json:"project_id"`
@@ -1655,7 +1675,7 @@ func exportPurgeLogV1(ctx context.Context, d *db.DB, enc *Encoder, opts ExportOp
 	})
 }
 
-func tableHasColumn(ctx context.Context, d *db.DB, table, column string) (bool, error) {
+func tableHasColumn(ctx context.Context, d exportQuerier, table, column string) (bool, error) {
 	rows, err := d.QueryContext(ctx, `PRAGMA table_info(`+table+`)`)
 	if err != nil {
 		return false, fmt.Errorf("inspect %s columns: %w", table, err)
@@ -1687,7 +1707,7 @@ func eventProjectNameExpr(sourceSchemaVersion int) (expr, joinProjects string) {
 	return "events.project_name", ""
 }
 
-func purgeProjectNameExpr(ctx context.Context, d *db.DB, sourceSchemaVersion int) (expr, joinProjects string, err error) {
+func purgeProjectNameExpr(ctx context.Context, d exportQuerier, sourceSchemaVersion int) (expr, joinProjects string, err error) {
 	if sourceSchemaVersion < 7 {
 		hasLegacy, err := tableHasColumn(ctx, d, "purge_log", "project_identity")
 		if err != nil {
@@ -1771,7 +1791,7 @@ func joinClauses(clauses []string) string {
 	return out
 }
 
-func exportSQLiteSequence(ctx context.Context, d *db.DB, enc *Encoder) error {
+func exportSQLiteSequence(ctx context.Context, d exportQuerier, enc *Encoder) error {
 	type record struct {
 		Name string `json:"name"`
 		Seq  int64  `json:"seq"`

--- a/internal/jsonl/export_test.go
+++ b/internal/jsonl/export_test.go
@@ -189,6 +189,37 @@ func TestExportProjectIDFiltersProjectScopedRows(t *testing.T) {
 	assertProjectIDs(t, records, map[int64]bool{p1.ID: true})
 }
 
+func TestExportUsesSingleSnapshot(t *testing.T) {
+	ctx, d, p := newExportEnv(t)
+	w := &mutatingExportWriter{
+		triggerNeedle: []byte(`"kind":"project"`),
+		trigger: func() {
+			createTesterIssue(ctx, t, d, p.ID, "created during export", "")
+		},
+	}
+
+	require.NoError(t, jsonl.Export(ctx, d, w, jsonl.ExportOptions{IncludeDeleted: true}))
+
+	records := decodeJSONLLines(t, w.Bytes())
+	assertRecordsDoNotContain(t, records, "created during export")
+}
+
+type mutatingExportWriter struct {
+	bytes.Buffer
+	triggerNeedle []byte
+	triggered     bool
+	trigger       func()
+}
+
+func (w *mutatingExportWriter) Write(p []byte) (int, error) {
+	n, err := w.Buffer.Write(p)
+	if !w.triggered && bytes.Contains(p, w.triggerNeedle) {
+		w.triggered = true
+		w.trigger()
+	}
+	return n, err
+}
+
 func TestExportNoIncludeDeletedOmitsSoftDeletedIssueDependents(t *testing.T) {
 	ctx, d, p := newExportEnv(t)
 	kept := createTesterIssue(ctx, t, d, p.ID, "kept issue", "")

--- a/internal/jsonl/import_test.go
+++ b/internal/jsonl/import_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,6 +46,31 @@ func TestImportRoundTripsExportedRows(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, issue.ShortID, got.ShortID)
 	assert.Equal(t, issue.Title, got.Title)
+}
+
+func TestImportRoundTripsExportedLargeIssueBody(t *testing.T) {
+	ctx := context.Background()
+	src := openExportTestDB(t)
+	p, err := src.CreateProject(ctx, "kata")
+	require.NoError(t, err)
+	body := strings.Repeat("large-body-", 2*1024*1024)
+	issue, _, err := src.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: p.ID,
+		Title:     "large round trip",
+		Body:      body,
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+
+	var exported bytes.Buffer
+	require.NoError(t, jsonl.Export(ctx, src, &exported, jsonl.ExportOptions{IncludeDeleted: true}))
+
+	dst := openImportTargetDB(t)
+	require.NoError(t, jsonl.Import(ctx, bytes.NewReader(exported.Bytes()), dst))
+
+	got, err := dst.IssueByID(ctx, issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, body, got.Body)
 }
 
 func TestImportSQLiteSequenceUsesUpdateOrInsert(t *testing.T) {

--- a/prek.toml
+++ b/prek.toml
@@ -4,6 +4,6 @@ default_stages = ["pre-commit"]
 [[repos]]
 repo = "local"
 hooks = [
-  { id = "make-lint", name = "make lint", entry = "make lint", language = "system", pass_filenames = false, always_run = true },
+  { id = "make-lint", name = "make lint", entry = "make lint", language = "system", stages = ["pre-push"], pass_filenames = false, always_run = true },
   { id = "nilaway", name = "nilaway", entry = "make nilaway", language = "system", stages = ["pre-push"], types_or = ["go", "go-mod", "go-sum"], pass_filenames = false },
 ]


### PR DESCRIPTION
## Summary
- remove the JSONL decoder scanner token cap so large issue bodies round-trip
- export from a single read-only snapshot and replace export files only after temp-file sync/close succeeds
- import into a temp DB and install it only after replay succeeds, preserving existing targets on failed forced imports
- audit mutation no-op paths so commit errors are checked before returning result values
- address review #20995 by removing the Windows delete-and-retry export fallback

## Verification
- `go test ./... -count=1`
