### PR TITLE
Publish release artifacts from tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   validate-tag:
@@ -14,6 +14,7 @@ jobs:
     outputs:
       tag_name: ${{ steps.validate.outputs.tag_name }}
       version: ${{ steps.validate.outputs.version }}
+      tag_sha: ${{ steps.validate.outputs.tag_sha }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
@@ -26,3 +27,64 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           scripts/verify-release-tag.sh "$TAG_NAME"
+
+  publish:
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ needs.validate-tag.outputs.tag_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Re-verify release tag before publish
+        env:
+          TAG_NAME: ${{ needs.validate-tag.outputs.tag_name }}
+          TAG_SHA: ${{ needs.validate-tag.outputs.tag_sha }}
+        run: |
+          git fetch --force --tags origin \
+            "+refs/tags/${TAG_NAME}:refs/tags/${TAG_NAME}" \
+            '+refs/heads/main:refs/remotes/origin/main'
+
+          current_sha="$(git rev-parse -q --verify "${TAG_NAME}^{commit}")"
+          if [[ "$current_sha" != "$TAG_SHA" ]]; then
+            printf 'Release tag %s moved from %s to %s before publish\n' \
+              "$TAG_NAME" "$TAG_SHA" "$current_sha" >&2
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            printf 'Release tag %s commit %s is not contained in origin/main\n' \
+              "$TAG_NAME" "$TAG_SHA" >&2
+            exit 1
+          fi
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ needs.validate-tag.outputs.tag_name }}
+        run: |
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Release $TAG_NAME already exists"
+            exit 0
+          fi
+
+          gh release create "$TAG_NAME" \
+            --verify-tag \
+            --title "$TAG_NAME" \
+            --notes-from-tag
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
+        with:
+          distribution: goreleaser
+          version: v2.16.0
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   validate-tag:
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -31,6 +32,8 @@ jobs:
   publish:
     needs: validate-tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -48,15 +48,26 @@ installer or updater, asset names that no longer match kit's default
 self-update contract, missing assets in a successful release, or code/docs
 that claim signed updates exist before signing is implemented.
 
-Semver tag pushes run a read-only Release validator. The write-capable
-GoReleaser publication path is an explicit default-branch Publish Release
-workflow_dispatch job gated by the `release` environment. It validates the
-operator-supplied semver tag, verifies the tag target is contained in
-`origin/main`, checks out the immutable validated commit SHA for packaging, and
-re-checks the tag immediately before creating the GitHub release. It is valid to
-flag shell injection in tag handling, publishing from non-semver tags, or
-changes that move release-write credentials back into tag-controlled workflow
-code.
+Semver tag pushes are the release publication mechanism. A repository writer
+who can push a semver release tag to a commit already contained in `origin/main`
+is trusted to initiate the GitHub release and GoReleaser artifact upload through
+the tag-triggered Release workflow. Do not raise a blocking finding merely
+because the tag-triggered release job has `contents: write`, lacks an additional
+`release` environment approval, or publishes with `GITHUB_TOKEN`.
+
+The release workflow must still validate the tag shape, verify the tag target is
+contained in `origin/main`, check out the immutable validated commit SHA for
+packaging, and re-check the tag immediately before creating the GitHub release.
+Valid findings remain: shell injection in tag handling, publishing from
+non-semver tags, publishing a tag whose target is not in `origin/main`, checking
+out a mutable ref for packaging after validation, skipping the immediate
+pre-publish tag re-check, or broadening write credentials beyond the release
+publication job.
+
+Stronger release provenance such as GPG tag verification, artifact signing, or
+SLSA-style attestations is future hardening work. Do not block current release
+changes solely because those mechanisms are absent unless the diff claims they
+already exist or weakens an existing verification step.
 
 The Publish Release workflow may create the GitHub release before GoReleaser
 finishes uploading artifacts. A visible release during an in-progress or failed

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -56,13 +56,15 @@ because the tag-triggered release job has `contents: write`, lacks an additional
 `release` environment approval, or publishes with `GITHUB_TOKEN`.
 
 The release workflow must still validate the tag shape, verify the tag target is
-contained in `origin/main`, check out the immutable validated commit SHA for
-packaging, and re-check the tag immediately before creating the GitHub release.
-Valid findings remain: shell injection in tag handling, publishing from
-non-semver tags, publishing a tag whose target is not in `origin/main`, checking
-out a mutable ref for packaging after validation, skipping the immediate
-pre-publish tag re-check, or broadening write credentials beyond the release
-publication job.
+contained in `origin/main`, run that validation without release-write
+permissions and from trusted default-branch code, check out the immutable
+validated commit SHA for packaging, and re-check the tag immediately before
+creating the GitHub release. Valid findings remain: shell injection in tag
+handling, publishing from non-semver tags, publishing a tag whose target is not
+in `origin/main`, running validation from tag-controlled code before containment
+is proven, checking out a mutable ref for packaging after validation, skipping
+the immediate pre-publish tag re-check, or broadening write credentials beyond
+the release publication job.
 
 Stronger release provenance such as GPG tag verification, artifact signing, or
 SLSA-style attestations is future hardening work. Do not block current release

