### PR TITLE
Adopt existing projects and restore federation's local-first intent

### DIFF
--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -288,6 +288,13 @@ func federationJoinCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if bundle.AdoptExisting && !bundle.PushEnabled {
+				return &cliError{
+					Message:  "--adopt-existing requires --push",
+					Kind:     kindValidation,
+					ExitCode: ExitValidation,
+				}
+			}
 			if err := validateFederationJoinCapabilities(internalCaps, bundle.PushEnabled); err != nil {
 				return err
 			}
@@ -322,6 +329,7 @@ func federationJoinCmd() *cobra.Command {
 					"token":                     bundle.Token,
 					"capabilities":              internalCaps,
 					"push_enabled":              bundle.PushEnabled,
+					"adopt_existing":            bundle.AdoptExisting,
 				})
 			if err != nil {
 				return err
@@ -343,6 +351,7 @@ func federationJoinCmd() *cobra.Command {
 	cmd.Flags().StringVar(&bundle.Token, "token", "", "enrollment token")
 	cmd.Flags().StringVar(&bundle.DisplayCapabilities, "capabilities", "pull,push,lease", "comma-separated capabilities: pull,push,lease")
 	cmd.Flags().BoolVar(&bundle.PushEnabled, "push", false, "enable spoke push")
+	cmd.Flags().BoolVar(&bundle.AdoptExisting, "adopt-existing", false, "adopt matching existing local data into the federation")
 	return cmd
 }
 
@@ -400,6 +409,7 @@ type federationJoinBundle struct {
 	Capabilities           string `json:"capabilities,omitempty"`
 	DisplayCapabilities    string `json:"-"`
 	PushEnabled            bool   `json:"push_enabled,omitempty"`
+	AdoptExisting          bool   `json:"adopt_existing,omitempty"`
 }
 
 func hydrateFederationJoinMetadata(ctx context.Context, bundle *federationJoinBundle) error {
@@ -617,10 +627,18 @@ func printFederationJoin(cmd *cobra.Command, bs []byte) error {
 			agentRowField("project", body.Project.Name),
 			agentRowField("project_id", strconv.FormatInt(body.Project.ID, 10)),
 			agentRowField("push_enabled", strconv.FormatBool(body.Binding.PushEnabled)),
+			agentRowField("adopted", strconv.FormatBool(body.Adopted)),
+			agentRowField("adoption_snapshots", strconv.FormatInt(body.AdoptionSnapshotCount, 10)),
 		)
 	}
 	if flags.Quiet {
 		return nil
+	}
+	if body.Adopted {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"adopted existing project %s into federation\nqueued %d issue snapshots for hub push; local event history was not imported\nexisting issues now require hub leases before edits\n",
+			textsafe.Line(body.Project.Name), body.AdoptionSnapshotCount)
+		return err
 	}
 	_, err := fmt.Fprintf(cmd.OutOrStdout(), "joined federation project %s (push-enabled: %t)\n",
 		textsafe.Line(body.Project.Name), body.Binding.PushEnabled)
@@ -709,6 +727,9 @@ func federationJoinCommand(bundle federationJoinBundle) string {
 	}
 	if bundle.PushEnabled {
 		args = append(args, "--push")
+	}
+	if bundle.AdoptExisting {
+		args = append(args, "--adopt-existing")
 	}
 	quoted := make([]string, 0, len(args))
 	for _, arg := range args {

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -636,7 +636,7 @@ func printFederationJoin(cmd *cobra.Command, bs []byte) error {
 	}
 	if body.Adopted {
 		_, err := fmt.Fprintf(cmd.OutOrStdout(),
-			"adopted existing project %s into federation\nqueued %d issue snapshots for hub push; local event history was not imported\nexisting issues now require hub leases before edits\n",
+			"adopted existing project %s into federation\nqueued %d issue snapshots for hub push; pre-adoption local event history was removed\nfuture edits remain local-first; acquire leases only for exclusive coordination\n",
 			textsafe.Line(body.Project.Name), body.AdoptionSnapshotCount)
 		return err
 	}

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -421,8 +421,9 @@ func TestFederationJoinCLIAdoptExistingOutput(t *testing.T) {
 		"--adopt-existing")
 
 	assert.Contains(t, out, "adopted existing project fedlab into federation")
-	assert.Contains(t, out, "queued 1 issue snapshots for hub push; local event history was not imported")
-	assert.Contains(t, out, "existing issues now require hub leases before edits")
+	assert.Contains(t, out, "queued 1 issue snapshots for hub push; pre-adoption local event history was removed")
+	assert.Contains(t, out, "future edits remain local-first; acquire leases only for exclusive coordination")
+	assert.NotContains(t, out, "require hub leases before edits")
 }
 
 func TestFederationJoinCLIAgentOutputIncludesAdoptionFields(t *testing.T) {

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -333,6 +333,40 @@ func TestFederationJoinCLIRequiresPushCapabilityWhenPushEnabled(t *testing.T) {
 	assert.Contains(t, err.Error(), "push")
 }
 
+func TestFederationJoinCLIAdoptExistingRequiresPush(t *testing.T) {
+	env := testenv.New(t)
+
+	_, err := runCmdOutput(t, env, "federation", "join",
+		"--project", "fedlab",
+		"--hub-url", "http://127.0.0.1:7787",
+		"--hub-project-id", "42",
+		"--hub-project-uid", "01HZNQ7VFPK1XGD8R5MABCD4EG",
+		"--replay-horizon", "7",
+		"--token", "join-token",
+		"--adopt-existing")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--adopt-existing requires --push")
+}
+
+func TestFederationJoinCLIAdoptExistingRequiresPushCapability(t *testing.T) {
+	env := testenv.New(t)
+
+	_, err := runCmdOutput(t, env, "federation", "join",
+		"--project", "fedlab",
+		"--hub-url", "http://127.0.0.1:7787",
+		"--hub-project-id", "42",
+		"--hub-project-uid", "01HZNQ7VFPK1XGD8R5MABCD4EG",
+		"--replay-horizon", "7",
+		"--token", "join-token",
+		"--adopt-existing",
+		"--push",
+		"--capabilities", "pull,lease")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "push")
+}
+
 func TestFederationJoinCLICreatesPushEnabledReplicaAndCredential(t *testing.T) {
 	env := testenv.New(t)
 	hubProjectUID := "01HZNQ7VFPK1XGD8R5MABCD4EG"
@@ -360,6 +394,63 @@ func TestFederationJoinCLICreatesPushEnabledReplicaAndCredential(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "join-token", creds.Projects[project.UID].Token)
 	assert.Equal(t, "claim,pull,push", creds.Projects[project.UID].Capabilities)
+}
+
+func TestFederationJoinCLIAdoptExistingOutput(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	project, err := env.DB.CreateProject(ctx, "fedlab")
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "local issue",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	hubProjectUID := "01HZNQ7VFPK1XGD8R5MABCD4EG"
+
+	out := requireCmdOutput(t, env, "federation", "join",
+		"--project", "fedlab",
+		"--hub-url", "http://100.64.0.5:7787",
+		"--hub-project-id", "42",
+		"--hub-project-uid", hubProjectUID,
+		"--replay-horizon", "7",
+		"--baseline-through", "9",
+		"--token", "join-token",
+		"--push",
+		"--adopt-existing")
+
+	assert.Contains(t, out, "adopted existing project fedlab into federation")
+	assert.Contains(t, out, "queued 1 issue snapshots for hub push; local event history was not imported")
+	assert.Contains(t, out, "existing issues now require hub leases before edits")
+}
+
+func TestFederationJoinCLIAgentOutputIncludesAdoptionFields(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	project, err := env.DB.CreateProject(ctx, "fedlab")
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "local issue",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	hubProjectUID := "01HZNQ7VFPK1XGD8R5MABCD4EG"
+
+	out := requireCmdOutput(t, env, "--agent", "federation", "join",
+		"--project", "fedlab",
+		"--hub-url", "http://100.64.0.5:7787",
+		"--hub-project-id", "42",
+		"--hub-project-uid", hubProjectUID,
+		"--replay-horizon", "7",
+		"--baseline-through", "9",
+		"--token", "join-token",
+		"--push",
+		"--adopt-existing")
+
+	assert.Contains(t, out, "adopted=true")
+	assert.Contains(t, out, "adoption_snapshots=1")
 }
 
 func TestFederationJoinCLIFetchesMissingHubMetadata(t *testing.T) {

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -199,6 +199,13 @@ On each spoke:
    remain local-first; use live hub leases only when you want exclusive
    coordination.
 
+   Adoption is a current-state cutover rather than a history merge. Operators
+   who need the pre-adoption event timeline for audit or rollback context should
+   run a scoped JSONL export before `--adopt-existing`, for example
+   `kata --project <project> export --output <path>.jsonl`. The federated event
+   stream starts from the adoption snapshots; kata does not currently retain a
+   separate in-product archive of pre-adoption events.
+
 Enrollment capabilities and local spoke behavior are separate knobs:
 `--capabilities pull,push,lease` on the hub says what the token may do, while
 `--push` on the spoke says this replica should actually push local-origin events

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -165,7 +165,8 @@ On each spoke:
    present.
 
    If the spoke already has a non-federated local project that should join the
-   hub under the same name, opt in explicitly:
+   hub under the same name, opt in explicitly with `--adopt-existing`, which
+   requires `--push`:
 
    ```bash
    kata federation join --project fedlab \

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -192,13 +192,12 @@ On each spoke:
 
    Adoption preserves the current state of local issues, including closed and
    soft-deleted issues, comments, labels, metadata, priority, owner, and
-   same-project links. It does not import the old local event history; instead
-   it queues fresh snapshots for the hub with same-project links embedded in the
-   snapshot payloads. That local-only event history is audit context below the
-   push cursor and may be discarded by a
-   later federation reset. After adoption, existing issues are ordinary
-   federated spoke issues. Future edits remain local-first; use live hub leases
-   only when you want exclusive coordination.
+   same-project links. It does not preserve the old local event history.
+   Instead it removes those pre-adoption local events and queues fresh snapshots
+   for the hub with same-project links embedded in the snapshot payloads. After
+   adoption, existing issues are ordinary federated spoke issues. Future edits
+   remain local-first; use live hub leases only when you want exclusive
+   coordination.
 
 Enrollment capabilities and local spoke behavior are separate knobs:
 `--capabilities pull,push,lease` on the hub says what the token may do, while

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -197,7 +197,8 @@ On each spoke:
    snapshot payloads. That local-only event history is audit context below the
    push cursor and may be discarded by a
    later federation reset. After adoption, existing issues are ordinary
-   federated spoke issues, so future edits require live hub leases.
+   federated spoke issues. Future edits remain local-first; use live hub leases
+   only when you want exclusive coordination.
 
 Enrollment capabilities and local spoke behavior are separate knobs:
 `--capabilities pull,push,lease` on the hub says what the token may do, while
@@ -207,8 +208,8 @@ spoke remains pull-only and the CLI prints a warning.
 
 The transport routes use enrollment bearer tokens. Local operator routes,
 including `kata federation status`, quarantine skip, force-release, and purge,
-use the normal daemon local/admin auth surface. Federated hub purge also
-requires the acting actor to hold the live issue lease; an operator can
+use the normal daemon local/admin auth surface. Federated hub purge uses the
+same live-lease conflict gate as other issue mutations; an operator can
 force-release first when an abandoned lease blocks destructive maintenance.
 
 The daemon federation runner polls every 30 seconds by default. For tests,
@@ -266,18 +267,31 @@ requests to the hub using an enrollment token with `claim` capability. The hub
 derives `holder_instance_uid` from that enrollment token; clients provide the
 human-readable holder string.
 
-For federated projects, mutations of existing issues, including comments,
-require a live lease. Creating new issues does not require a lease. Spokes use
-their cached lease state to gate local writes. When online, stale status is
-refreshed from the hub. When offline, cached hard leases can still be used so
-work is not lost. Timed leases expire by hub time.
+Leases exist for agent coordination, not for general edit permission. An agent
+acquires a lease to signal "I am actively working this issue" and to get
+temporary exclusivity against other non-comment mutations while the lease is
+live. Status and audit surfaces can then show who is actively working. A lease
+does not replace durable `owner`, does not serialize all collaboration, and is
+not required before ordinary federated edits.
+
+For federated projects, ordinary edits of existing issues are local-first and
+converge by LWW. Creating new issues is also local-first. A lease is optional
+coordination: when another holder has a live lease on an affected existing
+issue, non-comment mutations are denied until the lease is released or expires.
+Comments bypass leases because they are append-only.
+
+Spokes refresh cached lease state before checking exclusivity when online.
+When offline, cached hard leases can still be used as a continuity hint, but
+they are not proof that exclusivity still holds. Timed leases expire by hub
+time and stop blocking edits once expired.
 
 The hub checks pushed work against the live lease state at ingest time. Work
-that is not covered is not dropped; the hub records `claim.violated`. This is
-best-effort, not a causal proof that the work was unauthorized when originally
-performed. An offline edit that was covered at edit time can arrive after a
-release or force-release and be marked violated because the hub checks current
-state during ingest.
+that conflicts with another holder's live lease is not dropped; the hub records
+`claim.violated`. Work on unleased issues is normal and is not a violation.
+This is best-effort, not a causal proof that the work was unauthorized when
+originally performed. An offline edit that was covered at edit time can arrive
+after another holder acquires a lease and be marked violated because the hub
+checks current state during ingest.
 
 `kata show` surfaces the current lease and recent unresolved lease violations
 for a federated issue. `kata federation status` shows project-level counts and
@@ -393,15 +407,15 @@ outage, a hub operator can force-release the lease or another actor can acquire
 a later lease. When the offline work reconnects, the hub keeps the data but can
 record `claim.violated`.
 
-Use a shared daemon when leases must be enforced strictly online and stale
-offline leases are unacceptable.
+Use a shared daemon when every write must be serialized through one online
+authority and stale offline lease state is unacceptable.
 
 ### Lease Violation Signals Are Best-Effort
 
 Violation annotation checks live hub lease state at ingest time, not historical
 lease state at the event's HLC timestamp. It is an operational signal for
-"work arrived without currently valid coverage", not a complete audit proof of
-user intent or causal authorization.
+"work arrived while another holder currently has a live lease", not a complete
+audit proof of user intent or causal authorization.
 
 Use a shared daemon when lease compliance must be decided at the exact write
 time.

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -164,6 +164,40 @@ On each spoke:
    the local federation credentials file, and enables push only when `--push` is
    present.
 
+   If the spoke already has a non-federated local project that should join the
+   hub under the same name, opt in explicitly:
+
+   ```bash
+   kata federation join --project fedlab \
+     --hub-url http://<private-hub-ip>:7787 \
+     --hub-project-id 1 \
+     --token ... \
+     --push \
+     --adopt-existing
+   ```
+
+   Adoption works even when the local project name differs from the hub project
+   name; choose the local project with `--project` and the hub with the hub
+   selector:
+
+   ```bash
+   kata federation join --project shared-foo \
+     --hub-url http://<private-hub-ip>:7787 \
+     --hub-project-id 1 \
+     --token ... \
+     --push \
+     --adopt-existing
+   ```
+
+   Adoption preserves the current state of local issues, including closed and
+   soft-deleted issues, comments, labels, metadata, priority, owner, and
+   same-project links. It does not import the old local event history; instead
+   it queues fresh snapshots for the hub with same-project links embedded in the
+   snapshot payloads. That local-only event history is audit context below the
+   push cursor and may be discarded by a
+   later federation reset. After adoption, existing issues are ordinary
+   federated spoke issues, so future edits require live hub leases.
+
 Enrollment capabilities and local spoke behavior are separate knobs:
 `--capabilities pull,push,lease` on the hub says what the token may do, while
 `--push` on the spoke says this replica should actually push local-origin events
@@ -256,6 +290,8 @@ kata federation enable --project <project>
 kata federation enroll --project <project> --spoke-instance <uid> --hub-url <url>
 kata federation join --project <project> --hub-url <url> --hub-project-id <id> \
   --token <token> [--push]
+kata federation join --project <existing-project> --hub-url <url> --hub-project-id <id> \
+  --token <token> --push --adopt-existing
 kata federation enrollments list
 kata federation revoke <enrollment-id>
 kata federation status

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -119,11 +119,10 @@ with `--project` and the hub project with the hub selector.
 
 Adoption preserves the current state of local issues, including closed and
 soft-deleted issues, comments, labels, metadata, priority, owner, and
-same-project links. It does not import the old local event history. Instead it
-queues fresh snapshots for the hub with same-project links embedded in the
-snapshot payloads, and reports how many snapshots were queued. That local-only
-history stays as audit context below the push cursor and may be discarded by a
-later reset.
+same-project links. It does not preserve the old local event history. Instead
+it removes those pre-adoption local events, queues fresh snapshots for the hub
+with same-project links embedded in the snapshot payloads, and reports how many
+snapshots were queued.
 
 Adopted issues become ordinary federated spoke issues. You can keep editing
 them locally; acquire a hub lease only when you want exclusive coordination.

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -124,6 +124,12 @@ it removes those pre-adoption local events, queues fresh snapshots for the hub
 with same-project links embedded in the snapshot payloads, and reports how many
 snapshots were queued.
 
+> **Preserving the pre-adoption timeline:** Adoption is a cutover, not an
+> in-place history merge. If you need the old local event timeline for audit or
+> rollback context, run `kata --project <project> export --output <path>.jsonl`
+> before `kata federation join --adopt-existing`. kata does not currently keep a
+> separate in-product archive of pre-adoption events.
+
 Adopted issues become ordinary federated spoke issues. You can keep editing
 them locally; acquire a hub lease only when you want exclusive coordination.
 

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -125,8 +125,8 @@ snapshot payloads, and reports how many snapshots were queued. That local-only
 history stays as audit context below the push cursor and may be discarded by a
 later reset.
 
-After adoption, the adopted issues are ordinary federated spoke issues, so
-editing one requires a live hub lease.
+Adopted issues become ordinary federated spoke issues, so editing one requires
+a live hub lease.
 
 ## Sync model
 

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -100,6 +100,34 @@ Enrollment capabilities and local spoke behavior are separate:
 If a token has `push` but the spoke joins without `--push`, the spoke remains
 pull-only and the CLI prints a warning.
 
+### Adopting an existing project
+
+If a spoke already has a non-federated local project that should join the hub,
+add `--adopt-existing`. Adoption requires `--push`:
+
+```sh
+kata federation join --project fedlab \
+  --hub-url http://100.64.0.5:7787 \
+  --hub-project-id 1 \
+  --token ... \
+  --push \
+  --adopt-existing
+```
+
+The local and hub project names do not have to match. Select the local project
+with `--project` and the hub project with the hub selector.
+
+Adoption preserves the current state of local issues, including closed and
+soft-deleted issues, comments, labels, metadata, priority, owner, and
+same-project links. It does not import the old local event history. Instead it
+queues fresh snapshots for the hub with same-project links embedded in the
+snapshot payloads, and reports how many snapshots were queued. That local-only
+history stays as audit context below the push cursor and may be discarded by a
+later reset.
+
+After adoption, the adopted issues are ordinary federated spoke issues, so
+editing one requires a live hub lease.
+
 ## Sync model
 
 A spoke polls the hub for events after its pull cursor. It applies hub events
@@ -144,6 +172,8 @@ kata federation enable --project <project>
 kata federation enroll --project <project> --spoke-instance <uid> --hub-url <url>
 kata federation join --project <project> --hub-url <url> --hub-project-id <id> \
   --token <token> [--push]
+kata federation join --project <existing-project> --hub-url <url> \
+  --hub-project-id <id> --token <token> --push --adopt-existing
 kata federation enrollments list
 kata federation revoke <enrollment-id>
 kata federation status

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -125,8 +125,8 @@ snapshot payloads, and reports how many snapshots were queued. That local-only
 history stays as audit context below the push cursor and may be discarded by a
 later reset.
 
-Adopted issues become ordinary federated spoke issues, so editing one requires
-a live hub lease.
+Adopted issues become ordinary federated spoke issues. You can keep editing
+them locally; acquire a hub lease only when you want exclusive coordination.
 
 ## Sync model
 
@@ -153,16 +153,28 @@ status requests to the hub with an enrollment token that has lease capability.
 The hub derives `holder_instance_uid` from the enrollment token; clients provide
 the human-readable holder string.
 
-For federated projects, mutating existing issues, including comments, requires
-a live lease. Creating new issues does not require a lease because there is no
-existing issue to lease.
+Use leases when an agent or operator wants to say "I am actively working this
+issue; avoid overlapping non-comment edits until I release it." Holding a lease
+gives temporary exclusivity against other non-comment mutations while the lease
+is live. It also gives status and audit surfaces a clear current holder for
+coordination. It does not grant durable ownership, replace the issue `owner`
+field, serialize all collaboration, or act as a prerequisite for ordinary
+edits.
 
-Spokes gate local writes with cached lease state. When online, stale status is
-refreshed from the hub. When offline, cached hard leases can still be used so
-work is not lost. Timed leases expire by hub time.
+For federated projects, ordinary issue edits are local-first and converge by
+LWW. Creating new issues also stays local-first. A lease is optional
+coordination: when another holder has a live lease on an affected existing
+issue, non-comment mutations are denied until the lease is released or expires.
+Comments bypass leases because they are append-only.
 
-The hub checks pushed work against live lease state at ingest time. Uncovered
-work is kept, but the hub records `claim.violated`.
+Spokes refresh cached lease state before checking exclusivity when online.
+When offline, cached hard leases can still be used as a continuity hint, but
+they are not proof that exclusivity still holds. Timed leases expire by hub
+time and stop blocking edits once expired.
+
+The hub checks pushed work against live lease state at ingest time. Work that
+conflicts with another holder's live lease is kept, but the hub records
+`claim.violated`. Work on unleased issues is normal and is not a violation.
 
 ## Operator commands
 
@@ -208,7 +220,7 @@ hub.
 
 Hard purge is hub-admin-only for federated projects. A spoke rejects hard purge
 with `federated_admin_required`. A hub purge uses normal local/admin daemon
-auth, exact confirmation, and the same live-lease gate as other issue
+auth, exact confirmation, and the same live-lease conflict gate as other issue
 mutations.
 
 When a hub purge removes replay history, it records a reset boundary and writes
@@ -227,7 +239,8 @@ Federation has expected stale or deferred states:
 - Local spoke writes happen before hub acceptance.
 - Offline cached hard leases can later be superseded.
 - Lease violation signals are best-effort at ingest time, not proof of causal
-  authorization at original edit time.
+  authorization at original edit time. Unleased edits are expected and are not
+  violations.
 - Poisoned push batches require operator choice.
 - Hub outages degrade lease acquisition, pull, push, and status freshness.
 - Purge causes spoke re-bootstrap.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -224,6 +224,10 @@ kata federation quarantine skip <id> --confirm "SKIP FEDERATION BATCH <id>" --re
 ```
 
 Federation is an operator workflow. Most users never need these commands.
+Issue edits on push-enabled federated spokes remain local-first; use
+`kata federation lease acquire` only when you want exclusive coordination on an
+issue. A live lease held by another actor blocks non-comment mutations until it
+is released or expires.
 
 ## Ref forms
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -213,6 +213,8 @@ kata federation enable --project <project>
 kata federation enroll --project <project> --spoke-instance <uid> --hub-url <url>
 kata federation join --project <project> --hub-url <url> --hub-project-id <id> \
   --token <token> [--push]
+kata federation join --project <existing-project> --hub-url <url> \
+  --hub-project-id <id> --token <token> --push --adopt-existing
 kata federation status
 kata federation enrollments list
 kata federation revoke <enrollment-id>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -223,6 +223,11 @@ kata federation lease release <issue-ref>
 kata federation quarantine skip <id> --confirm "SKIP FEDERATION BATCH <id>" --reason <text>
 ```
 
+`--adopt-existing` is a current-state cutover. It removes the local project's
+pre-adoption event history from the live event stream and queues fresh snapshots
+for federation. Run `kata --project <project> export --output <path>.jsonl`
+first if you need to retain that local event timeline.
+
 Federation is an operator workflow. Most users never need these commands.
 Issue edits on push-enabled federated spokes remain local-first; use
 `kata federation lease acquire` only when you want exclusive coordination on an

--- a/docs/superpowers/plans/2026-05-31-federation-lww-claim-gate.md
+++ b/docs/superpowers/plans/2026-05-31-federation-lww-claim-gate.md
@@ -1,0 +1,115 @@
+# Federation LWW Claim Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore federation's local-first edit semantics so ordinary unclaimed edits are allowed, active claims only deny conflicting holders, and unclaimed ingest is not flagged as a lease violation.
+
+**Architecture:** Keep the existing claim table and daemon gate, but change the absence-of-claim branch from mandatory lease enforcement to pass-through. Update docs so D1, claim gating, operations, and CLI reference all describe claims as optional coordination with enforcement only when a live claim exists.
+
+**Tech Stack:** Go, SQLite-backed `internal/db`, daemon HTTP handlers, kata federation docs.
+
+---
+
+### Task 1: Database Claim Gate Semantics
+
+**Files:**
+- Modify: `internal/db/claims_test.go`
+- Modify: `internal/db/federation_test.go`
+- Modify: `internal/db/claims.go`
+
+- [x] **Step 1: Write failing tests**
+
+Add or update tests proving:
+- `CheckClaimGate` allows an unclaimed issue.
+- A pending claim does not authorize exclusivity and does not block ordinary edits.
+- An expired timed claim is treated as absent for edit gating.
+- Adoption clearing claims leaves edits allowed rather than claim-required.
+- Hub ingest emits `claim.violated` only for conflicts with another live claim, not for unclaimed work.
+
+- [x] **Step 2: Run tests to verify red**
+
+Run: `go test ./internal/db -run 'TestClaimGate|TestPendingClaimDoesNotSatisfyClaimGate|TestAdoptProjectIntoFederation'`
+
+Expected: FAIL because current code returns `ErrClaimRequired` or `ErrPendingClaimNotAuthoritative`.
+
+- [x] **Step 3: Implement minimal gate change**
+
+In `CheckClaimGate`, return nil when no live claim exists. If the live claim is an expired timed claim, return nil before holder comparison. Keep `ErrClaimDenied` for a live unexpired claim held by someone else.
+
+- [x] **Step 4: Run database tests**
+
+Run: `go test ./internal/db -run 'TestClaimGate|TestPendingClaimDoesNotSatisfyClaimGate|TestAdoptProjectIntoFederation'`
+
+Expected: PASS.
+
+### Task 2: Daemon Gate Behavior
+
+**Files:**
+- Modify: `internal/daemon/claim_gate_helper_test.go`
+- Modify: `internal/daemon/claim_gate_handlers_test.go`
+
+- [x] **Step 1: Write failing handler tests**
+
+Update helper and handler expectations so unclaimed federated issues mutate successfully, comments bypass the claim gate, while live claims held by another actor still return `claim_denied` for non-comment mutations.
+
+- [x] **Step 2: Run tests to verify red or regression exposure**
+
+Run: `go test ./internal/daemon -run 'TestClaimGateHelper|TestFederatedClaimGate'`
+
+Expected before Task 1 implementation: FAIL on unclaimed mutations. After Task 1, these should pass once expectations are updated.
+
+- [x] **Step 3: Keep daemon production code scoped**
+
+Remove the comment creation claim gate if tests show comments still block on another holder's live lease. Otherwise keep daemon production code scoped to stale error mapping or status-refresh behavior that still blocks unclaimed edits.
+
+- [x] **Step 4: Run daemon tests**
+
+Run: `go test ./internal/daemon -run 'TestClaimGateHelper|TestFederatedClaimGate'`
+
+Expected: PASS.
+
+### Task 3: Documentation And Spec Cleanup
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-20-kata-federation-design.md`
+- Modify: `docs/design/federation.md`
+- Modify: `docs/operations/federation.md`
+- Modify: `docs/reference/cli.md`
+- Modify other federation docs found by `rg "lease required|lease acquire|claim_required|editing.*lease|valid claim"`
+
+- [x] **Step 1: Update spec wording**
+
+Make D1 and §9.4 agree: ordinary edits are async/LWW; claims are exclusive coordination; a live claim denies conflicting work; unclaimed edits are normal; live-claim conflicts are audited, not dropped.
+
+- [x] **Step 2: Update user-facing docs**
+
+Replace "lease required before editing" wording with "acquire a lease when you want exclusive coordination; edits are denied only if another holder has a live lease."
+
+- [x] **Step 3: Search for stale wording**
+
+Run: `rg -n "lease required|claim_required|valid claim|holds a valid claim|federation lease acquire" docs internal`
+
+Expected: remaining matches are API codes, command reference, or wording consistent with optional claims.
+
+### Task 4: Full Verification And Commit
+
+**Files:**
+- All changed files.
+
+- [x] **Step 1: Run focused tests**
+
+Run the focused `internal/db` and `internal/daemon` commands above.
+
+- [x] **Step 2: Run broader verification**
+
+Run: `go test ./internal/db ./internal/daemon ./internal/federation`
+
+Expected: PASS.
+
+- [x] **Step 3: Commit**
+
+Run: `git status --short`, then commit all accepted changes with a message such as `fix: allow unclaimed federation edits`.
+
+- [x] **Step 4: Close kata issue**
+
+Run: `kata close az1k --done --message "<summary + verification>" --commit <sha> --agent`.

--- a/docs/superpowers/specs/2026-05-20-kata-federation-design.md
+++ b/docs/superpowers/specs/2026-05-20-kata-federation-design.md
@@ -499,6 +499,10 @@ A claim answers "who is *actively working* this issue right now," distinct from
 `owner` ("who is responsible"). It is hub-authoritative and exclusive per issue.
 A claim is a coordination primitive, not a cryptographic or consensus proof of
 global state.
+Holding a claim gives temporary exclusivity against other non-comment work while
+the claim is live. It does not replace durable ownership, does not serialize
+comments, and is not required for ordinary unclaimed edits, which still converge
+through the LWW fold.
 
 The default is a **hard claim**: it has no expiry and stays active until the
 holder releases it, the issue closes, or an admin/human force-releases it. For
@@ -548,22 +552,18 @@ happened offline. Enforcement therefore does not live in a synchronous write
 path; it is layered:
 
 1. **Claim exclusivity is mechanical** — the hub guarantees ≤1 live holder.
-2. **Spoke write-time gate** — a spoke daemon refuses *agent-initiated* work
-   mutations (edit/close/priority/links) on a shared issue unless the acting
-   agent holds a valid claim. While disconnected, a cached hub-confirmed claim is
-   a local continuity policy, not an exclusivity proof: timed claims may be used
-   only until cached `expires_at`, and hard claims may either be online-only or
-   accepted as an optimistic stale-cache path that the hub may later flag if the
-   claim was closed, force-released, or superseded. This is where double-work is
-   normally prevented — at the point of action, before an event exists. Comments
-   bypass. Human/admin work actions may bypass only through trusted spoke policy
-   or a server-authenticated role/capability/client kind; the free-form `--as`
-   actor string is never a bypass authority. If the deployment has no
-   authenticated client-kind signal, require claims for all non-comment work
-   mutations on federated projects.
-3. **Hub-side audit annotation** — if a work event still arrives uncovered by a
-   valid claim (stale client, genuine race), the hub emits `claim.violated` and
-   the origin spoke surfaces it on next sync. Nothing is dropped.
+2. **Spoke live-claim gate** — before non-comment work mutations
+   (edit/close/priority/links) on a shared issue, a spoke refreshes cached claim
+   state when it can. If no live claim exists, the mutation proceeds locally and
+   converges by LWW. If the acting agent holds the live claim, the mutation
+   proceeds. If another holder has a live, unexpired claim, the spoke refuses the
+   mutation. Timed claims stop blocking once expired. Pending offline claim
+   requests are never authoritative and do not block ordinary edits. Comments
+   bypass this gate because they are append-only.
+3. **Hub-side audit annotation** — if a work event arrives while another holder
+   has a live claim on the affected issue, the hub emits `claim.violated` and
+   the origin spoke surfaces it on next sync. Ordinary unclaimed work is not a
+   violation. Nothing is dropped.
 
 A strictly synchronous hub-reject model is possible only by making agent work
 mutations synchronous, which trades away offline editing; this design declines
@@ -572,9 +572,9 @@ that trade.
 ### 9.5 Offline pending-claim UX
 
 Offline, a spoke records and displays a **pending** claim request. It must not
-block others, must not appear authoritative, and is retried on reconnect. If the
-hub later denies it, the local daemon surfaces a *rejected pending claim* and the
-agent should stop or rebase its plan.
+block edits or other actors, must not appear authoritative, and is retried on
+reconnect. If the hub later denies it, the local daemon surfaces a *rejected
+pending claim* and the agent should stop relying on exclusivity.
 
 ### 9.6 Claim state authority
 
@@ -582,9 +582,10 @@ Current claim state — especially `expires_at` after timed-claim renewals — i
 authoritative from the **hub claim table/API**, not derived from the event log
 (renewals are not events). Spokes may cache claim state for display and local
 continuity, but must treat it as possibly stale and confirm against the hub before
-relying on exclusivity. Offline mutations made under a cached hard claim are
-therefore explicitly outside the strict ≤1-holder guarantee; on ingest the hub
-annotates uncovered/stale work with `claim.violated` instead of dropping data.
+relying on exclusivity. Offline mutations made while relying on a cached hard
+claim are therefore explicitly outside the strict ≤1-holder guarantee; on ingest
+the hub annotates work that conflicts with another currently live claim with
+`claim.violated` instead of dropping data.
 
 ---
 
@@ -715,8 +716,8 @@ section remains as historical context for how the implementation was staged.
 ### Phase 3 — Claims / optional timed claims
 - Claim table + atomic hub endpoints (§9.2); timed-claim sweeper +
   opportunistic expiry; enrollment-grant authorization for claim actions
-  (§7.4, §13); spoke write-time gate; pending-claim UX; `claim.*` events; lease
-  CLI/status surface.
+  (§7.4, §13); spoke live-claim conflict gate; pending-claim UX; `claim.*`
+  events; lease CLI/status surface.
 - **Exit:** two agents on different spokes cannot both hold a live claim; a
   crashed timed-claim holder's claim auto-expires and frees the issue.
 

--- a/e2e/federation_phase3_claims_test.go
+++ b/e2e/federation_phase3_claims_test.go
@@ -75,9 +75,8 @@ func TestFederationClaimsTwoSpokeLifecycle(t *testing.T) {
 		"--project", fx.hubProject.Name, "federation", "lease", "release", issueB.ShortID, "--as", "bob")
 	require.True(t, bobReleased.Granted)
 
-	charlieEdit := runKataWantExit(t, fx.bin, fx.spokeB.dirs, 5,
-		"--json", "--project", fx.hubProject.Name, "edit", issueB.ShortID, "--title", "charlie rejected", "--as", "charlie")
-	assert.Contains(t, charlieEdit.stderr, `"code":"claim_required"`)
+	runKataOK(t, fx.bin, fx.spokeB.dirs,
+		"--project", fx.hubProject.Name, "edit", issueB.ShortID, "--title", "charlie edit", "--as", "charlie")
 
 	waitForFoldedProjectionMatch(t, fx.hub.DB, fx.spokeA.db,
 		fx.hubProject.ID, fx.spokeA.replica.Project.ID, fx.replayAfterID, fx.spokeA.stderr)
@@ -86,7 +85,7 @@ func TestFederationClaimsTwoSpokeLifecycle(t *testing.T) {
 
 	finalHubIssue, err := fx.hub.DB.IssueByUID(ctx, fx.hubIssue.UID, db.IncludeDeletedNo)
 	require.NoError(t, err)
-	assert.Equal(t, "bob edit", finalHubIssue.Title)
+	assert.Equal(t, "charlie edit", finalHubIssue.Title)
 }
 
 func TestFederationTimedClaimExpires(t *testing.T) {

--- a/internal/api/federation.go
+++ b/internal/api/federation.go
@@ -212,13 +212,16 @@ type CreateFederationReplicaRequest struct {
 		Token                  string `json:"token,omitempty"`
 		Capabilities           string `json:"capabilities,omitempty"`
 		PushEnabled            bool   `json:"push_enabled,omitempty"`
+		AdoptExisting          bool   `json:"adopt_existing,omitempty"`
 	}
 }
 
 // CreateFederationReplicaBody is returned after binding a local spoke project.
 type CreateFederationReplicaBody struct {
-	Project ProjectOut           `json:"project"`
-	Binding FederationBindingOut `json:"binding"`
+	Project               ProjectOut           `json:"project"`
+	Binding               FederationBindingOut `json:"binding"`
+	Adopted               bool                 `json:"adopted,omitempty"`
+	AdoptionSnapshotCount int64                `json:"adoption_snapshot_count,omitempty"`
 }
 
 // CreateFederationReplicaResponse wraps CreateFederationReplicaBody.

--- a/internal/daemon/claim_gate.go
+++ b/internal/daemon/claim_gate.go
@@ -121,7 +121,7 @@ func claimGateAPIError(err error) error {
 			"lease expired for federated issue mutation", "run kata federation lease acquire <ref>", nil)
 	case errors.Is(err, db.ErrClaimRequired), errors.Is(err, db.ErrPendingClaimNotAuthoritative):
 		return api.NewError(http.StatusConflict, "claim_required",
-			"lease required for federated issue mutation", "run kata federation lease acquire <ref>", nil)
+			"lease is not authoritative for this federated issue mutation", "run kata show <ref>", nil)
 	case errors.Is(err, db.ErrClaimValidation):
 		return api.NewError(http.StatusBadRequest, "validation", err.Error(), "", nil)
 	case errors.Is(err, db.ErrNotFound):

