### PR TITLE
Finalize 0.11.0 release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ of humans and agents needs to share, you can opt into a remote daemon or
 federation; a shared daemon can use Postgres by setting `KATA_DSN`.
 Production Postgres deployments can use separate schema-owner and runtime roles;
 see the [operator ceremony](docs/operations/postgres.md).
+Go applications can instead mount kata's listener-free HTTP service in-process;
+see [Embedding kata in Go](docs/development/embedding.md).
 
 The documentation in [`docs/`](docs/) is the definitive guide, published with
 Zensical at <https://katatracker.com/>.
@@ -141,7 +143,10 @@ The [docs site](docs/) is the definitive reference:
   [Remote daemon](docs/operations/remote-daemon.md) ·
   [Federation](docs/operations/federation.md) ·
   [Hosted mode](docs/operations/hosted-mode.md) ·
+  [PostgreSQL](docs/operations/postgres.md) ·
   [Backup and restore](docs/operations/backup-restore.md)
+- Development: [Embedding kata in Go](docs/development/embedding.md) ·
+  [Contributing](docs/development/contributing.md)
 
 ## For coding agents
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,43 +8,52 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 ## Unreleased
 
+## 0.11.0
+<small>2026-07-18</small>
+
+kata 0.11.0 completes PostgreSQL support across kata's storage and sharing
+workflows and exposes the application as a listener-free Go service. It also
+strengthens machine-readable identity and semantic-search input validation.
+
 **New features**
 
-- Added production Postgres storage selected with `KATA_DSN`, `[storage].dsn`,
-  or a `postgres://` / `postgresql://` URL. Postgres now implements the complete
-  storage contract, including federation, claims, external import, JSONL
-  replay, lexical search, daemon startup, export, and atomic snapshot restore.
-- Added `kata storage postgres migrate` and `status`, plus validation-only
-  runtime configuration, so production deployments can separate schema-owner
-  and serving credentials.
-- Added PostgreSQL semantic search with pgvector `halfvec` storage and the same
-  generation/fill contract as SQLite, covered end to end against a real
-  pgvector service.
+- Added complete PostgreSQL support for the storage contract, daemon operation,
+  federation, claims, external and JSONL import, export and atomic snapshot
+  restore, lexical search, and pgvector-backed semantic search. Configure it
+  with `KATA_DSN`, `[storage].dsn`, or a `postgres://` / `postgresql://` URL.
+- Added `kata storage postgres migrate` and `status`, validation-only runtime
+  configuration, server-identity-verified TLS requirements, and separate
+  schema-owner and serving roles for production PostgreSQL deployments.
+- Exposed the module root at `go.kenn.io/kata` as a mountable Go service.
+  Applications construct a service with `kata.New`, mount its HTTP `Handler`,
+  run federation, GitHub sync, and timed-claim workers with `Run`, and release
+  owned storage and workers with `Close`; kata does not take over the listener,
+  signals, or host process lifecycle.
 
 **Improvements**
 
