### PR TITLE
Add daemon restart and improve status output

### DIFF
--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -39,6 +39,10 @@ func newDaemonCmd() *cobra.Command {
 
 const daemonTelemetryHeartbeatInterval = 24 * time.Hour
 
+// daemonRestartShutdownTimeout covers the sequential 10-second HTTP and hook
+// shutdown budgets, plus a small allowance for the remaining process cleanup.
+const daemonRestartShutdownTimeout = 25 * time.Second
+
 var newTelemetryReporter = func(opts telemetry.Options) telemetry.Client {
 	return telemetry.NewReporterOrDisabled(opts)
 }
@@ -405,10 +409,17 @@ type daemonStopOutput struct {
 }
 
 func daemonRestartCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		listen           string
+		insecureReadonly bool
+	)
+	cmd := &cobra.Command{
 		Use:   "restart",
 		Short: "restart the daemon",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := validateDaemonReplacement(listen, insecureReadonly); err != nil {
+				return fmt.Errorf("restart: validate replacement: %w", err)
+			}
 			ns, err := daemon.NewNamespace()
 			if err != nil {
 				return err
@@ -427,10 +438,10 @@ func daemonRestartCmd() *cobra.Command {
 				}
 				pids = append(pids, rec.PID)
 			}
-			if err := waitForDaemonProcesses(cmd.Context(), pids, 3*time.Second); err != nil {
+			if err := waitForDaemonProcesses(cmd.Context(), pids, daemonRestartShutdownTimeout); err != nil {
 				return err
 			}
-			out, err := startDetachedDaemon(cmd.Context(), "", false)
+			out, err := startDetachedDaemon(cmd.Context(), listen, insecureReadonly)
 			if err != nil {
 				return err
 			}
@@ -460,6 +471,27 @@ func daemonRestartCmd() *cobra.Command {
 			return err
 		},
 	}
+	cmd.Flags().StringVar(&listen, "listen", "",
+		"bind the replacement daemon to host:port (overrides config.toml)")
+	cmd.Flags().BoolVar(&insecureReadonly, "insecure-readonly", false,
+		"permit unauthenticated GETs on non-loopback TCP when no token is configured (DEV ONLY)")
+	return cmd
+}
+
+func validateDaemonReplacement(listen string, insecureReadonly bool) error {
+	dcfg, err := config.ReadDaemonConfig()
+	if err != nil {
+		return err
+	}
+	listen = effectiveDaemonListenWithConfig(listen, dcfg)
+	ns, err := daemon.NewNamespace()
+	if err != nil {
+		return err
+	}
+	if _, err := chooseEndpoint(ns, listen); err != nil {
+		return err
+	}
+	return daemon.CheckAuthStartup(listen, dcfg.Auth, insecureReadonly)
 }
 
 type daemonRestartOutput struct {

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -417,13 +417,11 @@ func daemonRestartCmd() *cobra.Command {
 		Use:   "restart",
 		Short: "restart the daemon",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := validateDaemonReplacement(listen, insecureReadonly); err != nil {
+			startup, err := preflightDaemonStartup(cmd.Context(), listen, insecureReadonly)
+			if err != nil {
 				return fmt.Errorf("restart: validate replacement: %w", err)
 			}
-			ns, err := daemon.NewNamespace()
-			if err != nil {
-				return err
-			}
+			ns := startup.Namespace
 			recs, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).List()
 			if err != nil {
 				return err
@@ -478,20 +476,71 @@ func daemonRestartCmd() *cobra.Command {
 	return cmd
 }
 
-func validateDaemonReplacement(listen string, insecureReadonly bool) error {
+type daemonStartupPreflight struct {
+	Config         *config.DaemonConfig
+	Listen         string
+	Namespace      *daemon.Namespace
+	Endpoint       kitdaemon.Endpoint
+	DBPath         string
+	KataHome       string
+	HookConfigPath string
+	HookConfig     hooks.LoadedConfig
+	Embedder       *embedding.Client
+	VectorsPath    string
+}
+
+func preflightDaemonStartup(ctx context.Context, listen string, insecureReadonly bool) (daemonStartupPreflight, error) {
 	dcfg, err := config.ReadDaemonConfig()
 	if err != nil {
-		return err
+		return daemonStartupPreflight{}, err
 	}
 	listen = effectiveDaemonListenWithConfig(listen, dcfg)
 	ns, err := daemon.NewNamespace()
 	if err != nil {
-		return err
+		return daemonStartupPreflight{}, err
 	}
-	if _, err := chooseEndpoint(ns, listen); err != nil {
-		return err
+	endpoint, err := chooseEndpoint(ns, listen)
+	if err != nil {
+		return daemonStartupPreflight{}, err
 	}
-	return daemon.CheckAuthStartup(listen, dcfg.Auth, insecureReadonly)
+	if err := daemon.CheckAuthStartup(listen, dcfg.Auth, insecureReadonly); err != nil {
+		return daemonStartupPreflight{}, err
+	}
+	dbPath, err := config.KataDSN(ctx)
+	if err != nil {
+		return daemonStartupPreflight{}, err
+	}
+	if err := storeopen.Validate(dbPath); err != nil {
+		return daemonStartupPreflight{}, err
+	}
+	home, err := config.KataHome()
+	if err != nil {
+		return daemonStartupPreflight{}, err
+	}
+	hookCfgPath, err := config.HookConfigPath()
+	if err != nil {
+		return daemonStartupPreflight{}, err
+	}
+	loadedHooks, err := hooks.LoadStartup(hookCfgPath)
+	if err != nil {
+		return daemonStartupPreflight{}, fmt.Errorf("hooks: %w", err)
+	}
+	embedder, vectorsPath, err := preflightEmbeddingStartup(dcfg.Search.Embeddings, dbPath)
+	if err != nil {
+		return daemonStartupPreflight{}, err
+	}
+	return daemonStartupPreflight{
+		Config:         dcfg,
+		Listen:         listen,
+		Namespace:      ns,
+		Endpoint:       endpoint,
+		DBPath:         dbPath,
+		KataHome:       home,
+		HookConfigPath: hookCfgPath,
+		HookConfig:     loadedHooks,
+		Embedder:       embedder,
+		VectorsPath:    vectorsPath,
+	}, nil
 }
 
 type daemonRestartOutput struct {
@@ -614,26 +663,14 @@ func redactRuntimeDSN(dsn string) string {
 // config value is used. CLI flag always wins over config.
 // insecureReadonly is the dev escape hatch from --insecure-readonly.
 func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bool) error {
-	dcfg, err := config.ReadDaemonConfig()
+	startup, err := preflightDaemonStartup(ctx, listen, insecureReadonly)
 	if err != nil {
 		return err
 	}
-	listen = effectiveDaemonListenWithConfig(listen, dcfg)
-	ns, err := daemon.NewNamespace()
-	if err != nil {
-		return err
-	}
-	// chooseEndpoint validates the listen shape and address rules (e.g.
-	// rejecting literal public IPs like 8.8.8.8) without binding. Run it
-	// before the auth-startup guard so a public-address user sees the
-	// "non-public" error rather than a generic auth-required message.
-	endpoint, err := chooseEndpoint(ns, listen)
-	if err != nil {
-		return err
-	}
-	if err := daemon.CheckAuthStartup(listen, dcfg.Auth, insecureReadonly); err != nil {
-		return err
-	}
+	dcfg := startup.Config
+	listen = startup.Listen
+	ns := startup.Namespace
+	endpoint := startup.Endpoint
 	if msg, ok := daemon.TrustPrivateNetworkWarning(listen, dcfg.Auth); ok {
 		fmt.Fprintln(os.Stderr, msg)
 	}
@@ -653,21 +690,19 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	stopCleanup := installStopWatcher(ns.DBHash, cancel)
 	defer stopCleanup()
 
-	dbPath, err := config.KataDSN(ctx)
-	if err != nil {
-		return err
-	}
+	dbPath := startup.DBPath
 	store, err := storeopen.Open(ctx, dbPath)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = store.Close() }()
 
-	disp, daemonLog, hookCfgPath, err := setupHooks(store, dbPath)
+	disp, daemonLog, err := setupHooks(store, dbPath, startup.KataHome, startup.HookConfig)
 	if err != nil {
 		return err
 	}
 	defer shutdownHooks(disp)
+	hookCfgPath := startup.HookConfigPath
 
 	telemetryReporter := newDaemonTelemetryReporter(store)
 	defer func() {
@@ -693,7 +728,9 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		return err
 	}
 
-	embedder, vectorIndex, reconcilerHealth, err := startEmbeddingReconciler(ctx, dcfg, store, dbPath, broadcaster, daemonLog)
+	embedder, vectorIndex, reconcilerHealth, err := startEmbeddingReconciler(
+		ctx, dcfg.Search.Embeddings, startup.Embedder, startup.VectorsPath, store, broadcaster, daemonLog,
+	)
 	if err != nil {
 		return err
 	}
@@ -895,25 +932,12 @@ func vectorsPathForDSN(dsn string) (string, error) {
 	return path + ".vectors", nil
 }
 
-// startEmbeddingReconciler constructs the embedding client, sidecar vector
-// index, and reconciler when semantic search is configured, starts the
-// reconciler goroutine, subscribes to the broadcaster so new/edited issues are
-// embedded promptly, and triggers an initial backfill sweep. It returns the
-// client, the index, and a health snapshot func to wire into ServerConfig.
-// When embeddings are not configured it returns nils so the daemon behaves
-// exactly as it did before semantic search existed. The caller owns the
-// returned *vector.Index's lifetime and must close it on shutdown.
-func startEmbeddingReconciler(
-	ctx context.Context,
-	dcfg *config.DaemonConfig,
-	store db.Storage,
+func preflightEmbeddingStartup(
+	ec config.EmbeddingsConfig,
 	dbPath string,
-	bcast *daemon.EventBroadcaster,
-	daemonLog *log.Logger,
-) (*embedding.Client, *vector.Index, func() daemon.ReconcilerHealth, error) {
-	ec := dcfg.Search.Embeddings
+) (*embedding.Client, string, error) {
 	if !ec.Enabled() {
-		return nil, nil, nil, nil
+		return nil, "", nil
 	}
 	embedder, err := embedding.New(embedding.Config{
 		BaseURL:             ec.BaseURL,
@@ -926,11 +950,34 @@ func startEmbeddingReconciler(
 		TrustPrivateNetwork: ec.TrustPrivateNetwork,
 	})
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("embedding client: %w", err)
+		return nil, "", fmt.Errorf("embedding client: %w", err)
 	}
 	vectorsPath, err := vectorsPathForDSN(dbPath)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("embedding index: %w", err)
+		return nil, "", fmt.Errorf("embedding index: %w", err)
+	}
+	return embedder, vectorsPath, nil
+}
+
+// startEmbeddingReconciler opens the sidecar vector index for the embedding
+// client validated during startup preflight, starts the reconciler goroutine,
+// subscribes to the broadcaster so new/edited issues are embedded promptly,
+// and triggers an initial backfill sweep. It returns the client, the index, and
+// a health snapshot func to wire into ServerConfig. When embeddings are not
+// configured it returns nils so the daemon behaves exactly as it did before
+// semantic search existed. The caller owns the returned *vector.Index's
+// lifetime and must close it on shutdown.
+func startEmbeddingReconciler(
+	ctx context.Context,
+	ec config.EmbeddingsConfig,
+	embedder *embedding.Client,
+	vectorsPath string,
+	store db.Storage,
+	bcast *daemon.EventBroadcaster,
+	daemonLog *log.Logger,
+) (*embedding.Client, *vector.Index, func() daemon.ReconcilerHealth, error) {
+	if embedder == nil {
+		return nil, nil, nil, nil
 	}
 	idx, err := vector.Open(ctx, vectorsPath)
 	if err != nil {
@@ -1124,26 +1171,16 @@ func listenFromPortEnv() (string, bool) {
 	return net.JoinHostPort("0.0.0.0", port), true
 }
 
-// setupHooks loads hooks.toml, materializes $KATA_HOME, and constructs
-// the dispatcher with DB-backed resolvers. Returned values are wired
-// into runDaemon: the dispatcher feeds ServerConfig.Hooks, the logger
-// is shared with runReloadLoop, and the config path is passed to
-// runReloadLoop so SIGHUP re-reads the same file.
-func setupHooks(store db.Storage, dbPath string) (*hooks.Dispatcher, *log.Logger, string, error) {
-	home, err := config.KataHome()
-	if err != nil {
-		return nil, nil, "", err
-	}
+// setupHooks materializes $KATA_HOME and constructs the dispatcher from the
+// hook configuration parsed during startup preflight.
+func setupHooks(
+	store db.Storage,
+	dbPath string,
+	home string,
+	loaded hooks.LoadedConfig,
+) (*hooks.Dispatcher, *log.Logger, error) {
 	if err := os.MkdirAll(home, 0o700); err != nil {
-		return nil, nil, "", err
-	}
-	hookCfgPath, err := config.HookConfigPath()
-	if err != nil {
-		return nil, nil, "", err
-	}
-	loaded, err := hooks.LoadStartup(hookCfgPath)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("hooks: %w", err)
+		return nil, nil, err
 	}
 	daemonLog := log.New(os.Stderr, "kata-daemon: ", log.LstdFlags)
 	deps := hooks.DispatcherDeps{
@@ -1159,9 +1196,9 @@ func setupHooks(store db.Storage, dbPath string) (*hooks.Dispatcher, *log.Logger
 	}
 	disp, err := hooks.New(loaded, deps)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("hooks: %w", err)
+		return nil, nil, fmt.Errorf("hooks: %w", err)
 	}
-	return disp, daemonLog, hookCfgPath, nil
+	return disp, daemonLog, nil
 }
 
 // shutdownHooks drives the dispatcher's Shutdown with a 10s ceiling.

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -33,7 +33,7 @@ import (
 
 func newDaemonCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "daemon", Short: "manage the kata daemon"}
-	cmd.AddCommand(daemonStartCmd(), daemonStatusCmd(), daemonStopCmd(), daemonReloadCmd(), daemonLogsCmd())
+	cmd.AddCommand(daemonStartCmd(), daemonStatusCmd(), daemonStopCmd(), daemonRestartCmd(), daemonReloadCmd(), daemonLogsCmd())
 	return cmd
 }
 
@@ -300,16 +300,28 @@ func daemonStatusCmd() *cobra.Command {
 				return emitJSON(cmd.OutOrStdout(), out)
 			}
 			if len(out.Daemons) == 0 {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no daemon running")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No kata daemon is running.")
 				return nil
 			}
 			for _, d := range out.Daemons {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "daemon pid=%d version=%s address=%s db=%s started_at=%s\n",
-					d.PID, d.Version, d.Address, d.DBPath, d.StartedAt.Format(time.RFC3339))
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "kata running at %s\n", daemonStatusAddress(d.Address))
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  pid:     %d\n", d.PID)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  version: %s\n", d.Version)
+				if !d.StartedAt.IsZero() {
+					uptime := time.Since(d.StartedAt).Round(time.Second)
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  uptime:  %s\n", uptime)
+				}
 			}
 			return nil
 		},
 	}
+}
+
+func daemonStatusAddress(address string) string {
+	if strings.Contains(address, "://") {
+		return address
+	}
+	return "http://" + address
 }
 
 type daemonStatusOutput struct {
@@ -390,6 +402,100 @@ type daemonStopOutput struct {
 	Action  string `json:"action"`
 	Stopped int    `json:"stopped"`
 	PIDs    []int  `json:"pids"`
+}
+
+func daemonRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart",
+		Short: "restart the daemon",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ns, err := daemon.NewNamespace()
+			if err != nil {
+				return err
+			}
+			recs, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).List()
+			if err != nil {
+				return err
+			}
+			pids := make([]int, 0, len(recs))
+			for _, rec := range recs {
+				if !kitdaemon.ProcessAlive(rec.PID) {
+					continue
+				}
+				if err := daemon.SignalDaemonStop(rec, ns.DBHash); err != nil {
+					return fmt.Errorf("restart: stop pid %d: %w", rec.PID, err)
+				}
+				pids = append(pids, rec.PID)
+			}
+			if err := waitForDaemonProcesses(cmd.Context(), pids, 3*time.Second); err != nil {
+				return err
+			}
+			out, err := startDetachedDaemon(cmd.Context(), "", false)
+			if err != nil {
+				return err
+			}
+			switch currentOutputMode() {
+			case outputJSON:
+				return emitJSON(cmd.OutOrStdout(), daemonRestartOutput{
+					Action:  "restart",
+					Stopped: len(pids),
+					PIDs:    pids,
+					PID:     out.PID,
+					Address: out.Address,
+					DBPath:  out.DBPath,
+				})
+			case outputAgent:
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK daemon action=restart pid=%d stopped=%d", out.PID, len(pids))
+				if len(pids) > 0 {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), " pids=%s", agentValue(joinInts(pids, ",")))
+				}
+				_, _ = fmt.Fprintln(cmd.OutOrStdout())
+			case outputHuman:
+				if len(pids) == 0 {
+					_, err = fmt.Fprintf(cmd.OutOrStdout(), "started pid=%d address=%s (was not running)\n", out.PID, out.Address)
+				} else {
+					_, err = fmt.Fprintf(cmd.OutOrStdout(), "restarted pid=%d address=%s\n", out.PID, out.Address)
+				}
+			}
+			return err
+		},
+	}
+}
+
+type daemonRestartOutput struct {
+	Action  string `json:"action"`
+	Stopped int    `json:"stopped"`
+	PIDs    []int  `json:"pids"`
+	PID     int    `json:"pid"`
+	Address string `json:"address"`
+	DBPath  string `json:"db_path,omitempty"`
+}
+
+func waitForDaemonProcesses(ctx context.Context, pids []int, timeout time.Duration) error {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		allStopped := true
+		for _, pid := range pids {
+			if kitdaemon.ProcessAlive(pid) {
+				allStopped = false
+				break
+			}
+		}
+		if allStopped {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("daemon did not stop within %s", timeout)
+		case <-tick.C:
+		}
+	}
 }
 
 func joinInts(values []int, sep string) string {

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -37,7 +37,32 @@ func TestDaemonStatus_NoDaemonReportsAbsent(t *testing.T) {
 	setupKataEnv(t)
 
 	out := executeRoot(t, newDaemonCmd(), "status")
-	assert.Contains(t, string(out), "no daemon")
+	assert.Equal(t, "No kata daemon is running.\n", string(out))
+}
+
+func TestDaemonStatus_HumanReportsLifecycleDetails(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	require.NoError(t, ns.EnsureDirs())
+	started := time.Now().Add(-52*time.Minute - 33*time.Second)
+	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
+		PID:       os.Getpid(),
+		Network:   "tcp",
+		Address:   "127.0.0.1:7777",
+		Version:   "v-test-status",
+		StartedAt: started,
+	})
+	require.NoError(t, err)
+
+	out := string(executeRoot(t, newRootCmd(), "daemon", "status"))
+
+	assert.Contains(t, out, "kata running at http://127.0.0.1:7777\n")
+	assert.Contains(t, out, "  pid:     "+strconv.Itoa(os.Getpid())+"\n")
+	assert.Contains(t, out, "  version: v-test-status\n")
+	assert.Regexp(t, `(?m)^  uptime:  52m3[3-4]s$`, out)
 }
 
 func TestDaemonStatus_JSONReportsDaemonsWithVersion(t *testing.T) {
@@ -481,6 +506,106 @@ func TestDaemonStop_JSONReportsMultiplePIDs(t *testing.T) {
 	assert.Equal(t, "stop", got.Action)
 	assert.Equal(t, 2, got.Stopped)
 	assert.ElementsMatch(t, []int{first.Process.Pid, second.Process.Pid}, got.PIDs)
+}
+
+func TestDaemonRestart_StartsWhenNoDaemonIsRunning(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+
+	orig := startDetachedDaemon
+	t.Cleanup(func() { startDetachedDaemon = orig })
+	startDetachedDaemon = func(context.Context, string, bool) (daemonStartOutput, error) {
+		return daemonStartOutput{
+			Action:  "started",
+			PID:     4242,
+			Address: "127.0.0.1:7777",
+		}, nil
+	}
+
+	out := executeRoot(t, newRootCmd(), "daemon", "restart")
+
+	assert.Equal(t, "started pid=4242 address=127.0.0.1:7777 (was not running)\n", string(out))
+}
+
+func TestDaemonRestart_StopsRunningDaemonBeforeStarting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the test helper does not install the Windows daemon stop event watcher")
+	}
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+
+	child := exec.Command(os.Args[0], "-test.run=TestDaemonCommandSleepHelperProcess", "--") //nolint:gosec // test helper starts this test binary
+	child.Env = append(os.Environ(), "KATA_DAEMON_CMD_SLEEP_HELPER=1")
+	require.NoError(t, child.Start())
+	exited := make(chan struct{})
+	go func() {
+		_ = child.Wait()
+		close(exited)
+	}()
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		<-exited
+	})
+	writeRuntimePID(t, tmp, child.Process.Pid)
+
+	orig := startDetachedDaemon
+	t.Cleanup(func() { startDetachedDaemon = orig })
+	startDetachedDaemon = func(context.Context, string, bool) (daemonStartOutput, error) {
+		select {
+		case <-exited:
+			return daemonStartOutput{Action: "started", PID: 4243, Address: "127.0.0.1:7777"}, nil
+		default:
+			return daemonStartOutput{}, errors.New("new daemon started before old daemon stopped")
+		}
+	}
+
+	out := executeRoot(t, newRootCmd(), "daemon", "restart")
+
+	assert.Equal(t, "restarted pid=4243 address=127.0.0.1:7777\n", string(out))
+}
+
+func TestDaemonRestart_JSONReportsStartedDaemon(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+
+	orig := startDetachedDaemon
+	t.Cleanup(func() { startDetachedDaemon = orig })
+	startDetachedDaemon = func(context.Context, string, bool) (daemonStartOutput, error) {
+		return daemonStartOutput{Action: "started", PID: 4242, Address: "127.0.0.1:7777"}, nil
+	}
+
+	out := executeRoot(t, newRootCmd(), "--json", "daemon", "restart")
+
+	var got struct {
+		KataAPIVersion int    `json:"kata_api_version"`
+		Action         string `json:"action"`
+		Stopped        int    `json:"stopped"`
+		PIDs           []int  `json:"pids"`
+		PID            int    `json:"pid"`
+		Address        string `json:"address"`
+	}
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, 1, got.KataAPIVersion)
+	assert.Equal(t, "restart", got.Action)
+	assert.Zero(t, got.Stopped)
+	assert.Empty(t, got.PIDs)
+	assert.Equal(t, 4242, got.PID)
+	assert.Equal(t, "127.0.0.1:7777", got.Address)
+}
+
+func TestDaemonRestart_AgentReportsStartedDaemon(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+
+	orig := startDetachedDaemon
+	t.Cleanup(func() { startDetachedDaemon = orig })
+	startDetachedDaemon = func(context.Context, string, bool) (daemonStartOutput, error) {
+		return daemonStartOutput{Action: "started", PID: 4242, Address: "127.0.0.1:7777"}, nil
+	}
+
+	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "restart")
+
+	assert.Equal(t, "OK daemon action=restart pid=4242 stopped=0\n", string(out))
 }
 
 func TestDaemonReload_AgentReportsReloadedPID(t *testing.T) {

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -674,39 +674,83 @@ func TestDaemonRestart_ValidatesReplacementBeforeStopping(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("the test helper does not install the Windows daemon stop event watcher")
 	}
-	resetFlags(t)
-	tmp := setupKataEnv(t)
-	require.NoError(t, os.WriteFile(filepath.Join(tmp, "config.toml"),
-		[]byte("listen = \"100.64.0.5:7777\"\n"), 0o600))
-
-	child := exec.Command(os.Args[0], "-test.run=TestDaemonCommandSleepHelperProcess", "--") //nolint:gosec // test helper starts this test binary
-	child.Env = append(os.Environ(), "KATA_DAEMON_CMD_SLEEP_HELPER=1")
-	require.NoError(t, child.Start())
-	exited := make(chan struct{})
-	go func() {
-		_ = child.Wait()
-		close(exited)
-	}()
-	t.Cleanup(func() {
-		_ = child.Process.Kill()
-		<-exited
-	})
-	writeRuntimePID(t, tmp, child.Process.Pid)
-
-	orig := startDetachedDaemon
-	t.Cleanup(func() { startDetachedDaemon = orig })
-	startCalled := false
-	startDetachedDaemon = func(context.Context, string, bool) (daemonStartOutput, error) {
-		startCalled = true
-		return daemonStartOutput{}, errors.New("replacement startup attempted")
+	tests := []struct {
+		name    string
+		setup   func(*testing.T, string)
+		wantErr string
+	}{
+		{
+			name: "auth config",
+			setup: func(t *testing.T, tmp string) {
+				require.NoError(t, os.WriteFile(filepath.Join(tmp, "config.toml"),
+					[]byte("listen = \"100.64.0.5:7777\"\n"), 0o600))
+			},
+			wantErr: "pass --insecure-readonly",
+		},
+		{
+			name: "storage DSN",
+			setup: func(t *testing.T, _ string) {
+				t.Setenv("KATA_DSN", "postgres://db.example/kata")
+			},
+			wantErr: "postgres backend is not selectable",
+		},
+		{
+			name: "hooks config",
+			setup: func(t *testing.T, tmp string) {
+				require.NoError(t, os.WriteFile(filepath.Join(tmp, "hooks.toml"),
+					[]byte("[[hook]\nevent =\n"), 0o600))
+			},
+			wantErr: "parse hooks config",
+		},
+		{
+			name: "embedding config",
+			setup: func(t *testing.T, tmp string) {
+				require.NoError(t, os.WriteFile(filepath.Join(tmp, "config.toml"), []byte(`
+[search.embeddings]
+base_url = "http://embedding.example"
+model = "example-model"
+`), 0o600))
+			},
+			wantErr: "embedding client",
+		},
 	}
 
-	_, _, err := executeRootCapture(t, context.Background(), "daemon", "restart")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFlags(t)
+			tmp := setupKataEnv(t)
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "pass --insecure-readonly")
-	assert.False(t, startCalled)
-	assert.True(t, kitdaemon.ProcessAlive(child.Process.Pid), "invalid replacement config must leave the daemon running")
+			child := exec.Command(os.Args[0], "-test.run=TestDaemonCommandSleepHelperProcess", "--") //nolint:gosec // test helper starts this test binary
+			child.Env = append(os.Environ(), "KATA_DAEMON_CMD_SLEEP_HELPER=1")
+			require.NoError(t, child.Start())
+			exited := make(chan struct{})
+			go func() {
+				_ = child.Wait()
+				close(exited)
+			}()
+			t.Cleanup(func() {
+				_ = child.Process.Kill()
+				<-exited
+			})
+			writeRuntimePID(t, tmp, child.Process.Pid)
+			tt.setup(t, tmp)
+
+			orig := startDetachedDaemon
+			t.Cleanup(func() { startDetachedDaemon = orig })
+			startCalled := false
+			startDetachedDaemon = func(context.Context, string, bool) (daemonStartOutput, error) {
+				startCalled = true
+				return daemonStartOutput{}, errors.New("replacement startup attempted")
+			}
+
+			_, _, err := executeRootCapture(t, context.Background(), "daemon", "restart")
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.False(t, startCalled)
+			assert.True(t, kitdaemon.ProcessAlive(child.Process.Pid), "invalid replacement config must leave the daemon running")
+		})
+	}
 }
 
 func TestDaemonReload_AgentReportsReloadedPID(t *testing.T) {

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -564,6 +565,47 @@ func TestDaemonRestart_StopsRunningDaemonBeforeStarting(t *testing.T) {
 	assert.Equal(t, "restarted pid=4243 address=127.0.0.1:7777\n", string(out))
 }
 
+func TestDaemonRestart_AllowsFullGracefulShutdownBudget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the test helper does not install the Windows daemon stop event watcher")
+	}
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	readyPath := filepath.Join(tmp, "shutdown-delay-ready")
+
+	child := exec.Command(os.Args[0], "-test.run=TestDaemonCommandSleepHelperProcess", "--") //nolint:gosec // test helper starts this test binary
+	child.Env = append(os.Environ(),
+		"KATA_DAEMON_CMD_SLEEP_HELPER=1",
+		"KATA_DAEMON_CMD_SHUTDOWN_DELAY=4s",
+		"KATA_DAEMON_CMD_READY_PATH="+readyPath,
+	)
+	require.NoError(t, child.Start())
+	exited := make(chan struct{})
+	go func() {
+		_ = child.Wait()
+		close(exited)
+	}()
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		<-exited
+	})
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(readyPath)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+	writeRuntimePID(t, tmp, child.Process.Pid)
+
+	orig := startDetachedDaemon
+	t.Cleanup(func() { startDetachedDaemon = orig })
+	startDetachedDaemon = func(context.Context, string, bool) (daemonStartOutput, error) {
+		return daemonStartOutput{Action: "started", PID: 4244, Address: "127.0.0.1:7777"}, nil
+	}
+
+	out := executeRoot(t, newRootCmd(), "daemon", "restart")
+
+	assert.Equal(t, "restarted pid=4244 address=127.0.0.1:7777\n", string(out))
+}
+
 func TestDaemonRestart_JSONReportsStartedDaemon(t *testing.T) {
 	resetFlags(t)
 	setupKataEnv(t)
@@ -606,6 +648,65 @@ func TestDaemonRestart_AgentReportsStartedDaemon(t *testing.T) {
 	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "restart")
 
 	assert.Equal(t, "OK daemon action=restart pid=4242 stopped=0\n", string(out))
+}
+
+func TestDaemonRestart_PassesStartupOverrides(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+
+	orig := startDetachedDaemon
+	t.Cleanup(func() { startDetachedDaemon = orig })
+	var gotListen string
+	var gotInsecureReadonly bool
+	startDetachedDaemon = func(_ context.Context, listen string, insecureReadonly bool) (daemonStartOutput, error) {
+		gotListen = listen
+		gotInsecureReadonly = insecureReadonly
+		return daemonStartOutput{Action: "started", PID: 4242, Address: listen}, nil
+	}
+
+	executeRoot(t, newRootCmd(), "daemon", "restart", "--listen", "100.64.0.5:7777", "--insecure-readonly")
+
+	assert.Equal(t, "100.64.0.5:7777", gotListen)
+	assert.True(t, gotInsecureReadonly)
+}
+
+func TestDaemonRestart_ValidatesReplacementBeforeStopping(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the test helper does not install the Windows daemon stop event watcher")
+	}
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "config.toml"),
+		[]byte("listen = \"100.64.0.5:7777\"\n"), 0o600))
+
+	child := exec.Command(os.Args[0], "-test.run=TestDaemonCommandSleepHelperProcess", "--") //nolint:gosec // test helper starts this test binary
+	child.Env = append(os.Environ(), "KATA_DAEMON_CMD_SLEEP_HELPER=1")
+	require.NoError(t, child.Start())
+	exited := make(chan struct{})
+	go func() {
+		_ = child.Wait()
+		close(exited)
+	}()
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		<-exited
+	})
+	writeRuntimePID(t, tmp, child.Process.Pid)
+
+	orig := startDetachedDaemon
+	t.Cleanup(func() { startDetachedDaemon = orig })
+	startCalled := false
+	startDetachedDaemon = func(context.Context, string, bool) (daemonStartOutput, error) {
+		startCalled = true
+		return daemonStartOutput{}, errors.New("replacement startup attempted")
+	}
+
+	_, _, err := executeRootCapture(t, context.Background(), "daemon", "restart")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pass --insecure-readonly")
+	assert.False(t, startCalled)
+	assert.True(t, kitdaemon.ProcessAlive(child.Process.Pid), "invalid replacement config must leave the daemon running")
 }
 
 func TestDaemonReload_AgentReportsReloadedPID(t *testing.T) {
@@ -1434,6 +1535,22 @@ func startSleepProcess(t *testing.T) *exec.Cmd {
 func TestDaemonCommandSleepHelperProcess(_ *testing.T) {
 	if os.Getenv("KATA_DAEMON_CMD_SLEEP_HELPER") != "1" {
 		return
+	}
+	if rawDelay := os.Getenv("KATA_DAEMON_CMD_SHUTDOWN_DELAY"); rawDelay != "" {
+		delay, err := time.ParseDuration(rawDelay)
+		if err != nil {
+			os.Exit(2)
+		}
+		shutdown := make(chan os.Signal, 1)
+		signal.Notify(shutdown)
+		if readyPath := os.Getenv("KATA_DAEMON_CMD_READY_PATH"); readyPath != "" {
+			if err := os.WriteFile(readyPath, nil, 0o600); err != nil { //nolint:gosec // test-controlled path under t.TempDir
+				os.Exit(3)
+			}
+		}
+		<-shutdown
+		time.Sleep(delay)
+		os.Exit(0)
 	}
 	_, _ = io.Copy(io.Discard, os.Stdin)
 	os.Exit(0)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -382,7 +382,7 @@ redaction tool. If `<project>` is omitted, kata resolves the project from
 kata daemon start [--foreground] [--listen <host:port>] [--insecure-readonly]
 kata daemon status
 kata daemon stop
-kata daemon restart
+kata daemon restart [--listen <host:port>] [--insecure-readonly]
 kata daemon reload
 kata daemon logs --hooks [--tail]
 kata health
@@ -397,8 +397,10 @@ background daemon and returns after startup is confirmed. Use
 `daemon start --foreground` for service managers, hosted deployments, and any
 setup where the daemon process should stay attached to the terminal. `daemon
 restart` gracefully stops any running local daemon, waits for it to exit, and
-starts a replacement using the configured listener. `daemon status` reports
-the running daemon's address, PID, version, and uptime.
+starts a replacement using the configured listener. It validates replacement
+settings before stopping the current daemon; use the restart flags to repeat
+transient startup overrides. `daemon status` reports the running daemon's
+address, PID, version, and uptime.
 `kata agent-instructions` is an alias for `kata quickstart`.
 For TCP listener auth modes, including trusted private-network bearer auth,
 read-only experiments, and explicit tokenless private-network writes, see

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -382,6 +382,7 @@ redaction tool. If `<project>` is omitted, kata resolves the project from
 kata daemon start [--foreground] [--listen <host:port>] [--insecure-readonly]
 kata daemon status
 kata daemon stop
+kata daemon restart
 kata daemon reload
 kata daemon logs --hooks [--tail]
 kata health
@@ -394,7 +395,10 @@ kata tui
 Local commands auto-start the daemon when appropriate. `daemon start` starts a
 background daemon and returns after startup is confirmed. Use
 `daemon start --foreground` for service managers, hosted deployments, and any
-setup where the daemon process should stay attached to the terminal.
+setup where the daemon process should stay attached to the terminal. `daemon
+restart` gracefully stops any running local daemon, waits for it to exit, and
+starts a replacement using the configured listener. `daemon status` reports
+the running daemon's address, PID, version, and uptime.
 `kata agent-instructions` is an alias for `kata quickstart`.
 For TCP listener auth modes, including trusted private-network bearer auth,
 read-only experiments, and explicit tokenless private-network writes, see

--- a/internal/db/storeopen/storeopen.go
+++ b/internal/db/storeopen/storeopen.go
@@ -27,18 +27,29 @@ import (
 // schema/bootstrap tests, but its domain methods are still stubs.
 var ErrPostgresNotSelectable = errors.New("postgres backend is not selectable until db.Storage methods are implemented")
 
+// Validate reports whether dsn selects a storage backend this binary can
+// start without opening or mutating the database.
+func Validate(dsn string) error {
+	scheme, _, hasScheme := splitScheme(dsn)
+	switch {
+	case hasScheme && (scheme == "postgres" || scheme == "postgresql"):
+		return ErrPostgresNotSelectable
+	case hasScheme && scheme != "sqlite":
+		return fmt.Errorf("unsupported dsn scheme %q", scheme)
+	default:
+		return nil
+	}
+}
+
 // Open selects a storage backend from the DSN and returns a ready-to-use
 // db.Storage. SQLite DSNs at a pre-current schema_version are upgraded through
 // internal/jsonl.AutoCutover before the backend handle is opened.
 func Open(ctx context.Context, dsn string, opts ...db.OpenOption) (db.Storage, error) {
 	cfg := db.ApplyOpenOptions(opts...)
-	scheme, _, hasScheme := splitScheme(dsn)
-	switch {
-	case hasScheme && (scheme == "postgres" || scheme == "postgresql"):
-		return nil, ErrPostgresNotSelectable
-	case hasScheme && scheme != "sqlite":
-		return nil, fmt.Errorf("unsupported dsn scheme %q", scheme)
+	if err := Validate(dsn); err != nil {
+		return nil, err
 	}
+	_, _, hasScheme := splitScheme(dsn)
 	path := dsn
 	if hasScheme {
 		path = strings.TrimPrefix(dsn, "sqlite://")


### PR DESCRIPTION
Routine daemon maintenance currently requires operators to compose stop and start themselves. That leaves a shutdown race and makes configuration-driven restarts unnecessarily awkward.

Restart validates listener, authentication, storage backend, hooks, and embedding settings before stopping the current daemon; supports the same transient listener and read-only overrides as startup; and allows the full graceful-shutdown budget before failing the cutover. Human status output shows the endpoint, PID, version, and uptime while the established JSON and agent status contracts remain unchanged.