### PR TITLE
Polish human-mode list/ready output: glyphs, priority chips, summary footer

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1753,6 +1753,8 @@ components:
       properties:
         author:
           type: string
+        blocked:
+          type: boolean
         blocked_by:
           items:
             $ref: "#/components/schemas/LinkPeer"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2104,6 +2104,8 @@ components:
           type: string
         short_id:
           type: string
+        status:
+          type: string
         uid:
           type: string
       required:
@@ -2111,6 +2113,7 @@ components:
         - short_id
         - project
         - qualified_id
+        - status
       type: object
     LinksDelta:
       additionalProperties: false

--- a/cmd/kata/list.go
+++ b/cmd/kata/list.go
@@ -119,9 +119,7 @@ func newListCmd() *cobra.Command {
 					Owner       *string  `json:"owner"`
 					Priority    *int64   `json:"priority"`
 					Labels      []string `json:"labels"`
-					BlockedBy   []struct {
-						Status string `json:"status"`
-					} `json:"blocked_by"`
+					Blocked     bool     `json:"blocked"`
 				} `json:"issues"`
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
@@ -158,22 +156,13 @@ func newListCmd() *cobra.Command {
 				if i.Owner != nil && *i.Owner != "" {
 					owner = *i.Owner
 				}
-				blocked := false
-				if i.Status == "open" {
-					for _, peer := range i.BlockedBy {
-						if peer.Status == "open" {
-							blocked = true
-							break
-						}
-					}
-				}
 				rows[idx] = issueRow{
 					ID:       i.ShortID,
 					Title:    i.Title,
 					Owner:    owner,
 					Priority: i.Priority,
 					Status:   i.Status,
-					Blocked:  blocked,
+					Blocked:  i.Blocked,
 					Labels:   i.Labels,
 				}
 			}

