### PR TITLE
Expose Kata as a mountable Go service

### DIFF
--- a/external_module_test.go
+++ b/external_module_test.go
@@ -1,0 +1,84 @@
+package kata_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalModuleCanServeAndStop(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repositoryRoot := filepath.Dir(currentFile)
+	consumerDir := t.TempDir()
+
+	goMod := fmt.Sprintf(`module example.com/kata-service-consumer
+
+go 1.26.3
+
+require go.kenn.io/kata v0.0.0
+
+replace go.kenn.io/kata => %s
+`, filepath.ToSlash(repositoryRoot))
+	require.NoError(t, os.WriteFile(filepath.Join(consumerDir, "go.mod"), []byte(goMod), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(consumerDir, "service_test.go"),
+		[]byte(externalConsumerTest),
+		0o600,
+	))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "test", "-mod=mod", "./...")
+	cmd.Dir = consumerDir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	output, err := cmd.CombinedOutput()
+	assert.NoError(t, err, string(output))
+}
+
+const externalConsumerTest = `package consumer_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"go.kenn.io/kata"
+)
+
+func TestMountedServiceLifecycle(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "kata.db"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/v1/health", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("health status = %d, body = %s", response.Code, response.Body.String())
+	}
+
+	runContext, cancelRun := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- service.Run(runContext) }()
+	cancelRun()
+	if err := <-runDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+`

