### PR TITLE
Refuse git-tracked .kata.local.toml to prevent daemon-URL redirect and token misrouting

### DIFF
--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -10,9 +10,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
+	gitcmd "go.kenn.io/kit/git/cmd"
 )
 
 // remoteServerEnvVar is the environment variable that names a kata
@@ -449,6 +451,13 @@ func remoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 // specific workspace via --workspace pass that path so the walk
 // honors the targeted workspace rather than wherever the user
 // happens to be.
+//
+// A .kata.local.toml discovered at the boundary is additionally
+// refused when it is git-tracked in its containing repo (see
+// localConfigTracked): the file is meant to be per-developer and
+// gitignored, so a committed one has unverifiable provenance and
+// could redirect [server].url to route a victim's bearer token to an
+// attacker-controlled host.
 func findLocalConfig(start string) (root, path string, ok bool) {
 	dir := start
 	if dir == "" {
@@ -478,6 +487,19 @@ func findLocalConfig(start string) (root, path string, ok bool) {
 		}
 		if isWorkspaceBoundary(dir) {
 			if foundLocal {
+				if localConfigTracked(localRoot) {
+					// A .kata.local.toml that is committed into the repo has
+					// attacker-controlled provenance: a hostile contributor
+					// can `git add -f` it past the gitignore and point
+					// [server].url at a host they control, so a victim who
+					// runs kata in the checkout (with a global bearer token
+					// configured) misroutes that token. The file is meant to
+					// be per-developer and gitignored; a tracked one is never
+					// honored as a server/URL override. Drop it and fall
+					// through to active_daemon/local resolution.
+					fmt.Fprintf(os.Stderr, "kata: warning: ignoring %s: it is tracked by git; a committed .kata.local.toml is not honored as a server override (keep it untracked/gitignored)\n", localPath)
+					return "", "", false
+				}
 				return localRoot, localPath, true
 			}
 			return "", "", false
@@ -507,6 +529,31 @@ func isWorkspaceBoundary(dir string) bool {
 		return true
 	}
 	return false
+}
+
+// localConfigGitRunner runs git with a sanitized environment (no inherited
+// GIT_* vars, no global/system config) so provenance checks cannot be steered
+// by ambient config while still honoring the user's safe.directory trust.
+var localConfigGitRunner = gitcmd.New()
+
+// localConfigTracked reports whether the .kata.local.toml in root is tracked
+// by git in root's containing repository. A tracked file is one that was
+// committed into the repo (including a force-add past the gitignore), which
+// gives its contents attacker-controlled provenance; callers must refuse to
+// honor its [server].url / allow_insecure overrides.
+//
+// Untracked and gitignored files — the legitimate per-developer remote
+// workflow — return false, as does a directory that is not a git repository
+// or any case where git cannot be run. `git ls-files --error-unmatch` exits
+// zero only when the pathspec matches a tracked file; any other outcome
+// (untracked, ignored, not a repo, git missing) surfaces as an error and is
+// treated as "not tracked, honor it".
+func localConfigTracked(root string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := localConfigGitRunner.Output(ctx, root,
+		"ls-files", "--error-unmatch", "--", config.LocalConfigFilename)
+	return err == nil
 }
 
 // normalizeRemoteURL parses a value as an http(s) URL and returns the

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -126,7 +126,10 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 		}
 		return u, true, nil
 	}
-	root, path, ok := findLocalConfig(workspaceStart)
+	root, path, ok, err := findLocalConfig(workspaceStart)
+	if err != nil {
+		return "", false, err
+	}
 	if !ok {
 		return resolveActiveRemote(ctx)
 	}
@@ -378,8 +381,11 @@ func higherPriorityRemoteSourceMatchesBaseURL(baseURL, workspaceStart string) bo
 		u, err := normalizeRemoteURL(v, envAllowInsecure())
 		return err == nil && u == baseURL
 	}
-	root, _, ok := findLocalConfig(workspaceStart)
-	if !ok {
+	// An unverifiable local config (findErr != nil) aborts resolution in
+	// resolveRemote, so no client reaches this point through it; report
+	// no match rather than guessing at its contents.
+	root, _, ok, findErr := findLocalConfig(workspaceStart)
+	if findErr != nil || !ok {
 		return false
 	}
 	cfg, err := config.ReadLocalConfig(root)
@@ -417,7 +423,11 @@ func remoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 		u, err := normalizeRemoteURL(v, allow)
 		return err == nil && u == baseURL && allow
 	}
-	root, _, ok := findLocalConfig(workspaceStart)
+	root, _, ok, findErr := findLocalConfig(workspaceStart)
+	if findErr != nil {
+		// Unverifiable provenance never grants a plaintext downgrade.
+		return false
+	}
 	if !ok {
 		return activeRemoteAllowInsecureForBaseURL(baseURL)
 	}
@@ -458,13 +468,21 @@ func remoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 // gitignored, so a committed one has unverifiable provenance and
 // could redirect [server].url to route a victim's bearer token to an
 // attacker-controlled host.
