### PR TITLE
Support CLAUDE.md in kata init --with-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ expand or collapse all parents in nested view, and `?` for the full keybinding
 list.
 
 For agent-heavy workspaces, use `kata init --with-agents` to also write a
-managed kata briefing into `AGENTS.md`; re-running it refreshes kata's block
-without overwriting the rest of the file.
+managed kata briefing into agent guidance files. It refreshes existing real
+`AGENTS.md` and `CLAUDE.md` files, or creates `AGENTS.md` when neither exists,
+without overwriting the rest of either file.
 
 ## What kata does
 

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -138,7 +138,7 @@ get committed.`,
 
 	cmd.Flags().BoolVar(&opts.Replace, "replace", false, "overwrite .kata.toml binding when it conflicts")
 	cmd.Flags().BoolVar(&opts.Reassign, "reassign", false, "move an existing alias to this project")
-	cmd.Flags().BoolVar(&opts.WithAgents, "with-agents", false, "write kata agent guidance into AGENTS.md in the workspace")
+	cmd.Flags().BoolVar(&opts.WithAgents, "with-agents", false, "write kata agent guidance into AGENTS.md/CLAUDE.md in the workspace")
 
 	return cmd
 }
@@ -373,7 +373,7 @@ func warnAgentsUpdate(err error) {
 	if currentOutputMode() != outputHuman {
 		return
 	}
-	fmt.Fprintf(os.Stderr, "kata: warning: could not update AGENTS.md: %v\n", err)
+	fmt.Fprintf(os.Stderr, "kata: warning: could not update agent guidance: %v\n", err)
 }
 
 // warnBeadsConflict tells the user kata declined to edit a file in place
@@ -606,53 +606,79 @@ func agentsManagedBlock() string {
 }
 
 // applyAgentGuidance is the entry point for `--with-agents`. It writes kata's
-// block into AGENTS.md and, when migrating off beads, sidesteps a destructive
-// edit: if a file still carries a beads integration block, kata leaves it
-// untouched and writes a <file>.kata-proposed copy (beads block removed, kata
-// block added) for the user to adopt or discard. CLAUDE.md is only considered
-// in that conflict case, and only when it is a real file rather than a symlink
-// (kata's own convention points CLAUDE.md at AGENTS.md).
+// block into existing real agent guidance files (AGENTS.md and CLAUDE.md), or
+// creates AGENTS.md when neither exists. When migrating off beads, it sidesteps
+// a destructive edit: if a file still carries a beads integration block, kata
+// leaves it untouched and writes a <file>.kata-proposed copy (beads block
+// removed, kata block added) for the user to adopt or discard.
 func applyAgentGuidance(dir string) (bool, error) {
 	changed := false
 
 	agentsPath := filepath.Join(dir, "AGENTS.md")
 	// Refuse a symlinked AGENTS.md before reading it. Following the link would
 	// let a hostile repo copy an outside file's content into the workspace via
-	// the migration sidecar, or rewrite the link target. CLAUDE.md gets the same
-	// treatment through regularFileWithBeads.
+	// the migration sidecar, or rewrite the link target.
 	if fi, lerr := os.Lstat(agentsPath); lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
 		return changed, fmt.Errorf("refusing to manage symlinked %s", agentsPath)
 	}
-	content, exists, err := readIfExists(agentsPath)
+
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	agentsExists, err := regularGuidanceFileExists(agentsPath)
 	if err != nil {
 		return changed, err
 	}
-	if exists && hasBeadsBlock(content) {
-		sidecar, err := writeMigrationProposal(agentsPath, content)
+	claudeExists, err := regularGuidanceFileExists(claudePath)
+	if err != nil {
+		return changed, err
+	}
+
+	if agentsExists || !claudeExists {
+		c, err := applyAgentGuidanceFile(agentsPath, agentsExists)
 		if err != nil {
 			return changed, err
 		}
-		warnBeadsConflict(agentsPath, sidecar)
-		changed = true
-	} else {
-		c, err := ensureAgentsBlock(agentsPath, content, exists)
+		changed = changed || c
+	}
+	if claudeExists {
+		c, err := applyAgentGuidanceFile(claudePath, true)
 		if err != nil {
 			return changed, err
 		}
 		changed = changed || c
 	}
 
-	claudePath := filepath.Join(dir, "CLAUDE.md")
-	if claude, ok := regularFileWithBeads(claudePath); ok {
-		sidecar, err := writeMigrationProposal(claudePath, claude)
-		if err != nil {
-			return changed, err
-		}
-		warnBeadsConflict(claudePath, sidecar)
-		changed = true
-	}
-
 	return changed, nil
+}
+
+// regularGuidanceFileExists reports whether path is an existing real guidance
+// file. Symlinks and directories are not managed through this path.
+func regularGuidanceFileExists(path string) (bool, error) {
+	fi, err := os.Lstat(path)
+	switch {
+	case err == nil:
+		return fi.Mode()&os.ModeSymlink == 0 && !fi.IsDir(), nil
+	case errors.Is(err, os.ErrNotExist):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func applyAgentGuidanceFile(path string, exists bool) (bool, error) {
+	content, readExists, err := readIfExists(path)
+	if err != nil {
+		return false, err
+	}
+	exists = exists && readExists
+	if exists && hasBeadsBlock(content) {
+		sidecar, err := writeMigrationProposal(path, content)
+		if err != nil {
+			return false, err
+		}
+		warnBeadsConflict(path, sidecar)
+		return true, nil
+	}
+	return ensureAgentsBlock(path, content, exists)
 }
 
 // ensureAgentsBlock writes kata's block into an agent guidance file whose
@@ -797,24 +823,4 @@ func readIfExists(path string) (string, bool, error) {
 	default:
 		return "", false, err
 	}
-}
-
-// regularFileWithBeads reports the content of path when it is a regular file
-// (not a symlink or directory) that carries a beads integration block. kata
-// skips symlinked CLAUDE.md so it never rewrites a file that merely points at
-// AGENTS.md.
-func regularFileWithBeads(path string) (string, bool) {
-	fi, err := os.Lstat(path)
-	if err != nil || fi.Mode()&os.ModeSymlink != 0 || fi.IsDir() {
-		return "", false
-	}
-	bs, err := os.ReadFile(path) //nolint:gosec
-	if err != nil {
-		return "", false
-	}
-	content := string(bs)
-	if !hasBeadsBlock(content) {
-		return "", false
-	}
-	return content, true
 }

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -512,6 +512,53 @@ func TestInit_WithAgents_AppendsToExistingFile(t *testing.T) {
 	assert.Contains(t, string(content), agentsBlockBegin)
 }
 
+func TestInit_WithAgents_AppendsToExistingClaudeFile(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "CLAUDE.md"), //nolint:gosec // test fixture under TempDir
+		[]byte("# Claude rules\n\nUse the project test helper.\n"), 0o644))
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "Use the project test helper.")
+	assert.Contains(t, string(content), agentsBlockBegin)
+	assert.NoFileExists(t, filepath.Join(dir, "AGENTS.md"))
+}
+
+func TestInit_WithAgents_AppendsToBothAgentFilesWhenBothExist(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), //nolint:gosec // test fixture under TempDir
+		[]byte("# Agent rules\n\nRun `go test`.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "CLAUDE.md"), //nolint:gosec // test fixture under TempDir
+		[]byte("# Claude rules\n\nUse the project test helper.\n"), 0o644))
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	agents, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	claude, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(agents), "Run `go test`.")
+	assert.Contains(t, string(agents), agentsBlockBegin)
+	assert.Contains(t, string(claude), "Use the project test helper.")
+	assert.Contains(t, string(claude), agentsBlockBegin)
+}
+
 func TestInit_WithAgents_RefreshesStaleBlock(t *testing.T) {
 	env := testenv.New(t)
 	dir := t.TempDir()
@@ -636,10 +683,9 @@ func TestInit_WithAgents_BeadsBlockInClaude_WritesSidecar(t *testing.T) {
 	assert.Contains(t, string(proposed), agentsBlockBegin)
 	assert.NotContains(t, string(proposed), beadsBlockBeginPrefix)
 
-	// AGENTS.md (absent here) still gets kata's block written normally.
-	agents, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
-	require.NoError(t, err)
-	assert.Contains(t, string(agents), agentsBlockBegin)
+	// CLAUDE.md is the only real guidance file here, so kata does not create
+	// AGENTS.md on the side.
+	assert.NoFileExists(t, filepath.Join(dir, "AGENTS.md"))
 }
 
 // kata's own convention symlinks CLAUDE.md at AGENTS.md. A symlinked CLAUDE.md

--- a/cmd/kata/init_with_agents_e2e_test.go
+++ b/cmd/kata/init_with_agents_e2e_test.go
@@ -41,9 +41,8 @@ func TestE2E_InitWithAgents_NewEmptyRepo(t *testing.T) {
 }
 
 // TestE2E_InitWithAgents_PreservesExistingAgentDocs runs init in a repo that
-// already ships a CLAUDE.md and an AGENTS.md full of unrelated guidance. The
-// CLAUDE.md must be byte-for-byte untouched, and every pre-existing AGENTS.md
-// section must survive alongside kata's appended block.
+// already ships a CLAUDE.md and an AGENTS.md full of unrelated guidance. Both
+// files keep their existing content and gain kata's appended block.
 func TestE2E_InitWithAgents_PreservesExistingAgentDocs(t *testing.T) {
 	resetFlags(t)
 	env := testenv.New(t)
@@ -58,10 +57,11 @@ func TestE2E_InitWithAgents_PreservesExistingAgentDocs(t *testing.T) {
 
 	runCLI(t, env, dir, "init", "--with-agents")
 
-	// CLAUDE.md is not part of the managed surface — it must be identical.
+	// CLAUDE.md is part of the managed surface when it already exists.
 	gotClaude, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md")) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
-	assert.Equal(t, claude, string(gotClaude), "CLAUDE.md must be left exactly as the project had it")
+	assert.Contains(t, string(gotClaude), "Project-specific Claude rules.")
+	assert.Contains(t, string(gotClaude), agentsBlockBegin)
 
 	// AGENTS.md keeps every pre-existing section and gains kata's block.
 	gotAgents, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -70,18 +70,20 @@ To also drop a short kata briefing where coding agents look for it, pass
 kata init --with-agents
 ```
 
