### PR TITLE
Add reachable issue graph API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2791,6 +2791,156 @@ components:
       required:
         - purge_log
       type: object
+    ReachableGraphEdge:
+      additionalProperties: true
+      properties:
+        from_uid:
+          type: string
+        kind:
+          enum:
+            - parent
+            - blocks
+            - related
+          type: string
+        layout:
+          type: boolean
+        to_uid:
+          type: string
+      required:
+        - from_uid
+        - to_uid
+        - kind
+        - layout
+      type: object
+    ReachableGraphNode:
+      additionalProperties: true
+      properties:
+        author:
+          type: string
+        body:
+          type: string
+        closed_at:
+          format: date-time
+          type: string
+        closed_reason:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        metadata:
+          additionalProperties: true
+          type: object
+        occurrence_key:
+          type: string
+        owner:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        project_uid:
+          type: string
+        qualified_id:
+          type: string
+        recurrence_id:
+          format: int64
+          type: integer
+        revision:
+          format: int64
+          type: integer
+        short_id:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - qualified_id
+        - id
+        - uid
+        - project_id
+        - short_id
+        - title
+        - body
+        - status
+        - author
+        - metadata
+        - revision
+        - created_at
+        - updated_at
+      type: object
+    ReachableGraphResponseBody:
+      additionalProperties: true
+      properties:
+        depth:
+          type: string
+        edges:
+          items:
+            $ref: "#/components/schemas/ReachableGraphEdge"
+          type:
+            - array
+            - "null"
+        hide_done:
+          type: boolean
+        nodes:
+          items:
+            $ref: "#/components/schemas/ReachableGraphNode"
+          type:
+            - array
+            - "null"
+        source_uid:
+          type: string
+        unresolved_refs:
+          items:
+            $ref: "#/components/schemas/ReachableGraphUnresolvedRef"
+          type:
+            - array
+            - "null"
+      required:
+        - source_uid
+        - depth
+        - hide_done
+        - nodes
+        - edges
+        - unresolved_refs
+      type: object
+    ReachableGraphUnresolvedRef:
+      additionalProperties: true
+      properties:
+        kind:
+          enum:
+            - parent
+            - blocks
+            - related
+          type: string
+        other_uid:
+          type: string
+        side:
+          enum:
+            - from
+            - to
+          type: string
+        uid:
+          type: string
+      required:
+        - uid
+        - side
+        - kind
+        - other_uid
+      type: object
     ReadyGlobalIssue:
       additionalProperties: true
       properties:
@@ -5110,6 +5260,46 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CommentResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/graph:
+    get:
+      operationId: reachableIssueGraph
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - description: full or a bounded hop count such as 1, 2, or 3
+          explode: false
+          in: query
+          name: depth
+          schema:
+            description: full or a bounded hop count such as 1, 2, or 3
+            type: string
+        - explode: false
+          in: query
+          name: hide_done
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReachableGraphResponseBody"
           description: OK
         default:
           content:

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -2,6 +2,7 @@
 package api //nolint:revive // package name "api" is fixed by Plan 1 §4 wire-types layout.
 
 import (
+	"cmp"
 	"encoding/json"
 	"time"
 
@@ -495,6 +496,12 @@ type ReachableGraphNode struct {
 	QualifiedID string `json:"qualified_id"`
 }
 
+// Compare orders graph nodes by stable issue UID for deterministic graph
+// payloads independent of insertion or query order.
+func (n ReachableGraphNode) Compare(other ReachableGraphNode) int {
+	return cmp.Compare(n.UID, other.UID)
+}
+
 // ReachableGraphEdge is a canonical directed relationship edge. Parent edges
 // are oriented parent -> child even though storage records child -> parent;
 // blocks edges are blocker -> blocked; related edges use storage-canonical
@@ -507,6 +514,17 @@ type ReachableGraphEdge struct {
 	Layout  bool   `json:"layout"`
 }
 
+// Compare orders graph edges by relationship kind and stable endpoint UIDs.
+func (e ReachableGraphEdge) Compare(other ReachableGraphEdge) int {
+	if n := cmp.Compare(e.Kind, other.Kind); n != 0 {
+		return n
+	}
+	if n := cmp.Compare(e.FromUID, other.FromUID); n != 0 {
+		return n
+	}
+	return cmp.Compare(e.ToUID, other.ToUID)
+}
+
 // ReachableGraphUnresolvedRef records a link endpoint that could not be
 // materialized into a node. Normal kata mutations prevent this; the field is
 // still part of the canonical response so clients can tolerate imported,
@@ -516,6 +534,21 @@ type ReachableGraphUnresolvedRef struct {
 	Side     string `json:"side" enum:"from,to"`
 	Kind     string `json:"kind" enum:"parent,blocks,related"`
 	OtherUID string `json:"other_uid"`
+}
+
+// Compare orders unresolved graph endpoints by the missing UID, then the
+// relationship metadata that explains how the reference was discovered.
+func (r ReachableGraphUnresolvedRef) Compare(other ReachableGraphUnresolvedRef) int {
+	if n := cmp.Compare(r.UID, other.UID); n != 0 {
+		return n
+	}
+	if n := cmp.Compare(r.Kind, other.Kind); n != 0 {
+		return n
+	}
+	if n := cmp.Compare(r.Side, other.Side); n != 0 {
+		return n
+	}
+	return cmp.Compare(r.OtherUID, other.OtherUID)
 }
 
 // ReachableGraphResponse is the graph payload for one source issue.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -476,6 +476,60 @@ type ShowIssueByUIDRequest struct {
 	IncludeDeleted bool   `query:"include_deleted,omitempty"`
 }
 
