### PR TITLE
Document 0.7.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ overwriting the rest of either file.
 ## Why kata
 
 - **Built for agents.** Stable short refs, `--json` and `--agent` output,
-  idempotent creates, a claim flow, and predictable failure modes agents can
-  script against.
+  idempotent creates, semantic-aware search, a claim flow, and predictable
+  failure modes agents can script against.
 - **Made for humans too.** `kata tui` browses, triages, and supervises
   agent-written work over the same data. No raw JSON required.
 - **Local-first, repo-clean.** One Go binary, no runtime dependencies. Issue
@@ -129,6 +129,7 @@ The [docs site](docs/) is the definitive reference:
   [Changelog](docs/changelog.md)
 - Guide: [Concepts](docs/guide/concepts.md) ·
   [Workspaces and projects](docs/guide/workspaces-projects.md) ·
+  [Semantic search](docs/guide/semantic-search.md) ·
   [Migrating from Beads](docs/guide/migrating-from-beads.md)
 - Reference: [CLI](docs/reference/cli.md) ·
   [Configuration](docs/reference/configuration.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,6 +59,11 @@ reliably.
 - Refreshed release documentation and docs navigation for semantic search,
   GitHub sync credentials, project purge, author rewrite, and comment redaction.
 
+**Acknowledgements**
+
+- Thanks to [andy-vdg](https://github.com/andy-vdg) for the scoped GitHub sync
+  service credential work and GitHub parent-link synchronization.
+
 ## 0.6.0
 <small>2026-06-24</small>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,59 @@ description: Release history for kata
 All notable changes to kata, grouped by release. Versioned releases start with
 0.5.0; earlier entries are a retroactive project history grouped by ISO week.
 
+## 0.7.0
+<small>2026-06-29</small>
+
+kata 0.7.0 improves discovery, sharing, and release operations. Search can now
+use opt-in embeddings for semantic recall while preserving lexical behavior by
+default, GitHub sync gains safer daemon-side credentials and parent-link
+reconciliation, and federation handles larger adoption and push workloads more
+reliably.
+
+**New features**
+
+- Added opt-in semantic search for SQLite-backed projects. Configure an
+  OpenAI-compatible `/embeddings` endpoint under `[search.embeddings]` to make
+  default `kata search` run hybrid lexical/vector search; use `--lexical`,
+  `--hybrid`, or `--semantic` to force a mode. Search remains lexical with no
+  embedding config, and automatic fallback reports degraded mode instead of
+  silently hiding vector failures.
+- Added daemon-scoped GitHub sync credentials. Shared daemons can use
+  `[[github_sync.app]]` GitHub App credentials matched by `(host, owner)`,
+  env-token fallback is host-scoped with `[github_sync].token_host`, and GitHub
+  Enterprise hosts must be explicitly allow-listed.
+- Added GitHub sub-issue parent-link synchronization. GitHub-sourced parent
+  links are imported and reconciled as source-managed kata parent links, while
+  unsupported Enterprise schemas preserve existing source-managed parent links
+  instead of deleting them.
+- Added `kata projects rewrite-author` and the matching HTTP action for
+  project-scoped current-state identity hygiene. It rewrites exact matches in
+  issue authors, issue owners, comment authors, and link authors before export,
+  sharing, or federation enrollment.
+- Added `kata comment edit` and the matching HTTP route. Comment edits preserve
+  the comment UID, author, creation time, and thread position, which makes them
+  useful for pre-federation content redaction.
+- Added `kata projects purge` for permanently deleting archived projects and
+  freeing their names, with force/confirmation guards, audit tombstones, JSON
+  output, and federation-binding refusal.
+
+**Improvements**
+
+- Improved federation adoption by chunking baseline snapshot pushes so large
+  existing projects can be adopted without sending one oversized push request.
+- Improved federation push reliability by splitting oversized outbound batches
+  and retrying them as smaller batches instead of quarantining only because a
+  request was too large.
+- Improved `kata update` behavior for development builds. Update checks fetch
+  fresh release data, show the latest official release and artifact metadata,
+  and require `--force` before replacing a dev build.
+- Published release artifacts automatically from tag pushes through the
+  release workflow.
+- Served nav-listed Markdown documentation sources from docs builds, so public
+  `.md` URLs come from the same deployment as the rendered pages.
+- Refreshed release documentation and docs navigation for semantic search,
+  GitHub sync credentials, project purge, author rewrite, and comment redaction.
+
 ## 0.6.0
 <small>2026-06-24</small>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,8 @@ Prefer `go install`, `.deb`/`.rpm` packages, or building from source? See
 -   __Built for agents__
 
     Stable short refs, `--json` and `--agent` output, idempotent creates, a
-    claim flow, and predictable failure modes agents can script against.
+    claim flow, semantic-aware search, and predictable failure modes agents can
+    script against.
 
 -   __Made for humans too__
 
@@ -110,7 +111,9 @@ walkthrough.
 The `kata` CLI resolves a project from your workspace, `.kata.toml`, or
 `--project`, then talks to a local daemon, starting one automatically when
 needed. The daemon owns a SQLite database under `KATA_HOME`, applies mutations,
-and records an event stream that both the CLI/TUI and hooks read. Optional
+and records an event stream that both the CLI/TUI and hooks read. Search is
+lexical by default and can opt into [semantic search](guide/semantic-search.md)
+with a local or hosted OpenAI-compatible embeddings endpoint. Optional
 [GitHub sync](operations/github-sync.md) can mirror upstream GitHub issues into
 kata, and federation can replicate selected projects through a hub. Your repo
 commits only the small `.kata.toml` binding, so issue history stays out of code
@@ -140,6 +143,8 @@ is a local ledger for the work itself. They coexist. See
 
 -   [__Concepts__](guide/concepts.md). The data model and how the pieces fit.
 -   [__CLI reference__](reference/cli.md). Every command and flag.
+-   [__Semantic search__](guide/semantic-search.md). Improve issue discovery
+    with opt-in embeddings.
 -   [__GitHub sync__](operations/github-sync.md). Bring GitHub issues into kata.
 -   [__Agent workflows__](workflows/agents.md). The operating contract for agents.
 -   [__Comparisons__](guide/comparisons.md). kata vs. SaaS issue trackers.


### PR DESCRIPTION
Finalizes the public docs for the 0.7.0 release using the tagged changelog, release-range commit history, and the shipped docs/code behavior as the source of truth. The public changelog now records the new semantic search, GitHub sync credential and parent-link sync work, federation reliability improvements, project hygiene commands, docs-build behavior, and verified contributor acknowledgement.

The previous public release history stopped at 0.6.0, and the main docs entry points did not surface semantic search even though the detailed guide and reference pages had already shipped. This brings the release-facing docs and navigation into line with the published 0.7.0 tag without duplicating the deeper operator runbooks.