### PR TITLE
Make pgvector optional for PostgreSQL storage

### DIFF
--- a/docs/design/semantic-search.md
+++ b/docs/design/semantic-search.md
@@ -5,7 +5,7 @@ rationale; for current operator-facing behavior see the
 [semantic search guide](../guide/semantic-search.md) and
 [Configuration](../reference/configuration.md#semantic-search). The
 "Storage" section reflects the backend-native indexes: a kit-based SQLite
-sidecar and canonical pgvector tables for PostgreSQL.
+sidecar and optional pgvector tables for PostgreSQL.
 
 kata's search is lexical: SQLite FTS5 with BM25 ranking and PostgreSQL tsvector
 ranking over title, body, and comments. Lexical search misses
@@ -22,8 +22,8 @@ Goals:
 - `kata search` finds paraphrased and conceptually-related issues, not just
   token matches, when an embedding endpoint is configured.
 - No embedding endpoint or network calls for deployments that do not opt in,
-  and no behavior change to ranking or scores. PostgreSQL installations carry
-  pgvector as part of their canonical schema even when semantic search is off.
+  and no behavior change to ranking or scores. PostgreSQL core storage does
+  not require pgvector when semantic search is off.
 - Index freshness is owned by the daemon, never by user discipline. Stale or
   missing embeddings degrade recall gracefully; they never break search.
 - Both storage backends reach the same observable contract, by different
@@ -294,10 +294,10 @@ issue UIDs; kata never writes chunk rows directly — `kitvec.Fill` chunks
 content (`vector.Split`, 2000 runes with 200-rune overlap) and writes chunks,
 stamps, and vec0 rows together.
 
-PostgreSQL keeps the corresponding mirror, generation, stamp, and chunk rows
-in its selected Kata schema. The canonical schema owns those tables and the
-schema-owner ceremony installs pgvector 0.7 or later in `public`; the daemon's
-runtime role needs DML only. Chunk embeddings use unbounded `public.halfvec`
+When pgvector 0.7 or later is available in `public`, PostgreSQL keeps the
+corresponding mirror, generation, stamp, and chunk rows in its selected Kata
+schema. The schema-owner ceremony creates these optional derived tables; the
+daemon's runtime role needs DML only. Chunk embeddings use unbounded `public.halfvec`
 so model dimensions can change without runtime DDL. Both forms are derived
 state and portable JSONL restore deliberately rebuilds them from issue content.
 
@@ -498,7 +498,7 @@ The CLI has three output surfaces, each handled to a precise shape:
 | Definitive 4xx in reconciler | Max backoff immediately + health error; no hot loop |
 | Rows not yet embedded (reconciler backlog) | Invisible to vector leg (not yet stamped in the active generation), carried by FTS leg; not degradation |
 | Model swap in progress (active generation fingerprint ≠ configured embedder) | Vector leg unavailable until cutover: `auto` → lexical + `degraded:true`; explicit `hybrid`/`semantic` → 503 |
-| PostgreSQL missing pgvector or canonical vector tables | Schema preparation/startup fails closed |
+| PostgreSQL missing pgvector or optional vector tables | Core storage starts normally; configuring semantic search reports the feature unavailable |
 | Missing or version-mismatched vector storage at query time | Treated as vector-leg failure (degraded / 503) |
 | Mirror/fill lag (edited issue before next reconcile) | Ranking-only effect; visibility always resolved against live `issues` |
 

--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -170,7 +170,8 @@ API key is only ever sent to the configured `base_url` origin.
 Embeddings are local derived state and **do not federate**: each daemon embeds
 only what it stores, and no vectors are sent to or pulled from federated hubs.
 SQLite keeps them in a sidecar database; PostgreSQL keeps them in pgvector
-tables in its selected Kata schema. They are not included in JSONL
+tables in its selected Kata schema when that optional extension is installed.
+They are not included in JSONL
 [backup/export](../operations/backup-restore.md) — a restore or a storage-format
 upgrade re-embeds from scratch rather than carrying vectors forward. Archives
 exported by older kata versions that still contain
@@ -181,9 +182,10 @@ reconciler rebuilds the vectors.
 
 - Only issue **title and body** are embedded today; comments are searchable
   lexically but a paraphrase that lives only in a comment will not vector-match.
-- PostgreSQL semantic search requires pgvector 0.7 or later. Its first
-  implementation uses bounded exact cosine scans; SQLite uses sqlite-vec KNN.
-  See [PostgreSQL operations](../operations/postgres.md) for setup.
+- PostgreSQL semantic search requires pgvector 0.7 or later, but core task and
+  lexical-search storage does not. Its first implementation uses bounded exact
+  cosine scans; SQLite uses sqlite-vec KNN. See
+  [PostgreSQL operations](../operations/postgres.md) for setup.
 
 For the design rationale and internals, see the
 [semantic search design note](../design/semantic-search.md).

--- a/docs/operations/postgres.md
+++ b/docs/operations/postgres.md
@@ -14,8 +14,9 @@ production posture.
 - PostgreSQL 17 or later;
 - one database reserved for the service, or a database in which the dedicated
   kata schema can be isolated;
-- the `unaccent` extension and pgvector 0.7 or later installed in the `public`
-  schema;
+- the `unaccent` extension installed in the `public` schema;
+- optionally, pgvector 0.7 or later in `public` when PostgreSQL semantic
+  search is wanted;
 - server-identity-verified TLS for every remote database endpoint;
 - one schema-owner credential for `kata storage postgres migrate` and offline
   `kata import` restore;
@@ -38,18 +39,21 @@ GRANT CREATE ON DATABASE kata TO kata_schema_owner;
 ```
 
 The schema owner needs `CREATE` on the database because the first preparation
-creates the dedicated schema and installs `unaccent` and pgvector. Managed
-PostgreSQL services may require an administrator to install the extensions
-first:
+creates the dedicated schema and installs `unaccent`. When pgvector is
+available, preparation installs it and adds the derived semantic-search
+tables. Managed PostgreSQL services may require an administrator to install
+extensions first:
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
+-- Optional: omit this when semantic search is not needed.
 CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
 ```
 
-If either extension already exists in another schema, move it to `public` as
-its owner before preparing Kata. The serving role does not need database-level
-`CREATE`.
+If either installed extension lives in another schema, move it to `public` as
+its owner before preparing Kata. A server without pgvector still supports all
+core task, federation, and lexical-search behavior. The serving role does not
+need database-level `CREATE`.
 
 Use the same schema-owner role for later upgrades. PostgreSQL default
 privileges are attached to the object-creating role, so silently changing the
@@ -162,8 +166,10 @@ burst of distinct idempotency keys from reserving every query connection while
 their mutations wait for the same pool. Multiply this budget by the maximum
 number of daemon replicas that can reach one database.
 
-When `[search.embeddings]` is configured, vectors are stored in canonical
-pgvector `halfvec` tables in the selected Kata schema. The runtime still needs
+When pgvector is installed and `[search.embeddings]` is configured, vectors
+are stored in `halfvec` tables in the selected Kata schema. Configuring
+embeddings without pgvector fails with a feature-unavailable error; it does not
+make core storage or lexical search unavailable. The runtime still needs
 only the table and sequence grants above. The first implementation performs a
 bounded exact cosine scan rather than creating model-dimension-specific ANN
 indexes, so model changes require no runtime DDL. pgvector's `halfvec` supports

--- a/docs/operations/postgres.md
+++ b/docs/operations/postgres.md
@@ -39,10 +39,9 @@ GRANT CREATE ON DATABASE kata TO kata_schema_owner;
 ```
 
 The schema owner needs `CREATE` on the database because the first preparation
-creates the dedicated schema and installs `unaccent`. When pgvector is
-available, preparation installs it and adds the derived semantic-search
-tables. Managed PostgreSQL services may require an administrator to install
-extensions first:
+creates the dedicated schema and installs `unaccent`. Kata never installs
+pgvector automatically. When semantic search is wanted, a database
+administrator must install pgvector before preparing Kata:
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
@@ -51,9 +50,10 @@ CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
 ```
 
 If either installed extension lives in another schema, move it to `public` as
-its owner before preparing Kata. A server without pgvector still supports all
-core task, federation, and lexical-search behavior. The serving role does not
-need database-level `CREATE`.
+its owner before preparing Kata. A server that offers pgvector but has not
+installed it behaves exactly like a server without pgvector: all core task,
+federation, and lexical-search behavior remains available. The serving role
+does not need database-level `CREATE`.
 
 Use the same schema-owner role for later upgrades. PostgreSQL default
 privileges are attached to the object-creating role, so silently changing the

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -318,9 +318,11 @@ everything past a fixed length cutoff.
 
 With SQLite, embeddings live in a sidecar database the daemon creates next to
 the main database (`kata.vectors.db` for the default `kata.db`). With
-PostgreSQL, they live in pgvector `halfvec` tables in the selected Kata schema;
-see [PostgreSQL operations](../operations/postgres.md) for extension and role
-requirements. Both forms are derived state and are rebuilt by re-embedding;
+PostgreSQL, they live in `halfvec` tables in the selected Kata schema when the
+optional pgvector extension is installed. See
+[PostgreSQL operations](../operations/postgres.md) for extension and role
+requirements. Core PostgreSQL storage works without pgvector. Both forms are
+derived state and are rebuilt by re-embedding;
 portable JSONL exports do not include vectors.
 
 Upgrading to a kata version that changes embedding storage re-embeds every

--- a/internal/daemon/reconciler_postgres_test.go
+++ b/internal/daemon/reconciler_postgres_test.go
@@ -40,7 +40,7 @@ func TestPostgresReconcilerReacquiresLeaseAfterSessionLoss(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	dsn, cleanup := testenv.NewPostgresWithPgvectorContainer(t, ctx)
 	t.Cleanup(cleanup)
 	store, err := pgstore.Open(ctx, dsn)
 	require.NoError(t, err)

--- a/internal/db/pgstore/migrations.go
+++ b/internal/db/pgstore/migrations.go
@@ -8,6 +8,9 @@ import (
 //go:embed schema.sql
 var canonicalSchemaSQL string
 
+//go:embed vector_schema.sql
+var vectorSchemaSQL string
+
 // Migration is one immutable Postgres schema transition. Assets form an exact
 // version chain; callers applying them externally must stamp ToVersion only
 // after SQL succeeds in the same transaction.

--- a/internal/db/pgstore/open.go
+++ b/internal/db/pgstore/open.go
@@ -402,6 +402,15 @@ func prepareOptionalVectorSchema(ctx context.Context, tx *sql.Tx, schema string)
 	if !extensionSchema.Valid {
 		return nil
 	}
+	var halfvecAvailable bool
+	if err := tx.QueryRowContext(ctx,
+		`SELECT pg_catalog.to_regtype('public.halfvec') IS NOT NULL`,
+	).Scan(&halfvecAvailable); err != nil {
+		return fmt.Errorf("inspect pgvector halfvec support: %w", err)
+	}
+	if !halfvecAvailable {
+		return nil
+	}
 
 	var relationCount int
 	if err := tx.QueryRowContext(ctx, `

--- a/internal/db/pgstore/open.go
+++ b/internal/db/pgstore/open.go
@@ -400,19 +400,7 @@ func prepareOptionalVectorSchema(ctx context.Context, tx *sql.Tx, schema string)
 		)
 	}
 	if !extensionSchema.Valid {
-		var available bool
-		if err := tx.QueryRowContext(ctx, `
-			SELECT EXISTS (
-				SELECT 1 FROM pg_catalog.pg_available_extensions WHERE name = 'vector'
-			)`).Scan(&available); err != nil {
-			return fmt.Errorf("inspect pgvector availability: %w", err)
-		}
-		if !available {
-			return nil
-		}
-		if _, err := tx.ExecContext(ctx, `CREATE EXTENSION vector WITH SCHEMA public`); err != nil {
-			return fmt.Errorf("install optional pgvector extension: %w", err)
-		}
+		return nil
 	}
 
 	var relationCount int

--- a/internal/db/pgstore/open.go
+++ b/internal/db/pgstore/open.go
@@ -375,10 +375,65 @@ func (s *Store) bootstrap(ctx context.Context) (bool, error) {
 			}
 		}
 	}
+	if err := prepareOptionalVectorSchema(ctx, tx, s.schema); err != nil {
+		return false, err
+	}
 	if err := tx.Commit(); err != nil {
 		return false, fmt.Errorf("commit schema bootstrap: %w", err)
 	}
 	return !schemaExists, nil
+}
+
+func prepareOptionalVectorSchema(ctx context.Context, tx *sql.Tx, schema string) error {
+	var extensionSchema sql.NullString
+	if err := tx.QueryRowContext(ctx, `
+		SELECT n.nspname
+		  FROM pg_catalog.pg_extension e
+		  JOIN pg_catalog.pg_namespace n ON n.oid = e.extnamespace
+		 WHERE e.extname = 'vector'`).Scan(&extensionSchema); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("inspect pgvector extension: %w", err)
+	}
+	if extensionSchema.Valid && extensionSchema.String != "public" {
+		return fmt.Errorf(
+			"postgres extension %q is installed in schema %q; move it to %q before installing kata",
+			"vector", extensionSchema.String, "public",
+		)
+	}
+	if !extensionSchema.Valid {
+		var available bool
+		if err := tx.QueryRowContext(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_catalog.pg_available_extensions WHERE name = 'vector'
+			)`).Scan(&available); err != nil {
+			return fmt.Errorf("inspect pgvector availability: %w", err)
+		}
+		if !available {
+			return nil
+		}
+		if _, err := tx.ExecContext(ctx, `CREATE EXTENSION vector WITH SCHEMA public`); err != nil {
+			return fmt.Errorf("install optional pgvector extension: %w", err)
+		}
+	}
+
+	var relationCount int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT count(*)
+		  FROM pg_catalog.pg_class c
+		  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+		 WHERE n.nspname = $1 AND c.relkind IN ('r', 'p')
+		   AND c.relname = ANY($2)`, schema, mapKeys(optionalVectorTableNames)).Scan(&relationCount); err != nil {
+		return fmt.Errorf("inspect optional vector schema: %w", err)
+	}
+	if relationCount == len(optionalVectorTableNames) {
+		return nil
+	}
+	if relationCount != 0 {
+		return fmt.Errorf("postgres schema %q has a partial optional vector schema", schema)
+	}
+	if _, err := tx.ExecContext(ctx, vectorSchemaSQL); err != nil {
+		return fmt.Errorf("install optional vector schema: %w", err)
+	}
+	return nil
 }
 
 func recordSchemaVersion(ctx context.Context, tx *sql.Tx, version int, source string) error {
@@ -425,10 +480,20 @@ var canonicalTableNames = map[string]struct{}{
 	"api_tokens": {}, "comments": {}, "events": {}, "federation_bindings": {},
 	"federation_enrollments": {}, "federation_quarantine": {}, "federation_sync_status": {},
 	"import_mappings": {}, "issue_claims": {}, "issue_labels": {}, "issue_sync_bindings": {},
-	"issue_sync_status": {}, "issue_vector_chunks": {}, "issue_vector_generations": {},
-	"issue_vector_mirror": {}, "issue_vector_stamps": {}, "issues": {}, "issues_search": {},
+	"issue_sync_status": {}, "issues": {}, "issues_search": {},
 	"links": {}, "meta": {}, "pending_claim_requests": {}, "project_aliases": {},
 	"project_purge_log": {}, "projects": {}, "purge_log": {}, "recurrences": {},
+}
+
+var optionalVectorTableNames = map[string]struct{}{
+	"issue_vector_chunks": {}, "issue_vector_generations": {},
+	"issue_vector_mirror": {}, "issue_vector_stamps": {},
+}
+
+func knownTableName(name string) bool {
+	_, core := canonicalTableNames[name]
+	_, vector := optionalVectorTableNames[name]
+	return core || vector
 }
 
 func (s *Store) validateSchemaOwnership(ctx context.Context) error {

--- a/internal/db/pgstore/optional_pgvector_test.go
+++ b/internal/db/pgstore/optional_pgvector_test.go
@@ -1,0 +1,39 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/pgstore"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+func TestPostgresBootstrapDoesNotRequirePgvector(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires postgres testcontainer")
+	}
+	ctx := context.Background()
+	dsn, cleanup := testenv.NewPlainPostgresContainer(t, ctx)
+	t.Cleanup(cleanup)
+
+	store, err := pgstore.Open(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	project, err := store.CreateProject(ctx, "example-project")
+	require.NoError(t, err)
+	created, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "plain postgres remains usable",
+		Author:    "operator",
+	})
+	require.NoError(t, err)
+
+	issues, err := store.SearchFTS(ctx, project.ID, "plain postgres", 10, false)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, created.UID, issues[0].Issue.UID)
+}

--- a/internal/db/pgstore/optional_pgvector_test.go
+++ b/internal/db/pgstore/optional_pgvector_test.go
@@ -2,14 +2,84 @@ package pgstore_test
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"os"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/pgstore"
 	"go.kenn.io/kata/internal/testenv"
 )
+
+func TestPostgresBootstrapDoesNotInstallAvailablePgvector(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires postgres testcontainer")
+	}
+	ctx := context.Background()
+	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	t.Cleanup(cleanup)
+
+	admin, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.Close() })
+	var databaseName string
+	require.NoError(t, admin.QueryRowContext(ctx, `SELECT current_database()`).Scan(&databaseName))
+	var vectorAvailable, vectorInstalled bool
+	require.NoError(t, admin.QueryRowContext(ctx, `
+		SELECT EXISTS (
+		         SELECT 1 FROM pg_catalog.pg_available_extensions WHERE name='vector'
+		       ),
+		       EXISTS (
+		         SELECT 1 FROM pg_catalog.pg_extension WHERE extname='vector'
+		       )`).Scan(&vectorAvailable, &vectorInstalled))
+	require.True(t, vectorAvailable, "test requires a server that offers pgvector")
+	require.False(t, vectorInstalled, "test requires pgvector to start uninstalled")
+
+	roleName := fmt.Sprintf("optional_vector_owner_%d", os.Getpid())
+	role := pgx.Identifier{roleName}.Sanitize()
+	database := pgx.Identifier{databaseName}.Sanitize()
+	_, err = admin.ExecContext(ctx, fmt.Sprintf(`
+		CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
+		CREATE ROLE %s LOGIN PASSWORD 'runtime-password';
+		GRANT CREATE ON DATABASE %s TO %s;
+	`, role, database, role)) // #nosec G201 -- identifiers are sanitized above.
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = admin.ExecContext(context.Background(), "DROP OWNED BY "+role)
+		_, _ = admin.ExecContext(context.Background(), "DROP ROLE IF EXISTS "+role)
+	})
+
+	store, err := pgstore.OpenWithConfig(
+		ctx,
+		postgresDSNWithUser(t, dsn, roleName, "runtime-password"),
+		pgstore.Config{Schema: "optional_vector_store", SchemaMode: pgstore.SchemaModeBootstrap},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	project, err := store.CreateProject(ctx, "example-project")
+	require.NoError(t, err)
+	created, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "core postgres remains usable",
+		Author:    "operator",
+	})
+	require.NoError(t, err)
+	issues, err := store.SearchFTS(ctx, project.ID, "core postgres", 10, false)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, created.UID, issues[0].Issue.UID)
+
+	require.NoError(t, admin.QueryRowContext(ctx, `
+		SELECT EXISTS (
+		  SELECT 1 FROM pg_catalog.pg_extension WHERE extname='vector'
+		)`).Scan(&vectorInstalled))
+	assert.False(t, vectorInstalled, "bootstrap must not install optional database extensions")
+}
 
 func TestPostgresBootstrapDoesNotRequirePgvector(t *testing.T) {
 	if testing.Short() {

--- a/internal/db/pgstore/optional_pgvector_test.go
+++ b/internal/db/pgstore/optional_pgvector_test.go
@@ -107,3 +107,48 @@ func TestPostgresBootstrapDoesNotRequirePgvector(t *testing.T) {
 	require.Len(t, issues, 1)
 	assert.Equal(t, created.UID, issues[0].Issue.UID)
 }
+
+func TestPostgresBootstrapDoesNotRequireHalfvec(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires pgvector testcontainer")
+	}
+	ctx := context.Background()
+	dsn, cleanup := testenv.NewPostgresWithPgvectorContainer(t, ctx)
+	t.Cleanup(cleanup)
+
+	admin, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.Close() })
+	_, err = admin.ExecContext(ctx, `
+		ALTER EXTENSION vector DROP TYPE public.halfvec;
+		DROP TYPE public.halfvec CASCADE;
+	`)
+	require.NoError(t, err)
+
+	store, err := pgstore.Open(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	project, err := store.CreateProject(ctx, "older-vector-project")
+	require.NoError(t, err)
+	created, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "core storage without halfvec",
+		Author:    "operator",
+	})
+	require.NoError(t, err)
+	issues, err := store.SearchFTS(ctx, project.ID, "without halfvec", 10, false)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, created.UID, issues[0].Issue.UID)
+
+	var vectorTables int
+	require.NoError(t, admin.QueryRowContext(ctx, `
+		SELECT count(*)
+		  FROM pg_catalog.pg_class relation
+		  JOIN pg_catalog.pg_namespace namespace ON namespace.oid=relation.relnamespace
+		 WHERE namespace.nspname='kata'
+		   AND relation.relname IN ('vector_generations', 'issue_vector_mirror', 'vector_chunks')
+	`).Scan(&vectorTables))
+	assert.Zero(t, vectorTables, "bootstrap must leave semantic storage unavailable without halfvec")
+}

--- a/internal/db/pgstore/runtime_privileges.go
+++ b/internal/db/pgstore/runtime_privileges.go
@@ -13,7 +13,9 @@ projects_id_seq project_aliases_id_seq recurrences_id_seq issues_id_seq
 comments_id_seq links_id_seq events_id_seq api_tokens_id_seq purge_log_id_seq
 project_purge_log_id_seq issue_sync_bindings_id_seq federation_quarantine_id_seq
 federation_enrollments_id_seq issue_claims_id_seq pending_claim_requests_id_seq
-import_mappings_id_seq issue_vector_generations_ordinal_seq`)
+import_mappings_id_seq`)
+
+const optionalVectorSequenceName = "issue_vector_generations_ordinal_seq"
 
 func (s *Store) validateRuntimePrivileges(ctx context.Context) error {
 	var allowed bool
@@ -56,7 +58,7 @@ func (s *Store) validateRuntimeTablePrivileges(ctx context.Context) error {
 		if err := rows.Scan(&table, &selectAllowed, &insertAllowed, &updateAllowed, &deleteAllowed); err != nil {
 			return fmt.Errorf("scan postgres schema %q runtime table privileges: %w", s.schema, err)
 		}
-		if _, canonical := canonicalTableNames[table]; !canonical {
+		if !knownTableName(table) {
 			continue
 		}
 		for _, check := range []struct {
@@ -135,6 +137,9 @@ func (s *Store) validateRuntimeSequencePrivileges(ctx context.Context) error {
 }
 
 func isCanonicalSequence(name string) bool {
+	if name == optionalVectorSequenceName {
+		return true
+	}
 	for _, canonical := range canonicalSequenceNames {
 		if name == canonical {
 			return true

--- a/internal/db/pgstore/schema.sql
+++ b/internal/db/pgstore/schema.sql
@@ -19,26 +19,19 @@
 -- before issues because issues references recurrences.
 
 CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
-CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
 DO $$
 DECLARE
-  extension_name TEXT;
   extension_schema TEXT;
 BEGIN
-  FOREACH extension_name IN ARRAY ARRAY['unaccent', 'vector'] LOOP
-    SELECT n.nspname
-      INTO extension_schema
-      FROM pg_extension e
-      JOIN pg_namespace n ON n.oid = e.extnamespace
-     WHERE e.extname = extension_name;
-    IF extension_schema <> 'public' THEN
-      RAISE EXCEPTION
-        'postgres extension "%" is installed in schema "%"; move it to "public" before installing kata',
-        extension_name, extension_schema;
-    END IF;
-  END LOOP;
-  IF to_regtype('public.halfvec') IS NULL THEN
-    RAISE EXCEPTION 'pgvector 0.7 or later with public.halfvec is required';
+  SELECT n.nspname
+    INTO extension_schema
+    FROM pg_extension e
+    JOIN pg_namespace n ON n.oid = e.extnamespace
+   WHERE e.extname = 'unaccent';
+  IF extension_schema <> 'public' THEN
+    RAISE EXCEPTION
+      'postgres extension "unaccent" is installed in schema "%"; move it to "public" before installing kata',
+      extension_schema;
   END IF;
 END
 $$;
@@ -732,41 +725,3 @@ CREATE TABLE import_mappings (
 CREATE INDEX idx_import_mappings_issue ON import_mappings(issue_id);
 CREATE INDEX idx_import_mappings_comment ON import_mappings(comment_id);
 CREATE INDEX idx_import_mappings_link ON import_mappings(link_id);
-
--- ----------------------------------------------------------------------
--- Semantic-search derived state. Unbounded halfvec permits model dimension
--- changes without runtime DDL; exact cosine scans are the first-release
--- posture. These rows are rebuildable from issues and intentionally omitted
--- from portable exports.
--- ----------------------------------------------------------------------
-CREATE TABLE issue_vector_mirror (
-  issue_uid        TEXT PRIMARY KEY,
-  project_uid      TEXT NOT NULL,
-  content          TEXT NOT NULL,
-  content_revision BIGINT NOT NULL,
-  embed_gen        TEXT
-);
-
-CREATE TABLE issue_vector_generations (
-  ordinal    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-  gen_key    TEXT NOT NULL UNIQUE,
-  model      TEXT NOT NULL,
-  dimensions INTEGER NOT NULL CHECK(dimensions > 0),
-  state      TEXT NOT NULL CHECK(state IN ('building','active','retired'))
-);
-
-CREATE TABLE issue_vector_stamps (
-  gen_key  TEXT NOT NULL REFERENCES issue_vector_generations(gen_key) ON DELETE CASCADE,
-  issue_uid TEXT NOT NULL REFERENCES issue_vector_mirror(issue_uid) ON DELETE CASCADE,
-  revision BIGINT NOT NULL,
-  PRIMARY KEY(gen_key, issue_uid)
-);
-
-CREATE TABLE issue_vector_chunks (
-  gen_key    TEXT NOT NULL REFERENCES issue_vector_generations(gen_key) ON DELETE CASCADE,
-  issue_uid  TEXT NOT NULL REFERENCES issue_vector_mirror(issue_uid) ON DELETE CASCADE,
-  chunk_index INTEGER NOT NULL,
-  embedding  public.halfvec NOT NULL,
-  PRIMARY KEY(gen_key, issue_uid, chunk_index)
-);
-CREATE INDEX idx_issue_vector_chunks_generation ON issue_vector_chunks(gen_key);

--- a/internal/db/pgstore/schema_manifest.go
+++ b/internal/db/pgstore/schema_manifest.go
@@ -10,41 +10,47 @@ import (
 )
 
 const (
-	canonicalColumnFingerprint     = "789e6ae6066ad24cfdc8f918275b90a26725c7fd6d1e942a0f76dc89ec15d1b9"
-	canonicalConstraintFingerprint = "3867e088c3ab4395d517d0788ffa658f589164b6b6bd68541fde3d648cd29363"
-	canonicalIndexFingerprint      = "3a9b60f05ac5c8064a0e61d867fed7ae3c9e0fa7b345bd3236e3300273801dac"
+	canonicalColumnFingerprint     = "a4f8495a566414a64a548b74a392f01f61afa9ff672484bde860fbba8f6e252b"
+	canonicalConstraintFingerprint = "53c7c7e43564e661f8b4c7fdda2a38c4588c0dbfc0371794ce5c800270dcf3ab"
+	canonicalIndexFingerprint      = "24c22eafa4d407a9567a592de7b437525d4f42a6efaf995581f551451f487ab8"
+	vectorColumnFingerprint        = "b8c7cb5e43f3c17502fc3e1deba77a772c3e9a486be623a96729de8866381c31"
+	vectorConstraintFingerprint    = "3a39a82331175295586fb3399dff2221fe511171f21e31a88410dd091c3a3cf4"
+	vectorIndexFingerprint         = "7868c4a815ebee6451cef203509dcedcd21401c76f49fb666e9facaad2f7aef3"
 	canonicalTriggerFingerprint    = "34f80f8e2b61c6cb1705bb8effb1548164e91f181fb58b68cf929ac90a190154"
 	canonicalFunctionFingerprint   = "f96c6a857ec7bc7c3e5c1cebdd3d7b795547f4399f8f65ea0aa9befa98681741"
 	canonicalTextSearchFingerprint = "1206eb613d5e4cf9c00c447998c337ece326819f8b3261668f7a8c685571db06"
 )
 
 var canonicalTableColumns = map[string]string{ //nolint:gosec // Catalog column names, not credential values.
-	"api_tokens":               "id,token_hash,actor,name,created_at,last_used_at,revoked_at",
-	"comments":                 "id,uid,issue_id,author,body,created_at",
-	"events":                   "id,uid,origin_instance_uid,project_id,project_name,issue_id,issue_uid,related_issue_id,related_issue_uid,type,actor,payload,hlc_physical_ms,hlc_counter,content_hash,created_at",
-	"federation_bindings":      "project_id,role,hub_url,hub_project_id,hub_project_uid,replay_horizon_event_id,pull_cursor_event_id,push_enabled,push_cursor_event_id,bound_actor,allow_insecure,enabled,created_at,updated_at,last_sync_at",
-	"federation_enrollments":   "id,token_hash,spoke_instance_uid,project_id,capabilities,bound_actor,allow_adoption_snapshot_authors,adoption_baseline_open,adoption_baseline_next_source_event_id,adoption_baseline_end_source_event_id,created_at,updated_at,revoked_at",
-	"federation_quarantine":    "id,project_id,direction,first_event_id,last_event_id,event_uids,error,created_at,skipped_at,skipped_by,skip_reason",
-	"federation_sync_status":   "project_id,last_pull_started_at,last_pull_success_at,last_push_started_at,last_push_success_at,last_error_at,last_error,last_reset_at",
-	"import_mappings":          "id,source,external_id,object_type,project_id,issue_id,comment_id,link_id,label,source_updated_at,imported_at",
-	"issue_claims":             "id,claim_uid,project_id,issue_id,issue_uid,holder,holder_instance_uid,client_kind,purpose,claim_kind,acquired_at,expires_at,released_at,release_reason,revision,updated_at",
-	"issue_labels":             "issue_id,label,author,created_at",
-	"issue_sync_bindings":      "id,project_id,provider,source_key,remote_id,display_name,config_json,enabled,interval_seconds,last_cursor_at,created_at,updated_at",
-	"issue_sync_status":        "binding_id,project_id,sync_started_at,last_attempt_at,last_success_at,last_error_at,last_error,last_created,last_updated,last_unchanged,last_comments",
+	"api_tokens":             "id,token_hash,actor,name,created_at,last_used_at,revoked_at",
+	"comments":               "id,uid,issue_id,author,body,created_at",
+	"events":                 "id,uid,origin_instance_uid,project_id,project_name,issue_id,issue_uid,related_issue_id,related_issue_uid,type,actor,payload,hlc_physical_ms,hlc_counter,content_hash,created_at",
+	"federation_bindings":    "project_id,role,hub_url,hub_project_id,hub_project_uid,replay_horizon_event_id,pull_cursor_event_id,push_enabled,push_cursor_event_id,bound_actor,allow_insecure,enabled,created_at,updated_at,last_sync_at",
+	"federation_enrollments": "id,token_hash,spoke_instance_uid,project_id,capabilities,bound_actor,allow_adoption_snapshot_authors,adoption_baseline_open,adoption_baseline_next_source_event_id,adoption_baseline_end_source_event_id,created_at,updated_at,revoked_at",
+	"federation_quarantine":  "id,project_id,direction,first_event_id,last_event_id,event_uids,error,created_at,skipped_at,skipped_by,skip_reason",
+	"federation_sync_status": "project_id,last_pull_started_at,last_pull_success_at,last_push_started_at,last_push_success_at,last_error_at,last_error,last_reset_at",
+	"import_mappings":        "id,source,external_id,object_type,project_id,issue_id,comment_id,link_id,label,source_updated_at,imported_at",
+	"issue_claims":           "id,claim_uid,project_id,issue_id,issue_uid,holder,holder_instance_uid,client_kind,purpose,claim_kind,acquired_at,expires_at,released_at,release_reason,revision,updated_at",
+	"issue_labels":           "issue_id,label,author,created_at",
+	"issue_sync_bindings":    "id,project_id,provider,source_key,remote_id,display_name,config_json,enabled,interval_seconds,last_cursor_at,created_at,updated_at",
+	"issue_sync_status":      "binding_id,project_id,sync_started_at,last_attempt_at,last_success_at,last_error_at,last_error,last_created,last_updated,last_unchanged,last_comments",
+	"issues":                 "id,uid,project_id,short_id,title,body,status,closed_reason,owner,priority,author,created_at,updated_at,closed_at,deleted_at,metadata,revision,content_revision,recurrence_id,occurrence_key",
+	"issues_search":          "issue_id,tsv",
+	"links":                  "id,from_issue_id,to_issue_id,from_issue_uid,to_issue_uid,type,author,created_at",
+	"meta":                   "key,value",
+	"pending_claim_requests": "id,request_uid,project_id,issue_id,issue_uid,holder,holder_instance_uid,client_kind,claim_kind,ttl_seconds,purpose,requested_at,last_attempt_at,last_error,rejected_at,resolved_at",
+	"project_aliases":        "id,project_id,alias_identity,alias_kind,created_at",
+	"project_purge_log":      "id,uid,origin_instance_uid,project_id,project_uid,project_name,issue_count,event_count,alias_count,comment_count,link_count,label_count,claim_count,pending_claim_request_count,events_deleted_min_id,events_deleted_max_id,purge_reset_after_event_id,actor,reason,purged_at",
+	"projects":               "id,uid,name,created_at,deleted_at,metadata,revision",
+	"purge_log":              "id,uid,origin_instance_uid,project_id,purged_issue_id,issue_uid,project_uid,project_name,issue_title,issue_author,comment_count,link_count,label_count,event_count,events_deleted_min_id,events_deleted_max_id,purge_reset_after_event_id,short_id,actor,reason,purged_at",
+	"recurrences":            "id,uid,project_id,rrule,dtstart,timezone,template_title,template_body,template_owner,template_priority,template_labels,template_metadata,next_occurrence_key,last_materialized_uid,author,revision,created_at,updated_at,deleted_at",
+}
+
+var optionalVectorTableColumns = map[string]string{ //nolint:gosec // Catalog column names, not credential values.
 	"issue_vector_chunks":      "gen_key,issue_uid,chunk_index,embedding",
 	"issue_vector_generations": "ordinal,gen_key,model,dimensions,state",
 	"issue_vector_mirror":      "issue_uid,project_uid,content,content_revision,embed_gen",
 	"issue_vector_stamps":      "gen_key,issue_uid,revision",
-	"issues":                   "id,uid,project_id,short_id,title,body,status,closed_reason,owner,priority,author,created_at,updated_at,closed_at,deleted_at,metadata,revision,content_revision,recurrence_id,occurrence_key",
-	"issues_search":            "issue_id,tsv",
-	"links":                    "id,from_issue_id,to_issue_id,from_issue_uid,to_issue_uid,type,author,created_at",
-	"meta":                     "key,value",
-	"pending_claim_requests":   "id,request_uid,project_id,issue_id,issue_uid,holder,holder_instance_uid,client_kind,claim_kind,ttl_seconds,purpose,requested_at,last_attempt_at,last_error,rejected_at,resolved_at",
-	"project_aliases":          "id,project_id,alias_identity,alias_kind,created_at",
-	"project_purge_log":        "id,uid,origin_instance_uid,project_id,project_uid,project_name,issue_count,event_count,alias_count,comment_count,link_count,label_count,claim_count,pending_claim_request_count,events_deleted_min_id,events_deleted_max_id,purge_reset_after_event_id,actor,reason,purged_at",
-	"projects":                 "id,uid,name,created_at,deleted_at,metadata,revision",
-	"purge_log":                "id,uid,origin_instance_uid,project_id,purged_issue_id,issue_uid,project_uid,project_name,issue_title,issue_author,comment_count,link_count,label_count,event_count,events_deleted_min_id,events_deleted_max_id,purge_reset_after_event_id,short_id,actor,reason,purged_at",
-	"recurrences":              "id,uid,project_id,rrule,dtstart,timezone,template_title,template_body,template_owner,template_priority,template_labels,template_metadata,next_occurrence_key,last_materialized_uid,author,revision,created_at,updated_at,deleted_at",
 }
 
 var canonicalIndexes = strings.Fields(`
@@ -62,7 +68,9 @@ idx_issue_sync_bindings_due idx_issue_sync_status_project idx_issue_sync_status_
 uniq_federation_quarantine_active idx_federation_enrollments_scope idx_federation_enrollments_spoke
 uniq_issue_claims_live_issue idx_issue_claims_project_issue idx_issue_claims_timed_expiry
 uniq_pending_claim_active idx_issues_search_tsv idx_import_mappings_issue
-idx_import_mappings_comment idx_import_mappings_link idx_issue_vector_chunks_generation`)
+idx_import_mappings_comment idx_import_mappings_link`)
+
+var optionalVectorIndexes = []string{"idx_issue_vector_chunks_generation"}
 
 var canonicalTriggers = strings.Fields(`
 trg_links_uid_consistency_insert trg_links_uid_consistency_update
@@ -82,10 +90,14 @@ issues_search_trigger_on_comment_update()
 issues_search_trigger_on_comment_delete()`)
 
 func (s *Store) validateSchemaManifest(ctx context.Context) error {
-	if err := s.validateCanonicalColumns(ctx); err != nil {
+	vectorsInstalled, err := s.vectorRelationsInstalled(ctx)
+	if err != nil {
 		return err
 	}
-	if err := s.validateCanonicalConstraints(ctx); err != nil {
+	if err := s.validateCanonicalColumns(ctx, vectorsInstalled); err != nil {
+		return err
+	}
+	if err := s.validateCanonicalConstraints(ctx, vectorsInstalled); err != nil {
 		return err
 	}
 	if err := s.validateCanonicalNamedObjects(ctx, "index", canonicalIndexes, `
@@ -95,7 +107,16 @@ func (s *Store) validateSchemaManifest(ctx context.Context) error {
 		 WHERE n.nspname = $1 AND c.relkind = 'i'`); err != nil {
 		return err
 	}
-	if err := s.validateCanonicalIndexes(ctx); err != nil {
+	if vectorsInstalled {
+		if err := s.validateCanonicalNamedObjects(ctx, "index", optionalVectorIndexes, `
+			SELECT c.relname
+			  FROM pg_catalog.pg_class c
+			  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+			 WHERE n.nspname = $1 AND c.relkind = 'i'`); err != nil {
+			return err
+		}
+	}
+	if err := s.validateCanonicalIndexes(ctx, vectorsInstalled); err != nil {
 		return err
 	}
 	if err := s.validateCanonicalNamedObjects(ctx, "trigger", canonicalTriggers, `
@@ -115,7 +136,32 @@ func (s *Store) validateSchemaManifest(ctx context.Context) error {
 	return s.validateCanonicalTextSearch(ctx)
 }
 
-func (s *Store) validateCanonicalColumns(ctx context.Context) error {
+func (s *Store) vectorRelationsInstalled(ctx context.Context) (bool, error) {
+	var count int
+	if err := s.QueryRowContext(ctx, `
+		SELECT count(*)
+		  FROM pg_catalog.pg_class c
+		  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+		 WHERE n.nspname = $1 AND c.relkind IN ('r', 'p')
+		   AND c.relname = ANY($2)`, s.schema, mapKeys(optionalVectorTableNames)).Scan(&count); err != nil {
+		return false, fmt.Errorf("inspect postgres schema %q optional vector relations: %w", s.schema, err)
+	}
+	if count != 0 && count != len(optionalVectorTableNames) {
+		return false, fmt.Errorf("postgres schema %q has a partial optional vector schema", s.schema)
+	}
+	return count == len(optionalVectorTableNames), nil
+}
+
+func mapKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (s *Store) validateCanonicalColumns(ctx context.Context, vectorsInstalled bool) error {
 	rows, err := s.QueryContext(ctx, `
 		SELECT table_name, column_name, udt_schema || '.' || udt_name, is_nullable
 		  FROM information_schema.columns
@@ -124,26 +170,41 @@ func (s *Store) validateCanonicalColumns(ctx context.Context) error {
 		return fmt.Errorf("inspect postgres schema %q columns: %w", s.schema, err)
 	}
 	defer func() { _ = rows.Close() }()
-	actual := make(map[string]map[string]struct{}, len(canonicalTableColumns))
-	var records []string
+	expectedTables := canonicalTableColumns
+	if vectorsInstalled {
+		expectedTables = make(map[string]string, len(canonicalTableColumns)+len(optionalVectorTableColumns))
+		for table, columns := range canonicalTableColumns {
+			expectedTables[table] = columns
+		}
+		for table, columns := range optionalVectorTableColumns {
+			expectedTables[table] = columns
+		}
+	}
+	actual := make(map[string]map[string]struct{}, len(expectedTables))
+	var coreRecords, vectorRecords []string
 	for rows.Next() {
 		var table, column, dataType, nullable string
 		if err := rows.Scan(&table, &column, &dataType, &nullable); err != nil {
 			return fmt.Errorf("scan postgres schema %q columns: %w", s.schema, err)
 		}
-		if _, canonical := canonicalTableColumns[table]; !canonical {
+		if _, canonical := expectedTables[table]; !canonical {
 			continue
 		}
 		if actual[table] == nil {
 			actual[table] = make(map[string]struct{})
 		}
 		actual[table][column] = struct{}{}
-		records = append(records, strings.Join([]string{"COLUMN", table, column, dataType, nullable}, "\x00"))
+		record := strings.Join([]string{"COLUMN", table, column, dataType, nullable}, "\x00")
+		if _, vector := optionalVectorTableColumns[table]; vector {
+			vectorRecords = append(vectorRecords, record)
+		} else {
+			coreRecords = append(coreRecords, record)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterate postgres schema %q columns: %w", s.schema, err)
 	}
-	for table, columns := range canonicalTableColumns {
+	for table, columns := range expectedTables {
 		expected := strings.Split(columns, ",")
 		if len(actual[table]) != len(expected) {
 			for _, column := range expected {
@@ -159,10 +220,16 @@ func (s *Store) validateCanonicalColumns(ctx context.Context) error {
 			}
 		}
 	}
-	return validateCatalogFingerprint(s.schema, "column", records, canonicalColumnFingerprint)
+	if err := validateCatalogFingerprint(s.schema, "column", coreRecords, canonicalColumnFingerprint); err != nil {
+		return err
+	}
+	if vectorsInstalled {
+		return validateCatalogFingerprint(s.schema, "vector column", vectorRecords, vectorColumnFingerprint)
+	}
+	return nil
 }
 
-func (s *Store) validateCanonicalConstraints(ctx context.Context) error {
+func (s *Store) validateCanonicalConstraints(ctx context.Context, vectorsInstalled bool) error {
 	rows, err := s.QueryContext(ctx, `
 		SELECT c.relname, con.conname, con.contype::text,
 		       pg_catalog.pg_get_constraintdef(con.oid, true)
@@ -174,21 +241,32 @@ func (s *Store) validateCanonicalConstraints(ctx context.Context) error {
 		return fmt.Errorf("inspect postgres schema %q constraints: %w", s.schema, err)
 	}
 	defer func() { _ = rows.Close() }()
-	var records []string
+	var coreRecords, vectorRecords []string
 	for rows.Next() {
 		var table, name, constraintType, definition string
 		if err := rows.Scan(&table, &name, &constraintType, &definition); err != nil {
 			return fmt.Errorf("scan postgres schema %q constraints: %w", s.schema, err)
 		}
-		records = append(records, strings.Join([]string{"CONSTRAINT", table, name, constraintType, definition}, "\x00"))
+		record := strings.Join([]string{"CONSTRAINT", table, name, constraintType, definition}, "\x00")
+		if _, vector := optionalVectorTableColumns[table]; vector {
+			vectorRecords = append(vectorRecords, record)
+		} else {
+			coreRecords = append(coreRecords, record)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterate postgres schema %q constraints: %w", s.schema, err)
 	}
-	return validateCatalogFingerprint(s.schema, "constraint", records, canonicalConstraintFingerprint)
+	if err := validateCatalogFingerprint(s.schema, "constraint", coreRecords, canonicalConstraintFingerprint); err != nil {
+		return err
+	}
+	if vectorsInstalled {
+		return validateCatalogFingerprint(s.schema, "vector constraint", vectorRecords, vectorConstraintFingerprint)
+	}
+	return nil
 }
 
-func (s *Store) validateCanonicalIndexes(ctx context.Context) error {
+func (s *Store) validateCanonicalIndexes(ctx context.Context, vectorsInstalled bool) error {
 	rows, err := s.QueryContext(ctx, `
 		SELECT idx.relname, tbl.relname, i.indisvalid, i.indisready,
 		       pg_catalog.pg_get_indexdef(i.indexrelid)
@@ -201,7 +279,7 @@ func (s *Store) validateCanonicalIndexes(ctx context.Context) error {
 		return fmt.Errorf("inspect postgres schema %q index definitions: %w", s.schema, err)
 	}
 	defer func() { _ = rows.Close() }()
-	var records []string
+	var coreRecords, vectorRecords []string
 	for rows.Next() {
 		var name, table, definition string
 		var valid, ready bool
@@ -209,14 +287,25 @@ func (s *Store) validateCanonicalIndexes(ctx context.Context) error {
 			return fmt.Errorf("scan postgres schema %q index definition: %w", s.schema, err)
 		}
 		definition = strings.ReplaceAll(definition, s.schema+".", "")
-		records = append(records, strings.Join([]string{
+		record := strings.Join([]string{
 			"INDEX", name, table, strconv.FormatBool(valid), strconv.FormatBool(ready), definition,
-		}, "\x00"))
+		}, "\x00")
+		if _, vector := optionalVectorTableColumns[table]; vector {
+			vectorRecords = append(vectorRecords, record)
+		} else {
+			coreRecords = append(coreRecords, record)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterate postgres schema %q index definitions: %w", s.schema, err)
 	}
-	return validateCatalogFingerprint(s.schema, "index", records, canonicalIndexFingerprint)
+	if err := validateCatalogFingerprint(s.schema, "index", coreRecords, canonicalIndexFingerprint); err != nil {
+		return err
+	}
+	if vectorsInstalled {
+		return validateCatalogFingerprint(s.schema, "vector index", vectorRecords, vectorIndexFingerprint)
+	}
+	return nil
 }
 
 func (s *Store) validateCanonicalTriggers(ctx context.Context) error {

--- a/internal/db/pgstore/vector_schema.sql
+++ b/internal/db/pgstore/vector_schema.sql
@@ -1,0 +1,34 @@
+-- Optional semantic-search state. Every row is derived from core issue data
+-- and omitted from portable exports. The schema bootstrap applies this asset
+-- only when pgvector 0.7 or later is available in public.
+CREATE TABLE issue_vector_mirror (
+  issue_uid        TEXT PRIMARY KEY,
+  project_uid      TEXT NOT NULL,
+  content          TEXT NOT NULL,
+  content_revision BIGINT NOT NULL,
+  embed_gen        TEXT
+);
+
+CREATE TABLE issue_vector_generations (
+  ordinal    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  gen_key    TEXT NOT NULL UNIQUE,
+  model      TEXT NOT NULL,
+  dimensions INTEGER NOT NULL CHECK(dimensions > 0),
+  state      TEXT NOT NULL CHECK(state IN ('building','active','retired'))
+);
+
+CREATE TABLE issue_vector_stamps (
+  gen_key  TEXT NOT NULL REFERENCES issue_vector_generations(gen_key) ON DELETE CASCADE,
+  issue_uid TEXT NOT NULL REFERENCES issue_vector_mirror(issue_uid) ON DELETE CASCADE,
+  revision BIGINT NOT NULL,
+  PRIMARY KEY(gen_key, issue_uid)
+);
+
+CREATE TABLE issue_vector_chunks (
+  gen_key    TEXT NOT NULL REFERENCES issue_vector_generations(gen_key) ON DELETE CASCADE,
+  issue_uid  TEXT NOT NULL REFERENCES issue_vector_mirror(issue_uid) ON DELETE CASCADE,
+  chunk_index INTEGER NOT NULL,
+  embedding  public.halfvec NOT NULL,
+  PRIMARY KEY(gen_key, issue_uid, chunk_index)
+);
+CREATE INDEX idx_issue_vector_chunks_generation ON issue_vector_chunks(gen_key);

--- a/internal/testenv/pgenv.go
+++ b/internal/testenv/pgenv.go
@@ -43,6 +43,21 @@ func NewPostgresContainer(t *testing.T, ctx context.Context) (string, func()) {
 	)
 }
 
+// NewPostgresWithPgvectorContainer starts PostgreSQL 17 and installs pgvector
+// explicitly for tests of semantic storage.
+//
+//nolint:revive // t is the canonical first arg for testing helpers
+func NewPostgresWithPgvectorContainer(t *testing.T, ctx context.Context) (string, func()) {
+	dsn, cleanup := newPostgresContainer(
+		ctx, t, "pgvector/pgvector:pg17", os.Getenv("KATA_TEST_POSTGRES_DSN"),
+	)
+	if err := installTestPgvector(ctx, dsn); err != nil {
+		cleanup()
+		t.Fatalf("install PostgreSQL test extension pgvector: %v", err)
+	}
+	return dsn, cleanup
+}
+
 // NewPlainPostgresContainer starts PostgreSQL 17 without third-party
 // extensions. It is used to prove that core storage does not depend on
 // optional database features.
@@ -88,6 +103,18 @@ func newPostgresContainer(
 		_ = container.Terminate(context.Background())
 	}
 	return dsn, cleanup
+}
+
+func installTestPgvector(ctx context.Context, dsn string) error {
+	database, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return fmt.Errorf("open PostgreSQL test database: %w", err)
+	}
+	defer func() { _ = database.Close() }()
+	if _, err := database.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+		return err
+	}
+	return nil
 }
 
 func skipAutomaticPostgresContainer(goos, explicitDSN, autostart string) bool {

--- a/internal/testenv/pgenv.go
+++ b/internal/testenv/pgenv.go
@@ -20,6 +20,7 @@ import (
 var postgresDatabaseCounter atomic.Uint64
 
 const postgresAutoContainerEnv = "KATA_TEST_POSTGRES_AUTO_CONTAINER"
+const plainPostgresDSNEnv = "KATA_TEST_PLAIN_POSTGRES_DSN"
 
 // NewPostgresContainer starts a pgvector-enabled PostgreSQL 17 container, waits for it to
 // become ready, and returns the DSN string plus a cleanup function. Callers
@@ -37,8 +38,27 @@ const postgresAutoContainerEnv = "KATA_TEST_POSTGRES_AUTO_CONTAINER"
 //
 //nolint:revive // t is the canonical first arg for testing helpers
 func NewPostgresContainer(t *testing.T, ctx context.Context) (string, func()) {
+	return newPostgresContainer(
+		ctx, t, "pgvector/pgvector:pg17", os.Getenv("KATA_TEST_POSTGRES_DSN"),
+	)
+}
+
+// NewPlainPostgresContainer starts PostgreSQL 17 without third-party
+// extensions. It is used to prove that core storage does not depend on
+// optional database features.
+//
+//nolint:revive // t is the canonical first arg for testing helpers
+func NewPlainPostgresContainer(t *testing.T, ctx context.Context) (string, func()) {
+	return newPostgresContainer(ctx, t, "postgres:17", os.Getenv(plainPostgresDSNEnv))
+}
+
+func newPostgresContainer(
+	ctx context.Context,
+	t *testing.T,
+	image string,
+	baseDSN string,
+) (string, func()) {
 	t.Helper()
-	baseDSN := os.Getenv("KATA_TEST_POSTGRES_DSN")
 	if baseDSN != "" {
 		return newIsolatedPostgresDatabase(ctx, t, baseDSN)
 	}
@@ -46,7 +66,7 @@ func NewPostgresContainer(t *testing.T, ctx context.Context) (string, func()) {
 		t.Skip("automatic PostgreSQL testcontainers are disabled; use KATA_TEST_POSTGRES_DSN to run PostgreSQL tests")
 	}
 	container, err := postgres.Run(ctx,
-		"pgvector/pgvector:pg17",
+		image,
 		postgres.WithDatabase("kata_test"),
 		postgres.WithUsername("kata"),
 		postgres.WithPassword("kata"),

--- a/internal/vector/lease_postgres_test.go
+++ b/internal/vector/lease_postgres_test.go
@@ -18,7 +18,7 @@ func TestPostgresReconcilerLeaseFencesWorkAfterSessionLoss(t *testing.T) {
 		t.Skip("requires pgvector testcontainer")
 	}
 	ctx := context.Background()
-	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	dsn, cleanup := testenv.NewPostgresWithPgvectorContainer(t, ctx)
 	t.Cleanup(cleanup)
 	store, err := pgstore.Open(ctx, dsn)
 	require.NoError(t, err)

--- a/internal/vector/postgres.go
+++ b/internal/vector/postgres.go
@@ -54,7 +54,7 @@ func (p *postgresIndex) validate(ctx context.Context) error {
 		return fmt.Errorf("vector: validate pgvector: %w", err)
 	}
 	if !halfvecAvailable {
-		return errors.New("vector: pgvector 0.7 or later in the public schema is required")
+		return errors.New("vector: pgvector is not installed; semantic search is unavailable")
 	}
 	var tablesReady bool
 	if err := p.db.QueryRowContext(ctx, `SELECT

--- a/internal/vector/postgres_e2e_test.go
+++ b/internal/vector/postgres_e2e_test.go
@@ -79,6 +79,22 @@ func TestPostgresPgvectorIndexesAndRanksSemanticIssue(t *testing.T) {
 	assert.Greater(t, rolledUp[0].Score, float32(0.99))
 }
 
+func TestPostgresSemanticSearchReportsUnavailableWithoutPgvector(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires postgres testcontainer")
+	}
+	ctx := context.Background()
+	dsn, cleanup := testenv.NewPlainPostgresContainer(t, ctx)
+	t.Cleanup(cleanup)
+	store, err := pgstore.Open(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	idx, err := vector.OpenPostgres(ctx, store.DB)
+	assert.Nil(t, idx)
+	require.ErrorContains(t, err, "pgvector is not installed; semantic search is unavailable")
+}
+
 func TestPostgresPgvectorRejectsDimensionsAboveHalfvecLimit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires pgvector testcontainer")

--- a/internal/vector/postgres_e2e_test.go
+++ b/internal/vector/postgres_e2e_test.go
@@ -26,7 +26,7 @@ func TestPostgresPgvectorIndexesAndRanksSemanticIssue(t *testing.T) {
 		t.Skip("requires pgvector testcontainer")
 	}
 	ctx := context.Background()
-	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	dsn, cleanup := testenv.NewPostgresWithPgvectorContainer(t, ctx)
 	t.Cleanup(cleanup)
 	store, err := pgstore.Open(ctx, dsn)
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestPostgresPgvectorRejectsDimensionsAboveHalfvecLimit(t *testing.T) {
 		t.Skip("requires pgvector testcontainer")
 	}
 	ctx := context.Background()
-	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	dsn, cleanup := testenv.NewPostgresWithPgvectorContainer(t, ctx)
 	t.Cleanup(cleanup)
 	store, err := pgstore.Open(ctx, dsn)
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestPostgresReconcilersElectOneLeaderPerSchema(t *testing.T) {
 		t.Skip("requires pgvector testcontainer")
 	}
 	ctx := context.Background()
-	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	dsn, cleanup := testenv.NewPostgresWithPgvectorContainer(t, ctx)
 	t.Cleanup(cleanup)
 	store, err := pgstore.Open(ctx, dsn)
 	require.NoError(t, err)


### PR DESCRIPTION
PostgreSQL task and federation storage should not depend on an optional semantic-search extension. A database without pgvector—or a managed database that offers pgvector but does not allow the schema owner to install it—must still be able to start Kata.

This change keeps the core PostgreSQL schema usable without pgvector. Kata creates vector tables only when an administrator has already installed pgvector in `public` and that version provides the required `halfvec` type. It never attempts to install pgvector itself. When the extension is absent, uninstalled, or too old, task storage, federation, and lexical search remain available; explicitly configuring semantic search returns a clear feature-unavailable error.

The operator guide makes the boundary explicit: install a compatible pgvector version separately before preparing Kata when semantic search is wanted. PostgreSQL test fixtures install it explicitly only for semantic-storage coverage. Separate regressions prove that core bootstrap succeeds when pgvector is available but uninstalled and when an installed extension does not provide `halfvec`.

The vector tables are rebuildable derived state and are omitted from portable exports, so their optional presence does not advance the core schema version or require a migration. Schema validation accepts either a complete vector schema or no vector schema and continues to reject partial or drifted state.
