### PR TITLE
Add Windows release installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,21 @@ contracts and UI details may still change before a stable release.
 
 ## Quick start
 
+Install the release binary:
+
 ```sh
 curl -fsSL https://katatracker.com/install.sh | bash
-# or: go install go.kenn.io/kata/cmd/kata@latest
+```
 
+Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://katatracker.com/install.ps1 | iex"
+```
+
+Then bind a workspace:
+
+```sh
 cd your-repo
 kata init                                    # bind this workspace to a kata project
 kata create "fix login race"                 # returns the issue's short_id, e.g. abc4
@@ -100,8 +111,14 @@ Linux, and Windows. Install the latest release binary:
 curl -fsSL https://katatracker.com/install.sh | bash
 ```
 
-The installer downloads the latest GitHub release archive for your platform and
-verifies it against `SHA256SUMS` before installing. Release builds can update
+Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://katatracker.com/install.ps1 | iex"
+```
+
+The installers download the latest GitHub release archive for your platform and
+verify it against `SHA256SUMS` before installing. Release builds can update
 themselves with `kata update`. Linux `.deb` and `.rpm` packages are published for `amd64` and `arm64`.
 
 If you prefer to install from source, kata needs **Go 1.26 or later**:

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -5,21 +5,32 @@ daemon it starts itself, and it stores data locally in SQLite.
 
 ## Requirements
 
-Install Go 1.26 or later from <https://go.dev/dl/>.
+The release installers below do not require Go. Install Go 1.26 or later from
+<https://go.dev/dl/> only when using `go install` or building from a clone.
 
 GitHub release binaries are available starting with `v0.5.0`. The recommended
-path for most users is the release installer:
+path for most users is the release installer for their platform.
+
+On macOS or Linux:
 
 ```sh
 curl -fsSL https://katatracker.com/install.sh | bash
 ```
 
-The installer detects your OS and CPU architecture and downloads the latest
+On Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://katatracker.com/install.ps1 | iex"
+```
+
+The installers detect your OS and CPU architecture and download the latest
 archive from [GitHub releases](https://github.com/kenn-io/kata/releases).
-The installer verifies the downloaded archive against `SHA256SUMS` before installing it.
-It places `kata` in `/usr/local/bin` or `~/.local/bin`. Review
-the installer at <https://katatracker.com/install.sh> before running it if you
-prefer.
+They verify the downloaded archive against `SHA256SUMS` before installing it.
+The shell installer places `kata` in `/usr/local/bin` or `~/.local/bin`.
+The PowerShell installer places `kata.exe` in `%USERPROFILE%\.kata\bin` by
+default and adds that directory to the user `Path`. Review the installers at
+<https://katatracker.com/install.sh> and <https://katatracker.com/install.ps1>
+before running them if you prefer.
 
 Linux `.deb` and `.rpm` packages are also published for `amd64` and `arm64`.
 Download the package for your distribution from

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -4,13 +4,19 @@ Install kata, enter a workspace, bind it to a kata project, and create your
 first issue:
 
 ```sh
-go install go.kenn.io/kata/cmd/kata@latest
+curl -fsSL https://katatracker.com/install.sh | bash
 
 cd your-repo
 kata init
 kata create "fix login race"
 kata list
 kata show abc4
+```
+
+On Windows PowerShell, install the release binary with:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://katatracker.com/install.ps1 | iex"
 ```
 
 `kata create` prints the issue's short ID. Use that short ID in later commands.

