### PR TITLE
feat(init): add --with-agents to write kata guidance into AGENTS.md

### DIFF
--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -376,20 +376,47 @@ func warnAgentsUpdate(err error) {
 	fmt.Fprintf(os.Stderr, "kata: warning: could not update AGENTS.md: %v\n", err)
 }
 
-// warnBeadsConflict tells the user kata declined to edit file in place because
-// it still carries a beads integration block, and points at the sidecar
+// warnBeadsConflict tells the user kata declined to edit a file in place
+// because it still carries a beads integration block, and points at the sidecar
 // proposal kata wrote instead. Suppressed in machine-output modes, matching
 // warnGitignoreUpdate.
-func warnBeadsConflict(file, sidecar string) {
+func warnBeadsConflict(originalPath, sidecarPath string) {
 	if currentOutputMode() != outputHuman {
 		return
 	}
-	base := filepath.Base(sidecar)
-	fmt.Fprintf(os.Stderr,
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
+	fmt.Fprint(os.Stderr, beadsConflictMessage(cwd, originalPath, sidecarPath))
+}
+
+// beadsConflictMessage builds the human hint for a declined in-place edit.
+// Paths are rendered relative to cwd when they sit under it, else absolute, so
+// the `mv` command is copy-pasteable no matter which directory init was invoked
+// from — the write destination is the workspace root, which need not be cwd.
+func beadsConflictMessage(cwd, originalPath, sidecarPath string) string {
+	label := filepath.Base(originalPath)
+	sidecar := displayPath(cwd, sidecarPath)
+	original := displayPath(cwd, originalPath)
+	return fmt.Sprintf(
 		"kata: %s still contains a beads integration block; left it untouched.\n"+
 			"      Wrote a migrated copy to %s (beads block removed, kata guidance added).\n"+
 			"      Review it, then `mv %s %s` to adopt — or delete it to keep the original.\n",
-		file, base, base, file)
+		label, sidecar, sidecar, original)
+}
+
+// displayPath renders abs for a shell hint: relative to cwd when abs sits under
+// it, else abs unchanged. An empty or unusable cwd yields the absolute path.
+func displayPath(cwd, abs string) string {
+	if cwd == "" {
+		return abs
+	}
+	rel, err := filepath.Rel(cwd, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return abs
+	}
+	return rel
 }
 
 // postProjects POSTs the request and returns the raw response body on
@@ -598,7 +625,7 @@ func applyAgentGuidance(dir string) (bool, error) {
 		if err != nil {
 			return changed, err
 		}
-		warnBeadsConflict("AGENTS.md", sidecar)
+		warnBeadsConflict(agentsPath, sidecar)
 		changed = true
 	} else {
 		c, err := ensureAgentsBlock(agentsPath, content, exists)
@@ -614,7 +641,7 @@ func applyAgentGuidance(dir string) (bool, error) {
 		if err != nil {
 			return changed, err
 		}
-		warnBeadsConflict("CLAUDE.md", sidecar)
+		warnBeadsConflict(claudePath, sidecar)
 		changed = true
 	}
 

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -661,7 +661,11 @@ func ensureAgentsBlock(path, content string, exists bool) (bool, error) {
 	if exists && updated == content {
 		return false, nil
 	}
-	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil { //nolint:gosec
+	if exists {
+		if err := rewriteGuidanceFile(path, []byte(updated)); err != nil {
+			return false, err
+		}
+	} else if err := writeNewGuidanceFile(path, []byte(updated)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -704,10 +708,39 @@ func writeMigrationProposal(path, content string) (string, error) {
 		return "", err
 	}
 	sidecar := path + agentsProposalSuffix
-	if err := os.WriteFile(sidecar, []byte(proposed), 0o644); err != nil { //nolint:gosec
+	if err := writeNewGuidanceFile(sidecar, []byte(proposed)); err != nil {
 		return "", err
 	}
 	return sidecar, nil
+}
+
+// writeNewGuidanceFile creates path with data, refusing to follow a symlink a
+// hostile repo may have planted there. O_EXCL fails (EEXIST) when anything —
+// regular file or symlink — already occupies the path, so kata never redirects
+// its write onto a victim file the path merely points at.
+func writeNewGuidanceFile(path string, data []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	_, werr := f.Write(data)
+	if cerr := f.Close(); werr == nil {
+		werr = cerr
+	}
+	return werr
+}
+
+// rewriteGuidanceFile overwrites an existing regular file, refusing to write
+// through a symlink so kata never rewrites a file the path merely points at.
+func rewriteGuidanceFile(path string, data []byte) error {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to write through symlinked %s", path)
+	}
+	return os.WriteFile(path, data, 0o644) //nolint:gosec
 }
 
 // hasBeadsBlock reports whether content carries a complete beads integration

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -403,7 +403,7 @@ func beadsConflictMessage(cwd, originalPath, sidecarPath string) string {
 		"kata: %s still contains a beads integration block; left it untouched.\n"+
 			"      Wrote a migrated copy to %s (beads block removed, kata guidance added).\n"+
 			"      Review it, then `mv %s %s` to adopt — or delete it to keep the original.\n",
-		label, sidecar, sidecar, original)
+		label, sidecar, shellQuote(sidecar), shellQuote(original))
 }
 
 // displayPath renders abs for a shell hint: relative to cwd when abs sits under

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -616,6 +616,13 @@ func applyAgentGuidance(dir string) (bool, error) {
 	changed := false
 
 	agentsPath := filepath.Join(dir, "AGENTS.md")
+	// Refuse a symlinked AGENTS.md before reading it. Following the link would
+	// let a hostile repo copy an outside file's content into the workspace via
+	// the migration sidecar, or rewrite the link target. CLAUDE.md gets the same
+	// treatment through regularFileWithBeads.
+	if fi, lerr := os.Lstat(agentsPath); lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return changed, fmt.Errorf("refusing to manage symlinked %s", agentsPath)
+	}
 	content, exists, err := readIfExists(agentsPath)
 	if err != nil {
 		return changed, err

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -19,16 +19,18 @@ import (
 
 // initOptions holds the flags specific to `kata init`.
 type initOptions struct {
-	Project  string
-	Replace  bool
-	Reassign bool
+	Project    string
+	Replace    bool
+	Reassign   bool
+	WithAgents bool
 }
 
 // callInitOpts is the parameter bag passed to callInit.
 type callInitOpts struct {
-	Project  string
-	Replace  bool
-	Reassign bool
+	Project    string
+	Replace    bool
+	Reassign   bool
+	WithAgents bool
 }
 
 // cliError is a structured error that carries an exit code for main().
@@ -136,6 +138,7 @@ get committed.`,
 
 	cmd.Flags().BoolVar(&opts.Replace, "replace", false, "overwrite .kata.toml binding when it conflicts")
 	cmd.Flags().BoolVar(&opts.Reassign, "reassign", false, "move an existing alias to this project")
+	cmd.Flags().BoolVar(&opts.WithAgents, "with-agents", false, "write kata agent guidance into AGENTS.md in the workspace")
 
 	return cmd
 }
@@ -295,8 +298,15 @@ func runNameInit(ctx context.Context, baseURL string, in localInit, opts callIni
 	if err != nil {
 		warnGitignoreUpdate(err)
 	}
+	agentsChanged := false
+	if opts.WithAgents {
+		agentsChanged, err = applyAgentGuidance(dest)
+		if err != nil {
+			warnAgentsUpdate(err)
+		}
+	}
 
-	return formatInitOutput(bs, resp.Project.Name, dest, resp.Created, resp.Created || tomlChanged || gitignoreChanged)
+	return formatInitOutput(bs, resp.Project.Name, dest, resp.Created, resp.Created || tomlChanged || gitignoreChanged || agentsChanged)
 }
 
 // runStartPathInit is the fallback used when the client cannot derive a name
@@ -339,10 +349,17 @@ func runStartPathInit(ctx context.Context, baseURL, startPath string, opts callI
 	if err != nil {
 		warnGitignoreUpdate(err)
 	}
+	agentsChanged := false
+	if opts.WithAgents {
+		agentsChanged, err = applyAgentGuidance(gitignoreDir)
+		if err != nil {
+			warnAgentsUpdate(err)
+		}
+	}
 
 	// The path-based daemon flow writes workspace files remotely and exposes no
 	// local file-change bit today; project creation is the closest stable signal.
-	return formatInitOutput(bs, resp.Project.Name, gitignoreDir, resp.Created, resp.Created || gitignoreChanged)
+	return formatInitOutput(bs, resp.Project.Name, gitignoreDir, resp.Created, resp.Created || gitignoreChanged || agentsChanged)
 }
 
 func warnGitignoreUpdate(err error) {
@@ -350,6 +367,29 @@ func warnGitignoreUpdate(err error) {
 		return
 	}
 	fmt.Fprintf(os.Stderr, "kata: warning: could not update .gitignore: %v\n", err)
+}
+
+func warnAgentsUpdate(err error) {
+	if currentOutputMode() != outputHuman {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "kata: warning: could not update AGENTS.md: %v\n", err)
+}
+
+// warnBeadsConflict tells the user kata declined to edit file in place because
+// it still carries a beads integration block, and points at the sidecar
+// proposal kata wrote instead. Suppressed in machine-output modes, matching
+// warnGitignoreUpdate.
+func warnBeadsConflict(file, sidecar string) {
+	if currentOutputMode() != outputHuman {
+		return
+	}
+	base := filepath.Base(sidecar)
+	fmt.Fprintf(os.Stderr,
+		"kata: %s still contains a beads integration block; left it untouched.\n"+
+			"      Wrote a migrated copy to %s (beads block removed, kata guidance added).\n"+
+			"      Review it, then `mv %s %s` to adopt — or delete it to keep the original.\n",
+		file, base, base, file)
 }
 
 // postProjects POSTs the request and returns the raw response body on
@@ -496,4 +536,218 @@ func ensureGitignoreEntry(dir, entry string) (bool, error) {
 	default:
 		return false, err
 	}
+}
+
+// agentsBlockBegin and agentsBlockEnd delimit the section kata manages inside
+// an agent guidance file. They let init refresh kata's guidance in place across
+// re-runs without disturbing anything else a project keeps in that file.
+const (
+	agentsBlockBegin = "<!-- BEGIN KATA (managed by `kata init --with-agents`) -->"
+	agentsBlockEnd   = "<!-- END KATA -->"
+)
+
+// beadsBlockBeginPrefix and beadsBlockEnd match the integration block Beads
+// writes into AGENTS.md/CLAUDE.md. The begin marker carries a trailing
+// version/profile/hash, so we match on its prefix and scan to the end marker.
+const (
+	beadsBlockBeginPrefix = "<!-- BEGIN BEADS INTEGRATION"
+	beadsBlockEnd         = "<!-- END BEADS INTEGRATION -->"
+)
+
+// agentsProposalSuffix names the sidecar kata writes when it refuses to edit a
+// file in place because it still carries a beads integration block. The user
+// reviews it and moves it over the original when ready.
+const agentsProposalSuffix = ".kata-proposed"
+
+// agentsBlockBody is the guidance kata injects between the markers. It mirrors
+// the contract `kata quickstart` prints, kept short so it complements rather
+// than duplicates the full quickstart text.
+const agentsBlockBody = "## kata issue tracker\n\n" +
+	"This project uses [kata](https://github.com/kenn-io/kata) as its shared issue\n" +
+	"ledger. Run `kata quickstart` at the start of each session for the full agent\n" +
+	"contract. The short version:\n\n" +
+	"- Search before creating: `kata search \"<keywords>\" --agent`.\n" +
+	"- Prefer updating existing issues over duplicates (`kata comment`, `kata label add`, `kata edit`).\n" +
+	"- Default to `--agent` for ordinary reads and mutations; use `--json` only when a script needs structured data.\n" +
+	"- Close only verified work: `kata close <ref> --done --message \"<scope + verification>\" --commit <sha>`.\n" +
+	"- If work is incomplete, label `needs-review` and comment what remains rather than closing.\n" +
+	"- Never `kata delete` or `kata purge` without explicit user authorization.\n"
+
+// agentsManagedBlock returns the full marker-delimited block kata writes.
+func agentsManagedBlock() string {
+	return agentsBlockBegin + "\n" + agentsBlockBody + agentsBlockEnd
+}
+
+// applyAgentGuidance is the entry point for `--with-agents`. It writes kata's
+// block into AGENTS.md and, when migrating off beads, sidesteps a destructive
+// edit: if a file still carries a beads integration block, kata leaves it
+// untouched and writes a <file>.kata-proposed copy (beads block removed, kata
+// block added) for the user to adopt or discard. CLAUDE.md is only considered
+// in that conflict case, and only when it is a real file rather than a symlink
+// (kata's own convention points CLAUDE.md at AGENTS.md).
+func applyAgentGuidance(dir string) (bool, error) {
+	changed := false
+
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+	content, exists, err := readIfExists(agentsPath)
+	if err != nil {
+		return changed, err
+	}
+	if exists && hasBeadsBlock(content) {
+		sidecar, err := writeMigrationProposal(agentsPath, content)
+		if err != nil {
+			return changed, err
+		}
+		warnBeadsConflict("AGENTS.md", sidecar)
+		changed = true
+	} else {
+		c, err := ensureAgentsBlock(agentsPath, content, exists)
+		if err != nil {
+			return changed, err
+		}
+		changed = changed || c
+	}
+
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	if claude, ok := regularFileWithBeads(claudePath); ok {
+		sidecar, err := writeMigrationProposal(claudePath, claude)
+		if err != nil {
+			return changed, err
+		}
+		warnBeadsConflict("CLAUDE.md", sidecar)
+		changed = true
+	}
+
+	return changed, nil
+}
+
+// ensureAgentsBlock writes kata's block into an agent guidance file whose
+// current content is already known. It creates the file when absent, appends
+// the block when the file has no kata markers, and rewrites the block in place
+// when its content drifts. A begin marker with no matching end marker is an
+// error rather than a guessed span. Returns whether the file changed.
+func ensureAgentsBlock(path, content string, exists bool) (bool, error) {
+	updated, err := upsertKataBlock(content)
+	if err != nil {
+		return false, err
+	}
+	if exists && updated == content {
+		return false, nil
+	}
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil { //nolint:gosec
+		return false, err
+	}
+	return true, nil
+}
+
+// upsertKataBlock returns content with kata's managed block present: appended
+// (with a blank line of separation) when absent, or rewritten in place when a
+// stale block already exists. A non-empty result always ends with a newline.
+func upsertKataBlock(content string) (string, error) {
+	block := agentsManagedBlock()
+	begin := strings.Index(content, agentsBlockBegin)
+	if begin == -1 {
+		var prefix string
+		switch {
+		case len(content) == 0, strings.HasSuffix(content, "\n\n"):
+		case strings.HasSuffix(content, "\n"):
+			prefix = "\n"
+		default:
+			prefix = "\n\n"
+		}
+		return content + prefix + block + "\n", nil
+	}
+	rel := strings.Index(content[begin:], agentsBlockEnd)
+	if rel == -1 {
+		return "", fmt.Errorf("agent guidance file has %q without a matching %q", agentsBlockBegin, agentsBlockEnd)
+	}
+	end := begin + rel + len(agentsBlockEnd)
+	if content[begin:end] == block {
+		return content, nil
+	}
+	return content[:begin] + block + content[end:], nil
+}
+
+// writeMigrationProposal writes a <path><suffix> copy of an existing file with
+// the beads block stripped and kata's block added, leaving the original
+// untouched. Returns the sidecar path.
+func writeMigrationProposal(path, content string) (string, error) {
+	proposed, err := upsertKataBlock(stripBeadsBlock(content))
+	if err != nil {
+		return "", err
+	}
+	sidecar := path + agentsProposalSuffix
+	if err := os.WriteFile(sidecar, []byte(proposed), 0o644); err != nil { //nolint:gosec
+		return "", err
+	}
+	return sidecar, nil
+}
+
+// hasBeadsBlock reports whether content carries a complete beads integration
+// block (both markers, in order).
+func hasBeadsBlock(content string) bool {
+	begin := strings.Index(content, beadsBlockBeginPrefix)
+	if begin == -1 {
+		return false
+	}
+	return strings.Contains(content[begin:], beadsBlockEnd)
+}
+
+// stripBeadsBlock removes the beads integration block and collapses the blank
+// space it leaves at the seam. Content without a complete block is returned
+// unchanged. A non-empty result ends with a newline.
+func stripBeadsBlock(content string) string {
+	begin := strings.Index(content, beadsBlockBeginPrefix)
+	if begin == -1 {
+		return content
+	}
+	rel := strings.Index(content[begin:], beadsBlockEnd)
+	if rel == -1 {
+		return content
+	}
+	end := begin + rel + len(beadsBlockEnd)
+	prefix := strings.TrimRight(content[:begin], "\n")
+	suffix := strings.TrimLeft(content[end:], "\n")
+	switch {
+	case prefix == "":
+		return suffix
+	case suffix == "":
+		return prefix + "\n"
+	default:
+		return prefix + "\n\n" + suffix
+	}
+}
+
+// readIfExists returns a file's content and whether it exists. A missing file
+// is reported as (",", false, nil); other read errors propagate.
+func readIfExists(path string) (string, bool, error) {
+	bs, err := os.ReadFile(path) //nolint:gosec
+	switch {
+	case err == nil:
+		return string(bs), true, nil
+	case errors.Is(err, os.ErrNotExist):
+		return "", false, nil
+	default:
+		return "", false, err
+	}
+}
+
+// regularFileWithBeads reports the content of path when it is a regular file
+// (not a symlink or directory) that carries a beads integration block. kata
+// skips symlinked CLAUDE.md so it never rewrites a file that merely points at
+// AGENTS.md.
+func regularFileWithBeads(path string) (string, bool) {
+	fi, err := os.Lstat(path)
+	if err != nil || fi.Mode()&os.ModeSymlink != 0 || fi.IsDir() {
+		return "", false
+	}
+	bs, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return "", false
+	}
+	content := string(bs)
+	if !hasBeadsBlock(content) {
+		return "", false
+	}
+	return content, true
 }

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -581,6 +581,24 @@ func TestInit_WithAgents_BeadsBlockInAgents_WritesSidecar(t *testing.T) {
 	assert.Contains(t, stderr, filepath.Base(sidecar))
 }
 
+// The adopt hint must name paths that resolve from the caller's working
+// directory. Run from the workspace root, paths collapse to clean base names;
+// run from a subdirectory (or with --workspace pointing elsewhere), a bare base
+// name would target the wrong directory, so the hint spells out absolute paths.
+func TestBeadsConflictMessage_PathsResolveFromCwd(t *testing.T) {
+	sidecar := "/repo/AGENTS.md" + agentsProposalSuffix
+
+	fromRoot := beadsConflictMessage("/repo", "/repo/AGENTS.md", sidecar)
+	assert.Contains(t, fromRoot, "AGENTS.md still contains a beads integration block")
+	assert.Contains(t, fromRoot, "mv AGENTS.md"+agentsProposalSuffix+" AGENTS.md",
+		"from the workspace root the mv command uses base names")
+
+	fromSubdir := beadsConflictMessage("/repo/cmd/kata", "/repo/AGENTS.md", sidecar)
+	assert.Contains(t, fromSubdir, "mv "+sidecar+" /repo/AGENTS.md",
+		"outside the workspace root the mv command must use resolvable absolute paths")
+	assert.NotContains(t, fromSubdir, "mv AGENTS.md"+agentsProposalSuffix+" AGENTS.md")
+}
+
 // A real (non-symlink) CLAUDE.md that still carries a beads block gets the same
 // sidecar treatment as AGENTS.md.
 func TestInit_WithAgents_BeadsBlockInClaude_WritesSidecar(t *testing.T) {

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -599,6 +599,17 @@ func TestBeadsConflictMessage_PathsResolveFromCwd(t *testing.T) {
 	assert.NotContains(t, fromSubdir, "mv AGENTS.md"+agentsProposalSuffix+" AGENTS.md")
 }
 
+// A workspace path with spaces would, unquoted, parse as extra mv operands, so
+// the adopt command must shell-quote both paths to stay copy-pasteable.
+func TestBeadsConflictMessage_ShellQuotesMvOperands(t *testing.T) {
+	original := "/Users/me/My Projects/app/AGENTS.md"
+	sidecar := original + agentsProposalSuffix
+
+	msg := beadsConflictMessage("/elsewhere", original, sidecar)
+	assert.Contains(t, msg, "mv '"+sidecar+"' '"+original+"'",
+		"mv operands must be single-quoted when the path contains spaces")
+}
+
 // A real (non-symlink) CLAUDE.md that still carries a beads block gets the same
 // sidecar treatment as AGENTS.md.
 func TestInit_WithAgents_BeadsBlockInClaude_WritesSidecar(t *testing.T) {

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -436,6 +436,207 @@ func TestInit_MachineOutputSuppressesGitignoreWarning(t *testing.T) {
 	}
 }
 
+func TestInit_WithAgents_WritesAgentsFileWhenAbsent(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(content), agentsBlockBegin)
+	assert.Contains(t, string(content), agentsBlockEnd)
+	assert.Contains(t, string(content), "kata quickstart")
+}
+
+func TestInit_WithoutFlag_DoesNotWriteAgents(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
+	require.NoError(t, err)
+
+	assert.NoFileExists(t, filepath.Join(dir, "AGENTS.md"))
+}
+
+func TestInit_WithAgents_Idempotent(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+	_, err = callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	// Exactly one managed block — no duplication on re-run.
+	assert.Equal(t, 1, strings.Count(string(content), agentsBlockBegin))
+	assert.Equal(t, 1, strings.Count(string(content), agentsBlockEnd))
+}
+
+func TestInit_WithAgents_AppendsToExistingFile(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), //nolint:gosec // test fixture under TempDir
+		[]byte("# House rules\n\nRun the linter before committing.\n"), 0o644))
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	// Pre-existing content is preserved and the managed block is appended.
+	assert.Contains(t, string(content), "Run the linter before committing.")
+	assert.Contains(t, string(content), agentsBlockBegin)
+}
+
+func TestInit_WithAgents_RefreshesStaleBlock(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	stale := agentsBlockBegin + "\nold kata guidance that should be replaced\n" + agentsBlockEnd + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), //nolint:gosec // test fixture under TempDir
+		[]byte("# House rules\n\n"+stale), 0o644))
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "old kata guidance that should be replaced")
+	assert.Contains(t, string(content), "kata quickstart")
+	assert.Contains(t, string(content), "# House rules", "content outside the markers must survive")
+	assert.Equal(t, 1, strings.Count(string(content), agentsBlockBegin))
+}
+
+// beadsFixtureBlock is a stand-in for the integration block Beads writes into
+// AGENTS.md/CLAUDE.md. kata matches on the begin-marker prefix and the end
+// marker, so the trailing version/profile/hash here is representative.
+const beadsFixtureBlock = "<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:deadbeef -->\n" +
+	"## Beads issue tracker\n\nRun `bd quickstart`.\n" +
+	"<!-- END BEADS INTEGRATION -->\n"
+
+// When AGENTS.md still carries a beads block, kata must not edit it in place.
+// It leaves the original byte-for-byte and writes a .kata-proposed sidecar with
+// the beads block removed and kata's block added, and warns where to find it.
+func TestInit_WithAgents_BeadsBlockInAgents_WritesSidecar(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	original := "# Agent guidance\n\nLegacy notes.\n\n" + beadsFixtureBlock
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+	require.NoError(t, os.WriteFile(agentsPath, []byte(original), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	var callErr error
+	stderr := captureProcessStderr(t, func() {
+		_, callErr = callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	})
+	require.NoError(t, callErr)
+
+	// Original is untouched.
+	got, err := os.ReadFile(agentsPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got), "AGENTS.md with a beads block must be left untouched")
+
+	// Sidecar carries kata's block, drops the beads block, keeps other content.
+	sidecar := agentsPath + agentsProposalSuffix
+	proposed, err := os.ReadFile(sidecar) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(proposed), "Legacy notes.")
+	assert.Contains(t, string(proposed), agentsBlockBegin)
+	assert.Contains(t, string(proposed), "kata quickstart")
+	assert.NotContains(t, string(proposed), beadsBlockBeginPrefix)
+	assert.NotContains(t, string(proposed), beadsBlockEnd)
+
+	// The user is told what to do.
+	assert.Contains(t, stderr, "beads integration block")
+	assert.Contains(t, stderr, filepath.Base(sidecar))
+}
+
+// A real (non-symlink) CLAUDE.md that still carries a beads block gets the same
+// sidecar treatment as AGENTS.md.
+func TestInit_WithAgents_BeadsBlockInClaude_WritesSidecar(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	claude := "# Claude guidance\n\n" + beadsFixtureBlock
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	require.NoError(t, os.WriteFile(claudePath, []byte(claude), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	// CLAUDE.md itself is untouched.
+	got, err := os.ReadFile(claudePath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, claude, string(got), "CLAUDE.md with a beads block must be left untouched")
+
+	proposed, err := os.ReadFile(claudePath + agentsProposalSuffix) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(proposed), "# Claude guidance")
+	assert.Contains(t, string(proposed), agentsBlockBegin)
+	assert.NotContains(t, string(proposed), beadsBlockBeginPrefix)
+
+	// AGENTS.md (absent here) still gets kata's block written normally.
+	agents, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(agents), agentsBlockBegin)
+}
+
+// kata's own convention symlinks CLAUDE.md at AGENTS.md. A symlinked CLAUDE.md
+// must never be rewritten or shadowed by a sidecar, even if it resolves to
+// content with a beads block.
+func TestInit_WithAgents_ClaudeSymlink_Skipped(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	// AGENTS.md holds a beads block; CLAUDE.md points at it.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), //nolint:gosec // test fixture under TempDir
+		[]byte("# Agent guidance\n\n"+beadsFixtureBlock), 0o644))
+	require.NoError(t, os.Symlink("AGENTS.md", filepath.Join(dir, "CLAUDE.md")))
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	// No sidecar for the symlink, and the symlink itself is preserved.
+	assert.NoFileExists(t, filepath.Join(dir, "CLAUDE.md"+agentsProposalSuffix))
+	fi, err := os.Lstat(filepath.Join(dir, "CLAUDE.md"))
+	require.NoError(t, err)
+	assert.NotZero(t, fi.Mode()&os.ModeSymlink, "CLAUDE.md must remain a symlink")
+}
+
 func captureProcessStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	old := os.Stderr

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -666,6 +666,51 @@ func TestInit_WithAgents_ClaudeSymlink_Skipped(t *testing.T) {
 	assert.NotZero(t, fi.Mode()&os.ModeSymlink, "CLAUDE.md must remain a symlink")
 }
 
