### PR TITLE
Add global daemon selection flag

### DIFF
--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -47,10 +47,17 @@ func envHTTPTimeout(def time.Duration) time.Duration {
 // the .kata.local.toml walk so a workspace-local [server] override is
 // honored even when the user is invoking kata from outside the repo.
 //
-// If a remote is explicitly configured (via KATA_SERVER, .kata.local.toml,
-// or active_daemon) but does not respond, the CLI surfaces this as a
-// daemon-unavailable error so callers see a stable exit code and shape.
+// If a daemon is explicitly configured (via --daemon, KATA_SERVER,
+// .kata.local.toml, or active_daemon) but does not respond, the CLI surfaces
+// this as a daemon-unavailable error so callers see a stable exit code and shape.
 func ensureDaemon(ctx context.Context) (string, error) {
+	if flags.Daemon != "" {
+		baseURL, err := client.EnsureNamedRunning(ctx, flags.Daemon)
+		if err == nil {
+			return baseURL, nil
+		}
+		return "", cliDaemonTargetError(err)
+	}
 	workspaceStart := workspaceStartForRemote()
 	baseURL, err := client.EnsureRunningInWorkspace(ctx, workspaceStart)
 	if err == nil {
@@ -90,12 +97,13 @@ func workspaceStartForRemote() string {
 // with the rest of the CLI about which daemon is "the" daemon:
 //
 //  1. BaseURLKey on the context (test injection).
-//  2. Configured remote (KATA_SERVER env, .kata.local.toml [server].url,
+//  2. --daemon named catalog entry.
+//  3. Configured remote (KATA_SERVER env, .kata.local.toml [server].url,
 //     or active_daemon). When the remote is set but unreachable,
 //     surface that as ErrRemoteUnavailable so health reports the
 //     explicitly-selected daemon's actual state rather than silently
 //     falling through to a local one.
-//  3. Local Discover (runtime files).
+//  4. Local Discover (runtime files).
 //
 // Returns a kindDaemonUnavail cliError when no live daemon is found,
 // matching hammer-test finding #1's expectation that `kata health`
@@ -103,6 +111,13 @@ func workspaceStartForRemote() string {
 func discoverDaemon(ctx context.Context) (string, error) {
 	if v, ok := ctx.Value(client.BaseURLKey{}).(string); ok && v != "" {
 		return v, nil
+	}
+	if flags.Daemon != "" {
+		baseURL, err := client.EnsureNamedRunning(ctx, flags.Daemon)
+		if err == nil {
+			return baseURL, nil
+		}
+		return "", cliDaemonTargetError(err)
 	}
 	if url, ok, err := client.ResolveRemote(ctx, workspaceStartForRemote()); err != nil {
 		if errors.Is(err, client.ErrRemoteUnavailable) {
@@ -130,6 +145,24 @@ func discoverDaemon(ctx context.Context) (string, error) {
 	}
 }
 
+func cliDaemonTargetError(err error) error {
+	if errors.Is(err, client.ErrNamedDaemonNotFound) {
+		return &cliError{
+			Message:  err.Error(),
+			Kind:     kindValidation,
+			ExitCode: ExitValidation,
+		}
+	}
+	if errors.Is(err, client.ErrRemoteUnavailable) {
+		return &cliError{
+			Message:  err.Error(),
+			Kind:     kindDaemonUnavail,
+			ExitCode: ExitDaemonUnavail,
+		}
+	}
+	return err
+}
+
 // httpClientFor returns an *http.Client whose transport understands the
 // unix-socket base URL emitted by ensureDaemon. The TUI calls into
 // client directly; this wrapper exists only because every existing
@@ -141,6 +174,7 @@ func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 			Timeout:        envHTTPTimeout(defaultHTTPTimeout),
 			AllowInsecure:  client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart),
 			WorkspaceStart: workspaceStart,
+			DaemonName:     flags.Daemon,
 		})
 }
 
@@ -154,6 +188,7 @@ func streamingClientFor(ctx context.Context, baseURL string) (*http.Client, erro
 		ResponseHeaderTimeout: client.SSEHandshakeTimeout,
 		AllowInsecure:         client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart),
 		WorkspaceStart:        workspaceStart,
+		DaemonName:            flags.Daemon,
 	})
 }
 