-func findLocalConfig(start string) (root, path string, ok bool) {
+//
+// A non-nil error means a .kata.local.toml was found but its tracked
+// status could not be verified inside a git worktree. That case must
+// abort resolution rather than fall through: the file may be a
+// developer's legitimate override, and silently ignoring it on a
+// transient git failure would reroute a state-changing command to an
+// active or auto-started local daemon. (A determined-tracked file, by
+// contrast, is definitively illegitimate, so treating it as absent
+// restores exactly the pre-attack behavior.)
+func findLocalConfig(start string) (root, path string, ok bool, err error) {
 	dir := start
 	if dir == "" {
-		var err error
 		dir, err = os.Getwd()
 		if err != nil {
-			return "", "", false
+			return "", "", false, nil
 		}
 	}
 
@@ -500,25 +518,28 @@ func findLocalConfig(start string) (root, path string, ok bool) {
 					// honored as a server/URL override. Drop it and fall
 					// through to active_daemon/local resolution.
 					fmt.Fprintf(os.Stderr, "kata: warning: ignoring %s: it is tracked by git; a committed .kata.local.toml is not honored as a server override (keep it untracked/gitignored)\n", localPath)
-					return "", "", false
+					return "", "", false, nil
 				case !determined && gitWorktreePresent(localRoot):
 					// Tracked status could not be established (git missing,
 					// broken, dubious-ownership, or the query timed out) but we
 					// ARE inside a git worktree, where the file could be a
-					// committed redirect. Fail closed: an attacker who can make
-					// the git query fail must not thereby get an unverifiable
-					// override honored.
-					fmt.Fprintf(os.Stderr, "kata: warning: cannot verify git-tracked status of %s inside a git repository; refusing it as a server override — ensure git is available and the checkout is trusted\n", localPath)
-					return "", "", false
+					// committed redirect. Fail closed with a hard error: an
+					// attacker who can make the git query fail must not get an
+					// unverifiable override honored, and a legitimate override
+					// must not be silently dropped in favor of another daemon.
+					return "", "", false, fmt.Errorf(
+						"cannot verify the git-tracked status of %s inside a git repository; "+
+							"refusing it as a server override — ensure git is available and the "+
+							"checkout is trusted, or remove the file", localPath)
 				default:
 					// Either determined-untracked (legitimate gitignored
 					// developer override) or unknown with no .git present at
 					// all (a genuine non-repo workspace anchored only by
 					// .kata.toml, where there is no notion of tracking). Honor.
-					return localRoot, localPath, true
+					return localRoot, localPath, true, nil
 				}
 			}
-			return "", "", false
+			return "", "", false, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -526,7 +547,7 @@ func findLocalConfig(start string) (root, path string, ok bool) {
 			// workspace boundary. A .kata.local.toml found in a
 			// shared ancestor without a workspace anchor is
 			// unverifiable provenance — drop it.
-			return "", "", false
+			return "", "", false, nil
 		}
 		dir = parent
 	}
@@ -565,6 +586,7 @@ var localConfigGitRunner gitOutputRunner = gitcmd.New()
 // does not shell out to git, so it still answers correctly when the git
 // binary is missing, broken, or slow — exactly the conditions under which the
 // provenance query itself cannot determine tracked status.
