### PR TITLE
Report live embedding progress and ETA

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -782,14 +782,30 @@ components:
           type: integer
         configured:
           type: boolean
+        embedded:
+          format: int64
+          type: integer
+        eta_seconds:
+          format: int64
+          type: integer
         last_error_status:
           format: int64
           type: integer
+        last_progress_at:
+          format: date-time
+          type: string
         last_success_at:
+          format: date-time
+          type: string
+        rate_per_second:
+          format: double
+          type: number
+        started_at:
           format: date-time
           type: string
       required:
         - configured
+        - embedded
         - backlog
       type: object
     EnableIssueSyncRequestBody:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -800,12 +800,16 @@ components:
         rate_per_second:
           format: double
           type: number
+        skipped:
+          format: int64
+          type: integer
         started_at:
           format: date-time
           type: string
       required:
         - configured
         - embedded
+        - skipped
         - backlog
       type: object
     EnableIssueSyncRequestBody:

--- a/docs/design/semantic-search.md
+++ b/docs/design/semantic-search.md
@@ -241,16 +241,15 @@ Failure classes:
   health.
 - 429 — honor `Retry-After` when present, otherwise normal backoff.
 - 5xx / timeouts / connection errors — exponential backoff, 1s doubling to a
-  5m cap. The backlog gauge is a snapshot, not a live counter: it is
-  published before each fill starts and refreshed when a fill fails partway
-  (and again after success), so `/health` shows the pending count as of the
-  cycle's start during a long backfill — never the previous cycle's value,
-  and never a stale zero across an outage — while documents stamped by an
-  in-flight fill are reflected at the next snapshot.
+  5m cap. The backlog gauge is published before each fill starts, decreases
+  after every successfully persisted document, and is refreshed when a fill
+  fails partway and after success. `/health` therefore exposes live progress
+  during a long backfill without reporting stale zero across an outage.
 
-Reconciler health — `{configured, last_success_at, last_error_status, backlog}` —
-joins the `/health` payload (following the `api_schema_version` reporting
-precedent) and is the operator's view of index freshness.
+Reconciler health includes current-generation embedded, skipped, and pending
+coverage plus progress timing and ETA alongside provider status. It joins the
+`/health` payload (following the `api_schema_version` reporting precedent) and
+is the operator's view of index freshness.
 
 ### Freshness contract
 

--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -110,6 +110,8 @@ You can watch the reconciler in `kata health --json` under `embeddings`:
 - `configured` — whether an endpoint is set;
 - `embedded` — how many issues are embedded at their current revision for the
   configured generation;
+- `skipped` — how many issues were deliberately stamped without vectors after
+  the configured model rejected their content;
 - `backlog` — how many issues are waiting to be (re-)embedded; decreases as
   each issue is persisted and trends to 0;
 - `rate_per_second` and `eta_seconds` — a smoothed measured rate and estimated

--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -108,8 +108,15 @@ Either way the staleness is brief and bounded by reconciler lag.
 You can watch the reconciler in `kata health --json` under `embeddings`:
 
 - `configured` — whether an endpoint is set;
+- `embedded` — how many issues are embedded at their current revision for the
+  configured generation;
 - `backlog` — how many issues are waiting to be (re-)embedded; decreases as
   each issue is persisted and trends to 0;
+- `rate_per_second` and `eta_seconds` — a smoothed measured rate and estimated
+  time remaining; omitted until at least two positive progress samples exist;
+- `started_at` and `last_progress_at` — when the current backfill began and
+  when its most recent issue was persisted, useful for distinguishing slow
+  progress from a stalled endpoint;
 - `last_success_at` — when the reconciler last completed a batch;
 - `last_error_status` — the HTTP status of the most recent embedding-endpoint
   error response, if any. It is set only when the endpoint answered with an

--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -108,7 +108,8 @@ Either way the staleness is brief and bounded by reconciler lag.
 You can watch the reconciler in `kata health --json` under `embeddings`:
 
 - `configured` — whether an endpoint is set;
