### PR TITLE
Add opt-in semantic search (Phase 1, SQLite)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -771,6 +771,23 @@ components:
         - event
         - changed
       type: object
+    EmbeddingsHealth:
+      additionalProperties: true
+      properties:
+        backlog:
+          format: int64
+          type: integer
+        configured:
+          type: boolean
+        last_error:
+          type: string
+        last_success_at:
+          format: date-time
+          type: string
+      required:
+        - configured
+        - backlog
+      type: object
     EnableIssueSyncRequestBody:
       additionalProperties: false
       properties:
@@ -1339,6 +1356,8 @@ components:
           type: string
         db_path:
           type: string
+        embeddings:
+          $ref: "#/components/schemas/EmbeddingsHealth"
         ok:
           type: boolean
         schema_version:
@@ -3142,6 +3161,12 @@ components:
     SearchResponseBody:
       additionalProperties: true
       properties:
+        degraded:
+          type: boolean
+        degraded_reason:
+          type: string
+        mode:
+          type: string
         query:
           type: string
         results:
@@ -3152,6 +3177,7 @@ components:
             - "null"
       required:
         - query
+        - mode
         - results
       type: object
     ShowIssueResponseBody:
@@ -5809,6 +5835,16 @@ paths:
           name: include_deleted
           schema:
             type: boolean
+        - explode: false
+          in: query
+          name: mode
+          schema:
+            enum:
+              - auto
+              - lexical
+              - hybrid
+              - semantic
+            type: string
       responses:
         "200":
           content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -779,8 +779,9 @@ components:
           type: integer
         configured:
           type: boolean
-        last_error:
-          type: string
+        last_error_status:
+          format: int64
+          type: integer
         last_success_at:
           format: date-time
           type: string
@@ -3333,7 +3334,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.3.0
+  version: 0.4.0
 openapi: 3.1.0
 paths:
   /api/v1/audit/closes:

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/storeopen"
+	"go.kenn.io/kata/internal/embedding"
 	"go.kenn.io/kata/internal/federation"
 	"go.kenn.io/kata/internal/githubsync"
 	"go.kenn.io/kata/internal/hooks"
@@ -545,6 +546,11 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		return err
 	}
 
+	embedder, reconcilerHealth, err := startEmbeddingReconciler(ctx, dcfg, store, broadcaster, daemonLog)
+	if err != nil {
+		return err
+	}
+
 	srv := daemon.NewServer(daemon.ServerConfig{
 		DB:                store,
 		StartedAt:         time.Now().UTC(),
@@ -560,6 +566,8 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		},
 		Auth:             dcfg.Auth,
 		InsecureReadonly: insecureReadonly,
+		Embedder:         embedder,
+		ReconcilerHealth: reconcilerHealth,
 	})
 	defer func() { _ = srv.Close() }()
 
@@ -711,6 +719,71 @@ func startFederationRunner(
 		}
 	}()
 	return wakeRunner