+//
 func gitWorktreePresent(dir string) bool {
 	for {
 		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
@@ -588,8 +610,8 @@ func gitWorktreePresent(dir string) bool {
 //   - determined && !tracked  → untracked/gitignored; honor (the legitimate
 //     per-developer remote workflow).
 //   - !determined             → git failed or timed out; tracked status is
-//     UNKNOWN and the caller must fail closed inside a worktree (see
-//     findLocalConfig). Failing open here is attacker-influenceable: a hostile
+//     UNKNOWN and the caller must fail closed with an error inside a worktree
+//     (see findLocalConfig). Failing open here is attacker-influenceable: a hostile
 //     repo can commit an evil override and then induce the git query to fail
 //     (a huge index blowing the timeout, a dubious-ownership checkout git
 //     refuses) to get the committed URL honored.

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -587,7 +587,25 @@ var localConfigGitRunner gitOutputRunner = gitcmd.New()
 // binary is missing, broken, or slow — exactly the conditions under which the
 // provenance query itself cannot determine tracked status.
 //
+// Both the lexical path and its symlink-resolved physical path are walked: a
+// workspace anchored through a symlink (e.g. --workspace /elsewhere/link →
+// /repo/nested/ws) has lexical parents with no .git even though the physical
+// location is inside a repo, and missing that would let a committed override
+// through the "no repo → honor" branch when the git query fails. If the
+// physical path cannot be resolved at all, repository membership cannot be
+// ruled out, so the check fails closed and reports a worktree.
 func gitWorktreePresent(dir string) bool {
+	if dotGitInAncestors(dir) {
+		return true
+	}
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return true
+	}
+	return resolved != dir && dotGitInAncestors(resolved)
+}
+
+func dotGitInAncestors(dir string) bool {
 	for {
 		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
 			return true

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -487,7 +487,9 @@ func findLocalConfig(start string) (root, path string, ok bool) {
 		}
 		if isWorkspaceBoundary(dir) {
 			if foundLocal {
-				if localConfigTracked(localRoot) {
+				tracked, determined := localConfigTrackState(localRoot)
+				switch {
+				case determined && tracked:
 					// A .kata.local.toml that is committed into the repo has
 					// attacker-controlled provenance: a hostile contributor
 					// can `git add -f` it past the gitignore and point
@@ -499,8 +501,22 @@ func findLocalConfig(start string) (root, path string, ok bool) {
 					// through to active_daemon/local resolution.
 					fmt.Fprintf(os.Stderr, "kata: warning: ignoring %s: it is tracked by git; a committed .kata.local.toml is not honored as a server override (keep it untracked/gitignored)\n", localPath)
 					return "", "", false
+				case !determined && gitWorktreePresent(localRoot):
+					// Tracked status could not be established (git missing,
+					// broken, dubious-ownership, or the query timed out) but we
+					// ARE inside a git worktree, where the file could be a
+					// committed redirect. Fail closed: an attacker who can make
+					// the git query fail must not thereby get an unverifiable
+					// override honored.
+					fmt.Fprintf(os.Stderr, "kata: warning: cannot verify git-tracked status of %s inside a git repository; refusing it as a server override — ensure git is available and the checkout is trusted\n", localPath)
+					return "", "", false
+				default:
+					// Either determined-untracked (legitimate gitignored
+					// developer override) or unknown with no .git present at
+					// all (a genuine non-repo workspace anchored only by
+					// .kata.toml, where there is no notion of tracking). Honor.
+					return localRoot, localPath, true
 				}
-				return localRoot, localPath, true
 			}
 			return "", "", false
 		}
@@ -531,20 +547,52 @@ func isWorkspaceBoundary(dir string) bool {
 	return false
 }
 
+// gitOutputRunner is the subset of gitcmd.Runner the provenance check needs.
+// Declaring it as an interface lets tests inject a failing/slow runner to
+// exercise the fail-closed path without a real git repo or a real timeout.
+type gitOutputRunner interface {
+	Output(ctx context.Context, dir string, args ...string) ([]byte, error)
+}
+
 // localConfigGitRunner runs git with a sanitized environment (no inherited
 // GIT_* vars, no global/system config) so provenance checks cannot be steered
 // by ambient config while still honoring the user's safe.directory trust.
-var localConfigGitRunner = gitcmd.New()
+var localConfigGitRunner gitOutputRunner = gitcmd.New()
 
-// localConfigTracked reports whether the .kata.local.toml in root is tracked
-// by git in root's containing repository. A tracked file is one that was
+// gitWorktreePresent reports whether dir sits inside a git worktree, decided
+// purely by walking the filesystem upward for a `.git` directory or file
+// (the file form covers submodules and linked worktrees). It intentionally
+// does not shell out to git, so it still answers correctly when the git
+// binary is missing, broken, or slow — exactly the conditions under which the
+// provenance query itself cannot determine tracked status.
+func gitWorktreePresent(dir string) bool {
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
+}
+
+// localConfigTrackState reports whether the .kata.local.toml in root is tracked
+// by git, as a tri-state: (tracked, determined). A tracked file is one that was
 // committed into the repo (including a force-add past the gitignore), which
 // gives its contents attacker-controlled provenance; callers must refuse to
 // honor its [server].url / allow_insecure overrides.
 //
-// Untracked and gitignored files — the legitimate per-developer remote
-// workflow — return false, as does a directory that is not a git repository
-// or any case where git cannot be run.
+//   - determined && tracked   → committed; refuse.
+//   - determined && !tracked  → untracked/gitignored; honor (the legitimate
+//     per-developer remote workflow).
+//   - !determined             → git failed or timed out; tracked status is
+//     UNKNOWN and the caller must fail closed inside a worktree (see
+//     findLocalConfig). Failing open here is attacker-influenceable: a hostile
+//     repo can commit an evil override and then induce the git query to fail
+//     (a huge index blowing the timeout, a dubious-ownership checkout git
+//     refuses) to get the committed URL honored.
 //
 // The match is case-insensitive on the basename and must not depend on git's
 // core.ignorecase: on a case-insensitive filesystem (macOS/APFS) findLocalConfig
@@ -552,14 +600,14 @@ var localConfigGitRunner = gitcmd.New()
 // searched only for the exact lowercase pathspec could miss the uppercase
 // tracked entry and honor the redirect. We instead enumerate the git index
 // entries located directly in root (NUL-delimited, no path separator) and
-// refuse if any basename case-insensitively equals config.LocalConfigFilename.
-// Erring toward refuse is the correct bias for a security control.
-func localConfigTracked(root string) bool {
+// treat the file as tracked if any basename case-insensitively equals
+// config.LocalConfigFilename.
+func localConfigTrackState(root string) (tracked, determined bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	out, err := localConfigGitRunner.Output(ctx, root, "ls-files", "-z", "--", ".")
 	if err != nil {
-		return false
+		return false, false
 	}
 	for _, entry := range strings.Split(string(out), "\x00") {
 		if entry == "" {
@@ -572,10 +620,10 @@ func localConfigTracked(root string) bool {
 			continue
 		}
 		if strings.EqualFold(entry, config.LocalConfigFilename) {
-			return true
+			return true, true
 		}
 	}
-	return false
+	return false, true
 }
 
 // normalizeRemoteURL parses a value as an http(s) URL and returns the

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -594,18 +594,21 @@ func gitWorktreePresent(dir string) bool {
 //     (a huge index blowing the timeout, a dubious-ownership checkout git
 //     refuses) to get the committed URL honored.
 //
-// The match is case-insensitive on the basename and must not depend on git's
-// core.ignorecase: on a case-insensitive filesystem (macOS/APFS) findLocalConfig
-// opens a committed `.KATA.LOCAL.TOML` via its lowercase stat, so a guard that
-// searched only for the exact lowercase pathspec could miss the uppercase
-// tracked entry and honor the redirect. We instead enumerate the git index
-// entries located directly in root (NUL-delimited, no path separator) and
-// treat the file as tracked if any basename case-insensitively equals
-// config.LocalConfigFilename.
+// The match is case-insensitive and must not depend on git's core.ignorecase:
+// on a case-insensitive filesystem (macOS/APFS) findLocalConfig opens a
+// committed `.KATA.LOCAL.TOML` via its lowercase stat, so a plain lowercase
+// pathspec could miss the uppercase tracked entry and honor the redirect. The
+// `:(icase)` pathspec magic performs the case-insensitive match explicitly and
+// is anchored to root (no wildcard, so it never matches a same-named file in a
+// subdirectory). Scoping the query to the single filename also avoids
+// enumerating every tracked file under root, which on a large repo could blow
+// the 5s timeout and — because we now fail closed inside a worktree — wrongly
+// lock a developer out of a legitimate override.
 func localConfigTrackState(root string) (tracked, determined bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	out, err := localConfigGitRunner.Output(ctx, root, "ls-files", "-z", "--", ".")
+	out, err := localConfigGitRunner.Output(ctx, root,
+		"ls-files", "-z", "--", ":(icase)"+config.LocalConfigFilename)
 	if err != nil {
 		return false, false
 	}
@@ -613,15 +616,12 @@ func localConfigTrackState(root string) (tracked, determined bool) {
 		if entry == "" {
 			continue
 		}
-		// Entries in subdirectories carry a path separator (git always
-		// reports forward slashes); only files directly in root are the
-		// workspace-boundary .kata.local.toml candidate.
+		// The pathspec is anchored to root, so a match is a root-level
+		// .kata.local.toml (any case); skip any unexpected nested path.
 		if strings.ContainsRune(entry, '/') {
 			continue
 		}
-		if strings.EqualFold(entry, config.LocalConfigFilename) {
-			return true, true
-		}
+		return true, true
 	}
 	return false, true
 }

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -544,16 +544,38 @@ var localConfigGitRunner = gitcmd.New()
 //
 // Untracked and gitignored files — the legitimate per-developer remote
 // workflow — return false, as does a directory that is not a git repository
-// or any case where git cannot be run. `git ls-files --error-unmatch` exits
-// zero only when the pathspec matches a tracked file; any other outcome
-// (untracked, ignored, not a repo, git missing) surfaces as an error and is
-// treated as "not tracked, honor it".
+// or any case where git cannot be run.
+//
+// The match is case-insensitive on the basename and must not depend on git's
+// core.ignorecase: on a case-insensitive filesystem (macOS/APFS) findLocalConfig
+// opens a committed `.KATA.LOCAL.TOML` via its lowercase stat, so a guard that
+// searched only for the exact lowercase pathspec could miss the uppercase
+// tracked entry and honor the redirect. We instead enumerate the git index
+// entries located directly in root (NUL-delimited, no path separator) and
+// refuse if any basename case-insensitively equals config.LocalConfigFilename.
+// Erring toward refuse is the correct bias for a security control.
 func localConfigTracked(root string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, err := localConfigGitRunner.Output(ctx, root,
-		"ls-files", "--error-unmatch", "--", config.LocalConfigFilename)
-	return err == nil
+	out, err := localConfigGitRunner.Output(ctx, root, "ls-files", "-z", "--", ".")
+	if err != nil {
+		return false
+	}
+	for _, entry := range strings.Split(string(out), "\x00") {
+		if entry == "" {
+			continue
+		}
+		// Entries in subdirectories carry a path separator (git always
+		// reports forward slashes); only files directly in root are the
+		// workspace-boundary .kata.local.toml candidate.
+		if strings.ContainsRune(entry, '/') {
+			continue
+		}
+		if strings.EqualFold(entry, config.LocalConfigFilename) {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeRemoteURL parses a value as an http(s) URL and returns the

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -616,12 +616,20 @@ func localConfigTrackState(root string) (tracked, determined bool) {
 		if entry == "" {
 			continue
 		}
-		// The pathspec is anchored to root, so a match is a root-level
-		// .kata.local.toml (any case); skip any unexpected nested path.
-		if strings.ContainsRune(entry, '/') {
-			continue
+		// The :(icase) pathspec matches only the root-level file (a nested
+		// same-named file is never returned), but git may print it either
+		// cwd-relative (".kata.local.toml") or repo-relative
+		// ("workspaces/app/.kata.local.toml") depending on version/config.
+		// Compare the basename (git always separates with "/") so a
+		// committed override is recognized regardless of the printed form;
+		// rejecting slashed entries would miss it and honor the redirect.
+		name := entry
+		if i := strings.LastIndex(entry, "/"); i >= 0 {
+			name = entry[i+1:]
 		}
-		return true, true
+		if strings.EqualFold(name, config.LocalConfigFilename) {
+			return true, true
+		}
 	}
 	return false, true
 }

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -771,11 +772,15 @@ url = "`+srv.URL+`"
 // a freshly cloned repo has .git but not yet .kata.toml; a developer
 // can still drop a .kata.local.toml beside .git to point at a remote
 // daemon for the upcoming `kata init`.
+//
+// Uses a real repo (not a fake empty .git dir): the provenance guard now
+// consults git inside a worktree, and a freshly cloned repo has a valid .git
+// where `git ls-files` succeeds and reports the untracked local config as
+// untracked — so it is honored, mirroring the real pre-init flow.
 func TestResolveRemote_GitMarkerCountsAsWorkspace(t *testing.T) {
 	srv := pingingServer(t)
 	t.Setenv("KATA_SERVER", "")
-	dir := t.TempDir()
-	require.NoError(t, os.Mkdir(filepath.Join(dir, ".git"), 0o755)) //nolint:gosec // test fixture under TempDir
+	dir := testfix.InitGitRepo(t)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
 		[]byte(`version = 1
 [server]
@@ -870,7 +875,7 @@ allow_insecure = true
 // core.ignorecase, so the repo pins it false and commits the uppercase name:
 // a lowercase-pathspec lookup would miss it, but the guard must still refuse.
 //
-// This exercises localConfigTracked directly because the end-to-end
+// This exercises localConfigTrackState directly because the end-to-end
 // resolveRemote manifestation only reproduces on a case-insensitive FS (the
 // lowercase os.Stat in findLocalConfig cannot open the uppercase file on the
 // case-sensitive Linux CI host); the guard function is the seam where the
@@ -886,7 +891,9 @@ url = "http://198.51.100.1:7777"
 	testfix.RunGit(t, dir, "add", "-f", ".KATA.LOCAL.TOML")
 	testfix.RunGit(t, dir, "commit", "--quiet", "-m", "plant case-variant config")
 
-	assert.True(t, localConfigTracked(dir),
+	tracked, determined := localConfigTrackState(dir)
+	assert.True(t, determined, "a working git query must yield a determined result")
+	assert.True(t, tracked,
 		"a committed case-variant .kata.local.toml must be treated as tracked")
 }
 
@@ -901,8 +908,80 @@ func TestLocalConfigTracked_UntrackedNotRefused(t *testing.T) {
 url = "http://198.51.100.1:7777"
 `), 0o600))
 
-	assert.False(t, localConfigTracked(dir),
+	tracked, determined := localConfigTrackState(dir)
+	assert.True(t, determined, "a working git query must yield a determined result")
+	assert.False(t, tracked,
 		"an untracked .kata.local.toml must not be treated as tracked")
+}
+
+// failingGitRunner stands in for a git binary that is missing, broken, or
+// hangs past the timeout. It never inspects args; the point is the error.
+type failingGitRunner struct{ err error }
+
+func (f failingGitRunner) Output(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return nil, f.err
+}
+
+// stubGitRunner swaps the package git runner for the duration of the test so
+// the fail-closed path is exercised without a real 5s timeout or a broken git.
+func stubGitRunner(t *testing.T, r gitOutputRunner) {
+	t.Helper()
+	saved := localConfigGitRunner
+	localConfigGitRunner = r
+	t.Cleanup(func() { localConfigGitRunner = saved })
+}
+
+// TestResolveRemote_GitQueryFailureInWorktreeFailsClosed covers the fail-open
+// escalation: a hostile repo commits an evil override and then induces the
+// tracked-status git query to fail (huge index blows the timeout, or a
+// dubious-ownership checkout git refuses). Because we are demonstrably inside a
+// git worktree, the unverifiable file must be refused, not honored — otherwise
+// the victim's global bearer token is routed to the committed URL. The server
+// is reachable so a pass could only come from honoring the file.
+func TestResolveRemote_GitQueryFailureInWorktreeFailsClosed(t *testing.T) {
+	srv := pingingServer(t)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "victim-global-token")
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+srv.URL+`"
+`), 0o600))
+	testfix.RunGit(t, dir, "add", "-f", ".kata.local.toml")
+	testfix.RunGit(t, dir, "commit", "--quiet", "-m", "plant evil override")
+	t.Chdir(dir)
+	stubGitRunner(t, failingGitRunner{err: errors.New("git unavailable")})
+
+	url, ok, err := resolveRemote(context.Background(), "")
+	require.NoError(t, err)
+	assert.False(t, ok, "unverifiable tracked status inside a git worktree must fail closed")
+	assert.Empty(t, url)
+	assert.NotEqual(t, srv.URL, url)
+}
+
+// TestResolveRemote_GitQueryFailureNonRepoHonored guards the legitimate
+// non-git workspace: a bare directory anchored only by .kata.toml (no .git
+// anywhere up the tree) has no notion of tracking, so an untracked
+// .kata.local.toml must still be honored even though the git query yields no
+// determined answer. This keeps kata usable without git in a non-repo project.
+func TestResolveRemote_GitQueryFailureNonRepoHonored(t *testing.T) {
+	srv := pingingServer(t)
+	t.Setenv("KATA_SERVER", "")
+	dir := t.TempDir()
+	writeWorkspaceMarker(t, dir) // .kata.toml boundary, no .git
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+srv.URL+`"
+`), 0o600))
+	t.Chdir(dir)
+	stubGitRunner(t, failingGitRunner{err: errors.New("not a git repository")})
+
+	url, ok, err := resolveRemote(context.Background(), "")
+	require.NoError(t, err)
+	assert.True(t, ok, "a non-repo workspace with no .git must honor its untracked local config")
+	assert.Equal(t, srv.URL, url)
 }
 
 // TestNormalizeRemoteURL_SchemeGuard covers the plain-http guard.

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -978,14 +978,19 @@ func TestLocalConfigTrackState_RepoRelativeMatchTracked(t *testing.T) {
 		"a matched root-level override must be tracked even when git prints a repo-relative path")
 }
 
-// TestResolveRemote_GitQueryFailureInWorktreeFailsClosed covers the fail-open
+// TestResolveRemote_GitQueryFailureInWorktreeErrors covers the fail-open
 // escalation: a hostile repo commits an evil override and then induces the
 // tracked-status git query to fail (huge index blows the timeout, or a
 // dubious-ownership checkout git refuses). Because we are demonstrably inside a
 // git worktree, the unverifiable file must be refused, not honored — otherwise
 // the victim's global bearer token is routed to the committed URL. The server
 // is reachable so a pass could only come from honoring the file.
-func TestResolveRemote_GitQueryFailureInWorktreeFailsClosed(t *testing.T) {
+//
+// Refusal must surface as an error, not a silent fall-through: the file may
+// equally be a developer's legitimate override, and treating a transient git
+// failure as "no override" would silently reroute a state-changing command to
+// an active or auto-started local daemon.
+func TestResolveRemote_GitQueryFailureInWorktreeErrors(t *testing.T) {
 	srv := pingingServer(t)
 	t.Setenv("KATA_SERVER", "")
 	t.Setenv("KATA_AUTH_TOKEN", "victim-global-token")
@@ -1001,10 +1006,11 @@ url = "`+srv.URL+`"
 	stubGitRunner(t, failingGitRunner{err: errors.New("git unavailable")})
 
 	url, ok, err := resolveRemote(context.Background(), "")
-	require.NoError(t, err)
-	assert.False(t, ok, "unverifiable tracked status inside a git worktree must fail closed")
+	require.Error(t, err,
+		"unverifiable tracked status inside a git worktree must error, not fall through to another daemon")
+	assert.Contains(t, err.Error(), ".kata.local.toml")
+	assert.False(t, ok)
 	assert.Empty(t, url)
-	assert.NotEqual(t, srv.URL, url)
 }
 
 // TestResolveRemote_GitQueryFailureNonRepoHonored guards the legitimate

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -1013,6 +1013,64 @@ url = "`+srv.URL+`"
 	assert.Empty(t, url)
 }
 
+// TestResolveRemote_SymlinkedWorkspaceGitFailureRefused closes the symlink
+// bypass of the fail-closed path: the workspace is anchored through a symlink
+// whose lexical parents contain no .git, while the physical target is a nested
+// workspace inside a git repo with a committed override. When the tracked-
+// status query fails, worktree detection must resolve symlinks and still
+// recognize the repo — otherwise the committed override lands in the
+// "no repo → honor" branch and the bearer token is misrouted.
+func TestResolveRemote_SymlinkedWorkspaceGitFailureRefused(t *testing.T) {
+	srv := pingingServer(t)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "victim-global-token")
+	repo := testfix.InitGitRepo(t)
+	nested := filepath.Join(repo, "ws")
+	require.NoError(t, os.Mkdir(nested, 0o755)) //nolint:gosec // test fixture under TempDir
+	writeWorkspaceMarker(t, nested)
+	require.NoError(t, os.WriteFile(filepath.Join(nested, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+srv.URL+`"
+`), 0o600))
+	testfix.RunGit(t, repo, "add", "-f", "ws/.kata.local.toml")
+	testfix.RunGit(t, repo, "commit", "--quiet", "-m", "plant nested override")
+	link := filepath.Join(t.TempDir(), "link")
+	require.NoError(t, os.Symlink(nested, link))
+	stubGitRunner(t, failingGitRunner{err: errors.New("git unavailable")})
+
+	url, ok, err := resolveRemote(context.Background(), link)
+	require.Error(t, err,
+		"a symlinked workspace physically inside a git repo must not dodge the fail-closed path")
+	assert.Contains(t, err.Error(), ".kata.local.toml")
+	assert.False(t, ok)
+	assert.Empty(t, url)
+}
+
+// TestResolveRemote_SymlinkedNonRepoWorkspaceGitFailureHonored guards the
+// legitimate side of the symlink fix: a workspace reached through a symlink
+// whose physical target is genuinely outside any git repo has no notion of
+// tracking, so its local config must still be honored when git is unavailable.
+func TestResolveRemote_SymlinkedNonRepoWorkspaceGitFailureHonored(t *testing.T) {
+	srv := pingingServer(t)
+	t.Setenv("KATA_SERVER", "")
+	dir := t.TempDir()
+	writeWorkspaceMarker(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+srv.URL+`"
+`), 0o600))
+	link := filepath.Join(t.TempDir(), "link")
+	require.NoError(t, os.Symlink(dir, link))
+	stubGitRunner(t, failingGitRunner{err: errors.New("not a git repository")})
+
+	url, ok, err := resolveRemote(context.Background(), link)
+	require.NoError(t, err)
+	assert.True(t, ok, "a symlinked non-repo workspace must still honor its local config")
+	assert.Equal(t, srv.URL, url)
+}
+
 // TestResolveRemote_GitQueryFailureNonRepoHonored guards the legitimate
 // non-git workspace: a bare directory anchored only by .kata.toml (no .git
 // anywhere up the tree) has no notion of tracking, so an untracked

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -914,6 +914,28 @@ url = "http://198.51.100.1:7777"
 		"an untracked .kata.local.toml must not be treated as tracked")
 }
 
