### PR TITLE
Add host-controlled access and project lifecycle APIs

### DIFF
--- a/access.go
+++ b/access.go
@@ -10,7 +10,9 @@ import (
 var ErrAccessDenied = errors.New("kata: access denied")
 
 // Principal is the authenticated identity supplied by an embedding host.
-// Subject is a stable opaque identifier and also anchors lease ownership.
+// Subject is a stable opaque identifier and also anchors lease ownership. Its
+// exact bytes are significant; callers must supply the same canonical value
+// on every request.
 // Actor is the display snapshot Kata records on mutations instead of accepting
 // an actor from request data.
 type Principal struct {

--- a/access.go
+++ b/access.go
@@ -24,6 +24,14 @@ type Operation struct {
 	Method     string
 	Path       string
 	PathParams map[string]string
+
+	// ProjectIDs and ProjectUIDs identify every project whose data the
+	// operation may read or change. AllProjects is true when an omitted filter
+	// selects the global project set. Values are parsed and validated before
+	// authorization; cross-project operations include both sides.
+	ProjectIDs  []int64
+	ProjectUIDs []string
+	AllProjects bool
 }
 
 // AccessRequest is the complete input to one host authorization decision.

--- a/access.go
+++ b/access.go
@@ -1,0 +1,66 @@
+package kata
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrAccessDenied is returned by an AccessController when a caller must not
+// learn whether the requested resource exists.
+var ErrAccessDenied = errors.New("kata: access denied")
+
+// Principal is the authenticated identity supplied by an embedding host.
+// Subject is a stable opaque identifier. Actor is the display snapshot Kata
+// records on mutations instead of accepting an actor from request data.
+type Principal struct {
+	Subject string
+	Actor   string
+}
+
+// Operation identifies the matched Kata HTTP operation without assigning any
+// host-specific meaning to it.
+type Operation struct {
+	ID         string
+	Method     string
+	Path       string
+	PathParams map[string]string
+}
+
+// AccessRequest is the complete input to one host authorization decision.
+type AccessRequest struct {
+	Principal Principal
+	Operation Operation
+}
+
+// AccessLease revalidates a host decision while a long-lived response is
+// active. Revalidate must fail as soon as the principal or resource authority
+// represented by the lease is no longer current.
+type AccessLease interface {
+	Revalidate(context.Context) error
+}
+
+// AccessDecision carries state needed after a request is admitted. Lease may
+// be nil for bounded responses; long-lived operations require one.
+type AccessDecision struct {
+	Lease AccessLease
+}
+
+// AccessController makes host-owned authorization decisions for a mounted
+// service. Returning ErrAccessDenied produces a generic not-found response;
+// other errors make only the mounted service temporarily unavailable.
+type AccessController interface {
+	Authorize(context.Context, AccessRequest) (AccessDecision, error)
+}
+
+type principalContextKey struct{}
+
+// WithPrincipal attaches a host-authenticated principal to an in-process
+// request. It is intended for middleware immediately outside Service.Handler.
+func WithPrincipal(ctx context.Context, principal Principal) context.Context {
+	return context.WithValue(ctx, principalContextKey{}, principal)
+}
+
+func principalFromContext(ctx context.Context) (Principal, bool) {
+	principal, ok := ctx.Value(principalContextKey{}).(Principal)
+	return principal, ok
+}

--- a/access.go
+++ b/access.go
@@ -26,8 +26,9 @@ type Operation struct {
 	PathParams map[string]string
 
 	// ProjectIDs and ProjectUIDs identify every project whose data the
-	// operation may read or change. AllProjects is true when an omitted filter
-	// selects the global project set. Values are parsed and validated before
+	// operation may read or change. AllProjects is true when a global selector
+	// is used or when an operation can depend on projects that cannot be safely
+	// bounded before dispatch. Values are parsed and validated before
 	// authorization; cross-project operations include both sides.
 	ProjectIDs  []int64
 	ProjectUIDs []string

--- a/access.go
+++ b/access.go
@@ -10,8 +10,9 @@ import (
 var ErrAccessDenied = errors.New("kata: access denied")
 
 // Principal is the authenticated identity supplied by an embedding host.
-// Subject is a stable opaque identifier. Actor is the display snapshot Kata
-// records on mutations instead of accepting an actor from request data.
+// Subject is a stable opaque identifier and also anchors lease ownership.
+// Actor is the display snapshot Kata records on mutations instead of accepting
+// an actor from request data.
 type Principal struct {
 	Subject string
 	Actor   string

--- a/access.go
+++ b/access.go
@@ -54,8 +54,11 @@ type AccessDecision struct {
 }
 
 // AccessController makes host-owned authorization decisions for a mounted
-// service. Returning ErrAccessDenied produces a generic not-found response;
-// other errors make only the mounted service temporarily unavailable.
+// service. A request may be repeated with a larger, cumulative project scope
+// when resolving a UID, link, or graph discovers another project, so
+// implementations must make retry-safe decisions. Returning ErrAccessDenied
+// produces a generic not-found response; other errors make only the mounted
+// service temporarily unavailable.
 type AccessController interface {
 	Authorize(context.Context, AccessRequest) (AccessDecision, error)
 }

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -71,9 +71,12 @@ The embedded service is listener-free. Its host application owns the network
 listener, TLS, signal handling, and process shutdown, and must choose a kata
 bearer token, an explicit trusted caller-authentication boundary, or the
 host-owned access-controller contract. The access contract supplies identity in
-process, authorizes the matched operation, and revalidates long-lived responses
-without defining the host's role model. The service owns its configured storage
-handle and its federation, GitHub sync, and timed-claim background workers.
+process, authorizes the matched operation and its complete validated project
+scope, and revalidates long-lived responses without defining the host's role
+model. Kata-managed project-scoped federation credentials continue to
+authenticate their own transport and lease routes. The service owns its
+configured storage handle and its federation, GitHub sync, and timed-claim
+background workers.
 Hosts with an external catalog can idempotently ensure and archive projects by
 stable UID through in-process application methods; they never need to write
 Kata tables or loop back through the mounted HTTP handler.

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -68,10 +68,12 @@ runtime files, or logs. Clients discover a running daemon by computing the
 a daemon only if none is live.
 
 The embedded service is listener-free. Its host application owns the network
-listener, TLS, signal handling, and process shutdown, and must choose either a
-kata bearer token or an explicit trusted caller-authentication boundary. The
-service owns its configured storage handle and its federation, GitHub sync, and
-timed-claim background workers.
+listener, TLS, signal handling, and process shutdown, and must choose a kata
+bearer token, an explicit trusted caller-authentication boundary, or the
+host-owned access-controller contract. The access contract supplies identity in
+process, authorizes the matched operation, and revalidates long-lived responses
+without defining the host's role model. The service owns its configured storage
+handle and its federation, GitHub sync, and timed-claim background workers.
 
 ## Project binding over current directory
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -74,6 +74,9 @@ host-owned access-controller contract. The access contract supplies identity in
 process, authorizes the matched operation, and revalidates long-lived responses
 without defining the host's role model. The service owns its configured storage
 handle and its federation, GitHub sync, and timed-claim background workers.
+Hosts with an external catalog can idempotently ensure and archive projects by
+stable UID through in-process application methods; they never need to write
+Kata tables or loop back through the mounted HTTP handler.
 
 ## Project binding over current directory
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -127,10 +127,15 @@ token over plaintext non-loopback HTTP.
 ## Host-owned access
 
 `AccessController` is the fine-grained embedding seam. Kata calls it after a
-route matches and before request decoding or handler work. The request contains
-the opaque authenticated subject, the actor snapshot used for new event and
-projection rows, and the matched operation ID, method, path template, and path
-parameters. It deliberately contains no application roles or tenant model.
+route matches and before the operation reads or changes Kata data. The request
+contains the opaque authenticated subject, the actor snapshot used for new
+event and projection rows, and the matched operation ID, method, path template,
+and path parameters. `Operation.ProjectIDs`, `ProjectUIDs`, and `AllProjects`
+carry the validated effective project scope. Cross-project operations include
+both projects; omitting the project filter from the event stream sets
+`AllProjects` instead of silently broadening an empty scope. Body- and
+query-selected projects are decoded and validated before this decision. The
+request deliberately contains no application roles or tenant model.
 
 An embedding host typically mounts the service behind its ordinary session or
 credential middleware:
@@ -173,6 +178,13 @@ audit attribution tied to the authenticated principal rather than caller input.
 `Auth.TrustCallerAuthentication` preserves the older all-or-nothing trusted
 middleware mode; use `Config.Access` when projects or operations need distinct
 authorization decisions.
+
+Federation transport and lease routes may authenticate with Kata-managed,
+project-scoped bearer credentials. When such a request has no in-process host
+principal, Kata validates the scoped credential in the route and does not call
+the host controller. The outer server must preserve the `Authorization` header
+on those routes. A request without either an in-process principal or a scoped
+bearer credential remains unauthenticated.
 
 ## Host-managed projects
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -140,10 +140,15 @@ Kata asks again with the expanded scope before returning or changing protected
 data. Controllers should therefore make retry-safe decisions from the complete
 request rather than treating a call as a one-time notification. Global
 operations set `AllProjects` explicitly. Operations such as purge, close,
-ready selection, and UID-prefix lookup also require `AllProjects` because
-their results or side effects can depend on relationships outside the project
-named in the URL. The request deliberately contains no application roles or
-tenant model.
+imports, ready selection, UID-prefix lookup, and event feeds also require
+`AllProjects` because their results or side effects can depend on relationships
+outside the project named in the URL. The request deliberately contains no
+application roles or tenant model.
+
+For lease operations, Kata derives an opaque holder key from the stable
+`Principal.Subject`; a request-provided `holder` cannot select or impersonate
+another mounted caller. `Principal.Actor` remains the human-readable audit
+snapshot for replica setup and other mutations.
 
 An embedding host typically mounts the service behind its ordinary session or
 credential middleware:

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -127,15 +127,20 @@ token over plaintext non-loopback HTTP.
 ## Host-owned access
 
 `AccessController` is the fine-grained embedding seam. Kata calls it after a
-route matches and before the operation reads or changes Kata data. The request
+route matches and before protected data is returned or changed. The request
 contains the opaque authenticated subject, the actor snapshot used for new
 event and projection rows, and the matched operation ID, method, path template,
 and path parameters. `Operation.ProjectIDs`, `ProjectUIDs`, and `AllProjects`
 carry the validated effective project scope. Cross-project operations include
 both projects; omitting the project filter from the event stream sets
 `AllProjects` instead of silently broadening an empty scope. Body- and
-query-selected projects are decoded and validated before this decision. The
-request deliberately contains no application roles or tenant model.
+query-selected projects are decoded and validated before this decision. When
+an operation discovers another project while resolving a link, UID, or graph,
+Kata asks again with the expanded scope before returning or changing protected
+data. Controllers should therefore make retry-safe decisions from the complete
+request rather than treating a call as a one-time notification. Global
+operations set `AllProjects` explicitly. The request deliberately contains no
+application roles or tenant model.
 
 An embedding host typically mounts the service behind its ordinary session or
 credential middleware:

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -110,8 +110,12 @@ handle. It is safe to call more than once.
 - Set `Auth.TrustCallerAuthentication` to `true` only when trusted middleware
   already authenticates every request before it reaches `service.Handler()`.
   Never expose that handler directly on an untrusted listener.
+- Set `Config.Access` when the host owns both identity and per-operation
+  authorization. The host middleware attaches an authenticated
+  `kata.Principal` in process with `kata.WithPrincipal`; Kata never accepts
+  that principal from a network header.
 
-Construction fails when neither policy is selected or when both are set. The
+Construction fails when no policy is selected or when policies are combined. The
 explicit choice prevents an embedded service from accidentally inheriting the
 standalone daemon's local-user trust boundary.
 
@@ -119,6 +123,56 @@ The lifecycle example deliberately binds to loopback. To accept remote clients,
 use `server.ListenAndServeTLS(certFile, keyFile)` with a valid certificate or
 mount the handler behind a TLS-terminating reverse proxy. Never send the bearer
 token over plaintext non-loopback HTTP.
+
+## Host-owned access
+
+`AccessController` is the fine-grained embedding seam. Kata calls it after a
+route matches and before request decoding or handler work. The request contains
+the opaque authenticated subject, the actor snapshot used for new event and
+projection rows, and the matched operation ID, method, path template, and path
+parameters. It deliberately contains no application roles or tenant model.
+
+An embedding host typically mounts the service behind its ordinary session or
+credential middleware:
+
+```go
+service, err := kata.New(ctx, kata.Config{
+	DSN:    "/var/lib/example-app/kata.db",
+	Access: applicationAccessController,
+})
+if err != nil {
+	return err
+}
+
+handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	principal, err := authenticateApplicationRequest(r)
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	ctx := kata.WithPrincipal(r.Context(), kata.Principal{
+		Subject: principal.StableID,
+		Actor:   principal.DisplayName,
+	})
+	service.Handler().ServeHTTP(w, r.WithContext(ctx))
+})
+```
+
+The controller returns `kata.ErrAccessDenied` for a rejected operation. Kata
+answers with a generic not-found envelope so the response does not confirm that
+a protected resource exists. Other controller failures return a bounded
+service-unavailable envelope without exposing the underlying error.
+
+Long-lived operations require an `AccessLease` in the successful decision.
+Kata revalidates that lease before each event or heartbeat; a failed
+revalidation closes the stream before more protected data is written. Bounded
+requests may return a decision with no lease.
+
+The host-supplied actor always replaces an actor in request JSON. This keeps
+audit attribution tied to the authenticated principal rather than caller input.
+`Auth.TrustCallerAuthentication` preserves the older all-or-nothing trusted
+middleware mode; use `Config.Access` when projects or operations need distinct
+authorization decisions.
 
 ## Storage and PostgreSQL policy
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -142,15 +142,18 @@ request rather than treating a call as a one-time notification. Global
 operations set `AllProjects` explicitly. Operations such as purge, close,
 imports, ready selection, UID-prefix lookup, event feeds, close audits, and
 project digests also require `AllProjects` because their results or side effects
-can depend on relationships outside the project named in the URL. The request
-deliberately contains no application roles or tenant model.
+can depend on relationships outside the project named in the URL. Parent-link
+changes and deletion by a global link ID use the same conservative scope. The
+request deliberately contains no application roles or tenant model.
 
 For lease operations, Kata derives an opaque holder key from the stable
 `Principal.Subject`; a request-provided `holder` cannot select or impersonate
 another mounted caller. Subject bytes are compared exactly after rejecting
 empty or whitespace-only values, so the embedding host must provide one
 canonical subject representation. Subject ownership remains distinct when a
-spoke forwards a lease through its shared federation identity.
+spoke forwards a lease through its shared federation identity. Existing
+non-host lease clients keep their established holder and client-kind behavior;
+mounting a service does not rewrite their persisted ownership tuples.
 `Principal.Actor` remains the human-readable audit snapshot for replica setup
 and other mutations.
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -174,6 +174,31 @@ audit attribution tied to the authenticated principal rather than caller input.
 middleware mode; use `Config.Access` when projects or operations need distinct
 authorization decisions.
 
+## Host-managed projects
+
+Applications that keep their own project catalog can establish one stable Kata
+project without calling the HTTP API internally:
+
+```go
+result, err := service.EnsureProject(ctx, kata.ProjectSpec{
+	UID:  "01HZNQ7VFPK1XGD8R5MABCD4EX",
+	Name: "example-host-project",
+})
+```
+
+`EnsureProject` is idempotent across processes. An exact UID-and-name match
+returns the existing numeric identity and history; a reused UID or name that
+points at a different project returns `kata.ErrProjectConflict`. The caller can
+therefore retry after an interrupted catalog update without creating a second
+project. Archived projects are returned as `kata.ProjectArchived` and are not
+silently reactivated.
+
+`ArchiveProject` retains that same UID, numeric identity, tasks, and events
+while removing the project from ordinary active reads. It is idempotent and
+requires an actor for the retained event history. These methods are in-process
+application methods: they do not authenticate a network caller and should be
+invoked only after the host has authorized its own catalog lifecycle change.
+
 ## Storage and PostgreSQL policy
 
 `Config.DSN` is required and accepts a bare SQLite path, a `sqlite://` URL, or a

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -155,7 +155,10 @@ empty or whitespace-only values, so the embedding host must provide one
 canonical subject representation. Subject ownership remains distinct when a
 spoke forwards a lease through its shared federation identity. Existing
 non-host lease clients keep their established holder and client-kind behavior;
-mounting a service does not rewrite their persisted ownership tuples.
+mounting a service does not rewrite their persisted ownership tuples. Host
+provenance is carried separately from those caller-visible strings, so
+reserved-looking holder or client-kind text cannot opt an ordinary client into
+mounted identity handling.
 `Principal.Actor` remains the human-readable audit snapshot for replica setup
 and other mutations.
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -140,15 +140,19 @@ Kata asks again with the expanded scope before returning or changing protected
 data. Controllers should therefore make retry-safe decisions from the complete
 request rather than treating a call as a one-time notification. Global
 operations set `AllProjects` explicitly. Operations such as purge, close,
-imports, ready selection, UID-prefix lookup, and event feeds also require
-`AllProjects` because their results or side effects can depend on relationships
-outside the project named in the URL. The request deliberately contains no
-application roles or tenant model.
+imports, ready selection, UID-prefix lookup, event feeds, close audits, and
+project digests also require `AllProjects` because their results or side effects
+can depend on relationships outside the project named in the URL. The request
+deliberately contains no application roles or tenant model.
 
 For lease operations, Kata derives an opaque holder key from the stable
 `Principal.Subject`; a request-provided `holder` cannot select or impersonate
-another mounted caller. `Principal.Actor` remains the human-readable audit
-snapshot for replica setup and other mutations.
+another mounted caller. Subject bytes are compared exactly after rejecting
+empty or whitespace-only values, so the embedding host must provide one
+canonical subject representation. Subject ownership remains distinct when a
+spoke forwards a lease through its shared federation identity.
+`Principal.Actor` remains the human-readable audit snapshot for replica setup
+and other mutations.
 
 An embedding host typically mounts the service behind its ordinary session or
 credential middleware:

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -144,7 +144,9 @@ imports, ready selection, UID-prefix lookup, event feeds, close audits, and
 project digests also require `AllProjects` because their results or side effects
 can depend on relationships outside the project named in the URL. Parent-link
 changes and deletion by a global link ID use the same conservative scope. The
-request deliberately contains no application roles or tenant model.
+same applies to tolerant relationship removals, whose missing-target no-op
+must not reveal whether a target belongs to a denied project. The request
+deliberately contains no application roles or tenant model.
 
 For lease operations, Kata derives an opaque holder key from the stable
 `Principal.Subject`; a request-provided `holder` cannot select or impersonate

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -139,8 +139,11 @@ an operation discovers another project while resolving a link, UID, or graph,
 Kata asks again with the expanded scope before returning or changing protected
 data. Controllers should therefore make retry-safe decisions from the complete
 request rather than treating a call as a one-time notification. Global
-operations set `AllProjects` explicitly. The request deliberately contains no
-application roles or tenant model.
+operations set `AllProjects` explicitly. Operations such as purge, close,
+ready selection, and UID-prefix lookup also require `AllProjects` because
+their results or side effects can depend on relationships outside the project
+named in the URL. The request deliberately contains no application roles or
+tenant model.
 
 An embedding host typically mounts the service behind its ordinary session or
 credential middleware:

--- a/internal/daemon/claim_gate.go
+++ b/internal/daemon/claim_gate.go
@@ -33,17 +33,19 @@ func requireFederatedIssueClaim(
 		return federationReadOnlyError(db.ErrFederatedReadOnly)
 	}
 
-	holder := strings.TrimSpace(actor)
-	if binding.Role == db.FederationRoleSpoke && binding.PushEnabled {
-		if bound := strings.TrimSpace(binding.Actor); bound != "" {
-			holder = bound
-		}
-	}
 	principal := db.ClaimPrincipal{
 		HolderInstanceUID: cfg.DB.InstanceUID(),
-		Holder:            holder,
-		ClientKind:        "",
+		Holder:            strings.TrimSpace(actor),
 	}
+	if cfg.HostAccess != nil {
+		requestPrincipal, ok := PrincipalFromContext(ctx)
+		if !ok || !validHostPrincipal(requestPrincipal) {
+			return api.NewError(http.StatusUnauthorized, "auth_required",
+				"valid host principal required", "", nil)
+		}
+		principal = hostClaimPrincipal(cfg, api.ClaimActionBody{}, requestPrincipal.Subject).ClaimPrincipal
+	}
+	principal = boundSpokeClaimPrincipal(binding, principal)
 
 	if binding.Role == db.FederationRoleSpoke {
 		if err := refreshSpokeClaimStatusForGate(ctx, cfg, binding, issue); err != nil {

--- a/internal/daemon/claims_auth.go
+++ b/internal/daemon/claims_auth.go
@@ -77,6 +77,10 @@ func authorizeClaimStatusRead(
 	authz string,
 ) error {
 	if cfg.Auth.Token == "" {
+		if cfg.HostAccess != nil && hasBearerHeader(authz) {
+			_, err := authorizeFederationRequest(ctx, cfg.DB, authz, projectID, "claim")
+			return err
+		}
 		if cfg.InsecureReadonly {
 			if !hasBearerHeader(authz) {
 				return localAuthError(cfg, authz)

--- a/internal/daemon/claims_auth.go
+++ b/internal/daemon/claims_auth.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/base64"
 	"errors"
 	"net/http"
 	"strings"
@@ -28,7 +30,7 @@ func resolveClaimPrincipal(
 ) (claimPrincipal, error) {
 	if cfg.HostAccess != nil {
 		if requestPrincipal, ok := PrincipalFromContext(ctx); ok && requestPrincipal.Kind == PrincipalHost {
-			return localClaimPrincipal(cfg, body), nil
+			return hostClaimPrincipal(cfg, body, requestPrincipal.Subject), nil
 		}
 		if allowEnrollment && hasBearerHeader(authz) {
 			return resolveEnrollmentClaimPrincipal(ctx, cfg, projectID, authz, body)
@@ -60,6 +62,12 @@ func resolveClaimPrincipal(
 		return claimPrincipal{}, localAuthError(cfg, authz)
 	}
 	return localClaimPrincipal(cfg, body), nil
+}
+
+func hostClaimPrincipal(cfg ServerConfig, body api.ClaimActionBody, subject string) claimPrincipal {
+	digest := sha256.Sum256([]byte("kata:host-claim-holder:v1\x00" + strings.TrimSpace(subject)))
+	return localClaimPrincipalWithHolder(cfg, body,
+		"host:"+base64.RawURLEncoding.EncodeToString(digest[:]))
 }
 
 func resolveEnrollmentClaimPrincipal(

--- a/internal/daemon/claims_auth.go
+++ b/internal/daemon/claims_auth.go
@@ -19,6 +19,8 @@ type claimPrincipal struct {
 	IdentityToken bool
 }
 
+const hostClaimClientKind = "host:v1"
+
 func resolveClaimPrincipal(
 	ctx context.Context,
 	cfg ServerConfig,
@@ -29,7 +31,11 @@ func resolveClaimPrincipal(
 	requireMutationLocal bool,
 ) (claimPrincipal, error) {
 	if cfg.HostAccess != nil {
-		if requestPrincipal, ok := PrincipalFromContext(ctx); ok && requestPrincipal.Kind == PrincipalHost {
+		if requestPrincipal, ok := PrincipalFromContext(ctx); ok {
+			if !validHostPrincipal(requestPrincipal) {
+				return claimPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
+					"valid host principal required", "", nil)
+			}
 			return hostClaimPrincipal(cfg, body, requestPrincipal.Subject), nil
 		}
 		if allowEnrollment && hasBearerHeader(authz) {
@@ -65,7 +71,9 @@ func resolveClaimPrincipal(
 }
 
 func hostClaimPrincipal(cfg ServerConfig, body api.ClaimActionBody, subject string) claimPrincipal {
-	return localClaimPrincipalWithHolder(cfg, body, hostClaimHolder(subject))
+	principal := localClaimPrincipalWithHolder(cfg, body, hostClaimHolder(subject))
+	principal.ClientKind = hostClaimClientKind
+	return principal
 }
 
 func hostClaimHolder(subject string) string {
@@ -98,8 +106,12 @@ func authorizeClaimStatusRead(
 	authz string,
 ) error {
 	if cfg.HostAccess != nil {
-		if requestPrincipal, ok := PrincipalFromContext(ctx); ok && requestPrincipal.Kind == PrincipalHost {
-			return nil
+		if requestPrincipal, ok := PrincipalFromContext(ctx); ok {
+			if validHostPrincipal(requestPrincipal) {
+				return nil
+			}
+			return api.NewError(http.StatusUnauthorized, "auth_required",
+				"valid host principal required", "", nil)
 		}
 		if hasBearerHeader(authz) {
 			_, err := authorizeFederationRequest(ctx, cfg.DB, authz, projectID, "claim")

--- a/internal/daemon/claims_auth.go
+++ b/internal/daemon/claims_auth.go
@@ -65,9 +65,12 @@ func resolveClaimPrincipal(
 }
 
 func hostClaimPrincipal(cfg ServerConfig, body api.ClaimActionBody, subject string) claimPrincipal {
-	digest := sha256.Sum256([]byte("kata:host-claim-holder:v1\x00" + strings.TrimSpace(subject)))
-	return localClaimPrincipalWithHolder(cfg, body,
-		"host:"+base64.RawURLEncoding.EncodeToString(digest[:]))
+	return localClaimPrincipalWithHolder(cfg, body, hostClaimHolder(subject))
+}
+
+func hostClaimHolder(subject string) string {
+	digest := sha256.Sum256([]byte("kata:host-claim-holder:v1\x00" + subject))
+	return "host:" + base64.RawURLEncoding.EncodeToString(digest[:])
 }
 
 func resolveEnrollmentClaimPrincipal(

--- a/internal/daemon/claims_auth.go
+++ b/internal/daemon/claims_auth.go
@@ -26,6 +26,16 @@ func resolveClaimPrincipal(
 	allowEnrollment bool,
 	requireMutationLocal bool,
 ) (claimPrincipal, error) {
+	if cfg.HostAccess != nil {
+		if requestPrincipal, ok := PrincipalFromContext(ctx); ok && requestPrincipal.Kind == PrincipalHost {
+			return localClaimPrincipal(cfg, body), nil
+		}
+		if allowEnrollment && hasBearerHeader(authz) {
+			return resolveEnrollmentClaimPrincipal(ctx, cfg, projectID, authz, body)
+		}
+		return claimPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
+			"host principal or scoped federation bearer required", "", nil)
+	}
 	if cfg.Auth.Token != "" {
 		if principal, ok, err := resolveLocalClaimPrincipal(ctx, cfg, authz, body, false); ok || err != nil {
 			return principal, err
@@ -76,11 +86,18 @@ func authorizeClaimStatusRead(
 	projectID int64,
 	authz string,
 ) error {
-	if cfg.Auth.Token == "" {
-		if cfg.HostAccess != nil && hasBearerHeader(authz) {
+	if cfg.HostAccess != nil {
+		if requestPrincipal, ok := PrincipalFromContext(ctx); ok && requestPrincipal.Kind == PrincipalHost {
+			return nil
+		}
+		if hasBearerHeader(authz) {
 			_, err := authorizeFederationRequest(ctx, cfg.DB, authz, projectID, "claim")
 			return err
 		}
+		return api.NewError(http.StatusUnauthorized, "auth_required",
+			"host principal or scoped federation bearer required", "", nil)
+	}
+	if cfg.Auth.Token == "" {
 		if cfg.InsecureReadonly {
 			if !hasBearerHeader(authz) {
 				return localAuthError(cfg, authz)

--- a/internal/daemon/claims_auth.go
+++ b/internal/daemon/claims_auth.go
@@ -73,6 +73,7 @@ func resolveClaimPrincipal(
 func hostClaimPrincipal(cfg ServerConfig, body api.ClaimActionBody, subject string) claimPrincipal {
 	principal := localClaimPrincipalWithHolder(cfg, body, hostClaimHolder(subject))
 	principal.ClientKind = hostClaimClientKind
+	principal.AuthenticatedHost = true
 	return principal
 }
 

--- a/internal/daemon/handlers_audit.go
+++ b/internal/daemon/handlers_audit.go
@@ -40,6 +40,11 @@ func doAuditCloses(
 		return nil, api.NewError(400, "validation",
 			"project_id must be a positive integer", "", nil)
 	}
+	var err error
+	ctx, err = authorizeHostProjectScope(ctx, []int64{in.ProjectID}, nil, false)
+	if err != nil {
+		return nil, err
+	}
 	if _, err := activeProjectByID(ctx, cfg.DB, in.ProjectID); err != nil {
 		return nil, err
 	}
@@ -306,6 +311,9 @@ func resolveAuditParentFilter(
 	}
 	issue, rerr := resolveLinkTargetRef(ctx, cfg.DB, projectID, parentRef, db.IncludeDeletedYes)
 	if rerr == nil {
+		if _, err := authorizeHostProjectScope(ctx, []int64{issue.ProjectID}, nil, false); err != nil {
+			return auditParentFilter{}, err
+		}
 		f.resolvedUID = issue.UID
 		if issue.ProjectID == projectID {
 			f.resolvedShortID = issue.ShortID

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -348,6 +350,13 @@ func boundSpokeClaimPrincipal(binding db.FederationBinding, principal db.ClaimPr
 	if actor == "" {
 		return principal
 	}
+	// Enrollment authentication binds the remote holder to the spoke actor.
+	// Preserve the local owner tuple in client_kind before replacing Holder so
+	// two mounted subjects (or two ordinary local holders) cannot control one
+	// another's remote lease through the shared spoke credential.
+	ownerDigest := sha256.Sum256([]byte("kata:spoke-claim-owner:v1\x00" +
+		principal.Holder + "\x00" + principal.ClientKind))
+	principal.ClientKind = "spoke:" + base64.RawURLEncoding.EncodeToString(ownerDigest[:])
 	principal.Holder = actor
 	return principal
 }

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -82,7 +82,7 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err := requireHubClaimBinding(ctx, cfg.DB, in.ProjectID); err != nil {
 			return nil, err
 		}
-		actor := strings.TrimSpace(in.Body.Actor)
+		actor := actorFor(ctx, strings.TrimSpace(in.Body.Actor))
 		if principal.IdentityToken {
 			actor = principal.Holder
 		}

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -353,7 +353,7 @@ func boundSpokeClaimPrincipal(binding db.FederationBinding, principal db.ClaimPr
 	// Existing clients keep their established actor/client-kind identity.
 	// Mounted callers carry an opaque subject-bound identity through the shared
 	// spoke credential so one subject cannot control another subject's lease.
-	if strings.HasPrefix(principal.Holder, "host:") {
+	if principal.AuthenticatedHost {
 		ownerDigest := sha256.Sum256([]byte("kata:spoke-host-claim-owner:v1\x00" + principal.Holder))
 		principal.ClientKind = "spoke-host:v1:" + base64.RawURLEncoding.EncodeToString(ownerDigest[:])
 	}

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -350,13 +350,13 @@ func boundSpokeClaimPrincipal(binding db.FederationBinding, principal db.ClaimPr
 	if actor == "" {
 		return principal
 	}
-	// Enrollment authentication binds the remote holder to the spoke actor.
-	// Preserve the local owner tuple in client_kind before replacing Holder so
-	// two mounted subjects (or two ordinary local holders) cannot control one
-	// another's remote lease through the shared spoke credential.
-	ownerDigest := sha256.Sum256([]byte("kata:spoke-claim-owner:v1\x00" +
-		principal.Holder + "\x00" + principal.ClientKind))
-	principal.ClientKind = "spoke:" + base64.RawURLEncoding.EncodeToString(ownerDigest[:])
+	// Existing clients keep their established actor/client-kind identity.
+	// Mounted callers carry an opaque subject-bound identity through the shared
+	// spoke credential so one subject cannot control another subject's lease.
+	if strings.HasPrefix(principal.Holder, "host:") {
+		ownerDigest := sha256.Sum256([]byte("kata:spoke-host-claim-owner:v1\x00" + principal.Holder))
+		principal.ClientKind = "spoke-host:v1:" + base64.RawURLEncoding.EncodeToString(ownerDigest[:])
+	}
 	principal.Holder = actor
 	return principal
 }

--- a/internal/daemon/handlers_claims_internal_test.go
+++ b/internal/daemon/handlers_claims_internal_test.go
@@ -21,10 +21,10 @@ import (
 func TestBoundSpokeClaimPrincipalPreservesLocalOwnerIdentity(t *testing.T) {
 	binding := db.FederationBinding{Role: db.FederationRoleSpoke, Actor: "spoke-actor"}
 	first := boundSpokeClaimPrincipal(binding, db.ClaimPrincipal{
-		Holder: hostClaimHolder("user-one"), ClientKind: "cli",
+		Holder: hostClaimHolder("user-one"), ClientKind: "cli", AuthenticatedHost: true,
 	})
 	second := boundSpokeClaimPrincipal(binding, db.ClaimPrincipal{
-		Holder: hostClaimHolder("user-two"), ClientKind: "cli",
+		Holder: hostClaimHolder("user-two"), ClientKind: "cli", AuthenticatedHost: true,
 	})
 
 	assert.Equal(t, "spoke-actor", first.Holder)
@@ -34,12 +34,14 @@ func TestBoundSpokeClaimPrincipalPreservesLocalOwnerIdentity(t *testing.T) {
 
 func TestBoundSpokeClaimPrincipalKeepsLegacyClientIdentity(t *testing.T) {
 	binding := db.FederationBinding{Role: db.FederationRoleSpoke, Actor: "spoke-actor"}
-	legacy := boundSpokeClaimPrincipal(binding, db.ClaimPrincipal{
-		Holder: "local-worker", ClientKind: "cli",
-	})
+	for _, holder := range []string{"local-worker", "host:worker"} {
+		legacy := boundSpokeClaimPrincipal(binding, db.ClaimPrincipal{
+			Holder: holder, ClientKind: "cli",
+		})
 
-	assert.Equal(t, "spoke-actor", legacy.Holder)
-	assert.Equal(t, "cli", legacy.ClientKind)
+		assert.Equal(t, "spoke-actor", legacy.Holder)
+		assert.Equal(t, "cli", legacy.ClientKind)
+	}
 }
 
 func TestNewClaimHubClientHonorsTrustedPrivateNetwork(t *testing.T) {

--- a/internal/daemon/handlers_claims_internal_test.go
+++ b/internal/daemon/handlers_claims_internal_test.go
@@ -14,8 +14,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/api"
+	"go.kenn.io/kata/internal/db"
 	kitdaemon "go.kenn.io/kit/daemon"
 )
+
+func TestBoundSpokeClaimPrincipalPreservesLocalOwnerIdentity(t *testing.T) {
+	binding := db.FederationBinding{Role: db.FederationRoleSpoke, Actor: "spoke-actor"}
+	first := boundSpokeClaimPrincipal(binding, db.ClaimPrincipal{
+		Holder: hostClaimHolder("user-one"), ClientKind: "cli",
+	})
+	second := boundSpokeClaimPrincipal(binding, db.ClaimPrincipal{
+		Holder: hostClaimHolder("user-two"), ClientKind: "cli",
+	})
+
+	assert.Equal(t, "spoke-actor", first.Holder)
+	assert.Equal(t, "spoke-actor", second.Holder)
+	assert.NotEqual(t, first.ClientKind, second.ClientKind)
+}
 
 func TestNewClaimHubClientHonorsTrustedPrivateNetwork(t *testing.T) {
 	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")

--- a/internal/daemon/handlers_claims_internal_test.go
+++ b/internal/daemon/handlers_claims_internal_test.go
@@ -32,6 +32,16 @@ func TestBoundSpokeClaimPrincipalPreservesLocalOwnerIdentity(t *testing.T) {
 	assert.NotEqual(t, first.ClientKind, second.ClientKind)
 }
 
+func TestBoundSpokeClaimPrincipalKeepsLegacyClientIdentity(t *testing.T) {
+	binding := db.FederationBinding{Role: db.FederationRoleSpoke, Actor: "spoke-actor"}
+	legacy := boundSpokeClaimPrincipal(binding, db.ClaimPrincipal{
+		Holder: "local-worker", ClientKind: "cli",
+	})
+
+	assert.Equal(t, "spoke-actor", legacy.Holder)
+	assert.Equal(t, "cli", legacy.ClientKind)
+}
+
 func TestNewClaimHubClientHonorsTrustedPrivateNetwork(t *testing.T) {
 	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
 

--- a/internal/daemon/handlers_claims_test.go
+++ b/internal/daemon/handlers_claims_test.go
@@ -964,9 +964,9 @@ func TestPendingClaimOfflineAcquireDuplicateReturnsExistingRequest(t *testing.T)
 	var n int
 	require.NoError(t, spoke.DB.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM pending_claim_requests
-		 WHERE issue_uid = ? AND holder = ? AND holder_instance_uid = ? AND client_kind = ?
+		 WHERE issue_uid = ? AND holder = ? AND holder_instance_uid = ?
 		   AND rejected_at IS NULL AND resolved_at IS NULL`,
-		issue.UID, "tester", spoke.DB.InstanceUID(), "cli").Scan(&n))
+		issue.UID, "tester", spoke.DB.InstanceUID()).Scan(&n))
 	assert.Equal(t, 1, n)
 }
 

--- a/internal/daemon/handlers_events.go
+++ b/internal/daemon/handlers_events.go
@@ -244,6 +244,9 @@ func registerEventsStream(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
+		if err := requireHostAccessLease(ctx); err != nil {
+			return nil, err
+		}
 
 		return &huma.StreamResponse{
 			Body: func(ctx huma.Context) {
@@ -304,6 +307,9 @@ func runSSEStream(hctx huma.Context, cfg ServerConfig, cursor, projectID int64) 
 		return
 	}
 	if resetTo > 0 {
+		if revalidateHostAccess(ctx) != nil {
+			return
+		}
 		writeResetFrame(w, resetTo)
 		flusher.Flush()
 		return
@@ -317,6 +323,9 @@ func runSSEStream(hctx huma.Context, cfg ServerConfig, cursor, projectID int64) 
 	}
 
 	if len(rows) == sseDrainCap+1 {
+		if revalidateHostAccess(ctx) != nil {
+			return
+		}
 		writeResetFrame(w, hwm)
 		flusher.Flush()
 		return
@@ -324,6 +333,9 @@ func runSSEStream(hctx huma.Context, cfg ServerConfig, cursor, projectID int64) 
 
 	lastSent := cursor
 	for _, ev := range rows {
+		if revalidateHostAccess(ctx) != nil {
+			return
+		}
 		writeEventFrame(w, ev)
 		flusher.Flush()
 		lastSent = ev.ID
@@ -423,6 +435,9 @@ func runLivePhase(ctx context.Context, deps livePhaseDeps, projectID, lastSent i
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			if revalidateHostAccess(ctx) != nil {
+				return
+			}
 			if _, err := io.WriteString(deps.w, ": keepalive\n\n"); err != nil {
 				return
 			}
@@ -433,6 +448,9 @@ func runLivePhase(ctx context.Context, deps livePhaseDeps, projectID, lastSent i
 			}
 			switch msg.Kind {
 			case "reset":
+				if revalidateHostAccess(ctx) != nil {
+					return
+				}
 				writeResetFrame(deps.w, msg.ResetID)
 				deps.flusher.Flush()
 				return
@@ -452,6 +470,9 @@ func runLivePhase(ctx context.Context, deps livePhaseDeps, projectID, lastSent i
 					return
 				}
 				if resetTo > 0 {
+					if revalidateHostAccess(ctx) != nil {
+						return
+					}
 					writeResetFrame(deps.w, resetTo)
 					deps.flusher.Flush()
 					return
@@ -472,6 +493,9 @@ func runLivePhase(ctx context.Context, deps livePhaseDeps, projectID, lastSent i
 						return
 					}
 					for _, ev := range rows {
+						if revalidateHostAccess(ctx) != nil {
+							return
+						}
 						writeEventFrame(deps.w, ev)
 						deps.flusher.Flush()
 						lastSent = ev.ID

--- a/internal/daemon/handlers_events.go
+++ b/internal/daemon/handlers_events.go
@@ -240,9 +240,22 @@ func registerEventsStream(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
-		projectID, err := parseSSEProjectID(ctx, cfg, in.query)
+		projectID, err := parseSSEProjectID(in.query)
 		if err != nil {
 			return nil, err
+		}
+		var projectIDs []int64
+		if projectID > 0 {
+			projectIDs = []int64{projectID}
+		}
+		ctx, err = authorizeHostProjectScope(ctx, projectIDs, nil, projectID == 0)
+		if err != nil {
+			return nil, err
+		}
+		if projectID > 0 {
+			if _, err := activeProjectByID(ctx, cfg.DB, projectID); err != nil {
+				return nil, err
+			}
 		}
 		if err := requireHostAccessLease(ctx); err != nil {
 			return nil, err
@@ -386,7 +399,7 @@ func parseNonNegativeInt64(raw, name string) (int64, error) {
 	return n, nil
 }
 
-func parseSSEProjectID(ctx context.Context, cfg ServerConfig, query map[string][]string) (int64, error) {
+func parseSSEProjectID(query map[string][]string) (int64, error) {
 	pidStr := ""
 	if vs, ok := query["project_id"]; ok && len(vs) > 0 {
 		pidStr = vs[0]
@@ -398,12 +411,6 @@ func parseSSEProjectID(ctx context.Context, cfg ServerConfig, query map[string][
 	if err != nil || n <= 0 {
 		return 0, api.NewError(400, "validation",
 			"project_id must be a positive integer", "", nil)
-	}
-	// Mirror the polling endpoint contract: an unknown positive project_id is
-	// project_not_found, not an idle 200 stream. Archived projects are also
-	// treated as not-found.
-	if _, err := activeProjectByID(ctx, cfg.DB, n); err != nil {
-		return 0, err
 	}
 	return n, nil
 }

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -252,9 +252,11 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if in.Body.PushEnabled && !federationCapabilitiesContain(capabilities, "push") {
 			return nil, api.NewError(400, "federation_capability_mismatch", "push-enabled federation replica requires push capability", "", nil)
 		}
-		if err := db.ValidateTokenActor(in.Body.Actor); err != nil {
+		actor := actorFor(ctx, in.Body.Actor)
+		if err := db.ValidateTokenActor(actor); err != nil {
 			return nil, api.NewError(400, "validation", err.Error(), "", nil)
 		}
+		in.Body.Actor = strings.TrimSpace(actor)
 		if in.Body.AdoptExisting {
 			if !in.Body.PushEnabled {
 				return nil, api.NewError(400, "federation_capability_mismatch", "adopting an existing project requires push to be enabled", "", nil)

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -166,6 +166,19 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(http.StatusBadRequest, "validation",
 				"allow_adoption_snapshot_authors requires project_id", "", nil)
 		}
+		var projectIDs []int64
+		if in.Body.ProjectID != nil {
+			if *in.Body.ProjectID <= 0 {
+				return nil, api.NewError(http.StatusBadRequest, "validation",
+					"project_id must be a positive integer", "", nil)
+			}
+			projectIDs = []int64{*in.Body.ProjectID}
+		}
+		var err error
+		ctx, err = authorizeHostProjectScope(ctx, projectIDs, nil, in.Body.ProjectID == nil)
+		if err != nil {
+			return nil, err
+		}
 		actor, err := attributedActor(ctx, in.Body.Actor)
 		if err != nil {
 			return nil, err

--- a/internal/daemon/handlers_graph.go
+++ b/internal/daemon/handlers_graph.go
@@ -74,7 +74,7 @@ func buildReachableIssueGraph(
 
 	dist, err := w.traverse(ctx, depth)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 
 	nodes := make([]api.ReachableGraphNode, 0, len(dist))
@@ -82,7 +82,7 @@ func buildReachableIssueGraph(
 		issue := w.issueByID[id]
 		project, err := w.project(ctx, issue.ProjectID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		nodes = append(nodes, api.ReachableGraphNode{
 			Issue:       issue,
@@ -93,7 +93,7 @@ func buildReachableIssueGraph(
 
 	links, err := w.linksForReached(ctx, dist)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	edges, unresolved := w.edgesAndUnresolved(links, dist, depth)
 	markTransitiveBlockLayout(edges)
@@ -154,6 +154,10 @@ func (w *graphWalk) issue(ctx context.Context, issueID int64) (db.Issue, bool, e
 func (w *graphWalk) project(ctx context.Context, projectID int64) (db.Project, error) {
 	if project, ok := w.projectByID[projectID]; ok {
 		return project, nil
+	}
+	ctx, err := authorizeHostProjectScope(ctx, []int64{projectID}, nil, false)
+	if err != nil {
+		return db.Project{}, err
 	}
 	project, err := w.store.ProjectByID(ctx, projectID)
 	if err != nil {

--- a/internal/daemon/handlers_graph.go
+++ b/internal/daemon/handlers_graph.go
@@ -132,6 +132,10 @@ func (w *graphWalk) issue(ctx context.Context, issueID int64) (db.Issue, bool, e
 	if err != nil {
 		return db.Issue{}, false, err
 	}
+	ctx, err = authorizeHostProjectScope(ctx, []int64{issue.ProjectID}, nil, false)
+	if err != nil {
+		return db.Issue{}, false, err
+	}
 	if issue.DeletedAt != nil {
 		w.hidden[issueID] = struct{}{}
 		return db.Issue{}, false, nil

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -418,6 +418,12 @@ func editIssueHandler(cfg ServerConfig) func(context.Context, *api.EditIssueRequ
 			if err := validateLinksDelta(in.Body.LinksDelta); err != nil {
 				return nil, err
 			}
+			if in.Body.LinksDelta.SetParent != nil || in.Body.LinksDelta.RemoveParent != nil {
+				ctx, err = authorizeHostProjectScope(ctx, nil, nil, true)
+				if err != nil {
+					return nil, err
+				}
+			}
 		}
 
 		params := db.EditIssueAtomicParams{

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -88,6 +88,10 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
+		ctx, err = authorizeHostProjectScope(ctx, issueProjectIDs(linkTargets), nil, false)
+		if err != nil {
+			return nil, err
+		}
 
 		// Validate priority before the idempotency lookup so an out-of-range
 		// value is rejected with a 400 instead of being silently absorbed by a
@@ -241,7 +245,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		issueOuts, err := hydrateIssueOuts(ctx, cfg.DB, in.ProjectID, issues)
 		out := &api.ListIssuesResponse{}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out.Body.Issues = issueOuts
 		return out, nil
@@ -262,6 +266,15 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if in.ProjectID < 0 {
 			return nil, api.NewError(400, "validation",
 				"project_id must be a positive integer", "", nil)
+		}
+		var projectIDs []int64
+		if in.ProjectID > 0 {
+			projectIDs = []int64{in.ProjectID}
+		}
+		var err error
+		ctx, err = authorizeHostProjectScope(ctx, projectIDs, nil, in.ProjectID == 0)
+		if err != nil {
+			return nil, err
 		}
 		if in.ProjectID > 0 {
 			if _, err := activeProjectByID(ctx, cfg.DB, in.ProjectID); err != nil {
@@ -288,7 +301,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		issueOuts, err := hydrateIssueOutsCrossProject(ctx, cfg.DB, issues)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.ListIssuesResponse{}
 		out.Body.Issues = issueOuts
@@ -321,6 +334,10 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 			include = db.IncludeDeletedYes
 		}
 		issue, err := resolveIssueByUIDOrPrefix(ctx, cfg.DB, in.UID, include)
+		if err != nil {
+			return nil, err
+		}
+		ctx, err = authorizeHostProjectScope(ctx, []int64{issue.ProjectID}, nil, false)
 		if err != nil {
 			return nil, err
 		}
@@ -638,6 +655,14 @@ func requireFederatedLinksDeltaClaims(
 	return requireFederatedLinkClaims(ctx, cfg, actor, issues...)
 }
 
+func issueProjectIDs(issues []db.Issue) []int64 {
+	projectIDs := make([]int64, 0, len(issues))
+	for _, issue := range issues {
+		projectIDs = appendUniqueInt64(projectIDs, issue.ProjectID)
+	}
+	return projectIDs
+}
+
 // firstIDConflict reports the first int64 present in both slices.
 func firstIDConflict(adds, removes []int64) (int64, bool) {
 	if len(adds) == 0 || len(removes) == 0 {
@@ -748,7 +773,7 @@ func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issu
 	}
 	links, err := loadLinkOuts(ctx, cfg.DB, issue.ID)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	labels, err := cfg.DB.LabelsByIssue(ctx, issue.ID)
 	if err != nil {
@@ -756,7 +781,7 @@ func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issu
 	}
 	parent, err := loadParentRef(ctx, cfg.DB, issue)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	children, err := cfg.DB.ChildrenOfIssue(ctx, issue.ID)
 	if err != nil {
@@ -768,7 +793,7 @@ func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issu
 	// prefix in qualified_id and its labels resolved against the wrong project.
 	childOuts, err := hydrateIssueOutsCrossProject(ctx, cfg.DB, children)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	out := &api.ShowIssueResponse{}
 	out.Body.Issue = issue
@@ -913,6 +938,10 @@ func (c *projectNames) name(ctx context.Context, id int64) (string, error) {
 	if n, ok := c.byID[id]; ok {
 		return n, nil
 	}
+	ctx, err := authorizeHostProjectScope(ctx, []int64{id}, nil, false)
+	if err != nil {
+		return "", err
+	}
 	p, err := c.store.ProjectByID(ctx, id)
 	if err != nil {
 		return "", err
@@ -983,6 +1012,10 @@ func collectLinkPeers(
 }
 
 func hydrateIssueOuts(ctx context.Context, store db.Storage, projectID int64, issues []db.Issue) ([]api.IssueOut, error) {
+	ctx, err := authorizeHostProjectScope(ctx, []int64{projectID}, nil, false)
+	if err != nil {
+		return nil, err
+	}
 	project, err := store.ProjectByID(ctx, projectID)
 	if err != nil {
 		return nil, err

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -418,7 +418,7 @@ func editIssueHandler(cfg ServerConfig) func(context.Context, *api.EditIssueRequ
 			if err := validateLinksDelta(in.Body.LinksDelta); err != nil {
 				return nil, err
 			}
-			if in.Body.LinksDelta.SetParent != nil || in.Body.LinksDelta.RemoveParent != nil {
+			if linksDeltaRequiresAllProjectsBeforeResolution(in.Body.LinksDelta) {
 				ctx, err = authorizeHostProjectScope(ctx, nil, nil, true)
 				if err != nil {
 					return nil, err
@@ -492,6 +492,20 @@ func editIssueHandler(cfg ServerConfig) func(context.Context, *api.EditIssueRequ
 		}
 		return out, nil
 	}
+}
+
+// linksDeltaRequiresAllProjectsBeforeResolution identifies relationship
+// changes whose target cannot be scoped safely after a lookup. Parent changes
+// inspect ancestry beyond the named target. Tolerant removals must treat a
+// missing target as a successful no-op, so mounted callers need complete
+// project authority before resolution to keep missing and denied targets
+// indistinguishable.
+func linksDeltaRequiresAllProjectsBeforeResolution(d *api.LinksDelta) bool {
+	if d == nil {
+		return false
+	}
+	return d.SetParent != nil || d.RemoveParent != nil ||
+		len(d.RemoveBlocks) > 0 || len(d.RemoveBlockedBy) > 0 || len(d.RemoveRelated) > 0
 }
 
 // linksDeltaRequestsAnyOp reports whether the delta carries at least one

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -1036,6 +1036,9 @@ func hydrateIssueOuts(ctx context.Context, store db.Storage, projectID int64, is
 	if err != nil {
 		return nil, err
 	}
+	if err := authorizeHostChildProjects(ctx, store, issues, childCounts); err != nil {
+		return nil, err
+	}
 	blocks, err := store.BlockNumbersByIssues(ctx, ids)
 	if err != nil {
 		return nil, err
@@ -1084,6 +1087,32 @@ func hydrateIssueOuts(ctx context.Context, store db.Storage, projectID int64, is
 		out[i] = row
 	}
 	return out, nil
+}
+
+// authorizeHostChildProjects expands the request scope to every project that
+// contributes to the child-count projection. Child links can cross project
+// boundaries even though the list itself is project-scoped.
+func authorizeHostChildProjects(
+	ctx context.Context,
+	store db.Storage,
+	issues []db.Issue,
+	counts map[int64]db.ChildCounts,
+) error {
+	projectIDs := make([]int64, 0)
+	for _, issue := range issues {
+		if counts[issue.ID].Total == 0 {
+			continue
+		}
+		children, err := store.ChildrenOfIssue(ctx, issue.ID)
+		if err != nil {
+			return err
+		}
+		for _, child := range children {
+			projectIDs = appendUniqueInt64(projectIDs, child.ProjectID)
+		}
+	}
+	_, err := authorizeHostProjectScope(ctx, projectIDs, nil, false)
+	return err
 }
 
 // peerSlice projects a slice of peer issue ids onto LinkPeer entries using

--- a/internal/daemon/handlers_links.go
+++ b/internal/daemon/handlers_links.go
@@ -74,6 +74,12 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 		if err != nil {
 			return nil, err
 		}
+		if in.Body.Type == "parent" {
+			ctx, err = authorizeHostProjectScope(ctx, nil, nil, true)
+			if err != nil {
+				return nil, err
+			}
+		}
 		to, err := resolveLinkTargetRef(ctx, cfg.DB, in.ProjectID, in.Body.ToRef, db.IncludeDeletedNo)
 		if err != nil {
 			return nil, err

--- a/internal/daemon/handlers_links.go
+++ b/internal/daemon/handlers_links.go
@@ -78,6 +78,10 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 		if err != nil {
 			return nil, err
 		}
+		ctx, err = authorizeHostProjectScope(ctx, []int64{to.ProjectID}, nil, false)
+		if err != nil {
+			return nil, err
+		}
 		if err := requireLinkTargetAddable(ctx, cfg.DB, in.ProjectID, to); err != nil {
 			return nil, err
 		}

--- a/internal/daemon/handlers_links.go
+++ b/internal/daemon/handlers_links.go
@@ -45,6 +45,9 @@ func registerLinksHandlers(humaAPI huma.API, cfg ServerConfig) {
 // peers are skipped (their link rows are still removable, but the issue can't
 // hold a live claim). Duplicates are evaluated once.
 func requireFederatedLinkClaims(ctx context.Context, cfg ServerConfig, actor string, issues ...db.Issue) error {
+	if _, err := authorizeHostProjectScope(ctx, issueProjectIDs(issues), nil, false); err != nil {
+		return err
+	}
 	seen := make(map[int64]struct{}, len(issues))
 	for _, issue := range issues {
 		if _, ok := seen[issue.ID]; ok {
@@ -102,11 +105,11 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 		names := &projectNames{store: cfg.DB}
 		canonicalFromPeer, err := linkPeerFor(ctx, names, from)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		canonicalToPeer, err := linkPeerFor(ctx, names, to)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if in.Body.Type == "related" && storageFromID > storageToID {
 			storageFromID, storageToID = storageToID, storageFromID

--- a/internal/daemon/handlers_move.go
+++ b/internal/daemon/handlers_move.go
@@ -46,6 +46,10 @@ func moveIssueHandler(cfg ServerConfig) func(context.Context, *api.MoveIssueRequ
 		if in.Body.ToProjectUID == "" {
 			return nil, api.NewError(400, "validation", "to_project_uid must be non-empty", "", nil)
 		}
+		ctx, err = authorizeHostProjectScope(ctx, nil, []string{in.Body.ToProjectUID}, false)
+		if err != nil {
+			return nil, err
+		}
 		rev, err := parseIfMatchRevision(in.IfMatch)
 		if err != nil {
 			return nil, err

--- a/internal/daemon/handlers_projects.go
+++ b/internal/daemon/handlers_projects.go
@@ -180,6 +180,11 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if in.Body.SourceProjectID == 0 {
 			return nil, api.NewError(400, "validation", "source_project_id required", "", nil)
 		}
+		var err error
+		ctx, err = authorizeHostProjectScope(ctx, []int64{in.Body.SourceProjectID}, nil, false)
+		if err != nil {
+			return nil, err
+		}
 		targetName := strings.TrimSpace(in.Body.TargetName)
 		var namePtr *string
 		if targetName != "" {

--- a/internal/daemon/handlers_ready.go
+++ b/internal/daemon/handlers_ready.go
@@ -35,7 +35,7 @@ func registerReadyHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		issueOuts, err := hydrateIssueOuts(ctx, cfg.DB, in.ProjectID, issues)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.ReadyResponse{}
 		out.Body.Issues = issueOuts
@@ -57,7 +57,7 @@ func registerReadyHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		issueOuts, err := hydrateIssueOutsCrossProject(ctx, cfg.DB, bare)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		rows := make([]api.ReadyGlobalIssueOut, len(issueOuts))
 		for i, io := range issueOuts {

--- a/internal/daemon/handlers_recurrences.go
+++ b/internal/daemon/handlers_recurrences.go
@@ -75,16 +75,24 @@ func parseIfMatchRevision(raw string) (int64, error) {
 func activeRecurrenceByUID(
 	ctx context.Context, d db.Storage, projectID int64, recUID string,
 ) (db.Recurrence, error) {
+	notFound := func() error {
+		if _, mounted := ctx.Value(hostAccessStateContextKey{}).(*hostAccessState); mounted {
+			return api.NewError(404, "not_found", "resource not found", "", nil)
+		}
+		return api.NewError(404, "not_found",
+			fmt.Sprintf("recurrence %q not found", recUID), "", nil)
+	}
 	rec, err := d.GetRecurrenceByUID(ctx, recUID)
 	if err != nil {
-		return db.Recurrence{}, api.NewError(404, "not_found",
-			fmt.Sprintf("recurrence %q not found", recUID), "", nil)
+		return db.Recurrence{}, notFound()
 	}
 	if rec.DeletedAt != nil {
-		return db.Recurrence{}, api.NewError(404, "not_found",
-			fmt.Sprintf("recurrence %q not found", recUID), "", nil)
+		return db.Recurrence{}, notFound()
 	}
 	if rec.ProjectID != projectID {
+		if _, mounted := ctx.Value(hostAccessStateContextKey{}).(*hostAccessState); mounted {
+			return db.Recurrence{}, notFound()
+		}
 		return db.Recurrence{}, api.NewError(404, "not_found",
 			fmt.Sprintf("recurrence %q not in project %d", recUID, projectID), "", nil)
 	}

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -46,52 +46,37 @@ type HostAccessController interface {
 	Authorize(context.Context, HostAccessRequest) (HostAccessDecision, error)
 }
 
-type hostAccessDecisionContextKey struct{}
-type pendingHostAccessContextKey struct{}
+type hostAccessStateContextKey struct{}
 
-type pendingHostAccess struct {
+type hostAccessState struct {
 	controller HostAccessController
 	request    HostAccessRequest
-	decision   *HostAccessDecision
+	decision   HostAccessDecision
+	authorized bool
 }
 
 func requireHostAccessLease(ctx context.Context) error {
-	if pending, ok := ctx.Value(pendingHostAccessContextKey{}).(pendingHostAccess); ok {
-		if pending.decision == nil || pending.decision.Revalidate == nil {
+	if state, ok := ctx.Value(hostAccessStateContextKey{}).(*hostAccessState); ok {
+		if !state.authorized || state.decision.Revalidate == nil {
 			return api.NewError(http.StatusServiceUnavailable, "access_lease_required",
 				"long-lived access lease required", "", nil)
 		}
-		if err := pending.decision.Revalidate(ctx); err != nil {
+		if err := state.decision.Revalidate(ctx); err != nil {
 			return api.NewError(http.StatusNotFound, "not_found", "resource not found", "", nil)
 		}
 		return nil
-	}
-	decision, ok := ctx.Value(hostAccessDecisionContextKey{}).(HostAccessDecision)
-	if !ok {
-		return nil
-	}
-	if decision.Revalidate == nil {
-		return api.NewError(http.StatusServiceUnavailable, "access_lease_required",
-			"long-lived access lease required", "", nil)
-	}
-	if err := decision.Revalidate(ctx); err != nil {
-		return api.NewError(http.StatusNotFound, "not_found", "resource not found", "", nil)
 	}
 	return nil
 }
 
 func revalidateHostAccess(ctx context.Context) error {
-	if pending, ok := ctx.Value(pendingHostAccessContextKey{}).(pendingHostAccess); ok {
-		if pending.decision == nil || pending.decision.Revalidate == nil {
+	if state, ok := ctx.Value(hostAccessStateContextKey{}).(*hostAccessState); ok {
+		if !state.authorized || state.decision.Revalidate == nil {
 			return nil
 		}
-		return pending.decision.Revalidate(ctx)
+		return state.decision.Revalidate(ctx)
 	}
-	decision, ok := ctx.Value(hostAccessDecisionContextKey{}).(HostAccessDecision)
-	if !ok || decision.Revalidate == nil {
-		return nil
-	}
-	return decision.Revalidate(ctx)
+	return nil
 }
 
 func withHostAccess(humaAPI huma.API, controller HostAccessController) {
@@ -135,14 +120,14 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 		if projectID, ok := positiveProjectID(pathParams["project_id"]); ok {
 			request.Operation.ProjectIDs = []int64{projectID}
 		}
+		state := &hostAccessState{controller: controller, request: request}
 		if hostAccessResolvedByHandler(operation.OperationID) {
-			decision := &HostAccessDecision{}
-			next(huma.WithValue(ctx, pendingHostAccessContextKey{}, pendingHostAccess{
-				controller: controller,
-				request:    request,
-				decision:   decision,
-			}))
+			next(huma.WithValue(ctx, hostAccessStateContextKey{}, state))
 			return
+		}
+		if len(request.Operation.ProjectIDs) == 0 && !hostAccessOperationWithoutProjectData(operation.OperationID) {
+			request.Operation.AllProjects = true
+			state.request.Operation.AllProjects = true
 		}
 		decision, err := controller.Authorize(ctx.Context(), request)
 		if errors.Is(err, ErrHostAccessDenied) {
@@ -154,7 +139,9 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 				"access_unavailable", "access decision unavailable")
 			return
 		}
-		next(huma.WithValue(ctx, hostAccessDecisionContextKey{}, decision))
+		state.decision = decision
+		state.authorized = true
+		next(huma.WithValue(ctx, hostAccessStateContextKey{}, state))
 	})
 }
 
@@ -175,7 +162,22 @@ func hostSelfAuthenticatedOperation(operationID string) bool {
 
 func hostAccessResolvedByHandler(operationID string) bool {
 	switch operationID {
-	case "mergeProject", "moveIssue", "streamEvents":
+	case "mergeProject",
+		"moveIssue",
+		"streamEvents",
+		"listAllIssues",
+		"auditCloses",
+		"showIssueByUID",
+		"createFederationEnrollment":
+		return true
+	default:
+		return false
+	}
+}
+
+func hostAccessOperationWithoutProjectData(operationID string) bool {
+	switch operationID {
+	case "ping", "health", "instance":
 		return true
 	default:
 		return false
@@ -193,16 +195,28 @@ func authorizeHostProjectScope(
 	projectUIDs []string,
 	allProjects bool,
 ) (context.Context, error) {
-	pending, ok := ctx.Value(pendingHostAccessContextKey{}).(pendingHostAccess)
+	state, ok := ctx.Value(hostAccessStateContextKey{}).(*hostAccessState)
 	if !ok {
 		return ctx, nil
 	}
-	pending.request.Operation.ProjectIDs = appendUniqueInt64(
-		pending.request.Operation.ProjectIDs, projectIDs...)
-	pending.request.Operation.ProjectUIDs = appendUniqueString(
-		pending.request.Operation.ProjectUIDs, projectUIDs...)
-	pending.request.Operation.AllProjects = allProjects
-	decision, err := pending.controller.Authorize(ctx, pending.request)
+	if state.authorized && state.request.Operation.AllProjects {
+		return ctx, nil
+	}
+	previousProjectIDs := len(state.request.Operation.ProjectIDs)
+	previousProjectUIDs := len(state.request.Operation.ProjectUIDs)
+	previousAllProjects := state.request.Operation.AllProjects
+	state.request.Operation.ProjectIDs = appendUniqueInt64(
+		state.request.Operation.ProjectIDs, projectIDs...)
+	state.request.Operation.ProjectUIDs = appendUniqueString(
+		state.request.Operation.ProjectUIDs, projectUIDs...)
+	state.request.Operation.AllProjects = state.request.Operation.AllProjects || allProjects
+	scopeChanged := previousProjectIDs != len(state.request.Operation.ProjectIDs) ||
+		previousProjectUIDs != len(state.request.Operation.ProjectUIDs) ||
+		previousAllProjects != state.request.Operation.AllProjects
+	if state.authorized && !scopeChanged {
+		return ctx, nil
+	}
+	decision, err := state.controller.Authorize(ctx, state.request)
 	if errors.Is(err, ErrHostAccessDenied) {
 		return ctx, api.NewError(http.StatusNotFound, "not_found", "resource not found", "", nil)
 	}
@@ -210,9 +224,8 @@ func authorizeHostProjectScope(
 		return ctx, api.NewError(http.StatusServiceUnavailable,
 			"access_unavailable", "access decision unavailable", "", nil)
 	}
-	if pending.decision != nil {
-		*pending.decision = decision
-	}
+	state.decision = decision
+	state.authorized = true
 	return ctx, nil
 }
 
@@ -294,4 +307,12 @@ func writeHostAccessError(ctx huma.Context, status int, code, message string) {
 	ctx.SetHeader("Content-Type", "application/json")
 	ctx.SetStatus(status)
 	_, _ = ctx.BodyWriter().Write(body)
+}
+
+func internalAPIError(err error) error {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr
+	}
+	return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
 }

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -19,10 +20,13 @@ var ErrHostAccessDenied = errors.New("host access denied")
 // HostOperation is the internal representation passed through the public
 // service adapter.
 type HostOperation struct {
-	ID         string
-	Method     string
-	Path       string
-	PathParams map[string]string
+	ID          string
+	Method      string
+	Path        string
+	PathParams  map[string]string
+	ProjectIDs  []int64
+	ProjectUIDs []string
+	AllProjects bool
 }
 
 // HostAccessRequest contains only generic request identity and route facts.
@@ -43,8 +47,25 @@ type HostAccessController interface {
 }
 
 type hostAccessDecisionContextKey struct{}
+type pendingHostAccessContextKey struct{}
+
+type pendingHostAccess struct {
+	controller HostAccessController
+	request    HostAccessRequest
+	decision   *HostAccessDecision
+}
 
 func requireHostAccessLease(ctx context.Context) error {
+	if pending, ok := ctx.Value(pendingHostAccessContextKey{}).(pendingHostAccess); ok {
+		if pending.decision == nil || pending.decision.Revalidate == nil {
+			return api.NewError(http.StatusServiceUnavailable, "access_lease_required",
+				"long-lived access lease required", "", nil)
+		}
+		if err := pending.decision.Revalidate(ctx); err != nil {
+			return api.NewError(http.StatusNotFound, "not_found", "resource not found", "", nil)
+		}
+		return nil
+	}
 	decision, ok := ctx.Value(hostAccessDecisionContextKey{}).(HostAccessDecision)
 	if !ok {
 		return nil
@@ -60,6 +81,12 @@ func requireHostAccessLease(ctx context.Context) error {
 }
 
 func revalidateHostAccess(ctx context.Context) error {
+	if pending, ok := ctx.Value(pendingHostAccessContextKey{}).(pendingHostAccess); ok {
+		if pending.decision == nil || pending.decision.Revalidate == nil {
+			return nil
+		}
+		return pending.decision.Revalidate(ctx)
+	}
 	decision, ok := ctx.Value(hostAccessDecisionContextKey{}).(HostAccessDecision)
 	if !ok || decision.Revalidate == nil {
 		return nil
@@ -72,34 +99,52 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 		return
 	}
 	humaAPI.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
-		principal, ok := PrincipalFromContext(ctx.Context())
-		if !ok || principal.Kind != PrincipalHost || strings.TrimSpace(principal.Subject) == "" ||
-			strings.TrimSpace(principal.Actor) == "" {
-			writeHostAccessError(ctx, http.StatusUnauthorized,
-				"authentication_required", "authentication required")
-			return
-		}
-
 		operation := ctx.Operation()
 		if operation == nil || strings.TrimSpace(operation.OperationID) == "" {
 			writeHostAccessError(ctx, http.StatusServiceUnavailable,
 				"access_unavailable", "access decision unavailable")
 			return
 		}
+		principal, ok := PrincipalFromContext(ctx.Context())
+		if !ok || principal.Kind != PrincipalHost || strings.TrimSpace(principal.Subject) == "" ||
+			strings.TrimSpace(principal.Actor) == "" {
+			if hostSelfAuthenticatedOperation(operation.OperationID) &&
+				hasBearerHeader(ctx.Header(authHeader)) {
+				next(ctx)
+				return
+			}
+			writeHostAccessError(ctx, http.StatusUnauthorized,
+				"authentication_required", "authentication required")
+			return
+		}
+
 		pathParams := make(map[string]string)
 		for _, parameter := range operation.Parameters {
 			if parameter != nil && parameter.In == "path" {
 				pathParams[parameter.Name] = ctx.Param(parameter.Name)
 			}
 		}
-		decision, err := controller.Authorize(ctx.Context(), HostAccessRequest{
+		request := HostAccessRequest{
 			Subject: principal.Subject,
 			Actor:   principal.Actor,
 			Operation: HostOperation{
 				ID: operation.OperationID, Method: operation.Method, Path: operation.Path,
 				PathParams: pathParams,
 			},
-		})
+		}
+		if projectID, ok := positiveProjectID(pathParams["project_id"]); ok {
+			request.Operation.ProjectIDs = []int64{projectID}
+		}
+		if hostAccessResolvedByHandler(operation.OperationID) {
+			decision := &HostAccessDecision{}
+			next(huma.WithValue(ctx, pendingHostAccessContextKey{}, pendingHostAccess{
+				controller: controller,
+				request:    request,
+				decision:   decision,
+			}))
+			return
+		}
+		decision, err := controller.Authorize(ctx.Context(), request)
 		if errors.Is(err, ErrHostAccessDenied) {
 			writeHostAccessError(ctx, http.StatusNotFound, "not_found", "resource not found")
 			return
@@ -111,6 +156,103 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 		}
 		next(huma.WithValue(ctx, hostAccessDecisionContextKey{}, decision))
 	})
+}
+
+func hostSelfAuthenticatedOperation(operationID string) bool {
+	switch operationID {
+	case "getFederationProjectMetadata",
+		"pollFederationProjectEvents",
+		"ingestFederationProjectEvents",
+		"acquireIssueLease",
+		"renewIssueLease",
+		"releaseIssueLease",
+		"getIssueLeaseStatus":
+		return true
+	default:
+		return false
+	}
+}
+
+func hostAccessResolvedByHandler(operationID string) bool {
+	switch operationID {
+	case "mergeProject", "moveIssue", "streamEvents":
+		return true
+	default:
+		return false
+	}
+}
+
+func positiveProjectID(raw string) (int64, bool) {
+	projectID, err := strconv.ParseInt(raw, 10, 64)
+	return projectID, err == nil && projectID > 0
+}
+
+func authorizeHostProjectScope(
+	ctx context.Context,
+	projectIDs []int64,
+	projectUIDs []string,
+	allProjects bool,
+) (context.Context, error) {
+	pending, ok := ctx.Value(pendingHostAccessContextKey{}).(pendingHostAccess)
+	if !ok {
+		return ctx, nil
+	}
+	pending.request.Operation.ProjectIDs = appendUniqueInt64(
+		pending.request.Operation.ProjectIDs, projectIDs...)
+	pending.request.Operation.ProjectUIDs = appendUniqueString(
+		pending.request.Operation.ProjectUIDs, projectUIDs...)
+	pending.request.Operation.AllProjects = allProjects
+	decision, err := pending.controller.Authorize(ctx, pending.request)
+	if errors.Is(err, ErrHostAccessDenied) {
+		return ctx, api.NewError(http.StatusNotFound, "not_found", "resource not found", "", nil)
+	}
+	if err != nil {
+		return ctx, api.NewError(http.StatusServiceUnavailable,
+			"access_unavailable", "access decision unavailable", "", nil)
+	}
+	if pending.decision != nil {
+		*pending.decision = decision
+	}
+	return ctx, nil
+}
+
+func appendUniqueInt64(values []int64, additional ...int64) []int64 {
+	for _, candidate := range additional {
+		if candidate <= 0 {
+			continue
+		}
+		found := false
+		for _, value := range values {
+			if value == candidate {
+				found = true
+				break
+			}
+		}
+		if !found {
+			values = append(values, candidate)
+		}
+	}
+	return values
+}
+
+func appendUniqueString(values []string, additional ...string) []string {
+	for _, candidate := range additional {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		found := false
+		for _, value := range values {
+			if value == candidate {
+				found = true
+				break
+			}
+		}
+		if !found {
+			values = append(values, candidate)
+		}
+	}
+	return values
 }
 
 func authorizeHostHTTP(

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -120,6 +120,9 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 		if projectID, ok := positiveProjectID(pathParams["project_id"]); ok {
 			request.Operation.ProjectIDs = []int64{projectID}
 		}
+		if hostAccessRequiresAllProjects(operation.OperationID) {
+			request.Operation.AllProjects = true
+		}
 		state := &hostAccessState{controller: controller, request: request}
 		if hostAccessResolvedByHandler(operation.OperationID) {
 			next(huma.WithValue(ctx, hostAccessStateContextKey{}, state))
@@ -167,8 +170,20 @@ func hostAccessResolvedByHandler(operationID string) bool {
 		"streamEvents",
 		"listAllIssues",
 		"auditCloses",
-		"showIssueByUID",
 		"createFederationEnrollment":
+		return true
+	default:
+		return false
+	}
+}
+
+// hostAccessRequiresAllProjects identifies operations whose result or side
+// effects can depend on relationships outside the project named in the URL.
+// Requiring complete authority before dispatch keeps denials from becoming
+// project-existence or relationship-state oracles.
+func hostAccessRequiresAllProjects(operationID string) bool {
+	switch operationID {
+	case "purgeIssue", "purgeProject", "closeIssue", "readyIssues", "showIssueByUID":
 		return true
 	default:
 		return false

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -1,0 +1,155 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/kata/internal/api"
+)
+
+// ErrHostAccessDenied is the private adapter sentinel for a host decision that
+// must not disclose resource existence.
+var ErrHostAccessDenied = errors.New("host access denied")
+
+// HostOperation is the internal representation passed through the public
+// service adapter.
+type HostOperation struct {
+	ID         string
+	Method     string
+	Path       string
+	PathParams map[string]string
+}
+
+// HostAccessRequest contains only generic request identity and route facts.
+type HostAccessRequest struct {
+	Subject   string
+	Actor     string
+	Operation HostOperation
+}
+
+// HostAccessDecision contains optional long-lived authorization state.
+type HostAccessDecision struct {
+	Revalidate func(context.Context) error
+}
+
+// HostAccessController is implemented by the public package adapter.
+type HostAccessController interface {
+	Authorize(context.Context, HostAccessRequest) (HostAccessDecision, error)
+}
+
+type hostAccessDecisionContextKey struct{}
+
+func requireHostAccessLease(ctx context.Context) error {
+	decision, ok := ctx.Value(hostAccessDecisionContextKey{}).(HostAccessDecision)
+	if !ok {
+		return nil
+	}
+	if decision.Revalidate == nil {
+		return api.NewError(http.StatusServiceUnavailable, "access_lease_required",
+			"long-lived access lease required", "", nil)
+	}
+	if err := decision.Revalidate(ctx); err != nil {
+		return api.NewError(http.StatusNotFound, "not_found", "resource not found", "", nil)
+	}
+	return nil
+}
+
+func revalidateHostAccess(ctx context.Context) error {
+	decision, ok := ctx.Value(hostAccessDecisionContextKey{}).(HostAccessDecision)
+	if !ok || decision.Revalidate == nil {
+		return nil
+	}
+	return decision.Revalidate(ctx)
+}
+
+func withHostAccess(humaAPI huma.API, controller HostAccessController) {
+	if controller == nil {
+		return
+	}
+	humaAPI.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+		principal, ok := PrincipalFromContext(ctx.Context())
+		if !ok || principal.Kind != PrincipalHost || strings.TrimSpace(principal.Subject) == "" ||
+			strings.TrimSpace(principal.Actor) == "" {
+			writeHostAccessError(ctx, http.StatusUnauthorized,
+				"authentication_required", "authentication required")
+			return
+		}
+
+		operation := ctx.Operation()
+		if operation == nil || strings.TrimSpace(operation.OperationID) == "" {
+			writeHostAccessError(ctx, http.StatusServiceUnavailable,
+				"access_unavailable", "access decision unavailable")
+			return
+		}
+		pathParams := make(map[string]string)
+		for _, parameter := range operation.Parameters {
+			if parameter != nil && parameter.In == "path" {
+				pathParams[parameter.Name] = ctx.Param(parameter.Name)
+			}
+		}
+		decision, err := controller.Authorize(ctx.Context(), HostAccessRequest{
+			Subject: principal.Subject,
+			Actor:   principal.Actor,
+			Operation: HostOperation{
+				ID: operation.OperationID, Method: operation.Method, Path: operation.Path,
+				PathParams: pathParams,
+			},
+		})
+		if errors.Is(err, ErrHostAccessDenied) {
+			writeHostAccessError(ctx, http.StatusNotFound, "not_found", "resource not found")
+			return
+		}
+		if err != nil {
+			writeHostAccessError(ctx, http.StatusServiceUnavailable,
+				"access_unavailable", "access decision unavailable")
+			return
+		}
+		next(huma.WithValue(ctx, hostAccessDecisionContextKey{}, decision))
+	})
+}
+
+func authorizeHostHTTP(
+	w http.ResponseWriter,
+	r *http.Request,
+	controller HostAccessController,
+	operation HostOperation,
+) bool {
+	if controller == nil {
+		return true
+	}
+	principal, ok := PrincipalFromContext(r.Context())
+	if !ok || principal.Kind != PrincipalHost || strings.TrimSpace(principal.Subject) == "" ||
+		strings.TrimSpace(principal.Actor) == "" {
+		api.WriteEnvelope(w, http.StatusUnauthorized,
+			"authentication_required", "authentication required")
+		return false
+	}
+	_, err := controller.Authorize(r.Context(), HostAccessRequest{
+		Subject: principal.Subject, Actor: principal.Actor, Operation: operation,
+	})
+	if errors.Is(err, ErrHostAccessDenied) {
+		api.WriteEnvelope(w, http.StatusNotFound, "not_found", "resource not found")
+		return false
+	}
+	if err != nil {
+		api.WriteEnvelope(w, http.StatusServiceUnavailable,
+			"access_unavailable", "access decision unavailable")
+		return false
+	}
+	return true
+}
+
+func writeHostAccessError(ctx huma.Context, status int, code, message string) {
+	body, _ := json.Marshal(api.ErrorEnvelope{
+		Status: status,
+		Error:  api.ErrorBody{Code: code, Message: message},
+	})
+	ctx.SetHeader("Content-Type", "application/json")
+	ctx.SetStatus(status)
+	_, _ = ctx.BodyWriter().Write(body)
+}

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -167,7 +167,6 @@ func hostAccessResolvedByHandler(operationID string) bool {
 	switch operationID {
 	case "mergeProject",
 		"moveIssue",
-		"streamEvents",
 		"listAllIssues",
 		"auditCloses",
 		"createFederationEnrollment":
@@ -183,7 +182,8 @@ func hostAccessResolvedByHandler(operationID string) bool {
 // project-existence or relationship-state oracles.
 func hostAccessRequiresAllProjects(operationID string) bool {
 	switch operationID {
-	case "purgeIssue", "purgeProject", "closeIssue", "readyIssues", "showIssueByUID":
+	case "purgeIssue", "purgeProject", "closeIssue", "readyIssues", "showIssueByUID",
+		"importIssues", "pollProjectEvents", "streamEvents":
 		return true
 	default:
 		return false

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -168,7 +168,6 @@ func hostAccessResolvedByHandler(operationID string) bool {
 	case "mergeProject",
 		"moveIssue",
 		"listAllIssues",
-		"auditCloses",
 		"createFederationEnrollment":
 		return true
 	default:
@@ -183,7 +182,7 @@ func hostAccessResolvedByHandler(operationID string) bool {
 func hostAccessRequiresAllProjects(operationID string) bool {
 	switch operationID {
 	case "purgeIssue", "purgeProject", "closeIssue", "readyIssues", "showIssueByUID",
-		"importIssues", "pollProjectEvents", "streamEvents":
+		"importIssues", "pollProjectEvents", "streamEvents", "auditCloses", "digestProject":
 		return true
 	default:
 		return false

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -91,8 +91,12 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 			return
 		}
 		principal, ok := PrincipalFromContext(ctx.Context())
-		if !ok || principal.Kind != PrincipalHost || strings.TrimSpace(principal.Subject) == "" ||
-			strings.TrimSpace(principal.Actor) == "" {
+		if ok && !validHostPrincipal(principal) {
+			writeHostAccessError(ctx, http.StatusUnauthorized,
+				"authentication_required", "authentication required")
+			return
+		}
+		if !ok {
 			if hostSelfAuthenticatedOperation(operation.OperationID) &&
 				hasBearerHeader(ctx.Header(authHeader)) {
 				next(ctx)
@@ -182,7 +186,8 @@ func hostAccessResolvedByHandler(operationID string) bool {
 func hostAccessRequiresAllProjects(operationID string) bool {
 	switch operationID {
 	case "purgeIssue", "purgeProject", "closeIssue", "readyIssues", "showIssueByUID",
-		"importIssues", "pollProjectEvents", "streamEvents", "auditCloses", "digestProject":
+		"importIssues", "pollProjectEvents", "streamEvents", "auditCloses", "digestProject",
+		"deleteLink":
 		return true
 	default:
 		return false
@@ -292,8 +297,7 @@ func authorizeHostHTTP(
 		return true
 	}
 	principal, ok := PrincipalFromContext(r.Context())
-	if !ok || principal.Kind != PrincipalHost || strings.TrimSpace(principal.Subject) == "" ||
-		strings.TrimSpace(principal.Actor) == "" {
+	if !ok || !validHostPrincipal(principal) {
 		api.WriteEnvelope(w, http.StatusUnauthorized,
 			"authentication_required", "authentication required")
 		return false

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -187,7 +187,7 @@ func hostAccessRequiresAllProjects(operationID string) bool {
 	switch operationID {
 	case "purgeIssue", "purgeProject", "closeIssue", "readyIssues", "showIssueByUID",
 		"importIssues", "pollProjectEvents", "streamEvents", "auditCloses", "digestProject",
-		"deleteLink":
+		"deleteLink", "rewriteAuthorIdentity":
 		return true
 	default:
 		return false

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"strings"
 
 	"go.kenn.io/kata/internal/api"
 	"go.kenn.io/kata/internal/db"
@@ -54,6 +55,12 @@ func WithPrincipal(ctx context.Context, p Principal) context.Context {
 func PrincipalFromContext(ctx context.Context) (Principal, bool) {
 	p, ok := ctx.Value(principalContextKey{}).(Principal)
 	return p, ok
+}
+
+func validHostPrincipal(principal Principal) bool {
+	return principal.Kind == PrincipalHost &&
+		strings.TrimSpace(principal.Subject) != "" &&
+		strings.TrimSpace(principal.Actor) != ""
 }
 
 func withInsecureReadonlyRequest(ctx context.Context) context.Context {

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -28,12 +28,16 @@ const (
 	// header (or its value is empty). Writes against this principal are
 	// rejected; reads pass through.
 	PrincipalTrustedProxyAbsent PrincipalKind = "trusted_proxy_absent"
+	// PrincipalHost is supplied in process by a mounted service's host access
+	// adapter. It never comes from a network header.
+	PrincipalHost PrincipalKind = "host"
 )
 
 // Principal is the request-local identity derived by auth middleware.
 type Principal struct {
 	Kind    PrincipalKind
 	Actor   string
+	Subject string
 	TokenID int64
 	Name    *string
 }

--- a/internal/daemon/resolver.go
+++ b/internal/daemon/resolver.go
@@ -246,7 +246,14 @@ func fillLinksDeltaParams(ctx context.Context, store db.Storage, projectID int64
 		return nil
 	}
 	resolve := func(ref string, include db.IncludeDeleted) (db.Issue, error) {
-		return resolveLinkTargetRef(ctx, store, projectID, ref, include)
+		issue, err := resolveLinkTargetRef(ctx, store, projectID, ref, include)
+		if err != nil {
+			return db.Issue{}, err
+		}
+		if _, err := authorizeHostProjectScope(ctx, []int64{issue.ProjectID}, nil, false); err != nil {
+			return db.Issue{}, err
+		}
+		return issue, nil
 	}
 	// resolveAdd is the add-side variant: resolve then gate the target so a
 	// peer in an archived project is rejected before any mutation runs.

--- a/internal/daemon/resolver.go
+++ b/internal/daemon/resolver.go
@@ -88,10 +88,13 @@ func qualifiedID(projectName, shortID string) string {
 // as an anti-fishing guard), link targets may live in any project: a bare
 // short_id resolves in the subject issue's project, a qualified
 // "project#short_id" in the named project, and a 26-char ULID globally. A
-// miss is a plain issue_not_found — it means "not found anywhere", and
-// single-token auth makes that no leak.
+// Standalone misses use issue_not_found. Mounted misses use the same generic
+// not_found response as an access denial so target state is not an oracle.
 func resolveLinkTargetRef(ctx context.Context, store db.Storage, subjectProjectID int64, ref string, include db.IncludeDeleted) (db.Issue, error) {
 	notFound := api.NewError(404, "issue_not_found", "issue not found", "", nil)
+	if _, mounted := ctx.Value(hostAccessStateContextKey{}).(*hostAccessState); mounted {
+		notFound = api.NewError(404, "not_found", "resource not found", "", nil)
+	}
 	parsed, err := shortid.Parse(ref)
 	if err != nil {
 		return db.Issue{}, notFound

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -73,6 +73,10 @@ type ServerConfig struct {
 	// state for /health. Nil means semantic search is disabled, in which case
 	// the health response omits the embeddings block entirely.
 	ReconcilerHealth func() ReconcilerHealth
+
+	// HostAccess enables in-process authentication and authorization supplied
+	// by a mounting application. It is nil for the standalone daemon.
+	HostAccess HostAccessController
 }
 
 // authPolicy returns the resolved bearer-auth policy in the form the
@@ -160,10 +164,11 @@ func NewServer(cfg ServerConfig) *Server {
 	// envelope shape, so we must disable the transform.
 	humaConfig.CreateHooks = nil
 	humaAPI := huma.NewAPI(humaConfig, api.WrapErrorAdapter(humago.NewAdapter(mux, "")))
+	withHostAccess(humaAPI, cfg.HostAccess)
 
 	s := &Server{cfg: cfg, api: humaAPI}
 	registerRoutes(humaAPI, mux, cfg)
-	registerOpenAPIYAML(mux)
+	registerOpenAPIYAML(mux, cfg.HostAccess)
 	applyErrorEnvelopeResponses(humaAPI.OpenAPI())
 	applyJSONBlobSchemaOverrides(humaAPI.OpenAPI())
 
@@ -201,8 +206,14 @@ func (s *Server) API() huma.API { return s.api }
 // owned by the caller.
 func (s *Server) Close() error { return nil }
 
-func registerOpenAPIYAML(mux *http.ServeMux) {
-	mux.HandleFunc(http.MethodGet+" /openapi.yaml", func(w http.ResponseWriter, _ *http.Request) {
+func registerOpenAPIYAML(mux *http.ServeMux, hostAccess HostAccessController) {
+	mux.HandleFunc(http.MethodGet+" /openapi.yaml", func(w http.ResponseWriter, r *http.Request) {
+		if !authorizeHostHTTP(w, r, hostAccess, HostOperation{
+			ID: "openAPI", Method: http.MethodGet, Path: "/openapi.yaml",
+			PathParams: map[string]string{},
+		}) {
+			return
+		}
 		out, err := OpenAPIYAML()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/db/claim_policy.go
+++ b/internal/db/claim_policy.go
@@ -70,17 +70,14 @@ func LeaseResultFor(claim IssueClaim, granted bool, events []Event) LeaseResult 
 
 // SameClaimGateHolder reports whether a mutation principal owns the cached
 // claim. Existing claim clients retain their holder-and-instance gate identity.
-// Mounted host claims also include their versioned client kind because it
-// carries the authenticated subject through spoke federation.
+// Authenticated mounted host principals also include their exact client kind
+// because it carries the subject through spoke federation. Caller-provided
+// holder or client-kind strings never opt into that comparison.
 func SameClaimGateHolder(claim IssueClaim, principal ClaimPrincipal) bool {
-	if subjectBoundClaimKind(claim.ClientKind) || subjectBoundClaimKind(principal.ClientKind) {
+	if principal.AuthenticatedHost {
 		return SameClaimPrincipal(claim, principal)
 	}
 	return claim.Holder == principal.Holder && claim.HolderInstanceUID == principal.HolderInstanceUID
-}
-
-func subjectBoundClaimKind(kind string) bool {
-	return kind == "host:v1" || strings.HasPrefix(kind, "spoke-host:v1:")
 }
 
 // ClaimStatusRefreshErrorKey returns the stable metadata key for one issue's

--- a/internal/db/claim_policy.go
+++ b/internal/db/claim_policy.go
@@ -69,10 +69,18 @@ func LeaseResultFor(claim IssueClaim, granted bool, events []Event) LeaseResult 
 }
 
 // SameClaimGateHolder reports whether a mutation principal owns the cached
-// claim. Client kind is deliberately not part of the mutation gate identity.
+// claim. Existing claim clients retain their holder-and-instance gate identity.
+// Mounted host claims also include their versioned client kind because it
+// carries the authenticated subject through spoke federation.
 func SameClaimGateHolder(claim IssueClaim, principal ClaimPrincipal) bool {
-	return claim.Holder == principal.Holder &&
-		claim.HolderInstanceUID == principal.HolderInstanceUID
+	if subjectBoundClaimKind(claim.ClientKind) || subjectBoundClaimKind(principal.ClientKind) {
+		return SameClaimPrincipal(claim, principal)
+	}
+	return claim.Holder == principal.Holder && claim.HolderInstanceUID == principal.HolderInstanceUID
+}
+
+func subjectBoundClaimKind(kind string) bool {
+	return kind == "host:v1" || strings.HasPrefix(kind, "spoke-host:v1:")
 }
 
 // ClaimStatusRefreshErrorKey returns the stable metadata key for one issue's

--- a/internal/db/claim_policy_test.go
+++ b/internal/db/claim_policy_test.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSameClaimGateHolderPreservesLegacyClientKindCompatibility(t *testing.T) {
+	claim := IssueClaim{Holder: "worker", HolderInstanceUID: "instance", ClientKind: "old-cli"}
+	principal := ClaimPrincipal{Holder: "worker", HolderInstanceUID: "instance", ClientKind: "new-cli"}
+
+	assert.True(t, SameClaimGateHolder(claim, principal))
+}
+
+func TestSameClaimGateHolderIncludesMountedSubjectIdentity(t *testing.T) {
+	claim := IssueClaim{Holder: "spoke", HolderInstanceUID: "instance", ClientKind: "spoke-host:v1:first"}
+	owner := ClaimPrincipal{Holder: "spoke", HolderInstanceUID: "instance", ClientKind: "spoke-host:v1:first"}
+	other := ClaimPrincipal{Holder: "spoke", HolderInstanceUID: "instance", ClientKind: "spoke-host:v1:second"}
+
+	assert.True(t, SameClaimGateHolder(claim, owner))
+	assert.False(t, SameClaimGateHolder(claim, other))
+}

--- a/internal/db/claim_policy_test.go
+++ b/internal/db/claim_policy_test.go
@@ -8,15 +8,16 @@ import (
 
 func TestSameClaimGateHolderPreservesLegacyClientKindCompatibility(t *testing.T) {
 	claim := IssueClaim{Holder: "worker", HolderInstanceUID: "instance", ClientKind: "old-cli"}
-	principal := ClaimPrincipal{Holder: "worker", HolderInstanceUID: "instance", ClientKind: "new-cli"}
-
-	assert.True(t, SameClaimGateHolder(claim, principal))
+	for _, clientKind := range []string{"new-cli", "host:v1", "spoke-host:v1:caller-controlled"} {
+		principal := ClaimPrincipal{Holder: "worker", HolderInstanceUID: "instance", ClientKind: clientKind}
+		assert.True(t, SameClaimGateHolder(claim, principal))
+	}
 }
 
 func TestSameClaimGateHolderIncludesMountedSubjectIdentity(t *testing.T) {
 	claim := IssueClaim{Holder: "spoke", HolderInstanceUID: "instance", ClientKind: "spoke-host:v1:first"}
-	owner := ClaimPrincipal{Holder: "spoke", HolderInstanceUID: "instance", ClientKind: "spoke-host:v1:first"}
-	other := ClaimPrincipal{Holder: "spoke", HolderInstanceUID: "instance", ClientKind: "spoke-host:v1:second"}
+	owner := ClaimPrincipal{Holder: "spoke", HolderInstanceUID: "instance", ClientKind: "spoke-host:v1:first", AuthenticatedHost: true}
+	other := ClaimPrincipal{Holder: "spoke", HolderInstanceUID: "instance", ClientKind: "spoke-host:v1:second", AuthenticatedHost: true}
 
 	assert.True(t, SameClaimGateHolder(claim, owner))
 	assert.False(t, SameClaimGateHolder(claim, other))

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -212,6 +212,10 @@ type ClaimPrincipal struct {
 	HolderInstanceUID string
 	Holder            string
 	ClientKind        string
+	// AuthenticatedHost is request provenance set only by mounted host
+	// authentication. It is deliberately not persisted or accepted from wire
+	// input; daemon binding and storage gates use it only during this request.
+	AuthenticatedHost bool
 }
 
 // AcquireClaimParams requests a hard or timed claim on a project-scoped issue

--- a/service.go
+++ b/service.go
@@ -310,7 +310,10 @@ func (a hostAccessControllerAdapter) Authorize(
 		Principal: Principal{Subject: request.Subject, Actor: request.Actor},
 		Operation: Operation{
 			ID: request.Operation.ID, Method: request.Operation.Method, Path: request.Operation.Path,
-			PathParams: request.Operation.PathParams,
+			PathParams:  request.Operation.PathParams,
+			ProjectIDs:  append([]int64(nil), request.Operation.ProjectIDs...),
+			ProjectUIDs: append([]string(nil), request.Operation.ProjectUIDs...),
+			AllProjects: request.Operation.AllProjects,
 		},
 	})
 	if errors.Is(err, ErrAccessDenied) {

--- a/service.go
+++ b/service.go
@@ -47,8 +47,8 @@ type PostgresConfig struct {
 	AllowInsecureTransport bool
 }
 
-// AuthConfig defines the authentication boundary for a mounted Service.
-// Exactly one of Token or TrustCallerAuthentication must be selected.
+// AuthConfig defines Kata-owned authentication for a mounted Service. Select
+// exactly one of Token, TrustCallerAuthentication, or Config.Access.
 type AuthConfig struct {
 	// Token protects Kata's ordinary HTTP surface. Federation transport and
 	// claim actions retain their own scoped credential checks.
@@ -84,6 +84,9 @@ type Config struct {
 	Postgres   PostgresConfig
 	Auth       AuthConfig
 	GitHubSync GitHubSyncConfig
+	// Access selects host-supplied in-process authentication and authorization.
+	// It is mutually exclusive with Auth.
+	Access AccessController
 	// FederationCredentials isolates secret material from other Service
 	// instances. Nil selects a service-owned in-memory store.
 	FederationCredentials FederationCredentialStore
@@ -107,6 +110,7 @@ type Service struct {
 	gitHubSyncFetcher     githubsync.Fetcher
 	federationCredentials config.FederationCredentialStore
 	logger                *slog.Logger
+	hostAccessEnabled     bool
 	lifetimeCtx           context.Context
 	lifetimeCancel        context.CancelFunc
 	handlerWG             sync.WaitGroup
@@ -130,11 +134,14 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 	if strings.TrimSpace(cfg.DSN) == "" {
 		return nil, errors.New("kata: storage DSN is required")
 	}
-	if strings.TrimSpace(cfg.Auth.Token) == "" && !cfg.Auth.TrustCallerAuthentication {
+	usesAccess := cfg.Access != nil
+	usesToken := strings.TrimSpace(cfg.Auth.Token) != ""
+	usesTrustedCaller := cfg.Auth.TrustCallerAuthentication
+	if !usesAccess && !usesToken && !usesTrustedCaller {
 		return nil, errors.New("kata: auth token is required unless caller authentication is explicitly trusted")
 	}
-	if strings.TrimSpace(cfg.Auth.Token) != "" && cfg.Auth.TrustCallerAuthentication {
-		return nil, errors.New("kata: auth token and trusted caller authentication are mutually exclusive")
+	if boolCount(usesAccess, usesToken, usesTrustedCaller) != 1 {
+		return nil, errors.New("kata: auth token, trusted caller authentication, and host access are mutually exclusive")
 	}
 	gitHubSyncConfig, err := resolveGitHubSyncConfig(cfg.GitHubSync)
 	if err != nil {
@@ -196,6 +203,10 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 		}
 		gitHubSyncFetcher = factory(gitHubSyncConfig)
 	}
+	var hostAccess daemon.HostAccessController
+	if cfg.Access != nil {
+		hostAccess = hostAccessControllerAdapter{controller: cfg.Access}
+	}
 	server := daemon.NewServer(daemon.ServerConfig{
 		DB:                    store,
 		StartedAt:             startedAt,
@@ -207,6 +218,7 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 		GitHubSyncWake:        wakeGitHubSync,
 		Hooks:                 hookSink,
 		Auth:                  config.AuthConfig{Token: cfg.Auth.Token},
+		HostAccess:            hostAccess,
 		Logger:                logger,
 	})
 
@@ -220,6 +232,7 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 		gitHubSyncFetcher:     gitHubSyncFetcher,
 		federationCredentials: federationCredentials,
 		logger:                logger,
+		hostAccessEnabled:     cfg.Access != nil,
 		lifetimeCtx:           lifetimeCtx,
 		lifetimeCancel:        lifetimeCancel,
 		closeDone:             make(chan struct{}),
@@ -264,7 +277,53 @@ func (s *Service) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		stopLifetimeCancel()
 		cancel()
 	}()
+	if principal, ok := principalFromContext(requestCtx); s.hostAccessEnabled && ok {
+		requestCtx = daemon.WithPrincipal(requestCtx, daemon.Principal{
+			Kind: daemon.PrincipalHost, Subject: principal.Subject, Actor: principal.Actor,
+		})
+	}
 	s.server.Handler().ServeHTTP(w, r.WithContext(requestCtx))
+}
+
+func boolCount(values ...bool) int {
+	count := 0
+	for _, value := range values {
+		if value {
+			count++
+		}
+	}
+	return count
+}
+
+type hostAccessControllerAdapter struct {
+	controller AccessController
+}
+
+func (a hostAccessControllerAdapter) Authorize(
+	ctx context.Context,
+	request daemon.HostAccessRequest,
+) (daemon.HostAccessDecision, error) {
+	if a.controller == nil {
+		return daemon.HostAccessDecision{}, nil
+	}
+	decision, err := a.controller.Authorize(ctx, AccessRequest{
+		Principal: Principal{Subject: request.Subject, Actor: request.Actor},
+		Operation: Operation{
+			ID: request.Operation.ID, Method: request.Operation.Method, Path: request.Operation.Path,
+			PathParams: request.Operation.PathParams,
+		},
+	})
+	if errors.Is(err, ErrAccessDenied) {
+		return daemon.HostAccessDecision{}, daemon.ErrHostAccessDenied
+	}
+	if err != nil {
+		return daemon.HostAccessDecision{}, err
+	}
+	var revalidate func(context.Context) error
+	if decision.Lease != nil {
+		revalidate = decision.Lease.Revalidate
+	}
+	return daemon.HostAccessDecision{Revalidate: revalidate}, nil
 }
 
 // Run executes Kata's federation, GitHub synchronization, and timed-claim

--- a/service_access_scope_test.go
+++ b/service_access_scope_test.go
@@ -102,9 +102,12 @@ func TestServiceAccessControllerScopesLookupHydrationAndTraversal(t *testing.T) 
 		`{"actor":"ignored","type":"related","to_ref":"`+target.Issue.UID+`"}`, nil)
 
 	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "showIssueByUID" && request.Operation.AllProjects {
+			return kata.ErrAccessDenied
+		}
 		if containsInt64(request.Operation.ProjectIDs, targetProject.Project.ID) {
 			switch request.Operation.ID {
-			case "showIssueByUID", "showIssue", "reachableIssueGraph":
+			case "showIssue", "reachableIssueGraph":
 				return kata.ErrAccessDenied
 			}
 		}
@@ -124,6 +127,155 @@ func TestServiceAccessControllerScopesLookupHydrationAndTraversal(t *testing.T) 
 		_ = response.Body.Close()
 		assert.Equal(t, http.StatusNotFound, response.StatusCode)
 	}
+}
+
+func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	project := createProject(t, server.URL, "example-project")
+	first := createAccessIssue(t, server, project.Project.ID, "first issue")
+	_ = createAccessIssue(t, server, project.Project.ID, "second issue")
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.AllProjects {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+
+	projectID := strconv.FormatInt(project.Project.ID, 10)
+	requests := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/projects/" + projectID + "/issues/" + first.Issue.ShortID + "/actions/purge"},
+		{http.MethodPost, "/api/v1/projects/" + projectID + "/actions/purge"},
+		{http.MethodPost, "/api/v1/projects/" + projectID + "/issues/" + first.Issue.ShortID + "/actions/close"},
+		{http.MethodGet, "/api/v1/projects/" + projectID + "/ready"},
+		{http.MethodGet, "/api/v1/issues/" + first.Issue.UID[:8]},
+		{http.MethodGet, "/api/v1/issues/01ABCDEFG"},
+	}
+	for _, tc := range requests {
+		request, err := http.NewRequest(tc.method, server.URL+tc.path, bytes.NewBufferString(`{}`))
+		require.NoError(t, err)
+		request.Header.Set("Content-Type", "application/json")
+		response, err := server.Client().Do(request)
+		require.NoError(t, err)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+		_ = response.Body.Close()
+		assert.Equal(t, http.StatusNotFound, response.StatusCode, tc.path)
+		assert.Equal(t, map[string]any{
+			"status": float64(http.StatusNotFound),
+			"error": map[string]any{
+				"code": "not_found", "message": "resource not found",
+			},
+		}, body, tc.path)
+	}
+
+	requireAll := map[string]bool{
+		"purgeIssue": true, "purgeProject": true, "closeIssue": true,
+		"readyIssues": true, "showIssueByUID": true,
+	}
+	seen := map[string]int{}
+	for _, request := range controller.snapshot() {
+		if !requireAll[request.Operation.ID] {
+			continue
+		}
+		seen[request.Operation.ID]++
+		assert.True(t, request.Operation.AllProjects, request.Operation.ID)
+	}
+	assert.Equal(t, map[string]int{
+		"purgeIssue": 1, "purgeProject": 1, "closeIssue": 1,
+		"readyIssues": 1, "showIssueByUID": 2,
+	}, seen)
+}
+
+func TestServiceAccessControllerAuthorizesProjectsContributingChildCounts(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	parentProject := createProject(t, server.URL, "parent-project")
+	childProject := createProject(t, server.URL, "child-project")
+	parent := createAccessIssue(t, server, parentProject.Project.ID, "parent issue")
+	child := createAccessIssue(t, server, childProject.Project.ID, "child issue")
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(childProject.Project.ID, 10)+"/issues/"+child.Issue.ShortID+"/links",
+		`{"actor":"ignored","type":"parent","to_ref":"`+parent.Issue.UID+`"}`, nil)
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "listIssues" &&
+			containsInt64(request.Operation.ProjectIDs, childProject.Project.ID) {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+
+	response, err := server.Client().Get(server.URL + "/api/v1/projects/" +
+		strconv.FormatInt(parentProject.Project.ID, 10) + "/issues")
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, response.StatusCode)
+
+	requests := controller.snapshot()
+	initial := operationRequest(t, requests, "listIssues", 0)
+	expanded := operationRequest(t, requests, "listIssues", 1)
+	assert.Equal(t, []int64{parentProject.Project.ID}, initial.Operation.ProjectIDs)
+	assert.ElementsMatch(t,
+		[]int64{parentProject.Project.ID, childProject.Project.ID},
+		expanded.Operation.ProjectIDs)
+}
+
+func TestServiceAccessControllerDenialLeavesCrossProjectLinksUnchangedOnPurge(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	sourceProject := createProject(t, server.URL, "source-project")
+	targetProject := createProject(t, server.URL, "target-project")
+	source := createAccessIssue(t, server, sourceProject.Project.ID, "source issue")
+	target := createAccessIssue(t, server, targetProject.Project.ID, "target issue")
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(sourceProject.Project.ID, 10)+"/issues/"+source.Issue.ShortID+"/links",
+		`{"actor":"ignored","type":"related","to_ref":"`+target.Issue.UID+`"}`, nil)
+
+	issuePath := server.URL + "/api/v1/projects/" +
+		strconv.FormatInt(sourceProject.Project.ID, 10) + "/issues/" + source.Issue.ShortID
+	deleteRequest, err := http.NewRequest(http.MethodPost, issuePath+"/actions/delete",
+		bytes.NewBufferString(`{"actor":"ignored"}`))
+	require.NoError(t, err)
+	deleteRequest.Header.Set("Content-Type", "application/json")
+	deleteRequest.Header.Set("X-Kata-Confirm", "DELETE source-project#"+source.Issue.ShortID)
+	deleteResponse, err := server.Client().Do(deleteRequest)
+	require.NoError(t, err)
+	_ = deleteResponse.Body.Close()
+	require.Equal(t, http.StatusOK, deleteResponse.StatusCode)
+
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "purgeIssue" && request.Operation.AllProjects {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+	purgeRequest, err := http.NewRequest(http.MethodPost, issuePath+"/actions/purge",
+		bytes.NewBufferString(`{"actor":"ignored"}`))
+	require.NoError(t, err)
+	purgeRequest.Header.Set("Content-Type", "application/json")
+	purgeRequest.Header.Set("X-Kata-Confirm", "PURGE source-project#"+source.Issue.ShortID)
+	purgeResponse, err := server.Client().Do(purgeRequest)
+	require.NoError(t, err)
+	_ = purgeResponse.Body.Close()
+	assert.Equal(t, http.StatusNotFound, purgeResponse.StatusCode)
+
+	showResponse, err := server.Client().Get(issuePath + "?include_deleted=true")
+	require.NoError(t, err)
+	defer func() { _ = showResponse.Body.Close() }()
+	require.Equal(t, http.StatusOK, showResponse.StatusCode)
+	var shown struct {
+		Links []struct {
+			To struct {
+				UID string `json:"uid"`
+			} `json:"to"`
+		} `json:"links"`
+	}
+	require.NoError(t, json.NewDecoder(showResponse.Body).Decode(&shown))
+	require.Len(t, shown.Links, 1)
+	assert.Equal(t, target.Issue.UID, shown.Links[0].To.UID)
 }
 
 func TestServiceAccessControllerScopesCrossProjectLinkMutation(t *testing.T) {

--- a/service_access_scope_test.go
+++ b/service_access_scope_test.go
@@ -57,7 +57,8 @@ func TestServiceAccessControllerScopesGlobalAndFilteredReads(t *testing.T) {
 	assert.False(t, filtered.Operation.AllProjects)
 	assert.Empty(t, global.Operation.ProjectIDs)
 	assert.True(t, global.Operation.AllProjects)
-	assert.Equal(t, []int64{project.Project.ID}, audit.Operation.ProjectIDs)
+	assert.Empty(t, audit.Operation.ProjectIDs)
+	assert.True(t, audit.Operation.AllProjects)
 }
 
 func TestServiceAccessControllerScopesFederationEnrollmentBody(t *testing.T) {
@@ -156,6 +157,7 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 		{http.MethodPost, "/api/v1/projects/" + projectID + "/imports"},
 		{http.MethodGet, "/api/v1/projects/" + projectID + "/events"},
 		{http.MethodGet, "/api/v1/events/stream?project_id=" + projectID},
+		{http.MethodGet, "/api/v1/projects/" + projectID + "/digest?since=2026-01-01T00:00:00Z"},
 	}
 	for _, tc := range requests {
 		request, err := http.NewRequest(tc.method, server.URL+tc.path, bytes.NewBufferString(`{}`))
@@ -178,7 +180,7 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 	requireAll := map[string]bool{
 		"purgeIssue": true, "purgeProject": true, "closeIssue": true,
 		"readyIssues": true, "showIssueByUID": true, "importIssues": true,
-		"pollProjectEvents": true, "streamEvents": true,
+		"pollProjectEvents": true, "streamEvents": true, "digestProject": true,
 	}
 	seen := map[string]int{}
 	for _, request := range controller.snapshot() {
@@ -191,7 +193,7 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 	assert.Equal(t, map[string]int{
 		"purgeIssue": 1, "purgeProject": 1, "closeIssue": 1,
 		"readyIssues": 1, "showIssueByUID": 2, "importIssues": 1,
-		"pollProjectEvents": 1, "streamEvents": 1,
+		"pollProjectEvents": 1, "streamEvents": 1, "digestProject": 1,
 	}, seen)
 }
 
@@ -204,8 +206,11 @@ func TestServiceAccessControllerDerivesLeaseHolderFromSubject(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, service.Close()) })
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		subject := r.Header.Get("X-Test-Subject")
-		if subject == "" {
+		switch subject {
+		case "":
 			subject = "user-one"
+		case "padded":
+			subject = " user-one "
 		}
 		principal := kata.Principal{Subject: subject, Actor: "Example User"}
 		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
@@ -234,7 +239,7 @@ func TestServiceAccessControllerDerivesLeaseHolderFromSubject(t *testing.T) {
 		bytes.NewBufferString(`{"holder":"`+acquired.Holder.Holder+`","client_kind":"cli"}`))
 	require.NoError(t, err)
 	impersonation.Header.Set("Content-Type", "application/json")
-	impersonation.Header.Set("X-Test-Subject", "user-two")
+	impersonation.Header.Set("X-Test-Subject", "padded")
 	impersonationResponse, err := server.Client().Do(impersonation)
 	require.NoError(t, err)
 	_ = impersonationResponse.Body.Close()
@@ -249,6 +254,54 @@ func TestServiceAccessControllerDerivesLeaseHolderFromSubject(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = ownerResponse.Body.Close() }()
 	assert.Equal(t, http.StatusOK, ownerResponse.StatusCode)
+}
+
+func TestServiceAccessControllerConcealsUnauthorizedLinkTargetState(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	sourceProject := createProject(t, server.URL, "source-project")
+	activeProject := createProject(t, server.URL, "active-project")
+	archivedProject := createProject(t, server.URL, "archived-project")
+	source := createAccessIssue(t, server, sourceProject.Project.ID, "source issue")
+	active := createAccessIssue(t, server, activeProject.Project.ID, "active target")
+	archived := createAccessIssue(t, server, archivedProject.Project.ID, "archived target")
+
+	archiveRequest, err := http.NewRequest(http.MethodDelete, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(archivedProject.Project.ID, 10)+"?actor=ignored&force=true", nil)
+	require.NoError(t, err)
+	archiveResponse, err := server.Client().Do(archiveRequest)
+	require.NoError(t, err)
+	_ = archiveResponse.Body.Close()
+	require.Equal(t, http.StatusOK, archiveResponse.StatusCode)
+
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "createLink" &&
+			(containsInt64(request.Operation.ProjectIDs, activeProject.Project.ID) ||
+				containsInt64(request.Operation.ProjectIDs, archivedProject.Project.ID)) {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+	linkPath := server.URL + "/api/v1/projects/" +
+		strconv.FormatInt(sourceProject.Project.ID, 10) + "/issues/" + source.Issue.ShortID + "/links"
+	for _, target := range []string{active.Issue.UID, archived.Issue.UID, "01HZNQ7VFPK1XGD8R5MABCD4EZ"} {
+		request, err := http.NewRequest(http.MethodPost, linkPath, bytes.NewBufferString(
+			`{"actor":"ignored","type":"related","to_ref":"`+target+`"}`))
+		require.NoError(t, err)
+		request.Header.Set("Content-Type", "application/json")
+		response, err := server.Client().Do(request)
+		require.NoError(t, err)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+		_ = response.Body.Close()
+		assert.Equal(t, http.StatusNotFound, response.StatusCode)
+		assert.Equal(t, map[string]any{
+			"status": float64(http.StatusNotFound),
+			"error": map[string]any{
+				"code": "not_found", "message": "resource not found",
+			},
+		}, body)
+	}
 }
 
 func TestServiceAccessControllerSuppliesFederationReplicaActor(t *testing.T) {

--- a/service_access_scope_test.go
+++ b/service_access_scope_test.go
@@ -1,0 +1,204 @@
+package kata_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata"
+)
+
+type accessIssue struct {
+	Issue struct {
+		UID      string `json:"uid"`
+		ShortID  string `json:"short_id"`
+		Revision int64  `json:"revision"`
+	} `json:"issue"`
+}
+
+func TestServiceAccessControllerScopesGlobalAndFilteredReads(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, server := newAccessTestServer(t, controller)
+	_ = service
+	project := createProject(t, server.URL, "example-project")
+	controller.authorize = func(request kata.AccessRequest) error {
+		switch request.Operation.ID {
+		case "listAllIssues", "auditCloses":
+			return kata.ErrAccessDenied
+		default:
+			return nil
+		}
+	}
+
+	paths := []string{
+		"/api/v1/issues?project_id=" + strconv.FormatInt(project.Project.ID, 10),
+		"/api/v1/issues",
+		"/api/v1/audit/closes?project_id=" + strconv.FormatInt(project.Project.ID, 10),
+	}
+	for _, path := range paths {
+		response, err := server.Client().Get(server.URL + path)
+		require.NoError(t, err)
+		_ = response.Body.Close()
+		assert.Equal(t, http.StatusNotFound, response.StatusCode)
+	}
+
+	requests := controller.snapshot()
+	filtered := operationRequest(t, requests, "listAllIssues", 0)
+	global := operationRequest(t, requests, "listAllIssues", 1)
+	audit := operationRequest(t, requests, "auditCloses", 0)
+	assert.Equal(t, []int64{project.Project.ID}, filtered.Operation.ProjectIDs)
+	assert.False(t, filtered.Operation.AllProjects)
+	assert.Empty(t, global.Operation.ProjectIDs)
+	assert.True(t, global.Operation.AllProjects)
+	assert.Equal(t, []int64{project.Project.ID}, audit.Operation.ProjectIDs)
+}
+
+func TestServiceAccessControllerScopesFederationEnrollmentBody(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	project := createProject(t, server.URL, "example-project")
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/federation/enable",
+		`{"actor":"ignored"}`, nil)
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "createFederationEnrollment" {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+
+	body := bytes.NewBufferString(`{"spoke_instance_uid":"01HZNQ7VFPK1XGD8R5MABCD4EA","project_id":` +
+		strconv.FormatInt(project.Project.ID, 10) +
+		`,"capabilities":"pull","actor":"ignored"}`)
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/federation/enrollments", body)
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := server.Client().Do(request)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, response.StatusCode)
+
+	authorized := operationRequest(t, controller.snapshot(), "createFederationEnrollment", 0)
+	assert.Equal(t, []int64{project.Project.ID}, authorized.Operation.ProjectIDs)
+	assert.False(t, authorized.Operation.AllProjects)
+}
+
+func TestServiceAccessControllerScopesLookupHydrationAndTraversal(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	sourceProject := createProject(t, server.URL, "source-project")
+	targetProject := createProject(t, server.URL, "target-project")
+	source := createAccessIssue(t, server, sourceProject.Project.ID, "source issue")
+	target := createAccessIssue(t, server, targetProject.Project.ID, "target issue")
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(sourceProject.Project.ID, 10)+"/issues/"+source.Issue.ShortID+"/links",
+		`{"actor":"ignored","type":"related","to_ref":"`+target.Issue.UID+`"}`, nil)
+
+	controller.authorize = func(request kata.AccessRequest) error {
+		if containsInt64(request.Operation.ProjectIDs, targetProject.Project.ID) {
+			switch request.Operation.ID {
+			case "showIssueByUID", "showIssue", "reachableIssueGraph":
+				return kata.ErrAccessDenied
+			}
+		}
+		return nil
+	}
+
+	paths := []string{
+		"/api/v1/issues/" + source.Issue.UID,
+		"/api/v1/projects/" + strconv.FormatInt(sourceProject.Project.ID, 10) +
+			"/issues/" + source.Issue.ShortID,
+		"/api/v1/projects/" + strconv.FormatInt(sourceProject.Project.ID, 10) +
+			"/issues/" + source.Issue.ShortID + "/graph",
+	}
+	for _, path := range paths {
+		response, err := server.Client().Get(server.URL + path)
+		require.NoError(t, err)
+		_ = response.Body.Close()
+		assert.Equal(t, http.StatusNotFound, response.StatusCode)
+	}
+}
+
+func TestServiceAccessControllerScopesCrossProjectLinkMutation(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	sourceProject := createProject(t, server.URL, "source-project")
+	targetProject := createProject(t, server.URL, "target-project")
+	source := createAccessIssue(t, server, sourceProject.Project.ID, "source issue")
+	target := createAccessIssue(t, server, targetProject.Project.ID, "target issue")
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "createLink" &&
+			containsInt64(request.Operation.ProjectIDs, targetProject.Project.ID) {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+
+	body := bytes.NewBufferString(`{"actor":"ignored","type":"related","to_ref":"` +
+		target.Issue.UID + `"}`)
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(sourceProject.Project.ID, 10)+"/issues/"+source.Issue.ShortID+"/links", body)
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := server.Client().Do(request)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, response.StatusCode)
+}
+
+func newAccessTestServer(
+	t *testing.T,
+	controller *recordingAccessController,
+) (*kata.Service, *httptest.Server) {
+	t.Helper()
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return service, server
+}
+
+func createAccessIssue(t *testing.T, server *httptest.Server, projectID int64, title string) accessIssue {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"actor": "ignored", "title": title})
+	require.NoError(t, err)
+	response, err := http.Post(server.URL+"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+
+		"/issues", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	var issue accessIssue
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&issue))
+	return issue
+}
+
+func operationRequest(
+	t *testing.T,
+	requests []kata.AccessRequest,
+	operationID string,
+	index int,
+) kata.AccessRequest {
+	t.Helper()
+	matching := make([]kata.AccessRequest, 0)
+	for _, request := range requests {
+		if request.Operation.ID == operationID {
+			matching = append(matching, request)
+		}
+	}
+	require.Greater(t, len(matching), index)
+	return matching[index]
+}

--- a/service_access_scope_test.go
+++ b/service_access_scope_test.go
@@ -147,21 +147,27 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 	requests := []struct {
 		method string
 		path   string
+		body   string
 	}{
-		{http.MethodPost, "/api/v1/projects/" + projectID + "/issues/" + first.Issue.ShortID + "/actions/purge"},
-		{http.MethodPost, "/api/v1/projects/" + projectID + "/actions/purge"},
-		{http.MethodPost, "/api/v1/projects/" + projectID + "/issues/" + first.Issue.ShortID + "/actions/close"},
-		{http.MethodGet, "/api/v1/projects/" + projectID + "/ready"},
-		{http.MethodGet, "/api/v1/issues/" + first.Issue.UID[:8]},
-		{http.MethodGet, "/api/v1/issues/01ABCDEFG"},
-		{http.MethodPost, "/api/v1/projects/" + projectID + "/imports"},
-		{http.MethodGet, "/api/v1/projects/" + projectID + "/events"},
-		{http.MethodGet, "/api/v1/events/stream?project_id=" + projectID},
-		{http.MethodGet, "/api/v1/projects/" + projectID + "/digest?since=2026-01-01T00:00:00Z"},
-		{http.MethodDelete, "/api/v1/projects/" + projectID + "/issues/" + first.Issue.ShortID + "/links/999?actor=ignored"},
+		{http.MethodPost, "/api/v1/projects/" + projectID + "/issues/" + first.Issue.ShortID + "/actions/purge", ""},
+		{http.MethodPost, "/api/v1/projects/" + projectID + "/actions/purge", ""},
+		{http.MethodPost, "/api/v1/projects/" + projectID + "/issues/" + first.Issue.ShortID + "/actions/close", ""},
+		{http.MethodGet, "/api/v1/projects/" + projectID + "/ready", ""},
+		{http.MethodGet, "/api/v1/issues/" + first.Issue.UID[:8], ""},
+		{http.MethodGet, "/api/v1/issues/01ABCDEFG", ""},
+		{http.MethodPost, "/api/v1/projects/" + projectID + "/imports", ""},
+		{http.MethodGet, "/api/v1/projects/" + projectID + "/events", ""},
+		{http.MethodGet, "/api/v1/events/stream?project_id=" + projectID, ""},
+		{http.MethodGet, "/api/v1/projects/" + projectID + "/digest?since=2026-01-01T00:00:00Z", ""},
+		{http.MethodDelete, "/api/v1/projects/" + projectID + "/issues/" + first.Issue.ShortID + "/links/999?actor=ignored", ""},
+		{http.MethodPost, "/api/v1/projects/" + projectID + "/actions/rewrite-author", `{"from":"old","to":"new"}`},
 	}
 	for _, tc := range requests {
-		request, err := http.NewRequest(tc.method, server.URL+tc.path, bytes.NewBufferString(`{}`))
+		requestBody := tc.body
+		if requestBody == "" {
+			requestBody = `{}`
+		}
+		request, err := http.NewRequest(tc.method, server.URL+tc.path, bytes.NewBufferString(requestBody))
 		require.NoError(t, err)
 		request.Header.Set("Content-Type", "application/json")
 		response, err := server.Client().Do(request)
@@ -182,7 +188,7 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 		"purgeIssue": true, "purgeProject": true, "closeIssue": true,
 		"readyIssues": true, "showIssueByUID": true, "importIssues": true,
 		"pollProjectEvents": true, "streamEvents": true, "digestProject": true,
-		"deleteLink": true,
+		"deleteLink": true, "rewriteAuthorIdentity": true,
 	}
 	seen := map[string]int{}
 	for _, request := range controller.snapshot() {
@@ -196,8 +202,51 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 		"purgeIssue": 1, "purgeProject": 1, "closeIssue": 1,
 		"readyIssues": 1, "showIssueByUID": 2, "importIssues": 1,
 		"pollProjectEvents": 1, "streamEvents": 1, "digestProject": 1,
-		"deleteLink": 1,
+		"deleteLink":            1,
+		"rewriteAuthorIdentity": 1,
 	}, seen)
+}
+
+func TestServiceAccessControllerDeniesCrossProjectAuthorRewriteBeforeMutation(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	sourceProject := createProject(t, server.URL, "source-project")
+	targetProject := createProject(t, server.URL, "target-project")
+	source := createAccessIssue(t, server, sourceProject.Project.ID, "source issue")
+	target := createAccessIssue(t, server, targetProject.Project.ID, "target issue")
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(sourceProject.Project.ID, 10)+"/issues/"+source.Issue.ShortID+"/links",
+		`{"actor":"ignored","type":"related","to_ref":"`+target.Issue.UID+`"}`, nil)
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "rewriteAuthorIdentity" && request.Operation.AllProjects {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+
+	rewriteRequest, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(sourceProject.Project.ID, 10)+"/actions/rewrite-author",
+		bytes.NewBufferString(`{"from":"Example User","to":"Replacement User"}`))
+	require.NoError(t, err)
+	rewriteRequest.Header.Set("Content-Type", "application/json")
+	rewriteResponse, err := server.Client().Do(rewriteRequest)
+	require.NoError(t, err)
+	_ = rewriteResponse.Body.Close()
+	require.Equal(t, http.StatusNotFound, rewriteResponse.StatusCode)
+
+	controller.authorize = nil
+	showResponse, err := server.Client().Get(server.URL + "/api/v1/projects/" +
+		strconv.FormatInt(sourceProject.Project.ID, 10) + "/issues/" + source.Issue.ShortID)
+	require.NoError(t, err)
+	defer func() { _ = showResponse.Body.Close() }()
+	var shown struct {
+		Links []struct {
+			Author string `json:"author"`
+		} `json:"links"`
+	}
+	require.NoError(t, json.NewDecoder(showResponse.Body).Decode(&shown))
+	require.Len(t, shown.Links, 1)
+	assert.Equal(t, "Example User", shown.Links[0].Author)
 }
 
 func TestServiceAccessControllerDerivesLeaseHolderFromSubject(t *testing.T) {

--- a/service_access_scope_test.go
+++ b/service_access_scope_test.go
@@ -158,6 +158,7 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 		{http.MethodGet, "/api/v1/projects/" + projectID + "/events"},
 		{http.MethodGet, "/api/v1/events/stream?project_id=" + projectID},
 		{http.MethodGet, "/api/v1/projects/" + projectID + "/digest?since=2026-01-01T00:00:00Z"},
+		{http.MethodDelete, "/api/v1/projects/" + projectID + "/issues/" + first.Issue.ShortID + "/links/999?actor=ignored"},
 	}
 	for _, tc := range requests {
 		request, err := http.NewRequest(tc.method, server.URL+tc.path, bytes.NewBufferString(`{}`))
@@ -181,6 +182,7 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 		"purgeIssue": true, "purgeProject": true, "closeIssue": true,
 		"readyIssues": true, "showIssueByUID": true, "importIssues": true,
 		"pollProjectEvents": true, "streamEvents": true, "digestProject": true,
+		"deleteLink": true,
 	}
 	seen := map[string]int{}
 	for _, request := range controller.snapshot() {
@@ -194,6 +196,7 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 		"purgeIssue": 1, "purgeProject": 1, "closeIssue": 1,
 		"readyIssues": 1, "showIssueByUID": 2, "importIssues": 1,
 		"pollProjectEvents": 1, "streamEvents": 1, "digestProject": 1,
+		"deleteLink": 1,
 	}, seen)
 }
 
@@ -234,6 +237,29 @@ func TestServiceAccessControllerDerivesLeaseHolderFromSubject(t *testing.T) {
 		`{"holder":"caller-selected","client_kind":"cli","claim_kind":"hard"}`, &acquired)
 	assert.NotEmpty(t, acquired.Holder.Holder)
 	assert.NotEqual(t, "caller-selected", acquired.Holder.Holder)
+	issuePath := server.URL + "/api/v1/projects/" + projectID + "/issues/" + issue.Issue.ShortID
+	ownerEdit, err := http.NewRequest(http.MethodPatch, issuePath,
+		bytes.NewBufferString(`{"actor":"ignored","title":"owner edit"}`))
+	require.NoError(t, err)
+	ownerEdit.Header.Set("Content-Type", "application/json")
+	ownerEdit.Header.Set("If-Match", `"rev-1"`)
+	ownerEditResponse, err := server.Client().Do(ownerEdit)
+	require.NoError(t, err)
+	var edited accessIssue
+	require.NoError(t, json.NewDecoder(ownerEditResponse.Body).Decode(&edited))
+	_ = ownerEditResponse.Body.Close()
+	assert.Equal(t, http.StatusOK, ownerEditResponse.StatusCode)
+
+	otherEdit, err := http.NewRequest(http.MethodPatch, issuePath,
+		bytes.NewBufferString(`{"actor":"ignored","title":"other edit"}`))
+	require.NoError(t, err)
+	otherEdit.Header.Set("Content-Type", "application/json")
+	otherEdit.Header.Set("If-Match", `"rev-`+strconv.FormatInt(edited.Issue.Revision, 10)+`"`)
+	otherEdit.Header.Set("X-Test-Subject", "padded")
+	otherEditResponse, err := server.Client().Do(otherEdit)
+	require.NoError(t, err)
+	_ = otherEditResponse.Body.Close()
+	assert.Equal(t, http.StatusConflict, otherEditResponse.StatusCode)
 
 	impersonation, err := http.NewRequest(http.MethodPost, leasePath+"release",
 		bytes.NewBufferString(`{"holder":"`+acquired.Holder.Holder+`","client_kind":"cli"}`))
@@ -254,6 +280,52 @@ func TestServiceAccessControllerDerivesLeaseHolderFromSubject(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = ownerResponse.Body.Close() }()
 	assert.Equal(t, http.StatusOK, ownerResponse.StatusCode)
+}
+
+func TestServiceAccessControllerRejectsMalformedHostPrincipalBeforeBearerFallback(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		principal := kata.Principal{Subject: "user-one", Actor: "Example User"}
+		if r.Header.Get("X-Test-Malformed") != "" {
+			principal = kata.Principal{Subject: " ", Actor: " "}
+		}
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	project := createProject(t, server.URL, "example-project")
+	issue := createAccessIssue(t, server, project.Project.ID, "leased issue")
+	projectID := strconv.FormatInt(project.Project.ID, 10)
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+projectID+"/federation/enable",
+		`{"actor":"ignored"}`, nil)
+	basePath := server.URL + "/api/v1/projects/" + projectID + "/issues/" + issue.Issue.ShortID + "/lease"
+
+	requests := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodPost, basePath + "/actions/acquire", `{"holder":"forged","client_kind":"cli","claim_kind":"hard"}`},
+		{http.MethodGet, basePath, ""},
+	}
+	before := len(controller.snapshot())
+	for _, tc := range requests {
+		request, err := http.NewRequest(tc.method, tc.path, bytes.NewBufferString(tc.body))
+		require.NoError(t, err)
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("Authorization", "Bearer invalid-token")
+		request.Header.Set("X-Test-Malformed", "1")
+		response, err := server.Client().Do(request)
+		require.NoError(t, err)
+		_ = response.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	}
+	assert.Len(t, controller.snapshot(), before)
 }
 
 func TestServiceAccessControllerConcealsUnauthorizedLinkTargetState(t *testing.T) {
@@ -300,6 +372,114 @@ func TestServiceAccessControllerConcealsUnauthorizedLinkTargetState(t *testing.T
 			"error": map[string]any{
 				"code": "not_found", "message": "resource not found",
 			},
+		}, body)
+	}
+}
+
+func TestServiceAccessControllerRequiresAllProjectsForParentMutations(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	project := createProject(t, server.URL, "example-project")
+	child := createAccessIssue(t, server, project.Project.ID, "child issue")
+	parent := createAccessIssue(t, server, project.Project.ID, "parent issue")
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.AllProjects {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+	basePath := server.URL + "/api/v1/projects/" + strconv.FormatInt(project.Project.ID, 10) +
+		"/issues/" + child.Issue.ShortID
+
+	createRequest, err := http.NewRequest(http.MethodPost, basePath+"/links",
+		bytes.NewBufferString(`{"actor":"ignored","type":"parent","to_ref":"`+parent.Issue.UID+`"}`))
+	require.NoError(t, err)
+	createRequest.Header.Set("Content-Type", "application/json")
+	createResponse, err := server.Client().Do(createRequest)
+	require.NoError(t, err)
+	_ = createResponse.Body.Close()
+	assert.Equal(t, http.StatusNotFound, createResponse.StatusCode)
+
+	editRequest, err := http.NewRequest(http.MethodPatch, basePath,
+		bytes.NewBufferString(`{"actor":"ignored","links_delta":{"set_parent":"`+parent.Issue.UID+`"}}`))
+	require.NoError(t, err)
+	editRequest.Header.Set("Content-Type", "application/json")
+	editRequest.Header.Set("If-Match", `"rev-1"`)
+	editResponse, err := server.Client().Do(editRequest)
+	require.NoError(t, err)
+	_ = editResponse.Body.Close()
+	assert.Equal(t, http.StatusNotFound, editResponse.StatusCode)
+}
+
+func TestServiceAccessControllerAuthorizesDeletedGraphPeerBeforeHidingIt(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	sourceProject := createProject(t, server.URL, "source-project")
+	targetProject := createProject(t, server.URL, "target-project")
+	source := createAccessIssue(t, server, sourceProject.Project.ID, "source issue")
+	target := createAccessIssue(t, server, targetProject.Project.ID, "target issue")
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(sourceProject.Project.ID, 10)+"/issues/"+source.Issue.ShortID+"/links",
+		`{"actor":"ignored","type":"related","to_ref":"`+target.Issue.UID+`"}`, nil)
+	deleteRequest, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(targetProject.Project.ID, 10)+"/issues/"+target.Issue.ShortID+"/actions/delete",
+		bytes.NewBufferString(`{"actor":"ignored"}`))
+	require.NoError(t, err)
+	deleteRequest.Header.Set("Content-Type", "application/json")
+	deleteRequest.Header.Set("X-Kata-Confirm", "DELETE target-project#"+target.Issue.ShortID)
+	deleteResponse, err := server.Client().Do(deleteRequest)
+	require.NoError(t, err)
+	_ = deleteResponse.Body.Close()
+	require.Equal(t, http.StatusOK, deleteResponse.StatusCode)
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "reachableIssueGraph" &&
+			containsInt64(request.Operation.ProjectIDs, targetProject.Project.ID) {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+
+	response, err := server.Client().Get(server.URL + "/api/v1/projects/" +
+		strconv.FormatInt(sourceProject.Project.ID, 10) + "/issues/" + source.Issue.ShortID + "/graph")
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, response.StatusCode)
+}
+
+func TestServiceAccessControllerConcealsForeignRecurrenceIdentity(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	sourceProject := createProject(t, server.URL, "source-project")
+	targetProject := createProject(t, server.URL, "target-project")
+	var created struct {
+		Recurrence struct {
+			UID string `json:"uid"`
+		} `json:"recurrence"`
+	}
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(targetProject.Project.ID, 10)+"/recurrences",
+		bytes.NewBufferString(`{"actor":"ignored","rrule":"FREQ=WEEKLY","dtstart":"2026-05-15","timezone":"UTC","template":{"title":"weekly review"}}`))
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := server.Client().Do(request)
+	require.NoError(t, err)
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&created))
+	_ = response.Body.Close()
+	require.Equal(t, http.StatusCreated, response.StatusCode)
+	require.NotEmpty(t, created.Recurrence.UID)
+
+	basePath := server.URL + "/api/v1/projects/" + strconv.FormatInt(sourceProject.Project.ID, 10) +
+		"/recurrences/"
+	for _, uid := range []string{created.Recurrence.UID, "01HZNQ7VFPK1XGD8R5MABCD4EA"} {
+		response, err := server.Client().Get(basePath + uid)
+		require.NoError(t, err)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+		_ = response.Body.Close()
+		assert.Equal(t, http.StatusNotFound, response.StatusCode)
+		assert.Equal(t, map[string]any{
+			"status": float64(http.StatusNotFound),
+			"error":  map[string]any{"code": "not_found", "message": "resource not found"},
 		}, body)
 	}
 }

--- a/service_access_scope_test.go
+++ b/service_access_scope_test.go
@@ -411,6 +411,60 @@ func TestServiceAccessControllerRequiresAllProjectsForParentMutations(t *testing
 	assert.Equal(t, http.StatusNotFound, editResponse.StatusCode)
 }
 
+func TestServiceAccessControllerConcealsLinkDeltaTargetsBeforeValidation(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, server := newAccessTestServer(t, controller)
+	sourceProject := createProject(t, server.URL, "source-project")
+	activeProject := createProject(t, server.URL, "active-project")
+	archivedProject := createProject(t, server.URL, "archived-project")
+	source := createAccessIssue(t, server, sourceProject.Project.ID, "source issue")
+	active := createAccessIssue(t, server, activeProject.Project.ID, "active target")
+	archived := createAccessIssue(t, server, archivedProject.Project.ID, "archived target")
+	_, err := service.ArchiveProject(t.Context(), archivedProject.Project.UID, "Example User")
+	require.NoError(t, err)
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.AllProjects ||
+			containsInt64(request.Operation.ProjectIDs, activeProject.Project.ID) ||
+			containsInt64(request.Operation.ProjectIDs, archivedProject.Project.ID) {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+
+	requests := []struct {
+		name  string
+		delta string
+	}{
+		{"active add", `{"add_related":["` + active.Issue.UID + `"]}`},
+		{"archived add", `{"add_related":["` + archived.Issue.UID + `"]}`},
+		{"missing add", `{"add_related":["01HZNQ7VFPK1XGD8R5MABCD4EA"]}`},
+		{"resolved conflict", `{"add_blocks":["` + active.Issue.UID + `"],"remove_blocks":["active-project#` + active.Issue.ShortID + `"]}`},
+		{"active tolerant removal", `{"remove_related":["` + active.Issue.UID + `"]}`},
+		{"missing tolerant removal", `{"remove_related":["01HZNQ7VFPK1XGD8R5MABCD4EA"]}`},
+	}
+	issuePath := server.URL + "/api/v1/projects/" + strconv.FormatInt(sourceProject.Project.ID, 10) +
+		"/issues/" + source.Issue.ShortID
+	for _, tc := range requests {
+		t.Run(tc.name, func(t *testing.T) {
+			request, err := http.NewRequest(http.MethodPatch, issuePath,
+				bytes.NewBufferString(`{"actor":"ignored","links_delta":`+tc.delta+`}`))
+			require.NoError(t, err)
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("If-Match", `"rev-1"`)
+			response, err := server.Client().Do(request)
+			require.NoError(t, err)
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+			_ = response.Body.Close()
+			assert.Equal(t, http.StatusNotFound, response.StatusCode)
+			assert.Equal(t, map[string]any{
+				"status": float64(http.StatusNotFound),
+				"error":  map[string]any{"code": "not_found", "message": "resource not found"},
+			}, body)
+		})
+	}
+}
+
 func TestServiceAccessControllerAuthorizesDeletedGraphPeerBeforeHidingIt(t *testing.T) {
 	controller := &recordingAccessController{}
 	_, server := newAccessTestServer(t, controller)

--- a/service_access_scope_test.go
+++ b/service_access_scope_test.go
@@ -153,6 +153,9 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 		{http.MethodGet, "/api/v1/projects/" + projectID + "/ready"},
 		{http.MethodGet, "/api/v1/issues/" + first.Issue.UID[:8]},
 		{http.MethodGet, "/api/v1/issues/01ABCDEFG"},
+		{http.MethodPost, "/api/v1/projects/" + projectID + "/imports"},
+		{http.MethodGet, "/api/v1/projects/" + projectID + "/events"},
+		{http.MethodGet, "/api/v1/events/stream?project_id=" + projectID},
 	}
 	for _, tc := range requests {
 		request, err := http.NewRequest(tc.method, server.URL+tc.path, bytes.NewBufferString(`{}`))
@@ -174,7 +177,8 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 
 	requireAll := map[string]bool{
 		"purgeIssue": true, "purgeProject": true, "closeIssue": true,
-		"readyIssues": true, "showIssueByUID": true,
+		"readyIssues": true, "showIssueByUID": true, "importIssues": true,
+		"pollProjectEvents": true, "streamEvents": true,
 	}
 	seen := map[string]int{}
 	for _, request := range controller.snapshot() {
@@ -186,8 +190,92 @@ func TestServiceAccessControllerRequiresAllProjectsBeforeUnboundedOperations(t *
 	}
 	assert.Equal(t, map[string]int{
 		"purgeIssue": 1, "purgeProject": 1, "closeIssue": 1,
-		"readyIssues": 1, "showIssueByUID": 2,
+		"readyIssues": 1, "showIssueByUID": 2, "importIssues": 1,
+		"pollProjectEvents": 1, "streamEvents": 1,
 	}, seen)
+}
+
+func TestServiceAccessControllerDerivesLeaseHolderFromSubject(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		subject := r.Header.Get("X-Test-Subject")
+		if subject == "" {
+			subject = "user-one"
+		}
+		principal := kata.Principal{Subject: subject, Actor: "Example User"}
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	project := createProject(t, server.URL, "example-project")
+	issue := createAccessIssue(t, server, project.Project.ID, "leased issue")
+	projectID := strconv.FormatInt(project.Project.ID, 10)
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+projectID+"/federation/enable",
+		`{"actor":"ignored"}`, nil)
+	leasePath := server.URL + "/api/v1/projects/" + projectID + "/issues/" +
+		issue.Issue.ShortID + "/lease/actions/"
+
+	var acquired struct {
+		Holder struct {
+			Holder string `json:"holder"`
+		} `json:"holder"`
+	}
+	postJSON(t, server.Client(), leasePath+"acquire",
+		`{"holder":"caller-selected","client_kind":"cli","claim_kind":"hard"}`, &acquired)
+	assert.NotEmpty(t, acquired.Holder.Holder)
+	assert.NotEqual(t, "caller-selected", acquired.Holder.Holder)
+
+	impersonation, err := http.NewRequest(http.MethodPost, leasePath+"release",
+		bytes.NewBufferString(`{"holder":"`+acquired.Holder.Holder+`","client_kind":"cli"}`))
+	require.NoError(t, err)
+	impersonation.Header.Set("Content-Type", "application/json")
+	impersonation.Header.Set("X-Test-Subject", "user-two")
+	impersonationResponse, err := server.Client().Do(impersonation)
+	require.NoError(t, err)
+	_ = impersonationResponse.Body.Close()
+	assert.Equal(t, http.StatusConflict, impersonationResponse.StatusCode)
+
+	ownerRelease, err := http.NewRequest(http.MethodPost, leasePath+"release",
+		bytes.NewBufferString(`{"holder":"another-caller-value","client_kind":"cli"}`))
+	require.NoError(t, err)
+	ownerRelease.Header.Set("Content-Type", "application/json")
+	ownerRelease.Header.Set("X-Test-Subject", "user-one")
+	ownerResponse, err := server.Client().Do(ownerRelease)
+	require.NoError(t, err)
+	defer func() { _ = ownerResponse.Body.Close() }()
+	assert.Equal(t, http.StatusOK, ownerResponse.StatusCode)
+}
+
+func TestServiceAccessControllerSuppliesFederationReplicaActor(t *testing.T) {
+	controller := &recordingAccessController{}
+	_, server := newAccessTestServer(t, controller)
+	body := bytes.NewBufferString(`{
+		"hub_url":"https://hub.example",
+		"hub_project_id":42,
+		"hub_project_uid":"01HZNQ7VFPK1XGD8R5MABCD4EX",
+		"project_name":"replica-project",
+		"replay_horizon_event_id":1,
+		"actor":"forged actor"
+	}`)
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/federation/replicas", body)
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := server.Client().Do(request)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	var created struct {
+		Binding struct {
+			Actor string `json:"actor"`
+		} `json:"binding"`
+	}
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&created))
+	assert.Equal(t, "Example User", created.Binding.Actor)
 }
 
 func TestServiceAccessControllerAuthorizesProjectsContributingChildCounts(t *testing.T) {

--- a/service_access_test.go
+++ b/service_access_test.go
@@ -447,7 +447,7 @@ func TestServiceAccessControllerAuthorizesMoveDestination(t *testing.T) {
 	assert.Equal(t, []string{target.Project.UID}, request.Operation.ProjectUIDs)
 }
 
-func TestServiceAccessControllerAuthorizesEffectiveEventStreamScope(t *testing.T) {
+func TestServiceAccessControllerRequiresCompleteEventStreamScope(t *testing.T) {
 	controller := &recordingAccessController{lease: &revocableAccessLease{}}
 	controller.authorize = func(request kata.AccessRequest) error {
 		if request.Operation.ID == "streamEvents" {
@@ -486,8 +486,8 @@ func TestServiceAccessControllerAuthorizesEffectiveEventStreamScope(t *testing.T
 	require.GreaterOrEqual(t, len(requests), 3)
 	projectStream := requests[len(requests)-2].Operation
 	globalStream := requests[len(requests)-1].Operation
-	assert.Equal(t, []int64{project.Project.ID}, projectStream.ProjectIDs)
-	assert.False(t, projectStream.AllProjects)
+	assert.Empty(t, projectStream.ProjectIDs)
+	assert.True(t, projectStream.AllProjects)
 	assert.Empty(t, globalStream.ProjectIDs)
 	assert.True(t, globalStream.AllProjects)
 }

--- a/service_access_test.go
+++ b/service_access_test.go
@@ -1,0 +1,345 @@
+package kata_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata"
+)
+
+type recordingAccessController struct {
+	mu       sync.Mutex
+	requests []kata.AccessRequest
+	err      error
+	lease    kata.AccessLease
+}
+
+func (c *recordingAccessController) Authorize(
+	_ context.Context,
+	request kata.AccessRequest,
+) (kata.AccessDecision, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.requests = append(c.requests, request)
+	decision := kata.AccessDecision{}
+	if request.Operation.ID == "streamEvents" {
+		decision.Lease = c.lease
+	}
+	return decision, c.err
+}
+
+type revocableAccessLease struct {
+	revoked atomic.Bool
+}
+
+func (l *revocableAccessLease) Revalidate(context.Context) error {
+	if l.revoked.Load() {
+		return kata.ErrAccessDenied
+	}
+	return nil
+}
+
+func (c *recordingAccessController) snapshot() []kata.AccessRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]kata.AccessRequest(nil), c.requests...)
+}
+
+func TestServiceAccessControllerRequiresAnInProcessPrincipal(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response,
+		httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil))
+
+	assert.Equal(t, http.StatusUnauthorized, response.Code)
+	assert.JSONEq(t, `{"status":401,"error":{"code":"authentication_required","message":"authentication required"}}`,
+		response.Body.String())
+	assert.Empty(t, controller.snapshot(), "authorization must not run without an authenticated principal")
+}
+
+func TestServiceAccessControllerDeniesWithoutDisclosingProjectData(t *testing.T) {
+	controller := &recordingAccessController{err: kata.ErrAccessDenied}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/42", nil)
+	request = request.WithContext(kata.WithPrincipal(request.Context(), kata.Principal{
+		Subject: "user-123",
+		Actor:   "Example User",
+	}))
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusNotFound, response.Code)
+	assert.JSONEq(t, `{"status":404,"error":{"code":"not_found","message":"resource not found"}}`,
+		response.Body.String())
+	require.Len(t, controller.snapshot(), 1)
+	assert.Equal(t, kata.Operation{
+		ID:         "showProject",
+		Method:     http.MethodGet,
+		Path:       "/api/v1/projects/{project_id}",
+		PathParams: map[string]string{"project_id": "42"},
+	}, controller.snapshot()[0].Operation)
+}
+
+func TestServiceAccessControllerSuppliesTheMutationActor(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	project := createProject(t, server.URL, "example-project")
+	require.NotZero(t, project.Project.ID)
+
+	body, err := json.Marshal(map[string]string{
+		"actor": "caller supplied actor",
+		"title": "Host-authorized change",
+	})
+	require.NoError(t, err)
+	response, err := http.Post(
+		server.URL+"/api/v1/projects/"+strconv.FormatInt(project.Project.ID, 10)+"/issues",
+		"application/json",
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	var created struct {
+		Issue struct {
+			Author string `json:"author"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&created))
+	assert.Equal(t, "Example User", created.Issue.Author)
+
+	requests := controller.snapshot()
+	require.GreaterOrEqual(t, len(requests), 2)
+	issueRequest := requests[len(requests)-1]
+	assert.Equal(t, principal, issueRequest.Principal)
+	assert.Equal(t, "createIssue", issueRequest.Operation.ID)
+	assert.Equal(t, strconv.FormatInt(project.Project.ID, 10), issueRequest.Operation.PathParams["project_id"])
+}
+
+func TestServiceAccessControllerKeepsUnexpectedFailuresDistinctFromDenials(t *testing.T) {
+	controller := &recordingAccessController{err: errors.New("policy store unavailable")}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil)
+	request = request.WithContext(kata.WithPrincipal(request.Context(), kata.Principal{
+		Subject: "user-123",
+		Actor:   "Example User",
+	}))
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusServiceUnavailable, response.Code)
+	assert.JSONEq(t, `{"status":503,"error":{"code":"access_unavailable","message":"access decision unavailable"}}`,
+		response.Body.String())
+}
+
+func TestServiceAccessLeaseStopsAStreamBeforeTheNextEvent(t *testing.T) {
+	lease := &revocableAccessLease{}
+	controller := &recordingAccessController{lease: lease}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	project := createProject(t, server.URL, "example-project")
+	streamRequest, err := http.NewRequest(http.MethodGet,
+		server.URL+"/api/v1/events/stream?after_id=0&project_id="+
+			strconv.FormatInt(project.Project.ID, 10), nil)
+	require.NoError(t, err)
+	streamRequest.Header.Set("Accept", "text/event-stream")
+	streamResponse, err := server.Client().Do(streamRequest)
+	require.NoError(t, err)
+	defer func() { _ = streamResponse.Body.Close() }()
+	require.Equal(t, http.StatusOK, streamResponse.StatusCode)
+
+	reader := bufio.NewReader(streamResponse.Body)
+	connected, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	assert.Equal(t, ": connected\n", connected)
+	_, err = reader.ReadString('\n')
+	require.NoError(t, err)
+
+	lease.revoked.Store(true)
+	body := bytes.NewBufferString(`{"actor":"untrusted","title":"must not reach revoked stream"}`)
+	mutation, err := http.Post(server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues", "application/json", body)
+	require.NoError(t, err)
+	defer func() { _ = mutation.Body.Close() }()
+	require.Equal(t, http.StatusOK, mutation.StatusCode)
+
+	streamResult := make(chan error, 1)
+	go func() {
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				streamResult <- nil
+				return
+			}
+			if line == "event: issue.created\n" {
+				streamResult <- errors.New("revoked stream received issue.created")
+				return
+			}
+		}
+	}()
+	select {
+	case streamErr := <-streamResult:
+		require.NoError(t, streamErr)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "revoked event stream did not close")
+	}
+}
+
+func TestServiceAccessControllerRequiresALeaseForEventStreams(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/events/stream?after_id=0", nil)
+	request.Header.Set("Accept", "text/event-stream")
+	request = request.WithContext(kata.WithPrincipal(request.Context(), kata.Principal{
+		Subject: "user-123",
+		Actor:   "Example User",
+	}))
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusServiceUnavailable, response.Code)
+	assert.JSONEq(t, `{"status":503,"error":{"code":"access_lease_required","message":"long-lived access lease required"}}`,
+		response.Body.String())
+}
+
+func TestNewRejectsHostAccessCombinedWithAnotherAuthenticationPolicy(t *testing.T) {
+	controller := &recordingAccessController{}
+	for _, auth := range []kata.AuthConfig{
+		{Token: "service-token"},
+		{TrustCallerAuthentication: true},
+	} {
+		service, err := kata.New(context.Background(), kata.Config{
+			DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller, Auth: auth,
+		})
+		assert.Nil(t, service)
+		assert.EqualError(t, err,
+			"kata: auth token, trusted caller authentication, and host access are mutually exclusive")
+	}
+}
+
+func TestWithPrincipalDoesNotChangeTrustedCallerMode(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := kata.WithPrincipal(r.Context(), kata.Principal{
+			Subject: "must-be-ignored", Actor: "must-be-ignored",
+		})
+		service.Handler().ServeHTTP(w, r.WithContext(ctx))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	project := createProject(t, server.URL, "example-project")
+
+	body := bytes.NewBufferString(`{"actor":"request actor","title":"ordinary trusted mutation"}`)
+	response, err := http.Post(server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues", "application/json", body)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	var created struct {
+		Issue struct {
+			Author string `json:"author"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&created))
+	assert.Equal(t, "request actor", created.Issue.Author)
+}
+
+func TestServiceAccessControllerProtectsTheOpenAPIDocument(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	missing := httptest.NewRecorder()
+	service.Handler().ServeHTTP(missing,
+		httptest.NewRequest(http.MethodGet, "/openapi.yaml", nil))
+	assert.Equal(t, http.StatusUnauthorized, missing.Code)
+
+	request := httptest.NewRequest(http.MethodGet, "/openapi.yaml", nil)
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	request = request.WithContext(kata.WithPrincipal(request.Context(), principal))
+	allowed := httptest.NewRecorder()
+	service.Handler().ServeHTTP(allowed, request)
+	require.Equal(t, http.StatusOK, allowed.Code)
+
+	requests := controller.snapshot()
+	require.Len(t, requests, 1)
+	assert.Equal(t, principal, requests[0].Principal)
+	assert.Equal(t, kata.Operation{
+		ID: "openAPI", Method: http.MethodGet, Path: "/openapi.yaml",
+		PathParams: map[string]string{},
+	}, requests[0].Operation)
+}

--- a/service_access_test.go
+++ b/service_access_test.go
@@ -21,10 +21,11 @@ import (
 )
 
 type recordingAccessController struct {
-	mu       sync.Mutex
-	requests []kata.AccessRequest
-	err      error
-	lease    kata.AccessLease
+	mu        sync.Mutex
+	requests  []kata.AccessRequest
+	err       error
+	lease     kata.AccessLease
+	authorize func(kata.AccessRequest) error
 }
 
 func (c *recordingAccessController) Authorize(
@@ -37,6 +38,9 @@ func (c *recordingAccessController) Authorize(
 	decision := kata.AccessDecision{}
 	if request.Operation.ID == "streamEvents" {
 		decision.Lease = c.lease
+	}
+	if c.authorize != nil {
+		return decision, c.authorize(request)
 	}
 	return decision, c.err
 }
@@ -103,6 +107,7 @@ func TestServiceAccessControllerDeniesWithoutDisclosingProjectData(t *testing.T)
 		Method:     http.MethodGet,
 		Path:       "/api/v1/projects/{project_id}",
 		PathParams: map[string]string{"project_id": "42"},
+		ProjectIDs: []int64{42},
 	}, controller.snapshot()[0].Operation)
 }
 
@@ -342,4 +347,315 @@ func TestServiceAccessControllerProtectsTheOpenAPIDocument(t *testing.T) {
 		ID: "openAPI", Method: http.MethodGet, Path: "/openapi.yaml",
 		PathParams: map[string]string{},
 	}, requests[0].Operation)
+}
+
+func TestServiceAccessControllerAuthorizesBothProjectsBeforeMerge(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	target := createProject(t, server.URL, "target-project")
+	source := createProject(t, server.URL, "source-project")
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "mergeProject" &&
+			containsInt64(request.Operation.ProjectIDs, source.Project.ID) {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+
+	body := bytes.NewBufferString(`{"source_project_id":` +
+		strconv.FormatInt(source.Project.ID, 10) + `}`)
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(target.Project.ID, 10)+"/merge", body)
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := server.Client().Do(request)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, response.StatusCode)
+
+	requests := controller.snapshot()
+	mergeRequest := requests[len(requests)-1]
+	assert.Equal(t, "mergeProject", mergeRequest.Operation.ID)
+	assert.ElementsMatch(t, []int64{target.Project.ID, source.Project.ID}, mergeRequest.Operation.ProjectIDs)
+}
+
+func TestServiceAccessControllerAuthorizesMoveDestination(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	source := createProject(t, server.URL, "source-project")
+	target := createProject(t, server.URL, "target-project")
+	issueBody := bytes.NewBufferString(`{"actor":"ignored","title":"stays in source"}`)
+	issueResponse, err := http.Post(server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(source.Project.ID, 10)+"/issues", "application/json", issueBody)
+	require.NoError(t, err)
+	defer func() { _ = issueResponse.Body.Close() }()
+	require.Equal(t, http.StatusOK, issueResponse.StatusCode)
+	var created struct {
+		Issue struct {
+			ShortID  string `json:"short_id"`
+			Revision int64  `json:"revision"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.NewDecoder(issueResponse.Body).Decode(&created))
+
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "moveIssue" &&
+			containsString(request.Operation.ProjectUIDs, target.Project.UID) {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+	moveBody := bytes.NewBufferString(`{"actor":"ignored","to_project_uid":"` + target.Project.UID + `"}`)
+	moveRequest, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(source.Project.ID, 10)+"/issues/"+created.Issue.ShortID+"/actions/move", moveBody)
+	require.NoError(t, err)
+	moveRequest.Header.Set("Content-Type", "application/json")
+	moveRequest.Header.Set("If-Match", `"rev-`+strconv.FormatInt(created.Issue.Revision, 10)+`"`)
+	moveResponse, err := server.Client().Do(moveRequest)
+	require.NoError(t, err)
+	defer func() { _ = moveResponse.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, moveResponse.StatusCode)
+
+	requests := controller.snapshot()
+	request := requests[len(requests)-1]
+	assert.Equal(t, "moveIssue", request.Operation.ID)
+	assert.Equal(t, []int64{source.Project.ID}, request.Operation.ProjectIDs)
+	assert.Equal(t, []string{target.Project.UID}, request.Operation.ProjectUIDs)
+}
+
+func TestServiceAccessControllerAuthorizesEffectiveEventStreamScope(t *testing.T) {
+	controller := &recordingAccessController{lease: &revocableAccessLease{}}
+	controller.authorize = func(request kata.AccessRequest) error {
+		if request.Operation.ID == "streamEvents" {
+			return kata.ErrAccessDenied
+		}
+		return nil
+	}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	project := createProject(t, server.URL, "example-project")
+
+	for _, path := range []string{
+		"/api/v1/events/stream?project_id=" + strconv.FormatInt(project.Project.ID, 10),
+		"/api/v1/events/stream",
+	} {
+		request, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
+		require.NoError(t, err)
+		request.Header.Set("Accept", "text/event-stream")
+		response, err := server.Client().Do(request)
+		require.NoError(t, err)
+		_ = response.Body.Close()
+		assert.Equal(t, http.StatusNotFound, response.StatusCode)
+	}
+
+	requests := controller.snapshot()
+	require.GreaterOrEqual(t, len(requests), 3)
+	projectStream := requests[len(requests)-2].Operation
+	globalStream := requests[len(requests)-1].Operation
+	assert.Equal(t, []int64{project.Project.ID}, projectStream.ProjectIDs)
+	assert.False(t, projectStream.AllProjects)
+	assert.Empty(t, globalStream.ProjectIDs)
+	assert.True(t, globalStream.AllProjects)
+}
+
+func TestServiceAccessControllerPreservesScopedFederationAuthentication(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			r = r.WithContext(kata.WithPrincipal(r.Context(), principal))
+		}
+		service.Handler().ServeHTTP(w, r)
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	project := createProject(t, server.URL, "federated-project")
+	issueBody := bytes.NewBufferString(`{"actor":"ignored","title":"claimable issue"}`)
+	issueResponse, err := http.Post(server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues", "application/json", issueBody)
+	require.NoError(t, err)
+	defer func() { _ = issueResponse.Body.Close() }()
+	require.Equal(t, http.StatusOK, issueResponse.StatusCode)
+	var issue struct {
+		Issue struct {
+			ShortID string `json:"short_id"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.NewDecoder(issueResponse.Body).Decode(&issue))
+
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/federation/enable",
+		`{"actor":"ignored"}`, nil)
+	var enrollment struct {
+		Token string `json:"token"`
+	}
+	postJSON(t, server.Client(), server.URL+"/api/v1/federation/enrollments",
+		`{"spoke_instance_uid":"01HZNQ7VFPK1XGD8R5MABCD4EA","project_id":`+
+			strconv.FormatInt(project.Project.ID, 10)+
+			`,"capabilities":"pull,claim","actor":"ignored"}`, &enrollment)
+	require.NotEmpty(t, enrollment.Token)
+
+	invalidMetadataRequest, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/federation/metadata", nil)
+	require.NoError(t, err)
+	invalidMetadataRequest.Header.Set("Authorization", "Bearer invalid-token")
+	invalidMetadataResponse, err := server.Client().Do(invalidMetadataRequest)
+	require.NoError(t, err)
+	defer func() { _ = invalidMetadataResponse.Body.Close() }()
+	assert.Equal(t, http.StatusForbidden, invalidMetadataResponse.StatusCode)
+
+	metadataRequest, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/federation/metadata", nil)
+	require.NoError(t, err)
+	metadataRequest.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	metadataResponse, err := server.Client().Do(metadataRequest)
+	require.NoError(t, err)
+	defer func() { _ = metadataResponse.Body.Close() }()
+	assert.Equal(t, http.StatusOK, metadataResponse.StatusCode)
+
+	claimRequest, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues/"+issue.Issue.ShortID+
+		"/lease/actions/acquire", bytes.NewBufferString(
+		`{"holder":"spoke-worker","client_kind":"cli","claim_kind":"hard"}`))
+	require.NoError(t, err)
+	claimRequest.Header.Set("Content-Type", "application/json")
+	claimRequest.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	claimResponse, err := server.Client().Do(claimRequest)
+	require.NoError(t, err)
+	defer func() { _ = claimResponse.Body.Close() }()
+	assert.Equal(t, http.StatusOK, claimResponse.StatusCode)
+
+	statusRequest, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues/"+issue.Issue.ShortID+"/lease", nil)
+	require.NoError(t, err)
+	statusRequest.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	statusResponse, err := server.Client().Do(statusRequest)
+	require.NoError(t, err)
+	defer func() { _ = statusResponse.Body.Close() }()
+	assert.Equal(t, http.StatusOK, statusResponse.StatusCode)
+
+	for _, request := range controller.snapshot() {
+		assert.NotEqual(t, "getFederationProjectMetadata", request.Operation.ID)
+		assert.NotEqual(t, "acquireIssueLease", request.Operation.ID)
+		assert.NotEqual(t, "getIssueLeaseStatus", request.Operation.ID)
+	}
+}
+
+func TestServiceAccessControllerSuppliesForceReleaseActor(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	project := createProject(t, server.URL, "claim-project")
+	issueBody := bytes.NewBufferString(`{"actor":"ignored","title":"claimed issue"}`)
+	issueResponse, err := http.Post(server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues", "application/json", issueBody)
+	require.NoError(t, err)
+	defer func() { _ = issueResponse.Body.Close() }()
+	require.Equal(t, http.StatusOK, issueResponse.StatusCode)
+	var issue struct {
+		Issue struct {
+			ShortID string `json:"short_id"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.NewDecoder(issueResponse.Body).Decode(&issue))
+	postJSON(t, server.Client(), server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/federation/enable",
+		`{"actor":"forged enable actor"}`, nil)
+
+	claimPath := server.URL + "/api/v1/projects/" + strconv.FormatInt(project.Project.ID, 10) +
+		"/issues/" + issue.Issue.ShortID + "/lease/actions/"
+	postJSON(t, server.Client(), claimPath+"acquire",
+		`{"holder":"local-worker","client_kind":"cli","claim_kind":"hard"}`, nil)
+	var released struct {
+		Event struct {
+			Actor string `json:"actor"`
+		} `json:"event"`
+	}
+	postJSON(t, server.Client(), claimPath+"force_release",
+		`{"actor":"forged audit actor","reason":"operator override"}`, &released)
+	assert.Equal(t, "Example User", released.Event.Actor)
+}
+
+func postJSON(t *testing.T, client *http.Client, url, body string, out any) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodPost, url, bytes.NewBufferString(body))
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.Do(request)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	if out != nil {
+		require.NoError(t, json.NewDecoder(response.Body).Decode(out))
+	}
+}
+
+func containsInt64(values []int64, want int64) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/service_access_test.go
+++ b/service_access_test.go
@@ -554,6 +554,18 @@ func TestServiceAccessControllerPreservesScopedFederationAuthentication(t *testi
 	defer func() { _ = metadataResponse.Body.Close() }()
 	assert.Equal(t, http.StatusOK, metadataResponse.StatusCode)
 
+	invalidClaimRequest, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues/"+issue.Issue.ShortID+
+		"/lease/actions/acquire", bytes.NewBufferString(
+		`{"holder":"unauthorized-worker","client_kind":"cli","claim_kind":"hard"}`))
+	require.NoError(t, err)
+	invalidClaimRequest.Header.Set("Content-Type", "application/json")
+	invalidClaimRequest.Header.Set("Authorization", "Bearer invalid-token")
+	invalidClaimResponse, err := server.Client().Do(invalidClaimRequest)
+	require.NoError(t, err)
+	defer func() { _ = invalidClaimResponse.Body.Close() }()
+	assert.Equal(t, http.StatusForbidden, invalidClaimResponse.StatusCode)
+
 	claimRequest, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/projects/"+
 		strconv.FormatInt(project.Project.ID, 10)+"/issues/"+issue.Issue.ShortID+
 		"/lease/actions/acquire", bytes.NewBufferString(

--- a/service_projects.go
+++ b/service_projects.go
@@ -1,0 +1,246 @@
+package kata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+	katauid "go.kenn.io/kata/internal/uid"
+)
+
+// ErrProjectConflict reports that a requested stable project identity or name
+// is already bound to a different project.
+var ErrProjectConflict = errors.New("kata: project identity conflict")
+
+// ErrProjectNotFound reports that no host-visible project has the requested
+// stable identity.
+var ErrProjectNotFound = errors.New("kata: project not found")
+
+// ProjectState describes whether a host-managed project is available for
+// ordinary operations.
+type ProjectState string
+
+const (
+	// ProjectActive is visible to ordinary task operations.
+	ProjectActive ProjectState = "active"
+	// ProjectArchived retains history but is hidden from ordinary operations.
+	ProjectArchived ProjectState = "archived"
+)
+
+// Project is the stable project identity returned to an embedding host.
+type Project struct {
+	ID        int64
+	UID       string
+	Name      string
+	State     ProjectState
+	CreatedAt time.Time
+}
+
+// ProjectSpec identifies the exact project a host wants to exist.
+type ProjectSpec struct {
+	UID  string
+	Name string
+}
+
+// EnsureProjectResult reports the stable project and whether this call
+// created it.
+type EnsureProjectResult struct {
+	Project Project
+	Created bool
+}
+
+// ProjectMutationResult reports the stable project and whether the call
+// changed its lifecycle.
+type ProjectMutationResult struct {
+	Project Project
+	Changed bool
+}
+
+// EnsureProject creates the exact requested project or returns the existing
+// exact binding. Reusing either the UID or name for a different project fails
+// with ErrProjectConflict. Archived projects are returned without reactivation.
+func (s *Service) EnsureProject(ctx context.Context, spec ProjectSpec) (EnsureProjectResult, error) {
+	if err := validateProjectSpec(spec); err != nil {
+		return EnsureProjectResult{}, err
+	}
+	callCtx, done, err := s.beginHostCall(ctx)
+	if err != nil {
+		return EnsureProjectResult{}, err
+	}
+	defer done()
+
+	if existing, found, err := s.projectByUID(callCtx, spec.UID); err != nil {
+		return EnsureProjectResult{}, err
+	} else if found {
+		return exactProjectResult(existing, spec)
+	}
+	if _, found, err := s.projectByName(callCtx, spec.Name); err != nil {
+		return EnsureProjectResult{}, err
+	} else if found {
+		return EnsureProjectResult{}, projectConflict(spec)
+	}
+
+	created, createErr := s.store.CreateProjectWithUID(callCtx, spec.Name, spec.UID)
+	if createErr == nil {
+		return EnsureProjectResult{Project: publicProject(created), Created: true}, nil
+	}
+
+	// Another service instance may have created the same identity after both
+	// lookups. Collapse that race into the same idempotent result.
+	if existing, found, lookupErr := s.projectByUID(callCtx, spec.UID); lookupErr != nil {
+		return EnsureProjectResult{}, errors.Join(createErr, lookupErr)
+	} else if found {
+		return exactProjectResult(existing, spec)
+	}
+	if _, found, lookupErr := s.projectByName(callCtx, spec.Name); lookupErr != nil {
+		return EnsureProjectResult{}, errors.Join(createErr, lookupErr)
+	} else if found {
+		return EnsureProjectResult{}, projectConflict(spec)
+	}
+	return EnsureProjectResult{}, fmt.Errorf("kata: ensure project: %w", createErr)
+}
+
+// ArchiveProject hides a project from ordinary operations while retaining its
+// stable identity, task history, and events. Repeating the exact archive is an
+// idempotent no-op.
+func (s *Service) ArchiveProject(
+	ctx context.Context,
+	projectUID string,
+	actor string,
+) (ProjectMutationResult, error) {
+	if !katauid.Valid(projectUID) || projectUID == db.SystemProjectUID {
+		return ProjectMutationResult{}, ErrProjectNotFound
+	}
+	if strings.TrimSpace(actor) == "" {
+		return ProjectMutationResult{}, errors.New("kata: archive actor is required")
+	}
+	callCtx, done, err := s.beginHostCall(ctx)
+	if err != nil {
+		return ProjectMutationResult{}, err
+	}
+	defer done()
+
+	existing, found, err := s.projectByUID(callCtx, projectUID)
+	if err != nil {
+		return ProjectMutationResult{}, err
+	}
+	if !found {
+		return ProjectMutationResult{}, ErrProjectNotFound
+	}
+	if existing.DeletedAt != nil {
+		return ProjectMutationResult{Project: publicProject(existing)}, nil
+	}
+
+	archived, event, err := s.store.RemoveProject(callCtx, db.RemoveProjectParams{
+		ProjectID: existing.ID, Actor: actor, Force: true,
+	})
+	if errors.Is(err, db.ErrProjectAlreadyArchived) {
+		converged, found, lookupErr := s.projectByUID(callCtx, projectUID)
+		if lookupErr != nil {
+			return ProjectMutationResult{}, lookupErr
+		}
+		if !found {
+			return ProjectMutationResult{}, ErrProjectNotFound
+		}
+		return ProjectMutationResult{Project: publicProject(converged)}, nil
+	}
+	if errors.Is(err, db.ErrNotFound) {
+		return ProjectMutationResult{}, ErrProjectNotFound
+	}
+	if err != nil {
+		return ProjectMutationResult{}, fmt.Errorf("kata: archive project: %w", err)
+	}
+	if event != nil {
+		s.broadcaster.Broadcast(daemon.StreamMsg{
+			Kind: "event", Event: event, ProjectID: archived.ID,
+		})
+		s.hookSink.Enqueue(*event)
+	}
+	return ProjectMutationResult{Project: publicProject(archived), Changed: true}, nil
+}
+
+func validateProjectSpec(spec ProjectSpec) error {
+	if !katauid.Valid(spec.UID) || spec.UID == db.SystemProjectUID {
+		return fmt.Errorf("kata: invalid project UID")
+	}
+	if spec.Name == db.SystemProjectName || strings.Contains(spec.Name, "#") {
+		return fmt.Errorf("kata: invalid project name")
+	}
+	if err := config.ValidateProjectName(spec.Name); err != nil {
+		return fmt.Errorf("kata: invalid project name: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) projectByUID(ctx context.Context, uid string) (db.Project, bool, error) {
+	project, err := s.store.ProjectByUID(ctx, uid)
+	if errors.Is(err, db.ErrNotFound) {
+		return db.Project{}, false, nil
+	}
+	if err != nil {
+		return db.Project{}, false, fmt.Errorf("kata: find project by UID: %w", err)
+	}
+	return project, true, nil
+}
+
+func (s *Service) projectByName(ctx context.Context, name string) (db.Project, bool, error) {
+	project, err := s.store.ProjectByNameIncludingArchived(ctx, name)
+	if errors.Is(err, db.ErrNotFound) {
+		return db.Project{}, false, nil
+	}
+	if err != nil {
+		return db.Project{}, false, fmt.Errorf("kata: find project by name: %w", err)
+	}
+	return project, true, nil
+}
+
+func exactProjectResult(existing db.Project, spec ProjectSpec) (EnsureProjectResult, error) {
+	if existing.Name != spec.Name {
+		return EnsureProjectResult{}, projectConflict(spec)
+	}
+	return EnsureProjectResult{Project: publicProject(existing)}, nil
+}
+
+func projectConflict(spec ProjectSpec) error {
+	return fmt.Errorf("%w: requested UID %q and name %q do not identify the same project",
+		ErrProjectConflict, spec.UID, spec.Name)
+}
+
+func publicProject(project db.Project) Project {
+	state := ProjectActive
+	if project.DeletedAt != nil {
+		state = ProjectArchived
+	}
+	return Project{
+		ID: project.ID, UID: project.UID, Name: project.Name,
+		State: state, CreatedAt: project.CreatedAt,
+	}
+}
+
+func (s *Service) beginHostCall(ctx context.Context) (context.Context, func(), error) {
+	if ctx == nil {
+		return nil, nil, errors.New("kata: context is required")
+	}
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, nil, errors.New("kata: service is closed")
+	}
+	s.handlerWG.Add(1)
+	lifetimeCtx := s.lifetimeCtx
+	s.mu.Unlock()
+
+	callCtx, cancel := context.WithCancel(ctx)
+	stopLifetimeCancel := context.AfterFunc(lifetimeCtx, cancel)
+	done := func() {
+		stopLifetimeCancel()
+		cancel()
+		s.handlerWG.Done()
+	}
+	return callCtx, done, nil
+}

--- a/service_projects_test.go
+++ b/service_projects_test.go
@@ -1,0 +1,130 @@
+package kata_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata"
+)
+
+func TestServiceEnsureProjectIsIdempotentByStableIdentity(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	spec := kata.ProjectSpec{
+		UID:  "01HZNQ7VFPK1XGD8R5MABCD4EX",
+		Name: "example-host-project",
+	}
+	first, err := service.EnsureProject(context.Background(), spec)
+	require.NoError(t, err)
+	assert.True(t, first.Created)
+	assert.Equal(t, spec.UID, first.Project.UID)
+	assert.Equal(t, spec.Name, first.Project.Name)
+	assert.Equal(t, kata.ProjectActive, first.Project.State)
+
+	second, err := service.EnsureProject(context.Background(), spec)
+	require.NoError(t, err)
+	assert.False(t, second.Created)
+	assert.Equal(t, first.Project, second.Project)
+}
+
+func TestServiceEnsureProjectRejectsIdentityAndNameCollisions(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	_, err = service.EnsureProject(context.Background(), kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EX", Name: "example-host-project",
+	})
+	require.NoError(t, err)
+
+	_, err = service.EnsureProject(context.Background(), kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EX", Name: "different-project-name",
+	})
+	require.ErrorIs(t, err, kata.ErrProjectConflict)
+
+	_, err = service.EnsureProject(context.Background(), kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EY", Name: "example-host-project",
+	})
+	require.ErrorIs(t, err, kata.ErrProjectConflict)
+}
+
+func TestServiceEnsureProjectConvergesConcurrentExactCalls(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	spec := kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EX", Name: "example-host-project",
+	}
+	results := make([]kata.EnsureProjectResult, 2)
+	errs := make([]error, 2)
+	var start sync.WaitGroup
+	start.Add(1)
+	var calls sync.WaitGroup
+	for i := range results {
+		calls.Add(1)
+		go func(index int) {
+			defer calls.Done()
+			start.Wait()
+			results[index], errs[index] = service.EnsureProject(context.Background(), spec)
+		}(i)
+	}
+	start.Done()
+	calls.Wait()
+
+	require.NoError(t, errors.Join(errs...))
+	assert.Equal(t, results[0].Project, results[1].Project)
+	assert.NotEqual(t, results[0].Created, results[1].Created,
+		"exactly one concurrent call must report creation")
+}
+
+func TestServiceArchiveProjectIsIdempotentAndRetainsIdentity(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	spec := kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EX", Name: "example-host-project",
+	}
+	ensured, err := service.EnsureProject(context.Background(), spec)
+	require.NoError(t, err)
+
+	archived, err := service.ArchiveProject(
+		context.Background(), spec.UID, "Example Operator",
+	)
+	require.NoError(t, err)
+	assert.True(t, archived.Changed)
+	assert.Equal(t, ensured.Project.ID, archived.Project.ID)
+	assert.Equal(t, kata.ProjectArchived, archived.Project.State)
+
+	retry, err := service.ArchiveProject(
+		context.Background(), spec.UID, "Example Operator",
+	)
+	require.NoError(t, err)
+	assert.False(t, retry.Changed)
+	assert.Equal(t, archived.Project, retry.Project)
+
+	retained, err := service.EnsureProject(context.Background(), spec)
+	require.NoError(t, err)
+	assert.False(t, retained.Created)
+	assert.Equal(t, archived.Project, retained.Project)
+}

--- a/service_test.go
+++ b/service_test.go
@@ -122,6 +122,7 @@ func TestServiceBearerAuthentication(t *testing.T) {
 type projectResponse struct {
 	Project struct {
 		ID   int64  `json:"id"`
+		UID  string `json:"uid"`
 		Name string `json:"name"`
 	} `json:"project"`
 	Created bool `json:"created"`

--- a/service_test.go
+++ b/service_test.go
@@ -88,7 +88,8 @@ func TestNewRejectsAmbiguousAuthenticationPolicy(t *testing.T) {
 	})
 
 	assert.Nil(t, service)
-	assert.EqualError(t, err, "kata: auth token and trusted caller authentication are mutually exclusive")
+	assert.EqualError(t, err,
+		"kata: auth token, trusted caller authentication, and host access are mutually exclusive")
 }
 
 func TestServiceBearerAuthentication(t *testing.T) {
@@ -120,6 +121,7 @@ func TestServiceBearerAuthentication(t *testing.T) {
 
 type projectResponse struct {
 	Project struct {
+		ID   int64  `json:"id"`
 		Name string `json:"name"`
 	} `json:"project"`
 	Created bool `json:"created"`


### PR DESCRIPTION
Applications that embed Kata may already own user identity and project permissions. The existing choices—a shared bearer token or an all-or-nothing trusted-caller mode—do not let those applications authorize individual Kata operations safely. They also need a retry-safe way to provision projects without reaching through the HTTP API or writing Kata tables directly.

This adds an in-process access controller for mounted services. Kata asks the controller about the matched API operation, records the caller identity supplied by the application, hides denied resources, and treats policy failures as service-unavailable. Event streams carry a revalidation lease so revoked access stops before later events are delivered.

It also adds small project lifecycle methods: ensure one exact project UID/name binding and archive it without deleting its identity or history. Existing bearer-token, trusted-caller, standalone daemon, SQLite, and PostgreSQL behavior is unchanged. This requires no schema change.