### PR TITLE
Add docs update helper

### DIFF
--- a/docs/development/deploying-docs.md
+++ b/docs/development/deploying-docs.md
@@ -77,7 +77,8 @@ scripts/update-docs.sh
 
 The helper regenerates and pushes the `docs-assets` screenshot branch, hydrates
 local screenshots, builds the docs, runs the docs checks, and deploys with
-Vercel. It does not commit source changes; commit docs edits before running it.
+Vercel. It does not commit source changes; commit or stash non-ignored docs
+edits before running it.
 
 If you need to run only the Vercel deploy step:
 

--- a/docs/development/deploying-docs.md
+++ b/docs/development/deploying-docs.md
@@ -68,7 +68,18 @@ deploy from inside `docs/`:
 vercel link
 ```
 
-Then deploy the current workspace to production from the repository root:
+Then deploy the current committed workspace to production from the repository
+root:
+
+```sh
+scripts/update-docs.sh
+```
+
+The helper regenerates and pushes the `docs-assets` screenshot branch, hydrates
+local screenshots, builds the docs, runs the docs checks, and deploys with
+Vercel. It does not commit source changes; commit docs edits before running it.
+
+If you need to run only the Vercel deploy step:
 
 ```sh
 make docs-deploy

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -24,6 +24,7 @@ required_files=(
   "docs/vercel.json"
   "docs/vercel-build.sh"
   "docs/zensical-docs.sh"
+  "scripts/update-docs.sh"
   "docs/pyproject.toml"
   "docs/uv.lock"
   "docs/design/index.md"
@@ -70,6 +71,11 @@ for file in "${required_files[@]}"; do
     missing=1
   fi
 done
+
+if [[ -f "scripts/update-docs.sh" && ! -x "scripts/update-docs.sh" ]]; then
+  printf 'docs deploy helper must be executable: scripts/update-docs.sh\n' >&2
+  missing=1
+fi
 
 if [[ "$missing" -ne 0 ]]; then
   exit 1
@@ -124,13 +130,20 @@ require_line docs/development/deploying-docs.md 'Vercel should build with `uv ru
 require_line docs/development/deploying-docs.md 'Vercel should publish the generated `site/` directory'
 require_line docs/development/deploying-docs.md 'vercel deploy --prod'
 require_line docs/development/deploying-docs.md 'make docs-deploy'
+require_line docs/development/deploying-docs.md 'scripts/update-docs.sh'
 require_line Makefile 'docs-deploy:'
 require_line Makefile 'vercel deploy --prod'
+require_line scripts/update-docs.sh 'bash docs/screenshots/update-assets-branch.sh --push'
+require_line scripts/update-docs.sh 'bash docs/screenshots/hydrate-assets.sh'
+require_line scripts/update-docs.sh 'make docs-build'
+require_line scripts/update-docs.sh 'make docs-check'
+require_line scripts/update-docs.sh 'make docs-deploy'
 require_line README.md 'kata close abc4 --done --message "Fixed the login race and verified the relevant tests pass." --commit <sha>'
 
 reject_line docs/development/deploying-docs.md 'vercel link --cwd docs'
 reject_line docs/development/deploying-docs.md 'vercel deploy --cwd docs --prod'
 reject_line Makefile 'vercel deploy --cwd docs --prod'
+reject_line scripts/update-docs.sh 'git commit'
 
 for stale_reference in Makefile docs/zensical-docs.sh docs/development/deploying-docs.md; do
   if grep -F -- "requirements-docs.txt" "$stale_reference" >/dev/null; then

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -138,12 +138,14 @@ require_line scripts/update-docs.sh 'bash docs/screenshots/hydrate-assets.sh'
 require_line scripts/update-docs.sh 'make docs-build'
 require_line scripts/update-docs.sh 'make docs-check'
 require_line scripts/update-docs.sh 'make docs-deploy'
+require_line scripts/update-docs.sh '--untracked-files=all'
 require_line README.md 'kata close abc4 --done --message "Fixed the login race and verified the relevant tests pass." --commit <sha>'
 
 reject_line docs/development/deploying-docs.md 'vercel link --cwd docs'
 reject_line docs/development/deploying-docs.md 'vercel deploy --cwd docs --prod'
 reject_line Makefile 'vercel deploy --cwd docs --prod'
 reject_line scripts/update-docs.sh 'git commit'
+reject_line scripts/update-docs.sh '--untracked-files=no'
 
 for stale_reference in Makefile docs/zensical-docs.sh docs/development/deploying-docs.md; do
   if grep -F -- "requirements-docs.txt" "$stale_reference" >/dev/null; then

--- a/scripts/update-docs.sh
+++ b/scripts/update-docs.sh
@@ -53,9 +53,9 @@ run() {
 
 require_clean_tracked_tree() {
   local status
-  status="$(git status --porcelain --untracked-files=no)"
+  status="$(git status --porcelain --untracked-files=all)"
   if [[ -n "$status" ]]; then
-    printf 'ERROR: tracked changes are present. Commit or stash docs source changes before deploying.\n' >&2
+    printf 'ERROR: uncommitted, non-ignored changes are present. Commit or stash docs source changes before deploying.\n' >&2
     printf '%s\n' "$status" >&2
     exit 1
   fi

--- a/scripts/update-docs.sh
+++ b/scripts/update-docs.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Regenerate docs screenshots, verify the docs build, and deploy to Vercel.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRY_RUN=false
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--dry-run]
+
+Regenerate and push docs screenshot assets, build and check the docs, then
+deploy the current committed workspace to production Vercel.
+
+Run this after docs source changes have already been committed.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'ERROR: %s is required for docs deployment\n' "$1" >&2
+    exit 1
+  fi
+}
+
+run() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  if [[ "$DRY_RUN" == false ]]; then
+    "$@"
+  fi
+}
+
+require_clean_tracked_tree() {
+  local status
+  status="$(git status --porcelain --untracked-files=no)"
+  if [[ -n "$status" ]]; then
+    printf 'ERROR: tracked changes are present. Commit or stash docs source changes before deploying.\n' >&2
+    printf '%s\n' "$status" >&2
+    exit 1
+  fi
+}
+
+require_cmd bash
+require_cmd git
+require_cmd make
+require_cmd vercel
+
+cd "$REPO_ROOT"
+if [[ "$DRY_RUN" == false ]]; then
+  require_clean_tracked_tree
+fi
+
+run make docs-install
+run bash docs/screenshots/update-assets-branch.sh --push
+run bash docs/screenshots/hydrate-assets.sh
+run make docs-build
+run make docs-check
+run make docs-deploy


### PR DESCRIPTION
## Summary

- add `scripts/update-docs.sh` as the one-command screenshot/docs deploy helper
- document the helper in the docs deployment guide
- extend docs validation to require the helper and prevent accidental commit behavior