### PR TITLE
Support named daemon catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,12 @@ A daemon can serve clients on other hosts over a private network:
   `kata daemon start --listen 100.64.0.5:7777`. Set
   `listen = "100.64.0.5:7777"` in `<KATA_HOME>/config.toml` so every
   daemon (including the auto-started one) binds TCP.
-- Client: `export KATA_SERVER=http://100.64.0.5:7777` or commit a
-  gitignored `.kata.local.toml` with `[server] url = "..."` next to
-  `.kata.toml`. `KATA_SERVER` env wins.
+- Client: `export KATA_SERVER=http://100.64.0.5:7777` for one-off routing, or
+  use a gitignored `.kata.local.toml` with `[server] daemon = "work"` next to
+  `.kata.toml`. Resolve that name from `<KATA_HOME>/config.toml` with
+  `[[daemon]] name = "work"` and `token_env = "KATA_WORK_TOKEN"`.
+  `KATA_SERVER` env wins. Do not put `[auth]` or tokens in `.kata.toml` or
+  `.kata.local.toml`.
 - Unauthenticated private-network mode is `--insecure-readonly`, which permits
   GET requests only. Mutations and the event stream require bearer auth.
 - Trusted plaintext bearer targets must be literal non-public IPs (loopback,

--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -135,10 +135,12 @@ func discoverDaemon(ctx context.Context) (string, error) {
 // client directly; this wrapper exists only because every existing
 // CLI command site is already named for it.
 func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
+	workspaceStart := workspaceStartForRemote()
 	return client.NewHTTPClient(ctx, baseURL,
 		client.Opts{
-			Timeout:       envHTTPTimeout(defaultHTTPTimeout),
-			AllowInsecure: client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStartForRemote()),
+			Timeout:        envHTTPTimeout(defaultHTTPTimeout),
+			AllowInsecure:  client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart),
+			WorkspaceStart: workspaceStart,
 		})
 }
 
@@ -147,9 +149,11 @@ func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 // ResponseHeaderTimeout so a stalled handshake can't hang forever. Body
 // cancellation comes from the request context.
 func streamingClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
+	workspaceStart := workspaceStartForRemote()
 	return client.NewHTTPClient(ctx, baseURL, client.Opts{
 		ResponseHeaderTimeout: client.SSEHandshakeTimeout,
-		AllowInsecure:         client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStartForRemote()),
+		AllowInsecure:         client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart),
+		WorkspaceStart:        workspaceStart,
 	})
 }
 

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -42,6 +42,7 @@ func daemonStartCmd() *cobra.Command {
 	var (
 		listen           string
 		insecureReadonly bool
+		name             string
 	)
 	cmd := &cobra.Command{
 		Use:   "start",
@@ -56,9 +57,11 @@ func daemonStartCmd() *cobra.Command {
 			}
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
-			return runDaemonWithListen(ctx, listen, insecureReadonly)
+			return runDaemonNamedWithListen(ctx, name, listen, insecureReadonly)
 		},
 	}