+// A hostile repo must not redirect kata's sidecar write through a pre-planted
+// symlink to clobber a file outside the workspace.
+func TestInit_WithAgents_SidecarSymlinkNotFollowed(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	victim := filepath.Join(t.TempDir(), "victim.txt")
+	require.NoError(t, os.WriteFile(victim, []byte("precious\n"), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+	require.NoError(t, os.WriteFile(agentsPath, //nolint:gosec // test fixture under TempDir
+		[]byte("# Agent guidance\n\n"+beadsFixtureBlock), 0o644))
+	// Attacker pre-plants the sidecar path as a symlink at the victim file.
+	require.NoError(t, os.Symlink(victim, agentsPath+agentsProposalSuffix))
+
+	_, _ = callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+
+	got, err := os.ReadFile(victim) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, "precious\n", string(got),
+		"kata must not write through a pre-planted sidecar symlink")
+}
+
+// kata must not write through a symlinked AGENTS.md, which a hostile repo could
+// point at a victim file to have init overwrite it.
+func TestInit_WithAgents_AgentsSymlinkNotFollowed(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	victim := filepath.Join(t.TempDir(), "victim.txt")
+	require.NoError(t, os.WriteFile(victim, []byte("precious\n"), 0o644)) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, os.Symlink(victim, filepath.Join(dir, "AGENTS.md")))
+
+	_, _ = callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+
+	got, err := os.ReadFile(victim) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, "precious\n", string(got),
+		"kata must not write through a symlinked AGENTS.md")
+}
+
 func captureProcessStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	old := os.Stderr

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -711,6 +711,31 @@ func TestInit_WithAgents_AgentsSymlinkNotFollowed(t *testing.T) {
 		"kata must not write through a symlinked AGENTS.md")
 }
 
