### PR TITLE
Add kata init --with-codex-hooks: Codex CLI attention-hook target

### DIFF
--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -19,20 +19,22 @@ import (
 
 // initOptions holds the flags specific to `kata init`.
 type initOptions struct {
-	Project    string
-	Replace    bool
-	Reassign   bool
-	WithAgents bool
-	WithHooks  bool
+	Project        string
+	Replace        bool
+	Reassign       bool
+	WithAgents     bool
+	WithHooks      bool
+	WithCodexHooks bool
 }
 
 // callInitOpts is the parameter bag passed to callInit.
 type callInitOpts struct {
-	Project    string
-	Replace    bool
-	Reassign   bool
-	WithAgents bool
-	WithHooks  bool
+	Project        string
+	Replace        bool
+	Reassign       bool
+	WithAgents     bool
+	WithHooks      bool
+	WithCodexHooks bool
 }
 
 // cliError is a structured error that carries an exit code for main().
@@ -142,6 +144,7 @@ get committed.`,
 	cmd.Flags().BoolVar(&opts.Reassign, "reassign", false, "move an existing alias to this project")
 	cmd.Flags().BoolVar(&opts.WithAgents, "with-agents", false, "write kata agent guidance into AGENTS.md/CLAUDE.md in the workspace")
 	cmd.Flags().BoolVar(&opts.WithHooks, "with-hooks", false, "install work.attention harness hooks into the workspace's Claude Code config (.claude/)")
+	cmd.Flags().BoolVar(&opts.WithCodexHooks, "with-codex-hooks", false, "install Codex CLI work.attention hook wiring (.codex/hooks.json)")
 
 	return cmd
 }
@@ -315,8 +318,17 @@ func runNameInit(ctx context.Context, baseURL string, in localInit, opts callIni
 			warnHooksUpdate(err)
 		}
 	}
+	codexHooksChanged := false
+	if opts.WithCodexHooks {
+		var warnings []string
+		codexHooksChanged, warnings, err = applyCodexHooks(dest)
+		if err != nil {
+			warnCodexHooksUpdate(err)
+		}
+		emitHookWarnings(warnings)
+	}
 
-	return formatInitOutput(bs, resp.Project.Name, dest, resp.Created, resp.Created || tomlChanged || gitignoreChanged || agentsChanged || hooksChanged)
+	return formatInitOutput(bs, resp.Project.Name, dest, resp.Created, resp.Created || tomlChanged || gitignoreChanged || agentsChanged || hooksChanged || codexHooksChanged)
 }
 
 // runStartPathInit is the fallback used when the client cannot derive a name
@@ -373,10 +385,19 @@ func runStartPathInit(ctx context.Context, baseURL, startPath string, opts callI
 			warnHooksUpdate(err)
 		}
 	}
+	codexHooksChanged := false
+	if opts.WithCodexHooks {
+		var warnings []string
+		codexHooksChanged, warnings, err = applyCodexHooks(gitignoreDir)
+		if err != nil {
+			warnCodexHooksUpdate(err)
+		}
+		emitHookWarnings(warnings)
+	}
 
 	// The path-based daemon flow writes workspace files remotely and exposes no
 	// local file-change bit today; project creation is the closest stable signal.
-	return formatInitOutput(bs, resp.Project.Name, gitignoreDir, resp.Created, resp.Created || gitignoreChanged || agentsChanged || hooksChanged)
+	return formatInitOutput(bs, resp.Project.Name, gitignoreDir, resp.Created, resp.Created || gitignoreChanged || agentsChanged || hooksChanged || codexHooksChanged)
 }
 
 func warnGitignoreUpdate(err error) {
@@ -398,6 +419,25 @@ func warnHooksUpdate(err error) {
 		return
 	}
 	fmt.Fprintf(os.Stderr, "kata: warning: could not install attention hooks: %v\n", err)
+}
+
+func warnCodexHooksUpdate(err error) {
+	if currentOutputMode() != outputHuman {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "kata: warning: could not install Codex attention hooks: %v\n", err)
+}
+
+// emitHookWarnings surfaces non-fatal advisories from a hook installer (e.g. a
+// pre-existing [hooks] table in .codex/config.toml) on stderr. Suppressed in
+// machine-output modes, matching the other init warnings.
+func emitHookWarnings(warnings []string) {
+	if currentOutputMode() != outputHuman {
+		return
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "kata: warning: %s\n", w)
+	}
 }
 
 // warnBeadsConflict tells the user kata declined to edit a file in place

--- a/cmd/kata/init_hooks_codex.go
+++ b/cmd/kata/init_hooks_codex.go
@@ -14,9 +14,11 @@ import (
 )
 
 // `kata init --with-codex-hooks` wires the work.attention harness into a Codex
-// CLI workspace by writing .codex/hooks.json. It installs a single SessionStart
-// command hook that runs `kata attention-hook start`, the same hidden
-// subcommand the Claude Code wiring calls.
+// CLI workspace by writing .codex/hooks.json. It installs a SessionStart
+// command hook for startup, resume, and clear transitions that runs
+// `kata attention-hook start`, the same hidden subcommand the Claude Code
+// wiring calls. Context compaction is excluded so it cannot reset live
+// attention state.
 //
 // Codex executes a command hook's `command` string through a login shell
 // ($SHELL -lc), so the whole invocation is one string rather than Claude
@@ -37,6 +39,8 @@ import (
 // codexHookHandler renders the managed Codex command-hook entry. timeout is in
 // seconds and is stored as a json.Number so a re-run's decoded file compares
 // equal to this desired handler (the merge is DeepEqual-based).
+const codexSessionStartMatcher = "startup|resume|clear"
+
 func codexHookHandler() map[string]any {
 	return map[string]any{
 		"type":    "command",
@@ -77,9 +81,10 @@ func applyCodexHooks(dir string) (bool, []string, error) {
 // (all I/O relative to the workspace root). The file is user-owned, so the
 // merge is additive: unknown keys (including "description") and existing hook
 // groups are preserved verbatim modulo re-encoding, and the managed group is
-// appended only when its exact handler is not already present in a matcher-less
-// SessionStart group. A file that fails to parse is left untouched and
-// reported.
+// appended only when its exact handler is not already present under the desired
+// SessionStart matcher. Older matcher-less kata groups are narrowed during
+// re-run so context compaction cannot reset attention. A file that fails to
+// parse is left untouched and reported.
 func ensureCodexHooksFile(root *os.Root) (bool, error) {
 	const rel = ".codex/hooks.json"
 	path := filepath.Join(root.Name(), rel) // display only
@@ -151,9 +156,10 @@ func ensureCodexHooksFile(root *os.Root) (bool, error) {
 }
 
 // upsertCodexHook appends the managed SessionStart command group unless the
-// exact managed handler is already present in a matcher-less SessionStart
-// group. Existing groups are otherwise preserved, including matcher-scoped
-// groups that cannot be interpreted as the managed wiring.
+// exact managed handler is already present under the desired matcher. It also
+// narrows matcher-less groups created by the original installer so compaction
+// does not rerun the start hook. Existing groups with other explicit matchers
+// are preserved as user-owned wiring.
 func upsertCodexHook(file map[string]any) (bool, error) {
 	hooks, err := ensureObject(file, "hooks")
 	if err != nil {
@@ -168,25 +174,65 @@ func upsertCodexHook(file map[string]any) (bool, error) {
 			return false, fmt.Errorf("hooks.%s has an unexpected shape", event)
 		}
 	}
+
+	desiredExists := false
 	for _, g := range groups {
 		gm, ok := g.(map[string]any)
 		if !ok {
 			continue
 		}
-		// The managed group carries no matcher; a matcher-scoped group cannot
-		// stand in for it, so skip those.
-		if _, hasMatcher := gm["matcher"]; hasMatcher {
+		matcher, _ := gm["matcher"].(string)
+		if matcher != codexSessionStartMatcher {
 			continue
 		}
 		entries, _ := gm["hooks"].([]any)
 		for _, e := range entries {
 			if reflect.DeepEqual(e, codexHookHandler()) {
-				return false, nil
+				desiredExists = true
+				break
 			}
 		}
 	}
+
+	legacyChanged := false
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, hasMatcher := gm["matcher"]; hasMatcher {
+			continue
+		}
+		entries, ok := gm["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		filtered := make([]any, 0, len(entries))
+		for _, e := range entries {
+			if reflect.DeepEqual(e, codexHookHandler()) {
+				legacyChanged = true
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		if len(filtered) == len(entries) {
+			continue
+		}
+		if len(filtered) == 0 && !desiredExists {
+			gm["matcher"] = codexSessionStartMatcher
+			gm["hooks"] = []any{codexHookHandler()}
+			desiredExists = true
+			continue
+		}
+		gm["hooks"] = filtered
+	}
+
+	if desiredExists {
+		return legacyChanged, nil
+	}
 	hooks[event] = append(groups, map[string]any{
-		"hooks": []any{codexHookHandler()},
+		"matcher": codexSessionStartMatcher,
+		"hooks":   []any{codexHookHandler()},
 	})
 	return true, nil
 }

--- a/cmd/kata/init_hooks_codex.go
+++ b/cmd/kata/init_hooks_codex.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"github.com/BurntSushi/toml"
+)
+
+// `kata init --with-codex-hooks` wires the work.attention harness into a Codex
+// CLI workspace by writing .codex/hooks.json. It installs a single SessionStart
+// command hook that runs `kata attention-hook start`, the same hidden
+// subcommand the Claude Code wiring calls.
+//
+// Codex executes a command hook's `command` string through a login shell
+// ($SHELL -lc), so the whole invocation is one string rather than Claude
+// Code's separate command+args exec form; `kata` resolves via PATH exactly as
+// an interactive shell would. Only the "start" mode is installed: Codex at the
+// pinned release has no session-end hook event, so an end wiring would be inert.
+//
+// Security boundary — the bare `kata` command is deliberate, not an oversight
+// (reviews keep flagging it as a PATH-impersonation risk). Pinning an absolute
+// path at install time would make hooks.json machine-specific, and the file
+// lives in the workspace where it may be committed or shared; the shipped
+// Claude Code wiring makes the same choice (bare "kata" in .claude/settings.json).
+// A PATH that resolves `kata` to a repository-controlled binary means the
+// developer's shell is already compromised — every make/npm/git invocation has
+// the same exposure — so a hostile PATH is outside this installer's threat
+// model.
+
+// codexHookHandler renders the managed Codex command-hook entry. timeout is in
+// seconds and is stored as a json.Number so a re-run's decoded file compares
+// equal to this desired handler (the merge is DeepEqual-based).
+func codexHookHandler() map[string]any {
+	return map[string]any{
+		"type":    "command",
+		"command": "kata attention-hook start",
+		"timeout": json.Number("10"),
+	}
+}
+
+// applyCodexHooks is the entry point for `--with-codex-hooks`. It merges the
+// SessionStart wiring into <dir>/.codex/hooks.json, preserving everything else
+// the file holds, and returns whether anything changed plus any best-effort
+// warnings for the caller to surface. Re-running on an installed workspace is a
+// no-op.
+//
+// All filesystem steps run fd-relative to the workspace root through os.Root,
+// so a component swapped for a symlink between validation and use cannot
+// redirect a read or write outside the workspace. Pre-existing symlinked
+// .codex or hooks.json components are refused outright, matching the Claude
+// wiring's posture.
+func applyCodexHooks(dir string) (bool, []string, error) {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() { _ = root.Close() }()
+	if err := refuseSymlinkComponents(root, ".codex", ".codex/hooks.json"); err != nil {
+		return false, nil, err
+	}
+	warnings := codexConfigHooksWarnings(root)
+	changed, err := ensureCodexHooksFile(root)
+	if err != nil {
+		return false, nil, err
+	}
+	return changed, warnings, nil
+}
+
+// ensureCodexHooksFile merges the managed SessionStart hook into hooks.json
+// (all I/O relative to the workspace root). The file is user-owned, so the
+// merge is additive: unknown keys (including "description") and existing hook
+// groups are preserved verbatim modulo re-encoding, and the managed group is
+// appended only when its exact handler is not already present in a matcher-less
+// SessionStart group. A file that fails to parse is left untouched and
+// reported.
+func ensureCodexHooksFile(root *os.Root) (bool, error) {
+	const rel = ".codex/hooks.json"
+	path := filepath.Join(root.Name(), rel) // display only
+	content, err := root.ReadFile(rel)
+	exists := true
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		exists = false
+	}
+	file := map[string]any{}
+	if exists {
+		decoder := json.NewDecoder(bytes.NewReader(content))
+		decoder.UseNumber()
+		if err := decoder.Decode(&file); err != nil {
+			return false, fmt.Errorf("parse %s: %w (fix or remove it, then re-run)", path, err)
+		}
+		var trailing any
+		if err := decoder.Decode(&trailing); err != io.EOF {
+			if err == nil {
+				err = errors.New("multiple JSON values")
+			}
+			return false, fmt.Errorf("parse %s: %w (fix or remove it, then re-run)", path, err)
+		}
+		// `null` is valid JSON and decodes to a nil map, which the merge below
+		// would panic assigning into.
+		if file == nil {
+			return false, fmt.Errorf("parse %s: hooks.json root is not an object (fix or remove it, then re-run)", path)
+		}
+	}
+
+	changed, err := upsertCodexHook(file)
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", path, err)
+	}
+	if exists && !changed {
+		return false, nil
+	}
+
+	encoded, err := encodeClaudeSettings(file)
+	if err != nil {
+		return false, err
+	}
+	if err := root.MkdirAll(".codex", 0o750); err != nil {
+		return false, err
+	}
+	if exists {
+		err = atomicReplaceSettings(root, rel, encoded)
+	} else {
+		// O_EXCL: something racing the file into place between read and write
+		// is surfaced rather than overwritten.
+		var f *os.File
+		f, err = root.OpenFile(rel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err == nil {
+			_, werr := f.Write(encoded)
+			if cerr := f.Close(); werr == nil {
+				werr = cerr
+			}
+			err = werr
+		} else if errors.Is(err, os.ErrExist) {
+			err = fmt.Errorf("refusing to overwrite %s: %w", path, err)
+		}
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// upsertCodexHook appends the managed SessionStart command group unless the
+// exact managed handler is already present in a matcher-less SessionStart
+// group. Existing groups are otherwise preserved, including matcher-scoped
+// groups that cannot be interpreted as the managed wiring.
+func upsertCodexHook(file map[string]any) (bool, error) {
+	hooks, err := ensureObject(file, "hooks")
+	if err != nil {
+		return false, err
+	}
+	const event = "SessionStart"
+	var groups []any
+	if raw, exists := hooks[event]; exists {
+		var ok bool
+		groups, ok = raw.([]any)
+		if !ok {
+			return false, fmt.Errorf("hooks.%s has an unexpected shape", event)
+		}
+	}
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		// The managed group carries no matcher; a matcher-scoped group cannot
+		// stand in for it, so skip those.
+		if _, hasMatcher := gm["matcher"]; hasMatcher {
+			continue
+		}
+		entries, _ := gm["hooks"].([]any)
+		for _, e := range entries {
+			if reflect.DeepEqual(e, codexHookHandler()) {
+				return false, nil
+			}
+		}
+	}
+	hooks[event] = append(groups, map[string]any{
+		"hooks": []any{codexHookHandler()},
+	})
+	return true, nil
+}
+
+// codexConfigHooksWarnings returns a best-effort warning when
+// .codex/config.toml already defines a [hooks] table. Codex loads hooks from
+// both config.toml and hooks.json, so an operator with pre-existing TOML hooks
+// should know kata's hooks.json now runs alongside them. Detection is a real
+// TOML parse (BurntSushi/toml, already a dependency) for a top-level `hooks`
+// key. A missing, symlinked, unreadable, or unparseable config.toml yields no
+// warning — config.toml is Codex's own file and the hooks.json install is what
+// this command guarantees.
+func codexConfigHooksWarnings(root *os.Root) []string {
+	const rel = ".codex/config.toml"
+	content, err := root.ReadFile(rel)
+	if err != nil {
+		// Missing is the common case; a symlinked or otherwise unreadable
+		// config.toml is not this installer's file to police, so stay silent.
+		return nil
+	}
+	var parsed map[string]any
+	if _, err := toml.Decode(string(content), &parsed); err != nil {
+		return nil
+	}
+	if _, ok := parsed["hooks"]; !ok {
+		return nil
+	}
+	return []string{fmt.Sprintf(
+		"%s already defines a [hooks] table; kata installed its SessionStart hook into %s, which Codex loads in addition to config.toml hooks",
+		filepath.Join(root.Name(), rel),
+		filepath.Join(root.Name(), ".codex/hooks.json"),
+	)}
+}

--- a/cmd/kata/init_hooks_codex_test.go
+++ b/cmd/kata/init_hooks_codex_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Unit tests for `kata init --with-codex-hooks`: merging the work.attention
+// SessionStart wiring into .codex/hooks.json. Codex runs `command` through a
+// shell, so the whole invocation is one string (contrast with Claude Code's
+// separate command+args exec form).
+
+func readCodexHooks(t *testing.T, dir string) map[string]any {
+	t.Helper()
+	bs, err := os.ReadFile(filepath.Join(dir, ".codex", "hooks.json")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	var file map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(bs))
+	decoder.UseNumber()
+	require.NoError(t, decoder.Decode(&file))
+	return file
+}
+
+func writeCodexHooks(t *testing.T, dir string, file map[string]any) string {
+	t.Helper()
+	bs, err := json.Marshal(file)
+	require.NoError(t, err)
+	return writeRawCodexHooks(t, dir, string(bs))
+}
+
+func writeRawCodexHooks(t *testing.T, dir, content string) string {
+	t.Helper()
+	codexDir := filepath.Join(dir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+	path := filepath.Join(codexDir, "hooks.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644)) //nolint:gosec // test fixture under TempDir
+	return path
+}
+
+func writeCodexConfig(t *testing.T, dir, content string) {
+	t.Helper()
+	codexDir := filepath.Join(dir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(content), 0o644)) //nolint:gosec // test fixture under TempDir
+}
+
+// expectedCodexHandler is the single managed command hook. timeout decodes to
+// json.Number under UseNumber, matching how the writer stores it.
+func expectedCodexHandler() map[string]any {
+	return map[string]any{
+		"type":    "command",
+		"command": "kata attention-hook start",
+		"timeout": json.Number("10"),
+	}
+}
+
+func TestApplyCodexHooks_FreshWorkspace(t *testing.T) {
+	dir := t.TempDir()
+
+	changed, warnings, err := applyCodexHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Empty(t, warnings)
+
+	// hooks.json holds exactly the one matcher-less SessionStart command group.
+	assert.Equal(t, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{
+				"hooks": []any{expectedCodexHandler()},
+			}},
+		},
+	}, readCodexHooks(t, dir))
+}
+
+func TestApplyCodexHooks_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	changed, _, err := applyCodexHooks(dir)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	path := filepath.Join(dir, ".codex", "hooks.json")
+	before, err := os.ReadFile(path) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+
+	changed, warnings, err := applyCodexHooks(dir)
+	require.NoError(t, err)
+	assert.False(t, changed, "an exact installation must be a no-op")
+	assert.Empty(t, warnings)
+
+	after, err := os.ReadFile(path) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+}
+
+func TestApplyCodexHooks_PreservesExistingContent(t *testing.T) {
+	dir := t.TempDir()
+
+	// A description, an unrelated event group, and a matcher-scoped
+	// SessionStart group the managed wiring must not touch.
+	preTool := []any{map[string]any{
+		"hooks": []any{map[string]any{"type": "command", "command": "lint"}},
+	}}
+	scopedStart := map[string]any{
+		"matcher": "startup",
+		"hooks":   []any{map[string]any{"type": "command", "command": "notify"}},
+	}
+	writeCodexHooks(t, dir, map[string]any{
+		"description": "project hooks",
+		"hooks": map[string]any{
+			"PreToolUse":   preTool,
+			"SessionStart": []any{scopedStart},
+		},
+	})
+
+	changed, warnings, err := applyCodexHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Empty(t, warnings)
+
+	file := readCodexHooks(t, dir)
+	assert.Equal(t, "project hooks", file["description"])
+	hooks := file["hooks"].(map[string]any)
+	assert.Equal(t, preTool, hooks["PreToolUse"])
+
+	// The matcher-scoped group does not cover the managed matcher-less wiring,
+	// so it is preserved and the managed group is appended after it.
+	assert.Equal(t, []any{
+		scopedStart,
+		map[string]any{"hooks": []any{expectedCodexHandler()}},
+	}, hooks["SessionStart"])
+}
+
+func TestApplyCodexHooks_RejectsMalformedWithoutWriting(t *testing.T) {
+	tests := map[string]string{
+		"invalid JSON":        "{ not json",
+		"multiple roots":      "{} {}",
+		"null root":           "null\n",
+		"array root":          "[]\n",
+		"null hooks":          `{"hooks":null}`,
+		"array hooks":         `{"hooks":[]}`,
+		"object SessionStart": `{"hooks":{"SessionStart":{}}}`,
+		"string SessionStart": `{"hooks":{"SessionStart":"broken"}}`,
+	}
+	for name, original := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeRawCodexHooks(t, dir, original)
+
+			_, _, err := applyCodexHooks(dir)
+			require.Error(t, err)
+
+			got, readErr := os.ReadFile(path) //nolint:gosec // test fixture under TempDir
+			require.NoError(t, readErr)
+			assert.Equal(t, original, string(got))
+		})
+	}
+}
+
+func TestApplyCodexHooks_RefusesSymlinks(t *testing.T) {
+	t.Run(".codex directory", func(t *testing.T) {
+		dir := t.TempDir()
+		outside := t.TempDir()
+		require.NoError(t, os.Symlink(outside, filepath.Join(dir, ".codex")))
+
+		_, _, err := applyCodexHooks(dir)
+		require.Error(t, err)
+
+		entries, readErr := os.ReadDir(outside)
+		require.NoError(t, readErr)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("hooks.json", func(t *testing.T) {
+		dir := t.TempDir()
+		codexDir := filepath.Join(dir, ".codex")
+		require.NoError(t, os.MkdirAll(codexDir, 0o750))
+		victim := filepath.Join(dir, "victim.json")
+		require.NoError(t, os.WriteFile(victim, []byte("{}"), 0o644)) //nolint:gosec // test fixture under TempDir
+		require.NoError(t, os.Symlink(victim, filepath.Join(codexDir, "hooks.json")))
+
+		_, _, err := applyCodexHooks(dir)
+		require.Error(t, err)
+
+		got, readErr := os.ReadFile(victim) //nolint:gosec // test fixture under TempDir
+		require.NoError(t, readErr)
+		assert.Equal(t, "{}", string(got))
+	})
+}
+
+func TestApplyCodexHooks_WarnsOnConfigTomlHooks(t *testing.T) {
+	t.Run("config.toml with [hooks] warns and still installs", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCodexConfig(t, dir, "[hooks]\nSessionStart = []\n")
+
+		changed, warnings, err := applyCodexHooks(dir)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		require.NotEmpty(t, warnings)
+
+		assert.Equal(t, map[string]any{
+			"hooks": map[string]any{
+				"SessionStart": []any{map[string]any{
+					"hooks": []any{expectedCodexHandler()},
+				}},
+			},
+		}, readCodexHooks(t, dir))
+	})
+
+	t.Run("config.toml without [hooks] does not warn", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCodexConfig(t, dir, "model = \"gpt-5\"\n")
+
+		changed, warnings, err := applyCodexHooks(dir)
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Empty(t, warnings)
+	})
+}

--- a/cmd/kata/init_hooks_codex_test.go
+++ b/cmd/kata/init_hooks_codex_test.go
@@ -68,11 +68,13 @@ func TestApplyCodexHooks_FreshWorkspace(t *testing.T) {
 	assert.True(t, changed)
 	assert.Empty(t, warnings)
 
-	// hooks.json holds exactly the one matcher-less SessionStart command group.
+	// The managed SessionStart group covers real session transitions without
+	// resetting attention during context compaction.
 	assert.Equal(t, map[string]any{
 		"hooks": map[string]any{
 			"SessionStart": []any{map[string]any{
-				"hooks": []any{expectedCodexHandler()},
+				"matcher": "startup|resume|clear",
+				"hooks":   []any{expectedCodexHandler()},
 			}},
 		},
 	}, readCodexHooks(t, dir))
@@ -97,6 +99,35 @@ func TestApplyCodexHooks_Idempotent(t *testing.T) {
 	after, err := os.ReadFile(path) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	assert.Equal(t, before, after)
+}
+
+func TestApplyCodexHooks_NarrowsLegacyMatcherlessHook(t *testing.T) {
+	dir := t.TempDir()
+	writeCodexHooks(t, dir, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{
+				"hooks": []any{expectedCodexHandler()},
+			}},
+		},
+	})
+
+	changed, warnings, err := applyCodexHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Empty(t, warnings)
+	assert.Equal(t, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{
+				"matcher": "startup|resume|clear",
+				"hooks":   []any{expectedCodexHandler()},
+			}},
+		},
+	}, readCodexHooks(t, dir))
+
+	changed, warnings, err = applyCodexHooks(dir)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Empty(t, warnings)
 }
 
 func TestApplyCodexHooks_PreservesExistingContent(t *testing.T) {
@@ -129,11 +160,14 @@ func TestApplyCodexHooks_PreservesExistingContent(t *testing.T) {
 	hooks := file["hooks"].(map[string]any)
 	assert.Equal(t, preTool, hooks["PreToolUse"])
 
-	// The matcher-scoped group does not cover the managed matcher-less wiring,
+	// The narrower matcher-scoped group does not cover the full managed wiring,
 	// so it is preserved and the managed group is appended after it.
 	assert.Equal(t, []any{
 		scopedStart,
-		map[string]any{"hooks": []any{expectedCodexHandler()}},
+		map[string]any{
+			"matcher": "startup|resume|clear",
+			"hooks":   []any{expectedCodexHandler()},
+		},
 	}, hooks["SessionStart"])
 }
 
@@ -207,7 +241,8 @@ func TestApplyCodexHooks_WarnsOnConfigTomlHooks(t *testing.T) {
 		assert.Equal(t, map[string]any{
 			"hooks": map[string]any{
 				"SessionStart": []any{map[string]any{
-					"hooks": []any{expectedCodexHandler()},
+					"matcher": "startup|resume|clear",
+					"hooks":   []any{expectedCodexHandler()},
 				}},
 			},
 		}, readCodexHooks(t, dir))

--- a/cmd/kata/init_with_codex_hooks_e2e_test.go
+++ b/cmd/kata/init_with_codex_hooks_e2e_test.go
@@ -29,7 +29,8 @@ func TestE2E_InitWithCodexHooks(t *testing.T) {
 	assert.Equal(t, map[string]any{
 		"hooks": map[string]any{
 			"SessionStart": []any{map[string]any{
-				"hooks": []any{expectedCodexHandler()},
+				"matcher": "startup|resume|clear",
+				"hooks":   []any{expectedCodexHandler()},
 			}},
 		},
 	}, readCodexHooks(t, dir))
@@ -69,7 +70,8 @@ func TestE2E_InitWithCodexHooks_ComposesWithAgentsAndHooks(t *testing.T) {
 	assert.Equal(t, map[string]any{
 		"hooks": map[string]any{
 			"SessionStart": []any{map[string]any{
-				"hooks": []any{expectedCodexHandler()},
+				"matcher": "startup|resume|clear",
+				"hooks":   []any{expectedCodexHandler()},
 			}},
 		},
 	}, readCodexHooks(t, dir))

--- a/cmd/kata/init_with_codex_hooks_e2e_test.go
+++ b/cmd/kata/init_with_codex_hooks_e2e_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+// This exercises `kata init --with-codex-hooks` as a user would run it: the
+// real CLI command against a live daemon. It complements the focused unit
+// tests in init_hooks_codex_test.go.
+
+// TestE2E_InitWithCodexHooks installs the Codex SessionStart wiring on its own.
+func TestE2E_InitWithCodexHooks(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/example-org/example-workspace.git")
+
+	out := runCLI(t, env, dir, "init", "--with-codex-hooks")
+	assert.Contains(t, out, "project")
+
+	assert.FileExists(t, filepath.Join(dir, ".kata.toml"))
+	assert.Equal(t, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{
+				"hooks": []any{expectedCodexHandler()},
+			}},
+		},
+	}, readCodexHooks(t, dir))
+}
+
+// TestE2E_InitWithCodexHooks_ComposesWithAgentsAndHooks runs all three
+// workspace-wiring flags together: guidance block, Claude Code hooks, and
+// Codex hooks all land in one init, and a second identical init is a no-op.
+func TestE2E_InitWithCodexHooks_ComposesWithAgentsAndHooks(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/example-org/example-workspace.git")
+
+	runCLI(t, env, dir, "init", "--with-agents", "--with-hooks", "--with-codex-hooks")
+
+	// All three artifacts exist.
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Contains(t, string(content), agentsBlockBegin)
+
+	assert.Equal(t, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{
+				"matcher": "startup|resume|clear",
+				"hooks":   []any{expectedHookHandler("start")},
+			}},
+			"SessionEnd": []any{map[string]any{
+				"matcher": "logout|prompt_input_exit|bypass_permissions_disabled|other",
+				"hooks":   []any{expectedHookHandler("end")},
+			}},
+		},
+	}, readSettings(t, dir))
+
+	codexPath := filepath.Join(dir, ".codex", "hooks.json")
+	assert.Equal(t, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{map[string]any{
+				"hooks": []any{expectedCodexHandler()},
+			}},
+		},
+	}, readCodexHooks(t, dir))
+
+	// Re-running the same init leaves the Codex hooks byte-for-byte unchanged.
+	before, err := os.ReadFile(codexPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	runCLI(t, env, dir, "init", "--with-agents", "--with-hooks", "--with-codex-hooks")
+	after, err := os.ReadFile(codexPath) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,10 @@ All notable changes to kata, grouped by release. Versioned releases start with
   status reads use the same fence, and controller failures return only bounded,
   generic authorization errors. Principal and federation fences compose when
   both apply to one request.
+- Added `kata init --with-codex-hooks` to install the `work.attention` harness
+  into a Codex CLI workspace's `.codex/hooks.json`. Only the `SessionStart`
+  half is wired, since Codex has no stable session-end hook event yet; cover
+  the end half with a launcher wrapper until upstream ships one.
 
 ## 0.12.0
 <small>2026-07-20</small>

--- a/docs/operations/agent-orchestration.md
+++ b/docs/operations/agent-orchestration.md
@@ -124,7 +124,8 @@ change independently. Re-running the command is a no-op, and symlinked
 
 For Codex CLI workspaces, `kata init --with-codex-hooks` installs the
 start half of the same wiring into `.codex/hooks.json`: a `SessionStart`
-command hook runs `kata attention-hook start`, using the same launcher-provided
+command hook runs `kata attention-hook start` for new, resumed, and cleared
+sessions, but not context compaction, using the same launcher-provided
 `KATA_REF` and hidden subcommand as the Claude Code wiring. Codex prompts to
 trust project-layer hooks the first time it loads them, so expect one
 interactive confirmation on first run. Re-running the command is a no-op, and

--- a/docs/operations/agent-orchestration.md
+++ b/docs/operations/agent-orchestration.md
@@ -122,6 +122,31 @@ exec-form command does not delegate to a repository script whose contents can
 change independently. Re-running the command is a no-op, and symlinked
 `.claude` or `settings.json` paths are refused.
 
+For Codex CLI workspaces, `kata init --with-codex-hooks` installs the
+start half of the same wiring into `.codex/hooks.json`: a `SessionStart`
+command hook runs `kata attention-hook start`, using the same launcher-provided
+`KATA_REF` and hidden subcommand as the Claude Code wiring. Codex prompts to
+trust project-layer hooks the first time it loads them, so expect one
+interactive confirmation on first run. Re-running the command is a no-op, and
+symlinked `.codex` or `hooks.json` paths are refused; if `.codex/config.toml`
+already defines a `[hooks]` table, the command prints a non-fatal warning that
+Codex loads both files' hooks together.
+
+Codex has no stable session-end hook event yet — the upstream event exists but
+is not yet in a stable Codex release — so `--with-codex-hooks` does not wire an
+end half, and wiring it once Codex ships a stable release is tracked as a
+follow-up. Until then, cover the end half with a launcher wrapper around the
+`codex` invocation (this also works for `codex exec`, since hook subprocesses
+inherit the parent environment). Run the end hook from an `EXIT` trap so it
+still fires if `codex` exits non-zero (or under `set -e`), and let the wrapper
+propagate Codex's own exit status rather than the always-succeeding hook's:
+
+```sh
+export KATA_REF=abc4
+trap 'status=$?; kata attention-hook end; exit "$status"' EXIT
+codex ...
+```
+
 ## Coordinate: wait and dashboards
 
 A delegating **coordinator** joins on sub-tasks with `kata wait`. Launch two

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,7 +19,7 @@ current flag list in your installed binary.
 ## Workspace initialization
 
 ```sh
-kata init [--project <name>] [--with-agents] [--with-hooks]
+kata init [--project <name>] [--with-agents] [--with-hooks] [--with-codex-hooks]
 kata init [--replace | --reassign]
 ```
 
@@ -54,6 +54,19 @@ than clear/resume transitions. Both use the
 launcher-provided `KATA_REF` and intentionally do nothing when it is absent.
 Everything else in `settings.json` is preserved, re-running is a no-op, and a
 symlinked `settings.json` or `.claude` directory is refused.
+
+Pass `--with-codex-hooks` to install the start half of the same
+[attention harness hooks](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
+into the workspace's Codex CLI config. It additively installs one command
+hook entry in `.codex/hooks.json`: `SessionStart` runs `kata attention-hook
+start`, using the launcher-provided `KATA_REF` and intentionally doing nothing
+when it is absent. Codex has no stable session-end hook event yet, so this
+flag does not install an end hook; pair it with a launcher wrapper that runs
+`kata attention-hook end` after the `codex` invocation exits. Everything else
+in `hooks.json` is preserved, re-running is a no-op, a symlinked `hooks.json`
+or `.codex` directory is refused, and a pre-existing `[hooks]` table in
+`.codex/config.toml` produces a non-fatal warning since Codex loads both
+files' hooks together.
 
 ## Issue lifecycle
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -59,14 +59,15 @@ Pass `--with-codex-hooks` to install the start half of the same
 [attention harness hooks](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
 into the workspace's Codex CLI config. It additively installs one command
 hook entry in `.codex/hooks.json`: `SessionStart` runs `kata attention-hook
-start`, using the launcher-provided `KATA_REF` and intentionally doing nothing
-when it is absent. Codex has no stable session-end hook event yet, so this
-flag does not install an end hook; pair it with a launcher wrapper that runs
-`kata attention-hook end` after the `codex` invocation exits. Everything else
-in `hooks.json` is preserved, re-running is a no-op, a symlinked `hooks.json`
-or `.codex` directory is refused, and a pre-existing `[hooks]` table in
-`.codex/config.toml` produces a non-fatal warning since Codex loads both
-files' hooks together.
+start` for new, resumed, and cleared sessions, but not context compaction,
+using the launcher-provided `KATA_REF` and intentionally doing nothing when it
+is absent. Codex has no stable session-end hook event yet, so this flag does
+not install an end hook; pair it with a launcher wrapper that runs `kata
+attention-hook end` after the `codex` invocation exits. Everything else in
+`hooks.json` is preserved, re-running is a no-op, a symlinked `hooks.json` or
+`.codex` directory is refused, and a pre-existing `[hooks]` table in
+`.codex/config.toml` produces a non-fatal warning since Codex loads both files'
+hooks together.
 
 ## Issue lifecycle
 

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -46,6 +46,15 @@ start` for new, resumed, and cleared sessions (but not context compaction), and
 than clear/resume transitions. Both use the
 launcher-provided `KATA_REF` and intentionally do nothing when it is absent.
 
+For Codex CLI workspaces, `kata init --with-codex-hooks` installs the start
+half of the same wiring into `.codex/hooks.json`: a `SessionStart` command
+hook runs `kata attention-hook start`, using the same launcher-provided
+`KATA_REF`. Codex has no stable session-end hook event yet, so pair this with
+a launcher wrapper that runs `kata attention-hook end` after the `codex`
+invocation exits — see
+[agent orchestration](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
+for the recipe.
+
 ## Search before creating
 
 ```sh

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -48,10 +48,11 @@ launcher-provided `KATA_REF` and intentionally do nothing when it is absent.
 
 For Codex CLI workspaces, `kata init --with-codex-hooks` installs the start
 half of the same wiring into `.codex/hooks.json`: a `SessionStart` command
-hook runs `kata attention-hook start`, using the same launcher-provided
-`KATA_REF`. Codex has no stable session-end hook event yet, so pair this with
-a launcher wrapper that runs `kata attention-hook end` after the `codex`
-invocation exits — see
+hook runs `kata attention-hook start` for new, resumed, and cleared sessions
+(but not context compaction), using the same launcher-provided `KATA_REF`.
+Codex has no stable session-end hook event yet, so pair this with a launcher
+wrapper that runs `kata attention-hook end` after the `codex` invocation exits
+— see
 [agent orchestration](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
 for the recipe.
 


### PR DESCRIPTION
Extends `kata init` so Codex CLI workspaces can participate in kata's
`work.attention` lifecycle. The new `--with-codex-hooks` flag installs the
Codex start hook while remaining independent from `--with-agents` and the
existing Claude Code `--with-hooks` option.

## Behavior

- Adds a `SessionStart` command hook to `.codex/hooks.json` that runs
  `kata attention-hook start`.
- Limits the hook to startup, resume, and clear transitions. Context compaction
  does not reset a live `needs-human` or `stuck` signal.
- Uses the launcher's `KATA_REF` environment variable, matching the existing
  Claude Code attention workflow.
- Migrates matcher-less kata hooks written by earlier versions of this branch
  to the scoped matcher on the next `kata init --with-codex-hooks` run.

## Session end

Stable Codex releases do not yet provide a session-end hook suitable for this
workflow, so this flag installs only the native start half. The agent
orchestration documentation includes a launcher-wrapper recipe that runs
`kata attention-hook end` when Codex exits; native end-hook wiring remains a
follow-up once the upstream event is stable.

## Configuration safety

The installer merges into the existing hooks file instead of replacing it. It
preserves unrelated events and metadata, is byte-stable on rerun, refuses
malformed files and symlinked targets, and atomically replaces an existing
file. If `.codex/config.toml` already defines hooks, kata emits a non-fatal
warning because Codex loads both sources.

The CLI reference, agent workflow, orchestration guide, and changelog describe
the new flag and the native-start/launcher-end workflow.

Extends #174 and advances #162.
