### PR TITLE
Serve docs Markdown sources from builds

### DIFF
--- a/docs/development/deploying-docs.md
+++ b/docs/development/deploying-docs.md
@@ -22,6 +22,11 @@ Vercel should install with `uv sync --frozen --no-dev`.
 Vercel should build with `uv run --frozen bash ./vercel-build.sh`.
 Vercel should publish the generated `site/` directory.
 
+The build wrapper also copies every nav-listed Markdown document into `site/`.
+That keeps source-form docs available from the same deployment as the rendered
+page: for example, `/get-started/quickstart.md` serves the Markdown source that
+generated `/get-started/quickstart/`.
+
 ## Repository config
 
 Prefer committing the deployment settings instead of relying only on dashboard

--- a/docs/scripts/check_public_markdown_sources.py
+++ b/docs/scripts/check_public_markdown_sources.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+from public_markdown_sources import fail, public_markdown_sources
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "zensical.toml"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check generated docs include public Markdown source files.",
+    )
+    parser.add_argument(
+        "--site-dir",
+        default="site",
+        help="generated site directory relative to docs root",
+    )
+    args = parser.parse_args()
+
+    site_dir = ROOT / args.site_dir
+    if not site_dir.is_dir():
+        fail(f"missing generated site directory: {site_dir.relative_to(ROOT)}")
+
+    for path in public_markdown_sources(CONFIG):
+        source = ROOT / path
+        generated = site_dir / path
+        if not source.is_file():
+            fail(f"nav source is missing: {path}")
+        if not generated.is_file():
+            fail(f"generated site is missing Markdown source: {generated.relative_to(ROOT)}")
+        if generated.read_bytes() != source.read_bytes():
+            fail(
+                "generated Markdown source differs from docs source: "
+                f"{generated.relative_to(ROOT)}",
+            )
+
+    print("public Markdown source checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/check_vercel_redirects.py
+++ b/docs/scripts/check_vercel_redirects.py
@@ -15,10 +15,6 @@ TEMPORARY = {
     "/install.ps1": "https://raw.githubusercontent.com/kenn-io/kata/main/scripts/install.ps1",
 }
 
-PERMANENT = {
-    "/get-started/quickstart.md": "/get-started/quickstart/",
-}
-
 
 def fail(message: str) -> None:
     print(f"FAIL: {message}", file=sys.stderr)
@@ -101,19 +97,16 @@ def main() -> None:
         fail("unexpected Vercel outputDirectory")
 
     redirects = collect_redirects(data)
+    for source in redirects:
+        if source.endswith(".md"):
+            fail(f"Markdown source URL must be served as a static file, not redirected: {source}")
+
     for source, destination in TEMPORARY.items():
         item = redirects.get(source)
         if not item:
             fail(f"missing temporary redirect {source}")
         if item.get("destination") != destination or item.get("permanent") is not False:
             fail(f"incorrect temporary redirect {source}")
-
-    for source, destination in PERMANENT.items():
-        item = redirects.get(source)
-        if not item:
-            fail(f"missing permanent redirect {source}")
-        if item.get("destination") != destination or item.get("permanent") is not True:
-            fail(f"incorrect permanent redirect {source}")
 
     print("vercel redirect checks passed")
 

--- a/docs/scripts/copy_public_markdown_sources.py
+++ b/docs/scripts/copy_public_markdown_sources.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import shutil
+
+from public_markdown_sources import fail, public_markdown_sources
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Copy public docs Markdown sources into the generated site.",
+    )
+    parser.add_argument(
+        "--docs-dir",
+        required=True,
+        help="public docs source directory relative to docs root",
+    )
+    parser.add_argument(
+        "--site-dir",
+        default="site",
+        help="generated site directory relative to docs root",
+    )
+    parser.add_argument(
+        "--config",
+        default="zensical.toml",
+        help="Zensical config path relative to docs root",
+    )
+    args = parser.parse_args()
+
+    docs_dir = ROOT / args.docs_dir
+    site_dir = ROOT / args.site_dir
+    config = ROOT / args.config
+    if not docs_dir.is_dir():
+        fail(f"missing public docs source directory: {docs_dir.relative_to(ROOT)}")
+    if not site_dir.is_dir():
+        fail(f"missing generated site directory: {site_dir.relative_to(ROOT)}")
+
+    for path in public_markdown_sources(config):
+        source = docs_dir / path
+        destination = site_dir / path
+        if not source.is_file():
+            fail(f"nav source is missing from public docs tree: {source.relative_to(ROOT)}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+
+    print("public Markdown sources copied")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/public_markdown_sources.py
+++ b/docs/scripts/public_markdown_sources.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import tomllib
+from collections.abc import Iterable
+from typing import Any
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def iter_nav_markdown(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        if value.endswith(".md"):
+            yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from iter_nav_markdown(item)
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            yield from iter_nav_markdown(item)
+
+
+def public_markdown_sources(config: pathlib.Path) -> list[str]:
+    try:
+        data = tomllib.loads(config.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing {config.name}")
+    except tomllib.TOMLDecodeError as error:
+        fail(f"invalid {config.name}: {error}")
+
+    project = data.get("project")
+    if not isinstance(project, dict):
+        fail(f"{config.name} missing [project]")
+    nav = project.get("nav")
+    if not isinstance(nav, list):
+        fail(f"{config.name} missing project.nav")
+
+    seen: set[str] = set()
+    sources: list[str] = []
+    for path in iter_nav_markdown(nav):
+        if path not in seen:
+            seen.add(path)
+            sources.append(path)
+    if not sources:
+        fail(f"{config.name} nav does not list any Markdown documents")
+    return sources

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -6,11 +6,6 @@
   "outputDirectory": "site",
   "redirects": [
     {
-      "source": "/get-started/quickstart.md",
-      "destination": "/get-started/quickstart/",
-      "permanent": true
-    },
-    {
       "source": "/install.sh",
       "destination": "https://raw.githubusercontent.com/kenn-io/kata/main/scripts/install.sh",
       "permanent": false

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -82,6 +82,7 @@ awk -v docs_dir="$tmp_docs_name" -v site_dir="$site_dir" '
 case "$command_name" in
   build)
     (cd "$docs_root" && "$zensical_bin" build --strict --config-file "$tmp_config_name" "$@")
+    (cd "$docs_root" && python3 scripts/copy_public_markdown_sources.py --docs-dir "$tmp_docs_name" --site-dir "$site_dir" --config "$tmp_config_name")
     ;;
   serve)
     (cd "$docs_root" && "$zensical_bin" serve --config-file "$tmp_config_name" "$@")

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -27,6 +27,9 @@ required_files=(
   "docs/vercel-build.sh"
   "docs/zensical-docs.sh"
   "docs/scripts/check_vercel_redirects.py"
+  "docs/scripts/check_public_markdown_sources.py"
+  "docs/scripts/copy_public_markdown_sources.py"
+  "docs/scripts/public_markdown_sources.py"
   "scripts/update-docs.sh"
   "docs/pyproject.toml"
   "docs/uv.lock"
@@ -143,8 +146,10 @@ mkdir -p "$vercel_docs_root/docs"
     -cf - .
 ) | (cd "$vercel_docs_root/docs" && tar -xf -)
 (cd "$vercel_docs_root/docs" && uv run --frozen bash ./vercel-build.sh)
+(cd "$vercel_docs_root/docs" && python3 scripts/check_public_markdown_sources.py)
 
 (cd docs && uv run --frozen bash ./zensical-docs.sh build)
+(cd docs && python3 scripts/check_public_markdown_sources.py)
 
 for generated in \
   docs/site/.env.local \


### PR DESCRIPTION
Agents that request source-style docs URLs need the Markdown document that generated the rendered page, not a redirect to the rendered HTML route and not a raw GitHub URL that can drift from the deployed site. This changes the docs build so nav-listed Markdown sources are copied into the generated `site` directory and served from the same deployment as their rendered pages.

The previous quickstart-only redirect fixed one URL for browser navigation, but it did not solve the broader agent-facing contract for public docs. Keeping `.md` URLs as static files makes the mapping predictable: `/path.md` is the source for `/path/`, with the Vercel redirect checker preventing the behavior from regressing back into `.md` redirects.

The branch also documents this deployment behavior for future docs maintenance.