+// TestLocalConfigTracked_SubdirSameNameNotRoot pins the scoping contract of the
+// `:(icase)` pathspec query: a tracked .kata.local.toml committed in a
+// subdirectory must not make the workspace root look tracked. Root here has
+// only an untracked file, so the guard must report determined + untracked
+// (honored) — not tracked because of the nested committed file.
+func TestLocalConfigTracked_SubdirSameNameNotRoot(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755)) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", ".kata.local.toml"),
+		[]byte("version = 1\n"), 0o600))
+	testfix.RunGit(t, dir, "add", "-f", "sub/.kata.local.toml")
+	testfix.RunGit(t, dir, "commit", "--quiet", "-m", "nested config")
+	// Untracked file at root — the candidate findLocalConfig would honor.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte("version = 1\n"), 0o600))
+
+	tracked, determined := localConfigTrackState(dir)
+	assert.True(t, determined)
+	assert.False(t, tracked,
+		"a committed config in a subdirectory must not mark the root as tracked")
+}
+
 // failingGitRunner stands in for a git binary that is missing, broken, or
 // hangs past the timeout. It never inspects args; the point is the error.
 type failingGitRunner struct{ err error }

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/testfix"
 )
 
 func pingingServer(t *testing.T) *httptest.Server {
@@ -786,6 +787,79 @@ url = "`+srv.URL+`"
 	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, srv.URL, url)
