### PR TITLE
Speed up Windows test fixtures

### DIFF
--- a/cmd/kata/testhelpers_test.go
+++ b/cmd/kata/testhelpers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/client"
+	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/sqlitestore"
@@ -187,6 +188,21 @@ func initBoundWorkspace(t *testing.T, baseURL, origin string) string {
 	runGit(t, dir, "remote", "add", "origin", origin)
 	postJSONOK(t, baseURL+"/api/v1/projects", map[string]string{"start_path": dir})
 	return dir
+}
+
+// initLocalBoundWorkspace creates a workspace binding without shelling out to
+// git or exercising the daemon init endpoint. Most CLI tests only need a
+// resolved project; init/git-specific tests should keep using initBoundWorkspace.
+func initLocalBoundWorkspace(t *testing.T, env *testenv.Env, projectName string) (string, int64) {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	require.NoError(t, config.WriteProjectConfig(dir, projectName))
+	project, err := env.DB.CreateProject(ctx, projectName)
+	require.NoError(t, err)
+	_, err = env.DB.AttachAlias(ctx, project.ID, "local://"+dir, "local")
+	require.NoError(t, err)
+	return dir, project.ID
 }
 
 // resolvePIDViaHTTP calls POST /api/v1/projects/resolve with start_path and
@@ -409,8 +425,7 @@ func setupCLIWorkspaceOptions(t *testing.T, opts ...testenv.Option) (*testenv.En
 	t.Helper()
 	resetFlags(t)
 	env := testenv.New(t, opts...)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
-	pid := resolvePIDViaHTTP(t, env.URL, dir)
+	dir, pid := initLocalBoundWorkspace(t, env, "kata")
 	return env, dir, pid
 }
 
@@ -443,7 +458,7 @@ func setupCLIEnv(t *testing.T) (*testenv.Env, string) {
 	t.Helper()
 	resetFlags(t)
 	env := testenv.New(t)
-	dir := initBoundWorkspace(t, env.URL, "https://github.com/wesm/kata.git")
+	dir, _ := initLocalBoundWorkspace(t, env, "kata")
 	return env, dir
 }
 
