### PR TITLE
Extend the init --with-agents managed block with work.* conventions

### DIFF
--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -598,7 +598,19 @@ const agentsBlockBody = "## kata issue tracker\n\n" +
 	"- Default to `--agent` for ordinary reads and mutations; use `--json` only when a script needs structured data.\n" +
 	"- Close only verified work: `kata close <ref> --done --message \"<scope + verification>\" --commit <sha>`.\n" +
 	"- If work is incomplete, label `needs-review` and comment what remains rather than closing.\n" +
-	"- Never `kata delete` or `kata purge` without explicit user authorization.\n"
+	"- Never `kata delete` or `kata purge` without explicit user authorization.\n\n" +
+	"## kata work.* conventions (agent orchestration)\n\n" +
+	"When working a kata-tracked issue, keep its `work.*` metadata truthful\n" +
+	"(see docs/operations/agent-orchestration.md for the full recipe):\n\n" +
+	"- On claim/start: `kata meta set <ref> work.attention ok`; if the work has a\n" +
+	"  dedicated branch, stamp it once with `kata meta set <ref> work.branch <branch>`.\n" +
+	"- Signal live state: `kata meta set <ref> work.attention stuck|needs-human|ok`\n" +
+	"  plus a one-line `work.attention_msg` saying why. Raise `stuck` when you cannot\n" +
+	"  proceed, `needs-human` when you want review; clear back to `ok` when unblocked.\n" +
+	"- Never stop with the signal stale: close the issue, or leave the attention\n" +
+	"  pair reflecting the hand-off.\n" +
+	"- Coordinators read `work.*` on issues they delegated; only the working agent\n" +
+	"  writes them. `work.*` on closed issues is meaningless.\n"
 
 // agentsManagedBlock returns the full marker-delimited block kata writes.
 func agentsManagedBlock() string {

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -582,6 +582,79 @@ func TestInit_WithAgents_RefreshesStaleBlock(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(string(content), agentsBlockBegin))
 }
 
+// TestInit_WithAgents_BlockIncludesWorkConventions pins the work.* conventions
+// section kata appends to its managed block, so an agent working a kata-tracked
+// issue finds the attention-signal recipe without leaving the guidance file.
+func TestInit_WithAgents_BlockIncludesWorkConventions(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	got := string(content)
+	assert.Contains(t, got, "## kata work.* conventions")
+	assert.Contains(t, got, "kata meta set <ref> work.attention ok")
+	assert.Contains(t, got, "work.attention_msg")
+	assert.Contains(t, got, "docs/operations/agent-orchestration.md")
+}
+
+// oldAgentsBlockBody is the managed-block body kata shipped before the work.*
+// conventions section was added. A repo initialized with an older kata carries
+// this verbatim between the markers; re-running --with-agents must upgrade it in
+// place. Kept as a literal so the refresh test does not tautologically rebuild
+// the current body.
+const oldAgentsBlockBody = "## kata issue tracker\n\n" +
+	"This project uses [kata](https://github.com/kenn-io/kata) as its shared issue\n" +
+	"ledger. Run `kata quickstart` at the start of each session for the full agent\n" +
+	"contract. The short version:\n\n" +
+	"- Search before creating: `kata search \"<keywords>\" --agent`.\n" +
+	"- Prefer updating existing issues over duplicates (`kata comment`, `kata label add`, `kata edit`).\n" +
+	"- Default to `--agent` for ordinary reads and mutations; use `--json` only when a script needs structured data.\n" +
+	"- Close only verified work: `kata close <ref> --done --message \"<scope + verification>\" --commit <sha>`.\n" +
+	"- If work is incomplete, label `needs-review` and comment what remains rather than closing.\n" +
+	"- Never `kata delete` or `kata purge` without explicit user authorization.\n"
+
+// TestInit_WithAgents_RefreshesPreWorkConventionsBlock is the upgrade path for a
+// repo that ran init before the work.* section existed: the file already carries
+// the marker-delimited block with the older body, and re-running --with-agents
+// must add the work.* section while leaving content outside the markers intact.
+func TestInit_WithAgents_RefreshesPreWorkConventionsBlock(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
+
+	stale := agentsBlockBegin + "\n" + oldAgentsBlockBody + agentsBlockEnd + "\n"
+	fixture := "# House rules\n\nKeep this line.\n\n" + stale + "\n## Trailing section\n\nAlso keep this.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), //nolint:gosec // test fixture under TempDir
+		[]byte(fixture), 0o644))
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	got := string(content)
+	assert.Contains(t, got, "## kata work.* conventions", "refresh must add the work.* section to an older block")
+	assert.Contains(t, got, "kata meta set <ref> work.attention ok")
+	assert.Contains(t, got, "# House rules", "content before the markers must survive")
+	assert.Contains(t, got, "Keep this line.")
+	assert.Contains(t, got, "## Trailing section", "content after the markers must survive")
+	assert.Contains(t, got, "Also keep this.")
+	assert.Equal(t, 1, strings.Count(got, agentsBlockBegin))
+}
+
 // beadsFixtureBlock is a stand-in for the integration block Beads writes into
 // AGENTS.md/CLAUDE.md. kata matches on the begin-marker prefix and the end
 // marker, so the trailing version/profile/hash here is representative.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,9 +30,11 @@ deriving it from the git remote.
 Pass `--with-agents` to add or refresh kata's marker-delimited guidance block
 where coding agents look for workspace instructions. Existing real `AGENTS.md`
 and `CLAUDE.md` files are both refreshed; if neither exists, kata creates
