### PR TITLE
feat(daemon): add kata openapi command + committed OpenAPI schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test test-short test-stress test-federation-docker lint vet clean fmt nilaway tui tui-demo docs-install docs-build docs-serve docs-check docs-deploy docs-screenshots docs-assets-branch
+.PHONY: build install test test-short test-stress test-federation-docker lint vet clean fmt nilaway openapi tui tui-demo docs-install docs-build docs-serve docs-check docs-deploy docs-screenshots docs-assets-branch
 
 GOFLAGS_TEST := -shuffle=on
 GOBIN ?= $(HOME)/.local/bin
@@ -15,6 +15,11 @@ install:
 
 test:
 	go test $(GOFLAGS_TEST) ./...
+
+# Regenerate the committed OpenAPI schema artifact from the daemon's routes.
+# The TestOpenAPIArtifactUpToDate test fails if api/openapi.yaml drifts from this.
+openapi:
+	go run ./cmd/kata openapi > api/openapi.yaml
 
 test-short:
 	go test -short $(GOFLAGS_TEST) ./...

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,5218 @@
+components:
+  schemas:
+    ActionRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        dry_run:
+          type: boolean
+        evidence:
+          items:
+            $ref: "#/components/schemas/Evidence"
+          type:
+            - array
+            - "null"
+        message:
+          type: string
+        reason:
+          enum:
+            - done
+            - wontfix
+            - duplicate
+            - superseded
+            - audit-no-change
+            - ""
+          type: string
+        source:
+          enum:
+            - tui
+            - ""
+          type: string
+      required:
+        - actor
+      type: object
+    AddLabelRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        label:
+          type: string
+      required:
+        - actor
+        - label
+      type: object
+    AddLabelResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        event:
+          $ref: "#/components/schemas/Event"
+        issue:
+          $ref: "#/components/schemas/Issue"
+        label:
+          $ref: "#/components/schemas/IssueLabel"
+      required:
+        - issue
+        - label
+        - event
+        - changed
+      type: object
+    AliasInput:
+      additionalProperties: false
+      properties:
+        identity:
+          description: alias identity (normalized git remote or local://<abs>)
+          type: string
+        kind:
+          description: "\"git\" or \"local\""
+          type: string
+      required:
+        - identity
+        - kind
+      type: object
+    AssignRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        owner:
+          type: string
+      required:
+        - actor
+        - owner
+      type: object
+    AuditCloseRow:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        evidence_types:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        flags:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        issue:
+          type: string
+        message:
+          type: string
+        parent:
+          type: string
+        reason:
+          type: string
+        time:
+          type: string
+      required:
+        - time
+        - actor
+        - issue
+        - reason
+      type: object
+    AuditClosesResponseBody:
+      additionalProperties: false
+      properties:
+        rows:
+          items:
+            $ref: "#/components/schemas/AuditCloseRow"
+          type:
+            - array
+            - "null"
+      required:
+        - rows
+      type: object
+    AuthInfoOut:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        kind:
+          type: string
+      required:
+        - kind
+      type: object
+    ChildCounts:
+      additionalProperties: false
+      properties:
+        open:
+          format: int64
+          type: integer
+        total:
+          format: int64
+          type: integer
+      required:
+        - open
+        - total
+      type: object
+    ClaimActionBody:
+      additionalProperties: true
+      properties:
+        actor:
+          type: string
+        claim_kind:
+          type: string
+        client_kind:
+          type: string
+        holder:
+          type: string
+        purpose:
+          type: string
+        reason:
+          type: string
+        ttl_seconds:
+          format: int64
+          type: integer
+      type: object
+    ClaimActionResponseBody:
+      additionalProperties: false
+      properties:
+        claim:
+          $ref: "#/components/schemas/IssueClaimOut"
+        event:
+          $ref: "#/components/schemas/Event"
+        granted:
+          type: boolean
+        holder:
+          $ref: "#/components/schemas/ClaimPrincipalOut"
+        lease:
+          $ref: "#/components/schemas/IssueClaimOut"
+        pending:
+          type: boolean
+        request_uid:
+          type: string
+      required:
+        - granted
+        - holder
+      type: object
+    ClaimPrincipalOut:
+      additionalProperties: false
+      properties:
+        client_kind:
+          type: string
+        holder:
+          type: string
+        holder_instance_uid:
+          type: string
+      required:
+        - holder_instance_uid
+        - holder
+        - client_kind
+      type: object
+    ClaimRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        force:
+          type: boolean
+      required:
+        - actor
+      type: object
+    ClaimResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        event:
+          $ref: "#/components/schemas/Event"
+        issue:
+          $ref: "#/components/schemas/Issue"
+        previous_owner:
+          type: string
+      required:
+        - issue
+        - changed
+      type: object
+    ClaimStatusBody:
+      additionalProperties: false
+      properties:
+        claim:
+          $ref: "#/components/schemas/IssueClaimOut"
+        held:
+          type: boolean
+        holder:
+          $ref: "#/components/schemas/ClaimPrincipalOut"
+        hub_now:
+          format: date-time
+          type: string
+        lease:
+          $ref: "#/components/schemas/IssueClaimOut"
+      required:
+        - held
+        - holder
+        - hub_now
+      type: object
+    ClaimViolationOut:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        at:
+          format: date-time
+          type: string
+        event_id:
+          format: int64
+          type: integer
+        event_uid:
+          type: string
+        issue_uid:
+          type: string
+        offending_event_type:
+          type: string
+        offending_event_uid:
+          type: string
+        offending_origin_instance_uid:
+          type: string
+        reason:
+          type: string
+        short_id:
+          type: string
+      required:
+        - event_id
+        - event_uid
+        - issue_uid
+        - at
+      type: object
+    Comment:
+      additionalProperties: false
+      properties:
+        author:
+          type: string
+        body:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        issue_id:
+          format: int64
+          type: integer
+        uid:
+          type: string
+      required:
+        - id
+        - uid
+        - issue_id
+        - author
+        - body
+        - created_at
+      type: object
+    CommentRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        body:
+          type: string
+      required:
+        - actor
+        - body
+      type: object
+    CommentResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        comment:
+          $ref: "#/components/schemas/Comment"
+        event:
+          $ref: "#/components/schemas/Event"
+        issue:
+          $ref: "#/components/schemas/Issue"
+      required:
+        - issue
+        - comment
+        - event
+        - changed
+      type: object
+    CreateFederationEnrollmentRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        allow_adoption_snapshot_authors:
+          type: boolean
+        capabilities:
+          type: string
+        project_id:
+          format: int64
+          type:
+            - integer
+            - "null"
+        spoke_instance_uid:
+          type: string
+        token:
+          type: string
+      required:
+        - spoke_instance_uid
+        - project_id
+        - capabilities
+      type: object
+    CreateFederationReplicaBody:
+      additionalProperties: false
+      properties:
+        adopted:
+          type: boolean
+        adoption_snapshot_count:
+          format: int64
+          type: integer
+        binding:
+          $ref: "#/components/schemas/FederationBindingOut"
+        project:
+          $ref: "#/components/schemas/ProjectOut"
+      required:
+        - project
+        - binding
+      type: object
+    CreateFederationReplicaRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        adopt_existing:
+          type: boolean
+        allow_insecure:
+          type: boolean
+        baseline_through_event_id:
+          format: int64
+          type: integer
+        capabilities:
+          type: string
+        hub_project_id:
+          format: int64
+          type: integer
+        hub_project_uid:
+          type: string
+        hub_url:
+          type: string
+        project_name:
+          type: string
+        push_enabled:
+          type: boolean
+        replay_horizon_event_id:
+          format: int64
+          type: integer
+        token:
+          type: string
+      required:
+        - hub_url
+        - hub_project_id
+        - hub_project_uid
+        - project_name
+        - replay_horizon_event_id
+      type: object
+    CreateInitialLinkBody:
+      additionalProperties: false
+      properties:
+        incoming:
+          type: boolean
+        to_ref:
+          type: string
+        type:
+          enum:
+            - parent
+            - blocks
+            - related
+          type: string
+      required:
+        - type
+        - to_ref
+      type: object
+    CreateIssueRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        body:
+          type: string
+        force_new:
+          type: boolean
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        links:
+          items:
+            $ref: "#/components/schemas/CreateInitialLinkBody"
+          type:
+            - array
+            - "null"
+        owner:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        title:
+          type: string
+      required:
+        - actor
+        - title
+      type: object
+    CreateLinkRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        replace:
+          type: boolean
+        to_ref:
+          type: string
+        type:
+          enum:
+            - parent
+            - blocks
+            - related
+          type: string
+      required:
+        - actor
+        - type
+        - to_ref
+      type: object
+    CreateLinkResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        event:
+          $ref: "#/components/schemas/Event"
+        issue:
+          $ref: "#/components/schemas/Issue"
+        link:
+          $ref: "#/components/schemas/LinkOut"
+      required:
+        - issue
+        - link
+        - event
+        - changed
+      type: object
+    CreateRecurrenceRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        dtstart:
+          type: string
+        rrule:
+          type: string
+        template:
+          $ref: "#/components/schemas/RecurrenceTemplateInput"
+        timezone:
+          type: string
+      required:
+        - actor
+        - rrule
+        - dtstart
+        - timezone
+        - template
+      type: object
+    CreateRecurrenceResponseBody:
+      additionalProperties: false
+      properties:
+        recurrence:
+          $ref: "#/components/schemas/Recurrence"
+      required:
+        - recurrence
+      type: object
+    CreateTokenRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        name:
+          type: string
+      required:
+        - actor
+      type: object
+    CreateTokenResponseBody:
+      additionalProperties: false
+      properties:
+        plaintext:
+          type: string
+        token:
+          $ref: "#/components/schemas/TokenOut"
+      required:
+        - token
+        - plaintext
+      type: object
+    DestructiveActionRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        reason:
+          type: string
+      required:
+        - actor
+      type: object
+    DetachProjectAliasResponseBody:
+      additionalProperties: false
+      properties:
+        alias:
+          $ref: "#/components/schemas/ProjectAlias"
+        event:
+          $ref: "#/components/schemas/Event"
+      required:
+        - alias
+        - event
+      type: object
+    DigestActorEntry:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        issues:
+          items:
+            $ref: "#/components/schemas/DigestIssueActions"
+          type:
+            - array
+            - "null"
+        totals:
+          $ref: "#/components/schemas/DigestTotals"
+      required:
+        - actor
+        - totals
+        - issues
+      type: object
+    DigestIssueActions:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        issue_short_id:
+          type: string
+        issue_uid:
+          type: string
+        project_id:
+          format: int64
+          type: integer
+        project_name:
+          type: string
+      required:
+        - project_id
+        - project_name
+        - issue_uid
+        - issue_short_id
+        - actions
+      type: object
+    DigestResponseBody:
+      additionalProperties: false
+      properties:
+        actors:
+          items:
+            $ref: "#/components/schemas/DigestActorEntry"
+          type:
+            - array
+            - "null"
+        event_count:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        since:
+          format: date-time
+          type: string
+        totals:
+          $ref: "#/components/schemas/DigestTotals"
+        until:
+          format: date-time
+          type: string
+      required:
+        - since
+        - until
+        - project_id
+        - event_count
+        - totals
+        - actors
+      type: object
+    DigestTotals:
+      additionalProperties: false
+      properties:
+        assigned:
+          format: int64
+          type: integer
+        closed:
+          format: int64
+          type: integer
+        commented:
+          format: int64
+          type: integer
+        created:
+          format: int64
+          type: integer
+        deleted:
+          format: int64
+          type: integer
+        edited:
+          format: int64
+          type: integer
+        labeled:
+          format: int64
+          type: integer
+        linked:
+          format: int64
+          type: integer
+        other:
+          format: int64
+          type: integer
+        priority_cleared:
+          format: int64
+          type: integer
+        priority_set:
+          format: int64
+          type: integer
+        reopened:
+          format: int64
+          type: integer
+        restored:
+          format: int64
+          type: integer
+        unassigned:
+          format: int64
+          type: integer
+        unblocked:
+          format: int64
+          type: integer
+        unlabeled:
+          format: int64
+          type: integer
+        unlinked:
+          format: int64
+          type: integer
+      required:
+        - created
+        - closed
+        - reopened
+        - commented
+        - edited
+        - assigned
+        - unassigned
+        - priority_set
+        - priority_cleared
+        - labeled
+        - unlabeled
+        - linked
+        - unlinked
+        - unblocked
+        - deleted
+        - restored
+        - other
+      type: object
+    EditIssueRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        body:
+          type: string
+        clear_priority:
+          type: boolean
+        links_delta:
+          $ref: "#/components/schemas/LinksDelta"
+        owner:
+          type: string
+        set_priority:
+          format: int64
+          type: integer
+        title:
+          type: string
+      required:
+        - actor
+      type: object
+    EditIssueResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        changes:
+          $ref: "#/components/schemas/LinkChanges"
+        event:
+          $ref: "#/components/schemas/Event"
+        events:
+          items:
+            $ref: "#/components/schemas/Event"
+          type:
+            - array
+            - "null"
+        issue:
+          $ref: "#/components/schemas/Issue"
+      required:
+        - issue
+        - event
+        - changed
+      type: object
+    EnableProjectFederationRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+      type: object
+    ErrorBody:
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+        data:
+          additionalProperties: {}
+          type: object
+        hint:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
+      type: object
+    ErrorEnvelope:
+      additionalProperties: false
+      properties:
+        error:
+          $ref: "#/components/schemas/ErrorBody"
+        status:
+          format: int64
+          type: integer
+      required:
+        - status
+        - error
+      type: object
+    Event:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        content_hash:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        hlc_counter:
+          format: int64
+          type: integer
+        hlc_physical_ms:
+          format: int64
+          type: integer
+        id:
+          format: int64
+          type: integer
+        issue_id:
+          format: int64
+          type: integer
+        issue_short_id:
+          type: string
+        issue_uid:
+          type: string
+        origin_instance_uid:
+          type: string
+        payload:
+          type: string
+        project_id:
+          format: int64
+          type: integer
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        related_issue_id:
+          format: int64
+          type: integer
+        related_issue_short_id:
+          type: string
+        related_issue_uid:
+          type: string
+        type:
+          type: string
+        uid:
+          type: string
+      required:
+        - id
+        - uid
+        - origin_instance_uid
+        - project_id
+        - project_uid
+        - project_name
+        - type
+        - actor
+        - payload
+        - hlc_physical_ms
+        - hlc_counter
+        - content_hash
+        - created_at
+      type: object
+    EventEnvelope:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        content_hash:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        event_id:
+          format: int64
+          type: integer
+        event_uid:
+          type: string
+        hlc_counter:
+          format: int64
+          type: integer
+        hlc_physical_ms:
+          format: int64
+          type: integer
+        issue_id:
+          format: int64
+          type: integer
+        issue_short_id:
+          type: string
+        issue_uid:
+          type: string
+        origin_instance_uid:
+          type: string
+        payload: {}
+        project_id:
+          format: int64
+          type: integer
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        related_issue_id:
+          format: int64
+          type: integer
+        related_issue_short_id:
+          type: string
+        related_issue_uid:
+          type: string
+        type:
+          type: string
+      required:
+        - event_id
+        - event_uid
+        - origin_instance_uid
+        - type
+        - project_id
+        - project_uid
+        - project_name
+        - actor
+        - hlc_physical_ms
+        - hlc_counter
+        - content_hash
+        - created_at
+      type: object
+    Evidence:
+      additionalProperties: false
+      properties:
+        command:
+          type: string
+        issue_ref:
+          type: string
+        paths:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        rationale:
+          type: string
+        sha:
+          type: string
+        type:
+          type: string
+        url:
+          type: string
+      required:
+        - type
+      type: object
+    FederationBindingOut:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        enabled:
+          type: boolean
+        hub_project_id:
+          format: int64
+          type: integer
+        hub_project_uid:
+          type: string
+        hub_url:
+          type: string
+        last_sync_at:
+          format: date-time
+          type: string
+        project_id:
+          format: int64
+          type: integer
+        pull_cursor_event_id:
+          format: int64
+          type: integer
+        push_cursor_event_id:
+          format: int64
+          type: integer
+        push_enabled:
+          type: boolean
+        replay_horizon_event_id:
+          format: int64
+          type: integer
+        role:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - project_id
+        - role
+        - hub_url
+        - hub_project_id
+        - hub_project_uid
+        - replay_horizon_event_id
+        - pull_cursor_event_id
+        - push_enabled
+        - push_cursor_event_id
+        - enabled
+        - created_at
+        - updated_at
+      type: object
+    FederationEnrollmentOut:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        capabilities:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type:
+            - integer
+            - "null"
+        revoked_at:
+          format: date-time
+          type: string
+        spoke_instance_uid:
+          type: string
+        token:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - id
+        - spoke_instance_uid
+        - project_id
+        - capabilities
+        - actor
+        - created_at
+        - updated_at
+      type: object
+    FederationIngestEventEnvelope:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        content_hash:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        event_id:
+          format: int64
+          type: integer
+        event_uid:
+          type: string
+        hlc_counter:
+          format: int64
+          type: integer
+        hlc_physical_ms:
+          format: int64
+          type: integer
+        issue_uid:
+          type: string
+        origin_instance_uid:
+          type: string
+        payload: {}
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        related_issue_uid:
+          type: string
+        type:
+          type: string
+      required:
+        - event_id
+        - event_uid
+        - origin_instance_uid
+        - project_uid
+        - project_name
+        - type
+        - actor
+        - hlc_physical_ms
+        - hlc_counter
+        - content_hash
+        - created_at
+      type: object
+    FederationIngestEventsBody:
+      additionalProperties: false
+      properties:
+        accepted:
+          format: int64
+          type: integer
+        duplicates:
+          format: int64
+          type: integer
+        push_cursor_event_id:
+          format: int64
+          type: integer
+      required:
+        - accepted
+        - duplicates
+        - push_cursor_event_id
+      type: object
+    FederationIngestEventsRequestBody:
+      additionalProperties: false
+      properties:
+        events:
+          items:
+            $ref: "#/components/schemas/FederationIngestEventEnvelope"
+          type:
+            - array
+            - "null"
+        schema_version:
+          format: int64
+          type: integer
+      required:
+        - schema_version
+      type: object
+    FederationProjectStatus:
+      additionalProperties: false
+      properties:
+        active_quarantine_count:
+          format: int64
+          type: integer
+        active_quarantines:
+          items:
+            $ref: "#/components/schemas/FederationQuarantineSummary"
+          type:
+            - array
+            - "null"
+        allow_insecure:
+          type: boolean
+        bound_actor:
+          type: string
+        capabilities:
+          type: string
+        credential_status:
+          type: string
+        enabled:
+          type: boolean
+        enrollment_count:
+          format: int64
+          type: integer
+        hub_project_id:
+          format: int64
+          type: integer
+        hub_project_uid:
+          type: string
+        hub_url:
+          type: string
+        last_error:
+          type: string
+        last_error_at:
+          format: date-time
+          type: string
+        last_pull_started_at:
+          format: date-time
+          type: string
+        last_pull_success_at:
+          format: date-time
+          type: string
+        last_push_started_at:
+          format: date-time
+          type: string
+        last_push_success_at:
+          format: date-time
+          type: string
+        last_reset_at:
+          format: date-time
+          type: string
+        last_successful_sync_at:
+          format: date-time
+          type: string
+        last_sync_at:
+          format: date-time
+          type: string
+        live_claim_count:
+          format: int64
+          type: integer
+        pending_claim_count:
+          format: int64
+          type: integer
+        pending_push_count:
+          format: int64
+          type: integer
+        pending_push_high_water_event_id:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        pull_cursor_event_id:
+          format: int64
+          type: integer
+        push_cursor_event_id:
+          format: int64
+          type: integer
+        push_enabled:
+          type: boolean
+        recent_violation_count:
+          format: int64
+          type: integer
+        recent_violations:
+          items:
+            $ref: "#/components/schemas/FederationViolationSummary"
+          type:
+            - array
+            - "null"
+        reset_blocker:
+          type: string
+        role:
+          type: string
+        unresolved_violation_count:
+          format: int64
+          type: integer
+      required:
+        - project_id
+        - project_uid
+        - project_name
+        - role
+        - enabled
+        - push_enabled
+        - pull_cursor_event_id
+        - push_cursor_event_id
+        - pending_push_count
+        - pending_push_high_water_event_id
+        - enrollment_count
+        - live_claim_count
+        - pending_claim_count
+        - active_quarantine_count
+        - active_quarantines
+        - unresolved_violation_count
+        - recent_violation_count
+        - recent_violations
+      type: object
+    FederationQuarantineSummary:
+      additionalProperties: false
+      properties:
+        created_at:
+          format: date-time
+          type: string
+        direction:
+          type: string
+        error:
+          type: string
+        event_uids:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        first_event_id:
+          format: int64
+          type: integer
+        id:
+          format: int64
+          type: integer
+        last_event_id:
+          format: int64
+          type: integer
+      required:
+        - id
+        - direction
+        - first_event_id
+        - last_event_id
+        - event_uids
+        - error
+        - created_at
+      type: object
+    FederationStatusBody:
+      additionalProperties: false
+      properties:
+        statuses:
+          items:
+            $ref: "#/components/schemas/FederationProjectStatus"
+          type:
+            - array
+            - "null"
+      required:
+        - statuses
+      type: object
+    FederationViolationSummary:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        at:
+          format: date-time
+          type: string
+        event_id:
+          format: int64
+          type: integer
+        event_uid:
+          type: string
+        issue_uid:
+          type: string
+        offending_event_type:
+          type: string
+        offending_event_uid:
+          type: string
+        offending_origin_instance_uid:
+          type: string
+        reason:
+          type: string
+        short_id:
+          type: string
+      required:
+        - event_id
+        - event_uid
+        - issue_uid
+        - at
+      type: object
+    HealthResponseBody:
+      additionalProperties: false
+      properties:
+        db_path:
+          type: string
+        ok:
+          type: boolean
+        schema_version:
+          format: int64
+          type: integer
+        started_at:
+          format: date-time
+          type: string
+        uptime:
+          type: string
+        version:
+          type: string
+      required:
+        - ok
+        - db_path
+        - schema_version
+        - version
+        - uptime
+        - started_at
+      type: object
+    ImportBatchResult:
+      additionalProperties: false
+      properties:
+        comments:
+          format: int64
+          type: integer
+        created:
+          format: int64
+          type: integer
+        errors:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        items:
+          items:
+            $ref: "#/components/schemas/ImportItemResult"
+          type:
+            - array
+            - "null"
+        links:
+          format: int64
+          type: integer
+        source:
+          type: string
+        unchanged:
+          format: int64
+          type: integer
+        updated:
+          format: int64
+          type: integer
+      required:
+        - source
+        - created
+        - updated
+        - unchanged
+        - comments
+        - links
+        - items
+        - errors
+      type: object
+    ImportCommentInput:
+      additionalProperties: false
+      properties:
+        author:
+          type: string
+        body:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        external_id:
+          type: string
+      required:
+        - external_id
+        - author
+        - body
+        - created_at
+      type: object
+    ImportIssueInput:
+      additionalProperties: false
+      properties:
+        author:
+          type: string
+        body:
+          type: string
+        closed_at:
+          format: date-time
+          type: string
+        closed_reason:
+          enum:
+            - done
+            - wontfix
+            - duplicate
+            - superseded
+            - audit-no-change
+            - ""
+          type: string
+        comments:
+          items:
+            $ref: "#/components/schemas/ImportCommentInput"
+          type:
+            - array
+            - "null"
+        created_at:
+          format: date-time
+          type: string
+        external_id:
+          type: string
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        links:
+          items:
+            $ref: "#/components/schemas/ImportLinkInput"
+          type:
+            - array
+            - "null"
+        owner:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        status:
+          enum:
+            - open
+            - closed
+          type: string
+        title:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - external_id
+        - title
+        - author
+        - status
+        - created_at
+        - updated_at
+      type: object
+    ImportItemResult:
+      additionalProperties: false
+      properties:
+        external_id:
+          type: string
+        issue_short_id:
+          type: string
+        reason:
+          type: string
+        status:
+          type: string
+      required:
+        - external_id
+        - issue_short_id
+        - status
+      type: object
+    ImportLinkInput:
+      additionalProperties: false
+      properties:
+        target_external_id:
+          type: string
+        type:
+          enum:
+            - parent
+            - blocks
+            - related
+          type: string
+      required:
+        - type
+        - target_external_id
+      type: object
+    ImportRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        items:
+          items:
+            $ref: "#/components/schemas/ImportIssueInput"
+          type:
+            - array
+            - "null"
+        source:
+          type: string
+      required:
+        - actor
+        - source
+        - items
+      type: object
+    InitProjectRequestBody:
+      additionalProperties: false
+      properties:
+        alias:
+          $ref: "#/components/schemas/AliasInput"
+          description: client-derived alias metadata; only honored when start_path is empty
+        name:
+          description: project name; required when start_path is empty
+          type: string
+        reassign:
+          type: boolean
+        replace:
+          type: boolean
+        start_path:
+          description: absolute path on the daemon's filesystem; omit for path-free init
+          type: string
+      type: object
+    InitProjectResponseBody:
+      additionalProperties: false
+      properties:
+        alias:
+          $ref: "#/components/schemas/ProjectAlias"
+        created:
+          type: boolean
+        project:
+          $ref: "#/components/schemas/ProjectOut"
+        workspace_root:
+          type: string
+      required:
+        - created
+        - project
+        - alias
+      type: object
+    InstanceResponseBody:
+      additionalProperties: false
+      properties:
+        auth:
+          $ref: "#/components/schemas/AuthInfoOut"
+        instance_uid:
+          type: string
+        schema_version:
+          format: int64
+          type: integer
+        version:
+          type: string
+      required:
+        - instance_uid
+        - version
+        - schema_version
+        - auth
+      type: object
+    Issue:
+      additionalProperties: false
+      properties:
+        author:
+          type: string
+        body:
+          type: string
+        closed_at:
+          format: date-time
+          type: string
+        closed_reason:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        metadata:
+          type: string
+        occurrence_key:
+          type: string
+        owner:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        project_uid:
+          type: string
+        recurrence_id:
+          format: int64
+          type: integer
+        revision:
+          format: int64
+          type: integer
+        short_id:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - id
+        - uid
+        - project_id
+        - short_id
+        - title
+        - body
+        - status
+        - author
+        - metadata
+        - revision
+        - created_at
+        - updated_at
+      type: object
+    IssueClaimOut:
+      additionalProperties: false
+      properties:
+        acquired_at:
+          format: date-time
+          type: string
+        claim_kind:
+          type: string
+        claim_uid:
+          type: string
+        client_kind:
+          type: string
+        expires_at:
+          format: date-time
+          type: string
+        holder:
+          type: string
+        holder_instance_uid:
+          type: string
+        issue_uid:
+          type: string
+        project_id:
+          format: int64
+          type: integer
+        purpose:
+          type: string
+        release_reason:
+          type: string
+        released_at:
+          format: date-time
+          type: string
+        revision:
+          format: int64
+          type: integer
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - claim_uid
+        - project_id
+        - issue_uid
+        - holder
+        - holder_instance_uid
+        - client_kind
+        - purpose
+        - claim_kind
+        - acquired_at
+        - revision
+        - updated_at
+      type: object
+    IssueLabel:
+      additionalProperties: false
+      properties:
+        author:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        issue_id:
+          format: int64
+          type: integer
+        label:
+          type: string
+      required:
+        - issue_id
+        - label
+        - author
+        - created_at
+      type: object
+    IssueOut:
+      additionalProperties: false
+      properties:
+        author:
+          type: string
+        blocked_by:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        blocks:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        body:
+          type: string
+        child_counts:
+          $ref: "#/components/schemas/ChildCounts"
+        closed_at:
+          format: date-time
+          type: string
+        closed_reason:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        metadata:
+          type: string
+        occurrence_key:
+          type: string
+        owner:
+          type: string
+        parent_short_id:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        project_uid:
+          type: string
+        qualified_id:
+          type: string
+        recurrence_id:
+          format: int64
+          type: integer
+        related:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        revision:
+          format: int64
+          type: integer
+        short_id:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - qualified_id
+        - id
+        - uid
+        - project_id
+        - short_id
+        - title
+        - body
+        - status
+        - author
+        - metadata
+        - revision
+        - created_at
+        - updated_at
+      type: object
+    IssueRef:
+      additionalProperties: false
+      properties:
+        qualified_id:
+          type: string
+        short_id:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+      required:
+        - uid
+        - short_id
+        - qualified_id
+        - title
+        - status
+      type: object
+    LabelCount:
+      additionalProperties: false
+      properties:
+        count:
+          format: int64
+          type: integer
+        label:
+          type: string
+      required:
+        - label
+        - count
+      type: object
+    LabelsListResponseBody:
+      additionalProperties: false
+      properties:
+        labels:
+          items:
+            $ref: "#/components/schemas/LabelCount"
+          type:
+            - array
+            - "null"
+      required:
+        - labels
+      type: object
+    LinkChanges:
+      additionalProperties: false
+      properties:
+        blocked_by_added:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        blocked_by_removed:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        blocks_added:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        blocks_removed:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        parent_removed:
+          $ref: "#/components/schemas/LinkPeer"
+        parent_set:
+          $ref: "#/components/schemas/LinkPeer"
+        related_added:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        related_removed:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+      type: object
+    LinkOut:
+      additionalProperties: false
+      properties:
+        author:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        from:
+          $ref: "#/components/schemas/LinkPeer"
+        id:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        to:
+          $ref: "#/components/schemas/LinkPeer"
+        type:
+          type: string
+      required:
+        - id
+        - project_id
+        - from
+        - to
+        - type
+        - author
+        - created_at
+      type: object
+    LinkPeer:
+      additionalProperties: false
+      properties:
+        short_id:
+          type: string
+        uid:
+          type: string
+      required:
+        - uid
+        - short_id
+      type: object
+    LinksDelta:
+      additionalProperties: false
+      properties:
+        add_blocked_by:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        add_blocks:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        add_related:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        remove_blocked_by:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        remove_blocks:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        remove_parent:
+          type: string
+        remove_related:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        set_parent:
+          type: string
+      type: object
+    ListFederationEnrollmentsBody:
+      additionalProperties: false
+      properties:
+        enrollments:
+          items:
+            $ref: "#/components/schemas/FederationEnrollmentOut"
+          type:
+            - array
+            - "null"
+      required:
+        - enrollments
+      type: object
+    ListIssuesResponseBody:
+      additionalProperties: false
+      properties:
+        issues:
+          items:
+            $ref: "#/components/schemas/IssueOut"
+          type:
+            - array
+            - "null"
+      required:
+        - issues
+      type: object
+    ListProjectsResponseBody:
+      additionalProperties: false
+      properties:
+        projects:
+          items:
+            $ref: "#/components/schemas/ProjectOut"
+          type:
+            - array
+            - "null"
+      required:
+        - projects
+      type: object
+    ListRecurrencesResponseBody:
+      additionalProperties: false
+      properties:
+        recurrences:
+          items:
+            $ref: "#/components/schemas/Recurrence"
+          type:
+            - array
+            - "null"
+      required:
+        - recurrences
+      type: object
+    ListTokensResponseBody:
+      additionalProperties: false
+      properties:
+        tokens:
+          items:
+            $ref: "#/components/schemas/TokenOut"
+          type:
+            - array
+            - "null"
+      required:
+        - tokens
+      type: object
+    MergeProjectRequestBody:
+      additionalProperties: false
+      properties:
+        source_project_id:
+          format: int64
+          type: integer
+        target_name:
+          type: string
+      required:
+        - source_project_id
+      type: object
+    MergeProjectResultOut:
+      additionalProperties: false
+      properties:
+        aliases_moved:
+          format: int64
+          type: integer
+        events_moved:
+          format: int64
+          type: integer
+        issues_moved:
+          format: int64
+          type: integer
+        purge_logs_moved:
+          format: int64
+          type: integer
+        short_id_extensions:
+          items:
+            $ref: "#/components/schemas/MergeShortIDExtension"
+          type:
+            - array
+            - "null"
+        source:
+          $ref: "#/components/schemas/ProjectOut"
+        target:
+          $ref: "#/components/schemas/ProjectOut"
+      required:
+        - source
+        - target
+        - issues_moved
+        - aliases_moved
+        - events_moved
+        - purge_logs_moved
+      type: object
+    MergeShortIDExtension:
+      additionalProperties: false
+      properties:
+        post_merge_short_id:
+          type: string
+        pre_merge_short_id:
+          type: string
+        uid:
+          type: string
+      required:
+        - uid
+        - pre_merge_short_id
+        - post_merge_short_id
+      type: object
+    MoveIssueRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        to_project_uid:
+          type: string
+      required:
+        - actor
+        - to_project_uid
+      type: object
+    MoveIssueResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        event_id:
+          format: int64
+          type: integer
+        issue:
+          $ref: "#/components/schemas/Issue"
+        new_short_id:
+          type: string
+      required:
+        - issue
+        - event_id
+        - new_short_id
+        - changed
+      type: object
+    MutationResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        event:
+          $ref: "#/components/schemas/Event"
+        issue:
+          $ref: "#/components/schemas/Issue"
+        original_event:
+          $ref: "#/components/schemas/Event"
+        reused:
+          type: boolean
+      required:
+        - issue
+        - event
+        - changed
+      type: object
+    PatchIssueMetadataRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        patch:
+          additionalProperties: {}
+          type: object
+      required:
+        - actor
+        - patch
+      type: object
+    PatchIssueMetadataResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        event:
+          $ref: "#/components/schemas/Event"
+        issue:
+          $ref: "#/components/schemas/Issue"
+      required:
+        - issue
+        - changed
+      type: object
+    PatchProjectMetadataRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        patch:
+          additionalProperties: {}
+          type: object
+      required:
+        - actor
+        - patch
+      type: object
+    PatchProjectMetadataResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        event:
+          $ref: "#/components/schemas/Event"
+        project:
+          $ref: "#/components/schemas/Project"
+      required:
+        - project
+        - changed
+      type: object
+    PatchRecurrenceRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        dtstart:
+          type: string
+        rrule:
+          type: string
+        template:
+          $ref: "#/components/schemas/RecurrenceTemplateUpdateInput"
+        timezone:
+          type: string
+      required:
+        - actor
+      type: object
+    PatchRecurrenceResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        recurrence:
+          $ref: "#/components/schemas/Recurrence"
+      required:
+        - recurrence
+        - changed
+      type: object
+    PendingClaimOut:
+      additionalProperties: false
+      properties:
+        claim_kind:
+          type: string
+        client_kind:
+          type: string
+        holder:
+          type: string
+        holder_instance_uid:
+          type: string
+        last_attempt_at:
+          format: date-time
+          type: string
+        last_error:
+          type: string
+        purpose:
+          type: string
+        request_uid:
+          type: string
+        requested_at:
+          format: date-time
+          type: string
+        ttl_seconds:
+          format: int64
+          type: integer
+      required:
+        - request_uid
+        - holder
+        - holder_instance_uid
+        - client_kind
+        - claim_kind
+        - requested_at
+      type: object
+    PingResponseBody:
+      additionalProperties: false
+      properties:
+        ok:
+          type: boolean
+        pid:
+          format: int64
+          type: integer
+        service:
+          type: string
+        version:
+          type: string
+      required:
+        - ok
+        - service
+        - version
+      type: object
+    PollEventsBody:
+      additionalProperties: false
+      properties:
+        events:
+          items:
+            $ref: "#/components/schemas/EventEnvelope"
+          type:
+            - array
+            - "null"
+        next_after_id:
+          format: int64
+          type: integer
+        reset_after_id:
+          format: int64
+          type: integer
+        reset_required:
+          type: boolean
+      required:
+        - reset_required
+        - events
+        - next_after_id
+      type: object
+    PriorityRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        priority:
+          format: int64
+          type: integer
+      required:
+        - actor
+      type: object
+    Project:
+      additionalProperties: false
+      properties:
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        metadata:
+          type: string
+        name:
+          type: string
+        revision:
+          format: int64
+          type: integer
+        uid:
+          type: string
+      required:
+        - id
+        - uid
+        - name
+        - metadata
+        - revision
+        - created_at
+      type: object
+    ProjectAlias:
+      additionalProperties: false
+      properties:
+        alias_identity:
+          type: string
+        alias_kind:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+      required:
+        - id
+        - project_id
+        - alias_identity
+        - alias_kind
+        - created_at
+      type: object
+    ProjectFederationBody:
+      additionalProperties: false
+      properties:
+        baseline_through_event_id:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        replay_horizon_event_id:
+          format: int64
+          type: integer
+      required:
+        - project_id
+        - project_uid
+        - project_name
+        - replay_horizon_event_id
+        - baseline_through_event_id
+      type: object
+    ProjectOut:
+      additionalProperties: false
+      properties:
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        metadata:
+          type: string
+        name:
+          type: string
+        revision:
+          format: int64
+          type: integer
+        stats:
+          $ref: "#/components/schemas/ProjectStatsOut"
+        uid:
+          type: string
+      required:
+        - id
+        - uid
+        - name
+        - metadata
+        - revision
+        - created_at
+      type: object
+    ProjectResolveBody:
+      additionalProperties: false
+      properties:
+        alias:
+          $ref: "#/components/schemas/ProjectAlias"
+        project:
+          $ref: "#/components/schemas/ProjectOut"
+        workspace_root:
+          type: string
+      required:
+        - project
+        - alias
+      type: object
+    ProjectStatsOut:
+      additionalProperties: false
+      properties:
+        closed:
+          format: int64
+          type: integer
+        last_event_at:
+          format: date-time
+          type:
+            - string
+            - "null"
+        open:
+          format: int64
+          type: integer
+      required:
+        - open
+        - closed
+        - last_event_at
+      type: object
+    PurgeLog:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        comment_count:
+          format: int64
+          type: integer
+        event_count:
+          format: int64
+          type: integer
+        events_deleted_max_id:
+          format: int64
+          type: integer
+        events_deleted_min_id:
+          format: int64
+          type: integer
+        id:
+          format: int64
+          type: integer
+        issue_author:
+          type: string
+        issue_title:
+          type: string
+        issue_uid:
+          type: string
+        label_count:
+          format: int64
+          type: integer
+        link_count:
+          format: int64
+          type: integer
+        origin_instance_uid:
+          type: string
+        project_id:
+          format: int64
+          type: integer
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        purge_reset_after_event_id:
+          format: int64
+          type: integer
+        purged_at:
+          format: date-time
+          type: string
+        purged_issue_id:
+          format: int64
+          type: integer
+        reason:
+          type: string
+        short_id:
+          type: string
+        uid:
+          type: string
+      required:
+        - id
+        - uid
+        - origin_instance_uid
+        - project_id
+        - purged_issue_id
+        - project_name
+        - issue_title
+        - issue_author
+        - comment_count
+        - link_count
+        - label_count
+        - event_count
+        - actor
+        - purged_at
+      type: object
+    PurgeResponseBody:
+      additionalProperties: false
+      properties:
+        purge_log:
+          $ref: "#/components/schemas/PurgeLog"
+      required:
+        - purge_log
+      type: object
+    ReadyGlobalIssue:
+      additionalProperties: false
+      properties:
+        author:
+          type: string
+        body:
+          type: string
+        closed_at:
+          format: date-time
+          type: string
+        closed_reason:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        metadata:
+          type: string
+        occurrence_key:
+          type: string
+        owner:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        recurrence_id:
+          format: int64
+          type: integer
+        revision:
+          format: int64
+          type: integer
+        short_id:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - project_name
+        - id
+        - uid
+        - project_id
+        - short_id
+        - title
+        - body
+        - status
+        - author
+        - metadata
+        - revision
+        - created_at
+        - updated_at
+      type: object
+    ReadyGlobalResponseBody:
+      additionalProperties: false
+      properties:
+        issues:
+          items:
+            $ref: "#/components/schemas/ReadyGlobalIssue"
+          type:
+            - array
+            - "null"
+      required:
+        - issues
+      type: object
+    ReadyResponseBody:
+      additionalProperties: false
+      properties:
+        issues:
+          items:
+            $ref: "#/components/schemas/Issue"
+          type:
+            - array
+            - "null"
+      required:
+        - issues
+      type: object
+    Recurrence:
+      additionalProperties: false
+      properties:
+        author:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        dtstart:
+          type: string
+        id:
+          format: int64
+          type: integer
+        last_materialized_uid:
+          type: string
+        next_occurrence_key:
+          type: string
+        project_id:
+          format: int64
+          type: integer
+        revision:
+          format: int64
+          type: integer
+        rrule:
+          type: string
+        template_body:
+          type: string
+        template_labels:
+          type: string
+        template_metadata:
+          type: string
+        template_owner:
+          type: string
+        template_priority:
+          format: int64
+          type: integer
+        template_title:
+          type: string
+        timezone:
+          type: string
+        uid:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - id
+        - uid
+        - project_id
+        - rrule
+        - dtstart
+        - timezone
+        - template_title
+        - template_body
+        - template_labels
+        - template_metadata
+        - author
+        - revision
+        - created_at
+        - updated_at
+      type: object
+    RecurrenceTemplateInput:
+      additionalProperties: false
+      properties:
+        body:
+          type: string
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        metadata: {}
+        owner:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        title:
+          type: string
+      required:
+        - title
+      type: object
+    RecurrenceTemplateUpdateInput:
+      additionalProperties: false
+      properties:
+        body:
+          type: string
+        labels:
+          items:
+            type: string
+          type: array
+        metadata: {}
+        owner:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        title:
+          type: string
+      type: object
+    RemoveProjectResponseBody:
+      additionalProperties: false
+      properties:
+        event:
+          $ref: "#/components/schemas/Event"
+        project:
+          $ref: "#/components/schemas/ProjectOut"
+      required:
+        - project
+        - event
+      type: object
+    RenameProjectRequestBody:
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+      required:
+        - name
+      type: object
+    ResolveProjectRequestBody:
+      additionalProperties: false
+      properties:
+        alias:
+          $ref: "#/components/schemas/AliasInput"
+          description: client-derived alias metadata; daemon resolves alias first, then falls back to name
+        name:
+          description: project name; required for first-seen alias attach
+          type: string
+        start_path:
+          description: absolute path to resolve from (daemon-side filesystem); legacy local-only fallback
+          type: string
+      type: object
+    RestoreProjectResponseBody:
+      additionalProperties: false
+      properties:
+        changed:
+          type: boolean
+        event:
+          $ref: "#/components/schemas/Event"
+        project:
+          $ref: "#/components/schemas/ProjectOut"
+      required:
+        - project
+        - event
+        - changed
+      type: object
+    RestoreRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+      required:
+        - actor
+      type: object
+    RevokeFederationEnrollmentBody:
+      additionalProperties: false
+      properties:
+        id:
+          format: int64
+          type: integer
+        revoked:
+          type: boolean
+      required:
+        - id
+        - revoked
+      type: object
+    RevokeTokenResponseBody:
+      additionalProperties: false
+      properties:
+        event:
+          $ref: "#/components/schemas/Event"
+        token:
+          $ref: "#/components/schemas/TokenOut"
+      required:
+        - token
+        - event
+      type: object
+    SearchHit:
+      additionalProperties: false
+      properties:
+        issue:
+          $ref: "#/components/schemas/Issue"
+        matched_in:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        score:
+          format: double
+          type: number
+      required:
+        - issue
+        - score
+        - matched_in
+      type: object
+    SearchResponseBody:
+      additionalProperties: false
+      properties:
+        query:
+          type: string
+        results:
+          items:
+            $ref: "#/components/schemas/SearchHit"
+          type:
+            - array
+            - "null"
+      required:
+        - query
+        - results
+      type: object
+    ShowIssueResponseBody:
+      additionalProperties: false
+      properties:
+        children:
+          items:
+            $ref: "#/components/schemas/IssueOut"
+          type:
+            - array
+            - "null"
+        claim:
+          $ref: "#/components/schemas/IssueClaimOut"
+        claim_hub_now:
+          format: date-time
+          type: string
+        claim_violation_count:
+          format: int64
+          type: integer
+        claim_violations:
+          items:
+            $ref: "#/components/schemas/ClaimViolationOut"
+          type:
+            - array
+            - "null"
+        comments:
+          items:
+            $ref: "#/components/schemas/Comment"
+          type:
+            - array
+            - "null"
+        issue:
+          $ref: "#/components/schemas/Issue"
+        labels:
+          items:
+            $ref: "#/components/schemas/IssueLabel"
+          type:
+            - array
+            - "null"
+        lease:
+          $ref: "#/components/schemas/IssueClaimOut"
+        lease_hub_now:
+          format: date-time
+          type: string
+        lease_violation_count:
+          format: int64
+          type: integer
+        lease_violations:
+          items:
+            $ref: "#/components/schemas/ClaimViolationOut"
+          type:
+            - array
+            - "null"
+        links:
+          items:
+            $ref: "#/components/schemas/LinkOut"
+          type:
+            - array
+            - "null"
+        parent:
+          $ref: "#/components/schemas/IssueRef"
+        pending_claims:
+          items:
+            $ref: "#/components/schemas/PendingClaimOut"
+          type:
+            - array
+            - "null"
+        pending_leases:
+          items:
+            $ref: "#/components/schemas/PendingClaimOut"
+          type:
+            - array
+            - "null"
+      required:
+        - issue
+        - comments
+        - links
+        - labels
+      type: object
+    ShowProjectResponseBody:
+      additionalProperties: false
+      properties:
+        aliases:
+          items:
+            $ref: "#/components/schemas/ProjectAlias"
+          type:
+            - array
+            - "null"
+        project:
+          $ref: "#/components/schemas/ProjectOut"
+      required:
+        - project
+        - aliases
+      type: object
+    ShowRecurrenceResponseBody:
+      additionalProperties: false
+      properties:
+        recurrence:
+          $ref: "#/components/schemas/Recurrence"
+      required:
+        - recurrence
+      type: object
+    SkipFederationQuarantineRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        reason:
+          type: string
+      required:
+        - actor
+      type: object
+    TokenOut:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        last_used_at:
+          format: date-time
+          type:
+            - string
+            - "null"
+        name:
+          type:
+            - string
+            - "null"
+        revoked_at:
+          format: date-time
+          type:
+            - string
+            - "null"
+      required:
+        - id
+        - actor
+        - name
+        - created_at
+        - last_used_at
+        - revoked_at
+      type: object
+    UnassignRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+      required:
+        - actor
+      type: object
+info:
+  title: kata
+  version: 0.1.0
+openapi: 3.1.0
+paths:
+  /api/v1/audit/closes:
+    get:
+      operationId: auditCloses
+      parameters:
+        - explode: false
+          in: query
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: "RFC3339 timestamp (default: zero time)"
+          explode: false
+          in: query
+          name: since
+          schema:
+            description: "RFC3339 timestamp (default: zero time)"
+            type: string
+        - description: "RFC3339 timestamp (default: now)"
+          explode: false
+          in: query
+          name: until
+          schema:
+            description: "RFC3339 timestamp (default: now)"
+            type: string
+        - explode: false
+          in: query
+          name: actor
+          schema:
+            type: string
+        - description: filter to closes of children of parent <ref>
+          explode: false
+          in: query
+          name: parent
+          schema:
+            description: filter to closes of children of parent <ref>
+            type: string
+        - explode: false
+          in: query
+          name: reason
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: no_evidence
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuditClosesResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/digest:
+    get:
+      operationId: digestGlobal
+      parameters:
+        - explode: false
+          in: query
+          name: since
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: until
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: actor
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DigestResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/events:
+    get:
+      operationId: pollEvents
+      parameters:
+        - explode: false
+          in: query
+          name: after_id
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollEventsBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/federation/enrollments:
+    get:
+      operationId: listFederationEnrollments
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListFederationEnrollmentsBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    post:
+      operationId: createFederationEnrollment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFederationEnrollmentRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FederationEnrollmentOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/federation/enrollments/{enrollment_id}/revoke:
+    post:
+      operationId: revokeFederationEnrollment
+      parameters:
+        - in: path
+          name: enrollment_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RevokeFederationEnrollmentBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/federation/replicas:
+    post:
+      operationId: createFederationReplica
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFederationReplicaRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateFederationReplicaBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/federation/status:
+    get:
+      operationId: getFederationStatus
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FederationStatusBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/health:
+    get:
+      operationId: health
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/instance:
+    get:
+      operationId: instance
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InstanceResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/issues:
+    get:
+      operationId: listAllIssues
+      parameters:
+        - explode: false
+          in: query
+          name: project_id
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: status
+          schema:
+            enum:
+              - open
+              - closed
+              - ""
+            type: string
+        - description: exact priority filter (0..4); empty = no filter
+          explode: false
+          in: query
+          name: priority
+          schema:
+            description: exact priority filter (0..4); empty = no filter
+            type: string
+        - description: include only priority <= this value (0..4); empty = no filter
+          explode: false
+          in: query
+          name: max_priority
+          schema:
+            description: include only priority <= this value (0..4); empty = no filter
+            type: string
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListIssuesResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/issues/{uid}:
+    get:
+      operationId: showIssueByUID
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: include_deleted
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ShowIssueResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/ping:
+    get:
+      operationId: ping
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PingResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects:
+    get:
+      operationId: listProjects
+      parameters:
+        - explode: false
+          in: query
+          name: include
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListProjectsResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    post:
+      operationId: initProject
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InitProjectRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InitProjectResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/resolve:
+    post:
+      operationId: resolveProject
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResolveProjectRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectResolveBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}:
+    delete:
+      operationId: removeProject
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: actor
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: force
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RemoveProjectResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    get:
+      operationId: showProject
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ShowProjectResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    patch:
+      operationId: renameProject
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RenameProjectRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ShowProjectResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/aliases/{alias_id}:
+    delete:
+      operationId: detachProjectAlias
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: alias_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: actor
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: force
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DetachProjectAliasResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/digest:
+    get:
+      operationId: digestProject
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: since
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: until
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: actor
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DigestResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/events:
+    get:
+      operationId: pollProjectEvents
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: after_id
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollEventsBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/federation:
+    get:
+      operationId: getProjectFederation
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectFederationBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/federation/enable:
+    post:
+      operationId: enableProjectFederation
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EnableProjectFederationRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectFederationBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/federation/events:
+    get:
+      operationId: pollFederationProjectEvents
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: after_id
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PollEventsBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/federation/events:ingest:
+    post:
+      operationId: ingestFederationProjectEvents
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FederationIngestEventsRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FederationIngestEventsBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/federation/metadata:
+    get:
+      operationId: getFederationProjectMetadata
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectFederationBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/federation/quarantine/{quarantine_id}/skip:
+    post:
+      operationId: skipFederationQuarantine
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: quarantine_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: header
+          name: X-Kata-Confirm
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SkipFederationQuarantineRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FederationQuarantineSummary"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/federation/status:
+    get:
+      operationId: getProjectFederationStatus
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FederationStatusBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/imports:
+    post:
+      operationId: importIssues
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportBatchResult"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues:
+    get:
+      operationId: listIssues
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: status
+          schema:
+            enum:
+              - open
+              - closed
+              - ""
+            type: string
+        - description: exact priority filter (0..4); empty = no filter
+          explode: false
+          in: query
+          name: priority
+          schema:
+            description: exact priority filter (0..4); empty = no filter
+            type: string
+        - description: include only priority <= this value (0..4); empty = no filter
+          explode: false
+          in: query
+          name: max_priority
+          schema:
+            description: include only priority <= this value (0..4); empty = no filter
+            type: string
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: unowned
+          schema:
+            type: boolean
+        - explode: false
+          in: query
+          name: owner
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: label
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+        - explode: false
+          in: query
+          name: exclude_label
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListIssuesResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    post:
+      operationId: createIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: header
+          name: Idempotency-Key
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateIssueRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}:
+    get:
+      operationId: showIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: include_deleted
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ShowIssueResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    patch:
+      operationId: editIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EditIssueRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EditIssueResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/assign:
+    post:
+      operationId: assignIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/claim:
+    post:
+      operationId: claimIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClaimRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/close:
+    post:
+      operationId: closeIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/delete:
+    post:
+      operationId: deleteIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: X-Kata-Confirm
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DestructiveActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/move:
+    post:
+      operationId: moveIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: If-Match
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveIssueRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MoveIssueResponseBody"
+          description: OK
+          headers:
+            ETag:
+              schema:
+                type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/priority:
+    post:
+      operationId: setIssuePriority
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PriorityRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/purge:
+    post:
+      operationId: purgeIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: X-Kata-Confirm
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DestructiveActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PurgeResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/reopen:
+    post:
+      operationId: reopenIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/restore:
+    post:
+      operationId: restoreIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestoreRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/actions/unassign:
+    post:
+      operationId: unassignIssue
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UnassignRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/comments:
+    post:
+      operationId: createComment
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommentRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommentResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/labels:
+    post:
+      operationId: addLabel
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddLabelRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AddLabelResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/labels/{label}:
+    delete:
+      operationId: removeLabel
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: label
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: actor
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/lease:
+    get:
+      operationId: getIssueLeaseStatus
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimStatusBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/lease/actions/acquire:
+    post:
+      operationId: acquireIssueLease
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClaimActionBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimActionResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/lease/actions/force_release:
+    post:
+      operationId: forceReleaseIssueLease
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClaimActionBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimActionResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/lease/actions/release:
+    post:
+      operationId: releaseIssueLease
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClaimActionBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimActionResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/lease/actions/renew:
+    post:
+      operationId: renewIssueLease
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClaimActionBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimActionResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/links:
+    post:
+      operationId: createLink
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateLinkRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateLinkResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/links/{link_id}:
+    delete:
+      operationId: deleteLink
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: link_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: actor
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/metadata:
+    post:
+      operationId: patchIssueMetadata
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: If-Match
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchIssueMetadataRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PatchIssueMetadataResponseBody"
+          description: OK
+          headers:
+            ETag:
+              schema:
+                type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/labels:
+    get:
+      operationId: listLabels
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LabelsListResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/merge:
+    post:
+      operationId: mergeProject
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MergeProjectRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MergeProjectResultOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/metadata:
+    post:
+      operationId: patchProjectMetadata
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: header
+          name: If-Match
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchProjectMetadataRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PatchProjectMetadataResponseBody"
+          description: OK
+          headers:
+            ETag:
+              schema:
+                type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/ready:
+    get:
+      operationId: readyIssues
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: unowned
+          schema:
+            type: boolean
+        - explode: false
+          in: query
+          name: owner
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: label
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+        - explode: false
+          in: query
+          name: exclude_label
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadyResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/recurrences:
+    get:
+      operationId: listRecurrences
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListRecurrencesResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    post:
+      operationId: createRecurrence
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRecurrenceRequestBody"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateRecurrenceResponseBody"
+          description: Created
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/recurrences/{recurrence_uid}:
+    delete:
+      operationId: deleteRecurrence
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: recurrence_uid
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: actor
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    get:
+      operationId: showRecurrence
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: recurrence_uid
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ShowRecurrenceResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    patch:
+      operationId: patchRecurrence
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: recurrence_uid
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: If-Match
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchRecurrenceRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PatchRecurrenceResponseBody"
+          description: OK
+          headers:
+            ETag:
+              schema:
+                type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/restore:
+    post:
+      operationId: restoreProject
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: actor
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestoreProjectResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/search:
+    get:
+      operationId: searchIssues
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: q
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+        - explode: false
+          in: query
+          name: include_deleted
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/ready:
+    get:
+      operationId: readyIssuesGlobal
+      parameters:
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadyGlobalResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/tokens:
+    get:
+      operationId: listTokens
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListTokensResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    post:
+      operationId: createToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTokenRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateTokenResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/tokens/{id}/actions/revoke:
+    post:
+      operationId: revokeToken
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RevokeTokenResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1578,7 +1578,8 @@ components:
           format: int64
           type: integer
         metadata:
-          type: string
+          additionalProperties: true
+          type: object
         occurrence_key:
           type: string
         owner:
@@ -1733,7 +1734,8 @@ components:
             - array
             - "null"
         metadata:
-          type: string
+          additionalProperties: true
+          type: object
         occurrence_key:
           type: string
         owner:
@@ -2299,7 +2301,8 @@ components:
           format: int64
           type: integer
         metadata:
-          type: string
+          additionalProperties: true
+          type: object
         name:
           type: string
         revision:
@@ -2374,7 +2377,8 @@ components:
           format: int64
           type: integer
         metadata:
-          type: string
+          additionalProperties: true
+          type: object
         name:
           type: string
         revision:
@@ -2526,7 +2530,8 @@ components:
           format: int64
           type: integer
         metadata:
-          type: string
+          additionalProperties: true
+          type: object
         occurrence_key:
           type: string
         owner:
@@ -2628,9 +2633,12 @@ components:
         template_body:
           type: string
         template_labels:
-          type: string
+          items:
+            type: string
+          type: array
         template_metadata:
-          type: string
+          additionalProperties: true
+          type: object
         template_owner:
           type: string
         template_priority:
@@ -2672,7 +2680,9 @@ components:
           type:
             - array
             - "null"
-        metadata: {}
+        metadata:
+          additionalProperties: true
+          type: object
         owner:
           type: string
         priority:
@@ -2692,7 +2702,9 @@ components:
           items:
             type: string
           type: array
-        metadata: {}
+        metadata:
+          additionalProperties: true
+          type: object
         owner:
           type: string
         priority:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3094,6 +3094,41 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
           description: Error
+  /api/v1/events/stream:
+    get:
+      description: Streams durable events as Server-Sent Events. Clients may resume with Last-Event-ID or after_id, but not both.
+      operationId: streamEvents
+      parameters:
+        - description: Exclusive event cursor. Mutually exclusive with Last-Event-ID.
+          in: query
+          name: after_id
+          schema:
+            type: integer
+        - description: Optional project ID filter. Omit to stream all visible project events.
+          in: query
+          name: project_id
+          schema:
+            type: integer
+        - description: Exclusive resume cursor from the last received SSE id. Mutually exclusive with after_id.
+          in: header
+          name: Last-Event-ID
+          schema:
+            type: integer
+      responses:
+        "200":
+          content:
+            text/event-stream:
+              schema:
+                description: UTF-8 Server-Sent Events frames containing event envelopes or sync.reset_required reset payloads.
+                type: string
+          description: Server-Sent Events stream.
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      summary: Stream events
   /api/v1/federation/enrollments:
     get:
       operationId: listFederationEnrollments

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2704,7 +2704,9 @@ components:
           type: array
         metadata:
           additionalProperties: true