+}
+
+// startEmbeddingReconciler constructs the embedding client and reconciler when
+// semantic search is configured, starts the reconciler goroutine, subscribes to
+// the broadcaster so new/edited issues are embedded promptly, and triggers an
+// initial backfill sweep. It returns the client and a health snapshot func to
+// wire into ServerConfig. When embeddings are not configured it returns nils so
+// the daemon behaves exactly as it did before semantic search existed.
+func startEmbeddingReconciler(
+	ctx context.Context,
+	dcfg *config.DaemonConfig,
+	store db.Storage,
+	bcast *daemon.EventBroadcaster,
+	daemonLog *log.Logger,
+) (*embedding.Client, func() daemon.ReconcilerHealth, error) {
+	ec := dcfg.Search.Embeddings
+	if !ec.Enabled() {
+		return nil, nil, nil
+	}
+	embedder, err := embedding.New(embedding.Config{
+		BaseURL:             ec.BaseURL,
+		Model:               ec.Model,
+		APIKey:              ec.ResolvedAPIKey(),
+		Salt:                ec.FingerprintSalt,
+		Dims:                ec.Dims,
+		BatchSize:           ec.BatchSize,
+		Timeout:             time.Duration(ec.TimeoutSeconds) * time.Second,
+		TrustPrivateNetwork: ec.TrustPrivateNetwork,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("embedding client: %w", err)
+	}
+	reconciler := daemon.NewReconciler(store, embedder, daemon.ReconcilerConfig{BatchSize: ec.BatchSize})
+	go func() {
+		if err := reconciler.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			daemonLog.Printf("reconciler: %v", err)
+		}
+	}()
+	startEmbeddingNudge(ctx, bcast, reconciler)
+	reconciler.Wake() // initial backfill sweep
+	return embedder, reconciler.Health, nil
+}
+
+// startEmbeddingNudge subscribes to the broadcaster and wakes the reconciler on
+// every committed event so new/edited issues are embedded promptly. The
+// goroutine exits when ctx is cancelled or the subscription channel closes, and
+// always releases the subscription via Unsub.
+func startEmbeddingNudge(ctx context.Context, bcast *daemon.EventBroadcaster, r *daemon.Reconciler) {
+	sub := bcast.Subscribe(daemon.SubFilter{})
+	go func() {
+		defer sub.Unsub()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-sub.Ch:
+				if !ok {
+					return
+				}
+				if msg.Kind == "event" {
+					r.Wake()
+				}
+			}
+		}
+	}()
 }
 
 func federationRunnerInterval() time.Duration {

--- a/cmd/kata/search.go
+++ b/cmd/kata/search.go
@@ -18,6 +18,7 @@ import (
 func newSearchCmd() *cobra.Command {
 	var limit int
 	var includeDeleted bool
+	var lexical, hybrid, semantic bool
 	cmd := &cobra.Command{
 		Use:   "search <query>...",
 		Short: "search issues by title/body/comments",
@@ -30,6 +31,24 @@ func newSearchCmd() *cobra.Command {
 			query := strings.Join(args, " ")
 			if strings.TrimSpace(query) == "" {
 				return &cliError{Message: "query must be non-empty", Kind: kindValidation, ExitCode: ExitValidation}
+			}
+			modeFlags := 0
+			for _, b := range []bool{lexical, hybrid, semantic} {
+				if b {
+					modeFlags++
+				}
+			}
+			if modeFlags > 1 {
+				return &cliError{Message: "--lexical, --hybrid, and --semantic are mutually exclusive", Kind: kindValidation, ExitCode: ExitValidation}
+			}
+			mode := ""
+			switch {
+			case lexical:
+				mode = "lexical"
+			case hybrid:
+				mode = "hybrid"
+			case semantic:
+				mode = "semantic"
 			}
 			// Mirror list / ready / events validation (hammer-test
 			// finding #5): --limit 0/-1 used to be silently treated
@@ -56,7 +75,7 @@ func newSearchCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			searchURL := buildSearchURL(baseURL, pid, query, limit, includeDeleted)
+			searchURL := buildSearchURL(baseURL, pid, query, limit, includeDeleted, mode)
 			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, searchURL, nil)
 			if err != nil {
 				return err
@@ -69,12 +88,15 @@ func newSearchCmd() *cobra.Command {
 	}
 	cmd.Flags().IntVar(&limit, "limit", 20, "max rows")
 	cmd.Flags().BoolVar(&includeDeleted, "include-deleted", false, "include soft-deleted issues")
+	cmd.Flags().BoolVar(&lexical, "lexical", false, "lexical (FTS) search only")
+	cmd.Flags().BoolVar(&hybrid, "hybrid", false, "hybrid lexical+semantic search")
+	cmd.Flags().BoolVar(&semantic, "semantic", false, "semantic (vector) search only")
 	return cmd
 }
 
 // buildSearchURL assembles the GET /search request URL with q, optional limit,
-// and optional include_deleted query params.
-func buildSearchURL(baseURL string, pid int64, query string, limit int, includeDeleted bool) string {
+// optional include_deleted, and optional mode query params.
+func buildSearchURL(baseURL string, pid int64, query string, limit int, includeDeleted bool, mode string) string {
 	q := url.Values{}
 	q.Set("q", query)
 	if limit > 0 {
@@ -82,6 +104,9 @@ func buildSearchURL(baseURL string, pid int64, query string, limit int, includeD
 	}
 	if includeDeleted {
 		q.Set("include_deleted", "true")
+	}
+	if mode != "" {
+		q.Set("mode", mode)
 	}
 	return fmt.Sprintf("%s/api/v1/projects/%d/search?%s", baseURL, pid, q.Encode())
 }
@@ -99,8 +124,11 @@ func printSearchResults(cmd *cobra.Command, bs []byte) error {
 		return err
 	}
 	var b struct {
-		Query   string `json:"query"`
-		Results []struct {
+		Query          string `json:"query"`
+		Mode           string `json:"mode"`
+		Degraded       bool   `json:"degraded"`
+		DegradedReason string `json:"degraded_reason"`
+		Results        []struct {
 			Issue struct {
 				ShortID string `json:"short_id"`
 				Title   string `json:"title"`
@@ -113,9 +141,19 @@ func printSearchResults(cmd *cobra.Command, bs []byte) error {
 	if err := json.Unmarshal(bs, &b); err != nil {
 		return err
 	}
+	// A pre-0.3.0 daemon (reachable only in remote-client mode) omits "mode";
+	// it only ever did lexical search, so render it as the lexical baseline
+	// rather than emitting a bare "# mode=" / "mode=" line.
+	if b.Mode == "" {
+		b.Mode = "lexical"
+	}
 	if mode == outputAgent {
 		out := cmd.OutOrStdout()
-		if _, err := fmt.Fprintf(out, "OK search count=%d query=%s\n", len(b.Results), agentValue(b.Query)); err != nil {
+		header := fmt.Sprintf("OK search count=%d query=%s mode=%s", len(b.Results), agentValue(b.Query), b.Mode)
+		if b.Degraded {
+			header += " degraded=" + agentValue(b.DegradedReason)
+		}
+		if _, err := fmt.Fprintln(out, header); err != nil {
 			return err
 		}
 		for _, r := range b.Results {
@@ -131,6 +169,21 @@ func printSearchResults(cmd *cobra.Command, bs []byte) error {
 		}
 		return nil
 	}
+	// Header rule keyed on whether this is the plain baseline, not the
+	// effective mode alone: print a leading "# mode=<mode>" line whenever the
+	// mode is hybrid/semantic OR the result is degraded. Baseline lexical
+	// (mode=lexical, not degraded) stays byte-identical to today — no header,
+	// %.2f scores — so degraded auto fallback is silent-but-labeled rather
+	// than silent. See docs/design/semantic-search.md "API and CLI contract".
+	if b.Mode != "lexical" || b.Degraded {
+		header := "# mode=" + b.Mode
+		if b.Degraded {
+			header += " degraded: " + b.DegradedReason
+		}
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), header); err != nil {
+			return err
+		}
+	}
 	if len(b.Results) == 0 {
 		if flags.Quiet {
 			return nil
@@ -138,8 +191,15 @@ func printSearchResults(cmd *cobra.Command, bs []byte) error {
 		_, err := fmt.Fprintln(cmd.OutOrStdout(), "no matches")
 		return err
 	}
+	// RRF and cosine scores cluster around 0.01-0.03, which %.2f would flatten;
+	// hybrid/semantic use %.4f. Degraded-lexical results are ordinary BM25 and
+	// keep %.2f.
+	scoreFmt := "%.2f"
+	if b.Mode == "hybrid" || b.Mode == "semantic" {
+		scoreFmt = "%.4f"
+	}
 	for _, r := range b.Results {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%-8s  %.2f  %-8s  %s  (%s)\n",
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%-8s  "+scoreFmt+"  %-8s  %s  (%s)\n",
 			r.Issue.ShortID, r.Score, r.Issue.Status,
 			textsafe.Line(r.Issue.Title),
 			strings.Join(r.MatchedIn, ",")); err != nil {

--- a/cmd/kata/search_test.go
+++ b/cmd/kata/search_test.go
@@ -1,12 +1,31 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// renderSearch drives printSearchResults directly: it sets the active output
+// mode, feeds the raw response body, and returns captured stdout. It isolates
+// the rendering contract (header rule, score precision, agent field order) from
+// daemon round-trips, mirroring the cobra output-capture pattern used by the
+// other cmd/kata tests.
+func renderSearch(t *testing.T, mode outputMode, body string) string {
+	t.Helper()
+	resetFlags(t)
+	flags.Mode = mode
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	require.NoError(t, printSearchResults(cmd, []byte(body)))
+	return buf.String()
+}
 
 // TestSearch_OutputsShortIDNotNumber pins the JSON wire shape: each search
 // result's nested issue carries short_id; the legacy `number` field is gone.
@@ -47,7 +66,7 @@ func TestSearch_AgentOutputEmptyEmitsOnlyHeader(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Empty(t, stderr)
-	assert.Equal(t, "OK search count=0 query=\"login race\"\n", out)
+	assert.Equal(t, "OK search count=0 query=\"login race\" mode=lexical\n", out)
 }
 
 func TestSearch_EmptyQueryIsValidationError(t *testing.T) {
@@ -66,6 +85,99 @@ func TestSearch_UnquotedMultiTerm(t *testing.T) {
 	out := runCLI(t, env, dir, "search", "login", "Safari")
 	assert.Contains(t, out, "fix login crash on Safari")
 	assert.NotContains(t, out, "unrelated issue")
+}
+
+// TestSearchHumanBaselineLexicalUnchanged pins that plain lexical output (the
+// unconfigured daemon, auto-with-embeddings-off, and explicit --lexical) stays
+// byte-identical to today: no mode header, %.2f scores.
+func TestSearchHumanBaselineLexicalUnchanged(t *testing.T) {
+	body := `{"query":"login","mode":"lexical","results":[
+	  {"issue":{"short_id":"abc4","title":"Fix login","status":"open"},"score":1.23,"matched_in":["title"]}]}`
+	out := renderSearch(t, outputHuman, body)
+	if strings.Contains(out, "# mode=") {
+		t.Fatalf("baseline lexical must not print a mode header:\n%s", out)
+	}
+	if !strings.Contains(out, "abc4") || !strings.Contains(out, "1.23") {
+		t.Fatalf("row format changed:\n%s", out)
+	}
+}
+
+// TestSearchHumanDegradedAutoPrintsNote pins that a degraded lexical result
+// (auto fell back because the embedder is down) still prints a labeled note so
+// the human knows semantic results are missing.
+func TestSearchHumanDegradedAutoPrintsNote(t *testing.T) {
+	body := `{"query":"login","mode":"lexical","degraded":true,"degraded_reason":"embedder unreachable","results":[]}`
+	out := renderSearch(t, outputHuman, body)
+	if !strings.Contains(out, "# mode=lexical") || !strings.Contains(out, "degraded") {
+		t.Fatalf("degraded auto must print a note:\n%s", out)
+	}
+}
+
+// TestSearchHumanHybridUsesHigherPrecision pins the %.4f precision for hybrid
+// (and semantic) scores, which cluster around 0.01-0.03 and would flatten
+// under %.2f, plus the mode header.
+func TestSearchHumanHybridUsesHigherPrecision(t *testing.T) {
+	body := `{"query":"login","mode":"hybrid","results":[
+	  {"issue":{"short_id":"abc4","title":"Fix login","status":"open"},"score":0.0163,"matched_in":["title","semantic"]}]}`
+	out := renderSearch(t, outputHuman, body)
+	if !strings.Contains(out, "# mode=hybrid") {
+		t.Fatalf("hybrid must print mode header:\n%s", out)
+	}
+	if !strings.Contains(out, "0.0163") {
+		t.Fatalf("hybrid must use %%.4f precision:\n%s", out)
+	}
+}
+
+// TestSearchAgentAppendsMode pins the appended agent field order: mode= follows
+// count= and query= without disturbing their names or positions.
+func TestSearchAgentAppendsMode(t *testing.T) {
+	body := `{"query":"login","mode":"lexical","results":[
+	  {"issue":{"short_id":"abc4","title":"Fix login","status":"open"},"score":1.2,"matched_in":["title"]}]}`
+	out := renderSearch(t, outputAgent, body)
+	if !strings.Contains(out, "OK search count=1 query=login mode=lexical") {
+		t.Fatalf("agent header order wrong:\n%s", out)
+	}
+}
+
+// TestSearch_ModeFlagsMutuallyExclusive pins that --lexical/--hybrid/--semantic
+// cannot be combined; each conflicting pair is a validation error.
+func TestSearch_ModeFlagsMutuallyExclusive(t *testing.T) {
+	pairs := [][]string{
+		{"--lexical", "--hybrid"},
+		{"--lexical", "--semantic"},
+		{"--hybrid", "--semantic"},
+	}
+	for _, p := range pairs {
+		args := append([]string{"search", "x"}, p...)
+		_, err := runCmdOutput(t, nil, args...)
+		_ = requireCLIError(t, err, ExitValidation)
+	}
+}
+
+// TestSearchHumanDegradedLexicalKeepsTwoDecimals pins that degraded-lexical
+// results (BM25 scores) keep %.2f — only hybrid/semantic use %.4f.
+func TestSearchHumanDegradedLexicalKeepsTwoDecimals(t *testing.T) {
+	body := `{"query":"login","mode":"lexical","degraded":true,"degraded_reason":"embedder unreachable","results":[
+	  {"issue":{"short_id":"abc4","title":"Fix login","status":"open"},"score":2.5,"matched_in":["title"]}]}`
+	out := renderSearch(t, outputHuman, body)
+	if !strings.Contains(out, "2.50") || strings.Contains(out, "2.5000") {
+		t.Fatalf("degraded-lexical must use %%.2f, not %%.4f:\n%s", out)
+	}
+}
+
+// TestSearchHumanOldDaemonEmptyModeRendersAsLexical pins that a response with
+// no "mode" field (a pre-0.3.0 daemon, reachable only in remote-client mode)
+// renders as the lexical baseline rather than a bare "# mode=" line.
+func TestSearchHumanOldDaemonEmptyModeRendersAsLexical(t *testing.T) {
+	body := `{"query":"login","results":[
+	  {"issue":{"short_id":"abc4","title":"Fix login","status":"open"},"score":1.23,"matched_in":["title"]}]}`
+	out := renderSearch(t, outputHuman, body)
+	if strings.Contains(out, "# mode=") {
+		t.Fatalf("empty mode must not print a header:\n%s", out)
+	}
+	if !strings.Contains(out, "1.23") {
+		t.Fatalf("empty mode must render lexical %%.2f rows:\n%s", out)
+	}
 }
 
 // TestSearch_RejectsNonPositiveLimit covers hammer-test #5: --limit

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -14,6 +14,7 @@ constraints that are too detailed for the main documentation.
 - [Federation technical notes](federation.md)
 - [GitHub sync](github-sync.md)
 - [Hosted mode technical notes](hosted-mode.md)
+- [Semantic search technical notes](semantic-search.md)
 
 These notes are the curated home for kata's design rationale. Earlier planning
 specs and implementation plans should be folded into these notes once the work

--- a/docs/design/semantic-search.md
+++ b/docs/design/semantic-search.md
@@ -1,0 +1,495 @@
+# Semantic search technical notes
+
+Status: design note for unshipped work. Remove this line when the feature
+lands and fold any drift back into this document.
+
+kata's search is lexical: SQLite FTS5 with BM25 ranking over title, body, and
+comments (`internal/db/sqlitestore/queries_search.go`), with the PostgreSQL
+equivalent stubbed pending its tsvector implementation. Lexical search misses
+issues that describe the same problem in different words — the exact case
+that matters for agents running search-before-create. This note describes the
+design for semantic search: embedding-based vector retrieval fused with the
+existing lexical search, opt-in by configuration, degrading to today's
+behavior whenever embeddings cannot help.
+
+## Goals and non-goals
+
+Goals:
+
+- `kata search` finds paraphrased and conceptually-related issues, not just
+  token matches, when an embedding endpoint is configured.
+- Zero new requirements for deployments that do not opt in: no extensions,
+  no network calls, no behavior change to ranking or scores.
+- Index freshness is owned by the daemon, never by user discipline. Stale or
+  missing embeddings degrade recall gracefully; they never break search.
+- Both storage backends reach the same observable contract, by different
+  execution strategies where that is the better engineering trade.
+
+Non-goals for v1 (future levers, in rough order of expected value):
+
+- Embedding-assisted duplicate detection. The create-time look-alike
+  soft-block keeps its lexical retrieval + Jaccard gate
+  (`internal/similarity/`); a follow-up can add a cosine gate over the same
+  vectors this design stores.
+- Comment and chunk-level vectors (see "Text recipe" for the implications).
+- LLM reranking and query expansion (qmd-style stages; they need a
+  generation model, which this design deliberately does not require).
+- sqlite-vec. The current driver (`modernc.org/sqlite`, pure Go) cannot load
+  native extensions. If the driver ever changes for other reasons, a
+  sqlite-vec fast path can slot in behind `SearchVector` without contract
+  changes; brute force is sufficient at issue-tracker scale (see "SQLite
+  vector execution").
+- Federating embeddings. They are local derived state; each daemon embeds
+  what it stores.
+- TUI affordances beyond what arrives transparently through the API.
+
+## Trust, privacy, and credentials
+
+Configuring an embedding endpoint sends issue titles and bodies to that
+endpoint. That is the consent boundary: the operator who writes the config
+section is authorizing that data flow. The docs recommend a local endpoint
+(for example Ollama on loopback) for sensitive projects.
+
+Credential handling follows the existing bearer-token trust model:
+
+- The embedding API key is attached only to requests whose origin exactly
+  matches the configured `base_url` origin. The client reuses the
+  origin-pinned transport machinery from `internal/config/bearer.go`
+  (`bearerTransport`, `CheckBearerTargetSafeURLWithTrust`): cross-origin
+  redirects are refused rather than followed, so a key configured for one
+  origin can never leak to another.
+- Plaintext HTTP targets follow the same safety ladder as other bearer
+  targets: HTTPS always allowed; HTTP to loopback allowed; HTTP to literal
+  non-public IPs only with `trust_private_network = true` in the embeddings
+  section; anything else (public IPs, DNS hostnames) requires HTTPS. v1 has
+  no public-plaintext escape hatch — point such targets at an HTTPS endpoint
+  or an SSH tunnel.
+
+## Architecture
+
+```
+write path:  mutation commit ──nudge──▶ reconciler ──▶ ListEmbedTargets
+                                           │              (dirty rows)
+                                           ▼
+                                     embedding client ──▶ UpsertIssueEmbedding
+                                     (batched HTTP)
+
+query path:  search q ──┬─▶ FTS leg (existing SearchFTS) ──┐
+                        │                                   ├─▶ RRF merge ─▶ results
+                        └─▶ embed(q) ─▶ SearchVector ──────┘
+                              │ (3s timeout)
+                              └─ failure ─▶ lexical-only, degraded:true
+```
+
+Components:
+
+- `internal/embedding` — the OpenAI-compatible embeddings client, the text
+  recipe, and the fingerprint. Storage-free: it does not import `internal/db`
+  and operates on plain strings (`EmbedText(title, body string)`). Named
+  `embedding`, not `embed`, to avoid colliding with the Go stdlib package.
+- `internal/db` interface additions — `UpsertIssueEmbedding`,
+  `ListEmbedTargets`, `SearchVector`, implemented per backend. Storage never
+  infers model state from the daemon: the active fingerprint is a parameter
+  to `ListEmbedTargets` and `SearchVector`.
+- `internal/daemon` — the reconciler goroutine (started only when
+  configured) and the hybrid orchestrator inside the search handler. The RRF
+  merge is a pure function.
+
+## Configuration
+
+```toml
+[search.embeddings]
+base_url = "http://localhost:11434/v1"  # any OpenAI-compatible /embeddings
+model    = "nomic-embed-text"
+# api_key      = "..."          # or api_key_env = "SOME_VAR"; mutually exclusive
+# fingerprint_salt = ""         # bump to force re-embed when weights change
+# trust_private_network = false # plaintext HTTP to literal non-public IPs
+# timeout_seconds, batch_size, dims  # defaulted; override rarely
+```
+
+- Presence of the section enables the feature. `base_url` and `model` are
+  both required once the section exists: partial configuration is a startup
+  error, not a silent disable.
+- `api_key` / `api_key_env` are mutually exclusive, mirroring the daemon
+  catalog's `token` / `token_env` pair
+  (`internal/config/daemon_config.go`). There is no additional hardcoded
+  environment variable; `api_key_env = "KATA_EMBED_API_KEY"` is the
+  conventional spelling if an env var is wanted.
+- The client POSTs `{model, input: [...]}` to `{base_url}/embeddings` and
+  L2-normalizes returned vectors at the boundary, so similarity is a dot
+  product everywhere downstream.
+
+## Embedding pipeline
+
+### Text recipe and fingerprint
+
+v1 embeds one vector per issue over `title + "\n\n" + body`, truncated to a
+fixed character cap (~8k chars). Comments are deliberately not embedded:
+
+- A new comment is findable immediately through the FTS comments column; it
+  never creates embedding staleness or an embedding API call.
+- The named gap: comment-only *conceptual* matches (paraphrase that lives
+  solely in comments) will not vector-match. Lexical comment matches still
+  hit. Chunked comment vectors are the v2 lever if this gap matters in
+  practice.
+
+`embed_fingerprint = sha256(model, dims, recipe_version, fingerprint_salt)`.
+Any component change marks every row stale and triggers gradual re-embedding.
+The salt is the operator's lever for "same model name, different weights"
+(for example a re-pulled Ollama model). The endpoint URL is deliberately not
+in the fingerprint: moving a port or switching localhost to a tunnel must not
+force a full re-embed.
+
+### Reconciler
+
+One goroutine, started only when embeddings are configured. The dirty
+predicate over the tables is the queue — there is no separate durable queue
+to maintain or to lose.
+
+Dirty means any of:
+
+1. no `issue_embeddings` row (never embedded);
+2. `embed_fingerprint != current` (model/recipe/salt changed);
+3. `issues.content_revision != issue_embeddings.embedded_content_revision`
+   (the embedded source text changed).
+
+The third predicate needs a counter that moves *exactly* when embeddable
+content changes. The existing `issues.revision` is unsuitable on both ends:
+it is the metadata If-Match counter (`internal/db/sqlitestore/store_metadata.go`),
+and title/body edits do not touch it — `editIssue` bumps only `updated_at`
+(`internal/db/sqlitestore/queries.go`). Reusing `revision` would therefore
+miss the very edits that matter, and broadening it would silently change
+metadata optimistic-concurrency semantics. So this design adds a dedicated
+`issues.content_revision`, monotonic, bumped by every writer that actually
+changes title or body and by nothing else. Today those writers are
+`EditIssue`, `EditIssueAtomic` (the active PATCH route,
+`internal/daemon/handlers_issues.go`), and issue import
+(`updateImportedIssue`, `internal/db/sqlitestore/imports.go`). The two
+interactive paths already funnel field changes through
+`issueFieldUpdatePlan`, which is the natural bump site — it must distinguish
+a title/body change from an owner-only edit, since owner does not bump —
+while import bumps in its direct `UPDATE`. Owner, priority, status,
+comments, links, and metadata all leave `content_revision` unchanged, and
+`revision` is left untouched. Timestamps are not used either: `updated_at`
+also moves on non-content mutations (status flips), and its millisecond
+precision can collapse same-instant edits.
+
+Soft-deleted issues are excluded from targets while deleted; their rows are
+kept so restore costs nothing. Purge removes rows via `ON DELETE CASCADE`.
+
+Cycle: wake on a debounced (~1–2s) post-commit nudge, on startup, and on a
+periodic safety sweep (~5m) that recovers anything missed across restarts.
+Take up to `batch_size` (default 64) dirty targets, embed them in one batched
+request, and upsert rows independently — each carrying the current
+`embed_fingerprint` and the issue's `content_revision` — so partial progress
+survives. Because `content_revision` moves only on real content change,
+status flips and comment adds never enter the queue, so there is no
+hash-recompute or no-op-touch step. The one inefficiency is a title/body edit
+that reverts to a prior value (`A→B→A`): the counter advances both times, so
+the unchanged content is re-embedded once. That is rare and harmless, and
+buys a simpler, exact dirty signal over carrying a content hash.
+
+Failure classes:
+
+- 401 / 403 / 404 / 400 model-not-found — definitive misconfiguration: pin
+  backoff at the maximum immediately (no hot loop) and surface the error in
+  health.
+- 429 — honor `Retry-After` when present, otherwise normal backoff.
+- 5xx / timeouts / connection errors — exponential backoff, 1s doubling to a
+  5m cap.
+
+Reconciler health — `{configured, last_success_at, last_error, backlog}` —
+joins the `/health` payload (following the `api_schema_version` reporting
+precedent) and is the operator's view of index freshness.
+
+### Freshness contract
+
+- **Lexical: same-commit.** FTS triggers fire in the writing transaction;
+  create-then-search (including the agent duplicate-check pattern) behaves
+  exactly as today.
+- **Semantic: eventual, seconds.** Nudge debounce plus one batch call —
+  typically under ~5s against a local endpoint, somewhat more against a
+  cloud API, unbounded only while the embedder is down (visible in
+  `/health`). Until a row is (re-)embedded it contributes nothing to the
+  vector leg and is carried by the FTS leg; an edited issue serves its old
+  vector for the lag window while FTS already ranks the new text.
+
+An issue is therefore never unsearchable because of embedding lag; only its
+semantic recall lags.
+
+## Storage
+
+### Canonical tables (both backends)
+
+```sql
+CREATE TABLE issue_embeddings (
+  issue_id                  INTEGER/BIGINT PRIMARY KEY
+                            REFERENCES issues(id) ON DELETE CASCADE,
+  embedded_content_revision INTEGER NOT NULL,  -- issues.content_revision at embed time
+  embed_fingerprint         TEXT NOT NULL CHECK (length(embed_fingerprint) = 64),
+  dims                      INTEGER NOT NULL CHECK (dims > 0),
+  vector_bytes              BLOB/BYTEA NOT NULL,  -- dims × float32 LE, L2-normalized
+  updated_at                TEXT/timestamptz NOT NULL,
+  CHECK (length(vector_bytes) = dims * 4)   -- octet_length() on PostgreSQL
+);
+```
+
+The column is `vector_bytes`, not `vector`, so nothing reads as pgvector's
+`vector(N)` type. The table is canonical schema on both backends and rides a
+schema-version bump that also adds the `issues.content_revision` column
+(default 0) and the title/body writer bumps above: SQLite upgrades via the
+usual JSONL cutover; PostgreSQL follows the existing operator-migration
+policy (`internal/db/pgstore/open.go` refuses version mismatches).
+
+pgvector is deliberately absent from the canonical schema. PostgreSQL
+deployments that never enable embeddings carry no extension requirement.
+
+### JSONL export/import
+
+`issue_embeddings` rows are exported (vectors base64-encoded) and keyed by
+`issue_uid`, with the numeric id treated as a local detail resolved at
+import. Embeddings are expensive derived state — re-embedding a large
+project costs real API calls and time — so they earn export the way cheap,
+trigger-rebuilt FTS state does not. Live-only exports emit an embedding row
+only when its parent issue is in the export set.
+
+For the export to actually save work, the issue's `content_revision` must
+travel with it. `IssueExport` (`internal/db/export_types.go`) carries
+`content_revision` alongside the existing `revision`, and import restores
+it. Otherwise an imported issue defaults to `content_revision = 0` while its
+embedding row carries the revision it was embedded at, so the dirty
+predicate would mark every imported-and-previously-edited issue stale and
+re-embed it on the first sweep — exactly the cost export is meant to avoid.
+Embedding import also validates `embedded_content_revision <=
+issues.content_revision`; a row that fails (a corrupt or hand-edited dump)
+is dropped and left for the reconciler rather than trusted.
+
+### SQLite vector execution: brute force behind a cache
+
+At issue-tracker scale (1–10k issues per project at 768 dims ≈ 3–30MB,
+~1–5ms to scan; 50k ≈ ~30ms) exhaustive cosine is sufficient and avoids any
+driver or extension dependency.
+
+The cache is keyed by `(project_id, embed_fingerprint)` and holds
+`(issue_id, vector)` for rows at that fingerprint only — a model swap creates
+a fresh entry under the new fingerprint and abandons the old one, so
+stale-fingerprint vectors can never be reused. It is consulted under one
+invariant: **the cache supplies candidates and similarities, never
+visibility or row data.** Every
+`SearchVector` resolves candidate ids against the live `issues` table —
+project scope, `deleted_at` filter, and all returned fields come from that
+final query. Soft delete, restore, and purge therefore cannot make the cache
+return a wrong result set; a stale entry either fails the join (purged) or
+is filtered (deleted). What cache staleness *can* do is rank an edited issue
+on slightly-old text until the reconciler catches up — bounded by the
+freshness contract, and the FTS leg ranks the fresh text in the same merge.
+
+Exact top-k under filtering: the linear scan ranks the entire cached set
+anyway, so the query walks the ranked list, joining live rows in batches,
+until k results are found or candidates are exhausted — filtered-out ids
+never silently shrink the result set.
+
+Cache freshness is verified per query with one cheap probe —
+`(count, max(updated_at))` over the project's rows *at the active
+fingerprint* (`WHERE embed_fingerprint = ?`), matching the cache key — rather
+than trusting in-process invalidation alone, which also keeps multi-daemon
+shared-database setups correct.
+
+### PostgreSQL vector execution: pgvector as best-effort acceleration
+
+When available, acceleration uses a derived table —
+`issue_embeddings_vec(issue_id PK REFERENCES issues(id) ON DELETE CASCADE,
+vec vector(N))` with an HNSW cosine index — maintained in the same
+transaction as the canonical row, rebuildable from `vector_bytes` at any
+time, and dropped/recreated on fingerprint change (N can change with the
+model).
+
+"Available" is probed, not assumed: the extension must be present in
+`pg_extension` *and* the idempotent ensure-DDL must succeed under
+`pg_advisory_xact_lock`. Any failure — missing extension, insufficient
+privileges, concurrent DDL — logs and falls back to the same brute-force
+path SQLite uses (BYTEA scan with the cache invariant above). Acceleration
+is a capability, not a mode: search behaves identically either way, modulo
+latency at scales SQLite deployments do not reach.
+
+Queries against the HNSW index apply the visibility join inside the query
+and rely on pgvector ≥ 0.8 iterative index scans, with oversample-and-refill
+as the fallback, because HNSW post-filtering can under-return.
+
+Daemons sharing one PostgreSQL database must share embedding configuration.
+The advisory lock prevents DDL corruption; the shared-config requirement
+prevents two daemons with different fingerprints from thrashing the derived
+table through drop/recreate cycles. Duplicate reconciler work across daemons
+is harmless (last-write-wins upserts of identical vectors).
+
+## Query pipeline
+
+### Modes
+
+`mode = auto | lexical | hybrid | semantic` (CLI: `--lexical` / `--hybrid` /
+`--semantic`; mutually exclusive flags).
+
+- `auto` (default): hybrid when embeddings are configured, lexical
+  otherwise. Degradation within auto is silent-but-labeled.
+- `lexical`: exactly today's FTS path.
+- `hybrid`, `semantic` (explicit): deterministic or an honest error — 400
+  when embeddings are unconfigured, 503 when the vector leg cannot run
+  (query embed failure or vector store failure). Never a silent downgrade.
+- `semantic` against an empty current-fingerprint index (backfill not yet
+  complete) is 200 with empty results: the request was served correctly;
+  `/health` backlog explains the emptiness.
+
+### Execution
+
+Both legs start concurrently — the FTS leg never waits on the embedder.
+Per-leg fetch depth is `max(limit*3, 50)`, capped at 200. The vector leg
+embeds the query (3s timeout; query text truncated to the recipe cap for
+embedding only — the lexical leg and the response's `query` echo always use
+the original), runs `SearchVector` with the current fingerprint, and drops
+hits below cosine 0.3 so weak vectors do not pad results. The fingerprint
+parameter makes cross-model comparison structurally impossible: rows
+embedded under a previous model are invisible to the vector leg until
+re-embedded, and the FTS leg carries them meanwhile.
+
+Fusion is reciprocal rank fusion with k=60 and equal leg weights:
+`score(d) = Σ_legs 1/(60 + rank_leg(d))`. Ties break deterministically
+(`updated_at` desc, then id). `matched_in` keeps its FTS column values and
+gains `"semantic"` when the vector leg contributed the document.
+
+There is no BM25-probe shortcut (qmd's optimization): the probe exists to
+dodge expensive LLM query-expansion stages this design does not have, and
+with legs running in parallel a probe saves nothing.
+
+`degraded` is narrowly defined: the vector leg could not run or complete
+*for this query* (query embed failure, dims mismatch with the configured
+model, vector store failure) in a mode that wanted it. A nonzero reconciler
+backlog is health state, not per-query degradation.
+
+`include_deleted=true` lets the vector leg rank soft-deleted issues on
+their last-known vectors (rows are not re-embedded while deleted) —
+acceptable for an explicitly archaeological flag.
+
+## API and CLI contract
+
+`SearchResponse` gains `mode` (always present), `degraded` and
+`degraded_reason` (omitempty). `score` semantics are mode-scoped, documented
+at `SearchHit` (`internal/api/types.go`): lexical → negated BM25 exactly as
+today; hybrid → RRF score; semantic → cosine similarity.
+
+This is explicit API evolution, not strict invisibility: `api_schema_version`
+takes a minor bump, the compatibility doc records that *ranking and score
+semantics of unconfigured search are unchanged* while the response gains
+`mode: "lexical"` and `/health` gains reconciler state. The alternative —
+omitting fields unless configured — was rejected because clients could not
+distinguish an old daemon from an unconfigured one, undermining the purpose
+of version reporting. An always-present `mode` also tells agents whether
+semantic search is even on. A CLI/API compatibility test pins the
+unconfigured-default response shape and score semantics.
+
+The CLI has three output surfaces, each handled to a precise shape:
+
+- `--json`: the response envelope is passed through unchanged
+  (`printSearchResults` JSON branch, `cmd/kata/search.go`), so `mode`,
+  `degraded`, and `degraded_reason` appear automatically.
+- Agent mode (`cmd/kata/search.go:116`) is a machine surface governed by
+  `docs/reference/agent-output.md`, where field order is part of the
+  contract and new fields may be *appended* without an `agent_format`
+  version bump. So `mode` is appended after the existing header fields —
+  exact order `OK search count=<n> query=<q> mode=<mode>` — and
+  `degraded=<reason>` follows only when the query degraded (nullable fields
+  are omitted when absent, per the contract). Result rows gain `semantic` in
+  their comma-separated `matched=` list when the vector leg contributed.
+  Because `count` and `query` keep their names, positions, and meanings,
+  this is purely additive and `agent_format` stays `1`; the HTTP API is what
+  takes the `api_schema_version` bump, since its JSON envelope always carries
+  `mode`. The compatibility test pins the appended field order, `mode=lexical`
+  on an unconfigured daemon, and unchanged lexical score semantics.
+- Human mode (`%-8s  %.2f  %-8s  %s  (%s)` per row, `cmd/kata/search.go:142`)
+  is an ergonomic surface. The header rule is keyed on whether the output is
+  the plain baseline, not on the effective mode alone: a leading
+  `# mode=<mode>` line (carrying a `degraded: <reason>` note when present)
+  prints whenever `mode` is hybrid/semantic **or** `degraded` is true.
+  Baseline lexical — `mode=lexical` and not degraded, which covers an
+  unconfigured daemon, `auto` with embeddings off, and explicit `--lexical`
+  — stays byte-identical to today (no header, `%.2f`) and is pinned by the
+  compatibility test. This split is what keeps `auto` degradation
+  "silent-but-labeled" rather than silent: when `auto` falls back because the
+  embedder is down, the effective mode is `lexical` but `degraded` is true,
+  so a `# mode=lexical degraded: <reason>` line still tells the human that
+  semantic results are missing. Scores render with `%.4f` only for hybrid and
+  semantic (RRF/cosine values cluster around 0.01–0.03, which `%.2f` would
+  flatten); degraded-lexical results are ordinary BM25 and keep `%.2f`.
+
+## Failure modes
+
+| Failure | Behavior |
+| --- | --- |
+| Embeddings unconfigured | `auto` → lexical, `mode:"lexical"`, not degraded (it is the baseline); explicit `hybrid`/`semantic` → 400 |
+| Embedder unreachable at query | `auto` → lexical + `degraded:true` + reason; explicit `hybrid`/`semantic` → 503 |
+| Query embed dims ≠ configured dims | Treated as embed failure (degraded / 503) + health error |
+| Embedder unreachable in reconciler | Backoff per failure class; backlog grows; search unaffected (FTS carries) |
+| Definitive 4xx in reconciler | Max backoff immediately + health error; no hot loop |
+| Rows not yet embedded / model swap in progress | Invisible to vector leg (fingerprint filter), carried by FTS leg |
+| pgvector DDL/index failure | Log + brute-force fallback; feature works without acceleration |
+| Cache staleness | Ranking-only effect; visibility always resolved against live `issues` |
+
+## Testing
+
+TDD throughout (red, green, refactor). Highlights, not an exhaustive list:
+
+- `internal/embedding` against an `httptest` fake: wire shape, key attached
+  only to the pinned origin, cross-origin redirect refusal (mirroring the
+  `bearer.go` tests), batching, timeout, 429-with-Retry-After versus 401
+  classification, truncation, fingerprint composition (each component
+  independently changes it), L2 normalization.
+- RRF as a pure function: overlapping/disjoint/empty legs, similarity floor,
+  determinism and tie-breaks.
+- Storage conformance suite shared by both backends (pgstore joins in
+  Phase 2): upsert round-trips including CHECK violations (dims, vector
+  length, fingerprint length); the three dirty predicates (missing,
+  fingerprint mismatch, `content_revision` mismatch); that `content_revision`
+  bumps via every title/body writer (`EditIssue`, `EditIssueAtomic`, import)
+  but not on owner-only edits, status flips, or comment adds; fingerprint
+  filtering; visibility joins under soft-delete/restore/purge; exact top-k
+  refill with deleted-heavy caches; the fingerprint-scoped cache key and
+  freshness probe; JSONL round-trip carrying `content_revision` so a
+  previously-edited issue's imported embedding is not falsely stale, plus the
+  `embedded_content_revision <= content_revision` validation dropping bad
+  rows; live-only exclusion of unexported parents.
+- Daemon: reconciler against a fake embedder (backfill, nudge debounce,
+  model-swap gradual migration, backoff classes, health fields); handler
+  mode-resolution matrix (hung embedder returns FTS results degraded;
+  explicit-mode 400/503; semantic-on-empty-index 200).
+- CLI/API compatibility test pinning the unconfigured-default search across
+  surfaces: JSON envelope and agent status line carry `mode:"lexical"` /
+  `mode=lexical`; human output is byte-identical to today; lexical score
+  semantics (negated BM25) unchanged. A companion human-rendering test pins
+  that degraded `auto` (embedder down, effective `mode=lexical`,
+  `degraded:true`) *does* print the `# mode=lexical degraded: <reason>` note
+  — distinguishing baseline lexical from degraded lexical.
+- e2e with a deterministic fixture-map embedder and neutral placeholder
+  data: create → instant lexical hit; after reconcile → paraphrase found
+  semantically; embedder killed → degraded lexical.
+- Explicitly untested: real model quality; no network in tests.
+
+## Phasing
+
+- **Phase 1 — SQLite end-to-end plus all backend-neutral machinery**: the
+  `internal/embedding` client, config section and validation, storage
+  interface methods with the sqlitestore implementation, reconciler, RRF
+  merge and mode resolution, API/CLI surface, JSONL export/import, health
+  reporting.
+- **Phase 2 — PostgreSQL parity**: implement `SearchFTS`/`SearchFTSAny`
+  over the existing tsvector machinery (currently stubbed in
+  `internal/db/pgstore/stubs_gen.go`), splitting or weighting the tsvector
+  so `matched_in` keeps parity with SQLite; the pgvector acceleration path
+  with probe + advisory locking; pgstore joins the storage conformance
+  suite.
+
+## Future work
+
+In rough order of expected value: embedding-assisted duplicate detection
+(cosine gate beside Jaccard in the look-alike soft-block); comment/chunk
+vectors; TUI degraded-state affordance in the search bar; LLM rerank and
+query expansion; sqlite-vec fast path if the driver story changes;
+quantization (int8) if vector storage size ever matters.

--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -1,0 +1,162 @@
+# Semantic search
+
+By default `kata search` is lexical: it matches the words you type against issue
+titles, bodies, and comments. That misses issues that describe the same problem
+in different words — the case that matters most when an agent searches before
+creating a duplicate. Semantic search adds a vector (embedding) leg so a query
+like "auth redirect duplicates" can surface an issue titled "Login callback
+double-submits on Safari" even though they share no keywords.
+
+Semantic search is **opt-in**. With no embedding endpoint configured, `kata
+search` behaves exactly as before and the daemon makes no network calls. This
+page explains how to turn it on and how it behaves; for the exact config fields
+see [Configuration](../reference/configuration.md#semantic-search), and for the
+command flags see the [CLI reference](../reference/cli.md).
+
+## How it works
+
+When you configure an embedding endpoint, the daemon embeds each issue's title
+and body into a vector and stores it alongside the issue. A search then runs two
+legs and fuses them:
+
+- the **lexical leg** — the existing full-text search, unchanged; and
+- the **vector leg** — embeds your query and finds issues whose vectors are
+  closest to it.
+
+Results are merged with reciprocal rank fusion, so an issue that ranks well in
+either leg surfaces, and an issue that ranks well in both rises to the top.
+
+Embeddings are produced by an **OpenAI-compatible `/embeddings` endpoint** that
+you point kata at. That can be a local runtime (Ollama, LM Studio, or a
+llama.cpp server) or a hosted provider (OpenAI, Voyage, and others) — kata only
+speaks the wire format and never bundles a model.
+
+## Enabling it
+
+1. Run an embeddings endpoint. For a fully local setup, install
+   [Ollama](https://ollama.com) and pull an embedding model:
+
+   ```sh
+   ollama pull nomic-embed-text
+   ```
+
+2. Add a `[search.embeddings]` block to `<KATA_HOME>/config.toml`:
+
+   ```toml
+   [search.embeddings]
+   base_url = "http://localhost:11434/v1"   # any OpenAI-compatible /embeddings
+   model    = "nomic-embed-text"
+   ```
+
+   `base_url` and `model` are both required once the section exists. A hosted
+   provider also needs a key — set `api_key` or, better, `api_key_env` pointing
+   at an environment variable. See
+   [Configuration](../reference/configuration.md#semantic-search) for every
+   field (`dims`, `batch_size`, `timeout_seconds`, `fingerprint_salt`,
+   `trust_private_network`).
+
+3. Restart the daemon (or start it — `kata` will pick up the config). It begins
+   embedding existing issues in the background immediately.
+
+4. Confirm it is live and watch the backfill drain. The reconciler state is in
+   the `embeddings` object of the JSON health response:
+
+   ```sh
+   kata health --json   # see the "embeddings" object: backlog, last_success_at
+   ```
+
+That is the whole setup. New and edited issues are embedded automatically from
+then on.
+
+## Search modes
+
+`kata search` takes three mutually exclusive flags; with none of them it runs in
+**auto** mode:
+
+| Mode | Flag | Behavior |
+| --- | --- | --- |
+| auto (default) | *(none)* | Hybrid when embeddings are configured, lexical otherwise. |
+| lexical | `--lexical` | Full-text search only — today's behavior. |
+| hybrid | `--hybrid` | Fuse the lexical and vector legs. |
+| semantic | `--semantic` | Vector results only. |
+
+Auto is the right default for almost everything, including agents: it transparently
+improves recall when embeddings are on and is unchanged when they are off. Reach
+for `--lexical` when you want an exact keyword/identifier lookup, or `--semantic`
+when you want pure concept matching regardless of wording.
+
+The effective mode is reported back on every response. In `--json` and `--agent`
+output it appears as a `mode` field (`lexical`, `hybrid`, or `semantic`); see the
+[agent output reference](../reference/agent-output.md) for the exact shape.
+
+## Freshness: lexical is instant, semantic is eventual
+
+Lexical search is always up to date the moment you write an issue — creating an
+issue and immediately searching for it works exactly as before, which keeps the
+agent search-before-create flow reliable.
+
+The vector index is **eventually consistent**. A background reconciler embeds new
+and edited issues a few seconds after they change (sooner against a fast local
+endpoint, longer against a busy cloud API). A brand-new issue is not in the
+vector leg until its first embedding lands — it is still found lexically, so
+nothing becomes unsearchable. An *edited* issue keeps serving its previous
+vector (so the vector leg may rank it on the old text) until the reconciler
+re-embeds it; the lexical leg already reflects the new text in the same results.
+Either way the staleness is brief and bounded by reconciler lag.
+
+You can watch the reconciler in `kata health --json` under `embeddings`:
+
+- `configured` — whether an endpoint is set;
+- `backlog` — how many issues are waiting to be (re-)embedded; trends to 0;
+- `last_success_at` — when the reconciler last completed a batch;
+- `last_error` — the most recent embedding failure, if any.
+
+## When the endpoint is unavailable
+
+If the embedding endpoint is unreachable for a query, behavior depends on the
+mode:
+
+- **auto** degrades to lexical results and labels the response so the fallback is
+  never silent: a `# mode=lexical degraded: …` note in human output, `degraded`
+  and `degraded_reason` fields in `--json`, and a `degraded=<reason>` field in
+  `--agent`.
+- **explicit `--hybrid` / `--semantic`** do not degrade — they return an error
+  (HTTP 503) so a caller that asked for semantic results knows it did not get
+  them. They return 400 when embeddings are not configured at all.
+
+A persistent endpoint problem shows up as a growing `backlog` and a `last_error`
+in health; the reconciler backs off and retries, and a misconfiguration (bad
+key, wrong model) is reported there rather than silently looping.
+
+## Changing the model
+
+Each stored vector records a fingerprint of the model, dimensionality, and text
+recipe it was produced under. If you switch `model`, kata notices the
+fingerprint changed and re-embeds every issue under the new model in the
+background; until a given issue is re-embedded it is carried by the lexical leg
+and never compared across models. If you keep the same model name but its weights
+changed underneath you (for example a re-pulled Ollama tag), bump
+`fingerprint_salt` to force the same re-embed.
+
+## Privacy and federation
+
+Configuring an endpoint sends issue titles and bodies to it on every embed —
+that is the consent boundary. For sensitive projects, prefer a local endpoint
+(such as Ollama on loopback) so issue text never leaves the host. The embedding
+API key is only ever sent to the configured `base_url` origin.
+
+Embeddings are local derived state and **do not federate**: each daemon embeds
+only what it stores, and no vectors are sent to or pulled from federated hubs.
+They are included in JSONL [backup/export](../operations/backup-restore.md) so a
+backup or schema upgrade does not force a full re-embed.
+
+## Scope and limits
+
+- Only issue **title and body** are embedded today; comments are searchable
+  lexically but a paraphrase that lives only in a comment will not vector-match.
+- The PostgreSQL backend stores the same embeddings, but accelerated vector
+  search there (pgvector) is not yet implemented; semantic search currently runs
+  on the SQLite backend.
+
+For the design rationale and internals, see the
+[semantic search design note](../design/semantic-search.md).

--- a/docs/reference/agent-output.md
+++ b/docs/reference/agent-output.md
@@ -129,6 +129,24 @@ Empty reads emit the header with `count=0` and no rows:
 OK search count=0 query="login race"
 ```
 
+`kata search` appends a `mode=` field to its header — `lexical`, `hybrid`, or
+`semantic` — reporting the strategy actually run. When the embedding endpoint is
+configured but could not serve a query, the search falls back to lexical and a
+`degraded=<reason>` field follows `mode=`; it is omitted when the query was not
+degraded. Result rows carry `matched=` listing the contributing sources (FTS
+column names), and a row gains `semantic` in that list when the vector leg
+matched it:
+
+```text
+OK search count=1 query="auth redirect duplicates" mode=hybrid
+- issue=abc4 score=0.0312 status=open matched=title,semantic title="Login callback double-submits on Safari"
+```
+
+`count`, `query`, and the existing row fields keep their names, positions, and
+meanings, so these additions are purely additive and `agent_format` stays `1`.
+A daemon without `[search.embeddings]` always reports `mode=lexical` and never
+sets `degraded=`, so its output is unchanged apart from the appended `mode=`.
+
 ### Events
 
 Non-tail reads use a header plus rows; tail mode is stream-safe and emits exactly

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -67,7 +67,27 @@ kata list [--status open|closed|all] [--limit N]
 kata list [--label LABEL] [--no-label LABEL] [--owner NAME] [--unowned]
 kata show <issue-ref>
 kata search <query> [--limit N] [--include-deleted]
+kata search <query> [--lexical | --hybrid | --semantic]
 ```
+
+By default `kata search` runs lexical (FTS) search. When the daemon has
+[semantic search](../guide/semantic-search.md) configured, search
+automatically fuses lexical and vector results. The mode flags are mutually
+exclusive and force a strategy:
+
+- `--lexical` — FTS only, exactly the default behavior on a daemon without
+  embeddings.
+- `--hybrid` — fuse the lexical and vector legs (reciprocal rank fusion).
+- `--semantic` — vector (embedding) results only.
+
+`--hybrid` and `--semantic` require `[search.embeddings]`; against a daemon
+without it they return an error rather than silently falling back. If the
+embedding endpoint is unreachable for a given query, only the default (auto)
+search falls back to lexical results and labels the response `degraded`;
+`--json` and `--agent` output carry the effective `mode` and the degraded
+reason so the downgrade is never silent. Explicit `--hybrid` and `--semantic`
+do not degrade: they return an error (HTTP 503) when the vector leg cannot run,
+just as they return 400 when embeddings are not configured at all.
 
 Edit:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -200,6 +200,50 @@ message-substance checks, and evidence checks. The TUI close path skips the
 message-substance and evidence checks because an interactive human confirms each
 close; the structural guards still apply.
 
+## Semantic search
+
+This section is the field reference; see the
+[Semantic search guide](../guide/semantic-search.md) for setup and behavior.
+
+Semantic (vector) search is opt-in. With no `[search.embeddings]` section,
+`kata search` behaves exactly as before — lexical FTS only — and the daemon
+makes no embedding network calls. Adding the section enables hybrid search: the
+daemon embeds each issue's title and body through an OpenAI-compatible
+`/embeddings` endpoint and fuses vector results with the lexical leg.
+
+```toml
+[search.embeddings]
+base_url = "http://localhost:11434/v1"  # any OpenAI-compatible /embeddings
+model    = "nomic-embed-text"
+# api_key      = "..."          # or api_key_env = "SOME_VAR"; mutually exclusive
+# fingerprint_salt = ""         # bump to force re-embed when model weights change
+# dims                          # expected vector dimensionality (default 768)
+# batch_size                    # inputs per request (default 64)
+# timeout_seconds               # per-request timeout (default 30)
+# trust_private_network = false # allow plaintext HTTP to literal non-public IPs
+```
+
+`base_url` and `model` are both required once the section exists; setting only
+one is a startup error rather than a silent disable. `api_key` and `api_key_env`
+are mutually exclusive. The embedding API key is attached only to requests whose
+origin matches `base_url`, following the same bearer-token trust ladder as
+daemon catalog tokens: HTTPS is always allowed, HTTP to loopback is allowed, and
+HTTP to other private IPs needs `trust_private_network = true`.
+
+Privacy: configuring an endpoint sends issue titles and bodies to it on every
+embed. That is the consent boundary — the operator who writes this section
+authorizes the data flow. For sensitive projects, prefer a local endpoint (for
+example Ollama on loopback) so issue text never leaves the host. Embeddings are
+local derived state and **do not federate**: each daemon embeds only what it
+stores, and no vectors are sent to or pulled from federated hubs.
+
+The daemon keeps the index fresh on its own: a background reconciler embeds new
+and edited issues within seconds, and `kata` reports its state under
+`embeddings` in the `/health` response (`configured`, `last_success_at`,
+`last_error`, and `backlog`). Search never blocks on embedding lag — an
+issue is findable lexically the instant it is created, and gains semantic recall
+once the reconciler catches up.
+
 ## Telemetry
 
 kata sends limited anonymous telemetry to PostHog when the daemon starts, and

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -38,7 +38,7 @@ The schema carries a version in its `info.version` field
 {
   "ok": true,
   "schema_version": 7,
-  "api_schema_version": "0.3.0",
+  "api_schema_version": "0.4.0",
   "version": "1.4.2",
   "uptime": "5m0s",
   "db_path": "/path/to/kata.db"
@@ -70,6 +70,7 @@ response of an older daemon that predates it. Treat an **absent or empty**
 
 | Version | Change |
 | --- | --- |
+| `0.4.0` | Added semantic-search response mode metadata and embeddings health fields. Search responses now always include the effective `mode`; configured daemons may also report sanitized embedding reconciler status from `/health`, including backlog and provider HTTP status without raw provider diagnostics. |
 | `0.3.0` | Moved the author identity rewrite endpoint from `POST /api/v1/projects/{project_id}/federation/rewrite-author` to `POST /api/v1/projects/{project_id}/actions/rewrite-author`. The operation is project current-state hygiene rather than a federation command, so generated clients should use the project action route. |
 | `0.2.0` | Removed `links[].project_id` from link projections. Links are now project-independent edges that may span projects, so a single `project_id` no longer describes a link. `links[].from` and `links[].to` (and the edit response's `changes` block peers) gain `project` and `qualified_id` — always populated. `IssueOut.parent_short_id` is replaced by `parent` (a `LinkPeer` object with all four fields). The cross-project link feature lands across this version. Event payloads are unchanged: a cross-project link mutation currently emits its event in the subject issue's project only (mirrored peer-project events are planned). |
 | `0.1.0` | Initial published contract. |

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -20,6 +20,7 @@ nav = [
   {"Guide" = [
     {"Concepts" = "guide/concepts.md"},
     {"Workspaces and projects" = "guide/workspaces-projects.md"},
+    {"Semantic search" = "guide/semantic-search.md"},
     {"Comparisons" = "guide/comparisons.md"},
     {"Migrating from Beads" = "guide/migrating-from-beads.md"},
   ]},
@@ -46,6 +47,7 @@ nav = [
     {"Data model and durability" = "design/data-model.md"},
     {"Federation technical notes" = "design/federation.md"},
     {"Hosted mode technical notes" = "design/hosted-mode.md"},
+    {"Semantic search technical notes" = "design/semantic-search.md"},
   ]},
   {"Development" = [
     {"Contributing" = "development/contributing.md"},

--- a/e2e/semantic_search_test.go
+++ b/e2e/semantic_search_test.go
@@ -1,0 +1,335 @@
+//go:build !windows
+
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2E_SemanticSearch_HybridAndDegraded boots a real `kata daemon`
+// subprocess configured with [search.embeddings] pointing at an in-test
+// deterministic embedder, and exercises the whole semantic-search path that
+// only exists in the daemon's process wiring (startEmbeddingReconciler: the
+// reconciler goroutine, the broadcaster nudge, the initial backfill, and the
+// /health backlog report):
+//
+//  1. create an issue → it is found lexically *immediately*, before any embed;
+//  2. a paraphrase that shares no salient tokens first misses lexically, then —
+//     once the reconciler embeds the issue — is found by polling the hybrid
+//     search until the vector leg surfaces it (mode=hybrid, "semantic" in
+//     matched_in). The wait is on this observable search result, not the
+//     /health backlog gauge;
+//  3. kill the embedder → an auto search returns results with mode=lexical and
+//     degraded=true, and an explicit --hybrid request is rejected 503.
+//
+// The deterministic embedder maps inputs to fixed unit vectors by topic, so a
+// paraphrase lands on the same axis as its source (cosine 1.0, clearing the
+// 0.3 floor) while an unrelated topic is orthogonal (cosine 0.0, filtered).
+// This is the e2e from the design note's testing plan ("create → instant
+// lexical hit; after reconcile → paraphrase found semantically; embedder
+// killed → degraded lexical") with neutral placeholder data.
+func TestE2E_SemanticSearch_HybridAndDegraded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e tests are slow")
+	}
+
+	embedder := newFixtureEmbedder(t)
+
+	dirs := newE2EDirs(t)
+	writeEmbeddingsConfig(t, dirs.home, embedder.URL())
+
+	bin := buildKataBinary(t)
+	env := dirs.env()
+
+	daemonStderr := startDaemon(t, bin, env)
+	url, client := connectDaemon(t, dirs, daemonStderr)
+
+	pid := initProjectE2E(t, client, url, dirs.repoDir)
+	pidStr := strconv.FormatInt(pid, 10)
+
+	// 1. Create an authentication-topic issue and assert it is searchable
+	// lexically the instant it is committed — before the reconciler has had a
+	// chance to embed anything. Lexical freshness is same-commit (FTS triggers
+	// fire in the writing transaction); semantic freshness is eventual.
+	short := createIssueWithBody(t, client, url, pid,
+		"Login callback double-submits on Safari",
+		"A redirect race condition fires the auth callback twice.")
+
+	lexical := searchHybrid(t, client, url, pidStr, "callback", "lexical")
+	require.Equal(t, "lexical", lexical.Mode)
+	require.True(t, containsIssue(lexical, short),
+		"freshly created issue must be found lexically before reconcile: %+v", lexical)
+
+	// 2. A paraphrase whose tokens appear nowhere in the issue's title or body
+	// ("credential loop on returning users" vs "Login callback double-submits
+	// on Safari" / "A redirect race condition fires the auth callback twice")
+	// can only surface via the vector leg. First confirm lexical search finds
+	// nothing, isolating the semantic contribution.
+	const paraphrase = "credential loop on returning users"
+	lexMiss := searchHybrid(t, client, url, pidStr, paraphrase, "lexical")
+	require.Falsef(t, containsIssue(lexMiss, short),
+		"paraphrase must NOT match lexically (isolates the semantic leg): %+v", lexMiss)
+
+	// 3. Poll the actual hybrid search until the reconciler has embedded the
+	// issue and the vector leg surfaces it. Asserting on the search behavior
+	// (rather than waiting for /health backlog==0) is immune to gauge timing:
+	// the reconciler's initial backlog==0 can read clean before the post-create
+	// wake has embedded anything, so a health wait can race ahead of the index.
+	hybrid := waitForSemanticHit(t, client, url, pidStr, paraphrase, short, daemonStderr)
+	require.Equal(t, "hybrid", hybrid.Mode, "explicit hybrid must run the vector leg: %+v", hybrid)
+	require.False(t, hybrid.Degraded, "embedder is up; hybrid must not be degraded: %+v", hybrid)
+	hit, ok := findHit(hybrid, short)
+	require.Truef(t, ok, "paraphrase must surface the issue via the vector leg: %+v", hybrid)
+	require.Containsf(t, hit.MatchedIn, "semantic",
+		"vector leg must be credited in matched_in: %+v", hit)
+
+	// 4. Kill the embedder. An auto/hybrid request can no longer embed the
+	// query, so the vector leg fails. auto degrades to labeled lexical; an
+	// explicit hybrid request is an honest 503 rather than a silent downgrade.
+	embedder.Close()
+
+	degraded := searchHybrid(t, client, url, pidStr, paraphrase, "")
+	require.Equal(t, "lexical", degraded.Mode,
+		"auto must fall back to lexical when the embedder is down: %+v", degraded)
+	require.True(t, degraded.Degraded,
+		"the fallback must be labeled degraded, not silent: %+v", degraded)
+	require.NotEmpty(t, degraded.DegradedReason, "degraded responses must carry a reason")
+
+	status, body := searchStatus(t, client, url, pidStr, paraphrase, "hybrid")
+	require.Equalf(t, http.StatusServiceUnavailable, status,
+		"explicit hybrid with a dead embedder must be 503, not a downgrade: %s", body)
+}
+
+// fixtureEmbedder is a deterministic OpenAI-compatible /embeddings endpoint
+// for the e2e. It returns one fixed unit vector per input, chosen by topic so
+// paraphrases of the same concept collide and unrelated text is orthogonal.
+type fixtureEmbedder struct {
+	srv    *httptest.Server
+	closed atomic.Bool
+}
+
+// newFixtureEmbedder starts the fake embedder on a loopback listener. Loopback
+// HTTP needs no trust_private_network and (because the fixture takes no API
+// key) never touches the bearer safety ladder.
+func newFixtureEmbedder(t *testing.T) *fixtureEmbedder {
+	t.Helper()
+	f := &fixtureEmbedder{}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var req struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		type vec struct {
+			Embedding []float32 `json:"embedding"`
+		}
+		out := struct {
+			Data []vec `json:"data"`
+		}{Data: make([]vec, len(req.Input))}
+		for i, in := range req.Input {
+			out.Data[i] = vec{Embedding: topicVector(in)}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	t.Cleanup(f.Close)
+	return f
+}
+
+func (f *fixtureEmbedder) URL() string { return f.srv.URL + "/v1" }
+
+// Close shuts the embedder down. Idempotent so both the explicit kill in the
+// test and the t.Cleanup registration are safe.
+func (f *fixtureEmbedder) Close() {
+	if f.closed.CompareAndSwap(false, true) {
+		f.srv.Close()
+	}
+}
+
+// topicVector maps text to a deterministic 2-D unit vector by topic. The
+// authentication concept (however phrased) lands on the x-axis; everything
+// else on the y-axis. Two phrasings of the same concept therefore have cosine
+// 1.0 (well above the 0.3 floor) while unrelated text is orthogonal.
+func topicVector(text string) []float32 {
+	lower := strings.ToLower(text)
+	for _, kw := range []string{"auth", "login", "callback", "redirect", "sign-in", "credential"} {
+		if strings.Contains(lower, kw) {
+			return []float32{1, 0}
+		}
+	}
+	return []float32{0, 1}
+}
+
+// writeEmbeddingsConfig drops a config.toml under home enabling semantic search
+// against baseURL. The daemon subprocess reads this from KATA_HOME at startup,
+// so the full startEmbeddingReconciler wiring runs.
+func writeEmbeddingsConfig(t *testing.T, home, baseURL string) {
+	t.Helper()
+	body := fmt.Sprintf(`[search.embeddings]
+base_url = %q
+model = "fixture-embed"
+dims = 2
+`, baseURL)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(body), 0o600))
+}
+
+// searchHitRow is the decoded subset of one /search result row.
+type searchHitRow struct {
+	Issue struct {
+		ShortID string `json:"short_id"`
+	} `json:"issue"`
+	MatchedIn []string `json:"matched_in"`
+}
+
+// searchResult is the decoded subset of the /search envelope the e2e asserts on.
+type searchResult struct {
+	Mode           string         `json:"mode"`
+	Degraded       bool           `json:"degraded"`
+	DegradedReason string         `json:"degraded_reason"`
+	Results        []searchHitRow `json:"results"`
+}
+
+// searchHybrid issues a search and requires a 200, returning the decoded
+// envelope. mode "" exercises the auto path.
+func searchHybrid(t *testing.T, client *http.Client, baseURL, pidStr, query, mode string) searchResult {
+	t.Helper()
+	status, body := searchStatus(t, client, baseURL, pidStr, query, mode)
+	require.Equalf(t, http.StatusOK, status, "search %q mode=%q: %s", query, mode, body)
+	var res searchResult
+	require.NoErrorf(t, json.Unmarshal(body, &res), "decode search response: %s", body)
+	return res
+}
+
+// searchStatus issues GET /search and returns the status code + raw body so
+// callers can assert non-200 paths (the explicit-hybrid 503).
+func searchStatus(t *testing.T, client *http.Client, baseURL, pidStr, query, mode string) (int, []byte) {
+	t.Helper()
+	q := url.Values{"q": {query}}
+	if mode != "" {
+		q.Set("mode", mode)
+	}
+	u := baseURL + "/api/v1/projects/" + pidStr + "/search?" + q.Encode()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req) //nolint:gosec // G704: test-only unix socket, fixed URL
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, raw
+}
+
+func findHit(res searchResult, shortID string) (searchHitRow, bool) {
+	for _, r := range res.Results {
+		if r.Issue.ShortID == shortID {
+			return r, true
+		}
+	}
+	return searchHitRow{}, false
+}
+
+func containsIssue(res searchResult, shortID string) bool {
+	_, ok := findHit(res, shortID)
+	return ok
+}
+
+// createIssueWithBody posts an issue with a title and body and returns its
+// short_id. The hooks harness's createIssueE2E hardcodes the title and returns
+// nothing; the semantic e2e needs distinct content and the resulting ref.
+func createIssueWithBody(t *testing.T, client *http.Client, baseURL string, pid int64, title, body string) string {
+	t.Helper()
+	u := baseURL + "/api/v1/projects/" + strconv.FormatInt(pid, 10) + "/issues"
+	payload, err := json.Marshal(map[string]any{"actor": "tester", "title": title, "body": body})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, u, bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req) //nolint:gosec // G704: test-only unix socket, fixed URL
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "create issue: %s", raw)
+	var parsed struct {
+		Issue struct {
+			ShortID string `json:"short_id"`
+		} `json:"issue"`
+	}
+	require.NoErrorf(t, json.Unmarshal(raw, &parsed), "create response: %s", raw)
+	require.NotEmptyf(t, parsed.Issue.ShortID, "short_id missing: %s", raw)
+	return parsed.Issue.ShortID
+}
+
+// waitForSemanticHit polls the real mode=hybrid search until the paraphrase
+// surfaces the target issue via the vector leg, then returns that response. It
+// asserts on observable search behavior rather than the /health backlog gauge,
+// so it is immune to gauge timing: the reconciler's pre-embed backlog can read
+// 0 before the post-create wake has embedded anything, which a backlog wait
+// would accept too early. The poll is deadline-bounded and, on timeout, reports
+// the last search response, the last /health snapshot, and daemon stderr so a
+// genuinely stuck embedder surfaces as a clear message instead of a bare
+// timeout.
+func waitForSemanticHit(t *testing.T, client *http.Client, baseURL, pidStr, query, shortID string, daemonStderr *safeBuffer) searchResult {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var lastSearch string
+	for time.Now().Before(deadline) {
+		status, body := searchStatus(t, client, baseURL, pidStr, query, "hybrid")
+		lastSearch = string(body)
+		if status == http.StatusOK {
+			var res searchResult
+			require.NoErrorf(t, json.Unmarshal(body, &res), "decode search response: %s", body)
+			if containsIssue(res, shortID) {
+				return res
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("paraphrase %q never surfaced issue %s via the vector leg.\nlast search: %s\nlast /health: %s\ndaemon stderr: %s",
+		query, shortID, lastSearch, embeddingHealth(t, client, baseURL), daemonStderr.String())
+	return searchResult{}
+}
+
+// embeddingHealth fetches /health and returns the embeddings block as a string
+// for diagnostics when a semantic poll times out. It is best-effort: any error
+// is folded into the returned string rather than failing the test, since it
+// only runs on an already-failing path.
+func embeddingHealth(t *testing.T, client *http.Client, baseURL string) string {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/api/v1/health", nil)
+	if err != nil {
+		return fmt.Sprintf("(health request error: %v)", err)
+	}
+	resp, err := client.Do(req) //nolint:gosec // G704: test-only unix socket, fixed URL
+	if err != nil {
+		return fmt.Sprintf("(health fetch error: %v)", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Sprintf("(health read error: %v)", err)
+	}
+	return string(raw)
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -47,10 +47,10 @@ type HealthResponse struct {
 // an absent block means semantic search is disabled. It mirrors
 // daemon.ReconcilerHealth.
 type EmbeddingsHealth struct {
-	Configured    bool       `json:"configured"`
-	LastSuccessAt *time.Time `json:"last_success_at,omitempty"`
-	LastError     string     `json:"last_error,omitempty"`
-	Backlog       int64      `json:"backlog"`
+	Configured      bool       `json:"configured"`
+	LastSuccessAt   *time.Time `json:"last_success_at,omitempty"`
+	LastErrorStatus int        `json:"last_error_status,omitempty"`
+	Backlog         int64      `json:"backlog"`
 }
 
 // InstanceResponse mirrors /api/v1/instance. Surfaces the local kata

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -31,14 +31,26 @@ type PingResponse struct {
 // than a parse failure. Current daemons always populate it.
 type HealthResponse struct {
 	Body struct {
-		OK               bool      `json:"ok"`
-		DBPath           string    `json:"db_path"`
-		SchemaVersion    int       `json:"schema_version"`
-		APISchemaVersion string    `json:"api_schema_version,omitempty"`
-		Version          string    `json:"version"`
-		Uptime           string    `json:"uptime"`
-		StartedAt        time.Time `json:"started_at"`
+		OK               bool              `json:"ok"`
+		DBPath           string            `json:"db_path"`
+		SchemaVersion    int               `json:"schema_version"`
+		APISchemaVersion string            `json:"api_schema_version,omitempty"`
+		Version          string            `json:"version"`
+		Uptime           string            `json:"uptime"`
+		StartedAt        time.Time         `json:"started_at"`
+		Embeddings       *EmbeddingsHealth `json:"embeddings,omitempty"`
 	}
+}
+
+// EmbeddingsHealth is the semantic-search reconciler's operator-visible state
+// on the wire. It is present only when the daemon has embeddings configured;
+// an absent block means semantic search is disabled. It mirrors
+// daemon.ReconcilerHealth.
+type EmbeddingsHealth struct {
+	Configured    bool       `json:"configured"`
+	LastSuccessAt *time.Time `json:"last_success_at,omitempty"`
+	LastError     string     `json:"last_error,omitempty"`
+	Backlog       int64      `json:"backlog"`
 }
 
 // InstanceResponse mirrors /api/v1/instance. Surfaces the local kata
@@ -990,27 +1002,44 @@ type DigestResponse struct {
 	}
 }
 
-// SearchRequest is GET /api/v1/projects/{id}/search?q=...&limit=...&include_deleted=...
+// SearchRequest is GET /api/v1/projects/{id}/search?q=...&limit=...&include_deleted=...&mode=...
+//
+// Mode selects the search strategy. "auto" (or empty) resolves to hybrid when
+// embeddings are configured, else lexical. "lexical" forces FTS-only.
+// "hybrid"/"semantic" require [search.embeddings]: an unconfigured daemon
+// returns 400, and a vector-leg failure returns 503 rather than silently
+// degrading.
 type SearchRequest struct {
 	ProjectID      int64  `path:"project_id" required:"true"`
 	Query          string `query:"q" required:"true"`
 	Limit          int    `query:"limit,omitempty"`
 	IncludeDeleted bool   `query:"include_deleted,omitempty"`
+	Mode           string `query:"mode,omitempty" enum:"auto,lexical,hybrid,semantic"`
 }
 
-// SearchHit is one row in SearchResponse. Score is the negated raw BM25
-// (higher = better match), MatchedIn is the FTS columns that contributed.
+// SearchHit is one row in SearchResponse. Score is mode-scoped — negated raw
+// BM25 (lexical, higher = better match), the RRF fusion score (hybrid), or
+// cosine similarity (semantic). MatchedIn lists the contributing sources: FTS
+// column names for the lexical leg plus "semantic" when the vector leg matched.
 type SearchHit struct {
 	Issue     db.Issue `json:"issue"`
 	Score     float64  `json:"score"`
 	MatchedIn []string `json:"matched_in"`
 }
 
-// SearchResponse mirrors spec §4.10.
+// SearchResponse mirrors spec §4.10. Mode is the effective mode actually run
+// (always present). Degraded is true only when an auto/hybrid request fell back
+// to lexical because the vector leg could not run; DegradedReason carries the
+// underlying cause. Both degraded fields are omitted on the baseline path so an
+// unconfigured daemon's response is byte-identical to its pre-semantic shape
+// apart from the always-present mode echo.
 type SearchResponse struct {
 	Body struct {
-		Query   string      `json:"query"`
-		Results []SearchHit `json:"results"`
+		Query          string      `json:"query"`
+		Mode           string      `json:"mode"`
+		Degraded       bool        `json:"degraded,omitempty"`
+		DegradedReason string      `json:"degraded_reason,omitempty"`
+		Results        []SearchHit `json:"results"`
 	}
 }
 

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -41,6 +41,66 @@ type DaemonConfig struct {
 	// Storage carries DB-selection settings. Today only `dsn` is honored;
 	// see config.KataDSN for the full precedence (env > file > default).
 	Storage StorageConfig `toml:"storage"`
+	// Search carries opt-in semantic-search settings. An empty
+	// [search.embeddings] section leaves kata on lexical-only FTS.
+	Search SearchConfig `toml:"search"`
+}
+
+// SearchConfig is the [search] block of <KATA_HOME>/config.toml. Today it only
+// nests [search.embeddings]; lexical FTS needs no configuration.
+type SearchConfig struct {
+	Embeddings EmbeddingsConfig `toml:"embeddings"`
+}
+
+// EmbeddingsConfig is the [search.embeddings] block. It is opt-in: when BaseURL
+// and Model are both empty kata stays on lexical-only search. BaseURL and Model
+// must be set together (a partial config is rejected at load), and APIKey is
+// mutually exclusive with APIKeyEnv, mirroring the [[daemon]] token pattern.
+type EmbeddingsConfig struct {
+	// BaseURL is the OpenAI-compatible endpoint base, e.g.
+	// "http://localhost:11434/v1". The client appends "/embeddings".
+	BaseURL string `toml:"base_url"`
+	// Model is the embedding model name sent in each request.
+	Model string `toml:"model"`
+	// APIKey is the inline bearer token, mutually exclusive with APIKeyEnv.
+	APIKey string `toml:"api_key"`
+	// APIKeyEnv names an environment variable holding the bearer token, so
+	// the secret stays out of the config file.
+	APIKeyEnv string `toml:"api_key_env"`
+	// FingerprintSalt is the operator's lever for "same model name,
+	// different weights"; changing it invalidates every stored vector.
+	FingerprintSalt string `toml:"fingerprint_salt"`
+	// Dims is the expected vector dimensionality. 0 means use the client
+	// default. Negative values are rejected.
+	Dims int `toml:"dims"`
+	// BatchSize caps inputs per embedding request. 0 means the client
+	// default; negative values are rejected.
+	BatchSize int `toml:"batch_size"`
+	// TimeoutSeconds is the per-request HTTP timeout. 0 means the client
+	// default; negative values are rejected.
+	TimeoutSeconds int `toml:"timeout_seconds"`
+	// TrustPrivateNetwork allows a plaintext bearer token to a private-network
+	// endpoint, mirroring [auth].trust_private_network.
+	TrustPrivateNetwork bool `toml:"trust_private_network"`
+}
+
+// Enabled reports whether semantic search is configured. Both base_url and
+// model are required; validateEmbeddings rejects a partial config so Enabled
+// never sees a half-set section.
+func (e EmbeddingsConfig) Enabled() bool {
+	return strings.TrimSpace(e.BaseURL) != "" && strings.TrimSpace(e.Model) != ""
+}
+
+// ResolvedAPIKey returns the literal api_key, or the value of the environment
+// variable named by api_key_env. Returns "" when neither is set.
+func (e EmbeddingsConfig) ResolvedAPIKey() string {
+	if e.APIKey != "" {
+		return e.APIKey
+	}
+	if e.APIKeyEnv != "" {
+		return os.Getenv(strings.TrimSpace(e.APIKeyEnv))
+	}
+	return ""
 }
 
 // StorageConfig is the [storage] block of <KATA_HOME>/config.toml. An empty
@@ -172,6 +232,7 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 		cfg.Auth.Proxy.TrustedActorHeader = strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
 		cfg.Storage.DSN = strings.TrimSpace(cfg.Storage.DSN)
 		cfg.Close.Throttle.Window = strings.TrimSpace(cfg.Close.Throttle.Window)
+		trimSearchEmbeddings(&cfg)
 		trimDaemonCatalog(&cfg)
 	case errors.Is(err, os.ErrNotExist):
 		// Absent file: fall through with zero-value cfg. Env merge and
@@ -185,6 +246,9 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 		return nil, err
 	}
 	if _, err := cfg.Close.Throttle.ThrottleWindow(); err != nil {
+		return nil, err
+	}
+	if err := validateEmbeddings(cfg.Search.Embeddings); err != nil {
 		return nil, err
 	}
 	if err := normalizeDaemonCatalog(&cfg); err != nil {
@@ -228,6 +292,15 @@ func ReadAuthConfig() (AuthConfig, error) {
 		return AuthConfig{}, err
 	}
 	return cfg.Auth, nil
+}
+
+func trimSearchEmbeddings(cfg *DaemonConfig) {
+	e := &cfg.Search.Embeddings
+	e.BaseURL = strings.TrimSpace(e.BaseURL)
+	e.Model = strings.TrimSpace(e.Model)
+	e.APIKey = strings.TrimSpace(e.APIKey)
+	e.APIKeyEnv = strings.TrimSpace(e.APIKeyEnv)
+	e.FingerprintSalt = strings.TrimSpace(e.FingerprintSalt)
 }
 
 func trimDaemonCatalog(cfg *DaemonConfig) {
@@ -278,6 +351,29 @@ func validateAuthProxy(p ProxyConfig) error {
 		return errors.New(
 			"auth.proxy: trusted_actor_header is set but trusted_proxy_listeners is empty. " +
 				"Set both to enable proxy attribution, or unset the header to disable")
+	}
+	return nil
+}
+
+// validateEmbeddings rejects partial or contradictory [search.embeddings]
+// config. base_url and model must both be set or both omitted (a half-set
+// section is an operator mistake, not a usable default). api_key and
+// api_key_env are mutually exclusive, mirroring the [[daemon]] token rule.
+// The numeric knobs are sizes/durations, so negatives are invalid.
+func validateEmbeddings(e EmbeddingsConfig) error {
+	hasBase := strings.TrimSpace(e.BaseURL) != ""
+	hasModel := strings.TrimSpace(e.Model) != ""
+	if hasBase != hasModel {
+		return errors.New(
+			"search.embeddings: base_url and model must both be set or both omitted")
+	}
+	if e.APIKey != "" && e.APIKeyEnv != "" {
+		return errors.New(
+			"search.embeddings: api_key and api_key_env are mutually exclusive")
+	}
+	if e.Dims < 0 || e.BatchSize < 0 || e.TimeoutSeconds < 0 {
+		return errors.New(
+			"search.embeddings: dims, batch_size, and timeout_seconds must be non-negative")
 	}
 	return nil
 }

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -578,6 +578,109 @@ func TestReadDaemonConfig_StorageRejectsUnknownKey(t *testing.T) {
 	assert.Contains(t, err.Error(), "storage.foo")
 }
 
+func TestReadDaemonConfig_SearchEmbeddingsValid(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[search.embeddings]
+base_url = "http://localhost:11434/v1"
+model = "nomic-embed-text"
+`), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.True(t, cfg.Search.Embeddings.Enabled(),
+		"base_url + model present must enable embeddings")
+	assert.Equal(t, "http://localhost:11434/v1", cfg.Search.Embeddings.BaseURL)
+	assert.Equal(t, "nomic-embed-text", cfg.Search.Embeddings.Model)
+}
+
+func TestReadDaemonConfig_SearchEmbeddingsDisabledWhenAbsent(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.False(t, cfg.Search.Embeddings.Enabled(),
+		"absent [search.embeddings] must leave semantic search disabled")
+}
+
+func TestReadDaemonConfig_SearchEmbeddingsRejectsBaseURLWithoutModel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[search.embeddings]
+base_url = "http://localhost:11434/v1"
+`), 0o600))
+
+	_, err := config.ReadDaemonConfig()
+	require.Error(t, err, "base_url without model is a partial config and must reject")
+	assert.Contains(t, err.Error(), "base_url")
+	assert.Contains(t, err.Error(), "model")
+}
+
+func TestReadDaemonConfig_SearchEmbeddingsRejectsModelWithoutBaseURL(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[search.embeddings]
+model = "nomic-embed-text"
+`), 0o600))
+
+	_, err := config.ReadDaemonConfig()
+	require.Error(t, err, "model without base_url is a partial config and must reject")
+	assert.Contains(t, err.Error(), "base_url")
+	assert.Contains(t, err.Error(), "model")
+}
+
+func TestReadDaemonConfig_SearchEmbeddingsRejectsAPIKeyAndAPIKeyEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[search.embeddings]
+base_url = "http://localhost:11434/v1"
+model = "m"
+api_key = "x"
+api_key_env = "Y"
+`), 0o600))
+
+	_, err := config.ReadDaemonConfig()
+	require.Error(t, err, "api_key and api_key_env are mutually exclusive")
+	assert.Contains(t, err.Error(), "api_key")
+	assert.Contains(t, err.Error(), "api_key_env")
+}
+
+func TestReadDaemonConfig_SearchEmbeddingsRejectsNegativeDims(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[search.embeddings]
+base_url = "http://localhost:11434/v1"
+model = "m"
+dims = -1
+`), 0o600))
+
+	_, err := config.ReadDaemonConfig()
+	require.Error(t, err, "negative dims must reject")
+	assert.Contains(t, err.Error(), "dims")
+}
+
+func TestReadDaemonConfig_SearchEmbeddingsResolvedAPIKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_EMBED_KEY", "secret-from-env")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[search.embeddings]
+base_url = "http://localhost:11434/v1"
+model = "m"
+api_key_env = "KATA_EMBED_KEY"
+`), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Search.Embeddings.APIKey)
+	assert.Equal(t, "secret-from-env", cfg.Search.Embeddings.ResolvedAPIKey(),
+		"api_key_env must resolve from the environment")
+}
+
 func TestApplyDaemonConfigEnv_AuthProxyListeners(t *testing.T) {
 	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -82,7 +82,7 @@ func requireBearer(p authPolicy, tokenStores ...db.Storage) func(http.Handler) h
 						"mutations and event stream require authentication; daemon is in --insecure-readonly mode")
 					return
 				}
-				next.ServeHTTP(w, r)
+				next.ServeHTTP(w, r.WithContext(withInsecureReadonlyRequest(r.Context())))
 				return
 			}
 			got := r.Header.Get(authHeader)

--- a/internal/daemon/handlers_health.go
+++ b/internal/daemon/handlers_health.go
@@ -46,6 +46,15 @@ func registerHealthHandlers(humaAPI huma.API, cfg ServerConfig) {
 		out.Body.Version = version.Version
 		out.Body.StartedAt = cfg.StartedAt
 		out.Body.Uptime = time.Since(cfg.StartedAt).Round(time.Second).String()
+		if cfg.ReconcilerHealth != nil {
+			h := cfg.ReconcilerHealth()
+			out.Body.Embeddings = &api.EmbeddingsHealth{
+				Configured:    h.Configured,
+				LastSuccessAt: h.LastSuccessAt,
+				LastError:     h.LastError,
+				Backlog:       h.Backlog,
+			}
+		}
 		return out, nil
 	})
 }

--- a/internal/daemon/handlers_health.go
+++ b/internal/daemon/handlers_health.go
@@ -49,10 +49,10 @@ func registerHealthHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if cfg.ReconcilerHealth != nil {
 			h := cfg.ReconcilerHealth()
 			out.Body.Embeddings = &api.EmbeddingsHealth{
-				Configured:    h.Configured,
-				LastSuccessAt: h.LastSuccessAt,
-				LastError:     h.LastError,
-				Backlog:       h.Backlog,
+				Configured:      h.Configured,
+				LastSuccessAt:   h.LastSuccessAt,
+				LastErrorStatus: h.LastErrorStatus,
+				Backlog:         h.Backlog,
 			}
 		}
 		return out, nil

--- a/internal/daemon/handlers_health_test.go
+++ b/internal/daemon/handlers_health_test.go
@@ -3,9 +3,12 @@ package daemon_test
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/kata/internal/api"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
 )
@@ -27,4 +30,42 @@ func TestHealth_ReportsSchemaAndUptime(t *testing.T) {
 	assert.NotEmpty(t, body.APISchemaVersion)
 	assert.NotEmpty(t, body.Uptime)
 	assert.NotEmpty(t, body.DBPath)
+}
+
+func TestHealth_OmitsEmbeddingsWhenUnconfigured(t *testing.T) {
+	ts, _ := startDefaultTestServer(t)
+
+	var body struct {
+		Embeddings *api.EmbeddingsHealth `json:"embeddings"`
+	}
+	getAndUnmarshal(t, ts, "/api/v1/health", http.StatusOK, &body)
+	assert.Nil(t, body.Embeddings, "embeddings health must be absent when no ReconcilerHealth is wired")
+}
+
+func TestHealth_IncludesEmbeddingsWhenConfigured(t *testing.T) {
+	d := openTestDB(t)
+	last := time.Date(2026, 6, 22, 10, 0, 0, 0, time.UTC)
+	ts := startTestServer(t, daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+		ReconcilerHealth: func() daemon.ReconcilerHealth {
+			return daemon.ReconcilerHealth{
+				Configured:    true,
+				LastSuccessAt: &last,
+				LastError:     "boom",
+				Backlog:       5,
+			}
+		},
+	})
+
+	var body struct {
+		Embeddings *api.EmbeddingsHealth `json:"embeddings"`
+	}
+	getAndUnmarshal(t, ts, "/api/v1/health", http.StatusOK, &body)
+	require.NotNil(t, body.Embeddings, "embeddings health must surface when ReconcilerHealth is wired")
+	assert.True(t, body.Embeddings.Configured)
+	assert.Equal(t, int64(5), body.Embeddings.Backlog)
+	assert.Equal(t, "boom", body.Embeddings.LastError)
+	require.NotNil(t, body.Embeddings.LastSuccessAt)
+	assert.True(t, body.Embeddings.LastSuccessAt.Equal(last))
 }

--- a/internal/daemon/handlers_health_test.go
+++ b/internal/daemon/handlers_health_test.go
@@ -1,6 +1,7 @@
 package daemon_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -50,10 +51,11 @@ func TestHealth_IncludesEmbeddingsWhenConfigured(t *testing.T) {
 		StartedAt: d.now,
 		ReconcilerHealth: func() daemon.ReconcilerHealth {
 			return daemon.ReconcilerHealth{
-				Configured:    true,
-				LastSuccessAt: &last,
-				LastError:     "boom",
-				Backlog:       5,
+				Configured:      true,
+				LastSuccessAt:   &last,
+				LastError:       "provider reflected issue body: secret project content",
+				LastErrorStatus: 400,
+				Backlog:         5,
 			}
 		},
 	})
@@ -65,7 +67,35 @@ func TestHealth_IncludesEmbeddingsWhenConfigured(t *testing.T) {
 	require.NotNil(t, body.Embeddings, "embeddings health must surface when ReconcilerHealth is wired")
 	assert.True(t, body.Embeddings.Configured)
 	assert.Equal(t, int64(5), body.Embeddings.Backlog)
-	assert.Equal(t, "boom", body.Embeddings.LastError)
+	assert.Equal(t, 400, body.Embeddings.LastErrorStatus)
 	require.NotNil(t, body.Embeddings.LastSuccessAt)
 	assert.True(t, body.Embeddings.LastSuccessAt.Equal(last))
+}
+
+func TestHealth_DoesNotExposeEmbeddingProviderDiagnostics(t *testing.T) {
+	d := openTestDB(t)
+	ts := startTestServer(t, daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+		ReconcilerHealth: func() daemon.ReconcilerHealth {
+			return daemon.ReconcilerHealth{
+				Configured:      true,
+				LastError:       "embedding endpoint returned 400: reflected issue title",
+				LastErrorStatus: 400,
+				Backlog:         1,
+			}
+		},
+	})
+
+	resp, bs := doReq(t, ts, http.MethodGet, "/api/v1/health", nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
+	assert.NotContains(t, string(bs), "reflected issue title")
+
+	var body struct {
+		Embeddings map[string]json.RawMessage `json:"embeddings"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &body))
+	_, hasLastError := body.Embeddings["last_error"]
+	assert.False(t, hasLastError, "unauthenticated health must omit raw embedding provider diagnostics")
+	assert.Contains(t, body.Embeddings, "last_error_status")
 }

--- a/internal/daemon/handlers_search.go
+++ b/internal/daemon/handlers_search.go
@@ -31,9 +31,19 @@ func registerSearchHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if limit <= 0 {
 			limit = 20
 		}
+		mode := in.Mode
+		if insecureReadonlyRequest(ctx) && cfg.Embedder != nil {
+			switch mode {
+			case "hybrid", "semantic":
+				return nil, api.NewError(401, "auth_required",
+					"semantic search requires authentication; daemon is in --insecure-readonly mode", "", nil)
+			case "", "auto":
+				mode = "lexical"
+			}
+		}
 		res, err := hybridSearch(ctx, cfg.DB, cfg.Embedder, hybridParams{
 			ProjectID: in.ProjectID, Query: in.Query, Limit: limit,
-			IncludeDeleted: in.IncludeDeleted, Requested: in.Mode,
+			IncludeDeleted: in.IncludeDeleted, Requested: mode,
 		})
 		if err != nil {
 			var me *modeError

--- a/internal/daemon/handlers_search.go
+++ b/internal/daemon/handlers_search.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -9,8 +10,10 @@ import (
 	"go.kenn.io/kata/internal/api"
 )
 
-// registerSearchHandlers installs GET /api/v1/projects/{id}/search. Returns
-// the spec §4.10 envelope: query echo + ranked results with score + matched_in.
+// registerSearchHandlers installs GET /api/v1/projects/{id}/search. Returns the
+// spec §4.10 envelope: query echo, effective mode, optional degraded fields,
+// and ranked results with mode-scoped score + matched_in. The lexical and
+// vector legs run concurrently; see hybridSearch.
 func registerSearchHandlers(humaAPI huma.API, cfg ServerConfig) {
 	huma.Register(humaAPI, huma.Operation{
 		OperationID: "searchIssues",
@@ -28,21 +31,34 @@ func registerSearchHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if limit <= 0 {
 			limit = 20
 		}
-		candidates, err := cfg.DB.SearchFTS(ctx, in.ProjectID, in.Query, limit, in.IncludeDeleted)
+		res, err := hybridSearch(ctx, cfg.DB, cfg.Embedder, hybridParams{
+			ProjectID: in.ProjectID, Query: in.Query, Limit: limit,
+			IncludeDeleted: in.IncludeDeleted, Requested: in.Mode,
+		})
 		if err != nil {
+			var me *modeError
+			if errors.As(err, &me) {
+				kind := "validation"
+				if me.Status() == 503 {
+					kind = "unavailable"
+				}
+				return nil, api.NewError(me.Status(), kind, me.Error(), "", nil)
+			}
 			return nil, api.NewError(500, "internal", err.Error(), "", nil)
 		}
-		hits := make([]api.SearchHit, 0, len(candidates))
-		for _, c := range candidates {
-			hits = append(hits, api.SearchHit{
+		out := &api.SearchResponse{}
+		out.Body.Query = in.Query
+		out.Body.Mode = string(res.Mode)
+		out.Body.Degraded = res.Degraded
+		out.Body.DegradedReason = res.DegradedReason
+		out.Body.Results = make([]api.SearchHit, 0, len(res.Hits))
+		for _, c := range res.Hits {
+			out.Body.Results = append(out.Body.Results, api.SearchHit{
 				Issue:     c.Issue,
 				Score:     c.Score,
 				MatchedIn: c.MatchedIn,
 			})
 		}
-		out := &api.SearchResponse{}
-		out.Body.Query = in.Query
-		out.Body.Results = hits
 		return out, nil
 	})
 }

--- a/internal/daemon/handlers_search_test.go
+++ b/internal/daemon/handlers_search_test.go
@@ -1,11 +1,19 @@
 package daemon_test
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/embedding"
 	"go.kenn.io/kata/internal/testenv"
 )
 
@@ -23,6 +31,60 @@ func TestSearchEndpoint_ReturnsHitsWithScores(t *testing.T) {
 	assert.Contains(t, body, `"matched_in"`)
 	assert.NotContains(t, body, `"title":"unrelated"`,
 		"unrelated issue should not appear in results")
+}
+
+func TestSearchEndpoint_InsecureReadonlyUnauthenticatedAutoSearchStaysLexical(t *testing.T) {
+	var embeddingCalls atomic.Int32
+	embedderSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		embeddingCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{"embedding": []float32{1, 0}}}})
+	}))
+	defer embedderSrv.Close()
+	emb, err := embedding.New(embedding.Config{BaseURL: embedderSrv.URL, Model: "m", Dims: 2})
+	require.NoError(t, err)
+
+	env := testenv.New(t, testenv.WithInsecureReadonly(), func(cfg *daemon.ServerConfig) {
+		cfg.Embedder = emb
+	})
+	ctx := context.Background()
+	project, err := env.DB.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "index credential rotation",
+		Body:      "keep provider calls behind daemon credentials",
+		Author:    "agent",
+	})
+	require.NoError(t, err)
+
+	resp, bs := envGetRaw(t, env, projectPath(project.ID)+"/search?q="+url.QueryEscape("credential rotation"))
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(bs))
+	assert.Contains(t, string(bs), `"mode":"lexical"`)
+	assert.Equal(t, int32(0), embeddingCalls.Load(), "unauthenticated read-only search must not call embedding provider")
+}
+
+func TestSearchEndpoint_InsecureReadonlyUnauthenticatedExplicitVectorModesRequireAuth(t *testing.T) {
+	var embeddingCalls atomic.Int32
+	embedderSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		embeddingCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{"embedding": []float32{1, 0}}}})
+	}))
+	defer embedderSrv.Close()
+	emb, err := embedding.New(embedding.Config{BaseURL: embedderSrv.URL, Model: "m", Dims: 2})
+	require.NoError(t, err)
+
+	env := testenv.New(t, testenv.WithInsecureReadonly(), func(cfg *daemon.ServerConfig) {
+		cfg.Embedder = emb
+	})
+	ctx := context.Background()
+	project, err := env.DB.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+
+	for _, mode := range []string{"semantic", "hybrid"} {
+		resp, bs := envGetRaw(t, env, projectPath(project.ID)+"/search?q=anything&mode="+mode)
+		assertAPIError(t, resp.StatusCode, bs, http.StatusUnauthorized, "auth_required")
+	}
+	assert.Equal(t, int32(0), embeddingCalls.Load(), "rejected semantic search must not call embedding provider")
 }
 
 func TestSearchEndpoint_EmptyQueryIsValidationError(t *testing.T) {

--- a/internal/daemon/hybrid_search.go
+++ b/internal/daemon/hybrid_search.go
@@ -1,0 +1,151 @@
+package daemon
+
+import (
+	"context"
+	"time"
+
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/embedding"
+)
+
+type hybridParams struct {
+	ProjectID      int64
+	Query          string
+	Limit          int
+	IncludeDeleted bool
+	Requested      string // raw mode param
+}
+
+type hybridResult struct {
+	Mode           searchMode
+	Degraded       bool
+	DegradedReason string
+	Hits           []db.SearchCandidate
+}
+
+// queryEmbedTimeout bounds the single query-embed call so a hung embedder can
+// never stall the request past a few seconds; the lexical leg, running
+// concurrently, is unaffected.
+const queryEmbedTimeout = 3 * time.Second
+
+// fetchFloor and fetchCap bound the per-leg candidate depth. Each leg fetches
+// max(limit*3, fetchFloor) rows (capped at fetchCap) so RRF has enough overlap
+// to fuse before the final truncation to limit.
+const (
+	fetchFloor = 50
+	fetchCap   = 200
+)
+
+// cosineFloor drops weak vector hits so they do not pad results. Vectors are
+// L2-normalized, so the dot product is cosine similarity in [-1, 1].
+const cosineFloor = 0.3
+
+// hybridSearch runs the lexical and (when applicable) vector legs and merges
+// them. The lexical leg never waits on the embedder. A vector-leg failure in
+// an auto/hybrid request degrades to lexical with a reason; an explicit
+// hybrid/semantic request that cannot run returns a *modeError for the handler
+// to map to 400 (unconfigured) or 503 (leg failure).
+func hybridSearch(ctx context.Context, store db.Storage, emb *embedding.Client, p hybridParams) (hybridResult, error) {
+	configured := emb != nil
+	mode, err := resolveMode(p.Requested, configured)
+	if err != nil {
+		return hybridResult{}, &modeError{status: 400, msg: err.Error()}
+	}
+	// strict = the caller explicitly asked for a leg that must run; a failure
+	// is 503, not a silent degrade. auto-resolved hybrid is not strict.
+	strict := p.Requested == "hybrid" || p.Requested == "semantic"
+
+	fetch := p.Limit * 3
+	if fetch < fetchFloor {
+		fetch = fetchFloor
+	}
+	if fetch > fetchCap {
+		fetch = fetchCap
+	}
+
+	// Lexical leg (skip for explicit semantic). It runs in a goroutine so the
+	// vector leg's embed round-trip never blocks FTS.
+	var lexical []db.SearchCandidate
+	lexErrCh := make(chan error, 1)
+	if mode != modeSemantic {
+		go func() {
+			c, e := store.SearchFTS(ctx, p.ProjectID, p.Query, fetch, p.IncludeDeleted)
+			lexical = c
+			lexErrCh <- e
+		}()
+	} else {
+		lexErrCh <- nil
+	}
+
+	// Vector leg.
+	var vector []db.SearchCandidate
+	var vecErr error
+	if mode == modeHybrid || mode == modeSemantic {
+		vector, vecErr = runVectorLeg(ctx, store, emb, p, fetch)
+	}
+
+	if e := <-lexErrCh; e != nil {
+		return hybridResult{}, &modeError{status: 500, msg: e.Error()}
+	}
+
+	// Handle vector-leg failure. Explicit hybrid/semantic → 503; auto → degrade
+	// to lexical, labeled (keeps "silent-but-labeled" honest).
+	if vecErr != nil {
+		if strict {
+			return hybridResult{}, &modeError{status: 503, msg: vecErr.Error()}
+		}
+		return hybridResult{
+			Mode: modeLexical, Degraded: true, DegradedReason: vecErr.Error(),
+			Hits: truncate(lexical, p.Limit),
+		}, nil
+	}
+
+	switch mode {
+	case modeLexical:
+		return hybridResult{Mode: modeLexical, Hits: truncate(lexical, p.Limit)}, nil
+	case modeSemantic:
+		return hybridResult{Mode: modeSemantic, Hits: truncate(vector, p.Limit)}, nil
+	default: // hybrid
+		return hybridResult{Mode: modeHybrid, Hits: mergeRRF(lexical, vector, p.Limit)}, nil
+	}
+}
+
+func runVectorLeg(ctx context.Context, store db.Storage, emb *embedding.Client, p hybridParams, fetch int) ([]db.SearchCandidate, error) {
+	ectx, cancel := context.WithTimeout(ctx, queryEmbedTimeout)
+	defer cancel()
+	// Embed only the query text under the recipe cap; the response echoes the
+	// caller's original query unchanged.
+	vecs, err := emb.Embed(ectx, []string{embedding.EmbedText(p.Query, "")})
+	if err != nil {
+		return nil, err
+	}
+	hits, err := store.SearchVector(ctx, p.ProjectID, vecs[0], emb.Fingerprint(), fetch, p.IncludeDeleted)
+	if err != nil {
+		return nil, err
+	}
+	// Drop weak vectors so they do not pad results. Filter in place: hits is a
+	// fresh slice owned by this call.
+	out := hits[:0]
+	for _, h := range hits {
+		if h.Score >= cosineFloor {
+			out = append(out, h)
+		}
+	}
+	return out, nil
+}
+
+func truncate(c []db.SearchCandidate, limit int) []db.SearchCandidate {
+	if limit > 0 && len(c) > limit {
+		return c[:limit]
+	}
+	return c
+}
+
+// modeError carries an HTTP status for the handler to translate.
+type modeError struct {
+	status int
+	msg    string
+}
+
+func (e *modeError) Error() string { return e.msg }
+func (e *modeError) Status() int   { return e.status }

--- a/internal/daemon/hybrid_search_test.go
+++ b/internal/daemon/hybrid_search_test.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/embedding"
+)
+
+func TestHybridSearchLexicalWhenUnconfigured(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "login race", Body: "x", Author: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := hybridSearch(ctx, store, nil /*embedder*/, hybridParams{
+		ProjectID: proj.ID, Query: "login", Limit: 10, Requested: "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Mode != modeLexical || res.Degraded {
+		t.Fatalf("unconfigured should be lexical, not degraded: %#v", res)
+	}
+	if len(res.Hits) != 1 {
+		t.Fatalf("expected the lexical hit to survive, got %d", len(res.Hits))
+	}
+}
+
+func TestHybridSearchExplicitHybridUnconfiguredErrors(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	_, err := hybridSearch(ctx, store, nil, hybridParams{ProjectID: proj.ID, Query: "x", Limit: 10, Requested: "hybrid"})
+	if err == nil {
+		t.Fatal("expected 400-class error for explicit hybrid without embeddings")
+	}
+	var me *modeError
+	if !errors.As(err, &me) {
+		t.Fatalf("want *modeError, got %T: %v", err, err)
+	}
+	if me.Status() != 400 {
+		t.Fatalf("unconfigured explicit mode should be 400, got %d", me.Status())
+	}
+}
+
+// failingEmbedClient builds a real *embedding.Client pointed at a server that
+// always errors, so the vector leg fails the way an unreachable endpoint would.
+func failingEmbedClient(t *testing.T, status int) *embedding.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"error":"unavailable"}`))
+	}))
+	t.Cleanup(srv.Close)
+	c, err := embedding.New(embedding.Config{BaseURL: srv.URL, Model: "m", Dims: 2})
+	if err != nil {
+		t.Fatalf("new embedding client: %v", err)
+	}
+	return c
+}
+
+func TestHybridSearchAutoDegradesOnVectorFailure(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "login race", Body: "x", Author: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := hybridSearch(ctx, store, failingEmbedClient(t, http.StatusServiceUnavailable), hybridParams{
+		ProjectID: proj.ID, Query: "login", Limit: 10, Requested: "auto",
+	})
+	if err != nil {
+		t.Fatalf("auto must degrade, not error: %v", err)
+	}
+	if res.Mode != modeLexical || !res.Degraded {
+		t.Fatalf("auto with a failing embedder should degrade to labeled lexical: %#v", res)
+	}
+	if res.DegradedReason == "" {
+		t.Fatal("degraded result must carry a reason")
+	}
+	if len(res.Hits) != 1 {
+		t.Fatalf("degraded lexical must still return the FTS hit, got %d", len(res.Hits))
+	}
+}
+
+func TestHybridSearchExplicitHybridLegFailureReturns503(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "login race", Body: "x", Author: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := hybridSearch(ctx, store, failingEmbedClient(t, http.StatusServiceUnavailable), hybridParams{
+		ProjectID: proj.ID, Query: "login", Limit: 10, Requested: "hybrid",
+	})
+	if err == nil {
+		t.Fatal("explicit hybrid with a failing vector leg must error, not degrade")
+	}
+	var me *modeError
+	if !errors.As(err, &me) {
+		t.Fatalf("want *modeError, got %T: %v", err, err)
+	}
+	if me.Status() != 503 {
+		t.Fatalf("leg failure under an explicit mode should be 503, got %d", me.Status())
+	}
+}

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -39,6 +39,7 @@ type Principal struct {
 }
 
 type principalContextKey struct{}
+type insecureReadonlyContextKey struct{}
 
 // WithPrincipal attaches an authenticated request principal to ctx.
 func WithPrincipal(ctx context.Context, p Principal) context.Context {
@@ -49,6 +50,15 @@ func WithPrincipal(ctx context.Context, p Principal) context.Context {
 func PrincipalFromContext(ctx context.Context) (Principal, bool) {
 	p, ok := ctx.Value(principalContextKey{}).(Principal)
 	return p, ok
+}
+
+func withInsecureReadonlyRequest(ctx context.Context) context.Context {
+	return context.WithValue(ctx, insecureReadonlyContextKey{}, true)
+}
+
+func insecureReadonlyRequest(ctx context.Context) bool {
+	v, _ := ctx.Value(insecureReadonlyContextKey{}).(bool)
+	return v
 }
 
 func actorFor(ctx context.Context, requestActor string) string {

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -12,7 +12,7 @@ import (
 // (info.version). It tracks the HTTP API contract, not the build version, so
 // the committed schema artifact stays stable across builds and is bumped
 // deliberately when the wire contract changes.
-const APISchemaVersion = "0.3.0"
+const APISchemaVersion = "0.4.0"
 
 // OpenAPIDocument builds the daemon's complete OpenAPI model by wiring every
 // route through NewServer with a zero ServerConfig. It binds no listener and

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -187,9 +187,9 @@ func TestOpenAPIDocumentShape(t *testing.T) {
 	}
 }
 
-func TestAPISchemaVersionReflectsRewriteAuthorEndpointMove(t *testing.T) {
-	if APISchemaVersion != "0.3.0" {
-		t.Fatalf("APISchemaVersion = %q, want 0.3.0 for rewrite-author endpoint move", APISchemaVersion)
+func TestAPISchemaVersionReflectsSemanticSearchContract(t *testing.T) {
+	if APISchemaVersion != "0.4.0" {
+		t.Fatalf("APISchemaVersion = %q, want 0.4.0 for semantic search response and health contract", APISchemaVersion)
 	}
 }
 

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -1,0 +1,201 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/embedding"
+)
+
+// embedder is the subset of *embedding.Client the reconciler needs (an
+// interface so tests can substitute a fake).
+type embedder interface {
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+	Fingerprint() string
+	Dims() int
+	BatchSize() int
+}
+
+// ReconcilerConfig tunes the reconciler.
+type ReconcilerConfig struct {
+	BatchSize  int
+	SweepEvery time.Duration // periodic safety sweep; default 5m
+	MinBackoff time.Duration // default 1s
+	MaxBackoff time.Duration // default 5m
+}
+
+// ReconcilerHealth is the operator-visible state surfaced in /health.
+type ReconcilerHealth struct {
+	Configured    bool       `json:"configured"`
+	LastSuccessAt *time.Time `json:"last_success_at,omitempty"`
+	LastError     string     `json:"last_error,omitempty"`
+	Backlog       int64      `json:"backlog"`
+}
+
+// Reconciler keeps issue_embeddings fresh by embedding dirty issues.
+type Reconciler struct {
+	store db.Storage
+	emb   embedder
+	cfg   ReconcilerConfig
+	wake  chan struct{}
+
+	mu     sync.Mutex
+	health ReconcilerHealth
+}
+
+// NewReconciler constructs a reconciler. It does no I/O.
+func NewReconciler(store db.Storage, emb embedder, cfg ReconcilerConfig) *Reconciler {
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = emb.BatchSize()
+	}
+	if cfg.SweepEvery <= 0 {
+		cfg.SweepEvery = 5 * time.Minute
+	}
+	if cfg.MinBackoff <= 0 {
+		cfg.MinBackoff = time.Second
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = 5 * time.Minute
+	}
+	return &Reconciler{
+		store:  store,
+		emb:    emb,
+		cfg:    cfg,
+		wake:   make(chan struct{}, 1),
+		health: ReconcilerHealth{Configured: true},
+	}
+}
+
+// Wake nudges the reconciler to run a cycle soon (non-blocking, coalesced).
+func (r *Reconciler) Wake() {
+	select {
+	case r.wake <- struct{}{}:
+	default:
+	}
+}
+
+// Health returns a snapshot of reconciler state. markSuccess swaps in a fresh
+// *time.Time rather than mutating in place, so today there is no shared pointer
+// to race on. Deep-copying LastSuccessAt here is defensive isolation: it locks
+// down the "a returned snapshot is never aliased to live state" invariant so a
+// future in-place mutation can't silently start leaking through callers.
+func (r *Reconciler) Health() ReconcilerHealth {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	h := r.health
+	if r.health.LastSuccessAt != nil {
+		t := *r.health.LastSuccessAt
+		h.LastSuccessAt = &t
+	}
+	return h
+}
+
+// Run drains dirty work until ctx is cancelled, waking on Wake(), a periodic
+// safety sweep, and after backoff on failure.
+func (r *Reconciler) Run(ctx context.Context) error {
+	backoff := r.cfg.MinBackoff
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-r.wake:
+		case <-timer.C:
+		}
+		if err := r.reconcileOnce(ctx); err == nil {
+			backoff = r.cfg.MinBackoff
+			timer.Reset(r.cfg.SweepEvery)
+		} else {
+			backoff = r.nextBackoff(backoff, err)
+			timer.Reset(backoff)
+		}
+	}
+}
+
+func (r *Reconciler) nextBackoff(cur time.Duration, err error) time.Duration {
+	var apiErr *embedding.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.Definitive() {
+			return r.cfg.MaxBackoff
+		}
+		if apiErr.RetryAfter > 0 {
+			return apiErr.RetryAfter
+		}
+	}
+	next := cur * 2
+	if next > r.cfg.MaxBackoff {
+		next = r.cfg.MaxBackoff
+	}
+	return next
+}
+
+// reconcileOnce embeds one batch of dirty targets and updates health.
+func (r *Reconciler) reconcileOnce(ctx context.Context) error {
+	fp := r.emb.Fingerprint()
+	targets, err := r.store.ListEmbedTargets(ctx, fp, r.cfg.BatchSize)
+	if err != nil {
+		return err
+	}
+	r.setBacklog(int64(len(targets)))
+	if len(targets) == 0 {
+		r.markSuccess()
+		return nil
+	}
+	texts := make([]string, len(targets))
+	for i, t := range targets {
+		texts[i] = embedding.EmbedText(t.Title, t.Body)
+	}
+	vecs, err := r.emb.Embed(ctx, texts)
+	if err != nil {
+		r.markError(err)
+		return err
+	}
+	for i, t := range targets {
+		if err := r.store.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+			IssueID:                 t.IssueID,
+			EmbeddedContentRevision: t.ContentRevision,
+			Fingerprint:             fp,
+			Dims:                    r.emb.Dims(),
+			Vector:                  vecs[i],
+		}); err != nil {
+			r.markError(err)
+			return err
+		}
+	}
+	r.markSuccess()
+	// Only a partial batch proves the queue is fully drained, so clear the
+	// gauge to 0 then. A full batch may have more dirty rows behind it; leave
+	// the gauge at the batch count set above (clearing it would make /health
+	// report backlog=0 while the index is still incomplete) and self-wake so
+	// the next cycle's ListEmbedTargets recomputes the true remaining count.
+	if len(targets) < r.cfg.BatchSize {
+		r.setBacklog(0)
+	} else {
+		r.Wake()
+	}
+	return nil
+}
+
+func (r *Reconciler) markSuccess() {
+	now := time.Now().UTC()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.health.LastSuccessAt = &now
+	r.health.LastError = ""
+}
+
+func (r *Reconciler) markError(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.health.LastError = err.Error()
+}
+
+func (r *Reconciler) setBacklog(n int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.health.Backlog = n
+}

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -29,10 +29,11 @@ type ReconcilerConfig struct {
 
 // ReconcilerHealth is the operator-visible state surfaced in /health.
 type ReconcilerHealth struct {
-	Configured    bool       `json:"configured"`
-	LastSuccessAt *time.Time `json:"last_success_at,omitempty"`
-	LastError     string     `json:"last_error,omitempty"`
-	Backlog       int64      `json:"backlog"`
+	Configured      bool       `json:"configured"`
+	LastSuccessAt   *time.Time `json:"last_success_at,omitempty"`
+	LastError       string     `json:"-"`
+	LastErrorStatus int        `json:"last_error_status,omitempty"`
+	Backlog         int64      `json:"backlog"`
 }
 
 // Reconciler keeps issue_embeddings fresh by embedding dirty issues.
@@ -186,12 +187,19 @@ func (r *Reconciler) markSuccess() {
 	defer r.mu.Unlock()
 	r.health.LastSuccessAt = &now
 	r.health.LastError = ""
+	r.health.LastErrorStatus = 0
 }
 
 func (r *Reconciler) markError(err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.health.LastError = err.Error()
+	var apiErr *embedding.APIError
+	if errors.As(err, &apiErr) {
+		r.health.LastErrorStatus = apiErr.StatusCode
+	} else {
+		r.health.LastErrorStatus = 0
+	}
 }
 
 func (r *Reconciler) setBacklog(n int64) {

--- a/internal/daemon/reconciler_test.go
+++ b/internal/daemon/reconciler_test.go
@@ -1,0 +1,335 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/sqlitestore"
+	"go.kenn.io/kata/internal/embedding"
+)
+
+// newReconcilerTestStore opens a real sqlitestore.Store at a temp path and
+// registers cleanup. The reconciler exercises live storage rather than a mock
+// so the dirty-target predicate and upsert round-trip are covered end to end.
+func newReconcilerTestStore(t *testing.T) *sqlitestore.Store {
+	t.Helper()
+	t.Setenv("KATA_HOME", t.TempDir())
+	ctx := context.Background()
+	d, err := sqlitestore.Open(ctx, filepath.Join(t.TempDir(), "kata.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return d
+}
+
+// fakeEmbedder implements the embedder interface the reconciler depends on.
+type fakeEmbedder struct {
+	fp   string
+	dims int
+	err  error
+	n    int
+}
+
+func (f *fakeEmbedder) Fingerprint() string { return f.fp }
+func (f *fakeEmbedder) Dims() int           { return f.dims }
+func (f *fakeEmbedder) BatchSize() int      { return 64 }
+func (f *fakeEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.n += len(texts)
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{1, 0}
+	}
+	return out, nil
+}
+
+func TestReconcileOnceEmbedsDirtyTargets(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	for i := 0; i < 3; i++ {
+		if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "t", Body: "b", Author: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	emb := &fakeEmbedder{fp: "a" + repeat63reconciler, dims: 2}
+	r := NewReconciler(store, emb, ReconcilerConfig{BatchSize: 64})
+
+	if err := r.reconcileOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if emb.n != 3 {
+		t.Fatalf("embedded %d, want 3", emb.n)
+	}
+	// Second pass: nothing dirty.
+	emb.n = 0
+	if err := r.reconcileOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if emb.n != 0 {
+		t.Fatalf("re-embedded %d on clean pass", emb.n)
+	}
+	if h := r.Health(); h.Backlog != 0 || h.LastError != "" {
+		t.Fatalf("unexpected health: %#v", h)
+	}
+	if h := r.Health(); h.LastSuccessAt == nil {
+		t.Fatal("a clean pass must record LastSuccessAt")
+	}
+}
+
+// TestReconcileOnceClearsBacklogAfterDrain pins the /health freshness signal:
+// once a cycle embeds the last dirty batch, Backlog must read 0 immediately,
+// not stay at the pre-embed count until the next 5m sweep. A partial batch
+// does not self-wake, so a stale gauge here would lie to operators (and to the
+// e2e that polls backlog==0) for minutes.
+func TestReconcileOnceClearsBacklogAfterDrain(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "t", Body: "b", Author: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	emb := &fakeEmbedder{fp: "a" + repeat63reconciler, dims: 2}
+	r := NewReconciler(store, emb, ReconcilerConfig{BatchSize: 64})
+
+	// A single cycle that embeds the only dirty issue must leave backlog at 0.
+	if err := r.reconcileOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if emb.n != 1 {
+		t.Fatalf("embedded %d, want 1", emb.n)
+	}
+	if h := r.Health(); h.Backlog != 0 {
+		t.Fatalf("backlog after draining the queue = %d, want 0", h.Backlog)
+	}
+}
+
+// TestReconcileOnceFullBatchKeepsBacklogNonZero is the counterpart to the
+// drain test: a FULL batch (more dirty rows remain) must NOT reset the gauge to
+// 0. Clearing it would make /health report backlog==0 while the index is still
+// incomplete, letting an operator or a polling test proceed too early. With
+// BatchSize 1 and 2 dirty issues the cycle embeds one and leaves one, so the
+// gauge must read the batch count (1), not 0. The next cycle re-lists and
+// reports the true remaining count.
+func TestReconcileOnceFullBatchKeepsBacklogNonZero(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	for i := 0; i < 2; i++ {
+		if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "t", Body: "b", Author: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	emb := &fakeEmbedder{fp: "a" + repeat63reconciler, dims: 2}
+	r := NewReconciler(store, emb, ReconcilerConfig{BatchSize: 1})
+
+	if err := r.reconcileOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if emb.n != 1 {
+		t.Fatalf("embedded %d, want 1 (one batch)", emb.n)
+	}
+	if h := r.Health(); h.Backlog != 1 {
+		t.Fatalf("backlog after a full batch = %d, want 1 (queue not yet drained)", h.Backlog)
+	}
+}
+
+func TestReconcileDefinitiveErrorPinsHealth(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	_, _, _ = store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "t", Body: "b", Author: "x"})
+	emb := &fakeEmbedder{fp: "a" + repeat63reconciler, dims: 2, err: &embedding.APIError{StatusCode: 401, Body: "bad key"}}
+	r := NewReconciler(store, emb, ReconcilerConfig{BatchSize: 64})
+
+	err := r.reconcileOnce(ctx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var apiErr *embedding.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want APIError, got %v", err)
+	}
+	if h := r.Health(); h.LastError == "" {
+		t.Fatal("health LastError not set")
+	}
+}
+
+func TestNextBackoffClassifiesErrors(t *testing.T) {
+	r := NewReconciler(newReconcilerTestStore(t), &fakeEmbedder{fp: "a" + repeat63reconciler, dims: 2},
+		ReconcilerConfig{MinBackoff: time.Second, MaxBackoff: 5 * time.Minute})
+
+	// Definitive 4xx pins straight to the max, regardless of current backoff.
+	if got := r.nextBackoff(time.Second, &embedding.APIError{StatusCode: 401}); got != 5*time.Minute {
+		t.Fatalf("definitive: got %v, want max 5m", got)
+	}
+	// 429 with Retry-After honors the server's delay.
+	got := r.nextBackoff(time.Second, &embedding.APIError{StatusCode: 429, RetryAfter: 7 * time.Second})
+	if got != 7*time.Second {
+		t.Fatalf("429 retry-after: got %v, want 7s", got)
+	}
+	// 429 without Retry-After falls back to exponential doubling.
+	if got := r.nextBackoff(2*time.Second, &embedding.APIError{StatusCode: 429}); got != 4*time.Second {
+		t.Fatalf("429 no retry-after: got %v, want 4s", got)
+	}
+	// Transient (non-APIError) errors double, capped at MaxBackoff.
+	if got := r.nextBackoff(2*time.Second, errors.New("connection refused")); got != 4*time.Second {
+		t.Fatalf("transient: got %v, want 4s", got)
+	}
+	if got := r.nextBackoff(4*time.Minute, errors.New("connection refused")); got != 5*time.Minute {
+		t.Fatalf("transient cap: got %v, want max 5m", got)
+	}
+}
+
+func TestReconcileOnceFullBatchWakesToContinue(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	for i := 0; i < 5; i++ {
+		if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "t", Body: "b", Author: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	emb := &fakeEmbedder{fp: "a" + repeat63reconciler, dims: 2}
+	// BatchSize 2 leaves more dirty targets than one batch can clear.
+	r := NewReconciler(store, emb, ReconcilerConfig{BatchSize: 2})
+
+	if err := r.reconcileOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if emb.n != 2 {
+		t.Fatalf("embedded %d, want 2 (one batch)", emb.n)
+	}
+	// A full batch must re-arm Wake so Run continues draining the backlog.
+	select {
+	case <-r.wake:
+	default:
+		t.Fatal("full batch did not wake the reconciler to continue")
+	}
+}
+
+func TestReconcileOncePartialBatchDoesNotWake(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	_, _, _ = store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "t", Body: "b", Author: "x"})
+	emb := &fakeEmbedder{fp: "a" + repeat63reconciler, dims: 2}
+	r := NewReconciler(store, emb, ReconcilerConfig{BatchSize: 64})
+
+	if err := r.reconcileOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-r.wake:
+		t.Fatal("partial batch should not re-arm Wake")
+	default:
+	}
+}
+
+// flakyEmbedder fails its first failUntil Embed calls with err, then succeeds.
+// It records the total number of successfully embedded texts. All access is
+// guarded so Run's goroutine and the test goroutine can read/write safely.
+type flakyEmbedder struct {
+	fp        string
+	dims      int
+	err       error
+	failUntil int
+
+	mu       sync.Mutex
+	calls    int
+	embedded int
+}
+
+func (f *flakyEmbedder) Fingerprint() string { return f.fp }
+func (f *flakyEmbedder) Dims() int           { return f.dims }
+func (f *flakyEmbedder) BatchSize() int      { return 64 }
+func (f *flakyEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.calls <= f.failUntil {
+		return nil, f.err
+	}
+	f.embedded += len(texts)
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{1, 0}
+	}
+	return out, nil
+}
+
+func (f *flakyEmbedder) embeddedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.embedded
+}
+
+func (f *flakyEmbedder) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func TestRunDrainsAfterTransientFailureThenExitsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	for i := 0; i < 3; i++ {
+		if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "t", Body: "b", Author: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Fail the first Embed (transient), then succeed. With tiny backoffs the
+	// retry happens almost immediately, so the loop drains the backlog quickly.
+	emb := &flakyEmbedder{fp: "a" + repeat63reconciler, dims: 2, failUntil: 1, err: errors.New("connection refused")}
+	r := NewReconciler(store, emb, ReconcilerConfig{
+		BatchSize:  64,
+		MinBackoff: time.Millisecond,
+		MaxBackoff: 5 * time.Millisecond,
+		SweepEvery: time.Millisecond,
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+	r.Wake()
+
+	// Poll until all three targets are embedded and the backoff has reset on
+	// success (LastError cleared, LastSuccessAt set). Poll rather than sleep so
+	// the test is robust against scheduling jitter.
+	require.Eventually(t, func() bool {
+		if emb.embeddedCount() < 3 {
+			return false
+		}
+		h := r.Health()
+		return h.LastSuccessAt != nil && h.LastError == "" && h.Backlog == 0
+	}, 2*time.Second, time.Millisecond, "reconciler did not drain the backlog after a transient failure")
+
+	// Cancelling ctx must make Run return promptly with the ctx error.
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit after ctx cancel")
+	}
+
+	// The failed first attempt must have set LastError at the time; the later
+	// success cleared it (backoff-reset-on-success), proving recovery.
+	if c := emb.callCount(); c < 2 {
+		t.Fatalf("expected at least one retry after the transient failure, got %d Embed calls", c)
+	}
+}
+
+const repeat63reconciler = "000000000000000000000000000000000000000000000000000000000000000"

--- a/internal/daemon/rrf.go
+++ b/internal/daemon/rrf.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"fmt"
+	"sort"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+type searchMode string
+
+const (
+	modeLexical  searchMode = "lexical"
+	modeHybrid   searchMode = "hybrid"
+	modeSemantic searchMode = "semantic"
+)
+
+const rrfK = 60
+
+// resolveMode maps a requested mode string and whether embeddings are
+// configured to the effective mode. An explicit hybrid/semantic request that
+// cannot be served (unconfigured) returns an error so the handler can reply
+// 400; "auto"/"" silently resolves to hybrid-when-configured, else lexical.
+func resolveMode(requested string, configured bool) (searchMode, error) {
+	switch requested {
+	case "", "auto":
+		if configured {
+			return modeHybrid, nil
+		}
+		return modeLexical, nil
+	case "lexical":
+		return modeLexical, nil
+	case "hybrid", "semantic":
+		if !configured {
+			return modeLexical, fmt.Errorf("mode %q requires [search.embeddings] to be configured", requested)
+		}
+		return searchMode(requested), nil
+	default:
+		return modeLexical, fmt.Errorf("unknown mode %q (want auto|lexical|hybrid|semantic)", requested)
+	}
+}
+
+// mergeRRF fuses two ranked legs with reciprocal rank fusion (k=60, equal
+// weights), deduping by issue id and unioning matched_in. Ties break by RRF
+// score desc, then updated_at desc, then issue id asc. The resulting Score is
+// the RRF score.
+func mergeRRF(lexical, vector []db.SearchCandidate, limit int) []db.SearchCandidate {
+	type agg struct {
+		issue   db.Issue
+		score   float64
+		matched map[string]bool
+	}
+	byID := map[int64]*agg{}
+	add := func(leg []db.SearchCandidate) {
+		for rank, c := range leg {
+			a := byID[c.Issue.ID]
+			if a == nil {
+				a = &agg{issue: c.Issue, matched: map[string]bool{}}
+				byID[c.Issue.ID] = a
+			}
+			a.score += 1.0 / float64(rrfK+rank+1)
+			for _, m := range c.MatchedIn {
+				a.matched[m] = true
+			}
+		}
+	}
+	add(lexical)
+	add(vector)
+
+	out := make([]db.SearchCandidate, 0, len(byID))
+	for _, a := range byID {
+		matched := make([]string, 0, len(a.matched))
+		for m := range a.matched {
+			matched = append(matched, m)
+		}
+		sort.Strings(matched)
+		out = append(out, db.SearchCandidate{Issue: a.issue, Score: a.score, MatchedIn: matched})
+	}
+	// Deterministic order: RRF score desc, then most-recently-updated first,
+	// then issue id asc as the final tiebreak (matches the design note).
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		if !out[i].Issue.UpdatedAt.Equal(out[j].Issue.UpdatedAt) {
+			return out[i].Issue.UpdatedAt.After(out[j].Issue.UpdatedAt)
+		}
+		return out[i].Issue.ID < out[j].Issue.ID
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}

--- a/internal/daemon/rrf_test.go
+++ b/internal/daemon/rrf_test.go
@@ -1,0 +1,124 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+)
+
+func cand(id int64, score float64, matched ...string) db.SearchCandidate {
+	return db.SearchCandidate{Issue: db.Issue{ID: id}, Score: score, MatchedIn: matched}
+}
+
+func TestMergeRRFCombinesAndDedupes(t *testing.T) {
+	lex := []db.SearchCandidate{cand(1, 5, "title"), cand(2, 4, "body")}
+	vec := []db.SearchCandidate{cand(2, 0.9, "semantic"), cand(3, 0.8, "semantic")}
+	merged := mergeRRF(lex, vec, 10)
+
+	// Issue 2 appears in both legs → ranks first.
+	if merged[0].Issue.ID != 2 {
+		t.Fatalf("expected issue 2 first, got %d", merged[0].Issue.ID)
+	}
+	// matched_in for issue 2 is the union.
+	if !contains(merged[0].MatchedIn, "body") || !contains(merged[0].MatchedIn, "semantic") {
+		t.Fatalf("matched_in not unioned: %v", merged[0].MatchedIn)
+	}
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 unique issues, got %d", len(merged))
+	}
+}
+
+func TestMergeRRFEmptyLegs(t *testing.T) {
+	if got := mergeRRF(nil, nil, 10); len(got) != 0 {
+		t.Fatalf("empty legs should yield empty, got %d", len(got))
+	}
+	lex := []db.SearchCandidate{cand(1, 5, "title")}
+	if got := mergeRRF(lex, nil, 10); len(got) != 1 || got[0].Issue.ID != 1 {
+		t.Fatalf("lexical-only passthrough failed: %#v", got)
+	}
+}
+
+func TestMergeRRFRespectsLimit(t *testing.T) {
+	lex := []db.SearchCandidate{cand(1, 5, "title"), cand(2, 4, "body")}
+	vec := []db.SearchCandidate{cand(2, 0.9, "semantic"), cand(3, 0.8, "semantic")}
+	merged := mergeRRF(lex, vec, 2)
+
+	require.Len(t, merged, 2)
+	// Issue 2 is in both legs (highest RRF), so it survives the truncation; the
+	// next slot goes to the higher-ranked of the remaining singletons (issue 1
+	// at lexical rank 0 outscores issue 3 at vector rank 1).
+	require.Equal(t, int64(2), merged[0].Issue.ID)
+	require.Equal(t, int64(1), merged[1].Issue.ID)
+}
+
+func TestMergeRRFTieBreaksByLowerIssueID(t *testing.T) {
+	// Issue 7 appears only in lexical at rank 0; issue 3 only in vector at rank
+	// 0. Both score 1/(60+0+1), an exact RRF tie. The deterministic tie-break
+	// is ascending issue id, so issue 3 must sort first even though issue 7 was
+	// added to the lexical leg first. This fails if the id tie-break is dropped
+	// or reversed.
+	lex := []db.SearchCandidate{cand(7, 5, "title")}
+	vec := []db.SearchCandidate{cand(3, 0.9, "semantic")}
+	merged := mergeRRF(lex, vec, 10)
+
+	require.Len(t, merged, 2)
+	require.InDelta(t, merged[0].Score, merged[1].Score, 1e-12, "scores must be an exact RRF tie")
+	require.Equalf(t, int64(3), merged[0].Issue.ID, "tie must break to the lower issue id")
+	require.Equal(t, int64(7), merged[1].Issue.ID)
+}
+
+func TestMergeRRFTieBreaksByMostRecentlyUpdated(t *testing.T) {
+	// Both issues score 1/(60+0+1): older only in lexical at rank 0, newer only
+	// in vector at rank 0. The design-note tiebreak is updated_at desc, so the
+	// newer issue must sort first even though it has the higher id (which would
+	// lose under the id-asc final tiebreak). Fails if updated_at is ignored.
+	older := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	lex := []db.SearchCandidate{{Issue: db.Issue{ID: 1, UpdatedAt: older}, MatchedIn: []string{"title"}}}
+	vec := []db.SearchCandidate{{Issue: db.Issue{ID: 2, UpdatedAt: newer}, MatchedIn: []string{"semantic"}}}
+	merged := mergeRRF(lex, vec, 10)
+
+	require.Len(t, merged, 2)
+	require.InDelta(t, merged[0].Score, merged[1].Score, 1e-12, "scores must be an exact RRF tie")
+	require.Equalf(t, int64(2), merged[0].Issue.ID, "more-recently-updated issue must sort first")
+	require.Equal(t, int64(1), merged[1].Issue.ID)
+}
+
+func TestResolveMode(t *testing.T) {
+	cases := []struct {
+		req        string
+		configured bool
+		want       searchMode
+		wantErr    bool
+	}{
+		{"", false, modeLexical, false},
+		{"", true, modeHybrid, false},
+		{"auto", true, modeHybrid, false},
+		{"lexical", false, modeLexical, false},
+		{"hybrid", false, modeLexical, true},   // 400
+		{"semantic", false, modeLexical, true}, // 400
+		{"hybrid", true, modeHybrid, false},
+		{"semantic", true, modeSemantic, false},
+		{"bogus", true, modeLexical, true},
+	}
+	for _, tc := range cases {
+		got, err := resolveMode(tc.req, tc.configured)
+		if (err != nil) != tc.wantErr {
+			t.Fatalf("resolveMode(%q,%v) err=%v wantErr=%v", tc.req, tc.configured, err, tc.wantErr)
+		}
+		if err == nil && got != tc.want {
+			t.Fatalf("resolveMode(%q,%v)=%v want %v", tc.req, tc.configured, got, tc.want)
+		}
+	}
+}
+
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -16,6 +16,7 @@ import (
 	"go.kenn.io/kata/internal/api"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/embedding"
 	"go.kenn.io/kata/internal/githubsync"
 	"go.kenn.io/kata/internal/hooks"
 )
