### PR TITLE
Add restricted embedding policy and transaction fences

### DIFF
--- a/access.go
+++ b/access.go
@@ -20,6 +20,47 @@ type Principal struct {
 	Actor   string
 }
 
+// Capability is the product-neutral authority class an operation requires.
+// Embedding hosts map these classes to their own roles and grants.
+type Capability string
+
+// Capability values form the stable authority vocabulary exposed to hosts.
+const (
+	CapabilityRead     Capability = "read"
+	CapabilityWrite    Capability = "write"
+	CapabilityManage   Capability = "manage"
+	CapabilityFederate Capability = "federate"
+)
+
+// OperationKind describes the domain boundary of a matched route. The values
+// are owned by Kata so embedding hosts do not have to duplicate route policy.
+type OperationKind string
+
+// Operation kinds group routes by their data and administration boundary.
+const (
+	OperationServiceRead               OperationKind = "service_read"
+	OperationProjectRead               OperationKind = "project_read"
+	OperationTaskRead                  OperationKind = "task_read"
+	OperationTaskMutation              OperationKind = "task_mutation"
+	OperationTaskAdministration        OperationKind = "task_administration"
+	OperationProjectAdministration     OperationKind = "project_administration"
+	OperationTokenAdministration       OperationKind = "token_administration"
+	OperationFederationRead            OperationKind = "federation_read"
+	OperationFederationAdministration  OperationKind = "federation_administration"
+	OperationFederationTransport       OperationKind = "federation_transport"
+	OperationIntegrationAdministration OperationKind = "integration_administration"
+)
+
+// OperationPolicy is Kata's deny-by-default classification of one route.
+// Mutation and LongLived let a host apply browser and resource controls without
+// inferring behavior from an HTTP verb or operation name.
+type OperationPolicy struct {
+	Kind       OperationKind
+	Capability Capability
+	Mutation   bool
+	LongLived  bool
+}
+
 // Operation identifies the matched Kata HTTP operation without assigning any
 // host-specific meaning to it.
 type Operation struct {
@@ -27,6 +68,7 @@ type Operation struct {
 	Method     string
 	Path       string
 	PathParams map[string]string
+	Policy     OperationPolicy
 
 	// ProjectIDs and ProjectUIDs identify every project whose data the
 	// operation may read or change. AllProjects is true when a global selector

--- a/access.go
+++ b/access.go
@@ -110,9 +110,9 @@ type TransactionFence func(context.Context, Transaction) error
 type AccessDecision struct {
 	Lease AccessLease
 	// TransactionFence should be present on every successful decision. Kata
-	// invokes it when handling the operation begins a storage transaction,
-	// before the transaction's first domain write, and retains its database
-	// locks through commit or rollback.
+	// invokes it when handling the operation begins a writable storage
+	// transaction, before the transaction's first domain write, and retains its
+	// database locks through commit or rollback.
 	TransactionFence TransactionFence
 }
 

--- a/access.go
+++ b/access.go
@@ -2,6 +2,7 @@ package kata
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 )
 
@@ -93,10 +94,26 @@ type AccessLease interface {
 	Revalidate(context.Context) error
 }
 
+// Transaction is the narrow database/sql surface supplied to a transaction
+// fence. Both SQLite and PostgreSQL transactions implement it.
+type Transaction interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// TransactionFence revalidates authority from inside the active storage
+// transaction. Returning an error aborts and rolls back the domain mutation.
+type TransactionFence func(context.Context, Transaction) error
+
 // AccessDecision carries state needed after a request is admitted. Lease may
 // be nil for bounded responses; long-lived operations require one.
 type AccessDecision struct {
 	Lease AccessLease
+	// TransactionFence should be present on every successful decision. Kata
+	// invokes it when handling the operation begins a storage transaction,
+	// before the transaction's first domain write, and retains its database
+	// locks through commit or rollback.
+	TransactionFence TransactionFence
 }
 
 // AccessController makes host-owned authorization decisions for a mounted

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -207,20 +207,27 @@ revalidation closes the stream before more protected data is written. Bounded
 requests may return a decision with no lease.
 
 Return a `TransactionFence` with every successful decision. Kata invokes it
-only when handling the operation begins a SQLite or PostgreSQL transaction,
-before the first domain write. This also covers read operations that perform
-transactional maintenance. SQL locks acquired by the callback are therefore
-held through the domain commit or rollback; the callback must not commit or
-roll back the supplied transaction itself. Returning `ErrAccessDenied` rolls
-the mutation back and produces the same generic not-found response as an
-initial authorization denial. Other failures roll back and make only the
-mounted service temporarily unavailable. A missing fence fails closed before
-writing.
+only when handling the operation begins a writable SQLite or PostgreSQL
+transaction, before the first domain write. This also covers read operations
+that perform transactional maintenance, while explicitly read-only snapshots
+remain outside the mutation fence. SQL locks acquired by the callback are
+therefore held through the domain commit or rollback; the callback must not
+commit or roll back the supplied transaction itself. Returning
+`ErrAccessDenied` rolls the mutation back and produces the same generic
+not-found response as an initial authorization denial. Other failures roll
+back and make only the mounted service temporarily unavailable. A missing
+fence fails closed before writing.
 
 Serializable transactions may retry, so a fence must be safe to invoke once
 per transaction attempt. The transaction exposes only `ExecContext` and
 `QueryRowContext`, which is enough to call a fixed host-owned validation
 function without exposing Kata's internal storage packages.
+
+When `Config.Access` is set, also configure `WorkerTransactionFence`. Kata
+applies it to every writable transaction started by the federation, GitHub
+sync, and timed-claim workers. A rejection rolls the transaction back, cancels
+all service workers, and is returned by `Run`; it cannot be reduced to a logged
+retry while stale authority remains active.
 
 The host-supplied actor always replaces an actor in request JSON. This keeps
 audit attribution tied to the authenticated principal rather than caller input.

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -206,6 +206,22 @@ Kata revalidates that lease before each event or heartbeat; a failed
 revalidation closes the stream before more protected data is written. Bounded
 requests may return a decision with no lease.
 
+Return a `TransactionFence` with every successful decision. Kata invokes it
+only when handling the operation begins a SQLite or PostgreSQL transaction,
+before the first domain write. This also covers read operations that perform
+transactional maintenance. SQL locks acquired by the callback are therefore
+held through the domain commit or rollback; the callback must not commit or
+roll back the supplied transaction itself. Returning `ErrAccessDenied` rolls
+the mutation back and produces the same generic not-found response as an
+initial authorization denial. Other failures roll back and make only the
+mounted service temporarily unavailable. A missing fence fails closed before
+writing.
+
+Serializable transactions may retry, so a fence must be safe to invoke once
+per transaction attempt. The transaction exposes only `ExecContext` and
+`QueryRowContext`, which is enough to call a fixed host-owned validation
+function without exposing Kata's internal storage packages.
+
 The host-supplied actor always replaces an actor in request JSON. This keeps
 audit attribution tied to the authenticated principal rather than caller input.
 `Auth.TrustCallerAuthentication` preserves the older all-or-nothing trusted

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -130,7 +130,15 @@ token over plaintext non-loopback HTTP.
 route matches and before protected data is returned or changed. The request
 contains the opaque authenticated subject, the actor snapshot used for new
 event and projection rows, and the matched operation ID, method, path template,
-and path parameters. `Operation.ProjectIDs`, `ProjectUIDs`, and `AllProjects`
+path parameters, and Kata's operation policy. The policy contains a stable
+domain kind, the required product-neutral `read`, `write`, `manage`, or
+`federate` capability, and explicit mutation and long-lived-response flags.
+Hosts map those capability classes to their own roles; they do not need to
+infer policy from operation names or HTTP verbs. Kata's registration test fails
+if a new route has no policy, and host-access mode fails closed if metadata is
+unavailable.
+
+`Operation.ProjectIDs`, `ProjectUIDs`, and `AllProjects`
 carry the validated effective project scope. Cross-project operations include
 both projects; omitting the project filter from the event stream sets
 `AllProjects` instead of silently broadening an empty scope. Body- and
@@ -210,6 +218,32 @@ principal, Kata validates the scoped credential in the route and does not call
 the host controller. The outer server must preserve the `Authorization` header
 on those routes. A request without either an in-process principal or a scoped
 bearer credential remains unauthenticated.
+
+## Restricted embedding profile
+
+Use `EmbeddingProfileRestricted` when the mounting application owns project
+lifecycle, API-token administration, federation setup, and external issue-sync
+configuration:
+
+```go
+service, err := kata.New(ctx, kata.Config{
+	DSN:     "/var/lib/example-app/kata.db",
+	Access:  applicationAccessController,
+	Profile: kata.EmbeddingProfileRestricted,
+})
+```
+
+Restricted mode returns a generic not-found response for native project
+mutations, token administration, federation administration, and issue-sync
+administration. Rejection happens before host authorization or request-body
+processing. Project and task reads, ordinary task changes, event streams, and
+Kata-authenticated federation transport remain available under their normal
+access checks. The zero-value profile preserves the full standalone-compatible
+HTTP API.
+
+Use the in-process project lifecycle methods below instead of enabling native
+project administration in restricted mode. Later profile revisions may add
+more host-owned application methods without changing standalone defaults.
 
 ## Host-managed projects
 

--- a/internal/daemon/claim_gate.go
+++ b/internal/daemon/claim_gate.go
@@ -24,7 +24,7 @@ func requireFederatedIssueClaim(
 		return nil
 	}
 	if err != nil {
-		return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	if !binding.Enabled {
 		return nil
@@ -77,7 +77,7 @@ func requireFederatedHubIssueClaim(
 		return nil
 	}
 	if err != nil {
-		return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	if !binding.Enabled || binding.Role != db.FederationRoleHub {
 		return nil
@@ -137,7 +137,7 @@ func isPendingSpokePushClaimStatusMiss(
 	}
 	pending, err := pendingPushMayMaterializeIssue(ctx, cfg.DB, binding, issue.UID)
 	if err != nil {
-		return false, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return false, internalAPIError(err)
 	}
 	return pending, nil
 }
@@ -213,6 +213,6 @@ func claimGateAPIError(err error) error {
 	case errors.Is(err, db.ErrNotFound):
 		return api.NewError(http.StatusNotFound, "issue_not_found", "issue not found", "", nil)
 	default:
-		return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 }

--- a/internal/daemon/federation_auth.go
+++ b/internal/daemon/federation_auth.go
@@ -42,7 +42,7 @@ func authorizeFederationRequest(
 			return federationPrincipal{}, api.NewError(http.StatusForbidden, "auth_invalid",
 				"federation token is invalid for this project or capability", "", nil)
 		}
-		return federationPrincipal{}, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return federationPrincipal{}, internalAPIError(err)
 	}
 	return federationPrincipal{
 		EnrollmentID:                 enrollment.ID,

--- a/internal/daemon/handlers_actions.go
+++ b/internal/daemon/handlers_actions.go
@@ -96,7 +96,7 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 							Parent: parentRef,
 							Cohort: cohort,
 						}); err != nil {
-						return nil, api.NewError(500, "internal", err.Error(), "", nil)
+						return nil, internalAPIError(err)
 					}
 				}
 				return nil, api.NewError(429, "sibling_throttle", refusal.Error(), "", nil)
@@ -111,7 +111,7 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 							Parent: parentRef,
 							Prior:  &priorRef,
 						}); err != nil {
-						return nil, api.NewError(500, "internal", err.Error(), "", nil)
+						return nil, internalAPIError(err)
 					}
 				}
 				return nil, api.NewError(429, "duplicate_message", refusal.Error(), "", nil)
@@ -159,7 +159,7 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if errors.Is(err, db.ErrFederatedReadOnly) {
 				return nil, federationReadOnlyError(err)
 			}
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if changed {
 			for i := range events {
@@ -208,7 +208,7 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if apiErr := federationReadOnlyError(err); apiErr != nil {
 				return nil, apiErr
 			}
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if changed && evt != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: in.ProjectID})

