### PR TITLE
Restore allow_insecure daemon hostnames

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -36,6 +36,28 @@ Not findings: missing API auth, `validateActor` "not authorizing"
 loops on local input, symlink-following under the kata data dir, races
 visible only to a colocated attacker.
 
+## Tailscale/private-overlay hostnames
+
+Kata intentionally supports private-network daemon access over operator-
+trusted plaintext. A configured `allow_insecure = true` daemon target, or
+`KATA_ALLOW_INSECURE=1` for `KATA_SERVER`, means the operator explicitly
+accepted HTTP for a trusted private overlay such as Tailscale. Do not raise a
+Medium/High finding merely because a token-bearing `http://hostname:port`
+request uses DNS or plaintext; Tailscale, MagicDNS, mDNS, and similar
+private-overlay hostnames are expected deployment shapes, not evidence of a
+public-network leak.
+
+Do not recommend DNS-resolution preflights that reject hostnames unless the
+diff is explicitly changing a literal-IP-only mode. Overlay hostnames can be
+the stable operator-facing identity while their addresses change underneath.
+
+Valid findings remain: bearer tokens sent to a different origin than the
+configured daemon, redirects that can receive tokens cross-origin, plaintext
+hostname access without an explicit `allow_insecure` opt-in, secrets logged or
+rendered in errors, a config/default that exposes bearer HTTP publicly by
+default, or a code path that claims to support `allow_insecure` but silently
+ignores it.
+
 ## Schema upgrades use JSONL cutover, not ALTER-TABLE migrations
 
 Schema lives in the embedded `internal/db/schema.sql`. There is no

--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -136,7 +136,10 @@ func discoverDaemon(ctx context.Context) (string, error) {
 // CLI command site is already named for it.
 func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 	return client.NewHTTPClient(ctx, baseURL,
-		client.Opts{Timeout: envHTTPTimeout(defaultHTTPTimeout)})
+		client.Opts{
+			Timeout:       envHTTPTimeout(defaultHTTPTimeout),
+			AllowInsecure: client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStartForRemote()),
+		})
 }
 
 // streamingClientFor builds the SSE-friendly variant: no overall
@@ -146,6 +149,7 @@ func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 func streamingClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 	return client.NewHTTPClient(ctx, baseURL, client.Opts{
 		ResponseHeaderTimeout: client.SSEHandshakeTimeout,
+		AllowInsecure:         client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStartForRemote()),
 	})
 }
 

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -54,9 +54,10 @@ func checkBearerTargetSafe(baseURL string, trustPrivateNetwork bool) (string, er
 	return config.BearerOriginForBaseURLWithTrust(baseURL, trustPrivateNetwork)
 }
 