-          type: object
+          type:
+            - object
+            - "null"
         owner:
           type: string
         priority:

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -105,6 +105,7 @@ func newRootCmd() *cobra.Command {
 		newQuickstartCmd(),
 		newWhoamiCmd(),
 		newHealthCmd(),
+		newOpenAPICmd(),
 		newProjectsCmd(),
 		newTokensCmd(),
 		newTUICmd(),

--- a/cmd/kata/openapi.go
+++ b/cmd/kata/openapi.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/kata/internal/daemon"
+)
+
+func newOpenAPICmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "openapi",
+		Short: "print the daemon's OpenAPI 3.1 schema (YAML)",
+		Long: `Print the daemon's OpenAPI 3.1 schema as YAML to stdout.
+
+The schema is generated in-process from the daemon's route definitions; it does
+not require a running daemon or a database. Redirect it to a file to generate a
+typed client or feed other tooling, e.g.:
+
+    kata openapi > openapi.yaml`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			doc, err := daemon.OpenAPIYAML()
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(doc)
+			return err
+		},
+	}
+}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -69,6 +70,16 @@ func (e *APIError) Envelope() ErrorEnvelope {
 // our wire shape rather than the framework default.
 func (e *APIError) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.Envelope())
+}
+
+// Schema implements huma.SchemaProvider so the generated OpenAPI document
+// describes error responses with the true wire shape (ErrorEnvelope) rather
+// than APIError's raw Go fields. Because APIError serializes via MarshalJSON,
+// Huma's struct reflection would otherwise publish the flat, exported-name
+// layout instead of the {status, error:{code,message,...}} envelope clients
+// actually receive — a schema that lies about every error response.
+func (e *APIError) Schema(r huma.Registry) *huma.Schema {
+	return r.Schema(reflect.TypeOf(ErrorEnvelope{}), true, "ErrorEnvelope")
 }
 
 // InstallErrorFormatter wires Huma so non-API-typed errors (panics, validation