+// A symlinked AGENTS.md whose target carries a beads block must not be migrated:
+// following it would copy the outside file's content into AGENTS.md.kata-proposed
+// inside the repo.
+func TestInit_WithAgents_AgentsBeadsSymlinkNotMigrated(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	// An outside file that happens to carry a beads block; a hostile repo points
+	// AGENTS.md at it to coax kata into copying its content into the workspace.
+	secret := filepath.Join(t.TempDir(), "secret.md")
+	body := "# secrets\n\n" + beadsFixtureBlock
+	require.NoError(t, os.WriteFile(secret, []byte(body), 0o644)) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, os.Symlink(secret, filepath.Join(dir, "AGENTS.md")))
+
+	_, _ = callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+
+	// kata must not copy the outside file into a sidecar in the repo.
+	assert.NoFileExists(t, filepath.Join(dir, "AGENTS.md"+agentsProposalSuffix))
+	got, err := os.ReadFile(secret) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, body, string(got), "the symlink target must be left untouched")
+}
+
 func captureProcessStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	old := os.Stderr

--- a/cmd/kata/init_with_agents_e2e_test.go
+++ b/cmd/kata/init_with_agents_e2e_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+// These exercise `kata init --with-agents` as a user would run it: the real
+// CLI command against a live daemon, in three realistic shapes — a brand-new
+// repo, an existing repo that already keeps agent docs, and a migration from
+// Beads. They complement the focused unit tests in init_test.go.
+
+// TestE2E_InitWithAgents_NewEmptyRepo is the happy path: a fresh git repo with
+// no agent docs. init binds the project and writes AGENTS.md, and does not
+// fabricate a CLAUDE.md.
+func TestE2E_InitWithAgents_NewEmptyRepo(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	out := runCLI(t, env, dir, "init", "--with-agents")
+	assert.Contains(t, out, "project")
+
+	assert.FileExists(t, filepath.Join(dir, ".kata.toml"))
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(content), agentsBlockBegin)
+	assert.Contains(t, string(content), agentsBlockEnd)
+	assert.Contains(t, string(content), "kata quickstart")
+
+	// kata writes AGENTS.md only; it does not invent a CLAUDE.md.
+	assert.NoFileExists(t, filepath.Join(dir, "CLAUDE.md"))
+}
+
+// TestE2E_InitWithAgents_PreservesExistingAgentDocs runs init in a repo that
+// already ships a CLAUDE.md and an AGENTS.md full of unrelated guidance. The
+// CLAUDE.md must be byte-for-byte untouched, and every pre-existing AGENTS.md
+// section must survive alongside kata's appended block.
+func TestE2E_InitWithAgents_PreservesExistingAgentDocs(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	claude := "# Claude guidance\n\nProject-specific Claude rules. Leave this file alone.\n"
+	agents := "# Agent guidance\n\n## Build\n\nRun `make build` before pushing.\n\n## Conventions\n\nTabs, not spaces.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(claude), 0o644)) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(agents), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	runCLI(t, env, dir, "init", "--with-agents")
+
+	// CLAUDE.md is not part of the managed surface — it must be identical.
+	gotClaude, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, claude, string(gotClaude), "CLAUDE.md must be left exactly as the project had it")
+
+	// AGENTS.md keeps every pre-existing section and gains kata's block.
+	gotAgents, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	got := string(gotAgents)
+	assert.Contains(t, got, "# Agent guidance")
+	assert.Contains(t, got, "Run `make build` before pushing.")
+	assert.Contains(t, got, "Tabs, not spaces.")
+	assert.Contains(t, got, agentsBlockBegin)
+	assert.Contains(t, got, "kata quickstart")
+}
+
+// TestE2E_InitWithAgents_ThenBeadsImport walks the realistic migration: a repo
+// coming from Beads (which already wrote its own AGENTS.md) runs
+// `kata init --with-agents` and then `kata import --source-format beads`. The
+// issues import and the AGENTS.md retains both the legacy content and kata's
+// block through the whole flow.
+func TestE2E_InitWithAgents_ThenBeadsImport(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	// A project migrating from Beads commonly already keeps an AGENTS.md.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), //nolint:gosec // test fixture under TempDir
+		[]byte("# Agent guidance\n\nLegacy notes from the Beads era.\n"), 0o644))
+
+	installFakeBD(t)
+
+	runCLI(t, env, dir, "init", "--with-agents")
+
+	out, err := runCLICapture(t, env, dir, "import", "--source-format", "beads", "--as", "importer")
+	require.NoError(t, err, "import output: %s", out)
+	assert.Contains(t, out, "imported beads: created 1")
+
+	// The imported issue is queryable through the normal read path.
+	listOut := runCLI(t, env, dir, "list", "--json")
+	assert.Contains(t, listOut, "Live bead")
+
+	// AGENTS.md survived the migration: legacy content + kata block coexist.
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "Legacy notes from the Beads era.")
+	assert.Contains(t, string(content), agentsBlockBegin)
+	assert.Contains(t, string(content), "kata quickstart")
+}

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -49,6 +49,26 @@ kata init --project product
 Commit `.kata.toml` when multiple agents, clones, or worktrees should resolve
 to the same kata project. The file is intentionally secret-free.
 
