### PR TITLE
Hydrate ready responses to IssueOut so ready rows carry labels

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2949,13 +2949,29 @@ components:
         - kind
         - other_uid
       type: object
-    ReadyGlobalIssue:
+    ReadyGlobalIssueOut:
       additionalProperties: true
       properties:
         author:
           type: string
+        blocked:
+          type: boolean
+        blocked_by:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        blocks:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
         body:
           type: string
+        child_counts:
+          $ref: "#/components/schemas/ChildCounts"
         closed_at:
           format: date-time
           type: string
@@ -2970,6 +2986,12 @@ components:
         id:
           format: int64
           type: integer
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
         metadata:
           additionalProperties: true
           type: object
@@ -2977,6 +2999,8 @@ components:
           type: string
         owner:
           type: string
+        parent:
+          $ref: "#/components/schemas/LinkPeer"
         priority:
           format: int64
           type: integer
@@ -2987,9 +3011,17 @@ components:
           type: string
         project_uid:
           type: string
+        qualified_id:
+          type: string
         recurrence_id:
           format: int64
           type: integer
+        related:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
         revision:
           format: int64
           type: integer
@@ -3006,6 +3038,7 @@ components:
           type: string
       required:
         - project_name
+        - qualified_id
         - id
         - uid
         - project_id
@@ -3024,7 +3057,7 @@ components:
       properties:
         issues:
           items:
-            $ref: "#/components/schemas/ReadyGlobalIssue"
+            $ref: "#/components/schemas/ReadyGlobalIssueOut"
           type:
             - array
             - "null"
@@ -3036,7 +3069,7 @@ components:
       properties:
         issues:
           items:
-            $ref: "#/components/schemas/Issue"
+            $ref: "#/components/schemas/IssueOut"
           type:
             - array
             - "null"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3530,7 +3530,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.5.0
+  version: 0.6.0
 openapi: 3.1.0
 paths:
   /api/v1/audit/closes:

--- a/cmd/kata/ready.go
+++ b/cmd/kata/ready.go
@@ -51,6 +51,9 @@ func newReadyCmd() *cobra.Command {
 							agentRowIntField("priority", i.Priority),
 							agentOptionalRowField("owner", i.Owner),
 							agentRowField("title", i.Title),
+							// Appended last: agent field order is a
+							// stability contract; new fields go at the end.
+							agentRowListField("labels", i.Labels),
 						); err != nil {
 							return err
 						}
@@ -69,6 +72,7 @@ func newReadyCmd() *cobra.Command {
 						Owner:    owner,
 						Priority: i.Priority,
 						Status:   "open",
+						Labels:   i.Labels,
 					}
 				}
 				renderer := newRowRenderer(cmd.OutOrStdout())
@@ -97,6 +101,9 @@ func newReadyCmd() *cobra.Command {
 						agentRowIntField("priority", i.Priority),
 						agentOptionalRowField("owner", i.Owner),
 						agentRowField("title", i.Title),
+						// Appended last: agent field order is a
+						// stability contract; new fields go at the end.
+						agentRowListField("labels", i.Labels),
 					); err != nil {
 						return err
 					}
@@ -115,6 +122,7 @@ func newReadyCmd() *cobra.Command {
 					Owner:    ownerStr,
 					Priority: i.Priority,
 					Status:   "open",
+					Labels:   i.Labels,
 				}
 			}
 			renderer := newRowRenderer(cmd.OutOrStdout())

