### PR TITLE
Document safe backups and checkpoint WAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,12 @@ auto-started on demand.
 a database from that file. Together they cover backups, machine moves,
 and migrations between schema versions.
 
+Use JSONL exports for backups. Do **not** copy `~/.kata/kata.db` while the
+daemon is running: kata uses SQLite WAL mode, so recent writes can live in
+`kata.db-wal` and a plain `cp kata.db ...` can create a stale snapshot that
+looks successful. The `kata.db.bak.*` files created by schema cutover are
+temporary rollback files, not scheduled backups.
+
 Back up the local database:
 
 ```sh
@@ -654,9 +660,12 @@ kata daemon start
 
 Without `--output`, `kata export` writes a timestamped file
 (`kata-export-YYYYMMDDTHHMMSSZ.jsonl`) in the current directory. Export
-refuses to run while a daemon holds the database open; pass
-`--allow-running-daemon` to take a best-effort snapshot on a host where
-you cannot stop the daemon.
+refuses to run while a local daemon holds the database open; pass
+`--allow-running-daemon` when you need an online backup on the same host:
+
+```sh
+kata export --allow-running-daemon --output backups/kata-$(date -u +%Y%m%d).jsonl
+```
 
 Restore into a fresh database file:
 

--- a/cmd/kata/export.go
+++ b/cmd/kata/export.go
@@ -40,7 +40,7 @@ func newExportCmd() *cobra.Command {
 			if output == "" {
 				output = "kata-export-" + time.Now().UTC().Format("20060102T150405Z") + ".jsonl"
 			}
-			d, err := db.Open(ctx, dbPath)
+			d, err := db.OpenReadOnly(ctx, dbPath)
 			if err != nil {
 				return err
 			}
@@ -112,9 +112,9 @@ func writeExportOutput(ctx context.Context, d *db.DB, output string, opts jsonl.
 
 // resolveExportProject reconciles the global --project NAME flag with the
 // local --project-id N flag. NAME is looked up against the projects table
-// since export reads the database directly (the daemon must be stopped).
-// Conflicts and unknown names surface as validation errors so scripts get
-// a clean failure rather than a silent full-DB export.
+// using the read-only export handle. Conflicts and unknown names surface as
+// validation errors so scripts get a clean failure rather than a silent
+// full-DB export.
 func resolveExportProject(ctx context.Context, d *db.DB, projectID int64) (int64, error) {
 	name := strings.TrimSpace(flags.Project)
 	if name == "" {

--- a/cmd/kata/export_test.go
+++ b/cmd/kata/export_test.go
@@ -39,6 +39,33 @@ func TestExportWritesJSONLToOutput(t *testing.T) {
 	assert.Contains(t, out, outPath)
 }
 
+func TestExportReadsDatabaseWithoutWritePermission(t *testing.T) {
+	home := setupKataEnv(t)
+	dbPath := filepath.Join(home, "kata.db")
+	d, err := db.Open(context.Background(), dbPath)
+	require.NoError(t, err)
+	p, err := d.CreateProject(context.Background(), "kata")
+	require.NoError(t, err)
+	_, _, err = d.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: p.ID,
+		Title:     "read-only export",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	require.NoError(t, os.Chmod(dbPath, 0o400))
+	t.Cleanup(func() { _ = os.Chmod(dbPath, 0o600) })
+
+	outPath := filepath.Join(home, "readonly.jsonl")
+	_, err = runCmdOutput(t, nil, "export", "--output", outPath)
+	require.NoError(t, err)
+
+	bs, err := os.ReadFile(outPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(bs), "read-only export")
+}
+
 func TestExportDoesNotReplaceExistingOutputOnFailure(t *testing.T) {
 	home := setupKataEnv(t)
 	dbPath := filepath.Join(home, "kata.db")

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	_ "modernc.org/sqlite" // pure-Go SQLite driver registered as "sqlite"
 
@@ -34,6 +35,7 @@ type DB struct {
 	*sql.DB
 	path        string
 	instanceUID string
+	readOnly    bool
 }
 
 // Open opens (and if needed initializes) the kata SQLite database at path.
@@ -150,7 +152,42 @@ func OpenReadOnly(ctx context.Context, path string) (*DB, error) {
 		_ = sdb.Close()
 		return nil, fmt.Errorf("ping read-only %s: %w", path, err)
 	}
-	return &DB{DB: sdb, path: path}, nil
+	return &DB{DB: sdb, path: path, readOnly: true}, nil
+}
+
+// Checkpoint runs a truncating WAL checkpoint for writable databases. It is
+// used by graceful shutdown paths so the durable main database file is brought
+// up to date before the process exits.
+func (d *DB) Checkpoint(ctx context.Context) error {
+	if d.readOnly {
+		return nil
+	}
+	var busy, logFrames, checkpointedFrames int
+	if err := d.QueryRowContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`).
+		Scan(&busy, &logFrames, &checkpointedFrames); err != nil {
+		return fmt.Errorf("checkpoint WAL: %w", err)
+	}
+	if busy != 0 {
+		return fmt.Errorf("checkpoint WAL: busy=%d log=%d checkpointed=%d",
+			busy, logFrames, checkpointedFrames)
+	}
+	return nil
+}
+
+// Close checkpoints writable WAL databases before closing the connection pool.
+// Read-only handles skip the checkpoint because SQLite rejects WAL checkpoints
+// on read-only connections.
+func (d *DB) Close() error {
+	if d == nil || d.DB == nil {
+		return nil
+	}
+	var checkpointErr error
+	if !d.readOnly {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		checkpointErr = d.Checkpoint(ctx)
+		cancel()
+	}
+	return errors.Join(checkpointErr, d.DB.Close())
 }
 
 // Path returns the resolved database path.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -138,4 +139,40 @@ func TestOpen_TimestampColumnsScanIntoTime(t *testing.T) {
 	// modernc.org/sqlite returns time.Time for DATETIME columns
 	_, ok := ts.(interface{ Year() int })
 	assert.True(t, ok, "expected time.Time, got %T", ts)