+To also drop a short kata briefing where coding agents look for it, pass
+`--with-agents`:
+
+```sh
+kata init --with-agents
+```
+
+This writes a marker-delimited block into `AGENTS.md` in the workspace, pointing
+agents at `kata quickstart` and the close discipline. The block is idempotent:
+re-running refreshes kata's section in place and leaves the rest of the file
+untouched. The flag is off by default, so a plain `kata init` still writes only
+`.kata.toml`.
+
+If `AGENTS.md` (or a real, non-symlinked `CLAUDE.md`) still carries a Beads
+integration block — common when migrating off Beads — kata refuses to edit it in
+place. It leaves the original untouched and writes a `<file>.kata-proposed`
+sidecar with the Beads block removed and kata's block added. Review the sidecar,
+then `mv AGENTS.md.kata-proposed AGENTS.md` to adopt it, or delete it to keep the
+original. kata prints where the sidecar landed.
+
 ## Create and inspect issues
 
 ```sh

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -22,6 +22,13 @@ kata whoami --agent
 Default to `--agent` for ordinary reads and mutations in agent logs. Use
 `--json` only when the script needs full structured data.
 
+To make a workspace self-documenting for agents that read `AGENTS.md`, run
+`kata init --with-agents` once. It writes a marker-delimited kata briefing into
+`AGENTS.md` that points back at `kata quickstart`; re-running refreshes only
+kata's block. If the file still carries a Beads integration block, kata leaves
+it untouched and writes a `<file>.kata-proposed` sidecar to adopt or discard —
+see [`--with-agents`](../get-started/quickstart.md#initialize-a-workspace).
+
 ## Search before creating
 
 ```sh


