### PR TITLE
fix(daemon): detach auto-started daemon from caller console/stdio on Windows

### DIFF
--- a/internal/daemonclient/detach_windows.go
+++ b/internal/daemonclient/detach_windows.go
@@ -2,9 +2,37 @@
 
 package daemonclient
 
-import "os/exec"
+import (
+	"os/exec"
+	"syscall"
+)
 
-// detachChild is a no-op on Windows; the kata daemon does not officially
-// support Windows in Plan 1 (Unix sockets only), but the build must still
-// compile for go test ./... on Windows CI.
-func detachChild(_ *exec.Cmd) {}
+// DETACHED_PROCESS is not exported by the syscall package; its value is
+// fixed in winbase.h. A process created with this flag has no console.
+const detachedProcess = 0x00000008
+
+// detachChild fully decouples the auto-started daemon from the launching
+// shell's console.
+//
+// On Windows a child created without special flags shares its parent's
+// console. When that console is later torn down — the foreground `kata`
+// process that auto-started the daemon exits — the long-lived daemon is left
+// holding a handle to a destroyed console. Any console subprocess it then
+// spawns fails at process startup: Git for Windows in particular is built on
+// the msys2 runtime, which requires a usable console to initialize, so it
+// aborts with STATUS_DLL_INIT_FAILED (reported by Go as "exit status
+// 0xc0000142"). The daemon resolves project identity by running `git remote`,
+// so every command that reaches the daemon then fails.
+//
+// DETACHED_PROCESS gives the daemon no console at all, so it never depends on
+// the launcher's console lifetime. When the daemon later spawns git, Windows
+// allocates a fresh console for that child and git initializes normally. This
+// mirrors the Unix detachChild, which uses Setpgid to isolate the daemon from
+// the foreground process group. CREATE_NEW_PROCESS_GROUP additionally ensures
+// a Ctrl+C / Ctrl+Break aimed at the caller is never delivered to the daemon.
+func detachChild(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= detachedProcess | syscall.CREATE_NEW_PROCESS_GROUP
+}

--- a/internal/daemonclient/detach_windows_test.go
+++ b/internal/daemonclient/detach_windows_test.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package daemonclient
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+// TestDetachChildDetachesFromConsole pins the fix for the daemon's
+// "git remote: exit status 0xc0000142" failure: the auto-started daemon must
+// be created with DETACHED_PROCESS so it never inherits (and later outlives)
+// the launching shell's console. Without DETACHED_PROCESS the daemon shares,
+// then is orphaned from, a destroyed console and can no longer spawn git.
+func TestDetachChildDetachesFromConsole(t *testing.T) {
+	cmd := exec.Command("kata", "daemon", "start")
+	detachChild(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("detachChild left SysProcAttr nil")
+	}
+	flags := cmd.SysProcAttr.CreationFlags
+	if flags&detachedProcess == 0 {
+		t.Errorf("DETACHED_PROCESS not set: CreationFlags = %#x", flags)
+	}
+	if flags&syscall.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Errorf("CREATE_NEW_PROCESS_GROUP not set: CreationFlags = %#x", flags)
+	}
+}
+
+// TestDetachChildPreservesExistingFlags ensures detachChild ORs its flags in
+// rather than clobbering any the caller already set.
+func TestDetachChildPreservesExistingFlags(t *testing.T) {
+	const sentinel = syscall.CREATE_UNICODE_ENVIRONMENT
+	cmd := exec.Command("kata")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: sentinel}
+	detachChild(cmd)
+
+	if cmd.SysProcAttr.CreationFlags&sentinel == 0 {
+		t.Errorf("detachChild dropped pre-existing flag: %#x", cmd.SysProcAttr.CreationFlags)
+	}
+}

--- a/internal/daemonclient/ensure.go
+++ b/internal/daemonclient/ensure.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"github.com/wesm/kata/internal/daemon"
@@ -44,11 +45,22 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 	}
 	//nolint:gosec // G204: exe is os.Executable()
 	cmd := exec.Command(exe, "daemon", "start")