+	cmd.Flags().StringVar(&name, "name", "",
+		"start the named local daemon from $KATA_HOME/config.toml's daemon catalog")
 	cmd.Flags().StringVar(&listen, "listen", "",
 		"bind TCP at host:port (admin-only; non-public addresses only). "+
 			"Falls back to $KATA_HOME/config.toml's `listen` value when "+
@@ -282,18 +285,23 @@ func redactRuntimeDSN(dsn string) string {
 // config value is used. CLI flag always wins over config.
 // insecureReadonly is the dev escape hatch from --insecure-readonly.
 func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bool) error {
+	return runDaemonNamedWithListen(ctx, "", listen, insecureReadonly)
+}
+
+func runDaemonNamedWithListen(ctx context.Context, name, listen string, insecureReadonly bool) error {
+	name = strings.TrimSpace(name)
 	dcfg, err := config.ReadDaemonConfig()
 	if err != nil {
 		return err
 	}
-	if listen == "" {
-		if listen = dcfg.Listen; listen == "" {
-			if addr, ok := listenFromPortEnv(); ok {
-				listen = addr
-			}
+	if name != "" {
+		dcfg, err = daemonConfigForNamedStart(dcfg, name)
+		if err != nil {
+			return err
 		}
 	}
-	ns, err := daemon.NewNamespace()
+	listen = daemonListenForStart(name, listen, dcfg)
+	ns, err := daemon.NewNamespaceForName(name)
 	if err != nil {
 		return err
 	}
@@ -324,7 +332,7 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	stopCleanup := installStopWatcher(ns.DBHash, cancel)
 	defer stopCleanup()
 
-	dbPath, err := config.KataDSN(ctx)
+	dbPath, err := config.KataDSNForName(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -395,6 +403,59 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	}
 
 	return srv.Serve(ctx, listener)
+}
+
+func daemonListenForStart(name, listen string, cfg *config.DaemonConfig) string {
+	if listen != "" {
+		return listen
+	}
+	if cfg != nil && cfg.Listen != "" {
+		return cfg.Listen
+	}
+	if name == "" {
+		if addr, ok := listenFromPortEnv(); ok {
+			return addr
+		}
+	}
+	return ""
+}
+
+func daemonConfigForNamedStart(cfg *config.DaemonConfig, name string) (*config.DaemonConfig, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return cfg, nil
+	}
+	for _, target := range cfg.Daemons {
+		if target.Name != name {
+			continue
+		}
+		if !target.Local {
+			return nil, fmt.Errorf("daemon %q is not local; only local catalog entries can be started by name", name)
+		}
+		token, err := namedStartToken(target)
+		if err != nil {
+			return nil, err
+		}
+		next := *cfg
+		next.Listen = ""
+		next.Auth = config.AuthConfig{
+			Token:               token,
+			TrustPrivateNetwork: cfg.Auth.TrustPrivateNetwork,
+		}
+		return &next, nil
+	}
+	return nil, fmt.Errorf("daemon %q is not configured in the daemon catalog", name)
+}
+
+func namedStartToken(target config.CatalogDaemonConfig) (string, error) {
+	if target.TokenEnv == "" {
+		return strings.TrimSpace(target.Token), nil
+	}
+	token := strings.TrimSpace(os.Getenv(target.TokenEnv))
+	if token == "" {
+		return "", fmt.Errorf("daemon %q: token_env %q is unset or empty", target.Name, target.TokenEnv)
+	}
+	return token, nil
 }
 
 func newDaemonTelemetryReporter(store db.Storage) telemetry.Client {

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/telemetry"
 	"go.kenn.io/kata/internal/testenv"
@@ -466,6 +467,24 @@ func TestDaemonStart_PortEnvBindsWildcard(t *testing.T) {
 	assert.Contains(t, err.Error(), "0.0.0.0:8081")
 }
 
+func TestDaemonListenForNamedStartIgnoresPortEnv(t *testing.T) {
+	t.Setenv(daemon.AutoStartMarkerEnv, "")
+	t.Setenv("PORT", "8081")
+
+	listen := daemonListenForStart("work", "", &config.DaemonConfig{})
+
+	assert.Empty(t, listen)
+}
+
+func TestDaemonListenForDefaultStartHonorsPortEnv(t *testing.T) {
+	t.Setenv(daemon.AutoStartMarkerEnv, "")
+	t.Setenv("PORT", "8081")
+
+	listen := daemonListenForStart("", "", &config.DaemonConfig{})
+
+	assert.Equal(t, "0.0.0.0:8081", listen)
+}
+
 // TestDaemonStart_ConfigFileListenIsHonored verifies that
 // <KATA_HOME>/config.toml's `listen = ...` value is picked up when the
 // --listen flag is absent. We use an obviously-public address so the
@@ -514,6 +533,49 @@ func TestDaemonStart_FlagWinsOverConfigFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "8.8.8.8")
 	assert.NotContains(t, err.Error(), "1.1.1.1",
 		"config.toml value must NOT win when --listen is set")
+}
+
+func TestDaemonConfigForNamedStartUsesSelectedTokenEnvInsteadOfGlobalAuth(t *testing.T) {
+	t.Setenv("KATA_WORK_AUTH", "work-auth")
+	cfg := &config.DaemonConfig{
+		Auth: config.AuthConfig{Token: "global-token"},
+		Daemons: []config.CatalogDaemonConfig{{ //nolint:gosec // Env var name fixture, not secret material.
+			Name:     "work",
+			Local:    true,
+			TokenEnv: "KATA_WORK_AUTH",
+		}},
+	}
+
+	got, err := daemonConfigForNamedStart(cfg, "work")
+	require.NoError(t, err)
+	assert.Equal(t, "work-auth", got.Auth.Token)
+}
+
+func TestDaemonConfigForNamedStartDoesNotInheritDefaultListen(t *testing.T) {
+	cfg := &config.DaemonConfig{
+		Listen: "100.64.0.5:7777",
+		Daemons: []config.CatalogDaemonConfig{{
+			Name:  "work",
+			Local: true,
+		}},
+	}
+
+	got, err := daemonConfigForNamedStart(cfg, "work")
+	require.NoError(t, err)
+	assert.Empty(t, got.Listen)
+}
+
+func TestDaemonConfigForNamedStartRejectsRemoteCatalogEntry(t *testing.T) {
+	cfg := &config.DaemonConfig{
+		Daemons: []config.CatalogDaemonConfig{{
+			Name: "work",
+			URL:  "https://daemon.example",
+		}},
+	}
+
+	_, err := daemonConfigForNamedStart(cfg, "work")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `daemon "work" is not local`)
 }
 
 func TestNewDaemonTelemetryReporterUsesInstanceUID(t *testing.T) {

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -115,9 +115,8 @@ Writes a committed .kata.toml that binds the workspace to a project
 name. The daemon derives the name from a git remote when one is present;
 pass --project to choose the project name explicitly.
 
-Also adds .kata.local.toml to .gitignore so a developer's per-machine
-overrides (e.g., a remote daemon URL via [server] url = "...") never
-get committed.`,
+Also adds .kata.local.toml to .gitignore so a developer's per-machine,
+non-secret overrides (e.g., [server] daemon = "work") never get committed.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			baseURL, err := ensureDaemon(cmd.Context())
 			if err != nil {

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -136,13 +136,22 @@ KATA_SERVER:
 
    export KATA_SERVER=http://100.64.0.5:7777
 
-Or commit-free per-workspace:
+For commit-free per-workspace routing, prefer a daemon name:
 
    # .kata.local.toml (gitignored by 'kata init')
    version = 1
 
    [server]
+   daemon = "work"
+
+Resolve that name from $KATA_HOME/config.toml:
+
+   [[daemon]]
+   name = "work"
    url = "http://100.64.0.5:7777"
+   token_env = "KATA_WORK_TOKEN"
+
+Do not put [auth] or tokens in .kata.toml or .kata.local.toml.
 
 KATA_SERVER wins over the file when both are set. A configured-but-down
 remote returns exit 7 (kata server not responding) — no silent fallback to

--- a/docs/guide/workspaces-projects.md
+++ b/docs/guide/workspaces-projects.md
@@ -18,7 +18,7 @@ kata init --project product
 ```
 
 `kata init` writes `.kata.toml` and ensures `.kata.local.toml` is ignored. The
-local file is for per-machine settings such as a remote daemon URL.
+local file is for per-machine, non-secret daemon routing.
 
 ## Bind many workspaces to one project
 
@@ -100,10 +100,34 @@ name = "product"
 
 Do not put tokens or host-specific daemon URLs in `.kata.toml`.
 
+If every checkout of the repository should use the same daemon, commit the
+daemon name only:
+
+```toml
+version = 1
+
+[project]
+name = "product"
+
+[server]
+daemon = "work"
+```
+
+Each developer's `KATA_HOME` resolves `work` through their daemon config.
+
 ## `.kata.local.toml`
 
 The local override file is ignored by git. A common use is routing one
-workspace to a remote daemon:
+workspace to a named daemon on this machine:
+
+```toml
+version = 1
+
+[server]
+daemon = "work"
+```
+
+For a local-only literal URL:
 
 ```toml
 version = 1
@@ -113,6 +137,10 @@ url = "http://100.64.0.5:7777"
 ```
 
 `KATA_SERVER` wins over `.kata.local.toml` when both are set.
+
+Do not put `[auth]`, bearer tokens, or token environment values in
+`.kata.toml` or `.kata.local.toml`. Use environment variables or
+`<KATA_HOME>/config.toml` for auth.
 
 ## Non-git workspaces
 

--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -27,6 +27,21 @@ The CLI flag wins over config. Auto-started daemons also read the config-file
 listener, so a host that should always use one TCP address only needs the config
 set once.
 
+For a named local daemon, define the daemon in `<KATA_HOME>/config.toml` and
+start it by name:
+
+```toml
+[[daemon]]
+name = "work"
+local = true
+token_env = "KATA_WORK_TOKEN"
+```
+
+```sh
+export KATA_WORK_TOKEN=change-me
+kata daemon start --name work
+```
+
 Run the daemon under a process manager such as launchd, systemd, or a container
 runtime on the host that owns the SQLite database.
 
@@ -40,16 +55,28 @@ export KATA_AUTH_TOKEN=change-me
 kata list
 ```
 
-For a per-workspace, gitignored setting:
+For a per-workspace, gitignored setting, prefer a named daemon:
 
 ```toml
 version = 1
 
 [server]
-url = "http://100.64.0.5:7777"
+daemon = "work"
 ```
 
-`KATA_SERVER` wins over `.kata.local.toml`.
+Define that daemon in the user's global config without putting secrets in the
+workspace file:
+
+```toml
+[[daemon]]
+name = "work"
+url = "http://100.64.0.5:7777"
+token_env = "KATA_WORK_TOKEN"
+```
+
+`KATA_SERVER` wins over `.kata.local.toml`. Do not put `[auth]` or tokens in
+`.kata.toml` or `.kata.local.toml`; they are daemon selectors, not secret
+stores.
 
 ## Plain HTTP guardrails
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -200,7 +200,7 @@ kata projects detach <alias-identity>
 ## Daemon and diagnostics
 
 ```sh
-kata daemon start [--listen <host:port>] [--insecure-readonly]
+kata daemon start [--name <daemon>] [--listen <host:port>] [--insecure-readonly]
 kata daemon status
 kata daemon stop
 kata daemon reload
@@ -213,8 +213,9 @@ kata tui
 ```
 
 Local commands auto-start the daemon when appropriate. `daemon start` runs in
-the foreground and is used for explicit service setups. `kata agent-instructions`
-is an alias for `kata quickstart`.
+the foreground and is used for explicit service setups. `--name <daemon>`
+starts a named local daemon from `<KATA_HOME>/config.toml`'s daemon catalog.
+`kata agent-instructions` is an alias for `kata quickstart`.
 
 `kata tui` opens the interactive issue browser. In the issue list, `v` toggles
 between nested and flat views: nested groups children under parents, while flat

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -30,6 +30,10 @@ kata resolves its database in this order:
 3. `[storage].dsn` in `<KATA_HOME>/config.toml`
 4. `<KATA_HOME>/kata.db`
 
+For named local daemons, `KATA_DSN` and `KATA_DB` still win first. Otherwise
+the named daemon defaults to `<KATA_HOME>/kata.<name>.db`. Named daemons do not
+read `[storage].dsn` from the default daemon config.
+
 Bare paths and `sqlite://` DSNs select SQLite. `postgres://` and
 `postgresql://` DSNs are reserved for the incomplete Postgres backend and are
 not selectable by normal daemon/CLI store opening yet. `KATA_DB` stays ahead of
@@ -52,11 +56,35 @@ version = 1
 name = "product"
 ```
 
-It should stay secret-free.
+It should stay secret-free. To make every checkout of a repository use the same
+named daemon, commit only the daemon name:
+
+```toml
+version = 1
+
+[project]
+name = "product"
+
+[server]
+daemon = "work"
+```
+
+The name resolves through the user's daemon config, not through repository
+secrets. A committed `.kata.toml` intentionally does not use `[server].url`.
 
 ## Local override
 
-`.kata.local.toml` is gitignored. Use it for machine-specific daemon routing:
+`.kata.local.toml` is gitignored. Use it for machine-specific, non-secret
+daemon routing. Prefer a daemon name when the target has auth or storage config:
+
+```toml
+version = 1
+
+[server]
+daemon = "work"
+```
+
+For a one-off local URL with no repository sharing:
 
 ```toml
 version = 1
@@ -66,6 +94,10 @@ url = "http://100.64.0.5:7777"
 ```
 
 `KATA_SERVER` wins over the local file.
+
+Do not put `[auth]`, bearer tokens, or token environment values in
+`.kata.toml` or `.kata.local.toml`. Workspace files are only selectors; daemon
+auth belongs in environment variables or `<KATA_HOME>/config.toml`.
 
 For trusted private-network hostnames that cannot be represented as literal
 non-public IP addresses, opt in per target:
@@ -80,7 +112,8 @@ allow_insecure = true
 
 ## Daemon config
 
-`<KATA_HOME>/config.toml` can configure storage, listener, and auth behavior:
+`<KATA_HOME>/config.toml` can configure the default daemon's storage,
+listener, and auth behavior:
 
 ```toml
 listen = "100.64.0.5:7777"
@@ -97,6 +130,34 @@ The `kata daemon start --listen <host:port>` flag wins over the config file.
 Auto-started daemons also read the config-file listener value.
 An empty `[storage].dsn` means "no storage override"; env vars or the default
 database path still apply.
+
+The global config can also hold a daemon catalog. Use `token_env` instead of
+inline `token` when the value should stay out of the file:
+
+```toml
+[[daemon]]
+name = "work"
+url = "http://100.64.0.5:7777"
+token_env = "KATA_WORK_TOKEN"
+```
+
+For a named local daemon, set `local = true` in the catalog and start it by
+name. The daemon reads token material from that catalog entry, not from the
+default `[auth].token`:
+
+```toml
+[[daemon]]
+name = "work"
+local = true
+token_env = "KATA_WORK_TOKEN"
+```
+
+```sh
+kata daemon start --name work
+```
+
+Pass `--listen <host:port>` when a named local daemon should bind TCP. The
+default named DB path is `<KATA_HOME>/kata.<name>.db`.
 
 Postgres DSNs may carry credentials. Although they are not selectable yet,
 runtime redaction handles both URL and libpq keyword forms defensively; userinfo

--- a/docs/workflows/sharing.md
+++ b/docs/workflows/sharing.md
@@ -23,7 +23,8 @@ Reach for this when several trusted hosts should share one daemon and one
 database.
 
 The daemon runs on the host that owns the SQLite database and listens on a
-private IP address. Clients set `KATA_SERVER` or `.kata.local.toml`.
+private IP address. Clients set `KATA_SERVER` or a non-secret
+`.kata.local.toml` `[server].daemon` selector.
 
 This model gives users one central copy of project state. It still assumes a
 trusted private network and a deliberately small auth model.

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -9,11 +10,12 @@ import (
 )
 
 // resolveAuthToken returns the auth token a client should attach to
-// outgoing requests. Resolution mirrors the daemon side:
+// outgoing requests. Resolution is:
 //
 //  1. KATA_AUTH_TOKEN env (highest priority).
-//  2. [auth].token in <KATA_HOME>/config.toml.
-//  3. Empty (no header injected).
+//  2. Selected named-daemon token/auth when a workspace selects one.
+//  3. [auth].token in <KATA_HOME>/config.toml for the default path.
+//  4. Empty (no header injected).
 //
 // Errors reading the TOML are not surfaced: a misformatted file should
 // not silently strand the CLI on a no-auth path, but it also should not
@@ -26,13 +28,90 @@ func resolveAuthToken() string {
 }
 
 func resolveAuthConfig() config.AuthConfig {
-	envToken := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
-	envTrust := config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
-	auth, err := config.ReadAuthConfig()
+	auth, err := resolveAuthConfigForBaseURL("", "")
 	if err != nil {
-		return config.AuthConfig{Token: envToken, TrustPrivateNetwork: envTrust}
+		return config.AuthConfig{
+			Token:               strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")),
+			TrustPrivateNetwork: config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK"),
+		}
 	}
 	return auth
+}
+
+func resolveAuthConfigForBaseURL(baseURL, workspaceStart string) (config.AuthConfig, error) {
+	envToken := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
+	envTrust := config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
+	auth, target, useNamedAuth, err := baseAuthConfigForTarget(baseURL, workspaceStart, false)
+	if err != nil {
+		return config.AuthConfig{}, err
+	}
+	if useNamedAuth && envToken == "" {
+		token, err := namedDaemonToken(target.Catalog)
+		if err != nil {
+			return config.AuthConfig{}, err
+		}
+		auth.Token = token
+	}
+	if envToken != "" {
+		auth.Token = envToken
+	}
+	if envTrust {
+		auth.TrustPrivateNetwork = true
+	}
+	return auth, nil
+}
+
+func resolveAuthConfigForExplicitBearer(baseURL, workspaceStart, token string) (config.AuthConfig, error) {
+	auth, _, _, err := baseAuthConfigForTarget(baseURL, workspaceStart, true)
+	if err != nil {
+		return config.AuthConfig{}, err
+	}
+	auth.Token = token
+	if config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK") {
+		auth.TrustPrivateNetwork = true
+	}
+	return auth, nil
+}
+
+func baseAuthConfigForTarget(
+	baseURL, workspaceStart string,
+	ignoreNamedTargetErrors bool,
+) (config.AuthConfig, namedDaemonTarget, bool, error) {
+	auth, err := config.ReadAuthConfig()
+	if err != nil {
+		auth = config.AuthConfig{}
+	}
+	target, ok, err := selectedNamedDaemonTarget(workspaceStart)
+	if err != nil {
+		if ignoreNamedTargetErrors {
+			return auth, namedDaemonTarget{}, false, nil
+		}
+		return config.AuthConfig{}, namedDaemonTarget{}, false, err
+	}
+	if ok && (baseURL == "" || namedDaemonTargetMatchesBaseURL(target.Catalog, baseURL)) {
+		return target.Auth, target, true, nil
+	}
+	return auth, namedDaemonTarget{}, false, nil
+}
+
+func namedDaemonTargetMatchesBaseURL(target config.CatalogDaemonConfig, baseURL string) bool {
+	if target.Local {
+		return baseURL == UnixBase || strings.HasPrefix(baseURL, UnixBase+"/")
+	}
+	u, err := normalizeRemoteURL(target.URL, target.AllowInsecure)
+	return err == nil && u == strings.TrimRight(baseURL, "/")
+}
+
+func namedDaemonToken(target config.CatalogDaemonConfig) (string, error) {
+	if target.TokenEnv == "" {
+		return strings.TrimSpace(target.Token), nil
+	}
+	token := strings.TrimSpace(os.Getenv(target.TokenEnv))
+	if token == "" {
+		return "", fmt.Errorf("daemon %q: token_env %q is unset or empty",
+			target.Name, target.TokenEnv)
+	}
+	return token, nil
 }
 
 // withBearer wraps base with bearer-token injection when token is

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -30,6 +30,256 @@ func TestResolveAuthTokenFallsBackToTOML(t *testing.T) {
 	assert.Equal(t, "from-toml", resolveAuthToken())
 }
 
