### PR TITLE
Add gzip response compression to daemon HTTP API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/doordash-oss/oapi-codegen-dd/v3 v3.75.5
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/klauspost/compress v1.18.6
 	github.com/mattn/go-runewidth v0.0.20
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/posthog/posthog-go v1.12.6
@@ -84,7 +85,6 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect

--- a/internal/daemon/gzip_test.go
+++ b/internal/daemon/gzip_test.go
@@ -1,0 +1,119 @@
+package daemon_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+// The tests in this file set Accept-Encoding explicitly on every request so
+// net/http's transparent gzip handling stays out of the way and the assertions
+// hold against the actual wire bytes.
+
+// mkLargeIssue creates an issue whose body is comfortably above any sane
+// compression minimum-size threshold, so list responses containing it are
+// eligible for gzip.
+func mkLargeIssue(t *testing.T, env *testenv.Env, projectID int64, title string) db.Issue {
+	t.Helper()
+	is, _, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: projectID,
+		Title:     title,
+		Body:      strings.Repeat("kata compresses large JSON responses over slow links. ", 100),
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	return is
+}
+
+func TestGzip_CompressesLargeJSONWhenRequested(t *testing.T) {
+	env := testenv.New(t)
+	pid := mkProject(t, env, "github.com/test/a", "a")
+	mkLargeIssue(t, env, pid, "compressible")
+
+	resp, bs := envDoRaw(t, env, http.MethodGet, "/api/v1/issues?status=open", nil,
+		map[string]string{"Accept-Encoding": "gzip"})
+	require.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+
+	zr, err := gzip.NewReader(bytes.NewReader(bs))
+	require.NoError(t, err)
+	plain, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	assert.Less(t, len(bs), len(plain), "compressed wire bytes must be smaller than the JSON they encode")
+
+	var body struct {
+		Issues []struct {
+			Title string `json:"title"`
+		} `json:"issues"`
+	}
+	require.NoError(t, json.Unmarshal(plain, &body), string(plain))
+	require.Len(t, body.Issues, 1)
+	assert.Equal(t, "compressible", body.Issues[0].Title)
+}
+
+func TestGzip_IdentityWhenClientDoesNotAcceptGzip(t *testing.T) {
+	env := testenv.New(t)
+	pid := mkProject(t, env, "github.com/test/a", "a")
+	mkLargeIssue(t, env, pid, "plain")
+
+	resp, bs := envDoRaw(t, env, http.MethodGet, "/api/v1/issues?status=open", nil,
+		map[string]string{"Accept-Encoding": "identity"})
+	require.Equal(t, 200, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Content-Encoding"))
+
+	var body struct {
+		Issues []struct {
+			Title string `json:"title"`
+		} `json:"issues"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &body), string(bs))
+	require.Len(t, body.Issues, 1)
+	assert.Equal(t, "plain", body.Issues[0].Title)
+}
+
+func TestGzip_SmallResponsesStayUncompressed(t *testing.T) {
+	env := testenv.New(t)
+
+	resp, bs := envDoRaw(t, env, http.MethodGet, "/api/v1/ping", nil,
+		map[string]string{"Accept-Encoding": "gzip"})
+	require.Equal(t, 200, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Content-Encoding"),
+		"tiny responses must skip gzip overhead")
+	assert.Contains(t, string(bs), `"ok":true`, "body must be plain JSON")
+}
+
+func TestGzip_SSEStreamNotCompressedAndStillStreams(t *testing.T) {
+	env := testenv.New(t)
+	pid := mkProject(t, env, "github.com/test/a", "a")
+	_, sentinelEvt := mkIssueWithEvent(t, env, pid, "sentinel")
+
+	hwm, err := env.DB.MaxEventID(context.Background())
+	require.NoError(t, err)
+	resp := openSSE(t, env, "after_id="+strconv.FormatInt(hwm-1, 10), http.Header{
+		"Accept":          {"text/event-stream"},
+		"Accept-Encoding": {"gzip"},
+	})
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	assert.Empty(t, resp.Header.Get("Content-Encoding"),
+		"SSE stream must not be compressed even when the client accepts gzip")
+
+	framer := newSSEFramer(resp.Body)
+	first, ok := framer.Next(t, 2*time.Second)
+	require.True(t, ok, "drain frame must arrive promptly over the uncompressed stream")
+	assert.Equal(t, strconv.FormatInt(sentinelEvt.ID, 10), first.id)
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/klauspost/compress/gzhttp"
 	kitdaemon "go.kenn.io/kit/daemon"
 
 	"go.kenn.io/kata/internal/api"
@@ -148,8 +150,28 @@ func NewServer(cfg ServerConfig) *Server {
 	registerOpenAPIYAML(mux)
 	applyJSONBlobSchemaOverrides(humaAPI.OpenAPI())
 
-	s.handler = withCSRFGuards(requireBearer(cfg.authPolicy(), cfg.DB)(withTrustedProxyActor(cfg)(mux)))
+	s.handler = withGzip(withCSRFGuards(requireBearer(cfg.authPolicy(), cfg.DB)(withTrustedProxyActor(cfg)(mux))))
 	return s
+}
+
+// withGzip compresses responses with gzip when the client sends
+// Accept-Encoding: gzip. Eligibility is limited to the JSON API surface and
+// the OpenAPI YAML document; text/event-stream is deliberately excluded so
+// SSE frames flush through to the client unbuffered (the events handler
+// also depends on the ResponseWriter passing http.Flusher through, which
+// gzhttp's wrapper preserves). Responses under gzhttp's default minimum
+// size are sent as-is since gzip overhead would outweigh the savings.
+func withGzip(next http.Handler) http.Handler {
+	wrap, err := gzhttp.NewWrapper(gzhttp.ContentTypes([]string{
+		"application/json",
+		"application/openapi+yaml",
+	}))
+	if err != nil {
+		// The options above are static; NewWrapper only fails on invalid
+		// option values, so any error here is a programming error.
+		panic(fmt.Errorf("build gzip middleware: %w", err))
+	}
+	return wrap(next)
 }
 
 // Handler returns the http.Handler suitable for httptest.NewServer.


### PR DESCRIPTION
The daemon now compresses responses with gzip when the client sends `Accept-Encoding: gzip`. Compression is limited to the JSON API surface and the OpenAPI YAML document; `text/event-stream` is excluded so SSE frames keep flushing to the client unbuffered, and responses under the minimum-size threshold are sent as-is since gzip overhead would outweigh the savings.

Motivation: measured against a remote daemon over a high-latency link, `GET /api/v1/issues?status=open` returned 650 KB of uncompressed JSON and took 1.5–2.7 s to transfer, while the same request on the daemon host completed in 50–73 ms — the transfer dominated. The same JSON compresses roughly 10–30×, and Go's HTTP client already requests and transparently decompresses gzip, so existing CLI/TUI clients benefit with no changes.

Implementation uses `klauspost/compress` gzhttp, promoted from an indirect to a direct dependency at the already-pinned version. The wrapper preserves `http.Flusher` passthrough, which the events handler requires.

Tracked as kata#5vdd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)