### PR TITLE
docs: add Vercel CLI deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test test-short test-stress test-federation-docker lint vet clean fmt nilaway tui tui-demo docs-install docs-build docs-serve docs-check
+.PHONY: build install test test-short test-stress test-federation-docker lint vet clean fmt nilaway tui tui-demo docs-install docs-build docs-serve docs-check docs-deploy
 
 GOFLAGS_TEST := -shuffle=on
 GOBIN ?= $(HOME)/.local/bin
@@ -34,6 +34,9 @@ docs-serve:
 
 docs-check:
 	bash scripts/check-docs.sh
+
+docs-deploy:
+	vercel deploy --cwd docs --prod
 
 lint:
 	golangci-lint run --config .golangci.yml

--- a/docs/development/deploying-docs.md
+++ b/docs/development/deploying-docs.md
@@ -57,6 +57,28 @@ package = false
 Update `docs/pyproject.toml` and refresh `docs/uv.lock` together whenever the
 docs toolchain changes.
 
+## CLI deployment
+
+After the Vercel GitHub integration is disconnected, deploy the docs project
+from the command line. Link the local docs directory to the existing Vercel
+project once:
+
+```sh
+vercel link --cwd docs
+```
+
+Then deploy the current workspace to production from the repository root:
+
+```sh
+make docs-deploy
+```
+
+The Make target runs:
+
+```sh
+vercel deploy --cwd docs --prod
+```
+
 ## Verification
 
 Before changing the Vercel project or merging deployment config, verify the

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -102,6 +102,10 @@ require_line docs/development/deploying-docs.md '| Root directory | `docs` |'
 require_line docs/development/deploying-docs.md 'Vercel should install with `uv sync --frozen --no-dev`'
 require_line docs/development/deploying-docs.md 'Vercel should build with `uv run --frozen bash ./vercel-build.sh`'
 require_line docs/development/deploying-docs.md 'Vercel should publish the generated `site/` directory'
+require_line docs/development/deploying-docs.md 'vercel link --cwd docs'
+require_line docs/development/deploying-docs.md 'make docs-deploy'
+require_line Makefile 'docs-deploy:'
+require_line Makefile 'vercel deploy --cwd docs --prod'
 require_line README.md 'kata close abc4 --done --message "Fixed the login race and verified the relevant tests pass." --commit <sha>'
 
 for stale_reference in Makefile scripts/zensical-docs.sh docs/development/deploying-docs.md; do


### PR DESCRIPTION
Summary:
- Add `make docs-deploy` for production docs deploys via Vercel CLI.
- Document `vercel link --cwd docs` for one-time local project linking after removing the GitHub integration.

Verified with `make docs-check`.