-`AGENTS.md`. The block points coding agents at `kata quickstart` and the close
-discipline; re-running the command updates only kata's block and leaves other
-content untouched.
+`AGENTS.md`. The block points coding agents at `kata quickstart`, the close
+discipline, and the `work.*` attention conventions (see
+[agent orchestration](../operations/agent-orchestration.md)); re-running the
+command updates only kata's block and leaves other content untouched, so a
+repo initialized before the `work.*` section shipped gains it on the next run.
 
 When migrating from Beads, an existing `AGENTS.md` or real `CLAUDE.md` may still
 carry a Beads integration block. kata leaves that file untouched and writes a

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -25,8 +25,12 @@ Default to `--agent` for ordinary reads and mutations in agent logs. Use
 To make a workspace self-documenting for agents, run `kata init --with-agents`
 once. It writes a marker-delimited kata briefing into existing real `AGENTS.md`
 and `CLAUDE.md` files, or creates `AGENTS.md` when neither exists. The block
-points back at `kata quickstart`; re-running refreshes only kata's block. If a
-target file still carries a Beads integration block, kata leaves it untouched
+points back at `kata quickstart` and carries a short `work.*` attention
+conventions section (see
+[agent orchestration](../operations/agent-orchestration.md)); re-running
+refreshes only kata's block, so a repo initialized before that section shipped
+gains it on the next run. If a target file still carries a Beads integration
+block, kata leaves it untouched
 and writes a `<file>.kata-proposed` sidecar to adopt or discard — see
 [`--with-agents`](../get-started/quickstart.md#initialize-a-workspace). If
 `AGENTS.md` is a symlink, kata refuses to manage it before reading the target;


### PR DESCRIPTION
The managed `<!-- BEGIN KATA … END KATA -->` block that `kata init --with-agents` writes covered ledger hygiene only. This adds a short, reference-grade `work.*` conventions section — claim/start marks `work.attention ok`, branch stamping, live stuck/needs-human signaling, and the never-stop-stale rule — pointing at `docs/operations/agent-orchestration.md` for the full recipe. No workflow mandates, and nothing outside the markers is touched.

Refresh path for repos initialized before this shipped: re-running `kata init --with-agents` already rewrites a drifted block in place via the existing upsert, so older repos gain the section on their next run. That upgrade is now pinned by a test seeding the previous block body verbatim (kept as a literal so the test can't tautologically rebuild the current body) between out-of-marker sections and asserting the refresh adds the work.* section while preserving everything around it.

Docs for `--with-agents` updated accordingly. Complements #171 (the copy-paste adoption section this block condenses) and #172 (the hook installer for the same conventions); textual overlap with #172 in `init.go`/docs is minor if they land in either order.