-This writes a marker-delimited block into `AGENTS.md` in the workspace, pointing
-agents at `kata quickstart` and the close discipline. The block is idempotent:
-re-running refreshes kata's section in place and leaves the rest of the file
-untouched. The flag is off by default, so a plain `kata init` still writes only
-`.kata.toml`.
+This writes a marker-delimited block where coding agents look for workspace
+guidance, pointing them at `kata quickstart` and the close discipline. If
+`AGENTS.md` and/or a real, non-symlinked `CLAUDE.md` already exist, kata
+refreshes each of those files. If neither exists, kata creates `AGENTS.md`. The
+block is idempotent: re-running refreshes kata's section in place and leaves the
+rest of each file untouched. The flag is off by default, so a plain `kata init`
+still writes only `.kata.toml`.
 
 If `AGENTS.md` (or a real, non-symlinked `CLAUDE.md`) still carries a Beads
 integration block — common when migrating off Beads — kata refuses to edit it in
 place. It leaves the original untouched and writes a `<file>.kata-proposed`
 sidecar with the Beads block removed and kata's block added. Review the sidecar,
-then `mv AGENTS.md.kata-proposed AGENTS.md` to adopt it, or delete it to keep the
-original. kata prints where the sidecar landed. For safety, a symlinked
+then move `<file>.kata-proposed` over the original to adopt it, or delete it to
+keep the original. kata prints where the sidecar landed. For safety, a symlinked
 `AGENTS.md` is refused before it is read; replace it with a regular file before
 using `--with-agents`.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,9 +27,11 @@ workspace. Pass `--project` to choose the project name explicitly instead of
 deriving it from the git remote.
 
 Pass `--with-agents` to add or refresh kata's marker-delimited guidance block
