### PR TITLE
Make TUI input safer and easier to navigate

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,19 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 ## Unreleased
 
+**Improvements**
+
+- Made Ctrl-O the canonical TUI save/apply chord while retaining Ctrl-S as a
+  compatibility alias for existing users.
+- Allowed Up and Down to navigate live search results before committing the
+  filter, with reversible query/results focus and an explicit keep-filter exit.
+
+**Bug fixes**
+
+- Protected non-empty TUI comment drafts with discard confirmation when Esc is
+  pressed; canceling preserves the full in-memory form state, and the modal
+  footer advertises the active discard and keep-editing actions.
+
 ## 0.11.1
 <small>2026-07-19</small>
 

--- a/internal/tui/daemon_view_render.go
+++ b/internal/tui/daemon_view_render.go
@@ -40,7 +40,7 @@ func renderDaemons(m Model) string {
 		body = append(body, subtleStyle.Render(daemonFooter(rows[cursor], m.width)))
 	}
 	body = append(body, "")
-	body = append(body, subtleStyle.Render(
+	body = append(body, renderAuxiliaryFooter(m,
 		"[↑/↓ k/j] move  [enter] switch  [esc] back  [q] quit  [?] help"))
 	return strings.Join(body, "\n")
 }

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -100,6 +101,7 @@ type detailModel struct {
 	loading         bool
 	err             error
 	gen             int64
+	fetchSeq        detailFetchSequences
 	activeTab       detailTab
 	scroll          int // unified viewport offset in document lines
 	tabCursor       int // active-tab row cursor
@@ -145,8 +147,133 @@ type detailModel struct {
 	// Model.input owns inline label/owner/link prompts now.
 }
 
+type detailFetchSequences struct {
+	issue    uint64
+	comments uint64
+	events   uint64
+	links    uint64
+}
+
 // newDetailModel returns a zeroed detailModel.
 func newDetailModel() detailModel { return detailModel{} }
+
+// cloneDetailModel returns a snapshot that shares no mutable issue, slice, or
+// event-payload state with dm. Error values are retained by interface because
+// detail errors are immutable once installed.
+func cloneDetailModel(dm detailModel) detailModel {
+	cloned := dm
+	cloned.issue = cloneIssue(dm.issue)
+	if dm.parent != nil {
+		parent := *dm.parent
+		cloned.parent = &parent
+	}
+	cloned.children = cloneIssues(dm.children)
+	cloned.comments = append([]CommentEntry(nil), dm.comments...)
+	cloned.events = cloneEventLogEntries(dm.events)
+	cloned.links = append([]LinkEntry(nil), dm.links...)
+	if dm.navStack != nil {
+		cloned.navStack = make([]detailModel, len(dm.navStack))
+		for i := range dm.navStack {
+			cloned.navStack[i] = cloneDetailModel(dm.navStack[i])
+		}
+	}
+	return cloned
+}
+
+func cloneIssue(issue *Issue) *Issue {
+	if issue == nil {
+		return nil
+	}
+	cloned := *issue
+	cloned.ClosedReason = cloneString(issue.ClosedReason)
+	cloned.Owner = cloneString(issue.Owner)
+	cloned.ClosedAt = cloneTime(issue.ClosedAt)
+	cloned.DeletedAt = cloneTime(issue.DeletedAt)
+	cloned.Labels = append([]string(nil), issue.Labels...)
+	if issue.Parent != nil {
+		parent := *issue.Parent
+		cloned.Parent = &parent
+	}
+	if issue.ChildCounts != nil {
+		counts := *issue.ChildCounts
+		cloned.ChildCounts = &counts
+	}
+	cloned.Blocks = append([]LinkPeer(nil), issue.Blocks...)
+	cloned.BlockedBy = append([]LinkPeer(nil), issue.BlockedBy...)
+	cloned.Related = append([]LinkPeer(nil), issue.Related...)
+	if issue.Priority != nil {
+		priority := *issue.Priority
+		cloned.Priority = &priority
+	}
+	return &cloned
+}
+
+func cloneIssues(issues []Issue) []Issue {
+	if issues == nil {
+		return nil
+	}
+	cloned := make([]Issue, len(issues))
+	for i := range issues {
+		cloned[i] = *cloneIssue(&issues[i])
+	}
+	return cloned
+}
+
+func cloneEventLogEntries(events []EventLogEntry) []EventLogEntry {
+	if events == nil {
+		return nil
+	}
+	cloned := make([]EventLogEntry, len(events))
+	for i, event := range events {
+		cloned[i] = event
+		cloned[i].IssueShortID = cloneString(event.IssueShortID)
+		cloned[i].RelatedIssueShortID = cloneString(event.RelatedIssueShortID)
+		cloned[i].Payload = cloneEventPayload(event.Payload)
+	}
+	return cloned
+}
+
+func cloneEventPayload(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(payload))
+	for key, value := range payload {
+		cloned[key] = cloneEventPayloadValue(value)
+	}
+	return cloned
+}
+
+func cloneEventPayloadValue(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		return cloneEventPayload(value)
+	case []any:
+		cloned := make([]any, len(value))
+		for i := range value {
+			cloned[i] = cloneEventPayloadValue(value[i])
+		}
+		return cloned
+	default:
+		return value
+	}
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
 
 // Update routes detail-view messages: keys and the four fetch results.
 // After M3b the dm.modal in-place input was retired; the panel-local
@@ -178,11 +305,22 @@ func (dm detailModel) Update(msg tea.Msg, km keymap, api detailAPI) (detailModel
 // initial-load Comments(0) → Events(N) jump from pulling focus away
 // once the user has cycled tabs themselves.
 func (dm detailModel) applyFetched(msg tea.Msg) detailModel {
+	dm, _ = dm.applyFetchedIfFresh(msg)
+	return dm
+}
+
+// applyFetchedIfFresh applies a generation-matched result only when no newer
+// request for the same component has already completed. requestSeq is assigned
+// when a real fetch command is created; zero remains accepted for synthetic
+// internal messages and focused model tests that do not represent overlapping
+// requests.
+func (dm detailModel) applyFetchedIfFresh(msg tea.Msg) (detailModel, bool) {
 	switch m := msg.(type) {
 	case detailFetchedMsg:
-		if m.gen != dm.gen {
-			return dm
+		if m.gen != dm.gen || detailFetchResultIsOlder(m.requestSeq, dm.fetchSeq.issue) {
+			return dm, false
 		}
+		dm.fetchSeq.issue = newestDetailFetchSeq(dm.fetchSeq.issue, m.requestSeq)
 		dm.loading = false
 		if m.issue != nil {
 			dm.issue = m.issue
@@ -192,31 +330,47 @@ func (dm detailModel) applyFetched(msg tea.Msg) detailModel {
 		dm = dm.clampChildFocus()
 		dm.err = mergeErr(dm.err, m.err)
 	case commentsFetchedMsg:
-		if m.gen != dm.gen {
-			return dm
+		if m.gen != dm.gen || detailFetchResultIsOlder(m.requestSeq, dm.fetchSeq.comments) {
+			return dm, false
 		}
+		dm.fetchSeq.comments = newestDetailFetchSeq(dm.fetchSeq.comments, m.requestSeq)
 		dm.commentsLoading = false
 		dm.comments = m.comments
 		dm.commentsErr = m.err
 		dm = dm.autoSelectActivityTab()
 	case eventsFetchedMsg:
-		if m.gen != dm.gen {
-			return dm
+		if m.gen != dm.gen || detailFetchResultIsOlder(m.requestSeq, dm.fetchSeq.events) {
+			return dm, false
 		}
+		dm.fetchSeq.events = newestDetailFetchSeq(dm.fetchSeq.events, m.requestSeq)
 		dm.eventsLoading = false
 		dm.events = m.events
 		dm.eventsErr = m.err
 		dm = dm.autoSelectActivityTab()
 	case linksFetchedMsg:
-		if m.gen != dm.gen {
-			return dm
+		if m.gen != dm.gen || detailFetchResultIsOlder(m.requestSeq, dm.fetchSeq.links) {
+			return dm, false
 		}
+		dm.fetchSeq.links = newestDetailFetchSeq(dm.fetchSeq.links, m.requestSeq)
 		dm.linksLoading = false
 		dm.links = m.links
 		dm.linksErr = m.err
 		dm = dm.autoSelectActivityTab()
+	default:
+		return dm, false
 	}
-	return dm
+	return dm, true
+}
+
+func detailFetchResultIsOlder(requestSeq, appliedSeq uint64) bool {
+	return requestSeq != 0 && requestSeq < appliedSeq
+}
+
+func newestDetailFetchSeq(appliedSeq, requestSeq uint64) uint64 {
+	if requestSeq > appliedSeq {
+		return requestSeq
+	}
+	return appliedSeq
 }
 
 // autoSelectActivityTab picks the first non-empty activity tab the

--- a/internal/tui/detail_fetch.go
+++ b/internal/tui/detail_fetch.go
@@ -2,10 +2,16 @@ package tui
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 )
+
+// nextDetailFetchRequestSeq orders detail requests independently of the
+// detail-open generation. A generation identifies the issue lifetime, while
+// this sequence distinguishes overlapping refetches within that lifetime.
+var nextDetailFetchRequestSeq atomic.Uint64
 
 // fetchIssue wraps Client.GetIssueDetail for the Enter-jump path. The 5s
 // ceiling matches fetchInitial so the detail view honors the same
@@ -14,6 +20,7 @@ import (
 // before the request finished. ref is a short_id, qualified short_id,
 // or 26-char ULID; the daemon's path resolver handles all three.
 func fetchIssue(api detailAPI, projectID int64, ref string, gen int64) tea.Cmd {
+	requestSeq := nextDetailFetchRequestSeq.Add(1)
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -26,7 +33,10 @@ func fetchIssue(api detailAPI, projectID int64, ref string, gen int64) tea.Cmd {
 			parent = detail.Parent
 			children = detail.Children
 		}
-		return detailFetchedMsg{gen: gen, issue: issue, parent: parent, children: children, err: err}
+		return detailFetchedMsg{
+			gen: gen, requestSeq: requestSeq,
+			issue: issue, parent: parent, children: children, err: err,
+		}
 	}
 }
 
@@ -34,11 +44,12 @@ func fetchIssue(api detailAPI, projectID int64, ref string, gen int64) tea.Cmd {
 // ceiling matches fetchInitial so the detail view honors the same
 // budget as the list-fetch path. See fetchIssue for the gen rationale.
 func fetchComments(api detailAPI, projectID int64, ref string, gen int64) tea.Cmd {
+	requestSeq := nextDetailFetchRequestSeq.Add(1)
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		comments, err := api.ListComments(ctx, projectID, ref)
-		return commentsFetchedMsg{gen: gen, comments: comments, err: err}
+		return commentsFetchedMsg{gen: gen, requestSeq: requestSeq, comments: comments, err: err}
 	}
 }
 
@@ -46,20 +57,22 @@ func fetchComments(api detailAPI, projectID int64, ref string, gen int64) tea.Cm
 // issue short_id; the client filters the project-wide poll response by
 // the issue_short_id embedded in each event row.
 func fetchEvents(api detailAPI, projectID int64, ref string, gen int64) tea.Cmd {
+	requestSeq := nextDetailFetchRequestSeq.Add(1)
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		events, err := api.ListEvents(ctx, projectID, ref)
-		return eventsFetchedMsg{gen: gen, events: events, err: err}
+		return eventsFetchedMsg{gen: gen, requestSeq: requestSeq, events: events, err: err}
 	}
 }
 
 // fetchLinks wraps Client.ListLinks for use as a tea.Cmd.
 func fetchLinks(api detailAPI, projectID int64, ref string, gen int64) tea.Cmd {
+	requestSeq := nextDetailFetchRequestSeq.Add(1)
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		links, err := api.ListLinks(ctx, projectID, ref)
-		return linksFetchedMsg{gen: gen, links: links, err: err}
+		return linksFetchedMsg{gen: gen, requestSeq: requestSeq, links: links, err: err}
 	}
 }

--- a/internal/tui/detail_mutation.go
+++ b/internal/tui/detail_mutation.go
@@ -130,7 +130,7 @@ func (dm detailModel) applyMutation(
 	if !applied || m.err != nil {
 		return dm, nil
 	}
-	return dm, dm.refetchAfterMutation(api)
+	return dm, dm.refetch(api)
 }
 
 // applyMutationState applies the generation-guarded, user-visible portion of
@@ -191,13 +191,10 @@ func mutationSuccessText(m mutationDoneMsg, iss *Issue) string {
 	return ""
 }
 
-// refetchAfterMutation re-fetches the issue and the three tabs so the
-// rendered detail reflects the new state without waiting for the SSE
-// consumer (Task 11) to invalidate. The four fetches run in parallel
-// via tea.Batch — the order they land doesn't matter because each
-// fetch updates a distinct slice on dm. dm.gen rides every fetch so a
-// later jump/pop discards stale results.
-func (dm detailModel) refetchAfterMutation(api detailAPI) tea.Cmd {
+// refetch re-fetches the issue and the three tabs so a retained detail model
+// can converge with daemon state after either a mutation or snapshot restore.
+// The four fetches run in parallel; dm.gen lets a later open/jump reject them.
+func (dm detailModel) refetch(api detailAPI) tea.Cmd {
 	if dm.issue == nil {
 		return nil
 	}

--- a/internal/tui/detail_mutation.go
+++ b/internal/tui/detail_mutation.go
@@ -125,18 +125,32 @@ func (dm detailModel) dispatchPanelPromptCommit(
 func (dm detailModel) applyMutation(
 	m mutationDoneMsg, api detailAPI,
 ) (detailModel, tea.Cmd) {
-	if m.origin != "detail" || m.gen != dm.gen {
+	var applied bool
+	dm, applied = dm.applyMutationState(m)
+	if !applied || m.err != nil {
 		return dm, nil
+	}
+	return dm, dm.refetchAfterMutation(api)
+}
+
+// applyMutationState applies the generation-guarded, user-visible portion of
+// a detail mutation completion without dispatching its follow-up refetch. The
+// search detail snapshot uses the same transition so cancellation can combine
+// fresher fetched content with mutation status and errors that arrived while
+// the search was active.
+func (dm detailModel) applyMutationState(m mutationDoneMsg) (detailModel, bool) {
+	if m.origin != "detail" || m.gen != dm.gen {
+		return dm, false
 	}
 	if m.err != nil {
 		dm.err = m.err
 		dm.status = errorStyle.Render(
 			fmt.Sprintf("%s failed: %s", m.kind, m.err.Error()),
 		)
-		return dm, nil
+		return dm, true
 	}
 	dm.status = mutationSuccessText(m, dm.issue)
-	return dm, dm.refetchAfterMutation(api)
+	return dm, true
 }
 
 // successTemplates maps mutation-kind to the printf template used by

--- a/internal/tui/edge_test.go
+++ b/internal/tui/edge_test.go
@@ -110,11 +110,16 @@ func TestEdge_SSEDuringSearchPrompt(t *testing.T) {
 		t.Fatalf("bar value = %q after second keystroke, want %q", v, "ab")
 	}
 
-	// Enter commits — bar closes, filter stays. No refetch (Search is
-	// client-side; the bar already mirrored the value live).
+	// The first Enter focuses results; the second commits. The bar then
+	// closes and the filter stays. No refetch (Search is client-side;
+	// the bar already mirrored the value live).
+	m, _ = updateModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.input.kind != inputSearchBar || m.input.searchFocus != searchFocusResults {
+		t.Fatal("first Enter did not focus search results")
+	}
 	m, _ = updateModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
 	if m.input.kind != inputNone {
-		t.Fatal("Enter did not close the bar")
+		t.Fatal("second Enter did not close the bar")
 	}
 	if m.list.filter.Search != "ab" {
 		t.Fatalf("filter.Search = %q, want %q", m.list.filter.Search, "ab")

--- a/internal/tui/federation_view_render.go
+++ b/internal/tui/federation_view_render.go
@@ -75,7 +75,7 @@ func renderFederation(m Model) string {
 		body = append(body, subtleStyle.Render(federationFooter(rows[cursor], m.width)))
 	}
 	body = append(body, "")
-	body = append(body, subtleStyle.Render(
+	body = append(body, renderAuxiliaryFooter(m,
 		"[↑/↓ k/j] move  [enter] detail  [esc] back  [r] refresh  [n] enroll  [x] leave  [b] browse hubs  [?] help"))
 	return strings.Join(body, "\n")
 }
@@ -92,7 +92,7 @@ func renderFederationSelectLocalProject(m Model) string {
 		body = append(body, renderFederationChoice(label, i == cursor))
 	}
 	body = appendFederationEnrollErr(body, m)
-	body = append(body, "", subtleStyle.Render("[↑/↓ k/j] move  [enter] select  [esc] back"))
+	body = append(body, "", renderAuxiliaryFooter(m, "[↑/↓ k/j] move  [enter] select  [esc] back"))
 	return strings.Join(body, "\n")
 }
 
@@ -119,7 +119,7 @@ func renderFederationSelectHub(m Model) string {
 		body = append(body, renderFederationChoice(label, i == cursor))
 	}
 	body = appendFederationEnrollErr(body, m)
-	body = append(body, "", subtleStyle.Render("[↑/↓ k/j] move  [enter] select  [esc] back"))
+	body = append(body, "", renderAuxiliaryFooter(m, "[↑/↓ k/j] move  [enter] select  [esc] back"))
 	return strings.Join(body, "\n")
 }
 
@@ -145,7 +145,7 @@ func renderFederationSelectHubProject(m Model) string {
 		}
 	}
 	body = appendFederationEnrollErr(body, m)
-	body = append(body, "", subtleStyle.Render("[↑/↓ k/j] move  [enter] preview  [esc] back"))
+	body = append(body, "", renderAuxiliaryFooter(m, "[↑/↓ k/j] move  [enter] preview  [esc] back"))
 	return strings.Join(body, "\n")
 }
 
@@ -173,7 +173,7 @@ func renderFederationBrowseHubs(m Model) string {
 			body = append(body, renderFederationChoice(federationBrowseHubProjectLabel(project), i == cursor))
 		}
 	}
-	body = append(body, "", subtleStyle.Render("[↑/↓ k/j] move  [esc] back"))
+	body = append(body, "", renderAuxiliaryFooter(m, "[↑/↓ k/j] move  [esc] back"))
 	return strings.Join(body, "\n")
 }
 
@@ -219,7 +219,7 @@ func renderFederationPreview(m Model) string {
 		body = append(body, "", errorStyle.Render("Blocked: "+sanitizeForLine(draft.BlockedReason)))
 	}
 	body = appendFederationEnrollErr(body, m)
-	body = append(body, "", subtleStyle.Render("[enter] confirm  [esc] back"))
+	body = append(body, "", renderAuxiliaryFooter(m, "[enter] confirm  [esc] back"))
 	return strings.Join(body, "\n")
 }
 
@@ -241,7 +241,7 @@ func renderFederationAdoptConfirm(m Model) string {
 			sanitizeForLine(m.federationAdoptConfirmInput)),
 	)
 	body = appendFederationEnrollErr(body, m)
-	body = append(body, "", subtleStyle.Render("[enter] confirm  [esc] back"))
+	body = append(body, "", renderAuxiliaryFooter(m, "[enter] confirm  [esc] back"))
 	return strings.Join(body, "\n")
 }
 
@@ -275,7 +275,7 @@ func renderFederationLeavePreview(m Model) string {
 	}
 	body = appendFederationEnrollErr(body, m)
 	body = append(body, "",
-		subtleStyle.Render("[enter] confirm  [d] keep / archive  [l] local-only  [esc] back"))
+		renderAuxiliaryFooter(m, "[enter] confirm  [d] keep / archive  [l] local-only  [esc] back"))
 	return strings.Join(body, "\n")
 }
 
@@ -311,7 +311,7 @@ func renderFederationResult(m Model) string {
 		fmt.Sprintf("hub project ID: %d", result.Metadata.ProjectID),
 		"hub project UID: "+sanitizeForLine(emptyDash(result.Metadata.ProjectUID)),
 		"",
-		subtleStyle.Render("[enter] list  [esc] list"),
+		renderAuxiliaryFooter(m, "[enter] list  [esc] list"),
 	)
 	return strings.Join(body, "\n")
 }
@@ -340,7 +340,7 @@ func renderFederationLeaveResult(m Model) string {
 	}
 	body = append(body,
 		"",
-		subtleStyle.Render("[enter] list  [esc] list"),
+		renderAuxiliaryFooter(m, "[enter] list  [esc] list"),
 	)
 	return strings.Join(body, "\n")
 }
@@ -375,7 +375,7 @@ func renderFederationRecovery(m Model) string {
 	}
 	body = append(body,
 		"",
-		subtleStyle.Render("[R] reveal recovery command  [esc] back"),
+		renderAuxiliaryFooter(m, "[R] reveal recovery command  [esc] back"),
 	)
 	if recovery.Reveal {
 		body = append(body,
@@ -736,6 +736,9 @@ func renderFederationDetail(m Model, rows []FederationProjectStatus, cursor int)
 	}
 	if cursor < 0 || cursor >= len(rows) {
 		body = append(body, subtleStyle.Render("no federation selected"))
+		if m.modal != modalNone {
+			body = append(body, "", renderAuxiliaryFooter(m, ""))
+		}
 		return strings.Join(fitFederationLines(body, m.height), "\n")
 	}
 	row := rows[cursor]
@@ -777,7 +780,7 @@ func renderFederationDetail(m Model, rows []FederationProjectStatus, cursor int)
 		"last sync success: "+formatOptionalTime(row.LastSuccessfulSyncAt),
 		"last error: "+formatOptionalError(row),
 		"",
-		subtleStyle.Render("[esc] back  [r] refresh  [q] quit  [?] help"),
+		renderAuxiliaryFooter(m, "[esc] back  [r] refresh  [q] quit  [?] help"),
 	)
 	return strings.Join(fitFederationLines(body, m.height), "\n")
 }

--- a/internal/tui/filter_form_test.go
+++ b/internal/tui/filter_form_test.go
@@ -305,20 +305,20 @@ func TestFilterForm_EscRestoresPreFilter(t *testing.T) {
 	}
 }
 
-// TestFilterForm_CtrlSCommitsViaCommitInputBranch_NotCommitFormInput
-// (load-bearing): ctrl+s on the filter modal MUST go through the
+// TestFilterForm_CtrlOCommitsViaCommitInputBranch_NotCommitFormInput
+// (load-bearing): ctrl+o on the filter modal MUST go through the
 // dedicated commitFilterForm path, not commitFormInput. The latter
 // would set saving=true and wait for a mutationDoneMsg that never
