### PR TITLE
Preserve local-first federation links across push lag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@
 - Do not commit rejected experiments. Revert them or ask before preserving them.
 - Test First: Write a failing test before the implementation, then make it pass, then refactor (red, green, refactor). Don't add production code without a failing test that requires it.
 - No Private Project Data: Do not use private project, workspace, customer,
-  host, or repository names in tests, docs, examples, PR text, or generated
+  host, or repository names in tests, docs, examples, planning documents,
+  design notes, issue or bug reports, review responses, PR text, or generated
   fixtures. Use neutral placeholders such as `spoke-project`, `hub-project`,
   `example-workspace`, or `daemon.example` unless the user explicitly asks
   to preserve a real name in a user-facing operational command.

--- a/internal/daemon/claim_gate.go
+++ b/internal/daemon/claim_gate.go
@@ -100,12 +100,75 @@ func refreshSpokeClaimStatusForGate(
 		if isTransportClaimError(err) {
 			return nil
 		}
+		pending, pendingErr := isPendingSpokePushClaimStatusMiss(ctx, cfg, binding, issue, err)
+		if pendingErr != nil {
+			return pendingErr
+		}
+		if pending {
+			return nil
+		}
 		return claimForwardError(err)
 	}
 	if err := cfg.DB.ApplyClaimStatus(ctx, binding.ProjectID, issue.UID, claimStatusFromAPI(resp)); err != nil {
 		return claimAPIError(err)
 	}
 	return nil
+}
+
+func isPendingSpokePushClaimStatusMiss(
+	ctx context.Context,
+	cfg ServerConfig,
+	binding db.FederationBinding,
+	issue db.Issue,
+	err error,
+) (bool, error) {
+	var statusErr *claimHubStatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
+		return false, nil
+	}
+	if binding.Role != db.FederationRoleSpoke || !binding.PushEnabled {
+		return false, nil
+	}
+	pending, err := pendingPushMayMaterializeIssue(ctx, cfg.DB, binding, issue.UID)
+	if err != nil {
+		return false, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+	}
+	return pending, nil
+}
+
+func pendingPushMayMaterializeIssue(
+	ctx context.Context,
+	store db.Storage,
+	binding db.FederationBinding,
+	issueUID string,
+) (bool, error) {
+	afterID := binding.PushCursorEventID
+	for {
+		events, err := store.PendingFederationPushEvents(ctx, binding.ProjectID, store.InstanceUID(), afterID, 1000)
+		if err != nil {
+			return false, err
+		}
+		if len(events) == 0 {
+			return false, nil
+		}
+		for _, ev := range events {
+			if pushEventMaterializesIssue(ev, issueUID) {
+				return true, nil
+			}
+		}
+		nextAfterID := events[len(events)-1].ID
+		if nextAfterID <= afterID {
+			return false, nil
+		}
+		afterID = nextAfterID
+	}
+}
+
+func pushEventMaterializesIssue(ev db.Event, issueUID string) bool {
+	if ev.Type != "issue.created" && ev.Type != "issue.snapshot" {
+		return false
+	}
+	return ev.IssueUID != nil && *ev.IssueUID == issueUID
 }
 
 func isOfflineClaimRefreshError(err error) bool {

--- a/internal/daemon/claim_gate.go
+++ b/internal/daemon/claim_gate.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -126,6 +127,9 @@ func isPendingSpokePushClaimStatusMiss(
 	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
 		return false, nil
 	}
+	if hubStatusErrorCode(statusErr) != "issue_not_found" {
+		return false, nil
+	}
 	if binding.Role != db.FederationRoleSpoke || !binding.PushEnabled {
 		return false, nil
 	}
@@ -134,6 +138,17 @@ func isPendingSpokePushClaimStatusMiss(
 		return false, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
 	}
 	return pending, nil
+}
+
+func hubStatusErrorCode(err *claimHubStatusError) string {
+	if err == nil {
+		return ""
+	}
+	var env api.ErrorEnvelope
+	if json.Unmarshal([]byte(err.Body), &env) != nil {
+		return ""
+	}
+	return strings.TrimSpace(env.Error.Code)
 }
 
 func pendingPushMayMaterializeIssue(

--- a/internal/daemon/claim_gate_helper_test.go
+++ b/internal/daemon/claim_gate_helper_test.go
@@ -210,6 +210,29 @@ func TestClaimGateHelperSpokeHubNotFoundStillFailsAfterIssuePushed(t *testing.T)
 	assertClaimGateHelperAPIError(t, err, http.StatusNotFound, "hub_claim_failed")
 }
 
