### PR TITLE
Suggest the unit when a duration flag gets a bare number

### DIFF
--- a/cmd/kata/duration_flag.go
+++ b/cmd/kata/duration_flag.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// durationFlag is a pflag.Value for duration flags that keeps Go's
+// units-required grammar but fails with guidance instead of the stock
+// parser error. The common mistake — agents especially — is a bare number
+// ("--timeout 1800"); bare numbers stay rejected because they are ambiguous
+// (seconds? milliseconds?), but the error suggests the seconds spelling
+// instead of just naming the parse failure.
+type durationFlag struct {
+	d *time.Duration
+}
+
+func (f durationFlag) String() string {
+	if f.d == nil {
+		return "0s"
+	}
+	return f.d.String()
+}
+
+func (f durationFlag) Set(s string) error {
+	trimmed := strings.TrimSpace(s)
+	d, err := time.ParseDuration(trimmed)
+	if err != nil {
+		if _, numErr := strconv.ParseFloat(trimmed, 64); numErr == nil {
+			return fmt.Errorf("missing unit in duration %q: did you mean %q? (units: s, m, h)",
+				trimmed, trimmed+"s")
+		}
+		return fmt.Errorf("invalid duration %q: use a Go duration such as 30s, 5m, or 1h30m", trimmed)
+	}
+	*f.d = d
+	return nil
+}
+
+func (f durationFlag) Type() string { return "duration" }

--- a/cmd/kata/duration_flag_test.go
+++ b/cmd/kata/duration_flag_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDurationFlagBareNumberSuggestsUnit: a unitless number is the common
+// agent mistake; it must stay rejected (ambiguous) but the error must
+// suggest the seconds spelling rather than echo the stock parse failure.
+func TestDurationFlagBareNumberSuggestsUnit(t *testing.T) {
+	for _, in := range []string{"1800", "1800.5", " 1800 "} {
+		var d time.Duration
+		err := durationFlag{&d}.Set(in)
+		if err == nil {
+			t.Fatalf("Set(%q): want error, got nil", in)
+		}
+		if !strings.Contains(err.Error(), `"`+strings.TrimSpace(in)+`s"`) {
+			t.Fatalf("Set(%q): error %q does not suggest the seconds spelling", in, err)
+		}
+	}
+}
+
+// TestDurationFlagGarbageGetsGuidance: non-numeric junk gets the generic
+// guidance message with example spellings, not a bare parse error.
+func TestDurationFlagGarbageGetsGuidance(t *testing.T) {
+	var d time.Duration
+	err := durationFlag{&d}.Set("soon")
+	if err == nil {
+		t.Fatal("Set(\"soon\"): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "30s, 5m, or 1h30m") {
+		t.Fatalf("Set(\"soon\"): error %q lacks example spellings", err)
+	}
+}
+
+// TestDurationFlagValidValues: valid Go durations (and the unit-less zero,
+// which ParseDuration accepts) must parse exactly, including surrounding
+// whitespace.
+func TestDurationFlagValidValues(t *testing.T) {
+	cases := map[string]time.Duration{
+		"30m":   30 * time.Minute,
+		"0":     0,
+		"1h30m": 90 * time.Minute,
+		" 2s ":  2 * time.Second,
+		"1800s": 1800 * time.Second,
+		"-1s":   -time.Second, // range checks are the command's job
+	}
+	for in, want := range cases {
+		var d time.Duration
+		if err := (durationFlag{&d}).Set(in); err != nil {
+			t.Fatalf("Set(%q): unexpected error: %v", in, err)
+		}
+		if d != want {
+			t.Fatalf("Set(%q) = %v, want %v", in, d, want)
+		}
+	}
+}
+
+// TestDurationFlagStringShowsCurrentValue: String() backs the flag's default
+// rendering in --help, so it must reflect the pointed-at value.
+func TestDurationFlagStringShowsCurrentValue(t *testing.T) {
+	d := 2 * time.Second
+	if got := (durationFlag{&d}).String(); got != "2s" {
+		t.Fatalf("String() = %q, want \"2s\"", got)
+	}
+	if got := (durationFlag{nil}).String(); got != "0s" {
+		t.Fatalf("String() on nil = %q, want \"0s\"", got)
+	}
+}

--- a/cmd/kata/wait.go
+++ b/cmd/kata/wait.go
@@ -199,9 +199,10 @@ aborts the whole wait with the daemon's exit code instead.`,
 	}
 	cmd.Flags().StringVar(&opts.until, "until", "closed",
 		"condition to wait for: closed|attention|needs-human|stuck")