+// ReachableGraphRequest is GET /api/v1/projects/{id}/issues/{ref}/graph.
+// Depth accepts "full" or a bounded hop count. HideDone excludes closed
+// non-source issues from traversal and output when callers want an active-work
+// graph.
+type ReachableGraphRequest struct {
+	ProjectID int64  `path:"project_id" required:"true"`
+	Ref       string `path:"ref" required:"true"`
+	Depth     string `query:"depth,omitempty" doc:"full or a bounded hop count such as 1, 2, or 3"`
+	HideDone  bool   `query:"hide_done,omitempty"`
+}
+
+// ReachableGraphNode is the canonical issue node returned by the reachable
+// graph endpoint. It intentionally carries issue data and stable display refs,
+// not frontend layout state.
+type ReachableGraphNode struct {
+	db.Issue
+	QualifiedID string `json:"qualified_id"`
+}
+
+// ReachableGraphEdge is a canonical directed relationship edge. Parent edges
+// are oriented parent -> child even though storage records child -> parent;
+// blocks edges are blocker -> blocked; related edges use storage-canonical
+// endpoint order. Layout=false means the edge remains part of the graph for
+// rendering/highlighting but can be omitted from layout force calculations.
+type ReachableGraphEdge struct {
+	FromUID string `json:"from_uid"`
+	ToUID   string `json:"to_uid"`
+	Kind    string `json:"kind" enum:"parent,blocks,related"`
+	Layout  bool   `json:"layout"`
+}
+
+// ReachableGraphUnresolvedRef records a link endpoint that could not be
+// materialized into a node. Normal kata mutations prevent this; the field is
+// still part of the canonical response so clients can tolerate imported,
+// federated, or manually repaired databases without dropping references.
+type ReachableGraphUnresolvedRef struct {
+	UID      string `json:"uid"`
+	Side     string `json:"side" enum:"from,to"`
+	Kind     string `json:"kind" enum:"parent,blocks,related"`
+	OtherUID string `json:"other_uid"`
+}
+
+// ReachableGraphResponse is the graph payload for one source issue.
+type ReachableGraphResponse struct {
+	Body struct {
+		SourceUID      string                        `json:"source_uid"`
+		Depth          string                        `json:"depth"`
+		HideDone       bool                          `json:"hide_done"`
+		Nodes          []ReachableGraphNode          `json:"nodes"`
+		Edges          []ReachableGraphEdge          `json:"edges"`
+		UnresolvedRefs []ReachableGraphUnresolvedRef `json:"unresolved_refs"`
+	}
+}
+
 // ShowIssueResponse is the per-issue read payload (Plan 2: + links, + labels).
 type ShowIssueResponse struct {
 	Body struct {

--- a/internal/daemon/handlers_graph.go
+++ b/internal/daemon/handlers_graph.go
@@ -1,0 +1,323 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"go.kenn.io/kata/internal/api"
+	"go.kenn.io/kata/internal/db"
+)
+
+type reachableGraphOptions struct {
+	Depth    string
+	HideDone bool
+}
+
+type parsedGraphDepth struct {
+	Label string
+	Full  bool
+	Max   int
+}
+
+type graphLinkRow struct {
+	ID           int64
+	FromIssueID  int64
+	ToIssueID    int64
+	FromIssueUID string
+	ToIssueUID   string
+	Kind         string
+}
+
+func buildReachableIssueGraph(
+	ctx context.Context,
+	store *db.DB,
+	projectID int64,
+	source db.Issue,
+	opts reachableGraphOptions,
+) (*api.ReachableGraphResponse, error) {
+	depth, err := parseReachableGraphDepth(opts.Depth)
+	if err != nil {
+		return nil, err
+	}
+	issues, err := store.ListIssues(ctx, db.ListIssuesParams{ProjectID: projectID})
+	if err != nil {
+		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	links, err := listGraphLinks(ctx, store, projectID)
+	if err != nil {
+		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+	project, err := store.ProjectByID(ctx, projectID)
+	if err != nil {
+		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	}
+
+	issueByID := make(map[int64]db.Issue, len(issues))
+	for _, issue := range issues {
+		issueByID[issue.ID] = issue
+	}
+	if _, ok := issueByID[source.ID]; !ok {
+		issueByID[source.ID] = source
+	}
+
+	visible := func(issue db.Issue) bool {
+		return issue.ID == source.ID || !opts.HideDone || issue.Status != "closed"
+	}
+	adjacent := make(map[int64][]int64)
+	for _, link := range links {
+		from, fromOK := issueByID[link.FromIssueID]
+		to, toOK := issueByID[link.ToIssueID]
+		if !fromOK || !toOK || !visible(from) || !visible(to) {
+			continue
+		}
+		adjacent[link.FromIssueID] = append(adjacent[link.FromIssueID], link.ToIssueID)
+		adjacent[link.ToIssueID] = append(adjacent[link.ToIssueID], link.FromIssueID)
+	}
+	for id := range adjacent {
+		sort.Slice(adjacent[id], func(i, j int) bool {
+			return issueByID[adjacent[id][i]].UID < issueByID[adjacent[id][j]].UID
+		})
+	}
+
+	dist := traverseGraph(source.ID, adjacent, depth)
+
+	nodes := make([]api.ReachableGraphNode, 0, len(dist))
+	for id := range dist {
+		issue, ok := issueByID[id]
+		if !ok || !visible(issue) {
+			continue
+		}
+		nodes = append(nodes, api.ReachableGraphNode{
+			Issue:       issue,
+			QualifiedID: project.Name + "#" + issue.ShortID,
+		})
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].UID < nodes[j].UID
+	})
+
+	edges, unresolved := graphEdgesAndUnresolved(links, issueByID, dist, depth, opts.HideDone, source.ID)
+	markTransitiveBlockLayout(edges)
+
+	out := &api.ReachableGraphResponse{}
+	out.Body.SourceUID = source.UID
+	out.Body.Depth = depth.Label
+	out.Body.HideDone = opts.HideDone
+	out.Body.Nodes = nodes
+	out.Body.Edges = edges
+	out.Body.UnresolvedRefs = unresolved
+	return out, nil
+}
+
+func parseReachableGraphDepth(raw string) (parsedGraphDepth, error) {
+	if raw == "" || raw == "full" {
+		return parsedGraphDepth{Label: "full", Full: true}, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return parsedGraphDepth{}, api.NewError(400, "validation",
+			"depth must be full or a non-negative integer", "", nil)
+	}
+	return parsedGraphDepth{Label: strconv.Itoa(n), Max: n}, nil
+}
+
+func listGraphLinks(ctx context.Context, store *db.DB, projectID int64) ([]graphLinkRow, error) {
+	rows, err := store.QueryContext(ctx,
+		`SELECT id, from_issue_id, to_issue_id, from_issue_uid, to_issue_uid, type
+		   FROM links
+		  WHERE project_id = ?
+		  ORDER BY type ASC, from_issue_uid ASC, to_issue_uid ASC, id ASC`,
+		projectID)
+	if err != nil {
+		return nil, fmt.Errorf("list graph links: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []graphLinkRow
+	for rows.Next() {
+		var link graphLinkRow
+		if err := rows.Scan(&link.ID, &link.FromIssueID, &link.ToIssueID,
+			&link.FromIssueUID, &link.ToIssueUID, &link.Kind); err != nil {
+			return nil, fmt.Errorf("scan graph link: %w", err)
+		}
+		out = append(out, link)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate graph links: %w", err)
+	}
+	return out, nil
+}
+
+func traverseGraph(sourceID int64, adjacent map[int64][]int64, depth parsedGraphDepth) map[int64]int {
+	dist := map[int64]int{sourceID: 0}
+	queue := []int64{sourceID}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		currentDepth := dist[id]
+		if !depth.Full && currentDepth >= depth.Max {
+			continue
+		}
+		for _, next := range adjacent[id] {
+			if _, seen := dist[next]; seen {
+				continue
+			}
+			dist[next] = currentDepth + 1
+			queue = append(queue, next)
+		}
+	}
+	return dist
+}
+
+func graphEdgesAndUnresolved(
+	links []graphLinkRow,
+	issueByID map[int64]db.Issue,
+	dist map[int64]int,
+	depth parsedGraphDepth,
+	hideDone bool,
+	sourceID int64,
+) ([]api.ReachableGraphEdge, []api.ReachableGraphUnresolvedRef) {
+	visible := func(id int64) bool {
+		issue, ok := issueByID[id]
+		if !ok {
+			return false
+		}
+		return id == sourceID || !hideDone || issue.Status != "closed"
+	}
+
+	edgeSeen := map[string]struct{}{}
+	unresolvedSeen := map[string]struct{}{}
+	var edges []api.ReachableGraphEdge
+	var unresolved []api.ReachableGraphUnresolvedRef
+	for _, link := range links {
+		fromID, toID, fromUID, toUID := canonicalGraphEdge(link)
+		fromIssue, fromExists := issueByID[fromID]
+		toIssue, toExists := issueByID[toID]
+		fromReachedDepth, fromReached := dist[fromID]
+		toReachedDepth, toReached := dist[toID]
+
+		include := false
+		if fromExists && toExists {
+			include = fromReached && toReached && visible(fromID) && visible(toID)
+		} else if fromExists && fromReached && visible(fromID) && canExpandUnresolved(fromReachedDepth, depth) {
+			include = true
+			unresolved = appendUnresolvedRef(unresolved, unresolvedSeen, toUID, "to", link.Kind, fromIssue.UID)
+		} else if toExists && toReached && visible(toID) && canExpandUnresolved(toReachedDepth, depth) {
+			include = true
+			unresolved = appendUnresolvedRef(unresolved, unresolvedSeen, fromUID, "from", link.Kind, toIssue.UID)
+		}
+		if !include {
+			continue
+		}
+		key := link.Kind + "\x00" + fromUID + "\x00" + toUID
+		if _, ok := edgeSeen[key]; ok {
+			continue
+		}
+		edgeSeen[key] = struct{}{}
+		edges = append(edges, api.ReachableGraphEdge{
+			FromUID: fromUID,
+			ToUID:   toUID,
+			Kind:    link.Kind,
+			Layout:  true,
+		})
+	}
+
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].Kind != edges[j].Kind {
+			return edges[i].Kind < edges[j].Kind
+		}
+		if edges[i].FromUID != edges[j].FromUID {
+			return edges[i].FromUID < edges[j].FromUID
+		}
+		return edges[i].ToUID < edges[j].ToUID
+	})
+	sort.Slice(unresolved, func(i, j int) bool {
+		if unresolved[i].UID != unresolved[j].UID {
+			return unresolved[i].UID < unresolved[j].UID
+		}
+		if unresolved[i].Kind != unresolved[j].Kind {
+			return unresolved[i].Kind < unresolved[j].Kind
+		}
+		if unresolved[i].Side != unresolved[j].Side {
+			return unresolved[i].Side < unresolved[j].Side
+		}
+		return unresolved[i].OtherUID < unresolved[j].OtherUID
+	})
+	return edges, unresolved
+}
+
+func canonicalGraphEdge(link graphLinkRow) (fromID, toID int64, fromUID, toUID string) {
+	if link.Kind == "parent" {
+		return link.ToIssueID, link.FromIssueID, link.ToIssueUID, link.FromIssueUID
+	}
+	return link.FromIssueID, link.ToIssueID, link.FromIssueUID, link.ToIssueUID
+}
+
+func canExpandUnresolved(nodeDepth int, depth parsedGraphDepth) bool {
+	return depth.Full || nodeDepth < depth.Max
+}
+
+func appendUnresolvedRef(
+	out []api.ReachableGraphUnresolvedRef,
+	seen map[string]struct{},
+	uid, side, kind, otherUID string,
+) []api.ReachableGraphUnresolvedRef {
+	key := uid + "\x00" + side + "\x00" + kind + "\x00" + otherUID
+	if _, ok := seen[key]; ok {
+		return out
+	}
+	seen[key] = struct{}{}
+	return append(out, api.ReachableGraphUnresolvedRef{
+		UID:      uid,
+		Side:     side,
+		Kind:     kind,
+		OtherUID: otherUID,
+	})
+}
+
+func markTransitiveBlockLayout(edges []api.ReachableGraphEdge) {
+	blockAdj := map[string][]string{}
+	for _, edge := range edges {
+		if edge.Kind != "blocks" {
+			continue
+		}
+		blockAdj[edge.FromUID] = append(blockAdj[edge.FromUID], edge.ToUID)
+	}
+	for uid := range blockAdj {
+		sort.Strings(blockAdj[uid])
+	}
+	for i := range edges {
+		if edges[i].Kind != "blocks" {
+			continue
+		}
+		if hasAlternateBlockPath(blockAdj, edges[i].FromUID, edges[i].ToUID) {
+			edges[i].Layout = false
+		}
+	}
+}
+
+func hasAlternateBlockPath(adj map[string][]string, from, to string) bool {
+	seen := map[string]struct{}{from: {}}
+	queue := append([]string(nil), adj[from]...)
+	for len(queue) > 0 {
+		next := queue[0]
+		queue = queue[1:]
+		if next == to {
+			continue
+		}
+		if _, ok := seen[next]; ok {
+			continue
+		}
+		seen[next] = struct{}{}
+		for _, peer := range adj[next] {
+			if peer == to {
+				return true
+			}
+			if _, ok := seen[peer]; !ok {
+				queue = append(queue, peer)
+			}
+		}
+	}
+	return false
+}

--- a/internal/daemon/handlers_graph.go
+++ b/internal/daemon/handlers_graph.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"cmp"
 	"context"
+	"errors"
 	"slices"
 	"strconv"
 
