### PR TITLE
feat(federation): spoke leave and rejoin — reversible enrollment (CLI + TUI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,27 @@ The daemon refuses parent-close while open children remain. Reviewers
 can replay activity with `kata audit closes` and undo specific lazy
 closes with `kata reopen <ref>`.
 
+## Federation trust/threat model (security-review triage)
+
+kata federation is mutual trust between a spoke and each hub it joins;
+there is no multi-tenant authorization model (`docs/design/federation.md`,
+"Tokens And Trust Boundaries" and "No Multi-Tenant Authorization Model").
+Triage security findings against that model:
+
+- **Out of scope: a hostile federated hub.** A hub the spoke joined is
+  trusted with that project's data and identity. Example: a hub "forging"
+  a project UID it already knows is not a defended attack — UIDs are
+  unguessable ULIDs, so UID equality means the same project. Don't fix
+  these; document the boundary inline where reviews keep re-flagging it
+  (see the rejoin note in `internal/daemon/handlers_federation.go`).
+- **Real, fix them: credential misrouting and partial/stranded state.**
+  A bearer token must only reach the origin it was configured for: the
+  local daemon's global token never goes to a hub, and a catalog entry's
+  admin token never goes to a different hub origin (`--hub-token` is the
+  only deliberate cross-origin path). Teardown/retry paths must not
+  strand state (archive-before-detach; leave's idempotent resume still
+  runs daemon-side credential cleanup).
+
 ## Remote-client mode (private network)
 
 A daemon can serve clients on other hosts over a private network:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1836,6 +1836,32 @@ components:
       required:
         - labels
       type: object
+    LeaveFederationReplicaRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        disposition:
+          type: string
+        force:
+          type: boolean
+      type: object
+    LeaveFederationReplicaResultBody:
+      additionalProperties: true
+      properties:
+        archived:
+          type: boolean
+        detached:
+          type: boolean
+        disposition:
+          type: string
+        project:
+          $ref: "#/components/schemas/ProjectOut"
+      required:
+        - project
+        - detached
+        - disposition
+      type: object
     LinkChanges:
       additionalProperties: true
       properties:
@@ -3223,6 +3249,39 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CreateFederationReplicaBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/federation/replicas/{project_id}/actions/leave:
+    post:
+      operationId: leaveFederationReplica
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: header
+          name: X-Kata-Confirm
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LeaveFederationReplicaRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LeaveFederationReplicaResultBody"
           description: OK
         default:
           content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3292,6 +3292,12 @@ paths:
   /api/v1/federation/status:
     get:
       operationId: getFederationStatus
+      parameters:
+        - explode: false
+          in: query
+          name: include
+          schema:
+            type: string
       responses:
         "200":
           content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1845,6 +1845,8 @@ components:
           type: string
         force:
           type: boolean
+        preflight:
+          type: boolean
       type: object
     LeaveFederationReplicaResultBody:
       additionalProperties: true

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -584,7 +584,7 @@ func federationLeaveCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&deleteFlag, "delete", false, "archive the local replica after detaching (reversible via kata projects restore)")
 	cmd.Flags().BoolVar(&force, "force", false, "with --delete, override the open-issue refusal")
 	cmd.Flags().BoolVar(&localOnly, "local-only", false, "skip the hub revoke when the hub is unreachable (leaves the token valid)")
-	cmd.Flags().StringVar(&hubName, "hub", "", "named daemon catalog entry for hub admin auth")
+	cmd.Flags().StringVar(&hubName, "hub", "", "named daemon catalog entry for hub admin auth (its URL must match the binding's hub URL)")
 	cmd.Flags().StringVar(&hubToken, "hub-token", "", "explicit hub admin token (highest precedence)")
 	cmd.Flags().BoolVar(&yes, "yes", false, "skip the interactive confirmation")
 	return cmd

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -481,10 +481,11 @@ func federationJoinCmd() *cobra.Command {
 }
 
 // spokeLeaveTarget captures the resolved local spoke a leave will tear down.
-// When standalone is true, the project has no federation binding; leave is a
-// no-op for plain detach and proceeds to archive-only (no hub revoke) for
-// --delete. hubURL, hubProjectID, and instanceUID are only valid when
-// standalone is false.
+// When standalone is true, the project has no federation binding; leave skips
+// hub revoke and confirmation for plain detach (the daemon call still runs to
+// clean up a stale credential) and proceeds to archive-only for --delete.
+// hubURL, hubProjectID, and instanceUID are only valid when standalone is
+// false.
 type spokeLeaveTarget struct {
 	projectID     int64
 	projectName   string
@@ -529,53 +530,42 @@ func federationLeaveCmd() *cobra.Command {
 			if deleteFlag {
 				disposition = "archive"
 			}
-			// Standalone path: project has no federation binding. Plain leave is a
-			// no-op success; --delete proceeds to archive without any hub revoke.
+			// Standalone path: project has no federation binding, so there is no
+			// hub contact either way. Plain leave skips the confirmation (nothing
+			// is detached or archived) but must NOT skip the daemon leave call:
+			// the route is the idempotent resume that deletes a stale hub
+			// credential left by a partial leave (binding gone, credential delete
+			// failed). --delete gates the archive on the same confirmation as the
+			// bound path (no hub revoke note, since there is no hub contact here).
 			if target.standalone {
-				if !deleteFlag {
-					// Already standalone: route through the output-mode-aware
-					// printer so --json/--agent are honored, not a raw string.
-					return printFederationLeaveAlreadyStandalone(cmd, target.projectName)
+				if deleteFlag {
+					if err := confirmFederationLeave(cmd, target, "archive", true, yes); err != nil {
+						return err
+					}
 				}
-				// --delete on a standalone project: archive only, skip hub revoke.
-				// Gate the archive on the same confirmation as the bound path
-				// (no hub revoke note, since there is no hub contact here).
-				if err := confirmFederationLeave(cmd, target, "archive", true, yes); err != nil {
-					return err
-				}
-				actor, _ := resolveActor(ctx, flags.As, nil)
-				status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-					fmt.Sprintf("%s/api/v1/federation/replicas/%d/actions/leave", baseURL, target.projectID),
-					map[string]any{"disposition": "archive", "force": force, "actor": actor})
-				if err != nil {
-					return err
-				}
-				if status >= 400 {
-					return apiErrFromBody(status, bs)
-				}
-				return printFederationLeave(cmd, bs)
-			}
-			if err := confirmFederationLeave(cmd, target, disposition, localOnly, yes); err != nil {
+			} else if err := confirmFederationLeave(cmd, target, disposition, localOnly, yes); err != nil {
 				return err
 			}
-			if localOnly {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-					"warning: --local-only skips hub revoke; the enrollment token remains valid until you run `kata federation revoke <id>` on the hub %s\n",
-					textsafe.Line(target.hubURL))
-			} else {
-				globals, err := revokeSpokeEnrollmentsOnHub(ctx, target, hubAuthInputs{
-					hubURL:        target.hubURL,
-					hubName:       hubName,
-					hubToken:      hubToken,
-					allowInsecure: target.allowInsecure,
-				})
-				if err != nil {
-					return err
-				}
-				if len(globals) > 0 {
+			if !target.standalone {
+				if localOnly {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-						"warning: global enrollment(s) %s for this spoke remain active on the hub and still authorize this project; revoke with `kata federation revoke <id>` if intended\n",
-						formatEnrollmentIDList(globals))
+						"warning: --local-only skips hub revoke; the enrollment token remains valid until you run `kata federation revoke <id>` on the hub %s\n",
+						textsafe.Line(target.hubURL))
+				} else {
+					globals, err := revokeSpokeEnrollmentsOnHub(ctx, target, hubAuthInputs{
+						hubURL:        target.hubURL,
+						hubName:       hubName,
+						hubToken:      hubToken,
+						allowInsecure: target.allowInsecure,
+					})
+					if err != nil {
+						return err
+					}
+					if len(globals) > 0 {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+							"warning: global enrollment(s) %s for this spoke remain active on the hub and still authorize this project; revoke with `kata federation revoke <id>` if intended\n",
+							formatEnrollmentIDList(globals))
+					}
 				}
 			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
@@ -603,7 +593,7 @@ func federationLeaveCmd() *cobra.Command {
 // resolveSpokeForLeave resolves the target project and its federation status:
 //   - spoke binding → returns a full spokeLeaveTarget (normal leave path).
 //   - no binding     → returns spokeLeaveTarget{standalone: true} (idempotent
-//     no-op for plain leave; archive-only path for --delete).
+//     resume for plain leave; archive-only path for --delete).
 //   - hub binding    → hard error "not_a_spoke" (this command does not disband
 //     hubs).
 func resolveSpokeForLeave(ctx context.Context, client *http.Client, baseURL string, args []string) (spokeLeaveTarget, error) {
@@ -630,8 +620,8 @@ func resolveSpokeForLeave(ctx context.Context, client *http.Client, baseURL stri
 		}
 	}
 	// No binding at all → project is already standalone. Return the standalone
-	// signal so the caller can no-op (plain leave) or archive (--delete) without
-	// any hub contact.
+	// signal so the caller skips hub contact; the daemon leave call still runs
+	// to finish any stale-credential cleanup (plain leave) or archive (--delete).
 	if match == nil {
 		return spokeLeaveTarget{
 			projectID:   project.ID,
@@ -819,35 +809,15 @@ func printFederationLeave(cmd *cobra.Command, bs []byte) error {
 			textsafe.Line(body.Project.Name), textsafe.Line(body.Project.Name))
 		return err
 	}
+	if !body.Detached {
+		// Idempotent resume: the daemon found no binding (it still cleans up
+		// any stale hub credential), so nothing was left this time.
+		_, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"project %s is already standalone\n", textsafe.Line(body.Project.Name))
+		return err
+	}
 	_, err := fmt.Fprintf(cmd.OutOrStdout(),
 		"left federation: %s is now a standalone local project\n", textsafe.Line(body.Project.Name))
-	return err
-}
-
-// printFederationLeaveAlreadyStandalone reports the no-op "already standalone"
-// outcome through the same output-mode-aware surface as printFederationLeave so
-// --json/--agent are honored. Nothing was detached or archived.
-func printFederationLeaveAlreadyStandalone(cmd *cobra.Command, projectName string) error {
-	if currentOutputMode() == outputJSON {
-		return emitJSON(cmd.OutOrStdout(), api.LeaveFederationReplicaResultBody{
-			Project:     api.ProjectOut{Name: projectName},
-			Detached:    false,
-			Disposition: "detach",
-		})
-	}
-	if currentOutputMode() == outputAgent {
-		return writeAgentKVRow(cmd.OutOrStdout(),
-			agentRowField("project", projectName),
-			agentRowField("disposition", "detach"),
-			agentRowField("detached", strconv.FormatBool(false)),
-			agentRowField("archived", strconv.FormatBool(false)),
-		)
-	}
-	if flags.Quiet {
-		return nil
-	}
-	_, err := fmt.Fprintf(cmd.OutOrStdout(),
-		"project %s is already standalone\n", textsafe.Line(projectName))
 	return err
 }
 

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -480,6 +480,26 @@ func federationJoinCmd() *cobra.Command {
 	return cmd
 }
 
+// resolveLeaveProject resolves the leave target like resolveFederationProject
+// but includes archived projects for the explicit argument and --project
+// forms: an archive-leave retry whose archive already committed must reach
+// the daemon's idempotent resume, and active-only resolution would report
+// the project as not found while detach/credential cleanup is pending. The
+// status list hides archived projects, so such a retry runs as the
+// standalone resume (no hub contact — the revoke-first ordering means the
+// hub side was already revoked before the original failure). The cwd
+// workspace form keeps active-only resolution: its alias surface treats
+// archived projects as gone.
+func resolveLeaveProject(ctx context.Context, client *http.Client, baseURL string, args []string) (projectRef, error) {
+	if len(args) > 0 {
+		return resolveProjectSelectorIncludingArchived(ctx, client, baseURL, args[0])
+	}
+	if projectName := strings.TrimSpace(flags.Project); projectName != "" {
+		return resolveProjectSelectorIncludingArchived(ctx, client, baseURL, projectName)
+	}
+	return resolveFederationProject(ctx, client, baseURL, args, false)
+}
+
 // spokeLeaveTarget captures the resolved local spoke a leave will tear down.
 // When standalone is true, the project has no federation binding; leave skips
 // hub revoke and confirmation for plain detach (the daemon call still runs to
@@ -602,7 +622,7 @@ func federationLeaveCmd() *cobra.Command {
 //   - hub binding    → hard error "not_a_spoke" (this command does not disband
 //     hubs).
 func resolveSpokeForLeave(ctx context.Context, client *http.Client, baseURL string, args []string) (spokeLeaveTarget, error) {
-	project, err := resolveFederationProject(ctx, client, baseURL, args, false)
+	project, err := resolveLeaveProject(ctx, client, baseURL, args)
 	if err != nil {
 		return spokeLeaveTarget{}, err
 	}

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -702,14 +702,19 @@ func resolveSpokeForLeave(ctx context.Context, client *http.Client, baseURL stri
 }
 
 // revokeSpokeEnrollmentsOnHub lists the hub's enrollments and revokes every
-// active one bound to this spoke instance and hub project. Zero active matches
-// is success (already revoked). Any hub transport/auth failure aborts before
-// local teardown and instructs the operator to retry with --local-only.
-// revokeSpokeEnrollmentsOnHub revokes every active project-scoped enrollment
-// for this spoke instance + hub project. Matching GLOBAL enrollments
+// active project-scoped one bound to this spoke instance and hub project.
+// Zero active matches is success (already revoked) ONLY when no other active
+// project-scoped enrollment authorizes the hub project: the spoke's instance
+// UID can drift from the enrollment's (clone/import refresh, or an enroll
+// created with an explicit --spoke-instance), and silently proceeding would
+// strand a live token with hub access. That case aborts with the surviving
+// enrollment IDs; --local-only is the explicit local-teardown escape. The
+// surviving IDs may also be other spokes of a shared hub project — the abort
+// names them so the operator decides. Matching GLOBAL enrollments
 // (project_id NULL) are returned, not revoked: they may authorize the spoke's
 // other projects on the hub, but they do keep authorizing the left project, so
-// the caller warns about them.
+// the caller warns about them. Any hub transport/auth failure aborts before
+// local teardown and instructs the operator to retry with --local-only.
 func revokeSpokeEnrollmentsOnHub(ctx context.Context, target spokeLeaveTarget, in hubAuthInputs) ([]int64, error) {
 	cat, err := config.ReadDaemonConfig()
 	if err != nil {
@@ -734,23 +739,39 @@ func revokeSpokeEnrollmentsOnHub(ctx context.Context, target spokeLeaveTarget, i
 	if err := json.Unmarshal(bs, &list); err != nil {
 		return nil, err
 	}
-	var globals []int64
+	var globals, matched, foreignScoped []int64
 	for _, enrollment := range list.Enrollments {
 		if enrollment.RevokedAt != nil {
 			continue
 		}
-		if enrollment.SpokeInstanceUID != target.instanceUID {
-			continue
-		}
 		if enrollment.ProjectID == nil {
-			globals = append(globals, enrollment.ID)
+			if enrollment.SpokeInstanceUID == target.instanceUID {
+				globals = append(globals, enrollment.ID)
+			}
 			continue
 		}
 		if *enrollment.ProjectID != target.hubProjectID {
 			continue
 		}
+		if enrollment.SpokeInstanceUID == target.instanceUID {
+			matched = append(matched, enrollment.ID)
+			continue
+		}
+		foreignScoped = append(foreignScoped, enrollment.ID)
+	}
+	if len(matched) == 0 && len(foreignScoped) > 0 {
+		return nil, &cliError{
+			Message: fmt.Sprintf(
+				"no active enrollment matches this spoke's instance UID, but enrollment(s) %s still authorize hub project %d — the instance UID can change after a clone/import, or the enrollment may belong to another spoke instance; revoke the right one with `kata federation revoke <id>` on the hub, or rerun with --local-only to tear down locally without revoking",
+				formatEnrollmentIDList(foreignScoped), target.hubProjectID),
+			Code:     "leave_enrollment_uid_mismatch",
+			Kind:     kindConflict,
+			ExitCode: ExitConflict,
+		}
+	}
+	for _, id := range matched {
 		status, bs, err := httpDoJSON(ctx, hub, http.MethodPost,
-			fmt.Sprintf("%s/api/v1/federation/enrollments/%d/revoke", auth.url, enrollment.ID), map[string]any{})
+			fmt.Sprintf("%s/api/v1/federation/enrollments/%d/revoke", auth.url, id), map[string]any{})
 		if err != nil {
 			return nil, federationLeaveHubError(err)
 		}

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -498,12 +498,13 @@ type spokeLeaveTarget struct {
 
 func federationLeaveCmd() *cobra.Command {
 	var (
-		deleteFlag bool
-		force      bool
-		localOnly  bool
-		hubName    string
-		hubToken   string
-		yes        bool
+		deleteFlag    bool
+		force         bool
+		localOnly     bool
+		hubName       string
+		hubToken      string
+		allowInsecure bool
+		yes           bool
 	)
 	cmd := &cobra.Command{
 		Use:   "leave [project]",
@@ -553,10 +554,13 @@ func federationLeaveCmd() *cobra.Command {
 						textsafe.Line(target.hubURL))
 				} else {
 					globals, err := revokeSpokeEnrollmentsOnHub(ctx, target, hubAuthInputs{
-						hubURL:        target.hubURL,
-						hubName:       hubName,
-						hubToken:      hubToken,
-						allowInsecure: target.allowInsecure,
+						hubURL:   target.hubURL,
+						hubName:  hubName,
+						hubToken: hubToken,
+						// Union of opt-ins: the binding/status flag (which can be
+						// lost with the credential during a partial-leave
+						// recovery) and the explicit leave-time flag.
+						allowInsecure: target.allowInsecure || allowInsecure,
 					})
 					if err != nil {
 						return err
@@ -586,6 +590,7 @@ func federationLeaveCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&localOnly, "local-only", false, "skip the hub revoke when the hub is unreachable (leaves the token valid)")
 	cmd.Flags().StringVar(&hubName, "hub", "", "named daemon catalog entry for hub admin auth (its URL must match the binding's hub URL)")
 	cmd.Flags().StringVar(&hubToken, "hub-token", "", "explicit hub admin token (highest precedence)")
+	cmd.Flags().BoolVar(&allowInsecure, "allow-insecure", false, "allow the hub revoke to send a bearer token to a plaintext HTTP hub hostname (private overlay networks); restores the join-time opt-in when it was lost with the credential")
 	cmd.Flags().BoolVar(&yes, "yes", false, "skip the interactive confirmation")
 	return cmd
 }

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -15,6 +16,8 @@ import (
 	"github.com/spf13/cobra"
 	"go.kenn.io/kata/internal/api"
 	clientpkg "go.kenn.io/kata/internal/client"
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/db"
 	hubclient "go.kenn.io/kata/internal/federation"
 	"go.kenn.io/kata/internal/textsafe"
 )
@@ -30,6 +33,7 @@ func newFederationCmd() *cobra.Command {
 		federationEnrollCmd(),
 		federationEnrollmentsCmd(),
 		federationJoinCmd(),
+		federationLeaveCmd(),
 		federationRevokeCmd(),
 		federationStatusCmd(),
 		federationQuarantineCmd(),
@@ -168,8 +172,16 @@ func federationEnrollCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			adoptExisting := adoptExistingFlag || (pushCapable &&
-				federationSpokeProjectExists(ctx, metadata.ProjectName, spokeInstance))
+			adoptExisting := adoptExistingFlag
+			if !adoptExisting && pushCapable {
+				if spokeUID, ok := federationSpokeProjectUID(ctx, metadata.ProjectName, spokeInstance); ok {
+					// A same-name spoke project is normally adopted — unless it
+					// already shares the hub project's UID (it previously left
+					// this federation). Then the join is a plain rejoin and
+					// adoption would needlessly rewrite its event history.
+					adoptExisting = spokeUID == "" || spokeUID != metadata.ProjectUID
+				}
+			}
 			status, bs, err := httpDoJSON(ctx, hubClient, http.MethodPost,
 				hubBaseURL+"/api/v1/federation/enrollments",
 				map[string]any{
@@ -236,20 +248,29 @@ func federationEnrollHTTPClientError(err error) error {
 }
 
 func federationSpokeProjectExists(ctx context.Context, projectName, spokeInstance string) bool {
+	_, ok := federationSpokeProjectUID(ctx, projectName, spokeInstance)
+	return ok
+}
+
+// federationSpokeProjectUID reports whether the default/spoke daemon (when its
+// instance matches spokeInstance) has a project named projectName, returning
+// that project's UID. The UID is "" when the daemon's list payload predates
+// uid, in which case callers should fall back to the adoption default.
+func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance string) (string, bool) {
 	spokeURL, err := ensureDaemon(ctx)
 	if err != nil {
-		return false
+		return "", false
 	}
 	spokeClient, err := clientpkg.NewHTTPClientForTarget(ctx, spokeURL, clientpkg.TargetAuth{}, clientpkg.Opts{
 		Timeout: envHTTPTimeout(defaultHTTPTimeout),
 	})
 	if err != nil {
-		return false
+		return "", false
 	}
 	if strings.TrimSpace(spokeInstance) != "" {
 		uid, err := federationSpokeInstanceUID(ctx, spokeClient, spokeURL)
 		if err != nil || uid != strings.TrimSpace(spokeInstance) {
-			return false
+			return "", false
 		}
 	}
 	return federationSpokeProjectNameExists(ctx, spokeClient, spokeURL, projectName)
@@ -272,27 +293,30 @@ func federationSpokeInstanceUID(ctx context.Context, client *http.Client, baseUR
 	return strings.TrimSpace(body.InstanceUID), nil
 }
 
-func federationSpokeProjectNameExists(ctx context.Context, client *http.Client, baseURL, projectName string) bool {
+func federationSpokeProjectNameExists(ctx context.Context, client *http.Client, baseURL, projectName string) (string, bool) {
 	projectName = strings.TrimSpace(projectName)
 	if projectName == "" {
-		return false
+		return "", false
 	}
 	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/projects", nil)
 	if err != nil || status >= 400 {
-		return false
+		return "", false
 	}
 	var body struct {
-		Projects []projectRef `json:"projects"`
+		Projects []struct {
+			Name string `json:"name"`
+			UID  string `json:"uid"`
+		} `json:"projects"`
 	}
 	if err := json.Unmarshal(bs, &body); err != nil {
-		return false
+		return "", false
 	}
 	for _, project := range body.Projects {
 		if project.Name == projectName {
-			return true
+			return project.UID, true
 		}
 	}
-	return false
+	return "", false
 }
 
 func federationEnrollmentsCmd() *cobra.Command {
@@ -454,6 +478,377 @@ func federationJoinCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&bundle.PushEnabled, "push", false, "enable spoke push")
 	cmd.Flags().BoolVar(&bundle.AdoptExisting, "adopt-existing", false, "adopt matching existing local data into the federation")
 	return cmd
+}
+
+// spokeLeaveTarget captures the resolved local spoke a leave will tear down.
+// When standalone is true, the project has no federation binding; leave is a
+// no-op for plain detach and proceeds to archive-only (no hub revoke) for
+// --delete. hubURL, hubProjectID, and instanceUID are only valid when
+// standalone is false.
+type spokeLeaveTarget struct {
+	projectID     int64
+	projectName   string
+	hubURL        string
+	hubProjectID  int64
+	instanceUID   string
+	allowInsecure bool
+	standalone    bool
+}
+
+func federationLeaveCmd() *cobra.Command {
+	var (
+		deleteFlag bool
+		force      bool
+		localOnly  bool
+		hubName    string
+		hubToken   string
+		yes        bool
+	)
+	cmd := &cobra.Command{
+		Use:   "leave [project]",
+		Short: "leave a hub federation as a spoke (revoke + local teardown)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if force && !deleteFlag {
+				return &cliError{Message: "--force requires --delete", Kind: kindValidation, ExitCode: ExitValidation}
+			}
+			ctx := cmd.Context()
+			baseURL, err := ensureDaemon(ctx)
+			if err != nil {
+				return err
+			}
+			client, err := httpClientFor(ctx, baseURL)
+			if err != nil {
+				return err
+			}
+			target, err := resolveSpokeForLeave(ctx, client, baseURL, args)
+			if err != nil {
+				return err
+			}
+			disposition := "detach"
+			if deleteFlag {
+				disposition = "archive"
+			}
+			// Standalone path: project has no federation binding. Plain leave is a
+			// no-op success; --delete proceeds to archive without any hub revoke.
+			if target.standalone {
+				if !deleteFlag {
+					// Already standalone: route through the output-mode-aware
+					// printer so --json/--agent are honored, not a raw string.
+					return printFederationLeaveAlreadyStandalone(cmd, target.projectName)
+				}
+				// --delete on a standalone project: archive only, skip hub revoke.
+				// Gate the archive on the same confirmation as the bound path
+				// (no hub revoke note, since there is no hub contact here).
+				if err := confirmFederationLeave(cmd, target, "archive", true, yes); err != nil {
+					return err
+				}
+				actor, _ := resolveActor(ctx, flags.As, nil)
+				status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
+					fmt.Sprintf("%s/api/v1/federation/replicas/%d/actions/leave", baseURL, target.projectID),
+					map[string]any{"disposition": "archive", "force": force, "actor": actor})
+				if err != nil {
+					return err
+				}
+				if status >= 400 {
+					return apiErrFromBody(status, bs)
+				}
+				return printFederationLeave(cmd, bs)
+			}
+			if err := confirmFederationLeave(cmd, target, disposition, localOnly, yes); err != nil {
+				return err
+			}
+			if localOnly {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+					"warning: --local-only skips hub revoke; the enrollment token remains valid until you run `kata federation revoke <id>` on the hub %s\n",
+					textsafe.Line(target.hubURL))
+			} else {
+				globals, err := revokeSpokeEnrollmentsOnHub(ctx, target, hubAuthInputs{
+					hubURL:        target.hubURL,
+					hubName:       hubName,
+					hubToken:      hubToken,
+					allowInsecure: target.allowInsecure,
+				})
+				if err != nil {
+					return err
+				}
+				if len(globals) > 0 {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: global enrollment(s) %s for this spoke remain active on the hub and still authorize this project; revoke with `kata federation revoke <id>` if intended\n",
+						formatEnrollmentIDList(globals))
+				}
+			}
+			actor, _ := resolveActor(ctx, flags.As, nil)
+			status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
+				fmt.Sprintf("%s/api/v1/federation/replicas/%d/actions/leave", baseURL, target.projectID),
+				map[string]any{"disposition": disposition, "force": force, "actor": actor})
+			if err != nil {
+				return err
+			}
+			if status >= 400 {
+				return apiErrFromBody(status, bs)
+			}
+			return printFederationLeave(cmd, bs)
+		},
+	}
+	cmd.Flags().BoolVar(&deleteFlag, "delete", false, "archive the local replica after detaching (reversible via kata projects restore)")
+	cmd.Flags().BoolVar(&force, "force", false, "with --delete, override the open-issue refusal")
+	cmd.Flags().BoolVar(&localOnly, "local-only", false, "skip the hub revoke when the hub is unreachable (leaves the token valid)")
+	cmd.Flags().StringVar(&hubName, "hub", "", "named daemon catalog entry for hub admin auth")
+	cmd.Flags().StringVar(&hubToken, "hub-token", "", "explicit hub admin token (highest precedence)")
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip the interactive confirmation")
+	return cmd
+}
+
+// resolveSpokeForLeave resolves the target project and its federation status:
+//   - spoke binding → returns a full spokeLeaveTarget (normal leave path).
+//   - no binding     → returns spokeLeaveTarget{standalone: true} (idempotent
+//     no-op for plain leave; archive-only path for --delete).
+//   - hub binding    → hard error "not_a_spoke" (this command does not disband
+//     hubs).
+func resolveSpokeForLeave(ctx context.Context, client *http.Client, baseURL string, args []string) (spokeLeaveTarget, error) {
+	project, err := resolveFederationProject(ctx, client, baseURL, args, false)
+	if err != nil {
+		return spokeLeaveTarget{}, err
+	}
+	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status", nil)
+	if err != nil {
+		return spokeLeaveTarget{}, err
+	}
+	if status >= 400 {
+		return spokeLeaveTarget{}, apiErrFromBody(status, bs)
+	}
+	var body api.FederationStatusBody
+	if err := json.Unmarshal(bs, &body); err != nil {
+		return spokeLeaveTarget{}, err
+	}
+	var match *api.FederationProjectStatus
+	for i := range body.Statuses {
+		if body.Statuses[i].ProjectID == project.ID {
+			match = &body.Statuses[i]
+			break
+		}
+	}
+	// No binding at all → project is already standalone. Return the standalone
+	// signal so the caller can no-op (plain leave) or archive (--delete) without
+	// any hub contact.
+	if match == nil {
+		return spokeLeaveTarget{
+			projectID:   project.ID,
+			projectName: project.Name,
+			standalone:  true,
+		}, nil
+	}
+	// Hub-role binding → refuse with not_a_spoke (this command only handles
+	// spoke teardown; hub disbanding is out of scope).
+	if match.Role != string(db.FederationRoleSpoke) {
+		return spokeLeaveTarget{}, &cliError{
+			Message:  fmt.Sprintf("project %s is not a spoke", project.Name),
+			Code:     "not_a_spoke",
+			Kind:     kindValidation,
+			ExitCode: ExitValidation,
+		}
+	}
+	instanceUID, err := federationSpokeInstanceUID(ctx, client, baseURL)
+	if err != nil {
+		return spokeLeaveTarget{}, err
+	}
+	return spokeLeaveTarget{
+		projectID:     project.ID,
+		projectName:   project.Name,
+		hubURL:        strings.TrimRight(match.HubURL, "/"),
+		hubProjectID:  match.HubProjectID,
+		instanceUID:   instanceUID,
+		allowInsecure: match.AllowInsecure,
+	}, nil
+}
+
+// revokeSpokeEnrollmentsOnHub lists the hub's enrollments and revokes every
+// active one bound to this spoke instance and hub project. Zero active matches
+// is success (already revoked). Any hub transport/auth failure aborts before
+// local teardown and instructs the operator to retry with --local-only.
+// revokeSpokeEnrollmentsOnHub revokes every active project-scoped enrollment
+// for this spoke instance + hub project. Matching GLOBAL enrollments
+// (project_id NULL) are returned, not revoked: they may authorize the spoke's
+// other projects on the hub, but they do keep authorizing the left project, so
+// the caller warns about them.
+func revokeSpokeEnrollmentsOnHub(ctx context.Context, target spokeLeaveTarget, in hubAuthInputs) ([]int64, error) {
+	cat, err := config.ReadDaemonConfig()
+	if err != nil {
+		return nil, err
+	}
+	auth, err := resolveHubAdminAuth(cat, in)
+	if err != nil {
+		return nil, err
+	}
+	hub, err := hubAdminClient(ctx, auth)
+	if err != nil {
+		return nil, federationLeaveHubError(err)
+	}
+	status, bs, err := httpDoJSON(ctx, hub, http.MethodGet, auth.url+"/api/v1/federation/enrollments", nil)
+	if err != nil {
+		return nil, federationLeaveHubError(err)
+	}
+	if status >= 400 {
+		return nil, federationLeaveHubError(apiErrFromBody(status, bs))
+	}
+	var list api.ListFederationEnrollmentsBody
+	if err := json.Unmarshal(bs, &list); err != nil {
+		return nil, err
+	}
+	var globals []int64
+	for _, enrollment := range list.Enrollments {
+		if enrollment.RevokedAt != nil {
+			continue
+		}
+		if enrollment.SpokeInstanceUID != target.instanceUID {
+			continue
+		}
+		if enrollment.ProjectID == nil {
+			globals = append(globals, enrollment.ID)
+			continue
+		}
+		if *enrollment.ProjectID != target.hubProjectID {
+			continue
+		}
+		status, bs, err := httpDoJSON(ctx, hub, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/federation/enrollments/%d/revoke", auth.url, enrollment.ID), map[string]any{})
+		if err != nil {
+			return nil, federationLeaveHubError(err)
+		}
+		if status >= 400 {
+			return nil, federationLeaveHubError(apiErrFromBody(status, bs))
+		}
+	}
+	return globals, nil
+}
+
+func formatEnrollmentIDList(ids []int64) string {
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprintf("#%d", id))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// federationLeaveHubError wraps a hub-side failure with guidance to retry the
+// leave with --local-only, since the local teardown is intentionally not
+// attempted when the hub revoke cannot complete.
+func federationLeaveHubError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("hub revoke failed: %w; rerun `kata federation leave --local-only` to tear down locally, then revoke on the hub later", err)
+}
+
+func confirmFederationLeave(cmd *cobra.Command, target spokeLeaveTarget, disposition string, localOnly, yes bool) error {
+	if yes {
+		return nil
+	}
+	action := "detach"
+	if disposition == "archive" {
+		action = "archive"
+	}
+	revokeNote := fmt.Sprintf("revoke the hub enrollment on %s, then ", textsafe.Line(target.hubURL))
+	if localOnly {
+		revokeNote = ""
+	}
+	prompt := fmt.Sprintf("This will %sleave federation for %q (%s). Continue? [y/N]: ",
+		revokeNote, textsafe.Line(target.projectName), action)
+	return resolveYesNo(cmd, prompt)
+}
+
+// resolveYesNo prompts for a yes/no confirmation on a TTY and accepts y/yes
+// (case-insensitive). Without a TTY it returns confirm_required, mirroring
+// resolveConfirm so noninteractive callers must pass --yes.
+func resolveYesNo(cmd *cobra.Command, prompt string) error {
+	if !isTTY(os.Stdin) {
+		return &cliError{
+			Message:  "no TTY: pass --yes to proceed noninteractively",
+			Code:     "confirm_required",
+			Kind:     kindConfirm,
+			ExitCode: ExitConfirm,
+		}
+	}
+	if _, err := fmt.Fprint(cmd.ErrOrStderr(), prompt); err != nil {
+		return err
+	}
+	r := bufio.NewReader(cmd.InOrStdin())
+	//nolint:errcheck // EOF here means stdin closed; treat as a "no".
+	line, _ := r.ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	default:
+		return &cliError{
+			Message:  "leave cancelled",
+			Code:     "confirm_mismatch",
+			Kind:     kindConfirm,
+			ExitCode: ExitConfirm,
+		}
+	}
+}
+
+func printFederationLeave(cmd *cobra.Command, bs []byte) error {
+	if currentOutputMode() == outputJSON {
+		var buf bytes.Buffer
+		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
+			return err
+		}
+		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+		return err
+	}
+	var body api.LeaveFederationReplicaResultBody
+	if err := json.Unmarshal(bs, &body); err != nil {
+		return err
+	}
+	if currentOutputMode() == outputAgent {
+		return writeAgentKVRow(cmd.OutOrStdout(),
+			agentRowField("project", body.Project.Name),
+			agentRowField("disposition", body.Disposition),
+			agentRowField("detached", strconv.FormatBool(body.Detached)),
+			agentRowField("archived", strconv.FormatBool(body.Archived)),
+		)
+	}
+	if flags.Quiet {
+		return nil
+	}
+	if body.Archived {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"left federation and archived %s (restore with `kata projects restore %s`)\n",
+			textsafe.Line(body.Project.Name), textsafe.Line(body.Project.Name))
+		return err
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(),
+		"left federation: %s is now a standalone local project\n", textsafe.Line(body.Project.Name))
+	return err
+}
+
+// printFederationLeaveAlreadyStandalone reports the no-op "already standalone"
+// outcome through the same output-mode-aware surface as printFederationLeave so
+// --json/--agent are honored. Nothing was detached or archived.
+func printFederationLeaveAlreadyStandalone(cmd *cobra.Command, projectName string) error {
+	if currentOutputMode() == outputJSON {
+		return emitJSON(cmd.OutOrStdout(), api.LeaveFederationReplicaResultBody{
+			Project:     api.ProjectOut{Name: projectName},
+			Detached:    false,
+			Disposition: "detach",
+		})
+	}
+	if currentOutputMode() == outputAgent {
+		return writeAgentKVRow(cmd.OutOrStdout(),
+			agentRowField("project", projectName),
+			agentRowField("disposition", "detach"),
+			agentRowField("detached", strconv.FormatBool(false)),
+			agentRowField("archived", strconv.FormatBool(false)),
+		)
+	}
+	if flags.Quiet {
+		return nil
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(),
+		"project %s is already standalone\n", textsafe.Line(projectName))
+	return err
 }
 
 func federationStatusCmd() *cobra.Command {

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -551,6 +551,22 @@ func federationLeaveCmd() *cobra.Command {
 			if deleteFlag {
 				disposition = "archive"
 			}
+			// Archive-eligibility preflight BEFORE the irreversible hub revoke:
+			// a predictable open-issue refusal must not strand the spoke
+			// hub-revoked but locally bound. Advisory only — the authoritative
+			// check stays inside the daemon's RemoveProject transaction.
+			if !target.standalone && deleteFlag {
+				actor, _ := resolveActor(ctx, flags.As, nil)
+				status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
+					fmt.Sprintf("%s/api/v1/federation/replicas/%d/actions/leave", baseURL, target.projectID),
+					map[string]any{"disposition": "archive", "force": force, "actor": actor, "preflight": true})
+				if err != nil {
+					return err
+				}
+				if status >= 400 {
+					return apiErrFromBody(status, bs)
+				}
+			}
 			// Standalone path: project has no federation binding, so there is no
 			// hub contact either way. Plain leave skips the confirmation (nothing
 			// is detached or archived) but must NOT skip the daemon leave call:

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -484,10 +484,10 @@ func federationJoinCmd() *cobra.Command {
 // but includes archived projects for the explicit argument and --project
 // forms: an archive-leave retry whose archive already committed must reach
 // the daemon's idempotent resume, and active-only resolution would report
-// the project as not found while detach/credential cleanup is pending. The
-// status list hides archived projects, so such a retry runs as the
-// standalone resume (no hub contact — the revoke-first ordering means the
-// hub side was already revoked before the original failure). The cwd
+// the project as not found while detach/credential cleanup is pending. A
+// surviving binding on the archived project is surfaced via the
+// include=archived status fetch in resolveSpokeForLeave, so such a retry
+// runs the normal bound path (idempotent hub revoke + teardown). The cwd
 // workspace form keeps active-only resolution: its alias surface treats
 // archived projects as gone.
 func resolveLeaveProject(ctx context.Context, client *http.Client, baseURL string, args []string) (projectRef, error) {
@@ -626,7 +626,14 @@ func resolveSpokeForLeave(ctx context.Context, client *http.Client, baseURL stri
 	if err != nil {
 		return spokeLeaveTarget{}, err
 	}
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status", nil)
+	// include=archived: an archived spoke can still hold a binding — either a
+	// partial archive-leave (detach failed after the archive committed) or a
+	// `kata projects remove` on a federated project, which archives without
+	// revoking. Both must take the bound path below; the hub revoke is
+	// idempotent, so the already-revoked retry is a no-op while the
+	// never-revoked remove case gets its enrollment revoked instead of
+	// silently stranded.
+	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status?include=archived", nil)
 	if err != nil {
 		return spokeLeaveTarget{}, err
 	}

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -551,15 +551,18 @@ func federationLeaveCmd() *cobra.Command {
 			if deleteFlag {
 				disposition = "archive"
 			}
-			// Archive-eligibility preflight BEFORE the irreversible hub revoke:
-			// a predictable open-issue refusal must not strand the spoke
-			// hub-revoked but locally bound. Advisory only — the authoritative
-			// check stays inside the daemon's RemoveProject transaction.
-			if !target.standalone && deleteFlag {
+			// Daemon preflight BEFORE the irreversible hub revoke, for every
+			// leave that will contact the hub: the route can refuse a detach
+			// too (role drift, vanished project, actor validation), and the
+			// archive disposition adds the open-issue refusal. A refusal
+			// discovered only after the revoke would strand the spoke locally
+			// bound with the hub side gone. Advisory only — the authoritative
+			// checks stay inside the daemon's transactions.
+			if !target.standalone && !localOnly {
 				actor, _ := resolveActor(ctx, flags.As, nil)
 				status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
 					fmt.Sprintf("%s/api/v1/federation/replicas/%d/actions/leave", baseURL, target.projectID),
-					map[string]any{"disposition": "archive", "force": force, "actor": actor, "preflight": true})
+					map[string]any{"disposition": disposition, "force": force, "actor": actor, "preflight": true})
 				if err != nil {
 					return err
 				}

--- a/cmd/kata/federation_hubadmin.go
+++ b/cmd/kata/federation_hubadmin.go
@@ -38,8 +38,13 @@ type hubAdminAuth struct {
 // A --hub <name> entry that is missing or whose URL differs from the binding
 // errors out — sending a named entry's admin token to a different origin is
 // the cross-origin leak this guards against; --hub-token is the only
-// deliberate cross-origin path. allow_insecure for the hub client likewise
-// comes from the binding (in.allowInsecure), not the catalog.
+// deliberate cross-origin path.
+//
+// allow_insecure for the hub client is the UNION of the caller's opt-in
+// (binding/status or --allow-insecure) and the matched same-origin catalog
+// entry's: every source is the operator's own local record for this exact
+// origin, so the catalog can restore an opt-in lost with the credential but
+// can never remove the binding's.
 //
 // When a catalog entry IS selected (by --hub <name> or by URL match) but its
 // token_env is set and empty, resolution returns an error instead of an empty
@@ -79,6 +84,7 @@ func resolveHubAdminAuth(cat *config.DaemonConfig, in hubAuthInputs) (hubAdminAu
 			return hubAdminAuth{}, err
 		}
 		out.token = token
+		out.allowInsecure = out.allowInsecure || e.AllowInsecure
 		return out, nil
 	}
 	if cat != nil {
@@ -88,6 +94,7 @@ func resolveHubAdminAuth(cat *config.DaemonConfig, in hubAuthInputs) (hubAdminAu
 				return hubAdminAuth{}, err
 			}
 			out.token = token
+			out.allowInsecure = out.allowInsecure || e.AllowInsecure
 			return out, nil
 		}
 	}

--- a/cmd/kata/federation_hubadmin.go
+++ b/cmd/kata/federation_hubadmin.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	clientpkg "go.kenn.io/kata/internal/client"
+	"go.kenn.io/kata/internal/config"
+)
+
+type hubAuthInputs struct {
+	hubURL        string
+	hubName       string
+	hubToken      string
+	allowInsecure bool
+}
+
+type hubAdminAuth struct {
+	url           string
+	token         string
+	allowInsecure bool
+}
+
+// resolveHubAdminAuth applies precedence: --hub-token > named catalog entry
+// token/token_env > URL-matched catalog entry token/token_env > no credential
+// (empty token here; the caller builds an UNAUTHENTICATED hub client — the
+// local daemon's global KATA_AUTH_TOKEN/[auth].token is never sent to the hub
+// origin implicitly; a token-protected hub requires --hub-token or a catalog
+// entry).
+//
+// The target URL is ALWAYS the binding's hub URL (in.hubURL); a catalog entry
+// supplies only the admin TOKEN, never the origin, so the admin token cannot be
+// redirected to a foreign host. allow_insecure for the hub client likewise
+// comes from the binding (in.allowInsecure), not the catalog.
+//
+// When a catalog entry IS selected (by --hub <name> or by URL match) but its
+// token_env is set and empty, resolution returns an error instead of an empty
+// token: a selected-but-unresolvable entry must not silently fall through to
+// the global daemon token, which would send the wrong credential to the hub.
+func resolveHubAdminAuth(cat *config.DaemonConfig, in hubAuthInputs) (hubAdminAuth, error) {
+	out := hubAdminAuth{url: strings.TrimRight(in.hubURL, "/"), allowInsecure: in.allowInsecure}
+	if strings.TrimSpace(in.hubToken) != "" {
+		out.token = in.hubToken
+		return out, nil
+	}
+	if cat != nil {
+		if e := catalogByName(cat, in.hubName); e != nil {
+			token, err := selectedCatalogToken(e)
+			if err != nil {
+				return hubAdminAuth{}, err
+			}
+			out.token = token
+			return out, nil
+		}
+		if e := catalogByURL(cat, out.url); e != nil {
+			token, err := selectedCatalogToken(e)
+			if err != nil {
+				return hubAdminAuth{}, err
+			}
+			out.token = token
+			return out, nil
+		}
+	}
+	return out, nil
+}
+
+// selectedCatalogToken returns the admin token for a catalog entry that was
+// actively selected. A literal token wins; otherwise a non-empty token_env is
+// read. token_env set but empty is an error so the wrong daemon token is not
+// sent — only an entry with NO token configured at all yields the empty-token
+// global fallback.
+func selectedCatalogToken(e *config.CatalogDaemonConfig) (string, error) {
+	if strings.TrimSpace(e.Token) != "" {
+		return e.Token, nil
+	}
+	if env := strings.TrimSpace(e.TokenEnv); env != "" {
+		token := strings.TrimSpace(os.Getenv(env))
+		if token == "" {
+			return "", &cliError{
+				Message:  fmt.Sprintf("hub admin token_env %q is set but empty; export it or pass --hub-token", env),
+				Code:     "hub_token_env_empty",
+				Kind:     kindValidation,
+				ExitCode: ExitValidation,
+			}
+		}
+		return token, nil
+	}
+	return "", nil
+}
+
+func catalogByName(cat *config.DaemonConfig, name string) *config.CatalogDaemonConfig {
+	if strings.TrimSpace(name) == "" {
+		return nil
+	}
+	for i := range cat.Daemons {
+		if cat.Daemons[i].Name == name {
+			return &cat.Daemons[i]
+		}
+	}
+	return nil
+}
+
+func catalogByURL(cat *config.DaemonConfig, url string) *config.CatalogDaemonConfig {
+	if url == "" {
+		return nil
+	}
+	for i := range cat.Daemons {
+		if strings.TrimRight(cat.Daemons[i].URL, "/") == url {
+			return &cat.Daemons[i]
+		}
+	}
+	return nil
+}
+
+// hubAdminClient builds an HTTP client for the resolved hub admin auth.
+func hubAdminClient(ctx context.Context, a hubAdminAuth) (*http.Client, error) {
+	opts := clientpkg.Opts{Timeout: envHTTPTimeout(defaultHTTPTimeout), AllowInsecure: a.allowInsecure}
+	// Always NewHTTPClientForTarget: the supplied TargetAuth is the COMPLETE
+	// bearer policy for the hub origin. With no resolved hub credential the
+	// client is unauthenticated — never fall back to NewHTTPClient, which
+	// would attach the local daemon's global KATA_AUTH_TOKEN/[auth].token to
+	// the (stored, potentially hostile) hub URL.
+	return clientpkg.NewHTTPClientForTarget(ctx, a.url, clientpkg.TargetAuth{Token: strings.TrimSpace(a.token), AllowInsecure: a.allowInsecure}, opts)
+}

--- a/cmd/kata/federation_hubadmin.go
+++ b/cmd/kata/federation_hubadmin.go
@@ -9,6 +9,7 @@ import (
 
 	clientpkg "go.kenn.io/kata/internal/client"
 	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/textsafe"
 )
 
 type hubAuthInputs struct {
@@ -31,9 +32,13 @@ type hubAdminAuth struct {
 // origin implicitly; a token-protected hub requires --hub-token or a catalog
 // entry).
 //
-// The target URL is ALWAYS the binding's hub URL (in.hubURL); a catalog entry
-// supplies only the admin TOKEN, never the origin, so the admin token cannot be
-// redirected to a foreign host. allow_insecure for the hub client likewise
+// The target URL is ALWAYS the binding's hub URL (in.hubURL), and a catalog
+// token is only attached when its entry's URL matches that target: token and
+// origin travel together, so neither can redirect the other to a foreign host.
+// A --hub <name> entry that is missing or whose URL differs from the binding
+// errors out — sending a named entry's admin token to a different origin is
+// the cross-origin leak this guards against; --hub-token is the only
+// deliberate cross-origin path. allow_insecure for the hub client likewise
 // comes from the binding (in.allowInsecure), not the catalog.
 //
 // When a catalog entry IS selected (by --hub <name> or by URL match) but its
@@ -46,15 +51,37 @@ func resolveHubAdminAuth(cat *config.DaemonConfig, in hubAuthInputs) (hubAdminAu
 		out.token = in.hubToken
 		return out, nil
 	}
-	if cat != nil {
-		if e := catalogByName(cat, in.hubName); e != nil {
-			token, err := selectedCatalogToken(e)
-			if err != nil {
-				return hubAdminAuth{}, err
-			}
-			out.token = token
-			return out, nil
+	if name := strings.TrimSpace(in.hubName); name != "" {
+		var e *config.CatalogDaemonConfig
+		if cat != nil {
+			e = catalogByName(cat, name)
 		}
+		if e == nil {
+			return hubAdminAuth{}, &cliError{
+				Message:  fmt.Sprintf("--hub %q does not match any daemon catalog entry", name),
+				Code:     "hub_catalog_entry_not_found",
+				Kind:     kindValidation,
+				ExitCode: ExitValidation,
+			}
+		}
+		if strings.TrimRight(e.URL, "/") != out.url {
+			return hubAdminAuth{}, &cliError{
+				Message: fmt.Sprintf(
+					"--hub %q resolves to %s, not this spoke's hub %s; refusing to send its admin token to a different origin (pass --hub-token to use an explicit token with this hub)",
+					name, textsafe.Line(e.URL), textsafe.Line(out.url)),
+				Code:     "hub_catalog_url_mismatch",
+				Kind:     kindValidation,
+				ExitCode: ExitValidation,
+			}
+		}
+		token, err := selectedCatalogToken(e)
+		if err != nil {
+			return hubAdminAuth{}, err
+		}
+		out.token = token
+		return out, nil
+	}
+	if cat != nil {
 		if e := catalogByURL(cat, out.url); e != nil {
 			token, err := selectedCatalogToken(e)
 			if err != nil {

--- a/cmd/kata/federation_hubadmin_test.go
+++ b/cmd/kata/federation_hubadmin_test.go
@@ -46,7 +46,7 @@ func TestResolveHubAdminAuthNamedEntryURLMismatchErrors(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected an error when the named entry's URL does not match the binding hub URL")
 	}
-	requireCLIError(t, err, ExitValidation)
+	_ = requireCLIError(t, err, ExitValidation)
 }
 
 // TestResolveHubAdminAuthNamedEntryMatchingURLUsesToken: a --hub <name> entry
@@ -77,7 +77,7 @@ func TestResolveHubAdminAuthNamedEntryNotFoundErrors(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected an error when --hub names a missing catalog entry")
 	}
-	requireCLIError(t, err, ExitValidation)
+	_ = requireCLIError(t, err, ExitValidation)
 }
 
 // TestResolveHubAdminAuthURLMatchToleratesTrailingSlash asserts the catalog
@@ -131,7 +131,7 @@ func TestResolveHubAdminAuthNoEntryGlobalFallback(t *testing.T) {
 // must error rather than silently fall back to global daemon auth.
 func TestResolveHubAdminAuthSelectedTokenEnvUnsetErrors(t *testing.T) {
 	t.Setenv("KATA_TEST_MISSING_HUB_TOKEN", "")
-	_, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+	_, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{ //nolint:gosec // G101 false positive: token_env holds an env var NAME, not a credential
 		Name: "hub", URL: "https://bound.example", TokenEnv: "KATA_TEST_MISSING_HUB_TOKEN",
 	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "hub"})
 	if err == nil {
@@ -143,7 +143,7 @@ func TestResolveHubAdminAuthSelectedTokenEnvUnsetErrors(t *testing.T) {
 // selection branch: a URL-matched entry with an empty token_env also errors.
 func TestResolveHubAdminAuthURLMatchTokenEnvUnsetErrors(t *testing.T) {
 	t.Setenv("KATA_TEST_MISSING_HUB_TOKEN", "")
-	_, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+	_, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{ //nolint:gosec // G101 false positive: token_env holds an env var NAME, not a credential
 		Name: "hub", URL: "https://bound.example", TokenEnv: "KATA_TEST_MISSING_HUB_TOKEN",
 	}), hubAuthInputs{hubURL: "https://bound.example"})
 	if err == nil {
@@ -155,7 +155,7 @@ func TestResolveHubAdminAuthURLMatchTokenEnvUnsetErrors(t *testing.T) {
 // token_env on a selected entry resolves to that token.
 func TestResolveHubAdminAuthSelectedTokenEnvSetSucceeds(t *testing.T) {
 	t.Setenv("KATA_TEST_HUB_TOKEN", "env-token")
-	out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+	out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{ //nolint:gosec // G101 false positive: token_env holds an env var NAME, not a credential
 		Name: "hub", URL: "https://bound.example", TokenEnv: "KATA_TEST_HUB_TOKEN",
 	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "hub"})
 	if err != nil {

--- a/cmd/kata/federation_hubadmin_test.go
+++ b/cmd/kata/federation_hubadmin_test.go
@@ -34,13 +34,27 @@ func TestResolveHubAdminAuthExplicitTokenKeepsBindingURL(t *testing.T) {
 	}
 }
 
-// TestResolveHubAdminAuthNamedEntryKeepsBindingURL is the core Fix 1 case: a
-// --hub <name> catalog entry supplies ONLY the token; the target URL must
-// remain the binding's hub URL even though the catalog entry has a different
-// URL, so the admin token is never sent to a foreign origin.
-func TestResolveHubAdminAuthNamedEntryKeepsBindingURL(t *testing.T) {
+// TestResolveHubAdminAuthNamedEntryURLMismatchErrors: a --hub <name> entry
+// whose URL differs from the binding's hub URL must be rejected. Attaching its
+// token while targeting the binding URL would send that entry's admin token to
+// a foreign origin (the binding hub); deliberate cross-origin token use is
+// --hub-token only.
+func TestResolveHubAdminAuthNamedEntryURLMismatchErrors(t *testing.T) {
+	_, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+		Name: "hub", URL: "https://trusted.example", Token: "catalog-token",
+	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "hub"})
+	if err == nil {
+		t.Fatalf("expected an error when the named entry's URL does not match the binding hub URL")
+	}
+	requireCLIError(t, err, ExitValidation)
+}
+
+// TestResolveHubAdminAuthNamedEntryMatchingURLUsesToken: a --hub <name> entry
+// whose URL matches the binding hub URL (modulo trailing slash) supplies its
+// token, and the target stays the normalized binding URL.
+func TestResolveHubAdminAuthNamedEntryMatchingURLUsesToken(t *testing.T) {
 	out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
-		Name: "hub", URL: "https://attacker.example", Token: "catalog-token",
+		Name: "hub", URL: "https://bound.example/", Token: "catalog-token",
 	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "hub"})
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -51,6 +65,19 @@ func TestResolveHubAdminAuthNamedEntryKeepsBindingURL(t *testing.T) {
 	if out.token != "catalog-token" {
 		t.Fatalf("token should come from the catalog entry, got %q", out.token)
 	}
+}
+
+// TestResolveHubAdminAuthNamedEntryNotFoundErrors: an explicitly selected
+// --hub <name> that resolves to no catalog entry must error rather than
+// silently falling through to URL-match or the unauthenticated fallback.
+func TestResolveHubAdminAuthNamedEntryNotFoundErrors(t *testing.T) {
+	_, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+		Name: "hub", URL: "https://bound.example", Token: "catalog-token",
+	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "other-hub"})
+	if err == nil {
+		t.Fatalf("expected an error when --hub names a missing catalog entry")
+	}
+	requireCLIError(t, err, ExitValidation)
 }
 
 // TestResolveHubAdminAuthURLMatchToleratesTrailingSlash asserts the catalog

--- a/cmd/kata/federation_hubadmin_test.go
+++ b/cmd/kata/federation_hubadmin_test.go
@@ -111,6 +111,37 @@ func TestResolveHubAdminAuthUsesBindingAllowInsecure(t *testing.T) {
 	}
 }
 
+// TestResolveHubAdminAuthUnionsSameOriginCatalogAllowInsecure: a catalog entry
+// for the SAME origin carries the operator's own transport opt-in, so it can
+// restore allow_insecure when the binding-side flag was lost with the
+// credential (partial-leave recovery). Opt-ins union; a catalog entry can add
+// the opt-in for its origin but never remove the binding's.
+func TestResolveHubAdminAuthUnionsSameOriginCatalogAllowInsecure(t *testing.T) {
+	t.Run("named entry", func(t *testing.T) {
+		out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+			Name: "hub", URL: "http://hub.internal:7373", Token: "catalog-token", AllowInsecure: true,
+		}), hubAuthInputs{hubURL: "http://hub.internal:7373", hubName: "hub"})
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if !out.allowInsecure {
+			t.Fatalf("same-origin named entry allow_insecure should union in, got %v", out.allowInsecure)
+		}
+	})
+
+	t.Run("url-matched entry", func(t *testing.T) {
+		out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+			Name: "hub", URL: "http://hub.internal:7373", Token: "catalog-token", AllowInsecure: true,
+		}), hubAuthInputs{hubURL: "http://hub.internal:7373"})
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if !out.allowInsecure {
+			t.Fatalf("same-origin URL-matched entry allow_insecure should union in, got %v", out.allowInsecure)
+		}
+	})
+}
+
 // TestResolveHubAdminAuthNoEntryGlobalFallback asserts the no-entry case yields
 // an empty token (the caller then falls back to global auth) with no error.
 func TestResolveHubAdminAuthNoEntryGlobalFallback(t *testing.T) {

--- a/cmd/kata/federation_hubadmin_test.go
+++ b/cmd/kata/federation_hubadmin_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/config"
+)
+
+// catalog builds a minimal daemon catalog for resolver tests.
+func catalog(entries ...config.CatalogDaemonConfig) *config.DaemonConfig {
+	return &config.DaemonConfig{Daemons: entries}
+}
+
+// TestResolveHubAdminAuthExplicitTokenKeepsBindingURL asserts an explicit
+// --hub-token wins and the target URL stays the binding's hub URL.
+func TestResolveHubAdminAuthExplicitTokenKeepsBindingURL(t *testing.T) {
+	out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+		Name: "hub", URL: "https://other.example", Token: "catalog-token",
+	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "hub", hubToken: "explicit"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if out.url != "https://bound.example" {
+		t.Fatalf("url should be the binding hub URL, got %q", out.url)
+	}
+	if out.token != "explicit" {
+		t.Fatalf("token should be the explicit --hub-token, got %q", out.token)
+	}
+}
+
+// TestResolveHubAdminAuthNamedEntryKeepsBindingURL is the core Fix 1 case: a
+// --hub <name> catalog entry supplies ONLY the token; the target URL must
+// remain the binding's hub URL even though the catalog entry has a different
+// URL, so the admin token is never sent to a foreign origin.
+func TestResolveHubAdminAuthNamedEntryKeepsBindingURL(t *testing.T) {
+	out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+		Name: "hub", URL: "https://attacker.example", Token: "catalog-token",
+	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "hub"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if out.url != "https://bound.example" {
+		t.Fatalf("url must stay the binding hub URL, got %q", out.url)
+	}
+	if out.token != "catalog-token" {
+		t.Fatalf("token should come from the catalog entry, got %q", out.token)
+	}
+}
+
+// TestResolveHubAdminAuthURLMatchToleratesTrailingSlash asserts the catalog
+// URL match normalizes trailing slashes on both sides (#273).
+func TestResolveHubAdminAuthURLMatchToleratesTrailingSlash(t *testing.T) {
+	out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+		Name: "hub", URL: "https://bound.example/", Token: "catalog-token",
+	}), hubAuthInputs{hubURL: "https://bound.example"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if out.token != "catalog-token" {
+		t.Fatalf("trailing-slash URL should still match, got token %q", out.token)
+	}
+	if out.url != "https://bound.example" {
+		t.Fatalf("url should be the normalized binding URL, got %q", out.url)
+	}
+}
+
+// TestResolveHubAdminAuthUsesBindingAllowInsecure asserts allow_insecure for
+// the hub client comes from the binding, not the catalog entry.
+func TestResolveHubAdminAuthUsesBindingAllowInsecure(t *testing.T) {
+	out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+		Name: "hub", URL: "https://bound.example", Token: "catalog-token", AllowInsecure: false,
+	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "hub", allowInsecure: true})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !out.allowInsecure {
+		t.Fatalf("allowInsecure should come from the binding (true), got %v", out.allowInsecure)
+	}
+}
+
+// TestResolveHubAdminAuthNoEntryGlobalFallback asserts the no-entry case yields
+// an empty token (the caller then falls back to global auth) with no error.
+func TestResolveHubAdminAuthNoEntryGlobalFallback(t *testing.T) {
+	out, err := resolveHubAdminAuth(catalog(), hubAuthInputs{hubURL: "https://bound.example"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if out.token != "" {
+		t.Fatalf("no matching entry should yield empty token, got %q", out.token)
+	}
+	if out.url != "https://bound.example" {
+		t.Fatalf("url should be the binding URL, got %q", out.url)
+	}
+}
+
+// TestResolveHubAdminAuthSelectedTokenEnvUnsetErrors is Fix 2: when a SELECTED
+// catalog entry (by name) has token_env set but the env var is empty, resolving
+// must error rather than silently fall back to global daemon auth.
+func TestResolveHubAdminAuthSelectedTokenEnvUnsetErrors(t *testing.T) {
+	t.Setenv("KATA_TEST_MISSING_HUB_TOKEN", "")
+	_, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+		Name: "hub", URL: "https://bound.example", TokenEnv: "KATA_TEST_MISSING_HUB_TOKEN",
+	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "hub"})
+	if err == nil {
+		t.Fatalf("expected an error when selected entry's token_env is unset")
+	}
+}
+
+// TestResolveHubAdminAuthURLMatchTokenEnvUnsetErrors is Fix 2 for the URL-match
+// selection branch: a URL-matched entry with an empty token_env also errors.
+func TestResolveHubAdminAuthURLMatchTokenEnvUnsetErrors(t *testing.T) {
+	t.Setenv("KATA_TEST_MISSING_HUB_TOKEN", "")
+	_, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+		Name: "hub", URL: "https://bound.example", TokenEnv: "KATA_TEST_MISSING_HUB_TOKEN",
+	}), hubAuthInputs{hubURL: "https://bound.example"})
+	if err == nil {
+		t.Fatalf("expected an error when URL-matched entry's token_env is unset")
+	}
+}
+
+// TestResolveHubAdminAuthSelectedTokenEnvSetSucceeds confirms a populated
+// token_env on a selected entry resolves to that token.
+func TestResolveHubAdminAuthSelectedTokenEnvSetSucceeds(t *testing.T) {
+	t.Setenv("KATA_TEST_HUB_TOKEN", "env-token")
+	out, err := resolveHubAdminAuth(catalog(config.CatalogDaemonConfig{
+		Name: "hub", URL: "https://bound.example", TokenEnv: "KATA_TEST_HUB_TOKEN",
+	}), hubAuthInputs{hubURL: "https://bound.example", hubName: "hub"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if out.token != "env-token" {
+		t.Fatalf("token should come from token_env, got %q", out.token)
+	}
+}
+
+// TestHubAdminClientNeverSendsGlobalTokenWithoutHubCredential: when no
+// hub-specific credential resolves, the hub client must be unauthenticated —
+// the local daemon's global bearer token must not leak to the hub origin.
+func TestHubAdminClientNeverSendsGlobalTokenWithoutHubCredential(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "local-daemon-secret")
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	hc, err := hubAdminClient(context.Background(), hubAdminAuth{url: srv.URL})
+	require.NoError(t, err)
+	resp, err := hc.Get(srv.URL + "/api/v1/federation/enrollments")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Empty(t, got, "global daemon token must not be sent to the hub origin")
+}

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -1343,21 +1343,53 @@ func TestFederationLeaveResolvesArchivedProject(t *testing.T) {
 		})
 		require.NoError(t, err)
 		// Partial archive-leave: archive committed, detach never ran. The
-		// status list hides archived projects, so the retry runs as the
-		// standalone resume — no hub contact (the revoke already happened
-		// before the original failure), full local teardown.
+		// surviving binding is visible to leave (include=archived), so the
+		// retry runs the normal bound path; with the hub unreachable,
+		// --local-only completes the local teardown like any bound leave.
 		_, _, err = env.DB.RemoveProject(ctx, db.RemoveProjectParams{
 			ProjectID: project.ID, Actor: "tester",
 		})
 		require.NoError(t, err)
 
-		_ = requireCmdOutput(t, env, "federation", "leave",
-			"--project", "spoke-project", "--yes")
+		_, _, err = runCmdCapture(t, env, "federation", "leave",
+			"--project", "spoke-project", "--local-only", "--yes")
+		require.NoError(t, err)
 
 		_, bindErr := env.DB.FederationBindingByProject(ctx, project.ID)
 		assert.ErrorIs(t, bindErr, db.ErrNotFound,
 			"the surviving binding must be detached on the archived-project retry")
 	})
+}
+
+// TestFederationLeaveRevokesAfterProjectsRemoveArchive: `kata projects remove`
+// archives a federated spoke without revoking its hub enrollment (the remove
+// route has no federation guard). Leave on that archived project must still
+// run the bound path — revoke the enrollment, then detach — instead of
+// classifying the hidden archived binding as standalone and silently
+// stranding an active enrollment on the hub. For the archive-leave retry,
+// where the enrollment was already revoked, the same pass is an idempotent
+// no-op (zero active matches is success).
+func TestFederationLeaveRevokesAfterProjectsRemoveArchive(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	ctx := context.Background()
+	const hubProjectID int64 = 42
+	hub, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+	project := seedLeaveSpoke(t, env, "spoke-project", hubSrv.URL, hubProjectID)
+	// Archive the bound spoke directly — the kata projects remove path.
+	_, _, err := env.DB.RemoveProject(ctx, db.RemoveProjectParams{
+		ProjectID: project.ID, Actor: "tester",
+	})
+	require.NoError(t, err)
+
+	_ = requireCmdOutput(t, env, "federation", "leave",
+		"--project", "spoke-project", "--yes")
+
+	require.Equal(t, []int64{hub.enrollmentID}, hub.revokedIDs,
+		"leave on an archived bound spoke must still revoke the hub enrollment")
+	_, bindErr := env.DB.FederationBindingByProject(ctx, project.ID)
+	assert.ErrorIs(t, bindErr, db.ErrNotFound)
+	assert.Equal(t, "missing", config.FederationCredentialMetadataFor(project.UID).Status)
 }
 
 // TestFederationLeaveAllowInsecureFlag covers the partial-leave recovery state

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -1333,6 +1333,29 @@ func TestFederationLeaveResumeWhenAlreadyStandalone(t *testing.T) {
 		assert.Nil(t, alive.DeletedAt)
 	})
 
+	t.Run("plain leave on no-binding project deletes a stale credential", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "standalone-project")
+		require.NoError(t, err)
+		// A partially failed leave deletes the binding but can leave the hub
+		// credential behind; the no-op retry must still complete that cleanup
+		// instead of reporting success around it.
+		require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+			HubURL:       "http://hub.example:7777",
+			HubProjectID: 42,
+			Token:        "stale-token",
+		}))
+
+		out := requireCmdOutput(t, env, "federation", "leave",
+			"--project", "standalone-project", "--yes")
+
+		assert.Contains(t, out, "already standalone")
+		assert.Equal(t, "missing", config.FederationCredentialMetadataFor(project.UID).Status,
+			"stale hub credential must be deleted by the resume path")
+	})
+
 	t.Run("plain leave on no-binding project honors --json", func(t *testing.T) {
 		resetFlags(t)
 		env := testenv.New(t)

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -1361,6 +1361,83 @@ func TestFederationLeaveResolvesArchivedProject(t *testing.T) {
 	})
 }
 
+// TestFederationLeaveDeletePreflightsArchiveBeforeRevoke: leave --delete must
+// validate archive eligibility BEFORE the irreversible hub revoke. A
+// predictable open-issue refusal after the revoke would leave the spoke
+// locally bound with a revoked hub token, breaking sync until manual
+// recovery.
+func TestFederationLeaveDeletePreflightsArchiveBeforeRevoke(t *testing.T) {
+	seed := func(t *testing.T, env *testenv.Env, hubURL string, hubProjectID int64) db.Project {
+		t.Helper()
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "spoke-project")
+		require.NoError(t, err)
+		// Open issue created before the binding so the spoke read-only guard
+		// does not block it.
+		_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID, Title: "open issue", Author: "tester",
+		})
+		require.NoError(t, err)
+		_, err = env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+			ProjectID:            project.ID,
+			Role:                 db.FederationRoleSpoke,
+			HubURL:               hubURL,
+			HubProjectID:         hubProjectID,
+			HubProjectUID:        project.UID,
+			ReplayHorizonEventID: 9,
+			Enabled:              true,
+		})
+		require.NoError(t, err)
+		require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+			HubURL:       hubURL,
+			HubProjectID: hubProjectID,
+			Token:        "spoke-token",
+		}))
+		return project
+	}
+
+	t.Run("open-issue refusal happens before any revoke", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		const hubProjectID int64 = 42
+		hub, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+		project := seed(t, env, hubSrv.URL, hubProjectID)
+
+		_, err := runCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--delete", "--yes")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "open issues")
+		assert.Empty(t, hub.revokedIDs,
+			"the hub enrollment must not be revoked when the archive would be refused")
+		_, bindErr := env.DB.FederationBindingByProject(ctx, project.ID)
+		require.NoError(t, bindErr, "binding must stay intact after the preflight refusal")
+		alive, dbErr := env.DB.ProjectByName(ctx, project.Name)
+		require.NoError(t, dbErr)
+		assert.Nil(t, alive.DeletedAt)
+	})
+
+	t.Run("--force skips the refusal and completes the leave", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		const hubProjectID int64 = 42
+		hub, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+		project := seed(t, env, hubSrv.URL, hubProjectID)
+
+		_ = requireCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--delete", "--force", "--yes")
+
+		assert.Equal(t, []int64{hub.enrollmentID}, hub.revokedIDs)
+		_, bindErr := env.DB.FederationBindingByProject(ctx, project.ID)
+		assert.ErrorIs(t, bindErr, db.ErrNotFound)
+		archived, dbErr := env.DB.ProjectByNameIncludingArchived(ctx, project.Name)
+		require.NoError(t, dbErr)
+		assert.NotNil(t, archived.DeletedAt, "forced archive-leave must archive")
+	})
+}
+
 // TestFederationLeaveRevokesAfterProjectsRemoveArchive: `kata projects remove`
 // archives a federated spoke without revoking its hub enrollment (the remove
 // route has no federation guard). Leave on that archived project must still

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -1271,7 +1271,7 @@ func TestFederationLeaveHubUnreachableAbortsWithoutLocalOnly(t *testing.T) {
 
 	// Start a server then immediately close it so the URL is syntactically valid
 	// but the port is closed when the command runs.
-	deadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadSrv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	deadURL := deadSrv.URL
 	deadSrv.Close()
 
@@ -1386,7 +1386,7 @@ func TestFederationLeaveResumeWhenAlreadyStandalone(t *testing.T) {
 		_, err = runCmdOutput(t, env, "federation", "leave",
 			"--project", "standalone-project", "--delete")
 		require.Error(t, err)
-		requireCLIError(t, err, ExitConfirm)
+		_ = requireCLIError(t, err, ExitConfirm)
 
 		// The project must still be active (the archive was gated, not run).
 		alive, dbErr := env.DB.ProjectByName(ctx, project.Name)

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -1028,10 +1028,11 @@ func TestResolveHubAdminAuthPrecedence(t *testing.T) {
 	if got.token != "catalog-tok" {
 		t.Fatalf("catalog token expected, got %q", got.token)
 	}
-	// allow_insecure comes from the binding, not the catalog entry: with the
-	// binding flag unset, the catalog's AllowInsecure must not leak through.
-	if got.allowInsecure {
-		t.Fatalf("allow_insecure must come from the binding, not the catalog, got %+v", got)
+	// allow_insecure unions the binding flag with the SAME-ORIGIN catalog
+	// entry's: the entry is the operator's own opt-in for this exact origin
+	// and restores the flag when it was lost with the credential.
+	if !got.allowInsecure {
+		t.Fatalf("same-origin catalog allow_insecure should union in, got %+v", got)
 	}
 	got, err = resolveHubAdminAuth(cat, hubAuthInputs{hubURL: "http://hub.example:7777"})
 	if err != nil {
@@ -1293,6 +1294,59 @@ func TestFederationLeaveHubUnreachableAbortsWithoutLocalOnly(t *testing.T) {
 	require.NoError(t, err)
 	_, bindErr = env.DB.FederationBindingByProject(ctx, project.ID)
 	assert.ErrorIs(t, bindErr, db.ErrNotFound)
+}
+
+// TestFederationLeaveAllowInsecureFlag covers the partial-leave recovery state
+// where the credential (and with it the recorded allow_insecure opt-in) is
+// gone but the binding to a plaintext-hostname overlay hub remains. Without a
+// restored opt-in the bearer transport refuses --hub-token before any I/O;
+// --allow-insecure is the explicit leave-time escape hatch.
+func TestFederationLeaveAllowInsecureFlag(t *testing.T) {
+	seed := func(t *testing.T, env *testenv.Env) {
+		t.Helper()
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "spoke-project")
+		require.NoError(t, err)
+		_, err = env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+			ProjectID:            project.ID,
+			Role:                 db.FederationRoleSpoke,
+			HubURL:               "http://hub.invalid:7373",
+			HubProjectID:         42,
+			HubProjectUID:        project.UID,
+			ReplayHorizonEventID: 9,
+			Enabled:              true,
+		})
+		require.NoError(t, err)
+		// No credential on disk: the opt-in recorded at join time is lost.
+	}
+
+	t.Run("hub token to a plaintext hostname is refused without the opt-in", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		seed(t, env)
+
+		_, err := runCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--hub-token", "admin-token", "--yes")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "refusing to attach bearer token",
+			"plaintext hostname + bearer token must be refused without allow_insecure")
+	})
+
+	t.Run("--allow-insecure restores the transport opt-in", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		seed(t, env)
+
+		_, err := runCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--hub-token", "admin-token", "--allow-insecure", "--yes")
+
+		// hub.invalid never resolves, so the revoke still fails — but at the
+		// network layer, past the bearer-transport refusal.
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "refusing to attach bearer token",
+			"--allow-insecure must get past the plaintext bearer refusal")
+	})
 }
 
 func TestFederationLeaveResumeWhenAlreadyStandalone(t *testing.T) {

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -1296,6 +1296,70 @@ func TestFederationLeaveHubUnreachableAbortsWithoutLocalOnly(t *testing.T) {
 	assert.ErrorIs(t, bindErr, db.ErrNotFound)
 }
 
+// TestFederationLeaveResolvesArchivedProject: an archive-leave retry must be
+// able to reach the daemon's idempotent resume by name even though the
+// project is archived — active-only resolution would report "not found"
+// while detach/credential cleanup is still pending.
+func TestFederationLeaveResolvesArchivedProject(t *testing.T) {
+	t.Run("stale credential cleaned through the archived project", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "spoke-project")
+		require.NoError(t, err)
+		// Partial archive-leave: archive committed, credential delete failed.
+		require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+			HubURL:       "http://hub.internal:7373",
+			HubProjectID: 42,
+			Token:        "stale-token",
+		}))
+		_, _, err = env.DB.RemoveProject(ctx, db.RemoveProjectParams{
+			ProjectID: project.ID, Actor: "tester",
+		})
+		require.NoError(t, err)
+
+		out := requireCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--yes")
+
+		assert.Contains(t, out, "already standalone")
+		assert.Equal(t, "missing", config.FederationCredentialMetadataFor(project.UID).Status,
+			"resume cleanup must be reachable for archived projects from the CLI")
+	})
+
+	t.Run("surviving binding detached through the archived project", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "spoke-project")
+		require.NoError(t, err)
+		_, err = env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+			ProjectID:            project.ID,
+			Role:                 db.FederationRoleSpoke,
+			HubURL:               "http://hub.internal:7373",
+			HubProjectID:         42,
+			HubProjectUID:        project.UID,
+			ReplayHorizonEventID: 9,
+			Enabled:              true,
+		})
+		require.NoError(t, err)
+		// Partial archive-leave: archive committed, detach never ran. The
+		// status list hides archived projects, so the retry runs as the
+		// standalone resume — no hub contact (the revoke already happened
+		// before the original failure), full local teardown.
+		_, _, err = env.DB.RemoveProject(ctx, db.RemoveProjectParams{
+			ProjectID: project.ID, Actor: "tester",
+		})
+		require.NoError(t, err)
+
+		_ = requireCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--yes")
+
+		_, bindErr := env.DB.FederationBindingByProject(ctx, project.ID)
+		assert.ErrorIs(t, bindErr, db.ErrNotFound,
+			"the surviving binding must be detached on the archived-project retry")
+	})
+}
+
 // TestFederationLeaveAllowInsecureFlag covers the partial-leave recovery state
 // where the credential (and with it the recorded allow_insecure opt-in) is
 // gone but the binding to a plaintext-hostname overlay hub remains. Without a

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -182,6 +182,7 @@ func TestFederationHelpIsVisible(t *testing.T) {
 	assert.Contains(t, out, "enroll")
 	assert.Contains(t, out, "enrollments")
 	assert.Contains(t, out, "join")
+	assert.Contains(t, out, "leave")
 	assert.Contains(t, out, "revoke")
 }
 
@@ -299,7 +300,9 @@ func TestFederationEnrollCLIPrintsJoinCommand(t *testing.T) {
 	assert.NotContains(t, out, "--replay-horizon")
 	assert.NotContains(t, out, "--baseline-through")
 	assert.Contains(t, out, "--push")
-	assert.Contains(t, out, "--adopt-existing")
+	// The single-daemon setup makes the spoke project the hub project itself
+	// (same UID), which is the rejoin shape: no adoption is auto-marked.
+	assert.NotContains(t, out, "--adopt-existing")
 	assert.Contains(t, out, "--token ")
 }
 
@@ -1007,6 +1010,368 @@ func TestFederationRevokeCLIRevokesEnrollment(t *testing.T) {
 	assert.ErrorIs(t, err, db.ErrNotFound)
 }
 
+func TestResolveHubAdminAuthPrecedence(t *testing.T) {
+	cat := &config.DaemonConfig{Daemons: []config.CatalogDaemonConfig{
+		{Name: "hub-daemon", URL: "http://hub.example:7777", Token: "catalog-tok", AllowInsecure: true},
+	}}
+	got, err := resolveHubAdminAuth(cat, hubAuthInputs{hubURL: "http://hub.example:7777", hubName: "hub-daemon", hubToken: "explicit"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.token != "explicit" {
+		t.Fatalf("explicit token should win, got %q", got.token)
+	}
+	got, err = resolveHubAdminAuth(cat, hubAuthInputs{hubURL: "http://hub.example:7777", hubName: "hub-daemon"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.token != "catalog-tok" {
+		t.Fatalf("catalog token expected, got %q", got.token)
+	}
+	// allow_insecure comes from the binding, not the catalog entry: with the
+	// binding flag unset, the catalog's AllowInsecure must not leak through.
+	if got.allowInsecure {
+		t.Fatalf("allow_insecure must come from the binding, not the catalog, got %+v", got)
+	}
+	got, err = resolveHubAdminAuth(cat, hubAuthInputs{hubURL: "http://hub.example:7777"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.token != "catalog-tok" {
+		t.Fatalf("url-matched catalog token expected, got %q", got.token)
+	}
+}
+
+// fakeLeaveHub is a minimal hub stub for federation-leave CLI tests. It serves
+// the enrollment list (one active enrollment matching the spoke instance and
+// hub project) and records revoke calls so a test can assert revoke-first
+// behavior. spokeInstanceUID and hubProjectID are matched by the command.
+type fakeLeaveHub struct {
+	spokeInstanceUID string
+	hubProjectID     int64
+	enrollmentID     int64
+	// globalEnrollmentID, when nonzero, is served as an active enrollment with
+	// nil project scope (a global grant for the same spoke instance).
+	globalEnrollmentID int64
+	revokedIDs         []int64
+}
+
+func newFakeLeaveHub(t *testing.T, spokeInstanceUID string, hubProjectID int64) (*fakeLeaveHub, *httptest.Server) {
+	t.Helper()
+	h := &fakeLeaveHub{spokeInstanceUID: spokeInstanceUID, hubProjectID: hubProjectID, enrollmentID: 7}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/ping":
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/federation/enrollments":
+			pid := h.hubProjectID
+			out := api.ListFederationEnrollmentsBody{Enrollments: []api.FederationEnrollmentOut{{
+				ID:               h.enrollmentID,
+				SpokeInstanceUID: h.spokeInstanceUID,
+				ProjectID:        &pid,
+				Capabilities:     "pull,push,claim",
+				Actor:            "wesm",
+			}}}
+			if h.globalEnrollmentID != 0 {
+				out.Enrollments = append(out.Enrollments, api.FederationEnrollmentOut{
+					ID:               h.globalEnrollmentID,
+					SpokeInstanceUID: h.spokeInstanceUID,
+					Capabilities:     "pull,push,claim",
+					Actor:            "wesm",
+				})
+			}
+			_ = json.NewEncoder(w).Encode(out)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1/federation/enrollments/") && strings.HasSuffix(r.URL.Path, "/revoke"):
+			idStr := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/federation/enrollments/"), "/revoke")
+			id, _ := strconv.ParseInt(idStr, 10, 64)
+			h.revokedIDs = append(h.revokedIDs, id)
+			_ = json.NewEncoder(w).Encode(api.RevokeFederationEnrollmentBody{ID: id, Revoked: true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return h, srv
+}
+
+// seedLeaveSpoke creates a push-enabled spoke project on env's daemon bound to
+// hubURL, with a stored transport credential. Mirrors the daemon leave-route
+// test fixtures but points hub_url at a caller-controlled fake hub.
+func seedLeaveSpoke(t *testing.T, env *testenv.Env, name, hubURL string, hubProjectID int64) db.Project {
+	t.Helper()
+	ctx := context.Background()
+	project, err := env.DB.CreateProject(ctx, name)
+	require.NoError(t, err)
+	_, err = env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            project.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               hubURL,
+		HubProjectID:         hubProjectID,
+		HubProjectUID:        project.UID,
+		ReplayHorizonEventID: 9,
+		PullCursorEventID:    8,
+		PushEnabled:          true,
+		Actor:                "wesm",
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+		HubURL:       hubURL,
+		HubProjectID: hubProjectID,
+		Token:        "spoke-token",
+		Actor:        "wesm",
+	}))
+	return project
+}
+
+func TestFederationLeaveDetachRevokesThenTearsDown(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	ctx := context.Background()
+	const hubProjectID int64 = 42
+	hub, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+	project := seedLeaveSpoke(t, env, "spoke-project", hubSrv.URL, hubProjectID)
+
+	out := requireCmdOutput(t, env, "federation", "leave", "--project", "spoke-project", "--yes")
+
+	// Hub revoke was called for the matching enrollment before teardown.
+	require.Equal(t, []int64{hub.enrollmentID}, hub.revokedIDs)
+	// Local binding is gone afterward: the project is standalone.
+	_, err := env.DB.FederationBindingByProject(ctx, project.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+	assert.Contains(t, out, "standalone")
+}
+
+func TestFederationLeaveLocalOnlySkipsRevoke(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	ctx := context.Background()
+	const hubProjectID int64 = 42
+	hub, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+	project := seedLeaveSpoke(t, env, "spoke-project", hubSrv.URL, hubProjectID)
+
+	stdout, stderr, err := runCmdCapture(t, env, "federation", "leave",
+		"--project", "spoke-project", "--local-only", "--yes")
+	require.NoError(t, err)
+
+	// --local-only must not touch the hub.
+	require.Empty(t, hub.revokedIDs)
+	// Local teardown still happened.
+	_, err = env.DB.FederationBindingByProject(ctx, project.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+	assert.Contains(t, stdout, "standalone")
+	assert.Contains(t, stderr, "token remains valid")
+}
+
+func TestFederationLeaveDeleteArchivesReplica(t *testing.T) {
+	t.Run("no open issues", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		const hubProjectID int64 = 42
+		hub, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+		project := seedLeaveSpoke(t, env, "spoke-project", hubSrv.URL, hubProjectID)
+
+		out := requireCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--delete", "--yes")
+
+		// Hub revoke happened before archive.
+		require.Equal(t, []int64{hub.enrollmentID}, hub.revokedIDs)
+		// Project is now archived (not resolving as active).
+		_, err := env.DB.ProjectByName(ctx, project.Name)
+		assert.ErrorIs(t, err, db.ErrNotFound)
+		// But it exists in the archive.
+		archived, err := env.DB.ProjectByNameIncludingArchived(ctx, project.Name)
+		require.NoError(t, err)
+		require.NotNil(t, archived.DeletedAt, "project should be archived")
+		assert.Contains(t, out, "archived")
+	})
+
+	t.Run("open issue without force returns error", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		const hubProjectID int64 = 42
+		_, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+		project := seedLeaveSpoke(t, env, "spoke-project", hubSrv.URL, hubProjectID)
+		_, _, err := env.DB.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID,
+			Title:     "open issue",
+			Author:    "tester",
+		})
+		require.NoError(t, err)
+
+		_, err = runCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--delete", "--yes")
+
+		require.Error(t, err)
+		ce := requireCLIError(t, err, ExitConflict)
+		assert.Contains(t, ce.Message, "open issues")
+		// The archive is refused BEFORE the local detach (preflight), so the
+		// binding is still present and the project is still active — no
+		// "detached-but-not-archived" partial state.
+		_, bindErr := env.DB.FederationBindingByProject(ctx, project.ID)
+		require.NoError(t, bindErr, "binding should still be present after refused archive")
+		alive, dbErr := env.DB.ProjectByName(ctx, project.Name)
+		require.NoError(t, dbErr, "project should still be active (not archived)")
+		assert.Nil(t, alive.DeletedAt)
+	})
+
+	t.Run("open issue with force archives", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		const hubProjectID int64 = 42
+		hub, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+		project := seedLeaveSpoke(t, env, "spoke-project", hubSrv.URL, hubProjectID)
+		_, _, err := env.DB.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID,
+			Title:     "open issue",
+			Author:    "tester",
+		})
+		require.NoError(t, err)
+
+		out := requireCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--delete", "--force", "--yes")
+
+		require.Equal(t, []int64{hub.enrollmentID}, hub.revokedIDs)
+		_, err = env.DB.ProjectByName(ctx, project.Name)
+		assert.ErrorIs(t, err, db.ErrNotFound)
+		assert.Contains(t, out, "archived")
+	})
+}
+
+func TestFederationLeaveNotASpoke(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	ctx := context.Background()
+	project, err := env.DB.CreateProject(ctx, "hub-project")
+	require.NoError(t, err)
+	// EnableProjectFederation creates a proper hub binding using the project's UID.
+	_, err = env.DB.EnableProjectFederation(ctx, project.ID, "tester")
+	require.NoError(t, err)
+	// Stand up a fake hub to confirm it gets zero calls.
+	hub, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), project.ID)
+	_ = hubSrv
+
+	_, err = runCmdOutput(t, env, "federation", "leave", "--project", "hub-project", "--yes")
+
+	require.Error(t, err)
+	ce := requireCLIError(t, err, ExitValidation)
+	assert.Equal(t, "not_a_spoke", ce.Code)
+	// No hub calls made.
+	require.Empty(t, hub.revokedIDs)
+}
+
+func TestFederationLeaveHubUnreachableAbortsWithoutLocalOnly(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	ctx := context.Background()
+	const hubProjectID int64 = 42
+
+	// Start a server then immediately close it so the URL is syntactically valid
+	// but the port is closed when the command runs.
+	deadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := deadSrv.URL
+	deadSrv.Close()
+
+	project := seedLeaveSpoke(t, env, "spoke-project", deadURL, hubProjectID)
+
+	// Without --local-only: should fail because hub is unreachable.
+	_, err := runCmdOutput(t, env, "federation", "leave",
+		"--project", "spoke-project", "--yes")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hub revoke failed")
+	// Local binding must still be present (teardown was not run).
+	_, bindErr := env.DB.FederationBindingByProject(ctx, project.ID)
+	require.NoError(t, bindErr, "binding should still be present after hub-unreachable abort")
+
+	// With --local-only: should succeed and tear down the local binding.
+	_, _, err = runCmdCapture(t, env, "federation", "leave",
+		"--project", "spoke-project", "--local-only", "--yes")
+	require.NoError(t, err)
+	_, bindErr = env.DB.FederationBindingByProject(ctx, project.ID)
+	assert.ErrorIs(t, bindErr, db.ErrNotFound)
+}
+
+func TestFederationLeaveResumeWhenAlreadyStandalone(t *testing.T) {
+	t.Run("delete on no-binding project archives it", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "standalone-project")
+		require.NoError(t, err)
+
+		// No hub server needed: no revoke should be attempted.
+		out := requireCmdOutput(t, env, "federation", "leave",
+			"--project", "standalone-project", "--delete", "--yes")
+
+		// Project is archived (no hub contact needed).
+		_, err = env.DB.ProjectByName(ctx, project.Name)
+		assert.ErrorIs(t, err, db.ErrNotFound)
+		archived, err := env.DB.ProjectByNameIncludingArchived(ctx, project.Name)
+		require.NoError(t, err)
+		require.NotNil(t, archived.DeletedAt, "project should be archived")
+		assert.Contains(t, out, "archived")
+	})
+
+	t.Run("plain leave on no-binding project prints already standalone", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "standalone-project")
+		require.NoError(t, err)
+
+		out := requireCmdOutput(t, env, "federation", "leave",
+			"--project", "standalone-project", "--yes")
+
+		assert.Contains(t, out, "already standalone")
+		// Project is still active (not archived).
+		alive, err := env.DB.ProjectByName(ctx, project.Name)
+		require.NoError(t, err)
+		assert.Nil(t, alive.DeletedAt)
+	})
+
+	t.Run("plain leave on no-binding project honors --json", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		_, err := env.DB.CreateProject(ctx, "standalone-project")
+		require.NoError(t, err)
+
+		out := requireCmdOutput(t, env, "--json", "federation", "leave",
+			"--project", "standalone-project", "--yes")
+
+		// Output must be machine-readable JSON, not the human one-liner.
+		var body map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &body),
+			"standalone no-op must honor --json, got: %s", out)
+		assert.Equal(t, false, body["detached"], "no-op did not detach")
+		assert.Equal(t, "detach", body["disposition"])
+	})
+
+	t.Run("delete on no-binding project requires confirmation without --yes", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "standalone-project")
+		require.NoError(t, err)
+
+		// No --yes and no TTY: the standalone --delete archive must be
+		// confirm-gated, not silently archived.
+		_, err = runCmdOutput(t, env, "federation", "leave",
+			"--project", "standalone-project", "--delete")
+		require.Error(t, err)
+		requireCLIError(t, err, ExitConfirm)
+
+		// The project must still be active (the archive was gated, not run).
+		alive, dbErr := env.DB.ProjectByName(ctx, project.Name)
+		require.NoError(t, dbErr)
+		assert.Nil(t, alive.DeletedAt, "archive must not run without confirmation")
+	})
+}
+
 func setupFederationStatusCLIState(t *testing.T) (*testenv.Env, db.Project) {
 	t.Helper()
 	resetFlags(t)
@@ -1123,4 +1488,111 @@ func ingestCLIClaimViolation(
 	})
 	require.NoError(t, err)
 	return ev
+}
+
+// TestFederationJoinLeaveJoinRoundTrip is the CLI round-trip contract: a spoke
+// that joins, leaves, and joins the same hub project again must come back as a
+// working replica. The leave keeps the local project's shared hub UID, so the
+// second join exercises the daemon's rejoin path.
+func TestFederationJoinLeaveJoinRoundTrip(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	ctx := context.Background()
+	const hubProjectID int64 = 42
+	hubProjectUID := "01HZNQ7VFPK1XGD8R5MABCD4EG"
+	_, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+
+	join := func(token string) string {
+		return requireCmdOutput(t, env, "federation", "join",
+			"--project", "fedlab",
+			"--hub-url", hubSrv.URL,
+			"--hub-project-id", "42",
+			"--hub-project-uid", hubProjectUID,
+			"--replay-horizon", "7",
+			"--token", token,
+			"--actor", "wesm",
+			"--push")
+	}
+
+	join("join-token")
+	project, err := env.DB.ProjectByUID(ctx, hubProjectUID)
+	require.NoError(t, err)
+
+	requireCmdOutput(t, env, "federation", "leave", "--project", "fedlab", "--yes")
+	_, err = env.DB.FederationBindingByProject(ctx, project.ID)
+	require.ErrorIs(t, err, db.ErrNotFound, "leave must remove the binding")
+
+	out := join("rejoin-token")
+	assert.Contains(t, out, "joined federation project fedlab")
+	binding, err := env.DB.FederationBindingByProject(ctx, project.ID)
+	require.NoError(t, err)
+	assert.True(t, binding.PushEnabled, "rejoin must honor --push")
+	assert.Equal(t, int64(0), binding.PushCursorEventID,
+		"rejoin re-offers local-origin events from 0 for hub-side dedup")
+	creds, err := config.ReadFederationCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, "rejoin-token", creds.Projects[project.UID].Token,
+		"rejoin must store the fresh enrollment token")
+}
+
+// TestFederationEnrollCLISameNameUIDHolderPrintsRejoinJoin: when the spoke's
+// same-name project already shares the hub project's UID (it previously left
+// this federation), enroll must not auto-mark adoption — the printed join is
+// a plain rejoin that rebinds without rewriting local event history.
+func TestFederationEnrollCLISameNameUIDHolderPrintsRejoinJoin(t *testing.T) {
+	resetFlags(t)
+	hub := testenv.New(t, testenv.WithAuthToken("hub-token"))
+	spoke := testenv.New(t)
+	t.Setenv("KATA_SERVER", spoke.URL)
+	ctx := context.Background()
+	hubProject, err := hub.DB.CreateProject(ctx, "fedlab")
+	require.NoError(t, err)
+	_, err = spoke.DB.CreateProjectWithUID(ctx, "fedlab", hubProject.UID)
+	require.NoError(t, err)
+
+	cmd := newRootCmd()
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--project", "fedlab",
+		"federation", "enroll",
+		"--spoke-instance", spoke.DB.InstanceUID(),
+		"--hub-url", hub.URL,
+		"--actor", "operator",
+	})
+
+	require.NoError(t, cmd.Execute())
+	out := buf.String()
+	assert.Contains(t, out, "federation join")
+	assert.NotContains(t, out, "--adopt-existing",
+		"a UID-holder rejoin must not be railroaded into adoption")
+
+	enrollments, err := hub.DB.ListFederationEnrollments(ctx)
+	require.NoError(t, err)
+	require.Len(t, enrollments, 1)
+	assert.False(t, enrollments[0].AllowAdoptionSnapshotAuthors)
+}
+
+// TestFederationLeaveWarnsAboutActiveGlobalEnrollment: leave revokes the
+// project-scoped enrollment but must not silently ignore a matching GLOBAL
+// enrollment — it still authorizes the project, yet may serve the spoke's
+// other projects, so it is surfaced as a warning instead of auto-revoked.
+func TestFederationLeaveWarnsAboutActiveGlobalEnrollment(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	const hubProjectID int64 = 42
+	hub, hubSrv := newFakeLeaveHub(t, env.DB.InstanceUID(), hubProjectID)
+	hub.globalEnrollmentID = 11
+	seedLeaveSpoke(t, env, "spoke-project", hubSrv.URL, hubProjectID)
+
+	stdout, stderr, err := runCmdCapture(t, env, "federation", "leave",
+		"--project", "spoke-project", "--yes")
+	require.NoError(t, err)
+
+	require.Equal(t, []int64{hub.enrollmentID}, hub.revokedIDs,
+		"only the project-scoped enrollment is revoked")
+	assert.Contains(t, stdout, "standalone")
+	assert.Contains(t, stderr, "global enrollment(s) #11")
+	assert.Contains(t, stderr, "remain active")
 }

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -1143,6 +1143,51 @@ func TestFederationLeaveDetachRevokesThenTearsDown(t *testing.T) {
 	assert.Contains(t, out, "standalone")
 }
 
+// TestFederationLeaveAbortsOnEnrollmentUIDMismatch: when no active enrollment
+// matches this spoke's instance UID but project-scoped enrollment(s) for the
+// hub project are still active, "zero matches is success" would silently
+// detach and delete the credential while a live token keeps hub access — the
+// instance UID can drift from the enrollment's (clone/import refresh, or an
+// enroll created with an explicit --spoke-instance). Leave must abort with
+// the surviving IDs; --local-only stays the explicit local-teardown path.
+func TestFederationLeaveAbortsOnEnrollmentUIDMismatch(t *testing.T) {
+	t.Run("aborts before any teardown", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		const hubProjectID int64 = 42
+		// The hub's only active enrollment is for a different spoke instance.
+		hub, hubSrv := newFakeLeaveHub(t, "01HZNQ7VFPK1XGD8R5MABCD4FF", hubProjectID)
+		project := seedLeaveSpoke(t, env, "spoke-project", hubSrv.URL, hubProjectID)
+
+		_, err := runCmdOutput(t, env, "federation", "leave",
+			"--project", "spoke-project", "--yes")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "#7", "the surviving enrollment ID must be named")
+		assert.Contains(t, err.Error(), "--local-only")
+		assert.Empty(t, hub.revokedIDs, "a foreign-instance enrollment must not be auto-revoked")
+		_, bindErr := env.DB.FederationBindingByProject(ctx, project.ID)
+		require.NoError(t, bindErr, "binding must stay intact after the abort")
+		assert.Equal(t, "present", config.FederationCredentialMetadataFor(project.UID).Status)
+	})
+
+	t.Run("--local-only remains the explicit escape", func(t *testing.T) {
+		resetFlags(t)
+		env := testenv.New(t)
+		ctx := context.Background()
+		const hubProjectID int64 = 42
+		_, hubSrv := newFakeLeaveHub(t, "01HZNQ7VFPK1XGD8R5MABCD4FF", hubProjectID)
+		project := seedLeaveSpoke(t, env, "spoke-project", hubSrv.URL, hubProjectID)
+
+		_, _, err := runCmdCapture(t, env, "federation", "leave",
+			"--project", "spoke-project", "--local-only", "--yes")
+		require.NoError(t, err)
+		_, bindErr := env.DB.FederationBindingByProject(ctx, project.ID)
+		assert.ErrorIs(t, bindErr, db.ErrNotFound)
+	})
+}
+
 func TestFederationLeaveLocalOnlySkipsRevoke(t *testing.T) {
 	resetFlags(t)
 	env := testenv.New(t)

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -353,9 +353,10 @@ retry). `--delete` also archives the
 now-standalone project (reversible via `kata projects restore`), with archive
 eligibility checked before any detach so an open-issue refusal cannot leave the
 project half-torn-down; `--force` overrides that refusal. An advisory daemon
-preflight (`preflight=true` on the leave route) runs the same eligibility check
-before the hub revoke, so the predictable refusal cannot strand a hub-revoked,
-locally bound spoke either. Retrying an
+preflight (`preflight=true` on the leave route) runs before the hub revoke for
+every hub-contacting leave — detach refusals (spoke-role drift, vanished
+project, actor validation) and the archive's open-issue check alike — so a
+predictable local refusal cannot strand a hub-revoked, locally bound spoke. Retrying an
 archive-leave whose archive already committed resumes rather than refusing:
 the already-archived step is skipped (that call reports `archived=false`) and
 any surviving detach and credential cleanup still run. The join-time

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -363,8 +363,10 @@ explicit `leave --allow-insecure` flag, so a credential loss cannot strand a
 plain-HTTP overlay hub's enrollment behind the plaintext-bearer refusal. `--local-only` tears
 down locally when the hub is unreachable, leaving the enrollment token to be
 revoked manually. A binding-aware guard stops an in-flight sync pass from
-re-creating `federation_sync_status` rows after a leave. A user-facing project
-purge for the `--delete` path is deferred.
+re-creating `federation_sync_status` rows after a leave, and quarantine
+recording no-ops the same way so a poisoned push response landing after the
+leave cannot recreate active quarantine state for a standalone or archived
+project. A user-facing project purge for the `--delete` path is deferred.
 
 Leave keeps the project's shared identity (its UID stays the hub project's
 UID), which makes the round-trip contract hold: **enroll → leave → enroll

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -357,7 +357,8 @@ archive-leave whose archive already committed resumes rather than refusing:
 the already-archived step is skipped (that call reports `archived=false`) and
 any surviving detach and credential cleanup still run. The join-time
 `--allow-insecure` transport opt-in is persisted on the binding (schema 15)
-and surfaced in status as the union with the credential's copy; the leave hub
+and surfaced in status as the union with the credential's copy (only when
+that credential names the binding's hub URL and project); the leave hub
 client further unions a same-origin catalog entry's `allow_insecure` and the
 explicit `leave --allow-insecure` flag, so a credential loss cannot strand a
 plain-HTTP overlay hub's enrollment behind the plaintext-bearer refusal. `--local-only` tears

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -347,7 +347,9 @@ standalone project — removing the binding, sync-status, quarantine, and claim
 rows and deleting the daemon-local hub credential in one daemon-route operation
 (`POST /api/v1/federation/replicas/{id}/actions/leave`). Leaving is revoke-first,
 so a hub failure leaves local state intact for a clean retry; it is idempotent
-(a project with no binding is a no-op success). `--delete` also archives the
+(a project with no binding reports "already standalone", and the daemon route
+still runs so a stale hub credential left by a partial leave is deleted on the
+retry). `--delete` also archives the
 now-standalone project (reversible via `kata projects restore`), with archive
 eligibility checked before any detach so an open-issue refusal cannot leave the
 project half-torn-down; `--force` overrides that refusal. `--local-only` tears

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -329,6 +329,7 @@ kata federation join --project <existing-project> --hub-url <url> --hub-project-
   --token <token> --actor <actor> --push --adopt-existing
 kata federation enrollments list
 kata federation revoke <enrollment-id>
+kata federation leave <project> [--delete [--force]] [--local-only] [--hub <name>]
 kata federation status
 kata federation status --json
 kata federation lease acquire <issue-ref> [--ttl 30m]
@@ -338,9 +339,37 @@ kata federation lease release <issue-ref>
 `kata federation enrollments list` audits hub-side spoke grants without showing
 token hashes or plaintext tokens. `kata federation revoke <enrollment-id>` marks
 an enrollment inactive so the token no longer authorizes pull, push, or lease
-transport calls. Project-level `leave` and `disable` teardown commands are not
-currently exposed; operators should treat those as a separate reset/removal
-workflow because local pending pushes and replicated state need explicit policy.
+transport calls.
+
+`kata federation leave <project>` is the spoke-side inverse of `join`. It
+revokes the matching hub enrollment, then detaches the local spoke back to a
+standalone project — removing the binding, sync-status, quarantine, and claim
+rows and deleting the daemon-local hub credential in one daemon-route operation
+(`POST /api/v1/federation/replicas/{id}/actions/leave`). Leaving is revoke-first,
+so a hub failure leaves local state intact for a clean retry; it is idempotent
+(a project with no binding is a no-op success). `--delete` also archives the
+now-standalone project (reversible via `kata projects restore`), with archive
+eligibility checked before any detach so an open-issue refusal cannot leave the
+project half-torn-down; `--force` overrides that refusal. `--local-only` tears
+down locally when the hub is unreachable, leaving the enrollment token to be
+revoked manually. A binding-aware guard stops an in-flight sync pass from
+re-creating `federation_sync_status` rows after a leave. A user-facing project
+purge for the `--delete` path is deferred.
+
+Leave keeps the project's shared identity (its UID stays the hub project's
+UID), which makes the round-trip contract hold: **enroll → leave → enroll
+works**. A `join` that targets a hub project whose UID is held by an unbound
+local project of the same name rebinds it (rejoin): pull restarts just below
+the replay horizon and event-UID dedup absorbs the overlap, while a
+push-enabled rejoin restarts the push cursor at 0 so the hub deduplicates
+re-offered events and absorbs edits made while standalone. The same path
+recovers a partially-failed join (project created, binding never written). A
+join naming a different project refuses with
+`federation_rejoin_name_mismatch`, naming the holder; an archived holder must
+be restored first. In the TUI, adoption (history-rewriting) is additionally
+gated behind a typed-confirmation screen stating the local-INTO-hub
+relationship, and the enrollment recovery screen prints the actual join error
+(the token-expiry hint is reserved for 401/403).
 
 `kata federation status` reports one entry for each local federation binding:
 

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -352,7 +352,10 @@ still runs so a stale hub credential left by a partial leave is deleted on the
 retry). `--delete` also archives the
 now-standalone project (reversible via `kata projects restore`), with archive
 eligibility checked before any detach so an open-issue refusal cannot leave the
-project half-torn-down; `--force` overrides that refusal. `--local-only` tears
+project half-torn-down; `--force` overrides that refusal. Retrying an
+archive-leave whose archive already committed resumes rather than refusing:
+the already-archived step is skipped (that call reports `archived=false`) and
+any surviving detach and credential cleanup still run. `--local-only` tears
 down locally when the hub is unreachable, leaving the enrollment token to be
 revoked manually. A binding-aware guard stops an in-flight sync pass from
 re-creating `federation_sync_status` rows after a leave. A user-facing project

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -355,7 +355,12 @@ eligibility checked before any detach so an open-issue refusal cannot leave the
 project half-torn-down; `--force` overrides that refusal. Retrying an
 archive-leave whose archive already committed resumes rather than refusing:
 the already-archived step is skipped (that call reports `archived=false`) and
-any surviving detach and credential cleanup still run. `--local-only` tears
+any surviving detach and credential cleanup still run. The join-time
+`--allow-insecure` transport opt-in is persisted on the binding (schema 15)
+and surfaced in status as the union with the credential's copy; the leave hub
+client further unions a same-origin catalog entry's `allow_insecure` and the
+explicit `leave --allow-insecure` flag, so a credential loss cannot strand a
+plain-HTTP overlay hub's enrollment behind the plaintext-bearer refusal. `--local-only` tears
 down locally when the hub is unreachable, leaving the enrollment token to be
 revoked manually. A binding-aware guard stops an in-flight sync pass from
 re-creating `federation_sync_status` rows after a leave. A user-facing project

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -352,7 +352,10 @@ still runs so a stale hub credential left by a partial leave is deleted on the
 retry). `--delete` also archives the
 now-standalone project (reversible via `kata projects restore`), with archive
 eligibility checked before any detach so an open-issue refusal cannot leave the
-project half-torn-down; `--force` overrides that refusal. Retrying an
+project half-torn-down; `--force` overrides that refusal. An advisory daemon
+preflight (`preflight=true` on the leave route) runs the same eligibility check
+before the hub revoke, so the predictable refusal cannot strand a hub-revoked,
+locally bound spoke either. Retrying an
 archive-leave whose archive already committed resumes rather than refusing:
 the already-archived step is skipped (that call reports `archived=false`) and
 any surviving detach and credential cleanup still run. The join-time

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -452,7 +452,12 @@ already-archived project also resumes instead of erroring: it detaches a
 surviving binding, deletes a stale credential, and reports `archived=false`
 for that call. The leave command resolves archived projects for its argument
 and `--project` forms, so rerunning the same `kata federation leave
-<project>` completes the pending cleanup directly.
+<project>` completes the pending cleanup directly. A binding surviving on an
+archived project takes the normal bound path: the hub revoke runs (it is
+idempotent, so a retry whose enrollment was already revoked is a no-op, while
+a spoke archived via `kata projects remove` — which does not revoke — gets
+its enrollment revoked instead of silently stranded), then the local teardown
+finishes. `--local-only` remains the unreachable-hub escape.
 
 In the TUI federation view, press `x` on a spoke row to open a leave preview
 (the mutation boundary), toggle detach/archive and local-only, then confirm.

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -404,9 +404,10 @@ kata federation leave <project> --delete
 ```
 
 If the project still has open issues and you do not pass `--force`, the leave
-is refused (`project_has_open_issues`) by an archive-eligibility preflight
-**before the hub enrollment is revoked**: the binding, the credential, and the
-hub enrollment all stay intact. Close the open issues (or re-run with
+is refused (`project_has_open_issues`) by a daemon preflight **before the hub
+enrollment is revoked**: the binding, the credential, and the hub enrollment
+all stay intact. The same preflight runs for plain detach leaves too, so any
+local refusal the daemon can predict surfaces before hub contact. Close the open issues (or re-run with
 `--force`) and run the leave again. The preflight is advisory — the
 authoritative check runs inside the archive transaction itself, which executes
 after the revoke — so an issue opened in that small window can still land the

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -422,7 +422,16 @@ the origin its entry is configured for: a `--hub <name>` entry that is missing
 or whose URL does not match the binding's hub URL is rejected, so a catalog
 admin token cannot leak to a different hub. Use `--hub-token` when you
 deliberately need to present a token the catalog does not associate with that
-hub. Leave also warns when the hub holds a
+hub.
+
+For plain-HTTP overlay hubs joined with `--allow-insecure`, the transport
+opt-in is recorded on the binding itself (as well as in the credential), so
+the leave-time hub client can carry a bearer token to the plaintext hostname
+even after a partial leave lost `credentials.toml`. A same-origin catalog
+entry with `allow_insecure = true` also restores the opt-in, and
+`kata federation leave --allow-insecure` asserts it explicitly when no local
+record of it survives. Without one of those, a token-bearing request to a
+plaintext hostname is refused before any network I/O. Leave also warns when the hub holds a
 matching **global** enrollment (no project scope) for this spoke: it still
 authorizes the left project but is not auto-revoked, since it may serve the
 spoke's other projects.

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -430,8 +430,10 @@ contacting the hub. The enrollment token then **remains valid** until you run
 kata federation leave <project> --local-only
 ```
 
-Leaving is idempotent: running it on a project that is already standalone is a
-no-op success, and `leave --delete` on a standalone project still archives it.
+Leaving is idempotent: running it on a project that is already standalone
+reports success and finishes any cleanup a failed earlier leave left behind
+(such as a stale hub credential in `credentials.toml`), and `leave --delete`
+on a standalone project still archives it.
 
 In the TUI federation view, press `x` on a spoke row to open a leave preview
 (the mutation boundary), toggle detach/archive and local-only, then confirm.

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -417,7 +417,12 @@ the binding's hub URL. With no hub credential the revoke request is sent
 **unauthenticated** — the local daemon's global `KATA_AUTH_TOKEN` /
 `[auth].token` is never sent to the hub origin implicitly, so a token-protected
 hub requires `--hub-token`, a catalog entry, or `--local-only`. The hub URL
-itself always comes from the binding. Leave also warns when the hub holds a
+itself always comes from the binding, and a catalog token is only ever sent to
+the origin its entry is configured for: a `--hub <name>` entry that is missing
+or whose URL does not match the binding's hub URL is rejected, so a catalog
+admin token cannot leak to a different hub. Use `--hub-token` when you
+deliberately need to present a token the catalog does not associate with that
+hub. Leave also warns when the hub holds a
 matching **global** enrollment (no project scope) for this spoke: it still
 authorizes the left project but is not auto-revoked, since it may serve the
 spoke's other projects.

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -438,6 +438,14 @@ matching **global** enrollment (no project scope) for this spoke: it still
 authorizes the left project but is not auto-revoked, since it may serve the
 spoke's other projects.
 
+If no active enrollment matches this spoke's instance UID but project-scoped
+enrollment(s) still authorize the hub project, the leave **aborts** and names
+them instead of treating zero matches as success — the instance UID can change
+after a clone/import, or the enrollment may have been created for another
+instance (including another spoke of a shared hub project). Revoke the right
+one with `kata federation revoke <id>` on the hub, or rerun with
+`--local-only`.
+
 If the hub is unreachable, `--local-only` tears down the local spoke without
 contacting the hub. The enrollment token then **remains valid** until you run
 `kata federation revoke <enrollment-id>` on the hub yourself:

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -450,9 +450,9 @@ reports success and finishes any cleanup a failed earlier leave left behind
 on a standalone project still archives it. An archive-leave retry on an
 already-archived project also resumes instead of erroring: it detaches a
 surviving binding, deletes a stale credential, and reports `archived=false`
-for that call. CLI name resolution hides archived projects, so retry via the
-API/TUI by project ID, or `kata projects restore <project>` and re-run the
-leave.
+for that call. The leave command resolves archived projects for its argument
+and `--project` forms, so rerunning the same `kata federation leave
+<project>` completes the pending cleanup directly.
 
 In the TUI federation view, press `x` on a spoke row to open a leave preview
 (the mutation boundary), toggle detach/archive and local-only, then confirm.

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -379,6 +379,102 @@ issues keep their original displayed content authors.
 Adopted issues become ordinary federated spoke issues. You can keep editing
 them locally; acquire a hub lease only when you want exclusive coordination.
 
+## Leaving a federation
+
+`kata federation leave` is the inverse of `join`: it revokes the spoke's hub
+enrollment, then tears down the local spoke state so the project becomes an
+ordinary standalone local project again.
+
+```sh
+kata federation leave <project>
+```
+
+By default this **detaches**: the local `federation_bindings`,
+`federation_sync_status`, and quarantine rows are removed, the stored hub
+credential is deleted, and all of the project's issues and current state are
+kept. Leaving is revoke-first — the hub enrollment is revoked before any local
+teardown, so a hub failure leaves local state intact for a clean retry.
+
+Add `--delete` to also archive the now-standalone project (reversible with
+`kata projects restore`); `--delete --force` archives even when the project has
+open issues:
+
+```sh
+kata federation leave <project> --delete
+```
+
+If the project still has open issues and you do not pass `--force`, the archive
+is **refused before the local detach happens** (`project_has_open_issues`): the
+spoke binding stays intact rather than landing in a detached-but-not-archived
+state. Close the open issues (or re-run with `--force`) to finish. Note that the
+hub enrollment is revoked first, so after a refused archive the spoke is
+"hub-revoked, locally intact"; re-running `leave --delete --local-only` (or
+`--force`) completes the teardown.
+
+Hub admin auth for the revoke is resolved, in order: `--hub-token`, the
+`--hub <name>` daemon-catalog entry, then the catalog entry whose URL matches
+the binding's hub URL. With no hub credential the revoke request is sent
+**unauthenticated** — the local daemon's global `KATA_AUTH_TOKEN` /
+`[auth].token` is never sent to the hub origin implicitly, so a token-protected
+hub requires `--hub-token`, a catalog entry, or `--local-only`. The hub URL
+itself always comes from the binding. Leave also warns when the hub holds a
+matching **global** enrollment (no project scope) for this spoke: it still
+authorizes the left project but is not auto-revoked, since it may serve the
+spoke's other projects.
+
+If the hub is unreachable, `--local-only` tears down the local spoke without
+contacting the hub. The enrollment token then **remains valid** until you run
+`kata federation revoke <enrollment-id>` on the hub yourself:
+
+```sh
+kata federation leave <project> --local-only
+```
+
+Leaving is idempotent: running it on a project that is already standalone is a
+no-op success, and `leave --delete` on a standalone project still archives it.
+
+In the TUI federation view, press `x` on a spoke row to open a leave preview
+(the mutation boundary), toggle detach/archive and local-only, then confirm.
+
+Removing the spoke's already-pushed data from the hub project is a separate
+hub-admin action. A user-facing project purge is not yet available; use
+`--delete` (archive) for now.
+
+### Rejoining after a leave
+
+Leaving keeps the local project's identity: it still shares the hub project's
+UID. A later `join` for that hub project recognizes this and **rejoins** —
+rebinding the existing local project instead of creating a second replica:
+
+```sh
+kata federation join --project <spoke-project> --hub-url <url> \
+  --hub-project-id <id> --token <fresh-enrollment-token> --actor <actor> --push
+```
+
+Pull restarts from the hub's replay horizon (already-applied events
+deduplicate by event UID), and a push-enabled rejoin re-offers local-origin
+events from the beginning — the hub deduplicates what it already has and
+absorbs any edits made while the project was standalone. Rejoin with the same
+actor the enrollment is bound to; events authored as a different actor are
+rejected by the hub and quarantined.
+
+A join that names a *different* project while a local project still holds the
+hub project's UID is refused with `federation_rejoin_name_mismatch`, which
+names the holder — rerun the join with `--project <holder>` to rejoin it. An
+archived holder must be restored (`kata projects restore`) first.
+
+In the TUI, selecting a hub project whose identity is already held by a local
+unbound project presents the operation as **rejoin** of that project rather
+than a new local replica.
+
+### Adoption confirmation in the TUI
+
+Because adoption rewrites the local project's event history, the TUI enroll
+preview no longer executes an adoption on a bare Enter. Enter opens a
+confirmation screen that states the operation — federate local project X
+INTO hub project Y — and requires typing the local project's name. Creating
+a new replica and rejoining stay single-step confirmations.
+
 ## Sync model
 
 A spoke polls the hub for events after its pull cursor. It applies hub events
@@ -445,6 +541,7 @@ kata federation join --project <existing-project> --hub-url <url> \
   --hub-project-id <id> --token <token> --actor <actor> --push --adopt-existing
 kata federation enrollments list
 kata federation revoke <enrollment-id>
+kata federation leave <project> [--delete [--force]] [--local-only] [--hub <name>]
 kata federation status
 kata federation status --json
 kata federation lease acquire <issue-ref> [--ttl 30m]

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -403,13 +403,15 @@ open issues:
 kata federation leave <project> --delete
 ```
 
-If the project still has open issues and you do not pass `--force`, the archive
-is **refused before the local detach happens** (`project_has_open_issues`): the
-spoke binding stays intact rather than landing in a detached-but-not-archived
-state. Close the open issues (or re-run with `--force`) to finish. Note that the
-hub enrollment is revoked first, so after a refused archive the spoke is
-"hub-revoked, locally intact"; re-running `leave --delete --local-only` (or
-`--force`) completes the teardown.
+If the project still has open issues and you do not pass `--force`, the leave
+is refused (`project_has_open_issues`) by an archive-eligibility preflight
+**before the hub enrollment is revoked**: the binding, the credential, and the
+hub enrollment all stay intact. Close the open issues (or re-run with
+`--force`) and run the leave again. The preflight is advisory — the
+authoritative check runs inside the archive transaction itself, which executes
+after the revoke — so an issue opened in that small window can still land the
+spoke "hub-revoked, locally intact"; re-running `leave --delete --local-only`
+(or `--force`) completes that teardown.
 
 Hub admin auth for the revoke is resolved, in order: `--hub-token`, the
 `--hub <name>` daemon-catalog entry, then the catalog entry whose URL matches

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -438,7 +438,12 @@ kata federation leave <project> --local-only
 Leaving is idempotent: running it on a project that is already standalone
 reports success and finishes any cleanup a failed earlier leave left behind
 (such as a stale hub credential in `credentials.toml`), and `leave --delete`
-on a standalone project still archives it.
+on a standalone project still archives it. An archive-leave retry on an
+already-archived project also resumes instead of erroring: it detaches a
+surviving binding, deletes a stale credential, and reports `archived=false`
+for that call. CLI name resolution hides archived projects, so retry via the
+API/TUI by project ID, or `kata projects restore <project>` and re-run the
+leave.
 
 In the TUI federation view, press `x` on a spoke row to open a leave preview
 (the mutation boundary), toggle detach/archive and local-only, then confirm.

--- a/internal/api/federation.go
+++ b/internal/api/federation.go
@@ -406,9 +406,9 @@ type LeaveFederationReplicaResultBody struct {
 	Project ProjectOut `json:"project"`
 	// Detached is true only when this call deleted a federation binding;
 	// false on an idempotent resume of an already-standalone project.
-	Detached    bool       `json:"detached"`
-	Disposition string     `json:"disposition"`
-	Archived    bool       `json:"archived,omitempty"`
+	Detached    bool   `json:"detached"`
+	Disposition string `json:"disposition"`
+	Archived    bool   `json:"archived,omitempty"`
 }
 
 // LeaveFederationReplicaResponse wraps LeaveFederationReplicaResultBody.

--- a/internal/api/federation.go
+++ b/internal/api/federation.go
@@ -403,7 +403,9 @@ type LeaveFederationReplicaRequestBody struct {
 
 // LeaveFederationReplicaResultBody reports the outcome of a leave.
 type LeaveFederationReplicaResultBody struct {
-	Project     ProjectOut `json:"project"`
+	Project ProjectOut `json:"project"`
+	// Detached is true only when this call deleted a federation binding;
+	// false on an idempotent resume of an already-standalone project.
 	Detached    bool       `json:"detached"`
 	Disposition string     `json:"disposition"`
 	Archived    bool       `json:"archived,omitempty"`

--- a/internal/api/federation.go
+++ b/internal/api/federation.go
@@ -22,7 +22,12 @@ type ProjectFederationRequest struct {
 
 // FederationStatusRequest reads status for all locally bound federation
 // projects through the normal local/admin daemon auth surface.
-type FederationStatusRequest struct{}
+// include=archived also surfaces bindings whose project is archived, so a
+// leave on an archived bound spoke can run the full bound path instead of
+// misclassifying it as standalone.
+type FederationStatusRequest struct {
+	Include string `query:"include"`
+}
 
 // ProjectFederationStatusRequest reads status for one locally bound
 // federation project through the normal local/admin daemon auth surface.

--- a/internal/api/federation.go
+++ b/internal/api/federation.go
@@ -378,3 +378,38 @@ type FederationBindingOut struct {
 	UpdatedAt            time.Time  `json:"updated_at"`
 	LastSyncAt           *time.Time `json:"last_sync_at,omitempty"`
 }
+
+// LeaveFederationReplicaRequest tears down a local spoke replica. disposition
+// is "detach" (default) or "archive"; force overrides the archive open-issue
+// refusal. Confirm reserves room for a future "purge" disposition.
+type LeaveFederationReplicaRequest struct {
+	ProjectID int64  `path:"project_id"`
+	Confirm   string `header:"X-Kata-Confirm"`
+	Body      LeaveFederationReplicaRequestBody
+}
+
+// LeaveFederationReplicaRequestBody is the named request payload for the leave
+// action. It is distinct from the LeaveFederationReplicaResultBody response
+// type so the generated OpenAPI client sends disposition/force/actor on the
+// request. The response schema must NOT be named "{operationID}Body": the
+// oapi-codegen request-options Body field is hardcoded to that name, so a
+// response component called LeaveFederationReplicaBody would shadow the request
+// body and the generated client could not send force/actor.
+type LeaveFederationReplicaRequestBody struct {
+	Disposition string `json:"disposition,omitempty"` // "detach" | "archive"
+	Force       bool   `json:"force,omitempty"`
+	Actor       string `json:"actor,omitempty"`
+}
+
+// LeaveFederationReplicaResultBody reports the outcome of a leave.
+type LeaveFederationReplicaResultBody struct {
+	Project     ProjectOut `json:"project"`
+	Detached    bool       `json:"detached"`
+	Disposition string     `json:"disposition"`
+	Archived    bool       `json:"archived,omitempty"`
+}
+
+// LeaveFederationReplicaResponse wraps LeaveFederationReplicaResultBody.
+type LeaveFederationReplicaResponse struct {
+	Body LeaveFederationReplicaResultBody
+}

--- a/internal/api/federation.go
+++ b/internal/api/federation.go
@@ -404,6 +404,13 @@ type LeaveFederationReplicaRequestBody struct {
 	Disposition string `json:"disposition,omitempty"` // "detach" | "archive"
 	Force       bool   `json:"force,omitempty"`
 	Actor       string `json:"actor,omitempty"`
+	// Preflight runs the same validation as the real call — spoke-role
+	// refusal and the archive's open-issue check (honoring Force, with an
+	// already-archived project passing as the resume) — without mutating
+	// anything. Leave clients use it to verify archive eligibility BEFORE
+	// the irreversible hub revoke. Advisory only: the authoritative check
+	// stays inside RemoveProject's transaction.
+	Preflight bool `json:"preflight,omitempty"`
 }
 
 // LeaveFederationReplicaResultBody reports the outcome of a leave.

--- a/internal/config/federation_credentials.go
+++ b/internal/config/federation_credentials.go
@@ -82,6 +82,36 @@ func FederationCredentialMetadataFor(projectUID string) FederationCredentialMeta
 	}
 }
 
+// DeleteFederationCredential removes one project credential from
+// <KATA_HOME>/credentials.toml. It is idempotent: a missing entry or a missing
+// file is not an error. Called from the daemon leave route, mirroring
+// WriteFederationCredential.
+func DeleteFederationCredential(projectUID string) error {
+	creds, err := ReadFederationCredentials()
+	if err != nil {
+		return err
+	}
+	if _, ok := creds.Projects[projectUID]; !ok {
+		return nil
+	}
+	delete(creds.Projects, projectUID)
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(creds); err != nil {
+		return fmt.Errorf("encode federation credentials: %w", err)
+	}
+	path, err := FederationCredentialsPath()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil { //nolint:gosec // credentials file must be owner-only
+		return err
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	return nil
+}
+
 // WriteFederationCredential upserts one project credential into
 // <KATA_HOME>/credentials.toml with owner-only permissions.
 func WriteFederationCredential(projectUID string, c FederationCredential) error {

--- a/internal/config/federation_credentials_test.go
+++ b/internal/config/federation_credentials_test.go
@@ -140,3 +140,31 @@ func TestFederationCredentialMetadataForUnreadableCredential(t *testing.T) {
 	assert.Equal(t, "unreadable", got.Status)
 	assert.False(t, got.AllowInsecure)
 }
+
+func TestDeleteFederationCredentialIdempotent(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	uid := "01KQJF75QFKWXHASB1QK74ZACZ"
+	other := "01KT4E0PJ4FRW0T0QB86EMZ1SN"
+	if err := config.WriteFederationCredential(uid, config.FederationCredential{HubURL: "http://hub.example", HubProjectID: 1, Token: "t"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteFederationCredential(other, config.FederationCredential{HubURL: "http://hub.example", HubProjectID: 2, Token: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.DeleteFederationCredential(uid); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got := config.FederationCredentialMetadataFor(uid).Status; got != "missing" {
+		t.Fatalf("want missing, got %q", got)
+	}
+	if got := config.FederationCredentialMetadataFor(other).Status; got != "present" {
+		t.Fatalf("other credential should survive, got %q", got)
+	}
+	if err := config.DeleteFederationCredential(uid); err != nil {
+		t.Fatalf("second delete should be nil, got %v", err)
+	}
+	t.Setenv("KATA_HOME", t.TempDir())
+	if err := config.DeleteFederationCredential(uid); err != nil {
+		t.Fatalf("delete with no file should be nil, got %v", err)
+	}
+}

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -251,6 +251,94 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 	})
 
 	huma.Register(humaAPI, huma.Operation{
+		OperationID: "leaveFederationReplica",
+		Method:      "POST",
+		Path:        "/api/v1/federation/replicas/{project_id}/actions/leave",
+	}, func(ctx context.Context, in *api.LeaveFederationReplicaRequest) (*api.LeaveFederationReplicaResponse, error) {
+		if in.ProjectID <= 0 {
+			return nil, api.NewError(http.StatusBadRequest, "validation", "project_id must be a positive integer", "", nil)
+		}
+		disposition := strings.TrimSpace(in.Body.Disposition)
+		if disposition == "" {
+			disposition = "detach"
+		}
+		if disposition != "detach" && disposition != "archive" {
+			return nil, api.NewError(http.StatusBadRequest, "validation", `disposition must be "detach" or "archive"`, "", nil)
+		}
+		actor, err := attributedActor(ctx, in.Body.Actor)
+		if err != nil {
+			return nil, err
+		}
+		// Refuse a non-spoke before any teardown so an archive-leave on a hub
+		// project does not archive it and then fail to detach. A project with no
+		// binding is the idempotent resume case and is allowed (RemoveProject and
+		// LeaveFederationReplica below handle existence and the standalone path).
+		if binding, bErr := cfg.DB.FederationBindingByProject(ctx, in.ProjectID); bErr == nil {
+			if binding.Role != db.FederationRoleSpoke {
+				return nil, api.NewError(http.StatusConflict, "not_a_spoke", "federation binding is not a spoke", "", nil)
+			}
+		} else if !errors.Is(bErr, db.ErrNotFound) {
+			return nil, api.NewError(http.StatusInternalServerError, "internal", bErr.Error(), "", nil)
+		}
+
+		body := api.LeaveFederationReplicaResultBody{Detached: true, Disposition: disposition}
+		// Archive FIRST when requested. RemoveProject's own transaction is the
+		// authoritative open-issue check, so a refused archive never tears down
+		// federation — there is no external-preflight TOCTOU and no
+		// "detached-but-not-archived" partial state. Only a committed archive
+		// proceeds to the detach below.
+		if disposition == "archive" {
+			project, evt, err := cfg.DB.RemoveProject(ctx, db.RemoveProjectParams{
+				ProjectID: in.ProjectID, Actor: actor, Force: in.Body.Force,
+			})
+			var openErr *db.ProjectHasOpenIssuesError
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				return nil, api.NewError(http.StatusNotFound, "project_not_found", "project not found", "", nil)
+			case errors.As(err, &openErr):
+				return nil, api.NewError(http.StatusConflict, "project_has_open_issues", "project has open issues",
+					"close the open issues first, or pass force=true",
+					map[string]any{"open_issues": openErr.OpenIssues})
+			case errors.Is(err, db.ErrProjectAlreadyArchived):
+				return nil, api.NewError(http.StatusConflict, "project_already_archived",
+					"project is already archived", "", nil)
+			case err != nil:
+				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			}
+			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: project.ID})
+			cfg.Hooks.Enqueue(*evt)
+			body.Project = dbProjectToOut(project)
+			body.Archived = true
+		}
+
+		res, err := cfg.DB.LeaveFederationReplica(ctx, in.ProjectID)
+		switch {
+		case errors.Is(err, db.ErrNotFound):
+			return nil, api.NewError(http.StatusNotFound, "project_not_found", "project not found", "", nil)
+		case errors.Is(err, db.ErrFederationNotSpoke):
+			return nil, api.NewError(http.StatusConflict, "not_a_spoke", "federation binding is not a spoke", "", nil)
+		case err != nil:
+			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		}
+		if res.ProjectUID != "" {
+			if err := config.DeleteFederationCredential(res.ProjectUID); err != nil {
+				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			}
+		}
+		if !body.Archived {
+			project, err := cfg.DB.ProjectByID(ctx, in.ProjectID)
+			if err != nil {
+				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			}
+			body.Project = dbProjectToOut(project)
+		}
+		if cfg.FederationWake != nil {
+			cfg.FederationWake()
+		}
+		return &api.LeaveFederationReplicaResponse{Body: body}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
 		OperationID: "pollFederationProjectEvents",
 		Method:      "GET",
 		Path:        "/api/v1/projects/{project_id}/federation/events",
@@ -424,6 +512,12 @@ func adoptExistingReplica(
 						api.NewError(409, "federation_project_collision",
 							fmt.Sprintf("hub project UID belongs to local project %q; cannot adopt local project %q", project.Name, projectName), "", nil)
 				}
+				// An explicit adopt_existing on an unbound UID-holder is
+				// honored: adoption is the actor-safe transmission path for
+				// local events authored by other actors (raw push would be
+				// rejected by the hub's actor binding). The post-leave rejoin
+				// railroading is prevented upstream — the enroll command and
+				// the TUI no longer request adoption for UID-holders.
 				result, err := store.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
 					ProjectID:            project.ID,
 					HubURL:               in.Body.HubURL,
@@ -517,7 +611,8 @@ func ensureReplicaBinding(
 	} else if err != nil {
 		return db.Project{}, db.FederationBinding{}, api.NewError(500, "internal", err.Error(), "", nil)
 	} else if project.DeletedAt != nil {
-		return db.Project{}, db.FederationBinding{}, api.NewError(409, "federation_project_collision", "a deleted project already has the hub project UID", "", nil)
+		return db.Project{}, db.FederationBinding{}, api.NewError(409, "federation_project_collision",
+			fmt.Sprintf("an archived local project %q already has the hub project UID; restore it with `kata projects restore` first", project.Name), "", nil)
 	}
 
 	replayHorizon := in.Body.ReplayHorizonEventID
@@ -540,7 +635,28 @@ func ensureReplicaBinding(
 	} else if !errors.Is(err, db.ErrNotFound) {
 		return db.Project{}, db.FederationBinding{}, api.NewError(500, "internal", err.Error(), "", nil)
 	} else if !createdProject {
-		return db.Project{}, db.FederationBinding{}, api.NewError(409, "federation_project_collision", "an existing unbound project already has the hub project UID", "", nil)
+		// An unbound local project holding the hub project UID is the normal
+		// post-leave state: leave removes the binding but the project keeps the
+		// shared identity. A join naming that project is a rejoin — rebind it.
+		// Pull restarts just below the replay horizon (event-UID dedup absorbs
+		// the overlap) and a push-enabled rejoin re-offers local-origin events
+		// from cursor 0 so the hub dedups what it already has and absorbs edits
+		// made while the project was standalone.
+		//
+		// Trust model: a spoke and the hubs it federates with trust each other
+		// (docs/design/federation.md "Tokens And Trust Boundaries" / "No
+		// Multi-Tenant Authorization Model"). The UID is an unguessable ULID, so
+		// a hub reporting it as a project identity means it IS the project that
+		// federated there; we do not defend against a hostile hub forging a known
+		// UID to capture local data (out of scope). The operator-facing rejoin
+		// preview (CLI/TUI) is the confirmation surface.
+		if project.Name != projectName {
+			return db.Project{}, db.FederationBinding{}, api.NewError(409, "federation_rejoin_name_mismatch",
+				fmt.Sprintf("hub project UID is held by local project %q, which previously left this federation; rerun join with --project %q to rejoin it", project.Name, project.Name), "", nil)
+		}
+		if in.Body.PushEnabled {
+			pushEnabled = true
+		}
 	}
 
 	binding, err := store.UpsertFederationBinding(ctx, db.FederationBinding{

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -281,7 +281,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(http.StatusInternalServerError, "internal", bErr.Error(), "", nil)
 		}
 
-		body := api.LeaveFederationReplicaResultBody{Detached: true, Disposition: disposition}
+		body := api.LeaveFederationReplicaResultBody{Disposition: disposition}
 		// Archive FIRST when requested. RemoveProject's own transaction is the
 		// authoritative open-issue check, so a refused archive never tears down
 		// federation — there is no external-preflight TOCTOU and no
@@ -320,6 +320,10 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		case err != nil:
 			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
 		}
+		// Zero role means there was no binding: this is the idempotent resume
+		// (only the credential delete below may still have work to do), so the
+		// response must not claim a detach happened.
+		body.Detached = res.Role == db.FederationRoleSpoke
 		if res.ProjectUID != "" {
 			if err := config.DeleteFederationCredential(res.ProjectUID); err != nil {
 				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -535,6 +535,7 @@ func adoptExistingReplica(
 					HubProjectUID:        in.Body.HubProjectUID,
 					ReplayHorizonEventID: in.Body.ReplayHorizonEventID,
 					Actor:                strings.TrimSpace(in.Body.Actor),
+					AllowInsecure:        in.Body.AllowInsecure,
 				})
 				if err != nil {
 					return db.AdoptProjectIntoFederationResult{}, false, api.NewError(500, "internal", err.Error(), "", nil)
@@ -587,6 +588,7 @@ func adoptExistingReplica(
 		HubProjectUID:        in.Body.HubProjectUID,
 		ReplayHorizonEventID: in.Body.ReplayHorizonEventID,
 		Actor:                strings.TrimSpace(in.Body.Actor),
+		AllowInsecure:        in.Body.AllowInsecure,
 	})
 	if err != nil {
 		return db.AdoptProjectIntoFederationResult{}, true, api.NewError(500, "internal", err.Error(), "", nil)
@@ -680,6 +682,7 @@ func ensureReplicaBinding(
 		PushEnabled:          pushEnabled,
 		PushCursorEventID:    pushCursor,
 		Actor:                strings.TrimSpace(in.Body.Actor),
+		AllowInsecure:        in.Body.AllowInsecure,
 		Enabled:              true,
 	})
 	if err != nil {
@@ -848,18 +851,21 @@ func federationProjectStatus(ctx context.Context, store db.Storage, binding db.F
 		credentialMetadata = config.FederationCredentialMetadataFor(project.UID)
 	}
 	return api.FederationProjectStatus{
-		ProjectID:                   project.ID,
-		ProjectUID:                  project.UID,
-		ProjectName:                 project.Name,
-		Role:                        string(binding.Role),
-		Enabled:                     binding.Enabled,
-		PushEnabled:                 binding.PushEnabled,
-		BoundActor:                  binding.Actor,
-		HubURL:                      binding.HubURL,
-		HubProjectID:                binding.HubProjectID,
-		HubProjectUID:               binding.HubProjectUID,
-		Capabilities:                credentialMetadata.Capabilities,
-		AllowInsecure:               credentialMetadata.AllowInsecure,
+		ProjectID:     project.ID,
+		ProjectUID:    project.UID,
+		ProjectName:   project.Name,
+		Role:          string(binding.Role),
+		Enabled:       binding.Enabled,
+		PushEnabled:   binding.PushEnabled,
+		BoundActor:    binding.Actor,
+		HubURL:        binding.HubURL,
+		HubProjectID:  binding.HubProjectID,
+		HubProjectUID: binding.HubProjectUID,
+		Capabilities:  credentialMetadata.Capabilities,
+		// Opt-ins union: the binding is the durable record (it survives a
+		// credential loss during leave recovery); the credential copy keeps
+		// bindings recorded before allow_insecure was persisted working.
+		AllowInsecure:               binding.AllowInsecure || credentialMetadata.AllowInsecure,
 		CredentialStatus:            credentialMetadata.Status,
 		PullCursorEventID:           binding.PullCursorEventID,
 		PushCursorEventID:           binding.PushCursorEventID,

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -285,8 +285,9 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		// Archive FIRST when requested. RemoveProject's own transaction is the
 		// authoritative open-issue check, so a refused archive never tears down
 		// federation — there is no external-preflight TOCTOU and no
-		// "detached-but-not-archived" partial state. Only a committed archive
-		// proceeds to the detach below.
+		// "detached-but-not-archived" partial state. Only a committed archive —
+		// from this call or a prior partial leave — proceeds to the detach
+		// below.
 		if disposition == "archive" {
 			project, evt, err := cfg.DB.RemoveProject(ctx, db.RemoveProjectParams{
 				ProjectID: in.ProjectID, Actor: actor, Force: in.Body.Force,
@@ -300,15 +301,20 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 					"close the open issues first, or pass force=true",
 					map[string]any{"open_issues": openErr.OpenIssues})
 			case errors.Is(err, db.ErrProjectAlreadyArchived):
-				return nil, api.NewError(http.StatusConflict, "project_already_archived",
-					"project is already archived", "", nil)
+				// Idempotent resume: a prior archive-leave committed the archive
+				// but failed before the detach or credential cleanup below.
+				// Refusing here would strand that state forever, so keep going;
+				// Archived stays false because this call archived nothing, and
+				// the project fill below uses ProjectByID, which includes
+				// archived rows.
 			case err != nil:
 				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			default:
+				cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: project.ID})
+				cfg.Hooks.Enqueue(*evt)
+				body.Project = dbProjectToOut(project)
+				body.Archived = true
 			}
-			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: project.ID})
-			cfg.Hooks.Enqueue(*evt)
-			body.Project = dbProjectToOut(project)
-			body.Archived = true
 		}
 
 		res, err := cfg.DB.LeaveFederationReplica(ctx, in.ProjectID)

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -850,6 +850,14 @@ func federationProjectStatus(ctx context.Context, store db.Storage, binding db.F
 	if binding.Role == db.FederationRoleSpoke {
 		credentialMetadata = config.FederationCredentialMetadataFor(project.UID)
 	}
+	// The credential's allow_insecure is only meaningful for the hub it was
+	// recorded for: a stale credential from an older enrollment (e.g. a
+	// tokenless rejoin that skipped the credential rewrite) must not authorize
+	// plaintext bearer transport to the binding's CURRENT hub. Same URL
+	// normalization as the leave client's catalog matching.
+	credentialAllowInsecure := credentialMetadata.AllowInsecure &&
+		credentialMetadata.HubProjectID == binding.HubProjectID &&
+		strings.TrimRight(credentialMetadata.HubURL, "/") == strings.TrimRight(binding.HubURL, "/")
 	return api.FederationProjectStatus{
 		ProjectID:     project.ID,
 		ProjectUID:    project.UID,
@@ -863,9 +871,9 @@ func federationProjectStatus(ctx context.Context, store db.Storage, binding db.F
 		HubProjectUID: binding.HubProjectUID,
 		Capabilities:  credentialMetadata.Capabilities,
 		// Opt-ins union: the binding is the durable record (it survives a
-		// credential loss during leave recovery); the credential copy keeps
-		// bindings recorded before allow_insecure was persisted working.
-		AllowInsecure:               binding.AllowInsecure || credentialMetadata.AllowInsecure,
+		// credential loss during leave recovery); the same-hub credential copy
+		// keeps bindings recorded before allow_insecure was persisted working.
+		AllowInsecure:               binding.AllowInsecure || credentialAllowInsecure,
 		CredentialStatus:            credentialMetadata.Status,
 		PullCursorEventID:           binding.PullCursorEventID,
 		PushCursorEventID:           binding.PushCursorEventID,

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -281,6 +281,39 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(http.StatusInternalServerError, "internal", bErr.Error(), "", nil)
 		}
 
+		if in.Body.Preflight {
+			// Advisory dry-run: surface what the real call would refuse —
+			// most importantly an archive's open-issue refusal — WITHOUT
+			// mutating anything, so leave clients can verify archive
+			// eligibility before the irreversible hub revoke. Advisory only:
+			// the authoritative check stays inside RemoveProject's
+			// transaction below.
+			project, err := cfg.DB.ProjectByID(ctx, in.ProjectID)
+			switch {
+			case errors.Is(err, db.ErrNotFound):
+				return nil, api.NewError(http.StatusNotFound, "project_not_found", "project not found", "", nil)
+			case err != nil:
+				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			}
+			// Mirror RemoveProject's refusal for a live archive target; an
+			// already-archived project passes (the real call resumes).
+			if disposition == "archive" && project.DeletedAt == nil && !in.Body.Force {
+				openIssues, err := cfg.DB.CountOpenIssues(ctx, in.ProjectID)
+				if err != nil {
+					return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+				}
+				if openIssues > 0 {
+					return nil, api.NewError(http.StatusConflict, "project_has_open_issues", "project has open issues",
+						"close the open issues first, or pass force=true",
+						map[string]any{"open_issues": openIssues})
+				}
+			}
+			return &api.LeaveFederationReplicaResponse{Body: api.LeaveFederationReplicaResultBody{
+				Disposition: disposition,
+				Project:     dbProjectToOut(project),
+			}}, nil
+		}
+
 		body := api.LeaveFederationReplicaResultBody{Disposition: disposition}
 		// Archive FIRST when requested. RemoveProject's own transaction is the
 		// authoritative open-issue check, so a refused archive never tears down

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -56,8 +56,8 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		OperationID: "getFederationStatus",
 		Method:      "GET",
 		Path:        "/api/v1/federation/status",
-	}, func(ctx context.Context, _ *api.FederationStatusRequest) (*api.FederationStatusResponse, error) {
-		body, err := federationStatusBody(ctx, cfg.DB, nil)
+	}, func(ctx context.Context, in *api.FederationStatusRequest) (*api.FederationStatusResponse, error) {
+		body, err := federationStatusBody(ctx, cfg.DB, nil, includeContains(in.Include, "archived"))
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +69,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      "GET",
 		Path:        "/api/v1/projects/{project_id}/federation/status",
 	}, func(ctx context.Context, in *api.ProjectFederationStatusRequest) (*api.FederationStatusResponse, error) {
-		body, err := federationStatusBody(ctx, cfg.DB, &in.ProjectID)
+		body, err := federationStatusBody(ctx, cfg.DB, &in.ProjectID, false)
 		if err != nil {
 			return nil, err
 		}
@@ -763,14 +763,14 @@ func federationEnrollmentToOut(enrollment db.FederationEnrollment, token string)
 	}
 }
 
-func federationStatusBody(ctx context.Context, store db.Storage, projectID *int64) (api.FederationStatusBody, error) {
+func federationStatusBody(ctx context.Context, store db.Storage, projectID *int64, includeArchived bool) (api.FederationStatusBody, error) {
 	bindings, err := federationStatusBindings(ctx, store, projectID)
 	if err != nil {
 		return api.FederationStatusBody{}, err
 	}
 	out := api.FederationStatusBody{Statuses: make([]api.FederationProjectStatus, 0, len(bindings))}
 	for _, binding := range bindings {
-		status, err := federationProjectStatus(ctx, store, binding)
+		status, err := federationProjectStatus(ctx, store, binding, includeArchived)
 		if err != nil {
 			if projectID == nil && isProjectNotFound(err) {
 				continue
@@ -811,9 +811,19 @@ func federationStatusBindings(ctx context.Context, store db.Storage, projectID *
 	return []db.FederationBinding{binding}, nil
 }
 
-func federationProjectStatus(ctx context.Context, store db.Storage, binding db.FederationBinding) (api.FederationProjectStatus, error) {
+func federationProjectStatus(ctx context.Context, store db.Storage, binding db.FederationBinding, includeArchived bool) (api.FederationProjectStatus, error) {
 	project, err := activeProjectByID(ctx, store, binding.ProjectID)
-	if err != nil {
+	if includeArchived && isProjectNotFound(err) {
+		// include=archived: an archived project's binding is still real —
+		// leave needs it to run the bound path (idempotent hub revoke +
+		// teardown) instead of misclassifying the spoke as standalone.
+		project, err = store.ProjectByID(ctx, binding.ProjectID)
+		if errors.Is(err, db.ErrNotFound) {
+			return api.FederationProjectStatus{}, api.NewError(http.StatusNotFound, "project_not_found", "project not found", "", nil)
+		} else if err != nil {
+			return api.FederationProjectStatus{}, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		}
+	} else if err != nil {
 		return api.FederationProjectStatus{}, err
 	}
 	syncStatus, err := store.FederationSyncStatusByProject(ctx, binding.ProjectID)

--- a/internal/daemon/handlers_federation_test.go
+++ b/internal/daemon/handlers_federation_test.go
@@ -2440,10 +2440,11 @@ func TestLeaveFederationReplicaRouteMissingProjectReturns404(t *testing.T) {
 }
 
 // TestLeaveFederationReplicaRouteArchiveAlreadyArchived guards re-running a
-// completed `--delete` leave: the binding-less detach is idempotent, so the
-// route reaches RemoveProject on the already-archived project. That must map
-// to a clean 409 project_already_archived (matching the removeProject
-// handler), not an ugly 500.
+// completed `--delete` leave: the archive step hits ErrProjectAlreadyArchived
+// and the binding-less detach is idempotent. The route must treat that as a
+// successful resume with nothing left to do — archived=false and
+// detached=false (this call did neither) — not refuse with a 409 that would
+// block credential cleanup after a partial failure.
 func TestLeaveFederationReplicaRouteArchiveAlreadyArchived(t *testing.T) {
 	env := testenv.New(t)
 
@@ -2457,15 +2458,89 @@ func TestLeaveFederationReplicaRouteArchiveAlreadyArchived(t *testing.T) {
 		t.Fatalf("want 200 on first archive, got %d body=%s", resp.StatusCode, raw)
 	}
 
-	// Second archive leave on the now-archived (binding-less) project: detach
-	// is idempotent and the archive step hits ErrProjectAlreadyArchived.
+	// Second archive leave on the now-archived (binding-less) project resumes
+	// idempotently and reports that nothing was archived or detached.
 	resp, raw = envDoRaw(t, env, http.MethodPost,
 		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
 		map[string]any{"disposition": "archive", "actor": "wesm"}, nil)
-	if resp.StatusCode != http.StatusConflict {
-		t.Fatalf("want 409 project_already_archived on re-archive, got %d body=%s", resp.StatusCode, raw)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200 resume on re-archive, got %d body=%s", resp.StatusCode, raw)
 	}
-	if !strings.Contains(string(raw), "project_already_archived") {
-		t.Fatalf("want project_already_archived code in body, got %s", raw)
+	var body struct {
+		Archived bool `json:"archived"`
+		Detached bool `json:"detached"`
 	}
+	require.NoError(t, json.Unmarshal(raw, &body))
+	if body.Archived || body.Detached {
+		t.Fatalf("re-archive resume must report archived=false detached=false, body=%s", raw)
+	}
+}
+
+// TestLeaveFederationReplicaRouteArchiveResumeFinishesTeardown covers retrying
+// an archive-leave whose archive committed but whose later steps failed: the
+// retry must not be refused as project_already_archived; it still detaches a
+// surviving binding and deletes the stale credential.
+func TestLeaveFederationReplicaRouteArchiveResumeFinishesTeardown(t *testing.T) {
+	t.Run("binding survived the partial failure", func(t *testing.T) {
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, _ := newSpokeProject(t, env)
+		// Archive directly (RemoveProject has no federation guard), leaving the
+		// binding and credential in place — the state after a leave that
+		// committed the archive and then failed.
+		_, _, err := env.DB.RemoveProject(ctx, db.RemoveProjectParams{
+			ProjectID: project.ID, Actor: "tester",
+		})
+		require.NoError(t, err)
+
+		resp, raw := envDoRaw(t, env, http.MethodPost,
+			fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+			map[string]any{"disposition": "archive", "actor": "tester"}, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("want 200 resume, got %d body=%s", resp.StatusCode, raw)
+		}
+		var body struct {
+			Archived bool `json:"archived"`
+			Detached bool `json:"detached"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &body))
+		if body.Archived {
+			t.Fatalf("resume must not claim this call archived, body=%s", raw)
+		}
+		if !body.Detached {
+			t.Fatalf("resume should detach the surviving binding, body=%s", raw)
+		}
+		if _, err := env.DB.FederationBindingByProject(ctx, project.ID); !errors.Is(err, db.ErrNotFound) {
+			t.Fatalf("binding should be gone after resume: %v", err)
+		}
+		if got := config.FederationCredentialMetadataFor(project.UID).Status; got != "missing" {
+			t.Fatalf("stale credential should be cleaned, got %q", got)
+		}
+	})
+
+	t.Run("only the credential survived the partial failure", func(t *testing.T) {
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "spoke-project")
+		require.NoError(t, err)
+		require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+			HubURL:       "http://127.0.0.1:7373",
+			HubProjectID: 42,
+			Token:        "spoke-token",
+		}))
+		_, _, err = env.DB.RemoveProject(ctx, db.RemoveProjectParams{
+			ProjectID: project.ID, Actor: "tester",
+		})
+		require.NoError(t, err)
+
+		resp, raw := envDoRaw(t, env, http.MethodPost,
+			fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+			map[string]any{"disposition": "archive", "actor": "tester"}, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("want 200 resume, got %d body=%s", resp.StatusCode, raw)
+		}
+		if got := config.FederationCredentialMetadataFor(project.UID).Status; got != "missing" {
+			t.Fatalf("stale credential should be cleaned, got %q", got)
+		}
+	})
 }

--- a/internal/daemon/handlers_federation_test.go
+++ b/internal/daemon/handlers_federation_test.go
@@ -2261,6 +2261,96 @@ func TestLeaveFederationReplicaRouteDetach(t *testing.T) {
 	}
 }
 
+// TestFederationReplicaPersistsAllowInsecureOnBinding: the join body's
+// allow_insecure opt-in must be recorded on the binding itself, not only in
+// the credential file — the binding is what survives a credential loss, and
+// leave needs the opt-in to rebuild the hub revoke transport.
+func TestFederationReplicaPersistsAllowInsecureOnBinding(t *testing.T) {
+	env := testenv.New(t)
+
+	var out api.CreateFederationReplicaBody
+	resp := envDoJSON(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
+		"hub_url":                 "http://hub.internal:7373",
+		"hub_project_id":          42,
+		"hub_project_uid":         "01HZNQ7VFPK1XGD8R5MABCD4EX",
+		"project_name":            "spoke-project",
+		"replay_horizon_event_id": 9,
+		"actor":                   "tester",
+		"token":                   "spoke-token",
+		"allow_insecure":          true,
+	}, &out)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	binding, err := env.DB.FederationBindingByProject(context.Background(), out.Project.ID)
+	require.NoError(t, err)
+	assert.True(t, binding.AllowInsecure, "join must persist allow_insecure on the binding")
+}
+
+// TestFederationStatusAllowInsecureBindingOrCredential: status must report the
+// allow_insecure opt-in when EITHER local record holds it. The binding is the
+// durable source (it survives credential loss during leave recovery); the
+// credential keeps legacy bindings created before the flag was persisted
+// working.
+func TestFederationStatusAllowInsecureBindingOrCredential(t *testing.T) {
+	t.Run("binding opt-in survives a missing credential", func(t *testing.T) {
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "spoke-project")
+		require.NoError(t, err)
+		_, err = env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+			ProjectID:            project.ID,
+			Role:                 db.FederationRoleSpoke,
+			HubURL:               "http://hub.internal:7373",
+			HubProjectID:         42,
+			HubProjectUID:        project.UID,
+			ReplayHorizonEventID: 9,
+			AllowInsecure:        true,
+			Enabled:              true,
+		})
+		require.NoError(t, err)
+		// No credential on disk: the partial-leave recovery state.
+
+		var body api.FederationStatusBody
+		resp := envDoJSON(t, env, http.MethodGet, "/api/v1/federation/status", nil, &body)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Len(t, body.Statuses, 1)
+		assert.Equal(t, "missing", body.Statuses[0].CredentialStatus)
+		assert.True(t, body.Statuses[0].AllowInsecure,
+			"binding allow_insecure must surface in status when the credential is gone")
+	})
+
+	t.Run("legacy credential opt-in still surfaces", func(t *testing.T) {
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "spoke-project")
+		require.NoError(t, err)
+		// Pre-persistence binding: allow_insecure lives only in the credential.
+		_, err = env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+			ProjectID:            project.ID,
+			Role:                 db.FederationRoleSpoke,
+			HubURL:               "http://hub.internal:7373",
+			HubProjectID:         42,
+			HubProjectUID:        project.UID,
+			ReplayHorizonEventID: 9,
+			Enabled:              true,
+		})
+		require.NoError(t, err)
+		require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+			HubURL:        "http://hub.internal:7373",
+			HubProjectID:  42,
+			Token:         "spoke-token",
+			AllowInsecure: true,
+		}))
+
+		var body api.FederationStatusBody
+		resp := envDoJSON(t, env, http.MethodGet, "/api/v1/federation/status", nil, &body)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Len(t, body.Statuses, 1)
+		assert.True(t, body.Statuses[0].AllowInsecure,
+			"credential allow_insecure must still surface for legacy bindings")
+	})
+}
+
 // TestLeaveFederationReplicaRouteResumeCleansStaleCredential covers the
 // idempotent resume: a prior leave deleted the binding but failed before the
 // credential delete. The route must still delete the stale credential and

--- a/internal/daemon/handlers_federation_test.go
+++ b/internal/daemon/handlers_federation_test.go
@@ -2261,6 +2261,41 @@ func TestLeaveFederationReplicaRouteDetach(t *testing.T) {
 	}
 }
 
+// TestLeaveFederationReplicaRouteResumeCleansStaleCredential covers the
+// idempotent resume: a prior leave deleted the binding but failed before the
+// credential delete. The route must still delete the stale credential and
+// report detached=false, since nothing was detached on this call.
+func TestLeaveFederationReplicaRouteResumeCleansStaleCredential(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+
+	project, err := env.DB.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+		HubURL:       "http://127.0.0.1:7373",
+		HubProjectID: 42,
+		Token:        "spoke-token",
+	}))
+
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+		map[string]any{"disposition": "detach", "actor": "tester"}, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+
+	var body struct {
+		Detached bool `json:"detached"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &body))
+	if body.Detached {
+		t.Fatalf("resume leave must report detached=false, body=%s", raw)
+	}
+	if got := config.FederationCredentialMetadataFor(project.UID).Status; got != "missing" {
+		t.Fatalf("stale credential should be cleaned, got %q", got)
+	}
+}
+
 func TestLeaveFederationReplicaRouteArchiveRefusesOpenIssues(t *testing.T) {
 	env := testenv.New(t)
 

--- a/internal/daemon/handlers_federation_test.go
+++ b/internal/daemon/handlers_federation_test.go
@@ -2386,6 +2386,81 @@ func TestFederationStatusAllowInsecureBindingOrCredential(t *testing.T) {
 	})
 }
 
+// TestLeaveFederationReplicaRoutePreflight: preflight=true validates what the
+// real call would refuse — most importantly an archive's open-issue refusal —
+// without mutating anything, so leave clients can check archive eligibility
+// BEFORE the irreversible hub revoke.
+func TestLeaveFederationReplicaRoutePreflight(t *testing.T) {
+	t.Run("archive open-issue refusal mutates nothing", func(t *testing.T) {
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, _ := newSpokeProjectWithOpenIssue(t, env)
+
+		resp, raw := envDoRaw(t, env, http.MethodPost,
+			fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+			map[string]any{"disposition": "archive", "actor": "tester", "preflight": true}, nil)
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("want 409 preflight refusal, got %d body=%s", resp.StatusCode, raw)
+		}
+		if !strings.Contains(string(raw), "project_has_open_issues") {
+			t.Fatalf("want project_has_open_issues, got %s", raw)
+		}
+		if _, err := env.DB.FederationBindingByProject(ctx, project.ID); err != nil {
+			t.Fatalf("binding must be untouched by preflight: %v", err)
+		}
+		alive, err := env.DB.ProjectByName(ctx, project.Name)
+		require.NoError(t, err)
+		require.Nil(t, alive.DeletedAt, "preflight must not archive")
+		if got := config.FederationCredentialMetadataFor(project.UID).Status; got != "present" {
+			t.Fatalf("credential must be untouched by preflight, got %q", got)
+		}
+	})
+
+	t.Run("force passes without mutating", func(t *testing.T) {
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, _ := newSpokeProjectWithOpenIssue(t, env)
+
+		resp, raw := envDoRaw(t, env, http.MethodPost,
+			fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+			map[string]any{"disposition": "archive", "actor": "tester", "preflight": true, "force": true}, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("want 200 forced preflight, got %d body=%s", resp.StatusCode, raw)
+		}
+		var body struct {
+			Archived bool `json:"archived"`
+			Detached bool `json:"detached"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &body))
+		if body.Archived || body.Detached {
+			t.Fatalf("preflight must not claim work happened, body=%s", raw)
+		}
+		if _, err := env.DB.FederationBindingByProject(ctx, project.ID); err != nil {
+			t.Fatalf("binding must be untouched by preflight: %v", err)
+		}
+	})
+
+	t.Run("already-archived target passes for the resume", func(t *testing.T) {
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, _ := newSpokeProject(t, env)
+		_, _, err := env.DB.RemoveProject(ctx, db.RemoveProjectParams{
+			ProjectID: project.ID, Actor: "tester",
+		})
+		require.NoError(t, err)
+
+		resp, raw := envDoRaw(t, env, http.MethodPost,
+			fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+			map[string]any{"disposition": "archive", "actor": "tester", "preflight": true}, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("archived resume preflight should pass, got %d body=%s", resp.StatusCode, raw)
+		}
+		if _, err := env.DB.FederationBindingByProject(ctx, project.ID); err != nil {
+			t.Fatalf("binding must be untouched by preflight: %v", err)
+		}
+	})
+}
+
 // TestFederationStatusIncludeArchived: the status list hides archived
 // projects by default; include=archived surfaces their bindings so the CLI
 // leave can run the bound path (idempotent hub revoke + teardown) for spokes

--- a/internal/daemon/handlers_federation_test.go
+++ b/internal/daemon/handlers_federation_test.go
@@ -2386,6 +2386,31 @@ func TestFederationStatusAllowInsecureBindingOrCredential(t *testing.T) {
 	})
 }
 
+// TestFederationStatusIncludeArchived: the status list hides archived
+// projects by default; include=archived surfaces their bindings so the CLI
+// leave can run the bound path (idempotent hub revoke + teardown) for spokes
+// archived via projects remove or a partial archive-leave.
+func TestFederationStatusIncludeArchived(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+	project, _ := newSpokeProject(t, env)
+	_, _, err := env.DB.RemoveProject(ctx, db.RemoveProjectParams{
+		ProjectID: project.ID, Actor: "tester",
+	})
+	require.NoError(t, err)
+
+	var hidden api.FederationStatusBody
+	resp := envDoJSON(t, env, http.MethodGet, "/api/v1/federation/status", nil, &hidden)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, hidden.Statuses, "archived projects stay hidden by default")
+
+	var shown api.FederationStatusBody
+	resp = envDoJSON(t, env, http.MethodGet, "/api/v1/federation/status?include=archived", nil, &shown)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, shown.Statuses, 1, "include=archived must surface the archived binding")
+	assert.Equal(t, project.ID, shown.Statuses[0].ProjectID)
+}
+
 // TestLeaveFederationReplicaRouteResumeCleansStaleCredential covers the
 // idempotent resume: a prior leave deleted the binding but failed before the
 // credential delete. The route must still delete the stale credential and

--- a/internal/daemon/handlers_federation_test.go
+++ b/internal/daemon/handlers_federation_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -714,12 +715,17 @@ func TestFederationReplicaSetupCanUpgradePhase1BindingToPush(t *testing.T) {
 	assert.Equal(t, localEventID, upgraded.Binding.PushCursorEventID)
 }
 
-func TestFederationReplicaSetupRejectsUnboundProjectCollision(t *testing.T) {
+// TestFederationReplicaSetupRebindsUnboundUIDHolder: an unbound local project
+// already holding the hub project UID under the same name is rebound, not
+// refused. This is the post-leave rejoin state and also the recovery path for
+// a partially-failed join (project created, binding upsert never ran).
+func TestFederationReplicaSetupRebindsUnboundUIDHolder(t *testing.T) {
 	env := testenv.New(t)
 	ctx := context.Background()
-	_, err := env.DB.CreateProjectWithUID(ctx, "hub", "01HZNQ7VFPK1XGD8R5MABCD4EX")
+	holder, err := env.DB.CreateProjectWithUID(ctx, "hub", "01HZNQ7VFPK1XGD8R5MABCD4EX")
 	require.NoError(t, err)
 
+	var out api.CreateFederationReplicaBody
 	resp := envDoJSON(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
 		"hub_url":                 "http://127.0.0.1:7373",
 		"hub_project_id":          42,
@@ -727,9 +733,14 @@ func TestFederationReplicaSetupRejectsUnboundProjectCollision(t *testing.T) {
 		"project_name":            "hub",
 		"replay_horizon_event_id": 9,
 		"actor":                   "wesm",
-	}, nil)
+	}, &out)
 
-	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, holder.ID, out.Project.ID, "must rebind the holder, not create a new project")
+	binding, err := env.DB.FederationBindingByProject(ctx, holder.ID)
+	require.NoError(t, err)
+	assert.False(t, binding.PushEnabled, "pull-only join must not enable push")
+	assert.Equal(t, int64(8), binding.PullCursorEventID)
 }
 
 func TestFederationReplicaSetupValidatesProjectName(t *testing.T) {
@@ -2166,5 +2177,260 @@ func federationIngestBody(events ...any) map[string]any {
 	return map[string]any{
 		"schema_version": db.CurrentSchemaVersion(),
 		"events":         events,
+	}
+}
+
+func newSpokeProject(t *testing.T, env *testenv.Env) (db.Project, db.FederationBinding) {
+	t.Helper()
+	ctx := context.Background()
+	// Use CreateProject so the daemon generates a valid UID; read it back for credential ops.
+	project, err := env.DB.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	binding, err := env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            project.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://127.0.0.1:7373",
+		HubProjectID:         42,
+		HubProjectUID:        project.UID,
+		ReplayHorizonEventID: 9,
+		PullCursorEventID:    8,
+		Actor:                "wesm",
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+		HubURL:       "http://127.0.0.1:7373",
+		HubProjectID: 42,
+		Token:        "spoke-token",
+		Actor:        "wesm",
+	}))
+	return project, binding
+}
+
+func newSpokeProjectWithOpenIssue(t *testing.T, env *testenv.Env) (db.Project, db.FederationBinding) {
+	t.Helper()
+	ctx := context.Background()
+	// Create the issue before the binding so the spoke read-only guard doesn't block it.
+	project, err := env.DB.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "open issue",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	binding, err := env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            project.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://127.0.0.1:7373",
+		HubProjectID:         42,
+		HubProjectUID:        project.UID,
+		ReplayHorizonEventID: 9,
+		PullCursorEventID:    8,
+		Actor:                "wesm",
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+		HubURL:       "http://127.0.0.1:7373",
+		HubProjectID: 42,
+		Token:        "spoke-token",
+		Actor:        "wesm",
+	}))
+	return project, binding
+}
+
+func TestLeaveFederationReplicaRouteDetach(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+
+	project, _ := newSpokeProject(t, env)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+		map[string]any{"disposition": "detach", "actor": "wesm"}, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+
+	if _, err := env.DB.FederationBindingByProject(ctx, project.ID); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("binding should be gone: %v", err)
+	}
+	if got := config.FederationCredentialMetadataFor(project.UID).Status; got != "missing" {
+		t.Fatalf("credential should be cleaned, got %q", got)
+	}
+}
+
+func TestLeaveFederationReplicaRouteArchiveRefusesOpenIssues(t *testing.T) {
+	env := testenv.New(t)
+
+	project, _ := newSpokeProjectWithOpenIssue(t, env)
+
+	// archive without force should 409 due to open issues.
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+		map[string]any{"disposition": "archive", "actor": "wesm"}, nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("want 409 for open issues, got %d body=%s", resp.StatusCode, raw)
+	}
+
+	// archive with force should succeed.
+	resp, raw = envDoRaw(t, env, http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+		map[string]any{"disposition": "archive", "force": true, "actor": "wesm"}, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200 with force, got %d body=%s", resp.StatusCode, raw)
+	}
+}
+
+// TestLeaveFederationReplicaRouteArchiveOpenIssuesDoesNotDetach is the Fix 6
+// preflight guarantee: an archive (no force) on a spoke WITH open issues must
+// 409 BEFORE detaching, leaving the binding AND the stored credential intact so
+// the spoke is not left in a "detached-but-not-archived" partial state.
+func TestLeaveFederationReplicaRouteArchiveOpenIssuesDoesNotDetach(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+
+	project, _ := newSpokeProjectWithOpenIssue(t, env)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+		map[string]any{"disposition": "archive", "actor": "example-actor"}, nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("want 409 for open issues, got %d body=%s", resp.StatusCode, raw)
+	}
+	if !strings.Contains(string(raw), "project_has_open_issues") {
+		t.Fatalf("want project_has_open_issues code, got %s", raw)
+	}
+
+	// The binding must still be present (no detach happened).
+	if _, err := env.DB.FederationBindingByProject(ctx, project.ID); err != nil {
+		t.Fatalf("binding should still be present after refused archive: %v", err)
+	}
+	// The stored credential must still be present (not cleaned).
+	if got := config.FederationCredentialMetadataFor(project.UID).Status; got == "missing" {
+		t.Fatalf("credential should still be present after refused archive, got %q", got)
+	}
+}
+
+// TestCreateFederationReplicaRejoinsAfterLeave is the round-trip contract:
+// enroll -> leave -> enroll must work. After leave, the local project still
+// carries the hub project UID with no binding; a fresh join for that hub
+// project must rebind it (rejoin), not refuse it as a collision.
+func TestCreateFederationReplicaRejoinsAfterLeave(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+
+	project, binding := newSpokeProject(t, env)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+		map[string]any{"disposition": "detach", "actor": "wesm"}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "leave: %s", raw)
+
+	var out api.CreateFederationReplicaBody
+	jresp := envDoJSON(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
+		"hub_url":                 binding.HubURL,
+		"hub_project_id":          binding.HubProjectID,
+		"hub_project_uid":         binding.HubProjectUID,
+		"project_name":            project.Name,
+		"replay_horizon_event_id": 9,
+		"actor":                   "wesm",
+		"token":                   "rejoin-token",
+		"capabilities":            "pull,push",
+		"push_enabled":            true,
+	}, &out)
+	require.Equal(t, http.StatusOK, jresp.StatusCode, "rejoin must succeed after leave")
+
+	assert.Equal(t, project.ID, out.Project.ID,
+		"rejoin must bind the existing UID-holder, not create a new project")
+	rebound, err := env.DB.FederationBindingByProject(ctx, project.ID)
+	require.NoError(t, err)
+	assert.True(t, rebound.PushEnabled)
+	assert.Equal(t, int64(0), rebound.PushCursorEventID,
+		"rejoin must re-offer local-origin events from 0 so the hub dedups what it has and absorbs standalone-era edits")
+	assert.Equal(t, int64(8), rebound.PullCursorEventID,
+		"rejoin restarts pull just below the replay horizon")
+	assert.Equal(t, "present", config.FederationCredentialMetadataFor(project.UID).Status)
+}
+
+// TestCreateFederationReplicaRejoinNameMismatchIsActionable: when the hub
+// project UID is held by a local project under a different name (the holder
+// previously left), a join for another name must refuse with an error that
+// names the holder and explains how to rejoin, and must not bind anything.
+func TestCreateFederationReplicaRejoinNameMismatchIsActionable(t *testing.T) {
+	env := testenv.New(t)
+	ctx := context.Background()
+
+	project, binding := newSpokeProject(t, env)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+		map[string]any{"disposition": "detach", "actor": "wesm"}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "leave: %s", raw)
+
+	resp, raw = envDoRaw(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
+		"hub_url":                 binding.HubURL,
+		"hub_project_id":          binding.HubProjectID,
+		"hub_project_uid":         binding.HubProjectUID,
+		"project_name":            "hub-project",
+		"replay_horizon_event_id": 9,
+		"actor":                   "wesm",
+		"token":                   "rejoin-token",
+	}, nil)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	assert.Contains(t, string(raw), "spoke-project", "error must name the local UID-holder")
+	assert.Contains(t, string(raw), "previously left", "error must explain this is a rejoin situation")
+	assert.Contains(t, string(raw), "--project", "error must carry the recovery command hint")
+	if _, err := env.DB.FederationBindingByProject(ctx, project.ID); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("name-mismatch rejoin must not bind anything: %v", err)
+	}
+}
+
+// TestLeaveFederationReplicaRouteMissingProjectReturns404 confirms the leave
+// route maps a missing project to 404 project_not_found (the storage layer now
+// surfaces db.ErrNotFound from the UID lookup) rather than a 500.
+func TestLeaveFederationReplicaRouteMissingProjectReturns404(t *testing.T) {
+	env := testenv.New(t)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		"/api/v1/federation/replicas/999999/actions/leave",
+		map[string]any{"disposition": "detach", "actor": "example-actor"}, nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404 for missing project, got %d body=%s", resp.StatusCode, raw)
+	}
+	if !strings.Contains(string(raw), "project_not_found") {
+		t.Fatalf("want project_not_found code in body, got %s", raw)
+	}
+}
+
+// TestLeaveFederationReplicaRouteArchiveAlreadyArchived guards re-running a
+// completed `--delete` leave: the binding-less detach is idempotent, so the
+// route reaches RemoveProject on the already-archived project. That must map
+// to a clean 409 project_already_archived (matching the removeProject
+// handler), not an ugly 500.
+func TestLeaveFederationReplicaRouteArchiveAlreadyArchived(t *testing.T) {
+	env := testenv.New(t)
+
+	project, _ := newSpokeProject(t, env)
+
+	// First archive leave: detach + archive succeed (no open issues).
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+		map[string]any{"disposition": "archive", "actor": "wesm"}, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200 on first archive, got %d body=%s", resp.StatusCode, raw)
+	}
+
+	// Second archive leave on the now-archived (binding-less) project: detach
+	// is idempotent and the archive step hits ErrProjectAlreadyArchived.
+	resp, raw = envDoRaw(t, env, http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", project.ID),
+		map[string]any{"disposition": "archive", "actor": "wesm"}, nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("want 409 project_already_archived on re-archive, got %d body=%s", resp.StatusCode, raw)
+	}
+	if !strings.Contains(string(raw), "project_already_archived") {
+		t.Fatalf("want project_already_archived code in body, got %s", raw)
 	}
 }

--- a/internal/daemon/handlers_federation_test.go
+++ b/internal/daemon/handlers_federation_test.go
@@ -2335,8 +2335,10 @@ func TestFederationStatusAllowInsecureBindingOrCredential(t *testing.T) {
 			Enabled:              true,
 		})
 		require.NoError(t, err)
+		// Trailing slash: the same-hub check must use the leave client's URL
+		// normalization, not exact string equality.
 		require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
-			HubURL:        "http://hub.internal:7373",
+			HubURL:        "http://hub.internal:7373/",
 			HubProjectID:  42,
 			Token:         "spoke-token",
 			AllowInsecure: true,
@@ -2348,6 +2350,39 @@ func TestFederationStatusAllowInsecureBindingOrCredential(t *testing.T) {
 		require.Len(t, body.Statuses, 1)
 		assert.True(t, body.Statuses[0].AllowInsecure,
 			"credential allow_insecure must still surface for legacy bindings")
+	})
+
+	t.Run("stale credential for a different hub does not leak its opt-in", func(t *testing.T) {
+		env := testenv.New(t)
+		ctx := context.Background()
+		project, err := env.DB.CreateProject(ctx, "spoke-project")
+		require.NoError(t, err)
+		// Binding points at hub B with no transport opt-in...
+		_, err = env.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+			ProjectID:            project.ID,
+			Role:                 db.FederationRoleSpoke,
+			HubURL:               "http://hub-b.internal:7373",
+			HubProjectID:         43,
+			HubProjectUID:        project.UID,
+			ReplayHorizonEventID: 9,
+			Enabled:              true,
+		})
+		require.NoError(t, err)
+		// ...while a stale credential from an older hub A enrollment (e.g. a
+		// tokenless rejoin skipped the credential rewrite) still carries one.
+		require.NoError(t, config.WriteFederationCredential(project.UID, config.FederationCredential{
+			HubURL:        "http://hub-a.internal:7373",
+			HubProjectID:  42,
+			Token:         "stale-token",
+			AllowInsecure: true,
+		}))
+
+		var body api.FederationStatusBody
+		resp := envDoJSON(t, env, http.MethodGet, "/api/v1/federation/status", nil, &body)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Len(t, body.Statuses, 1)
+		assert.False(t, body.Statuses[0].AllowInsecure,
+			"a different hub's credential opt-in must not authorize plaintext bearer to this binding's hub")
 	})
 }
 

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -172,6 +172,10 @@ var (
 	// ErrFederationIngestValidation is returned by IngestFederationEvents when a
 	// batch fails validation.
 	ErrFederationIngestValidation = errors.New("federation ingest validation")
+
+	// ErrFederationNotSpoke is returned when a leave is attempted on a project
+	// whose binding is not a spoke (e.g. a hub).
+	ErrFederationNotSpoke = errors.New("federation binding is not a spoke")
 )
 
 // LinkTargetNotFoundError carries the offending project-scoped number

--- a/internal/db/export_types.go
+++ b/internal/db/export_types.go
@@ -131,6 +131,7 @@ type FederationBindingExport struct {
 	PushEnabled          bool    `json:"push_enabled"`
 	PushCursorEventID    int64   `json:"push_cursor_event_id"`
 	Actor                string  `json:"bound_actor,omitempty"`
+	AllowInsecure        bool    `json:"allow_insecure,omitempty"`
 	Enabled              bool    `json:"enabled"`
 	CreatedAt            string  `json:"created_at"`
 	UpdatedAt            string  `json:"updated_at"`

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -518,6 +518,14 @@ type AdoptProjectIntoFederationResult struct {
 	AdoptionSnapshotCount int64
 }
 
+// LeaveFederationResult reports what LeaveFederationReplica removed. ProjectUID
+// lets the daemon route run credential cleanup after the DB transaction.
+type LeaveFederationResult struct {
+	ProjectID  int64
+	ProjectUID string
+	Role       FederationRole
+}
+
 // FederationIngestEvent carries one spoke event plus the spoke-local event row
 // id used only for push cursor acknowledgement.
 type FederationIngestEvent struct {

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -508,6 +508,7 @@ type AdoptProjectIntoFederationParams struct {
 	HubProjectUID        string
 	ReplayHorizonEventID int64
 	Actor                string
+	AllowInsecure        bool
 }
 
 // AdoptProjectIntoFederationResult describes the adopted project, binding, and

--- a/internal/db/pgstore/stubs_gen.go
+++ b/internal/db/pgstore/stubs_gen.go
@@ -158,6 +158,10 @@ func (s *Store) CountLiveClaims(_ context.Context, _ int64) (int64, error) {
 	return 0, ErrNotImplementedPhase3
 }
 
+func (s *Store) CountOpenIssues(_ context.Context, _ int64) (int64, error) {
+	return 0, ErrNotImplementedPhase3
+}
+
 func (s *Store) CountPendingClaims(_ context.Context, _ int64) (int64, error) {
 	return 0, ErrNotImplementedPhase3
 }
@@ -456,6 +460,10 @@ func (s *Store) LabelsForIssue(_ context.Context, _ int64) ([]string, error) {
 
 func (s *Store) LatestAliasForProject(_ context.Context, _ int64) (db.AliasRow, bool, error) {
 	return db.AliasRow{}, false, ErrNotImplementedPhase3
+}
+
+func (s *Store) LeaveFederationReplica(_ context.Context, _ int64) (db.LeaveFederationResult, error) {
+	return db.LeaveFederationResult{}, ErrNotImplementedPhase3
 }
 
 func (s *Store) LinkByEndpoints(_ context.Context, _ int64, _ int64, _ string) (db.Link, error) {

--- a/internal/db/schema_version.go
+++ b/internal/db/schema_version.go
@@ -5,7 +5,7 @@ package db
 // compare on-disk state against this number when opening existing ones; a
 // mismatch surfaces either ErrSchemaCutoverRequired (for older sources, so
 // storeopen can drive a JSONL cutover) or a newer-than-binary error.
-const currentSchemaVersion = 14
+const currentSchemaVersion = 15
 
 // CurrentSchemaVersion returns the schema version expected by this binary.
 // Backends and the cutover path read this to align freshly created databases

--- a/internal/db/sqlitestore/export.go
+++ b/internal/db/sqlitestore/export.go
@@ -328,7 +328,7 @@ func (d *Store) ExportImportMappings(ctx context.Context, f db.ExportFilter) ite
 func (d *Store) ExportFederationBindings(ctx context.Context, f db.ExportFilter) iter.Seq2[db.FederationBindingExport, error] {
 	query := `SELECT project_id, role, hub_url, hub_project_id, hub_project_uid,
 	                 replay_horizon_event_id, pull_cursor_event_id, push_enabled,
-	                 push_cursor_event_id, bound_actor, enabled,
+	                 push_cursor_event_id, bound_actor, allow_insecure, enabled,
 	                 CAST(created_at AS TEXT), CAST(updated_at AS TEXT),
 	                 CAST(last_sync_at AS TEXT)
 	          FROM federation_bindings`
@@ -337,14 +337,15 @@ func (d *Store) ExportFederationBindings(ctx context.Context, f db.ExportFilter)
 	return streamRows(ctx, d.readQ, "federation_bindings", query, args,
 		func(rows *sql.Rows) (db.FederationBindingExport, error) {
 			var rec db.FederationBindingExport
-			var enabled, pushEnabled int
+			var enabled, pushEnabled, allowInsecure int
 			if err := rows.Scan(&rec.ProjectID, &rec.Role, &rec.HubURL, &rec.HubProjectID,
 				&rec.HubProjectUID, &rec.ReplayHorizonEventID, &rec.PullCursorEventID,
-				&pushEnabled, &rec.PushCursorEventID, &rec.Actor, &enabled, &rec.CreatedAt,
-				&rec.UpdatedAt, &rec.LastSyncAt); err != nil {
+				&pushEnabled, &rec.PushCursorEventID, &rec.Actor, &allowInsecure, &enabled,
+				&rec.CreatedAt, &rec.UpdatedAt, &rec.LastSyncAt); err != nil {
 				return db.FederationBindingExport{}, scanError("federation_binding", err)
 			}
 			rec.PushEnabled = pushEnabled == 1
+			rec.AllowInsecure = allowInsecure == 1
 			rec.Enabled = enabled == 1
 			return rec, nil
 		})

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -332,13 +332,17 @@ func (d *Store) upsertFederationBinding(ctx context.Context, b db.FederationBind
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	allowInsecure := 0
+	if b.AllowInsecure {
+		allowInsecure = 1
+	}
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO federation_bindings(
 			project_id, role, hub_url, hub_project_id, hub_project_uid,
 			replay_horizon_event_id, pull_cursor_event_id, push_enabled,
-			push_cursor_event_id, bound_actor, enabled
+			push_cursor_event_id, bound_actor, allow_insecure, enabled
 		)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(project_id) DO UPDATE SET
 			role = excluded.role,
 			hub_url = excluded.hub_url,
@@ -349,11 +353,12 @@ func (d *Store) upsertFederationBinding(ctx context.Context, b db.FederationBind
 			push_enabled = excluded.push_enabled,
 			push_cursor_event_id = excluded.push_cursor_event_id,
 			bound_actor = excluded.bound_actor,
+			allow_insecure = excluded.allow_insecure,
 			enabled = excluded.enabled,
 			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')`,
 		b.ProjectID, string(b.Role), b.HubURL, b.HubProjectID, b.HubProjectUID,
 		b.ReplayHorizonEventID, b.PullCursorEventID, pushEnabled, b.PushCursorEventID,
-		actor, enabled)
+		actor, allowInsecure, enabled)
 	if err != nil {
 		return db.FederationBinding{}, fmt.Errorf("upsert federation binding: %w", err)
 	}
@@ -939,7 +944,7 @@ func ensureFederatedMoveAllowedTx(ctx context.Context, q sqlReader, projectIDs .
 
 const federationBindingSelect = `SELECT project_id, role, hub_url, hub_project_id, hub_project_uid,
        replay_horizon_event_id, pull_cursor_event_id, push_enabled, push_cursor_event_id,
-       bound_actor, enabled, created_at, updated_at, last_sync_at
+       bound_actor, allow_insecure, enabled, created_at, updated_at, last_sync_at
   FROM federation_bindings`
 
 func federationBindingByProject(ctx context.Context, q sqlReader, projectID int64) (db.FederationBinding, error) {
@@ -949,18 +954,20 @@ func federationBindingByProject(ctx context.Context, q sqlReader, projectID int6
 
 func scanFederationBinding(r rowScanner) (db.FederationBinding, error) {
 	var (
-		b           db.FederationBinding
-		role        string
-		enabled     int
-		pushEnabled int
-		lastSyncAt  sql.NullTime
+		b             db.FederationBinding
+		role          string
+		enabled       int
+		pushEnabled   int
+		allowInsecure int
+		lastSyncAt    sql.NullTime
 	)
 	err := r.Scan(&b.ProjectID, &role, &b.HubURL, &b.HubProjectID, &b.HubProjectUID,
 		&b.ReplayHorizonEventID, &b.PullCursorEventID, &pushEnabled,
-		&b.PushCursorEventID, &b.Actor, &enabled, &b.CreatedAt, &b.UpdatedAt, &lastSyncAt)
+		&b.PushCursorEventID, &b.Actor, &allowInsecure, &enabled, &b.CreatedAt, &b.UpdatedAt, &lastSyncAt)
 	if err == nil {
 		b.Role = db.FederationRole(role)
 		b.PushEnabled = pushEnabled == 1
+		b.AllowInsecure = allowInsecure == 1
 		b.Enabled = enabled == 1
 		if lastSyncAt.Valid {
 			b.LastSyncAt = &lastSyncAt.Time
@@ -1886,15 +1893,19 @@ func (d *Store) adoptProjectIntoFederation(
 	if pullCursor < 0 {
 		pullCursor = 0
 	}
+	allowInsecure := 0
+	if p.AllowInsecure {
+		allowInsecure = 1
+	}
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO federation_bindings(
 			project_id, role, hub_url, hub_project_id, hub_project_uid,
 			replay_horizon_event_id, pull_cursor_event_id, push_enabled,
-			push_cursor_event_id, bound_actor, enabled
+			push_cursor_event_id, bound_actor, allow_insecure, enabled
 		)
-		VALUES(?, ?, ?, ?, ?, ?, ?, 1, ?, ?, 1)`,
+		VALUES(?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 1)`,
 		project.ID, string(db.FederationRoleSpoke), p.HubURL, p.HubProjectID, p.HubProjectUID,
-		p.ReplayHorizonEventID, pullCursor, pushFloor, actor); err != nil {
+		p.ReplayHorizonEventID, pullCursor, pushFloor, actor, allowInsecure); err != nil {
 		return db.AdoptProjectIntoFederationResult{}, fmt.Errorf("insert adoption federation binding: %w", err)
 	}
 

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -118,7 +118,11 @@ func (d *Store) ClearFederationSyncError(ctx context.Context, projectID int64) e
 
 // RecordFederationQuarantine creates or returns the active quarantine for one
 // project/direction. A second failure while a quarantine is active preserves
-// the original poisoned batch so status and skip stay stable.
+// the original poisoned batch so status and skip stay stable. Like the
+// sync-status writers, it no-ops (zero quarantine, nil error) when the
+// project has no federation binding: an in-flight sync pass that loaded the
+// binding before a leave must not recreate quarantine state for a standalone
+// or archived project.
 func (d *Store) RecordFederationQuarantine(
 	ctx context.Context,
 	p db.RecordFederationQuarantineParams,
@@ -149,14 +153,24 @@ func (d *Store) recordFederationQuarantine(
 		INSERT INTO federation_quarantine(
 			project_id, direction, first_event_id, last_event_id, event_uids, error, created_at
 		)
-		VALUES(?, ?, ?, ?, ?, ?, ?)
+		SELECT ?, ?, ?, ?, ?, ?, ?
+		WHERE EXISTS (SELECT 1 FROM federation_bindings WHERE project_id = ?)
 		ON CONFLICT(project_id, direction) WHERE skipped_at IS NULL DO NOTHING`,
 		p.ProjectID, string(p.Direction), p.FirstEventID, p.LastEventID, string(eventUIDs),
-		p.Error, p.CreatedAt.UTC().Format(sqliteTimeFormat))
+		p.Error, p.CreatedAt.UTC().Format(sqliteTimeFormat), p.ProjectID)
 	if err != nil {
 		return db.FederationQuarantine{}, fmt.Errorf("record federation quarantine: %w", err)
 	}
 	quarantine, err := activeFederationQuarantine(ctx, tx, p.ProjectID, p.Direction)
+	if errors.Is(err, db.ErrNotFound) {
+		// The guarded insert no-opped: no binding row, so leave already tore
+		// this project down (or it was never federated). Surface the no-op,
+		// not an error — the in-flight pass has nothing left to quarantine.
+		if commitErr := tx.Commit(); commitErr != nil {
+			return db.FederationQuarantine{}, commitErr
+		}
+		return db.FederationQuarantine{}, nil
+	}
 	if err != nil {
 		return db.FederationQuarantine{}, err
 	}

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -85,11 +85,12 @@ func (d *Store) RecordFederationSyncError(ctx context.Context, projectID int64, 
 	return d.RetryTransient(ctx, func() error {
 		_, err := d.ExecContext(ctx, `
 			INSERT INTO federation_sync_status(project_id, last_error_at, last_error)
-			VALUES(?, ?, ?)
+			SELECT ?, ?, ?
+			WHERE EXISTS (SELECT 1 FROM federation_bindings WHERE project_id = ?)
 			ON CONFLICT(project_id) DO UPDATE SET
 				last_error_at = excluded.last_error_at,
 				last_error = excluded.last_error`,
-			projectID, at.UTC().Format(sqliteTimeFormat), msg)
+			projectID, at.UTC().Format(sqliteTimeFormat), msg, projectID)
 		if err != nil {
 			return fmt.Errorf("record federation sync error: %w", err)
 		}
@@ -103,10 +104,11 @@ func (d *Store) ClearFederationSyncError(ctx context.Context, projectID int64) e
 	return d.RetryTransient(ctx, func() error {
 		_, err := d.ExecContext(ctx, `
 			INSERT INTO federation_sync_status(project_id, last_error_at, last_error)
-			VALUES(?, NULL, NULL)
+			SELECT ?, NULL, NULL
+			WHERE EXISTS (SELECT 1 FROM federation_bindings WHERE project_id = ?)
 			ON CONFLICT(project_id) DO UPDATE SET
 				last_error_at = NULL,
-				last_error = NULL`, projectID)
+				last_error = NULL`, projectID, projectID)
 		if err != nil {
 			return fmt.Errorf("clear federation sync error: %w", err)
 		}
@@ -292,10 +294,11 @@ func (d *Store) upsertFederationSyncTime(ctx context.Context, projectID int64, c
 	return d.RetryTransient(ctx, func() error {
 		_, err := d.ExecContext(ctx, fmt.Sprintf(`
 			INSERT INTO federation_sync_status(project_id, %s)
-			VALUES(?, ?)
+			SELECT ?, ?
+			WHERE EXISTS (SELECT 1 FROM federation_bindings WHERE project_id = ?)
 			ON CONFLICT(project_id) DO UPDATE SET
 				%s = excluded.%s`, column, column, column),
-			projectID, at.UTC().Format(sqliteTimeFormat))
+			projectID, at.UTC().Format(sqliteTimeFormat), projectID)
 		if err != nil {
 			return fmt.Errorf("record federation sync %s: %w", column, err)
 		}
@@ -362,6 +365,61 @@ func (d *Store) upsertFederationBinding(ctx context.Context, b db.FederationBind
 		return db.FederationBinding{}, err
 	}
 	return binding, nil
+}
+
+// LeaveFederationReplica detaches a spoke project: it deletes the binding,
+// sync-status, and quarantine rows and clears claim projection state in one
+// transaction, returning the project UID for credential cleanup. It is
+// idempotent: a project with no binding returns a zero-role result and no
+// error. A hub binding returns db.ErrFederationNotSpoke.
+func (d *Store) LeaveFederationReplica(ctx context.Context, projectID int64) (db.LeaveFederationResult, error) {
+	return retryWrite1(ctx, d, func() (db.LeaveFederationResult, error) {
+		return d.leaveFederationReplica(ctx, projectID)
+	})
+}
+
+func (d *Store) leaveFederationReplica(ctx context.Context, projectID int64) (db.LeaveFederationResult, error) {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return db.LeaveFederationResult{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	uid, err := projectUIDTx(ctx, tx, projectID)
+	if err != nil {
+		return db.LeaveFederationResult{}, err
+	}
+
+	binding, err := federationBindingByProject(ctx, tx, projectID)
+	switch {
+	case errors.Is(err, db.ErrNotFound):
+		if err := tx.Commit(); err != nil {
+			return db.LeaveFederationResult{}, err
+		}
+		return db.LeaveFederationResult{ProjectID: projectID, ProjectUID: uid}, nil
+	case err != nil:
+		return db.LeaveFederationResult{}, err
+	}
+	if binding.Role != db.FederationRoleSpoke {
+		return db.LeaveFederationResult{}, db.ErrFederationNotSpoke
+	}
+
+	for _, stmt := range []string{
+		`DELETE FROM federation_quarantine WHERE project_id = ?`,
+		`DELETE FROM federation_sync_status WHERE project_id = ?`,
+		`DELETE FROM federation_bindings WHERE project_id = ?`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt, projectID); err != nil {
+			return db.LeaveFederationResult{}, fmt.Errorf("leave federation replica: %w", err)
+		}
+	}
+	if err := clearProjectClaimStateTx(ctx, tx, projectID); err != nil {
+		return db.LeaveFederationResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return db.LeaveFederationResult{}, err
+	}
+	return db.LeaveFederationResult{ProjectID: projectID, ProjectUID: uid, Role: db.FederationRoleSpoke}, nil
 }
 
 func (d *Store) boundFederationActorTx(ctx context.Context, tx *sql.Tx, projectID int64) (string, bool, error) {
@@ -1220,8 +1278,14 @@ func federationFoldEvents(ctx context.Context, tx *sql.Tx, projectID int64) ([]d
 
 func projectUIDTx(ctx context.Context, tx *sql.Tx, projectID int64) (string, error) {
 	var uid string
-	if err := tx.QueryRowContext(ctx,
-		`SELECT uid FROM projects WHERE id = ?`, projectID).Scan(&uid); err != nil {
+	err := tx.QueryRowContext(ctx,
+		`SELECT uid FROM projects WHERE id = ?`, projectID).Scan(&uid)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Surface the domain not-found sentinel so callers (e.g. the daemon
+		// leave route) can map a missing project to 404 via errors.Is.
+		return "", db.ErrNotFound
+	}
+	if err != nil {
 		return "", fmt.Errorf("lookup project uid: %w", err)
 	}
 	return uid, nil

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -130,6 +130,7 @@ func TestFederationBindingUpsertRoundTrip(t *testing.T) {
 
 func TestFederationSyncStatusRecordsOperationalState(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
+	upsertTestSpokeFederationBinding(ctx, t, d, p, true)
 	pullStarted := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	pullSuccess := pullStarted.Add(2 * time.Second)
 	pushStarted := pullSuccess.Add(3 * time.Second)
@@ -159,6 +160,7 @@ func TestFederationSyncStatusRecordsOperationalState(t *testing.T) {
 
 func TestFederationSyncStatusSuccessDoesNotClearPriorError(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
+	upsertTestSpokeFederationBinding(ctx, t, d, p, true)
 	errorAt := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	successAt := errorAt.Add(time.Minute)
 
@@ -175,6 +177,7 @@ func TestFederationSyncStatusSuccessDoesNotClearPriorError(t *testing.T) {
 
 func TestFederationSyncStatusClearErrorExplicitly(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
+	upsertTestSpokeFederationBinding(ctx, t, d, p, true)
 	errorAt := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 
 	require.NoError(t, d.RecordFederationSyncError(ctx, p.ID, errors.New("hub offline"), errorAt))
@@ -3167,4 +3170,121 @@ func TestCountActiveFederationEnrollments(t *testing.T) {
 	got, err = d.CountActiveFederationEnrollments(ctx, p.ID)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), got, "active project + active global counted; revoked excluded")
+}
+
+// newTestSpokeProject creates a project with a spoke federation binding and a
+// sync status row, returning the projectID and projectUID.
+func newTestSpokeProject(t *testing.T, d *sqlitestore.Store) (int64, string) {
+	t.Helper()
+	ctx := context.Background()
+	p := createProject(ctx, t, d, "spoke-project")
+	_, err := d.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            p.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://hub.example:7373",
+		HubProjectID:         42,
+		HubProjectUID:        newTestUID(t),
+		ReplayHorizonEventID: 1,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, d.RecordFederationSyncPullStarted(ctx, p.ID, time.Now().UTC()))
+	return p.ID, p.UID
+}
+
+// newTestStandaloneProject creates a plain project with no federation binding.
+func newTestStandaloneProject(t *testing.T, d *sqlitestore.Store) int64 {
+	t.Helper()
+	ctx := context.Background()
+	p := createProject(ctx, t, d, "standalone-project")
+	return p.ID
+}
+
+// newTestHubProject creates a project with a hub federation binding.
+func newTestHubProject(t *testing.T, d *sqlitestore.Store) int64 {
+	t.Helper()
+	ctx := context.Background()
+	p := createProject(ctx, t, d, "hub-project")
+	_, err := d.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:     p.ID,
+		Role:          db.FederationRoleHub,
+		HubProjectUID: p.UID,
+		Enabled:       true,
+	})
+	require.NoError(t, err)
+	return p.ID
+}
+
+func TestLeaveFederationReplicaDetachesSpoke(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	projectID, projectUID := newTestSpokeProject(t, d)
+
+	res, err := d.LeaveFederationReplica(ctx, projectID)
+	if err != nil {
+		t.Fatalf("leave: %v", err)
+	}
+	if res.ProjectUID != projectUID || res.Role != db.FederationRoleSpoke {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if _, err := d.FederationBindingByProject(ctx, projectID); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("binding should be gone, got %v", err)
+	}
+	if _, err := d.ProjectByID(ctx, projectID); err != nil {
+		t.Fatalf("project should survive detach: %v", err)
+	}
+}
+
+func TestLeaveFederationReplicaIdempotentWhenStandalone(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	projectID := newTestStandaloneProject(t, d)
+	res, err := d.LeaveFederationReplica(ctx, projectID)
+	if err != nil {
+		t.Fatalf("leave on standalone should be nil error, got %v", err)
+	}
+	if res.ProjectID != projectID || res.Role != "" {
+		t.Fatalf("standalone leave should report empty role, got %+v", res)
+	}
+}
+
+func TestLeaveFederationReplicaRejectsHub(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	projectID := newTestHubProject(t, d)
+	if _, err := d.LeaveFederationReplica(ctx, projectID); !errors.Is(err, db.ErrFederationNotSpoke) {
+		t.Fatalf("want ErrFederationNotSpoke, got %v", err)
+	}
+}
+
+// TestLeaveFederationReplicaMissingProjectIsNotFound guards the daemon route's
+// 404 mapping: a missing project must surface db.ErrNotFound, not a wrapped
+// sql.ErrNoRows (which would slip past errors.Is and yield a 500).
+func TestLeaveFederationReplicaMissingProjectIsNotFound(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	if _, err := d.LeaveFederationReplica(ctx, 999999); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("want db.ErrNotFound for missing project, got %v", err)
+	}
+}
+
+func TestSyncStatusWritersNoOpWithoutBinding(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	projectID := newTestStandaloneProject(t, d)
+
+	if err := d.RecordFederationSyncPullSuccess(ctx, projectID, time.Now().UTC()); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if err := d.RecordFederationSyncError(ctx, projectID, errors.New("x"), time.Now().UTC()); err != nil {
+		t.Fatalf("record err: %v", err)
+	}
+	var n int
+	if err := d.QueryRowContext(ctx,
+		`SELECT count(*) FROM federation_sync_status WHERE project_id = ?`, projectID).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("expected no sync_status row without a binding, got %d", n)
+	}
 }

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -192,6 +192,8 @@ func TestFederationSyncStatusClearErrorExplicitly(t *testing.T) {
 
 func TestFederationQuarantineRecordAndActiveRoundTrip(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
+	// Quarantine recording is binding-guarded (leave race); seed the binding.
+	upsertTestSpokeFederationBinding(ctx, t, d, p, true)
 	createdAt := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	params := db.RecordFederationQuarantineParams{
 		ProjectID:    p.ID,
@@ -223,6 +225,8 @@ func TestFederationQuarantineRecordAndActiveRoundTrip(t *testing.T) {
 
 func TestFederationQuarantineRecordIsIdempotentPerProjectDirection(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
+	// Quarantine recording is binding-guarded (leave race); seed the binding.
+	upsertTestSpokeFederationBinding(ctx, t, d, p, true)
 	first, err := d.RecordFederationQuarantine(ctx, db.RecordFederationQuarantineParams{
 		ProjectID:    p.ID,
 		Direction:    db.FederationQuarantineDirectionPush,
@@ -3267,6 +3271,48 @@ func TestLeaveFederationReplicaMissingProjectIsNotFound(t *testing.T) {
 	if _, err := d.LeaveFederationReplica(ctx, 999999); !errors.Is(err, db.ErrNotFound) {
 		t.Fatalf("want db.ErrNotFound for missing project, got %v", err)
 	}
+}
+
+// TestQuarantineRecordingNoOpsWithoutBinding: an in-flight push sync that
+// loaded the binding before a leave can receive the hub's poison response
+// after the leave committed. Recording must no-op like the sync-status
+// writers so the race cannot recreate active quarantine state for a
+// standalone (or archived) project and block a later rejoin.
+func TestQuarantineRecordingNoOpsWithoutBinding(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	p := createProject(ctx, t, d, "spoke-project")
+	_, err := d.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            p.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://127.0.0.1:7373",
+		HubProjectID:         42,
+		HubProjectUID:        p.UID,
+		ReplayHorizonEventID: 1,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+
+	// Leave deletes the binding and quarantine rows; the poisoned push
+	// response lands afterwards.
+	_, err = d.LeaveFederationReplica(ctx, p.ID)
+	require.NoError(t, err)
+
+	got, err := d.RecordFederationQuarantine(ctx, db.RecordFederationQuarantineParams{
+		ProjectID:    p.ID,
+		Direction:    db.FederationQuarantineDirectionPush,
+		FirstEventID: 7,
+		LastEventID:  9,
+		EventUIDs:    []string{"evt-7"},
+		Error:        "hub rejected batch",
+		CreatedAt:    time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err, "post-leave quarantine recording must no-op, not error")
+	assert.Zero(t, got.ID, "no quarantine row should be created without a binding")
+
+	active, err := d.ActiveFederationQuarantinesByProject(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Empty(t, active, "leave racing a poisoned push must not recreate quarantine state")
 }
 
 func TestSyncStatusWritersNoOpWithoutBinding(t *testing.T) {

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -20,7 +20,7 @@ import (
 func TestFederationSchemaVersionAndTable(t *testing.T) {
 	d := openTestDB(t)
 
-	assert.Equal(t, 14, db.CurrentSchemaVersion())
+	assert.Equal(t, 15, db.CurrentSchemaVersion())
 	assertSchemaVersion(t, d, db.CurrentSchemaVersion())
 	assertSchemaObject(t, d, "federation_bindings")
 	assertSchemaObject(t, d, "idx_federation_bindings_role_enabled")
@@ -31,6 +31,7 @@ func TestFederationSchemaVersionAndTable(t *testing.T) {
 	assertSchemaObject(t, d, "idx_events_origin_project_id")
 	assertFederationBindingColumn(t, d, "push_enabled")
 	assertFederationBindingColumn(t, d, "push_cursor_event_id")
+	assertFederationBindingColumn(t, d, "allow_insecure")
 	for _, column := range []string{
 		"last_pull_started_at", "last_pull_success_at",
 		"last_push_started_at", "last_push_success_at",

--- a/internal/db/sqlitestore/import_replay.go
+++ b/internal/db/sqlitestore/import_replay.go
@@ -307,17 +307,21 @@ func importFederationBinding(ctx context.Context, tx *sql.Tx, b *db.FederationBi
 	if b.Role == string(db.FederationRoleSpoke) && pushEnabled == 1 && actor == "" {
 		pushEnabled = 0
 	}
+	allowInsecure := 0
+	if b.AllowInsecure {
+		allowInsecure = 1
+	}
 	_, err := tx.ExecContext(ctx,
 		`INSERT INTO federation_bindings(
 		   project_id, role, hub_url, hub_project_id, hub_project_uid,
 		   replay_horizon_event_id, pull_cursor_event_id, push_enabled,
-		   push_cursor_event_id, bound_actor, enabled,
+		   push_cursor_event_id, bound_actor, allow_insecure, enabled,
 		   created_at, updated_at, last_sync_at
 		 )
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		b.ProjectID, b.Role, b.HubURL, b.HubProjectID, b.HubProjectUID,
 		b.ReplayHorizonEventID, b.PullCursorEventID, pushEnabled,
-		b.PushCursorEventID, actor, enabled,
+		b.PushCursorEventID, actor, allowInsecure, enabled,
 		b.CreatedAt, b.UpdatedAt, b.LastSyncAt)
 	return wrapImportErr(db.ImportKindFederationBinding, err)
 }

--- a/internal/db/sqlitestore/queries_projects_remove.go
+++ b/internal/db/sqlitestore/queries_projects_remove.go
@@ -235,11 +235,20 @@ func (d *Store) detachProjectAlias(ctx context.Context, p db.DetachAliasParams) 
 	return alias, &evt, nil
 }
 
+// CountOpenIssues returns the number of open, non-deleted issues for one
+// project without mutating state. It is the non-transactional sibling of the
+// refusal check inside RemoveProject, used by preflight callers such as the
+// federation leave route.
+func (d *Store) CountOpenIssues(ctx context.Context, projectID int64) (int64, error) {
+	return countOpenIssues(ctx, d, projectID)
+}
+
 // countOpenIssues returns the number of open, non-deleted issues belonging
-// to projectID. Used by RemoveProject's refusal check.
-func countOpenIssues(ctx context.Context, tx *sql.Tx, projectID int64) (int64, error) {
+// to projectID. Used by RemoveProject's refusal check and the CountOpenIssues
+// preflight; it reads through any sqlReader (a *sql.Tx or the Store itself).
+func countOpenIssues(ctx context.Context, q sqlReader, projectID int64) (int64, error) {
 	var n int64
-	if err := tx.QueryRowContext(ctx,
+	if err := q.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM issues
 		 WHERE project_id = ? AND status = 'open' AND deleted_at IS NULL`,
 		projectID).Scan(&n); err != nil {

--- a/internal/db/sqlitestore/queries_projects_remove_test.go
+++ b/internal/db/sqlitestore/queries_projects_remove_test.go
@@ -82,6 +82,40 @@ func TestRemoveProject_ForceOverridesOpenIssues(t *testing.T) {
 		`SELECT COUNT(*) FROM issues WHERE project_id = ? AND status = 'open'`, p.ID)
 }
 
+// TestCountOpenIssues pins the non-mutating preflight count used by the
+// federation leave route: it returns the number of open, non-deleted issues
+// and does not archive or otherwise mutate the project.
+func TestCountOpenIssues(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	p, err := d.CreateProject(ctx, "counted")
+	require.NoError(t, err)
+
+	n, err := d.CountOpenIssues(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "fresh project has no open issues")
+
+	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: p.ID, Title: "open one", Author: "tester",
+	})
+	require.NoError(t, err)
+	closed, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: p.ID, Title: "to close", Author: "tester",
+	})
+	require.NoError(t, err)
+	_, _, _, err = d.CloseIssue(ctx, closed.ID, "done", "tester", "", nil)
+	require.NoError(t, err)
+
+	n, err = d.CountOpenIssues(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "only the still-open issue counts")
+
+	// The count must not have archived the project.
+	got, err := d.ProjectByID(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.DeletedAt, "CountOpenIssues must not mutate the project")
+}
+
 // TestRemoveProject_AlreadyArchived covers the idempotency-rejection: a
 // second RemoveProject on an archived project surfaces a clean error rather
 // than silently re-archiving.

--- a/internal/db/sqlitestore/schema.sql
+++ b/internal/db/sqlitestore/schema.sql
@@ -304,6 +304,7 @@ CREATE TABLE federation_bindings (
   push_enabled            INTEGER NOT NULL DEFAULT 0 CHECK(push_enabled IN (0,1)),
   push_cursor_event_id    INTEGER NOT NULL DEFAULT 0 CHECK(push_cursor_event_id >= 0),
   bound_actor             TEXT NOT NULL DEFAULT '',
+  allow_insecure          INTEGER NOT NULL DEFAULT 0 CHECK(allow_insecure IN (0,1)),
   enabled                 INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0,1)),
   created_at              DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   updated_at              DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -36,6 +36,11 @@ type Storage interface {
 	ListProjectsIncludingArchived(ctx context.Context) ([]Project, error)
 	RenameProject(ctx context.Context, id int64, name string) (Project, error)
 	RemoveProject(ctx context.Context, p RemoveProjectParams) (Project, *Event, error)
+	// CountOpenIssues returns the number of open, non-deleted issues for one
+	// project without mutating any state. It mirrors the refusal check inside
+	// RemoveProject for preflight callers (e.g. the federation leave route,
+	// which must reject an archive before detaching).
+	CountOpenIssues(ctx context.Context, projectID int64) (int64, error)
 	RestoreProject(ctx context.Context, projectID int64, actor string) (Project, *Event, bool, error)
 	HardDeleteProject(ctx context.Context, id int64) error
 	MergeProjects(ctx context.Context, p MergeProjectsParams) (ProjectMergeResult, error)
@@ -193,6 +198,7 @@ type Storage interface {
 	CountActiveFederationEnrollments(ctx context.Context, projectID int64) (int64, error)
 	SkipFederationQuarantine(ctx context.Context, p SkipFederationQuarantineParams) (FederationQuarantine, error)
 	UpsertFederationBinding(ctx context.Context, b FederationBinding) (FederationBinding, error)
+	LeaveFederationReplica(ctx context.Context, projectID int64) (LeaveFederationResult, error)
 	AdoptProjectIntoFederation(ctx context.Context, p AdoptProjectIntoFederationParams) (AdoptProjectIntoFederationResult, error)
 	AdvanceFederationPullCursor(ctx context.Context, projectID, nextCursor int64) error
 	InsertRemoteEvent(ctx context.Context, projectID int64, ev RemoteEvent) (bool, error)

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -89,10 +89,14 @@ type FederationBinding struct {
 	PushEnabled          bool
 	PushCursorEventID    int64
 	Actor                string
-	Enabled              bool
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
-	LastSyncAt           *time.Time
+	// AllowInsecure records the join-time plaintext-HTTP transport opt-in on
+	// the binding itself so leave can rebuild the hub client even when the
+	// credential file (the only other holder of the flag) is gone.
+	AllowInsecure bool
+	Enabled       bool
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	LastSyncAt    *time.Time
 }
 
 // FederationQuarantineDirection identifies which federation stream is blocked.

--- a/internal/jsonl/export.go
+++ b/internal/jsonl/export.go
@@ -892,6 +892,7 @@ func exportFederationBindings(
 		PushEnabled          bool    `json:"push_enabled"`
 		PushCursorEventID    int64   `json:"push_cursor_event_id"`
 		Actor                string  `json:"bound_actor,omitempty"`
+		AllowInsecure        bool    `json:"allow_insecure,omitempty"`
 		Enabled              bool    `json:"enabled"`
 		CreatedAt            string  `json:"created_at"`
 		UpdatedAt            string  `json:"updated_at"`
@@ -901,9 +902,13 @@ func exportFederationBindings(
 	if sourceSchemaVersion >= 13 {
 		actorSelect = `bound_actor`
 	}
+	allowInsecureSelect := `0`
+	if sourceSchemaVersion >= 15 {
+		allowInsecureSelect = `allow_insecure`
+	}
 	query := `SELECT project_id, role, hub_url, hub_project_id, hub_project_uid,
 	                 replay_horizon_event_id, pull_cursor_event_id, push_enabled,
-	                 push_cursor_event_id, ` + actorSelect + `, enabled,
+	                 push_cursor_event_id, ` + actorSelect + `, ` + allowInsecureSelect + `, enabled,
 	                 CAST(created_at AS TEXT), CAST(updated_at AS TEXT),
 	                 CAST(last_sync_at AS TEXT)
 	          FROM federation_bindings`
@@ -919,12 +924,13 @@ func exportFederationBindings(
 	}
 	return scanRecords(rows, KindFederationBinding, enc, func(rows *sql.Rows) (record, error) {
 		var rec record
-		var enabled, pushEnabled int
+		var enabled, pushEnabled, allowInsecure int
 		err := rows.Scan(&rec.ProjectID, &rec.Role, &rec.HubURL, &rec.HubProjectID,
 			&rec.HubProjectUID, &rec.ReplayHorizonEventID, &rec.PullCursorEventID,
-			&pushEnabled, &rec.PushCursorEventID, &rec.Actor, &enabled, &rec.CreatedAt,
-			&rec.UpdatedAt, &rec.LastSyncAt)
+			&pushEnabled, &rec.PushCursorEventID, &rec.Actor, &allowInsecure, &enabled,
+			&rec.CreatedAt, &rec.UpdatedAt, &rec.LastSyncAt)
 		rec.PushEnabled = pushEnabled == 1
+		rec.AllowInsecure = allowInsecure == 1
 		rec.Enabled = enabled == 1
 		return rec, err
 	})

--- a/internal/jsonl/export_test.go
+++ b/internal/jsonl/export_test.go
@@ -215,7 +215,17 @@ func TestExportFederationKindOrderPlacesEnrollmentBeforeEvent(t *testing.T) {
 
 func TestExportFederationSyncStatus(t *testing.T) {
 	ctx, d, p := newExportEnv(t)
-	err := d.RecordFederationSyncPullStarted(ctx, p.ID, mustParseTime(t, "2026-05-23T01:00:00.000Z"))
+	// federation_sync_status writers no-op without a live binding (the leave
+	// sync-race guard), so seed one before recording sync status.
+	_, err := d.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            p.ID,
+		Role:                 db.FederationRoleHub,
+		HubProjectUID:        p.UID,
+		ReplayHorizonEventID: 1,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	err = d.RecordFederationSyncPullStarted(ctx, p.ID, mustParseTime(t, "2026-05-23T01:00:00.000Z"))
 	require.NoError(t, err)
 	err = d.RecordFederationSyncPullSuccess(ctx, p.ID, mustParseTime(t, "2026-05-23T01:00:01.000Z"))
 	require.NoError(t, err)

--- a/internal/jsonl/roundtrip_test.go
+++ b/internal/jsonl/roundtrip_test.go
@@ -158,6 +158,16 @@ func TestFederationSyncStatusRoundTrip(t *testing.T) {
 	srcDB := openExportTestDB(t)
 	p, err := srcDB.CreateProject(ctx, "sync-status")
 	require.NoError(t, err)
+	// federation_sync_status writers no-op without a live binding (the leave
+	// sync-race guard), so seed one before recording sync status.
+	_, err = srcDB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            p.ID,
+		Role:                 db.FederationRoleHub,
+		HubProjectUID:        p.UID,
+		ReplayHorizonEventID: 1,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
 	require.NoError(t, srcDB.RecordFederationSyncPullStarted(ctx, p.ID, mustParseTime(t, "2026-05-23T01:00:00.000Z")))
 	require.NoError(t, srcDB.RecordFederationSyncPullSuccess(ctx, p.ID, mustParseTime(t, "2026-05-23T01:00:01.000Z")))
 	require.NoError(t, srcDB.RecordFederationSyncPushStarted(ctx, p.ID, mustParseTime(t, "2026-05-23T01:00:02.000Z")))

--- a/internal/jsonl/roundtrip_test.go
+++ b/internal/jsonl/roundtrip_test.go
@@ -415,6 +415,7 @@ func TestRoundtrip_FederationBindingCarriesPushState(t *testing.T) {
 		PushEnabled:          true,
 		PushCursorEventID:    5,
 		Actor:                "wesm",
+		AllowInsecure:        true,
 		Enabled:              true,
 	}
 	_, err = srcDB.UpsertFederationBinding(ctx, binding)
@@ -438,6 +439,7 @@ func TestRoundtrip_FederationBindingCarriesPushState(t *testing.T) {
 	assert.Equal(t, true, bindingPayload["push_enabled"])
 	assert.Equal(t, float64(5), bindingPayload["push_cursor_event_id"])
 	assert.Equal(t, "wesm", bindingPayload["bound_actor"])
+	assert.Equal(t, true, bindingPayload["allow_insecure"])
 	assert.NotContains(t, bindingPayload, "materialize_after_event_id")
 
 	dstDB := openImportTargetDB(t)
@@ -447,6 +449,7 @@ func TestRoundtrip_FederationBindingCarriesPushState(t *testing.T) {
 	assert.True(t, got.PushEnabled)
 	assert.Equal(t, int64(5), got.PushCursorEventID)
 	assert.Equal(t, "wesm", got.Actor)
+	assert.True(t, got.AllowInsecure, "allow_insecure must survive the JSONL round trip")
 }
 
 func TestRoundtrip_FederationEnrollmentRows(t *testing.T) {

--- a/internal/tui/api.go
+++ b/internal/tui/api.go
@@ -27,6 +27,7 @@ type federationSpokeAPI interface {
 	ListProjects(ctx context.Context) ([]ProjectSummary, error)
 	FederationStatus(ctx context.Context) (FederationStatusBody, error)
 	CreateFederationReplica(ctx context.Context, body CreateFederationReplicaInput) (FederationReplicaResult, error)
+	LeaveFederationReplica(ctx context.Context, projectID int64, body LeaveFederationReplicaInput) (LeaveFederationReplicaResult, error)
 }
 
 type federationHubAdminAPI interface {
@@ -35,6 +36,8 @@ type federationHubAdminAPI interface {
 	EnsureProject(ctx context.Context, name string) (ProjectSummary, error)
 	EnableFederation(ctx context.Context, projectID int64, actor string) (ProjectFederationMetadata, error)
 	CreateFederationEnrollment(ctx context.Context, body CreateFederationEnrollmentInput) (FederationEnrollment, error)
+	ListFederationEnrollments(ctx context.Context) ([]FederationEnrollment, error)
+	RevokeFederationEnrollment(ctx context.Context, enrollmentID int64) error
 }
 
 type federationEnrollmentAPI interface {

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -406,6 +406,40 @@ func (c *Client) CreateFederationReplica(
 	return resp, err
 }
 
+// ListFederationEnrollments lists the hub's federation transport grants. Used
+// by the leave flow to find the active enrollments to revoke before teardown.
+// Tokens are never returned by this endpoint.
+func (c *Client) ListFederationEnrollments(ctx context.Context) ([]FederationEnrollment, error) {
+	var resp struct {
+		Enrollments []FederationEnrollment `json:"enrollments"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/api/v1/federation/enrollments", nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Enrollments, nil
+}
+
+// RevokeFederationEnrollment revokes one hub enrollment by ID. Revocation is
+// idempotent at the daemon; an already-revoked row still reports revoked.
+func (c *Client) RevokeFederationEnrollment(ctx context.Context, enrollmentID int64) error {
+	path := fmt.Sprintf("/api/v1/federation/enrollments/%d/revoke", enrollmentID)
+	return c.do(ctx, http.MethodPost, path, map[string]any{}, nil)
+}
+
+// LeaveFederationReplica tears down a local spoke replica (detach or archive).
+// This is the local-only daemon primitive; the hub revoke is composed by the
+// caller before invoking it, mirroring the CLI leave orchestration.
+func (c *Client) LeaveFederationReplica(
+	ctx context.Context,
+	projectID int64,
+	body LeaveFederationReplicaInput,
+) (LeaveFederationReplicaResult, error) {
+	var resp LeaveFederationReplicaResult
+	path := fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", projectID)
+	err := c.do(ctx, http.MethodPost, path, body, &resp)
+	return resp, err
+}
+
 // ListProjectsWithStats returns every active project with per-project
 // aggregates {open, closed, last_event_at} populated. Used by the
 // projects view. Spec §7.3.

--- a/internal/tui/client_types.go
+++ b/internal/tui/client_types.go
@@ -166,6 +166,9 @@ type ResolveResp struct {
 	Project struct {
 		ID   int64  `json:"id"`
 		Name string `json:"name"`
+		// UID seeds projectUIDByID at boot so the enroll flow's rejoin
+		// detection works before the async project-list fetch lands.
+		UID string `json:"uid"`
 	} `json:"project"`
 	WorkspaceRoot string `json:"workspace_root"`
 }

--- a/internal/tui/client_types.go
+++ b/internal/tui/client_types.go
@@ -216,6 +216,9 @@ type LeaveFederationReplicaInput struct {
 	Disposition string `json:"disposition,omitempty"` // "detach" | "archive"
 	Force       bool   `json:"force,omitempty"`
 	Actor       string `json:"actor,omitempty"`
+	// Preflight validates (archive eligibility, spoke role) without mutating,
+	// so the archive's open-issue refusal can surface BEFORE the hub revoke.
+	Preflight bool `json:"preflight,omitempty"`
 }
 
 // CreateFederationReplicaInput is the spoke join/adoption request body.

--- a/internal/tui/client_types.go
+++ b/internal/tui/client_types.go
@@ -174,6 +174,9 @@ type ResolveResp struct {
 type ProjectSummary struct {
 	ID   int64  `json:"id"`
 	Name string `json:"name"`
+	// UID is the project's durable identity. Federated replicas share it with
+	// their hub project, which is how the enroll flow recognizes a rejoin.
+	UID string `json:"uid,omitempty"`
 }
 
 // InstanceInfo is the daemon instance identity returned by /api/v1/instance.
@@ -201,6 +204,16 @@ type ProjectFederationMetadata = api.ProjectFederationBody
 
 // FederationReplicaResult is the spoke join/adoption result response.
 type FederationReplicaResult = api.CreateFederationReplicaBody
+
+// LeaveFederationReplicaResult is the spoke leave (detach/archive) response.
+type LeaveFederationReplicaResult = api.LeaveFederationReplicaResultBody
+
+// LeaveFederationReplicaInput is the spoke leave request body.
+type LeaveFederationReplicaInput struct {
+	Disposition string `json:"disposition,omitempty"` // "detach" | "archive"
+	Force       bool   `json:"force,omitempty"`
+	Actor       string `json:"actor,omitempty"`
+}
 
 // CreateFederationReplicaInput is the spoke join/adoption request body.
 type CreateFederationReplicaInput struct {

--- a/internal/tui/daemon_view.go
+++ b/internal/tui/daemon_view.go
@@ -142,6 +142,7 @@ func (m Model) installDaemonConnection(conn daemonConnection) (Model, tea.Cmd) {
 	m.cache = newIssueCache()
 	m.projectLabels = newLabelCache()
 	m.projectsByID = map[int64]string{}
+	m.projectUIDByID = map[int64]string{}
 	m.projectIdentByID = map[int64]string{}
 	m.projectStats = map[int64]ProjectStatsSummary{}
 	m.projectsCursor = 0
@@ -178,10 +179,12 @@ func (m Model) installDaemonConnection(conn daemonConnection) (Model, tea.Cmd) {
 	m.nextDetailFollowGen++
 	if len(conn.init.projects) > 0 {
 		m.projectsByID = make(map[int64]string, len(conn.init.projects))
+		m.projectUIDByID = make(map[int64]string, len(conn.init.projects))
 		m.projectIdentByID = make(map[int64]string, len(conn.init.projects))
 		m.projectStats = make(map[int64]ProjectStatsSummary, len(conn.init.projects))
 		for _, r := range conn.init.projects {
 			m.projectsByID[r.ID] = r.Name
+			m.projectUIDByID[r.ID] = r.UID
 			m.projectIdentByID[r.ID] = r.Name
 			if r.Stats != nil {
 				m.projectStats[r.ID] = *r.Stats

--- a/internal/tui/federation_view.go
+++ b/internal/tui/federation_view.go
@@ -898,9 +898,17 @@ type federationLocalProjectRow struct {
 
 func federationLocalProjectRows(m Model) []federationLocalProjectRow {
 	rows := []federationLocalProjectRow{{createReplica: true}}
-	projects := make([]ProjectSummary, 0, len(m.projectsByID))
+	projects := make([]ProjectSummary, 0, len(m.projectsByID)+1)
 	for id, name := range m.projectsByID {
 		projects = append(projects, ProjectSummary{ID: id, Name: name})
+	}
+	// The boot project-list fetch is asynchronous and can fail, so the
+	// scoped/selected project must stay adoptable from scope state alone —
+	// an empty cache must not reduce the flow to "create replica" only.
+	if id, name, ok := m.defaultFederationProject(); ok {
+		if _, cached := m.projectsByID[id]; !cached {
+			projects = append(projects, ProjectSummary{ID: id, Name: name})
+		}
 	}
 	sort.SliceStable(projects, func(i, j int) bool {
 		li, lj := strings.ToLower(projects[i].Name), strings.ToLower(projects[j].Name)

--- a/internal/tui/federation_view.go
+++ b/internal/tui/federation_view.go
@@ -605,11 +605,13 @@ func (m Model) federationLeaveHubTarget(hubURL string, allowInsecure bool) daemo
 		if strings.TrimRight(target.URL, "/") == want {
 			// Token/token_env come from the catalog entry, but pin the URL to
 			// the binding's hub URL so the admin token is sent only to the
-			// bound origin, and take allow_insecure from the BINDING (the
-			// transport opt-in recorded at join time), not the catalog.
+			// bound origin. allow_insecure is the UNION of the binding's
+			// join-time opt-in and the same-origin catalog entry's: the
+			// catalog can restore an opt-in lost with the credential during a
+			// partial-leave recovery, but can never remove the binding's.
 			matched := target
 			matched.URL = want
-			matched.AllowInsecure = allowInsecure
+			matched.AllowInsecure = allowInsecure || target.AllowInsecure
 			return matched
 		}
 	}

--- a/internal/tui/federation_view.go
+++ b/internal/tui/federation_view.go
@@ -1253,6 +1253,14 @@ func (m Model) previewFederationEnrollment() (Model, tea.Cmd) {
 				m.projectUIDByID[draft.SpokeProjectID] == hubUID {
 				draft.Operation = federationOperationRejoin
 				draft.AdoptExisting = false
+			} else if m.projectUIDByID[draft.SpokeProjectID] == "" {
+				// Unknown local UID means the rejoin check above could not
+				// run (project-list fetch still in flight, or it failed).
+				// Block rather than default to adoption, which would rewrite
+				// a post-leave project's history.
+				draft.BlockedReason = fmt.Sprintf(
+					"local project %q identity is still loading; press esc and retry",
+					draft.SpokeProjectName)
 			}
 		}
 	}

--- a/internal/tui/federation_view.go
+++ b/internal/tui/federation_view.go
@@ -637,6 +637,22 @@ func runFederationLeave(
 	if spoke == nil {
 		return result, errors.New("spoke: leave failed: daemon client unavailable")
 	}
+	disposition := draft.Disposition
+	if disposition == "" {
+		disposition = "detach"
+	}
+	if disposition == "archive" {
+		// Archive-eligibility preflight BEFORE the irreversible hub revoke:
+		// a predictable open-issue refusal must not strand the spoke
+		// hub-revoked but locally bound.
+		if _, err := spoke.LeaveFederationReplica(ctx, draft.ProjectID, LeaveFederationReplicaInput{
+			Disposition: disposition,
+			Actor:       draft.Actor,
+			Preflight:   true,
+		}); err != nil {
+			return result, fmt.Errorf("spoke: leave preflight failed: %w", err)
+		}
+	}
 	if draft.LocalOnly {
 		result.SkippedRevoke = true
 	} else {
@@ -646,10 +662,6 @@ func runFederationLeave(
 		}
 		result.RevokedCount = revoked
 		result.GlobalEnrollmentIDs = globals
-	}
-	disposition := draft.Disposition
-	if disposition == "" {
-		disposition = "detach"
 	}
 	body, err := spoke.LeaveFederationReplica(ctx, draft.ProjectID, LeaveFederationReplicaInput{
 		Disposition: disposition,

--- a/internal/tui/federation_view.go
+++ b/internal/tui/federation_view.go
@@ -648,10 +648,13 @@ func runFederationLeave(
 	if disposition == "" {
 		disposition = "detach"
 	}
-	if disposition == "archive" {
-		// Archive-eligibility preflight BEFORE the irreversible hub revoke:
-		// a predictable open-issue refusal must not strand the spoke
-		// hub-revoked but locally bound.
+	if !draft.LocalOnly {
+		// Daemon preflight BEFORE the irreversible hub revoke, for every
+		// leave that will contact the hub: the route can refuse a detach too
+		// (role drift, vanished project, actor validation), and the archive
+		// disposition adds the open-issue refusal. A refusal discovered only
+		// after the revoke would strand the spoke locally bound with the hub
+		// side gone.
 		if _, err := spoke.LeaveFederationReplica(ctx, draft.ProjectID, LeaveFederationReplicaInput{
 			Disposition: disposition,
 			Actor:       draft.Actor,

--- a/internal/tui/federation_view.go
+++ b/internal/tui/federation_view.go
@@ -704,7 +704,12 @@ func revokeFederationLeaveEnrollments(
 	if err != nil {
 		return 0, nil, federationLeaveHubError(err)
 	}
-	ids, globals := matchFederationLeaveEnrollments(enrollments, draft.InstanceUID, draft.HubProjectID)
+	ids, globals, foreign := matchFederationLeaveEnrollments(enrollments, draft.InstanceUID, draft.HubProjectID)
+	if len(ids) == 0 && len(foreign) > 0 {
+		return 0, nil, fmt.Errorf(
+			"no active enrollment matches this spoke's instance UID, but enrollment(s) %s still authorize the hub project — the instance UID can change after a clone/import, or the enrollment may belong to another spoke instance; revoke the right one with `kata federation revoke <id>` on the hub, or retry with local-only to tear down locally without revoking",
+			formatEnrollmentIDs(foreign))
+	}
 	for _, id := range ids {
 		if err := hub.RevokeFederationEnrollment(ctx, id); err != nil {
 			return 0, nil, federationLeaveHubError(err)
@@ -715,32 +720,39 @@ func revokeFederationLeaveEnrollments(
 
 // matchFederationLeaveEnrollments returns the IDs of active (not-revoked)
 // enrollments whose spoke instance UID and hub project ID match this spoke's
-// binding, plus the IDs of active GLOBAL enrollments (nil project scope) for
-// the same spoke — those still authorize this project but are not auto-revoked
-// because they may serve the spoke's other projects on the hub. Mirrors the
-// CLI's revokeSpokeEnrollmentsOnHub selection.
+// binding, the IDs of active GLOBAL enrollments (nil project scope) for the
+// same spoke — those still authorize this project but are not auto-revoked
+// because they may serve the spoke's other projects on the hub — and the IDs
+// of active project-scoped enrollments for OTHER spoke instances. The caller
+// must not treat zero matches as success while foreign ones exist: the
+// instance UID can drift from the enrollment's (clone/import refresh or an
+// explicit --spoke-instance enroll), and silently proceeding would strand a
+// live token. Mirrors the CLI's revokeSpokeEnrollmentsOnHub selection.
 func matchFederationLeaveEnrollments(
 	enrollments []FederationEnrollment,
 	instanceUID string,
 	hubProjectID int64,
-) (ids []int64, globals []int64) {
+) (ids, globals, foreign []int64) {
 	for _, enrollment := range enrollments {
 		if enrollment.RevokedAt != nil {
 			continue
 		}
-		if enrollment.SpokeInstanceUID != instanceUID {
-			continue
-		}
 		if enrollment.ProjectID == nil {
-			globals = append(globals, enrollment.ID)
+			if enrollment.SpokeInstanceUID == instanceUID {
+				globals = append(globals, enrollment.ID)
+			}
 			continue
 		}
 		if *enrollment.ProjectID != hubProjectID {
 			continue
 		}
-		ids = append(ids, enrollment.ID)
+		if enrollment.SpokeInstanceUID == instanceUID {
+			ids = append(ids, enrollment.ID)
+			continue
+		}
+		foreign = append(foreign, enrollment.ID)
 	}
-	return ids, globals
+	return ids, globals, foreign
 }
 
 // federationLeaveHubError wraps a hub-side failure with guidance to retry with
@@ -1268,18 +1280,22 @@ func (m Model) previewFederationEnrollment() (Model, tea.Cmd) {
 			// project's identity — the post-leave state. Adoption would rewrite
 			// its event history a second time; rejoin just rebinds it. Mirrors
 			// the create-replica branch's detection for the adopt-first flow.
-			if hubUID := federationHubProjectUIDByID(m, draft.HubProjectID); hubUID != "" &&
-				m.projectUIDByID[draft.SpokeProjectID] == hubUID {
+			// Either UID being unknown disables that comparison, so block
+			// rather than default to history-rewriting adoption.
+			hubUID := federationHubProjectUIDByID(m, draft.HubProjectID)
+			localUID := m.projectUIDByID[draft.SpokeProjectID]
+			switch {
+			case hubUID != "" && localUID == hubUID:
 				draft.Operation = federationOperationRejoin
 				draft.AdoptExisting = false
-			} else if m.projectUIDByID[draft.SpokeProjectID] == "" {
-				// Unknown local UID means the rejoin check above could not
-				// run (project-list fetch still in flight, or it failed).
-				// Block rather than default to adoption, which would rewrite
-				// a post-leave project's history.
+			case localUID == "":
 				draft.BlockedReason = fmt.Sprintf(
 					"local project %q identity is still loading; press esc and retry",
 					draft.SpokeProjectName)
+			case hubUID == "":
+				draft.BlockedReason = fmt.Sprintf(
+					"hub project %q identity is unknown; refresh the hub project list and retry",
+					draft.HubProjectName)
 			}
 		}
 	}

--- a/internal/tui/federation_view.go
+++ b/internal/tui/federation_view.go
@@ -471,7 +471,14 @@ func (m Model) routeFederationAdoptConfirmKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 			m.federationAdoptConfirmInput = string(r[:len(r)-1])
 		}
 		return m, nil
-	case tea.KeyRunes, tea.KeySpace:
+	case tea.KeySpace:
+		// bubbletea v1.3.10 delivers KeySpace with Runes{' '} (a back-compat
+		// detail) and Windows sends KeyRunes, so msg.Runes works today —
+		// append the literal so a runeless KeySpace from another backend or a
+		// future library version cannot silently drop the character.
+		m.federationAdoptConfirmInput += " "
+		return m, nil
+	case tea.KeyRunes:
 		m.federationAdoptConfirmInput += string(msg.Runes)
 		return m, nil
 	}

--- a/internal/tui/federation_view.go
+++ b/internal/tui/federation_view.go
@@ -24,6 +24,11 @@ const (
 	federationModeSelectHub
 	federationModeSelectHubProject
 	federationModeBrowseHubs
+	federationModeLeavePreview
+	// federationModeAdoptConfirm is the typed-confirmation gate between the
+	// enroll preview and execution for adoption operations, which rewrite the
+	// local project's event history.
+	federationModeAdoptConfirm
 )
 
 type federationOperation string
@@ -32,6 +37,9 @@ const (
 	federationOperationAdoptSameName    federationOperation = "adopt-same-name"
 	federationOperationAdoptSelectedHub federationOperation = "adopt-selected-hub"
 	federationOperationCreateReplica    federationOperation = "create-replica"
+	// federationOperationRejoin rebinds a local project that previously left
+	// this hub project's federation (it still shares the hub project's UID).
+	federationOperationRejoin federationOperation = "rejoin"
 )
 
 type federationDraft struct {
@@ -60,6 +68,38 @@ type federationEnrollResult struct {
 	Metadata   ProjectFederationMetadata
 	Replica    FederationReplicaResult
 	Recovery   federationRecovery
+}
+
+// federationLeaveDraft captures one spoke row's leave intent. It is the
+// mutation boundary: populated when `x` is pressed on a spoke row and
+// rendered in federationModeLeavePreview before any hub revoke or local
+// teardown runs. Disposition is "detach" (default) or "archive". LocalOnly
+// skips the hub revoke (leaving the enrollment token valid). BlockedReason is
+// set when the selected row cannot be left (e.g. not a spoke).
+type federationLeaveDraft struct {
+	ProjectID     int64
+	ProjectName   string
+	HubURL        string
+	HubProjectID  int64
+	InstanceUID   string
+	AllowInsecure bool
+	Disposition   string
+	Actor         string
+	LocalOnly     bool
+	BlockedReason string
+}
+
+// federationLeaveResult is the outcome surfaced on the result screen after a
+// successful leave.
+type federationLeaveResult struct {
+	Draft         federationLeaveDraft
+	RevokedCount  int
+	SkippedRevoke bool
+	// GlobalEnrollmentIDs are active hub enrollments with global (nil) project
+	// scope for this spoke: they still authorize the left project but are not
+	// auto-revoked, since they may serve other projects.
+	GlobalEnrollmentIDs []int64
+	Body                LeaveFederationReplicaResult
 }
 
 type federationRecovery struct {
@@ -197,6 +237,7 @@ func (m Model) handleFederationEnrollResult(msg federationEnrollResultMsg) (Mode
 		return m, nil
 	}
 	m.federationResult = msg.result
+	m.federationResultIsLeave = false
 	m.federationMode = federationModeResult
 	m.federationLoading = true
 	m.federationErr = nil
@@ -219,6 +260,10 @@ func (m Model) routeFederationViewKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m.routeFederationBrowseHubsKey(msg)
 	case federationModePreview:
 		return m.routeFederationPreviewKey(msg)
+	case federationModeAdoptConfirm:
+		return m.routeFederationAdoptConfirmKey(msg)
+	case federationModeLeavePreview:
+		return m.routeFederationLeavePreviewKey(msg)
 	case federationModeRecovery:
 		return m.routeFederationRecoveryKey(msg)
 	case federationModeResult:
@@ -239,6 +284,11 @@ func (m Model) routeFederationViewKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, m.fetchFederationStatus()
 	case "b":
 		return m.startFederationHubBrowse()
+	case "x":
+		if m.federationCursor < 0 || m.federationCursor >= len(rows) {
+			return m, nil
+		}
+		return m.startFederationLeave(rows[m.federationCursor])
 	case "enter":
 		if m.federationCursor < 0 || m.federationCursor >= len(rows) {
 			return m, nil
@@ -259,6 +309,13 @@ func (m Model) routeFederationDetailKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		m.federationErr = nil
 		m.federationGen++
 		return m, m.fetchFederationStatus()
+	case "x":
+		rows := federationSpokeStatuses(m.federationStatuses)
+		cursor := clampFederationCursor(m.federationCursor, rows)
+		if cursor < 0 || cursor >= len(rows) {
+			return m, nil
+		}
+		return m.startFederationLeave(rows[cursor])
 	}
 	return m, nil
 }
@@ -370,10 +427,53 @@ func (m Model) routeFederationPreviewKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		if m.federationDraft.BlockedReason != "" || m.federationEnrollRunning {
 			return m, nil
 		}
+		if m.federationDraft.AdoptExisting {
+			// Adoption rewrites the local project's event history; require the
+			// operator to type the project name before executing.
+			m.federationAdoptConfirmInput = ""
+			m.federationEnrollErr = nil
+			m.federationMode = federationModeAdoptConfirm
+			return m, nil
+		}
 		m.federationEnrollAttempt++
 		m.federationEnrollRunning = true
 		m.federationEnrollErr = nil
 		return m, m.executeFederationEnrollment(m.federationEnrollAttempt)
+	}
+	return m, nil
+}
+
+// routeFederationAdoptConfirmKey is a single-field typed confirmation: the
+// operator must type the local project's name exactly before an adoption
+// executes. Esc returns to the preview.
+func (m Model) routeFederationAdoptConfirmKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.federationAdoptConfirmInput = ""
+		m.federationEnrollErr = nil
+		m.federationMode = federationModePreview
+		return m, nil
+	case tea.KeyEnter:
+		if m.federationEnrollRunning {
+			return m, nil
+		}
+		if m.federationAdoptConfirmInput != m.federationDraft.SpokeProjectName {
+			m.federationEnrollErr = fmt.Errorf("type %q to confirm adoption", m.federationDraft.SpokeProjectName)
+			return m, nil
+		}
+		m.federationAdoptConfirmInput = ""
+		m.federationEnrollAttempt++
+		m.federationEnrollRunning = true
+		m.federationEnrollErr = nil
+		return m, m.executeFederationEnrollment(m.federationEnrollAttempt)
+	case tea.KeyBackspace:
+		if r := []rune(m.federationAdoptConfirmInput); len(r) > 0 {
+			m.federationAdoptConfirmInput = string(r[:len(r)-1])
+		}
+		return m, nil
+	case tea.KeyRunes, tea.KeySpace:
+		m.federationAdoptConfirmInput += string(msg.Runes)
+		return m, nil
 	}
 	return m, nil
 }
@@ -397,6 +497,239 @@ func (m Model) routeFederationResultKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+// startFederationLeave builds the leave draft from a selected row and enters
+// the preview. Leave is spoke-only: a non-spoke row is a no-op (the guard).
+// The preview is the mutation boundary — nothing is torn down here.
+func (m Model) startFederationLeave(row FederationProjectStatus) (Model, tea.Cmd) {
+	if row.Role != "spoke" {
+		return m, nil
+	}
+	m.federationEnrollErr = nil
+	m.federationLeaveRunning = false
+	m.federationLeaveDraft = federationLeaveDraft{
+		ProjectID:    row.ProjectID,
+		ProjectName:  row.ProjectName,
+		HubURL:       row.HubURL,
+		HubProjectID: row.HubProjectID,
+		InstanceUID:  strings.TrimSpace(m.federationInstance.InstanceUID),
+		// The binding's transport opt-in, so a plain-HTTP overlay hub joined
+		// with allow_insecure can also be left from the TUI.
+		AllowInsecure: row.AllowInsecure,
+		Disposition:   "detach",
+		Actor:         m.list.actor,
+	}
+	m.federationMode = federationModeLeavePreview
+	return m, nil
+}
+
+func (m Model) routeFederationLeavePreviewKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "backspace":
+		m.federationMode = federationModeList
+		m.federationEnrollErr = nil
+		return m, nil
+	case "d":
+		if m.federationLeaveDraft.Disposition == "archive" {
+			m.federationLeaveDraft.Disposition = "detach"
+		} else {
+			m.federationLeaveDraft.Disposition = "archive"
+		}
+		return m, nil
+	case "l":
+		m.federationLeaveDraft.LocalOnly = !m.federationLeaveDraft.LocalOnly
+		return m, nil
+	case "enter":
+		if m.federationLeaveDraft.BlockedReason != "" || m.federationLeaveRunning {
+			return m, nil
+		}
+		m.federationLeaveAttempt++
+		m.federationLeaveRunning = true
+		m.federationEnrollErr = nil
+		return m, m.executeFederationLeave(m.federationLeaveAttempt)
+	}
+	return m, nil
+}
+
+func (m Model) handleFederationLeaveResult(msg federationLeaveResultMsg) (Model, tea.Cmd) {
+	if m.staleConnMsg(msg.connGen) || msg.attempt != m.federationLeaveAttempt {
+		return m, nil
+	}
+	m.federationLeaveRunning = false
+	if msg.err != nil {
+		m.federationEnrollErr = msg.err
+		m.federationMode = federationModeLeavePreview
+		return m, nil
+	}
+	m.federationLeaveResult = msg.result
+	m.federationResultIsLeave = true
+	m.federationMode = federationModeResult
+	m.federationLoading = true
+	m.federationErr = nil
+	m.federationGen++
+	return m, m.fetchFederationStatus()
+}
+
+func (m Model) executeFederationLeave(attempt uint64) tea.Cmd {
+	connGen := m.connGen
+	draft := m.federationLeaveDraft
+	spoke := m.api
+	hubTarget := m.federationLeaveHubTarget(draft.HubURL, draft.AllowInsecure)
+	return func() tea.Msg {
+		result, err := runFederationLeave(context.Background(), draft, hubTarget, spoke)
+		return federationLeaveResultMsg{
+			connGen: connGen,
+			attempt: attempt,
+			result:  result,
+			err:     err,
+		}
+	}
+}
+
+// federationLeaveHubTarget resolves the hub admin daemonTarget for a leave by
+// matching the binding's hub URL against the catalog (so its token/token_env
+// is used), falling back to an implicit target that picks up global auth.
+// This mirrors the CLI's hub-admin auth precedence: the catalog entry whose URL
+// matches the binding's hub_url supplies only the admin token, else the global
+// KATA_AUTH_TOKEN fallback. The target URL is ALWAYS the binding's hub URL —
+// the catalog entry never redirects the admin token to a different origin — and
+// the URL comparison normalizes trailing slashes so a catalog/binding slash
+// mismatch still matches (#273).
+func (m Model) federationLeaveHubTarget(hubURL string, allowInsecure bool) daemonTarget {
+	want := strings.TrimRight(hubURL, "/")
+	for _, target := range m.daemonTargets {
+		if target.Local {
+			continue
+		}
+		if strings.TrimRight(target.URL, "/") == want {
+			// Token/token_env come from the catalog entry, but pin the URL to
+			// the binding's hub URL so the admin token is sent only to the
+			// bound origin, and take allow_insecure from the BINDING (the
+			// transport opt-in recorded at join time), not the catalog.
+			matched := target
+			matched.URL = want
+			matched.AllowInsecure = allowInsecure
+			return matched
+		}
+	}
+	// No catalog match: an unauthenticated, non-implicit target. Implicit
+	// targets pick up the global KATA_AUTH_TOKEN/[auth].token in
+	// resolvedDaemonTarget, which must never be sent to the hub origin.
+	return daemonTarget{URL: want, AllowInsecure: allowInsecure}
+}
+
+// runFederationLeave mirrors runFederationEnrollment: revoke-first on the hub
+// (unless LocalOnly), then call the spoke's local teardown route. The hub
+// revoke aborts the leave on failure so local state is never half torn down,
+// matching the CLI ordering.
+func runFederationLeave(
+	parent context.Context,
+	draft federationLeaveDraft,
+	hubTarget daemonTarget,
+	spoke federationSpokeAPI,
+) (federationLeaveResult, error) {
+	ctx, cancel := context.WithTimeout(parent, 15*time.Second)
+	defer cancel()
+	result := federationLeaveResult{Draft: draft}
+	if spoke == nil {
+		return result, errors.New("spoke: leave failed: daemon client unavailable")
+	}
+	if draft.LocalOnly {
+		result.SkippedRevoke = true
+	} else {
+		revoked, globals, err := revokeFederationLeaveEnrollments(ctx, draft, hubTarget)
+		if err != nil {
+			return result, err
+		}
+		result.RevokedCount = revoked
+		result.GlobalEnrollmentIDs = globals
+	}
+	disposition := draft.Disposition
+	if disposition == "" {
+		disposition = "detach"
+	}
+	body, err := spoke.LeaveFederationReplica(ctx, draft.ProjectID, LeaveFederationReplicaInput{
+		Disposition: disposition,
+		Actor:       draft.Actor,
+	})
+	if err != nil {
+		return result, fmt.Errorf("spoke: leave failed: %w", err)
+	}
+	result.Body = body
+	return result, nil
+}
+
+// revokeFederationLeaveEnrollments lists the hub's enrollments and revokes
+// every active project-scoped one bound to this spoke instance + hub project.
+// Zero matches is success (already revoked). Matching GLOBAL enrollments
+// (project_id NULL) are returned, not revoked — they may authorize other
+// projects on the hub — so the result screen can warn that they still
+// authorize this project. A hub transport/auth failure aborts the leave
+// before local teardown, with guidance to retry with local-only.
+func revokeFederationLeaveEnrollments(
+	ctx context.Context,
+	draft federationLeaveDraft,
+	hubTarget daemonTarget,
+) (int, []int64, error) {
+	if strings.TrimSpace(draft.InstanceUID) == "" {
+		return 0, nil, errors.New("spoke instance UID is not loaded; refresh federation status before leaving")
+	}
+	hub, _, err := newFederationHubAdminClient(ctx, hubTarget)
+	if err != nil {
+		return 0, nil, federationLeaveHubError(err)
+	}
+	enrollments, err := hub.ListFederationEnrollments(ctx)
+	if err != nil {
+		return 0, nil, federationLeaveHubError(err)
+	}
+	ids, globals := matchFederationLeaveEnrollments(enrollments, draft.InstanceUID, draft.HubProjectID)
+	for _, id := range ids {
+		if err := hub.RevokeFederationEnrollment(ctx, id); err != nil {
+			return 0, nil, federationLeaveHubError(err)
+		}
+	}
+	return len(ids), globals, nil
+}
+
+// matchFederationLeaveEnrollments returns the IDs of active (not-revoked)
+// enrollments whose spoke instance UID and hub project ID match this spoke's
+// binding, plus the IDs of active GLOBAL enrollments (nil project scope) for
+// the same spoke — those still authorize this project but are not auto-revoked
+// because they may serve the spoke's other projects on the hub. Mirrors the
+// CLI's revokeSpokeEnrollmentsOnHub selection.
+func matchFederationLeaveEnrollments(
+	enrollments []FederationEnrollment,
+	instanceUID string,
+	hubProjectID int64,
+) (ids []int64, globals []int64) {
+	for _, enrollment := range enrollments {
+		if enrollment.RevokedAt != nil {
+			continue
+		}
+		if enrollment.SpokeInstanceUID != instanceUID {
+			continue
+		}
+		if enrollment.ProjectID == nil {
+			globals = append(globals, enrollment.ID)
+			continue
+		}
+		if *enrollment.ProjectID != hubProjectID {
+			continue
+		}
+		ids = append(ids, enrollment.ID)
+	}
+	return ids, globals
+}
+
+// federationLeaveHubError wraps a hub-side failure with guidance to retry with
+// local-only, since local teardown is intentionally skipped when the hub
+// revoke cannot complete (mirrors the CLI guidance).
+func federationLeaveHubError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("hub revoke failed: %w; retry with local-only to tear down locally, then revoke on the hub later", err)
 }
 
 func (m Model) cursorMoveFederation(msg tea.KeyMsg, rows []FederationProjectStatus) (Model, bool) {
@@ -453,12 +786,18 @@ func (m Model) startFederationEnrollment() (Model, tea.Cmd) {
 	m.federationHubProjects = nil
 	m.federationHubProjectsLoading = false
 	m.federationEnrollErr = nil
-	if projectID, projectName, ok := m.defaultFederationProject(); ok {
-		m.federationDraft.SpokeProjectID = projectID
-		m.federationDraft.SpokeProjectName = projectName
-		m.federationDraft.AdoptExisting = true
-		m.federationMode = federationModeSelectHub
-		return m, nil
+	// Never skip the local-project step: the choice between adopting a local
+	// project and creating a new replica must stay explicit and visible. An
+	// active project only pre-positions the cursor (the adopt flow costs one
+	// Enter), instead of silently pre-arming adoption — which is how a
+	// misclick could federate the wrong project.
+	if projectID, _, ok := m.defaultFederationProject(); ok {
+		for i, row := range federationLocalProjectRows(m) {
+			if !row.createReplica && row.project.ID == projectID {
+				m.federationLocalProjectCursor = i
+				break
+			}
+		}
 	}
 	m.federationMode = federationModeSelectLocalProject
 	return m, nil
@@ -785,7 +1124,10 @@ func resolveFederationHubProject(
 }
 
 func federationReplicaProjectName(draft federationDraft, hubProjectName string) string {
-	if draft.AdoptExisting && strings.TrimSpace(draft.SpokeProjectName) != "" {
+	if strings.TrimSpace(draft.SpokeProjectName) != "" &&
+		(draft.AdoptExisting || draft.Operation == federationOperationRejoin) {
+		// Adoption and rejoin both target an existing local project, which may
+		// be named differently from the hub project.
 		return draft.SpokeProjectName
 	}
 	return hubProjectName
@@ -844,7 +1186,24 @@ func (m Model) previewFederationEnrollment() (Model, tea.Cmd) {
 		m.federationSelectedProjectSet = true
 		m.federationSelectedProjectID = 0
 		m.federationSelectedProjectName = project.Name
-		if localProjectNameExists(m, draft.SpokeProjectName) {
+		if holderID, holderName, ok := localProjectByUID(m, project.UID); ok {
+			// The hub project's identity already exists locally, so this is a
+			// rejoin of that project (it previously left this federation), not
+			// a new replica — the daemon would refuse the new-replica request.
+			if status, bound := localProjectFederationBinding(m, holderID, holderName); bound {
+				role := status.Role
+				if role == "" {
+					role = "unknown"
+				}
+				draft.BlockedReason = fmt.Sprintf(
+					"local project %q already has federation binding as %s", holderName, role)
+			} else {
+				draft.Operation = federationOperationRejoin
+				draft.SpokeProjectName = holderName
+				m.federationSelectedProjectID = holderID
+				m.federationSelectedProjectName = holderName
+			}
+		} else if localProjectNameExists(m, draft.SpokeProjectName) {
 			draft.BlockedReason = fmt.Sprintf("local project %q already exists", draft.SpokeProjectName)
 		}
 	} else {
@@ -874,6 +1233,17 @@ func (m Model) previewFederationEnrollment() (Model, tea.Cmd) {
 				projectName,
 				role,
 			)
+		}
+		if draft.BlockedReason == "" && draft.HubProjectID != 0 {
+			// The selected local project may already share the target hub
+			// project's identity — the post-leave state. Adoption would rewrite
+			// its event history a second time; rejoin just rebinds it. Mirrors
+			// the create-replica branch's detection for the adopt-first flow.
+			if hubUID := federationHubProjectUIDByID(m, draft.HubProjectID); hubUID != "" &&
+				m.projectUIDByID[draft.SpokeProjectID] == hubUID {
+				draft.Operation = federationOperationRejoin
+				draft.AdoptExisting = false
+			}
 		}
 	}
 	draft.AllowInsecure = draft.HubTarget.AllowInsecure
@@ -931,6 +1301,32 @@ func localProjectNameExists(m Model, name string) bool {
 		}
 	}
 	return false
+}
+
+// federationHubProjectUIDByID returns the UID of a listed hub project, or ""
+// when the project (or its UID) is unknown.
+func federationHubProjectUIDByID(m Model, hubProjectID int64) string {
+	for _, p := range m.federationHubProjects {
+		if p.ID == hubProjectID {
+			return p.UID
+		}
+	}
+	return ""
+}
+
+// localProjectByUID finds the local project holding a hub project's UID. A
+// match means the local project shares identity with the hub project — the
+// post-leave rejoin state.
+func localProjectByUID(m Model, uid string) (int64, string, bool) {
+	if strings.TrimSpace(uid) == "" {
+		return 0, "", false
+	}
+	for id, projectUID := range m.projectUIDByID {
+		if projectUID == uid {
+			return id, m.projectsByID[id], true
+		}
+	}
+	return 0, "", false
 }
 
 func localProjectFederationBinding(

--- a/internal/tui/federation_view_render.go
+++ b/internal/tui/federation_view_render.go
@@ -1,7 +1,9 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -31,6 +33,10 @@ func renderFederation(m Model) string {
 		return renderFederationBrowseHubs(m)
 	case federationModePreview:
 		return renderFederationPreview(m)
+	case federationModeAdoptConfirm:
+		return renderFederationAdoptConfirm(m)
+	case federationModeLeavePreview:
+		return renderFederationLeavePreview(m)
 	case federationModeResult:
 		return renderFederationResult(m)
 	case federationModeRecovery:
@@ -70,7 +76,7 @@ func renderFederation(m Model) string {
 	}
 	body = append(body, "")
 	body = append(body, subtleStyle.Render(
-		"[↑/↓ k/j] move  [enter] detail  [esc] back  [r] refresh  [n] enroll  [b] browse hubs  [?] help"))
+		"[↑/↓ k/j] move  [enter] detail  [esc] back  [r] refresh  [n] enroll  [x] leave  [b] browse hubs  [?] help"))
 	return strings.Join(body, "\n")
 }
 
@@ -189,8 +195,25 @@ func renderFederationPreview(m Model) string {
 	if draft.AdoptExisting {
 		body = append(body,
 			"",
+			fmt.Sprintf("this federates local project %q INTO hub project %q",
+				sanitizeForLine(emptyDash(draft.SpokeProjectName)),
+				sanitizeForLine(emptyDash(draft.HubProjectName))),
 			"adoption warning: pre-adoption event history is replaced by snapshot events for federation",
 		)
+	}
+	if draft.Operation == federationOperationRejoin {
+		body = append(body,
+			"",
+			fmt.Sprintf("local project %q previously left this federation and still shares the hub project's identity;",
+				sanitizeForLine(draft.SpokeProjectName)),
+			fmt.Sprintf("rejoining resumes syncing with hub project %q (edits made while standalone sync to the hub)",
+				sanitizeForLine(draft.HubProjectName)),
+		)
+		if draft.SpokeProjectName != draft.HubProjectName {
+			body = append(body,
+				"the local project keeps its name; spoke and hub project names do not need to match",
+			)
+		}
 	}
 	if draft.BlockedReason != "" {
 		body = append(body, "", errorStyle.Render("Blocked: "+sanitizeForLine(draft.BlockedReason)))
@@ -200,7 +223,80 @@ func renderFederationPreview(m Model) string {
 	return strings.Join(body, "\n")
 }
 
+// renderFederationAdoptConfirm is the typed-confirmation gate for adoption:
+// the consequence is stated in full and the operator must type the local
+// project's name before Enter executes.
+func renderFederationAdoptConfirm(m Model) string {
+	draft := m.federationDraft
+	body := federationModeHeader(m, "Confirm Adoption")
+	body = append(body,
+		fmt.Sprintf("federate local project %q INTO hub project %q?",
+			sanitizeForLine(emptyDash(draft.SpokeProjectName)),
+			sanitizeForLine(emptyDash(draft.HubProjectName))),
+		fmt.Sprintf("%q's issues will be adopted into the hub project and its local event history rewritten as snapshots",
+			sanitizeForLine(emptyDash(draft.SpokeProjectName))),
+		"",
+		fmt.Sprintf("type %q to confirm: %s",
+			sanitizeForLine(draft.SpokeProjectName),
+			sanitizeForLine(m.federationAdoptConfirmInput)),
+	)
+	body = appendFederationEnrollErr(body, m)
+	body = append(body, "", subtleStyle.Render("[enter] confirm  [esc] back"))
+	return strings.Join(body, "\n")
+}
+
+func renderFederationLeavePreview(m Model) string {
+	draft := m.federationLeaveDraft
+	disposition := draft.Disposition
+	if disposition == "" {
+		disposition = "detach"
+	}
+	body := federationModeHeader(m, "Leave Federation")
+	body = append(body,
+		"local spoke project: "+sanitizeForLine(emptyDash(draft.ProjectName)),
+		"hub: "+sanitizeForLine(federationHubDisplay(draft.HubURL)),
+		fmt.Sprintf("hub project ID: %d", draft.HubProjectID),
+		"local project: "+federationLeaveDispositionLabel(disposition),
+		fmt.Sprintf("local-only: %t", draft.LocalOnly),
+		"",
+	)
+	if draft.LocalOnly {
+		body = append(body,
+			errorStyle.Render("local-only: skipping hub revoke; the enrollment token stays valid until manually revoked"),
+			"local teardown only: "+federationLeaveTeardownLabel(disposition),
+		)
+	} else {
+		body = append(body,
+			"will revoke the enrollment(s) on the hub, then "+federationLeaveTeardownLabel(disposition),
+		)
+	}
+	if draft.BlockedReason != "" {
+		body = append(body, "", errorStyle.Render("Blocked: "+sanitizeForLine(draft.BlockedReason)))
+	}
+	body = appendFederationEnrollErr(body, m)
+	body = append(body, "",
+		subtleStyle.Render("[enter] confirm  [d] keep / archive  [l] local-only  [esc] back"))
+	return strings.Join(body, "\n")
+}
+
+func federationLeaveDispositionLabel(disposition string) string {
+	if disposition == "archive" {
+		return "archive — remove the replica (reversible via kata projects restore)"
+	}
+	return "keep (detach) — standalone with all issues"
+}
+
+func federationLeaveTeardownLabel(disposition string) string {
+	if disposition == "archive" {
+		return "archive the local replica"
+	}
+	return "detach locally (keep the project standalone)"
+}
+
 func renderFederationResult(m Model) string {
+	if m.federationResultIsLeave {
+		return renderFederationLeaveResult(m)
+	}
 	result := m.federationResult
 	body := federationModeHeader(m, "Enrollment Result")
 	status := "joined"
@@ -220,6 +316,43 @@ func renderFederationResult(m Model) string {
 	return strings.Join(body, "\n")
 }
 
+func renderFederationLeaveResult(m Model) string {
+	result := m.federationLeaveResult
+	body := federationModeHeader(m, "Leave Result")
+	status := "detached"
+	if result.Body.Archived {
+		status = "archived"
+	}
+	revoke := fmt.Sprintf("revoked %d enrollment(s) on the hub", result.RevokedCount)
+	if result.SkippedRevoke {
+		revoke = "hub revoke skipped (local-only): the enrollment token remains valid until manually revoked"
+	}
+	body = append(body,
+		"status: "+status,
+		"local spoke project: "+sanitizeForLine(emptyDash(result.Draft.ProjectName)),
+		"hub: "+sanitizeForLine(federationHubDisplay(result.Draft.HubURL)),
+		revoke,
+	)
+	if len(result.GlobalEnrollmentIDs) > 0 {
+		body = append(body, errorStyle.Render(fmt.Sprintf(
+			"warning: global enrollment(s) %s for this spoke remain active and still authorize this project; revoke manually if intended",
+			formatEnrollmentIDs(result.GlobalEnrollmentIDs))))
+	}
+	body = append(body,
+		"",
+		subtleStyle.Render("[enter] list  [esc] list"),
+	)
+	return strings.Join(body, "\n")
+}
+
+func formatEnrollmentIDs(ids []int64) string {
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprintf("#%d", id))
+	}
+	return strings.Join(parts, ", ")
+}
+
 func renderFederationRecovery(m Model) string {
 	recovery := m.federationRecovery
 	body := federationModeHeader(m, "Enrollment Recovery")
@@ -228,9 +361,19 @@ func renderFederationRecovery(m Model) string {
 	} else {
 		body = append(body, "hub: enrollment created", "spoke: join failed")
 	}
+	if recovery.Err != nil {
+		body = append(body, errorStyle.Render(sanitizeForLine(recovery.Err.Error())))
+	}
+	body = append(body, "token: hidden")
+	// The token guess is only a plausible explanation for auth failures (or
+	// when no specific error was captured); blaming the token for a 409 sends
+	// the operator chasing the wrong problem.
+	var apiErr *APIError
+	if recovery.Err == nil || (errors.As(recovery.Err, &apiErr) &&
+		(apiErr.Status == http.StatusUnauthorized || apiErr.Status == http.StatusForbidden)) {
+		body = append(body, "the hub enrollment may be single-use, expired, revoked, or invalidated")
+	}
 	body = append(body,
-		"token: hidden",
-		"the hub enrollment may be single-use, expired, revoked, or invalidated",
 		"",
 		subtleStyle.Render("[R] reveal recovery command  [esc] back"),
 	)
@@ -309,6 +452,8 @@ func federationOperationLabel(operation federationOperation) string {
 		return "adopt existing local project into selected hub project"
 	case federationOperationCreateReplica:
 		return "create new local replica from hub project"
+	case federationOperationRejoin:
+		return "rejoin: resume syncing a local project that previously left this federation"
 	default:
 		return "-"
 	}
@@ -421,6 +566,9 @@ func federationSelectedProjectLine(m Model) string {
 }
 
 func federationSelectedProjectDisplay(m Model) string {
+	if m.federationDraft.Operation == federationOperationRejoin {
+		return m.federationDraft.SpokeProjectName + " (rejoin)"
+	}
 	if m.federationDraft.CreateReplica {
 		if m.federationDraft.SpokeProjectName != "" {
 			return m.federationDraft.SpokeProjectName + " (new local replica)"

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -1030,9 +1030,15 @@ func TestFederationLeaveAbortsWhenOnlyForeignEnrollmentsMatchProject(t *testing.
 	})
 	realLeaveRan := false
 	spoke := mockDaemon(t, map[string]http.HandlerFunc{
-		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, _ *http.Request) {
-			realLeaveRan = true
-			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: true, Disposition: "detach"})
+		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, r *http.Request) {
+			var body LeaveFederationReplicaInput
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			// The non-mutating preflight legitimately precedes the revoke;
+			// only the real teardown must be blocked by the abort.
+			if !body.Preflight {
+				realLeaveRan = true
+			}
+			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: !body.Preflight, Disposition: "detach"})
 		},
 	})
 
@@ -1051,6 +1057,59 @@ func TestFederationLeaveAbortsWhenOnlyForeignEnrollmentsMatchProject(t *testing.
 	assert.Contains(t, msg.err.Error(), "#21", "the surviving enrollment ID must be named")
 	assert.Empty(t, hub.revokedEnrollmentIDs, "a foreign-instance enrollment must not be auto-revoked")
 	assert.False(t, realLeaveRan, "local teardown must not run after the abort")
+	_ = out
+}
+
+// TestFederationLeaveDetachPreflightRefusalSkipsRevoke: detach leaves run the
+// same daemon preflight as archive leaves — the route can refuse a detach too
+// (role drift, vanished project, actor validation), and a refusal discovered
+// only after the hub revoke would strand the spoke locally bound with the hub
+// side gone.
+func TestFederationLeaveDetachPreflightRefusalSkipsRevoke(t *testing.T) {
+	hubProject := int64(42)
+	hub := &recordingFederationHubAdmin{
+		enrollments: []FederationEnrollment{
+			{ID: 11, SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4EA", ProjectID: &hubProject},
+		},
+	}
+	restoreFederationHubAdminClient(t, func(
+		_ context.Context,
+		target daemonTarget,
+	) (federationHubAdminAPI, daemonTarget, error) {
+		return hub, target, nil
+	})
+	realLeaveRan := false
+	spoke := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, r *http.Request) {
+			var body LeaveFederationReplicaInput
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			if body.Preflight {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"status":409,"error":{"code":"not_a_spoke","message":"federation binding is not a spoke"}}`))
+				return
+			}
+			realLeaveRan = true
+			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: true, Disposition: "detach"})
+		},
+	})
+
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.api = NewClient(spoke.URL, spoke.Client())
+	m.list.actor = "operator"
+	m.federationCursor = 0
+	out, _ := m.routeFederationViewKey(keyRune('x'))
+	require.Equal(t, federationModeLeavePreview, out.federationMode)
+	require.NotEqual(t, "archive", out.federationLeaveDraft.Disposition, "this test covers the default detach path")
+
+	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	msg := cmd().(federationLeaveResultMsg)
+
+	require.Error(t, msg.err, "the refused detach must surface before any teardown")
+	assert.Empty(t, hub.revokedEnrollmentIDs,
+		"the hub enrollment must not be revoked when the local detach would be refused")
+	assert.False(t, realLeaveRan, "the real leave must not run after a refused preflight")
 	_ = out
 }
 
@@ -1158,9 +1217,15 @@ func TestFederationLeaveHubRevokeFailureReturnsToPreview(t *testing.T) {
 	})
 	var leaveCalled bool
 	spoke := mockDaemon(t, map[string]http.HandlerFunc{
-		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, _ *http.Request) {
-			leaveCalled = true
-			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: true})
+		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, r *http.Request) {
+			var body LeaveFederationReplicaInput
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			// The non-mutating preflight legitimately precedes the revoke;
+			// only the real teardown call must be blocked by the hub failure.
+			if !body.Preflight {
+				leaveCalled = true
+			}
+			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: !body.Preflight})
 		},
 	})
 

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -1097,6 +1097,24 @@ func TestFederationLeaveHubTargetUsesBindingURLAndToleratesTrailingSlash(t *test
 	assert.False(t, got.Implicit, "a matched catalog entry is not an implicit target")
 }
 
+// TestFederationLeaveHubTargetUnionsCatalogAllowInsecure: a same-origin
+// catalog entry's allow_insecure is the operator's own transport opt-in and
+// must be able to RESTORE the flag when the binding-side value was lost with
+// the credential; the union means the catalog can add but never remove the
+// binding's opt-in.
+func TestFederationLeaveHubTargetUnionsCatalogAllowInsecure(t *testing.T) {
+	m := newTestModel()
+	m.daemonTargets = []daemonTarget{
+		{Name: "hub", URL: "http://hub.internal:7373", Token: "catalog-token", AllowInsecure: true},
+	}
+
+	got := m.federationLeaveHubTarget("http://hub.internal:7373", false)
+
+	assert.Equal(t, "catalog-token", got.Token)
+	assert.True(t, got.AllowInsecure,
+		"same-origin catalog allow_insecure must union into the leave hub target")
+}
+
 func TestFederationLeaveHubTargetNoMatchFallsBackToBindingURL(t *testing.T) {
 	m := newTestModel()
 	m.daemonTargets = []daemonTarget{{Name: "local", Local: true}}

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -1008,6 +1008,60 @@ func TestFederationLeaveEnterRevokesHubEnrollmentThenTearsDownSpoke(t *testing.T
 	assert.Contains(t, rendered, "revoked 1 enrollment")
 }
 
+// TestFederationLeaveArchivePreflightRefusalSkipsRevoke: an archive-leave
+// whose archive would be refused (open issues) must fail BEFORE the hub
+// revoke — otherwise the spoke is left locally bound with a revoked hub
+// token, breaking sync until manual recovery.
+func TestFederationLeaveArchivePreflightRefusalSkipsRevoke(t *testing.T) {
+	hubProject := int64(42)
+	hub := &recordingFederationHubAdmin{
+		enrollments: []FederationEnrollment{
+			{ID: 11, SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4EA", ProjectID: &hubProject},
+		},
+	}
+	restoreFederationHubAdminClient(t, func(
+		_ context.Context,
+		target daemonTarget,
+	) (federationHubAdminAPI, daemonTarget, error) {
+		return hub, target, nil
+	})
+	realLeaveRan := false
+	spoke := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, r *http.Request) {
+			var body LeaveFederationReplicaInput
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			if body.Preflight {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"status":409,"error":{"code":"project_has_open_issues","message":"project has open issues"}}`))
+				return
+			}
+			realLeaveRan = true
+			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: true, Disposition: "archive", Archived: true})
+		},
+	})
+
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.api = NewClient(spoke.URL, spoke.Client())
+	m.list.actor = "operator"
+	m.federationCursor = 0
+	out, _ := m.routeFederationViewKey(keyRune('x'))
+	require.Equal(t, federationModeLeavePreview, out.federationMode)
+	out, _ = out.routeFederationViewKey(keyRune('d')) // toggle disposition to archive
+	require.Equal(t, "archive", out.federationLeaveDraft.Disposition)
+
+	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	msg := cmd().(federationLeaveResultMsg)
+
+	require.Error(t, msg.err, "the refused archive must surface as the leave error")
+	assert.Contains(t, msg.err.Error(), "open issues")
+	assert.Empty(t, hub.revokedEnrollmentIDs,
+		"the hub enrollment must not be revoked when the archive would be refused")
+	assert.False(t, realLeaveRan, "the real leave must not run after a refused preflight")
+	_ = out
+}
+
 func TestFederationLeaveLocalOnlySkipsHubRevoke(t *testing.T) {
 	hub := &recordingFederationHubAdmin{}
 	restoreFederationHubAdminClient(t, func(

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -39,7 +40,7 @@ func TestFederationView_EnterOpensSelectedStatusDetail(t *testing.T) {
 	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
 	m.federationCursor = 0
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 
 	require.Nil(t, cmd)
 	assert.Equal(t, federationModeDetail, out.federationMode)
@@ -231,12 +232,20 @@ func TestFederationBrowse_ReadOnlyDoesNotCreateEnrollment(t *testing.T) {
 	assert.NotContains(t, rendered, enrollmentSecret())
 }
 
-func TestFederationEnroll_NWithCurrentProjectStartsHubSelection(t *testing.T) {
+// TestFederationEnroll_NWithCurrentProjectStartsLocalSelectionCursored: an
+// active project must never skip the local-project step (that hid the
+// create-replica row and silently pre-armed adoption); it only positions the
+// cursor, so the adopt flow costs exactly one Enter more.
+func TestFederationEnroll_NWithCurrentProjectStartsLocalSelectionCursored(t *testing.T) {
 	t.Setenv("KATA_AUTHOR", "")
 	t.Setenv("USER", "operator")
 	m := setupFederationView()
 	m.list.actor = resolveTUIActor()
 	m.scope = homedScope(7, "spoke-project")
+	injectProjects(&m,
+		mockProject{ID: 7, Name: "spoke-project"},
+		mockProject{ID: 9, Name: "other-project"},
+	)
 	m.daemonTargets = []daemonTarget{
 		{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"},
 		{Name: "hub", URL: "https://hub.example", Token: "hub-auth"},
@@ -246,11 +255,24 @@ func TestFederationEnroll_NWithCurrentProjectStartsHubSelection(t *testing.T) {
 	out, cmd := m.routeFederationViewKey(keyRune('n'))
 
 	require.Nil(t, cmd)
+	assert.Equal(t, federationModeSelectLocalProject, out.federationMode)
+	rendered := stripANSI(renderFederation(out))
+	assert.Contains(t, rendered, "create new local replica from hub project",
+		"the replica path must stay reachable with an active project")
+	rows := federationLocalProjectRows(out)
+	require.Greater(t, len(rows), out.federationLocalProjectCursor)
+	cursorRow := rows[out.federationLocalProjectCursor]
+	require.False(t, cursorRow.createReplica, "cursor should pre-position on the active project")
+	assert.Equal(t, "spoke-project", cursorRow.project.Name)
+
+	// One Enter keeps the previous adopt ergonomics.
+	out, cmd = out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
 	assert.Equal(t, federationModeSelectHub, out.federationMode)
 	assert.Equal(t, int64(7), out.federationDraft.SpokeProjectID)
 	assert.Equal(t, "spoke-project", out.federationDraft.SpokeProjectName)
 	assert.True(t, out.federationDraft.AdoptExisting)
-	rendered := stripANSI(renderFederation(out))
+	rendered = stripANSI(renderFederation(out))
 	assert.Contains(t, rendered, "Select hub daemon")
 	assert.Contains(t, rendered, "hub https://hub.example auth token")
 	assert.Equal(t, "operator", out.federationDraft.RequestedActor)
@@ -304,7 +326,7 @@ func TestFederationEnroll_SelectHubThenSelectSameNameHubProjectPreview(t *testin
 	assert.NotContains(t, renderedSelection, "will be created if missing")
 	assert.NotContains(t, renderedSelection, "\n  spoke-project\n")
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 
 	require.Nil(t, cmd)
 	assert.Equal(t, federationModePreview, out.federationMode)
@@ -336,6 +358,7 @@ func TestFederationEnroll_SelectHubLoadsHubAuthPrincipal(t *testing.T) {
 	})
 	m := setupFederationView()
 	m.scope = homedScope(7, "spoke-project")
+	injectProjects(&m, mockProject{ID: 7, Name: "spoke-project"})
 	m.daemonTargets = []daemonTarget{
 		{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"},
 		{Name: "hub", URL: "https://hub.example", Token: "hub-auth"},
@@ -343,6 +366,7 @@ func TestFederationEnroll_SelectHubLoadsHubAuthPrincipal(t *testing.T) {
 	m.activeDaemon = m.daemonTargets[0]
 
 	out, _ := m.routeFederationViewKey(keyRune('n'))
+	out, _ = out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter}) // adopt the pre-cursored active project
 	out.federationHubCursor = 1
 	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
 	require.NotNil(t, cmd)
@@ -367,7 +391,7 @@ func TestFederationEnroll_SelectDifferentHubProjectSkipsSameNameDuplicate(t *tes
 	}
 	m.federationHubProjectCursor = 1
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 
 	require.Nil(t, cmd)
 	assert.Equal(t, federationModePreview, out.federationMode)
@@ -383,7 +407,7 @@ func TestFederationEnroll_SelectDifferentExistingHubProjectStillAdoptsLocalProje
 	m.federationHubProjects = []ProjectSummary{{ID: 42, Name: "hub-project"}}
 	m.federationHubProjectCursor = 1
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 
 	require.Nil(t, cmd)
 	assert.Equal(t, federationModePreview, out.federationMode)
@@ -441,7 +465,7 @@ func TestFederationEnroll_CreateReplicaBranchPreflightsLocalNameConflict(t *test
 	m.federationDraft.HubTarget = daemonTarget{Name: "hub", URL: "https://hub.example"}
 	m.federationHubProjects = []ProjectSummary{{ID: 42, Name: "spoke-project"}}
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 
 	require.Nil(t, cmd)
 	assert.Equal(t, federationModePreview, out.federationMode)
@@ -484,6 +508,7 @@ func TestFederationEnroll_MissingTokenEnvBlocksBeforeMutation(t *testing.T) {
 	t.Setenv(missingHubAuthEnvName(), "")
 	m := setupFederationView()
 	m.scope = homedScope(7, "spoke-project")
+	injectProjects(&m, mockProject{ID: 7, Name: "spoke-project"})
 	m.daemonTargets = []daemonTarget{
 		{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"},
 		{Name: "hub", URL: "https://hub.example", TokenEnv: missingHubAuthEnvName()},
@@ -491,6 +516,7 @@ func TestFederationEnroll_MissingTokenEnvBlocksBeforeMutation(t *testing.T) {
 	m.activeDaemon = m.daemonTargets[0]
 
 	out, _ := m.routeFederationViewKey(keyRune('n'))
+	out, _ = out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter}) // adopt the pre-cursored active project
 	out.federationHubCursor = 1
 	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
 
@@ -502,10 +528,12 @@ func TestFederationEnroll_MissingTokenEnvBlocksBeforeMutation(t *testing.T) {
 func TestFederationEnroll_ActiveDaemonAsHubBlocked(t *testing.T) {
 	m := setupFederationView()
 	m.scope = homedScope(7, "spoke-project")
+	injectProjects(&m, mockProject{ID: 7, Name: "spoke-project"})
 	m.daemonTargets = []daemonTarget{{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"}}
 	m.activeDaemon = m.daemonTargets[0]
 
 	out, _ := m.routeFederationViewKey(keyRune('n'))
+	out, _ = out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter}) // adopt the pre-cursored active project
 	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
 
 	require.Nil(t, cmd)
@@ -526,7 +554,7 @@ func TestFederationEnroll_LocalHubTargetBlocksBeforeMutation(t *testing.T) {
 	}
 	m.federationHubCursor = 1
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 
 	require.Nil(t, cmd)
 	assert.Equal(t, federationModeSelectHub, out.federationMode)
@@ -538,6 +566,7 @@ func TestFederationEnroll_LocalHubTargetBlocksBeforeMutation(t *testing.T) {
 func TestFederationEnroll_PlainHTTPHostnameRequiresCatalogAllowInsecure(t *testing.T) {
 	m := setupFederationView()
 	m.scope = homedScope(7, "spoke-project")
+	injectProjects(&m, mockProject{ID: 7, Name: "spoke-project"})
 	m.daemonTargets = []daemonTarget{
 		{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"},
 		{Name: "hub", URL: "http://hub.internal:7777", Token: "hub-auth"},
@@ -545,6 +574,7 @@ func TestFederationEnroll_PlainHTTPHostnameRequiresCatalogAllowInsecure(t *testi
 	m.activeDaemon = m.daemonTargets[0]
 
 	out, _ := m.routeFederationViewKey(keyRune('n'))
+	out, _ = out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter}) // adopt the pre-cursored active project
 	out.federationHubCursor = 1
 	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
 
@@ -555,7 +585,7 @@ func TestFederationEnroll_PlainHTTPHostnameRequiresCatalogAllowInsecure(t *testi
 func TestFederationEnroll_EnterCreatesEnrollmentAndJoinsSpoke(t *testing.T) {
 	m, joinBody := setupFederationExecutionPreview(t, federationExecutionServerOptions{})
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	require.NotNil(t, cmd)
 	msg := cmd().(federationEnrollResultMsg)
 	out, refresh := updateModel(out, msg)
@@ -577,7 +607,7 @@ func TestFederationEnroll_AdoptSelectedHubJoinsSelectedLocalProjectName(t *testi
 	m.federationDraft.SpokeProjectName = "local-spoke-project"
 	m.federationDraft.HubProjectName = "hub-project"
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	require.NotNil(t, cmd)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
@@ -596,7 +626,7 @@ func TestFederationEnroll_AdoptSelectedHubRecoveryUsesSelectedLocalProjectName(t
 	m.federationDraft.Operation = federationOperationAdoptSelectedHub
 	m.federationDraft.SpokeProjectName = "local-spoke-project"
 	m.federationDraft.HubProjectName = "hub-project"
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	require.NotNil(t, cmd)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
@@ -612,7 +642,7 @@ func TestFederationEnroll_AdoptSelectedHubRecoveryUsesSelectedLocalProjectName(t
 func TestFederationEnroll_ResultShowsBoundActorAndHubMetadata(t *testing.T) {
 	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{})
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	require.NotNil(t, cmd)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
@@ -630,7 +660,7 @@ func TestFederationEnroll_ResultShowsBoundActorAndHubMetadata(t *testing.T) {
 func TestFederationEnroll_MetadataFailureShowsHubLabeledRecoveryAndHidesToken(t *testing.T) {
 	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{metadataStatus: 500})
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	require.NotNil(t, cmd)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
@@ -643,7 +673,7 @@ func TestFederationEnroll_MetadataFailureShowsHubLabeledRecoveryAndHidesToken(t 
 
 func TestFederationEnroll_MetadataFailureRecoveryRevealUsesOnlyAvailableFields(t *testing.T) {
 	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{metadataStatus: 500})
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
 
@@ -670,7 +700,7 @@ func TestFederationEnroll_MetadataFailureRecoveryRevealUsesOnlyAvailableFields(t
 func TestFederationEnroll_JoinFailureShowsSpokeLabeledRecoveryAndHidesToken(t *testing.T) {
 	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{joinStatus: 500})
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	require.NotNil(t, cmd)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
@@ -691,7 +721,7 @@ func TestFederationEnroll_PreEnrollmentFailureReturnsToPreview(t *testing.T) {
 		return nil, daemonTarget{}, errors.New("hub unavailable")
 	})
 
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	require.NotNil(t, cmd)
 	msg := cmd().(federationEnrollResultMsg)
 	out, nextCmd := updateModel(out, msg)
@@ -730,7 +760,7 @@ func TestFederationEnroll_MissingSpokeInstanceBlocksBeforeHubMutation(t *testing
 
 func TestFederationEnroll_JoinFailureRecoveryRevealIsExplicitAndSecretBearing(t *testing.T) {
 	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{joinStatus: 500})
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
 
@@ -758,7 +788,7 @@ func TestFederationEnroll_JoinFailureRecoveryRevealIsExplicitAndSecretBearing(t 
 func TestFederationEnroll_RecoveryCommandPreservesSpokeAllowInsecure(t *testing.T) {
 	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{joinStatus: 500})
 	m.activeDaemon.AllowInsecure = true
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
 
@@ -774,7 +804,7 @@ func TestFederationEnroll_RecoveryCommandPreservesSpokeAuthOnlyAfterReveal(t *te
 	spokeToken := spokeAuthSecret()
 	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{joinStatus: 500})
 	m.activeDaemon.Token = spokeToken
-	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	out, cmd := enterThroughAdoptConfirm(t, m)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
 
@@ -813,6 +843,272 @@ func TestFederationEnroll_RecoveryCommandQuotesShellMetacharacters(t *testing.T)
 	assert.NotContains(t, rendered, "--project spoke;project")
 	assert.NotContains(t, rendered, "--token token$(secret)")
 	assert.NotContains(t, rendered, "--actor hub$(actor)")
+}
+
+func TestFederationLeaveKeyOpensPreviewOnSpokeRowOnly(t *testing.T) {
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.federationCursor = 0
+
+	out, cmd := m.routeFederationViewKey(keyRune('x'))
+
+	require.Nil(t, cmd)
+	assert.Equal(t, federationModeLeavePreview, out.federationMode)
+	assert.Equal(t, "spoke-proj", out.federationLeaveDraft.ProjectName)
+	assert.Equal(t, "http://hub.internal:7777", out.federationLeaveDraft.HubURL)
+	assert.Equal(t, int64(42), out.federationLeaveDraft.HubProjectID)
+	assert.Equal(t, int64(7), out.federationLeaveDraft.ProjectID)
+	assert.Equal(t, "detach", out.federationLeaveDraft.Disposition)
+	assert.Empty(t, out.federationLeaveDraft.BlockedReason)
+}
+
+func TestFederationLeaveKeyDoesNotOpenPreviewOnNonSpokeRow(t *testing.T) {
+	// The list only ever shows spoke rows, but the guard is the contract:
+	// a non-spoke selection must never enter leave preview. Drive the guard
+	// directly by exercising the detail router on a hub status.
+	m := setupFederationViewWithStatuses(federationStatusFixture("hub-only", "hub"))
+	m.federationCursor = 0
+	m.federationMode = federationModeDetail
+
+	out, cmd := m.routeFederationDetailKey(keyRune('x'))
+
+	require.Nil(t, cmd)
+	assert.NotEqual(t, federationModeLeavePreview, out.federationMode)
+	assert.Equal(t, federationModeDetail, out.federationMode)
+}
+
+func TestFederationLeavePreviewRender(t *testing.T) {
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.federationCursor = 0
+	out, _ := m.routeFederationViewKey(keyRune('x'))
+
+	rendered := stripANSI(renderFederation(out))
+
+	assert.Contains(t, rendered, "Leave Federation")
+	assert.Contains(t, rendered, "spoke-proj")
+	assert.Contains(t, rendered, "hub.internal:7777")
+	assert.Contains(t, rendered, "detach")
+	assert.Contains(t, rendered, "revoke")
+	assert.Contains(t, rendered, "[enter] confirm")
+}
+
+func TestFederationLeaveListFooterAdvertisesLeaveKey(t *testing.T) {
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+
+	rendered := stripANSI(renderFederation(m))
+
+	assert.Contains(t, rendered, "[x] leave")
+}
+
+func TestFederationLeavePreviewTogglesDispositionAndLocalOnly(t *testing.T) {
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.federationCursor = 0
+	out, _ := m.routeFederationViewKey(keyRune('x'))
+	require.Equal(t, "detach", out.federationLeaveDraft.Disposition)
+
+	out, cmd := out.routeFederationViewKey(keyRune('d'))
+	require.Nil(t, cmd)
+	assert.Equal(t, "archive", out.federationLeaveDraft.Disposition)
+
+	out, cmd = out.routeFederationViewKey(keyRune('d'))
+	require.Nil(t, cmd)
+	assert.Equal(t, "detach", out.federationLeaveDraft.Disposition)
+
+	out, cmd = out.routeFederationViewKey(keyRune('l'))
+	require.Nil(t, cmd)
+	assert.True(t, out.federationLeaveDraft.LocalOnly)
+	assert.Contains(t, stripANSI(renderFederation(out)), "local-only")
+
+	out, cmd = out.routeFederationViewKey(keyRune('l'))
+	require.Nil(t, cmd)
+	assert.False(t, out.federationLeaveDraft.LocalOnly)
+}
+
+func TestFederationLeavePreviewEscReturnsToList(t *testing.T) {
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.federationCursor = 0
+	out, _ := m.routeFederationViewKey(keyRune('x'))
+	require.Equal(t, federationModeLeavePreview, out.federationMode)
+
+	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	require.Nil(t, cmd)
+	assert.Equal(t, federationModeList, out.federationMode)
+}
+
+func TestFederationLeaveEnterRevokesHubEnrollmentThenTearsDownSpoke(t *testing.T) {
+	hubProject := int64(42)
+	hub := &recordingFederationHubAdmin{
+		enrollments: []FederationEnrollment{
+			{ID: 11, SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4EA", ProjectID: &hubProject},
+		},
+	}
+	restoreFederationHubAdminClient(t, func(
+		_ context.Context,
+		target daemonTarget,
+	) (federationHubAdminAPI, daemonTarget, error) {
+		return hub, target, nil
+	})
+	var leaveBody LeaveFederationReplicaInput
+	spoke := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&leaveBody))
+			// Mirror the real daemon's attributedActor requirement: an empty
+			// actor with no auth principal is rejected with 400. The TUI must
+			// thread the model actor so detach + archive attribution succeed.
+			require.NotEmpty(t, leaveBody.Actor, "leave request body must carry an actor")
+			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: true, Disposition: "detach"})
+		},
+	})
+
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.api = NewClient(spoke.URL, spoke.Client())
+	m.list.actor = "operator"
+	m.federationCursor = 0
+	out, _ := m.routeFederationViewKey(keyRune('x'))
+	require.Equal(t, federationModeLeavePreview, out.federationMode)
+
+	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	msg := cmd().(federationLeaveResultMsg)
+	out, refresh := updateModel(out, msg)
+
+	require.NotNil(t, refresh)
+	require.NoError(t, msg.err)
+	assert.Equal(t, federationModeResult, out.federationMode)
+	assert.Equal(t, []int64{11}, hub.revokedEnrollmentIDs)
+	assert.Equal(t, "detach", leaveBody.Disposition)
+	assert.Equal(t, "operator", leaveBody.Actor)
+	assert.Equal(t, 1, out.federationLeaveResult.RevokedCount)
+	rendered := stripANSI(renderFederation(out))
+	assert.Contains(t, rendered, "Leave Result")
+	assert.Contains(t, rendered, "detached")
+	assert.Contains(t, rendered, "revoked 1 enrollment")
+}
+
+func TestFederationLeaveLocalOnlySkipsHubRevoke(t *testing.T) {
+	hub := &recordingFederationHubAdmin{}
+	restoreFederationHubAdminClient(t, func(
+		_ context.Context,
+		target daemonTarget,
+	) (federationHubAdminAPI, daemonTarget, error) {
+		return hub, target, nil
+	})
+	var leaveBody LeaveFederationReplicaInput
+	spoke := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&leaveBody))
+			// The local teardown route still goes through attributedActor on
+			// the real daemon, so the threaded actor must be present even in
+			// the local-only path.
+			require.NotEmpty(t, leaveBody.Actor, "leave request body must carry an actor")
+			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: true, Disposition: "detach"})
+		},
+	})
+
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.api = NewClient(spoke.URL, spoke.Client())
+	m.list.actor = "operator"
+	m.federationCursor = 0
+	out, _ := m.routeFederationViewKey(keyRune('x'))
+	out, _ = out.routeFederationViewKey(keyRune('l')) // toggle local-only
+	require.True(t, out.federationLeaveDraft.LocalOnly)
+
+	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	msg := cmd().(federationLeaveResultMsg)
+	out, _ = updateModel(out, msg)
+
+	require.NoError(t, msg.err)
+	assert.Equal(t, federationModeResult, out.federationMode)
+	assert.Equal(t, 0, hub.listEnrollmentsCalls)
+	assert.Empty(t, hub.revokedEnrollmentIDs)
+	assert.True(t, out.federationLeaveResult.SkippedRevoke)
+	assert.Contains(t, stripANSI(renderFederation(out)), "hub revoke skipped")
+}
+
+func TestFederationLeaveHubRevokeFailureReturnsToPreview(t *testing.T) {
+	restoreFederationHubAdminClient(t, func(
+		_ context.Context,
+		_ daemonTarget,
+	) (federationHubAdminAPI, daemonTarget, error) {
+		return nil, daemonTarget{}, errors.New("hub unavailable")
+	})
+	var leaveCalled bool
+	spoke := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, _ *http.Request) {
+			leaveCalled = true
+			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: true})
+		},
+	})
+
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.api = NewClient(spoke.URL, spoke.Client())
+	m.federationCursor = 0
+	out, _ := m.routeFederationViewKey(keyRune('x'))
+
+	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	msg := cmd().(federationLeaveResultMsg)
+	out, next := updateModel(out, msg)
+
+	require.Nil(t, next)
+	assert.False(t, leaveCalled, "local teardown must not run when hub revoke fails")
+	assert.Equal(t, federationModeLeavePreview, out.federationMode)
+	require.Error(t, out.federationEnrollErr)
+	assert.Contains(t, out.federationEnrollErr.Error(), "hub revoke failed")
+}
+
+func TestFederationLeaveMatchesActiveEnrollmentsForSpokeInstanceAndHubProject(t *testing.T) {
+	hubProject := int64(42)
+	otherProject := int64(99)
+	revoked := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	enrollments := []FederationEnrollment{
+		{ID: 1, SpokeInstanceUID: "spoke-uid", ProjectID: &hubProject},
+		{ID: 2, SpokeInstanceUID: "spoke-uid", ProjectID: &hubProject, RevokedAt: &revoked},
+		{ID: 3, SpokeInstanceUID: "other-uid", ProjectID: &hubProject},
+		{ID: 4, SpokeInstanceUID: "spoke-uid", ProjectID: &otherProject},
+		{ID: 5, SpokeInstanceUID: "spoke-uid", ProjectID: nil},
+	}
+
+	got, globals := matchFederationLeaveEnrollments(enrollments, "spoke-uid", hubProject)
+
+	assert.Equal(t, []int64{1}, got)
+	assert.Equal(t, []int64{5}, globals,
+		"active global enrollments for this spoke must be surfaced (they still authorize the project) without being auto-revoked")
+}
+
+func TestFederationLeaveHubTargetUsesBindingURLAndToleratesTrailingSlash(t *testing.T) {
+	m := newTestModel()
+	m.daemonTargets = []daemonTarget{
+		{Name: "local", Local: true},
+		// Catalog entry's URL carries a trailing slash and a foreign-looking
+		// path; only its token must be reused.
+		{Name: "hub", URL: "https://bound.example/", Token: "catalog-token"},
+	}
+
+	got := m.federationLeaveHubTarget("https://bound.example", true)
+
+	// Token comes from the matched catalog entry (slash-tolerant match)...
+	assert.Equal(t, "catalog-token", got.Token)
+	// ...but the target URL is pinned to the binding's hub URL, normalized,
+	// and allow_insecure comes from the binding, not the catalog entry.
+	assert.Equal(t, "https://bound.example", got.URL)
+	assert.True(t, got.AllowInsecure, "binding allow_insecure must carry through")
+	assert.False(t, got.Implicit, "a matched catalog entry is not an implicit target")
+}
+
+func TestFederationLeaveHubTargetNoMatchFallsBackToBindingURL(t *testing.T) {
+	m := newTestModel()
+	m.daemonTargets = []daemonTarget{{Name: "local", Local: true}}
+
+	got := m.federationLeaveHubTarget("https://bound.example/", true)
+
+	// The fallback must be unauthenticated and non-implicit: implicit targets
+	// pick up the global daemon token, which must never go to the hub origin.
+	assert.False(t, got.Implicit, "fallback must not be implicit (global-auth pickup)")
+	assert.Equal(t, "https://bound.example", got.URL)
+	assert.Empty(t, got.Token)
+	assert.True(t, got.AllowInsecure, "binding allow_insecure must carry through")
 }
 
 func setupFederationSourceModel() Model {
@@ -999,11 +1295,14 @@ func spokeAuthSecret() string {
 type recordingFederationHubAdmin struct {
 	instance              InstanceInfo
 	projects              []ProjectSummary
+	enrollments           []FederationEnrollment
 	getInstanceCalls      int
 	listProjectsCalls     int
 	ensureProjectCalls    int
 	enableFederationCalls int
 	createEnrollmentCalls int
+	listEnrollmentsCalls  int
+	revokedEnrollmentIDs  []int64
 }
 
 func (h *recordingFederationHubAdmin) GetInstance(_ context.Context) (InstanceInfo, error) {
@@ -1041,6 +1340,21 @@ func (h *recordingFederationHubAdmin) CreateFederationEnrollment(
 	return FederationEnrollment{Token: enrollmentSecret()}, nil
 }
 
+func (h *recordingFederationHubAdmin) ListFederationEnrollments(
+	_ context.Context,
+) ([]FederationEnrollment, error) {
+	h.listEnrollmentsCalls++
+	return h.enrollments, nil
+}
+
+func (h *recordingFederationHubAdmin) RevokeFederationEnrollment(
+	_ context.Context,
+	enrollmentID int64,
+) error {
+	h.revokedEnrollmentIDs = append(h.revokedEnrollmentIDs, enrollmentID)
+	return nil
+}
+
 func restoreFederationHubAdminClient(
 	t *testing.T,
 	replacement func(context.Context, daemonTarget) (federationHubAdminAPI, daemonTarget, error),
@@ -1051,4 +1365,234 @@ func restoreFederationHubAdminClient(
 	t.Cleanup(func() {
 		newFederationHubAdminClient = orig
 	})
+}
+
+// TestFederationRecoveryShowsRealJoinError: the recovery screen must print the
+// actual join error instead of hiding it behind the canned token guess. A
+// non-auth failure (here the rejoin name-mismatch 409) must not be blamed on
+// the enrollment token.
+func TestFederationRecoveryShowsRealJoinError(t *testing.T) {
+	m := setupFederationView()
+	m.federationMode = federationModeRecovery
+	m.federationRecovery = federationRecovery{
+		Stage: "join",
+		Err: fmt.Errorf("spoke: join failed: %w", &APIError{
+			Status:  409,
+			Code:    "federation_rejoin_name_mismatch",
+			Message: `hub project UID is held by local project "spoke-project", which previously left this federation; rerun join with --project "spoke-project" to rejoin it`,
+		}),
+	}
+
+	rendered := stripANSI(renderFederation(m))
+	assert.Contains(t, rendered, "federation_rejoin_name_mismatch")
+	assert.Contains(t, rendered, "previously left")
+	assert.NotContains(t, rendered, "may be single-use",
+		"a non-auth failure must not be blamed on the token")
+}
+
+// TestFederationRecoveryKeepsTokenHintForAuthFailures: 401/403 failures keep
+// the token-oriented hint alongside the real error.
+func TestFederationRecoveryKeepsTokenHintForAuthFailures(t *testing.T) {
+	m := setupFederationView()
+	m.federationMode = federationModeRecovery
+	m.federationRecovery = federationRecovery{
+		Stage: "join",
+		Err:   fmt.Errorf("spoke: join failed: %w", &APIError{Status: 401, Code: "unauthorized", Message: "bearer token rejected"}),
+	}
+
+	rendered := stripANSI(renderFederation(m))
+	assert.Contains(t, rendered, "bearer token rejected")
+	assert.Contains(t, rendered, "may be single-use")
+}
+
+// TestFederationPreviewDetectsRejoinForUIDHolder: selecting a hub project
+// whose UID is already held by an unbound local project must present the
+// operation as a rejoin of that project (it previously left this federation),
+// not as a new local replica that would dead-end on the daemon.
+func TestFederationPreviewDetectsRejoinForUIDHolder(t *testing.T) {
+	m := setupFederationView()
+	m.projectsByID = map[int64]string{7: "spoke-project"}
+	m.projectUIDByID = map[int64]string{7: "01HZNQ7VFPK1XGD8R5MABCD4EX"}
+	m.federationDraft = federationDraft{CreateReplica: true}
+	m.federationHubProjects = []ProjectSummary{{ID: 42, Name: "hub-project", UID: "01HZNQ7VFPK1XGD8R5MABCD4EX"}}
+	m.federationHubProjectCursor = 0
+
+	out, _ := m.previewFederationEnrollment()
+
+	draft := out.federationDraft
+	assert.Equal(t, federationOperationRejoin, draft.Operation)
+	assert.Equal(t, "spoke-project", draft.SpokeProjectName, "rejoin must target the local UID-holder")
+	assert.False(t, draft.AdoptExisting)
+	assert.Empty(t, draft.BlockedReason)
+	assert.Equal(t, "spoke-project", federationReplicaProjectName(draft, "hub-project"),
+		"the join must name the holder, not the hub project")
+	rendered := stripANSI(renderFederation(out))
+	assert.Contains(t, rendered, "rejoin")
+	assert.Contains(t, rendered, "previously left")
+}
+
+// TestFederationPreviewBlocksRejoinWhenHolderStillBound: a UID-holder that
+// still has a live binding is not silently rebound; the preview is blocked
+// with a message naming it.
+func TestFederationPreviewBlocksRejoinWhenHolderStillBound(t *testing.T) {
+	m := setupFederationView()
+	m.projectsByID = map[int64]string{7: "spoke-project"}
+	m.projectUIDByID = map[int64]string{7: "01HZNQ7VFPK1XGD8R5MABCD4EX"}
+	m.federationStatuses = []FederationProjectStatus{{ProjectID: 7, ProjectName: "spoke-project", Role: "spoke"}}
+	m.federationDraft = federationDraft{CreateReplica: true}
+	m.federationHubProjects = []ProjectSummary{{ID: 42, Name: "hub-project", UID: "01HZNQ7VFPK1XGD8R5MABCD4EX"}}
+	m.federationHubProjectCursor = 0
+
+	out, _ := m.previewFederationEnrollment()
+
+	assert.NotEqual(t, federationOperationRejoin, out.federationDraft.Operation)
+	assert.Contains(t, out.federationDraft.BlockedReason, "spoke-project")
+}
+
+// TestFederationPreviewCreateReplicaUnaffectedWithoutUIDMatch: no local
+// UID-holder means the plain create-replica path is unchanged.
+func TestFederationPreviewCreateReplicaUnaffectedWithoutUIDMatch(t *testing.T) {
+	m := setupFederationView()
+	m.projectsByID = map[int64]string{7: "other-project"}
+	m.projectUIDByID = map[int64]string{7: "01HZNQ7VFPK1XGD8R5MABCD4ZZ"}
+	m.federationDraft = federationDraft{CreateReplica: true}
+	m.federationHubProjects = []ProjectSummary{{ID: 42, Name: "hub-project", UID: "01HZNQ7VFPK1XGD8R5MABCD4EX"}}
+	m.federationHubProjectCursor = 0
+
+	out, _ := m.previewFederationEnrollment()
+
+	assert.Equal(t, federationOperationCreateReplica, out.federationDraft.Operation)
+	assert.Empty(t, out.federationDraft.BlockedReason)
+}
+
+// typeFederationKeys feeds individual rune key presses into the federation
+// view router.
+func typeFederationKeys(m Model, text string) Model {
+	out := m
+	for _, r := range text {
+		out, _ = out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	return out
+}
+
+// enterThroughAdoptConfirm presses Enter on the federation view; when that
+// lands in the adoption typed-confirmation gate it types the local project
+// name and confirms. Non-adopt presses pass through unchanged.
+func enterThroughAdoptConfirm(t *testing.T, m Model) (Model, tea.Cmd) {
+	t.Helper()
+	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if out.federationMode != federationModeAdoptConfirm {
+		return out, cmd
+	}
+	require.Nil(t, cmd, "entering the adopt confirmation must not execute")
+	out = typeFederationKeys(out, out.federationDraft.SpokeProjectName)
+	return out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+}
+
+// TestFederationAdoptEnterOpensTypedConfirmation: adoption never executes on a
+// bare Enter; the gate states the INTO relationship, a wrong name keeps it
+// gated, and Esc returns to the preview.
+func TestFederationAdoptEnterOpensTypedConfirmation(t *testing.T) {
+	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{})
+
+	out, cmd := m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd, "adoption must not execute on bare enter")
+	assert.Equal(t, federationModeAdoptConfirm, out.federationMode)
+	rendered := stripANSI(renderFederation(out))
+	assert.Contains(t, rendered, "INTO hub project")
+	assert.Contains(t, rendered, "spoke-project")
+
+	out = typeFederationKeys(out, "wrong-name")
+	out, cmd = out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
+	assert.Equal(t, federationModeAdoptConfirm, out.federationMode)
+	assert.False(t, out.federationEnrollRunning)
+	require.Error(t, out.federationEnrollErr)
+
+	out, _ = out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEsc})
+	assert.Equal(t, federationModePreview, out.federationMode)
+}
+
+// TestFederationAdoptTypedConfirmationExecutes: typing the exact project name
+// and confirming runs the enrollment.
+func TestFederationAdoptTypedConfirmationExecutes(t *testing.T) {
+	m, joinBody := setupFederationExecutionPreview(t, federationExecutionServerOptions{})
+
+	out, cmd := enterThroughAdoptConfirm(t, m)
+	require.NotNil(t, cmd)
+	assert.True(t, out.federationEnrollRunning)
+	msg := cmd().(federationEnrollResultMsg)
+	out, _ = updateModel(out, msg)
+	assert.Equal(t, federationModeResult, out.federationMode)
+	assert.True(t, joinBody.AdoptExisting)
+}
+
+// TestFederationPreviewAdoptFlowDetectsRejoinForUIDHolder: selecting a local
+// project that already shares the target hub project's identity (the
+// post-leave state) must present rejoin, not adoption — adoption would
+// rewrite the project's event history a second time. Covers the adopt-flow
+// branch (local project picked first), which the create-replica-branch
+// detection missed.
+func TestFederationPreviewAdoptFlowDetectsRejoinForUIDHolder(t *testing.T) {
+	m := setupFederationView()
+	m.projectsByID = map[int64]string{7: "spoke-project"}
+	m.projectUIDByID = map[int64]string{7: "01HZNQ7VFPK1XGD8R5MABCD4EX"}
+	m.federationDraft = newFederationDraft("operator")
+	m.federationDraft.SpokeProjectID = 7
+	m.federationDraft.SpokeProjectName = "spoke-project"
+	m.federationHubProjects = []ProjectSummary{{ID: 42, Name: "spoke-project", UID: "01HZNQ7VFPK1XGD8R5MABCD4EX"}}
+	m.federationHubProjectCursor = 0 // adopt-same-name row
+
+	out, _ := m.previewFederationEnrollment()
+
+	draft := out.federationDraft
+	assert.Equal(t, federationOperationRejoin, draft.Operation)
+	assert.False(t, draft.AdoptExisting, "rejoin must not request adoption snapshots")
+	assert.Equal(t, int64(42), draft.HubProjectID)
+	rendered := stripANSI(renderFederation(out))
+	assert.Contains(t, rendered, "previously left")
+	assert.NotContains(t, rendered, "adoption warning")
+}
+
+// TestFederationPreviewAdoptFlowStaysAdoptWithoutUIDMatch: a local project
+// with its own identity adopts normally.
+func TestFederationPreviewAdoptFlowStaysAdoptWithoutUIDMatch(t *testing.T) {
+	m := setupFederationView()
+	m.projectsByID = map[int64]string{7: "spoke-project"}
+	m.projectUIDByID = map[int64]string{7: "01HZNQ7VFPK1XGD8R5MABCD4ZZ"}
+	m.federationDraft = newFederationDraft("operator")
+	m.federationDraft.SpokeProjectID = 7
+	m.federationDraft.SpokeProjectName = "spoke-project"
+	m.federationHubProjects = []ProjectSummary{{ID: 42, Name: "spoke-project", UID: "01HZNQ7VFPK1XGD8R5MABCD4EX"}}
+	m.federationHubProjectCursor = 0
+
+	out, _ := m.previewFederationEnrollment()
+
+	assert.Equal(t, federationOperationAdoptSameName, out.federationDraft.Operation)
+	assert.True(t, out.federationDraft.AdoptExisting)
+}
+
+// TestFetchProjectsCarriesUIDs is the rejoin-detection prerequisite: the
+// boot/refresh list fetch must populate projectUIDByID, otherwise
+// previewFederationEnrollment cannot recognize a UID-holder and silently
+// degrades a rejoin into history-rewriting adoption.
+func TestFetchProjectsCarriesUIDs(t *testing.T) {
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects": func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"projects":[{"id":7,"uid":"01HZNQ7VFPK1XGD8R5MABCD4EX","name":"spoke-project"}]}`))
+		},
+	})
+	m := newTestModel()
+	m.api = NewClient(srv.URL, srv.Client())
+
+	msg, ok := m.fetchProjects()().(projectsLoadedMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.err)
+	assert.Equal(t, "spoke-project", msg.projects[7])
+	assert.Equal(t, "01HZNQ7VFPK1XGD8R5MABCD4EX", msg.uids[7],
+		"fetchProjects must carry project UIDs for rejoin detection")
+
+	// And the loaded handler must apply them to projectUIDByID.
+	out, _ := updateModel(m, msg)
+	assert.Equal(t, "01HZNQ7VFPK1XGD8R5MABCD4EX", out.projectUIDByID[7])
 }

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -278,6 +278,29 @@ func TestFederationEnroll_NWithCurrentProjectStartsLocalSelectionCursored(t *tes
 	assert.Equal(t, "operator", out.federationDraft.RequestedActor)
 }
 
+// TestFederationEnroll_ScopedProjectAdoptableWithEmptyProjectCache: the boot
+// project-list fetch is asynchronous and can fail, so the scoped project must
+// be adoptable from scope state alone — an empty projectsByID cache must not
+// reduce the enroll flow to "create replica" only.
+func TestFederationEnroll_ScopedProjectAdoptableWithEmptyProjectCache(t *testing.T) {
+	m := setupFederationView()
+	m.scope = homedScope(7, "spoke-project")
+	// No injectProjects: simulate pressing `n` before projectsLoadedMsg (or
+	// after a failed boot fetch).
+
+	out, cmd := m.routeFederationViewKey(keyRune('n'))
+
+	require.Nil(t, cmd)
+	require.Equal(t, federationModeSelectLocalProject, out.federationMode)
+	rows := federationLocalProjectRows(out)
+	require.Greater(t, len(rows), out.federationLocalProjectCursor)
+	cursorRow := rows[out.federationLocalProjectCursor]
+	require.False(t, cursorRow.createReplica,
+		"scoped project must be selectable (and pre-positioned) without the project cache")
+	assert.Equal(t, "spoke-project", cursorRow.project.Name)
+	assert.Equal(t, int64(7), cursorRow.project.ID)
+}
+
 func TestFederationEnroll_NWithoutProjectStartsLocalProjectSelection(t *testing.T) {
 	m := setupFederationView()
 	m.scope = scope{allProjects: true}

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -1568,6 +1568,29 @@ func TestFederationAdoptTypedConfirmationExecutes(t *testing.T) {
 	assert.True(t, joinBody.AdoptExisting)
 }
 
+// TestFederationPreviewAdoptFlowBlocksWithoutLocalUID: when the selected
+// local project's UID is not yet known (the async project-list fetch has not
+// landed, or it failed), the adopt-first preview cannot distinguish genuine
+// adoption from a post-leave rejoin. It must block rather than default to
+// adoption, which would rewrite the project's event history.
+func TestFederationPreviewAdoptFlowBlocksWithoutLocalUID(t *testing.T) {
+	m := setupFederationView()
+	m.projectsByID = map[int64]string{7: "spoke-project"}
+	// projectUIDByID intentionally unseeded: the boot race window.
+	m.federationDraft = newFederationDraft("operator")
+	m.federationDraft.SpokeProjectID = 7
+	m.federationDraft.SpokeProjectName = "spoke-project"
+	m.federationHubProjects = []ProjectSummary{{ID: 42, Name: "spoke-project", UID: "01HZNQ7VFPK1XGD8R5MABCD4EX"}}
+	m.federationHubProjectCursor = 0 // adopt-same-name row
+
+	out, _ := m.previewFederationEnrollment()
+
+	draft := out.federationDraft
+	assert.NotEmpty(t, draft.BlockedReason,
+		"unknown local project UID must block adoption, not silently proceed with it")
+	assert.NotEqual(t, federationOperationRejoin, draft.Operation)
+}
+
 // TestFederationPreviewAdoptFlowDetectsRejoinForUIDHolder: selecting a local
 // project that already shares the target hub project's identity (the
 // post-leave state) must present rejoin, not adoption — adoption would

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -1608,6 +1608,37 @@ func TestFederationAdoptEnterOpensTypedConfirmation(t *testing.T) {
 	assert.Equal(t, federationModePreview, out.federationMode)
 }
 
+// TestFederationAdoptConfirmTypesSpaces: project names may contain spaces
+// (ValidateProjectName rejects only non-printables), so the typed
+// confirmation gate must accept the space key in every event shape: unix
+// terminals deliver KeySpace WITH Runes{' '} (bubbletea v1.3.10 keeps the
+// rune "for backwards compatibility"), Windows delivers KeyRunes, and a
+// runeless KeySpace — a hand-built message or a future input backend — must
+// not silently drop the character.
+func TestFederationAdoptConfirmTypesSpaces(t *testing.T) {
+	newConfirm := func() Model {
+		m := setupFederationView()
+		m.federationMode = federationModeAdoptConfirm
+		m.federationDraft = newFederationDraft("operator")
+		m.federationDraft.SpokeProjectName = "spoke project"
+		return m
+	}
+
+	t.Run("runeless KeySpace appends a space", func(t *testing.T) {
+		m := typeFederationKeys(newConfirm(), "spoke")
+		m, _ = m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeySpace})
+		m = typeFederationKeys(m, "project")
+		assert.Equal(t, "spoke project", m.federationAdoptConfirmInput)
+	})
+
+	t.Run("unix-shape KeySpace with rune appends one space", func(t *testing.T) {
+		m := typeFederationKeys(newConfirm(), "spoke")
+		m, _ = m.routeFederationViewKey(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
+		m = typeFederationKeys(m, "project")
+		assert.Equal(t, "spoke project", m.federationAdoptConfirmInput)
+	})
+}
+
 // TestFederationAdoptTypedConfirmationExecutes: typing the exact project name
 // and confirming runs the enrollment.
 func TestFederationAdoptTypedConfirmationExecutes(t *testing.T) {

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -1030,7 +1030,7 @@ func TestFederationLeaveAbortsWhenOnlyForeignEnrollmentsMatchProject(t *testing.
 	})
 	realLeaveRan := false
 	spoke := mockDaemon(t, map[string]http.HandlerFunc{
-		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, r *http.Request) {
+		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, _ *http.Request) {
 			realLeaveRan = true
 			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: true, Disposition: "detach"})
 		},

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -1008,6 +1008,52 @@ func TestFederationLeaveEnterRevokesHubEnrollmentThenTearsDownSpoke(t *testing.T
 	assert.Contains(t, rendered, "revoked 1 enrollment")
 }
 
+// TestFederationLeaveAbortsWhenOnlyForeignEnrollmentsMatchProject: when no
+// active enrollment matches this spoke's instance UID but the hub project
+// still has active project-scoped enrollment(s), the leave must abort before
+// local teardown instead of treating zero matches as success — the instance
+// UID can drift from the enrollment's (clone/import refresh or an explicit
+// --spoke-instance enroll), and proceeding would strand a live token.
+func TestFederationLeaveAbortsWhenOnlyForeignEnrollmentsMatchProject(t *testing.T) {
+	hubProject := int64(42)
+	hub := &recordingFederationHubAdmin{
+		enrollments: []FederationEnrollment{
+			// Active, project-scoped, but for a different spoke instance.
+			{ID: 21, SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4FF", ProjectID: &hubProject},
+		},
+	}
+	restoreFederationHubAdminClient(t, func(
+		_ context.Context,
+		target daemonTarget,
+	) (federationHubAdminAPI, daemonTarget, error) {
+		return hub, target, nil
+	})
+	realLeaveRan := false
+	spoke := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/federation/replicas/7/actions/leave": func(w http.ResponseWriter, r *http.Request) {
+			realLeaveRan = true
+			respondJSON(t, w, api.LeaveFederationReplicaResultBody{Detached: true, Disposition: "detach"})
+		},
+	})
+
+	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
+	m.api = NewClient(spoke.URL, spoke.Client())
+	m.list.actor = "operator"
+	m.federationCursor = 0
+	out, _ := m.routeFederationViewKey(keyRune('x'))
+	require.Equal(t, federationModeLeavePreview, out.federationMode)
+
+	out, cmd := out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	msg := cmd().(federationLeaveResultMsg)
+
+	require.Error(t, msg.err)
+	assert.Contains(t, msg.err.Error(), "#21", "the surviving enrollment ID must be named")
+	assert.Empty(t, hub.revokedEnrollmentIDs, "a foreign-instance enrollment must not be auto-revoked")
+	assert.False(t, realLeaveRan, "local teardown must not run after the abort")
+	_ = out
+}
+
 // TestFederationLeaveArchivePreflightRefusalSkipsRevoke: an archive-leave
 // whose archive would be refused (open issues) must fail BEFORE the hub
 // revoke — otherwise the spoke is left locally bound with a revoked hub
@@ -1147,11 +1193,13 @@ func TestFederationLeaveMatchesActiveEnrollmentsForSpokeInstanceAndHubProject(t 
 		{ID: 5, SpokeInstanceUID: "spoke-uid", ProjectID: nil},
 	}
 
-	got, globals := matchFederationLeaveEnrollments(enrollments, "spoke-uid", hubProject)
+	got, globals, foreign := matchFederationLeaveEnrollments(enrollments, "spoke-uid", hubProject)
 
 	assert.Equal(t, []int64{1}, got)
 	assert.Equal(t, []int64{5}, globals,
 		"active global enrollments for this spoke must be surfaced (they still authorize the project) without being auto-revoked")
+	assert.Equal(t, []int64{3}, foreign,
+		"active project-scoped enrollments for other spoke instances must be surfaced so a zero-match leave can refuse instead of stranding them")
 }
 
 func TestFederationLeaveHubTargetUsesBindingURLAndToleratesTrailingSlash(t *testing.T) {
@@ -1673,6 +1721,29 @@ func TestFederationPreviewAdoptFlowBlocksWithoutLocalUID(t *testing.T) {
 	draft := out.federationDraft
 	assert.NotEmpty(t, draft.BlockedReason,
 		"unknown local project UID must block adoption, not silently proceed with it")
+	assert.NotEqual(t, federationOperationRejoin, draft.Operation)
+}
+
+// TestFederationPreviewAdoptFlowBlocksWithoutHubUID: an unknown HUB project
+// UID disables the rejoin comparison just like an unknown local UID — the
+// preview must block rather than default to adoption, which could rewrite a
+// post-leave project's event history.
+func TestFederationPreviewAdoptFlowBlocksWithoutHubUID(t *testing.T) {
+	m := setupFederationView()
+	m.projectsByID = map[int64]string{7: "spoke-project"}
+	m.projectUIDByID = map[int64]string{7: "01HZNQ7VFPK1XGD8R5MABCD4EX"}
+	m.federationDraft = newFederationDraft("operator")
+	m.federationDraft.SpokeProjectID = 7
+	m.federationDraft.SpokeProjectName = "spoke-project"
+	// Hub row carries no UID (e.g. an older hub daemon's project list).
+	m.federationHubProjects = []ProjectSummary{{ID: 42, Name: "spoke-project"}}
+	m.federationHubProjectCursor = 0 // adopt-same-name row
+
+	out, _ := m.previewFederationEnrollment()
+
+	draft := out.federationDraft
+	assert.NotEmpty(t, draft.BlockedReason,
+		"unknown hub project UID must block adoption, not silently proceed with it")
 	assert.NotEqual(t, federationOperationRejoin, draft.Operation)
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -252,6 +252,7 @@ type labelsFetchedMsg struct {
 type projectsLoadedMsg struct {
 	connGen  uint64
 	projects map[int64]string
+	uids     map[int64]string
 	idents   map[int64]string
 	stats    map[int64]ProjectStatsSummary
 	err      error
@@ -279,6 +280,13 @@ type federationEnrollResultMsg struct {
 	connGen uint64
 	attempt uint64
 	result  federationEnrollResult
+	err     error
+}
+
+type federationLeaveResultMsg struct {
+	connGen uint64
+	attempt uint64
+	result  federationLeaveResult
 	err     error
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -123,6 +123,11 @@ type Model struct {
 	// owning project's name. Stays nil-safe — a missing entry renders
 	// as a numeric "[#N]" prefix instead of crashing.
 	projectsByID map[int64]string
+	// projectUIDByID maps project_id → project UID alongside projectsByID.
+	// The federation enroll flow compares these against a hub project's UID
+	// to recognize a rejoin (a local project that previously left the hub
+	// project's federation still shares its UID). nil-safe like projectsByID.
+	projectUIDByID map[int64]string
 	// projectStats is the per-project aggregate cache populated by
 	// fetchProjectsWithStats. nil-safe: viewProjects renders rows for
 	// projects in projectsByID even if their stats haven't loaded yet.
@@ -157,8 +162,14 @@ type Model struct {
 	federationEnrollGen           uint64
 	federationEnrollAttempt       uint64
 	federationEnrollRunning       bool
+	federationAdoptConfirmInput   string
 	federationResult              federationEnrollResult
 	federationRecovery            federationRecovery
+	federationLeaveDraft          federationLeaveDraft
+	federationLeaveResult         federationLeaveResult
+	federationLeaveAttempt        uint64
+	federationLeaveRunning        bool
+	federationResultIsLeave       bool
 	// layout is the EFFECTIVE rendered layout — what the View functions
 	// actually draw. Re-evaluated on every WindowSizeMsg via
 	// resolveLayout, which consults preferredLayout + layoutLocked +
@@ -304,10 +315,16 @@ func (m Model) fetchProjects() tea.Cmd {
 			return projectsLoadedMsg{connGen: connGen, err: err}
 		}
 		out := make(map[int64]string, len(summaries))
+		uids := make(map[int64]string, len(summaries))
 		for _, p := range summaries {
 			out[p.ID] = p.Name
+			uids[p.ID] = p.UID
 		}
-		return projectsLoadedMsg{connGen: connGen, projects: out}
+		// uids must ride alongside projects: the federation enroll flow reads
+		// projectUIDByID to detect a rejoin (a local UID-holder). Without it the
+		// boot/refresh path leaves the UID cache stale and rejoin silently
+		// degrades to history-rewriting adoption.
+		return projectsLoadedMsg{connGen: connGen, projects: out, uids: uids}
 	}
 }
 
@@ -433,6 +450,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if pl.projects != nil {
 			m.projectsByID = pl.projects
 		}
+		if pl.uids != nil {
+			m.projectUIDByID = pl.uids
+		}
 		if pl.idents != nil {
 			m.projectIdentByID = pl.idents
 		}
@@ -468,6 +488,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	if fer, ok := msg.(federationEnrollResultMsg); ok {
 		next, cmd := m.handleFederationEnrollResult(fer)
+		return next, cmd
+	}
+	if flr, ok := msg.(federationLeaveResultMsg); ok {
+		next, cmd := m.handleFederationLeaveResult(flr)
 		return next, cmd
 	}
 	if _, ok := msg.(projectsDebounceFireMsg); ok {

--- a/internal/tui/projects_view.go
+++ b/internal/tui/projects_view.go
@@ -35,10 +35,12 @@ func (m Model) fetchProjectsWithStats() tea.Cmd {
 			return projectsLoadedMsg{connGen: connGen, err: err, gen: gen}
 		}
 		names := make(map[int64]string, len(rows))
+		uids := make(map[int64]string, len(rows))
 		idents := make(map[int64]string, len(rows))
 		stats := make(map[int64]ProjectStatsSummary, len(rows))
 		for _, r := range rows {
 			names[r.ID] = r.Name
+			uids[r.ID] = r.UID
 			idents[r.ID] = r.Name
 			if r.Stats != nil {
 				stats[r.ID] = *r.Stats
@@ -47,6 +49,7 @@ func (m Model) fetchProjectsWithStats() tea.Cmd {
 		return projectsLoadedMsg{
 			connGen:  connGen,
 			projects: names,
+			uids:     uids,
 			idents:   idents,
 			stats:    stats,
 			gen:      gen,

--- a/internal/tui/projects_view_test.go
+++ b/internal/tui/projects_view_test.go
@@ -142,6 +142,16 @@ func TestProjectsView_FTransitionsToFederationWithHighlightedProjectSelected(t *
 	out, cmd = out.routeFederationViewKey(keyRune('n'))
 
 	require.Nil(t, cmd)
+	// The local-project step is shown with the highlighted project pre-cursored
+	// (never skipped); one Enter proceeds to hub selection with it adopted.
+	assert.Equal(t, federationModeSelectLocalProject, out.federationMode)
+	rows := federationLocalProjectRows(out)
+	require.Greater(t, len(rows), out.federationLocalProjectCursor)
+	require.False(t, rows[out.federationLocalProjectCursor].createReplica)
+	assert.Equal(t, "beta-project", rows[out.federationLocalProjectCursor].project.Name)
+
+	out, cmd = out.routeFederationViewKey(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
 	assert.Equal(t, federationModeSelectHub, out.federationMode)
 	assert.Equal(t, int64(22), out.federationDraft.SpokeProjectID)
 	assert.Equal(t, "beta-project", out.federationDraft.SpokeProjectName)

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -257,6 +257,17 @@ func bootResolveScope(ctx context.Context, c *Client, cwd string) (bootInit, err
 				homeProjectID:   rr.Project.ID,
 				homeProjectName: rr.Project.Name,
 			},
+			// Seed the cache maps with the resolved project so its UID is
+			// known from the first frame — the enroll flow's rejoin detection
+			// must not wait on the async project-list fetch. The full fetch
+			// replaces these maps when it lands.
+			projects: []ProjectSummaryWithStats{{
+				ProjectSummary: ProjectSummary{
+					ID:   rr.Project.ID,
+					Name: rr.Project.Name,
+					UID:  rr.Project.UID,
+				},
+			}},
 			view: viewList,
 		}, nil
 	}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -138,10 +138,12 @@ func buildRunModel(opts Options, c *Client, bi bootInit, conns ...daemonConnecti
 	}
 	if len(bi.projects) > 0 {
 		m.projectsByID = make(map[int64]string, len(bi.projects))
+		m.projectUIDByID = make(map[int64]string, len(bi.projects))
 		m.projectIdentByID = make(map[int64]string, len(bi.projects))
 		m.projectStats = make(map[int64]ProjectStatsSummary, len(bi.projects))
 		for _, r := range bi.projects {
 			m.projectsByID[r.ID] = r.Name
+			m.projectUIDByID[r.ID] = r.UID
 			m.projectIdentByID[r.ID] = r.Name
 			if r.Stats != nil {
 				m.projectStats[r.ID] = *r.Stats

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -196,6 +196,30 @@ func TestBoot_UnresolvedWithProjects_LandsViewProjects(t *testing.T) {
 	assert.Equal(t, "kata", bi.projects[0].Name)
 }
 
+// TestBootScopedResolveSeedsProjectUID: a TUI launched inside a project must
+// know that project's UID from the first frame. The adopt-first enroll flow's
+// rejoin detection reads projectUIDByID; before the async project-list fetch
+// lands, an unseeded cache would let a post-leave adoption rewrite the
+// project's history instead of rebinding it.
+func TestBootScopedResolveSeedsProjectUID(t *testing.T) {
+	c := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/projects/resolve", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(
+			`{"project":{"id":7,"uid":"01HZNQ7VFPK1XGD8R5MABCD4EX","name":"spoke-project"},"workspace_root":"/tmp/ws"}`))
+	})
+
+	bi, err := bootResolveScope(t.Context(), c, "/tmp/ws")
+	require.NoError(t, err)
+	assert.Equal(t, viewList, bi.view)
+	assert.Equal(t, int64(7), bi.scope.projectID)
+
+	m := buildRunModel(Options{}, c, bi)
+	assert.Equal(t, "spoke-project", m.projectsByID[7])
+	assert.Equal(t, "01HZNQ7VFPK1XGD8R5MABCD4EX", m.projectUIDByID[7],
+		"scoped boot must seed the resolved project's UID for rejoin detection")
+}
+
 // TestBuildRunModel_SeedsViewProjectsCacheFromBoot pins that when boot
 // lands on viewProjects, the initial model's cache maps are populated
 // from the boot fetch — no empty-then-fill flicker on the first frame.

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -142,6 +142,9 @@ type ClientInterface interface {
 	CreateFederationReplica(ctx context.Context, options *CreateFederationReplicaRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateFederationReplicaResponse, error)
 	CreateFederationReplicaWithResponse(ctx context.Context, options *CreateFederationReplicaRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateFederationReplicaResp, error)
 
+	LeaveFederationReplica(ctx context.Context, options *LeaveFederationReplicaRequestOptions, reqEditors ...runtime.RequestEditorFn) (*LeaveFederationReplicaResponse, error)
+	LeaveFederationReplicaWithResponse(ctx context.Context, options *LeaveFederationReplicaRequestOptions, reqEditors ...runtime.RequestEditorFn) (*LeaveFederationReplicaResp, error)
+
 	GetFederationStatus(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResponse, error)
 	GetFederationStatusWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResp, error)
 
@@ -833,6 +836,69 @@ func (c *Client) CreateFederationReplica(ctx context.Context, options *CreateFed
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/federation/replicas")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) LeaveFederationReplica(ctx context.Context, options *LeaveFederationReplicaRequestOptions, reqEditors ...runtime.RequestEditorFn) (*LeaveFederationReplicaResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/federation/replicas/{project_id}/actions/leave",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*LeaveFederationReplicaResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(LeaveFederationReplicaErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "LeaveFederationReplicaErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(LeaveFederationReplicaResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "LeaveFederationReplicaResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/federation/replicas/{project_id}/actions/leave")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -145,8 +145,8 @@ type ClientInterface interface {
 	LeaveFederationReplica(ctx context.Context, options *LeaveFederationReplicaRequestOptions, reqEditors ...runtime.RequestEditorFn) (*LeaveFederationReplicaResponse, error)
 	LeaveFederationReplicaWithResponse(ctx context.Context, options *LeaveFederationReplicaRequestOptions, reqEditors ...runtime.RequestEditorFn) (*LeaveFederationReplicaResp, error)
 
-	GetFederationStatus(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResponse, error)
-	GetFederationStatusWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResp, error)
+	GetFederationStatus(ctx context.Context, options *GetFederationStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResponse, error)
+	GetFederationStatusWithResponse(ctx context.Context, options *GetFederationStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResp, error)
 
 	Health(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*HealthResponse, error)
 	HealthWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*HealthResp, error)
@@ -905,11 +905,17 @@ func (c *Client) LeaveFederationReplica(ctx context.Context, options *LeaveFeder
 	return responseParser(ctx, resp)
 }
 
-func (c *Client) GetFederationStatus(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResponse, error) {
+func (c *Client) GetFederationStatus(ctx context.Context, options *GetFederationStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResponse, error) {
 	var err error
+
+	queryEncoding := map[string]runtime.QueryEncoding{
+		"include": {Style: "form", Explode: &[]bool{false}[0]},
+	}
 	reqParams := runtime.RequestOptionsParameters{
-		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/federation/status",
-		Method:     "GET",
+		RequestURL:    c.apiClient.GetBaseURL() + "/api/v1/federation/status",
+		Method:        "GET",
+		Options:       options,
+		QueryEncoding: queryEncoding,
 	}
 
 	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -323,6 +323,68 @@ func (o *CreateFederationReplicaRequestOptions) GetHeader() (map[string]string, 
 	return nil, nil
 }
 
+// LeaveFederationReplicaRequestOptions is the options needed to make a request to LeaveFederationReplica.
+type LeaveFederationReplicaRequestOptions struct {
+	PathParams *LeaveFederationReplicaPath
+	Body       *LeaveFederationReplicaBody
+	Header     *LeaveFederationReplicaHeaders
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *LeaveFederationReplicaRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+
+	if o.Header != nil {
+		if v, ok := any(o.Header).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Header", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *LeaveFederationReplicaRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *LeaveFederationReplicaRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *LeaveFederationReplicaRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *LeaveFederationReplicaRequestOptions) GetHeader() (map[string]string, error) {
+	return runtime.AsMap[string](o.Header)
+}
+
 // ListAllIssuesRequestOptions is the options needed to make a request to ListAllIssues.
 type ListAllIssuesRequestOptions struct {
 	Query *ListAllIssuesQuery

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -385,6 +385,50 @@ func (o *LeaveFederationReplicaRequestOptions) GetHeader() (map[string]string, e
 	return runtime.AsMap[string](o.Header)
 }
 
+// GetFederationStatusRequestOptions is the options needed to make a request to GetFederationStatus.
+type GetFederationStatusRequestOptions struct {
+	Query *GetFederationStatusQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetFederationStatusRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetFederationStatusRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetFederationStatusRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetFederationStatusRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetFederationStatusRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // ListAllIssuesRequestOptions is the options needed to make a request to ListAllIssues.
 type ListAllIssuesRequestOptions struct {
 	Query *ListAllIssuesQuery

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -431,11 +431,12 @@ func (c *Client) LeaveFederationReplicaWithResponse(ctx context.Context, options
 	}
 }
 
-func (c *Client) GetFederationStatusWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResp, error) {
+func (c *Client) GetFederationStatusWithResponse(ctx context.Context, options *GetFederationStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResp, error) {
 	var err error
 	reqParams := runtime.RequestOptionsParameters{
 		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/federation/status",
 		Method:     "GET",
+		Options:    options,
 	}
 
 	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -382,6 +382,55 @@ func (c *Client) CreateFederationReplicaWithResponse(ctx context.Context, option
 	}
 }
 
+func (c *Client) LeaveFederationReplicaWithResponse(ctx context.Context, options *LeaveFederationReplicaRequestOptions, reqEditors ...runtime.RequestEditorFn) (*LeaveFederationReplicaResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/federation/replicas/{project_id}/actions/leave",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/federation/replicas/{project_id}/actions/leave")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &LeaveFederationReplicaResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(LeaveFederationReplicaResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "LeaveFederationReplicaResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 func (c *Client) GetFederationStatusWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*GetFederationStatusResp, error) {
 	var err error
 	reqParams := runtime.RequestOptionsParameters{

--- a/pkg/client/generated/headers.go
+++ b/pkg/client/generated/headers.go
@@ -7,6 +7,10 @@ type StreamEventsHeaders struct {
 	LastEventID *int64 `json:"Last-Event-ID,omitempty"`
 }
 
+type LeaveFederationReplicaHeaders struct {
+	XKataConfirm *string `json:"X-Kata-Confirm,omitempty"`
+}
+
 type PollFederationProjectEventsHeaders struct {
 	Authorization *string `json:"Authorization,omitempty"`
 }

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -10,6 +10,10 @@ type RevokeFederationEnrollmentPath struct {
 	EnrollmentID int64 `json:"enrollment_id"`
 }
 
+type LeaveFederationReplicaPath struct {
+	ProjectID int64 `json:"project_id"`
+}
+
 type ShowIssueByUIDPath struct {
 	UID string `json:"uid" validate:"required"`
 }

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -4,6 +4,8 @@ package generated
 
 type CreateFederationEnrollmentBody = CreateFederationEnrollmentRequestBody
 
+type LeaveFederationReplicaBody = LeaveFederationReplicaRequestBody
+
 type InitProjectBody = InitProjectRequestBody
 
 type ResolveProjectBody = ResolveProjectRequestBody

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -45,6 +45,10 @@ type StreamEventsQuery struct {
 	ProjectID *int64 `json:"project_id,omitempty"`
 }
 
+type GetFederationStatusQuery struct {
+	Include *string `json:"include,omitempty"`
+}
+
 type ListAllIssuesQuery struct {
 	ProjectID *int64                    `json:"project_id,omitempty"`
 	Status    *ListAllIssuesQueryStatus `json:"status,omitempty"`

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -37,6 +37,10 @@ type CreateFederationReplicaResponse = CreateFederationReplicaBody
 
 type CreateFederationReplicaErrorResponse = ErrorEnvelope
 
+type LeaveFederationReplicaResponse = LeaveFederationReplicaResultBody
+
+type LeaveFederationReplicaErrorResponse = ErrorEnvelope
+
 type GetFederationStatusResponse = FederationStatusBody
 
 type GetFederationStatusErrorResponse = ErrorEnvelope
@@ -340,6 +344,13 @@ type CreateFederationReplicaResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *CreateFederationReplicaResponse
+}
+
+type LeaveFederationReplicaResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *LeaveFederationReplicaResponse
 }
 
 type GetFederationStatusResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -7477,6 +7477,7 @@ type LeaveFederationReplicaRequestBody struct {
 	Actor       *string `json:"actor,omitempty"`
 	Disposition *string `json:"disposition,omitempty"`
 	Force       *bool   `json:"force,omitempty"`
+	Preflight   *bool   `json:"preflight,omitempty"`
 }
 
 type LeaveFederationReplicaResultBody struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -7473,6 +7473,133 @@ func (l LabelsListResponseBody) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
+type LeaveFederationReplicaRequestBody struct {
+	Actor       *string `json:"actor,omitempty"`
+	Disposition *string `json:"disposition,omitempty"`
+	Force       *bool   `json:"force,omitempty"`
+}
+
+type LeaveFederationReplicaResultBody struct {
+	Archived             *bool          `json:"archived,omitempty"`
+	Detached             bool           `json:"detached"`
+	Disposition          string         `json:"disposition" validate:"required"`
+	Project              ProjectOut     `json:"project"`
+	AdditionalProperties map[string]any `json:"-"`
+}
+
+func (l LeaveFederationReplicaResultBody) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(l.Disposition, "required"); err != nil {
+		errors = errors.Append("Disposition", err)
+	}
+	if v, ok := any(l.Project).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Project", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+// Getter for additional properties for LeaveFederationReplicaResultBody. Returns the specified
+// element and whether it was found
+func (l LeaveFederationReplicaResultBody) Get(fieldName string) (value any, found bool) {
+	if l.AdditionalProperties != nil {
+		value, found = l.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for LeaveFederationReplicaResultBody
+func (l *LeaveFederationReplicaResultBody) Set(fieldName string, value any) {
+	if l.AdditionalProperties == nil {
+		l.AdditionalProperties = make(map[string]any)
+	}
+	l.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for LeaveFederationReplicaResultBody to handle AdditionalProperties
+func (l *LeaveFederationReplicaResultBody) UnmarshalJSON(data []byte) error {
+	object := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &object); err != nil {
+		return err
+	}
+
+	if raw, found := object["archived"]; found {
+		if err := json.Unmarshal(raw, &l.Archived); err != nil {
+			return fmt.Errorf("error reading 'archived': %w", err)
+		}
+		delete(object, "archived")
+	}
+	if raw, found := object["detached"]; found {
+		if err := json.Unmarshal(raw, &l.Detached); err != nil {
+			return fmt.Errorf("error reading 'detached': %w", err)
+		}
+		delete(object, "detached")
+	}
+	if raw, found := object["disposition"]; found {
+		if err := json.Unmarshal(raw, &l.Disposition); err != nil {
+			return fmt.Errorf("error reading 'disposition': %w", err)
+		}
+		delete(object, "disposition")
+	}
+	if raw, found := object["project"]; found {
+		if err := json.Unmarshal(raw, &l.Project); err != nil {
+			return fmt.Errorf("error reading 'project': %w", err)
+		}
+		delete(object, "project")
+	}
+	if len(object) != 0 {
+		l.AdditionalProperties = make(map[string]any)
+		for fieldName, fieldBuf := range object {
+			var fieldVal any
+			if err := json.Unmarshal(fieldBuf, &fieldVal); err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			l.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for LeaveFederationReplicaResultBody to handle AdditionalProperties
+func (l LeaveFederationReplicaResultBody) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if l.Archived != nil {
+		object["archived"], err = json.Marshal(l.Archived)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'archived': %w", err)
+		}
+	}
+
+	object["detached"], err = json.Marshal(l.Detached)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'detached': %w", err)
+	}
+
+	object["disposition"], err = json.Marshal(l.Disposition)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'disposition': %w", err)
+	}
+
+	object["project"], err = json.Marshal(l.Project)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'project': %w", err)
+	}
+
+	for fieldName, field := range l.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
 type LinkChanges struct {
 	BlockedByAdded       []LinkPeer     `json:"blocked_by_added,omitempty"`
 	BlockedByRemoved     []LinkPeer     `json:"blocked_by_removed,omitempty"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -3224,6 +3224,12 @@ paths:
   /api/v1/federation/status:
     get:
       operationId: getFederationStatus
+      parameters:
+        - explode: false
+          in: query
+          name: include
+          schema:
+            type: string
       responses:
         "200":
           content:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -1816,6 +1816,8 @@ components:
           type: string
         force:
           type: boolean
+        preflight:
+          type: boolean
       type: object
     LeaveFederationReplicaResultBody:
       additionalProperties: true

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -1807,6 +1807,32 @@ components:
       required:
         - labels
       type: object
+    LeaveFederationReplicaRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        disposition:
+          type: string
+        force:
+          type: boolean
+      type: object
+    LeaveFederationReplicaResultBody:
+      additionalProperties: true
+      properties:
+        archived:
+          type: boolean
+        detached:
+          type: boolean
+        disposition:
+          type: string
+        project:
+          $ref: "#/components/schemas/ProjectOut"
+      required:
+        - project
+        - detached
+        - disposition
+      type: object
     LinkChanges:
       additionalProperties: true
       properties:
@@ -3155,6 +3181,39 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CreateFederationReplicaBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/federation/replicas/{project_id}/actions/leave:
+    post:
+      operationId: leaveFederationReplica
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: header
+          name: X-Kata-Confirm
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LeaveFederationReplicaRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LeaveFederationReplicaResultBody"
           description: OK
         default:
           content:


### PR DESCRIPTION
## Summary

`kata federation join` had no inverse: an accidental enrollment (for example, adopting the wrong local project into a hub) could only be undone by wiping the local daemon state. This PR makes spoke enrollment fully reversible — and re-doable:

- **`kata federation leave [project]`** — revokes the spoke's hub enrollment(s), then detaches the local spoke back to a standalone project: the binding, sync-status, quarantine, and claim state plus the daemon-local credential are removed in one daemon-route operation (`POST /api/v1/federation/replicas/{id}/actions/leave`). `--delete` archives the now-standalone project (reversible via `kata projects restore`); archive eligibility is checked **before** detach so an open-issue refusal cannot leave partial state, and `--force` overrides it. `--local-only` handles an unreachable hub, leaving the token to revoke manually. Idempotent and resumable.
- **Rejoin — the round-trip contract.** Leave keeps the project's shared hub UID, and `join` now recognizes an unbound UID-holder as a rejoin and rebinds it instead of refusing: **enroll → leave → enroll works**, with acceptance tests at the daemon and CLI level. Pull restarts below the replay horizon (event-UID dedup absorbs the overlap); a push-enabled rejoin re-offers local-origin events from cursor 0, so the hub dedups what it already has and absorbs edits made while standalone. A join naming a different project gets an actionable `federation_rejoin_name_mismatch` that names the holder. The same path heals a partially-failed join.
- **TUI.** `[x] leave` on a spoke row opens a preview (keep/archive and local-only toggles). The enroll flow **never skips the local-project step** anymore — an active project only pre-positions the cursor instead of silently pre-arming adoption, so the create-replica path stays reachable. Rejoin is detected from **both** directions: selecting a hub project whose identity is held by an unbound local project, or selecting that local project first, presents the operation as a rejoin instead of a doomed new-replica or history-rewriting adoption. Adoption itself no longer executes on a bare Enter: a confirmation screen states "federate local project X INTO hub project Y" and requires typing the local project name. The enrollment recovery screen now shows the **actual join error**; the token-expiry hint is reserved for 401/403.

## Design notes

- Revoke-first ordering: a hub failure aborts before any local teardown.
- Credential cleanup runs in the spoke daemon (`credentials.toml` is daemon-local), symmetric with join writing it.
- Hub-admin auth for the revoke resolves `--hub-token` → `--hub <name>` catalog `token`/`token_env` → URL-matched catalog entry; with no hub credential the request is **unauthenticated** — the local daemon's global `KATA_AUTH_TOKEN`/`[auth].token` is never sent to the hub origin implicitly. The hub URL and `allow_insecure` always come from the binding (CLI and TUI), so the admin token cannot be sent to a different origin. A selected catalog entry with an unset `token_env` errors instead of silently falling back. Leave warns about matching **global** enrollments (nil project scope), which still authorize the project but are not auto-revoked.
- A binding-aware guard keeps an in-flight sync pass from re-creating `federation_sync_status` rows after a leave.
- A user-facing project purge for the `--delete` path is deferred.

## Compatibility

Spoke-only deployment: the single new HTTP route is on the spoke's own daemon, and every hub interaction (enrollment list/revoke, enroll/enable, metadata fetch, event pull, push ingest with its existing dedup) uses pre-existing hub API and documented protocol behavior. Hubs need no upgrade for spokes to leave and rejoin.

The full cycle — accidental adoption → leave → rename/workspace split → rejoin — has been exercised end to end against a live hub.

Documentation updated in `docs/operations/federation.md` and `docs/design/federation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

