### PR TITLE
fix(client): honor active daemon config

### DIFF
--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -135,10 +135,12 @@ func discoverDaemon(ctx context.Context) (string, error) {
 // client directly; this wrapper exists only because every existing
 // CLI command site is already named for it.
 func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
+	workspaceStart := workspaceStartForRemote()
 	return client.NewHTTPClient(ctx, baseURL,
 		client.Opts{
-			Timeout:       envHTTPTimeout(defaultHTTPTimeout),
-			AllowInsecure: client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStartForRemote()),
+			Timeout:        envHTTPTimeout(defaultHTTPTimeout),
+			AllowInsecure:  client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart),
+			WorkspaceStart: workspaceStart,
 		})
 }
 
@@ -147,9 +149,11 @@ func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 // ResponseHeaderTimeout so a stalled handshake can't hang forever. Body
 // cancellation comes from the request context.
 func streamingClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
+	workspaceStart := workspaceStartForRemote()
 	return client.NewHTTPClient(ctx, baseURL, client.Opts{
 		ResponseHeaderTimeout: client.SSEHandshakeTimeout,
-		AllowInsecure:         client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStartForRemote()),
+		AllowInsecure:         client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart),
+		WorkspaceStart:        workspaceStart,
 	})
 }
 

--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -47,8 +47,8 @@ func envHTTPTimeout(def time.Duration) time.Duration {
 // the .kata.local.toml walk so a workspace-local [server] override is
 // honored even when the user is invoking kata from outside the repo.
 //
-// If a remote is explicitly configured (via KATA_SERVER or
-// .kata.local.toml) but does not respond, the CLI surfaces this as a
+// If a remote is explicitly configured (via KATA_SERVER, .kata.local.toml,
+// or active_daemon) but does not respond, the CLI surfaces this as a
 // daemon-unavailable error so callers see a stable exit code and shape.
 func ensureDaemon(ctx context.Context) (string, error) {
 	workspaceStart := workspaceStartForRemote()
@@ -90,11 +90,11 @@ func workspaceStartForRemote() string {
 // with the rest of the CLI about which daemon is "the" daemon:
 //
 //  1. BaseURLKey on the context (test injection).
-//  2. Configured remote (KATA_SERVER env or .kata.local.toml
-//     [server].url). When the remote is set but unreachable, surface
-//     that as ErrRemoteUnavailable so health reports the explicitly-
-//     selected daemon's actual state rather than silently falling
-//     through to a local one.
+//  2. Configured remote (KATA_SERVER env, .kata.local.toml [server].url,
+//     or active_daemon). When the remote is set but unreachable,
+//     surface that as ErrRemoteUnavailable so health reports the
+//     explicitly-selected daemon's actual state rather than silently
+//     falling through to a local one.
 //  3. Local Discover (runtime files).
 //
 // Returns a kindDaemonUnavail cliError when no live daemon is found,

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -144,10 +144,11 @@ Or commit-free per-workspace:
    [server]
    url = "http://100.64.0.5:7777"
 
-KATA_SERVER wins over the file when both are set. A configured-but-down
-remote returns exit 7 (kata server not responding) — no silent fallback to
-spawning a local daemon. The default (no env, no .kata.local.toml) remains a
-local daemon: Unix socket on Unix platforms, loopback TCP on Windows.
+KATA_SERVER wins over the file when both are set. If neither is set, clients
+next honor active_daemon in <KATA_HOME>/config.toml; otherwise they use the
+local daemon: Unix socket on Unix platforms, loopback TCP on Windows. A
+configured-but-down remote returns exit 7 (kata server not responding) — no
+silent fallback to spawning a local daemon.
 `
 
 const agentQuickstartCompactText = `Use kata as the shared issue ledger for this workspace.

--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -50,6 +50,9 @@ url = "http://100.64.0.5:7777"
 ```
 
 `KATA_SERVER` wins over `.kata.local.toml`.
+If neither is set, clients next honor `active_daemon` in
+`<KATA_HOME>/config.toml`; otherwise they use local daemon discovery or
+auto-start.
 
 ## Plain HTTP guardrails
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -67,6 +67,16 @@ url = "http://100.64.0.5:7777"
 
 `KATA_SERVER` wins over the local file.
 
+Daemon target resolution order is:
+
+1. `KATA_SERVER`
+2. `.kata.local.toml` `[server].url`
+3. `active_daemon` in `<KATA_HOME>/config.toml`
+4. local daemon discovery or auto-start
+
+Committed `.kata.toml` files bind the project name only; do not put daemon
+routing or tokens there.
+
 For trusted private-network hostnames that cannot be represented as literal
 non-public IP addresses, opt in per target:
 
@@ -80,10 +90,17 @@ allow_insecure = true
 
 ## Daemon config
 
-`<KATA_HOME>/config.toml` can configure storage, listener, and auth behavior:
+`<KATA_HOME>/config.toml` can configure storage, listener, auth behavior, and
+named daemon targets:
 
 ```toml
 listen = "100.64.0.5:7777"
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "http://100.64.0.5:7777"
+token_env = "KATA_SHARED_TOKEN"
 
 [storage]
 dsn = "/var/lib/kata/kata.db"

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -189,6 +189,42 @@ func TestNewHTTPClientWithBearerAttachesExplicitToken(t *testing.T) {
 	assert.Equal(t, "Bearer explicit-token", got)
 }
 
+func TestNewHTTPClientUsesActiveDaemonTargetToken(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `
+active_daemon = "shared"
+
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token = "target-token"
+`))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer target-token", got)
+}
+
 func TestNewHTTPClientForTargetAttachesExplicitTokenOverGlobal(t *testing.T) {
 	var got string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -337,6 +337,90 @@ url = "`+srv.URL+`"
 	assert.Equal(t, "Bearer global-token", got)
 }
 
+func TestNewHTTPClientKataServerDoesNotSuppressExplicitActiveDaemonAuth(t *testing.T) {
+	var got string
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(active.Close)
+	ambient := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(ambient.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", ambient.URL)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "`+active.URL+`"
+token = "active-token"
+`))
+
+	c, err := NewHTTPClient(context.Background(), active.URL, Opts{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		active.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: active.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer active-token", got)
+}
+
+func TestNewHTTPClientLocalConfigDoesNotSuppressExplicitActiveDaemonAuth(t *testing.T) {
+	var got string
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(active.Close)
+	ambient := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(ambient.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "`+active.URL+`"
+token = "active-token"
+`))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+ambient.URL+`"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), active.URL, Opts{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		active.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: active.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer active-token", got)
+}
+
 func TestNewHTTPClientWithBearerAttachesExplicitToken(t *testing.T) {
 	var got string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -337,6 +337,60 @@ url = "`+srv.URL+`"
 	assert.Equal(t, "Bearer global-token", got)
 }
 
+func TestNewHTTPClientWorkspaceLocalConfigIgnoresInvalidActiveDaemon(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+			return
+		}
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `
+active_daemon = "broken"
+
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "broken"
+url = "::not-a-url::"
+`))
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	workspace := t.TempDir()
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+srv.URL+`"
+`), 0o600))
+
+	baseURL, ok, err := resolveRemote(context.Background(), workspace)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, srv.URL, baseURL)
+	c, err := NewHTTPClient(context.Background(), baseURL, Opts{WorkspaceStart: workspace})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer global-token", got)
+}
+
 func TestNewHTTPClientKataServerDoesNotSuppressExplicitActiveDaemonAuth(t *testing.T) {
 	var got string
 	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -409,6 +463,50 @@ url = "`+ambient.URL+`"
 `), 0o600))
 
 	c, err := NewHTTPClient(context.Background(), active.URL, Opts{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		active.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: active.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer active-token", got)
+}
+
+func TestNewHTTPClientWorkspaceStartIgnoresUnrelatedCWDLocalConfig(t *testing.T) {
+	var got string
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(active.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "`+active.URL+`"
+token = "active-token"
+`))
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	writeWorkspaceMarker(t, cwd)
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+active.URL+`"
+`), 0o600))
+	workspace := t.TempDir()
+	writeWorkspaceMarker(t, workspace)
+
+	c, err := NewHTTPClient(context.Background(), active.URL, Opts{WorkspaceStart: workspace})
 	require.NoError(t, err)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -168,6 +168,86 @@ func TestNewHTTPClientAttachesAuthHeader(t *testing.T) {
 	assert.Equal(t, "Bearer client-tok", got)
 }
 
+func TestNewHTTPClientIgnoresAuthTokenInLocalConfig(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+			return
+		}
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+srv.URL+`"
+
+[auth]
+token = "local-token"
+`), 0o600))
+
+	baseURL, ok, err := resolveRemote(context.Background(), "")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, srv.URL, baseURL)
+	c, err := NewHTTPClient(context.Background(), baseURL, Opts{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Empty(t, got)
+}
+
+func TestNewHTTPClientIgnoresAuthTokenInProjectConfig(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.toml"),
+		[]byte(`version = 1
+[project]
+name = "example-workspace"
+
+[auth]
+token = "project-token"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Empty(t, got)
+}
+
 func TestNewHTTPClientWithBearerAttachesExplicitToken(t *testing.T) {
 	var got string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -248,6 +248,95 @@ token = "project-token"
 	assert.Empty(t, got)
 }
 
+func TestNewHTTPClientKataServerIgnoresInvalidActiveDaemon(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", srv.URL)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `
+active_daemon = "broken"
+
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "broken"
+url = "::not-a-url::"
+`))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer global-token", got)
+}
+
+func TestNewHTTPClientLocalConfigIgnoresInvalidActiveDaemon(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+			return
+		}
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `
+active_daemon = "broken"
+
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "broken"
+url = "::not-a-url::"
+`))
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	writeWorkspaceMarker(t, workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+srv.URL+`"
+`), 0o600))
+
+	baseURL, ok, err := resolveRemote(context.Background(), "")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, srv.URL, baseURL)
+	c, err := NewHTTPClient(context.Background(), baseURL, Opts{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		srv.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Bearer global-token", got)
+}
+
 func TestNewHTTPClientWithBearerAttachesExplicitToken(t *testing.T) {
 	var got string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -132,6 +132,7 @@ type Opts struct {
 	Timeout               time.Duration
 	ResponseHeaderTimeout time.Duration
 	AllowInsecure         bool
+	WorkspaceStart        string
 }
 
 // TargetAuth is explicit per-target bearer configuration. It is used by
@@ -156,7 +157,7 @@ type TargetAuth struct {
 // from the first-party CLI/TUI without callers having to plumb the header
 // through every request site.
 func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client, error) {
-	if auth, ok, err := activeRemoteTargetAuthForBaseURL(baseURL); err != nil {
+	if auth, ok, err := activeRemoteTargetAuthForBaseURL(baseURL, opts.WorkspaceStart); err != nil {
 		return nil, err
 	} else if ok {
 		return NewHTTPClientForTarget(ctx, baseURL, auth, opts)
@@ -198,7 +199,7 @@ func newHTTPClientWithAuth(ctx context.Context, baseURL string, auth config.Auth
 	if err != nil {
 		return nil, err
 	}
-	allowInsecure := opts.AllowInsecure || remoteAllowInsecureForBaseURL(baseURL, "")
+	allowInsecure := opts.AllowInsecure || remoteAllowInsecureForBaseURL(baseURL, opts.WorkspaceStart)
 	rt, err := authBearerTransport(c.Transport, auth.Token, baseURL, auth.TrustPrivateNetwork, allowInsecure)
 	if err != nil {
 		return nil, err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -156,6 +156,11 @@ type TargetAuth struct {
 // from the first-party CLI/TUI without callers having to plumb the header
 // through every request site.
 func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client, error) {
+	if auth, ok, err := activeRemoteTargetAuthForBaseURL(baseURL); err != nil {
+		return nil, err
+	} else if ok {
+		return NewHTTPClientForTarget(ctx, baseURL, auth, opts)
+	}
 	auth := resolveAuthConfig()
 	return newHTTPClientWithAuth(ctx, baseURL, auth, opts)
 }

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -25,15 +25,23 @@ const remoteServerEnvVar = "KATA_SERVER"
 // equivalent there is `[server].allow_insecure = true`.
 const allowInsecureEnvVar = "KATA_ALLOW_INSECURE"
 
+type activeRemoteTarget struct {
+	Name          string
+	BaseURL       string
+	Token         string
+	TokenEnv      string
+	AllowInsecure bool
+}
+
 // ErrRemoteUnavailable wraps probe failures against an explicitly
-// configured remote URL (env or .kata.local.toml). Callers translate
+// configured remote URL. Callers translate
 // this into a daemon-unavailable CLI error; we keep the package free
 // of CLI-layer types so this package stays importable from the TUI.
 var ErrRemoteUnavailable = errors.New("kata server not responding")
 
 // ResolveRemote is the exported view of resolveRemote so callers
 // outside client (e.g. cmd/kata health) can honor the same
-// KATA_SERVER / .kata.local.toml resolution rules without
+// KATA_SERVER / .kata.local.toml / active_daemon resolution rules without
 // auto-starting a local daemon.
 func ResolveRemote(ctx context.Context, workspaceStart string) (string, bool, error) {
 	return resolveRemote(ctx, workspaceStart)
@@ -42,7 +50,7 @@ func ResolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 // NormalizeRemoteURL exposes kata's remote URL validation/canonicalization
 // for TUI daemon-catalog entries. It returns scheme://host[:port] with path
 // and query stripped, and applies the same allow_insecure semantics used by
-// KATA_SERVER and .kata.local.toml.
+// KATA_SERVER, .kata.local.toml, and active daemon-catalog entries.
 func NormalizeRemoteURL(v string, allowInsecure bool) (string, error) {
 	return normalizeRemoteURL(v, allowInsecure)
 }
@@ -53,11 +61,13 @@ func RemoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 	return remoteAllowInsecureForBaseURL(baseURL, workspaceStart)
 }
 
-// resolveRemote checks the two opt-in remote sources, in order:
+// resolveRemote checks the opt-in remote sources, in order:
 //
 //  1. KATA_SERVER env (highest precedence)
 //  2. .kata.local.toml [server].url walked up from workspaceStart
 //     (CWD when workspaceStart is empty)
+//  3. active_daemon in <KATA_HOME>/config.toml when it names a remote
+//     catalog entry
 //
 // If neither is set, returns ("", false, nil) and the caller falls
 // through to local Discover/auto-start. If a URL is configured, the
@@ -82,7 +92,7 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 	}
 	root, path, ok := findLocalConfig(workspaceStart)
 	if !ok {
-		return "", false, nil
+		return resolveActiveRemote(ctx)
 	}
 	cfg, err := config.ReadLocalConfig(root)
 	if err != nil {
@@ -92,7 +102,7 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 		return "", false, fmt.Errorf("read %s: %w", path, err)
 	}
 	if cfg.Server.URL == "" {
-		return "", false, nil
+		return resolveActiveRemote(ctx)
 	}
 	u, err := normalizeRemoteURL(cfg.Server.URL, cfg.Server.AllowInsecure)
 	if err != nil {
@@ -102,6 +112,99 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 		return "", false, fmt.Errorf("%w: %s (%s)", ErrRemoteUnavailable, u, path)
 	}
 	return u, true, nil
+}
+
+func resolveActiveRemote(ctx context.Context) (string, bool, error) {
+	target, ok, err := activeRemoteFromConfig()
+	if err != nil || !ok {
+		return "", false, err
+	}
+	if _, err := resolveActiveRemoteTargetToken(target); err != nil {
+		return "", false, err
+	}
+	if !probeRemote(ctx, target.BaseURL) {
+		return "", false, fmt.Errorf("%w: %s (%s active_daemon %q)",
+			ErrRemoteUnavailable, target.BaseURL, daemonConfigSource(), target.Name)
+	}
+	return target.BaseURL, true, nil
+}
+
+func activeRemoteFromConfig() (activeRemoteTarget, bool, error) {
+	cfg, err := config.ReadDaemonConfig()
+	if err != nil {
+		return activeRemoteTarget{}, false, err
+	}
+	if cfg.ActiveDaemon == "" {
+		return activeRemoteTarget{}, false, nil
+	}
+	for _, daemon := range cfg.Daemons {
+		if daemon.Name != cfg.ActiveDaemon {
+			continue
+		}
+		if daemon.Local {
+			return activeRemoteTarget{}, false, nil
+		}
+		baseURL, err := normalizeRemoteURL(daemon.URL, daemon.AllowInsecure)
+		if err != nil {
+			return activeRemoteTarget{}, false,
+				fmt.Errorf("%s daemon %q url %q: %w",
+					daemonConfigSource(), daemon.Name, daemon.URL, err)
+		}
+		return activeRemoteTarget{
+			Name:          daemon.Name,
+			BaseURL:       baseURL,
+			Token:         daemon.Token,
+			TokenEnv:      daemon.TokenEnv,
+			AllowInsecure: daemon.AllowInsecure,
+		}, true, nil
+	}
+	return activeRemoteTarget{}, false, nil
+}
+
+func resolveActiveRemoteTargetToken(target activeRemoteTarget) (string, error) {
+	if target.TokenEnv == "" {
+		return target.Token, nil
+	}
+	token := strings.TrimSpace(os.Getenv(target.TokenEnv))
+	if token == "" {
+		return "", fmt.Errorf("daemon %q: token_env %q is unset or empty",
+			target.Name, target.TokenEnv)
+	}
+	return token, nil
+}
+
+func activeRemoteTargetAuthForBaseURL(baseURL string) (TargetAuth, bool, error) {
+	if strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")) != "" {
+		return TargetAuth{}, false, nil
+	}
+	target, ok, err := activeRemoteFromConfig()
+	if err != nil || !ok {
+		return TargetAuth{}, false, err
+	}
+	if target.BaseURL != strings.TrimRight(baseURL, "/") {
+		return TargetAuth{}, false, nil
+	}
+	token, err := resolveActiveRemoteTargetToken(target)
+	if err != nil {
+		return TargetAuth{}, false, err
+	}
+	return TargetAuth{
+		Token:         token,
+		AllowInsecure: target.AllowInsecure,
+	}, true, nil
+}
+
+func activeRemoteAllowInsecureForBaseURL(baseURL string) bool {
+	target, ok, err := activeRemoteFromConfig()
+	return err == nil && ok && target.BaseURL == baseURL && target.AllowInsecure
+}
+
+func daemonConfigSource() string {
+	path, err := config.DaemonConfigPath()
+	if err != nil {
+		return "<KATA_HOME>/config.toml"
+	}
+	return path
 }
 
 // envAllowInsecure reports whether KATA_ALLOW_INSECURE is set to a
@@ -120,14 +223,20 @@ func remoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 	}
 	root, _, ok := findLocalConfig(workspaceStart)
 	if !ok {
-		return false
+		return activeRemoteAllowInsecureForBaseURL(baseURL)
 	}
 	cfg, err := config.ReadLocalConfig(root)
-	if err != nil || cfg.Server.URL == "" || !cfg.Server.AllowInsecure {
+	if err != nil {
 		return false
 	}
-	u, err := normalizeRemoteURL(cfg.Server.URL, true)
-	return err == nil && u == baseURL
+	if cfg.Server.URL != "" {
+		if !cfg.Server.AllowInsecure {
+			return false
+		}
+		u, err := normalizeRemoteURL(cfg.Server.URL, true)
+		return err == nil && u == baseURL
+	}
+	return activeRemoteAllowInsecureForBaseURL(baseURL)
 }
 
 // findLocalConfig walks upward from start looking for .kata.local.toml,

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -119,7 +119,10 @@ func resolveActiveRemote(ctx context.Context) (string, bool, error) {
 	if err != nil || !ok {
 		return "", false, err
 	}
-	if _, err := resolveActiveRemoteTargetToken(target); err != nil {
+	if !globalAuthTokenOverrideSet() {
+		_, err = resolveActiveRemoteTargetToken(target)
+	}
+	if err != nil {
 		return "", false, err
 	}
 	if !probeRemote(ctx, target.BaseURL) {
@@ -174,7 +177,7 @@ func resolveActiveRemoteTargetToken(target activeRemoteTarget) (string, error) {
 }
 
 func activeRemoteTargetAuthForBaseURL(baseURL string) (TargetAuth, bool, error) {
-	if strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")) != "" {
+	if globalAuthTokenOverrideSet() {
 		return TargetAuth{}, false, nil
 	}
 	target, ok, err := activeRemoteFromConfig()
@@ -192,6 +195,10 @@ func activeRemoteTargetAuthForBaseURL(baseURL string) (TargetAuth, bool, error) 
 		Token:         token,
 		AllowInsecure: target.AllowInsecure,
 	}, true, nil
+}
+
+func globalAuthTokenOverrideSet() bool {
+	return strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")) != ""
 }
 
 func activeRemoteAllowInsecureForBaseURL(baseURL string) bool {

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -177,7 +177,7 @@ func resolveActiveRemoteTargetToken(target activeRemoteTarget) (string, error) {
 }
 
 func activeRemoteTargetAuthForBaseURL(baseURL string) (TargetAuth, bool, error) {
-	if globalAuthTokenOverrideSet() {
+	if globalAuthTokenOverrideSet() || higherPriorityRemoteSourceConfigured("") {
 		return TargetAuth{}, false, nil
 	}
 	target, ok, err := activeRemoteFromConfig()
@@ -199,6 +199,18 @@ func activeRemoteTargetAuthForBaseURL(baseURL string) (TargetAuth, bool, error) 
 
 func globalAuthTokenOverrideSet() bool {
 	return strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")) != ""
+}
+
+func higherPriorityRemoteSourceConfigured(workspaceStart string) bool {
+	if os.Getenv(remoteServerEnvVar) != "" {
+		return true
+	}
+	root, _, ok := findLocalConfig(workspaceStart)
+	if !ok {
+		return false
+	}
+	cfg, err := config.ReadLocalConfig(root)
+	return err == nil && cfg.Server.URL != ""
 }
 
 func activeRemoteAllowInsecureForBaseURL(baseURL string) bool {

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -176,8 +176,8 @@ func resolveActiveRemoteTargetToken(target activeRemoteTarget) (string, error) {
 	return token, nil
 }
 
-func activeRemoteTargetAuthForBaseURL(baseURL string) (TargetAuth, bool, error) {
-	if globalAuthTokenOverrideSet() || higherPriorityRemoteSourceMatchesBaseURL(baseURL, "") {
+func activeRemoteTargetAuthForBaseURL(baseURL, workspaceStart string) (TargetAuth, bool, error) {
+	if globalAuthTokenOverrideSet() || higherPriorityRemoteSourceMatchesBaseURL(baseURL, workspaceStart) {
 		return TargetAuth{}, false, nil
 	}
 	target, ok, err := activeRemoteFromConfig()

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -177,7 +177,7 @@ func resolveActiveRemoteTargetToken(target activeRemoteTarget) (string, error) {
 }
 
 func activeRemoteTargetAuthForBaseURL(baseURL string) (TargetAuth, bool, error) {
-	if globalAuthTokenOverrideSet() || higherPriorityRemoteSourceConfigured("") {
+	if globalAuthTokenOverrideSet() || higherPriorityRemoteSourceMatchesBaseURL(baseURL, "") {
 		return TargetAuth{}, false, nil
 	}
 	target, ok, err := activeRemoteFromConfig()
@@ -201,16 +201,22 @@ func globalAuthTokenOverrideSet() bool {
 	return strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")) != ""
 }
 
-func higherPriorityRemoteSourceConfigured(workspaceStart string) bool {
-	if os.Getenv(remoteServerEnvVar) != "" {
-		return true
+func higherPriorityRemoteSourceMatchesBaseURL(baseURL, workspaceStart string) bool {
+	baseURL = strings.TrimRight(baseURL, "/")
+	if v := os.Getenv(remoteServerEnvVar); v != "" {
+		u, err := normalizeRemoteURL(v, envAllowInsecure())
+		return err == nil && u == baseURL
 	}
 	root, _, ok := findLocalConfig(workspaceStart)
 	if !ok {
 		return false
 	}
 	cfg, err := config.ReadLocalConfig(root)
-	return err == nil && cfg.Server.URL != ""
+	if err != nil || cfg == nil || cfg.Server.URL == "" {
+		return false
+	}
+	u, err := normalizeRemoteURL(cfg.Server.URL, cfg.Server.AllowInsecure)
+	return err == nil && u == baseURL
 }
 
 func activeRemoteAllowInsecureForBaseURL(baseURL string) bool {

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -123,6 +123,29 @@ url = ""
 	assert.Empty(t, url)
 }
 
+func TestResolveRemote_ActiveDaemonFromHomeConfigWhenNoEnvOrLocal(t *testing.T) {
+	srv := pingingServer(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeWorkspaceMarker(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+`), 0o600))
+
+	url, ok, err := resolveRemote(context.Background(), "")
+
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, srv.URL, url)
+}
+
 func TestResolveRemote_FileUnreachableErrors(t *testing.T) {
 	t.Setenv("KATA_SERVER", "")
 	dir := t.TempDir()

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -146,6 +146,32 @@ url = "`+srv.URL+`"
 	assert.Equal(t, srv.URL, url)
 }
 