### PR DESCRIPTION
## Summary

`kata init` writes only `.kata.toml` and a `.gitignore` line, so a freshly bound workspace gives coding agents no in-repo hint that kata is the issue ledger — agents have to be told to run `kata quickstart` out of band. Beads, by contrast, writes/updates `AGENTS.md` on `bd init` by default.

This adds an **opt-in** `--with-agents` flag to `kata init` that writes a marker-delimited kata briefing into `AGENTS.md` in the workspace, pointing agents at `kata quickstart` and the close discipline.

Design choices, aimed at fitting kata's "smallest repo footprint" philosophy:

- **Off by default.** A plain `kata init` still writes only `.kata.toml`; nothing changes unless you ask for the block.
- **Marker-delimited + idempotent.** The block lives between `<!-- BEGIN KATA ... -->` / `<!-- END KATA -->`. Re-running refreshes only kata's section, preserves everything else in the file, appends cleanly when `AGENTS.md` already exists, and errors rather than guessing when a begin marker has no matching end.
- **Non-destructive beads migration.** If `AGENTS.md` (or a real, non-symlinked `CLAUDE.md`) still carries a Beads integration block, kata refuses to edit it in place. It leaves the original byte-for-byte untouched and writes a `<file>.kata-proposed` sidecar with the Beads block removed and kata's block added, then prints how to adopt (`mv`) or discard it. A symlinked `CLAUDE.md` is skipped so kata never rewrites a file that just points at `AGENTS.md`.
- **Short by design.** The injected block mirrors the quickstart contract in brief and points back at `kata quickstart` rather than duplicating it.
- **Works in both init flows** (path-free client-side write and path-based fallback), writing alongside where `.gitignore` is managed.

