### PR TITLE
Finalize 0.10.0 release documentation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,24 +8,79 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 ## Unreleased
 
+## 0.10.0
+<small>2026-07-11</small>
+
+kata 0.10.0 makes ready-work selection priority-aware, carries cross-project
+relationships through federation, and improves daemon and agent-workflow
+operations.
+
 **New features**
 
+- Added `kata next`, which deterministically selects one ready issue. Explicit
+  priorities beat unprioritized work, lower numeric priorities win, and ties
+  retain the ready API's order. It supports the scoped `ready` filters,
+  cross-project `--all` selection, compact human/agent/JSON output, and
+  `--full` issue detail.
+- Rendered parent/child trees in human `kata list` output with box-drawing
+  connectors while preserving server order in JSON and agent output. Children
+  whose parent is outside the fetched result remain visible at the top level.
+- Added `kata daemon restart`. It validates replacement settings before
+  stopping the current local daemon, waits for graceful shutdown, and starts a
+  replacement with configured or explicitly repeated listener settings.
+- Synchronized cross-project links across federated projects. Link events are
+  retained when a peer has not arrived yet, then materialize after both
+  endpoint projects join the same hub federation group regardless of project
+  enrollment or synchronization order.
 - Added `kata federation quarantine list` and `show` so operators can inspect
   project ownership, event ranges and UIDs, timestamps, and retained errors
   before retrying or skipping. Federation project detail in the TUI now shows
   the same retained quarantine errors.
 
-**Fixed**
+**Improvements**
+
+- Reported live semantic-search backfill progress through the `/health`
+  `embeddings` object, including start and last-progress timestamps plus a
+  smoothed processing rate and ETA once enough progress samples exist.
+- Improved human `kata daemon status` output with the daemon address, PID,
+  binary version, and uptime. JSON status includes the database path and start
+  time for programmatic diagnostics.
+- Added `kata init --with-hooks` for Claude Code workspaces and moved the
+  attention lifecycle logic into the installed `kata` binary. The generated
+  exec-form hooks no longer depend on a repository script whose contents could
+  change behind an already approved command.
+- Extended the managed block written by `kata init --with-agents` with the
+  `work.branch`, `work.attention`, and `work.attention_msg` conventions.
+  Re-running the command refreshes an older managed block in place.
+- Improved `kata wait --timeout` and `--poll-interval` validation: a bare
+  number remains rejected as ambiguous, but the error now suggests the
+  seconds-qualified spelling and lists supported duration units.
+
+**Bug fixes**
 
 - Fixed a federation deadlock where two projects whose first pending batches
   referenced each other's new issues could both become permanently