+}
+
+func TestCheckpointTruncatesWAL(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "kata.db")
+	d, err := db.Open(ctx, path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+	d.SetMaxOpenConns(1)
+
+	_, err = d.ExecContext(ctx, `PRAGMA wal_autocheckpoint=0`)
+	require.NoError(t, err)
+	_, err = d.ExecContext(ctx, `CREATE TABLE checkpoint_noise(id INTEGER PRIMARY KEY, body BLOB)`)
+	require.NoError(t, err)
+	_, err = d.ExecContext(ctx, `
+		WITH RECURSIVE seq(x) AS (
+			SELECT 1
+			UNION ALL
+			SELECT x + 1 FROM seq WHERE x < 128
+		)
+		INSERT INTO checkpoint_noise(body)
+		SELECT randomblob(4096) FROM seq`)
+	require.NoError(t, err)
+
+	before, err := os.Stat(path + "-wal")
+	require.NoError(t, err)
+	require.Positive(t, before.Size(), "test setup must create WAL frames")
+
+	require.NoError(t, d.Checkpoint(ctx))
+
+	after, err := os.Stat(path + "-wal")
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	require.NoError(t, err)
+	assert.Zero(t, after.Size(), "TRUNCATE checkpoint should leave no WAL bytes")
 }


### PR DESCRIPTION
## Summary
- document that JSONL export is the supported backup path and live `cp kata.db` can miss WAL contents
- make `kata export` use a read-only database handle so backups do not perform startup writes
- checkpoint and truncate writable WAL files on `db.Close` for graceful daemon shutdown

Fixes #68

## Test Plan
- `go test ./... -count=1`
- `git diff --check`
- pre-push hook: `make lint`
- pre-push hook: `nilaway`