-	cmd.Stdout = nil
-	cmd.Stderr = os.Stderr
-	// Detach the child into its own process group so SIGINT delivered to the
-	// foreground caller (e.g. ctrl-C on `kata create` or `kata tui`) is not
-	// propagated to the daemon we just spawned.
+	// The auto-started daemon outlives this process, so it must not inherit
+	// our stdio. Inheriting the caller's stderr keeps that handle open after
+	// the daemon detaches, which hangs any parent that captures our output
+	// (command substitution, CI, pipelines). Send the daemon's stdout/stderr
+	// to a daemon.log file under the data dir; if that can't be opened, leave
+	// them nil so exec connects the child to the null device. Either way we
+	// never hand the daemon the caller's stderr.
+	if logw := daemonLogWriter(dataDir); logw != nil {
+		cmd.Stdout = logw
+		cmd.Stderr = logw
+		defer func() { _ = logw.Close() }() // child keeps its own handle after Start
+	}
+	// Detach the child into its own process group (and, on Windows, off the
+	// caller's console) so SIGINT delivered to the foreground caller (e.g.
+	// ctrl-C on `kata create` or `kata tui`) is not propagated to the daemon,
+	// and the daemon never depends on the caller's console lifetime.
 	detachChild(cmd)
 	if err := cmd.Start(); err != nil {
 		return "", fmt.Errorf("auto-start daemon: %w", err)
@@ -66,4 +78,19 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 		}
 	}
 	return "", errors.New("daemon failed to start within 5s")
+}
+
+// daemonLogWriter opens <dataDir>/daemon.log for the auto-started daemon's
+// stdout+stderr. Returns nil (so exec falls back to the null device) if the
+// directory or file cannot be created — the caller must never substitute its
+// own stderr, which a detached daemon would hold open and hang the caller.
+func daemonLogWriter(dataDir string) *os.File {
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		return nil
+	}
+	f, err := os.OpenFile(filepath.Join(dataDir, "daemon.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil
+	}
+	return f
 }


### PR DESCRIPTION
Fixes #73.

## Problem

On Windows, once a kata daemon has outlived the shell that launched it, every command that reaches the daemon fails with:

```
kata: git remote: exit status 0xc0000142
```

`git remote` runs **inside the daemon** (`handlers_projects.go` → `ComputeAliasIdentity` → `readGitRemote`). `0xc0000142` is `STATUS_DLL_INIT_FAILED` — git failing to initialize as a process.

The auto-started daemon (`daemonclient.autoStart`) is created **sharing the launching shell's console**, because `detachChild` is a no-op on Windows. When that shell exits and its console is destroyed, the long-lived daemon holds a dead console handle. Git for Windows' msys2 runtime needs a usable console to initialize, so it aborts at startup.

## Fix

1. **`detach_windows.go`** — create the daemon with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` (the Windows analogue of the Unix `Setpgid`). With no inherited console the daemon never depends on the caller's console lifetime, and Windows allocates a fresh console for each `git` child so it initializes normally.

2. **`ensure.go`** — route the auto-started daemon's stdout/stderr to a `daemon.log` file under the data dir instead of inheriting the caller's stderr. Once the daemon correctly *survives* its launcher (point 1), a retained stderr pipe would hang any parent that captures output (command substitution, CI, pipelines); this avoids that and persists the daemon's log. Falls back to the null device if the log can't be opened — it never hands the daemon the caller's stderr.

Unix behavior is unchanged (`detach_windows.go` is Windows-only; on Unix the daemon already detaches via `Setpgid`, and it now logs to `daemon.log` instead of the caller's terminal on auto-start).

## Testing

- `go build ./...`, `go vet ./...`, `go test ./internal/daemonclient/` all pass.
- New Windows-only regression test (`detach_windows_test.go`) pins that `detachChild` sets `DETACHED_PROCESS` and preserves pre-existing creation flags.
- Manual, on Windows 11 with Git for Windows 2.53:
  - Reproduced the original failure against a 3-day-old daemon.
  - With the fix: a fresh `kata list` cold-starts the daemon and returns cleanly (no hang); a `kata list` from a *separate* shell — after the launching console is gone — still resolves `git remote` successfully (no `0xc0000142`); `daemon.log` is created in the data dir.
