### PR TITLE
Converge federated cross-project links

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           cache: true
 
       - name: Run tests
-        run: go test -p 1 ./...
+        run: env -u KATA_AUTH_TOKEN go test -p 1 ./...
 
   windows:
     name: Windows
@@ -52,9 +52,10 @@ jobs:
         run: go vet ./...
 
       - name: Run tests
+        shell: bash
         env:
           KATA_TEST_FAST_SQLITE: "1"
-        run: go test -p 4 -vet=off ./...
+        run: env -u KATA_AUTH_TOKEN go test -p 4 -vet=off ./...
 
   lint:
     name: golangci-lint
@@ -89,7 +90,7 @@ jobs:
           persist-credentials: false
 
       - name: Run release script tests
-        run: make release-scripts-test
+        run: env -u KATA_AUTH_TOKEN make release-scripts-test
 
   nilaway:
     name: nilaway
@@ -130,7 +131,7 @@ jobs:
           cache: true
 
       - name: Run federation stress tests
-        run: make test-stress
+        run: env -u KATA_AUTH_TOKEN make test-stress
 
   federation-docker:
     name: Federation Docker tests
@@ -149,4 +150,4 @@ jobs:
           cache: true
 
       - name: Run federation Docker tests
-        run: make test-federation-docker
+        run: env -u KATA_AUTH_TOKEN make test-federation-docker

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,13 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 ## Unreleased
 
+**Fixed**
+
+- Fixed a federation deadlock where two projects whose first pending batches
+  referenced each other's new issues could both become permanently
+  quarantined. Link peers now resolve eventually within the same hub
+  federation group; true validation failures remain quarantined.
+
 ## 0.9.0
 <small>2026-07-09</small>
 

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -205,9 +205,11 @@ On each spoke:
 
    Adoption preserves the current state of local issues, including closed and
    soft-deleted issues, comments, labels, metadata, priority, owner, and
-   same-project links. It does not preserve the old local event history.
+   links. It does not preserve the old local event history.
    Instead it removes those pre-adoption local events and queues fresh snapshots
-   for the hub with same-project links embedded in the snapshot payloads. After
+   for the hub with links embedded in the snapshot payloads. A cross-project
+   edge materializes after both endpoint projects reach the same hub; until
+   then its event is retained and the edge is absent. After
    adoption, existing issues are ordinary federated spoke issues. Future edits
    remain local-first; use live hub leases only when you want exclusive
    coordination.
@@ -301,6 +303,24 @@ If the response is lost after the hub commits, retrying the same batch is safe:
 the hub treats fully duplicated same-hash batches as successful and returns an
 advanced cursor. Permanent validation failures or hash conflicts record a
 quarantine on the spoke instead of retrying forever.
+
+### Cross-Project Link Convergence
+
+A missing link peer is not a permanent validation failure. The hub accepts the
+event, advances the push cursor, and keeps the edge absent until both endpoint
+issues are materialized inside one compatible federation group. Hub projects
+on one daemon form a group. Spoke projects form a group when they are enabled
+and their stored hub URLs have the same scheme, lowercase hostname, and
+effective port.
+
+Link folding and reconciliation run across the complete group whenever any
+member project materializes. The event log therefore acts as durable pending
+state: whichever endpoint arrives second causes the edge to appear. An
+unfederated peer, a peer on a different hub origin, or a peer that never arrives
+stays absent without blocking later events. Clients must enroll both endpoint
+projects through the same hub to project the edge locally. Different DNS names
+and IP aliases are deliberately different spoke groups even if they route to
+the same daemon.
 
 ## Leases And Write Gates
 
@@ -444,6 +464,11 @@ without advancing the push cursor, so the same local events are sent again on
 the next sync. Stale push quarantines whose stored error is the legacy
 `unsupported_federation_schema` response are released automatically on sync;
 operators use `retry` for other fixed push quarantines.
+
+Older builds may have quarantined a valid batch because a cross-project link
+peer had not reached the hub. After upgrading the hub and spoke, use `retry`,
+not `skip`. The original events are resent without advancing the cursor and
+the edge materializes when both endpoint projects reach the upgraded hub.
 
 Operators can also intentionally skip a quarantined batch:
 

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -272,6 +272,13 @@ Federation compatibility is asymmetric during rolling upgrades:
   `invalid_federation_schema`. These are protocol errors, not rolling-upgrade
   skew.
 
+This compatibility policy does not extend to legacy v0.9 directional unlink
+payloads. `issue.unlinked` events for `blocks` and `parent` must carry
+`link_from_uid` and `link_to_uid` in storage orientation. The hub rejects a
+payload that omits them; it does not infer orientation from current graph state
+or rewrite the event. This is a deliberate pre-1.0 contract boundary, not a
+transient version-skew condition.
+
 Upgrade hubs before push-enabled spokes when rolling out a new federation
 schema. If an older build already quarantined a batch because of transient
 schema skew, upgrade the hub and then restart each spoke on a build with this
@@ -352,6 +359,9 @@ time and stop blocking edits once expired.
 The hub checks pushed work against the live lease state at ingest time. Work
 that conflicts with another holder's live lease is not dropped; the hub records
 `claim.violated`. Work on unleased issues is normal and is not a violation.
+For link work, the audit checks every materialized endpoint in the compatible
+federation group and records the violation in the endpoint's owning project.
+Timed leases are expired in each affected owning project before that check.
 This is best-effort, not a causal proof that the work was unauthorized when
 originally performed. An offline edit that was covered at edit time can arrive
 after another holder acquires a lease and be marked violated because the hub

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -576,6 +576,9 @@ time and stop blocking edits once expired.
 The hub checks pushed work against live lease state at ingest time. Work that
 conflicts with another holder's live lease is kept, but the hub records
 `claim.violated`. Work on unleased issues is normal and is not a violation.
+Link mutations check both materialized endpoints in the compatible federation
+group, expire timed leases in each endpoint's owning project, and record any
+violation in that owning project.
 
 ## Operator commands
 
@@ -625,6 +628,14 @@ sync retries the same pending events automatically.
 Malformed schema declarations are not rolling-upgrade skew. Missing schema
 versions fail request validation, and explicit non-positive schema versions
 return `invalid_federation_schema`.
+
+Legacy v0.9 directional unlink payloads are also outside the supported ingest
+contract. `blocks` and `parent` unlinks must include storage-oriented
+`link_from_uid` and `link_to_uid`; the hub rejects events that omit them and
+never guesses orientation from the current graph. Such a validation quarantine
+is not released by upgrading or retrying because kata does not rewrite the
+stored event. Handle it through the normal explicit quarantine disposition
+workflow.
 
 Older kata builds may already have quarantined a batch after a transient
 schema-skew rejection. After upgrading the hub, upgrade and restart each spoke

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -372,17 +372,17 @@ selector.
 
 Adoption preserves the current state of local issues, including closed and
 soft-deleted issues, comments, labels, metadata, priority, owner, and
-same-project links. It does not preserve the old local event history. Instead
+links. It does not preserve the old local event history. Instead
 it removes those pre-adoption local events, queues fresh snapshots for the hub
 with each issue's links embedded in the snapshot payloads, and reports how
-many snapshots were queued. Links between issues in the adopted project
-replicate to the hub. A link to an issue in another project does not: the hub
-rejects ingest batches that reference issues it does not have, so a
-cross-project link on an adopted issue can land the adoption push in
-quarantine (see Consistency limitations). Remove cross-project links from the
-project's issues before adopting. Adoption snapshot event actors are the
-bound federation actor. Snapshot payload authors and comment authors are
-preserved, so adopted issues keep their original displayed content authors.
+many snapshots were queued. The hub stores a cross-project link event even
+when its peer issue has not arrived yet and materializes the edge after both
+endpoint projects reach the same hub. Until then the edge is absent. Spoke
+projects that share links must use the same hub URL origin; different DNS names
+or IP aliases are intentionally separate federation groups. Adoption snapshot
+event actors are the bound federation actor. Snapshot payload authors and
+comment authors are preserved, so adopted issues keep their original displayed
+content authors.
 
 > **Preserving the pre-adoption timeline:** Adoption is a cutover, not an
 > in-place history merge. If you need the old local event timeline for audit or
@@ -652,6 +652,20 @@ quarantine created by older builds for `unsupported_federation_schema` is
 released automatically on sync after the spoke runs a fixed build; manual retry
 is for other fixed push-quarantine root causes.
 
+Older kata versions may have quarantined an otherwise valid batch because a
+cross-project link peer had not reached the hub. Upgrade the hub first, then
+the spoke. Release each affected push quarantine with `retry`, not `skip`:
+
+```sh
+kata federation quarantine retry <id> \
+  --confirm "RETRY FEDERATION BATCH <id>" \
+  --reason "peer links now use deferred same-hub reconciliation"
+```
+
+Retry leaves the push cursor unchanged and resends the original events. Once
+both endpoint projects reach the upgraded hub, the edge materializes
+automatically.
+
 Intentionally skip only when the operator accepts that local events will not be
 federated:
 
@@ -701,19 +715,14 @@ Federation has expected stale or deferred states:
 - Pushed event actors are bound to the enrollment actor. A buggy, old, or
   malicious spoke that pushes a different actor is rejected by the hub and the
   spoke records the failed batch in quarantine.