--- a/internal/daemon/handlers_events.go
+++ b/internal/daemon/handlers_events.go
@@ -254,20 +254,13 @@ func registerEventsStream(humaAPI huma.API, cfg ServerConfig) {
 }
 
 func registerEventsStreamMethodGuards(mux *http.ServeMux) {
-	for _, method := range []string{
-		http.MethodHead,
-		http.MethodPost,
-		http.MethodPut,
-		http.MethodPatch,
-		http.MethodDelete,
-		http.MethodOptions,
-	} {
-		mux.HandleFunc(method+" /api/v1/events/stream", func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Allow", http.MethodGet)
-			api.WriteEnvelope(w, http.StatusMethodNotAllowed, "method_not_allowed",
-				"events stream only accepts GET")
-		})
+	guard := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Allow", http.MethodGet)
+		api.WriteEnvelope(w, http.StatusMethodNotAllowed, "method_not_allowed",
+			"events stream only accepts GET")
 	}
+	mux.HandleFunc(http.MethodHead+" /api/v1/events/stream", guard)
+	mux.HandleFunc("/api/v1/events/stream", guard)
 }
 
 // runSSEStream implements the streaming body for GET /api/v1/events/stream.

--- a/internal/daemon/handlers_events.go
+++ b/internal/daemon/handlers_events.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -57,8 +56,8 @@ func registerEventsHandlers(humaAPI huma.API, mux *http.ServeMux, cfg ServerConf
 		return doPollEvents(ctx, cfg, in.AfterID, in.Limit, in.ProjectID)
 	})
 