+func TestNewHTTPClientUsesSelectedNamedDaemonTokenEnv(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_WORK_TOKEN", "named-token")
+	require.NoError(t, writeRawConfig(home, `[auth]
+token = "global-token"
+
+[[daemon]]
+name = "work"
+url = "`+srv.URL+`"
+token_env = "KATA_WORK_TOKEN"
+`))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`version = 1
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer named-token", got)
+}
+
+func TestNewHTTPClientUsesSelectedNamedDaemonTokenEnvWhenConfigNameTomlExists(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_WORK_TOKEN", "named-token")
+	require.NoError(t, writeRawConfig(home, `[[daemon]]
+name = "work"
+url = "`+srv.URL+`"
+token_env = "KATA_WORK_TOKEN"
+`))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.work.toml"), []byte(`listen = "`+srv.Listener.Addr().String()+`"
+
+[auth]
+token = "wrong-token"
+`), 0o600))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`version = 1
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer named-token", got)
+}
+
+func TestNewHTTPClientSelectedNamedDaemonDoesNotUseGlobalAuthToken(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `[auth]
+token = "global-token"
+
+[[daemon]]
+name = "work"
+url = "`+srv.URL+`"
+`))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`version = 1
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Empty(t, got)
+}
+
+func TestNewHTTPClientKATAServerIgnoresWorkspaceNamedDaemon(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", srv.URL)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeAuthConfig(home, "global-token"))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`version = 1
+
+[server]
+daemon = "missing"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer global-token", got)
+}
+
+func TestNewHTTPClientEnvTokenWinsOverSelectedNamedDaemonToken(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "env-token")
+	require.NoError(t, writeRawConfig(home, `[[daemon]]
+name = "work"
+url = "`+srv.URL+`"
+token = "named-token"
+`))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`version = 1
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer env-token", got)
+}
+
+func TestNewHTTPClientEnvTokenSkipsSelectedNamedDaemonTokenEnv(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "env-token")
+	t.Setenv("KATA_WORK_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `[[daemon]]
+name = "work"
+url = "`+srv.URL+`"
+token_env = "KATA_WORK_TOKEN"
+`))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`version = 1
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer env-token", got)
+}
+
+func TestNewHTTPClientUsesSelectedNamedDaemonAllowInsecure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `[[daemon]]
+name = "work"
+url = "http://tailscale-host:7777"
+token = "named-token"
+allow_insecure = true
+`))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`version = 1
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), "http://tailscale-host:7777", Opts{})
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
 func TestResolveAuthTokenIgnoresUnresolvedCatalogTokenEnv(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("KATA_HOME", tmp)
@@ -179,6 +429,82 @@ func TestNewHTTPClientWithBearerAttachesExplicitToken(t *testing.T) {
 	c, err := NewHTTPClientWithBearer(context.Background(), srv.URL, "explicit-token", Opts{})
 	require.NoError(t, err)
 
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer explicit-token", got)
+}
+
+func TestNewHTTPClientWithBearerSkipsSelectedNamedDaemonTokenEnv(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_WORK_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `[[daemon]]
+name = "work"
+url = "`+srv.URL+`"
+token_env = "KATA_WORK_TOKEN"
+`))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`version = 1
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	c, err := NewHTTPClientWithBearer(context.Background(), srv.URL, "explicit-token", Opts{})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer explicit-token", got)
+}
+
+func TestNewHTTPClientWithBearerIgnoresConfigNameToml(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `[[daemon]]
+name = "work"
+url = "`+srv.URL+`"
+`))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.work.toml"),
+		[]byte(`listen = "127.0.0.1:7777"`+"\n"), 0o600))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`version = 1
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	c, err := NewHTTPClientWithBearer(context.Background(), srv.URL, "explicit-token", Opts{})
+	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		srv.URL+"/api/v1/projects", nil)
 	require.NoError(t, err)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -132,6 +132,7 @@ type Opts struct {
 	Timeout               time.Duration
 	ResponseHeaderTimeout time.Duration
 	AllowInsecure         bool
+	WorkspaceStart        string
 }
 
 // TargetAuth is explicit per-target bearer configuration. It is used by
@@ -156,7 +157,10 @@ type TargetAuth struct {
 // from the first-party CLI/TUI without callers having to plumb the header
 // through every request site.
 func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client, error) {
-	auth := resolveAuthConfig()
+	auth, err := resolveAuthConfigForBaseURL(baseURL, opts.WorkspaceStart)
+	if err != nil {
+		return nil, err
+	}
 	return newHTTPClientWithAuth(ctx, baseURL, auth, opts)
 }
 
@@ -166,8 +170,10 @@ func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client
 // federation callers honour the operator opt-in even when supplying their
 // own token.
 func NewHTTPClientWithBearer(ctx context.Context, baseURL, token string, opts Opts) (*http.Client, error) {
-	auth := resolveAuthConfig()
-	auth.Token = token
+	auth, err := resolveAuthConfigForExplicitBearer(baseURL, opts.WorkspaceStart, token)
+	if err != nil {
+		return nil, err
+	}
 	return newHTTPClientWithAuth(ctx, baseURL, auth, opts)
 }
 
@@ -193,7 +199,7 @@ func newHTTPClientWithAuth(ctx context.Context, baseURL string, auth config.Auth
 	if err != nil {
 		return nil, err
 	}
-	allowInsecure := opts.AllowInsecure || remoteAllowInsecureForBaseURL(baseURL, "")
+	allowInsecure := opts.AllowInsecure || remoteAllowInsecureForBaseURL(baseURL, opts.WorkspaceStart)
 	rt, err := authBearerTransport(c.Transport, auth.Token, baseURL, auth.TrustPrivateNetwork, allowInsecure)
 	if err != nil {
 		return nil, err

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -28,6 +28,7 @@ const (
 var (
 	currentVersionForEnsure     = func() string { return version.Version }
 	startDaemonForEnsure        = autoStart
+	startNamedDaemonForEnsure   = autoStartNamed
 	stopRunningDaemonsForEnsure = stopRunningDaemons
 	signalDaemonStopForEnsure   = daemon.SignalDaemonStop
 )
@@ -93,6 +94,27 @@ func ensureLocalRunning(ctx context.Context) (string, error) {
 		return startDaemonForEnsure(ctx, ns.DataDir)
 	}
 	return startDaemonForEnsure(ctx, ns.DataDir)
+}
+
+func ensureLocalRunningForName(ctx context.Context, name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ensureLocalRunning(ctx)
+	}
+	ns, err := daemon.NewNamespaceForName(name)
+	if err != nil {
+		return "", err
+	}
+	if url, compatible, ok := discoverForEnsure(ctx, ns.DataDir); ok {
+		if compatible {
+			return url, nil
+		}
+		if err := stopRunningDaemonsForEnsure(ctx, ns.DataDir, ns.DBHash); err != nil {
+			return "", err
+		}
+		return startNamedDaemonForEnsure(ctx, name, ns.DataDir)
+	}
+	return startNamedDaemonForEnsure(ctx, name, ns.DataDir)
 }
 
 func discoverForEnsure(ctx context.Context, dataDir string) (string, bool, bool) {
@@ -167,6 +189,14 @@ func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
 }
 
 func autoStart(ctx context.Context, dataDir string) (string, error) {
+	return autoStartDaemon(ctx, "", dataDir)
+}
+
+func autoStartNamed(ctx context.Context, name, dataDir string) (string, error) {
+	return autoStartDaemon(ctx, name, dataDir)
+}
+
+func autoStartDaemon(ctx context.Context, name, dataDir string) (string, error) {
 	exe, err := os.Executable()
 	if err != nil {
 		return "", err
@@ -174,8 +204,12 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 	if shouldRefuseAutoStartDaemon(exe) {
 		return "", fmt.Errorf("refusing to auto-start daemon from ephemeral binary %s", filepath.Base(exe))
 	}
+	args := []string{"daemon", "start"}
+	if name != "" {
+		args = append(args, "--name", name)
+	}
 	//nolint:gosec // G204: exe is os.Executable()
-	cmd := exec.Command(exe, "daemon", "start")
+	cmd := exec.Command(exe, args...)
 	// The auto-started daemon outlives this process, so it must not inherit
 	// our stdio. Inheriting the caller's stderr keeps that handle open after
 	// the daemon detaches, which hangs any parent that captures our output

--- a/internal/client/named_daemon.go
+++ b/internal/client/named_daemon.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"strings"
+
+	"go.kenn.io/kata/internal/config"
+)
+
+type namedDaemonTarget struct {
+	Catalog    config.CatalogDaemonConfig
+	Auth       config.AuthConfig
+	SourcePath string
+}
+
+func selectedNamedDaemonTarget(workspaceStart string) (namedDaemonTarget, bool, error) {
+	server, _, ok, err := workspaceServerSelection(workspaceStart)
+	if err != nil {
+		return namedDaemonTarget{}, false, err
+	}
+	if !ok || server.Daemon == "" {
+		return namedDaemonTarget{}, false, nil
+	}
+	return lookupNamedDaemonTarget(server.Daemon)
+}
+
+func lookupNamedDaemonTarget(name string) (namedDaemonTarget, bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return namedDaemonTarget{}, false, nil
+	}
+	globalPath, err := config.DaemonConfigPath()
+	if err != nil {
+		return namedDaemonTarget{}, false, err
+	}
+	global, err := config.ReadDaemonConfig()
+	if err != nil {
+		return namedDaemonTarget{}, false, err
+	}
+	for _, target := range global.Daemons {
+		if target.Name != name {
+			continue
+		}
+		return namedDaemonTarget{
+			Catalog:    target,
+			SourcePath: globalPath,
+		}, true, nil
+	}
+	return namedDaemonTarget{}, false, nil
+}

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -80,28 +80,106 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 		}
 		return u, true, nil
 	}
-	root, path, ok := findLocalConfig(workspaceStart)
+	server, path, ok, err := workspaceServerSelection(workspaceStart)
+	if err != nil {
+		return "", false, err
+	}
 	if !ok {
 		return "", false, nil
 	}
-	cfg, err := config.ReadLocalConfig(root)
-	if err != nil {
-		if errors.Is(err, config.ErrLocalConfigMissing) {
-			return "", false, nil
+	if server.URL != "" {
+		u, err := normalizeRemoteURL(server.URL, server.AllowInsecure)
+		if err != nil {
+			return "", false, fmt.Errorf("%s server.url %q: %w", path, server.URL, err)
 		}
-		return "", false, fmt.Errorf("read %s: %w", path, err)
+		if !probeRemote(ctx, u) {
+			return "", false, fmt.Errorf("%w: %s (%s)", ErrRemoteUnavailable, u, path)
+		}
+		return u, true, nil
 	}
-	if cfg.Server.URL == "" {
-		return "", false, nil
+	if server.Daemon != "" {
+		u, err := resolveNamedRemote(ctx, server.Daemon, path)
+		if err != nil {
+			return "", false, err
+		}
+		return u, true, nil
 	}
-	u, err := normalizeRemoteURL(cfg.Server.URL, cfg.Server.AllowInsecure)
+	return "", false, nil
+}
+
+func workspaceServerSelection(workspaceStart string) (config.ServerConfig, string, bool, error) {
+	start := workspaceStart
+	if start == "" {
+		var err error
+		start, err = os.Getwd()
+		if err != nil {
+			return config.ServerConfig{}, "", false, nil
+		}
+	}
+
+	if root, path, ok := findLocalConfig(start); ok {
+		cfg, err := config.ReadLocalConfig(root)
+		if err != nil {
+			if errors.Is(err, config.ErrLocalConfigMissing) {
+				return config.ServerConfig{}, "", false, nil
+			}
+			return config.ServerConfig{}, "", false, fmt.Errorf("read %s: %w", path, err)
+		}
+		if err := validateServerSelection(cfg.Server, path); err != nil {
+			return config.ServerConfig{}, "", false, err
+		}
+		if cfg.Server.URL != "" || cfg.Server.Daemon != "" {
+			return cfg.Server, path, true, nil
+		}
+	}
+
+	cfg, root, err := config.FindProjectConfig(start)
 	if err != nil {
-		return "", false, fmt.Errorf("%s server.url %q: %w", path, cfg.Server.URL, err)
+		if errors.Is(err, config.ErrProjectConfigMissing) {
+			return config.ServerConfig{}, "", false, nil
+		}
+		return config.ServerConfig{}, "", false, err
+	}
+	path := filepath.Join(root, config.ProjectConfigFilename)
+	if err := validateServerSelection(cfg.Server, path); err != nil {
+		return config.ServerConfig{}, "", false, err
+	}
+	if cfg.Server.Daemon == "" {
+		return config.ServerConfig{}, "", false, nil
+	}
+	return config.ServerConfig{Daemon: cfg.Server.Daemon}, path, true, nil
+}
+
+func validateServerSelection(server config.ServerConfig, path string) error {
+	if server.URL != "" && server.Daemon != "" {
+		return fmt.Errorf("%s [server]: exactly one of url or daemon is allowed", path)
+	}
+	return nil
+}
+
+func resolveNamedRemote(ctx context.Context, name, sourcePath string) (string, error) {
+	target, ok, err := lookupNamedDaemonTarget(name)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("%s server.daemon: daemon %q is not configured", sourcePath, name)
+	}
+	if target.Catalog.Local {
+		u, err := ensureLocalRunningForName(ctx, name)
+		if err != nil {
+			return "", err
+		}
+		return u, nil
+	}
+	u, err := normalizeRemoteURL(target.Catalog.URL, target.Catalog.AllowInsecure)
+	if err != nil {
+		return "", fmt.Errorf("daemon %q url %q: %w", name, target.Catalog.URL, err)
 	}
 	if !probeRemote(ctx, u) {
-		return "", false, fmt.Errorf("%w: %s (%s)", ErrRemoteUnavailable, u, path)
+		return "", fmt.Errorf("%w: %s (daemon %q from %s)", ErrRemoteUnavailable, u, name, sourcePath)
 	}
-	return u, true, nil
+	return u, nil
 }
 
 // envAllowInsecure reports whether KATA_ALLOW_INSECURE is set to a
@@ -118,16 +196,26 @@ func remoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 		u, err := normalizeRemoteURL(v, allow)
 		return err == nil && u == baseURL && allow
 	}
-	root, _, ok := findLocalConfig(workspaceStart)
-	if !ok {
+	server, _, ok, err := workspaceServerSelection(workspaceStart)
+	if err != nil || !ok {
 		return false
 	}
-	cfg, err := config.ReadLocalConfig(root)
-	if err != nil || cfg.Server.URL == "" || !cfg.Server.AllowInsecure {
-		return false
+	if server.URL != "" {
+		if !server.AllowInsecure {
+			return false
+		}
+		u, err := normalizeRemoteURL(server.URL, true)
+		return err == nil && u == baseURL
 	}
-	u, err := normalizeRemoteURL(cfg.Server.URL, true)
-	return err == nil && u == baseURL
+	if server.Daemon != "" {
+		target, ok, err := selectedNamedDaemonTarget(workspaceStart)
+		if err != nil || !ok || !target.Catalog.AllowInsecure || target.Catalog.Local {
+			return false
+		}
+		u, err := normalizeRemoteURL(target.Catalog.URL, true)
+		return err == nil && u == baseURL
+	}
+	return false
 }
 
 // findLocalConfig walks upward from start looking for .kata.local.toml,

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -88,6 +88,167 @@ url = "`+srv.URL+`"
 	assert.Equal(t, srv.URL, url)
 }
 
+func TestResolveRemote_ProjectNamedDaemonWhenNoEnvOrLocalURL(t *testing.T) {
+	srv := pingingServer(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte(`[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+`), 0o600))
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"),
+		[]byte(`version = 1
+
+[project]
+name = "spoke-project"
+
+[server]
+daemon = "shared"
+`), 0o600))
+
+	url, ok, err := resolveRemote(context.Background(), "")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, srv.URL, url)
+}
+
+func TestResolveRemote_LocalNamedDaemonOverridesProjectDaemon(t *testing.T) {
+	projectSrv := pingingServer(t)
+	localSrv := pingingServer(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte(`[[daemon]]
+name = "project"
+url = "`+projectSrv.URL+`"
+
+[[daemon]]
+name = "local"
+url = "`+localSrv.URL+`"
+`), 0o600))
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"),
+		[]byte(`version = 1
+
+[project]
+name = "spoke-project"
+
+[server]
+daemon = "project"
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+
+[server]
+daemon = "local"
+`), 0o600))
+
+	url, ok, err := resolveRemote(context.Background(), "")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, localSrv.URL, url)
+}
+
+func TestResolveRemote_NamedDaemonMissingErrorsWithoutFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"),
+		[]byte(`version = 1
+
+[project]
+name = "spoke-project"
+
+[server]
+daemon = "missing"
+`), 0o600))
+
+	url, ok, err := resolveRemote(context.Background(), "")
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, url)
+	assert.Contains(t, err.Error(), `daemon "missing"`)
+}
+
+func TestResolveRemote_NamedDaemonRequiresCatalogEntryEvenWhenConfigNameTomlExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.work.toml"),
+		[]byte(`listen = "127.0.0.1:7777"`+"\n"), 0o600))
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"),
+		[]byte(`version = 1
+
+[project]
+name = "spoke-project"
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	url, ok, err := resolveRemote(context.Background(), "")
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, url)
+	assert.Contains(t, err.Error(), `daemon "work"`)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestResolveRemote_LocalCatalogDaemonUsesNamedLocalDaemon(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`[[daemon]]
+name = "work"
+local = true
+`), 0o600))
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"),
+		[]byte(`version = 1
+
+[project]
+name = "spoke-project"
+
+[server]
+daemon = "work"
+`), 0o600))
+
+	var defaultStarted bool
+	var namedStarted string
+	oldStartDefault := startDaemonForEnsure
+	oldStartNamed := startNamedDaemonForEnsure
+	startDaemonForEnsure = func(context.Context, string) (string, error) {
+		defaultStarted = true
+		return "unix-default", nil
+	}
+	startNamedDaemonForEnsure = func(_ context.Context, name, _ string) (string, error) {
+		namedStarted = name
+		return "unix-named", nil
+	}
+	t.Cleanup(func() {
+		startDaemonForEnsure = oldStartDefault
+		startNamedDaemonForEnsure = oldStartNamed
+	})
+
+	url, ok, err := resolveRemote(context.Background(), "")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "unix-named", url)
+	assert.False(t, defaultStarted, "named local daemon must not fall back to the default local daemon")
+	assert.Equal(t, "work", namedStarted)
+}
+
 func TestResolveRemote_EnvWinsOverFile(t *testing.T) {
 	srv := pingingServer(t)
 	t.Setenv("KATA_SERVER", srv.URL)

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -127,6 +127,10 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	return readDaemonConfigFile(path, true)
+}
+
+func readDaemonConfigFile(path string, missingOK bool) (*DaemonConfig, error) {
 	var cfg DaemonConfig
 	data, err := os.ReadFile(path) //nolint:gosec // path is derived from KATA_HOME, not user input
 	switch {
@@ -148,6 +152,9 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 		cfg.Storage.DSN = strings.TrimSpace(cfg.Storage.DSN)
 		trimDaemonCatalog(&cfg)
 	case errors.Is(err, os.ErrNotExist):
+		if !missingOK {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
 		// Absent file: fall through with zero-value cfg. Env merge and
 		// validation below still apply so an env-only misconfig is
 		// caught the same way a TOML-only one is.

--- a/internal/config/dsn_resolve.go
+++ b/internal/config/dsn_resolve.go
@@ -60,6 +60,39 @@ func KataDSN(ctx context.Context) (string, error) {
 	return filepath.Join(home, "kata.db"), nil
 }
 
+// KataDSNForName returns the effective database DSN for a named local daemon.
+// The empty name preserves KataDSN. Non-empty names still honor KATA_DSN and
+// KATA_DB first, then default to <KATA_HOME>/kata.<name>.db. Named daemons do
+// not read <KATA_HOME>/config.toml [storage] because that belongs to the
+// default daemon.
+func KataDSNForName(ctx context.Context, name string) (string, error) {
+	_ = ctx
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return KataDSN(ctx)
+	}
+	if err := validateNamedDaemonName(name); err != nil {
+		return "", err
+	}
+	if v := strings.TrimSpace(os.Getenv("KATA_DSN")); v != "" {
+		if err := validateDSN(v); err != nil {
+			return "", err
+		}
+		return v, nil
+	}
+	if v := strings.TrimSpace(os.Getenv("KATA_DB")); v != "" {
+		if err := validateDSN(v); err != nil {
+			return "", err
+		}
+		return v, nil
+	}
+	home, err := KataHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "kata."+name+".db"), nil
+}
+
 // validateDSN performs shape-only validation: it rejects unknown schemes,
 // scheme-less libpq keyword DSNs, and libpq query params on sqlite/bare DSNs,
 // and propagates the ambiguous-credentials probe from CanonicalDSNIdentity for

--- a/internal/config/dsn_resolve_test.go
+++ b/internal/config/dsn_resolve_test.go
@@ -238,6 +238,40 @@ func TestKataDSN_StorageDSNUsedWhenKataDBUnset(t *testing.T) {
 	assert.Equal(t, "postgres://from-toml/kata", got)
 }
 
+func TestKataDSNForName_IgnoresConfigNameTomlStorage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DSN", "")
+	t.Setenv("KATA_DB", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.work.toml"),
+		[]byte("[storage]\ndsn = \"postgres://work/kata\"\n"), 0o600))
+
+	got, err := config.KataDSNForName(context.Background(), "work")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "kata.work.db"), got)
+}
+
+func TestKataDSNForName_DefaultsToNamedDBPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_DSN", "")
+	t.Setenv("KATA_DB", "")
+
+	got, err := config.KataDSNForName(context.Background(), "work")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "kata.work.db"), got)
+}
+
+func TestKataDSNForName_RejectsUnsafeName(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_DSN", "")
+	t.Setenv("KATA_DB", "")
+
+	_, err := config.KataDSNForName(context.Background(), "../work")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon name")
+}
+
 func TestKataDSN_KataDSNOverridesStorageDSN(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)

