### PR TITLE
Improve release changelog output

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -17,6 +17,16 @@ else
   fi
 fi
 
+git_diff_stat() {
+  if [[ -n "$range_spec" ]]; then
+    git diff --stat "$range_spec"
+  else
+    local empty_tree
+    empty_tree="$(git hash-object -t tree /dev/null)"
+    git diff --stat "$empty_tree" HEAD
+  fi
+}
+
 git_log() {
   if [[ -n "$range_spec" ]]; then
     git log --no-merges "$@" "$range_spec"
@@ -26,17 +36,55 @@ git_log() {
 }
 
 fallback_changelog() {
-  printf '### Changes\n\n'
   local log_output
   log_output="$(git_log --pretty=format:'%s%x09%h')"
   if [[ -z "$log_output" ]]; then
+    printf '### Changes\n\n'
     printf '%s\n' '- No commits since the previous release.'
     return
   fi
+
+  local features=""
+  local improvements=""
+  local fixes=""
+
   while IFS=$'\t' read -r subject short_hash; do
     [[ -n "$subject" ]] || continue
-    printf '%s\n' "- ${subject} (${short_hash})"
+    local entry="- ${subject} (${short_hash})"
+    case "$subject" in
+      feat:*|feat\(*\):*|feature:*|feature\(*\):*)
+        features+="${entry}"$'\n'
+        ;;
+      fix:*|fix\(*\):*|bugfix:*|bugfix\(*\):*)
+        fixes+="${entry}"$'\n'
+        ;;
+      docs:*|docs\(*\):*|doc:*|doc\(*\):*)
+        ;;
+      *)
+        improvements+="${entry}"$'\n'
+        ;;
+    esac
   done <<<"$log_output"
+
+  local printed=0
+  if [[ -n "$features" ]]; then
+    printf '### New Features\n\n%s\n' "$features"
+    printed=1
+  fi
+  if [[ -n "$improvements" ]]; then
+    [[ $printed -eq 0 ]] || printf '\n'
+    printf '### Improvements\n\n%s\n' "$improvements"
+    printed=1
+  fi
+  if [[ -n "$fixes" ]]; then
+    [[ $printed -eq 0 ]] || printf '\n'
+    printf '### Bug Fixes\n\n%s\n' "$fixes"
+    printed=1
+  fi
+  if [[ $printed -eq 0 ]]; then
+    printf '### Improvements\n\n'
+    printf '%s\n' '- No user-facing changes in this commit range.'
+  fi
 }
 
 agent="${CHANGELOG_AGENT:-codex}"
@@ -48,25 +96,37 @@ fi
 
 prompt_file="$(mktemp)"
 log_file="$(mktemp)"
+diff_file="$(mktemp)"
 notes_file="$(mktemp)"
 err_file="$(mktemp)"
-trap 'rm -f "$prompt_file" "$log_file" "$notes_file" "$err_file"' EXIT
+trap 'rm -f "$prompt_file" "$log_file" "$diff_file" "$notes_file" "$err_file"' EXIT
 
 git_log --date=short --pretty=format:'%ad%x09%h%x09%s' >"$log_file"
+git_diff_stat >"$diff_file"
 
 {
   printf 'Write concise Markdown release notes for kata %s.\n\n' "$version"
   printf 'IMPORTANT: Do not use tools, run shell commands, search, or read files.\n'
-  printf 'All required information is provided below. Analyze the commit log only.\n\n'
+  printf 'All required information is provided below. Analyze the commit log and diff summary only.\n\n'
   printf 'kata is a local-first issue tracker with a daemon, CLI, TUI, federation, and documentation.\n'
-  printf 'Use user-facing language, group related changes when useful, and avoid private workspace or repository names.\n'
+  printf 'Use user-facing language and avoid private workspace or repository names.\n'
+  printf 'Group changes into these Markdown sections when applicable:\n'
+  printf '%s\n' '- ### New Features'
+  printf '%s\n' '- ### Improvements'
+  printf '%s\n' '- ### Bug Fixes'
+  printf 'Use only sections that have entries.\n'
   printf 'Skip internal refactoring unless it affects users.\n'
+  printf 'Do NOT mention documentation-only changes, including docs, changelog, release notes, README, website copy, screenshots, or generated docs asset updates, unless documentation is the user-facing product being released.\n'
+  printf 'Do NOT mention bugs that were introduced and fixed within this same release cycle.\n'
+  printf 'Keep descriptions brief, one line each, and use present tense.\n'
   printf 'Output only the release notes, with no preamble.\n'
   if [[ -n "$extra_instructions" ]]; then
     printf '\nAdditional instructions:\n%s\n' "$extra_instructions"
   fi
   printf '\nCommits:\n'
   cat "$log_file"
+  printf '\n\nDiff summary:\n'
+  cat "$diff_file"
 } >"$prompt_file"
 
 run_agent() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,36 +43,39 @@ fi
 notes_file="$(mktemp)"
 trap 'rm -f "$notes_file"' EXIT
 