+}
+
+// TestResolveRemote_TrackedFileNotHonored covers the credential-misrouting
+// fix: a .kata.local.toml that a hostile contributor force-committed past
+// the gitignore has attacker-controlled provenance, so its [server].url
+// override must NOT be honored even though the URL is reachable. Without the
+// provenance guard, resolution would return the committed URL and the CLI
+// would attach the victim's global bearer token to it.
+func TestResolveRemote_TrackedFileNotHonored(t *testing.T) {
+	srv := pingingServer(t) // reachable: proves refusal is provenance-based, not a probe failure
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "victim-global-token")
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+srv.URL+`"
+`), 0o600))
+	// Force-commit past the gitignore, mirroring `git add -f`.
+	testfix.RunGit(t, dir, "add", "-f", ".kata.local.toml")
+	testfix.RunGit(t, dir, "commit", "--quiet", "-m", "plant local config")
+	t.Chdir(dir)
+
+	url, ok, err := resolveRemote(context.Background(), "")
+	require.NoError(t, err)
+	assert.False(t, ok, "a git-tracked .kata.local.toml must not be honored as a server override")
+	assert.Empty(t, url)
+	assert.NotEqual(t, srv.URL, url)
+}
+
+// TestResolveRemote_UntrackedFileHonoredInGitRepo guards the legitimate
+// developer workflow: a gitignored (untracked) .kata.local.toml inside a real
+// git repo pointing at the developer's own remote daemon must still resolve.
+// The provenance guard only refuses tracked files.
+func TestResolveRemote_UntrackedFileHonoredInGitRepo(t *testing.T) {
+	srv := pingingServer(t)
+	t.Setenv("KATA_SERVER", "")
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"),
+		[]byte(".kata.local.toml\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+srv.URL+`"
+`), 0o600))
+	t.Chdir(dir)
+
+	url, ok, err := resolveRemote(context.Background(), "")
+	require.NoError(t, err)
+	assert.True(t, ok, "an untracked/gitignored .kata.local.toml must remain honored")
+	assert.Equal(t, srv.URL, url)
+}
+
+// TestRemoteAllowInsecureForBaseURL_TrackedFileDenied covers the plaintext
+// vector: a tracked .kata.local.toml cannot grant allow_insecure for its URL,
+// so the CLI will not downgrade the bearer-token transport to cleartext toward
+// an attacker-chosen host.
+func TestRemoteAllowInsecureForBaseURL_TrackedFileDenied(t *testing.T) {
+	t.Setenv("KATA_SERVER", "")
+	dir := testfix.InitGitRepo(t)
+	const baseURL = "http://198.51.100.1:7777" // TEST-NET-3, never dialed
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "`+baseURL+`"
+allow_insecure = true
+`), 0o600))
+	testfix.RunGit(t, dir, "add", "-f", ".kata.local.toml")
+	testfix.RunGit(t, dir, "commit", "--quiet", "-m", "plant local config")
+	t.Chdir(dir)
+
+	assert.False(t, remoteAllowInsecureForBaseURL(baseURL, ""),
+		"a tracked .kata.local.toml must not grant allow_insecure for its URL")
 }
 
 // TestNormalizeRemoteURL_SchemeGuard covers the plain-http guard.

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -862,6 +862,49 @@ allow_insecure = true
 		"a tracked .kata.local.toml must not grant allow_insecure for its URL")
 }
 
