### PR TITLE
Improve dev-build update prompts

### DIFF
--- a/cmd/kata/update.go
+++ b/cmd/kata/update.go
@@ -47,11 +47,12 @@ func newUpdateCmd() *cobra.Command {
 		Short: "check for and install kata updates",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			currentIsDevBuild := selfupdate.IsDevBuildVersion(version.Version)
 			client, err := newSelfUpdateClient(version.Version)
 			if err != nil {
 				return err
 			}
-			opts := selfupdate.CheckOptions{Force: force}
+			opts := selfupdate.CheckOptions{Force: force || currentIsDevBuild}
 			info, err := client.Check(cmd.Context(), opts)
 			if err != nil {
 				return err
@@ -72,6 +73,14 @@ func newUpdateCmd() *cobra.Command {
 					return printUpdateResult(cmd, nil)
 				}
 			}
+			if currentOutputMode() == outputHuman && !yes {
+				if err := printUpdateSummary(cmd, info); err != nil {
+					return err
+				}
+			}
+			if info.IsDevBuild && !force {
+				return printDevBuildForceHint(cmd, info)
+			}
 			if !yes {
 				if err := confirmUpdate(cmd, info); err != nil {
 					return err
@@ -91,6 +100,57 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "force a fresh update check")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "install without prompting")
 	return cmd
+}
+
+func printUpdateSummary(cmd *cobra.Command, info *selfupdate.Info) error {
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "\nCurrent version: %s\nLatest version:  %s\n",
+		currentUpdateVersion(info), latestUpdateVersion(info)); err != nil {
+		return err
+	}
+	if info.IsDevBuild {
+		if _, err := fmt.Fprintln(out, "\nYou're running a dev build. Latest official release available."); err != nil {
+			return err
+		}
+	} else if _, err := fmt.Fprintln(out, "\nUpdate available."); err != nil {
+		return err
+	}
+	if info.DownloadURL == "" && info.Size == 0 && info.Checksum == "" {
+		_, err := fmt.Fprintln(out)
+		return err
+	}
+	if _, err := fmt.Fprintln(out, "\nDownload:"); err != nil {
+		return err
+	}
+	if info.DownloadURL != "" {
+		if _, err := fmt.Fprintf(out, "  URL:    %s\n", info.DownloadURL); err != nil {
+			return err
+		}
+	}
+	if info.Size > 0 {
+		if _, err := fmt.Fprintf(out, "  Size:   %s\n", selfupdate.FormatSize(info.Size)); err != nil {
+			return err
+		}
+	}
+	if info.Checksum != "" {
+		if _, err := fmt.Fprintf(out, "  SHA256: %s\n", info.Checksum); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(out)
+	return err
+}
+
+func printDevBuildForceHint(cmd *cobra.Command, info *selfupdate.Info) error {
+	switch currentOutputMode() {
+	case outputHuman:
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "Use 'kata update --force' to install the latest official release.")
+		return err
+	case outputAgent, outputJSON:
+		return printUpdateResult(cmd, info)
+	default:
+		return nil
+	}
 }
 
 func confirmUpdate(cmd *cobra.Command, info *selfupdate.Info) error {
@@ -175,6 +235,10 @@ func printUpdateResult(cmd *cobra.Command, info *selfupdate.Info) error {
 		_, err := fmt.Fprint(out, buf.String())
 		return err
 	default:
+		if info != nil && info.IsDevBuild {
+			_, err := fmt.Fprintf(out, "dev build: %s\nlatest official release: %s\nUse 'kata update --force' to install the latest official release.\n", current, latest)
+			return err
+		}
 		if info == nil {
 			_, err := fmt.Fprintf(out, "kata is up to date (%s)\n", current)
 			return err

--- a/cmd/kata/update_test.go
+++ b/cmd/kata/update_test.go
@@ -88,6 +88,26 @@ func TestUpdateCheck_HumanUpdateAvailable(t *testing.T) {
 	assert.Empty(t, fake.installed)
 }
 
+func TestUpdateCheck_DevBuildForcesFreshCheckAndShowsOfficialRelease(t *testing.T) {
+	resetFlags(t)
+	stubVersionInfo(t, "v0.5.0-9-gcf994f5", "cf994f5", "2026-06-24T15:00:00Z")
+	fake := &fakeUpdateClient{checkResults: []*selfupdate.Info{{
+		CurrentVersion: "v0.5.0-9-gcf994f5",
+		LatestVersion:  "v0.6.0",
+		AssetName:      "kata_0.6.0_linux_amd64.tar.gz",
+		IsDevBuild:     true,
+	}}}
+	stubUpdateClient(t, fake)
+
+	stdout, _, err := executeRootCapture(t, context.Background(), "update", "--check")
+
+	require.NoError(t, err)
+	assert.Equal(t, "dev build: v0.5.0-9-gcf994f5\nlatest official release: v0.6.0\nUse 'kata update --force' to install the latest official release.\n", stdout)
+	require.Len(t, fake.checks, 1)
+	assert.True(t, fake.checks[0].Force)
+	assert.Empty(t, fake.installed)
+}
+
 func TestUpdateCheck_JSONOutput(t *testing.T) {
 	resetFlags(t)
 	stubVersionInfo(t, "v0.4.0", "abc1234", "2026-06-19T12:00:00Z")
@@ -132,6 +152,70 @@ func TestUpdateCheck_AgentOutput(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "OK update update_available=true current=v0.4.0 latest=v0.5.0\n", stdout)
+}
+
+func TestUpdateInstall_HumanShowsDownloadDetailsBeforeConfirmation(t *testing.T) {
+	resetFlags(t)
+	stubVersionInfo(t, "v0.4.0", "abc1234", "2026-06-19T12:00:00Z")
+	fake := &fakeUpdateClient{checkResults: []*selfupdate.Info{{
+		CurrentVersion: "v0.4.0",
+		LatestVersion:  "v0.5.0",
+		DownloadURL:    "https://example.test/kata_0.5.0_linux_amd64.tar.gz",
+		AssetName:      "kata_0.5.0_linux_amd64.tar.gz",
+		Size:           2048,
+		Checksum:       "abc123checksum",
+	}}}
+	stubUpdateClient(t, fake)
+
+	stdout, stderr, err := executeRootCaptureWithInput(t, context.Background(), "n\n", "update")
+
+	ce := requireCLIError(t, err, ExitConfirm)
+	assert.Equal(t, kindConfirm, ce.Kind)
+	assert.Equal(t, "\nCurrent version: v0.4.0\nLatest version:  v0.5.0\n\nUpdate available.\n\nDownload:\n  URL:    https://example.test/kata_0.5.0_linux_amd64.tar.gz\n  Size:   2.0 KB\n  SHA256: abc123checksum\n\n", stdout)
+	assert.Contains(t, stderr, "Install kata update v0.4.0 -> v0.5.0?")
+	assert.Empty(t, fake.installed)
+}
+
+func TestUpdateInstall_DevBuildRequiresForce(t *testing.T) {
+	resetFlags(t)
+	stubVersionInfo(t, "v0.5.0-9-gcf994f5", "cf994f5", "2026-06-24T15:00:00Z")
+	fake := &fakeUpdateClient{checkResults: []*selfupdate.Info{{
+		CurrentVersion: "v0.5.0-9-gcf994f5",
+		LatestVersion:  "v0.6.0",
+		DownloadURL:    "https://example.test/kata_0.6.0_linux_amd64.tar.gz",
+		AssetName:      "kata_0.6.0_linux_amd64.tar.gz",
+		Size:           4096,
+		Checksum:       "def456checksum",
+		IsDevBuild:     true,
+	}}}
+	stubUpdateClient(t, fake)
+
+	stdout, stderr, err := executeRootCapture(t, context.Background(), "update")
+
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.Equal(t, "\nCurrent version: v0.5.0-9-gcf994f5\nLatest version:  v0.6.0\n\nYou're running a dev build. Latest official release available.\n\nDownload:\n  URL:    https://example.test/kata_0.6.0_linux_amd64.tar.gz\n  Size:   4.0 KB\n  SHA256: def456checksum\n\nUse 'kata update --force' to install the latest official release.\n", stdout)
+	require.Len(t, fake.checks, 1)
+	assert.True(t, fake.checks[0].Force)
+	assert.Empty(t, fake.installed)
+}
+
+func TestUpdateInstall_DevBuildForceInstalls(t *testing.T) {
+	resetFlags(t)
+	stubVersionInfo(t, "v0.5.0-9-gcf994f5", "cf994f5", "2026-06-24T15:00:00Z")
+	fake := &fakeUpdateClient{checkResults: []*selfupdate.Info{{
+		CurrentVersion: "v0.5.0-9-gcf994f5",
+		LatestVersion:  "v0.6.0",
+		AssetName:      "kata_0.6.0_linux_amd64.tar.gz",
+		IsDevBuild:     true,
+	}}}
+	stubUpdateClient(t, fake)
+
+	stdout, _, err := executeRootCapture(t, context.Background(), "update", "--force", "--yes")
+
+	require.NoError(t, err)
+	assert.Equal(t, "installed kata v0.6.0\n", stdout)
+	assert.Len(t, fake.installed, 1)
 }
 
 func TestUpdateInstall_RefetchesCachedInfoBeforeInstall(t *testing.T) {


### PR DESCRIPTION
Dev builds could reuse cached release data and tell users they were up to date, even when an official release was available. That made the update path confusing because it did not show the latest production version, did not explain that replacing a dev build requires --force, and did not show the release metadata users need before trusting an install.

This change makes dev-build update checks fetch fresh release data, surfaces the latest official release with download URL, size, and SHA256 before human confirmation, and stops short of installing over a dev build unless the user explicitly passes --force. JSON and agent modes keep their structured update result so automation can still decide how to proceed.