-- Runs the same behavioral storage conformance fixtures against SQLite and
-  Postgres, with no expected Postgres failures or generated method stubs.
-- Added Postgres JSONL restore targets. Fresh restores install the dedicated
-  `kata` schema; `--force` atomically replaces existing kata-owned state, and
-  failed first restores remove only an unchanged fresh schema.
-- Established the first released Postgres schema as the migration floor rather
-  than retaining migrations for development-only versions that never shipped.
-- Added an append-only numbered migration convention and pre-commit history
-  guard for PostgreSQL schema changes after that release floor.
-- Required server-identity-verified TLS for every remote Postgres connection
-  candidate, with a separately configured lab-only insecure opt-in.
-- Added a dedicated PostgreSQL CI service job that cannot silently skip backend
-  conformance and operator-ceremony tests when Docker discovery is unavailable.
-- Made generic CI lanes skip automatic PostgreSQL testcontainers immediately
-  while preserving local autostart and fail-hard coverage in the explicit
-  service job.
-- Added a real-daemon federation matrix proving bidirectional synchronization,
-  durable restart recovery, and lease-authorized edits across every SQLite and
-  PostgreSQL hub/spoke pairing.
-- Isolated daemon namespaces by PostgreSQL schema, fenced restore against
-  daemons on every host, and made failed fresh-import cleanup survive request
-  cancellation.
+- Added the stable canonical identity `"name": "kata"` to `kata version
+  --json`, alongside the existing version and build fields, so automation can
+  identify the binary without parsing human-readable output or contacting a
+  daemon.
+- Rejected embedding responses with null components or zero-norm vectors before
+  they can be persisted or used for a query. Background fills remain pending
+  and retry after an invalid provider response instead of marking unusable
+  vectors complete.
+
+**Bug fixes**
+
+- Honored `KATA_HTTP_TIMEOUT` for probes of explicitly configured remote
+  servers, while keeping the separate one-second local runtime-discovery probe.
+  Slow healthy WAN and reverse-proxied daemons now get the same request budget
+  as the command that follows the probe.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for complete PostgreSQL
+  support, the mountable Go service, and configured-remote timeout handling.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for stable
+  JSON version identity and invalid embedding-vector rejection.
 
 ## 0.10.0
 <small>2026-07-11</small>

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -42,13 +42,15 @@ no agentic worker pool and no daemon-driven code execution beyond the user's own
 configured hooks. Adopting a proven runtime shape kept the build simple; refusing
 roborev's execution surface kept kata a tracker rather than a workflow engine.
 
-## The daemon is the single access path
+## The HTTP service is the single access path
 
