### PR TITLE
Add kata init --with-hooks: install work.attention hooks for Claude Code

### DIFF
--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -23,6 +23,7 @@ type initOptions struct {
 	Replace    bool
 	Reassign   bool
 	WithAgents bool
+	WithHooks  bool
 }
 
 // callInitOpts is the parameter bag passed to callInit.
@@ -31,6 +32,7 @@ type callInitOpts struct {
 	Replace    bool
 	Reassign   bool
 	WithAgents bool
+	WithHooks  bool
 }
 
 // cliError is a structured error that carries an exit code for main().
@@ -139,6 +141,7 @@ get committed.`,
 	cmd.Flags().BoolVar(&opts.Replace, "replace", false, "overwrite .kata.toml binding when it conflicts")
 	cmd.Flags().BoolVar(&opts.Reassign, "reassign", false, "move an existing alias to this project")
 	cmd.Flags().BoolVar(&opts.WithAgents, "with-agents", false, "write kata agent guidance into AGENTS.md/CLAUDE.md in the workspace")
+	cmd.Flags().BoolVar(&opts.WithHooks, "with-hooks", false, "install work.attention harness hooks into the workspace's Claude Code config (.claude/)")
 
 	return cmd
 }
@@ -305,8 +308,15 @@ func runNameInit(ctx context.Context, baseURL string, in localInit, opts callIni
 			warnAgentsUpdate(err)
 		}
 	}
+	hooksChanged := false
+	if opts.WithHooks {
+		hooksChanged, err = applyClaudeHooks(dest)
+		if err != nil {
+			warnHooksUpdate(err)
+		}
+	}
 
-	return formatInitOutput(bs, resp.Project.Name, dest, resp.Created, resp.Created || tomlChanged || gitignoreChanged || agentsChanged)
+	return formatInitOutput(bs, resp.Project.Name, dest, resp.Created, resp.Created || tomlChanged || gitignoreChanged || agentsChanged || hooksChanged)
 }
 
 // runStartPathInit is the fallback used when the client cannot derive a name
@@ -356,10 +366,17 @@ func runStartPathInit(ctx context.Context, baseURL, startPath string, opts callI
 			warnAgentsUpdate(err)
 		}
 	}
+	hooksChanged := false
+	if opts.WithHooks {
+		hooksChanged, err = applyClaudeHooks(gitignoreDir)
+		if err != nil {
+			warnHooksUpdate(err)
+		}
+	}
 
 	// The path-based daemon flow writes workspace files remotely and exposes no
 	// local file-change bit today; project creation is the closest stable signal.
-	return formatInitOutput(bs, resp.Project.Name, gitignoreDir, resp.Created, resp.Created || gitignoreChanged || agentsChanged)
+	return formatInitOutput(bs, resp.Project.Name, gitignoreDir, resp.Created, resp.Created || gitignoreChanged || agentsChanged || hooksChanged)
 }
 
 func warnGitignoreUpdate(err error) {
@@ -374,6 +391,13 @@ func warnAgentsUpdate(err error) {
 		return
 	}
 	fmt.Fprintf(os.Stderr, "kata: warning: could not update agent guidance: %v\n", err)
+}
+
+func warnHooksUpdate(err error) {
+	if currentOutputMode() != outputHuman {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "kata: warning: could not install attention hooks: %v\n", err)
 }
 
 // warnBeadsConflict tells the user kata declined to edit a file in place

--- a/cmd/kata/init_hooks.go
+++ b/cmd/kata/init_hooks.go
@@ -99,8 +99,10 @@ func ensureClaudeHookScript(path string) (bool, error) {
 
 // ensureExecutable restores the execute bits on the managed script when a
 // pre-existing copy lost them — content-identical but 0644 still means the
-// wired hooks never run. Reports whether the mode changed. No-op on Windows,
-// which has no Unix execute bits.
+// wired hooks never run. The owner bit specifically is what counts: Unix
+// checks only the owner class for the owning user, so group/other execute
+// bits alone leave the script unrunnable. Reports whether the mode changed.
+// No-op on Windows, which has no Unix execute bits.
 func ensureExecutable(path string) (bool, error) {
 	if runtime.GOOS == "windows" {
 		return false, nil
@@ -109,7 +111,7 @@ func ensureExecutable(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if fi.Mode()&0o111 != 0 {
+	if fi.Mode()&0o100 != 0 {
 		return false, nil
 	}
 	if err := os.Chmod(path, 0o755); err != nil { //nolint:gosec // hook script must be executable

--- a/cmd/kata/init_hooks.go
+++ b/cmd/kata/init_hooks.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // `kata init --with-hooks` installs the attention hooks from
@@ -78,12 +79,40 @@ func ensureClaudeHookScript(path string) (bool, error) {
 		return false, err
 	}
 	if exists && current == claudeHookScript {
-		return false, nil
+		return ensureExecutable(path)
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return false, err
 	}
 	if err := os.WriteFile(path, []byte(claudeHookScript), 0o755); err != nil { //nolint:gosec // hook script must be executable
+		return false, err
+	}
+	if exists {
+		// WriteFile's permission argument only applies at creation; a
+		// pre-existing drifted file keeps its old mode unless fixed here.
+		if _, err := ensureExecutable(path); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// ensureExecutable restores the execute bits on the managed script when a
+// pre-existing copy lost them — content-identical but 0644 still means the
+// wired hooks never run. Reports whether the mode changed. No-op on Windows,
+// which has no Unix execute bits.
+func ensureExecutable(path string) (bool, error) {
+	if runtime.GOOS == "windows" {
+		return false, nil
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	if fi.Mode()&0o111 != 0 {
+		return false, nil
+	}
+	if err := os.Chmod(path, 0o755); err != nil { //nolint:gosec // hook script must be executable
 		return false, err
 	}
 	return true, nil

--- a/cmd/kata/init_hooks.go
+++ b/cmd/kata/init_hooks.go
@@ -53,6 +53,14 @@ func claudeHookSpecs() []claudeHookSpec {
 // Returns whether anything changed; re-running on an installed workspace is
 // a no-op.
 func applyClaudeHooks(dir string) (bool, error) {
+	// Refuse symlinked parents before any write: a hostile repo can commit
+	// .claude (or .claude/hooks) as a symlink to an outside directory, and
+	// MkdirAll/WriteFile on paths beneath it would follow the link —
+	// rewriting the user's global Claude config or planting files at an
+	// attacker-chosen location. Matches the leaf-level symlink posture.
+	if err := refuseSymlinkComponents(dir, ".claude", "hooks"); err != nil {
+		return false, err
+	}
 	scriptChanged, err := ensureClaudeHookScript(
 		filepath.Join(dir, ".claude", "hooks", claudeHookScriptName))
 	if err != nil {
@@ -64,6 +72,26 @@ func applyClaudeHooks(dir string) (bool, error) {
 		return scriptChanged, err
 	}
 	return scriptChanged || settingsChanged, nil
+}
+
+// refuseSymlinkComponents walks the relative path components under root and
+// rejects any existing component that is a symlink. Components that do not
+// exist yet are fine — they will be created as real directories.
+func refuseSymlinkComponents(root string, parts ...string) error {
+	p := root
+	for _, part := range parts {
+		p = filepath.Join(p, part)
+		fi, err := os.Lstat(p)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			return nil
+		case err != nil:
+			return err
+		case fi.Mode()&os.ModeSymlink != 0:
+			return fmt.Errorf("refusing to manage symlinked %s", p)
+		}
+	}
+	return nil
 }
 
 // ensureClaudeHookScript writes the managed script, creating parent

--- a/cmd/kata/init_hooks.go
+++ b/cmd/kata/init_hooks.go
@@ -38,12 +38,14 @@ type claudeHookSpec struct {
 	Command string
 }
 
-// claudeHookSpecs returns the three wirings --with-hooks manages.
+// claudeHookSpecs returns the three wirings --with-hooks manages. The
+// terminal sweep rides SessionEnd, not Stop: Stop fires after every response
+// turn, which would flip ordinary mid-session pauses to needs-human.
 func claudeHookSpecs() []claudeHookSpec {
 	return []claudeHookSpec{
 		{Event: "SessionStart", Command: claudeHookCommand("start")},
 		{Event: "PostToolUse", Matcher: "Bash", Command: claudeHookCommand("claim")},
-		{Event: "Stop", Command: claudeHookCommand("stop")},
+		{Event: "SessionEnd", Command: claudeHookCommand("stop")},
 	}
 }
 
@@ -165,6 +167,11 @@ func ensureClaudeSettingsHooks(path string) (bool, error) {
 	if exists {
 		if err := json.Unmarshal([]byte(content), &settings); err != nil {
 			return false, fmt.Errorf("parse %s: %w (fix or remove it, then re-run)", path, err)
+		}
+		// `null` is valid JSON and decodes to a nil map, which the merge
+		// below would panic assigning into.
+		if settings == nil {
+			return false, fmt.Errorf("parse %s: settings root is not an object (fix or remove it, then re-run)", path)
 		}
 	}
 

--- a/cmd/kata/init_hooks.go
+++ b/cmd/kata/init_hooks.go
@@ -175,7 +175,10 @@ func ensureClaudeSettingsHooks(path string) (bool, error) {
 		}
 	}
 
-	changed := false
+	// Migrate wiring from earlier layouts: older installs registered the
+	// sweep on Stop (which fires every turn, not at session end); leaving it
+	// would keep the mid-session false alerts alive on upgraded workspaces.
+	changed := pruneClaudeHook(settings, "Stop", claudeHookCommand("stop"))
 	for _, spec := range claudeHookSpecs() {
 		c, err := upsertClaudeHook(settings, spec)
 		if err != nil {
@@ -246,6 +249,52 @@ func upsertClaudeHook(settings map[string]any, spec claudeHookSpec) (bool, error
 	}
 	hooks[spec.Event] = append(groups, group)
 	return true, nil
+}
+
+// pruneClaudeHook removes kata's own obsolete wiring: every hook entry under
+// event whose command equals command. Groups and events left empty by the
+// prune are dropped; anything user-owned is untouched. Reports whether the
+// settings changed.
+func pruneClaudeHook(settings map[string]any, event, command string) bool {
+	hooks, _ := settings["hooks"].(map[string]any)
+	groups, _ := hooks[event].([]any)
+	if len(groups) == 0 {
+		return false
+	}
+	changed := false
+	var keptGroups []any
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			keptGroups = append(keptGroups, g)
+			continue
+		}
+		entries, _ := gm["hooks"].([]any)
+		var kept []any
+		for _, e := range entries {
+			if em, ok := e.(map[string]any); ok && em["command"] == command {
+				changed = true
+				continue
+			}
+			kept = append(kept, e)
+		}
+		if len(kept) == 0 && len(entries) > 0 {
+			continue // group held only kata's wiring; drop it entirely
+		}
+		if len(kept) != len(entries) {
+			gm["hooks"] = kept
+		}
+		keptGroups = append(keptGroups, gm)
+	}
+	if !changed {
+		return false
+	}
+	if len(keptGroups) == 0 {
+		delete(hooks, event)
+	} else {
+		hooks[event] = keptGroups
+	}
+	return true
 }
 
 // ensureObject returns m[key] as an object, creating it when absent.

--- a/cmd/kata/init_hooks.go
+++ b/cmd/kata/init_hooks.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// `kata init --with-hooks` installs the attention hooks from
+// docs/operations/agent-orchestration.md ("Keep attention truthful with
+// hooks") into a Claude Code workspace: a managed hook script plus the
+// .claude/settings.json wiring that runs it at session start, after Bash
+// tool calls (to spot `kata claim`), and at session stop.
+
+//go:embed kata_attention_hook.sh
+var claudeHookScript string
+
+// claudeHookScriptName is the managed script's filename under .claude/hooks.
+const claudeHookScriptName = "kata-attention.sh"
+
+// claudeHookCommand renders the settings.json command line for one hook mode.
+// $CLAUDE_PROJECT_DIR keeps the wiring correct regardless of the cwd Claude
+// Code runs hooks from.
+func claudeHookCommand(mode string) string {
+	return `"$CLAUDE_PROJECT_DIR"/.claude/hooks/` + claudeHookScriptName + " " + mode
+}
+
+// claudeHookSpec is one desired settings.json wiring: an event, an optional
+// tool matcher, and the command to run.
+type claudeHookSpec struct {
+	Event   string
+	Matcher string
+	Command string
+}
+
+// claudeHookSpecs returns the three wirings --with-hooks manages.
+func claudeHookSpecs() []claudeHookSpec {
+	return []claudeHookSpec{
+		{Event: "SessionStart", Command: claudeHookCommand("start")},
+		{Event: "PostToolUse", Matcher: "Bash", Command: claudeHookCommand("claim")},
+		{Event: "Stop", Command: claudeHookCommand("stop")},
+	}
+}
+
+// applyClaudeHooks is the entry point for `--with-hooks`. It writes the
+// managed hook script under <dir>/.claude/hooks and merges the wiring into
+// <dir>/.claude/settings.json, preserving everything else the file holds.
+// Returns whether anything changed; re-running on an installed workspace is
+// a no-op.
+func applyClaudeHooks(dir string) (bool, error) {
+	scriptChanged, err := ensureClaudeHookScript(
+		filepath.Join(dir, ".claude", "hooks", claudeHookScriptName))
+	if err != nil {
+		return false, err
+	}
+	settingsChanged, err := ensureClaudeSettingsHooks(
+		filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		return scriptChanged, err
+	}
+	return scriptChanged || settingsChanged, nil
+}
+
+// ensureClaudeHookScript writes the managed script, creating parent
+// directories as needed and refreshing the file when its content drifts.
+// The script is wholly kata-owned, so drift is overwritten rather than
+// merged. Symlinks are refused, matching the guidance-file posture.
+func ensureClaudeHookScript(path string) (bool, error) {
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("refusing to manage symlinked %s", path)
+	}
+	current, exists, err := readIfExists(path)
+	if err != nil {
+		return false, err
+	}
+	if exists && current == claudeHookScript {
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(path, []byte(claudeHookScript), 0o755); err != nil { //nolint:gosec // hook script must be executable
+		return false, err
+	}
+	return true, nil
+}
+
+// ensureClaudeSettingsHooks merges the hook wiring into settings.json. The
+// file is user-owned, so the merge is additive: unknown keys and existing
+// hook entries are preserved verbatim (modulo re-encoding), and each kata
+// wiring is appended only when its command is not already present under its
+// event. A file that fails to parse is left untouched and reported.
+func ensureClaudeSettingsHooks(path string) (bool, error) {
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("refusing to manage symlinked %s", path)
+	}
+	content, exists, err := readIfExists(path)
+	if err != nil {
+		return false, err
+	}
+	settings := map[string]any{}
+	if exists {
+		if err := json.Unmarshal([]byte(content), &settings); err != nil {
+			return false, fmt.Errorf("parse %s: %w (fix or remove it, then re-run)", path, err)
+		}
+	}
+
+	changed := false
+	for _, spec := range claudeHookSpecs() {
+		c, err := upsertClaudeHook(settings, spec)
+		if err != nil {
+			return false, fmt.Errorf("%s: %w", path, err)
+		}
+		changed = changed || c
+	}
+	if exists && !changed {
+		return false, nil
+	}
+
+	encoded, err := encodeClaudeSettings(settings)
+	if err != nil {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return false, err
+	}
+	if exists {
+		err = os.WriteFile(path, encoded, 0o644) //nolint:gosec // settings.json is committed config
+	} else {
+		err = writeNewGuidanceFile(path, encoded)
+		if errors.Is(err, os.ErrExist) {
+			// Something raced the file into place between read and write;
+			// surface it rather than overwriting what appeared.
+			err = fmt.Errorf("refusing to overwrite %s: %w", path, err)
+		}
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// upsertClaudeHook appends spec's wiring under its event unless a hook with
+// the same command is already wired there. Existing structures with
+// unexpected shapes are an error rather than a guessed edit.
+func upsertClaudeHook(settings map[string]any, spec claudeHookSpec) (bool, error) {
+	hooks, err := ensureObject(settings, "hooks")
+	if err != nil {
+		return false, err
+	}
+	groups, ok := hooks[spec.Event].([]any)
+	if !ok && hooks[spec.Event] != nil {
+		return false, fmt.Errorf("hooks.%s has an unexpected shape", spec.Event)
+	}
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		entries, _ := gm["hooks"].([]any)
+		for _, e := range entries {
+			em, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			if em["command"] == spec.Command {
+				return false, nil
+			}
+		}
+	}
+	group := map[string]any{
+		"hooks": []any{map[string]any{"type": "command", "command": spec.Command}},
+	}
+	if spec.Matcher != "" {
+		group["matcher"] = spec.Matcher
+	}
+	hooks[spec.Event] = append(groups, group)
+	return true, nil
+}
+
+// ensureObject returns m[key] as an object, creating it when absent.
+func ensureObject(m map[string]any, key string) (map[string]any, error) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		obj := map[string]any{}
+		m[key] = obj
+		return obj, nil
+	}
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%q has an unexpected shape", key)
+	}
+	return obj, nil
+}
+
+// encodeClaudeSettings renders settings as 2-space-indented JSON without
+// HTML escaping, trailing newline included — the conventional settings.json
+// shape. Object keys come out sorted; that is the one formatting liberty the
+// merge takes with a user-owned file.
+func encodeClaudeSettings(settings map[string]any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(settings); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/cmd/kata/init_hooks_test.go
+++ b/cmd/kata/init_hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,7 +55,9 @@ func TestApplyClaudeHooks_FreshWorkspace(t *testing.T) {
 	scriptPath := filepath.Join(dir, ".claude", "hooks", "kata-attention.sh")
 	fi, err := os.Stat(scriptPath)
 	require.NoError(t, err)
-	assert.NotZero(t, fi.Mode()&0o111, "hook script must be executable")
+	if runtime.GOOS != "windows" { // NTFS has no Unix execute bits
+		assert.NotZero(t, fi.Mode()&0o111, "hook script must be executable")
+	}
 	script, err := os.ReadFile(scriptPath) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	for _, mode := range []string{"start)", "claim)", "stop)"} {
@@ -143,6 +146,54 @@ func TestApplyClaudeHooks_RewritesDriftedScript(t *testing.T) {
 	script, err := os.ReadFile(scriptPath) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	assert.Contains(t, string(script), "kata meta set")
+}
+
+// TestApplyClaudeHooks_RestoresExecutableBit covers a pre-existing script
+// with the right content but no execute permission (e.g. checked out through
+// a filter that dropped the bit): the apply must correct the mode and report
+// a change, or the wired hooks silently never run.
+func TestApplyClaudeHooks_RestoresExecutableBit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no Unix execute bits on Windows")
+	}
+	dir := t.TempDir()
+	_, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+
+	scriptPath := filepath.Join(dir, ".claude", "hooks", "kata-attention.sh")
+	require.NoError(t, os.Chmod(scriptPath, 0o600)) // strip the execute bits
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed, "restoring the execute bit is a change")
+	fi, err := os.Stat(scriptPath)
+	require.NoError(t, err)
+	assert.NotZero(t, fi.Mode()&0o111, "execute bit must be restored")
+
+	changed, err = applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.False(t, changed, "mode correction must stay idempotent")
+}
+
+// TestApplyClaudeHooks_DriftedScriptRegainsExecutableBit covers drifted
+// content on a non-executable file: os.WriteFile does not touch an existing
+// file's mode, so the rewrite must fix it explicitly.
+func TestApplyClaudeHooks_DriftedScriptRegainsExecutableBit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no Unix execute bits on Windows")
+	}
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".claude", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o750))
+	scriptPath := filepath.Join(hooksDir, "kata-attention.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\n# stale\n"), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	fi, err := os.Stat(scriptPath)
+	require.NoError(t, err)
+	assert.NotZero(t, fi.Mode()&0o111, "rewritten script must be executable")
 }
 
 func TestApplyClaudeHooks_MalformedSettingsLeftUntouched(t *testing.T) {

--- a/cmd/kata/init_hooks_test.go
+++ b/cmd/kata/init_hooks_test.go
@@ -68,7 +68,7 @@ func TestApplyClaudeHooks_FreshWorkspace(t *testing.T) {
 	settings := readSettings(t, dir)
 	assert.Contains(t, hookCommands(t, settings, "SessionStart"), claudeHookCommand("start"))
 	assert.Contains(t, hookCommands(t, settings, "PostToolUse"), claudeHookCommand("claim"))
-	assert.Contains(t, hookCommands(t, settings, "Stop"), claudeHookCommand("stop"))
+	assert.Contains(t, hookCommands(t, settings, "SessionEnd"), claudeHookCommand("stop"))
 
 	// The PostToolUse wiring is scoped to Bash tool calls.
 	hooks := settings["hooks"].(map[string]any)
@@ -106,7 +106,7 @@ func TestApplyClaudeHooks_PreservesExistingSettings(t *testing.T) {
 	assert.Contains(t, hookCommands(t, settings, "Stop"), "notify.sh")
 	// kata's wiring is appended alongside.
 	assert.Contains(t, hookCommands(t, settings, "PostToolUse"), claudeHookCommand("claim"))
-	assert.Contains(t, hookCommands(t, settings, "Stop"), claudeHookCommand("stop"))
+	assert.Contains(t, hookCommands(t, settings, "SessionEnd"), claudeHookCommand("stop"))
 	assert.Contains(t, hookCommands(t, settings, "SessionStart"), claudeHookCommand("start"))
 }
 
@@ -266,6 +266,24 @@ func TestApplyClaudeHooks_RefusesSymlinkedHooksDir(t *testing.T) {
 	entries, err := os.ReadDir(outside)
 	require.NoError(t, err)
 	assert.Empty(t, entries, "nothing may be written through the symlinked dir")
+}
+
+// TestApplyClaudeHooks_NullSettingsRejected covers a settings.json holding
+// the valid JSON document `null`: it decodes to a nil map and the merge must
+// report the unexpected shape rather than panic on assignment.
+func TestApplyClaudeHooks_NullSettingsRejected(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o750))
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	require.NoError(t, os.WriteFile(settingsPath, []byte("null\n"), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	_, err := applyClaudeHooks(dir)
+	require.Error(t, err)
+
+	got, err := os.ReadFile(settingsPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, "null\n", string(got), "null settings must not be clobbered")
 }
 
 func TestApplyClaudeHooks_RefusesSymlinkedSettings(t *testing.T) {

--- a/cmd/kata/init_hooks_test.go
+++ b/cmd/kata/init_hooks_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Unit tests for `kata init --with-hooks`: installing the work.attention
+// harness hooks (script + .claude/settings.json wiring) for Claude Code.
+// They complement the e2e coverage in init_with_hooks_e2e_test.go.
+
+// readSettings decodes .claude/settings.json under dir for structural asserts.
+func readSettings(t *testing.T, dir string) map[string]any {
+	t.Helper()
+	bs, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(bs, &m))
+	return m
+}
+
+// hookCommands flattens every command string wired under one hook event.
+func hookCommands(t *testing.T, settings map[string]any, event string) []string {
+	t.Helper()
+	hooks, _ := settings["hooks"].(map[string]any)
+	groups, _ := hooks[event].([]any)
+	var cmds []string
+	for _, g := range groups {
+		gm, _ := g.(map[string]any)
+		entries, _ := gm["hooks"].([]any)
+		for _, e := range entries {
+			em, _ := e.(map[string]any)
+			if c, ok := em["command"].(string); ok {
+				cmds = append(cmds, c)
+			}
+		}
+	}
+	return cmds
+}
+
+func TestApplyClaudeHooks_FreshWorkspace(t *testing.T) {
+	dir := t.TempDir()
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	// The hook script exists, is executable, and carries the three modes.
+	scriptPath := filepath.Join(dir, ".claude", "hooks", "kata-attention.sh")
+	fi, err := os.Stat(scriptPath)
+	require.NoError(t, err)
+	assert.NotZero(t, fi.Mode()&0o111, "hook script must be executable")
+	script, err := os.ReadFile(scriptPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	for _, mode := range []string{"start)", "claim)", "stop)"} {
+		assert.Contains(t, string(script), mode)
+	}
+
+	// settings.json wires the script into all three events.
+	settings := readSettings(t, dir)
+	assert.Contains(t, hookCommands(t, settings, "SessionStart"), claudeHookCommand("start"))
+	assert.Contains(t, hookCommands(t, settings, "PostToolUse"), claudeHookCommand("claim"))
+	assert.Contains(t, hookCommands(t, settings, "Stop"), claudeHookCommand("stop"))
+
+	// The PostToolUse wiring is scoped to Bash tool calls.
+	hooks := settings["hooks"].(map[string]any)
+	groups := hooks["PostToolUse"].([]any)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "Bash", groups[0].(map[string]any)["matcher"])
+}
+
+func TestApplyClaudeHooks_PreservesExistingSettings(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o750))
+	existing := `{
+  "permissions": {"allow": ["WebFetch"]},
+  "hooks": {
+    "PostToolUse": [
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "lint.sh"}]}
+    ],
+    "Stop": [
+      {"hooks": [{"type": "command", "command": "notify.sh"}]}
+    ]
+  }
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(existing), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	settings := readSettings(t, dir)
+	// Pre-existing config survives untouched.
+	perms := settings["permissions"].(map[string]any)
+	assert.Equal(t, []any{"WebFetch"}, perms["allow"])
+	assert.Contains(t, hookCommands(t, settings, "PostToolUse"), "lint.sh")
+	assert.Contains(t, hookCommands(t, settings, "Stop"), "notify.sh")
+	// kata's wiring is appended alongside.
+	assert.Contains(t, hookCommands(t, settings, "PostToolUse"), claudeHookCommand("claim"))
+	assert.Contains(t, hookCommands(t, settings, "Stop"), claudeHookCommand("stop"))
+	assert.Contains(t, hookCommands(t, settings, "SessionStart"), claudeHookCommand("start"))
+}
+
+func TestApplyClaudeHooks_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	require.True(t, changed)
+	settingsBefore, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	scriptBefore, err := os.ReadFile(filepath.Join(dir, ".claude", "hooks", "kata-attention.sh")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+
+	changed, err = applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.False(t, changed, "second run must be a no-op")
+	settingsAfter, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	scriptAfter, err := os.ReadFile(filepath.Join(dir, ".claude", "hooks", "kata-attention.sh")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, string(settingsBefore), string(settingsAfter))
+	assert.Equal(t, string(scriptBefore), string(scriptAfter))
+}
+
+func TestApplyClaudeHooks_RewritesDriftedScript(t *testing.T) {
+	dir := t.TempDir()
+	_, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+
+	scriptPath := filepath.Join(dir, ".claude", "hooks", "kata-attention.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\n# stale\n"), 0o755)) //nolint:gosec // test fixture under TempDir
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed, "drifted managed script must be refreshed")
+	script, err := os.ReadFile(scriptPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(script), "kata meta set")
+}
+
+func TestApplyClaudeHooks_MalformedSettingsLeftUntouched(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o750))
+	malformed := "{ not json"
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	require.NoError(t, os.WriteFile(settingsPath, []byte(malformed), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	_, err := applyClaudeHooks(dir)
+	require.Error(t, err)
+
+	got, err := os.ReadFile(settingsPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, malformed, string(got), "malformed settings must not be clobbered")
+}
+
+func TestApplyClaudeHooks_RefusesSymlinkedSettings(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o750))
+	victim := filepath.Join(dir, "victim.json")
+	require.NoError(t, os.WriteFile(victim, []byte("{}"), 0o644)) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, os.Symlink(victim, filepath.Join(claudeDir, "settings.json")))
+
+	_, err := applyClaudeHooks(dir)
+	require.Error(t, err)
+
+	got, err := os.ReadFile(victim) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(got), "symlink target must not be written through")
+}
+
+func TestApplyClaudeHooks_RefusesSymlinkedScript(t *testing.T) {
+	dir := t.TempDir()
+	hooksDir := filepath.Join(dir, ".claude", "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o750))
+	victim := filepath.Join(dir, "victim.sh")
+	require.NoError(t, os.WriteFile(victim, []byte("original"), 0o644)) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, os.Symlink(victim, filepath.Join(hooksDir, "kata-attention.sh")))
+
+	_, err := applyClaudeHooks(dir)
+	require.Error(t, err)
+
+	got, err := os.ReadFile(victim) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(got), "symlink target must not be written through")
+}

