### PR TITLE
feat(cli): add issue project move command

### DIFF
--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -83,6 +83,7 @@ func newRootCmd() *cobra.Command {
 		newShowCmd(),
 		newListCmd(),
 		newEditCmd(),
+		newMoveCmd(),
 		newCommentCmd(),
 		newCloseCmd(),
 		newReopenCmd(),

--- a/cmd/kata/move.go
+++ b/cmd/kata/move.go
@@ -36,12 +36,6 @@ type moveIssueWire struct {
 	Revision  int64  `json:"revision"`
 }
 
-type moveProjectWire struct {
-	ID   int64  `json:"id"`
-	UID  string `json:"uid"`
-	Name string `json:"name"`
-}
-
 type moveResponseWire struct {
 	Issue      moveIssueWire `json:"issue"`
 	EventID    int64         `json:"event_id"`

--- a/cmd/kata/move.go
+++ b/cmd/kata/move.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kata/internal/textsafe"
+)
+
+func newMoveCmd() *cobra.Command {
+	var dryRun bool
+	cmd := &cobra.Command{
+		Use:   "move <issue-ref> <project>",
+		Short: "move an issue to another project",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMove(cmd, args[0], args[1], dryRun)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate and preview without mutating")
+	addCommentFlag(cmd)
+	return cmd
+}
+
+type moveIssueWire struct {
+	ID        int64  `json:"id"`
+	ProjectID int64  `json:"project_id"`
+	ShortID   string `json:"short_id"`
+	Revision  int64  `json:"revision"`
+}
+
+type moveProjectWire struct {
+	ID   int64  `json:"id"`
+	UID  string `json:"uid"`
+	Name string `json:"name"`
+}
+
+type moveResponseWire struct {
+	Issue      moveIssueWire `json:"issue"`
+	EventID    int64         `json:"event_id"`
+	NewShortID string        `json:"new_short_id"`
+	Changed    bool          `json:"changed"`
+}
+
+func runMove(cmd *cobra.Command, rawRef, targetProject string, dryRun bool) error {
+	comment, err := commentFromFlag(cmd)
+	if err != nil {
+		return err
+	}
+	ctx, baseURL, pid, ref, err := resolveIssueRefForCommand(cmd, rawRef)
+	if err != nil {
+		return err
+	}
+	client, err := httpClientFor(ctx, baseURL)
+	if err != nil {
+		return err
+	}
+	target, err := resolveProjectSelector(ctx, client, baseURL, targetProject)
+	if err != nil {
+		return err
+	}
+	if target.UID == "" {
+		return &cliError{
+			Message:  fmt.Sprintf("project %q has no UID", target.Name),
+			Kind:     kindValidation,
+			ExitCode: ExitValidation,
+		}
+	}
+	sourceIssue, err := fetchMoveIssue(ctx, client, baseURL, pid, ref.RefForAPI)
+	if err != nil {
+		return err
+	}
+	if dryRun {
+		return printMovePreview(cmd, ref.ProjectName, sourceIssue.ShortID, target.Name)
+	}
+	actor, _ := resolveActor(ctx, flags.As, nil)
+	status, bs, err := httpDoJSONHeaders(ctx, client, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/projects/%d/issues/%s/actions/move", baseURL, pid, url.PathEscape(ref.RefForAPI)),
+		map[string]any{
+			"actor":          actor,
+			"to_project_uid": target.UID,
+		},
+		map[string]string{"If-Match": fmt.Sprintf(`"rev-%d"`, sourceIssue.Revision)})
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return apiErrFromBody(status, bs)
+	}
+	var moved moveResponseWire
+	if err := json.Unmarshal(bs, &moved); err != nil {
+		return err
+	}
+	if err := postFollowupComment(ctx, client, baseURL, moved.Issue.ProjectID, moved.Issue.ShortID, actor, comment); err != nil {
+		return err
+	}
+	return printMove(cmd, bs, ref.ProjectName, sourceIssue.ShortID, target.Name)
+}
+
+func fetchMoveIssue(ctx context.Context, client *http.Client, baseURL string, projectID int64, ref string) (moveIssueWire, error) {
+	status, bs, err := httpDoJSON(ctx, client, http.MethodGet,
+		fmt.Sprintf("%s/api/v1/projects/%d/issues/%s", baseURL, projectID, url.PathEscape(ref)), nil)
+	if err != nil {
+		return moveIssueWire{}, err
+	}
+	if status >= 400 {
+		return moveIssueWire{}, apiErrFromBody(status, bs)
+	}
+	var out struct {
+		Issue moveIssueWire `json:"issue"`
+	}
+	if err := json.Unmarshal(bs, &out); err != nil {
+		return moveIssueWire{}, err
+	}
+	return out.Issue, nil
+}
+
+func httpDoJSONHeaders(ctx context.Context, client *http.Client, method, path string, body any, headers map[string]string) (int, []byte, error) {
+	var rdr io.Reader
+	if body != nil {
+		bs, err := json.Marshal(body)
+		if err != nil {
+			return 0, nil, err
+		}
+		rdr = bytes.NewReader(bs)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, path, rdr)
+	if err != nil {
+		return 0, nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := client.Do(req) //nolint:gosec // daemon-local URL, same as httpDoJSON.
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	bs, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, bs, nil
+}
+
+func printMove(cmd *cobra.Command, bs []byte, sourceProject, oldShortID, targetProject string) error {
+	mode := currentOutputMode()
+	if mode == outputJSON {
+		var buf bytes.Buffer
+		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
+			return err
+		}
+		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+		return err
+	}
+	var b moveResponseWire
+	if err := json.Unmarshal(bs, &b); err != nil {
+		return err
+	}
+	oldRef := moveQualifiedID(sourceProject, oldShortID)
+	newRef := moveQualifiedID(targetProject, b.NewShortID)
+	if mode == outputAgent {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "OK move %s changed=%t dry_run=%t\n",
+			agentValue(oldRef), b.Changed, false); err != nil {
+			return err
+		}
+		return writeAgentKVRow(cmd.OutOrStdout(),
+			agentRowField("from", oldRef),
+			agentRowField("to", newRef),
+			agentRowField("event_id", strconv.FormatInt(b.EventID, 10)),
+		)
+	}
+	if flags.Quiet {
+		return nil
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s %s to %s\n",
+		"moved", textsafe.Line(oldRef), textsafe.Line(newRef))
+	return err
+}
+
+func printMovePreview(cmd *cobra.Command, sourceProject, oldShortID, targetProject string) error {
+	if flags.Quiet {
+		return nil
+	}
+	oldRef := moveQualifiedID(sourceProject, oldShortID)
+	mode := currentOutputMode()
+	if mode == outputJSON {
+		var buf bytes.Buffer
+		payload := map[string]any{
+			"dry_run":         true,
+			"changed":         false,
+			"from":            oldRef,
+			"to_project":      targetProject,
+			"target_ref_note": "target short_id is assigned by the daemon during move",
+		}
+		if err := emitJSON(&buf, payload); err != nil {
+			return err
+		}
+		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+		return err
+	}
+	if mode == outputAgent {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "OK move %s changed=false dry_run=true\n", agentValue(oldRef)); err != nil {
+			return err
+		}
+		return writeAgentKVRow(cmd.OutOrStdout(),
+			agentRowField("from", oldRef),
+			agentRowField("to_project", targetProject),
+		)
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(),
+		"dry-run: would move %s to project %s; target short_id will be assigned by the daemon\n",
+		textsafe.Line(oldRef), textsafe.Line(targetProject))
+	return err
+}
+
+func moveQualifiedID(projectName, shortID string) string {
+	return projectName + "#" + shortID
+}

