### PR TITLE
Add comment edit redaction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ overwriting the rest of either file.
   state lives in SQLite under `KATA_HOME`; your repo commits only a small,
   secret-free `.kata.toml`.
 - **Auditable by design.** Closing an issue is an explicit completion claim with
-  a reason, message, evidence, and actor attribution, on top of append-only
+  a reason, message, evidence, and actor attribution, on top of editable
   comments and durable events.
 
 ## How kata compares

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -717,6 +717,17 @@ components:
     DisableIssueSyncRequestBody:
       additionalProperties: false
       type: object
+    EditCommentRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        body:
+          type: string
+      required:
+        - actor
+        - body
+      type: object
     EditIssueRequestBody:
       additionalProperties: false
       properties:
@@ -4949,6 +4960,45 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CommentRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommentResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}:
+    patch:
+      operationId: editComment
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: comment_ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EditCommentRequestBody"
         required: true
       responses:
         "200":

--- a/cmd/kata/comment.go
+++ b/cmd/kata/comment.go
@@ -40,16 +40,9 @@ func newCommentCmd() *cobra.Command {
 		src.BodySet = cmd.Flags().Changed("body")
 		src.FileSet = cmd.Flags().Changed("body-file")
 
-		body, err := resolveBody(src, cmd.InOrStdin())
+		body, err := resolveCommentBody(cmd, src)
 		if err != nil {
-			code := ExitValidation
-			if strings.HasPrefix(err.Error(), "must pass exactly one of") {
-				code = ExitUsage
-			}
-			return &cliError{Message: err.Error(), Kind: kindForExit(code), ExitCode: code}
-		}
-		if strings.TrimSpace(body) == "" {
-			return &cliError{Message: "comment body is required (--body, --body-file, --body-stdin)", Kind: kindValidation, ExitCode: ExitValidation}
+			return err
 		}
 		ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, args[0])
 		if err != nil {
@@ -88,7 +81,85 @@ func newCommentCmd() *cobra.Command {
 		}
 		return nil
 	}
+	cmd.AddCommand(newCommentEditCmd())
 	return cmd
