### PR TITLE
Tighten close issue throttle window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Instead:
 
 Close each issue as soon as its work is verified, not at the end of a
 batch. The daemon throttles >3 sibling closes by one actor under one
-parent in 5 minutes; close eagerly and you will not see it. Operators
+parent in 60 seconds; close eagerly and you will not see it. Operators
 can disable the throttle via `[close.throttle] enabled = false` in
 `<KATA_HOME>/config.toml`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Never Squash or Amend: Do not squash commits, amend commits, or otherwise rewrite git history unless the user explicitly asks for that history rewrite.
 - Do not commit rejected experiments. Revert them or ask before preserving them.
 - Test First: Write a failing test before the implementation, then make it pass, then refactor (red, green, refactor). Don't add production code without a failing test that requires it.
+- No Testing Plan in PRs: Do not include a testing plan or test plan section in pull request descriptions.
 
 ## Project management
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ The [docs site](docs/) is the definitive reference:
 Run `kata quickstart` (alias `kata agent-instructions`) for the operating
 contract: search before creating, pass an idempotency key on create, prefer
 `--agent` output, claim work with `kata claim`, and close only when the work is
-verified. [Agent workflows](docs/workflows/agents.md) is the same contract
-in long form.
+verified. Close each verified issue promptly; batching sibling closes can trip
+the 60-second close throttle. [Agent workflows](docs/workflows/agents.md) is
+the same contract in long form.
 
 ## Contributing
 

--- a/cmd/kata/close.go
+++ b/cmd/kata/close.go
@@ -37,9 +37,9 @@ substantive message.
 
 Close each issue as soon as its work is verified, not in a batch at
 the end. The daemon throttles >3 sibling closes by one actor under