-All reads and writes go through the daemon's HTTP API. The CLI and TUI are
-clients of the same API; neither opens SQLite directly. One access path means
-every client sees identical resolution, validation, and event ordering, and it
-keeps the door open to remote and shared deployments where the database is not
-on the caller's machine (see [trust boundaries](#trust-boundaries) below).
+All reads and writes go through kata's HTTP API. The standalone daemon owns that
+service for CLI and TUI clients; a Go application can instead construct and
+[mount the service](../development/embedding.md) in its own process. No client
+opens SQLite or PostgreSQL directly. One access path means every client sees
+identical resolution, validation, and event ordering, and it supports remote,
+shared, and embedded deployments where the database is not on the caller's
+machine (see [trust boundaries](#trust-boundaries) below).
 
 A read-only direct-SQLite fast path was considered and deferred. It would create
 an immediate split between local behavior and any networked deployment, so kata
@@ -56,14 +58,20 @@ does not pay that complexity until a measured hot path justifies it.
 
 ### Transport and discovery
 
-The daemon listens on a Unix socket by default on Unix platforms (parent
-directory `0700`, socket `0600`) and loopback TCP by default on Windows; TCP
-binds are validated as loopback unless an operator opts into a
-remote listener. Runtime state is namespaced per database: a `<dbhash>` derived
-from the absolute database path keeps two databases from colliding on sockets,
+The standalone daemon listens on a Unix socket by default on Unix platforms
+(parent directory `0700`, socket `0600`) and loopback TCP by default on Windows;
+TCP binds are validated as loopback unless an operator opts into a remote
+listener. Runtime state is namespaced per database: a `<dbhash>` derived from
+the absolute database path keeps two databases from colliding on sockets,
 runtime files, or logs. Clients discover a running daemon by computing the
 `<dbhash>`, scanning its runtime files, probing `/api/v1/ping`, and auto-starting
 a daemon only if none is live.
+
+The embedded service is listener-free. Its host application owns the network
+listener, TLS, signal handling, and process shutdown, and must choose either a
+kata bearer token or an explicit trusted caller-authentication boundary. The
+service owns its configured storage handle and its federation, GitHub sync, and
+timed-claim background workers.
 
 ## Project binding over current directory
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -53,39 +53,53 @@ func main() {
 		log.Fatal(err)
 	}
 
-	runDone := make(chan error, 1)
-	go func() { runDone <- service.Run(ctx) }()
-
 	server := &http.Server{
-		Addr:              ":8080",
+		Addr:              "127.0.0.1:8080",
 		Handler:           service.Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-	go func() {
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		_ = server.Shutdown(shutdownCtx)
-	}()
+	runDone := make(chan error, 1)
+	serveDone := make(chan error, 1)
+	go func() { runDone <- service.Run(ctx) }()
+	go func() { serveDone <- server.ListenAndServe() }()
 
-	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		log.Print(err)
-		stop()
+	var runErr, serveErr error
+	var runFinished, serveFinished bool
+	select {
+	case runErr = <-runDone:
+		runFinished = true
+	case serveErr = <-serveDone:
+		serveFinished = true
+	case <-ctx.Done():
 	}
-	if err := <-runDone; err != nil {
-		log.Print(err)
+	stop()
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownErr := server.Shutdown(shutdownCtx)
+	cancelShutdown()
+	if !runFinished {
+		runErr = <-runDone
 	}
-	if err := service.Close(); err != nil {
-		log.Print(err)
+	if !serveFinished {
+		serveErr = <-serveDone
+	}
+	if errors.Is(serveErr, http.ErrServerClosed) {
+		serveErr = nil
+	}
+	if err := errors.Join(runErr, serveErr, shutdownErr, service.Close()); err != nil {
+		log.Fatal(err)
 	}
 }
 ```
 
 `Run` does not open a listener. It blocks while federation, scheduled GitHub
 sync, and timed-claim workers are active, then returns when its context is
-canceled or `Close` begins. Only one `Run` call may be active for a service.
-`Close` cancels active work and requests, waits for them to stop, and closes the
-owned storage handle. It is safe to call more than once.
+canceled or `Close` begins, and it may return an error from any background
+worker. Treat any `Run` return as service termination: stop accepting HTTP
+traffic, cancel the shared context, and inspect the error after both the workers
+and server stop. Only one `Run` call may be active for a service. `Close` cancels
+active work and requests, waits for them to stop, and closes the owned storage
+handle. It is safe to call more than once.
 
 ## Authentication is explicit
 
@@ -100,6 +114,11 @@ owned storage handle. It is safe to call more than once.
 Construction fails when neither policy is selected or when both are set. The
 explicit choice prevents an embedded service from accidentally inheriting the
 standalone daemon's local-user trust boundary.
+
+The lifecycle example deliberately binds to loopback. To accept remote clients,
+use `server.ListenAndServeTLS(certFile, keyFile)` with a valid certificate or
+mount the handler behind a TLS-terminating reverse proxy. Never send the bearer
+token over plaintext non-loopback HTTP.
 
 ## Storage and PostgreSQL policy
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -1,0 +1,140 @@
+---
+title: Embedding kata in Go
+description: Mount kata's HTTP service inside a Go application.
+---
+
+# Embedding kata in Go
+
+The module root, `go.kenn.io/kata`, exposes kata as a listener-free application
+service. Use it when a Go application should own the HTTP server and process
+lifecycle instead of supervising a separate `kata daemon` process. The mounted
+handler serves the same [HTTP API](../reference/http-api.md) used by the CLI and
+TUI.
+
+The host application remains responsible for the listener, TLS, signal
+handling, and HTTP server shutdown. A `kata.Service` owns its storage handle and
+the federation, GitHub sync, and timed-claim background workers associated with
+that handle.
+
+## Minimal lifecycle
+
+Construct the service, start its workers with `Run`, and use its `Handler` in a
+caller-owned server:
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"go.kenn.io/kata"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(
+		context.Background(), syscall.SIGINT, syscall.SIGTERM,
+	)
+	defer stop()
+
+	service, err := kata.New(ctx, kata.Config{
+		DSN: "/var/lib/example-app/kata.db",
+		Auth: kata.AuthConfig{
+			Token: os.Getenv("EXAMPLE_KATA_TOKEN"),
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- service.Run(ctx) }()
+
+	server := &http.Server{
+		Addr:              ":8080",
+		Handler:           service.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Print(err)
+		stop()
+	}
+	if err := <-runDone; err != nil {
+		log.Print(err)
+	}
+	if err := service.Close(); err != nil {
+		log.Print(err)
+	}
+}
+```
+
+`Run` does not open a listener. It blocks while federation, scheduled GitHub
+sync, and timed-claim workers are active, then returns when its context is
+canceled or `Close` begins. Only one `Run` call may be active for a service.
+`Close` cancels active work and requests, waits for them to stop, and closes the
+owned storage handle. It is safe to call more than once.
+
+## Authentication is explicit
+
+`kata.New` requires exactly one authentication policy:
+
+- Set `Auth.Token` to make kata enforce a bearer token on its protected HTTP
+  routes. The host remains responsible for transport security.
+- Set `Auth.TrustCallerAuthentication` to `true` only when trusted middleware
+  already authenticates every request before it reaches `service.Handler()`.
+  Never expose that handler directly on an untrusted listener.
+
+Construction fails when neither policy is selected or when both are set. The
+explicit choice prevents an embedded service from accidentally inheriting the
+standalone daemon's local-user trust boundary.
+
+## Storage and PostgreSQL policy
+
+`Config.DSN` is required and accepts a bare SQLite path, a `sqlite://` URL, or a
+`postgres://` / `postgresql://` URL. A PostgreSQL-backed service can make schema
+handling explicit:
+
+```go
+service, err := kata.New(ctx, kata.Config{
+	DSN: os.Getenv("EXAMPLE_KATA_DSN"),
+	Postgres: kata.PostgresConfig{
+		Schema:      "kata",
+		SchemaMode:  kata.PostgresSchemaValidate,
+		SchemaOwner: "kata_schema_owner",
+	},
+	Auth: kata.AuthConfig{Token: os.Getenv("EXAMPLE_KATA_TOKEN")},
+})
+```
+
+`PostgresSchemaBootstrap` installs missing migrations before serving.
+`PostgresSchemaValidate` performs no schema installation and requires an
+already compatible schema, which lets production applications separate schema
+preparation from runtime serving. The standalone
+[PostgreSQL operator ceremony](../operations/postgres.md) describes the same
+role, migration, TLS, and rollback requirements.
+
+## Service-scoped credentials
+
+GitHub sync credentials are supplied through `Config.GitHubSync`. Federation
+credentials are isolated per service through `Config.FederationCredentials`.
+When that field is nil, kata uses a service-owned in-memory credential store;
+credentials then disappear when the process exits. Applications that need
+federation enrollment to survive restarts should implement
+`kata.FederationCredentialStore` with durable, concurrency-safe storage.
+
+The embedded service does not read a listener address, install signal handlers,
+or take over the host application's logger. Pass a `*slog.Logger` in
+`Config.Logger` when kata should use an application-specific logger.

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,6 +122,11 @@ bearer auth on trusted private HTTP or opt a single-user private IP into
 tokenless writes. See [Concepts](guide/concepts.md) and
 [Architecture](design/architecture.md) for the full model.
 
+Go applications can also run kata in-process through the listener-free
+`go.kenn.io/kata` service. The host application mounts the same HTTP API and
+owns the listener, authentication boundary, and process lifecycle; see
+[Embedding kata in Go](development/embedding.md).
+
 ## When to use kata
 
 Reach for kata when work should stay close to the machine doing it:

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -54,6 +54,7 @@ nav = [
   ]},
   {"Development" = [
     {"Contributing" = "development/contributing.md"},
+    {"Embedding kata in Go" = "development/embedding.md"},
     {"PostgreSQL migrations" = "development/postgres-migrations.md"},
     {"Deploying docs" = "development/deploying-docs.md"},
   ]},


### PR DESCRIPTION
v0.11.0 is published, but the changelog still classified the PostgreSQL work as unreleased and the public guide did not explain the new in-process Go service boundary. That left the release history incomplete and made the security and lifecycle responsibilities of embedded deployments difficult for integrators to discover.

This PR finalizes the tagged release notes from verified source and pull-request authorship, credits the contributors behind the shipped user-facing changes, and adds a focused embedding guide. The guide uses a loopback listener for plaintext bearer authentication, requires TLS for remote exposure, and supervises the HTTP server together with background workers so either side terminating shuts down the service. Architecture and documentation entry points now cover both standalone-daemon and mounted-service deployments.

After merge, the production documentation still requires the normal manual deployment flow.