+// TestLocalConfigTracked_CaseVariantCommittedRefused hardens the provenance
+// guard against a case-insensitive-filesystem bypass. On macOS/APFS a
+// committed `.KATA.LOCAL.TOML` is opened by findLocalConfig's lowercase stat,
+// so its [server].url would be applied; the guard must therefore recognize it
+// as tracked regardless of case. The check must not lean on git's
+// core.ignorecase, so the repo pins it false and commits the uppercase name:
+// a lowercase-pathspec lookup would miss it, but the guard must still refuse.
+//
+// This exercises localConfigTracked directly because the end-to-end
+// resolveRemote manifestation only reproduces on a case-insensitive FS (the
+// lowercase os.Stat in findLocalConfig cannot open the uppercase file on the
+// case-sensitive Linux CI host); the guard function is the seam where the
+// break is deterministically observable everywhere.
+func TestLocalConfigTracked_CaseVariantCommittedRefused(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	testfix.RunGit(t, dir, "config", "core.ignorecase", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".KATA.LOCAL.TOML"),
+		[]byte(`version = 1
+[server]
+url = "http://198.51.100.1:7777"
+`), 0o600))
+	testfix.RunGit(t, dir, "add", "-f", ".KATA.LOCAL.TOML")
+	testfix.RunGit(t, dir, "commit", "--quiet", "-m", "plant case-variant config")
+
+	assert.True(t, localConfigTracked(dir),
+		"a committed case-variant .kata.local.toml must be treated as tracked")
+}
+
+// TestLocalConfigTracked_UntrackedNotRefused pins the legitimate path at the
+// same seam: an untracked lowercase file is not in the git index, so the guard
+// must report it not-tracked (honored).
+func TestLocalConfigTracked_UntrackedNotRefused(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.local.toml"),
+		[]byte(`version = 1
+[server]
+url = "http://198.51.100.1:7777"
+`), 0o600))
+
+	assert.False(t, localConfigTracked(dir),
+		"an untracked .kata.local.toml must not be treated as tracked")
+}
+
 // TestNormalizeRemoteURL_SchemeGuard covers the plain-http guard.
 // Plain http is rejected for public IPs and hostnames; loopback and
 // private IPs are accepted; https and allow_insecure short-circuit.

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -953,6 +953,31 @@ func stubGitRunner(t *testing.T, r gitOutputRunner) {
 	t.Cleanup(func() { localConfigGitRunner = saved })
 }
 