-  quarantined. Link peers now resolve eventually within the same hub
-  federation group; true validation failures remain quarantined.
-- Automatically resend older push quarantines created by the former missing
-  link-peer validator after compatible hub and spoke builds are deployed,
-  without advancing the cursor. Multi-project coverage now crosses task
-  creation before and after enrollment, eager and batched sync, and both
-  project orderings.
+  quarantined. Compatible spokes also resend older push quarantines created by
+  the former missing-peer validator without advancing the cursor; unrelated
+  validation failures remain quarantined.
+- Preserved labels in project-scoped and cross-project `kata ready` results by
+  returning the same hydrated issue projection used elsewhere in the API.
+- Fixed GitHub issue and comment pagination when a `Link` header uses GitHub's
+  numeric `/repositories/{id}/...` URL form. kata rewrites that form to the
+  bound owner/repository path before applying its credential egress guard.
+
+**Acknowledgements**
+
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for parent/child list
+  rendering, ready-result labels, duration guidance, `work.*` managed guidance,
+  and the binary-backed attention hooks.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for
+  federated cross-project link convergence, quarantine recovery and discovery,
+  and live embedding progress reporting.
+- Thanks to [Wes McKinney](https://github.com/wesm) for priority-aware
+  `kata next`, daemon restart, and daemon status improvements.
+- Thanks to [Barret Schloerke](https://github.com/schloerke) for numeric GitHub
+  pagination URL support.
 
 ## 0.9.0
 <small>2026-07-09</small>

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -121,6 +121,11 @@ kata comment abc4 --body "Reproduced on macOS."
 Priorities run from `0` to `4`; `0` is highest. Omit priority when it is not
 useful.
 
+Human `kata list` output groups fetched children beneath their fetched parents
+with tree connectors. A child remains a top-level row when its parent is outside
+the active filters or `--limit` result, so filtering never hides a matching
+issue. JSON and agent output preserve the API's flat order for scripts.
+
 ## Use relationships
 
 Relationships are attached to `kata create` and `kata edit`. They are framed
@@ -146,7 +151,17 @@ relationship flags are repeatable.
 
 ## Find ready work
 
-`kata ready` lists open issues with no open predecessor blocking them:
+`kata next` chooses the highest-priority open issue with no open predecessor
+blocking it:
+
+```sh
+kata next
+kata next --unowned --label backend
+```
+
+Lower numeric priorities win, explicitly prioritized issues beat unprioritized
+ones, and ties preserve ready-list order. Use `kata ready` when you want to
+inspect the queue instead of choosing one issue:
 
 ```sh
 kata ready

--- a/docs/operations/agent-orchestration.md
+++ b/docs/operations/agent-orchestration.md
@@ -117,8 +117,10 @@ exec-form lifecycle hooks in `.claude/settings.json`: `SessionStart` runs
 context compaction), and `SessionEnd` runs `kata attention-hook end` only for
 terminal exits rather than clear/resume transitions.
 Both use the launcher-provided `KATA_REF` and intentionally do nothing when it
-is absent. Re-running the command is a no-op, and symlinked `.claude` or
-`settings.json` paths are refused.
+is absent. The hook logic lives in the installed `kata` binary, so the approved
+exec-form command does not delegate to a repository script whose contents can
+change independently. Re-running the command is a no-op, and symlinked
+`.claude` or `settings.json` paths are refused.
 
 ## Coordinate: wait and dashboards
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,6 +91,12 @@ For `kata list`, `--meta` is repeatable. A bare key filters on presence,
 while `key=value` filters on string equality. Multiple filters combine with
 AND logic.
 
+Human `kata list` output groups fetched children beneath their fetched parents
+with box-drawing connectors. When a parent is absent because it did not match
+the filters, belongs to another project, or fell outside `--limit`, its child
+stays visible as a top-level row. JSON and agent output remain flat in the
+server's order.
+
 By default `kata search` runs lexical (FTS) search. When the daemon has
 [semantic search](../guide/semantic-search.md) configured, search
 automatically fuses lexical and vector results. The mode flags are mutually
@@ -253,6 +259,10 @@ kata wait <ref> [<ref>...] [--until closed|attention|needs-human|stuck] \
 `--all` (waiting for every ref). In attention modes, a closed issue also
 completes the wait. A timeout exits with a dedicated nonzero code and covers the
 whole command, including project/ref resolution and polling.
+
+Both duration flags require an explicit unit using Go duration syntax, such as
+`30s`, `5m`, or `1h30m`. A bare number is ambiguous and rejected; the error
+suggests the equivalent seconds-qualified spelling.
 
 ## Ready work
 

--- a/docs/screenshots/generate-federation-tui.sh
+++ b/docs/screenshots/generate-federation-tui.sh
@@ -251,6 +251,8 @@ sleep 0.3
 capture "federation-tui/list"
 
 send "n"
+wait_until "Select local spoke project"
+send "Enter"
 wait_until "Select hub daemon"
 sleep 0.3
 capture "federation-tui/select-hub"
@@ -268,6 +270,9 @@ wait_until "Operation: adopt existing local project"
 sleep 0.3
 capture "federation-tui/preview"
 
+send "Enter"
+wait_until "Confirm Adoption"
+send "demo-spoke-project"
 send "Enter"
 wait_until "Enrollment Result" 45
 sleep 0.5


### PR DESCRIPTION
Finalizes the public docs for the 0.10.0 release using the tagged changelog and verified pull-request authorship. It brings priority-aware work selection, list trees, daemon operations, federation convergence and recovery, embedding progress, agent hooks, and the shipped fixes into the release history with contributor acknowledgements.

The affected quickstart and reference pages now explain the user-facing selection, tree-rendering, duration, and binary-backed hook contracts where readers encounter them. The screenshot workflow also follows the current federation project-selection and typed adoption-confirmation flow, and the refreshed generated assets are already published on the dedicated docs-assets branch.

After merge, the production documentation still needs the normal manual deployment flow.