-func explicitBearerTransport(
+func authBearerTransport(
 	base http.RoundTripper,
 	token, baseURL string,
+	trustPrivateNetwork bool,
 	allowInsecure bool,
 ) (http.RoundTripper, error) {
 	if token == "" {
@@ -70,9 +71,17 @@ func explicitBearerTransport(
 		return config.BearerTransportWithPolicy(base, token, origin,
 			config.BearerPolicy{AllowInsecurePlaintext: true}), nil
 	}
-	origin, err := checkBearerTargetSafe(baseURL, allowInsecure)
+	origin, err := checkBearerTargetSafe(baseURL, trustPrivateNetwork)
 	if err != nil {
 		return nil, err
 	}
-	return withBearer(base, token, origin, allowInsecure), nil
+	return withBearer(base, token, origin, trustPrivateNetwork), nil
+}
+
+func explicitBearerTransport(
+	base http.RoundTripper,
+	token, baseURL string,
+	allowInsecure bool,
+) (http.RoundTripper, error) {
+	return authBearerTransport(base, token, baseURL, false, allowInsecure)
 }

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -62,6 +62,14 @@ func explicitBearerTransport(
 	if token == "" {
 		return base, nil
 	}
+	if allowInsecure {
+		origin, err := config.BearerOriginForBaseURLAllowInsecure(baseURL)
+		if err != nil {
+			return nil, err
+		}
+		return config.BearerTransportWithPolicy(base, token, origin,
+			config.BearerPolicy{AllowInsecurePlaintext: true}), nil
+	}
 	origin, err := checkBearerTargetSafe(baseURL, allowInsecure)
 	if err != nil {
 		return nil, err

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -223,12 +223,12 @@ func TestNewHTTPClientForTargetAllowsBearerForPrivateIPWhenAllowInsecureSet(t *t
 	assert.NotNil(t, c)
 }
 
-func TestNewHTTPClientForTargetRefusesPlaintextHostnameWithAllowInsecure(t *testing.T) {
-	_, err := NewHTTPClientForTarget(context.Background(), "http://daemon.internal:7373",
+func TestNewHTTPClientForTargetAllowsTailscaleHostnameWithAllowInsecure(t *testing.T) {
+	c, err := NewHTTPClientForTarget(context.Background(), "http://tailscale-host:7777",
 		TargetAuth{Token: "target-token", AllowInsecure: true}, Opts{})
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "literal IP")
+	require.NoError(t, err)
+	assert.NotNil(t, c)
 }
 
 func TestNewHTTPClientForTargetRefusesPlaintextHostnameWithoutAllowInsecure(t *testing.T) {

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -352,6 +352,39 @@ func TestNewHTTPClient_TrustPrivateNetworkRejectsPlaintextHostname(t *testing.T)
 	assert.Contains(t, err.Error(), "literal IP")
 }
 
+func TestNewHTTPClient_EnvRemoteAllowInsecureAllowsBearerOnPlaintextHostname(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_AUTH_TOKEN", "secret")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_SERVER", "http://tailscale-host:7777")
+	t.Setenv("KATA_ALLOW_INSECURE", "1")
+
+	_, err := NewHTTPClient(context.Background(), "http://tailscale-host:7777", Opts{})
+	require.NoError(t, err)
+}
+
+func TestNewHTTPClient_FileRemoteAllowInsecureAllowsBearerOnPlaintextHostname(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_AUTH_TOKEN", "secret")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+	t.Setenv("KATA_SERVER", "")
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeWorkspaceMarker(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "http://tailscale-host:7777"
+allow_insecure = true
+`), 0o600))
+
+	_, err := NewHTTPClient(context.Background(), "http://tailscale-host:7777", Opts{})
+	require.NoError(t, err)
+}
+
 // TestNewHTTPClient_AllowsBearerOnLoopback covers the safe-target arm of
 // checkBearerTargetSafe: 127.0.0.1 and [::1] keep the token in-host even
 // over plaintext HTTP.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -130,6 +130,7 @@ const SSEHandshakeTimeout = 10 * time.Second
 type Opts struct {
 	Timeout               time.Duration
 	ResponseHeaderTimeout time.Duration
+	AllowInsecure         bool
 }
 
 // TargetAuth is explicit per-target bearer configuration. It is used by
@@ -191,13 +192,12 @@ func newHTTPClientWithAuth(ctx context.Context, baseURL string, auth config.Auth
 	if err != nil {
 		return nil, err
 	}
-	var origin string
-	if auth.Token != "" {
-		if origin, err = checkBearerTargetSafe(baseURL, auth.TrustPrivateNetwork); err != nil {
-			return nil, err
-		}
+	allowInsecure := opts.AllowInsecure || remoteAllowInsecureForBaseURL(baseURL, "")
+	rt, err := authBearerTransport(c.Transport, auth.Token, baseURL, auth.TrustPrivateNetwork, allowInsecure)
+	if err != nil {
+		return nil, err
 	}
-	c.Transport = withBearer(c.Transport, auth.Token, origin, auth.TrustPrivateNetwork)
+	c.Transport = rt
 	return c, nil
 }
 

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -47,6 +47,12 @@ func NormalizeRemoteURL(v string, allowInsecure bool) (string, error) {
 	return normalizeRemoteURL(v, allowInsecure)
 }
 
+// RemoteAllowInsecureForBaseURL reports whether the configured remote source
+// for workspaceStart explicitly opted baseURL into plaintext HTTP.
+func RemoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
+	return remoteAllowInsecureForBaseURL(baseURL, workspaceStart)
+}
+
 // resolveRemote checks the two opt-in remote sources, in order:
 //
 //  1. KATA_SERVER env (highest precedence)
@@ -104,6 +110,24 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 func envAllowInsecure() bool {
 	v := strings.TrimSpace(os.Getenv(allowInsecureEnvVar))
 	return v == "1" || strings.EqualFold(v, "true")
+}
+
+func remoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
+	if v := os.Getenv(remoteServerEnvVar); v != "" {
+		allow := envAllowInsecure()
+		u, err := normalizeRemoteURL(v, allow)
+		return err == nil && u == baseURL && allow
+	}
+	root, _, ok := findLocalConfig(workspaceStart)
+	if !ok {
+		return false
+	}
+	cfg, err := config.ReadLocalConfig(root)
+	if err != nil || cfg.Server.URL == "" || !cfg.Server.AllowInsecure {
+		return false
+	}
+	u, err := normalizeRemoteURL(cfg.Server.URL, true)
+	return err == nil && u == baseURL
 }
 
 // findLocalConfig walks upward from start looking for .kata.local.toml,

--- a/internal/config/bearer.go
+++ b/internal/config/bearer.go
@@ -49,13 +49,29 @@ func BearerTransport(base http.RoundTripper, token, origin string) http.RoundTri
 // BearerTransportWithTrust wraps base with bearer-token injection when token is
 // non-empty, allowing plaintext private-IP targets only when trust is explicit.
 func BearerTransportWithTrust(base http.RoundTripper, token, origin string, trustPrivateNetwork bool) http.RoundTripper {
+	return BearerTransportWithPolicy(base, token, origin, BearerPolicy{TrustPrivateNetwork: trustPrivateNetwork})
+}
+
+// BearerPolicy controls bearer-token target validation.
+type BearerPolicy struct {
+	// TrustPrivateNetwork allows plaintext HTTP only for literal non-public
+	// IPs. It is intended for daemon-wide private-network opt-in.
+	TrustPrivateNetwork bool
+	// AllowInsecurePlaintext skips the plaintext target safety check. Origin
+	// pinning still applies, so cross-origin redirects cannot receive tokens.
+	AllowInsecurePlaintext bool
+}
+
+// BearerTransportWithPolicy wraps base with bearer-token injection when token
+// is non-empty, applying the supplied target-validation policy.
+func BearerTransportWithPolicy(base http.RoundTripper, token, origin string, policy BearerPolicy) http.RoundTripper {
 	if token == "" {
 		return base
 	}
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	return &bearerTransport{base: base, token: token, origin: origin, trustPrivateNetwork: trustPrivateNetwork}
+	return &bearerTransport{base: base, token: token, origin: origin, policy: policy}
 }
 
 // BearerOriginForBaseURL validates baseURL as a safe bearer target and returns
@@ -77,19 +93,42 @@ func BearerOriginForBaseURLWithTrust(baseURL string, trustPrivateNetwork bool) (
 	return u.Scheme + "://" + u.Host, nil
 }
 
+// BearerOriginForBaseURLAllowInsecure validates only the URL shape and returns
+// the scheme://host origin used for redirect pinning. It is for explicit
+// per-target allow_insecure configuration where the operator has opted out of
+// plaintext target safety checks.
+func BearerOriginForBaseURLAllowInsecure(baseURL string) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse base URL %q for bearer-token safety check: %w", baseURL, err)
+	}
+	if u.Host == "kata.invalid" {
+		return u.Scheme + "://" + u.Host, nil
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("unsupported URL scheme %q for bearer-token client", u.Scheme)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("bearer-token target %q must include host", u.Redacted())
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
 type bearerTransport struct {
-	base                http.RoundTripper
-	token               string
-	origin              string
-	trustPrivateNetwork bool
+	base   http.RoundTripper
+	token  string
+	origin string
+	policy BearerPolicy
 }
 
 func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.token == "" || req.Header.Get("Authorization") != "" {
 		return t.base.RoundTrip(req)
 	}
-	if err := CheckBearerTargetSafeURLWithTrust(req.URL, t.trustPrivateNetwork); err != nil {
-		return nil, err
+	if !t.policy.AllowInsecurePlaintext {
+		if err := CheckBearerTargetSafeURLWithTrust(req.URL, t.policy.TrustPrivateNetwork); err != nil {
+			return nil, err
+		}
 	}
 	if reqOrigin := req.URL.Scheme + "://" + req.URL.Host; reqOrigin != t.origin {
 		return nil, fmt.Errorf("refusing to attach bearer token to %q - "+

--- a/internal/tui/daemon_target.go
+++ b/internal/tui/daemon_target.go
@@ -54,12 +54,16 @@ var (
 		target daemonTarget,
 		kind clientOptsKind,
 	) (*http.Client, error) {
+		opts := optsForKind(kind)
 		if (target.Local || target.Implicit) && target.Token == "" {
-			return client.NewHTTPClient(ctx, endpoint, optsForKind(kind))
+			if target.Implicit {
+				opts.AllowInsecure = client.RemoteAllowInsecureForBaseURL(endpoint, "")
+			}
+			return client.NewHTTPClient(ctx, endpoint, opts)
 		}
 		return client.NewHTTPClientForTarget(ctx, endpoint,
 			client.TargetAuth{Token: target.Token, AllowInsecure: target.AllowInsecure},
-			optsForKind(kind))
+			opts)
 	}
 	bootResolveScopeForTUI    = bootResolveScope
 	connectDaemonTargetForTUI = connectDaemonTarget


### PR DESCRIPTION
## Summary
- Restore per-daemon `allow_insecure` as an explicit plaintext-hostname opt-out for configured daemon targets.
- Keep bearer tokens origin-pinned so redirects cannot receive tokens across origins.
- Add regression coverage for Tailscale-style hostnames with `allow_insecure = true`.

Fixes gk8w.