+func TestClaimGateHelperSpokeHubProjectNotFoundStillFailsForPendingPushIssue(t *testing.T) {
+	ctx := context.Background()
+	store := openClaimGateHelperDB(t)
+	project, issue := createClaimGateHelperIssue(t, store)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/projects/99/issues/"+issue.ShortID+"/lease", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": http.StatusNotFound,
+			"error": map[string]any{
+				"code":    "project_not_found",
+				"message": "project not found",
+			},
+		})
+	}))
+	t.Cleanup(hub.Close)
+	enableClaimGateHelperSpoke(t, store, project, hub.URL, 99)
+
+	err := requireFederatedIssueClaim(ctx, ServerConfig{DB: store}, project.ID, issue, "agent")
+
+	assertClaimGateHelperAPIError(t, err, http.StatusNotFound, "hub_claim_failed")
+}
+
 func TestClaimGateHelperPushSpokeUsesBoundActorForGate(t *testing.T) {
 	ctx := context.Background()
 	store := openClaimGateHelperDB(t)

--- a/internal/daemon/claim_gate_helper_test.go
+++ b/internal/daemon/claim_gate_helper_test.go
@@ -160,6 +160,56 @@ func TestClaimGateHelperSpokeTransportFailureFallsBackToCachedClaim(t *testing.T
 	require.NoError(t, err)
 }
 
+func TestClaimGateHelperSpokeHubNotFoundFallsBackForPendingPushIssue(t *testing.T) {
+	ctx := context.Background()
+	store := openClaimGateHelperDB(t)
+	project, issue := createClaimGateHelperIssue(t, store)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/projects/99/issues/"+issue.ShortID+"/lease", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": http.StatusNotFound,
+			"error": map[string]any{
+				"code":    "issue_not_found",
+				"message": "issue not found",
+			},
+		})
+	}))
+	t.Cleanup(hub.Close)
+	enableClaimGateHelperSpoke(t, store, project, hub.URL, 99)
+
+	err := requireFederatedIssueClaim(ctx, ServerConfig{DB: store}, project.ID, issue, "agent")
+
+	require.NoError(t, err)
+}
+
+func TestClaimGateHelperSpokeHubNotFoundStillFailsAfterIssuePushed(t *testing.T) {
+	ctx := context.Background()
+	store := openClaimGateHelperDB(t)
+	project, issue := createClaimGateHelperIssue(t, store)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/projects/99/issues/"+issue.ShortID+"/lease", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": http.StatusNotFound,
+			"error": map[string]any{
+				"code":    "issue_not_found",
+				"message": "issue not found",
+			},
+		})
+	}))
+	t.Cleanup(hub.Close)
+	enableClaimGateHelperSpoke(t, store, project, hub.URL, 99)
+	events, err := store.PendingFederationPushEvents(ctx, project.ID, store.InstanceUID(), 0, 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, events)
+	require.NoError(t, store.AdvanceFederationPushCursor(ctx, project.ID, events[len(events)-1].ID))
+
+	err = requireFederatedIssueClaim(ctx, ServerConfig{DB: store}, project.ID, issue, "agent")
+
+	assertClaimGateHelperAPIError(t, err, http.StatusNotFound, "hub_claim_failed")
+}
+
 func TestClaimGateHelperPushSpokeUsesBoundActorForGate(t *testing.T) {
 	ctx := context.Background()
 	store := openClaimGateHelperDB(t)


### PR DESCRIPTION
Push-enabled spokes can hand back a local issue ref before the hub has ingested the materializing event. Relationship mutations still need to respect authoritative hub leases, but treating hub issue_not_found during that narrow window as a hard failure makes local-first workflows observe internal replication timing.

This keeps the synchronous claim refresh for known hub issues, while treating only issue_not_found on a still-pending local issue create or snapshot as a local cache miss. Other hub 404s, such as a missing hub project, remain visible so federation misconfiguration is not masked.

The agent guidance also clarifies that private project details must stay out of planning documents, bug reports, review responses, and PR text.