-printf 'Preparing release %s\n' "$tag"
-printf '%s\n' '- Checking that the tag does not already exist and the worktree is clean.'
 case "$changelog_agent" in
   codex)
-    printf '%s\n' '- Generating release notes with CHANGELOG_AGENT=codex; this calls codex exec on the git log.'
+    printf 'Generating release notes for %s with CHANGELOG_AGENT=codex; this calls codex exec on the git log.\n' "$tag"
     ;;
   claude)
-    printf '%s\n' '- Generating release notes with CHANGELOG_AGENT=claude; this calls claude --print on the git log.'
+    printf 'Generating release notes for %s with CHANGELOG_AGENT=claude; this calls claude --print on the git log.\n' "$tag"
     ;;
   none)
-    printf '%s\n' '- Generating release notes with CHANGELOG_AGENT=none; this uses the deterministic git-log fallback.'
+    printf 'Generating release notes for %s with CHANGELOG_AGENT=none; this uses the deterministic git-log fallback.\n' "$tag"
     ;;
   *)
-    printf '%s\n' "- Generating release notes with CHANGELOG_AGENT=${changelog_agent}; scripts/changelog.sh will validate this value."
+    printf 'Generating release notes for %s with CHANGELOG_AGENT=%s; scripts/changelog.sh will validate this value.\n' "$tag" "$changelog_agent"
     ;;
 esac
-printf '%s\n\n' '- Showing the release notes preview before creating or pushing any tag.'
 
 "$repo_root/scripts/changelog.sh" "$version" "-" "$extra_instructions" >"$notes_file"
 
-printf 'Release %s\n\n' "$tag"
+printf '\n'
+printf '==========================================\n'
+printf 'PROPOSED CHANGELOG FOR %s\n' "$tag"
+printf '==========================================\n'
 cat "$notes_file"
 printf '\n'
+printf '==========================================\n'
+printf '\n'
 
-printf 'Create and push %s? [y/N] ' "$tag"
+printf 'Accept this changelog and create release %s? [y/N] ' "$tag"
 answer=""
 read -r answer || true
+printf '\n'
 if [[ "$answer" != "y" && "$answer" != "Y" && "$answer" != "yes" && "$answer" != "YES" ]]; then
-  printf 'release aborted\n' >&2
-  exit 1
+  printf 'Release cancelled.\n'
+  exit 0
 fi
 
 tag_message="$(mktemp)"
@@ -87,4 +90,6 @@ git tag -a "$tag" -F "$tag_message"
 printf 'Pushing %s to origin...\n' "$tag"
 git push origin "$tag"
 
-printf 'pushed %s\n' "$tag"
+printf '\n'
+printf 'Release %s created and pushed successfully.\n' "$tag"
+printf 'GitHub Actions will build and publish the release.\n'