kata's own repo treats `AGENTS.md` as the source of truth with `CLAUDE.md` as a symlink (per #57), so `CLAUDE.md` is only ever touched in the beads-conflict case above, and never when it is a symlink.

## Changes

- `cmd/kata/init.go`: `--with-agents` flag; `applyAgentGuidance` orchestrator; `ensureAgentsBlock`/`upsertKataBlock` managed-block handling; `writeMigrationProposal` + beads detection (`hasBeadsBlock`/`stripBeadsBlock`/`regularFileWithBeads`) for the sidecar path; `warnBeadsConflict` user guidance. Wired into `runNameInit` and `runStartPathInit`.
- `cmd/kata/init_test.go`: writes-when-absent, no-op-without-flag, idempotent, appends-to-existing, refreshes-stale-block, plus beads-block-in-AGENTS sidecar, beads-block-in-CLAUDE sidecar, and symlinked-CLAUDE-skipped.
- `cmd/kata/init_with_agents_e2e_test.go`: end-to-end flows via the real CLI — new empty repo, existing CLAUDE.md + AGENTS.md preserved, and a beads import migration.
- `docs/get-started/quickstart.md`, `docs/workflows/agents.md`: document the flag and the sidecar behavior.

Local checks: `go test ./cmd/kata/`, `go vet`, and `golangci-lint` all pass. (`nilaway` not installed in my environment; change is plain string handling with no new nil paths.) Also verified by hand against a real 59-issue beads database: AGENTS.md preserved, CLAUDE.md untouched, sidecar produced as expected.

Opening as **draft** to get maintainer read on whether an opt-in AGENTS.md writer fits kata's direction before polishing.