### PR TITLE
Recover quarantined federation batches automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 	go install -ldflags="$(LDFLAGS)" ./cmd/kata
 
 test:
-	go test $(GOFLAGS_TEST) ./...
+	env -u KATA_AUTH_TOKEN go test $(GOFLAGS_TEST) ./...
 
 # Regenerate the committed OpenAPI schema and generated Go client.
 # Drift tests fail if the OpenAPI artifacts or generated client differ from this output.
@@ -31,7 +31,7 @@ api-check:
 openapi: api-generate
 
 test-short:
-	go test -short $(GOFLAGS_TEST) ./...
+	env -u KATA_AUTH_TOKEN go test -short $(GOFLAGS_TEST) ./...
 
 test-stress:
 	go test -tags federation_stress ./e2e -run 'TestFederationStress|TestFederationFailpoint' -rapid.checks=5 -count=1 -timeout 2m

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1480,8 +1481,245 @@ func federationQuarantineCmd() *cobra.Command {
 		Use:   "quarantine",
 		Short: "manage federation quarantines",
 	}
-	cmd.AddCommand(federationQuarantineSkipCmd(), federationQuarantineRetryCmd())
+	cmd.AddCommand(
+		federationQuarantineListCmd(),
+		federationQuarantineShowCmd(),
+		federationQuarantineSkipCmd(),
+		federationQuarantineRetryCmd(),
+	)
 	return cmd