-in `AGENTS.md`. The block points coding agents at `kata quickstart` and the
-close discipline; re-running the command updates only kata's block and leaves
-other content untouched.
+where coding agents look for workspace instructions. Existing real `AGENTS.md`
+and `CLAUDE.md` files are both refreshed; if neither exists, kata creates
+`AGENTS.md`. The block points coding agents at `kata quickstart` and the close
+discipline; re-running the command updates only kata's block and leaves other
+content untouched.
 
 When migrating from Beads, an existing `AGENTS.md` or real `CLAUDE.md` may still
 carry a Beads integration block. kata leaves that file untouched and writes a

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -22,12 +22,13 @@ kata whoami --agent
 Default to `--agent` for ordinary reads and mutations in agent logs. Use
 `--json` only when the script needs full structured data.
 
-To make a workspace self-documenting for agents that read `AGENTS.md`, run
-`kata init --with-agents` once. It writes a marker-delimited kata briefing into
-`AGENTS.md` that points back at `kata quickstart`; re-running refreshes only
-kata's block. If the file still carries a Beads integration block, kata leaves
-it untouched and writes a `<file>.kata-proposed` sidecar to adopt or discard —
-see [`--with-agents`](../get-started/quickstart.md#initialize-a-workspace). If
+To make a workspace self-documenting for agents, run `kata init --with-agents`
+once. It writes a marker-delimited kata briefing into existing real `AGENTS.md`
+and `CLAUDE.md` files, or creates `AGENTS.md` when neither exists. The block
+points back at `kata quickstart`; re-running refreshes only kata's block. If a
+target file still carries a Beads integration block, kata leaves it untouched
+and writes a `<file>.kata-proposed` sidecar to adopt or discard — see
+[`--with-agents`](../get-started/quickstart.md#initialize-a-workspace). If
 `AGENTS.md` is a symlink, kata refuses to manage it before reading the target;
 replace it with a regular file before using `--with-agents`.
 


### PR DESCRIPTION
Fixes #110.

This updates `kata init --with-agents` so projects that already use Claude Code guidance get the managed kata block in `CLAUDE.md` without manual copy/paste. Existing real `AGENTS.md` and `CLAUDE.md` files are both refreshed when present; a fresh workspace still gets `AGENTS.md` by default.

The symlink safety stance remains intact: symlinked `AGENTS.md` is still refused before reading, and only real `CLAUDE.md` files are managed. The docs and CLI help now describe the broader target-selection behavior.