-one parent in 5 minutes (operators can disable this via
+one parent in 60 seconds (operators can disable this via
 [close.throttle] enabled = false in <KATA_HOME>/config.toml), so a
-bulk "close everything now" pass will trip the guard.
+bulk "close everything now" pass can trip the guard.
 
 If you have not completed and tested this work, do not close it.
 Instead, label and comment:

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -30,11 +30,11 @@ Use kata as the shared issue ledger for this workspace.
         --message "Fixed Safari callback double-submit; verified tests pass." \
         --commit <sha>
 
-   Close each issue as soon as its work is verified, not in a single
-   "close everything" pass at the end. The daemon throttles >3 sibling
-   closes by one actor under one parent in 5 minutes; close eagerly
-   and you will not see the throttle. Operators can disable it via
-   [close.throttle] enabled = false in <KATA_HOME>/config.toml.
+   Close each issue as soon as its work is verified, not in a batch or a
+   single "close everything" pass at the end. The daemon throttles >3 sibling
+   closes by one actor under one parent in 60 seconds; close eagerly as each
+   issue is verified and you will not see the throttle. Operators can disable
+   it via [close.throttle] enabled = false in <KATA_HOME>/config.toml.
 
    Other close forms:
 
@@ -156,6 +156,7 @@ Default to --agent for ordinary kata reads and mutations in agent logs.
 Use --json only when your script needs complete structured data.
 If work is incomplete, label needs-review and comment with what remains.
 Close only verified work with substantive prose and typed evidence.
+Close each verified issue promptly; batching sibling closes can trigger the 60-second throttle.
 Do not run delete or purge unless explicitly asked for that exact action and issue ref.
 Poll kata events with a saved cursor; reset cached state on reset_required.
 `

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -31,6 +31,8 @@ func TestQuickstart_PromotesCloseStep(t *testing.T) {
 	assert.Contains(t, out, "asserts that the work is complete")
 	assert.Contains(t, out, "--evidence")
 	assert.Contains(t, out, "needs-review")
+	assert.Contains(t, out, "60 seconds")
+	assert.Contains(t, out, "not in a batch")
 }
 
 func TestQuickstart_JSON(t *testing.T) {
@@ -56,6 +58,7 @@ func TestQuickstart_AgentOutput(t *testing.T) {
 	assert.NotContains(t, out, "Remote daemon")
 	assert.Contains(t, out, "Default to --agent for ordinary kata reads and mutations in agent logs.")
 	assert.Contains(t, out, "Use --json only when your script needs complete structured data.")
+	assert.Contains(t, out, "Close each verified issue promptly; batching sibling closes can trigger the 60-second throttle.")
 }
 
 func TestQuickstart_AgentInstructionsAliasMentionsAgentOutput(t *testing.T) {

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -155,3 +155,7 @@ kata close abc4 --done \
 
 Other close reasons are `--wontfix`, `--duplicate-of <ref>`,
 `--superseded-by <ref>`, and `--audit-no-change`.
+
+Close issues as soon as each one is complete and verified. Do not save a batch
+of sibling closes for the end of a run: the daemon refuses more than three
+sibling closes by one actor under one parent within 60 seconds.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -92,13 +92,14 @@ kata refuses structurally dangerous close patterns. The parent-completeness
 guard always refuses closing an issue while it has open children. Two further
 guards throttle close bursts by one actor under a shared parent:
 
-- sibling-burst: closing more than three sibling issues within five minutes is
+- sibling-burst: closing more than three sibling issues within 60 seconds is
   refused;
 - repeated-message: closing a second sibling with an identical `done` or
   `audit-no-change` message within thirty minutes is refused.
 
-Closing each issue as soon as its work is verified, rather than batching closes
-at the end of a run, keeps an actor under both limits.
+Close each issue as soon as its work is verified. Batching closes at the end of
+a run is the pattern this guard is meant to catch, and it can push one actor
+over the sibling-burst limit even when each individual issue is legitimate.
 
 Operators can disable both throttles daemon-wide:
 

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -106,9 +106,10 @@ kata close abc4 --done \
 ```
 
 Close each issue as soon as its work is verified, not in a batch at the end of a
-run. The daemon refuses more than three sibling closes under one parent within
-five minutes, so end-of-run close bursts get throttled; closing as you finish
-each issue keeps you under the limit. See
+run. The daemon refuses more than three sibling closes by one actor under one
+parent within 60 seconds, so end-of-run close bursts can get throttled even when
+the underlying work is complete. Closing as you finish each issue keeps you
+under the limit and leaves a better audit trail. See
 [Close throttle](../reference/configuration.md#close-throttle).
 
 If work is incomplete:

--- a/internal/daemon/close_guards.go
+++ b/internal/daemon/close_guards.go
@@ -18,9 +18,9 @@ const openChildrenSampleLimit = 10
 // the same actor under the same parent are counted. siblingThrottleLimit is
 // the threshold: at the Nth close (N == limit) the actor has already closed
 // (limit) prior siblings, and the next close is refused. Spec §3.9 fixes both
-// values at "3 closes in 5 minutes" for v1; neither is configurable.
+// values at "3 closes in 60 seconds" for v1; neither is configurable.
 const (
-	siblingThrottleWindow = 5 * time.Minute
+	siblingThrottleWindow = 60 * time.Second
 	siblingThrottleLimit  = 3
 )
 

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -270,6 +271,52 @@ func TestSiblingThrottle_FourthCloseUnderSameParentRefused(t *testing.T) {
 	assert.Contains(t, body, "sibling-close throttle")
 	// The error should reference the parent issue short_id.
 	assert.Contains(t, body, refForIssue(t, env, parent))
+}
+
+func TestSiblingThrottle_AllowsFourthCloseWhenOldestSiblingIsOutsideDefaultWindow(t *testing.T) {
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	parent := createIssueViaHTTP(t, env, pid, "parent issue")
+	children := make([]int64, 0, 4)
+	for i := 0; i < 4; i++ {
+		c := createIssueViaHTTP(t, env, pid, fmt.Sprintf("child %d", i+1))
+		postLink(t, env, pid, c, "parent", parent)
+		children = append(children, c)
+	}
+
+	resp, bs := closeIssueWithEvidence(t, env, pid, children[0], "agent-a",
+		"done",
+		"Implementation of child 1 complete and tested.",
+		[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+	require.Equalf(t, http.StatusOK, resp.StatusCode,
+		"close child 1: %s", string(bs))
+
+	oldestOutsideWindow := time.Now().Add(-2 * time.Minute).UTC().Format("2006-01-02T15:04:05.000Z")
+	_, err := env.DB.ExecContext(t.Context(), `
+		UPDATE events
+		   SET created_at = ?
+		 WHERE project_id = ?
+		   AND issue_id = ?
+		   AND type = 'issue.closed'`,
+		oldestOutsideWindow, pid, children[0])
+	require.NoError(t, err)
+
+	for i, c := range children[1:3] {
+		resp, bs := closeIssueWithEvidence(t, env, pid, c, "agent-a",
+			"done",
+			fmt.Sprintf("Implementation of child %d complete and tested.", i+2),
+			[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+		require.Equalf(t, http.StatusOK, resp.StatusCode,
+			"close child %d: %s", i+2, string(bs))
+	}
+
+	resp, bs = closeIssueWithEvidence(t, env, pid, children[3], "agent-a",
+		"done",
+		"Implementation of child 4 complete and tested.",
+		[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+	require.Equalf(t, http.StatusOK, resp.StatusCode,
+		"oldest sibling close should be outside the default throttle window: %s",
+		string(bs))
 }
 
 // TestSiblingThrottle_DisabledByConfig pins that operators who opt out


### PR DESCRIPTION
## Summary
- Tighten the default sibling close throttle window from 5 minutes to 60 seconds.
- Add regression coverage for the shorter throttle window and quickstart guidance.
- Update agent-facing docs and help text to recommend closing verified issues promptly, plus document that PR descriptions should omit testing-plan sections.