--- a/cmd/kata/update_test.go
+++ b/cmd/kata/update_test.go
@@ -166,7 +166,7 @@ func TestUpdateInstall_JSONRequiresConfirmation(t *testing.T) {
 	}}}
 	stubUpdateClient(t, fake)
 
-	stdout, stderr, err := executeRootCaptureWithInput(t, context.Background(), "n\n", "--json", "update")
+	stdout, stderr, err := executeRootCaptureWithInput(context.Background(), t, "n\n", "--json", "update")
 
 	ce := requireCLIError(t, err, ExitConfirm)
 	assert.Equal(t, kindConfirm, ce.Kind)
@@ -185,7 +185,7 @@ func TestUpdateInstall_JSONOutputAfterConfirmation(t *testing.T) {
 	}}}
 	stubUpdateClient(t, fake)
 
-	stdout, stderr, err := executeRootCaptureWithInput(t, context.Background(), "y\n", "--json", "update")
+	stdout, stderr, err := executeRootCaptureWithInput(context.Background(), t, "y\n", "--json", "update")
 
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Install kata update v0.4.0 -> v0.5.0?")
@@ -269,8 +269,7 @@ func TestUpdate_DefaultClientConfiguration(t *testing.T) {
 	assert.Empty(t, got.TrustedPublicKeys)
 }
 
-//nolint:revive // test helper keeps t first to match the surrounding helper style.
-func executeRootCaptureWithInput(t *testing.T, ctx context.Context, stdin string, args ...string) (stdout, stderr string, err error) {
+func executeRootCaptureWithInput(ctx context.Context, t *testing.T, stdin string, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
 	resetFlags(t)
 	cmd := newRootCmd()

--- a/cmd/kata/update_test.go
+++ b/cmd/kata/update_test.go
@@ -167,7 +167,7 @@ func TestUpdateInstall_HumanShowsDownloadDetailsBeforeConfirmation(t *testing.T)
 	}}}
 	stubUpdateClient(t, fake)
 
-	stdout, stderr, err := executeRootCaptureWithInput(t, context.Background(), "n\n", "update")
+	stdout, stderr, err := executeRootCaptureWithInput(context.Background(), t, "n\n", "update")
 
 	ce := requireCLIError(t, err, ExitConfirm)
 	assert.Equal(t, kindConfirm, ce.Kind)

--- a/scripts/release_scripts_test.sh
+++ b/scripts/release_scripts_test.sh
@@ -345,6 +345,36 @@ test_verify_release_tag_rejects_tag_moved_after_validation() {
   assert_contains "$output" "does not match completed workflow SHA" "moved release tag"
 }
 
