### PR TITLE
Relax close throttling and remind agents on close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ start of each session for the agent contract; the short version:
   `kata close <ref> --done --message "<scope + verification>" --commit <sha>`.
   Use `--duplicate-of <ref>`, `--superseded-by <ref>`, `--audit-no-change`, or
   `--wontfix` when those reasons fit. The daemon refuses parent-close while
-  children are open and throttles sibling-close bursts.
+  children are open and sibling closes that reuse identical evidence.
 - Never `kata delete` or `kata purge` without explicit user authorization.
 
 For long-running work, `kata events --tail` streams NDJSON.
@@ -53,10 +53,10 @@ Instead:
     kata comment <ref> --body "what was attempted, what remains"
 
 Close each issue as soon as its work is verified, not at the end of a
-batch. The daemon throttles >3 sibling closes by one actor under one
-parent in 60 seconds; close eagerly and you will not see it. Operators
-can disable the throttle via `[close.throttle] enabled = false` in
-`<KATA_HOME>/config.toml`.
+batch. By default the daemon allows sibling close bursts when each close
+has distinct evidence, and refuses sibling closes that reuse identical
+evidence. Operators can enable stricter burst throttling via
+`[close.throttle] enabled = true` in `<KATA_HOME>/config.toml`.
 
 When the work IS done, close with substantive prose and typed
 `--evidence` so a reviewer can verify the claim later:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ start of each session for the agent contract; the short version:
   `kata close <ref> --done --message "<scope + verification>" --commit <sha>`.
   Use `--duplicate-of <ref>`, `--superseded-by <ref>`, `--audit-no-change`, or
   `--wontfix` when those reasons fit. The daemon refuses parent-close while
-  children are open and sibling closes that reuse identical evidence.
+  children are open.
 - Never `kata delete` or `kata purge` without explicit user authorization.
 
 For long-running work, `kata events --tail` streams NDJSON.
@@ -54,8 +54,8 @@ Instead:
 
 Close each issue as soon as its work is verified, not at the end of a
 batch. By default the daemon allows sibling close bursts when each close
-has distinct evidence, and refuses sibling closes that reuse identical
-evidence. Operators can enable stricter burst throttling via
+has valid evidence and a substantive message. Operators can enable stricter
+burst/prose throttling via
 `[close.throttle] enabled = true` in `<KATA_HOME>/config.toml`.
 
 When the work IS done, close with substantive prose and typed

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ The [docs site](docs/) is the definitive reference:
 Run `kata quickstart` (alias `kata agent-instructions`) for the operating
 contract: search before creating, pass an idempotency key on create, prefer
 `--agent` output, claim work with `kata claim`, and close only when the work is
-verified. Close each verified issue promptly and use distinct evidence for each
-sibling close. [Agent workflows](docs/workflows/agents.md) is the same contract
-in long form.
+verified. Close each verified issue promptly with valid evidence and a
+substantive message. [Agent workflows](docs/workflows/agents.md) is the same
+contract in long form.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ The [docs site](docs/) is the definitive reference:
 Run `kata quickstart` (alias `kata agent-instructions`) for the operating
 contract: search before creating, pass an idempotency key on create, prefer
 `--agent` output, claim work with `kata claim`, and close only when the work is
-verified. Close each verified issue promptly; batching sibling closes can trip
-the 60-second close throttle. [Agent workflows](docs/workflows/agents.md) is
-the same contract in long form.
+verified. Close each verified issue promptly and use distinct evidence for each
+sibling close. [Agent workflows](docs/workflows/agents.md) is the same contract
+in long form.
 
 ## Contributing
 

