### PR TITLE
build: check generated api artifacts before push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test test-short test-stress test-federation-docker lint vet clean fmt nilaway openapi api-generate tui tui-demo docs-install docs-build docs-serve docs-check docs-deploy docs-screenshots docs-assets-branch
+.PHONY: build install test test-short test-stress test-federation-docker lint vet clean fmt nilaway openapi api-generate api-check tui tui-demo docs-install docs-build docs-serve docs-check docs-deploy docs-screenshots docs-assets-branch
 
 GOFLAGS_TEST := -shuffle=on
 GOBIN ?= $(HOME)/.local/bin
@@ -22,6 +22,9 @@ api-generate:
 	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; go run ./cmd/kata openapi > "$$tmp"; if [ -f api/openapi.yaml ] && cmp -s "$$tmp" api/openapi.yaml; then rm "$$tmp"; else mv "$$tmp" api/openapi.yaml; fi; trap - EXIT
 	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; go run ./cmd/kata openapi --version 3.0 --format yaml > "$$tmp"; if [ -f pkg/client/openapi.yaml ] && cmp -s "$$tmp" pkg/client/openapi.yaml; then rm "$$tmp"; else mv "$$tmp" pkg/client/openapi.yaml; fi; trap - EXIT
 	cd pkg/client/generated && find . -maxdepth 1 -type f -name '*.go' ! -name 'generate.go' -delete && go run github.com/doordash-oss/oapi-codegen-dd/v3/cmd/oapi-codegen@v3.75.5 -config config.yaml ../openapi.yaml
+
+api-check:
+	go test ./internal/daemon -run 'TestOpenAPI(ArtifactUpToDate|ClientSpecArtifactUpToDate|ClientArtifactUpToDate)$$'
 
 openapi: api-generate
 

--- a/prek.toml
+++ b/prek.toml
@@ -4,6 +4,7 @@ default_stages = ["pre-commit"]
 [[repos]]
 repo = "local"
 hooks = [
+  { id = "api-check", name = "make api-check", entry = "make api-check", language = "system", stages = ["pre-push"], pass_filenames = false, always_run = true },
   { id = "make-lint", name = "make lint", entry = "make lint", language = "system", stages = ["pre-push"], pass_filenames = false, always_run = true },
   { id = "nilaway", name = "nilaway", entry = "make nilaway", language = "system", stages = ["pre-push"], types_or = ["go", "go-mod", "go-sum"], pass_filenames = false },
 ]


### PR DESCRIPTION
Extracted from #112.\n\nAdds a focused make api-check target for the committed OpenAPI schema, client schema, and generated client drift tests. Wires that target into the existing prek pre-push configuration so generated API drift is caught before pushing.