--- a/cmd/kata/move_test.go
+++ b/cmd/kata/move_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+func setupMoveCLIProjects(t *testing.T) (*testenv.Env, string, db.Project, db.Project, db.Issue) {
+	t.Helper()
+	env, dir := setupCLIEnv(t)
+	ctx := context.Background()
+	source, err := env.DB.CreateProject(ctx, "source-project")
+	require.NoError(t, err)
+	target, err := env.DB.CreateProject(ctx, "target-project")
+	require.NoError(t, err)
+	issue, _, err := env.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: source.ID,
+		Title:     "misfiled issue",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	return env, dir, source, target, issue
+}
+
+func TestMoveCLI_RoundTrip(t *testing.T) {
+	env, dir, source, target, issue := setupMoveCLIProjects(t)
+
+	out := runCLI(t, env, dir, "--project", source.Name, "move", issue.ShortID, target.Name)
+
+	assert.Contains(t, out, source.Name+"#"+issue.ShortID)
+	assert.Contains(t, out, target.Name+"#")
+	stored, err := env.DB.IssueByUID(context.Background(), issue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	assert.Equal(t, target.ID, stored.ProjectID)
+	assert.NotEmpty(t, stored.ShortID)
+}
+
+func TestMoveCLI_DryRunDoesNotMoveIssue(t *testing.T) {
+	env, dir, source, target, issue := setupMoveCLIProjects(t)
+
+	out := runCLI(t, env, dir, "--project", source.Name, "move", issue.ShortID, target.Name, "--dry-run")
+
+	assert.Contains(t, out, "dry-run")
+	assert.Contains(t, out, source.Name+"#"+issue.ShortID)
+	assert.Contains(t, out, "project "+target.Name)
+	stored, err := env.DB.IssueByID(context.Background(), issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, source.ID, stored.ProjectID)
+	assert.Equal(t, issue.ShortID, stored.ShortID)
+}
+
+func TestMoveCLI_WithCommentAppendsToMovedIssue(t *testing.T) {
+	env, dir, source, target, issue := setupMoveCLIProjects(t)
+
+	runCLI(t, env, dir, "--project", source.Name, "move", issue.ShortID, target.Name,
+		"--comment", "relocated to the target project")
+
+	stored, err := env.DB.IssueByUID(context.Background(), issue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	got := fetchIssueViaHTTPWithComments(t, env, target.ID, stored.ShortID)
+	require.Len(t, got.Comments, 1)
+	assert.Equal(t, "relocated to the target project", got.Comments[0].Body)
+}

--- a/cmd/kata/projects.go
+++ b/cmd/kata/projects.go
@@ -27,6 +27,7 @@ type projectAliasRef struct {
 
 type projectRef struct {
 	ID        int64             `json:"id"`
+	UID       string            `json:"uid"`
 	Name      string            `json:"name"`
 	DeletedAt *time.Time        `json:"deleted_at,omitempty"`
 	Aliases   []projectAliasRef `json:"aliases,omitempty"`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,6 +85,19 @@ kata edit <issue-ref> \
   [--comment TEXT]
 ```
 
+Move between projects:
+
+```sh
+kata move <issue-ref> <project> [--dry-run] [--comment TEXT]
+```
+
+`move` keeps the issue UID and history, then assigns the issue to the target
+project. The target project is resolved the same way as `kata projects show`.
+The issue's target `short_id` is assigned by the daemon during the move, so it
+may differ from the source `short_id` if the target project already has a
+collision. `--dry-run` is a client-side preview: it resolves the source issue
+and target project without mutating anything.
+
 Comment:
 
 ```sh


### PR DESCRIPTION
Issue #104 is blocked at the user-facing layer: the daemon already has the single-issue project move primitive, but CLI users still have to avoid or work around misfiled issues because there is no command that calls it.

This adds `kata move <issue-ref> <project>` as the CLI surface for that existing endpoint. The command resolves the source issue, resolves the target project to its stable UID, sends the optimistic move request with `If-Match`, and posts any follow-up comment against the issue after relocation. `--dry-run` is intentionally a client-side preview because the existing daemon/kataflow contract does not define a backend dry-run field.

The CLI reference now documents the command, target short-id assignment, and the preview-only nature of `--dry-run`.

Part of #104.
