### PR TITLE
fix(githubsync): canonicalize numeric /repositories pagination URLs

### DIFF
--- a/internal/githubsync/http_fetcher.go
+++ b/internal/githubsync/http_fetcher.go
@@ -114,7 +114,7 @@ func (f *HTTPFetcher) Issues(ctx context.Context, binding Binding, since *time.T
 	if err != nil {
 		return nil, err
 	}
-	return fetchRESTPagesWithClient[Issue](ctx, f, client, requestURL, "GitHub issues")
+	return fetchRESTPagesWithClient[Issue](ctx, f, client, binding, requestURL, "GitHub issues")
 }
 
 // Comments reads issue comments over REST, following Link rel="next" pages.
@@ -134,10 +134,10 @@ func (f *HTTPFetcher) Comments(ctx context.Context, binding Binding, issueNumber
 	if err != nil {
 		return nil, err
 	}
-	return fetchRESTPagesWithClient[Comment](ctx, f, client, requestURL, "GitHub comments for issue "+strconv.Itoa(issueNumber))
+	return fetchRESTPagesWithClient[Comment](ctx, f, client, binding, requestURL, "GitHub comments for issue "+strconv.Itoa(issueNumber))
 }
 
-func fetchRESTPagesWithClient[T any](ctx context.Context, f *HTTPFetcher, client *http.Client, firstURL, resource string) ([]T, error) {
+func fetchRESTPagesWithClient[T any](ctx context.Context, f *HTTPFetcher, client *http.Client, binding Binding, firstURL, resource string) ([]T, error) {
 	var out []T
 	retryBudget := &gitHubRetryBudget{}
 	for nextURL := firstURL; nextURL != ""; {
@@ -155,6 +155,10 @@ func fetchRESTPagesWithClient[T any](ctx context.Context, f *HTTPFetcher, client
 		}
 		out = append(out, page...)
 		nextURL, err = nextGitHubLinkURL(currentURL, headers.Get("Link"))
+		if err != nil {
+			return nil, err
+		}
+		nextURL, err = canonicalGitHubPageURL(binding, nextURL)
 		if err != nil {
 			return nil, err
 		}
@@ -207,7 +211,7 @@ func (s *httpFetcherBindingSession) Issues(ctx context.Context, binding Binding,
 	if err != nil {
 		return nil, err
 	}
-	return fetchRESTPagesWithClient[Issue](ctx, s.fetcher, s.client, requestURL, "GitHub issues")
+	return fetchRESTPagesWithClient[Issue](ctx, s.fetcher, s.client, binding, requestURL, "GitHub issues")
 }
 
 func (s *httpFetcherBindingSession) Comments(ctx context.Context, binding Binding, issueNumber int) ([]Comment, error) {
@@ -226,7 +230,7 @@ func (s *httpFetcherBindingSession) Comments(ctx context.Context, binding Bindin
 	if err != nil {
 		return nil, err
 	}
-	return fetchRESTPagesWithClient[Comment](ctx, s.fetcher, s.client, requestURL, "GitHub comments for issue "+strconv.Itoa(issueNumber))
+	return fetchRESTPagesWithClient[Comment](ctx, s.fetcher, s.client, binding, requestURL, "GitHub comments for issue "+strconv.Itoa(issueNumber))
 }
 
 func (s *httpFetcherBindingSession) ParentData(ctx context.Context, binding Binding) (ParentData, error) {
@@ -411,6 +415,34 @@ func nextGitHubLinkURL(currentURL, linkHeader string) (string, error) {
 		return "", fmt.Errorf("parse GitHub next page URL: %w", err)
 	}
 	return base.ResolveReference(nextURL).String(), nil
+}
+
+// canonicalGitHubPageURL rewrites pagination URLs that GitHub returns in
+// numeric /repositories/{id}/... form back to the /repos/{owner}/{repo}/...
+// form so the credential egress guard can verify they target the bound
+// repository.
+func canonicalGitHubPageURL(binding Binding, raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse GitHub next page URL: %w", err)
+	}
+	segments := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	offset := 0
+	if binding.Host != "github.com" {
+		offset = 2
+	}
+	if len(segments) < offset+2 || segments[offset] != "repositories" {
+		return raw, nil
+	}
+	rewritten := append([]string{}, segments[:offset]...)
+	rewritten = append(rewritten, "repos", binding.Owner, binding.Repo)
+	rewritten = append(rewritten, segments[offset+2:]...)
+	u.Path = "/" + strings.Join(rewritten, "/")
+	u.RawPath = ""
+	return u.String(), nil
 }
 
 func nextGitHubLink(linkHeader string) string {

--- a/internal/githubsync/http_fetcher_test.go
+++ b/internal/githubsync/http_fetcher_test.go
@@ -136,6 +136,96 @@ func TestHTTPFetcherIssuesPaginationUsesOriginGuardWithCanonicalCase(t *testing.
 	assert.Equal(t, []string{"/repos/example-owner/example-repo/issues", "/repos/Example-Owner/Example-Repo/issues"}, seenPaths)
 }
 
+func TestHTTPFetcherIssuesPaginationRewritesNumericRepositoryURLs(t *testing.T) {
+	tokenEnv := "EXAMPLE_" + "GITHUB_TOKEN"
+	t.Setenv(tokenEnv, "env-token")
+	var server *httptest.Server
+	var seenPaths []string
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertHTTPFetcherHeaders(t, r)
+		assert.Equal(t, "Bearer env-token", r.Header.Get("Authorization"))
+		seenPaths = append(seenPaths, r.URL.Path)
+		switch r.URL.Query().Get("page") {
+		case "":
+			assert.Equal(t, "/repos/example-owner/example-repo/issues", r.URL.Path)
+			w.Header().Set("Link", `<https://api.github.com/repositories/123456789012/issues?page=2>; rel="next"`)
+			writeHTTPFetcherTestResponse(t, w, `[{"id":101,"node_id":"I_first","number":1,"title":"first"}]`)
+		case "2":
+			assert.Equal(t, "/repos/example-owner/example-repo/issues", r.URL.Path)
+			writeHTTPFetcherTestResponse(t, w, `[{"id":102,"node_id":"I_second","number":2,"title":"second"}]`)
+		default:
+			t.Fatalf("unexpected numeric pagination page %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	fetcher := NewHTTPFetcher(HTTPFetcherConfig{
+		Client: &http.Client{
+			Transport: &rewriteHostRoundTripper{
+				target: serverURL,
+				next:   server.Client().Transport,
+			},
+		},
+		CredentialResolver: NewCredentialResolver(config.GitHubSyncConfig{TokenEnv: tokenEnv}, &fakeCommandRunner{}),
+	})
+
+	issues, err := fetcher.Issues(context.Background(), Binding{
+		Host:  "github.com",
+		Owner: "example-owner",
+		Repo:  "example-repo",
+	}, nil)
+	require.NoError(t, err)
+
+	require.Len(t, issues, 2)
+	assert.Equal(t, []string{"/repos/example-owner/example-repo/issues", "/repos/example-owner/example-repo/issues"}, seenPaths)
+}
+
+func TestCanonicalGitHubPageURL(t *testing.T) {
+	githubBinding := Binding{Host: "github.com", Owner: "example-owner", Repo: "example-repo"}
+	enterpriseBinding := Binding{Host: "github.example.com", Owner: "example-owner", Repo: "example-repo"}
+
+	tests := []struct {
+		name    string
+		binding Binding
+		raw     string
+		want    string
+	}{
+		{
+			name:    "rewrites numeric repositories path",
+			binding: githubBinding,
+			raw:     "https://api.github.com/repositories/123456789012/issues?page=2",
+			want:    "https://api.github.com/repos/example-owner/example-repo/issues?page=2",
+		},
+		{
+			name:    "rewrites enterprise numeric repositories path",
+			binding: enterpriseBinding,
+			raw:     "https://github.example.com/api/v3/repositories/42/issues/7/comments?page=3",
+			want:    "https://github.example.com/api/v3/repos/example-owner/example-repo/issues/7/comments?page=3",
+		},
+		{
+			name:    "leaves canonical repos path unchanged",
+			binding: githubBinding,
+			raw:     "https://api.github.com/repos/example-owner/example-repo/issues?page=2",
+			want:    "https://api.github.com/repos/example-owner/example-repo/issues?page=2",
+		},
+		{
+			name:    "leaves empty URL unchanged",
+			binding: githubBinding,
+			raw:     "",
+			want:    "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := canonicalGitHubPageURL(tc.binding, tc.raw)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestHTTPFetcherCommentsPaginates(t *testing.T) {
 	var server *httptest.Server
 	var seenPages []string


### PR DESCRIPTION

Fixes #168.

## Problem

GitHub's REST API returns pagination `Link` headers whose `rel="next"` URLs use the numeric `/repositories/{id}/...` form. The credential egress guard only allows `/repos/{owner}/{repo}/...` paths, so any repository with more than one page of issues or comments (>100) fails at page 2 with `GitHub credential egress blocked`.

## Fix

`fetchRESTPagesWithClient` now passes the binding through and rewrites each next-page URL back to the canonical `/repos/{owner}/{repo}/...` form for the bound repository (via a new `canonicalGitHubPageURL` helper) before following it. URLs that are not in the numeric form pass through unchanged, and the egress guard itself is untouched — every followed URL is still validated against the binding.

Handles both github.com (`/repositories/{id}/...`) and GHES (`/api/v3/repositories/{id}/...`) path shapes.

## Tests

- `TestHTTPFetcherIssuesPaginationRewritesNumericRepositoryURLs`: guard-integration test (real `originGuardTransport`) where the test server returns a numeric `Link` next URL; without the fix this fails with the egress-blocked error.
- `TestCanonicalGitHubPageURL`: unit table test covering github.com and GHES rewrites, canonical-path passthrough, and empty input.

`go test ./internal/githubsync/` and `go vet ./internal/githubsync/` pass.

## Verified against real repos

With this patch, one-shot and daemon sync completed against `rstudio/shinytest2` (256 issues, 534 comments), `rstudio/promises` (106 issues), and `rstudio/reactlog` (58 issues); v0.9.0 failed at page 2 on the first two.