+// fixedGitRunner returns canned NUL-delimited ls-files output, letting a test
+// pin how the tracked-status parser reacts to a specific git output shape.
+type fixedGitRunner struct{ out string }
+
+func (f fixedGitRunner) Output(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	return []byte(f.out), nil
+}
+
+// TestLocalConfigTrackState_RepoRelativeMatchTracked pins the tracked verdict
+// against git output that reports the matched file as a repo-relative path
+// (e.g. "workspaces/app/.kata.local.toml") rather than cwd-relative. The
+// :(icase) pathspec only ever matches the root-level file — never a nested
+// same-named file — so any returned entry is that file regardless of how git
+// prints the path. Comparing the basename (not rejecting any entry containing
+// a slash) keeps a committed override in a nested workspace recognized as
+// tracked; the slash-rejecting form silently treated it as untracked and
+// honored the redirect.
+func TestLocalConfigTrackState_RepoRelativeMatchTracked(t *testing.T) {
+	stubGitRunner(t, fixedGitRunner{out: "workspaces/app/.kata.local.toml\x00"})
+	tracked, determined := localConfigTrackState("/repo/workspaces/app")
+	assert.True(t, determined, "a successful git query is determined")
+	assert.True(t, tracked,
+		"a matched root-level override must be tracked even when git prints a repo-relative path")
+}
+
 // TestResolveRemote_GitQueryFailureInWorktreeFailsClosed covers the fail-open
 // escalation: a hostile repo commits an evil override and then induces the
 // tracked-status git query to fail (huge index blows the timeout, or a


