### PR TITLE
fix(links): make cross-project link errors honest and document the limitation

### DIFF
--- a/cmd/kata/edit_test.go
+++ b/cmd/kata/edit_test.go
@@ -253,9 +253,10 @@ func TestEdit_EquivalentParentRefsAccepted(t *testing.T) {
 
 // TestEdit_CrossProjectLinkRefRejected pins that link flags refuse a
 // qualified ref naming a project other than the URL issue's project.
-// The daemon's wire shape (RefForAPI is just the short_id resolved
-// against the current project) would silently target the wrong issue;
-// the user must pass the peer's ULID for a cross-project link.
+// Cross-project links are not supported (the schema forbids them), so
+// the error must state that constraint — and must NOT steer the user
+// toward passing a ULID, which the daemon also resolves only inside the
+// URL issue's project.
 func TestEdit_CrossProjectLinkRefRejected(t *testing.T) {
 	env, dir := setupCLIEnv(t)
 	pid := resolvePIDViaHTTP(t, env.URL, dir)
@@ -264,8 +265,10 @@ func TestEdit_CrossProjectLinkRefRejected(t *testing.T) {
 
 	_, err := runCLICapture(t, env, dir, "edit", subject, "--blocks", "other#"+peer)
 	require.Error(t, err, "cross-project qualified ref must be rejected")
-	assert.Contains(t, err.Error(), "cross-project")
+	assert.Contains(t, err.Error(), "cross-project links are not supported")
 	assert.Contains(t, err.Error(), "--blocks")
+	assert.NotContains(t, err.Error(), "ULID",
+		"error must not suggest ULIDs: the daemon scopes ULID link refs to the issue's project too")
 }
 
 // TestEdit_ConflictDetectedAcrossRefForms pins that the add/remove

--- a/cmd/kata/issue_ref_cli.go
+++ b/cmd/kata/issue_ref_cli.go
@@ -138,9 +138,10 @@ func workspaceProjectName(startPath string) string {
 // currentProject is the canonical name of the project the surrounding command
 // targets (i.e. the URL issue's project for `kata edit`, or the create-time
 // project for `kata create`). A qualified ref whose project segment names a
-// different project is rejected — cross-project links require the full ULID
-// path, not a `<other>#abc4` shortcut. Pass "" to skip the cross-project
-// check (intended for callers that can't yet plumb the canonical name).
+// different project is rejected — links can only join issues in the same
+// project (the schema forbids cross-project link rows), so such a ref can
+// never be satisfied. Pass "" to skip the cross-project check (intended for
+// callers that can't yet plumb the canonical name).
 //
 // includeDeleted=true matches the soft-delete-tolerant lookup the daemon's
 // remove paths use: the link row is real, and the user can still ask to
@@ -186,19 +187,20 @@ func resolveRefToWireOpts(ctx context.Context, baseURL, currentProject string, p
 			ExitCode: ExitValidation,
 		}
 	}
-	// A qualified ref ("other#abc4") names a project explicitly. The
-	// wire shape we hand the daemon (RefForAPI is just the short_id) is
-	// resolved against the URL issue's project, so a cross-project ref
-	// would silently target the wrong issue. Reject up front and steer
-	// the user toward the ULID form, which the daemon resolves
-	// project-independently. parsed.ProjectName matches currentProject
+	// A qualified ref ("other#abc4") names a project explicitly. Links can
+	// only join issues in the same project: the daemon resolves link refs
+	// (short_ids and ULIDs alike) against the URL issue's project, and the
+	// schema forbids cross-project link rows outright. A ref naming a
+	// different project can therefore never be satisfied — reject up front
+	// with the real constraint instead of letting the daemon report a
+	// bare "issue not found". parsed.ProjectName matches currentProject
 	// for both bare refs (workspace fallback) and same-project qualified
 	// refs ("kata#abc4" when current project is "kata"); the inequality
 	// fires only when the ref names a different project.
 	if currentProject != "" && parsed.ProjectName != "" && parsed.ProjectName != currentProject {
 		return "", &cliError{
-			Message: fmt.Sprintf("%s: cross-project refs not supported here; pass the issue's ULID instead of %q",
-				flagName, ref),
+			Message: fmt.Sprintf("%s: cross-project links are not supported; %q must name an issue in project %q",
+				flagName, ref, currentProject),
 			Kind:     kindValidation,
 			ExitCode: ExitValidation,
 		}

--- a/cmd/kata/move.go
+++ b/cmd/kata/move.go
@@ -19,7 +19,17 @@ func newMoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "move <issue-ref> <project>",
 		Short: "move an issue to another project",
-		Args:  cobra.ExactArgs(2),
+		Long: `Move an issue to another project.
+
+The issue keeps its UID, comments, and history; a fresh short_id is
+assigned in the target project.
+
+Moving is refused while the issue has links (parent, blocks/blocked-by,
+related): links can only join issues in the same project, so they cannot
+survive the move. Remove the links first (kata edit <ref> --remove-*),
+move the issue, and re-create the links in the target project — moving
+the peer issues there too if you need to keep the relationships.`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runMove(cmd, args[0], args[1], dryRun)
 		},

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -71,6 +71,9 @@ irreversibly removed except for tombstones needed to preserve external refs.
 ## Relationships
 
 Relationships are normalized links between issues in the same project.
+Links cannot span projects: relationship flags only accept refs that resolve
+inside the issue's own project (a foreign `<project>#<short_id>` or ULID is
+rejected), and `kata move` refuses to move an issue that still has links.
 
 | Relationship | Cardinality | Meaning |
 | --- | --- | --- |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -98,6 +98,15 @@ may differ from the source `short_id` if the target project already has a
 collision. `--dry-run` is a client-side preview: it resolves the source issue
 and target project without mutating anything.
 
+`move` refuses while the issue has links (`parent`, `blocks`/`blocked-by`,
+`related`). Links can only join issues in the same project — cross-project
+links are not supported — so a moved issue's links would otherwise dangle
+across projects. To move a linked issue: remove its links (`kata edit <ref>
+--remove-blocks/--remove-blocked-by/--remove-related/--remove-parent`), move
+it, and re-create the links in the target project. Re-linking requires the
+peer issues to live in the target project too, so `kata move` each peer you
+want to stay connected before re-linking.
+
 Comment:
 
 ```sh

--- a/internal/daemon/handlers_move.go
+++ b/internal/daemon/handlers_move.go
@@ -79,7 +79,8 @@ func moveIssueHandler(cfg ServerConfig) func(context.Context, *api.MoveIssueRequ
 		var cpErr *db.CrossProjectLinksError
 		if errors.As(err, &cpErr) {
 			return nil, api.NewError(409, "cross_project_links",
-				cpErr.Error(), "remove the cross-project links before moving",
+				cpErr.Error(),
+				"remove the issue's links, move, then re-link in the target project (peers must live there too — links cannot span projects)",
 				map[string]any{"blockers": cpErr.Blockers})
 		}
 		var rpErr *db.RecurrencePinnedError

--- a/internal/daemon/handlers_move_test.go
+++ b/internal/daemon/handlers_move_test.go
@@ -220,6 +220,8 @@ func TestMoveIssue_CrossProjectLinks_409_WithBlockers(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(raw, &env409))
 	assert.Equal(t, "cross_project_links", env409.Error.Code)
+	assert.Contains(t, env409.Error.Message, "would become cross-project",
+		"message must explain the links are not yet cross-project; the move would make them so")
 	require.Len(t, env409.Error.Data.Blockers, 1)
 	assert.Equal(t, "blocks", env409.Error.Data.Blockers[0].Type)
 	assert.Equal(t, b.UID, env409.Error.Data.Blockers[0].PeerUID)
@@ -263,4 +265,54 @@ func TestMoveIssue_RecurrencePinned_409(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(raw, &env409))
 	assert.Equal(t, "recurrence_pinned", env409.Error.Code)
+}
+
+// TestEditIssue_LinkTargetULIDInOtherProject_404 pins the daemon-side scoping
+// of link refs: a links_delta add naming the ULID of an issue that lives in a
+// different project resolves to issue_not_found. Cross-project links are not
+// supported (the schema forbids the rows), and ULID resolution for link refs
+// is deliberately scoped to the URL issue's project so the endpoint cannot be
+// used to fish for foreign issues. The 404 message must spell out the
+// same-project constraint instead of a bare "issue not found" — the miss is
+// otherwise indistinguishable from a typo'd ref, and the response must read
+// the same whether or not the foreign issue exists.
+func TestEditIssue_LinkTargetULIDInOtherProject_404(t *testing.T) {
+	env := testenv.New(t, testenv.WithAuthToken("tok"))
+	src, tgt, iss := seedMovePair(t, env)
+	foreign, _, err := env.DB.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: tgt.ID, Title: "peer in another project", Author: "tester",
+	})
+	require.NoError(t, err)
+
+	body := fmt.Sprintf(`{"actor":"tester","links_delta":{"add_related":[%q]}}`, foreign.UID)
+	resp := doPatch(t, env, env.URL+issuePathRef(src.ID, iss.ShortID, ""), body, "")
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	require.Equalf(t, http.StatusNotFound, resp.StatusCode, "body: %s", raw)
+
+	var env404 struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env404))
+	assert.Equal(t, "issue_not_found", env404.Error.Code)
+	assert.Contains(t, env404.Error.Message, "links can only join issues in the same project")
+
+	// A nonexistent ULID must produce the identical message so the
+	// response does not leak whether a foreign issue exists.
+	bogus := `{"actor":"tester","links_delta":{"add_related":["01ZZZZZZZZZZZZZZZZZZZZZZZZ"]}}`
+	resp2 := doPatch(t, env, env.URL+issuePathRef(src.ID, iss.ShortID, ""), bogus, "")
+	defer func() { _ = resp2.Body.Close() }()
+	raw2, _ := io.ReadAll(resp2.Body)
+	require.Equalf(t, http.StatusNotFound, resp2.StatusCode, "body: %s", raw2)
+	var env404b struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw2, &env404b))
+	assert.Equal(t, env404.Error.Message, env404b.Error.Message,
+		"404 message must be identical for foreign and nonexistent link targets")
 }

--- a/internal/daemon/resolver.go
+++ b/internal/daemon/resolver.go
@@ -82,6 +82,23 @@ func qualifiedID(projectName, shortID string) string {
 	return projectName + "#" + shortID
 }
 
+// linkTargetNotFound rewraps an issue_not_found miss from link-ref
+// resolution with a message that states the real constraint: link refs are
+// resolved inside the linking issue's project, and the schema forbids
+// cross-project link rows, so a ULID that lives in another project is just
+// as unreachable as one that does not exist. The message is identical in
+// both cases on purpose — it must not leak whether a foreign issue exists.
+// Non-404 errors pass through unchanged.
+func linkTargetNotFound(err error) error {
+	var ae *api.APIError
+	if errors.As(err, &ae) && ae.Status == 404 && ae.Code == "issue_not_found" {
+		return api.NewError(404, "issue_not_found",
+			"link target not found in this project (links can only join issues in the same project)",
+			"", nil)
+	}
+	return err
+}
+
 // resolveInitialLinks turns CreateInitialLinkBody entries (string ToRef) into
 // db.InitialLink entries (int64 ToNumber, which the db layer treats as an
 // issue row id). Soft-deleted targets are excluded — initial-link creation
@@ -91,7 +108,7 @@ func resolveInitialLinks(ctx context.Context, store db.Storage, projectID int64,
 	for _, l := range links {
 		target, err := resolveIssueRef(ctx, store, projectID, l.ToRef, db.IncludeDeletedNo)
 		if err != nil {
-			return nil, err
+			return nil, linkTargetNotFound(err)
 		}
 		out = append(out, db.InitialLink{
 			Type:     l.Type,
@@ -105,7 +122,8 @@ func resolveInitialLinks(ctx context.Context, store db.Storage, projectID int64,
 // fillLinksDeltaParams resolves each api.LinksDelta string ref into an
 // issue id and stuffs the int64-keyed slices into params. Each ref is
 // resolved through resolveIssueRef, which already maps to issue_not_found
-// 404 for misses, so error returns are wire-ready.
+// 404 for misses; linkTargetNotFound then rewords the 404 to spell out the
+// same-project scoping, so error returns are wire-ready.
 func fillLinksDeltaParams(ctx context.Context, store db.Storage, projectID int64, d *api.LinksDelta, params *db.EditIssueAtomicParams) error {
 	if d == nil {
 		return nil
@@ -113,7 +131,7 @@ func fillLinksDeltaParams(ctx context.Context, store db.Storage, projectID int64
 	resolve := func(ref string, include db.IncludeDeleted) (int64, error) {
 		issue, err := resolveIssueRef(ctx, store, projectID, ref, include)
 		if err != nil {
-			return 0, err
+			return 0, linkTargetNotFound(err)
 		}
 		return issue.ID, nil
 	}

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -236,7 +236,7 @@ type CrossProjectLinksError struct {
 }
 
 func (e *CrossProjectLinksError) Error() string {
-	return fmt.Sprintf("cannot move: %d cross-project link(s) anchored in source project",
+	return fmt.Sprintf("cannot move: %d link(s) would become cross-project; unlink before moving (links can only join issues in the same project)",
 		len(e.Blockers))
 }
 


### PR DESCRIPTION
## What this fixes

Found while using `kata move` (#106 / #104) to reorganize issues between projects: every error around the cross-project link constraint points the user at a workaround that cannot work, ending in a dead end with severed links.

Cross-project links are intentionally unsupported — the schema's `trg_links_same_project_insert`/`_update` triggers abort any link row whose endpoints live in different projects. The messaging just never says so:

### Repro (two projects `alpha`, `beta`; `alpha#z0bv --related alpha#0qxz`)

```
$ kata move alpha#z0bv beta
ERR move conflict: cannot move: 1 cross-project link(s) anchored in source project
```
The links aren't cross-project (they can't be); they *would become* cross-project. The wording suggests detach → move → re-attach works. So:

```
$ kata edit alpha#z0bv --remove-related 0qxz   # detach
$ kata move alpha#z0bv beta                    # moves fine
$ kata edit beta#z0bv --related "alpha#0qxz"   # re-attach?
ERR edit validation: --related: cross-project refs not supported here; pass the issue's ULID instead of "alpha#0qxz"
```
The hint says a ULID should work. It can't — `resolveIssueRef` (deliberately, to prevent cross-project fishing via the URL path) rejects ULIDs outside the URL issue's project, and the schema trigger would refuse the row anyway:

```
$ kata edit beta#z0bv --related 01KTSW6M314NZSVH5MTDEY0QXZ
ERR edit not_found: issue not found
```

So the user is told to do something impossible, and the failure is indistinguishable from a typo'd ref.

## Changes

Given the schema triggers, I treated "no cross-project links" as the intended design and made the messaging/docs honest rather than changing link semantics:

- **CLI** (`cmd/kata/issue_ref_cli.go`): qualified-ref rejection now states the real constraint — `--related: cross-project links are not supported; "alpha#0qxz" must name an issue in project "beta"` — instead of recommending the ULID dead end.
- **daemon** (`internal/daemon/resolver.go`): link-target resolution misses (links_delta + create-time links) now read `link target not found in this project (links can only join issues in the same project)`. The message is identical for foreign and nonexistent targets, so it leaks nothing about foreign issues (the anti-fishing 404 behavior is unchanged — only the wording).
- **db** (`internal/db/errors.go`): `CrossProjectLinksError` → `cannot move: N link(s) would become cross-project; unlink before moving (links can only join issues in the same project)`.
- **docs + `kata move --help`**: document that `move` refuses while links exist and describe the only sequence that works: remove links → move the issue (and any peers you want to stay connected) → re-link in the target project.

Tests: updated `TestEdit_CrossProjectLinkRefRejected` (now also pins that the error no longer suggests ULIDs), added `TestEditIssue_LinkTargetULIDInOtherProject_404` (foreign-ULID link target 404s with the same-project wording, and the message is byte-identical for a nonexistent ULID), and pinned the reworded 409 in `TestMoveIssue_CrossProjectLinks_409_WithBlockers`. `go test ./...` passes.

## Design question (out of scope here, but worth a maintainer call)

Is "links never span projects" permanent design, or should `move` eventually preserve relationships? Two possible follow-ups if there's appetite:

1. `kata move --with-links` that refuses unless all peers are moved in the same operation (move the closed set), or
2. actual cross-project link support (drop the triggers, decide how `links.project_id` should be scoped, what events/export/federation do with links whose endpoints live in two projects).

Either is a schema/design decision, so this PR only stops the tooling from pointing at a workaround that doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)