### PR TITLE
Document 0.6.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,25 @@
   behavior coverage is not practical, document the manual check instead of
   adding a brittle shell content test.
 
+## Documentation and release PRs
+
+Update documentation as behavior lands whenever practical: CLI flags, config
+keys, operator workflows, installation paths, and user-facing contracts should
+not wait for a release-only sweep when they can be documented with the code.
+
+After a release is tagged and confirmed available, do a normal post-release
+documentation pass based on the release changelog. This final pass should add
+or refresh release notes, check overview/navigation paths, and make sure the
+public docs describe the shipped state accurately.
+
+When opening a post-release docs PR, describe it as standard release
+finalization. Do not frame the update as a surprising docs gap, a failure of
+prior work, or a problem caused by the release tag. Good framing:
+
+- "Finalizes the public docs for the 0.6.0 release using the tagged changelog."
+- "Adds the 0.6.0 changelog entry and updates overview links for the shipped
+  GitHub sync and Windows installer docs."
+
 ## Project management
 
 This project tracks its own work in **kata**. Run `kata quickstart` at the

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ The [docs site](docs/) is the definitive reference:
   [Configuration](docs/reference/configuration.md)
 - Workflows: [Agent workflows](docs/workflows/agents.md) ·
   [Sharing models](docs/workflows/sharing.md)
-- Operations: [Remote daemon](docs/operations/remote-daemon.md) ·
+- Operations: [GitHub sync](docs/operations/github-sync.md) ·
+  [Remote daemon](docs/operations/remote-daemon.md) ·
   [Federation](docs/operations/federation.md) ·
   [Hosted mode](docs/operations/hosted-mode.md) ·
   [Backup and restore](docs/operations/backup-restore.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,65 @@ description: Release history for kata
 All notable changes to kata, grouped by release. Versioned releases start with
 0.5.0; earlier entries are a retroactive project history grouped by ISO week.
 
+## 0.6.0
+<small>2026-06-24</small>
+
+kata 0.6.0 expands kata's release and sharing surface: GitHub Issues can now
+feed a kata project, private-network daemon deployments have an explicit
+tokenless write mode for trusted single-user networks, and Windows users have a
+hosted release installer.
+
+**New features**
+
+- Added one-way GitHub issue sync with `kata sync github`, backed by
+  daemon-owned bindings, cursors, import mappings, status, and a poller. The
+  first provider imports GitHub issues and issue comments through the daemon's
+  `gh api` environment, skips pull requests, prefixes imported titles by
+  default, and keeps GitHub as the source of truth for synced fields.
+- Added provider-neutral issue-sync API/storage foundations so GitHub sync
+  state participates in backup, restore, JSONL cutover, and daemon status
+  flows. Restored sync bindings come back disabled until explicitly re-enabled
+  on the new host.
+- Added support for running GitHub sync on federation hubs, so GitHub-origin
+  kata events can replicate to spokes while direct GitHub sync on spokes stays
+  rejected.
+- Added explicitly enabled tokenless writes and event streams for daemons bound
+  to literal private IP addresses. Operators can opt in with
+  `[auth].allow_unauthenticated_private_network_writes = true` or
+  `KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES=1`; token administration
+  remains blocked without authentication.
+- Added a hosted Windows PowerShell release installer at
+  `https://katatracker.com/install.ps1`, including release-asset selection,
+  checksum verification, user-local install, and user `Path` updates.
+
+**Improvements**
+
+- Improved local-first federation resilience by preserving relationship writes
+  to newly created local issues while their create or snapshot events are still
+  pending push to the hub. Once the hub has acknowledged the materializing
+  event, later missing-issue responses remain visible errors.
+- Tightened the pending-push federation exception to `issue_not_found` errors
+  so broader hub route or project misconfiguration is not hidden.
+- Changed explicit `kata daemon start` to start a background daemon by default
+  and return after startup is confirmed; `kata daemon start --foreground`
+  remains the service-manager and hosted-deployment mode.
+- Sped up Windows development and release validation by moving broad CLI and
+  daemon handler fixtures off slower git/init paths when tests only need a
+  seeded project.
+- Revamped the README and docs front page into a clearer landing page with
+  direct install, quickstart, and feature-orientation paths.
+- Expanded the 0.5.0 changelog into a fuller first-release history.
+
+**Bug fixes**
+
+- Restored TUI daemon selection recovery when switching from the daemon
+  selector to a daemon with no registered projects. Escape now returns to the
+  selector for that switch path while direct empty-daemon startup still shows
+  the onboarding state.
+- Preserved the federation trust boundary for delayed push scenarios without
+  hiding real broken mappings or missing hub state after the pending local
+  issue has materialized.
+
 ## 0.5.0
 <small>2026-06-22</small>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,6 +140,7 @@ is a local ledger for the work itself. They coexist. See
 
 -   [__Concepts__](guide/concepts.md). The data model and how the pieces fit.
 -   [__CLI reference__](reference/cli.md). Every command and flag.
+-   [__GitHub sync__](operations/github-sync.md). Bring GitHub issues into kata.
 -   [__Agent workflows__](workflows/agents.md). The operating contract for agents.
 -   [__Comparisons__](guide/comparisons.md). kata vs. SaaS issue trackers.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -271,6 +271,9 @@ background daemon and returns after startup is confirmed. Use
 `daemon start --foreground` for service managers, hosted deployments, and any
 setup where the daemon process should stay attached to the terminal.
 `kata agent-instructions` is an alias for `kata quickstart`.
+For TCP listener auth modes, including trusted private-network bearer auth,
+read-only experiments, and explicit tokenless private-network writes, see
+[Remote daemon](../operations/remote-daemon.md).
 
 `kata tui` opens the interactive issue browser. In the issue list, `v` toggles
 between nested and flat views: nested groups children under parents, while flat


### PR DESCRIPTION
Finalizes the public docs for the 0.6.0 release after the tag was confirmed available. This uses the tagged changelog as the release source of truth, adds the 0.6.0 changelog entry, and keeps the overview/navigation paths aligned with the shipped GitHub sync, Windows installer, private-network daemon write mode, and federation resilience work.

The detailed operational runbooks already cover the underlying behavior, so the overview changes link readers to those pages instead of duplicating setup instructions. This also records the release-documentation convention in `AGENTS.md`: update docs as behavior lands when practical, then do a normal post-release changelog-based finalization pass.