--- a/docs/scripts/check_vercel_redirects.py
+++ b/docs/scripts/check_vercel_redirects.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+import sys
+from typing import Any
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+VERCEL = ROOT / "vercel.json"
+
+TEMPORARY = {
+    "/install.sh": "https://raw.githubusercontent.com/kenn-io/kata/main/scripts/install.sh",
+    "/install.ps1": "https://raw.githubusercontent.com/kenn-io/kata/main/scripts/install.ps1",
+}
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def reject_json_constant(constant: str) -> None:
+    raise ValueError(f"non-finite numeric constant {constant}")
+
+
+def validate_finite_json_numbers(path: str, value: object) -> None:
+    if isinstance(value, bool):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            fail(f"{path} contains non-finite number")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            validate_finite_json_numbers(f"{path}.{key}", item)
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            validate_finite_json_numbers(f"{path}[{index}]", item)
+
+
+def load_vercel() -> dict[str, Any]:
+    try:
+        data = json.loads(
+            VERCEL.read_text(encoding="utf-8"),
+            parse_constant=reject_json_constant,
+        )
+    except FileNotFoundError:
+        fail("missing vercel.json")
+    except json.JSONDecodeError as error:
+        fail(f"invalid vercel.json: {error}")
+    except ValueError as error:
+        fail(f"invalid vercel.json: {error}")
+
+    if not isinstance(data, dict):
+        fail("vercel.json must contain an object")
+    validate_finite_json_numbers("vercel.json", data)
+    return data
+
+
+def collect_redirects(data: dict[str, object]) -> dict[str, dict[str, object]]:
+    raw_redirects = data.get("redirects", [])
+    if not isinstance(raw_redirects, list):
+        fail("vercel redirects must be a list")
+
+    redirects: dict[str, dict[str, object]] = {}
+    for index, item in enumerate(raw_redirects):
+        if not isinstance(item, dict):
+            fail(f"redirect entry {index} must be an object")
+        if set(item) != {"source", "destination", "permanent"}:
+            fail(f"redirect entry {index} must contain source, destination, and permanent only")
+        source = item.get("source")
+        destination = item.get("destination")
+        permanent = item.get("permanent")
+        if not isinstance(source, str) or not source:
+            fail(f"redirect entry {index} missing source")
+        if not isinstance(destination, str) or not destination:
+            fail(f"redirect entry {index} missing destination")
+        if not isinstance(permanent, bool):
+            fail(f"redirect entry {index} permanent must be boolean")
+        if source in redirects:
+            fail(f"duplicate redirect source {source}")
+        redirects[source] = item
+    return redirects
+
+
+def main() -> None:
+    data = load_vercel()
+    if "framework" not in data or data["framework"] is not None:
+        fail("vercel framework must be null")
+    if data.get("installCommand") != "uv sync --frozen --no-dev":
+        fail("unexpected Vercel installCommand")
+    if data.get("buildCommand") != "uv run --frozen bash ./vercel-build.sh":
+        fail("unexpected Vercel buildCommand")
+    if data.get("outputDirectory") != "site":
+        fail("unexpected Vercel outputDirectory")
+
+    redirects = collect_redirects(data)
+    for source, destination in TEMPORARY.items():
+        item = redirects.get(source)
+        if not item:
+            fail(f"missing temporary redirect {source}")
+        if item.get("destination") != destination or item.get("permanent") is not False:
+            fail(f"incorrect temporary redirect {source}")
+
+    print("vercel redirect checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -9,6 +9,11 @@
       "source": "/install.sh",
       "destination": "https://raw.githubusercontent.com/kenn-io/kata/main/scripts/install.sh",
       "permanent": false
+    },
+    {
+      "source": "/install.ps1",
+      "destination": "https://raw.githubusercontent.com/kenn-io/kata/main/scripts/install.ps1",
+      "permanent": false
     }
   ]
 }

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -25,6 +25,7 @@ required_files=(
   "docs/vercel.json"
   "docs/vercel-build.sh"
   "docs/zensical-docs.sh"
+  "docs/scripts/check_vercel_redirects.py"
   "scripts/update-docs.sh"
   "docs/pyproject.toml"
   "docs/uv.lock"
@@ -81,6 +82,8 @@ fi
 if [[ "$missing" -ne 0 ]]; then
   exit 1
 fi
+
+python3 docs/scripts/check_vercel_redirects.py
 
 stale_config="docs/.zensical-build.XXXXXX.toml"
 stale_docs="docs/zensical-public-docs.XXXXXX"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,329 @@
+# kata installer for Windows
+# Usage: powershell -ExecutionPolicy ByPass -c "irm https://katatracker.com/install.ps1 | iex"
+
+$ErrorActionPreference = 'Stop'
+
+$repo = 'kenn-io/kata'
+$binaryName = 'kata.exe'
+
+function Write-Info($msg) { Write-Host $msg -ForegroundColor Green }
+function Write-Warn($msg) { Write-Host $msg -ForegroundColor Yellow }
+function Write-Err($msg) { Write-Host $msg -ForegroundColor Red }
+
+function Test-EnvBool($name) {
+    $val = [Environment]::GetEnvironmentVariable($name)
+    return ($val -match '^(1|true|yes)$')
+}
+
+function Get-Architecture {
+    if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+        return 'arm64'
+    }
+
+    try {
+        $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+        switch ($arch.ToString()) {
+            'X64' { return 'amd64' }
+            'X86' { return '386' }
+            'Arm64' { return 'arm64' }
+            default { return 'amd64' }
+        }
+    } catch {
+        if ([System.Environment]::Is64BitOperatingSystem) {
+            return 'amd64'
+        } else {
+            return '386'
+        }
+    }
+}
+
+function Invoke-WebRequestCompat {
+    param([string]$Uri, [string]$OutFile)
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    }
+
+    $params = @{ Uri = $Uri }
+    if ($OutFile) { $params.OutFile = $OutFile }
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $params.UseBasicParsing = $true
+    }
+
+    if ($OutFile) {
+        Invoke-WebRequest @params
+    } else {
+        Invoke-RestMethod @params
+    }
+}
+
+function Get-FinalUrl {
+    param($Response)
+    try {
+        if ($Response.BaseResponse.ResponseUri) {
+            return $Response.BaseResponse.ResponseUri.AbsoluteUri
+        }
+    } catch {}
+    try {
+        if ($Response.BaseResponse.RequestMessage.RequestUri) {
+            return $Response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+        }
+    } catch {}
+    return $null
+}
+
+function Get-LatestVersion {
+    $url = "https://github.com/$repo/releases/latest"
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    }
+
+    $params = @{
+        Uri = $url
+        Method = 'Head'
+        ErrorAction = 'Stop'
+    }
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $params.UseBasicParsing = $true
+    }
+
+    $finalUrl = $null
+    try {
+        $response = Invoke-WebRequest @params
+        $finalUrl = Get-FinalUrl $response
+    } catch {
+        throw "Failed to fetch latest version: $_"
+    }
+
+    if (-not $finalUrl) {
+        throw "Failed to fetch latest version: could not resolve release URL from $url"
+    }
+    if ($finalUrl -notmatch '/releases/tag/([^/]+)/?$') {
+        throw "Failed to fetch latest version: unexpected release URL $finalUrl"
+    }
+    return $Matches[1]
+}
+
+function Test-ReleaseAsset {
+    param([string]$Url)
+
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    }
+
+    $params = @{
+        Uri = $Url
+        Method = 'Head'
+        ErrorAction = 'Stop'
+    }
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        $params.UseBasicParsing = $true
+    }
+
+    try {
+        $response = Invoke-WebRequest @params
+        return ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300)
+    } catch {
+        return $false
+    }
+}
+
+function Resolve-ReleaseArch {
+    param([string]$DetectedArch, [string]$Version)
+
+    $candidates = @($DetectedArch)
+    if ($DetectedArch -eq 'arm64') {
+        $candidates += 'amd64'
+    }
+
+    $versionNum = $Version.TrimStart('v')
+    foreach ($candidate in $candidates) {
+        $name = "kata_${versionNum}_windows_${candidate}.zip"
+        $url = "https://github.com/$repo/releases/download/$Version/$name"
+        if (Test-ReleaseAsset $url) {
+            return $candidate
+        }
+    }
+    return $null
+}
+
+function Get-InstallDir {
+    if ($env:KATA_INSTALL_DIR) {
+        return $env:KATA_INSTALL_DIR
+    }
+    return Join-Path $env:USERPROFILE '.kata\bin'
+}
+
+function Add-ToPath($dir) {
+    $currentPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+
+    $normalizedDir = $dir.TrimEnd('\', '/')
+    $alreadyInPath = $currentPath -split ';' | Where-Object {
+        $_.TrimEnd('\', '/') -ieq $normalizedDir
+    }
+    if ($alreadyInPath) {
+        Write-Info "Directory already in PATH"
+        return $false
+    }
+
+    $newPath = "$currentPath;$dir"
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    $env:Path = "$env:Path;$dir"
+
+    return $true
+}
+
+function Install-Kata {
+    Write-Info "Installing kata..."
+    Write-Host ""
+
+    $arch = Get-Architecture
+    Write-Info "Platform: windows/$arch"
+
+    if ($arch -eq '386') {
+        Write-Err "Error: 32-bit Windows is not supported."
+        Write-Err "kata requires 64-bit Windows (amd64 or arm64)."
+        exit 1
+    }
+
+    $version = Get-LatestVersion
+    Write-Info "Latest version: $version"
+
+    $resolvedArch = Resolve-ReleaseArch -DetectedArch $arch -Version $version
+    if (-not $resolvedArch) {
+        Write-Err "Error: No Windows release asset found for $version (detected windows/$arch)."
+        Write-Err "See https://github.com/$repo for build-from-source instructions."
+        exit 1
+    }
+    if ($resolvedArch -ne $arch) {
+        Write-Warn "No native windows/$arch build for $version; installing windows/$resolvedArch (runs under emulation)."
+        $arch = $resolvedArch
+    }
+
+    $versionNum = $version.TrimStart('v')
+    $archiveName = "kata_${versionNum}_windows_${arch}.zip"
+    $downloadUrl = "https://github.com/$repo/releases/download/$version/$archiveName"
+
+    $installDir = Get-InstallDir
+    Write-Info "Install directory: $installDir"
+    Write-Host ""
+
+    if (-not (Test-Path $installDir)) {
+        New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+    }
+
+    $tmpDir = Join-Path $env:TEMP "kata-install-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+
+    try {
+        $archivePath = Join-Path $tmpDir $archiveName
+
+        Write-Info "Downloading $archiveName..."
+        Invoke-WebRequestCompat -Uri $downloadUrl -OutFile $archivePath
+
+        $checksumUrl = "https://github.com/$repo/releases/download/$version/SHA256SUMS"
+        $checksumFile = Join-Path $tmpDir "SHA256SUMS"
+
+        Write-Info "Verifying checksum..."
+        try {
+            Invoke-WebRequestCompat -Uri $checksumUrl -OutFile $checksumFile
+        } catch {
+            Write-Err "Error: Could not download checksums file: $_"
+            exit 1
+        }
+
+        $matchingLines = @()
+        foreach ($line in Get-Content $checksumFile) {
+            if ($line -match '^\s*$') { continue }
+            $parts = $line -split '\s+', 2
+            if ($parts.Count -lt 2) { continue }
+            $hash = $parts[0]
+            $filename = $parts[1]
+            $filename = $filename -replace '^[\*]', ''
+            $filename = $filename -replace '^\.\/', ''
+            $filename = $filename -replace '^\.\\', ''
+            if ($filename -eq $archiveName) {
+                $matchingLines += $hash
+            }
+        }
+
+        if ($matchingLines.Count -eq 0) {
+            Write-Err "Error: Could not find checksum for $archiveName in SHA256SUMS"
+            exit 1
+        }
+
+        if ($matchingLines.Count -gt 1) {
+            Write-Err "Error: Multiple checksum entries found for $archiveName"
+            exit 1
+        }
+
+        $expectedHash = $matchingLines[0]
+        $actualHash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLower()
+
+        if ($actualHash -ne $expectedHash.ToLower()) {
+            Write-Err "Error: Checksum verification failed!"
+            Write-Err "Expected: $expectedHash"
+            Write-Err "Got:      $actualHash"
+            exit 1
+        }
+        Write-Info "Checksum verified."
+
+        Write-Info "Extracting..."
+        if ($PSVersionTable.PSVersion.Major -lt 5) {
+            Write-Err "Error: PowerShell 5.0 or later is required for Expand-Archive."
+            Write-Err "Please upgrade PowerShell or download the release manually from GitHub."
+            exit 1
+        }
+        try {
+            Expand-Archive -Path $archivePath -DestinationPath $tmpDir -Force
+        } catch {
+            Write-Err "Error: Failed to extract archive: $_"
+            exit 1
+        }
+
+        $binaryFile = Get-ChildItem -Path $tmpDir -Recurse -Filter $binaryName | Select-Object -First 1
+        if (-not $binaryFile) {
+            Write-Err "Error: Could not find $binaryName in extracted archive"
+            exit 1
+        }
+
+        $destPath = Join-Path $installDir $binaryName
+
+        if (Test-Path $destPath) {
+            Remove-Item $destPath -Force
+        }
+
+        Move-Item $binaryFile.FullName $destPath -Force
+
+        Write-Host ""
+        Write-Info "Installation complete!"
+        Write-Host ""
+
+        if (-not (Test-EnvBool 'KATA_NO_MODIFY_PATH')) {
+            $pathUpdated = Add-ToPath $installDir
+            if ($pathUpdated) {
+                Write-Info "Added $installDir to PATH"
+                Write-Warn "Restart your terminal for PATH changes to take effect."
+                Write-Host ""
+            }
+        }
+
+        Write-Host "Check the install:"
+        Write-Host "  kata version"
+        Write-Host "  kata update --check"
+        Write-Host ""
+        Write-Host "Get started:"
+        Write-Host "  cd your-repo"
+        Write-Host "  kata init"
+        Write-Host "  kata tui"
+
+    } finally {
+        if (Test-Path $tmpDir) {
+            Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Install-Kata

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -133,20 +133,47 @@ function Test-ReleaseAsset {
 function Resolve-ReleaseArch {
     param([string]$DetectedArch, [string]$Version)
 
-    $candidates = @($DetectedArch)
-    if ($DetectedArch -eq 'arm64') {
-        $candidates += 'amd64'
-    }
-
     $versionNum = $Version.TrimStart('v')
-    foreach ($candidate in $candidates) {
-        $name = "kata_${versionNum}_windows_${candidate}.zip"
-        $url = "https://github.com/$repo/releases/download/$Version/$name"
-        if (Test-ReleaseAsset $url) {
-            return $candidate
-        }
+    $name = "kata_${versionNum}_windows_${DetectedArch}.zip"
+    $url = "https://github.com/$repo/releases/download/$Version/$name"
+    if (Test-ReleaseAsset $url) {
+        return $DetectedArch
     }
     return $null
+}
+
+function Verify-Checksum {
+    param([string]$ArchivePath, [string]$ChecksumFile, [string]$ArchiveName)
+
+    $matchingLines = @()
+    foreach ($line in Get-Content $ChecksumFile) {
+        if ($line -match '^\s*$') { continue }
+        $parts = $line -split '\s+', 2
+        if ($parts.Count -lt 2) { continue }
+        $hash = $parts[0]
+        $filename = $parts[1]
+        $filename = $filename -replace '^[\*]', ''
+        $filename = $filename -replace '^\.\/', ''
+        $filename = $filename -replace '^\.\\', ''
+        if ($filename -eq $ArchiveName) {
+            $matchingLines += $hash
+        }
+    }
+
+    if ($matchingLines.Count -eq 0) {
+        throw "Could not find checksum for $ArchiveName in SHA256SUMS"
+    }
+
+    if ($matchingLines.Count -gt 1) {
+        throw "Multiple checksum entries found for $ArchiveName"
+    }
+
+    $expectedHash = $matchingLines[0]
+    $actualHash = (Get-FileHash -Path $ArchivePath -Algorithm SHA256).Hash.ToLower()
+
+    if ($actualHash -ne $expectedHash.ToLower()) {
+        throw "Checksum verification failed! Expected: $expectedHash Got: $actualHash"
+    }
 }
 
 function Get-InstallDir {
@@ -197,10 +224,7 @@ function Install-Kata {
         Write-Err "See https://github.com/$repo for build-from-source instructions."
         exit 1
     }
-    if ($resolvedArch -ne $arch) {
-        Write-Warn "No native windows/$arch build for $version; installing windows/$resolvedArch (runs under emulation)."
-        $arch = $resolvedArch
-    }
+    $arch = $resolvedArch
 
     $versionNum = $version.TrimStart('v')
     $archiveName = "kata_${versionNum}_windows_${arch}.zip"
@@ -234,38 +258,10 @@ function Install-Kata {
             exit 1
         }
 
-        $matchingLines = @()
-        foreach ($line in Get-Content $checksumFile) {
-            if ($line -match '^\s*$') { continue }
-            $parts = $line -split '\s+', 2
-            if ($parts.Count -lt 2) { continue }
-            $hash = $parts[0]
-            $filename = $parts[1]
-            $filename = $filename -replace '^[\*]', ''
-            $filename = $filename -replace '^\.\/', ''
-            $filename = $filename -replace '^\.\\', ''
-            if ($filename -eq $archiveName) {
-                $matchingLines += $hash
-            }
-        }
-
-        if ($matchingLines.Count -eq 0) {
-            Write-Err "Error: Could not find checksum for $archiveName in SHA256SUMS"
-            exit 1
-        }
-
-        if ($matchingLines.Count -gt 1) {
-            Write-Err "Error: Multiple checksum entries found for $archiveName"
-            exit 1
-        }
-
-        $expectedHash = $matchingLines[0]
-        $actualHash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLower()
-
-        if ($actualHash -ne $expectedHash.ToLower()) {
-            Write-Err "Error: Checksum verification failed!"
-            Write-Err "Expected: $expectedHash"
-            Write-Err "Got:      $actualHash"
+        try {
+            Verify-Checksum -ArchivePath $archivePath -ChecksumFile $checksumFile -ArchiveName $archiveName
+        } catch {
+            Write-Err "Error: $_"
             exit 1
         }
         Write-Info "Checksum verified."
@@ -326,4 +322,6 @@ function Install-Kata {
     }
 }
 
-Install-Kata
+if ($MyInvocation.InvocationName -ne '.') {
+    Install-Kata
+}

--- a/scripts/install_ps1_test.ps1
+++ b/scripts/install_ps1_test.ps1
@@ -36,6 +36,15 @@ function Invoke-WebRequest {
 }
 
 . $script:InstallerPath
+$script:OriginalTestReleaseAsset = (Get-Command Test-ReleaseAsset).ScriptBlock
+
+function Set-ReleaseAssetMock([scriptblock]$Mock) {
+    Set-Item -Path function:script:Test-ReleaseAsset -Value $Mock
+}
+
+function Restore-ReleaseAssetMock {
+    Set-Item -Path function:script:Test-ReleaseAsset -Value $script:OriginalTestReleaseAsset
+}
 
 function Test-DotSourceLoadsHelpersWithoutInstalling {
     Assert-True (Get-Command Resolve-ReleaseArch -ErrorAction SilentlyContinue) "Resolve-ReleaseArch should be loaded"
@@ -44,7 +53,7 @@ function Test-DotSourceLoadsHelpersWithoutInstalling {
 
 function Test-ResolveReleaseArchUsesDetectedWindowsArm64Asset {
     $script:ReleaseAssetUrls = @()
-    function global:Test-ReleaseAsset {
+    Set-ReleaseAssetMock {
         param([string]$Url)
         $script:ReleaseAssetUrls += $Url
         return $true
@@ -57,13 +66,13 @@ function Test-ResolveReleaseArchUsesDetectedWindowsArm64Asset {
         Assert-Equal 1 $script:ReleaseAssetUrls.Count "arm64 asset selection URL count"
         Assert-True ($script:ReleaseAssetUrls[0].EndsWith('/kata_0.5.0_windows_arm64.zip')) "arm64 asset selection URL"
     } finally {
-        Remove-Item function:global:Test-ReleaseAsset -Force -ErrorAction SilentlyContinue
+        Restore-ReleaseAssetMock
     }
 }
 
 function Test-ResolveReleaseArchDoesNotFallbackFromArm64ToAmd64 {
     $script:ReleaseAssetUrls = @()
-    function global:Test-ReleaseAsset {
+    Set-ReleaseAssetMock {
         param([string]$Url)
         $script:ReleaseAssetUrls += $Url
         return $false
@@ -76,7 +85,7 @@ function Test-ResolveReleaseArchDoesNotFallbackFromArm64ToAmd64 {
         Assert-Equal 1 $script:ReleaseAssetUrls.Count "missing arm64 asset URL count"
         Assert-True ($script:ReleaseAssetUrls[0].EndsWith('/kata_0.5.0_windows_arm64.zip')) "missing arm64 asset URL"
     } finally {
-        Remove-Item function:global:Test-ReleaseAsset -Force -ErrorAction SilentlyContinue
+        Restore-ReleaseAssetMock
     }
 }
 

--- a/scripts/install_ps1_test.ps1
+++ b/scripts/install_ps1_test.ps1
@@ -1,0 +1,124 @@
+$ErrorActionPreference = 'Stop'
+
+$script:InstallerPath = Join-Path $PSScriptRoot 'install.ps1'
+
+function Fail($Message) {
+    Write-Error "FAIL: $Message"
+    exit 1
+}
+
+function Assert-Equal($Expected, $Actual, $Context) {
+    if ($Expected -ne $Actual) {
+        Fail "$Context expected [$Expected], got [$Actual]"
+    }
+}
+
+function Assert-True($Condition, $Context) {
+    if (-not $Condition) {
+        Fail $Context
+    }
+}
+
+function Assert-Throws($ExpectedMessage, [scriptblock]$Block, $Context) {
+    try {
+        & $Block
+    } catch {
+        if ($_.Exception.Message -notlike "*$ExpectedMessage*") {
+            Fail "$Context expected error containing [$ExpectedMessage], got [$($_.Exception.Message)]"
+        }
+        return
+    }
+    Fail "$Context expected an error"
+}
+
+function Invoke-WebRequest {
+    throw "installer unexpectedly ran while dot-sourced"
+}
+
+. $script:InstallerPath
+
+function Test-DotSourceLoadsHelpersWithoutInstalling {
+    Assert-True (Get-Command Resolve-ReleaseArch -ErrorAction SilentlyContinue) "Resolve-ReleaseArch should be loaded"
+    Assert-True (Get-Command Verify-Checksum -ErrorAction SilentlyContinue) "Verify-Checksum should be loaded"
+}
+
+function Test-ResolveReleaseArchUsesDetectedWindowsArm64Asset {
+    $script:ReleaseAssetUrls = @()
+    function global:Test-ReleaseAsset {
+        param([string]$Url)
+        $script:ReleaseAssetUrls += $Url
+        return $true
+    }
+
+    try {
+        $arch = Resolve-ReleaseArch -DetectedArch 'arm64' -Version 'v0.5.0'
+
+        Assert-Equal 'arm64' $arch "arm64 asset selection"
+        Assert-Equal 1 $script:ReleaseAssetUrls.Count "arm64 asset selection URL count"
+        Assert-True ($script:ReleaseAssetUrls[0].EndsWith('/kata_0.5.0_windows_arm64.zip')) "arm64 asset selection URL"
+    } finally {
+        Remove-Item function:global:Test-ReleaseAsset -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-ResolveReleaseArchDoesNotFallbackFromArm64ToAmd64 {
+    $script:ReleaseAssetUrls = @()
+    function global:Test-ReleaseAsset {
+        param([string]$Url)
+        $script:ReleaseAssetUrls += $Url
+        return $false
+    }
+
+    try {
+        $arch = Resolve-ReleaseArch -DetectedArch 'arm64' -Version 'v0.5.0'
+
+        Assert-Equal $null $arch "missing arm64 asset selection"
+        Assert-Equal 1 $script:ReleaseAssetUrls.Count "missing arm64 asset URL count"
+        Assert-True ($script:ReleaseAssetUrls[0].EndsWith('/kata_0.5.0_windows_arm64.zip')) "missing arm64 asset URL"
+    } finally {
+        Remove-Item function:global:Test-ReleaseAsset -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-VerifyChecksumAcceptsMatchingHash {
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "kata-install-ps1-test-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+    try {
+        $archiveName = 'kata_0.5.0_windows_amd64.zip'
+        $archivePath = Join-Path $tmp $archiveName
+        $checksumFile = Join-Path $tmp 'SHA256SUMS'
+        Set-Content -LiteralPath $archivePath -Value 'archive payload' -NoNewline
+        $hash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLower()
+        Set-Content -LiteralPath $checksumFile -Value "$hash  *$archiveName"
+
+        Verify-Checksum -ArchivePath $archivePath -ChecksumFile $checksumFile -ArchiveName $archiveName
+    } finally {
+        Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-VerifyChecksumRejectsMismatch {
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "kata-install-ps1-test-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+    try {
+        $archiveName = 'kata_0.5.0_windows_amd64.zip'
+        $archivePath = Join-Path $tmp $archiveName
+        $checksumFile = Join-Path $tmp 'SHA256SUMS'
+        Set-Content -LiteralPath $archivePath -Value 'archive payload' -NoNewline
+        Set-Content -LiteralPath $checksumFile -Value "0000000000000000000000000000000000000000000000000000000000000000  $archiveName"
+
+        Assert-Throws 'Checksum verification failed' {
+            Verify-Checksum -ArchivePath $archivePath -ChecksumFile $checksumFile -ArchiveName $archiveName
+        } "checksum mismatch"
+    } finally {
+        Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Test-DotSourceLoadsHelpersWithoutInstalling
+Test-ResolveReleaseArchUsesDetectedWindowsArm64Asset
+Test-ResolveReleaseArchDoesNotFallbackFromArm64ToAmd64
+Test-VerifyChecksumAcceptsMatchingHash
+Test-VerifyChecksumRejectsMismatch
+
+Write-Host "PowerShell installer tests passed"

--- a/scripts/release_scripts_test.sh
+++ b/scripts/release_scripts_test.sh
@@ -367,27 +367,19 @@ test_install_checksum_cannot_be_skipped() {
   assert_not_contains "$output" "Checksum verification skipped" "installer checksum enforcement"
 }
 
-test_powershell_installer_parses() {
+test_powershell_installer() {
   if ! command -v pwsh >/dev/null 2>&1; then
-    printf 'skipping PowerShell installer parser test: pwsh not found\n'
+    printf 'skipping PowerShell installer tests: pwsh not found\n'
     return
   fi
 
   local output status
   set +e
-  output="$(KATA_INSTALL_PS1="$repo_root/scripts/install.ps1" pwsh -NoProfile -Command '
-    $tokens = $null
-    $errors = $null
-    [System.Management.Automation.PSParser]::Tokenize((Get-Content -Raw $env:KATA_INSTALL_PS1), [ref]$errors) > $null
-    if ($errors.Count -gt 0) {
-      $errors | ForEach-Object { Write-Error $_.Message }
-      exit 1
-    }
-  ' 2>&1)"
+  output="$(pwsh -NoProfile -File "$repo_root/scripts/install_ps1_test.ps1" 2>&1)"
   status=$?
   set -e
 
-  [[ $status -eq 0 ]] || fail "PowerShell installer should parse: $output"
+  [[ $status -eq 0 ]] || fail "PowerShell installer tests should pass: $output"
 }
 
 test_release_rejects_missing_version
@@ -405,6 +397,6 @@ test_verify_release_tag_accepts_tag_on_origin_main
 test_verify_release_tag_rejects_workflow_sha_mismatch
 test_verify_release_tag_rejects_tag_moved_after_validation
 test_install_checksum_cannot_be_skipped
-test_powershell_installer_parses
+test_powershell_installer
 
 printf 'release script tests passed\n'

--- a/scripts/release_scripts_test.sh
+++ b/scripts/release_scripts_test.sh
@@ -367,6 +367,29 @@ test_install_checksum_cannot_be_skipped() {
   assert_not_contains "$output" "Checksum verification skipped" "installer checksum enforcement"
 }
 
+test_powershell_installer_parses() {
+  if ! command -v pwsh >/dev/null 2>&1; then
+    printf 'skipping PowerShell installer parser test: pwsh not found\n'
+    return
+  fi
+
+  local output status
+  set +e
+  output="$(KATA_INSTALL_PS1="$repo_root/scripts/install.ps1" pwsh -NoProfile -Command '
+    $tokens = $null
+    $errors = $null
+    [System.Management.Automation.PSParser]::Tokenize((Get-Content -Raw $env:KATA_INSTALL_PS1), [ref]$errors) > $null
+    if ($errors.Count -gt 0) {
+      $errors | ForEach-Object { Write-Error $_.Message }
+      exit 1
+    }
+  ' 2>&1)"
+  status=$?
+  set -e
+
+  [[ $status -eq 0 ]] || fail "PowerShell installer should parse: $output"
+}
+
 test_release_rejects_missing_version
 test_release_rejects_v_prefixed_version
 test_release_rejects_non_semver_version
@@ -382,5 +405,6 @@ test_verify_release_tag_accepts_tag_on_origin_main
 test_verify_release_tag_rejects_workflow_sha_mismatch
 test_verify_release_tag_rejects_tag_moved_after_validation
 test_install_checksum_cannot_be_skipped
+test_powershell_installer_parses
 
 printf 'release script tests passed\n'


### PR DESCRIPTION
Windows users currently have release archives but no short hosted installer URL matching the Unix `https://katatracker.com/install.sh` path. That leaves the normal install story asymmetric and makes the docs less useful for anyone starting from PowerShell.

This adds a kata-adapted PowerShell installer at `scripts/install.ps1`, exposes it through `https://katatracker.com/install.ps1`, and updates the README plus install and quickstart docs so both hosted installer paths are visible. The docs redirect checker now treats `/install.sh` and `/install.ps1` as part of the Vercel contract, which makes it harder to accidentally drop either public install URL later.

The PowerShell installer follows the sibling project pattern where it fits: resolve the latest GitHub release, select the Windows asset for the detected architecture, verify `SHA256SUMS`, install into a user-local bin directory, and update the user Path unless disabled. The helper functions are guarded so tests can dot-source the installer without starting a real install, and the mocked PowerShell tests cover asset naming plus checksum match and mismatch behavior.