--- a/cmd/kata/init_hooks_test.go
+++ b/cmd/kata/init_hooks_test.go
@@ -175,6 +175,29 @@ func TestApplyClaudeHooks_RestoresExecutableBit(t *testing.T) {
 	assert.False(t, changed, "mode correction must stay idempotent")
 }
 
+// TestApplyClaudeHooks_RestoresOwnerExecuteBit covers a script that carries
+// group/other execute bits but not the owner's: Unix checks only the owner
+// class for the owning user, so the file is not actually runnable and the
+// mode must still be corrected.
+func TestApplyClaudeHooks_RestoresOwnerExecuteBit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no Unix execute bits on Windows")
+	}
+	dir := t.TempDir()
+	_, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+
+	scriptPath := filepath.Join(dir, ".claude", "hooks", "kata-attention.sh")
+	require.NoError(t, os.Chmod(scriptPath, 0o655)) //nolint:gosec // deliberately exec-for-group-only to exercise the owner-bit check
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed, "missing owner-execute bit is a change")
+	fi, err := os.Stat(scriptPath)
+	require.NoError(t, err)
+	assert.NotZero(t, fi.Mode()&0o100, "owner-execute bit must be restored")
+}
+
 // TestApplyClaudeHooks_DriftedScriptRegainsExecutableBit covers drifted
 // content on a non-executable file: os.WriteFile does not touch an existing
 // file's mode, so the rewrite must fix it explicitly.