+}
+
+func newCommentEditCmd() *cobra.Command {
+	var src BodySources
+	cmd := &cobra.Command{
+		Use:   "edit <issue-ref> <comment-uid>",
+		Short: "edit a comment body",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			src.BodySet = cmd.Flags().Changed("body")
+			src.FileSet = cmd.Flags().Changed("body-file")
+			body, err := resolveCommentBody(cmd, src)
+			if err != nil {
+				return err
+			}
+			commentRef := strings.TrimSpace(args[1])
+			if commentRef == "" {
+				return &cliError{Message: "comment uid is required", Kind: kindValidation, ExitCode: ExitValidation}
+			}
+			ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, args[0])
+			if err != nil {
+				return err
+			}
+			actor, _ := resolveActor(ctx, flags.As, nil)
+			client, err := httpClientFor(ctx, baseURL)
+			if err != nil {
+				return err
+			}
+			status, bs, err := httpDoJSON(ctx, client, http.MethodPatch,
+				fmt.Sprintf("%s/api/v1/projects/%d/issues/%s/comments/%s",
+					baseURL, pid, url.PathEscape(issue.RefForAPI), url.PathEscape(commentRef)),
+				map[string]any{"actor": actor, "body": body})
+			if err != nil {
+				return err
+			}
+			if status >= 400 {
+				return apiErrFromBody(status, bs)
+			}
+			switch currentOutputMode() {
+			case outputJSON:
+				var buf bytes.Buffer
+				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
+					return err
+				}
+				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+				return err
+			case outputAgent:
+				return printAgentMutation(cmd, "comment", bs, func(w io.Writer, _ agentIssueMutation) error {
+					return writeAgentField(w, "Comment", "edited")
+				})
+			}
+			if !flags.Quiet {
+				_, err = fmt.Fprintln(cmd.OutOrStdout(), "comment edited")
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&src.Body, "body", "m", "", "comment body")
+	cmd.Flags().StringVar(&src.File, "body-file", "", "read body from file")
+	cmd.Flags().BoolVar(&src.Stdin, "body-stdin", false, "read body from stdin")
+	return cmd
+}
+
+func resolveCommentBody(cmd *cobra.Command, src BodySources) (string, error) {
+	body, err := resolveBody(src, cmd.InOrStdin())
+	if err != nil {
+		code := ExitValidation
+		if strings.HasPrefix(err.Error(), "must pass exactly one of") {
+			code = ExitUsage
+		}
+		return "", &cliError{Message: err.Error(), Kind: kindForExit(code), ExitCode: code}
+	}
+	if strings.TrimSpace(body) == "" {
+		return "", &cliError{Message: "comment body is required (--body, --body-file, --body-stdin)", Kind: kindValidation, ExitCode: ExitValidation}
+	}
+	return body, nil
 }
 
 type commentRelationshipFlags struct {

--- a/cmd/kata/comment_test.go
+++ b/cmd/kata/comment_test.go
@@ -28,6 +28,27 @@ func TestComment_MessageShorthandAppendsToIssue(t *testing.T) {
 	assert.Equal(t, "looks good", issue.Comments[0].Body)
 }
 
+func TestComment_EditUpdatesExistingCommentByUID(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	short := createIssue(t, env, pid, "x")
+	runCLI(t, env, dir, "comment", short, "--body", "token=leaked")
+	issue := fetchIssueViaHTTPWithComments(t, env, pid, short)
+	require.Len(t, issue.Comments, 1)
+	commentUID := issue.Comments[0].UID
+	require.NotEmpty(t, commentUID)
+
+	out := runCLI(t, env, dir, "comment", "edit", short, commentUID, "--body", "[redacted]")
+	assert.True(t, strings.Contains(out, "comment edited") || strings.Contains(out, "comment"))
+
+	updated := fetchIssueViaHTTPWithComments(t, env, pid, short)
+	require.Len(t, updated.Comments, 1)
+	assert.Equal(t, commentUID, updated.Comments[0].UID)
+	assert.Equal(t, "[redacted]", updated.Comments[0].Body)
+	assert.NotContains(t, runCLI(t, env, dir, "show", short), "token=leaked")
+	assert.Contains(t, runCLI(t, env, dir, "show", short), commentUID)
+	assert.Contains(t, runCLI(t, env, dir, "--agent", "show", short), "uid="+commentUID)
+}
+
 func TestComment_RelationshipFlagSuggestsEditCommentComposition(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)

--- a/cmd/kata/show.go
+++ b/cmd/kata/show.go
@@ -79,8 +79,8 @@ func newShowCmd() *cobra.Command {
 					return err
 				}
 				for _, c := range b.Comments {
-					if _, err := fmt.Fprintf(out, "%s: %s\n",
-						textsafe.Line(c.Author), textsafe.Block(c.Body)); err != nil {
+					if _, err := fmt.Fprintf(out, "%s %s: %s\n",
+						textsafe.Line(c.UID), textsafe.Line(c.Author), textsafe.Block(c.Body)); err != nil {
 						return err
 					}
 				}
@@ -128,6 +128,7 @@ type showResponseForCLI struct {
 		Priority *int64  `json:"priority"`
 	} `json:"issue"`
 	Comments []struct {
+		UID       string `json:"uid"`
 		Author    string `json:"author"`
 		Body      string `json:"body"`
 		CreatedAt string `json:"created_at"`
@@ -192,6 +193,7 @@ func printShowAgent(w io.Writer, b showResponseForCLI, subjectProject string) er
 		}
 		for _, c := range b.Comments {
 			if err := writeAgentKVRow(w,
+				agentRowField("uid", c.UID),
 				agentRowField("author", c.Author),
 				agentRowField("created_at", c.CreatedAt),
 			); err != nil {

--- a/cmd/kata/show_test.go
+++ b/cmd/kata/show_test.go
@@ -62,7 +62,7 @@ func TestShow_AgentOutputRendersIssueBodyLabelsAndComments(t *testing.T) {
 	assert.Contains(t, out, "Labels: bug,safari\n")
 	assert.Contains(t, out, "Priority: 2\n")
 	assert.Contains(t, out, "Body:\n```text\nSafari can double-submit the callback.\n```\n")
-	assert.Regexp(t, regexp.MustCompile(`(?m)^- author=tester created_at=[^ \n]+$`), out)
+	assert.Regexp(t, regexp.MustCompile(`(?m)^- uid=[0-9A-HJKMNP-TV-Z]{26} author=tester created_at=[^ \n]+$`), out)
 	assert.Contains(t, out, "\n```text\nReproduced on macOS.\n```")
 	assert.NotContains(t, out, "Owner:")
 }

--- a/cmd/kata/testhelpers_test.go
+++ b/cmd/kata/testhelpers_test.go
@@ -563,6 +563,7 @@ type IssueResponse struct {
 		To   linkPeerTest `json:"to"`
 	} `json:"links"`
 	Comments []struct {
+		UID    string `json:"uid"`
 		Author string `json:"author"`
 		Body   string `json:"body"`
 	} `json:"comments"`

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -18,8 +18,9 @@ idempotency keys with fingerprints, structured error envelopes, and no implicit
 never silently writes into the wrong namespace.
 
 **Auditability.** Every state change appends to an immutable event log with the
-actor recorded. Comments are append-only. Deletion has a reversible soft tier
-and an irreversible hard tier, each gated behind explicit confirmation.
+actor recorded. Comments can be appended and body-edited while preserving their
+identity and original attribution. Deletion has a reversible soft tier and an
+irreversible hard tier, each gated behind explicit confirmation.
 
 **A small, sharp surface.** Issue lifecycle, three relationship types
 (`parent`, `blocks`, `related`, with `blocked_by` as the inverse of `blocks`),

--- a/docs/design/data-model.md
+++ b/docs/design/data-model.md
@@ -33,7 +33,9 @@ State changes are not just stored; they are recorded. Three rules follow:
 - The **events** table is append-only and is the authoritative record of every
   state change. Each event carries the actor, a stable event `uid`, the
   originating instance UID, and a payload with the field-level diff.
-- The **comments** table is append-only — no edit, no delete short of purge.
+- The **comments** table stores current comment bodies. Comment bodies can be
+  edited in place for redaction while preserving UID, author, and creation
+  time; there is no comment delete short of issue purge.
 - Issues themselves are mutable current-state rows, but every mutation emits an
   event, so the current row is always reconstructable from history.
 

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -320,7 +320,9 @@ For federated projects, ordinary edits of existing issues are local-first and
 converge by LWW. Creating new issues is also local-first. A lease is optional
 coordination: when another holder has a live lease on an affected existing
 issue, non-comment mutations are denied until the lease is released or expires.
-Comments bypass leases because they are append-only.
+Comment creation and comment body edits bypass leases because they remain
+comment-level collaboration and maintenance actions rather than leased issue
+work.
 
 Spokes refresh cached lease state before checking exclusivity when online.
 When offline, cached hard leases can still be used as a continuity hint, but
@@ -572,7 +574,8 @@ preserve. Ordinary edits are therefore always local-first and converge by LWW. A
 lease adds only temporary exclusivity against *conflicting* non-comment work by
 another holder while it is live — the hub guarantees at most one live holder.
 Unleased work is normal and is never a violation; pending or expired leases do
-not block edits; and comments always pass because they are append-only.
+not block edits; and comment creation or body edits always pass as comment-level
+work.
 
 Because the hub cannot reject a mutation that already happened offline, it does
 not try to. When pushed work conflicts with another holder's live lease the hub

--- a/docs/design/github-sync.md
+++ b/docs/design/github-sync.md
@@ -125,8 +125,8 @@ GitHub sync v1 intentionally excludes several features:
   filtered out.
 - No propagation for deleted or transferred GitHub issues. Imported issues can
   remain in kata until a future reconciliation feature exists.
-- No propagation for edited or deleted GitHub comments. Imported comments are
-  append-only.
+- No propagation for edited or deleted GitHub comments. Local edits to imported
+  comment bodies are not written back to GitHub.
 - No multiple external issue sources per kata project.
 - No co-assignee fan-out. Only the first GitHub assignee maps to the kata owner.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ Prefer `go install`, `.deb`/`.rpm` packages, or building from source? See
 -   __Auditable by design__
 
     Closing an issue is an explicit completion claim with a reason, message,
-    evidence, and actor attribution, on top of append-only comments and durable
+    evidence, and actor attribution, on top of editable comments and durable
     events.
 
 </div>

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -555,7 +555,9 @@ For federated projects, ordinary issue edits are local-first and converge by
 LWW. Creating new issues also stays local-first. A lease is optional
 coordination: when another holder has a live lease on an affected existing
 issue, non-comment mutations are denied until the lease is released or expires.
-Comments bypass leases because they are append-only.
+Comment creation and comment body edits bypass leases because they remain
+comment-level collaboration and maintenance actions rather than leased issue
+work.
 
 Spokes refresh cached lease state before checking exclusivity when online.
 When offline, cached hard leases can still be used as a continuity hint, but

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -118,6 +118,8 @@ Comment:
 
 ```sh
 kata comment <ref> [--body TEXT | --body-file PATH | --body-stdin]
+kata comment edit <ref> <comment-uid> \
+  [--body TEXT | --body-file PATH | --body-stdin]
 ```
 
 Close:
@@ -216,8 +218,8 @@ re-enabled locally.
 
 Synced issues are GitHub-owned for title, body, state, labels, owner, and
 imported GitHub comments. Treat those fields as read-mostly in kata: local
-edits are not written back to GitHub and can be overwritten by newer GitHub
-state. Only the first GitHub assignee maps to the kata owner.
+issue or comment edits are not written back to GitHub and can be overwritten by
+newer GitHub state. Only the first GitHub assignee maps to the kata owner.
 
 `disable` stops polling but preserves the binding and import mappings.
 `status` reports the current binding and last sync outcome. `once` runs an

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -102,6 +102,20 @@ If you build against this schema and hit a gap, please open an issue — the
 contract is meant to be useful to external clients, and feedback shapes how far
 the compatibility guarantees are taken.
 
+## Comment Endpoints
+
+Comments can be appended with `POST
+/api/v1/projects/{project_id}/issues/{ref}/comments` and edited in place with
+`PATCH /api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}`.
+Use the comment UID as `comment_ref`; numeric comment IDs are local storage
+artifacts.
+
+Editing a comment overwrites the current comment body while preserving the
+original author, UID, creation time, and thread position. This is the supported
+primitive for redacting comment text before enrolling a project in federation.
+It is not a purge mechanism for data that has already crossed into another
+federated event log.
+
 ## Issue Sync Endpoints
 
 Issue sync endpoints are project-scoped and provider-qualified. They configure
@@ -199,7 +213,7 @@ The shared response body contains:
 Synced issues are GitHub-owned for title, body, state, labels, owner, and
 imported GitHub comments. API clients should treat those fields as read-mostly
 in kata: kata does not write back to GitHub, and newer GitHub updates can
-overwrite local edits to those fields.
+overwrite local issue or comment edits to those fields.
 
 V1 does not support GitHub write-back, timeline events, pull requests, deleted
 or transferred issue propagation, edited or deleted comment propagation, or

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -582,6 +582,17 @@ type CommentRequest struct {
 	}
 }
 
+// EditCommentRequest is PATCH /api/v1/projects/{id}/issues/{ref}/comments/{comment_ref}.
+type EditCommentRequest struct {
+	ProjectID  int64  `path:"project_id" required:"true"`
+	Ref        string `path:"ref" required:"true"`
+	CommentRef string `path:"comment_ref" required:"true"`
+	Body       struct {
+		Actor string `json:"actor" required:"true"`
+		Body  string `json:"body" required:"true"`
+	}
+}
+
 // CommentResponse mirrors MutationResponse but adds the new comment row.
 type CommentResponse struct {
 	Body struct {

--- a/internal/daemon/handlers_comments.go
+++ b/internal/daemon/handlers_comments.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 
@@ -48,6 +50,56 @@ func registerCommentsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		out.Body.Comment = c
 		out.Body.Event = &evt
 		out.Body.Changed = true
+		return out, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "editComment",
+		Method:      "PATCH",
+		Path:        "/api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}",
+	}, func(ctx context.Context, in *api.EditCommentRequest) (*api.CommentResponse, error) {
+		actor, err := attributedActor(ctx, in.Body.Actor)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(in.Body.Body) == "" {
+			return nil, api.NewError(400, "validation", "comment body is required", "", nil)
+		}
+		issue, err := activeIssueByRef(ctx, cfg.DB, in.ProjectID, in.Ref, db.IncludeDeletedNo)
+		if err != nil {
+			return nil, err
+		}
+		// Comment creation has always sat outside the federation claim gate;
+		// comment edits follow that model so redaction remains a comment-level
+		// maintenance action rather than leased issue work.
+		c, evt, changed, err := cfg.DB.EditComment(ctx, db.EditCommentParams{
+			IssueID:    issue.ID,
+			CommentUID: in.CommentRef,
+			Actor:      actor,
+			Body:       in.Body.Body,
+		})
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, api.NewError(404, "comment_not_found", "comment not found", "", nil)
+		}
+		if err != nil {
+			if apiErr := federationReadOnlyError(err); apiErr != nil {
+				return nil, apiErr
+			}
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		if changed && evt != nil {
+			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: in.ProjectID})
+			cfg.Hooks.Enqueue(*evt)
+		}
+		updated, err := cfg.DB.IssueByID(ctx, issue.ID)
+		if err != nil {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		out := &api.CommentResponse{}
+		out.Body.Issue = updated
+		out.Body.Comment = c
+		out.Body.Event = evt
+		out.Body.Changed = changed
 		return out, nil
 	})
 }

--- a/internal/daemon/handlers_comments_test.go
+++ b/internal/daemon/handlers_comments_test.go
@@ -1,6 +1,7 @@
 package daemon_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,28 @@ func TestCommentEndpoint_AppendsAndEmitsEvent(t *testing.T) {
 	require.Equal(t, 200, resp.StatusCode, string(bs))
 	assert.Contains(t, string(bs), `"body":"first comment"`)
 	assert.Contains(t, string(bs), `"type":"issue.commented"`)
+}
+
+func TestCommentEndpoint_EditsCommentAndEmitsEvent(t *testing.T) {
+	_, ts, pid, num := bootstrapProjectWithIssue(t)
+
+	resp, bs := postJSON(t, ts, issueURL(pid, num, "comments"),
+		map[string]any{"actor": "agent", "body": "token=leaked"})
+	require.Equal(t, 200, resp.StatusCode, string(bs))
+	var created struct {
+		Comment struct {
+			UID string `json:"uid"`
+		} `json:"comment"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &created))
+	require.NotEmpty(t, created.Comment.UID)
+
+	editResp, editBS := patchJSON(t, ts, issueURL(pid, num, "comments/"+created.Comment.UID),
+		map[string]any{"actor": "redactor", "body": "[redacted]"})
+	require.Equal(t, 200, editResp.StatusCode, string(editBS))
+	assert.Contains(t, string(editBS), `"body":"[redacted]"`)
+	assert.Contains(t, string(editBS), `"type":"issue.comment_edited"`)
+	assert.NotContains(t, string(editBS), "token=leaked")
 }
 
 func TestActionsClose_ReopenRoundtrip(t *testing.T) {

--- a/internal/daemon/handlers_digest.go
+++ b/internal/daemon/handlers_digest.go
@@ -240,6 +240,11 @@ func applyEvent(e db.Event, totals, grand *api.DigestTotals, acc *issueAccum) {
 		if acc != nil {
 			acc.Edited = true
 		}
+	case "issue.comment_edited":
+		bump(&totals.Edited, &grand.Edited)
+		if acc != nil {
+			acc.Edited = true
+		}
 	case "issue.assigned":
 		bump(&totals.Assigned, &grand.Assigned)
 		if acc != nil {

--- a/internal/db/fold.go
+++ b/internal/db/fold.go
@@ -48,6 +48,8 @@ func (p *FoldProjection) apply(e FoldEvent) {
 		p.applyRestored(e, payload)
 	case "issue.commented":
 		p.applyComment(e, payload)
+	case "issue.comment_edited":
+		p.applyCommentEdited(e, payload)
 	case "issue.labeled":
 		p.applyLabel(e, payload, true)
 	case "issue.unlabeled":
@@ -318,6 +320,24 @@ func (p *FoldProjection) applyComment(e FoldEvent, payload map[string]json.RawMe
 	p.touchIssue(uid, createdAt)
 }
 
+func (p *FoldProjection) applyCommentEdited(e FoldEvent, payload map[string]json.RawMessage) {
+	commentUID, ok := stringValue(payload["comment_uid"])
+	if !ok || commentUID == "" {
+		return
+	}
+	body, ok := stringValue(payload["body"])
+	if !ok {
+		return
+	}
+	uid := issueUID(e, payload)
+	p.editCommentBody(commentUID, uid, body, clockOf(e))
+	editedAt := e.CreatedAt
+	if v, ok := stringValue(payload["edited_at"]); ok && v != "" {
+		editedAt = v
+	}
+	p.touchIssue(uid, editedAt)
+}
+
 func (p *FoldProjection) setComment(commentUID, issueUID, author, body, createdAt string, clock FoldClock) {
 	if commentUID == "" {
 		return
@@ -332,6 +352,22 @@ func (p *FoldProjection) setComment(commentUID, issueUID, author, body, createdA
 		}
 		return
 	}
+	p.Comments[commentUID] = comment
+}
+
+func (p *FoldProjection) editCommentBody(commentUID, issueUID, body string, clock FoldClock) {
+	if commentUID == "" {
+		return
+	}
+	comment, exists := p.Comments[commentUID]
+	if !exists {
+		comment = FoldComment{UID: commentUID, IssueUID: issueUID, Clock: clock}
+	}
+	if comment.IssueUID == "" {
+		comment.IssueUID = issueUID
+	}
+	comment.Body = body
+	comment.Clock = clock
 	p.Comments[commentUID] = comment
 }
 

--- a/internal/db/fold_test.go
+++ b/internal/db/fold_test.go
@@ -290,3 +290,18 @@ func TestFold_CommentDuplicateKeepsFirstAndWarns(t *testing.T) {
 	assert.Equal(t, "first", got.Comments["comment-1"].Body)
 	require.Len(t, got.Warnings, 1)
 }
+
+func TestFold_CommentEditOverwritesBodyOnly(t *testing.T) {
+	events := []FoldEvent{
+		testEvent("issue.created", 1, `{"uid":"issue-1","short_id":"abcd","title":"t","body":"","author":"agent","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`),
+		testEvent("issue.commented", 2, `{"comment_uid":"comment-1","author":"agent","body":"token=leaked","created_at":"2026-05-23T12:00:01.000Z"}`),
+		testEvent("issue.comment_edited", 3, `{"comment_uid":"comment-1","body":"[redacted]","edited_at":"2026-05-23T12:00:02.000Z"}`),
+	}
+
+	got := FoldEvents(events)
+	comment := got.Comments["comment-1"]
+	assert.Equal(t, "agent", comment.Author)
+	assert.Equal(t, "[redacted]", comment.Body)
+	assert.Equal(t, "2026-05-23T12:00:01.000Z", comment.CreatedAt)
+	assert.Empty(t, got.Warnings)
+}

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -103,6 +103,14 @@ type CreateCommentParams struct {
 	Body    string
 }
 
+// EditCommentParams carries inputs for editing one existing comment body.
+type EditCommentParams struct {
+	IssueID    int64
+	CommentUID string
+	Actor      string
+	Body       string
+}
+
 // CloseThrottleReason values for CloseThrottledPayload.Reason. Sibling-burst
 // fires when an actor closes too many siblings under one parent in a short
 // window; duplicate-message fires when an actor reuses identical close prose

--- a/internal/db/pgstore/schema.sql
+++ b/internal/db/pgstore/schema.sql
@@ -12,7 +12,7 @@
 --   x NOT GLOB '*pat*'                 -> x NOT LIKE '%pat%'
 --   x NOT GLOB '*[^...]*'              -> x !~ '[^...]'                     (POSIX regex)
 --   json_extract(p, '$.k')             -> (p::jsonb ->> 'k')
---   FTS5 virtual table + 5 triggers    -> issues_search table + 4 triggers + FK CASCADE
+--   FTS5 virtual table + 6 triggers    -> issues_search table + 5 triggers + FK CASCADE
 --   SQLite RAISE(ABORT, msg) trigger   -> PL/pgSQL function + trigger
 --
 -- Table order is FK-dependency: parents before children. recurrences appears
@@ -553,7 +553,7 @@ CREATE UNIQUE INDEX uniq_pending_claim_active
   WHERE rejected_at IS NULL AND resolved_at IS NULL;
 
 -- ----------------------------------------------------------------------
--- FTS surface: issues_search table + rebuild function + 4 sync triggers.
+-- FTS surface: issues_search table + rebuild function + 5 sync triggers.
 -- FK CASCADE replaces SQLite's issue-delete FTS trigger.
 -- ----------------------------------------------------------------------
 
@@ -600,6 +600,12 @@ BEGIN
   RETURN NULL;
 END $$;
 
+CREATE OR REPLACE FUNCTION issues_search_trigger_on_comment_update() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM rebuild_issue_search(NEW.issue_id);
+  RETURN NULL;
+END $$;
+
 CREATE OR REPLACE FUNCTION issues_search_trigger_on_comment_delete() RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
   PERFORM rebuild_issue_search(OLD.issue_id);
@@ -617,6 +623,10 @@ CREATE TRIGGER issues_search_after_issue_update
 CREATE TRIGGER issues_search_after_comment_insert
   AFTER INSERT ON comments
   FOR EACH ROW EXECUTE FUNCTION issues_search_trigger_on_comment_insert();
+
+CREATE TRIGGER issues_search_after_comment_update
+  AFTER UPDATE OF body ON comments
+  FOR EACH ROW EXECUTE FUNCTION issues_search_trigger_on_comment_update();
 
 CREATE TRIGGER issues_search_after_comment_delete
   AFTER DELETE ON comments

--- a/internal/db/pgstore/schema_test.go
+++ b/internal/db/pgstore/schema_test.go
@@ -51,6 +51,7 @@ var expectedTriggers = []string{
 	"issues_search_after_issue_insert",
 	"issues_search_after_issue_update",
 	"issues_search_after_comment_insert",
+	"issues_search_after_comment_update",
 	"issues_search_after_comment_delete",
 }
 
@@ -160,13 +161,14 @@ func TestSchema_BaselineMatchesExpectedSurface(t *testing.T) {
 		assert.Equal(t, want, n, "fk count mismatch on %s", table)
 	}
 
-	// --- 3 PL/pgSQL trigger functions exist ---
+	// --- PL/pgSQL trigger functions exist ---
 	for _, fn := range []string{
 		"enforce_links_uid_consistency",
 		"enforce_uid_immutable",
 		"rebuild_issue_search",
 		"issues_search_trigger_on_issue",
 		"issues_search_trigger_on_comment_insert",
+		"issues_search_trigger_on_comment_update",
 		"issues_search_trigger_on_comment_delete",
 	} {
 		var name string

--- a/internal/db/pgstore/stubs_gen.go
+++ b/internal/db/pgstore/stubs_gen.go
@@ -222,6 +222,10 @@ func (s *Store) DisableIssueSyncBinding(_ context.Context, _ int64) (db.IssueSyn
 	return db.IssueSyncBinding{}, ErrNotImplementedPhase3
 }
 
+func (s *Store) EditComment(_ context.Context, _ db.EditCommentParams) (db.Comment, *db.Event, bool, error) {
+	return db.Comment{}, nil, false, ErrNotImplementedPhase3
+}
+
 func (s *Store) EditIssue(_ context.Context, _ db.EditIssueParams) (db.Issue, *db.Event, bool, error) {
 	return db.Issue{}, nil, false, ErrNotImplementedPhase3
 }

--- a/internal/db/schema_version.go
+++ b/internal/db/schema_version.go
@@ -5,7 +5,7 @@ package db
 // compare on-disk state against this number when opening existing ones; a
 // mismatch surfaces either ErrSchemaCutoverRequired (for older sources, so
 // storeopen can drive a JSONL cutover) or a newer-than-binary error.
-const currentSchemaVersion = 20
+const currentSchemaVersion = 21
 
 // CurrentSchemaVersion returns the schema version expected by this binary.
 // Backends and the cutover path read this to align freshly created databases

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -489,7 +489,7 @@ func validateFederationProjectEvent(
 	case "issue.updated", "issue.assigned", "issue.unassigned",
 		"issue.priority_set", "issue.priority_cleared",
 		"issue.closed", "issue.reopened", "issue.soft_deleted", "issue.restored",
-		"issue.commented", "issue.labeled", "issue.unlabeled",
+		"issue.commented", "issue.comment_edited", "issue.labeled", "issue.unlabeled",
 		"issue.linked", "issue.unlinked", "issue.links_changed", "issue.metadata_updated":
 		if issueUID == "" {
 			return fmt.Errorf("%w: %s missing issue uid", db.ErrFederationIngestValidation, ev.Type)

--- a/internal/db/sqlitestore/federation_push.go
+++ b/internal/db/sqlitestore/federation_push.go
@@ -129,7 +129,7 @@ func federationPushEventTypeCondition(column string) string {
 	return column + ` IN (
 		'project.metadata_updated',
 		'issue.created', 'issue.snapshot', 'issue.updated', 'issue.closed', 'issue.reopened',
-		'issue.soft_deleted', 'issue.restored', 'issue.commented',
+		'issue.soft_deleted', 'issue.restored', 'issue.commented', 'issue.comment_edited',
 		'issue.assigned', 'issue.unassigned', 'issue.priority_set', 'issue.priority_cleared',
 		'issue.labeled', 'issue.unlabeled',
 		'issue.linked', 'issue.unlinked', 'issue.links_changed', 'issue.metadata_updated'
@@ -267,7 +267,7 @@ func (d *Store) resetFederatedProjectIfNoPendingPush(
 		          AND type IN (
 		            'project.metadata_updated',
 		            'issue.created', 'issue.snapshot', 'issue.updated', 'issue.closed', 'issue.reopened',
-		            'issue.soft_deleted', 'issue.restored', 'issue.commented',
+		            'issue.soft_deleted', 'issue.restored', 'issue.commented', 'issue.comment_edited',
 		            'issue.assigned', 'issue.unassigned', 'issue.priority_set', 'issue.priority_cleared',
 		            'issue.labeled', 'issue.unlabeled',
 		            'issue.linked', 'issue.unlinked', 'issue.links_changed', 'issue.metadata_updated'

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -808,6 +808,54 @@ func TestAdoptProjectIntoFederationPreservesSnapshotPayloadAuthors(t *testing.T)
 	assert.Equal(t, "bob", payload.Comments[0].Author)
 }
 
+func TestAdoptProjectIntoFederationSnapshotsEditedCommentWithoutLeakedBody(t *testing.T) {
+	d, ctx, p := setupTestProject(t)
+	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: p.ID,
+		Title:     "redaction target",
+		Author:    "agent",
+	})
+	require.NoError(t, err)
+	comment, _, err := d.CreateComment(ctx, db.CreateCommentParams{
+		IssueID: issue.ID,
+		Author:  "agent",
+		Body:    "token=leaked",
+	})
+	require.NoError(t, err)
+	_, _, changed, err := d.EditComment(ctx, db.EditCommentParams{
+		IssueID: issue.ID, CommentUID: comment.UID, Actor: "redactor", Body: "[redacted]",
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	_, err = d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+		ProjectID:            p.ID,
+		HubURL:               "http://hub:7373",
+		HubProjectID:         42,
+		HubProjectUID:        newTestUID(t),
+		ReplayHorizonEventID: 10,
+		Actor:                "bound-actor",
+	})
+	require.NoError(t, err)
+
+	events, err := d.EventsAfter(ctx, db.EventsAfterParams{ProjectID: p.ID, Limit: 10})
+	require.NoError(t, err)
+	var snapshot *db.Event
+	for i := range events {
+		assert.NotContains(t, events[i].Payload, "token=leaked")
+		assert.NotEqual(t, "issue.commented", events[i].Type)
+		assert.NotEqual(t, "issue.comment_edited", events[i].Type)
+		if events[i].Type == "issue.snapshot" {
+			snapshot = &events[i]
+		}
+	}
+	require.NotNil(t, snapshot)
+	payload := unmarshalPayload[federationSnapshotPayload](t, snapshot.Payload)
+	require.Len(t, payload.Comments, 1)
+	assert.Equal(t, comment.UID, payload.Comments[0].CommentUID)
+	assert.Equal(t, "[redacted]", payload.Comments[0].Body)
+}
+
 func TestFederationBindingPhase1StyleDefaultsPushState(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
 
@@ -1557,6 +1605,35 @@ func TestIngestFederationEvents(t *testing.T) {
 		issue, err := d.IssueByUID(ctx, issueUID, db.IncludeDeletedYes)
 		require.NoError(t, err)
 		assert.Equal(t, "spoke work", issue.Title)
+	})
+
+	t.Run("accepts comment edit and updates projection", func(t *testing.T) {
+		d, ctx, p, spokeUID := setupFederationIngestHub(t)
+		issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: p.ID,
+			Title:     "known",
+			Author:    "agent",
+		})
+		require.NoError(t, err)
+		comment, _, err := d.CreateComment(ctx, db.CreateCommentParams{
+			IssueID: issue.ID,
+			Author:  "agent",
+			Body:    "token=leaked",
+		})
+		require.NoError(t, err)
+		ev := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &issue.UID, nil,
+			"issue.comment_edited", 100,
+			`{"comment_uid":"`+comment.UID+`","body":"[redacted]","edited_at":"2026-05-23T12:00:01.000Z"}`)
+
+		got, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, ev))
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, got.Accepted)
+		comments, err := d.CommentsByIssue(ctx, issue.ID)
+		require.NoError(t, err)
+		require.Len(t, comments, 1)
+		assert.Equal(t, comment.UID, comments[0].UID)
+		assert.Equal(t, "[redacted]", comments[0].Body)
 	})
 
 	t.Run("accepts stale project name after hub rename", func(t *testing.T) {

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -20,7 +20,7 @@ import (
 func TestFederationSchemaVersionAndTable(t *testing.T) {
 	d := openTestDB(t)
 
-	assert.Equal(t, 20, db.CurrentSchemaVersion())
+	assert.Equal(t, 21, db.CurrentSchemaVersion())
 	assertSchemaVersion(t, d, db.CurrentSchemaVersion())
 	assertSchemaObject(t, d, "federation_bindings")
 	assertSchemaObject(t, d, "idx_federation_bindings_role_enabled")

--- a/internal/db/sqlitestore/github_sync_test.go
+++ b/internal/db/sqlitestore/github_sync_test.go
@@ -17,11 +17,11 @@ func TestGitHubSyncSchemaVersion(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
 
-	assert.Equal(t, 20, db.CurrentSchemaVersion())
+	assert.Equal(t, 21, db.CurrentSchemaVersion())
 	got, err := d.SchemaVersion(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 20, got)
-	assertSchemaVersion(t, d, 20)
+	assert.Equal(t, 21, got)
+	assertSchemaVersion(t, d, 21)
 }
 
 func TestGitHubSyncEnableAndReenableSameRepository(t *testing.T) {

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -997,6 +997,34 @@ var readCreatedComment = func(ctx context.Context, d *Store, commentID int64) (d
 	return c, nil
 }
 
+func commentByUIDForIssueTx(ctx context.Context, tx *sql.Tx, issueID int64, commentUID string) (db.Comment, error) {
+	var c db.Comment
+	err := tx.QueryRowContext(ctx,
+		`SELECT id, uid, issue_id, author, body, created_at FROM comments WHERE issue_id = ? AND uid = ?`,
+		issueID, commentUID).Scan(&c.ID, &c.UID, &c.IssueID, &c.Author, &c.Body, &c.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.Comment{}, db.ErrNotFound
+	}
+	if err != nil {
+		return db.Comment{}, fmt.Errorf("lookup comment: %w", err)
+	}
+	return c, nil
+}
+
+func commentByIDTx(ctx context.Context, tx *sql.Tx, commentID int64) (db.Comment, error) {
+	var c db.Comment
+	err := tx.QueryRowContext(ctx,
+		`SELECT id, uid, issue_id, author, body, created_at FROM comments WHERE id = ?`,
+		commentID).Scan(&c.ID, &c.UID, &c.IssueID, &c.Author, &c.Body, &c.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.Comment{}, db.ErrNotFound
+	}
+	if err != nil {
+		return db.Comment{}, fmt.Errorf("read comment: %w", err)
+	}
+	return c, nil
+}
+
 // CreateComment appends a comment + issue.commented event in one tx, bumping
 // issues.updated_at.
 func (d *Store) CreateComment(ctx context.Context, p db.CreateCommentParams) (db.Comment, db.Event, error) {
@@ -1090,6 +1118,91 @@ func (d *Store) createComment(ctx context.Context, p db.CreateCommentParams) (in
 		return 0, db.Event{}, err
 	}
 	return commentID, evt, nil
+}
+
+// EditComment overwrites one comment body in place and emits
+// issue.comment_edited. Author and created_at are preserved so redaction keeps
+// the thread position and attribution intact.
+func (d *Store) EditComment(ctx context.Context, p db.EditCommentParams) (db.Comment, *db.Event, bool, error) {
+	return retryWrite3(ctx, d, func() (db.Comment, *db.Event, bool, error) {
+		return d.editComment(ctx, p)
+	})
+}
+
+func (d *Store) editComment(ctx context.Context, p db.EditCommentParams) (db.Comment, *db.Event, bool, error) {
+	p.CommentUID = strings.TrimSpace(p.CommentUID)
+	if p.CommentUID == "" {
+		return db.Comment{}, nil, false, db.ErrNotFound
+	}
+	if strings.TrimSpace(p.Body) == "" {
+		return db.Comment{}, nil, false, fmt.Errorf("comment body is required")
+	}
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return db.Comment{}, nil, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	issue, projectName, err := lookupIssueForEvent(ctx, tx, p.IssueID)
+	if err != nil {
+		return db.Comment{}, nil, false, err
+	}
+	actor, err := d.effectiveLocalMutationActorTx(ctx, tx, issue.ProjectID, p.Actor)
+	if err != nil {
+		return db.Comment{}, nil, false, err
+	}
+	comment, err := commentByUIDForIssueTx(ctx, tx, p.IssueID, p.CommentUID)
+	if err != nil {
+		return db.Comment{}, nil, false, err
+	}
+	if comment.Body == p.Body {
+		if err := tx.Commit(); err != nil {
+			return db.Comment{}, nil, false, err
+		}
+		return comment, nil, false, nil
+	}
+
+	editedAt := nowTimestamp()
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE comments SET body = ? WHERE id = ?`, p.Body, comment.ID); err != nil {
+		return db.Comment{}, nil, false, fmt.Errorf("update comment: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE issues SET updated_at = ? WHERE id = ?`, editedAt, p.IssueID); err != nil {
+		return db.Comment{}, nil, false, fmt.Errorf("touch issue: %w", err)
+	}
+	payloadBytes, err := json.Marshal(struct {
+		CommentUID string `json:"comment_uid"`
+		Body       string `json:"body"`
+		EditedAt   string `json:"edited_at"`
+	}{
+		CommentUID: comment.UID,
+		Body:       p.Body,
+		EditedAt:   editedAt,
+	})
+	if err != nil {
+		return db.Comment{}, nil, false, fmt.Errorf("marshal comment edit payload: %w", err)
+	}
+	evt, err := d.insertEventTx(ctx, tx, eventInsert{
+		ProjectID:   issue.ProjectID,
+		ProjectName: projectName,
+		IssueID:     &issue.ID,
+		Type:        "issue.comment_edited",
+		Actor:       actor,
+		Payload:     string(payloadBytes),
+		CreatedAt:   editedAt,
+	})
+	if err != nil {
+		return db.Comment{}, nil, false, err
+	}
+	updated, err := commentByIDTx(ctx, tx, comment.ID)
+	if err != nil {
+		return db.Comment{}, nil, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return db.Comment{}, nil, false, err
+	}
+	return updated, &evt, true, nil
 }
 
 // CommentsByIssue returns every comment on issueID in chronological order

--- a/internal/db/sqlitestore/queries_issues_test.go
+++ b/internal/db/sqlitestore/queries_issues_test.go
@@ -364,6 +364,49 @@ func TestCreateComment_EmitsEvent(t *testing.T) {
 	assert.NotEmpty(t, payload.CreatedAt)
 }
 
+func TestEditComment_UpdatesBodyOnlyAndEmitsEvent(t *testing.T) {
+	d, ctx, p, issue := setupTestIssue(t)
+
+	cmt, _, err := d.CreateComment(ctx, db.CreateCommentParams{
+		IssueID: issue.ID, Author: "agent", Body: "token=leaked",
+	})
+	require.NoError(t, err)
+	originalAuthor := cmt.Author
+	originalCreatedAt := cmt.CreatedAt
+
+	updated, evt, changed, err := d.EditComment(ctx, db.EditCommentParams{
+		IssueID: issue.ID, CommentUID: cmt.UID, Actor: "redactor", Body: "[redacted]",
+	})
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, cmt.ID, updated.ID)
+	assert.Equal(t, cmt.UID, updated.UID)
+	assert.Equal(t, originalAuthor, updated.Author)
+	assert.Equal(t, originalCreatedAt, updated.CreatedAt)
+	assert.Equal(t, "[redacted]", updated.Body)
+	require.NotNil(t, evt)
+	assert.Equal(t, "issue.comment_edited", evt.Type)
+	assert.Equal(t, "redactor", evt.Actor)
+	assert.Equal(t, p.UID, evt.ProjectUID)
+	require.NotNil(t, evt.IssueUID)
+	assert.Equal(t, issue.UID, *evt.IssueUID)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(evt.Payload), &payload))
+	assert.Equal(t, cmt.UID, payload["comment_uid"])
+	assert.Equal(t, "[redacted]", payload["body"])
+	assert.NotEmpty(t, payload["edited_at"])
+	assert.NotContains(t, payload, "author")
+	assert.NotContains(t, payload, "created_at")
+
+	comments, err := d.CommentsByIssue(ctx, issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Equal(t, "[redacted]", comments[0].Body)
+	assert.Equal(t, originalAuthor, comments[0].Author)
+	assert.Equal(t, originalCreatedAt, comments[0].CreatedAt)
+}
+
 func TestCloseIssue_SetsStatusAndEmitsEvent(t *testing.T) {
 	d, ctx, _, issue := setupTestIssue(t)
 

--- a/internal/db/sqlitestore/queries_search_test.go
+++ b/internal/db/sqlitestore/queries_search_test.go
@@ -43,6 +43,25 @@ func TestFTS_CommentInsertReindexes(t *testing.T) {
 		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'watermelon'`)
 }
 
+func TestFTS_CommentUpdateReindexes(t *testing.T) {
+	d, ctx, p := setupTestProject(t)
+	issue := createTesterIssueWithBody(ctx, t, d, p.ID, "boring", "body")
+	comment, _, err := d.CreateComment(ctx, db.CreateCommentParams{
+		IssueID: issue.ID, Author: "tester", Body: "leakedtoken",
+	})
+	require.NoError(t, err)
+
+	_, _, _, err = d.EditComment(ctx, db.EditCommentParams{
+		IssueID: issue.ID, CommentUID: comment.UID, Actor: "tester", Body: "redactedtoken",
+	})
+	require.NoError(t, err)
+
+	assertRowCount(ctx, t, d, 0, "old comment tokens must be gone after edit",
+		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'leakedtoken'`)
+	assertRowCount(ctx, t, d, 1, "new comment tokens must be searchable after edit",
+		`SELECT count(*) FROM issues_fts WHERE issues_fts MATCH 'redactedtoken'`)
+}
+
 func TestSearchFTS_RanksByBM25(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
 

--- a/internal/db/sqlitestore/schema.sql
+++ b/internal/db/sqlitestore/schema.sql
@@ -506,7 +506,7 @@ CREATE VIRTUAL TABLE issues_fts USING fts5(
 
 -- FTS5 sync triggers. The issues_fts table uses content='' so each delete must
 -- provide the previously indexed column values; we stay in sync by routing every
--- title/body/comments mutation through one of the five triggers below. comments
+-- title/body/comments mutation through one of the six triggers below. comments
 -- is stored as a single space-separated aggregate built from the comments table
 -- at trigger time.
 --
@@ -565,6 +565,31 @@ CREATE TRIGGER comments_ai_fts AFTER INSERT ON comments BEGIN
     )), '')
   );
   -- Post-insert state (what FTS should hold) includes it.
+  INSERT INTO issues_fts(rowid, title, body, comments) VALUES (
+    NEW.issue_id,
+    (SELECT title FROM issues WHERE id = NEW.issue_id),
+    (SELECT body  FROM issues WHERE id = NEW.issue_id),
+    COALESCE((SELECT GROUP_CONCAT(body, ' ') FROM (
+      SELECT body FROM comments WHERE issue_id = NEW.issue_id ORDER BY id
+    )), '')
+  );
+END;
+
+CREATE TRIGGER comments_au_fts AFTER UPDATE OF body ON comments BEGIN
+  -- Pre-update state (what FTS currently holds) contained OLD.body at OLD.id.
+  INSERT INTO issues_fts(issues_fts, rowid, title, body, comments) VALUES (
+    'delete',
+    OLD.issue_id,
+    (SELECT title FROM issues WHERE id = OLD.issue_id),
+    (SELECT body  FROM issues WHERE id = OLD.issue_id),
+    COALESCE((SELECT GROUP_CONCAT(body, ' ') FROM (
+      SELECT id, body FROM comments WHERE issue_id = OLD.issue_id AND id <> OLD.id
+      UNION ALL
+      SELECT OLD.id, OLD.body
+      ORDER BY id
+    )), '')
+  );
+  -- Post-update state (what FTS should hold) includes NEW.body.
   INSERT INTO issues_fts(rowid, title, body, comments) VALUES (
     NEW.issue_id,
     (SELECT title FROM issues WHERE id = NEW.issue_id),

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -89,6 +89,7 @@ type Storage interface {
 
 	// comments
 	CreateComment(ctx context.Context, p CreateCommentParams) (Comment, Event, error)
+	EditComment(ctx context.Context, p EditCommentParams) (Comment, *Event, bool, error)
 	CommentBodyByID(ctx context.Context, id int64) (string, error)
 	CommentsByIssue(ctx context.Context, issueID int64) ([]Comment, error)
 

--- a/internal/hooks/config_validate.go
+++ b/internal/hooks/config_validate.go
@@ -14,7 +14,7 @@ import (
 // entries belong here whenever a new hook-eligible event is added.
 var knownEventTypes = map[string]struct{}{
 	"issue.created": {}, "issue.updated": {}, "issue.closed": {},
-	"issue.reopened": {}, "issue.commented": {}, "issue.linked": {},
+	"issue.reopened": {}, "issue.commented": {}, "issue.comment_edited": {}, "issue.linked": {},
 	"issue.unlinked": {}, "issue.labeled": {}, "issue.unlabeled": {},
 	"issue.assigned": {}, "issue.unassigned": {},
 	"issue.priority_set": {}, "issue.priority_cleared": {},

--- a/internal/hooks/payload.go
+++ b/internal/hooks/payload.go
@@ -124,7 +124,7 @@ func buildPayloadBlock(ctx context.Context, evt db.Event, rc commentResolver, lo
 			}
 		}
 	}
-	if evt.Type == "issue.commented" {
+	if evt.Type == "issue.commented" || evt.Type == "issue.comment_edited" {
 		if body, ok := payload["body"].(string); ok {
 			truncStringField(payload, "comment_body", body, maxCommentBodyBytes)
 		} else if cidF, ok := payload["comment_id"].(float64); ok {

--- a/internal/tui/detail_event.go
+++ b/internal/tui/detail_event.go
@@ -37,6 +37,7 @@ var eventDescribers = map[string]eventDescriber{
 	"issue.closed":           func(e EventLogEntry) string { return "closed" + reasonSuffix(e) },
 	"issue.reopened":         staticDesc("reopened"),
 	"issue.commented":        staticDesc("added comment"),
+	"issue.comment_edited":   staticDesc("edited comment"),
 	"issue.labeled":          payloadDesc("labeled", "label"),
 	"issue.unlabeled":        payloadDesc("unlabeled", "label"),
 	"issue.linked":           func(e EventLogEntry) string { return "linked " + linkPayloadDesc(e) },

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -277,6 +277,9 @@ type ClientInterface interface {
 	CreateComment(ctx context.Context, options *CreateCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateCommentResponse, error)
 	CreateCommentWithResponse(ctx context.Context, options *CreateCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateCommentResp, error)
 
+	EditComment(ctx context.Context, options *EditCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EditCommentResponse, error)
+	EditCommentWithResponse(ctx context.Context, options *EditCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EditCommentResp, error)
+
 	AddLabel(ctx context.Context, options *AddLabelRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AddLabelResponse, error)
 	AddLabelWithResponse(ctx context.Context, options *AddLabelRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AddLabelResp, error)
 
@@ -3736,6 +3739,69 @@ func (c *Client) CreateComment(ctx context.Context, options *CreateCommentReques
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/comments")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) EditComment(ctx context.Context, options *EditCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EditCommentResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}",
+		Method:      "PATCH",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*EditCommentResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(EditCommentErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "EditCommentErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(EditCommentResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "EditCommentResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -2558,6 +2558,59 @@ func (o *CreateCommentRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// EditCommentRequestOptions is the options needed to make a request to EditComment.
+type EditCommentRequestOptions struct {
+	PathParams *EditCommentPath
+	Body       *EditCommentBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *EditCommentRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *EditCommentRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *EditCommentRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *EditCommentRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *EditCommentRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // AddLabelRequestOptions is the options needed to make a request to AddLabel.
 type AddLabelRequestOptions struct {
 	PathParams *AddLabelPath

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -2568,6 +2568,55 @@ func (c *Client) CreateCommentWithResponse(ctx context.Context, options *CreateC
 	}
 }
 
+func (c *Client) EditCommentWithResponse(ctx context.Context, options *EditCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EditCommentResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}",
+		Method:      "PATCH",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &EditCommentResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(EditCommentResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "EditCommentResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 func (c *Client) AddLabelWithResponse(ctx context.Context, options *AddLabelRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AddLabelResp, error) {
 	var err error
 	reqParams := runtime.RequestOptionsParameters{

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -250,6 +250,16 @@ func (c CreateCommentPath) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(c))
 }
 
+type EditCommentPath struct {
+	ProjectID  int64  `json:"project_id"`
+	Ref        string `json:"ref" validate:"required"`
+	CommentRef string `json:"comment_ref" validate:"required"`
+}
+
+func (e EditCommentPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(e))
+}
+
 type AddLabelPath struct {
 	ProjectID int64  `json:"project_id"`
 	Ref       string `json:"ref" validate:"required"`

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -56,6 +56,8 @@ type UnassignIssueBody = UnassignRequestBody
 
 type CreateCommentBody = CommentRequestBody
 
+type EditCommentBody = EditCommentRequestBody
+
 type AddLabelBody = AddLabelRequestBody
 
 type AcquireIssueLeaseBody = ClaimActionBody

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -217,6 +217,10 @@ type CreateCommentResponse = CommentResponseBody
 
 type CreateCommentErrorResponse = ErrorEnvelope
 
+type EditCommentResponse = CommentResponseBody
+
+type EditCommentErrorResponse = ErrorEnvelope
+
 type AddLabelResponse = AddLabelResponseBody
 
 type AddLabelErrorResponse = ErrorEnvelope
@@ -688,6 +692,13 @@ type CreateCommentResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *CreateCommentResponse
+}
+
+type EditCommentResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *EditCommentResponse
 }
 
 type AddLabelResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -879,6 +879,15 @@ type DigestTotals struct {
 
 type DisableIssueSyncRequestBody = map[string]any
 
+type EditCommentRequestBody struct {
+	Actor string `json:"actor" validate:"required"`
+	Body  string `json:"body" validate:"required"`
+}
+
+func (e EditCommentRequestBody) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(e))
+}
+
 type EditIssueRequestBody struct {
 	Actor         string      `json:"actor" validate:"required"`
 	Body          *string     `json:"body,omitempty"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -686,6 +686,17 @@ components:
     DisableIssueSyncRequestBody:
       additionalProperties: false
       type: object
+    EditCommentRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        body:
+          type: string
+      required:
+        - actor
+        - body
+      type: object
     EditIssueRequestBody:
       additionalProperties: false
       properties:
@@ -4786,6 +4797,45 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CommentRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommentResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}:
+    patch:
+      operationId: editComment
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: comment_ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EditCommentRequestBody"
         required: true
       responses:
         "200":


### PR DESCRIPTION
Operators need to scrub private data from comments before enrolling a project in federation, but kata only allowed issue bodies to be overwritten in place. Appending a replacement comment or purging an entire issue either leaves the original comment content in current state or destroys useful engineering history.

This adds a comment body edit primitive that mirrors issue-body edits: the current comment row is overwritten while preserving UID, author, creation time, and thread position. Federation adoption snapshots read the sanitized current rows, while already-federated leak remediation stays out of scope because that remains a baseline-reset problem rather than a per-comment projection edit.

The branch also wires the new comment edit event through local and federated projections and refreshes search indexing on comment body updates, including a schema version bump so existing SQLite databases receive the new FTS trigger through the established cutover path.