--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -113,9 +113,12 @@ func discoverDaemon(ctx context.Context) (string, error) {
 		return v, nil
 	}
 	if flags.Daemon != "" {
-		baseURL, err := client.EnsureNamedRunning(ctx, flags.Daemon)
-		if err == nil {
+		baseURL, ok, err := client.DiscoverNamed(ctx, flags.Daemon)
+		if err == nil && ok {
 			return baseURL, nil
+		}
+		if err == nil {
+			return "", noDaemonRunningError()
 		}
 		return "", cliDaemonTargetError(err)
 	}
@@ -138,7 +141,11 @@ func discoverDaemon(ctx context.Context) (string, error) {
 	if url, ok := client.Discover(ctx, ns.DataDir); ok {
 		return url, nil
 	}
-	return "", &cliError{
+	return "", noDaemonRunningError()
+}
+
+func noDaemonRunningError() error {
+	return &cliError{
 		Message:  "no daemon running (start one with `kata daemon start`)",
 		Kind:     kindDaemonUnavail,
 		ExitCode: ExitDaemonUnavail,

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -155,6 +155,11 @@ func federationEnrollCmd() *cobra.Command {
 				return err
 			}
 			ctx := cmd.Context()
+			if !adoptExistingFlag && pushCapable {
+				if err := federationSpokeProbePreflight(ctx, spokeInstance); err != nil {
+					return err
+				}
+			}
 			hubBaseURL := strings.TrimRight(hubURL, "/")
 			hubClient, err := federationEnrollHTTPClient(ctx, hubBaseURL, allowInsecure)
 			if err != nil {
@@ -303,17 +308,33 @@ func federationSpokeProbeExplicit(ctx context.Context) bool {
 	return ok || err != nil
 }
 
+func federationSpokeProbePreflight(ctx context.Context, spokeInstance string) error {
+	if !federationSpokeProbeExplicit(ctx) {
+		return nil
+	}
+	spokeURL, err := ensureDaemon(ctx)
+	if err != nil {
+		return err
+	}
+	spokeClient, err := federationSpokeHTTPClient(ctx, spokeURL)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(spokeInstance) == "" {
+		return nil
+	}
+	_, err = federationSpokeInstanceUID(ctx, spokeClient, spokeURL)
+	return err
+}
+
 func federationSpokeHTTPClient(ctx context.Context, spokeURL string) (*http.Client, error) {
 	opts := clientpkg.Opts{Timeout: envHTTPTimeout(defaultHTTPTimeout)}
 	if strings.TrimSpace(flags.Daemon) == "" {
-		workspaceStart := workspaceStartForRemote()
-		if remoteURL, ok, err := clientpkg.ResolveRemote(ctx, workspaceStart); err != nil {
+		auth, err := federationImplicitSpokeTargetAuth(ctx, spokeURL)
+		if err != nil {
 			return nil, err
-		} else if ok && strings.TrimRight(remoteURL, "/") == strings.TrimRight(spokeURL, "/") {
-			opts.WorkspaceStart = workspaceStart
-			return clientpkg.NewHTTPClient(ctx, spokeURL, opts)
 		}
-		return clientpkg.NewHTTPClientForTarget(ctx, spokeURL, clientpkg.TargetAuth{}, opts)
+		return clientpkg.NewHTTPClientForTarget(ctx, spokeURL, auth, opts)
 	}
 	cfg, err := config.ReadDaemonConfig()
 	if err != nil {
@@ -337,8 +358,8 @@ func federationSpokeHTTPClient(ctx context.Context, spokeURL string) (*http.Clie
 		return nil, err
 	}
 	if strings.TrimSpace(token) == "" {
-		opts.DaemonName = strings.TrimSpace(flags.Daemon)
-		return clientpkg.NewHTTPClient(ctx, spokeURL, opts)
+		return clientpkg.NewHTTPClientForTarget(ctx, spokeURL,
+			clientpkg.TargetAuth{AllowInsecure: entry.AllowInsecure}, opts)
 	}
 	auth, err := config.ReadAuthConfig()
 	if err != nil {
@@ -350,6 +371,49 @@ func federationSpokeHTTPClient(ctx context.Context, spokeURL string) (*http.Clie
 			AllowInsecure:       entry.AllowInsecure,
 			TrustPrivateNetwork: auth.TrustPrivateNetwork,
 		}, opts)
+}
+
+func federationImplicitSpokeTargetAuth(ctx context.Context, spokeURL string) (clientpkg.TargetAuth, error) {
+	workspaceStart := workspaceStartForRemote()
+	if remoteURL, ok, err := clientpkg.ResolveRemote(ctx, workspaceStart); err != nil {
+		return clientpkg.TargetAuth{}, err
+	} else if !ok || strings.TrimRight(remoteURL, "/") != strings.TrimRight(spokeURL, "/") {
+		return clientpkg.TargetAuth{}, nil
+	}
+	if os.Getenv("KATA_SERVER") != "" {
+		return clientpkg.TargetAuth{}, nil
+	}
+	cfg, err := config.ReadDaemonConfig()
+	if err != nil {
+		return clientpkg.TargetAuth{}, err
+	}
+	if strings.TrimSpace(cfg.ActiveDaemon) == "" {
+		return clientpkg.TargetAuth{}, nil
+	}
+	entry := catalogByName(cfg, cfg.ActiveDaemon)
+	if entry == nil || entry.Local {
+		return clientpkg.TargetAuth{}, nil
+	}
+	entryURL, err := clientpkg.NormalizeRemoteURL(entry.URL, entry.AllowInsecure)
+	if err != nil {
+		return clientpkg.TargetAuth{}, err
+	}
+	if strings.TrimRight(entryURL, "/") != strings.TrimRight(spokeURL, "/") {
+		return clientpkg.TargetAuth{}, nil
+	}
+	token, err := selectedCatalogToken(entry)
+	if err != nil {
+		return clientpkg.TargetAuth{}, err
+	}
+	auth, err := config.ReadAuthConfig()
+	if err != nil {
+		auth.TrustPrivateNetwork = config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
+	}
+	return clientpkg.TargetAuth{
+		Token:               token,
+		AllowInsecure:       entry.AllowInsecure,
+		TrustPrivateNetwork: auth.TrustPrivateNetwork,
+	}, nil
 }
 
 func federationSpokeInstanceUID(ctx context.Context, client *http.Client, baseURL string) (string, error) {

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -174,7 +174,11 @@ func federationEnrollCmd() *cobra.Command {
 			}
 			adoptExisting := adoptExistingFlag
 			if !adoptExisting && pushCapable {
-				if spokeUID, ok := federationSpokeProjectUID(ctx, metadata.ProjectName, spokeInstance); ok {
+				spokeUID, ok, err := federationSpokeProjectUID(ctx, metadata.ProjectName, spokeInstance)
+				if err != nil {
+					return err
+				}
+				if ok {
 					// A same-name spoke project is normally adopted — unless it
 					// already shares the hub project's UID (it previously left
 					// this federation). Then the join is a plain rejoin and
@@ -248,7 +252,7 @@ func federationEnrollHTTPClientError(err error) error {
 }
 
 func federationSpokeProjectExists(ctx context.Context, projectName, spokeInstance string) bool {
-	_, ok := federationSpokeProjectUID(ctx, projectName, spokeInstance)
+	_, ok, _ := federationSpokeProjectUID(ctx, projectName, spokeInstance)
 	return ok
 }
 
@@ -256,22 +260,39 @@ func federationSpokeProjectExists(ctx context.Context, projectName, spokeInstanc
 // instance matches spokeInstance) has a project named projectName, returning
 // that project's UID. The UID is "" when the daemon's list payload predates
 // uid, in which case callers should fall back to the adoption default.
-func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance string) (string, bool) {
+func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance string) (string, bool, error) {
+	explicitDaemon := strings.TrimSpace(flags.Daemon) != ""
 	spokeURL, err := ensureDaemon(ctx)
 	if err != nil {
-		return "", false
+		if explicitDaemon {
+			return "", false, err
+		}
+		return "", false, nil
 	}
 	spokeClient, err := federationSpokeHTTPClient(ctx, spokeURL)
 	if err != nil {
-		return "", false
+		if explicitDaemon {
+			return "", false, err
+		}
+		return "", false, nil
 	}
 	if strings.TrimSpace(spokeInstance) != "" {
 		uid, err := federationSpokeInstanceUID(ctx, spokeClient, spokeURL)
 		if err != nil || uid != strings.TrimSpace(spokeInstance) {
-			return "", false
+			if err != nil && explicitDaemon {
+				return "", false, err
+			}
+			return "", false, nil
 		}
 	}
-	return federationSpokeProjectNameExists(ctx, spokeClient, spokeURL, projectName)
+	uid, ok, err := federationSpokeProjectNameExists(ctx, spokeClient, spokeURL, projectName)
+	if err != nil && explicitDaemon {
+		return "", false, err
+	}
+	if err != nil {
+		return "", false, nil
+	}
+	return uid, ok, nil
 }
 
 func federationSpokeHTTPClient(ctx context.Context, spokeURL string) (*http.Client, error) {
@@ -333,14 +354,17 @@ func federationSpokeInstanceUID(ctx context.Context, client *http.Client, baseUR
 	return strings.TrimSpace(body.InstanceUID), nil
 }
 
-func federationSpokeProjectNameExists(ctx context.Context, client *http.Client, baseURL, projectName string) (string, bool) {
+func federationSpokeProjectNameExists(ctx context.Context, client *http.Client, baseURL, projectName string) (string, bool, error) {
 	projectName = strings.TrimSpace(projectName)
 	if projectName == "" {
-		return "", false
+		return "", false, nil
 	}
 	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/projects", nil)
-	if err != nil || status >= 400 {
-		return "", false
+	if err != nil {
+		return "", false, err
+	}
+	if status >= 400 {
+		return "", false, apiErrFromBody(status, bs)
 	}
 	var body struct {
 		Projects []struct {
@@ -349,14 +373,14 @@ func federationSpokeProjectNameExists(ctx context.Context, client *http.Client, 
 		} `json:"projects"`
 	}
 	if err := json.Unmarshal(bs, &body); err != nil {
-		return "", false
+		return "", false, err
 	}
 	for _, project := range body.Projects {
 		if project.Name == projectName {
-			return project.UID, true
+			return project.UID, true, nil
 		}
 	}
-	return "", false
+	return "", false, nil
 }
 
 func federationEnrollmentsCmd() *cobra.Command {

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -300,8 +300,20 @@ func federationSpokeHTTPClient(ctx context.Context, spokeURL string) (*http.Clie
 	if err != nil {
 		return nil, err
 	}
+	if strings.TrimSpace(token) == "" {
+		opts.DaemonName = strings.TrimSpace(flags.Daemon)
+		return clientpkg.NewHTTPClient(ctx, spokeURL, opts)
+	}
+	auth, err := config.ReadAuthConfig()
+	if err != nil {
+		auth.TrustPrivateNetwork = config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
+	}
 	return clientpkg.NewHTTPClientForTarget(ctx, spokeURL,
-		clientpkg.TargetAuth{Token: token, AllowInsecure: entry.AllowInsecure}, opts)
+		clientpkg.TargetAuth{
+			Token:               token,
+			AllowInsecure:       entry.AllowInsecure,
+			TrustPrivateNetwork: auth.TrustPrivateNetwork,
+		}, opts)
 }
 
 func federationSpokeInstanceUID(ctx context.Context, client *http.Client, baseURL string) (string, error) {

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -261,9 +261,7 @@ func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance s
 	if err != nil {
 		return "", false
 	}
-	spokeClient, err := clientpkg.NewHTTPClientForTarget(ctx, spokeURL, clientpkg.TargetAuth{}, clientpkg.Opts{
-		Timeout: envHTTPTimeout(defaultHTTPTimeout),
-	})
+	spokeClient, err := federationSpokeHTTPClient(ctx, spokeURL)
 	if err != nil {
 		return "", false
 	}
@@ -274,6 +272,36 @@ func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance s
 		}
 	}
 	return federationSpokeProjectNameExists(ctx, spokeClient, spokeURL, projectName)
+}
+
+func federationSpokeHTTPClient(ctx context.Context, spokeURL string) (*http.Client, error) {
+	opts := clientpkg.Opts{Timeout: envHTTPTimeout(defaultHTTPTimeout)}
+	if strings.TrimSpace(flags.Daemon) == "" {
+		return clientpkg.NewHTTPClientForTarget(ctx, spokeURL, clientpkg.TargetAuth{}, opts)
+	}
+	cfg, err := config.ReadDaemonConfig()
+	if err != nil {
+		return nil, err
+	}
+	entry := catalogByName(cfg, flags.Daemon)
+	if entry == nil {
+		return clientpkg.NewHTTPClientForTarget(ctx, spokeURL, clientpkg.TargetAuth{}, opts)
+	}
+	if !entry.Local {
+		entryURL, err := clientpkg.NormalizeRemoteURL(entry.URL, entry.AllowInsecure)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimRight(entryURL, "/") != strings.TrimRight(spokeURL, "/") {
+			return clientpkg.NewHTTPClientForTarget(ctx, spokeURL, clientpkg.TargetAuth{}, opts)
+		}
+	}
+	token, err := selectedCatalogToken(entry)
+	if err != nil {
+		return nil, err
+	}
+	return clientpkg.NewHTTPClientForTarget(ctx, spokeURL,
+		clientpkg.TargetAuth{Token: token, AllowInsecure: entry.AllowInsecure}, opts)
 }
 
 func federationSpokeInstanceUID(ctx context.Context, client *http.Client, baseURL string) (string, error) {

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -261,7 +261,7 @@ func federationSpokeProjectExists(ctx context.Context, projectName, spokeInstanc
 // that project's UID. The UID is "" when the daemon's list payload predates
 // uid, in which case callers should fall back to the adoption default.
 func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance string) (string, bool, error) {
-	explicitDaemon := strings.TrimSpace(flags.Daemon) != ""
+	explicitDaemon := federationSpokeProbeExplicit(ctx)
 	spokeURL, err := ensureDaemon(ctx)
 	if err != nil {
 		if explicitDaemon {
@@ -293,6 +293,14 @@ func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance s
 		return "", false, nil
 	}
 	return uid, ok, nil
+}
+
+func federationSpokeProbeExplicit(ctx context.Context) bool {
+	if strings.TrimSpace(flags.Daemon) != "" {
+		return true
+	}
+	_, ok, err := clientpkg.ResolveRemote(ctx, workspaceStartForRemote())
+	return ok || err != nil
 }
 
 func federationSpokeHTTPClient(ctx context.Context, spokeURL string) (*http.Client, error) {

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -306,6 +306,13 @@ func federationSpokeProbeExplicit(ctx context.Context) bool {
 func federationSpokeHTTPClient(ctx context.Context, spokeURL string) (*http.Client, error) {
 	opts := clientpkg.Opts{Timeout: envHTTPTimeout(defaultHTTPTimeout)}
 	if strings.TrimSpace(flags.Daemon) == "" {
+		workspaceStart := workspaceStartForRemote()
+		if remoteURL, ok, err := clientpkg.ResolveRemote(ctx, workspaceStart); err != nil {
+			return nil, err
+		} else if ok && strings.TrimRight(remoteURL, "/") == strings.TrimRight(spokeURL, "/") {
+			opts.WorkspaceStart = workspaceStart
+			return clientpkg.NewHTTPClient(ctx, spokeURL, opts)
+		}
 		return clientpkg.NewHTTPClientForTarget(ctx, spokeURL, clientpkg.TargetAuth{}, opts)
 	}
 	cfg, err := config.ReadDaemonConfig()

--- a/cmd/kata/federation_hubadmin.go
+++ b/cmd/kata/federation_hubadmin.go
@@ -152,10 +152,19 @@ func catalogByURL(cat *config.DaemonConfig, url string) *config.CatalogDaemonCon
 // hubAdminClient builds an HTTP client for the resolved hub admin auth.
 func hubAdminClient(ctx context.Context, a hubAdminAuth) (*http.Client, error) {
 	opts := clientpkg.Opts{Timeout: envHTTPTimeout(defaultHTTPTimeout), AllowInsecure: a.allowInsecure}
+	auth, err := config.ReadAuthConfig()
+	if err != nil {
+		auth.TrustPrivateNetwork = config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
+	}
 	// Always NewHTTPClientForTarget: the supplied TargetAuth is the COMPLETE
 	// bearer policy for the hub origin. With no resolved hub credential the
 	// client is unauthenticated — never fall back to NewHTTPClient, which
 	// would attach the local daemon's global KATA_AUTH_TOKEN/[auth].token to
 	// the (stored, potentially hostile) hub URL.
-	return clientpkg.NewHTTPClientForTarget(ctx, a.url, clientpkg.TargetAuth{Token: strings.TrimSpace(a.token), AllowInsecure: a.allowInsecure}, opts)
+	return clientpkg.NewHTTPClientForTarget(ctx, a.url,
+		clientpkg.TargetAuth{
+			Token:               strings.TrimSpace(a.token),
+			AllowInsecure:       a.allowInsecure,
+			TrustPrivateNetwork: auth.TrustPrivateNetwork,
+		}, opts)
 }

--- a/cmd/kata/federation_hubadmin_test.go
+++ b/cmd/kata/federation_hubadmin_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -216,4 +218,21 @@ func TestHubAdminClientNeverSendsGlobalTokenWithoutHubCredential(t *testing.T) {
 	_ = resp.Body.Close()
 
 	assert.Empty(t, got, "global daemon token must not be sent to the hub origin")
+}
+
+func TestHubAdminClientHonorsTrustPrivateNetwork(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[auth]
+trust_private_network = true
+`), 0o600))
+
+	hc, err := hubAdminClient(context.Background(), hubAdminAuth{
+		url:   "http://100.64.0.5:7373",
+		token: "hub-admin-token",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, hc)
 }

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -477,7 +477,9 @@ func TestFederationEnrollCLIKATAServerSpokeAuthFailureErrors(t *testing.T) {
 	err = cmd.Execute()
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "token mismatch")
+	assert.Contains(t, err.Error(), "Authorization bearer required")
+	_, projectErr := hub.DB.ProjectByName(ctx, "fedlab")
+	assert.ErrorIs(t, projectErr, db.ErrNotFound)
 	enrollments, listErr := hub.DB.ListFederationEnrollments(ctx)
 	require.NoError(t, listErr)
 	assert.Empty(t, enrollments)
@@ -738,9 +740,9 @@ func TestFederationSpokeProjectExistsDoesNotAttachHubTokenToSpokeProbe(t *testin
 	assert.Equal(t, []string{""}, seenAuth)
 }
 
-func TestFederationSpokeHTTPClientUsesKATAServerGlobalAuth(t *testing.T) {
+func TestFederationSpokeHTTPClientDoesNotUseKATAServerGlobalAuth(t *testing.T) {
 	resetFlags(t)
-	t.Setenv("KATA_AUTH_TOKEN", "spoke-token")
+	t.Setenv("KATA_AUTH_TOKEN", "hub-token")
 	var gotAuth string
 	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -765,10 +767,10 @@ func TestFederationSpokeHTTPClientUsesKATAServerGlobalAuth(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-	assert.Equal(t, "Bearer spoke-token", gotAuth)
+	assert.Empty(t, gotAuth)
 }
 
-func TestFederationSpokeHTTPClientUsesNamedDaemonGlobalAuthFallback(t *testing.T) {
+func TestFederationSpokeHTTPClientDoesNotUseNamedDaemonGlobalAuthFallback(t *testing.T) {
 	resetFlags(t)
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
@@ -795,7 +797,7 @@ url = "`+spoke.URL+`"
 	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-	assert.Equal(t, "Bearer env-token", gotAuth)
+	assert.Empty(t, gotAuth)
 }
 
 func TestFederationSpokeHTTPClientNamedDaemonTokenEnvHonorsTrustPrivateNetwork(t *testing.T) {

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -382,6 +383,44 @@ func TestFederationEnrollCLIUsesKATAServerAsSpokeForAdoption(t *testing.T) {
 	require.Len(t, enrollments, 1)
 	require.NotNil(t, enrollments[0].ProjectID)
 	assert.Equal(t, hubProject.ID, *enrollments[0].ProjectID)
+	assert.True(t, enrollments[0].AllowAdoptionSnapshotAuthors)
+}
+
+func TestFederationEnrollCLIUsesNamedSpokeCatalogAuthForAdoption(t *testing.T) {
+	resetFlags(t)
+	spoke := testenv.New(t, testenv.WithAuthToken("spoke-token"))
+	hub := testenv.New(t, testenv.WithAuthToken("hub-token"))
+	ctx := context.Background()
+	_, err := spoke.DB.CreateProject(ctx, "fedlab")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(hub.Home, "config.toml"), []byte(`
+[[daemon]]
+name = "spoke"
+url = "`+spoke.URL+`"
+token = "spoke-token"
+`), 0o600))
+
+	cmd := newRootCmd()
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--daemon", "spoke",
+		"--project", "fedlab",
+		"federation", "enroll",
+		"--spoke-instance", spoke.DB.InstanceUID(),
+		"--hub-url", hub.URL,
+		"--actor", "wesm",
+	})
+
+	require.NoError(t, cmd.Execute())
+	out := buf.String()
+	assert.Contains(t, out, "--hub-url "+hub.URL)
+	assert.Contains(t, out, "--adopt-existing")
+
+	enrollments, err := hub.DB.ListFederationEnrollments(ctx)
+	require.NoError(t, err)
+	require.Len(t, enrollments, 1)
 	assert.True(t, enrollments[0].AllowAdoptionSnapshotAuthors)
 }
 

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -477,7 +477,7 @@ func TestFederationEnrollCLIKATAServerSpokeAuthFailureErrors(t *testing.T) {
 	err = cmd.Execute()
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Authorization bearer required")
+	assert.Contains(t, err.Error(), "token mismatch")
 	enrollments, listErr := hub.DB.ListFederationEnrollments(ctx)
 	require.NoError(t, listErr)
 	assert.Empty(t, enrollments)
@@ -736,6 +736,36 @@ func TestFederationSpokeProjectExistsDoesNotAttachHubTokenToSpokeProbe(t *testin
 	require.True(t, exists)
 	require.NotEmpty(t, seenAuth)
 	assert.Equal(t, []string{""}, seenAuth)
+}
+
+func TestFederationSpokeHTTPClientUsesKATAServerGlobalAuth(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("KATA_AUTH_TOKEN", "spoke-token")
+	var gotAuth string
+	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/ping":
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+		case "/probe":
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(spoke.Close)
+	t.Setenv("KATA_SERVER", spoke.URL)
+
+	hc, err := federationSpokeHTTPClient(context.Background(), spoke.URL)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, spoke.URL+"/probe", nil)
+	require.NoError(t, err)
+	resp, err := hc.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer spoke-token", gotAuth)
 }
 
 func TestFederationSpokeHTTPClientUsesNamedDaemonGlobalAuthFallback(t *testing.T) {

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -424,6 +424,34 @@ token = "spoke-token"
 	assert.True(t, enrollments[0].AllowAdoptionSnapshotAuthors)
 }
 
+func TestFederationEnrollCLIExplicitDaemonResolutionFailureErrors(t *testing.T) {
+	resetFlags(t)
+	hub := testenv.New(t, testenv.WithAuthToken("hub-token"))
+	ctx := context.Background()
+	t.Setenv("KATA_AUTH_TOKEN", "hub-token")
+
+	cmd := newRootCmd()
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--daemon", "missing-spoke",
+		"--project", "fedlab",
+		"federation", "enroll",
+		"--spoke-instance", "01HZNQ7VFPK1XGD8R5MABCD4EF",
+		"--hub-url", hub.URL,
+		"--actor", "operator",
+	})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-spoke")
+	enrollments, listErr := hub.DB.ListFederationEnrollments(ctx)
+	require.NoError(t, listErr)
+	assert.Empty(t, enrollments)
+}
+
 func TestFederationEnrollCLISameNameAutoAdoptionRequiresMatchingSpokeInstance(t *testing.T) {
 	resetFlags(t)
 	hub := testenv.New(t, testenv.WithAuthToken("hub-token"))

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -679,6 +679,59 @@ func TestFederationSpokeProjectExistsDoesNotAttachHubTokenToSpokeProbe(t *testin
 	assert.Equal(t, []string{""}, seenAuth)
 }
 
+func TestFederationSpokeHTTPClientUsesNamedDaemonGlobalAuthFallback(t *testing.T) {
+	resetFlags(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "env-token")
+	flags.Daemon = "spoke"
+	var gotAuth string
+	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(spoke.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "spoke"
+url = "`+spoke.URL+`"
+`), 0o600))
+
+	hc, err := federationSpokeHTTPClient(context.Background(), spoke.URL)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, spoke.URL+"/probe", nil)
+	require.NoError(t, err)
+	resp, err := hc.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer env-token", gotAuth)
+}
+
+func TestFederationSpokeHTTPClientNamedDaemonTokenEnvHonorsTrustPrivateNetwork(t *testing.T) {
+	resetFlags(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SPOKE_TOKEN", "spoke-token")
+	flags.Daemon = "spoke"
+	baseURL := "http://100.64.0.5:7373"
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[auth]
+trust_private_network = true
+
+[[daemon]]
+name = "spoke"
+url = "`+baseURL+`"
+token_env = "KATA_SPOKE_TOKEN"
+`), 0o600))
+
+	hc, err := federationSpokeHTTPClient(context.Background(), baseURL)
+
+	require.NoError(t, err)
+	assert.NotNil(t, hc)
+}
+
 func TestFederationSpokeProjectExistsUsesReadonlyGETProbe(t *testing.T) {
 	spokeUID := "01HZNQ7VFPK1XGD8R5MABCD4EF"
 	var seenMethods []string

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -452,6 +452,37 @@ func TestFederationEnrollCLIExplicitDaemonResolutionFailureErrors(t *testing.T) 
 	assert.Empty(t, enrollments)
 }
 
+func TestFederationEnrollCLIKATAServerSpokeAuthFailureErrors(t *testing.T) {
+	resetFlags(t)
+	spoke := testenv.New(t, testenv.WithAuthToken("spoke-token"))
+	hub := testenv.New(t, testenv.WithAuthToken("hub-token"))
+	t.Setenv("KATA_SERVER", spoke.URL)
+	t.Setenv("KATA_AUTH_TOKEN", "hub-token")
+	ctx := context.Background()
+	_, err := spoke.DB.CreateProject(ctx, "fedlab")
+	require.NoError(t, err)
+
+	cmd := newRootCmd()
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--project", "fedlab",
+		"federation", "enroll",
+		"--spoke-instance", spoke.DB.InstanceUID(),
+		"--hub-url", hub.URL,
+		"--actor", "operator",
+	})
+
+	err = cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Authorization bearer required")
+	enrollments, listErr := hub.DB.ListFederationEnrollments(ctx)
+	require.NoError(t, listErr)
+	assert.Empty(t, enrollments)
+}
+
 func TestFederationEnrollCLISameNameAutoAdoptionRequiresMatchingSpokeInstance(t *testing.T) {
 	resetFlags(t)
 	hub := testenv.New(t, testenv.WithAuthToken("hub-token"))

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -26,6 +26,7 @@ type globalFlags struct {
 	As           string
 	Workspace    string
 	Project      string
+	Daemon       string
 }
 
 var flags globalFlags
@@ -67,6 +68,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.As, "as", "", "override actor (default: $KATA_AUTHOR > $USER > git > anonymous)")
 	cmd.PersistentFlags().StringVar(&flags.Workspace, "workspace", "", "path used for project resolution (default: cwd)")
 	cmd.PersistentFlags().StringVar(&flags.Project, "project", "", "project name for project-scoped commands")
+	cmd.PersistentFlags().StringVar(&flags.Daemon, "daemon", "", "named daemon catalog entry to target for this command")
 	// Catch the cobra/pflag pitfall where a positional that looks like
 	// a negative integer (kata show -1, kata delete -1) is parsed as
 	// a flag and produces "unknown shorthand flag: '1' in -1" — useless

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -498,6 +500,29 @@ func TestHealth_DoesNotAutoStartDaemon(t *testing.T) {
 	assert.Equal(t, kindDaemonUnavail, ce.Kind)
 	assert.Contains(t, ce.Message, "no daemon running",
 		"hint must point the user at the right action")
+}
+
+func TestHealth_NamedLocalDaemonDoesNotAutoStart(t *testing.T) {
+	resetFlags(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "local"
+local = true
+`), 0o600))
+	flags.Daemon = "local"
+
+	_, err := discoverDaemon(context.Background())
+
+	require.Error(t, err)
+	var ce *cliError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, ExitDaemonUnavail, ce.ExitCode)
+	assert.Equal(t, kindDaemonUnavail, ce.Kind)
+	assert.Contains(t, ce.Message, "no daemon running",
+		"named local health must inspect existing runtime files, not auto-start")
 }
 
 // TestHealth_HonorsKataServer ensures a configured remote URL is

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -21,6 +21,7 @@ func TestRoot_HelpListsUniversalFlags(t *testing.T) {
 	assert.Contains(t, out, "--quiet")
 	assert.Contains(t, out, "--as")
 	assert.Contains(t, out, "--workspace")
+	assert.Contains(t, out, "--daemon")
 	assertNoFederationStorageInternals(t, out)
 }
 
@@ -93,6 +94,7 @@ func TestNewRootCmdResetsGlobalFlagState(t *testing.T) {
 	flags.JSON = true
 	flags.Agent = true
 	flags.Workspace = "/tmp/leaked"
+	flags.Daemon = "shared"
 
 	var out bytes.Buffer
 	cmd := newRootCmd()
@@ -105,6 +107,7 @@ func TestNewRootCmdResetsGlobalFlagState(t *testing.T) {
 	assert.False(t, flags.Agent)
 	assert.Empty(t, flags.FormatValues)
 	assert.Empty(t, flags.Workspace)
+	assert.Empty(t, flags.Daemon)
 }
 
 // TestExitCodeFor_PureMapping pins the exit-code decision logic so a future

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -144,11 +144,12 @@ Or commit-free per-workspace:
    [server]
    url = "http://100.64.0.5:7777"
 
-KATA_SERVER wins over the file when both are set. If neither is set, clients
-next honor active_daemon in <KATA_HOME>/config.toml; otherwise they use the
-local daemon: Unix socket on Unix platforms, loopback TCP on Windows. A
-configured-but-down remote returns exit 7 (kata server not responding) — no
-silent fallback to spawning a local daemon.
+KATA_SERVER wins over the file when both are set unless a command passes
+--daemon <name>. If none of those are set, clients next honor active_daemon
+in <KATA_HOME>/config.toml; otherwise they use the local daemon: Unix socket
+on Unix platforms, loopback TCP on Windows. A configured-but-down remote
+returns exit 7 (kata server not responding) — no silent fallback to spawning
+a local daemon.
 `
 
 const agentQuickstartCompactText = `Use kata as the shared issue ledger for this workspace.

--- a/cmd/kata/tui_cmd.go
+++ b/cmd/kata/tui_cmd.go
@@ -51,6 +51,7 @@ terminal text selection while mouse tracking is enabled.`,
 				Stdout:           cmd.OutOrStdout(),
 				Stderr:           cmd.ErrOrStderr(),
 				DisplayUIDFormat: uidFormat,
+				DaemonName:       flags.Daemon,
 				Mouse:            mouseEnabled,
 			})
 		},

--- a/docker/federation/runner.sh
+++ b/docker/federation/runner.sh
@@ -111,10 +111,19 @@ expect_cli_failure() {
 log "verifying CLI enrollment creates a missing hub project"
 cli_project=federation-cli-enroll-missing
 cli_token=federation-cli-enroll-token
+cli_enroll_home=/data/kata/runner-cli-enroll
 spoke_a_uid=$(get "$spoke_a/api/v1/instance" | jq -r '.instance_uid')
+mkdir -p "$cli_enroll_home"
+cat >"$cli_enroll_home/config.toml" <<EOF
+[[daemon]]
+name = "spoke-a"
+url = "$spoke_a"
+token_env = "KATA_SPOKE_TOKEN"
+allow_insecure = true
+EOF
 cli_enroll_out=$(
-  KATA_HOME=/data/kata/runner-cli-enroll KATA_SERVER="$spoke_a" \
-    kata --project "$cli_project" federation enroll \
+  KATA_HOME="$cli_enroll_home" KATA_SPOKE_TOKEN="$hub_token" \
+    kata --daemon spoke-a --project "$cli_project" federation enroll \
       --spoke-instance "$spoke_a_uid" \
       --hub-url "$hub_hostname" \
       --capabilities pull,push \
@@ -157,7 +166,7 @@ fi
 get "$hub/api/v1/projects/$cli_project_id/federation" >/dev/null
 
 log "verifying CLI enrollment join command syncs over plaintext hostname"
-KATA_HOME=/data/kata/runner-cli-enroll KATA_SERVER="$spoke_a" bash -c "$cli_join_cmd" >/dev/null
+KATA_HOME="$cli_enroll_home" KATA_SERVER="$spoke_a" bash -c "$cli_join_cmd" >/dev/null
 cli_spoke_project_id=$(get "$spoke_a/api/v1/projects" | jq -r --arg name "$cli_project" '.projects[]? | select(.name == $name) | .id')
 if [[ -z "$cli_spoke_project_id" ]]; then
   log "CLI join did not create spoke project $cli_project"

--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -49,8 +49,9 @@ version = 1
 url = "http://100.64.0.5:7777"
 ```
 
-`KATA_SERVER` wins over `.kata.local.toml`.
-If neither is set, clients next honor `active_daemon` in
+`KATA_SERVER` wins over `.kata.local.toml` unless a command passes
+`--daemon <name>`.
+If none of those are set, clients next honor `active_daemon` in
 `<KATA_HOME>/config.toml`; otherwise they use local daemon discovery or
 auto-start.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,6 +9,7 @@ current flag list in your installed binary.
 | --- | --- |
 | `--workspace <path>` | Resolve project context from a specific workspace. |
 | `--project <name>` | Select a project explicitly for project-scoped commands. |
+| `--daemon <name>` | Target a named daemon catalog entry for this command. |
 | `--as <actor>` | Override the actor for this command. |
 | `--agent` | Emit concise agent-readable text. |
 | `--json` | Emit machine-readable JSON. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -65,14 +65,16 @@ version = 1
 url = "http://100.64.0.5:7777"
 ```
 
-`KATA_SERVER` wins over the local file.
+`KATA_SERVER` wins over the local file unless a command passes
+`--daemon <name>`.
 
 Daemon target resolution order is:
 
-1. `KATA_SERVER`
-2. `.kata.local.toml` `[server].url`
-3. `active_daemon` in `<KATA_HOME>/config.toml`
-4. local daemon discovery or auto-start
+1. `--daemon <name>`
+2. `KATA_SERVER`
+3. `.kata.local.toml` `[server].url`
+4. `active_daemon` in `<KATA_HOME>/config.toml`
+5. local daemon discovery or auto-start
 
 Committed `.kata.toml` files bind the project name only; do not put daemon
 routing or tokens there.

--- a/e2e/token_identity_test.go
+++ b/e2e/token_identity_test.go
@@ -168,7 +168,7 @@ func TestTokenIdentity_FederationPersonalTokenEnrollJoinAndPush(t *testing.T) {
 		"KATA_HTTP_TIMEOUT=10s",
 	)
 	spokeStderr := startDaemon(t, bin, spokeEnv)
-	spokeURL, _ := connectDaemon(t, spokeDirs, spokeStderr)
+	_, _ = connectDaemon(t, spokeDirs, spokeStderr)
 	spokeIdentityOut := runRemoteCmdOutput(t, bin, spokeDirs.repoDir, spokeEnv,
 		"--json", "federation", "identity")
 	var spokeIdentity struct {
@@ -179,7 +179,6 @@ func TestTokenIdentity_FederationPersonalTokenEnrollJoinAndPush(t *testing.T) {
 	require.NotEmpty(t, spokeIdentity.InstanceUID)
 
 	bootstrapEnrollEnv := append(spokeDirs.env(),
-		"KATA_SERVER="+spokeURL,
 		"KATA_AUTH_TOKEN="+identityBootstrapToken,
 		"KATA_AUTHOR=e2e-client",
 		"KATA_HTTP_TIMEOUT=10s",
@@ -193,7 +192,6 @@ func TestTokenIdentity_FederationPersonalTokenEnrollJoinAndPush(t *testing.T) {
 	assert.Contains(t, bootstrapOut, "bootstrap token cannot perform attributed writes")
 
 	enrollEnv := append(spokeDirs.env(),
-		"KATA_SERVER="+spokeURL,
 		"KATA_AUTH_TOKEN="+userToken,
 		"KATA_AUTHOR=e2e-client",
 		"KATA_HTTP_TIMEOUT=10s",

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -85,7 +85,8 @@ func authBearerTransport(
 func explicitBearerTransport(
 	base http.RoundTripper,
 	token, baseURL string,
+	trustPrivateNetwork bool,
 	allowInsecure bool,
 ) (http.RoundTripper, error) {
-	return authBearerTransport(base, token, baseURL, false, allowInsecure)
+	return authBearerTransport(base, token, baseURL, trustPrivateNetwork, allowInsecure)
 }

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -26,13 +26,17 @@ func resolveAuthToken() string {
 }
 
 func resolveAuthConfig() config.AuthConfig {
-	envToken := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
+	envToken := authTokenEnvOverride()
 	envTrust := config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
 	auth, err := config.ReadAuthConfig()
 	if err != nil {
 		return config.AuthConfig{Token: envToken, TrustPrivateNetwork: envTrust}
 	}
 	return auth
+}
+
+func authTokenEnvOverride() string {
+	return strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
 }
 
 // withBearer wraps base with bearer-token injection when token is

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -632,7 +632,7 @@ func TestNewHTTPClientForTargetAllowInsecureStillRefusesCrossOrigin(t *testing.T
 		called = true
 		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
 	})
-	rt, err := explicitBearerTransport(base, "target-token", "http://100.64.0.5:7373", true)
+	rt, err := explicitBearerTransport(base, "target-token", "http://100.64.0.5:7373", false, true)
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		"http://100.64.0.6:7373/api/v1/ping", nil)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -169,8 +169,8 @@ func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client
 				target.Name, target.BaseURL, strings.TrimRight(baseURL, "/"))
 		}
 		if !target.Local {
+			auth := resolveAuthConfig()
 			if token := authTokenEnvOverride(); token != "" {
-				auth := resolveAuthConfig()
 				return NewHTTPClientForTarget(ctx, baseURL,
 					TargetAuth{
 						Token:               token,
@@ -179,7 +179,11 @@ func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client
 					}, opts)
 			}
 			return NewHTTPClientForTarget(ctx, baseURL,
-				TargetAuth{Token: target.Token, AllowInsecure: target.AllowInsecure}, opts)
+				TargetAuth{
+					Token:               target.Token,
+					AllowInsecure:       target.AllowInsecure,
+					TrustPrivateNetwork: auth.TrustPrivateNetwork,
+				}, opts)
 		}
 		if target.Token != "" {
 			return NewHTTPClientWithBearer(ctx, baseURL, target.Token, opts)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -168,9 +168,9 @@ func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client
 				target.Name, target.BaseURL, strings.TrimRight(baseURL, "/"))
 		}
 		if !target.Local {
-			if globalAuthTokenOverrideSet() {
+			if token := authTokenEnvOverride(); token != "" {
 				return NewHTTPClientForTarget(ctx, baseURL,
-					TargetAuth{Token: resolveAuthConfig().Token, AllowInsecure: target.AllowInsecure}, opts)
+					TargetAuth{Token: token, AllowInsecure: target.AllowInsecure}, opts)
 			}
 			return NewHTTPClientForTarget(ctx, baseURL,
 				TargetAuth{Token: target.Token, AllowInsecure: target.AllowInsecure}, opts)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -141,8 +141,9 @@ type Opts struct {
 // process and therefore cannot rely on the package-global auth resolution
 // path.
 type TargetAuth struct {
-	Token         string
-	AllowInsecure bool
+	Token               string
+	AllowInsecure       bool
+	TrustPrivateNetwork bool
 }
 
 // NewHTTPClient returns an *http.Client whose transport matches baseURL —
@@ -169,8 +170,13 @@ func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client
 		}
 		if !target.Local {
 			if token := authTokenEnvOverride(); token != "" {
+				auth := resolveAuthConfig()
 				return NewHTTPClientForTarget(ctx, baseURL,
-					TargetAuth{Token: token, AllowInsecure: target.AllowInsecure}, opts)
+					TargetAuth{
+						Token:               token,
+						AllowInsecure:       target.AllowInsecure,
+						TrustPrivateNetwork: auth.TrustPrivateNetwork,
+					}, opts)
 			}
 			return NewHTTPClientForTarget(ctx, baseURL,
 				TargetAuth{Token: target.Token, AllowInsecure: target.AllowInsecure}, opts)
@@ -210,7 +216,8 @@ func NewHTTPClientForTarget(ctx context.Context, baseURL string, auth TargetAuth
 	if err != nil {
 		return nil, err
 	}
-	rt, err := explicitBearerTransport(c.Transport, auth.Token, baseURL, auth.AllowInsecure)
+	rt, err := explicitBearerTransport(c.Transport, auth.Token, baseURL,
+		auth.TrustPrivateNetwork, auth.AllowInsecure)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -159,7 +159,7 @@ type TargetAuth struct {
 // through every request site.
 func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client, error) {
 	if opts.DaemonName != "" {
-		target, err := resolveNamedDaemonTarget(ctx, opts.DaemonName)
+		target, err := namedDaemonTargetForBaseURL(opts.DaemonName, baseURL)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -174,6 +174,8 @@ func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client
 		if target.Token != "" {
 			return NewHTTPClientWithBearer(ctx, baseURL, target.Token, opts)
 		}
+		auth := resolveAuthConfig()
+		return newHTTPClientWithAuth(ctx, baseURL, auth, opts)
 	}
 	if auth, ok, err := activeRemoteTargetAuthForBaseURL(baseURL, opts.WorkspaceStart); err != nil {
 		return nil, err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -133,6 +133,7 @@ type Opts struct {
 	ResponseHeaderTimeout time.Duration
 	AllowInsecure         bool
 	WorkspaceStart        string
+	DaemonName            string
 }
 
 // TargetAuth is explicit per-target bearer configuration. It is used by
@@ -157,6 +158,23 @@ type TargetAuth struct {
 // from the first-party CLI/TUI without callers having to plumb the header
 // through every request site.
 func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client, error) {
+	if opts.DaemonName != "" {
+		target, err := resolveNamedDaemonTarget(ctx, opts.DaemonName)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimRight(baseURL, "/") != target.BaseURL {
+			return nil, fmt.Errorf("daemon %q resolved to %s, not %s",
+				target.Name, target.BaseURL, strings.TrimRight(baseURL, "/"))
+		}
+		if !target.Local {
+			return NewHTTPClientForTarget(ctx, baseURL,
+				TargetAuth{Token: target.Token, AllowInsecure: target.AllowInsecure}, opts)
+		}
+		if target.Token != "" {
+			return NewHTTPClientWithBearer(ctx, baseURL, target.Token, opts)
+		}
+	}
 	if auth, ok, err := activeRemoteTargetAuthForBaseURL(baseURL, opts.WorkspaceStart); err != nil {
 		return nil, err
 	} else if ok {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -168,6 +168,10 @@ func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client
 				target.Name, target.BaseURL, strings.TrimRight(baseURL, "/"))
 		}
 		if !target.Local {
+			if globalAuthTokenOverrideSet() {
+				return NewHTTPClientForTarget(ctx, baseURL,
+					TargetAuth{Token: resolveAuthConfig().Token, AllowInsecure: target.AllowInsecure}, opts)
+			}
 			return NewHTTPClientForTarget(ctx, baseURL,
 				TargetAuth{Token: target.Token, AllowInsecure: target.AllowInsecure}, opts)
 		}

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -39,12 +39,36 @@ type activeRemoteTarget struct {
 // of CLI-layer types so this package stays importable from the TUI.
 var ErrRemoteUnavailable = errors.New("kata server not responding")
 
+// ErrNamedDaemonNotFound marks a --daemon/catalog selection that does not
+// match any [[daemon]] entry in <KATA_HOME>/config.toml.
+var ErrNamedDaemonNotFound = errors.New("named daemon not found")
+
+type namedDaemonTarget struct {
+	Name          string
+	Local         bool
+	BaseURL       string
+	Token         string
+	AllowInsecure bool
+}
+
 // ResolveRemote is the exported view of resolveRemote so callers
 // outside client (e.g. cmd/kata health) can honor the same
 // KATA_SERVER / .kata.local.toml / active_daemon resolution rules without
 // auto-starting a local daemon.
 func ResolveRemote(ctx context.Context, workspaceStart string) (string, bool, error) {
 	return resolveRemote(ctx, workspaceStart)
+}
+
+// EnsureNamedRunning returns the base URL for a named daemon catalog entry,
+// auto-starting local entries and probing remote entries. It is an explicit
+// per-invocation selection and therefore ignores KATA_SERVER, .kata.local.toml,
+// and active_daemon.
+func EnsureNamedRunning(ctx context.Context, name string) (string, error) {
+	target, err := resolveNamedDaemonTarget(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	return target.BaseURL, nil
 }
 
 // NormalizeRemoteURL exposes kata's remote URL validation/canonicalization
@@ -130,6 +154,72 @@ func resolveActiveRemote(ctx context.Context) (string, bool, error) {
 			ErrRemoteUnavailable, target.BaseURL, daemonConfigSource(), target.Name)
 	}
 	return target.BaseURL, true, nil
+}
+
+func resolveNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTarget, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return namedDaemonTarget{}, fmt.Errorf("%w: empty name", ErrNamedDaemonNotFound)
+	}
+	cfg, err := config.ReadDaemonConfig()
+	if err != nil {
+		return namedDaemonTarget{}, err
+	}
+	for _, daemon := range cfg.Daemons {
+		if daemon.Name != name {
+			continue
+		}
+		if daemon.Local {
+			baseURL, err := EnsureLocalRunning(ctx)
+			if err != nil {
+				return namedDaemonTarget{}, err
+			}
+			target := activeRemoteTarget{
+				Name:          daemon.Name,
+				Token:         daemon.Token,
+				TokenEnv:      daemon.TokenEnv,
+				AllowInsecure: daemon.AllowInsecure,
+			}
+			token, err := resolveActiveRemoteTargetToken(target)
+			if err != nil {
+				return namedDaemonTarget{}, err
+			}
+			return namedDaemonTarget{
+				Name:          daemon.Name,
+				Local:         true,
+				BaseURL:       baseURL,
+				Token:         token,
+				AllowInsecure: daemon.AllowInsecure,
+			}, nil
+		}
+		baseURL, err := normalizeRemoteURL(daemon.URL, daemon.AllowInsecure)
+		if err != nil {
+			return namedDaemonTarget{}, fmt.Errorf("%s daemon %q url %q: %w",
+				daemonConfigSource(), daemon.Name, daemon.URL, err)
+		}
+		target := activeRemoteTarget{
+			Name:          daemon.Name,
+			BaseURL:       baseURL,
+			Token:         daemon.Token,
+			TokenEnv:      daemon.TokenEnv,
+			AllowInsecure: daemon.AllowInsecure,
+		}
+		token, err := resolveActiveRemoteTargetToken(target)
+		if err != nil {
+			return namedDaemonTarget{}, err
+		}
+		if !probeRemote(ctx, baseURL) {
+			return namedDaemonTarget{}, fmt.Errorf("%w: %s (%s daemon %q)",
+				ErrRemoteUnavailable, baseURL, daemonConfigSource(), daemon.Name)
+		}
+		return namedDaemonTarget{
+			Name:          daemon.Name,
+			BaseURL:       baseURL,
+			Token:         token,
+			AllowInsecure: daemon.AllowInsecure,
+		}, nil
+	}
+	return namedDaemonTarget{}, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, name)
 }
 
 func activeRemoteFromConfig() (activeRemoteTarget, bool, error) {

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -59,6 +59,17 @@ func ResolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 	return resolveRemote(ctx, workspaceStart)
 }
 
+// DiscoverNamed returns the base URL for a named daemon catalog entry without
+// starting a local daemon. Local entries inspect runtime files only; remote
+// entries are normalized and probed.
+func DiscoverNamed(ctx context.Context, name string) (string, bool, error) {
+	target, ok, err := discoverNamedDaemonTarget(ctx, name)
+	if err != nil || !ok {
+		return "", ok, err
+	}
+	return target.BaseURL, true, nil
+}
+
 // EnsureNamedRunning returns the base URL for a named daemon catalog entry,
 // auto-starting local entries and probing remote entries. It is an explicit
 // per-invocation selection and therefore ignores KATA_SERVER, .kata.local.toml,
@@ -156,6 +167,47 @@ func resolveActiveRemote(ctx context.Context) (string, bool, error) {
 	return target.BaseURL, true, nil
 }
 
+func discoverNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTarget, bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return namedDaemonTarget{}, false, fmt.Errorf("%w: empty name", ErrNamedDaemonNotFound)
+	}
+	cfg, err := config.ReadDaemonConfig()
+	if err != nil {
+		return namedDaemonTarget{}, false, err
+	}
+	for _, d := range cfg.Daemons {
+		if d.Name != name {
+			continue
+		}
+		if d.Local {
+			ns, err := daemon.NewNamespace()
+			if err != nil {
+				return namedDaemonTarget{}, false, err
+			}
+			baseURL, ok := Discover(ctx, ns.DataDir)
+			if !ok {
+				return namedDaemonTarget{}, false, nil
+			}
+			target, err := namedDaemonTargetFromCatalog(d, baseURL, true)
+			if err != nil {
+				return namedDaemonTarget{}, false, err
+			}
+			return target, true, nil
+		}
+		target, err := namedDaemonTargetFromCatalog(d, "", false)
+		if err != nil {
+			return namedDaemonTarget{}, false, err
+		}
+		if !probeRemote(ctx, target.BaseURL) {
+			return namedDaemonTarget{}, false, fmt.Errorf("%w: %s (%s daemon %q)",
+				ErrRemoteUnavailable, target.BaseURL, daemonConfigSource(), d.Name)
+		}
+		return target, true, nil
+	}
+	return namedDaemonTarget{}, false, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, name)
+}
+
 func resolveNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTarget, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -165,61 +217,62 @@ func resolveNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTarg
 	if err != nil {
 		return namedDaemonTarget{}, err
 	}
-	for _, daemon := range cfg.Daemons {
-		if daemon.Name != name {
+	for _, d := range cfg.Daemons {
+		if d.Name != name {
 			continue
 		}
-		if daemon.Local {
+		if d.Local {
 			baseURL, err := EnsureLocalRunning(ctx)
 			if err != nil {
 				return namedDaemonTarget{}, err
 			}
-			target := activeRemoteTarget{
-				Name:          daemon.Name,
-				Token:         daemon.Token,
-				TokenEnv:      daemon.TokenEnv,
-				AllowInsecure: daemon.AllowInsecure,
-			}
-			token, err := resolveActiveRemoteTargetToken(target)
-			if err != nil {
-				return namedDaemonTarget{}, err
-			}
-			return namedDaemonTarget{
-				Name:          daemon.Name,
-				Local:         true,
-				BaseURL:       baseURL,
-				Token:         token,
-				AllowInsecure: daemon.AllowInsecure,
-			}, nil
+			return namedDaemonTargetFromCatalog(d, baseURL, true)
 		}
-		baseURL, err := normalizeRemoteURL(daemon.URL, daemon.AllowInsecure)
+		target, err := namedDaemonTargetFromCatalog(d, "", false)
+		if err != nil {
+			return namedDaemonTarget{}, err
+		}
+		if !probeRemote(ctx, target.BaseURL) {
+			return namedDaemonTarget{}, fmt.Errorf("%w: %s (%s daemon %q)",
+				ErrRemoteUnavailable, target.BaseURL, daemonConfigSource(), d.Name)
+		}
+		return target, nil
+	}
+	return namedDaemonTarget{}, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, name)
+}
+
+func namedDaemonTargetFromCatalog(
+	daemon config.CatalogDaemonConfig,
+	localBaseURL string,
+	local bool,
+) (namedDaemonTarget, error) {
+	baseURL := localBaseURL
+	if !local {
+		var err error
+		baseURL, err = normalizeRemoteURL(daemon.URL, daemon.AllowInsecure)
 		if err != nil {
 			return namedDaemonTarget{}, fmt.Errorf("%s daemon %q url %q: %w",
 				daemonConfigSource(), daemon.Name, daemon.URL, err)
 		}
-		target := activeRemoteTarget{
-			Name:          daemon.Name,
-			BaseURL:       baseURL,
-			Token:         daemon.Token,
-			TokenEnv:      daemon.TokenEnv,
-			AllowInsecure: daemon.AllowInsecure,
-		}
-		token, err := resolveActiveRemoteTargetToken(target)
-		if err != nil {
-			return namedDaemonTarget{}, err
-		}
-		if !probeRemote(ctx, baseURL) {
-			return namedDaemonTarget{}, fmt.Errorf("%w: %s (%s daemon %q)",
-				ErrRemoteUnavailable, baseURL, daemonConfigSource(), daemon.Name)
-		}
-		return namedDaemonTarget{
-			Name:          daemon.Name,
-			BaseURL:       baseURL,
-			Token:         token,
-			AllowInsecure: daemon.AllowInsecure,
-		}, nil
 	}
-	return namedDaemonTarget{}, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, name)
+	target := activeRemoteTarget{
+		Name:          daemon.Name,
+		BaseURL:       baseURL,
+		Token:         daemon.Token,
+		TokenEnv:      daemon.TokenEnv,
+		AllowInsecure: daemon.AllowInsecure,
+	}
+	token, err := resolveActiveRemoteTargetToken(target)
+	if err != nil {
+		return namedDaemonTarget{}, err
+	}
+	return namedDaemonTarget{
+		Name:          daemon.Name,
+		Local:         local,
+		BaseURL:       baseURL,
+		Token:         token,
+		AllowInsecure: daemon.AllowInsecure,
+	}, nil
 }
 
 func activeRemoteFromConfig() (activeRemoteTarget, bool, error) {

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -283,9 +283,13 @@ func namedDaemonTargetFromCatalog(
 		TokenEnv:      daemon.TokenEnv,
 		AllowInsecure: daemon.AllowInsecure,
 	}
-	token, err := resolveActiveRemoteTargetToken(target)
-	if err != nil {
-		return namedDaemonTarget{}, err
+	token := daemon.Token
+	if local || !globalAuthTokenOverrideSet() {
+		var err error
+		token, err = resolveActiveRemoteTargetToken(target)
+		if err != nil {
+			return namedDaemonTarget{}, err
+		}
 	}
 	return namedDaemonTarget{
 		Name:          daemon.Name,

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -359,9 +359,11 @@ func activeRemoteTargetAuthForBaseURL(baseURL, workspaceStart string) (TargetAut
 	if err != nil {
 		return TargetAuth{}, false, err
 	}
+	auth := resolveAuthConfig()
 	return TargetAuth{
-		Token:         token,
-		AllowInsecure: target.AllowInsecure,
+		Token:               token,
+		AllowInsecure:       target.AllowInsecure,
+		TrustPrivateNetwork: auth.TrustPrivateNetwork,
 	}, true, nil
 }
 

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -241,6 +241,27 @@ func resolveNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTarg
 	return namedDaemonTarget{}, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, name)
 }
 
+func namedDaemonTargetForBaseURL(name, baseURL string) (namedDaemonTarget, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return namedDaemonTarget{}, fmt.Errorf("%w: empty name", ErrNamedDaemonNotFound)
+	}
+	cfg, err := config.ReadDaemonConfig()
+	if err != nil {
+		return namedDaemonTarget{}, err
+	}
+	for _, d := range cfg.Daemons {
+		if d.Name != name {
+			continue
+		}
+		if d.Local {
+			return namedDaemonTargetFromCatalog(d, strings.TrimRight(baseURL, "/"), true)
+		}
+		return namedDaemonTargetFromCatalog(d, "", false)
+	}
+	return namedDaemonTarget{}, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, name)
+}
+
 func namedDaemonTargetFromCatalog(
 	daemon config.CatalogDaemonConfig,
 	localBaseURL string,

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -388,6 +388,27 @@ url = "`+baseURL+`"
 	assert.NotNil(t, c)
 }
 
+func TestNewHTTPClient_NamedRemoteCatalogTokenHonorsTrustPrivateNetwork(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+	baseURL := "http://100.64.0.5:7373"
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "shared"
+url = "`+baseURL+`"
+token = "catalog-token"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), baseURL, Opts{
+		Timeout:    time.Second,
+		DaemonName: "shared",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
 func TestNewHTTPClient_NamedLocalUsesCatalogToken(t *testing.T) {
 	home := setupKataEnv(t)
 	var gotAuth string

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -409,6 +409,30 @@ token = "catalog-token"
 	assert.NotNil(t, c)
 }
 
+func TestNewHTTPClient_ActiveRemoteTokenEnvHonorsTrustPrivateNetwork(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_SHARED_TOKEN", "catalog-env-token")
+	baseURL := "http://100.64.0.5:7373"
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+active_daemon = "shared"
+
+[auth]
+trust_private_network = true
+
+[[daemon]]
+name = "shared"
+url = "`+baseURL+`"
+token_env = "KATA_SHARED_TOKEN"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), baseURL, Opts{Timeout: time.Second})
+
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
 func TestNewHTTPClient_NamedLocalUsesCatalogToken(t *testing.T) {
 	home := setupKataEnv(t)
 	var gotAuth string

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -170,6 +172,109 @@ token_env = "KATA_SHARED_TOKEN"
 	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, srv.URL, url)
+}
+
+func TestEnsureNamedRunning_RemoteCatalogTargetWinsOverEnv(t *testing.T) {
+	selected := pingingServer(t)
+	env := pingingServer(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", env.URL)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "shared"
+url = "`+selected.URL+`"
+`), 0o600))
+
+	url, err := EnsureNamedRunning(context.Background(), "shared")
+
+	require.NoError(t, err)
+	assert.Equal(t, selected.URL, url)
+}
+
+func TestNewHTTPClient_NamedRemoteUsesCatalogToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/ping":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"service": "kata",
+				"version": "test",
+			})
+		case "/protected":
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token = "catalog-token"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
+		Timeout:    time.Second,
+		DaemonName: "shared",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer catalog-token", gotAuth)
+}
+
+func TestNewHTTPClient_NamedLocalUsesCatalogToken(t *testing.T) {
+	home := setupKataEnv(t)
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/ping":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"service": "kata",
+				"version": currentVersionForEnsure(),
+				"pid":     os.Getpid(),
+			})
+		case "/protected":
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, writeRuntimeRecord(t, home, strings.TrimPrefix(srv.URL, "http://")))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "local-auth"
+local = true
+token = "local-token"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
+		Timeout:    time.Second,
+		DaemonName: "local-auth",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer local-token", gotAuth)
 }
 
 func TestResolveRemote_FileUnreachableErrors(t *testing.T) {

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -307,6 +307,46 @@ token = "local-token"
 	assert.Equal(t, "Bearer local-token", gotAuth)
 }
 
+func TestNewHTTPClient_NamedLocalBypassesActiveDaemonAuth(t *testing.T) {
+	home := setupKataEnv(t)
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("KATA_REMOTE_TOKEN", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+active_daemon = "remote"
+
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "local"
+local = true
+
+[[daemon]]
+name = "remote"
+url = "`+srv.URL+`"
+token_env = "KATA_REMOTE_TOKEN"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
+		Timeout:    time.Second,
+		DaemonName: "local",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer global-token", gotAuth)
+}
+
 func TestResolveRemote_FileUnreachableErrors(t *testing.T) {
 	t.Setenv("KATA_SERVER", "")
 	dir := t.TempDir()

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -367,6 +367,27 @@ url = "`+srv.URL+`"
 	assert.Equal(t, "Bearer client-token", gotAuth)
 }
 
+func TestNewHTTPClient_NamedRemoteAuthTokenEnvHonorsTrustPrivateNetwork(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "env-token")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+	baseURL := "http://100.64.0.5:7373"
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "shared"
+url = "`+baseURL+`"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), baseURL, Opts{
+		Timeout:    time.Second,
+		DaemonName: "shared",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
 func TestNewHTTPClient_NamedLocalUsesCatalogToken(t *testing.T) {
 	home := setupKataEnv(t)
 	var gotAuth string

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -234,6 +234,92 @@ token = "catalog-token"
 	assert.Equal(t, "Bearer catalog-token", gotAuth)
 }
 
+func TestNewHTTPClient_NamedRemoteAuthTokenEnvOverridesUnsetCatalogTokenEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "env-token")
+	t.Setenv("KATA_SHARED_TOKEN", "")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/ping":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"service": "kata",
+				"version": "test",
+			})
+		case "/protected":
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_SHARED_TOKEN"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
+		Timeout:    time.Second,
+		DaemonName: "shared",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer env-token", gotAuth)
+}
+
+func TestNewHTTPClient_NamedRemoteAuthTokenEnvSuppliesTokenlessCatalog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "env-token")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/ping":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"service": "kata",
+				"version": "test",
+			})
+		case "/protected":
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
+		Timeout:    time.Second,
+		DaemonName: "shared",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer env-token", gotAuth)
+}
+
 func TestNewHTTPClient_NamedLocalUsesCatalogToken(t *testing.T) {
 	home := setupKataEnv(t)
 	var gotAuth string

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -320,6 +320,53 @@ url = "`+srv.URL+`"
 	assert.Equal(t, "Bearer env-token", gotAuth)
 }
 
