### PR TITLE
Move the attention hook into the kata binary

### DIFF
--- a/cmd/kata/attention_hook.go
+++ b/cmd/kata/attention_hook.go
@@ -23,6 +23,7 @@ const (
 	attnValueOK         = "ok"
 	attnValueNeedsHuman = "needs-human"
 	attnHandoffMsg      = "session ended without hand-off"
+	attnWriteAttempts   = 2
 )
 
 func newAttentionHookCmd() *cobra.Command {
@@ -82,8 +83,16 @@ type attnLookup struct {
 
 type attnDaemon interface {
 	lookup(ref string) attnLookup
-	setMetaIfRevision(ref string, patch map[string]string, revision int64) bool
+	setMetaIfRevision(ref string, patch map[string]string, revision int64) attnWriteResult
 }
+
+type attnWriteResult uint8
+
+const (
+	attnWriteFailed attnWriteResult = iota
+	attnWriteApplied
+	attnWriteConflict
+)
 
 func attentionRef(kataRef string) (string, bool) {
 	ref := strings.TrimSpace(kataRef)
@@ -97,9 +106,14 @@ func attnStart(d attnDaemon, kataRef string) {
 	if !ok {
 		return
 	}
-	lookup := d.lookup(ref)
-	if lookup.kind == lookupOpen {
-		d.setMetaIfRevision(ref, map[string]string{attentionKey: attnValueOK}, lookup.revision)
+	for range attnWriteAttempts {
+		lookup := d.lookup(ref)
+		if lookup.kind != lookupOpen {
+			return
+		}
+		if d.setMetaIfRevision(ref, map[string]string{attentionKey: attnValueOK}, lookup.revision) != attnWriteConflict {
+			return
+		}
 	}
 }
 
@@ -111,14 +125,18 @@ func attnEnd(d attnDaemon, kataRef string) {
 	if !ok {
 		return
 	}
-	lookup := d.lookup(ref)
-	if lookup.kind != lookupOpen || !lookup.hasAttn || lookup.attention != attnValueOK {
-		return
+	for range attnWriteAttempts {
+		lookup := d.lookup(ref)
+		if lookup.kind != lookupOpen || !lookup.hasAttn || lookup.attention != attnValueOK {
+			return
+		}
+		if d.setMetaIfRevision(ref, map[string]string{
+			attentionKey:    attnValueNeedsHuman,
+			attentionMsgKey: attnHandoffMsg,
+		}, lookup.revision) != attnWriteConflict {
+			return
+		}
 	}
-	d.setMetaIfRevision(ref, map[string]string{
-		attentionKey:    attnValueNeedsHuman,
-		attentionMsgKey: attnHandoffMsg,
-	}, lookup.revision)
 }
 
 // liveAttnDaemon resolves refs and reads/writes metadata through the running
@@ -171,21 +189,21 @@ func (l *liveAttnDaemon) lookup(ref string) attnLookup {
 	return lookup
 }
 
-func (l *liveAttnDaemon) setMetaIfRevision(ref string, patch map[string]string, revision int64) bool {
+func (l *liveAttnDaemon) setMetaIfRevision(ref string, patch map[string]string, revision int64) attnWriteResult {
 	ctx, baseURL, pid, resolved, err := resolveIssueRefForCommand(l.cmd, ref)
 	if err != nil {
-		return false
+		return attnWriteFailed
 	}
 	client, err := httpClientFor(ctx, baseURL)
 	if err != nil {
-		return false
+		return attnWriteFailed
 	}
 	actor, _ := resolveActor(ctx, flags.As, nil)
 	rawPatch := make(map[string]json.RawMessage, len(patch))
 	for key, value := range patch {
 		valueJSON, err := json.Marshal(value)
 		if err != nil {
-			return false
+			return attnWriteFailed
 		}
 		rawPatch[key] = json.RawMessage(valueJSON)
 	}
@@ -195,5 +213,14 @@ func (l *liveAttnDaemon) setMetaIfRevision(ref string, patch map[string]string, 
 			"actor": actor,
 			"patch": rawPatch,
 		}, map[string]string{"If-Match": fmt.Sprintf(`"rev-%d"`, revision)})
-	return err == nil && status < http.StatusBadRequest
+	if err != nil {
+		return attnWriteFailed
+	}
+	if status == http.StatusPreconditionFailed {
+		return attnWriteConflict
+	}
+	if status >= http.StatusBadRequest {
+		return attnWriteFailed
+	}
+	return attnWriteApplied
 }

--- a/cmd/kata/attention_hook.go
+++ b/cmd/kata/attention_hook.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// `kata attention-hook <start|end>` is launcher-only lifecycle plumbing for
+// the work.attention convention. The launcher supplies the tracked issue in
+// KATA_REF for both hooks. No session payload or local state is involved.
+//
+// Hooks must never break the harness: every mode exits zero and silently
+// ignores invalid refs, unavailable daemons, stale revisions, and other
+// internal failures.
+
+const (
+	attnValueOK         = "ok"
+	attnValueNeedsHuman = "needs-human"
+	attnHandoffMsg      = "session ended without hand-off"
+)
+
+func newAttentionHookCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:                "attention-hook <start|end>",
+		Short:              "launcher attention lifecycle plumbing (installed by kata init --with-hooks)",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Treat every malformed invocation as a silent no-op. In particular,
+			// dash-leading args must not reach Cobra's non-zero flag-error path.
+			if len(args) != 1 {
+				return nil
+			}
+			runAttentionHook(cmd, args[0])
+			return nil
+		},
+	}
+}
+
+func runAttentionHook(cmd *cobra.Command, mode string) {
+	if mode != "start" && mode != "end" {
+		return
+	}
+
+	// Claude Code exposes the workspace it launched from even when hook cwd
+	// differs. Prefer it as the normal project-resolution anchor when present.
+	if projectDir := strings.TrimSpace(os.Getenv("CLAUDE_PROJECT_DIR")); projectDir != "" {
+		previous := flags.Workspace
+		flags.Workspace = projectDir
+		defer func() { flags.Workspace = previous }()
+	}
+
+	d := &liveAttnDaemon{cmd: cmd}
+	switch mode {
+	case "start":
+		attnStart(d, os.Getenv("KATA_REF"))
+	case "end":
+		attnEnd(d, os.Getenv("KATA_REF"))
+	}
+}
+
+type attnLookupKind uint8
+
+const (
+	lookupTransient attnLookupKind = iota
+	lookupGone
+	lookupOpen
+)
+
+type attnLookup struct {
+	kind      attnLookupKind
+	attention string
+	hasAttn   bool
+	revision  int64
+}
+
+type attnDaemon interface {
+	lookup(ref string) attnLookup
+	setMetaIfRevision(ref string, patch map[string]string, revision int64) bool
+}
+
+func attentionRef(kataRef string) (string, bool) {
+	ref := strings.TrimSpace(kataRef)
+	return ref, ref != "" && !strings.HasPrefix(ref, "-")
+}
+
+// attnStart establishes the launcher's active-session baseline. It mutates
+// only work.attention and only if the open lookup revision is still current.
+func attnStart(d attnDaemon, kataRef string) {
+	ref, ok := attentionRef(kataRef)
+	if !ok {
+		return
+	}
+	lookup := d.lookup(ref)
+	if lookup.kind == lookupOpen {
+		d.setMetaIfRevision(ref, map[string]string{attentionKey: attnValueOK}, lookup.revision)
+	}
+}
+
+// attnEnd escalates an issue only when the lookup snapshot is open and its
+// work.attention value is exactly ok. If-Match makes the two-key hand-off
+// patch atomic with respect to any concurrent metadata change.
+func attnEnd(d attnDaemon, kataRef string) {
+	ref, ok := attentionRef(kataRef)
+	if !ok {
+		return
+	}
+	lookup := d.lookup(ref)
+	if lookup.kind != lookupOpen || !lookup.hasAttn || lookup.attention != attnValueOK {
+		return
+	}
+	d.setMetaIfRevision(ref, map[string]string{
+		attentionKey:    attnValueNeedsHuman,
+		attentionMsgKey: attnHandoffMsg,
+	}, lookup.revision)
+}
+
+// liveAttnDaemon resolves refs and reads/writes metadata through the running
+// daemon using the same workspace/project routing as ordinary CLI commands.
+type liveAttnDaemon struct {
+	cmd *cobra.Command
+}
+
+func (l *liveAttnDaemon) lookup(ref string) attnLookup {
+	ctx, baseURL, pid, resolved, err := resolveIssueRefForCommand(l.cmd, ref)
+	if err != nil {
+		return attnLookup{kind: lookupTransient}
+	}
+	client, err := httpClientFor(ctx, baseURL)
+	if err != nil {
+		return attnLookup{kind: lookupTransient}
+	}
+	status, body, err := httpDoJSON(ctx, client, http.MethodGet,
+		fmt.Sprintf("%s/api/v1/projects/%d/issues/%s", baseURL, pid, url.PathEscape(resolved.RefForAPI)), nil)
+	if err != nil {
+		return attnLookup{kind: lookupTransient}
+	}
+	if status == http.StatusNotFound {
+		return attnLookup{kind: lookupGone}
+	}
+	if status >= http.StatusBadRequest {
+		return attnLookup{kind: lookupTransient}
+	}
+	var response struct {
+		Issue struct {
+			Status   string                     `json:"status"`
+			Metadata map[string]json.RawMessage `json:"metadata"`
+			Revision int64                      `json:"revision"`
+		} `json:"issue"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return attnLookup{kind: lookupTransient}
+	}
+	if response.Issue.Status != "open" {
+		return attnLookup{kind: lookupGone}
+	}
+	if response.Issue.Revision <= 0 {
+		return attnLookup{kind: lookupTransient}
+	}
+	lookup := attnLookup{kind: lookupOpen, revision: response.Issue.Revision}
+	if raw, ok := response.Issue.Metadata[attentionKey]; ok {
+		lookup.hasAttn = true
+		_ = json.Unmarshal(raw, &lookup.attention)
+	}
+	return lookup
+}
+
+func (l *liveAttnDaemon) setMetaIfRevision(ref string, patch map[string]string, revision int64) bool {
+	ctx, baseURL, pid, resolved, err := resolveIssueRefForCommand(l.cmd, ref)
+	if err != nil {
+		return false
+	}
+	client, err := httpClientFor(ctx, baseURL)
+	if err != nil {
+		return false
+	}
+	actor, _ := resolveActor(ctx, flags.As, nil)
+	rawPatch := make(map[string]json.RawMessage, len(patch))
+	for key, value := range patch {
+		valueJSON, err := json.Marshal(value)
+		if err != nil {
+			return false
+		}
+		rawPatch[key] = json.RawMessage(valueJSON)
+	}
+	status, _, err := httpDoJSONHeaders(ctx, client, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/projects/%d/issues/%s/metadata", baseURL, pid, url.PathEscape(resolved.RefForAPI)),
+		map[string]any{
+			"actor": actor,
+			"patch": rawPatch,
+		}, map[string]string{"If-Match": fmt.Sprintf(`"rev-%d"`, revision)})
+	return err == nil && status < http.StatusBadRequest
+}

--- a/cmd/kata/attention_hook_e2e_test.go
+++ b/cmd/kata/attention_hook_e2e_test.go
@@ -113,11 +113,11 @@ func TestE2E_AttentionHook_ConditionalEndRejectsConcurrentChange(t *testing.T) {
 	// A deliberate hand-off after lookup advances the revision. The stale
 	// If-Match must reject the hook patch and preserve the newer value.
 	runCLI(t, env, dir, "meta", "set", ref, attentionKey, "stuck")
-	ok := d.setMetaIfRevision(ref, map[string]string{
+	result := d.setMetaIfRevision(ref, map[string]string{
 		attentionKey:    attnValueNeedsHuman,
 		attentionMsgKey: attnHandoffMsg,
 	}, lookup.revision)
-	assert.False(t, ok)
+	assert.Equal(t, attnWriteConflict, result)
 
 	value, exists := attnMetaValue(t, env, pid, ref, attentionKey)
 	require.True(t, exists)

--- a/cmd/kata/attention_hook_e2e_test.go
+++ b/cmd/kata/attention_hook_e2e_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+// runAttnHook runs the real hidden command against env's live daemon. The
+// launcher project directory, rather than hook stdin or process cwd, anchors
+// normal workspace/project resolution.
+func runAttnHook(t *testing.T, env *testenv.Env, dir string, args ...string) error {
+	t.Helper()
+	resetFlags(t)
+	t.Setenv("CLAUDE_PROJECT_DIR", dir)
+	cmd := newRootCmd()
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetArgs(args)
+	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
+	return cmd.Execute()
+}
+
+func attnMetaValue(t *testing.T, env *testenv.Env, pid int64, ref, key string) (string, bool) {
+	t.Helper()
+	type resp struct {
+		Issue struct {
+			Metadata map[string]json.RawMessage `json:"metadata"`
+		} `json:"issue"`
+	}
+	got := getJSON[resp](t, env.URL+"/api/v1/projects/"+itoa(pid)+"/issues/"+ref)
+	raw, ok := got.Issue.Metadata[key]
+	if !ok {
+		return "", false
+	}
+	var value string
+	require.NoError(t, json.Unmarshal(raw, &value))
+	return value, true
+}
+
+func TestE2E_AttentionHook_StartSetsOnlyAttentionFromKataRef(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "launcher-tracked work")
+	runCLI(t, env, dir, "meta", "set", ref, attentionMsgKey, "existing context")
+	t.Setenv("KATA_REF", ref)
+
+	require.NoError(t, runAttnHook(t, env, dir, "attention-hook", "start"))
+
+	value, ok := attnMetaValue(t, env, pid, ref, attentionKey)
+	require.True(t, ok)
+	assert.Equal(t, attnValueOK, value)
+	message, ok := attnMetaValue(t, env, pid, ref, attentionMsgKey)
+	require.True(t, ok)
+	assert.Equal(t, "existing context", message)
+}
+
+func TestE2E_AttentionHook_EndEscalatesDirectlyFromKataRefWithoutState(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "unhanded-off work")
+	runCLI(t, env, dir, "meta", "set", ref, attentionKey, attnValueOK)
+	t.Setenv("KATA_REF", ref)
+
+	// SessionEnd needs only the launcher-provided ref: stdin is empty and no
+	// session state is created or consulted.
+	require.NoError(t, runAttnHook(t, env, dir, "attention-hook", "end"))
+
+	value, ok := attnMetaValue(t, env, pid, ref, attentionKey)
+	require.True(t, ok)
+	assert.Equal(t, attnValueNeedsHuman, value)
+	message, ok := attnMetaValue(t, env, pid, ref, attentionMsgKey)
+	require.True(t, ok)
+	assert.Equal(t, attnHandoffMsg, message)
+}
+
+func TestE2E_AttentionHook_EndSkipsClosedIssue(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "closed before session end")
+	runCLI(t, env, dir, "meta", "set", ref, attentionKey, attnValueOK)
+	runCLIAs(t, env, dir, "agent-a", "close", ref, "--done", "--message",
+		"closing this issue before the session-end attention hook runs",
+		"--commit", "deadbeef")
+	t.Setenv("KATA_REF", ref)
+
+	require.NoError(t, runAttnHook(t, env, dir, "attention-hook", "end"))
+
+	value, ok := attnMetaValue(t, env, pid, ref, attentionKey)
+	require.True(t, ok)
+	assert.Equal(t, attnValueOK, value)
+	_, ok = attnMetaValue(t, env, pid, ref, attentionMsgKey)
+	assert.False(t, ok)
+}
+
+func TestE2E_AttentionHook_ConditionalEndRejectsConcurrentChange(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "concurrent hand-off")
+	runCLI(t, env, dir, "meta", "set", ref, attentionKey, attnValueOK)
+
+	resetFlags(t)
+	cmd := newRootCmd()
+	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
+	flags.Workspace = dir
+	d := &liveAttnDaemon{cmd: cmd}
+	lookup := d.lookup(ref)
+	require.Equal(t, lookupOpen, lookup.kind)
+
+	// A deliberate hand-off after lookup advances the revision. The stale
+	// If-Match must reject the hook patch and preserve the newer value.
+	runCLI(t, env, dir, "meta", "set", ref, attentionKey, "stuck")
+	ok := d.setMetaIfRevision(ref, map[string]string{
+		attentionKey:    attnValueNeedsHuman,
+		attentionMsgKey: attnHandoffMsg,
+	}, lookup.revision)
+	assert.False(t, ok)
+
+	value, exists := attnMetaValue(t, env, pid, ref, attentionKey)
+	require.True(t, exists)
+	assert.Equal(t, "stuck", value)
+}

--- a/cmd/kata/attention_hook_unit_test.go
+++ b/cmd/kata/attention_hook_unit_test.go
@@ -16,9 +16,10 @@ import (
 
 type fakeAttnDaemon struct {
 	lookups            map[string]attnLookup
+	lookupSequence     []attnLookup
 	lookupRefs         []string
 	conditionalWrites  []conditionalMetaWrite
-	failConditionalSet bool
+	conditionalResults []attnWriteResult
 }
 
 type conditionalMetaWrite struct {
@@ -29,17 +30,24 @@ type conditionalMetaWrite struct {
 
 func (f *fakeAttnDaemon) lookup(ref string) attnLookup {
 	f.lookupRefs = append(f.lookupRefs, ref)
+	if call := len(f.lookupRefs) - 1; call < len(f.lookupSequence) {
+		return f.lookupSequence[call]
+	}
 	if lookup, ok := f.lookups[ref]; ok {
 		return lookup
 	}
 	return attnLookup{kind: lookupGone}
 }
 
-func (f *fakeAttnDaemon) setMetaIfRevision(ref string, patch map[string]string, revision int64) bool {
+func (f *fakeAttnDaemon) setMetaIfRevision(ref string, patch map[string]string, revision int64) attnWriteResult {
+	call := len(f.conditionalWrites)
 	f.conditionalWrites = append(f.conditionalWrites, conditionalMetaWrite{
 		ref: ref, patch: patch, revision: revision,
 	})
-	return !f.failConditionalSet
+	if call < len(f.conditionalResults) {
+		return f.conditionalResults[call]
+	}
+	return attnWriteApplied
 }
 
 func TestAttnStart_ConditionallySetsOnlyAttentionOKForOpenIssue(t *testing.T) {
@@ -72,6 +80,24 @@ func TestAttnStart_SkipsMissingAndTransientIssues(t *testing.T) {
 			assert.Empty(t, d.conditionalWrites)
 		})
 	}
+}
+
+func TestAttnStart_RetriesOnceAfterRevisionConflict(t *testing.T) {
+	d := &fakeAttnDaemon{
+		lookupSequence: []attnLookup{
+			{kind: lookupOpen, revision: 13},
+			{kind: lookupOpen, revision: 14},
+		},
+		conditionalResults: []attnWriteResult{attnWriteConflict},
+	}
+
+	attnStart(d, "abc4")
+
+	assert.Equal(t, []string{"abc4", "abc4"}, d.lookupRefs)
+	assert.Equal(t, []conditionalMetaWrite{
+		{ref: "abc4", patch: map[string]string{attentionKey: attnValueOK}, revision: 13},
+		{ref: "abc4", patch: map[string]string{attentionKey: attnValueOK}, revision: 14},
+	}, d.conditionalWrites)
 }
 
 func TestAttnEnd_AtomicallySetsHandoffForOpenOKIssue(t *testing.T) {
@@ -112,6 +138,21 @@ func TestAttnEnd_SkipsNonActionableIssues(t *testing.T) {
 			assert.Empty(t, d.conditionalWrites)
 		})
 	}
+}
+
+func TestAttnEnd_RechecksAttentionAfterRevisionConflict(t *testing.T) {
+	d := &fakeAttnDaemon{
+		lookupSequence: []attnLookup{
+			{kind: lookupOpen, hasAttn: true, attention: attnValueOK, revision: 17},
+			{kind: lookupOpen, hasAttn: true, attention: attnValueNeedsHuman, revision: 18},
+		},
+		conditionalResults: []attnWriteResult{attnWriteConflict},
+	}
+
+	attnEnd(d, "abc4")
+
+	assert.Equal(t, []string{"abc4", "abc4"}, d.lookupRefs)
+	assert.Len(t, d.conditionalWrites, 1)
 }
 
 func TestAttentionHooks_IgnoreEmptyAndDashLeadingRefs(t *testing.T) {
@@ -160,12 +201,12 @@ func TestAttentionHookCommand_InvalidInvocationsExitZeroWithoutDaemonActivity(t 
 	assert.Zero(t, requests.Load())
 }
 
-func TestAttnEnd_ConflictDoesNotRetry(t *testing.T) {
+func TestAttnEnd_WriteFailureDoesNotRetry(t *testing.T) {
 	d := &fakeAttnDaemon{
 		lookups: map[string]attnLookup{
 			"abc4": {kind: lookupOpen, hasAttn: true, attention: attnValueOK, revision: 23},
 		},
-		failConditionalSet: true,
+		conditionalResults: []attnWriteResult{attnWriteFailed},
 	}
 
 	attnEnd(d, "abc4")
@@ -211,12 +252,12 @@ func TestLiveAttnDaemon_ConditionalSetSendsOnlyActorPatchAndIfMatch(t *testing.T
 	flags.Project = "example-project"
 	flags.As = "agent-a"
 	d := &liveAttnDaemon{cmd: cmd}
-	ok := d.setMetaIfRevision("abc4", map[string]string{
+	result := d.setMetaIfRevision("abc4", map[string]string{
 		attentionKey:    attnValueNeedsHuman,
 		attentionMsgKey: attnHandoffMsg,
 	}, 17)
 
-	assert.True(t, ok)
+	assert.Equal(t, attnWriteApplied, result)
 	assert.True(t, requestSeen)
 }
 

--- a/cmd/kata/attention_hook_unit_test.go
+++ b/cmd/kata/attention_hook_unit_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAttnDaemon struct {
+	lookups            map[string]attnLookup
+	lookupRefs         []string
+	conditionalWrites  []conditionalMetaWrite
+	failConditionalSet bool
+}
+
+type conditionalMetaWrite struct {
+	ref      string
+	patch    map[string]string
+	revision int64
+}
+
+func (f *fakeAttnDaemon) lookup(ref string) attnLookup {
+	f.lookupRefs = append(f.lookupRefs, ref)
+	if lookup, ok := f.lookups[ref]; ok {
+		return lookup
+	}
+	return attnLookup{kind: lookupGone}
+}
+
+func (f *fakeAttnDaemon) setMetaIfRevision(ref string, patch map[string]string, revision int64) bool {
+	f.conditionalWrites = append(f.conditionalWrites, conditionalMetaWrite{
+		ref: ref, patch: patch, revision: revision,
+	})
+	return !f.failConditionalSet
+}
+
+func TestAttnStart_ConditionallySetsOnlyAttentionOKForOpenIssue(t *testing.T) {
+	d := &fakeAttnDaemon{lookups: map[string]attnLookup{
+		"abc4": {kind: lookupOpen, hasAttn: true, attention: attnValueNeedsHuman, revision: 13},
+	}}
+
+	attnStart(d, "  abc4  ")
+
+	assert.Equal(t, []string{"abc4"}, d.lookupRefs)
+	assert.Equal(t, []conditionalMetaWrite{{
+		ref: "abc4", patch: map[string]string{attentionKey: attnValueOK}, revision: 13,
+	}}, d.conditionalWrites)
+}
+
+func TestAttnStart_SkipsMissingAndTransientIssues(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		lookup attnLookup
+	}{
+		{name: "missing", lookup: attnLookup{kind: lookupGone}},
+		{name: "transient", lookup: attnLookup{kind: lookupTransient}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &fakeAttnDaemon{lookups: map[string]attnLookup{"abc4": tc.lookup}}
+
+			attnStart(d, "abc4")
+
+			assert.Equal(t, []string{"abc4"}, d.lookupRefs)
+			assert.Empty(t, d.conditionalWrites)
+		})
+	}
+}
+
+func TestAttnEnd_AtomicallySetsHandoffForOpenOKIssue(t *testing.T) {
+	d := &fakeAttnDaemon{lookups: map[string]attnLookup{
+		"abc4": {kind: lookupOpen, hasAttn: true, attention: attnValueOK, revision: 17},
+	}}
+
+	attnEnd(d, " abc4 ")
+
+	assert.Equal(t, []string{"abc4"}, d.lookupRefs)
+	require.Equal(t, []conditionalMetaWrite{{
+		ref: "abc4",
+		patch: map[string]string{
+			attentionKey:    attnValueNeedsHuman,
+			attentionMsgKey: attnHandoffMsg,
+		},
+		revision: 17,
+	}}, d.conditionalWrites)
+}
+
+func TestAttnEnd_SkipsNonActionableIssues(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		lookup attnLookup
+	}{
+		{name: "missing", lookup: attnLookup{kind: lookupGone}},
+		{name: "transient", lookup: attnLookup{kind: lookupTransient}},
+		{name: "attention absent", lookup: attnLookup{kind: lookupOpen}},
+		{name: "attention non-ok", lookup: attnLookup{kind: lookupOpen, hasAttn: true, attention: attnValueNeedsHuman}},
+		{name: "attention empty", lookup: attnLookup{kind: lookupOpen, hasAttn: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &fakeAttnDaemon{lookups: map[string]attnLookup{"abc4": tc.lookup}}
+
+			attnEnd(d, "abc4")
+
+			assert.Equal(t, []string{"abc4"}, d.lookupRefs)
+			assert.Empty(t, d.conditionalWrites)
+		})
+	}
+}
+
+func TestAttentionHooks_IgnoreEmptyAndDashLeadingRefs(t *testing.T) {
+	for _, ref := range []string{"", "   ", "-abc4", "  --project  "} {
+		t.Run(ref, func(t *testing.T) {
+			d := &fakeAttnDaemon{}
+
+			attnStart(d, ref)
+			attnEnd(d, ref)
+
+			assert.Empty(t, d.lookupRefs)
+			assert.Empty(t, d.conditionalWrites)
+		})
+	}
+}
+
+func TestAttentionHookCommand_InvalidInvocationsExitZeroWithoutDaemonActivity(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("KATA_REF", "abc4")
+
+	for _, args := range [][]string{
+		nil,
+		{"unknown"},
+		{"-bogus"},
+		{"start", "extra"},
+		{"end", "extra"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			resetFlags(t)
+			cmd := newRootCmd()
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			cmd.SetArgs(append([]string{"attention-hook"}, args...))
+			cmd.SetContext(contextWithBaseURL(context.Background(), server.URL))
+
+			assert.NoError(t, cmd.Execute())
+			assert.Empty(t, output.String())
+		})
+	}
+	assert.Zero(t, requests.Load())
+}
+
+func TestAttnEnd_ConflictDoesNotRetry(t *testing.T) {
+	d := &fakeAttnDaemon{
+		lookups: map[string]attnLookup{
+			"abc4": {kind: lookupOpen, hasAttn: true, attention: attnValueOK, revision: 23},
+		},
+		failConditionalSet: true,
+	}
+
+	attnEnd(d, "abc4")
+
+	assert.Equal(t, []string{"abc4"}, d.lookupRefs)
+	assert.Len(t, d.conditionalWrites, 1)
+}
+
+func TestLiveAttnDaemon_ConditionalSetSendsOnlyActorPatchAndIfMatch(t *testing.T) {
+	resetFlags(t)
+	requestSeen := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/projects/resolve":
+			require.Equal(t, http.MethodPost, r.Method)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"project": map[string]any{"id": 42, "name": "example-project"},
+			}))
+		case "/api/v1/projects/42/issues/abc4/metadata":
+			requestSeen = true
+			require.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, `"rev-17"`, r.Header.Get("If-Match"))
+			var body map[string]json.RawMessage
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.ElementsMatch(t, []string{"actor", "patch"}, mapKeys(body))
+			assert.JSONEq(t, `"agent-a"`, string(body["actor"]))
+			var patch map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(body["patch"], &patch))
+			assert.ElementsMatch(t, []string{attentionKey, attentionMsgKey}, mapKeys(patch))
+			assert.JSONEq(t, `"needs-human"`, string(patch[attentionKey]))
+			assert.JSONEq(t, `"session ended without hand-off"`, string(patch[attentionMsgKey]))
+			_, _ = w.Write([]byte(`{"issue":{}}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := newRootCmd()
+	cmd.SetContext(contextWithBaseURL(context.Background(), server.URL))
+	flags.Project = "example-project"
+	flags.As = "agent-a"
+	d := &liveAttnDaemon{cmd: cmd}
+	ok := d.setMetaIfRevision("abc4", map[string]string{
+		attentionKey:    attnValueNeedsHuman,
+		attentionMsgKey: attnHandoffMsg,
+	}, 17)
+
+	assert.True(t, ok)
+	assert.True(t, requestSeen)
+}
+
+func mapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/cmd/kata/helpers.go
+++ b/cmd/kata/helpers.go
@@ -174,7 +174,7 @@ func httpDoJSON(ctx context.Context, client *http.Client, method, url string, bo
 		}
 		rdr = bytes.NewReader(bs)
 	}
-	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr) //nolint:gosec // daemon targets come from trusted routing; external refs are path-escaped
 	if err != nil {
 		return 0, nil, err
 	}

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -23,6 +23,7 @@ type initOptions struct {
 	Replace    bool
 	Reassign   bool
 	WithAgents bool
+	WithHooks  bool
 }
 
 // callInitOpts is the parameter bag passed to callInit.
@@ -31,6 +32,7 @@ type callInitOpts struct {
 	Replace    bool
 	Reassign   bool
 	WithAgents bool
+	WithHooks  bool
 }
 
 // cliError is a structured error that carries an exit code for main().
@@ -139,6 +141,7 @@ get committed.`,
 	cmd.Flags().BoolVar(&opts.Replace, "replace", false, "overwrite .kata.toml binding when it conflicts")
 	cmd.Flags().BoolVar(&opts.Reassign, "reassign", false, "move an existing alias to this project")
 	cmd.Flags().BoolVar(&opts.WithAgents, "with-agents", false, "write kata agent guidance into AGENTS.md/CLAUDE.md in the workspace")
+	cmd.Flags().BoolVar(&opts.WithHooks, "with-hooks", false, "install work.attention harness hooks into the workspace's Claude Code config (.claude/)")
 
 	return cmd
 }
@@ -305,8 +308,15 @@ func runNameInit(ctx context.Context, baseURL string, in localInit, opts callIni
 			warnAgentsUpdate(err)
 		}
 	}
+	hooksChanged := false
+	if opts.WithHooks {
+		hooksChanged, err = applyClaudeHooks(dest)
+		if err != nil {
+			warnHooksUpdate(err)
+		}
+	}
 
-	return formatInitOutput(bs, resp.Project.Name, dest, resp.Created, resp.Created || tomlChanged || gitignoreChanged || agentsChanged)
+	return formatInitOutput(bs, resp.Project.Name, dest, resp.Created, resp.Created || tomlChanged || gitignoreChanged || agentsChanged || hooksChanged)
 }
 
 // runStartPathInit is the fallback used when the client cannot derive a name
@@ -356,10 +366,17 @@ func runStartPathInit(ctx context.Context, baseURL, startPath string, opts callI
 			warnAgentsUpdate(err)
 		}
 	}
+	hooksChanged := false
+	if opts.WithHooks {
+		hooksChanged, err = applyClaudeHooks(gitignoreDir)
+		if err != nil {
+			warnHooksUpdate(err)
+		}
+	}
 
 	// The path-based daemon flow writes workspace files remotely and exposes no
 	// local file-change bit today; project creation is the closest stable signal.
-	return formatInitOutput(bs, resp.Project.Name, gitignoreDir, resp.Created, resp.Created || gitignoreChanged || agentsChanged)
+	return formatInitOutput(bs, resp.Project.Name, gitignoreDir, resp.Created, resp.Created || gitignoreChanged || agentsChanged || hooksChanged)
 }
 
 func warnGitignoreUpdate(err error) {
@@ -374,6 +391,13 @@ func warnAgentsUpdate(err error) {
 		return
 	}
 	fmt.Fprintf(os.Stderr, "kata: warning: could not update agent guidance: %v\n", err)
+}
+
+func warnHooksUpdate(err error) {
+	if currentOutputMode() != outputHuman {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "kata: warning: could not install attention hooks: %v\n", err)
 }
 
 // warnBeadsConflict tells the user kata declined to edit a file in place

--- a/cmd/kata/init_hooks.go
+++ b/cmd/kata/init_hooks.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+)
+
+// `kata init --with-hooks` wires the work.attention harness hooks from
+// docs/operations/agent-orchestration.md ("Keep attention truthful with
+// hooks") into a Claude Code workspace. It writes only the
+// .claude/settings.json wiring: each event executes
+// `kata attention-hook <mode>`, the hidden subcommand that carries all the
+// hook logic in the kata binary.
+//
+// There is deliberately no repo-committed hook script. Claude Code re-prompts
+// for approval when a settings.json hook command changes, but not when a
+// separate script file's *content* changes under a stable command string — so
+// a committed script would be a code-execution vector a hostile commit could
+// mutate silently. Keeping the logic in the installed binary makes the
+// settings.json executable and arguments the whole approval contract.
+
+// claudeHookSpec is one desired settings.json lifecycle wiring.
+type claudeHookSpec struct {
+	Event   string
+	Matcher string
+	Mode    string
+}
+
+// claudeHookSpecs returns the two lifecycle wirings --with-hooks manages.
+func claudeHookSpecs() []claudeHookSpec {
+	return []claudeHookSpec{
+		{Event: "SessionStart", Matcher: "startup|resume|clear", Mode: "start"},
+		{Event: "SessionEnd", Matcher: "logout|prompt_input_exit|bypass_permissions_disabled|other", Mode: "end"},
+	}
+}
+
+// claudeHookHandler renders Claude Code's exec form, keeping the executable
+// and arguments separate so no shell parses the command.
+func claudeHookHandler(mode string) map[string]any {
+	return map[string]any{
+		"type":    "command",
+		"command": "kata",
+		"args":    []any{"attention-hook", mode},
+	}
+}
+
+// applyClaudeHooks is the entry point for `--with-hooks`. It merges the wiring
+// into <dir>/.claude/settings.json, preserving everything else the file holds.
+// Returns whether anything changed; re-running on an installed workspace is a
+// no-op.
+//
+// Every filesystem step runs fd-relative to the workspace root through
+// os.Root, so a component swapped for a symlink between validation and use
+// (TOCTOU in a shared-writable checkout) cannot redirect a read or write
+// outside the workspace. Pre-existing symlinked components — .claude or
+// settings.json pointing anywhere, even inside the workspace — are refused
+// outright, matching the guidance-file posture.
+func applyClaudeHooks(dir string) (bool, error) {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = root.Close() }()
+	if err := refuseSymlinkComponents(root, ".claude", ".claude/settings.json"); err != nil {
+		return false, err
+	}
+	return ensureClaudeSettingsHooks(root)
+}
+
+// refuseSymlinkComponents rejects any existing symlink among the given
+// root-relative paths (each successive entry one component deeper). Paths
+// that do not exist yet are fine — they will be created as real entries.
+// Root.Lstat is fd-relative, so the check itself cannot be redirected by a
+// concurrent rename outside the root.
+func refuseSymlinkComponents(root *os.Root, rels ...string) error {
+	for _, rel := range rels {
+		fi, err := root.Lstat(rel)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			return nil
+		case err != nil:
+			return err
+		case fi.Mode()&os.ModeSymlink != 0:
+			return fmt.Errorf("refusing to manage symlinked %s", filepath.Join(root.Name(), rel))
+		}
+	}
+	return nil
+}
+
+// ensureClaudeSettingsHooks merges the hook wiring into settings.json (all
+// I/O relative to the workspace root). The file is user-owned, so the merge
+// is additive: unknown keys and existing hook entries are preserved verbatim
+// (modulo re-encoding), and each kata wiring is appended only when its exact
+// handler is not already present under the required event matcher. A file that
+// fails to parse is left untouched and reported.
+func ensureClaudeSettingsHooks(root *os.Root) (bool, error) {
+	const rel = ".claude/settings.json"
+	path := filepath.Join(root.Name(), rel) // display only
+	content, err := root.ReadFile(rel)
+	exists := true
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		exists = false
+	}
+	settings := map[string]any{}
+	if exists {
+		decoder := json.NewDecoder(bytes.NewReader(content))
+		decoder.UseNumber()
+		if err := decoder.Decode(&settings); err != nil {
+			return false, fmt.Errorf("parse %s: %w (fix or remove it, then re-run)", path, err)
+		}
+		var trailing any
+		if err := decoder.Decode(&trailing); err != io.EOF {
+			if err == nil {
+				err = errors.New("multiple JSON values")
+			}
+			return false, fmt.Errorf("parse %s: %w (fix or remove it, then re-run)", path, err)
+		}
+		// `null` is valid JSON and decodes to a nil map, which the merge
+		// below would panic assigning into.
+		if settings == nil {
+			return false, fmt.Errorf("parse %s: settings root is not an object (fix or remove it, then re-run)", path)
+		}
+	}
+
+	changed := false
+	for _, spec := range claudeHookSpecs() {
+		c, err := upsertClaudeHook(settings, spec)
+		if err != nil {
+			return false, fmt.Errorf("%s: %w", path, err)
+		}
+		changed = changed || c
+	}
+	if exists && !changed {
+		return false, nil
+	}
+
+	encoded, err := encodeClaudeSettings(settings)
+	if err != nil {
+		return false, err
+	}
+	if err := root.MkdirAll(".claude", 0o750); err != nil {
+		return false, err
+	}
+	if exists {
+		err = atomicReplaceSettings(root, rel, encoded)
+	} else {
+		// O_EXCL: something racing the file into place between read and
+		// write is surfaced rather than overwritten.
+		var f *os.File
+		f, err = root.OpenFile(rel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err == nil {
+			_, werr := f.Write(encoded)
+			if cerr := f.Close(); werr == nil {
+				werr = cerr
+			}
+			err = werr
+		} else if errors.Is(err, os.ErrExist) {
+			err = fmt.Errorf("refusing to overwrite %s: %w", path, err)
+		}
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// atomicReplaceSettings rewrites an existing settings.json without ever
+// exposing a partial document. The merged JSON is staged in a sibling temp
+// file in .claude, fully written, fsynced, and closed; only then is it
+// renamed over rel. A rename within a directory is atomic, so a reader always
+// observes either the old file or the whole new one — an interrupted or short
+// write can only truncate the throwaway temp, never the user's live config.
+// The existing file's permissions are carried onto the replacement so a
+// tightened mode is not silently reset to the default.
+func atomicReplaceSettings(root *os.Root, rel string, encoded []byte) error {
+	perm := os.FileMode(0o644)
+	if fi, err := root.Stat(rel); err == nil {
+		perm = fi.Mode().Perm()
+	}
+	tmp, f, err := createSettingsTemp(root, filepath.Dir(rel))
+	if err != nil {
+		return err
+	}
+	// Any exit before the rename lands must not leave the temp behind.
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = root.Remove(tmp)
+		}
+	}()
+	writeErr := func() error {
+		if _, err := f.Write(encoded); err != nil {
+			return err
+		}
+		if err := f.Chmod(perm); err != nil {
+			return err
+		}
+		return f.Sync()
+	}()
+	if cerr := f.Close(); writeErr == nil {
+		writeErr = cerr
+	}
+	if writeErr != nil {
+		return writeErr
+	}
+	// os.Root.Rename replaces an existing destination on every supported OS:
+	// on Unix it is renameat(2), and on Windows it is renameat via
+	// windows.Renameat, which sets FILE_RENAME_REPLACE_IF_EXISTS. The export
+	// path's separate MoveFileEx helper is not needed here — routing the
+	// rename through the *os.Root keeps it fd-relative so the atomic swap
+	// cannot be redirected outside the workspace by a concurrent symlink.
+	if err := root.Rename(tmp, rel); err != nil {
+		return err
+	}
+	renamed = true
+	return nil
+}
+
+// createSettingsTemp opens a fresh, exclusively-created temp file for staging
+// settings.json inside dir (root-relative). O_EXCL with a random name means a
+// concurrent installer gets its own staging file rather than a shared one, and
+// the create cannot be redirected through a pre-planted symlink.
+func createSettingsTemp(root *os.Root, dir string) (string, *os.File, error) {
+	for range 10 {
+		var b [8]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			return "", nil, err
+		}
+		name := filepath.Join(dir, "settings.json."+hex.EncodeToString(b[:])+".tmp")
+		f, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			return name, f, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return "", nil, err
+		}
+	}
+	return "", nil, fmt.Errorf("could not create a staging temp file in %s", filepath.Join(root.Name(), dir))
+}
+
+// upsertClaudeHook appends spec's wiring under its event unless the exact
+// managed handler is already present in a group with the exact desired scope.
+// Existing groups are otherwise preserved, including groups with wildcard or
+// malformed matchers that cannot be interpreted as the managed wiring.
+func upsertClaudeHook(settings map[string]any, spec claudeHookSpec) (bool, error) {
+	hooks, err := ensureObject(settings, "hooks")
+	if err != nil {
+		return false, err
+	}
+	var groups []any
+	if rawGroups, exists := hooks[spec.Event]; exists {
+		var ok bool
+		groups, ok = rawGroups.([]any)
+		if !ok {
+			return false, fmt.Errorf("hooks.%s has an unexpected shape", spec.Event)
+		}
+	}
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		rawMatcher, hasMatcher := gm["matcher"]
+		if spec.Matcher == "" {
+			if hasMatcher {
+				continue
+			}
+		} else {
+			matcher, ok := rawMatcher.(string)
+			if !ok || matcher != spec.Matcher {
+				continue
+			}
+		}
+		entries, _ := gm["hooks"].([]any)
+		for _, e := range entries {
+			if reflect.DeepEqual(e, claudeHookHandler(spec.Mode)) {
+				return false, nil
+			}
+		}
+	}
+	group := map[string]any{
+		"hooks": []any{claudeHookHandler(spec.Mode)},
+	}
+	if spec.Matcher != "" {
+		group["matcher"] = spec.Matcher
+	}
+	hooks[spec.Event] = append(groups, group)
+	return true, nil
+}
+
+// ensureObject returns m[key] as an object, creating it when absent.
+func ensureObject(m map[string]any, key string) (map[string]any, error) {
+	v, ok := m[key]
+	if !ok {
+		obj := map[string]any{}
+		m[key] = obj
+		return obj, nil
+	}
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%q has an unexpected shape", key)
+	}
+	return obj, nil
+}
+
+// encodeClaudeSettings renders settings as 2-space-indented JSON without
+// HTML escaping, trailing newline included — the conventional settings.json
+// shape. Object keys come out sorted; that is the one formatting liberty the
+// merge takes with a user-owned file.
+func encodeClaudeSettings(settings map[string]any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(settings); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/cmd/kata/init_hooks_test.go
+++ b/cmd/kata/init_hooks_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Unit tests for `kata init --with-hooks`: merging the work.attention
+// lifecycle wiring into .claude/settings.json. The hooks call the installed
+// kata binary directly through Claude Code's exec form.
+
+func readSettings(t *testing.T, dir string) map[string]any {
+	t.Helper()
+	bs, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	var settings map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(bs))
+	decoder.UseNumber()
+	require.NoError(t, decoder.Decode(&settings))
+	return settings
+}
+
+func writeSettings(t *testing.T, dir string, settings map[string]any) string {
+	t.Helper()
+	bs, err := json.Marshal(settings)
+	require.NoError(t, err)
+	return writeRawSettings(t, dir, string(bs))
+}
+
+func writeRawSettings(t *testing.T, dir, content string) string {
+	t.Helper()
+	claudeDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o750))
+	path := filepath.Join(claudeDir, "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644)) //nolint:gosec // test fixture under TempDir
+	return path
+}
+
+func expectedHookHandler(mode string) map[string]any {
+	return map[string]any{
+		"type":    "command",
+		"command": "kata",
+		"args":    []any{"attention-hook", mode},
+	}
+}
+
+func TestApplyClaudeHooks_FreshWorkspace(t *testing.T) {
+	dir := t.TempDir()
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	// settings.json contains exactly the two managed lifecycle hooks. Claude
+	// Code's exec form keeps the binary and arguments separate, with no shell
+	// command string and no PostToolUse wiring.
+	assert.Equal(t, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{
+				"matcher": "startup|resume|clear",
+				"hooks": []any{map[string]any{
+					"type":    "command",
+					"command": "kata",
+					"args":    []any{"attention-hook", "start"},
+				}},
+			}},
+			"SessionEnd": []any{map[string]any{
+				"matcher": "logout|prompt_input_exit|bypass_permissions_disabled|other",
+				"hooks": []any{map[string]any{
+					"type":    "command",
+					"command": "kata",
+					"args":    []any{"attention-hook", "end"},
+				}},
+			}},
+		},
+	}, readSettings(t, dir))
+}
+
+func TestApplyClaudeHooks_PreservesSettingsAndIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	unscopedStartGroup := map[string]any{
+		"custom": "keep",
+		"hooks": []any{
+			map[string]any{"type": "command", "command": "notify-start"},
+			expectedHookHandler("start"),
+		},
+	}
+	unscopedEndGroup := map[string]any{
+		"hooks": []any{
+			map[string]any{"type": "command", "command": "notify-end"},
+			expectedHookHandler("end"),
+		},
+	}
+	postToolUse := []any{map[string]any{
+		"matcher": "Bash",
+		"hooks":   []any{map[string]any{"type": "command", "command": "lint"}},
+	}}
+	stop := []any{map[string]any{
+		"hooks": []any{map[string]any{"type": "command", "command": "notify-stop"}},
+	}}
+	writeSettings(t, dir, map[string]any{
+		"permissions":  map[string]any{"allow": []any{"WebFetch"}},
+		"futureKey":    map[string]any{"enabled": true},
+		"largeInteger": json.Number("9007199254740993"),
+		"hooks": map[string]any{
+			"SessionStart": []any{unscopedStartGroup},
+			"SessionEnd":   []any{unscopedEndGroup},
+			"PostToolUse":  postToolUse,
+			"Stop":         stop,
+		},
+	})
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	settings := readSettings(t, dir)
+	assert.Equal(t, map[string]any{"allow": []any{"WebFetch"}}, settings["permissions"])
+	assert.Equal(t, map[string]any{"enabled": true}, settings["futureKey"])
+	assert.Equal(t, json.Number("9007199254740993"), settings["largeInteger"])
+	hooks := settings["hooks"].(map[string]any)
+	assert.Equal(t, postToolUse, hooks["PostToolUse"])
+	assert.Equal(t, stop, hooks["Stop"])
+
+	// Unscoped lifecycle handlers do not cover the exact managed matchers.
+	// Preserve their shared groups and add the two managed scoped groups.
+	assert.Equal(t, []any{
+		unscopedStartGroup,
+		map[string]any{
+			"matcher": "startup|resume|clear",
+			"hooks":   []any{expectedHookHandler("start")},
+		},
+	}, hooks["SessionStart"])
+	assert.Equal(t, []any{
+		unscopedEndGroup,
+		map[string]any{
+			"matcher": "logout|prompt_input_exit|bypass_permissions_disabled|other",
+			"hooks":   []any{expectedHookHandler("end")},
+		},
+	}, hooks["SessionEnd"])
+
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	before, err := os.ReadFile(settingsPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	changed, err = applyClaudeHooks(dir)
+	require.NoError(t, err)
+	assert.False(t, changed, "an exact installation must be a no-op")
+	after, err := os.ReadFile(settingsPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+}
+
+func TestApplyClaudeHooks_RejectsMalformedSettingsWithoutWriting(t *testing.T) {
+	tests := map[string]string{
+		"invalid JSON":             "{ not json",
+		"multiple roots":           "{} {}",
+		"null root":                "null\n",
+		"array root":               "[]\n",
+		"null hooks":               `{"hooks":null}`,
+		"array hooks":              `{"hooks":[]}`,
+		"null SessionStart":        `{"hooks":{"SessionStart":null}}`,
+		"object SessionStart":      `{"hooks":{"SessionStart":{}}}`,
+		"string SessionEnd":        `{"hooks":{"SessionEnd":"broken"}}`,
+		"valid start, invalid end": `{"hooks":{"SessionStart":[],"SessionEnd":null}}`,
+	}
+	for name, original := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			settingsPath := writeRawSettings(t, dir, original)
+
+			_, err := applyClaudeHooks(dir)
+			require.Error(t, err)
+
+			got, readErr := os.ReadFile(settingsPath) //nolint:gosec // test fixture under TempDir
+			require.NoError(t, readErr)
+			assert.Equal(t, original, string(got))
+		})
+	}
+}
+
+func TestApplyClaudeHooks_RefusesSymlinks(t *testing.T) {
+	t.Run(".claude directory", func(t *testing.T) {
+		dir := t.TempDir()
+		outside := t.TempDir()
+		require.NoError(t, os.Symlink(outside, filepath.Join(dir, ".claude")))
+
+		_, err := applyClaudeHooks(dir)
+		require.Error(t, err)
+
+		entries, readErr := os.ReadDir(outside)
+		require.NoError(t, readErr)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("settings.json", func(t *testing.T) {
+		dir := t.TempDir()
+		claudeDir := filepath.Join(dir, ".claude")
+		require.NoError(t, os.MkdirAll(claudeDir, 0o750))
+		victim := filepath.Join(dir, "victim.json")
+		require.NoError(t, os.WriteFile(victim, []byte("{}"), 0o644)) //nolint:gosec // test fixture under TempDir
+		require.NoError(t, os.Symlink(victim, filepath.Join(claudeDir, "settings.json")))
+
+		_, err := applyClaudeHooks(dir)
+		require.Error(t, err)
+
+		got, readErr := os.ReadFile(victim) //nolint:gosec // test fixture under TempDir
+		require.NoError(t, readErr)
+		assert.Equal(t, "{}", string(got))
+	})
+}
+
+func TestApplyClaudeHooks_AtomicRewritePreservesOriginalOnFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod does not make a directory unwritable for file creation on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory write permissions")
+	}
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	settingsPath := writeRawSettings(t, dir, "{\n  \"permissions\": {}\n}\n")
+	original, err := os.ReadFile(settingsPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chmod(claudeDir, 0o500))       //nolint:gosec // test fixture under TempDir
+	t.Cleanup(func() { _ = os.Chmod(claudeDir, 0o750) }) //nolint:gosec // restore for TempDir cleanup
+
+	_, err = applyClaudeHooks(dir)
+	require.Error(t, err)
+	got, readErr := os.ReadFile(settingsPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, readErr)
+	assert.Equal(t, original, got)
+}
+
+func TestApplyClaudeHooks_AtomicRewritePreservesMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file mode bits are not represented on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root reports unrestricted file modes")
+	}
+	dir := t.TempDir()
+	settingsPath := writeRawSettings(t, dir, "{}\n")
+	require.NoError(t, os.Chmod(settingsPath, 0o640)) //nolint:gosec // test fixture under TempDir
+
+	changed, err := applyClaudeHooks(dir)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	info, err := os.Stat(settingsPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	entries, err := os.ReadDir(filepath.Dir(settingsPath))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "settings.json", entries[0].Name())
+}

--- a/cmd/kata/init_with_hooks_e2e_test.go
+++ b/cmd/kata/init_with_hooks_e2e_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+// This exercises `kata init --with-hooks` as a user would run it: the real CLI
+// command against a live daemon. It complements the focused unit tests in
+// init_hooks_test.go.
+
+// TestE2E_InitWithHooks_ComposesWithAgents runs both flags together: guidance
+// block and the exact exec-form lifecycle hooks land in one init.
+func TestE2E_InitWithHooks_ComposesWithAgents(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/example-org/example-workspace.git")
+
+	out := runCLI(t, env, dir, "init", "--with-agents", "--with-hooks")
+	assert.Contains(t, out, "project")
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(content), agentsBlockBegin)
+	assert.FileExists(t, filepath.Join(dir, ".kata.toml"))
+	assert.Equal(t, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{
+				"matcher": "startup|resume|clear",
+				"hooks":   []any{expectedHookHandler("start")},
+			}},
+			"SessionEnd": []any{map[string]any{
+				"matcher": "logout|prompt_input_exit|bypass_permissions_disabled|other",
+				"hooks":   []any{expectedHookHandler("end")},
+			}},
+		},
+	}, readSettings(t, dir))
+}

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -99,6 +99,7 @@ func newRootCmd() *cobra.Command {
 		newAssignCmd(),
 		newUnassignCmd(),
 		newClaimCmd(),
+		newAttentionHookCmd(),
 		newReadyCmd(),
 		newNextCmd(),
 		newWaitCmd(),

--- a/cmd/kata/move.go
+++ b/cmd/kata/move.go
@@ -131,7 +131,7 @@ func httpDoJSONHeaders(ctx context.Context, client *http.Client, method, path st
 		}
 		rdr = bytes.NewReader(bs)
 	}
-	req, err := http.NewRequestWithContext(ctx, method, path, rdr)
+	req, err := http.NewRequestWithContext(ctx, method, path, rdr) //nolint:gosec // daemon targets come from trusted routing; external refs are path-escaped
 	if err != nil {
 		return 0, nil, err
 	}

--- a/docs/operations/agent-orchestration.md
+++ b/docs/operations/agent-orchestration.md
@@ -111,6 +111,15 @@ truthful terminal signal, self-assertion is the finer-grained live signal. Both
 write the same two keys, and because attention is last-write-wins by design,
 whichever fired most recently is the state coordinators see.
 
+For Claude Code workspaces, `kata init --with-hooks` additively installs two
+exec-form lifecycle hooks in `.claude/settings.json`: `SessionStart` runs
+`kata attention-hook start` for new, resumed, and cleared sessions (but not
+context compaction), and `SessionEnd` runs `kata attention-hook end` only for
+terminal exits rather than clear/resume transitions.
+Both use the launcher-provided `KATA_REF` and intentionally do nothing when it
+is absent. Re-running the command is a no-op, and symlinked `.claude` or
+`settings.json` paths are refused.
+
 ## Coordinate: wait and dashboards
 
 A delegating **coordinator** joins on sub-tasks with `kata wait`. Launch two

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,7 +19,7 @@ current flag list in your installed binary.
 ## Workspace initialization
 
 ```sh
-kata init [--project <name>] [--with-agents]
+kata init [--project <name>] [--with-agents] [--with-hooks]
 kata init [--replace | --reassign]
 ```
 
@@ -43,6 +43,17 @@ added. Review the sidecar before replacing the original.
 
 A symlinked `AGENTS.md` is refused before it is read; replace it with a regular
 file before using `--with-agents`.
+
+Pass `--with-hooks` to install the `work.attention` lifecycle hooks from the
+[agent orchestration recipe](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
+into the workspace's Claude Code config. It additively installs two exec-form
+entries in `.claude/settings.json`: `SessionStart` runs `kata attention-hook
+start` for new, resumed, and cleared sessions (but not context compaction), and
+`SessionEnd` runs `kata attention-hook end` only for terminal exits rather
+than clear/resume transitions. Both use the
+launcher-provided `KATA_REF` and intentionally do nothing when it is absent.
+Everything else in `settings.json` is preserved, re-running is a no-op, and a
+symlinked `settings.json` or `.claude` directory is refused.
 
 ## Issue lifecycle
 

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -36,6 +36,16 @@ and writes a `<file>.kata-proposed` sidecar to adopt or discard — see
 `AGENTS.md` is a symlink, kata refuses to manage it before reading the target;
 replace it with a regular file before using `--with-agents`.
 
+Guidance files produce tendency, not contract: an agent can still end a session
+without updating its issue. For Claude Code workspaces,
+`kata init --with-hooks` additionally installs the
+[attention harness hooks](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
+as two exec-form lifecycle entries: `SessionStart` runs `kata attention-hook
+start` for new, resumed, and cleared sessions (but not context compaction), and
+`SessionEnd` runs `kata attention-hook end` only for terminal exits rather
+than clear/resume transitions. Both use the
+launcher-provided `KATA_REF` and intentionally do nothing when it is absent.
+
 ## Search before creating
 
 ```sh


### PR DESCRIPTION
Supersedes the script half of #172 (whose commits this branch includes — the diff on top is the rework), responding to the review finding that a repo-committed hook script is a code-execution vector: Claude Code re-prompts when a settings.json hook *command* changes, but the command string `.claude/hooks/kata-attention.sh` stays constant while a hostile commit can rewrite the script's content after first approval.

The hook logic now lives in the installed binary as a hidden plumbing command, and `kata init --with-hooks` wires `.claude/settings.json` to call it directly:

- SessionStart → `kata attention-hook start`
- PostToolUse (Bash) → `kata attention-hook claim`
- SessionEnd → `kata attention-hook stop`

What executes is now exactly what the approval dialog shows, and no executable content is written into the repository. It also retires the whole class of problems inherent to a shell artifact — execute-bit management, BSD/bash-3.2 portability, the jq dependency — and made the two remaining review findings on the script fixable properly:

- Claim parsing is a real two-pass tokenizer: global flags on either side of `claim` (`kata --project spoke-project claim abc4`), value-bearing flags with space or `=` forms, quoted arguments with escape handling, and one effective actor (`--as` never falls back to ambient) resolved before any probing.
- Routing context is honored end-to-end: a claim's `--project`/`--workspace`/`--daemon` route its verification and mutations, and session state stores project-qualified refs so the SessionEnd sweep resolves the same issue the claim did. (Known limitation, documented inline: a claim against a different daemon/workspace can't be swept from the ambient session context.)
- Upgrading is destructive toward the old layout on purpose: refreshing prunes every legacy script-based hook entry across all events, so no previously-approved script command survives pointing at stale on-disk content.
- Session state lives under `XDG_RUNTIME_DIR` (or the user cache dir — never world-writable /tmp), with session-id validation so hook input can't traverse outside it.

Hook semantics are unchanged from #172: launcher-supplied `$KATA_REF` at start, `kata claim` discovery for hand-started sessions gated on daemon-verified ownership, and the terminal ok→needs-human sweep with transient-failure retry. Behavior that was previously verified by hand is now pinned by parser unit tests and live-daemon e2e tests fed real hook JSON over stdin.