-- `backlog` — how many issues are waiting to be (re-)embedded; trends to 0;
+- `backlog` — how many issues are waiting to be (re-)embedded; decreases as
+  each issue is persisted and trends to 0;
 - `last_success_at` — when the reconciler last completed a batch;
 - `last_error_status` — the HTTP status of the most recent embedding-endpoint
   error response, if any. It is set only when the endpoint answered with an

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -263,7 +263,7 @@ stores, and no vectors are sent to or pulled from federated hubs.
 The daemon keeps the index fresh on its own: a background reconciler embeds new
 and edited issues within seconds, and `kata` reports its state under
 `embeddings` in the `/health` response (`configured`, `last_success_at`,
-`last_error_status`, `embedded`, and `backlog`). During a backfill it also
+`last_error_status`, `embedded`, `skipped`, and `backlog`). During a backfill it also
 reports `started_at` and `last_progress_at`, then adds a smoothed
 `rate_per_second` and `eta_seconds` after two positive progress samples. Search
 never blocks on embedding lag — an issue is findable lexically the instant it

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -263,9 +263,11 @@ stores, and no vectors are sent to or pulled from federated hubs.
 The daemon keeps the index fresh on its own: a background reconciler embeds new
 and edited issues within seconds, and `kata` reports its state under
 `embeddings` in the `/health` response (`configured`, `last_success_at`,
-`last_error_status`, and `backlog`). Search never blocks on embedding lag — an
-issue is findable lexically the instant it is created, and gains semantic recall
-once the reconciler catches up.
+`last_error_status`, `embedded`, and `backlog`). During a backfill it also
+reports `started_at` and `last_progress_at`, then adds a smoothed
+`rate_per_second` and `eta_seconds` after two positive progress samples. Search
+never blocks on embedding lag — an issue is findable lexically the instant it
+is created, and gains semantic recall once the reconciler catches up.
 
 Issue text is chunked before embedding rather than embedded as a single
 truncated vector, so long issues get full semantic coverage instead of losing

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -52,6 +52,7 @@ type EmbeddingsHealth struct {
 	LastSuccessAt   *time.Time `json:"last_success_at,omitempty"`
 	LastErrorStatus int        `json:"last_error_status,omitempty"`
 	Embedded        int64      `json:"embedded"`
+	Skipped         int64      `json:"skipped"`
 	Backlog         int64      `json:"backlog"`
 	RatePerSecond   *float64   `json:"rate_per_second,omitempty"`
 	ETASeconds      *int64     `json:"eta_seconds,omitempty"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -51,7 +51,12 @@ type EmbeddingsHealth struct {
 	Configured      bool       `json:"configured"`
 	LastSuccessAt   *time.Time `json:"last_success_at,omitempty"`
 	LastErrorStatus int        `json:"last_error_status,omitempty"`
+	Embedded        int64      `json:"embedded"`
 	Backlog         int64      `json:"backlog"`
+	RatePerSecond   *float64   `json:"rate_per_second,omitempty"`
+	ETASeconds      *int64     `json:"eta_seconds,omitempty"`
+	StartedAt       *time.Time `json:"started_at,omitempty"`
+	LastProgressAt  *time.Time `json:"last_progress_at,omitempty"`
 }
 
 // InstanceResponse mirrors /api/v1/instance. Surfaces the local kata

--- a/internal/daemon/handlers_health.go
+++ b/internal/daemon/handlers_health.go
@@ -53,6 +53,7 @@ func registerHealthHandlers(humaAPI huma.API, cfg ServerConfig) {
 				LastSuccessAt:   h.LastSuccessAt,
 				LastErrorStatus: h.LastErrorStatus,
 				Embedded:        h.Embedded,
+				Skipped:         h.Skipped,
 				Backlog:         h.Backlog,
 				RatePerSecond:   h.RatePerSecond,
 				ETASeconds:      h.ETASeconds,

--- a/internal/daemon/handlers_health.go
+++ b/internal/daemon/handlers_health.go
@@ -52,7 +52,12 @@ func registerHealthHandlers(humaAPI huma.API, cfg ServerConfig) {
 				Configured:      h.Configured,
 				LastSuccessAt:   h.LastSuccessAt,
 				LastErrorStatus: h.LastErrorStatus,
+				Embedded:        h.Embedded,
 				Backlog:         h.Backlog,
+				RatePerSecond:   h.RatePerSecond,
+				ETASeconds:      h.ETASeconds,
+				StartedAt:       h.StartedAt,
+				LastProgressAt:  h.LastProgressAt,
 			}
 		}
 		return out, nil

--- a/internal/daemon/handlers_health_test.go
+++ b/internal/daemon/handlers_health_test.go
@@ -46,6 +46,10 @@ func TestHealth_OmitsEmbeddingsWhenUnconfigured(t *testing.T) {
 func TestHealth_IncludesEmbeddingsWhenConfigured(t *testing.T) {
 	d := openTestDB(t)
 	last := time.Date(2026, 6, 22, 10, 0, 0, 0, time.UTC)
+	started := last.Add(-time.Minute)
+	lastProgress := last.Add(-time.Second)
+	rate := 2.5
+	eta := int64(2)
 	ts := startTestServer(t, daemon.ServerConfig{
 		DB:        d.db,
 		StartedAt: d.now,
@@ -55,7 +59,12 @@ func TestHealth_IncludesEmbeddingsWhenConfigured(t *testing.T) {
 				LastSuccessAt:   &last,
 				LastError:       "provider reflected issue body: secret project content",
 				LastErrorStatus: 400,
+				Embedded:        7,
 				Backlog:         5,
+				RatePerSecond:   &rate,
+				ETASeconds:      &eta,
+				StartedAt:       &started,
+				LastProgressAt:  &lastProgress,
 			}
 		},
 	})
@@ -66,7 +75,16 @@ func TestHealth_IncludesEmbeddingsWhenConfigured(t *testing.T) {
 	getAndUnmarshal(t, ts, "/api/v1/health", http.StatusOK, &body)
 	require.NotNil(t, body.Embeddings, "embeddings health must surface when ReconcilerHealth is wired")
 	assert.True(t, body.Embeddings.Configured)
+	assert.Equal(t, int64(7), body.Embeddings.Embedded)
 	assert.Equal(t, int64(5), body.Embeddings.Backlog)
+	require.NotNil(t, body.Embeddings.RatePerSecond)
+	assert.InDelta(t, 2.5, *body.Embeddings.RatePerSecond, 0.001)
+	require.NotNil(t, body.Embeddings.ETASeconds)
+	assert.Equal(t, int64(2), *body.Embeddings.ETASeconds)
+	require.NotNil(t, body.Embeddings.StartedAt)
+	assert.True(t, body.Embeddings.StartedAt.Equal(started))
+	require.NotNil(t, body.Embeddings.LastProgressAt)
+	assert.True(t, body.Embeddings.LastProgressAt.Equal(lastProgress))
 	assert.Equal(t, 400, body.Embeddings.LastErrorStatus)
 	require.NotNil(t, body.Embeddings.LastSuccessAt)
 	assert.True(t, body.Embeddings.LastSuccessAt.Equal(last))

--- a/internal/daemon/handlers_health_test.go
+++ b/internal/daemon/handlers_health_test.go
@@ -60,6 +60,7 @@ func TestHealth_IncludesEmbeddingsWhenConfigured(t *testing.T) {
 				LastError:       "provider reflected issue body: secret project content",
 				LastErrorStatus: 400,
 				Embedded:        7,
+				Skipped:         1,
 				Backlog:         5,
 				RatePerSecond:   &rate,
 				ETASeconds:      &eta,
@@ -76,6 +77,7 @@ func TestHealth_IncludesEmbeddingsWhenConfigured(t *testing.T) {
 	require.NotNil(t, body.Embeddings, "embeddings health must surface when ReconcilerHealth is wired")
 	assert.True(t, body.Embeddings.Configured)
 	assert.Equal(t, int64(7), body.Embeddings.Embedded)
+	assert.Equal(t, int64(1), body.Embeddings.Skipped)
 	assert.Equal(t, int64(5), body.Embeddings.Backlog)
 	require.NotNil(t, body.Embeddings.RatePerSecond)
 	assert.InDelta(t, 2.5, *body.Embeddings.RatePerSecond, 0.001)

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"math"
 	"sync"
 	"time"
 
@@ -26,6 +27,7 @@ type ReconcilerConfig struct {
 	SweepEvery time.Duration // periodic safety sweep; default 5m
 	MinBackoff time.Duration // default 1s
 	MaxBackoff time.Duration // default 5m
+	Now        func() time.Time
 }
 
 // ReconcilerHealth is the operator-visible state surfaced in /health.
@@ -34,7 +36,12 @@ type ReconcilerHealth struct {
 	LastSuccessAt   *time.Time `json:"last_success_at,omitempty"`
 	LastError       string     `json:"-"`
 	LastErrorStatus int        `json:"last_error_status,omitempty"`
+	Embedded        int64      `json:"embedded"`
 	Backlog         int64      `json:"backlog"`
+	RatePerSecond   *float64   `json:"rate_per_second,omitempty"`
+	ETASeconds      *int64     `json:"eta_seconds,omitempty"`
+	StartedAt       *time.Time `json:"started_at,omitempty"`
+	LastProgressAt  *time.Time `json:"last_progress_at,omitempty"`
 }
 
 // Reconciler keeps the vector sidecar's active generation fresh: it mirrors
@@ -46,10 +53,24 @@ type Reconciler struct {
 	emb   embedder
 	cfg   ReconcilerConfig
 	wake  chan struct{}
+	now   func() time.Time
 
-	mu     sync.Mutex
-	health ReconcilerHealth
+	mu       sync.Mutex
+	health   ReconcilerHealth
+	progress embeddingProgress
 }
+
+type embeddingProgress struct {
+	generation   string
+	total        int64
+	lastEmbedded int64
+	lastAt       time.Time
+	startedAt    time.Time
+	rate         float64
+	samples      int
+}
+
+const progressRateAlpha = 0.3
 
 // NewReconciler constructs a reconciler. It does no I/O.
 func NewReconciler(store db.Storage, idx *vector.Index, emb embedder, cfg ReconcilerConfig) *Reconciler {
@@ -62,12 +83,16 @@ func NewReconciler(store db.Storage, idx *vector.Index, emb embedder, cfg Reconc
 	if cfg.MaxBackoff <= 0 {
 		cfg.MaxBackoff = 5 * time.Minute
 	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
 	return &Reconciler{
 		store:  store,
 		idx:    idx,
 		emb:    emb,
 		cfg:    cfg,
 		wake:   make(chan struct{}, 1),
+		now:    cfg.Now,
 		health: ReconcilerHealth{Configured: true},
 	}
 }
@@ -92,6 +117,14 @@ func (r *Reconciler) Health() ReconcilerHealth {
 	if r.health.LastSuccessAt != nil {
 		t := *r.health.LastSuccessAt
 		h.LastSuccessAt = &t
+	}
+	if r.health.StartedAt != nil {
+		t := *r.health.StartedAt
+		h.StartedAt = &t
+	}
+	if r.health.LastProgressAt != nil {
+		t := *r.health.LastProgressAt
+		h.LastProgressAt = &t
 	}
 	return h
 }
@@ -169,15 +202,15 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 	}
 	// Publish the pending count before the fill so /health reports the real
 	// backlog during a long backfill instead of the previous cycle's value.
-	backlog, err := r.idx.Backlog(ctx, key)
+	embedded, backlog, err := r.idx.Coverage(ctx, key)
 	if err != nil {
 		r.markError(err)
 		return err
 	}
-	r.setBacklog(backlog)
+	r.setCoverage(key, embedded, backlog)
 	if _, err := r.idx.Fill(ctx, key, r.emb.EncodeFunc(), r.cfg.BatchSize, r.emb.BatchSize(), r.markDocumentFilled); err != nil {
-		if backlog, berr := r.idx.Backlog(ctx, key); berr == nil {
-			r.setBacklog(backlog)
+		if embedded, backlog, coverageErr := r.idx.Coverage(ctx, key); coverageErr == nil {
+			r.setCoverage(key, embedded, backlog)
 		}
 		r.markError(err)
 		return err
@@ -186,12 +219,12 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 		r.markError(err)
 		return err
 	}
-	backlog, err = r.idx.Backlog(ctx, key)
+	embedded, backlog, err = r.idx.Coverage(ctx, key)
 	if err != nil {
 		r.markError(err)
 		return err
 	}
-	r.setBacklog(backlog)
+	r.setCoverage(key, embedded, backlog)
 	r.markSuccess()
 	return nil
 }
@@ -199,7 +232,9 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 func (r *Reconciler) markDocumentFilled() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.health.Embedded++
 	r.health.Backlog--
+	r.recordProgressLocked(r.health.Embedded, r.now())
 }
 
 func (r *Reconciler) markSuccess() {
@@ -215,6 +250,7 @@ func (r *Reconciler) markError(err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.health.LastError = err.Error()
+	r.health.ETASeconds = nil
 	var apiErr *embedding.APIError
 	if errors.As(err, &apiErr) {
 		r.health.LastErrorStatus = apiErr.StatusCode
@@ -223,8 +259,70 @@ func (r *Reconciler) markError(err error) {
 	}
 }
 
-func (r *Reconciler) setBacklog(n int64) {
+func (r *Reconciler) setCoverage(generation string, embedded, backlog int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.health.Backlog = n
+	r.health.Embedded = embedded
+	r.health.Backlog = backlog
+	if backlog == 0 {
+		r.resetProgressLocked()
+		return
+	}
+	total := embedded + backlog
+	if r.progress.generation != generation || r.progress.total != total ||
+		embedded < r.progress.lastEmbedded || r.progress.startedAt.IsZero() {
+		now := r.now()
+		r.progress = embeddingProgress{
+			generation:   generation,
+			total:        total,
+			lastEmbedded: embedded,
+			lastAt:       now,
+			startedAt:    now,
+		}
+		r.health.StartedAt = &now
+		r.health.LastProgressAt = nil
+		r.health.RatePerSecond = nil
+		r.health.ETASeconds = nil
+		return
+	}
+	if embedded > r.progress.lastEmbedded {
+		r.recordProgressLocked(embedded, r.now())
+	}
+}
+
+func (r *Reconciler) recordProgressLocked(embedded int64, now time.Time) {
+	delta := embedded - r.progress.lastEmbedded
+	elapsed := now.Sub(r.progress.lastAt).Seconds()
+	r.progress.lastEmbedded = embedded
+	r.progress.lastAt = now
+	r.health.LastProgressAt = &now
+	if delta <= 0 || elapsed <= 0 {
+		return
+	}
+	instantRate := float64(delta) / elapsed
+	if r.progress.samples == 0 {
+		r.progress.rate = instantRate
+	} else {
+		r.progress.rate = progressRateAlpha*instantRate + (1-progressRateAlpha)*r.progress.rate
+	}
+	r.progress.samples++
+	if r.progress.samples < 2 {
+		return
+	}
+	rate := r.progress.rate
+	r.health.RatePerSecond = &rate
+	if r.health.Backlog > 0 {
+		eta := int64(math.Ceil(float64(r.health.Backlog) / rate))
+		r.health.ETASeconds = &eta
+	} else {
+		r.health.ETASeconds = nil
+	}
+}
+
+func (r *Reconciler) resetProgressLocked() {
+	r.progress = embeddingProgress{}
+	r.health.RatePerSecond = nil
+	r.health.ETASeconds = nil
+	r.health.StartedAt = nil
+	r.health.LastProgressAt = nil
 }

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -175,7 +175,7 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 		return err
 	}
 	r.setBacklog(backlog)
-	if _, err := r.idx.Fill(ctx, key, r.emb.EncodeFunc(), r.cfg.BatchSize, r.emb.BatchSize()); err != nil {
+	if _, err := r.idx.Fill(ctx, key, r.emb.EncodeFunc(), r.cfg.BatchSize, r.emb.BatchSize(), r.markDocumentFilled); err != nil {
 		if backlog, berr := r.idx.Backlog(ctx, key); berr == nil {
 			r.setBacklog(backlog)
 		}
@@ -194,6 +194,12 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 	r.setBacklog(backlog)
 	r.markSuccess()
 	return nil
+}
+
+func (r *Reconciler) markDocumentFilled() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.health.Backlog--
 }
 
 func (r *Reconciler) markSuccess() {

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -37,6 +37,7 @@ type ReconcilerHealth struct {
 	LastError       string     `json:"-"`
 	LastErrorStatus int        `json:"last_error_status,omitempty"`
 	Embedded        int64      `json:"embedded"`
+	Skipped         int64      `json:"skipped"`
 	Backlog         int64      `json:"backlog"`
 	RatePerSecond   *float64   `json:"rate_per_second,omitempty"`
 	ETASeconds      *int64     `json:"eta_seconds,omitempty"`
@@ -61,13 +62,13 @@ type Reconciler struct {
 }
 
 type embeddingProgress struct {
-	generation   string
-	total        int64
-	lastEmbedded int64
-	lastAt       time.Time
-	startedAt    time.Time
-	rate         float64
-	samples      int
+	generation    string
+	total         int64
+	lastProcessed int64
+	lastAt        time.Time
+	startedAt     time.Time
+	rate          float64
+	samples       int
 }
 
 const progressRateAlpha = 0.3
@@ -202,15 +203,15 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 	}
 	// Publish the pending count before the fill so /health reports the real
 	// backlog during a long backfill instead of the previous cycle's value.
-	embedded, backlog, err := r.idx.Coverage(ctx, key)
+	embedded, skipped, backlog, err := r.idx.Coverage(ctx, key)
 	if err != nil {
 		r.markError(err)
 		return err
 	}
-	r.setCoverage(key, embedded, backlog)
+	r.setCoverage(key, embedded, skipped, backlog)
 	if _, err := r.idx.Fill(ctx, key, r.emb.EncodeFunc(), r.cfg.BatchSize, r.emb.BatchSize(), r.markDocumentFilled); err != nil {
-		if embedded, backlog, coverageErr := r.idx.Coverage(ctx, key); coverageErr == nil {
-			r.setCoverage(key, embedded, backlog)
+		if embedded, skipped, backlog, coverageErr := r.idx.Coverage(ctx, key); coverageErr == nil {
+			r.setCoverage(key, embedded, skipped, backlog)
 		}
 		r.markError(err)
 		return err
@@ -219,22 +220,26 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 		r.markError(err)
 		return err
 	}
-	embedded, backlog, err = r.idx.Coverage(ctx, key)
+	embedded, skipped, backlog, err = r.idx.Coverage(ctx, key)
 	if err != nil {
 		r.markError(err)
 		return err
 	}
-	r.setCoverage(key, embedded, backlog)
+	r.setCoverage(key, embedded, skipped, backlog)
 	r.markSuccess()
 	return nil
 }
 
-func (r *Reconciler) markDocumentFilled() {
+func (r *Reconciler) markDocumentFilled(embedded bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.health.Embedded++
+	if embedded {
+		r.health.Embedded++
+	} else {
+		r.health.Skipped++
+	}
 	r.health.Backlog--
-	r.recordProgressLocked(r.health.Embedded, r.now())
+	r.recordProgressLocked(r.health.Embedded+r.health.Skipped, r.now())
 }
 
 func (r *Reconciler) markSuccess() {
@@ -259,25 +264,27 @@ func (r *Reconciler) markError(err error) {
 	}
 }
 
-func (r *Reconciler) setCoverage(generation string, embedded, backlog int64) {
+func (r *Reconciler) setCoverage(generation string, embedded, skipped, backlog int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.health.Embedded = embedded
+	r.health.Skipped = skipped
 	r.health.Backlog = backlog
 	if backlog == 0 {
 		r.resetProgressLocked()
 		return
 	}
-	total := embedded + backlog
+	processed := embedded + skipped
+	total := processed + backlog
 	if r.progress.generation != generation || r.progress.total != total ||
-		embedded < r.progress.lastEmbedded || r.progress.startedAt.IsZero() {
+		processed < r.progress.lastProcessed || r.progress.startedAt.IsZero() {
 		now := r.now()
 		r.progress = embeddingProgress{
-			generation:   generation,
-			total:        total,
-			lastEmbedded: embedded,
-			lastAt:       now,
-			startedAt:    now,
+			generation:    generation,
+			total:         total,
+			lastProcessed: processed,
+			lastAt:        now,
+			startedAt:     now,
 		}
 		r.health.StartedAt = &now
 		r.health.LastProgressAt = nil
@@ -285,15 +292,15 @@ func (r *Reconciler) setCoverage(generation string, embedded, backlog int64) {
 		r.health.ETASeconds = nil
 		return
 	}
-	if embedded > r.progress.lastEmbedded {
-		r.recordProgressLocked(embedded, r.now())
+	if processed > r.progress.lastProcessed {
+		r.recordProgressLocked(processed, r.now())
 	}
 }
 
-func (r *Reconciler) recordProgressLocked(embedded int64, now time.Time) {
-	delta := embedded - r.progress.lastEmbedded
+func (r *Reconciler) recordProgressLocked(processed int64, now time.Time) {
+	delta := processed - r.progress.lastProcessed
 	elapsed := now.Sub(r.progress.lastAt).Seconds()
-	r.progress.lastEmbedded = embedded
+	r.progress.lastProcessed = processed
 	r.progress.lastAt = now
 	r.health.LastProgressAt = &now
 	if delta <= 0 || elapsed <= 0 {

--- a/internal/daemon/reconciler_test.go
+++ b/internal/daemon/reconciler_test.go
@@ -51,6 +51,9 @@ type fakeEmbedder struct {
 	dims      int
 	err       error
 	failAfter int
+	blockAt   int
+	blocked   chan struct{}
+	release   chan struct{}
 	calls     int
 	n         int
 }
@@ -62,6 +65,10 @@ func (f *fakeEmbedder) BatchSize() int { return 64 }
 func (f *fakeEmbedder) EncodeFunc() kitvec.EncodeFunc {
 	return func(_ context.Context, texts []string) ([][]float32, error) {
 		f.calls++
+		if f.calls == f.blockAt {
+			close(f.blocked)
+			<-f.release
+		}
 		if f.err != nil && f.calls > f.failAfter {
 			return nil, f.err
 		}
@@ -207,6 +214,45 @@ func TestReconcileErrorReportsPendingBacklog(t *testing.T) {
 	}
 	if h := r.Health(); h.Backlog != 2 {
 		t.Fatalf("backlog after failed fill = %d, want 2 (documents still pending)", h.Backlog)
+	}
+}
+
+func TestReconcileReportsProgressDuringFill(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	for i := 0; i < 2; i++ {
+		if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "t", Body: "b", Author: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	idx := openTestVectorIndex(t)
+	release := make(chan struct{})
+	defer func() {
+		if release != nil {
+			close(release)
+		}
+	}()
+	emb := &fakeEmbedder{
+		model:   "m1",
+		dims:    2,
+		blockAt: 2,
+		blocked: make(chan struct{}),
+		release: release,
+	}
+	r := NewReconciler(store, idx, emb, ReconcilerConfig{BatchSize: 1})
+
+	done := make(chan error, 1)
+	go func() { done <- r.reconcileOnce(ctx) }()
+	<-emb.blocked
+
+	if h := r.Health(); h.Backlog != 1 {
+		t.Fatalf("backlog while second document is encoding = %d, want 1", h.Backlog)
+	}
+	close(release)
+	release = nil
+	if err := <-done; err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/daemon/reconciler_test.go
+++ b/internal/daemon/reconciler_test.go
@@ -339,16 +339,16 @@ func TestEmbeddingProgressEstimatorResetsAcrossDiscontinuities(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			now := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
 			r := NewReconciler(nil, nil, nil, ReconcilerConfig{Now: func() time.Time { return now }})
-			r.setCoverage("m1", 0, 3)
+			r.setCoverage("m1", 0, 0, 3)
 			now = now.Add(time.Second)
-			r.markDocumentFilled()
+			r.markDocumentFilled(true)
 			now = now.Add(time.Second)
-			r.markDocumentFilled()
+			r.markDocumentFilled(true)
 			if h := r.Health(); h.RatePerSecond == nil || h.ETASeconds == nil {
 				t.Fatalf("expected established estimate before reset: %+v", h)
 			}
 
-			r.setCoverage(tt.generation, tt.embedded, tt.backlog)
+			r.setCoverage(tt.generation, tt.embedded, 0, tt.backlog)
 			h := r.Health()
 			if h.RatePerSecond != nil || h.ETASeconds != nil || h.LastProgressAt != nil {
 				t.Fatalf("progress estimate survived discontinuity: %+v", h)

--- a/internal/daemon/reconciler_test.go
+++ b/internal/daemon/reconciler_test.go
@@ -54,6 +54,7 @@ type fakeEmbedder struct {
 	blockAt   int
 	blocked   chan struct{}
 	release   chan struct{}
+	onCall    func(int)
 	calls     int
 	n         int
 }
@@ -65,6 +66,9 @@ func (f *fakeEmbedder) BatchSize() int { return 64 }
 func (f *fakeEmbedder) EncodeFunc() kitvec.EncodeFunc {
 	return func(_ context.Context, texts []string) ([][]float32, error) {
 		f.calls++
+		if f.onCall != nil {
+			f.onCall(f.calls)
+		}
 		if f.calls == f.blockAt {
 			close(f.blocked)
 			<-f.release
@@ -246,13 +250,113 @@ func TestReconcileReportsProgressDuringFill(t *testing.T) {
 	go func() { done <- r.reconcileOnce(ctx) }()
 	<-emb.blocked
 
-	if h := r.Health(); h.Backlog != 1 {
-		t.Fatalf("backlog while second document is encoding = %d, want 1", h.Backlog)
+	if h := r.Health(); h.Backlog != 1 || h.Embedded != 1 {
+		t.Fatalf("health while second document is encoding = %+v, want backlog 1 and embedded 1", h)
 	}
 	close(release)
 	release = nil
 	if err := <-done; err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestReconcileReportsSmoothedRateAndETA(t *testing.T) {
+	ctx := context.Background()
+	store := newReconcilerTestStore(t)
+	proj, _ := store.CreateProject(ctx, "spoke-project")
+	for i := 0; i < 3; i++ {
+		if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{ProjectID: proj.ID, Title: "t", Body: "b", Author: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	idx := openTestVectorIndex(t)
+	now := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	release := make(chan struct{})
+	defer func() {
+		if release != nil {
+			close(release)
+		}
+	}()
+	emb := &fakeEmbedder{
+		model:   "m1",
+		dims:    2,
+		blockAt: 3,
+		blocked: make(chan struct{}),
+		release: release,
+		onCall: func(call int) {
+			if call == 1 {
+				now = now.Add(2 * time.Second)
+			} else {
+				now = now.Add(time.Second)
+			}
+		},
+	}
+	r := NewReconciler(store, idx, emb, ReconcilerConfig{
+		BatchSize: 1,
+		Now:       func() time.Time { return now },
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- r.reconcileOnce(ctx) }()
+	<-emb.blocked
+
+	h := r.Health()
+	if h.Embedded != 2 || h.Backlog != 1 {
+		t.Fatalf("health counts while third document is encoding = %+v", h)
+	}
+	if h.RatePerSecond == nil || h.ETASeconds == nil {
+		t.Fatalf("health must report rate and ETA after two progress samples: %+v", h)
+	}
+	if diff := *h.RatePerSecond - 0.65; diff < -0.001 || diff > 0.001 {
+		t.Fatalf("smoothed rate = %f, want 0.65 docs/s", *h.RatePerSecond)
+	}
+	if *h.ETASeconds != 2 {
+		t.Fatalf("ETA = %d seconds, want 2", *h.ETASeconds)
+	}
+	if h.StartedAt == nil || h.LastProgressAt == nil {
+		t.Fatalf("health must expose progress timestamps: %+v", h)
+	}
+
+	close(release)
+	release = nil
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEmbeddingProgressEstimatorResetsAcrossDiscontinuities(t *testing.T) {
+	tests := []struct {
+		name       string
+		generation string
+		embedded   int64
+		backlog    int64
+	}{
+		{name: "generation change", generation: "m2", embedded: 2, backlog: 1},
+		{name: "total change", generation: "m1", embedded: 2, backlog: 2},
+		{name: "progress moved backward", generation: "m1", embedded: 1, backlog: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+			r := NewReconciler(nil, nil, nil, ReconcilerConfig{Now: func() time.Time { return now }})
+			r.setCoverage("m1", 0, 3)
+			now = now.Add(time.Second)
+			r.markDocumentFilled()
+			now = now.Add(time.Second)
+			r.markDocumentFilled()
+			if h := r.Health(); h.RatePerSecond == nil || h.ETASeconds == nil {
+				t.Fatalf("expected established estimate before reset: %+v", h)
+			}
+
+			r.setCoverage(tt.generation, tt.embedded, tt.backlog)
+			h := r.Health()
+			if h.RatePerSecond != nil || h.ETASeconds != nil || h.LastProgressAt != nil {
+				t.Fatalf("progress estimate survived discontinuity: %+v", h)
+			}
+			if h.StartedAt == nil {
+				t.Fatalf("reset backfill must enter estimating state: %+v", h)
+			}
+		})
 	}
 }
 

--- a/internal/vector/fill.go
+++ b/internal/vector/fill.go
@@ -30,10 +30,11 @@ const (
 // aborts so the reconciler can back off instead of stamping the corpus as
 // skipped. Every non-400 error aborts unconditionally — an auth failure must
 // never stamp anything.
-func (ix *Index) Fill(ctx context.Context, key string, enc kitvec.EncodeFunc, scanBatch, encodeBatch int) (kitvec.FillStats, error) {
+func (ix *Index) Fill(ctx context.Context, key string, enc kitvec.EncodeFunc, scanBatch, encodeBatch int, onDocument func()) (kitvec.FillStats, error) {
 	split := kitvec.SplitOptions{MaxRunes: splitMaxRunes, Overlap: splitOverlap}
 	batch := kitvec.BatchOptions{BatchSize: encodeBatch}
-	return kitvec.Fill(ctx, ix.store, key, enc, kitvec.FillOptions[string]{
+	store := progressStore{Store: ix.store, onDocument: onDocument}
+	return kitvec.Fill(ctx, store, key, enc, kitvec.FillOptions[string]{
 		ScanBatch: scanBatch,
 		Split:     split,
 		Batch:     batch,
@@ -45,6 +46,21 @@ func (ix *Index) Fill(ctx context.Context, key string, enc kitvec.EncodeFunc, sc
 			return ix.contentSpecific400(ctx, doc, enc, split, batch)
 		},
 	})
+}
+
+type progressStore struct {
+	kitvec.Store[string, string]
+	onDocument func()
+}
+
+func (s progressStore) SaveVectors(ctx context.Context, gen, doc string, revision any, vectors []kitvec.ChunkVector) error {
+	if err := s.Store.SaveVectors(ctx, gen, doc, revision, vectors); err != nil {
+		return err
+	}
+	if s.onDocument != nil {
+		s.onDocument()
+	}
+	return nil
 }
 
 // contentSpecific400 reports whether a 400 from encoding doc is provably

--- a/internal/vector/fill.go
+++ b/internal/vector/fill.go
@@ -30,7 +30,7 @@ const (
 // aborts so the reconciler can back off instead of stamping the corpus as
 // skipped. Every non-400 error aborts unconditionally — an auth failure must
 // never stamp anything.
-func (ix *Index) Fill(ctx context.Context, key string, enc kitvec.EncodeFunc, scanBatch, encodeBatch int, onDocument func()) (kitvec.FillStats, error) {
+func (ix *Index) Fill(ctx context.Context, key string, enc kitvec.EncodeFunc, scanBatch, encodeBatch int, onDocument func(bool)) (kitvec.FillStats, error) {
 	split := kitvec.SplitOptions{MaxRunes: splitMaxRunes, Overlap: splitOverlap}
 	batch := kitvec.BatchOptions{BatchSize: encodeBatch}
 	store := progressStore{Store: ix.store, onDocument: onDocument}
@@ -50,7 +50,7 @@ func (ix *Index) Fill(ctx context.Context, key string, enc kitvec.EncodeFunc, sc
 
 type progressStore struct {
 	kitvec.Store[string, string]
-	onDocument func()
+	onDocument func(bool)
 }
 
 func (s progressStore) SaveVectors(ctx context.Context, gen, doc string, revision any, vectors []kitvec.ChunkVector) error {
@@ -58,7 +58,7 @@ func (s progressStore) SaveVectors(ctx context.Context, gen, doc string, revisio
 		return err
 	}
 	if s.onDocument != nil {
-		s.onDocument()
+		s.onDocument(len(vectors) > 0)
 	}
 	return nil
 }

--- a/internal/vector/fill_test.go
+++ b/internal/vector/fill_test.go
@@ -169,6 +169,13 @@ func TestFillSkipsOnlyContentRejectedDocs(t *testing.T) {
 	if stats.Skipped != 1 || stats.Documents != 1 {
 		t.Fatalf("stats = %+v; want 1 skipped, 1 embedded", stats)
 	}
+	embedded, skipped, backlog, err := ix.Coverage(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if embedded != 1 || skipped != 1 || backlog != 0 {
+		t.Fatalf("coverage = embedded %d, skipped %d, backlog %d; want 1, 1, 0", embedded, skipped, backlog)
+	}
 
 	// Auth failure: 401 aborts the fill, nothing is stamped as skipped.
 	seedMirror(t, ix, "u3", 1)

--- a/internal/vector/fill_test.go
+++ b/internal/vector/fill_test.go
@@ -51,7 +51,7 @@ func TestFillEmbedsChunksAndQueryFindsThem(t *testing.T) {
 		}
 		return out, nil
 	}
-	stats, err := ix.Fill(ctx, key, enc, 0, 0)
+	stats, err := ix.Fill(ctx, key, enc, 0, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestFillAbortsOnRequestLevel400(t *testing.T) {
 	enc := func(_ context.Context, _ []string) ([][]float32, error) {
 		return nil, &embedding.APIError{StatusCode: 400, Body: "invalid model"}
 	}
-	stats, err := ix.Fill(ctx, key, enc, 0, 0)
+	stats, err := ix.Fill(ctx, key, enc, 0, 0, nil)
 	var apiErr *embedding.APIError
 	if err == nil || !errors.As(err, &apiErr) || apiErr.StatusCode != 400 {
 		t.Fatalf("request-level 400 must abort the fill, got %v", err)
@@ -129,7 +129,7 @@ func TestFillAbortsOnBatchShape400(t *testing.T) {
 		}
 		return [][]float32{{1, 0, 0, 0}}, nil
 	}
-	stats, err := ix.Fill(ctx, key, enc, 0, 0)
+	stats, err := ix.Fill(ctx, key, enc, 0, 0, nil)
 	var apiErr *embedding.APIError
 	if err == nil || !errors.As(err, &apiErr) || apiErr.StatusCode != 400 {
 		t.Fatalf("shape-level 400 must abort the fill, got %v", err)
@@ -162,7 +162,7 @@ func TestFillSkipsOnlyContentRejectedDocs(t *testing.T) {
 		}
 		return out, nil
 	}
-	stats, err := ix.Fill(ctx, key, enc, 0, 0)
+	stats, err := ix.Fill(ctx, key, enc, 0, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestFillSkipsOnlyContentRejectedDocs(t *testing.T) {
 	authFail := func(_ context.Context, _ []string) ([][]float32, error) {
 		return nil, &embedding.APIError{StatusCode: 401, Body: "no"}
 	}
-	_, err = ix.Fill(ctx, key, authFail, 0, 0)
+	_, err = ix.Fill(ctx, key, authFail, 0, 0, nil)
 	var apiErr *embedding.APIError
 	if err == nil || !errors.As(err, &apiErr) || apiErr.StatusCode != 401 {
 		t.Fatalf("401 must abort the fill, got %v", err)

--- a/internal/vector/generations.go
+++ b/internal/vector/generations.go
@@ -147,6 +147,20 @@ func (ix *Index) Backlog(ctx context.Context, key string) (int64, error) {
 	return n, nil
 }
 
+// Coverage counts mirror rows stamped at their current revision for key and
+// rows still awaiting that generation.
+func (ix *Index) Coverage(ctx context.Context, key string) (embedded, backlog int64, err error) {
+	backlog, err = ix.Backlog(ctx, key)
+	if err != nil {
+		return 0, 0, err
+	}
+	var total int64
+	if err := ix.db.QueryRowContext(ctx, `SELECT count(*) FROM issue_mirror`).Scan(&total); err != nil {
+		return 0, 0, fmt.Errorf("vector: coverage: %w", err)
+	}
+	return total - backlog, backlog, nil
+}
+
 func (ix *Index) generationState(ctx context.Context, key string) (string, error) {
 	var state string
 	err := ix.db.QueryRowContext(ctx, fmt.Sprintf(

--- a/internal/vector/generations.go
+++ b/internal/vector/generations.go
@@ -147,18 +147,29 @@ func (ix *Index) Backlog(ctx context.Context, key string) (int64, error) {
 	return n, nil
 }
 
-// Coverage counts mirror rows stamped at their current revision for key and
-// rows still awaiting that generation.
-func (ix *Index) Coverage(ctx context.Context, key string) (embedded, backlog int64, err error) {
+// Coverage counts current-revision mirror rows with vectors, rows deliberately
+// stamped without vectors, and rows still awaiting key.
+func (ix *Index) Coverage(ctx context.Context, key string) (embedded, skipped, backlog int64, err error) {
 	backlog, err = ix.Backlog(ctx, key)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	var total int64
 	if err := ix.db.QueryRowContext(ctx, `SELECT count(*) FROM issue_mirror`).Scan(&total); err != nil {
-		return 0, 0, fmt.Errorf("vector: coverage: %w", err)
+		return 0, 0, 0, fmt.Errorf("vector: coverage total: %w", err)
 	}
-	return total - backlog, backlog, nil
+	err = ix.db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT count(*) FROM issue_mirror m
+		WHERE EXISTS (
+		  SELECT 1 FROM %s_stamps s
+		  JOIN %s_generations g ON g.ordinal = s.ordinal
+		  JOIN %s_chunks c ON c.ordinal = s.ordinal AND c.doc_key = s.doc_key
+		  WHERE g.gen_key = ? AND s.doc_key = m.issue_uid AND s.revision = m.content_revision
+		)`, vectorsPrefix, vectorsPrefix, vectorsPrefix), key).Scan(&embedded)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("vector: coverage embedded: %w", err)
+	}
+	return embedded, total - backlog - embedded, backlog, nil
 }
 
 func (ix *Index) generationState(ctx context.Context, key string) (string, error) {

--- a/internal/vector/generations_test.go
+++ b/internal/vector/generations_test.go
@@ -21,7 +21,7 @@ func fillAll(t *testing.T, ix *Index, key string) {
 		}
 		return out, nil
 	}