--- a/cmd/kata/list.go
+++ b/cmd/kata/list.go
@@ -181,18 +181,20 @@ func newListCmd() *cobra.Command {
 			if err := renderer.renderRows(cmd.OutOrStdout(), rows); err != nil {
 				return err
 			}
+			// Truncation heuristic: when we got exactly --limit rows back
+			// the daemon may have more. Has a false positive when the
+			// project has exactly --limit issues, which we accept as a
+			// much smaller harm than silently reporting a total that
+			// isn't one.
+			truncated := len(b.Issues) == limit
 			if !flags.Quiet && len(rows) > 0 {
-				if err := renderer.renderListFooter(cmd.OutOrStdout(), rows); err != nil {
+				if err := renderer.renderListFooter(cmd.OutOrStdout(), rows, truncated); err != nil {
 					return err
 				}
 			}
-			// Truncation hint: when we got exactly --limit rows back the
-			// daemon may have more. Print to stderr so pipelines stay
-			// clean (kata list | grep ...). Quiet suppresses it. Has a
-			// false positive when the project has exactly --limit issues,
-			// which we accept as a much smaller harm than silent
-			// truncation on projects above the default.
-			if !flags.Quiet && len(b.Issues) == limit {
+			// Truncation hint: print to stderr so pipelines stay clean
+			// (kata list | grep ...). Quiet suppresses it.
+			if !flags.Quiet && truncated {
 				if _, err := fmt.Fprintf(cmd.ErrOrStderr(),
 					"... showing %d (raise --limit to see more)\n", limit); err != nil {
 					return err

--- a/cmd/kata/list.go
+++ b/cmd/kata/list.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"go.kenn.io/kata/internal/textsafe"
 )
 
 func newListCmd() *cobra.Command {
@@ -120,6 +119,9 @@ func newListCmd() *cobra.Command {
 					Owner       *string  `json:"owner"`
 					Priority    *int64   `json:"priority"`
 					Labels      []string `json:"labels"`
+					BlockedBy   []struct {
+						Status string `json:"status"`
+					} `json:"blocked_by"`
 				} `json:"issues"`
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
@@ -150,14 +152,37 @@ func newListCmd() *cobra.Command {
 			// list and ready confused users (hammer-test finding #10).
 			// Unowned issues render as "(unowned)" so the trailing
 			// "(...)" cell is never empty.
-			for _, i := range b.Issues {
+			rows := make([]issueRow, len(b.Issues))
+			for idx, i := range b.Issues {
 				owner := "unowned"
 				if i.Owner != nil && *i.Owner != "" {
 					owner = *i.Owner
 				}
-				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%-8s  %-8s  %s  (%s)\n",
-					i.ShortID, i.Status,
-					textsafe.Line(i.Title), textsafe.Line(owner)); err != nil {
+				blocked := false
+				if i.Status == "open" {
+					for _, peer := range i.BlockedBy {
+						if peer.Status == "open" {
+							blocked = true
+							break
+						}
+					}
+				}
+				rows[idx] = issueRow{
+					ID:       i.ShortID,
+					Title:    i.Title,
+					Owner:    owner,
+					Priority: i.Priority,
+					Status:   i.Status,
+					Blocked:  blocked,
+					Labels:   i.Labels,
+				}
+			}
+			renderer := newRowRenderer(cmd.OutOrStdout())
+			if err := renderer.renderRows(cmd.OutOrStdout(), rows); err != nil {
+				return err
+			}
+			if !flags.Quiet && len(rows) > 0 {
+				if err := renderer.renderListFooter(cmd.OutOrStdout(), rows); err != nil {
 					return err
 				}
 			}

--- a/cmd/kata/list_test.go
+++ b/cmd/kata/list_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
 )
 
 // TestList_OutputsShortIDNotNumber pins the JSON wire shape: each issue
@@ -105,6 +107,37 @@ func TestList_HumanRowBlockedGlyphFollowsOpenBlocker(t *testing.T) {
 	blockedLine = findLineContaining(t, out, "blocked issue")
 	assert.Contains(t, blockedLine, "○", "expected open glyph once blocker is closed")
 	assert.NotContains(t, blockedLine, "●")
+}
+
+// TestList_HumanRowIgnoresBlockerInArchivedProject pins that `kata list`
+// agrees with `kata ready`: an open blocker whose project has been archived
+// must not mark the blocked issue as blocked. The issue lives in the bound
+// workspace project; the blocker lives in a separate project that gets
+// archived via the same path `kata projects remove` uses (RemoveProject).
+func TestList_HumanRowIgnoresBlockerInArchivedProject(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ctx := context.Background()
+	blockerProject, err := env.DB.CreateProject(ctx, "blocker-project")
+	require.NoError(t, err)
+
+	blocked := createIssue(t, env, pid, "blocked issue")
+	blocker := createIssue(t, env, blockerProject.ID, "blocker issue")
+	// Cross-project link target must be qualified ("project#short_id"); a
+	// bare short_id resolves within the subject's own (blocker) project.
+	createLinkViaHTTP(t, env, blockerProject.ID, blocker, "blocks", "kata#"+blocked)
+
+	_, _, err = env.DB.RemoveProject(ctx, db.RemoveProjectParams{
+		ProjectID: blockerProject.ID, Actor: "tester", Force: true,
+	})
+	require.NoError(t, err)
+
+	out := runCLI(t, env, dir, "list")
+	blockedLine := findLineContaining(t, out, "blocked issue")
+	assert.Contains(t, blockedLine, "○",
+		"blocker in an archived project must not render the blocked glyph")
+	assert.NotContains(t, blockedLine, "●")
+	assert.Contains(t, out, "Total: 1 issue (1 open)",
+		"footer must count the issue as open, not blocked")
 }
 
 // TestList_HumanFooterShowsTotalsAndLegend pins the footer: non-quiet human

--- a/cmd/kata/list_test.go
+++ b/cmd/kata/list_test.go
@@ -42,6 +42,134 @@ func TestList_DefaultsToOpenIssuesInProject(t *testing.T) {
 	assert.Contains(t, out, "beta")
 }
 
+// TestList_HumanRowUsesGlyphLayout pins the new row renderer's layout: an
+// open issue renders the open glyph "○ " ahead of its title, replacing the
+// old "%-8s  %-8s" column format.
+func TestList_HumanRowUsesGlyphLayout(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out := runCLI(t, env, dir, "list")
+
+	assert.Contains(t, out, "○ ", "expected open glyph prefix in human list output")
+	assert.Contains(t, out, "alpha")
+}
+
+// TestList_HumanRowRendersPriorityChip pins that an issue created with a
+// priority renders the "• P<n>" chip in human list output.
+func TestList_HumanRowRendersPriorityChip(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	type createResp struct {
+		Issue struct {
+			ShortID string `json:"short_id"`
+		} `json:"issue"`
+	}
+	postJSON[createResp](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues",
+		map[string]any{"actor": "tester", "title": "urgent fix", "priority": int64(1)})
+
+	out := runCLI(t, env, dir, "list")
+
+	assert.Contains(t, out, "• P1")
+}
+
+// TestList_HumanRowRendersBugLabelChip pins that a bug-labeled issue renders
+// the "[bug] " chip in human list output.
+func TestList_HumanRowRendersBugLabelChip(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "broken thing")
+	runCLI(t, env, dir, "label", "add", ref, "bug")
+
+	out := runCLI(t, env, dir, "list")
+
+	assert.Contains(t, out, "[bug] ")
+}
+
+// TestList_HumanRowBlockedGlyphFollowsOpenBlocker pins the Blocked
+// derivation: an open issue with an OPEN blocker renders the blocked glyph
+// "●", and once the blocker is closed (or the blocker starts out closed)
+// the same issue renders the open glyph "○" instead.
+func TestList_HumanRowBlockedGlyphFollowsOpenBlocker(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	blocker := createIssue(t, env, pid, "blocker issue")
+	blocked := createIssue(t, env, pid, "blocked issue")
+	createLinkViaHTTP(t, env, pid, blocker, "blocks", blocked)
+
+	out := runCLI(t, env, dir, "list")
+	blockedLine := findLineContaining(t, out, "blocked issue")
+	assert.Contains(t, blockedLine, "●", "expected blocked glyph while blocker is open")
+
+	runCLI(t, env, dir, "close", blocker, "--done", "--message",
+		"resolved for test; blocker no longer applies", "--commit", "abc1234")
+
+	out = runCLI(t, env, dir, "list", "--status", "all")
+	blockedLine = findLineContaining(t, out, "blocked issue")
+	assert.Contains(t, blockedLine, "○", "expected open glyph once blocker is closed")
+	assert.NotContains(t, blockedLine, "●")
+}
+
+// TestList_HumanFooterShowsTotalsAndLegend pins the footer: non-quiet human
+// list output includes the rule, a "Total: N issues" summary, and the
+// "Status: ○ open" legend.
+func TestList_HumanFooterShowsTotalsAndLegend(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out := runCLI(t, env, dir, "list")
+
+	assert.Contains(t, out, "Total: 1 issue")
+	assert.Contains(t, out, "Status: ○ open")
+}
+
+// TestList_HumanFooterAbsentUnderQuiet pins that --quiet suppresses the
+// footer entirely, even when rows were printed.
+func TestList_HumanFooterAbsentUnderQuiet(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out := runCLI(t, env, dir, "--quiet", "list")
+
+	assert.NotContains(t, out, "Total:")
+	assert.NotContains(t, out, "Status: ○ open")
+}
+
+// TestList_HumanFooterAbsentOnZeroRows pins that an empty result set prints
+// no footer (no rule, no "Total:" line).
+func TestList_HumanFooterAbsentOnZeroRows(t *testing.T) {
+	env, dir, _ := setupCLIWorkspace(t)
+
+	out := runCLI(t, env, dir, "list")
+
+	assert.Empty(t, out)
+	assert.NotContains(t, out, "Total:")
+}
+
+// rowLines returns the leading non-blank lines of human list output — the
+// issue rows themselves, stopping before the footer's blank separator line.
+func rowLines(out string) []string {
+	var lines []string
+	for _, ln := range strings.Split(out, "\n") {
+		if ln == "" {
+			break
+		}
+		lines = append(lines, ln)
+	}
+	return lines
+}
+
+// findLineContaining returns the single line of out containing substr,
+// failing the test if zero or more than one line matches.
+func findLineContaining(t *testing.T, out, substr string) string {
+	t.Helper()
+	var matches []string
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.Contains(ln, substr) {
+			matches = append(matches, ln)
+		}
+	}
+	require.Len(t, matches, 1, "expected exactly one line containing %q, got %v", substr, matches)
+	return matches[0]
+}
+
 func TestList_AgentOutputRowsOmitAbsentOwner(t *testing.T) {
 	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "unowned task")
@@ -76,9 +204,13 @@ func TestList_SanitizesAnsiAndNewlinesInTitle(t *testing.T) {
 	out := runCLI(t, env, dir, "list")
 	assert.NotContains(t, out, "\x1b", "ESC reached stdout")
 	// The newline in the title must be escaped (\n literal) so the
-	// list row stays on one visual line.
+	// list row stays on one visual line. Only the row section (before
+	// the footer's intentional blank separator lines) is checked.
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 	for _, ln := range lines {
+		if ln == "" {
+			break // footer begins with a blank separator line
+		}
 		assert.NotEmpty(t, ln, "list output produced a blank row from injected newline")
 	}
 }
@@ -95,8 +227,9 @@ func TestList_HintsWhenTruncated(t *testing.T) {
 
 	stdout, stderr, err := runCLIWithErr(t, env, dir, "list", "--limit", "2")
 	require.NoError(t, err)
-	// Two rows on stdout, no hint on stdout.
-	rows := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	// Two rows on stdout (before the footer's blank separator line), no
+	// hint on stdout.
+	rows := rowLines(strings.TrimRight(stdout, "\n"))
 	assert.Len(t, rows, 2, "stdout should carry exactly --limit rows")
 	assert.NotContains(t, stdout, "--limit", "hint must go to stderr, not stdout")
 	// Hint on stderr.

--- a/cmd/kata/list_test.go
+++ b/cmd/kata/list_test.go
@@ -215,6 +215,36 @@ func TestList_SanitizesAnsiAndNewlinesInTitle(t *testing.T) {
 	}
 }
 
+// TestList_HumanFooterShowsShowingWhenTruncated pins that when the returned
+// page is exactly --limit rows, the human footer swaps "Total:" for
+// "Showing:" so the summary doesn't misread as a project-wide total.
+func TestList_HumanFooterShowsShowingWhenTruncated(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	for _, title := range []string{"alpha", "beta", "gamma"} {
+		createIssue(t, env, pid, title)
+	}
+
+	out := runCLI(t, env, dir, "list", "--limit", "2")
+
+	assert.Contains(t, out, "Showing: 2 issues")
+	assert.NotContains(t, out, "Total:")
+}
+
+// TestList_HumanFooterShowsTotalWhenNotTruncated pins the non-truncated
+// counterpart: when all matching rows fit under --limit, the footer keeps
+// the "Total:" wording.
+func TestList_HumanFooterShowsTotalWhenNotTruncated(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	for _, title := range []string{"alpha", "beta"} {
+		createIssue(t, env, pid, title)
+	}
+
+	out := runCLI(t, env, dir, "list", "--limit", "10")
+
+	assert.Contains(t, out, "Total: 2 issues")
+	assert.NotContains(t, out, "Showing:")
+}
+
 // TestList_HintsWhenTruncated covers the silent-truncation pitfall: when the
 // returned page is exactly --limit rows, the CLI prints a stderr hint so users
 // realize there may be more. Hint goes to stderr so it doesn't pollute pipes

--- a/cmd/kata/ready.go
+++ b/cmd/kata/ready.go
@@ -161,8 +161,11 @@ func newReadyCmd() *cobra.Command {
 				if err := renderer.renderRows(cmd.OutOrStdout(), rows); err != nil {
 					return err
 				}
+				// ready's default limit is 0 (no limit); a positive limit
+				// that returned exactly that many rows may be truncating.
+				truncated := limit > 0 && len(rows) == limit
 				if !flags.Quiet && len(rows) > 0 {
-					if err := renderer.renderReadyFooter(cmd.OutOrStdout(), len(rows)); err != nil {
+					if err := renderer.renderReadyFooter(cmd.OutOrStdout(), len(rows), truncated); err != nil {
 						return err
 					}
 				}
@@ -215,8 +218,11 @@ func newReadyCmd() *cobra.Command {
 			if err := renderer.renderRows(cmd.OutOrStdout(), rows); err != nil {
 				return err
 			}
+			// ready's default limit is 0 (no limit); a positive limit
+			// that returned exactly that many rows may be truncating.
+			truncated := limit > 0 && len(rows) == limit
 			if !flags.Quiet && len(rows) > 0 {
-				if err := renderer.renderReadyFooter(cmd.OutOrStdout(), len(rows)); err != nil {
+				if err := renderer.renderReadyFooter(cmd.OutOrStdout(), len(rows), truncated); err != nil {
 					return err
 				}
 			}

--- a/cmd/kata/ready.go
+++ b/cmd/kata/ready.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"go.kenn.io/kata/internal/textsafe"
 )
 
 func newReadyCmd() *cobra.Command {
@@ -121,19 +120,32 @@ func newReadyCmd() *cobra.Command {
 						Title       string  `json:"title"`
 						Owner       *string `json:"owner,omitempty"`
 						ProjectName string  `json:"project_name"`
+						Priority    *int64  `json:"priority"`
 					} `json:"issues"`
 				}
 				if err := json.Unmarshal(bs, &b); err != nil {
 					return err
 				}
-				for _, i := range b.Issues {
+				rows := make([]issueRow, len(b.Issues))
+				for idx, i := range b.Issues {
 					owner := "-"
 					if i.Owner != nil {
 						owner = *i.Owner
 					}
-					qualified := i.ProjectName + "#" + i.ShortID
-					if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%-16s  %s  (%s)\n",
-						qualified, textsafe.Line(i.Title), textsafe.Line(owner)); err != nil {
+					rows[idx] = issueRow{
+						ID:       i.ProjectName + "#" + i.ShortID,
+						Title:    i.Title,
+						Owner:    owner,
+						Priority: i.Priority,
+						Status:   "open",
+					}
+				}
+				renderer := newRowRenderer(cmd.OutOrStdout())
+				if err := renderer.renderRows(cmd.OutOrStdout(), rows); err != nil {
+					return err
+				}
+				if !flags.Quiet && len(rows) > 0 {
+					if err := renderer.renderReadyFooter(cmd.OutOrStdout(), len(rows)); err != nil {
 						return err
 					}
 				}
@@ -168,13 +180,26 @@ func newReadyCmd() *cobra.Command {
 				}
 				return nil
 			}
-			for _, i := range b.Issues {
+			rows := make([]issueRow, len(b.Issues))
+			for idx, i := range b.Issues {
 				ownerStr := "-"
 				if i.Owner != nil {
 					ownerStr = *i.Owner
 				}
-				if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%-8s  %s  (%s)\n",
-					i.ShortID, textsafe.Line(i.Title), textsafe.Line(ownerStr)); err != nil {
+				rows[idx] = issueRow{
+					ID:       i.ShortID,
+					Title:    i.Title,
+					Owner:    ownerStr,
+					Priority: i.Priority,
+					Status:   "open",
+				}
+			}
+			renderer := newRowRenderer(cmd.OutOrStdout())
+			if err := renderer.renderRows(cmd.OutOrStdout(), rows); err != nil {
+				return err
+			}
+			if !flags.Quiet && len(rows) > 0 {
+				if err := renderer.renderReadyFooter(cmd.OutOrStdout(), len(rows)); err != nil {
 					return err
 				}
 			}

--- a/cmd/kata/ready.go
+++ b/cmd/kata/ready.go
@@ -126,6 +126,23 @@ func newReadyCmd() *cobra.Command {
 				if err := json.Unmarshal(bs, &b); err != nil {
 					return err
 				}
+				if mode == outputAgent {
+					out := cmd.OutOrStdout()
+					if _, err := fmt.Fprintf(out, "OK ready count=%d\n", len(b.Issues)); err != nil {
+						return err
+					}
+					for _, i := range b.Issues {
+						if err := writeAgentKVRow(out,
+							agentRowField("issue", i.ProjectName+"#"+i.ShortID),
+							agentRowIntField("priority", i.Priority),
+							agentOptionalRowField("owner", i.Owner),
+							agentRowField("title", i.Title),
+						); err != nil {
+							return err
+						}
+					}
+					return nil
+				}
 				rows := make([]issueRow, len(b.Issues))
 				for idx, i := range b.Issues {
 					owner := "-"

--- a/cmd/kata/ready_test.go
+++ b/cmd/kata/ready_test.go
@@ -118,6 +118,107 @@ func TestReady_AllFromBoundDirSkipsLocalProject(t *testing.T) {
 // global ready endpoint does not apply --unowned / --owner / --label /
 // --no-label, so accepting those alongside --all would return misleading
 // (unfiltered) results.
+// TestReady_HumanRowUsesGlyphLayout pins that the project-scoped human
+// path renders through the shared row renderer: open glyph + title.
+func TestReady_HumanRowUsesGlyphLayout(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out := runCLI(t, env, dir, "ready")
+
+	assert.Contains(t, out, "○ ", "expected open glyph prefix in human ready output")
+	assert.Contains(t, out, "alpha")
+}
+
+// TestReady_HumanRowRendersPriorityChip pins that a ready issue with a
+// priority renders the "• P<n>" chip in project-scoped human output.
+func TestReady_HumanRowRendersPriorityChip(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	postJSON[map[string]any](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues",
+		map[string]any{"actor": "tester", "title": "urgent fix", "priority": int64(1)})
+
+	out := runCLI(t, env, dir, "ready")
+
+	assert.Contains(t, out, "• P1")
+}
+
+// TestReady_HumanFooterShowsSummaryAndLegend pins the ready footer: rule,
+// "Ready: N issues with no active blockers" summary, and the
+// "Status: ○ open" legend (no "● blocked" clause since ready results are
+// by definition unblocked).
+func TestReady_HumanFooterShowsSummaryAndLegend(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out := runCLI(t, env, dir, "ready")
+
+	assert.Contains(t, out, "Ready: 1 issue with no active blockers")
+	assert.Contains(t, out, "Status: ○ open")
+	assert.NotContains(t, out, "● blocked")
+}
+
+// TestReady_HumanFooterAbsentUnderQuiet pins that --quiet suppresses the
+// ready footer even when rows were printed.
+func TestReady_HumanFooterAbsentUnderQuiet(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out := runCLI(t, env, dir, "--quiet", "ready")
+
+	assert.NotContains(t, out, "Ready:")
+	assert.NotContains(t, out, "Status: ○ open")
+}
+
+// TestReady_HumanFooterAbsentOnZeroRows pins that an empty ready result
+// prints no footer at all.
+func TestReady_HumanFooterAbsentOnZeroRows(t *testing.T) {
+	env, dir, _ := setupCLIWorkspace(t)
+
+	out := runCLI(t, env, dir, "ready")
+
+	assert.NotContains(t, out, "Ready:")
+}
+
+// TestReady_AllHumanRowUsesGlyphLayoutAndQualifiedID pins that the --all
+// human path renders through the shared row renderer with the qualified
+// "project#short_id" id and the open glyph.
+func TestReady_AllHumanRowUsesGlyphLayoutAndQualifiedID(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out, err := runCmdOutput(t, env, "--workspace", dir, "ready", "--all")
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "○ ", "expected open glyph prefix in --all human ready output")
+	assert.Contains(t, out, "#")
+	assert.Contains(t, out, "alpha")
+}
+
+// TestReady_AllHumanRowRendersPriorityChip pins that --all human output
+// renders the priority chip for a ready issue created with a priority.
+func TestReady_AllHumanRowRendersPriorityChip(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	postJSON[map[string]any](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues",
+		map[string]any{"actor": "tester", "title": "urgent fix", "priority": int64(1)})
+
+	out, err := runCmdOutput(t, env, "--workspace", dir, "ready", "--all")
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "• P1")
+}
+
+// TestReady_AllHumanFooterShowsSummaryAndLegend pins the --all footer.
+func TestReady_AllHumanFooterShowsSummaryAndLegend(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out, err := runCmdOutput(t, env, "--workspace", dir, "ready", "--all")
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Ready: 1 issue with no active blockers")
+	assert.Contains(t, out, "Status: ○ open")
+}
+
 func TestReady_AllRejectsFilterFlags(t *testing.T) {
 	cases := []struct {
 		name string

--- a/cmd/kata/ready_test.go
+++ b/cmd/kata/ready_test.go
@@ -212,6 +212,52 @@ func TestReady_HumanFooterAbsentOnZeroRows(t *testing.T) {
 	assert.NotContains(t, out, "Ready:")
 }
 
+// TestReady_HumanFooterShowsShowingWhenTruncated pins that when the
+// returned page is exactly --limit rows, the scoped ready footer swaps
+// "Ready:" for "Showing:" so the summary doesn't misread as a full count
+// of ready issues.
+func TestReady_HumanFooterShowsShowingWhenTruncated(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	for _, title := range []string{"alpha", "beta", "gamma"} {
+		createIssue(t, env, pid, title)
+	}
+
+	out := runCLI(t, env, dir, "ready", "--limit", "2")
+
+	assert.Contains(t, out, "Showing: 2 ready issues with no active blockers")
+	assert.NotContains(t, out, "Ready:")
+}
+
+// TestReady_HumanFooterShowsReadyWhenNotTruncated pins the non-truncated
+// counterpart: when all ready rows fit under --limit, the footer keeps
+// the "Ready:" wording.
+func TestReady_HumanFooterShowsReadyWhenNotTruncated(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	for _, title := range []string{"alpha", "beta"} {
+		createIssue(t, env, pid, title)
+	}
+
+	out := runCLI(t, env, dir, "ready", "--limit", "10")
+
+	assert.Contains(t, out, "Ready: 2 issues with no active blockers")
+	assert.NotContains(t, out, "Showing:")
+}
+
+// TestReady_AllHumanFooterShowsShowingWhenTruncated pins the --all path's
+// truncation wording, mirroring the scoped-project case above.
+func TestReady_AllHumanFooterShowsShowingWhenTruncated(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	for _, title := range []string{"alpha", "beta", "gamma"} {
+		createIssue(t, env, pid, title)
+	}
+
+	out, err := runCmdOutput(t, env, "--workspace", dir, "ready", "--all", "--limit", "2")
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Showing: 2 ready issues with no active blockers")
+	assert.NotContains(t, out, "Ready:")
+}
+
 // TestReady_AllHumanRowUsesGlyphLayoutAndQualifiedID pins that the --all
 // human path renders through the shared row renderer with the qualified
 // "project#short_id" id and the open glyph.

--- a/cmd/kata/ready_test.go
+++ b/cmd/kata/ready_test.go
@@ -54,6 +54,39 @@ func TestReady_AgentOutputRowsOmitAbsentOwner(t *testing.T) {
 	assert.NotContains(t, out, "owner=")
 }
 
+// TestReady_AgentAllEmitsKVRows pins the agent-mode contract for the global
+// path: `--agent ready --all` emits the structured `OK ready count=N` header
+// plus one kv row per issue whose issue field is the qualified
+// "<project>#<short_id>" ref — never the human glyph rows.
+func TestReady_AgentAllEmitsKVRows(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	sid := createIssue(t, env, pid, "agent all row")
+
+	out, err := runCmdOutput(t, env, "--workspace", dir, "--agent", "ready", "--all")
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "OK ready count=1\n")
+	assert.Contains(t, out, "- issue=kata#"+sid)
+	assert.Contains(t, out, `title="agent all row"`)
+	assert.NotContains(t, out, "○ ", "agent mode must not emit human glyph rows")
+	assert.NotContains(t, out, "Ready:", "agent mode must not emit the human footer")
+}
+
+// TestReady_AgentAllRowCarriesPriorityAndOmitsAbsentOwner pins the field set
+// on --all agent rows: priority is rendered when set, owner is omitted when
+// absent (same optional-field idiom as the project-scoped agent path).
+func TestReady_AgentAllRowCarriesPriorityAndOmitsAbsentOwner(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	postJSON[map[string]any](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues",
+		map[string]any{"actor": "tester", "title": "urgent fix", "priority": int64(1)})
+
+	out, err := runCmdOutput(t, env, "--workspace", dir, "--agent", "ready", "--all")
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "priority=1")
+	assert.NotContains(t, out, "owner=")
+}
+
 func TestReady_UnownedAndOwnerMutualExclusion(t *testing.T) {
 	env, dir := setupCLIEnv(t)
 	resetFlags(t)

--- a/cmd/kata/render.go
+++ b/cmd/kata/render.go
@@ -129,7 +129,9 @@ func (r *rowRenderer) glyph(row issueRow) string {
 
 // priorityField renders the fixed 4-cell priority field. P3 and any
 // unrecognized value render as unstyled default-fg text (matching
-// the Visual Spec's "P3: default fg, no color").
+// the Visual Spec's "P3: default fg, no color"). The fixed 4-cell
+// width ("• P<n>") relies on the daemon clamping priority to 0-4;
+// a multi-digit priority would break column alignment.
 func (r *rowRenderer) priorityField(p *int64) string {
 	if p == nil {
 		return "    "

--- a/cmd/kata/render.go
+++ b/cmd/kata/render.go
@@ -180,7 +180,10 @@ func (r *rowRenderer) chipsField(labels []string) string {
 // (blocked wins over open for the bucket, matching renderRow's
 // glyph precedence) rather than trusting a caller-supplied total, so
 // the summary always reflects what was actually printed above it.
-func (r *rowRenderer) renderListFooter(w io.Writer, rows []issueRow) error {
+// When truncated is true (the caller hit --limit and there may be
+// more matching issues than were returned), the summary uses
+// "Showing:" instead of "Total:" so it doesn't read as a full count.
+func (r *rowRenderer) renderListFooter(w io.Writer, rows []issueRow, truncated bool) error {
 	if len(rows) == 0 {
 		return nil
 	}
@@ -206,17 +209,29 @@ func (r *rowRenderer) renderListFooter(w io.Writer, rows []issueRow) error {
 		clauses = append(clauses, fmt.Sprintf("%d closed", closed))
 	}
 	total := len(rows)
-	summary := fmt.Sprintf("Total: %d %s (%s)", total, issueWord(total), strings.Join(clauses, ", "))
+	label := "Total"
+	if truncated {
+		label = "Showing"
+	}
+	summary := fmt.Sprintf("%s: %d %s (%s)", label, total, issueWord(total), strings.Join(clauses, ", "))
 	return r.renderFooter(w, summary, "Status: ○ open  ● blocked  ✓ closed")
 }
 
 // renderReadyFooter writes the footer for `kata ready`. The legend
 // omits "● blocked" since ready results are, by definition, unblocked.
-func (r *rowRenderer) renderReadyFooter(w io.Writer, n int) error {
+// When truncated is true (the caller hit --limit and there may be
+// more ready issues than were returned), the summary uses "Showing:"
+// instead of "Ready:" so it doesn't read as a full count.
+func (r *rowRenderer) renderReadyFooter(w io.Writer, n int, truncated bool) error {
 	if n == 0 {
 		return nil
 	}
-	summary := fmt.Sprintf("Ready: %d %s with no active blockers", n, issueWord(n))
+	var summary string
+	if truncated {
+		summary = fmt.Sprintf("Showing: %d ready %s with no active blockers", n, issueWord(n))
+	} else {
+		summary = fmt.Sprintf("Ready: %d %s with no active blockers", n, issueWord(n))
+	}
 	return r.renderFooter(w, summary, "Status: ○ open")
 }
 

--- a/cmd/kata/render.go
+++ b/cmd/kata/render.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"go.kenn.io/kata/internal/textsafe"
+)
+
+// issueRow is the render-ready projection of one issue line. Callers
+// map their wire structs into this; the renderer sanitizes all
+// strings itself via textsafe.Line so a hostile title/owner can't
+// break row layout or inject terminal control sequences.
+type issueRow struct {
+	ID       string // short_id or qualified id
+	Title    string
+	Owner    string   // already fallback-resolved ("unowned" / "-")
+	Priority *int64   // nil = no chip
+	Status   string   // "open" | "closed"
+	Blocked  bool     // wins over Status for the glyph when Status=="open"
+	Labels   []string // renderer picks out epic/bug chips
+}
+
+// footerRuleWidth is the width in cells of the "─" rule printed
+// between the row list and the summary line.
+const footerRuleWidth = 50
+
+// rowRenderer holds lipgloss styles bound to one renderer/output
+// stream so color-capability detection (TTY, NO_COLOR, forced
+// profile in tests) is resolved once and reused across every row and
+// footer line it renders.
+type rowRenderer struct {
+	idStyle           lipgloss.Style
+	blockedGlyphStyle lipgloss.Style
+	closedGlyphStyle  lipgloss.Style
+	p0Style           lipgloss.Style
+	p1Style           lipgloss.Style
+	p2Style           lipgloss.Style
+	p4Style           lipgloss.Style
+	epicChipStyle     lipgloss.Style
+	bugChipStyle      lipgloss.Style
+	ownerStyle        lipgloss.Style
+	ruleStyle         lipgloss.Style
+	legendStyle       lipgloss.Style
+}
+
+// newRowRenderer builds a rowRenderer bound to w, detecting TTY /
+// NO_COLOR / color-profile capability from w itself (so piping to a
+// file or a NO_COLOR environment degrades to plain text).
+func newRowRenderer(w io.Writer) *rowRenderer {
+	return newRowRendererFor(lipgloss.NewRenderer(w))
+}
+
+// newRowRendererFor builds a rowRenderer bound to an existing
+// lipgloss.Renderer. This is the test seam: callers can force a
+// color profile via r.SetColorProfile(...) before construction.
+func newRowRendererFor(r *lipgloss.Renderer) *rowRenderer {
+	return &rowRenderer{
+		idStyle:           r.NewStyle().Foreground(lipgloss.Color("6")),
+		blockedGlyphStyle: r.NewStyle().Foreground(lipgloss.Color("1")),
+		closedGlyphStyle:  r.NewStyle().Foreground(lipgloss.Color("2")),
+		p0Style:           r.NewStyle().Bold(true).Foreground(lipgloss.Color("9")),
+		p1Style:           r.NewStyle().Foreground(lipgloss.Color("1")),
+		p2Style:           r.NewStyle().Foreground(lipgloss.Color("3")),
+		p4Style:           r.NewStyle().Faint(true),
+		epicChipStyle:     r.NewStyle().Foreground(lipgloss.Color("5")),
+		bugChipStyle:      r.NewStyle().Foreground(lipgloss.Color("1")),
+		ownerStyle:        r.NewStyle().Faint(true),
+		ruleStyle:         r.NewStyle().Faint(true),
+		legendStyle:       r.NewStyle().Faint(true),
+	}
+}
+
+// renderRows writes one formatted line per row to w:
+//
+//	<glyph> <short_id padded>  <prio>  <chips><title> (<owner>)
+//
+// The id column is left-aligned and padded to the widest id across
+// rows (minimum 4 cells), measured with lipgloss.Width so wide
+// glyphs and any embedded ANSI don't throw off alignment. Printing
+// nothing for an empty slice is intentional: callers skip calling
+// renderRows/footers on zero rows, but the renderer tolerates it too.
+func (r *rowRenderer) renderRows(w io.Writer, rows []issueRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	idWidth := 4
+	ids := make([]string, len(rows))
+	for i, row := range rows {
+		ids[i] = textsafe.Line(row.ID)
+		if width := lipgloss.Width(ids[i]); width > idWidth {
+			idWidth = width
+		}
+	}
+	for i, row := range rows {
+		line := r.renderRow(row, ids[i], idWidth)
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *rowRenderer) renderRow(row issueRow, id string, idWidth int) string {
+	glyph := r.glyph(row)
+	idCell := r.idStyle.Render(id + strings.Repeat(" ", idWidth-lipgloss.Width(id)))
+	prio := r.priorityField(row.Priority)
+	chips := r.chipsField(row.Labels)
+	title := textsafe.Line(row.Title)
+	owner := r.ownerStyle.Render("(" + textsafe.Line(row.Owner) + ")")
+	return glyph + " " + idCell + "  " + prio + "  " + chips + title + " " + owner
+}
+
+// glyph picks the status glyph. Closed wins outright; otherwise
+// Blocked wins over the open status per the Architecture contract.
+// The open glyph carries no style (default terminal fg, unstyled).
+func (r *rowRenderer) glyph(row issueRow) string {
+	switch {
+	case row.Status == "closed":
+		return r.closedGlyphStyle.Render("✓")
+	case row.Blocked:
+		return r.blockedGlyphStyle.Render("●")
+	default:
+		return "○"
+	}
+}
+
+// priorityField renders the fixed 4-cell priority field. P3 and any
+// unrecognized value render as unstyled default-fg text (matching
+// the Visual Spec's "P3: default fg, no color").
+func (r *rowRenderer) priorityField(p *int64) string {
+	if p == nil {
+		return "    "
+	}
+	text := fmt.Sprintf("• P%d", *p)
+	switch *p {
+	case 0:
+		return r.p0Style.Render(text)
+	case 1:
+		return r.p1Style.Render(text)
+	case 2:
+		return r.p2Style.Render(text)
+	case 4:
+		return r.p4Style.Render(text)
+	default:
+		return text
+	}
+}
+
+// chipsField renders the well-known label chips, epic then bug, each
+// as "[label] " (trailing space). Only these two labels render;
+// everything else is not a recognized chip and is dropped.
+func (r *rowRenderer) chipsField(labels []string) string {
+	has := func(want string) bool {
+		for _, l := range labels {
+			if l == want {
+				return true
+			}
+		}
+		return false
+	}
+	var b strings.Builder
+	if has("epic") {
+		b.WriteString(r.epicChipStyle.Render("[epic]"))
+		b.WriteString(" ")
+	}
+	if has("bug") {
+		b.WriteString(r.bugChipStyle.Render("[bug]"))
+		b.WriteString(" ")
+	}
+	return b.String()
+}
+
+// renderListFooter writes the blank-line/rule/summary/blank-line/
+// legend footer for `kata list`. Counts are derived from rows
+// (blocked wins over open for the bucket, matching renderRow's
+// glyph precedence) rather than trusting a caller-supplied total, so
+// the summary always reflects what was actually printed above it.
+func (r *rowRenderer) renderListFooter(w io.Writer, rows []issueRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	var open, blocked, closed int
+	for _, row := range rows {
+		switch {
+		case row.Status == "closed":
+			closed++
+		case row.Blocked:
+			blocked++
+		default:
+			open++
+		}
+	}
+	var clauses []string
+	if open > 0 {
+		clauses = append(clauses, fmt.Sprintf("%d open", open))
+	}
+	if blocked > 0 {
+		clauses = append(clauses, fmt.Sprintf("%d blocked", blocked))
+	}
+	if closed > 0 {
+		clauses = append(clauses, fmt.Sprintf("%d closed", closed))
+	}
+	total := len(rows)
+	summary := fmt.Sprintf("Total: %d %s (%s)", total, issueWord(total), strings.Join(clauses, ", "))
+	return r.renderFooter(w, summary, "Status: ○ open  ● blocked  ✓ closed")
+}
+
+// renderReadyFooter writes the footer for `kata ready`. The legend
+// omits "● blocked" since ready results are, by definition, unblocked.
+func (r *rowRenderer) renderReadyFooter(w io.Writer, n int) error {
+	if n == 0 {
+		return nil
+	}
+	summary := fmt.Sprintf("Ready: %d %s with no active blockers", n, issueWord(n))
+	return r.renderFooter(w, summary, "Status: ○ open")
+}
+
+func (r *rowRenderer) renderFooter(w io.Writer, summary, legend string) error {
+	rule := r.ruleStyle.Render(strings.Repeat("─", footerRuleWidth))
+	legendLine := r.legendStyle.Render(legend)
+	_, err := fmt.Fprintf(w, "\n%s\n%s\n\n%s\n", rule, summary, legendLine)
+	return err
+}
+
+// issueWord returns the singular/plural noun for a count.
+func issueWord(n int) string {
+	if n == 1 {
+		return "issue"
+	}
+	return "issues"
+}

--- a/cmd/kata/render_test.go
+++ b/cmd/kata/render_test.go
@@ -183,7 +183,7 @@ func TestRenderListFooter_ColorOff(t *testing.T) {
 			{ID: "a2", Status: "open", Blocked: true},
 			{ID: "a3", Status: "closed"},
 		}
-		require.NoError(t, r.renderListFooter(&buf, rows))
+		require.NoError(t, r.renderListFooter(&buf, rows, false))
 		want := "\n" + rule + "\n" + "Total: 3 issues (1 open, 1 blocked, 1 closed)\n" + "\n" + legend + "\n"
 		assert.Equal(t, want, buf.String())
 	})
@@ -191,7 +191,7 @@ func TestRenderListFooter_ColorOff(t *testing.T) {
 	t.Run("singular, all open", func(t *testing.T) {
 		var buf bytes.Buffer
 		rows := []issueRow{{ID: "a1", Status: "open"}}
-		require.NoError(t, r.renderListFooter(&buf, rows))
+		require.NoError(t, r.renderListFooter(&buf, rows, false))
 		want := "\n" + rule + "\n" + "Total: 1 issue (1 open)\n" + "\n" + legend + "\n"
 		assert.Equal(t, want, buf.String())
 	})
@@ -202,7 +202,7 @@ func TestRenderListFooter_ColorOff(t *testing.T) {
 			{ID: "a1", Status: "open"},
 			{ID: "a2", Status: "closed"},
 		}
-		require.NoError(t, r.renderListFooter(&buf, rows))
+		require.NoError(t, r.renderListFooter(&buf, rows, false))
 		want := "\n" + rule + "\n" + "Total: 2 issues (1 open, 1 closed)\n" + "\n" + legend + "\n"
 		assert.Equal(t, want, buf.String())
 	})
@@ -212,15 +212,35 @@ func TestRenderListFooter_ColorOff(t *testing.T) {
 		rows := []issueRow{
 			{ID: "a1", Status: "open", Blocked: true},
 		}
-		require.NoError(t, r.renderListFooter(&buf, rows))
+		require.NoError(t, r.renderListFooter(&buf, rows, false))
 		want := "\n" + rule + "\n" + "Total: 1 issue (1 blocked)\n" + "\n" + legend + "\n"
 		assert.Equal(t, want, buf.String())
 	})
 
 	t.Run("zero rows prints nothing", func(t *testing.T) {
 		var buf bytes.Buffer
-		require.NoError(t, r.renderListFooter(&buf, nil))
+		require.NoError(t, r.renderListFooter(&buf, nil, false))
 		assert.Empty(t, buf.String())
+	})
+
+	t.Run("truncated uses Showing wording, not Total", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{
+			{ID: "a1", Status: "open"},
+			{ID: "a2", Status: "open", Blocked: true},
+			{ID: "a3", Status: "closed"},
+		}
+		require.NoError(t, r.renderListFooter(&buf, rows, true))
+		want := "\n" + rule + "\n" + "Showing: 3 issues (1 open, 1 blocked, 1 closed)\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
+	})
+
+	t.Run("truncated singular uses Showing wording", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{ID: "a1", Status: "open"}}
+		require.NoError(t, r.renderListFooter(&buf, rows, true))
+		want := "\n" + rule + "\n" + "Showing: 1 issue (1 open)\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
 	})
 }
 
@@ -232,22 +252,36 @@ func TestRenderReadyFooter_ColorOff(t *testing.T) {
 
 	t.Run("plural", func(t *testing.T) {
 		var buf bytes.Buffer
-		require.NoError(t, r.renderReadyFooter(&buf, 3))
+		require.NoError(t, r.renderReadyFooter(&buf, 3, false))
 		want := "\n" + rule + "\n" + "Ready: 3 issues with no active blockers\n" + "\n" + legend + "\n"
 		assert.Equal(t, want, buf.String())
 	})
 
 	t.Run("singular", func(t *testing.T) {
 		var buf bytes.Buffer
-		require.NoError(t, r.renderReadyFooter(&buf, 1))
+		require.NoError(t, r.renderReadyFooter(&buf, 1, false))
 		want := "\n" + rule + "\n" + "Ready: 1 issue with no active blockers\n" + "\n" + legend + "\n"
 		assert.Equal(t, want, buf.String())
 	})
 
 	t.Run("zero prints nothing", func(t *testing.T) {
 		var buf bytes.Buffer
-		require.NoError(t, r.renderReadyFooter(&buf, 0))
+		require.NoError(t, r.renderReadyFooter(&buf, 0, false))
 		assert.Empty(t, buf.String())
+	})
+
+	t.Run("truncated plural uses Showing wording", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, r.renderReadyFooter(&buf, 3, true))
+		want := "\n" + rule + "\n" + "Showing: 3 ready issues with no active blockers\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
+	})
+
+	t.Run("truncated singular uses Showing wording", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, r.renderReadyFooter(&buf, 1, true))
+		want := "\n" + rule + "\n" + "Showing: 1 ready issue with no active blockers\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
 	})
 }
 
@@ -290,7 +324,7 @@ func TestRenderListFooter_ColorOn(t *testing.T) {
 
 	rows := []issueRow{{ID: "a1", Status: "open"}}
 	var buf bytes.Buffer
-	require.NoError(t, r.renderListFooter(&buf, rows))
+	require.NoError(t, r.renderListFooter(&buf, rows, false))
 
 	const rule = "──────────────────────────────────────────────────"
 	want := "\n" +
@@ -302,7 +336,7 @@ func TestRenderListFooter_ColorOn(t *testing.T) {
 
 	off := newRowRendererFor(lipgloss.NewRenderer(&bytes.Buffer{}, termenv.WithProfile(termenv.Ascii)))
 	var offBuf bytes.Buffer
-	require.NoError(t, off.renderListFooter(&offBuf, rows))
+	require.NoError(t, off.renderListFooter(&offBuf, rows, false))
 	assert.Equal(t, offBuf.String(), stripANSITest(buf.String()))
 }
 

--- a/cmd/kata/render_test.go
+++ b/cmd/kata/render_test.go
@@ -1,0 +1,352 @@
+package main
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var ansiSequence = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSITest(s string) string {
+	return ansiSequence.ReplaceAllString(s, "")
+}
+
+// gutter is the literal two-space separator the Visual Spec places
+// between the id/prio/chips fields. noPrio is the 4-cell empty
+// priority field ("<prio>" is a fixed 4-cell field).
+const gutter = "  "
+const noPrio = "    "
+
+// row builds the expected plain-text line for a color-off row so test
+// expectations are computed from the spec's field layout rather than
+// hand-counted whitespace:
+//
+//	<glyph> <id padded><gutter><prio><gutter><chips><title> (<owner>)
+func row(glyph, idPadded, prio, chips, title, owner string) string {
+	return glyph + " " + idPadded + gutter + prio + gutter + chips + title + " (" + owner + ")\n"
+}
+
+func TestRenderRows_ColorOff(t *testing.T) {
+	r := newRowRendererFor(lipgloss.NewRenderer(&bytes.Buffer{}, termenv.WithProfile(termenv.Ascii)))
+
+	t.Run("open row with P1 and epic chip", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{
+			ID:       "abc1",
+			Title:    "fix the thing",
+			Owner:    "alice",
+			Priority: ptrInt64(1),
+			Status:   "open",
+			Labels:   []string{"epic"},
+		}}
+		require.NoError(t, r.renderRows(&buf, rows))
+		assert.Equal(t, row("○", "abc1", "• P1", "[epic] ", "fix the thing", "alice"), buf.String())
+	})
+
+	t.Run("blocked row", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{
+			ID:      "abc1",
+			Title:   "waiting on dep",
+			Owner:   "bob",
+			Status:  "open",
+			Blocked: true,
+		}}
+		require.NoError(t, r.renderRows(&buf, rows))
+		assert.Equal(t, row("●", "abc1", noPrio, "", "waiting on dep", "bob"), buf.String())
+	})
+
+	t.Run("closed row", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{
+			ID:     "abc1",
+			Title:  "done deal",
+			Owner:  "carol",
+			Status: "closed",
+		}}
+		require.NoError(t, r.renderRows(&buf, rows))
+		assert.Equal(t, row("✓", "abc1", noPrio, "", "done deal", "carol"), buf.String())
+	})
+
+	t.Run("closed but also blocked: closed glyph wins", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{
+			ID:      "abc1",
+			Title:   "done deal",
+			Owner:   "carol",
+			Status:  "closed",
+			Blocked: true,
+		}}
+		require.NoError(t, r.renderRows(&buf, rows))
+		assert.Equal(t, row("✓", "abc1", noPrio, "", "done deal", "carol"), buf.String())
+	})
+
+	t.Run("nil priority row", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{
+			ID:     "abc1",
+			Title:  "no priority",
+			Owner:  "dave",
+			Status: "open",
+		}}
+		require.NoError(t, r.renderRows(&buf, rows))
+		assert.Equal(t, row("○", "abc1", noPrio, "", "no priority", "dave"), buf.String())
+	})
+
+	t.Run("id width alignment across mixed-width ids", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{
+			{ID: "a1", Title: "short id", Owner: "eve", Status: "open"},
+			{ID: "abcdefgh", Title: "long id", Owner: "eve", Status: "open"},
+		}
+		require.NoError(t, r.renderRows(&buf, rows))
+		want := row("○", "a1"+strings.Repeat(" ", 6), noPrio, "", "short id", "eve") +
+			row("○", "abcdefgh", noPrio, "", "long id", "eve")
+		assert.Equal(t, want, buf.String())
+	})
+
+	t.Run("bug chip", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{
+			ID:     "abc1",
+			Title:  "crash on load",
+			Owner:  "eve",
+			Status: "open",
+			Labels: []string{"bug"},
+		}}
+		require.NoError(t, r.renderRows(&buf, rows))
+		assert.Equal(t, row("○", "abc1", noPrio, "[bug] ", "crash on load", "eve"), buf.String())
+	})
+
+	t.Run("epic and bug chips together, ordered, non-chip labels ignored", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{
+			ID:     "abc1",
+			Title:  "big scary thing",
+			Owner:  "eve",
+			Status: "open",
+			Labels: []string{"bug", "epic", "other"},
+		}}
+		require.NoError(t, r.renderRows(&buf, rows))
+		assert.Equal(t, row("○", "abc1", noPrio, "[epic] [bug] ", "big scary thing", "eve"), buf.String())
+	})
+
+	t.Run("p4 priority", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{
+			ID:       "abc1",
+			Title:    "low priority",
+			Owner:    "eve",
+			Priority: ptrInt64(4),
+			Status:   "open",
+		}}
+		require.NoError(t, r.renderRows(&buf, rows))
+		assert.Equal(t, row("○", "abc1", "• P4", "", "low priority", "eve"), buf.String())
+	})
+
+	t.Run("zero rows prints nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, r.renderRows(&buf, nil))
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("title newline is sanitized single-line", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{
+			ID:     "abc1",
+			Title:  "line one\nline two",
+			Owner:  "eve",
+			Status: "open",
+		}}
+		require.NoError(t, r.renderRows(&buf, rows))
+		assert.Equal(t, row("○", "abc1", noPrio, "", `line one\nline two`, "eve"), buf.String())
+	})
+}
+
+func TestRenderListFooter_ColorOff(t *testing.T) {
+	r := newRowRendererFor(lipgloss.NewRenderer(&bytes.Buffer{}, termenv.WithProfile(termenv.Ascii)))
+
+	const rule = "──────────────────────────────────────────────────"
+	const legend = "Status: ○ open  ● blocked  ✓ closed"
+
+	t.Run("mixed counts", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{
+			{ID: "a1", Status: "open"},
+			{ID: "a2", Status: "open", Blocked: true},
+			{ID: "a3", Status: "closed"},
+		}
+		require.NoError(t, r.renderListFooter(&buf, rows))
+		want := "\n" + rule + "\n" + "Total: 3 issues (1 open, 1 blocked, 1 closed)\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
+	})
+
+	t.Run("singular, all open", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{{ID: "a1", Status: "open"}}
+		require.NoError(t, r.renderListFooter(&buf, rows))
+		want := "\n" + rule + "\n" + "Total: 1 issue (1 open)\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
+	})
+
+	t.Run("no closed, no blocked clauses when zero", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{
+			{ID: "a1", Status: "open"},
+			{ID: "a2", Status: "closed"},
+		}
+		require.NoError(t, r.renderListFooter(&buf, rows))
+		want := "\n" + rule + "\n" + "Total: 2 issues (1 open, 1 closed)\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
+	})
+
+	t.Run("open+blocked counts as blocked only", func(t *testing.T) {
+		var buf bytes.Buffer
+		rows := []issueRow{
+			{ID: "a1", Status: "open", Blocked: true},
+		}
+		require.NoError(t, r.renderListFooter(&buf, rows))
+		want := "\n" + rule + "\n" + "Total: 1 issue (1 blocked)\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
+	})
+
+	t.Run("zero rows prints nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, r.renderListFooter(&buf, nil))
+		assert.Empty(t, buf.String())
+	})
+}
+
+func TestRenderReadyFooter_ColorOff(t *testing.T) {
+	r := newRowRendererFor(lipgloss.NewRenderer(&bytes.Buffer{}, termenv.WithProfile(termenv.Ascii)))
+
+	const rule = "──────────────────────────────────────────────────"
+	const legend = "Status: ○ open"
+
+	t.Run("plural", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, r.renderReadyFooter(&buf, 3))
+		want := "\n" + rule + "\n" + "Ready: 3 issues with no active blockers\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
+	})
+
+	t.Run("singular", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, r.renderReadyFooter(&buf, 1))
+		want := "\n" + rule + "\n" + "Ready: 1 issue with no active blockers\n" + "\n" + legend + "\n"
+		assert.Equal(t, want, buf.String())
+	})
+
+	t.Run("zero prints nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, r.renderReadyFooter(&buf, 0))
+		assert.Empty(t, buf.String())
+	})
+}
+
+// TestRenderRows_ColorOn pins the exact ANSI-containing output for one
+// representative row so regressions in the escape sequences are loud.
+// It also asserts that stripping the ANSI from the color-ON row yields
+// byte-identical output to the color-OFF rendering (layout invariance).
+func TestRenderRows_ColorOn(t *testing.T) {
+	lr := lipgloss.NewRenderer(&bytes.Buffer{})
+	lr.SetColorProfile(termenv.ANSI256)
+	r := newRowRendererFor(lr)
+
+	rows := []issueRow{{
+		ID:       "abc1",
+		Title:    "fix the thing",
+		Owner:    "alice",
+		Priority: ptrInt64(1),
+		Status:   "open",
+		Labels:   []string{"epic"},
+	}}
+	var buf bytes.Buffer
+	require.NoError(t, r.renderRows(&buf, rows))
+
+	const want = "○ \x1b[36mabc1\x1b[0m  \x1b[31m• P1\x1b[0m  \x1b[35m[epic]\x1b[0m " +
+		"fix the thing \x1b[2m(alice)\x1b[0m\n"
+	assert.Equal(t, want, buf.String())
+
+	off := newRowRendererFor(lipgloss.NewRenderer(&bytes.Buffer{}, termenv.WithProfile(termenv.Ascii)))
+	var offBuf bytes.Buffer
+	require.NoError(t, off.renderRows(&offBuf, rows))
+	assert.Equal(t, offBuf.String(), stripANSITest(buf.String()))
+}
+
+// TestRenderListFooter_ColorOn pins the rule's and legend's exact ANSI
+// output (both faint).
+func TestRenderListFooter_ColorOn(t *testing.T) {
+	lr := lipgloss.NewRenderer(&bytes.Buffer{})
+	lr.SetColorProfile(termenv.ANSI256)
+	r := newRowRendererFor(lr)
+
+	rows := []issueRow{{ID: "a1", Status: "open"}}
+	var buf bytes.Buffer
+	require.NoError(t, r.renderListFooter(&buf, rows))
+
+	const rule = "──────────────────────────────────────────────────"
+	want := "\n" +
+		"\x1b[2m" + rule + "\x1b[0m\n" +
+		"Total: 1 issue (1 open)\n" +
+		"\n" +
+		"\x1b[2mStatus: ○ open  ● blocked  ✓ closed\x1b[0m\n"
+	assert.Equal(t, want, buf.String())
+
+	off := newRowRendererFor(lipgloss.NewRenderer(&bytes.Buffer{}, termenv.WithProfile(termenv.Ascii)))
+	var offBuf bytes.Buffer
+	require.NoError(t, off.renderListFooter(&offBuf, rows))
+	assert.Equal(t, offBuf.String(), stripANSITest(buf.String()))
+}
+
+// TestRenderRows_WideGlyphID covers a row whose id contains wide glyphs
+// and confirms id-column alignment uses cell width, not len(), and does
+// not panic. "カタ1" is 5 cells wide (2 + 2 + 1).
+func TestRenderRows_WideGlyphID(t *testing.T) {
+	r := newRowRendererFor(lipgloss.NewRenderer(&bytes.Buffer{}, termenv.WithProfile(termenv.Ascii)))
+
+	rows := []issueRow{
+		{ID: "カタ1", Title: "wide id row", Owner: "eve", Status: "open"},
+		{ID: "a1", Title: "narrow id row", Owner: "eve", Status: "open"},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, r.renderRows(&buf, rows))
+
+	want := row("○", "カタ1", noPrio, "", "wide id row", "eve") +
+		row("○", "a1"+strings.Repeat(" ", 3), noPrio, "", "narrow id row", "eve")
+	assert.Equal(t, want, buf.String())
+}
+
+// TestRenderRows_WideGlyphTitle covers a wide-glyph title on a row
+// whose id is not the widest, confirming it renders without panicking
+// and doesn't perturb id-column alignment (the id column precedes the
+// title, so only id padding affects alignment).
+func TestRenderRows_WideGlyphTitle(t *testing.T) {
+	r := newRowRendererFor(lipgloss.NewRenderer(&bytes.Buffer{}, termenv.WithProfile(termenv.Ascii)))
+
+	rows := []issueRow{
+		{ID: "abcdefgh", Title: "long id row", Owner: "eve", Status: "open"},
+		{ID: "a1", Title: "カタ祭り", Owner: "eve", Status: "open"},
+	}
+	var buf bytes.Buffer
+	require.NotPanics(t, func() {
+		require.NoError(t, r.renderRows(&buf, rows))
+	})
+
+	want := row("○", "abcdefgh", noPrio, "", "long id row", "eve") +
+		row("○", "a1"+strings.Repeat(" ", 6), noPrio, "", "カタ祭り", "eve")
+	assert.Equal(t, want, buf.String())
+}
+
+func TestNewRowRenderer(t *testing.T) {
+	var buf bytes.Buffer
+	r := newRowRenderer(&buf)
+	require.NotNil(t, r)
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/mattn/go-runewidth v0.0.20
 	github.com/mattn/go-sqlite3 v1.14.47
+	github.com/muesli/termenv v0.16.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/posthog/posthog-go v1.12.6
 	github.com/spf13/cobra v1.10.2
@@ -106,7 +107,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -448,6 +448,11 @@ type IssueOut struct {
 	Blocks      []LinkPeer      `json:"blocks,omitempty"`
 	BlockedBy   []LinkPeer      `json:"blocked_by,omitempty"`
 	Related     []LinkPeer      `json:"related,omitempty"`
+	// Blocked reports whether this issue is actively blocked per the ready
+	// predicate: at least one open blocker in a non-archived project. It is
+	// server-computed display state, distinct from BlockedBy which carries
+	// the full (policy-free) set of blocker relationship edges.
+	Blocked bool `json:"blocked,omitempty"`
 }
 
 // ListIssuesResponse is the list payload. Plan 8 commit 5b: each row

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -753,12 +753,15 @@ type CreateLinkRequest struct {
 // LinkPeer identifies one endpoint of a link. Project and QualifiedID are
 // always populated (0.2.0): links may span projects, so a bare short_id
 // is ambiguous without them. ShortID stays bare — it never carries a
-// "project#" prefix.
+// "project#" prefix. Status carries the peer issue's own status (0.9.0)
+// so clients (e.g. `kata list` human output) can render a blocked glyph
+// without an extra per-peer lookup.
 type LinkPeer struct {
 	UID         string `json:"uid"`
 	ShortID     string `json:"short_id"`
 	Project     string `json:"project"`
 	QualifiedID string `json:"qualified_id"`
+	Status      string `json:"status"`
 }
 
 // LinkOut is the wire projection of a link with both endpoints rendered as

--- a/internal/api/types_test.go
+++ b/internal/api/types_test.go
@@ -106,6 +106,19 @@ func TestIssueOutUsesLinkPeerForParent(t *testing.T) {
 	assert.Equal(t, peerPtrType, f.Type, "IssueOut.Parent must be *LinkPeer")
 }
 
+// TestLinkPeerHasStatus pins that LinkPeer carries the peer issue's status
+// (0.9.0), so clients (e.g. `kata list` human output) can render a blocked
+// glyph without an extra lookup per blocked_by peer.
+func TestLinkPeerHasStatus(t *testing.T) {
+	typ := reflect.TypeOf(api.LinkPeer{})
+	f, ok := typ.FieldByName("Status")
+	if !ok {
+		t.Fatal("LinkPeer.Status missing")
+	}
+	assert.Equal(t, reflect.TypeOf(""), f.Type, "LinkPeer.Status must be string")
+	assert.Equal(t, "status", f.Tag.Get("json"), `LinkPeer.Status must be tagged json:"status"`)
+}
+
 // TestLinkOutUsesLinkPeer covers the wire projection of one link: from/to are
 // now structured peer objects rather than flat integer numbers, and the
 // project_id field is gone now that links are project-independent edges

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -987,6 +987,12 @@ func hydrateIssueOuts(ctx context.Context, store db.Storage, projectID int64, is
 	if err != nil {
 		return nil, err
 	}
+	// Blocked is server-computed display state (ready predicate), kept
+	// separate from the full blocked_by relationship hydration above.
+	activelyBlocked, err := store.ActivelyBlockedIssueIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
 	// Gather peer ids referenced by any relationship slice so we can resolve
 	// each to a fully-populated LinkPeer in one pass.
 	names := &projectNames{store: store, byID: map[int64]string{project.ID: project.Name}}
@@ -1003,6 +1009,7 @@ func hydrateIssueOuts(ctx context.Context, store db.Storage, projectID int64, is
 			Blocks:      peerSlice(peerCache, blocks[iss.ID]),
 			BlockedBy:   peerSlice(peerCache, blockedBy[iss.ID]),
 			Related:     peerSlice(peerCache, related[iss.ID]),
+			Blocked:     activelyBlocked[iss.ID],
 		}
 		if parentID, ok := parentNumbers[iss.ID]; ok {
 			if peer, ok := peerCache[parentID]; ok {

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -908,6 +908,7 @@ func linkPeerFor(ctx context.Context, names *projectNames, iss db.Issue) (api.Li
 		ShortID:     iss.ShortID,
 		Project:     project,
 		QualifiedID: qualifiedID(project, iss.ShortID),
+		Status:      iss.Status,
 	}, nil
 }
 

--- a/internal/daemon/handlers_issues_test.go
+++ b/internal/daemon/handlers_issues_test.go
@@ -2095,9 +2095,19 @@ func TestListIssues_BlockedFieldFollowsReadyPredicate(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Closed target with an open blocker → blocked must be false/omitted:
+	// "actively blocked" requires the target itself to be open, so closed
+	// rows never serialize blocked:true on all-status list responses (the
+	// unfiltered request below returns every status).
+	blockedClosed := createIssueViaHTTP(t, env, hubPID, "blocked-closed")
+	blockerOfClosed := createIssueViaHTTP(t, env, hubPID, "blocker-of-closed")
+	postLink(t, env, hubPID, blockerOfClosed, "blocks", blockedClosed)
+	closeIssueAs(t, env, hubPID, blockedClosed, "tester", "done")
+
 	blockedActiveShort := refForIssue(t, env, blockedActive)
 	blockedArchivedShort := refForIssue(t, env, blockedArchived)
 	blockerArchivedShort := refForIssue(t, env, blockerArchived)
+	blockedClosedShort := refForIssue(t, env, blockedClosed)
 
 	var out struct {
 		Issues []struct {
@@ -2128,6 +2138,12 @@ func TestListIssues_BlockedFieldFollowsReadyPredicate(t *testing.T) {
 		"archived-project blocker edge must still hydrate into blocked_by")
 	assert.Equal(t, blockerArchivedShort, archivedRow.blockedBy[0].ShortID,
 		"blocked_by must carry the archived-project peer (wire completeness)")
+
+	closedRow := byShort[blockedClosedShort]
+	assert.False(t, closedRow.blocked,
+		"closed issue with an open blocker must not serialize blocked:true")
+	require.Len(t, closedRow.blockedBy, 1,
+		"closed issue's blocker edge must still hydrate into blocked_by")
 }
 
 // TestListAllIssues_AcrossProjects pins #22's wire contract: GET /api/v1/issues

--- a/internal/daemon/handlers_issues_test.go
+++ b/internal/daemon/handlers_issues_test.go
@@ -2064,6 +2064,72 @@ func TestListIssues_BlockedByPeerCarriesStatus(t *testing.T) {
 	assert.Equal(t, "closed", byShort[blockedShort][0].Status)
 }
 
+// TestListIssues_BlockedFieldFollowsReadyPredicate pins the server-computed
+// `blocked` field: true when an issue has an open blocker in an active
+// project, false when the only blocker's project is archived — mirroring the
+// ready predicate. Crucially it also asserts wire completeness: the
+// archived-project blocker still appears in blocked_by (relationship
+// hydration is not display policy), so `kata show`/`kata list --json`
+// consumers see the full edge set even though the row reads as unblocked.
+func TestListIssues_BlockedFieldFollowsReadyPredicate(t *testing.T) {
+	env := testenv.New(t)
+	hubPID := initLocalWorkspace(t, env, "hub-project")
+	spokePID := mkProject(t, env, "", "spoke-project")
+
+	// Active blocker in the same project → blocked:true.
+	blockedActive := createIssueViaHTTP(t, env, hubPID, "blocked-active")
+	blockerActive := createIssueViaHTTP(t, env, hubPID, "blocker-active")
+	postLink(t, env, hubPID, blockerActive, "blocks", blockedActive)
+
+	// Blocker in a soon-to-be-archived project → blocked:false, but the edge
+	// must still hydrate into blocked_by.
+	blockedArchived := createIssueViaHTTP(t, env, hubPID, "blocked-archived")
+	blockerArchived := createIssueViaHTTP(t, env, spokePID, "blocker-archived")
+	_, err := env.DB.CreateLink(t.Context(), db.CreateLinkParams{
+		FromIssueID: blockerArchived, ToIssueID: blockedArchived,
+		Type: "blocks", Author: "tester",
+	})
+	require.NoError(t, err)
+	_, _, err = env.DB.RemoveProject(t.Context(), db.RemoveProjectParams{
+		ProjectID: spokePID, Actor: "tester", Force: true,
+	})
+	require.NoError(t, err)
+
+	blockedActiveShort := refForIssue(t, env, blockedActive)
+	blockedArchivedShort := refForIssue(t, env, blockedArchived)
+	blockerArchivedShort := refForIssue(t, env, blockerArchived)
+
+	var out struct {
+		Issues []struct {
+			ShortID   string         `json:"short_id"`
+			Blocked   bool           `json:"blocked"`
+			BlockedBy []linkPeerTest `json:"blocked_by,omitempty"`
+		} `json:"issues"`
+	}
+	envGetJSON(t, env, projectPath(hubPID)+"/issues", &out)
+	byShort := map[string]struct {
+		blocked   bool
+		blockedBy []linkPeerTest
+	}{}
+	for _, iss := range out.Issues {
+		byShort[iss.ShortID] = struct {
+			blocked   bool
+			blockedBy []linkPeerTest
+		}{iss.Blocked, iss.BlockedBy}
+	}
+
+	assert.True(t, byShort[blockedActiveShort].blocked,
+		"open blocker in an active project must set blocked:true")
+
+	archivedRow := byShort[blockedArchivedShort]
+	assert.False(t, archivedRow.blocked,
+		"blocker in an archived project must not set blocked (ready predicate)")
+	require.Len(t, archivedRow.blockedBy, 1,
+		"archived-project blocker edge must still hydrate into blocked_by")
+	assert.Equal(t, blockerArchivedShort, archivedRow.blockedBy[0].ShortID,
+		"blocked_by must carry the archived-project peer (wire completeness)")
+}
+
 // TestListAllIssues_AcrossProjects pins #22's wire contract: GET /api/v1/issues
 // with no project_id returns issues from every project, hydrating labels
 // per-issue across project boundaries.

--- a/internal/daemon/handlers_issues_test.go
+++ b/internal/daemon/handlers_issues_test.go
@@ -1988,6 +1988,47 @@ func TestListIssues_IncludesBlockerMetadata(t *testing.T) {
 	assert.Empty(t, byShort[blockedShort])
 }
 
+// TestListIssues_BlockedByPeerCarriesStatus pins that a list response's
+// blocked_by LinkPeer entries carry the blocker issue's own status (0.9.0),
+// so `kata list` human output can render a blocked glyph without a
+// per-peer lookup. Status must reflect the blocker's current state: open
+// while unresolved, closed once the blocker is closed.
+func TestListIssues_BlockedByPeerCarriesStatus(t *testing.T) {
+	env := testenv.New(t)
+	pid := initLocalWorkspace(t, env, "kata")
+	blocker := createIssueViaHTTP(t, env, pid, "blocker")
+	blocked := createIssueViaHTTP(t, env, pid, "blocked")
+	postLink(t, env, pid, blocker, "blocks", blocked)
+	blockerShort := refForIssue(t, env, blocker)
+	blockedShort := refForIssue(t, env, blocked)
+
+	fetchBlockedBy := func() map[string][]linkPeerTest {
+		var out struct {
+			Issues []struct {
+				ShortID   string         `json:"short_id"`
+				BlockedBy []linkPeerTest `json:"blocked_by,omitempty"`
+			} `json:"issues"`
+		}
+		envGetJSON(t, env, projectPath(pid)+"/issues", &out)
+		byShort := map[string][]linkPeerTest{}
+		for _, iss := range out.Issues {
+			byShort[iss.ShortID] = iss.BlockedBy
+		}
+		return byShort
+	}
+
+	byShort := fetchBlockedBy()
+	require.Len(t, byShort[blockedShort], 1)
+	assert.Equal(t, blockerShort, byShort[blockedShort][0].ShortID)
+	assert.Equal(t, "open", byShort[blockedShort][0].Status)
+
+	closeIssueAs(t, env, pid, blocker, "tester", "done")
+
+	byShort = fetchBlockedBy()
+	require.Len(t, byShort[blockedShort], 1)
+	assert.Equal(t, "closed", byShort[blockedShort][0].Status)
+}
+
 // TestListAllIssues_AcrossProjects pins #22's wire contract: GET /api/v1/issues
 // with no project_id returns issues from every project, hydrating labels
 // per-issue across project boundaries.

--- a/internal/daemon/handlers_issues_test.go
+++ b/internal/daemon/handlers_issues_test.go
@@ -424,6 +424,41 @@ func TestEditIssue_LinksDelta_AddBlocks(t *testing.T) {
 	assert.Equal(t, target, show.Links[0].To.ShortID)
 }
 
+// TestEditIssue_LinksDelta_PeerCarriesStatus pins that edit-delta LinkPeer
+// entries carry the peer issue's own status (0.9.0), matching the list
+// response's LinkPeer contract — the wire schema marks status required, so
+// edit responses must not serialize an empty string.
+func TestEditIssue_LinksDelta_PeerCarriesStatus(t *testing.T) {
+	_, ts, pid, src := bootstrapProjectWithIssue(t)
+	resp, bs := postJSON(t, ts, issuesURL(pid),
+		map[string]any{"actor": "tester", "title": "blocked target"})
+	require.Equal(t, 200, resp.StatusCode)
+	var created struct {
+		Issue struct {
+			ShortID string `json:"short_id"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &created))
+	target := created.Issue.ShortID
+
+	resp, bs = patchJSON(t, ts, issueURL(pid, src, ""), map[string]any{
+		"actor": "tester",
+		"links_delta": map[string]any{
+			"add_blocks": []string{target},
+		},
+	})
+	require.Equalf(t, 200, resp.StatusCode, "patch: %s", string(bs))
+
+	var out struct {
+		Changes struct {
+			BlocksAdded []linkPeerTest `json:"blocks_added"`
+		} `json:"changes"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &out))
+	require.Len(t, out.Changes.BlocksAdded, 1)
+	assert.Equal(t, "open", out.Changes.BlocksAdded[0].Status)
+}
+
 // TestEditIssue_LinksDelta_AddBlockedBy verifies the inverse-direction add:
 // `add_blocked_by: [N]` on URL issue X stores a `blocks` link from N to X
 // (i.e. N blocks X). The Changes block reports it under blocked_by_added.

--- a/internal/daemon/resolver.go
+++ b/internal/daemon/resolver.go
@@ -333,8 +333,8 @@ func fillLinksDeltaParams(ctx context.Context, store db.Storage, projectID int64
 }
 
 // buildLinkChanges projects db.AtomicEditChanges into the wire-facing
-// api.LinkChanges. PeerIdentity carries the project name captured in-tx,
-// so no storage lookup is required.
+// api.LinkChanges. PeerIdentity carries the project name and peer status
+// captured in-tx, so no storage lookup is required.
 func buildLinkChanges(changes db.AtomicEditChanges) *api.LinkChanges {
 	peer := func(p db.PeerIdentity) api.LinkPeer {
 		return api.LinkPeer{
@@ -342,6 +342,7 @@ func buildLinkChanges(changes db.AtomicEditChanges) *api.LinkChanges {
 			ShortID:     p.ShortID,
 			Project:     p.Project,
 			QualifiedID: qualifiedID(p.Project, p.ShortID),
+			Status:      p.Status,
 		}
 	}
 	peers := func(ps []db.PeerIdentity) []api.LinkPeer {

--- a/internal/daemon/testhelpers_test.go
+++ b/internal/daemon/testhelpers_test.go
@@ -105,6 +105,7 @@ type linkPeerTest struct {
 	ShortID     string `json:"short_id"`
 	Project     string `json:"project"`
 	QualifiedID string `json:"qualified_id"`
+	Status      string `json:"status"`
 }
 
 // issueShortIDFromCreate decodes the short_id field from a /issues POST

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -251,10 +251,14 @@ type EditIssueAtomicParams struct {
 // the mutating transaction: display ref, canonical pointer, and the
 // peer's project at mutation time (links span projects since storage
 // v16, so a bare short_id no longer identifies a peer unambiguously).
+// Status is the peer issue's own status at mutation time, so edit-delta
+// wire responses can populate api.LinkPeer.Status (required, 0.9.0)
+// without a post-transaction lookup.
 type PeerIdentity struct {
 	ShortID string
 	UID     string
 	Project string
+	Status  string
 }
 
 // AtomicEditChanges describes which link mutations actually applied.

--- a/internal/db/pgstore/stubs_gen.go
+++ b/internal/db/pgstore/stubs_gen.go
@@ -46,6 +46,10 @@ func (s *Store) ActiveFederationQuarantinesByProject(_ context.Context, _ int64)
 	return nil, ErrNotImplementedPhase3
 }
 
+func (s *Store) ActivelyBlockedIssueIDs(_ context.Context, _ []int64) (map[int64]bool, error) {
+	return nil, ErrNotImplementedPhase3
+}
+
 func (s *Store) AddLabel(_ context.Context, _ int64, _ string, _ string) (db.IssueLabel, error) {
 	return db.IssueLabel{}, ErrNotImplementedPhase3
 }

--- a/internal/db/sqlitestore/queries_edit_atomic.go
+++ b/internal/db/sqlitestore/queries_edit_atomic.go
@@ -470,9 +470,9 @@ func (d *Store) applyLinksDeltaTx(ctx context.Context, tx *sql.Tx, issue db.Issu
 func peerIdentityTx(ctx context.Context, tx *sql.Tx, issueID int64) (db.PeerIdentity, error) {
 	var p db.PeerIdentity
 	err := tx.QueryRowContext(ctx, `
-		SELECT i.short_id, i.uid, pr.name
+		SELECT i.short_id, i.uid, pr.name, i.status
 		  FROM issues i JOIN projects pr ON pr.id = i.project_id
-		 WHERE i.id = ?`, issueID).Scan(&p.ShortID, &p.UID, &p.Project)
+		 WHERE i.id = ?`, issueID).Scan(&p.ShortID, &p.UID, &p.Project, &p.Status)
 	if errors.Is(err, sql.ErrNoRows) {
 		return db.PeerIdentity{}, fmt.Errorf("peer identity for issue %d: %w", issueID, db.ErrNotFound)
 	}

--- a/internal/db/sqlitestore/queries_links.go
+++ b/internal/db/sqlitestore/queries_links.go
@@ -269,12 +269,16 @@ func (d *Store) appendBlockNumbersForChunk(
 	return nil
 }
 
-// BlockedByNumbersByIssues returns issue ID -> issue numbers that block
-// that issue. Inverse of BlockNumbersByIssues: for each issue X, the
+// BlockedByNumbersByIssues returns issue ID -> issue numbers that actively
+// block that issue. Inverse of BlockNumbersByIssues: for each issue X, the
 // returned numbers are the issues whose outgoing `blocks` link points
 // at X. Used by `kata list --json` to surface every relationship type
 // per row, not just outgoing blocks. Links are project-independent edges
-// (storage v16), so a blocker in another project is still returned.
+// (storage v16), so a blocker in another project is still returned — but
+// only carries ACTIVE blockers: a blocker whose project is archived
+// (projects.deleted_at IS NOT NULL) is excluded, mirroring ReadyIssues'
+// active-blocker predicate so `kata list` and `kata ready` agree on
+// whether an issue is actually blocked.
 func (d *Store) BlockedByNumbersByIssues(
 	ctx context.Context, issueIDs []int64,
 ) (map[int64][]int64, error) {
@@ -302,8 +306,10 @@ func (d *Store) appendBlockedByNumbersForChunk(
 	          FROM links l
 	          JOIN issues blocker ON blocker.id = l.from_issue_id
 	          JOIN issues blocked ON blocked.id = l.to_issue_id
+	          JOIN projects bp ON bp.id = blocker.project_id
 	          WHERE l.type = 'blocks'
 	            AND blocker.deleted_at IS NULL
+	            AND bp.deleted_at IS NULL
 	            AND l.to_issue_id IN (` + placeholders + `)
 	          ORDER BY l.to_issue_id ASC, blocker.id ASC`
 	rows, err := d.QueryContext(ctx, query, args...)

--- a/internal/db/sqlitestore/queries_links.go
+++ b/internal/db/sqlitestore/queries_links.go
@@ -269,16 +269,17 @@ func (d *Store) appendBlockNumbersForChunk(
 	return nil
 }
 
-// BlockedByNumbersByIssues returns issue ID -> issue numbers that actively
-// block that issue. Inverse of BlockNumbersByIssues: for each issue X, the
+// BlockedByNumbersByIssues returns issue ID -> issue numbers that block
+// that issue. Inverse of BlockNumbersByIssues: for each issue X, the
 // returned numbers are the issues whose outgoing `blocks` link points
 // at X. Used by `kata list --json` to surface every relationship type
 // per row, not just outgoing blocks. Links are project-independent edges
-// (storage v16), so a blocker in another project is still returned — but
-// only carries ACTIVE blockers: a blocker whose project is archived
-// (projects.deleted_at IS NOT NULL) is excluded, mirroring ReadyIssues'
-// active-blocker predicate so `kata list` and `kata ready` agree on
-// whether an issue is actually blocked.
+// (storage v16), so this carries the FULL relationship set: a blocker in
+// another project — including one whose project is archived
+// (projects.deleted_at IS NOT NULL) — is still returned, because this is
+// relationship hydration, not display policy. Whether an issue is
+// "actively blocked" for display is a separate concern computed by
+// ActivelyBlockedIssueIDs, which mirrors the ready predicate.
 func (d *Store) BlockedByNumbersByIssues(
 	ctx context.Context, issueIDs []int64,
 ) (map[int64][]int64, error) {
@@ -306,10 +307,8 @@ func (d *Store) appendBlockedByNumbersForChunk(
 	          FROM links l
 	          JOIN issues blocker ON blocker.id = l.from_issue_id
 	          JOIN issues blocked ON blocked.id = l.to_issue_id
-	          JOIN projects bp ON bp.id = blocker.project_id
 	          WHERE l.type = 'blocks'
 	            AND blocker.deleted_at IS NULL
-	            AND bp.deleted_at IS NULL
 	            AND l.to_issue_id IN (` + placeholders + `)
 	          ORDER BY l.to_issue_id ASC, blocker.id ASC`
 	rows, err := d.QueryContext(ctx, query, args...)
@@ -323,6 +322,65 @@ func (d *Store) appendBlockedByNumbersForChunk(
 			return fmt.Errorf("scan blocked-by numbers by issues: %w", err)
 		}
 		out[blockedID] = append(out[blockedID], blockerNumber)
+	}
+	return rows.Err()
+}
+
+// ActivelyBlockedIssueIDs returns issue ID -> true for each input issue that
+// has at least one ACTIVE incoming `blocks` blocker, mirroring the ReadyIssues
+// predicate exactly: the blocker issue must be open, not soft-deleted, and its
+// project must not be archived (projects.deleted_at IS NULL). Issues with no
+// active blocker are absent from the map (callers treat absence as false). This
+// is the display-policy counterpart to BlockedByNumbersByIssues (which carries
+// the full relationship set): `kata list` renders the blocked glyph from this
+// so it agrees with `kata ready`. Chunks its inputs like the sibling
+// relationship queries.
+func (d *Store) ActivelyBlockedIssueIDs(
+	ctx context.Context, issueIDs []int64,
+) (map[int64]bool, error) {
+	out := map[int64]bool{}
+	if len(issueIDs) == 0 {
+		return out, nil
+	}
+	for i := 0; i < len(issueIDs); i += relationshipChunkSize {
+		end := i + relationshipChunkSize
+		if end > len(issueIDs) {
+			end = len(issueIDs)
+		}
+		if err := d.appendActivelyBlockedForChunk(ctx, issueIDs[i:end], out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (d *Store) appendActivelyBlockedForChunk(
+	ctx context.Context, chunk []int64, out map[int64]bool,
+) error {
+	placeholders, args := relationshipChunkPlaceholders(chunk)
+	// Mirrors the ReadyIssues NOT EXISTS predicate: a row is actively blocked
+	// iff an incoming `blocks` link has an open, live blocker in a non-archived
+	// project. DISTINCT collapses multiple qualifying blockers to one row.
+	query := `SELECT DISTINCT l.to_issue_id
+	          FROM links l
+	          JOIN issues blocker ON blocker.id = l.from_issue_id
+	          JOIN projects bp ON bp.id = blocker.project_id
+	          WHERE l.type = 'blocks'
+	            AND blocker.status = 'open'
+	            AND blocker.deleted_at IS NULL
+	            AND bp.deleted_at IS NULL
+	            AND l.to_issue_id IN (` + placeholders + `)`
+	rows, err := d.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("actively blocked issue ids: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var blockedID int64
+		if err := rows.Scan(&blockedID); err != nil {
+			return fmt.Errorf("scan actively blocked issue ids: %w", err)
+		}
+		out[blockedID] = true
 	}
 	return rows.Err()
 }

--- a/internal/db/sqlitestore/queries_links.go
+++ b/internal/db/sqlitestore/queries_links.go
@@ -327,12 +327,15 @@ func (d *Store) appendBlockedByNumbersForChunk(
 }
 
 // ActivelyBlockedIssueIDs returns issue ID -> true for each input issue that
-// has at least one ACTIVE incoming `blocks` blocker, mirroring the ReadyIssues
-// predicate exactly: the blocker issue must be open, not soft-deleted, and its
-// project must not be archived (projects.deleted_at IS NULL). Issues with no
-// active blocker are absent from the map (callers treat absence as false). This
-// is the display-policy counterpart to BlockedByNumbersByIssues (which carries
-// the full relationship set): `kata list` renders the blocked glyph from this
+// is actively blocked, mirroring the ReadyIssues predicate on both sides:
+// the TARGET issue must itself be open and not soft-deleted, and at least
+// one incoming `blocks` blocker must be open, not soft-deleted, and in a
+// non-archived project (projects.deleted_at IS NULL). A closed target is
+// never actively blocked, even with an open blocker — blocked is actionable
+// display state, not relationship data. Issues not actively blocked are
+// absent from the map (callers treat absence as false). This is the
+// display-policy counterpart to BlockedByNumbersByIssues (which carries the
+// full relationship set): `kata list` renders the blocked glyph from this
 // so it agrees with `kata ready`. Chunks its inputs like the sibling
 // relationship queries.
 func (d *Store) ActivelyBlockedIssueIDs(
@@ -358,14 +361,18 @@ func (d *Store) appendActivelyBlockedForChunk(
 	ctx context.Context, chunk []int64, out map[int64]bool,
 ) error {
 	placeholders, args := relationshipChunkPlaceholders(chunk)
-	// Mirrors the ReadyIssues NOT EXISTS predicate: a row is actively blocked
-	// iff an incoming `blocks` link has an open, live blocker in a non-archived
-	// project. DISTINCT collapses multiple qualifying blockers to one row.
+	// Mirrors the ReadyIssues predicate on both sides: the target row must be
+	// an open, live issue, and an incoming `blocks` link must carry an open,
+	// live blocker in a non-archived project. DISTINCT collapses multiple
+	// qualifying blockers to one row.
 	query := `SELECT DISTINCT l.to_issue_id
 	          FROM links l
+	          JOIN issues blocked ON blocked.id = l.to_issue_id
 	          JOIN issues blocker ON blocker.id = l.from_issue_id
 	          JOIN projects bp ON bp.id = blocker.project_id
 	          WHERE l.type = 'blocks'
+	            AND blocked.status = 'open'
+	            AND blocked.deleted_at IS NULL
 	            AND blocker.status = 'open'
 	            AND blocker.deleted_at IS NULL
 	            AND bp.deleted_at IS NULL

--- a/internal/db/sqlitestore/queries_links_test.go
+++ b/internal/db/sqlitestore/queries_links_test.go
@@ -469,12 +469,13 @@ func TestChildCountsByParents_ExcludesArchivedProjectChildren(t *testing.T) {
 		"archived-project child must not count toward open or total")
 }
 
-// TestBlockedByNumbersByIssues_IgnoresBlockerInArchivedProject: an open
-// blocker whose project is archived must not appear in blocked_by hydration,
-// mirroring ReadyIssues' archived-project exclusion (storage v16 links
-// survive project archival, so without this join a hidden archived blocker
-// would still render the downstream issue as blocked in `kata list`).
-func TestBlockedByNumbersByIssues_IgnoresBlockerInArchivedProject(t *testing.T) {
+// TestBlockedByNumbersByIssues_IncludesBlockerInArchivedProject pins that
+// blocked_by hydration carries the FULL relationship set: a blocker whose
+// project is archived is still returned, because this is relationship data on
+// the wire, not display policy. `kata show` exposes the same link via
+// LinksByIssue, so `kata list --json` must not silently drop it. "Actively
+// blocked" display state is a separate concern (ActivelyBlockedIssueIDs).
+func TestBlockedByNumbersByIssues_IncludesBlockerInArchivedProject(t *testing.T) {
 	d, ctx, p1 := setupTestProject(t)
 	p2, err := d.CreateProject(ctx, "blocker-project")
 	require.NoError(t, err)
@@ -485,6 +486,43 @@ func TestBlockedByNumbersByIssues_IgnoresBlockerInArchivedProject(t *testing.T) 
 
 	got, err := d.BlockedByNumbersByIssues(ctx, []int64{blocked.ID})
 	require.NoError(t, err)
-	assert.NotContains(t, got[blocked.ID], blocker.ID,
-		"blocker in an archived project must not count as an active blocker")
+	assert.Contains(t, got[blocked.ID], blocker.ID,
+		"archived-project blocker is still a relationship edge and must hydrate")
+}
+
+// TestActivelyBlockedIssueIDs pins the display-policy predicate that mirrors
+// ReadyIssues: true iff an incoming blocker is open, live, and in a
+// non-archived project. Closed blockers, archived-project blockers, and issues
+// with no blocker are all not actively blocked (absent from the map).
+func TestActivelyBlockedIssueIDs(t *testing.T) {
+	d, ctx, p1 := setupTestProject(t)
+	p2, err := d.CreateProject(ctx, "blocker-project")
+	require.NoError(t, err)
+
+	openBlocked := makeIssue(t, ctx, d, p1.ID, "open-blocked", "tester")
+	openBlocker := makeIssue(t, ctx, d, p1.ID, "open-blocker", "tester")
+	makeLink(ctx, t, d, openBlocker.ID, openBlocked.ID, "blocks")
+
+	closedBlocked := makeIssue(t, ctx, d, p1.ID, "closed-blocked", "tester")
+	closedBlocker := makeIssue(t, ctx, d, p1.ID, "closed-blocker", "tester")
+	makeLink(ctx, t, d, closedBlocker.ID, closedBlocked.ID, "blocks")
+	_, _, _, err = d.CloseIssue(ctx, closedBlocker.ID, "done", "tester", "", nil)
+	require.NoError(t, err)
+
+	archivedBlocked := makeIssue(t, ctx, d, p1.ID, "archived-blocked", "tester")
+	archivedBlocker := makeIssue(t, ctx, d, p2.ID, "archived-blocker", "tester")
+	makeLink(ctx, t, d, archivedBlocker.ID, archivedBlocked.ID, "blocks")
+	archiveProjectByID(ctx, t, d, p2.ID)
+
+	unblocked := makeIssue(t, ctx, d, p1.ID, "unblocked", "tester")
+
+	got, err := d.ActivelyBlockedIssueIDs(ctx, []int64{
+		openBlocked.ID, closedBlocked.ID, archivedBlocked.ID, unblocked.ID,
+	})
+	require.NoError(t, err)
+	assert.True(t, got[openBlocked.ID], "open blocker must mark issue actively blocked")
+	assert.False(t, got[closedBlocked.ID], "closed blocker must not mark issue blocked")
+	assert.False(t, got[archivedBlocked.ID],
+		"blocker in an archived project must not mark issue blocked")
+	assert.False(t, got[unblocked.ID], "issue with no blocker must not be blocked")
 }

--- a/internal/db/sqlitestore/queries_links_test.go
+++ b/internal/db/sqlitestore/queries_links_test.go
@@ -491,9 +491,10 @@ func TestBlockedByNumbersByIssues_IncludesBlockerInArchivedProject(t *testing.T)
 }
 
 // TestActivelyBlockedIssueIDs pins the display-policy predicate that mirrors
-// ReadyIssues: true iff an incoming blocker is open, live, and in a
-// non-archived project. Closed blockers, archived-project blockers, and issues
-// with no blocker are all not actively blocked (absent from the map).
+// ReadyIssues: true iff the target issue is itself open and live AND an
+// incoming blocker is open, live, and in a non-archived project. Closed
+// blockers, archived-project blockers, issues with no blocker, and closed
+// target issues are all not actively blocked (absent from the map).
 func TestActivelyBlockedIssueIDs(t *testing.T) {
 	d, ctx, p1 := setupTestProject(t)
 	p2, err := d.CreateProject(ctx, "blocker-project")
@@ -516,8 +517,19 @@ func TestActivelyBlockedIssueIDs(t *testing.T) {
 
 	unblocked := makeIssue(t, ctx, d, p1.ID, "unblocked", "tester")
 
+	// A CLOSED target with an open blocker is not actively blocked: the
+	// predicate is two-sided (target must itself be open, mirroring the
+	// blocked-side conditions of the ready predicate), so closed rows never
+	// serialize blocked:true on status=closed|all list responses.
+	closedTarget := makeIssue(t, ctx, d, p1.ID, "closed-target", "tester")
+	closedTargetBlocker := makeIssue(t, ctx, d, p1.ID, "closed-target-blocker", "tester")
+	makeLink(ctx, t, d, closedTargetBlocker.ID, closedTarget.ID, "blocks")
+	_, _, _, err = d.CloseIssue(ctx, closedTarget.ID, "done", "tester", "", nil)
+	require.NoError(t, err)
+
 	got, err := d.ActivelyBlockedIssueIDs(ctx, []int64{
 		openBlocked.ID, closedBlocked.ID, archivedBlocked.ID, unblocked.ID,
+		closedTarget.ID,
 	})
 	require.NoError(t, err)
 	assert.True(t, got[openBlocked.ID], "open blocker must mark issue actively blocked")
@@ -525,4 +537,6 @@ func TestActivelyBlockedIssueIDs(t *testing.T) {
 	assert.False(t, got[archivedBlocked.ID],
 		"blocker in an archived project must not mark issue blocked")
 	assert.False(t, got[unblocked.ID], "issue with no blocker must not be blocked")
+	assert.False(t, got[closedTarget.ID],
+		"closed target with an open blocker must not be actively blocked")
 }

--- a/internal/db/sqlitestore/queries_links_test.go
+++ b/internal/db/sqlitestore/queries_links_test.go
@@ -468,3 +468,23 @@ func TestChildCountsByParents_ExcludesArchivedProjectChildren(t *testing.T) {
 	assert.Equal(t, db.ChildCounts{Open: 1, Total: 1}, got[parent.ID],
 		"archived-project child must not count toward open or total")
 }
+
+// TestBlockedByNumbersByIssues_IgnoresBlockerInArchivedProject: an open
+// blocker whose project is archived must not appear in blocked_by hydration,
+// mirroring ReadyIssues' archived-project exclusion (storage v16 links
+// survive project archival, so without this join a hidden archived blocker
+// would still render the downstream issue as blocked in `kata list`).
+func TestBlockedByNumbersByIssues_IgnoresBlockerInArchivedProject(t *testing.T) {
+	d, ctx, p1 := setupTestProject(t)
+	p2, err := d.CreateProject(ctx, "blocker-project")
+	require.NoError(t, err)
+	blocked := makeIssue(t, ctx, d, p1.ID, "blocked", "tester")
+	blocker := makeIssue(t, ctx, d, p2.ID, "blocker", "tester")
+	makeLink(ctx, t, d, blocker.ID, blocked.ID, "blocks")
+	archiveProjectByID(ctx, t, d, p2.ID)
+
+	got, err := d.BlockedByNumbersByIssues(ctx, []int64{blocked.ID})
+	require.NoError(t, err)
+	assert.NotContains(t, got[blocked.ID], blocker.ID,
+		"blocker in an archived project must not count as an active blocker")
+}

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -120,6 +120,7 @@ type Storage interface {
 	ParentShortIDsByIssues(ctx context.Context, issueIDs []int64) (map[int64]string, error)
 	BlockNumbersByIssues(ctx context.Context, issueIDs []int64) (map[int64][]int64, error)
 	BlockedByNumbersByIssues(ctx context.Context, issueIDs []int64) (map[int64][]int64, error)
+	ActivelyBlockedIssueIDs(ctx context.Context, issueIDs []int64) (map[int64]bool, error)
 	RelatedNumbersByIssues(ctx context.Context, issueIDs []int64) (map[int64][]int64, error)
 
 	// recurrences

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -1971,6 +1971,7 @@ type LinkPeer struct {
 	Project     string `json:"project" validate:"required"`
 	QualifiedID string `json:"qualified_id" validate:"required"`
 	ShortID     string `json:"short_id" validate:"required"`
+	Status      string `json:"status" validate:"required"`
 	UID         string `json:"uid" validate:"required"`
 }
 

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -1623,6 +1623,7 @@ func (i IssueLabel) Validate() error {
 
 type IssueOut struct {
 	Author        string         `json:"author" validate:"required"`
+	Blocked       *bool          `json:"blocked,omitempty"`
 	BlockedBy     []LinkPeer     `json:"blocked_by,omitempty"`
 	Blocks        []LinkPeer     `json:"blocks,omitempty"`
 	Body          string         `json:"body" validate:"required"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -1686,6 +1686,8 @@ components:
       properties:
         author:
           type: string
+        blocked:
+          type: boolean
         blocked_by:
           items:
             $ref: "#/components/schemas/LinkPeer"

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2016,6 +2016,8 @@ components:
           type: string
         short_id:
           type: string
+        status:
+          type: string
         uid:
           type: string
       required:
@@ -2023,6 +2025,7 @@ components:
         - short_id
         - project
         - qualified_id
+        - status
       type: object
     LinksDelta:
       additionalProperties: false


### PR DESCRIPTION
Polishes the human-mode output of `kata list` and `kata ready` with status
glyphs, colored priority chips, label tags, and a summary footer — closes the
gap with comparable issue-tracker CLIs. Implements `kata#4ymf` (child of epic
`kata#mdq8`).

## Screenshots

### `kata list --status all` (before/after)

**before**:

<img width="2627" height="736" alt="before-list" src="https://github.com/user-attachments/assets/cb1296d6-2ba8-4eb4-a813-92cd02074571" />

**after**:

<img width="2627" height="1072" alt="after-list" src="https://github.com/user-attachments/assets/0281d5ca-d69a-4b88-a23f-04bbc7ca001f" />

### `kata ready`

<img width="2194" height="872" alt="after-ready" src="https://github.com/user-attachments/assets/ab6cb4b7-6aa9-410a-9f19-6e8264c3e4a1" />

Truncated listings switch to non-totalizing wording (`kata list --limit 3`):

<img width="2627" height="872" alt="after-truncated" src="https://github.com/user-attachments/assets/c460d4ee-8493-48c5-ad2c-43f74fbc5505" />

## What changed

- **New shared renderer** (`cmd/kata/render.go`): status glyphs (`○` open,
  `●` blocked, `✓` closed), `• P0`–`P4` priority chips with severity-graded
  colors, `[epic]`/`[bug]` label tags, id column padded by display width,
  faint `(owner)` suffix, and a footer (rule + count summary + glyph legend).
  Color renders only on TTY writers and honors `NO_COLOR`; pipes get the
  identical layout with zero ANSI. All strings pass through `textsafe.Line`.
- **`kata list`**: human rows render through the shared renderer; the blocked
  glyph derives from having at least one open blocker. Footer is suppressed
  under `--quiet` and on empty results; the stderr truncation hint is
  unchanged. When row count hits `--limit`, the summary reads `Showing: N
  issues (...)` instead of `Total:` so a partial listing never masquerades as
  a total.
- **`kata ready`** (project-scoped and `--all`): same treatment, flat rows,
  `Ready: N issues with no active blockers` summary with the same
  truncation-aware wording; `--all` rows show qualified `project#short_id`
  ids and now parse `priority` from the payload.
- **API: `LinkPeer` gains `status`** (additive) so clients can derive blocked
  state from `blocked_by` peers. Populated by every producer, including
  edit-delta responses via a new `Status` field on `db.PeerIdentity`, so the
  OpenAPI `required` marker is truthful.
- **Contract fix:** `kata --agent ready --all` previously fell through to
  human-formatted rows; it now emits the structured `OK ready count=N` kv
  format matching the project-scoped agent path, pinned by tests.

`--agent` and `--json` output is otherwise byte-identical; the only wire
delta is the additive `status` field on link peers