--- a/internal/daemon/handlers_audit.go
+++ b/internal/daemon/handlers_audit.go
@@ -66,7 +66,7 @@ func doAuditCloses(
 	}
 	events, err := cfg.DB.EventsInWindow(ctx, params)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	rows, err := buildAuditRows(ctx, cfg, in, events)
 	if err != nil {
@@ -342,7 +342,7 @@ func resolveAuditParentFilter(
 	if perr == nil && parsed.Project != "" {
 		project, projErr := cfg.DB.ProjectByID(ctx, projectID)
 		if projErr != nil {
-			return auditParentFilter{}, api.NewError(500, "internal", projErr.Error(), "", nil)
+			return auditParentFilter{}, internalAPIError(projErr)
 		}
 		if parsed.Project != project.Name {
 			// Clear every parsed identifier, not just parsedShortID, so a
@@ -422,7 +422,7 @@ func loadLegacyParentsForCloseEvents(
 	}
 	parents, err := cfg.DB.ParentShortIDsByIssues(ctx, ids)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	return parents, nil
 }
@@ -454,7 +454,7 @@ func resolveParentQualifiers(
 	}
 	out, err := cfg.DB.IssueQualifiersByUIDs(ctx, uids)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	return out, nil
 }

--- a/internal/daemon/handlers_author_rewrite.go
+++ b/internal/daemon/handlers_author_rewrite.go
@@ -42,7 +42,7 @@ func registerAuthorRewriteHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(http.StatusConflict, "project_federated", err.Error(), "", nil)
 		}
 		if err != nil {
-			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if result.Event != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: result.Event, ProjectID: in.ProjectID})

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -331,7 +331,7 @@ func claimBinding(ctx context.Context, store db.Storage, projectID int64) (db.Fe
 		return db.FederationBinding{}, api.NewError(http.StatusNotFound, "federation_not_found", "project is not federated", "", nil)
 	}
 	if err != nil {
-		return db.FederationBinding{}, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return db.FederationBinding{}, internalAPIError(err)
 	}
 	if !binding.Enabled {
 		return db.FederationBinding{}, api.NewError(http.StatusConflict, "federated_read_only", "federation binding is disabled", "", nil)
@@ -372,7 +372,7 @@ func claimForwardClient(
 	}
 	cred, _, err := cfg.federationCredentialStore().FederationCredential(ctx, project.UID)
 	if err != nil {
-		return nil, config.FederationCredential{}, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return nil, config.FederationCredential{}, internalAPIError(err)
 	}
 	if strings.TrimSpace(cred.Token) == "" {
 		return nil, config.FederationCredential{}, api.NewError(http.StatusServiceUnavailable, "federation_offline", "federation claim credentials are unavailable", "", nil)
@@ -692,7 +692,7 @@ func requireHubClaimBinding(ctx context.Context, store db.Storage, projectID int
 		return api.NewError(http.StatusNotFound, "federation_not_found", "project is not a federation hub", "", nil)
 	}
 	if err != nil {
-		return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	if !binding.Enabled || binding.Role != db.FederationRoleHub {
 		return api.NewError(http.StatusConflict, "federated_read_only", "claim actions must be resolved by the hub project", "", nil)
@@ -730,7 +730,7 @@ func claimAPIError(err error) error {
 	case errors.Is(err, db.ErrNotFound):
 		return api.NewError(http.StatusNotFound, "issue_not_found", "issue not found", "", nil)
 	default:
-		return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 }
 
@@ -775,7 +775,7 @@ func refreshShowClaimStatus(ctx context.Context, cfg ServerConfig, issue db.Issu
 		return nil, nil
 	}
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	if !binding.Enabled || binding.Role != db.FederationRoleSpoke {
 		if binding.Enabled && binding.Role == db.FederationRoleHub {
@@ -794,7 +794,7 @@ func refreshShowClaimStatus(ctx context.Context, cfg ServerConfig, issue db.Issu
 	}
 	now := time.Now().UTC()
 	if skip, err := skipRecentShowClaimStatusError(ctx, cfg.DB, issue, now); err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	} else if skip {
 		return nil, nil
 	}
@@ -871,15 +871,15 @@ func markShowClaimStatusRefreshFailure(
 	now time.Time,
 ) error {
 	if err := store.MarkClaimStatusRefreshError(ctx, issue.ProjectID, issue.UID, statusCode, msg, now); err != nil {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	pending, err := store.ListPendingClaimRequestsForIssue(ctx, issue.ProjectID, issue.UID, 0)
 	if err != nil {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	for _, req := range pending {
 		if err := store.MarkPendingClaimAttempt(ctx, req.RequestUID, msg, now); err != nil {
-			return api.NewError(500, "internal", err.Error(), "", nil)
+			return internalAPIError(err)
 		}
 	}
 	return nil
@@ -889,11 +889,11 @@ func hydrateClaimOutForIssue(ctx context.Context, cfg ServerConfig, issue db.Iss
 	now := time.Now().UTC()
 	status, err := cfg.DB.ClaimStatusReadOnly(ctx, issue.ProjectID, issue.UID, now)
 	if err != nil {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	pending, err := cfg.DB.ListPendingClaimRequestsForIssue(ctx, issue.ProjectID, issue.UID, 0)
 	if err != nil {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	out.Body.Claim = issueClaimOut(status.Claim)
 	out.Body.Lease = out.Body.Claim

--- a/internal/daemon/handlers_comments.go
+++ b/internal/daemon/handlers_comments.go
@@ -37,13 +37,13 @@ func registerCommentsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if apiErr := federationReadOnlyError(err); apiErr != nil {
 				return nil, apiErr
 			}
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &evt, ProjectID: in.ProjectID})
 		cfg.Hooks.Enqueue(evt)
 		updated, err := cfg.DB.IssueByID(ctx, issue.ID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.CommentResponse{}
 		out.Body.Issue = updated
@@ -85,7 +85,7 @@ func registerCommentsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if apiErr := federationReadOnlyError(err); apiErr != nil {
 				return nil, apiErr
 			}
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if changed && evt != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: in.ProjectID})
@@ -93,7 +93,7 @@ func registerCommentsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		updated, err := cfg.DB.IssueByID(ctx, issue.ID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.CommentResponse{}
 		out.Body.Issue = updated

--- a/internal/daemon/handlers_destructive.go
+++ b/internal/daemon/handlers_destructive.go
@@ -32,7 +32,7 @@ func registerDestructiveHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		project, perr := cfg.DB.ProjectByID(ctx, issue.ProjectID)
 		if perr != nil {
-			return nil, api.NewError(500, "internal", perr.Error(), "", nil)
+			return nil, internalAPIError(perr)
 		}
 		if err := validateConfirm(in.Confirm, "DELETE", project.Name, issue.ShortID); err != nil {
 			return nil, err
@@ -48,7 +48,7 @@ func registerDestructiveHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, federationReadOnlyError(err)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if changed && evt != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: in.ProjectID})
@@ -86,7 +86,7 @@ func registerDestructiveHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, federationReadOnlyError(err)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if changed && evt != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: in.ProjectID})
@@ -116,7 +116,7 @@ func registerDestructiveHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		project, perr := cfg.DB.ProjectByID(ctx, issue.ProjectID)
 		if perr != nil {
-			return nil, api.NewError(500, "internal", perr.Error(), "", nil)
+			return nil, internalAPIError(perr)
 		}
 		if err := validateConfirm(in.Confirm, "PURGE", project.Name, issue.ShortID); err != nil {
 			return nil, err
@@ -140,11 +140,11 @@ func registerDestructiveHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, federationReadOnlyError(err)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if pl.PurgeResetAfterEventID != nil {
 			if err := refreshFederationBaselineAfterPurge(ctx, cfg, in.ProjectID, actor); err != nil {
-				return nil, api.NewError(500, "internal", err.Error(), "", nil)
+				return nil, internalAPIError(err)
 			}
 			cfg.Broadcaster.Broadcast(StreamMsg{
 				Kind:      "reset",

--- a/internal/daemon/handlers_digest.go
+++ b/internal/daemon/handlers_digest.go
@@ -74,7 +74,7 @@ func doDigest(
 		Actors:    actors,
 	})
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 
 	out := &api.DigestResponse{}

--- a/internal/daemon/handlers_events.go
+++ b/internal/daemon/handlers_events.go
@@ -97,7 +97,7 @@ func doPollEvents(
 
 	resetTo, err := cfg.DB.PurgeResetCheck(ctx, afterID, projectID)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	if resetTo > 0 {
 		out := &api.PollEventsResponse{}
@@ -114,7 +114,7 @@ func doPollEvents(
 		Limit:     limit,
 	})
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 
 	out := &api.PollEventsResponse{}

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -99,7 +99,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(http.StatusNotFound, "federation_quarantine_not_found", "federation quarantine not found", "", nil)
 		}
 		if err != nil {
-			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		return &api.SkipFederationQuarantineResponse{Body: federationQuarantineSummary(q)}, nil
 	})
@@ -131,7 +131,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 				"federation quarantine retry only supports push quarantines", "", nil)
 		}
 		if err != nil {
-			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		return &api.RetryFederationQuarantineResponse{Body: federationQuarantineSummary(q)}, nil
 	})
@@ -192,7 +192,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			AllowAdoptionSnapshotAuthors: in.Body.AllowAdoptionSnapshotAuthors,
 		})
 		if err != nil {
-			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		return &api.CreateFederationEnrollmentResponse{
 			Body: federationEnrollmentToOut(created.Enrollment, created.Token),
@@ -206,7 +206,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 	}, func(ctx context.Context, _ *api.ListFederationEnrollmentsRequest) (*api.ListFederationEnrollmentsResponse, error) {
 		enrollments, err := cfg.DB.ListFederationEnrollments(ctx)
 		if err != nil {
-			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := make([]api.FederationEnrollmentOut, 0, len(enrollments))
 		for _, enrollment := range enrollments {
@@ -226,7 +226,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if errors.Is(err, db.ErrNotFound) {
 				return nil, api.NewError(http.StatusNotFound, "federation_enrollment_not_found", "federation enrollment not found", "", nil)
 			}
-			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		return &api.RevokeFederationEnrollmentResponse{
 			Body: api.RevokeFederationEnrollmentBody{ID: in.EnrollmentID, Revoked: true},
@@ -281,7 +281,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 				Actor:         strings.TrimSpace(in.Body.Actor),
 				AllowInsecure: in.Body.AllowInsecure,
 			}); err != nil {
-				return nil, api.NewError(500, "internal", err.Error(), "", nil)
+				return nil, internalAPIError(err)
 			}
 		}
 		if in.Body.PushEnabled && !binding.PushEnabled {
@@ -329,7 +329,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 				return nil, api.NewError(http.StatusConflict, "not_a_spoke", "federation binding is not a spoke", "", nil)
 			}
 		} else if !errors.Is(bErr, db.ErrNotFound) {
-			return nil, api.NewError(http.StatusInternalServerError, "internal", bErr.Error(), "", nil)
+			return nil, internalAPIError(bErr)
 		}
 
 		if in.Body.Preflight {
@@ -344,14 +344,14 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 			case errors.Is(err, db.ErrNotFound):
 				return nil, api.NewError(http.StatusNotFound, "project_not_found", "project not found", "", nil)
 			case err != nil:
-				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+				return nil, internalAPIError(err)
 			}
 			// Mirror RemoveProject's refusal for a live archive target; an
 			// already-archived project passes (the real call resumes).
 			if disposition == "archive" && project.DeletedAt == nil && !in.Body.Force {
 				openIssues, err := cfg.DB.CountOpenIssues(ctx, in.ProjectID)
 				if err != nil {
-					return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+					return nil, internalAPIError(err)
 				}
 				if openIssues > 0 {
 					return nil, api.NewError(http.StatusConflict, "project_has_open_issues", "project has open issues",
@@ -392,7 +392,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 				// the project fill below uses ProjectByID, which includes
 				// archived rows.
 			case err != nil:
-				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+				return nil, internalAPIError(err)
 			default:
 				cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: project.ID})
 				cfg.Hooks.Enqueue(*evt)
@@ -408,7 +408,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		case errors.Is(err, db.ErrFederationNotSpoke):
 			return nil, api.NewError(http.StatusConflict, "not_a_spoke", "federation binding is not a spoke", "", nil)
 		case err != nil:
-			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		// Zero role means there was no binding: this is the idempotent resume
 		// (only the credential delete below may still have work to do), so the
@@ -416,13 +416,13 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		body.Detached = res.Role == db.FederationRoleSpoke
 		if res.ProjectUID != "" {
 			if err := cfg.federationCredentialStore().DeleteFederationCredential(ctx, res.ProjectUID); err != nil {
-				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+				return nil, internalAPIError(err)
 			}
 		}
 		if !body.Archived {
 			project, err := cfg.DB.ProjectByID(ctx, in.ProjectID)
 			if err != nil {
-				return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+				return nil, internalAPIError(err)
 			}
 			body.Project = dbProjectToOut(project)
 		}
@@ -489,7 +489,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		inserted, err := cfg.DB.EventsByUIDs(ctx, in.ProjectID, result.InsertedEventUIDs)
 		if err != nil {
-			return nil, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		for _, evt := range inserted {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &evt, ProjectID: in.ProjectID})
@@ -570,7 +570,7 @@ func federationIngestError(err error) error {
 	case errors.Is(err, db.ErrNotFound):
 		return api.NewError(http.StatusNotFound, "federation_not_found", err.Error(), "", nil)
 	default:
-		return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 }
 
@@ -651,11 +651,11 @@ func adoptExistingReplica(
 					if errors.Is(err, db.ErrIssueSyncFederationBinding) {
 						return db.AdoptProjectIntoFederationResult{}, false, issueSyncFederationConflict()
 					}
-					return db.AdoptProjectIntoFederationResult{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+					return db.AdoptProjectIntoFederationResult{}, false, internalAPIError(err)
 				}
 				return result, true, nil
 			}
-			return db.AdoptProjectIntoFederationResult{}, false, api.NewError(500, "internal", bindErr.Error(), "", nil)
+			return db.AdoptProjectIntoFederationResult{}, false, internalAPIError(bindErr)
 		}
 		if details := replicaBindingConflictDetails(binding, in); len(details) > 0 {
 			return db.AdoptProjectIntoFederationResult{}, false,
@@ -669,7 +669,7 @@ func adoptExistingReplica(
 		}
 		return db.AdoptProjectIntoFederationResult{}, false, nil
 	} else if !errors.Is(err, db.ErrNotFound) {
-		return db.AdoptProjectIntoFederationResult{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.AdoptProjectIntoFederationResult{}, false, internalAPIError(err)
 	}
 	existing, err := store.ProjectByNameIncludingArchived(ctx, projectName)
 	if errors.Is(err, db.ErrNotFound) {
@@ -677,7 +677,7 @@ func adoptExistingReplica(
 			api.NewError(404, "federation_project_not_found", "adoption requested but no local project exists with this name", "", nil)
 	}
 	if err != nil {
-		return db.AdoptProjectIntoFederationResult{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.AdoptProjectIntoFederationResult{}, false, internalAPIError(err)
 	}
 	if existing.UID == in.Body.HubProjectUID {
 		return db.AdoptProjectIntoFederationResult{}, false,
@@ -692,7 +692,7 @@ func adoptExistingReplica(
 			api.NewError(409, "federation_binding_conflict",
 				fmt.Sprintf("project already has %q federation binding", binding.Role), "", nil)
 	} else if !errors.Is(err, db.ErrNotFound) {
-		return db.AdoptProjectIntoFederationResult{}, true, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.AdoptProjectIntoFederationResult{}, true, internalAPIError(err)
 	}
 	result, err := store.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
 		ProjectID:            existing.ID,
@@ -707,7 +707,7 @@ func adoptExistingReplica(
 		if errors.Is(err, db.ErrIssueSyncFederationBinding) {
 			return db.AdoptProjectIntoFederationResult{}, true, issueSyncFederationConflict()
 		}
-		return db.AdoptProjectIntoFederationResult{}, true, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.AdoptProjectIntoFederationResult{}, true, internalAPIError(err)
 	}
 	return result, true, nil
 }
@@ -729,15 +729,15 @@ func ensureReplicaBinding(
 				return db.Project{}, db.FederationBinding{}, api.NewError(409, "federation_project_collision", "a project with this name already has a different UID; rerun with --adopt-existing --push to adopt it into federation", "", nil)
 			}
 		} else if !errors.Is(lookupErr, db.ErrNotFound) {
-			return db.Project{}, db.FederationBinding{}, api.NewError(500, "internal", lookupErr.Error(), "", nil)
+			return db.Project{}, db.FederationBinding{}, internalAPIError(lookupErr)
 		}
 		project, err = store.CreateProjectWithUID(ctx, projectName, in.Body.HubProjectUID)
 		if err != nil {
-			return db.Project{}, db.FederationBinding{}, api.NewError(500, "internal", err.Error(), "", nil)
+			return db.Project{}, db.FederationBinding{}, internalAPIError(err)
 		}
 		createdProject = true
 	} else if err != nil {
-		return db.Project{}, db.FederationBinding{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Project{}, db.FederationBinding{}, internalAPIError(err)
 	} else if project.DeletedAt != nil {
 		return db.Project{}, db.FederationBinding{}, api.NewError(409, "federation_project_collision",
 			fmt.Sprintf("an archived local project %q already has the hub project UID; restore it with `kata projects restore` first", project.Name), "", nil)
@@ -761,7 +761,7 @@ func ensureReplicaBinding(
 		pushEnabled = existing.PushEnabled
 		pushCursor = existing.PushCursorEventID
 	} else if !errors.Is(err, db.ErrNotFound) {
-		return db.Project{}, db.FederationBinding{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Project{}, db.FederationBinding{}, internalAPIError(err)
 	} else if !createdProject {
 		// An unbound local project holding the hub project UID is the normal
 		// post-leave state: leave removes the binding but the project keeps the
@@ -805,7 +805,7 @@ func ensureReplicaBinding(
 		if errors.Is(err, db.ErrIssueSyncFederationBinding) {
 			return db.Project{}, db.FederationBinding{}, issueSyncFederationConflict()
 		}
-		return db.Project{}, db.FederationBinding{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Project{}, db.FederationBinding{}, internalAPIError(err)
 	}
 	return project, binding, nil
 }
@@ -813,11 +813,11 @@ func ensureReplicaBinding(
 func enableReplicaPush(ctx context.Context, store db.Storage, projectID int64) (db.FederationBinding, error) {
 	localCursor, err := maxLocalOriginEventID(ctx, store, projectID)
 	if err != nil {
-		return db.FederationBinding{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.FederationBinding{}, internalAPIError(err)
 	}
 	binding, err := store.EnableFederationPush(ctx, projectID, localCursor)
 	if err != nil {
-		return db.FederationBinding{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.FederationBinding{}, internalAPIError(err)
 	}
 	return binding, nil
 }
@@ -919,7 +919,7 @@ func federationStatusBindings(ctx context.Context, store db.Storage, projectID *
 	if projectID == nil {
 		bindings, err := store.ListFederationBindings(ctx)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		return bindings, nil
 	}
@@ -931,7 +931,7 @@ func federationStatusBindings(ctx context.Context, store db.Storage, projectID *
 		return []db.FederationBinding{}, nil
 	}
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	return []db.FederationBinding{binding}, nil
 }
@@ -952,7 +952,7 @@ func federationProjectStatus(
 		if errors.Is(err, db.ErrNotFound) {
 			return api.FederationProjectStatus{}, api.NewError(http.StatusNotFound, "project_not_found", "project not found", "", nil)
 		} else if err != nil {
-			return api.FederationProjectStatus{}, api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+			return api.FederationProjectStatus{}, internalAPIError(err)
 		}
 	} else if err != nil {
 		return api.FederationProjectStatus{}, err
@@ -961,31 +961,31 @@ func federationProjectStatus(
 	if errors.Is(err, db.ErrNotFound) {
 		syncStatus = db.FederationSyncStatus{}
 	} else if err != nil {
-		return api.FederationProjectStatus{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return api.FederationProjectStatus{}, internalAPIError(err)
 	}
 	pendingPush, pendingHighWater, err := federationPendingPushStats(ctx, store, binding)
 	if err != nil {
-		return api.FederationProjectStatus{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return api.FederationProjectStatus{}, internalAPIError(err)
 	}
 	enrollments, err := federationEnrollmentCount(ctx, store, binding)
 	if err != nil {
-		return api.FederationProjectStatus{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return api.FederationProjectStatus{}, internalAPIError(err)
 	}
 	liveClaims, err := federationLiveClaimCount(ctx, store, binding.ProjectID)
 	if err != nil {
-		return api.FederationProjectStatus{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return api.FederationProjectStatus{}, internalAPIError(err)
 	}
 	pendingClaims, err := federationPendingClaimCount(ctx, store, binding.ProjectID)
 	if err != nil {
-		return api.FederationProjectStatus{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return api.FederationProjectStatus{}, internalAPIError(err)
 	}
 	activeQuarantines, err := store.ActiveFederationQuarantinesByProject(ctx, binding.ProjectID)
 	if err != nil {
-		return api.FederationProjectStatus{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return api.FederationProjectStatus{}, internalAPIError(err)
 	}
 	recentViolations, unresolvedViolationCount, err := store.UnresolvedClaimViolationsForProject(ctx, binding.ProjectID, 5)
 	if err != nil {
-		return api.FederationProjectStatus{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return api.FederationProjectStatus{}, internalAPIError(err)
 	}
 	var credentialMetadata config.FederationCredentialMetadata
 	if binding.Role == db.FederationRoleSpoke {
@@ -1138,19 +1138,19 @@ func projectFederationBody(ctx context.Context, store db.Storage, projectID int6
 	if binding.Role == db.FederationRoleHub && binding.Enabled {
 		resetTo, err := store.PurgeResetCheck(ctx, binding.ReplayHorizonEventID, projectID)
 		if err != nil {
-			return api.ProjectFederationBody{}, api.NewError(500, "internal", err.Error(), "", nil)
+			return api.ProjectFederationBody{}, internalAPIError(err)
 		}
 		if resetTo > 0 {
 			binding, _, err = store.RefreshProjectFederationBaseline(ctx, projectID, "federation")
 			if err != nil {
-				return api.ProjectFederationBody{}, api.NewError(500, "internal", err.Error(), "", nil)
+				return api.ProjectFederationBody{}, internalAPIError(err)
 			}
 		}
 	}
 	through := binding.ReplayHorizonEventID
 	maxSnapshot, err := store.MaxFederationBaselineEventID(ctx, projectID, binding.ReplayHorizonEventID)
 	if err != nil {
-		return api.ProjectFederationBody{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return api.ProjectFederationBody{}, internalAPIError(err)
 	}
 	if maxSnapshot > 0 {
 		through = maxSnapshot
@@ -1171,7 +1171,7 @@ func federationError(err error) error {
 	if errors.Is(err, db.ErrIssueSyncFederationBinding) {
 		return issueSyncFederationConflict()
 	}
-	return api.NewError(500, "internal", err.Error(), "", nil)
+	return internalAPIError(err)
 }
 
 // issueSyncFederationConflict reports a 409 for the lifecycle rule that an

--- a/internal/daemon/handlers_github_sync.go
+++ b/internal/daemon/handlers_github_sync.go
@@ -359,7 +359,7 @@ func issueSyncStorageError(err error) error {
 	if errors.Is(err, db.ErrIssueSyncProjectAlreadyBound) || errors.Is(err, db.ErrImportValidation) {
 		return api.NewError(http.StatusBadRequest, "validation", err.Error(), "", nil)
 	}
-	return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+	return internalAPIError(err)
 }
 
 func issueSyncRunError(err error) error {
@@ -372,7 +372,7 @@ func issueSyncRunError(err error) error {
 	if errors.Is(err, db.ErrImportValidation) {
 		return api.NewError(http.StatusBadRequest, "validation", err.Error(), "", nil)
 	}
-	return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
+	return internalAPIError(err)
 }
 
 func issueSyncBody(binding *db.IssueSyncBinding, status db.IssueSyncStatus) (api.IssueSyncBody, error) {

--- a/internal/daemon/handlers_health.go
+++ b/internal/daemon/handlers_health.go
@@ -36,7 +36,7 @@ func registerHealthHandlers(humaAPI huma.API, cfg ServerConfig) {
 	}, func(ctx context.Context, _ *struct{}) (*api.HealthResponse, error) {
 		schema, err := cfg.DB.SchemaVersion(ctx)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.HealthResponse{}
 		out.Body.OK = true

--- a/internal/daemon/handlers_imports.go
+++ b/internal/daemon/handlers_imports.go
@@ -82,7 +82,7 @@ func registerImportsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		case errors.Is(err, db.ErrNotFound):
 			return nil, api.NewError(404, "issue_not_found", err.Error(), "", nil)
 		case err != nil:
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 
 		for i := range events {
@@ -110,7 +110,7 @@ func requireFederatedImportClaims(
 		return nil
 	}
 	if err != nil {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	if !binding.Enabled {
 		return nil
@@ -166,7 +166,7 @@ func importItemFederatedClaimState(
 		return importClaimItemState{}, nil
 	}
 	if err != nil {
-		return importClaimItemState{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return importClaimItemState{}, internalAPIError(err)
 	}
 	if mapping.IssueID == nil {
 		return importClaimItemState{}, api.NewError(404, "issue_not_found", "import issue mapping is missing issue id", "", nil)
@@ -176,7 +176,7 @@ func importItemFederatedClaimState(
 		return importClaimItemState{}, api.NewError(404, "issue_not_found", err.Error(), "", nil)
 	}
 	if err != nil {
-		return importClaimItemState{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return importClaimItemState{}, internalAPIError(err)
 	}
 	if issue.DeletedAt != nil {
 		return importClaimItemState{}, api.NewError(404, "issue_not_found", "mapped import issue is deleted", "", nil)
@@ -237,7 +237,7 @@ func importItemLinkAddClaimPeers(
 			if _, err := store.LinkByEndpoints(ctx, fromID, toID, importLink.Type); err == nil {
 				continue
 			} else if !errors.Is(err, db.ErrNotFound) {
-				return nil, api.NewError(500, "internal", err.Error(), "", nil)
+				return nil, internalAPIError(err)
 			}
 		}
 		out = append(out, target)
@@ -262,7 +262,7 @@ func importItemLinkRemovalClaimPeers(
 	}
 	mappings, err := store.ImportMappingsByProjectSource(ctx, projectID, source)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	var out []db.Issue
 	for _, mapping := range mappings {
@@ -280,7 +280,7 @@ func importItemLinkRemovalClaimPeers(
 			continue
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		peerID := link.ToIssueID
 		if peerID == state.issue.ID {
@@ -288,7 +288,7 @@ func importItemLinkRemovalClaimPeers(
 		}
 		peer, err := store.IssueByID(ctx, peerID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out = append(out, peer)
 	}
@@ -311,7 +311,7 @@ func importLinkClaimTarget(
 		return db.Issue{}, false, api.NewError(404, "issue_not_found", fmt.Sprintf("import link target %q not found", externalID), "", nil)
 	}
 	if err != nil {
-		return db.Issue{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Issue{}, false, internalAPIError(err)
 	}
 	if mapping.IssueID == nil {
 		return db.Issue{}, false, api.NewError(404, "issue_not_found", fmt.Sprintf("import link target %q is missing issue id", externalID), "", nil)
@@ -321,7 +321,7 @@ func importLinkClaimTarget(
 		return db.Issue{}, false, api.NewError(404, "issue_not_found", fmt.Sprintf("import link target %q not found", externalID), "", nil)
 	}
 	if err != nil {
-		return db.Issue{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Issue{}, false, internalAPIError(err)
 	}
 	if issue.DeletedAt != nil {
 		return db.Issue{}, false, api.NewError(404, "issue_not_found", fmt.Sprintf("import link target %q is deleted", externalID), "", nil)

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -117,7 +117,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		// daemon processes can serve the same schema.
 		releaseIdempotency, err := cfg.DB.AcquireIdempotencyLock(ctx, in.ProjectID, in.IdempotencyKey)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		defer func() { _ = releaseIdempotency() }()
 
@@ -191,7 +191,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		case errors.Is(err, db.ErrNotFound):
 			return nil, api.NewError(404, "project_not_found", "project not found", "", nil)
 		case err != nil:
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &evt, ProjectID: in.ProjectID})
 		cfg.Hooks.Enqueue(evt)
@@ -240,7 +240,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 			Meta:          metaFilters,
 		})
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		issueOuts, err := hydrateIssueOuts(ctx, cfg.DB, in.ProjectID, issues)
 		out := &api.ListIssuesResponse{}
@@ -297,7 +297,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 			Limit:       in.Limit,
 		})
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		issueOuts, err := hydrateIssueOutsCrossProject(ctx, cfg.DB, issues)
 		if err != nil {
@@ -557,7 +557,7 @@ func mapAtomicEditError(err error, issueShortID string, delta *api.LinksDelta) e
 	case errors.Is(err, db.ErrFederatedReadOnly):
 		return federationReadOnlyError(err)
 	default:
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 }
 
@@ -648,7 +648,7 @@ func requireFederatedLinksDeltaClaims(
 			}
 		case errors.Is(err, db.ErrNotFound):
 		default:
-			return api.NewError(500, "internal", err.Error(), "", nil)
+			return internalAPIError(err)
 		}
 	}
 	if p.RemoveParent != nil {
@@ -668,7 +668,7 @@ func requireFederatedLinksDeltaClaims(
 	for id := range ids {
 		issue, err := cfg.DB.IssueByID(ctx, id)
 		if err != nil {
-			return api.NewError(500, "internal", err.Error(), "", nil)
+			return internalAPIError(err)
 		}
 		issues = append(issues, issue)
 	}
@@ -744,7 +744,7 @@ func resolveIssueByUIDOrPrefix(ctx context.Context, store db.Storage, ref string
 				fmt.Sprintf("no issue matches uid %s", normalized), "", nil)
 		}
 		if err != nil {
-			return db.Issue{}, api.NewError(500, "internal", err.Error(), "", nil)
+			return db.Issue{}, internalAPIError(err)
 		}
 		return issue, nil
 	}
@@ -760,7 +760,7 @@ func resolveIssueByUIDOrPrefix(ctx context.Context, store db.Storage, ref string
 	}
 	matches, err := store.IssueUIDPrefixMatch(ctx, normalized, 20, include)
 	if err != nil {
-		return db.Issue{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Issue{}, internalAPIError(err)
 	}
 	switch len(matches) {
 	case 0:
@@ -789,7 +789,7 @@ func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issu
 	}
 	comments, err := listComments(ctx, cfg.DB, issue.ID)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	links, err := loadLinkOuts(ctx, cfg.DB, issue.ID)
 	if err != nil {
@@ -797,7 +797,7 @@ func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issu
 	}
 	labels, err := cfg.DB.LabelsByIssue(ctx, issue.ID)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	parent, err := loadParentRef(ctx, cfg.DB, issue)
 	if err != nil {
@@ -805,7 +805,7 @@ func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issu
 	}
 	children, err := cfg.DB.ChildrenOfIssue(ctx, issue.ID)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	// ChildrenOfIssue returns children from any project (links span projects,
 	// storage v16), so hydrate each child against its OWN project rather than
@@ -824,7 +824,7 @@ func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issu
 	out.Body.Children = childOuts
 	claimRelevant, err := showIssueClaimRelevant(ctx, cfg.DB, issue.ProjectID)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	if !claimRelevant {
 		return out, nil
@@ -840,7 +840,7 @@ func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issu
 		return nil, err
 	}
 	if err := hydrateClaimViolationsForIssue(ctx, cfg.DB, issue, out); err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	if err := hydrateClaimOutForIssue(ctx, cfg, issue, out); err != nil {
 		return nil, err
@@ -1242,7 +1242,7 @@ func tryIdempotencyMatch(ctx context.Context, cfg ServerConfig, in *api.CreateIs
 	since := time.Now().Add(-idempotencyWindow)
 	match, err := cfg.DB.LookupIdempotency(ctx, in.ProjectID, in.IdempotencyKey, since)
 	if err != nil {
-		return "", nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return "", nil, internalAPIError(err)
 	}
 	if match == nil {
 		return fp, nil, nil
@@ -1252,11 +1252,11 @@ func tryIdempotencyMatch(ctx context.Context, cfg ServerConfig, in *api.CreateIs
 		// short_id + qualified_id rather than the dropped numeric ref.
 		prior, err := cfg.DB.IssueByID(ctx, match.IssueID)
 		if err != nil {
-			return "", nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return "", nil, internalAPIError(err)
 		}
 		priorProject, err := cfg.DB.ProjectByID(ctx, prior.ProjectID)
 		if err != nil {
-			return "", nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return "", nil, internalAPIError(err)
 		}
 		return "", nil, api.NewError(409, "idempotency_mismatch",
 			"idempotency key matched a prior issue with a different fingerprint",
@@ -1269,12 +1269,12 @@ func tryIdempotencyMatch(ctx context.Context, cfg ServerConfig, in *api.CreateIs
 	}
 	existing, err := cfg.DB.IssueByID(ctx, match.IssueID)
 	if err != nil {
-		return "", nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return "", nil, internalAPIError(err)
 	}
 	if existing.DeletedAt != nil {
 		existingProject, err := cfg.DB.ProjectByID(ctx, existing.ProjectID)
 		if err != nil {
-			return "", nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return "", nil, internalAPIError(err)
 		}
 		return "", nil, api.NewError(409, "idempotency_deleted",
 			"idempotency key matched a soft-deleted issue",
@@ -1307,7 +1307,7 @@ func runLookalikeCheck(ctx context.Context, cfg ServerConfig, in *api.CreateIssu
 	q := strings.TrimSpace(in.Body.Title + " " + in.Body.Body)
 	candidates, err := cfg.DB.SearchFTSAny(ctx, in.ProjectID, q, 20, false)
 	if err != nil {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	matched := []map[string]any{}
 	for _, c := range candidates {

--- a/internal/daemon/handlers_labels.go
+++ b/internal/daemon/handlers_labels.go
@@ -59,7 +59,7 @@ func addLabelHandler(cfg ServerConfig) func(context.Context, *api.AddLabelReques
 			// No-op: re-fetch existing row to populate the response.
 			existing, lerr := cfg.DB.LabelByEndpoints(ctx, issue.ID, in.Body.Label)
 			if lerr != nil {
-				return nil, api.NewError(500, "internal", lerr.Error(), "", nil)
+				return nil, internalAPIError(lerr)
 			}
 			out := &api.AddLabelResponse{}
 			out.Body.Issue = issue
@@ -73,14 +73,14 @@ func addLabelHandler(cfg ServerConfig) func(context.Context, *api.AddLabelReques
 		case errors.Is(err, db.ErrFederatedReadOnly):
 			return nil, federationReadOnlyError(err)
 		case err != nil:
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 
 		cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &evt, ProjectID: in.ProjectID})
 		cfg.Hooks.Enqueue(evt)
 		updatedIssue, err := cfg.DB.IssueByID(ctx, issue.ID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.AddLabelResponse{}
 		out.Body.Issue = updatedIssue
@@ -123,14 +123,14 @@ func removeLabelHandler(cfg ServerConfig) func(context.Context, *api.RemoveLabel
 			return nil, federationReadOnlyError(err)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 
 		cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &evt, ProjectID: in.ProjectID})
 		cfg.Hooks.Enqueue(evt)
 		updatedIssue, err := cfg.DB.IssueByID(ctx, issue.ID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.MutationResponse{}
 		out.Body.Issue = updatedIssue
@@ -147,7 +147,7 @@ func listLabelsHandler(cfg ServerConfig) func(context.Context, *api.LabelsListRe
 		}
 		counts, err := cfg.DB.LabelCounts(ctx, in.ProjectID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.LabelsListResponse{}
 		out.Body.Labels = counts

--- a/internal/daemon/handlers_links.go
+++ b/internal/daemon/handlers_links.go
@@ -128,7 +128,7 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 		if existing, lookupErr := cfg.DB.LinkByEndpoints(ctx, storageFromID, storageToID, in.Body.Type); lookupErr == nil {
 			return mutationLinkResponse(from, existing, canonicalFromPeer, canonicalToPeer, nil, false), nil
 		} else if !errors.Is(lookupErr, db.ErrNotFound) {
-			return nil, api.NewError(500, "internal", lookupErr.Error(), "", nil)
+			return nil, internalAPIError(lookupErr)
 		}
 		if err := requireFederatedIssueClaim(ctx, cfg, to.ProjectID, to, actor); err != nil {
 			return nil, err
@@ -146,7 +146,7 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 			// race backstop; this closes the practical gap.
 			cycle, cerr := parentReplaceWouldCycle(ctx, cfg.DB, from.ID, to.ID)
 			if cerr != nil {
-				return nil, api.NewError(500, "internal", cerr.Error(), "", nil)
+				return nil, internalAPIError(cerr)
 			}
 			if cycle {
 				// Byte-identical to the insert path's db.ErrParentCycle mapping.
@@ -163,7 +163,7 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 				// payload records the parent we're actually removing.
 				oldParentIssue, err := cfg.DB.IssueByID(ctx, existing.ToIssueID)
 				if err != nil {
-					return nil, api.NewError(500, "internal", err.Error(), "", nil)
+					return nil, internalAPIError(err)
 				}
 				if err := requireFederatedLinkClaims(ctx, cfg, actor, oldParentIssue); err != nil {
 					return nil, err
@@ -182,12 +182,12 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 					if apiErr := federationReadOnlyError(err); apiErr != nil {
 						return nil, apiErr
 					}
-					return nil, api.NewError(500, "internal", err.Error(), "", nil)
+					return nil, internalAPIError(err)
 				}
 				cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &unlinkEvt, ProjectID: in.ProjectID})
 				cfg.Hooks.Enqueue(unlinkEvt)
 			} else if !errors.Is(perr, db.ErrNotFound) {
-				return nil, api.NewError(500, "internal", perr.Error(), "", nil)
+				return nil, internalAPIError(perr)
 			}
 		}
 
@@ -213,7 +213,7 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 			// Duplicate (from, to, type) → no-op. Re-fetch and return existing.
 			existing, lookupErr := cfg.DB.LinkByEndpoints(ctx, storageFromID, storageToID, in.Body.Type)
 			if lookupErr != nil {
-				return nil, api.NewError(500, "internal", lookupErr.Error(), "", nil)
+				return nil, internalAPIError(lookupErr)
 			}
 			return mutationLinkResponse(from, existing, canonicalFromPeer, canonicalToPeer, nil, false), nil
 		case errors.Is(err, db.ErrParentAlreadySet):
@@ -231,12 +231,12 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 		case errors.Is(err, db.ErrFederatedReadOnly):
 			return nil, federationReadOnlyError(err)
 		case err != nil:
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 
 		updatedIssue, err := cfg.DB.IssueByID(ctx, from.ID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &evt, ProjectID: in.ProjectID})
 		cfg.Hooks.Enqueue(evt)
@@ -294,7 +294,7 @@ func deleteLinkHandler(cfg ServerConfig) func(context.Context, *api.DeleteLinkRe
 			return out, nil
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		// The URL says we're operating on issue {ref}'s links. Reject if
 		// the link's two endpoints don't include this issue — defends against
@@ -317,11 +317,11 @@ func deleteLinkHandler(cfg ServerConfig) func(context.Context, *api.DeleteLinkRe
 		// the stored row holds.
 		linkFrom, err := cfg.DB.IssueByID(ctx, link.FromIssueID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		linkTo, err := cfg.DB.IssueByID(ctx, link.ToIssueID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if link.FromIssueID != from.ID {
 			linkFrom, linkTo = linkTo, linkFrom
@@ -351,11 +351,11 @@ func deleteLinkHandler(cfg ServerConfig) func(context.Context, *api.DeleteLinkRe
 			return nil, federationReadOnlyError(err)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		updatedIssue, err := cfg.DB.IssueByID(ctx, from.ID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &evt, ProjectID: in.ProjectID})
 		cfg.Hooks.Enqueue(evt)

--- a/internal/daemon/handlers_metadata.go
+++ b/internal/daemon/handlers_metadata.go
@@ -79,7 +79,7 @@ func patchIssueMetadataHandler(cfg ServerConfig) func(context.Context, *api.Patc
 			return nil, federationReadOnlyError(err)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 
 		out := &api.PatchIssueMetadataResponse{}
@@ -131,7 +131,7 @@ func patchProjectMetadataHandler(cfg ServerConfig) func(context.Context, *api.Pa
 			return nil, federationReadOnlyError(err)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.PatchProjectMetadataResponse{}
 		out.ETag = fmt.Sprintf(`"rev-%d"`, res.NewRevision)

--- a/internal/daemon/handlers_move.go
+++ b/internal/daemon/handlers_move.go
@@ -29,7 +29,7 @@ func activeProjectByUID(ctx context.Context, store db.Storage, uid string) (db.P
 		if errors.Is(err, db.ErrNotFound) {
 			return db.Project{}, api.NewError(404, "project_not_found", "project not found", "", nil)
 		}
-		return db.Project{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Project{}, internalAPIError(err)
 	}
 	if p.DeletedAt != nil {
 		return db.Project{}, api.NewError(404, "project_not_found", "project not found", "", nil)
@@ -89,7 +89,7 @@ func moveIssueHandler(cfg ServerConfig) func(context.Context, *api.MoveIssueRequ
 			return nil, apiErr
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 
 		out := &api.MoveIssueResponse{}

--- a/internal/daemon/handlers_ownership.go
+++ b/internal/daemon/handlers_ownership.go
@@ -38,7 +38,7 @@ func registerOwnershipHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if apiErr := federationReadOnlyError(err); apiErr != nil {
 				return nil, apiErr
 			}
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if changed && evt != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: in.ProjectID})
@@ -72,7 +72,7 @@ func registerOwnershipHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if apiErr := federationReadOnlyError(err); apiErr != nil {
 				return nil, apiErr
 			}
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if changed && evt != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: in.ProjectID})
@@ -119,7 +119,7 @@ func registerOwnershipHandlers(humaAPI huma.API, cfg ServerConfig) {
 				map[string]any{"current_owner": currentOwner})
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 
 		if result.Changed && result.Event != nil {

--- a/internal/daemon/handlers_priority.go
+++ b/internal/daemon/handlers_priority.go
@@ -35,7 +35,7 @@ func registerPriorityHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if apiErr := federationReadOnlyError(err); apiErr != nil {
 				return nil, apiErr
 			}
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if changed && evt != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: in.ProjectID})

--- a/internal/daemon/handlers_projects.go
+++ b/internal/daemon/handlers_projects.go
@@ -26,7 +26,7 @@ func activeProjectByID(ctx context.Context, store db.Storage, id int64) (db.Proj
 		if errors.Is(err, db.ErrNotFound) {
 			return db.Project{}, api.NewError(404, "project_not_found", "project not found", "", nil)
 		}
-		return db.Project{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Project{}, internalAPIError(err)
 	}
 	if p.DeletedAt != nil {
 		return db.Project{}, api.NewError(404, "project_not_found", "project not found", "", nil)
@@ -119,7 +119,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			ps, err = cfg.DB.ListProjects(ctx)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		outs := make([]api.ProjectOut, len(ps))
 		for i, p := range ps {
@@ -128,7 +128,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if includeContains(in.Include, "stats") {
 			stats, err := cfg.DB.BatchProjectStats(ctx)
 			if err != nil {
-				return nil, api.NewError(500, "internal", err.Error(), "", nil)
+				return nil, internalAPIError(err)
 			}
 			for i, p := range ps {
 				if s, ok := stats[p.ID]; ok {
@@ -161,7 +161,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		aliases, err := cfg.DB.ProjectAliases(ctx, p.ID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.ShowProjectResponse{}
 		out.Body.Project = dbProjectToOut(p)
@@ -226,7 +226,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(404, "project_not_found", "project not found", "", nil)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		extensions := make([]api.MergeShortIDExtension, 0, len(merged.ShortIDExtensions))
 		for _, ext := range merged.ShortIDExtensions {
@@ -274,7 +274,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 				map[string]any{"open_issues": openErr.OpenIssues})
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: project.ID})
 		cfg.Hooks.Enqueue(*evt)
@@ -300,7 +300,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(404, "project_not_found", "project not found", "", nil)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if err := validateExactConfirm(in.Confirm, "PURGE "+project.Name); err != nil {
 			return nil, err
@@ -331,7 +331,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 				fedErr.Error(), hint, map[string]any{"role": string(fedErr.Role)})
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if pl.PurgeResetAfterEventID != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{
@@ -359,7 +359,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(404, "project_not_found", "project not found", "", nil)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if changed && evt != nil {
 			cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: project.ID})
@@ -397,7 +397,7 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 				"detach with force=true to drop it anyway, or attach a replacement first", nil)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: evt, ProjectID: alias.ProjectID})
 		cfg.Hooks.Enqueue(*evt)
@@ -427,11 +427,11 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(404, "project_not_found", "project not found", "", nil)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		aliases, err := cfg.DB.ProjectAliases(ctx, p.ID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.ShowProjectResponse{}
 		out.Body.Project = dbProjectToOut(p)
@@ -506,7 +506,7 @@ func resolveByAliasInput(ctx context.Context, store db.Storage, in *api.AliasInp
 	case err == nil:
 		project, err := store.ProjectByID(ctx, alias.ProjectID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if project.DeletedAt != nil {
 			return nil, api.NewError(404, "project_not_initialized",
@@ -518,7 +518,7 @@ func resolveByAliasInput(ctx context.Context, store db.Storage, in *api.AliasInp
 			Alias:   alias,
 		}, nil
 	case !errors.Is(err, db.ErrNotFound):
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 
 	// Alias unknown. Fall back to name lookup if supplied so a fresh
@@ -540,7 +540,7 @@ func resolveByAliasInput(ctx context.Context, store db.Storage, in *api.AliasInp
 			`run "kata init" in this workspace`, nil)
 	}
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	// First-seen attach: bind the supplied alias to the matched project
 	// so subsequent resolves hit the alias path. Reassign=false matches
@@ -571,7 +571,7 @@ func resolveByName(ctx context.Context, store db.Storage, name string) (*api.Pro
 			`run "kata init" in this workspace`, nil)
 	}
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	return &api.ProjectResolveBody{Project: dbProjectToOut(project)}, nil
 }
@@ -598,7 +598,7 @@ func resolveByKataToml(ctx context.Context, store db.Storage, disc config.Discov
 		}
 		if cfgFile.Project.Name != "" && body.Project.Name != cfgFile.Project.Name {
 			if err := config.WriteProjectConfig(disc.WorkspaceRoot, body.Project.Name); err != nil {
-				return nil, false, api.NewError(500, "internal", err.Error(), "", nil)
+				return nil, false, internalAPIError(err)
 			}
 		}
 		return body, true, nil
@@ -610,7 +610,7 @@ func resolveByKataToml(ctx context.Context, store db.Storage, disc config.Discov
 			`run "kata init" in this workspace`, nil)
 	}
 	if err != nil {
-		return nil, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, false, internalAPIError(err)
 	}
 	alias, err := upsertAliasFor(ctx, store, project.ID, disc, false)
 	if err != nil {
@@ -636,11 +636,11 @@ func resolveByAliasIfAvailable(ctx context.Context, store db.Storage, disc confi
 		return nil, false, nil
 	}
 	if err != nil {
-		return nil, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, false, internalAPIError(err)
 	}
 	project, err := store.ProjectByID(ctx, alias.ProjectID)
 	if err != nil {
-		return nil, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, false, internalAPIError(err)
 	}
 	return &api.ProjectResolveBody{
 		Project:       dbProjectToOut(project),
@@ -663,11 +663,11 @@ func resolveByAlias(ctx context.Context, store db.Storage, disc config.Discovere
 			`run "kata init" in this workspace`, nil)
 	}
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	project, err := store.ProjectByID(ctx, alias.ProjectID)
 	if err != nil {
-		return nil, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, internalAPIError(err)
 	}
 	return &api.ProjectResolveBody{
 		Project:       dbProjectToOut(project),
@@ -730,7 +730,7 @@ func initProject(ctx context.Context, store db.Storage, req *api.InitProjectRequ
 			}
 		}
 	} else if !errors.Is(err, db.ErrNotFound) {
-		return nil, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return nil, false, internalAPIError(err)
 	}
 	// Preflight alias conflict before mutating anything: without this, a fresh
 	// project row would be created and then orphaned when alias attach fails.
@@ -759,7 +759,7 @@ func initProject(ctx context.Context, store db.Storage, req *api.InitProjectRequ
 	dest := config.WriteDestination(disc, abs)
 	if tomlCfg == nil || tomlCfg.Project.Name != project.Name {
 		if err := config.WriteProjectConfig(dest, project.Name); err != nil {
-			return nil, false, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, false, internalAPIError(err)
 		}
 	}
 
@@ -867,7 +867,7 @@ func upsertProject(ctx context.Context, store db.Storage, name string) (db.Proje
 		return got, false, nil
 	}
 	if !errors.Is(err, db.ErrNotFound) {
-		return db.Project{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Project{}, false, internalAPIError(err)
 	}
 	if archived, archErr := store.ProjectByNameIncludingArchived(ctx, name); archErr == nil && archived.DeletedAt != nil {
 		return db.Project{}, false, api.NewError(409, "project_archived",
@@ -877,7 +877,7 @@ func upsertProject(ctx context.Context, store db.Storage, name string) (db.Proje
 	}
 	created, err := store.CreateProject(ctx, name)
 	if err != nil {
-		return db.Project{}, false, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Project{}, false, internalAPIError(err)
 	}
 	return created, true, nil
 }
@@ -903,7 +903,7 @@ func attachAlias(ctx context.Context, store db.Storage, projectID int64, info co
 		return applyExistingAlias(ctx, store, projectID, info, existing, reassign)
 	}
 	if !errors.Is(err, db.ErrNotFound) {
-		return db.ProjectAlias{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.ProjectAlias{}, internalAPIError(err)
 	}
 	a, err := store.AttachAlias(ctx, projectID, info.Identity, info.Kind)
 	if err != nil {
@@ -919,7 +919,7 @@ func attachAlias(ctx context.Context, store db.Storage, projectID int64, info co
 			}
 			return applyExistingAlias(ctx, store, projectID, info, raced, reassign)
 		}
-		return db.ProjectAlias{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.ProjectAlias{}, internalAPIError(err)
 	}
 	return a, nil
 }
@@ -941,7 +941,7 @@ func applyExistingAlias(ctx context.Context, store db.Storage, projectID int64, 
 			})
 	}
 	if execErr := store.ReassignAlias(ctx, existing.ID, projectID); execErr != nil {
-		return db.ProjectAlias{}, api.NewError(500, "internal", execErr.Error(), "", nil)
+		return db.ProjectAlias{}, internalAPIError(execErr)
 	}
 	refreshed, _ := store.AliasByIdentity(ctx, info.Identity)
 	return refreshed, nil
@@ -960,11 +960,11 @@ func preflightAliasConflict(ctx context.Context, store db.Storage, info config.A
 		return nil
 	}
 	if err != nil {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	existingProject, err := store.ProjectByID(ctx, existing.ProjectID)
 	if err != nil {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	if existingProject.Name == targetName {
 		return nil
@@ -974,7 +974,7 @@ func preflightAliasConflict(ctx context.Context, store db.Storage, info config.A
 		return nil
 	}
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	return api.NewError(http.StatusConflict, "project_alias_conflict",
 		"alias already attached to a different project",

--- a/internal/daemon/handlers_ready.go
+++ b/internal/daemon/handlers_ready.go
@@ -31,7 +31,7 @@ func registerReadyHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		issues, err := cfg.DB.ReadyIssues(ctx, in.ProjectID, in.Limit, filter)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		issueOuts, err := hydrateIssueOuts(ctx, cfg.DB, in.ProjectID, issues)
 		if err != nil {
@@ -49,7 +49,7 @@ func registerReadyHandlers(humaAPI huma.API, cfg ServerConfig) {
 	}, func(ctx context.Context, in *api.ReadyGlobalRequest) (*api.ReadyGlobalResponse, error) {
 		issues, err := cfg.DB.ReadyIssuesGlobal(ctx, in.Limit)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		bare := make([]db.Issue, len(issues))
 		for i, iss := range issues {

--- a/internal/daemon/handlers_recurrences.go
+++ b/internal/daemon/handlers_recurrences.go
@@ -133,7 +133,7 @@ func createRecurrenceHandler(cfg ServerConfig) func(context.Context, *api.Create
 			return nil, federationReadOnlyError(err)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.CreateRecurrenceResponse{}
 		out.Body.Recurrence = rec
@@ -148,7 +148,7 @@ func listRecurrencesHandler(cfg ServerConfig) func(context.Context, *api.ListRec
 		}
 		list, err := cfg.DB.ListRecurrencesByProject(ctx, in.ProjectID)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		if list == nil {
 			list = []db.Recurrence{}
@@ -216,7 +216,7 @@ func patchRecurrenceHandler(cfg ServerConfig) func(context.Context, *api.PatchRe
 			return nil, federationReadOnlyError(err)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.PatchRecurrenceResponse{}
 		out.ETag = fmt.Sprintf(`"rev-%d"`, res.NewRevision)
@@ -240,7 +240,7 @@ func deleteRecurrenceHandler(cfg ServerConfig) func(context.Context, *api.Delete
 			if apiErr := federationReadOnlyError(err); apiErr != nil {
 				return nil, apiErr
 			}
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		return &api.DeleteRecurrenceResponse{}, nil
 	}

--- a/internal/daemon/handlers_search.go
+++ b/internal/daemon/handlers_search.go
@@ -54,7 +54,7 @@ func registerSearchHandlers(humaAPI huma.API, cfg ServerConfig) {
 				}
 				return nil, api.NewError(me.Status(), kind, me.Error(), "", nil)
 			}
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.SearchResponse{}
 		out.Body.Query = in.Query

--- a/internal/daemon/handlers_tokens.go
+++ b/internal/daemon/handlers_tokens.go
@@ -28,7 +28,7 @@ func registerTokenHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		plaintext, err := newPlaintextToken()
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		var name *string
 		if trimmed := strings.TrimSpace(in.Body.Name); trimmed != "" {
@@ -41,7 +41,7 @@ func registerTokenHandlers(humaAPI huma.API, cfg ServerConfig) {
 			AdminActor:     tokenAdminAuditActor(ctx, db.BootstrapActor),
 		})
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.CreateTokenResponse{}
 		out.Body.Token = tokenOut(tok)
@@ -59,7 +59,7 @@ func registerTokenHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		toks, err := cfg.DB.ListAPITokens(ctx)
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.ListTokensResponse{}
 		out.Body.Tokens = make([]api.TokenOut, 0, len(toks))
@@ -82,7 +82,7 @@ func registerTokenHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(404, "token_not_found", "token not found", "", nil)
 		}
 		if err != nil {
-			return nil, api.NewError(500, "internal", err.Error(), "", nil)
+			return nil, internalAPIError(err)
 		}
 		out := &api.RevokeTokenResponse{}
 		out.Body.Token = tokenOut(tok)

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -27,6 +27,7 @@ type HostOperation struct {
 	ProjectIDs  []int64
 	ProjectUIDs []string
 	AllProjects bool
+	Policy      HostOperationPolicy
 }
 
 // HostAccessRequest contains only generic request identity and route facts.
@@ -121,6 +122,13 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 				PathParams: pathParams,
 			},
 		}
+		policy, ok := hostOperationPolicy(operation.OperationID)
+		if !ok {
+			writeHostAccessError(ctx, http.StatusServiceUnavailable,
+				"access_unavailable", "access decision unavailable")
+			return
+		}
+		request.Operation.Policy = policy
 		if projectID, ok := positiveProjectID(pathParams["project_id"]); ok {
 			request.Operation.ProjectIDs = []int64{projectID}
 		}
@@ -302,6 +310,13 @@ func authorizeHostHTTP(
 			"authentication_required", "authentication required")
 		return false
 	}
+	policy, ok := hostOperationPolicy(operation.ID)
+	if !ok {
+		api.WriteEnvelope(w, http.StatusServiceUnavailable,
+			"access_unavailable", "access decision unavailable")
+		return false
+	}
+	operation.Policy = policy
 	_, err := controller.Authorize(r.Context(), HostAccessRequest{
 		Subject: principal.Subject, Actor: principal.Actor, Operation: operation,
 	})

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -11,6 +11,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 
 	"go.kenn.io/kata/internal/api"
+	"go.kenn.io/kata/internal/db"
 )
 
 // ErrHostAccessDenied is the private adapter sentinel for a host decision that
@@ -39,7 +40,8 @@ type HostAccessRequest struct {
 
 // HostAccessDecision contains optional long-lived authorization state.
 type HostAccessDecision struct {
-	Revalidate func(context.Context) error
+	Revalidate       func(context.Context) error
+	TransactionFence db.TransactionFence
 }
 
 // HostAccessController is implemented by the public package adapter.
@@ -137,7 +139,7 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 		}
 		state := &hostAccessState{controller: controller, request: request}
 		if hostAccessResolvedByHandler(operation.OperationID) {
-			next(huma.WithValue(ctx, hostAccessStateContextKey{}, state))
+			next(withHostAccessState(ctx, state))
 			return
 		}
 		if len(request.Operation.ProjectIDs) == 0 && !hostAccessOperationWithoutProjectData(operation.OperationID) {
@@ -156,8 +158,30 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 		}
 		state.decision = decision
 		state.authorized = true
-		next(huma.WithValue(ctx, hostAccessStateContextKey{}, state))
+		next(withHostAccessState(ctx, state))
 	})
+}
+
+func withHostAccessState(ctx huma.Context, state *hostAccessState) huma.Context {
+	ctx = huma.WithValue(ctx, hostAccessStateContextKey{}, state)
+	fenced := db.WithTransactionFence(ctx.Context(), func(
+		fenceCtx context.Context,
+		transaction db.Transaction,
+	) error {
+		if !state.authorized || state.decision.TransactionFence == nil {
+			return api.NewError(http.StatusServiceUnavailable,
+				"access_unavailable", "transaction access decision unavailable", "", nil)
+		}
+		if err := state.decision.TransactionFence(fenceCtx, transaction); err != nil {
+			if errors.Is(err, ErrHostAccessDenied) {
+				return api.NewError(http.StatusNotFound, "not_found", "resource not found", "", nil)
+			}
+			return api.NewError(http.StatusServiceUnavailable,
+				"access_unavailable", "transaction access decision unavailable", "", nil)
+		}
+		return nil
+	})
+	return huma.WithContext(ctx, fenced)
 }
 
 func hostSelfAuthenticatedOperation(operationID string) bool {

--- a/internal/daemon/host_operation_policy.go
+++ b/internal/daemon/host_operation_policy.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// EmbeddingProfile is the daemon-side representation of the public service
+// profile. Standalone construction always uses the zero value.
+type EmbeddingProfile string
+
+const embeddingProfileRestricted EmbeddingProfile = "restricted"
+
+// HostCapability is the internal authority class forwarded through the public adapter.
+type HostCapability string
+
+const (
+	hostCapabilityRead     HostCapability = "read"
+	hostCapabilityWrite    HostCapability = "write"
+	hostCapabilityManage   HostCapability = "manage"
+	hostCapabilityFederate HostCapability = "federate"
+)
+
+// HostOperationKind is the internal domain classification for a route.
+type HostOperationKind string
+
+const (
+	hostOperationServiceRead               HostOperationKind = "service_read"
+	hostOperationProjectRead               HostOperationKind = "project_read"
+	hostOperationTaskRead                  HostOperationKind = "task_read"
+	hostOperationTaskMutation              HostOperationKind = "task_mutation"
+	hostOperationTaskAdministration        HostOperationKind = "task_administration"
+	hostOperationProjectAdministration     HostOperationKind = "project_administration"
+	hostOperationTokenAdministration       HostOperationKind = "token_administration"
+	hostOperationFederationRead            HostOperationKind = "federation_read"
+	hostOperationFederationAdministration  HostOperationKind = "federation_administration"
+	hostOperationFederationTransport       HostOperationKind = "federation_transport"
+	hostOperationIntegrationAdministration HostOperationKind = "integration_administration"
+)
+
+// HostOperationPolicy carries Kata-owned route metadata through the public adapter.
+type HostOperationPolicy struct {
+	Kind       HostOperationKind
+	Capability HostCapability
+	Mutation   bool
+	LongLived  bool
+	restricted bool
+}
+
+var hostOperationPolicies = buildHostOperationPolicies()
+
+func buildHostOperationPolicies() map[string]HostOperationPolicy {
+	policies := make(map[string]HostOperationPolicy)
+	registerServiceOperationPolicies(policies)
+	registerProjectOperationPolicies(policies)
+	registerTaskOperationPolicies(policies)
+	registerFederationOperationPolicies(policies)
+	return policies
+}
+
+func registerHostOperations(
+	policies map[string]HostOperationPolicy,
+	policy HostOperationPolicy,
+	operationIDs ...string,
+) {
+	for _, operationID := range operationIDs {
+		if _, exists := policies[operationID]; exists {
+			panic("duplicate host operation policy: " + operationID)
+		}
+		policies[operationID] = policy
+	}
+}
+
+func hostOperationPolicy(operationID string) (HostOperationPolicy, bool) {
+	policy, ok := hostOperationPolicies[operationID]
+	return policy, ok
+}
+
+func withEmbeddingProfile(humaAPI huma.API, profile EmbeddingProfile) {
+	if profile != embeddingProfileRestricted {
+		return
+	}
+	humaAPI.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+		operation := ctx.Operation()
+		if operation == nil {
+			writeHostAccessError(ctx, http.StatusNotFound, "not_found", "resource not found")
+			return
+		}
+		policy, ok := hostOperationPolicy(operation.OperationID)
+		if !ok || policy.restricted {
+			writeHostAccessError(ctx, http.StatusNotFound, "not_found", "resource not found")
+			return
+		}
+		next(ctx)
+	})
+}
+
+func registerServiceOperationPolicies(policies map[string]HostOperationPolicy) {
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationServiceRead, Capability: hostCapabilityRead,
+	}, "ping", "health", "instance", "openAPI")
+}

--- a/internal/daemon/host_operation_policy_federation.go
+++ b/internal/daemon/host_operation_policy_federation.go
@@ -1,0 +1,25 @@
+package daemon
+
+func registerFederationOperationPolicies(policies map[string]HostOperationPolicy) {
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationFederationRead, Capability: hostCapabilityRead,
+	}, "getFederationStatus", "getProjectFederation", "getProjectFederationStatus")
+
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationFederationAdministration, Capability: hostCapabilityFederate,
+		restricted: true,
+	}, "listFederationEnrollments")
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationFederationAdministration, Capability: hostCapabilityFederate,
+		Mutation: true, restricted: true,
+	}, "enableProjectFederation", "skipFederationQuarantine", "retryFederationQuarantine",
+		"createFederationEnrollment", "revokeFederationEnrollment", "createFederationReplica",
+		"leaveFederationReplica")
+
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationFederationTransport, Capability: hostCapabilityFederate,
+	}, "getFederationProjectMetadata", "pollFederationProjectEvents")
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationFederationTransport, Capability: hostCapabilityFederate, Mutation: true,
+	}, "ingestFederationProjectEvents")
+}

--- a/internal/daemon/host_operation_policy_projects.go
+++ b/internal/daemon/host_operation_policy_projects.go
@@ -1,0 +1,31 @@
+package daemon
+
+func registerProjectOperationPolicies(policies map[string]HostOperationPolicy) {
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationProjectRead, Capability: hostCapabilityRead,
+	}, "listProjects", "showProject")
+
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationProjectAdministration, Capability: hostCapabilityManage,
+		Mutation: true, restricted: true,
+	}, "resolveProject", "initProject", "mergeProject", "removeProject", "purgeProject",
+		"restoreProject", "detachProjectAlias", "renameProject", "patchProjectMetadata")
+
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationTokenAdministration, Capability: hostCapabilityManage,
+		restricted: true,
+	}, "listTokens")
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationTokenAdministration, Capability: hostCapabilityManage,
+		Mutation: true, restricted: true,
+	}, "createToken", "revokeToken")
+
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationIntegrationAdministration, Capability: hostCapabilityManage,
+		restricted: true,
+	}, "getIssueSyncStatus")
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationIntegrationAdministration, Capability: hostCapabilityManage,
+		Mutation: true, restricted: true,
+	}, "enableIssueSync", "disableIssueSync", "runIssueSyncOnce")
+}

--- a/internal/daemon/host_operation_policy_tasks.go
+++ b/internal/daemon/host_operation_policy_tasks.go
@@ -1,0 +1,26 @@
+package daemon
+
+func registerTaskOperationPolicies(policies map[string]HostOperationPolicy) {
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationTaskRead, Capability: hostCapabilityRead,
+	}, "listAllIssues", "listIssues", "showIssue", "showIssueByUID", "reachableIssueGraph",
+		"listLabels", "listRecurrences", "showRecurrence", "readyIssues", "readyIssuesGlobal",
+		"searchIssues", "pollEvents", "pollProjectEvents", "auditCloses", "digestGlobal",
+		"digestProject", "getIssueLeaseStatus")
+
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationTaskRead, Capability: hostCapabilityRead, LongLived: true,
+	}, "streamEvents")
+
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationTaskMutation, Capability: hostCapabilityWrite, Mutation: true,
+	}, "createIssue", "editIssue", "createComment", "editComment", "addLabel", "removeLabel",
+		"createLink", "deleteLink", "assignIssue", "unassignIssue", "claimIssue",
+		"setIssuePriority", "closeIssue", "reopenIssue", "deleteIssue", "restoreIssue",
+		"createRecurrence", "patchRecurrence", "deleteRecurrence", "patchIssueMetadata",
+		"moveIssue", "importIssues", "acquireIssueLease", "renewIssueLease", "releaseIssueLease")
+
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationTaskAdministration, Capability: hostCapabilityManage, Mutation: true,
+	}, "purgeIssue", "forceReleaseIssueLease", "rewriteAuthorIdentity")
+}

--- a/internal/daemon/resolver.go
+++ b/internal/daemon/resolver.go
@@ -36,7 +36,7 @@ func resolveIssueRef(ctx context.Context, store db.Storage, projectID int64, ref
 			return db.Issue{}, api.NewError(404, "issue_not_found", "issue not found", "", nil)
 		}
 		if err != nil {
-			return db.Issue{}, api.NewError(500, "internal", err.Error(), "", nil)
+			return db.Issue{}, internalAPIError(err)
 		}
 		if issue.ProjectID != projectID {
 			return db.Issue{}, api.NewError(404, "issue_not_found", "issue not found", "", nil)
@@ -49,7 +49,7 @@ func resolveIssueRef(ctx context.Context, store db.Storage, projectID int64, ref
 			if errors.Is(err, db.ErrNotFound) {
 				return db.Issue{}, api.NewError(404, "issue_not_found", "issue not found", "", nil)
 			}
-			return db.Issue{}, api.NewError(500, "internal", err.Error(), "", nil)
+			return db.Issue{}, internalAPIError(err)
 		}
 		if parsed.Project != project.Name {
 			return db.Issue{}, api.NewError(404, "issue_not_found", "issue not found", "", nil)
@@ -60,7 +60,7 @@ func resolveIssueRef(ctx context.Context, store db.Storage, projectID int64, ref
 		return db.Issue{}, api.NewError(404, "issue_not_found", "issue not found", "", nil)
 	}
 	if err != nil {
-		return db.Issue{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Issue{}, internalAPIError(err)
 	}
 	return issue, nil
 }
@@ -105,7 +105,7 @@ func resolveLinkTargetRef(ctx context.Context, store db.Storage, subjectProjectI
 			return db.Issue{}, notFound
 		}
 		if err != nil {
-			return db.Issue{}, api.NewError(500, "internal", err.Error(), "", nil)
+			return db.Issue{}, internalAPIError(err)
 		}
 		return issue, nil
 	}
@@ -118,7 +118,7 @@ func resolveLinkTargetRef(ctx context.Context, store db.Storage, subjectProjectI
 			return db.Issue{}, notFound
 		}
 		if err != nil {
-			return db.Issue{}, api.NewError(500, "internal", err.Error(), "", nil)
+			return db.Issue{}, internalAPIError(err)
 		}
 		projectID = project.ID
 	}
@@ -127,7 +127,7 @@ func resolveLinkTargetRef(ctx context.Context, store db.Storage, subjectProjectI
 		return db.Issue{}, notFound
 	}
 	if err != nil {
-		return db.Issue{}, api.NewError(500, "internal", err.Error(), "", nil)
+		return db.Issue{}, internalAPIError(err)
 	}
 	return issue, nil
 }
@@ -145,7 +145,7 @@ func requireLinkTargetAddable(ctx context.Context, store db.Storage, subjectProj
 	}
 	project, err := store.ProjectByID(ctx, target.ProjectID)
 	if err != nil {
-		return api.NewError(500, "internal", err.Error(), "", nil)
+		return internalAPIError(err)
 	}
 	if project.DeletedAt != nil {
 		return api.NewError(409, "link_target_archived",

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -77,6 +77,11 @@ type ServerConfig struct {
 	// HostAccess enables in-process authentication and authorization supplied
 	// by a mounting application. It is nil for the standalone daemon.
 	HostAccess HostAccessController
+
+	// EmbeddingProfile removes native administrative routes when their
+	// lifecycle is owned by a mounting application. The standalone daemon uses
+	// the zero value and retains every route.
+	EmbeddingProfile EmbeddingProfile
 }
 
 // authPolicy returns the resolved bearer-auth policy in the form the
@@ -164,6 +169,7 @@ func NewServer(cfg ServerConfig) *Server {
 	// envelope shape, so we must disable the transform.
 	humaConfig.CreateHooks = nil
 	humaAPI := huma.NewAPI(humaConfig, api.WrapErrorAdapter(humago.NewAdapter(mux, "")))
+	withEmbeddingProfile(humaAPI, cfg.EmbeddingProfile)
 	withHostAccess(humaAPI, cfg.HostAccess)
 
 	s := &Server{cfg: cfg, api: humaAPI}

--- a/internal/daemon/server_internal_test.go
+++ b/internal/daemon/server_internal_test.go
@@ -4,10 +4,52 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
 
 	"go.kenn.io/kata/internal/hooks"
 )
+
+func TestEveryRegisteredOperationHasHostPolicy(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { _ = srv.Close() })
+
+	registered := make(map[string]struct{})
+	for _, pathItem := range srv.API().OpenAPI().Paths {
+		operations := []*huma.Operation{
+			pathItem.Get, pathItem.Put, pathItem.Post, pathItem.Delete,
+			pathItem.Options, pathItem.Head, pathItem.Patch, pathItem.Trace,
+		}
+		for _, operation := range operations {
+			if operation == nil {
+				continue
+			}
+			policy, ok := hostOperationPolicy(operation.OperationID)
+			if !ok {
+				t.Errorf("operation %q has no host policy", operation.OperationID)
+				continue
+			}
+			if policy.Kind == "" || policy.Capability == "" {
+				t.Errorf("operation %q has incomplete host policy: %+v", operation.OperationID, policy)
+			}
+			registered[operation.OperationID] = struct{}{}
+		}
+	}
+	registered["openAPI"] = struct{}{}
+
+	var stale []string
+	for operationID := range hostOperationPolicies {
+		if _, ok := registered[operationID]; !ok {
+			stale = append(stale, operationID)
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("host policies reference unregistered operations: %v", stale)
+	}
+}
 
 // TestServerConfig_NilHooks_FillsNoop verifies NewServer substitutes a
 // hooks.NewNoop() Sink when ServerConfig.Hooks is nil so handler tests

--- a/internal/db/pgstore/aliases.go
+++ b/internal/db/pgstore/aliases.go
@@ -15,10 +15,10 @@ func (s *Store) AttachAlias(ctx context.Context, projectID int64, identity, kind
 	var alias db.ProjectAlias
 	err := s.RetryTransient(ctx, func() error {
 		var err error
-		alias, err = scanAlias(s.QueryRowContext(ctx,
+		alias, err = fencedQueryRow(ctx, s, scanAlias,
 			`INSERT INTO project_aliases(project_id, alias_identity, alias_kind) VALUES($1, $2, $3) `+
 				`RETURNING id, project_id, alias_identity, alias_kind, created_at`,
-			projectID, identity, kind))
+			projectID, identity, kind)
 		return mapSQLError(err, map[string]error{
 			"project_aliases_alias_identity_key": db.ErrAliasExists,
 		})

--- a/internal/db/pgstore/labels.go
+++ b/internal/db/pgstore/labels.go
@@ -25,9 +25,9 @@ func (s *Store) AddLabel(ctx context.Context, issueID int64, label, author strin
 	var issueLabel db.IssueLabel
 	err := s.RetryTransient(ctx, func() error {
 		var err error
-		issueLabel, err = scanLabel(s.QueryRowContext(ctx,
+		issueLabel, err = fencedQueryRow(ctx, s, scanLabel,
 			`INSERT INTO issue_labels(issue_id, label, author) VALUES($1,$2,$3)
-			 RETURNING issue_id, label, author, created_at`, issueID, label, author))
+			 RETURNING issue_id, label, author, created_at`, issueID, label, author)
 		return mapSQLError(err, labelConstraintErrors)
 	})
 	return issueLabel, err

--- a/internal/db/pgstore/projects.go
+++ b/internal/db/pgstore/projects.go
@@ -44,10 +44,10 @@ func (s *Store) CreateProjectWithUID(ctx context.Context, name, projectUID strin
 	var project db.Project
 	err := s.RetryTransient(ctx, func() error {
 		var err error
-		project, err = scanProject(s.QueryRowContext(ctx,
+		project, err = fencedQueryRow(ctx, s, scanProject,
 			`INSERT INTO projects(uid, name) VALUES($1, $2) `+
 				`RETURNING id, uid, name, metadata, revision, created_at, deleted_at`,
-			projectUID, name))
+			projectUID, name)
 		return mapSQLError(err, nil)
 	})
 	return project, err
@@ -82,10 +82,10 @@ func (s *Store) RenameProject(ctx context.Context, id int64, name string) (db.Pr
 	var project db.Project
 	err := s.RetryTransient(ctx, func() error {
 		var err error
-		project, err = scanProject(s.QueryRowContext(ctx,
+		project, err = fencedQueryRow(ctx, s, scanProject,
 			`UPDATE projects SET name = $1 WHERE id = $2 AND name <> $3 AND uid <> $4 `+
 				`RETURNING id, uid, name, metadata, revision, created_at, deleted_at`,
-			name, id, db.SystemProjectName, db.SystemProjectUID))
+			name, id, db.SystemProjectName, db.SystemProjectUID)
 		return mapSQLError(err, nil)
 	})
 	return visibleProject(project, err)

--- a/internal/db/pgstore/transaction_fence.go
+++ b/internal/db/pgstore/transaction_fence.go
@@ -1,0 +1,72 @@
+package pgstore
+
+import (
+	"context"
+	"database/sql"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+// BeginTx applies a request-scoped transaction fence before returning a
+// transaction to storage code. Contexts without a host fence retain the
+// ordinary standalone behavior.
+func (s *Store) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	tx, err := s.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.ApplyTransactionFence(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	return tx, nil
+}
+
+// ExecContext wraps otherwise-autocommit writes in a fenced transaction when
+// the request carries host access state.
+func (s *Store) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if !db.HasTransactionFence(ctx) {
+		return s.DB.ExecContext(ctx, query, args...)
+	}
+	tx, err := s.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func fencedQueryRow[T any](
+	ctx context.Context,
+	s *Store,
+	scan func(rowScanner) (T, error),
+	query string,
+	args ...any,
+) (T, error) {
+	if !db.HasTransactionFence(ctx) {
+		return scan(s.QueryRowContext(ctx, query, args...))
+	}
+	tx, err := s.BeginTx(ctx, nil)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	value, err := scan(tx.QueryRowContext(ctx, query, args...))
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	if err := tx.Commit(); err != nil {
+		var zero T
+		return zero, err
+	}
+	return value, nil
+}

--- a/internal/db/pgstore/transaction_fence.go
+++ b/internal/db/pgstore/transaction_fence.go
@@ -15,6 +15,9 @@ func (s *Store) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, erro
 	if err != nil {
 		return nil, err
 	}
+	if opts != nil && opts.ReadOnly {
+		return tx, nil
+	}
 	if err := db.ApplyTransactionFence(ctx, tx); err != nil {
 		_ = tx.Rollback()
 		return nil, err

--- a/internal/db/sqlitestore/claims.go
+++ b/internal/db/sqlitestore/claims.go
@@ -1001,7 +1001,7 @@ func (d *Store) withImmediateClaimTx(ctx context.Context, fn func(*sql.Conn) err
 		}
 		defer func() { _ = conn.Close() }()
 
-		if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE TRANSACTION"); err != nil {
+		if err := d.beginImmediateTransaction(ctx, conn); err != nil {
 			return fmt.Errorf("begin immediate: %w", err)
 		}
 		committed := false

--- a/internal/db/sqlitestore/queries_delete.go
+++ b/internal/db/sqlitestore/queries_delete.go
@@ -204,7 +204,7 @@ func (d *Store) purgeIssue(ctx context.Context, issueID int64, actor string, rea
 	}
 	defer func() { _ = conn.Close() }()
 
-	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE TRANSACTION"); err != nil {
+	if err := d.beginImmediateTransaction(ctx, conn); err != nil {
 		return db.PurgeLog{}, fmt.Errorf("begin immediate: %w", err)
 	}
 	committed := false

--- a/internal/db/sqlitestore/queries_projects_purge.go
+++ b/internal/db/sqlitestore/queries_projects_purge.go
@@ -26,7 +26,7 @@ func (d *Store) purgeProject(ctx context.Context, p db.PurgeProjectParams) (db.P
 	}
 	defer func() { _ = conn.Close() }()
 
-	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE TRANSACTION"); err != nil {
+	if err := d.beginImmediateTransaction(ctx, conn); err != nil {
 		return db.ProjectPurgeLog{}, fmt.Errorf("begin immediate: %w", err)
 	}
 	committed := false

--- a/internal/db/sqlitestore/transaction_fence.go
+++ b/internal/db/sqlitestore/transaction_fence.go
@@ -1,0 +1,55 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+// BeginTx applies a request-scoped transaction fence before returning a
+// transaction to storage code. Contexts without a host fence retain the
+// ordinary standalone behavior.
+func (d *Store) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	tx, err := d.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.ApplyTransactionFence(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	return tx, nil
+}
+
+// ExecContext wraps otherwise-autocommit writes in a fenced transaction when
+// the request carries host access state.
+func (d *Store) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if !db.HasTransactionFence(ctx) {
+		return d.DB.ExecContext(ctx, query, args...)
+	}
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (d *Store) beginImmediateTransaction(ctx context.Context, conn *sql.Conn) error {
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE TRANSACTION"); err != nil {
+		return err
+	}
+	if err := db.ApplyTransactionFence(ctx, conn); err != nil {
+		_, _ = conn.ExecContext(context.WithoutCancel(ctx), "ROLLBACK")
+		return err
+	}
+	return nil
+}

--- a/internal/db/sqlitestore/transaction_fence.go
+++ b/internal/db/sqlitestore/transaction_fence.go
@@ -15,6 +15,9 @@ func (d *Store) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, erro
 	if err != nil {
 		return nil, err
 	}
+	if opts != nil && opts.ReadOnly {
+		return tx, nil
+	}
 	if err := db.ApplyTransactionFence(ctx, tx); err != nil {
 		_ = tx.Rollback()
 		return nil, err

--- a/internal/db/sqlitestore/transaction_fence_test.go
+++ b/internal/db/sqlitestore/transaction_fence_test.go
@@ -2,13 +2,29 @@ package sqlitestore_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/db"
 )
+
+func TestTransactionFenceSkipsExplicitReadOnlyTransactions(t *testing.T) {
+	d, ctx, _, _ := setupSoftDeletedIssue(t)
+	var calls atomic.Int64
+	fenced := db.WithTransactionFence(ctx, func(context.Context, db.Transaction) error {
+		calls.Add(1)
+		return errors.New("must not run for a read-only transaction")
+	})
+
+	tx, err := d.BeginTx(fenced, &sql.TxOptions{ReadOnly: true})
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+	assert.Zero(t, calls.Load())
+}
 
 func TestTransactionFenceRollsBackAutocommitAndImmediateMutations(t *testing.T) {
 	d, ctx, _, issue := setupSoftDeletedIssue(t)

--- a/internal/db/sqlitestore/transaction_fence_test.go
+++ b/internal/db/sqlitestore/transaction_fence_test.go
@@ -1,0 +1,46 @@
+package sqlitestore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+)
+
+func TestTransactionFenceRollsBackAutocommitAndImmediateMutations(t *testing.T) {
+	d, ctx, _, issue := setupSoftDeletedIssue(t)
+	_, err := d.ExecContext(ctx, `CREATE TABLE fence_markers (operation TEXT NOT NULL)`)
+	require.NoError(t, err)
+	_, err = d.AddLabel(ctx, issue.ID, "retained", "tester")
+	require.NoError(t, err)
+
+	rejected := errors.New("test transaction fence rejected")
+	fenced := db.WithTransactionFence(ctx, func(ctx context.Context, tx db.Transaction) error {
+		_, insertErr := tx.ExecContext(ctx,
+			`INSERT INTO fence_markers(operation) VALUES(?)`, "rejected")
+		if insertErr != nil {
+			return insertErr
+		}
+		return rejected
+	})
+
+	err = d.RemoveLabel(fenced, issue.ID, "retained")
+	require.ErrorIs(t, err, rejected)
+	hasLabel, err := d.HasLabel(ctx, issue.ID, "retained")
+	require.NoError(t, err)
+	assert.True(t, hasLabel)
+
+	_, err = d.PurgeIssue(fenced, issue.ID, "tester", nil)
+	require.ErrorIs(t, err, rejected)
+	retained, err := d.IssueByID(ctx, issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, issue.ID, retained.ID)
+
+	var markerCount int
+	require.NoError(t, d.QueryRowContext(ctx,
+		`SELECT count(*) FROM fence_markers`).Scan(&markerCount))
+	assert.Zero(t, markerCount)
+}

--- a/internal/db/transaction_fence.go
+++ b/internal/db/transaction_fence.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+)
+
+// Transaction is the storage-neutral database/sql surface available to a
+// request-scoped fence. *sql.Tx and manually managed *sql.Conn transactions
+// both implement it.
+type Transaction interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// TransactionFence runs after a transaction begins and before its first
+// domain write. Any returned error aborts the transaction.
+type TransactionFence func(context.Context, Transaction) error
+
+type transactionFenceContextKey struct{}
+
+// WithTransactionFence attaches one request-scoped fence to ctx.
+func WithTransactionFence(ctx context.Context, fence TransactionFence) context.Context {
+	if fence == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, transactionFenceContextKey{}, fence)
+}
+
+// ApplyTransactionFence invokes the request fence, if any, against tx.
+func ApplyTransactionFence(ctx context.Context, tx Transaction) error {
+	fence, _ := ctx.Value(transactionFenceContextKey{}).(TransactionFence)
+	if fence == nil {
+		return nil
+	}
+	return fence(ctx, tx)
+}
+
+// HasTransactionFence reports whether ctx carries a request-scoped fence.
+func HasTransactionFence(ctx context.Context) bool {
+	fence, _ := ctx.Value(transactionFenceContextKey{}).(TransactionFence)
+	return fence != nil
+}

--- a/internal/githubsync/runner.go
+++ b/internal/githubsync/runner.go
@@ -221,7 +221,7 @@ func (r *Runner) runClaimed(ctx context.Context, binding db.IssueSyncBinding, sy
 	if err != nil {
 		return r.recordError(ctx, binding, syncStartedAt, err, importResult)
 	}
-	cleanupCtx, cleanupCancel := r.cleanupContext()
+	cleanupCtx, cleanupCancel := r.cleanupContext(ctx)
 	defer cleanupCancel()
 	if parentLinkBackfill {
 		backfilledConfig := ghConfig.WithParentLinksBackfilled()
@@ -478,8 +478,8 @@ func (r *Runner) emitEvents(ctx context.Context, projectID int64, events []db.Ev
 	}
 }
 
-func (r *Runner) recordError(_ context.Context, binding db.IssueSyncBinding, startedAt time.Time, cause error, importResult db.ImportBatchResult) (RunResult, error) {
-	cleanupCtx, cleanupCancel := r.cleanupContext()
+func (r *Runner) recordError(ctx context.Context, binding db.IssueSyncBinding, startedAt time.Time, cause error, importResult db.ImportBatchResult) (RunResult, error) {
+	cleanupCtx, cleanupCancel := r.cleanupContext(ctx)
 	defer cleanupCancel()
 	status, recordErr := r.config.Store.RecordIssueSyncError(cleanupCtx, db.IssueSyncErrorParams{
 		BindingID: binding.ID,
@@ -493,8 +493,8 @@ func (r *Runner) recordError(_ context.Context, binding db.IssueSyncBinding, sta
 	return RunResult{Binding: binding, Status: status, Import: importResult}, cause
 }
 
-func (r *Runner) cleanupContext() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), runnerCleanupTimeout)
+func (r *Runner) cleanupContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), runnerCleanupTimeout)
 }
 
 func (r *Runner) now() time.Time {

--- a/internal/githubsync/runner_test.go
+++ b/internal/githubsync/runner_test.go
@@ -478,6 +478,65 @@ func TestRunnerSuccessCleanupIgnoresCallerCancellation(t *testing.T) {
 	assertCursorAt(h.ctx, t, h.db, h.binding.ID, h.now)
 }
 
+func TestRunnerSuccessCleanupRetainsTransactionFenceAfterCancellation(t *testing.T) {
+	h := newRunnerHarness(t)
+	rejectCleanup := false
+	fenceErr := errors.New("host authority changed before success cleanup")
+	fenced := db.WithTransactionFence(h.ctx, func(context.Context, db.Transaction) error {
+		if rejectCleanup {
+			return fenceErr
+		}
+		return nil
+	})
+	ctx, cancel := context.WithCancel(fenced)
+	h.runner.config.EventSink = func(context.Context, int64, []db.Event) error {
+		rejectCleanup = true
+		cancel()
+		return nil
+	}
+	h.fetcher.issues = []Issue{testIssue(101, 1, "first issue", h.now.Add(-time.Hour))}
+
+	_, err := h.runner.RunOnce(ctx, h.binding.ID)
+
+	require.ErrorIs(t, err, fenceErr)
+	assertCursorNil(h.ctx, t, h.db, h.binding.ID)
+	status, err := h.db.IssueSyncStatusByProject(h.ctx, h.project.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, status.SyncStartedAt)
+	assert.Nil(t, status.LastSuccessAt)
+}
+
+func TestRunnerBackfillRefreshRetainsTransactionFenceAfterCancellation(t *testing.T) {
+	h := newRunnerHarness(t)
+	rejectCleanup := false
+	fenceErr := errors.New("host authority changed before binding refresh")
+	fenced := db.WithTransactionFence(h.ctx, func(context.Context, db.Transaction) error {
+		if rejectCleanup {
+			return fenceErr
+		}
+		return nil
+	})
+	ctx, cancel := context.WithCancel(fenced)
+	h.runner.config.EventSink = func(context.Context, int64, []db.Event) error {
+		rejectCleanup = true
+		cancel()
+		return nil
+	}
+	h.fetcher.parentData = ParentData{Authoritative: true}
+	h.fetcher.parentDataSet = true
+	h.fetcher.issues = []Issue{testIssue(101, 1, "first issue", h.now.Add(-time.Hour))}
+
+	_, err := h.runner.RunOnce(ctx, h.binding.ID)
+
+	require.ErrorIs(t, err, fenceErr)
+	stored, err := h.db.IssueSyncBindingByID(h.ctx, h.binding.ID)
+	require.NoError(t, err)
+	storedConfig, err := DecodeConfig(stored.Config)
+	require.NoError(t, err)
+	assert.True(t, storedConfig.NeedsParentLinkBackfill())
+	assertCursorNil(h.ctx, t, h.db, h.binding.ID)
+}
+
 func TestRunnerIncrementalUsesCursorMinusOverlap(t *testing.T) {
 	h := newRunnerHarness(t)
 	lastCursor := h.now.Add(-10 * time.Minute)
@@ -651,6 +710,34 @@ func TestRunnerErrorCleanupIgnoresCallerCancellation(t *testing.T) {
 	assert.Nil(t, status.SyncStartedAt)
 	require.NotNil(t, status.LastErrorAt)
 	assert.Contains(t, status.LastError, "github unavailable")
+}
+
+func TestRunnerErrorCleanupRetainsTransactionFenceAfterCancellation(t *testing.T) {
+	h := newRunnerHarness(t)
+	rejectCleanup := false
+	fenceErr := errors.New("host authority changed before error cleanup")
+	fenced := db.WithTransactionFence(h.ctx, func(context.Context, db.Transaction) error {
+		if rejectCleanup {
+			return fenceErr
+		}
+		return nil
+	})
+	ctx, cancel := context.WithCancel(fenced)
+	h.fetcher.beforeIssuesReturn = func() {
+		rejectCleanup = true
+		cancel()
+	}
+	h.fetcher.issuesErr = errors.New("github unavailable")
+
+	_, err := h.runner.RunOnce(ctx, h.binding.ID)
+
+	require.ErrorIs(t, err, fenceErr)
+	assertCursorNil(h.ctx, t, h.db, h.binding.ID)
+	status, err := h.db.IssueSyncStatusByProject(h.ctx, h.project.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, status.SyncStartedAt)
+	assert.Nil(t, status.LastErrorAt)
+	assert.Empty(t, status.LastError)
 }
 
 func TestRunnerImportFailureClearsInFlightAndLeavesCursorUnchanged(t *testing.T) {

--- a/service.go
+++ b/service.go
@@ -510,10 +510,14 @@ func (s *Service) Run(ctx context.Context) error {
 		default:
 		}
 	}
+	shuttingDown := ctx.Err() != nil || s.isClosed()
+	if shuttingDown && errors.Is(workerFenceFailure, context.Canceled) {
+		return nil
+	}
 	if workerFenceFailure != nil {
 		return fmt.Errorf("kata: worker transaction fence: %w", workerFenceFailure)
 	}
-	if runCtx.Err() != nil && (ctx.Err() != nil || s.isClosed()) {
+	if runCtx.Err() != nil && shuttingDown {
 		return nil
 	}
 	for i := range workerResults {

--- a/service.go
+++ b/service.go
@@ -353,7 +353,19 @@ func (a hostAccessControllerAdapter) Authorize(
 	if decision.Lease != nil {
 		revalidate = decision.Lease.Revalidate
 	}
-	return daemon.HostAccessDecision{Revalidate: revalidate}, nil
+	var transactionFence db.TransactionFence
+	if decision.TransactionFence != nil {
+		transactionFence = func(ctx context.Context, transaction db.Transaction) error {
+			err := decision.TransactionFence(ctx, transaction)
+			if errors.Is(err, ErrAccessDenied) {
+				return daemon.ErrHostAccessDenied
+			}
+			return err
+		}
+	}
+	return daemon.HostAccessDecision{
+		Revalidate: revalidate, TransactionFence: transactionFence,
+	}, nil
 }
 
 // Run executes Kata's federation, GitHub synchronization, and timed-claim

--- a/service.go
+++ b/service.go
@@ -38,6 +38,20 @@ const (
 	PostgresSchemaValidate PostgresSchemaMode = "validate"
 )
 
+// EmbeddingProfile selects which HTTP administration surfaces a mounted
+// service exposes. The zero value preserves the standalone-compatible API.
+type EmbeddingProfile string
+
+// Embedding profiles supported by Config.Profile.
+const (
+	EmbeddingProfileStandalone EmbeddingProfile = ""
+	// EmbeddingProfileRestricted is for applications that own project,
+	// credential, federation, and external-integration administration. It keeps
+	// task and federation transport behavior while failing closed on native
+	// administration routes.
+	EmbeddingProfileRestricted EmbeddingProfile = "restricted"
+)
+
 // PostgresConfig selects an isolated PostgreSQL schema and startup policy.
 // Empty fields use Kata's standalone defaults.
 type PostgresConfig struct {
@@ -87,6 +101,9 @@ type Config struct {
 	// Access selects host-supplied in-process authentication and authorization.
 	// It is mutually exclusive with Auth.
 	Access AccessController
+	// Profile optionally removes native administration routes that an embedding
+	// host owns. The zero value keeps the complete standalone-compatible API.
+	Profile EmbeddingProfile
 	// FederationCredentials isolates secret material from other Service
 	// instances. Nil selects a service-owned in-memory store.
 	FederationCredentials FederationCredentialStore
@@ -133,6 +150,9 @@ func New(ctx context.Context, cfg Config) (*Service, error) {
 func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, error) {
 	if strings.TrimSpace(cfg.DSN) == "" {
 		return nil, errors.New("kata: storage DSN is required")
+	}
+	if cfg.Profile != EmbeddingProfileStandalone && cfg.Profile != EmbeddingProfileRestricted {
+		return nil, fmt.Errorf("kata: unknown embedding profile %q", cfg.Profile)
 	}
 	usesAccess := cfg.Access != nil
 	usesToken := strings.TrimSpace(cfg.Auth.Token) != ""
@@ -219,6 +239,7 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 		Hooks:                 hookSink,
 		Auth:                  config.AuthConfig{Token: cfg.Auth.Token},
 		HostAccess:            hostAccess,
+		EmbeddingProfile:      daemon.EmbeddingProfile(cfg.Profile),
 		Logger:                logger,
 	})
 
@@ -310,7 +331,13 @@ func (a hostAccessControllerAdapter) Authorize(
 		Principal: Principal{Subject: request.Subject, Actor: request.Actor},
 		Operation: Operation{
 			ID: request.Operation.ID, Method: request.Operation.Method, Path: request.Operation.Path,
-			PathParams:  request.Operation.PathParams,
+			PathParams: request.Operation.PathParams,
+			Policy: OperationPolicy{
+				Kind:       OperationKind(request.Operation.Policy.Kind),
+				Capability: Capability(request.Operation.Policy.Capability),
+				Mutation:   request.Operation.Policy.Mutation,
+				LongLived:  request.Operation.Policy.LongLived,
+			},
 			ProjectIDs:  append([]int64(nil), request.Operation.ProjectIDs...),
 			ProjectUIDs: append([]string(nil), request.Operation.ProjectUIDs...),
 			AllProjects: request.Operation.AllProjects,

--- a/service.go
+++ b/service.go
@@ -101,6 +101,10 @@ type Config struct {
 	// Access selects host-supplied in-process authentication and authorization.
 	// It is mutually exclusive with Auth.
 	Access AccessController
+	// WorkerTransactionFence revalidates host authority from inside every
+	// background-worker writable storage transaction. It is required when
+	// Access is set.
+	WorkerTransactionFence TransactionFence
 	// Profile optionally removes native administration routes that an embedding
 	// host owns. The zero value keeps the complete standalone-compatible API.
 	Profile EmbeddingProfile
@@ -118,19 +122,20 @@ type serviceDeps struct {
 
 // Service is a mountable Kata HTTP application and its owned lifecycle.
 type Service struct {
-	store                 db.Storage
-	server                *daemon.Server
-	broadcaster           *daemon.EventBroadcaster
-	hookSink              hooks.Sink
-	federationWake        chan struct{}
-	gitHubSyncWake        chan struct{}
-	gitHubSyncFetcher     githubsync.Fetcher
-	federationCredentials config.FederationCredentialStore
-	logger                *slog.Logger
-	hostAccessEnabled     bool
-	lifetimeCtx           context.Context
-	lifetimeCancel        context.CancelFunc
-	handlerWG             sync.WaitGroup
+	store                  db.Storage
+	server                 *daemon.Server
+	broadcaster            *daemon.EventBroadcaster
+	hookSink               hooks.Sink
+	federationWake         chan struct{}
+	gitHubSyncWake         chan struct{}
+	gitHubSyncFetcher      githubsync.Fetcher
+	federationCredentials  config.FederationCredentialStore
+	logger                 *slog.Logger
+	hostAccessEnabled      bool
+	workerTransactionFence TransactionFence
+	lifetimeCtx            context.Context
+	lifetimeCancel         context.CancelFunc
+	handlerWG              sync.WaitGroup
 
 	mu        sync.Mutex
 	running   bool
@@ -244,19 +249,20 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 	})
 
 	return &Service{
-		store:                 store,
-		server:                server,
-		broadcaster:           broadcaster,
-		hookSink:              hookSink,
-		federationWake:        federationWake,
-		gitHubSyncWake:        gitHubSyncWake,
-		gitHubSyncFetcher:     gitHubSyncFetcher,
-		federationCredentials: federationCredentials,
-		logger:                logger,
-		hostAccessEnabled:     cfg.Access != nil,
-		lifetimeCtx:           lifetimeCtx,
-		lifetimeCancel:        lifetimeCancel,
-		closeDone:             make(chan struct{}),
+		store:                  store,
+		server:                 server,
+		broadcaster:            broadcaster,
+		hookSink:               hookSink,
+		federationWake:         federationWake,
+		gitHubSyncWake:         gitHubSyncWake,
+		gitHubSyncFetcher:      gitHubSyncFetcher,
+		federationCredentials:  federationCredentials,
+		logger:                 logger,
+		hostAccessEnabled:      cfg.Access != nil,
+		workerTransactionFence: cfg.WorkerTransactionFence,
+		lifetimeCtx:            lifetimeCtx,
+		lifetimeCancel:         lifetimeCancel,
+		closeDone:              make(chan struct{}),
 	}, nil
 }
 
@@ -375,6 +381,9 @@ func (s *Service) Run(ctx context.Context) error {
 	if ctx == nil {
 		return errors.New("kata: run context is required")
 	}
+	if s.hostAccessEnabled && s.workerTransactionFence == nil {
+		return errors.New("kata: worker transaction fence is required with host access")
+	}
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
@@ -385,6 +394,23 @@ func (s *Service) Run(ctx context.Context) error {
 		return errors.New("kata: service is already running")
 	}
 	runCtx, cancel := context.WithCancel(ctx)
+	workerFenceFailures := make(chan error, 1)
+	var reportWorkerFenceFailure sync.Once
+	if s.workerTransactionFence != nil {
+		runCtx = db.WithTransactionFence(runCtx, func(
+			fenceCtx context.Context,
+			transaction db.Transaction,
+		) error {
+			err := s.workerTransactionFence(fenceCtx, transaction)
+			if err != nil {
+				reportWorkerFenceFailure.Do(func() {
+					workerFenceFailures <- err
+					cancel()
+				})
+			}
+			return err
+		})
+	}
 	done := make(chan struct{})
 	s.running = true
 	s.runCancel = cancel
@@ -467,14 +493,25 @@ func (s *Service) Run(ctx context.Context) error {
 	go func() { workerErrs <- sweeper.Run(runCtx) }()
 
 	workerResults := make([]error, 0, 3)
+	var workerFenceFailure error
 	select {
 	case <-runCtx.Done():
+	case workerFenceFailure = <-workerFenceFailures:
 	case err := <-workerErrs:
 		workerResults = append(workerResults, err)
 	}
 	cancel()
 	for len(workerResults) < 3 {
 		workerResults = append(workerResults, <-workerErrs)
+	}
+	if workerFenceFailure == nil {
+		select {
+		case workerFenceFailure = <-workerFenceFailures:
+		default:
+		}
+	}
+	if workerFenceFailure != nil {
+		return fmt.Errorf("kata: worker transaction fence: %w", workerFenceFailure)
 	}
 	if runCtx.Err() != nil && (ctx.Err() != nil || s.isClosed()) {
 		return nil

--- a/service_access_postgres_test.go
+++ b/service_access_postgres_test.go
@@ -1,0 +1,69 @@
+package kata_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+func TestServicePostgresTransactionFenceRollsBackWithMutation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	t.Cleanup(cleanup)
+
+	controller := &recordingAccessController{}
+	controller.transactionFence = func(ctx context.Context, tx kata.Transaction) error {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO kata.fence_markers(attempt) VALUES($1)`, 1); err != nil {
+			return err
+		}
+		return kata.ErrAccessDenied
+	}
+	service, err := kata.New(ctx, kata.Config{
+		DSN: dsn, Access: controller,
+		Postgres: kata.PostgresConfig{Schema: "kata", SchemaMode: kata.PostgresSchemaBootstrap},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	project, err := service.EnsureProject(ctx, kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EX", Name: "example-project",
+	})
+	require.NoError(t, err)
+
+	inspection, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inspection.Close()) })
+	_, err = inspection.ExecContext(ctx,
+		`CREATE TABLE kata.fence_markers (attempt BIGINT NOT NULL)`)
+	require.NoError(t, err)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues",
+		bytes.NewBufferString(`{"actor":"ignored","title":"must roll back"}`))
+	request.Header.Set("Content-Type", "application/json")
+	request = request.WithContext(kata.WithPrincipal(request.Context(), kata.Principal{
+		Subject: "user-123", Actor: "Example User",
+	}))
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusNotFound, response.Code)
+	var markerCount, issueCount int
+	require.NoError(t, inspection.QueryRowContext(ctx,
+		`SELECT count(*) FROM kata.fence_markers`).Scan(&markerCount))
+	require.NoError(t, inspection.QueryRowContext(ctx,
+		`SELECT count(*) FROM kata.issues WHERE title = $1`, "must roll back").Scan(&issueCount))
+	assert.Zero(t, markerCount)
+	assert.Zero(t, issueCount)
+}

--- a/service_access_test.go
+++ b/service_access_test.go
@@ -107,8 +107,115 @@ func TestServiceAccessControllerDeniesWithoutDisclosingProjectData(t *testing.T)
 		Method:     http.MethodGet,
 		Path:       "/api/v1/projects/{project_id}",
 		PathParams: map[string]string{"project_id": "42"},
+		Policy: kata.OperationPolicy{
+			Kind: kata.OperationProjectRead, Capability: kata.CapabilityRead,
+		},
 		ProjectIDs: []int64{42},
 	}, controller.snapshot()[0].Operation)
+}
+
+func TestServiceAccessControllerReceivesOperationPolicy(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	project, err := service.EnsureProject(context.Background(), kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EX", Name: "example-project",
+	})
+	require.NoError(t, err)
+
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	serve := func(method, target string, body []byte) *httptest.ResponseRecorder {
+		request := httptest.NewRequest(method, target, bytes.NewReader(body))
+		if len(body) > 0 {
+			request.Header.Set("Content-Type", "application/json")
+		}
+		request = request.WithContext(kata.WithPrincipal(request.Context(), principal))
+		response := httptest.NewRecorder()
+		service.Handler().ServeHTTP(response, request)
+		return response
+	}
+
+	response := serve(http.MethodGet,
+		"/api/v1/projects/"+strconv.FormatInt(project.Project.ID, 10)+"/issues", nil)
+	require.Equal(t, http.StatusOK, response.Code)
+	response = serve(http.MethodPost,
+		"/api/v1/projects/"+strconv.FormatInt(project.Project.ID, 10)+"/issues",
+		[]byte(`{"actor":"ignored","title":"Classified task mutation"}`))
+	require.Equal(t, http.StatusOK, response.Code)
+	response = serve(http.MethodGet, "/api/v1/tokens", nil)
+	require.Equal(t, http.StatusForbidden, response.Code)
+
+	requests := controller.snapshot()
+	require.Len(t, requests, 3)
+	assert.Equal(t, kata.OperationPolicy{
+		Kind: kata.OperationTaskRead, Capability: kata.CapabilityRead,
+	}, requests[0].Operation.Policy)
+	assert.Equal(t, kata.OperationPolicy{
+		Kind: kata.OperationTaskMutation, Capability: kata.CapabilityWrite, Mutation: true,
+	}, requests[1].Operation.Policy)
+	assert.Equal(t, kata.OperationPolicy{
+		Kind: kata.OperationTokenAdministration, Capability: kata.CapabilityManage,
+	}, requests[2].Operation.Policy)
+}
+
+func TestRestrictedEmbeddingProfileDeniesNativeAdministration(t *testing.T) {
+	controller := &recordingAccessController{}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+		Profile: kata.EmbeddingProfileRestricted,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	project, err := service.EnsureProject(context.Background(), kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EX", Name: "example-project",
+	})
+	require.NoError(t, err)
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	serve := func(method, target string) *httptest.ResponseRecorder {
+		request := httptest.NewRequest(method, target, nil)
+		request = request.WithContext(kata.WithPrincipal(request.Context(), principal))
+		response := httptest.NewRecorder()
+		service.Handler().ServeHTTP(response, request)
+		return response
+	}
+
+	for _, request := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/projects"},
+		{http.MethodGet, "/api/v1/tokens"},
+		{http.MethodPost, "/api/v1/federation/enrollments"},
+		{http.MethodPost, "/api/v1/projects/" + strconv.FormatInt(project.Project.ID, 10) +
+			"/issue-sync/github/enable"},
+	} {
+		response := serve(request.method, request.path)
+		assert.Equal(t, http.StatusNotFound, response.Code, "%s %s", request.method, request.path)
+		assert.JSONEq(t, `{"status":404,"error":{"code":"not_found","message":"resource not found"}}`,
+			response.Body.String())
+	}
+
+	response := serve(http.MethodGet,
+		"/api/v1/projects/"+strconv.FormatInt(project.Project.ID, 10)+"/issues")
+	assert.Equal(t, http.StatusOK, response.Code)
+	requests := controller.snapshot()
+	require.Len(t, requests, 1, "restricted operations must fail before host authorization")
+	assert.Equal(t, "listIssues", requests[0].Operation.ID)
+}
+
+func TestNewRejectsUnknownEmbeddingProfile(t *testing.T) {
+	_, err := kata.New(context.Background(), kata.Config{
+		DSN:     filepath.Join(t.TempDir(), "service.db"),
+		Auth:    kata.AuthConfig{TrustCallerAuthentication: true},
+		Profile: kata.EmbeddingProfile("unknown"),
+	})
+	require.EqualError(t, err, `kata: unknown embedding profile "unknown"`)
 }
 
 func TestServiceAccessControllerSuppliesTheMutationActor(t *testing.T) {
@@ -346,6 +453,9 @@ func TestServiceAccessControllerProtectsTheOpenAPIDocument(t *testing.T) {
 	assert.Equal(t, kata.Operation{
 		ID: "openAPI", Method: http.MethodGet, Path: "/openapi.yaml",
 		PathParams: map[string]string{},
+		Policy: kata.OperationPolicy{
+			Kind: kata.OperationServiceRead, Capability: kata.CapabilityRead,
+		},
 	}, requests[0].Operation)
 }
 

--- a/service_access_test.go
+++ b/service_access_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -21,11 +22,13 @@ import (
 )
 
 type recordingAccessController struct {
-	mu        sync.Mutex
-	requests  []kata.AccessRequest
-	err       error
-	lease     kata.AccessLease
-	authorize func(kata.AccessRequest) error
+	mu                   sync.Mutex
+	requests             []kata.AccessRequest
+	err                  error
+	lease                kata.AccessLease
+	transactionFence     kata.TransactionFence
+	omitTransactionFence bool
+	authorize            func(kata.AccessRequest) error
 }
 
 func (c *recordingAccessController) Authorize(
@@ -36,6 +39,10 @@ func (c *recordingAccessController) Authorize(
 	defer c.mu.Unlock()
 	c.requests = append(c.requests, request)
 	decision := kata.AccessDecision{}
+	decision.TransactionFence = c.transactionFence
+	if decision.TransactionFence == nil && !c.omitTransactionFence {
+		decision.TransactionFence = func(context.Context, kata.Transaction) error { return nil }
+	}
 	if request.Operation.ID == "streamEvents" {
 		decision.Lease = c.lease
 	}
@@ -43,6 +50,132 @@ func (c *recordingAccessController) Authorize(
 		return decision, c.authorize(request)
 	}
 	return decision, c.err
+}
+
+func TestServiceMutationFailsClosedWithoutTransactionFence(t *testing.T) {
+	controller := &recordingAccessController{omitTransactionFence: true}
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: filepath.Join(t.TempDir(), "service.db"), Access: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	project, err := service.EnsureProject(context.Background(), kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EX", Name: "example-project",
+	})
+	require.NoError(t, err)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues",
+		bytes.NewBufferString(`{"actor":"ignored","title":"must not be stored"}`))
+	request.Header.Set("Content-Type", "application/json")
+	request = request.WithContext(kata.WithPrincipal(request.Context(), kata.Principal{
+		Subject: "user-123", Actor: "Example User",
+	}))
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusServiceUnavailable, response.Code)
+	assert.JSONEq(t,
+		`{"status":503,"error":{"code":"access_unavailable","message":"transaction access decision unavailable"}}`,
+		response.Body.String())
+
+	listRequest := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(project.Project.ID, 10)+"/issues", nil)
+	listRequest = listRequest.WithContext(kata.WithPrincipal(listRequest.Context(), kata.Principal{
+		Subject: "user-123", Actor: "Example User",
+	}))
+	listed := httptest.NewRecorder()
+	service.Handler().ServeHTTP(listed, listRequest)
+	require.Equal(t, http.StatusOK, listed.Code)
+	assert.NotContains(t, listed.Body.String(), "must not be stored")
+}
+
+func TestServiceTransactionFenceSharesMutationCommitAndRollback(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "service.db")
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var attempts atomic.Int64
+	controller := &recordingAccessController{}
+	controller.transactionFence = func(ctx context.Context, tx kata.Transaction) error {
+		attempt := attempts.Add(1)
+		_, err := tx.ExecContext(ctx, `INSERT INTO fence_markers(attempt) VALUES(?)`, attempt)
+		if err != nil {
+			return err
+		}
+		if attempt == 1 {
+			entered <- struct{}{}
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return kata.ErrAccessDenied
+	}
+	service, err := kata.New(context.Background(), kata.Config{DSN: databasePath, Access: controller})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	project, err := service.EnsureProject(context.Background(), kata.ProjectSpec{
+		UID: "01HZNQ7VFPK1XGD8R5MABCD4EX", Name: "example-project",
+	})
+	require.NoError(t, err)
+
+	inspection, err := sql.Open("sqlite", databasePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inspection.Close()) })
+	_, err = inspection.Exec(`CREATE TABLE fence_markers (attempt INTEGER NOT NULL)`)
+	require.NoError(t, err)
+
+	principal := kata.Principal{Subject: "user-123", Actor: "Example User"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		service.Handler().ServeHTTP(w, r.WithContext(kata.WithPrincipal(r.Context(), principal)))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	create := func(title string) (*http.Response, error) {
+		body := bytes.NewBufferString(`{"actor":"ignored","title":` + strconv.Quote(title) + `}`)
+		return http.Post(server.URL+"/api/v1/projects/"+
+			strconv.FormatInt(project.Project.ID, 10)+"/issues", "application/json", body)
+	}
+
+	firstResponse := make(chan *http.Response, 1)
+	firstError := make(chan error, 1)
+	go func() {
+		response, requestErr := create("committed after fence")
+		firstResponse <- response
+		firstError <- requestErr
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "transaction fence was not reached")
+	}
+	var issuesBeforeRelease int
+	require.NoError(t, inspection.QueryRow(
+		`SELECT count(*) FROM issues WHERE title = ?`, "committed after fence").Scan(&issuesBeforeRelease))
+	assert.Zero(t, issuesBeforeRelease, "domain write must not run before the transaction fence")
+	close(release)
+	require.NoError(t, <-firstError)
+	committed := <-firstResponse
+	require.NotNil(t, committed)
+	defer func() { _ = committed.Body.Close() }()
+	require.Equal(t, http.StatusOK, committed.StatusCode)
+
+	rejected, err := create("rolled back with fence")
+	require.NoError(t, err)
+	defer func() { _ = rejected.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, rejected.StatusCode)
+
+	var markerCount, committedIssues, rejectedIssues int
+	require.NoError(t, inspection.QueryRow(`SELECT count(*) FROM fence_markers`).Scan(&markerCount))
+	require.NoError(t, inspection.QueryRow(
+		`SELECT count(*) FROM issues WHERE title = ?`, "committed after fence").Scan(&committedIssues))
+	require.NoError(t, inspection.QueryRow(
+		`SELECT count(*) FROM issues WHERE title = ?`, "rolled back with fence").Scan(&rejectedIssues))
+	assert.Equal(t, 1, markerCount, "rejected fence work must roll back with the domain transaction")
+	assert.Equal(t, 1, committedIssues)
+	assert.Zero(t, rejectedIssues)
 }
 
 type revocableAccessLease struct {

--- a/service_worker_fence_postgres_test.go
+++ b/service_worker_fence_postgres_test.go
@@ -1,0 +1,83 @@
+package kata
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+func TestServicePostgresWorkerTransactionFenceRollsBackAndStopsWorkers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	t.Cleanup(cleanup)
+	rejected := errors.New("worker transaction rejected")
+	service, err := New(ctx, Config{
+		DSN:      dsn,
+		Postgres: PostgresConfig{Schema: "kata", SchemaMode: PostgresSchemaBootstrap},
+		Access:   allowWorkerFenceAccess{},
+		WorkerTransactionFence: func(ctx context.Context, tx Transaction) error {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO kata.worker_fence_markers(attempt) VALUES($1)`, 1); err != nil {
+				return err
+			}
+			return rejected
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	project, err := service.store.CreateProject(ctx, "worker-project")
+	require.NoError(t, err)
+	_, err = service.store.EnableProjectFederation(ctx, project.ID, "worker")
+	require.NoError(t, err)
+	issue, _, err := service.store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "expired claim", Author: "worker",
+	})
+	require.NoError(t, err)
+	_, err = service.store.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: project.ID,
+		IssueRef:  issue.ShortID,
+		Principal: db.ClaimPrincipal{
+			HolderInstanceUID: service.store.InstanceUID(),
+			Holder:            "worker",
+			ClientKind:        "test",
+		},
+		ClaimKind: "timed",
+		TTL:       time.Minute,
+		Now:       time.Now().UTC().Add(-2 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	inspection, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inspection.Close()) })
+	_, err = inspection.ExecContext(ctx,
+		`CREATE TABLE kata.worker_fence_markers (attempt BIGINT NOT NULL)`)
+	require.NoError(t, err)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- service.Run(ctx) }()
+	select {
+	case runErr := <-runDone:
+		require.ErrorIs(t, runErr, rejected)
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "worker fence rejection did not stop the service workers")
+	}
+
+	var markerCount, released int
+	require.NoError(t, inspection.QueryRowContext(ctx,
+		`SELECT count(*) FROM kata.worker_fence_markers`).Scan(&markerCount))
+	require.NoError(t, inspection.QueryRowContext(ctx,
+		`SELECT CASE WHEN released_at IS NOT NULL THEN 1 ELSE 0 END
+		   FROM kata.issue_claims WHERE issue_uid = $1`, issue.UID).Scan(&released))
+	assert.Zero(t, markerCount)
+	assert.Zero(t, released)
+}

--- a/service_worker_fence_test.go
+++ b/service_worker_fence_test.go
@@ -1,0 +1,97 @@
+package kata
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+)
+
+type allowWorkerFenceAccess struct{}
+
+func (allowWorkerFenceAccess) Authorize(context.Context, AccessRequest) (AccessDecision, error) {
+	return AccessDecision{TransactionFence: func(context.Context, Transaction) error { return nil }}, nil
+}
+
+func TestServiceWorkerTransactionFenceRollsBackAndStopsWorkers(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "service.db")
+	rejected := errors.New("worker transaction rejected")
+	service, err := New(ctx, Config{
+		DSN:    databasePath,
+		Access: allowWorkerFenceAccess{},
+		WorkerTransactionFence: func(ctx context.Context, tx Transaction) error {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO worker_fence_markers(attempt) VALUES(?)`, 1); err != nil {
+				return err
+			}
+			return rejected
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	project, err := service.store.CreateProject(ctx, "worker-project")
+	require.NoError(t, err)
+	_, err = service.store.EnableProjectFederation(ctx, project.ID, "worker")
+	require.NoError(t, err)
+	issue, _, err := service.store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "expired claim", Author: "worker",
+	})
+	require.NoError(t, err)
+	_, err = service.store.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: project.ID,
+		IssueRef:  issue.ShortID,
+		Principal: db.ClaimPrincipal{
+			HolderInstanceUID: service.store.InstanceUID(),
+			Holder:            "worker",
+			ClientKind:        "test",
+		},
+		ClaimKind: "timed",
+		TTL:       time.Minute,
+		Now:       time.Now().UTC().Add(-2 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	inspection, err := sql.Open("sqlite", databasePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inspection.Close()) })
+	_, err = inspection.ExecContext(ctx,
+		`CREATE TABLE worker_fence_markers (attempt INTEGER NOT NULL)`)
+	require.NoError(t, err)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- service.Run(ctx) }()
+	select {
+	case runErr := <-runDone:
+		require.ErrorIs(t, runErr, rejected)
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "worker fence rejection did not stop the service workers")
+	}
+
+	var markerCount, released int
+	require.NoError(t, inspection.QueryRowContext(ctx,
+		`SELECT count(*) FROM worker_fence_markers`).Scan(&markerCount))
+	require.NoError(t, inspection.QueryRowContext(ctx,
+		`SELECT released_at IS NOT NULL FROM issue_claims WHERE issue_uid = ?`, issue.UID).Scan(&released))
+	assert.Zero(t, markerCount)
+	assert.Zero(t, released)
+}
+
+func TestServiceRunRequiresWorkerFenceWithHostAccess(t *testing.T) {
+	service, err := New(context.Background(), Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: allowWorkerFenceAccess{},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	err = service.Run(context.Background())
+	assert.EqualError(t, err, "kata: worker transaction fence is required with host access")
+}

--- a/service_worker_fence_test.go
+++ b/service_worker_fence_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -37,27 +38,7 @@ func TestServiceWorkerTransactionFenceRollsBackAndStopsWorkers(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, service.Close()) })
 
-	project, err := service.store.CreateProject(ctx, "worker-project")
-	require.NoError(t, err)
-	_, err = service.store.EnableProjectFederation(ctx, project.ID, "worker")
-	require.NoError(t, err)
-	issue, _, err := service.store.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: project.ID, Title: "expired claim", Author: "worker",
-	})
-	require.NoError(t, err)
-	_, err = service.store.AcquireClaim(ctx, db.AcquireClaimParams{
-		ProjectID: project.ID,
-		IssueRef:  issue.ShortID,
-		Principal: db.ClaimPrincipal{
-			HolderInstanceUID: service.store.InstanceUID(),
-			Holder:            "worker",
-			ClientKind:        "test",
-		},
-		ClaimKind: "timed",
-		TTL:       time.Minute,
-		Now:       time.Now().UTC().Add(-2 * time.Minute),
-	})
-	require.NoError(t, err)
+	issue := seedExpiredWorkerClaim(ctx, t, service)
 
 	inspection, err := sql.Open("sqlite", databasePath)
 	require.NoError(t, err)
@@ -82,6 +63,106 @@ func TestServiceWorkerTransactionFenceRollsBackAndStopsWorkers(t *testing.T) {
 		`SELECT released_at IS NOT NULL FROM issue_claims WHERE issue_uid = ?`, issue.UID).Scan(&released))
 	assert.Zero(t, markerCount)
 	assert.Zero(t, released)
+}
+
+func TestServiceRunTreatsCanceledInFlightWorkerFenceAsCleanShutdown(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		close bool
+	}{
+		{name: "caller cancellation"},
+		{name: "service close", close: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			fenceStarted := make(chan struct{})
+			var startOnce sync.Once
+			service, err := New(ctx, Config{
+				DSN:    filepath.Join(t.TempDir(), "service.db"),
+				Access: allowWorkerFenceAccess{},
+				WorkerTransactionFence: func(ctx context.Context, _ Transaction) error {
+					startOnce.Do(func() { close(fenceStarted) })
+					<-ctx.Done()
+					return ctx.Err()
+				},
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+			seedExpiredWorkerClaim(ctx, t, service)
+
+			runCtx, cancelRun := context.WithCancel(ctx)
+			defer cancelRun()
+			runDone := make(chan error, 1)
+			go func() { runDone <- service.Run(runCtx) }()
+			select {
+			case <-fenceStarted:
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "worker did not enter transaction fence")
+			}
+
+			closeDone := make(chan error, 1)
+			if testCase.close {
+				go func() { closeDone <- service.Close() }()
+			} else {
+				cancelRun()
+			}
+			select {
+			case runErr := <-runDone:
+				require.NoError(t, runErr)
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "Run did not stop after cancellation")
+			}
+			if testCase.close {
+				require.NoError(t, <-closeDone)
+			}
+		})
+	}
+}
+
+func TestServiceRunReportsWorkerInitiatedContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	service, err := New(ctx, Config{
+		DSN:    filepath.Join(t.TempDir(), "service.db"),
+		Access: allowWorkerFenceAccess{},
+		WorkerTransactionFence: func(context.Context, Transaction) error {
+			return context.Canceled
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	seedExpiredWorkerClaim(ctx, t, service)
+
+	runErr := service.Run(ctx)
+
+	require.ErrorIs(t, runErr, context.Canceled)
+	assert.ErrorContains(t, runErr, "worker transaction fence")
+}
+
+func seedExpiredWorkerClaim(ctx context.Context, t *testing.T, service *Service) db.Issue {
+	t.Helper()
+	project, err := service.store.CreateProject(ctx, "worker-project")
+	require.NoError(t, err)
+	_, err = service.store.EnableProjectFederation(ctx, project.ID, "worker")
+	require.NoError(t, err)
+	issue, _, err := service.store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "expired claim", Author: "worker",
+	})
+	require.NoError(t, err)
+	_, err = service.store.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: project.ID,
+		IssueRef:  issue.ShortID,
+		Principal: db.ClaimPrincipal{
+			HolderInstanceUID: service.store.InstanceUID(),
+			Holder:            "worker",
+			ClientKind:        "test",
+		},
+		ClaimKind: "timed",
+		TTL:       time.Minute,
+		Now:       time.Now().UTC().Add(-2 * time.Minute),
+	})
+	require.NoError(t, err)
+	return issue
 }
 
 func TestServiceRunRequiresWorkerFenceWithHostAccess(t *testing.T) {


### PR DESCRIPTION
Applications that mount Kata inside a larger service often already own identity, authorization, and administrative lifecycle. Before this change, each host had to infer permissions from route names, and authorization happened only before dispatch. That made new routes easy to overlook and left a race where authority could change while a write or background worker transaction was still in flight.

This gives every registered operation a deny-by-default, product-neutral policy using read, write, manage, and federate capabilities. A restricted embedding profile removes native project, credential, federation-enrollment, and external-sync administration when the surrounding application owns those concerns, while the default standalone surface remains unchanged.

For mutation safety, the host can revalidate authority from inside the exact writable SQLite or PostgreSQL transaction used by Kata. The callback and domain write commit or roll back together. The same boundary covers federation, synchronization, and timed-claim workers; a rejected worker fence stops the worker group instead of becoming an indefinite logged retry. Explicitly read-only snapshots remain outside the mutation fence.

This changes no persisted schema. Real SQLite and PostgreSQL coverage proves commit and rollback behavior, operation registration is checked for complete policy metadata, and the standard Go, lint, vet, and documentation gates pass.