@@ -53,6 +54,15 @@ type ServerConfig struct {
 	// bearer-derived principal). Nil uses slog.Default(); tests inject a
 	// per-test logger so output is observable and isolated.
 	Logger *slog.Logger
+
+	// Embedder is the semantic-search embedding client. Nil means semantic
+	// search is disabled and the search handler falls back to lexical-only.
+	Embedder *embedding.Client
+
+	// ReconcilerHealth snapshots the embedding reconciler's operator-visible
+	// state for /health. Nil means semantic search is disabled, in which case
+	// the health response omits the embeddings block entirely.
+	ReconcilerHealth func() ReconcilerHealth
 }
 
 // authPolicy returns the resolved bearer-auth policy in the form the

--- a/internal/db/embedding_types.go
+++ b/internal/db/embedding_types.go
@@ -1,0 +1,19 @@
+package db
+
+// IssueEmbedding is one stored vector for an issue.
+type IssueEmbedding struct {
+	IssueID                 int64
+	EmbeddedContentRevision int64
+	Fingerprint             string
+	Dims                    int
+	Vector                  []float32 // L2-normalized
+}
+
+// EmbedTarget is an issue whose embedding is missing or stale for the active
+// fingerprint, carrying the text the reconciler must embed.
+type EmbedTarget struct {
+	IssueID         int64
+	ContentRevision int64
+	Title           string
+	Body            string
+}