--- a/cmd/kata/ready_client.go
+++ b/cmd/kata/ready_client.go
@@ -19,6 +19,7 @@ type readyIssueForCLI struct {
 	Title       string          `json:"title"`
 	Owner       *string         `json:"owner,omitempty"`
 	Priority    *int64          `json:"priority,omitempty"`
+	Labels      []string        `json:"labels"`
 }
 
 type readyOptions struct {

--- a/cmd/kata/ready_test.go
+++ b/cmd/kata/ready_test.go
@@ -87,6 +87,39 @@ func TestReady_AgentAllRowCarriesPriorityAndOmitsAbsentOwner(t *testing.T) {
 	assert.NotContains(t, out, "owner=")
 }
 
+// TestReady_AgentRowEmitsLabels pins that ready agent rows carry a
+// labels= field when the issue has labels. Per the agent stability
+// contract (docs/reference/agent-output.md) field order is part of the
+// contract and new fields append to the line, so labels goes AFTER the
+// pre-existing issue/priority/owner/title fields.
+func TestReady_AgentRowEmitsLabels(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "labeled ready")
+	runCLI(t, env, dir, "label", "add", ref, "bug")
+	runCLI(t, env, dir, "label", "add", ref, "epic")
+
+	out := runCLI(t, env, dir, "--agent", "ready")
+
+	assert.Contains(t, out,
+		`- issue=`+ref+` title="labeled ready" labels=bug,epic`,
+		"labels append after the existing fields, order-stable")
+}
+
+// TestReady_AgentAllRowEmitsLabels pins the same appended labels= field
+// on the --all agent path.
+func TestReady_AgentAllRowEmitsLabels(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "labeled global ready")
+	runCLI(t, env, dir, "label", "add", ref, "epic")
+
+	out, err := runCmdOutput(t, env, "--workspace", dir, "--agent", "ready", "--all")
+	require.NoError(t, err)
+
+	assert.Contains(t, out,
+		`- issue=kata#`+ref+` title="labeled global ready" labels=epic`,
+		"labels append after the existing fields, order-stable")
+}
+
 func TestReady_UnownedAndOwnerMutualExclusion(t *testing.T) {
 	env, dir := setupCLIEnv(t)
 	resetFlags(t)
@@ -173,6 +206,32 @@ func TestReady_HumanRowRendersPriorityChip(t *testing.T) {
 	out := runCLI(t, env, dir, "ready")
 
 	assert.Contains(t, out, "• P1")
+}
+
+// TestReady_HumanRowRendersLabelChips pins that a labeled ready issue
+// renders the well-known "[epic] " / "[bug] " chips in project-scoped
+// human output, now that the ready payload carries labels.
+func TestReady_HumanRowRendersLabelChips(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "broken thing")
+	runCLI(t, env, dir, "label", "add", ref, "bug")
+
+	out := runCLI(t, env, dir, "ready")
+
+	assert.Contains(t, out, "[bug] ")
+}
+
+// TestReady_AllHumanRowRendersLabelChips pins the same label-chip
+// rendering on the --all (global) human path.
+func TestReady_AllHumanRowRendersLabelChips(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "big effort")
+	runCLI(t, env, dir, "label", "add", ref, "epic")
+
+	out, err := runCmdOutput(t, env, "--workspace", dir, "ready", "--all")
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "[epic] ")
 }
 
 // TestReady_HumanFooterShowsSummaryAndLegend pins the ready footer: rule,

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -38,7 +38,7 @@ The schema carries a version in its `info.version` field
 {
   "ok": true,
   "schema_version": 7,
-  "api_schema_version": "0.5.0",
+  "api_schema_version": "0.6.0",
   "version": "1.4.2",
   "uptime": "5m0s",
   "db_path": "/path/to/kata.db"
@@ -70,6 +70,7 @@ response of an older daemon that predates it. Treat an **absent or empty**
 
 | Version | Change |
 | --- | --- |
+| `0.6.0` | Ready responses now return fully hydrated issues. Project-scoped ready rows are `IssueOut` instead of the slimmer `Issue` projection, and global ready rows (`ReadyGlobalIssueOut`, renamed from `ReadyGlobalIssue`) embed `IssueOut` plus `project_name` — so both gain `labels`, `qualified_id` (required), link peers (`parent`, `blocks`, `blocked_by`, `related`), `blocked`, and `child_counts`. Clients regenerated from the schema see the new component name; the shipped Go client keeps `ReadyGlobalIssue` as a deprecated alias. |
 | `0.5.0` | Added metadata patch endpoints for issues and projects, issue create metadata, and metadata-key filters on project issue lists. Generated clients can patch metadata with `If-Match` revisions, send initial metadata in create requests, and request selected metadata keys with the `meta` query parameter. |
 | `0.4.0` | Added semantic-search response mode metadata and embeddings health fields. Search responses now always include the effective `mode`; configured daemons may also report sanitized embedding reconciler status from `/health`, including backlog and provider HTTP status without raw provider diagnostics. |
 | `0.3.0` | Moved the author identity rewrite endpoint from `POST /api/v1/projects/{project_id}/federation/rewrite-author` to `POST /api/v1/projects/{project_id}/actions/rewrite-author`. The operation is project current-state hygiene rather than a federation command, so generated clients should use the project action route. |

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -966,10 +966,12 @@ type ReadyRequest struct {
 	ExcludeLabels []string `query:"exclude_label,omitempty"`
 }
 
-// ReadyResponse is the ready-issue list.
+// ReadyResponse is the ready-issue list. Rows are hydrated IssueOuts so
+// human/agent renderers get labels (and the other list-parity fields)
+// without a follow-up fetch per row.
 type ReadyResponse struct {
 	Body struct {
-		Issues []db.Issue `json:"issues"`
+		Issues []IssueOut `json:"issues"`
 	}
 }
 
@@ -979,12 +981,18 @@ type ReadyGlobalRequest struct {
 	Limit int `query:"limit,omitempty"`
 }
 
-// ReadyGlobalResponse is the cross-project ready-issue list. Each row
-// carries the project name so clients can render qualified refs
+// ReadyGlobalIssueOut is one cross-project ready row: a hydrated IssueOut
+// plus the project's canonical name so clients can render qualified refs
 // (<project>#<short_id>) without a separate lookup.
+type ReadyGlobalIssueOut struct {
+	IssueOut
+	ProjectName string `json:"project_name"`
+}
+
+// ReadyGlobalResponse is the cross-project ready-issue list.
 type ReadyGlobalResponse struct {
 	Body struct {
-		Issues []db.ReadyGlobalIssue `json:"issues"`
+		Issues []ReadyGlobalIssueOut `json:"issues"`
 	}
 }
 

--- a/internal/daemon/handlers_ready.go
+++ b/internal/daemon/handlers_ready.go
@@ -33,8 +33,12 @@ func registerReadyHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, api.NewError(500, "internal", err.Error(), "", nil)
 		}
