### PR TITLE
Redirect source-style quickstart docs URL

### DIFF
--- a/docs/scripts/check_vercel_redirects.py
+++ b/docs/scripts/check_vercel_redirects.py
@@ -15,6 +15,10 @@ TEMPORARY = {
     "/install.ps1": "https://raw.githubusercontent.com/kenn-io/kata/main/scripts/install.ps1",
 }
 
+PERMANENT = {
+    "/get-started/quickstart.md": "/get-started/quickstart/",
+}
+
 
 def fail(message: str) -> None:
     print(f"FAIL: {message}", file=sys.stderr)
@@ -103,6 +107,13 @@ def main() -> None:
             fail(f"missing temporary redirect {source}")
         if item.get("destination") != destination or item.get("permanent") is not False:
             fail(f"incorrect temporary redirect {source}")
+
+    for source, destination in PERMANENT.items():
+        item = redirects.get(source)
+        if not item:
+            fail(f"missing permanent redirect {source}")
+        if item.get("destination") != destination or item.get("permanent") is not True:
+            fail(f"incorrect permanent redirect {source}")
 
     print("vercel redirect checks passed")
 

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -6,6 +6,11 @@
   "outputDirectory": "site",
   "redirects": [
     {
+      "source": "/get-started/quickstart.md",
+      "destination": "/get-started/quickstart/",
+      "permanent": true
+    },
+    {
       "source": "/install.sh",
       "destination": "https://raw.githubusercontent.com/kenn-io/kata/main/scripts/install.sh",
       "permanent": false


### PR DESCRIPTION
Users can reasonably land on the public quickstart source path after seeing `quickstart.md` in repo and documentation contexts. The generated docs site serves the canonical directory URL, so the source-style path currently falls through to Vercel's 404 page even though the page exists.

This adds the compatibility redirect to the docs deployment contract and locks it into the existing redirect checker so future Vercel config changes keep the public URL working. Reviewers should note that the live URL will not change until this branch is deployed.