### PR TITLE
Allow tokenless private-network daemon writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,13 @@ A daemon can serve clients on other hosts over a private network:
 - Client: `export KATA_SERVER=http://100.64.0.5:7777` or commit a
   gitignored `.kata.local.toml` with `[server] url = "..."` next to
   `.kata.toml`. `KATA_SERVER` env wins.
-- Unauthenticated private-network mode is `--insecure-readonly`, which permits
-  GET requests only. Mutations and the event stream require bearer auth.
+- Unauthenticated read-only private-network mode is `--insecure-readonly`,
+  which permits GET requests only. Mutations and the event stream require
+  bearer auth unless the server explicitly sets
+  `[auth].allow_unauthenticated_private_network_writes = true` (or
+  `KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES=1`) on a literal private IP
+  bind. That writable tokenless mode treats the private network as the access
+  boundary, uses client-supplied actors, and blocks token administration.
 - Trusted plaintext bearer targets must be literal non-public IPs (loopback,
   RFC1918, CGNAT, link-local, ULA). Public IPs and DNS hostnames require HTTPS
   termination or an SSH tunnel.

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -311,6 +311,9 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	if msg, ok := daemon.TrustPrivateNetworkWarning(listen, dcfg.Auth); ok {
 		fmt.Fprintln(os.Stderr, msg)
 	}
+	if msg, ok := daemon.UnauthenticatedPrivateNetworkWritesWarning(listen, dcfg.Auth); ok {
+		fmt.Fprintln(os.Stderr, msg)
+	}
 	if err := ns.EnsureDirs(); err != nil {
 		return err
 	}

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,9 @@ The `kata` CLI resolves a project from your workspace, `.kata.toml`, or
 needed. The daemon owns a SQLite database under `KATA_HOME`, applies mutations,
 and records an event stream that both the CLI/TUI and hooks read. Your repo
 commits only the small `.kata.toml` binding, so issue history stays out of code
-history. See [Concepts](guide/concepts.md) and
+history. Private-network remote daemon modes are explicit: operators can use
+bearer auth on trusted private HTTP or opt a single-user private IP into
+tokenless writes. See [Concepts](guide/concepts.md) and
 [Architecture](design/architecture.md) for the full model.
 
 ## When to use kata

--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -57,10 +57,10 @@ auto-start.
 
 ## Plain HTTP guardrails
 
-Mutable non-loopback HTTP requires both:
+Mutable non-loopback HTTP requires one of:
 
-- a daemon API token;
-- explicit trusted private-network opt-in.
+- a daemon API token plus explicit trusted private-network opt-in;
+- explicit unauthenticated private-network write opt-in on a literal private IP.
 
 Plain HTTP bearer-token targets must be literal non-public IPs: loopback,
 RFC1918, CGNAT, link-local, or ULA. Public IPs and DNS hostnames are rejected
@@ -83,6 +83,41 @@ allow_insecure = true
 
 Unix sockets, loopback HTTP, and HTTPS do not require the same private-network
 trust opt-in.
+
+## Tokenless private-network writes
+
+For a single-user private network where the network itself is the access
+boundary:
+
+```toml
+listen = "100.64.0.5:7777"
+
+[auth]
+allow_unauthenticated_private_network_writes = true
+```
+
+or:
+
+```sh
+KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES=1 \
+  kata daemon start --listen 100.64.0.5:7777
+```
+
+This moves kata's local no-token trust model onto the configured private IP:
+mutations and the event stream are accepted without a bearer token, and write
+actors come from the client request body just as they do on loopback and Unix
+sockets. Any device that can reach the bound address can assert any actor string,
+so use this only when tailnet or private-network membership is the intended
+trust boundary.
+
+The bind must be a literal private IP address: RFC1918, CGNAT, link-local, or
+ULA. Hostnames, public IPs, and wildcard binds such as `0.0.0.0:7777` or
+`:7777` are rejected for this mode. It cannot be combined with `token`,
+`require_token_identity = true`, or `--insecure-readonly`.
+
+Token administration remains authenticated-only in this mode. `/api/v1/tokens`
+requests are rejected rather than letting unauthenticated private-network
+clients mint, list, or revoke API tokens.
 
 ## Identity tokens
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -14,6 +14,7 @@ bindings, local per-machine overrides, and daemon config.
 | `KATA_SERVER` | Remote daemon URL. Skips local discovery and auto-start. |
 | `KATA_AUTH_TOKEN` | Bearer token for daemon API auth. |
 | `KATA_TRUST_PRIVATE_NETWORK` | Set to `1` to permit trusted plaintext bearer use on private non-loopback HTTP. |
