### PR TITLE
Document 0.8.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,42 @@ description: Release history for kata
 All notable changes to kata, grouped by release. Versioned releases start with
 0.5.0; earlier entries are a retroactive project history grouped by ISO week.
 
+## 0.8.0
+<small>2026-07-04</small>
+
+kata 0.8.0 adds a graph-shaped issue API for clients that need to visualize or
+analyze connected work, makes daemon projects easier to create without a local
+workspace, and records testing guidance for behavior-based validation.
+
+**New features**
+
+- Added `GET /api/v1/projects/{project_id}/issues/{ref}/graph` for reachable
+  issue graphs. The endpoint walks parent, `blocks`, and related relationships
+  from a source issue, supports `depth=full` or a bounded hop count, can hide
+  closed non-source issues with `hide_done=true`, includes cross-project
+  `qualified_id` values, and reports unresolved link endpoints without dropping
+  the rest of the graph.
+- Added `kata projects create <name>` for creating or returning an active
+  daemon project by name without writing `.kata.toml`, `.gitignore`, or agent
+  guidance files and without attaching a workspace alias.
+- Added testing guidance that discourages tautological content assertions,
+  especially shell tests that grep scripts or config for implementation text,
+  and favors assertions against observable behavior, persisted state, command
+  output, API responses, events, or rendered UI.
+
+**Improvements**
+
+- Documented the name-only project creation workflow in quickstart and CLI
+  reference docs so projects that are not tied one-to-one to a repository can
+  be created before any workspace is initialized.
+
+**Acknowledgements**
+
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the
+  reachable issue graph API and testing-without-tautologies guidance.
+- Thanks to [Wes McKinney](https://github.com/wesm) for name-only project
+  creation.
+
 ## 0.7.0
 <small>2026-06-29</small>
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -45,28 +45,6 @@ RAPID_SEED=<seed> go test -tags federation_stress ./e2e \
   -timeout 2m
 ```
 
-## Testing standards
-
-Tests should protect behavior that users, operators, or callers can observe.
-Prefer assertions against returned values, persisted rows, HTTP response bodies
-and status codes, emitted events, CLI output and exit codes, rendered TUI
-output, or auth outcomes. Avoid tests that only prove the current source text
-contains a string or that a private implementation detail is arranged the way it
-is today.
-
-For shell scripts, workflows, config, and generated artifacts, do not add tests
-that grep implementation files for expected text. Those content checks are
-usually tautological: they pass when the file contains the searched string, not
-when the release, installer, workflow, or daemon behavior works. Exercise the
-command or tool behavior directly, use the tool's own validation command, or
-document a manual check when direct behavior coverage is not practical.
-
-When a fake stands in for an external boundary such as a hub, GitHub, or an
-embedding provider, keep it specific enough to catch the wrong branch,
-argument, status, or side effect. Do not mock the subject under test, and do
-not update golden snapshots or expected literals just to silence a failure
-without first confirming that the new output is the intended contract.
-
 ## Documentation checks
 
 Install Zensical:

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -45,6 +45,28 @@ RAPID_SEED=<seed> go test -tags federation_stress ./e2e \
   -timeout 2m
 ```
 
+## Testing standards
+
+Tests should protect behavior that users, operators, or callers can observe.
+Prefer assertions against returned values, persisted rows, HTTP response bodies
+and status codes, emitted events, CLI output and exit codes, rendered TUI
+output, or auth outcomes. Avoid tests that only prove the current source text
+contains a string or that a private implementation detail is arranged the way it
+is today.
+
+For shell scripts, workflows, config, and generated artifacts, do not add tests
+that grep implementation files for expected text. Those content checks are
+usually tautological: they pass when the file contains the searched string, not
+when the release, installer, workflow, or daemon behavior works. Exercise the
+command or tool behavior directly, use the tool's own validation command, or
+document a manual check when direct behavior coverage is not practical.
+
+When a fake stands in for an external boundary such as a hub, GitHub, or an
+embedding provider, keep it specific enough to catch the wrong branch,
+argument, status, or side effect. Do not mock the subject under test, and do
+not update golden snapshots or expected literals just to silence a failure
+without first confirming that the new output is the intended contract.
+
 ## Documentation checks
 
 Install Zensical:

--- a/docs/guide/workspaces-projects.md
+++ b/docs/guide/workspaces-projects.md
@@ -56,6 +56,18 @@ kata projects list
 kata projects show product
 ```
 
+Create a project by name without binding the current directory:
+
+```sh
+kata projects create research
+```
+
+`projects create` talks to the daemon only. It creates or returns the active
+project named `research` without writing `.kata.toml`, `.gitignore`, or agent
+guidance files, and without attaching a git alias. Use it for projects that do
+not map one-to-one to a repository workspace, then run `kata init --project
+research` later from any workspace that should resolve to the same project.
+
 Rename a project:
 
 ```sh

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -129,6 +129,38 @@ returns per-field counts. The endpoint refuses already-federated projects
 because it is a current-state hygiene operation for local project rows, not a
 federated history rewrite.
 
+## Issue Graph Endpoint
+
+`GET /api/v1/projects/{project_id}/issues/{ref}/graph` returns the relationship
+graph reachable from one source issue. The path `ref` accepts the same issue ref
+forms as other project-scoped issue endpoints. The optional `depth` query value
+is either `full` (the default) or a non-negative hop count such as `1`, `2`, or
+`3`. Pass `hide_done=true` to keep the source issue but exclude closed
+non-source issues from traversal and output.
+
+The response body is a canonical graph payload:
+
+| Field | Meaning |
+| --- | --- |
+| `source_uid` | Stable UID of the source issue. |
+| `depth` | Effective traversal depth, either `full` or the bounded hop count. |
+| `hide_done` | Whether closed non-source issues were hidden. |
+| `nodes` | Reached issues, including normal issue fields plus `qualified_id` (`project#short_id`) for display. |
+| `edges` | Directed relationship edges with `from_uid`, `to_uid`, `kind`, and `layout`. |
+| `unresolved_refs` | Link endpoints that exist in storage but could not be materialized as graph nodes. |
+
+Edge direction is normalized for clients: parent edges point parent -> child,
+`blocks` edges point blocker -> blocked, and related edges use kata's canonical
+related-link ordering. `layout=false` keeps an edge in the graph while telling
+layout engines they can omit it from force/layout calculations; current daemons
+use that hint for transitive `blocks` edges.
+
+Soft-deleted issues and issues in archived projects are hidden instead of
+reported as unresolved references. `unresolved_refs` is reserved for dangling
+endpoints that can appear after imports, federation repair, or manual database
+maintenance, so graph clients can surface incomplete data without discarding
+the reachable graph.
+
 ## Issue Sync Endpoints
 
 Issue sync endpoints are project-scoped and provider-qualified. They configure


### PR DESCRIPTION
Finalizes the public docs for the 0.8.0 release using the tagged source and commit history. The release adds a reachable issue graph API, name-only daemon project creation, and testing guidance for behavior-based validation; without this pass the public release history and reference docs would stop short of those shipped contracts.

The PR also records verified contributor acknowledgements and documents the graph response semantics clients need to render relationships consistently. After merge, the docs site still needs the normal manual deployment flow.