--- a/cmd/kata/audit_closes_test.go
+++ b/cmd/kata/audit_closes_test.go
@@ -211,7 +211,8 @@ func TestAuditCloses_ParentFrozenAtCloseTime(t *testing.T) {
 // would keep stamping "throttled" on closes that have nothing to do
 // with the original refusal.
 func TestAuditCloses_ThrottledFlagDoesNotBleedAcrossReopenCycles(t *testing.T) {
-	env, dir, pid, parent := setupWorkspaceWithIssue(t, "parent issue")
+	env, dir, pid, parent := setupWorkspaceWithIssueOptions(
+		t, "parent issue", testenv.WithCloseThrottleEnabled())
 	childA := createIssue(t, env, pid, "child a")
 	childB := createIssue(t, env, pid, "child b")
 	runCLI(t, env, dir, "edit", childA, "--parent", parent)
@@ -329,7 +330,8 @@ func TestAuditCloses_FilterByParent_SoftDeletedParent(t *testing.T) {
 // reopen) must NOT inherit a stale flag from before the intervening
 // close.
 func TestAuditCloses_ThrottledFlag_DifferentActorEndsCycle(t *testing.T) {
-	env, dir, pid, parent := setupWorkspaceWithIssue(t, "parent issue")
+	env, dir, pid, parent := setupWorkspaceWithIssueOptions(
+		t, "parent issue", testenv.WithCloseThrottleEnabled())
 	childA := createIssue(t, env, pid, "child a")
 	childB := createIssue(t, env, pid, "child b")
 	runCLI(t, env, dir, "edit", childA, "--parent", parent)
@@ -405,7 +407,8 @@ func TestAuditCloses_ThrottledFlag_DifferentActorEndsCycle(t *testing.T) {
 // Lifting --actor to the row-emit pass keeps the marker walk
 // consistent regardless of which actor the caller filters on.
 func TestAuditCloses_ActorFilterDoesNotHideThrottleEndingClose(t *testing.T) {
-	env, dir, pid, parent := setupWorkspaceWithIssue(t, "parent issue")
+	env, dir, pid, parent := setupWorkspaceWithIssueOptions(
+		t, "parent issue", testenv.WithCloseThrottleEnabled())
 	childA := createIssue(t, env, pid, "child a")
 	childB := createIssue(t, env, pid, "child b")
 	runCLI(t, env, dir, "edit", childA, "--parent", parent)
@@ -560,11 +563,12 @@ func TestAuditCloses_ThrottledFlagIgnoresLaterThrottle(t *testing.T) {
 }
 
 // TestAuditCloses_ThrottledFlagSurfaces verifies that a close that
-// previously hit the duplicate-evidence guard (and thus emitted a
+// previously hit the repeated-message guard (and thus emitted a
 // close.throttled event) is flagged "throttled" in the audit row once
-// the same actor retries successfully with different evidence.
+// the same actor retries successfully with a different message.
 func TestAuditCloses_ThrottledFlagSurfaces(t *testing.T) {
-	env, dir, pid, parent := setupWorkspaceWithIssue(t, "parent issue")
+	env, dir, pid, parent := setupWorkspaceWithIssueOptions(
+		t, "parent issue", testenv.WithCloseThrottleEnabled())
 	childA := createIssue(t, env, pid, "child a")
 	childB := createIssue(t, env, pid, "child b")
 	runCLI(t, env, dir, "edit", childA, "--parent", parent)
@@ -573,13 +577,13 @@ func TestAuditCloses_ThrottledFlagSurfaces(t *testing.T) {
 	runCLIAs(t, env, dir, "agent-a", "close", childA, "--audit-no-change",
 		"--message", msg,
 		"--evidence", "no-change-audit:metadata-only")
-	// Second close with identical evidence trips the duplicate-evidence
+	// Second close with identical message trips the repeated-message
 	// guard and emits a close.throttled event tagged with agent-a/childB.
 	_, _, _ = runCLIWithErr(t, env, dir, "close", childB, "--as", "agent-a",
 		"--audit-no-change",
 		"--message", msg,
-		"--evidence", "no-change-audit:metadata-only")
-	// Retry with distinct evidence — the close succeeds; the prior
+		"--evidence", "no-change-audit:sibling-b metadata-only")
+	// Retry with a distinct message — the close succeeds; the prior
 	// close.throttled event for agent-a/childB stays in the audit window.
 	runCLIAs(t, env, dir, "agent-a", "close", childB, "--audit-no-change",
 		"--message", "Reviewed sibling B; same conclusion under a fresh narrative.",

--- a/cmd/kata/audit_closes_test.go
+++ b/cmd/kata/audit_closes_test.go
@@ -507,7 +507,8 @@ func TestAuditCloses_FilterByParent_CrossProjectQualifierMatchesNothing(t *testi
 // The throttle there is a later retry against the same key, not a guard
 // the original close tripped — flagging it would mislead a reviewer.
 func TestAuditCloses_ThrottledFlagIgnoresLaterThrottle(t *testing.T) {
-	env, dir, pid, parent := setupWorkspaceWithIssue(t, "parent issue")
+	env, dir, pid, parent := setupWorkspaceWithIssueOptions(
+		t, "parent issue", testenv.WithCloseThrottleEnabled())
 	siblingA := createIssue(t, env, pid, "sibling a")
 	siblingB := createIssue(t, env, pid, "sibling b")
 	runCLI(t, env, dir, "edit", siblingA, "--parent", parent)
@@ -532,10 +533,12 @@ func TestAuditCloses_ThrottledFlagIgnoresLaterThrottle(t *testing.T) {
 	// repeated-message guard fires because siblingB's prior close used
 	// the same msg under the same parent. Event 4 ≈ close.throttled
 	// (siblingA, agent-a).
-	_, _, _ = runCLIWithErr(t, env, dir, "close", siblingA, "--as", "agent-a",
+	_, retryErr, err := runCLIWithErr(t, env, dir, "close", siblingA, "--as", "agent-a",
 		"--done",
 		"--message", msg,
 		"--commit", "abc1234")
+	require.Error(t, err)
+	assert.Contains(t, retryErr, "identical close message")
 
 	out := runCLI(t, env, dir, "audit", "closes", "--actor", "agent-a", "--json")
 	// The successful close of siblingA (event 2) must NOT carry a

--- a/cmd/kata/audit_closes_test.go
+++ b/cmd/kata/audit_closes_test.go
@@ -560,9 +560,9 @@ func TestAuditCloses_ThrottledFlagIgnoresLaterThrottle(t *testing.T) {
 }
 
 // TestAuditCloses_ThrottledFlagSurfaces verifies that a close that
-// previously hit the repeated-message guard (and thus emitted a
+// previously hit the duplicate-evidence guard (and thus emitted a
 // close.throttled event) is flagged "throttled" in the audit row once
-// the same actor retries successfully with a different message.
+// the same actor retries successfully with different evidence.
 func TestAuditCloses_ThrottledFlagSurfaces(t *testing.T) {
 	env, dir, pid, parent := setupWorkspaceWithIssue(t, "parent issue")
 	childA := createIssue(t, env, pid, "child a")
@@ -573,17 +573,17 @@ func TestAuditCloses_ThrottledFlagSurfaces(t *testing.T) {
 	runCLIAs(t, env, dir, "agent-a", "close", childA, "--audit-no-change",
 		"--message", msg,
 		"--evidence", "no-change-audit:metadata-only")
-	// Second close with identical message trips the repeated-message
+	// Second close with identical evidence trips the duplicate-evidence
 	// guard and emits a close.throttled event tagged with agent-a/childB.
 	_, _, _ = runCLIWithErr(t, env, dir, "close", childB, "--as", "agent-a",
 		"--audit-no-change",
 		"--message", msg,
 		"--evidence", "no-change-audit:metadata-only")
-	// Retry with a distinct message — the close succeeds; the prior
+	// Retry with distinct evidence — the close succeeds; the prior
 	// close.throttled event for agent-a/childB stays in the audit window.
 	runCLIAs(t, env, dir, "agent-a", "close", childB, "--audit-no-change",
 		"--message", "Reviewed sibling B; same conclusion under a fresh narrative.",
-		"--evidence", "no-change-audit:metadata-only")
+		"--evidence", "no-change-audit:sibling-b metadata-only")
 
 	out := runCLI(t, env, dir, "audit", "closes", "--actor", "agent-a", "--json")
 	assert.Contains(t, out, `"throttled"`)

--- a/cmd/kata/close.go
+++ b/cmd/kata/close.go
@@ -40,6 +40,8 @@ the end. By default the daemon allows sibling close bursts when each
 close has valid evidence and a substantive message. Operators can enable
 stricter burst/prose throttling via
 [close.throttle] enabled = true in <KATA_HOME>/config.toml.
+Each successful CLI close prints a reminder that the close is a completion
+claim and that the message and evidence should be specific to the issue.
 
 If you have not completed and tested this work, do not close it.
 Instead, label and comment:

--- a/cmd/kata/close.go
+++ b/cmd/kata/close.go
@@ -37,8 +37,8 @@ substantive message.
 
 Close each issue as soon as its work is verified, not in a batch at
 the end. By default the daemon allows sibling close bursts when each
-close has distinct evidence, but refuses identical evidence on sibling
-closes. Operators can enable stricter burst throttling via
+close has valid evidence and a substantive message. Operators can enable
+stricter burst/prose throttling via
 [close.throttle] enabled = true in <KATA_HOME>/config.toml.
 
 If you have not completed and tested this work, do not close it.

--- a/cmd/kata/close.go
+++ b/cmd/kata/close.go
@@ -36,10 +36,10 @@ This is a stronger claim than a comment. Provide evidence and a
 substantive message.
 
 Close each issue as soon as its work is verified, not in a batch at
-the end. The daemon throttles >3 sibling closes by one actor under
-one parent in 60 seconds (operators can disable this via
-[close.throttle] enabled = false in <KATA_HOME>/config.toml), so a
-bulk "close everything now" pass can trip the guard.
+the end. By default the daemon allows sibling close bursts when each
+close has distinct evidence, but refuses identical evidence on sibling
+closes. Operators can enable stricter burst throttling via
+[close.throttle] enabled = true in <KATA_HOME>/config.toml.
 
 If you have not completed and tested this work, do not close it.
 Instead, label and comment:

--- a/cmd/kata/close_reopen_test.go
+++ b/cmd/kata/close_reopen_test.go
@@ -19,9 +19,11 @@ func TestCloseReopen_RoundTrip(t *testing.T) {
 		"--reason", "wontfix",
 		"--message", "Decided not to fix this; it doesn't match the current product direction.")
 	assert.Contains(t, out, "closed")
+	assert.Contains(t, out, "Reminder:")
 
 	out = runCLI(t, env, dir, "reopen", ref)
 	assert.Contains(t, out, "open")
+	assert.NotContains(t, out, "Reminder:")
 }
 
 func TestClose_AgentOutput(t *testing.T) {
@@ -36,6 +38,7 @@ func TestClose_AgentOutput(t *testing.T) {
 	assert.Contains(t, out, "Status: closed")
 	assert.Contains(t, out, "Reason: done")
 	assert.Contains(t, out, "Evidence: commit:abc1234")
+	assert.Contains(t, out, "Reminder:")
 }
 
 func TestClose_AgentDryRunSuppressesHumanBanner(t *testing.T) {
@@ -49,6 +52,7 @@ func TestClose_AgentDryRunSuppressesHumanBanner(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Regexp(t, `(?m)^OK close \S+`, stdout)
+	assert.NotContains(t, stdout, "Reminder:")
 	assert.Empty(t, stderr)
 }
 

--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -443,6 +443,12 @@ func printMutation(cmd *cobra.Command, bs []byte) error {
 	return printMutationWithApplied(cmd, bs, nil, "")
 }
 
+const closeReminderText = "closing asserts this issue is complete; verify the message and evidence are specific to this issue."
+
+func shouldPrintCloseReminder(verb string, changed bool) bool {
+	return verb == "close" && changed
+}
+
 // printMutationWithApplied formats a mutation response with an optional
 // synthetic changes block for the create path. applied is a fallback `changes`
 // block used when the wire response carries none (create path); nil elsewhere.
@@ -465,6 +471,7 @@ func printMutationWithApplied(cmd *cobra.Command, bs []byte, applied *mutationCh
 	if err := json.Unmarshal(bs, &b); err != nil {
 		return err
 	}
+	verb := commandLeaf(cmd)
 	if mode == outputJSON {
 		var buf bytes.Buffer
 		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
@@ -478,7 +485,6 @@ func printMutationWithApplied(cmd *cobra.Command, bs []byte, applied *mutationCh
 		if err := json.Unmarshal(bs, &m); err != nil {
 			return err
 		}
-		verb := commandLeaf(cmd)
 		includeChangedTrue := verb == "edit"
 		return printAgentMutationDecoded(cmd.OutOrStdout(), verb, m, includeChangedTrue, func(w io.Writer, m agentIssueMutation) error {
 			if m.Issue.ClosedReason != nil {
@@ -489,6 +495,11 @@ func printMutationWithApplied(cmd *cobra.Command, bs []byte, applied *mutationCh
 			if verb == "close" {
 				for _, evidence := range agentEvidenceSummaries(m) {
 					if err := writeAgentField(w, "Evidence", agentValue(evidence)); err != nil {
+						return err
+					}
+				}
+				if shouldPrintCloseReminder(verb, m.Changed) {
+					if err := writeAgentField(w, "Reminder", agentValue(closeReminderText)); err != nil {
 						return err
 					}
 				}
@@ -529,8 +540,14 @@ func printMutationWithApplied(cmd *cobra.Command, bs []byte, applied *mutationCh
 			return err
 		}
 	}
-	_, err := fmt.Fprintln(cmd.OutOrStdout())
-	return err
+	if _, err := fmt.Fprintln(cmd.OutOrStdout()); err != nil {
+		return err
+	}
+	if shouldPrintCloseReminder(verb, changed) {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "Reminder: %s\n", closeReminderText)
+		return err
+	}
+	return nil
 }
 
 // mutationChanges mirrors the wire `changes` block produced by `kata edit`

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -357,6 +357,10 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	go runReloadLoop(ctx, sigs, hookCfgPath, disp, daemonLog)
 	broadcaster := daemon.NewEventBroadcaster()
 	federationWake := startFederationRunner(ctx, store, broadcaster, disp, daemonLog)
+	closeThrottleWindow, err := dcfg.Close.Throttle.ThrottleWindow()
+	if err != nil {
+		return err
+	}
 
 	srv := daemon.NewServer(daemon.ServerConfig{
 		DB:             store,
@@ -366,7 +370,8 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		Broadcaster:    broadcaster,
 		FederationWake: federationWake,
 		CloseThrottle: daemon.CloseThrottlePolicy{
-			ThrottleDisabled: !dcfg.Close.Throttle.ThrottleEnabled(),
+			SiblingBurstEnabled: dcfg.Close.Throttle.ThrottleEnabled(),
+			SiblingBurstWindow:  closeThrottleWindow,
 		},
 		Auth:             dcfg.Auth,
 		InsecureReadonly: insecureReadonly,

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -32,9 +32,9 @@ Use kata as the shared issue ledger for this workspace.
 
    Close each issue as soon as its work is verified, not in a batch or a
    single "close everything" pass at the end. By default the daemon permits
-   sibling close bursts when each close has distinct evidence, but refuses
-   identical evidence on sibling closes. Operators can enable stricter burst
-   throttling via [close.throttle] enabled = true in <KATA_HOME>/config.toml.
+   sibling close bursts when each close has valid evidence and a substantive
+   message. Operators can enable stricter burst/prose throttling via
+   [close.throttle] enabled = true in <KATA_HOME>/config.toml.
 
    Other close forms:
 
@@ -158,7 +158,7 @@ Default to --agent for ordinary kata reads and mutations in agent logs.
 Use --json only when your script needs complete structured data.
 If work is incomplete, label needs-review and comment with what remains.
 Close only verified work with substantive prose and typed evidence.
-Close each verified issue promptly; distinct evidence keeps sibling close bursts admissible by default.
+Close each verified issue promptly; valid evidence keeps sibling close bursts admissible by default.
 Do not run delete or purge unless explicitly asked for that exact action and issue ref.
 Poll kata events with a saved cursor; reset cached state on reset_required.
 `

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -31,10 +31,10 @@ Use kata as the shared issue ledger for this workspace.
         --commit <sha>
 
    Close each issue as soon as its work is verified, not in a batch or a
-   single "close everything" pass at the end. The daemon throttles >3 sibling
-   closes by one actor under one parent in 60 seconds; close eagerly as each
-   issue is verified and you will not see the throttle. Operators can disable
-   it via [close.throttle] enabled = false in <KATA_HOME>/config.toml.
+   single "close everything" pass at the end. By default the daemon permits
+   sibling close bursts when each close has distinct evidence, but refuses
+   identical evidence on sibling closes. Operators can enable stricter burst
+   throttling via [close.throttle] enabled = true in <KATA_HOME>/config.toml.
 
    Other close forms:
 
@@ -158,7 +158,7 @@ Default to --agent for ordinary kata reads and mutations in agent logs.
 Use --json only when your script needs complete structured data.
 If work is incomplete, label needs-review and comment with what remains.
 Close only verified work with substantive prose and typed evidence.
-Close each verified issue promptly; batching sibling closes can trigger the 60-second throttle.
+Close each verified issue promptly; distinct evidence keeps sibling close bursts admissible by default.
 Do not run delete or purge unless explicitly asked for that exact action and issue ref.
 Poll kata events with a saved cursor; reset cached state on reset_required.
 `

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -31,7 +31,7 @@ func TestQuickstart_PromotesCloseStep(t *testing.T) {
 	assert.Contains(t, out, "asserts that the work is complete")
 	assert.Contains(t, out, "--evidence")
 	assert.Contains(t, out, "needs-review")
-	assert.Contains(t, out, "60 seconds")
+	assert.Contains(t, out, "distinct evidence")
 	assert.Contains(t, out, "not in a batch")
 }
 
@@ -58,7 +58,7 @@ func TestQuickstart_AgentOutput(t *testing.T) {
 	assert.NotContains(t, out, "Remote daemon")
 	assert.Contains(t, out, "Default to --agent for ordinary kata reads and mutations in agent logs.")
 	assert.Contains(t, out, "Use --json only when your script needs complete structured data.")
-	assert.Contains(t, out, "Close each verified issue promptly; batching sibling closes can trigger the 60-second throttle.")
+	assert.Contains(t, out, "Close each verified issue promptly; distinct evidence keeps sibling close bursts admissible by default.")
 }
 
 func TestQuickstart_AgentInstructionsAliasMentionsAgentOutput(t *testing.T) {

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -31,7 +31,7 @@ func TestQuickstart_PromotesCloseStep(t *testing.T) {
 	assert.Contains(t, out, "asserts that the work is complete")
 	assert.Contains(t, out, "--evidence")
 	assert.Contains(t, out, "needs-review")
-	assert.Contains(t, out, "distinct evidence")
+	assert.Contains(t, out, "valid evidence")
 	assert.Contains(t, out, "not in a batch")
 }
 
@@ -58,7 +58,7 @@ func TestQuickstart_AgentOutput(t *testing.T) {
 	assert.NotContains(t, out, "Remote daemon")
 	assert.Contains(t, out, "Default to --agent for ordinary kata reads and mutations in agent logs.")
 	assert.Contains(t, out, "Use --json only when your script needs complete structured data.")
-	assert.Contains(t, out, "Close each verified issue promptly; distinct evidence keeps sibling close bursts admissible by default.")
+	assert.Contains(t, out, "Close each verified issue promptly; valid evidence keeps sibling close bursts admissible by default.")
 }
 
 func TestQuickstart_AgentInstructionsAliasMentionsAgentOutput(t *testing.T) {

--- a/cmd/kata/testhelpers_test.go
+++ b/cmd/kata/testhelpers_test.go
@@ -390,13 +390,25 @@ func setupWorkspaceWithIssue(t *testing.T, issueTitle string) (*testenv.Env, str
 	return env, dir, pid, short
 }
 
+func setupWorkspaceWithIssueOptions(
+	t *testing.T, issueTitle string, opts ...testenv.Option,
+) (*testenv.Env, string, int64, string) {
+	env, dir, pid := setupCLIWorkspaceOptions(t, opts...)
+	short := createIssue(t, env, pid, issueTitle)
+	return env, dir, pid, short
+}
+
 // setupCLIWorkspace bundles resetFlags, testenv.New, initBoundWorkspace, and
 // project ID resolution into one call. Use for CLI tests that seed their own
 // issues; setupWorkspaceWithIssue is the one-issue convenience wrapper.
 func setupCLIWorkspace(t *testing.T) (*testenv.Env, string, int64) {
+	return setupCLIWorkspaceOptions(t)
+}
+
+func setupCLIWorkspaceOptions(t *testing.T, opts ...testenv.Option) (*testenv.Env, string, int64) {
 	t.Helper()
 	resetFlags(t)
-	env := testenv.New(t)
+	env := testenv.New(t, opts...)
 	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
 	pid := resolvePIDViaHTTP(t, env.URL, dir)
 	return env, dir, pid

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -195,5 +195,6 @@ Other close reasons are `--wontfix`, `--duplicate-of <ref>`,
 `--superseded-by <ref>`, and `--audit-no-change`.
 
 Close issues as soon as each one is complete and verified. Do not save a batch
-of sibling closes for the end of a run: the daemon refuses more than three
-sibling closes by one actor under one parent within 60 seconds.
+of sibling closes for the end of a run. By default the daemon allows sibling
+close bursts when each close carries distinct evidence, and refuses sibling
+closes that reuse identical evidence.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -196,5 +196,4 @@ Other close reasons are `--wontfix`, `--duplicate-of <ref>`,
 
 Close issues as soon as each one is complete and verified. Do not save a batch
 of sibling closes for the end of a run. By default the daemon allows sibling
-close bursts when each close carries distinct evidence, and refuses sibling
-closes that reuse identical evidence.
+close bursts when each close carries valid evidence and a substantive message.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -197,3 +197,5 @@ Other close reasons are `--wontfix`, `--duplicate-of <ref>`,
 Close issues as soon as each one is complete and verified. Do not save a batch
 of sibling closes for the end of a run. By default the daemon allows sibling
 close bursts when each close carries valid evidence and a substantive message.
+Successful CLI closes print a reminder that each close is a completion claim
+and that the message and evidence should be specific to the issue.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -151,30 +151,37 @@ actor from that token.
 ## Close throttle
 
 kata refuses structurally dangerous close patterns. The parent-completeness
-guard always refuses closing an issue while it has open children. Two further
-guards throttle close bursts by one actor under a shared parent:
+guard always refuses closing an issue while it has open children. The
+duplicate-evidence guard also runs by default: closing a second sibling with
+identical `done` or `audit-no-change` evidence within thirty minutes is
+refused.
 
-- sibling-burst: closing more than three sibling issues within 60 seconds is
-  refused;
+By default, kata does not throttle sibling close bursts when each close carries
+distinct evidence. Operators who want stricter pacing can enable two additional
+guards daemon-wide:
+
+- sibling-burst: closing more than three sibling issues within the configured
+  window is refused;
 - repeated-message: closing a second sibling with an identical `done` or
   `audit-no-change` message within thirty minutes is refused.
 
-Close each issue as soon as its work is verified. Batching closes at the end of
-a run is the pattern this guard is meant to catch, and it can push one actor
-over the sibling-burst limit even when each individual issue is legitimate.
-
-Operators can disable both throttles daemon-wide:
+Enable the optional throttles with:
 
 ```toml
 [close.throttle]
-enabled = false
+enabled = true
+window = "60s"
 ```
 
-`enabled = false` relaxes only the two sibling throttles. Normal CLI and API
-close paths still run the parent-completeness refusal, message-substance checks,
-and evidence checks. The TUI close path skips the message-substance and evidence
-checks because an interactive human confirms each close; the structural guards
-still apply.
+`enabled` defaults to `false`. `window` controls only the sibling-burst lookback
+and defaults to `"60s"`; use Go duration syntax such as `"30s"`, `"2m"`, or
+`"1h"`. When a sibling-burst close is refused, the error message reports the
+resolved window.
+
+Normal CLI and API close paths still run the parent-completeness refusal,
+message-substance checks, evidence checks, and duplicate-evidence guard. The TUI
+close path skips the message-substance and evidence checks because an
+interactive human confirms each close; the structural guards still apply.
 
 ## Telemetry
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -151,14 +151,11 @@ actor from that token.
 ## Close throttle
 
 kata refuses structurally dangerous close patterns. The parent-completeness
-guard always refuses closing an issue while it has open children. The
-duplicate-evidence guard also runs by default: closing a second sibling with
-identical `done` or `audit-no-change` evidence within thirty minutes is
-refused.
+guard always refuses closing an issue while it has open children. Normal CLI
+and API close paths also require close evidence and a substantive message.
 
-By default, kata does not throttle sibling close bursts when each close carries
-distinct evidence. Operators who want stricter pacing can enable two additional
-guards daemon-wide:
+By default, kata does not throttle sibling close bursts. Operators who want
+stricter pacing can enable two additional guards daemon-wide:
 
 - sibling-burst: closing more than three sibling issues within the configured
   window is refused;
@@ -179,9 +176,9 @@ and defaults to `"60s"`; use Go duration syntax such as `"30s"`, `"2m"`, or
 resolved window.
 
 Normal CLI and API close paths still run the parent-completeness refusal,
-message-substance checks, evidence checks, and duplicate-evidence guard. The TUI
-close path skips the message-substance and evidence checks because an
-interactive human confirms each close; the structural guards still apply.
+message-substance checks, and evidence checks. The TUI close path skips the
+message-substance and evidence checks because an interactive human confirms each
+close; the structural guards still apply.
 
 ## Telemetry
 

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -116,10 +116,10 @@ kata close abc4 --done \
 ```
 
 Close each issue as soon as its work is verified, not in a batch at the end of a
-run. The daemon refuses more than three sibling closes by one actor under one
-parent within 60 seconds, so end-of-run close bursts can get throttled even when
-the underlying work is complete. Closing as you finish each issue keeps you
-under the limit and leaves a better audit trail. See
+run. By default the daemon allows sibling close bursts when each close carries
+distinct evidence, and refuses sibling closes that reuse identical evidence.
+Operators can enable stricter burst throttling when they want pacing in addition
+to evidence checks. Closing as you finish each issue leaves a better audit trail. See
 [Close throttle](../reference/configuration.md#close-throttle).
 
 If work is incomplete:

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -119,6 +119,8 @@ Close each issue as soon as its work is verified, not in a batch at the end of a
 run. By default the daemon allows sibling close bursts when each close carries
 valid evidence and a substantive message. Operators can enable stricter
 burst/prose throttling when they want pacing in addition to evidence checks.
+Successful CLI closes also print a reminder that each close is a completion
+claim and that the message and evidence should be specific to the issue.
 Closing as you finish each issue leaves a better audit trail. See
 [Close throttle](../reference/configuration.md#close-throttle).
 

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -117,9 +117,9 @@ kata close abc4 --done \
 
 Close each issue as soon as its work is verified, not in a batch at the end of a
 run. By default the daemon allows sibling close bursts when each close carries
-distinct evidence, and refuses sibling closes that reuse identical evidence.
-Operators can enable stricter burst throttling when they want pacing in addition
-to evidence checks. Closing as you finish each issue leaves a better audit trail. See
+valid evidence and a substantive message. Operators can enable stricter
+burst/prose throttling when they want pacing in addition to evidence checks.
+Closing as you finish each issue leaves a better audit trail. See
 [Close throttle](../reference/configuration.md#close-throttle).
 
 If work is incomplete:

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -98,25 +99,44 @@ type CloseConfig struct {
 	Throttle CloseThrottleConfig `toml:"throttle"`
 }
 
-// CloseThrottleConfig toggles the sibling-burst and repeated-message
-// guards. Enabled is a *bool so an absent key defaults to enabled —
-// disabling is opt-in. Projects that rely on bulk-subagent close
-// patterns can set `enabled = false` to skip the guards entirely.
+const defaultCloseThrottleWindow = 60 * time.Second
+
+// CloseThrottleConfig toggles the opt-in sibling-burst and repeated-message
+// guards. Enabled is a *bool so an absent key defaults to disabled; operators
+// who want burst throttling can set `enabled = true`.
 //
 // The on/off behavior is daemon-wide: every project served by this
 // daemon picks up the same policy. Per-project knobs would need a
 // project_settings table and are out of scope for v1.
 type CloseThrottleConfig struct {
-	Enabled *bool `toml:"enabled"`
+	Enabled *bool  `toml:"enabled"`
+	Window  string `toml:"window"`
 }
 
-// ThrottleEnabled returns the resolved policy: true when the key is
-// absent or explicitly set to true, false only when explicitly disabled.
+// ThrottleEnabled returns the resolved sibling-burst policy. Burst throttling
+// is off unless explicitly enabled.
 func (c CloseThrottleConfig) ThrottleEnabled() bool {
 	if c.Enabled == nil {
-		return true
+		return false
 	}
 	return *c.Enabled
+}
+
+// ThrottleWindow returns the resolved sibling-burst look-back window. The
+// default is 60 seconds; configured values use Go duration syntax, such as
+// "30s", "2m", or "1h".
+func (c CloseThrottleConfig) ThrottleWindow() (time.Duration, error) {
+	if strings.TrimSpace(c.Window) == "" {
+		return defaultCloseThrottleWindow, nil
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(c.Window))
+	if err != nil {
+		return 0, fmt.Errorf("close.throttle.window: %w", err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("close.throttle.window must be positive")
+	}
+	return d, nil
 }
 
 // ReadDaemonConfig parses <KATA_HOME>/config.toml. Returns a zero-value
@@ -147,6 +167,7 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 		cfg.Auth.Token = strings.TrimSpace(cfg.Auth.Token)
 		cfg.Auth.Proxy.TrustedActorHeader = strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
 		cfg.Storage.DSN = strings.TrimSpace(cfg.Storage.DSN)
+		cfg.Close.Throttle.Window = strings.TrimSpace(cfg.Close.Throttle.Window)
 		trimDaemonCatalog(&cfg)
 	case errors.Is(err, os.ErrNotExist):
 		// Absent file: fall through with zero-value cfg. Env merge and
@@ -157,6 +178,9 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 	}
 	applyDaemonConfigEnv(&cfg)
 	if err := validateAuthProxy(cfg.Auth.Proxy); err != nil {
+		return nil, err
+	}
+	if _, err := cfg.Close.Throttle.ThrottleWindow(); err != nil {
 		return nil, err
 	}
 	if err := normalizeDaemonCatalog(&cfg); err != nil {

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -233,15 +234,15 @@ token_env = "  KATA_WORK_TOKEN  "
 	assert.Empty(t, cfg.Daemons[0].Token)
 }
 
-func TestReadDaemonConfig_ThrottleDefaultsEnabled(t *testing.T) {
+func TestReadDaemonConfig_ThrottleDefaultsDisabled(t *testing.T) {
 	t.Setenv("KATA_HOME", t.TempDir())
 	cfg, err := config.ReadDaemonConfig()
 	require.NoError(t, err)
-	assert.True(t, cfg.Close.Throttle.ThrottleEnabled(),
-		"absent [close.throttle] must default to enabled")
+	assert.False(t, cfg.Close.Throttle.ThrottleEnabled(),
+		"absent [close.throttle] must default sibling-burst throttling off")
 }
 
-func TestReadDaemonConfig_ThrottleDisabled(t *testing.T) {
+func TestReadDaemonConfig_ThrottleExplicitlyDisabled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
@@ -261,6 +262,30 @@ func TestReadDaemonConfig_ThrottleExplicitlyEnabled(t *testing.T) {
 	cfg, err := config.ReadDaemonConfig()
 	require.NoError(t, err)
 	assert.True(t, cfg.Close.Throttle.ThrottleEnabled())
+}
+
+func TestReadDaemonConfig_ThrottleWindow(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[close.throttle]\nenabled = true\nwindow = \"2m\"\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	window, err := cfg.Close.Throttle.ThrottleWindow()
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Minute, window)
+}
+
+func TestReadDaemonConfig_ThrottleWindowRejectsInvalidDuration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[close.throttle]\nwindow = \"eventually\"\n"), 0o600))
+
+	_, err := config.ReadDaemonConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "close.throttle.window")
 }
 
 func TestReadDaemonConfig_RejectsMalformed(t *testing.T) {

--- a/internal/daemon/close_guards.go
+++ b/internal/daemon/close_guards.go
@@ -2,9 +2,7 @@ package daemon
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -30,11 +28,6 @@ const (
 // guard (spec §3.10). Closes of sibling issues with an identical normalized
 // message by the same actor within this window are refused.
 const repeatedMessageWindow = 30 * time.Minute
-
-// duplicateEvidenceWindow is the look-back period for the duplicate-evidence
-// guard. It matches the repeated-message window because both guards look for
-// copy/paste close justification across sibling issues by one actor.
-const duplicateEvidenceWindow = 30 * time.Minute
 
 // CheckParentCloseCompleteness refuses a close on an issue with open
 // children. Implements spec §3.8: the close handler maps a non-nil return
@@ -199,57 +192,6 @@ func CheckSiblingCloseThrottle(
 	return parentRef, refs, refusal
 }
 
-// CheckDuplicateEvidenceGuard refuses close attempts that reuse identical
-// evidence on a sibling issue under the same parent. This is the always-on
-// close safety net for agent workflows: burst closing is allowed by default
-// when each issue carries distinct evidence, but copy/pasted evidence is still
-// refused.
-func CheckDuplicateEvidenceGuard(
-	ctx context.Context, d db.Storage,
-	issue db.Issue,
-	actor, reason string, evidence []db.Evidence, now time.Time,
-) (priorRef, parentRef string, refusal error) {
-	if reason != "done" && reason != "audit-no-change" {
-		return "", "", nil
-	}
-	signature := evidenceSignature(evidence)
-	if signature == "" {
-		return "", "", nil
-	}
-	parentLink, err := d.ParentOf(ctx, issue.ID)
-	if err != nil {
-		return "", "", nil
-	}
-	siblings, err := d.RecentSiblingCloses(
-		ctx, parentLink.ToIssueID, issue.ID, actor, now.Add(-duplicateEvidenceWindow))
-	if err != nil {
-		return "", "", nil
-	}
-	var prior *db.Event
-	for i := range siblings {
-		if closeEventEvidenceSignature(siblings[i]) == signature {
-			prior = &siblings[i]
-			break
-		}
-	}
-	if prior == nil {
-		return "", "", nil
-	}
-	render := newGuardRefRenderer(d, issue.ProjectID)
-	if ref, ok := render.eventIssueRef(ctx, *prior); ok {
-		priorRef = ref
-	}
-	if parentIssue, perr := d.IssueByID(ctx, parentLink.ToIssueID); perr == nil {
-		parentRef = render.issueRef(ctx, parentIssue)
-	}
-	refusal = fmt.Errorf(
-		"refusing — identical close evidence to your close of %s at %s. "+
-			"Both issues share a parent, and each closure should carry evidence "+
-			"specific to its issue",
-		priorRef, prior.CreatedAt.Format("15:04:05"))
-	return priorRef, parentRef, refusal
-}
-
 // CheckRepeatedMessageGuard implements spec §3.10. When the close is allowed,
 // all returns are zero. When refused, it returns the prior matching close's
 // display ref, the parent's display ref, and a descriptive error; the
@@ -318,53 +260,6 @@ func CheckRepeatedMessageGuard(
 			"`--superseded-by` instead",
 		priorRef, prior.CreatedAt.Format("15:04:05"))
 	return priorRef, parentRef, refusal
-}
-
-func closeEventEvidenceSignature(ev db.Event) string {
-	var payload struct {
-		Evidence []db.Evidence `json:"evidence,omitempty"`
-	}
-	if err := json.Unmarshal([]byte(ev.Payload), &payload); err != nil {
-		return ""
-	}
-	return evidenceSignature(payload.Evidence)
-}
-
-func evidenceSignature(evidence []db.Evidence) string {
-	if len(evidence) == 0 {
-		return ""
-	}
-	items := make([]string, 0, len(evidence))
-	for _, e := range evidence {
-		items = append(items, evidenceItemSignature(e))
-	}
-	sort.Strings(items)
-	return strings.Join(items, "\x1f")
-}
-
-func evidenceItemSignature(e db.Evidence) string {
-	switch e.Type {
-	case "commit":
-		return e.Type + "\x00" + e.SHA
-	case "pr":
-		return e.Type + "\x00" + e.URL
-	case "test":
-		return e.Type + "\x00" + e.Command
-	case "no-change-audit":
-		return e.Type + "\x00" + e.Rationale
-	case "duplicate-of", "superseded-by":
-		return e.Type + "\x00" + e.IssueRef
-	case "reviewed-paths":
-		paths := append([]string(nil), e.Paths...)
-		sort.Strings(paths)
-		return e.Type + "\x00" + strings.Join(paths, "\x00")
-	default:
-		bs, err := json.Marshal(e)
-		if err != nil {
-			return e.Type
-		}
-		return string(bs)
-	}
 }
 
 // humanizeDuration renders d as "N sec" through one minute and "N min"

--- a/internal/daemon/close_guards.go
+++ b/internal/daemon/close_guards.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,20 +16,25 @@ import (
 // suffix so the user knows to consult `kata show` for the rest.
 const openChildrenSampleLimit = 10
 
-// siblingThrottleWindow is the look-back period over which sibling closes by
-// the same actor under the same parent are counted. siblingThrottleLimit is
-// the threshold: at the Nth close (N == limit) the actor has already closed
-// (limit) prior siblings, and the next close is refused. Spec §3.9 fixes both
-// values at "3 closes in 60 seconds" for v1; neither is configurable.
+// defaultSiblingThrottleWindow is the default look-back period over which
+// sibling closes by the same actor under the same parent are counted when the
+// opt-in burst throttle is enabled. siblingThrottleLimit is the threshold: at
+// the Nth close (N == limit) the actor has already closed (limit) prior
+// siblings, and the next close is refused.
 const (
-	siblingThrottleWindow = 60 * time.Second
-	siblingThrottleLimit  = 3
+	defaultSiblingThrottleWindow = 60 * time.Second
+	siblingThrottleLimit         = 3
 )
 
 // repeatedMessageWindow is the look-back period for the repeated-message
 // guard (spec §3.10). Closes of sibling issues with an identical normalized
 // message by the same actor within this window are refused.
 const repeatedMessageWindow = 30 * time.Minute
+
+// duplicateEvidenceWindow is the look-back period for the duplicate-evidence
+// guard. It matches the repeated-message window because both guards look for
+// copy/paste close justification across sibling issues by one actor.
+const duplicateEvidenceWindow = 30 * time.Minute
 
 // CheckParentCloseCompleteness refuses a close on an issue with open
 // children. Implements spec §3.8: the close handler maps a non-nil return
@@ -147,15 +154,18 @@ func (r *guardRefRenderer) eventIssueRef(ctx context.Context, ev db.Event) (stri
 // the practical bound.
 func CheckSiblingCloseThrottle(
 	ctx context.Context, d db.Storage,
-	issue db.Issue, actor string, now time.Time,
+	issue db.Issue, actor string, now time.Time, window time.Duration,
 ) (parentRef string, cohort []string, refusal error) {
+	if window <= 0 {
+		window = defaultSiblingThrottleWindow
+	}
 	parentLink, err := d.ParentOf(ctx, issue.ID)
 	if err != nil {
 		// ErrNotFound = no parent set; any other error is treated as a soft
 		// failure rather than blocking the close.
 		return "", nil, nil
 	}
-	since := now.Add(-siblingThrottleWindow)
+	since := now.Add(-window)
 	siblings, err := d.RecentSiblingCloses(ctx, parentLink.ToIssueID, issue.ID, actor, since)
 	if err != nil {
 		return "", nil, nil
@@ -184,9 +194,60 @@ func CheckSiblingCloseThrottle(
 		"sibling-close throttle: you closed %d children of %s in the last %s:\n%s\n"+
 			"Slow down and review the scope of each remaining child before closing. "+
 			"Wait for the throttle window to clear, or ask a human reviewer to inspect and close",
-		len(siblings), parentRef, humanizeDuration(siblingThrottleWindow),
+		len(siblings), parentRef, humanizeDuration(window),
 		strings.Join(lines, "\n"))
 	return parentRef, refs, refusal
+}
+
+// CheckDuplicateEvidenceGuard refuses close attempts that reuse identical
+// evidence on a sibling issue under the same parent. This is the always-on
+// close safety net for agent workflows: burst closing is allowed by default
+// when each issue carries distinct evidence, but copy/pasted evidence is still
+// refused.
+func CheckDuplicateEvidenceGuard(
+	ctx context.Context, d db.Storage,
+	issue db.Issue,
+	actor, reason string, evidence []db.Evidence, now time.Time,
+) (priorRef, parentRef string, refusal error) {
+	if reason != "done" && reason != "audit-no-change" {
+		return "", "", nil
+	}
+	signature := evidenceSignature(evidence)
+	if signature == "" {
+		return "", "", nil
+	}
+	parentLink, err := d.ParentOf(ctx, issue.ID)
+	if err != nil {
+		return "", "", nil
+	}
+	siblings, err := d.RecentSiblingCloses(
+		ctx, parentLink.ToIssueID, issue.ID, actor, now.Add(-duplicateEvidenceWindow))
+	if err != nil {
+		return "", "", nil
+	}
+	var prior *db.Event
+	for i := range siblings {
+		if closeEventEvidenceSignature(siblings[i]) == signature {
+			prior = &siblings[i]
+			break
+		}
+	}
+	if prior == nil {
+		return "", "", nil
+	}
+	render := newGuardRefRenderer(d, issue.ProjectID)
+	if ref, ok := render.eventIssueRef(ctx, *prior); ok {
+		priorRef = ref
+	}
+	if parentIssue, perr := d.IssueByID(ctx, parentLink.ToIssueID); perr == nil {
+		parentRef = render.issueRef(ctx, parentIssue)
+	}
+	refusal = fmt.Errorf(
+		"refusing — identical close evidence to your close of %s at %s. "+
+			"Both issues share a parent, and each closure should carry evidence "+
+			"specific to its issue",
+		priorRef, prior.CreatedAt.Format("15:04:05"))
+	return priorRef, parentRef, refusal
 }
 
 // CheckRepeatedMessageGuard implements spec §3.10. When the close is allowed,
@@ -259,10 +320,58 @@ func CheckRepeatedMessageGuard(
 	return priorRef, parentRef, refusal
 }
 
-// humanizeDuration renders d as "N sec" under a minute and "N min" otherwise.
+func closeEventEvidenceSignature(ev db.Event) string {
+	var payload struct {
+		Evidence []db.Evidence `json:"evidence,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(ev.Payload), &payload); err != nil {
+		return ""
+	}
+	return evidenceSignature(payload.Evidence)
+}
+
+func evidenceSignature(evidence []db.Evidence) string {
+	if len(evidence) == 0 {
+		return ""
+	}
+	items := make([]string, 0, len(evidence))
+	for _, e := range evidence {
+		items = append(items, evidenceItemSignature(e))
+	}
+	sort.Strings(items)
+	return strings.Join(items, "\x1f")
+}
+
+func evidenceItemSignature(e db.Evidence) string {
+	switch e.Type {
+	case "commit":
+		return e.Type + "\x00" + e.SHA
+	case "pr":
+		return e.Type + "\x00" + e.URL
+	case "test":
+		return e.Type + "\x00" + e.Command
+	case "no-change-audit":
+		return e.Type + "\x00" + e.Rationale
+	case "duplicate-of", "superseded-by":
+		return e.Type + "\x00" + e.IssueRef
+	case "reviewed-paths":
+		paths := append([]string(nil), e.Paths...)
+		sort.Strings(paths)
+		return e.Type + "\x00" + strings.Join(paths, "\x00")
+	default:
+		bs, err := json.Marshal(e)
+		if err != nil {
+			return e.Type
+		}
+		return string(bs)
+	}
+}
+
+// humanizeDuration renders d as "N sec" through one minute and "N min"
+// otherwise.
 // Used by the throttle error to describe how long ago each sibling closed.
 func humanizeDuration(d time.Duration) string {
-	if d < time.Minute {
+	if d <= time.Minute {
 		return fmt.Sprintf("%d sec", int(d.Seconds()))
 	}
 	return fmt.Sprintf("%d min", int(d.Minutes()))

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -239,8 +239,30 @@ func TestCloseDuplicateOf_AcceptsExistingTarget(t *testing.T) {
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "duplicate close: %s", string(bs))
 }
 
-func TestSiblingThrottle_FourthCloseUnderSameParentRefused(t *testing.T) {
+func TestSiblingThrottle_DefaultAllowsBurstWithDistinctEvidence(t *testing.T) {
 	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	parent := createIssueViaHTTP(t, env, pid, "parent issue")
+	children := make([]int64, 0, 5)
+	for i := 0; i < 5; i++ {
+		c := createIssueViaHTTP(t, env, pid, fmt.Sprintf("child %d", i+1))
+		postLink(t, env, pid, c, "parent", parent)
+		children = append(children, c)
+	}
+
+	for i, c := range children {
+		resp, bs := closeIssueWithEvidence(t, env, pid, c, "agent-a",
+			"done",
+			fmt.Sprintf("Implementation of child %d complete and tested.", i+1),
+			[]map[string]any{{"type": "commit", "sha": fmt.Sprintf("abc123%d", i+1)}})
+		require.Equalf(t, http.StatusOK, resp.StatusCode,
+			"default policy should allow distinct-evidence sibling close %d: %s",
+			i+1, string(bs))
+	}
+}
+
+func TestSiblingThrottle_FourthCloseUnderSameParentRefusedWhenEnabled(t *testing.T) {
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
@@ -255,7 +277,7 @@ func TestSiblingThrottle_FourthCloseUnderSameParentRefused(t *testing.T) {
 		resp, bs := closeIssueWithEvidence(t, env, pid, c, "agent-a",
 			"done",
 			fmt.Sprintf("Implementation of child %d complete and tested.", i+1),
-			[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+			[]map[string]any{{"type": "commit", "sha": fmt.Sprintf("abc123%d", i+1)}})
 		require.Equalf(t, http.StatusOK, resp.StatusCode,
 			"close child %d: %s", i+1, string(bs))
 	}
@@ -271,6 +293,7 @@ func TestSiblingThrottle_FourthCloseUnderSameParentRefused(t *testing.T) {
 	assert.Contains(t, body, "sibling-close throttle")
 	// The error should reference the parent issue short_id.
 	assert.Contains(t, body, refForIssue(t, env, parent))
+	assert.Contains(t, body, "last 60 sec")
 }
 
 // Parent links may span projects, so the sibling cohort can too. The
@@ -278,7 +301,7 @@ func TestSiblingThrottle_FourthCloseUnderSameParentRefused(t *testing.T) {
 // of which project each child lives in — distributing sibling closes across
 // projects must not reset the counter.
 func TestSiblingThrottle_CountsCrossProjectSiblings(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pidA := initWorkspaceViaHTTP(t, env, "https://github.com/example/hub-project.git")
 	pidB := mkProject(t, env, "github.com/example/spoke-project", "spoke-project")
 	parent := createIssueViaHTTP(t, env, pidA, "parent issue")
@@ -295,7 +318,7 @@ func TestSiblingThrottle_CountsCrossProjectSiblings(t *testing.T) {
 		closeResp, bs := closeIssueWithEvidence(t, env, pidB, c, "agent-a",
 			"done",
 			fmt.Sprintf("Implementation of spoke child %d complete and tested.", i+1),
-			[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+			[]map[string]any{{"type": "commit", "sha": fmt.Sprintf("abc123%d", i+1)}})
 		require.Equalf(t, http.StatusOK, closeResp.StatusCode,
 			"close spoke child %d: %s", i+1, string(bs))
 	}
@@ -344,7 +367,7 @@ func TestSiblingThrottle_CountsCrossProjectSiblings(t *testing.T) {
 // identical close message on a sibling in another project is still a
 // duplicate.
 func TestRepeatedMessageGuard_CountsCrossProjectSiblings(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pidA := initWorkspaceViaHTTP(t, env, "https://github.com/example/hub-project.git")
 	pidB := mkProject(t, env, "github.com/example/spoke-project", "spoke-project")
 	parent := createIssueViaHTTP(t, env, pidA, "parent issue")
@@ -366,7 +389,7 @@ func TestRepeatedMessageGuard_CountsCrossProjectSiblings(t *testing.T) {
 	postLinkAs(t, env, pidA, hubChild, "agent-a", "parent", parent)
 	closeResp, bs = closeIssueWithEvidence(t, env, pidA, hubChild, "agent-a",
 		"done", message,
-		[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+		[]map[string]any{{"type": "commit", "sha": "def5678"}})
 	assertAPIError(t, closeResp.StatusCode, bs, http.StatusTooManyRequests, "duplicate_message")
 
 	// The prior close lives in another project: the refusal text and the
@@ -399,7 +422,7 @@ func TestRepeatedMessageGuard_CountsCrossProjectSiblings(t *testing.T) {
 }
 
 func TestSiblingThrottle_AllowsFourthCloseWhenOldestSiblingIsOutsideDefaultWindow(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
@@ -412,7 +435,7 @@ func TestSiblingThrottle_AllowsFourthCloseWhenOldestSiblingIsOutsideDefaultWindo
 	resp, bs := closeIssueWithEvidence(t, env, pid, children[0], "agent-a",
 		"done",
 		"Implementation of child 1 complete and tested.",
-		[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+		[]map[string]any{{"type": "commit", "sha": "abc1231"}})
 	require.Equalf(t, http.StatusOK, resp.StatusCode,
 		"close child 1: %s", string(bs))
 
@@ -430,7 +453,7 @@ func TestSiblingThrottle_AllowsFourthCloseWhenOldestSiblingIsOutsideDefaultWindo
 		resp, bs := closeIssueWithEvidence(t, env, pid, c, "agent-a",
 			"done",
 			fmt.Sprintf("Implementation of child %d complete and tested.", i+2),
-			[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+			[]map[string]any{{"type": "commit", "sha": fmt.Sprintf("abc123%d", i+2)}})
 		require.Equalf(t, http.StatusOK, resp.StatusCode,
 			"close child %d: %s", i+2, string(bs))
 	}
@@ -444,32 +467,37 @@ func TestSiblingThrottle_AllowsFourthCloseWhenOldestSiblingIsOutsideDefaultWindo
 		string(bs))
 }
 
-// TestSiblingThrottle_DisabledByConfig pins that operators who opt out
-// via [close.throttle] enabled=false get unthrottled sibling closes:
-// the same scenario that 429s in the default-config test must succeed
-// on every close when the daemon is started with throttle disabled.
-func TestSiblingThrottle_DisabledByConfig(t *testing.T) {
-	env := testenv.New(t, testenv.WithCloseThrottleDisabled())
+func TestSiblingThrottle_UsesConfiguredWindowInRefusal(t *testing.T) {
+	env := testenv.New(t,
+		testenv.WithCloseThrottleEnabled(),
+		testenv.WithCloseThrottleWindow(2*time.Minute))
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
-	children := make([]int64, 0, 5)
-	for i := 0; i < 5; i++ {
+	children := make([]int64, 0, 4)
+	for i := 0; i < 4; i++ {
 		c := createIssueViaHTTP(t, env, pid, fmt.Sprintf("child %d", i+1))
 		postLink(t, env, pid, c, "parent", parent)
 		children = append(children, c)
 	}
-	for i, c := range children {
+	for i, c := range children[:3] {
 		resp, bs := closeIssueWithEvidence(t, env, pid, c, "agent-a",
 			"done",
 			fmt.Sprintf("Implementation of child %d complete and tested.", i+1),
-			[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+			[]map[string]any{{"type": "commit", "sha": fmt.Sprintf("abc123%d", i+1)}})
 		require.Equalf(t, http.StatusOK, resp.StatusCode,
-			"close child %d with throttle disabled: %s", i+1, string(bs))
+			"close child %d: %s", i+1, string(bs))
 	}
+
+	resp, bs := closeIssueWithEvidence(t, env, pid, children[3], "agent-a",
+		"done",
+		"Implementation of child 4 complete and tested.",
+		[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode, string(bs))
+	assert.Contains(t, string(bs), "last 2 min")
 }
 
 func TestSiblingThrottle_DifferentActorNotThrottled(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
@@ -484,7 +512,7 @@ func TestSiblingThrottle_DifferentActorNotThrottled(t *testing.T) {
 		resp, bs := closeIssueWithEvidence(t, env, pid, c, "agent-a",
 			"done",
 			fmt.Sprintf("Implementation of child %d complete and tested.", i+1),
-			[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+			[]map[string]any{{"type": "commit", "sha": fmt.Sprintf("abc123%d", i+1)}})
 		require.Equalf(t, http.StatusOK, resp.StatusCode,
 			"close child %d: %s", i+1, string(bs))
 	}
@@ -499,7 +527,7 @@ func TestSiblingThrottle_DifferentActorNotThrottled(t *testing.T) {
 }
 
 func TestSiblingThrottle_UnparentedIssuesNotThrottled(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	// Four issues with no parent link — the throttle only applies to siblings
 	// under a shared parent, so all four closes should succeed.
@@ -519,7 +547,7 @@ func TestSiblingThrottle_UnparentedIssuesNotThrottled(t *testing.T) {
 }
 
 func TestRepeatedMessageGuard_RefusesIdenticalSiblingMessage(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	a := createIssueViaHTTP(t, env, pid, "child a")
@@ -531,7 +559,7 @@ func TestRepeatedMessageGuard_RefusesIdenticalSiblingMessage(t *testing.T) {
 	// First close succeeds.
 	firstResp, firstBody := closeIssueWithEvidence(t, env, pid, a, "agent-a",
 		"audit-no-change", msg,
-		[]map[string]any{{"type": "no-change-audit", "rationale": "metadata"}})
+		[]map[string]any{{"type": "no-change-audit", "rationale": "metadata-a"}})
 	require.Equalf(t, http.StatusOK, firstResp.StatusCode,
 		"first close: %s", string(firstBody))
 
@@ -539,13 +567,39 @@ func TestRepeatedMessageGuard_RefusesIdenticalSiblingMessage(t *testing.T) {
 	// actor is refused with 429 duplicate_message.
 	resp, bs := closeIssueWithEvidence(t, env, pid, b, "agent-a",
 		"audit-no-change", msg,
-		[]map[string]any{{"type": "no-change-audit", "rationale": "metadata"}})
+		[]map[string]any{{"type": "no-change-audit", "rationale": "metadata-b"}})
 	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode, string(bs))
 	assertAPIError(t, resp.StatusCode, bs, http.StatusTooManyRequests, "duplicate_message")
 	body := string(bs)
 	assert.Contains(t, body, "identical close message")
 	// The refusal should reference the prior close's issue short_id.
 	assert.Contains(t, body, refForIssue(t, env, a))
+}
+
+func TestDuplicateEvidenceGuard_RefusesIdenticalSiblingEvidence(t *testing.T) {
+	env := testenv.New(t)
+	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	parent := createIssueViaHTTP(t, env, pid, "parent issue")
+	a := createIssueViaHTTP(t, env, pid, "child a")
+	b := createIssueViaHTTP(t, env, pid, "child b")
+	postLink(t, env, pid, a, "parent", parent)
+	postLink(t, env, pid, b, "parent", parent)
+
+	firstResp, firstBody := closeIssueWithEvidence(t, env, pid, a, "agent-a",
+		"done",
+		"Implementation of child a complete and tested.",
+		[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+	require.Equalf(t, http.StatusOK, firstResp.StatusCode,
+		"first close: %s", string(firstBody))
+
+	resp, bs := closeIssueWithEvidence(t, env, pid, b, "agent-a",
+		"done",
+		"Implementation of child b complete and tested.",
+		[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode, string(bs))
+	assertAPIError(t, resp.StatusCode, bs, http.StatusTooManyRequests, "duplicate_evidence")
+	assert.Contains(t, string(bs), "identical close evidence")
+	assert.Contains(t, string(bs), refForIssue(t, env, a))
 }
 
 func TestRepeatedMessageGuard_SkipsForWontfix(t *testing.T) {
@@ -632,7 +686,7 @@ func TestRepeatedMessageGuard_SkipsSelfAfterReopen(t *testing.T) {
 // reopen. Otherwise an actor could exhaust the limit by repeatedly
 // reopening one issue.
 func TestSiblingThrottle_SkipsSelfAfterReopen(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
@@ -648,7 +702,7 @@ func TestSiblingThrottle_SkipsSelfAfterReopen(t *testing.T) {
 		resp, bs := closeIssueWithEvidence(t, env, pid, c, "agent-a",
 			"done",
 			fmt.Sprintf("Implementation of child %d complete and verified.", i+1),
-			[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+			[]map[string]any{{"type": "commit", "sha": fmt.Sprintf("abc123%d", i+1)}})
 		require.Equalf(t, http.StatusOK, resp.StatusCode,
 			"close child %d: %s", i+1, string(bs))
 	}
@@ -704,7 +758,7 @@ func TestRepeatedMessageGuard_SkipsTUIBypassEmptyMessage(t *testing.T) {
 }
 
 func TestThrottle_EmitsCloseThrottledEvent_SiblingBurst(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
@@ -719,7 +773,7 @@ func TestThrottle_EmitsCloseThrottledEvent_SiblingBurst(t *testing.T) {
 		resp, bs := closeIssueWithEvidence(t, env, pid, c, "agent-a",
 			"done",
 			fmt.Sprintf("Implementation of child %d complete and tested.", i+1),
-			[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+			[]map[string]any{{"type": "commit", "sha": fmt.Sprintf("abc123%d", i+1)}})
 		require.Equalf(t, http.StatusOK, resp.StatusCode,
 			"close child %d: %s", i+1, string(bs))
 	}
@@ -769,7 +823,7 @@ func TestThrottle_EmitsCloseThrottledEvent_SiblingBurst(t *testing.T) {
 }
 
 func TestThrottle_EmitsCloseThrottledEvent_DuplicateMessage(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	a := createIssueViaHTTP(t, env, pid, "child a")
@@ -780,13 +834,13 @@ func TestThrottle_EmitsCloseThrottledEvent_DuplicateMessage(t *testing.T) {
 	msg := "Schema review complete; table remains metadata-only and unchanged."
 	firstResp, firstBody := closeIssueWithEvidence(t, env, pid, a, "agent-a",
 		"audit-no-change", msg,
-		[]map[string]any{{"type": "no-change-audit", "rationale": "metadata"}})
+		[]map[string]any{{"type": "no-change-audit", "rationale": "metadata-a"}})
 	require.Equalf(t, http.StatusOK, firstResp.StatusCode,
 		"first close: %s", string(firstBody))
 
 	resp, bs := closeIssueWithEvidence(t, env, pid, b, "agent-a",
 		"audit-no-change", msg,
-		[]map[string]any{{"type": "no-change-audit", "rationale": "metadata"}})
+		[]map[string]any{{"type": "no-change-audit", "rationale": "metadata-b"}})
 	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode, string(bs))
 
 	events := fetchEvents(t, env, pid)
@@ -819,7 +873,7 @@ func TestThrottle_EmitsCloseThrottledEvent_DuplicateMessage(t *testing.T) {
 }
 
 func TestThrottle_DryRunDoesNotEmitEvent(t *testing.T) {
-	env := testenv.New(t)
+	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
@@ -832,7 +886,7 @@ func TestThrottle_DryRunDoesNotEmitEvent(t *testing.T) {
 		resp, bs := closeIssueWithEvidence(t, env, pid, c, "agent-a",
 			"done",
 			fmt.Sprintf("Implementation of child %d complete and tested.", i+1),
-			[]map[string]any{{"type": "commit", "sha": "abc1234"}})
+			[]map[string]any{{"type": "commit", "sha": fmt.Sprintf("abc123%d", i+1)}})
 		require.Equalf(t, http.StatusOK, resp.StatusCode,
 			"close child %d: %s", i+1, string(bs))
 	}

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -576,7 +576,7 @@ func TestRepeatedMessageGuard_RefusesIdenticalSiblingMessage(t *testing.T) {
 	assert.Contains(t, body, refForIssue(t, env, a))
 }
 
-func TestDuplicateEvidenceGuard_RefusesIdenticalSiblingEvidence(t *testing.T) {
+func TestClose_DefaultAllowsSiblingClosesWithSameCommitEvidence(t *testing.T) {
 	env := testenv.New(t)
 	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
@@ -596,10 +596,7 @@ func TestDuplicateEvidenceGuard_RefusesIdenticalSiblingEvidence(t *testing.T) {
 		"done",
 		"Implementation of child b complete and tested.",
 		[]map[string]any{{"type": "commit", "sha": "abc1234"}})
-	require.Equal(t, http.StatusTooManyRequests, resp.StatusCode, string(bs))
-	assertAPIError(t, resp.StatusCode, bs, http.StatusTooManyRequests, "duplicate_evidence")
-	assert.Contains(t, string(bs), "identical close evidence")
-	assert.Contains(t, string(bs), refForIssue(t, env, a))
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
 }
 
 func TestRepeatedMessageGuard_SkipsForWontfix(t *testing.T) {

--- a/internal/daemon/handlers_actions.go
+++ b/internal/daemon/handlers_actions.go
@@ -81,23 +81,8 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		now := time.Now()
 		dbEvidence := evidenceToDB(in.Body.Evidence)
-		if priorRef, parentRef, refusal := CheckDuplicateEvidenceGuard(
-			ctx, cfg.DB, issue,
-			actor, in.Body.Reason, dbEvidence, now); refusal != nil {
-			if !in.Body.DryRun {
-				if err := emitThrottledEvent(ctx, cfg, issue, actor,
-					db.CloseThrottledPayload{
-						Reason: db.CloseThrottleReasonDuplicateEvidence,
-						Parent: parentRef,
-						Prior:  &priorRef,
-					}); err != nil {
-					return nil, api.NewError(500, "internal", err.Error(), "", nil)
-				}
-			}
-			return nil, api.NewError(429, "duplicate_evidence", refusal.Error(), "", nil)
-		}
 		// Burst/prose throttles are opt-in via [close.throttle] enabled=true
-		// for operators who want stricter pacing than distinct evidence.
+		// for operators who want stricter pacing.
 		if cfg.CloseThrottle.SiblingBurstEnabled {
 			if parentRef, cohort, refusal := CheckSiblingCloseThrottle(
 				ctx, cfg.DB, issue, actor, now, cfg.CloseThrottle.SiblingBurstWindow); refusal != nil {

--- a/internal/daemon/handlers_actions.go
+++ b/internal/daemon/handlers_actions.go
@@ -80,14 +80,27 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(409, "parent_has_open_children", err.Error(), "", nil)
 		}
 		now := time.Now()
-		// Throttle/repeated-message guards run only when the operator
-		// hasn't disabled them in [close.throttle] of config.toml.
-		// Projects that rely on bulk-subagent close patterns opt out
-		// here; the substance/evidence gates (and the parent-close
-		// completeness guard above) still apply.
-		if !cfg.CloseThrottle.ThrottleDisabled {
+		dbEvidence := evidenceToDB(in.Body.Evidence)
+		if priorRef, parentRef, refusal := CheckDuplicateEvidenceGuard(
+			ctx, cfg.DB, issue,
+			actor, in.Body.Reason, dbEvidence, now); refusal != nil {
+			if !in.Body.DryRun {
+				if err := emitThrottledEvent(ctx, cfg, issue, actor,
+					db.CloseThrottledPayload{
+						Reason: db.CloseThrottleReasonDuplicateEvidence,
+						Parent: parentRef,
+						Prior:  &priorRef,
+					}); err != nil {
+					return nil, api.NewError(500, "internal", err.Error(), "", nil)
+				}
+			}
+			return nil, api.NewError(429, "duplicate_evidence", refusal.Error(), "", nil)
+		}
+		// Burst/prose throttles are opt-in via [close.throttle] enabled=true
+		// for operators who want stricter pacing than distinct evidence.
+		if cfg.CloseThrottle.SiblingBurstEnabled {
 			if parentRef, cohort, refusal := CheckSiblingCloseThrottle(
-				ctx, cfg.DB, issue, actor, now); refusal != nil {
+				ctx, cfg.DB, issue, actor, now, cfg.CloseThrottle.SiblingBurstWindow); refusal != nil {
 				// Dry-run is side-effect-free: surface the 429 but skip persisting
 				// an audit event so kata events --tail doesn't fill with would-be
 				// refusals from validation probes.
@@ -138,8 +151,7 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			evt = nil
 			events = nil
 			updated, events, changed, err = cfg.DB.CloseIssueWithEvents(ctx, issue.ID,
-				in.Body.Reason, actor, in.Body.Message,
-				evidenceToDB(in.Body.Evidence))
+				in.Body.Reason, actor, in.Body.Message, dbEvidence)
 			if len(events) > 0 {
 				evt = &events[0]
 			}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -31,12 +31,9 @@ type ServerConfig struct {
 	Broadcaster    *EventBroadcaster
 	FederationWake func()
 	Hooks          hooks.Sink
-	// CloseThrottle controls whether the sibling-burst and repeated-
-	// message guards run on close. Zero-value (Enabled=false) is taken
-	// as "guards on" so handler tests and existing test harness setups
-	// keep the v1 default behavior without plumbing the policy through;
-	// the daemon entry point sets ThrottleDisabled=true only when the
-	// operator opts out via [close.throttle] in config.toml.
+	// CloseThrottle controls whether the opt-in sibling-burst and repeated-
+	// message guards run on close. Zero-value means "guards off" for burst
+	// throttling; duplicate-evidence protection is enforced separately.
 	CloseThrottle CloseThrottlePolicy
 
 	// Auth carries the bearer-token policy resolved at daemon start.
@@ -68,10 +65,10 @@ func (c ServerConfig) authPolicy() authPolicy {
 }
 
 // CloseThrottlePolicy is the runtime form of [close.throttle] in
-// <KATA_HOME>/config.toml. Using ThrottleDisabled (rather than Enabled)
-// makes the zero value match the v1 default: guards on.
+// <KATA_HOME>/config.toml.
 type CloseThrottlePolicy struct {
-	ThrottleDisabled bool
+	SiblingBurstEnabled bool
+	SiblingBurstWindow  time.Duration
 }
 
 // Server bundles the http handler and lifecycle.

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -32,8 +32,7 @@ type ServerConfig struct {
 	FederationWake func()
 	Hooks          hooks.Sink
 	// CloseThrottle controls whether the opt-in sibling-burst and repeated-
-	// message guards run on close. Zero-value means "guards off" for burst
-	// throttling; duplicate-evidence protection is enforced separately.
+	// message guards run on close. Zero-value means "guards off".
 	CloseThrottle CloseThrottlePolicy
 
 	// Auth carries the bearer-token policy resolved at daemon start.

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -108,9 +108,8 @@ type CreateCommentParams struct {
 // window; duplicate-message fires when an actor reuses identical close prose
 // across sibling issues.
 const (
-	CloseThrottleReasonSiblingBurst      = "sibling-burst"
-	CloseThrottleReasonDuplicateMessage  = "duplicate-message"
-	CloseThrottleReasonDuplicateEvidence = "duplicate-evidence"
+	CloseThrottleReasonSiblingBurst     = "sibling-burst"
+	CloseThrottleReasonDuplicateMessage = "duplicate-message"
 )
 
 // CloseThrottledPayload is the JSON wire shape persisted on close.throttled

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -108,8 +108,9 @@ type CreateCommentParams struct {
 // window; duplicate-message fires when an actor reuses identical close prose
 // across sibling issues.
 const (
-	CloseThrottleReasonSiblingBurst     = "sibling-burst"
-	CloseThrottleReasonDuplicateMessage = "duplicate-message"
+	CloseThrottleReasonSiblingBurst      = "sibling-burst"
+	CloseThrottleReasonDuplicateMessage  = "duplicate-message"
+	CloseThrottleReasonDuplicateEvidence = "duplicate-evidence"
 )
 
 // CloseThrottledPayload is the JSON wire shape persisted on close.throttled

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -33,15 +33,23 @@ type Env struct {
 
 // Option configures the test daemon. Applied to a ServerConfig before
 // daemon.NewServer; tests use options to opt into non-default policy
-// (e.g. throttle disabled) without forking the constructor.
+// (e.g. throttle enabled) without forking the constructor.
 type Option func(*daemon.ServerConfig)
 
-// WithCloseThrottleDisabled tells the test daemon to skip the close
-// throttle / repeated-message guards, mirroring [close.throttle]
-// enabled=false in <KATA_HOME>/config.toml.
-func WithCloseThrottleDisabled() Option {
+// WithCloseThrottleEnabled tells the test daemon to enforce the sibling-burst
+// close throttle, mirroring [close.throttle] enabled=true in
+// <KATA_HOME>/config.toml.
+func WithCloseThrottleEnabled() Option {
 	return func(cfg *daemon.ServerConfig) {
-		cfg.CloseThrottle.ThrottleDisabled = true
+		cfg.CloseThrottle.SiblingBurstEnabled = true
+	}
+}
+
+// WithCloseThrottleWindow tells the test daemon to use a non-default
+// sibling-burst close throttle window.
+func WithCloseThrottleWindow(window time.Duration) Option {
+	return func(cfg *daemon.ServerConfig) {
+		cfg.CloseThrottle.SiblingBurstWindow = window
 	}
 }
 


### PR DESCRIPTION
Agent workflows can legitimately close multiple sibling issues in quick succession, especially when a single commit or PR resolves several related tasks. The old default treated those close bursts as suspicious even when each close had valid evidence, which made normal completion workflows hit throttling instead of relying on the existing close validation gates.

This makes sibling-burst and repeated-message throttling an explicit operator policy under `[close.throttle] enabled = true`, while keeping the default path focused on parent-completeness, substantive close messages, and valid evidence. The sibling-burst window is configurable, and throttle refusals now report the resolved window so tuned deployments do not show stale timing guidance.

To keep guidance visible without blocking legitimate shared evidence, successful CLI closes now print a reminder that closing is a completion claim and that the message and evidence should be specific to the issue. The reminder appears in human and agent output for actual close mutations, but not in JSON, quiet, dry-run, or no-op responses.

As a result, shared implementation evidence is allowed by default: the same commit or PR can close multiple sibling issues. Audit tests that depend on throttle markers now opt into the throttle policy they exercise.