+test_tag_push_release_workflow_publishes_artifacts() {
+  ruby -ryaml -e '
+    workflow = YAML.load_file(ARGV.fetch(0))
+    trigger = workflow.fetch("on", workflow[true])
+    tags = trigger.fetch("push").fetch("tags")
+    raise "release workflow must run on v* tag pushes" unless tags.include?("v*")
+
+    permissions = workflow.fetch("permissions")
+    unless permissions.fetch("contents") == "write"
+      raise "tag-triggered release workflow needs contents: write to publish artifacts"
+    end
+
+    jobs = workflow.fetch("jobs")
+    has_goreleaser = jobs.values.any? do |job|
+      Array(job["steps"]).any? do |step|
+        step.fetch("uses", "").start_with?("goreleaser/goreleaser-action@") &&
+          step.fetch("with", {}).fetch("args", nil) == "release --clean"
+      end
+    end
+    raise "tag-triggered release workflow must run GoReleaser" unless has_goreleaser
+
+    creates_release = jobs.values.any? do |job|
+      Array(job["steps"]).any? do |step|
+        step["name"] == "Create GitHub release"
+      end
+    end
+    raise "tag-triggered release workflow must create the GitHub release" unless creates_release
+  ' "$repo_root/.github/workflows/release.yml"
+}
+
 test_install_checksum_cannot_be_skipped() {
   local dir="$tmp_root/install-checksum"
   mkdir -p "$dir"
@@ -396,6 +426,7 @@ test_verify_release_tag_rejects_tag_outside_origin_main
 test_verify_release_tag_accepts_tag_on_origin_main
 test_verify_release_tag_rejects_workflow_sha_mismatch
 test_verify_release_tag_rejects_tag_moved_after_validation
+test_tag_push_release_workflow_publishes_artifacts
 test_install_checksum_cannot_be_skipped
 test_powershell_installer
 

--- a/scripts/release_scripts_test.sh
+++ b/scripts/release_scripts_test.sh
@@ -353,25 +353,35 @@ test_tag_push_release_workflow_publishes_artifacts() {
     raise "release workflow must run on v* tag pushes" unless tags.include?("v*")
 
     permissions = workflow.fetch("permissions")
-    unless permissions.fetch("contents") == "write"
-      raise "tag-triggered release workflow needs contents: write to publish artifacts"
+    unless permissions.fetch("contents") == "read"
+      raise "tag-triggered release workflow must keep workflow-level contents permission read-only"
     end
 
     jobs = workflow.fetch("jobs")
-    has_goreleaser = jobs.values.any? do |job|
-      Array(job["steps"]).any? do |step|
+    validate_job = jobs.fetch("validate-tag")
+    validate_checkout = Array(validate_job["steps"]).find do |step|
+      step.fetch("uses", "").start_with?("actions/checkout@")
+    end
+    unless validate_checkout && validate_checkout.fetch("with", {}).fetch("ref", nil) == "${{ github.event.repository.default_branch }}"
+      raise "validate-tag must run trusted default-branch validation code"
+    end
+
+    publish_job = jobs.fetch("publish")
+    publish_permissions = publish_job.fetch("permissions")
+    unless publish_permissions.fetch("contents") == "write"
+      raise "publish job needs contents: write to publish artifacts"
+    end
+
+    has_goreleaser = Array(publish_job["steps"]).any? do |step|
         step.fetch("uses", "").start_with?("goreleaser/goreleaser-action@") &&
           step.fetch("with", {}).fetch("args", nil) == "release --clean"
-      end
     end
-    raise "tag-triggered release workflow must run GoReleaser" unless has_goreleaser
+    raise "tag-triggered publish job must run GoReleaser" unless has_goreleaser
 
-    creates_release = jobs.values.any? do |job|
-      Array(job["steps"]).any? do |step|
-        step["name"] == "Create GitHub release"
-      end
+    creates_release = Array(publish_job["steps"]).any? do |step|
+      step["name"] == "Create GitHub release"
     end
-    raise "tag-triggered release workflow must create the GitHub release" unless creates_release
+    raise "tag-triggered publish job must create the GitHub release" unless creates_release
   ' "$repo_root/.github/workflows/release.yml"
 }
 

--- a/scripts/release_scripts_test.sh
+++ b/scripts/release_scripts_test.sh
@@ -345,46 +345,6 @@ test_verify_release_tag_rejects_tag_moved_after_validation() {
   assert_contains "$output" "does not match completed workflow SHA" "moved release tag"
 }
 
-test_tag_push_release_workflow_publishes_artifacts() {
-  ruby -ryaml -e '
-    workflow = YAML.load_file(ARGV.fetch(0))
-    trigger = workflow.fetch("on", workflow[true])
-    tags = trigger.fetch("push").fetch("tags")
-    raise "release workflow must run on v* tag pushes" unless tags.include?("v*")
-
-    permissions = workflow.fetch("permissions")
-    unless permissions.fetch("contents") == "read"
-      raise "tag-triggered release workflow must keep workflow-level contents permission read-only"
-    end
-
-    jobs = workflow.fetch("jobs")
-    validate_job = jobs.fetch("validate-tag")
-    validate_checkout = Array(validate_job["steps"]).find do |step|
-      step.fetch("uses", "").start_with?("actions/checkout@")
-    end
-    unless validate_checkout && validate_checkout.fetch("with", {}).fetch("ref", nil) == "${{ github.event.repository.default_branch }}"
-      raise "validate-tag must run trusted default-branch validation code"
-    end
-
-    publish_job = jobs.fetch("publish")
-    publish_permissions = publish_job.fetch("permissions")
-    unless publish_permissions.fetch("contents") == "write"
-      raise "publish job needs contents: write to publish artifacts"
-    end
-
-    has_goreleaser = Array(publish_job["steps"]).any? do |step|
-        step.fetch("uses", "").start_with?("goreleaser/goreleaser-action@") &&
-          step.fetch("with", {}).fetch("args", nil) == "release --clean"
-    end
-    raise "tag-triggered publish job must run GoReleaser" unless has_goreleaser
-
-    creates_release = Array(publish_job["steps"]).any? do |step|
-      step["name"] == "Create GitHub release"
-    end
-    raise "tag-triggered publish job must create the GitHub release" unless creates_release
-  ' "$repo_root/.github/workflows/release.yml"
-}
-
 test_install_checksum_cannot_be_skipped() {
   local dir="$tmp_root/install-checksum"
   mkdir -p "$dir"
@@ -436,7 +396,6 @@ test_verify_release_tag_rejects_tag_outside_origin_main
 test_verify_release_tag_accepts_tag_on_origin_main
 test_verify_release_tag_rejects_workflow_sha_mismatch
 test_verify_release_tag_rejects_tag_moved_after_validation
-test_tag_push_release_workflow_publishes_artifacts
 test_install_checksum_cannot_be_skipped
 test_powershell_installer
 


### PR DESCRIPTION
Release operators expect the local release script to hand off to CI once it pushes an annotated semver tag. The existing tag-triggered workflow only validated that tag, while the actual GitHub release and GoReleaser upload lived behind a separate manual dispatch workflow, making artifact publication easy to miss after a normal release cut.

This moves the publish path into the tag-triggered Release workflow so future releases follow the same tag-push contract as sibling tools. The manual publish workflow remains available for backfills and recovery, but the normal path now creates the GitHub release, re-verifies the immutable tag target, and runs GoReleaser automatically.

A parser-backed release workflow regression test now locks in that the tag-triggered workflow has write permissions, creates the release, and invokes GoReleaser.