--- a/internal/daemon/claim_gate_handlers_test.go
+++ b/internal/daemon/claim_gate_handlers_test.go
@@ -15,7 +15,7 @@ import (
 	"go.kenn.io/kata/internal/testenv"
 )
 
-func TestClaimGateEditCloseReopenPriorityRequiresLiveClaimForFederatedHubIssueMutations(t *testing.T) {
+func TestClaimGateEditCloseReopenPriorityAllowsUnclaimedFederatedHubIssueMutations(t *testing.T) {
 	for _, tc := range []claimGateHTTPCase{
 		{name: "EditTitle", build: claimGateEditTitleRequest},
 		{name: "EditBody", build: claimGateEditBodyRequest},
@@ -31,12 +31,12 @@ func TestClaimGateEditCloseReopenPriorityRequiresLiveClaimForFederatedHubIssueMu
 
 			resp, raw := envDoRaw(t, env, req.method, req.path, req.body, req.headers)
 
-			assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
+			require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
 		})
 	}
 }
 
-func TestClaimGateLinkLabelAssignUnassignMetadataDeleteRestoreRequiresLiveClaimForFederatedHubIssueMutations(t *testing.T) {
+func TestClaimGateLinkLabelAssignUnassignMetadataDeleteRestoreAllowsUnclaimedFederatedHubIssueMutations(t *testing.T) {
 	for _, tc := range []claimGateHTTPCase{
 		{name: "ClaimOwner", build: claimGateClaimOwnerRequest},
 		{name: "Assign", build: claimGateAssignRequest},
@@ -54,13 +54,13 @@ func TestClaimGateLinkLabelAssignUnassignMetadataDeleteRestoreRequiresLiveClaimF
 
 			resp, raw := envDoRaw(t, env, req.method, req.path, req.body, req.headers)
 
-			assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
+			require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
 		})
 	}
 }
 
 func TestClaimGateStableDenialCodes(t *testing.T) {
-	t.Run("pending claim still requires authoritative live claim", func(t *testing.T) {
+	t.Run("pending claim does not block unclaimed issue", func(t *testing.T) {
 		env, project, issue := setupClaimGateIssue(t, true)
 		_, err := env.DB.EnqueuePendingClaim(context.Background(), db.PendingClaimParams{
 			ProjectID: project.ID,
@@ -74,7 +74,7 @@ func TestClaimGateStableDenialCodes(t *testing.T) {
 		req := claimGateEditTitleRequestFor(project, issue)
 		resp, raw := envDoRaw(t, env, req.method, req.path, req.body, req.headers)
 
-		assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
 	})
 
 	t.Run("other live holder denies", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestClaimGateStableDenialCodes(t *testing.T) {
 		assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
 	})
 
-	t.Run("matching timed claim expired", func(t *testing.T) {
+	t.Run("matching timed claim expired is treated as absent", func(t *testing.T) {
 		env, project, issue := setupClaimGateIssue(t, true)
 		_, err := env.DB.AcquireClaim(context.Background(), db.AcquireClaimParams{
 			ProjectID: project.ID,
@@ -109,11 +109,11 @@ func TestClaimGateStableDenialCodes(t *testing.T) {
 		req := claimGateEditTitleRequestFor(project, issue)
 		resp, raw := envDoRaw(t, env, req.method, req.path, req.body, req.headers)
 
-		assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_expired")
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
 	})
 }
 
-func TestClaimGateLinkCreateRequiresClaimsForBothEndpoints(t *testing.T) {
+func TestClaimGateLinkCreateAllowsUnclaimedPeer(t *testing.T) {
 	env := testenv.New(t)
 	project, issue, peer := setupClaimGateProject(t, env, true)
 	acquireClaimGateIssue(t, env, project, issue, "agent")
@@ -124,15 +124,22 @@ func TestClaimGateLinkCreateRequiresClaimsForBothEndpoints(t *testing.T) {
 		"to_ref": peer.ShortID,
 	}, nil)
 
-	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+}
 
-	acquireClaimGateIssue(t, env, project, peer, "agent")
-	resp, raw = envDoRaw(t, env, http.MethodPost, issuePathRef(project.ID, issue.ShortID, "links"), map[string]string{
+func TestClaimGateLinkCreateDeniesOtherPeerClaimHolder(t *testing.T) {
+	env := testenv.New(t)
+	project, issue, peer := setupClaimGateProject(t, env, true)
+	acquireClaimGateIssue(t, env, project, issue, "agent")
+	acquireClaimGateIssue(t, env, project, peer, "other")
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, issuePathRef(project.ID, issue.ShortID, "links"), map[string]string{
 		"actor":  "agent",
 		"type":   "related",
 		"to_ref": peer.ShortID,
 	}, nil)
-	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
 }
 
 func TestClaimGateDuplicateLinkCreateDoesNotRequirePeerClaim(t *testing.T) {
@@ -164,7 +171,7 @@ func TestClaimGateDuplicateLinkCreateDoesNotRequirePeerClaim(t *testing.T) {
 	require.Nil(t, out.Event)
 }
 
-func TestClaimGateLinkDeleteRequiresClaimsForBothEndpoints(t *testing.T) {
+func TestClaimGateLinkDeleteAllowsUnclaimedPeer(t *testing.T) {
 	env := testenv.New(t)
 	project, issue, peer := setupClaimGateProject(t, env, true)
 	link, err := env.DB.CreateLink(context.Background(), db.CreateLinkParams{
@@ -180,12 +187,27 @@ func TestClaimGateLinkDeleteRequiresClaimsForBothEndpoints(t *testing.T) {
 	resp, raw := envDoRaw(t, env, http.MethodDelete,
 		issuePathRef(project.ID, issue.ShortID, "links/"+strconv.FormatInt(link.ID, 10))+"?actor=agent", nil, nil)
 
-	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
-
-	acquireClaimGateIssue(t, env, project, peer, "agent")
-	resp, raw = envDoRaw(t, env, http.MethodDelete,
-		issuePathRef(project.ID, issue.ShortID, "links/"+strconv.FormatInt(link.ID, 10))+"?actor=agent", nil, nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+}
+
+func TestClaimGateLinkDeleteDeniesOtherPeerClaimHolder(t *testing.T) {
+	env := testenv.New(t)
+	project, issue, peer := setupClaimGateProject(t, env, true)
+	link, err := env.DB.CreateLink(context.Background(), db.CreateLinkParams{
+		ProjectID:   project.ID,
+		FromIssueID: issue.ID,
+		ToIssueID:   peer.ID,
+		Type:        "related",
+		Author:      "tester",
+	})
+	require.NoError(t, err)
+	acquireClaimGateIssue(t, env, project, issue, "agent")
+	acquireClaimGateIssue(t, env, project, peer, "other")
+
+	resp, raw := envDoRaw(t, env, http.MethodDelete,
+		issuePathRef(project.ID, issue.ShortID, "links/"+strconv.FormatInt(link.ID, 10))+"?actor=agent", nil, nil)
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
 }
 
 func TestClaimGateLinkDeleteSkipsSoftDeletedPeerClaim(t *testing.T) {
@@ -209,7 +231,7 @@ func TestClaimGateLinkDeleteSkipsSoftDeletedPeerClaim(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
 }
 
-func TestClaimGateParentReplaceRequiresClaimForOldAndNewParent(t *testing.T) {
+func TestClaimGateParentReplaceAllowsUnclaimedOldParent(t *testing.T) {
 	env := testenv.New(t)
 	project, child, oldParent := setupClaimGateProject(t, env, true)
 	newParent, _, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
@@ -236,16 +258,38 @@ func TestClaimGateParentReplaceRequiresClaimForOldAndNewParent(t *testing.T) {
 		"replace": true,
 	}, nil)
 
-	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+}
 
-	acquireClaimGateIssue(t, env, project, oldParent, "agent")
-	resp, raw = envDoRaw(t, env, http.MethodPost, issuePathRef(project.ID, child.ShortID, "links"), map[string]any{
+func TestClaimGateParentReplaceDeniesOtherOldParentClaimHolder(t *testing.T) {
+	env := testenv.New(t)
+	project, child, oldParent := setupClaimGateProject(t, env, true)
+	newParent, _, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "new parent",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, err = env.DB.CreateLink(context.Background(), db.CreateLinkParams{
+		ProjectID:   project.ID,
+		FromIssueID: child.ID,
+		ToIssueID:   oldParent.ID,
+		Type:        "parent",
+		Author:      "tester",
+	})
+	require.NoError(t, err)
+	acquireClaimGateIssue(t, env, project, child, "agent")
+	acquireClaimGateIssue(t, env, project, newParent, "agent")
+	acquireClaimGateIssue(t, env, project, oldParent, "other")
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, issuePathRef(project.ID, child.ShortID, "links"), map[string]any{
 		"actor":   "agent",
 		"type":    "parent",
 		"to_ref":  newParent.ShortID,
 		"replace": true,
 	}, nil)
-	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
 }
 
 func TestClaimGateParentReplaceSkipsSoftDeletedOldParentClaim(t *testing.T) {
@@ -280,7 +324,7 @@ func TestClaimGateParentReplaceSkipsSoftDeletedOldParentClaim(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
 }
 
-func TestClaimGateEditLinksDeltaRequiresClaimsForAffectedEndpoints(t *testing.T) {
+func TestClaimGateEditLinksDeltaAllowsUnclaimedPeer(t *testing.T) {
 	env := testenv.New(t)
 	project, issue, peer := setupClaimGateProject(t, env, true)
 	acquireClaimGateIssue(t, env, project, issue, "agent")
@@ -290,14 +334,21 @@ func TestClaimGateEditLinksDeltaRequiresClaimsForAffectedEndpoints(t *testing.T)
 		"links_delta": map[string]any{"add_related": []string{peer.ShortID}},
 	}, nil)
 
-	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+}
 
-	acquireClaimGateIssue(t, env, project, peer, "agent")
-	resp, raw = envDoRaw(t, env, http.MethodPatch, issuePathRef(project.ID, issue.ShortID, ""), map[string]any{
+func TestClaimGateEditLinksDeltaDeniesOtherPeerClaimHolder(t *testing.T) {
+	env := testenv.New(t)
+	project, issue, peer := setupClaimGateProject(t, env, true)
+	acquireClaimGateIssue(t, env, project, issue, "agent")
+	acquireClaimGateIssue(t, env, project, peer, "other")
+
+	resp, raw := envDoRaw(t, env, http.MethodPatch, issuePathRef(project.ID, issue.ShortID, ""), map[string]any{
 		"actor":       "agent",
 		"links_delta": map[string]any{"add_related": []string{peer.ShortID}},
 	}, nil)
-	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
 }
 
 func TestClaimGateEditLinksDeltaRemoveSkipsSoftDeletedPeerClaim(t *testing.T) {
@@ -323,7 +374,7 @@ func TestClaimGateEditLinksDeltaRemoveSkipsSoftDeletedPeerClaim(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
 }
 
-func TestClaimGateEditLinksDeltaParentReplaceRequiresClaimForOldAndNewParent(t *testing.T) {
+func TestClaimGateEditLinksDeltaParentReplaceAllowsUnclaimedOldParent(t *testing.T) {
 	env := testenv.New(t)
 	project, child, oldParent := setupClaimGateProject(t, env, true)
 	newParent, _, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
@@ -348,14 +399,36 @@ func TestClaimGateEditLinksDeltaParentReplaceRequiresClaimForOldAndNewParent(t *
 		"links_delta": map[string]any{"set_parent": newParent.ShortID},
 	}, nil)
 
-	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+}
 
-	acquireClaimGateIssue(t, env, project, oldParent, "agent")
-	resp, raw = envDoRaw(t, env, http.MethodPatch, issuePathRef(project.ID, child.ShortID, ""), map[string]any{
+func TestClaimGateEditLinksDeltaParentReplaceDeniesOtherOldParentClaimHolder(t *testing.T) {
+	env := testenv.New(t)
+	project, child, oldParent := setupClaimGateProject(t, env, true)
+	newParent, _, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "new parent",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, err = env.DB.CreateLink(context.Background(), db.CreateLinkParams{
+		ProjectID:   project.ID,
+		FromIssueID: child.ID,
+		ToIssueID:   oldParent.ID,
+		Type:        "parent",
+		Author:      "tester",
+	})
+	require.NoError(t, err)
+	acquireClaimGateIssue(t, env, project, child, "agent")
+	acquireClaimGateIssue(t, env, project, newParent, "agent")
+	acquireClaimGateIssue(t, env, project, oldParent, "other")
+
+	resp, raw := envDoRaw(t, env, http.MethodPatch, issuePathRef(project.ID, child.ShortID, ""), map[string]any{
 		"actor":       "agent",
 		"links_delta": map[string]any{"set_parent": newParent.ShortID},
 	}, nil)
-	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
 }
 
 func TestClaimGateRestoreCanAcquireLeaseAfterSoftDelete(t *testing.T) {
@@ -405,16 +478,16 @@ func TestClaimGateUsesResolvedTokenActorForFederatedMutation(t *testing.T) {
 }
 
 func TestClaimGateCommentsCreateAndNonFederatedProjects(t *testing.T) {
-	t.Run("comments require claim on federated project", func(t *testing.T) {
+	t.Run("comments bypass claim gate on federated project", func(t *testing.T) {
 		env, project, issue := setupClaimGateIssue(t, true)
 
 		resp, raw := envDoRaw(t, env, http.MethodPost, issuePathRef(project.ID, issue.ShortID, "comments"),
 			map[string]string{"actor": "agent", "body": "comment without claim"}, nil)
 
-		assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
 	})
 
-	t.Run("comments deny conflicting holder on federated project", func(t *testing.T) {
+	t.Run("comments bypass other live holder on federated project", func(t *testing.T) {
 		env, project, issue := setupClaimGateIssue(t, true)
 		_, err := env.DB.AcquireClaim(context.Background(), db.AcquireClaimParams{
 			ProjectID: project.ID,
@@ -428,7 +501,7 @@ func TestClaimGateCommentsCreateAndNonFederatedProjects(t *testing.T) {
 		resp, raw := envDoRaw(t, env, http.MethodPost, issuePathRef(project.ID, issue.ShortID, "comments"),
 			map[string]string{"actor": "agent", "body": "comment without claim"}, nil)
 
-		assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
 	})
 
 	t.Run("issue create bypass on federated project", func(t *testing.T) {

--- a/internal/daemon/claim_gate_helper_test.go
+++ b/internal/daemon/claim_gate_helper_test.go
@@ -28,21 +28,28 @@ func TestClaimGateHelperBypassesProjectsWithoutEnabledFederation(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestClaimGateHelperHubRequiresLocalLiveClaim(t *testing.T) {
+func TestClaimGateHelperHubAllowsUnclaimedIssue(t *testing.T) {
 	ctx := context.Background()
 	store := openClaimGateHelperDB(t)
 	project, issue := createClaimGateHelperIssue(t, store)
 	enableClaimGateHelperHub(t, store, project.ID)
 
 	err := requireFederatedIssueClaim(ctx, ServerConfig{DB: store}, project.ID, issue, "agent")
-	assertClaimGateHelperAPIError(t, err, http.StatusConflict, "claim_required")
+	require.NoError(t, err)
+}
 
-	_, err = store.AcquireClaim(ctx, db.AcquireClaimParams{
+func TestClaimGateHelperHubDeniesOtherLiveClaimHolder(t *testing.T) {
+	ctx := context.Background()
+	store := openClaimGateHelperDB(t)
+	project, issue := createClaimGateHelperIssue(t, store)
+	enableClaimGateHelperHub(t, store, project.ID)
+
+	_, err := store.AcquireClaim(ctx, db.AcquireClaimParams{
 		ProjectID: project.ID,
 		IssueRef:  issue.ShortID,
 		Principal: db.ClaimPrincipal{
 			HolderInstanceUID: store.InstanceUID(),
-			Holder:            "agent",
+			Holder:            "other",
 			ClientKind:        "",
 		},
 		ClaimKind: "hard",
@@ -51,10 +58,10 @@ func TestClaimGateHelperHubRequiresLocalLiveClaim(t *testing.T) {
 	require.NoError(t, err)
 
 	err = requireFederatedIssueClaim(ctx, ServerConfig{DB: store}, project.ID, issue, "agent")
-	require.NoError(t, err)
+	assertClaimGateHelperAPIError(t, err, http.StatusConflict, "claim_denied")
 }
 
-func TestClaimGateHelperPendingClaimMapsToClaimRequired(t *testing.T) {
+func TestClaimGateHelperPendingClaimDoesNotBlockUnclaimedIssue(t *testing.T) {
 	ctx := context.Background()
 	store := openClaimGateHelperDB(t)
 	project, issue := createClaimGateHelperIssue(t, store)
@@ -74,7 +81,7 @@ func TestClaimGateHelperPendingClaimMapsToClaimRequired(t *testing.T) {
 
 	err = requireFederatedIssueClaim(ctx, ServerConfig{DB: store}, project.ID, issue, "agent")
 
-	assertClaimGateHelperAPIError(t, err, http.StatusConflict, "claim_required")
+	require.NoError(t, err)
 }
 
 func TestClaimGateHelperSpokeRefreshesHubStatusBeforeCheckingCache(t *testing.T) {

--- a/internal/daemon/handlers_comments.go
+++ b/internal/daemon/handlers_comments.go
@@ -26,9 +26,6 @@ func registerCommentsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
-		if err := requireFederatedIssueClaim(ctx, cfg, in.ProjectID, issue, actor); err != nil {
-			return nil, err
-		}
 		c, evt, err := cfg.DB.CreateComment(ctx, db.CreateCommentParams{
 			IssueID: issue.ID,
 			Author:  actor,

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -183,6 +183,9 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			in.Body.ProjectName == "" || in.Body.ReplayHorizonEventID <= 0 {
 			return nil, api.NewError(400, "validation", "hub_url, hub_project_id, hub_project_uid, project_name, and replay_horizon_event_id are required", "", nil)
 		}
+		if !katauid.Valid(in.Body.HubProjectUID) {
+			return nil, api.NewError(400, "validation", "hub_project_uid must be a valid UID", "", nil)
+		}
 		capabilities, err := normalizedReplicaCapabilities(in.Body.Capabilities)
 		if err != nil {
 			return nil, err
@@ -190,7 +193,15 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if in.Body.PushEnabled && !federationCapabilitiesContain(capabilities, "push") {
 			return nil, api.NewError(400, "federation_capability_mismatch", "push-enabled federation replica requires push capability", "", nil)
 		}
-		project, binding, err := ensureReplicaBinding(ctx, cfg.DB, in)
+		if in.Body.AdoptExisting {
+			if !in.Body.PushEnabled {
+				return nil, api.NewError(400, "federation_capability_mismatch", "adopting an existing project requires push to be enabled", "", nil)
+			}
+			if !federationCapabilitiesContain(capabilities, "pull") || !federationCapabilitiesContain(capabilities, "push") {
+				return nil, api.NewError(400, "federation_capability_mismatch", "adopting an existing project requires pull and push capabilities", "", nil)
+			}
+		}
+		project, binding, adopted, adoptionSnapshotCount, err := ensureReplicaBindingOrAdopt(ctx, cfg.DB, in)
 		if err != nil {
 			return nil, err
 		}
@@ -217,8 +228,10 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			cfg.FederationWake()
 		}
 		return &api.CreateFederationReplicaResponse{Body: api.CreateFederationReplicaBody{
-			Project: dbProjectToOut(project),
-			Binding: federationBindingToOut(binding),
+			Project:               dbProjectToOut(project),
+			Binding:               federationBindingToOut(binding),
+			Adopted:               adopted,
+			AdoptionSnapshotCount: adoptionSnapshotCount,
 		}}, nil
 	})
 
@@ -355,6 +368,108 @@ func federationCapabilitiesContain(capabilities, want string) bool {
 	return false
 }
 
+func ensureReplicaBindingOrAdopt(
+	ctx context.Context,
+	store *db.DB,
+	in *api.CreateFederationReplicaRequest,
+) (db.Project, db.FederationBinding, bool, int64, error) {
+	if in.Body.AdoptExisting {
+		if result, adopted, err := adoptExistingReplica(ctx, store, in); err != nil {
+			return db.Project{}, db.FederationBinding{}, false, 0, err
+		} else if adopted {
+			return result.Project, result.Binding, true, result.AdoptionSnapshotCount, nil
+		}
+	}
+	project, binding, err := ensureReplicaBinding(ctx, store, in)
+	return project, binding, false, 0, err
+}
+
+func adoptExistingReplica(
+	ctx context.Context,
+	store *db.DB,
+	in *api.CreateFederationReplicaRequest,
+) (db.AdoptProjectIntoFederationResult, bool, error) {
+	projectName := strings.TrimSpace(in.Body.ProjectName)
+	if err := config.ValidateProjectName(projectName); err != nil {
+		return db.AdoptProjectIntoFederationResult{}, false, api.NewError(400, "validation", err.Error(), "", nil)
+	}
+	if project, err := store.ProjectByUID(ctx, in.Body.HubProjectUID); err == nil {
+		if project.DeletedAt != nil {
+			return db.AdoptProjectIntoFederationResult{}, false,
+				api.NewError(409, "federation_project_collision", "hub project UID belongs to an archived local project", "", nil)
+		}
+		binding, bindErr := store.FederationBindingByProject(ctx, project.ID)
+		if bindErr != nil {
+			if errors.Is(bindErr, db.ErrNotFound) {
+				if project.Name != projectName {
+					return db.AdoptProjectIntoFederationResult{}, false,
+						api.NewError(409, "federation_project_collision",
+							fmt.Sprintf("hub project UID belongs to local project %q; cannot adopt local project %q", project.Name, projectName), "", nil)
+				}
+				result, err := store.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+					ProjectID:            project.ID,
+					HubURL:               in.Body.HubURL,
+					HubProjectID:         in.Body.HubProjectID,
+					HubProjectUID:        in.Body.HubProjectUID,
+					ReplayHorizonEventID: in.Body.ReplayHorizonEventID,
+					Actor:                "federation",
+				})
+				if err != nil {
+					return db.AdoptProjectIntoFederationResult{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+				}
+				return result, true, nil
+			}
+			return db.AdoptProjectIntoFederationResult{}, false, api.NewError(500, "internal", bindErr.Error(), "", nil)
+		}
+		if !compatibleReplicaBinding(binding, in) {
+			return db.AdoptProjectIntoFederationResult{}, false,
+				api.NewError(409, "federation_binding_conflict", "existing federation binding is incompatible with the requested hub", "", nil)
+		}
+		if project.Name != projectName {
+			return db.AdoptProjectIntoFederationResult{}, false,
+				api.NewError(409, "federation_project_collision",
+					fmt.Sprintf("hub project UID is already bound to local project %q; cannot adopt local project %q", project.Name, projectName), "", nil)
+		}
+		return db.AdoptProjectIntoFederationResult{}, false, nil
+	} else if !errors.Is(err, db.ErrNotFound) {
+		return db.AdoptProjectIntoFederationResult{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	existing, err := store.ProjectByNameIncludingArchived(ctx, projectName)
+	if errors.Is(err, db.ErrNotFound) {
+		return db.AdoptProjectIntoFederationResult{}, false,
+			api.NewError(404, "federation_project_not_found", "adoption requested but no local project exists with this name", "", nil)
+	}
+	if err != nil {
+		return db.AdoptProjectIntoFederationResult{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	if existing.UID == in.Body.HubProjectUID {
+		return db.AdoptProjectIntoFederationResult{}, false,
+			api.NewError(409, "federation_project_collision", "hub project UID already exists locally but is not bound to federation", "", nil)
+	}
+	if existing.DeletedAt != nil {
+		return db.AdoptProjectIntoFederationResult{}, true,
+			api.NewError(409, "federation_project_collision", "a deleted project with this name cannot be adopted into federation", "", nil)
+	}
+	if binding, err := store.FederationBindingByProject(ctx, existing.ID); err == nil {
+		return db.AdoptProjectIntoFederationResult{}, true,
+			api.NewError(409, "federation_binding_conflict",
+				fmt.Sprintf("project already has %q federation binding", binding.Role), "", nil)
+	} else if !errors.Is(err, db.ErrNotFound) {
+		return db.AdoptProjectIntoFederationResult{}, true, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	result, err := store.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+		ProjectID:            existing.ID,
+		HubURL:               in.Body.HubURL,
+		HubProjectID:         in.Body.HubProjectID,
+		HubProjectUID:        in.Body.HubProjectUID,
+		ReplayHorizonEventID: in.Body.ReplayHorizonEventID,
+	})
+	if err != nil {
+		return db.AdoptProjectIntoFederationResult{}, true, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	return result, true, nil
+}
+
 func ensureReplicaBinding(
 	ctx context.Context,
 	store *db.DB,
@@ -369,7 +484,7 @@ func ensureReplicaBinding(
 	if errors.Is(err, db.ErrNotFound) {
 		if existing, lookupErr := store.ProjectByNameIncludingArchived(ctx, projectName); lookupErr == nil {
 			if existing.UID != in.Body.HubProjectUID {
-				return db.Project{}, db.FederationBinding{}, api.NewError(409, "federation_project_collision", "a project with this name already has a different UID", "", nil)
+				return db.Project{}, db.FederationBinding{}, api.NewError(409, "federation_project_collision", "a project with this name already has a different UID; rerun with --adopt-existing --push to adopt it into federation", "", nil)
 			}
 		} else if !errors.Is(lookupErr, db.ErrNotFound) {
 			return db.Project{}, db.FederationBinding{}, api.NewError(500, "internal", lookupErr.Error(), "", nil)

--- a/internal/daemon/handlers_federation_test.go
+++ b/internal/daemon/handlers_federation_test.go
@@ -211,6 +211,232 @@ func TestFederationReplicaSetupRejectsPushEnabledWithoutPushCapability(t *testin
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+func TestFederationReplicaSetupAdoptsExistingProject(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	project, err := env.DB.CreateProjectWithUID(ctx, "spoke", "01HZNQ7VFPK1XGD8R5MABCD4EA")
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "local issue",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+
+	body := map[string]any{
+		"hub_url":                 "http://127.0.0.1:7373",
+		"hub_project_id":          42,
+		"hub_project_uid":         "01HZNQ7VFPK1XGD8R5MABCD4EX",
+		"project_name":            "spoke",
+		"replay_horizon_event_id": 9,
+		"token":                   "push-token",
+		"capabilities":            "pull,push",
+		"push_enabled":            true,
+		"adopt_existing":          true,
+	}
+	var out api.CreateFederationReplicaBody
+	resp := envDoJSON(t, env, http.MethodPost, "/api/v1/federation/replicas", body, &out)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, out.Adopted)
+	assert.Equal(t, int64(1), out.AdoptionSnapshotCount)
+	assert.Equal(t, project.ID, out.Project.ID)
+	assert.Equal(t, "01HZNQ7VFPK1XGD8R5MABCD4EX", out.Project.UID)
+	assert.True(t, out.Binding.PushEnabled)
+	assert.Equal(t, int64(42), out.Binding.HubProjectID)
+
+	adopted, err := env.DB.ProjectByID(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "01HZNQ7VFPK1XGD8R5MABCD4EX", adopted.UID)
+	binding, err := env.DB.FederationBindingByProject(ctx, project.ID)
+	require.NoError(t, err)
+	assert.True(t, binding.PushEnabled)
+	assert.Equal(t, "01HZNQ7VFPK1XGD8R5MABCD4EX", binding.HubProjectUID)
+
+	var retry api.CreateFederationReplicaBody
+	resp = envDoJSON(t, env, http.MethodPost, "/api/v1/federation/replicas", body, &retry)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.False(t, retry.Adopted)
+
+	creds, err := config.ReadFederationCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, "push-token", creds.Projects[out.Project.UID].Token)
+}
+
+func TestFederationReplicaSetupAdoptExistingBindsUnboundProjectWithHubUID(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	project, err := env.DB.CreateProjectWithUID(ctx, "spoke", "01HZNQ7VFPK1XGD8R5MABCD4EX")
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "existing",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+
+	var out api.CreateFederationReplicaBody
+	resp := envDoJSON(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
+		"hub_url":                 "http://127.0.0.1:7373",
+		"hub_project_id":          42,
+		"hub_project_uid":         "01HZNQ7VFPK1XGD8R5MABCD4EX",
+		"project_name":            "spoke",
+		"replay_horizon_event_id": 9,
+		"token":                   "push-token",
+		"capabilities":            "pull,push",
+		"push_enabled":            true,
+		"adopt_existing":          true,
+	}, &out)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, out.Adopted)
+	assert.Equal(t, int64(1), out.AdoptionSnapshotCount)
+	assert.Equal(t, project.ID, out.Project.ID)
+	assert.Equal(t, "01HZNQ7VFPK1XGD8R5MABCD4EX", out.Binding.HubProjectUID)
+	assert.True(t, out.Binding.PushEnabled)
+}
+
+func TestFederationReplicaSetupRejectsInvalidHubProjectUID(t *testing.T) {
+	env := testenv.New(t)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
+		"hub_url":                 "http://127.0.0.1:7373",
+		"hub_project_id":          42,
+		"hub_project_uid":         "!!!!!!!!!!!!!!!!!!!!!!!!!!",
+		"project_name":            "spoke",
+		"replay_horizon_event_id": 9,
+		"token":                   "push-token",
+		"capabilities":            "pull,push",
+		"push_enabled":            true,
+		"adopt_existing":          true,
+	}, nil)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "response: %s", raw)
+	assert.Contains(t, string(raw), "hub_project_uid must be a valid UID")
+}
+
+func TestFederationReplicaSetupAdoptExistingRejectsArchivedProjectWithHubUID(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	project, err := env.DB.CreateProjectWithUID(ctx, "spoke", "01HZNQ7VFPK1XGD8R5MABCD4EX")
+	require.NoError(t, err)
+	_, _, err = env.DB.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: project.ID, Actor: "tester"})
+	require.NoError(t, err)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
+		"hub_url":                 "http://127.0.0.1:7373",
+		"hub_project_id":          42,
+		"hub_project_uid":         "01HZNQ7VFPK1XGD8R5MABCD4EX",
+		"project_name":            "spoke",
+		"replay_horizon_event_id": 9,
+		"token":                   "push-token",
+		"capabilities":            "pull,push",
+		"push_enabled":            true,
+		"adopt_existing":          true,
+	}, nil)
+
+	assert.Equal(t, http.StatusConflict, resp.StatusCode, "response: %s", raw)
+	assert.Contains(t, string(raw), "federation_project_collision")
+}
+
+func TestFederationReplicaSetupAdoptExistingRejectsHubUIDBoundToDifferentProject(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	bound, err := env.DB.CreateProjectWithUID(ctx, "already-bound", "01HZNQ7VFPK1XGD8R5MABCD4EX")
+	require.NoError(t, err)
+	_, err = env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            bound.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://127.0.0.1:7373",
+		HubProjectID:         42,
+		HubProjectUID:        "01HZNQ7VFPK1XGD8R5MABCD4EX",
+		ReplayHorizonEventID: 9,
+		PullCursorEventID:    8,
+		PushEnabled:          true,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	spoke, err := env.DB.CreateProjectWithUID(ctx, "spoke", "01HZNQ7VFPK1XGD8R5MABCD4EA")
+	require.NoError(t, err)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
+		"hub_url":                 "http://127.0.0.1:7373",
+		"hub_project_id":          42,
+		"hub_project_uid":         "01HZNQ7VFPK1XGD8R5MABCD4EX",
+		"project_name":            "spoke",
+		"replay_horizon_event_id": 9,
+		"token":                   "push-token",
+		"capabilities":            "pull,push",
+		"push_enabled":            true,
+		"adopt_existing":          true,
+	}, nil)
+
+	assert.Equal(t, http.StatusConflict, resp.StatusCode, string(raw))
+	assert.Contains(t, string(raw), "federation_project_collision")
+	assert.Contains(t, string(raw), "already-bound")
+	assert.Contains(t, string(raw), "spoke")
+	unchanged, err := env.DB.ProjectByID(ctx, spoke.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "01HZNQ7VFPK1XGD8R5MABCD4EA", unchanged.UID)
+	_, err = env.DB.FederationBindingByProject(ctx, spoke.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}
+
+func TestFederationReplicaSetupAdoptExistingRequiresPullAndPushCapabilities(t *testing.T) {
+	tests := []struct {
+		name         string
+		capabilities string
+	}{
+		{name: "missing push", capabilities: "pull"},
+		{name: "missing pull", capabilities: "push"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := testenv.New(t)
+			ctx := context.Background()
+			_, err := env.DB.CreateProjectWithUID(ctx, "spoke", "01HZNQ7VFPK1XGD8R5MABCD4EA")
+			require.NoError(t, err)
+
+			resp, raw := envDoRaw(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
+				"hub_url":                 "http://127.0.0.1:7373",
+				"hub_project_id":          42,
+				"hub_project_uid":         "01HZNQ7VFPK1XGD8R5MABCD4EX",
+				"project_name":            "spoke",
+				"replay_horizon_event_id": 9,
+				"token":                   "push-token",
+				"capabilities":            tt.capabilities,
+				"push_enabled":            true,
+				"adopt_existing":          true,
+			}, nil)
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, string(raw))
+			assert.Contains(t, string(raw), "federation_capability_mismatch")
+		})
+	}
+}
+
+func TestFederationReplicaSetupAdoptExistingRejectsMissingLocalProject(t *testing.T) {
+	env := testenv.New(t)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
+		"hub_url":                 "http://127.0.0.1:7373",
+		"hub_project_id":          42,
+		"hub_project_uid":         "01HZNQ7VFPK1XGD8R5MABCD4EX",
+		"project_name":            "typo-spoke",
+		"replay_horizon_event_id": 9,
+		"token":                   "push-token",
+		"capabilities":            "pull,push",
+		"push_enabled":            true,
+		"adopt_existing":          true,
+	}, nil)
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, string(raw))
+	assert.Contains(t, string(raw), "federation_project_not_found")
+	projects, err := env.DB.ListProjects(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, projects)
+}
+
 func TestFederationReplicaSetupRejectsCredentialDowngradeOnPushBinding(t *testing.T) {
 	env := testenv.New(t)
 	body := map[string]any{
@@ -392,6 +618,7 @@ func TestFederationReplicaSetupRejectsNameCollisionWithDifferentUID(t *testing.T
 
 	assert.Equal(t, http.StatusConflict, resp.StatusCode, string(raw))
 	assert.Contains(t, string(raw), "federation_project_collision")
+	assert.Contains(t, string(raw), "--adopt-existing --push")
 }
 
 func TestFederatedSpokeMutationReturnsReadOnlyError(t *testing.T) {

--- a/internal/daemon/handlers_imports.go
+++ b/internal/daemon/handlers_imports.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/danielgtaylor/huma/v2"
 
@@ -114,49 +115,220 @@ func requireFederatedImportClaims(
 	if !binding.Enabled {
 		return nil
 	}
+	states := make(map[string]importClaimItemState, len(items))
 	for _, item := range items {
-		issue, needsClaim, err := importItemNeedsFederatedClaim(ctx, cfg.DB, projectID, source, item)
+		state, err := importItemFederatedClaimState(ctx, cfg.DB, projectID, source, item)
 		if err != nil {
 			return err
 		}
-		if needsClaim {
-			if err := requireFederatedIssueClaim(ctx, cfg, projectID, issue, actor); err != nil {
+		states[item.ExternalID] = state
+	}
+	for _, item := range items {
+		state := states[item.ExternalID]
+		if state.mapped && state.sourceNewer {
+			if err := requireFederatedIssueClaim(ctx, cfg, projectID, state.issue, actor); err != nil {
 				return err
 			}
+		}
+		if !state.reconcilesLinks() {
+			continue
+		}
+		peers, err := importItemLinkClaimPeers(ctx, cfg.DB, projectID, source, item, state, states)
+		if err != nil {
+			return err
+		}
+		if err := requireFederatedLinkClaims(ctx, cfg, projectID, actor, peers...); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func importItemNeedsFederatedClaim(
+type importClaimItemState struct {
+	issue       db.Issue
+	mapped      bool
+	sourceNewer bool
+}
+
+func (s importClaimItemState) reconcilesLinks() bool {
+	return !s.mapped || s.sourceNewer
+}
+
+func importItemFederatedClaimState(
 	ctx context.Context,
 	store *db.DB,
 	projectID int64,
 	source string,
 	item db.ImportItem,
-) (db.Issue, bool, error) {
+) (importClaimItemState, error) {
 	mapping, err := store.ImportMappingBySource(ctx, projectID, source, "issue", item.ExternalID)
 	if errors.Is(err, db.ErrNotFound) {
-		return db.Issue{}, false, nil
+		return importClaimItemState{}, nil
+	}
+	if err != nil {
+		return importClaimItemState{}, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	if mapping.IssueID == nil {
+		return importClaimItemState{}, api.NewError(404, "issue_not_found", "import issue mapping is missing issue id", "", nil)
+	}
+	issue, err := store.IssueByID(ctx, *mapping.IssueID)
+	if errors.Is(err, db.ErrNotFound) {
+		return importClaimItemState{}, api.NewError(404, "issue_not_found", err.Error(), "", nil)
+	}
+	if err != nil {
+		return importClaimItemState{}, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	if issue.DeletedAt != nil {
+		return importClaimItemState{}, api.NewError(404, "issue_not_found", "mapped import issue is deleted", "", nil)
+	}
+	return importClaimItemState{
+		issue:       issue,
+		mapped:      true,
+		sourceNewer: item.UpdatedAt.After(issue.UpdatedAt),
+	}, nil
+}
+
+func importItemLinkClaimPeers(
+	ctx context.Context,
+	store *db.DB,
+	projectID int64,
+	source string,
+	item db.ImportItem,
+	state importClaimItemState,
+	states map[string]importClaimItemState,
+) ([]db.Issue, error) {
+	peers, err := importItemLinkAddClaimPeers(ctx, store, projectID, source, item, state, states)
+	if err != nil {
+		return nil, err
+	}
+	removalPeers, err := importItemLinkRemovalClaimPeers(ctx, store, projectID, source, item, state)
+	if err != nil {
+		return nil, err
+	}
+	return append(peers, removalPeers...), nil
+}
+
+func importItemLinkAddClaimPeers(
+	ctx context.Context,
+	store *db.DB,
+	projectID int64,
+	source string,
+	item db.ImportItem,
+	state importClaimItemState,
+	states map[string]importClaimItemState,
+) ([]db.Issue, error) {
+	if len(item.Links) == 0 {
+		return nil, nil
+	}
+	var out []db.Issue
+	for _, importLink := range item.Links {
+		target, mapped, err := importLinkClaimTarget(ctx, store, projectID, source, importLink.TargetExternalID, states)
+		if err != nil {
+			return nil, err
+		}
+		if !mapped {
+			continue
+		}
+		if state.mapped {
+			fromID, toID := state.issue.ID, target.ID
+			if importLink.Type == "related" && fromID > toID {
+				fromID, toID = toID, fromID
+			}
+			if _, err := store.LinkByEndpoints(ctx, fromID, toID, importLink.Type); err == nil {
+				continue
+			} else if !errors.Is(err, db.ErrNotFound) {
+				return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			}
+		}
+		out = append(out, target)
+	}
+	return out, nil
+}
+
+func importItemLinkRemovalClaimPeers(
+	ctx context.Context,
+	store *db.DB,
+	projectID int64,
+	source string,
+	item db.ImportItem,
+	state importClaimItemState,
+) ([]db.Issue, error) {
+	if !state.mapped {
+		return nil, nil
+	}
+	desired := make(map[string]struct{}, len(item.Links))
+	for _, importLink := range item.Links {
+		desired[importClaimLinkExternalID(item.ExternalID, importLink)] = struct{}{}
+	}
+	mappings, err := store.ImportMappingsByProjectSource(ctx, projectID, source)
+	if err != nil {
+		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	var out []db.Issue
+	for _, mapping := range mappings {
+		if mapping.ObjectType != "link" || mapping.IssueID == nil || *mapping.IssueID != state.issue.ID {
+			continue
+		}
+		if _, keep := desired[mapping.ExternalID]; keep {
+			continue
+		}
+		if mapping.LinkID == nil {
+			continue
+		}
+		link, err := store.LinkByID(ctx, *mapping.LinkID)
+		if errors.Is(err, db.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		peerID := link.ToIssueID
+		if peerID == state.issue.ID {
+			peerID = link.FromIssueID
+		}
+		peer, err := store.IssueByID(ctx, peerID)
+		if err != nil {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		out = append(out, peer)
+	}
+	return out, nil
+}
+
+func importLinkClaimTarget(
+	ctx context.Context,
+	store *db.DB,
+	projectID int64,
+	source string,
+	externalID string,
+	states map[string]importClaimItemState,
+) (db.Issue, bool, error) {
+	if state, ok := states[externalID]; ok {
+		return state.issue, state.mapped, nil
+	}
+	mapping, err := store.ImportMappingBySource(ctx, projectID, source, "issue", externalID)
+	if errors.Is(err, db.ErrNotFound) {
+		return db.Issue{}, false, api.NewError(404, "issue_not_found", fmt.Sprintf("import link target %q not found", externalID), "", nil)
 	}
 	if err != nil {
 		return db.Issue{}, false, api.NewError(500, "internal", err.Error(), "", nil)
 	}
 	if mapping.IssueID == nil {
-		return db.Issue{}, false, api.NewError(404, "issue_not_found", "import issue mapping is missing issue id", "", nil)
+		return db.Issue{}, false, api.NewError(404, "issue_not_found", fmt.Sprintf("import link target %q is missing issue id", externalID), "", nil)
 	}
 	issue, err := store.IssueByID(ctx, *mapping.IssueID)
 	if errors.Is(err, db.ErrNotFound) {
-		return db.Issue{}, false, api.NewError(404, "issue_not_found", err.Error(), "", nil)
+		return db.Issue{}, false, api.NewError(404, "issue_not_found", fmt.Sprintf("import link target %q not found", externalID), "", nil)
 	}
 	if err != nil {
 		return db.Issue{}, false, api.NewError(500, "internal", err.Error(), "", nil)
 	}
 	if issue.DeletedAt != nil {
-		return db.Issue{}, false, api.NewError(404, "issue_not_found", "mapped import issue is deleted", "", nil)
+		return db.Issue{}, false, api.NewError(404, "issue_not_found", fmt.Sprintf("import link target %q is deleted", externalID), "", nil)
 	}
-	if item.UpdatedAt.After(issue.UpdatedAt) {
-		return issue, true, nil
-	}
-	return issue, false, nil
+	return issue, true, nil
+}
+
+func importClaimLinkExternalID(issueExternalID string, link db.ImportLink) string {
+	return issueExternalID + ":" + link.Type + ":" + link.TargetExternalID
 }

--- a/internal/daemon/handlers_imports.go
+++ b/internal/daemon/handlers_imports.go
@@ -158,14 +158,5 @@ func importItemNeedsFederatedClaim(
 	if item.UpdatedAt.After(issue.UpdatedAt) {
 		return issue, true, nil
 	}
-	for _, comment := range item.Comments {
-		_, err := store.ImportMappingBySource(ctx, projectID, source, "comment", comment.ExternalID)
-		if errors.Is(err, db.ErrNotFound) {
-			return issue, true, nil
-		}
-		if err != nil {
-			return db.Issue{}, false, api.NewError(500, "internal", err.Error(), "", nil)
-		}
-	}
 	return issue, false, nil
 }

--- a/internal/daemon/handlers_imports_test.go
+++ b/internal/daemon/handlers_imports_test.go
@@ -300,6 +300,78 @@ func TestImportEndpoint_FederatedExistingIssueDeniesOtherLeaseHolder(t *testing.
 	assert.Equal(t, "Old title", unchanged.Title)
 }
 
+func TestImportEndpoint_FederatedCommentOnlyImportBypassesOtherLeaseHolder(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.New(t)
+	project := createImportTestProject(t, env, "github.com/wesm/kata", "kata")
+	initial := map[string]any{
+		"actor":  "importer",
+		"source": "beads",
+		"items": []map[string]any{{
+			"external_id": "beads-1",
+			"title":       "Imported",
+			"body":        "body",
+			"author":      "alice",
+			"status":      "open",
+			"created_at":  "2026-05-01T10:00:00Z",
+			"updated_at":  "2026-05-01T10:00:00Z",
+		}},
+	}
+	var first struct {
+		Items []struct {
+			IssueShortID string `json:"issue_short_id"`
+		} `json:"items"`
+	}
+	envPostJSON(t, env, importEndpointPath(project.ID), initial, &first)
+	require.Len(t, first.Items, 1)
+	issue, err := env.DB.IssueByShortID(ctx, project.ID, first.Items[0].IssueShortID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	_, err = env.DB.EnableProjectFederation(ctx, project.ID, "tester")
+	require.NoError(t, err)
+	_, err = env.DB.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: project.ID,
+		IssueRef:  issue.ShortID,
+		Principal: db.ClaimPrincipal{
+			HolderInstanceUID: env.DB.InstanceUID(),
+			Holder:            "other",
+			ClientKind:        "cli",
+		},
+		ClaimKind: "hard",
+		Now:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	commentOnly := map[string]any{
+		"actor":  "importer",
+		"source": "beads",
+		"items": []map[string]any{{
+			"external_id": "beads-1",
+			"title":       "Imported",
+			"body":        "body",
+			"author":      "alice",
+			"status":      "open",
+			"created_at":  "2026-05-01T10:00:00Z",
+			"updated_at":  "2026-05-01T10:00:00Z",
+			"comments": []map[string]any{{
+				"external_id": "c1",
+				"author":      "alice",
+				"body":        "append-only note",
+				"created_at":  "2026-05-01T10:01:00Z",
+			}},
+		}},
+	}
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, importEndpointPath(project.ID), commentOnly, nil)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+	var out struct {
+		Unchanged int `json:"unchanged"`
+		Comments  int `json:"comments"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, 1, out.Unchanged)
+	assert.Equal(t, 1, out.Comments)
+}
+
 func TestImportEndpoint_FederatedIdempotentReimportDoesNotRequireLease(t *testing.T) {
 	env := testenv.New(t)
 	project := createImportTestProject(t, env, "github.com/wesm/kata", "kata")

--- a/internal/daemon/handlers_imports_test.go
+++ b/internal/daemon/handlers_imports_test.go
@@ -455,6 +455,148 @@ func TestImportEndpoint_FederatedNewIssueLinkTargetDoesNotRequireTargetLease(t *
 	assert.Equal(t, 1, out.Links)
 }
 
+func TestImportEndpoint_FederatedImportLinkAddDeniesOtherPeerLeaseHolder(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.New(t)
+	project := createImportTestProject(t, env, "github.com/wesm/kata", "kata")
+	parent := map[string]any{
+		"actor":  "importer",
+		"source": "beads",
+		"items": []map[string]any{{
+			"external_id": "parent",
+			"title":       "Parent",
+			"body":        "parent body",
+			"author":      "alice",
+			"status":      "open",
+			"created_at":  "2026-05-01T10:00:00Z",
+			"updated_at":  "2026-05-01T10:00:00Z",
+		}},
+	}
+	envPostJSON(t, env, importEndpointPath(project.ID), parent, &struct{}{})
+	parentMapping, err := env.DB.ImportMappingBySource(ctx, project.ID, "beads", "issue", "parent")
+	require.NoError(t, err)
+	require.NotNil(t, parentMapping.IssueID)
+	parentIssue, err := env.DB.IssueByID(ctx, *parentMapping.IssueID)
+	require.NoError(t, err)
+	_, err = env.DB.EnableProjectFederation(ctx, project.ID, "tester")
+	require.NoError(t, err)
+	_, err = env.DB.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: project.ID,
+		IssueRef:  parentIssue.ShortID,
+		Principal: db.ClaimPrincipal{
+			HolderInstanceUID: env.DB.InstanceUID(),
+			Holder:            "other",
+			ClientKind:        "cli",
+		},
+		ClaimKind: "hard",
+		Now:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	child := map[string]any{
+		"actor":  "importer",
+		"source": "beads",
+		"items": []map[string]any{{
+			"external_id": "child",
+			"title":       "Child",
+			"body":        "child body",
+			"author":      "alice",
+			"status":      "open",
+			"created_at":  "2026-05-01T10:00:00Z",
+			"updated_at":  "2026-05-01T10:00:00Z",
+			"links": []map[string]any{{
+				"type":               "parent",
+				"target_external_id": "parent",
+			}},
+		}},
+	}
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, importEndpointPath(project.ID), child, nil)
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
+	_, err = env.DB.ImportMappingBySource(ctx, project.ID, "beads", "issue", "child")
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}
+
+func TestImportEndpoint_FederatedImportLinkRemovalDeniesOtherPeerLeaseHolder(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.New(t)
+	project := createImportTestProject(t, env, "github.com/wesm/kata", "kata")
+	initial := map[string]any{
+		"actor":  "importer",
+		"source": "beads",
+		"items": []map[string]any{
+			{
+				"external_id": "source",
+				"title":       "Source",
+				"body":        "source body",
+				"author":      "alice",
+				"status":      "open",
+				"created_at":  "2026-05-01T10:00:00Z",
+				"updated_at":  "2026-05-01T10:00:00Z",
+				"links": []map[string]any{{
+					"type":               "blocks",
+					"target_external_id": "peer",
+				}},
+			},
+			{
+				"external_id": "peer",
+				"title":       "Peer",
+				"body":        "peer body",
+				"author":      "alice",
+				"status":      "open",
+				"created_at":  "2026-05-01T10:00:00Z",
+				"updated_at":  "2026-05-01T10:00:00Z",
+			},
+		},
+	}
+	envPostJSON(t, env, importEndpointPath(project.ID), initial, &struct{}{})
+	sourceMapping, err := env.DB.ImportMappingBySource(ctx, project.ID, "beads", "issue", "source")
+	require.NoError(t, err)
+	require.NotNil(t, sourceMapping.IssueID)
+	peerMapping, err := env.DB.ImportMappingBySource(ctx, project.ID, "beads", "issue", "peer")
+	require.NoError(t, err)
+	require.NotNil(t, peerMapping.IssueID)
+	sourceIssue, err := env.DB.IssueByID(ctx, *sourceMapping.IssueID)
+	require.NoError(t, err)
+	peerIssue, err := env.DB.IssueByID(ctx, *peerMapping.IssueID)
+	require.NoError(t, err)
+	link, err := env.DB.LinkByEndpoints(ctx, sourceIssue.ID, peerIssue.ID, "blocks")
+	require.NoError(t, err)
+	_, err = env.DB.EnableProjectFederation(ctx, project.ID, "tester")
+	require.NoError(t, err)
+	_, err = env.DB.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: project.ID,
+		IssueRef:  peerIssue.ShortID,
+		Principal: db.ClaimPrincipal{
+			HolderInstanceUID: env.DB.InstanceUID(),
+			Holder:            "other",
+			ClientKind:        "cli",
+		},
+		ClaimKind: "hard",
+		Now:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	updateWithoutLink := map[string]any{
+		"actor":  "importer",
+		"source": "beads",
+		"items": []map[string]any{{
+			"external_id": "source",
+			"title":       "Source without link",
+			"body":        "source body",
+			"author":      "alice",
+			"status":      "open",
+			"created_at":  "2026-05-01T10:00:00Z",
+			"updated_at":  "2026-05-01T11:00:00Z",
+		}},
+	}
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, importEndpointPath(project.ID), updateWithoutLink, nil)
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
+	_, err = env.DB.LinkByID(ctx, link.ID)
+	assert.NoError(t, err)
+}
+
 func TestImportEndpoint_PriorityRoundtrips(t *testing.T) {
 	env := testenv.New(t)
 	pid := createImportTestProject(t, env, "github.com/wesm/kata", "kata").ID

--- a/internal/daemon/handlers_imports_test.go
+++ b/internal/daemon/handlers_imports_test.go
@@ -2,6 +2,7 @@ package daemon_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -169,7 +170,7 @@ func TestImportEndpoint_SourceNewerUpdatesIssue(t *testing.T) {
 	assert.Equal(t, "done", *issue.ClosedReason)
 }
 
-func TestImportEndpoint_FederatedExistingIssueRequiresLease(t *testing.T) {
+func TestImportEndpoint_FederatedExistingIssueAllowsUnclaimedUpdate(t *testing.T) {
 	ctx := context.Background()
 	env := testenv.New(t)
 	project := createImportTestProject(t, env, "github.com/wesm/kata", "kata")
@@ -219,28 +220,84 @@ func TestImportEndpoint_FederatedExistingIssueRequiresLease(t *testing.T) {
 
 	resp, raw := envDoRaw(t, env, http.MethodPost, importEndpointPath(project.ID), update, nil)
 
-	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_required")
-	unchanged, err := env.DB.IssueByID(ctx, issue.ID)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+	var out struct {
+		Updated int `json:"updated"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, 1, out.Updated)
+	changed, err := env.DB.IssueByID(ctx, issue.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "Old title", unchanged.Title)
+	assert.Equal(t, "New title", changed.Title)
+}
+
+func TestImportEndpoint_FederatedExistingIssueDeniesOtherLeaseHolder(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.New(t)
+	project := createImportTestProject(t, env, "github.com/wesm/kata", "kata")
+	initial := map[string]any{
+		"actor":  "importer",
+		"source": "beads",
+		"items": []map[string]any{{
+			"external_id": "beads-1",
+			"title":       "Old title",
+			"body":        "old body",
+			"author":      "alice",
+			"status":      "open",
+			"created_at":  "2026-05-01T10:00:00Z",
+			"updated_at":  "2026-05-01T10:00:00Z",
+		}},
+	}
+	var first struct {
+		Items []struct {
+			IssueShortID string `json:"issue_short_id"`
+		} `json:"items"`
+	}
+	envPostJSON(t, env, importEndpointPath(project.ID), initial, &first)
+	require.Len(t, first.Items, 1)
+	issue, err := env.DB.IssueByShortID(ctx, project.ID, first.Items[0].IssueShortID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	_, err = env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            project.ID,
+		Role:                 db.FederationRoleHub,
+		HubProjectUID:        project.UID,
+		ReplayHorizonEventID: 1,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
 
 	_, err = env.DB.AcquireClaim(ctx, db.AcquireClaimParams{
 		ProjectID: project.ID,
 		IssueRef:  issue.ShortID,
 		Principal: db.ClaimPrincipal{
 			HolderInstanceUID: env.DB.InstanceUID(),
-			Holder:            "importer",
+			Holder:            "other",
 			ClientKind:        "cli",
 		},
 		ClaimKind: "hard",
 		Now:       time.Now().UTC(),
 	})
 	require.NoError(t, err)
-	var out struct {
-		Updated int `json:"updated"`
+	update := map[string]any{
+		"actor":  "importer",
+		"source": "beads",
+		"items": []map[string]any{{
+			"external_id": "beads-1",
+			"title":       "New title",
+			"body":        "new body",
+			"author":      "alice",
+			"status":      "open",
+			"created_at":  "2026-05-01T10:00:00Z",
+			"updated_at":  "2026-05-01T11:00:00Z",
+		}},
 	}
-	envPostJSON(t, env, importEndpointPath(project.ID), update, &out)
-	assert.Equal(t, 1, out.Updated)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, importEndpointPath(project.ID), update, nil)
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "claim_denied")
+	unchanged, err := env.DB.IssueByID(ctx, issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Old title", unchanged.Title)
 }
 
 func TestImportEndpoint_FederatedIdempotentReimportDoesNotRequireLease(t *testing.T) {

--- a/internal/db/claims.go
+++ b/internal/db/claims.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	// ErrClaimRequired reports that an issue mutation needs a live claim.
+	// ErrClaimRequired is retained for legacy claim-action error mapping.
 	ErrClaimRequired = errors.New("claim required")
 	// ErrClaimDenied reports that another holder owns the relevant claim.
 	ErrClaimDenied = errors.New("claim denied")
@@ -23,7 +23,7 @@ var (
 	ErrClaimExpired = errors.New("claim expired")
 	// ErrClaimValidation reports an invalid claim request or state transition.
 	ErrClaimValidation = errors.New("claim validation")
-	// ErrPendingClaimNotAuthoritative reports that a pending claim cannot authorize work.
+	// ErrPendingClaimNotAuthoritative reports that a pending claim cannot prove exclusivity.
 	ErrPendingClaimNotAuthoritative = errors.New("pending claim not authoritative")
 )
 
@@ -710,23 +710,16 @@ func (d *DB) CheckClaimGate(ctx context.Context, p ClaimGateParams) error {
 		}
 		live, err := liveClaimForIssueTx(ctx, conn, issue.UID)
 		if errors.Is(err, ErrNotFound) {
-			pending, err := activePendingClaimRequestForPrincipalTx(ctx, conn, issue.UID, p.Principal)
-			if err == nil && pending.ID != 0 {
-				return ErrPendingClaimNotAuthoritative
-			}
-			if err != nil && !errors.Is(err, ErrNotFound) {
-				return err
-			}
-			return ErrClaimRequired
+			return nil
 		}
 		if err != nil {
 			return err
 		}
+		if live.ClaimKind == "timed" && live.ExpiresAt != nil && !live.ExpiresAt.After(now) {
+			return nil
+		}
 		if !sameClaimGateHolder(live, p.Principal) {
 			return ErrClaimDenied
-		}
-		if live.ClaimKind == "timed" && live.ExpiresAt != nil && !live.ExpiresAt.After(now) {
-			return ErrClaimExpired
 		}
 		return nil
 	})
@@ -1290,19 +1283,16 @@ func (d *DB) annotateClaimWorkMutationTx(
 		}
 		in.OffendingEventUID = uid
 	}
+	shouldAuditClaim := in.RequireClaim || claimWorkMutationRequiresClaim(in.EventType)
 	live, err := liveClaimForIssueTx(ctx, tx, in.IssueUID)
 	if errors.Is(err, ErrNotFound) {
-		if in.RequireClaim || claimWorkMutationRequiresClaim(in.EventType) {
-			evt, err := d.insertClaimViolationWithoutLiveClaimTx(ctx, tx, in, "claim_required")
-			if err != nil {
-				return nil, err
-			}
-			return append(events, evt), nil
-		}
 		return events, nil
 	}
 	if err != nil {
 		return nil, err
+	}
+	if !shouldAuditClaim {
+		return events, nil
 	}
 	if !claimWorkCoveredByLiveClaim(live, in.HolderInstanceUID, in.Actor) {
 		evt, err := d.insertClaimEventTx(ctx, tx, claimEventInput{
@@ -1333,7 +1323,7 @@ func claimWorkMutationRequiresClaim(eventType string) bool {
 		"issue.priority_set", "issue.priority_cleared",
 		"issue.closed", "issue.reopened", "issue.soft_deleted", "issue.restored",
 		"issue.labeled", "issue.unlabeled", "issue.linked", "issue.unlinked",
-		"issue.links_changed", "issue.metadata_updated", "issue.commented":
+		"issue.links_changed", "issue.metadata_updated":
 		return true
 	default:
 		return false
@@ -1406,76 +1396,6 @@ func latestClaimOffendingEventUIDTx(
 		return "", fmt.Errorf("lookup claim violation offender event: %w", err)
 	}
 	return uid, nil
-}
-
-func (d *DB) insertClaimViolationWithoutLiveClaimTx(
-	ctx context.Context,
-	tx claimStore,
-	in claimWorkMutationInput,
-	reason string,
-) (Event, error) {
-	payload := map[string]any{
-		"issue_uid":                     in.IssueUID,
-		"offending_event_uid":           in.OffendingEventUID,
-		"offending_event_type":          in.EventType,
-		"offending_origin_instance_uid": in.HolderInstanceUID,
-		"actor":                         in.Actor,
-		"reason":                        reason,
-	}
-	b, err := json.Marshal(payload)
-	if err != nil {
-		return Event{}, fmt.Errorf("marshal claim violation payload: %w", err)
-	}
-	eventUID, err := katauid.New()
-	if err != nil {
-		return Event{}, fmt.Errorf("generate event uid: %w", err)
-	}
-	now := time.Now().UTC()
-	createdAt := now.Format(sqliteTimeFormat)
-	clock, err := nextClaimEventHLC(ctx, tx, now)
-	if err != nil {
-		return Event{}, fmt.Errorf("next event hlc: %w", err)
-	}
-	projectUID, projectName, err := claimEventProjectIdentityTx(ctx, tx, in.ProjectID, in.ProjectName)
-	if err != nil {
-		return Event{}, err
-	}
-	contentHash, err := EventContentHash(EventHashInput{
-		UID:               eventUID,
-		OriginInstanceUID: d.instanceUID,
-		ProjectUID:        projectUID,
-		ProjectName:       projectName,
-		IssueUID:          &in.IssueUID,
-		Type:              "claim.violated",
-		Actor:             in.Actor,
-		HLCPhysicalMS:     clock.PhysicalMS,
-		HLCCounter:        clock.Counter,
-		CreatedAt:         createdAt,
-		Payload:           json.RawMessage(b),
-	})
-	if err != nil {
-		return Event{}, fmt.Errorf("content hash: %w", err)
-	}
-	res, err := tx.ExecContext(ctx, `
-		INSERT INTO events(
-		  uid, origin_instance_uid, project_id, project_name, issue_id, issue_uid,
-		  type, actor, payload, hlc_physical_ms, hlc_counter, content_hash, created_at
-		)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		eventUID, d.instanceUID, in.ProjectID, projectName, in.IssueID, in.IssueUID,
-		"claim.violated", in.Actor, string(b), clock.PhysicalMS, clock.Counter, contentHash, createdAt)
-	if err != nil {
-		return Event{}, fmt.Errorf("insert claim violation event: %w", err)
-	}
-	id, err := res.LastInsertId()
-	if err != nil {
-		return Event{}, err
-	}
-	e, err := scanEvent(tx.QueryRowContext(ctx, eventSelectByID, id))
-	if err != nil {
-		return Event{}, fmt.Errorf("read claim violation event: %w", err)
-	}
-	return e, nil
 }
 
 type claimEventInput struct {

--- a/internal/db/claims.go
+++ b/internal/db/claims.go
@@ -1147,6 +1147,12 @@ type claimWorkMutationInput struct {
 	EventType         string
 	Actor             string
 	HolderInstanceUID string
+	RequireClaim      bool
+}
+
+type federationIngestClaimAuditIssue struct {
+	UID          string
+	RequireClaim bool
 }
 
 func (d *DB) annotateFederationIngestClaimWorkTx(
@@ -1156,38 +1162,109 @@ func (d *DB) annotateFederationIngestClaimWorkTx(
 	projectName string,
 	ev RemoteEvent,
 ) ([]Event, error) {
-	if !claimWorkMutationRequiresClaim(ev.Type) {
-		return nil, nil
-	}
-	issueUID := ""
-	if ev.IssueUID != nil {
-		issueUID = *ev.IssueUID
-	}
-	if issueUID == "" {
-		if uid, err := payloadIssueUID(ev, payloadMap(ev.Payload)); err == nil {
-			issueUID = uid
-		}
-	}
-	if issueUID == "" {
-		return nil, nil
-	}
-	issueID, err := issueIDByUIDForClaimAuditTx(ctx, tx, projectID, issueUID)
-	if errors.Is(err, ErrNotFound) {
-		return nil, nil
-	}
+	issueUIDs, err := federationIngestClaimAuditIssueUIDs(ev)
 	if err != nil {
 		return nil, err
 	}
-	return d.annotateClaimWorkMutationTx(ctx, tx, claimWorkMutationInput{
-		ProjectID:         projectID,
-		ProjectName:       projectName,
-		IssueID:           issueID,
-		IssueUID:          issueUID,
-		OffendingEventUID: ev.EventUID,
-		EventType:         ev.Type,
-		Actor:             ev.Actor,
-		HolderInstanceUID: ev.OriginInstanceUID,
-	})
+	if len(issueUIDs) == 0 {
+		return nil, nil
+	}
+	var events []Event
+	claimsExpired := false
+	ensureClaimsExpired := func() error {
+		if claimsExpired {
+			return nil
+		}
+		expiredEvents, err := d.expireTimedClaimsForProjectTx(ctx, tx, projectID, time.Now().UTC(), 0)
+		if err != nil {
+			return err
+		}
+		events = append(events, expiredEvents...)
+		claimsExpired = true
+		return nil
+	}
+	for _, issue := range issueUIDs {
+		issueID, err := issueIDByUIDForClaimAuditTx(ctx, tx, projectID, issue.UID)
+		if errors.Is(err, ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := ensureClaimsExpired(); err != nil {
+			return nil, err
+		}
+		auditEvents, err := d.annotateClaimWorkMutationTx(ctx, tx, claimWorkMutationInput{
+			ProjectID:         projectID,
+			ProjectName:       projectName,
+			IssueID:           issueID,
+			IssueUID:          issue.UID,
+			OffendingEventUID: ev.EventUID,
+			EventType:         ev.Type,
+			Actor:             ev.Actor,
+			HolderInstanceUID: ev.OriginInstanceUID,
+			RequireClaim:      issue.RequireClaim,
+		})
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, auditEvents...)
+	}
+	return events, nil
+}
+
+func federationIngestClaimAuditIssueUIDs(ev RemoteEvent) ([]federationIngestClaimAuditIssue, error) {
+	payload := payloadMap(ev.Payload)
+	out := make([]federationIngestClaimAuditIssue, 0, 1)
+	seen := map[string]struct{}{}
+	add := func(issue federationIngestClaimAuditIssue) {
+		uid := issue.UID
+		if uid == "" {
+			return
+		}
+		if _, ok := seen[uid]; ok {
+			return
+		}
+		seen[uid] = struct{}{}
+		out = append(out, issue)
+	}
+	if claimWorkMutationRequiresClaim(ev.Type) {
+		issueUID := ""
+		if ev.IssueUID != nil {
+			issueUID = *ev.IssueUID
+		}
+		if issueUID == "" {
+			uid, err := payloadIssueUID(ev, payload)
+			if err != nil {
+				return nil, err
+			}
+			issueUID = uid
+		}
+		add(federationIngestClaimAuditIssue{UID: issueUID, RequireClaim: true})
+	}
+	if ev.Type == "issue.snapshot" {
+		issueUID := ""
+		if ev.IssueUID != nil {
+			issueUID = *ev.IssueUID
+		}
+		if issueUID == "" {
+			uid, err := payloadIssueUID(ev, payload)
+			if err != nil {
+				return nil, err
+			}
+			issueUID = uid
+		}
+		add(federationIngestClaimAuditIssue{UID: issueUID, RequireClaim: true})
+	}
+	if ev.Type == "issue.created" || ev.Type == "issue.snapshot" || claimWorkMutationRequiresPeerClaim(ev.Type) {
+		for _, ref := range payloadReferencedIssueUIDs(ev, payload) {
+			add(federationIngestClaimAuditIssue{
+				UID:          ref,
+				RequireClaim: true,
+			})
+		}
+	}
+	return out, nil
 }
 
 func (d *DB) annotateClaimWorkMutationTx(
@@ -1215,7 +1292,7 @@ func (d *DB) annotateClaimWorkMutationTx(
 	}
 	live, err := liveClaimForIssueTx(ctx, tx, in.IssueUID)
 	if errors.Is(err, ErrNotFound) {
-		if claimWorkMutationRequiresClaim(in.EventType) {
+		if in.RequireClaim || claimWorkMutationRequiresClaim(in.EventType) {
 			evt, err := d.insertClaimViolationWithoutLiveClaimTx(ctx, tx, in, "claim_required")
 			if err != nil {
 				return nil, err
@@ -1257,6 +1334,15 @@ func claimWorkMutationRequiresClaim(eventType string) bool {
 		"issue.closed", "issue.reopened", "issue.soft_deleted", "issue.restored",
 		"issue.labeled", "issue.unlabeled", "issue.linked", "issue.unlinked",
 		"issue.links_changed", "issue.metadata_updated", "issue.commented":
+		return true
+	default:
+		return false
+	}
+}
+
+func claimWorkMutationRequiresPeerClaim(eventType string) bool {
+	switch eventType {
+	case "issue.linked", "issue.unlinked", "issue.links_changed":
 		return true
 	default:
 		return false

--- a/internal/db/claims_test.go
+++ b/internal/db/claims_test.go
@@ -1863,15 +1863,6 @@ func payloadString(t *testing.T, payload map[string]any, key string) string {
 	return got
 }
 
-func assertPayloadFieldOmittedOrNull(t *testing.T, payload map[string]any, key string) {
-	t.Helper()
-	raw, ok := payload[key]
-	if !ok {
-		return
-	}
-	assert.Nil(t, raw, "payload key %s must be omitted or null", key)
-}
-
 func claimPrincipal(t *testing.T, holder string) db.ClaimPrincipal {
 	t.Helper()
 	return db.ClaimPrincipal{

--- a/internal/db/claims_test.go
+++ b/internal/db/claims_test.go
@@ -374,23 +374,14 @@ func TestIngestClaimViolationPayloadIncludesCanonicalOffenderFields(t *testing.T
 	assert.Equal(t, spokeUID, payloadString(t, payload, "holder_instance_uid"))
 }
 
-func TestIngestClaimRequiredViolationPayloadOmitsLiveClaimFields(t *testing.T) {
+func TestIngestWithoutLiveClaimDoesNotEmitViolation(t *testing.T) {
 	d, ctx, p, spokeUID, issue, _ := setupIngestClaimIssue(t)
 	offending := remoteClaimWorkEvent(t, p, spokeUID, issue.UID, nil, "issue.updated", "remote-agent")
 
 	_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, offending))
 	require.NoError(t, err)
 
-	payload := latestClaimViolationPayload(t, d)
-	assert.Equal(t, issue.UID, payloadString(t, payload, "issue_uid"))
-	assert.Equal(t, offending.EventUID, payloadString(t, payload, "offending_event_uid"))
-	assert.Equal(t, "issue.updated", payloadString(t, payload, "offending_event_type"))
-	assert.Equal(t, spokeUID, payloadString(t, payload, "offending_origin_instance_uid"))
-	assert.Equal(t, "remote-agent", payloadString(t, payload, "actor"))
-	assert.Equal(t, "claim_required", payloadString(t, payload, "reason"))
-	assertPayloadFieldOmittedOrNull(t, payload, "claim_uid")
-	assertPayloadFieldOmittedOrNull(t, payload, "holder")
-	assertPayloadFieldOmittedOrNull(t, payload, "holder_instance_uid")
+	assertEventCount(t, d, "claim.violated", 0)
 }
 
 func TestClaimViolationQueriesUseLegacyPayloadOriginFallback(t *testing.T) {
@@ -1043,7 +1034,18 @@ func TestPendingClaimRequestLegacyEmptyHolderInstanceStillDedupesByHolder(t *tes
 	assert.Empty(t, got.HolderInstanceUID)
 }
 
-func TestPendingClaimDoesNotSatisfyClaimGate(t *testing.T) {
+func TestClaimGateAllowsUnclaimedIssue(t *testing.T) {
+	d, ctx, p, issue := setupTestIssue(t)
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+
+	err := d.CheckClaimGate(ctx, db.ClaimGateParams{
+		ProjectID: p.ID, IssueRef: issue.ShortID, Principal: claimPrincipal(t, "alice"), Now: now,
+	})
+
+	require.NoError(t, err)
+}
+
+func TestPendingClaimDoesNotBlockUnclaimedClaimGate(t *testing.T) {
 	d, ctx, p, issue := setupTestIssue(t)
 	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
 	alice := claimPrincipal(t, "alice")
@@ -1056,8 +1058,7 @@ func TestPendingClaimDoesNotSatisfyClaimGate(t *testing.T) {
 		ProjectID: p.ID, IssueRef: issue.ShortID, Principal: alice, Now: now,
 	})
 
-	require.Error(t, err)
-	assert.ErrorIs(t, err, db.ErrPendingClaimNotAuthoritative)
+	require.NoError(t, err)
 }
 
 func TestPendingClaimResolveStoresCachedClaim(t *testing.T) {
@@ -1203,7 +1204,7 @@ func TestClaimGateIgnoresClientKindForLiveHolderMatch(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("same holder instance expired timed claim with non-empty client kind returns expired", func(t *testing.T) {
+	t.Run("same holder instance expired timed claim with non-empty client kind is treated as absent", func(t *testing.T) {
 		d, ctx, p, issue := setupTestIssue(t)
 		now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
 		acquired := db.ClaimPrincipal{
@@ -1231,8 +1232,7 @@ func TestClaimGateIgnoresClientKindForLiveHolderMatch(t *testing.T) {
 			Now: now.Add(time.Minute),
 		})
 
-		require.Error(t, err)
-		assert.ErrorIs(t, err, db.ErrClaimExpired)
+		require.NoError(t, err)
 	})
 
 	t.Run("different holder instance still returns denied", func(t *testing.T) {
@@ -1266,7 +1266,7 @@ func TestClaimGateIgnoresClientKindForLiveHolderMatch(t *testing.T) {
 	})
 }
 
-func TestCachedClaimTimedGateDeniesAfterExpiry(t *testing.T) {
+func TestCachedClaimTimedGateAllowsAfterExpiry(t *testing.T) {
 	d, ctx, p, issue := setupTestIssue(t)
 	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
 	expires := now.Add(time.Minute)
@@ -1280,11 +1280,10 @@ func TestCachedClaimTimedGateDeniesAfterExpiry(t *testing.T) {
 	err := d.CheckClaimGate(ctx, db.ClaimGateParams{
 		ProjectID: p.ID, IssueRef: issue.ShortID, Principal: alice, Now: expires,
 	})
-	require.Error(t, err)
-	assert.ErrorIs(t, err, db.ErrClaimExpired)
+	require.NoError(t, err)
 }
 
-func TestCachedClaimTimedGateDeniesDifferentTupleBeforeExpiryClassification(t *testing.T) {
+func TestCachedClaimTimedGateDeniesDifferentTupleBeforeExpiry(t *testing.T) {
 	d, ctx, p, issue := setupTestIssue(t)
 	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
 	expires := now.Add(time.Minute)
@@ -1293,18 +1292,17 @@ func TestCachedClaimTimedGateDeniesDifferentTupleBeforeExpiryClassification(t *t
 	require.NoError(t, d.UpsertClaimCache(ctx, cachedClaim(t, issue, alice, "timed", now, &expires)))
 
 	err := d.CheckClaimGate(ctx, db.ClaimGateParams{
-		ProjectID: p.ID, IssueRef: issue.ShortID, Principal: bob, Now: expires,
+		ProjectID: p.ID, IssueRef: issue.ShortID, Principal: bob, Now: now.Add(30 * time.Second),
 	})
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, db.ErrClaimDenied)
 
 	err = d.CheckClaimGate(ctx, db.ClaimGateParams{
-		ProjectID: p.ID, IssueRef: issue.ShortID, Principal: alice, Now: expires,
+		ProjectID: p.ID, IssueRef: issue.ShortID, Principal: bob, Now: expires,
 	})
 
-	require.Error(t, err)
-	assert.ErrorIs(t, err, db.ErrClaimExpired)
+	require.NoError(t, err)
 }
 
 func TestCachedClaimDeniedForDifferentHolder(t *testing.T) {

--- a/internal/db/federation.go
+++ b/internal/db/federation.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.kenn.io/kata/internal/shortid"
+	katauid "go.kenn.io/kata/internal/uid"
 )
 
 // ErrRemoteEventHashMismatch reports a remote event whose advertised content
@@ -91,6 +92,25 @@ type SkipFederationQuarantineParams struct {
 	Actor     string
 	Reason    string
 	Now       time.Time
+}
+
+// AdoptProjectIntoFederationParams configures adoption of an existing local
+// project into a hub federation.
+type AdoptProjectIntoFederationParams struct {
+	ProjectID            int64
+	HubURL               string
+	HubProjectID         int64
+	HubProjectUID        string
+	ReplayHorizonEventID int64
+	Actor                string
+}
+
+// AdoptProjectIntoFederationResult describes the adopted project, binding, and
+// snapshot emission count.
+type AdoptProjectIntoFederationResult struct {
+	Project               Project
+	Binding               FederationBinding
+	AdoptionSnapshotCount int64
 }
 
 // FederationSyncStatusByProject returns the stored sync status for one local
@@ -424,6 +444,160 @@ func (d *DB) InsertRemoteEvent(ctx context.Context, projectID int64, ev RemoteEv
 		return false, fmt.Errorf("commit remote event insert: %w", err)
 	}
 	return true, nil
+}
+
+// AdoptProjectIntoFederation converts an existing local project into a
+// push-enabled spoke replica for the hub project UID. The adoption emits a
+// current-state push baseline above the captured local push cursor floor.
+func (d *DB) AdoptProjectIntoFederation(
+	ctx context.Context,
+	p AdoptProjectIntoFederationParams,
+) (AdoptProjectIntoFederationResult, error) {
+	actor := strings.TrimSpace(p.Actor)
+	if actor == "" {
+		actor = "federation"
+	}
+	if !katauid.Valid(p.HubProjectUID) {
+		return AdoptProjectIntoFederationResult{}, fmt.Errorf("invalid hub project uid %q", p.HubProjectUID)
+	}
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return AdoptProjectIntoFederationResult{}, fmt.Errorf("begin federation adoption: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	project, err := scanProject(tx.QueryRowContext(ctx,
+		projectSelect+` WHERE id = ?`, p.ProjectID))
+	if err != nil {
+		return AdoptProjectIntoFederationResult{}, err
+	}
+	if project.DeletedAt != nil {
+		return AdoptProjectIntoFederationResult{}, fmt.Errorf("adopt project into federation: project %d is archived", p.ProjectID)
+	}
+
+	existing, err := scanFederationBinding(tx.QueryRowContext(ctx,
+		federationBindingSelect+` WHERE project_id = ?`, p.ProjectID))
+	if err == nil {
+		if existing.Role == FederationRoleSpoke && existing.HubProjectUID == p.HubProjectUID {
+			if err := tx.Commit(); err != nil {
+				return AdoptProjectIntoFederationResult{}, fmt.Errorf("commit idempotent federation adoption: %w", err)
+			}
+			return AdoptProjectIntoFederationResult{
+				Project: project,
+				Binding: existing,
+			}, nil
+		}
+		return AdoptProjectIntoFederationResult{}, fmt.Errorf("project %d already has %q federation binding", p.ProjectID, existing.Role)
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return AdoptProjectIntoFederationResult{}, err
+	}
+
+	issues, err := federationIssuesForSnapshot(ctx, tx, project.ID)
+	if err != nil {
+		return AdoptProjectIntoFederationResult{}, err
+	}
+
+	pushFloor, err := federationAdoptionPushFloor(ctx, tx, project.ID, d.InstanceUID())
+	if err != nil {
+		return AdoptProjectIntoFederationResult{}, err
+	}
+
+	if project.UID != p.HubProjectUID {
+		if err := replaceProjectUIDTx(ctx, tx, project.ID, p.HubProjectUID); err != nil {
+			return AdoptProjectIntoFederationResult{}, err
+		}
+		project.UID = p.HubProjectUID
+	}
+	if err := clearProjectClaimStateTx(ctx, tx, project.ID); err != nil {
+		return AdoptProjectIntoFederationResult{}, err
+	}
+	boundary, err := nextEventHLC(ctx, tx, time.Now().UTC())
+	if err != nil {
+		return AdoptProjectIntoFederationResult{}, err
+	}
+	baselineCreatedAt := time.Now().UTC().Format(sqliteTimeFormat)
+	if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE project_id = ?`, project.ID); err != nil {
+		return AdoptProjectIntoFederationResult{}, fmt.Errorf("delete pre-adoption local events: %w", err)
+	}
+
+	pullCursor := p.ReplayHorizonEventID - 1
+	if pullCursor < 0 {
+		pullCursor = 0
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO federation_bindings(
+			project_id, role, hub_url, hub_project_id, hub_project_uid,
+			replay_horizon_event_id, pull_cursor_event_id, push_enabled,
+			push_cursor_event_id, enabled
+		)
+		VALUES(?, ?, ?, ?, ?, ?, ?, 1, ?, 1)`,
+		project.ID, string(FederationRoleSpoke), p.HubURL, p.HubProjectID, p.HubProjectUID,
+		p.ReplayHorizonEventID, pullCursor, pushFloor); err != nil {
+		return AdoptProjectIntoFederationResult{}, fmt.Errorf("insert adoption federation binding: %w", err)
+	}
+
+	if len(project.Metadata) > 0 && string(project.Metadata) != "{}" {
+		payload, err := projectMetadataAdoptionPayload(project.Metadata)
+		if err != nil {
+			return AdoptProjectIntoFederationResult{}, err
+		}
+		if _, err := d.insertEventTx(ctx, tx, eventInsert{
+			ProjectID:   project.ID,
+			ProjectUID:  project.UID,
+			ProjectName: project.Name,
+			Type:        "project.metadata_updated",
+			Actor:       actor,
+			Payload:     payload,
+			HLC:         &boundary,
+			CreatedAt:   baselineCreatedAt,
+		}); err != nil {
+			return AdoptProjectIntoFederationResult{}, err
+		}
+	}
+
+	var snapshotCount int64
+	for _, issue := range issues {
+		payload, err := d.federationIssueSnapshotPayload(ctx, tx, issue)
+		if err != nil {
+			return AdoptProjectIntoFederationResult{}, err
+		}
+		issueUID := issue.UID
+		if _, err := d.insertEventTx(ctx, tx, eventInsert{
+			ProjectID:   project.ID,
+			ProjectUID:  project.UID,
+			ProjectName: project.Name,
+			IssueID:     &issue.ID,
+			IssueUID:    &issueUID,
+			Type:        "issue.snapshot",
+			Actor:       actor,
+			Payload:     payload,
+			HLC:         &boundary,
+			CreatedAt:   baselineCreatedAt,
+		}); err != nil {
+			return AdoptProjectIntoFederationResult{}, err
+		}
+		snapshotCount++
+	}
+
+	binding, err := scanFederationBinding(tx.QueryRowContext(ctx,
+		federationBindingSelect+` WHERE project_id = ?`, project.ID))
+	if err != nil {
+		return AdoptProjectIntoFederationResult{}, err
+	}
+	project, err = scanProject(tx.QueryRowContext(ctx,
+		projectSelect+` WHERE id = ?`, project.ID))
+	if err != nil {
+		return AdoptProjectIntoFederationResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AdoptProjectIntoFederationResult{}, fmt.Errorf("commit federation adoption: %w", err)
+	}
+	return AdoptProjectIntoFederationResult{
+		Project:               project,
+		Binding:               binding,
+		AdoptionSnapshotCount: snapshotCount,
+	}, nil
 }
 
 // EnableProjectFederation marks a local project as a pull hub and writes a
@@ -761,9 +935,9 @@ func ensureFederatedMoveAllowedTx(ctx context.Context, q sqlReader, projectIDs .
 }
 
 const federationBindingSelect = `SELECT project_id, role, hub_url, hub_project_id, hub_project_uid,
-       replay_horizon_event_id, pull_cursor_event_id, push_enabled, push_cursor_event_id,
-       enabled, created_at, updated_at, last_sync_at
-  FROM federation_bindings`
+	       replay_horizon_event_id, pull_cursor_event_id, push_enabled, push_cursor_event_id,
+	       enabled, created_at, updated_at, last_sync_at
+	  FROM federation_bindings`
 
 func scanFederationBinding(r rowScanner) (FederationBinding, error) {
 	var (
@@ -905,6 +1079,68 @@ func validateFederationQuarantine(p RecordFederationQuarantineParams) error {
 	return nil
 }
 
+func federationAdoptionPushFloor(ctx context.Context, tx *sql.Tx, projectID int64, originInstanceUID string) (int64, error) {
+	var maxID sql.NullInt64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT MAX(id)
+		  FROM events
+		 WHERE project_id = ?
+		   AND origin_instance_uid = ?
+		   AND `+federationPushEventTypeCondition("type"),
+		projectID, originInstanceUID).Scan(&maxID); err != nil {
+		return 0, fmt.Errorf("capture adoption push cursor floor: %w", err)
+	}
+	if maxID.Valid {
+		return maxID.Int64, nil
+	}
+	return 0, nil
+}
+
+func replaceProjectUIDTx(ctx context.Context, tx *sql.Tx, projectID int64, uid string) error {
+	if _, err := tx.ExecContext(ctx, `DROP TRIGGER IF EXISTS trg_projects_uid_immutable`); err != nil {
+		return fmt.Errorf("drop project uid immutability trigger for adoption: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE projects SET uid = ? WHERE id = ?`, uid, projectID); err != nil {
+		return fmt.Errorf("update adopted project uid: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TRIGGER trg_projects_uid_immutable
+		BEFORE UPDATE OF uid ON projects
+		FOR EACH ROW BEGIN
+		  SELECT RAISE(ABORT, 'projects.uid is immutable')
+		  WHERE NEW.uid <> OLD.uid;
+		END`); err != nil {
+		return fmt.Errorf("restore project uid immutability trigger after adoption: %w", err)
+	}
+	return nil
+}
+
+func projectMetadataAdoptionPayload(metadata JSONBlob) (string, error) {
+	current := map[string]json.RawMessage{}
+	if len(metadata) > 0 {
+		if err := json.Unmarshal([]byte(metadata), &current); err != nil {
+			return "", fmt.Errorf("decode adopted project metadata: %w", err)
+		}
+	}
+	type diffEntry struct {
+		From any             `json:"from"`
+		To   json.RawMessage `json:"to"`
+	}
+	diff := make(map[string]diffEntry, len(current))
+	for key, value := range current {
+		diff[key] = diffEntry{From: nil, To: value}
+	}
+	payload, err := json.Marshal(struct {
+		Diff map[string]diffEntry `json:"diff"`
+	}{
+		Diff: diff,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal adopted project metadata event: %w", err)
+	}
+	return string(payload), nil
+}
+
 func federationIssuesForSnapshot(ctx context.Context, tx *sql.Tx, projectID int64) ([]Issue, error) {
 	rows, err := tx.QueryContext(ctx,
 		issueSelect+` WHERE i.project_id = ? ORDER BY i.id ASC`, projectID)
@@ -991,8 +1227,9 @@ func federationIssueLabels(ctx context.Context, tx *sql.Tx, issueID int64) ([]st
 
 func federationIssueLinks(ctx context.Context, tx *sql.Tx, issueID int64) ([]createdLinkOut, error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT l.type, peer.short_id, peer.uid
+		SELECT l.type, peer.short_id, peer.uid, subject.project_id, peer.project_id
 		  FROM links l
+		  JOIN issues subject ON subject.id = l.from_issue_id
 		  JOIN issues peer ON peer.id = l.to_issue_id
 		 WHERE l.from_issue_id = ?
 		 ORDER BY l.type ASC, peer.uid ASC`, issueID)
@@ -1002,9 +1239,15 @@ func federationIssueLinks(ctx context.Context, tx *sql.Tx, issueID int64) ([]cre
 	defer func() { _ = rows.Close() }()
 	var out []createdLinkOut
 	for rows.Next() {
-		var link createdLinkOut
-		if err := rows.Scan(&link.Type, &link.ToShortID, &link.ToIssueUID); err != nil {
+		var (
+			link                        createdLinkOut
+			subjectProject, peerProject int64
+		)
+		if err := rows.Scan(&link.Type, &link.ToShortID, &link.ToIssueUID, &subjectProject, &peerProject); err != nil {
 			return nil, fmt.Errorf("scan federation snapshot link: %w", err)
+		}
+		if subjectProject != peerProject {
+			return nil, fmt.Errorf("out-of-project link in federation snapshot for issue %d", issueID)
 		}
 		out = append(out, link)
 	}
@@ -1104,9 +1347,10 @@ func projectUIDTx(ctx context.Context, tx *sql.Tx, projectID int64) (string, err
 }
 
 func clearFederatedProjection(ctx context.Context, tx *sql.Tx, projectID int64) error {
+	if err := clearProjectClaimStateTx(ctx, tx, projectID); err != nil {
+		return err
+	}
 	for _, stmt := range []string{
-		`DELETE FROM pending_claim_requests WHERE project_id = ?`,
-		`DELETE FROM issue_claims WHERE project_id = ?`,
 		`DELETE FROM issue_labels WHERE issue_id IN (SELECT id FROM issues WHERE project_id = ?)`,
 		`DELETE FROM comments WHERE issue_id IN (SELECT id FROM issues WHERE project_id = ?)`,
 		`DELETE FROM links WHERE project_id = ?`,
@@ -1114,6 +1358,18 @@ func clearFederatedProjection(ctx context.Context, tx *sql.Tx, projectID int64) 
 	} {
 		if _, err := tx.ExecContext(ctx, stmt, projectID); err != nil {
 			return fmt.Errorf("clear federated projection: %w", err)
+		}
+	}
+	return nil
+}
+
+func clearProjectClaimStateTx(ctx context.Context, tx *sql.Tx, projectID int64) error {
+	for _, stmt := range []string{
+		`DELETE FROM pending_claim_requests WHERE project_id = ?`,
+		`DELETE FROM issue_claims WHERE project_id = ?`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt, projectID); err != nil {
+			return fmt.Errorf("clear project claim state: %w", err)
 		}
 	}
 	return nil

--- a/internal/db/federation_ingest.go
+++ b/internal/db/federation_ingest.go
@@ -81,9 +81,14 @@ func (d *DB) ingestFederationEventsOnce(
 	if err != nil {
 		return FederationIngestResult{}, err
 	}
+	batchCreateSnapshotUIDs, err := federationIngestCreateSnapshotUIDSet(p.Events)
+	if err != nil {
+		return FederationIngestResult{}, err
+	}
 	prepared := make([]preparedFederationIngestEvent, 0, len(p.Events))
 	result := FederationIngestResult{}
 	seenBatch := map[string]string{}
+	freshSnapshotSeen := false
 	for _, in := range p.Events {
 		if in.SourceEventID <= 0 {
 			return FederationIngestResult{}, fmt.Errorf("%w: source event id must be positive", ErrFederationIngestValidation)
@@ -95,7 +100,7 @@ func (d *DB) ingestFederationEventsOnce(
 		if len(ev.Payload) == 0 {
 			ev.Payload = json.RawMessage(`{}`)
 		}
-		if err := validateFederationProjectEvent(projectUID, p.SpokeInstanceUID, ev, knownIssueUIDs); err != nil {
+		if err := validateFederationProjectEvent(projectUID, p.SpokeInstanceUID, ev, knownIssueUIDs, batchCreateSnapshotUIDs); err != nil {
 			return FederationIngestResult{}, err
 		}
 		if err := validateFederationEventHash(ev); err != nil {
@@ -130,8 +135,15 @@ func (d *DB) ingestFederationEventsOnce(
 		if !errors.Is(err, ErrNotFound) {
 			return FederationIngestResult{}, err
 		}
+		if freshSnapshotSeen && ev.Type != "issue.snapshot" {
+			return FederationIngestResult{}, fmt.Errorf("%w: non-snapshot event %s follows snapshot baseline in same batch",
+				ErrFederationIngestValidation, ev.EventUID)
+		}
 		if err := rejectFreshCreateSnapshotForKnownIssue(ev, knownIssueUIDs); err != nil {
 			return FederationIngestResult{}, err
+		}
+		if ev.Type == "issue.snapshot" {
+			freshSnapshotSeen = true
 		}
 		seenBatch[ev.EventUID] = ev.ContentHash
 		rememberIngestIssueUIDs(ev, knownIssueUIDs)
@@ -188,6 +200,10 @@ func insertFederationEventTx(
 	projectName string,
 	ev RemoteEvent,
 ) (bool, error) {
+	storedProjectName := ev.ProjectName
+	if storedProjectName == "" {
+		storedProjectName = projectName
+	}
 	res, err := tx.ExecContext(ctx,
 		`INSERT INTO events(
 		   uid, origin_instance_uid, project_id, project_name,
@@ -197,7 +213,7 @@ func insertFederationEventTx(
 		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(uid) DO NOTHING`,
 		ev.EventUID, ev.OriginInstanceUID,
-		projectID, projectName,
+		projectID, storedProjectName,
 		nil, stringPtrValue(ev.IssueUID),
 		nil, stringPtrValue(ev.RelatedIssueUID),
 		ev.Type, ev.Actor, string(ev.Payload),
@@ -285,6 +301,7 @@ func validateFederationProjectEvent(
 	projectUID, spokeInstanceUID string,
 	ev RemoteEvent,
 	knownIssueUIDs map[string]struct{},
+	batchCreateSnapshotUIDs map[string]struct{},
 ) error {
 	if ev.ProjectUID != projectUID {
 		return fmt.Errorf("%w: event %s targets project %s", ErrFederationIngestValidation, ev.EventUID, ev.ProjectUID)
@@ -328,15 +345,49 @@ func validateFederationProjectEvent(
 	default:
 		return fmt.Errorf("%w: unsupported event type %s", ErrFederationIngestValidation, ev.Type)
 	}
+	deferredSnapshotLinks := map[string]struct{}{}
+	if ev.Type == "issue.snapshot" {
+		for _, ref := range payloadLinkIssueUIDs(ev) {
+			if _, ok := batchCreateSnapshotUIDs[ref]; ok {
+				deferredSnapshotLinks[ref] = struct{}{}
+			}
+		}
+	}
 	for _, ref := range payloadReferencedIssueUIDs(ev, payload) {
 		if ref == issueUID {
 			continue
 		}
 		if _, ok := knownIssueUIDs[ref]; !ok {
+			if _, deferred := deferredSnapshotLinks[ref]; deferred {
+				continue
+			}
 			return fmt.Errorf("%w: event %s references unknown issue %s", ErrFederationIngestValidation, ev.EventUID, ref)
 		}
 	}
 	return nil
+}
+
+func federationIngestCreateSnapshotUIDSet(events []FederationIngestEvent) (map[string]struct{}, error) {
+	out := map[string]struct{}{}
+	for _, in := range events {
+		ev := in.Event
+		if len(ev.Payload) == 0 {
+			ev.Payload = json.RawMessage(`{}`)
+		}
+		switch ev.Type {
+		case "issue.created", "issue.snapshot":
+		default:
+			continue
+		}
+		uid, err := payloadIssueUID(ev, payloadMap(ev.Payload))
+		if err != nil {
+			return nil, err
+		}
+		if uid != "" {
+			out[uid] = struct{}{}
+		}
+	}
+	return out, nil
 }
 
 func rejectFreshCreateSnapshotForKnownIssue(ev RemoteEvent, knownIssueUIDs map[string]struct{}) error {
@@ -396,12 +447,18 @@ func payloadReferencedIssueUIDs(ev RemoteEvent, payload map[string]json.RawMessa
 	} {
 		refs = append(refs, stringSlice(payload[key])...)
 	}
+	refs = append(refs, payloadLinkIssueUIDs(ev)...)
+	return refs
+}
+
+func payloadLinkIssueUIDs(ev RemoteEvent) []string {
 	var created struct {
 		Links []struct {
 			ToIssueUID string `json:"to_issue_uid"`
 		} `json:"links"`
 	}
 	_ = json.Unmarshal(ev.Payload, &created)
+	var refs []string
 	for _, link := range created.Links {
 		if link.ToIssueUID != "" {
 			refs = append(refs, link.ToIssueUID)

--- a/internal/db/federation_push.go
+++ b/internal/db/federation_push.go
@@ -31,6 +31,60 @@ func (d *DB) PendingFederationPushEvents(
 	if limit <= 0 {
 		limit = 1000
 	}
+	out, err := d.queryPendingFederationPushEvents(ctx, `
+		WHERE e.project_id = ?
+		  AND e.origin_instance_uid = ?
+		  AND e.id > ?
+		  AND `+federationPushEventTypeCondition("e.type")+`
+		ORDER BY e.id ASC
+		LIMIT ?`, projectID, originInstanceUID, afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == limit && len(out) > 0 && out[len(out)-1].Type == "issue.snapshot" {
+		runStartAfterID := afterID
+		for i := len(out) - 1; i >= 0; i-- {
+			if out[i].Type != "issue.snapshot" {
+				runStartAfterID = out[i].ID
+				break
+			}
+		}
+		extra, err := d.queryPendingFederationPushEvents(ctx, `
+			WHERE e.project_id = ?
+			  AND e.origin_instance_uid = ?
+			  AND e.id > ?
+			  AND e.type = 'issue.snapshot'
+			  AND NOT EXISTS (
+			    SELECT 1
+			      FROM events barrier
+			     WHERE barrier.project_id = e.project_id
+			       AND barrier.origin_instance_uid = e.origin_instance_uid
+			       AND barrier.id > ?
+			       AND barrier.id < e.id
+			       AND `+federationPushEventTypeCondition("barrier.type")+`
+			       AND barrier.type <> 'issue.snapshot'
+			  )
+			ORDER BY e.id ASC`, projectID, originInstanceUID, out[len(out)-1].ID, runStartAfterID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, extra...)
+	}
+	for i, ev := range out {
+		if ev.Type != "issue.snapshot" {
+			continue
+		}
+		for j := i + 1; j < len(out); j++ {
+			if out[j].Type != "issue.snapshot" {
+				return out[:j], nil
+			}
+		}
+		break
+	}
+	return out, nil
+}
+
+func (d *DB) queryPendingFederationPushEvents(ctx context.Context, where string, args ...any) ([]Event, error) {
 	rows, err := d.QueryContext(ctx, `SELECT e.id, e.uid, e.origin_instance_uid, e.project_id, p.uid, e.project_name,
 	             e.issue_id, e.issue_uid, i.short_id, e.related_issue_id, e.related_issue_uid, ri.short_id,
 	             e.type, e.actor, e.payload, e.hlc_physical_ms, e.hlc_counter, e.content_hash, e.created_at
@@ -38,12 +92,7 @@ func (d *DB) PendingFederationPushEvents(
 	      JOIN projects p ON p.id = e.project_id
 	      LEFT JOIN issues i ON i.project_id = e.project_id AND (i.id = e.issue_id OR (e.issue_id IS NULL AND e.issue_uid IS NOT NULL AND i.uid = e.issue_uid))
 	      LEFT JOIN issues ri ON ri.project_id = e.project_id AND (ri.id = e.related_issue_id OR (e.related_issue_id IS NULL AND e.related_issue_uid IS NOT NULL AND ri.uid = e.related_issue_uid))
-	      WHERE e.project_id = ?
-	        AND e.origin_instance_uid = ?
-	        AND e.id > ?
-	        AND `+federationPushEventTypeCondition("e.type")+`
-	      ORDER BY e.id ASC
-	      LIMIT ?`, projectID, originInstanceUID, afterID, limit)
+	      `+where, args...)
 	if err != nil {
 		return nil, fmt.Errorf("pending federation push events: %w", err)
 	}
@@ -101,11 +150,14 @@ func federationPushEventTypeCondition(column string) string {
 func (d *DB) AdvanceFederationPushCursor(ctx context.Context, projectID, nextCursor int64) error {
 	res, err := d.ExecContext(ctx, `
 		UPDATE federation_bindings
-		   SET push_cursor_event_id = ?,
+		   SET push_cursor_event_id = CASE
+		         WHEN push_cursor_event_id < ? THEN ?
+		         ELSE push_cursor_event_id
+		       END,
 		       last_sync_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
 		       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
 		 WHERE project_id = ?`,
-		nextCursor, projectID)
+		nextCursor, nextCursor, projectID)
 	if err != nil {
 		return fmt.Errorf("advance federation push cursor: %w", err)
 	}

--- a/internal/db/federation_test.go
+++ b/internal/db/federation_test.go
@@ -851,8 +851,7 @@ func TestAdoptProjectIntoFederationClearsLocalClaimState(t *testing.T) {
 		Principal: principal,
 		Now:       now,
 	})
-	require.Error(t, err)
-	assert.ErrorIs(t, err, db.ErrClaimRequired)
+	require.NoError(t, err)
 }
 
 func TestAdoptionSnapshotLinksIngestDoesNotEmitClaimViolation(t *testing.T) {
@@ -2178,7 +2177,7 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		assertEventCount(t, d, "claim.violated", 1)
+		assertEventCount(t, d, "claim.violated", 0)
 	})
 
 	for _, eventType := range []string{"issue.created", "issue.snapshot"} {
@@ -2369,7 +2368,7 @@ func TestIngestClaimViolationWorkMutationCoverage(t *testing.T) {
 		"issue.priority_set", "issue.priority_cleared",
 		"issue.closed", "issue.reopened", "issue.soft_deleted", "issue.restored",
 		"issue.labeled", "issue.unlabeled", "issue.linked", "issue.unlinked",
-		"issue.links_changed", "issue.metadata_updated", "issue.commented",
+		"issue.links_changed", "issue.metadata_updated",
 	} {
 		t.Run(eventType, func(t *testing.T) {
 			d, ctx, p, spokeUID, issue, peer := setupIngestClaimIssue(t)
@@ -2387,9 +2386,6 @@ func TestIngestClaimViolationWorkMutationCoverage(t *testing.T) {
 
 			require.NoError(t, err)
 			wantViolations := 1
-			if eventType == "issue.linked" || eventType == "issue.unlinked" || eventType == "issue.links_changed" {
-				wantViolations = 2
-			}
 			assertEventCount(t, d, "claim.violated", wantViolations)
 		})
 	}
@@ -2413,6 +2409,24 @@ func TestIngestClaimViolationWorkMutationCoverage(t *testing.T) {
 			assertEventCount(t, d, "claim.violated", 0)
 		})
 	}
+
+	t.Run("issue.commented bypasses live claims", func(t *testing.T) {
+		d, ctx, p, spokeUID, issue, peer := setupIngestClaimIssue(t)
+		_, err := d.AcquireClaim(ctx, db.AcquireClaimParams{
+			ProjectID: p.ID,
+			IssueRef:  issue.ShortID,
+			Principal: db.ClaimPrincipal{HolderInstanceUID: spokeUID, Holder: "holder"},
+			ClaimKind: "hard",
+			Now:       time.Now().UTC(),
+		})
+		require.NoError(t, err)
+
+		_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID,
+			remoteClaimWorkEvent(t, p, spokeUID, issue.UID, &peer.UID, "issue.commented", "remote-agent")))
+
+		require.NoError(t, err)
+		assertEventCount(t, d, "claim.violated", 0)
+	})
 }
 
 func TestIngestClaimAuditRejectsForgedAdoptionLinkBaseline(t *testing.T) {
@@ -2432,7 +2446,7 @@ func TestIngestClaimAuditRejectsForgedAdoptionLinkBaseline(t *testing.T) {
 	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, ev))
 
 	require.NoError(t, err)
-	assertEventCount(t, d, "claim.violated", 2)
+	assertEventCount(t, d, "claim.violated", 1)
 }
 
 func TestIngestClaimAuditRejectsForgedAdoptionLinkBaselineAfterSnapshots(t *testing.T) {
@@ -2465,10 +2479,10 @@ func TestIngestClaimAuditRejectsForgedAdoptionLinkBaselineAfterSnapshots(t *test
 	})
 
 	require.NoError(t, err)
-	assertEventCount(t, d, "claim.violated", 2)
+	assertEventCount(t, d, "claim.violated", 0)
 }
 
-func TestIngestClaimAuditSnapshotLinkToExistingIssueRequiresPeerClaim(t *testing.T) {
+func TestIngestClaimAuditSnapshotLinkToUnclaimedExistingIssueDoesNotViolate(t *testing.T) {
 	d, ctx, p, spokeUID := setupFederationIngestHub(t)
 	peer, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: p.ID,
@@ -2484,13 +2498,13 @@ func TestIngestClaimAuditSnapshotLinkToExistingIssueRequiresPeerClaim(t *testing
 	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, snapshot))
 
 	require.NoError(t, err)
-	assertEventCount(t, d, "claim.violated", 1)
+	assertEventCount(t, d, "claim.violated", 0)
 	assertRowCount(ctx, t, d, 1, "snapshot link to existing peer materialized",
 		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'related'`,
 		p.ID)
 }
 
-func TestIngestClaimAuditSnapshotLinkToUnclaimedSameOriginPeerRequiresClaim(t *testing.T) {
+func TestIngestClaimAuditSnapshotLinkToUnclaimedSameOriginPeerDoesNotViolate(t *testing.T) {
 	d, ctx, p, spokeUID := setupFederationIngestHub(t)
 	parentUID := newTestUID(t)
 	childUID := newTestUID(t)
@@ -2506,7 +2520,7 @@ func TestIngestClaimAuditSnapshotLinkToUnclaimedSameOriginPeerRequiresClaim(t *t
 	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, childSnapshot))
 
 	require.NoError(t, err)
-	assertEventCount(t, d, "claim.violated", 1)
+	assertEventCount(t, d, "claim.violated", 0)
 	assertRowCount(ctx, t, d, 1, "snapshot baseline parent link materialized",
 		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'parent'`,
 		p.ID)
@@ -2544,7 +2558,7 @@ func TestIngestClaimAuditSnapshotLinkToClaimedSameOriginPeerRequiresClaim(t *tes
 		p.ID)
 }
 
-func TestIngestClaimAuditLaterSnapshotLinkToPriorSameOriginPeerRequiresClaim(t *testing.T) {
+func TestIngestClaimAuditLaterSnapshotLinkToPriorUnclaimedSameOriginPeerDoesNotViolate(t *testing.T) {
 	d, ctx, p, spokeUID := setupFederationIngestHub(t)
 	peerUID := newTestUID(t)
 	childUID := newTestUID(t)
@@ -2560,7 +2574,7 @@ func TestIngestClaimAuditLaterSnapshotLinkToPriorSameOriginPeerRequiresClaim(t *
 	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, laterSnapshot))
 
 	require.NoError(t, err)
-	assertEventCount(t, d, "claim.violated", 1)
+	assertEventCount(t, d, "claim.violated", 0)
 	assertRowCount(ctx, t, d, 1, "later snapshot parent link materialized",
 		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'parent'`,
 		p.ID)
@@ -2596,12 +2610,20 @@ func TestIngestClaimAuditCreatedLinkToExistingIssueRequiresPeerClaim(t *testing.
 		p.ID)
 }
 
-func TestIngestClaimAuditLinksChangedRequiresPeerClaim(t *testing.T) {
+func TestIngestClaimAuditLinksChangedViolatesOtherPeerClaimHolder(t *testing.T) {
 	d, ctx, p, spokeUID, issue, peer := setupIngestClaimIssue(t)
 	_, err := d.AcquireClaim(ctx, db.AcquireClaimParams{
 		ProjectID: p.ID,
 		IssueRef:  issue.ShortID,
 		Principal: db.ClaimPrincipal{HolderInstanceUID: spokeUID, Holder: "remote-agent"},
+		ClaimKind: "hard",
+		Now:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: p.ID,
+		IssueRef:  peer.ShortID,
+		Principal: db.ClaimPrincipal{HolderInstanceUID: d.InstanceUID(), Holder: "hub-agent"},
 		ClaimKind: "hard",
 		Now:       time.Now().UTC(),
 	})
@@ -2632,7 +2654,7 @@ func TestIngestClaimViolationExpiresTimedClaimBeforeAudit(t *testing.T) {
 	require.NoError(t, err)
 	assertLiveClaimCount(t, d, issue.UID, 0)
 	assertEventCount(t, d, "claim.expired", 1)
-	assertEventCount(t, d, "claim.violated", 1)
+	assertEventCount(t, d, "claim.violated", 0)
 }
 
 func TestMaterializeFederatedProject(t *testing.T) {

--- a/internal/db/federation_test.go
+++ b/internal/db/federation_test.go
@@ -411,6 +411,64 @@ func TestPendingFederationPushEvents(t *testing.T) {
 	assertSchemaObject(t, d, "idx_events_origin_project_id")
 }
 
+func TestPendingFederationPushEventsDoesNotSplitAdoptionSnapshots(t *testing.T) {
+	d, ctx, p := setupTestProject(t)
+	parent, _ := createTesterIssue(ctx, t, d, p.ID, "parent")
+	child, _ := createTesterIssue(ctx, t, d, p.ID, "child")
+	_, err := d.EditIssueAtomic(ctx, db.EditIssueAtomicParams{
+		IssueID:   child.ID,
+		Actor:     "tester",
+		SetParent: &parent.ID,
+	})
+	require.NoError(t, err)
+	adopted, err := d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+		ProjectID:            p.ID,
+		HubURL:               "http://127.0.0.1:7373",
+		HubProjectID:         42,
+		HubProjectUID:        newTestUID(t),
+		ReplayHorizonEventID: 1,
+		Actor:                "adopter",
+	})
+	require.NoError(t, err)
+
+	got, err := d.PendingFederationPushEvents(ctx, p.ID, d.InstanceUID(), adopted.Binding.PushCursorEventID, 1)
+
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, []string{"issue.snapshot", "issue.snapshot"}, []string{got[0].Type, got[1].Type})
+}
+
+func TestPendingFederationPushEventsStopsAfterAdoptionSnapshotRun(t *testing.T) {
+	d, ctx, p := setupTestProject(t)
+	baseline, _ := createTesterIssue(ctx, t, d, p.ID, "baseline")
+	adopted, err := d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+		ProjectID:            p.ID,
+		HubURL:               "http://127.0.0.1:7373",
+		HubProjectID:         42,
+		HubProjectUID:        newTestUID(t),
+		ReplayHorizonEventID: 1,
+		Actor:                "adopter",
+	})
+	require.NoError(t, err)
+	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: p.ID,
+		Title:     "post-adoption child",
+		Author:    "tester",
+		Links:     []db.InitialLink{{Type: "parent", ToNumber: baseline.ID}},
+	})
+	require.NoError(t, err)
+
+	got, err := d.PendingFederationPushEvents(ctx, p.ID, d.InstanceUID(), adopted.Binding.PushCursorEventID, 100)
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "issue.snapshot", got[0].Type)
+	afterSnapshots, err := d.PendingFederationPushEvents(ctx, p.ID, d.InstanceUID(), got[0].ID, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, afterSnapshots)
+	assert.Equal(t, "issue.created", afterSnapshots[0].Type)
+}
+
 func TestAdvanceFederationPushCursor(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
 	_, err := d.UpsertFederationBinding(ctx, db.FederationBinding{
@@ -430,6 +488,477 @@ func TestAdvanceFederationPushCursor(t *testing.T) {
 	assert.Equal(t, int64(12), got.PushCursorEventID)
 
 	assert.ErrorIs(t, d.AdvanceFederationPushCursor(ctx, 999, 1), db.ErrNotFound)
+}
+
+func TestAdoptProjectIntoFederation(t *testing.T) {
+	t.Run("rejects invalid hub project uid", func(t *testing.T) {
+		d, ctx, p := setupTestProject(t)
+
+		_, err := d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+			ProjectID:            p.ID,
+			HubURL:               "http://127.0.0.1:7373",
+			HubProjectID:         42,
+			HubProjectUID:        "!!!!!!!!!!!!!!!!!!!!!!!!!!",
+			ReplayHorizonEventID: 9,
+			Actor:                "adopter",
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid hub project uid")
+	})
+
+	t.Run("adopts current state into push-enabled spoke stream", func(t *testing.T) {
+		d, ctx, p := setupTestProject(t)
+		require.NoError(t, renameProjectForAdoptionTest(ctx, d, p.ID, "shared-foo"))
+		p, err := d.ProjectByID(ctx, p.ID)
+		require.NoError(t, err)
+		oldProjectUID := p.UID
+
+		owner := "alice"
+		priority := int64(1)
+		openIssue, createEvent, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: p.ID,
+			Title:     "open adoption issue",
+			Body:      "body survives",
+			Author:    "alice",
+			Owner:     &owner,
+			Priority:  &priority,
+			Labels:    []string{"area:db"},
+		})
+		require.NoError(t, err)
+		closedIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: p.ID,
+			Title:     "closed adoption issue",
+			Author:    "bob",
+		})
+		require.NoError(t, err)
+		comment, _, err := d.CreateComment(ctx, db.CreateCommentParams{
+			IssueID: openIssue.ID,
+			Author:  "carol",
+			Body:    "comment survives",
+		})
+		require.NoError(t, err)
+		metaOut, err := d.PatchIssueMetadata(ctx, db.PatchIssueMetadataIn{
+			IssueID:    openIssue.ID,
+			IfMatchRev: openIssue.Revision,
+			Actor:      "alice",
+			Patch: map[string]json.RawMessage{
+				"component": json.RawMessage(`"db"`),
+			},
+		})
+		require.NoError(t, err)
+		openIssue = metaOut.Issue
+		projectMetaOut, err := d.PatchProjectMetadata(ctx, db.PatchProjectMetadataIn{
+			ProjectID:  p.ID,
+			IfMatchRev: p.Revision,
+			Actor:      "alice",
+			Patch: map[string]json.RawMessage{
+				"team": json.RawMessage(`"federation"`),
+			},
+		})
+		require.NoError(t, err)
+		p = projectMetaOut.Project
+		closedIssue, _, _, err = d.CloseIssue(ctx, closedIssue.ID, "done", "bob", "completed before adoption", nil)
+		require.NoError(t, err)
+		_, err = d.CreateLink(ctx, db.CreateLinkParams{
+			ProjectID:   p.ID,
+			FromIssueID: openIssue.ID,
+			ToIssueID:   closedIssue.ID,
+			Type:        "related",
+			Author:      "alice",
+		})
+		require.NoError(t, err)
+
+		futurePhysical := time.Now().UTC().Add(10 * time.Minute).UnixMilli()
+		futureEventUID := newTestUID(t)
+		_, err = d.ExecContext(ctx, `
+			INSERT INTO events(
+				uid, origin_instance_uid, project_id, project_name, issue_id, issue_uid,
+				type, actor, payload, hlc_physical_ms, hlc_counter, content_hash, created_at
+			)
+			VALUES(?, ?, ?, ?, ?, ?, 'issue.updated', 'tester',
+			       '{"title":"pre-adoption high water"}', ?, 7, ?, ?)`,
+			futureEventUID, d.InstanceUID(), p.ID, p.Name, openIssue.ID, openIssue.UID,
+			futurePhysical, strings.Repeat("a", 64),
+			time.Now().UTC().Format("2006-01-02T15:04:05.000Z"))
+		require.NoError(t, err)
+		var pushFloor int64
+		require.NoError(t, d.QueryRowContext(ctx, `SELECT MAX(id) FROM events WHERE project_id = ?`, p.ID).Scan(&pushFloor))
+
+		hubUID := newTestUID(t)
+		result, err := d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+			ProjectID:            p.ID,
+			HubURL:               "http://127.0.0.1:7373",
+			HubProjectID:         42,
+			HubProjectUID:        hubUID,
+			ReplayHorizonEventID: 9,
+			Actor:                "adopter",
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, oldProjectUID, result.Project.UID)
+		assert.Equal(t, hubUID, result.Project.UID)
+		assert.Equal(t, int64(2), result.AdoptionSnapshotCount)
+		assert.Equal(t, db.FederationRoleSpoke, result.Binding.Role)
+		assert.True(t, result.Binding.PushEnabled)
+		assert.True(t, result.Binding.Enabled)
+		assert.Equal(t, int64(8), result.Binding.PullCursorEventID)
+		assert.Equal(t, pushFloor, result.Binding.PushCursorEventID)
+		assertRowCount(ctx, t, d, 0, "pre-adoption local events deleted during adoption",
+			`SELECT COUNT(*) FROM events WHERE project_id = ? AND id <= ?`, p.ID, pushFloor)
+
+		pending, err := d.PendingFederationPushEvents(ctx, p.ID, d.InstanceUID(), result.Binding.PushCursorEventID, 20)
+		require.NoError(t, err)
+		require.Len(t, pending, 3)
+		for _, ev := range pending {
+			assert.Greater(t, ev.ID, pushFloor)
+			assert.Equal(t, hubUID, ev.ProjectUID)
+			assert.True(t, ev.HLCPhysicalMS > futurePhysical ||
+				(ev.HLCPhysicalMS == futurePhysical && ev.HLCCounter > 7),
+				"adoption event %s should sort after pre-adoption future event", ev.Type)
+		}
+		require.NoError(t, d.AdvanceFederationPushCursor(ctx, p.ID, 0))
+		unchangedFloor, err := d.FederationBindingByProject(ctx, p.ID)
+		require.NoError(t, err)
+		assert.Equal(t, pushFloor, unchangedFloor.PushCursorEventID)
+		afterLowAdvance, err := d.PendingFederationPushEvents(ctx, p.ID, d.InstanceUID(), unchangedFloor.PushCursorEventID, 20)
+		require.NoError(t, err)
+		assert.Equal(t, eventIDs(pending), eventIDs(afterLowAdvance))
+		var eventCountBeforeRetry int
+		require.NoError(t, d.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE project_id = ?`, p.ID).Scan(&eventCountBeforeRetry))
+		retryResult, err := d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+			ProjectID:            p.ID,
+			HubURL:               "http://127.0.0.1:7373",
+			HubProjectID:         42,
+			HubProjectUID:        hubUID,
+			ReplayHorizonEventID: 9,
+			Actor:                "adopter",
+		})
+		require.NoError(t, err)
+		assert.Zero(t, retryResult.AdoptionSnapshotCount)
+		assert.Equal(t, pushFloor, retryResult.Binding.PushCursorEventID)
+		var eventCountAfterRetry int
+		require.NoError(t, d.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE project_id = ?`, p.ID).Scan(&eventCountAfterRetry))
+		assert.Equal(t, eventCountBeforeRetry, eventCountAfterRetry, "idempotent adoption retry must not emit duplicate events")
+		quarantine, err := d.RecordFederationQuarantine(ctx, db.RecordFederationQuarantineParams{
+			ProjectID:    p.ID,
+			Direction:    db.FederationQuarantineDirectionPush,
+			FirstEventID: 1,
+			LastEventID:  pushFloor - 1,
+			EventUIDs:    []string{futureEventUID},
+			Error:        "pre-adoption poisoned batch",
+			CreatedAt:    time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		_, err = d.SkipFederationQuarantine(ctx, db.SkipFederationQuarantineParams{
+			ID:        quarantine.ID,
+			ProjectID: p.ID,
+			Actor:     "operator",
+			Reason:    "below adoption floor",
+			Now:       time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		afterSkip, err := d.FederationBindingByProject(ctx, p.ID)
+		require.NoError(t, err)
+		assert.Equal(t, pushFloor, afterSkip.PushCursorEventID)
+
+		assert.Equal(t, []string{
+			"project.metadata_updated",
+			"issue.snapshot",
+			"issue.snapshot",
+		}, []string{pending[0].Type, pending[1].Type, pending[2].Type})
+
+		projectMetaPayload := unmarshalPayload[struct {
+			Diff map[string]struct {
+				From *json.RawMessage `json:"from"`
+				To   json.RawMessage  `json:"to"`
+			} `json:"diff"`
+		}](t, pending[0].Payload)
+		require.Contains(t, projectMetaPayload.Diff, "team")
+		assert.Nil(t, projectMetaPayload.Diff["team"].From)
+		assert.JSONEq(t, `"federation"`, string(projectMetaPayload.Diff["team"].To))
+
+		snapshots := map[string]db.Event{}
+		for _, ev := range pending {
+			if ev.Type == "issue.snapshot" {
+				require.NotNil(t, ev.IssueUID)
+				snapshots[*ev.IssueUID] = ev
+			}
+		}
+		require.Len(t, snapshots, 2)
+		openPayload := unmarshalPayload[federationSnapshotPayload](t, snapshots[openIssue.UID].Payload)
+		require.Len(t, openPayload.Links, 1)
+		assert.Equal(t, "related", openPayload.Links[0].Type)
+		assert.Equal(t, closedIssue.UID, openPayload.Links[0].ToIssueUID)
+		assert.Equal(t, openIssue.UID, openPayload.UID)
+		assert.Equal(t, "open adoption issue", openPayload.Title)
+		require.NotNil(t, openPayload.Owner)
+		assert.Equal(t, owner, *openPayload.Owner)
+		require.NotNil(t, openPayload.Priority)
+		assert.Equal(t, priority, *openPayload.Priority)
+		assert.JSONEq(t, `{"component":"db"}`, string(openPayload.Metadata))
+		assert.Equal(t, []string{"area:db"}, openPayload.Labels)
+		require.Len(t, openPayload.Comments, 1)
+		assert.Equal(t, comment.UID, openPayload.Comments[0].CommentUID)
+		assert.Equal(t, "comment survives", openPayload.Comments[0].Body)
+		closedPayload := unmarshalPayload[federationSnapshotPayload](t, snapshots[closedIssue.UID].Payload)
+		assert.Empty(t, closedPayload.Links)
+		assert.Equal(t, "closed", closedPayload.Status)
+		require.NotNil(t, closedPayload.ClosedReason)
+		assert.Equal(t, "done", *closedPayload.ClosedReason)
+		require.NotNil(t, closedPayload.ClosedAt)
+
+		require.NoError(t, d.MaterializeFederatedProject(ctx, p.ID))
+		materializedProject, err := d.ProjectByID(ctx, p.ID)
+		require.NoError(t, err)
+		assert.Equal(t, hubUID, materializedProject.UID)
+		assert.JSONEq(t, `{"team":"federation"}`, string(materializedProject.Metadata))
+		materializedOpen, err := d.IssueByUID(ctx, openIssue.UID, db.IncludeDeletedYes)
+		require.NoError(t, err)
+		assert.Equal(t, "open adoption issue", materializedOpen.Title)
+		assert.Equal(t, openIssue.UpdatedAt, materializedOpen.UpdatedAt)
+		materializedClosed, err := d.IssueByUID(ctx, closedIssue.UID, db.IncludeDeletedYes)
+		require.NoError(t, err)
+		assert.Equal(t, "closed", materializedClosed.Status)
+		assertRowCount(ctx, t, d, 1, "adopted related link materialized",
+			`SELECT COUNT(*) FROM links WHERE project_id = ? AND from_issue_uid = ? AND to_issue_uid = ? AND type = 'related'`,
+			p.ID, openIssue.UID, closedIssue.UID)
+		assert.Greater(t, createEvent.ID, int64(0), "pre-adoption fixture event should have existed before adoption")
+		require.NoError(t, d.AdvanceFederationPushCursor(ctx, p.ID, pending[len(pending)-1].ID))
+		require.NoError(t, d.ResetFederatedProjectIfNoPendingPush(ctx, p.ID, 20, 19, d.InstanceUID(), pending[len(pending)-1].ID))
+		afterResetPending, err := d.PendingFederationPushEvents(ctx, p.ID, d.InstanceUID(), 0, 20)
+		require.NoError(t, err)
+		assert.Empty(t, afterResetPending, "reset must delete pre-adoption history before a lower cursor can select it")
+	})
+
+	t.Run("rejects malformed out-of-project links before commit", func(t *testing.T) {
+		d, ctx, p := setupTestProject(t)
+		require.NoError(t, renameProjectForAdoptionTest(ctx, d, p.ID, "shared-foo"))
+		p, err := d.ProjectByID(ctx, p.ID)
+		require.NoError(t, err)
+		beforeUID := p.UID
+		base, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: p.ID,
+			Title:     "base",
+			Author:    "tester",
+		})
+		require.NoError(t, err)
+		otherProject, err := d.CreateProject(ctx, "other-project")
+		require.NoError(t, err)
+		foreign, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: otherProject.ID,
+			Title:     "foreign",
+			Author:    "tester",
+		})
+		require.NoError(t, err)
+		require.NoError(t, insertMalformedAdoptionLink(ctx, d, p.ID, base, foreign))
+
+		_, err = d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+			ProjectID:            p.ID,
+			HubURL:               "http://127.0.0.1:7373",
+			HubProjectID:         42,
+			HubProjectUID:        newTestUID(t),
+			ReplayHorizonEventID: 9,
+			Actor:                "adopter",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out-of-project link")
+
+		after, err := d.ProjectByID(ctx, p.ID)
+		require.NoError(t, err)
+		assert.Equal(t, beforeUID, after.UID)
+		_, err = d.FederationBindingByProject(ctx, p.ID)
+		assert.ErrorIs(t, err, db.ErrNotFound)
+		assertRowCount(ctx, t, d, 0, "no adoption snapshots after rollback",
+			`SELECT COUNT(*) FROM events WHERE project_id = ? AND type = 'issue.snapshot'`, p.ID)
+	})
+
+	t.Run("materialization ignores issues moved out before adoption", func(t *testing.T) {
+		d, ctx, p := setupTestProject(t)
+		target, err := d.CreateProject(ctx, "target")
+		require.NoError(t, err)
+		moved, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: p.ID,
+			Title:     "moved before adoption",
+			Author:    "alice",
+		})
+		require.NoError(t, err)
+		moveOut, err := d.MoveIssueProject(ctx, db.MoveIssueProjectIn{
+			IssueID:       moved.ID,
+			FromProjectID: p.ID,
+			ToProjectID:   target.ID,
+			IfMatchRev:    moved.Revision,
+			Actor:         "alice",
+		})
+		require.NoError(t, err)
+		require.Equal(t, target.ID, moveOut.Issue.ProjectID)
+
+		hubUID := newTestUID(t)
+		_, err = d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+			ProjectID:            p.ID,
+			HubURL:               "http://127.0.0.1:7373",
+			HubProjectID:         42,
+			HubProjectUID:        hubUID,
+			ReplayHorizonEventID: 9,
+			Actor:                "adopter",
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, d.MaterializeFederatedProject(ctx, p.ID))
+		after, err := d.IssueByUID(ctx, moved.UID, db.IncludeDeletedYes)
+		require.NoError(t, err)
+		assert.Equal(t, target.ID, after.ProjectID)
+		assertRowCount(ctx, t, d, 0, "moved-out issue must not be recreated in adopted project",
+			`SELECT COUNT(*) FROM issues WHERE project_id = ? AND uid = ?`, p.ID, moved.UID)
+	})
+}
+
+func TestAdoptProjectIntoFederationClearsLocalClaimState(t *testing.T) {
+	d, ctx, p := setupTestProject(t)
+	issue := makeIssue(t, ctx, d, p.ID, "claimed", "tester")
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	principal := claimPrincipal(t, "alice")
+	_, err := d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: p.ID,
+		IssueRef:  issue.ShortID,
+		Principal: principal,
+		ClaimKind: "hard",
+		Now:       now,
+	})
+	require.NoError(t, err)
+	_, err = d.EnqueuePendingClaim(ctx, db.PendingClaimParams{
+		ProjectID: p.ID,
+		IssueRef:  issue.ShortID,
+		Principal: claimPrincipal(t, "bob"),
+		ClaimKind: "hard",
+		Now:       now,
+	})
+	require.NoError(t, err)
+
+	_, err = d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+		ProjectID:            p.ID,
+		HubURL:               "http://127.0.0.1:7373",
+		HubProjectID:         42,
+		HubProjectUID:        newTestUID(t),
+		ReplayHorizonEventID: 1,
+		Actor:                "adopter",
+	})
+	require.NoError(t, err)
+
+	assertClaimProjectionCounts(ctx, t, d, p.ID, 0, 0)
+	err = d.CheckClaimGate(ctx, db.ClaimGateParams{
+		ProjectID: p.ID,
+		IssueRef:  issue.ShortID,
+		Principal: principal,
+		Now:       now,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrClaimRequired)
+}
+
+func TestAdoptionSnapshotLinksIngestDoesNotEmitClaimViolation(t *testing.T) {
+	spoke, ctx, localProject := setupTestProject(t)
+	first, _ := createTesterIssue(ctx, t, spoke, localProject.ID, "first")
+	second, _ := createTesterIssue(ctx, t, spoke, localProject.ID, "second")
+	_, err := spoke.EditIssueAtomic(ctx, db.EditIssueAtomicParams{
+		IssueID:    first.ID,
+		Actor:      "tester",
+		AddRelated: []int64{second.ID},
+	})
+	require.NoError(t, err)
+
+	hubUID := newTestUID(t)
+	adopted, err := spoke.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+		ProjectID:            localProject.ID,
+		HubURL:               "http://hub.example.test",
+		HubProjectID:         42,
+		HubProjectUID:        hubUID,
+		ReplayHorizonEventID: 1,
+		Actor:                "federation",
+	})
+	require.NoError(t, err)
+	pending, err := spoke.PendingFederationPushEvents(ctx, localProject.ID, spoke.InstanceUID(), adopted.Binding.PushCursorEventID, 20)
+	require.NoError(t, err)
+
+	var snapshots []db.FederationIngestEvent
+	for _, ev := range pending {
+		if ev.Type == "issue.snapshot" {
+			snapshots = append(snapshots, db.FederationIngestEvent{
+				SourceEventID: ev.ID,
+				Event:         remoteEventFromLocalEvent(ev),
+			})
+		}
+	}
+	require.Len(t, snapshots, 2)
+
+	hub := openTestDB(t)
+	hubProject, err := hub.CreateProjectWithUID(ctx, "hub", hubUID)
+	require.NoError(t, err)
+	_, err = hub.EnableProjectFederation(ctx, hubProject.ID, "hub")
+	require.NoError(t, err)
+
+	_, err = hub.IngestFederationEvents(ctx, db.FederationIngestParams{
+		ProjectID:        hubProject.ID,
+		SpokeInstanceUID: spoke.InstanceUID(),
+		Events:           snapshots,
+	})
+	require.NoError(t, err)
+	assertEventCount(t, hub, "claim.violated", 0)
+	assertRowCount(ctx, t, hub, 1, "adoption snapshot link materialized",
+		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'related'`,
+		hubProject.ID)
+}
+
+func TestAdoptionSnapshotParentLinkInSingleBaselineBatchDoesNotEmitClaimViolation(t *testing.T) {
+	spoke, ctx, localProject := setupTestProject(t)
+	parent, _ := createTesterIssue(ctx, t, spoke, localProject.ID, "parent")
+	child, _ := createTesterIssue(ctx, t, spoke, localProject.ID, "child")
+	_, err := spoke.EditIssueAtomic(ctx, db.EditIssueAtomicParams{
+		IssueID:   child.ID,
+		Actor:     "tester",
+		SetParent: &parent.ID,
+	})
+	require.NoError(t, err)
+
+	hubUID := newTestUID(t)
+	adopted, err := spoke.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+		ProjectID:            localProject.ID,
+		HubURL:               "http://hub.example.test",
+		HubProjectID:         42,
+		HubProjectUID:        hubUID,
+		ReplayHorizonEventID: 1,
+		Actor:                "federation",
+	})
+	require.NoError(t, err)
+	pending, err := spoke.PendingFederationPushEvents(ctx, localProject.ID, spoke.InstanceUID(), adopted.Binding.PushCursorEventID, 20)
+	require.NoError(t, err)
+
+	var snapshots []db.FederationIngestEvent
+	for _, ev := range pending {
+		if ev.Type == "issue.snapshot" {
+			snapshots = append(snapshots, db.FederationIngestEvent{
+				SourceEventID: ev.ID,
+				Event:         remoteEventFromLocalEvent(ev),
+			})
+		}
+	}
+	require.Len(t, snapshots, 2)
+
+	hub := openTestDB(t)
+	hubProject, err := hub.CreateProjectWithUID(ctx, "hub", hubUID)
+	require.NoError(t, err)
+	_, err = hub.EnableProjectFederation(ctx, hubProject.ID, "hub")
+	require.NoError(t, err)
+
+	_, err = hub.IngestFederationEvents(ctx, db.FederationIngestParams{
+		ProjectID:        hubProject.ID,
+		SpokeInstanceUID: spoke.InstanceUID(),
+		Events:           snapshots,
+	})
+	require.NoError(t, err)
+	assertEventCount(t, hub, "claim.violated", 0)
+	assertRowCount(ctx, t, hub, 1, "adoption snapshot parent link materialized",
+		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'parent'`,
+		hubProject.ID)
 }
 
 func TestEnableFederationPush(t *testing.T) {
@@ -1340,6 +1869,10 @@ func TestIngestFederationEvents(t *testing.T) {
 		issue, err := d.IssueByUID(ctx, issueUID, db.IncludeDeletedNo)
 		require.NoError(t, err)
 		assert.Equal(t, "spoke work", issue.Title)
+		events, err := d.EventsAfter(ctx, db.EventsAfterParams{ProjectID: p.ID, Limit: 10})
+		require.NoError(t, err)
+		require.Len(t, events, 2, "project.federation_enabled + ingested event")
+		assert.Equal(t, ev.ProjectName, events[1].ProjectName)
 	})
 
 	t.Run("rejects hash mismatch before insert", func(t *testing.T) {
@@ -1584,6 +2117,70 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("rejects snapshot link reference missing from same batch", func(t *testing.T) {
+		d, ctx, p, spokeUID := setupFederationIngestHub(t)
+		fromUID := newTestUID(t)
+		missingUID := newTestUID(t)
+		ev := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &fromUID, nil,
+			"issue.snapshot", 100,
+			`{"uid":"`+fromUID+`","short_id":"`+shortID(fromUID)+`","title":"from","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z","links":[{"type":"related","to_issue_uid":"`+missingUID+`"}]}`)
+
+		_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, ev))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+	})
+
+	t.Run("rejects non-snapshot work after snapshot baseline in same batch", func(t *testing.T) {
+		d, ctx, p, spokeUID := setupFederationIngestHub(t)
+		baselineUID := newTestUID(t)
+		childUID := newTestUID(t)
+		snapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &baselineUID, nil,
+			"issue.snapshot", 100,
+			`{"uid":"`+baselineUID+`","short_id":"`+shortID(baselineUID)+`","title":"baseline","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+		created := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &childUID, &baselineUID,
+			"issue.created", 101,
+			`{"uid":"`+childUID+`","short_id":"`+shortID(childUID)+`","title":"child","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"parent","to_issue_uid":"`+baselineUID+`"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+
+		_, err := d.IngestFederationEvents(ctx, db.FederationIngestParams{
+			ProjectID:        p.ID,
+			SpokeInstanceUID: spokeUID,
+			Events: []db.FederationIngestEvent{
+				{SourceEventID: 1, Event: snapshot},
+				{SourceEventID: 2, Event: created},
+			},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+	})
+
+	t.Run("allows duplicate snapshot before fresh work", func(t *testing.T) {
+		d, ctx, p, spokeUID := setupFederationIngestHub(t)
+		baselineUID := newTestUID(t)
+		childUID := newTestUID(t)
+		snapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &baselineUID, nil,
+			"issue.snapshot", 100,
+			`{"uid":"`+baselineUID+`","short_id":"`+shortID(baselineUID)+`","title":"baseline","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+		_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, snapshot))
+		require.NoError(t, err)
+		created := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &childUID, &baselineUID,
+			"issue.created", 101,
+			`{"uid":"`+childUID+`","short_id":"`+shortID(childUID)+`","title":"child","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"parent","to_issue_uid":"`+baselineUID+`"}],"created_at":"2026-05-23T12:01:00.000Z"}`)
+
+		_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+			ProjectID:        p.ID,
+			SpokeInstanceUID: spokeUID,
+			Events: []db.FederationIngestEvent{
+				{SourceEventID: 2, Event: snapshot},
+				{SourceEventID: 3, Event: created},
+			},
+		})
+
+		require.NoError(t, err)
+		assertEventCount(t, d, "claim.violated", 1)
+	})
+
 	for _, eventType := range []string{"issue.created", "issue.snapshot"} {
 		t.Run("rejects fresh "+eventType+" for known issue uid", func(t *testing.T) {
 			d, ctx, p, spokeUID := setupFederationIngestHub(t)
@@ -1635,6 +2232,32 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		issue, err := d.IssueByUID(ctx, issueUID, db.IncludeDeletedYes)
 		require.NoError(t, err)
 		assert.Equal(t, "after create", issue.Title)
+	})
+
+	t.Run("allows snapshot link reference created in same batch", func(t *testing.T) {
+		d, ctx, p, spokeUID := setupFederationIngestHub(t)
+		fromUID := newTestUID(t)
+		toUID := newTestUID(t)
+		fromSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &fromUID, nil,
+			"issue.snapshot", 100,
+			`{"uid":"`+fromUID+`","short_id":"`+shortID(fromUID)+`","title":"from","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z","links":[{"type":"related","to_issue_uid":"`+toUID+`"}]}`)
+		toSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &toUID, nil,
+			"issue.snapshot", 101,
+			`{"uid":"`+toUID+`","short_id":"`+shortID(toUID)+`","title":"to","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+
+		_, err := d.IngestFederationEvents(ctx, db.FederationIngestParams{
+			ProjectID:        p.ID,
+			SpokeInstanceUID: spokeUID,
+			Events: []db.FederationIngestEvent{
+				{SourceEventID: 1, Event: fromSnapshot},
+				{SourceEventID: 2, Event: toSnapshot},
+			},
+		})
+
+		require.NoError(t, err)
+		assertRowCount(ctx, t, d, 1, "snapshot link materializes after target arrives in same batch",
+			`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'related'`,
+			p.ID)
 	})
 
 	t.Run("rejects related issue outside project", func(t *testing.T) {
@@ -1763,7 +2386,11 @@ func TestIngestClaimViolationWorkMutationCoverage(t *testing.T) {
 				remoteClaimWorkEvent(t, p, spokeUID, issue.UID, &peer.UID, eventType, "remote-agent")))
 
 			require.NoError(t, err)
-			assertEventCount(t, d, "claim.violated", 1)
+			wantViolations := 1
+			if eventType == "issue.linked" || eventType == "issue.unlinked" || eventType == "issue.links_changed" {
+				wantViolations = 2
+			}
+			assertEventCount(t, d, "claim.violated", wantViolations)
 		})
 	}
 
@@ -1786,6 +2413,205 @@ func TestIngestClaimViolationWorkMutationCoverage(t *testing.T) {
 			assertEventCount(t, d, "claim.violated", 0)
 		})
 	}
+}
+
+func TestIngestClaimAuditRejectsForgedAdoptionLinkBaseline(t *testing.T) {
+	d, ctx, p, spokeUID, issue, peer := setupIngestClaimIssue(t)
+	_, err := d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: p.ID,
+		IssueRef:  issue.ShortID,
+		Principal: db.ClaimPrincipal{HolderInstanceUID: spokeUID, Holder: "holder"},
+		ClaimKind: "hard",
+		Now:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	ev := remoteClaimWorkEvent(t, p, spokeUID, issue.UID, &peer.UID, "issue.links_changed", "remote-agent")
+	ev.Payload = json.RawMessage(`{"issue_uid":"` + issue.UID + `","related_added_uids":["` + peer.UID + `"],"adoption_baseline":true}`)
+	ev.ContentHash = remoteEventHash(t, ev)
+
+	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, ev))
+
+	require.NoError(t, err)
+	assertEventCount(t, d, "claim.violated", 2)
+}
+
+func TestIngestClaimAuditRejectsForgedAdoptionLinkBaselineAfterSnapshots(t *testing.T) {
+	d, ctx, p, spokeUID := setupFederationIngestHub(t)
+	fromUID := newTestUID(t)
+	toUID := newTestUID(t)
+	fromSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &fromUID, nil,
+		"issue.snapshot", 100,
+		`{"uid":"`+fromUID+`","short_id":"`+shortID(fromUID)+`","title":"from","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+	toSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &toUID, nil,
+		"issue.snapshot", 101,
+		`{"uid":"`+toUID+`","short_id":"`+shortID(toUID)+`","title":"to","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+	_, err := d.IngestFederationEvents(ctx, db.FederationIngestParams{
+		ProjectID:        p.ID,
+		SpokeInstanceUID: spokeUID,
+		Events: []db.FederationIngestEvent{
+			{SourceEventID: 1, Event: fromSnapshot},
+			{SourceEventID: 2, Event: toSnapshot},
+		},
+	})
+	require.NoError(t, err)
+	link := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &fromUID, &toUID,
+		"issue.links_changed", 102,
+		`{"issue_uid":"`+fromUID+`","related_added_uids":["`+toUID+`"],"adoption_baseline":true}`)
+
+	_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+		ProjectID:        p.ID,
+		SpokeInstanceUID: spokeUID,
+		Events:           []db.FederationIngestEvent{{SourceEventID: 3, Event: link}},
+	})
+
+	require.NoError(t, err)
+	assertEventCount(t, d, "claim.violated", 2)
+}
+
+func TestIngestClaimAuditSnapshotLinkToExistingIssueRequiresPeerClaim(t *testing.T) {
+	d, ctx, p, spokeUID := setupFederationIngestHub(t)
+	peer, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: p.ID,
+		Title:     "existing peer",
+		Author:    "hub-agent",
+	})
+	require.NoError(t, err)
+	fromUID := newTestUID(t)
+	snapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &fromUID, nil,
+		"issue.snapshot", 100,
+		`{"uid":"`+fromUID+`","short_id":"`+shortID(fromUID)+`","title":"from","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z","links":[{"type":"related","to_issue_uid":"`+peer.UID+`"}]}`)
+
+	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, snapshot))
+
+	require.NoError(t, err)
+	assertEventCount(t, d, "claim.violated", 1)
+	assertRowCount(ctx, t, d, 1, "snapshot link to existing peer materialized",
+		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'related'`,
+		p.ID)
+}
+
+func TestIngestClaimAuditSnapshotLinkToUnclaimedSameOriginPeerRequiresClaim(t *testing.T) {
+	d, ctx, p, spokeUID := setupFederationIngestHub(t)
+	parentUID := newTestUID(t)
+	childUID := newTestUID(t)
+	parentSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &parentUID, nil,
+		"issue.snapshot", 100,
+		`{"uid":"`+parentUID+`","short_id":"`+shortID(parentUID)+`","title":"parent","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+	childSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &childUID, nil,
+		"issue.snapshot", 101,
+		`{"uid":"`+childUID+`","short_id":"`+shortID(childUID)+`","title":"child","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z","links":[{"type":"parent","to_issue_uid":"`+parentUID+`"}]}`)
+
+	_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, parentSnapshot))
+	require.NoError(t, err)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, childSnapshot))
+
+	require.NoError(t, err)
+	assertEventCount(t, d, "claim.violated", 1)
+	assertRowCount(ctx, t, d, 1, "snapshot baseline parent link materialized",
+		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'parent'`,
+		p.ID)
+}
+
+func TestIngestClaimAuditSnapshotLinkToClaimedSameOriginPeerRequiresClaim(t *testing.T) {
+	d, ctx, p, spokeUID := setupFederationIngestHub(t)
+	peerUID := newTestUID(t)
+	childUID := newTestUID(t)
+	peerSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &peerUID, nil,
+		"issue.snapshot", 100,
+		`{"uid":"`+peerUID+`","short_id":"`+shortID(peerUID)+`","title":"peer","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+	childSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &childUID, nil,
+		"issue.snapshot", 101,
+		`{"uid":"`+childUID+`","short_id":"`+shortID(childUID)+`","title":"child","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z","links":[{"type":"related","to_issue_uid":"`+peerUID+`"}]}`)
+
+	_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, peerSnapshot))
+	require.NoError(t, err)
+	peer, err := d.IssueByUID(ctx, peerUID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	_, err = d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: p.ID,
+		IssueRef:  peer.ShortID,
+		Principal: db.ClaimPrincipal{HolderInstanceUID: d.InstanceUID(), Holder: "hub-agent"},
+		ClaimKind: "hard",
+		Now:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, childSnapshot))
+
+	require.NoError(t, err)
+	assertEventCount(t, d, "claim.violated", 1)
+	assertRowCount(ctx, t, d, 1, "snapshot link to claimed same-origin peer materialized",
+		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'related'`,
+		p.ID)
+}
+
+func TestIngestClaimAuditLaterSnapshotLinkToPriorSameOriginPeerRequiresClaim(t *testing.T) {
+	d, ctx, p, spokeUID := setupFederationIngestHub(t)
+	peerUID := newTestUID(t)
+	childUID := newTestUID(t)
+	peerSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &peerUID, nil,
+		"issue.snapshot", 100,
+		`{"uid":"`+peerUID+`","short_id":"`+shortID(peerUID)+`","title":"peer","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+	_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, peerSnapshot))
+	require.NoError(t, err)
+	laterSnapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &childUID, nil,
+		"issue.snapshot", 101,
+		`{"uid":"`+childUID+`","short_id":"`+shortID(childUID)+`","title":"child","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:01:00.000Z","links":[{"type":"parent","to_issue_uid":"`+peerUID+`"}]}`)
+
+	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, laterSnapshot))
+
+	require.NoError(t, err)
+	assertEventCount(t, d, "claim.violated", 1)
+	assertRowCount(ctx, t, d, 1, "later snapshot parent link materialized",
+		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'parent'`,
+		p.ID)
+}
+
+func TestIngestClaimAuditCreatedLinkToExistingIssueRequiresPeerClaim(t *testing.T) {
+	d, ctx, p, spokeUID := setupFederationIngestHub(t)
+	peer, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: p.ID,
+		Title:     "existing peer",
+		Author:    "hub-agent",
+	})
+	require.NoError(t, err)
+	_, err = d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: p.ID,
+		IssueRef:  peer.ShortID,
+		Principal: db.ClaimPrincipal{HolderInstanceUID: d.InstanceUID(), Holder: "hub-agent"},
+		ClaimKind: "hard",
+		Now:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	issueUID := newTestUID(t)
+	created := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &issueUID, nil,
+		"issue.created", 100,
+		`{"uid":"`+issueUID+`","short_id":"`+shortID(issueUID)+`","title":"created","body":"","author":"spoke","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z","links":[{"type":"related","to_issue_uid":"`+peer.UID+`"}]}`)
+
+	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, created))
+
+	require.NoError(t, err)
+	assertEventCount(t, d, "claim.violated", 1)
+	assertRowCount(ctx, t, d, 1, "created initial link to existing peer materialized",
+		`SELECT COUNT(*) FROM links WHERE project_id = ? AND type = 'related'`,
+		p.ID)
+}
+
+func TestIngestClaimAuditLinksChangedRequiresPeerClaim(t *testing.T) {
+	d, ctx, p, spokeUID, issue, peer := setupIngestClaimIssue(t)
+	_, err := d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: p.ID,
+		IssueRef:  issue.ShortID,
+		Principal: db.ClaimPrincipal{HolderInstanceUID: spokeUID, Holder: "remote-agent"},
+		ClaimKind: "hard",
+		Now:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	ev := remoteClaimWorkEvent(t, p, spokeUID, issue.UID, &peer.UID, "issue.links_changed", "remote-agent")
+
+	_, err = d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, ev))
+
+	require.NoError(t, err)
+	assertEventCount(t, d, "claim.violated", 1)
 }
 
 func TestIngestClaimViolationExpiresTimedClaimBeforeAudit(t *testing.T) {
@@ -2347,6 +3173,61 @@ func shortID(uid string) string {
 	return strings.ToLower(uid[len(uid)-4:])
 }
 
+func eventIDs(events []db.Event) []int64 {
+	out := make([]int64, 0, len(events))
+	for _, event := range events {
+		out = append(out, event.ID)
+	}
+	return out
+}
+
+func renameProjectForAdoptionTest(ctx context.Context, d *db.DB, projectID int64, name string) error {
+	_, err := d.ExecContext(ctx, `UPDATE projects SET name = ? WHERE id = ?`, name, projectID)
+	return err
+}
+
+func insertMalformedAdoptionLink(ctx context.Context, d *db.DB, projectID int64, base, foreign db.Issue) error {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `DROP TRIGGER trg_links_same_project_insert`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DROP TRIGGER trg_links_uid_consistency_insert`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO links(project_id, from_issue_id, to_issue_id, from_issue_uid, to_issue_uid, type, author)
+		VALUES(?, ?, ?, ?, ?, 'related', 'tester')`,
+		projectID, base.ID, foreign.ID, base.UID, foreign.UID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TRIGGER trg_links_same_project_insert
+		BEFORE INSERT ON links
+		FOR EACH ROW BEGIN
+		  SELECT RAISE(ABORT, 'cross-project links are not allowed')
+		  WHERE (SELECT project_id FROM issues WHERE id = NEW.from_issue_id) <> NEW.project_id
+		     OR (SELECT project_id FROM issues WHERE id = NEW.to_issue_id)   <> NEW.project_id;
+		END`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TRIGGER trg_links_uid_consistency_insert
+		BEFORE INSERT ON links
+		FOR EACH ROW BEGIN
+		  SELECT RAISE(ABORT, 'from_issue_uid does not match from_issue_id')
+		  WHERE NEW.from_issue_uid <> (SELECT uid FROM issues WHERE id = NEW.from_issue_id);
+		  SELECT RAISE(ABORT, 'to_issue_uid does not match to_issue_id')
+		  WHERE NEW.to_issue_uid <> (SELECT uid FROM issues WHERE id = NEW.to_issue_id);
+		END`); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func upsertTestHubFederationBinding(ctx context.Context, t *testing.T, d *db.DB, p db.Project, enabled bool) {
 	t.Helper()
 	_, err := d.UpsertFederationBinding(ctx, db.FederationBinding{
@@ -2575,6 +3456,24 @@ func remoteEvent(
 	}
 	ev.ContentHash = remoteEventHash(t, ev)
 	return ev
+}
+
+func remoteEventFromLocalEvent(ev db.Event) db.RemoteEvent {
+	return db.RemoteEvent{
+		EventUID:          ev.UID,
+		OriginInstanceUID: ev.OriginInstanceUID,
+		ProjectUID:        ev.ProjectUID,
+		ProjectName:       ev.ProjectName,
+		IssueUID:          ev.IssueUID,
+		RelatedIssueUID:   ev.RelatedIssueUID,
+		Type:              ev.Type,
+		Actor:             ev.Actor,
+		HLCPhysicalMS:     ev.HLCPhysicalMS,
+		HLCCounter:        ev.HLCCounter,
+		ContentHash:       ev.ContentHash,
+		Payload:           json.RawMessage(ev.Payload),
+		CreatedAt:         ev.CreatedAt,
+	}
 }
 
 func remoteEventHash(t *testing.T, ev db.RemoteEvent) string {

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -1343,6 +1343,105 @@ func TestFederationPushOfflineReconnect(t *testing.T) {
 	assert.Equal(t, "offline second", comments[0])
 }
 
+func TestSyncFederationOncePushesAdoptedIssueSnapshotsAndLinks(t *testing.T) {
+	ctx := context.Background()
+	hub := testenv.New(t)
+	spoke := testenv.New(t)
+
+	hubProject := createFederatedHubForPush(t, hub)
+	created, err := hub.DB.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{ //nolint:gosec // test-only bearer token
+		Token:            "adopt-token",
+		SpokeInstanceUID: spoke.DB.InstanceUID(),
+		ProjectID:        &hubProject.ID,
+		Capabilities:     "pull,push",
+	})
+	require.NoError(t, err)
+	hubBinding, err := hub.DB.FederationBindingByProject(ctx, hubProject.ID)
+	require.NoError(t, err)
+
+	localProject, err := spoke.DB.CreateProject(ctx, "shared-foo")
+	require.NoError(t, err)
+	source, _, err := spoke.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: localProject.ID,
+		Title:     "adopted source",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	target, _, err := spoke.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: localProject.ID,
+		Title:     "adopted target",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	deleted, _, err := spoke.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: localProject.ID,
+		Title:     "adopted deleted",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	deleted, _, _, err = spoke.DB.SoftDeleteIssue(ctx, deleted.ID, "tester")
+	require.NoError(t, err)
+	_, err = spoke.DB.CreateLink(ctx, db.CreateLinkParams{
+		ProjectID:   localProject.ID,
+		FromIssueID: source.ID,
+		ToIssueID:   target.ID,
+		Type:        "related",
+		Author:      "tester",
+	})
+	require.NoError(t, err)
+
+	var replica api.CreateFederationReplicaBody
+	postJSON(t, spoke.URL, "/api/v1/federation/replicas", map[string]any{
+		"hub_url":                 hub.URL,
+		"hub_project_id":          hubProject.ID,
+		"hub_project_uid":         hubProject.UID,
+		"project_name":            localProject.Name,
+		"replay_horizon_event_id": hubBinding.ReplayHorizonEventID,
+		"token":                   created.Token,
+		"capabilities":            "pull,push",
+		"push_enabled":            true,
+		"adopt_existing":          true,
+	}, &replica)
+	require.True(t, replica.Adopted)
+	require.Equal(t, int64(3), replica.AdoptionSnapshotCount)
+
+	binding, err := spoke.DB.FederationBindingByProject(ctx, replica.Project.ID)
+	require.NoError(t, err)
+	err = SyncFederationOnce(ctx, spoke.DB, binding, config.FederationCredential{
+		HubURL:       hub.URL,
+		HubProjectID: hubProject.ID,
+		Token:        created.Token,
+		Capabilities: "pull,push",
+	})
+	require.NoError(t, err)
+
+	pushedSource, err := hub.DB.IssueByUID(ctx, source.UID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	assert.Equal(t, "adopted source", pushedSource.Title)
+	pushedTarget, err := hub.DB.IssueByUID(ctx, target.UID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	assert.Equal(t, "adopted target", pushedTarget.Title)
+	pushedDeleted, err := hub.DB.IssueByUID(ctx, deleted.UID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	assert.Equal(t, "adopted deleted", pushedDeleted.Title)
+	require.NotNil(t, pushedDeleted.DeletedAt)
+	var linkCount int
+	require.NoError(t, hub.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM links
+		 WHERE project_id = ? AND from_issue_uid = ? AND to_issue_uid = ? AND type = 'related'`,
+		hubProject.ID, source.UID, target.UID).Scan(&linkCount))
+	assert.Equal(t, 1, linkCount)
+	var quarantineCount int
+	require.NoError(t, hub.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM federation_quarantine
+		 WHERE project_id = ? AND direction = 'push' AND skipped_at IS NULL`,
+		hubProject.ID).Scan(&quarantineCount))
+	assert.Zero(t, quarantineCount)
+	require.NoError(t, assertHubOriginEventCount(ctx, hub.DB, hubProject.ID, spoke.DB.InstanceUID(), 3))
+}
+
 func TestSyncFederationOncePushesAllPendingBatchesBeforePull(t *testing.T) {
 	ctx := context.Background()
 	spoke := testenv.New(t)

--- a/internal/jsonl/roundtrip_test.go
+++ b/internal/jsonl/roundtrip_test.go
@@ -424,6 +424,7 @@ func TestRoundtrip_FederationBindingCarriesPushState(t *testing.T) {
 	require.NotNil(t, bindingPayload)
 	assert.Equal(t, true, bindingPayload["push_enabled"])
 	assert.Equal(t, float64(5), bindingPayload["push_cursor_event_id"])
+	assert.NotContains(t, bindingPayload, "materialize_after_event_id")
 
 	dstDB := openImportTargetDB(t)
 	require.NoError(t, jsonl.Import(ctx, bytes.NewReader(buf.Bytes()), dstDB))


### PR DESCRIPTION
## Summary
- Add `kata federation join --adopt-existing --push` support for adopting an existing local project into a hub-backed spoke, whether the local project name matches the hub name or not.
- Address federation spec drift by restoring the original local-first write model: ordinary federated edits remain async/LWW, while leases/claims are optional coordination for exclusive work.
- Preserve current issue state during adoption in fresh snapshots, including closed/soft-deleted issues, comments, labels, metadata, owners, priorities, and same-project links.
- Update the technical spec, design docs, operations guide, and CLI reference so users and agents do not treat leases as a prerequisite for editing federated issues.

## Spec Drift Alignment
The original federation spec intended claims/leases to answer "who is actively working this issue?" and to help agents avoid double-work. They were not meant to gate ordinary collaboration or force a hub round-trip before touching a federated issue.

This PR realigns the implementation and docs with that intent:
- No live lease: edit locally; replicas converge through LWW.
- Live lease held by the actor: non-comment work proceeds.
- Live lease held by another actor: conflicting non-comment mutations are denied.
- Comments bypass leases because they are append-only, including comment-only imports.
- Pending or expired leases do not block ordinary edits.
- Hub ingest records `claim.violated` only when work conflicts with another holder's live lease, not for normal unleased work.

## Adoption Behavior
Adoption is a current-state handoff. It does not preserve old local event history. Instead, adoption removes pre-adoption local events and queues fresh snapshots for the hub with same-project links embedded in snapshot payloads.

Adopted issues become ordinary federated spoke issues. Future edits remain local-first; acquire a federation lease only when an agent or operator wants temporary exclusive coordination on an issue.

## Scope Notes
- No schema version bump or federation binding column is introduced by this PR.
- Recurrence membership remains out of scope; adopted occurrences transfer as ordinary issues.
- Leases do not replace durable `owner`, serialize comments, or act as edit permission.

## Concrete Adoption Commands

Same-name adoption, where the hub project and local project are both called `notes`:

```bash
# On the spoke, print the spoke instance UID and give it to the hub operator.
kata federation identity
# => 01JEXAMPLEINSTANCEUID000000

# On the hub, enroll that spoke for hub project `notes`.
# --hub-url is the hub URL the spoke should use later; enroll needs it only
# so it can print the pasteable join command below.
kata federation enroll \
  --project notes \
  --spoke-instance 01JEXAMPLEINSTANCEUID000000 \
  --hub-url http://hub.example.test:7787

# Hub output includes the generated token and hub project id:
# enrolled 01JEXAMPLEINSTANCEUID000000 for notes
# join: kata federation join --project notes --hub-url http://hub.example.test:7787 --hub-project-id 42 --token ktok_example_secret --capabilities pull,push,lease --push

# On the spoke, paste the printed join command and add --adopt-existing.
kata federation join \
  --project notes \
  --hub-url http://hub.example.test:7787 \
  --hub-project-id 42 \
  --token ktok_example_secret \
  --capabilities pull,push,lease \
  --push \
  --adopt-existing
```

Result: the existing local `notes` project is bound to the hub `notes` project. Its current issue state is pushed as the adoption baseline, pre-adoption local events are removed, and future edits remain local-first.

Different-name adoption, where the hub project is `notes` but the existing local project is `shared-notes`:

```bash
# On the spoke, print the spoke instance UID and give it to the hub operator.
kata federation identity
# => 01JEXAMPLEINSTANCEUID000000

# On the hub, enroll that spoke for hub project `notes`.
kata federation enroll \
  --project notes \
  --spoke-instance 01JEXAMPLEINSTANCEUID000000 \
  --hub-url http://hub.example.test:7787

# Hub output includes a join command for hub project `notes`:
# enrolled 01JEXAMPLEINSTANCEUID000000 for notes
# join: kata federation join --project notes --hub-url http://hub.example.test:7787 --hub-project-id 42 --token ktok_example_secret --capabilities pull,push,lease --push

# On the spoke, paste the printed join command, change --project to the
# existing local project name, and add --adopt-existing.
kata federation join \
  --project shared-notes \
  --hub-url http://hub.example.test:7787 \
  --hub-project-id 42 \
  --token ktok_example_secret \
  --capabilities pull,push,lease \
  --push \
  --adopt-existing
```

Result: the existing local `shared-notes` project is bound to the hub `notes` project. The local name can differ from the hub name; the hub identity comes from the enrollment metadata and `--hub-project-id` printed by the hub.

## Test Plan
- `go test ./...`
- `make lint`