--- a/internal/db/export_types.go
+++ b/internal/db/export_types.go
@@ -17,26 +17,40 @@ type MetaKV struct {
 
 // IssueExport is one issue row in export shape (recurrence_uid resolved via join).
 type IssueExport struct {
-	ID            int64           `json:"id"`
-	UID           string          `json:"uid"`
-	ProjectID     int64           `json:"project_id"`
-	ShortID       string          `json:"short_id"`
-	Title         string          `json:"title"`
-	Body          string          `json:"body"`
-	Status        string          `json:"status"`
-	ClosedReason  *string         `json:"closed_reason"`
-	Owner         *string         `json:"owner"`
-	Priority      *int64          `json:"priority,omitempty"`
-	Author        string          `json:"author"`
-	CreatedAt     string          `json:"created_at"`
-	UpdatedAt     string          `json:"updated_at"`
-	ClosedAt      *string         `json:"closed_at"`
-	DeletedAt     *string         `json:"deleted_at"`
-	Metadata      json.RawMessage `json:"metadata"`
-	Revision      int64           `json:"revision"`
-	RecurrenceID  *int64          `json:"recurrence_id,omitempty"`
-	RecurrenceUID *string         `json:"recurrence_uid,omitempty"`
-	OccurrenceKey *string         `json:"occurrence_key,omitempty"`
+	ID              int64           `json:"id"`
+	UID             string          `json:"uid"`
+	ProjectID       int64           `json:"project_id"`
+	ShortID         string          `json:"short_id"`
+	Title           string          `json:"title"`
+	Body            string          `json:"body"`
+	Status          string          `json:"status"`
+	ClosedReason    *string         `json:"closed_reason"`
+	Owner           *string         `json:"owner"`
+	Priority        *int64          `json:"priority,omitempty"`
+	Author          string          `json:"author"`
+	CreatedAt       string          `json:"created_at"`
+	UpdatedAt       string          `json:"updated_at"`
+	ClosedAt        *string         `json:"closed_at"`
+	DeletedAt       *string         `json:"deleted_at"`
+	Metadata        json.RawMessage `json:"metadata"`
+	Revision        int64           `json:"revision"`
+	ContentRevision int64           `json:"content_revision"`
+	RecurrenceID    *int64          `json:"recurrence_id,omitempty"`
+	RecurrenceUID   *string         `json:"recurrence_uid,omitempty"`
+	OccurrenceKey   *string         `json:"occurrence_key,omitempty"`
+}
+
+// IssueEmbeddingExport is one issue_embeddings row in export shape, keyed by
+// issue UID so import resolves identity independent of local numeric ids. The
+// vector is base64-encoded (dims x float32 little-endian, L2-normalized).
+// Embeddings are expensive derived state, so they are exported to avoid
+// re-embedding a whole project after a schema cutover or backup restore.
+type IssueEmbeddingExport struct {
+	IssueUID                string `json:"issue_uid"`
+	EmbeddedContentRevision int64  `json:"embedded_content_revision"`
+	Fingerprint             string `json:"embed_fingerprint"`
+	Dims                    int    `json:"dims"`
+	VectorB64               string `json:"vector_b64"`
 }
 
 // RecurrenceExport is one recurrence row in export shape.

--- a/internal/db/import_types.go
+++ b/internal/db/import_types.go
@@ -49,6 +49,7 @@ type ImportRecord struct {
 	IssueSyncStatus      *IssueSyncStatusExport
 	Recurrence           *RecurrenceExport
 	Issue                *IssueExport
+	IssueEmbedding       *IssueEmbeddingExport
 	Comment              *CommentExport
 	Label                *IssueLabelExport
 	Link                 *LinkExport
@@ -77,6 +78,7 @@ const (
 	ImportKindIssueSyncStatus      = "issue_sync_status"
 	ImportKindRecurrence           = "recurrence"
 	ImportKindIssue                = "issue"
+	ImportKindIssueEmbedding       = "issue_embedding"
 	ImportKindComment              = "comment"
 	ImportKindIssueLabel           = "issue_label"
 	ImportKindLink                 = "link"
@@ -108,6 +110,7 @@ func (r ImportRecord) Validate() error {
 		{ImportKindIssueSyncStatus, r.IssueSyncStatus != nil},
 		{ImportKindRecurrence, r.Recurrence != nil},
 		{ImportKindIssue, r.Issue != nil},
+		{ImportKindIssueEmbedding, r.IssueEmbedding != nil},
 		{ImportKindComment, r.Comment != nil},
 		{ImportKindIssueLabel, r.Label != nil},
 		{ImportKindLink, r.Link != nil},

--- a/internal/db/pgstore/schema.sql
+++ b/internal/db/pgstore/schema.sql
@@ -113,6 +113,7 @@ CREATE TABLE issues (
   metadata      TEXT NOT NULL DEFAULT '{}'
                   CHECK (jsonb_typeof((metadata)::jsonb) = 'object'),
   revision      BIGINT NOT NULL DEFAULT 1,
+  content_revision BIGINT NOT NULL DEFAULT 0,
   recurrence_id   BIGINT REFERENCES recurrences(id) ON DELETE SET NULL,
   occurrence_key  TEXT,
   CHECK (length(uid) = 26),
@@ -551,6 +552,22 @@ CREATE TABLE pending_claim_requests (
 CREATE UNIQUE INDEX uniq_pending_claim_active
   ON pending_claim_requests(issue_uid, holder_instance_uid, holder, client_kind)
   WHERE rejected_at IS NULL AND resolved_at IS NULL;
+
+-- ----------------------------------------------------------------------
+-- Semantic search: one L2-normalized vector per issue. Canonical derived
+-- state, mirroring sqlitestore. pgvector acceleration is built from this in
+-- a later phase; this table is the source of truth either way.
+-- ----------------------------------------------------------------------
+
+CREATE TABLE issue_embeddings (
+  issue_id                  BIGINT PRIMARY KEY REFERENCES issues(id) ON DELETE CASCADE,
+  embedded_content_revision BIGINT NOT NULL,
+  embed_fingerprint         TEXT NOT NULL CHECK (length(embed_fingerprint) = 64),
+  dims                      INTEGER NOT NULL CHECK (dims > 0),
+  vector_bytes              BYTEA NOT NULL CHECK (octet_length(vector_bytes) = dims * 4),
+  updated_at                TEXT NOT NULL
+);
+CREATE INDEX idx_issue_embeddings_fingerprint ON issue_embeddings(embed_fingerprint);
 
 -- ----------------------------------------------------------------------
 -- FTS surface: issues_search table + rebuild function + 5 sync triggers.

--- a/internal/db/pgstore/schema_test.go
+++ b/internal/db/pgstore/schema_test.go
@@ -24,6 +24,7 @@ var expectedTables = []string{
 	"federation_sync_status",
 	"import_mappings",
 	"issue_claims",
+	"issue_embeddings",
 	"issue_labels",
 	"issues",
 	"issues_search",
@@ -73,6 +74,7 @@ var expectedFKCounts = map[string]int{
 	"issue_claims":           2, // -> projects, -> issues
 	"pending_claim_requests": 2, // -> projects, -> issues
 	"issues_search":          1, // -> issues (CASCADE)
+	"issue_embeddings":       1, // -> issues (CASCADE)
 	"import_mappings":        4, // -> projects, issues, comments, links
 }
 

--- a/internal/db/pgstore/stubs_gen.go
+++ b/internal/db/pgstore/stubs_gen.go
@@ -234,6 +234,10 @@ func (s *Store) EditIssueAtomic(_ context.Context, _ db.EditIssueAtomicParams) (
 	return db.EditIssueAtomicResult{}, ErrNotImplementedPhase3
 }
 
+func (s *Store) EmbeddingStats(_ context.Context, _ int64, _ string) (int64, string, error) {
+	return 0, "", ErrNotImplementedPhase3
+}
+
 func (s *Store) EnableFederationPush(_ context.Context, _ int64, _ int64) (db.FederationBinding, error) {
 	return db.FederationBinding{}, ErrNotImplementedPhase3
 }
@@ -315,6 +319,12 @@ func (s *Store) ExportImportMappings(_ context.Context, _ db.ExportFilter) iter.
 func (s *Store) ExportIssueClaims(_ context.Context, _ db.ExportFilter) iter.Seq2[db.IssueClaimExport, error] {
 	return func(yield func(db.IssueClaimExport, error) bool) {
 		yield(db.IssueClaimExport{}, ErrNotImplementedPhase3)
+	}
+}
+
+func (s *Store) ExportIssueEmbeddings(_ context.Context, _ db.ExportFilter) iter.Seq2[db.IssueEmbeddingExport, error] {
+	return func(yield func(db.IssueEmbeddingExport, error) bool) {
+		yield(db.IssueEmbeddingExport{}, ErrNotImplementedPhase3)
 	}
 }
 
@@ -533,6 +543,10 @@ func (s *Store) ListAllIssues(_ context.Context, _ db.ListAllIssuesParams) ([]db
 }
 
 func (s *Store) ListDueIssueSyncBindings(_ context.Context, _ string, _ time.Time, _ time.Time, _ int) ([]db.IssueSyncBinding, error) {
+	return nil, ErrNotImplementedPhase3
+}
+
+func (s *Store) ListEmbedTargets(_ context.Context, _ string, _ int) ([]db.EmbedTarget, error) {
 	return nil, ErrNotImplementedPhase3
 }
 
@@ -824,6 +838,10 @@ func (s *Store) SearchFTSAny(_ context.Context, _ int64, _ string, _ int, _ bool
 	return nil, ErrNotImplementedPhase3
 }
 
+func (s *Store) SearchVector(_ context.Context, _ int64, _ []float32, _ string, _ int, _ bool) ([]db.SearchCandidate, error) {
+	return nil, ErrNotImplementedPhase3
+}
+
 func (s *Store) SkipFederationQuarantine(_ context.Context, _ db.SkipFederationQuarantineParams) (db.FederationQuarantine, error) {
 	return db.FederationQuarantine{}, ErrNotImplementedPhase3
 }
@@ -866,6 +884,10 @@ func (s *Store) UpsertFederationBinding(_ context.Context, _ db.FederationBindin
 
 func (s *Store) UpsertImportMapping(_ context.Context, _ db.ImportMappingParams) (db.ImportMapping, error) {
 	return db.ImportMapping{}, ErrNotImplementedPhase3
+}
+
+func (s *Store) UpsertIssueEmbedding(_ context.Context, _ db.IssueEmbedding) error {
+	return ErrNotImplementedPhase3
 }
 
 func (s *Store) UpsertIssueSyncBinding(_ context.Context, _ db.UpsertIssueSyncBindingParams) (db.IssueSyncBinding, error) {

--- a/internal/db/schema_version.go
+++ b/internal/db/schema_version.go
@@ -5,7 +5,7 @@ package db
 // compare on-disk state against this number when opening existing ones; a
 // mismatch surfaces either ErrSchemaCutoverRequired (for older sources, so
 // storeopen can drive a JSONL cutover) or a newer-than-binary error.
-const currentSchemaVersion = 21
+const currentSchemaVersion = 22
 
 // CurrentSchemaVersion returns the schema version expected by this binary.
 // Backends and the cutover path read this to align freshly created databases

--- a/internal/db/sqlitestore/content_revision_test.go
+++ b/internal/db/sqlitestore/content_revision_test.go
@@ -1,0 +1,143 @@
+package sqlitestore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/sqlitestore"
+)
+
+// contentRev reads issues.content_revision for issueID directly.
+func contentRev(ctx context.Context, t *testing.T, d *sqlitestore.Store, issueID int64) int64 {
+	t.Helper()
+	var cr int64
+	require.NoError(t, d.QueryRowContext(ctx,
+		`SELECT content_revision FROM issues WHERE id = ?`, issueID).Scan(&cr))
+	return cr
+}
+
+func TestContentRevisionBumpsOnTitleBodyOnly(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	iss, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: proj.ID, Title: "first", Body: "b", Author: "tester",
+	})
+	require.NoError(t, err)
+	base := contentRev(ctx, t, d, iss.ID)
+
+	// Title edit bumps.
+	newTitle := "second"
+	_, _, _, err = d.EditIssue(ctx, db.EditIssueParams{IssueID: iss.ID, Title: &newTitle, Actor: "tester"})
+	require.NoError(t, err)
+	afterTitle := contentRev(ctx, t, d, iss.ID)
+	require.Equalf(t, base+1, afterTitle, "title edit must bump content_revision")
+
+	// Body edit bumps.
+	newBody := "c"
+	_, _, _, err = d.EditIssue(ctx, db.EditIssueParams{IssueID: iss.ID, Body: &newBody, Actor: "tester"})
+	require.NoError(t, err)
+	afterBody := contentRev(ctx, t, d, iss.ID)
+	require.Equalf(t, afterTitle+1, afterBody, "body edit must bump content_revision")
+
+	// Re-applying the same title does NOT bump (no-op edit).
+	_, _, _, err = d.EditIssue(ctx, db.EditIssueParams{IssueID: iss.ID, Title: &newTitle, Actor: "tester"})
+	require.NoError(t, err)
+	require.Equalf(t, afterBody, contentRev(ctx, t, d, iss.ID),
+		"re-applying the same title must not bump content_revision")
+
+	// Owner edit does NOT bump.
+	owner := "alice"
+	_, _, _, err = d.EditIssue(ctx, db.EditIssueParams{IssueID: iss.ID, Owner: &owner, Actor: "tester"})
+	require.NoError(t, err)
+	require.Equalf(t, afterBody, contentRev(ctx, t, d, iss.ID),
+		"owner edit must not bump content_revision")
+
+	// Comment does NOT bump.
+	_, _, err = d.CreateComment(ctx, db.CreateCommentParams{IssueID: iss.ID, Body: "c", Author: "tester"})
+	require.NoError(t, err)
+	require.Equalf(t, afterBody, contentRev(ctx, t, d, iss.ID),
+		"comment must not bump content_revision")
+}
+
+func TestContentRevisionBumpsFromEditIssueAtomic(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	iss, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: proj.ID, Title: "first", Body: "b", Author: "tester",
+	})
+	require.NoError(t, err)
+	base := contentRev(ctx, t, d, iss.ID)
+
+	// Atomic title edit bumps.
+	newTitle := "second"
+	_, err = d.EditIssueAtomic(ctx, db.EditIssueAtomicParams{IssueID: iss.ID, Title: &newTitle, Actor: "tester"})
+	require.NoError(t, err)
+	afterTitle := contentRev(ctx, t, d, iss.ID)
+	require.Equalf(t, base+1, afterTitle, "atomic title edit must bump content_revision")
+
+	// Atomic priority-only edit does NOT bump.
+	prio := int64(2)
+	_, err = d.EditIssueAtomic(ctx, db.EditIssueAtomicParams{IssueID: iss.ID, SetPriority: &prio, Actor: "tester"})
+	require.NoError(t, err)
+	require.Equalf(t, afterTitle, contentRev(ctx, t, d, iss.ID),
+		"atomic priority edit must not bump content_revision")
+}
+
+func TestContentRevisionBumpsFromImport(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC)
+
+	// Initial import creates the issue.
+	_, _, err := d.ImportBatch(ctx, db.ImportBatchParams{
+		ProjectID: proj.ID, Source: "beads", Actor: "importer",
+		Items: []db.ImportItem{{
+			ExternalID: "a", Title: "first", Body: "b", Author: "alice",
+			Status: "open", CreatedAt: t1, UpdatedAt: t1,
+		}},
+	})
+	require.NoError(t, err)
+	m, err := d.ImportMappingBySource(ctx, proj.ID, "beads", "issue", "a")
+	require.NoError(t, err)
+	require.NotNil(t, m.IssueID)
+	issueID := *m.IssueID
+	base := contentRev(ctx, t, d, issueID)
+
+	// Re-import the same ExternalID with a changed Title (newer UpdatedAt so
+	// updateImportedIssue runs) bumps content_revision.
+	res, _, err := d.ImportBatch(ctx, db.ImportBatchParams{
+		ProjectID: proj.ID, Source: "beads", Actor: "importer",
+		Items: []db.ImportItem{{
+			ExternalID: "a", Title: "second", Body: "b", Author: "alice",
+			Status: "open", CreatedAt: t1, UpdatedAt: t2,
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Updated)
+	afterTitle := contentRev(ctx, t, d, issueID)
+	require.Equalf(t, base+1, afterTitle, "import title change must bump content_revision")
+
+	// Re-import again with same Title/Body but a non-content change (status,
+	// owner) and newer UpdatedAt. updateImportedIssue runs but must NOT bump.
+	res, _, err = d.ImportBatch(ctx, db.ImportBatchParams{
+		ProjectID: proj.ID, Source: "beads", Actor: "importer",
+		Items: []db.ImportItem{{
+			ExternalID: "a", Title: "second", Body: "b", Author: "alice",
+			Owner: strPtr("bob"), Status: "closed", ClosedReason: strPtr("done"),
+			CreatedAt: t1, UpdatedAt: t3, ClosedAt: &t3,
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Updated)
+	require.Equalf(t, afterTitle, contentRev(ctx, t, d, issueID),
+		"import non-content change must not bump content_revision")
+}

--- a/internal/db/sqlitestore/content_revision_test.go
+++ b/internal/db/sqlitestore/content_revision_test.go
@@ -141,3 +141,36 @@ func TestContentRevisionBumpsFromImport(t *testing.T) {
 	require.Equalf(t, afterTitle, contentRev(ctx, t, d, issueID),
 		"import non-content change must not bump content_revision")
 }
+
+func TestContentRevisionBumpsFromImportPresentationTitleCorrection(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	sourceTime := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+
+	_, _, err := d.ImportBatch(ctx, db.ImportBatchParams{
+		ProjectID: proj.ID, Source: "github:R_example", Actor: "sync-agent",
+		Items: []db.ImportItem{{
+			ExternalID: "issue-id:101", Title: "Original title", Body: "body",
+			Author: "sync-agent", Status: "open",
+			CreatedAt: sourceTime.Add(-time.Minute), UpdatedAt: sourceTime,
+		}},
+	})
+	require.NoError(t, err)
+	m, err := d.ImportMappingBySource(ctx, proj.ID, "github:R_example", "issue", "issue-id:101")
+	require.NoError(t, err)
+	require.NotNil(t, m.IssueID)
+	base := contentRev(ctx, t, d, *m.IssueID)
+
+	_, _, err = d.ImportBatch(ctx, db.ImportBatchParams{
+		ProjectID: proj.ID, Source: "github:R_example", Actor: "sync-agent",
+		Items: []db.ImportItem{{
+			ExternalID: "issue-id:101", Title: "[GitHub #1] Original title", Body: "body",
+			Author: "sync-agent", Status: "open",
+			CreatedAt: sourceTime.Add(-time.Minute), UpdatedAt: sourceTime,
+		}},
+	})
+	require.NoError(t, err)
+	require.Equalf(t, base+1, contentRev(ctx, t, d, *m.IssueID),
+		"source-owned title correction must bump content_revision")
+}

--- a/internal/db/sqlitestore/export.go
+++ b/internal/db/sqlitestore/export.go
@@ -128,7 +128,7 @@ func (d *Store) ExportIssues(ctx context.Context, f db.ExportFilter) iter.Seq2[d
 	                 i.status, i.closed_reason, i.owner, i.priority, i.author,
 	                 CAST(i.created_at AS TEXT), CAST(i.updated_at AS TEXT),
 	                 CAST(i.closed_at AS TEXT), CAST(i.deleted_at AS TEXT),
-	                 i.metadata, i.revision,
+	                 i.metadata, i.revision, i.content_revision,
 	                 i.recurrence_id, r.uid, i.occurrence_key
 	          FROM issues i
 	          LEFT JOIN recurrences r ON r.id = i.recurrence_id` +
@@ -139,7 +139,7 @@ func (d *Store) ExportIssues(ctx context.Context, f db.ExportFilter) iter.Seq2[d
 			var metadata string
 			if err := rows.Scan(&rec.ID, &rec.UID, &rec.ProjectID, &rec.ShortID, &rec.Title, &rec.Body,
 				&rec.Status, &rec.ClosedReason, &rec.Owner, &rec.Priority, &rec.Author, &rec.CreatedAt,
-				&rec.UpdatedAt, &rec.ClosedAt, &rec.DeletedAt, &metadata, &rec.Revision,
+				&rec.UpdatedAt, &rec.ClosedAt, &rec.DeletedAt, &metadata, &rec.Revision, &rec.ContentRevision,
 				&rec.RecurrenceID, &rec.RecurrenceUID, &rec.OccurrenceKey); err != nil {
 				return db.IssueExport{}, scanError("issue", err)
 			}

--- a/internal/db/sqlitestore/export_embeddings.go
+++ b/internal/db/sqlitestore/export_embeddings.go
@@ -1,0 +1,32 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"iter"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+// ExportIssueEmbeddings streams issue_embeddings rows joined to their issue
+// UID, ordered by issue id. The join reuses the issue export's WHERE clause so
+// a live-only (non-include-deleted) export omits any embedding whose parent
+// issue is excluded, and a project-scoped export omits embeddings of issues in
+// other projects. The vector is base64-encoded at the boundary.
+func (d *Store) ExportIssueEmbeddings(ctx context.Context, f db.ExportFilter) iter.Seq2[db.IssueEmbeddingExport, error] {
+	query := `SELECT i.uid, e.embedded_content_revision, e.embed_fingerprint, e.dims, e.vector_bytes
+	          FROM issue_embeddings e
+	          JOIN issues i ON i.id = e.issue_id` +
+		exportWhere("i", f) + ` ORDER BY i.id ASC`
+	return streamRows(ctx, d.readQ, "issue_embeddings", query, exportArgs(f),
+		func(rows *sql.Rows) (db.IssueEmbeddingExport, error) {
+			var rec db.IssueEmbeddingExport
+			var raw []byte
+			if err := rows.Scan(&rec.IssueUID, &rec.EmbeddedContentRevision, &rec.Fingerprint, &rec.Dims, &raw); err != nil {
+				return db.IssueEmbeddingExport{}, scanError("issue_embedding", err)
+			}
+			rec.VectorB64 = base64.StdEncoding.EncodeToString(raw)
+			return rec, nil
+		})
+}

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -1441,6 +1441,7 @@ func reconcileFederatedIssues(
 				string(metadata),
 			}
 			args := append([]any{}, issueValues...)
+			args = append(args, issue.Title, issue.Body)
 			args = append(args, row.id)
 			args = append(args, issueValues...)
 			_, err := tx.ExecContext(ctx, `
@@ -1458,7 +1459,11 @@ func reconcileFederatedIssues(
 				       closed_at = ?,
 					       deleted_at = ?,
 					       metadata = ?,
-					       revision = revision + 1
+					       revision = revision + 1,
+					       content_revision = content_revision + CASE
+					           WHEN title IS NOT ? OR body IS NOT ? THEN 1
+					           ELSE 0
+					       END
 					 WHERE id = ?
 					   AND (
 					       short_id IS NOT ? OR

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -2890,6 +2890,8 @@ func TestMaterializeFederatedProject_ReconcilesExistingRowsAndEdges(t *testing.T
 	assert.Equal(t, "remote title", reconciled.Title)
 	assert.Equal(t, "remote body", reconciled.Body)
 	assert.Greater(t, reconciled.Revision, issue.Revision)
+	assert.Greater(t, contentRev(ctx, t, d, issue.ID), contentRev(ctx, t, d, peer.ID),
+		"federated title/body update must mark embeddings stale")
 	reconciledRevision := reconciled.Revision
 
 	require.NoError(t, d.MaterializeFederatedProject(ctx, p.ID))

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -20,7 +20,7 @@ import (
 func TestFederationSchemaVersionAndTable(t *testing.T) {
 	d := openTestDB(t)
 
-	assert.Equal(t, 21, db.CurrentSchemaVersion())
+	assert.Equal(t, 22, db.CurrentSchemaVersion())
 	assertSchemaVersion(t, d, db.CurrentSchemaVersion())
 	assertSchemaObject(t, d, "federation_bindings")
 	assertSchemaObject(t, d, "idx_federation_bindings_role_enabled")

--- a/internal/db/sqlitestore/github_sync_test.go
+++ b/internal/db/sqlitestore/github_sync_test.go
@@ -17,11 +17,11 @@ func TestGitHubSyncSchemaVersion(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
 
-	assert.Equal(t, 21, db.CurrentSchemaVersion())
+	assert.Equal(t, 22, db.CurrentSchemaVersion())
 	got, err := d.SchemaVersion(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 21, got)
-	assertSchemaVersion(t, d, 21)
+	assert.Equal(t, 22, got)
+	assertSchemaVersion(t, d, 22)
 }
 
 func TestGitHubSyncEnableAndReenableSameRepository(t *testing.T) {

--- a/internal/db/sqlitestore/import_replay.go
+++ b/internal/db/sqlitestore/import_replay.go
@@ -3,6 +3,7 @@ package sqlitestore
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -142,6 +143,8 @@ func importRecord(ctx context.Context, tx *sql.Tx, r db.ImportRecord, opts db.Im
 		return linkSkipNone, importRecurrence(ctx, tx, r.Recurrence)
 	case db.ImportKindIssue:
 		return linkSkipNone, importIssue(ctx, tx, r.Issue)
+	case db.ImportKindIssueEmbedding:
+		return linkSkipNone, importIssueEmbedding(ctx, tx, r.IssueEmbedding)
 	case db.ImportKindComment:
 		return linkSkipNone, importComment(ctx, tx, r.Comment)
 	case db.ImportKindIssueLabel:
@@ -340,13 +343,47 @@ func importIssue(ctx context.Context, tx *sql.Tx, i *db.IssueExport) error {
 	}
 	_, err := tx.ExecContext(ctx,
 		`INSERT INTO issues(id, uid, project_id, short_id, title, body, status, closed_reason, owner, priority, author,
-		                    created_at, updated_at, closed_at, deleted_at, metadata, revision,
+		                    created_at, updated_at, closed_at, deleted_at, metadata, revision, content_revision,
 		                    recurrence_id, occurrence_key)
-		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		i.ID, i.UID, i.ProjectID, i.ShortID, i.Title, i.Body, i.Status, i.ClosedReason,
 		i.Owner, i.Priority, i.Author, i.CreatedAt, i.UpdatedAt, i.ClosedAt, i.DeletedAt,
-		string(metadata), revision, recurrenceID, i.OccurrenceKey)
+		string(metadata), revision, i.ContentRevision, recurrenceID, i.OccurrenceKey)
 	return wrapImportErr(db.ImportKindIssue, err)
+}
+
+// importIssueEmbedding resolves the embedding's issue_uid to a local id and
+// inserts the row. It silently drops (returns nil without inserting) when the
+// parent issue is absent — a project-scoped export can carry an embedding whose
+// issue lives in an omitted project — or when embedded_content_revision exceeds
+// the imported issue's content_revision, which only happens for a corrupt or
+// hand-edited dump; the reconciler re-embeds such an issue on its next sweep.
+// A malformed base64 vector is a hard error: it is a structurally invalid
+// envelope, not recoverable derived state.
+func importIssueEmbedding(ctx context.Context, tx *sql.Tx, e *db.IssueEmbeddingExport) error {
+	var issueID, contentRevision int64
+	err := tx.QueryRowContext(ctx,
+		`SELECT id, content_revision FROM issues WHERE uid = ?`, e.IssueUID).Scan(&issueID, &contentRevision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return wrapImportErr(db.ImportKindIssueEmbedding, err)
+	}
+	if e.EmbeddedContentRevision > contentRevision {
+		return nil
+	}
+	vec, err := base64.StdEncoding.DecodeString(e.VectorB64)
+	if err != nil {
+		return wrapImportErr(db.ImportKindIssueEmbedding,
+			fmt.Errorf("issue %s: decode vector_b64: %w", e.IssueUID, err))
+	}
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO issue_embeddings
+		   (issue_id, embedded_content_revision, embed_fingerprint, dims, vector_bytes, updated_at)
+		 VALUES(?, ?, ?, ?, ?, ?)`,
+		issueID, e.EmbeddedContentRevision, e.Fingerprint, e.Dims, vec, nowTimestamp())
+	return wrapImportErr(db.ImportKindIssueEmbedding, err)
 }
 
 func importComment(ctx context.Context, tx *sql.Tx, c *db.CommentExport) error {

--- a/internal/db/sqlitestore/imports.go
+++ b/internal/db/sqlitestore/imports.go
@@ -445,7 +445,7 @@ func (d *Store) updateImportedIssue(ctx context.Context, tx *sql.Tx, p db.Import
 }
 
 func (d *Store) updateImportedPresentationTitle(ctx context.Context, tx *sql.Tx, p db.ImportBatchParams, item db.ImportItem, existing db.Issue, projectName string) (db.Issue, db.Event, error) {
-	_, err := tx.ExecContext(ctx, `UPDATE issues SET title = ? WHERE id = ?`, item.Title, existing.ID)
+	_, err := tx.ExecContext(ctx, `UPDATE issues SET title = ?, content_revision = content_revision + 1 WHERE id = ?`, item.Title, existing.ID)
 	if err != nil {
 		return db.Issue{}, db.Event{}, fmt.Errorf("update imported title: %w", err)
 	}

--- a/internal/db/sqlitestore/imports.go
+++ b/internal/db/sqlitestore/imports.go
@@ -416,8 +416,15 @@ func (d *Store) updateImportedIssue(ctx context.Context, tx *sql.Tx, p db.Import
 	if item.CreatedAt.Before(createdAt) {
 		createdAt = item.CreatedAt
 	}
+	// Bump content_revision only when the embeddable text actually changes,
+	// mirroring editIssue. The fragment is a fixed literal with no bound
+	// value, so it never widens the args list. See docs/design/semantic-search.md.
+	bump := ""
+	if item.Title != existing.Title || item.Body != existing.Body {
+		bump = `, content_revision = content_revision + 1`
+	}
 	_, err := tx.ExecContext(ctx, `UPDATE issues
-		SET title = ?, body = ?, status = ?, closed_reason = ?, owner = ?, created_at = ?, updated_at = ?, closed_at = ?, priority = ?
+		SET title = ?, body = ?, status = ?, closed_reason = ?, owner = ?, created_at = ?, updated_at = ?, closed_at = ?, priority = ?`+bump+`
 		WHERE id = ?`, item.Title, item.Body, item.Status, item.ClosedReason, normalizeOwner(item.Owner), createdAt, item.UpdatedAt, item.ClosedAt, item.Priority, existing.ID)
 	if err != nil {
 		return db.Issue{}, db.Event{}, fmt.Errorf("update imported issue: %w", err)

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -1532,6 +1532,9 @@ func (d *Store) editIssue(ctx context.Context, p db.EditIssueParams) (db.Issue, 
 	}
 	sets = append([]string{`updated_at = ?`}, sets...)
 	args = append([]any{ts}, args...)
+	if contentFieldsChanged(issue, p.Title, p.Body) {
+		sets = append(sets, `content_revision = content_revision + 1`)
+	}
 	args = append(args, p.IssueID)
 	// `sets` only contains string literals chosen above; user-provided values
 	// are parameterized via `args`. Safe to concatenate.
@@ -1566,6 +1569,20 @@ func (d *Store) editIssue(ctx context.Context, p db.EditIssueParams) (db.Issue, 
 // of falling back to the event's independently clocked created_at.
 func nowTimestamp() string {
 	return time.Now().UTC().Format(sqliteTimeFormat)
+}
+
+// contentFieldsChanged reports whether a title or body edit actually changes
+// the embeddable content of issue. It is the precise trigger for bumping
+// issues.content_revision; owner, priority, status, comments, links, and
+// metadata deliberately do not bump it. See docs/design/semantic-search.md.
+func contentFieldsChanged(issue db.Issue, title, body *string) bool {
+	if title != nil && *title != issue.Title {
+		return true
+	}
+	if body != nil && *body != issue.Body {
+		return true
+	}
+	return false
 }
 
 func issueFieldUpdatePlan(issue db.Issue, title, body, owner *string, ts string) ([]string, []any, string, bool, error) {

--- a/internal/db/sqlitestore/queries_edit_atomic.go
+++ b/internal/db/sqlitestore/queries_edit_atomic.go
@@ -65,6 +65,9 @@ func (d *Store) editIssueAtomic(ctx context.Context, p db.EditIssueAtomicParams)
 	if fieldsChanged {
 		sets = append([]string{`updated_at = ?`}, sets...)
 		args = append([]any{ts}, args...)
+		if contentFieldsChanged(issue, p.Title, p.Body) {
+			sets = append(sets, `content_revision = content_revision + 1`)
+		}
 		args = append(args, p.IssueID)
 		// `sets` only contains fixed string literals; user values are bound
 		// via `args`. Concatenation is safe.

--- a/internal/db/sqlitestore/queries_embeddings.go
+++ b/internal/db/sqlitestore/queries_embeddings.go
@@ -1,0 +1,252 @@
+package sqlitestore
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+// vectorToBytes serializes float32s little-endian. The schema CHECK requires
+// length(vector_bytes) = dims * 4, so the caller must pass len(v) == dims.
+func vectorToBytes(v []float32) []byte {
+	b := make([]byte, len(v)*4)
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(b[i*4:], math.Float32bits(f))
+	}
+	return b
+}
+
+// bytesToVector is the little-endian inverse of vectorToBytes. A trailing
+// partial group (len not a multiple of 4) is dropped; the schema CHECK keeps
+// stored blobs aligned to dims*4, so this only guards against corruption. A
+// nil/empty blob yields a nil vector (vector_bytes is NOT NULL, so this is
+// defensive only).
+func bytesToVector(b []byte) []float32 {
+	if len(b) < 4 {
+		return nil
+	}
+	v := make([]float32, len(b)/4)
+	for i := range v {
+		v[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
+	return v
+}
+
+// UpsertIssueEmbedding inserts or replaces the embedding row for an issue. The
+// conflict target is issue_id, so each issue holds at most one vector; a model
+// swap overwrites the prior vector and fingerprint in place.
+func (d *Store) UpsertIssueEmbedding(ctx context.Context, e db.IssueEmbedding) error {
+	return d.RetryTransient(ctx, func() error {
+		_, err := d.ExecContext(ctx, `
+			INSERT INTO issue_embeddings
+			  (issue_id, embedded_content_revision, embed_fingerprint, dims, vector_bytes, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?)
+			ON CONFLICT(issue_id) DO UPDATE SET
+			  embedded_content_revision = excluded.embedded_content_revision,
+			  embed_fingerprint = excluded.embed_fingerprint,
+			  dims = excluded.dims,
+			  vector_bytes = excluded.vector_bytes,
+			  updated_at = excluded.updated_at`,
+			e.IssueID, e.EmbeddedContentRevision, e.Fingerprint, e.Dims,
+			vectorToBytes(e.Vector), nowTimestamp())
+		if err != nil {
+			return fmt.Errorf("upsert issue embedding: %w", err)
+		}
+		d.vectorCache.invalidate(e.Fingerprint)
+		return nil
+	})
+}
+
+// ListEmbedTargets returns issues that are missing an embedding, embedded under
+// a different fingerprint, or whose content_revision has moved since they were
+// embedded. Soft-deleted issues are excluded. Results are ordered by issue id
+// so the reconciler makes deterministic forward progress.
+func (d *Store) ListEmbedTargets(ctx context.Context, fingerprint string, limit int) ([]db.EmbedTarget, error) {
+	if limit <= 0 {
+		limit = 64
+	}
+	rows, err := d.QueryContext(ctx, `
+		SELECT i.id, i.content_revision, i.title, i.body
+		FROM issues i
+		LEFT JOIN issue_embeddings e ON e.issue_id = i.id
+		WHERE i.deleted_at IS NULL
+		  AND (e.issue_id IS NULL
+		       OR e.embed_fingerprint != ?
+		       OR e.embedded_content_revision != i.content_revision)
+		ORDER BY i.id ASC
+		LIMIT ?`, fingerprint, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list embed targets: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []db.EmbedTarget
+	for rows.Next() {
+		var t db.EmbedTarget
+		if err := rows.Scan(&t.IssueID, &t.ContentRevision, &t.Title, &t.Body); err != nil {
+			return nil, fmt.Errorf("scan embed target: %w", err)
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// EmbeddingStats returns the count and max updated_at of embedding rows for a
+// project at the active fingerprint — the per-query cache freshness probe. The
+// max is empty when no rows exist.
+func (d *Store) EmbeddingStats(ctx context.Context, projectID int64, fingerprint string) (int64, string, error) {
+	var count int64
+	var maxUpdated *string
+	err := d.QueryRowContext(ctx, `
+		SELECT count(*), max(e.updated_at)
+		FROM issue_embeddings e
+		JOIN issues i ON i.id = e.issue_id
+		WHERE i.project_id = ? AND e.embed_fingerprint = ?`,
+		projectID, fingerprint).Scan(&count, &maxUpdated)
+	if err != nil {
+		return 0, "", fmt.Errorf("embedding stats: %w", err)
+	}
+	if maxUpdated == nil {
+		return count, "", nil
+	}
+	return count, *maxUpdated, nil
+}
+
+// SearchVector returns up to k issues ranked by cosine similarity to queryVec,
+// scoped to projectID and the active fingerprint. Vectors are cached per
+// (project, fingerprint); the cache supplies candidates and similarities only.
+// Visibility and row data always come from a live join against issues, so
+// soft-delete/restore/purge can never surface a wrong result.
+func (d *Store) SearchVector(ctx context.Context, projectID int64, queryVec []float32, fingerprint string, k int, includeDeleted bool) ([]db.SearchCandidate, error) {
+	if k <= 0 {
+		k = 20
+	}
+	count, maxUpdated, err := d.EmbeddingStats(ctx, projectID, fingerprint)
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	vecs, ok := d.vectorCache.get(projectID, fingerprint, count, maxUpdated)
+	if !ok {
+		vecs, err = d.loadVectors(ctx, projectID, fingerprint)
+		if err != nil {
+			return nil, err
+		}
+		d.vectorCache.put(projectID, fingerprint, count, maxUpdated, vecs)
+	}
+
+	// Rank all candidates by dot product (vectors are L2-normalized → cosine).
+	ranked := make([]scoredVec, 0, len(vecs))
+	for _, cv := range vecs {
+		ranked = append(ranked, scoredVec{issueID: cv.issueID, score: dot(queryVec, cv.vec)})
+	}
+	sortScoredVecDesc(ranked)
+
+	// Walk ranked candidates, resolving each against the live issues table
+	// until k visible rows are collected. This is a deliberate N+1: one live
+	// lookup per surviving candidate, bounded by k (the walk stops once k
+	// visible rows are collected). Acceptable at brute-force scale; a batched
+	// WHERE id IN (...) resolve is a future option if k or the survivor count
+	// grows large.
+	out := make([]db.SearchCandidate, 0, k)
+	for _, s := range ranked {
+		if len(out) >= k {
+			break
+		}
+		iss, err := d.liveIssue(ctx, projectID, s.issueID, includeDeleted)
+		if err != nil {
+			return nil, err
+		}
+		if iss == nil {
+			continue // purged or (when !includeDeleted) soft-deleted
+		}
+		out = append(out, db.SearchCandidate{Issue: *iss, Score: s.score, MatchedIn: []string{"semantic"}})
+	}
+	return out, nil
+}
+
+// loadVectors reads every stored vector for a project at the active fingerprint,
+// joined against issues so vectors for purged issues are excluded. Visibility
+// (soft-delete) is resolved later, per result, in liveIssue.
+func (d *Store) loadVectors(ctx context.Context, projectID int64, fingerprint string) ([]cachedVec, error) {
+	rows, err := d.QueryContext(ctx, `
+		SELECT e.issue_id, e.vector_bytes
+		FROM issue_embeddings e
+		JOIN issues i ON i.id = e.issue_id
+		WHERE i.project_id = ? AND e.embed_fingerprint = ?`,
+		projectID, fingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("load vectors: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []cachedVec
+	for rows.Next() {
+		var id int64
+		var b []byte
+		if err := rows.Scan(&id, &b); err != nil {
+			return nil, fmt.Errorf("scan vector: %w", err)
+		}
+		out = append(out, cachedVec{issueID: id, vec: bytesToVector(b)})
+	}
+	return out, rows.Err()
+}
+
+// liveIssue returns the issue if visible, or nil if absent/soft-deleted (when
+// includeDeleted is false). Uses the shared issueSelect for full row data. The
+// project filter is defense-in-depth: callers already scope candidate
+// retrieval by project, but binding i.project_id here — matching SearchFTS —
+// enforces the cross-project invariant at the point of trust, so a foreign id
+// can never resolve.
+func (d *Store) liveIssue(ctx context.Context, projectID, id int64, includeDeleted bool) (*db.Issue, error) {
+	where := ` WHERE i.id = ? AND i.project_id = ?`
+	if !includeDeleted {
+		where += ` AND i.deleted_at IS NULL`
+	}
+	iss, err := scanIssue(d.QueryRowContext(ctx, issueSelect+where, id, projectID))
+	if errorsIsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &iss, nil
+}
+
+// scoredVec pairs an issue id with its similarity score for ranking.
+type scoredVec struct {
+	issueID int64
+	score   float64
+}
+
+// sortScoredVecDesc orders by descending score, breaking ties by ascending
+// issue id so results are deterministic.
+func sortScoredVecDesc(xs []scoredVec) {
+	sort.SliceStable(xs, func(i, j int) bool {
+		if xs[i].score != xs[j].score {
+			return xs[i].score > xs[j].score
+		}
+		return xs[i].issueID < xs[j].issueID
+	})
+}
+
+func dot(a, b []float32) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+	var s float64
+	for i := range a {
+		s += float64(a[i]) * float64(b[i])
+	}
+	return s
+}
+
+// errorsIsNotFound reports whether err is db.ErrNotFound. scanIssue returns
+// that sentinel when a row is absent; liveIssue treats it as "not visible"
+// rather than a query failure.
+func errorsIsNotFound(err error) bool { return errors.Is(err, db.ErrNotFound) }

--- a/internal/db/sqlitestore/queries_embeddings.go
+++ b/internal/db/sqlitestore/queries_embeddings.go
@@ -73,8 +73,10 @@ func (d *Store) ListEmbedTargets(ctx context.Context, fingerprint string, limit 
 	rows, err := d.QueryContext(ctx, `
 		SELECT i.id, i.content_revision, i.title, i.body
 		FROM issues i
+		JOIN projects p ON p.id = i.project_id
 		LEFT JOIN issue_embeddings e ON e.issue_id = i.id
 		WHERE i.deleted_at IS NULL
+		  AND p.deleted_at IS NULL
 		  AND (e.issue_id IS NULL
 		       OR e.embed_fingerprint != ?
 		       OR e.embedded_content_revision != i.content_revision)

--- a/internal/db/sqlitestore/queries_embeddings_internal_test.go
+++ b/internal/db/sqlitestore/queries_embeddings_internal_test.go
@@ -1,0 +1,53 @@
+package sqlitestore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+)
+
+// TestLiveIssueEnforcesProjectFilter pins liveIssue's `i.project_id = ?`
+// clause directly. The external-package TestSearchVectorIsolatesProjects
+// passes even with that clause removed, because loadVectors already scopes
+// candidate retrieval by project — the foreign id never reaches liveIssue
+// through SearchVector. This test calls liveIssue with a deliberately
+// cross-project id so the project filter is the only thing standing between
+// the query and a foreign row.
+func TestLiveIssueEnforcesProjectFilter(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("KATA_HOME", t.TempDir())
+	d, err := Open(ctx, filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	projA, err := d.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	projB, err := d.CreateProject(ctx, "hub-project")
+	require.NoError(t, err)
+
+	_, _, err = d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: projA.ID, Title: "a", Body: "b", Author: "tester",
+	})
+	require.NoError(t, err)
+	issB, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: projB.ID, Title: "b", Body: "b", Author: "tester",
+	})
+	require.NoError(t, err)
+
+	// Resolving issue B's id against project A must return (nil, nil): the
+	// project filter rejects the foreign id even though the row exists and is
+	// live. Without `i.project_id = ?`, this would return B's row.
+	got, err := d.liveIssue(ctx, projA.ID, issB.ID, false)
+	require.NoError(t, err)
+	require.Nilf(t, got, "liveIssue must not resolve an id from another project")
+
+	// Sanity: B's id does resolve under its own project, so the nil above is
+	// the project filter at work, not a missing row.
+	got, err = d.liveIssue(ctx, projB.ID, issB.ID, false)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, issB.ID, got.ID)
+}

--- a/internal/db/sqlitestore/queries_embeddings_test.go
+++ b/internal/db/sqlitestore/queries_embeddings_test.go
@@ -1,0 +1,369 @@
+package sqlitestore_test
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/sqlitestore"
+)
+
+// repeat63 is 63 zero characters; prefixing one distinguishing character makes
+// a 64-char fingerprint that satisfies the schema's length(embed_fingerprint)=64
+// CHECK.
+const repeat63 = "000000000000000000000000000000000000000000000000000000000000000"
+
+// mkEmbeddingIssue creates an issue with a non-empty title and body so the
+// embed-target text columns are populated.
+func mkEmbeddingIssue(ctx context.Context, t *testing.T, d *sqlitestore.Store, projID int64, title string) db.Issue {
+	t.Helper()
+	iss, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: projID, Title: title, Body: "body", Author: "tester",
+	})
+	require.NoError(t, err)
+	return iss
+}
+
+func TestListEmbedTargetsAndUpsert(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	iss := mkEmbeddingIssue(ctx, t, d, proj.ID, "needs embedding")
+	fp := "a" + repeat63
+
+	// Initially: the issue is a target (no embedding row yet).
+	targets, err := d.ListEmbedTargets(ctx, fp, 10)
+	require.NoError(t, err)
+	require.Lenf(t, targets, 1, "expected the fresh issue to be a target")
+	require.Equal(t, iss.ID, targets[0].IssueID)
+	require.Equal(t, "needs embedding", targets[0].Title)
+	require.Equal(t, "body", targets[0].Body)
+
+	// Upsert an embedding at the issue's current content_revision.
+	require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+		IssueID: iss.ID, EmbeddedContentRevision: targets[0].ContentRevision,
+		Fingerprint: fp, Dims: 2, Vector: []float32{1, 0},
+	}))
+
+	// Now it is not a target.
+	targets, err = d.ListEmbedTargets(ctx, fp, 10)
+	require.NoError(t, err)
+	require.Emptyf(t, targets, "expected no targets after upsert")
+
+	// Editing the title makes it a target again (content_revision moved).
+	nt := "edited"
+	_, _, _, err = d.EditIssue(ctx, db.EditIssueParams{IssueID: iss.ID, Title: &nt, Actor: "tester"})
+	require.NoError(t, err)
+	targets, err = d.ListEmbedTargets(ctx, fp, 10)
+	require.NoError(t, err)
+	require.Lenf(t, targets, 1, "expected the stale issue to be a target after a title edit")
+	require.Equal(t, "edited", targets[0].Title)
+
+	// A different fingerprint sees the issue as a target (model swap).
+	targets, err = d.ListEmbedTargets(ctx, "b"+repeat63, 10)
+	require.NoError(t, err)
+	require.Lenf(t, targets, 1, "a fingerprint swap must re-target every issue")
+}
+
+func TestUpsertIssueEmbeddingReplacesRowAndRoundTripsVector(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	iss := mkEmbeddingIssue(ctx, t, d, proj.ID, "vec")
+	fp := "a" + repeat63
+
+	readVector := func() (int, []float32) {
+		t.Helper()
+		var dims int
+		var raw []byte
+		require.NoError(t, d.QueryRowContext(ctx,
+			`SELECT dims, vector_bytes FROM issue_embeddings WHERE issue_id = ?`, iss.ID).
+			Scan(&dims, &raw))
+		out := make([]float32, len(raw)/4)
+		for i := range out {
+			out[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[i*4:]))
+		}
+		return dims, out
+	}
+
+	first := []float32{0.6, 0.8}
+	require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+		IssueID: iss.ID, EmbeddedContentRevision: 0, Fingerprint: fp, Dims: 2, Vector: first,
+	}))
+	gotDims, gotVec := readVector()
+	require.Equal(t, 2, gotDims)
+	require.InDelta(t, float64(first[0]), float64(gotVec[0]), 1e-6)
+	require.InDelta(t, float64(first[1]), float64(gotVec[1]), 1e-6)
+
+	// The conflict target is issue_id, so a second upsert replaces the row,
+	// including dims and the vector blob.
+	second := []float32{1, 0, 0}
+	require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+		IssueID: iss.ID, EmbeddedContentRevision: 0, Fingerprint: fp, Dims: 3, Vector: second,
+	}))
+	gotDims, gotVec = readVector()
+	require.Equal(t, 3, gotDims)
+	require.Len(t, gotVec, 3)
+	require.InDelta(t, 1.0, float64(gotVec[0]), 1e-6)
+
+	// Exactly one row per issue.
+	var rows int
+	require.NoError(t, d.QueryRowContext(ctx,
+		`SELECT count(*) FROM issue_embeddings WHERE issue_id = ?`, iss.ID).Scan(&rows))
+	require.Equal(t, 1, rows)
+}
+
+func TestListEmbedTargetsExcludesSoftDeleted(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	live := mkEmbeddingIssue(ctx, t, d, proj.ID, "live")
+	gone := mkEmbeddingIssue(ctx, t, d, proj.ID, "gone")
+	fp := "a" + repeat63
+
+	_, _, _, err := d.SoftDeleteIssue(ctx, gone.ID, "tester")
+	require.NoError(t, err)
+
+	targets, err := d.ListEmbedTargets(ctx, fp, 10)
+	require.NoError(t, err)
+	require.Lenf(t, targets, 1, "soft-deleted issues must not be embed targets")
+	require.Equal(t, live.ID, targets[0].IssueID)
+}
+
+func TestListEmbedTargetsRespectsLimit(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	for i := 0; i < 5; i++ {
+		mkEmbeddingIssue(ctx, t, d, proj.ID, "issue")
+	}
+	fp := "a" + repeat63
+
+	targets, err := d.ListEmbedTargets(ctx, fp, 2)
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+}
+
+func TestSearchVectorRanksAndRespectsVisibility(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	fp := "a" + repeat63
+
+	near := mkEmbeddingIssue(ctx, t, d, proj.ID, "near")
+	far := mkEmbeddingIssue(ctx, t, d, proj.ID, "far")
+	embed := func(iss db.Issue, v []float32) {
+		cr := contentRev(ctx, t, d, iss.ID)
+		require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+			IssueID: iss.ID, EmbeddedContentRevision: cr, Fingerprint: fp, Dims: 2, Vector: v,
+		}))
+	}
+	embed(near, []float32{1, 0})
+	embed(far, []float32{0, 1})
+
+	// Query close to "near".
+	hits, err := d.SearchVector(ctx, proj.ID, []float32{1, 0}, fp, 10, false)
+	require.NoError(t, err)
+	require.Lenf(t, hits, 2, "both embedded issues should rank")
+	require.Equalf(t, near.ID, hits[0].Issue.ID, "the nearer vector must rank first")
+	require.Greaterf(t, hits[0].Score, hits[1].Score, "similarity must be strictly descending")
+	for _, h := range hits {
+		require.Equalf(t, []string{"semantic"}, h.MatchedIn, "matched_in must be the semantic leg")
+	}
+
+	// Soft-delete "near": it must drop out (visibility resolved live).
+	_, _, _, err = d.SoftDeleteIssue(ctx, near.ID, "tester")
+	require.NoError(t, err)
+	hits, err = d.SearchVector(ctx, proj.ID, []float32{1, 0}, fp, 10, false)
+	require.NoError(t, err)
+	require.Lenf(t, hits, 1, "a soft-deleted issue must not surface")
+	require.Equal(t, far.ID, hits[0].Issue.ID)
+
+	// A wrong-fingerprint query returns nothing (no cross-model compare).
+	hits, err = d.SearchVector(ctx, proj.ID, []float32{1, 0}, "b"+repeat63, 10, false)
+	require.NoError(t, err)
+	require.Emptyf(t, hits, "a different fingerprint must not match any vector")
+}
+
+func TestSearchVectorIsolatesProjects(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	projA := createProject(ctx, t, d, "spoke-project")
+	projB := createProject(ctx, t, d, "hub-project")
+	fp := "a" + repeat63
+
+	// Same fingerprint, same vector, one issue in each project. The cosine
+	// scores are identical, so only the project scope can separate them.
+	issA := mkEmbeddingIssue(ctx, t, d, projA.ID, "shared-A")
+	issB := mkEmbeddingIssue(ctx, t, d, projB.ID, "shared-B")
+	embed := func(iss db.Issue, v []float32) {
+		cr := contentRev(ctx, t, d, iss.ID)
+		require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+			IssueID: iss.ID, EmbeddedContentRevision: cr, Fingerprint: fp, Dims: 2, Vector: v,
+		}))
+	}
+	embed(issA, []float32{1, 0})
+	embed(issB, []float32{1, 0})
+
+	// A search scoped to project A returns only A's issue, never B's.
+	hits, err := d.SearchVector(ctx, projA.ID, []float32{1, 0}, fp, 10, false)
+	require.NoError(t, err)
+	require.Lenf(t, hits, 1, "project A search must see exactly one issue")
+	require.Equalf(t, issA.ID, hits[0].Issue.ID, "project A search must return A's issue")
+
+	// And the reverse: a search scoped to project B returns only B's issue.
+	hits, err = d.SearchVector(ctx, projB.ID, []float32{1, 0}, fp, 10, false)
+	require.NoError(t, err)
+	require.Lenf(t, hits, 1, "project B search must see exactly one issue")
+	require.Equalf(t, issB.ID, hits[0].Issue.ID, "project B search must return B's issue")
+}
+
+func TestSearchVectorRefillsPastSoftDeletedTopHits(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	fp := "a" + repeat63
+
+	// Five issues with strictly decreasing similarity to the query [1, 0]:
+	// the dot product with [1, 0] is just the first component, so issues[0]
+	// is the closest and issues[4] the farthest.
+	firstComponents := []float32{1.0, 0.9, 0.8, 0.7, 0.6}
+	issues := make([]db.Issue, len(firstComponents))
+	for i, x := range firstComponents {
+		iss := mkEmbeddingIssue(ctx, t, d, proj.ID, "issue")
+		issues[i] = iss
+		cr := contentRev(ctx, t, d, iss.ID)
+		require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+			IssueID: iss.ID, EmbeddedContentRevision: cr, Fingerprint: fp, Dims: 2,
+			Vector: []float32{x, float32(math.Sqrt(1 - float64(x)*float64(x)))},
+		}))
+	}
+
+	// Soft-delete the three closest (top-ranked) issues. With k=2, a naive
+	// walk that stopped at the first two ranked candidates would return zero
+	// live rows; the refill walk must continue past the deleted top hits.
+	for i := 0; i < 3; i++ {
+		_, _, _, err := d.SoftDeleteIssue(ctx, issues[i].ID, "tester")
+		require.NoError(t, err)
+	}
+
+	hits, err := d.SearchVector(ctx, proj.ID, []float32{1, 0}, fp, 2, false)
+	require.NoError(t, err)
+	require.Lenf(t, hits, 2, "refill must return exactly k live rows past the soft-deleted top hits")
+	// The two surviving issues, in rank order: issues[3] (0.7) then issues[4] (0.6).
+	require.Equalf(t, issues[3].ID, hits[0].Issue.ID, "first live hit must be the higher-ranked survivor")
+	require.Equalf(t, issues[4].ID, hits[1].Issue.ID, "second live hit must be the lower-ranked survivor")
+	require.Greaterf(t, hits[0].Score, hits[1].Score, "survivors must remain in descending rank order")
+}
+
+func TestSearchVectorReflectsReEmbedAfterCacheWarm(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	fp := "a" + repeat63
+
+	a := mkEmbeddingIssue(ctx, t, d, proj.ID, "a")
+	b := mkEmbeddingIssue(ctx, t, d, proj.ID, "b")
+	embed := func(iss db.Issue, v []float32) {
+		cr := contentRev(ctx, t, d, iss.ID)
+		require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+			IssueID: iss.ID, EmbeddedContentRevision: cr, Fingerprint: fp, Dims: 2, Vector: v,
+		}))
+	}
+	// Initially a is nearer to the query [1, 0] than b.
+	embed(a, []float32{1, 0})
+	embed(b, []float32{0, 1})
+
+	// Warm the cache: this first search loads and caches the vector set with a
+	// ranking (a before b).
+	hits, err := d.SearchVector(ctx, proj.ID, []float32{1, 0}, fp, 10, false)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	require.Equalf(t, a.ID, hits[0].Issue.ID, "a should rank first before the re-embed")
+
+	// Re-embed to flip the ranking: tilt a off-axis (worse) and align b on-axis
+	// (best). The upsert must invalidate the cache, and the (count, maxUpdated)
+	// freshness probe is the backstop, so the next search reflects the NEW
+	// order — not the stale cached ranking that put a first.
+	embed(a, []float32{0.6, 0.8})
+	embed(b, []float32{1, 0})
+	hits, err = d.SearchVector(ctx, proj.ID, []float32{1, 0}, fp, 10, false)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	require.Equalf(t, b.ID, hits[0].Issue.ID, "re-embed must flip the ranking; cache was not invalidated")
+	require.Greaterf(t, hits[0].Score, hits[1].Score, "scores must reflect the re-embedded vectors")
+}
+
+func TestSearchVectorIncludeDeletedSurfacesSoftDeletedAndCapsK(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	fp := "a" + repeat63
+
+	near := mkEmbeddingIssue(ctx, t, d, proj.ID, "near")
+	far := mkEmbeddingIssue(ctx, t, d, proj.ID, "far")
+	embed := func(iss db.Issue, v []float32) {
+		cr := contentRev(ctx, t, d, iss.ID)
+		require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+			IssueID: iss.ID, EmbeddedContentRevision: cr, Fingerprint: fp, Dims: 2, Vector: v,
+		}))
+	}
+	embed(near, []float32{1, 0})
+	embed(far, []float32{0.5, float32(math.Sqrt(1 - 0.25))})
+
+	// Soft-delete the top hit.
+	_, _, _, err := d.SoftDeleteIssue(ctx, near.ID, "tester")
+	require.NoError(t, err)
+
+	// includeDeleted=true: the soft-deleted top hit must still surface, ranked
+	// first (covers the includeDeleted branch of liveIssue).
+	hits, err := d.SearchVector(ctx, proj.ID, []float32{1, 0}, fp, 10, true)
+	require.NoError(t, err)
+	require.Lenf(t, hits, 2, "includeDeleted must surface the soft-deleted issue")
+	require.Equalf(t, near.ID, hits[0].Issue.ID, "soft-deleted top hit must rank first under includeDeleted")
+	require.Equal(t, far.ID, hits[1].Issue.ID)
+
+	// k=1 caps to exactly the single top result.
+	hits, err = d.SearchVector(ctx, proj.ID, []float32{1, 0}, fp, 1, true)
+	require.NoError(t, err)
+	require.Lenf(t, hits, 1, "k=1 must cap to exactly one result")
+	require.Equal(t, near.ID, hits[0].Issue.ID)
+}
+
+func TestEmbeddingStats(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	proj := createProject(ctx, t, d, "spoke-project")
+	other := createProject(ctx, t, d, "hub-project")
+	fp := "a" + repeat63
+
+	// No embeddings yet: zero count, empty maxUpdatedAt.
+	count, maxUpdated, err := d.EmbeddingStats(ctx, proj.ID, fp)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+	require.Empty(t, maxUpdated)
+
+	a := mkEmbeddingIssue(ctx, t, d, proj.ID, "a")
+	b := mkEmbeddingIssue(ctx, t, d, proj.ID, "b")
+	otherIss := mkEmbeddingIssue(ctx, t, d, other.ID, "c")
+	for _, iss := range []db.Issue{a, b, otherIss} {
+		require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+			IssueID: iss.ID, EmbeddedContentRevision: 0, Fingerprint: fp, Dims: 2, Vector: []float32{1, 0},
+		}))
+	}
+
+	// Stats are scoped to the project and the fingerprint.
+	count, maxUpdated, err = d.EmbeddingStats(ctx, proj.ID, fp)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), count)
+	require.NotEmpty(t, maxUpdated)
+
+	// A different fingerprint sees nothing for this project.
+	count, maxUpdated, err = d.EmbeddingStats(ctx, proj.ID, "b"+repeat63)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+	require.Empty(t, maxUpdated)
+}

--- a/internal/db/sqlitestore/queries_embeddings_test.go
+++ b/internal/db/sqlitestore/queries_embeddings_test.go
@@ -133,6 +133,28 @@ func TestListEmbedTargetsExcludesSoftDeleted(t *testing.T) {
 	require.Equal(t, live.ID, targets[0].IssueID)
 }
 
+func TestListEmbedTargetsExcludesArchivedProjects(t *testing.T) {
+	ctx := context.Background()
+	d := openTestDB(t)
+	liveProj := createProject(ctx, t, d, "spoke-project")
+	archivedProj := createProject(ctx, t, d, "hub-project")
+	live := mkEmbeddingIssue(ctx, t, d, liveProj.ID, "live")
+	mkEmbeddingIssue(ctx, t, d, archivedProj.ID, "archived")
+	fp := "a" + repeat63
+
+	_, _, err := d.RemoveProject(ctx, db.RemoveProjectParams{
+		ProjectID: archivedProj.ID,
+		Actor:     "tester",
+		Force:     true,
+	})
+	require.NoError(t, err)
+
+	targets, err := d.ListEmbedTargets(ctx, fp, 10)
+	require.NoError(t, err)
+	require.Lenf(t, targets, 1, "issues in archived projects must not be embed targets")
+	require.Equal(t, live.ID, targets[0].IssueID)
+}
+
 func TestListEmbedTargetsRespectsLimit(t *testing.T) {
 	ctx := context.Background()
 	d := openTestDB(t)

--- a/internal/db/sqlitestore/queries_search.go
+++ b/internal/db/sqlitestore/queries_search.go
@@ -105,7 +105,7 @@ func (d *Store) searchFTS(ctx context.Context, r searchFTSReq) ([]db.SearchCandi
 	// column on contentless tables. Each subquery returns 1 if the row's
 	// title/body/comments column matches the per-column phrase, 0 otherwise.
 	query := fmt.Sprintf(`
-		SELECT i.id, i.project_id, i.short_id, i.title, i.body, i.status,
+		SELECT i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status,
 		       i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision,
 		       i.recurrence_id, i.occurrence_key,
 		       i.created_at, i.updated_at, i.closed_at, i.deleted_at,
@@ -115,6 +115,7 @@ func (d *Store) searchFTS(ctx context.Context, r searchFTSReq) ([]db.SearchCandi
 		       (issues_fts.rowid IN (SELECT rowid FROM issues_fts WHERE comments MATCH ?)) AS in_comments
 		FROM issues_fts
 		JOIN issues i ON i.id = issues_fts.rowid
+		JOIN projects p ON p.id = i.project_id
 		WHERE issues_fts MATCH ?
 		  AND i.project_id = ?
 		  %s
@@ -138,7 +139,7 @@ func (d *Store) searchFTS(ctx context.Context, r searchFTSReq) ([]db.SearchCandi
 			rawScore                    float64
 			inTitle, inBody, inComments bool
 		)
-		if err := rows.Scan(&i.ID, &i.ProjectID, &i.ShortID, &i.Title, &i.Body, &i.Status,
+		if err := rows.Scan(&i.ID, &i.UID, &i.ProjectID, &i.ProjectUID, &i.ShortID, &i.Title, &i.Body, &i.Status,
 			&i.ClosedReason, &i.Owner, &i.Priority, &i.Author, &i.Metadata, &i.Revision,
 			&i.RecurrenceID, &i.OccurrenceKey,
 			&i.CreatedAt, &i.UpdatedAt, &i.ClosedAt, &i.DeletedAt,

--- a/internal/db/sqlitestore/queries_search_test.go
+++ b/internal/db/sqlitestore/queries_search_test.go
@@ -129,6 +129,17 @@ func TestSearchFTS_FiltersByProject(t *testing.T) {
 	assert.Equal(t, p1.ID, got[0].Issue.ProjectID)
 }
 
+func TestSearchFTS_PopulatesIssueUIDs(t *testing.T) {
+	d, ctx, p := setupTestProject(t)
+	issue := createTesterIssueWithBody(ctx, t, d, p.ID, "login bug", "")
+
+	got, err := d.SearchFTS(ctx, p.ID, "login", 20, false)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, issue.UID, got[0].Issue.UID)
+	assert.Equal(t, p.UID, got[0].Issue.ProjectUID)
+}
+
 func TestSearchFTS_ExcludesDeletedByDefault(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
 	keep := createTesterIssueWithBody(ctx, t, d, p.ID, "keep login", "")

--- a/internal/db/sqlitestore/schema.sql
+++ b/internal/db/sqlitestore/schema.sql
@@ -47,6 +47,7 @@ CREATE TABLE issues (
   metadata      TEXT NOT NULL DEFAULT '{}'
                   CHECK (json_valid(metadata) AND json_type(metadata) = 'object'),
   revision      INTEGER NOT NULL DEFAULT 1,
+  content_revision INTEGER NOT NULL DEFAULT 0,
   recurrence_id   INTEGER REFERENCES recurrences(id) ON DELETE SET NULL,
   occurrence_key  TEXT,
   CHECK (length(uid) = 26),
@@ -69,6 +70,18 @@ CREATE UNIQUE INDEX uniq_issues_project_short_id
 CREATE UNIQUE INDEX issues_recurrence_occurrence_uniq
   ON issues(recurrence_id, occurrence_key)
   WHERE recurrence_id IS NOT NULL AND occurrence_key IS NOT NULL;
+
+-- Semantic search: one L2-normalized vector per issue. Canonical derived
+-- state; pgvector acceleration (Phase 2) is built from this, never instead.
+CREATE TABLE issue_embeddings (
+  issue_id                  INTEGER PRIMARY KEY REFERENCES issues(id) ON DELETE CASCADE,
+  embedded_content_revision INTEGER NOT NULL,
+  embed_fingerprint         TEXT NOT NULL CHECK (length(embed_fingerprint) = 64),
+  dims                      INTEGER NOT NULL CHECK (dims > 0),
+  vector_bytes              BLOB NOT NULL CHECK (length(vector_bytes) = dims * 4),
+  updated_at                TEXT NOT NULL
+);
+CREATE INDEX idx_issue_embeddings_fingerprint ON issue_embeddings(embed_fingerprint);
 
 CREATE TABLE comments (
   id         INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/db/sqlitestore/schema_completeness_test.go
+++ b/internal/db/sqlitestore/schema_completeness_test.go
@@ -12,9 +12,9 @@ import (
 // TestAllSchemaTablesExist guards against a future schema edit accidentally
 // dropping a table that Plan 1 doesn't actively exercise. Plan 1 reads/writes
 // projects, project_aliases, issues, comments, events, and meta. The other
-// names below (links, issue_labels, purge_log, issues_fts) are scaffolded by
-// schema.sql for later plans; this test is the only thing that catches a
-// silent removal.
+// names below (links, issue_labels, purge_log, issues_fts, issue_embeddings)
+// are scaffolded by schema.sql for later plans; this test is the only thing
+// that catches a silent removal.
 func TestAllSchemaTablesExist(t *testing.T) {
 	d := openTestDB(t)
 	wanted := []string{
@@ -25,6 +25,7 @@ func TestAllSchemaTablesExist(t *testing.T) {
 		"issue_sync_bindings", "issue_sync_status",
 		"issue_claims", "pending_claim_requests",
 		"meta", "issues_fts", "import_mappings", "recurrences",
+		"issue_embeddings",
 	}
 	for _, name := range wanted {
 		assertSchemaObject(t, d, name)

--- a/internal/db/sqlitestore/schema_embeddings_test.go
+++ b/internal/db/sqlitestore/schema_embeddings_test.go
@@ -1,0 +1,26 @@
+package sqlitestore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaHasEmbeddingSurface(t *testing.T) {
+	d := openTestDB(t)
+
+	// issues.content_revision exists and is NOT NULL.
+	assertColumn(t, d, "issues", "content_revision", "INTEGER", true)
+
+	// issue_embeddings table exists with its six expected columns.
+	assertSchemaObject(t, d, "issue_embeddings")
+	var n int
+	require.NoError(t, d.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM pragma_table_info('issue_embeddings')
+		   WHERE name IN ('issue_id','embedded_content_revision','embed_fingerprint',
+		                  'dims','vector_bytes','updated_at')`,
+	).Scan(&n))
+	assert.Equal(t, 6, n, "issue_embeddings must expose all six expected columns")
+}

--- a/internal/db/sqlitestore/store.go
+++ b/internal/db/sqlitestore/store.go
@@ -44,6 +44,7 @@ type Store struct {
 	instanceUID string
 	readOnly    bool
 	readQ       readQuerier
+	vectorCache *vectorCache
 }
 
 // readQuerier is the read-only query surface shared between *sql.DB and *sql.Tx.
@@ -97,7 +98,7 @@ func Open(ctx context.Context, path string, opts ...db.OpenOption) (*Store, erro
 		_ = sdb.Close()
 		return nil, fmt.Errorf("ping %s: %w", path, err)
 	}
-	d := &Store{DB: sdb, path: path}
+	d := &Store{DB: sdb, path: path, vectorCache: newVectorCache()}
 	d.readQ = sdb
 	if err := d.bootstrap(ctx); err != nil {
 		_ = sdb.Close()
@@ -267,7 +268,7 @@ func openReadOnly(ctx context.Context, path string) (*Store, error) {
 		_ = sdb.Close()
 		return nil, fmt.Errorf("ping read-only %s: %w", path, err)
 	}
-	s := &Store{DB: sdb, path: path, readOnly: true}
+	s := &Store{DB: sdb, path: path, readOnly: true, vectorCache: newVectorCache()}
 	s.readQ = sdb
 	return s, nil
 }

--- a/internal/db/sqlitestore/vector_cache.go
+++ b/internal/db/sqlitestore/vector_cache.go
@@ -1,0 +1,73 @@
+package sqlitestore
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// cachedVec is one issue's normalized vector held in memory. It carries only
+// the issue id and the vector, never any visibility or row data.
+type cachedVec struct {
+	issueID int64
+	vec     []float32
+}
+
+// cacheEntry is the cached vector set for one (projectID, fingerprint) plus the
+// freshness probe it was loaded under.
+type cacheEntry struct {
+	count      int64
+	maxUpdated string
+	vecs       []cachedVec
+}
+
+// vectorCache holds normalized vectors per (projectID, fingerprint) for the
+// brute-force vector search leg. It never holds visibility or row data:
+// SearchVector resolves candidate ids against the live issues table on every
+// call. Freshness is validated per query with a (count, maxUpdated) probe, so a
+// model swap (new fingerprint) lands in a fresh entry and the old one is
+// abandoned.
+type vectorCache struct {
+	mu      sync.Mutex
+	entries map[string]*cacheEntry
+}
+
+func newVectorCache() *vectorCache {
+	return &vectorCache{entries: map[string]*cacheEntry{}}
+}
+
+func cacheKey(projectID int64, fingerprint string) string {
+	return fmt.Sprintf("%d:%s", projectID, fingerprint)
+}
+
+// invalidate drops every cached entry for the given fingerprint, across all
+// projects. UpsertIssueEmbedding calls this after a write so the next query
+// reloads vectors; the per-query freshness probe is the backstop for any entry
+// this misses.
+func (c *vectorCache) invalidate(fingerprint string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	suffix := ":" + fingerprint
+	for k := range c.entries {
+		if strings.HasSuffix(k, suffix) {
+			delete(c.entries, k)
+		}
+	}
+}
+
+// get returns cached vectors when the probe matches; ok is false otherwise.
+func (c *vectorCache) get(projectID int64, fingerprint string, count int64, maxUpdated string) ([]cachedVec, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[cacheKey(projectID, fingerprint)]
+	if !ok || e.count != count || e.maxUpdated != maxUpdated {
+		return nil, false
+	}
+	return e.vecs, true
+}
+
+func (c *vectorCache) put(projectID int64, fingerprint string, count int64, maxUpdated string, vecs []cachedVec) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[cacheKey(projectID, fingerprint)] = &cacheEntry{count: count, maxUpdated: maxUpdated, vecs: vecs}
+}

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -147,6 +147,12 @@ type Storage interface {
 	SearchFTS(ctx context.Context, projectID int64, q string, limit int, includeDeleted bool) ([]SearchCandidate, error)
 	SearchFTSAny(ctx context.Context, projectID int64, q string, limit int, includeDeleted bool) ([]SearchCandidate, error)
 
+	// embeddings (semantic search)
+	UpsertIssueEmbedding(ctx context.Context, e IssueEmbedding) error
+	ListEmbedTargets(ctx context.Context, fingerprint string, limit int) ([]EmbedTarget, error)
+	EmbeddingStats(ctx context.Context, projectID int64, fingerprint string) (count int64, maxUpdatedAt string, err error)
+	SearchVector(ctx context.Context, projectID int64, queryVec []float32, fingerprint string, k int, includeDeleted bool) ([]SearchCandidate, error)
+
 	// import support
 	ImportBatch(ctx context.Context, p ImportBatchParams) (ImportBatchResult, []Event, error)
 	UpsertImportMapping(ctx context.Context, p ImportMappingParams) (ImportMapping, error)
@@ -241,6 +247,7 @@ type Storage interface {
 	ExportIssueSyncStatus(ctx context.Context, f ExportFilter) iter.Seq2[IssueSyncStatusExport, error]
 	ExportRecurrences(ctx context.Context, f ExportFilter) iter.Seq2[RecurrenceExport, error]
 	ExportIssues(ctx context.Context, f ExportFilter) iter.Seq2[IssueExport, error]
+	ExportIssueEmbeddings(ctx context.Context, f ExportFilter) iter.Seq2[IssueEmbeddingExport, error]
 	ExportComments(ctx context.Context, f ExportFilter) iter.Seq2[CommentExport, error]
 	ExportIssueLabels(ctx context.Context, f ExportFilter) iter.Seq2[IssueLabelExport, error]
 	ExportLinks(ctx context.Context, f ExportFilter) iter.Seq2[LinkExport, error]

--- a/internal/embedding/client.go
+++ b/internal/embedding/client.go
@@ -1,0 +1,219 @@
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/kata/internal/config"
+)
+
+// Config configures an embedding Client. BaseURL and Model are required by the
+// caller (daemon config validation enforces this). Dims defaults to 768.
+type Config struct {
+	BaseURL             string
+	Model               string
+	APIKey              string
+	Salt                string
+	Dims                int
+	BatchSize           int
+	Timeout             time.Duration
+	TrustPrivateNetwork bool
+}
+
+// Client calls an OpenAI-compatible /embeddings endpoint.
+type Client struct {
+	http      *http.Client
+	baseURL   string
+	model     string
+	salt      string
+	dims      int
+	batchSize int
+}
+
+const (
+	defaultDims      = 768
+	defaultBatchSize = 64
+	defaultTimeout   = 30 * time.Second
+)
+
+// New builds a Client with an origin-pinned HTTP transport. The API key is
+// attached only to the configured origin (see internal/config/bearer.go);
+// cross-origin redirects are refused.
+func New(cfg Config) (*Client, error) {
+	if strings.TrimSpace(cfg.BaseURL) == "" || strings.TrimSpace(cfg.Model) == "" {
+		return nil, fmt.Errorf("embedding: base_url and model are required")
+	}
+	dims := cfg.Dims
+	if dims <= 0 {
+		dims = defaultDims
+	}
+	batch := cfg.BatchSize
+	if batch <= 0 {
+		batch = defaultBatchSize
+	}
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	hc := &http.Client{Timeout: timeout}
+	if cfg.APIKey != "" {
+		if err := config.ConfigureBearerClientWithTrust(hc, cfg.BaseURL, cfg.APIKey, cfg.TrustPrivateNetwork); err != nil {
+			return nil, fmt.Errorf("embedding: configure client: %w", err)
+		}
+	}
+	return &Client{
+		http:      hc,
+		baseURL:   strings.TrimRight(cfg.BaseURL, "/"),
+		model:     cfg.Model,
+		salt:      cfg.Salt,
+		dims:      dims,
+		batchSize: batch,
+	}, nil
+}
+
+// Dims returns the configured/expected vector dimensionality.
+func (c *Client) Dims() int { return c.dims }
+
+// Fingerprint identifies the model/dims/recipe/salt of vectors this client
+// produces.
+func (c *Client) Fingerprint() string { return Fingerprint(c.model, c.dims, c.salt) }
+
+// BatchSize is the maximum number of inputs per request.
+func (c *Client) BatchSize() int { return c.batchSize }
+
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type embedResponse struct {
+	Data []struct {
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
+}
+
+// APIError is a non-2xx response from the embedding endpoint.
+type APIError struct {
+	StatusCode int
+	RetryAfter time.Duration
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("embedding endpoint returned %d: %s", e.StatusCode, e.Body)
+}
+
+// Definitive reports whether retrying is pointless without operator action.
+func (e *APIError) Definitive() bool {
+	switch e.StatusCode {
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	}
+	return false
+}
+
+// Embed returns one L2-normalized vector per input, preserving order. Inputs
+// are sent in batches of at most BatchSize.
+func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, 0, len(texts))
+	for start := 0; start < len(texts); start += c.batchSize {
+		end := start + c.batchSize
+		if end > len(texts) {
+			end = len(texts)
+		}
+		vecs, err := c.embedBatch(ctx, texts[start:end])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+func (c *Client) embedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	body, err := json.Marshal(embedRequest{Model: c.model, Input: texts})
+	if err != nil {
+		return nil, fmt.Errorf("embedding: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embedding: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// Cap the response read, but scale it to the expected payload: one vector
+	// per input at `dims` float32s, JSON-encoded (~16 bytes/float) plus 1 MiB
+	// of structural overhead. A fixed 1 MiB cap silently truncated common
+	// configs (e.g. 3072-dim models at batch 64 ≈ 3 MiB), surfacing as a
+	// misleading decode error.
+	maxBytes := int64(c.dims)*int64(len(texts))*16 + (1 << 20)
+	rb, _ := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
+	if resp.StatusCode != http.StatusOK {
+		return nil, &APIError{
+			StatusCode: resp.StatusCode,
+			RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+			Body:       string(rb),
+		}
+	}
+	var er embedResponse
+	if err := json.Unmarshal(rb, &er); err != nil {
+		return nil, fmt.Errorf("embedding: decode response: %w", err)
+	}
+	if len(er.Data) != len(texts) {
+		return nil, fmt.Errorf("embedding: got %d vectors for %d inputs", len(er.Data), len(texts))
+	}
+	vecs := make([][]float32, len(er.Data))
+	for i, d := range er.Data {
+		if len(d.Embedding) != c.dims {
+			return nil, fmt.Errorf("embedding: vector dims %d != configured %d", len(d.Embedding), c.dims)
+		}
+		vecs[i] = normalize(d.Embedding)
+	}
+	return vecs, nil
+}
+
+func parseRetryAfter(h string) time.Duration {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(h); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	// RFC 7231 also allows an HTTP-date form. Convert it to a delay; clamp a
+	// past date to 0 so callers never treat it as a negative backoff.
+	if t, err := http.ParseTime(h); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+func normalize(v []float32) []float32 {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	if sum == 0 {
+		return v
+	}
+	inv := float32(1 / math.Sqrt(sum))
+	out := make([]float32, len(v))
+	for i, x := range v {
+		out[i] = x * inv
+	}
+	return out
+}

--- a/internal/embedding/client.go
+++ b/internal/embedding/client.go
@@ -44,9 +44,9 @@ const (
 	defaultTimeout   = 30 * time.Second
 )
 
-// New builds a Client with an origin-pinned HTTP transport. The API key is
-// attached only to the configured origin (see internal/config/bearer.go);
-// cross-origin redirects are refused.
+// New builds a Client with an origin-pinned HTTP transport. Embedding request
+// bodies carry issue text, so target safety and redirect origin pinning apply
+// even when the endpoint does not use an API key.
 func New(cfg Config) (*Client, error) {
 	if strings.TrimSpace(cfg.BaseURL) == "" || strings.TrimSpace(cfg.Model) == "" {
 		return nil, fmt.Errorf("embedding: base_url and model are required")
@@ -63,11 +63,17 @@ func New(cfg Config) (*Client, error) {
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	hc := &http.Client{Timeout: timeout}
-	if cfg.APIKey != "" {
-		if err := config.ConfigureBearerClientWithTrust(hc, cfg.BaseURL, cfg.APIKey, cfg.TrustPrivateNetwork); err != nil {
-			return nil, fmt.Errorf("embedding: configure client: %w", err)
-		}
+	origin, err := config.BearerOriginForBaseURLWithTrust(cfg.BaseURL, cfg.TrustPrivateNetwork)
+	if err != nil {
+		return nil, fmt.Errorf("embedding: configure client: %w", err)
+	}
+	hc := &http.Client{
+		Timeout: timeout,
+		Transport: &embeddingTransport{
+			origin:              origin,
+			apiKey:              cfg.APIKey,
+			trustPrivateNetwork: cfg.TrustPrivateNetwork,
+		},
 	}
 	return &Client{
 		http:      hc,
@@ -77,6 +83,32 @@ func New(cfg Config) (*Client, error) {
 		dims:      dims,
 		batchSize: batch,
 	}, nil
+}
+
+type embeddingTransport struct {
+	base                http.RoundTripper
+	origin              string
+	apiKey              string
+	trustPrivateNetwork bool
+}
+
+func (t *embeddingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if err := config.CheckBearerTargetSafeURLWithTrust(req.URL, t.trustPrivateNetwork); err != nil {
+		return nil, err
+	}
+	if reqOrigin := req.URL.Scheme + "://" + req.URL.Host; reqOrigin != t.origin {
+		return nil, fmt.Errorf("refusing embedding request to origin %q - client is bound to embedding origin %q", reqOrigin, t.origin)
+	}
+	if t.apiKey == "" || req.Header.Get("Authorization") != "" {
+		return base.RoundTrip(req)
+	}
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+t.apiKey)
+	return base.RoundTrip(clone)
 }
 
 // Dims returns the configured/expected vector dimensionality.

--- a/internal/embedding/client_test.go
+++ b/internal/embedding/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -186,5 +187,41 @@ func TestEmbedKeyOnlyToConfiguredOrigin(t *testing.T) {
 	}
 	if gotAuth != "Bearer secret" {
 		t.Fatalf("auth header = %q", gotAuth)
+	}
+}
+
+func TestNewRejectsUnsafeBaseURLWithoutAPIKey(t *testing.T) {
+	_, err := New(Config{BaseURL: "http://example.com/v1", Model: "m", Dims: 2})
+	if err == nil {
+		t.Fatal("expected unsafe plaintext public URL to be rejected without an API key")
+	}
+}
+
+func TestEmbedRejectsCrossOriginRedirectWithoutAPIKey(t *testing.T) {
+	var redirected bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirected = true
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{"embedding": []float32{1, 0}}}})
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/embeddings", http.StatusTemporaryRedirect)
+	}))
+	defer redirector.Close()
+
+	c, err := New(Config{BaseURL: redirector.URL, Model: "m", Dims: 2})
+	if err != nil {
+		t.Fatalf("new embedding client: %v", err)
+	}
+	_, err = c.Embed(context.Background(), []string{"x"})
+	if err == nil {
+		t.Fatal("expected cross-origin redirect to be rejected without an API key")
+	}
+	if redirected {
+		t.Fatal("embedding payload followed cross-origin redirect")
+	}
+	if !strings.Contains(err.Error(), "origin") {
+		t.Fatalf("error = %v, want origin context", err)
 	}
 }

--- a/internal/embedding/client_test.go
+++ b/internal/embedding/client_test.go
@@ -1,0 +1,190 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func newFakeServer(t *testing.T, status int, body string, retryAfter string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if retryAfter != "" {
+			w.Header().Set("Retry-After", retryAfter)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestEmbedNormalizesVectors(t *testing.T) {
+	srv := newFakeServer(t, 200, `{"data":[{"embedding":[3,4]}]}`, "")
+	defer srv.Close()
+	c, err := New(Config{BaseURL: srv.URL, Model: "m", Dims: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vecs, err := c.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// [3,4] normalized is [0.6,0.8].
+	if math.Abs(float64(vecs[0][0])-0.6) > 1e-6 || math.Abs(float64(vecs[0][1])-0.8) > 1e-6 {
+		t.Fatalf("not normalized: %v", vecs[0])
+	}
+}
+
+func TestEmbedDimsMismatchErrors(t *testing.T) {
+	srv := newFakeServer(t, 200, `{"data":[{"embedding":[1,2,3]}]}`, "")
+	defer srv.Close()
+	c, _ := New(Config{BaseURL: srv.URL, Model: "m", Dims: 2})
+	_, err := c.Embed(context.Background(), []string{"x"})
+	if err == nil {
+		t.Fatal("expected dims-mismatch error")
+	}
+}
+
+func TestEmbed401IsDefinitive(t *testing.T) {
+	srv := newFakeServer(t, 401, `{"error":"bad key"}`, "")
+	defer srv.Close()
+	c, _ := New(Config{BaseURL: srv.URL, Model: "m", Dims: 2})
+	_, err := c.Embed(context.Background(), []string{"x"})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || !apiErr.Definitive() {
+		t.Fatalf("want definitive APIError, got %v", err)
+	}
+}
+
+func TestEmbed429CarriesRetryAfter(t *testing.T) {
+	srv := newFakeServer(t, 429, `{}`, "7")
+	defer srv.Close()
+	c, _ := New(Config{BaseURL: srv.URL, Model: "m", Dims: 2})
+	_, err := c.Embed(context.Background(), []string{"x"})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want APIError, got %v", err)
+	}
+	if apiErr.Definitive() {
+		t.Fatal("429 must not be definitive")
+	}
+	if apiErr.RetryAfter != 7*time.Second {
+		t.Fatalf("RetryAfter = %v, want 7s", apiErr.RetryAfter)
+	}
+}
+
+func TestEmbed429RetryAfterHTTPDate(t *testing.T) {
+	// A future HTTP-date Retry-After must be converted to a positive delay,
+	// bounded by the offset (plus a little slack for the round trip).
+	const offset = 30 * time.Second
+	future := time.Now().UTC().Add(offset).Format(http.TimeFormat)
+	srv := newFakeServer(t, 429, `{}`, future)
+	defer srv.Close()
+	c, _ := New(Config{BaseURL: srv.URL, Model: "m", Dims: 2})
+	_, err := c.Embed(context.Background(), []string{"x"})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want APIError, got %v", err)
+	}
+	if apiErr.RetryAfter <= 0 {
+		t.Fatalf("RetryAfter = %v, want a positive delay from the HTTP-date", apiErr.RetryAfter)
+	}
+	// http.TimeFormat has 1-second resolution, so the parsed instant can sit up
+	// to a second beyond `offset`; add slack for that plus request latency.
+	if apiErr.RetryAfter > offset+5*time.Second {
+		t.Fatalf("RetryAfter = %v, want <= %v", apiErr.RetryAfter, offset+5*time.Second)
+	}
+}
+
+func TestEmbed429RetryAfterPastHTTPDateClampsToZero(t *testing.T) {
+	// A past HTTP-date must clamp to 0, never a negative backoff.
+	past := time.Now().UTC().Add(-1 * time.Hour).Format(http.TimeFormat)
+	srv := newFakeServer(t, 429, `{}`, past)
+	defer srv.Close()
+	c, _ := New(Config{BaseURL: srv.URL, Model: "m", Dims: 2})
+	_, err := c.Embed(context.Background(), []string{"x"})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want APIError, got %v", err)
+	}
+	if apiErr.RetryAfter != 0 {
+		t.Fatalf("RetryAfter = %v, want 0 (past date clamped)", apiErr.RetryAfter)
+	}
+}
+
+func TestEmbedBatchesPreserveOrder(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		calls++
+		var req struct {
+			Model string   `json:"model"`
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		// Encode each input's position into a distinct raw vector so the test
+		// can verify global ordering even though the server sees only one batch
+		// per call. Input "n" -> raw vector [n+1, 1].
+		data := make([]map[string]any, len(req.Input))
+		for i, s := range req.Input {
+			n, err := strconv.Atoi(s)
+			if err != nil {
+				t.Errorf("input %q not an integer: %v", s, err)
+			}
+			data[i] = map[string]any{"embedding": []float32{float32(n + 1), 1}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+	defer srv.Close()
+
+	c, err := New(Config{BaseURL: srv.URL, Model: "m", Dims: 2, BatchSize: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs := []string{"0", "1", "2", "3", "4"}
+	vecs, err := c.Embed(context.Background(), inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != len(inputs) {
+		t.Fatalf("got %d vectors, want %d", len(vecs), len(inputs))
+	}
+	// 5 inputs at BatchSize 2 -> ceil(5/2) = 3 HTTP calls.
+	if calls != 3 {
+		t.Fatalf("server received %d calls, want 3", calls)
+	}
+	for i := range inputs {
+		want := normalize([]float32{float32(i + 1), 1})
+		if math.Abs(float64(vecs[i][0]-want[0])) > 1e-6 || math.Abs(float64(vecs[i][1]-want[1])) > 1e-6 {
+			t.Fatalf("vec[%d] = %v, want %v (out of order or wrong batch)", i, vecs[i], want)
+		}
+	}
+}
+
+func TestEmbedKeyOnlyToConfiguredOrigin(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{"embedding": []float32{1, 0}}}})
+	}))
+	defer srv.Close()
+	c, _ := New(Config{BaseURL: srv.URL, Model: "m", Dims: 2, APIKey: "secret"})
+	if _, err := c.Embed(context.Background(), []string{"x"}); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer secret" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+}

--- a/internal/embedding/recipe.go
+++ b/internal/embedding/recipe.go
@@ -1,0 +1,45 @@
+// Package embedding produces vector embeddings of issue text via an
+// OpenAI-compatible HTTP endpoint. It is storage-free: it imports neither
+// internal/db nor internal/daemon and operates on plain strings.
+package embedding
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// RecipeVersion is part of the fingerprint. Bump it when EmbedText changes,
+// so every stored embedding is recomputed against the new text recipe.
+const RecipeVersion = 1
+
+// maxEmbedChars caps the runes sent to the embedder. Most embedding models
+// truncate long inputs anyway; capping keeps batch payloads bounded.
+const maxEmbedChars = 8000
+
+// EmbedText is the v1 recipe: title and body joined, truncated on a rune
+// boundary. Comments are intentionally excluded (see the design note).
+func EmbedText(title, body string) string {
+	s := title + "\n\n" + body
+	r := []rune(s)
+	if len(r) > maxEmbedChars {
+		r = r[:maxEmbedChars]
+	}
+	return string(r)
+}
+
+// Fingerprint identifies the (model, dims, recipe, salt) tuple a vector was
+// produced under. A change in any component invalidates stored vectors. The
+// endpoint URL is deliberately excluded so moving a port or host does not
+// force a re-embed. salt is the operator's lever for "same model name,
+// different weights".
+//
+// model and salt are operator-supplied, so they are length-prefixed before
+// hashing: this makes the encoding unambiguous regardless of their bytes
+// (including NUL), so no two distinct component tuples can collide.
+func Fingerprint(model string, dims int, salt string) string {
+	h := sha256.New()
+	// hash.Hash.Write never returns an error, so the Fprintf result is discarded.
+	_, _ = fmt.Fprintf(h, "v%d|%d:%s|%d|%d:%s", RecipeVersion, len(model), model, dims, len(salt), salt)
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/embedding/recipe_test.go
+++ b/internal/embedding/recipe_test.go
@@ -1,0 +1,79 @@
+package embedding
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestEmbedTextJoinsAndTruncatesOnRuneBoundary(t *testing.T) {
+	got := EmbedText("Title", "Body")
+	if got != "Title\n\nBody" {
+		t.Fatalf("join: got %q", got)
+	}
+	// Use a 3-byte rune so a byte-based truncation (s[:maxEmbedChars]) would
+	// slice mid-rune and corrupt UTF-8. The recipe must cut on a rune boundary.
+	// "三" is 3 bytes; maxEmbedChars is not a multiple of 3, so a byte cut lands
+	// inside a rune.
+	long := strings.Repeat("三", maxEmbedChars+100)
+	out := EmbedText(long, "")
+	if !utf8.ValidString(out) {
+		t.Fatalf("truncation split a multi-byte rune: output is not valid UTF-8")
+	}
+	if n := utf8.RuneCountInString(out); n != maxEmbedChars {
+		t.Fatalf("truncation kept %d runes, want exactly %d", n, maxEmbedChars)
+	}
+}
+
+func TestFingerprintIsStableAndComponentSensitive(t *testing.T) {
+	base := Fingerprint("nomic-embed-text", 768, "")
+	if len(base) != 64 {
+		t.Fatalf("fingerprint length = %d, want 64", len(base))
+	}
+	if base == Fingerprint("other-model", 768, "") {
+		t.Fatal("model change did not alter fingerprint")
+	}
+	if base == Fingerprint("nomic-embed-text", 1024, "") {
+		t.Fatal("dims change did not alter fingerprint")
+	}
+	if base == Fingerprint("nomic-embed-text", 768, "salt") {
+		t.Fatal("salt change did not alter fingerprint")
+	}
+	if base != Fingerprint("nomic-embed-text", 768, "") {
+		t.Fatal("fingerprint not deterministic")
+	}
+}
+
+// TestFingerprintResistsComponentBoundaryCollisions pins the length-prefixed
+// encoding. A naive NUL-separated stream ("v%d\x00%s\x00%d\x00%s" over model,
+// dims, salt) lets the boundaries between components slide: distinct tuples can
+// serialize to the same byte stream and thus the same hash. The length prefixes
+// make every component's extent explicit, so no two distinct tuples collide.
+func TestFingerprintResistsComponentBoundaryCollisions(t *testing.T) {
+	// Under a NUL-joined encoding both of these produce the identical stream
+	// "...x\x001\x00p\x002\x00q": the first reads model="x", dims=1,
+	// salt="p\x002\x00q"; the second reads model="x\x001\x00p", dims=2,
+	// salt="q". Length prefixing forces a distinct serialization for each.
+	a := Fingerprint("x", 1, "p\x002\x00q")
+	b := Fingerprint("x\x001\x00p", 2, "q")
+	if a == b {
+		t.Fatal("NUL-boundary-sliding tuples collided: encoding is not length-prefixed")
+	}
+
+	// Components containing the delimiter bytes used by the length-prefixed
+	// format ("|", ":") and digits must not let a "shifted" decomposition of
+	// the salt collide with a different (model, salt) split.
+	c := Fingerprint("m|7", 768, "x")
+	d := Fingerprint("m", 768, "7|x")
+	if c == d {
+		t.Fatal("delimiter-bearing components collided across a shifted split")
+	}
+	// A digit run that abuts the dims field must not merge with it: model="m"
+	// followed by salt="1:24" must differ from model="m1", dims still distinct
+	// only by where the boundary falls.
+	e := Fingerprint("m", 124, "")
+	f := Fingerprint("m1", 24, "")
+	if e == f {
+		t.Fatal("digit-adjacent model/dims boundary collided")
+	}
+}

--- a/internal/jsonl/fixtures_test.go
+++ b/internal/jsonl/fixtures_test.go
@@ -253,6 +253,18 @@ func buildRichJSONLFixture(t *testing.T) richJSONLFixture {
 	addTesterComment(ctx, t, d, login.ID, "watermelon comment text")
 	addTesterComment(ctx, t, d, purged.ID, "purged comment text")
 
+	// Seed one embedding so the byte-equivalence round-trip exercises the
+	// issue_embeddings export/import path. content_revision is 0 here (the
+	// issue is unedited), which is the boundary case for the import's
+	// embedded_content_revision <= content_revision validation.
+	require.NoError(t, d.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+		IssueID:                 login.ID,
+		EmbeddedContentRevision: 0,
+		Fingerprint:             "e" + strings.Repeat("0", 63),
+		Dims:                    3,
+		Vector:                  []float32{0, 0, 1},
+	}))
+
 	_, _, err = d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
 		FromIssueID: blocker.ID,
 		ToIssueID:   login.ID,
@@ -504,6 +516,7 @@ func dropV10Additions(t *testing.T, raw *sql.DB) {
 		`DROP TABLE recurrences`,
 		`ALTER TABLE issues DROP COLUMN metadata`,
 		`ALTER TABLE issues DROP COLUMN revision`,
+		`ALTER TABLE issues DROP COLUMN content_revision`,
 		`DROP INDEX IF EXISTS projects_area`,
 		`ALTER TABLE projects DROP COLUMN metadata`,
 		`ALTER TABLE projects DROP COLUMN revision`,

--- a/internal/jsonl/import.go
+++ b/internal/jsonl/import.go
@@ -258,6 +258,12 @@ func toImportRecord(env Envelope, exportVersion int, localInstanceUID string, pr
 		}
 		i := rec.IssueExport
 		return db.ImportRecord{Kind: string(KindIssue), Issue: &i}, nil
+	case KindIssueEmbedding:
+		var rec db.IssueEmbeddingExport
+		if err := decodeData(env, &rec); err != nil {
+			return db.ImportRecord{}, err
+		}
+		return db.ImportRecord{Kind: string(KindIssueEmbedding), IssueEmbedding: &rec}, nil
 	case KindComment:
 		var rec db.CommentExport
 		if err := decodeData(env, &rec); err != nil {

--- a/internal/jsonl/roundtrip_embeddings_test.go
+++ b/internal/jsonl/roundtrip_embeddings_test.go
@@ -1,0 +1,106 @@
+package jsonl_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/jsonl"
+)
+
+// repeat63jsonl is a 63-char zero run; prefixing a leading char yields a
+// 64-char fingerprint that satisfies the schema CHECK.
+const repeat63jsonl = "000000000000000000000000000000000000000000000000000000000000000"
+
+// TestEmbeddingsRoundTripPreservesContentRevision proves the JSONL export
+// carries issues.content_revision and the issue_embeddings rows, so an issue
+// that was edited (content_revision > 0) then embedded is not falsely stale
+// after a cutover/backup round-trip: ListEmbedTargets must return nothing for
+// it under the same fingerprint.
+func TestEmbeddingsRoundTripPreservesContentRevision(t *testing.T) {
+	ctx := context.Background()
+	src := openExportTestDB(t)
+	proj, err := src.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	iss, _, err := src.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: proj.ID, Title: "t", Body: "b", Author: "a",
+	})
+	require.NoError(t, err)
+	nt := "edited"
+	_, _, _, err = src.EditIssue(ctx, db.EditIssueParams{IssueID: iss.ID, Title: &nt, Actor: "a"})
+	require.NoError(t, err)
+
+	var cr int64
+	require.NoError(t, src.QueryRowContext(ctx,
+		`SELECT content_revision FROM issues WHERE id=?`, iss.ID).Scan(&cr))
+	require.Greater(t, cr, int64(0), "edit must bump content_revision above zero")
+
+	fp := "a" + repeat63jsonl
+	require.NoError(t, src.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+		IssueID: iss.ID, EmbeddedContentRevision: cr, Fingerprint: fp, Dims: 2, Vector: []float32{1, 0},
+	}))
+
+	var buf bytes.Buffer
+	require.NoError(t, jsonl.Export(ctx, src, &buf, jsonl.ExportOptions{}))
+
+	dst := openImportTargetDB(t)
+	require.NoError(t, jsonl.Import(ctx, &buf, dst))
+
+	// Imported issue carries content_revision, so the imported embedding is
+	// NOT stale: ListEmbedTargets returns nothing under the same fingerprint.
+	targets, err := dst.ListEmbedTargets(ctx, fp, 10)
+	require.NoError(t, err)
+	require.Empty(t, targets, "imported embedding falsely stale")
+
+	// And the vector survived the round-trip intact.
+	var dims int
+	var raw []byte
+	require.NoError(t, dst.QueryRowContext(ctx, `
+		SELECT e.dims, e.vector_bytes
+		  FROM issue_embeddings e
+		  JOIN issues i ON i.id = e.issue_id
+		 WHERE i.uid = ?`, iss.UID).Scan(&dims, &raw))
+	require.Equal(t, 2, dims)
+	require.Len(t, raw, 8, "2 float32 == 8 bytes")
+}
+
+// TestEmbeddingImportDropsRowExceedingContentRevision proves the import
+// validation: an embedding whose embedded_content_revision exceeds the
+// imported issue's content_revision (a corrupt or hand-edited dump) is dropped
+// and left for the reconciler rather than inserted.
+func TestEmbeddingImportDropsRowExceedingContentRevision(t *testing.T) {
+	ctx := context.Background()
+	src := openExportTestDB(t)
+	proj, err := src.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	iss, _, err := src.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: proj.ID, Title: "t", Body: "b", Author: "a",
+	})
+	require.NoError(t, err)
+	// content_revision is 0 (never edited); embed at 0 so the row is valid in
+	// the source DB (the CHECK is import-only).
+	fp := "a" + repeat63jsonl
+	require.NoError(t, src.UpsertIssueEmbedding(ctx, db.IssueEmbedding{
+		IssueID: iss.ID, EmbeddedContentRevision: 0, Fingerprint: fp, Dims: 2, Vector: []float32{1, 0},
+	}))
+	// Forge a future embedded_content_revision the imported issue can't match.
+	_, err = src.ExecContext(ctx,
+		`UPDATE issue_embeddings SET embedded_content_revision = 99 WHERE issue_id = ?`, iss.ID)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, jsonl.Export(ctx, src, &buf, jsonl.ExportOptions{}))
+
+	dst := openImportTargetDB(t)
+	require.NoError(t, jsonl.Import(ctx, &buf, dst))
+
+	var count int
+	require.NoError(t, dst.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM issue_embeddings e
+		  JOIN issues i ON i.id = e.issue_id
+		 WHERE i.uid = ?`, iss.UID).Scan(&count))
+	require.Equal(t, 0, count, "embedding exceeding content_revision must be dropped on import")
+}

--- a/internal/jsonl/roundtrip_test.go
+++ b/internal/jsonl/roundtrip_test.go
@@ -145,7 +145,7 @@ func TestRoundtrip_DuplicateTokenRevokedEventsKeepFirstRevokedAt(t *testing.T) {
 func assertRoundtripTableCounts(t *testing.T, src, dst *sqlitestore.Store) {
 	t.Helper()
 	for _, table := range []string{
-		"projects", "project_aliases", "issues", "comments", "issue_labels",
+		"projects", "project_aliases", "issues", "issue_embeddings", "comments", "issue_labels",
 		"links", "import_mappings", "federation_bindings", "federation_enrollments",
 		"federation_sync_status", "federation_quarantine", "issue_claims", "pending_claim_requests", "events", "purge_log",
 	} {

--- a/internal/jsonl/storage_export.go
+++ b/internal/jsonl/storage_export.go
@@ -76,6 +76,9 @@ func Export(ctx context.Context, store db.Storage, w io.Writer, opts ExportOptio
 	if err := streamExport(enc, KindIssue, store.ExportIssues(ctx, f)); err != nil {
 		return err
 	}
+	if err := streamExport(enc, KindIssueEmbedding, store.ExportIssueEmbeddings(ctx, f)); err != nil {
+		return err
+	}
 	if err := streamExport(enc, KindComment, store.ExportComments(ctx, f)); err != nil {
 		return err
 	}

--- a/internal/jsonl/types.go
+++ b/internal/jsonl/types.go
@@ -20,6 +20,7 @@ const (
 	KindGitHubSyncStatus     Kind = "github_sync_status"
 	KindRecurrence           Kind = "recurrence"
 	KindIssue                Kind = "issue"
+	KindIssueEmbedding       Kind = "issue_embedding"
 	KindComment              Kind = "comment"
 	KindIssueLabel           Kind = "issue_label"
 	KindLink                 Kind = "link"
@@ -53,20 +54,21 @@ var kindOrder = map[Kind]int{
 	KindGitHubSyncStatus:     4,
 	KindRecurrence:           5,
 	KindIssue:                6,
-	KindComment:              7,
-	KindIssueLabel:           8,
-	KindLink:                 9,
-	KindImportMapping:        10,
-	KindFederationBinding:    11,
-	KindFederationSyncStatus: 12,
-	KindFederationQuarantine: 13,
-	KindFederationEnrollment: 14,
-	KindIssueClaim:           15,
-	KindPendingClaimRequest:  16,
-	KindEvent:                17,
-	KindPurgeLog:             18,
-	KindProjectPurgeLog:      19,
-	KindSQLiteSequence:       20,
+	KindIssueEmbedding:       7,
+	KindComment:              8,
+	KindIssueLabel:           9,
+	KindLink:                 10,
+	KindImportMapping:        11,
+	KindFederationBinding:    12,
+	KindFederationSyncStatus: 13,
+	KindFederationQuarantine: 14,
+	KindFederationEnrollment: 15,
+	KindIssueClaim:           16,
+	KindPendingClaimRequest:  17,
+	KindEvent:                18,
+	KindPurgeLog:             19,
+	KindProjectPurgeLog:      20,
+	KindSQLiteSequence:       21,
 }
 
 // Envelope is one NDJSON record.

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -5143,6 +5143,7 @@ func (c *Client) SearchIssues(ctx context.Context, options *SearchIssuesRequestO
 	queryEncoding := map[string]runtime.QueryEncoding{
 		"include_deleted": {Style: "form", Explode: &[]bool{false}[0]},
 		"limit":           {Style: "form", Explode: &[]bool{false}[0]},
+		"mode":            {Style: "form", Explode: &[]bool{false}[0]},
 		"q":               {Style: "form", Explode: &[]bool{false}[0]},
 	}
 	reqParams := runtime.RequestOptionsParameters{

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -173,3 +173,22 @@ func (l ListIssuesQueryStatus) Validate() error {
 		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ListIssuesQueryStatus value, got: %v", l))
 	}
 }
+
+type SearchIssuesQueryMode string
+
+const (
+	Auto     SearchIssuesQueryMode = "auto"
+	Hybrid   SearchIssuesQueryMode = "hybrid"
+	Lexical  SearchIssuesQueryMode = "lexical"
+	Semantic SearchIssuesQueryMode = "semantic"
+)
+
+// Validate checks if the SearchIssuesQueryMode value is valid
+func (s SearchIssuesQueryMode) Validate() error {
+	switch s {
+	case Auto, Hybrid, Lexical, Semantic:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid SearchIssuesQueryMode value, got: %v", s))
+	}
+}

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -197,13 +197,28 @@ func (r RestoreProjectQuery) Validate() error {
 }
 
 type SearchIssuesQuery struct {
-	Q              string `json:"q" validate:"required"`
-	Limit          *int64 `json:"limit,omitempty"`
-	IncludeDeleted *bool  `json:"include_deleted,omitempty"`
+	Q              string                 `json:"q" validate:"required"`
+	Limit          *int64                 `json:"limit,omitempty"`
+	IncludeDeleted *bool                  `json:"include_deleted,omitempty"`
+	Mode           *SearchIssuesQueryMode `json:"mode,omitempty"`
 }
 
 func (s SearchIssuesQuery) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(s))
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(s.Q, "required"); err != nil {
+		errors = errors.Append("Q", err)
+	}
+	if s.Mode != nil {
+		if v, ok := any(s.Mode).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Mode", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type ReadyIssuesGlobalQuery struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -956,6 +956,13 @@ func (e EditIssueResponseBody) Validate() error {
 	return errors
 }
 
+type EmbeddingsHealth struct {
+	Backlog       int64      `json:"backlog"`
+	Configured    bool       `json:"configured"`
+	LastError     *string    `json:"last_error,omitempty"`
+	LastSuccessAt *time.Time `json:"last_success_at,omitempty"`
+}
+
 type EnableIssueSyncRequestBody struct {
 	Config          map[string]any `json:"config,omitempty"`
 	Interval        *string        `json:"interval,omitempty"`
@@ -1269,17 +1276,41 @@ func (f FederationViolationSummary) Validate() error {
 }
 
 type HealthResponseBody struct {
-	APISchemaVersion *string   `json:"api_schema_version,omitempty"`
-	DBPath           string    `json:"db_path" validate:"required"`
-	Ok               bool      `json:"ok"`
-	SchemaVersion    int64     `json:"schema_version"`
-	StartedAt        time.Time `json:"started_at" validate:"required"`
-	Uptime           string    `json:"uptime" validate:"required"`
-	Version          string    `json:"version" validate:"required"`
+	APISchemaVersion *string           `json:"api_schema_version,omitempty"`
+	DBPath           string            `json:"db_path" validate:"required"`
+	Embeddings       *EmbeddingsHealth `json:"embeddings,omitempty"`
+	Ok               bool              `json:"ok"`
+	SchemaVersion    int64             `json:"schema_version"`
+	StartedAt        time.Time         `json:"started_at" validate:"required"`
+	Uptime           string            `json:"uptime" validate:"required"`
+	Version          string            `json:"version" validate:"required"`
 }
 
 func (h HealthResponseBody) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(h))
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(h.DBPath, "required"); err != nil {
+		errors = errors.Append("DBPath", err)
+	}
+	if h.Embeddings != nil {
+		if v, ok := any(h.Embeddings).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Embeddings", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(h.StartedAt, "required"); err != nil {
+		errors = errors.Append("StartedAt", err)
+	}
+	if err := typesValidator.Var(h.Uptime, "required"); err != nil {
+		errors = errors.Append("Uptime", err)
+	}
+	if err := typesValidator.Var(h.Version, "required"); err != nil {
+		errors = errors.Append("Version", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type ImportBatchResult struct {
@@ -2871,12 +2902,18 @@ func (s SearchHit) Validate() error {
 }
 
 type SearchResponseBody struct {
-	Query   string      `json:"query" validate:"required"`
-	Results []SearchHit `json:"results,omitempty" validate:"required"`
+	Degraded       *bool       `json:"degraded,omitempty"`
+	DegradedReason *string     `json:"degraded_reason,omitempty"`
+	Mode           string      `json:"mode" validate:"required"`
+	Query          string      `json:"query" validate:"required"`
+	Results        []SearchHit `json:"results,omitempty" validate:"required"`
 }
 
 func (s SearchResponseBody) Validate() error {
 	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(s.Mode, "required"); err != nil {
+		errors = errors.Append("Mode", err)
+	}
 	if err := typesValidator.Var(s.Query, "required"); err != nil {
 		errors = errors.Append("Query", err)
 	}

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -957,10 +957,10 @@ func (e EditIssueResponseBody) Validate() error {
 }
 
 type EmbeddingsHealth struct {
-	Backlog       int64      `json:"backlog"`
-	Configured    bool       `json:"configured"`
-	LastError     *string    `json:"last_error,omitempty"`
-	LastSuccessAt *time.Time `json:"last_success_at,omitempty"`
+	Backlog         int64      `json:"backlog"`
+	Configured      bool       `json:"configured"`
+	LastErrorStatus *int64     `json:"last_error_status,omitempty"`
+	LastSuccessAt   *time.Time `json:"last_success_at,omitempty"`
 }
 
 type EnableIssueSyncRequestBody struct {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -738,6 +738,22 @@ components:
         - event
         - changed
       type: object
+    EmbeddingsHealth:
+      properties:
+        backlog:
+          format: int64
+          type: integer
+        configured:
+          type: boolean
+        last_error:
+          type: string
+        last_success_at:
+          format: date-time
+          type: string
+      required:
+        - configured
+        - backlog
+      type: object
     EnableIssueSyncRequestBody:
       additionalProperties: false
       properties:
@@ -1287,6 +1303,8 @@ components:
           type: string
         db_path:
           type: string
+        embeddings:
+          $ref: "#/components/schemas/EmbeddingsHealth"
         ok:
           type: boolean
         schema_version:
@@ -2999,6 +3017,12 @@ components:
       type: object
     SearchResponseBody:
       properties:
+        degraded:
+          type: boolean
+        degraded_reason:
+          type: string
+        mode:
+          type: string
         query:
           type: string
         results:
@@ -3008,6 +3032,7 @@ components:
           type: array
       required:
         - query
+        - mode
         - results
       type: object
     ShowIssueResponseBody:
@@ -5643,6 +5668,16 @@ paths:
           name: include_deleted
           schema:
             type: boolean
+        - explode: false
+          in: query
+          name: mode
+          schema:
+            enum:
+              - auto
+              - lexical
+              - hybrid
+              - semantic
+            type: string
       responses:
         "200":
           content:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -745,8 +745,9 @@ components:
           type: integer
         configured:
           type: boolean
-        last_error:
-          type: string
+        last_error_status:
+          format: int64
+          type: integer
         last_success_at:
           format: date-time
           type: string
@@ -3172,7 +3173,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.3.0
+  version: 0.4.0
 openapi: 3.0.3
 paths:
   /api/v1/audit/closes:

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -38,6 +38,8 @@ required_files=(
   "docs/design/hosted-mode.md"
   "docs/design/architecture.md"
   "docs/design/data-model.md"
+  "docs/design/semantic-search.md"
+  "docs/guide/semantic-search.md"
   "docs/reference/agent-output.md"
   "docs/stylesheets/extra.css"
 )
@@ -168,7 +170,8 @@ for generated in \
   docs/site/design/architecture/index.html \
   docs/site/design/data-model/index.html \
   docs/site/design/federation/index.html \
-  docs/site/design/hosted-mode/index.html; do
+  docs/site/design/hosted-mode/index.html \
+  docs/site/design/semantic-search/index.html; do
   if [[ ! -e "$generated" ]]; then
     printf 'generated site is missing design docs page: %s\n' "$generated" >&2
     exit 1


### PR DESCRIPTION
Adds opt-in hybrid (lexical + vector) semantic search. By default `kata search`
is lexical, so it misses issues that describe the same problem in different
words — the case that matters most when an agent searches before creating a
duplicate. With an embedding endpoint configured, a query like "auth redirect
duplicates" can surface an issue titled "Login callback double-submits on
Safari".

## What this adds

- A `[search.embeddings]` config section pointing at any OpenAI-compatible
  `/embeddings` endpoint (local Ollama/LM Studio/llama.cpp, or a hosted
  provider). With no section, nothing changes.
- Per-issue embeddings (title + body) kept fresh by a daemon reconciler, with
  its state reported under `embeddings` in `/health`.
- `kata search` fuses lexical and vector results (reciprocal rank fusion) in
  `auto` mode, with `--lexical`, `--hybrid`, and `--semantic` flags to force a
  strategy.
- Embeddings round-trip through JSONL export/import, so a backup or schema
  upgrade does not force a re-embed.
- A user guide (`docs/guide/semantic-search.md`) plus reference and config docs.

## Behavior reviewers should know

- Opt-in with no behavior change when unconfigured: lexical ranking and output
  are unchanged and the daemon makes no embedding network calls.
  `api_schema_version` moves to 0.3.0, `/health` gains an `embeddings` object,
  and the search response always carries an effective `mode`.
- Freshness is split by design: lexical results are available the instant an
  issue is written (create-then-search is unchanged), while the vector index is
  eventually consistent — an issue is never unsearchable because of embedding
  lag, only its semantic recall lags briefly.
- Degradation is labeled, never silent: `auto` falls back to lexical and sets
  `degraded` when the embedder is unreachable; explicit `--hybrid`/`--semantic`
  return 503 instead of degrading, and 400 when embeddings are not configured.
- The embedding API key is sent only to the configured endpoint origin; issue
  text leaves the host only when an endpoint is configured (the consent
  boundary). Embeddings are local derived state and do not federate.

## Scope

Phase 1 covers the SQLite backend end to end plus the backend-neutral
machinery. The PostgreSQL schema carries the same `content_revision` column and
`issue_embeddings` table, but accelerated vector search there (pgvector) and the
PG search methods are deferred to a Phase 2 change; the PG embedding/search
methods are stubs today.

Design rationale and internals: `docs/design/semantic-search.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
