### PR TITLE
Restore daemon selector from empty switch

### DIFF
--- a/internal/tui/daemon_view.go
+++ b/internal/tui/daemon_view.go
@@ -126,6 +126,7 @@ func (m Model) handleDaemonSwitchResult(msg daemonSwitchResultMsg) (Model, tea.C
 
 func (m Model) installDaemonConnection(conn daemonConnection) (Model, tea.Cmd) {
 	actor := m.list.actor
+	previousView := m.view
 	m.connGen++
 	m.api = conn.api
 	m.activeDaemon = conn.target
@@ -134,7 +135,11 @@ func (m Model) installDaemonConnection(conn daemonConnection) (Model, tea.Cmd) {
 	}
 	m.scope = conn.init.scope
 	m.view = conn.init.view
-	m.prevView = viewList
+	if previousView == viewDaemons && conn.init.view == viewEmpty {
+		m.prevView = viewDaemons
+	} else {
+		m.prevView = viewList
+	}
 	m.focus = focusList
 	m.list = newListModel()
 	m.list.actor = actor

--- a/internal/tui/daemon_view_test.go
+++ b/internal/tui/daemon_view_test.go
@@ -217,6 +217,29 @@ func TestDaemonSwitchSuccessResetsDaemonLocalState(t *testing.T) {
 	assert.True(t, restarted)
 }
 
+func TestDaemonSwitchToEmptyDaemonEscReturnsToSelector(t *testing.T) {
+	m := setupDaemonView()
+	conn := daemonConnection{
+		api:     &Client{},
+		target:  daemonTarget{Name: "empty", URL: "https://empty.example"},
+		catalog: m.daemonTargets,
+		init: bootInit{
+			view:  viewEmpty,
+			scope: scope{empty: true},
+		},
+	}
+
+	out, cmd := updateModel(m, daemonSwitchResultMsg{conn: conn})
+	require.Nil(t, cmd)
+	require.Equal(t, viewEmpty, out.view)
+
+	out, cmd = updateModel(out, tea.KeyMsg{Type: tea.KeyEsc})
+
+	require.Nil(t, cmd)
+	assert.Equal(t, viewDaemons, out.view)
+	assert.Equal(t, "empty", out.activeDaemon.Name)
+}
+
 func TestDaemonSwitchFailureKeepsCurrentSession(t *testing.T) {
 	m := setupDaemonViewSource()
 	m.connGen = 2

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1649,6 +1649,10 @@ func (m Model) routeGlobalKey(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 		return next, cmd, true
 	}
 	if m.view == viewEmpty {
+		if msg.Type == tea.KeyEsc && m.prevView == viewDaemons {
+			m.view = viewDaemons
+			return m, nil, true
+		}
 		return m, nil, true
 	}
 	if m.keymap.Help.matches(msg) {


### PR DESCRIPTION
Switching from the daemon selector to a daemon with no registered projects left the TUI on the onboarding screen, where non-quit keys are intentionally absorbed. That made Escape unable to recover even though the user had arrived from a navigable selector.

This keeps the empty-state behavior unchanged for direct startup into a daemon with no projects, while preserving the selector as the prior view for this specific switch path. Escape can then return to the daemon list without opening up the rest of the empty screen to accidental navigation.