+}
+
+type federationQuarantineView struct {
+	ProjectID   int64  `json:"project_id"`
+	ProjectUID  string `json:"project_uid"`
+	ProjectName string `json:"project_name"`
+	api.FederationQuarantineSummary
+}
+
+func federationQuarantineListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "list active federation quarantines",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			body, err := loadFederationStatus(cmd.Context())
+			if err != nil {
+				return err
+			}
+			rows := federationQuarantineViews(body)
+			if flags.Quiet {
+				return nil
+			}
+			switch currentOutputMode() {
+			case outputJSON:
+				return emitJSON(cmd.OutOrStdout(), struct {
+					Quarantines []federationQuarantineView `json:"quarantines"`
+				}{Quarantines: rows})
+			case outputAgent:
+				return printFederationQuarantineListAgent(cmd, rows)
+			default:
+				return printFederationQuarantineList(cmd, rows)
+			}
+		},
+	}
+}
+
+func federationQuarantineShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <id>",
+		Short: "show one active federation quarantine",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := parseFederationQuarantineID(args[0])
+			if err != nil {
+				return err
+			}
+			body, err := loadFederationStatus(cmd.Context())
+			if err != nil {
+				return err
+			}
+			row, err := federationQuarantineViewByID(body, id)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			switch currentOutputMode() {
+			case outputJSON:
+				return emitJSON(cmd.OutOrStdout(), row)
+			case outputAgent:
+				return printFederationQuarantineShowAgent(cmd, row)
+			default:
+				return printFederationQuarantineShow(cmd, row)
+			}
+		},
+	}
+}
+
+func parseFederationQuarantineID(raw string) (int64, error) {
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, &cliError{
+			Message:  "quarantine id must be a positive integer",
+			Kind:     kindValidation,
+			ExitCode: ExitValidation,
+		}
+	}
+	return id, nil
+}
+
+func loadFederationStatus(ctx context.Context) (api.FederationStatusBody, error) {
+	baseURL, err := ensureDaemon(ctx)
+	if err != nil {
+		return api.FederationStatusBody{}, err
+	}
+	client, err := httpClientFor(ctx, baseURL)
+	if err != nil {
+		return api.FederationStatusBody{}, err
+	}
+	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status", nil)
+	if err != nil {
+		return api.FederationStatusBody{}, err
+	}
+	if status >= 400 {
+		return api.FederationStatusBody{}, apiErrFromBody(status, bs)
+	}
+	var body api.FederationStatusBody
+	if err := json.Unmarshal(bs, &body); err != nil {
+		return api.FederationStatusBody{}, err
+	}
+	return body, nil
+}
+
+func federationQuarantineViews(body api.FederationStatusBody) []federationQuarantineView {
+	rows := make([]federationQuarantineView, 0)
+	for _, status := range body.Statuses {
+		if flags.Project != "" && status.ProjectName != flags.Project {
+			continue
+		}
+		for _, quarantine := range status.ActiveQuarantines {
+			rows = append(rows, federationQuarantineView{
+				ProjectID:                   status.ProjectID,
+				ProjectUID:                  status.ProjectUID,
+				ProjectName:                 status.ProjectName,
+				FederationQuarantineSummary: quarantine,
+			})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].ProjectName != rows[j].ProjectName {
+			return rows[i].ProjectName < rows[j].ProjectName
+		}
+		return rows[i].ID < rows[j].ID
+	})
+	return rows
+}
+
+func federationQuarantineViewByID(body api.FederationStatusBody, id int64) (federationQuarantineView, error) {
+	for _, row := range federationQuarantineViews(body) {
+		if row.ID == id {
+			return row, nil
+		}
+	}
+	return federationQuarantineView{}, &cliError{
+		Message:  fmt.Sprintf("federation quarantine %d not found", id),
+		Code:     "federation_quarantine_not_found",
+		Kind:     kindNotFound,
+		ExitCode: ExitNotFound,
+	}
+}
+
+func printFederationQuarantineList(cmd *cobra.Command, rows []federationQuarantineView) error {
+	if len(rows) == 0 {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "no active federation quarantines")
+		return err
+	}
+	for _, row := range rows {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"%s: quarantine #%d %s events %d-%d (%d events) at %s (%s)\n",
+			textsafe.Line(row.ProjectName),
+			row.ID,
+			textsafe.Line(row.Direction),
+			row.FirstEventID,
+			row.LastEventID,
+			len(row.EventUIDs),
+			row.CreatedAt.UTC().Format(time.RFC3339),
+			textsafe.Line(row.Error)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printFederationQuarantineListAgent(cmd *cobra.Command, rows []federationQuarantineView) error {
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "OK federation-quarantine-list count=%d\n", len(rows)); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := writeAgentKVRow(cmd.OutOrStdout(),
+			agentRowField("project", row.ProjectName),
+			agentRowField("project_id", strconv.FormatInt(row.ProjectID, 10)),
+			agentRowField("quarantine_id", strconv.FormatInt(row.ID, 10)),
+			agentRowField("direction", row.Direction),
+			agentRowField("first_event", strconv.FormatInt(row.FirstEventID, 10)),
+			agentRowField("last_event", strconv.FormatInt(row.LastEventID, 10)),
+			agentRowField("event_count", strconv.Itoa(len(row.EventUIDs))),
+			agentRowField("created_at", row.CreatedAt.UTC().Format(time.RFC3339)),
+			agentRowField("error", row.Error),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printFederationQuarantineShow(cmd *cobra.Command, row federationQuarantineView) error {
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s\nquarantine #%d\n", textsafe.Line(row.ProjectName), row.ID); err != nil {
+		return err
+	}
+	lines := []string{
+		"direction: " + textsafe.Line(row.Direction),
+		fmt.Sprintf("events: %d-%d (%d events)", row.FirstEventID, row.LastEventID, len(row.EventUIDs)),
+		"created at: " + row.CreatedAt.UTC().Format(time.RFC3339),
+		"error: " + textsafe.Line(row.Error),
+	}
+	for _, line := range lines {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", line); err != nil {
+			return err
+		}
+	}
+	for _, uid := range row.EventUIDs {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  event uid: %s\n", textsafe.Line(uid)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printFederationQuarantineShowAgent(cmd *cobra.Command, row federationQuarantineView) error {
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "OK federation-quarantine-show quarantine_id=%d\n", row.ID); err != nil {
+		return err
+	}
+	if err := writeAgentKVRow(cmd.OutOrStdout(),
+		agentRowField("project", row.ProjectName),
+		agentRowField("project_id", strconv.FormatInt(row.ProjectID, 10)),
+		agentRowField("direction", row.Direction),
+		agentRowField("first_event", strconv.FormatInt(row.FirstEventID, 10)),
+		agentRowField("last_event", strconv.FormatInt(row.LastEventID, 10)),
+		agentRowField("event_count", strconv.Itoa(len(row.EventUIDs))),
+		agentRowField("created_at", row.CreatedAt.UTC().Format(time.RFC3339)),
+		agentRowField("error", row.Error),
+	); err != nil {
+		return err
+	}
+	for _, uid := range row.EventUIDs {
+		if err := writeAgentKVRow(cmd.OutOrStdout(), agentRowField("event_uid", uid)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func federationQuarantineSkipCmd() *cobra.Command {
@@ -1492,13 +1730,9 @@ func federationQuarantineSkipCmd() *cobra.Command {
 		Short: "skip a quarantined federation batch",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := strconv.ParseInt(args[0], 10, 64)
-			if err != nil || id <= 0 {
-				return &cliError{
-					Message:  "quarantine id must be a positive integer",
-					Kind:     kindValidation,
-					ExitCode: ExitValidation,
-				}
+			id, err := parseFederationQuarantineID(args[0])
+			if err != nil {
+				return err
 			}
 			expected := fmt.Sprintf("SKIP FEDERATION BATCH %d", id)
 			confirm, err := resolveConfirm(cmd, confirm, expected,
@@ -1521,16 +1755,14 @@ func federationQuarantineRetryCmd() *cobra.Command {
 		Use:   "retry <id>",
 		Short: "release a quarantined federation push batch for retry",
 		Long: "Release a quarantined push batch without advancing the push cursor.\n" +
-			"The same local events remain pending and are sent again on the next sync.",
+			"The same local events remain pending and are sent again on the next sync.\n" +
+			"Inspect active batches first with `kata federation quarantine list` and " +
+			"`kata federation quarantine show <id>`.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := strconv.ParseInt(args[0], 10, 64)
-			if err != nil || id <= 0 {
-				return &cliError{
-					Message:  "quarantine id must be a positive integer",
-					Kind:     kindValidation,
-					ExitCode: ExitValidation,
-				}
+			id, err := parseFederationQuarantineID(args[0])
+			if err != nil {
+				return err
 			}
 			expected := fmt.Sprintf("RETRY FEDERATION BATCH %d", id)
 			confirm, err := resolveConfirm(cmd, confirm, expected,
@@ -1657,19 +1889,11 @@ func runFederationQuarantineRetry(ctx context.Context, cmd *cobra.Command, id in
 }
 
 func federationProjectForQuarantine(body api.FederationStatusBody, id int64) (int64, error) {
-	for _, status := range body.Statuses {
-		for _, quarantine := range status.ActiveQuarantines {
-			if quarantine.ID == id {
-				return status.ProjectID, nil
-			}
-		}
+	row, err := federationQuarantineViewByID(body, id)
+	if err != nil {
+		return 0, err
 	}
-	return 0, &cliError{
-		Message:  fmt.Sprintf("federation quarantine %d not found", id),
-		Code:     "federation_quarantine_not_found",
-		Kind:     kindNotFound,
-		ExitCode: ExitNotFound,
-	}
+	return row.ProjectID, nil
 }
 
 func printFederationStatus(cmd *cobra.Command, body api.FederationStatusBody) error {

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -101,6 +101,80 @@ func TestFederationStatusTextOutputIncludesOperatorFields(t *testing.T) {
 	}
 }
 
+func TestFederationQuarantineListHumanAndShow(t *testing.T) {
+	env, project := setupFederationStatusCLIState(t)
+	q, err := env.DB.ActiveFederationQuarantine(
+		context.Background(), project.ID, db.FederationQuarantineDirectionPush)
+	require.NoError(t, err)
+
+	list := requireCmdOutput(t, env, "federation", "quarantine", "list")
+	assert.Contains(t, list, "spoke-cli")
+	assert.Contains(t, list, fmt.Sprintf("quarantine #%d", q.ID))
+	assert.Contains(t, list, "push events 3-5")
+	assert.Contains(t, list, "3 events")
+	assert.Contains(t, list, "2026-05-23T12:08:00Z")
+	assert.Contains(t, list, "hub rejected batch")
+
+	show := requireCmdOutput(t, env, "federation", "quarantine", "show", strconv.FormatInt(q.ID, 10))
+	assert.Contains(t, show, "spoke-cli")
+	assert.Contains(t, show, fmt.Sprintf("quarantine #%d", q.ID))
+	for _, uid := range []string{"evt-3", "evt-4", "evt-5"} {
+		assert.Contains(t, show, uid)
+	}
+}
+
+func TestFederationQuarantineListAgentAndJSON(t *testing.T) {
+	env, project := setupFederationStatusCLIState(t)
+	q, err := env.DB.ActiveFederationQuarantine(
+		context.Background(), project.ID, db.FederationQuarantineDirectionPush)
+	require.NoError(t, err)
+
+	agent := requireCmdOutput(t, env, "--agent", "federation", "quarantine", "list")
+	assert.Contains(t, agent, "OK federation-quarantine-list count=1")
+	assert.Contains(t, agent,
+		fmt.Sprintf("project=spoke-cli project_id=%d quarantine_id=%d direction=push first_event=3 last_event=5 event_count=3", project.ID, q.ID))
+	assert.Contains(t, agent, "error=\"hub rejected batch\"")
+
+	showAgent := requireCmdOutput(t, env, "--agent", "federation", "quarantine", "show", strconv.FormatInt(q.ID, 10))
+	assert.Contains(t, showAgent, fmt.Sprintf("OK federation-quarantine-show quarantine_id=%d", q.ID))
+	assert.Contains(t, showAgent, "event_uid=evt-3")
+	assert.Contains(t, showAgent, "event_uid=evt-4")
+	assert.Contains(t, showAgent, "event_uid=evt-5")
+
+	jsonOut := requireCmdOutput(t, env, "--json", "federation", "quarantine", "list")
+	var got struct {
+		KataAPIVersion int `json:"kata_api_version"`
+		Quarantines    []struct {
+			ProjectID   int64    `json:"project_id"`
+			ProjectName string   `json:"project_name"`
+			ID          int64    `json:"id"`
+			EventUIDs   []string `json:"event_uids"`
+			Error       string   `json:"error"`
+		} `json:"quarantines"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(jsonOut), &got))
+	assert.Equal(t, 1, got.KataAPIVersion)
+	require.Len(t, got.Quarantines, 1)
+	assert.Equal(t, project.ID, got.Quarantines[0].ProjectID)
+	assert.Equal(t, "spoke-cli", got.Quarantines[0].ProjectName)
+	assert.Equal(t, q.ID, got.Quarantines[0].ID)
+	assert.Equal(t, []string{"evt-3", "evt-4", "evt-5"}, got.Quarantines[0].EventUIDs)
+	assert.Equal(t, "hub rejected batch", got.Quarantines[0].Error)
+}
+
+func TestFederationQuarantineListEmptyAndShowMissing(t *testing.T) {
+	env := testenv.New(t)
+
+	human := requireCmdOutput(t, env, "federation", "quarantine", "list")
+	assert.Contains(t, human, "no active federation quarantines")
+	agent := requireCmdOutput(t, env, "--agent", "federation", "quarantine", "list")
+	assert.Equal(t, "OK federation-quarantine-list count=0\n", agent)
+
+	_, err := runCmdOutput(t, env, "federation", "quarantine", "show", "99")
+	ce := requireCLIError(t, err, ExitNotFound)
+	assert.Equal(t, "federation_quarantine_not_found", ce.Code)
+}
+
 func TestFederationStatusIncludesRecentClaimViolations(t *testing.T) {
 	env, _, pid, ref := setupFederatedHubIssue(t, "status violation")
 	ctx := context.Background()

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -737,7 +737,9 @@ func TestFederationEnrollCLICreatesMissingProjectFromProjectFlag(t *testing.T) {
 }
 
 func TestFederationEnrollHTTPClientRequiresExplicitAllowInsecureForPlaintextHostname(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
 	t.Setenv("KATA_AUTH_TOKEN", "hub-token")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
 
 	client, err := federationEnrollHTTPClient(context.Background(), "http://hub.internal:7787", false)
 
@@ -763,6 +765,7 @@ func TestFederationEnrollCLIExplicitAllowInsecurePrintsJoinFlag(t *testing.T) {
 func TestFederationEnrollCLIPlaintextBearerErrorMentionsAllowInsecure(t *testing.T) {
 	env, dir, _ := setupCLIWorkspace(t)
 	t.Setenv("KATA_AUTH_TOKEN", "hub-token")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
 
 	_, err := runCLICapture(t, env, dir,
 		"--project", "fedlab",
@@ -1803,6 +1806,8 @@ func TestFederationLeaveRevokesAfterProjectsRemoveArchive(t *testing.T) {
 // restored opt-in the bearer transport refuses --hub-token before any I/O;
 // --allow-insecure is the explicit leave-time escape hatch.
 func TestFederationLeaveAllowInsecureFlag(t *testing.T) {
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+
 	seed := func(t *testing.T, env *testenv.Env) {
 		t.Helper()
 		ctx := context.Background()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,12 +8,24 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 ## Unreleased
 
+**New features**
+
+- Added `kata federation quarantine list` and `show` so operators can inspect
+  project ownership, event ranges and UIDs, timestamps, and retained errors
+  before retrying or skipping. Federation project detail in the TUI now shows
+  the same retained quarantine errors.
+
 **Fixed**
 
 - Fixed a federation deadlock where two projects whose first pending batches
   referenced each other's new issues could both become permanently
   quarantined. Link peers now resolve eventually within the same hub
   federation group; true validation failures remain quarantined.
+- Automatically resend older push quarantines created by the former missing
+  link-peer validator after compatible hub and spoke builds are deployed,
+  without advancing the cursor. Multi-project coverage now crosses task
+  creation before and after enrollment, eager and batched sync, and both
+  project orderings.
 
 ## 0.9.0
 <small>2026-07-09</small>

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -452,6 +452,7 @@ relationship, and the enrollment recovery screen prints the actual join error
 - enrollment count on hubs
 - live and pending lease counts
 - active quarantine count and reset blocker
+- active quarantine summaries, including retained event UIDs and errors
 - unresolved lease violation count and recent violation summaries
 
 A daemon with no federation bindings returns an empty status list and prints
@@ -460,8 +461,20 @@ A daemon with no federation bindings returns an empty status list and prints
 ## Quarantine
 
 A spoke records an active quarantine when it sees a permanently poisoned push
-batch. Quarantine blocks further push and can block reset. Operators can inspect
-it with status and release it for retry after fixing the root cause:
+batch. Quarantine blocks further push and can block reset. Operators inspect
+active rows through the status-backed discovery commands before choosing a
+mutation:
+
+```bash
+kata federation quarantine list
+kata federation quarantine show <id>
+```
+
+The TUI renders retained quarantine summaries only in project detail so the
+compact binding list stays scannable. Operators must not edit SQLite to clear a
+row or move a cursor; recovery goes through the durable retry transition.
+
+After fixing a recoverable root cause, an operator can explicitly retry:
 
 ```bash
 kata federation quarantine retry <id> \
@@ -476,9 +489,13 @@ the next sync. Stale push quarantines whose stored error is the legacy
 operators use `retry` for other fixed push quarantines.
 
 Older builds may have quarantined a valid batch because a cross-project link
-peer had not reached the hub. After upgrading the hub and spoke, use `retry`,
-not `skip`. The original events are resent without advancing the cursor and
-the edge materializes when both endpoint projects reach the upgraded hub.
+peer had not reached the hub. A compatible spoke recognizes only that former
+peer-reference error shape, releases the quarantine through the same retry
+transition, and resends the original events without advancing the cursor.
+Current hubs retain a missing peer as deferred event-backed state, and the edge
+materializes when both endpoint projects arrive. Unknown-primary failures such
+as `issue.updated references unknown issue` do not match this recovery gate;
+they remain quarantined and stop push before network access.
 
 Operators can also intentionally skip a quarantined batch:
 

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -610,7 +610,11 @@ enrollment.
 
 `kata federation status` reports local bindings, enabled/push state, cursors,
 pending push depth, sync timestamps, enrollment counts, lease counts,
-quarantine counts, reset blockers, and recent lease violations.
+quarantine counts, reset blockers, and recent lease violations. Use
+`kata federation quarantine list` to inspect every active quarantine and
+`kata federation quarantine show <id>` to see its complete retained event UID
+list and error. The TUI shows the same retained errors in a spoke row's detail
+view.
 
 ## Compatibility and rolling upgrades
 
@@ -648,7 +652,25 @@ the push cursor.
 A spoke records active quarantine when it sees a permanently poisoned push
 batch. Quarantine blocks further push and can block reset.
 
-Inspect with status and retry after fixing the root cause:
+Inspect the retained event range and error before choosing any disposition:
+
+```sh
+kata federation quarantine list
+kata federation quarantine show <id>
+```
+
+Do not edit kata's SQLite database to clear a quarantine or advance a cursor.
+Those changes bypass the retry and audit transitions and can silently strand
+events. A compatible spoke automatically releases and resends a push
+quarantine whose retained error has the exact former cross-project peer
+validation shape. Current hubs accept a missing link peer as deferred state,
+so the original batch can advance and the edge materializes after both endpoint
+projects reach the same hub federation group.
+
+Unknown primary issues are different: errors such as `issue.updated references
+unknown issue` still indicate a poisoned mutation, remain quarantined, and stop
+before another network request. Fix the root cause and explicitly retry other
+recoverable push quarantines:
 
 ```sh
 kata federation quarantine retry <id> \
@@ -661,21 +683,9 @@ cursor, so the same local events are sent again on the next sync. Retrying a
 pull quarantine returns `federation_quarantine_retry_unsupported`. A stale push
 quarantine created by older builds for `unsupported_federation_schema` is
 released automatically on sync after the spoke runs a fixed build; manual retry
-is for other fixed push-quarantine root causes.
-
-Older kata versions may have quarantined an otherwise valid batch because a
-cross-project link peer had not reached the hub. Upgrade the hub first, then
-the spoke. Release each affected push quarantine with `retry`, not `skip`:
-
-```sh
-kata federation quarantine retry <id> \
-  --confirm "RETRY FEDERATION BATCH <id>" \
-  --reason "peer links now use deferred same-hub reconciliation"
-```
-
-Retry leaves the push cursor unchanged and resends the original events. Once
-both endpoint projects reach the upgraded hub, the edge materializes
-automatically.
+is for other fixed push-quarantine root causes. Older peer-validation
+quarantines also auto-release after both hub and spoke run compatible builds;
+their retry transition preserves the cursor and resends the original events.
 
 Intentionally skip only when the operator accepts that local events will not be
 federated:
@@ -720,6 +730,9 @@ Federation has expected stale or deferred states:
 - Future-schema push skew pauses push until the hub is upgraded. Stale
   schema-skew quarantines from older spoke builds auto-release after the spoke
   is upgraded and restarted.
+- Stale peer-validation quarantines from older builds auto-release when a
+  compatible spoke syncs against a compatible hub. Unknown-primary and other
+  validation failures remain blocked for operator diagnosis.
 - Purge causes spoke re-bootstrap.
 - Enrollment creation uses normal daemon auth; the generated enrollment token
   only authorizes the spoke transport grant and is not a user daemon API token.

--- a/docs/reference/agent-output.md
+++ b/docs/reference/agent-output.md
@@ -129,6 +129,33 @@ Empty reads emit the header with `count=0` and no rows:
 OK search count=0 query="login race"
 ```
 
+#### Federation quarantine discovery
+
+`kata federation quarantine list --agent` emits one row per active quarantine:
+
+```text
+OK federation-quarantine-list count=1
+- project=spoke-project project_id=7 quarantine_id=3 direction=push first_event=41 last_event=44 event_count=4 created_at=2026-07-10T12:00:00Z error="hub rejected batch"
+```
+
+The row field order is `project`, `project_id`, `quarantine_id`, `direction`,
+`first_event`, `last_event`, `event_count`, `created_at`, and `error`. An empty
+list emits only `OK federation-quarantine-list count=0`.
+
+`kata federation quarantine show <id> --agent` emits the owning project and
+batch summary followed by one row per quarantined event UID:
+
+```text
+OK federation-quarantine-show quarantine_id=3
+- project=spoke-project project_id=7 direction=push first_event=41 last_event=44 event_count=4 created_at=2026-07-10T12:00:00Z error="hub rejected batch"
+- event_uid=01HZNQ7VFPK1XGD8R5MABCD4EA
+- event_uid=01HZNQ7VFPK1XGD8R5MABCD4EB
+```
+
+The event UID rows preserve the order recorded for the quarantined batch.
+Operators can inspect these read-only commands before invoking the separately
+confirmed `quarantine retry` or `quarantine skip` mutation.
+
 `kata search` appends a `mode=` field to its header — `lexical`, `hybrid`, or
 `semantic` — reporting the strategy actually run. When the embedding endpoint is
 configured but could not serve a query, the search falls back to lexical and a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -457,6 +457,8 @@ kata federation enrollments list
 kata federation revoke <enrollment-id>
 kata federation lease acquire <issue-ref> [--ttl 30m]
 kata federation lease release <issue-ref>
+kata federation quarantine list
+kata federation quarantine show <id>
 kata federation quarantine retry <id> --confirm "RETRY FEDERATION BATCH <id>" --reason <text>
 kata federation quarantine skip <id> --confirm "SKIP FEDERATION BATCH <id>" --reason <text>
 ```
@@ -487,6 +489,13 @@ Issue edits on push-enabled federated spokes remain local-first; use
 `kata federation lease acquire` only when you want exclusive coordination on an
 issue. A live lease held by another actor blocks non-comment mutations until it
 is released or expires.
+
+`kata federation quarantine list` reports every active quarantine with its
+project, direction, event range, creation time, and retained error. Use
+`kata federation quarantine show <id>` for the complete event UID list before
+retrying or skipping. Retry preserves the push cursor and resends the same
+events; skip advances past the range and means those events will not reach the
+hub. Do not repair quarantine state by editing SQLite directly.
 
 ## Ref forms
 

--- a/docs/superpowers/plans/2026-07-10-federation-quarantine-recovery.md
+++ b/docs/superpowers/plans/2026-07-10-federation-quarantine-recovery.md
@@ -1,0 +1,310 @@
+# Federation Quarantine Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make multi-project federation converge across pre/post-enrollment task creation and synchronization ordering, automatically resend batches quarantined by the former peer validator, and expose quarantined events before manual disposition.
+
+**Architecture:** Keep quarantine storage and HTTP schemas unchanged. Extend the spoke's existing signature-specific recovery gate, add a real-store sixteen-case lifecycle matrix, build CLI list/show projections from federation status, and render the same retained errors in TUI detail.
+
+**Tech Stack:** Go, Cobra, SQLite test stores, `httptest`, Bubble Tea/Lip Gloss rendering tests, Markdown.
+
+## Global Constraints
+
+- Never edit, rewrite, or silently skip persisted events.
+- Never advance a push cursor before hub acknowledgement.
+- Automatically recover only push quarantines with the former peer-reference error shape.
+- Keep unknown-primary and other genuine validation failures quarantined before network access.
+- Use neutral fixture names such as `spoke-project`, `peer-project`, and `daemon.example`.
+- Write and run a failing test before production behavior.
+- Add no database migration, compatibility alias, or TUI mutation.
+- Keep claims/leases, recurrences, moves, and destructive issue disposition in their focused suites.
+
+---
+
+### Task 1: Automatically resend former peer-reference quarantines
+
+**Files:**
+- Modify: `internal/federation/federation_sync_test.go`
+- Modify: `internal/federation/federation_sync.go`
+
+**Interfaces:**
+- Consumes: `db.FederationQuarantine` and `db.Storage.RetryFederationQuarantine`.
+- Produces: `autoRetryFederationQuarantine(q db.FederationQuarantine) (bool, string)`.
+
+- [ ] **Step 1: Write the failing resend regression**
+
+Add `TestSyncFederationOnceAutoRetriesFormerPeerReferenceQuarantine` beside the schema-skew recovery test. Create one pending event and an active push quarantine whose retained hub error contains:
+
+```text
+federation ingest validation: event 01HZNQ7VFPK1XGD8R5MABCD4EA references unknown issue 01HZNQ7VFPK1XGD8R5MABCD4EB
+```
+
+Use `httptest.NewServer` to acknowledge ingest and return an empty pull. Assert one request, cursor advancement to the local event, no active quarantine, and skip reason `retry: auto-retry after deferred link peer fix`.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```sh
+go test ./internal/federation -run TestSyncFederationOnceAutoRetriesFormerPeerReferenceQuarantine -count=1
+```
+
+Expected: FAIL with `federation push quarantined` and zero ingest requests.
+
+- [ ] **Step 3: Pin the unknown-primary boundary**
+
+Add `TestSyncFederationOnceUnknownPrimaryQuarantineStillStopsBeforeNetwork` using:
+
+```text
+federation ingest validation: issue.updated references unknown issue 01HZNQ7VFPK1XGD8R5MABCD4EB
+```
+
+Assert `ErrFederationPushQuarantined`, an active row, and zero network requests.
+
+- [ ] **Step 4: Implement the narrow classifier**
+
+Use a package-level regexp for the exact peer form and preserve schema-skew behavior:
+
+```go
+var formerPeerReferenceQuarantine = regexp.MustCompile(
+    `federation ingest validation: event [0-9A-HJKMNP-TV-Z]{26} references unknown issue [0-9A-HJKMNP-TV-Z]{26}`,
+)
+
+func autoRetryFederationQuarantine(q db.FederationQuarantine) (bool, string) {
+    if q.Direction != db.FederationQuarantineDirectionPush {
+        return false, ""
+    }
+    if strings.Contains(q.Error, `"code":"unsupported_federation_schema"`) {
+        return true, "auto-retry after transient schema skew"
+    }
+    if formerPeerReferenceQuarantine.MatchString(q.Error) {
+        return true, "auto-retry after deferred link peer fix"
+    }
+    return false, ""
+}
+```
+
+Call the existing retry transition with the returned reason, then continue the same sync pass.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run:
+
+```sh
+go test ./internal/federation -run 'TestSyncFederationOnce(ActiveQuarantineStopsPushBeforeNetwork|AutoRetriesLegacySchemaSkewQuarantine|AutoRetriesFormerPeerReferenceQuarantine|UnknownPrimaryQuarantineStillStopsBeforeNetwork)$' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+Commit only the sync implementation and tests with rationale explaining why deployed ingest behavior cannot see an already-quarantined batch.
+
+---
+
+### Task 2: Add the general multi-project lifecycle matrix
+
+**Files:**
+- Modify: `internal/federation/federation_sync_test.go`
+
+**Interfaces:**
+- Consumes: real local/hub test stores, adoption, portable issue mutations, link mutations, and `SyncFederationOnce`.
+- Produces: `TestFederationMultiProjectEnrollmentSyncMatrix` with sixteen named cases.
+
+- [ ] **Step 1: Enumerate the matrix**
+
+Build the Cartesian product of:
+
+```go
+type enrollmentSyncScenario struct {
+    firstTaskBeforeEnrollment bool
+    peerTaskBeforeEnrollment  bool
+    eagerSync                 bool
+    peerSyncsFirst            bool
+}
+```
+
+Assert exactly sixteen scenarios and include all dimensions in each subtest name.
+
+- [ ] **Step 2: Exercise pre/post-enrollment state paths**
+
+For each row, create `spoke-project` and `peer-project` locally plus matching enabled hub projects. Create each task before or after its project's adoption as directed. Across both tasks, write this representative portable bundle on both sides of the enrollment boundary:
+
+```go
+// Snapshot-carried or event-carried depending on the matrix row.
+title/body update
+label add
+owner assignment
+priority set
+issue metadata update
+comment
+close then reopen
+project metadata update
+```
+
+After both tasks exist, create a cross-project `blocks` edge with `CreateLinkAndEvent`. Eager rows sync after every eligible creation, enrollment, mutation bundle, and link transition. Batched rows sync only after setup. Run each round first-project-first or peer-project-first according to the row.
+
+- [ ] **Step 3: Assert full push convergence and isolation**
+
+For every row, assert both hub projections contain the expected title, body, labels, owner, priority, metadata, comment, final open status, and project metadata. Assert the edge materializes exactly once, each push cursor reaches its own local high-water mark, no active quarantine remains, and neither task appears in the wrong hub project.
+
+- [ ] **Step 4: Assert hub-to-spoke pullback**
+
+After push convergence, make a hub-authored update/comment on `spoke-project` and a distinct label/status change on `peer-project`. Run sync in the row's order and assert each local projection receives only its own changes. Assert independent pull cursors and no cross-project leakage.
+
+- [ ] **Step 5: Assert idempotence**
+
+Run another complete sync round. Reassert projection values, one edge, stable event identity, unchanged pending counts, and no quarantine.
+
+- [ ] **Step 6: Run the matrix**
+
+Run:
+
+```sh
+go test ./internal/federation -run TestFederationMultiProjectEnrollmentSyncMatrix -count=1 -timeout 60s
+```
+
+Expected: all sixteen named cases PASS. If a case fails, preserve it as the reproduction and trace that lifecycle before changing production behavior.
+
+- [ ] **Step 7: Run and commit the package**
+
+Run `go test ./internal/federation -shuffle=on -count=1`, then commit the matrix separately from Task 1.
+
+---
+
+### Task 3: Add quarantine list and show commands
+
+**Files:**
+- Modify: `cmd/kata/federation_test.go`
+- Modify: `cmd/kata/federation.go`
+- Modify: `docs/reference/agent-output.md`
+
+**Interfaces:**
+- Consumes: `GET /api/v1/federation/status` and `api.FederationQuarantineSummary`.
+- Produces: `kata federation quarantine list` and `show <id>` in human, agent, and JSON modes.
+
+- [ ] **Step 1: Write failing human-mode tests**
+
+Using `setupFederationStatusCLIState`, assert list shows project, ID, direction, event range/count, creation time, and retained error. Assert show includes the full event UID list. Add empty-list and missing-ID tests.
+
+- [ ] **Step 2: Write failing agent/JSON tests**
+
+Agent list starts with `OK federation-quarantine-list count=N` and emits fields in this order: `project`, `project_id`, `quarantine_id`, `direction`, `first_event`, `last_event`, `event_count`, `created_at`, `error`. Show emits its summary plus one `event_uid=` row per event. JSON returns project identity alongside the existing quarantine summary.
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```sh
+go test ./cmd/kata -run 'TestFederationQuarantine(List|Show)' -count=1
+```
+
+Expected: FAIL because both commands are unknown.
+
+- [ ] **Step 4: Implement discovery from status**
+
+Extract the repeated authenticated status GET/unmarshal path into `loadFederationStatus(ctx)`. Flatten active summaries with their owning project, sort by project name then ID, and render the three output modes. Reuse the same lookup for retry/skip so mutation behavior remains unchanged. Add list/show to `federationQuarantineCmd`.
+
+- [ ] **Step 5: Improve retry help and agent docs**
+
+Point retry help to list/show before mutation. Document stable agent field order and empty behavior in `docs/reference/agent-output.md`.
+
+- [ ] **Step 6: Verify GREEN and commit**
+
+Run `go test ./cmd/kata -run 'TestFederation(Quarantine|Status)' -count=1`; expected PASS. Commit CLI discovery and agent documentation together.
+
+---
+
+### Task 4: Show retained quarantine errors in TUI detail
+
+**Files:**
+- Modify: `internal/tui/federation_view_test.go`
+- Modify: `internal/tui/federation_view_render.go`
+
+**Interfaces:**
+- Consumes: `FederationProjectStatus.ActiveQuarantines`.
+- Produces: line-safe detail lines; compact list mode remains unchanged.
+
+- [ ] **Step 1: Write the failing render test**
+
+Put one `api.FederationQuarantineSummary` in `federationStatusFixture`. Assert detail contains `quarantine #7: push events 11-13` and the retained neutral error. Assert list mode does not expose the long error.
+
+- [ ] **Step 2: Verify RED**
+
+Run `go test ./internal/tui -run 'TestFederationView_.*Detail' -count=1`; expected FAIL because only the count renders.
+
+- [ ] **Step 3: Render summaries safely**
+
+After the detail count, append one line per summary using `sanitizeForLine` for direction/error and the existing UTC format. Preserve height fitting and footer behavior.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+Run `go test ./internal/tui -run TestFederationView -count=1`; expected PASS. Commit the renderer and focused test.
+
+---
+
+### Task 5: Align public documentation
+
+**Files:**
+- Modify: `docs/operations/federation.md`
+- Modify: `docs/design/federation.md`
+- Modify: `docs/reference/cli.md`
+- Modify: `docs/changelog.md`
+
+**Interfaces:**
+- Consumes: implemented behavior.
+- Produces: discoverable recovery and CLI contracts.
+
+- [ ] **Step 1: Update operations and design**
+
+State that current builds accept missing link peers, compatible deployments automatically resend batches quarantined by the former peer validator, unknown-primary poison remains blocked, and operators must not edit SQLite. Document list/show and retain the data-loss warning for skip.
+
+- [ ] **Step 2: Update CLI reference and changelog**
+
+Add list/show syntax and an Unreleased entry covering automatic recovery, the multi-project matrix, CLI discovery, and TUI detail.
+
+- [ ] **Step 3: Validate and commit**
+
+Run `make docs-check`; expected PASS. Commit the public documentation.
+
+---
+
+### Task 6: Integrated verification and issue closure
+
+**Files:**
+- Verify all modified files.
+- Update kata issue `hf3y` only after verification.
+
+**Interfaces:**
+- Consumes: all implementation commits.
+- Produces: clean repository state and evidence-backed issue closure.
+
+- [ ] **Step 1: Format and inspect**
+
+Run `gofmt -w` on all changed Go files, then `git diff --check` and `git status --short`. Expected: no whitespace errors or unrelated files.
+
+- [ ] **Step 2: Run focused verification**
+
+Run:
+
+```sh
+go test ./internal/federation ./cmd/kata ./internal/tui -shuffle=on -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repository verification**
+
+Run `make test-short`, `make lint`, and `make docs-check`. Expected: PASS.
+
+- [ ] **Step 4: Commit any remaining intended formatting**
+
+Create a normal commit only if formatting changed intended files. Never amend, squash, or bypass hooks.
+
+- [ ] **Step 5: Close the issue**
+
+Close `hf3y` with the final implementation SHA and typed test evidence only after every required check passes.
+
+- [ ] **Step 6: Report handoff**
+
+Report behavior, matrix dimensions, commands, TUI detail, checks, commits, and issue closure. Do not claim the user's live quarantine drained until a newly built binary has been deployed and observed against that database.

--- a/docs/superpowers/specs/2026-07-10-federation-quarantine-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-10-federation-quarantine-recovery-design.md
@@ -1,0 +1,163 @@
+# Federation Quarantine Recovery Design
+
+## Problem
+
+Federation accepts unresolved cross-project link peers on current builds, but a
+push batch rejected by the former validator remains blocked by its durable
+quarantine row. The spoke checks active quarantine before making a network
+request, so deploying the corrected hub and spoke does not give the corrected
+ingest path another chance to accept the batch. Operators are left with a
+generic TUI error and mutation commands whose command group cannot enumerate
+the quarantine IDs they require.
+
+This creates two separate obligations:
+
+1. New cross-project work must converge across task-creation, enrollment, and
+   synchronization ordering without entering quarantine.
+2. A push quarantine produced by the former missing-link-peer validation must
+   release automatically after compatible behavior is deployed.
+
+No operator should edit SQLite to recover either case.
+
+## Behavioral Contract
+
+An unresolved link peer remains eventual-consistency state. The hub accepts the
+event, advances the spoke push cursor, and retains the event as the durable
+source for group reconciliation. The edge stays absent until both endpoint
+projects are enrolled through the same normalized hub origin, then materializes
+regardless of arrival order.
+
+Before blocking on an active push quarantine, the spoke recognizes the former
+peer-reference validation shape:
+
+```text
+federation ingest validation: event <event-uid> references unknown issue <issue-uid>
+```
+
+That shape identifies an unknown peer reference. The old validator used a
+different message for an unknown primary issue, such as:
+
+```text
+federation ingest validation: issue.updated references unknown issue <issue-uid>
+```
+
+Only the peer-reference shape is released automatically. The release uses the
+existing retry state transition, does not advance the push cursor, and resends
+the original local events during the same sync pass. Schema-skew recovery keeps
+its existing behavior. Unknown-primary mutations, malformed payloads, actor
+violations, hash conflicts, unsupported events, and other poisoned batches stay
+quarantined without a network request.
+
+If the hub has not yet received compatible behavior, it can reject the resent
+batch and the spoke records quarantine again. Once both sides are compatible,
+the same events drain through normal ingest. No schema migration, direct SQL
+repair, cursor skip, or event rewrite is introduced.
+
+## Lifecycle Matrix
+
+The regression suite must exercise the lifecycle above the storage validator.
+It uses two neutral projects, `spoke-project` and `peer-project`, real local and
+hub stores, real issue/link mutations, enrollment/adoption behavior, and normal
+federation sync calls.
+
+The core matrix crosses:
+
+| Dimension | Values |
+| --- | --- |
+| First task relative to its project enrollment | before, after |
+| Peer task relative to its project enrollment | before, after |
+| Synchronization schedule | eager after each eligible transition, batched after setup |
+| First synchronization order | first project then peer, peer then first project |
+
+These dimensions produce sixteen named subtests. Link creation occurs after
+both tasks exist at the enrollment stage implied by each row. Eager scenarios
+sync after task creation, enrollment, and link creation whenever a binding is
+eligible; batched scenarios defer synchronization until all scheduled local
+mutations and enrollments are complete.
+
+Every subtest must prove behavior, not only final storage shape:
+
+- both issues reach the hub;
+- both spoke push cursors drain to their local high-water marks;
+- neither project retains an active quarantine;
+- the cross-project edge materializes after both endpoint projects arrive; and
+- additional sync passes are idempotent.
+
+The focused recovery regression separately seeds a quarantine with the former
+peer-reference error, runs one sync against a compatible ingest endpoint, and
+proves that the quarantine resolves and the cursor advances. A companion test
+seeds an unknown-primary quarantine and proves that it remains active without a
+network request.
+
+## Operator Discovery
+
+The quarantine command group gains read-only discovery commands backed by the
+existing federation status response. No database or HTTP schema change is
+required.
+
+### `kata federation quarantine list`
+
+List every active quarantine visible on the selected daemon. Human output shows
+the project, quarantine ID, direction, event range, event count, creation time,
+and retained error. Agent output emits one stable key/value row per quarantine.
+JSON output returns a stable envelope containing the project identity alongside
+the existing quarantine summary.
+
+An empty result succeeds and says that no active quarantines exist. The command
+honors the normal `--daemon`, `--project`, output-mode, and quiet behavior.
+
+### `kata federation quarantine show <id>`
+
+Show one active quarantine with project identity, direction, event range, full
+event UID list, creation time, and retained error. A missing or inactive ID
+returns the existing not-found CLI error. Human and agent modes keep untrusted
+error text line-safe; JSON preserves the structured response.
+
+### Retry guidance
+
+`kata federation quarantine retry <id>` remains the supported resend action.
+Its long help points operators to `quarantine list` and `quarantine show <id>`
+before mutation. Retry continues to require its exact confirmation string and
+never advances the cursor.
+
+## TUI Behavior
+
+The federation detail view renders each active quarantine's ID, direction,
+event range, creation time, and retained error. The summary badge and count
+remain compact. The generic sync status `federation push quarantined` no longer
+hides the actionable error when the operator opens the detail view.
+
+The TUI consumes the quarantine summaries already returned by federation
+status. It does not add retry or skip mutations in this change.
+
+## Error Handling and Safety
+
+- Automatic recovery is push-only and signature-specific.
+- Automatic recovery never advances a cursor before hub acknowledgement.
+- Genuine poison retains the existing stop-before-network behavior.
+- List and show are read-only and expose only data already present in federation
+  status.
+- Error strings are sanitized in human and agent line-oriented output.
+- Event UIDs are identifiers, not event payloads; discovery does not expose task
+  bodies or comments.
+- No direct database mutation, migration, compatibility alias, dual path, or
+  hidden skip is added.
+
+## Documentation
+
+The federation operations and design guides will state that current builds do
+not quarantine missing link peers, compatible deployments automatically resend
+push batches quarantined by the former peer validator, and operators should not
+edit SQLite. They will document `quarantine list`, `quarantine show`, and the
+existing confirmed retry command for other root causes that an operator has
+actually corrected.
+
+## Out of Scope
+
+- Automatically retrying every validation quarantine.
+- Automatically skipping any event or advancing a cursor without hub
+  acknowledgement.
+- Rewriting historical event payloads.
+- Adding a quarantine schema migration or a second pending-event store.
+- Adding TUI retry/skip controls.
+- Treating a deferred peer as authorization for a later primary-issue mutation.

--- a/docs/superpowers/specs/2026-07-10-federation-quarantine-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-10-federation-quarantine-recovery-design.md
@@ -53,7 +53,7 @@ batch and the spoke records quarantine again. Once both sides are compatible,
 the same events drain through normal ingest. No schema migration, direct SQL
 repair, cursor skip, or event rewrite is introduced.
 
-## Lifecycle Matrix
+## Multi-Project Lifecycle Matrix
 
 The regression suite must exercise the lifecycle above the storage validator.
 It uses two neutral projects, `spoke-project` and `peer-project`, real local and
@@ -75,13 +75,38 @@ sync after task creation, enrollment, and link creation whenever a binding is
 eligible; batched scenarios defer synchronization until all scheduled local
 mutations and enrollments are complete.
 
+The matrix is the general portable federation contract, not only a link
+regression. Each task carries a representative state bundle. State written
+before enrollment must survive adoption snapshots; state written after
+enrollment must arrive as ordinary portable events. Across the rows, the bundle
+covers:
+
+- issue title and body updates;
+- labels, owner, priority, and issue metadata;
+- comments and open/closed/reopened status;
+- project metadata;
+- a cross-project `blocks` edge;
+- hub-to-spoke updates after the initial push converges; and
+- project isolation, independent cursors, and idempotent repeat sync.
+
 Every subtest must prove behavior, not only final storage shape:
 
 - both issues reach the hub;
+- the complete portable issue and project state matches on the hub regardless
+  of whether it traveled through an adoption snapshot or ordinary events;
 - both spoke push cursors drain to their local high-water marks;
 - neither project retains an active quarantine;
 - the cross-project edge materializes after both endpoint projects arrive; and
+- hub-authored follow-up mutations pull into the correct local project without
+  leaking into its peer;
+- each project's pull and push cursors advance independently; and
 - additional sync passes are idempotent.
+
+Claims and leases, recurrence expansion, issue moves, and destructive issue
+disposition are not folded into this matrix. They have distinct authorization
+or lifecycle contracts and retain their focused suites; combining them here
+would obscure whether a failure came from enrollment ordering or from those
+separate protocols.
 
 The focused recovery regression separately seeds a quarantine with the former
 peer-reference error, runs one sync against a compatible ingest endpoint, and

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -821,7 +821,7 @@ func (d *Store) enableProjectFederation(ctx context.Context, projectID int64, ac
 			if err != nil {
 				return db.FederationBinding{}, err
 			}
-			if err := reconcileFederatedLinkGroup(ctx, tx, groupProjectIDs, groupProjectIDs, 0, nil); err != nil {
+			if err := reconcileFederatedLinkGroup(ctx, tx, groupProjectIDs, groupProjectIDs, false, 0, nil); err != nil {
 				return db.FederationBinding{}, err
 			}
 		}
@@ -1888,7 +1888,7 @@ func reconcileFederatedLinks(
 	if err != nil {
 		return err
 	}
-	return reconcileFederatedLinkGroup(ctx, tx, projectIDs, projectIDs, currentProjectID, currentIssueIDs)
+	return reconcileFederatedLinkGroup(ctx, tx, projectIDs, projectIDs, false, currentProjectID, currentIssueIDs)
 }
 
 func reconcileFederatedLinkGroup(
@@ -1896,6 +1896,7 @@ func reconcileFederatedLinkGroup(
 	tx *sql.Tx,
 	desiredProjectIDs []int64,
 	ownedProjectIDs []int64,
+	includeBoundaryLinks bool,
 	currentProjectID int64,
 	currentIssueIDs map[string]int64,
 ) error {
@@ -1907,7 +1908,7 @@ func reconcileFederatedLinkGroup(
 	if err != nil {
 		return err
 	}
-	existing, err := federatedLinkRows(ctx, tx, ownedProjectIDs)
+	existing, err := federatedLinkRows(ctx, tx, ownedProjectIDs, includeBoundaryLinks)
 	if err != nil {
 		return err
 	}
@@ -2049,7 +2050,7 @@ func reconcileFederationBindingTransitionLinks(
 			return err
 		}
 		if err := reconcileFederatedLinkGroup(
-			ctx, tx, remainingProjectIDs, remainingProjectIDs, 0, nil,
+			ctx, tx, remainingProjectIDs, remainingProjectIDs, true, 0, nil,
 		); err != nil {
 			return err
 		}
@@ -2061,7 +2062,7 @@ func reconcileFederationBindingTransitionLinks(
 	if err != nil {
 		return err
 	}
-	return reconcileFederatedLinkGroup(ctx, tx, currentProjectIDs, currentProjectIDs, 0, nil)
+	return reconcileFederatedLinkGroup(ctx, tx, currentProjectIDs, currentProjectIDs, false, 0, nil)
 }
 
 func normalizedFederationHubOrigin(raw string) (string, error) {
@@ -2200,10 +2201,17 @@ func federationGroupIssueIDs(
 	return out, nil
 }
 
-// federatedLinkRows returns every existing link touching a federation group.
-// Group reconciliation owns both insertion and deletion so one member cannot
-// remove an edge represented by another member's event stream.
-func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectIDs []int64) (map[db.FoldLinkKey]federatedLinkRow, error) {
+// federatedLinkRows normally returns links whose endpoints are both inside a
+// federation group. A group cannot delete a link owned by an event stream that
+// has not joined it. Binding transitions include boundary links touching the
+// remaining old group so cross-group projections are removed without deleting
+// same-project state from a detached project.
+func federatedLinkRows(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectIDs []int64,
+	includeBoundaryLinks bool,
+) (map[db.FoldLinkKey]federatedLinkRow, error) {
 	if len(projectIDs) == 0 {
 		return map[db.FoldLinkKey]federatedLinkRow{}, nil
 	}
@@ -2211,6 +2219,10 @@ func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectIDs []int64) (map
 	queryArgs := make([]any, 0, len(args)*2)
 	queryArgs = append(queryArgs, args...)
 	queryArgs = append(queryArgs, args...)
+	endpointOperator := "AND"
+	if includeBoundaryLinks {
+		endpointOperator = "OR"
+	}
 	//nolint:gosec // IN values use generated ? placeholders with separately bound integer IDs.
 	rows, err := tx.QueryContext(ctx, `
 		SELECT l.id, l.from_issue_id, l.to_issue_id, l.from_issue_uid, l.to_issue_uid, l.type, l.author
@@ -2218,7 +2230,7 @@ func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectIDs []int64) (map
 		  JOIN issues f ON f.id = l.from_issue_id
 		  JOIN issues t ON t.id = l.to_issue_id
 		 WHERE f.project_id IN (`+placeholders+`)
-		    OR t.project_id IN (`+placeholders+`)`, queryArgs...)
+		   `+endpointOperator+` t.project_id IN (`+placeholders+`)`, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("list federated links: %w", err)
 	}

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -2062,7 +2062,62 @@ func reconcileFederationBindingTransitionLinks(
 	if err != nil {
 		return err
 	}
+	if err := removeIncompatibleFederatedBoundaryLinks(ctx, tx, current.ProjectID, currentProjectIDs); err != nil {
+		return err
+	}
 	return reconcileFederatedLinkGroup(ctx, tx, currentProjectIDs, currentProjectIDs, false, 0, nil)
+}
+
+func removeIncompatibleFederatedBoundaryLinks(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectID int64,
+	compatibleProjectIDs []int64,
+) error {
+	compatible := make(map[int64]struct{}, len(compatibleProjectIDs))
+	for _, id := range compatibleProjectIDs {
+		compatible[id] = struct{}{}
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT l.id,
+		       CASE WHEN f.project_id = ? THEN t.project_id ELSE f.project_id END AS peer_project_id
+		  FROM links l
+		  JOIN issues f ON f.id = l.from_issue_id
+		  JOIN issues t ON t.id = l.to_issue_id
+		  JOIN federation_bindings peer_binding
+		    ON peer_binding.project_id = CASE
+		         WHEN f.project_id = ? THEN t.project_id ELSE f.project_id
+		       END
+		   AND peer_binding.enabled = 1
+		 WHERE f.project_id <> t.project_id
+		   AND (f.project_id = ? OR t.project_id = ?)`,
+		projectID, projectID, projectID, projectID)
+	if err != nil {
+		return fmt.Errorf("list incompatible federation boundary links: %w", err)
+	}
+	var stale []int64
+	for rows.Next() {
+		var linkID, peerProjectID int64
+		if err := rows.Scan(&linkID, &peerProjectID); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan incompatible federation boundary link: %w", err)
+		}
+		if _, ok := compatible[peerProjectID]; !ok {
+			stale = append(stale, linkID)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close incompatible federation boundary links: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate incompatible federation boundary links: %w", err)
+	}
+	for _, linkID := range stale {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM links WHERE id = ?`, linkID); err != nil {
+			return fmt.Errorf("delete incompatible federation boundary link %d: %w", linkID, err)
+		}
+	}
+	return nil
 }
 
 func normalizedFederationHubOrigin(raw string) (string, error) {

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -821,7 +821,7 @@ func (d *Store) enableProjectFederation(ctx context.Context, projectID int64, ac
 			if err != nil {
 				return db.FederationBinding{}, err
 			}
-			if err := reconcileFederatedLinkGroup(ctx, tx, groupProjectIDs, groupProjectIDs, false, 0, nil); err != nil {
+			if err := reconcileFederatedLinkGroup(ctx, tx, groupProjectIDs, groupProjectIDs, 0, nil); err != nil {
 				return db.FederationBinding{}, err
 			}
 		}
@@ -1888,7 +1888,7 @@ func reconcileFederatedLinks(
 	if err != nil {
 		return err
 	}
-	return reconcileFederatedLinkGroup(ctx, tx, projectIDs, projectIDs, false, currentProjectID, currentIssueIDs)
+	return reconcileFederatedLinkGroup(ctx, tx, projectIDs, projectIDs, currentProjectID, currentIssueIDs)
 }
 
 func reconcileFederatedLinkGroup(
@@ -1896,7 +1896,6 @@ func reconcileFederatedLinkGroup(
 	tx *sql.Tx,
 	desiredProjectIDs []int64,
 	ownedProjectIDs []int64,
-	includeBoundaryLinks bool,
 	currentProjectID int64,
 	currentIssueIDs map[string]int64,
 ) error {
@@ -1908,7 +1907,7 @@ func reconcileFederatedLinkGroup(
 	if err != nil {
 		return err
 	}
-	existing, err := federatedLinkRows(ctx, tx, ownedProjectIDs, includeBoundaryLinks)
+	existing, err := federatedLinkRows(ctx, tx, ownedProjectIDs)
 	if err != nil {
 		return err
 	}
@@ -2050,9 +2049,20 @@ func reconcileFederationBindingTransitionLinks(
 			return err
 		}
 		if err := reconcileFederatedLinkGroup(
-			ctx, tx, remainingProjectIDs, remainingProjectIDs, true, 0, nil,
+			ctx, tx, remainingProjectIDs, remainingProjectIDs, 0, nil,
 		); err != nil {
 			return err
+		}
+		stillMember := false
+		for _, projectID := range remainingProjectIDs {
+			stillMember = stillMember || projectID == previous.ProjectID
+		}
+		if !stillMember {
+			if err := removeFederatedBoundaryLinksBetweenProjectAndGroup(
+				ctx, tx, previous.ProjectID, remainingProjectIDs,
+			); err != nil {
+				return err
+			}
 		}
 	}
 	if !current.Enabled {
@@ -2065,7 +2075,38 @@ func reconcileFederationBindingTransitionLinks(
 	if err := removeIncompatibleFederatedBoundaryLinks(ctx, tx, current.ProjectID, currentProjectIDs); err != nil {
 		return err
 	}
-	return reconcileFederatedLinkGroup(ctx, tx, currentProjectIDs, currentProjectIDs, false, 0, nil)
+	return reconcileFederatedLinkGroup(ctx, tx, currentProjectIDs, currentProjectIDs, 0, nil)
+}
+
+func removeFederatedBoundaryLinksBetweenProjectAndGroup(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectID int64,
+	groupProjectIDs []int64,
+) error {
+	if len(groupProjectIDs) == 0 {
+		return nil
+	}
+	placeholders, groupArgs := projectIDPlaceholders(groupProjectIDs)
+	args := make([]any, 0, 2+len(groupArgs)*2)
+	args = append(args, projectID)
+	args = append(args, groupArgs...)
+	args = append(args, projectID)
+	args = append(args, groupArgs...)
+	//nolint:gosec // IN values use generated ? placeholders with separately bound integer IDs.
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM links
+		 WHERE id IN (
+			SELECT l.id
+			  FROM links l
+			  JOIN issues f ON f.id = l.from_issue_id
+			  JOIN issues t ON t.id = l.to_issue_id
+			 WHERE (f.project_id = ? AND t.project_id IN (`+placeholders+`))
+			    OR (t.project_id = ? AND f.project_id IN (`+placeholders+`))
+		 )`, args...); err != nil {
+		return fmt.Errorf("remove former federation group boundary links: %w", err)
+	}
+	return nil
 }
 
 func removeIncompatibleFederatedBoundaryLinks(
@@ -2256,17 +2297,11 @@ func federationGroupIssueIDs(
 	return out, nil
 }
 
-// federatedLinkRows normally returns links whose endpoints are both inside a
-// federation group. A group cannot delete a link owned by an event stream that
-// has not joined it. Binding transitions include boundary links touching the
-// remaining old group so cross-group projections are removed without deleting
-// same-project state from a detached project.
-func federatedLinkRows(
-	ctx context.Context,
-	tx *sql.Tx,
-	projectIDs []int64,
-	includeBoundaryLinks bool,
-) (map[db.FoldLinkKey]federatedLinkRow, error) {
+// federatedLinkRows returns links whose endpoints are both inside a federation
+// group. A group cannot delete a link owned by an event stream that has not
+// joined it; binding transitions remove only the departing project's former
+// group boundaries through removeFederatedBoundaryLinksBetweenProjectAndGroup.
+func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectIDs []int64) (map[db.FoldLinkKey]federatedLinkRow, error) {
 	if len(projectIDs) == 0 {
 		return map[db.FoldLinkKey]federatedLinkRow{}, nil
 	}
@@ -2274,10 +2309,6 @@ func federatedLinkRows(
 	queryArgs := make([]any, 0, len(args)*2)
 	queryArgs = append(queryArgs, args...)
 	queryArgs = append(queryArgs, args...)
-	endpointOperator := "AND"
-	if includeBoundaryLinks {
-		endpointOperator = "OR"
-	}
 	//nolint:gosec // IN values use generated ? placeholders with separately bound integer IDs.
 	rows, err := tx.QueryContext(ctx, `
 		SELECT l.id, l.from_issue_id, l.to_issue_id, l.from_issue_uid, l.to_issue_uid, l.type, l.author
@@ -2285,7 +2316,7 @@ func federatedLinkRows(
 		  JOIN issues f ON f.id = l.from_issue_id
 		  JOIN issues t ON t.id = l.to_issue_id
 		 WHERE f.project_id IN (`+placeholders+`)
-		   `+endpointOperator+` t.project_id IN (`+placeholders+`)`, queryArgs...)
+		   AND t.project_id IN (`+placeholders+`)`, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("list federated links: %w", err)
 	}

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -2231,6 +2231,66 @@ func TestFederationMembershipDestinationFirstPreservesIncomingLink(t *testing.T)
 	})
 }
 
+func TestFederationMembershipDifferentOriginsRemoveLocalBoundaryLink(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	firstProject := createProject(ctx, t, d, "spoke-project")
+	peerProject := createProject(ctx, t, d, "peer-project")
+	firstIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: firstProject.ID,
+		Title:     "first",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	peerIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: peerProject.ID,
+		Title:     "peer",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, _, err = d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
+		FromIssueID: firstIssue.ID,
+		ToIssueID:   peerIssue.ID,
+		Type:        "blocks",
+		Author:      "tester",
+	}, db.LinkEventParams{
+		EventType:    "issue.linked",
+		EventIssueID: firstIssue.ID,
+		FromShortID:  firstIssue.ShortID,
+		FromUID:      firstIssue.UID,
+		ToShortID:    peerIssue.ShortID,
+		ToUID:        peerIssue.UID,
+		Actor:        "tester",
+	})
+	require.NoError(t, err)
+
+	_, err = d.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:     firstProject.ID,
+		Role:          db.FederationRoleSpoke,
+		HubURL:        "https://hub-a.example",
+		HubProjectID:  41,
+		HubProjectUID: firstProject.UID,
+		Enabled:       true,
+	})
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 1, "first enrollment preserves link to standalone peer",
+		`SELECT count(*) FROM links WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssue.UID, peerIssue.UID)
+
+	_, err = d.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:     peerProject.ID,
+		Role:          db.FederationRoleSpoke,
+		HubURL:        "https://hub-b.example",
+		HubProjectID:  42,
+		HubProjectUID: peerProject.UID,
+		Enabled:       true,
+	})
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 0, "incompatible peer enrollment removes boundary link",
+		`SELECT count(*) FROM links WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstIssue.UID, peerIssue.UID)
+}
+
 func TestUpsertFederationBindingReconcilesChangedGroupMembership(t *testing.T) {
 	d := openTestDB(t)
 	ctx := context.Background()

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -2296,6 +2296,7 @@ func TestUpsertFederationBindingReconcilesChangedGroupMembership(t *testing.T) {
 	ctx := context.Background()
 	firstProject := createProject(ctx, t, d, "spoke-project")
 	secondProject := createProject(ctx, t, d, "peer-project")
+	standaloneProject := createProject(ctx, t, d, "standalone-project")
 	firstIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: firstProject.ID,
 		Title:     "first",
@@ -2305,6 +2306,18 @@ func TestUpsertFederationBindingReconcilesChangedGroupMembership(t *testing.T) {
 	secondIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: secondProject.ID,
 		Title:     "second",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	secondSibling, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: secondProject.ID,
+		Title:     "second sibling",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	standaloneIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: standaloneProject.ID,
+		Title:     "standalone",
 		Author:    "tester",
 	})
 	require.NoError(t, err)
@@ -2323,6 +2336,42 @@ func TestUpsertFederationBindingReconcilesChangedGroupMembership(t *testing.T) {
 		`SELECT count(*) FROM links
 		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
 		firstIssue.UID, secondIssue.UID)
+	_, _, err = d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
+		FromIssueID: firstIssue.ID,
+		ToIssueID:   standaloneIssue.ID,
+		Type:        "related",
+		Author:      "tester",
+	}, db.LinkEventParams{
+		EventType:    "issue.linked",
+		EventIssueID: firstIssue.ID,
+		FromShortID:  firstIssue.ShortID,
+		FromUID:      firstIssue.UID,
+		ToShortID:    standaloneIssue.ShortID,
+		ToUID:        standaloneIssue.UID,
+		Actor:        "tester",
+	})
+	require.NoError(t, err)
+	_, _, err = d.CreateLinkAndEvent(ctx, db.CreateLinkParams{
+		FromIssueID: secondIssue.ID,
+		ToIssueID:   secondSibling.ID,
+		Type:        "related",
+		Author:      "tester",
+	}, db.LinkEventParams{
+		EventType:    "issue.linked",
+		EventIssueID: secondIssue.ID,
+		FromShortID:  secondIssue.ShortID,
+		FromUID:      secondIssue.UID,
+		ToShortID:    secondSibling.ShortID,
+		ToUID:        secondSibling.UID,
+		Actor:        "tester",
+	})
+	require.NoError(t, err)
+
+	_, err = d.UpsertFederationBinding(ctx, secondBinding)
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 1, "no-op upsert preserves unrelated standalone boundary",
+		`SELECT count(*) FROM links WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'related'`,
+		firstIssue.UID, standaloneIssue.UID)
 
 	secondBinding.Enabled = false
 	_, err = d.UpsertFederationBinding(ctx, secondBinding)
@@ -2331,6 +2380,12 @@ func TestUpsertFederationBindingReconcilesChangedGroupMembership(t *testing.T) {
 		`SELECT count(*) FROM links
 		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
 		firstIssue.UID, secondIssue.UID)
+	assertRowCount(ctx, t, d, 1, "disabling peer preserves unrelated standalone boundary",
+		`SELECT count(*) FROM links WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'related'`,
+		firstIssue.UID, standaloneIssue.UID)
+	assertRowCount(ctx, t, d, 1, "disabling peer preserves detached same-project link",
+		`SELECT count(*) FROM links WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'related'`,
+		secondIssue.UID, secondSibling.UID)
 
 	secondBinding.Enabled = true
 	_, err = d.UpsertFederationBinding(ctx, secondBinding)

--- a/internal/federation/federation_sync.go
+++ b/internal/federation/federation_sync.go
@@ -96,7 +96,14 @@ func SyncFederationOnceWithPulledEvents(
 	if binding.PushEnabled {
 		for {
 			if q, err := store.ActiveFederationQuarantine(ctx, binding.ProjectID, db.FederationQuarantineDirectionPush); err == nil {
-				if retry, reason := autoRetryFederationQuarantine(q); retry {
+				quarantinedEvents, eventErr := store.EventsByUIDs(ctx, binding.ProjectID, q.EventUIDs)
+				if eventErr != nil {
+					if errors.Is(eventErr, db.ErrNotFound) {
+						return recordFederationSyncError(ctx, store, binding.ProjectID, ErrFederationPushQuarantined)
+					}
+					return recordFederationSyncError(ctx, store, binding.ProjectID, eventErr)
+				}
+				if retry, reason := autoRetryFederationQuarantine(q, quarantinedEvents); retry {
 					if _, err := store.RetryFederationQuarantine(ctx, db.RetryFederationQuarantineParams{
 						ID:        q.ID,
 						ProjectID: binding.ProjectID,
@@ -495,10 +502,10 @@ func federationHubErrorCode(body string) string {
 }
 
 var formerPeerReferenceQuarantine = regexp.MustCompile(
-	`^federation ingest validation: event [0-9A-HJKMNP-TV-Z]{26} references unknown issue [0-9A-HJKMNP-TV-Z]{26}$`,
+	`^federation ingest validation: event ([0-9A-HJKMNP-TV-Z]{26}) references unknown issue ([0-9A-HJKMNP-TV-Z]{26})$`,
 )
 
-func autoRetryFederationQuarantine(q db.FederationQuarantine) (bool, string) {
+func autoRetryFederationQuarantine(q db.FederationQuarantine, events []db.Event) (bool, string) {
 	if q.Direction != db.FederationQuarantineDirectionPush {
 		return false, ""
 	}
@@ -506,10 +513,111 @@ func autoRetryFederationQuarantine(q db.FederationQuarantine) (bool, string) {
 		return true, "auto-retry after transient schema skew"
 	}
 	hubError, ok := federationQuarantineHubError(q.Error)
-	if ok && hubError.Code == "validation" && formerPeerReferenceQuarantine.MatchString(hubError.Message) {
-		return true, "auto-retry after deferred link peer fix"
+	if !ok || hubError.Code != "validation" {
+		return false, ""
+	}
+	match := formerPeerReferenceQuarantine.FindStringSubmatch(hubError.Message)
+	if len(match) != 3 {
+		return false, ""
+	}
+	for _, event := range events {
+		if event.UID == match[1] && federationQuarantineEventDefersLinkPeer(event, match[2]) {
+			return true, "auto-retry after deferred link peer fix"
+		}
 	}
 	return false, ""
+}
+
+func federationQuarantineEventDefersLinkPeer(event db.Event, peerUID string) bool {
+	if event.IssueUID == nil || *event.IssueUID == "" || *event.IssueUID == peerUID {
+		return false
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(event.Payload), &payload); err != nil {
+		return false
+	}
+	supportedType := func(linkType string) bool {
+		return linkType == "parent" || linkType == "blocks" || linkType == "related"
+	}
+	switch event.Type {
+	case "issue.created", "issue.snapshot":
+		var links []struct {
+			Type       string `json:"type"`
+			ToIssueUID string `json:"to_issue_uid"`
+			Incoming   bool   `json:"incoming"`
+		}
+		if err := json.Unmarshal(payload["links"], &links); err != nil {
+			return false
+		}
+		for _, link := range links {
+			if supportedType(link.Type) && link.ToIssueUID == peerUID &&
+				(event.Type != "issue.created" || link.Type != "parent" || !link.Incoming) {
+				return true
+			}
+		}
+	case "issue.linked", "issue.unlinked":
+		fromUID, fromOK := federationQuarantinePayloadString(payload, "from_uid", "from_issue_uid")
+		toUID, toOK := federationQuarantinePayloadString(payload, "to_uid", "to_issue_uid")
+		linkType, typeOK := db.StringValue(payload["type"])
+		if !fromOK || !toOK || !typeOK || !supportedType(linkType) {
+			return false
+		}
+		var eventPeer string
+		switch *event.IssueUID {
+		case fromUID:
+			eventPeer = toUID
+		case toUID:
+			eventPeer = fromUID
+		default:
+			return false
+		}
+		if eventPeer != peerUID || (event.RelatedIssueUID != nil && *event.RelatedIssueUID != peerUID) {
+			return false
+		}
+		if event.Type == "issue.unlinked" && (linkType == "parent" || linkType == "blocks") {
+			linkFromUID, linkFromOK := db.StringValue(payload["link_from_uid"])
+			linkToUID, linkToOK := db.StringValue(payload["link_to_uid"])
+			matchesEndpoints := (linkFromUID == fromUID && linkToUID == toUID) ||
+				(linkFromUID == toUID && linkToUID == fromUID)
+			if !linkFromOK || !linkToOK || !matchesEndpoints {
+				return false
+			}
+		}
+		return true
+	case "issue.links_changed":
+		found := false
+		for _, key := range []string{"parent_set_uid", "parent_removed_uid"} {
+			if value, ok := db.StringValue(payload[key]); ok && value == peerUID {
+				found = true
+			}
+		}
+		for _, key := range []string{
+			"blocks_added_uids", "blocks_removed_uids",
+			"blocked_by_added_uids", "blocked_by_removed_uids",
+			"related_added_uids", "related_removed_uids",
+		} {
+			if raw, ok := payload[key]; ok {
+				var uids []string
+				if err := json.Unmarshal(raw, &uids); err != nil {
+					return false
+				}
+				for _, uid := range uids {
+					found = found || uid == peerUID
+				}
+			}
+		}
+		return found && (event.RelatedIssueUID == nil || *event.RelatedIssueUID == peerUID)
+	}
+	return false
+}
+
+func federationQuarantinePayloadString(payload map[string]json.RawMessage, keys ...string) (string, bool) {
+	for _, key := range keys {
+		if value, ok := db.StringValue(payload[key]); ok {
+			return value, true
+		}
+	}
+	return "", false
 }
 
 func federationQuarantineHubError(raw string) (api.ErrorBody, bool) {

--- a/internal/federation/federation_sync.go
+++ b/internal/federation/federation_sync.go
@@ -495,7 +495,7 @@ func federationHubErrorCode(body string) string {
 }
 
 var formerPeerReferenceQuarantine = regexp.MustCompile(
-	`federation ingest validation: event [0-9A-HJKMNP-TV-Z]{26} references unknown issue [0-9A-HJKMNP-TV-Z]{26}`,
+	`^federation ingest validation: event [0-9A-HJKMNP-TV-Z]{26} references unknown issue [0-9A-HJKMNP-TV-Z]{26}$`,
 )
 
 func autoRetryFederationQuarantine(q db.FederationQuarantine) (bool, string) {
@@ -505,10 +505,23 @@ func autoRetryFederationQuarantine(q db.FederationQuarantine) (bool, string) {
 	if strings.Contains(q.Error, `"code":"unsupported_federation_schema"`) {
 		return true, "auto-retry after transient schema skew"
 	}
-	if formerPeerReferenceQuarantine.MatchString(q.Error) {
+	hubError, ok := federationQuarantineHubError(q.Error)
+	if ok && hubError.Code == "validation" && formerPeerReferenceQuarantine.MatchString(hubError.Message) {
 		return true, "auto-retry after deferred link peer fix"
 	}
 	return false, ""
+}
+
+func federationQuarantineHubError(raw string) (api.ErrorBody, bool) {
+	start := strings.IndexByte(raw, '{')
+	if start < 0 {
+		return api.ErrorBody{}, false
+	}
+	var envelope api.ErrorEnvelope
+	if err := json.Unmarshal([]byte(raw[start:]), &envelope); err != nil {
+		return api.ErrorBody{}, false
+	}
+	return envelope.Error, true
 }
 
 func recordFederationPushQuarantine(

--- a/internal/federation/federation_sync.go
+++ b/internal/federation/federation_sync.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -95,12 +96,12 @@ func SyncFederationOnceWithPulledEvents(
 	if binding.PushEnabled {
 		for {
 			if q, err := store.ActiveFederationQuarantine(ctx, binding.ProjectID, db.FederationQuarantineDirectionPush); err == nil {
-				if autoRetryLegacySchemaSkewQuarantine(q) {
+				if retry, reason := autoRetryFederationQuarantine(q); retry {
 					if _, err := store.RetryFederationQuarantine(ctx, db.RetryFederationQuarantineParams{
 						ID:        q.ID,
 						ProjectID: binding.ProjectID,
 						Actor:     binding.Actor,
-						Reason:    "auto-retry after transient schema skew",
+						Reason:    reason,
 						Now:       time.Now().UTC(),
 					}); err != nil {
 						return recordFederationSyncError(ctx, store, binding.ProjectID, err)
@@ -493,9 +494,21 @@ func federationHubErrorCode(body string) string {
 	return envelope.Error.Code
 }
 
-func autoRetryLegacySchemaSkewQuarantine(q db.FederationQuarantine) bool {
-	return q.Direction == db.FederationQuarantineDirectionPush &&
-		strings.Contains(q.Error, `"code":"unsupported_federation_schema"`)
+var formerPeerReferenceQuarantine = regexp.MustCompile(
+	`federation ingest validation: event [0-9A-HJKMNP-TV-Z]{26} references unknown issue [0-9A-HJKMNP-TV-Z]{26}`,
+)
+
+func autoRetryFederationQuarantine(q db.FederationQuarantine) (bool, string) {
+	if q.Direction != db.FederationQuarantineDirectionPush {
+		return false, ""
+	}
+	if strings.Contains(q.Error, `"code":"unsupported_federation_schema"`) {
+		return true, "auto-retry after transient schema skew"
+	}
+	if formerPeerReferenceQuarantine.MatchString(q.Error) {
+		return true, "auto-retry after deferred link peer fix"
+	}
+	return false, ""
 }
 
 func recordFederationPushQuarantine(

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -972,6 +972,34 @@ func TestSyncFederationOnceAutoRetriesFormerPeerReferenceQuarantine(t *testing.T
 	assert.Equal(t, "retry: auto-retry after deferred link peer fix", skipReason)
 }
 
+func TestAutoRetryFederationQuarantineRequiresExactFormerPeerMessage(t *testing.T) {
+	legacyMessage := "federation ingest validation: event " +
+		"01HZNQ7VFPK1XGD8R5MABCD4EA references unknown issue " +
+		"01HZNQ7VFPK1XGD8R5MABCD4EB"
+	for _, message := range []string{
+		"additional validation: " + legacyMessage,
+		legacyMessage + "; primary issue also missing",
+	} {
+		body, err := json.Marshal(api.ErrorEnvelope{
+			Status: http.StatusBadRequest,
+			Error: api.ErrorBody{
+				Code:    "validation",
+				Message: message,
+			},
+		})
+		require.NoError(t, err)
+
+		retry, reason := autoRetryFederationQuarantine(db.FederationQuarantine{
+			Direction: db.FederationQuarantineDirectionPush,
+			Error: "hub /api/v1/projects/42/federation/events:ingest returned 400: " +
+				string(body),
+		})
+
+		assert.False(t, retry)
+		assert.Empty(t, reason)
+	}
+}
+
 func TestSyncFederationOnceUnknownPrimaryQuarantineStillStopsBeforeNetwork(t *testing.T) {
 	ctx := context.Background()
 	spoke := testenv.New(t)

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -911,21 +911,45 @@ func TestSyncFederationOnceAutoRetriesFormerPeerReferenceQuarantine(t *testing.T
 		Enabled:              true,
 	})
 	require.NoError(t, err)
-	_, localEvent, err := spoke.DB.CreateIssue(ctx, db.CreateIssueParams{
+	localIssue, localEvent, err := spoke.DB.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: project.ID,
 		Title:     "pending local",
 		Author:    "tester",
+	})
+	require.NoError(t, err)
+	peerProject, err := spoke.DB.CreateProject(ctx, "peer-project")
+	require.NoError(t, err)
+	peerIssue, _, err := spoke.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: peerProject.ID,
+		Title:     "pending peer",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, linkEvent, err := spoke.DB.CreateLinkAndEvent(ctx, db.CreateLinkParams{
+		FromIssueID: localIssue.ID,
+		ToIssueID:   peerIssue.ID,
+		Type:        "blocks",
+		Author:      "tester",
+	}, db.LinkEventParams{
+		EventType:    "issue.linked",
+		EventIssueID: localIssue.ID,
+		FromShortID:  localIssue.ShortID,
+		FromUID:      localIssue.UID,
+		ToShortID:    peerIssue.ShortID,
+		ToUID:        peerIssue.UID,
+		Actor:        "tester",
 	})
 	require.NoError(t, err)
 	_, err = spoke.DB.RecordFederationQuarantine(ctx, db.RecordFederationQuarantineParams{
 		ProjectID:    project.ID,
 		Direction:    db.FederationQuarantineDirectionPush,
 		FirstEventID: localEvent.ID,
-		LastEventID:  localEvent.ID,
-		EventUIDs:    []string{localEvent.UID},
+		LastEventID:  linkEvent.ID,
+		EventUIDs:    []string{localEvent.UID, linkEvent.UID},
 		Error: `hub /api/v1/projects/42/federation/events:ingest returned 400: ` +
 			`{"status":400,"error":{"code":"validation","message":` +
-			`"federation ingest validation: event 01HZNQ7VFPK1XGD8R5MABCD4EA references unknown issue 01HZNQ7VFPK1XGD8R5MABCD4EB"}}`,
+			`"federation ingest validation: event ` + linkEvent.UID +
+			` references unknown issue ` + peerIssue.UID + `"}}`,
 		CreatedAt: time.Now().UTC(),
 	})
 	require.NoError(t, err)
@@ -936,11 +960,12 @@ func TestSyncFederationOnceAutoRetriesFormerPeerReferenceQuarantine(t *testing.T
 			ingestRequests++
 			var body api.FederationIngestEventsRequestBody
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-			require.Len(t, body.Events, 1)
+			require.Len(t, body.Events, 2)
 			assert.Equal(t, localEvent.ID, body.Events[0].EventID)
+			assert.Equal(t, linkEvent.ID, body.Events[1].EventID)
 			require.NoError(t, json.NewEncoder(w).Encode(api.FederationIngestEventsBody{
-				Accepted:          1,
-				PushCursorEventID: localEvent.ID,
+				Accepted:          2,
+				PushCursorEventID: linkEvent.ID,
 			}))
 		case "/api/v1/projects/42/federation/events":
 			require.NoError(t, json.NewEncoder(w).Encode(api.PollEventsBody{NextAfterID: 49}))
@@ -960,7 +985,7 @@ func TestSyncFederationOnceAutoRetriesFormerPeerReferenceQuarantine(t *testing.T
 	assert.Equal(t, 1, ingestRequests)
 	binding, err = spoke.DB.FederationBindingByProject(ctx, project.ID)
 	require.NoError(t, err)
-	assert.Equal(t, localEvent.ID, binding.PushCursorEventID)
+	assert.Equal(t, linkEvent.ID, binding.PushCursorEventID)
 	_, err = spoke.DB.ActiveFederationQuarantine(ctx, project.ID, db.FederationQuarantineDirectionPush)
 	assert.ErrorIs(t, err, db.ErrNotFound)
 	var skipReason string
@@ -993,11 +1018,71 @@ func TestAutoRetryFederationQuarantineRequiresExactFormerPeerMessage(t *testing.
 			Direction: db.FederationQuarantineDirectionPush,
 			Error: "hub /api/v1/projects/42/federation/events:ingest returned 400: " +
 				string(body),
-		})
+		}, nil)
 
 		assert.False(t, retry)
 		assert.Empty(t, reason)
 	}
+}
+
+func TestSyncFederationOnceNonLinkSecondaryReferenceQuarantineStillStopsBeforeNetwork(t *testing.T) {
+	ctx := context.Background()
+	spoke := testenv.New(t)
+	project, err := spoke.DB.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	binding, err := spoke.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            project.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://127.0.0.1:1",
+		HubProjectID:         42,
+		HubProjectUID:        project.UID,
+		ReplayHorizonEventID: 50,
+		PullCursorEventID:    49,
+		PushEnabled:          true,
+		Actor:                "tester",
+		PushCursorEventID:    0,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	_, localEvent, err := spoke.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "pending local",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	unknownPeerUID := "01HZNQ7VFPK1XGD8R5MABCD4EB"
+	_, err = spoke.DB.ExecContext(ctx,
+		`UPDATE events SET related_issue_uid = ? WHERE id = ?`, unknownPeerUID, localEvent.ID)
+	require.NoError(t, err)
+	_, err = spoke.DB.RecordFederationQuarantine(ctx, db.RecordFederationQuarantineParams{
+		ProjectID:    project.ID,
+		Direction:    db.FederationQuarantineDirectionPush,
+		FirstEventID: localEvent.ID,
+		LastEventID:  localEvent.ID,
+		EventUIDs:    []string{localEvent.UID},
+		Error: `hub /api/v1/projects/42/federation/events:ingest returned 400: ` +
+			`{"status":400,"error":{"code":"validation","message":"federation ingest validation: event ` +
+			localEvent.UID + ` references unknown issue ` + unknownPeerUID + `"}}`,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	requests := 0
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(hub.Close)
+
+	err = SyncFederationOnce(ctx, spoke.DB, binding, config.FederationCredential{
+		HubURL:       hub.URL,
+		HubProjectID: 42,
+		Token:        "token",
+	})
+
+	require.ErrorIs(t, err, ErrFederationPushQuarantined)
+	assert.Equal(t, 0, requests)
+	_, err = spoke.DB.ActiveFederationQuarantine(ctx, project.ID, db.FederationQuarantineDirectionPush)
+	require.NoError(t, err)
 }
 
 func TestSyncFederationOnceUnknownPrimaryQuarantineStillStopsBeforeNetwork(t *testing.T) {
@@ -1273,6 +1358,9 @@ func TestFederationMultiProjectEnrollmentSyncMatrix(t *testing.T) {
 				}
 				if tc.eagerSync {
 					syncEligible()
+					if tc.peerSyncsFirst && project == peer && !first.enrolled && linked {
+						matrixAssertLinkCount(t, spoke.DB, first.issue.UID, peer.issue.UID, 1)
+					}
 				}
 			}
 			require.True(t, linked)

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -892,6 +892,142 @@ func TestSyncFederationOnceAutoRetriesLegacySchemaSkewQuarantine(t *testing.T) {
 	assert.Equal(t, "retry: auto-retry after transient schema skew", skipReason)
 }
 
+func TestSyncFederationOnceAutoRetriesFormerPeerReferenceQuarantine(t *testing.T) {
+	ctx := context.Background()
+	spoke := testenv.New(t)
+	project, err := spoke.DB.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	binding, err := spoke.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            project.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://127.0.0.1:1",
+		HubProjectID:         42,
+		HubProjectUID:        project.UID,
+		ReplayHorizonEventID: 50,
+		PullCursorEventID:    49,
+		PushEnabled:          true,
+		Actor:                "tester",
+		PushCursorEventID:    0,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	_, localEvent, err := spoke.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "pending local",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, err = spoke.DB.RecordFederationQuarantine(ctx, db.RecordFederationQuarantineParams{
+		ProjectID:    project.ID,
+		Direction:    db.FederationQuarantineDirectionPush,
+		FirstEventID: localEvent.ID,
+		LastEventID:  localEvent.ID,
+		EventUIDs:    []string{localEvent.UID},
+		Error: `hub /api/v1/projects/42/federation/events:ingest returned 400: ` +
+			`{"status":400,"error":{"code":"validation","message":` +
+			`"federation ingest validation: event 01HZNQ7VFPK1XGD8R5MABCD4EA references unknown issue 01HZNQ7VFPK1XGD8R5MABCD4EB"}}`,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	ingestRequests := 0
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects/42/federation/events:ingest":
+			ingestRequests++
+			var body api.FederationIngestEventsRequestBody
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			require.Len(t, body.Events, 1)
+			assert.Equal(t, localEvent.ID, body.Events[0].EventID)
+			require.NoError(t, json.NewEncoder(w).Encode(api.FederationIngestEventsBody{
+				Accepted:          1,
+				PushCursorEventID: localEvent.ID,
+			}))
+		case "/api/v1/projects/42/federation/events":
+			require.NoError(t, json.NewEncoder(w).Encode(api.PollEventsBody{NextAfterID: 49}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(hub.Close)
+
+	err = SyncFederationOnce(ctx, spoke.DB, binding, config.FederationCredential{
+		HubURL:       hub.URL,
+		HubProjectID: 42,
+		Token:        "token",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, ingestRequests)
+	binding, err = spoke.DB.FederationBindingByProject(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Equal(t, localEvent.ID, binding.PushCursorEventID)
+	_, err = spoke.DB.ActiveFederationQuarantine(ctx, project.ID, db.FederationQuarantineDirectionPush)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+	var skipReason string
+	require.NoError(t, spoke.DB.QueryRow(`
+		SELECT skip_reason
+		  FROM federation_quarantine
+		 WHERE project_id = ?`,
+		project.ID).Scan(&skipReason))
+	assert.Equal(t, "retry: auto-retry after deferred link peer fix", skipReason)
+}
+
+func TestSyncFederationOnceUnknownPrimaryQuarantineStillStopsBeforeNetwork(t *testing.T) {
+	ctx := context.Background()
+	spoke := testenv.New(t)
+	project, err := spoke.DB.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	binding, err := spoke.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            project.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://127.0.0.1:1",
+		HubProjectID:         42,
+		HubProjectUID:        project.UID,
+		ReplayHorizonEventID: 50,
+		PullCursorEventID:    49,
+		PushEnabled:          true,
+		Actor:                "tester",
+		PushCursorEventID:    0,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	_, localEvent, err := spoke.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "pending local",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, err = spoke.DB.RecordFederationQuarantine(ctx, db.RecordFederationQuarantineParams{
+		ProjectID:    project.ID,
+		Direction:    db.FederationQuarantineDirectionPush,
+		FirstEventID: localEvent.ID,
+		LastEventID:  localEvent.ID,
+		EventUIDs:    []string{localEvent.UID},
+		Error: `hub /api/v1/projects/42/federation/events:ingest returned 400: ` +
+			`{"status":400,"error":{"code":"validation","message":` +
+			`"federation ingest validation: issue.updated references unknown issue 01HZNQ7VFPK1XGD8R5MABCD4EB"}}`,
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	requests := 0
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(hub.Close)
+
+	err = SyncFederationOnce(ctx, spoke.DB, binding, config.FederationCredential{
+		HubURL:       hub.URL,
+		HubProjectID: 42,
+		Token:        "token",
+	})
+
+	require.ErrorIs(t, err, ErrFederationPushQuarantined)
+	assert.Equal(t, 0, requests)
+	_, err = spoke.DB.ActiveFederationQuarantine(ctx, project.ID, db.FederationQuarantineDirectionPush)
+	require.NoError(t, err)
+}
+
 func TestSyncFederationOnceAfterQuarantineRetryPushesAgain(t *testing.T) {
 	ctx := context.Background()
 	spoke := testenv.New(t)

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -1233,16 +1233,16 @@ func TestFederationMultiProjectEnrollmentSyncMatrix(t *testing.T) {
 			require.NoError(t, err)
 			firstEnrollment := matrixCreateEnrollment(t, hub, spoke, firstHub, "first-matrix-token")
 			peerEnrollment := matrixCreateEnrollment(t, hub, spoke, peerHub, "peer-matrix-token")
-			projects := []*matrixFederationProject{
-				{tag: "first", hub: firstHub, local: firstLocal,
-					credential: matrixCredential(hub.URL, firstHub.ID, firstEnrollment.Token),
-					before:     tc.firstTaskBeforeEnrollment},
-				{tag: "peer", hub: peerHub, local: peerLocal,
-					credential: matrixCredential(hub.URL, peerHub.ID, peerEnrollment.Token),
-					before:     tc.peerTaskBeforeEnrollment},
-			}
+			first := &matrixFederationProject{tag: "first", hub: firstHub, local: firstLocal,
+				credential: matrixCredential(hub.URL, firstHub.ID, firstEnrollment.Token),
+				before:     tc.firstTaskBeforeEnrollment}
+			peer := &matrixFederationProject{tag: "peer", hub: peerHub, local: peerLocal,
+				credential: matrixCredential(hub.URL, peerHub.ID, peerEnrollment.Token),
+				before:     tc.peerTaskBeforeEnrollment}
+			projects := []*matrixFederationProject{first, peer}
+			syncOrder := []*matrixFederationProject{first, peer}
 			if tc.peerSyncsFirst {
-				projects[0], projects[1] = projects[1], projects[0]
+				syncOrder[0], syncOrder[1] = syncOrder[1], syncOrder[0]
 			}
 
 			for _, project := range projects {
@@ -1251,24 +1251,24 @@ func TestFederationMultiProjectEnrollmentSyncMatrix(t *testing.T) {
 				}
 			}
 			linked := false
-			if projects[0].issue.ID != 0 && projects[1].issue.ID != 0 {
-				matrixCreateCrossProjectLink(t, spoke.DB, projects[0].issue, projects[1].issue)
+			if first.issue.ID != 0 && peer.issue.ID != 0 {
+				matrixCreateCrossProjectLink(t, spoke.DB, first.issue, peer.issue)
 				linked = true
 			}
 			syncEligible := func() {
-				for _, project := range projects {
+				for _, project := range syncOrder {
 					if project.enrolled {
 						matrixSyncProject(t, spoke.DB, project)
 					}
 				}
 			}
-			for _, project := range projects {
+			for _, project := range syncOrder {
 				matrixAdoptProject(t, hub.DB, spoke.DB, hub.URL, project)
 				if !project.before {
 					project.issue = matrixCreateInitialState(t, spoke.DB, project.local, project.tag)
 				}
-				if !linked && projects[0].issue.ID != 0 && projects[1].issue.ID != 0 {
-					matrixCreateCrossProjectLink(t, spoke.DB, projects[0].issue, projects[1].issue)
+				if !linked && first.issue.ID != 0 && peer.issue.ID != 0 {
+					matrixCreateCrossProjectLink(t, spoke.DB, first.issue, peer.issue)
 					linked = true
 				}
 				if tc.eagerSync {
@@ -1289,12 +1289,10 @@ func TestFederationMultiProjectEnrollmentSyncMatrix(t *testing.T) {
 				matrixAssertPortableState(t, hub.DB, project.hub.ID, project.issue.UID, project.tag)
 				matrixAssertPushDrained(t, spoke.DB, project.local.ID)
 			}
-			matrixAssertLinkCount(t, hub.DB, projects[0].issue.UID, projects[1].issue.UID, 1)
-			firstByTag := matrixProjectByTag(projects, "first")
-			peerByTag := matrixProjectByTag(projects, "peer")
-			matrixApplyHubFollowup(t, hub.DB, firstByTag, peerByTag)
+			matrixAssertLinkCount(t, hub.DB, first.issue.UID, peer.issue.UID, 1)
+			matrixApplyHubFollowup(t, hub.DB, first, peer)
 			syncEligible()
-			matrixAssertPulledFollowup(t, spoke.DB, firstByTag, peerByTag)
+			matrixAssertPulledFollowup(t, spoke.DB, first, peer)
 			matrixAssertPullCursors(t, hub.DB, spoke.DB, projects)
 
 			beforeRepeat, err := spoke.DB.MaxEventID(ctx)
@@ -1303,7 +1301,7 @@ func TestFederationMultiProjectEnrollmentSyncMatrix(t *testing.T) {
 			afterRepeat, err := spoke.DB.MaxEventID(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, beforeRepeat, afterRepeat)
-			matrixAssertLinkCount(t, hub.DB, projects[0].issue.UID, projects[1].issue.UID, 1)
+			matrixAssertLinkCount(t, hub.DB, first.issue.UID, peer.issue.UID, 1)
 		})
 	}
 }
@@ -3775,15 +3773,6 @@ func matrixAssertLinkCount(t *testing.T, store *sqlitestore.Store, firstUID, pee
 		 WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
 		firstUID, peerUID).Scan(&got))
 	assert.Equal(t, want, got)
-}
-
-func matrixProjectByTag(projects []*matrixFederationProject, tag string) *matrixFederationProject {
-	for _, project := range projects {
-		if project.tag == tag {
-			return project
-		}
-	}
-	panic("matrix project tag not found: " + tag)
 }
 
 func matrixApplyHubFollowup(

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -1171,6 +1171,115 @@ func TestSyncFederationOnceResetBlockedByLocalEventCreatedDuringMetadataRefresh(
 	require.NoError(t, err)
 }
 
+func TestFederationMultiProjectEnrollmentSyncMatrix(t *testing.T) {
+	type scenario struct {
+		firstTaskBeforeEnrollment bool
+		peerTaskBeforeEnrollment  bool
+		eagerSync                 bool
+		peerSyncsFirst            bool
+	}
+	var scenarios []scenario
+	for _, firstBefore := range []bool{false, true} {
+		for _, peerBefore := range []bool{false, true} {
+			for _, eager := range []bool{false, true} {
+				for _, peerFirst := range []bool{false, true} {
+					scenarios = append(scenarios, scenario{firstBefore, peerBefore, eager, peerFirst})
+				}
+			}
+		}
+	}
+	require.Len(t, scenarios, 16)
+
+	for _, tc := range scenarios {
+		name := fmt.Sprintf("first_before=%t/peer_before=%t/eager=%t/peer_first=%t",
+			tc.firstTaskBeforeEnrollment, tc.peerTaskBeforeEnrollment, tc.eagerSync, tc.peerSyncsFirst)
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			hub := testenv.New(t)
+			spoke := testenv.New(t)
+			firstHub := matrixCreateHubProject(t, hub, "spoke-project")
+			peerHub := matrixCreateHubProject(t, hub, "peer-project")
+			firstLocal, err := spoke.DB.CreateProject(ctx, firstHub.Name)
+			require.NoError(t, err)
+			peerLocal, err := spoke.DB.CreateProject(ctx, peerHub.Name)
+			require.NoError(t, err)
+			firstEnrollment := matrixCreateEnrollment(t, hub, spoke, firstHub, "first-matrix-token")
+			peerEnrollment := matrixCreateEnrollment(t, hub, spoke, peerHub, "peer-matrix-token")
+			projects := []*matrixFederationProject{
+				{tag: "first", hub: firstHub, local: firstLocal,
+					credential: matrixCredential(hub.URL, firstHub.ID, firstEnrollment.Token),
+					before:     tc.firstTaskBeforeEnrollment},
+				{tag: "peer", hub: peerHub, local: peerLocal,
+					credential: matrixCredential(hub.URL, peerHub.ID, peerEnrollment.Token),
+					before:     tc.peerTaskBeforeEnrollment},
+			}
+			if tc.peerSyncsFirst {
+				projects[0], projects[1] = projects[1], projects[0]
+			}
+
+			for _, project := range projects {
+				if project.before {
+					project.issue = matrixCreateInitialState(t, spoke.DB, project.local, project.tag)
+				}
+			}
+			linked := false
+			if projects[0].issue.ID != 0 && projects[1].issue.ID != 0 {
+				matrixCreateCrossProjectLink(t, spoke.DB, projects[0].issue, projects[1].issue)
+				linked = true
+			}
+			syncEligible := func() {
+				for _, project := range projects {
+					if project.enrolled {
+						matrixSyncProject(t, spoke.DB, project)
+					}
+				}
+			}
+			for _, project := range projects {
+				matrixAdoptProject(t, hub.DB, spoke.DB, hub.URL, project)
+				if !project.before {
+					project.issue = matrixCreateInitialState(t, spoke.DB, project.local, project.tag)
+				}
+				if !linked && projects[0].issue.ID != 0 && projects[1].issue.ID != 0 {
+					matrixCreateCrossProjectLink(t, spoke.DB, projects[0].issue, projects[1].issue)
+					linked = true
+				}
+				if tc.eagerSync {
+					syncEligible()
+				}
+			}
+			require.True(t, linked)
+			for _, project := range projects {
+				project.issue = matrixApplyPostEnrollmentState(t, spoke.DB, project.issue, project.tag)
+				if tc.eagerSync {
+					syncEligible()
+				}
+			}
+			syncEligible()
+			syncEligible()
+
+			for _, project := range projects {
+				matrixAssertPortableState(t, hub.DB, project.hub.ID, project.issue.UID, project.tag)
+				matrixAssertPushDrained(t, spoke.DB, project.local.ID)
+			}
+			matrixAssertLinkCount(t, hub.DB, projects[0].issue.UID, projects[1].issue.UID, 1)
+			firstByTag := matrixProjectByTag(projects, "first")
+			peerByTag := matrixProjectByTag(projects, "peer")
+			matrixApplyHubFollowup(t, hub.DB, firstByTag, peerByTag)
+			syncEligible()
+			matrixAssertPulledFollowup(t, spoke.DB, firstByTag, peerByTag)
+			matrixAssertPullCursors(t, hub.DB, spoke.DB, projects)
+
+			beforeRepeat, err := spoke.DB.MaxEventID(ctx)
+			require.NoError(t, err)
+			syncEligible()
+			afterRepeat, err := spoke.DB.MaxEventID(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, beforeRepeat, afterRepeat)
+			matrixAssertLinkCount(t, hub.DB, projects[0].issue.UID, projects[1].issue.UID, 1)
+		})
+	}
+}
+
 func TestSyncFederationOncePushesAndAdvancesCursor(t *testing.T) {
 	ctx := context.Background()
 	hub := testenv.New(t)
@@ -3406,6 +3515,319 @@ func assertHubOriginEventCount(ctx context.Context, store *sqlitestore.Store, pr
 		return fmt.Errorf("origin event count = %d, want %d", got, want)
 	}
 	return nil
+}
+
+type matrixFederationProject struct {
+	tag        string
+	hub        db.Project
+	local      db.Project
+	issue      db.Issue
+	credential config.FederationCredential
+	before     bool
+	enrolled   bool
+}
+
+func matrixCreateHubProject(t *testing.T, hub *testenv.Env, name string) db.Project {
+	t.Helper()
+	project, err := hub.DB.CreateProject(context.Background(), name)
+	require.NoError(t, err)
+	_, err = hub.DB.EnableProjectFederation(context.Background(), project.ID, "tester")
+	require.NoError(t, err)
+	return project
+}
+
+func matrixCreateEnrollment(
+	t *testing.T,
+	hub, spoke *testenv.Env,
+	project db.Project,
+	token string,
+) db.CreatedFederationEnrollment {
+	t.Helper()
+	created, err := hub.DB.CreateFederationEnrollment(context.Background(), db.CreateFederationEnrollmentParams{
+		Token:                        token,
+		SpokeInstanceUID:             spoke.DB.InstanceUID(),
+		ProjectID:                    &project.ID,
+		Capabilities:                 "pull,push",
+		Actor:                        "tester",
+		AllowAdoptionSnapshotAuthors: true,
+	})
+	require.NoError(t, err)
+	return created
+}
+
+func matrixCredential(hubURL string, projectID int64, token string) config.FederationCredential {
+	return config.FederationCredential{
+		HubURL:       hubURL,
+		HubProjectID: projectID,
+		Token:        token,
+		Capabilities: "pull,push",
+	}
+}
+
+func matrixCreateInitialState(t *testing.T, store *sqlitestore.Store, project db.Project, tag string) db.Issue {
+	t.Helper()
+	owner := tag + "-initial-owner"
+	priority := int64(3)
+	issue, _, err := store.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     tag + " initial title",
+		Body:      tag + " initial body",
+		Author:    "tester",
+		Labels:    []string{tag + "-initial-label"},
+		Owner:     &owner,
+		Priority:  &priority,
+		Metadata: map[string]json.RawMessage{
+			"phase": json.RawMessage(`"initial"`),
+		},
+	})
+	require.NoError(t, err)
+	_, _, err = store.CreateComment(context.Background(), db.CreateCommentParams{
+		IssueID: issue.ID,
+		Author:  "tester",
+		Body:    tag + " initial comment",
+	})
+	require.NoError(t, err)
+	_, _, changed, err := store.CloseIssue(context.Background(), issue.ID, "done", "tester", "initial close", nil)
+	require.NoError(t, err)
+	require.True(t, changed)
+	issue, _, changed, err = store.ReopenIssue(context.Background(), issue.ID, "tester")
+	require.NoError(t, err)
+	require.True(t, changed)
+	_, err = store.PatchProjectMetadata(context.Background(), db.PatchProjectMetadataIn{
+		ProjectID: project.ID,
+		Actor:     "tester",
+		Patch: map[string]json.RawMessage{
+			"phase": json.RawMessage(`"` + tag + `-initial"`),
+		},
+	})
+	require.NoError(t, err)
+	return issue
+}
+
+func matrixCreateCrossProjectLink(t *testing.T, store *sqlitestore.Store, first, peer db.Issue) {
+	t.Helper()
+	_, _, err := store.CreateLinkAndEvent(context.Background(), db.CreateLinkParams{
+		FromIssueID: first.ID,
+		ToIssueID:   peer.ID,
+		Type:        "blocks",
+		Author:      "tester",
+	}, db.LinkEventParams{
+		EventType:    "issue.linked",
+		EventIssueID: first.ID,
+		FromShortID:  first.ShortID,
+		FromUID:      first.UID,
+		ToShortID:    peer.ShortID,
+		ToUID:        peer.UID,
+		Actor:        "tester",
+	})
+	require.NoError(t, err)
+}
+
+func matrixAdoptProject(
+	t *testing.T,
+	hub, spoke *sqlitestore.Store,
+	hubURL string,
+	project *matrixFederationProject,
+) {
+	t.Helper()
+	hubBinding, err := hub.FederationBindingByProject(context.Background(), project.hub.ID)
+	require.NoError(t, err)
+	result, err := spoke.AdoptProjectIntoFederation(context.Background(), db.AdoptProjectIntoFederationParams{
+		ProjectID:            project.local.ID,
+		HubURL:               hubURL,
+		HubProjectID:         project.hub.ID,
+		HubProjectUID:        project.hub.UID,
+		ReplayHorizonEventID: hubBinding.ReplayHorizonEventID,
+		Actor:                "tester",
+	})
+	require.NoError(t, err)
+	project.local = result.Project
+	if project.issue.ID != 0 {
+		project.issue, err = spoke.IssueByUID(context.Background(), project.issue.UID, db.IncludeDeletedYes)
+		require.NoError(t, err)
+	}
+	project.enrolled = true
+}
+
+func matrixApplyPostEnrollmentState(
+	t *testing.T,
+	store *sqlitestore.Store,
+	issue db.Issue,
+	tag string,
+) db.Issue {
+	t.Helper()
+	title := tag + " final title"
+	body := tag + " final body"
+	owner := tag + "-final-owner"
+	priority := int64(1)
+	result, err := store.EditIssueAtomic(context.Background(), db.EditIssueAtomicParams{
+		IssueID: issue.ID, Actor: "tester", Title: &title, Body: &body,
+		Owner: &owner, SetPriority: &priority,
+	})
+	require.NoError(t, err)
+	_, _, err = store.AddLabelAndEvent(context.Background(), issue.ID, db.LabelEventParams{
+		EventType: "issue.labeled", Label: tag + "-final-label", Actor: "tester",
+	})
+	require.NoError(t, err)
+	_, err = store.PatchIssueMetadata(context.Background(), db.PatchIssueMetadataIn{
+		IssueID: issue.ID,
+		Actor:   "tester",
+		Patch: map[string]json.RawMessage{
+			"phase": json.RawMessage(`"final"`),
+		},
+	})
+	require.NoError(t, err)
+	_, _, err = store.CreateComment(context.Background(), db.CreateCommentParams{
+		IssueID: issue.ID, Author: "tester", Body: tag + " final comment",
+	})
+	require.NoError(t, err)
+	return result.Issue
+}
+
+func matrixSyncProject(t *testing.T, spoke *sqlitestore.Store, project *matrixFederationProject) {
+	t.Helper()
+	binding, err := spoke.FederationBindingByProject(context.Background(), project.local.ID)
+	require.NoError(t, err)
+	require.NoError(t, SyncFederationOnce(context.Background(), spoke, binding, project.credential))
+}
+
+func matrixAssertPortableState(
+	t *testing.T,
+	hub *sqlitestore.Store,
+	hubProjectID int64,
+	issueUID, tag string,
+) {
+	t.Helper()
+	issue, err := hub.IssueByUID(context.Background(), issueUID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	assert.Equal(t, hubProjectID, issue.ProjectID)
+	assert.Equal(t, tag+" final title", issue.Title)
+	assert.Equal(t, tag+" final body", issue.Body)
+	require.NotNil(t, issue.Owner)
+	assert.Equal(t, tag+"-final-owner", *issue.Owner)
+	require.NotNil(t, issue.Priority)
+	assert.Equal(t, int64(1), *issue.Priority)
+	assert.Equal(t, "open", issue.Status)
+	assert.JSONEq(t, `{"phase":"final"}`, string(issue.Metadata))
+	labels, err := hub.LabelsByIssue(context.Background(), issue.ID)
+	require.NoError(t, err)
+	var gotLabels []string
+	for _, label := range labels {
+		gotLabels = append(gotLabels, label.Label)
+	}
+	assert.ElementsMatch(t, []string{tag + "-initial-label", tag + "-final-label"}, gotLabels)
+	comments, err := hub.CommentsByIssue(context.Background(), issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 2)
+	assert.Equal(t, tag+" initial comment", comments[0].Body)
+	assert.Equal(t, tag+" final comment", comments[1].Body)
+	project, err := hub.ProjectByID(context.Background(), hubProjectID)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"phase":"`+tag+`-initial"}`, string(project.Metadata))
+}
+
+func matrixAssertPushDrained(t *testing.T, spoke *sqlitestore.Store, projectID int64) {
+	t.Helper()
+	binding, err := spoke.FederationBindingByProject(context.Background(), projectID)
+	require.NoError(t, err)
+	pending, _, err := spoke.PendingFederationPushStats(
+		context.Background(), projectID, spoke.InstanceUID(), binding.PushCursorEventID)
+	require.NoError(t, err)
+	assert.Zero(t, pending)
+	_, err = spoke.ActiveFederationQuarantine(context.Background(), projectID, db.FederationQuarantineDirectionPush)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}
+
+func matrixAssertLinkCount(t *testing.T, store *sqlitestore.Store, firstUID, peerUID string, want int) {
+	t.Helper()
+	var got int
+	require.NoError(t, store.QueryRowContext(context.Background(), `
+		SELECT COUNT(*)
+		  FROM links
+		 WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`,
+		firstUID, peerUID).Scan(&got))
+	assert.Equal(t, want, got)
+}
+
+func matrixProjectByTag(projects []*matrixFederationProject, tag string) *matrixFederationProject {
+	for _, project := range projects {
+		if project.tag == tag {
+			return project
+		}
+	}
+	panic("matrix project tag not found: " + tag)
+}
+
+func matrixApplyHubFollowup(
+	t *testing.T,
+	hub *sqlitestore.Store,
+	first, peer *matrixFederationProject,
+) {
+	t.Helper()
+	firstIssue, err := hub.IssueByUID(context.Background(), first.issue.UID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	title := "first hub followup"
+	_, err = hub.EditIssueAtomic(context.Background(), db.EditIssueAtomicParams{
+		IssueID: firstIssue.ID, Actor: "hub-operator", Title: &title,
+	})
+	require.NoError(t, err)
+	_, _, err = hub.CreateComment(context.Background(), db.CreateCommentParams{
+		IssueID: firstIssue.ID, Author: "hub-operator", Body: "first hub comment",
+	})
+	require.NoError(t, err)
+	peerIssue, err := hub.IssueByUID(context.Background(), peer.issue.UID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	_, _, err = hub.AddLabelAndEvent(context.Background(), peerIssue.ID, db.LabelEventParams{
+		EventType: "issue.labeled", Label: "peer-hub-label", Actor: "hub-operator",
+	})
+	require.NoError(t, err)
+	_, _, changed, err := hub.CloseIssue(
+		context.Background(), peerIssue.ID, "done", "hub-operator", "hub close", nil)
+	require.NoError(t, err)
+	require.True(t, changed)
+}
+
+func matrixAssertPulledFollowup(
+	t *testing.T,
+	spoke *sqlitestore.Store,
+	first, peer *matrixFederationProject,
+) {
+	t.Helper()
+	firstIssue, err := spoke.IssueByUID(context.Background(), first.issue.UID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	assert.Equal(t, first.local.ID, firstIssue.ProjectID)
+	assert.Equal(t, "first hub followup", firstIssue.Title)
+	comments, err := spoke.CommentsByIssue(context.Background(), firstIssue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 3)
+	assert.Equal(t, "first hub comment", comments[2].Body)
+	peerIssue, err := spoke.IssueByUID(context.Background(), peer.issue.UID, db.IncludeDeletedYes)
+	require.NoError(t, err)
+	assert.Equal(t, peer.local.ID, peerIssue.ProjectID)
+	assert.Equal(t, "closed", peerIssue.Status)
+	labels, err := spoke.LabelsByIssue(context.Background(), peerIssue.ID)
+	require.NoError(t, err)
+	var hasHubLabel bool
+	for _, label := range labels {
+		hasHubLabel = hasHubLabel || label.Label == "peer-hub-label"
+	}
+	assert.True(t, hasHubLabel)
+}
+
+func matrixAssertPullCursors(
+	t *testing.T,
+	hub, spoke *sqlitestore.Store,
+	projects []*matrixFederationProject,
+) {
+	t.Helper()
+	for _, project := range projects {
+		var hubHighWater int64
+		require.NoError(t, hub.QueryRowContext(context.Background(),
+			`SELECT COALESCE(MAX(id), 0) FROM events WHERE project_id = ?`, project.hub.ID).Scan(&hubHighWater))
+		binding, err := spoke.FederationBindingByProject(context.Background(), project.local.ID)
+		require.NoError(t, err)
+		assert.Equal(t, hubHighWater, binding.PullCursorEventID)
+	}
 }
 
 func createFederatedHubForPush(t *testing.T, env *testenv.Env) db.Project {

--- a/internal/tui/federation_view_render.go
+++ b/internal/tui/federation_view_render.go
@@ -757,12 +757,6 @@ func renderFederationDetail(m Model, rows []FederationProjectStatus, cursor int)
 		fmt.Sprintf("pending claims: %d", row.PendingClaimCount),
 		fmt.Sprintf("live claims: %d", row.LiveClaimCount),
 		fmt.Sprintf("quarantine count: %d", row.ActiveQuarantineCount),
-		"reset blocker: "+sanitizeForLine(emptyDash(row.ResetBlocker)),
-		fmt.Sprintf("claim violations: %d unresolved, %d recent", row.UnresolvedViolationCount, row.RecentViolationCount),
-		"last pull success: "+formatOptionalTime(row.LastPullSuccessAt),
-		"last push success: "+formatOptionalTime(row.LastPushSuccessAt),
-		"last sync success: "+formatOptionalTime(row.LastSuccessfulSyncAt),
-		"last error: "+formatOptionalError(row),
 	)
 	for _, quarantine := range row.ActiveQuarantines {
 		body = append(body, fmt.Sprintf(
@@ -775,7 +769,16 @@ func renderFederationDetail(m Model, rows []FederationProjectStatus, cursor int)
 			sanitizeForLine(quarantine.Error),
 		))
 	}
-	body = append(body, "", subtleStyle.Render("[esc] back  [r] refresh  [q] quit  [?] help"))
+	body = append(body,
+		"reset blocker: "+sanitizeForLine(emptyDash(row.ResetBlocker)),
+		fmt.Sprintf("claim violations: %d unresolved, %d recent", row.UnresolvedViolationCount, row.RecentViolationCount),
+		"last pull success: "+formatOptionalTime(row.LastPullSuccessAt),
+		"last push success: "+formatOptionalTime(row.LastPushSuccessAt),
+		"last sync success: "+formatOptionalTime(row.LastSuccessfulSyncAt),
+		"last error: "+formatOptionalError(row),
+		"",
+		subtleStyle.Render("[esc] back  [r] refresh  [q] quit  [?] help"),
+	)
 	return strings.Join(fitFederationLines(body, m.height), "\n")
 }
 

--- a/internal/tui/federation_view_render.go
+++ b/internal/tui/federation_view_render.go
@@ -763,9 +763,19 @@ func renderFederationDetail(m Model, rows []FederationProjectStatus, cursor int)
 		"last push success: "+formatOptionalTime(row.LastPushSuccessAt),
 		"last sync success: "+formatOptionalTime(row.LastSuccessfulSyncAt),
 		"last error: "+formatOptionalError(row),
-		"",
-		subtleStyle.Render("[esc] back  [r] refresh  [q] quit  [?] help"),
 	)
+	for _, quarantine := range row.ActiveQuarantines {
+		body = append(body, fmt.Sprintf(
+			"quarantine #%d: %s events %d-%d at %s: %s",
+			quarantine.ID,
+			sanitizeForLine(quarantine.Direction),
+			quarantine.FirstEventID,
+			quarantine.LastEventID,
+			quarantine.CreatedAt.UTC().Format("2006-01-02 15:04:05Z"),
+			sanitizeForLine(quarantine.Error),
+		))
+	}
+	body = append(body, "", subtleStyle.Render("[esc] back  [r] refresh  [q] quit  [?] help"))
 	return strings.Join(fitFederationLines(body, m.height), "\n")
 }
 

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -39,7 +39,6 @@ func TestFederationView_EscReturnsToPreviousView(t *testing.T) {
 func TestFederationView_EnterOpensSelectedStatusDetail(t *testing.T) {
 	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
 	m.federationCursor = 0
-	m.height = 40
 
 	out, cmd := enterThroughAdoptConfirm(t, m)
 

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -39,6 +39,7 @@ func TestFederationView_EscReturnsToPreviousView(t *testing.T) {
 func TestFederationView_EnterOpensSelectedStatusDetail(t *testing.T) {
 	m := setupFederationViewWithStatuses(federationStatusFixture("spoke-proj", "spoke"))
 	m.federationCursor = 0
+	m.height = 40
 
 	out, cmd := enterThroughAdoptConfirm(t, m)
 
@@ -48,6 +49,8 @@ func TestFederationView_EnterOpensSelectedStatusDetail(t *testing.T) {
 	assert.Contains(t, rendered, "hub project UID")
 	assert.Contains(t, rendered, "pull cursor")
 	assert.Contains(t, rendered, "credential")
+	assert.Contains(t, rendered, "quarantine #7: push events 11-13")
+	assert.Contains(t, rendered, "hub rejected deferred peer")
 }
 
 func TestFederationView_RenderIncludesActiveSpokeStatus(t *testing.T) {
@@ -70,6 +73,7 @@ func TestFederationView_RenderIncludesActiveSpokeStatus(t *testing.T) {
 	assert.Contains(t, rendered, "quarantine")
 	assert.Contains(t, rendered, "reset")
 	assert.Contains(t, rendered, "violations")
+	assert.NotContains(t, rendered, "hub rejected deferred peer")
 }
 
 func TestFederationView_ActiveLocalGlobalAuthDisplaysTokenActor(t *testing.T) {
@@ -1380,12 +1384,25 @@ func federationStatusFixture(projectName, role string) FederationProjectStatus {
 		PendingPushHighWaterEventID: 15,
 		PendingClaimCount:           1,
 		ActiveQuarantineCount:       1,
-		ResetBlocker:                "pending push",
-		UnresolvedViolationCount:    2,
-		RecentViolationCount:        2,
-		LastSuccessfulSyncAt:        &last,
-		LastPullSuccessAt:           &last,
-		LastPushSuccessAt:           &last,
+		ActiveQuarantines: []api.FederationQuarantineSummary{{
+			ID:           7,
+			Direction:    "push",
+			FirstEventID: 11,
+			LastEventID:  13,
+			EventUIDs: []string{
+				"01HZNQ7VFPK1XGD8R5MABCD4EA",
+				"01HZNQ7VFPK1XGD8R5MABCD4EB",
+				"01HZNQ7VFPK1XGD8R5MABCD4EC",
+			},
+			Error:     "hub rejected deferred peer",
+			CreatedAt: last.Add(time.Minute),
+		}},
+		ResetBlocker:             "pending push",
+		UnresolvedViolationCount: 2,
+		RecentViolationCount:     2,
+		LastSuccessfulSyncAt:     &last,
+		LastPullSuccessAt:        &last,
+		LastPushSuccessAt:        &last,
 	}
 }
 


### PR DESCRIPTION
A corrected hub cannot reconsider a batch that an older validator already quarantined because the spoke stops before making a network request. This PR makes those valid cross-project batches recover through the existing durable retry transition without editing event history or advancing a cursor early.

The branch now:

- automatically releases only push quarantines matching the former event-to-missing-peer validation signature, while unknown-primary and other poisoned mutations remain blocked before network access
- exercises a sixteen-case, two-project lifecycle matrix across task creation before/after enrollment, eager/batched synchronization, and both project orders, including portable state, pullback, isolation, independent cursors, links, and idempotence
- adds read-only `kata federation quarantine list` and `show <id>` output in human, agent, and JSON modes
- exposes retained quarantine errors in TUI project detail while keeping the compact list unchanged
- documents retry/skip behavior and explicitly directs operators not to repair quarantine state in SQLite

The design and task-by-task execution plan remain in the opening commits, followed by separate implementation checkpoints for recovery, matrix coverage, CLI discovery, TUI detail, and public documentation. No database migration or compatibility storage path is introduced.

<sup>generated by a clanker</sup>