--- a/scripts/release_scripts_test.sh
+++ b/scripts/release_scripts_test.sh
@@ -113,8 +113,67 @@ test_changelog_fallback_includes_first_commit_without_tags() {
   local output
   output="$(run_in_repo "$repo" env CHANGELOG_AGENT=none "$repo_root/scripts/changelog.sh" NEXT -)"
 
-  assert_contains "$output" "### Changes" "fallback changelog heading"
+  assert_contains "$output" "### New Features" "fallback changelog heading"
   assert_contains "$output" "feat: add task list" "fallback changelog commit"
+}
+
+test_changelog_fallback_groups_commits_by_user_facing_sections() {
+  local repo="$tmp_root/changelog-sections"
+  init_repo "$repo"
+  printf 'faster release notes\n' >"$repo/perf.txt"
+  git -C "$repo" add perf.txt
+  git -C "$repo" commit -q -m "perf: speed up release notes"
+  printf 'release cancellation\n' >"$repo/fix.txt"
+  git -C "$repo" add fix.txt
+  git -C "$repo" commit -q -m "fix: handle cancelled releases"
+
+  local output
+  output="$(run_in_repo "$repo" env CHANGELOG_AGENT=none "$repo_root/scripts/changelog.sh" NEXT -)"
+
+  assert_contains "$output" "### New Features" "fallback changelog feature section"
+  assert_contains "$output" "- feat: add task list" "fallback changelog feature entry"
+  assert_contains "$output" "### Improvements" "fallback changelog improvement section"
+  assert_contains "$output" "- perf: speed up release notes" "fallback changelog improvement entry"
+  assert_contains "$output" "### Bug Fixes" "fallback changelog bug fix section"
+  assert_contains "$output" "- fix: handle cancelled releases" "fallback changelog bug fix entry"
+  assert_not_contains "$output" "### Changes" "fallback changelog should use categorized headings"
+}
+
+test_changelog_agent_prompt_requests_categorized_sections() {
+  local repo="$tmp_root/changelog-prompt-sections"
+  local fake_bin="$tmp_root/fake-bin-prompt-sections"
+  local prompt_capture="$tmp_root/changelog-prompt.txt"
+  init_repo "$repo"
+  mkdir -p "$fake_bin"
+  cat >"$fake_bin/codex" <<'EOF'
+#!/usr/bin/env bash
+out=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    shift
+    out="$1"
+  fi
+  shift || true
+done
+prompt="$(cat)"
+printf '%s' "$prompt" >"${PROMPT_CAPTURE:?}"
+if [[ -n "$out" ]]; then
+  printf '### New Features\n\n- AI changelog was invoked\n' >"$out"
+else
+  printf '### New Features\n\n- AI changelog was invoked\n'
+fi
+EOF
+  chmod +x "$fake_bin/codex"
+
+  local output prompt
+  output="$(run_in_repo "$repo" env PATH="$fake_bin:$PATH" PROMPT_CAPTURE="$prompt_capture" "$repo_root/scripts/changelog.sh" NEXT -)"
+  prompt="$(cat "$prompt_capture")"
+
+  assert_contains "$output" "AI changelog was invoked" "agent changelog output"
+  assert_contains "$prompt" "### New Features" "agent prompt feature section"
+  assert_contains "$prompt" "### Improvements" "agent prompt improvement section"
+  assert_contains "$prompt" "### Bug Fixes" "agent prompt bug fix section"
+  assert_contains "$prompt" "Do NOT mention documentation-only changes" "agent prompt docs filtering"
 }
 
 test_changelog_defaults_to_codex_agent() {
@@ -144,7 +203,7 @@ EOF
   output="$(run_in_repo "$repo" env PATH="$fake_bin:$PATH" "$repo_root/scripts/changelog.sh" NEXT -)"
 
   assert_contains "$output" "AI changelog was invoked" "default changelog agent"
-  assert_not_contains "$output" "### Changes" "default changelog should not use deterministic fallback"
+  assert_not_contains "$output" "feat: add task list" "default changelog should not use deterministic fallback"
 }
 
 test_changelog_allows_explicit_agent_opt_in() {
@@ -200,9 +259,32 @@ test_release_creates_and_pushes_bare_semver_tag() {
   local output
   output="$(printf 'y\n' | run_in_repo "$repo" env CHANGELOG_AGENT=none "$repo_root/scripts/release.sh" 0.5.0)"
 
-  assert_contains "$output" "Release v0.5.0" "release preview"
+  assert_contains "$output" "PROPOSED CHANGELOG FOR v0.5.0" "release preview"
   git -C "$repo" rev-parse -q --verify refs/tags/v0.5.0 >/dev/null || fail "local tag v0.5.0 missing"
   git -C "$remote" rev-parse -q --verify refs/tags/v0.5.0 >/dev/null || fail "remote tag v0.5.0 missing"
+}
+
+test_release_preview_matches_categorized_changelog_style() {
+  local repo="$tmp_root/release-preview"
+  local remote="$tmp_root/release-preview-origin.git"
+  init_repo "$repo"
+  git init -q --bare "$remote"
+  git -C "$repo" remote add origin "$remote"
+
+  local output status
+  set +e
+  output="$(printf 'n\n' | run_in_repo "$repo" env CHANGELOG_AGENT=none "$repo_root/scripts/release.sh" 0.5.0 2>&1)"
+  status=$?
+  set -e
+
+  [[ $status -eq 0 ]] || fail "release.sh should treat an operator cancellation as a clean cancellation"
+  assert_contains "$output" "PROPOSED CHANGELOG FOR v0.5.0" "release preview heading"
+  assert_contains "$output" "### New Features" "release preview categorized changelog"
+  assert_contains "$output" "Accept this changelog and create release v0.5.0? [y/N]" "release confirmation prompt"
+  assert_contains "$output" "Release cancelled." "release cancellation"
+  if git -C "$repo" rev-parse -q --verify refs/tags/v0.5.0 >/dev/null; then
+    fail "release cancellation should not create a tag"
+  fi
 }
 
 test_release_uses_codex_changelog_by_default() {
@@ -387,10 +469,13 @@ test_release_rejects_v_prefixed_version
 test_release_rejects_non_semver_version
 test_release_refuses_dirty_worktree
 test_changelog_fallback_includes_first_commit_without_tags
+test_changelog_fallback_groups_commits_by_user_facing_sections
+test_changelog_agent_prompt_requests_categorized_sections
 test_changelog_defaults_to_codex_agent
 test_changelog_allows_explicit_agent_opt_in
 test_changelog_rejects_unknown_agent
 test_release_creates_and_pushes_bare_semver_tag
+test_release_preview_matches_categorized_changelog_style
 test_release_uses_codex_changelog_by_default
 test_verify_release_tag_rejects_tag_outside_origin_main
 test_verify_release_tag_accepts_tag_on_origin_main

--- a/scripts/release_scripts_test.sh
+++ b/scripts/release_scripts_test.sh
@@ -139,10 +139,9 @@ test_changelog_fallback_groups_commits_by_user_facing_sections() {
   assert_not_contains "$output" "### Changes" "fallback changelog should use categorized headings"
 }
 
-test_changelog_agent_prompt_requests_categorized_sections() {
-  local repo="$tmp_root/changelog-prompt-sections"
-  local fake_bin="$tmp_root/fake-bin-prompt-sections"
-  local prompt_capture="$tmp_root/changelog-prompt.txt"
+test_changelog_agent_receives_release_context() {
+  local repo="$tmp_root/changelog-agent-context"
+  local fake_bin="$tmp_root/fake-bin-agent-context"
   init_repo "$repo"
   mkdir -p "$fake_bin"
   cat >"$fake_bin/codex" <<'EOF'
@@ -155,25 +154,27 @@ while [[ $# -gt 0 ]]; do
   fi
   shift || true
 done
-prompt="$(cat)"
-printf '%s' "$prompt" >"${PROMPT_CAPTURE:?}"
+release_context="$(cat)"
+case "$release_context" in
+  *"feat: add task list"*) ;;
+  *)
+    printf 'missing commit context\n' >&2
+    exit 3
+    ;;
+esac
 if [[ -n "$out" ]]; then
-  printf '### New Features\n\n- AI changelog was invoked\n' >"$out"
+  printf '### New Features\n\n- Summarized fixture feature from provided commits\n' >"$out"
 else
-  printf '### New Features\n\n- AI changelog was invoked\n'
+  printf '### New Features\n\n- Summarized fixture feature from provided commits\n'
 fi
 EOF
   chmod +x "$fake_bin/codex"
 
-  local output prompt
-  output="$(run_in_repo "$repo" env PATH="$fake_bin:$PATH" PROMPT_CAPTURE="$prompt_capture" "$repo_root/scripts/changelog.sh" NEXT -)"
-  prompt="$(cat "$prompt_capture")"
+  local output
+  output="$(run_in_repo "$repo" env PATH="$fake_bin:$PATH" "$repo_root/scripts/changelog.sh" NEXT -)"
 
-  assert_contains "$output" "AI changelog was invoked" "agent changelog output"
-  assert_contains "$prompt" "### New Features" "agent prompt feature section"
-  assert_contains "$prompt" "### Improvements" "agent prompt improvement section"
-  assert_contains "$prompt" "### Bug Fixes" "agent prompt bug fix section"
-  assert_contains "$prompt" "Do NOT mention documentation-only changes" "agent prompt docs filtering"
+  assert_contains "$output" "### New Features" "agent changelog section"
+  assert_contains "$output" "Summarized fixture feature from provided commits" "agent changelog output"
 }
 
 test_changelog_defaults_to_codex_agent() {
@@ -470,7 +471,7 @@ test_release_rejects_non_semver_version
 test_release_refuses_dirty_worktree
 test_changelog_fallback_includes_first_commit_without_tags
 test_changelog_fallback_groups_commits_by_user_facing_sections
-test_changelog_agent_prompt_requests_categorized_sections
+test_changelog_agent_receives_release_context
 test_changelog_defaults_to_codex_agent
 test_changelog_allows_explicit_agent_opt_in
 test_changelog_rejects_unknown_agent


### PR DESCRIPTION
Release operators currently have to review agent-generated notes that can arrive as a flat list, and the fallback path always uses a generic Changes section. That makes the release gate less predictable at the moment they decide whether to create a tag.

This PR gives both the agent prompt and fallback generator a shared categorized shape for user-facing release notes, while keeping the external-agent handoff explicit. The release wrapper now presents the proposed changelog in a framed preview and treats cancellation as a clean no-op so operators can reject generated notes without creating a failure state.

The shell coverage exercises the release commands against temporary repositories and keeps the agent test at the command boundary rather than asserting script source or prompt text.