@@ -54,10 +55,6 @@ func buildReachableIssueGraph(
 	if err != nil {
 		return nil, api.NewError(500, "internal", err.Error(), "", nil)
 	}
-	project, err := store.ProjectByID(ctx, projectID)
-	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
-	}
 
 	issueByID := make(map[int64]db.Issue, len(issues))
 	for _, issue := range issues {
@@ -78,14 +75,19 @@ func buildReachableIssueGraph(
 	}
 
 	nodes := make([]api.ReachableGraphNode, 0, len(dist))
+	names := &projectNames{store: store}
 	for id := range dist {
 		issue, ok := issueByID[id]
 		if !ok || !visible(issue) {
 			continue
 		}
+		projectName, err := names.name(ctx, issue.ProjectID)
+		if err != nil {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
 		nodes = append(nodes, api.ReachableGraphNode{
 			Issue:       issue,
-			QualifiedID: project.Name + "#" + issue.ShortID,
+			QualifiedID: qualifiedID(projectName, issue.ShortID),
 		})
 	}
 	slices.SortFunc(nodes, api.ReachableGraphNode.Compare)
@@ -220,7 +222,17 @@ func graphNeighbors(
 			continue
 		}
 		neighbor, ok := issueByID[neighborID]
-		if !ok || !visible(neighbor) {
+		if !ok {
+			var err error
+			neighbor, ok, err = hydrateGraphIssue(ctx, cache.store, issueByID, neighborID)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				continue
+			}
+		}
+		if !visible(neighbor) {
 			continue
 		}
 		seen[neighborID] = struct{}{}
@@ -231,6 +243,39 @@ func graphNeighbors(
 	}
 	slices.SortFunc(neighbors, graphNeighbor.Compare)
 	return neighbors, nil
+}
+
+func hydrateGraphIssue(
+	ctx context.Context,
+	store db.Storage,
+	issueByID map[int64]db.Issue,
+	issueID int64,
+) (db.Issue, bool, error) {
+	if issue, ok := issueByID[issueID]; ok {
+		return issue, true, nil
+	}
+	issue, err := store.IssueByID(ctx, issueID)
+	if errors.Is(err, db.ErrNotFound) {
+		return db.Issue{}, false, nil
+	}
+	if err != nil {
+		return db.Issue{}, false, err
+	}
+	if issue.DeletedAt != nil {
+		return db.Issue{}, false, nil
+	}
+	project, err := store.ProjectByID(ctx, issue.ProjectID)
+	if errors.Is(err, db.ErrNotFound) {
+		return db.Issue{}, false, nil
+	}
+	if err != nil {
+		return db.Issue{}, false, err
+	}
+	if project.DeletedAt != nil {
+		return db.Issue{}, false, nil
+	}
+	issueByID[issue.ID] = issue
+	return issue, true, nil
 }
 
 func graphEdgesAndUnresolved(

--- a/internal/daemon/handlers_graph.go
+++ b/internal/daemon/handlers_graph.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"cmp"
 	"context"
-	"fmt"
 	"slices"
 	"strconv"
 
@@ -42,7 +41,7 @@ func (n graphNeighbor) Compare(other graphNeighbor) int {
 
 func buildReachableIssueGraph(
 	ctx context.Context,
-	store *db.DB,
+	store db.Storage,
 	projectID int64,
 	source db.Issue,
 	opts reachableGraphOptions,
@@ -52,10 +51,6 @@ func buildReachableIssueGraph(
 		return nil, err
 	}
 	issues, err := store.ListIssues(ctx, db.ListIssuesParams{ProjectID: projectID})
-	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
-	}
-	links, err := listGraphLinks(ctx, store, projectID)
 	if err != nil {
 		return nil, api.NewError(500, "internal", err.Error(), "", nil)
 	}
@@ -75,27 +70,12 @@ func buildReachableIssueGraph(
 	visible := func(issue db.Issue) bool {
 		return issue.ID == source.ID || !opts.HideDone || issue.Status != "closed"
 	}
-	adjacent := make(map[int64][]graphNeighbor)
-	for _, link := range links {
-		from, fromOK := issueByID[link.FromIssueID]
-		to, toOK := issueByID[link.ToIssueID]
-		if !fromOK || !toOK || !visible(from) || !visible(to) {
-			continue
-		}
-		adjacent[link.FromIssueID] = append(adjacent[link.FromIssueID], graphNeighbor{
-			IssueID:  link.ToIssueID,
-			IssueUID: to.UID,
-		})
-		adjacent[link.ToIssueID] = append(adjacent[link.ToIssueID], graphNeighbor{
-			IssueID:  link.FromIssueID,
-			IssueUID: from.UID,
-		})
-	}
-	for id := range adjacent {
-		slices.SortFunc(adjacent[id], graphNeighbor.Compare)
-	}
 
-	dist := traverseGraph(source.ID, adjacent, depth)
+	cache := &graphLinkCache{store: store, linksByIssue: map[int64][]graphLinkRow{}}
+	dist, err := traverseGraph(ctx, source.ID, issueByID, visible, cache, depth)
+	if err != nil {
+		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	}
 
 	nodes := make([]api.ReachableGraphNode, 0, len(dist))
 	for id := range dist {
@@ -110,6 +90,10 @@ func buildReachableIssueGraph(
 	}
 	slices.SortFunc(nodes, api.ReachableGraphNode.Compare)
 
+	links, err := cache.linksForReached(ctx, dist)
+	if err != nil {
+		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	}
 	edges, unresolved := graphEdgesAndUnresolved(links, issueByID, dist, depth, opts.HideDone, source.ID)
 	markTransitiveBlockLayout(edges)
 
@@ -135,33 +119,61 @@ func parseReachableGraphDepth(raw string) (parsedGraphDepth, error) {
 	return parsedGraphDepth{Label: strconv.Itoa(n), Max: n}, nil
 }
 
-func listGraphLinks(ctx context.Context, store *db.DB, projectID int64) ([]graphLinkRow, error) {
-	rows, err := store.QueryContext(ctx,
-		`SELECT id, from_issue_id, to_issue_id, from_issue_uid, to_issue_uid, type
-		   FROM links
-		  WHERE project_id = ?
-		  ORDER BY type ASC, from_issue_uid ASC, to_issue_uid ASC, id ASC`,
-		projectID)
+type graphLinkCache struct {
+	store        db.Storage
+	linksByIssue map[int64][]graphLinkRow
+}
+
+func (c *graphLinkCache) linksForIssue(ctx context.Context, issueID int64) ([]graphLinkRow, error) {
+	if links, ok := c.linksByIssue[issueID]; ok {
+		return links, nil
+	}
+	dbLinks, err := c.store.LinksByIssue(ctx, issueID)
 	if err != nil {
-		return nil, fmt.Errorf("list graph links: %w", err)
+		return nil, err
 	}
-	defer func() { _ = rows.Close() }()
+	links := make([]graphLinkRow, 0, len(dbLinks))
+	for _, link := range dbLinks {
+		links = append(links, graphLinkRow{
+			ID:           link.ID,
+			FromIssueID:  link.FromIssueID,
+			ToIssueID:    link.ToIssueID,
+			FromIssueUID: link.FromIssueUID,
+			ToIssueUID:   link.ToIssueUID,
+			Kind:         link.Type,
+		})
+	}
+	c.linksByIssue[issueID] = links
+	return links, nil
+}
+
+func (c *graphLinkCache) linksForReached(ctx context.Context, dist map[int64]int) ([]graphLinkRow, error) {
+	seen := map[int64]struct{}{}
 	var out []graphLinkRow
-	for rows.Next() {
-		var link graphLinkRow
-		if err := rows.Scan(&link.ID, &link.FromIssueID, &link.ToIssueID,
-			&link.FromIssueUID, &link.ToIssueUID, &link.Kind); err != nil {
-			return nil, fmt.Errorf("scan graph link: %w", err)
+	for issueID := range dist {
+		links, err := c.linksForIssue(ctx, issueID)
+		if err != nil {
+			return nil, err
 		}
-		out = append(out, link)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate graph links: %w", err)
+		for _, link := range links {
+			if _, ok := seen[link.ID]; ok {
+				continue
+			}
+			seen[link.ID] = struct{}{}
+			out = append(out, link)
+		}
 	}
 	return out, nil
 }
 
-func traverseGraph(sourceID int64, adjacent map[int64][]graphNeighbor, depth parsedGraphDepth) map[int64]int {
+func traverseGraph(
+	ctx context.Context,
+	sourceID int64,
+	issueByID map[int64]db.Issue,
+	visible func(db.Issue) bool,
+	cache *graphLinkCache,
+	depth parsedGraphDepth,
+) (map[int64]int, error) {
 	dist := map[int64]int{sourceID: 0}
 	queue := []int64{sourceID}
 	for len(queue) > 0 {
@@ -171,7 +183,11 @@ func traverseGraph(sourceID int64, adjacent map[int64][]graphNeighbor, depth par
 		if !depth.Full && currentDepth >= depth.Max {
 			continue
 		}
-		for _, next := range adjacent[id] {
+		neighbors, err := graphNeighbors(ctx, id, issueByID, visible, cache)
+		if err != nil {
+			return nil, err
+		}
+		for _, next := range neighbors {
 			if _, seen := dist[next.IssueID]; seen {
 				continue
 			}
@@ -179,7 +195,42 @@ func traverseGraph(sourceID int64, adjacent map[int64][]graphNeighbor, depth par
 			queue = append(queue, next.IssueID)
 		}
 	}
-	return dist
+	return dist, nil
+}
+
+func graphNeighbors(
+	ctx context.Context,
+	issueID int64,
+	issueByID map[int64]db.Issue,
+	visible func(db.Issue) bool,
+	cache *graphLinkCache,
+) ([]graphNeighbor, error) {
+	links, err := cache.linksForIssue(ctx, issueID)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[int64]struct{}{}
+	neighbors := make([]graphNeighbor, 0, len(links))
+	for _, link := range links {
+		neighborID := link.ToIssueID
+		if link.ToIssueID == issueID {
+			neighborID = link.FromIssueID
+		}
+		if _, ok := seen[neighborID]; ok {
+			continue
+		}
+		neighbor, ok := issueByID[neighborID]
+		if !ok || !visible(neighbor) {
+			continue
+		}
+		seen[neighborID] = struct{}{}
+		neighbors = append(neighbors, graphNeighbor{
+			IssueID:  neighbor.ID,
+			IssueUID: neighbor.UID,
+		})
+	}
+	slices.SortFunc(neighbors, graphNeighbor.Compare)
+	return neighbors, nil
 }
 
 func graphEdgesAndUnresolved(

--- a/internal/daemon/handlers_graph.go
+++ b/internal/daemon/handlers_graph.go
@@ -1,9 +1,10 @@
 package daemon
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 
 	"go.kenn.io/kata/internal/api"
@@ -28,6 +29,15 @@ type graphLinkRow struct {
 	FromIssueUID string
 	ToIssueUID   string
 	Kind         string
+}
+
+type graphNeighbor struct {
+	IssueID  int64
+	IssueUID string
+}
+
+func (n graphNeighbor) Compare(other graphNeighbor) int {
+	return cmp.Compare(n.IssueUID, other.IssueUID)
 }
 
 func buildReachableIssueGraph(
@@ -65,20 +75,24 @@ func buildReachableIssueGraph(
 	visible := func(issue db.Issue) bool {
 		return issue.ID == source.ID || !opts.HideDone || issue.Status != "closed"
 	}
-	adjacent := make(map[int64][]int64)
+	adjacent := make(map[int64][]graphNeighbor)
 	for _, link := range links {
 		from, fromOK := issueByID[link.FromIssueID]
 		to, toOK := issueByID[link.ToIssueID]
 		if !fromOK || !toOK || !visible(from) || !visible(to) {
 			continue
 		}
-		adjacent[link.FromIssueID] = append(adjacent[link.FromIssueID], link.ToIssueID)
-		adjacent[link.ToIssueID] = append(adjacent[link.ToIssueID], link.FromIssueID)
+		adjacent[link.FromIssueID] = append(adjacent[link.FromIssueID], graphNeighbor{
+			IssueID:  link.ToIssueID,
+			IssueUID: to.UID,
+		})
+		adjacent[link.ToIssueID] = append(adjacent[link.ToIssueID], graphNeighbor{
+			IssueID:  link.FromIssueID,
+			IssueUID: from.UID,
+		})
 	}
 	for id := range adjacent {
-		sort.Slice(adjacent[id], func(i, j int) bool {
-			return issueByID[adjacent[id][i]].UID < issueByID[adjacent[id][j]].UID
-		})
+		slices.SortFunc(adjacent[id], graphNeighbor.Compare)
 	}
 
 	dist := traverseGraph(source.ID, adjacent, depth)
@@ -94,9 +108,7 @@ func buildReachableIssueGraph(
 			QualifiedID: project.Name + "#" + issue.ShortID,
 		})
 	}
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].UID < nodes[j].UID
-	})
+	slices.SortFunc(nodes, api.ReachableGraphNode.Compare)
 
 	edges, unresolved := graphEdgesAndUnresolved(links, issueByID, dist, depth, opts.HideDone, source.ID)
 	markTransitiveBlockLayout(edges)
@@ -149,7 +161,7 @@ func listGraphLinks(ctx context.Context, store *db.DB, projectID int64) ([]graph
 	return out, nil
 }
 
-func traverseGraph(sourceID int64, adjacent map[int64][]int64, depth parsedGraphDepth) map[int64]int {
+func traverseGraph(sourceID int64, adjacent map[int64][]graphNeighbor, depth parsedGraphDepth) map[int64]int {
 	dist := map[int64]int{sourceID: 0}
 	queue := []int64{sourceID}
 	for len(queue) > 0 {
@@ -160,11 +172,11 @@ func traverseGraph(sourceID int64, adjacent map[int64][]int64, depth parsedGraph
 			continue
 		}
 		for _, next := range adjacent[id] {
-			if _, seen := dist[next]; seen {
+			if _, seen := dist[next.IssueID]; seen {
 				continue
 			}
-			dist[next] = currentDepth + 1
-			queue = append(queue, next)
+			dist[next.IssueID] = currentDepth + 1
+			queue = append(queue, next.IssueID)
 		}
 	}
 	return dist
@@ -223,27 +235,8 @@ func graphEdgesAndUnresolved(
 		})
 	}
 
-	sort.Slice(edges, func(i, j int) bool {
-		if edges[i].Kind != edges[j].Kind {
-			return edges[i].Kind < edges[j].Kind
-		}
-		if edges[i].FromUID != edges[j].FromUID {
-			return edges[i].FromUID < edges[j].FromUID
-		}
-		return edges[i].ToUID < edges[j].ToUID
-	})
-	sort.Slice(unresolved, func(i, j int) bool {
-		if unresolved[i].UID != unresolved[j].UID {
-			return unresolved[i].UID < unresolved[j].UID
-		}
-		if unresolved[i].Kind != unresolved[j].Kind {
-			return unresolved[i].Kind < unresolved[j].Kind
-		}
-		if unresolved[i].Side != unresolved[j].Side {
-			return unresolved[i].Side < unresolved[j].Side
-		}
-		return unresolved[i].OtherUID < unresolved[j].OtherUID
-	})
+	slices.SortFunc(edges, api.ReachableGraphEdge.Compare)
+	slices.SortFunc(unresolved, api.ReachableGraphUnresolvedRef.Compare)
 	return edges, unresolved
 }
 
@@ -285,7 +278,7 @@ func markTransitiveBlockLayout(edges []api.ReachableGraphEdge) {
 		blockAdj[edge.FromUID] = append(blockAdj[edge.FromUID], edge.ToUID)
 	}
 	for uid := range blockAdj {
-		sort.Strings(blockAdj[uid])
+		slices.Sort(blockAdj[uid])
 	}
 	for i := range edges {
 		if edges[i].Kind != "blocks" {

--- a/internal/daemon/handlers_graph.go
+++ b/internal/daemon/handlers_graph.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"slices"
@@ -17,33 +16,45 @@ type reachableGraphOptions struct {
 }
 
 type parsedGraphDepth struct {
-	Label string
-	Full  bool
-	Max   int
+	Full bool
+	Max  int
 }
 
-type graphLinkRow struct {
-	ID           int64
-	FromIssueID  int64
-	ToIssueID    int64
-	FromIssueUID string
-	ToIssueUID   string
-	Kind         string
+func (d parsedGraphDepth) String() string {
+	if d.Full {
+		return "full"
+	}
+	return strconv.Itoa(d.Max)
 }
 
-type graphNeighbor struct {
-	IssueID  int64
-	IssueUID string
+func parseReachableGraphDepth(raw string) (parsedGraphDepth, error) {
+	if raw == "" || raw == "full" {
+		return parsedGraphDepth{Full: true}, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return parsedGraphDepth{}, api.NewError(400, "validation",
+			"depth must be full or a non-negative integer", "", nil)
+	}
+	return parsedGraphDepth{Max: n}, nil
 }
 
-func (n graphNeighbor) Compare(other graphNeighbor) int {
-	return cmp.Compare(n.IssueUID, other.IssueUID)
+// graphWalk holds per-request traversal state: lazily hydrated issues and
+// projects, memoized link reads, and link endpoints that exist in storage but
+// are hidden from the active graph (soft-deleted issues, archived projects).
+type graphWalk struct {
+	store        db.Storage
+	sourceID     int64
+	hideDone     bool
+	issueByID    map[int64]db.Issue
+	projectByID  map[int64]db.Project
+	linksByIssue map[int64][]db.Link
+	hidden       map[int64]struct{}
 }
 
 func buildReachableIssueGraph(
 	ctx context.Context,
 	store db.Storage,
-	projectID int64,
 	source db.Issue,
 	opts reachableGraphOptions,
 ) (*api.ReachableGraphResponse, error) {
@@ -51,57 +62,45 @@ func buildReachableIssueGraph(
 	if err != nil {
 		return nil, err
 	}
-	issues, err := store.ListIssues(ctx, db.ListIssuesParams{ProjectID: projectID})
-	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+	w := &graphWalk{
+		store:        store,
+		sourceID:     source.ID,
+		hideDone:     opts.HideDone,
+		issueByID:    map[int64]db.Issue{source.ID: source},
+		projectByID:  map[int64]db.Project{},
+		linksByIssue: map[int64][]db.Link{},
+		hidden:       map[int64]struct{}{},
 	}
 
-	issueByID := make(map[int64]db.Issue, len(issues))
-	for _, issue := range issues {
-		issueByID[issue.ID] = issue
-	}
-	if _, ok := issueByID[source.ID]; !ok {
-		issueByID[source.ID] = source
-	}
-
-	visible := func(issue db.Issue) bool {
-		return issue.ID == source.ID || !opts.HideDone || issue.Status != "closed"
-	}
-
-	cache := &graphLinkCache{store: store, linksByIssue: map[int64][]graphLinkRow{}}
-	dist, err := traverseGraph(ctx, source.ID, issueByID, visible, cache, depth)
+	dist, err := w.traverse(ctx, depth)
 	if err != nil {
 		return nil, api.NewError(500, "internal", err.Error(), "", nil)
 	}
 
 	nodes := make([]api.ReachableGraphNode, 0, len(dist))
-	names := &projectNames{store: store}
 	for id := range dist {
-		issue, ok := issueByID[id]
-		if !ok || !visible(issue) {
-			continue
-		}
-		projectName, err := names.name(ctx, issue.ProjectID)
+		issue := w.issueByID[id]
+		project, err := w.project(ctx, issue.ProjectID)
 		if err != nil {
 			return nil, api.NewError(500, "internal", err.Error(), "", nil)
 		}
 		nodes = append(nodes, api.ReachableGraphNode{
 			Issue:       issue,
-			QualifiedID: qualifiedID(projectName, issue.ShortID),
+			QualifiedID: qualifiedID(project.Name, issue.ShortID),
 		})
 	}
 	slices.SortFunc(nodes, api.ReachableGraphNode.Compare)
 
-	links, err := cache.linksForReached(ctx, dist)
+	links, err := w.linksForReached(ctx, dist)
 	if err != nil {
 		return nil, api.NewError(500, "internal", err.Error(), "", nil)
 	}
-	edges, unresolved := graphEdgesAndUnresolved(links, issueByID, dist, depth, opts.HideDone, source.ID)
+	edges, unresolved := w.edgesAndUnresolved(links, dist, depth)
 	markTransitiveBlockLayout(edges)
 
 	out := &api.ReachableGraphResponse{}
 	out.Body.SourceUID = source.UID
-	out.Body.Depth = depth.Label
+	out.Body.Depth = depth.String()
 	out.Body.HideDone = opts.HideDone
 	out.Body.Nodes = nodes
 	out.Body.Edges = edges
@@ -109,51 +108,115 @@ func buildReachableIssueGraph(
 	return out, nil
 }
 
-func parseReachableGraphDepth(raw string) (parsedGraphDepth, error) {
-	if raw == "" || raw == "full" {
-		return parsedGraphDepth{Label: "full", Full: true}, nil
-	}
-	n, err := strconv.Atoi(raw)
-	if err != nil || n < 0 {
-		return parsedGraphDepth{}, api.NewError(400, "validation",
-			"depth must be full or a non-negative integer", "", nil)
-	}
-	return parsedGraphDepth{Label: strconv.Itoa(n), Max: n}, nil
+// visible reports whether an issue participates in the graph under the
+// hide-done option. The source issue is always shown.
+func (w *graphWalk) visible(issue db.Issue) bool {
+	return issue.ID == w.sourceID || !w.hideDone || issue.Status != "closed"
 }
 
-type graphLinkCache struct {
-	store        db.Storage
-	linksByIssue map[int64][]graphLinkRow
+// issue lazily hydrates an issue by id. ok is false when the issue does not
+// exist or is hidden (soft-deleted, or its project is archived); hidden
+// endpoints are recorded so edge building can drop their links instead of
+// reporting them as unresolved references.
+func (w *graphWalk) issue(ctx context.Context, issueID int64) (db.Issue, bool, error) {
+	if issue, ok := w.issueByID[issueID]; ok {
+		return issue, true, nil
+	}
+	if _, ok := w.hidden[issueID]; ok {
+		return db.Issue{}, false, nil
+	}
+	issue, err := w.store.IssueByID(ctx, issueID)
+	if errors.Is(err, db.ErrNotFound) {
+		return db.Issue{}, false, nil
+	}
+	if err != nil {
+		return db.Issue{}, false, err
+	}
+	if issue.DeletedAt != nil {
+		w.hidden[issueID] = struct{}{}
+		return db.Issue{}, false, nil
+	}
+	project, err := w.project(ctx, issue.ProjectID)
+	if errors.Is(err, db.ErrNotFound) {
+		return db.Issue{}, false, nil
+	}
+	if err != nil {
+		return db.Issue{}, false, err
+	}
+	if project.DeletedAt != nil {
+		w.hidden[issueID] = struct{}{}
+		return db.Issue{}, false, nil
+	}
+	w.issueByID[issueID] = issue
+	return issue, true, nil
 }
 
-func (c *graphLinkCache) linksForIssue(ctx context.Context, issueID int64) ([]graphLinkRow, error) {
-	if links, ok := c.linksByIssue[issueID]; ok {
+func (w *graphWalk) project(ctx context.Context, projectID int64) (db.Project, error) {
+	if project, ok := w.projectByID[projectID]; ok {
+		return project, nil
+	}
+	project, err := w.store.ProjectByID(ctx, projectID)
+	if err != nil {
+		return db.Project{}, err
+	}
+	w.projectByID[projectID] = project
+	return project, nil
+}
+
+func (w *graphWalk) links(ctx context.Context, issueID int64) ([]db.Link, error) {
+	if links, ok := w.linksByIssue[issueID]; ok {
 		return links, nil
 	}
-	dbLinks, err := c.store.LinksByIssue(ctx, issueID)
+	links, err := w.store.LinksByIssue(ctx, issueID)
 	if err != nil {
 		return nil, err
 	}
-	links := make([]graphLinkRow, 0, len(dbLinks))
-	for _, link := range dbLinks {
-		links = append(links, graphLinkRow{
-			ID:           link.ID,
-			FromIssueID:  link.FromIssueID,
-			ToIssueID:    link.ToIssueID,
-			FromIssueUID: link.FromIssueUID,
-			ToIssueUID:   link.ToIssueUID,
-			Kind:         link.Type,
-		})
-	}
-	c.linksByIssue[issueID] = links
+	w.linksByIssue[issueID] = links
 	return links, nil
 }
 
-func (c *graphLinkCache) linksForReached(ctx context.Context, dist map[int64]int) ([]graphLinkRow, error) {
+// traverse runs a breadth-first walk over links from the source, returning
+// each reached issue's hop distance. Only visible issues are entered.
+func (w *graphWalk) traverse(ctx context.Context, depth parsedGraphDepth) (map[int64]int, error) {
+	dist := map[int64]int{w.sourceID: 0}
+	queue := []int64{w.sourceID}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if !depth.Full && dist[id] >= depth.Max {
+			continue
+		}
+		links, err := w.links(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		for _, link := range links {
+			neighborID := link.ToIssueID
+			if link.ToIssueID == id {
+				neighborID = link.FromIssueID
+			}
+			if _, seen := dist[neighborID]; seen {
+				continue
+			}
+			neighbor, ok, err := w.issue(ctx, neighborID)
+			if err != nil {
+				return nil, err
+			}
+			if !ok || !w.visible(neighbor) {
+				continue
+			}
+			dist[neighborID] = dist[id] + 1
+			queue = append(queue, neighborID)
+		}
+	}
+	return dist, nil
+}
+
+func (w *graphWalk) linksForReached(ctx context.Context, dist map[int64]int) ([]db.Link, error) {
 	seen := map[int64]struct{}{}
-	var out []graphLinkRow
+	var out []db.Link
 	for issueID := range dist {
-		links, err := c.linksForIssue(ctx, issueID)
+		links, err := w.links(ctx, issueID)
 		if err != nil {
 			return nil, err
 		}
@@ -168,130 +231,14 @@ func (c *graphLinkCache) linksForReached(ctx context.Context, dist map[int64]int
 	return out, nil
 }
 
-func traverseGraph(
-	ctx context.Context,
-	sourceID int64,
-	issueByID map[int64]db.Issue,
-	visible func(db.Issue) bool,
-	cache *graphLinkCache,
-	depth parsedGraphDepth,
-) (map[int64]int, error) {
-	dist := map[int64]int{sourceID: 0}
-	queue := []int64{sourceID}
-	for len(queue) > 0 {
-		id := queue[0]
-		queue = queue[1:]
-		currentDepth := dist[id]
-		if !depth.Full && currentDepth >= depth.Max {
-			continue
-		}
-		neighbors, err := graphNeighbors(ctx, id, issueByID, visible, cache)
-		if err != nil {
-			return nil, err
-		}
-		for _, next := range neighbors {
-			if _, seen := dist[next.IssueID]; seen {
-				continue
-			}
-			dist[next.IssueID] = currentDepth + 1
-			queue = append(queue, next.IssueID)
-		}
-	}
-	return dist, nil
-}
-
-func graphNeighbors(
-	ctx context.Context,
-	issueID int64,
-	issueByID map[int64]db.Issue,
-	visible func(db.Issue) bool,
-	cache *graphLinkCache,
-) ([]graphNeighbor, error) {
-	links, err := cache.linksForIssue(ctx, issueID)
-	if err != nil {
-		return nil, err
-	}
-	seen := map[int64]struct{}{}
-	neighbors := make([]graphNeighbor, 0, len(links))
-	for _, link := range links {
-		neighborID := link.ToIssueID
-		if link.ToIssueID == issueID {
-			neighborID = link.FromIssueID
-		}
-		if _, ok := seen[neighborID]; ok {
-			continue
-		}
-		neighbor, ok := issueByID[neighborID]
-		if !ok {
-			var err error
-			neighbor, ok, err = hydrateGraphIssue(ctx, cache.store, issueByID, neighborID)
-			if err != nil {
-				return nil, err
-			}
-			if !ok {
-				continue
-			}
-		}
-		if !visible(neighbor) {
-			continue
-		}
-		seen[neighborID] = struct{}{}
-		neighbors = append(neighbors, graphNeighbor{
-			IssueID:  neighbor.ID,
-			IssueUID: neighbor.UID,
-		})
-	}
-	slices.SortFunc(neighbors, graphNeighbor.Compare)
-	return neighbors, nil
-}
-
-func hydrateGraphIssue(
-	ctx context.Context,
-	store db.Storage,
-	issueByID map[int64]db.Issue,
-	issueID int64,
-) (db.Issue, bool, error) {
-	if issue, ok := issueByID[issueID]; ok {
-		return issue, true, nil
-	}
-	issue, err := store.IssueByID(ctx, issueID)
-	if errors.Is(err, db.ErrNotFound) {
-		return db.Issue{}, false, nil
-	}
-	if err != nil {
-		return db.Issue{}, false, err
-	}
-	if issue.DeletedAt != nil {
-		return db.Issue{}, false, nil
-	}
-	project, err := store.ProjectByID(ctx, issue.ProjectID)
-	if errors.Is(err, db.ErrNotFound) {
-		return db.Issue{}, false, nil
-	}
-	if err != nil {
-		return db.Issue{}, false, err
-	}
-	if project.DeletedAt != nil {
-		return db.Issue{}, false, nil
-	}
-	issueByID[issue.ID] = issue
-	return issue, true, nil
-}
-
-func graphEdgesAndUnresolved(
-	links []graphLinkRow,
-	issueByID map[int64]db.Issue,
+func (w *graphWalk) edgesAndUnresolved(
+	links []db.Link,
 	dist map[int64]int,
 	depth parsedGraphDepth,
-	hideDone bool,
-	sourceID int64,
 ) ([]api.ReachableGraphEdge, []api.ReachableGraphUnresolvedRef) {
 	visible := func(id int64) bool {
-		issue, ok := issueByID[id]
-		if !ok {
-			return false
-		}
-		return id == sourceID || !hideDone || issue.Status != "closed"
+		issue, ok := w.issueByID[id]
+		return ok && w.visible(issue)
 	}
 
 	edgeSeen := map[string]struct{}{}
@@ -300,8 +247,14 @@ func graphEdgesAndUnresolved(
 	var unresolved []api.ReachableGraphUnresolvedRef
 	for _, link := range links {
 		fromID, toID, fromUID, toUID := canonicalGraphEdge(link)
-		fromIssue, fromExists := issueByID[fromID]
-		toIssue, toExists := issueByID[toID]
+		if _, ok := w.hidden[fromID]; ok {
+			continue
+		}
+		if _, ok := w.hidden[toID]; ok {
+			continue
+		}
+		fromIssue, fromExists := w.issueByID[fromID]
+		toIssue, toExists := w.issueByID[toID]
 		fromReachedDepth, fromReached := dist[fromID]
 		toReachedDepth, toReached := dist[toID]
 
@@ -310,15 +263,15 @@ func graphEdgesAndUnresolved(
 			include = fromReached && toReached && visible(fromID) && visible(toID)
 		} else if fromExists && fromReached && visible(fromID) && canExpandUnresolved(fromReachedDepth, depth) {
 			include = true
-			unresolved = appendUnresolvedRef(unresolved, unresolvedSeen, toUID, "to", link.Kind, fromIssue.UID)
+			unresolved = appendUnresolvedRef(unresolved, unresolvedSeen, toUID, "to", link.Type, fromIssue.UID)
 		} else if toExists && toReached && visible(toID) && canExpandUnresolved(toReachedDepth, depth) {
 			include = true
-			unresolved = appendUnresolvedRef(unresolved, unresolvedSeen, fromUID, "from", link.Kind, toIssue.UID)
+			unresolved = appendUnresolvedRef(unresolved, unresolvedSeen, fromUID, "from", link.Type, toIssue.UID)
 		}
 		if !include {
 			continue
 		}
-		key := link.Kind + "\x00" + fromUID + "\x00" + toUID
+		key := link.Type + "\x00" + fromUID + "\x00" + toUID
 		if _, ok := edgeSeen[key]; ok {
 			continue
 		}
@@ -326,7 +279,7 @@ func graphEdgesAndUnresolved(
 		edges = append(edges, api.ReachableGraphEdge{
 			FromUID: fromUID,
 			ToUID:   toUID,
-			Kind:    link.Kind,
+			Kind:    link.Type,
 			Layout:  true,
 		})
 	}
@@ -336,13 +289,18 @@ func graphEdgesAndUnresolved(
 	return edges, unresolved
 }
 
-func canonicalGraphEdge(link graphLinkRow) (fromID, toID int64, fromUID, toUID string) {
-	if link.Kind == "parent" {
+// canonicalGraphEdge orients an edge for display: parent links are stored
+// child -> parent but rendered parent -> child.
+func canonicalGraphEdge(link db.Link) (fromID, toID int64, fromUID, toUID string) {
+	if link.Type == "parent" {
 		return link.ToIssueID, link.FromIssueID, link.ToIssueUID, link.FromIssueUID
 	}
 	return link.FromIssueID, link.ToIssueID, link.FromIssueUID, link.ToIssueUID
 }
 
+// canExpandUnresolved reports whether traversal would have expanded a node's
+// neighbors, i.e. whether a dangling endpoint next to it is genuinely
+// unresolved rather than simply beyond the depth bound.
 func canExpandUnresolved(nodeDepth int, depth parsedGraphDepth) bool {
 	return depth.Full || nodeDepth < depth.Max
 }

--- a/internal/daemon/handlers_graph_test.go
+++ b/internal/daemon/handlers_graph_test.go
@@ -194,7 +194,6 @@ func graphIssue(t *testing.T, h *httptestServerHandle, projectID int64, uid, tit
 func graphLink(t *testing.T, h *httptestServerHandle, projectID, fromID, toID int64, kind string) {
 	t.Helper()
 	_, err := h.DB().CreateLink(context.Background(), db.CreateLinkParams{
-		ProjectID:   projectID,
 		FromIssueID: fromID,
 		ToIssueID:   toID,
 		Type:        kind,
@@ -221,9 +220,9 @@ func insertUnresolvedGraphLink(
 	_, err := h.DB().ExecContext(context.Background(), `PRAGMA foreign_keys = OFF`)
 	require.NoError(t, err)
 	_, err = h.DB().ExecContext(context.Background(),
-		`INSERT INTO links(project_id, from_issue_id, to_issue_id, from_issue_uid, to_issue_uid, type, author)
-		 VALUES(?, ?, ?, ?, ?, ?, ?)`,
-		projectID, fromID, toID, fromUID, toUID, kind, "tester")
+		`INSERT INTO links(from_issue_id, to_issue_id, from_issue_uid, to_issue_uid, type, author)
+		 VALUES(?, ?, ?, ?, ?, ?)`,
+		fromID, toID, fromUID, toUID, kind, "tester")
 	require.NoError(t, err)
 }
 

--- a/internal/daemon/handlers_graph_test.go
+++ b/internal/daemon/handlers_graph_test.go
@@ -105,6 +105,30 @@ func TestReachableGraph_RelatedEdges(t *testing.T) {
 	assert.Equal(t, []string{"related:" + a.UID + "->" + b.UID + ":true"}, graphEdgeKeys(graph))
 }
 
+func TestReachableGraph_TraversesCrossProjectLinksWithQualifiedIDs(t *testing.T) {
+	h, ts, sourceProjectID := graphProject(t)
+	ctx := context.Background()
+	foreignProject, err := h.DB().CreateProject(ctx, "foreign")
+	require.NoError(t, err)
+	source := graphIssue(t, h, sourceProjectID, "01HZNQ7VFPK1XGD8R5MABCD4E1", "source")
+	foreign := graphIssue(t, h, foreignProject.ID, "01HZNQ7VFPK1XGD8R5MABCD4E2", "foreign")
+	foreignChild := graphIssue(t, h, foreignProject.ID, "01HZNQ7VFPK1XGD8R5MABCD4E3", "foreign child")
+	graphLink(t, h, sourceProjectID, source.ID, foreign.ID, "blocks")
+	graphLink(t, h, foreignProject.ID, foreign.ID, foreignChild.ID, "blocks")
+
+	graph := getGraph(t, ts, sourceProjectID, source.ShortID, "?depth=full")
+
+	assert.Equal(t, []string{source.UID, foreign.UID, foreignChild.UID}, graphNodeUIDs(graph))
+	assert.Equal(t, "kata#"+source.ShortID, graphNodeByUID(t, graph, source.UID).QualifiedID)
+	assert.Equal(t, "foreign#"+foreign.ShortID, graphNodeByUID(t, graph, foreign.UID).QualifiedID)
+	assert.Equal(t, "foreign#"+foreignChild.ShortID, graphNodeByUID(t, graph, foreignChild.UID).QualifiedID)
+	assert.Equal(t, []string{
+		"blocks:" + source.UID + "->" + foreign.UID + ":true",
+		"blocks:" + foreign.UID + "->" + foreignChild.UID + ":true",
+	}, graphEdgeKeys(graph))
+	assert.Empty(t, graph.UnresolvedRefs)
+}
+
 func TestReachableGraph_BoundedDepthVsFullTraversal(t *testing.T) {
 	h, ts, pid := graphProject(t)
 	a := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E1", "a")
@@ -251,6 +275,17 @@ func graphNodeUIDs(graph graphResponseTest) []string {
 		out = append(out, node.UID)
 	}
 	return out
+}
+
+func graphNodeByUID(t *testing.T, graph graphResponseTest, uid string) graphNodeTest {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.UID == uid {
+			return node
+		}
+	}
+	t.Fatalf("graph missing node uid %s", uid)
+	return graphNodeTest{}
 }
 
 func graphEdgeKeys(graph graphResponseTest) []string {

--- a/internal/daemon/handlers_graph_test.go
+++ b/internal/daemon/handlers_graph_test.go
@@ -191,7 +191,7 @@ func graphIssue(t *testing.T, h *httptestServerHandle, projectID int64, uid, tit
 	return issue
 }
 
-func graphLink(t *testing.T, h *httptestServerHandle, projectID, fromID, toID int64, kind string) {
+func graphLink(t *testing.T, h *httptestServerHandle, _ int64, fromID, toID int64, kind string) {
 	t.Helper()
 	_, err := h.DB().CreateLink(context.Background(), db.CreateLinkParams{
 		FromIssueID: fromID,
@@ -213,7 +213,7 @@ func graphRelated(t *testing.T, h *httptestServerHandle, projectID, aID, bID int
 func insertUnresolvedGraphLink(
 	t *testing.T,
 	h *httptestServerHandle,
-	projectID, fromID, toID int64,
+	_ int64, fromID, toID int64,
 	fromUID, toUID, kind string,
 ) {
 	t.Helper()

--- a/internal/daemon/handlers_graph_test.go
+++ b/internal/daemon/handlers_graph_test.go
@@ -178,6 +178,34 @@ func TestReachableGraph_UnresolvedReferences(t *testing.T) {
 	assert.Equal(t, source.UID, graph.UnresolvedRefs[0].Other)
 }
 
+func TestReachableGraph_OmitsDeletedAndArchivedEndpoints(t *testing.T) {
+	h, ts, pid := graphProject(t)
+	ctx := context.Background()
+	source := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E1", "source")
+	deleted := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E2", "deleted")
+	graphLink(t, h, pid, source.ID, deleted.ID, "blocks")
+	_, _, changed, err := h.DB().SoftDeleteIssue(ctx, deleted.ID, "tester")
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	archivedProject, err := h.DB().CreateProject(ctx, "archived-project")
+	require.NoError(t, err)
+	archived := graphIssue(t, h, archivedProject.ID, "01HZNQ7VFPK1XGD8R5MABCD4E3", "archived")
+	graphLink(t, h, pid, source.ID, archived.ID, "blocks")
+	_, _, err = h.DB().RemoveProject(ctx, db.RemoveProjectParams{
+		ProjectID: archivedProject.ID,
+		Actor:     "tester",
+		Force:     true,
+	})
+	require.NoError(t, err)
+
+	graph := getGraph(t, ts, pid, source.ShortID, "?depth=full")
+
+	assert.Equal(t, []string{source.UID}, graphNodeUIDs(graph))
+	assert.Empty(t, graph.Edges)
+	assert.Empty(t, graph.UnresolvedRefs)
+}
+
 func TestReachableGraph_TransitiveBlockPruningForLayoutOnlyAndStableOrdering(t *testing.T) {
 	h, ts, pid := graphProject(t)
 	c := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E3", "c")

--- a/internal/daemon/handlers_graph_test.go
+++ b/internal/daemon/handlers_graph_test.go
@@ -1,0 +1,263 @@
+package daemon_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+type graphResponseTest struct {
+	SourceUID      string                `json:"source_uid"`
+	Depth          string                `json:"depth"`
+	HideDone       bool                  `json:"hide_done"`
+	Nodes          []graphNodeTest       `json:"nodes"`
+	Edges          []graphEdgeTest       `json:"edges"`
+	UnresolvedRefs []graphUnresolvedTest `json:"unresolved_refs"`
+}
+
+type graphNodeTest struct {
+	UID         string `json:"uid"`
+	ShortID     string `json:"short_id"`
+	QualifiedID string `json:"qualified_id"`
+	Title       string `json:"title"`
+	Status      string `json:"status"`
+}
+
+type graphEdgeTest struct {
+	FromUID string `json:"from_uid"`
+	ToUID   string `json:"to_uid"`
+	Kind    string `json:"kind"`
+	Layout  bool   `json:"layout"`
+}
+
+type graphUnresolvedTest struct {
+	UID   string `json:"uid"`
+	Side  string `json:"side"`
+	Kind  string `json:"kind"`
+	Other string `json:"other_uid"`
+}
+
+func TestReachableGraph_SourceOnly(t *testing.T) {
+	h, ts, pid := graphProject(t)
+	source := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4EX", "source")
+
+	graph := getGraph(t, ts, pid, source.ShortID, "")
+
+	assert.Equal(t, source.UID, graph.SourceUID)
+	assert.Equal(t, "full", graph.Depth)
+	assert.False(t, graph.HideDone)
+	require.Len(t, graph.Nodes, 1)
+	assert.Equal(t, source.UID, graph.Nodes[0].UID)
+	assert.Equal(t, "kata#"+source.ShortID, graph.Nodes[0].QualifiedID)
+	assert.Empty(t, graph.Edges)
+	assert.Empty(t, graph.UnresolvedRefs)
+}
+
+func TestReachableGraph_ParentChildDirectionAndReachability(t *testing.T) {
+	h, ts, pid := graphProject(t)
+	parent := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E1", "parent")
+	child := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E2", "child")
+	grandchild := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E3", "grandchild")
+	graphLink(t, h, pid, child.ID, parent.ID, "parent")
+	graphLink(t, h, pid, grandchild.ID, child.ID, "parent")
+
+	depthOne := getGraph(t, ts, pid, parent.ShortID, "?depth=1")
+	assert.Equal(t, []string{parent.UID, child.UID}, graphNodeUIDs(depthOne))
+	assert.Equal(t, []string{"parent:" + parent.UID + "->" + child.UID + ":true"}, graphEdgeKeys(depthOne))
+
+	full := getGraph(t, ts, pid, parent.ShortID, "?depth=full")
+	assert.Equal(t, []string{parent.UID, child.UID, grandchild.UID}, graphNodeUIDs(full))
+	assert.Equal(t, []string{
+		"parent:" + parent.UID + "->" + child.UID + ":true",
+		"parent:" + child.UID + "->" + grandchild.UID + ":true",
+	}, graphEdgeKeys(full))
+}
+
+func TestReachableGraph_BlocksDirectionAndDedupe(t *testing.T) {
+	h, ts, pid := graphProject(t)
+	blocker := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E1", "blocker")
+	blocked := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E2", "blocked")
+	graphLink(t, h, pid, blocker.ID, blocked.ID, "blocks")
+
+	graph := getGraph(t, ts, pid, blocked.ShortID, "?depth=1")
+
+	assert.Equal(t, []string{blocker.UID, blocked.UID}, graphNodeUIDs(graph))
+	assert.Equal(t, []string{"blocks:" + blocker.UID + "->" + blocked.UID + ":true"}, graphEdgeKeys(graph))
+}
+
+func TestReachableGraph_RelatedEdges(t *testing.T) {
+	h, ts, pid := graphProject(t)
+	a := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E1", "a")
+	b := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E2", "b")
+	graphRelated(t, h, pid, b.ID, a.ID)
+
+	graph := getGraph(t, ts, pid, b.ShortID, "?depth=1")
+
+	assert.Equal(t, []string{a.UID, b.UID}, graphNodeUIDs(graph))
+	assert.Equal(t, []string{"related:" + a.UID + "->" + b.UID + ":true"}, graphEdgeKeys(graph))
+}
+
+func TestReachableGraph_BoundedDepthVsFullTraversal(t *testing.T) {
+	h, ts, pid := graphProject(t)
+	a := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E1", "a")
+	b := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E2", "b")
+	c := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E3", "c")
+	graphLink(t, h, pid, a.ID, b.ID, "blocks")
+	graphLink(t, h, pid, b.ID, c.ID, "blocks")
+
+	depthOne := getGraph(t, ts, pid, a.ShortID, "?depth=1")
+	assert.Equal(t, []string{a.UID, b.UID}, graphNodeUIDs(depthOne))
+
+	full := getGraph(t, ts, pid, a.ShortID, "?depth=full")
+	assert.Equal(t, []string{a.UID, b.UID, c.UID}, graphNodeUIDs(full))
+}
+
+func TestReachableGraph_HideDoneFiltersClosedTraversal(t *testing.T) {
+	h, ts, pid := graphProject(t)
+	a := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E1", "a")
+	b := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E2", "b")
+	c := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E3", "c")
+	graphLink(t, h, pid, a.ID, b.ID, "blocks")
+	graphLink(t, h, pid, b.ID, c.ID, "blocks")
+	_, _, changed, err := h.DB().CloseIssue(context.Background(), b.ID, "done", "tester", "closed for graph test", nil)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	graph := getGraph(t, ts, pid, a.ShortID, "?depth=full&hide_done=true")
+
+	assert.Equal(t, []string{a.UID}, graphNodeUIDs(graph))
+	assert.Empty(t, graph.Edges)
+}
+
+func TestReachableGraph_UnresolvedReferences(t *testing.T) {
+	h, ts, pid := graphProject(t)
+	source := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E1", "source")
+	missingUID := "01HZNQ7VFPK1XGD8R5MABCD4E2"
+	insertUnresolvedGraphLink(t, h, pid, source.ID, 9001, source.UID, missingUID, "blocks")
+
+	graph := getGraph(t, ts, pid, source.ShortID, "?depth=full")
+
+	assert.Equal(t, []string{source.UID}, graphNodeUIDs(graph))
+	assert.Equal(t, []string{"blocks:" + source.UID + "->" + missingUID + ":true"}, graphEdgeKeys(graph))
+	require.Len(t, graph.UnresolvedRefs, 1)
+	assert.Equal(t, missingUID, graph.UnresolvedRefs[0].UID)
+	assert.Equal(t, "to", graph.UnresolvedRefs[0].Side)
+	assert.Equal(t, "blocks", graph.UnresolvedRefs[0].Kind)
+	assert.Equal(t, source.UID, graph.UnresolvedRefs[0].Other)
+}
+
+func TestReachableGraph_TransitiveBlockPruningForLayoutOnlyAndStableOrdering(t *testing.T) {
+	h, ts, pid := graphProject(t)
+	c := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E3", "c")
+	a := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E1", "a")
+	b := graphIssue(t, h, pid, "01HZNQ7VFPK1XGD8R5MABCD4E2", "b")
+	graphLink(t, h, pid, b.ID, c.ID, "blocks")
+	graphLink(t, h, pid, a.ID, c.ID, "blocks")
+	graphLink(t, h, pid, a.ID, b.ID, "blocks")
+
+	graph := getGraph(t, ts, pid, a.UID, "?depth=full")
+
+	assert.Equal(t, []string{a.UID, b.UID, c.UID}, graphNodeUIDs(graph))
+	assert.Equal(t, []string{
+		"blocks:" + a.UID + "->" + b.UID + ":true",
+		"blocks:" + a.UID + "->" + c.UID + ":false",
+		"blocks:" + b.UID + "->" + c.UID + ":true",
+	}, graphEdgeKeys(graph))
+}
+
+func graphProject(t *testing.T) (*httptestServerHandle, *httptest.Server, int64) {
+	t.Helper()
+	h, pid := bootstrapProject(t)
+	return h, h.ts.(*httptest.Server), pid
+}
+
+func graphIssue(t *testing.T, h *httptestServerHandle, projectID int64, uid, title string) db.Issue {
+	t.Helper()
+	issue, _, err := h.DB().CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: projectID,
+		UID:       uid,
+		Title:     title,
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	return issue
+}
+
+func graphLink(t *testing.T, h *httptestServerHandle, projectID, fromID, toID int64, kind string) {
+	t.Helper()
+	_, err := h.DB().CreateLink(context.Background(), db.CreateLinkParams{
+		ProjectID:   projectID,
+		FromIssueID: fromID,
+		ToIssueID:   toID,
+		Type:        kind,
+		Author:      "tester",
+	})
+	require.NoError(t, err)
+}
+
+func graphRelated(t *testing.T, h *httptestServerHandle, projectID, aID, bID int64) {
+	t.Helper()
+	if aID > bID {
+		aID, bID = bID, aID
+	}
+	graphLink(t, h, projectID, aID, bID, "related")
+}
+
+func insertUnresolvedGraphLink(
+	t *testing.T,
+	h *httptestServerHandle,
+	projectID, fromID, toID int64,
+	fromUID, toUID, kind string,
+) {
+	t.Helper()
+	_, err := h.DB().ExecContext(context.Background(), `PRAGMA foreign_keys = OFF`)
+	require.NoError(t, err)
+	_, err = h.DB().ExecContext(context.Background(),
+		`INSERT INTO links(project_id, from_issue_id, to_issue_id, from_issue_uid, to_issue_uid, type, author)
+		 VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		projectID, fromID, toID, fromUID, toUID, kind, "tester")
+	require.NoError(t, err)
+}
+
+func getGraph(t *testing.T, ts *httptest.Server, projectID int64, ref, query string) graphResponseTest {
+	t.Helper()
+	resp, bs := getStatusBody(t, ts, "/api/v1/projects/"+
+		strconv.FormatInt(projectID, 10)+"/issues/"+ref+"/graph"+query)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "body: %s", string(bs))
+	var graph graphResponseTest
+	require.NoError(t, json.Unmarshal(bs, &graph), string(bs))
+	if graph.Nodes == nil {
+		graph.Nodes = []graphNodeTest{}
+	}
+	if graph.Edges == nil {
+		graph.Edges = []graphEdgeTest{}
+	}
+	if graph.UnresolvedRefs == nil {
+		graph.UnresolvedRefs = []graphUnresolvedTest{}
+	}
+	return graph
+}
+
+func graphNodeUIDs(graph graphResponseTest) []string {
+	out := make([]string, 0, len(graph.Nodes))
+	for _, node := range graph.Nodes {
+		out = append(out, node.UID)
+	}
+	return out
+}
+
+func graphEdgeKeys(graph graphResponseTest) []string {
+	out := make([]string, 0, len(graph.Edges))
+	for _, edge := range graph.Edges {
+		out = append(out, edge.Kind+":"+edge.FromUID+"->"+edge.ToUID+":"+strconv.FormatBool(edge.Layout))
+	}
+	return out
+}

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -256,6 +256,21 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 	})
 
 	huma.Register(humaAPI, huma.Operation{
+		OperationID: "reachableIssueGraph",
+		Method:      "GET",
+		Path:        "/api/v1/projects/{project_id}/issues/{ref}/graph",
+	}, func(ctx context.Context, in *api.ReachableGraphRequest) (*api.ReachableGraphResponse, error) {
+		source, err := activeIssueByRef(ctx, cfg.DB, in.ProjectID, in.Ref, db.IncludeDeletedNo)
+		if err != nil {
+			return nil, err
+		}
+		return buildReachableIssueGraph(ctx, cfg.DB, in.ProjectID, source, reachableGraphOptions{
+			Depth:    in.Depth,
+			HideDone: in.HideDone,
+		})
+	})
+
+	huma.Register(humaAPI, huma.Operation{
 		OperationID: "editIssue",
 		Method:      "PATCH",
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}",

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -264,7 +264,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
-		return buildReachableIssueGraph(ctx, cfg.DB, in.ProjectID, source, reachableGraphOptions{
+		return buildReachableIssueGraph(ctx, cfg.DB, source, reachableGraphOptions{
 			Depth:    in.Depth,
 			HideDone: in.HideDone,
 		})

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -283,6 +283,9 @@ type ClientInterface interface {
 	EditComment(ctx context.Context, options *EditCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EditCommentResponse, error)
 	EditCommentWithResponse(ctx context.Context, options *EditCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EditCommentResp, error)
 
+	ReachableIssueGraph(ctx context.Context, options *ReachableIssueGraphRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReachableIssueGraphResponse, error)
+	ReachableIssueGraphWithResponse(ctx context.Context, options *ReachableIssueGraphRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReachableIssueGraphResp, error)
+
 	AddLabel(ctx context.Context, options *AddLabelRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AddLabelResponse, error)
 	AddLabelWithResponse(ctx context.Context, options *AddLabelRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AddLabelResp, error)
 
@@ -3868,6 +3871,74 @@ func (c *Client) EditComment(ctx context.Context, options *EditCommentRequestOpt
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) ReachableIssueGraph(ctx context.Context, options *ReachableIssueGraphRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReachableIssueGraphResponse, error) {
+	var err error
+
+	queryEncoding := map[string]runtime.QueryEncoding{
+		"depth":     {Style: "form", Explode: &[]bool{false}[0]},
+		"hide_done": {Style: "form", Explode: &[]bool{false}[0]},
+	}
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:    c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/graph",
+		Method:        "GET",
+		Options:       options,
+		QueryEncoding: queryEncoding,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ReachableIssueGraphResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ReachableIssueGraphErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ReachableIssueGraphErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ReachableIssueGraphResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ReachableIssueGraphResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/graph")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -2664,6 +2664,59 @@ func (o *EditCommentRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// ReachableIssueGraphRequestOptions is the options needed to make a request to ReachableIssueGraph.
+type ReachableIssueGraphRequestOptions struct {
+	PathParams *ReachableIssueGraphPath
+	Query      *ReachableIssueGraphQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ReachableIssueGraphRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ReachableIssueGraphRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ReachableIssueGraphRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ReachableIssueGraphRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *ReachableIssueGraphRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // AddLabelRequestOptions is the options needed to make a request to AddLabel.
 type AddLabelRequestOptions struct {
 	PathParams *AddLabelPath

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -2666,6 +2666,54 @@ func (c *Client) EditCommentWithResponse(ctx context.Context, options *EditComme
 	}
 }
 
+func (c *Client) ReachableIssueGraphWithResponse(ctx context.Context, options *ReachableIssueGraphRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReachableIssueGraphResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/graph",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/graph")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ReachableIssueGraphResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ReachableIssueGraphResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ReachableIssueGraphResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 func (c *Client) AddLabelWithResponse(ctx context.Context, options *AddLabelRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AddLabelResp, error) {
 	var err error
 	reqParams := runtime.RequestOptionsParameters{

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -138,6 +138,59 @@ func (i ImportLinkInputType) Validate() error {
 	}
 }
 
+type ReachableGraphEdgeKind string
+
+const (
+	ReachableGraphEdgeKindBlocks  ReachableGraphEdgeKind = "blocks"
+	ReachableGraphEdgeKindParent  ReachableGraphEdgeKind = "parent"
+	ReachableGraphEdgeKindRelated ReachableGraphEdgeKind = "related"
+)
+
+// Validate checks if the ReachableGraphEdgeKind value is valid
+func (r ReachableGraphEdgeKind) Validate() error {
+	switch r {
+	case ReachableGraphEdgeKindBlocks, ReachableGraphEdgeKindParent, ReachableGraphEdgeKindRelated:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ReachableGraphEdgeKind value, got: %v", r))
+	}
+}
+
+type ReachableGraphUnresolvedRefKind string
+
+const (
+	ReachableGraphUnresolvedRefKindBlocks  ReachableGraphUnresolvedRefKind = "blocks"
+	ReachableGraphUnresolvedRefKindParent  ReachableGraphUnresolvedRefKind = "parent"
+	ReachableGraphUnresolvedRefKindRelated ReachableGraphUnresolvedRefKind = "related"
+)
+
+// Validate checks if the ReachableGraphUnresolvedRefKind value is valid
+func (r ReachableGraphUnresolvedRefKind) Validate() error {
+	switch r {
+	case ReachableGraphUnresolvedRefKindBlocks, ReachableGraphUnresolvedRefKindParent, ReachableGraphUnresolvedRefKindRelated:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ReachableGraphUnresolvedRefKind value, got: %v", r))
+	}
+}
+
+type ReachableGraphUnresolvedRefSide string
+
+const (
+	From ReachableGraphUnresolvedRefSide = "from"
+	To   ReachableGraphUnresolvedRefSide = "to"
+)
+
+// Validate checks if the ReachableGraphUnresolvedRefSide value is valid
+func (r ReachableGraphUnresolvedRefSide) Validate() error {
+	switch r {
+	case From, To:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ReachableGraphUnresolvedRefSide value, got: %v", r))
+	}
+}
+
 type ListAllIssuesQueryStatus string
 
 const (

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -264,6 +264,15 @@ func (e EditCommentPath) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(e))
 }
 
+type ReachableIssueGraphPath struct {
+	ProjectID int64  `json:"project_id"`
+	Ref       string `json:"ref" validate:"required"`
+}
+
+func (r ReachableIssueGraphPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
 type AddLabelPath struct {
 	ProjectID int64  `json:"project_id"`
 	Ref       string `json:"ref" validate:"required"`

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -156,6 +156,12 @@ type ShowIssueQuery struct {
 	IncludeDeleted *bool `json:"include_deleted,omitempty"`
 }
 
+type ReachableIssueGraphQuery struct {
+	// Depth full or a bounded hop count such as 1, 2, or 3
+	Depth    *string `json:"depth,omitempty"`
+	HideDone *bool   `json:"hide_done,omitempty"`
+}
+
 type RemoveLabelQuery struct {
 	Actor string `json:"actor" validate:"required"`
 }

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -225,6 +225,10 @@ type EditCommentResponse = CommentResponseBody
 
 type EditCommentErrorResponse = ErrorEnvelope
 
+type ReachableIssueGraphResponse = ReachableGraphResponseBody
+
+type ReachableIssueGraphErrorResponse = ErrorEnvelope
+
 type AddLabelResponse = AddLabelResponseBody
 
 type AddLabelErrorResponse = ErrorEnvelope
@@ -710,6 +714,13 @@ type EditCommentResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *EditCommentResponse
+}
+
+type ReachableIssueGraphResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ReachableIssueGraphResponse
 }
 
 type AddLabelResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -2576,6 +2576,135 @@ func (p PurgeResponseBody) Validate() error {
 	return errors
 }
 
+type ReachableGraphEdge struct {
+	FromUID string                 `json:"from_uid" validate:"required"`
+	Kind    ReachableGraphEdgeKind `json:"kind" validate:"required"`
+	Layout  bool                   `json:"layout"`
+	ToUID   string                 `json:"to_uid" validate:"required"`
+}
+
+func (r ReachableGraphEdge) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(r.FromUID, "required"); err != nil {
+		errors = errors.Append("FromUID", err)
+	}
+	if v, ok := any(r.Kind).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Kind", err)
+		}
+	}
+	if err := typesValidator.Var(r.ToUID, "required"); err != nil {
+		errors = errors.Append("ToUID", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ReachableGraphNode struct {
+	Author        string         `json:"author" validate:"required"`
+	Body          string         `json:"body" validate:"required"`
+	ClosedAt      *time.Time     `json:"closed_at,omitempty"`
+	ClosedReason  *string        `json:"closed_reason,omitempty"`
+	CreatedAt     time.Time      `json:"created_at" validate:"required"`
+	DeletedAt     *time.Time     `json:"deleted_at,omitempty"`
+	ID            int64          `json:"id"`
+	Metadata      map[string]any `json:"metadata"`
+	OccurrenceKey *string        `json:"occurrence_key,omitempty"`
+	Owner         *string        `json:"owner,omitempty"`
+	Priority      *int64         `json:"priority,omitempty"`
+	ProjectID     int64          `json:"project_id"`
+	ProjectUID    *string        `json:"project_uid,omitempty"`
+	QualifiedID   string         `json:"qualified_id" validate:"required"`
+	RecurrenceID  *int64         `json:"recurrence_id,omitempty"`
+	Revision      int64          `json:"revision"`
+	ShortID       string         `json:"short_id" validate:"required"`
+	Status        string         `json:"status" validate:"required"`
+	Title         string         `json:"title" validate:"required"`
+	UID           string         `json:"uid" validate:"required"`
+	UpdatedAt     time.Time      `json:"updated_at" validate:"required"`
+}
+
+func (r ReachableGraphNode) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
+type ReachableGraphResponseBody struct {
+	Depth          string                        `json:"depth" validate:"required"`
+	Edges          []ReachableGraphEdge          `json:"edges,omitempty" validate:"required"`
+	HideDone       bool                          `json:"hide_done"`
+	Nodes          []ReachableGraphNode          `json:"nodes,omitempty" validate:"required"`
+	SourceUID      string                        `json:"source_uid" validate:"required"`
+	UnresolvedRefs []ReachableGraphUnresolvedRef `json:"unresolved_refs,omitempty" validate:"required"`
+}
+
+func (r ReachableGraphResponseBody) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(r.Depth, "required"); err != nil {
+		errors = errors.Append("Depth", err)
+	}
+	for i, item := range r.Edges {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Edges[%d]", i), err)
+			}
+		}
+	}
+	for i, item := range r.Nodes {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Nodes[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(r.SourceUID, "required"); err != nil {
+		errors = errors.Append("SourceUID", err)
+	}
+	for i, item := range r.UnresolvedRefs {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("UnresolvedRefs[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ReachableGraphUnresolvedRef struct {
+	Kind     ReachableGraphUnresolvedRefKind `json:"kind" validate:"required"`
+	OtherUID string                          `json:"other_uid" validate:"required"`
+	Side     ReachableGraphUnresolvedRefSide `json:"side" validate:"required"`
+	UID      string                          `json:"uid" validate:"required"`
+}
+
+func (r ReachableGraphUnresolvedRef) Validate() error {
+	var errors runtime.ValidationErrors
+	if v, ok := any(r.Kind).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Kind", err)
+		}
+	}
+	if err := typesValidator.Var(r.OtherUID, "required"); err != nil {
+		errors = errors.Append("OtherUID", err)
+	}
+	if v, ok := any(r.Side).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Side", err)
+		}
+	}
+	if err := typesValidator.Var(r.UID, "required"); err != nil {
+		errors = errors.Append("UID", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type ReadyGlobalIssue struct {
 	Author        string         `json:"author" validate:"required"`
 	Body          string         `json:"body" validate:"required"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2664,6 +2664,149 @@ components:
       required:
         - purge_log
       type: object
+    ReachableGraphEdge:
+      properties:
+        from_uid:
+          type: string
+        kind:
+          enum:
+            - parent
+            - blocks
+            - related
+          type: string
+        layout:
+          type: boolean
+        to_uid:
+          type: string
+      required:
+        - from_uid
+        - to_uid
+        - kind
+        - layout
+      type: object
+    ReachableGraphNode:
+      properties:
+        author:
+          type: string
+        body:
+          type: string
+        closed_at:
+          format: date-time
+          type: string
+        closed_reason:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        metadata:
+          additionalProperties: true
+          type: object
+        occurrence_key:
+          type: string
+        owner:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        project_uid:
+          type: string
+        qualified_id:
+          type: string
+        recurrence_id:
+          format: int64
+          type: integer
+        revision:
+          format: int64
+          type: integer
+        short_id:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - qualified_id
+        - id
+        - uid
+        - project_id
+        - short_id
+        - title
+        - body
+        - status
+        - author
+        - metadata
+        - revision
+        - created_at
+        - updated_at
+      type: object
+    ReachableGraphResponseBody:
+      properties:
+        depth:
+          type: string
+        edges:
+          items:
+            $ref: "#/components/schemas/ReachableGraphEdge"
+          nullable: true
+          type: array
+        hide_done:
+          type: boolean
+        nodes:
+          items:
+            $ref: "#/components/schemas/ReachableGraphNode"
+          nullable: true
+          type: array
+        source_uid:
+          type: string
+        unresolved_refs:
+          items:
+            $ref: "#/components/schemas/ReachableGraphUnresolvedRef"
+          nullable: true
+          type: array
+      required:
+        - source_uid
+        - depth
+        - hide_done
+        - nodes
+        - edges
+        - unresolved_refs
+      type: object
+    ReachableGraphUnresolvedRef:
+      properties:
+        kind:
+          enum:
+            - parent
+            - blocks
+            - related
+          type: string
+        other_uid:
+          type: string
+        side:
+          enum:
+            - from
+            - to
+          type: string
+        uid:
+          type: string
+      required:
+        - uid
+        - side
+        - kind
+        - other_uid
+      type: object
     ReadyGlobalIssue:
       properties:
         author:
@@ -4945,6 +5088,46 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CommentResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/graph:
+    get:
+      operationId: reachableIssueGraph
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - description: full or a bounded hop count such as 1, 2, or 3
+          explode: false
+          in: query
+          name: depth
+          schema:
+            description: full or a bounded hop count such as 1, 2, or 3
+            type: string
+        - explode: false
+          in: query
+          name: hide_done
+          schema:
+            type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReachableGraphResponseBody"
           description: OK
         default:
           content:


### PR DESCRIPTION
Middleman currently has to reconstruct canonical kata relationship semantics in frontend TypeScript before it can render the reachable graph. That puts backend concerns like relationship direction, reciprocal dedupe, missing endpoint preservation, stable ordering, and layout-only transitive block pruning in the browser layer.

This PR moves the canonical reachable graph read model into the daemon. Clients can fetch a source issue graph with bounded or full depth and optional done filtering, then focus on rendering, local emphasis, viewport state, and browser layout concerns without owning kata graph semantics.

The branch is based on current mainline storage abstractions, so graph traversal reads links through db.Storage rather than a SQLite-only project-link query. The OpenAPI and generated client artifacts are included so downstream consumers can call the new route directly.

Related: kenn-io/middleman#621.

Validation: `env -u KATA_SERVER go test -shuffle=on ./internal/api ./internal/daemon`; `make lint`; push hooks also ran `make api-check`, `make lint`, and `nilaway`.