+| `KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES` | Set to `1` to permit tokenless writes and event streams on a literal private-IP daemon bind. |
 | `KATA_ALLOW_INSECURE` | Set to `1` or `true` to allow a configured remote daemon hostname over plain HTTP. Federation uses `kata federation enroll --allow-insecure` and `kata federation join --allow-insecure` instead because enrollment credentials are stored separately. |
 | `KATA_TELEMETRY_ENABLED` | Set to `0` to disable anonymous PostHog telemetry. |
 | `KATA_HTTP_TIMEOUT` | Per-request CLI timeout for non-streaming daemon calls, such as `30s` or `2m`. Defaults to `5s`; raise it for bulk imports. |
@@ -116,6 +117,21 @@ The `kata daemon start --listen <host:port>` flag wins over the config file.
 Auto-started daemons also read the config-file listener value.
 An empty `[storage].dsn` means "no storage override"; env vars or the default
 database path still apply.
+
+For a single-user private network where the private IP itself is the access
+boundary, omit `token` and use:
+
+```toml
+listen = "100.64.0.5:7777"
+
+[auth]
+allow_unauthenticated_private_network_writes = true
+```
+
+This permits writes and event streams without bearer auth, with client-supplied
+actor attribution. It requires a literal private-IP bind and cannot be combined
+with `token`, `require_token_identity`, or `--insecure-readonly`; token
+administration endpoints remain blocked.
 
 Postgres DSNs may carry credentials. Although they are not selectable yet,
 runtime redaction handles both URL and libpq keyword forms defensively; userinfo

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -53,16 +53,20 @@ type StorageConfig struct {
 // AuthConfig is the [auth] block of <KATA_HOME>/config.toml. An empty
 // Token disables bearer auth — appropriate for Unix-socket and loopback-TCP
 // deployments; non-loopback TCP requires either --insecure-readonly with no
-// token, or a token plus TrustPrivateNetwork.
+// token, a token plus TrustPrivateNetwork, or the explicit
+// AllowUnauthenticatedPrivateNetworkWrites opt-in on a literal private IP bind.
 //
 // KATA_AUTH_TOKEN, when set, overrides the TOML value. Use it for
 // ephemeral or CI-only tokens that should never be persisted to disk.
 // KATA_TRUST_PRIVATE_NETWORK=1 is equivalent to trust_private_network = true.
+// KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES=1 is equivalent to
+// allow_unauthenticated_private_network_writes = true.
 type AuthConfig struct {
-	Token                string      `toml:"token"`
-	TrustPrivateNetwork  bool        `toml:"trust_private_network"`
-	RequireTokenIdentity bool        `toml:"require_token_identity"`
-	Proxy                ProxyConfig `toml:"proxy"`
+	Token                                    string      `toml:"token"`
+	TrustPrivateNetwork                      bool        `toml:"trust_private_network"`
+	AllowUnauthenticatedPrivateNetworkWrites bool        `toml:"allow_unauthenticated_private_network_writes"`
+	RequireTokenIdentity                     bool        `toml:"require_token_identity"`
+	Proxy                                    ProxyConfig `toml:"proxy"`
 }
 
 // ProxyConfig is the [auth.proxy] sub-table. Both keys empty/absent means
@@ -285,6 +289,9 @@ func applyDaemonConfigEnv(cfg *DaemonConfig) {
 	}
 	if EnvTruthy("KATA_TRUST_PRIVATE_NETWORK") {
 		cfg.Auth.TrustPrivateNetwork = true
+	}
+	if EnvTruthy("KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES") {
+		cfg.Auth.AllowUnauthenticatedPrivateNetworkWrites = true
 	}
 	if v := strings.TrimSpace(os.Getenv("KATA_TRUSTED_ACTOR_HEADER")); v != "" {
 		cfg.Auth.Proxy.TrustedActorHeader = v

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -323,6 +323,18 @@ func TestReadDaemonConfig_ReadsAuthTrustPrivateNetwork(t *testing.T) {
 	assert.True(t, cfg.Auth.TrustPrivateNetwork)
 }
 
+func TestReadDaemonConfig_ReadsAllowUnauthenticatedPrivateNetworkWrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth]\nallow_unauthenticated_private_network_writes = true\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.True(t, cfg.Auth.AllowUnauthenticatedPrivateNetworkWrites)
+}
+
 func TestReadDaemonConfig_ReadsRequireTokenIdentity(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
@@ -344,6 +356,18 @@ func TestReadDaemonConfig_AuthTrustPrivateNetworkEnvOverridesTOML(t *testing.T) 
 	cfg, err := config.ReadDaemonConfig()
 	require.NoError(t, err)
 	assert.True(t, cfg.Auth.TrustPrivateNetwork)
+}
+
+func TestReadDaemonConfig_AllowUnauthenticatedPrivateNetworkWritesEnvOverridesTOML(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES", "1")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth]\nallow_unauthenticated_private_network_writes = false\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.True(t, cfg.Auth.AllowUnauthenticatedPrivateNetworkWrites)
 }
 
 func TestReadDaemonConfig_AuthTokenEnvOverridesTOML(t *testing.T) {

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -23,15 +23,17 @@ const (
 
 // authPolicy is the resolved auth posture at daemon start. Token == "" disables
 // bearer auth; TrustPrivateNetwork is the explicit operator opt-in that allows
-// token auth on non-loopback private-network TCP; InsecureReadonly is the dev
-// escape hatch that allows GETs on non-loopback TCP without a token. These
-// fields are also surfaced through ServerConfig; this struct exists so the
-// middleware itself does not depend on ServerConfig.
+// token auth on non-loopback private-network TCP; AllowUnauthenticatedPrivateNetworkWrites
+// moves the local no-token trust model onto a literal private IP bind; InsecureReadonly
+// is the dev escape hatch that allows GETs on non-loopback TCP without a token.
+// These fields are also surfaced through ServerConfig; this struct exists so
+// the middleware itself does not depend on ServerConfig.
 type authPolicy struct {
-	Token                string
-	TrustPrivateNetwork  bool
-	InsecureReadonly     bool
-	RequireTokenIdentity bool
+	Token                                    string
+	TrustPrivateNetwork                      bool
+	AllowUnauthenticatedPrivateNetworkWrites bool
+	InsecureReadonly                         bool
+	RequireTokenIdentity                     bool
 }
 
 // requireBearer returns an HTTP middleware that enforces bearer-token auth
@@ -64,6 +66,11 @@ func requireBearer(p authPolicy, tokenStores ...db.Storage) func(http.Handler) h
 				return
 			}
 			if p.Token == "" {
+				if p.AllowUnauthenticatedPrivateNetworkWrites && isTokenAdminPath(r.URL.Path) {
+					api.WriteEnvelope(w, http.StatusUnauthorized, "auth_required",
+						"token administration requires authentication; daemon allows unauthenticated private-network writes")
+					return
+				}
 				if !p.InsecureReadonly {
 					next.ServeHTTP(w, r)
 					return
@@ -203,10 +210,11 @@ func isFederationTransportRoute(method, path string) bool {
 // convention as runDaemonWithListen: "" means platform-default local
 // transport; "host:port" means TCP. The matrix on non-loopback TCP is:
 //
-//	Token != "" && TrustPrivateNetwork -> permit (operator accepts private-network confidentiality)
-//	Token != "" && !TrustPrivateNetwork -> REFUSE (token would travel in cleartext)
-//	Token == "" &&  InsecureReadonly   -> permit (dev-only GET access)
-//	Token == "" && !InsecureReadonly   -> REFUSE (would expose mutations to the LAN)
+//	Token != "" && TrustPrivateNetwork                 -> permit (operator accepts private-network confidentiality)
+//	Token != "" && !TrustPrivateNetwork                -> REFUSE (token would travel in cleartext)
+//	Token == "" && AllowUnauthenticatedPrivateNetworkWrites -> permit only on literal private IP binds
+//	Token == "" &&  InsecureReadonly                   -> permit (dev-only GET access)
+//	Token == "" && !InsecureReadonly                   -> REFUSE (would expose mutations to the LAN)
 //
 // The daemon does not terminate TLS, so a bearer token on plaintext non-
 // loopback HTTP is a passive-capture risk. Operators wanting cross-host
@@ -214,11 +222,27 @@ func isFederationTransportRoute(method, path string) bool {
 // daemon with a TLS-terminating reverse proxy and bind the daemon to a
 // Unix socket or 127.0.0.1.
 func checkAuthStartup(listen string, p authPolicy) error {
+	if p.AllowUnauthenticatedPrivateNetworkWrites && p.Token != "" {
+		return fmt.Errorf("allow_unauthenticated_private_network_writes requires no auth token")
+	}
+	if p.AllowUnauthenticatedPrivateNetworkWrites && p.RequireTokenIdentity {
+		return fmt.Errorf("allow_unauthenticated_private_network_writes cannot be combined with require_token_identity")
+	}
+	if p.AllowUnauthenticatedPrivateNetworkWrites && p.InsecureReadonly {
+		return fmt.Errorf("allow_unauthenticated_private_network_writes cannot be combined with --insecure-readonly")
+	}
 	if p.RequireTokenIdentity && p.Token == "" {
 		return fmt.Errorf("require_token_identity requires a bootstrap token")
 	}
 	if p.RequireTokenIdentity && p.InsecureReadonly {
 		return fmt.Errorf("require_token_identity cannot be combined with --insecure-readonly")
+	}
+	if p.AllowUnauthenticatedPrivateNetworkWrites {
+		if isLiteralPrivateNetworkTCP(listen) {
+			return nil
+		}
+		return fmt.Errorf("listen %q with unauthenticated writes requires a literal private IP bind "+
+			"(RFC1918, CGNAT, link-local, or ULA); hostnames, public IPs, and wildcard binds are not supported", listen)
 	}
 	if !isNonLoopbackTCP(listen) {
 		return nil
@@ -243,10 +267,11 @@ func checkAuthStartup(listen string, p authPolicy) error {
 // CheckAuthStartup is the exported form used by the CLI entry point.
 func CheckAuthStartup(listen string, auth config.AuthConfig, insecureReadonly bool) error {
 	return checkAuthStartup(listen, authPolicy{
-		Token:                auth.Token,
-		TrustPrivateNetwork:  auth.TrustPrivateNetwork,
-		InsecureReadonly:     insecureReadonly,
-		RequireTokenIdentity: auth.RequireTokenIdentity,
+		Token:                                    auth.Token,
+		TrustPrivateNetwork:                      auth.TrustPrivateNetwork,
+		AllowUnauthenticatedPrivateNetworkWrites: auth.AllowUnauthenticatedPrivateNetworkWrites,
+		InsecureReadonly:                         insecureReadonly,
+		RequireTokenIdentity:                     auth.RequireTokenIdentity,
 	})
 }
 
@@ -258,6 +283,18 @@ func TrustPrivateNetworkWarning(listen string, auth config.AuthConfig) (string, 
 	}
 	return "kata daemon: WARNING: listening on non-loopback TCP with bearer auth; " +
 		"operator has asserted private-network confidentiality.", true
+}
+
+// UnauthenticatedPrivateNetworkWritesWarning returns the startup warning shown
+// when the daemon is configured to accept writes from a private-network TCP bind
+// without bearer authentication.
+func UnauthenticatedPrivateNetworkWritesWarning(listen string, auth config.AuthConfig) (string, bool) {
+	if auth.Token != "" || !auth.AllowUnauthenticatedPrivateNetworkWrites || !isLiteralPrivateNetworkTCP(listen) {
+		return "", false
+	}
+	return "kata daemon: WARNING: listening on private-network TCP with unauthenticated writes; " +
+		"any device that can reach this address can mutate data, open the event stream, " +
+		"and assert client-supplied actors. Token administration remains blocked.", true
 }
 
 // isNonLoopbackTCP reports whether listen designates a TCP bind that's
@@ -290,4 +327,23 @@ func isNonLoopbackTCP(listen string) bool {
 	// DNS, so treat as non-loopback. Operators can use 127.0.0.1 / ::1
 	// explicitly if they want the loopback-only path.
 	return true
+}
+
+func isLiteralPrivateNetworkTCP(listen string) bool {
+	host, _, err := net.SplitHostPort(listen)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || ip.IsUnspecified() || ip.IsLoopback() {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLinkLocalUnicast() || cgnatBlock.Contains(ip)
+}
+
+// cgnatBlock is RFC6598 100.64.0.0/10. Go's net.IP.IsPrivate() intentionally
+// excludes it, but private overlay networks commonly use this range.
+var cgnatBlock = &net.IPNet{
+	IP:   net.IPv4(100, 64, 0, 0),
+	Mask: net.CIDRMask(10, 32),
 }

--- a/internal/daemon/auth_startup_test.go
+++ b/internal/daemon/auth_startup_test.go
@@ -70,6 +70,71 @@ func TestAuthStartupGuard_TrustPrivateNetworkWithoutToken_StillRefuses(t *testin
 	assert.Contains(t, err.Error(), "non-loopback TCP")
 }
 
+func TestAuthStartupGuard_UnauthenticatedPrivateNetworkWrites_PrivateLiteralIPPermitted(t *testing.T) {
+	p := authPolicy{AllowUnauthenticatedPrivateNetworkWrites: true}
+	for _, addr := range []string{
+		"10.1.2.3:7777",
+		"172.16.1.2:7777",
+		"192.168.1.20:7777",
+		"100.64.0.5:7777",
+		"169.254.1.2:7777",
+		"[fd00::1]:7777",
+		"[fe80::1]:7777",
+	} {
+		t.Run(addr, func(t *testing.T) {
+			require.NoError(t, checkAuthStartup(addr, p))
+		})
+	}
+}
+
+func TestAuthStartupGuard_UnauthenticatedPrivateNetworkWrites_RejectsUnsafeBinds(t *testing.T) {
+	p := authPolicy{AllowUnauthenticatedPrivateNetworkWrites: true}
+	for _, addr := range []string{
+		"",
+		"127.0.0.1:7777",
+		"[::1]:7777",
+		":7777",
+		"0.0.0.0:7777",
+		"[::]:7777",
+		"8.8.8.8:7777",
+		"example.internal:7777",
+	} {
+		t.Run(addr, func(t *testing.T) {
+			err := checkAuthStartup(addr, p)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "literal private")
+		})
+	}
+}
+
+func TestAuthStartupGuard_UnauthenticatedPrivateNetworkWrites_RejectsToken(t *testing.T) {
+	err := checkAuthStartup("100.64.0.5:7777", authPolicy{
+		Token:                                    "tok",
+		TrustPrivateNetwork:                      true,
+		AllowUnauthenticatedPrivateNetworkWrites: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token")
+}
+
+func TestAuthStartupGuard_UnauthenticatedPrivateNetworkWrites_RejectsIdentityMode(t *testing.T) {
+	err := checkAuthStartup("100.64.0.5:7777", authPolicy{
+		AllowUnauthenticatedPrivateNetworkWrites: true,
+		RequireTokenIdentity:                     true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "require_token_identity")
+}
+
+func TestAuthStartupGuard_UnauthenticatedPrivateNetworkWrites_RejectsInsecureReadonly(t *testing.T) {
+	err := checkAuthStartup("100.64.0.5:7777", authPolicy{
+		AllowUnauthenticatedPrivateNetworkWrites: true,
+		InsecureReadonly:                         true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insecure-readonly")
+}
+
 func TestTrustPrivateNetworkWarning(t *testing.T) {
 	msg, ok := TrustPrivateNetworkWarning("100.64.0.5:7777",
 		config.AuthConfig{Token: "tok", TrustPrivateNetwork: true})
@@ -91,6 +156,36 @@ func TestTrustPrivateNetworkWarning_OnlyWhenEffective(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, ok := TrustPrivateNetworkWarning(tc.listen, tc.auth)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestUnauthenticatedPrivateNetworkWritesWarning(t *testing.T) {
+	msg, ok := UnauthenticatedPrivateNetworkWritesWarning("100.64.0.5:7777",
+		config.AuthConfig{AllowUnauthenticatedPrivateNetworkWrites: true})
+	require.True(t, ok)
+	assert.Contains(t, msg, "WARNING")
+	assert.Contains(t, msg, "unauthenticated writes")
+	assert.Contains(t, msg, "any device")
+	assert.Contains(t, msg, "client-supplied actors")
+	assert.Contains(t, msg, "event stream")
+}
+
+func TestUnauthenticatedPrivateNetworkWritesWarning_OnlyWhenEffective(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		listen string
+		auth   config.AuthConfig
+	}{
+		{name: "loopback", listen: "127.0.0.1:7777", auth: config.AuthConfig{AllowUnauthenticatedPrivateNetworkWrites: true}},
+		{name: "public ip", listen: "8.8.8.8:7777", auth: config.AuthConfig{AllowUnauthenticatedPrivateNetworkWrites: true}},
+		{name: "wildcard", listen: "0.0.0.0:7777", auth: config.AuthConfig{AllowUnauthenticatedPrivateNetworkWrites: true}},
+		{name: "token", listen: "100.64.0.5:7777", auth: config.AuthConfig{Token: "tok", TrustPrivateNetwork: true, AllowUnauthenticatedPrivateNetworkWrites: true}},
+		{name: "disabled", listen: "100.64.0.5:7777", auth: config.AuthConfig{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := UnauthenticatedPrivateNetworkWritesWarning(tc.listen, tc.auth)
 			assert.False(t, ok)
 		})
 	}
@@ -129,7 +224,7 @@ func TestAuthStartupGuard_RejectsIdentityModeWithoutBootstrapToken(t *testing.T)
 // TestAuthStartupGuard_WildcardBindWithoutToken_Refuses covers the listen
 // shapes that bind every interface in Go's net.Listen — :port (empty host),
 // 0.0.0.0:port, and [::]:port. Each is reachable from anywhere on the
-// network and so must require a token unless --insecure-readonly is set.
+// network and so must stay refused in the default no-token write posture.
 func TestAuthStartupGuard_WildcardBindWithoutToken_Refuses(t *testing.T) {
 	for _, addr := range []string{":7777", "0.0.0.0:7777", "[::]:7777"} {
 		t.Run(addr, func(t *testing.T) {
@@ -168,5 +263,6 @@ func TestServerConfig_AuthPolicyThreaded(t *testing.T) {
 	assert.Equal(t, "tok-123", got.Token)
 	assert.True(t, got.TrustPrivateNetwork)
 	assert.True(t, got.RequireTokenIdentity)
+	assert.False(t, got.AllowUnauthenticatedPrivateNetworkWrites)
 	assert.False(t, got.InsecureReadonly)
 }

--- a/internal/daemon/auth_test.go
+++ b/internal/daemon/auth_test.go
@@ -23,6 +23,47 @@ func TestAuthMiddleware_NoTokenConfigured_AllRequestsPass(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
+func TestAuthMiddleware_UnauthenticatedPrivateNetworkWrites_AllowsWritesAndEventStream(t *testing.T) {
+	mw := requireBearer(authPolicy{AllowUnauthenticatedPrivateNetworkWrites: true})
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/v1/projects", nil))
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	rr = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events/stream", nil)
+	req.Header.Set("Accept", "text/event-stream")
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestAuthMiddleware_UnauthenticatedPrivateNetworkWrites_BlocksTokenAdmin(t *testing.T) {
+	mw := requireBearer(authPolicy{AllowUnauthenticatedPrivateNetworkWrites: true})
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: "/api/v1/tokens"},
+		{method: http.MethodPost, path: "/api/v1/tokens"},
+		{method: http.MethodPost, path: "/api/v1/tokens/1/actions/revoke"},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path, nil))
+			assert.Equal(t, http.StatusUnauthorized, rr.Code)
+			assert.Contains(t, rr.Body.String(), `"auth_required"`)
+			assert.Contains(t, rr.Body.String(), "token administration")
+		})
+	}
+}
+
 func TestAuthMiddleware_TokenConfigured_MissingHeader_401(t *testing.T) {
 	mw := requireBearer(authPolicy{Token: "expected-token"})
 	h := mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -56,10 +56,11 @@ type ServerConfig struct {
 // stays unaware of ServerConfig and config.AuthConfig.
 func (c ServerConfig) authPolicy() authPolicy {
 	return authPolicy{
-		Token:                c.Auth.Token,
-		TrustPrivateNetwork:  c.Auth.TrustPrivateNetwork,
-		InsecureReadonly:     c.InsecureReadonly,
-		RequireTokenIdentity: c.Auth.RequireTokenIdentity,
+		Token:                                    c.Auth.Token,
+		TrustPrivateNetwork:                      c.Auth.TrustPrivateNetwork,
+		AllowUnauthenticatedPrivateNetworkWrites: c.Auth.AllowUnauthenticatedPrivateNetworkWrites,
+		InsecureReadonly:                         c.InsecureReadonly,
+		RequireTokenIdentity:                     c.Auth.RequireTokenIdentity,
 	}
 }
 


### PR DESCRIPTION
Private single-user deployments can already run kata tokenless through loopback or Unix sockets, but direct private-network access forced operators to provision and distribute a bearer token even when the private network itself was the intended access boundary. That made Tailscale-style personal daemon deployments carry secret-management ceremony without changing the operator's trust model.

This adds an explicit opt-in for tokenless writable private-network daemon access while preserving the old default. The mode only starts on a tokenless literal private IP bind, rejects conflicting identity/read-only/token configurations, warns operators at startup, and keeps token administration behind authentication so unauthenticated private-network clients cannot mint, list, or revoke API tokens.

The important review tradeoff is intentional: this extends kata's existing local no-token actor model to a configured private IP. Any device that can reach that address can submit writes with client-supplied actors, so the feature is appropriate only when private-network membership is the operator's chosen boundary.