--- a/cmd/kata/init_hooks_test.go
+++ b/cmd/kata/init_hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -266,6 +267,39 @@ func TestApplyClaudeHooks_RefusesSymlinkedHooksDir(t *testing.T) {
 	entries, err := os.ReadDir(outside)
 	require.NoError(t, err)
 	assert.Empty(t, entries, "nothing may be written through the symlinked dir")
+}
+
+// TestApplyClaudeHooks_MigratesStopWiringToSessionEnd covers upgrading a
+// workspace installed by an older kata that wired the sweep to the Stop
+// event (which fires every turn): the refresh must move kata's wiring to
+// SessionEnd and prune the obsolete Stop entry, without touching the user's
+// own Stop hooks.
+func TestApplyClaudeHooks_MigratesStopWiringToSessionEnd(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o750))
+	legacy := `{
+  "hooks": {
+    "Stop": [
+      {"hooks": [{"type": "command", "command": "notify.sh"}]},
+      {"hooks": [{"type": "command", "command": ` + strconv.Quote(claudeHookCommand("stop")) + `}]}
+    ]
+  }
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(legacy), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	settings := readSettings(t, dir)
+	assert.NotContains(t, hookCommands(t, settings, "Stop"), claudeHookCommand("stop"), "obsolete Stop wiring must be pruned")
+	assert.Contains(t, hookCommands(t, settings, "Stop"), "notify.sh", "user's own Stop hook must survive")
+	assert.Contains(t, hookCommands(t, settings, "SessionEnd"), claudeHookCommand("stop"))
+
+	changed, err = applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.False(t, changed, "migration must be idempotent")
 }
 
 // TestApplyClaudeHooks_NullSettingsRejected covers a settings.json holding

--- a/cmd/kata/init_hooks_test.go
+++ b/cmd/kata/init_hooks_test.go
@@ -235,6 +235,39 @@ func TestApplyClaudeHooks_MalformedSettingsLeftUntouched(t *testing.T) {
 	assert.Equal(t, malformed, string(got), "malformed settings must not be clobbered")
 }
 
+// TestApplyClaudeHooks_RefusesSymlinkedClaudeDir covers a hostile repo that
+// commits .claude itself as a symlink to an outside directory (e.g. the
+// user's global ~/.claude): following it would install hooks and rewrite
+// settings outside the workspace.
+func TestApplyClaudeHooks_RefusesSymlinkedClaudeDir(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, ".claude")))
+
+	_, err := applyClaudeHooks(dir)
+	require.Error(t, err)
+
+	entries, err := os.ReadDir(outside)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "nothing may be written through the symlinked dir")
+}
+
+// TestApplyClaudeHooks_RefusesSymlinkedHooksDir is the same attack one level
+// down: .claude is real but .claude/hooks points outside the workspace.
+func TestApplyClaudeHooks_RefusesSymlinkedHooksDir(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o750))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, ".claude", "hooks")))
+
+	_, err := applyClaudeHooks(dir)
+	require.Error(t, err)
+
+	entries, err := os.ReadDir(outside)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "nothing may be written through the symlinked dir")
+}
+
 func TestApplyClaudeHooks_RefusesSymlinkedSettings(t *testing.T) {
 	dir := t.TempDir()
 	claudeDir := filepath.Join(dir, ".claude")

--- a/cmd/kata/init_with_hooks_e2e_test.go
+++ b/cmd/kata/init_with_hooks_e2e_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+// These exercise `kata init --with-hooks` as a user would run it: the real CLI
+// command against a live daemon. They complement the focused unit tests in
+// init_hooks_test.go.
+
+// TestE2E_InitWithHooks_NewRepo installs the Claude Code attention hooks in a
+// fresh repo: the managed script and the settings.json wiring both appear.
+func TestE2E_InitWithHooks_NewRepo(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	out := runCLI(t, env, dir, "init", "--with-hooks")
+	assert.Contains(t, out, "project")
+
+	assert.FileExists(t, filepath.Join(dir, ".kata.toml"))
+	assert.FileExists(t, filepath.Join(dir, ".claude", "hooks", "kata-attention.sh"))
+
+	settings, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(settings), "kata-attention.sh claim")
+	assert.Contains(t, string(settings), "kata-attention.sh stop")
+
+	// --with-hooks does not drag in the guidance block.
+	assert.NoFileExists(t, filepath.Join(dir, "AGENTS.md"))
+}
+
+// TestE2E_InitWithHooks_ComposesWithAgents runs both flags together: guidance
+// block and hooks land in one init.
+func TestE2E_InitWithHooks_ComposesWithAgents(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	runCLI(t, env, dir, "init", "--with-agents", "--with-hooks")
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(content), agentsBlockBegin)
+	assert.FileExists(t, filepath.Join(dir, ".claude", "hooks", "kata-attention.sh"))
+}

--- a/cmd/kata/kata_attention_hook.sh
+++ b/cmd/kata/kata_attention_hook.sh
@@ -30,9 +30,14 @@ state_dir="${XDG_RUNTIME_DIR:-/tmp}/kata-attention"
 state_file="$state_dir/$session_id"
 
 # record_ref remembers a ref for the stop sweep and floors its signal at ok:
-# tracked work is visible from the moment it is grabbed.
+# tracked work is visible from the moment it is grabbed. Refs that don't
+# resolve to an open issue are ignored — work.attention on closed issues is
+# meaningless, and a grepped ref may simply be wrong.
 record_ref() {
-  local ref="$1"
+  local ref status
+  ref="$1"
+  status="$(kata show "$ref" --format json 2>/dev/null | jq -r '.issue.status // empty')"
+  [[ -n "$status" && "$status" != "closed" ]] || return 0
   mkdir -p "$state_dir"
   grep -qxF "$ref" "$state_file" 2>/dev/null || echo "$ref" >>"$state_file"
   kata meta set "$ref" work.attention ok >/dev/null 2>&1 || true

--- a/cmd/kata/kata_attention_hook.sh
+++ b/cmd/kata/kata_attention_hook.sh
@@ -73,28 +73,52 @@ claim)
     fi
   done <<<"$cmd"
   [[ -n "$seg" ]] || exit 0
+  # Quoted spans are flag values (--comment "fix the bug"), never refs:
+  # collapse each to a placeholder so multi-word values don't shed junk
+  # tokens, while still occupying their token slot for flag-value skipping.
+  # The placeholder starts non-alphanumeric, so it can never probe as a ref.
+  quote_re='("[^"]*"|'\''[^'\'']*'\'')'
+  while [[ "$seg" =~ $quote_re ]]; do
+    seg="${seg/"${BASH_REMATCH[1]}"/ _quoted_ }"
+  done
   # The command text alone doesn't prove the claim executed, succeeded, or
-  # even which token was the ref (a flag's value looks the same). The daemon
-  # is the oracle for both problems: try each plausible token and record the
-  # first one that is an open issue owned by this session's actor — flooring
-  # attention on someone else's issue is the harmful false positive. Tokens
-  # must start alphanumeric, which also keeps a crafted dash-leading token
-  # from ever reaching kata as a flag.
+  # even which token was the ref (a flag's value looks the same). Skip the
+  # values of claim's value-bearing flags, then let the daemon arbitrate the
+  # rest: probe each plausible token and record the first that is an open
+  # issue owned by the claim's effective actor — flooring attention on
+  # someone else's issue is the harmful false positive. Tokens must start
+  # alphanumeric, which also keeps a crafted dash-leading token from ever
+  # reaching kata as a flag.
   actor="$(kata whoami --format json 2>/dev/null | jq -r '.actor // empty')"
-  [[ -n "$actor" ]] || exit 0
+  value_flag_re='^--(comment|as|format|project|workspace|daemon)$'
   token_re='^[A-Za-z0-9][A-Za-z0-9#_-]*$'
   read -ra tokens <<<"$seg"
   tried=0
+  skip_next=0
+  as_actor=""
+  prev=""
   for tok in "${tokens[@]}"; do
-    tok="${tok#[\"\']}"
-    tok="${tok%[\"\']}"
+    if ((skip_next)); then
+      # `--as <handle>` overrides the claim's actor; ownership must be
+      # checked against it rather than the ambient identity.
+      [[ "$prev" == "--as" ]] && as_actor="$tok"
+      skip_next=0
+      continue
+    fi
+    if [[ "$tok" =~ $value_flag_re ]]; then
+      prev="$tok"
+      skip_next=1
+      continue
+    fi
+    [[ "$tok" == --as=* ]] && { as_actor="${tok#--as=}"; continue; }
+    [[ "$tok" == -* ]] && continue
     [[ "$tok" =~ $token_re ]] || continue
     ((tried++ >= 4)) && break # bound the daemon probes on noisy segments
     info="$(kata show "$tok" --format json 2>/dev/null)"
     status="$(issue_status "$info")"
     [[ -n "$status" && "$status" != "closed" ]] || continue
     owner="$(jq -r '.issue.owner // empty' <<<"$info")"
-    [[ "$owner" == "$actor" ]] || continue
+    [[ -n "$owner" && ("$owner" == "$actor" || "$owner" == "$as_actor") ]] || continue
     remember_ref "$tok"
     break
   done
@@ -114,7 +138,19 @@ stop)
     fi
     status="$(issue_status "$info")"
     [[ -n "$status" && "$status" != "closed" ]] || continue # attention on closed issues is meaningless
-    current="$(kata meta get "$ref" work.attention --format json 2>/dev/null | jq -r '.value // empty')"
+    meta_out="$(kata meta get "$ref" work.attention --format json 2>/dev/null)"
+    rc=$?
+    if ((rc != 0)); then
+      # kata exits 4 when the key is genuinely absent — nothing to escalate.
+      # Any other failure (daemon unreachable, etc.) is transient: retry
+      # later rather than assuming the signal was handled.
+      ((rc == 4)) || remaining+=("$ref")
+      continue
+    fi
+    if ! current="$(jq -r '.value // empty' <<<"$meta_out" 2>/dev/null)"; then
+      remaining+=("$ref") # undecodable response: retry rather than assume
+      continue
+    fi
     if [[ "$current" == "ok" ]]; then
       # The session ended while the issue still claimed to be fine: the
       # agent never handed off, so raise the flag a coordinator can see.

--- a/cmd/kata/kata_attention_hook.sh
+++ b/cmd/kata/kata_attention_hook.sh
@@ -51,9 +51,17 @@ start)
   ;;
 claim)
   cmd="$(jq -r '.tool_input.command // empty' <<<"$input")"
-  # Only react to claims that actually happened in this Bash call.
-  ref="$(grep -oP 'kata\s+claim\s+\K[A-Za-z0-9/_-]+' <<<"$cmd" | head -1)" || true
+  # Match `kata claim <ref>` only in command position (line start or after a
+  # separator), not the string merely appearing inside echoed/quoted text.
+  ref="$(grep -oP '(?:^|[;&|(])\s*kata\s+claim\s+(?:--\S+\s+)*\K[A-Za-z0-9#_-]+' <<<"$cmd" | head -1)" || true
   [[ -n "${ref:-}" ]] || exit 0
+  # The command text alone doesn't prove the claim executed or succeeded
+  # (failed claims, unexecuted conditionals). Verify it took: the issue must
+  # now be owned by this session's actor — flooring attention on someone
+  # else's issue is the harmful false positive.
+  actor="$(kata whoami --format json 2>/dev/null | jq -r '.actor // empty')"
+  owner="$(kata show "$ref" --format json 2>/dev/null | jq -r '.issue.owner // empty')"
+  [[ -n "$actor" && "$owner" == "$actor" ]] || exit 0
   record_ref "$ref"
   ;;
 stop)

--- a/cmd/kata/kata_attention_hook.sh
+++ b/cmd/kata/kata_attention_hook.sh
@@ -12,7 +12,7 @@
 # Wiring (.claude/settings.json):
 #   SessionStart       -> kata-attention.sh start   ($KATA_REF, when launched)
 #   PostToolUse [Bash] -> kata-attention.sh claim   (watch for `kata claim`)
-#   Stop               -> kata-attention.sh stop    (sweep: still ok -> needs-human)
+#   SessionEnd         -> kata-attention.sh stop   (sweep: still ok -> needs-human)
 #
 # Hook stdin is Claude Code's hook JSON; needs jq + kata on PATH.
 

--- a/cmd/kata/kata_attention_hook.sh
+++ b/cmd/kata/kata_attention_hook.sh
@@ -73,13 +73,22 @@ claim)
     fi
   done <<<"$cmd"
   [[ -n "$seg" ]] || exit 0
-  # Quoted spans are flag values (--comment "fix the bug"), never refs:
-  # collapse each to a placeholder so multi-word values don't shed junk
-  # tokens, while still occupying their token slot for flag-value skipping.
-  # The placeholder starts non-alphanumeric, so it can never probe as a ref.
+  # Unwrap quoted spans: a single-word span is a real argument (`kata claim
+  # "abc4"`, `--as "agent-a"`) and keeps its content; a multi-word span is
+  # prose (--comment "fix the bug") and collapses to a placeholder so it
+  # doesn't shed junk tokens, while still occupying its token slot for
+  # flag-value skipping. The placeholder starts non-alphanumeric, so it can
+  # never probe as a ref.
   quote_re='("[^"]*"|'\''[^'\'']*'\'')'