+		issueOuts, err := hydrateIssueOuts(ctx, cfg.DB, in.ProjectID, issues)
+		if err != nil {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
 		out := &api.ReadyResponse{}
-		out.Body.Issues = issues
+		out.Body.Issues = issueOuts
 		return out, nil
 	})
 
@@ -47,8 +51,20 @@ func registerReadyHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, api.NewError(500, "internal", err.Error(), "", nil)
 		}
+		bare := make([]db.Issue, len(issues))
+		for i, iss := range issues {
+			bare[i] = iss.Issue
+		}
+		issueOuts, err := hydrateIssueOutsCrossProject(ctx, cfg.DB, bare)
+		if err != nil {
+			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		}
+		rows := make([]api.ReadyGlobalIssueOut, len(issueOuts))
+		for i, io := range issueOuts {
+			rows[i] = api.ReadyGlobalIssueOut{IssueOut: io, ProjectName: issues[i].ProjectName}
+		}
 		out := &api.ReadyGlobalResponse{}
-		out.Body.Issues = issues
+		out.Body.Issues = rows
 		return out, nil
 	})
 }

--- a/internal/daemon/handlers_ready_test.go
+++ b/internal/daemon/handlers_ready_test.go
@@ -13,7 +13,8 @@ import (
 // fields the tests assert on.
 type readyResp struct {
 	Issues []struct {
-		ShortID string `json:"short_id"`
+		ShortID string   `json:"short_id"`
+		Labels  []string `json:"labels"`
 	} `json:"issues"`
 }
 
@@ -64,12 +65,33 @@ func TestReady_UnownedAndOwnerMutuallyExclusive(t *testing.T) {
 	assert.Equal(t, 400, status)
 }
 
+// TestReady_HydratesLabels pins that ready rows carry attached labels the
+// way list rows do, so `kata ready` human output can render label chips.
+func TestReady_HydratesLabels(t *testing.T) {
+	env := testenv.New(t)
+	pid := initLocalWorkspace(t, env, "kata")
+	labeled := createIssueViaHTTP(t, env, pid, "labeled")
+	createIssueViaHTTP(t, env, pid, "bare")
+	postLabel(t, env, pid, labeled, "epic")
+	postLabel(t, env, pid, labeled, "bug")
+	labeledShort := refForIssue(t, env, labeled)
+
+	out := getReady(t, env, pid, "")
+	byShort := map[string][]string{}
+	for _, i := range out.Issues {
+		byShort[i.ShortID] = i.Labels
+	}
+	assert.ElementsMatch(t, []string{"bug", "epic"}, byShort[labeledShort],
+		"ready rows carry the issue's labels")
+}
+
 // readyGlobalResp narrows the global response body to the fields these tests
 // assert on.
 type readyGlobalResp struct {
 	Issues []struct {
-		ShortID     string `json:"short_id"`
-		ProjectName string `json:"project_name"`
+		ShortID     string   `json:"short_id"`
+		ProjectName string   `json:"project_name"`
+		Labels      []string `json:"labels"`
 	} `json:"issues"`
 }
 
@@ -123,6 +145,39 @@ func TestReadyGlobal_ExcludesArchivedProjects(t *testing.T) {
 			"archived project's issues must not appear in /api/v1/ready")
 	}
 	_ = pid1