-	// SSE: not Huma — needs a streaming http.HandlerFunc on the raw mux.
-	mux.HandleFunc("/api/v1/events/stream", sseHandler(cfg))
+	registerEventsStream(humaAPI, cfg)
+	registerEventsStreamMethodGuards(mux)
 }
 
 // resolveLimit normalizes the optional Limit query param: explicit non-positive
@@ -171,7 +170,107 @@ func nextAfterID(rows []db.Event, afterID int64) int64 {
 	return rows[len(rows)-1].ID
 }
 
-// sseHandler implements GET /api/v1/events/stream.
+type eventsStreamInput struct {
+	accept             string
+	lastEventID        string
+	lastEventIDPresent bool
+	query              map[string][]string
+}
+
+func (in *eventsStreamInput) Resolve(ctx huma.Context) []error {
+	in.accept = ctx.Header("Accept")
+	u := ctx.URL()
+	in.query = u.Query()
+	ctx.EachHeader(func(name, value string) {
+		if !strings.EqualFold(name, "Last-Event-ID") || in.lastEventIDPresent {
+			return
+		}
+		in.lastEventID = value
+		in.lastEventIDPresent = true
+	})
+	return nil
+}
+
+func registerEventsStream(humaAPI huma.API, cfg ServerConfig) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "streamEvents",
+		Method:      http.MethodGet,
+		Path:        "/api/v1/events/stream",
+		Summary:     "Stream events",
+		Description: "Streams durable events as Server-Sent Events. Clients may resume with Last-Event-ID or after_id, but not both.",
+		Parameters: []*huma.Param{
+			{
+				Name:        "after_id",
+				In:          "query",
+				Description: "Exclusive event cursor. Mutually exclusive with Last-Event-ID.",
+				Schema:      &huma.Schema{Type: huma.TypeInteger},
+			},
+			{
+				Name:        "project_id",
+				In:          "query",
+				Description: "Optional project ID filter. Omit to stream all visible project events.",
+				Schema:      &huma.Schema{Type: huma.TypeInteger},
+			},
+			{
+				Name:        "Last-Event-ID",
+				In:          "header",
+				Description: "Exclusive resume cursor from the last received SSE id. Mutually exclusive with after_id.",
+				Schema:      &huma.Schema{Type: huma.TypeInteger},
+			},
+		},
+		Responses: map[string]*huma.Response{
+			"200": {
+				Description: "Server-Sent Events stream.",
+				Content: map[string]*huma.MediaType{
+					"text/event-stream": {
+						Schema: &huma.Schema{
+							Type:        huma.TypeString,
+							Description: "UTF-8 Server-Sent Events frames containing event envelopes or sync.reset_required reset payloads.",
+						},
+					},
+				},
+			},
+		},
+	}, func(ctx context.Context, in *eventsStreamInput) (*huma.StreamResponse, error) {
+		if !acceptableForSSE(in.accept) {
+			return nil, api.NewError(406, "not_acceptable", "Accept must be text/event-stream", "", nil)
+		}
+
+		cursor, err := parseSSECursor(in)
+		if err != nil {
+			return nil, err
+		}
+		projectID, err := parseSSEProjectID(ctx, cfg, in.query)
+		if err != nil {
+			return nil, err
+		}
+
+		return &huma.StreamResponse{
+			Body: func(ctx huma.Context) {
+				runSSEStream(ctx, cfg, cursor, projectID)
+			},
+		}, nil
+	})
+}
+
+func registerEventsStreamMethodGuards(mux *http.ServeMux) {
+	for _, method := range []string{
+		http.MethodHead,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodOptions,
+	} {
+		mux.HandleFunc(method+" /api/v1/events/stream", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Allow", http.MethodGet)
+			api.WriteEnvelope(w, http.StatusMethodNotAllowed, "method_not_allowed",
+				"events stream only accepts GET")
+		})
+	}
+}
+
+// runSSEStream implements the streaming body for GET /api/v1/events/stream.
 //
 // Order of operations: (1) Accept negotiation — 406 on miss/wrong;
 // (2) cursor parse — 400 cursor_conflict if both header and ?after_id set;
@@ -184,117 +283,130 @@ func nextAfterID(rows []db.Event, afterID int64) int64 {
 // Steps 4–6 are Subscribe-first / check-second so a purge that fires between
 // cursor parse and Subscribe lands on sub.Ch via the live channel; one
 // committed before parse is captured by PurgeResetCheck. See spec §5.3.
-func sseHandler(cfg ServerConfig) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			w.Header().Set("Allow", http.MethodGet)
-			api.WriteEnvelope(w, http.StatusMethodNotAllowed, "method_not_allowed",
-				"events stream only accepts GET")
-			return
-		}
-		if !acceptableForSSE(r.Header.Get("Accept")) {
-			api.WriteEnvelope(w, http.StatusNotAcceptable, "not_acceptable",
-				"Accept must be text/event-stream")
-			return
-		}
-
-		// cursor_conflict is checked on header/query *key presence* before
-		// parsing values. A request with `Last-Event-ID: 5` plus `?after_id=`
-		// (empty) or `?after_id=&after_id=5` (multi-value) would otherwise
-		// bypass detection if we asked Get(), which only returns the first
-		// non-empty value.
-		_, hadHeader := r.Header[http.CanonicalHeaderKey("Last-Event-ID")]
-		_, hadQuery := r.URL.Query()["after_id"]
-		if hadHeader && hadQuery {
-			renderAPIError(w, api.NewError(400, "cursor_conflict",
-				"pass either Last-Event-ID or ?after_id, not both", "", nil))
-			return
-		}
-		cursor, perr := parseSSECursor(r)
-		if perr != nil {
-			renderAPIError(w, perr)
-			return
-		}
-
-		var projectID int64
-		if pidStr := r.URL.Query().Get("project_id"); pidStr != "" {
-			n, err := strconv.ParseInt(pidStr, 10, 64)
-			if err != nil || n <= 0 {
-				renderAPIError(w, api.NewError(400, "validation",
-					"project_id must be a positive integer", "", nil))
-				return
-			}
-			// Mirror the polling endpoint contract: an unknown positive
-			// project_id is project_not_found, not an idle 200 stream.
-			// Archived projects are also treated as not-found.
-			if _, err := activeProjectByID(r.Context(), cfg.DB, n); err != nil {
-				renderAPIError(w, err)
-				return
-			}
-			projectID = n
-		}
-
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			renderAPIError(w, api.NewError(500, "internal", "streaming not supported", "", nil))
-			return
-		}
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
-		w.WriteHeader(http.StatusOK)
-		if _, err := io.WriteString(w, ": connected\n\n"); err != nil {
-			return
-		}
-		flusher.Flush()
-
-		sub := cfg.Broadcaster.Subscribe(SubFilter{ProjectID: projectID})
-		defer sub.Unsub()
-
-		ctx := r.Context()
-		hwm, err := cfg.DB.MaxEventID(ctx)
-		if err != nil {
-			return
-		}
-
-		resetTo, err := cfg.DB.PurgeResetCheck(ctx, cursor, projectID)
-		if err != nil {
-			return
-		}
-		if resetTo > 0 {
-			writeResetFrame(w, resetTo)
-			flusher.Flush()
-			return
-		}
-
-		rows, err := cfg.DB.EventsAfter(ctx, db.EventsAfterParams{
-			AfterID: cursor, ProjectID: projectID, ThroughID: hwm, Limit: sseDrainCap + 1,
-		})
-		if err != nil {
-			return
-		}
-
-		if len(rows) == sseDrainCap+1 {
-			writeResetFrame(w, hwm)
-			flusher.Flush()
-			return
-		}
-
-		lastSent := cursor
-		for _, ev := range rows {
-			writeEventFrame(w, ev)
-			flusher.Flush()
-			lastSent = ev.ID
-		}
-
-		runLivePhase(ctx, livePhaseDeps{w: w, flusher: flusher, cfg: cfg, ch: sub.Ch}, projectID, lastSent)
+func runSSEStream(hctx huma.Context, cfg ServerConfig, cursor, projectID int64) {
+	w := hctx.BodyWriter()
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return
 	}