+  word_re='^[^[:space:]"'\'']+$'
   while [[ "$seg" =~ $quote_re ]]; do
-    seg="${seg/"${BASH_REMATCH[1]}"/ _quoted_ }"
+    span="${BASH_REMATCH[1]}"
+    inner="${span:1:${#span}-2}"
+    if [[ "$inner" =~ $word_re ]]; then
+      seg="${seg/"$span"/ $inner }"
+    else
+      seg="${seg/"$span"/ _quoted_ }"
+    fi
   done
   # The command text alone doesn't prove the claim executed, succeeded, or
   # even which token was the ref (a flag's value looks the same). Skip the
@@ -112,6 +121,12 @@ claim)
     fi
     [[ "$tok" == --as=* ]] && { as_actor="${tok#--as=}"; continue; }
     [[ "$tok" == -* ]] && continue
+    # A literal $KATA_REF the agent typed can be resolved from the hook's own
+    # environment when a launcher exported it.
+    # shellcheck disable=SC2016 # matching the literal text the agent typed
+    if [[ "$tok" == '$KATA_REF' || "$tok" == '${KATA_REF}' ]]; then
+      tok="${KATA_REF:-}"
+    fi
     [[ "$tok" =~ $token_re ]] || continue
     ((tried++ >= 4)) && break # bound the daemon probes on noisy segments
     info="$(kata show "$tok" --format json 2>/dev/null)"

