### PR TITLE
Add stable JSON version identity

### DIFF
--- a/cmd/kata/version.go
+++ b/cmd/kata/version.go
@@ -25,6 +25,7 @@ func newVersionCmd() *cobra.Command {
 			case outputJSON:
 				var buf bytes.Buffer
 				payload := map[string]any{
+					"tool":         "kata",
 					"version":      version.Version,
 					"commit":       version.Commit,
 					"built":        version.BuildDate,

--- a/cmd/kata/version.go
+++ b/cmd/kata/version.go
@@ -25,7 +25,7 @@ func newVersionCmd() *cobra.Command {
 			case outputJSON:
 				var buf bytes.Buffer
 				payload := map[string]any{
-					"tool":         "kata",
+					"name":         "kata",
 					"version":      version.Version,
 					"commit":       version.Commit,
 					"built":        version.BuildDate,

--- a/cmd/kata/version_test.go
+++ b/cmd/kata/version_test.go
@@ -51,7 +51,7 @@ func TestVersion_JSONEnvelope(t *testing.T) {
 
 	var got struct {
 		APIVersion int    `json:"kata_api_version"`
-		Tool       string `json:"tool"`
+		Name       string `json:"name"`
 		Version    string `json:"version"`
 		Commit     string `json:"commit"`
 		Built      string `json:"built"`
@@ -61,7 +61,7 @@ func TestVersion_JSONEnvelope(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(out, &got))
 	assert.Equal(t, 1, got.APIVersion)
-	assert.Equal(t, "kata", got.Tool)
+	assert.Equal(t, "kata", got.Name)
 	assert.Equal(t, "v0.0.1-test", got.Version)
 	assert.Equal(t, "abc1234", got.Commit)
 	assert.Equal(t, "2026-05-12T11:17:12Z", got.Built)

--- a/cmd/kata/version_test.go
+++ b/cmd/kata/version_test.go
@@ -44,18 +44,24 @@ func TestVersion_HumanFormatIncludesBuildMetadata(t *testing.T) {
 func TestVersion_JSONEnvelope(t *testing.T) {
 	resetFlags(t)
 	stubVersionInfo(t, "v0.0.1-test", "abc1234", "2026-05-12T11:17:12Z")
+	t.Chdir(t.TempDir())
+	t.Setenv("KATA_SERVER", "http://127.0.0.1:1")
 
-	out := executeRoot(t, newRootCmd(), "--json", "version")
+	out := executeRoot(t, newRootCmd(), "version", "--json")
 
 	var got struct {
-		Version string `json:"version"`
-		Commit  string `json:"commit"`
-		Built   string `json:"built"`
-		Go      string `json:"go"`
-		OS      string `json:"os"`
-		Arch    string `json:"arch"`
+		APIVersion int    `json:"kata_api_version"`
+		Tool       string `json:"tool"`
+		Version    string `json:"version"`
+		Commit     string `json:"commit"`
+		Built      string `json:"built"`
+		Go         string `json:"go"`
+		OS         string `json:"os"`
+		Arch       string `json:"arch"`
 	}
 	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, 1, got.APIVersion)
+	assert.Equal(t, "kata", got.Tool)
 	assert.Equal(t, "v0.0.1-test", got.Version)
 	assert.Equal(t, "abc1234", got.Commit)
 	assert.Equal(t, "2026-05-12T11:17:12Z", got.Built)

--- a/docs/reference/agent-output.md
+++ b/docs/reference/agent-output.md
@@ -61,8 +61,9 @@ $ kata version --agent
 OK version version=0.0.0 agent_format=1
 ```
 
-The same value appears as `agent_format` in `kata version --json`. Ordinary
-command output does not repeat the version, to keep transcripts small.
+The same value appears as `agent_format` in `kata version --json`; the complete
+JSON schema is documented in the [CLI reference](cli.md#daemon-and-diagnostics).
+Ordinary command output does not repeat the version, to keep transcripts small.
 
 ## Errors
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -409,7 +409,7 @@ not require a workspace or a running daemon. The output is a single JSON object:
 ```json
 {
   "kata_api_version": 1,
-  "tool": "kata",
+  "name": "kata",
   "version": "v0.6.0",
   "commit": "abcdef0",
   "built": "2026-07-12T12:00:00Z",
@@ -420,7 +420,7 @@ not require a workspace or a running daemon. The output is a single JSON object:
 }
 ```
 
-`tool` is the canonical tool name. `version` is the semantic version for a
+`name` is the canonical tool name. `version` is the semantic version for a
 release build; development builds may report a development identifier.
 `commit` and `built` identify the source revision and build time, while `go`,
 `os`, and `arch` describe the build runtime and target. `agent_format` is the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -399,9 +399,34 @@ kata daemon logs --hooks [--tail]
 kata health
 kata whoami
 kata quickstart
-kata version
+kata version [--json]
 kata tui
 ```
+
+`kata version --json` is a local-only machine-readable version check. It does
+not require a workspace or a running daemon. The output is a single JSON object:
+
+```json
+{
+  "kata_api_version": 1,
+  "tool": "kata",
+  "version": "v0.6.0",
+  "commit": "abcdef0",
+  "built": "2026-07-12T12:00:00Z",
+  "go": "go1.25.0",
+  "os": "linux",
+  "arch": "amd64",
+  "agent_format": 1
+}
+```
+
+`tool` is the canonical tool name. `version` is the semantic version for a
+release build; development builds may report a development identifier.
+`commit` and `built` identify the source revision and build time, while `go`,
+`os`, and `arch` describe the build runtime and target. `agent_format` is the
+version of the agent-readable text contract. Consumers should use
+`kata_api_version` to select the JSON schema and ignore additional fields they
+do not recognize. Plain `kata version` retains its human-readable output.
 
 Local commands auto-start the daemon when appropriate. `daemon start` starts a
 background daemon and returns after startup is confirmed. Use


### PR DESCRIPTION
Automation and integration consumers need a stable way to identify the kata binary without parsing human-readable output or requiring workspace or daemon access.

This adds the canonical `name: kata` identity to the existing versioned JSON envelope, documents the complete field contract and additive compatibility rule, and preserves the existing plaintext output. The contract test exercises the documented `kata version --json` form from an unbound directory with an unavailable configured server.

<sup>generated by a clanker</sup>