### PR TITLE
Improve agent recovery for kata comment

### DIFF
--- a/cmd/kata/comment.go
+++ b/cmd/kata/comment.go
@@ -14,17 +14,29 @@ import (
 
 func newCommentCmd() *cobra.Command {
 	var src BodySources
+	var unsupportedRelationships commentRelationshipFlags
 	cmd := &cobra.Command{
 		Use:   "comment <issue-ref>",
 		Short: "append a comment to an issue",
 		Args:  cobra.ExactArgs(1),
 	}
-	cmd.Flags().StringVar(&src.Body, "body", "", "comment body")
+	cmd.Flags().StringVarP(&src.Body, "body", "m", "", "comment body")
 	cmd.Flags().StringVar(&src.File, "body-file", "", "read body from file")
 	cmd.Flags().BoolVar(&src.Stdin, "body-stdin", false, "read body from stdin")
+	cmd.Flags().StringVar(&unsupportedRelationships.Parent, "parent", "", "unsupported on comment; use edit")
+	cmd.Flags().StringVar(&unsupportedRelationships.Blocks, "blocks", "", "unsupported on comment; use edit")
+	cmd.Flags().StringVar(&unsupportedRelationships.BlockedBy, "blocked-by", "", "unsupported on comment; use edit")
+	cmd.Flags().StringVar(&unsupportedRelationships.Related, "related", "", "unsupported on comment; use edit")
+	_ = cmd.Flags().MarkHidden("parent")
+	_ = cmd.Flags().MarkHidden("blocks")
+	_ = cmd.Flags().MarkHidden("blocked-by")
+	_ = cmd.Flags().MarkHidden("related")
 
 	// RunE is set after flag registration so we can reference cmd.Flags().Changed.
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := unsupportedRelationships.err(cmd, args[0]); err != nil {
+			return err
+		}
 		src.BodySet = cmd.Flags().Changed("body")
 		src.FileSet = cmd.Flags().Changed("body-file")
 
@@ -77,4 +89,40 @@ func newCommentCmd() *cobra.Command {
 		return nil
 	}
 	return cmd
+}
+
+type commentRelationshipFlags struct {
+	Parent    string
+	Blocks    string
+	BlockedBy string
+	Related   string
+}
+
+func (f commentRelationshipFlags) err(cmd *cobra.Command, issueRef string) error {
+	for _, rel := range []struct {
+		flag  string
+		value string
+	}{
+		{flag: "parent", value: f.Parent},
+		{flag: "blocks", value: f.Blocks},
+		{flag: "blocked-by", value: f.BlockedBy},
+		{flag: "related", value: f.Related},
+	} {
+		if !cmd.Flags().Changed(rel.flag) {
+			continue
+		}
+		target := rel.value
+		if strings.TrimSpace(target) == "" {
+			target = "<target-ref>"
+		}
+		return &cliError{
+			Message: fmt.Sprintf(
+				"kata comment does not support --%s; use `kata edit %s --%s %s --comment \"...\"`",
+				rel.flag, issueRef, rel.flag, target,
+			),
+			Kind:     kindUsage,
+			ExitCode: ExitUsage,
+		}
+	}
+	return nil
 }

--- a/cmd/kata/comment_test.go
+++ b/cmd/kata/comment_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestComment_AppendsToIssue(t *testing.T) {
@@ -13,6 +15,29 @@ func TestComment_AppendsToIssue(t *testing.T) {
 
 	out := runCLI(t, env, dir, "comment", short, "--body", "looks good")
 	assert.True(t, strings.Contains(out, "looks good") || strings.Contains(out, "comment"))
+}
+
+func TestComment_MessageShorthandAppendsToIssue(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	short := createIssue(t, env, pid, "x")
+
+	runCLI(t, env, dir, "comment", short, "-m", "looks good")
+
+	issue := fetchIssueViaHTTPWithComments(t, env, pid, short)
+	require.Len(t, issue.Comments, 1)
+	assert.Equal(t, "looks good", issue.Comments[0].Body)
+}
+
+func TestComment_RelationshipFlagSuggestsEditCommentComposition(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+
+	_, stderr, err := executeRootCapture(t, context.Background(),
+		"comment", "abc4", "--blocks", "d4ex")
+
+	require.Error(t, err)
+	assert.Contains(t, stderr, "kata comment does not support --blocks")
+	assert.Contains(t, stderr, `kata edit abc4 --blocks d4ex --comment "..."`)
 }
 
 func TestComment_AgentOutput(t *testing.T) {

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -54,6 +54,10 @@ Use kata as the shared issue ledger for this workspace.
    Use --json only when your script needs complete structured data, for
    example when piping into jq.
 
+   Use kata for real repository work only.
+   Do not create practice, tutorial, example, or scratchpad issues unless the user explicitly asks for them.
+   If the work belongs to another repository or project, use that project.
+
 3. Search before creating:
 
    kata search "login race" --agent
@@ -153,6 +157,7 @@ a local daemon.
 `
 
 const agentQuickstartCompactText = `Use kata as the shared issue ledger for this workspace.
+Do not create practice, tutorial, example, or scratchpad issues.
 Search before creating or updating work.
 Default to --agent for ordinary kata reads and mutations in agent logs.
 Use --json only when your script needs complete structured data.

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -14,6 +14,7 @@ func TestQuickstart_PrintsAgentInstructions(t *testing.T) {
 	out := string(executeRoot(t, newQuickstartCmd()))
 	assert.Contains(t, out, "kata agent quickstart")
 	assert.Contains(t, out, "Search before creating")
+	assert.Contains(t, out, "Do not create practice, tutorial, example, or scratchpad issues")
 	assert.Contains(t, out, "Do not run delete or purge")
 	assert.Contains(t, out, "Default to --agent for ordinary kata reads and mutations in agent logs.")
 	assert.Contains(t, out, "Use --json only when your script needs complete structured data")
@@ -58,6 +59,7 @@ func TestQuickstart_AgentOutput(t *testing.T) {
 	assert.NotContains(t, out, "Remote daemon")
 	assert.Contains(t, out, "Default to --agent for ordinary kata reads and mutations in agent logs.")
 	assert.Contains(t, out, "Use --json only when your script needs complete structured data.")
+	assert.Contains(t, out, "Do not create practice, tutorial, example, or scratchpad issues.")
 	assert.Contains(t, out, "Close each verified issue promptly; valid evidence keeps sibling close bursts admissible by default.")
 }
 


### PR DESCRIPTION
Agents are already treating kata like other CLIs they know: `comment -m` comes from git muscle memory, and relationship flags on `comment` come from over-generalizing kata's `edit --comment` composition. The status quo made both failures recoverable only after a generic flag error, which is noisy for agents and leaves them guessing about the intended command boundary.

This keeps relationship mutation authority on `kata edit`, but makes the common failure mode actionable by pointing `kata comment <issue> --blocks <target>` at the corresponding `kata edit <issue> --blocks <target> --comment "..."` shape. It also accepts `-m` as a low-risk alias for `--body` and tightens quickstart guidance so agents do not create practice or scratchpad issues in the active project.

Routine repository tests and pre-push hooks passed before opening the PR.