-- Links may span projects, but federation replicates one project per binding,
-  and link replication is scoped to the binding: an edge materializes only
-  when both endpoint issues belong to the same federated project. A
-  cross-project link does not propagate through federation — even when both
-  endpoint projects are federated between the same instances — and stays
-  local to the instance where it was created. Pushes are stricter: the hub
-  rejects a batch whose link payloads reference an issue it does not have
-  (unless that peer's snapshot arrives in the same batch), so a cross-project
-  link mutation on a push-enabled spoke, or an adoption snapshot embedding
-  one, can land the push batch in quarantine. Same-project edges are
-  unaffected: a baseline arriving over multiple poll pages defers an edge
-  whose peer snapshot is on a later page to a later materialization pass
-  rather than dropping it.
+- Links may span projects. A missing peer does not quarantine push: the event
+  and cursor advance while the edge remains absent. The edge materializes when
+  both endpoint projects are enabled through the same hub federation group.
+  Pulling clients must enroll both projects and use the same normalized hub URL
+  origin to project it locally. Unfederated peers, different hub origins, and
+  peers that never arrive stay absent. Malformed events, unknown primary
+  issues, actor violations, and hash conflicts remain permanent validation
+  failures and can quarantine push.
 
 ## Cutover notes
 

--- a/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+++ b/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
@@ -806,3 +806,53 @@ Run the shuffled SQLite store suite, shuffled repository suite, lint, API,
 documentation, workflow, and diff checks. Commit without rewriting history,
 push, and run a fresh full branch review. Do not reply to or resolve the GitHub
 review comment without explicit user instruction.
+
+---
+
+### Task 7: Reject Malformed Link JSON and Invalid Deferred Parent Graphs
+
+**Files:**
+- Modify: `internal/db/sqlitestore/claims.go:1210-1260`
+- Modify: `internal/db/sqlitestore/federation.go:1880-2020`
+- Modify: `internal/db/sqlitestore/federation_ingest.go:980-1220`
+- Test: `internal/db/sqlitestore/federation_test.go`
+
+**Interfaces:**
+- Consumes: decoded snapshot/create link payloads, folded desired link rows,
+  `db.MaxParentDepth`, and `db.ErrParentCycle`.
+- Produces: decode errors classified as federation ingest validation and parent
+  graph validation before any reconciliation write.
+
+- [ ] **Step 1: Add malformed link JSON regressions**
+
+Submit fresh snapshots whose `links` value is an object instead of an array and
+whose `incoming` field is a string instead of a boolean. Both must return
+`db.ErrFederationIngestValidation` and store no event. Verify they fail because
+the current decoder silently returns an empty or partially decoded link set.
+
+- [ ] **Step 2: Propagate link decoding errors**
+
+Change `payloadLinks` to return `([]payloadLink, error)`. Propagate decoding
+failures through referenced-UID collection, deferred-peer classification, and
+claim-audit reference extraction. Wrap the JSON error with
+`db.ErrFederationIngestValidation` at the ingest boundary.
+
+- [ ] **Step 3: Add a deferred cross-project parent-cycle regression**
+
+Store `first parent second` while `second` is unresolved, then ingest `second`
+with `second parent first` through another enabled project in the same group.
+The second batch must return `db.ErrFederationIngestValidation`, roll back, and
+leave zero materialized parent links.
+
+- [ ] **Step 4: Validate the folded parent graph before writes**
+
+Build a child-to-parent map from desired `parent` rows. Reject multiple parents,
+revisiting any node, or a chain that reaches `db.MaxParentDepth`. Perform this
+check after endpoint resolution and before deleting, updating, or inserting
+links so a failed federation batch remains atomic.
+
+- [ ] **Step 5: Verify, commit, and re-review**
+
+Run the complete shuffled verification set, commit without history rewriting,
+push, and require a fresh full-branch review to pass. Leave existing GitHub
+comments and review state untouched.

--- a/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+++ b/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
@@ -931,3 +931,39 @@ with `[`; `null`, objects, and scalars are validation failures.
 
 Run the full shuffled verification set, commit without rewriting history,
 push, and require the next complete branch review to pass.
+
+---
+
+### Task 10: Audit Cross-Project Link Claims
+
+**Files:**
+- Modify: `internal/db/sqlitestore/claims.go`
+- Test: `internal/db/sqlitestore/federation_test.go`
+- Modify: `docs/design/federation.md`
+- Modify: `docs/operations/federation.md`
+
+**Interfaces:**
+- Consumes: compatible-group claim state for every materialized link endpoint.
+- Produces: endpoint-owning-project claim audit.
+
+**Compatibility decision:** Legacy v0.9 directional unlinks remain outside the
+supported contract. Do not add graph inference, payload rewriting, or another
+fallback for events missing `link_from_uid` and `link_to_uid`.
+
+- [ ] **Step 1: Prove the review finding**
+
+Add a link mutation whose peer has a claim in another compatible hub project.
+Confirm the owning project does not receive `claim.violated` before
+implementation.
+
+- [ ] **Step 2: Audit compatible-project link peers**
+
+Resolve claim-audit issue UIDs across the binding group. Pass each endpoint's
+owning project ID and name into the existing mutation audit so timed claims
+expire and violations are recorded in the correct project.
+
+- [ ] **Step 3: Verify, commit, and re-review**
+
+Run the full shuffled verification set with local auth environment variables
+unset, commit without rewriting history, push, and require the next complete
+branch review to pass.

--- a/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+++ b/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
@@ -1,0 +1,531 @@
+# Federated Cross-Project Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let independently synchronized projects converge cross-project links without quarantining either stream when the peer issue arrives later.
+
+**Architecture:** Keep issue, comment, label, and metadata projection project-scoped. Treat link peer UIDs as deferred references during ingest, then fold and reconcile links across the compatible federation group whenever any member project materializes.
+
+**Tech Stack:** Go, SQLite, `testify`, the existing event fold and federation ingest/materialization layers.
+
+## Global Constraints
+
+- Do not add a database migration or a second pending-link store; events are the durable pending state.
+- Unknown primary issue references remain validation failures.
+- A hub group contains enabled hub bindings on one daemon.
+- A spoke group contains enabled spoke bindings whose stored hub URLs have the same normalized scheme, lowercase hostname, and effective port.
+- Different DNS names or IP aliases remain different groups even when they reach the same daemon.
+- Use neutral names such as `spoke-project`, `peer-project`, and `hub.example` in tests and documentation.
+- Do not add bash content-assertion tests or tests of `net/url` behavior.
+- Recover old quarantines with retry, never skip, after compatible binaries are running.
+
+---
+
+### Task 1: Accept Deferred Link Peers Without Weakening Primary-Issue Validation
+
+**Files:**
+- Modify: `internal/db/sqlitestore/federation_ingest.go:45-205`
+- Modify: `internal/db/sqlitestore/federation_ingest.go:955-1235`
+- Test: `internal/db/sqlitestore/federation_test.go:1578-2840`
+
+**Interfaces:**
+- Consumes: `validateFederationProjectEvent`, `payloadReferencedIssueUIDs`, `payloadLinkIssueUIDs`, and `db.FederationIngestParams`.
+- Produces: `payloadDeferredLinkIssueUIDs(ev db.RemoteEvent, payload map[string]json.RawMessage) map[string]struct{}` and ingest behavior that accepts missing link peers while rejecting missing primary issues.
+
+- [ ] **Step 1: Add a failing ordinary-ingest regression test**
+
+Add a top-level test next to `TestIngestFederationEvents_Validation`:
+
+~~~go
+func TestIngestFederationEventsDefersUnknownLinkPeer(t *testing.T) {
+	d, ctx, project, spokeUID := setupFederationIngestHub(t)
+	issueUID := newTestUID(t)
+	peerUID := newTestUID(t)
+	event := ingestEventWithPayload(t, project.UID, project.Name, spokeUID, &issueUID, nil,
+		"issue.created", 100,
+		`{"uid":"`+issueUID+`","short_id":"`+shortID(issueUID)+`","title":"subject","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"blocks","to_issue_uid":"`+peerUID+`","author":"spoke"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+
+	result, err := d.IngestFederationEvents(ctx, ingestParams(project.ID, spokeUID, event))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Accepted)
+	issue, err := d.IssueByUID(ctx, issueUID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	links, err := d.LinksByIssue(ctx, issue.ID)
+	require.NoError(t, err)
+	assert.Empty(t, links, "the peer is unresolved, so the edge must stay absent")
+}
+~~~
+
+- [ ] **Step 2: Verify the regression test fails for the observed reason**
+
+Run:
+
+~~~bash
+go test ./internal/db/sqlitestore -run '^TestIngestFederationEventsDefersUnknownLinkPeer$' -count=1
+~~~
+
+Expected: FAIL with `federation ingest validation` and `references unknown issue`.
+
+- [ ] **Step 3: Classify deferred link-peer references explicitly**
+
+Add this helper beside `payloadReferencedIssueUIDs`:
+
+~~~go
+func payloadDeferredLinkIssueUIDs(
+	ev db.RemoteEvent,
+	payload map[string]json.RawMessage,
+) map[string]struct{} {
+	out := map[string]struct{}{}
+	add := func(uid string) {
+		if uid != "" {
+			out[uid] = struct{}{}
+		}
+	}
+	for _, key := range []string{
+		"from_uid", "to_uid", "from_issue_uid", "to_issue_uid",
+		"parent_set_uid", "parent_removed_uid",
+	} {
+		if uid, ok := db.StringValue(payload[key]); ok {
+			add(uid)
+		}
+	}
+	for _, key := range []string{
+		"blocks_added_uids", "blocks_removed_uids",
+		"blocked_by_added_uids", "blocked_by_removed_uids",
+		"related_added_uids", "related_removed_uids",
+	} {
+		for _, uid := range db.StringSlice(payload[key]) {
+			add(uid)
+		}
+	}
+	for _, uid := range payloadLinkIssueUIDs(ev) {
+		add(uid)
+	}
+	switch ev.Type {
+	case "issue.linked", "issue.unlinked", "issue.links_changed":
+		if ev.RelatedIssueUID != nil {
+			add(*ev.RelatedIssueUID)
+		}
+	}
+	return out
+}
+~~~
+
+In `validateFederationProjectEvent`, preserve the existing primary-issue check, then replace the unknown-peer branch with:
+
+~~~go
+	deferredLinkUIDs := payloadDeferredLinkIssueUIDs(ev, payload)
+	for _, ref := range payloadReferencedIssueUIDs(ev, payload) {
+		if ref == issueUID {
+			continue
+		}
+		if _, ok := knownIssueUIDs[ref]; ok {
+			continue
+		}
+		if _, ok := deferredLinkUIDs[ref]; ok {
+			continue
+		}
+		return fmt.Errorf("%w: event %s references unknown issue %s",
+			db.ErrFederationIngestValidation, ev.EventUID, ref)
+	}
+~~~
+
+Remove the now-redundant batch snapshot-peer set and future-snapshot exception from `validateFederationProjectEvent`. Keep the test that rejects a snapshot whose envelope alone names an unknown related issue; it proves the relaxation is limited to actual link payloads.
+
+- [ ] **Step 4: Make adoption completion preserve unresolved link events**
+
+Delete the terminal call to `validateFederationAdoptionSnapshotLinksResolved`, its `verifySnapshotLinks` state bit, and the unused validator. Change these three subtests in `TestIngestFederationEvents_Validation`:
+
+- `rejects complete adoption baseline with unresolved open chunk snapshot link`
+- `rejects metadata-only complete adoption baseline with unresolved open chunk snapshot link`
+- `rejects deferred snapshot link when only related envelope mentions missing issue`
+
+Rename each from `rejects` to `accepts`. Replace the terminal assertions with:
+
+~~~go
+	require.NoError(t, err)
+	authorized, err := d.AuthorizeFederationToken(ctx, markerValue, p.ID, "push")
+	require.NoError(t, err)
+	assert.False(t, authorized.AllowAdoptionSnapshotAuthors)
+	assertIngestedEventCount(ctx, t, d, p.ID, 2)
+~~~
+
+The first open-chunk event remains durable, while its unresolved edge remains absent until group projection can resolve the peer.
+
+- [ ] **Step 5: Run focused ingest tests**
+
+Run:
+
+~~~bash
+go test ./internal/db/sqlitestore -run 'TestIngestFederationEvents(DefersUnknownLinkPeer|_Validation)?$' -count=1
+~~~
+
+Expected: PASS. The unknown-primary and envelope-only unknown-related tests must still pass unchanged.
+
+- [ ] **Step 6: Commit the ingest boundary**
+
+Use the mandatory `commit` skill, then:
+
+~~~bash
+git add internal/db/sqlitestore/federation_ingest.go internal/db/sqlitestore/federation_test.go
+git commit -m "Defer unresolved federation link peers"
+~~~
+
+The commit body must explain why missing link peers are eventual-consistency state while missing primary issues remain poisoned input.
+
+---
+
+### Task 2: Reconcile Links Across a Compatible Federation Group
+
+**Files:**
+- Modify: `internal/db/sqlitestore/federation.go:989-1045`
+- Modify: `internal/db/sqlitestore/federation.go:1835-1965`
+- Test: `internal/db/sqlitestore/federation_test.go:3586-3795`
+
+**Interfaces:**
+- Consumes: `db.FoldEvents`, `federationFoldEvents`, `federationBindingSelect`, `projectIDPlaceholders`, and materialized `issues` rows.
+- Produces:
+  - `normalizedFederationHubOrigin(raw string) (string, error)`
+  - `federationBindingGroupProjectIDs(ctx context.Context, tx *sql.Tx, current db.FederationBinding) ([]int64, error)`
+  - `federationGroupFoldProjection(ctx context.Context, tx *sql.Tx, projectIDs []int64) (db.FoldProjection, error)`
+  - `federationGroupIssueIDs(ctx context.Context, tx *sql.Tx, projectIDs []int64, currentProjectID int64, currentIssueIDs map[string]int64) (map[string]int64, error)`
+  - `reconcileFederatedLinks(ctx context.Context, tx *sql.Tx, binding db.FederationBinding, currentProjectID int64, currentIssueIDs map[string]int64) error`
+
+- [ ] **Step 1: Extend the ingest regression into the circular two-project case**
+
+Create a new test with two neutral hub projects. Enable federation on both,
+ingest `issueA` with a `blocks` link to missing `issueB`, assert the first
+result is accepted and no link exists, then ingest `issueB` and assert:
+
+~~~go
+	assert.Equal(t, 1, secondResult.Accepted)
+	assertRowCount(ctx, t, d, 1, "deferred cross-project link materialized",
+		`SELECT count(*)
+		   FROM links
+		  WHERE from_issue_uid = ?
+		    AND to_issue_uid = ?
+		    AND type = 'blocks'`,
+		issueAUID, issueBUID)
+~~~
+
+Append an `issue.unlinked` event in the first project at a later HLC and assert
+the same query returns zero. This pins both eventual creation and group-owned
+deletion.
+
+- [ ] **Step 2: Verify the circular test fails after the peer arrives**
+
+Run:
+
+~~~bash
+go test ./internal/db/sqlitestore -run '^TestIngestFederationEventsConvergesCircularCrossProjectLinks$' -count=1
+~~~
+
+Expected: FAIL because the second project materialization still scopes issue
+resolution and existing-link ownership to one project.
+
+- [ ] **Step 3: Add same-origin spoke convergence and different-origin isolation tests**
+
+Add a table-driven materialization test with two cases:
+
+~~~go
+cases := []struct {
+	name       string
+	firstURL   string
+	secondURL  string
+	wantLinks  int
+}{
+	{
+		name:      "same normalized hub origin",
+		firstURL:  "https://Hub.Example:443/path-a",
+		secondURL: "https://hub.example/path-b",
+		wantLinks: 1,
+	},
+	{
+		name:      "different hub origin",
+		firstURL:  "https://hub-a.example",
+		secondURL: "https://hub-b.example",
+		wantLinks: 0,
+	},
+}
+~~~
+
+For each case, create two projects with enabled spoke bindings, insert a
+snapshot containing the cross-project link into the first project and the peer
+snapshot into the second, materialize first then second, and assert the number
+of matching `links` rows equals `wantLinks`. This tests kata's grouping and
+reconciliation logic, not URL-library behavior.
+
+- [ ] **Step 4: Verify both materialization tests fail correctly**
+
+Run:
+
+~~~bash
+go test ./internal/db/sqlitestore -run 'Test(IngestFederationEventsConvergesCircularCrossProjectLinks|MaterializeFederatedProjectGroupsCrossProjectLinksByHubOrigin)$' -count=1
+~~~
+
+Expected: the circular and same-origin cases FAIL with zero links; the
+different-origin case already reports zero.
+
+- [ ] **Step 5: Implement federation-group membership**
+
+Add `net/url` to `internal/db/sqlitestore/federation.go` imports. Implement
+`normalizedFederationHubOrigin` by parsing the stored URL, lowercasing scheme
+and hostname, using port `80` for HTTP and `443` for HTTPS when omitted, and
+returning `scheme://host:port`. Reject empty hosts and unsupported schemes with
+an error containing `invalid federation hub URL`.
+
+Implement `federationBindingGroupProjectIDs` by scanning enabled bindings with
+the current role:
+
+~~~go
+	rows, err := tx.QueryContext(ctx,
+		federationBindingSelect+` WHERE role = ? AND enabled = 1 ORDER BY project_id ASC`,
+		string(current.Role))
+~~~
+
+For hub bindings, include every scanned project. For spoke bindings, include
+only bindings whose normalized hub origin equals the current binding's origin.
+Return an error if the current role is neither `hub` nor `spoke`.
+
+- [ ] **Step 6: Fold group link state and resolve only compatible endpoints**
+
+Implement `federationGroupFoldProjection` by concatenating
+`federationFoldEvents` for every group project and calling `db.FoldEvents` once;
+the fold already supplies deterministic global HLC ordering and parent-link
+last-writer behavior.
+
+Implement `federationGroupIssueIDs` with:
+
+~~~sql
+SELECT uid, id, project_id
+  FROM issues
+ WHERE project_id IN (<project placeholders>)
+ ORDER BY project_id, id
+~~~
+
+For the currently materializing project, populate the result only from
+`currentIssueIDs` so stale rows excluded by the freshly folded project
+projection cannot keep stale links alive. Use all materialized issue rows for
+the other group members.
+
+- [ ] **Step 7: Make link reconciliation group-scoped**
+
+Change `materializeFederatedProjectTx` to keep current project reconciliation
+for issues, comments, and labels, but call:
+
+~~~go
+	if err := reconcileFederatedLinks(ctx, tx, binding, projectID, issueIDs); err != nil {
+		return err
+	}
+~~~
+
+Inside `reconcileFederatedLinks`:
+
+1. Resolve the compatible project IDs.
+2. Fold the group's events once.
+3. Resolve endpoint UIDs from the group's materialized issues.
+4. Skip a desired edge if either endpoint is unresolved.
+5. Query existing links where either endpoint project belongs to the group:
+
+~~~sql
+SELECT l.id, l.from_issue_id, l.to_issue_id,
+       l.from_issue_uid, l.to_issue_uid, l.type, l.author
+  FROM links l
+  JOIN issues f ON f.id = l.from_issue_id
+  JOIN issues t ON t.id = l.to_issue_id
+ WHERE f.project_id IN (<group placeholders>)
+    OR t.project_id IN (<group placeholders>)
+~~~
+
+6. Reuse the existing deterministic desired/existing diff, related-link
+canonicalization, author update, insert, and delete behavior.
+
+Because existing rows touching the group are reconciled against one complete
+group projection, one project cannot delete an edge owned by another member,
+and links to standalone or different-hub projects are removed.
+
+- [ ] **Step 8: Run focused and package tests**
+
+Run:
+
+~~~bash
+go test ./internal/db/sqlitestore -run 'Test(IngestFederationEvents|MaterializeFederatedProject)' -count=1
+go test ./internal/db/sqlitestore -count=1
+~~~
+
+Expected: PASS with no new warnings.
+
+- [ ] **Step 9: Commit group projection**
+
+Use the mandatory `commit` skill, then:
+
+~~~bash
+git add internal/db/sqlitestore/federation.go internal/db/sqlitestore/federation_test.go
+git commit -m "Converge federated cross-project links"
+~~~
+
+The commit body must record the same-hub boundary, event-backed deferral, and
+why group-wide deletion ownership is necessary.
+
+---
+
+### Task 3: Document the Same-Hub Constraint and Old-Quarantine Recovery
+
+**Files:**
+- Modify: `docs/design/federation.md:260-280`
+- Modify: `docs/design/federation.md:640-660`
+- Modify: `docs/operations/federation.md:374-390`
+- Modify: `docs/operations/federation.md:625-670`
+- Modify: `docs/operations/federation.md:700-720`
+- Modify: `docs/changelog.md:9`
+
+**Interfaces:**
+- Consumes: the behavior established in Tasks 1-2 and `kata federation quarantine retry`.
+- Produces: public operator guidance for deferred edges, compatible federation groups, consistent hub URLs, and non-lossy retry recovery.
+
+- [ ] **Step 1: Replace obsolete cross-project quarantine guidance**
+
+In the adoption section of `docs/operations/federation.md`, replace the warning
+to remove cross-project links with:
+
+~~~markdown
+Cross-project links are included in adoption snapshots. The hub stores a link
+event even when its peer issue has not arrived yet and materializes the edge
+after both endpoint projects are enrolled through the same hub. Until then the
+edge is absent. Spoke projects that share links must use the same hub URL
+origin; aliases are intentionally treated as separate federation groups.
+~~~
+
+In the consistency limitations section, document:
+
+- missing link peers do not quarantine push;
+- events and cursors advance while the edge is absent;
+- both projects must be enrolled on the same hub;
+- clients must enroll both projects to see the edge;
+- different hub origins and unfederated peers stay absent; and
+- true validation failures still quarantine.
+
+- [ ] **Step 2: Add explicit recovery instructions**
+
+After the quarantine retry documentation, add:
+
+~~~markdown
+Older kata versions may have quarantined an otherwise valid batch because a
+cross-project link peer had not reached the hub. Upgrade the hub first, then
+the spoke. Release each affected push quarantine with `retry`, not `skip`:
+
+    kata federation quarantine retry <id> \
+      --confirm "RETRY FEDERATION BATCH <id>" \
+      --reason "peer links now use deferred same-hub reconciliation"
+
+Retry leaves the push cursor unchanged and resends the original events. Once
+both endpoint projects reach the upgraded hub, the edge materializes
+automatically.
+~~~
+
+Make the matching design document sections describe the same event-backed
+projection and group ownership rules.
+
+- [ ] **Step 3: Add an Unreleased changelog entry**
+
+Under `## Unreleased` add:
+
+~~~markdown
+**Fixed**
+
+- Fixed a federation deadlock where two projects whose first pending batches
+  referenced each other's new issues could both become permanently
+  quarantined. Link peers now resolve eventually within the same hub
+  federation group; true validation failures remain quarantined.
+~~~
+
+- [ ] **Step 4: Validate documentation and the complete codebase**
+
+Run:
+
+~~~bash
+git diff --check
+go test ./internal/db/sqlitestore ./internal/federation ./internal/daemon ./cmd/kata -count=1
+make test-short
+~~~
+
+Expected: every command exits zero. Do not add tests that grep documentation
+or source text.
+
+- [ ] **Step 5: Commit documentation**
+
+Use the mandatory `commit` skill, then:
+
+~~~bash
+git add docs/design/federation.md docs/operations/federation.md docs/changelog.md
+git commit -m "Document deferred federated links"
+~~~
+
+The commit body must explain the same-hub constraint and retry-not-skip
+recovery for quarantines created by older versions.
+
+---
+
+### Task 4: Recover the Existing Quarantines After Rollout
+
+**Files:**
+- No repository files.
+
+**Interfaces:**
+- Consumes: upgraded hub and spoke daemons plus the quarantine IDs from
+  `kata federation status --daemon local --agent`.
+- Produces: both original event streams accepted without cursor skipping and a
+  materialized cross-project edge after convergence.
+
+- [ ] **Step 1: Verify compatible binaries are running**
+
+Run:
+
+~~~bash
+kata federation identity --daemon local --agent
+kata federation identity --daemon hub --agent
+~~~
+
+Both must report builds containing Tasks 1-3. If daemon replacement or restart
+is required, show the exact process targets and commands to the user and wait
+for explicit approval before changing either runtime.
+
+- [ ] **Step 2: Re-read the exact active quarantine list**
+
+Run:
+
+~~~bash
+kata federation status --daemon local --agent
+~~~
+
+Record each project, quarantine ID, direction, event range, and error. Proceed
+only with push quarantines whose error is an unknown link peer.
+
+- [ ] **Step 3: Retry each affected batch without advancing its cursor**
+
+For each affected neutral project:
+
+~~~bash
+kata federation quarantine retry <id> \
+  --daemon local \
+  --project <project> \
+  --confirm "RETRY FEDERATION BATCH <id>" \
+  --reason "peer links now use deferred same-hub reconciliation"
+~~~
+
+Never use `skip`. The daemon's next sync resends the original events.
+
+- [ ] **Step 4: Verify convergence**
+
+Run:
+
+~~~bash
+kata federation status --daemon local --agent
+kata federation status --daemon hub --agent
+~~~
+
+Expected: both projects report `active_quarantine=0`, pending push counts drain
+to zero, push cursors advance, and no new validation error appears. Finally,
+read both endpoint issues through the hub and confirm the cross-project
+relationship is present.

--- a/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+++ b/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
@@ -856,3 +856,35 @@ links so a failed federation batch remains atomic.
 Run the complete shuffled verification set, commit without history rewriting,
 push, and require a fresh full-branch review to pass. Leave existing GitHub
 comments and review state untouched.
+
+---
+
+### Task 8: Strictly Decode Aggregated Link-Change UIDs
+
+**Files:**
+- Modify: `internal/db/sqlitestore/federation_ingest.go:1035-1190`
+- Test: `internal/db/sqlitestore/federation_test.go`
+
+**Interfaces:**
+- Consumes: `issue.links_changed` parent UID scalars and add/remove UID arrays.
+- Produces: one strict UID extraction path used by referenced-issue validation
+  and deferred-peer classification.
+
+- [ ] **Step 1: Add malformed aggregate regressions**
+
+Submit `issue.links_changed` events with an object instead of a UID array, a
+mixed string/number UID array, and a numeric parent UID. Each must return
+`db.ErrFederationIngestValidation` without storing the event.
+
+- [ ] **Step 2: Decode aggregate UID fields strictly**
+
+Implement `payloadLinksChangedIssueUIDs`. Decode parent fields with
+`json.Unmarshal` into strings and add/remove fields into `[]string`. Wrap type
+errors with `db.ErrFederationIngestValidation`. Use the helper from both
+`payloadReferencedIssueUIDs` and `payloadDeferredLinkIssueUIDs` so permissive
+`db.StringValue` or `db.StringSlice` fallbacks cannot advance the cursor.
+
+- [ ] **Step 3: Verify, commit, and re-review**
+
+Run the full shuffled verification set, commit without rewriting history,
+push, and require the next complete branch review to pass.

--- a/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+++ b/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
@@ -616,3 +616,130 @@ Expected: both projects report `active_quarantine=0`, pending push counts drain
 to zero, push cursors advance, and no new validation error appears. Finally,
 read both endpoint issues through the hub and confirm the cross-project
 relationship is present.
+
+---
+
+### Task 5: Enforce Deferred-Link Authorization and Membership Convergence
+
+**Files:**
+- Modify: `internal/db/sqlitestore/federation_ingest.go:942-1175`
+- Modify: `internal/db/sqlitestore/federation.go:383-455`
+- Modify: `internal/db/sqlitestore/federation.go:783-846`
+- Modify: `internal/db/sqlitestore/federation.go:1850-2110`
+- Test: `internal/db/sqlitestore/federation_test.go:1840-1940`
+- Test: `internal/db/sqlitestore/federation_test.go:3360-3540`
+
+**Interfaces:**
+- Consumes: the validated primary issue UID, link payload endpoint fields,
+  materialized issues, create/snapshot events, and old/new federation bindings.
+- Produces: endpoint-scoped peer deferral, a primary-only cross-batch known set,
+  and transactional old/new federation-group link reconciliation.
+
+- [ ] **Step 1: Add failing endpoint-authorization tests**
+
+Add validation subtests that create a valid primary issue in `spoke-project`,
+then submit `issue.linked` events where `from_uid` and `to_uid` are two other
+UIDs or where `related_issue_uid` disagrees with the opposite endpoint. Assert
+`db.ErrFederationIngestValidation`, zero accepted events from the invalid
+batch, and no link row between the unrelated UIDs.
+
+- [ ] **Step 2: Verify endpoint authorization fails red**
+
+Run:
+
+~~~bash
+go test ./internal/db/sqlitestore -run 'TestIngestFederationEvents_Validation/(rejects link whose primary is not an endpoint|rejects related issue that is not the opposite endpoint)$' -count=1
+~~~
+
+Expected: FAIL because the current deferral helper accepts every link-shaped
+UID without binding the edge to the event's validated primary issue.
+
+- [ ] **Step 3: Restrict deferral to authenticated link peers**
+
+Change `payloadDeferredLinkIssueUIDs(ev db.RemoteEvent, payload
+map[string]json.RawMessage, primaryIssueUID string) (map[string]struct{}, error)`
+to return a validation error with the peer set.
+For `issue.linked` and `issue.unlinked`, require both endpoint UIDs, require the
+primary issue to equal one endpoint, and require `RelatedIssueUID`, when set,
+to equal the other endpoint. For `issue.links_changed`, treat the payload's
+parent and link-delta UIDs as peers of the primary and require an envelope peer
+to be one of those UIDs. For create and snapshot payloads, defer only
+`links[].to_issue_uid`. Propagate validation errors before checking unknown
+references.
+
+- [ ] **Step 4: Add and run the consecutive-batch primary-identity test**
+
+In the first batch, accept a valid link from a materialized primary issue to an
+unknown peer. In the second batch, send `issue.updated` with that peer as its
+primary `issue_uid`. Assert the second batch returns
+`db.ErrFederationIngestValidation`, stores no second event, and does not create
+the peer issue.
+
+Run:
+
+~~~bash
+go test ./internal/db/sqlitestore -run '^TestIngestFederationEventsDeferredPeerDoesNotBecomeKnownPrimary$' -count=1
+~~~
+
+Expected before implementation: FAIL because `currentFederatedIssueUIDSet`
+includes stored `related_issue_uid` values.
+
+- [ ] **Step 5: Derive known primaries from primary-producing state only**
+
+Keep materialized issue UIDs, but change the stored-event query to select only
+non-null `issue_uid` values from `issue.created` and `issue.snapshot` events.
+Do not read `related_issue_uid`. Keep `rememberIngestIssueUIDs` limited to
+validated create and snapshot events so later events in the same batch retain
+their current behavior.
+
+- [ ] **Step 6: Add and run the membership-enable convergence test**
+
+Create two projects and issues while only the first project has an enabled hub
+binding. Store a deferred link event in the first project, assert the edge is
+absent, then call `EnableProjectFederation` for the existing peer project.
+Assert the link row appears before that call returns without ingesting another
+event.
+
+Run:
+
+~~~bash
+go test ./internal/db/sqlitestore -run '^TestEnableProjectFederationReconcilesDeferredGroupLinks$' -count=1
+~~~
+
+Expected before implementation: FAIL with zero matching link rows because
+binding creation does not trigger group link reconciliation.
+
+- [ ] **Step 7: Reconcile old and new groups inside binding transactions**
+
+Capture the enabled old group before changing a binding. After the binding is
+inserted or updated, resolve the enabled new group. Reconcile desired links for
+each affected group against existing links touching the union of its previous
+and current members, processing the old group before the new group. Use the
+same helper from `UpsertFederationBinding`, `EnableProjectFederation`, and
+adoption binding creation. An empty resulting group owns no desired links and
+therefore removes old group projection touching its former members.
+
+- [ ] **Step 8: Run focused and package verification**
+
+Run:
+
+~~~bash
+go test ./internal/db/sqlitestore -run 'Test(IngestFederationEvents|EnableProjectFederation|MaterializeFederatedProject)' -count=1
+go test ./internal/db/sqlitestore -count=1
+~~~
+
+Expected: PASS with the three new regressions and all existing federation
+tests green.
+
+- [ ] **Step 9: Commit review remediation**
+
+Use the mandatory `commit` skill, then:
+
+~~~bash
+git add internal/db/sqlitestore/federation_ingest.go internal/db/sqlitestore/federation.go internal/db/sqlitestore/federation_test.go docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+git commit -m "Harden deferred federation links"
+~~~
+
+The commit body must explain why project-scoped authorization must bind every
+edge to the primary issue, why deferred peers are not primary identity, and why
+membership transitions reconcile before commit.

--- a/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+++ b/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
@@ -715,9 +715,12 @@ Capture the enabled old group before changing a binding. After the binding is
 inserted or updated, resolve the enabled new group. Reconcile desired links for
 each affected group against existing links touching the union of its previous
 and current members, processing the old group before the new group. Use the
-same helper from `UpsertFederationBinding`, `EnableProjectFederation`, and
-adoption binding creation. An empty resulting group owns no desired links and
-therefore removes old group projection touching its former members.
+same helper from `UpsertFederationBinding`, `EnableProjectFederation`, adoption
+binding creation, and `LeaveFederationReplica`. An empty resulting group owns
+no desired links and therefore removes old group projection touching its former
+members. Add a leave regression that materializes a same-origin spoke link,
+detaches one endpoint project, and asserts the former-group edge is removed
+before leave returns.
 
 - [ ] **Step 8: Run focused and package verification**
 

--- a/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+++ b/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
@@ -746,3 +746,63 @@ git commit -m "Harden deferred federation links"
 The commit body must explain why project-scoped authorization must bind every
 edge to the primary issue, why deferred peers are not primary identity, and why
 membership transitions reconcile before commit.
+
+---
+
+### Task 6: Preserve Destination-First Links and Reject Latent Invalid Edges
+
+**Files:**
+- Modify: `internal/db/fold.go:95-175`
+- Modify: `internal/db/sqlitestore/federation.go:1395-1440`
+- Modify: `internal/db/sqlitestore/federation_ingest.go:1060-1210`
+- Test: `internal/db/sqlitestore/federation_test.go`
+
+**Interfaces:**
+- Consumes: issue snapshot `links`, stored incident link rows, canonical
+  explicit-link endpoint fields, and `katauid.Valid`.
+- Produces: direction-complete federation snapshots and eager structural
+  validation for deferred peers.
+
+- [ ] **Step 1: Prove destination-first adoption loses an incoming edge**
+
+Create a cross-project `blocks` edge while both projects are standalone. Adopt
+the destination project first and the source project second through paths on
+the same normalized hub origin. Assert the edge exists after both projects
+join. Before the fix, adoption deletes local event history and the destination
+snapshot omits the incoming edge, so the assertion fails with zero links.
+
+- [ ] **Step 2: Snapshot every incident link with direction**
+
+Change `federationIssueLinks` to select both `from_issue_id = issueID` and
+`to_issue_id = issueID`. Outgoing rows use `incoming = false`. Incoming
+directional rows use `incoming = true`; incoming related rows remain false
+because the fold canonicalizes symmetric endpoints. Change snapshot folding to
+reverse every incoming directional link, including `parent`, while preserving
+related canonicalization.
+
+- [ ] **Step 3: Add malformed deferred-link regressions**
+
+After creating a valid primary issue, submit separate unresolved-peer link
+events with an unsupported type, a non-ULID peer, and a self-link. Each must
+return `db.ErrFederationIngestValidation` and leave the invalid event unstored.
+
+- [ ] **Step 4: Validate deferred structure before classifying absence**
+
+Require explicit and snapshot links to use `parent`, `blocks`, or `related`.
+Require every peer UID to pass `katauid.Valid` and differ from the primary
+issue. Apply the same peer rule to aggregated link-change payloads. Preserve
+the existing rule that created parent links cannot be incoming.
+
+- [ ] **Step 5: Reject alternate-only explicit endpoints**
+
+Add a regression using only `from_issue_uid` and `to_issue_uid`; it must fail
+with `db.ErrFederationIngestValidation`. Require canonical `from_uid` and
+`to_uid` because those are the fields `db.FoldEvents` reads. If alternate
+fields are also present, require them to agree with the canonical values.
+
+- [ ] **Step 6: Verify, commit, and re-review**
+
+Run the shuffled SQLite store suite, shuffled repository suite, lint, API,
+documentation, workflow, and diff checks. Commit without rewriting history,
+push, and run a fresh full branch review. Do not reply to or resolve the GitHub
+review comment without explicit user instruction.

--- a/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+++ b/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
@@ -888,3 +888,46 @@ errors with `db.ErrFederationIngestValidation`. Use the helper from both
 
 Run the full shuffled verification set, commit without rewriting history,
 push, and require the next complete branch review to pass.
+
+---
+
+### Task 9: Preserve Directional Unlink Orientation and Reject Null UID Lists
+
+**Files:**
+- Modify: `internal/db/fold.go:390-415`
+- Modify: `internal/db/sqlitestore/federation_ingest.go:1090-1240`
+- Modify: `internal/db/sqlitestore/queries_links.go:850-915`
+- Test: `internal/daemon/handlers_links_test.go`
+- Test: `internal/db/sqlitestore/federation_test.go`
+
+**Interfaces:**
+- Consumes: URL-oriented unlink fields, stored `db.Link` endpoints, and strict
+  aggregated UID-list JSON.
+- Produces: `link_from_uid`/`link_to_uid` storage orientation and explicit JSON
+  array enforcement.
+
+- [ ] **Step 1: Add destination-side unlink regressions**
+
+Create a cross-project `blocks` edge, submit an unlink attributed to its
+destination issue, and assert group folding removes the source-to-destination
+edge. Extend the daemon payload test to require URL-oriented `from_uid` and
+`to_uid` plus storage-oriented `link_from_uid` and `link_to_uid`.
+
+- [ ] **Step 2: Emit, validate, and fold storage endpoints**
+
+Add the stored link UIDs to `DeleteLinkAndEvent` payloads. For directional
+federation unlinks, require both fields, validate them as distinct ULIDs, and
+require their unordered pair to equal the user-facing endpoint pair. Keep the
+primary issue envelope unchanged. Make `db.FoldEvents` prefer the storage pair
+when applying unlink tombstones.
+
+- [ ] **Step 3: Reject null aggregate UID lists**
+
+Add a `blocks_removed_uids: null` regression. Before unmarshalling any
+aggregated UID-list field into `[]string`, require its trimmed JSON to begin
+with `[`; `null`, objects, and scalars are validation failures.
+
+- [ ] **Step 4: Verify, commit, and re-review**
+
+Run the full shuffled verification set, commit without rewriting history,
+push, and require the next complete branch review to pass.

--- a/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
+++ b/docs/superpowers/plans/2026-07-09-federated-cross-project-links.md
@@ -17,7 +17,94 @@
 - Different DNS names or IP aliases remain different groups even when they reach the same daemon.
 - Use neutral names such as `spoke-project`, `peer-project`, and `hub.example` in tests and documentation.
 - Do not add bash content-assertion tests or tests of `net/url` behavior.
+- Every CI test command must remove `KATA_AUTH_TOKEN` from its process
+  environment; an empty value is not a substitute for unsetting it.
 - Recover old quarantines with retry, never skip, after compatible binaries are running.
+
+---
+
+### Task 0: Isolate CI Tests From Inherited Daemon Credentials
+
+**Files:**
+- Modify: `.github/workflows/test.yml:28-30`
+- Modify: `.github/workflows/test.yml:53-57`
+- Modify: `.github/workflows/test.yml:89-90`
+- Modify: `.github/workflows/test.yml:132-133`
+- Modify: `.github/workflows/test.yml:151-152`
+
+**Interfaces:**
+- Consumes: the existing GitHub Actions test commands on Ubuntu and Windows.
+- Produces: every CI test process starts without `KATA_AUTH_TOKEN`; build,
+  vet, lint, and publishing jobs keep their current environments.
+
+- [ ] **Step 1: Unset the token at every test command boundary**
+
+Change the five test entry points to:
+
+~~~yaml
+      - name: Run tests
+        run: env -u KATA_AUTH_TOKEN go test -p 1 ./...
+~~~
+
+~~~yaml
+      - name: Run tests
+        shell: bash
+        env:
+          KATA_TEST_FAST_SQLITE: "1"
+        run: env -u KATA_AUTH_TOKEN go test -p 4 -vet=off ./...
+~~~
+
+~~~yaml
+      - name: Run release script tests
+        run: env -u KATA_AUTH_TOKEN make release-scripts-test
+~~~
+
+~~~yaml
+      - name: Run federation stress tests
+        run: env -u KATA_AUTH_TOKEN make test-stress
+~~~
+
+~~~yaml
+      - name: Run federation Docker tests
+        run: env -u KATA_AUTH_TOKEN make test-federation-docker
+~~~
+
+Do not change build, vet, lint, nilaway, release, or publishing commands.
+
+- [ ] **Step 2: Validate the workflow as configuration**
+
+Run:
+
+~~~bash
+if command -v actionlint >/dev/null 2>&1; then actionlint .github/workflows/test.yml; fi
+git diff --check
+~~~
+
+Expected: both commands exit zero. Do not add a test that greps or parses the
+workflow to assert its source text.
+
+- [ ] **Step 3: Prove the clean test environment fixes the untouched baseline**
+
+Run:
+
+~~~bash
+env -u KATA_AUTH_TOKEN go test -shuffle=on ./...
+~~~
+
+Expected: PASS. This is the same untouched baseline that failed when the
+developer shell's daemon credential was inherited.
+
+- [ ] **Step 4: Commit CI isolation**
+
+Use the mandatory `commit` skill, then:
+
+~~~bash
+git add .github/workflows/test.yml
+git commit -m "Isolate CI tests from daemon credentials"
+~~~
+
+The commit body must explain that inherited runner credentials override test
+fixtures and that commands remove the variable rather than setting it empty.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
+++ b/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
@@ -70,7 +70,14 @@ parent map must also satisfy the normal single-parent, acyclic, and
 Aggregated `issue.links_changed` UID fields are decoded strictly as well:
 parent fields are strings and add/remove fields are arrays containing only
 strings. Wrong containers, mixed element types, and wrong scalar types fail the
-originating batch instead of becoming an empty link delta.
+originating batch instead of becoming an empty link delta. JSON `null` is not
+an array and is rejected for every UID-list field.
+
+Directional unlink events keep `issue_uid` and the user-facing `from_uid` for
+project attribution, while carrying `link_from_uid` and `link_to_uid` in stored
+edge orientation. Federation validates that both endpoint pairs describe the
+same issues and folds the storage-oriented pair, so deleting through the
+destination endpoint tombstones the actual `blocks` or `parent` edge.
 
 Deferred peer UIDs are never promoted to known primary issues. Across ingest
 batches, the known-primary set comes from materialized issues and stored
@@ -158,6 +165,8 @@ assertions:
   before projection writes;
 - malformed aggregated link-change UID fields cannot advance the cursor as an
   empty mutation;
+- destination-side directional unlinks remove the stored edge without losing
+  primary-issue attribution;
 - unknown primary issues and existing poisoned-event cases remain rejected;
   and
 - same-project links continue to materialize and unlink correctly.

--- a/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
+++ b/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
@@ -1,0 +1,118 @@
+# Federated Cross-Project Links Design
+
+## Problem
+
+Federation currently validates every issue reference within the project being
+ingested. If two independently synchronized projects create issues whose links
+refer to each other, either project can arrive first and be rejected because
+the other endpoint is not present yet. Both spokes then quarantine their first
+outbound batches, and neither project can make the issue visible that would
+allow the other batch to pass validation.
+
+Temporary absence is acceptable for a cross-project edge. Permanent
+quarantine is not.
+
+## Behavioral Contract
+
+An otherwise valid federation event is accepted when a link peer is not
+present yet. Its event remains the durable source of pending projection state.
+The edge is absent from the read model until both endpoints exist.
+
+The edge materializes only when both endpoint projects belong to the same
+federation group:
+
+- Hub projects are compatible when both are enabled hub bindings on the same
+  daemon.
+- Spoke projects are compatible when both are enabled spoke bindings targeting
+  the same normalized hub origin. The origin comparison uses the stored hub
+  URL's scheme, lowercase hostname, and effective port. Different DNS names or
+  IP aliases are different groups even if they reach the same daemon, so
+  operators must use one consistent hub URL for projects that share links.
+
+If the peer never arrives, is not federated, or belongs to another federation
+group, the event remains stored but the edge remains absent. Arrival order does
+not affect the eventual result.
+
+## Validation Boundary
+
+Federation ingest continues to reject:
+
+- an event targeting the wrong project or originating from the wrong spoke;
+- malformed envelopes or payloads;
+- unknown primary issue references for non-create events;
+- actor or payload-author violations;
+- content-hash conflicts;
+- unsupported event types; and
+- fresh create or snapshot events that collide with known issues.
+
+Only peer references used to describe links may be unresolved. An unknown
+primary issue is still a poisoned event rather than deferred work.
+
+## Projection Architecture
+
+Issue, comment, label, and metadata projection remains project-scoped.
+Federated link projection becomes group-scoped.
+
+After a member project materializes its project-scoped state, kata folds link
+events for the compatible federation group, resolves endpoint UIDs against
+materialized issues in that group, and reconciles the group's links. Unresolved
+edges are skipped for that pass without discarding their events. Materializing
+any group member reruns link reconciliation, so the later endpoint causes a
+previously deferred edge to appear.
+
+Group-scoped reconciliation also owns deletion. It computes desired links from
+the complete compatible event set before removing stale federated links, so
+one project cannot delete an edge whose authoritative event belongs to another
+project.
+
+Same-project links use the same reconciliation path and retain their current
+observable behavior.
+
+## Data Flow
+
+1. `spoke-project` pushes an issue event containing a link to an issue UID that
+   is not present on the hub.
+2. The hub validates the event's envelope, primary issue, actor, payload, and
+   hash, then stores it and advances the push cursor.
+3. Group link reconciliation cannot resolve the peer, so it leaves the edge
+   absent.
+4. `peer-project` later pushes the peer issue.
+5. Materializing `peer-project` triggers reconciliation for the shared
+   federation group.
+6. Both endpoint UIDs now resolve inside the group, so kata materializes the
+   edge.
+7. Pulling clients converge through the same group reconciliation when they
+   have enrolled both projects. A client with only one project keeps the edge
+   absent.
+
+## Error and Recovery Behavior
+
+A missing link peer is eventual-consistency state and must not create a
+quarantine. Genuine validation failures retain existing quarantine behavior.
+
+Quarantines created by older versions for missing cross-project peers are not
+silently skipped. After compatible versions are running on the hub and spoke,
+an operator retries each affected push quarantine. Retry preserves the cursor
+and resends the original events; successful ingest then converges normally.
+
+## Verification
+
+Tests use neutral project names and exercise behavior rather than source-text
+assertions:
+
+- a cross-project link event is accepted before its peer exists;
+- the edge is initially absent and appears after the peer project arrives;
+- two projects whose first batches reference each other both advance without
+  quarantine;
+- an unresolved peer remains absent without blocking later events;
+- projects assigned to different federation groups do not materialize an edge;
+- unknown primary issues and existing poisoned-event cases remain rejected;
+  and
+- same-project links continue to materialize and unlink correctly.
+
+## Documentation
+
+The federation design and operations guides will describe deferred
+cross-project edges, the same-hub constraint, client enrollment requirements,
+temporary absence, and retry-based recovery for quarantines produced by older
+versions.

--- a/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
+++ b/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
@@ -110,6 +110,21 @@ assertions:
   and
 - same-project links continue to materialize and unlink correctly.
 
+## CI Environment Isolation
+
+CI tests must not inherit `KATA_AUTH_TOKEN` from a runner or job environment.
+Every test entry point in `.github/workflows/test.yml` removes the variable at
+the command boundary with `env -u KATA_AUTH_TOKEN`. The Windows Go test step
+uses Bash so the same exact unset operation applies on every operating system.
+
+This applies to the main Go suite, the Windows Go suite, release-script tests,
+federation stress tests, and federation Docker tests. Build, vet, lint,
+release publication, and production commands are unchanged.
+
+The workflow change is verified by running `actionlint` when available and by
+running the repository test suite with the token absent. No test asserts
+workflow source text.
+
 ## Documentation
 
 The federation design and operations guides will describe deferred

--- a/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
+++ b/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
@@ -84,8 +84,8 @@ Changing federation-group membership reconciles links in the same transaction
 as the binding change. Kata captures the old group, applies the new binding,
 then reconciles the affected old and new groups. A standalone peer that becomes
 an enabled member therefore activates a previously deferred link immediately;
-moving or disabling a member also removes link projection that the old group no
-longer owns.
+moving, disabling, or leaving a member also removes link projection that the
+old group no longer owns.
 
 ## Data Flow
 

--- a/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
+++ b/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
@@ -55,6 +55,12 @@ envelope `related_issue_uid`, when present, must identify the opposite
 endpoint. Snapshot and aggregated link payloads treat their listed targets as
 peers of the primary issue. Only those peers may be unresolved.
 
+Deferred links must already be structurally valid before storage. Their type
+is one of `parent`, `blocks`, or `related`; every peer is a valid non-self issue
+UID; and explicit link events use the canonical `from_uid` and `to_uid` fields
+that the fold consumes. Deferral relaxes endpoint existence only, not payload
+shape or link semantics.
+
 Deferred peer UIDs are never promoted to known primary issues. Across ingest
 batches, the known-primary set comes from materialized issues and stored
 `issue.created` or `issue.snapshot` primary UIDs. Within one batch, only a
@@ -86,6 +92,12 @@ then reconciles the affected old and new groups. A standalone peer that becomes
 an enabled member therefore activates a previously deferred link immediately;
 moving, disabling, or leaving a member also removes link projection that the
 old group no longer owns.
+
+Federation baselines snapshot every incident link, not only links where the
+snapshot issue is the stored source endpoint. Directional incoming edges carry
+`incoming: true`; symmetric related edges retain canonical fold ordering. This
+preserves the durable edge event when adoption replaces local event history and
+the destination endpoint joins before the source endpoint.
 
 ## Data Flow
 
@@ -128,6 +140,9 @@ assertions:
 - a project-scoped event cannot mutate an edge between two unrelated issues;
 - a deferred peer cannot authorize a later primary-issue mutation;
 - enabling an existing peer project immediately materializes its deferred edge;
+- destination-first adoption preserves incoming cross-project edges;
+- malformed types, peer UIDs, self-links, and alternate-only endpoints fail at
+  ingest rather than after peer arrival;
 - unknown primary issues and existing poisoned-event cases remain rejected;
   and
 - same-project links continue to materialize and unlink correctly.

--- a/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
+++ b/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
@@ -61,6 +61,12 @@ UID; and explicit link events use the canonical `from_uid` and `to_uid` fields
 that the fold consumes. Deferral relaxes endpoint existence only, not payload
 shape or link semantics.
 
+Snapshot and create `links` containers and fields must decode without JSON
+type errors; malformed link JSON is a validation failure, never an empty-link
+fallback. Before group reconciliation writes any edge, the complete desired
+parent map must also satisfy the normal single-parent, acyclic, and
+`MaxParentDepth` invariants.
+
 Deferred peer UIDs are never promoted to known primary issues. Across ingest
 batches, the known-primary set comes from materialized issues and stored
 `issue.created` or `issue.snapshot` primary UIDs. Within one batch, only a
@@ -143,6 +149,8 @@ assertions:
 - destination-first adoption preserves incoming cross-project edges;
 - malformed types, peer UIDs, self-links, and alternate-only endpoints fail at
   ingest rather than after peer arrival;
+- malformed link JSON and deferred cross-project parent cycles are rejected
+  before projection writes;
 - unknown primary issues and existing poisoned-event cases remain rejected;
   and
 - same-project links continue to materialize and unlink correctly.

--- a/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
+++ b/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
@@ -48,6 +48,18 @@ Federation ingest continues to reject:
 Only peer references used to describe links may be unresolved. An unknown
 primary issue is still a poisoned event rather than deferred work.
 
+Deferral does not expand a project-scoped federation credential. Every link
+mutation must involve the event's validated primary issue. For explicit
+`from_uid`/`to_uid` events, one endpoint must equal the primary issue and an
+envelope `related_issue_uid`, when present, must identify the opposite
+endpoint. Snapshot and aggregated link payloads treat their listed targets as
+peers of the primary issue. Only those peers may be unresolved.
+
+Deferred peer UIDs are never promoted to known primary issues. Across ingest
+batches, the known-primary set comes from materialized issues and stored
+`issue.created` or `issue.snapshot` primary UIDs. Within one batch, only a
+validated create or snapshot adds its primary UID to that set.
+
 ## Projection Architecture
 
 Issue, comment, label, and metadata projection remains project-scoped.
@@ -67,6 +79,13 @@ project.
 
 Same-project links use the same reconciliation path and retain their current
 observable behavior.
+
+Changing federation-group membership reconciles links in the same transaction
+as the binding change. Kata captures the old group, applies the new binding,
+then reconciles the affected old and new groups. A standalone peer that becomes
+an enabled member therefore activates a previously deferred link immediately;
+moving or disabling a member also removes link projection that the old group no
+longer owns.
 
 ## Data Flow
 
@@ -106,6 +125,9 @@ assertions:
   quarantine;
 - an unresolved peer remains absent without blocking later events;
 - projects assigned to different federation groups do not materialize an edge;
+- a project-scoped event cannot mutate an edge between two unrelated issues;
+- a deferred peer cannot authorize a later primary-issue mutation;
+- enabling an existing peer project immediately materializes its deferred edge;
 - unknown primary issues and existing poisoned-event cases remain rejected;
   and
 - same-project links continue to materialize and unlink correctly.

--- a/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
+++ b/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
@@ -67,6 +67,11 @@ fallback. Before group reconciliation writes any edge, the complete desired
 parent map must also satisfy the normal single-parent, acyclic, and
 `MaxParentDepth` invariants.
 
+Aggregated `issue.links_changed` UID fields are decoded strictly as well:
+parent fields are strings and add/remove fields are arrays containing only
+strings. Wrong containers, mixed element types, and wrong scalar types fail the
+originating batch instead of becoming an empty link delta.
+
 Deferred peer UIDs are never promoted to known primary issues. Across ingest
 batches, the known-primary set comes from materialized issues and stored
 `issue.created` or `issue.snapshot` primary UIDs. Within one batch, only a
@@ -151,6 +156,8 @@ assertions:
   ingest rather than after peer arrival;
 - malformed link JSON and deferred cross-project parent cycles are rejected
   before projection writes;
+- malformed aggregated link-change UID fields cannot advance the cursor as an
+  empty mutation;
 - unknown primary issues and existing poisoned-event cases remain rejected;
   and
 - same-project links continue to materialize and unlink correctly.

--- a/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
+++ b/docs/superpowers/specs/2026-07-09-federated-cross-project-links-design.md
@@ -79,6 +79,11 @@ edge orientation. Federation validates that both endpoint pairs describe the
 same issues and folds the storage-oriented pair, so deleting through the
 destination endpoint tombstones the actual `blocks` or `parent` edge.
 
+Legacy v0.9 directional unlink payloads without that storage pair are
+intentionally unsupported. Ingest rejects them instead of inferring direction
+from graph state or adding a compatibility read path. This is a deliberate
+pre-1.0 event-contract boundary.
+
 Deferred peer UIDs are never promoted to known primary issues. Across ingest
 batches, the known-primary set comes from materialized issues and stored
 `issue.created` or `issue.snapshot` primary UIDs. Within one batch, only a
@@ -88,6 +93,12 @@ validated create or snapshot adds its primary UID to that set.
 
 Issue, comment, label, and metadata projection remains project-scoped.
 Federated link projection becomes group-scoped.
+
+Best-effort claim-violation annotation follows that same group boundary for
+link mutations. Every materialized endpoint is resolved to its owning project,
+that project's timed claims are expired, and a live conflicting claim produces
+`claim.violated` in the endpoint's project rather than only in the project that
+carried the link event.
 
 After a member project materializes its project-scoped state, kata folds link
 events for the compatible federation group, resolves endpoint UIDs against
@@ -167,6 +178,8 @@ assertions:
   empty mutation;
 - destination-side directional unlinks remove the stored edge without losing
   primary-issue attribution;
+- legacy v0.9 directional unlinks without storage endpoints remain rejected;
+- claim-violation audit covers materialized link peers in compatible projects;
 - unknown primary issues and existing poisoned-event cases remain rejected;
   and
 - same-project links continue to materialize and unlink correctly.

--- a/internal/daemon/handlers_links_test.go
+++ b/internal/daemon/handlers_links_test.go
@@ -352,12 +352,16 @@ func TestDeleteLink_EventPayloadOrientsFromURLIssue(t *testing.T) {
 		ToShortID   string `json:"to_short_id"`
 		FromUID     string `json:"from_uid"`
 		ToUID       string `json:"to_uid"`
+		LinkFromUID string `json:"link_from_uid"`
+		LinkToUID   string `json:"link_to_uid"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(lastEventPayload(t, env, pid, "issue.unlinked")), &pl))
 	assert.Equal(t, bIss.ShortID, pl.FromShortID, "from_short_id must be the URL issue (B)")
 	assert.Equal(t, aIss.ShortID, pl.ToShortID, "to_short_id must be the peer (A)")
 	assert.Equal(t, bIss.UID, pl.FromUID, "from_uid must be the URL issue (B)")
 	assert.Equal(t, aIss.UID, pl.ToUID, "to_uid must be the peer (A)")
+	assert.Equal(t, aIss.UID, pl.LinkFromUID, "link_from_uid must preserve storage direction")
+	assert.Equal(t, bIss.UID, pl.LinkToUID, "link_to_uid must preserve storage direction")
 }
 
 // TestCreateLink_ArchivedPeerIs409 pins that POST /links rejects a link whose

--- a/internal/db/fold.go
+++ b/internal/db/fold.go
@@ -403,6 +403,16 @@ func (p *FoldProjection) applyLinkEvent(e FoldEvent, payload map[string]json.Raw
 		linkTo, linkToOK := stringValue(payload["link_to_uid"])
 		if linkFromOK && linkToOK {
 			from, to = linkFrom, linkTo
+		} else if _, fromPresent := payload["link_from_uid"]; !fromPresent {
+			if _, toPresent := payload["link_to_uid"]; !toPresent && (typ == "blocks" || typ == "parent") {
+				// Legacy unlinks describe the edge from the event issue's point
+				// of view. Resolve a destination-side event against folded state.
+				forward := p.Links[FoldLinkKey{FromUID: from, ToUID: to, Type: typ}]
+				reverse := p.Links[FoldLinkKey{FromUID: to, ToUID: from, Type: typ}]
+				if !forward.Present && reverse.Present {
+					from, to = to, from
+				}
+			}
 		}
 	}
 	p.setLink(from, to, typ, present, clockOf(e), e.Actor)

--- a/internal/db/fold.go
+++ b/internal/db/fold.go
@@ -398,6 +398,13 @@ func (p *FoldProjection) applyLinkEvent(e FoldEvent, payload map[string]json.Raw
 	if !fromOK || !toOK {
 		return
 	}
+	if !present {
+		linkFrom, linkFromOK := stringValue(payload["link_from_uid"])
+		linkTo, linkToOK := stringValue(payload["link_to_uid"])
+		if linkFromOK && linkToOK {
+			from, to = linkFrom, linkTo
+		}
+	}
 	p.setLink(from, to, typ, present, clockOf(e), e.Actor)
 	p.touchIssue(issueUID(e, payload), issueUpdatedAt(e, payload))
 }

--- a/internal/db/fold.go
+++ b/internal/db/fold.go
@@ -164,7 +164,7 @@ func (p *FoldProjection) applyIssueCreated(e FoldEvent) {
 			continue
 		}
 		from, to := uid, link.ToIssueUID
-		if link.Incoming && link.Type == "blocks" {
+		if link.Incoming && link.Type != "related" {
 			from, to = to, from
 		}
 		author := link.Author

--- a/internal/db/sqlitestore/claims.go
+++ b/internal/db/sqlitestore/claims.go
@@ -1241,7 +1241,11 @@ func federationIngestClaimAuditIssueUIDs(ev db.RemoteEvent) ([]federationIngestC
 		add(federationIngestClaimAuditIssue{UID: issueUID, RequireClaim: true})
 	}
 	if ev.Type == "issue.created" || ev.Type == "issue.snapshot" || claimWorkMutationRequiresPeerClaim(ev.Type) {
-		for _, ref := range payloadReferencedIssueUIDs(ev, payload) {
+		refs, err := payloadReferencedIssueUIDs(ev, payload)
+		if err != nil {
+			return nil, err
+		}
+		for _, ref := range refs {
 			add(federationIngestClaimAuditIssue{
 				UID:          ref,
 				RequireClaim: true,

--- a/internal/db/sqlitestore/claims.go
+++ b/internal/db/sqlitestore/claims.go
@@ -1141,9 +1141,8 @@ type federationIngestClaimAuditIssue struct {
 
 func (d *Store) annotateFederationIngestClaimWorkTx(
 	ctx context.Context,
-	tx claimStore,
+	tx *sql.Tx,
 	projectID int64,
-	projectName string,
 	ev db.RemoteEvent,
 ) ([]db.Event, error) {
 	issueUIDs, err := federationIngestClaimAuditIssueUIDs(ev)
@@ -1153,35 +1152,28 @@ func (d *Store) annotateFederationIngestClaimWorkTx(
 	if len(issueUIDs) == 0 {
 		return nil, nil
 	}
-	var events []db.Event
-	claimsExpired := false
-	ensureClaimsExpired := func() error {
-		if claimsExpired {
-			return nil
-		}
-		expiredEvents, err := d.expireTimedClaimsForProjectTx(ctx, tx, projectID, time.Now().UTC(), 0)
-		if err != nil {
-			return err
-		}
-		events = append(events, expiredEvents...)
-		claimsExpired = true
-		return nil
+	binding, err := scanFederationBinding(tx.QueryRowContext(ctx,
+		federationBindingSelect+` WHERE project_id = ?`, projectID))
+	if err != nil {
+		return nil, err
 	}
+	groupProjectIDs, err := federationBindingGroupProjectIDs(ctx, tx, binding)
+	if err != nil {
+		return nil, err
+	}
+	var events []db.Event
 	for _, issue := range issueUIDs {
-		issueID, err := issueIDByUIDForClaimAuditTx(ctx, tx, projectID, issue.UID)
+		target, err := issueForClaimAuditInGroupTx(ctx, tx, groupProjectIDs, issue.UID)
 		if errors.Is(err, db.ErrNotFound) {
 			continue
 		}
 		if err != nil {
 			return nil, err
 		}
-		if err := ensureClaimsExpired(); err != nil {
-			return nil, err
-		}
 		auditEvents, err := d.annotateClaimWorkMutationTx(ctx, tx, claimWorkMutationInput{
-			ProjectID:         projectID,
-			ProjectName:       projectName,
-			IssueID:           issueID,
+			ProjectID:         target.ProjectID,
+			ProjectName:       target.ProjectName,
+			IssueID:           target.IssueID,
 			IssueUID:          issue.UID,
 			OffendingEventUID: ev.EventUID,
 			EventType:         ev.Type,
@@ -1353,17 +1345,41 @@ func enabledHubFederationBindingTx(ctx context.Context, tx claimStore, projectID
 	return enabled == 1 && role == string(db.FederationRoleHub), nil
 }
 
-func issueIDByUIDForClaimAuditTx(ctx context.Context, tx claimStore, projectID int64, issueUID string) (int64, error) {
-	var id int64
-	err := tx.QueryRowContext(ctx,
-		`SELECT id FROM issues WHERE project_id = ? AND uid = ?`, projectID, issueUID).Scan(&id)
+type federationClaimAuditTarget struct {
+	IssueID     int64
+	ProjectID   int64
+	ProjectName string
+}
+
+func issueForClaimAuditInGroupTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectIDs []int64,
+	issueUID string,
+) (federationClaimAuditTarget, error) {
+	if len(projectIDs) == 0 {
+		return federationClaimAuditTarget{}, db.ErrNotFound
+	}
+	placeholders, projectArgs := projectIDPlaceholders(projectIDs)
+	args := make([]any, 0, len(projectArgs)+1)
+	args = append(args, issueUID)
+	args = append(args, projectArgs...)
+	var target federationClaimAuditTarget
+	//nolint:gosec // IN values use generated ? placeholders with separately bound integer IDs.
+	err := tx.QueryRowContext(ctx, `
+		SELECT i.id, i.project_id, p.name
+		  FROM issues i
+		  JOIN projects p ON p.id = i.project_id
+		 WHERE i.uid = ?
+		   AND i.project_id IN (`+placeholders+`)`, args...).
+		Scan(&target.IssueID, &target.ProjectID, &target.ProjectName)
 	if errors.Is(err, sql.ErrNoRows) {
-		return 0, db.ErrNotFound
+		return federationClaimAuditTarget{}, db.ErrNotFound
 	}
 	if err != nil {
-		return 0, fmt.Errorf("lookup claim audit issue: %w", err)
+		return federationClaimAuditTarget{}, fmt.Errorf("lookup claim audit issue: %w", err)
 	}
-	return id, nil
+	return target, nil
 }
 
 func latestClaimOffendingEventUIDTx(

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -1024,7 +1026,7 @@ func (d *Store) materializeFederatedProjectTx(ctx context.Context, tx *sql.Tx, p
 	if err := reconcileFederatedLabels(ctx, tx, projectID, issueIDs, projection); err != nil {
 		return err
 	}
-	if err := reconcileFederatedLinks(ctx, tx, projectID, issueIDs, projection); err != nil {
+	if err := reconcileFederatedLinks(ctx, tx, binding, projectID, issueIDs); err != nil {
 		return err
 	}
 	if err := pruneFederatedIssues(ctx, tx, projectID, issueIDs); err != nil {
@@ -1847,8 +1849,26 @@ func (r federatedLinkRow) key() db.FoldLinkKey {
 	return db.FoldLinkKey{FromUID: r.fromUID, ToUID: r.toUID, Type: r.typ}
 }
 
-func reconcileFederatedLinks(ctx context.Context, tx *sql.Tx, projectID int64, issueIDs map[string]int64, projection db.FoldProjection) error {
-	existing, err := federatedLinkRows(ctx, tx, projectID)
+func reconcileFederatedLinks(
+	ctx context.Context,
+	tx *sql.Tx,
+	binding db.FederationBinding,
+	currentProjectID int64,
+	currentIssueIDs map[string]int64,
+) error {
+	projectIDs, err := federationBindingGroupProjectIDs(ctx, tx, binding)
+	if err != nil {
+		return err
+	}
+	projection, err := federationGroupFoldProjection(ctx, tx, projectIDs)
+	if err != nil {
+		return err
+	}
+	issueIDs, err := federationGroupIssueIDs(ctx, tx, projectIDs, currentProjectID, currentIssueIDs)
+	if err != nil {
+		return err
+	}
+	existing, err := federatedLinkRows(ctx, tx, projectIDs)
 	if err != nil {
 		return err
 	}
@@ -1926,17 +1946,153 @@ func reconcileFederatedLinks(ctx context.Context, tx *sql.Tx, projectID int64, i
 	return nil
 }
 
-// federatedLinkRows returns the existing mirror links for a federated
-// project. Storage v16 dropped links.project_id, so the project scope now
-// comes from the endpoints: a federated mirror links two issues materialized
-// into the same shadow project, so both endpoints sit in projectID.
-func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectID int64) (map[db.FoldLinkKey]federatedLinkRow, error) {
+func normalizedFederationHubOrigin(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" {
+		return "", fmt.Errorf("invalid federation hub URL %q", raw)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	port := parsed.Port()
+	switch scheme {
+	case "http":
+		if port == "" {
+			port = "80"
+		}
+	case "https":
+		if port == "" {
+			port = "443"
+		}
+	default:
+		return "", fmt.Errorf("invalid federation hub URL %q: unsupported scheme %q", raw, parsed.Scheme)
+	}
+	return scheme + "://" + net.JoinHostPort(strings.ToLower(parsed.Hostname()), port), nil
+}
+
+func federationBindingGroupProjectIDs(
+	ctx context.Context,
+	tx *sql.Tx,
+	current db.FederationBinding,
+) ([]int64, error) {
+	switch current.Role {
+	case db.FederationRoleHub:
+	case db.FederationRoleSpoke:
+	default:
+		return nil, fmt.Errorf("unsupported federation group role %q", current.Role)
+	}
+	currentOrigin := ""
+	if current.Role == db.FederationRoleSpoke {
+		var err error
+		currentOrigin, err = normalizedFederationHubOrigin(current.HubURL)
+		if err != nil {
+			return nil, err
+		}
+	}
+	rows, err := tx.QueryContext(ctx,
+		federationBindingSelect+` WHERE role = ? AND enabled = 1 ORDER BY project_id ASC`,
+		string(current.Role))
+	if err != nil {
+		return nil, fmt.Errorf("list federation group bindings: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var projectIDs []int64
+	for rows.Next() {
+		candidate, err := scanFederationBinding(rows)
+		if err != nil {
+			return nil, err
+		}
+		if current.Role == db.FederationRoleSpoke {
+			candidateOrigin, err := normalizedFederationHubOrigin(candidate.HubURL)
+			if err != nil {
+				if candidate.ProjectID == current.ProjectID {
+					return nil, err
+				}
+				continue
+			}
+			if candidateOrigin != currentOrigin {
+				continue
+			}
+		}
+		projectIDs = append(projectIDs, candidate.ProjectID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate federation group bindings: %w", err)
+	}
+	return projectIDs, nil
+}
+
+func federationGroupFoldProjection(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectIDs []int64,
+) (db.FoldProjection, error) {
+	var events []db.FoldEvent
+	for _, projectID := range projectIDs {
+		projectEvents, err := federationFoldEvents(ctx, tx, projectID)
+		if err != nil {
+			return db.FoldProjection{}, err
+		}
+		events = append(events, projectEvents...)
+	}
+	return db.FoldEvents(events), nil
+}
+
+func federationGroupIssueIDs(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectIDs []int64,
+	currentProjectID int64,
+	currentIssueIDs map[string]int64,
+) (map[string]int64, error) {
+	placeholders, args := projectIDPlaceholders(projectIDs)
+	rows, err := tx.QueryContext(ctx, `
+		SELECT uid, id, project_id
+		  FROM issues
+		 WHERE project_id IN (`+placeholders+`)
+		 ORDER BY project_id, id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list federation group issues: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := map[string]int64{}
+	for rows.Next() {
+		var (
+			uid       string
+			issueID   int64
+			projectID int64
+		)
+		if err := rows.Scan(&uid, &issueID, &projectID); err != nil {
+			return nil, fmt.Errorf("scan federation group issue: %w", err)
+		}
+		if projectID == currentProjectID {
+			currentIssueID, ok := currentIssueIDs[uid]
+			if ok {
+				out[uid] = currentIssueID
+			}
+			continue
+		}
+		out[uid] = issueID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate federation group issues: %w", err)
+	}
+	return out, nil
+}
+
+// federatedLinkRows returns every existing link touching a federation group.
+// Group reconciliation owns both insertion and deletion so one member cannot
+// remove an edge represented by another member's event stream.
+func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectIDs []int64) (map[db.FoldLinkKey]federatedLinkRow, error) {
+	placeholders, args := projectIDPlaceholders(projectIDs)
+	queryArgs := make([]any, 0, len(args)*2)
+	queryArgs = append(queryArgs, args...)
+	queryArgs = append(queryArgs, args...)
 	rows, err := tx.QueryContext(ctx, `
 		SELECT l.id, l.from_issue_id, l.to_issue_id, l.from_issue_uid, l.to_issue_uid, l.type, l.author
 		  FROM links l
 		  JOIN issues f ON f.id = l.from_issue_id
 		  JOIN issues t ON t.id = l.to_issue_id
-		 WHERE f.project_id = ? AND t.project_id = ?`, projectID, projectID)
+		 WHERE f.project_id IN (`+placeholders+`)
+		    OR t.project_id IN (`+placeholders+`)`, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("list federated links: %w", err)
 	}

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -2044,6 +2044,7 @@ func federationGroupIssueIDs(
 	currentIssueIDs map[string]int64,
 ) (map[string]int64, error) {
 	placeholders, args := projectIDPlaceholders(projectIDs)
+	//nolint:gosec // IN values use generated ? placeholders with separately bound integer IDs.
 	rows, err := tx.QueryContext(ctx, `
 		SELECT uid, id, project_id
 		  FROM issues
@@ -2086,6 +2087,7 @@ func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectIDs []int64) (map
 	queryArgs := make([]any, 0, len(args)*2)
 	queryArgs = append(queryArgs, args...)
 	queryArgs = append(queryArgs, args...)
+	//nolint:gosec // IN values use generated ? placeholders with separately bound integer IDs.
 	rows, err := tx.QueryContext(ctx, `
 		SELECT l.id, l.from_issue_id, l.to_issue_id, l.from_issue_uid, l.to_issue_uid, l.type, l.author
 		  FROM links l

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -411,7 +411,10 @@ func (d *Store) upsertFederationBinding(ctx context.Context, b db.FederationBind
 			return db.FederationBinding{}, err
 		}
 	}
-
+	previous, previousGroupProjectIDs, err := federationBindingTransitionState(ctx, tx, b.ProjectID)
+	if err != nil {
+		return db.FederationBinding{}, err
+	}
 	allowInsecure := 0
 	if b.AllowInsecure {
 		allowInsecure = 1
@@ -444,6 +447,11 @@ func (d *Store) upsertFederationBinding(ctx context.Context, b db.FederationBind
 	}
 	binding, err := federationBindingByProject(ctx, tx, b.ProjectID)
 	if err != nil {
+		return db.FederationBinding{}, err
+	}
+	if err := reconcileFederationBindingTransitionLinks(
+		ctx, tx, previous, previousGroupProjectIDs, binding,
+	); err != nil {
 		return db.FederationBinding{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -488,6 +496,13 @@ func (d *Store) leaveFederationReplica(ctx context.Context, projectID int64) (db
 	if binding.Role != db.FederationRoleSpoke {
 		return db.LeaveFederationResult{}, db.ErrFederationNotSpoke
 	}
+	var previousGroupProjectIDs []int64
+	if binding.Enabled {
+		previousGroupProjectIDs, err = federationBindingGroupProjectIDs(ctx, tx, binding)
+		if err != nil {
+			return db.LeaveFederationResult{}, err
+		}
+	}
 
 	for _, stmt := range []string{
 		`DELETE FROM federation_quarantine WHERE project_id = ?`,
@@ -499,6 +514,11 @@ func (d *Store) leaveFederationReplica(ctx context.Context, projectID int64) (db
 		}
 	}
 	if err := clearProjectClaimStateTx(ctx, tx, projectID); err != nil {
+		return db.LeaveFederationResult{}, err
+	}
+	if err := reconcileFederationBindingTransitionLinks(
+		ctx, tx, &binding, previousGroupProjectIDs, db.FederationBinding{},
+	); err != nil {
 		return db.LeaveFederationResult{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -808,6 +828,15 @@ func (d *Store) enableProjectFederation(ctx context.Context, projectID int64, ac
 		if existing.Role != db.FederationRoleHub {
 			return db.FederationBinding{}, fmt.Errorf("project %d already has %q federation binding", projectID, existing.Role)
 		}
+		if existing.Enabled {
+			groupProjectIDs, err := federationBindingGroupProjectIDs(ctx, tx, existing)
+			if err != nil {
+				return db.FederationBinding{}, err
+			}
+			if err := reconcileFederatedLinkGroup(ctx, tx, groupProjectIDs, groupProjectIDs, 0, nil); err != nil {
+				return db.FederationBinding{}, err
+			}
+		}
 		if err := tx.Commit(); err != nil {
 			return db.FederationBinding{}, fmt.Errorf("commit existing federation binding: %w", err)
 		}
@@ -838,6 +867,9 @@ func (d *Store) enableProjectFederation(ctx context.Context, projectID int64, ac
 	binding, err := scanFederationBinding(tx.QueryRowContext(ctx,
 		federationBindingSelect+` WHERE project_id = ?`, project.ID))
 	if err != nil {
+		return db.FederationBinding{}, err
+	}
+	if err := reconcileFederationBindingTransitionLinks(ctx, tx, nil, nil, binding); err != nil {
 		return db.FederationBinding{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -1860,15 +1892,26 @@ func reconcileFederatedLinks(
 	if err != nil {
 		return err
 	}
-	projection, err := federationGroupFoldProjection(ctx, tx, projectIDs)
+	return reconcileFederatedLinkGroup(ctx, tx, projectIDs, projectIDs, currentProjectID, currentIssueIDs)
+}
+
+func reconcileFederatedLinkGroup(
+	ctx context.Context,
+	tx *sql.Tx,
+	desiredProjectIDs []int64,
+	ownedProjectIDs []int64,
+	currentProjectID int64,
+	currentIssueIDs map[string]int64,
+) error {
+	projection, err := federationGroupFoldProjection(ctx, tx, desiredProjectIDs)
 	if err != nil {
 		return err
 	}
-	issueIDs, err := federationGroupIssueIDs(ctx, tx, projectIDs, currentProjectID, currentIssueIDs)
+	issueIDs, err := federationGroupIssueIDs(ctx, tx, desiredProjectIDs, currentProjectID, currentIssueIDs)
 	if err != nil {
 		return err
 	}
-	existing, err := federatedLinkRows(ctx, tx, projectIDs)
+	existing, err := federatedLinkRows(ctx, tx, ownedProjectIDs)
 	if err != nil {
 		return err
 	}
@@ -1944,6 +1987,57 @@ func reconcileFederatedLinks(
 		}
 	}
 	return nil
+}
+
+func federationBindingTransitionState(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectID int64,
+) (*db.FederationBinding, []int64, error) {
+	previous, err := scanFederationBinding(tx.QueryRowContext(ctx,
+		federationBindingSelect+` WHERE project_id = ?`, projectID))
+	if errors.Is(err, db.ErrNotFound) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	if !previous.Enabled {
+		return &previous, nil, nil
+	}
+	projectIDs, err := federationBindingGroupProjectIDs(ctx, tx, previous)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &previous, projectIDs, nil
+}
+
+func reconcileFederationBindingTransitionLinks(
+	ctx context.Context,
+	tx *sql.Tx,
+	previous *db.FederationBinding,
+	previousGroupProjectIDs []int64,
+	current db.FederationBinding,
+) error {
+	if previous != nil && previous.Enabled {
+		remainingProjectIDs, err := federationBindingGroupProjectIDs(ctx, tx, *previous)
+		if err != nil {
+			return err
+		}
+		if err := reconcileFederatedLinkGroup(
+			ctx, tx, remainingProjectIDs, previousGroupProjectIDs, 0, nil,
+		); err != nil {
+			return err
+		}
+	}
+	if !current.Enabled {
+		return nil
+	}
+	currentProjectIDs, err := federationBindingGroupProjectIDs(ctx, tx, current)
+	if err != nil {
+		return err
+	}
+	return reconcileFederatedLinkGroup(ctx, tx, currentProjectIDs, currentProjectIDs, 0, nil)
 }
 
 func normalizedFederationHubOrigin(raw string) (string, error) {
@@ -2043,6 +2137,9 @@ func federationGroupIssueIDs(
 	currentProjectID int64,
 	currentIssueIDs map[string]int64,
 ) (map[string]int64, error) {
+	if len(projectIDs) == 0 {
+		return map[string]int64{}, nil
+	}
 	placeholders, args := projectIDPlaceholders(projectIDs)
 	//nolint:gosec // IN values use generated ? placeholders with separately bound integer IDs.
 	rows, err := tx.QueryContext(ctx, `
@@ -2083,6 +2180,9 @@ func federationGroupIssueIDs(
 // Group reconciliation owns both insertion and deletion so one member cannot
 // remove an edge represented by another member's event stream.
 func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectIDs []int64) (map[db.FoldLinkKey]federatedLinkRow, error) {
+	if len(projectIDs) == 0 {
+		return map[db.FoldLinkKey]federatedLinkRow{}, nil
+	}
 	placeholders, args := projectIDPlaceholders(projectIDs)
 	queryArgs := make([]any, 0, len(args)*2)
 	queryArgs = append(queryArgs, args...)
@@ -2342,6 +2442,9 @@ func (d *Store) adoptProjectIntoFederation(
 	binding, err := scanFederationBinding(tx.QueryRowContext(ctx,
 		federationBindingSelect+` WHERE project_id = ?`, project.ID))
 	if err != nil {
+		return db.AdoptProjectIntoFederationResult{}, err
+	}
+	if err := reconcileFederationBindingTransitionLinks(ctx, tx, nil, nil, binding); err != nil {
 		return db.AdoptProjectIntoFederationResult{}, err
 	}
 	project, err = scanProject(tx.QueryRowContext(ctx,

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -1412,11 +1412,19 @@ func federationIssueLabels(ctx context.Context, tx *sql.Tx, issueID int64) ([]st
 
 func federationIssueLinks(ctx context.Context, tx *sql.Tx, issueID int64) ([]createdLinkOut, error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT l.type, peer.short_id, peer.uid, l.author
+		SELECT l.type, peer.short_id, peer.uid, 0 AS incoming, l.author
 		  FROM links l
 		  JOIN issues peer ON peer.id = l.to_issue_id
 		 WHERE l.from_issue_id = ?
-		 ORDER BY l.type ASC, peer.uid ASC`, issueID)
+		UNION ALL
+		SELECT l.type, peer.short_id, peer.uid,
+		       CASE WHEN l.type = 'related' THEN 0 ELSE 1 END AS incoming,
+		       l.author
+		  FROM links l
+		  JOIN issues peer ON peer.id = l.from_issue_id
+		 WHERE l.to_issue_id = ?
+		   AND peer.project_id <> (SELECT project_id FROM issues WHERE id = ?)
+		 ORDER BY type ASC, uid ASC, incoming ASC`, issueID, issueID, issueID)
 	if err != nil {
 		return nil, fmt.Errorf("list federation snapshot links: %w", err)
 	}
@@ -1424,7 +1432,7 @@ func federationIssueLinks(ctx context.Context, tx *sql.Tx, issueID int64) ([]cre
 	var out []createdLinkOut
 	for rows.Next() {
 		var link createdLinkOut
-		if err := rows.Scan(&link.Type, &link.ToShortID, &link.ToIssueUID, &link.Author); err != nil {
+		if err := rows.Scan(&link.Type, &link.ToShortID, &link.ToIssueUID, &link.Incoming, &link.Author); err != nil {
 			return nil, fmt.Errorf("scan federation snapshot link: %w", err)
 		}
 		out = append(out, link)

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -411,7 +411,7 @@ func (d *Store) upsertFederationBinding(ctx context.Context, b db.FederationBind
 			return db.FederationBinding{}, err
 		}
 	}
-	previous, previousGroupProjectIDs, err := federationBindingTransitionState(ctx, tx, b.ProjectID)
+	previous, err := federationBindingTransitionState(ctx, tx, b.ProjectID)
 	if err != nil {
 		return db.FederationBinding{}, err
 	}
@@ -449,9 +449,7 @@ func (d *Store) upsertFederationBinding(ctx context.Context, b db.FederationBind
 	if err != nil {
 		return db.FederationBinding{}, err
 	}
-	if err := reconcileFederationBindingTransitionLinks(
-		ctx, tx, previous, previousGroupProjectIDs, binding,
-	); err != nil {
+	if err := reconcileFederationBindingTransitionLinks(ctx, tx, previous, binding); err != nil {
 		return db.FederationBinding{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -496,14 +494,6 @@ func (d *Store) leaveFederationReplica(ctx context.Context, projectID int64) (db
 	if binding.Role != db.FederationRoleSpoke {
 		return db.LeaveFederationResult{}, db.ErrFederationNotSpoke
 	}
-	var previousGroupProjectIDs []int64
-	if binding.Enabled {
-		previousGroupProjectIDs, err = federationBindingGroupProjectIDs(ctx, tx, binding)
-		if err != nil {
-			return db.LeaveFederationResult{}, err
-		}
-	}
-
 	for _, stmt := range []string{
 		`DELETE FROM federation_quarantine WHERE project_id = ?`,
 		`DELETE FROM federation_sync_status WHERE project_id = ?`,
@@ -516,9 +506,7 @@ func (d *Store) leaveFederationReplica(ctx context.Context, projectID int64) (db
 	if err := clearProjectClaimStateTx(ctx, tx, projectID); err != nil {
 		return db.LeaveFederationResult{}, err
 	}
-	if err := reconcileFederationBindingTransitionLinks(
-		ctx, tx, &binding, previousGroupProjectIDs, db.FederationBinding{},
-	); err != nil {
+	if err := reconcileFederationBindingTransitionLinks(ctx, tx, &binding, db.FederationBinding{}); err != nil {
 		return db.LeaveFederationResult{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -869,7 +857,7 @@ func (d *Store) enableProjectFederation(ctx context.Context, projectID int64, ac
 	if err != nil {
 		return db.FederationBinding{}, err
 	}
-	if err := reconcileFederationBindingTransitionLinks(ctx, tx, nil, nil, binding); err != nil {
+	if err := reconcileFederationBindingTransitionLinks(ctx, tx, nil, binding); err != nil {
 		return db.FederationBinding{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -2037,30 +2025,22 @@ func federationBindingTransitionState(
 	ctx context.Context,
 	tx *sql.Tx,
 	projectID int64,
-) (*db.FederationBinding, []int64, error) {
+) (*db.FederationBinding, error) {
 	previous, err := scanFederationBinding(tx.QueryRowContext(ctx,
 		federationBindingSelect+` WHERE project_id = ?`, projectID))
 	if errors.Is(err, db.ErrNotFound) {
-		return nil, nil, nil
+		return nil, nil
 	}
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	if !previous.Enabled {
-		return &previous, nil, nil
-	}
-	projectIDs, err := federationBindingGroupProjectIDs(ctx, tx, previous)
-	if err != nil {
-		return nil, nil, err
-	}
-	return &previous, projectIDs, nil
+	return &previous, nil
 }
 
 func reconcileFederationBindingTransitionLinks(
 	ctx context.Context,
 	tx *sql.Tx,
 	previous *db.FederationBinding,
-	previousGroupProjectIDs []int64,
 	current db.FederationBinding,
 ) error {
 	if previous != nil && previous.Enabled {
@@ -2069,7 +2049,7 @@ func reconcileFederationBindingTransitionLinks(
 			return err
 		}
 		if err := reconcileFederatedLinkGroup(
-			ctx, tx, remainingProjectIDs, previousGroupProjectIDs, 0, nil,
+			ctx, tx, remainingProjectIDs, remainingProjectIDs, 0, nil,
 		); err != nil {
 			return err
 		}
@@ -2488,7 +2468,7 @@ func (d *Store) adoptProjectIntoFederation(
 	if err != nil {
 		return db.AdoptProjectIntoFederationResult{}, err
 	}
-	if err := reconcileFederationBindingTransitionLinks(ctx, tx, nil, nil, binding); err != nil {
+	if err := reconcileFederationBindingTransitionLinks(ctx, tx, nil, binding); err != nil {
 		return db.AdoptProjectIntoFederationResult{}, err
 	}
 	project, err = scanProject(tx.QueryRowContext(ctx,

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -1964,6 +1964,9 @@ func reconcileFederatedLinkGroup(
 		}
 		desired[row.key()] = row
 	}
+	if err := validateFederatedParentGraph(desired); err != nil {
+		return err
+	}
 	for key, row := range existing {
 		if _, ok := desired[key]; ok {
 			continue
@@ -1992,6 +1995,39 @@ func reconcileFederatedLinkGroup(
 			VALUES(?, ?, ?, ?, ?, ?)`,
 			row.fromID, row.toID, row.fromUID, row.toUID, row.typ, nonEmptyAuthor(row.author)); err != nil {
 			return fmt.Errorf("insert federated link %s %s->%s: %w", key.Type, key.FromUID, key.ToUID, err)
+		}
+	}
+	return nil
+}
+
+func validateFederatedParentGraph(desired map[db.FoldLinkKey]federatedLinkRow) error {
+	parents := map[string]string{}
+	for key := range desired {
+		if key.Type != "parent" {
+			continue
+		}
+		if existing, ok := parents[key.FromUID]; ok && existing != key.ToUID {
+			return fmt.Errorf("%w: issue %s has multiple parents", db.ErrFederationIngestValidation, key.FromUID)
+		}
+		parents[key.FromUID] = key.ToUID
+	}
+	for childUID := range parents {
+		current := childUID
+		seen := map[string]struct{}{}
+		for depth := 0; depth < db.MaxParentDepth; depth++ {
+			if _, ok := seen[current]; ok {
+				return fmt.Errorf("%w: %w", db.ErrFederationIngestValidation, db.ErrParentCycle)
+			}
+			seen[current] = struct{}{}
+			parentUID, ok := parents[current]
+			if !ok {
+				break
+			}
+			current = parentUID
+			if depth == db.MaxParentDepth-1 {
+				return fmt.Errorf("%w: parent chain exceeds depth limit %d",
+					db.ErrFederationIngestValidation, db.MaxParentDepth)
+			}
 		}
 	}
 	return nil

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -1137,6 +1137,9 @@ func payloadDeferredLinkIssueUIDs(
 		if err := validateFederationLinkPeer(primaryIssueUID, peerUID); err != nil {
 			return nil, err
 		}
+		if err := validateFederationUnlinkStorageEndpoints(ev, payload, linkType, fromUID, toUID); err != nil {
+			return nil, err
+		}
 		add(peerUID)
 	case "issue.links_changed":
 		peerUIDs, err := payloadLinksChangedIssueUIDs(ev, payload)
@@ -1190,6 +1193,10 @@ func payloadLinksChangedIssueUIDs(
 		if !ok {
 			continue
 		}
+		if trimmed := strings.TrimSpace(string(raw)); len(trimmed) == 0 || trimmed[0] != '[' {
+			return nil, fmt.Errorf("%w: %s must be an array of strings",
+				db.ErrFederationIngestValidation, key)
+		}
 		var uids []string
 		if err := json.Unmarshal(raw, &uids); err != nil {
 			return nil, fmt.Errorf("%w: %s must be an array of strings: %v",
@@ -1198,6 +1205,45 @@ func payloadLinksChangedIssueUIDs(
 		refs = append(refs, uids...)
 	}
 	return refs, nil
+}
+
+func validateFederationUnlinkStorageEndpoints(
+	ev db.RemoteEvent,
+	payload map[string]json.RawMessage,
+	linkType, fromUID, toUID string,
+) error {
+	if ev.Type != "issue.unlinked" {
+		return nil
+	}
+	rawFrom, fromPresent := payload["link_from_uid"]
+	rawTo, toPresent := payload["link_to_uid"]
+	if fromPresent != toPresent {
+		return fmt.Errorf("%w: issue.unlinked storage endpoints must be paired", db.ErrFederationIngestValidation)
+	}
+	if !fromPresent {
+		if linkType == "blocks" || linkType == "parent" {
+			return fmt.Errorf("%w: issue.unlinked missing directional storage endpoints",
+				db.ErrFederationIngestValidation)
+		}
+		return nil
+	}
+	linkFromUID, fromOK := db.StringValue(rawFrom)
+	linkToUID, toOK := db.StringValue(rawTo)
+	if !fromOK || !toOK {
+		return fmt.Errorf("%w: issue.unlinked storage endpoints must be strings",
+			db.ErrFederationIngestValidation)
+	}
+	if !katauid.Valid(linkFromUID) || !katauid.Valid(linkToUID) || linkFromUID == linkToUID {
+		return fmt.Errorf("%w: issue.unlinked has invalid storage endpoints",
+			db.ErrFederationIngestValidation)
+	}
+	matchesForward := linkFromUID == fromUID && linkToUID == toUID
+	matchesReverse := linkFromUID == toUID && linkToUID == fromUID
+	if !matchesForward && !matchesReverse {
+		return fmt.Errorf("%w: issue.unlinked storage endpoints disagree with payload endpoints",
+			db.ErrFederationIngestValidation)
+	}
+	return nil
 }
 
 func validateFederationLinkType(linkType string) error {

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -173,7 +173,7 @@ func (d *Store) ingestFederationEventsOnce(
 		// claim.violated is best-effort audit metadata evaluated against
 		// current hub claim state at ingest time. It is not a causally precise
 		// historical authorization judgment for offline work.
-		auditEvents, err := d.annotateFederationIngestClaimWorkTx(ctx, tx, p.ProjectID, projectName, ev)
+		auditEvents, err := d.annotateFederationIngestClaimWorkTx(ctx, tx, p.ProjectID, ev)
 		if err != nil {
 			return db.FederationIngestResult{}, err
 		}

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -988,7 +988,11 @@ func validateFederationProjectEvent(
 	if err != nil {
 		return err
 	}
-	for _, ref := range payloadReferencedIssueUIDs(ev, payload) {
+	referencedIssueUIDs, err := payloadReferencedIssueUIDs(ev, payload)
+	if err != nil {
+		return err
+	}
+	for _, ref := range referencedIssueUIDs {
 		if ref == issueUID {
 			continue
 		}
@@ -1039,7 +1043,7 @@ func payloadIssueUID(ev db.RemoteEvent, payload map[string]json.RawMessage) (str
 	return payloadUID, nil
 }
 
-func payloadReferencedIssueUIDs(ev db.RemoteEvent, payload map[string]json.RawMessage) []string {
+func payloadReferencedIssueUIDs(ev db.RemoteEvent, payload map[string]json.RawMessage) ([]string, error) {
 	var refs []string
 	if ev.RelatedIssueUID != nil && *ev.RelatedIssueUID != "" {
 		refs = append(refs, *ev.RelatedIssueUID)
@@ -1059,8 +1063,16 @@ func payloadReferencedIssueUIDs(ev db.RemoteEvent, payload map[string]json.RawMe
 	} {
 		refs = append(refs, db.StringSlice(payload[key])...)
 	}
-	refs = append(refs, payloadLinkIssueUIDs(ev)...)
-	return refs
+	links, err := payloadLinks(ev)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decode links: %v", db.ErrFederationIngestValidation, err)
+	}
+	for _, link := range links {
+		if link.ToIssueUID != "" {
+			refs = append(refs, link.ToIssueUID)
+		}
+	}
+	return refs, nil
 }
 
 func payloadDeferredLinkIssueUIDs(
@@ -1076,7 +1088,11 @@ func payloadDeferredLinkIssueUIDs(
 	}
 	switch ev.Type {
 	case "issue.created", "issue.snapshot":
-		for _, link := range payloadLinks(ev) {
+		links, err := payloadLinks(ev)
+		if err != nil {
+			return nil, fmt.Errorf("%w: decode links: %v", db.ErrFederationIngestValidation, err)
+		}
+		for _, link := range links {
 			if err := validateFederationLinkType(link.Type); err != nil {
 				return nil, fmt.Errorf("links: %w", err)
 			}
@@ -1196,22 +1212,14 @@ type payloadLink struct {
 	Incoming   bool   `json:"incoming"`
 }
 
-func payloadLinks(ev db.RemoteEvent) []payloadLink {
+func payloadLinks(ev db.RemoteEvent) ([]payloadLink, error) {
 	var created struct {
 		Links []payloadLink `json:"links"`
 	}
-	_ = json.Unmarshal(ev.Payload, &created)
-	return created.Links
-}
-
-func payloadLinkIssueUIDs(ev db.RemoteEvent) []string {
-	var refs []string
-	for _, link := range payloadLinks(ev) {
-		if link.ToIssueUID != "" {
-			refs = append(refs, link.ToIssueUID)
-		}
+	if err := json.Unmarshal(ev.Payload, &created); err != nil {
+		return nil, err
 	}
-	return refs
+	return created.Links, nil
 }
 
 func currentFederatedIssueUIDSet(ctx context.Context, tx *sql.Tx, projectID int64) (map[string]struct{}, error) {

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -1222,7 +1222,8 @@ func validateFederationUnlinkStorageEndpoints(
 	}
 	if !fromPresent {
 		// Older supported spokes stored only the attribution-oriented endpoint
-		// pair. Fold falls back to that pair when storage endpoints are absent.
+		// pair. Fold resolves it against existing directional state when storage
+		// endpoints are absent.
 		return nil
 	}
 	linkFromUID, fromOK := db.StringValue(rawFrom)

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -76,9 +76,7 @@ func (d *Store) ingestFederationEventsOnce(
 		if len(ev.Payload) == 0 {
 			ev.Payload = json.RawMessage(`{}`)
 		}
-		if err := validateFederationProjectEvent(
-			projectUID, p.SpokeInstanceUID, ev, knownIssueUIDs,
-		); err != nil {
+		if err := validateFederationProjectEvent(projectUID, p.SpokeInstanceUID, ev, knownIssueUIDs); err != nil {
 			return db.FederationIngestResult{}, err
 		}
 		if boundActor != "" && ev.Actor != boundActor {

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -54,10 +54,6 @@ func (d *Store) ingestFederationEventsOnce(
 	if err != nil {
 		return db.FederationIngestResult{}, err
 	}
-	batchCreateSnapshotUIDs, err := federationIngestCreateSnapshotUIDSet(p.Events)
-	if err != nil {
-		return db.FederationIngestResult{}, err
-	}
 	adoptionSnapshotAuthorState, err := computeFederationIngestAdoptionSnapshotAuthorState(ctx, tx,
 		p.ProjectID, p.FederationEnrollmentID, p.SpokeInstanceUID,
 		p.AllowSnapshotAuthorPreservation, p.AdoptionBaseline, p.AdoptionBaselineEndSourceEventID, p.Events)
@@ -80,8 +76,9 @@ func (d *Store) ingestFederationEventsOnce(
 		if len(ev.Payload) == 0 {
 			ev.Payload = json.RawMessage(`{}`)
 		}
-		if err := validateFederationProjectEvent(projectUID, p.SpokeInstanceUID, ev,
-			knownIssueUIDs, batchCreateSnapshotUIDs, adoptionSnapshotAuthorState.allowFutureSnapshotLinks); err != nil {
+		if err := validateFederationProjectEvent(
+			projectUID, p.SpokeInstanceUID, ev, knownIssueUIDs,
+		); err != nil {
 			return db.FederationIngestResult{}, err
 		}
 		if boundActor != "" && ev.Actor != boundActor {
@@ -191,11 +188,6 @@ func (d *Store) ingestFederationEventsOnce(
 		if err := d.materializeFederatedProjectTx(ctx, tx, p.ProjectID); err != nil {
 			return db.FederationIngestResult{}, err
 		}
-		if adoptionSnapshotAuthorState.verifySnapshotLinks {
-			if err := validateFederationAdoptionSnapshotLinksResolved(ctx, tx, p.ProjectID, p.SpokeInstanceUID); err != nil {
-				return db.FederationIngestResult{}, err
-			}
-		}
 		if !adoptionSnapshotAuthorState.shouldDeferMarker {
 			if err := consumeFederationAdoptionSnapshotAuthorMarker(ctx, tx,
 				p.ProjectID, p.FederationEnrollmentID, p.SpokeInstanceUID); err != nil {
@@ -255,8 +247,6 @@ func validateFederationBoundActorPayload(
 
 type federationIngestAdoptionSnapshotAuthorState struct {
 	allowAuthorPreservation      bool
-	allowFutureSnapshotLinks     bool
-	verifySnapshotLinks          bool
 	shouldDeferMarker            bool
 	deferAuthorPreservationGrant bool
 	overrideSnapshotAuthors      bool
@@ -354,9 +344,8 @@ func computeFederationIngestConsumedAdoptionBaselineRetryState(
 		return federationIngestAdoptionSnapshotAuthorState{}, err
 	}
 	return federationIngestAdoptionSnapshotAuthorState{
-		allowFutureSnapshotLinks: true,
-		overrideSnapshotAuthors:  baselineShape.hasSnapshot,
-		duplicateOnly:            true,
+		overrideSnapshotAuthors: baselineShape.hasSnapshot,
+		duplicateOnly:           true,
 	}, nil
 }
 
@@ -378,7 +367,6 @@ func computeFederationIngestOpenAdoptionBaselineState(
 ) (federationIngestAdoptionSnapshotAuthorState, error) {
 	state := federationIngestAdoptionSnapshotAuthorState{
 		allowAuthorPreservation:      baselineShape.hasSnapshot && marker.allowSnapshotAuthors,
-		allowFutureSnapshotLinks:     true,
 		shouldDeferMarker:            true,
 		deferAuthorPreservationGrant: marker.allowSnapshotAuthors && !baselineShape.hasSnapshot,
 		overrideSnapshotAuthors:      baselineShape.hasSnapshot && marker.baselineOpen && !marker.allowSnapshotAuthors,
@@ -419,7 +407,6 @@ func computeFederationIngestCompleteAdoptionBaselineState(
 ) (federationIngestAdoptionSnapshotAuthorState, error) {
 	state := federationIngestAdoptionSnapshotAuthorState{
 		allowAuthorPreservation: baselineShape.hasSnapshot && marker.allowSnapshotAuthors,
-		verifySnapshotLinks:     baselineShape.hasSnapshot || marker.baselineOpen,
 		overrideSnapshotAuthors: baselineShape.hasSnapshot && marker.baselineOpen && !marker.allowSnapshotAuthors,
 		endSourceEventID:        adoptionBaselineEndSourceEventID,
 	}
@@ -432,7 +419,6 @@ func computeFederationIngestCompleteAdoptionBaselineState(
 		}
 		if baselineShape.minSourceEventID < marker.nextSourceEventID {
 			state.duplicateOnly = true
-			state.allowFutureSnapshotLinks = true
 		}
 		return state, nil
 	}
@@ -956,8 +942,6 @@ func validateFederationProjectEvent(
 	projectUID, spokeInstanceUID string,
 	ev db.RemoteEvent,
 	knownIssueUIDs map[string]struct{},
-	batchCreateSnapshotUIDs map[string]struct{},
-	allowFutureSnapshotLinks bool,
 ) error {
 	if ev.ProjectUID != projectUID {
 		return fmt.Errorf("%w: event %s targets project %s", db.ErrFederationIngestValidation, ev.EventUID, ev.ProjectUID)
@@ -1001,57 +985,19 @@ func validateFederationProjectEvent(
 	default:
 		return fmt.Errorf("%w: unsupported event type %s", db.ErrFederationIngestValidation, ev.Type)
 	}
-	snapshotLinkRefs := map[string]struct{}{}
-	deferredSnapshotLinks := map[string]struct{}{}
-	if ev.Type == "issue.snapshot" {
-		for _, ref := range payloadLinkIssueUIDs(ev) {
-			snapshotLinkRefs[ref] = struct{}{}
-			if _, ok := batchCreateSnapshotUIDs[ref]; ok {
-				deferredSnapshotLinks[ref] = struct{}{}
-			}
-		}
-	}
+	deferredLinkUIDs := payloadDeferredLinkIssueUIDs(ev, payload)
 	for _, ref := range payloadReferencedIssueUIDs(ev, payload) {
 		if ref == issueUID {
 			continue
 		}
 		if _, ok := knownIssueUIDs[ref]; !ok {
-			if _, deferred := deferredSnapshotLinks[ref]; deferred {
-				continue
-			}
-			if allowFutureSnapshotLinks && ev.Type == "issue.snapshot" {
-				if _, ok := snapshotLinkRefs[ref]; !ok {
-					return fmt.Errorf("%w: event %s references unknown issue %s", db.ErrFederationIngestValidation, ev.EventUID, ref)
-				}
+			if _, deferred := deferredLinkUIDs[ref]; deferred {
 				continue
 			}
 			return fmt.Errorf("%w: event %s references unknown issue %s", db.ErrFederationIngestValidation, ev.EventUID, ref)
 		}
 	}
 	return nil
-}
-
-func federationIngestCreateSnapshotUIDSet(events []db.FederationIngestEvent) (map[string]struct{}, error) {
-	out := map[string]struct{}{}
-	for _, in := range events {
-		ev := in.Event
-		if len(ev.Payload) == 0 {
-			ev.Payload = json.RawMessage(`{}`)
-		}
-		switch ev.Type {
-		case "issue.created", "issue.snapshot":
-		default:
-			continue
-		}
-		uid, err := payloadIssueUID(ev, db.PayloadMap(ev.Payload))
-		if err != nil {
-			return nil, err
-		}
-		if uid != "" {
-			out[uid] = struct{}{}
-		}
-	}
-	return out, nil
 }
 
 func rejectFreshCreateSnapshotForKnownIssue(ev db.RemoteEvent, knownIssueUIDs map[string]struct{}) error {
@@ -1115,6 +1061,45 @@ func payloadReferencedIssueUIDs(ev db.RemoteEvent, payload map[string]json.RawMe
 	return refs
 }
 
+func payloadDeferredLinkIssueUIDs(
+	ev db.RemoteEvent,
+	payload map[string]json.RawMessage,
+) map[string]struct{} {
+	out := map[string]struct{}{}
+	add := func(uid string) {
+		if uid != "" {
+			out[uid] = struct{}{}
+		}
+	}
+	for _, key := range []string{
+		"from_uid", "to_uid", "from_issue_uid", "to_issue_uid",
+		"parent_set_uid", "parent_removed_uid",
+	} {
+		if uid, ok := db.StringValue(payload[key]); ok {
+			add(uid)
+		}
+	}
+	for _, key := range []string{
+		"blocks_added_uids", "blocks_removed_uids",
+		"blocked_by_added_uids", "blocked_by_removed_uids",
+		"related_added_uids", "related_removed_uids",
+	} {
+		for _, uid := range db.StringSlice(payload[key]) {
+			add(uid)
+		}
+	}
+	for _, uid := range payloadLinkIssueUIDs(ev) {
+		add(uid)
+	}
+	switch ev.Type {
+	case "issue.linked", "issue.unlinked", "issue.links_changed":
+		if ev.RelatedIssueUID != nil {
+			add(*ev.RelatedIssueUID)
+		}
+	}
+	return out
+}
+
 func payloadLinkIssueUIDs(ev db.RemoteEvent) []string {
 	var created struct {
 		Links []struct {
@@ -1129,50 +1114,6 @@ func payloadLinkIssueUIDs(ev db.RemoteEvent) []string {
 		}
 	}
 	return refs
-}
-
-func validateFederationAdoptionSnapshotLinksResolved(
-	ctx context.Context,
-	tx *sql.Tx,
-	projectID int64,
-	spokeInstanceUID string,
-) error {
-	knownIssueUIDs, err := materializedIssueUIDSet(ctx, tx, projectID)
-	if err != nil {
-		return err
-	}
-	rows, err := tx.QueryContext(ctx, `
-		SELECT uid, payload
-		  FROM events
-		 WHERE project_id = ?
-		   AND origin_instance_uid = ?
-		   AND type = 'issue.snapshot'
-		 ORDER BY id ASC`,
-		projectID, spokeInstanceUID)
-	if err != nil {
-		return fmt.Errorf("list adoption snapshot links: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-	for rows.Next() {
-		var (
-			eventUID string
-			payload  string
-		)
-		if err := rows.Scan(&eventUID, &payload); err != nil {
-			return fmt.Errorf("scan adoption snapshot link: %w", err)
-		}
-		for _, ref := range payloadLinkIssueUIDs(db.RemoteEvent{Payload: json.RawMessage(payload)}) {
-			if _, ok := knownIssueUIDs[ref]; ok {
-				continue
-			}
-			return fmt.Errorf("%w: adoption baseline unresolved snapshot link %s references unknown issue %s",
-				db.ErrFederationIngestValidation, eventUID, ref)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate adoption snapshot links: %w", err)
-	}
-	return nil
 }
 
 func currentFederatedIssueUIDSet(ctx context.Context, tx *sql.Tx, projectID int64) (map[string]struct{}, error) {

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -1050,19 +1050,16 @@ func payloadReferencedIssueUIDs(ev db.RemoteEvent, payload map[string]json.RawMe
 	}
 	for _, key := range []string{
 		"from_uid", "to_uid", "from_issue_uid", "to_issue_uid",
-		"parent_set_uid", "parent_removed_uid",
 	} {
 		if uid, ok := db.StringValue(payload[key]); ok {
 			refs = append(refs, uid)
 		}
 	}
-	for _, key := range []string{
-		"blocks_added_uids", "blocks_removed_uids",
-		"blocked_by_added_uids", "blocked_by_removed_uids",
-		"related_added_uids", "related_removed_uids",
-	} {
-		refs = append(refs, db.StringSlice(payload[key])...)
+	changedRefs, err := payloadLinksChangedIssueUIDs(ev, payload)
+	if err != nil {
+		return nil, err
 	}
+	refs = append(refs, changedRefs...)
 	links, err := payloadLinks(ev)
 	if err != nil {
 		return nil, fmt.Errorf("%w: decode links: %v", db.ErrFederationIngestValidation, err)
@@ -1142,19 +1139,12 @@ func payloadDeferredLinkIssueUIDs(
 		}
 		add(peerUID)
 	case "issue.links_changed":
-		for _, key := range []string{"parent_set_uid", "parent_removed_uid"} {
-			if uid, ok := db.StringValue(payload[key]); ok {
-				add(uid)
-			}
+		peerUIDs, err := payloadLinksChangedIssueUIDs(ev, payload)
+		if err != nil {
+			return nil, err
 		}
-		for _, key := range []string{
-			"blocks_added_uids", "blocks_removed_uids",
-			"blocked_by_added_uids", "blocked_by_removed_uids",
-			"related_added_uids", "related_removed_uids",
-		} {
-			for _, uid := range db.StringSlice(payload[key]) {
-				add(uid)
-			}
+		for _, uid := range peerUIDs {
+			add(uid)
 		}
 		if ev.RelatedIssueUID != nil {
 			if _, ok := out[*ev.RelatedIssueUID]; !ok {
@@ -1169,6 +1159,45 @@ func payloadDeferredLinkIssueUIDs(
 		}
 	}
 	return out, nil
+}
+
+func payloadLinksChangedIssueUIDs(
+	ev db.RemoteEvent,
+	payload map[string]json.RawMessage,
+) ([]string, error) {
+	if ev.Type != "issue.links_changed" {
+		return nil, nil
+	}
+	var refs []string
+	for _, key := range []string{"parent_set_uid", "parent_removed_uid"} {
+		raw, ok := payload[key]
+		if !ok {
+			continue
+		}
+		var uid string
+		if err := json.Unmarshal(raw, &uid); err != nil {
+			return nil, fmt.Errorf("%w: %s must be a string: %v",
+				db.ErrFederationIngestValidation, key, err)
+		}
+		refs = append(refs, uid)
+	}
+	for _, key := range []string{
+		"blocks_added_uids", "blocks_removed_uids",
+		"blocked_by_added_uids", "blocked_by_removed_uids",
+		"related_added_uids", "related_removed_uids",
+	} {
+		raw, ok := payload[key]
+		if !ok {
+			continue
+		}
+		var uids []string
+		if err := json.Unmarshal(raw, &uids); err != nil {
+			return nil, fmt.Errorf("%w: %s must be an array of strings: %v",
+				db.ErrFederationIngestValidation, key, err)
+		}
+		refs = append(refs, uids...)
+	}
+	return refs, nil
 }
 
 func validateFederationLinkType(linkType string) error {

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"go.kenn.io/kata/internal/db"
+	katauid "go.kenn.io/kata/internal/uid"
 )
 
 type preparedFederationIngestEvent struct {
@@ -1075,8 +1076,17 @@ func payloadDeferredLinkIssueUIDs(
 	}
 	switch ev.Type {
 	case "issue.created", "issue.snapshot":
-		for _, uid := range payloadLinkIssueUIDs(ev) {
-			add(uid)
+		for _, link := range payloadLinks(ev) {
+			if err := validateFederationLinkType(link.Type); err != nil {
+				return nil, fmt.Errorf("links: %w", err)
+			}
+			if err := validateFederationLinkPeer(primaryIssueUID, link.ToIssueUID); err != nil {
+				return nil, fmt.Errorf("links: %w", err)
+			}
+			if ev.Type == "issue.created" && link.Type == "parent" && link.Incoming {
+				return nil, fmt.Errorf("%w: parent link cannot be incoming", db.ErrFederationIngestValidation)
+			}
+			add(link.ToIssueUID)
 		}
 	case "issue.linked", "issue.unlinked":
 		fromUID, fromOK, err := payloadLinkEndpointUID(payload, "from_uid", "from_issue_uid")
@@ -1089,6 +1099,13 @@ func payloadDeferredLinkIssueUIDs(
 		}
 		if !fromOK || !toOK {
 			return nil, fmt.Errorf("%w: %s missing link endpoint uid", db.ErrFederationIngestValidation, ev.Type)
+		}
+		linkType, ok := db.StringValue(payload["type"])
+		if !ok {
+			return nil, fmt.Errorf("%w: %s missing link type", db.ErrFederationIngestValidation, ev.Type)
+		}
+		if err := validateFederationLinkType(linkType); err != nil {
+			return nil, err
 		}
 		peerUID := ""
 		switch primaryIssueUID {
@@ -1103,6 +1120,9 @@ func payloadDeferredLinkIssueUIDs(
 		if ev.RelatedIssueUID != nil && *ev.RelatedIssueUID != peerUID {
 			return nil, fmt.Errorf("%w: %s related issue %s is not the opposite endpoint %s",
 				db.ErrFederationIngestValidation, ev.Type, *ev.RelatedIssueUID, peerUID)
+		}
+		if err := validateFederationLinkPeer(primaryIssueUID, peerUID); err != nil {
+			return nil, err
 		}
 		add(peerUID)
 	case "issue.links_changed":
@@ -1126,8 +1146,32 @@ func payloadDeferredLinkIssueUIDs(
 					db.ErrFederationIngestValidation, ev.Type, *ev.RelatedIssueUID)
 			}
 		}
+		for peerUID := range out {
+			if err := validateFederationLinkPeer(primaryIssueUID, peerUID); err != nil {
+				return nil, err
+			}
+		}
 	}
 	return out, nil
+}
+
+func validateFederationLinkType(linkType string) error {
+	switch linkType {
+	case "parent", "blocks", "related":
+		return nil
+	default:
+		return fmt.Errorf("%w: unsupported link type %q", db.ErrFederationIngestValidation, linkType)
+	}
+}
+
+func validateFederationLinkPeer(primaryIssueUID, peerUID string) error {
+	if !katauid.Valid(peerUID) {
+		return fmt.Errorf("%w: invalid link peer uid %q", db.ErrFederationIngestValidation, peerUID)
+	}
+	if peerUID == primaryIssueUID {
+		return fmt.Errorf("%w: issue cannot link to itself", db.ErrFederationIngestValidation)
+	}
+	return nil
 }
 
 func payloadLinkEndpointUID(
@@ -1136,24 +1180,33 @@ func payloadLinkEndpointUID(
 ) (string, bool, error) {
 	canonical, canonicalOK := db.StringValue(payload[canonicalKey])
 	alternate, alternateOK := db.StringValue(payload[alternateKey])
+	if !canonicalOK && alternateOK {
+		return "", false, fmt.Errorf("%w: link endpoint must use %s",
+			db.ErrFederationIngestValidation, canonicalKey)
+	}
 	if canonicalOK && alternateOK && canonical != alternate {
 		return "", false, fmt.Errorf("%w: link endpoint uid disagreement", db.ErrFederationIngestValidation)
 	}
-	if canonicalOK {
-		return canonical, true, nil
+	return canonical, canonicalOK, nil
+}
+
+type payloadLink struct {
+	Type       string `json:"type"`
+	ToIssueUID string `json:"to_issue_uid"`
+	Incoming   bool   `json:"incoming"`
+}
+
+func payloadLinks(ev db.RemoteEvent) []payloadLink {
+	var created struct {
+		Links []payloadLink `json:"links"`
 	}
-	return alternate, alternateOK, nil
+	_ = json.Unmarshal(ev.Payload, &created)
+	return created.Links
 }
 
 func payloadLinkIssueUIDs(ev db.RemoteEvent) []string {
-	var created struct {
-		Links []struct {
-			ToIssueUID string `json:"to_issue_uid"`
-		} `json:"links"`
-	}
-	_ = json.Unmarshal(ev.Payload, &created)
 	var refs []string
-	for _, link := range created.Links {
+	for _, link := range payloadLinks(ev) {
 		if link.ToIssueUID != "" {
 			refs = append(refs, link.ToIssueUID)
 		}

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -983,7 +983,10 @@ func validateFederationProjectEvent(
 	default:
 		return fmt.Errorf("%w: unsupported event type %s", db.ErrFederationIngestValidation, ev.Type)
 	}
-	deferredLinkUIDs := payloadDeferredLinkIssueUIDs(ev, payload)
+	deferredLinkUIDs, err := payloadDeferredLinkIssueUIDs(ev, payload, issueUID)
+	if err != nil {
+		return err
+	}
 	for _, ref := range payloadReferencedIssueUIDs(ev, payload) {
 		if ref == issueUID {
 			continue
@@ -1062,40 +1065,84 @@ func payloadReferencedIssueUIDs(ev db.RemoteEvent, payload map[string]json.RawMe
 func payloadDeferredLinkIssueUIDs(
 	ev db.RemoteEvent,
 	payload map[string]json.RawMessage,
-) map[string]struct{} {
+	primaryIssueUID string,
+) (map[string]struct{}, error) {
 	out := map[string]struct{}{}
 	add := func(uid string) {
 		if uid != "" {
 			out[uid] = struct{}{}
 		}
 	}
-	for _, key := range []string{
-		"from_uid", "to_uid", "from_issue_uid", "to_issue_uid",
-		"parent_set_uid", "parent_removed_uid",
-	} {
-		if uid, ok := db.StringValue(payload[key]); ok {
-			add(uid)
-		}
-	}
-	for _, key := range []string{
-		"blocks_added_uids", "blocks_removed_uids",
-		"blocked_by_added_uids", "blocked_by_removed_uids",
-		"related_added_uids", "related_removed_uids",
-	} {
-		for _, uid := range db.StringSlice(payload[key]) {
-			add(uid)
-		}
-	}
-	for _, uid := range payloadLinkIssueUIDs(ev) {
-		add(uid)
-	}
 	switch ev.Type {
-	case "issue.linked", "issue.unlinked", "issue.links_changed":
+	case "issue.created", "issue.snapshot":
+		for _, uid := range payloadLinkIssueUIDs(ev) {
+			add(uid)
+		}
+	case "issue.linked", "issue.unlinked":
+		fromUID, fromOK, err := payloadLinkEndpointUID(payload, "from_uid", "from_issue_uid")
+		if err != nil {
+			return nil, err
+		}
+		toUID, toOK, err := payloadLinkEndpointUID(payload, "to_uid", "to_issue_uid")
+		if err != nil {
+			return nil, err
+		}
+		if !fromOK || !toOK {
+			return nil, fmt.Errorf("%w: %s missing link endpoint uid", db.ErrFederationIngestValidation, ev.Type)
+		}
+		peerUID := ""
+		switch primaryIssueUID {
+		case fromUID:
+			peerUID = toUID
+		case toUID:
+			peerUID = fromUID
+		default:
+			return nil, fmt.Errorf("%w: %s primary issue %s is not a link endpoint",
+				db.ErrFederationIngestValidation, ev.Type, primaryIssueUID)
+		}
+		if ev.RelatedIssueUID != nil && *ev.RelatedIssueUID != peerUID {
+			return nil, fmt.Errorf("%w: %s related issue %s is not the opposite endpoint %s",
+				db.ErrFederationIngestValidation, ev.Type, *ev.RelatedIssueUID, peerUID)
+		}
+		add(peerUID)
+	case "issue.links_changed":
+		for _, key := range []string{"parent_set_uid", "parent_removed_uid"} {
+			if uid, ok := db.StringValue(payload[key]); ok {
+				add(uid)
+			}
+		}
+		for _, key := range []string{
+			"blocks_added_uids", "blocks_removed_uids",
+			"blocked_by_added_uids", "blocked_by_removed_uids",
+			"related_added_uids", "related_removed_uids",
+		} {
+			for _, uid := range db.StringSlice(payload[key]) {
+				add(uid)
+			}
+		}
 		if ev.RelatedIssueUID != nil {
-			add(*ev.RelatedIssueUID)
+			if _, ok := out[*ev.RelatedIssueUID]; !ok {
+				return nil, fmt.Errorf("%w: %s related issue %s is not a payload peer",
+					db.ErrFederationIngestValidation, ev.Type, *ev.RelatedIssueUID)
+			}
 		}
 	}
-	return out
+	return out, nil
+}
+
+func payloadLinkEndpointUID(
+	payload map[string]json.RawMessage,
+	canonicalKey, alternateKey string,
+) (string, bool, error) {
+	canonical, canonicalOK := db.StringValue(payload[canonicalKey])
+	alternate, alternateOK := db.StringValue(payload[alternateKey])
+	if canonicalOK && alternateOK && canonical != alternate {
+		return "", false, fmt.Errorf("%w: link endpoint uid disagreement", db.ErrFederationIngestValidation)
+	}
+	if canonicalOK {
+		return canonical, true, nil
+	}
+	return alternate, alternateOK, nil
 }
 
 func payloadLinkIssueUIDs(ev db.RemoteEvent) []string {
@@ -1120,10 +1167,11 @@ func currentFederatedIssueUIDSet(ctx context.Context, tx *sql.Tx, projectID int6
 		return nil, err
 	}
 	eventRows, err := tx.QueryContext(ctx, `
-		SELECT issue_uid FROM events WHERE project_id = ? AND issue_uid IS NOT NULL
-		UNION
-		SELECT related_issue_uid FROM events WHERE project_id = ? AND related_issue_uid IS NOT NULL`,
-		projectID, projectID)
+		SELECT issue_uid
+		  FROM events
+		 WHERE project_id = ?
+		   AND issue_uid IS NOT NULL
+		   AND type IN ('issue.created', 'issue.snapshot')`, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("list event issue uids: %w", err)
 	}

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -1137,7 +1137,7 @@ func payloadDeferredLinkIssueUIDs(
 		if err := validateFederationLinkPeer(primaryIssueUID, peerUID); err != nil {
 			return nil, err
 		}
-		if err := validateFederationUnlinkStorageEndpoints(ev, payload, linkType, fromUID, toUID); err != nil {
+		if err := validateFederationUnlinkStorageEndpoints(ev, payload, fromUID, toUID); err != nil {
 			return nil, err
 		}
 		add(peerUID)
@@ -1210,7 +1210,7 @@ func payloadLinksChangedIssueUIDs(
 func validateFederationUnlinkStorageEndpoints(
 	ev db.RemoteEvent,
 	payload map[string]json.RawMessage,
-	linkType, fromUID, toUID string,
+	fromUID, toUID string,
 ) error {
 	if ev.Type != "issue.unlinked" {
 		return nil
@@ -1221,10 +1221,8 @@ func validateFederationUnlinkStorageEndpoints(
 		return fmt.Errorf("%w: issue.unlinked storage endpoints must be paired", db.ErrFederationIngestValidation)
 	}
 	if !fromPresent {
-		if linkType == "blocks" || linkType == "parent" {
-			return fmt.Errorf("%w: issue.unlinked missing directional storage endpoints",
-				db.ErrFederationIngestValidation)
-		}
+		// Older supported spokes stored only the attribution-oriented endpoint
+		// pair. Fold falls back to that pair when storage endpoints are absent.
 		return nil
 	}
 	linkFromUID, fromOK := db.StringValue(rawFrom)

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -2005,7 +2005,7 @@ func TestIngestFederationEventsConvergesCircularCrossProjectLinks(t *testing.T) 
 
 	unlink := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
 		&firstIssueUID, &secondIssueUID, "issue.unlinked", 102,
-		`{"issue_uid":"`+firstIssueUID+`","from_uid":"`+firstIssueUID+`","to_uid":"`+secondIssueUID+`","type":"blocks"}`)
+		`{"issue_uid":"`+firstIssueUID+`","from_uid":"`+firstIssueUID+`","to_uid":"`+secondIssueUID+`","link_from_uid":"`+firstIssueUID+`","link_to_uid":"`+secondIssueUID+`","type":"blocks"}`)
 	_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
 		ProjectID:        firstProject.ID,
 		SpokeInstanceUID: spokeUID,
@@ -2046,6 +2046,48 @@ func TestIngestFederationEventsRejectsDeferredCrossProjectParentCycle(t *testing
 	assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
 	assertRowCount(ctx, t, d, 0, "invalid parent cycle is not materialized",
 		`SELECT count(*) FROM links WHERE type = 'parent'`)
+}
+
+func TestIngestFederationEventsUnlinksDirectionalEdgeThroughDestination(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	firstProject := createProject(ctx, t, d, "spoke-project")
+	secondProject := createProject(ctx, t, d, "peer-project")
+	_, err := d.EnableProjectFederation(ctx, firstProject.ID, "tester")
+	require.NoError(t, err)
+	_, err = d.EnableProjectFederation(ctx, secondProject.ID, "tester")
+	require.NoError(t, err)
+
+	spokeUID := newTestUID(t)
+	firstIssueUID := newTestUID(t)
+	secondIssueUID := newTestUID(t)
+	first := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
+		&firstIssueUID, nil, "issue.created", 100,
+		`{"uid":"`+firstIssueUID+`","short_id":"`+shortID(firstIssueUID)+`","title":"first","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"blocks","to_issue_uid":"`+secondIssueUID+`","author":"spoke"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(firstProject.ID, spokeUID, first))
+	require.NoError(t, err)
+	second := ingestIssueCreatedEvent(t, secondProject.UID, secondProject.Name, spokeUID, secondIssueUID, 101)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(secondProject.ID, spokeUID, second))
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 1, "directional edge materialized",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssueUID, secondIssueUID)
+
+	unlink := ingestEventWithPayload(t, secondProject.UID, secondProject.Name, spokeUID,
+		&secondIssueUID, &firstIssueUID, "issue.unlinked", 102,
+		`{"issue_uid":"`+secondIssueUID+`","from_uid":"`+secondIssueUID+`","to_uid":"`+firstIssueUID+`","link_from_uid":"`+firstIssueUID+`","link_to_uid":"`+secondIssueUID+`","type":"blocks"}`)
+	_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+		ProjectID:        secondProject.ID,
+		SpokeInstanceUID: spokeUID,
+		Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: unlink}},
+	})
+
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 0, "destination-side unlink removes storage-oriented edge",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssueUID, secondIssueUID)
 }
 
 func TestEnableProjectFederationReconcilesDeferredGroupLinks(t *testing.T) {
@@ -3846,6 +3888,10 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		{
 			name:         "rejects non-array links changed uid list",
 			payloadField: `"blocks_added_uids":{}`,
+		},
+		{
+			name:         "rejects null links changed uid list",
+			payloadField: `"blocks_removed_uids":null`,
 		},
 		{
 			name:         "rejects mixed links changed uid list",

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -4183,6 +4183,49 @@ func TestIngestClaimViolationWorkMutationCoverage(t *testing.T) {
 	}
 }
 
+func TestIngestClaimViolationAuditsCompatibleCrossProjectPeer(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	firstProject := createProject(ctx, t, d, "spoke-project")
+	secondProject := createProject(ctx, t, d, "peer-project")
+	firstIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: firstProject.ID,
+		Title:     "first",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	secondIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: secondProject.ID,
+		Title:     "second",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, err = d.EnableProjectFederation(ctx, firstProject.ID, "tester")
+	require.NoError(t, err)
+	_, err = d.EnableProjectFederation(ctx, secondProject.ID, "tester")
+	require.NoError(t, err)
+	_, err = d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: secondProject.ID,
+		IssueRef:  secondIssue.ShortID,
+		Principal: db.ClaimPrincipal{HolderInstanceUID: newTestUID(t), Holder: "holder"},
+		ClaimKind: "hard",
+		Now:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	spokeUID := newTestUID(t)
+	link := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
+		&firstIssue.UID, &secondIssue.UID, "issue.linked", 100,
+		`{"issue_uid":"`+firstIssue.UID+`","from_uid":"`+firstIssue.UID+`","to_uid":"`+secondIssue.UID+`","type":"blocks"}`)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(firstProject.ID, spokeUID, link))
+
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 1, "peer claim violation emitted in owning project",
+		`SELECT count(*) FROM events
+		  WHERE project_id = ? AND issue_uid = ? AND type = 'claim.violated'`,
+		secondProject.ID, secondIssue.UID)
+}
+
 func TestIngestClaimViolationExpiresTimedClaimBeforeAudit(t *testing.T) {
 	d, ctx, p, spokeUID, issue, _ := setupIngestClaimIssue(t)
 	_, err := d.AcquireClaim(ctx, db.AcquireClaimParams{

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -1856,6 +1856,25 @@ func TestIngestFederationEvents(t *testing.T) {
 	})
 }
 
+func TestIngestFederationEventsDefersUnknownLinkPeer(t *testing.T) {
+	d, ctx, project, spokeUID := setupFederationIngestHub(t)
+	issueUID := newTestUID(t)
+	peerUID := newTestUID(t)
+	event := ingestEventWithPayload(t, project.UID, project.Name, spokeUID, &issueUID, nil,
+		"issue.created", 100,
+		`{"uid":"`+issueUID+`","short_id":"`+shortID(issueUID)+`","title":"subject","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"blocks","to_issue_uid":"`+peerUID+`","author":"spoke"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+
+	result, err := d.IngestFederationEvents(ctx, ingestParams(project.ID, spokeUID, event))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Accepted)
+	issue, err := d.IssueByUID(ctx, issueUID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	links, err := d.LinksByIssue(ctx, issue.ID)
+	require.NoError(t, err)
+	assert.Empty(t, links, "the peer is unresolved, so the edge must stay absent")
+}
+
 func TestIngestFederationEvents_Validation(t *testing.T) {
 	t.Run("rejects project uid mismatch", func(t *testing.T) {
 		d, ctx, p, spokeUID := setupFederationIngestHub(t)
@@ -2664,7 +2683,7 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		assertIngestedEventCount(ctx, t, d, p.ID, 0)
 	})
 
-	t.Run("rejects complete adoption baseline with unresolved open chunk snapshot link", func(t *testing.T) {
+	t.Run("accepts complete adoption baseline with unresolved open chunk snapshot link", func(t *testing.T) {
 		d, ctx, p, spokeUID := setupFederationIngestHub(t)
 		markerValue := strings.Join([]string{"snapshot", "adoption", "missing", "link"}, "-")
 		created, err := d.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{
@@ -2713,16 +2732,14 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 			Events:                           []db.FederationIngestEvent{{SourceEventID: 2, Event: second}},
 		})
 
-		require.Error(t, err)
-		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
-		assert.Contains(t, err.Error(), "unresolved snapshot link")
+		require.NoError(t, err)
 		authorized, err := d.AuthorizeFederationToken(ctx, markerValue, p.ID, "push")
 		require.NoError(t, err)
 		assert.False(t, authorized.AllowAdoptionSnapshotAuthors)
-		assertIngestedEventCount(ctx, t, d, p.ID, 1)
+		assertIngestedEventCount(ctx, t, d, p.ID, 2)
 	})
 
-	t.Run("rejects metadata-only complete adoption baseline with unresolved open chunk snapshot link", func(t *testing.T) {
+	t.Run("accepts metadata-only complete adoption baseline with unresolved open chunk snapshot link", func(t *testing.T) {
 		d, ctx, p, spokeUID := setupFederationIngestHub(t)
 		markerValue := strings.Join([]string{"snapshot", "adoption", "metadata", "missing"}, "-")
 		created, err := d.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{
@@ -2770,16 +2787,14 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 			Events:                           []db.FederationIngestEvent{{SourceEventID: 2, Event: metadata}},
 		})
 
-		require.Error(t, err)
-		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
-		assert.Contains(t, err.Error(), "unresolved snapshot link")
+		require.NoError(t, err)
 		authorized, err := d.AuthorizeFederationToken(ctx, markerValue, p.ID, "push")
 		require.NoError(t, err)
 		assert.False(t, authorized.AllowAdoptionSnapshotAuthors)
-		assertIngestedEventCount(ctx, t, d, p.ID, 1)
+		assertIngestedEventCount(ctx, t, d, p.ID, 2)
 	})
 
-	t.Run("rejects deferred snapshot link when only related envelope mentions missing issue", func(t *testing.T) {
+	t.Run("accepts deferred snapshot link when related envelope also mentions missing issue", func(t *testing.T) {
 		d, ctx, p, spokeUID := setupFederationIngestHub(t)
 		markerValue := strings.Join([]string{"snapshot", "adoption", "related", "missing"}, "-")
 		created, err := d.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{
@@ -2827,13 +2842,11 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 			Events:                           []db.FederationIngestEvent{{SourceEventID: 2, Event: metadata}},
 		})
 
-		require.Error(t, err)
-		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
-		assert.Contains(t, err.Error(), "unresolved snapshot link")
+		require.NoError(t, err)
 		authorized, err := d.AuthorizeFederationToken(ctx, markerValue, p.ID, "push")
 		require.NoError(t, err)
 		assert.False(t, authorized.AllowAdoptionSnapshotAuthors)
-		assertIngestedEventCount(ctx, t, d, p.ID, 1)
+		assertIngestedEventCount(ctx, t, d, p.ID, 2)
 	})
 
 	t.Run("recovers v22 imported open adoption baseline without terminal cursor", func(t *testing.T) {
@@ -3411,7 +3424,7 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		assert.Equal(t, "after create", issue.Title)
 	})
 
-	t.Run("rejects related issue outside project", func(t *testing.T) {
+	t.Run("accepts related issue outside federation group without materializing edge", func(t *testing.T) {
 		d, ctx, p, spokeUID := setupFederationIngestHub(t)
 		foreignProject, err := d.CreateProject(ctx, "foreign")
 		require.NoError(t, err)
@@ -3435,7 +3448,12 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 			},
 		})
 
-		require.Error(t, err)
+		require.NoError(t, err)
+		issue, err := d.IssueByUID(ctx, *base.IssueUID, db.IncludeDeletedYes)
+		require.NoError(t, err)
+		links, err := d.LinksByIssue(ctx, issue.ID)
+		require.NoError(t, err)
+		assert.Empty(t, links)
 	})
 
 	for _, eventType := range []string{"issue.moved", "recurrence.created", "recurrence.updated", "recurrence.deleted"} {

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -2057,6 +2057,108 @@ func TestEnableProjectFederationReconcilesDeferredGroupLinks(t *testing.T) {
 		firstIssue.UID, secondIssue.UID)
 }
 
+func TestFederationMembershipDestinationFirstPreservesIncomingLink(t *testing.T) {
+	t.Run("hub enable", func(t *testing.T) {
+		d := openTestDB(t)
+		ctx := context.Background()
+		firstProject := createProject(ctx, t, d, "spoke-project")
+		secondProject := createProject(ctx, t, d, "peer-project")
+		firstIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: firstProject.ID,
+			Title:     "first",
+			Author:    "tester",
+		})
+		require.NoError(t, err)
+		secondIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: secondProject.ID,
+			Title:     "second",
+			Author:    "tester",
+		})
+		require.NoError(t, err)
+		_, _, err = d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
+			FromIssueID: firstIssue.ID,
+			ToIssueID:   secondIssue.ID,
+			Type:        "blocks",
+			Author:      "tester",
+		}, db.LinkEventParams{
+			EventType:    "issue.linked",
+			EventIssueID: firstIssue.ID,
+			FromShortID:  firstIssue.ShortID,
+			FromUID:      firstIssue.UID,
+			ToShortID:    secondIssue.ShortID,
+			ToUID:        secondIssue.UID,
+			Actor:        "tester",
+		})
+		require.NoError(t, err)
+
+		_, err = d.EnableProjectFederation(ctx, secondProject.ID, "tester")
+		require.NoError(t, err)
+		_, err = d.EnableProjectFederation(ctx, firstProject.ID, "tester")
+		require.NoError(t, err)
+		assertRowCount(ctx, t, d, 1, "source enrollment restores incoming snapshot link",
+			`SELECT count(*) FROM links
+			  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+			firstIssue.UID, secondIssue.UID)
+	})
+
+	t.Run("spoke adoption", func(t *testing.T) {
+		d := openTestDB(t)
+		ctx := context.Background()
+		firstProject := createProject(ctx, t, d, "spoke-project")
+		secondProject := createProject(ctx, t, d, "peer-project")
+		firstIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: firstProject.ID,
+			Title:     "first",
+			Author:    "tester",
+		})
+		require.NoError(t, err)
+		secondIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: secondProject.ID,
+			Title:     "second",
+			Author:    "tester",
+		})
+		require.NoError(t, err)
+		_, _, err = d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
+			FromIssueID: firstIssue.ID,
+			ToIssueID:   secondIssue.ID,
+			Type:        "blocks",
+			Author:      "tester",
+		}, db.LinkEventParams{
+			EventType:    "issue.linked",
+			EventIssueID: firstIssue.ID,
+			FromShortID:  firstIssue.ShortID,
+			FromUID:      firstIssue.UID,
+			ToShortID:    secondIssue.ShortID,
+			ToUID:        secondIssue.UID,
+			Actor:        "tester",
+		})
+		require.NoError(t, err)
+
+		_, err = d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+			ProjectID:            secondProject.ID,
+			HubURL:               "https://hub.example/projects/second",
+			HubProjectID:         42,
+			HubProjectUID:        newTestUID(t),
+			ReplayHorizonEventID: 10,
+			Actor:                "bound-agent",
+		})
+		require.NoError(t, err)
+		_, err = d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+			ProjectID:            firstProject.ID,
+			HubURL:               "https://hub.example/projects/first",
+			HubProjectID:         41,
+			HubProjectUID:        newTestUID(t),
+			ReplayHorizonEventID: 10,
+			Actor:                "bound-agent",
+		})
+		require.NoError(t, err)
+		assertRowCount(ctx, t, d, 1, "source adoption restores incoming snapshot link",
+			`SELECT count(*) FROM links
+			  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+			firstIssue.UID, secondIssue.UID)
+	})
+}
+
 func TestUpsertFederationBindingReconcilesChangedGroupMembership(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
@@ -3650,6 +3752,74 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
 		assertIngestedEventCount(ctx, t, d, p.ID, 1)
 	})
+
+	t.Run("rejects alternate-only link endpoint fields", func(t *testing.T) {
+		d, ctx, p, spokeUID := setupFederationIngestHub(t)
+		primaryUID := newTestUID(t)
+		create := ingestIssueCreatedEvent(t, p.UID, p.Name, spokeUID, primaryUID, 100)
+		_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, create))
+		require.NoError(t, err)
+
+		peerUID := newTestUID(t)
+		link := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &primaryUID, &peerUID,
+			"issue.linked", 101,
+			`{"issue_uid":"`+primaryUID+`","from_issue_uid":"`+primaryUID+`","to_issue_uid":"`+peerUID+`","type":"blocks"}`)
+
+		_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+			ProjectID:        p.ID,
+			SpokeInstanceUID: spokeUID,
+			Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: link}},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+		assertIngestedEventCount(ctx, t, d, p.ID, 1)
+	})
+
+	for _, tc := range []struct {
+		name     string
+		linkType string
+		peerUID  func(*testing.T, string) string
+	}{
+		{
+			name:     "rejects deferred link with unsupported type",
+			linkType: "depends",
+			peerUID:  func(t *testing.T, _ string) string { return newTestUID(t) },
+		},
+		{
+			name:     "rejects deferred link with invalid peer uid",
+			linkType: "blocks",
+			peerUID:  func(*testing.T, string) string { return "not-an-issue-uid" },
+		},
+		{
+			name:     "rejects deferred self link",
+			linkType: "blocks",
+			peerUID:  func(_ *testing.T, primaryUID string) string { return primaryUID },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ctx, p, spokeUID := setupFederationIngestHub(t)
+			primaryUID := newTestUID(t)
+			create := ingestIssueCreatedEvent(t, p.UID, p.Name, spokeUID, primaryUID, 100)
+			_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, create))
+			require.NoError(t, err)
+
+			peerUID := tc.peerUID(t, primaryUID)
+			link := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &primaryUID, &peerUID,
+				"issue.linked", 101,
+				`{"issue_uid":"`+primaryUID+`","from_uid":"`+primaryUID+`","to_uid":"`+peerUID+`","type":"`+tc.linkType+`"}`)
+
+			_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+				ProjectID:        p.ID,
+				SpokeInstanceUID: spokeUID,
+				Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: link}},
+			})
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+			assertIngestedEventCount(ctx, t, d, p.ID, 1)
+		})
+	}
 
 	for _, eventType := range []string{"issue.created", "issue.snapshot"} {
 		t.Run("rejects fresh "+eventType+" for known issue uid", func(t *testing.T) {

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -3840,6 +3840,50 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
+		name         string
+		payloadField string
+	}{
+		{
+			name:         "rejects non-array links changed uid list",
+			payloadField: `"blocks_added_uids":{}`,
+		},
+		{
+			name:         "rejects mixed links changed uid list",
+			payloadField: `"related_added_uids":["%s",42]`,
+		},
+		{
+			name:         "rejects non-string links changed parent uid",
+			payloadField: `"parent_set_uid":42`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ctx, p, spokeUID := setupFederationIngestHub(t)
+			primaryUID := newTestUID(t)
+			create := ingestIssueCreatedEvent(t, p.UID, p.Name, spokeUID, primaryUID, 100)
+			_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, create))
+			require.NoError(t, err)
+
+			payloadField := tc.payloadField
+			if strings.Contains(payloadField, "%s") {
+				payloadField = fmt.Sprintf(payloadField, newTestUID(t))
+			}
+			changed := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &primaryUID, nil,
+				"issue.links_changed", 101,
+				`{"issue_uid":"`+primaryUID+`",`+payloadField+`,"updated_at":"2026-05-23T12:01:00.000Z"}`)
+
+			_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+				ProjectID:        p.ID,
+				SpokeInstanceUID: spokeUID,
+				Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: changed}},
+			})
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+			assertIngestedEventCount(ctx, t, d, p.ID, 1)
+		})
+	}
+
+	for _, tc := range []struct {
 		name     string
 		linkType string
 		peerUID  func(*testing.T, string) string

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -1968,7 +1968,7 @@ func TestIngestFederationEventsDeferredPeerDoesNotBecomeKnownPrimary(t *testing.
 	assert.ErrorIs(t, err, db.ErrNotFound)
 }
 
-func TestIngestFederationEventsConvergesCircularCrossProjectLinks(t *testing.T) {
+func TestIngestFederationEventsAcceptsLegacyCrossProjectUnlinkRetry(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
 	firstProject := createProject(ctx, t, d, "spoke-project")
@@ -2005,17 +2005,27 @@ func TestIngestFederationEventsConvergesCircularCrossProjectLinks(t *testing.T) 
 
 	unlink := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
 		&firstIssueUID, &secondIssueUID, "issue.unlinked", 102,
-		`{"issue_uid":"`+firstIssueUID+`","from_uid":"`+firstIssueUID+`","to_uid":"`+secondIssueUID+`","link_from_uid":"`+firstIssueUID+`","link_to_uid":"`+secondIssueUID+`","type":"blocks"}`)
-	_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+		`{"issue_uid":"`+firstIssueUID+`","from_uid":"`+firstIssueUID+`","to_uid":"`+secondIssueUID+`","type":"blocks"}`)
+	result, err := d.IngestFederationEvents(ctx, db.FederationIngestParams{
 		ProjectID:        firstProject.ID,
 		SpokeInstanceUID: spokeUID,
 		Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: unlink}},
 	})
 	require.NoError(t, err)
+	assert.Equal(t, 1, result.Accepted)
 	assertRowCount(ctx, t, d, 0, "cross-project unlink reconciled",
 		`SELECT count(*) FROM links
 		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
 		firstIssueUID, secondIssueUID)
+
+	retry, err := d.IngestFederationEvents(ctx, db.FederationIngestParams{
+		ProjectID:        firstProject.ID,
+		SpokeInstanceUID: spokeUID,
+		Events:           []db.FederationIngestEvent{{SourceEventID: 3, Event: unlink}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, retry.Accepted)
+	assert.Equal(t, 1, retry.Duplicates)
 }
 
 func TestIngestFederationEventsRejectsDeferredCrossProjectParentCycle(t *testing.T) {
@@ -5225,7 +5235,7 @@ func TestLeaveFederationReplicaDetachesSpoke(t *testing.T) {
 	}
 }
 
-func TestLeaveFederationReplicaReconcilesFormerGroupLinks(t *testing.T) {
+func TestLeaveFederationReplicaPreservesDetachedProjectState(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
 	firstProject := createProject(ctx, t, d, "spoke-project")
@@ -5244,16 +5254,23 @@ func TestLeaveFederationReplicaReconcilesFormerGroupLinks(t *testing.T) {
 
 	firstIssueUID := newTestUID(t)
 	secondIssueUID := newTestUID(t)
+	thirdIssueUID := newTestUID(t)
 	firstSnapshot := remoteEvent(t, firstProject.UID, firstProject.Name,
 		&firstIssueUID, nil, "issue.snapshot", "remote-agent", 100,
 		`{"uid":"`+firstIssueUID+`","short_id":"`+shortID(firstIssueUID)+`","title":"first","body":"","author":"remote-agent","status":"open","metadata":{},"links":[{"type":"blocks","to_issue_uid":"`+secondIssueUID+`","author":"remote-agent"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
 	secondSnapshot := remoteEvent(t, secondProject.UID, secondProject.Name,
 		&secondIssueUID, nil, "issue.snapshot", "remote-agent", 101,
-		`{"uid":"`+secondIssueUID+`","short_id":"`+shortID(secondIssueUID)+`","title":"second","body":"","author":"remote-agent","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+		`{"uid":"`+secondIssueUID+`","short_id":"`+shortID(secondIssueUID)+`","title":"second","body":"","author":"remote-agent","status":"open","metadata":{},"links":[{"type":"blocks","to_issue_uid":"`+thirdIssueUID+`","author":"remote-agent"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+	thirdSnapshot := remoteEvent(t, secondProject.UID, secondProject.Name,
+		&thirdIssueUID, nil, "issue.snapshot", "remote-agent", 102,
+		`{"uid":"`+thirdIssueUID+`","short_id":"`+shortID(thirdIssueUID)+`","title":"third","body":"","author":"remote-agent","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
 	inserted, err := d.InsertRemoteEvent(ctx, firstProject.ID, firstSnapshot)
 	require.NoError(t, err)
 	require.True(t, inserted)
 	inserted, err = d.InsertRemoteEvent(ctx, secondProject.ID, secondSnapshot)
+	require.NoError(t, err)
+	require.True(t, inserted)
+	inserted, err = d.InsertRemoteEvent(ctx, secondProject.ID, thirdSnapshot)
 	require.NoError(t, err)
 	require.True(t, inserted)
 	require.NoError(t, d.MaterializeFederatedProject(ctx, firstProject.ID))
@@ -5262,6 +5279,10 @@ func TestLeaveFederationReplicaReconcilesFormerGroupLinks(t *testing.T) {
 		`SELECT count(*) FROM links
 		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
 		firstIssueUID, secondIssueUID)
+	assertRowCount(ctx, t, d, 1, "same-project link exists before leaving group",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		secondIssueUID, thirdIssueUID)
 
 	_, err = d.LeaveFederationReplica(ctx, secondProject.ID)
 
@@ -5270,6 +5291,10 @@ func TestLeaveFederationReplicaReconcilesFormerGroupLinks(t *testing.T) {
 		`SELECT count(*) FROM links
 		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
 		firstIssueUID, secondIssueUID)
+	assertRowCount(ctx, t, d, 1, "leaving preserves the detached project's same-project link",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		secondIssueUID, thirdIssueUID)
 }
 
 func TestLeaveFederationReplicaIdempotentWhenStandalone(t *testing.T) {

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -2100,6 +2100,66 @@ func TestIngestFederationEventsUnlinksDirectionalEdgeThroughDestination(t *testi
 		firstIssueUID, secondIssueUID)
 }
 
+func TestIngestFederationEventsAcceptsLegacyDestinationUnlinkRetry(t *testing.T) {
+	for _, linkType := range []string{"blocks", "parent"} {
+		t.Run(linkType, func(t *testing.T) {
+			d := openTestDB(t)
+			ctx := context.Background()
+			firstProject := createProject(ctx, t, d, "spoke-project")
+			secondProject := createProject(ctx, t, d, "peer-project")
+			_, err := d.EnableProjectFederation(ctx, firstProject.ID, "tester")
+			require.NoError(t, err)
+			_, err = d.EnableProjectFederation(ctx, secondProject.ID, "tester")
+			require.NoError(t, err)
+
+			spokeUID := newTestUID(t)
+			firstIssueUID := newTestUID(t)
+			secondIssueUID := newTestUID(t)
+			first := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
+				&firstIssueUID, nil, "issue.created", 100,
+				`{"uid":"`+firstIssueUID+`","short_id":"`+shortID(firstIssueUID)+`","title":"first","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"`+linkType+`","to_issue_uid":"`+secondIssueUID+`","author":"spoke"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+			_, err = d.IngestFederationEvents(ctx, ingestParams(firstProject.ID, spokeUID, first))
+			require.NoError(t, err)
+			second := ingestIssueCreatedEvent(t, secondProject.UID, secondProject.Name, spokeUID, secondIssueUID, 101)
+			_, err = d.IngestFederationEvents(ctx, ingestParams(secondProject.ID, spokeUID, second))
+			require.NoError(t, err)
+			assertRowCount(ctx, t, d, 1, "directional edge materialized",
+				`SELECT count(*) FROM links
+				  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = ?`,
+				firstIssueUID, secondIssueUID, linkType)
+
+			unlink := ingestEventWithPayload(t, secondProject.UID, secondProject.Name, spokeUID,
+				&secondIssueUID, &firstIssueUID, "issue.unlinked", 102,
+				`{"issue_uid":"`+secondIssueUID+`","from_uid":"`+secondIssueUID+`","to_uid":"`+firstIssueUID+`","type":"`+linkType+`"}`)
+			result, err := d.IngestFederationEvents(ctx, db.FederationIngestParams{
+				ProjectID:        secondProject.ID,
+				SpokeInstanceUID: spokeUID,
+				Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: unlink}},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.Accepted)
+			assertRowCount(ctx, t, d, 0, "legacy destination-side unlink removes directional edge",
+				`SELECT count(*) FROM links
+				  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = ?`,
+				firstIssueUID, secondIssueUID, linkType)
+
+			retry, err := d.IngestFederationEvents(ctx, db.FederationIngestParams{
+				ProjectID:        secondProject.ID,
+				SpokeInstanceUID: spokeUID,
+				Events:           []db.FederationIngestEvent{{SourceEventID: 3, Event: unlink}},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 0, retry.Accepted)
+			assert.Equal(t, 1, retry.Duplicates)
+			assert.Equal(t, int64(3), retry.PushCursorEventID)
+			assertRowCount(ctx, t, d, 0, "legacy destination-side unlink retry keeps edge absent",
+				`SELECT count(*) FROM links
+				  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = ?`,
+				firstIssueUID, secondIssueUID, linkType)
+		})
+	}
+}
+
 func TestEnableProjectFederationReconcilesDeferredGroupLinks(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -856,6 +856,63 @@ func TestAdoptProjectIntoFederationSnapshotsEditedCommentWithoutLeakedBody(t *te
 	assert.Equal(t, "[redacted]", payload.Comments[0].Body)
 }
 
+func TestAdoptProjectIntoFederationReconcilesDeferredGroupLinks(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	firstProject := createProject(ctx, t, d, "spoke-project")
+	peerProject := createProject(ctx, t, d, "peer-project")
+	peerIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: peerProject.ID,
+		Title:     "peer",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            firstProject.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://hub.example:7373/projects/first",
+		HubProjectID:         41,
+		HubProjectUID:        firstProject.UID,
+		ReplayHorizonEventID: 1,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+
+	firstIssueUID := newTestUID(t)
+	for _, event := range []db.RemoteEvent{
+		remoteEvent(t, firstProject.UID, firstProject.Name, nil, nil,
+			"project.federation_enabled", "remote-agent", 99,
+			`{"project_uid":"`+firstProject.UID+`","project_name":"`+firstProject.Name+`"}`),
+		remoteEvent(t, firstProject.UID, firstProject.Name, &firstIssueUID, nil,
+			"issue.snapshot", "remote-agent", 100,
+			`{"uid":"`+firstIssueUID+`","short_id":"`+shortID(firstIssueUID)+`","title":"first","body":"","author":"remote-agent","status":"open","metadata":{},"links":[{"type":"blocks","to_issue_uid":"`+peerIssue.UID+`","author":"remote-agent"}],"created_at":"2026-05-23T12:00:00.000Z"}`),
+	} {
+		inserted, err := d.InsertRemoteEvent(ctx, firstProject.ID, event)
+		require.NoError(t, err)
+		require.True(t, inserted)
+	}
+	require.NoError(t, d.MaterializeFederatedProject(ctx, firstProject.ID))
+	assertRowCount(ctx, t, d, 0, "link waits for adopted peer project",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssueUID, peerIssue.UID)
+
+	_, err = d.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+		ProjectID:            peerProject.ID,
+		HubURL:               "http://hub.example:7373/projects/peer",
+		HubProjectID:         42,
+		HubProjectUID:        newTestUID(t),
+		ReplayHorizonEventID: 10,
+		Actor:                "bound-agent",
+	})
+
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 1, "adoption reconciles deferred link",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssueUID, peerIssue.UID)
+}
+
 func TestFederationBindingPhase1StyleDefaultsPushState(t *testing.T) {
 	d, ctx, p := setupTestProject(t)
 
@@ -1875,6 +1932,42 @@ func TestIngestFederationEventsDefersUnknownLinkPeer(t *testing.T) {
 	assert.Empty(t, links, "the peer is unresolved, so the edge must stay absent")
 }
 
+func TestIngestFederationEventsDeferredPeerDoesNotBecomeKnownPrimary(t *testing.T) {
+	d, ctx, project, spokeUID := setupFederationIngestHub(t)
+	primaryUID := newTestUID(t)
+	peerUID := newTestUID(t)
+	create := ingestIssueCreatedEvent(t, project.UID, project.Name, spokeUID, primaryUID, 100)
+	_, err := d.IngestFederationEvents(ctx, ingestParams(project.ID, spokeUID, create))
+	require.NoError(t, err)
+
+	link := ingestEventWithPayload(t, project.UID, project.Name, spokeUID, &primaryUID, &peerUID,
+		"issue.linked", 101,
+		`{"issue_uid":"`+primaryUID+`","from_uid":"`+primaryUID+`","to_uid":"`+peerUID+`","type":"blocks"}`)
+	_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+		ProjectID:        project.ID,
+		SpokeInstanceUID: spokeUID,
+		Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: link}},
+	})
+	require.NoError(t, err)
+	_, err = d.IssueByUID(ctx, peerUID, db.IncludeDeletedYes)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+
+	update := ingestEventWithPayload(t, project.UID, project.Name, spokeUID, &peerUID, nil,
+		"issue.updated", 102,
+		`{"issue_uid":"`+peerUID+`","title":"phantom","updated_at":"2026-05-23T12:01:00.000Z"}`)
+	_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+		ProjectID:        project.ID,
+		SpokeInstanceUID: spokeUID,
+		Events:           []db.FederationIngestEvent{{SourceEventID: 3, Event: update}},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+	assertIngestedEventCount(ctx, t, d, project.ID, 2)
+	_, err = d.IssueByUID(ctx, peerUID, db.IncludeDeletedYes)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}
+
 func TestIngestFederationEventsConvergesCircularCrossProjectLinks(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
@@ -1923,6 +2016,95 @@ func TestIngestFederationEventsConvergesCircularCrossProjectLinks(t *testing.T) 
 		`SELECT count(*) FROM links
 		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
 		firstIssueUID, secondIssueUID)
+}
+
+func TestEnableProjectFederationReconcilesDeferredGroupLinks(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	firstProject := createProject(ctx, t, d, "spoke-project")
+	secondProject := createProject(ctx, t, d, "peer-project")
+	firstIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: firstProject.ID,
+		Title:     "first",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	secondIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: secondProject.ID,
+		Title:     "second",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, err = d.EnableProjectFederation(ctx, firstProject.ID, "tester")
+	require.NoError(t, err)
+
+	spokeUID := newTestUID(t)
+	link := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
+		&firstIssue.UID, &secondIssue.UID, "issue.linked", 100,
+		`{"issue_uid":"`+firstIssue.UID+`","from_uid":"`+firstIssue.UID+`","to_uid":"`+secondIssue.UID+`","type":"blocks"}`)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(firstProject.ID, spokeUID, link))
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 0, "link waits for standalone peer project",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssue.UID, secondIssue.UID)
+
+	_, err = d.EnableProjectFederation(ctx, secondProject.ID, "tester")
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 1, "enabling peer reconciles deferred link",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssue.UID, secondIssue.UID)
+}
+
+func TestUpsertFederationBindingReconcilesChangedGroupMembership(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	firstProject := createProject(ctx, t, d, "spoke-project")
+	secondProject := createProject(ctx, t, d, "peer-project")
+	firstIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: firstProject.ID,
+		Title:     "first",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	secondIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: secondProject.ID,
+		Title:     "second",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, err = d.EnableProjectFederation(ctx, firstProject.ID, "tester")
+	require.NoError(t, err)
+	secondBinding, err := d.EnableProjectFederation(ctx, secondProject.ID, "tester")
+	require.NoError(t, err)
+
+	spokeUID := newTestUID(t)
+	link := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
+		&firstIssue.UID, &secondIssue.UID, "issue.linked", 100,
+		`{"issue_uid":"`+firstIssue.UID+`","from_uid":"`+firstIssue.UID+`","to_uid":"`+secondIssue.UID+`","type":"blocks"}`)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(firstProject.ID, spokeUID, link))
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 1, "link exists while both projects are enabled",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssue.UID, secondIssue.UID)
+
+	secondBinding.Enabled = false
+	_, err = d.UpsertFederationBinding(ctx, secondBinding)
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 0, "disabling peer removes old group projection",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssue.UID, secondIssue.UID)
+
+	secondBinding.Enabled = true
+	_, err = d.UpsertFederationBinding(ctx, secondBinding)
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 1, "re-enabling peer restores deferred link",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssue.UID, secondIssue.UID)
 }
 
 func TestIngestFederationEvents_Validation(t *testing.T) {
@@ -3421,6 +3603,54 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("rejects link whose primary is not an endpoint", func(t *testing.T) {
+		d, ctx, p, spokeUID := setupFederationIngestHub(t)
+		primaryUID := newTestUID(t)
+		create := ingestIssueCreatedEvent(t, p.UID, p.Name, spokeUID, primaryUID, 100)
+		_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, create))
+		require.NoError(t, err)
+
+		fromUID := newTestUID(t)
+		toUID := newTestUID(t)
+		link := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &primaryUID, &toUID,
+			"issue.linked", 101,
+			`{"issue_uid":"`+primaryUID+`","from_uid":"`+fromUID+`","to_uid":"`+toUID+`","type":"blocks"}`)
+
+		_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+			ProjectID:        p.ID,
+			SpokeInstanceUID: spokeUID,
+			Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: link}},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+		assertIngestedEventCount(ctx, t, d, p.ID, 1)
+	})
+
+	t.Run("rejects related issue that is not the opposite endpoint", func(t *testing.T) {
+		d, ctx, p, spokeUID := setupFederationIngestHub(t)
+		primaryUID := newTestUID(t)
+		create := ingestIssueCreatedEvent(t, p.UID, p.Name, spokeUID, primaryUID, 100)
+		_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, create))
+		require.NoError(t, err)
+
+		peerUID := newTestUID(t)
+		unrelatedUID := newTestUID(t)
+		link := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &primaryUID, &unrelatedUID,
+			"issue.linked", 101,
+			`{"issue_uid":"`+primaryUID+`","from_uid":"`+primaryUID+`","to_uid":"`+peerUID+`","type":"blocks"}`)
+
+		_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+			ProjectID:        p.ID,
+			SpokeInstanceUID: spokeUID,
+			Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: link}},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+		assertIngestedEventCount(ctx, t, d, p.ID, 1)
+	})
+
 	for _, eventType := range []string{"issue.created", "issue.snapshot"} {
 		t.Run("rejects fresh "+eventType+" for known issue uid", func(t *testing.T) {
 			d, ctx, p, spokeUID := setupFederationIngestHub(t)
@@ -4670,6 +4900,53 @@ func TestLeaveFederationReplicaDetachesSpoke(t *testing.T) {
 	if _, err := d.ProjectByID(ctx, projectID); err != nil {
 		t.Fatalf("project should survive detach: %v", err)
 	}
+}
+
+func TestLeaveFederationReplicaReconcilesFormerGroupLinks(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	firstProject := createProject(ctx, t, d, "spoke-project")
+	secondProject := createProject(ctx, t, d, "peer-project")
+	for _, project := range []db.Project{firstProject, secondProject} {
+		_, err := d.UpsertFederationBinding(ctx, db.FederationBinding{
+			ProjectID:     project.ID,
+			Role:          db.FederationRoleSpoke,
+			HubURL:        "https://hub.example/projects/" + project.Name,
+			HubProjectID:  project.ID,
+			HubProjectUID: project.UID,
+			Enabled:       true,
+		})
+		require.NoError(t, err)
+	}
+
+	firstIssueUID := newTestUID(t)
+	secondIssueUID := newTestUID(t)
+	firstSnapshot := remoteEvent(t, firstProject.UID, firstProject.Name,
+		&firstIssueUID, nil, "issue.snapshot", "remote-agent", 100,
+		`{"uid":"`+firstIssueUID+`","short_id":"`+shortID(firstIssueUID)+`","title":"first","body":"","author":"remote-agent","status":"open","metadata":{},"links":[{"type":"blocks","to_issue_uid":"`+secondIssueUID+`","author":"remote-agent"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+	secondSnapshot := remoteEvent(t, secondProject.UID, secondProject.Name,
+		&secondIssueUID, nil, "issue.snapshot", "remote-agent", 101,
+		`{"uid":"`+secondIssueUID+`","short_id":"`+shortID(secondIssueUID)+`","title":"second","body":"","author":"remote-agent","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+	inserted, err := d.InsertRemoteEvent(ctx, firstProject.ID, firstSnapshot)
+	require.NoError(t, err)
+	require.True(t, inserted)
+	inserted, err = d.InsertRemoteEvent(ctx, secondProject.ID, secondSnapshot)
+	require.NoError(t, err)
+	require.True(t, inserted)
+	require.NoError(t, d.MaterializeFederatedProject(ctx, firstProject.ID))
+	require.NoError(t, d.MaterializeFederatedProject(ctx, secondProject.ID))
+	assertRowCount(ctx, t, d, 1, "link exists before leaving group",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssueUID, secondIssueUID)
+
+	_, err = d.LeaveFederationReplica(ctx, secondProject.ID)
+
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 0, "leaving peer removes former group link",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssueUID, secondIssueUID)
 }
 
 func TestLeaveFederationReplicaIdempotentWhenStandalone(t *testing.T) {

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -2018,6 +2018,36 @@ func TestIngestFederationEventsConvergesCircularCrossProjectLinks(t *testing.T) 
 		firstIssueUID, secondIssueUID)
 }
 
+func TestIngestFederationEventsRejectsDeferredCrossProjectParentCycle(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	firstProject := createProject(ctx, t, d, "spoke-project")
+	secondProject := createProject(ctx, t, d, "peer-project")
+	_, err := d.EnableProjectFederation(ctx, firstProject.ID, "tester")
+	require.NoError(t, err)
+	_, err = d.EnableProjectFederation(ctx, secondProject.ID, "tester")
+	require.NoError(t, err)
+
+	spokeUID := newTestUID(t)
+	firstIssueUID := newTestUID(t)
+	secondIssueUID := newTestUID(t)
+	first := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
+		&firstIssueUID, nil, "issue.created", 100,
+		`{"uid":"`+firstIssueUID+`","short_id":"`+shortID(firstIssueUID)+`","title":"first","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"parent","to_issue_uid":"`+secondIssueUID+`","author":"spoke"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(firstProject.ID, spokeUID, first))
+	require.NoError(t, err)
+
+	second := ingestEventWithPayload(t, secondProject.UID, secondProject.Name, spokeUID,
+		&secondIssueUID, nil, "issue.created", 101,
+		`{"uid":"`+secondIssueUID+`","short_id":"`+shortID(secondIssueUID)+`","title":"second","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"parent","to_issue_uid":"`+firstIssueUID+`","author":"spoke"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(secondProject.ID, spokeUID, second))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+	assertRowCount(ctx, t, d, 0, "invalid parent cycle is not materialized",
+		`SELECT count(*) FROM links WHERE type = 'parent'`)
+}
+
 func TestEnableProjectFederationReconcilesDeferredGroupLinks(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()
@@ -3775,6 +3805,39 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
 		assertIngestedEventCount(ctx, t, d, p.ID, 1)
 	})
+
+	for _, tc := range []struct {
+		name  string
+		links string
+	}{
+		{
+			name:  "rejects malformed snapshot links container",
+			links: `{}`,
+		},
+		{
+			name:  "rejects malformed snapshot link field",
+			links: `[{"type":"blocks","to_issue_uid":"%s","incoming":"yes"}]`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ctx, p, spokeUID := setupFederationIngestHub(t)
+			issueUID := newTestUID(t)
+			peerUID := newTestUID(t)
+			links := tc.links
+			if strings.Contains(links, "%s") {
+				links = fmt.Sprintf(links, peerUID)
+			}
+			snapshot := ingestEventWithPayload(t, p.UID, p.Name, spokeUID, &issueUID, nil,
+				"issue.snapshot", 100,
+				`{"uid":"`+issueUID+`","short_id":"`+shortID(issueUID)+`","title":"subject","body":"","author":"spoke","status":"open","metadata":{},"links":`+links+`,"created_at":"2026-05-23T12:00:00.000Z"}`)
+
+			_, err := d.IngestFederationEvents(ctx, ingestParams(p.ID, spokeUID, snapshot))
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, db.ErrFederationIngestValidation)
+			assertIngestedEventCount(ctx, t, d, p.ID, 0)
+		})
+	}
 
 	for _, tc := range []struct {
 		name     string

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -1875,6 +1875,56 @@ func TestIngestFederationEventsDefersUnknownLinkPeer(t *testing.T) {
 	assert.Empty(t, links, "the peer is unresolved, so the edge must stay absent")
 }
 
+func TestIngestFederationEventsConvergesCircularCrossProjectLinks(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	firstProject := createProject(ctx, t, d, "spoke-project")
+	secondProject := createProject(ctx, t, d, "peer-project")
+	_, err := d.EnableProjectFederation(ctx, firstProject.ID, "tester")
+	require.NoError(t, err)
+	_, err = d.EnableProjectFederation(ctx, secondProject.ID, "tester")
+	require.NoError(t, err)
+
+	spokeUID := newTestUID(t)
+	firstIssueUID := newTestUID(t)
+	secondIssueUID := newTestUID(t)
+	first := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
+		&firstIssueUID, nil, "issue.created", 100,
+		`{"uid":"`+firstIssueUID+`","short_id":"`+shortID(firstIssueUID)+`","title":"first","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"blocks","to_issue_uid":"`+secondIssueUID+`","author":"spoke"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+	firstResult, err := d.IngestFederationEvents(ctx, ingestParams(firstProject.ID, spokeUID, first))
+	require.NoError(t, err)
+	assert.Equal(t, 1, firstResult.Accepted)
+	assertRowCount(ctx, t, d, 0, "link waits for peer issue",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssueUID, secondIssueUID)
+
+	second := ingestEventWithPayload(t, secondProject.UID, secondProject.Name, spokeUID,
+		&secondIssueUID, nil, "issue.created", 101,
+		`{"uid":"`+secondIssueUID+`","short_id":"`+shortID(secondIssueUID)+`","title":"second","body":"","author":"spoke","status":"open","metadata":{},"links":[{"type":"blocks","to_issue_uid":"`+firstIssueUID+`","incoming":true,"author":"spoke"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+	secondResult, err := d.IngestFederationEvents(ctx, ingestParams(secondProject.ID, spokeUID, second))
+	require.NoError(t, err)
+	assert.Equal(t, 1, secondResult.Accepted)
+	assertRowCount(ctx, t, d, 1, "deferred cross-project link materialized",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssueUID, secondIssueUID)
+
+	unlink := ingestEventWithPayload(t, firstProject.UID, firstProject.Name, spokeUID,
+		&firstIssueUID, &secondIssueUID, "issue.unlinked", 102,
+		`{"issue_uid":"`+firstIssueUID+`","from_uid":"`+firstIssueUID+`","to_uid":"`+secondIssueUID+`","type":"blocks"}`)
+	_, err = d.IngestFederationEvents(ctx, db.FederationIngestParams{
+		ProjectID:        firstProject.ID,
+		SpokeInstanceUID: spokeUID,
+		Events:           []db.FederationIngestEvent{{SourceEventID: 2, Event: unlink}},
+	})
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 0, "cross-project unlink reconciled",
+		`SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssueUID, secondIssueUID)
+}
+
 func TestIngestFederationEvents_Validation(t *testing.T) {
 	t.Run("rejects project uid mismatch", func(t *testing.T) {
 		d, ctx, p, spokeUID := setupFederationIngestHub(t)
@@ -3697,6 +3747,79 @@ func TestMaterializeFederatedProject(t *testing.T) {
 		`SELECT count(*) FROM links
 		   WHERE from_issue_id IN (SELECT id FROM issues WHERE project_id = ?)
 		     AND type = 'related'`, p.ID)
+}
+
+func TestMaterializeFederatedProjectGroupsCrossProjectLinksByHubOrigin(t *testing.T) {
+	cases := []struct {
+		name      string
+		firstURL  string
+		secondURL string
+		wantLinks int
+	}{
+		{
+			name:      "same normalized hub origin",
+			firstURL:  "https://Hub.Example:443/path-a",
+			secondURL: "https://hub.example/path-b",
+			wantLinks: 1,
+		},
+		{
+			name:      "different hub origin",
+			firstURL:  "https://hub-a.example",
+			secondURL: "https://hub-b.example",
+			wantLinks: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := openTestDB(t)
+			ctx := context.Background()
+			firstProject := createProject(ctx, t, d, "spoke-project")
+			secondProject := createProject(ctx, t, d, "peer-project")
+			_, err := d.UpsertFederationBinding(ctx, db.FederationBinding{
+				ProjectID:     firstProject.ID,
+				Role:          db.FederationRoleSpoke,
+				HubURL:        tc.firstURL,
+				HubProjectID:  41,
+				HubProjectUID: firstProject.UID,
+				Enabled:       true,
+			})
+			require.NoError(t, err)
+			_, err = d.UpsertFederationBinding(ctx, db.FederationBinding{
+				ProjectID:     secondProject.ID,
+				Role:          db.FederationRoleSpoke,
+				HubURL:        tc.secondURL,
+				HubProjectID:  42,
+				HubProjectUID: secondProject.UID,
+				Enabled:       true,
+			})
+			require.NoError(t, err)
+
+			firstIssueUID := newTestUID(t)
+			secondIssueUID := newTestUID(t)
+			firstSnapshot := remoteEvent(t, firstProject.UID, firstProject.Name,
+				&firstIssueUID, nil, "issue.snapshot", "remote-agent", 100,
+				`{"uid":"`+firstIssueUID+`","short_id":"`+shortID(firstIssueUID)+`","title":"first","body":"","author":"remote-agent","status":"open","metadata":{},"links":[{"type":"related","to_issue_uid":"`+secondIssueUID+`","author":"remote-agent"}],"created_at":"2026-05-23T12:00:00.000Z"}`)
+			secondSnapshot := remoteEvent(t, secondProject.UID, secondProject.Name,
+				&secondIssueUID, nil, "issue.snapshot", "remote-agent", 101,
+				`{"uid":"`+secondIssueUID+`","short_id":"`+shortID(secondIssueUID)+`","title":"second","body":"","author":"remote-agent","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`)
+			inserted, err := d.InsertRemoteEvent(ctx, firstProject.ID, firstSnapshot)
+			require.NoError(t, err)
+			require.True(t, inserted)
+			inserted, err = d.InsertRemoteEvent(ctx, secondProject.ID, secondSnapshot)
+			require.NoError(t, err)
+			require.True(t, inserted)
+
+			require.NoError(t, d.MaterializeFederatedProject(ctx, firstProject.ID))
+			require.NoError(t, d.MaterializeFederatedProject(ctx, secondProject.ID))
+
+			assertRowCount(ctx, t, d, tc.wantLinks, "cross-project link count",
+				`SELECT count(*) FROM links
+				  WHERE type = 'related'
+				    AND (from_issue_uid = ? OR to_issue_uid = ?)
+				    AND (from_issue_uid = ? OR to_issue_uid = ?)`,
+				firstIssueUID, firstIssueUID, secondIssueUID, secondIssueUID)
+		})
+	}
 }
 
 func TestMaterializeFederatedProject_ReconcilesExistingRowsAndEdges(t *testing.T) {

--- a/internal/db/sqlitestore/queries_links.go
+++ b/internal/db/sqlitestore/queries_links.go
@@ -896,6 +896,8 @@ func (d *Store) deleteLinkAndEvent(ctx context.Context, link db.Link, ev db.Link
 		"from_uid":      ev.FromUID,
 		"to_short_id":   ev.ToShortID,
 		"to_uid":        ev.ToUID,
+		"link_from_uid": link.FromIssueUID,
+		"link_to_uid":   link.ToIssueUID,
 		"updated_at":    ts,
 	})
 	if err != nil {


### PR DESCRIPTION
## Why

Federation currently quarantines a valid batch whenever a link peer has not reached the hub yet. If two independently synchronized projects create cross-references in their first pending batches, each waits for an issue that only the other quarantined batch can create, permanently blocking both push cursors.

## What changes

- accept valid link events with unresolved peers while preserving strict validation for primary issues, actor violations, malformed events, and hash conflicts
- reconcile links across enabled hub projects on one daemon or spoke projects sharing the same normalized hub origin, so arrival order no longer matters
- keep unfederated and different-origin peers absent without blocking subsequent events
- ensure CI test commands cannot inherit KATA_AUTH_TOKEN
- document same-hub enrollment constraints and retry-based recovery for quarantines created by older builds

Missing peers remain event-backed deferred state; no schema migration or separate pending-link store is added. Existing quarantines should be retried, not skipped, after compatible hub and spoke binaries are deployed.

The full shuffled Go suite, lint, API compatibility check, workflow validation, documentation checks, and push hooks passed on the committed branch.