--- a/cmd/kata/kata_attention_hook.sh
+++ b/cmd/kata/kata_attention_hook.sh
@@ -85,10 +85,18 @@ claim)
     span="${BASH_REMATCH[1]}"
     inner="${span:1:${#span}-2}"
     if [[ "$inner" =~ $word_re ]]; then
-      seg="${seg/"$span"/ $inner }"
+      repl=" $inner "
     else
-      seg="${seg/"$span"/ _quoted_ }"
+      repl=" _quoted_ "
     fi
+    # Rebuild around the span with anchored prefix/suffix expansions rather
+    # than ${seg/pattern/}: quoted-pattern substitution mis-handles
+    # backslashes and slashes on older bash (3.2 still ships on macOS). If
+    # the span somehow fails to anchor, bail rather than loop — a hung hook
+    # stalls the whole agent session.
+    prefix="${seg%%"$span"*}"
+    [[ "$prefix" != "$seg" ]] || break
+    seg="${prefix}${repl}${seg#*"$span"}"
   done
   # The command text alone doesn't prove the claim executed, succeeded, or
   # even which token was the ref (a flag's value looks the same). Skip the

--- a/cmd/kata/kata_attention_hook.sh
+++ b/cmd/kata/kata_attention_hook.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Keep kata work.attention truthful across an agent session. Managed by
+# `kata init --with-hooks`; local edits are overwritten on refresh. See
+# kata's docs/operations/agent-orchestration.md ("Keep attention truthful
+# with hooks") for the recipe this implements.
+#
+# Ref discovery: a launcher-run session knows its tracking issue up front
+# ($KATA_REF); a hand-started session doesn't, so the agent's own
+# `kata claim <ref>` is treated as the discovery event. Discovered refs
+# are remembered in a per-session state file for the stop-time sweep.
+#
+# Wiring (.claude/settings.json):
+#   SessionStart       -> kata-attention.sh start   ($KATA_REF, when launched)
+#   PostToolUse [Bash] -> kata-attention.sh claim   (watch for `kata claim`)
+#   Stop               -> kata-attention.sh stop    (sweep: still ok -> needs-human)
+#
+# Hook stdin is Claude Code's hook JSON; needs jq + kata on PATH.
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v kata >/dev/null 2>&1 || exit 0
+
+mode="${1:?usage: kata-attention.sh start|claim|stop}"
+input="$(cat)"
+
+session_id="$(jq -r '.session_id // empty' <<<"$input")"
+[[ -n "$session_id" ]] || exit 0
+state_dir="${XDG_RUNTIME_DIR:-/tmp}/kata-attention"
+state_file="$state_dir/$session_id"
+
+# record_ref remembers a ref for the stop sweep and floors its signal at ok:
+# tracked work is visible from the moment it is grabbed.
+record_ref() {
+  local ref="$1"
+  mkdir -p "$state_dir"
+  grep -qxF "$ref" "$state_file" 2>/dev/null || echo "$ref" >>"$state_file"
+  kata meta set "$ref" work.attention ok >/dev/null 2>&1 || true
+}
+
+case "$mode" in
+start)
+  # Launcher-run sessions pass the tracking issue in the environment.
+  [[ -n "${KATA_REF:-}" ]] || exit 0
+  record_ref "$KATA_REF"
+  ;;
+claim)
+  cmd="$(jq -r '.tool_input.command // empty' <<<"$input")"
+  # Only react to claims that actually happened in this Bash call.
+  ref="$(grep -oP 'kata\s+claim\s+\K[A-Za-z0-9/_-]+' <<<"$cmd" | head -1)" || true
+  [[ -n "${ref:-}" ]] || exit 0
+  record_ref "$ref"
+  ;;
+stop)
+  [[ -f "$state_file" ]] || exit 0
+  while IFS= read -r ref; do
+    [[ -n "$ref" ]] || continue
+    status="$(kata show "$ref" --format json 2>/dev/null | jq -r '.issue.status // empty')"
+    [[ -n "$status" && "$status" != "closed" ]] || continue # attention on closed issues is meaningless
+    current="$(kata meta get "$ref" work.attention --format json 2>/dev/null | jq -r '.value // empty')"
+    if [[ "$current" == "ok" ]]; then
+      # The session ended while the issue still claimed to be fine: the
+      # agent never handed off, so raise the flag a coordinator can see.
+      kata meta set "$ref" work.attention needs-human >/dev/null 2>&1 || true
+      kata meta set "$ref" work.attention_msg "session ended without hand-off" >/dev/null 2>&1 || true
+    fi
+  done <"$state_file"
+  ;;
+esac
+exit 0