--- a/internal/config/local_config.go
+++ b/internal/config/local_config.go
@@ -46,6 +46,7 @@ func ReadLocalConfig(workspaceRoot string) (*ProjectConfig, error) {
 		}
 	}
 	cfg.Server.URL = strings.TrimSpace(cfg.Server.URL)
+	cfg.Server.Daemon = strings.TrimSpace(cfg.Server.Daemon)
 	return &cfg, nil
 }
 
@@ -69,6 +70,11 @@ func MergeLocalWithStderr(base, local *ProjectConfig, stderr io.Writer) *Project
 	}
 	if local.Server.URL != "" {
 		merged.Server.URL = local.Server.URL
+		merged.Server.Daemon = ""
+	}
+	if local.Server.Daemon != "" {
+		merged.Server.Daemon = local.Server.Daemon
+		merged.Server.URL = ""
 	}
 	return &merged
 }

--- a/internal/config/local_config_test.go
+++ b/internal/config/local_config_test.go
@@ -36,6 +36,18 @@ url = "http://100.64.0.5:7777"
 	assert.Equal(t, "http://100.64.0.5:7777", cfg.Server.URL)
 }
 
+func TestReadLocalConfig_NamedServerDaemonOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeKataLocal(t, dir, `version = 1
+
+[server]
+daemon = "work"
+`)
+	cfg, err := config.ReadLocalConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "work", cfg.Server.Daemon)
+}
+
 func TestReadLocalConfig_RejectsBadVersion(t *testing.T) {
 	dir := t.TempDir()
 	writeKataLocal(t, dir, `version = 2
@@ -85,6 +97,7 @@ func TestMergeLocal_LocalServerWins(t *testing.T) {
 	base := &config.ProjectConfig{
 		Version: 1,
 		Project: config.ProjectBindings{Name: "kata"},
+		Server:  config.ServerConfig{Daemon: "work"},
 	}
 	local := &config.ProjectConfig{
 		Version: 1,
@@ -95,6 +108,20 @@ func TestMergeLocal_LocalServerWins(t *testing.T) {
 	assert.Equal(t, "kata", got.Project.Name)
 	assert.Equal(t, "http://100.64.0.5:7777", got.Server.URL)
 	assert.Empty(t, stderr.String())
+}
+
+func TestMergeLocal_LocalDaemonOverridesBase(t *testing.T) {
+	base := &config.ProjectConfig{
+		Version: 1,
+		Project: config.ProjectBindings{Name: "kata"},
+		Server:  config.ServerConfig{Daemon: "work"},
+	}
+	local := &config.ProjectConfig{
+		Version: 1,
+		Server:  config.ServerConfig{Daemon: "personal"},
+	}
+	got := config.MergeLocal(base, local)
+	assert.Equal(t, "personal", got.Server.Daemon)
 }
 
 func TestMergeLocal_LocalNameOverridesBase(t *testing.T) {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -104,6 +104,20 @@ func DaemonConfigPath() (string, error) {
 	return filepath.Join(home, "config.toml"), nil
 }
 
+func validateNamedDaemonName(name string) error {
+	if name == "." || name == ".." || strings.HasPrefix(name, ".") {
+		return fmt.Errorf("daemon name %q is not valid in a filename", name)
+	}
+	for _, r := range name {
+		isLetter := r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z'
+		isDigit := r >= '0' && r <= '9'
+		if !isLetter && !isDigit && r != '-' && r != '_' && r != '.' {
+			return fmt.Errorf("daemon name %q is not valid in a filename", name)
+		}
+	}
+	return nil
+}
+
 // FederationCredentialsPath returns <KataHome>/credentials.toml. It stores
 // local secrets such as federation bearer tokens and must not be committed to a
 // workspace.

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -34,10 +34,10 @@ type ProjectBindings struct {
 }
 
 // ServerConfig carries the [server] block. Optional in both committed
-// and local config files. URL is the daemon base URL (e.g.
-// http://100.64.0.5:7777). When set on .kata.local.toml it directs
-// the client to a remote daemon; ignored if it appears in committed
-// .kata.toml in v1, but parsed without error.
+// and local config files. Daemon is a non-secret named daemon selector.
+// URL is the daemon base URL (e.g. http://100.64.0.5:7777). When set
+// on .kata.local.toml it directs the client to a remote daemon; ignored
+// if it appears in committed .kata.toml in v1, but parsed without error.
 //
 // AllowInsecure opts out of the client-side scheme guard that rejects
 // plain http to a non-private host. Required when URL uses a hostname
@@ -45,6 +45,7 @@ type ProjectBindings struct {
 // over plain http. Has no effect on https URLs.
 type ServerConfig struct {
 	URL           string `toml:"url,omitempty"`
+	Daemon        string `toml:"daemon,omitempty"`
 	AllowInsecure bool   `toml:"allow_insecure,omitempty"`
 }
 
@@ -75,6 +76,7 @@ func ReadProjectConfig(workspaceRoot string) (*ProjectConfig, error) {
 	if err := ValidateProjectName(cfg.Project.Name); err != nil {
 		return nil, fmt.Errorf("project.name: %w", err)
 	}
+	cfg.Server.Daemon = strings.TrimSpace(cfg.Server.Daemon)
 	return &cfg, nil
 }
 

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -156,6 +156,20 @@ url = "http://127.0.0.1:7777"
 	assert.Equal(t, "http://127.0.0.1:7777", cfg.Server.URL)
 }
 
+func TestReadProjectConfig_AcceptsNamedServerDaemon(t *testing.T) {
+	dir := setupKataProjectDir(t, `version = 1
+
+[project]
+name = "kata"
+
+[server]
+daemon = "work"
+`)
+	cfg, err := config.ReadProjectConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "work", cfg.Server.Daemon)
+}
+
 func TestReadProjectConfig_NoServerBlockYieldsZeroValue(t *testing.T) {
 	dir := setupKataProjectDir(t, `version = 1
 

--- a/internal/daemon/namespace.go
+++ b/internal/daemon/namespace.go
@@ -30,18 +30,30 @@ func NewNamespace() (*Namespace, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve kata DSN: %w", err)
 	}
-	dataRoot, err := config.RuntimeDir()
+	return namespaceForDSN(dbPath)
+}
+
+// NewNamespaceForName resolves directories for a named local daemon. Named
+// daemons use their own default DB path, so their runtime records and sockets
+// do not collide with the default daemon.
+func NewNamespaceForName(name string) (*Namespace, error) {
+	dbPath, err := config.KataDSNForName(context.Background(), name)
 	if err != nil {
-		return nil, fmt.Errorf("resolve runtime dir: %w", err)
+		return nil, fmt.Errorf("resolve kata DSN: %w", err)
+	}
+	return namespaceForDSN(dbPath)
+}
+
+func namespaceForDSN(dbPath string) (*Namespace, error) {
+	home, err := config.KataHome()
+	if err != nil {
+		return nil, fmt.Errorf("resolve kata home: %w", err)
 	}
 	hash := config.DBHash(dbPath)
-
-	socketDir := socketParent(hash)
-
 	return &Namespace{
 		DBHash:    hash,
-		DataDir:   dataRoot,
-		SocketDir: socketDir,
+		DataDir:   filepath.Join(home, "runtime", hash),
+		SocketDir: socketParent(hash),
 	}, nil
 }
 

--- a/internal/daemon/namespace_test.go
+++ b/internal/daemon/namespace_test.go
@@ -32,6 +32,17 @@ func TestNamespace_DataDirIsKataHomeRuntime(t *testing.T) {
 	assert.Equal(t, hash, ns.DBHash)
 }
 
+func TestNamespaceForName_DataDirUsesNamedDSN(t *testing.T) {
+	tmp := setupMockEnv(t)
+	t.Setenv("KATA_DB", "")
+
+	ns, err := daemon.NewNamespaceForName("work")
+	require.NoError(t, err)
+	hash := config.DBHash(filepath.Join(tmp, "kata.work.db"))
+	assert.Equal(t, filepath.Join(tmp, "runtime", hash), ns.DataDir)
+	assert.Equal(t, hash, ns.DBHash)
+}
+
 func TestNamespace_SocketDirHonorsXDGRuntimeDir(t *testing.T) {
 	setupMockEnv(t)
 	xdg := t.TempDir()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,6 +40,7 @@ type TransportOptions struct {
 	Timeout               time.Duration
 	ResponseHeaderTimeout time.Duration
 	AllowInsecure         bool
+	WorkspaceStart        string
 }
 
 type options struct {
@@ -180,6 +181,7 @@ func internalOpts(opts TransportOptions) internalclient.Opts {
 		Timeout:               opts.Timeout,
 		ResponseHeaderTimeout: opts.ResponseHeaderTimeout,
 		AllowInsecure:         opts.AllowInsecure,
+		WorkspaceStart:        opts.WorkspaceStart,
 	}
 }
 


### PR DESCRIPTION
## What changed

This adds a named daemon catalog flow for repo-specific daemon selection without putting secrets in repo-local config. `.kata.toml` and `.kata.local.toml` can select `[server].daemon = "work"`, and each user's `KATA_HOME/config.toml` resolves that name through a `[[daemon]]` catalog entry.

Client auth now treats the selected daemon's catalog entry as the auth boundary: `token_env` is the preferred secret path, explicit `KATA_AUTH_TOKEN` and explicit bearer clients still override token lookup, and unrelated global auth is not consumed for a selected named daemon.

Named local daemons get separate runtime/storage identity via `kata.<name>.db`, and `kata daemon start --name` starts only local catalog entries. Named starts do not inherit the default daemon listener or hosted `PORT` fallback unless the operator supplies `--listen`.

## Why

The repo-local files should be selectors, not secret stores. This lets a repository say "use the work daemon" while keeping each developer's URL/token/env details in their own global config and shell environment.

## Tradeoffs

This intentionally uses a single global daemon catalog so daemon selection, auth env var names, and local/remote targets have one owner. Inline catalog `token` remains supported, but the docs steer users to `token_env`.

## Where to look

- `internal/client/remote.go` and `internal/client/named_daemon.go` for workspace daemon selection.
- `internal/client/auth.go` for selected-daemon auth isolation and explicit-token precedence.
- `cmd/kata/daemon_cmd.go` and `internal/daemon/namespace.go` for named local daemon startup/runtime behavior.
- `docs/reference/configuration.md` and `docs/operations/remote-daemon.md` for the documented setup.