-	cmd.Flags().DurationVar(&opts.timeout, "timeout", 0,
+	opts.pollInterval = defaultWaitPollInterval
+	cmd.Flags().Var(durationFlag{&opts.timeout}, "timeout",
 		"maximum time to wait (0 = wait forever)")
-	cmd.Flags().DurationVar(&opts.pollInterval, "poll-interval", defaultWaitPollInterval,
+	cmd.Flags().Var(durationFlag{&opts.pollInterval}, "poll-interval",
 		"state poll cadence (must be > 0)")
 	cmd.Flags().BoolVar(&opts.anyMode, "any", false,
 		"return as soon as the first ref's condition is met")

--- a/cmd/kata/wait_test.go
+++ b/cmd/kata/wait_test.go
@@ -305,6 +305,23 @@ func TestWaitUsageNegativeTimeout(t *testing.T) {
 	_ = requireCLIError(t, err, ExitValidation)
 }
 
+// TestWaitUsageBareTimeoutSuggestsUnit: "--timeout 1800" (no unit) is the
+// first mistake real agents make (kenn-io/kata#159). It must fail at flag
+// parsing with an error suggesting the "1800s" spelling, not Go's stock
+// parse failure.
+func TestWaitUsageBareTimeoutSuggestsUnit(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "bare timeout")
+
+	_, err := runCLICapture(t, env, dir, "wait", ref, "--timeout", "1800")
+	if err == nil {
+		t.Fatal("bare --timeout 1800: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), `"1800s"`) {
+		t.Fatalf("bare --timeout error %q does not suggest \"1800s\"", err)
+	}
+}
+
 // TestWaitTimeoutBoundsHungFetch: a daemon state fetch that never returns must
 // be bounded by --timeout. Ref resolution answers immediately, but the issue
 // GET hangs; the command must still return an ExitWaitTimeout well before the


### PR DESCRIPTION
## Summary

Fixes #159 (option 2, per the precedent survey there): duration flags keep the units-required grammar, but a bare number now fails with a suggestion of the seconds spelling instead of Go's stock parse error, and non-numeric input gets example spellings.

```
$ kata wait abc4 --timeout 1800
kata: invalid argument "1800" for "--timeout" flag: missing unit in duration "1800": did you mean "1800s"? (units: s, m, h)

$ kata wait abc4 --timeout soon
kata: invalid argument "soon" for "--timeout" flag: invalid duration "soon": use a Go duration such as 30s, 5m, or 1h30m
```

## What ships

- `durationFlag`, a small `pflag.Value` wrapping `time.ParseDuration` with the friendlier failure modes (`cmd/kata/duration_flag.go`). Follows the existing "strict grammar, generous errors" precedents (`digest`'s `parseSinceUntil`, `internal/hooks`' `parseDuration`).
- Wired into `kata wait --timeout` and `--poll-interval` (previously stock `DurationVar`). Accepted values are unchanged — `0` still parses (Go accepts unit-less zero), negative durations still reach the command's existing range validation.
- Tests: unit coverage for the suggestion/guidance/valid/default-rendering paths, plus a CLI-level regression for the exact real-world failure (`--timeout 1800`).

## Deliberately not included

`--ttl` (federation lease) and `--interval` (github-sync) are `StringVar` today and parsed later; converting them to `durationFlag` also moves their validation client-side, which is a behavior question worth its own decision. The type is reusable if you want them switched — happy to follow up either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