+}
+
+// TestReadyGlobal_HydratesLabelsAndKeepsProjectName pins that the global
+// ready payload gains labels while still carrying project_name on each row
+// (needed for qualified refs).
+func TestReadyGlobal_HydratesLabelsAndKeepsProjectName(t *testing.T) {
+	env := testenv.New(t)
+	pid1 := initLocalWorkspace(t, env, "kata")
+	pid2 := initWorkspaceViaHTTP(t, env, "https://github.com/wesm/other.git")
+	iss1 := createIssueViaHTTP(t, env, pid1, "p1 labeled")
+	iss2 := createIssueViaHTTP(t, env, pid2, "p2 labeled")
+	postLabel(t, env, pid1, iss1, "epic")
+	postLabel(t, env, pid2, iss2, "bug")
+	short1 := refForIssue(t, env, iss1)
+	short2 := refForIssue(t, env, iss2)
+
+	out := getReadyGlobal(t, env, "")
+	type row struct {
+		project string
+		labels  []string
+	}
+	byShort := map[string]row{}
+	for _, i := range out.Issues {
+		byShort[i.ShortID] = row{project: i.ProjectName, labels: i.Labels}
+	}
+	require.Contains(t, byShort, short1)
+	require.Contains(t, byShort, short2)
+	assert.NotEmpty(t, byShort[short1].project, "project_name kept on global rows")
+	assert.NotEmpty(t, byShort[short2].project, "project_name kept on global rows")
+	assert.Equal(t, []string{"epic"}, byShort[short1].labels,
+		"labels scoped to the right project's issue")
+	assert.Equal(t, []string{"bug"}, byShort[short2].labels,
+		"labels scoped to the right project's issue")
 }
 
 func TestReadyGlobal_LimitCapsTotalRows(t *testing.T) {

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -12,7 +12,7 @@ import (
 // (info.version). It tracks the HTTP API contract, not the build version, so
 // the committed schema artifact stays stable across builds and is bumped
 // deliberately when the wire contract changes.
-const APISchemaVersion = "0.5.0"
+const APISchemaVersion = "0.6.0"
 
 // OpenAPIDocument builds the daemon's complete OpenAPI model by wiring every
 // route through NewServer with a zero ServerConfig. It binds no listener and

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -187,9 +187,9 @@ func TestOpenAPIDocumentShape(t *testing.T) {
 	}
 }
 
-func TestAPISchemaVersionReflectsBranchOrchestrationContract(t *testing.T) {
-	if APISchemaVersion != "0.5.0" {
-		t.Fatalf("APISchemaVersion = %q, want 0.5.0 for create metadata and list metadata filter contract", APISchemaVersion)
+func TestAPISchemaVersionReflectsReadyHydrationContract(t *testing.T) {
+	if APISchemaVersion != "0.6.0" {
+		t.Fatalf("APISchemaVersion = %q, want 0.6.0 for hydrated ready rows (IssueOut projection with required qualified_id)", APISchemaVersion)
 	}
 }
 

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -219,7 +219,7 @@ func TestOpenAPIDocumentJSONBlobShapes(t *testing.T) {
 		t.Fatalf("CreateIssueRequestBody.metadata additionalProperties = %#v, want true", createMeta.AdditionalProperties)
 	}
 	assertSchemaPropertyType(t, doc, "ProjectOut", "metadata", huma.TypeObject)
-	assertSchemaPropertyType(t, doc, "ReadyGlobalIssue", "metadata", huma.TypeObject)
+	assertSchemaPropertyType(t, doc, "ReadyGlobalIssueOut", "metadata", huma.TypeObject)
 	assertSchemaPropertyType(t, doc, "Recurrence", "template_labels", huma.TypeArray)
 	assertSchemaPropertyType(t, doc, "Recurrence", "template_metadata", huma.TypeObject)
 	assertSchemaPropertyType(t, doc, "RecurrenceTemplateUpdateInput", "metadata", huma.TypeObject)

--- a/pkg/client/deprecated_aliases_test.go
+++ b/pkg/client/deprecated_aliases_test.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// ReadyGlobalIssue was renamed to ReadyGlobalIssueOut when ready rows were
+// hydrated to full IssueOut. The deprecated alias must keep pre-rename
+// consumers compiling and decoding the expanded payload, labels included.
+func TestDeprecatedReadyGlobalIssueAliasDecodesHydratedRow(t *testing.T) {
+	rowJSON := []byte(`{
+		"uid":"01TESTISSUEAAAAAAAAAAAAAAA",
+		"short_id":"abc4",
+		"qualified_id":"spoke-project#abc4",
+		"title":"ready row",
+		"body":"ready body",
+		"status":"open",
+		"author":"tester",
+		"created_at":"2026-06-23T00:00:00Z",
+		"updated_at":"2026-06-23T00:00:00Z",
+		"project_id":1,
+		"project_name":"spoke-project",
+		"labels":["infra","p1"]
+	}`)
+	var issue generated.ReadyGlobalIssue //nolint:staticcheck // exercising the deprecated alias is the point
+	require.NoError(t, json.Unmarshal(rowJSON, &issue))
+	require.NoError(t, issue.Validate())
+	require.Equal(t, []string{"infra", "p1"}, issue.Labels)
+	require.Equal(t, "spoke-project", issue.ProjectName)
+}

--- a/pkg/client/generated/generate.go
+++ b/pkg/client/generated/generate.go
@@ -2,3 +2,11 @@ package generated
 
 //go:generate sh -c "go run ../../../cmd/kata openapi --version 3.0 --format yaml > ../openapi.yaml"
 //go:generate go run github.com/doordash-oss/oapi-codegen-dd/v3/cmd/oapi-codegen@v3.75.5 -config config.yaml ../openapi.yaml
+
+// ReadyGlobalIssue is the pre-0.10 name of the cross-project ready row,
+// renamed when ready responses were hydrated to full IssueOut. It lives in
+// this file rather than the generated ones because regeneration deletes
+// every other .go file in this package.
+//
+// Deprecated: use ReadyGlobalIssueOut.
+type ReadyGlobalIssue = ReadyGlobalIssueOut

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -2708,22 +2708,30 @@ func (r ReachableGraphUnresolvedRef) Validate() error {
 	return errors
 }
 
-type ReadyGlobalIssue struct {
+type ReadyGlobalIssueOut struct {
 	Author        string         `json:"author" validate:"required"`
+	Blocked       *bool          `json:"blocked,omitempty"`
+	BlockedBy     []LinkPeer     `json:"blocked_by,omitempty"`
+	Blocks        []LinkPeer     `json:"blocks,omitempty"`
 	Body          string         `json:"body" validate:"required"`
+	ChildCounts   *ChildCounts   `json:"child_counts,omitempty"`
 	ClosedAt      *time.Time     `json:"closed_at,omitempty"`
 	ClosedReason  *string        `json:"closed_reason,omitempty"`
 	CreatedAt     time.Time      `json:"created_at" validate:"required"`
 	DeletedAt     *time.Time     `json:"deleted_at,omitempty"`
 	ID            int64          `json:"id"`
+	Labels        []string       `json:"labels,omitempty"`
 	Metadata      map[string]any `json:"metadata"`
 	OccurrenceKey *string        `json:"occurrence_key,omitempty"`
 	Owner         *string        `json:"owner,omitempty"`
+	Parent        *LinkPeer      `json:"parent,omitempty"`
 	Priority      *int64         `json:"priority,omitempty"`
 	ProjectID     int64          `json:"project_id"`
 	ProjectName   string         `json:"project_name" validate:"required"`
 	ProjectUID    *string        `json:"project_uid,omitempty"`
+	QualifiedID   string         `json:"qualified_id" validate:"required"`
 	RecurrenceID  *int64         `json:"recurrence_id,omitempty"`
+	Related       []LinkPeer     `json:"related,omitempty"`
 	Revision      int64          `json:"revision"`
 	ShortID       string         `json:"short_id" validate:"required"`
 	Status        string         `json:"status" validate:"required"`
@@ -2732,12 +2740,81 @@ type ReadyGlobalIssue struct {
 	UpdatedAt     time.Time      `json:"updated_at" validate:"required"`
 }
 
-func (r ReadyGlobalIssue) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+func (r ReadyGlobalIssueOut) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(r.Author, "required"); err != nil {
+		errors = errors.Append("Author", err)
+	}
+	for i, item := range r.BlockedBy {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("BlockedBy[%d]", i), err)
+			}
+		}
+	}
+	for i, item := range r.Blocks {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Blocks[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(r.Body, "required"); err != nil {
+		errors = errors.Append("Body", err)
+	}
+	if r.ChildCounts != nil {
+		if v, ok := any(r.ChildCounts).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("ChildCounts", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(r.CreatedAt, "required"); err != nil {
+		errors = errors.Append("CreatedAt", err)
+	}
+	if r.Parent != nil {
+		if v, ok := any(r.Parent).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Parent", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(r.ProjectName, "required"); err != nil {
+		errors = errors.Append("ProjectName", err)
+	}
+	if err := typesValidator.Var(r.QualifiedID, "required"); err != nil {
+		errors = errors.Append("QualifiedID", err)
+	}
+	for i, item := range r.Related {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Related[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(r.ShortID, "required"); err != nil {
+		errors = errors.Append("ShortID", err)
+	}
+	if err := typesValidator.Var(r.Status, "required"); err != nil {
+		errors = errors.Append("Status", err)
+	}
+	if err := typesValidator.Var(r.Title, "required"); err != nil {
+		errors = errors.Append("Title", err)
+	}
+	if err := typesValidator.Var(r.UID, "required"); err != nil {
+		errors = errors.Append("UID", err)
+	}
+	if err := typesValidator.Var(r.UpdatedAt, "required"); err != nil {
+		errors = errors.Append("UpdatedAt", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type ReadyGlobalResponseBody struct {
-	Issues []ReadyGlobalIssue `json:"issues,omitempty" validate:"required"`
+	Issues []ReadyGlobalIssueOut `json:"issues,omitempty" validate:"required"`
 }
 
 func (r ReadyGlobalResponseBody) Validate() error {
@@ -2756,7 +2833,7 @@ func (r ReadyGlobalResponseBody) Validate() error {
 }
 
 type ReadyResponseBody struct {
-	Issues []Issue `json:"issues,omitempty" validate:"required"`
+	Issues []IssueOut `json:"issues,omitempty" validate:"required"`
 }
 
 func (r ReadyResponseBody) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2815,12 +2815,26 @@ components:
         - kind
         - other_uid
       type: object
-    ReadyGlobalIssue:
+    ReadyGlobalIssueOut:
       properties:
         author:
           type: string
+        blocked:
+          type: boolean
+        blocked_by:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          nullable: true
+          type: array
+        blocks:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          nullable: true
+          type: array
         body:
           type: string
+        child_counts:
+          $ref: "#/components/schemas/ChildCounts"
         closed_at:
           format: date-time
           type: string
@@ -2835,6 +2849,11 @@ components:
         id:
           format: int64
           type: integer
+        labels:
+          items:
+            type: string
+          nullable: true
+          type: array
         metadata:
           additionalProperties: true
           type: object
@@ -2842,6 +2861,8 @@ components:
           type: string
         owner:
           type: string
+        parent:
+          $ref: "#/components/schemas/LinkPeer"
         priority:
           format: int64
           type: integer
@@ -2852,9 +2873,16 @@ components:
           type: string
         project_uid:
           type: string
+        qualified_id:
+          type: string
         recurrence_id:
           format: int64
           type: integer
+        related:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          nullable: true
+          type: array
         revision:
           format: int64
           type: integer
@@ -2871,6 +2899,7 @@ components:
           type: string
       required:
         - project_name
+        - qualified_id
         - id
         - uid
         - project_id
@@ -2888,7 +2917,7 @@ components:
       properties:
         issues:
           items:
-            $ref: "#/components/schemas/ReadyGlobalIssue"
+            $ref: "#/components/schemas/ReadyGlobalIssueOut"
           nullable: true
           type: array
       required:
@@ -2898,7 +2927,7 @@ components:
       properties:
         issues:
           items:
-            $ref: "#/components/schemas/Issue"
+            $ref: "#/components/schemas/IssueOut"
           nullable: true
           type: array
       required:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -3358,7 +3358,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.5.0
+  version: 0.6.0
 openapi: 3.0.3
 paths:
   /api/v1/audit/closes:


### PR DESCRIPTION
Closes the ready/list output parity gap from the human-output polish epic: `kata ready` rows now carry labels (and the other list-parity fields), so the shared row renderer can show `[epic]`/`[bug]` chips on ready output.

- **Daemon**: `ReadyResponse` rows are hydrated `api.IssueOut` instead of bare `db.Issue`, matching `ListIssuesResponse`. The global variant returns `ReadyGlobalIssueOut` (`IssueOut` + the `project_name` each row already carried for qualified refs). Additive on the wire: existing clients unmarshal a subset; `--json` consumers gain fields. OpenAPI artifacts and the generated client are regenerated.
- **CLI (human)**: `kata ready` and `kata ready --all` pass labels to the shared row renderer, lighting up the well-known label chips.
- **CLI (agent)**: `--agent` rows gain a `labels=` field, appended after the existing fields per the agent field-order stability contract (docs/reference/agent-output.md), with order-sensitive tests.

Note: the regenerated Go client changes exported types (`ReadyGlobalIssue` → `ReadyGlobalIssueOut`, `[]Issue` → `[]IssueOut`); accepted pre-1.0, same precedent as the earlier `ListIssuesResponse` move to `IssueOut`.
