### PR TITLE
kata list: parent/child tree rendering with box-drawing connectors

### DIFF
--- a/cmd/kata/list.go
+++ b/cmd/kata/list.go
@@ -120,6 +120,9 @@ func newListCmd() *cobra.Command {
 					Priority    *int64   `json:"priority"`
 					Labels      []string `json:"labels"`
 					Blocked     bool     `json:"blocked"`
+					Parent      *struct {
+						ShortID string `json:"short_id"`
+					} `json:"parent"`
 				} `json:"issues"`
 			}
 			if err := json.Unmarshal(bs, &b); err != nil {
@@ -151,6 +154,7 @@ func newListCmd() *cobra.Command {
 			// Unowned issues render as "(unowned)" so the trailing
 			// "(...)" cell is never empty.
 			rows := make([]issueRow, len(b.Issues))
+			parents := make([]string, len(b.Issues))
 			for idx, i := range b.Issues {
 				owner := "unowned"
 				if i.Owner != nil && *i.Owner != "" {
@@ -165,7 +169,11 @@ func newListCmd() *cobra.Command {
 					Blocked:  i.Blocked,
 					Labels:   i.Labels,
 				}
+				if i.Parent != nil {
+					parents[idx] = i.Parent.ShortID
+				}
 			}
+			rows = treeRows(rows, parents)
 			renderer := newRowRenderer(cmd.OutOrStdout())
 			if err := renderer.renderRows(cmd.OutOrStdout(), rows); err != nil {
 				return err

--- a/cmd/kata/list.go
+++ b/cmd/kata/list.go
@@ -121,7 +121,7 @@ func newListCmd() *cobra.Command {
 					Labels      []string `json:"labels"`
 					Blocked     bool     `json:"blocked"`
 					Parent      *struct {
-						ShortID string `json:"short_id"`
+						QualifiedID string `json:"qualified_id"`
 					} `json:"parent"`
 				} `json:"issues"`
 			}
@@ -154,6 +154,9 @@ func newListCmd() *cobra.Command {
 			// Unowned issues render as "(unowned)" so the trailing
 			// "(...)" cell is never empty.
 			rows := make([]issueRow, len(b.Issues))
+			// Tree keys are qualified ids: parent links can cross
+			// projects, and a bare short_id is only unique per project.
+			keys := make([]string, len(b.Issues))
 			parents := make([]string, len(b.Issues))
 			for idx, i := range b.Issues {
 				owner := "unowned"
@@ -169,11 +172,12 @@ func newListCmd() *cobra.Command {
 					Blocked:  i.Blocked,
 					Labels:   i.Labels,
 				}
+				keys[idx] = i.QualifiedID
 				if i.Parent != nil {
-					parents[idx] = i.Parent.ShortID
+					parents[idx] = i.Parent.QualifiedID
 				}
 			}
-			rows = treeRows(rows, parents)
+			rows = treeRows(rows, keys, parents)
 			renderer := newRowRenderer(cmd.OutOrStdout())
 			if err := renderer.renderRows(cmd.OutOrStdout(), rows); err != nil {
 				return err

--- a/cmd/kata/list_test.go
+++ b/cmd/kata/list_test.go
@@ -86,6 +86,84 @@ func TestList_HumanRowRendersBugLabelChip(t *testing.T) {
 	assert.Contains(t, out, "[bug] ")
 }
 
+// TestList_HumanTreeIndentsChildrenUnderParent pins bd-style tree
+// rendering: children move directly beneath their parent, non-last
+// children connect with "├─ ", the last child with "└─ ", and the
+// parent row stays unindented.
+func TestList_HumanTreeIndentsChildrenUnderParent(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	parent := createIssue(t, env, pid, "parent epic")
+	childA := createIssue(t, env, pid, "child alpha")
+	childB := createIssue(t, env, pid, "child beta")
+	runCLI(t, env, dir, "edit", childA, "--parent", parent)
+	runCLI(t, env, dir, "edit", childB, "--parent", parent)
+
+	out := runCLI(t, env, dir, "list")
+
+	assert.Contains(t, out, "├─ ○ ", "non-last child connects with ├─")
+	assert.Contains(t, out, "└─ ○ ", "last child connects with └─")
+	parentIdx := strings.Index(out, "parent epic")
+	require.GreaterOrEqual(t, parentIdx, 0)
+	for _, title := range []string{"child alpha", "child beta"} {
+		idx := strings.Index(out, title)
+		require.GreaterOrEqual(t, idx, 0)
+		assert.Greater(t, idx, parentIdx, "%s renders beneath its parent", title)
+	}
+}
+
+// TestList_HumanTreeRendersGrandchildRecursively pins recursion through
+// parent chains: a grandchild nests one level deeper with the rail
+// continuation prefix.
+func TestList_HumanTreeRendersGrandchildRecursively(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	root := createIssue(t, env, pid, "tree root")
+	mid := createIssue(t, env, pid, "tree mid")
+	leaf := createIssue(t, env, pid, "tree leaf")
+	runCLI(t, env, dir, "edit", mid, "--parent", root)
+	runCLI(t, env, dir, "edit", leaf, "--parent", mid)
+
+	out := runCLI(t, env, dir, "list")
+
+	assert.Contains(t, out, "└─ ○ ", "mid connects under root")
+	assert.Contains(t, out, "   └─ ○ ", "leaf nests one level deeper")
+}
+
+// TestList_HumanTreeOrphanedChildRendersFlat pins the filter-mismatch
+// fallback: when a child's parent does not match the active filter
+// (here excluded via --no-label), the child renders flat at top level
+// rather than being dropped or indented.
+func TestList_HumanTreeOrphanedChildRendersFlat(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	parent := createIssue(t, env, pid, "filtered parent")
+	child := createIssue(t, env, pid, "orphan child")
+	runCLI(t, env, dir, "edit", child, "--parent", parent)
+	runCLI(t, env, dir, "label", "add", parent, "hidden")
+
+	out := runCLI(t, env, dir, "list", "--no-label", "hidden")
+
+	assert.NotContains(t, out, "filtered parent")
+
+	assert.Contains(t, out, "orphan child")
+	assert.NotContains(t, out, "├─", "orphan renders flat, no connector")
+	assert.NotContains(t, out, "└─", "orphan renders flat, no connector")
+}
+
+// TestList_AgentOutputUnchangedByTree pins that tree rendering is human
+// mode only: agent rows keep the flat "- issue=..." shape with no
+// box-drawing connectors.
+func TestList_AgentOutputUnchangedByTree(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	parent := createIssue(t, env, pid, "agent parent")
+	child := createIssue(t, env, pid, "agent child")
+	runCLI(t, env, dir, "edit", child, "--parent", parent)
+
+	out := runCLI(t, env, dir, "--agent", "list")
+
+	assert.NotContains(t, out, "├─")
+	assert.NotContains(t, out, "└─")
+	assert.Contains(t, out, "- issue=")
+}
+
 // TestList_HumanRowBlockedGlyphFollowsOpenBlocker pins the Blocked
 // derivation: an open issue with an OPEN blocker renders the blocked glyph
 // "●", and once the blocker is closed (or the blocker starts out closed)

--- a/cmd/kata/render.go
+++ b/cmd/kata/render.go
@@ -23,6 +23,10 @@ type issueRow struct {
 	Status   string   // "open" | "closed"
 	Blocked  bool     // wins over Status for the glyph when Status=="open"
 	Labels   []string // renderer picks out epic/bug chips
+	// TreePrefix is the box-drawing connector rendered before the glyph
+	// ("├─ ", "└─ ", with rail continuation). Set by treeRows for `kata
+	// list`; empty for flat output.
+	TreePrefix string
 }
 
 // footerRuleWidth is the width in cells of the "─" rule printed
@@ -122,7 +126,7 @@ func (r *rowRenderer) renderRow(row issueRow, id string, idWidth int) string {
 	chips := r.chipsField(row.Labels)
 	title := textsafe.Line(row.Title)
 	owner := r.ownerStyle.Render("(" + textsafe.Line(row.Owner) + ")")
-	return glyph + " " + idCell + "  " + prio + "  " + chips + title + " " + owner
+	return row.TreePrefix + glyph + " " + idCell + "  " + prio + "  " + chips + title + " " + owner
 }
 
 // glyph picks the status glyph. Closed wins outright; otherwise

--- a/cmd/kata/tree.go
+++ b/cmd/kata/tree.go
@@ -1,0 +1,67 @@
+package main
+
+// treeRows reorders rows into parent/child tree order for human `kata
+// list` output, setting each row's TreePrefix to bd-style box-drawing
+// connectors ("├─ " / "└─ ", with "│  " / "   " continuation rails for
+// deeper levels). parents[i] names rows[i]'s parent by ID, "" for none.
+//
+// Roots keep their input order. A child whose parent is not in the
+// fetched set (the parent didn't match the active filter, or --limit
+// truncated it away) is rendered flat at top level rather than dropped.
+// Parent chains nest recursively; a visited guard keeps a (never
+// expected) parent cycle from looping or dropping rows — cycle members
+// degrade to flat top-level rows.
+func treeRows(rows []issueRow, parents []string) []issueRow {
+	index := make(map[string]int, len(rows))
+	for i, row := range rows {
+		index[row.ID] = i
+	}
+	childrenOf := make(map[string][]int)
+	out := make([]issueRow, 0, len(rows))
+	visited := make([]bool, len(rows))
+
+	var emit func(i int, prefix string, rail string)
+	emit = func(i int, prefix, rail string) {
+		visited[i] = true
+		row := rows[i]
+		row.TreePrefix = prefix
+		out = append(out, row)
+		kids := childrenOf[row.ID]
+		for k, child := range kids {
+			if visited[child] {
+				continue
+			}
+			connector, childRail := "├─ ", rail+"│  "
+			if k == len(kids)-1 {
+				connector, childRail = "└─ ", rail+"   "
+			}
+			emit(child, rail+connector, childRail)
+		}
+	}
+
+	// A row is a child only if its parent is present in the fetched set;
+	// otherwise it stays a top-level (flat) row.
+	isChild := make([]bool, len(rows))
+	for i, parent := range parents {
+		if parent == "" {
+			continue
+		}
+		if _, ok := index[parent]; ok {
+			isChild[i] = true
+			childrenOf[parent] = append(childrenOf[parent], i)
+		}
+	}
+	for i := range rows {
+		if !isChild[i] && !visited[i] {
+			emit(i, "", "")
+		}
+	}
+	// Cycle fallback: rows reachable only through a parent cycle were
+	// never emitted above; render them flat so nothing is dropped.
+	for i := range rows {
+		if !visited[i] {
+			emit(i, "", "")
+		}
+	}
+	return out
+}

--- a/cmd/kata/tree.go
+++ b/cmd/kata/tree.go
@@ -3,18 +3,22 @@ package main
 // treeRows reorders rows into parent/child tree order for human `kata
 // list` output, setting each row's TreePrefix to bd-style box-drawing
 // connectors ("├─ " / "└─ ", with "│  " / "   " continuation rails for
-// deeper levels). parents[i] names rows[i]'s parent by ID, "" for none.
+// deeper levels). keys[i] identifies rows[i] and parents[i] names its
+// parent ("" for none) — callers pass qualified ids for both, since
+// parent links can cross projects and a bare short_id is only unique
+// within one project (a foreign parent's short_id could collide with a
+// local issue).
 //
 // Roots keep their input order. A child whose parent is not in the
-// fetched set (the parent didn't match the active filter, or --limit
-// truncated it away) is rendered flat at top level rather than dropped.
-// Parent chains nest recursively; a visited guard keeps a (never
-// expected) parent cycle from looping or dropping rows — cycle members
-// degrade to flat top-level rows.
-func treeRows(rows []issueRow, parents []string) []issueRow {
+// fetched set (the parent didn't match the active filter, lives in
+// another project, or --limit truncated it away) is rendered flat at
+// top level rather than dropped. Parent chains nest recursively; a
+// visited guard keeps a (never expected) parent cycle from looping or
+// dropping rows — cycle members degrade to flat top-level rows.
+func treeRows(rows []issueRow, keys, parents []string) []issueRow {
 	index := make(map[string]int, len(rows))
-	for i, row := range rows {
-		index[row.ID] = i
+	for i := range rows {
+		index[keys[i]] = i
 	}
 	childrenOf := make(map[string][]int)
 	out := make([]issueRow, 0, len(rows))
@@ -26,7 +30,7 @@ func treeRows(rows []issueRow, parents []string) []issueRow {
 		row := rows[i]
 		row.TreePrefix = prefix
 		out = append(out, row)
-		kids := childrenOf[row.ID]
+		kids := childrenOf[keys[i]]
 		for k, child := range kids {
 			if visited[child] {
 				continue

--- a/cmd/kata/tree_test.go
+++ b/cmd/kata/tree_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ids extracts the ID sequence from rows, for order assertions.
+func ids(rows []issueRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.ID
+	}
+	return out
+}
+
+// prefixes extracts the TreePrefix sequence from rows.
+func prefixes(rows []issueRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.TreePrefix
+	}
+	return out
+}
+
+// TestTreeRows_GroupsChildrenUnderParent pins the core grouping: children
+// move directly beneath their parent, non-last children get "├─ ", the
+// last child gets "└─ ", and roots keep list order with no prefix.
+func TestTreeRows_GroupsChildrenUnderParent(t *testing.T) {
+	rows := []issueRow{
+		{ID: "p1"},
+		{ID: "solo"},
+		{ID: "c1"},
+		{ID: "c2"},
+	}
+	got := treeRows(rows, []string{"", "", "p1", "p1"})
+
+	assert.Equal(t, []string{"p1", "c1", "c2", "solo"}, ids(got))
+	assert.Equal(t, []string{"", "├─ ", "└─ ", ""}, prefixes(got))
+}
+
+// TestTreeRows_OrphanedChildRendersFlat pins the filter-mismatch fallback:
+// a child whose parent is not in the fetched set renders flat at top
+// level, in list order, with no connector.
+func TestTreeRows_OrphanedChildRendersFlat(t *testing.T) {
+	rows := []issueRow{
+		{ID: "a"},
+		{ID: "orphan"},
+	}
+	got := treeRows(rows, []string{"", "gone"})
+
+	assert.Equal(t, []string{"a", "orphan"}, ids(got))
+	assert.Equal(t, []string{"", ""}, prefixes(got))
+}
+
+// TestTreeRows_RendersNestedChainsRecursively pins recursion: a
+// grandchild nests under its parent with the ancestor continuation
+// prefix ("   " when the ancestor was a last child, "│  " otherwise).
+func TestTreeRows_RendersNestedChainsRecursively(t *testing.T) {
+	rows := []issueRow{
+		{ID: "root"},
+		{ID: "mid1"},
+		{ID: "mid2"},
+		{ID: "leaf"},
+	}
+	// root -> mid1, mid2; mid1 -> leaf. mid1 is NOT the last child, so
+	// leaf's prefix continues the "│" rail.
+	got := treeRows(rows, []string{"", "root", "root", "mid1"})
+
+	assert.Equal(t, []string{"root", "mid1", "leaf", "mid2"}, ids(got))
+	assert.Equal(t, []string{"", "├─ ", "│  └─ ", "└─ "}, prefixes(got))
+}
+
+// TestTreeRows_LastChildDescendantsUseBlankRail pins the counterpart:
+// descendants of a LAST child indent with spaces, not the "│" rail.
+func TestTreeRows_LastChildDescendantsUseBlankRail(t *testing.T) {
+	rows := []issueRow{
+		{ID: "root"},
+		{ID: "mid"},
+		{ID: "leaf"},
+	}
+	got := treeRows(rows, []string{"", "root", "mid"})
+
+	assert.Equal(t, []string{"root", "mid", "leaf"}, ids(got))
+	assert.Equal(t, []string{"", "└─ ", "   └─ "}, prefixes(got))
+}
+
+// TestTreeRows_ParentCycleDoesNotLoopOrDropRows guards the degenerate
+// case: if parent links ever form a cycle, every row still renders
+// exactly once (flat is acceptable; hanging or dropping rows is not).
+func TestTreeRows_ParentCycleDoesNotLoopOrDropRows(t *testing.T) {
+	rows := []issueRow{
+		{ID: "a"},
+		{ID: "b"},
+	}
+	got := treeRows(rows, []string{"b", "a"})
+
+	assert.ElementsMatch(t, []string{"a", "b"}, ids(got))
+}

--- a/cmd/kata/tree_test.go
+++ b/cmd/kata/tree_test.go
@@ -24,6 +24,16 @@ func prefixes(rows []issueRow) []string {
 	return out
 }
 
+// keyed builds the keys slice for treeRows from row IDs, for tests where
+// display ID and tree key coincide.
+func keyed(rows []issueRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.ID
+	}
+	return out
+}
+
 // TestTreeRows_GroupsChildrenUnderParent pins the core grouping: children
 // move directly beneath their parent, non-last children get "├─ ", the
 // last child gets "└─ ", and roots keep list order with no prefix.
@@ -34,7 +44,7 @@ func TestTreeRows_GroupsChildrenUnderParent(t *testing.T) {
 		{ID: "c1"},
 		{ID: "c2"},
 	}
-	got := treeRows(rows, []string{"", "", "p1", "p1"})
+	got := treeRows(rows, keyed(rows), []string{"", "", "p1", "p1"})
 
 	assert.Equal(t, []string{"p1", "c1", "c2", "solo"}, ids(got))
 	assert.Equal(t, []string{"", "├─ ", "└─ ", ""}, prefixes(got))
@@ -48,10 +58,27 @@ func TestTreeRows_OrphanedChildRendersFlat(t *testing.T) {
 		{ID: "a"},
 		{ID: "orphan"},
 	}
-	got := treeRows(rows, []string{"", "gone"})
+	got := treeRows(rows, keyed(rows), []string{"", "gone"})
 
 	assert.Equal(t, []string{"a", "orphan"}, ids(got))
 	assert.Equal(t, []string{"", ""}, prefixes(got))
+}
+
+// TestTreeRows_KeysAreQualifiedNotShort pins the cross-project collision
+// guard: rows are keyed by qualified id, so a foreign parent whose
+// SHORT id collides with a local issue must NOT capture the child —
+// the child renders flat.
+func TestTreeRows_KeysAreQualifiedNotShort(t *testing.T) {
+	rows := []issueRow{
+		{ID: "abcd"}, // local issue whose short id collides with the foreign parent
+		{ID: "wxyz"}, // child of other-project#abcd, not local abcd
+	}
+	keys := []string{"local#abcd", "local#wxyz"}
+	got := treeRows(rows, keys, []string{"", "other#abcd"})
+
+	assert.Equal(t, []string{"abcd", "wxyz"}, ids(got))
+	assert.Equal(t, []string{"", ""}, prefixes(got),
+		"foreign parent must not match a colliding local short id")
 }
 
 // TestTreeRows_RendersNestedChainsRecursively pins recursion: a
@@ -66,7 +93,7 @@ func TestTreeRows_RendersNestedChainsRecursively(t *testing.T) {
 	}
 	// root -> mid1, mid2; mid1 -> leaf. mid1 is NOT the last child, so
 	// leaf's prefix continues the "│" rail.
-	got := treeRows(rows, []string{"", "root", "root", "mid1"})
+	got := treeRows(rows, keyed(rows), []string{"", "root", "root", "mid1"})
 
 	assert.Equal(t, []string{"root", "mid1", "leaf", "mid2"}, ids(got))
 	assert.Equal(t, []string{"", "├─ ", "│  └─ ", "└─ "}, prefixes(got))
@@ -80,7 +107,7 @@ func TestTreeRows_LastChildDescendantsUseBlankRail(t *testing.T) {
 		{ID: "mid"},
 		{ID: "leaf"},
 	}
-	got := treeRows(rows, []string{"", "root", "mid"})
+	got := treeRows(rows, keyed(rows), []string{"", "root", "mid"})
 
 	assert.Equal(t, []string{"root", "mid", "leaf"}, ids(got))
 	assert.Equal(t, []string{"", "└─ ", "   └─ "}, prefixes(got))
@@ -94,7 +121,7 @@ func TestTreeRows_ParentCycleDoesNotLoopOrDropRows(t *testing.T) {
 		{ID: "a"},
 		{ID: "b"},
 	}
-	got := treeRows(rows, []string{"b", "a"})
+	got := treeRows(rows, keyed(rows), []string{"b", "a"})
 
 	assert.ElementsMatch(t, []string{"a", "b"}, ids(got))
 }


### PR DESCRIPTION
Directly follows the human-mode output polish in #156, adding bd-style tree rendering to human-mode `kata list`: children indent beneath their parent with `├─` / `└─` connectors and `│` rail continuation for deeper nesting, building the parent→children index client-side from the parent peer the list API already returns.

- Roots keep list order; children group beneath their parent recursively through parent chains.
- A child whose parent did not match the active filter (or was truncated by `--limit`, or lives in another project) renders flat at top level rather than being dropped.
- Tree keys use `qualified_id`, not bare `short_id` — parent links can cross projects, and a foreign parent whose short_id collides with a local issue must not capture the child.
- A visited guard keeps a degenerate parent cycle from looping or dropping rows.
- Human mode only: `--agent` and `--json` output are byte-identical, and `kata ready` stays flat (blocker-free by definition).

## Screenshots

Same demo project (`spoke-project`), an epic with two children and one grandchild plus two flat issues.

**Before (main)** — flat list:

![kata list before: flat rows](https://raw.githubusercontent.com/mjacobs/kata/ad41429a2293ce23902ef5ddef647805f1a462ae/before.png)

**After (this branch)** — children nest under their parent with box-drawing connectors:

![kata list after: tree-rendered rows](https://raw.githubusercontent.com/mjacobs/kata/ad41429a2293ce23902ef5ddef647805f1a462ae/after.png)