-// arrives. The assertion is direct: after ctrl+s, the form is closed
+// arrives. The assertion is direct: after ctrl+o, the form is closed
 // (kind=inputNone) and saving is NOT true.
-func TestFilterForm_CtrlSCommitsViaCommitInputBranch_NotCommitFormInput(
+func TestFilterForm_CtrlOCommitsViaCommitInputBranch_NotCommitFormInput(
 	t *testing.T,
 ) {
 	m := openFilterForm(t, filterFormFixture())
-	nm, _ := stepModel(m, tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	nm, _ := stepModel(m, tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 	assertInputKind(t, nm, inputNone)
 	if nm.input.saving {
-		t.Fatal("saving=true after ctrl+s; filter form fell into commitFormInput")
+		t.Fatal("saving=true after ctrl+o; filter form fell into commitFormInput")
 	}
 }
 

--- a/internal/tui/footer_hints.go
+++ b/internal/tui/footer_hints.go
@@ -16,7 +16,7 @@ func (m Model) helpRows() [][]helpItem {
 		return modalHelpRows(m.modal)
 	}
 	if m.input.kind != inputNone {
-		return inputHelpRows(m.input.kind)
+		return inputHelpRows(m.input)
 	}
 	if m.layout == layoutSplit {
 		return m.splitHelpRows()
@@ -35,7 +35,7 @@ func (m Model) queueHelpRows() [][]helpItem {
 		return modalHelpRows(m.modal)
 	}
 	if m.input.kind != inputNone {
-		return inputHelpRows(m.input.kind)
+		return inputHelpRows(m.input)
 	}
 	return m.list.queueHelpRows()
 }
@@ -45,7 +45,7 @@ func (m Model) detailHelpRows() [][]helpItem {
 		return modalHelpRows(m.modal)
 	}
 	if m.input.kind != inputNone {
-		return inputHelpRows(m.input.kind)
+		return inputHelpRows(m.input)
 	}
 	return m.detail.detailHelpRows()
 }
@@ -55,7 +55,7 @@ func (m Model) splitHelpRows() [][]helpItem {
 		return modalHelpRows(m.modal)
 	}
 	if m.input.kind != inputNone {
-		return inputHelpRows(m.input.kind)
+		return inputHelpRows(m.input)
 	}
 	if m.focus == focusDetail {
 		return m.detail.detailHelpRows()
@@ -64,27 +64,43 @@ func (m Model) splitHelpRows() [][]helpItem {
 }
 
 func listHelpRows(lm listModel, chrome viewChrome) [][]helpItem {
+	if chrome.modal != modalNone {
+		return modalHelpRows(chrome.modal)
+	}
 	if chrome.input.kind != inputNone {
-		return inputHelpRows(chrome.input.kind)
+		return inputHelpRows(chrome.input)
 	}
 	return lm.queueHelpRows()
 }
 
 func detailHelpRows(dm detailModel, chrome viewChrome) [][]helpItem {
+	if chrome.modal != modalNone {
+		return modalHelpRows(chrome.modal)
+	}
 	if chrome.input.kind != inputNone {
-		return inputHelpRows(chrome.input.kind)
+		return inputHelpRows(chrome.input)
 	}
 	return dm.detailHelpRows()
 }
 
-func inputHelpRows(kind inputKind) [][]helpItem {
-	switch {
-	case kind.isCommandBar():
+func inputHelpRows(input inputState) [][]helpItem {
+	if input.kind == inputSearchBar && input.searchFocus == searchFocusResults {
 		return [][]helpItem{{
-			{key: "enter", desc: "commit"},
+			{key: "↑↓", desc: "move"},
+			{key: "enter", desc: "apply"},
+			{key: "esc", desc: "query"},
+			{key: "/", desc: "query"},
+		}}
+	}
+	if input.kind == inputSearchBar {
+		return [][]helpItem{{
+			{key: "↑↓/enter", desc: "results"},
 			{key: "esc", desc: "cancel"},
 			{key: "ctrl+u", desc: "clear"},
 		}}
+	}
+	kind := input.kind
+	switch {
 	case kind.isPanelPrompt():
 		return [][]helpItem{{
 			{key: "enter", desc: "commit"},
@@ -92,20 +108,20 @@ func inputHelpRows(kind inputKind) [][]helpItem {
 		}}
 	case kind == inputFilterForm:
 		return [][]helpItem{{
-			{key: "ctrl+s", desc: "apply"},
+			{key: "ctrl+o", desc: "apply"},
 			{key: "esc", desc: "cancel"},
 			{key: "ctrl+r", desc: "reset"},
 		}}
 	case kind == inputNewIssueForm:
 		return [][]helpItem{{
-			{key: "ctrl+s", desc: "create"},
+			{key: "ctrl+o", desc: "create"},
 			{key: "esc", desc: "cancel"},
 			{key: "tab", desc: "field"},
 			{key: "ctrl+e", desc: "editor"},
 		}}
 	case kind.isCenteredForm():
 		return [][]helpItem{{
-			{key: "ctrl+s", desc: "save"},
+			{key: "ctrl+o", desc: "save"},
 			{key: "esc", desc: "cancel"},
 			{key: "ctrl+e", desc: "editor"},
 		}}
@@ -208,8 +224,27 @@ func modalHelpRows(kind modalKind) [][]helpItem {
 			{key: "y", desc: "confirm"},
 			{key: "n/esc", desc: "cancel"},
 		}}
+	case modalDiscardComment:
+		return [][]helpItem{{
+			{key: "y", desc: "discard"},
+			{key: "n/esc", desc: "keep editing"},
+		}}
 	}
 	return nil
+}
+
+func modalFirstHelpRows(kind modalKind, fallback [][]helpItem) [][]helpItem {
+	if kind != modalNone {
+		return modalHelpRows(kind)
+	}
+	return fallback
+}
+
+func renderAuxiliaryFooter(m Model, ordinary string) string {
+	if rows := modalFirstHelpRows(m.modal, nil); rows != nil {
+		return renderFooterHelpTable(rows, m.width)
+	}
+	return subtleStyle.Render(ordinary)
 }
 
 func globalHelpRows() [][]helpItem {

--- a/internal/tui/footer_hints_test.go
+++ b/internal/tui/footer_hints_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -84,40 +85,175 @@ func TestHelpRows_InputAndModalContexts(t *testing.T) {
 	tests := []struct {
 		name string
 		m    Model
-		want []helpItem
+		want [][]helpItem
 	}{
 		{
-			name: "search bar",
+			name: "search query focus",
 			m:    Model{input: inputState{kind: inputSearchBar}},
-			want: []helpItem{
-				{key: "enter", desc: "commit"},
+			want: [][]helpItem{{
+				{key: "↑↓/enter", desc: "results"},
 				{key: "esc", desc: "cancel"},
 				{key: "ctrl+u", desc: "clear"},
-			},
+			}},
+		},
+		{
+			name: "search results focus",
+			m: Model{input: inputState{
+				kind:        inputSearchBar,
+				searchFocus: searchFocusResults,
+			}},
+			want: [][]helpItem{{
+				{key: "↑↓", desc: "move"},
+				{key: "enter", desc: "apply"},
+				{key: "esc", desc: "query"},
+				{key: "/", desc: "query"},
+			}},
 		},
 		{
 			name: "filter form",
 			m:    Model{input: inputState{kind: inputFilterForm}},
-			want: []helpItem{
-				{key: "ctrl+s", desc: "apply"},
+			want: [][]helpItem{{
+				{key: "ctrl+o", desc: "apply"},
 				{key: "esc", desc: "cancel"},
 				{key: "ctrl+r", desc: "reset"},
-			},
+			}},
 		},
 		{
 			name: "quit modal",
 			m:    Model{modal: modalQuitConfirm},
-			want: []helpItem{
+			want: [][]helpItem{{
 				{key: "y", desc: "confirm"},
 				{key: "n/esc", desc: "cancel"},
+			}},
+		},
+		{
+			name: "discard modal in split layout",
+			m: Model{
+				layout: layoutSplit,
+				input:  inputState{kind: inputCommentForm},
+				modal:  modalDiscardComment,
 			},
+			want: [][]helpItem{{
+				{key: "y", desc: "discard"},
+				{key: "n/esc", desc: "keep editing"},
+			}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assertHelpItemsPresent(t, tt.m.helpRows(), tt.want...)
+			if got := tt.m.helpRows(); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("help rows = %+v, want %+v", got, tt.want)
+			}
 		})
 	}
+}
+
+func TestViewChromeHelpRows_ModalPrecedesInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		modal modalKind
+		want  [][]helpItem
+	}{
+		{
+			name:  "discard comment",
+			modal: modalDiscardComment,
+			want: [][]helpItem{{
+				{key: "y", desc: "discard"},
+				{key: "n/esc", desc: "keep editing"},
+			}},
+		},
+		{
+			name:  "quit",
+			modal: modalQuitConfirm,
+			want: [][]helpItem{{
+				{key: "y", desc: "confirm"},
+				{key: "n/esc", desc: "cancel"},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{
+				input: inputState{kind: inputCommentForm},
+				modal: tt.modal,
+			}
+			chrome := m.chrome()
+			if got := listHelpRows(listModel{}, chrome); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("list help rows = %+v, want %+v", got, tt.want)
+			}
+			if got := detailHelpRows(detailModel{}, chrome); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("detail help rows = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuxiliaryViewFooters_ModalPrecedesActions(t *testing.T) {
+	projects := setupProjectsView()
+	daemons := setupDaemonView()
+	federation := setupFederationView()
+	federation.width, federation.height = 120, 24
+
+	tests := []struct {
+		name       string
+		model      Model
+		render     func(Model) string
+		normalWant string
+	}{
+		{
+			name:       "projects",
+			model:      projects,
+			render:     renderProjects,
+			normalWant: "q quit",
+		},
+		{
+			name:       "daemons",
+			model:      daemons,
+			render:     renderDaemons,
+			normalWant: "[q] quit",
+		},
+		{
+			name:       "federation",
+			model:      federation,
+			render:     renderFederation,
+			normalWant: "[?] help",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalFooter := lastRenderedLine(tt.render(tt.model))
+			if !strings.Contains(normalFooter, tt.normalWant) {
+				t.Fatalf("ordinary footer = %q, want %q action", normalFooter, tt.normalWant)
+			}
+
+			modalModel := tt.model
+			modalModel.modal = modalQuitConfirm
+			if got := lastRenderedLine(tt.render(modalModel)); got != "y confirm▕ n/esc cancel" {
+				t.Fatalf("quit modal footer = %q", got)
+			}
+		})
+	}
+}
+
+func TestFederationDetailEmpty_ModalFooterPrecedesEarlyReturn(t *testing.T) {
+	m := setupFederationView()
+	m.width, m.height = 120, 24
+	m.federationMode = federationModeDetail
+	m.federationStatuses = nil
+
+	if got := lastRenderedLine(renderFederation(m)); got != "no federation selected" {
+		t.Fatalf("ordinary empty-detail footer = %q", got)
+	}
+
+	m.modal = modalQuitConfirm
+	if got := lastRenderedLine(renderFederation(m)); got != "y confirm▕ n/esc cancel" {
+		t.Fatalf("quit modal empty-detail footer = %q", got)
+	}
+}
+
+func lastRenderedLine(rendered string) string {
+	lines := strings.Split(stripANSI(rendered), "\n")
+	return strings.TrimSpace(lines[len(lines)-1])
 }
 
 // TestPersistentHelpRowsPreferArrowNotation guards the queue (list)

--- a/internal/tui/form_test.go
+++ b/internal/tui/form_test.go
@@ -1,12 +1,38 @@
 package tui
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 )
+
+func TestFormCommitKeys_CtrlOCanonical_CtrlSCompatible(t *testing.T) {
+	for _, kind := range []inputKind{
+		inputBodyEditForm,
+		inputCommentForm,
+		inputNewIssueForm,
+		inputFilterForm,
+	} {
+		for _, key := range []rune{'o', 's'} {
+			t.Run(fmt.Sprintf("kind-%d/ctrl-%c", kind, key), func(t *testing.T) {
+				s := inputState{kind: kind}
+				_, action := s.Update(tea.KeyPressMsg{Code: key, Mod: tea.ModCtrl})
+				if action != actionCommit {
+					t.Fatalf("action = %v, want actionCommit", action)
+				}
+
+				s.saving = true
+				_, action = s.Update(tea.KeyPressMsg{Code: key, Mod: tea.ModCtrl})
+				if action != actionNone {
+					t.Fatalf("saving action = %v, want actionNone", action)
+				}
+			})
+		}
+	}
+}
 
 // captureCreateIssue stands up a test client whose handler records the
 // request path and replies with a minimal successful CreateIssue
@@ -202,14 +228,14 @@ func TestForm_OpenCommentForm_StartsEmpty(t *testing.T) {
 	}
 }
 
-// TestForm_CtrlS_OnEmptyComment_BlocksAndShowsError: ctrl+s on an
+// TestForm_CtrlO_OnEmptyComment_BlocksAndShowsError: ctrl+o on an
 // empty comment form must NOT dispatch AddComment; the form stays
 // open with an error message. Distinguishes from body edit, where
 // empty content is legitimate.
-func TestForm_CtrlS_OnEmptyComment_BlocksAndShowsError(t *testing.T) {
+func TestForm_CtrlO_OnEmptyComment_BlocksAndShowsError(t *testing.T) {
 	m := formFixture()
 	m = m.openCommentForm()
-	out, cmd := m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	out, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 	nm := out.(Model)
 	if cmd != nil {
 		t.Fatalf("empty comment dispatched cmd %T; want nil", cmd)
@@ -222,67 +248,151 @@ func TestForm_CtrlS_OnEmptyComment_BlocksAndShowsError(t *testing.T) {
 	}
 }
 
-// TestForm_CtrlS_OnEmptyBodyEdit_AllowedToCommit: clearing a body
-// is legitimate; ctrl+s on an empty body edit form must dispatch
+// TestForm_CtrlO_OnEmptyBodyEdit_AllowedToCommit: clearing a body
+// is legitimate; ctrl+o on an empty body edit form must dispatch
 // EditBody with body="" — no in-form error.
-func TestForm_CtrlS_OnEmptyBodyEdit_AllowedToCommit(t *testing.T) {
+func TestForm_CtrlO_OnEmptyBodyEdit_AllowedToCommit(t *testing.T) {
 	m := formFixture()
 	m = m.openBodyEditForm()
 	// Clear the textarea (it pre-filled with the existing body).
 	m.input.activeField().setValue("")
 	m.input.fields[m.input.active] = *m.input.activeField()
-	_, cmd := m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 	if cmd == nil {
 		t.Fatal("empty body edit must dispatch EditBody (clearing is legitimate)")
 	}
 }
 
-// TestForm_CtrlS_SetsSavingGate: the first ctrl+s flips saving=true
-// and a duplicate ctrl+s while saving is absorbed (no second cmd).
-// Regression for the "duplicate ctrl+s issues two mutations" race.
-func TestForm_CtrlS_SetsSavingGate(t *testing.T) {
+// TestForm_CtrlO_SetsSavingGate: the first ctrl+o flips saving=true
+// and a duplicate ctrl+o while saving is absorbed (no second cmd).
+// Regression for the "duplicate ctrl+o issues two mutations" race.
+func TestForm_CtrlO_SetsSavingGate(t *testing.T) {
 	m := formFixture()
 	m = m.openCommentForm()
 	m.input.activeField().setValue("hello")
 	m.input.fields[m.input.active] = *m.input.activeField()
-	out, cmd := m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	out, cmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 	nm := out.(Model)
 	if cmd == nil {
-		t.Fatal("first ctrl+s should dispatch AddComment")
+		t.Fatal("first ctrl+o should dispatch AddComment")
 	}
 	if !nm.input.saving {
-		t.Fatal("saving flag not set after first ctrl+s")
+		t.Fatal("saving flag not set after first ctrl+o")
 	}
-	// Duplicate ctrl+s while saving must be a no-op.
-	out2, cmd2 := nm.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	// Duplicate ctrl+o while saving must be a no-op.
+	out2, cmd2 := nm.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 	nm2 := out2.(Model)
 	if cmd2 != nil {
-		t.Fatalf("duplicate ctrl+s dispatched cmd %T; want nil (saving gate)", cmd2)
+		t.Fatalf("duplicate ctrl+o dispatched cmd %T; want nil (saving gate)", cmd2)
 	}
 	if !nm2.input.saving {
-		t.Fatal("saving flag cleared by duplicate ctrl+s; should still be set")
+		t.Fatal("saving flag cleared by duplicate ctrl+o; should still be set")
 	}
 }
 
-// TestForm_Esc_CancelsAndClosesForm: esc on any form kind closes
-// the form without dispatching a mutation.
-func TestForm_Esc_CancelsAndClosesForm(t *testing.T) {
-	m := formFixture()
-	m = m.openCommentForm()
+func TestCommentForm_EscEmptyClosesImmediately(t *testing.T) {
+	m := formFixture().openCommentForm()
+	out, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	nm := out.(Model)
+	if nm.input.kind != inputNone || nm.modal != modalNone || cmd != nil {
+		t.Fatalf("empty cancel = input %v modal %v cmd %T", nm.input.kind, nm.modal, cmd)
+	}
+}
+
+func TestCommentForm_EscWhitespaceOnlyClosesImmediately(t *testing.T) {
+	m := formFixture().openCommentForm()
+	m.input.activeField().setValue(" \t\n")
+	out, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	nm := out.(Model)
+	if nm.input.kind != inputNone || nm.modal != modalNone || cmd != nil {
+		t.Fatalf("whitespace cancel = input %v modal %v cmd %T", nm.input.kind, nm.modal, cmd)
+	}
+}
+
+func TestCommentForm_EscDirtyRequiresConfirmation(t *testing.T) {
+	m := formFixture().openCommentForm()
 	m.input.activeField().setValue("draft comment")
 	out, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
 	nm := out.(Model)
-	if nm.input.kind != inputNone {
-		t.Fatalf("esc did not close form; kind = %v", nm.input.kind)
+	if cmd != nil || nm.modal != modalDiscardComment {
+		t.Fatalf("dirty cancel = modal %v cmd %T", nm.modal, cmd)
 	}
-	if cmd != nil {
-		// No mutation cmd; cancel cmd path is reserved for the post-create
-		// detail-open in commit 2.
-		if msg := cmd(); msg != nil {
-			if _, isMut := msg.(mutationDoneMsg); isMut {
-				t.Fatalf("esc dispatched mutation: %v", msg)
-			}
+	if got := nm.input.activeField().value(); got != "draft comment" {
+		t.Fatalf("draft = %q, want preserved", got)
+	}
+}
+
+func TestCommentForm_EscWhileSavingIsAbsorbed(t *testing.T) {
+	m := formFixture().openCommentForm()
+	m.input.activeField().setValue("draft comment")
+
+	out, saveCmd := m.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	saving := out.(Model)
+	if saveCmd == nil || !saving.input.saving {
+		t.Fatalf("save dispatch = cmd %T saving %v", saveCmd, saving.input.saving)
+	}
+	before := saving.input
+
+	out, cancelCmd := saving.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	nm := out.(Model)
+	if cancelCmd != nil || nm.modal != modalNone || nm.input.kind != inputCommentForm {
+		t.Fatalf("saving cancel = input %v modal %v cmd %T", nm.input.kind, nm.modal, cancelCmd)
+	}
+	if !nm.input.saving || nm.input.activeField().value() != "draft comment" ||
+		nm.input.active != before.active || nm.input.target != before.target ||
+		nm.input.formGen != before.formGen {
+		t.Fatal("saving cancel changed the installed comment form state")
+	}
+}
+
+func TestCommentDiscardModal_CancelPreservesDraft(t *testing.T) {
+	for _, msg := range []tea.KeyPressMsg{
+		runeKey('n'),
+		{Code: tea.KeyEsc},
+	} {
+		m := formFixture().openCommentForm()
+		m.input.activeField().setValue("draft comment")
+		m.modal = modalDiscardComment
+		before := m.input
+		beforeArea := before.activeField().area
+		out, cmd := m.Update(msg)
+		nm := out.(Model)
+		if cmd != nil || nm.modal != modalNone || nm.input.kind != inputCommentForm {
+			t.Fatalf("cancel = input %v modal %v cmd %T", nm.input.kind, nm.modal, cmd)
 		}
+		afterArea := nm.input.activeField().area
+		if afterArea.Value() != beforeArea.Value() ||
+			afterArea.Line() != beforeArea.Line() ||
+			afterArea.Column() != beforeArea.Column() ||
+			afterArea.ScrollYOffset() != beforeArea.ScrollYOffset() ||
+			nm.input.active != before.active ||
+			nm.input.target != before.target ||
+			nm.input.formGen != before.formGen {
+			t.Fatal("cancel changed the installed comment form state")
+		}
+	}
+}
+
+func TestCommentDiscardModal_ConfirmClearsDraft(t *testing.T) {
+	m := formFixture().openCommentForm()
+	m.input.activeField().setValue("draft comment")
+	m.modal = modalDiscardComment
+	out, cmd := m.Update(runeKey('y'))
+	nm := out.(Model)
+	if cmd != nil || nm.modal != modalNone || nm.input.kind != inputNone {
+		t.Fatalf("confirm = input %v modal %v cmd %T", nm.input.kind, nm.modal, cmd)
+	}
+}
+
+func TestCommentDiscardModal_AbsorbsOtherKeys(t *testing.T) {
+	m := formFixture().openCommentForm()
+	m.input.activeField().setValue("draft comment")
+	m.modal = modalDiscardComment
+	out, cmd := m.Update(runeKey('j'))
+	nm := out.(Model)
+	if cmd != nil || nm.modal != modalDiscardComment ||
+		nm.input.activeField().value() != "draft comment" {
+		t.Fatal("unrelated key escaped discard modal")
 	}
 }
 

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -40,7 +40,7 @@ func helpSections(km keymap) []helpSection {
 			{key: "enter", desc: "open child"},
 		}},
 		{"Forms", []helpItem{
-			{key: "ctrl+s", desc: "save or apply"},
+			{key: "ctrl+o", desc: "save or apply"},
 			{key: "esc", desc: "cancel"},
 			{key: "tab/shift+tab", desc: "change field"},
 			{key: "ctrl+e", desc: "open editor"},

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -35,6 +35,13 @@ const (
 	inputFilterForm        // list `f` — multi-axis filter modal: Status/Owner/Search
 )
 
+type searchFocus int
+
+const (
+	searchFocusQuery searchFocus = iota
+	searchFocusResults
+)
+
 // isPanelPrompt reports whether a kind is one of the M3b panel-local
 // prompt kinds (anchored to the bottom of the detail pane).
 func (k inputKind) isPanelPrompt() bool {
@@ -55,7 +62,8 @@ func (k inputKind) isCommandBar() bool {
 }
 
 // isCenteredForm reports whether a kind is one of the centered form
-// kinds (multi-line textarea, ctrl+s commit, esc cancel, ctrl+e
+// kinds (multi-line textarea, ctrl+o commit with ctrl+s compatibility,
+// esc cancel, ctrl+e
 // $EDITOR escape hatch). M4 introduced edit-body and comment;
 // Plan 8 commit 4 added the multi-field new-issue form; Plan 8
 // commit 5a added the filter modal. The filter modal renders via
@@ -205,9 +213,18 @@ func (f *inputField) blur() {
 // reads field values and dispatches the mutation; on actionCancel it
 // discards and restores any pre-open snapshot.
 //
-// preFilter is the listFilter snapshot captured when an inline
-// command bar opened, so a cancel can revert any live-applied changes.
-// Empty filter for non-bar inputs.
+// preFilter snapshots the filter when a command bar or filter form
+// opens. preListSelection additionally snapshots the highlighted row
+// for a search bar, so cancel can revert every live-applied search
+// change without leaving cursor and stable identity out of sync.
+// restoreSplitDetail records whether that search has owned a populated split
+// detail pane, whose hidden state must follow the restored selection even if
+// the terminal becomes stacked before cancel. preSplitDetail is a deep copy
+// of the detail model the search first inherited, when one existed.
+// preSplitDetailCaptured distinguishes an intentionally captured nil detail
+// from a search that has not entered split layout yet. preSplitDetailAhead is
+// set when a matching async result updated the snapshot without reaching live
+// detail.
 //
 // target / err / saving / formGen are populated for centered-form and
 // panel-prompt kinds. target carries the issue context so a stale
@@ -222,17 +239,30 @@ func (f *inputField) blur() {
 // visible row in the menu when the entry list overflows the menu's
 // height. Both are zero on every non-suggesting input kind.
 type inputState struct {
-	kind             inputKind
-	title            string
-	fields           []inputField
-	active           int
-	err              string
-	saving           bool
-	preFilter        ListFilter
-	target           formTarget
-	formGen          int64
-	suggestHighlight int
-	suggestScroll    int
+	kind                   inputKind
+	searchFocus            searchFocus
+	title                  string
+	fields                 []inputField
+	active                 int
+	err                    string
+	saving                 bool
+	preFilter              ListFilter
+	preListSelection       listSelectionSnapshot
+	restoreSplitDetail     bool
+	preSplitDetail         *detailModel
+	preSplitDetailCaptured bool
+	preSplitDetailAhead    bool
+	target                 formTarget
+	formGen                int64
+	suggestHighlight       int
+	suggestScroll          int
+}
+
+type listSelectionSnapshot struct {
+	cursor            int
+	windowStart       int
+	selectedUID       string
+	selectedProjectID int64
 }
 
 // formTarget carries the issue identity a centered form is acting
@@ -277,11 +307,20 @@ func (s *inputState) activeField() *inputField {
 	return &s.fields[idx]
 }
 
+func (s *inputState) hasCommentDraft() bool {
+	if s == nil || s.kind != inputCommentForm {
+		return false
+	}
+	f := s.activeField()
+	return f != nil && strings.TrimSpace(f.value()) != ""
+}
+
 // Update routes a key into the active field and reports the action
 // the caller should take. Centered forms route differently from bars
-// and prompts: ctrl+s commits (Enter inserts a newline into the
-// textarea); ctrl+e requests the $EDITOR escape hatch; saving=true
-// blocks duplicate commits while a mutation is in flight.
+// and prompts: ctrl+o is the canonical commit key, with ctrl+s retained
+// for compatibility (Enter inserts a newline into the textarea);
+// ctrl+e requests the $EDITOR escape hatch; saving=true blocks duplicate
+// commits while a mutation is in flight.
 //
 // Label-prompt kinds (`+` / `-`) intercept ↑/↓/⇥ BEFORE delegating to
 // the textinput so the autocomplete menu's highlight cursor moves
@@ -353,13 +392,14 @@ func (s inputState) handleSuggestKey(msg tea.KeyPressMsg) (inputState, bool) {
 	return s, false
 }
 
-// updateForm is the Update path for centered forms. ctrl+s commits
-// (Model-level handler validates kind-specific empty rules); esc
-// cancels; ctrl+e hands off to $EDITOR (gated to the body field on
-// multi-field forms so the user does not get $EDITOR for a one-line
-// owner string); tab/shift+tab cycle fields with wrap on multi-field
+// updateForm is the Update path for centered forms. ctrl+o is the canonical
+// commit key, with ctrl+s retained for compatibility (Model-level handler
+// validates kind-specific empty rules); esc cancels; ctrl+e hands off
+// to $EDITOR (gated to the body field on multi-field forms so the user
+// does not get $EDITOR for a one-line owner string); tab/shift+tab cycle
+// fields with wrap on multi-field
 // forms; enter on a single-line field advances to the next field
-// rather than committing (commit is ctrl+s only).
+// rather than committing (commit is ctrl+o, with ctrl+s compatibility).
 //
 // On single-field forms (edit-body, comment) tab and shift+tab fall
 // through to the textarea so the user can still indent. The Body
@@ -367,7 +407,7 @@ func (s inputState) handleSuggestKey(msg tea.KeyPressMsg) (inputState, bool) {
 // can use tab natively. The cycling only triggers for the single-line
 // fields on a multi-field form.
 //
-// While saving=true, ctrl+s is absorbed (no duplicate dispatches).
+// While saving=true, ctrl+o and ctrl+s are absorbed (no duplicate dispatches).
 //
 // The filter form (Plan 8 commit 5a) honors ctrl+r as a reset gesture
 // (zeros every field; preFilter intact for esc) and routes ←/→/space
@@ -389,14 +429,15 @@ func (s inputState) updateForm(msg tea.KeyPressMsg) (inputState, inputAction) {
 }
 
 // handleFormControlKey handles the action-emitting key family
-// (ctrl+s, esc, ctrl+e, ctrl+r). handled=true means the key was
+// (canonical ctrl+o, compatible ctrl+s, esc, ctrl+e, ctrl+r).
+// handled=true means the key was
 // consumed (the action may still be actionNone for absorbed gestures
-// like ctrl+r and the saving=true ctrl+s gate).
+// like ctrl+r and the saving=true commit gate).
 func (s inputState) handleFormControlKey(
 	msg tea.KeyPressMsg,
 ) (inputState, inputAction, bool) {
 	switch msg.String() {
-	case "ctrl+s":
+	case "ctrl+o", "ctrl+s":
 		if s.saving {
 			return s, actionNone, true
 		}
@@ -519,8 +560,8 @@ func (s inputState) shouldCycleFields() bool {
 // line field should advance to the next field. The body field on the
 // new-issue form stays as a newline-insert (textarea native
 // behavior); other fields treat enter as "next field." Commit is
-// reserved for ctrl+s. The filter form has no multi-line field, so
-// every field advances on enter.
+// reserved for canonical ctrl+o, with ctrl+s compatibility. The filter
+// form has no multi-line field, so every field advances on enter.
 func (s inputState) shouldAdvanceOnEnter() bool {
 	if len(s.fields) <= 1 {
 		return false
@@ -648,7 +689,8 @@ const (
 // newBodyEditForm constructs the centered multi-line editor opened by
 // `e` on the detail view. current pre-fills the textarea with the
 // existing body so the user starts on top of what's there. esc
-// closes the form (returns to detail); ctrl+s dispatches EditBody;
+// closes the form (returns to detail); ctrl+o dispatches EditBody
+// (ctrl+s remains compatible);
 // ctrl+e suspends to $EDITOR.
 func newBodyEditForm(target formTarget, current string) inputState {
 	return inputState{
@@ -661,9 +703,9 @@ func newBodyEditForm(target formTarget, current string) inputState {
 
 // newCommentForm is the centered multi-line comment editor opened
 // by `c` on the detail view. esc cancels (no comment posted);
-// ctrl+s dispatches AddComment; empty content blocks commit per the
-// kind-specific gate (comments must have content; clearing a body is
-// legitimate but posting an empty comment is not).
+// ctrl+o dispatches AddComment (ctrl+s remains compatible); empty content
+// blocks commit per the kind-specific gate (comments must have content;
+// clearing a body is legitimate but posting an empty comment is not).
 func newCommentForm(target formTarget) inputState {
 	return inputState{
 		kind:   inputCommentForm,
@@ -773,7 +815,8 @@ func joinLabelsForFilterForm(labels []string) string {
 // only multi-line field (so ctrl+e for $EDITOR escape only fires when
 // it owns focus); Labels accepts a comma-separated string normalized
 // at commit time; Owner is a single-line textinput, nil-on-wire when
-// blank. tab cycles fields with wrap; ctrl+s commits; esc cancels.
+// blank. tab cycles fields with wrap; ctrl+o commits (ctrl+s remains
+// compatible); esc cancels.
 func newNewIssueForm() inputState {
 	return newNewIssueFormBase("new issue")
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -222,9 +222,7 @@ func (f *inputField) blur() {
 // the terminal becomes stacked before cancel. preSplitDetail is a deep copy
 // of the detail model the search first inherited, when one existed.
 // preSplitDetailCaptured distinguishes an intentionally captured nil detail
-// from a search that has not entered split layout yet. preSplitDetailAhead is
-// set when a matching async result updated the snapshot without reaching live
-// detail.
+// from a search that has not entered split layout yet.
 //
 // target / err / saving / formGen are populated for centered-form and
 // panel-prompt kinds. target carries the issue context so a stale
@@ -251,7 +249,6 @@ type inputState struct {
 	restoreSplitDetail     bool
 	preSplitDetail         *detailModel
 	preSplitDetailCaptured bool
-	preSplitDetailAhead    bool
 	target                 formTarget
 	formGen                int64
 	suggestHighlight       int

--- a/internal/tui/inputs_render.go
+++ b/internal/tui/inputs_render.go
@@ -178,7 +178,7 @@ func renderFilterFormFooter(s inputState) string {
 	if s.saving {
 		return statusStyle.Render("saving…")
 	}
-	hint := "ctrl+s apply · esc cancel · tab next · ctrl+r reset"
+	hint := "ctrl+o apply · esc cancel · tab next · ctrl+r reset"
 	return subtleStyle.Render(hint)
 }
 
@@ -289,12 +289,12 @@ func renderFormFooter(s inputState, innerW int, allowEditor bool) string {
 	if s.saving {
 		return statusStyle.Render("saving…")
 	}
-	hint := "ctrl+s save · esc cancel · ctrl+e $EDITOR"
+	hint := "ctrl+o save · esc cancel · ctrl+e $EDITOR"
 	if !allowEditor {
-		hint = "ctrl+s save · esc cancel · tab next · ctrl+e (body only)"
+		hint = "ctrl+o save · esc cancel · tab next · ctrl+e (body only)"
 	}
 	if len(hint) > innerW {
-		hint = "ctrl+s save · esc cancel"
+		hint = "ctrl+o save · esc cancel"
 	}
 	return subtleStyle.Render(hint)
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -191,11 +191,21 @@ func (m Model) handleLayoutFlip(prev layoutMode) (Model, tea.Cmd) {
 		} else {
 			m.focus = focusList
 		}
+		// Capture inherited detail before an active search takes ownership.
+		// Search must follow the filtered highlight even when a hidden detail
+		// is already populated; the ordinary nil-only bootstrap remains the
+		// right behavior for non-search layout transitions.
+		m = m.captureSearchSplitDetail()
+		if m.input.kind.isCommandBar() {
+			m, cmd := m.followSearchResultIfNeeded(nil)
+			return m.markSearchSplitDetailOwned(), cmd
+		}
 		// Bootstrap the detail pane on the first stacked→split flip so
 		// a launch that landed before the size msg, or a runtime
 		// widen/resize/toggle, populates the right pane without
 		// requiring a j/k nudge.
-		return m.maybeBootstrapSplitDetail()
+		m, cmd := m.maybeBootstrapSplitDetail()
+		return m.markSearchSplitDetailOwned(), cmd
 	}
 	return m, nil
 }

--- a/internal/tui/list_filter_test.go
+++ b/internal/tui/list_filter_test.go
@@ -259,7 +259,8 @@ func TestList_StatusOpenShowsNestedMatchingGrandchildContext(t *testing.T) {
 // TestList_Search_AccumulatesAndCommits drives /, then "abc", then
 // Enter through Model.Update so the M3a inline command bar handles
 // the keys. The buffer mirrors live into filter.Search on every
-// keystroke; Enter closes the bar leaving the filter applied.
+// keystroke; the first Enter focuses results and the second closes
+// the bar leaving the filter applied.
 //
 // The filter changes are *client-side* (filteredIssues), so no API
 // refetch fires for Search/Owner — only Status filter changes
@@ -279,8 +280,13 @@ func TestList_Search_AccumulatesAndCommits(t *testing.T) {
 		t.Fatalf("filter.Search = %q, want abc (live mirror)", m.list.filter.Search)
 	}
 	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.input.kind != inputSearchBar || m.input.searchFocus != searchFocusResults {
+		t.Fatalf("search state = kind %v focus %v, want focused results",
+			m.input.kind, m.input.searchFocus)
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
 	if m.input.kind != inputNone {
-		t.Fatalf("input.kind = %v, want inputNone after Enter", m.input.kind)
+		t.Fatalf("input.kind = %v, want inputNone after second Enter", m.input.kind)
 	}
 	if m.list.filter.Search != "abc" {
 		t.Fatalf("filter.Search = %q, want abc (preserved on commit)", m.list.filter.Search)
@@ -350,6 +356,219 @@ func openBarFromCmd(t *testing.T, m Model, key rune) Model {
 	msg := cmd()
 	out, _ = m.Update(msg)
 	return out.(Model)
+}
+
+func searchNavigationFixture(t *testing.T) Model {
+	t.Helper()
+	m := mFixtureForBar()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "fix alpha", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "fix beta", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-ccc3", ShortID: "ccc3", Title: "other", Status: "open"},
+	}
+	return openBarFromCmd(t, m, '/')
+}
+
+func TestSearch_DownMovesIntoResultsAndAdvancesCursor(t *testing.T) {
+	m := searchNavigationFixture(t)
+	for _, r := range "fix" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.input.kind != inputSearchBar || m.input.searchFocus != searchFocusResults {
+		t.Fatalf("search state = kind %v focus %v", m.input.kind, m.input.searchFocus)
+	}
+	if m.list.cursor != 1 || m.input.activeField().value() != "fix" {
+		t.Fatalf("cursor/query = %d/%q", m.list.cursor, m.input.activeField().value())
+	}
+}
+
+func TestSearch_UpMovesIntoResultsRelativeToCursor(t *testing.T) {
+	m := searchNavigationFixture(t)
+	m.list.cursor = 1
+	for _, r := range "fix" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyUp})
+	if m.input.searchFocus != searchFocusResults || m.list.cursor != 0 {
+		t.Fatalf("up state = focus %v cursor %d", m.input.searchFocus, m.list.cursor)
+	}
+}
+
+func TestSearch_EnterMovesToResultsThenCommitsFilter(t *testing.T) {
+	m := searchNavigationFixture(t)
+	for _, r := range "fix" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.input.kind != inputSearchBar || m.input.searchFocus != searchFocusResults {
+		t.Fatal("first enter did not focus results")
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyDown})
+	wantCursor := m.list.cursor
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.input.kind != inputNone || m.list.filter.Search != "fix" ||
+		m.list.cursor != wantCursor {
+		t.Fatal("commit lost filter or selection")
+	}
+}
+
+func TestSearch_EnterSynchronizesSelectionAcrossRefetch(t *testing.T) {
+	m := mFixtureForBar()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "fix beta", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-ccc3", ShortID: "ccc3", Title: "fix gamma", Status: "open"},
+	}
+	m.list.cursor = 1
+	m.list.selectedUID = "01TEST-bbb2"
+	m.list.selectedProjectID = 7
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "fix" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	if highlighted, ok := pickHighlightedIssue(m.list); !ok || highlighted.UID != "01TEST-ccc3" {
+		t.Fatalf("highlighted issue = (%+v, %v), want ccc3", highlighted, ok)
+	}
+	assertSelection(t, m, 1, "01TEST-bbb2")
+
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = stepModel(m, refetchedMsg{
+		dispatchKey: m.currentCacheKey(),
+		issues: []Issue{
+			{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other", Status: "open"},
+			{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "fix beta", Status: "open"},
+			{ProjectID: 7, UID: "01TEST-ccc3", ShortID: "ccc3", Title: "fix gamma", Status: "open"},
+		},
+	})
+	assertSelection(t, m, 1, "01TEST-ccc3")
+	if m.list.selectedProjectID != 7 {
+		t.Fatalf("selectedProjectID = %d, want 7", m.list.selectedProjectID)
+	}
+}
+
+func TestSearch_EscReturnsToQueryThenCancels(t *testing.T) {
+	m := mFixtureForBar()
+	m.list.filter.Search = "previous"
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "fix" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m.input.searchFocus = searchFocusResults
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m.input.kind != inputSearchBar || m.input.searchFocus != searchFocusQuery {
+		t.Fatal("first esc did not restore query focus")
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m.input.kind != inputNone || m.list.filter.Search != "previous" {
+		t.Fatal("second esc did not restore pre-search filter")
+	}
+}
+
+func TestSearch_CancelRestoresSelectionAcrossRefetch(t *testing.T) {
+	m := mFixtureForBar()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other alpha", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "fix beta", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-ccc3", ShortID: "ccc3", Title: "fix gamma", Status: "open"},
+	}
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "fix" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	assertSelection(t, m, 0, "01TEST-bbb2")
+
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m.input.kind != inputNone || m.list.filter.Search != "" {
+		t.Fatalf("cancel state = input %v filter %q", m.input.kind, m.list.filter.Search)
+	}
+	assertSelection(t, m, 0, "01TEST-aaa1")
+	if m.list.selectedProjectID != 7 {
+		t.Fatalf("selectedProjectID = %d, want 7", m.list.selectedProjectID)
+	}
+	if highlighted, ok := pickHighlightedIssue(m.list); !ok || highlighted.UID != "01TEST-aaa1" {
+		t.Fatalf("highlighted issue = (%+v, %v), want aaa1", highlighted, ok)
+	}
+
+	m, _ = stepModel(m, refetchedMsg{
+		dispatchKey: m.currentCacheKey(),
+		issues: []Issue{
+			{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other alpha", Status: "open"},
+			{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "fix beta", Status: "open"},
+			{ProjectID: 7, UID: "01TEST-ccc3", ShortID: "ccc3", Title: "fix gamma", Status: "open"},
+		},
+	})
+	assertSelection(t, m, 0, "01TEST-aaa1")
+	if m.list.selectedProjectID != 7 {
+		t.Fatalf("selectedProjectID after refetch = %d, want 7", m.list.selectedProjectID)
+	}
+}
+
+func TestSearch_ResultsAbsorbUnrelatedKeys(t *testing.T) {
+	m := searchNavigationFixture(t)
+	m.input.activeField().setValue("fix")
+	m = m.applyLiveBarFilter()
+	m.input.searchFocus = searchFocusResults
+	out, cmd := m.Update(runeKey('q'))
+	nm := out.(Model)
+	if cmd != nil || nm.input.activeField().value() != "fix" ||
+		nm.input.searchFocus != searchFocusResults {
+		t.Fatal("unrelated key escaped results focus")
+	}
+}
+
+func TestSearch_ResultsAbsorbPaste(t *testing.T) {
+	m := searchNavigationFixture(t)
+	for _, r := range "fix" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyDown})
+	wantQuery := m.input.activeField().value()
+	wantFilter := m.list.filter
+	wantFocus := m.input.searchFocus
+	wantCursor := m.list.cursor
+	wantUID := m.list.selectedUID
+	wantPID := m.list.selectedProjectID
+
+	out, cmd := m.Update(tea.PasteMsg{Content: "other"})
+	nm := out.(Model)
+	if cmd != nil {
+		t.Fatalf("paste returned cmd %T, want nil", cmd)
+	}
+	if got := nm.input.activeField().value(); got != wantQuery {
+		t.Fatalf("query = %q, want %q", got, wantQuery)
+	}
+	require.Equal(t, wantFilter, nm.list.filter)
+	if nm.input.searchFocus != wantFocus || nm.list.cursor != wantCursor ||
+		nm.list.selectedUID != wantUID || nm.list.selectedProjectID != wantPID {
+		t.Fatalf("focus/cursor/selection = %v/%d/%q/%d, want %v/%d/%q/%d",
+			nm.input.searchFocus, nm.list.cursor, nm.list.selectedUID, nm.list.selectedProjectID,
+			wantFocus, wantCursor, wantUID, wantPID)
+	}
+}
+
+func TestSearch_SlashReturnsFromResultsToQuery(t *testing.T) {
+	m := searchNavigationFixture(t)
+	m.input.searchFocus = searchFocusResults
+	m, _ = stepModel(m, runeKey('/'))
+	if m.input.kind != inputSearchBar || m.input.searchFocus != searchFocusQuery {
+		t.Fatal("slash did not restore query focus")
+	}
+}
+
+func TestSearch_ZeroResultsNavigationIsSafe(t *testing.T) {
+	m := searchNavigationFixture(t)
+	m.input.activeField().setValue("no-match")
+	m = m.applyLiveBarFilter()
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.input.searchFocus != searchFocusResults || m.list.cursor != 0 {
+		t.Fatalf("zero-result state = focus %v cursor %d", m.input.searchFocus, m.list.cursor)
+	}
 }
 
 // TestList_ClearFilters_ZeroesEveryField: `c` zeroes every filter slot

--- a/internal/tui/list_render.go
+++ b/internal/tui/list_render.go
@@ -18,9 +18,10 @@ import (
 // footer help row. Plumbed from Model so the sub-views don't have to
 // reach back into parent state. Zero-value renders a "minimal chrome"
 // view (used by snapshot tests that exercise just the body) — no
-// version, no SSE indicator text, no toast, no input.
+// version, no SSE indicator text, no toast, no input, no modal.
 //
-// input is the active inline command bar / panel-local prompt /
+// modal is the active centered confirmation and owns footer help while
+// installed. input is the active inline command bar / panel-local prompt /
 // centered form. When input.kind is a command bar, the chrome
 // renders the bar on the info line just above the footer (msgvault
 // pattern) and swaps the help row to the bar's keys.
@@ -40,6 +41,7 @@ type viewChrome struct {
 	narrow       bool             // M6 split mode list pane: drop owner column
 	projectsByID map[int64]string // for all-projects mode: pid → display name (empty otherwise)
 	daemon       string           // active daemon display label
+	modal        modalKind        // active confirmation; takes footer precedence
 }
 
 // View renders the list under the M3.5 chrome layer:

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -29,34 +29,39 @@ type refetchedMsg struct {
 // in Task 11. gen tags the detail-open generation that dispatched the
 // fetch — applyFetched discards messages whose gen no longer matches
 // dm.gen so a fetch in flight when the user pops/jumps cannot pollute
-// the new view with stale data.
+// the new view with stale data. requestSeq orders overlapping requests
+// within the same generation so an older response cannot replace a newer one.
 type detailFetchedMsg struct {
-	gen      int64
-	issue    *Issue
-	parent   *IssueRef
-	children []Issue
-	err      error
+	gen        int64
+	requestSeq uint64
+	issue      *Issue
+	parent     *IssueRef
+	children   []Issue
+	err        error
 }
 
 // commentsFetchedMsg, eventsFetchedMsg, and linksFetchedMsg carry the
 // per-tab fetch results dispatched in parallel by openDetailMsg. gen
 // is the detail-open generation; see detailFetchedMsg for the rationale.
 type commentsFetchedMsg struct {
-	gen      int64
-	comments []CommentEntry
-	err      error
+	gen        int64
+	requestSeq uint64
+	comments   []CommentEntry
+	err        error
 }
 
 type eventsFetchedMsg struct {
-	gen    int64
-	events []EventLogEntry
-	err    error
+	gen        int64
+	requestSeq uint64
+	events     []EventLogEntry
+	err        error
 }
 
 type linksFetchedMsg struct {
-	gen   int64
-	links []LinkEntry
-	err   error
+	gen        int64
+	requestSeq uint64
+	links      []LinkEntry
+	err        error
 }
 
 // openDetailMsg is emitted by the list view when Enter selects a row.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -88,8 +88,8 @@ type Model struct {
 	// route normally. While an input is open, all non-Quit keys go to
 	// the input's bubbles model; canQuit() gates global keys.
 	input inputState
-	// modal is the active centered confirm/info overlay (M3.5b: the
-	// quit-confirm modal; future plans add delete-confirm etc.).
+	// modal is the active centered confirm/info overlay (quit confirm or
+	// dirty-comment discard confirm; future plans may add others).
 	// modalNone is the quiescent state. While a modal is open it
 	// owns key dispatch — `y`/`n`/`esc` route through it instead of
 	// reaching list/detail handlers.
@@ -387,6 +387,7 @@ func initialFilter(_ Options) ListFilter {
 // comments tab — but the list sub-model is untouched on pop, preserving
 // the user's cursor and filter state across the round trip.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	m = m.syncSearchDetailSnapshot(msg)
 	if next, cmd, ok := m.routeTopLevel(msg); ok {
 		return next, cmd
 	}
@@ -411,8 +412,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.staleConnMsg(mut.connGen) {
 			return m, nil
 		}
+		snapshotCmd := m.searchSnapshotMutationRefetch(mut)
 		next, cmd := m.routeMutation(mut)
-		return next, cmd
+		return next, combineCmds(cmd, snapshotCmd)
 	}
 	// Editor returns from a centered form's ctrl+e handoff land here
 	// before dispatchToView so the writeback can hit m.input. formGen=0
@@ -710,6 +712,9 @@ func (m Model) routeTopLevel(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		// type. Forward to the active input's bubbles model so a paste
 		// lands atomically (newlines included) instead of as
 		// keystrokes; without an open input the paste has no target.
+		if m.input.kind == inputSearchBar && m.input.searchFocus == searchFocusResults {
+			return m, nil, true
+		}
 		if m.modal == modalNone && m.input.kind != inputNone {
 			m.input, _ = m.input.delegateToField(msg)
 			if m.input.kind.isCommandBar() {
@@ -867,8 +872,9 @@ func (m Model) cacheDetailViewport(dm detailModel) detailModel {
 // AND the formTarget rides on inputState.target so the autocomplete
 // dispatch (label suggestions) can scope to the right project. For
 // the centered new-issue form (Plan 8 commit 4), the form has no
-// issue context — ctrl+s dispatches CreateIssue with the four-field
-// payload. For other centered forms (edit-body, comment), openInput
+// issue context — ctrl+o dispatches CreateIssue with the four-field
+// payload (ctrl+s remains compatible). For other centered forms
+// (edit-body, comment), openInput
 // delegates to openBodyEditForm / openCommentForm — they need extra
 // context (current body, issue target) so they're called directly
 // from the detail key handler instead of via openInputMsg.
@@ -887,7 +893,10 @@ func (m Model) openInputFromMsg(msg openInputMsg) (Model, tea.Cmd) {
 	kind := msg.kind
 	switch {
 	case kind == inputSearchBar:
-		m.input = newSearchBar(m.list.filter)
+		s := newSearchBar(m.list.filter)
+		s.preListSelection = snapshotListSelection(m.list)
+		m.input = s
+		m = m.captureSearchSplitDetail()
 	case kind == inputNewIssueForm:
 		m.nextFormGen++
 		s := newNewIssueForm()
@@ -999,6 +1008,11 @@ func (m Model) openCommentForm() Model {
 // highlighted suggestion's label (suggestion source is computed at
 // the Model level — see suggestionsForPrompt).
 func (m Model) routeInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
+	if m.input.kind == inputSearchBar {
+		if next, cmd, handled := m.routeSearchInputKey(msg); handled {
+			return next, cmd
+		}
+	}
 	prevKind := m.input.kind
 	next, action := m.input.Update(msg)
 	m.input = next
@@ -1006,7 +1020,7 @@ func (m Model) routeInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	case actionCommit:
 		return m.commitInput()
 	case actionCancel:
-		return m.cancelInput()
+		return m.requestInputCancel()
 	case actionEditorHandoff:
 		return m.handoffToEditor()
 	}
@@ -1017,6 +1031,225 @@ func (m Model) routeInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		m = m.applyLabelPromptKey(msg)
 	}
 	return m, nil
+}
+
+func (m Model) routeSearchInputKey(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
+	if m.input.searchFocus == searchFocusQuery {
+		switch msg.String() {
+		case "enter":
+			m.list = m.list.syncSelection(m.list.visibleRows())
+			m.input.searchFocus = searchFocusResults
+			next, cmd := m.followSearchResultIfNeeded(nil)
+			return next, cmd, true
+		case "up", "down":
+			m.input.searchFocus = searchFocusResults
+			next, cmd := m.dispatchListKey(msg)
+			next, cmd = next.followSearchResultIfNeeded(cmd)
+			return next, cmd, true
+		}
+		return m, nil, false
+	}
+
+	switch msg.String() {
+	case "up", "down":
+		next, cmd := m.dispatchListKey(msg)
+		return next, cmd, true
+	case "esc", "/":
+		m.input.searchFocus = searchFocusQuery
+		return m, nil, true
+	case "enter":
+		next, cmd := m.commitInput()
+		return next, cmd, true
+	default:
+		return m, nil, true
+	}
+}
+
+func (m Model) followSearchResultIfNeeded(prior tea.Cmd) (Model, tea.Cmd) {
+	if m.layout != layoutSplit {
+		return m, prior
+	}
+	return m.followHighlightedIssueIfNeeded(prior)
+}
+
+// restoreSearchDetailIfNeeded bypasses the ordinary split-only search-result
+// gate after an active search has owned a split detail pane, so a later stacked
+// resize cannot leave that hidden pane pinned to the canceled result.
+func (m Model) restoreSearchDetailIfNeeded(
+	snapshot *detailModel, snapshotAhead bool, prior tea.Cmd,
+) (Model, tea.Cmd) {
+	if iss, ok := pickHighlightedIssue(m.list); ok {
+		pid := detailProjectID(iss, m.scope)
+		if snapshotAhead && detailModelMatches(snapshot, iss.UID, pid) {
+			liveMatches := detailModelMatches(&m.detail, iss.UID, pid)
+			if liveMatches && m.detail.gen > snapshot.gen {
+				// The search returned to the inherited issue after the saved
+				// generation advanced while hidden. Keep that newer live shell so
+				// its outstanding responses still match and can complete it.
+				return m, prior
+			}
+			if !liveMatches {
+				// Installing the snapshot replaces a search-owned live target.
+				// Invalidate its pending debounce tick without scheduling a fetch.
+				m.nextDetailFollowGen++
+			}
+			m.detail = m.applyDetailViewportCache(cloneDetailModel(*snapshot))
+			return m, prior
+		}
+		return m.followHighlightedIssueIfNeeded(prior)
+	}
+	// No restored row can drive scheduleDetailFollow. Invalidate the search's
+	// pending tick directly, then reinstate its inherited detail model or clear
+	// a pane that the search itself created.
+	m.nextDetailFollowGen++
+	if snapshot == nil {
+		m.detail = m.applyDetailViewportCache(newDetailModel())
+		return m, prior
+	}
+	m.detail = m.applyDetailViewportCache(cloneDetailModel(*snapshot))
+	return m, prior
+}
+
+// captureSearchSplitDetail snapshots the first populated split detail model an
+// active search inherits. It runs before split bootstrap so a detail created
+// from the live query is never mistaken for pre-search state.
+func (m Model) captureSearchSplitDetail() Model {
+	if !m.input.kind.isCommandBar() || m.layout != layoutSplit {
+		return m
+	}
+	if m.input.preSplitDetailCaptured {
+		return m
+	}
+	m.input.preSplitDetailCaptured = true
+	if m.detail.issue != nil {
+		snapshot := cloneDetailModel(m.detail)
+		m.input.preSplitDetail = &snapshot
+		m.input.restoreSplitDetail = true
+	}
+	return m
+}
+
+// syncSearchDetailSnapshot mirrors every generation-matched async detail
+// result into the saved pre-search model. Fetch results flow through
+// detailModel.applyFetched, while mutation completions share the state-only
+// portion of detailModel.applyMutation. This keeps fetched content plus
+// mutation status/errors converged without dispatching a duplicate refetch,
+// while preserving the snapshot's tab, cursor, scroll, and navigation state.
+func (m Model) syncSearchDetailSnapshot(msg tea.Msg) Model {
+	if !m.input.kind.isCommandBar() || m.input.preSplitDetail == nil {
+		return m
+	}
+	if mut, ok := msg.(mutationDoneMsg); ok {
+		if m.staleConnMsg(mut.connGen) {
+			return m
+		}
+		updated, applied := m.input.preSplitDetail.applyMutationState(mut)
+		if !applied {
+			return m
+		}
+		if mut.gen != m.detail.gen {
+			m.input.preSplitDetailAhead = true
+		}
+		snapshot := cloneDetailModel(updated)
+		m.input.preSplitDetail = &snapshot
+		return m
+	}
+	if !isDetailFetchMsg(msg) {
+		return m
+	}
+	updated, applied := m.input.preSplitDetail.applyFetchedIfFresh(msg)
+	if !applied {
+		return m
+	}
+	if gen, ok := detailFetchGeneration(msg); ok &&
+		gen == m.input.preSplitDetail.gen && !m.detailFetchReachesLive(gen) {
+		m.input.preSplitDetailAhead = true
+	}
+	snapshot := cloneDetailModel(updated)
+	m.input.preSplitDetail = &snapshot
+	return m
+}
+
+// searchSnapshotMutationRefetch returns the normal post-mutation detail
+// refresh when a successful completion belongs to the saved pre-search detail
+// but can no longer reach the retargeted live pane. syncSearchDetailSnapshot
+// has already applied the mutation status to that saved model; this preserves
+// the issue and activity refresh that detailModel.applyMutation would have
+// dispatched if its generation still matched live detail.
+func (m Model) searchSnapshotMutationRefetch(mut mutationDoneMsg) tea.Cmd {
+	if m.api == nil || mut.err != nil || mut.origin != "detail" ||
+		m.input.preSplitDetail == nil || mut.gen != m.input.preSplitDetail.gen ||
+		mut.gen == m.detail.gen {
+		return nil
+	}
+	return m.input.preSplitDetail.refetchAfterMutation(m.api)
+}
+
+func combineCmds(first, second tea.Cmd) tea.Cmd {
+	switch {
+	case first == nil:
+		return second
+	case second == nil:
+		return first
+	default:
+		return tea.Batch(first, second)
+	}
+}
+
+func detailModelMatches(detail *detailModel, uid string, pid int64) bool {
+	return detail != nil && detail.issue != nil &&
+		detail.issue.UID == uid && detail.scopePID == pid
+}
+
+func detailFetchGeneration(msg tea.Msg) (int64, bool) {
+	switch msg := msg.(type) {
+	case detailFetchedMsg:
+		return msg.gen, true
+	case commentsFetchedMsg:
+		return msg.gen, true
+	case eventsFetchedMsg:
+		return msg.gen, true
+	case linksFetchedMsg:
+		return msg.gen, true
+	}
+	return 0, false
+}
+
+func (m Model) detailFetchReachesLive(gen int64) bool {
+	if m.detail.gen != gen {
+		return false
+	}
+	return m.layout == layoutSplit || m.view == viewDetail
+}
+
+// markSearchSplitDetailOwned records that the active search has controlled a
+// visible split detail pane. The marker is monotonic for the search lifetime:
+// once set, cancel must restore that pane even after a later stacked resize.
+// It is state-only so layout changes never introduce another follow command.
+func (m Model) markSearchSplitDetailOwned() Model {
+	if m.input.kind.isCommandBar() && m.layout == layoutSplit && m.detail.issue != nil {
+		m.input.restoreSplitDetail = true
+	}
+	return m
+}
+
+func (m Model) followHighlightedIssueIfNeeded(prior tea.Cmd) (Model, tea.Cmd) {
+	iss, ok := pickHighlightedIssue(m.list)
+	if !ok {
+		return m, prior
+	}
+	pid := detailProjectID(iss, m.scope)
+	if m.detail.issue != nil && m.detail.issue.UID == iss.UID && m.detail.scopePID == pid {
+		return m, prior
+	}
+	m, follow := m.scheduleDetailFollow()
+	if prior == nil {
+		return m, follow
+	}
+	if follow == nil {
+		return m, prior
+	}
+	return m, tea.Batch(prior, follow)
 }
 
 // applyLabelPromptKey post-processes a key into a label prompt:
@@ -1353,7 +1586,8 @@ func (m Model) applyLiveBarFilter() Model {
 //
 // For centered forms, commitInput keeps the form open with
 // saving=true while the mutation is in flight (so a duplicate
-// ctrl+s is absorbed by the form's updateForm gate). The form is
+// canonical ctrl+o or compatible ctrl+s is absorbed by the form's
+// updateForm gate). The form is
 // closed by routeFormMutation when the response arrives. Per-form
 // gates: comments require non-empty content; body edits allow empty
 // (clearing a body is legitimate); the new-issue form requires a
@@ -1363,9 +1597,9 @@ func (m Model) applyLiveBarFilter() Model {
 // isCenteredForm() check. The filter form IS in isCenteredForm() for
 // rendering (overlayModal needs to know to draw it), but its commit
 // is filter-apply-and-refetch, not mutation-dispatch. Without the
-// explicit early branch, ctrl+s on the filter modal would fall into
-// commitFormInput, set saving=true, and wait forever for a
-// mutationDoneMsg that never arrives (no daemon round-trip is in
+// explicit early branch, canonical ctrl+o (or compatible ctrl+s) on
+// the filter modal would fall into commitFormInput, set saving=true,
+// and wait forever for a mutationDoneMsg that never arrives (no daemon round-trip is in
 // flight). Order matters here.
 func (m Model) commitInput() (Model, tea.Cmd) {
 	kind := m.input.kind
@@ -1423,9 +1657,10 @@ func (m Model) commitFilterForm(form inputState) (Model, tea.Cmd) {
 	return m, nil
 }
 
-// commitFormInput handles ctrl+s on a centered form. The form stays
-// open with saving=true while the daemon round-trip runs; the
-// arriving mutationDoneMsg closes it (success: clear and update
+// commitFormInput handles canonical ctrl+o and compatible ctrl+s on a
+// centered form. The form stays open with saving=true while the daemon
+// round-trip runs; the arriving mutationDoneMsg closes it (success:
+// clear and update
 // detail / list; error: surface on the form's status line and leave
 // open). Render-side sanitization elsewhere handles display safety;
 // mutation payloads go to the wire untouched so the user's content
@@ -1636,12 +1871,51 @@ func dispatchFormEditBody(
 // with the bar path so any future "live preview" mode plugs in
 // without changing this code.
 func (m Model) cancelInput() (Model, tea.Cmd) {
-	if m.input.kind.isCommandBar() || m.input.kind == inputFilterForm {
+	searchCanceled := m.input.kind.isCommandBar()
+	restoreSplitDetail := searchCanceled && m.input.restoreSplitDetail
+	preSplitDetail := m.input.preSplitDetail
+	preSplitDetailAhead := m.input.preSplitDetailAhead
+	if searchCanceled {
+		m.list.filter = m.input.preFilter
+		snapshot := m.input.preListSelection
+		m.list.cursor = snapshot.cursor
+		m.list.windowStart = snapshot.windowStart
+		m.list.selectedUID = snapshot.selectedUID
+		m.list.selectedProjectID = snapshot.selectedProjectID
+		m.list = m.list.restoreCursorToSelection()
+	} else if m.input.kind == inputFilterForm {
 		m.list.filter = m.input.preFilter
 		m.list = m.list.clampCursorToFilter()
 	}
 	m.input = inputState{}
+	if restoreSplitDetail {
+		return m.restoreSearchDetailIfNeeded(preSplitDetail, preSplitDetailAhead, nil)
+	}
+	if searchCanceled {
+		return m.followSearchResultIfNeeded(nil)
+	}
 	return m, nil
+}
+
+func snapshotListSelection(lm listModel) listSelectionSnapshot {
+	lm = lm.syncSelection(lm.visibleRows())
+	return listSelectionSnapshot{
+		cursor:            lm.cursor,
+		windowStart:       lm.windowStart,
+		selectedUID:       lm.selectedUID,
+		selectedProjectID: lm.selectedProjectID,
+	}
+}
+
+func (m Model) requestInputCancel() (Model, tea.Cmd) {
+	if m.input.kind == inputCommentForm && m.input.saving {
+		return m, nil
+	}
+	if m.input.hasCommentDraft() {
+		m.modal = modalDiscardComment
+		return m, nil
+	}
+	return m.cancelInput()
 }
 
 // routeGlobalKey handles the global key family (quit, help, scope
@@ -2241,7 +2515,7 @@ func toastExpireCmd(d time.Duration) tea.Cmd {
 
 // canQuit reports whether a global keystroke (q, ?, R) should be
 // honored. False while an input shell (M3a/M3b/M3.5c bars/prompts
-// /forms) or a confirm modal (M3.5b quit confirm) is open. Both
+// /forms) or a confirm modal (quit or comment discard) is open. Both
 // gates redirect global keys into the field instead of firing.
 func (m Model) canQuit() bool {
 	if m.modal != modalNone {
@@ -2253,10 +2527,11 @@ func (m Model) canQuit() bool {
 	return true
 }
 
-// routeModalKey delivers a key to the active centered modal. M3.5b
-// only handles modalQuitConfirm: y/Y commits → tea.Quit; n/N/esc
-// cancels → close the modal. Other keys are absorbed (the modal owns
-// dispatch; nothing reaches the underlying view).
+// routeModalKey delivers a key to the active centered modal. Quit
+// confirmation maps y/Y to tea.Quit and n/N/esc to close; comment
+// discard maps y/Y to cancelInput and n/N/esc to resume editing.
+// Other keys are absorbed (the modal owns dispatch; nothing reaches
+// the underlying view).
 //
 // ctrl+c always fast-quits regardless of which modal is open — the
 // power-user escape hatch must not be trapped behind a confirmation
@@ -2270,6 +2545,15 @@ func (m Model) routeModalKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		switch msg.String() {
 		case "y", "Y":
 			return m, tea.Quit
+		case "n", "N", "esc":
+			m.modal = modalNone
+			return m, nil
+		}
+	case modalDiscardComment:
+		switch msg.String() {
+		case "y", "Y":
+			m.modal = modalNone
+			return m.cancelInput()
 		case "n", "N", "esc":
 			m.modal = modalNone
 			return m, nil
@@ -2602,6 +2886,7 @@ func (m Model) scheduleDetailFollow() (Model, tea.Cmd) {
 	m.detail.eventsLoading = true
 	m.detail.linksLoading = true
 	m.detail = m.applyDetailViewportCache(m.detail)
+	m = m.markSearchSplitDetailOwned()
 	m.nextDetailFollowGen++
 	tickGen := m.nextDetailFollowGen
 	return m, tea.Tick(detailFollowDebounce, func(time.Time) tea.Msg {
@@ -2696,25 +2981,12 @@ func (m Model) viewContent() string {
 			body = renderTooNarrow(m.width, m.height)
 		}
 		body = m.appendNonListDetailExtras(body)
-		if m.modal == modalQuitConfirm {
-			return overlayModal(body, renderQuitConfirmModal(), m.width, m.height)
-		}
-		if m.input.kind.isCenteredForm() {
-			form := renderCenteredForm(m.input, m.width, m.height)
-			return overlayModal(body, form, m.width, m.height)
-		}
-		return body
+		return m.overlayInputAndModal(body)
 	}
 	body := m.viewBody()
 	body = m.appendNonListDetailExtras(body)
-	// M3.5b: a centered modal overlays the rendered view when active.
-	if m.modal == modalQuitConfirm {
-		return overlayModal(body, renderQuitConfirmModal(), m.width, m.height)
-	}
-	// M4: centered form overlays the rendered view when active.
-	if m.input.kind.isCenteredForm() {
-		form := renderCenteredForm(m.input, m.width, m.height)
-		return overlayModal(body, form, m.width, m.height)
+	if m.input.kind.isCenteredForm() || m.modal != modalNone {
+		return m.overlayInputAndModal(body)
 	}
 	// Plan-8: label-prompt autocomplete menu overlays the detail view
 	// above the info line. The detail layout reserves the menu's
@@ -2724,6 +2996,17 @@ func (m Model) viewContent() string {
 	// user is on focusDetail regardless of m.view.
 	if m.detailIsActive() && isLabelPromptKind(m.input.kind) {
 		body = m.overlaySuggestMenu(body)
+	}
+	return body
+}
+
+func (m Model) overlayInputAndModal(body string) string {
+	if m.input.kind.isCenteredForm() {
+		form := renderCenteredForm(m.input, m.width, m.height)
+		body = overlayModal(body, form, m.width, m.height)
+	}
+	if m.modal != modalNone {
+		body = overlayModal(body, renderConfirmModal(m.modal), m.width, m.height)
 	}
 	return body
 }
@@ -2842,7 +3125,7 @@ func (m Model) viewBody() string {
 // chrome assembles the cross-cutting render inputs both the list view
 // and the detail view need from Model state: scope, SSE status,
 // pending invalidation flag, the active toast (if any), the
-// build-time version string, and the active input shell. Centralising
+// build-time version string, active input shell, and active modal. Centralising
 // this keeps the sub-views free of Model coupling.
 func (m Model) chrome() viewChrome {
 	return viewChrome{
@@ -2854,6 +3137,7 @@ func (m Model) chrome() viewChrome {
 		input:        m.input,
 		projectsByID: m.projectsByID,
 		daemon:       activeDaemonDisplay(m.activeDaemon),
+		modal:        m.modal,
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1225,20 +1225,6 @@ func detailModelMatches(detail *detailModel, uid string, pid int64) bool {
 		detail.issue.UID == uid && detail.scopePID == pid
 }
 
-func detailFetchGeneration(msg tea.Msg) (int64, bool) {
-	switch msg := msg.(type) {
-	case detailFetchedMsg:
-		return msg.gen, true
-	case commentsFetchedMsg:
-		return msg.gen, true
-	case eventsFetchedMsg:
-		return msg.gen, true
-	case linksFetchedMsg:
-		return msg.gen, true
-	}
-	return 0, false
-}
-
 // markSearchSplitDetailOwned records that the active search has controlled a
 // visible split detail pane. The marker is monotonic for the search lifetime:
 // once set, cancel must restore that pane even after a later stacked resize.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1095,6 +1095,11 @@ func (m Model) followSearchResultIfNeeded(prior tea.Cmd) (Model, tea.Cmd) {
 	if m.layout != layoutSplit {
 		return m, prior
 	}
+	if _, ok := pickHighlightedIssue(m.list); !ok {
+		m.nextDetailFollowGen++
+		m.detail = m.applyDetailViewportCache(newDetailModel())
+		return m, prior
+	}
 	return m.followHighlightedIssueIfNeeded(prior)
 }
 
@@ -1109,10 +1114,15 @@ func (m Model) restoreSearchDetailIfNeeded(
 		if detailModelMatches(snapshot, iss.UID, pid) {
 			liveMatches := detailModelMatches(&m.detail, iss.UID, pid)
 			if liveMatches {
-				// The live pane already represents the restored issue. Detail
-				// responses now reach it in every layout, and a newer generation
-				// must retain its outstanding-response eligibility.
-				return m, prior
+				// Preserve the newer live generation so its outstanding responses
+				// remain eligible, but retain a mutation outcome that advanced only
+				// on the saved generation. A fresh live-generation refetch converges
+				// component data without allowing older snapshot requests to win.
+				if snapshot.status != "" {
+					m.detail.status = snapshot.status
+					m.detail.err = snapshot.err
+				}
+				return m, combineCmds(prior, m.refetchRestoredDetail())
 			}
 			// Installing the snapshot replaces a search-owned live target.
 			// Invalidate its pending debounce tick without scheduling a fetch.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -394,7 +394,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if next, cmd, ok := m.routeSSE(msg); ok {
 		return next, cmd
 	}
-	var bootstrapCmd tea.Cmd
+	var postFetchCmd tea.Cmd
 	switch msg.(type) {
 	case initialFetchMsg, refetchedMsg:
 		if m.staleConnResult(msg) {
@@ -403,9 +403,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.isStaleListFetch(msg) {
 			return m, nil
 		}
+		prevPID, prevUID, prevHas := highlightedIdentity(m.list)
 		m = m.populateCache(msg)
 		if _, isInitial := msg.(initialFetchMsg); isInitial {
-			m, bootstrapCmd = m.maybeBootstrapSplitDetail()
+			m, postFetchCmd = m.maybeBootstrapSplitDetail()
+		} else {
+			m, postFetchCmd = m.reconcileSearchDetailAfterRefetch(prevPID, prevUID, prevHas)
 		}
 	}
 	if mut, ok := msg.(mutationDoneMsg); ok {
@@ -516,13 +519,36 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return next, cmd
 	}
 	next, cmd := m.dispatchToView(msg)
-	if bootstrapCmd == nil {
+	if postFetchCmd == nil {
 		return next, cmd
 	}
 	if cmd == nil {
-		return next, bootstrapCmd
+		return next, postFetchCmd
 	}
-	return next, tea.Batch(cmd, bootstrapCmd)
+	return next, tea.Batch(cmd, postFetchCmd)
+}
+
+// reconcileSearchDetailAfterRefetch applies the same detail-follows-selection
+// invariant as keyboard navigation when an accepted list response moves the
+// highlighted search result. Empty results clear the search-owned pane and
+// invalidate any debounce tick for the departed issue.
+func (m Model) reconcileSearchDetailAfterRefetch(
+	prevPID int64, prevUID string, prevHas bool,
+) (Model, tea.Cmd) {
+	if m.input.kind != inputSearchBar || m.input.searchFocus != searchFocusResults ||
+		m.layout != layoutSplit {
+		return m, nil
+	}
+	newPID, newUID, newHas := highlightedIdentity(m.list)
+	if prevHas == newHas && prevPID == newPID && prevUID == newUID {
+		return m, nil
+	}
+	if !newHas {
+		m.nextDetailFollowGen++
+		m.detail = m.applyDetailViewportCache(newDetailModel())
+		return m, nil
+	}
+	return m.scheduleDetailFollow()
 }
 
 // maybeBootstrapSplitDetail auto-loads the highlighted list row into the
@@ -1076,25 +1102,23 @@ func (m Model) followSearchResultIfNeeded(prior tea.Cmd) (Model, tea.Cmd) {
 // gate after an active search has owned a split detail pane, so a later stacked
 // resize cannot leave that hidden pane pinned to the canceled result.
 func (m Model) restoreSearchDetailIfNeeded(
-	snapshot *detailModel, snapshotAhead bool, prior tea.Cmd,
+	snapshot *detailModel, prior tea.Cmd,
 ) (Model, tea.Cmd) {
 	if iss, ok := pickHighlightedIssue(m.list); ok {
 		pid := detailProjectID(iss, m.scope)
-		if snapshotAhead && detailModelMatches(snapshot, iss.UID, pid) {
+		if detailModelMatches(snapshot, iss.UID, pid) {
 			liveMatches := detailModelMatches(&m.detail, iss.UID, pid)
-			if liveMatches && m.detail.gen > snapshot.gen {
-				// The search returned to the inherited issue after the saved
-				// generation advanced while hidden. Keep that newer live shell so
-				// its outstanding responses still match and can complete it.
+			if liveMatches {
+				// The live pane already represents the restored issue. Detail
+				// responses now reach it in every layout, and a newer generation
+				// must retain its outstanding-response eligibility.
 				return m, prior
 			}
-			if !liveMatches {
-				// Installing the snapshot replaces a search-owned live target.
-				// Invalidate its pending debounce tick without scheduling a fetch.
-				m.nextDetailFollowGen++
-			}
+			// Installing the snapshot replaces a search-owned live target.
+			// Invalidate its pending debounce tick without scheduling a fetch.
+			m.nextDetailFollowGen++
 			m.detail = m.applyDetailViewportCache(cloneDetailModel(*snapshot))
-			return m, prior
+			return m, combineCmds(prior, m.refetchRestoredDetail())
 		}
 		return m.followHighlightedIssueIfNeeded(prior)
 	}
@@ -1107,7 +1131,14 @@ func (m Model) restoreSearchDetailIfNeeded(
 		return m, prior
 	}
 	m.detail = m.applyDetailViewportCache(cloneDetailModel(*snapshot))
-	return m, prior
+	return m, combineCmds(prior, m.refetchRestoredDetail())
+}
+
+func (m Model) refetchRestoredDetail() tea.Cmd {
+	if m.api == nil {
+		return nil
+	}
+	return m.detail.refetch(m.api)
 }
 
 // captureSearchSplitDetail snapshots the first populated split detail model an
@@ -1147,9 +1178,6 @@ func (m Model) syncSearchDetailSnapshot(msg tea.Msg) Model {
 		if !applied {
 			return m
 		}
-		if mut.gen != m.detail.gen {
-			m.input.preSplitDetailAhead = true
-		}
 		snapshot := cloneDetailModel(updated)
 		m.input.preSplitDetail = &snapshot
 		return m
@@ -1160,10 +1188,6 @@ func (m Model) syncSearchDetailSnapshot(msg tea.Msg) Model {
 	updated, applied := m.input.preSplitDetail.applyFetchedIfFresh(msg)
 	if !applied {
 		return m
-	}
-	if gen, ok := detailFetchGeneration(msg); ok &&
-		gen == m.input.preSplitDetail.gen && !m.detailFetchReachesLive(gen) {
-		m.input.preSplitDetailAhead = true
 	}
 	snapshot := cloneDetailModel(updated)
 	m.input.preSplitDetail = &snapshot
@@ -1182,7 +1206,7 @@ func (m Model) searchSnapshotMutationRefetch(mut mutationDoneMsg) tea.Cmd {
 		mut.gen == m.detail.gen {
 		return nil
 	}
-	return m.input.preSplitDetail.refetchAfterMutation(m.api)
+	return m.input.preSplitDetail.refetch(m.api)
 }
 
 func combineCmds(first, second tea.Cmd) tea.Cmd {
@@ -1213,13 +1237,6 @@ func detailFetchGeneration(msg tea.Msg) (int64, bool) {
 		return msg.gen, true
 	}
 	return 0, false
-}
-
-func (m Model) detailFetchReachesLive(gen int64) bool {
-	if m.detail.gen != gen {
-		return false
-	}
-	return m.layout == layoutSplit || m.view == viewDetail
 }
 
 // markSearchSplitDetailOwned records that the active search has controlled a
@@ -1874,7 +1891,6 @@ func (m Model) cancelInput() (Model, tea.Cmd) {
 	searchCanceled := m.input.kind.isCommandBar()
 	restoreSplitDetail := searchCanceled && m.input.restoreSplitDetail
 	preSplitDetail := m.input.preSplitDetail
-	preSplitDetailAhead := m.input.preSplitDetailAhead
 	if searchCanceled {
 		m.list.filter = m.input.preFilter
 		snapshot := m.input.preListSelection
@@ -1889,7 +1905,7 @@ func (m Model) cancelInput() (Model, tea.Cmd) {
 	}
 	m.input = inputState{}
 	if restoreSplitDetail {
-		return m.restoreSearchDetailIfNeeded(preSplitDetail, preSplitDetailAhead, nil)
+		return m.restoreSearchDetailIfNeeded(preSplitDetail, nil)
 	}
 	if searchCanceled {
 		return m.followSearchResultIfNeeded(nil)
@@ -2740,6 +2756,14 @@ func (m Model) projectIDForName(name string) (int64, bool) {
 //
 // In stacked layout the original m.view path is preserved.
 func (m Model) dispatchToView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Detail responses remain relevant when stacked list view temporarily hides
+	// a retained pane. Generation checks inside detailModel reject obsolete
+	// responses, so route them independently of the active layout/view.
+	if isDetailFetchMsg(msg) {
+		var cmd tea.Cmd
+		m.detail, cmd = m.detail.Update(msg, m.keymap, m.api)
+		return m, withConnGen(cmd, m.connGen)
+	}
 	if m.layout == layoutSplit {
 		return m.dispatchToSplitPane(msg)
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -585,17 +585,15 @@ func (m Model) isStaleListFetch(msg tea.Msg) bool {
 //  1. origin=list, view!=viewList → apply directly to listModel so
 //     the list status/refetch fires even though the user is in
 //     detail view now.
-//  2. origin=detail, view!=viewDetail → apply directly to dm; its
-//     gen is unchanged (no new open since pop) so applyMutation
-//     accepts the message.
-//  3. origin=detail, view==viewDetail, mut.gen != m.detail.gen →
-//     the user opened a *different* detail issue between dispatch
-//     and arrival. dm.applyMutation would silently drop the message
-//     on the gen mismatch and leave the list cache stale. Mark the
-//     cache stale here so the next list refetch (or SSE invalidation)
-//     repopulates the rows the original mutation touched.
+//  2. origin=detail, mut.gen != m.detail.gen → the user opened or
+//     followed a *different* detail generation between dispatch and
+//     arrival. dm.applyMutation would silently drop the message and
+//     leave the list cache stale. Mark the cache stale regardless of
+//     which pane now owns focus.
+//  3. origin=detail, inactive pane, matching gen → apply directly
+//     to dm so its status and component refetch still land.
 //
-// Without case (3), a "close issue A in detail → jump to issue B
+// Without case (2), a "close issue A in detail → jump to issue B
 // before the close completes" sequence would update neither A's UI
 // (it's gone) nor any cache, and the list rows would stay stale
 // until an unrelated SSE event happened to refresh them.
@@ -614,11 +612,6 @@ func (m Model) routeMutation(mut mutationDoneMsg) (tea.Model, tea.Cmd) {
 		return m, withConnGen(cmd, m.connGen)
 	}
 	if mut.origin == "detail" {
-		if !m.detailIsActive() {
-			var cmd tea.Cmd
-			m.detail, cmd = m.detail.applyMutation(mut, m.api)
-			return m, withConnGen(cmd, m.connGen)
-		}
 		if mut.gen != m.detail.gen {
 			// Stale-to-current-detail: the original UI is gone but
 			// the underlying data still changed. Mark the list cache
@@ -633,6 +626,11 @@ func (m Model) routeMutation(mut mutationDoneMsg) (tea.Model, tea.Cmd) {
 				return m, debouncedRefetch(refetchDebounce)
 			}
 			return m, nil
+		}
+		if !m.detailIsActive() {
+			var cmd tea.Cmd
+			m.detail, cmd = m.detail.applyMutation(mut, m.api)
+			return m, withConnGen(cmd, m.connGen)
 		}
 	}
 	next, cmd := m.routeMutationToActivePane(mut)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1113,9 +1113,18 @@ func (m Model) restoreSearchDetailIfNeeded(
 			liveMatches := detailModelMatches(&m.detail, iss.UID, pid)
 			if liveMatches {
 				// Preserve the newer live generation so its outstanding responses
-				// remain eligible, but retain a mutation outcome that advanced only
-				// on the saved generation. A fresh live-generation refetch converges
-				// component data without allowing older snapshot requests to win.
+				// and fetched content remain eligible, while restoring the pre-search
+				// presentation/navigation state and any mutation outcome that advanced
+				// only on the saved generation. A fresh live-generation refetch
+				// converges component data without allowing older requests to win.
+				saved := cloneDetailModel(*snapshot)
+				m.detail.detailFocus = saved.detailFocus
+				m.detail.activeTab = saved.activeTab
+				m.detail.scroll = saved.scroll
+				m.detail.tabCursor = saved.tabCursor
+				m.detail.childCursor = saved.childCursor
+				m.detail.navStack = saved.navStack
+				m.detail.tabExplicit = saved.tabExplicit
 				if snapshot.status != "" {
 					m.detail.status = snapshot.status
 					m.detail.err = snapshot.err
@@ -2827,6 +2836,9 @@ func (m Model) dispatchListKey(msg tea.Msg) (Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m = m.applyListViewportCache()
 	m.list, cmd = m.list.Update(msg, m.keymap, m.api, m.scope)
+	if m.layout != layoutSplit {
+		return m, withConnGen(cmd, m.connGen)
+	}
 	newPID, newUID, newHas := highlightedIdentity(m.list)
 	if prevHas == newHas && prevPID == newPID && prevUID == newUID {
 		return m, withConnGen(cmd, m.connGen)

--- a/internal/tui/new_issue_form_test.go
+++ b/internal/tui/new_issue_form_test.go
@@ -210,13 +210,13 @@ func TestNewIssueForm_EnterInBodyInsertsNewline(t *testing.T) {
 	}
 }
 
-// TestNewIssueForm_CtrlSEmptyTitleSetsErrNoDispatch: ctrl+s with a
+// TestNewIssueForm_CtrlOEmptyTitleSetsErrNoDispatch: ctrl+o with a
 // blank Title sets the in-form err and does NOT dispatch.
-func TestNewIssueForm_CtrlSEmptyTitleSetsErrNoDispatch(t *testing.T) {
+func TestNewIssueForm_CtrlOEmptyTitleSetsErrNoDispatch(t *testing.T) {
 	m := openNewIssueForm(t, newIssueFormFixture())
-	nm, cmd := stepModel(m, tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	nm, cmd := stepModel(m, tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 	if cmd != nil {
-		t.Fatalf("empty-title ctrl+s dispatched cmd %T; want nil", cmd)
+		t.Fatalf("empty-title ctrl+o dispatched cmd %T; want nil", cmd)
 	}
 	assertInputKind(t, nm, inputNewIssueForm)
 	if nm.input.err == "" {

--- a/internal/tui/projects_view_render.go
+++ b/internal/tui/projects_view_render.go
@@ -25,7 +25,7 @@ func renderProjects(m Model) string {
 	if cursor < 0 {
 		cursor = 0
 	}
-	helpRows := projectsHelpRows()
+	helpRows := modalFirstHelpRows(m.modal, projectsHelpRows())
 	footerLines := helpLines(helpRows, m.width)
 
 	rowBudget := len(rows)

--- a/internal/tui/quit_modal.go
+++ b/internal/tui/quit_modal.go
@@ -9,13 +9,15 @@ import (
 )
 
 // modalKind names which centered confirm/info modal is active.
-// modalNone is the quiescent state. After M3.5b only the quit-confirm
-// case exists; future plans (delete-confirm, etc.) extend the enum.
+// modalNone is the quiescent state. The current cases confirm quitting
+// and discarding a dirty comment draft; future confirmations extend the
+// enum.
 type modalKind int
 
 const (
 	modalNone modalKind = iota
 	modalQuitConfirm
+	modalDiscardComment
 )
 
 // renderQuitConfirmModal returns the centered "Are you sure?" panel.
@@ -31,6 +33,27 @@ func renderQuitConfirmModal() string {
 		"[Y] Yes    [N] No",
 	}, "\n")
 	return modalBoxStyle.Render(body)
+}
+
+func renderDiscardCommentModal() string {
+	body := strings.Join([]string{
+		"Discard comment draft?",
+		"",
+		"Your unsaved comment will be lost.",
+		"",
+		"[Y] Discard    [N] Keep editing",
+	}, "\n")
+	return modalBoxStyle.Render(body)
+}
+
+func renderConfirmModal(kind modalKind) string {
+	switch kind {
+	case modalQuitConfirm:
+		return renderQuitConfirmModal()
+	case modalDiscardComment:
+		return renderDiscardCommentModal()
+	}
+	return ""
 }
 
 // overlayModal centers a modal panel over the rendered background

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -266,9 +266,30 @@ func TestSnapshot_QuitConfirmModal(t *testing.T) {
 	defer snapshotInit(t)()
 	lm := snapListModel(snapListFixture())
 	lm.cursor = 1
-	bg := lm.View(120, 30, snapViewChrome())
+	chrome := snapViewChrome()
+	chrome.modal = modalQuitConfirm
+	bg := lm.View(120, 30, chrome)
 	got := overlayModal(bg, renderQuitConfirmModal(), 120, 30)
 	assertGolden(t, "quit-confirm-modal", got)
+}
+
+func TestSnapshot_CommentDiscardConfirmModal(t *testing.T) {
+	defer snapshotInit(t)()
+	m := formFixture()
+	m.width, m.height = 120, 30
+	m.view = viewDetail
+	m = m.openCommentForm()
+	m.input.activeField().setValue("draft comment")
+	m.modal = modalDiscardComment
+	got := m.viewContent()
+	lines := strings.Split(stripANSI(got), "\n")
+	footer := lines[len(lines)-1]
+	if !strings.Contains(footer, "y discard") ||
+		!strings.Contains(footer, "n/esc keep editing") ||
+		strings.Contains(footer, "ctrl+o save") {
+		t.Fatalf("discard modal footer = %q", footer)
+	}
+	assertGolden(t, "comment-discard-confirm-modal", got)
 }
 
 // TestSnapshot_List_SearchBarActive covers the inline command bar
@@ -281,6 +302,16 @@ func TestSnapshot_List_SearchBarActive(t *testing.T) {
 	chrome.input = newSearchBar(ListFilter{Search: "login"})
 	got := lm.View(120, 30, chrome)
 	assertGolden(t, "list-search-bar-active", got)
+}
+
+func TestSnapshot_List_SearchResultsFocused(t *testing.T) {
+	defer snapshotInit(t)()
+	lm := snapListModel(snapListFixture())
+	chrome := snapViewChrome()
+	chrome.input = newSearchBar(ListFilter{Search: "login"})
+	chrome.input.searchFocus = searchFocusResults
+	got := lm.View(120, 30, chrome)
+	assertGolden(t, "list-search-results-focused", got)
 }
 
 // TestSnapshot_List_ScrollIndicator covers the scroll-indicator slot

--- a/internal/tui/split_test.go
+++ b/internal/tui/split_test.go
@@ -123,6 +123,51 @@ func TestSplit_SearchEnterRetargetsDetailToFilteredResult(t *testing.T) {
 	}
 }
 
+func TestSplit_SearchEnterWithNoResultsClearsDetail(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other row", Status: "open"},
+	}
+	m.list.cursor = 0
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	seed := m.list.issues[0]
+	m.detail = detailModel{issue: &seed, scopePID: 7, gen: 41}
+	m.nextGen = m.detail.gen
+
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "missing" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	if rows := m.list.visibleRows(); len(rows) != 0 {
+		t.Fatalf("query rows = %d, want zero", len(rows))
+	}
+	if m.input.preSplitDetail == nil || m.input.preSplitDetail.issue == nil ||
+		m.input.preSplitDetail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("saved detail = %+v, want aaa1", m.input.preSplitDetail)
+	}
+	startFollowGen := m.nextDetailFollowGen
+
+	m, cmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("empty results transition returned unexpected command %T", cmd)
+	}
+	if m.input.searchFocus != searchFocusResults {
+		t.Fatalf("searchFocus = %v, want results", m.input.searchFocus)
+	}
+	if m.detail.issue != nil {
+		t.Fatalf("empty results detail = %+v, want nil", m.detail.issue)
+	}
+	if delta := m.nextDetailFollowGen - startFollowGen; delta != 1 {
+		t.Fatalf("empty results follow generation advanced by %d, want 1 invalidation", delta)
+	}
+	if m.input.preSplitDetail == nil || m.input.preSplitDetail.issue == nil ||
+		m.input.preSplitDetail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("empty results lost saved detail: %+v", m.input.preSplitDetail)
+	}
+}
+
 func TestSplit_SearchResultsRefetchRetargetsChangedHighlight(t *testing.T) {
 	m, cleanup := splitSearchTransitionFixture(t)
 	defer cleanup()
@@ -576,8 +621,8 @@ func TestSplit_SearchCancelPrefersCompletedSnapshotOverStaleMatchingDetail(t *te
 	}
 
 	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
-	if cancelCmd != nil {
-		t.Fatalf("matching-snapshot cancel returned unexpected command %T", cancelCmd)
+	if cancelCmd == nil {
+		t.Fatal("matching-snapshot cancel returned no freshness refetch")
 	}
 	assertSelection(t, m, 0, "01TEST-aaa1")
 	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
@@ -721,8 +766,8 @@ func TestSplit_SearchCancelPreservesNewerMatchingLiveDetail(t *testing.T) {
 
 	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
 	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
-	if cancelCmd != nil {
-		t.Fatalf("matching-live cancel returned unexpected command %T", cancelCmd)
+	if cancelCmd == nil {
+		t.Fatal("matching-live cancel returned no freshness refetch")
 	}
 	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.gen != newerGen {
 		t.Fatalf("detail after cancel = %+v gen %d, want newer live aaa1 gen %d", m.detail.issue, m.detail.gen, newerGen)
@@ -736,6 +781,89 @@ func TestSplit_SearchCancelPreservesNewerMatchingLiveDetail(t *testing.T) {
 	m, _ = stepModel(m, detailFetchedMsg{gen: newerGen, issue: &newest})
 	if m.detail.issue == nil || m.detail.issue.Title != "newest live detail" || m.detail.loading {
 		t.Fatalf("newer response result = detail %+v loading %v, want newest/non-loading", m.detail.issue, m.detail.loading)
+	}
+}
+
+func TestSplit_SearchCancelMergesSnapshotMutationIntoNewerMatchingLiveDetail(t *testing.T) {
+	mutationErr := errors.New("mutation rejected")
+	tests := []struct {
+		name       string
+		mutation   mutationDoneMsg
+		wantStatus string
+		wantErr    error
+	}{
+		{
+			name: "failure",
+			mutation: mutationDoneMsg{
+				origin: "detail", gen: 41, kind: "close", err: mutationErr,
+			},
+			wantStatus: "close failed",
+			wantErr:    mutationErr,
+		},
+		{
+			name: "success",
+			mutation: mutationDoneMsg{
+				origin: "detail", gen: 41, kind: "close",
+				resp: &MutationResp{Issue: &Issue{
+					ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Status: "closed",
+				}},
+			},
+			wantStatus: "closed #aaa1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, cleanup := splitSearchTransitionFixture(t)
+			defer cleanup()
+			m.detail.gen = 41
+			m.nextGen = 41
+			m.input.preSplitDetail.gen = 41
+
+			m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+			if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+				t.Fatalf("target detail = %+v, want bbb2", m.detail.issue)
+			}
+			m, _ = stepModel(m, tc.mutation)
+			if m.input.preSplitDetail == nil ||
+				!strings.Contains(stripANSI(m.input.preSplitDetail.status), tc.wantStatus) {
+				t.Fatalf("saved mutation status = %q, want %q",
+					stripANSI(m.input.preSplitDetail.status), tc.wantStatus)
+			}
+
+			m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+			m, _ = stepModel(m, tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
+			for _, r := range "other" {
+				m, _ = stepModel(m, runeKey(r))
+			}
+			m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+			if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+				t.Fatalf("retargeted detail = %+v, want aaa1", m.detail.issue)
+			}
+			newerGen := m.detail.gen
+			if newerGen <= 41 {
+				t.Fatalf("retargeted detail generation = %d, want newer than 41", newerGen)
+			}
+
+			m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+			m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+			if cancelCmd == nil {
+				t.Fatal("matching-live cancel returned no freshness refetch")
+			}
+			batch, ok := cancelCmd().(tea.BatchMsg)
+			if !ok || len(batch) != 4 {
+				t.Fatalf("matching-live refetch = %T len %d, want four-command batch", batch, len(batch))
+			}
+			if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.gen != newerGen {
+				t.Fatalf("cancel detail = %+v gen %d, want aaa1/live gen %d", m.detail.issue, m.detail.gen, newerGen)
+			}
+			if got := stripANSI(m.detail.status); !strings.Contains(got, tc.wantStatus) {
+				t.Fatalf("cancel mutation status = %q, want %q", got, tc.wantStatus)
+			}
+			if !errors.Is(m.detail.err, tc.wantErr) {
+				t.Fatalf("cancel mutation err = %v, want %v", m.detail.err, tc.wantErr)
+			}
+		})
 	}
 }
 
@@ -851,8 +979,8 @@ func TestSplit_SearchCancelConvergesSnapshotWithSameGenerationMutation(t *testin
 			}
 
 			m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
-			if cancelCmd != nil {
-				t.Fatalf("matching-snapshot cancel returned unexpected command %T", cancelCmd)
+			if cancelCmd == nil {
+				t.Fatal("matching-snapshot cancel returned no freshness refetch")
 			}
 			if m.detail.issue == nil || m.detail.issue.Title != "completed snapshot" || m.detail.issue.Body != "fresh fetched body" {
 				t.Fatalf("restored fetched detail = %+v, want completed snapshot/fresh body", m.detail.issue)
@@ -969,8 +1097,8 @@ func TestSplit_SearchCancelRejectsOlderSameGenerationFetchResults(t *testing.T) 
 	}
 
 	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
-	if cancelCmd != nil {
-		t.Fatalf("matching-snapshot cancel returned unexpected command %T", cancelCmd)
+	if cancelCmd == nil {
+		t.Fatal("matching-snapshot cancel returned no freshness refetch")
 	}
 	if m.detail.issue == nil || m.detail.issue.Title != "newer issue response" {
 		t.Errorf("restored issue = %+v, want newer response", m.detail.issue)

--- a/internal/tui/split_test.go
+++ b/internal/tui/split_test.go
@@ -168,6 +168,47 @@ func TestSplit_SearchEnterWithNoResultsClearsDetail(t *testing.T) {
 	}
 }
 
+func TestStacked_SearchArrowNavigationDoesNotRetargetHiddenDetail(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "first row", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "second row", Status: "open"},
+	}
+	m.list.cursor = 0
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	seed := m.list.issues[0]
+	m.detail = detailModel{issue: &seed, scopePID: 7, gen: 41}
+	m.nextGen = m.detail.gen
+
+	m = openBarFromCmd(t, m, '/')
+	if m.input.preSplitDetailCaptured || m.input.preSplitDetail != nil {
+		t.Fatalf("stacked search captured split detail: %+v", m.input.preSplitDetail)
+	}
+	m, cmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyDown})
+	if cmd != nil {
+		t.Fatalf("stacked search arrow returned unexpected detail command %T", cmd)
+	}
+	if m.input.searchFocus != searchFocusResults || m.list.selectedUID != "01TEST-bbb2" {
+		t.Fatalf("stacked results focus/selection = %v/%q, want results/bbb2",
+			m.input.searchFocus, m.list.selectedUID)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.gen != 41 {
+		t.Fatalf("stacked hidden detail = %+v gen %d, want unchanged aaa1/gen 41", m.detail.issue, m.detail.gen)
+	}
+
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m.input.kind != inputNone || m.list.selectedUID != "01TEST-aaa1" {
+		t.Fatalf("stacked cancel input/selection = %v/%q, want none/aaa1", m.input.kind, m.list.selectedUID)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.gen != 41 {
+		t.Fatalf("stacked canceled detail = %+v gen %d, want unchanged aaa1/gen 41", m.detail.issue, m.detail.gen)
+	}
+}
+
 func TestSplit_SearchResultsRefetchRetargetsChangedHighlight(t *testing.T) {
 	m, cleanup := splitSearchTransitionFixture(t)
 	defer cleanup()
@@ -735,7 +776,25 @@ func TestSplit_SearchCancelPreservesNewerMatchingLiveDetail(t *testing.T) {
 	m.list.selectedUID = "01TEST-aaa1"
 	m.list.selectedProjectID = 7
 	seed := m.list.issues[0]
-	m.detail = detailModel{issue: &seed, scopePID: 7, gen: 41, loading: true}
+	childOne := Issue{ProjectID: 7, UID: "01TEST-ccc3", ShortID: "ccc3", Title: "child one", Status: "open"}
+	childTwo := Issue{ProjectID: 7, UID: "01TEST-ddd4", ShortID: "ddd4", Title: "child two", Status: "open"}
+	navIssue := Issue{ProjectID: 7, UID: "01TEST-nnn5", ShortID: "nnn5", Title: "prior nav", Status: "open"}
+	m.detail = detailModel{
+		issue:       &seed,
+		children:    []Issue{childOne, childTwo},
+		detailFocus: focusChildren,
+		loading:     true,
+		gen:         41,
+		activeTab:   tabLinks,
+		scroll:      7,
+		tabCursor:   2,
+		childCursor: 1,
+		navStack: []detailModel{{
+			issue: &navIssue, scopePID: 7, gen: 40,
+		}},
+		scopePID:    7,
+		tabExplicit: true,
+	}
 	m.nextGen = m.detail.gen
 
 	m = openBarFromCmd(t, m, '/')
@@ -746,7 +805,9 @@ func TestSplit_SearchCancelPreservesNewerMatchingLiveDetail(t *testing.T) {
 
 	completed := m.list.issues[0]
 	completed.Title = "older completed snapshot"
-	m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &completed})
+	m, _ = stepModel(m, detailFetchedMsg{
+		gen: 41, issue: &completed, children: []Issue{childOne, childTwo},
+	})
 
 	m, toTargetCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
 	if toTargetCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
@@ -763,6 +824,14 @@ func TestSplit_SearchCancelPreservesNewerMatchingLiveDetail(t *testing.T) {
 	if newerGen <= 41 {
 		t.Fatalf("new live detail generation = %d, want newer than snapshot generation 41", newerGen)
 	}
+	newest := m.list.issues[0]
+	newest.Title = "newest live detail"
+	m, _ = stepModel(m, detailFetchedMsg{
+		gen: newerGen, issue: &newest, children: []Issue{childOne, childTwo},
+	})
+	m, _ = stepModel(m, commentsFetchedMsg{
+		gen: newerGen, comments: []CommentEntry{{ID: 9, Body: "newest live comment"}},
+	})
 
 	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
 	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
@@ -772,15 +841,19 @@ func TestSplit_SearchCancelPreservesNewerMatchingLiveDetail(t *testing.T) {
 	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.gen != newerGen {
 		t.Fatalf("detail after cancel = %+v gen %d, want newer live aaa1 gen %d", m.detail.issue, m.detail.gen, newerGen)
 	}
-	if m.detail.issue.Title != "loading detail" {
-		t.Fatalf("detail title after cancel = %q, want newer live shell", m.detail.issue.Title)
+	if m.detail.issue.Title != "newest live detail" || len(m.detail.comments) != 1 ||
+		m.detail.comments[0].Body != "newest live comment" {
+		t.Fatalf("detail content after cancel = %+v comments %+v, want newest live data", m.detail.issue, m.detail.comments)
 	}
-
-	newest := m.list.issues[0]
-	newest.Title = "newest live detail"
-	m, _ = stepModel(m, detailFetchedMsg{gen: newerGen, issue: &newest})
-	if m.detail.issue == nil || m.detail.issue.Title != "newest live detail" || m.detail.loading {
-		t.Fatalf("newer response result = detail %+v loading %v, want newest/non-loading", m.detail.issue, m.detail.loading)
+	if m.detail.detailFocus != focusChildren || m.detail.activeTab != tabLinks ||
+		m.detail.scroll != 7 || m.detail.tabCursor != 2 || m.detail.childCursor != 1 || !m.detail.tabExplicit {
+		t.Fatalf("restored presentation = focus %v tab %v scroll %d cursors %d/%d explicit %v",
+			m.detail.detailFocus, m.detail.activeTab, m.detail.scroll,
+			m.detail.tabCursor, m.detail.childCursor, m.detail.tabExplicit)
+	}
+	if len(m.detail.navStack) != 1 || m.detail.navStack[0].issue == nil ||
+		m.detail.navStack[0].issue.UID != "01TEST-nnn5" {
+		t.Fatalf("restored navigation stack = %+v, want prior nav issue", m.detail.navStack)
 	}
 }
 

--- a/internal/tui/split_test.go
+++ b/internal/tui/split_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -73,6 +74,997 @@ func TestSplit_CursorMoveRetargetsDetail(t *testing.T) {
 	}
 	if m.list.cursor != 2 {
 		t.Errorf("list.cursor = %d, want 2", m.list.cursor)
+	}
+}
+
+func splitSearchTransitionFixture(t *testing.T) (Model, func()) {
+	t.Helper()
+	m, cleanup := splitTestSetup(t)
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other row", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.cursor = 0
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	first := m.list.issues[0]
+	m.detail.issue = &first
+	m.detail.scopePID = 7
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	if highlighted, ok := pickHighlightedIssue(m.list); !ok || highlighted.UID != "01TEST-bbb2" {
+		t.Fatalf("highlighted issue = (%+v, %v), want bbb2", highlighted, ok)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("detail issue = %+v, want pre-filter aaa1", m.detail.issue)
+	}
+	return m, cleanup
+}
+
+func TestSplit_SearchEnterRetargetsDetailToFilteredResult(t *testing.T) {
+	m, cleanup := splitSearchTransitionFixture(t)
+	defer cleanup()
+	startGen := m.nextDetailFollowGen
+
+	m, cmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.input.searchFocus != searchFocusResults {
+		t.Fatalf("searchFocus = %v, want results", m.input.searchFocus)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("detail issue = %+v, want filtered bbb2", m.detail.issue)
+	}
+	if cmd == nil {
+		t.Fatal("Enter transition returned no detail-follow command")
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 1 {
+		t.Fatalf("detail follow gen advanced by %d, want 1", delta)
+	}
+}
+
+func TestSplit_SearchCancelRetargetsDetailToRestoredSelection(t *testing.T) {
+	m, cleanup := splitSearchTransitionFixture(t)
+	defer cleanup()
+	startGen := m.nextDetailFollowGen
+
+	m, enterCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if enterCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("results transition = detail %+v cmd %T, want bbb2 and follow", m.detail.issue, enterCmd)
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 1 {
+		t.Fatalf("results follow gen advanced by %d, want 1", delta)
+	}
+
+	m, firstEscCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if firstEscCmd != nil || m.input.searchFocus != searchFocusQuery {
+		t.Fatalf("first Esc = focus %v cmd %T, want query/nil", m.input.searchFocus, firstEscCmd)
+	}
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m.input.kind != inputNone {
+		t.Fatalf("second Esc left input kind %v open", m.input.kind)
+	}
+	assertSelection(t, m, 0, "01TEST-aaa1")
+	if m.list.selectedProjectID != 7 {
+		t.Fatalf("selectedProjectID = %d, want 7", m.list.selectedProjectID)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("restored detail issue = %+v, want aaa1", m.detail.issue)
+	}
+	if cancelCmd == nil {
+		t.Fatal("second Esc returned no restored-selection follow command")
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 2 {
+		t.Fatalf("total follow gen advanced by %d, want 2", delta)
+	}
+
+	m, _ = stepModel(m, refetchedMsg{
+		dispatchKey: m.currentCacheKey(),
+		issues: []Issue{
+			{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other row", Status: "open"},
+			{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+		},
+	})
+	assertSelection(t, m, 0, "01TEST-aaa1")
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("detail after refetch = %+v, want aaa1", m.detail.issue)
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 2 {
+		t.Fatalf("refetch added follow generation: delta %d, want 2", delta)
+	}
+}
+
+func TestSplit_SearchCancelWhileStackedRestoresHiddenDetail(t *testing.T) {
+	m, cleanup := splitSearchTransitionFixture(t)
+	defer cleanup()
+	startGen := m.nextDetailFollowGen
+
+	m, enterCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if enterCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("results transition = detail %+v cmd %T, want bbb2 and follow", m.detail.issue, enterCmd)
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 1 {
+		t.Fatalf("results follow gen advanced by %d, want 1", delta)
+	}
+
+	m, resizeCmd := updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	if m.layout != layoutStacked {
+		t.Fatalf("layout after narrow resize = %v, want stacked", m.layout)
+	}
+	if resizeCmd != nil {
+		t.Fatalf("split-to-stacked resize returned unexpected command %T", resizeCmd)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("hidden detail after narrow resize = %+v, want bbb2", m.detail.issue)
+	}
+
+	m, firstEscCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if firstEscCmd != nil || m.input.searchFocus != searchFocusQuery {
+		t.Fatalf("first Esc = focus %v cmd %T, want query/nil", m.input.searchFocus, firstEscCmd)
+	}
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m.input.kind != inputNone {
+		t.Fatalf("second Esc left input kind %v open", m.input.kind)
+	}
+	assertSelection(t, m, 0, "01TEST-aaa1")
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("restored hidden detail issue = %+v, want aaa1", m.detail.issue)
+	}
+	if cancelCmd == nil {
+		t.Fatal("second Esc returned no restored-selection follow command")
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 2 {
+		t.Fatalf("total follow gen advanced by %d, want 2", delta)
+	}
+
+	m, widenCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if m.layout != layoutSplit {
+		t.Fatalf("layout after wide resize = %v, want split", m.layout)
+	}
+	if widenCmd != nil {
+		t.Fatalf("stacked-to-split resize returned duplicate follow command %T", widenCmd)
+	}
+	assertSelection(t, m, 0, "01TEST-aaa1")
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("detail after returning to split = %+v, want aaa1", m.detail.issue)
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 2 {
+		t.Fatalf("wide resize added follow generation: delta %d, want 2", delta)
+	}
+}
+
+func TestSplit_SearchCancelRestoresDetailWhenPreFilterHasNoRows(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "original detail", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.filter.Search = "no-match-anywhere"
+	m.list = m.list.clampCursorToFilter()
+	m.list = m.list.syncSelection(m.list.visibleRows())
+	if rows := m.list.visibleRows(); len(rows) != 0 {
+		t.Fatalf("pre-search visible rows = %d, want 0", len(rows))
+	}
+	original := m.list.issues[0]
+	original.Labels = []string{"keep"}
+	m.detail = detailModel{
+		issue:     &original,
+		scopePID:  7,
+		gen:       41,
+		activeTab: tabEvents,
+		comments:  []CommentEntry{{ID: 1, Body: "original comment"}},
+		events: []EventLogEntry{{
+			ID:      2,
+			Payload: map[string]any{"state": "original"},
+		}},
+	}
+	m.nextGen = m.detail.gen
+	startFollowGen := m.nextDetailFollowGen
+
+	m = openBarFromCmd(t, m, '/')
+	// Mutating the live model after open must not mutate the saved pre-search
+	// detail through shared pointers, slices, or maps.
+	m.detail.issue.Labels[0] = "changed"
+	m.detail.comments[0].Body = "changed comment"
+	m.detail.events[0].Payload["state"] = "changed"
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	if highlighted, ok := pickHighlightedIssue(m.list); !ok || highlighted.UID != "01TEST-bbb2" {
+		t.Fatalf("highlighted issue = (%+v, %v), want bbb2", highlighted, ok)
+	}
+	m, enterCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if enterCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("results transition = detail %+v cmd %T, want bbb2 and follow", m.detail.issue, enterCmd)
+	}
+	pendingFollowGen := m.nextDetailFollowGen
+	if delta := pendingFollowGen - startFollowGen; delta != 1 {
+		t.Fatalf("results follow gen advanced by %d, want 1", delta)
+	}
+
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd != nil {
+		t.Fatalf("empty-list cancel returned unexpected follow command %T", cancelCmd)
+	}
+	if m.input.kind != inputNone || m.list.filter.Search != "no-match-anywhere" {
+		t.Fatalf("cancel state = input %v search %q, want none/no-match-anywhere", m.input.kind, m.list.filter.Search)
+	}
+	if rows := m.list.visibleRows(); len(rows) != 0 {
+		t.Fatalf("restored visible rows = %d, want 0", len(rows))
+	}
+	if m.list.selectedUID != "" || m.list.selectedProjectID != 0 {
+		t.Fatalf("restored selection = %q/%d, want empty", m.list.selectedUID, m.list.selectedProjectID)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("restored hidden detail = %+v, want aaa1", m.detail.issue)
+	}
+	if got := m.detail.issue.Labels; len(got) != 1 || got[0] != "keep" {
+		t.Fatalf("restored labels = %v, want [keep]", got)
+	}
+	if got := m.detail.comments; len(got) != 1 || got[0].Body != "original comment" {
+		t.Fatalf("restored comments = %+v, want original comment", got)
+	}
+	if got := m.detail.events[0].Payload["state"]; got != "original" {
+		t.Fatalf("restored event state = %v, want original", got)
+	}
+	if m.detail.gen != 41 || m.detail.activeTab != tabEvents {
+		t.Fatalf("restored detail state = gen %d tab %v, want 41/events", m.detail.gen, m.detail.activeTab)
+	}
+	if delta := m.nextDetailFollowGen - startFollowGen; delta != 2 {
+		t.Fatalf("cancel invalidation advanced total follow gen by %d, want 2", delta)
+	}
+
+	m, staleCmd := stepModel(m, detailFollowTickMsg{gen: pendingFollowGen})
+	if staleCmd != nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("stale follow = detail %+v cmd %T, want aaa1/nil", m.detail.issue, staleCmd)
+	}
+	m, _ = stepModel(m, refetchedMsg{
+		dispatchKey: m.currentCacheKey(),
+		issues: []Issue{
+			{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "original detail", Status: "open"},
+			{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+		},
+	})
+	if rows := m.list.visibleRows(); len(rows) != 0 {
+		t.Fatalf("visible rows after refetch = %d, want 0", len(rows))
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("detail after refetch = %+v, want aaa1", m.detail.issue)
+	}
+	m, widenCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if widenCmd != nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("final split resize = detail %+v cmd %T, want aaa1/nil", m.detail.issue, widenCmd)
+	}
+}
+
+func TestSplit_SearchCancelDoesNotCaptureSearchCreatedDetailAfterResize(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other row", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.filter.Search = "no-match-anywhere"
+	m.list = m.list.clampCursorToFilter()
+	m.list = m.list.syncSelection(m.list.visibleRows())
+	m.detail = newDetailModel()
+	startFollowGen := m.nextDetailFollowGen
+
+	m = openBarFromCmd(t, m, '/')
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, enterCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if enterCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("results transition = detail %+v cmd %T, want bbb2 and follow", m.detail.issue, enterCmd)
+	}
+
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m, widenCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if widenCmd != nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("search-owned split roundtrip = detail %+v cmd %T, want bbb2/nil", m.detail.issue, widenCmd)
+	}
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd != nil {
+		t.Fatalf("empty-list cancel returned unexpected command %T", cancelCmd)
+	}
+	if rows := m.list.visibleRows(); len(rows) != 0 {
+		t.Fatalf("restored visible rows = %d, want 0", len(rows))
+	}
+	if m.detail.issue != nil {
+		t.Fatalf("restored detail = %+v, want nil pre-search detail", m.detail.issue)
+	}
+	if delta := m.nextDetailFollowGen - startFollowGen; delta != 2 {
+		t.Fatalf("total follow gen advanced by %d, want 2", delta)
+	}
+
+	m, finalWidenCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if finalWidenCmd != nil || m.detail.issue != nil {
+		t.Fatalf("final split resize = detail %+v cmd %T, want nil/nil", m.detail.issue, finalWidenCmd)
+	}
+}
+
+func TestSplit_SearchDetailSnapshotTracksAsyncCompletion(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "loading detail", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.filter.Search = "no-match-anywhere"
+	m.list = m.list.clampCursorToFilter()
+	m.list = m.list.syncSelection(m.list.visibleRows())
+	seed := m.list.issues[0]
+	m.detail = detailModel{
+		issue:           &seed,
+		scopePID:        7,
+		gen:             41,
+		loading:         true,
+		commentsLoading: true,
+		eventsLoading:   true,
+	}
+	m.nextGen = m.detail.gen
+
+	m = openBarFromCmd(t, m, '/')
+	completed := m.list.issues[0]
+	completed.Title = "completed detail"
+	completed.Body = "fresh body"
+	m, _ = stepModel(m, detailFetchedMsg{
+		gen:      41,
+		issue:    &completed,
+		parent:   &IssueRef{UID: "01TEST-ppp3", ShortID: "ppp3", Title: "parent", Status: "open"},
+		children: []Issue{{ProjectID: 7, UID: "01TEST-ccc3", ShortID: "ccc3", Title: "child", Status: "open"}},
+	})
+	m, _ = stepModel(m, commentsFetchedMsg{
+		gen:      41,
+		comments: []CommentEntry{{ID: 1, Body: "fresh comment"}},
+	})
+	eventsErr := errors.New("events temporarily unavailable")
+	m, _ = stepModel(m, eventsFetchedMsg{gen: 41, err: eventsErr})
+	if m.detail.loading || m.detail.commentsLoading || m.detail.eventsLoading {
+		t.Fatalf("live completion loading flags = %v/%v/%v, want false", m.detail.loading, m.detail.commentsLoading, m.detail.eventsLoading)
+	}
+
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("results detail = %+v, want bbb2", m.detail.issue)
+	}
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("restored detail = %+v, want aaa1", m.detail.issue)
+	}
+	if m.detail.issue.Title != "completed detail" || m.detail.issue.Body != "fresh body" {
+		t.Fatalf("restored issue = %+v, want completed detail/fresh body", m.detail.issue)
+	}
+	if m.detail.loading || m.detail.commentsLoading || m.detail.eventsLoading {
+		t.Fatalf("restored loading flags = %v/%v/%v, want false", m.detail.loading, m.detail.commentsLoading, m.detail.eventsLoading)
+	}
+	if m.detail.parent == nil || m.detail.parent.UID != "01TEST-ppp3" || len(m.detail.children) != 1 {
+		t.Fatalf("restored relationships = parent %+v children %+v", m.detail.parent, m.detail.children)
+	}
+	if len(m.detail.comments) != 1 || m.detail.comments[0].Body != "fresh comment" {
+		t.Fatalf("restored comments = %+v, want fresh comment", m.detail.comments)
+	}
+	if !errors.Is(m.detail.eventsErr, eventsErr) {
+		t.Fatalf("restored events error = %v, want %v", m.detail.eventsErr, eventsErr)
+	}
+}
+
+func TestSplit_SearchCancelPrefersCompletedSnapshotOverStaleMatchingDetail(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "loading detail", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.cursor = 0
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	seed := m.list.issues[0]
+	m.detail = detailModel{
+		issue:           &seed,
+		scopePID:        7,
+		gen:             41,
+		loading:         true,
+		commentsLoading: true,
+	}
+	m.nextGen = m.detail.gen
+	startFollowGen := m.nextDetailFollowGen
+
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	if highlighted, ok := pickHighlightedIssue(m.list); !ok || highlighted.UID != "01TEST-bbb2" {
+		t.Fatalf("highlighted issue = (%+v, %v), want bbb2", highlighted, ok)
+	}
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	completed := m.list.issues[0]
+	completed.Title = "completed detail"
+	completed.Body = "fresh body"
+	m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &completed})
+	commentsErr := errors.New("comments temporarily unavailable")
+	m, _ = stepModel(m, commentsFetchedMsg{gen: 41, err: commentsErr})
+	if m.detail.issue == nil || m.detail.issue.Title != "loading detail" || !m.detail.loading || !m.detail.commentsLoading {
+		t.Fatalf("hidden live detail unexpectedly converged: %+v loading %v/%v", m.detail.issue, m.detail.loading, m.detail.commentsLoading)
+	}
+
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd != nil {
+		t.Fatalf("matching-snapshot cancel returned unexpected command %T", cancelCmd)
+	}
+	assertSelection(t, m, 0, "01TEST-aaa1")
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("restored detail = %+v, want aaa1", m.detail.issue)
+	}
+	if m.detail.issue.Title != "completed detail" || m.detail.issue.Body != "fresh body" {
+		t.Fatalf("restored issue = %+v, want completed detail/fresh body", m.detail.issue)
+	}
+	if m.detail.loading || m.detail.commentsLoading {
+		t.Fatalf("restored loading flags = %v/%v, want false", m.detail.loading, m.detail.commentsLoading)
+	}
+	if !errors.Is(m.detail.commentsErr, commentsErr) {
+		t.Fatalf("restored comments error = %v, want %v", m.detail.commentsErr, commentsErr)
+	}
+	if delta := m.nextDetailFollowGen - startFollowGen; delta != 0 {
+		t.Fatalf("cancel advanced follow gen by %d, want 0", delta)
+	}
+
+	m, widenCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if widenCmd != nil {
+		t.Fatalf("final split resize returned unexpected command %T", widenCmd)
+	}
+	if m.detail.issue == nil || m.detail.issue.Title != "completed detail" || m.detail.loading {
+		t.Fatalf("final split detail = %+v loading %v, want completed/non-loading", m.detail.issue, m.detail.loading)
+	}
+	if delta := m.nextDetailFollowGen - startFollowGen; delta != 0 {
+		t.Fatalf("final resize advanced follow gen by %d, want 0", delta)
+	}
+}
+
+func TestSplit_SearchCancelPreservesNewerMatchingLiveDetail(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "loading detail", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.cursor = 0
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	seed := m.list.issues[0]
+	m.detail = detailModel{issue: &seed, scopePID: 7, gen: 41, loading: true}
+	m.nextGen = m.detail.gen
+
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	completed := m.list.issues[0]
+	completed.Title = "older completed snapshot"
+	m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &completed})
+	if !m.input.preSplitDetailAhead {
+		t.Fatal("stacked fetch did not mark saved detail ahead")
+	}
+
+	m, toTargetCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if toTargetCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("split transition = detail %+v cmd %T, want bbb2 and follow", m.detail.issue, toTargetCmd)
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
+	m, toOriginalCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if toOriginalCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("original transition = detail %+v cmd %T, want aaa1 and follow", m.detail.issue, toOriginalCmd)
+	}
+	newerGen := m.detail.gen
+	if newerGen <= 41 {
+		t.Fatalf("new live detail generation = %d, want newer than snapshot generation 41", newerGen)
+	}
+
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd != nil {
+		t.Fatalf("matching-live cancel returned unexpected command %T", cancelCmd)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.gen != newerGen {
+		t.Fatalf("detail after cancel = %+v gen %d, want newer live aaa1 gen %d", m.detail.issue, m.detail.gen, newerGen)
+	}
+	if m.detail.issue.Title != "loading detail" {
+		t.Fatalf("detail title after cancel = %q, want newer live shell", m.detail.issue.Title)
+	}
+
+	newest := m.list.issues[0]
+	newest.Title = "newest live detail"
+	m, _ = stepModel(m, detailFetchedMsg{gen: newerGen, issue: &newest})
+	if m.detail.issue == nil || m.detail.issue.Title != "newest live detail" || m.detail.loading {
+		t.Fatalf("newer response result = detail %+v loading %v, want newest/non-loading", m.detail.issue, m.detail.loading)
+	}
+}
+
+func TestSplit_SearchCancelSnapshotInvalidatesDifferentLiveFollow(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "loading detail", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.cursor = 0
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	seed := m.list.issues[0]
+	m.detail = detailModel{issue: &seed, scopePID: 7, gen: 41, loading: true}
+	m.nextGen = m.detail.gen
+	startFollowGen := m.nextDetailFollowGen
+
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	completed := m.list.issues[0]
+	completed.Title = "completed snapshot"
+	m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &completed})
+
+	m, followCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if followCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("split transition = detail %+v cmd %T, want bbb2 and follow", m.detail.issue, followCmd)
+	}
+	pendingFollowGen := m.nextDetailFollowGen
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd != nil {
+		t.Fatalf("snapshot cancel returned unexpected command %T", cancelCmd)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.issue.Title != "completed snapshot" || m.detail.loading {
+		t.Fatalf("restored snapshot = detail %+v loading %v, want completed aaa1", m.detail.issue, m.detail.loading)
+	}
+	if delta := m.nextDetailFollowGen - startFollowGen; delta != 2 {
+		t.Fatalf("follow generation advanced by %d, want target follow plus snapshot invalidation", delta)
+	}
+
+	m, staleCmd := stepModel(m, detailFollowTickMsg{gen: pendingFollowGen})
+	if staleCmd != nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("stale follow = detail %+v cmd %T, want restored aaa1/nil", m.detail.issue, staleCmd)
+	}
+}
+
+func TestSplit_SearchCancelConvergesSnapshotWithSameGenerationMutation(t *testing.T) {
+	mutationErr := errors.New("mutation rejected")
+	tests := []struct {
+		name       string
+		mutation   mutationDoneMsg
+		wantStatus string
+		wantErr    error
+	}{
+		{
+			name: "failure",
+			mutation: mutationDoneMsg{
+				origin: "detail", gen: 41, kind: "close", err: mutationErr,
+			},
+			wantStatus: "close failed",
+			wantErr:    mutationErr,
+		},
+		{
+			name: "success",
+			mutation: mutationDoneMsg{
+				origin: "detail", gen: 41, kind: "close",
+				resp: &MutationResp{Issue: &Issue{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Status: "closed"}},
+			},
+			wantStatus: "closed #aaa1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, cleanup := splitTestSetup(t)
+			defer cleanup()
+			m.list.issues = []Issue{
+				{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "loading detail", Status: "open"},
+				{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+			}
+			m.list.cursor = 0
+			m.list.selectedUID = "01TEST-aaa1"
+			m.list.selectedProjectID = 7
+			seed := m.list.issues[0]
+			m.detail = detailModel{issue: &seed, scopePID: 7, gen: 41, loading: true}
+			m.nextGen = m.detail.gen
+
+			m = openBarFromCmd(t, m, '/')
+			for _, r := range "target" {
+				m, _ = stepModel(m, runeKey(r))
+			}
+			m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+
+			completed := m.list.issues[0]
+			completed.Title = "completed snapshot"
+			completed.Body = "fresh fetched body"
+			m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &completed})
+			if !m.input.preSplitDetailAhead {
+				t.Fatal("stacked fetch did not mark saved detail ahead")
+			}
+
+			m, mutationCmd := stepModel(m, tc.mutation)
+			if !strings.Contains(stripANSI(m.detail.status), tc.wantStatus) {
+				t.Fatalf("live mutation status = %q, want %q", stripANSI(m.detail.status), tc.wantStatus)
+			}
+			if tc.wantErr != nil && mutationCmd != nil {
+				t.Fatalf("failed mutation returned unexpected command %T", mutationCmd)
+			}
+			if tc.wantErr == nil && mutationCmd == nil {
+				t.Fatal("successful mutation returned no refetch command")
+			}
+
+			m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+			if cancelCmd != nil {
+				t.Fatalf("matching-snapshot cancel returned unexpected command %T", cancelCmd)
+			}
+			if m.detail.issue == nil || m.detail.issue.Title != "completed snapshot" || m.detail.issue.Body != "fresh fetched body" {
+				t.Fatalf("restored fetched detail = %+v, want completed snapshot/fresh body", m.detail.issue)
+			}
+			if !strings.Contains(stripANSI(m.detail.status), tc.wantStatus) {
+				t.Fatalf("restored mutation status = %q, want %q", stripANSI(m.detail.status), tc.wantStatus)
+			}
+			if !errors.Is(m.detail.err, tc.wantErr) {
+				t.Fatalf("restored mutation err = %v, want %v", m.detail.err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSplit_SearchRetargetMutationRefetchesSavedDetail(t *testing.T) {
+	m, cleanup := splitSearchTransitionFixture(t)
+	defer cleanup()
+	m.detail.gen = 41
+	m.nextGen = 41
+	m.input.preSplitDetail.gen = 41
+
+	m, followCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if followCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("results transition = detail %+v cmd %T, want bbb2/follow", m.detail.issue, followCmd)
+	}
+
+	mutation := mutationDoneMsg{
+		origin: "detail",
+		gen:    41,
+		kind:   "close",
+		resp: &MutationResp{Issue: &Issue{
+			ProjectID: 7,
+			UID:       "01TEST-aaa1",
+			ShortID:   "aaa1",
+			Title:     "other row",
+			Status:    "closed",
+		}},
+	}
+	m, mutationCmd := stepModel(m, mutation)
+	if mutationCmd == nil {
+		t.Fatal("snapshot-only mutation returned no detail refetch command")
+	}
+	batch, ok := mutationCmd().(tea.BatchMsg)
+	if !ok || len(batch) != 4 {
+		t.Fatalf("snapshot refetch = %T len %d, want four-command batch", batch, len(batch))
+	}
+
+	closed := Issue{
+		ProjectID: 7,
+		UID:       "01TEST-aaa1",
+		ShortID:   "aaa1",
+		Title:     "other row",
+		Status:    "closed",
+	}
+	m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &closed})
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd != nil {
+		t.Fatalf("cancel returned unexpected command %T", cancelCmd)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.issue.Status != "closed" {
+		t.Fatalf("restored detail = %+v, want refreshed closed aaa1", m.detail.issue)
+	}
+	if got := stripANSI(m.detail.status); !strings.Contains(got, "closed #aaa1") {
+		t.Fatalf("restored mutation status = %q, want close confirmation", got)
+	}
+}
+
+func TestSplit_SearchCancelRejectsOlderSameGenerationFetchResults(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "initial detail", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.cursor = 0
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	seed := m.list.issues[0]
+	m.detail = detailModel{issue: &seed, scopePID: 7, gen: 41}
+	m.nextGen = m.detail.gen
+
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+
+	oldAPI := &fakeDetailAPI{
+		getIssueResult: &Issue{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "older issue response", Status: "open"},
+		commentsResult: []CommentEntry{{ID: 1, Body: "older comment response"}},
+	}
+	newAPI := &fakeDetailAPI{
+		getIssueResult: &Issue{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "newer issue response", Status: "open"},
+		commentsResult: []CommentEntry{{ID: 2, Body: "newer comment response"}},
+	}
+	oldIssueCmd := fetchIssue(oldAPI, 7, "aaa1", 41)
+	oldCommentsCmd := fetchComments(oldAPI, 7, "aaa1", 41)
+	newIssueCmd := fetchIssue(newAPI, 7, "aaa1", 41)
+	newCommentsCmd := fetchComments(newAPI, 7, "aaa1", 41)
+
+	m, _ = stepModel(m, newIssueCmd())
+	m, _ = stepModel(m, newCommentsCmd())
+	if m.detail.issue == nil || m.detail.issue.Title != "newer issue response" ||
+		len(m.detail.comments) != 1 || m.detail.comments[0].Body != "newer comment response" {
+		t.Fatalf("newer split responses = detail %+v comments %+v", m.detail.issue, m.detail.comments)
+	}
+
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m, _ = stepModel(m, oldIssueCmd())
+	m, _ = stepModel(m, oldCommentsCmd())
+	if m.detail.issue == nil || m.detail.issue.Title != "newer issue response" ||
+		len(m.detail.comments) != 1 || m.detail.comments[0].Body != "newer comment response" {
+		t.Fatalf("hidden live detail changed = detail %+v comments %+v", m.detail.issue, m.detail.comments)
+	}
+
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd != nil {
+		t.Fatalf("matching-snapshot cancel returned unexpected command %T", cancelCmd)
+	}
+	if m.detail.issue == nil || m.detail.issue.Title != "newer issue response" {
+		t.Errorf("restored issue = %+v, want newer response", m.detail.issue)
+	}
+	if len(m.detail.comments) != 1 || m.detail.comments[0].Body != "newer comment response" {
+		t.Errorf("restored comments = %+v, want newer response", m.detail.comments)
+	}
+}
+
+func TestSplit_SearchSnapshotRejectsOlderFetchAfterLiveRetarget(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "initial detail", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.cursor = 0
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	seed := m.list.issues[0]
+	m.detail = detailModel{issue: &seed, scopePID: 7, gen: 41}
+	m.nextGen = m.detail.gen
+
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	oldAPI := &fakeDetailAPI{
+		getIssueResult: &Issue{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "older issue response", Status: "open"},
+		commentsResult: []CommentEntry{{ID: 1, Body: "older comment response"}},
+	}
+	newAPI := &fakeDetailAPI{
+		getIssueResult: &Issue{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "newer issue response", Status: "open"},
+		commentsResult: []CommentEntry{{ID: 2, Body: "newer comment response"}},
+	}
+	oldIssueCmd := fetchIssue(oldAPI, 7, "aaa1", 41)
+	oldCommentsCmd := fetchComments(oldAPI, 7, "aaa1", 41)
+	newIssueCmd := fetchIssue(newAPI, 7, "aaa1", 41)
+	newCommentsCmd := fetchComments(newAPI, 7, "aaa1", 41)
+
+	m, followCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if followCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("live retarget = detail %+v cmd %T, want bbb2/follow", m.detail.issue, followCmd)
+	}
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m, _ = stepModel(m, newIssueCmd())
+	m, _ = stepModel(m, newCommentsCmd())
+	if !m.input.preSplitDetailAhead {
+		t.Fatal("newer snapshot-only responses did not mark saved detail ahead")
+	}
+	m, _ = stepModel(m, oldIssueCmd())
+	m, _ = stepModel(m, oldCommentsCmd())
+
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd != nil {
+		t.Fatalf("snapshot cancel returned unexpected command %T", cancelCmd)
+	}
+	if m.detail.issue == nil || m.detail.issue.Title != "newer issue response" {
+		t.Errorf("restored issue = %+v, want newer response", m.detail.issue)
+	}
+	if len(m.detail.comments) != 1 || m.detail.comments[0].Body != "newer comment response" {
+		t.Errorf("restored comments = %+v, want newer response", m.detail.comments)
+	}
+}
+
+func stackedSearchTransitionFixture(t *testing.T) (Model, func()) {
+	t.Helper()
+	t.Setenv("KATA_COLOR_MODE", "none")
+	t.Setenv("NO_COLOR", "")
+	applyDefaultColorMode()
+
+	m := initialModel(Options{})
+	m.api = &Client{}
+	m.scope = scope{projectID: 7, projectName: "example-project"}
+	m.list.loading = false
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other row", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	if m.layout != layoutStacked || m.detail.issue != nil {
+		t.Fatalf("stacked setup = layout %v detail %+v, want stacked/nil", m.layout, m.detail.issue)
+	}
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	if highlighted, ok := pickHighlightedIssue(m.list); !ok || highlighted.UID != "01TEST-bbb2" {
+		t.Fatalf("highlighted issue = (%+v, %v), want bbb2", highlighted, ok)
+	}
+	return m, func() { applyDefaultColorMode() }
+}
+
+func TestStacked_SearchResizeIntoSplitThenCancelRestoresDetail(t *testing.T) {
+	m, cleanup := stackedSearchTransitionFixture(t)
+	defer cleanup()
+	startGen := m.nextDetailFollowGen
+
+	m, widenCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if m.layout != layoutSplit {
+		t.Fatalf("layout after wide resize = %v, want split", m.layout)
+	}
+	if widenCmd == nil {
+		t.Fatal("stacked-to-split resize returned no bootstrap follow command")
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("bootstrapped detail after wide resize = %+v, want bbb2", m.detail.issue)
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 1 {
+		t.Fatalf("bootstrap follow gen advanced by %d, want 1", delta)
+	}
+
+	m, narrowCmd := updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	if m.layout != layoutStacked {
+		t.Fatalf("layout after narrow resize = %v, want stacked", m.layout)
+	}
+	if narrowCmd != nil {
+		t.Fatalf("split-to-stacked resize returned unexpected command %T", narrowCmd)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("hidden detail after narrow resize = %+v, want bbb2", m.detail.issue)
+	}
+
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m.input.kind != inputNone {
+		t.Fatalf("Esc left input kind %v open", m.input.kind)
+	}
+	assertSelection(t, m, 0, "01TEST-aaa1")
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("restored hidden detail issue = %+v, want aaa1", m.detail.issue)
+	}
+	if cancelCmd == nil {
+		t.Fatal("Esc returned no restored-selection follow command")
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 2 {
+		t.Fatalf("total follow gen advanced by %d, want 2", delta)
+	}
+
+	m, finalWidenCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if m.layout != layoutSplit {
+		t.Fatalf("final layout after wide resize = %v, want split", m.layout)
+	}
+	if finalWidenCmd != nil {
+		t.Fatalf("final stacked-to-split resize returned duplicate follow command %T", finalWidenCmd)
+	}
+	assertSelection(t, m, 0, "01TEST-aaa1")
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("detail after returning to split = %+v, want aaa1", m.detail.issue)
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 2 {
+		t.Fatalf("final resize added follow generation: delta %d, want 2", delta)
+	}
+}
+
+func TestStacked_SearchResizeIntoSplitRetargetsInheritedDetail(t *testing.T) {
+	t.Setenv("KATA_COLOR_MODE", "none")
+	t.Setenv("NO_COLOR", "")
+	applyDefaultColorMode()
+	defer applyDefaultColorMode()
+
+	m := initialModel(Options{})
+	m.api = &Client{}
+	m.scope = scope{projectID: 7, projectName: "example-project"}
+	m.list.loading = false
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other row", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	inherited := m.list.issues[0]
+	m.detail = detailModel{issue: &inherited, scopePID: 7, gen: 41}
+	m.nextGen = 41
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+
+	m, widenCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
+	if m.layout != layoutSplit {
+		t.Fatalf("layout after widen = %v, want split", m.layout)
+	}
+	if widenCmd == nil {
+		t.Fatal("active-search widen returned no detail-follow command")
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("detail after widen = %+v, want highlighted bbb2", m.detail.issue)
+	}
+	if m.input.preSplitDetail == nil || m.input.preSplitDetail.issue == nil ||
+		m.input.preSplitDetail.issue.UID != "01TEST-aaa1" {
+		t.Fatalf("captured inherited detail = %+v, want aaa1", m.input.preSplitDetail)
+	}
+}
+
+func TestStacked_SearchCancelWithoutSplitDetailDoesNotScheduleFollow(t *testing.T) {
+	m, cleanup := stackedSearchTransitionFixture(t)
+	defer cleanup()
+	startGen := m.nextDetailFollowGen
+
+	m, enterCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if enterCmd != nil || m.detail.issue != nil {
+		t.Fatalf("stacked results transition = detail %+v cmd %T, want nil/nil", m.detail.issue, enterCmd)
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd != nil || m.detail.issue != nil {
+		t.Fatalf("stacked cancel = detail %+v cmd %T, want nil/nil", m.detail.issue, cancelCmd)
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 0 {
+		t.Fatalf("stacked-only search advanced follow gen by %d, want 0", delta)
+	}
+}
+
+func TestSplit_SearchNoOpArrowRetargetsDetailToFilteredResult(t *testing.T) {
+	m, cleanup := splitSearchTransitionFixture(t)
+	defer cleanup()
+	startGen := m.nextDetailFollowGen
+
+	m, cmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.input.searchFocus != searchFocusResults || m.list.cursor != 0 {
+		t.Fatalf("search/cursor = %v/%d, want results/0", m.input.searchFocus, m.list.cursor)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("detail issue = %+v, want filtered bbb2", m.detail.issue)
+	}
+	if cmd == nil {
+		t.Fatal("no-op arrow transition returned no detail-follow command")
+	}
+	if delta := m.nextDetailFollowGen - startGen; delta != 1 {
+		t.Fatalf("detail follow gen advanced by %d, want 1", delta)
 	}
 }
 

--- a/internal/tui/split_test.go
+++ b/internal/tui/split_test.go
@@ -1021,11 +1021,14 @@ func TestSplit_SearchRetargetMutationRefetchesSavedDetail(t *testing.T) {
 	}
 	m, mutationCmd := stepModel(m, mutation)
 	if mutationCmd == nil {
-		t.Fatal("snapshot-only mutation returned no detail refetch command")
+		t.Fatal("snapshot-only mutation returned no refresh commands")
 	}
 	batch, ok := mutationCmd().(tea.BatchMsg)
-	if !ok || len(batch) != 4 {
-		t.Fatalf("snapshot refetch = %T len %d, want four-command batch", batch, len(batch))
+	if !ok || len(batch) != 2 {
+		t.Fatalf("mutation refresh = %T len %d, want list debounce plus detail batch", batch, len(batch))
+	}
+	if !m.pendingRefetch {
+		t.Fatal("snapshot-only mutation did not schedule list refetch")
 	}
 
 	closed := Issue{
@@ -1046,6 +1049,20 @@ func TestSplit_SearchRetargetMutationRefetchesSavedDetail(t *testing.T) {
 	}
 	if got := stripANSI(m.detail.status); !strings.Contains(got, "closed #aaa1") {
 		t.Fatalf("restored mutation status = %q, want close confirmation", got)
+	}
+	if m.list.issues[0].Status != "open" || !m.pendingRefetch {
+		t.Fatalf("pre-refetch list status/pending = %q/%v, want open/true", m.list.issues[0].Status, m.pendingRefetch)
+	}
+
+	m, _ = stepModel(m, refetchedMsg{
+		dispatchKey: m.currentCacheKey(),
+		issues: []Issue{
+			closed,
+			{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+		},
+	})
+	if m.list.issues[0].Status != "closed" || m.detail.issue == nil || m.detail.issue.Status != "closed" {
+		t.Fatalf("refetched list/detail = %q/%+v, want closed/closed", m.list.issues[0].Status, m.detail.issue)
 	}
 }
 

--- a/internal/tui/split_test.go
+++ b/internal/tui/split_test.go
@@ -123,6 +123,77 @@ func TestSplit_SearchEnterRetargetsDetailToFilteredResult(t *testing.T) {
 	}
 }
 
+func TestSplit_SearchResultsRefetchRetargetsChangedHighlight(t *testing.T) {
+	m, cleanup := splitSearchTransitionFixture(t)
+	defer cleanup()
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("results detail = %+v, want bbb2", m.detail.issue)
+	}
+
+	m, refetchCmd := stepModel(m, refetchedMsg{
+		dispatchKey: m.currentCacheKey(),
+		issues: []Issue{
+			{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other row", Status: "open"},
+			{ProjectID: 7, UID: "01TEST-ccc3", ShortID: "ccc3", Title: "target replacement", Status: "open"},
+		},
+	})
+	if refetchCmd == nil {
+		t.Fatal("changed search highlight returned no detail-follow command")
+	}
+	if m.list.selectedUID != "01TEST-ccc3" || m.detail.issue == nil || m.detail.issue.UID != "01TEST-ccc3" {
+		t.Fatalf("refetched selection/detail = %q/%+v, want ccc3/c3 detail", m.list.selectedUID, m.detail.issue)
+	}
+}
+
+func TestSplit_SearchResultsRefetchClearsDetailWhenResultsDisappear(t *testing.T) {
+	m, cleanup := splitSearchTransitionFixture(t)
+	defer cleanup()
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	startFollowGen := m.nextDetailFollowGen
+
+	m, refetchCmd := stepModel(m, refetchedMsg{
+		dispatchKey: m.currentCacheKey(),
+		issues: []Issue{
+			{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other row", Status: "open"},
+		},
+	})
+	if refetchCmd != nil {
+		t.Fatalf("empty search results returned unexpected command %T", refetchCmd)
+	}
+	if m.list.selectedUID != "" || m.detail.issue != nil {
+		t.Fatalf("empty-results selection/detail = %q/%+v, want empty/nil", m.list.selectedUID, m.detail.issue)
+	}
+	if delta := m.nextDetailFollowGen - startFollowGen; delta != 1 {
+		t.Fatalf("empty-results follow generation advanced by %d, want 1 invalidation", delta)
+	}
+}
+
+func TestSplit_SearchResultsRefetchKeepsMatchingDetailWithoutFollow(t *testing.T) {
+	m, cleanup := splitSearchTransitionFixture(t)
+	defer cleanup()
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	startDetailGen := m.detail.gen
+	startFollowGen := m.nextDetailFollowGen
+
+	m, refetchCmd := stepModel(m, refetchedMsg{
+		dispatchKey: m.currentCacheKey(),
+		issues: []Issue{
+			{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row refreshed", Status: "open"},
+			{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "other row", Status: "open"},
+		},
+	})
+	if refetchCmd != nil {
+		t.Fatalf("unchanged search highlight returned unexpected command %T", refetchCmd)
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" || m.detail.gen != startDetailGen {
+		t.Fatalf("matching detail = %+v gen %d, want bbb2/gen %d", m.detail.issue, m.detail.gen, startDetailGen)
+	}
+	if delta := m.nextDetailFollowGen - startFollowGen; delta != 0 {
+		t.Fatalf("unchanged-results follow generation advanced by %d, want 0", delta)
+	}
+}
+
 func TestSplit_SearchCancelRetargetsDetailToRestoredSelection(t *testing.T) {
 	m, cleanup := splitSearchTransitionFixture(t)
 	defer cleanup()
@@ -287,8 +358,8 @@ func TestSplit_SearchCancelRestoresDetailWhenPreFilterHasNoRows(t *testing.T) {
 	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
 	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
-	if cancelCmd != nil {
-		t.Fatalf("empty-list cancel returned unexpected follow command %T", cancelCmd)
+	if cancelCmd == nil {
+		t.Fatal("empty-list snapshot restore returned no freshness refetch")
 	}
 	if m.input.kind != inputNone || m.list.filter.Search != "no-match-anywhere" {
 		t.Fatalf("cancel state = input %v search %q, want none/no-match-anywhere", m.input.kind, m.list.filter.Search)
@@ -500,8 +571,8 @@ func TestSplit_SearchCancelPrefersCompletedSnapshotOverStaleMatchingDetail(t *te
 	m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &completed})
 	commentsErr := errors.New("comments temporarily unavailable")
 	m, _ = stepModel(m, commentsFetchedMsg{gen: 41, err: commentsErr})
-	if m.detail.issue == nil || m.detail.issue.Title != "loading detail" || !m.detail.loading || !m.detail.commentsLoading {
-		t.Fatalf("hidden live detail unexpectedly converged: %+v loading %v/%v", m.detail.issue, m.detail.loading, m.detail.commentsLoading)
+	if m.detail.issue == nil || m.detail.issue.Title != "completed detail" || m.detail.loading || m.detail.commentsLoading {
+		t.Fatalf("hidden live detail did not converge: %+v loading %v/%v", m.detail.issue, m.detail.loading, m.detail.commentsLoading)
 	}
 
 	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
@@ -537,6 +608,77 @@ func TestSplit_SearchCancelPrefersCompletedSnapshotOverStaleMatchingDetail(t *te
 	}
 }
 
+func TestStacked_SearchCancelRefetchesAndCompletesRestoredSnapshot(t *testing.T) {
+	m, cleanup := splitTestSetup(t)
+	defer cleanup()
+	m.list.issues = []Issue{
+		{ProjectID: 7, UID: "01TEST-aaa1", ShortID: "aaa1", Title: "loading detail", Status: "open"},
+		{ProjectID: 7, UID: "01TEST-bbb2", ShortID: "bbb2", Title: "target row", Status: "open"},
+	}
+	m.list.cursor = 0
+	m.list.selectedUID = "01TEST-aaa1"
+	m.list.selectedProjectID = 7
+	seed := m.list.issues[0]
+	m.detail = detailModel{
+		issue:           &seed,
+		scopePID:        7,
+		gen:             41,
+		loading:         true,
+		commentsLoading: true,
+		eventsLoading:   true,
+		linksLoading:    true,
+	}
+	m.nextGen = m.detail.gen
+
+	m = openBarFromCmd(t, m, '/')
+	for _, r := range "target" {
+		m, _ = stepModel(m, runeKey(r))
+	}
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
+		t.Fatalf("results detail = %+v, want bbb2", m.detail.issue)
+	}
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	completed := seed
+	completed.Title = "fresh issue"
+	m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &completed})
+	if m.input.preSplitDetail == nil || m.input.preSplitDetail.issue == nil ||
+		m.input.preSplitDetail.issue.Title != "fresh issue" {
+		t.Fatalf("partial off-screen response did not update snapshot: %+v", m.input.preSplitDetail)
+	}
+
+	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if cancelCmd == nil {
+		t.Fatal("partial snapshot restore returned no freshness refetch")
+	}
+	batch, ok := cancelCmd().(tea.BatchMsg)
+	if !ok || len(batch) != 4 {
+		t.Fatalf("snapshot restore refetch = %T len %d, want four-command batch", batch, len(batch))
+	}
+	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.issue.Title != "fresh issue" {
+		t.Fatalf("restored detail = %+v, want fresh aaa1 snapshot", m.detail.issue)
+	}
+	if !m.detail.commentsLoading || !m.detail.eventsLoading || !m.detail.linksLoading {
+		t.Fatalf("partial snapshot loading flags = %v/%v/%v, want all true",
+			m.detail.commentsLoading, m.detail.eventsLoading, m.detail.linksLoading)
+	}
+
+	m, _ = stepModel(m, commentsFetchedMsg{gen: 41, comments: []CommentEntry{{ID: 1, Body: "fresh comment"}}})
+	m, _ = stepModel(m, eventsFetchedMsg{gen: 41, events: []EventLogEntry{{ID: 2}}})
+	m, _ = stepModel(m, linksFetchedMsg{gen: 41, links: []LinkEntry{{Type: "related"}}})
+	if m.detail.commentsLoading || m.detail.eventsLoading || m.detail.linksLoading {
+		t.Fatalf("late restored responses left loading flags = %v/%v/%v, want all false",
+			m.detail.commentsLoading, m.detail.eventsLoading, m.detail.linksLoading)
+	}
+	if len(m.detail.comments) != 1 || m.detail.comments[0].Body != "fresh comment" ||
+		len(m.detail.events) != 1 || len(m.detail.links) != 1 {
+		t.Fatalf("restored activity = comments %+v events %+v links %+v, want fresh payloads",
+			m.detail.comments, m.detail.events, m.detail.links)
+	}
+}
+
 func TestSplit_SearchCancelPreservesNewerMatchingLiveDetail(t *testing.T) {
 	m, cleanup := splitTestSetup(t)
 	defer cleanup()
@@ -560,9 +702,6 @@ func TestSplit_SearchCancelPreservesNewerMatchingLiveDetail(t *testing.T) {
 	completed := m.list.issues[0]
 	completed.Title = "older completed snapshot"
 	m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &completed})
-	if !m.input.preSplitDetailAhead {
-		t.Fatal("stacked fetch did not mark saved detail ahead")
-	}
 
 	m, toTargetCmd := updateModel(m, tea.WindowSizeMsg{Width: 160, Height: 40})
 	if toTargetCmd == nil || m.detail.issue == nil || m.detail.issue.UID != "01TEST-bbb2" {
@@ -633,8 +772,8 @@ func TestSplit_SearchCancelSnapshotInvalidatesDifferentLiveFollow(t *testing.T) 
 
 	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
 	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
-	if cancelCmd != nil {
-		t.Fatalf("snapshot cancel returned unexpected command %T", cancelCmd)
+	if cancelCmd == nil {
+		t.Fatal("snapshot cancel returned no freshness refetch")
 	}
 	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.issue.Title != "completed snapshot" || m.detail.loading {
 		t.Fatalf("restored snapshot = detail %+v loading %v, want completed aaa1", m.detail.issue, m.detail.loading)
@@ -699,9 +838,6 @@ func TestSplit_SearchCancelConvergesSnapshotWithSameGenerationMutation(t *testin
 			completed.Title = "completed snapshot"
 			completed.Body = "fresh fetched body"
 			m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &completed})
-			if !m.input.preSplitDetailAhead {
-				t.Fatal("stacked fetch did not mark saved detail ahead")
-			}
 
 			m, mutationCmd := stepModel(m, tc.mutation)
 			if !strings.Contains(stripANSI(m.detail.status), tc.wantStatus) {
@@ -774,8 +910,8 @@ func TestSplit_SearchRetargetMutationRefetchesSavedDetail(t *testing.T) {
 	m, _ = stepModel(m, detailFetchedMsg{gen: 41, issue: &closed})
 	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
 	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
-	if cancelCmd != nil {
-		t.Fatalf("cancel returned unexpected command %T", cancelCmd)
+	if cancelCmd == nil {
+		t.Fatal("snapshot cancel returned no freshness refetch")
 	}
 	if m.detail.issue == nil || m.detail.issue.UID != "01TEST-aaa1" || m.detail.issue.Status != "closed" {
 		t.Fatalf("restored detail = %+v, want refreshed closed aaa1", m.detail.issue)
@@ -882,16 +1018,17 @@ func TestSplit_SearchSnapshotRejectsOlderFetchAfterLiveRetarget(t *testing.T) {
 	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	m, _ = stepModel(m, newIssueCmd())
 	m, _ = stepModel(m, newCommentsCmd())
-	if !m.input.preSplitDetailAhead {
-		t.Fatal("newer snapshot-only responses did not mark saved detail ahead")
+	if m.input.preSplitDetail == nil || m.input.preSplitDetail.issue == nil ||
+		m.input.preSplitDetail.issue.Title != "newer issue response" {
+		t.Fatalf("newer snapshot-only responses did not update saved detail: %+v", m.input.preSplitDetail)
 	}
 	m, _ = stepModel(m, oldIssueCmd())
 	m, _ = stepModel(m, oldCommentsCmd())
 
 	m, _ = stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
 	m, cancelCmd := stepModel(m, tea.KeyPressMsg{Code: tea.KeyEsc})
-	if cancelCmd != nil {
-		t.Fatalf("snapshot cancel returned unexpected command %T", cancelCmd)
+	if cancelCmd == nil {
+		t.Fatal("snapshot cancel returned no freshness refetch")
 	}
 	if m.detail.issue == nil || m.detail.issue.Title != "newer issue response" {
 		t.Errorf("restored issue = %+v, want newer response", m.detail.issue)

--- a/internal/tui/testdata/golden/comment-discard-confirm-modal.txt
+++ b/internal/tui/testdata/golden/comment-discard-confirm-modal.txt
@@ -1,0 +1,30 @@
+ Project: kata                                                                                          kata カタ · dev
+
+  #42aa  fix bug                                                                            [open]
+  owner: none   p╭────────────────────────────────────────────────────────────────────────────────────╮
+  priority: none │ comment on #42aa                                                                   │
+                 │ draft comment                                                                      │
+  Body           │                                                                                    │
+  current body   │                                                                                    │
+                 │                                                                                    │
+                 │                                                                                    │
+                 │                      ╭──────────────────────────────────────╮                      │
+                 │                      │                                      │                      │
+                 │                      │  Discard comment draft?              │                      │
+                 │                      │                                      │                      │
+                 │                      │  Your unsaved comment will be lost.  │                      │
+                 │                      │                                      │                      │
+                 │                      │  [Y] Discard    [N] Keep editing     │                      │
+                 │                      │                                      │                      │
+                 │                      ╰──────────────────────────────────────╯                      │
+                 │                                                                                    │
+                 │                                                                                    │
+                 │                                                                                    │
+                 │                                                                                    │
+                 │                                                                                    │
+                 │ ctrl+o save · esc cancel · ctrl+e $EDITOR                                          │
+                 ╰────────────────────────────────────────────────────────────────────────────────────╯
+
+
+
+ y discard▕ n/esc keep editing

--- a/internal/tui/testdata/golden/filter-form-all-axes.txt
+++ b/internal/tui/testdata/golden/filter-form-all-axes.txt
@@ -8,5 +8,5 @@
 │ login                                                                              │
 │ Labels                                                                             │
 │                                                                                    │
-│ ctrl+s apply · esc cancel · tab next · ctrl+r reset                                │
+│ ctrl+o apply · esc cancel · tab next · ctrl+r reset                                │
 ╰────────────────────────────────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/golden/filter-form-with-labels-axis.txt
+++ b/internal/tui/testdata/golden/filter-form-with-labels-axis.txt
@@ -8,5 +8,5 @@
 │ login                                                                              │
 │ Labels                                                                             │
 │ bug, prio-1                                                                        │
-│ ctrl+s apply · esc cancel · tab next · ctrl+r reset                                │
+│ ctrl+o apply · esc cancel · tab next · ctrl+r reset                                │
 ╰────────────────────────────────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/golden/help-narrow.txt
+++ b/internal/tui/testdata/golden/help-narrow.txt
@@ -51,7 +51,7 @@ j/k    move child cursor
 enter  open child
 
 Forms
-ctrl+s         save or apply
+ctrl+o         save or apply
 esc            cancel
 tab/shift+tab  change field
 ctrl+e         open editor

--- a/internal/tui/testdata/golden/help-wide.txt
+++ b/internal/tui/testdata/golden/help-wide.txt
@@ -1,7 +1,7 @@
 kata — keybindings
 
 Global                             Detail                                     Forms
-?         help                     tab            next tab                    ctrl+s         save or apply
+?         help                     tab            next tab                    ctrl+o         save or apply
 q/ctrl+c  quit                     shift+tab      prev tab                    esc            cancel
 P         projects                 enter          jump to referenced issue    tab/shift+tab  change field
 D         daemons                  esc/backspace  back                        ctrl+e         open editor

--- a/internal/tui/testdata/golden/list-search-results-focused.txt
+++ b/internal/tui/testdata/golden/list-search-results-focused.txt
@@ -27,4 +27,4 @@
 
 
  /login
- ↑↓/enter results▕ esc cancel▕ ctrl+u clear
+ ↑↓ move▕ enter apply▕ esc query▕ / query

--- a/internal/tui/testdata/golden/new-child-form.txt
+++ b/internal/tui/testdata/golden/new-child-form.txt
@@ -19,5 +19,5 @@
 │                                                                                    │
 │ Parent                                                                             │
 │ 42aa                                                                               │
-│ ctrl+s save · esc cancel · tab next · ctrl+e (body only)                           │
+│ ctrl+o save · esc cancel · tab next · ctrl+e (body only)                           │
 ╰────────────────────────────────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/golden/new-issue-form-all-fields.txt
+++ b/internal/tui/testdata/golden/new-issue-form-all-fields.txt
@@ -19,5 +19,5 @@
 │ alice                                                                              │
 │ Parent                                                                             │
 │                                                                                    │
-│ ctrl+s save · esc cancel · ctrl+e $EDITOR                                          │
+│ ctrl+o save · esc cancel · ctrl+e $EDITOR                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/golden/quit-confirm-modal.txt
+++ b/internal/tui/testdata/golden/quit-confirm-modal.txt
@@ -25,6 +25,6 @@
 
 
 
+
                                                                                                                   [2/3]
- ↑↓ move   ▕ ↵ open   ▕ n new       ▕ N child ▕ / search▕ f filter▕ s status▕ v view▕ o order▕ c clear▕ x close
- ! priority▕ D daemons▕ F federation▕ L layout▕ ? help  ▕ q quit
+ y confirm▕ n/esc cancel


### PR DESCRIPTION
Routine TUI work was too easy to derail: terminal flow control could swallow the only save key, Esc could erase a draft, and live search required an extra focus-confirm step before navigation.

This makes Ctrl-O the canonical save/apply chord while retaining Ctrl-S compatibility, introduces reversible query/results focus, and protects non-empty comment drafts with discard confirmation. Stacked search navigation remains list-only; split search clears stale detail for empty results and restores the pre-search tab, scroll, navigation stack, and mutation feedback over fresh live content on cancellation. Event-driven list refreshes keep the selected result and split detail aligned across asynchronous fetches, mutations, and layout changes. Modal footers advertise the keys that currently own input across every view.

The interaction state remains local to the TUI, with no API or persisted-schema changes. Command mode, configurable bindings, and comment editing remain separate follow-on work.