+func TestResolveRemote_ActiveDaemonAllowsAuthTokenOverrideForMissingTokenEnv(t *testing.T) {
+	srv := pingingServer(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "global-token")
+	t.Setenv("KATA_SHARED_TOKEN", "")
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeWorkspaceMarker(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_SHARED_TOKEN"
+`), 0o600))
+
+	url, ok, err := resolveRemote(context.Background(), "")
+
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, srv.URL, url)
+}
+
 func TestResolveRemote_FileUnreachableErrors(t *testing.T) {
 	t.Setenv("KATA_SERVER", "")
 	dir := t.TempDir()

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -13,8 +13,9 @@ import (
 // file is optional; an absent file yields a zero-value DaemonConfig and
 // no error so callers can use this unconditionally at daemon start.
 //
-// Only daemon-side fields belong here. Client-side overrides
-// (KATA_SERVER, .kata.local.toml) live in their own resolution path.
+// This file holds daemon-side settings plus user-level client defaults such as
+// TUI preferences and the named daemon catalog. Workspace-local remote
+// overrides (KATA_SERVER, .kata.local.toml) live in their own resolution path.
 type DaemonConfig struct {
 	// Listen is the bind address used by `kata daemon start` when no
 	// --listen flag is supplied. Same syntax as the flag (host:port).


### PR DESCRIPTION
## What Changed

CLI daemon discovery now honors `active_daemon` entries from `<KATA_HOME>/config.toml` after the existing higher-priority `KATA_SERVER` and `.kata.local.toml [server].url` paths.

When the active daemon catalog entry points at a remote daemon, the CLI uses that target's configured `token` or `token_env` for HTTP auth. `KATA_AUTH_TOKEN` still remains the top auth override.

## Why

Named daemon config was already parsed and used by the TUI, but normal CLI commands fell through to local daemon discovery unless users restated the daemon URL and token in environment variables. That made the documented daemon catalog behave inconsistently across surfaces.

## Notes For Review

The change keeps the existing repo policy for `.kata.local.toml [server].url`; it does not introduce that path. It also adds negative coverage proving bearer auth is not read from `.kata.toml` or `.kata.local.toml`.

Primary files to review are `internal/client/remote.go`, `internal/client/client.go`, and the new resolver/auth tests in `internal/client`.