--- a/cmd/kata/kata_attention_hook.sh
+++ b/cmd/kata/kata_attention_hook.sh
@@ -59,50 +59,79 @@ start)
   ;;
 claim)
   cmd="$(jq -r '.tool_input.command // empty' <<<"$input")"
-  # Match `kata claim <ref>` only in command position (line start or after a
+  # Match `kata claim ...` only in command position (line start or after a
   # separator), not the string merely appearing inside echoed/quoted text.
-  # Bash ERE, not `grep -P` — BSD grep on macOS has no -P. The ref's first
-  # character must be alphanumeric so a crafted token can't reach kata as a
-  # flag.
-  claim_re='(^|[;&|(])[[:space:]]*kata[[:space:]]+claim[[:space:]]+(--[^[:space:]]+[[:space:]]+)*([A-Za-z0-9][A-Za-z0-9#_-]*)'
-  ref=""
+  # Bash ERE, not `grep -P` — BSD grep on macOS has no -P. Capture the whole
+  # argument segment: the ref may sit before or after flags, including
+  # value-bearing ones (`kata claim --as agent-a abc4`).
+  seg=""
+  claim_re='(^|[;&|(])[[:space:]]*kata[[:space:]]+claim[[:space:]]+([^;&|)]+)'
   while IFS= read -r line; do
     if [[ "$line" =~ $claim_re ]]; then