-	if _, err := ix.Fill(context.Background(), key, enc, 0, 0); err != nil {
+	if _, err := ix.Fill(context.Background(), key, enc, 0, 0, nil); err != nil {
 		t.Fatalf("fill: %v", err)
 	}
 }

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -966,6 +966,7 @@ type EmbeddingsHealth struct {
 	LastProgressAt  *time.Time `json:"last_progress_at,omitempty"`
 	LastSuccessAt   *time.Time `json:"last_success_at,omitempty"`
 	RatePerSecond   *float64   `json:"rate_per_second,omitempty"`
+	Skipped         int64      `json:"skipped"`
 	StartedAt       *time.Time `json:"started_at,omitempty"`
 }
 

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -960,8 +960,13 @@ func (e EditIssueResponseBody) Validate() error {
 type EmbeddingsHealth struct {
 	Backlog         int64      `json:"backlog"`
 	Configured      bool       `json:"configured"`
+	Embedded        int64      `json:"embedded"`
+	EtaSeconds      *int64     `json:"eta_seconds,omitempty"`
 	LastErrorStatus *int64     `json:"last_error_status,omitempty"`
+	LastProgressAt  *time.Time `json:"last_progress_at,omitempty"`
 	LastSuccessAt   *time.Time `json:"last_success_at,omitempty"`
+	RatePerSecond   *float64   `json:"rate_per_second,omitempty"`
+	StartedAt       *time.Time `json:"started_at,omitempty"`
 }
 
 type EnableIssueSyncRequestBody struct {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -748,14 +748,30 @@ components:
           type: integer
         configured:
           type: boolean
+        embedded:
+          format: int64
+          type: integer
+        eta_seconds:
+          format: int64
+          type: integer
         last_error_status:
           format: int64
           type: integer
+        last_progress_at:
+          format: date-time
+          type: string
         last_success_at:
+          format: date-time
+          type: string
+        rate_per_second:
+          format: double
+          type: number
+        started_at:
           format: date-time
           type: string
       required:
         - configured
+        - embedded
         - backlog
       type: object
     EnableIssueSyncRequestBody:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -766,12 +766,16 @@ components:
         rate_per_second:
           format: double
           type: number
+        skipped:
+          format: int64
+          type: integer
         started_at:
           format: date-time
           type: string
       required:
         - configured
         - embedded
+        - skipped
         - backlog
       type: object
     EnableIssueSyncRequestBody:


### PR DESCRIPTION
Embedding health currently snapshots the pending count before a long fill and does not change it until the whole corpus finishes, making a healthy backfill look stalled.

This advances `backlog` and `embedded` after each task is successfully persisted, so health reflects the vector coverage already available to search. It also exposes a measured EWMA throughput, ETA, and start/last-progress timestamps after enough positive samples exist. Estimates reset across generation, total-work, and backward-progress discontinuities rather than treating unrelated fills as continuous.

The OpenAPI contract, generated Go client, and semantic-search documentation describe the new health fields.

<sup>generated by a clanker</sup>