+	hctx.SetHeader("Content-Type", "text/event-stream")
+	hctx.SetHeader("Cache-Control", "no-cache")
+	hctx.SetHeader("Connection", "keep-alive")
+	if _, err := io.WriteString(w, ": connected\n\n"); err != nil {
+		return
+	}
+	flusher.Flush()
+
+	sub := cfg.Broadcaster.Subscribe(SubFilter{ProjectID: projectID})
+	defer sub.Unsub()
+
+	ctx := hctx.Context()
+	hwm, err := cfg.DB.MaxEventID(ctx)
+	if err != nil {
+		return
+	}
+
+	resetTo, err := cfg.DB.PurgeResetCheck(ctx, cursor, projectID)
+	if err != nil {
+		return
+	}
+	if resetTo > 0 {
+		writeResetFrame(w, resetTo)
+		flusher.Flush()
+		return
+	}
+
+	rows, err := cfg.DB.EventsAfter(ctx, db.EventsAfterParams{
+		AfterID: cursor, ProjectID: projectID, ThroughID: hwm, Limit: sseDrainCap + 1,
+	})
+	if err != nil {
+		return
+	}
+
+	if len(rows) == sseDrainCap+1 {
+		writeResetFrame(w, hwm)
+		flusher.Flush()
+		return
+	}
+
+	lastSent := cursor
+	for _, ev := range rows {
+		writeEventFrame(w, ev)
+		flusher.Flush()
+		lastSent = ev.ID
+	}
+
+	runLivePhase(ctx, livePhaseDeps{w: w, flusher: flusher, cfg: cfg, ch: sub.Ch}, projectID, lastSent)
+}
+
+func parseSSECursor(in *eventsStreamInput) (int64, error) {
+	// cursor_conflict is checked on header/query *key presence* before
+	// parsing values. A request with `Last-Event-ID: 5` plus `?after_id=`
+	// (empty) or `?after_id=&after_id=5` would otherwise bypass detection if
+	// we asked Get(), which only returns the first non-empty value.
+	_, hadQuery := in.query["after_id"]
+	if in.lastEventIDPresent && hadQuery {
+		return 0, api.NewError(400, "cursor_conflict",
+			"pass either Last-Event-ID or ?after_id, not both", "", nil)
+	}
+
+	var cursor int64
+	if in.lastEventIDPresent {
+		n, err := parseNonNegativeInt64(in.lastEventID, "Last-Event-ID")
+		if err != nil {
+			return 0, err
+		}
+		cursor = n
+	}
+	if vs, ok := in.query["after_id"]; ok {
+		v := ""
+		if len(vs) > 0 {
+			v = vs[0]
+		}
+		n, err := parseNonNegativeInt64(v, "after_id")
+		if err != nil {
+			return 0, err
+		}
+		cursor = n
+	}
+	return cursor, nil
+}
+
+func parseNonNegativeInt64(raw, name string) (int64, error) {
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n < 0 {
+		return 0, api.NewError(400, "validation",
+			name+" must be a non-negative integer", "", nil)
+	}
+	return n, nil
+}
+
+func parseSSEProjectID(ctx context.Context, cfg ServerConfig, query map[string][]string) (int64, error) {
+	pidStr := ""
+	if vs, ok := query["project_id"]; ok && len(vs) > 0 {
+		pidStr = vs[0]
+	}
+	if pidStr == "" {
+		return 0, nil
+	}
+	n, err := strconv.ParseInt(pidStr, 10, 64)
+	if err != nil || n <= 0 {
+		return 0, api.NewError(400, "validation",
+			"project_id must be a positive integer", "", nil)
+	}
+	// Mirror the polling endpoint contract: an unknown positive project_id is
+	// project_not_found, not an idle 200 stream. Archived projects are also
+	// treated as not-found.
+	if _, err := activeProjectByID(ctx, cfg.DB, n); err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // livePhaseDeps bundles the long-lived SSE writer state so runLivePhase stays
 // within the project's positional-parameter limit.
 type livePhaseDeps struct {
-	w       http.ResponseWriter
+	w       io.Writer
 	flusher http.Flusher
 	cfg     ServerConfig
 	ch      <-chan StreamMsg
@@ -391,49 +503,6 @@ func acceptableForSSE(accept string) bool {
 		}
 	}
 	return false
-}
-
-// parseSSECursor parses the SSE resume cursor from Last-Event-ID and/or
-// ?after_id. Both are presence-based (per CursorConflict semantics): a
-// present-but-empty value is a 400 validation error rather than a silent
-// "no cursor". Caller is responsible for checking the cursor_conflict
-// case (both present) before invoking this.
-func parseSSECursor(r *http.Request) (int64, error) {
-	var cursor int64
-	if vs, ok := r.Header[http.CanonicalHeaderKey("Last-Event-ID")]; ok {
-		v := ""
-		if len(vs) > 0 {
-			v = vs[0]
-		}
-		n, perr := strconv.ParseInt(v, 10, 64)
-		if perr != nil || n < 0 {
-			return 0, api.NewError(400, "validation",
-				"Last-Event-ID must be a non-negative integer", "", nil)
-		}
-		cursor = n
-	}
-	if vs, ok := r.URL.Query()["after_id"]; ok {
-		v := ""
-		if len(vs) > 0 {
-			v = vs[0]
-		}
-		n, perr := strconv.ParseInt(v, 10, 64)
-		if perr != nil || n < 0 {
-			return 0, api.NewError(400, "validation",
-				"after_id must be a non-negative integer", "", nil)
-		}
-		cursor = n
-	}
-	return cursor, nil
-}
-
-func renderAPIError(w http.ResponseWriter, e error) {
-	var ae *api.APIError
-	if !errors.As(e, &ae) {
-		api.WriteEnvelope(w, 500, "internal", e.Error())
-		return
-	}
-	api.WriteEnvelope(w, ae.Status, ae.Code, ae.Message)
 }
 
 func writeEventFrame(w io.Writer, e db.Event) {

--- a/internal/daemon/handlers_events_test.go
+++ b/internal/daemon/handlers_events_test.go
@@ -483,7 +483,14 @@ func TestSSE_CursorConflictPresenceBased(t *testing.T) {
 // so a misrouted client can recover without scraping the message.
 func TestSSE_NonGETReturnsAllowHeader(t *testing.T) {
 	env := testenv.New(t)
-	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+	for _, method := range []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodConnect,
+		http.MethodTrace,
+		"BREW",
+	} {
 		resp, _ := envDoRaw(t, env, method, "/api/v1/events/stream", nil, nil)
 		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "method=%s", method)
 		assert.Equal(t, http.MethodGet, resp.Header.Get("Allow"), "method=%s", method)

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -1,0 +1,25 @@
+package daemon
+
+import "github.com/danielgtaylor/huma/v2"
+
+// APISchemaVersion is the version stamped into the daemon's OpenAPI document
+// (info.version). It tracks the HTTP API contract, not the build version, so
+// the committed schema artifact stays stable across builds and is bumped
+// deliberately when the wire contract changes.
+const APISchemaVersion = "0.1.0"
+
+// OpenAPIDocument builds the daemon's complete OpenAPI model by wiring every
+// route through NewServer with a zero ServerConfig. It binds no listener and
+// needs no database: route handlers capture the config but are never invoked
+// here, so the registration alone is enough to materialize the schema. Because
+// it reuses NewServer, the emitted document reflects the daemon's real Huma
+// configuration — notably the disabled SchemaLinkTransformer — so the schema
+// matches the daemon's actual wire shapes.
+func OpenAPIDocument() *huma.OpenAPI {
+	return NewServer(ServerConfig{}).API().OpenAPI()
+}
+
+// OpenAPIYAML renders the OpenAPI document (OpenAPI 3.1) as YAML.
+func OpenAPIYAML() ([]byte, error) {
+	return OpenAPIDocument().YAML()
+}

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -16,10 +16,67 @@ const APISchemaVersion = "0.1.0"
 // configuration — notably the disabled SchemaLinkTransformer — so the schema
 // matches the daemon's actual wire shapes.
 func OpenAPIDocument() *huma.OpenAPI {
-	return NewServer(ServerConfig{}).API().OpenAPI()
+	doc := NewServer(ServerConfig{}).API().OpenAPI()
+	applyJSONBlobSchemaOverrides(doc)
+	return doc
 }
 
 // OpenAPIYAML renders the OpenAPI document (OpenAPI 3.1) as YAML.
 func OpenAPIYAML() ([]byte, error) {
 	return OpenAPIDocument().YAML()
+}
+
+func applyJSONBlobSchemaOverrides(doc *huma.OpenAPI) {
+	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
+		return
+	}
+	for _, schema := range doc.Components.Schemas.Map() {
+		applyJSONBlobSchemaOverridesTo(schema, map[*huma.Schema]struct{}{})
+	}
+}
+
+func applyJSONBlobSchemaOverridesTo(schema *huma.Schema, seen map[*huma.Schema]struct{}) {
+	if schema == nil {
+		return
+	}
+	if _, ok := seen[schema]; ok {
+		return
+	}
+	seen[schema] = struct{}{}
+
+	for name, prop := range schema.Properties {
+		switch name {
+		case "metadata", "template_metadata":
+			schema.Properties[name] = jsonObjectSchema()
+		case "template_labels":
+			schema.Properties[name] = jsonStringArraySchema()
+		default:
+			applyJSONBlobSchemaOverridesTo(prop, seen)
+		}
+	}
+	applyJSONBlobSchemaOverridesTo(schema.Items, seen)
+	for _, child := range schema.OneOf {
+		applyJSONBlobSchemaOverridesTo(child, seen)
+	}
+	for _, child := range schema.AnyOf {
+		applyJSONBlobSchemaOverridesTo(child, seen)
+	}
+	for _, child := range schema.AllOf {
+		applyJSONBlobSchemaOverridesTo(child, seen)
+	}
+	applyJSONBlobSchemaOverridesTo(schema.Not, seen)
+}
+
+func jsonObjectSchema() *huma.Schema {
+	return &huma.Schema{
+		Type:                 huma.TypeObject,
+		AdditionalProperties: true,
+	}
+}
+
+func jsonStringArraySchema() *huma.Schema {
+	return &huma.Schema{
+		Type:  huma.TypeArray,
+		Items: &huma.Schema{Type: huma.TypeString},
+	}
 }

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -30,12 +30,12 @@ func applyJSONBlobSchemaOverrides(doc *huma.OpenAPI) {
 	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
 		return
 	}
-	for _, schema := range doc.Components.Schemas.Map() {
-		applyJSONBlobSchemaOverridesTo(schema, map[*huma.Schema]struct{}{})
+	for name, schema := range doc.Components.Schemas.Map() {
+		applyJSONBlobSchemaOverridesTo(name, schema, map[*huma.Schema]struct{}{})
 	}
 }
 
-func applyJSONBlobSchemaOverridesTo(schema *huma.Schema, seen map[*huma.Schema]struct{}) {
+func applyJSONBlobSchemaOverridesTo(componentName string, schema *huma.Schema, seen map[*huma.Schema]struct{}) {
 	if schema == nil {
 		return
 	}
@@ -46,25 +46,31 @@ func applyJSONBlobSchemaOverridesTo(schema *huma.Schema, seen map[*huma.Schema]s
 
 	for name, prop := range schema.Properties {
 		switch name {
-		case "metadata", "template_metadata":
+		case "metadata":
+			if componentName == "RecurrenceTemplateUpdateInput" {
+				schema.Properties[name] = jsonNullableObjectSchema()
+				continue
+			}
+			schema.Properties[name] = jsonObjectSchema()
+		case "template_metadata":
 			schema.Properties[name] = jsonObjectSchema()
 		case "template_labels":
 			schema.Properties[name] = jsonStringArraySchema()
 		default:
-			applyJSONBlobSchemaOverridesTo(prop, seen)
+			applyJSONBlobSchemaOverridesTo("", prop, seen)
 		}
 	}
-	applyJSONBlobSchemaOverridesTo(schema.Items, seen)
+	applyJSONBlobSchemaOverridesTo("", schema.Items, seen)
 	for _, child := range schema.OneOf {
-		applyJSONBlobSchemaOverridesTo(child, seen)
+		applyJSONBlobSchemaOverridesTo("", child, seen)
 	}
 	for _, child := range schema.AnyOf {
-		applyJSONBlobSchemaOverridesTo(child, seen)
+		applyJSONBlobSchemaOverridesTo("", child, seen)
 	}
 	for _, child := range schema.AllOf {
-		applyJSONBlobSchemaOverridesTo(child, seen)
+		applyJSONBlobSchemaOverridesTo("", child, seen)
 	}
-	applyJSONBlobSchemaOverridesTo(schema.Not, seen)
+	applyJSONBlobSchemaOverridesTo("", schema.Not, seen)
 }
 
 func jsonObjectSchema() *huma.Schema {
@@ -72,6 +78,12 @@ func jsonObjectSchema() *huma.Schema {
 		Type:                 huma.TypeObject,
 		AdditionalProperties: true,
 	}
+}
+
+func jsonNullableObjectSchema() *huma.Schema {
+	schema := jsonObjectSchema()
+	schema.Nullable = true
+	return schema
 }
 
 func jsonStringArraySchema() *huma.Schema {

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -56,3 +56,18 @@ func TestOpenAPIDocumentShape(t *testing.T) {
 		t.Error("no paths registered in document")
 	}
 }
+
+func TestOpenAPIDocumentIncludesEventsStream(t *testing.T) {
+	doc := OpenAPIDocument()
+	path := doc.Paths["/api/v1/events/stream"]
+	if path == nil || path.Get == nil {
+		t.Fatal("missing GET /api/v1/events/stream")
+	}
+	resp := path.Get.Responses["200"]
+	if resp == nil {
+		t.Fatal("missing 200 response for GET /api/v1/events/stream")
+	}
+	if resp.Content["text/event-stream"] == nil {
+		t.Fatal("missing text/event-stream response content")
+	}
+}

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// artifactPath is the committed OpenAPI schema, relative to this package dir.
+// A const (not a var) keeps gosec G304 quiet: the path is fixed, not caller-supplied.
+const artifactPath = "../../api/openapi.yaml"
+
+// TestOpenAPIArtifactUpToDate fails if the committed api/openapi.yaml no longer
+// matches the schema generated from the current routes. Regenerate with
+// `make openapi`.
+func TestOpenAPIArtifactUpToDate(t *testing.T) {
+	got, err := OpenAPIYAML()
+	if err != nil {
+		t.Fatalf("OpenAPIYAML: %v", err)
+	}
+	want, err := os.ReadFile(artifactPath)
+	if err != nil {
+		t.Fatalf("read %s: %v (run `make openapi` to generate it)", artifactPath, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("%s is stale; run `make openapi` to regenerate", artifactPath)
+	}
+}
+
+// TestOpenAPIYAMLDeterministic guards against map-ordering nondeterminism that
+// would make the committed artifact churn between generations.
+func TestOpenAPIYAMLDeterministic(t *testing.T) {
+	first, err := OpenAPIYAML()
+	if err != nil {
+		t.Fatalf("OpenAPIYAML (first): %v", err)
+	}
+	second, err := OpenAPIYAML()
+	if err != nil {
+		t.Fatalf("OpenAPIYAML (second): %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("OpenAPIYAML is nondeterministic across calls")
+	}
+}
+
+// TestOpenAPIDocumentShape sanity-checks the generated document.
+func TestOpenAPIDocumentShape(t *testing.T) {
+	doc := OpenAPIDocument()
+	if doc.OpenAPI == "" {
+		t.Error("missing openapi version string")
+	}
+	if doc.Info == nil || doc.Info.Version != APISchemaVersion {
+		t.Errorf("info.version = %+v, want %s", doc.Info, APISchemaVersion)
+	}
+	if len(doc.Paths) == 0 {
+		t.Error("no paths registered in document")
+	}
+}

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -81,10 +81,15 @@ func TestOpenAPIDocumentJSONBlobShapes(t *testing.T) {
 	assertSchemaPropertyType(t, doc, "ReadyGlobalIssue", "metadata", huma.TypeObject)
 	assertSchemaPropertyType(t, doc, "Recurrence", "template_labels", huma.TypeArray)
 	assertSchemaPropertyType(t, doc, "Recurrence", "template_metadata", huma.TypeObject)
+	assertSchemaPropertyType(t, doc, "RecurrenceTemplateUpdateInput", "metadata", huma.TypeObject)
 
 	labels := doc.Components.Schemas.Map()["Recurrence"].Properties["template_labels"]
 	if labels.Items == nil || labels.Items.Type != huma.TypeString {
 		t.Fatalf("Recurrence.template_labels items = %+v, want string items", labels.Items)
+	}
+	updateMetadata := doc.Components.Schemas.Map()["RecurrenceTemplateUpdateInput"].Properties["metadata"]
+	if !updateMetadata.Nullable {
+		t.Fatal("RecurrenceTemplateUpdateInput.metadata must allow null")
 	}
 }
 

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"os"
 	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
 )
 
 // artifactPath is the committed OpenAPI schema, relative to this package dir.
@@ -69,5 +71,34 @@ func TestOpenAPIDocumentIncludesEventsStream(t *testing.T) {
 	}
 	if resp.Content["text/event-stream"] == nil {
 		t.Fatal("missing text/event-stream response content")
+	}
+}
+
+func TestOpenAPIDocumentJSONBlobShapes(t *testing.T) {
+	doc := OpenAPIDocument()
+	assertSchemaPropertyType(t, doc, "Issue", "metadata", huma.TypeObject)
+	assertSchemaPropertyType(t, doc, "ProjectOut", "metadata", huma.TypeObject)
+	assertSchemaPropertyType(t, doc, "ReadyGlobalIssue", "metadata", huma.TypeObject)
+	assertSchemaPropertyType(t, doc, "Recurrence", "template_labels", huma.TypeArray)
+	assertSchemaPropertyType(t, doc, "Recurrence", "template_metadata", huma.TypeObject)
+
+	labels := doc.Components.Schemas.Map()["Recurrence"].Properties["template_labels"]
+	if labels.Items == nil || labels.Items.Type != huma.TypeString {
+		t.Fatalf("Recurrence.template_labels items = %+v, want string items", labels.Items)
+	}
+}
+
+func assertSchemaPropertyType(t *testing.T, doc *huma.OpenAPI, schemaName, propertyName, want string) {
+	t.Helper()
+	schema := doc.Components.Schemas.Map()[schemaName]
+	if schema == nil {
+		t.Fatalf("missing schema %s", schemaName)
+	}
+	prop := schema.Properties[propertyName]
+	if prop == nil {
+		t.Fatalf("missing %s.%s schema property", schemaName, propertyName)
+	}
+	if prop.Type != want {
+		t.Fatalf("%s.%s type = %q, want %q", schemaName, propertyName, prop.Type, want)
 	}
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -192,8 +192,8 @@ func isMutation(method string) bool {
 // registerRoutes installs the per-resource handler groups onto humaAPI. Each
 // group lives in its own file (handlers_health.go, handlers_projects.go, etc.)
 // and replaces the matching stub below as it lands. The events handler also
-// receives mux so it can register the SSE endpoint as a raw http.HandlerFunc
-// (Huma doesn't model streaming responses).
+// receives mux so it can preserve the SSE endpoint's method-not-allowed
+// contract around the Huma streaming route.
 func registerRoutes(humaAPI huma.API, mux *http.ServeMux, cfg ServerConfig) {
 	registerHealth(humaAPI, cfg)
 	registerInstanceHandlers(humaAPI, cfg)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -93,8 +93,8 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 
 	mux := http.NewServeMux()
-	humaConfig := huma.DefaultConfig("kata", "0.1.0")
-	humaConfig.OpenAPIPath = "" // Plan 1: no /openapi.json
+	humaConfig := huma.DefaultConfig("kata", APISchemaVersion)
+	humaConfig.OpenAPIPath = "" // Plan 1: no /openapi.json served at runtime; see `kata openapi` + OpenAPIDocument
 	// Drop DefaultConfig's SchemaLinkTransformer: it rebuilds response structs
 	// via reflection (adding a $schema field), which silently bypasses any
 	// MarshalJSON. Our APIError relies on MarshalJSON to emit the wire-spec


### PR DESCRIPTION
## What

Adds a `kata openapi` command that prints the daemon's OpenAPI 3.1 schema, and
commits the generated artifact at `api/openapi.yaml` with a golden test that
keeps it from drifting.

This is a **reviewable first slice of #97** — a generated *snapshot of the
current daemon API*, useful for client generation and review. It deliberately
does **not** make stronger compatibility promises, and it's meant as an
implementation path for your feedback rather than an assumption about policy.
The "API schema version in `health` output" and "compatibility-expectations doc"
items from #97 are left as follow-ups, pending your preference on how far you
want to take this.

## Approach

- **Runtime `/openapi.json` stays disabled.** The existing decision in
  `internal/daemon/server.go` is untouched; the schema is generated
  **in-process** from the route definitions (no running daemon or DB required),
  so this doesn't reverse it or add a network surface.
- **Stdout-only command.** `kata openapi` writes to stdout with no `-o`/file
  flag, so the shipped binary introduces no path/symlink write surface. The
  committed artifact is produced by `make openapi` (a stdout redirect), not by
  the binary writing files itself.
- **Drift guard.** `make openapi` regenerates `api/openapi.yaml`;
  `TestOpenAPIArtifactUpToDate` fails if the committed file no longer matches the
  routes. Output is deterministic (verified across repeated generation), and
  regenerating after a route/schema change is a single `make openapi`.

## Error-schema fidelity (worth a look)

`APIError` serializes through a custom `MarshalJSON` into the `ErrorEnvelope`
wire shape — `{status, error:{code,message,hint?,data?}}` — which Huma's
reflection can't see. Left alone, the generated schema would describe every
non-2xx response using `APIError`'s raw Go fields (flat, exported names): a
schema that misrepresents all error responses. This PR has `APIError` implement
`huma.SchemaProvider` so the document references the true `ErrorEnvelope` shape
instead.

## Open to your preference

I defaulted to the most concrete thing to review, but I'm happy to adjust any of
these rather than presume the call is made:

- **Committing the artifact vs not** — if a ~5.2k-line generated file is review
  noise, this can be command-only (no `api/openapi.yaml` in-tree), or the
  artifact can be published only at release time instead of committed.
- **Which routes appear** — the snapshot currently includes every registered
  route. If some endpoints shouldn't be presented as part of a published
  surface, I can filter them.
- **The golden test** — it's there to stop silent drift, but easy to relax or
  drop if you'd rather not couple route changes to artifact regeneration.

## Notes

- Verified locally: `go test` (incl. `-short` across `internal/...`/`cmd/...`),
  `go vet`, `golangci-lint` (0 issues), `nilaway` (clean), `gofmt`.

Part of #97.