-      ref="${BASH_REMATCH[3]}"
+      seg="${BASH_REMATCH[2]}"
       break
     fi
   done <<<"$cmd"
-  [[ -n "$ref" ]] || exit 0
-  # The command text alone doesn't prove the claim executed or succeeded
-  # (failed claims, unexecuted conditionals). Verify it took: the issue must
-  # be open and owned by this session's actor — flooring attention on
-  # someone else's issue is the harmful false positive. One `kata show`
-  # serves both checks.
-  info="$(kata show "$ref" --format json 2>/dev/null)"
-  status="$(issue_status "$info")"
-  [[ -n "$status" && "$status" != "closed" ]] || exit 0
+  [[ -n "$seg" ]] || exit 0
+  # The command text alone doesn't prove the claim executed, succeeded, or
+  # even which token was the ref (a flag's value looks the same). The daemon
+  # is the oracle for both problems: try each plausible token and record the
+  # first one that is an open issue owned by this session's actor — flooring
+  # attention on someone else's issue is the harmful false positive. Tokens
+  # must start alphanumeric, which also keeps a crafted dash-leading token
+  # from ever reaching kata as a flag.
   actor="$(kata whoami --format json 2>/dev/null | jq -r '.actor // empty')"
-  owner="$(jq -r '.issue.owner // empty' <<<"$info")"
-  [[ -n "$actor" && "$owner" == "$actor" ]] || exit 0
-  remember_ref "$ref"
+  [[ -n "$actor" ]] || exit 0
+  token_re='^[A-Za-z0-9][A-Za-z0-9#_-]*$'
+  read -ra tokens <<<"$seg"
+  tried=0
+  for tok in "${tokens[@]}"; do
+    tok="${tok#[\"\']}"
+    tok="${tok%[\"\']}"
+    [[ "$tok" =~ $token_re ]] || continue
+    ((tried++ >= 4)) && break # bound the daemon probes on noisy segments
+    info="$(kata show "$tok" --format json 2>/dev/null)"
+    status="$(issue_status "$info")"
+    [[ -n "$status" && "$status" != "closed" ]] || continue
+    owner="$(jq -r '.issue.owner // empty' <<<"$info")"
+    [[ "$owner" == "$actor" ]] || continue
+    remember_ref "$tok"
+    break
+  done
   ;;
 stop)
   [[ -f "$state_file" ]] || exit 0
+  # Refs whose daemon calls fail mid-sweep are carried over so a later
+  # stop/idle firing can retry; dropping them with the state file would
+  # leave a stale ok in place for good. Refs that resolve (closed, already
+  # escalated, or escalated now) are dropped.
+  remaining=()
   while IFS= read -r ref; do
     [[ -n "$ref" ]] || continue
-    status="$(issue_status "$(kata show "$ref" --format json 2>/dev/null)")"
+    if ! info="$(kata show "$ref" --format json 2>/dev/null)" || [[ -z "$info" ]]; then
+      remaining+=("$ref") # daemon unreachable or transient failure: retry
+      continue
+    fi
+    status="$(issue_status "$info")"
     [[ -n "$status" && "$status" != "closed" ]] || continue # attention on closed issues is meaningless
     current="$(kata meta get "$ref" work.attention --format json 2>/dev/null | jq -r '.value // empty')"
     if [[ "$current" == "ok" ]]; then
       # The session ended while the issue still claimed to be fine: the
       # agent never handed off, so raise the flag a coordinator can see.
-      kata meta set "$ref" work.attention needs-human >/dev/null 2>&1 || true
+      if ! kata meta set "$ref" work.attention needs-human >/dev/null 2>&1; then
+        remaining+=("$ref")
+        continue
+      fi
       kata meta set "$ref" work.attention_msg "session ended without hand-off" >/dev/null 2>&1 || true
     fi
   done <"$state_file"
-  # The sweep is terminal for the session; drop its state rather than
-  # accumulating orphaned files.
-  rm -f "$state_file"
+  if ((${#remaining[@]} > 0)); then
+    printf '%s\n' "${remaining[@]}" >"$state_file"
+  else
+    # The sweep fully resolved; drop the session state rather than
+    # accumulating orphaned files.
+    rm -f "$state_file"
+  fi
   ;;
 esac
 exit 0

--- a/cmd/kata/kata_attention_hook.sh
+++ b/cmd/kata/kata_attention_hook.sh
@@ -18,57 +18,79 @@
 
 set -u
 
-command -v jq >/dev/null 2>&1 || exit 0
-command -v kata >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || { echo "kata-attention: jq not on PATH; attention hook inactive" >&2; exit 0; }
+command -v kata >/dev/null 2>&1 || { echo "kata-attention: kata not on PATH; attention hook inactive" >&2; exit 0; }
 
 mode="${1:?usage: kata-attention.sh start|claim|stop}"
 input="$(cat)"
+[[ -n "$input" ]] || exit 0
 
 session_id="$(jq -r '.session_id // empty' <<<"$input")"
 [[ -n "$session_id" ]] || exit 0
-state_dir="${XDG_RUNTIME_DIR:-/tmp}/kata-attention"
+# Per-user state: XDG_RUNTIME_DIR is already private; the /tmp fallback is
+# uid-suffixed and chmod'd so users on a shared machine neither collide on
+# nor read each other's session refs.
+state_dir="${XDG_RUNTIME_DIR:-/tmp}/kata-attention-$(id -u)"
 state_file="$state_dir/$session_id"
 
-# record_ref remembers a ref for the stop sweep and floors its signal at ok:
-# tracked work is visible from the moment it is grabbed. Refs that don't
-# resolve to an open issue are ignored — work.attention on closed issues is
-# meaningless, and a grepped ref may simply be wrong.
-record_ref() {
-  local ref status
-  ref="$1"
-  status="$(kata show "$ref" --format json 2>/dev/null | jq -r '.issue.status // empty')"
-  [[ -n "$status" && "$status" != "closed" ]] || return 0
-  mkdir -p "$state_dir"
+# issue_status extracts .issue.status from a `kata show` JSON payload.
+issue_status() { jq -r '.issue.status // empty' <<<"$1"; }
+
+# remember_ref appends an already-validated ref to the session state file and
+# floors its signal at ok: tracked work is visible from the moment it is
+# grabbed. Callers validate first (open issue; for claims, ownership too).
+remember_ref() {
+  local ref="$1"
+  mkdir -p "$state_dir" 2>/dev/null && chmod 700 "$state_dir" 2>/dev/null || return 0
   grep -qxF "$ref" "$state_file" 2>/dev/null || echo "$ref" >>"$state_file"
   kata meta set "$ref" work.attention ok >/dev/null 2>&1 || true
 }
 
 case "$mode" in
 start)
-  # Launcher-run sessions pass the tracking issue in the environment.
-  [[ -n "${KATA_REF:-}" ]] || exit 0
-  record_ref "$KATA_REF"
+  # Launcher-run sessions pass the tracking issue in the environment. Refuse
+  # a dash-leading value — kata would parse it as a flag, not a ref.
+  ref="${KATA_REF:-}"
+  [[ -n "$ref" && "$ref" != -* ]] || exit 0
+  status="$(issue_status "$(kata show "$ref" --format json 2>/dev/null)")"
+  # work.attention on closed issues is meaningless.
+  [[ -n "$status" && "$status" != "closed" ]] || exit 0
+  remember_ref "$ref"
   ;;
 claim)
   cmd="$(jq -r '.tool_input.command // empty' <<<"$input")"
   # Match `kata claim <ref>` only in command position (line start or after a
   # separator), not the string merely appearing inside echoed/quoted text.
-  ref="$(grep -oP '(?:^|[;&|(])\s*kata\s+claim\s+(?:--\S+\s+)*\K[A-Za-z0-9#_-]+' <<<"$cmd" | head -1)" || true
-  [[ -n "${ref:-}" ]] || exit 0
+  # Bash ERE, not `grep -P` — BSD grep on macOS has no -P. The ref's first
+  # character must be alphanumeric so a crafted token can't reach kata as a
+  # flag.
+  claim_re='(^|[;&|(])[[:space:]]*kata[[:space:]]+claim[[:space:]]+(--[^[:space:]]+[[:space:]]+)*([A-Za-z0-9][A-Za-z0-9#_-]*)'
+  ref=""
+  while IFS= read -r line; do
+    if [[ "$line" =~ $claim_re ]]; then
+      ref="${BASH_REMATCH[3]}"
+      break
+    fi
+  done <<<"$cmd"
+  [[ -n "$ref" ]] || exit 0
   # The command text alone doesn't prove the claim executed or succeeded
   # (failed claims, unexecuted conditionals). Verify it took: the issue must
-  # now be owned by this session's actor — flooring attention on someone
-  # else's issue is the harmful false positive.
+  # be open and owned by this session's actor — flooring attention on
+  # someone else's issue is the harmful false positive. One `kata show`
+  # serves both checks.
+  info="$(kata show "$ref" --format json 2>/dev/null)"
+  status="$(issue_status "$info")"
+  [[ -n "$status" && "$status" != "closed" ]] || exit 0
   actor="$(kata whoami --format json 2>/dev/null | jq -r '.actor // empty')"
-  owner="$(kata show "$ref" --format json 2>/dev/null | jq -r '.issue.owner // empty')"
+  owner="$(jq -r '.issue.owner // empty' <<<"$info")"
   [[ -n "$actor" && "$owner" == "$actor" ]] || exit 0
-  record_ref "$ref"
+  remember_ref "$ref"
   ;;
 stop)
   [[ -f "$state_file" ]] || exit 0
   while IFS= read -r ref; do
     [[ -n "$ref" ]] || continue
-    status="$(kata show "$ref" --format json 2>/dev/null | jq -r '.issue.status // empty')"
+    status="$(issue_status "$(kata show "$ref" --format json 2>/dev/null)")"
     [[ -n "$status" && "$status" != "closed" ]] || continue # attention on closed issues is meaningless
     current="$(kata meta get "$ref" work.attention --format json 2>/dev/null | jq -r '.value // empty')"
     if [[ "$current" == "ok" ]]; then
@@ -78,6 +100,9 @@ stop)
       kata meta set "$ref" work.attention_msg "session ended without hand-off" >/dev/null 2>&1 || true
     fi
   done <"$state_file"