@@ -637,4 +652,17 @@ func (a *asyncCLI) stop() {
 func fetchIssueViaHTTP(t *testing.T, env *testenv.Env, pid int64, ref string) IssueResponse {
 	t.Helper()
 	return getJSON[IssueResponse](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues/"+ref)
+}
+
+func TestSetupCLIWorkspaceUsesFastLocalBinding(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	require.NotZero(t, pid)
+
+	require.NoDirExists(t, filepath.Join(dir, ".git"))
+	cfg, err := config.ReadProjectConfig(dir)
+	require.NoError(t, err)
+	require.Equal(t, "kata", cfg.Project.Name)
+
+	out := runCLI(t, env, dir, "--quiet", "create", "fast fixture issue")
+	require.NotEmpty(t, out)
 }

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -104,7 +104,7 @@ func closeIssueWithEvidence(
 
 func TestParentCloseCompleteness_RefusesWhenOpenChildrenExist(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	child := createIssueViaHTTP(t, env, pid, "first child")
 	postLink(t, env, pid, child, "parent", parent)
@@ -121,7 +121,7 @@ func TestParentCloseCompleteness_RefusesWhenOpenChildrenExist(t *testing.T) {
 
 func TestParentCloseCompleteness_AllowsWhenChildrenClosed(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent")
 	child := createIssueViaHTTP(t, env, pid, "child")
 	postLink(t, env, pid, child, "parent", parent)
@@ -143,7 +143,7 @@ func TestParentCloseCompleteness_AllowsWhenChildrenClosed(t *testing.T) {
 
 func TestParentCloseCompleteness_TruncatesLongChildList(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent with many children")
 	// Create more children than the sample limit (10) so the suffix renders.
 	const totalChildren = 12
@@ -171,7 +171,7 @@ func TestParentCloseCompleteness_TruncatesLongChildList(t *testing.T) {
 
 func TestCloseDuplicateOf_RejectsMissingTarget(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	issue := createIssueViaHTTP(t, env, pid, "issue")
 
 	// Target #999 does not exist in this project.
@@ -186,7 +186,7 @@ func TestCloseDuplicateOf_RejectsMissingTarget(t *testing.T) {
 
 func TestCloseDuplicateOf_RejectsSelfTarget(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	issue := createIssueViaHTTP(t, env, pid, "issue")
 
 	resp, bs := closeIssueWithEvidence(t, env, pid, issue, "tester",
@@ -200,7 +200,7 @@ func TestCloseDuplicateOf_RejectsSelfTarget(t *testing.T) {
 
 func TestCloseSupersededBy_RejectsMissingTarget(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	issue := createIssueViaHTTP(t, env, pid, "issue")
 
 	resp, bs := closeIssueWithEvidence(t, env, pid, issue, "tester",
@@ -214,7 +214,7 @@ func TestCloseSupersededBy_RejectsMissingTarget(t *testing.T) {
 
 func TestCloseSupersededBy_RejectsSelfTarget(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	issue := createIssueViaHTTP(t, env, pid, "issue")
 
 	resp, bs := closeIssueWithEvidence(t, env, pid, issue, "tester",
@@ -228,7 +228,7 @@ func TestCloseSupersededBy_RejectsSelfTarget(t *testing.T) {
 
 func TestCloseDuplicateOf_AcceptsExistingTarget(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	other := createIssueViaHTTP(t, env, pid, "real target")
 	issue := createIssueViaHTTP(t, env, pid, "duplicate of the other")
 
@@ -241,7 +241,7 @@ func TestCloseDuplicateOf_AcceptsExistingTarget(t *testing.T) {
 
 func TestSiblingThrottle_DefaultAllowsBurstWithDistinctEvidence(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 5)
 	for i := 0; i < 5; i++ {
@@ -263,7 +263,7 @@ func TestSiblingThrottle_DefaultAllowsBurstWithDistinctEvidence(t *testing.T) {
 
 func TestSiblingThrottle_FourthCloseUnderSameParentRefusedWhenEnabled(t *testing.T) {
 	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
 	for i := 0; i < 4; i++ {
@@ -423,7 +423,7 @@ func TestRepeatedMessageGuard_CountsCrossProjectSiblings(t *testing.T) {
 
 func TestSiblingThrottle_AllowsFourthCloseWhenOldestSiblingIsOutsideDefaultWindow(t *testing.T) {
 	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
 	for i := 0; i < 4; i++ {
@@ -471,7 +471,7 @@ func TestSiblingThrottle_UsesConfiguredWindowInRefusal(t *testing.T) {
 	env := testenv.New(t,
 		testenv.WithCloseThrottleEnabled(),
 		testenv.WithCloseThrottleWindow(2*time.Minute))
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
 	for i := 0; i < 4; i++ {
@@ -498,7 +498,7 @@ func TestSiblingThrottle_UsesConfiguredWindowInRefusal(t *testing.T) {
 
 func TestSiblingThrottle_DifferentActorNotThrottled(t *testing.T) {
 	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
 	for i := 0; i < 4; i++ {
@@ -528,7 +528,7 @@ func TestSiblingThrottle_DifferentActorNotThrottled(t *testing.T) {
 
 func TestSiblingThrottle_UnparentedIssuesNotThrottled(t *testing.T) {
 	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	// Four issues with no parent link — the throttle only applies to siblings
 	// under a shared parent, so all four closes should succeed.
 	issues := make([]int64, 0, 4)
@@ -548,7 +548,7 @@ func TestSiblingThrottle_UnparentedIssuesNotThrottled(t *testing.T) {
 
 func TestRepeatedMessageGuard_RefusesIdenticalSiblingMessage(t *testing.T) {
 	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	a := createIssueViaHTTP(t, env, pid, "child a")
 	b := createIssueViaHTTP(t, env, pid, "child b")
@@ -578,7 +578,7 @@ func TestRepeatedMessageGuard_RefusesIdenticalSiblingMessage(t *testing.T) {
 
 func TestClose_DefaultAllowsSiblingClosesWithSameCommitEvidence(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	a := createIssueViaHTTP(t, env, pid, "child a")
 	b := createIssueViaHTTP(t, env, pid, "child b")
@@ -601,7 +601,7 @@ func TestClose_DefaultAllowsSiblingClosesWithSameCommitEvidence(t *testing.T) {
 
 func TestRepeatedMessageGuard_SkipsForWontfix(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	a := createIssueViaHTTP(t, env, pid, "child a")
 	b := createIssueViaHTTP(t, env, pid, "child b")
@@ -623,7 +623,7 @@ func TestRepeatedMessageGuard_SkipsForWontfix(t *testing.T) {
 
 func TestRepeatedMessageGuard_SkipsForUnparentedIssues(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	// Two issues with no parent link — the rule applies only to siblings
 	// under a shared parent, so identical messages should be allowed.
 	a := createIssueViaHTTP(t, env, pid, "standalone a")
@@ -650,7 +650,7 @@ func TestRepeatedMessageGuard_SkipsForUnparentedIssues(t *testing.T) {
 // issues, not to block a legitimate re-close of one issue.
 func TestRepeatedMessageGuard_SkipsSelfAfterReopen(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	a := createIssueViaHTTP(t, env, pid, "child a")
 	postLink(t, env, pid, a, "parent", parent)
@@ -684,7 +684,7 @@ func TestRepeatedMessageGuard_SkipsSelfAfterReopen(t *testing.T) {
 // reopening one issue.
 func TestSiblingThrottle_SkipsSelfAfterReopen(t *testing.T) {
 	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
 	for i := 0; i < 4; i++ {
@@ -733,7 +733,7 @@ func TestSiblingThrottle_SkipsSelfAfterReopen(t *testing.T) {
 // as duplicate_message, breaking the interactive close keystroke.
 func TestRepeatedMessageGuard_SkipsTUIBypassEmptyMessage(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	a := createIssueViaHTTP(t, env, pid, "child a")
 	b := createIssueViaHTTP(t, env, pid, "child b")
@@ -756,7 +756,7 @@ func TestRepeatedMessageGuard_SkipsTUIBypassEmptyMessage(t *testing.T) {
 
 func TestThrottle_EmitsCloseThrottledEvent_SiblingBurst(t *testing.T) {
 	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
 	for i := 0; i < 4; i++ {
@@ -821,7 +821,7 @@ func TestThrottle_EmitsCloseThrottledEvent_SiblingBurst(t *testing.T) {
 
 func TestThrottle_EmitsCloseThrottledEvent_DuplicateMessage(t *testing.T) {
 	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	a := createIssueViaHTTP(t, env, pid, "child a")
 	b := createIssueViaHTTP(t, env, pid, "child b")
@@ -871,7 +871,7 @@ func TestThrottle_EmitsCloseThrottledEvent_DuplicateMessage(t *testing.T) {
 
 func TestThrottle_DryRunDoesNotEmitEvent(t *testing.T) {
 	env := testenv.New(t, testenv.WithCloseThrottleEnabled())
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent issue")
 	children := make([]int64, 0, 4)
 	for i := 0; i < 4; i++ {

--- a/internal/daemon/envhelpers_test.go
+++ b/internal/daemon/envhelpers_test.go
@@ -8,11 +8,14 @@ import (
 	"net/http"
 	"net/url"
 	"os/exec"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/testenv"
 )
 
@@ -167,6 +170,25 @@ func initWorkspaceViaHTTP(t *testing.T, env *testenv.Env, origin string) int64 {
 	return out.Project.ID
 }
 
+// initLocalWorkspace seeds the project state that most daemon handler tests
+// need without paying for git process startup or exercising project init.
+func initLocalWorkspace(t *testing.T, env *testenv.Env, projectName string) int64 {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, config.WriteProjectConfig(dir, projectName))
+	project, err := env.DB.CreateProject(context.Background(), projectName)
+	require.NoError(t, err)
+	_, err = env.DB.AttachAlias(context.Background(), project.ID, "local://"+dir, "local")
+	require.NoError(t, err)
+	currentEnvForIssuePath = env
+	t.Cleanup(func() {
+		if currentEnvForIssuePath == env {
+			currentEnvForIssuePath = nil
+		}
+	})
+	return project.ID
+}
+
 // mustRun runs a command in dir, failing the test on error.
 func mustRun(t *testing.T, dir, name string, args ...string) {
 	t.Helper()
@@ -178,7 +200,7 @@ func mustRun(t *testing.T, dir, name string, args ...string) {
 // setupOneIssue creates a workspace + one issue, returns (project_id, issue_number).
 func setupOneIssue(t *testing.T, env *testenv.Env) (int64, int64) {
 	t.Helper()
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	n := createIssueViaHTTP(t, env, pid, "x")
 	return pid, n
 }
@@ -186,7 +208,7 @@ func setupOneIssue(t *testing.T, env *testenv.Env) (int64, int64) {
 // setupTwoIssues creates a workspace + two issues, returns (project_id, a_number, b_number).
 func setupTwoIssues(t *testing.T, env *testenv.Env) (int64, int64, int64) {
 	t.Helper()
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	a := createIssueViaHTTP(t, env, pid, "a")
 	b := createIssueViaHTTP(t, env, pid, "b")
 	return pid, a, b
@@ -492,4 +514,16 @@ func deleteLinkBlocksAs(t *testing.T, env *testenv.Env, projectID, fromNumber in
 		"?actor=" + url.QueryEscape(actor)
 	resp := envDoJSON(t, env, http.MethodDelete, delPath, nil, nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestSetupOneIssueUsesFastLocalBinding(t *testing.T) {
+	env := testenv.New(t)
+	pid, issueID := setupOneIssue(t, env)
+	require.NotZero(t, issueID)
+
+	aliases, err := env.DB.ProjectAliases(context.Background(), pid)
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	require.Equal(t, "local", aliases[0].AliasKind)
+	require.NoDirExists(t, filepath.Join(strings.TrimPrefix(aliases[0].AliasIdentity, "local://"), ".git"))
 }

--- a/internal/daemon/handlers_digest_test.go
+++ b/internal/daemon/handlers_digest_test.go
@@ -111,7 +111,7 @@ func fetchDigest(t *testing.T, env *testenv.Env, projectID int64, since, until s
 // digest then surfaces per-actor totals and per-issue action sequences.
 func TestDigest_AggregatesByActor(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 
 	// Alice creates two issues, comments on the first twice, closes it.
 	a := createIssueAs(t, env, pid, "alice", "first")
@@ -165,7 +165,7 @@ func TestDigest_AggregatesByActor(t *testing.T) {
 // TestDigest_ActorFilter only returns events for the named actors.
 func TestDigest_ActorFilter(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	_ = createIssueAs(t, env, pid, "alice", "x")
 	_ = createIssueAs(t, env, pid, "bob", "y")
 
@@ -183,7 +183,7 @@ func TestDigest_ActorFilter(t *testing.T) {
 // bug --owner alice --blocks 7` activity.
 func TestDigest_CountsCreateTimeLabelsOwnerLinks(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 
 	// Seed a target issue alice's later issue can block.
 	target := createIssueAs(t, env, pid, "alice", "target")
@@ -237,7 +237,7 @@ func TestDigest_CountsCreateTimeLabelsOwnerLinks(t *testing.T) {
 // reversed.
 func TestDigest_CreateTimeBlockedByEmitsBlockedByAction(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 
 	blocker := createIssueAs(t, env, pid, "alice", "blocker")
 	blockerShortID := shortIDOf(t, env, blocker)
@@ -274,7 +274,7 @@ func TestDigest_CreateTimeBlockedByEmitsBlockedByAction(t *testing.T) {
 // Y with unblocking.
 func TestDigest_BlockedByRemovedIsPlainUnlink(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 
 	blocker := createIssueAs(t, env, pid, "alice", "blocker")
 	child := createIssueAs(t, env, pid, "alice", "blocked")
@@ -306,7 +306,7 @@ func TestDigest_BlockedByRemovedIsPlainUnlink(t *testing.T) {
 // applyEvent rather than falling into the Other bucket.
 func TestDigest_PriorityEvents(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	n := createIssueAs(t, env, pid, "alice", "p3 issue")
 
 	prio := int64(0)
@@ -328,7 +328,7 @@ func TestDigest_PriorityEvents(t *testing.T) {
 // TestDigest_RejectsBadSince validates the since parameter.
 func TestDigest_RejectsBadSince(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	resp := envDoJSON(t, env, "GET", projectPath(pid)+"/digest?since=not-a-time", nil, nil)
 	assert.Equal(t, 400, resp.StatusCode)
 }
@@ -336,7 +336,7 @@ func TestDigest_RejectsBadSince(t *testing.T) {
 // TestDigest_GlobalEndpoint covers the cross-project route.
 func TestDigest_GlobalEndpoint(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	_ = createIssueAs(t, env, pid, "alice", "x")
 
 	var body struct {

--- a/internal/daemon/handlers_issues_test.go
+++ b/internal/daemon/handlers_issues_test.go
@@ -1379,7 +1379,7 @@ func TestCreateIssue_WithInitialState(t *testing.T) {
 
 func TestCreateIssue_InitialLinkToMissingTargetIs404(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	resp, _ := envDoRaw(t, env, http.MethodPost, projectPath(pid)+"/issues", map[string]any{
 		"actor": "tester", "title": "child",
 		"links": []map[string]any{{"type": "parent", "to_ref": "zzzz"}},
@@ -1407,7 +1407,7 @@ func TestCreateIssue_RejectsArchivedProject(t *testing.T) {
 
 func TestCreateIssue_InvalidLabelIs400(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	resp, _ := envDoRaw(t, env, http.MethodPost, projectPath(pid)+"/issues", map[string]any{
 		"actor": "tester", "title": "x",
 		"labels": []string{"BadCase"},
@@ -1421,7 +1421,7 @@ func TestCreateIssue_InvalidLabelIs400(t *testing.T) {
 // catches this via ErrSelfLink and the handler must map it.
 func TestCreateIssue_InitialSelfLinkIs400(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	resp, _ := envDoRaw(t, env, http.MethodPost, projectPath(pid)+"/issues", map[string]any{
 		"actor": "tester", "title": "self",
 		"links": []map[string]any{{"type": "parent", "to_number": 1}},
@@ -1899,7 +1899,7 @@ func TestCreate_IdempotencyWinsOverForceNew(t *testing.T) {
 // can render label chips without an extra fetch per row.
 func TestListIssues_HydratesLabels(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	first := createIssueViaHTTP(t, env, pid, "first")
 	second := createIssueViaHTTP(t, env, pid, "second")
 	postLabel(t, env, pid, first, "prio-1")
@@ -1926,7 +1926,7 @@ func TestListIssues_HydratesLabels(t *testing.T) {
 
 func TestListIssues_IncludesHierarchyMetadata(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent")
 	child := createIssueViaHTTP(t, env, pid, "child")
 	postLink(t, env, pid, child, "parent", parent)
@@ -1961,7 +1961,7 @@ func TestListIssues_IncludesHierarchyMetadata(t *testing.T) {
 
 func TestListIssues_IncludesBlockerMetadata(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	project, err := env.DB.ProjectByID(t.Context(), pid)
 	require.NoError(t, err)
 	blocker := createIssueViaHTTP(t, env, pid, "blocker")
@@ -2144,7 +2144,7 @@ func TestShowIssue_IncludesLinksAndLabels(t *testing.T) {
 
 func TestShowIssue_IncludesParentAndChildren(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	parent := createIssueViaHTTP(t, env, pid, "parent")
 	child := createIssueViaHTTP(t, env, pid, "child")
 	grandchild := createIssueViaHTTP(t, env, pid, "grandchild")

--- a/internal/daemon/handlers_ready_test.go
+++ b/internal/daemon/handlers_ready_test.go
@@ -47,7 +47,7 @@ func TestReady_FiltersBlocked(t *testing.T) {
 
 func TestReady_RespectsLimit(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	for i := 0; i < 3; i++ {
 		createIssueViaHTTP(t, env, pid, "x")
 	}
@@ -58,7 +58,7 @@ func TestReady_RespectsLimit(t *testing.T) {
 
 func TestReady_UnownedAndOwnerMutuallyExclusive(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 
 	status, _ := env.Get(t, projectPath(pid)+"/ready?unowned=true&owner=alice")
 	assert.Equal(t, 400, status)
@@ -127,7 +127,7 @@ func TestReadyGlobal_ExcludesArchivedProjects(t *testing.T) {
 
 func TestReadyGlobal_LimitCapsTotalRows(t *testing.T) {
 	env := testenv.New(t)
-	pid1 := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid1 := initLocalWorkspace(t, env, "kata")
 	pid2 := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/other.git")
 	for i := 0; i < 3; i++ {
 		createIssueViaHTTP(t, env, pid1, "p1")

--- a/internal/daemon/handlers_search_test.go
+++ b/internal/daemon/handlers_search_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSearchEndpoint_ReturnsHitsWithScores(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 	createIssueViaHTTP(t, env, pid, "fix login crash on Safari")
 	createIssueViaHTTP(t, env, pid, "unrelated")
 
@@ -27,7 +27,7 @@ func TestSearchEndpoint_ReturnsHitsWithScores(t *testing.T) {
 
 func TestSearchEndpoint_EmptyQueryIsValidationError(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 
 	resp, bs := envGetRaw(t, env, projectPath(pid)+"/search?q=")
 	assertAPIError(t, resp.StatusCode, bs, 400, "validation")
@@ -46,7 +46,7 @@ func TestSearchEndpoint_UnknownProjectIs404(t *testing.T) {
 // emit null and break clients that assume an array.
 func TestSearchEndpoint_EmptyResultsIsArrayNotNull(t *testing.T) {
 	env := testenv.New(t)
-	pid := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/kata.git")
+	pid := initLocalWorkspace(t, env, "kata")
 
 	resp, bs := envGetRaw(t, env, projectPath(pid)+"/search?q=zxqyq-no-such-token")
 	require.Equal(t, 200, resp.StatusCode)

--- a/internal/daemon/testhelpers_test.go
+++ b/internal/daemon/testhelpers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/sqlitestore"
@@ -121,16 +122,13 @@ func issueShortIDFromCreate(t *testing.T, bs []byte) string {
 	return out.Issue.ShortID
 }
 
-// bootstrapProject spins up a fresh server + git workspace and runs `kata
-// init` against it, returning the handle and the project rowid. Used as a
-// shared setup for every issue handler test. Optional serverOptions are
-// forwarded to newServerWithGitWorkspace (e.g. to install a hooks sink).
+// bootstrapProject spins up a fresh server with a local workspace binding,
+// returning the handle and the project rowid. Used as a shared setup for
+// handler tests that need a project, not the project-init path itself. Tests
+// for git/init behavior should use newServerWithGitWorkspace directly.
 func bootstrapProject(t *testing.T, opts ...serverOption) (*httptestServerHandle, int64) {
 	t.Helper()
-	h := newServerWithGitWorkspace(t, "https://github.com/wesm/kata.git", opts...)
-	_, bs := postJSON(t, h.ts.(*httptest.Server), "/api/v1/projects", map[string]any{"start_path": h.dir})
-	var resp struct{ Project struct{ ID int64 } }
-	require.NoError(t, json.Unmarshal(bs, &resp))
+	h, projectID := newServerWithLocalWorkspace(t, "kata", opts...)
 	// Register the handle so issueURL can look up issue.short_id at request
 	// time without each test passing the handle in. Tests in this package
 	// don't run in parallel, so a single pointer is enough; t.Cleanup
@@ -141,7 +139,7 @@ func bootstrapProject(t *testing.T, opts ...serverOption) (*httptestServerHandle
 			currentHandleForIssueURL = nil
 		}
 	})
-	return h, resp.Project.ID
+	return h, projectID
 }
 
 // bootstrapProjectWithIssue runs bootstrapProject and additionally posts a
@@ -246,6 +244,25 @@ func newServerWithGitWorkspace(t *testing.T, originURL string, opts ...serverOpt
 	}
 	ts := startTestServer(t, cfg)
 	return &httptestServerHandle{ts: ts, dir: dir, db: d.db}
+}
+
+func newServerWithLocalWorkspace(
+	t *testing.T, projectName string, opts ...serverOption,
+) (*httptestServerHandle, int64) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, config.WriteProjectConfig(dir, projectName))
+	d := openTestDB(t)
+	project, err := d.db.CreateProject(context.Background(), projectName)
+	require.NoError(t, err)
+	_, err = d.db.AttachAlias(context.Background(), project.ID, "local://"+dir, "local")
+	require.NoError(t, err)
+	cfg := daemon.ServerConfig{DB: d.db, StartedAt: d.now}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	ts := startTestServer(t, cfg)
+	return &httptestServerHandle{ts: ts, dir: dir, db: d.db}, project.ID
 }
 
 // resolveProjectID posts /api/v1/projects/resolve for the given workspace dir
@@ -533,4 +550,15 @@ func seedProject(t *testing.T, env *testenv.Env, name string) db.Project {
 	p, err := env.DB.CreateProject(t.Context(), name)
 	require.NoError(t, err)
 	return p
+}
+
+func TestBootstrapProjectUsesFastLocalBinding(t *testing.T) {
+	h, projectID := bootstrapProject(t)
+	require.NotZero(t, projectID)
+	require.NoDirExists(t, filepath.Join(h.dir, ".git"))
+
+	aliases, err := h.DB().ProjectAliases(context.Background(), projectID)
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	require.Equal(t, "local", aliases[0].AliasKind)
 }


### PR DESCRIPTION
## Summary

- replace the default CLI workspace fixture with a local `.kata.toml` and DB-seeded project binding, avoiding git and daemon init for generic command tests
- add equivalent local project fixtures for daemon handler tests while preserving git-backed helpers for project/init coverage
- move standard handler tests that only need a project row off the git/init fixture path

This cuts the local Windows full test command from about 10m31s before the refactor to about 1m57s with an uncached `-count=1` run.