+func TestNewHTTPClient_NamedRemoteAuthTokenEnvWinsInIdentityAutostartMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "client-token")
+	t.Setenv("KATA_AUTOSTART", "1")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/ping":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"service": "kata",
+				"version": "test",
+			})
+		case "/protected":
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[auth]
+token = "bootstrap-token"
+require_token_identity = true
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
+		Timeout:    time.Second,
+		DaemonName: "shared",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer client-token", gotAuth)
+}
+
 func TestNewHTTPClient_NamedLocalUsesCatalogToken(t *testing.T) {
 	home := setupKataEnv(t)
 	var gotAuth string

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -277,6 +277,36 @@ token = "local-token"
 	assert.Equal(t, "Bearer local-token", gotAuth)
 }
 
+func TestNewHTTPClient_NamedLocalUsesProvidedBaseURLWithoutStarting(t *testing.T) {
+	home := setupKataEnv(t)
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "local-auth"
+local = true
+token = "local-token"
+`), 0o600))
+
+	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
+		Timeout:    time.Second,
+		DaemonName: "local-auth",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer local-token", gotAuth)
+}
+
 func TestResolveRemote_FileUnreachableErrors(t *testing.T) {
 	t.Setenv("KATA_SERVER", "")
 	dir := t.TempDir()

--- a/internal/tui/daemon_target.go
+++ b/internal/tui/daemon_target.go
@@ -100,14 +100,21 @@ func activeDaemonTarget(targets []daemonTarget, active string) (daemonTarget, bo
 	return daemonTarget{}, false
 }
 
-func bootDaemonConnection(ctx context.Context, _ Options) (daemonConnection, error) {
+func bootDaemonConnection(ctx context.Context, opts Options) (daemonConnection, error) {
 	cfg, err := readDaemonConfigForTUI()
 	if err != nil {
 		return daemonConnection{}, err
 	}
 	catalog := daemonTargetsFromConfig(cfg.Daemons)
-	target, ok := activeDaemonTarget(catalog, cfg.ActiveDaemon)
+	targetName := cfg.ActiveDaemon
+	if strings.TrimSpace(opts.DaemonName) != "" {
+		targetName = strings.TrimSpace(opts.DaemonName)
+	}
+	target, ok := activeDaemonTarget(catalog, targetName)
 	if !ok {
+		if targetName != "" {
+			return daemonConnection{}, fmt.Errorf("daemon %q is not in daemon catalog", targetName)
+		}
 		conn, err := connectImplicitDaemonTarget(ctx)
 		if err != nil {
 			return daemonConnection{}, err
@@ -115,7 +122,7 @@ func bootDaemonConnection(ctx context.Context, _ Options) (daemonConnection, err
 		conn.catalog = catalog
 		return conn, nil
 	}
-	conn, err := connectDaemonTarget(ctx, target)
+	conn, err := connectDaemonTargetForTUI(ctx, target)
 	if err != nil {
 		return daemonConnection{}, err
 	}

--- a/internal/tui/daemon_target.go
+++ b/internal/tui/daemon_target.go
@@ -13,13 +13,14 @@ import (
 )
 
 type daemonTarget struct {
-	Name          string
-	Local         bool
-	URL           string
-	Token         string
-	TokenEnv      string
-	AllowInsecure bool
-	Implicit      bool
+	Name                 string
+	Local                bool
+	URL                  string
+	Token                string
+	TokenEnv             string
+	AllowInsecure        bool
+	Implicit             bool
+	UseAuthTokenOverride bool
 }
 
 type daemonConnection struct {
@@ -68,8 +69,19 @@ var (
 			}
 			return client.NewHTTPClient(ctx, endpoint, opts)
 		}
+		auth := effectiveGlobalAuthForTUI()
+		token := target.Token
+		if target.UseAuthTokenOverride {
+			if envToken := authTokenEnvOverrideForTUI(); envToken != "" {
+				token = envToken
+			}
+		}
 		return client.NewHTTPClientForTarget(ctx, endpoint,
-			client.TargetAuth{Token: target.Token, AllowInsecure: target.AllowInsecure},
+			client.TargetAuth{
+				Token:               token,
+				AllowInsecure:       target.AllowInsecure,
+				TrustPrivateNetwork: auth.TrustPrivateNetwork,
+			},
 			opts)
 	}
 	bootResolveScopeForTUI    = bootResolveScope
@@ -144,6 +156,7 @@ func connectImplicitDaemonTarget(ctx context.Context) (daemonConnection, error) 
 
 func connectDaemonTarget(ctx context.Context, target daemonTarget) (daemonConnection, error) {
 	var err error
+	target.UseAuthTokenOverride = true
 	target, err = resolveDaemonTargetToken(target)
 	if err != nil {
 		return daemonConnection{}, err
@@ -156,6 +169,13 @@ func connectDaemonTarget(ctx context.Context, target daemonTarget) (daemonConnec
 }
 
 func resolveDaemonTargetToken(target daemonTarget) (daemonTarget, error) {
+	if target.UseAuthTokenOverride && !target.Local {
+		if token := authTokenEnvOverrideForTUI(); token != "" {
+			target.Token = token
+			target.TokenEnv = ""
+			return target, nil
+		}
+	}
 	if target.TokenEnv == "" {
 		return target, nil
 	}
@@ -241,15 +261,23 @@ func resolvedDaemonTarget(target daemonTarget, endpoint string) daemonTarget {
 }
 
 func effectiveGlobalAuthTokenForTUI() string {
-	envToken := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
-	if envToken != "" {
-		return envToken
-	}
+	return strings.TrimSpace(effectiveGlobalAuthForTUI().Token)
+}
+
+func effectiveGlobalAuthForTUI() config.AuthConfig {
 	auth, err := config.ReadAuthConfig()
 	if err != nil {
-		return ""
+		auth.TrustPrivateNetwork = config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
 	}
-	return strings.TrimSpace(auth.Token)
+	if token := authTokenEnvOverrideForTUI(); token != "" {
+		auth.Token = token
+	}
+	return auth
+}
+
+func authTokenEnvOverrideForTUI() string {
+	envToken := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
+	return envToken
 }
 
 func implicitDaemonTarget(endpoint string) daemonTarget {

--- a/internal/tui/daemon_target.go
+++ b/internal/tui/daemon_target.go
@@ -63,6 +63,9 @@ var (
 			if target.Token != "" {
 				return client.NewHTTPClientWithBearer(ctx, endpoint, target.Token, opts)
 			}
+			if target.Local && target.Name != "" {
+				opts.DaemonName = target.Name
+			}
 			return client.NewHTTPClient(ctx, endpoint, opts)
 		}
 		return client.NewHTTPClientForTarget(ctx, endpoint,

--- a/internal/tui/daemon_target_test.go
+++ b/internal/tui/daemon_target_test.go
@@ -350,6 +350,33 @@ token_env = "KATA_REMOTE_TOKEN"
 	assert.Equal(t, "Bearer global-token", gotAuth)
 }
 
+func TestNewHTTPClientForTUIExplicitRemoteAuthTokenEnvOverridesCatalogToken(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_AUTH_TOKEN", "env-token")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	hc, err := newHTTPClientForTUI(t.Context(), srv.URL,
+		daemonTarget{
+			Name:                 "shared",
+			URL:                  srv.URL,
+			Token:                "catalog-token",
+			UseAuthTokenOverride: true,
+		}, clientOptsNormal)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := hc.Do(req) //nolint:gosec // test request targets httptest.Server's loopback URL
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, "Bearer env-token", gotAuth)
+}
+
 func TestNewHTTPClientForTUIImplicitRemoteFallsBackToGlobalAuth(t *testing.T) {
 	t.Setenv("KATA_AUTH_TOKEN", "global-token")
 	var gotAuth string
@@ -406,8 +433,10 @@ func TestConnectDaemonTargetRemoteUsesPerDaemonAuth(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "http://daemon.internal:7777", conn.endpoint)
-	assert.Equal(t, target, gotNormal)
-	assert.Equal(t, target, gotSSE)
+	expected := target
+	expected.UseAuthTokenOverride = true
+	assert.Equal(t, expected, gotNormal)
+	assert.Equal(t, expected, gotSSE)
 	assert.Equal(t, "shared", conn.target.Name)
 }
 
@@ -448,6 +477,47 @@ func TestConnectDaemonTargetRemoteResolvesTokenEnvOnUse(t *testing.T) {
 	assert.Equal(t, "secret-from-env", gotNormal.Token)
 	assert.Equal(t, "secret-from-env", gotSSE.Token)
 	assert.Equal(t, "secret-from-env", conn.target.Token)
+}
+
+func TestConnectDaemonTargetRemoteAuthTokenEnvOverridesUnsetTokenEnv(t *testing.T) {
+	oldNormalize := normalizeRemoteURLForTUI
+	oldProbe := probeRemoteForTUI
+	oldNewClient := newHTTPClientForTUI
+	oldBootScope := bootResolveScopeForTUI
+	t.Cleanup(func() {
+		normalizeRemoteURLForTUI = oldNormalize
+		probeRemoteForTUI = oldProbe
+		newHTTPClientForTUI = oldNewClient
+		bootResolveScopeForTUI = oldBootScope
+	})
+	t.Setenv("KATA_AUTH_TOKEN", "env-token")
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_WORK_TOKEN", "")
+
+	target := daemonTarget{Name: "shared", URL: "https://daemon.example", TokenEnv: "KATA_WORK_TOKEN"} //nolint:gosec // env var name, not a credential
+	var gotNormal, gotSSE daemonTarget
+	normalizeRemoteURLForTUI = func(v string, _ bool) (string, error) {
+		return v, nil
+	}
+	probeRemoteForTUI = func(context.Context, string) bool { return true }
+	newHTTPClientForTUI = func(_ context.Context, _ string, target daemonTarget, kind clientOptsKind) (*http.Client, error) {
+		if kind == clientOptsNormal {
+			gotNormal = target
+		} else {
+			gotSSE = target
+		}
+		return &http.Client{}, nil
+	}
+	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+		return bootInit{view: viewEmpty, scope: scope{empty: true}}, nil
+	}
+
+	conn, err := connectDaemonTarget(context.Background(), target)
+
+	require.NoError(t, err)
+	assert.Equal(t, "env-token", gotNormal.Token)
+	assert.Equal(t, "env-token", gotSSE.Token)
+	assert.Equal(t, "env-token", conn.target.Token)
 }
 
 func TestConnectResolvedLocalTargetRetryRefreshPreservesTargetToken(t *testing.T) {

--- a/internal/tui/daemon_target_test.go
+++ b/internal/tui/daemon_target_test.go
@@ -143,6 +143,37 @@ func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *t
 	assert.Equal(t, viewEmpty, conn.init.view)
 }
 
+func TestBootDaemonConnectionOptionsDaemonNameOverridesActiveDaemon(t *testing.T) {
+	oldRead := readDaemonConfigForTUI
+	oldConnect := connectDaemonTargetForTUI
+	t.Cleanup(func() {
+		readDaemonConfigForTUI = oldRead
+		connectDaemonTargetForTUI = oldConnect
+	})
+
+	readDaemonConfigForTUI = func() (*config.DaemonConfig, error) {
+		return &config.DaemonConfig{
+			ActiveDaemon: "active",
+			Daemons: []config.CatalogDaemonConfig{
+				{Name: "active", URL: "https://active.example"},
+				{Name: "selected", URL: "https://selected.example"},
+			},
+		}, nil
+	}
+	var got daemonTarget
+	connectDaemonTargetForTUI = func(_ context.Context, target daemonTarget) (daemonConnection, error) {
+		got = target
+		return daemonConnection{target: target}, nil
+	}
+
+	conn, err := bootDaemonConnection(context.Background(), Options{DaemonName: "selected"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "selected", got.Name)
+	assert.Equal(t, "selected", conn.target.Name)
+	require.Len(t, conn.catalog, 2)
+}
+
 func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testing.T) {
 	oldRead := readDaemonConfigForTUI
 	oldEnsure := ensureRunningForTUI

--- a/internal/tui/daemon_target_test.go
+++ b/internal/tui/daemon_target_test.go
@@ -312,6 +312,44 @@ func TestNewHTTPClientForTUILocalFallsBackToGlobalAuth(t *testing.T) {
 	assert.Equal(t, "Bearer global-token", gotAuth)
 }
 
+func TestNewHTTPClientForTUIExplicitLocalBypassesActiveDaemonAuth(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_REMOTE_TOKEN", "")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+active_daemon = "remote"
+
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "local"
+local = true
+
+[[daemon]]
+name = "remote"
+url = "`+srv.URL+`"
+token_env = "KATA_REMOTE_TOKEN"
+`), 0o600))
+
+	hc, err := newHTTPClientForTUI(t.Context(), srv.URL,
+		daemonTarget{Name: "local", Local: true}, clientOptsNormal)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := hc.Do(req) //nolint:gosec // test request targets httptest.Server's loopback URL
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, "Bearer global-token", gotAuth)
+}
+
 func TestNewHTTPClientForTUIImplicitRemoteFallsBackToGlobalAuth(t *testing.T) {
 	t.Setenv("KATA_AUTH_TOKEN", "global-token")
 	var gotAuth string

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -85,6 +85,7 @@ type Options struct {
 	Stdout           io.Writer // typically os.Stdout
 	Stderr           io.Writer // typically os.Stderr
 	DisplayUIDFormat string    // none, short, or full
+	DaemonName       string    // named daemon catalog entry for this run
 	Mouse            bool      // opt-in mouse capture and mouse-driven navigation
 }
 


### PR DESCRIPTION
## Summary
- Add global `--daemon <name>` support for selecting a named daemon catalog entry per invocation.
- Resolve named local and remote targets ahead of ambient remote configuration, including catalog token/token_env auth.
- Update CLI, quickstart, and remote-daemon docs for the new resolution order.