### PR DESCRIPTION
## Problem

`.kata.local.toml` is a per-developer, gitignored file that can point the CLI's daemon `[server].url` at a remote daemon. The runtime never verified that the discovered file was actually untracked, so a hostile contributor could `git add -f .kata.local.toml` past the gitignore and commit a `[server].url` pointing at a host they control. A victim who ran **any** `kata` command in that checkout with a global bearer token configured (`KATA_AUTH_TOKEN` or `[auth].token`) would then have that token attached to the attacker's origin during daemon resolution — the credential-misrouting class the federation trust model calls out as a real bug to fix. The worst case (`https://attacker-host`) needs no victim opt-in beyond having a token configured.

This exposure is **pre-existing on `main`** — it predates and is unrelated to the Codex-hooks work in #191. It already ships via `kata init --with-hooks` (Claude Code) and via any manual `kata` command in a hostile checkout; the attention-hook is simply an unattended trigger. The fix lives at the shared daemon-resolution seam, so it protects every command, not just the hooks.

## Fix

A provenance guard at `findLocalConfig` (`internal/client/remote.go`). When a `.kata.local.toml` is discovered at the workspace boundary, its git-tracked status is checked via `git ls-files` through kata's sanitized git runner (no inherited `GIT_*`, no global/system config, so the check can't be steered by ambient config). The guard is tri-state:

- **Determined tracked** (committed, incl. force-add past gitignore) → refused; resolution falls through to `active_daemon`/local. The attacker URL is never resolved and no token is attached to it.
- **Determined untracked / gitignored** → honored (the legitimate per-developer remote workflow, unchanged), as are `KATA_SERVER` and `active_daemon` catalog entries.
- **Unverifiable inside a git worktree** (git missing/broken, dubious-ownership checkout, or the query times out) → **fails closed** and refuses the override. Worktree presence is detected by walking the filesystem for a `.git` marker, so it still answers when the git binary is unavailable — exactly when the query can't decide. This closes an attacker-influenceable fail-open (a huge committed index blowing the timeout, or a dubious-ownership checkout).

The tracked-status match is case-insensitive on the basename and independent of git's `core.ignorecase`, so a committed `.KATA.LOCAL.TOML` cannot slip past on a case-insensitive filesystem.

## Known tradeoffs

- **Availability, fail-closed bias:** a legitimate gitignored `.kata.local.toml` is refused if you are inside a git worktree but git is unavailable or the query times out. This is the intended bias for a credential-routing control; the genuine non-git workspace path (a bare dir anchored only by `.kata.toml`) is unaffected and still honored.
- **Minor known false-positive (accepted):** on a case-sensitive filesystem, if a repo tracks a distinct case-variant such as `.KATA.LOCAL.TOML` while you use an untracked lowercase `.kata.local.toml`, the case-insensitive match refuses the valid file. This is an intentional erring-toward-refuse edge of the case-insensitive hardening; it is availability-only and requires an implausible repo layout (tracking a case-variant of a gitignored dotfile). Tightening it with an inode-identity (`os.SameFile`) check is a possible follow-up.

## Optional follow-up (not in this PR)

Origin-pinning the global bearer token at the token-attach seam — mirroring `resolveHubAdminAuth`'s discipline for federation hub tokens — as defense-in-depth. The provenance guard already closes the reported hole at the source; a naive pin risked regressing the documented `.kata.local.toml` remote workflow, so it was deferred.