+  # The sweep is terminal for the session; drop its state rather than
+  # accumulating orphaned files.
+  rm -f "$state_file"
   ;;
 esac
 exit 0

--- a/docs/operations/agent-orchestration.md
+++ b/docs/operations/agent-orchestration.md
@@ -111,6 +111,15 @@ truthful terminal signal, self-assertion is the finer-grained live signal. Both
 write the same two keys, and because attention is last-write-wins by design,
 whichever fired most recently is the state coordinators see.
 
+For Claude Code workspaces, `kata init --with-hooks` installs this wiring
+directly: a managed hook script under `.claude/hooks/` plus the
+`.claude/settings.json` entries that run it at session start (honoring
+`$KATA_REF` when a launcher passes one), after each shell tool call (treating
+the agent's own `kata claim <ref>` as ref discovery for hand-started sessions),
+and at session stop (the sweep that raises `needs-human` on refs still sitting
+at `ok`). Re-running the command refreshes the script and leaves the rest of
+`settings.json` untouched.
+
 ## Coordinate: wait and dashboards
 
 A delegating **coordinator** joins on sub-tasks with `kata wait`. Launch two

--- a/docs/operations/agent-orchestration.md
+++ b/docs/operations/agent-orchestration.md
@@ -116,7 +116,7 @@ directly: a managed hook script under `.claude/hooks/` plus the
 `.claude/settings.json` entries that run it at session start (honoring
 `$KATA_REF` when a launcher passes one), after each shell tool call (treating
 the agent's own `kata claim <ref>` as ref discovery for hand-started sessions),
-and at session stop (the sweep that raises `needs-human` on refs still sitting
+and at session end (the sweep that raises `needs-human` on refs still sitting
 at `ok`). Re-running the command refreshes the script and leaves the rest of
 `settings.json` untouched.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,7 +19,7 @@ current flag list in your installed binary.
 ## Workspace initialization
 
 ```sh
-kata init [--project <name>] [--with-agents]
+kata init [--project <name>] [--with-agents] [--with-hooks]
 kata init [--replace | --reassign]
 ```
 
@@ -41,6 +41,15 @@ added. Review the sidecar before replacing the original.
 
 A symlinked `AGENTS.md` is refused before it is read; replace it with a regular
 file before using `--with-agents`.
+
+Pass `--with-hooks` to install the `work.attention` harness hooks from the
+[agent orchestration recipe](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
+into the workspace's Claude Code config: a managed script at
+`.claude/hooks/kata-attention.sh` plus the `.claude/settings.json` wiring that
+runs it at session start, after shell tool calls, and at session stop. The
+merge is additive — everything else in `settings.json` is preserved — and
+re-running refreshes only kata's managed pieces. Symlinked targets are refused,
+matching `--with-agents`.
 
 ## Issue lifecycle
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,7 +46,7 @@ Pass `--with-hooks` to install the `work.attention` harness hooks from the
 [agent orchestration recipe](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
 into the workspace's Claude Code config: a managed script at
 `.claude/hooks/kata-attention.sh` plus the `.claude/settings.json` wiring that
-runs it at session start, after shell tool calls, and at session stop. The
+runs it at session start, after shell tool calls, and at session end. The
 merge is additive — everything else in `settings.json` is preserved — and
 re-running refreshes only kata's managed pieces. Symlinked targets are refused,
 matching `--with-agents`.

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -32,6 +32,13 @@ and writes a `<file>.kata-proposed` sidecar to adopt or discard — see
 `AGENTS.md` is a symlink, kata refuses to manage it before reading the target;
 replace it with a regular file before using `--with-agents`.
 
+Guidance files produce tendency, not contract: an agent can still end a session
+without updating its issue. For Claude Code workspaces,
+`kata init --with-hooks` additionally installs the
+[attention harness hooks](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
+that keep the `work.attention` signal truthful even when the agent says
+nothing.
+
 ## Search before creating
 
 ```sh


### PR DESCRIPTION
Implements the installer proposed in #162: `kata init --with-hooks` writes the attention-hook wiring from `docs/operations/agent-orchestration.md` ("Keep attention truthful with hooks") into a Claude Code workspace, so the reliability floor no longer depends on hand-wiring.

What it installs:

- A managed script at `.claude/hooks/kata-attention.sh` (embedded in the binary, refreshed on drift). Three modes:
  - `start` (SessionStart) — honors `$KATA_REF` from a launcher and floors that issue to `work.attention ok`;
  - `claim` (PostToolUse, Bash matcher) — answers the ref-discovery question for hand-started sessions by treating the agent's own `kata claim <ref>` as the discovery event, recording refs in a per-session state file;
  - `stop` (Stop) — sweeps recorded refs still sitting at `ok` up to `needs-human` / "session ended without hand-off".
- Additive `.claude/settings.json` wiring for those three events. The merge preserves everything else in the file (unknown keys, existing hooks), is idempotent across re-runs, reports rather than clobbers a malformed file, and refuses symlinked targets — matching the `--with-agents` posture. `--with-hooks` and `--with-agents` compose in one init.

On the open design questions in #162: ref discovery is start-env + claim-watch as above; the surface is the sibling-flag option (`kata init --with-hooks`), idempotent alongside the managed guidance block; harness scope is Claude Code first, with the script body kept to the generic shell shape so other harnesses can reuse it.

Beyond unit/e2e coverage, the script was exercised against a live daemon on a seeded scratch board: launcher start, claim discovery, non-claim commands ignored, stop sweep raising `needs-human`, closed/unknown refs skipped end-to-end (that dry-run caught — and this PR guards — the claim-time floor writing onto a closed issue), mid-session `stuck` self-assertion surviving the sweep, and repeat-stop idempotency.

---

**Gated on #174.** Review found the repo-committed hook script is a code-execution vector (approval covers the settings.json command string, not the script content it points at). #174 reworks this installer to embed the hook logic in the kata binary; this PR is draft until that lands or the maintainer prefers them folded together.