--- a/external_module_test.go
+++ b/external_module_test.go
@@ -58,7 +58,8 @@ import (
 
 func TestMountedServiceLifecycle(t *testing.T) {
 	service, err := kata.New(context.Background(), kata.Config{
-		DSN: filepath.Join(t.TempDir(), "kata.db"),
+		DSN:  filepath.Join(t.TempDir(), "kata.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/api/error_format_test.go
+++ b/internal/api/error_format_test.go
@@ -1,11 +1,11 @@
-// Internal test for the unexported foldDetailsIntoMessage helper
-// and the public InstallErrorFormatter contract.
+// Internal tests for Kata's Huma error conversion.
 //
 //nolint:revive // package-name lint flagged externally; internal test needs the package name
 package api
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -78,19 +78,14 @@ func TestFoldDetailsIntoMessage(t *testing.T) {
 	}
 }
 
-// TestInstallErrorFormatter_FoldsDetailsIntoApiError pins that
-// InstallErrorFormatter's huma.NewError replacement actually wires
-// up the fold for code paths that go through the framework's
-// validation pipeline.
-func TestInstallErrorFormatter_FoldsDetailsIntoApiError(t *testing.T) {
-	InstallErrorFormatter()
-	// huma.NewError is the package-level function we replaced.
-	se := huma.NewError(400, "validation failed",
-		&huma.ErrorDetail{Location: "body.reason", Message: "must be one of done, wontfix"})
-	apiErr, ok := se.(*APIError)
-	if !ok {
-		t.Fatalf("expected *APIError, got %T", se)
-	}
+func TestAPIErrorFromHuma_FoldsDetails(t *testing.T) {
+	apiErr := apiErrorFromHuma(&huma.ErrorModel{
+		Status: http.StatusUnprocessableEntity,
+		Detail: "validation failed",
+		Errors: []*huma.ErrorDetail{
+			{Location: "body.reason", Message: "must be one of done, wontfix"},
+		},
+	})
 	assert.Equal(t, 400, apiErr.Status)
 	assert.Equal(t, "validation", apiErr.Code)
 	assert.Contains(t, apiErr.Message, "reason: must be one of done, wontfix",

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -82,30 +82,82 @@ func (e *APIError) Schema(r huma.Registry) *huma.Schema {
 	return r.Schema(reflect.TypeOf(ErrorEnvelope{}), true, "ErrorEnvelope")
 }
 
-// InstallErrorFormatter wires Huma so non-API-typed errors (panics, validation
-// failures) also serialize to ErrorEnvelope. Call once at server startup.
-// Huma emits 422 for request-body validation failures; we normalize that to
-// 400 with code "validation" so the wire contract documented in spec §4.7
-// (no 422 in the status table) holds.
-//
-// Validation errors arrive with a generic message ("validation failed") plus
-// a slice of huma.ErrorDetail entries that carry the per-field details.
-// Without folding the details into the message, both human ("kata: validation
-// failed") and JSON envelope payloads tell the user nothing about what went
-// wrong (hammer-test finding #11). Fold up to ~3 details into the surfaced
-// message in "field: reason" form so close --reason banana, link 3 banana 4,
-// and list --status nonsense surface actionable feedback.
-func InstallErrorFormatter() {
-	huma.NewError = func(status int, message string, errs ...error) huma.StatusError {
-		if status == http.StatusUnprocessableEntity {
-			status = http.StatusBadRequest
-		}
+// WrapErrorAdapter keeps Huma's validation status normalization local to one
+// API. Huma writes a response status before running response transformers, so
+// the adapter context must translate 422 to Kata's documented 400 at the first
+// SetStatus call. This avoids mutating Huma's process-global error factories,
+// which would otherwise affect unrelated APIs in an embedding host.
+func WrapErrorAdapter(adapter huma.Adapter) huma.Adapter {
+	return &errorAdapter{Adapter: adapter}
+}
+
+type errorAdapter struct {
+	huma.Adapter
+}
+
+func (a *errorAdapter) Handle(operation *huma.Operation, handler func(huma.Context)) {
+	a.Adapter.Handle(operation, func(ctx huma.Context) {
+		handler(&errorContext{embeddedContext: ctx})
+	})
+}
+
+type embeddedContext = huma.Context
+
+type errorContext struct {
+	embeddedContext
+}
+
+func (c *errorContext) SetStatus(status int) {
+	c.embeddedContext.SetStatus(normalizeHumaStatus(status))
+}
+
+// TransformHumaError converts framework-generated errors to Kata's stable
+// envelope. Explicit APIError values pass through unchanged. Setting the
+// content type here also prevents Huma's default ErrorModel from leaving an
+// application/problem+json header behind after transformation.
+func TransformHumaError(ctx huma.Context, _ string, value any) (any, error) {
+	if _, ok := value.(*APIError); ok {
+		return value, nil
+	}
+
+	if model, ok := value.(*huma.ErrorModel); ok {
+		ctx.SetHeader("Content-Type", "application/json")
+		return apiErrorFromHuma(model), nil
+	}
+
+	if statusError, ok := value.(huma.StatusError); ok {
+		status := normalizeHumaStatus(statusError.GetStatus())
+		ctx.SetHeader("Content-Type", "application/json")
 		return &APIError{
 			Status:  status,
 			Code:    codeForStatus(status),
-			Message: foldDetailsIntoMessage(message, errs),
+			Message: statusError.Error(),
+		}, nil
+	}
+
+	return value, nil
+}
+
+func apiErrorFromHuma(model *huma.ErrorModel) *APIError {
+	status := normalizeHumaStatus(model.Status)
+	details := make([]error, 0, len(model.Errors))
+	for _, detail := range model.Errors {
+		if detail != nil {
+			details = append(details, detail)
 		}
 	}
+	return &APIError{
+		Status:  status,
+		Code:    codeForStatus(status),
+		Message: foldDetailsIntoMessage(model.Detail, details),
+	}
+}
+
+func normalizeHumaStatus(status int) int {
+	if status == http.StatusUnprocessableEntity {
+		return http.StatusBadRequest
+	}
+	return status
 }
 
 // foldDetailsIntoMessage appends per-error detail to the generic huma

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -166,6 +166,17 @@ type GitHubAppConfig struct {
 	PrivateKeyPath string `toml:"private_key_path"`
 }
 
+// NormalizeGitHubSyncConfig applies the same defaults and validation used by
+// daemon configuration loading to a programmatically supplied configuration.
+func NormalizeGitHubSyncConfig(cfg GitHubSyncConfig) (GitHubSyncConfig, error) {
+	daemonCfg := DaemonConfig{GitHubSync: cfg}
+	trimGitHubSync(&daemonCfg)
+	if err := validateGitHubSync(daemonCfg.GitHubSync); err != nil {
+		return GitHubSyncConfig{}, err
+	}
+	return daemonCfg.GitHubSync, nil
+}
+
 // AuthConfig is the [auth] block of <KATA_HOME>/config.toml. An empty
 // Token disables bearer auth — appropriate for Unix-socket and loopback-TCP
 // deployments; non-loopback TCP requires either --insecure-readonly with no

--- a/internal/config/federation_credentials.go
+++ b/internal/config/federation_credentials.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -37,6 +38,47 @@ type FederationCredentialMetadata struct {
 	AllowInsecure bool
 }
 
+// FederationCredentialStore isolates secret-bearing federation credentials
+// from the database and from other service instances in the same process.
+type FederationCredentialStore interface {
+	FederationCredential(context.Context, string) (FederationCredential, bool, error)
+	StoreFederationCredential(context.Context, string, FederationCredential) error
+	DeleteFederationCredential(context.Context, string) error
+}
+
+// homeFederationCredentialStore uses the standalone daemon's
+// <KATA_HOME>/credentials.toml file.
+type homeFederationCredentialStore struct{}
+
+func (homeFederationCredentialStore) FederationCredential(
+	_ context.Context, projectUID string,
+) (FederationCredential, bool, error) {
+	credentials, err := ReadFederationCredentials()
+	if err != nil {
+		return FederationCredential{}, false, err
+	}
+	credential, ok := credentials.Projects[projectUID]
+	return credential, ok, nil
+}
+
+func (homeFederationCredentialStore) StoreFederationCredential(
+	_ context.Context, projectUID string, credential FederationCredential,
+) error {
+	return WriteFederationCredential(projectUID, credential)
+}
+
+func (homeFederationCredentialStore) DeleteFederationCredential(
+	_ context.Context, projectUID string,
+) error {
+	return DeleteFederationCredential(projectUID)
+}
+
+// DefaultFederationCredentialStore returns the standalone daemon credential
+// store. Embedded services supply their own isolated store.
+func DefaultFederationCredentialStore() FederationCredentialStore {
+	return homeFederationCredentialStore{}
+}
+
 // ReadFederationCredentials reads <KATA_HOME>/credentials.toml. Missing files
 // return an empty credential set.
 func ReadFederationCredentials() (*FederationCredentials, error) {
@@ -64,11 +106,17 @@ func ReadFederationCredentials() (*FederationCredentials, error) {
 // FederationCredentialMetadataFor returns redacted federation credential
 // metadata for projectUID without exposing the stored token.
 func FederationCredentialMetadataFor(projectUID string) FederationCredentialMetadata {
-	creds, err := ReadFederationCredentials()
+	return FederationCredentialMetadataFromStore(context.Background(), DefaultFederationCredentialStore(), projectUID)
+}
+
+// FederationCredentialMetadataFromStore returns redacted metadata from store.
+func FederationCredentialMetadataFromStore(
+	ctx context.Context, store FederationCredentialStore, projectUID string,
+) FederationCredentialMetadata {
+	c, ok, err := store.FederationCredential(ctx, projectUID)
 	if err != nil {
 		return FederationCredentialMetadata{Status: "unreadable"}
 	}
-	c, ok := creds.Projects[projectUID]
 	if !ok {
 		return FederationCredentialMetadata{Status: "missing"}
 	}

--- a/internal/daemon/claim_gate.go
+++ b/internal/daemon/claim_gate.go
@@ -89,7 +89,7 @@ func refreshSpokeClaimStatusForGate(
 	binding db.FederationBinding,
 	issue db.Issue,
 ) error {
-	remote, cred, err := claimForwardClient(ctx, cfg.DB, binding)
+	remote, cred, err := claimForwardClient(ctx, cfg, binding)
 	if err != nil {
 		if isOfflineClaimRefreshError(err) {
 			return nil

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -163,7 +163,7 @@ func handleClaimAcquire(
 		}
 		return claimResultBody(result), nil
 	}
-	remote, cred, err := claimForwardClient(ctx, cfg.DB, binding)
+	remote, cred, err := claimForwardClient(ctx, cfg, binding)
 	if err != nil {
 		return api.ClaimActionResponseBody{}, err
 	}
@@ -226,7 +226,7 @@ func handleClaimRenew(
 		emitClaimEvents(cfg, result.Events)
 		return claimResultBody(result), nil
 	}
-	remote, cred, err := claimForwardClient(ctx, cfg.DB, binding)
+	remote, cred, err := claimForwardClient(ctx, cfg, binding)
 	if err != nil {
 		return api.ClaimActionResponseBody{}, err
 	}
@@ -271,7 +271,7 @@ func handleClaimRelease(
 		emitClaimEvent(cfg, projectID, result.Event)
 		return claimResultBody(result), nil
 	}
-	remote, cred, err := claimForwardClient(ctx, cfg.DB, binding)
+	remote, cred, err := claimForwardClient(ctx, cfg, binding)
 	if err != nil {
 		return api.ClaimActionResponseBody{}, err
 	}
@@ -298,7 +298,7 @@ func handleClaimStatus(ctx context.Context, cfg ServerConfig, projectID int64, r
 		emitClaimEvents(cfg, status.Events)
 		return claimStatusBody(status), nil
 	}
-	remote, cred, err := claimForwardClient(ctx, cfg.DB, binding)
+	remote, cred, err := claimForwardClient(ctx, cfg, binding)
 	if err != nil {
 		return api.ClaimStatusBody{}, err
 	}
@@ -354,18 +354,17 @@ func boundSpokeClaimPrincipal(binding db.FederationBinding, principal db.ClaimPr
 
 func claimForwardClient(
 	ctx context.Context,
-	store db.Storage,
+	cfg ServerConfig,
 	binding db.FederationBinding,
 ) (*claimHubClient, config.FederationCredential, error) {
-	project, err := store.ProjectByID(ctx, binding.ProjectID)
+	project, err := cfg.DB.ProjectByID(ctx, binding.ProjectID)
 	if err != nil {
 		return nil, config.FederationCredential{}, claimAPIError(err)
 	}
-	creds, err := config.ReadFederationCredentials()
+	cred, _, err := cfg.federationCredentialStore().FederationCredential(ctx, project.UID)
 	if err != nil {
 		return nil, config.FederationCredential{}, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
 	}
-	cred := creds.Projects[project.UID]
 	if strings.TrimSpace(cred.Token) == "" {
 		return nil, config.FederationCredential{}, api.NewError(http.StatusServiceUnavailable, "federation_offline", "federation claim credentials are unavailable", "", nil)
 	}
@@ -790,7 +789,7 @@ func refreshShowClaimStatus(ctx context.Context, cfg ServerConfig, issue db.Issu
 	} else if skip {
 		return nil, nil
 	}
-	remote, cred, err := claimForwardClient(ctx, cfg.DB, binding)
+	remote, cred, err := claimForwardClient(ctx, cfg, binding)
 	if err != nil {
 		if isOfflineClaimRefreshError(err) {
 			return nil, nil

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -57,7 +57,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      "GET",
 		Path:        "/api/v1/federation/status",
 	}, func(ctx context.Context, in *api.FederationStatusRequest) (*api.FederationStatusResponse, error) {
-		body, err := federationStatusBody(ctx, cfg.DB, nil, includeContains(in.Include, "archived"))
+		body, err := federationStatusBody(ctx, cfg.DB, cfg.federationCredentialStore(), nil, includeContains(in.Include, "archived"))
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +69,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      "GET",
 		Path:        "/api/v1/projects/{project_id}/federation/status",
 	}, func(ctx context.Context, in *api.ProjectFederationStatusRequest) (*api.FederationStatusResponse, error) {
-		body, err := federationStatusBody(ctx, cfg.DB, &in.ProjectID, false)
+		body, err := federationStatusBody(ctx, cfg.DB, cfg.federationCredentialStore(), &in.ProjectID, false)
 		if err != nil {
 			return nil, err
 		}
@@ -258,7 +258,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(400, "federation_capability_mismatch", "push-enabled federation replica credentials require push capability", "", nil)
 		}
 		if in.Body.Token != "" {
-			if err := config.WriteFederationCredential(project.UID, config.FederationCredential{
+			if err := cfg.federationCredentialStore().StoreFederationCredential(ctx, project.UID, config.FederationCredential{
 				HubURL:        in.Body.HubURL,
 				HubProjectID:  in.Body.HubProjectID,
 				Token:         in.Body.Token,
@@ -400,7 +400,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		// response must not claim a detach happened.
 		body.Detached = res.Role == db.FederationRoleSpoke
 		if res.ProjectUID != "" {
-			if err := config.DeleteFederationCredential(res.ProjectUID); err != nil {
+			if err := cfg.federationCredentialStore().DeleteFederationCredential(ctx, res.ProjectUID); err != nil {
 				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
 			}
 		}
@@ -867,14 +867,20 @@ func federationEnrollmentToOut(enrollment db.FederationEnrollment, token string)
 	}
 }
 
-func federationStatusBody(ctx context.Context, store db.Storage, projectID *int64, includeArchived bool) (api.FederationStatusBody, error) {
+func federationStatusBody(
+	ctx context.Context,
+	store db.Storage,
+	credentialStore config.FederationCredentialStore,
+	projectID *int64,
+	includeArchived bool,
+) (api.FederationStatusBody, error) {
 	bindings, err := federationStatusBindings(ctx, store, projectID)
 	if err != nil {
 		return api.FederationStatusBody{}, err
 	}
 	out := api.FederationStatusBody{Statuses: make([]api.FederationProjectStatus, 0, len(bindings))}
 	for _, binding := range bindings {
-		status, err := federationProjectStatus(ctx, store, binding, includeArchived)
+		status, err := federationProjectStatus(ctx, store, credentialStore, binding, includeArchived)
 		if err != nil {
 			if projectID == nil && isProjectNotFound(err) {
 				continue
@@ -915,7 +921,13 @@ func federationStatusBindings(ctx context.Context, store db.Storage, projectID *
 	return []db.FederationBinding{binding}, nil
 }
 
-func federationProjectStatus(ctx context.Context, store db.Storage, binding db.FederationBinding, includeArchived bool) (api.FederationProjectStatus, error) {
+func federationProjectStatus(
+	ctx context.Context,
+	store db.Storage,
+	credentialStore config.FederationCredentialStore,
+	binding db.FederationBinding,
+	includeArchived bool,
+) (api.FederationProjectStatus, error) {
 	project, err := activeProjectByID(ctx, store, binding.ProjectID)
 	if includeArchived && isProjectNotFound(err) {
 		// include=archived: an archived project's binding is still real —
@@ -962,7 +974,7 @@ func federationProjectStatus(ctx context.Context, store db.Storage, binding db.F
 	}
 	var credentialMetadata config.FederationCredentialMetadata
 	if binding.Role == db.FederationRoleSpoke {
-		credentialMetadata = config.FederationCredentialMetadataFor(project.UID)
+		credentialMetadata = config.FederationCredentialMetadataFromStore(ctx, credentialStore, project.UID)
 	}
 	// The credential's allow_insecure is only meaningful for the hub it was
 	// recorded for: a stale credential from an older enrollment (e.g. a

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -4,8 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strconv"
 
 	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/kata/internal/api"
 )
 
 // APISchemaVersion is the version stamped into the daemon's OpenAPI document
@@ -182,6 +186,36 @@ func documentOperations(doc *huma.OpenAPI) []*huma.Operation {
 		}
 	}
 	return ops
+}
+
+// applyErrorEnvelopeResponses replaces Huma's process-global default error
+// model in this API's document only. Runtime framework errors are converted by
+// api.TransformHumaError; keeping the same transformation local here preserves
+// the published wire contract without changing other Huma APIs in the process.
+func applyErrorEnvelopeResponses(doc *huma.OpenAPI) {
+	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
+		return
+	}
+
+	registry := doc.Components.Schemas
+	errorSchema := registry.Schema(reflect.TypeOf(api.ErrorEnvelope{}), true, "ErrorEnvelope")
+	for _, operation := range documentOperations(doc) {
+		for code, response := range operation.Responses {
+			status, err := strconv.Atoi(code)
+			if code != "default" && (err != nil || status < 400) {
+				continue
+			}
+			response.Content = map[string]*huma.MediaType{
+				"application/json": {Schema: errorSchema},
+			}
+		}
+	}
+
+	// These framework schemas are no longer referenced after every error
+	// response is rewritten. Do not leak unrelated Huma error components into
+	// Kata's committed API artifact.
+	delete(registry.Map(), "ErrorDetail")
+	delete(registry.Map(), "ErrorModel")
 }
 
 // walkSchemaTree visits schema and every schema reachable from it, resolving

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -35,6 +35,7 @@ type ServerConfig struct {
 	Endpoint                 *kitdaemon.Endpoint
 	Broadcaster              *EventBroadcaster
 	FederationWake           func()
+	FederationCredentials    config.FederationCredentialStore
 	GitHubSyncFetcher        githubsync.Fetcher
 	GitHubSyncConfig         config.GitHubSyncConfig
 	GitHubSyncFetcherFactory func(config.GitHubSyncConfig) githubsync.Fetcher
@@ -87,6 +88,13 @@ func (c ServerConfig) authPolicy() authPolicy {
 	}
 }
 
+func (c ServerConfig) federationCredentialStore() config.FederationCredentialStore {
+	if c.FederationCredentials != nil {
+		return c.FederationCredentials
+	}
+	return config.DefaultFederationCredentialStore()
+}
+
 // CloseThrottlePolicy is the runtime form of [close.throttle] in
 // <KATA_HOME>/config.toml.
 type CloseThrottlePolicy struct {
@@ -137,6 +145,9 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 	if cfg.Hooks == nil {
 		cfg.Hooks = hooks.NewNoop()
+	}
+	if cfg.FederationCredentials == nil {
+		cfg.FederationCredentials = config.DefaultFederationCredentialStore()
 	}
 
 	mux := http.NewServeMux()

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -139,7 +139,6 @@ type Server struct {
 // NewServer wires routes onto a fresh http.ServeMux. The returned handler is
 // safe to mount in tests via httptest.NewServer.
 func NewServer(cfg ServerConfig) *Server {
-	api.InstallErrorFormatter()
 	if cfg.Broadcaster == nil {
 		cfg.Broadcaster = NewEventBroadcaster()
 	}
@@ -154,16 +153,18 @@ func NewServer(cfg ServerConfig) *Server {
 	humaConfig := huma.DefaultConfig("kata", APISchemaVersion)
 	humaConfig.OpenAPIPath = "" // Plan 1: no /openapi.json served at runtime; see `kata openapi` + OpenAPIDocument
 	humaConfig.DocsPath = ""
+	humaConfig.Transformers = append(humaConfig.Transformers, api.TransformHumaError)
 	// Drop DefaultConfig's SchemaLinkTransformer: it rebuilds response structs
 	// via reflection (adding a $schema field), which silently bypasses any
 	// MarshalJSON. Our APIError relies on MarshalJSON to emit the wire-spec
 	// envelope shape, so we must disable the transform.
 	humaConfig.CreateHooks = nil
-	humaAPI := humago.New(mux, humaConfig)
+	humaAPI := huma.NewAPI(humaConfig, api.WrapErrorAdapter(humago.NewAdapter(mux, "")))
 
 	s := &Server{cfg: cfg, api: humaAPI}
 	registerRoutes(humaAPI, mux, cfg)
 	registerOpenAPIYAML(mux)
+	applyErrorEnvelopeResponses(humaAPI.OpenAPI())
 	applyJSONBlobSchemaOverrides(humaAPI.OpenAPI())
 
 	s.handler = withGzip(withCSRFGuards(requireBearer(cfg.authPolicy(), cfg.DB)(withTrustedProxyActor(cfg)(mux))))

--- a/internal/daemon/server_error_isolation_test.go
+++ b/internal/daemon/server_error_isolation_test.go
@@ -1,0 +1,43 @@
+package daemon_test
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/daemon"
+)
+
+func TestNewServerLeavesHumaErrorFactoryUntouched(t *testing.T) {
+	original := huma.NewError
+	t.Cleanup(func() { huma.NewError = original })
+	originalPointer := reflect.ValueOf(original).Pointer()
+
+	_ = daemon.NewServer(daemon.ServerConfig{})
+
+	require.Equal(t, originalPointer, reflect.ValueOf(huma.NewError).Pointer())
+	_, ok := huma.NewError(400, "foreign error").(*huma.ErrorModel)
+	require.True(t, ok, "constructing Kata must not change another Huma API's error model")
+}
+
+func TestNewServerConcurrentConstructionLeavesHumaErrorFactoryUntouched(t *testing.T) {
+	original := huma.NewError
+	t.Cleanup(func() { huma.NewError = original })
+	originalPointer := reflect.ValueOf(original).Pointer()
+
+	const servers = 16
+	var wg sync.WaitGroup
+	wg.Add(servers)
+	for range servers {
+		go func() {
+			defer wg.Done()
+			_ = daemon.NewServer(daemon.ServerConfig{})
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, originalPointer, reflect.ValueOf(huma.NewError).Pointer())
+}

--- a/internal/db/pgstore/event_hash_repair.go
+++ b/internal/db/pgstore/event_hash_repair.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"go.kenn.io/kata/internal/db"
 )
@@ -36,6 +37,7 @@ func recomputeEventContentHashesTx(ctx context.Context, tx *sql.Tx, ids []int64)
 		seen[id] = struct{}{}
 		var input db.EventHashInput
 		var payload string
+		var createdAt time.Time
 		err := tx.QueryRowContext(ctx, `
 SELECT e.uid, e.origin_instance_uid, p.uid, e.project_name,
        e.issue_uid, e.related_issue_uid, e.type, e.actor,
@@ -45,11 +47,12 @@ SELECT e.uid, e.origin_instance_uid, p.uid, e.project_name,
  WHERE e.id = $1`, id).Scan(
 			&input.UID, &input.OriginInstanceUID, &input.ProjectUID, &input.ProjectName,
 			&input.IssueUID, &input.RelatedIssueUID, &input.Type, &input.Actor,
-			&input.HLCPhysicalMS, &input.HLCCounter, &input.CreatedAt, &payload,
+			&input.HLCPhysicalMS, &input.HLCCounter, &createdAt, &payload,
 		)
 		if err != nil {
 			return mapSQLError(err, nil)
 		}
+		input.CreatedAt = createdAt.UTC().Format(db.EventTimestampFormat)
 		input.Payload = json.RawMessage(payload)
 		hash, err := db.EventContentHash(input)
 		if err != nil {

--- a/internal/db/pgstore/event_hash_repair.go
+++ b/internal/db/pgstore/event_hash_repair.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"go.kenn.io/kata/internal/db"
 )
@@ -37,7 +36,6 @@ func recomputeEventContentHashesTx(ctx context.Context, tx *sql.Tx, ids []int64)
 		seen[id] = struct{}{}
 		var input db.EventHashInput
 		var payload string
-		var createdAt time.Time
 		err := tx.QueryRowContext(ctx, `
 SELECT e.uid, e.origin_instance_uid, p.uid, e.project_name,
        e.issue_uid, e.related_issue_uid, e.type, e.actor,
@@ -47,12 +45,11 @@ SELECT e.uid, e.origin_instance_uid, p.uid, e.project_name,
  WHERE e.id = $1`, id).Scan(
 			&input.UID, &input.OriginInstanceUID, &input.ProjectUID, &input.ProjectName,
 			&input.IssueUID, &input.RelatedIssueUID, &input.Type, &input.Actor,
-			&input.HLCPhysicalMS, &input.HLCCounter, &createdAt, &payload,
+			&input.HLCPhysicalMS, &input.HLCCounter, &input.CreatedAt, &payload,
 		)
 		if err != nil {
 			return mapSQLError(err, nil)
 		}
-		input.CreatedAt = createdAt.UTC().Format(db.EventTimestampFormat)
 		input.Payload = json.RawMessage(payload)
 		hash, err := db.EventContentHash(input)
 		if err != nil {

--- a/internal/db/pgstore/tokens.go
+++ b/internal/db/pgstore/tokens.go
@@ -34,7 +34,7 @@ type tokenRevokedPayload struct {
 func (s *Store) EnsureSystemProject(ctx context.Context) error {
 	return s.RetryTransient(ctx, func() error {
 		if _, err := s.ExecContext(ctx, `INSERT INTO projects(uid, name)
-VALUES($1, $2) ON CONFLICT(name) DO NOTHING`, db.SystemProjectUID, db.SystemProjectName); err != nil {
+VALUES($1, $2) ON CONFLICT DO NOTHING`, db.SystemProjectUID, db.SystemProjectName); err != nil {
 			return fmt.Errorf("ensure system project: %w", mapSQLError(err, nil))
 		}
 		project, err := s.SystemProject(ctx)

--- a/internal/db/sqlitestore/event_hash_repair.go
+++ b/internal/db/sqlitestore/event_hash_repair.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"go.kenn.io/kata/internal/db"
 )
@@ -36,6 +37,7 @@ func recomputeEventContentHashesTx(ctx context.Context, tx *sql.Tx, ids []int64)
 		seen[id] = struct{}{}
 		var input db.EventHashInput
 		var payload string
+		var createdAt time.Time
 		err := tx.QueryRowContext(ctx, `
 SELECT e.uid, e.origin_instance_uid, p.uid, e.project_name,
        e.issue_uid, e.related_issue_uid, e.type, e.actor,
@@ -45,11 +47,12 @@ SELECT e.uid, e.origin_instance_uid, p.uid, e.project_name,
  WHERE e.id = ?`, id).Scan(
 			&input.UID, &input.OriginInstanceUID, &input.ProjectUID, &input.ProjectName,
 			&input.IssueUID, &input.RelatedIssueUID, &input.Type, &input.Actor,
-			&input.HLCPhysicalMS, &input.HLCCounter, &input.CreatedAt, &payload,
+			&input.HLCPhysicalMS, &input.HLCCounter, &createdAt, &payload,
 		)
 		if err != nil {
 			return fmt.Errorf("load retained event %d: %w", id, err)
 		}
+		input.CreatedAt = createdAt.UTC().Format(db.EventTimestampFormat)
 		input.Payload = json.RawMessage(payload)
 		hash, err := db.EventContentHash(input)
 		if err != nil {

--- a/internal/federation/federation_sync.go
+++ b/internal/federation/federation_sync.go
@@ -718,6 +718,7 @@ func remoteEventFromEnvelope(ev api.EventEnvelope) db.RemoteEvent {
 // Runner quietly pulls every enabled spoke binding.
 type Runner struct {
 	DB             db.Storage
+	Credentials    config.FederationCredentialStore
 	Opts           clientpkg.Opts
 	Interval       time.Duration
 	Wake           <-chan struct{}
@@ -778,20 +779,9 @@ func (r *Runner) runOnce(ctx context.Context, validateLease func(context.Context
 	if len(spokes) == 0 {
 		return nil
 	}
-	creds, err := config.ReadFederationCredentials()
-	if err != nil {
-		var errs []error
-		errs = append(errs, err)
-		for _, spoke := range spokes {
-			if leaseErr := validateFederationRunnerLease(ctx, validateLease); leaseErr != nil {
-				return leaseErr
-			}
-			binding := spoke.binding
-			if recordErr := r.DB.RecordFederationSyncError(ctx, binding.ProjectID, err, time.Now().UTC()); recordErr != nil {
-				errs = append(errs, recordErr)
-			}
-		}
-		return errors.Join(errs...)
+	credentialStore := r.Credentials
+	if credentialStore == nil {
+		credentialStore = config.DefaultFederationCredentialStore()
 	}
 	var errs []error
 	for _, spoke := range spokes {
@@ -801,7 +791,14 @@ func (r *Runner) runOnce(ctx context.Context, validateLease func(context.Context
 		binding := spoke.binding
 		bindingErrs := len(errs)
 		project := spoke.project
-		cred := creds.Projects[project.UID]
+		cred, _, credentialErr := credentialStore.FederationCredential(ctx, project.UID)
+		if credentialErr != nil {
+			errs = append(errs, credentialErr)
+			if recordErr := r.DB.RecordFederationSyncError(ctx, binding.ProjectID, credentialErr, time.Now().UTC()); recordErr != nil {
+				errs = append(errs, recordErr)
+			}
+			continue
+		}
 		if cred.HubURL == "" {
 			cred.HubURL = binding.HubURL
 		}

--- a/service.go
+++ b/service.go
@@ -16,11 +16,13 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/pgstore"
 	"go.kenn.io/kata/internal/db/storeopen"
 	"go.kenn.io/kata/internal/federation"
+	"go.kenn.io/kata/internal/githubsync"
 	"go.kenn.io/kata/internal/hooks"
 )
 
@@ -45,22 +47,42 @@ type PostgresConfig struct {
 	AllowInsecureTransport bool
 }
 
+// AuthConfig defines the authentication boundary for a mounted Service.
+// Exactly one of Token or TrustCallerAuthentication must be selected.
+type AuthConfig struct {
+	// Token protects Kata's ordinary HTTP surface. Federation transport and
+	// claim actions retain their own scoped credential checks.
+	Token string
+	// TrustCallerAuthentication disables Kata's bearer check because the
+	// caller guarantees that Handler is mounted behind its own authentication
+	// boundary. Never mount that handler directly on an untrusted listener.
+	TrustCallerAuthentication bool
+}
+
 // Config contains the process-neutral inputs needed to construct a Service.
 type Config struct {
 	// DSN accepts a SQLite path, sqlite:// URL, or PostgreSQL URL.
 	DSN       string
 	Postgres  PostgresConfig
+	Auth      AuthConfig
 	StartedAt time.Time
 	Logger    *slog.Logger
 }
 
+type serviceDeps struct {
+	gitHubSyncFetcher githubsync.Fetcher
+}
+
 // Service is a mountable Kata HTTP application and its owned lifecycle.
 type Service struct {
-	store       db.Storage
-	server      *daemon.Server
-	broadcaster *daemon.EventBroadcaster
-	wake        chan struct{}
-	logger      *slog.Logger
+	store             db.Storage
+	server            *daemon.Server
+	broadcaster       *daemon.EventBroadcaster
+	hookSink          hooks.Sink
+	federationWake    chan struct{}
+	gitHubSyncWake    chan struct{}
+	gitHubSyncFetcher githubsync.Fetcher
+	logger            *slog.Logger
 
 	mu        sync.Mutex
 	running   bool
@@ -74,8 +96,18 @@ type Service struct {
 // New opens the configured backend and constructs a listener-free service.
 // The returned Service owns the backend handle and closes it from Close.
 func New(ctx context.Context, cfg Config) (*Service, error) {
+	return newService(ctx, cfg, serviceDeps{})
+}
+
+func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, error) {
 	if strings.TrimSpace(cfg.DSN) == "" {
 		return nil, errors.New("kata: storage DSN is required")
+	}
+	if strings.TrimSpace(cfg.Auth.Token) == "" && !cfg.Auth.TrustCallerAuthentication {
+		return nil, errors.New("kata: auth token is required unless caller authentication is explicitly trusted")
+	}
+	if strings.TrimSpace(cfg.Auth.Token) != "" && cfg.Auth.TrustCallerAuthentication {
+		return nil, errors.New("kata: auth token and trusted caller authentication are mutually exclusive")
 	}
 
 	openCfg := storeopen.DefaultConfig()
@@ -100,38 +132,60 @@ func New(ctx context.Context, cfg Config) (*Service, error) {
 		logger = slog.Default()
 	}
 	broadcaster := daemon.NewEventBroadcaster()
-	wake := make(chan struct{}, 1)
-	wakeRunner := func() {
+	hookSink := hooks.NewNoop()
+	federationWake := make(chan struct{}, 1)
+	wakeFederation := func() {
 		select {
-		case wake <- struct{}{}:
+		case federationWake <- struct{}{}:
 		default:
 		}
 	}
+	gitHubSyncWake := make(chan struct{}, 1)
+	wakeGitHubSync := func() {
+		select {
+		case gitHubSyncWake <- struct{}{}:
+		default:
+		}
+	}
+	gitHubSyncConfig := config.GitHubSyncConfig{}
+	gitHubSyncFetcher := deps.gitHubSyncFetcher
+	if gitHubSyncFetcher == nil {
+		gitHubSyncFetcher = githubsync.NewHTTPFetcher(githubsync.HTTPFetcherConfig{
+			CredentialResolver: githubsync.NewCredentialResolver(gitHubSyncConfig, nil),
+		})
+	}
 	server := daemon.NewServer(daemon.ServerConfig{
-		DB:             store,
-		StartedAt:      startedAt,
-		Broadcaster:    broadcaster,
-		FederationWake: wakeRunner,
-		Hooks:          hooks.NewNoop(),
-		Logger:         logger,
+		DB:                store,
+		StartedAt:         startedAt,
+		Broadcaster:       broadcaster,
+		FederationWake:    wakeFederation,
+		GitHubSyncFetcher: gitHubSyncFetcher,
+		GitHubSyncConfig:  gitHubSyncConfig,
+		GitHubSyncWake:    wakeGitHubSync,
+		Hooks:             hookSink,
+		Auth:              config.AuthConfig{Token: cfg.Auth.Token},
+		Logger:            logger,
 	})
 
 	return &Service{
-		store:       store,
-		server:      server,
-		broadcaster: broadcaster,
-		wake:        wake,
-		logger:      logger,
-		closeDone:   make(chan struct{}),
+		store:             store,
+		server:            server,
+		broadcaster:       broadcaster,
+		hookSink:          hookSink,
+		federationWake:    federationWake,
+		gitHubSyncWake:    gitHubSyncWake,
+		gitHubSyncFetcher: gitHubSyncFetcher,
+		logger:            logger,
+		closeDone:         make(chan struct{}),
 	}, nil
 }
 
 // Handler returns the HTTP application for mounting in a caller-owned server.
 func (s *Service) Handler() http.Handler { return s.server.Handler() }
 
-// Run executes Kata's core federation and timed-claim workers until ctx is
-// canceled or Close is called. Run does not start a listener and may be called
-// only once at a time.
+// Run executes Kata's federation, GitHub synchronization, and timed-claim
+// workers until ctx is canceled or Close is called. Run does not start a
+// listener and may be called only once at a time.
 func (s *Service) Run(ctx context.Context) error {
 	if ctx == nil {
 		return errors.New("kata: run context is required")
@@ -161,12 +215,11 @@ func (s *Service) Run(ctx context.Context) error {
 		s.mu.Unlock()
 	}()
 
-	workerErrs := make(chan error, 2)
-	sink := hooks.NewNoop()
+	workerErrs := make(chan error, 3)
 	runner := &federation.Runner{
 		DB:       s.store,
 		Interval: 30 * time.Second,
-		Wake:     s.wake,
+		Wake:     s.federationWake,
 		OnError: func(err error) {
 			s.logger.Error("kata federation worker", "err", err)
 		},
@@ -179,30 +232,48 @@ func (s *Service) Run(ctx context.Context) error {
 			}
 		},
 	}
-	sweeper := daemon.NewTimedClaimSweeper(s.store, s.broadcaster, sink)
+	gitHubSyncRunner := githubsync.NewRunner(githubsync.RunnerConfig{
+		Store:    s.store,
+		Fetcher:  s.gitHubSyncFetcher,
+		Logger:   s.logger,
+		Interval: 5 * time.Minute,
+		Wake:     s.gitHubSyncWake,
+		EventSink: func(_ context.Context, projectID int64, events []db.Event) error {
+			for i := range events {
+				event := events[i]
+				s.broadcaster.Broadcast(daemon.StreamMsg{
+					Kind: "event", Event: &event, ProjectID: projectID,
+				})
+				s.hookSink.Enqueue(event)
+			}
+			return nil
+		},
+	})
+	sweeper := daemon.NewTimedClaimSweeper(s.store, s.broadcaster, s.hookSink)
 	sweeper.OnError = func(err error) {
 		s.logger.Error("kata timed-claim worker", "err", err)
 	}
 	go func() { workerErrs <- runner.Run(runCtx) }()
+	go func() { workerErrs <- gitHubSyncRunner.Run(runCtx) }()
 	go func() { workerErrs <- sweeper.Run(runCtx) }()
 
-	workerResults := make([]error, 0, 2)
+	workerResults := make([]error, 0, 3)
 	select {
 	case <-runCtx.Done():
 	case err := <-workerErrs:
 		workerResults = append(workerResults, err)
 	}
 	cancel()
-	for len(workerResults) < 2 {
+	for len(workerResults) < 3 {
 		workerResults = append(workerResults, <-workerErrs)
 	}
 	if runCtx.Err() != nil && (ctx.Err() != nil || s.isClosed()) {
 		return nil
 	}
-	return errors.Join(
-		normalizeWorkerError(workerResults[0]),
-		normalizeWorkerError(workerResults[1]),
-	)
+	for i := range workerResults {
+		workerResults[i] = normalizeWorkerError(workerResults[i])
+	}
+	return errors.Join(workerResults...)
 }
 
 func normalizeWorkerError(err error) error {

--- a/service.go
+++ b/service.go
@@ -84,8 +84,11 @@ type Config struct {
 	Postgres   PostgresConfig
 	Auth       AuthConfig
 	GitHubSync GitHubSyncConfig
-	StartedAt  time.Time
-	Logger     *slog.Logger
+	// FederationCredentials isolates secret material from other Service
+	// instances. Nil selects a service-owned in-memory store.
+	FederationCredentials FederationCredentialStore
+	StartedAt             time.Time
+	Logger                *slog.Logger
 }
 
 type serviceDeps struct {
@@ -95,17 +98,18 @@ type serviceDeps struct {
 
 // Service is a mountable Kata HTTP application and its owned lifecycle.
 type Service struct {
-	store             db.Storage
-	server            *daemon.Server
-	broadcaster       *daemon.EventBroadcaster
-	hookSink          hooks.Sink
-	federationWake    chan struct{}
-	gitHubSyncWake    chan struct{}
-	gitHubSyncFetcher githubsync.Fetcher
-	logger            *slog.Logger
-	lifetimeCtx       context.Context
-	lifetimeCancel    context.CancelFunc
-	handlerWG         sync.WaitGroup
+	store                 db.Storage
+	server                *daemon.Server
+	broadcaster           *daemon.EventBroadcaster
+	hookSink              hooks.Sink
+	federationWake        chan struct{}
+	gitHubSyncWake        chan struct{}
+	gitHubSyncFetcher     githubsync.Fetcher
+	federationCredentials config.FederationCredentialStore
+	logger                *slog.Logger
+	lifetimeCtx           context.Context
+	lifetimeCancel        context.CancelFunc
+	handlerWG             sync.WaitGroup
 
 	mu        sync.Mutex
 	running   bool
@@ -136,6 +140,11 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 	if err != nil {
 		return nil, fmt.Errorf("kata: GitHub sync config: %w", err)
 	}
+	publicFederationCredentials := cfg.FederationCredentials
+	if publicFederationCredentials == nil {
+		publicFederationCredentials = newMemoryFederationCredentialStore()
+	}
+	federationCredentials := serviceCredentialStoreAdapter{store: publicFederationCredentials}
 
 	openCfg := storeopen.DefaultConfig()
 	pgCfg := cfg.Postgres
@@ -188,30 +197,32 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 		gitHubSyncFetcher = factory(gitHubSyncConfig)
 	}
 	server := daemon.NewServer(daemon.ServerConfig{
-		DB:                store,
-		StartedAt:         startedAt,
-		Broadcaster:       broadcaster,
-		FederationWake:    wakeFederation,
-		GitHubSyncFetcher: gitHubSyncFetcher,
-		GitHubSyncConfig:  gitHubSyncConfig,
-		GitHubSyncWake:    wakeGitHubSync,
-		Hooks:             hookSink,
-		Auth:              config.AuthConfig{Token: cfg.Auth.Token},
-		Logger:            logger,
+		DB:                    store,
+		StartedAt:             startedAt,
+		Broadcaster:           broadcaster,
+		FederationWake:        wakeFederation,
+		FederationCredentials: federationCredentials,
+		GitHubSyncFetcher:     gitHubSyncFetcher,
+		GitHubSyncConfig:      gitHubSyncConfig,
+		GitHubSyncWake:        wakeGitHubSync,
+		Hooks:                 hookSink,
+		Auth:                  config.AuthConfig{Token: cfg.Auth.Token},
+		Logger:                logger,
 	})
 
 	return &Service{
-		store:             store,
-		server:            server,
-		broadcaster:       broadcaster,
-		hookSink:          hookSink,
-		federationWake:    federationWake,
-		gitHubSyncWake:    gitHubSyncWake,
-		gitHubSyncFetcher: gitHubSyncFetcher,
-		logger:            logger,
-		lifetimeCtx:       lifetimeCtx,
-		lifetimeCancel:    lifetimeCancel,
-		closeDone:         make(chan struct{}),
+		store:                 store,
+		server:                server,
+		broadcaster:           broadcaster,
+		hookSink:              hookSink,
+		federationWake:        federationWake,
+		gitHubSyncWake:        gitHubSyncWake,
+		gitHubSyncFetcher:     gitHubSyncFetcher,
+		federationCredentials: federationCredentials,
+		logger:                logger,
+		lifetimeCtx:           lifetimeCtx,
+		lifetimeCancel:        lifetimeCancel,
+		closeDone:             make(chan struct{}),
 	}, nil
 }
 
@@ -313,9 +324,10 @@ func (s *Service) Run(ctx context.Context) error {
 
 	workerErrs := make(chan error, 3)
 	runner := &federation.Runner{
-		DB:       s.store,
-		Interval: 30 * time.Second,
-		Wake:     s.federationWake,
+		DB:          s.store,
+		Credentials: s.federationCredentials,
+		Interval:    30 * time.Second,
+		Wake:        s.federationWake,
 		OnError: func(err error) {
 			s.logger.Error("kata federation worker", "err", err)
 		},

--- a/service.go
+++ b/service.go
@@ -83,6 +83,9 @@ type Service struct {
 	gitHubSyncWake    chan struct{}
 	gitHubSyncFetcher githubsync.Fetcher
 	logger            *slog.Logger
+	lifetimeCtx       context.Context
+	lifetimeCancel    context.CancelFunc
+	handlerWG         sync.WaitGroup
 
 	mu        sync.Mutex
 	running   bool
@@ -131,6 +134,7 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 	if logger == nil {
 		logger = slog.Default()
 	}
+	lifetimeCtx, lifetimeCancel := context.WithCancel(context.Background())
 	broadcaster := daemon.NewEventBroadcaster()
 	hookSink := hooks.NewNoop()
 	federationWake := make(chan struct{}, 1)
@@ -176,12 +180,35 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 		gitHubSyncWake:    gitHubSyncWake,
 		gitHubSyncFetcher: gitHubSyncFetcher,
 		logger:            logger,
+		lifetimeCtx:       lifetimeCtx,
+		lifetimeCancel:    lifetimeCancel,
 		closeDone:         make(chan struct{}),
 	}, nil
 }
 
 // Handler returns the HTTP application for mounting in a caller-owned server.
-func (s *Service) Handler() http.Handler { return s.server.Handler() }
+func (s *Service) Handler() http.Handler { return http.HandlerFunc(s.serveHTTP) }
+
+func (s *Service) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		http.Error(w, "kata service is closed", http.StatusServiceUnavailable)
+		return
+	}
+	s.handlerWG.Add(1)
+	lifetimeCtx := s.lifetimeCtx
+	s.mu.Unlock()
+	defer s.handlerWG.Done()
+
+	requestCtx, cancel := context.WithCancel(r.Context())
+	stopLifetimeCancel := context.AfterFunc(lifetimeCtx, cancel)
+	defer func() {
+		stopLifetimeCancel()
+		cancel()
+	}()
+	s.server.Handler().ServeHTTP(w, r.WithContext(requestCtx))
+}
 
 // Run executes Kata's federation, GitHub synchronization, and timed-claim
 // workers until ctx is canceled or Close is called. Run does not start a
@@ -302,6 +329,7 @@ func (s *Service) Close() error {
 		return s.closeErr
 	}
 	s.closed = true
+	s.lifetimeCancel()
 	cancel := s.runCancel
 	runDone := s.runDone
 	s.mu.Unlock()
@@ -310,6 +338,7 @@ func (s *Service) Close() error {
 		cancel()
 		<-runDone
 	}
+	s.handlerWG.Wait()
 	err := errors.Join(s.server.Close(), s.store.Close())
 
 	s.mu.Lock()

--- a/service.go
+++ b/service.go
@@ -59,18 +59,38 @@ type AuthConfig struct {
 	TrustCallerAuthentication bool
 }
 
+// GitHubSyncConfig supplies credentials used by GitHub issue synchronization.
+// TokenEnv names an environment variable containing a token; token values are
+// never stored in Config. Empty fields use Kata's standalone defaults.
+type GitHubSyncConfig struct {
+	TokenEnv  string
+	TokenHost string
+	Apps      []GitHubAppConfig
+}
+
+// GitHubAppConfig identifies one GitHub App installation credential.
+type GitHubAppConfig struct {
+	Host           string
+	Owner          string
+	AppID          int64
+	InstallationID int64
+	PrivateKeyPath string
+}
+
 // Config contains the process-neutral inputs needed to construct a Service.
 type Config struct {
 	// DSN accepts a SQLite path, sqlite:// URL, or PostgreSQL URL.
-	DSN       string
-	Postgres  PostgresConfig
-	Auth      AuthConfig
-	StartedAt time.Time
-	Logger    *slog.Logger
+	DSN        string
+	Postgres   PostgresConfig
+	Auth       AuthConfig
+	GitHubSync GitHubSyncConfig
+	StartedAt  time.Time
+	Logger     *slog.Logger
 }
 
 type serviceDeps struct {
-	gitHubSyncFetcher githubsync.Fetcher
+	gitHubSyncFetcher        githubsync.Fetcher
+	gitHubSyncFetcherFactory func(config.GitHubSyncConfig) githubsync.Fetcher
 }
 
 // Service is a mountable Kata HTTP application and its owned lifecycle.
@@ -112,6 +132,10 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 	if strings.TrimSpace(cfg.Auth.Token) != "" && cfg.Auth.TrustCallerAuthentication {
 		return nil, errors.New("kata: auth token and trusted caller authentication are mutually exclusive")
 	}
+	gitHubSyncConfig, err := resolveGitHubSyncConfig(cfg.GitHubSync)
+	if err != nil {
+		return nil, fmt.Errorf("kata: GitHub sync config: %w", err)
+	}
 
 	openCfg := storeopen.DefaultConfig()
 	pgCfg := cfg.Postgres
@@ -151,12 +175,17 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 		default:
 		}
 	}
-	gitHubSyncConfig := config.GitHubSyncConfig{}
 	gitHubSyncFetcher := deps.gitHubSyncFetcher
 	if gitHubSyncFetcher == nil {
-		gitHubSyncFetcher = githubsync.NewHTTPFetcher(githubsync.HTTPFetcherConfig{
-			CredentialResolver: githubsync.NewCredentialResolver(gitHubSyncConfig, nil),
-		})
+		factory := deps.gitHubSyncFetcherFactory
+		if factory == nil {
+			factory = func(cfg config.GitHubSyncConfig) githubsync.Fetcher {
+				return githubsync.NewHTTPFetcher(githubsync.HTTPFetcherConfig{
+					CredentialResolver: githubsync.NewCredentialResolver(cfg, nil),
+				})
+			}
+		}
+		gitHubSyncFetcher = factory(gitHubSyncConfig)
 	}
 	server := daemon.NewServer(daemon.ServerConfig{
 		DB:                store,
@@ -184,6 +213,23 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 		lifetimeCancel:    lifetimeCancel,
 		closeDone:         make(chan struct{}),
 	}, nil
+}
+
+func resolveGitHubSyncConfig(cfg GitHubSyncConfig) (config.GitHubSyncConfig, error) {
+	apps := make([]config.GitHubAppConfig, len(cfg.Apps))
+	for i := range cfg.Apps {
+		app := cfg.Apps[i]
+		apps[i] = config.GitHubAppConfig{
+			Host:           app.Host,
+			Owner:          app.Owner,
+			AppID:          app.AppID,
+			InstallationID: app.InstallationID,
+			PrivateKeyPath: app.PrivateKeyPath,
+		}
+	}
+	return config.NormalizeGitHubSyncConfig(config.GitHubSyncConfig{
+		TokenEnv: cfg.TokenEnv, TokenHost: cfg.TokenHost, Apps: apps,
+	})
 }
 
 // Handler returns the HTTP application for mounting in a caller-owned server.
@@ -240,6 +286,29 @@ func (s *Service) Run(ctx context.Context) error {
 		s.runCancel = nil
 		close(done)
 		s.mu.Unlock()
+	}()
+	federationSub := s.broadcaster.Subscribe(daemon.SubFilter{})
+	federationWakeDone := make(chan struct{})
+	go func() {
+		defer close(federationWakeDone)
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case msg, ok := <-federationSub.Ch:
+				if !ok {
+					return
+				}
+				if msg.Kind == "event" {
+					signalWake(s.federationWake)
+				}
+			}
+		}
+	}()
+	defer func() {
+		cancel()
+		<-federationWakeDone
+		federationSub.Unsub()
 	}()
 
 	workerErrs := make(chan error, 3)
@@ -301,6 +370,13 @@ func (s *Service) Run(ctx context.Context) error {
 		workerResults[i] = normalizeWorkerError(workerResults[i])
 	}
 	return errors.Join(workerResults...)
+}
+
+func signalWake(ch chan<- struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
 }
 
 func normalizeWorkerError(err error) error {

--- a/service.go
+++ b/service.go
@@ -1,0 +1,249 @@
+// Package kata exposes Kata as a listener-free application service.
+//
+// A Service owns its configured storage handle and core background workers.
+// Callers mount Handler in their own HTTP server, run background work with Run,
+// and release owned resources with Close. The package does not open a network
+// listener, install signal handlers, or manage its caller's process lifecycle.
+package kata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/pgstore"
+	"go.kenn.io/kata/internal/db/storeopen"
+	"go.kenn.io/kata/internal/federation"
+	"go.kenn.io/kata/internal/hooks"
+)
+
+// PostgresSchemaMode controls how a PostgreSQL-backed service treats its
+// configured schema at startup.
+type PostgresSchemaMode string
+
+const (
+	// PostgresSchemaBootstrap installs missing Kata migrations before serving.
+	PostgresSchemaBootstrap PostgresSchemaMode = "bootstrap"
+	// PostgresSchemaValidate requires an already-installed, compatible schema
+	// and performs no schema installation.
+	PostgresSchemaValidate PostgresSchemaMode = "validate"
+)
+
+// PostgresConfig selects an isolated PostgreSQL schema and startup policy.
+// Empty fields use Kata's standalone defaults.
+type PostgresConfig struct {
+	Schema                 string
+	SchemaMode             PostgresSchemaMode
+	SchemaOwner            string
+	AllowInsecureTransport bool
+}
+
+// Config contains the process-neutral inputs needed to construct a Service.
+type Config struct {
+	// DSN accepts a SQLite path, sqlite:// URL, or PostgreSQL URL.
+	DSN       string
+	Postgres  PostgresConfig
+	StartedAt time.Time
+	Logger    *slog.Logger
+}
+
+// Service is a mountable Kata HTTP application and its owned lifecycle.
+type Service struct {
+	store       db.Storage
+	server      *daemon.Server
+	broadcaster *daemon.EventBroadcaster
+	wake        chan struct{}
+	logger      *slog.Logger
+
+	mu        sync.Mutex
+	running   bool
+	runCancel context.CancelFunc
+	runDone   chan struct{}
+	closed    bool
+	closeDone chan struct{}
+	closeErr  error
+}
+
+// New opens the configured backend and constructs a listener-free service.
+// The returned Service owns the backend handle and closes it from Close.
+func New(ctx context.Context, cfg Config) (*Service, error) {
+	if strings.TrimSpace(cfg.DSN) == "" {
+		return nil, errors.New("kata: storage DSN is required")
+	}
+
+	openCfg := storeopen.DefaultConfig()
+	pgCfg := cfg.Postgres
+	openCfg.Postgres = pgstore.ConfigFromValues(
+		pgCfg.Schema,
+		string(pgCfg.SchemaMode),
+		pgCfg.SchemaOwner,
+		pgCfg.AllowInsecureTransport,
+	)
+	store, err := storeopen.OpenWithConfig(ctx, cfg.DSN, openCfg, db.Serving())
+	if err != nil {
+		return nil, fmt.Errorf("kata: open storage: %w", err)
+	}
+
+	startedAt := cfg.StartedAt
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	broadcaster := daemon.NewEventBroadcaster()
+	wake := make(chan struct{}, 1)
+	wakeRunner := func() {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+	}
+	server := daemon.NewServer(daemon.ServerConfig{
+		DB:             store,
+		StartedAt:      startedAt,
+		Broadcaster:    broadcaster,
+		FederationWake: wakeRunner,
+		Hooks:          hooks.NewNoop(),
+		Logger:         logger,
+	})
+
+	return &Service{
+		store:       store,
+		server:      server,
+		broadcaster: broadcaster,
+		wake:        wake,
+		logger:      logger,
+		closeDone:   make(chan struct{}),
+	}, nil
+}
+
+// Handler returns the HTTP application for mounting in a caller-owned server.
+func (s *Service) Handler() http.Handler { return s.server.Handler() }
+
+// Run executes Kata's core federation and timed-claim workers until ctx is
+// canceled or Close is called. Run does not start a listener and may be called
+// only once at a time.
+func (s *Service) Run(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("kata: run context is required")
+	}
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return errors.New("kata: service is closed")
+	}
+	if s.running {
+		s.mu.Unlock()
+		return errors.New("kata: service is already running")
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	s.running = true
+	s.runCancel = cancel
+	s.runDone = done
+	s.mu.Unlock()
+
+	defer func() {
+		cancel()
+		s.mu.Lock()
+		s.running = false
+		s.runCancel = nil
+		close(done)
+		s.mu.Unlock()
+	}()
+
+	workerErrs := make(chan error, 2)
+	sink := hooks.NewNoop()
+	runner := &federation.Runner{
+		DB:       s.store,
+		Interval: 30 * time.Second,
+		Wake:     s.wake,
+		OnError: func(err error) {
+			s.logger.Error("kata federation worker", "err", err)
+		},
+		OnPulledEvents: func(projectID int64, events []db.Event) {
+			for i := range events {
+				event := events[i]
+				s.broadcaster.Broadcast(daemon.StreamMsg{
+					Kind: "event", Event: &event, ProjectID: projectID,
+				})
+			}
+		},
+	}
+	sweeper := daemon.NewTimedClaimSweeper(s.store, s.broadcaster, sink)
+	sweeper.OnError = func(err error) {
+		s.logger.Error("kata timed-claim worker", "err", err)
+	}
+	go func() { workerErrs <- runner.Run(runCtx) }()
+	go func() { workerErrs <- sweeper.Run(runCtx) }()
+
+	workerResults := make([]error, 0, 2)
+	select {
+	case <-runCtx.Done():
+	case err := <-workerErrs:
+		workerResults = append(workerResults, err)
+	}
+	cancel()
+	for len(workerResults) < 2 {
+		workerResults = append(workerResults, <-workerErrs)
+	}
+	if runCtx.Err() != nil && (ctx.Err() != nil || s.isClosed()) {
+		return nil
+	}
+	return errors.Join(
+		normalizeWorkerError(workerResults[0]),
+		normalizeWorkerError(workerResults[1]),
+	)
+}
+
+func normalizeWorkerError(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+func (s *Service) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// Close stops active background work and releases every resource owned by the
+// service. It is safe to call Close more than once.
+func (s *Service) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		done := s.closeDone
+		s.mu.Unlock()
+		<-done
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.closeErr
+	}
+	s.closed = true
+	cancel := s.runCancel
+	runDone := s.runDone
+	s.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+		<-runDone
+	}
+	err := errors.Join(s.server.Close(), s.store.Close())
+
+	s.mu.Lock()
+	s.closeErr = err
+	close(s.closeDone)
+	s.mu.Unlock()
+	return err
+}

--- a/service_credentials.go
+++ b/service_credentials.go
@@ -1,0 +1,111 @@
+package kata
+
+import (
+	"context"
+	"sync"
+
+	"go.kenn.io/kata/internal/config"
+)
+
+// FederationCredential is the secret material used by one spoke project to
+// communicate with its hub.
+type FederationCredential struct {
+	HubURL        string
+	HubProjectID  int64
+	Token         string
+	Capabilities  string
+	Actor         string
+	AllowInsecure bool
+}
+
+// FederationCredentialStore supplies service-scoped federation secrets.
+// Implementations must be safe for concurrent use. Callers that need
+// credentials to survive process restarts should provide a durable store;
+// otherwise each Service receives its own in-memory store.
+type FederationCredentialStore interface {
+	FederationCredential(context.Context, string) (FederationCredential, bool, error)
+	StoreFederationCredential(context.Context, string, FederationCredential) error
+	DeleteFederationCredential(context.Context, string) error
+}
+
+type serviceCredentialStoreAdapter struct {
+	store FederationCredentialStore
+}
+
+func (a serviceCredentialStoreAdapter) FederationCredential(
+	ctx context.Context, projectUID string,
+) (config.FederationCredential, bool, error) {
+	credential, ok, err := a.store.FederationCredential(ctx, projectUID)
+	if err != nil || !ok {
+		return config.FederationCredential{}, ok, err
+	}
+	return internalFederationCredential(credential), true, nil
+}
+
+func (a serviceCredentialStoreAdapter) StoreFederationCredential(
+	ctx context.Context, projectUID string, credential config.FederationCredential,
+) error {
+	return a.store.StoreFederationCredential(ctx, projectUID, publicFederationCredential(credential))
+}
+
+func (a serviceCredentialStoreAdapter) DeleteFederationCredential(ctx context.Context, projectUID string) error {
+	return a.store.DeleteFederationCredential(ctx, projectUID)
+}
+
+func internalFederationCredential(credential FederationCredential) config.FederationCredential {
+	return config.FederationCredential{
+		HubURL:        credential.HubURL,
+		HubProjectID:  credential.HubProjectID,
+		Token:         credential.Token,
+		Capabilities:  credential.Capabilities,
+		Actor:         credential.Actor,
+		AllowInsecure: credential.AllowInsecure,
+	}
+}
+
+func publicFederationCredential(credential config.FederationCredential) FederationCredential {
+	return FederationCredential{
+		HubURL:        credential.HubURL,
+		HubProjectID:  credential.HubProjectID,
+		Token:         credential.Token,
+		Capabilities:  credential.Capabilities,
+		Actor:         credential.Actor,
+		AllowInsecure: credential.AllowInsecure,
+	}
+}
+
+type memoryFederationCredentialStore struct {
+	mu      sync.RWMutex
+	entries map[string]FederationCredential
+}
+
+func newMemoryFederationCredentialStore() *memoryFederationCredentialStore {
+	return &memoryFederationCredentialStore{entries: make(map[string]FederationCredential)}
+}
+
+func (s *memoryFederationCredentialStore) FederationCredential(
+	_ context.Context, projectUID string,
+) (FederationCredential, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	credential, ok := s.entries[projectUID]
+	return credential, ok, nil
+}
+
+func (s *memoryFederationCredentialStore) StoreFederationCredential(
+	_ context.Context, projectUID string, credential FederationCredential,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[projectUID] = credential
+	return nil
+}
+
+func (s *memoryFederationCredentialStore) DeleteFederationCredential(
+	_ context.Context, projectUID string,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, projectUID)
+	return nil
+}

--- a/service_federation_test.go
+++ b/service_federation_test.go
@@ -1,0 +1,100 @@
+package kata
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+)
+
+func TestServiceRunWakesFederationOnCommittedEvent(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	ctx := context.Background()
+	hubService, err := New(ctx, Config{
+		DSN:  filepath.Join(t.TempDir(), "hub.db"),
+		Auth: AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, hubService.Close()) })
+	hubServer := httptest.NewServer(hubService.Handler())
+	t.Cleanup(hubServer.Close)
+
+	hubProject, err := hubService.store.CreateProject(ctx, "hub-project")
+	require.NoError(t, err)
+	hubBinding, err := hubService.store.EnableProjectFederation(ctx, hubProject.ID, "example-user")
+	require.NoError(t, err)
+
+	spokeService, err := New(ctx, Config{
+		DSN:  filepath.Join(t.TempDir(), "spoke.db"),
+		Auth: AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, spokeService.Close()) })
+	spokeProject, err := spokeService.store.CreateProjectWithUID(ctx, "spoke-project", hubProject.UID)
+	require.NoError(t, err)
+	enrollment, err := hubService.store.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{
+		SpokeInstanceUID: spokeService.store.InstanceUID(),
+		ProjectID:        &hubProject.ID,
+		Capabilities:     "pull,push",
+		Actor:            "example-user",
+	})
+	require.NoError(t, err)
+
+	offlineHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(offlineHub.Close)
+	_, err = spokeService.store.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            spokeProject.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               offlineHub.URL,
+		HubProjectID:         hubProject.ID,
+		HubProjectUID:        hubProject.UID,
+		ReplayHorizonEventID: hubBinding.ReplayHorizonEventID,
+		PushEnabled:          true,
+		Actor:                "example-user",
+		AllowInsecure:        true,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, config.WriteFederationCredential(spokeProject.UID, config.FederationCredential{
+		HubURL: offlineHub.URL, HubProjectID: hubProject.ID,
+		Token: enrollment.Token, AllowInsecure: true,
+	}))
+
+	runCtx, cancelRun := context.WithCancel(ctx)
+	runDone := make(chan error, 1)
+	go func() { runDone <- spokeService.Run(runCtx) }()
+	t.Cleanup(func() {
+		cancelRun()
+		require.NoError(t, <-runDone)
+	})
+	require.Eventually(t, func() bool {
+		status, statusErr := spokeService.store.FederationSyncStatusByProject(ctx, spokeProject.ID)
+		return statusErr == nil && status.LastError != nil
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, config.WriteFederationCredential(spokeProject.UID, config.FederationCredential{
+		HubURL: hubServer.URL, HubProjectID: hubProject.ID,
+		Token: enrollment.Token, AllowInsecure: true,
+	}))
+	issue, event, err := spokeService.store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: spokeProject.ID, Title: "wake federation", Author: "example-user",
+	})
+	require.NoError(t, err)
+	spokeService.broadcaster.Broadcast(daemon.StreamMsg{
+		Kind: "event", Event: &event, ProjectID: spokeProject.ID,
+	})
+
+	require.Eventually(t, func() bool {
+		_, issueErr := hubService.store.IssueByUID(ctx, issue.UID, db.IncludeDeletedNo)
+		return issueErr == nil
+	}, 2*time.Second, 10*time.Millisecond, "federation push should be event-driven, not wait for the 30-second poll")
+}

--- a/service_federation_test.go
+++ b/service_federation_test.go
@@ -1,15 +1,20 @@
 package kata
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/api"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
 )
@@ -31,9 +36,11 @@ func TestServiceRunWakesFederationOnCommittedEvent(t *testing.T) {
 	hubBinding, err := hubService.store.EnableProjectFederation(ctx, hubProject.ID, "example-user")
 	require.NoError(t, err)
 
+	credentials := newServiceFederationCredentialStore()
 	spokeService, err := New(ctx, Config{
-		DSN:  filepath.Join(t.TempDir(), "spoke.db"),
-		Auth: AuthConfig{TrustCallerAuthentication: true},
+		DSN:                   filepath.Join(t.TempDir(), "spoke.db"),
+		Auth:                  AuthConfig{TrustCallerAuthentication: true},
+		FederationCredentials: credentials,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, spokeService.Close()) })
@@ -64,7 +71,7 @@ func TestServiceRunWakesFederationOnCommittedEvent(t *testing.T) {
 		Enabled:              true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, config.WriteFederationCredential(spokeProject.UID, config.FederationCredential{
+	require.NoError(t, credentials.StoreFederationCredential(ctx, spokeProject.UID, FederationCredential{
 		HubURL: offlineHub.URL, HubProjectID: hubProject.ID,
 		Token: enrollment.Token, AllowInsecure: true,
 	}))
@@ -81,7 +88,7 @@ func TestServiceRunWakesFederationOnCommittedEvent(t *testing.T) {
 		return statusErr == nil && status.LastError != nil
 	}, 2*time.Second, 10*time.Millisecond)
 
-	require.NoError(t, config.WriteFederationCredential(spokeProject.UID, config.FederationCredential{
+	require.NoError(t, credentials.StoreFederationCredential(ctx, spokeProject.UID, FederationCredential{
 		HubURL: hubServer.URL, HubProjectID: hubProject.ID,
 		Token: enrollment.Token, AllowInsecure: true,
 	}))
@@ -97,4 +104,109 @@ func TestServiceRunWakesFederationOnCommittedEvent(t *testing.T) {
 		_, issueErr := hubService.store.IssueByUID(ctx, issue.UID, db.IncludeDeletedNo)
 		return issueErr == nil
 	}, 2*time.Second, 10*time.Millisecond, "federation push should be event-driven, not wait for the 30-second poll")
+}
+
+func TestServicesIsolateFederationCredentialsForSharedProjectUID(t *testing.T) {
+	ctx := context.Background()
+	projectUID := "01HZNQ7VFPK1XGD8R5MABCD4EX"
+	capabilities := []string{"pull", "pull,push"}
+	services := make([]*Service, len(capabilities))
+	projectIDs := make([]int64, len(capabilities))
+	for i := range capabilities {
+		service, err := New(ctx, Config{
+			DSN:  filepath.Join(t.TempDir(), "service.db"),
+			Auth: AuthConfig{TrustCallerAuthentication: true},
+		})
+		require.NoError(t, err)
+		services[i] = service
+		t.Cleanup(func() { require.NoError(t, service.Close()) })
+		requestBody, err := json.Marshal(map[string]any{
+			"hub_url":                 "https://hub.example",
+			"hub_project_id":          42,
+			"hub_project_uid":         projectUID,
+			"project_name":            "shared-project",
+			"replay_horizon_event_id": 1,
+			"actor":                   "example-user",
+			"token":                   "token-" + capabilities[i],
+			"capabilities":            capabilities[i],
+		})
+		require.NoError(t, err)
+		request := httptest.NewRequest(http.MethodPost, "/api/v1/federation/replicas", bytes.NewReader(requestBody))
+		request.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+		service.Handler().ServeHTTP(response, request)
+		require.Equal(t, http.StatusOK, response.Code)
+		var created api.CreateFederationReplicaBody
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &created))
+		projectIDs[i] = created.Project.ID
+	}
+
+	for i := range services {
+		statuses := serviceFederationStatuses(t, services[i])
+		require.Len(t, statuses, 1)
+		assert.Equal(t, capabilities[i], statuses[0].Capabilities)
+	}
+
+	leaveBody, err := json.Marshal(map[string]any{"actor": "example-user"})
+	require.NoError(t, err)
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/federation/replicas/"+fmt.Sprint(projectIDs[0])+"/actions/leave",
+		bytes.NewReader(leaveBody),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	services[0].Handler().ServeHTTP(response, request)
+	require.Equal(t, http.StatusOK, response.Code)
+	assert.Empty(t, serviceFederationStatuses(t, services[0]))
+	secondStatuses := serviceFederationStatuses(t, services[1])
+	require.Len(t, secondStatuses, 1)
+	assert.Equal(t, capabilities[1], secondStatuses[0].Capabilities)
+}
+
+func serviceFederationStatuses(t *testing.T, service *Service) []api.FederationProjectStatus {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/federation/status", nil)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	require.Equal(t, http.StatusOK, response.Code)
+	var body api.FederationStatusBody
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+	return body.Statuses
+}
+
+type serviceFederationCredentialStore struct {
+	mu      sync.Mutex
+	entries map[string]FederationCredential
+}
+
+func newServiceFederationCredentialStore() *serviceFederationCredentialStore {
+	return &serviceFederationCredentialStore{entries: make(map[string]FederationCredential)}
+}
+
+func (s *serviceFederationCredentialStore) FederationCredential(
+	_ context.Context, projectUID string,
+) (FederationCredential, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	credential, ok := s.entries[projectUID]
+	return credential, ok, nil
+}
+
+func (s *serviceFederationCredentialStore) StoreFederationCredential(
+	_ context.Context, projectUID string, credential FederationCredential,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[projectUID] = credential
+	return nil
+}
+
+func (s *serviceFederationCredentialStore) DeleteFederationCredential(
+	_ context.Context, projectUID string,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, projectUID)
+	return nil
 }

--- a/service_github_sync_test.go
+++ b/service_github_sync_test.go
@@ -1,0 +1,86 @@
+package kata
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/githubsync"
+)
+
+func TestServiceRunProcessesEnabledGitHubSyncBinding(t *testing.T) {
+	fetcher := &serviceGitHubFetcher{
+		repositoryCalls: make(chan githubsync.Binding, 1),
+	}
+	service, err := newService(context.Background(), Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: AuthConfig{TrustCallerAuthentication: true},
+	}, serviceDeps{gitHubSyncFetcher: fetcher})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	project, err := service.store.CreateProject(context.Background(), "example-project")
+	require.NoError(t, err)
+	titlePrefix := true
+	bindingConfig, err := githubsync.EncodeConfig(githubsync.Config{
+		Host: "github.com", Owner: "example-owner", Repo: "example-repo",
+		RepoID: 12345, TitlePrefix: &titlePrefix,
+	})
+	require.NoError(t, err)
+	_, err = service.store.UpsertIssueSyncBinding(context.Background(), db.UpsertIssueSyncBindingParams{
+		ProjectID: project.ID, Provider: "github", SourceKey: "github:R_exampleNode",
+		RemoteID: "R_exampleNode", DisplayName: "example-owner/example-repo",
+		Config: bindingConfig, IntervalSeconds: 300,
+	})
+	require.NoError(t, err)
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- service.Run(runCtx) }()
+
+	select {
+	case call := <-fetcher.repositoryCalls:
+		assert.Equal(t, githubsync.Binding{
+			Host: "github.com", Owner: "example-owner", Repo: "example-repo",
+		}, call)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "GitHub sync worker did not process the enabled binding")
+	}
+	require.Eventually(t, func() bool {
+		status, statusErr := service.store.IssueSyncStatusByProject(context.Background(), project.ID)
+		return statusErr == nil && status.LastSuccessAt != nil
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancelRun()
+	select {
+	case runErr := <-runDone:
+		require.NoError(t, runErr)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Run did not stop after cancellation")
+	}
+}
+
+type serviceGitHubFetcher struct {
+	repositoryCalls chan githubsync.Binding
+}
+
+func (f *serviceGitHubFetcher) Repository(_ context.Context, host, owner, repo string) (githubsync.Repository, error) {
+	f.repositoryCalls <- githubsync.Binding{Host: host, Owner: owner, Repo: repo}
+	return githubsync.Repository{NodeID: "R_exampleNode", ID: 12345, FullName: "example-owner/example-repo"}, nil
+}
+
+func (*serviceGitHubFetcher) Issues(context.Context, githubsync.Binding, *time.Time) ([]githubsync.Issue, error) {
+	return nil, nil
+}
+
+func (*serviceGitHubFetcher) Comments(context.Context, githubsync.Binding, int) ([]githubsync.Comment, error) {
+	return nil, nil
+}
+
+func (*serviceGitHubFetcher) ParentData(context.Context, githubsync.Binding) (githubsync.ParentData, error) {
+	return githubsync.ParentData{Unsupported: true}, nil
+}

--- a/service_github_sync_test.go
+++ b/service_github_sync_test.go
@@ -1,16 +1,97 @@
 package kata
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	internalconfig "go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/githubsync"
 )
+
+func TestServiceGitHubSyncConfigDrivesHandlersAndRunner(t *testing.T) {
+	t.Setenv("KATA_GITHUB_SYNC_ALLOWED_HOSTS", "github.example")
+	fetcher := &serviceGitHubFetcher{
+		repositoryCalls: make(chan githubsync.Binding, 2),
+	}
+	var resolved internalconfig.GitHubSyncConfig
+	service, err := newService(context.Background(), Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: AuthConfig{TrustCallerAuthentication: true},
+		GitHubSync: GitHubSyncConfig{ //nolint:gosec // TokenEnv is an environment variable name, not a credential.
+			TokenEnv:  " EXAMPLE_GITHUB_TOKEN ",
+			TokenHost: " GitHub.Example ",
+			Apps: []GitHubAppConfig{{
+				Host: " GitHub.Example ", Owner: " example-owner ",
+				AppID: 123, InstallationID: 456, PrivateKeyPath: " /keys/example.pem ",
+			}},
+		},
+	}, serviceDeps{
+		gitHubSyncFetcherFactory: func(cfg internalconfig.GitHubSyncConfig) githubsync.Fetcher {
+			resolved = cfg
+			return fetcher
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	assert.Equal(t, internalconfig.GitHubSyncConfig{ //nolint:gosec // TokenEnv is an environment variable name, not a credential.
+		TokenEnv: "EXAMPLE_GITHUB_TOKEN", TokenHost: "github.example",
+		Apps: []internalconfig.GitHubAppConfig{{
+			Host: "github.example", Owner: "example-owner", AppID: 123,
+			InstallationID: 456, PrivateKeyPath: "/keys/example.pem",
+		}},
+	}, resolved)
+
+	project, err := service.store.CreateProject(context.Background(), "example-project")
+	require.NoError(t, err)
+	server := httptest.NewServer(service.Handler())
+	t.Cleanup(server.Close)
+	body, err := json.Marshal(map[string]any{
+		"config": map[string]any{
+			"host": "github.example", "owner": "example-owner", "repo": "example-repo",
+		},
+	})
+	require.NoError(t, err)
+	response, err := http.Post(
+		server.URL+"/api/v1/projects/"+fmt.Sprint(project.ID)+"/issue-sync/github/enable",
+		"application/json", bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	select {
+	case call := <-fetcher.repositoryCalls:
+		assert.Equal(t, githubsync.Binding{
+			Host: "github.example", Owner: "example-owner", Repo: "example-repo",
+		}, call)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "configured GitHub fetcher was not used by the HTTP handler")
+	}
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- service.Run(runCtx) }()
+	select {
+	case call := <-fetcher.repositoryCalls:
+		assert.Equal(t, githubsync.Binding{
+			Host: "github.example", Owner: "example-owner", Repo: "example-repo",
+		}, call)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "configured GitHub fetcher was not used by the background runner")
+	}
+	cancelRun()
+	require.NoError(t, <-runDone)
+}
 
 func TestServiceRunProcessesEnabledGitHubSyncBinding(t *testing.T) {
 	fetcher := &serviceGitHubFetcher{

--- a/service_lifecycle_test.go
+++ b/service_lifecycle_test.go
@@ -1,0 +1,97 @@
+package kata
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+)
+
+func TestServiceCloseTerminatesActiveEventStream(t *testing.T) {
+	service, err := New(context.Background(), Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(service.Handler())
+	t.Cleanup(server.Close)
+
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/events/stream?after_id=0", nil)
+	require.NoError(t, err)
+	request.Header.Set("Accept", "text/event-stream")
+	response, err := server.Client().Do(request)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	project, err := service.store.CreateProject(context.Background(), "example-project")
+	require.NoError(t, err)
+	_, event, err := service.store.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "observe shutdown",
+		Author:    "example-user",
+	})
+	require.NoError(t, err)
+	service.broadcaster.Broadcast(daemon.StreamMsg{
+		Kind: "event", Event: &event, ProjectID: project.ID,
+	})
+
+	reader := bufio.NewReader(response.Body)
+	eventSeen := make(chan error, 1)
+	go func() {
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				eventSeen <- readErr
+				return
+			}
+			if strings.TrimSpace(line) == "event: issue.created" {
+				eventSeen <- nil
+				return
+			}
+		}
+	}()
+	select {
+	case eventErr := <-eventSeen:
+		require.NoError(t, eventErr)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "event stream did not enter its live phase")
+	}
+
+	streamDone := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(io.Discard, reader)
+		streamDone <- copyErr
+	}()
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- service.Close() }()
+
+	select {
+	case closeErr := <-closeDone:
+		require.NoError(t, closeErr)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Close did not wait for the active event stream")
+	}
+	select {
+	case streamErr := <-streamDone:
+		require.NoError(t, streamErr)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "active event stream outlived Close")
+	}
+
+	postClose, err := server.Client().Get(server.URL + "/api/v1/health")
+	require.NoError(t, err)
+	defer func() { _ = postClose.Body.Close() }()
+	assert.Equal(t, http.StatusServiceUnavailable, postClose.StatusCode)
+}

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,105 @@
+package kata_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata"
+)
+
+func TestServiceMountRunAndClose(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "service.db")
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: dsn,
+	})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(service.Handler())
+	project := createProject(t, server.URL, "example-project")
+	assert.Equal(t, "example-project", project.Project.Name)
+	assert.True(t, project.Created)
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- service.Run(runCtx) }()
+	select {
+	case err := <-runDone:
+		require.Failf(t, "Run returned before cancellation", "error: %v", err)
+	default:
+	}
+	cancelRun()
+	select {
+	case err := <-runDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "Run did not stop after cancellation")
+	}
+
+	server.Close()
+	require.NoError(t, service.Close())
+	require.NoError(t, service.Close())
+
+	reopened, err := kata.New(context.Background(), kata.Config{
+		DSN: dsn,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+
+	reopenedServer := httptest.NewServer(reopened.Handler())
+	t.Cleanup(reopenedServer.Close)
+	projects := listProjects(t, reopenedServer.URL)
+	require.Len(t, projects.Projects, 1)
+	assert.Equal(t, "example-project", projects.Projects[0].Name)
+}
+
+func TestNewRejectsMissingDSN(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{})
+
+	assert.Nil(t, service)
+	assert.EqualError(t, err, "kata: storage DSN is required")
+}
+
+type projectResponse struct {
+	Project struct {
+		Name string `json:"name"`
+	} `json:"project"`
+	Created bool `json:"created"`
+}
+
+func createProject(t *testing.T, baseURL, name string) projectResponse {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"name": name})
+	require.NoError(t, err)
+	resp, err := http.Post(baseURL+"/api/v1/projects", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out projectResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	return out
+}
+
+type projectsResponse struct {
+	Projects []struct {
+		Name string `json:"name"`
+	} `json:"projects"`
+}
+
+func listProjects(t *testing.T, baseURL string) projectsResponse {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/api/v1/projects")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var out projectsResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	return out
+}

--- a/service_test.go
+++ b/service_test.go
@@ -18,7 +18,8 @@ import (
 func TestServiceMountRunAndClose(t *testing.T) {
 	dsn := filepath.Join(t.TempDir(), "service.db")
 	service, err := kata.New(context.Background(), kata.Config{
-		DSN: dsn,
+		DSN:  dsn,
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
 	})
 	require.NoError(t, err)
 
@@ -48,7 +49,8 @@ func TestServiceMountRunAndClose(t *testing.T) {
 	require.NoError(t, service.Close())
 
 	reopened, err := kata.New(context.Background(), kata.Config{
-		DSN: dsn,
+		DSN:  dsn,
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
@@ -65,6 +67,55 @@ func TestNewRejectsMissingDSN(t *testing.T) {
 
 	assert.Nil(t, service)
 	assert.EqualError(t, err, "kata: storage DSN is required")
+}
+
+func TestNewRejectsMissingAuthenticationPolicy(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"),
+	})
+
+	assert.Nil(t, service)
+	assert.EqualError(t, err, "kata: auth token is required unless caller authentication is explicitly trusted")
+}
+
+func TestNewRejectsAmbiguousAuthenticationPolicy(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{
+			Token:                     "service-token",
+			TrustCallerAuthentication: true,
+		},
+	})
+
+	assert.Nil(t, service)
+	assert.EqualError(t, err, "kata: auth token and trusted caller authentication are mutually exclusive")
+}
+
+func TestServiceBearerAuthentication(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{Token: "service-token"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	server := httptest.NewServer(service.Handler())
+	t.Cleanup(server.Close)
+
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+
+	authorized, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	authorized.Header.Set("Authorization", "Bearer service-token")
+	authorizedResponse, err := http.DefaultClient.Do(authorized)
+	require.NoError(t, err)
+	defer func() { _ = authorizedResponse.Body.Close() }()
+	assert.Equal(t, http.StatusOK, authorizedResponse.StatusCode)
 }
 
 type projectResponse struct {

--- a/service_test.go
+++ b/service_test.go
@@ -80,7 +80,7 @@ func createProject(t *testing.T, baseURL, name string) projectResponse {
 	require.NoError(t, err)
 	resp, err := http.Post(baseURL+"/api/v1/projects", "application/json", bytes.NewReader(body))
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	var out projectResponse
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
@@ -97,7 +97,7 @@ func listProjects(t *testing.T, baseURL string) projectsResponse {
 	t.Helper()
 	resp, err := http.Get(baseURL + "/api/v1/projects")
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	var out projectsResponse
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))


### PR DESCRIPTION
Kata currently exposes its application server only through internal packages and the standalone daemon. Go applications that want Kata in-process therefore have no supported lifecycle boundary and must either depend on internals or supervise a separate process.

This establishes the module root as the public service API. A caller provides a SQLite or PostgreSQL DSN, mounts the returned HTTP handler in its own server, runs Kata federation, GitHub issue-sync, and timed-claim workers under its own context, and closes the resources owned by the service. Kata does not open a listener, install signals, or take over the caller process lifecycle.

Authentication is fail-closed because a caller-owned listener has no inherent local-trust boundary. Construction requires either a Kata bearer token or an explicit declaration that the caller wraps the handler with its own trusted authentication. The unauthenticated choice is intentionally visible rather than inherited from standalone daemon defaults.

The root import (`go.kenn.io/kata`) is intentional: `pkg/kata` would stutter and add ceremony, while `pkg/client` remains the distinct generated HTTP client. PostgreSQL bootstrap-versus-validation policy stays explicit so applications can separate schema preparation from runtime serving.

A temporary external Go module protects the actual consumer-facing import and lifecycle contract. The standalone daemon remains unchanged in this slice; it can adopt the same service boundary after the public contract settles.