### PR TITLE
Honor repeated query filter values

### DIFF
--- a/cmd/kata/list_test.go
+++ b/cmd/kata/list_test.go
@@ -44,6 +44,33 @@ func TestList_DefaultsToOpenIssuesInProject(t *testing.T) {
 	assert.Contains(t, out, "beta")
 }
 
+func TestList_RepeatedLabelFiltersRequireEveryLabel(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	alphaOnly := createIssue(t, env, pid, "alpha only")
+	alphaBeta := createIssue(t, env, pid, "alpha beta")
+	runCLI(t, env, dir, "label", "add", alphaOnly, "alpha")
+	runCLI(t, env, dir, "label", "add", alphaBeta, "alpha")
+	runCLI(t, env, dir, "label", "add", alphaBeta, "beta")
+
+	out := runCLI(t, env, dir, "list", "--label", "alpha", "--label", "beta")
+	assert.Contains(t, out, "alpha beta")
+	assert.NotContains(t, out, "alpha only")
+}
+
+func TestList_RepeatedNoLabelFiltersExcludeEveryLabel(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	alpha := createIssue(t, env, pid, "alpha candidate")
+	beta := createIssue(t, env, pid, "beta candidate")
+	createIssue(t, env, pid, "plain candidate")
+	runCLI(t, env, dir, "label", "add", alpha, "alpha")
+	runCLI(t, env, dir, "label", "add", beta, "beta")
+
+	out := runCLI(t, env, dir, "list", "--no-label", "alpha", "--no-label", "beta")
+	assert.Contains(t, out, "plain candidate")
+	assert.NotContains(t, out, "alpha candidate")
+	assert.NotContains(t, out, "beta candidate")
+}
+
 // TestList_HumanRowUsesGlyphLayout pins the new row renderer's layout: an
 // open issue renders the open glyph "○ " ahead of its title, replacing the
 // old "%-8s  %-8s" column format.

--- a/cmd/kata/metadata_cli_test.go
+++ b/cmd/kata/metadata_cli_test.go
@@ -62,6 +62,18 @@ func TestList_MetaFilterPresence(t *testing.T) {
 	assert.NotContains(t, out, "unbranched")
 }
 
+func TestList_RepeatedMetaFiltersRequireEveryMatch(t *testing.T) {
+	env, dir, _ := setupCLIWorkspace(t)
+	_ = runCLI(t, env, dir, "--quiet", "create", "matching metadata",
+		"--meta", "team=core", "--meta", "tier=one")
+	_ = runCLI(t, env, dir, "--quiet", "create", "partial metadata",
+		"--meta", "team=core")
+
+	out := runCLI(t, env, dir, "list", "--meta", "team=core", "--meta", "tier=one")
+	assert.Contains(t, out, "matching metadata")
+	assert.NotContains(t, out, "partial metadata")
+}
+
 // TestShow_HumanRendersMetadataSection pins the human-mode metadata section.
 func TestShow_HumanRendersMetadataSection(t *testing.T) {
 	env, dir, _ := setupCLIWorkspace(t)

--- a/cmd/kata/ready_test.go
+++ b/cmd/kata/ready_test.go
@@ -43,6 +43,33 @@ func TestReady_FiltersBlocked(t *testing.T) {
 		"blocked is hidden while blocker is open")
 }
 
+func TestReady_RepeatedLabelFiltersRequireEveryLabel(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	alphaOnly := createIssue(t, env, pid, "alpha only")
+	alphaBeta := createIssue(t, env, pid, "alpha beta")
+	runCLI(t, env, dir, "label", "add", alphaOnly, "alpha")
+	runCLI(t, env, dir, "label", "add", alphaBeta, "alpha")
+	runCLI(t, env, dir, "label", "add", alphaBeta, "beta")
+
+	out := runCLI(t, env, dir, "ready", "--label", "alpha", "--label", "beta")
+	assert.Contains(t, out, "alpha beta")
+	assert.NotContains(t, out, "alpha only")
+}
+
+func TestReady_RepeatedNoLabelFiltersExcludeEveryLabel(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	alpha := createIssue(t, env, pid, "alpha candidate")
+	beta := createIssue(t, env, pid, "beta candidate")
+	createIssue(t, env, pid, "plain candidate")
+	runCLI(t, env, dir, "label", "add", alpha, "alpha")
+	runCLI(t, env, dir, "label", "add", beta, "beta")
+
+	out := runCLI(t, env, dir, "ready", "--no-label", "alpha", "--no-label", "beta")
+	assert.Contains(t, out, "plain candidate")
+	assert.NotContains(t, out, "alpha candidate")
+	assert.NotContains(t, out, "beta candidate")
+}
+
 func TestReady_AgentOutputRowsOmitAbsentOwner(t *testing.T) {
 	env, dir, pid := setupCLIWorkspace(t)
 	createIssue(t, env, pid, "ready unowned")

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -394,13 +394,13 @@ type ListIssuesRequest struct {
 	Limit         int      `query:"limit,omitempty"`
 	Unowned       bool     `query:"unowned,omitempty"`
 	Owner         string   `query:"owner,omitempty"`
-	Labels        []string `query:"label,omitempty"`
-	ExcludeLabels []string `query:"exclude_label,omitempty"`
+	Labels        []string `query:"label,explode"`
+	ExcludeLabels []string `query:"exclude_label,explode"`
 	// Meta is a repeatable metadata filter. Each entry is "key" (key present
 	// in top-level metadata) or "key=value" (the key's JSON string value
 	// equals value); split on the FIRST "=". Multiple entries AND together.
 	// An empty key is a validation error.
-	Meta []string `query:"meta,omitempty"`
+	Meta []string `query:"meta,explode"`
 }
 
 // ListAllIssuesRequest is GET /api/v1/issues — the cross-project list. The
@@ -968,8 +968,8 @@ type ReadyRequest struct {
 	Limit         int      `query:"limit,omitempty"`
 	Unowned       bool     `query:"unowned,omitempty"`
 	Owner         string   `query:"owner,omitempty"`
-	Labels        []string `query:"label,omitempty"`
-	ExcludeLabels []string `query:"exclude_label,omitempty"`
+	Labels        []string `query:"label,explode"`
+	ExcludeLabels []string `query:"exclude_label,explode"`
 }
 
 // ReadyResponse is the ready-issue list. Rows are hydrated IssueOuts so
@@ -1052,7 +1052,7 @@ type PurgeResponse struct {
 type DigestRequest struct {
 	Since  string   `query:"since" required:"true"`
 	Until  string   `query:"until,omitempty"`
-	Actors []string `query:"actor,omitempty"`
+	Actors []string `query:"actor,explode"`
 }
 
 // DigestProjectRequest is the per-project variant. Only the path param differs.
@@ -1060,7 +1060,7 @@ type DigestProjectRequest struct {
 	ProjectID int64    `path:"project_id" required:"true"`
 	Since     string   `query:"since" required:"true"`
 	Until     string   `query:"until,omitempty"`
-	Actors    []string `query:"actor,omitempty"`
+	Actors    []string `query:"actor,explode"`
 }
 
 // DigestTotals is the per-actor and grand-total breakdown of mutations the

--- a/internal/daemon/handlers_digest_test.go
+++ b/internal/daemon/handlers_digest_test.go
@@ -175,6 +175,25 @@ func TestDigest_ActorFilter(t *testing.T) {
 	assert.Equal(t, "alice", body.Actors[0].Actor)
 }
 
+func TestDigest_RepeatedActorFiltersIncludeEveryActor(t *testing.T) {
+	env := testenv.New(t)
+	pid := initLocalWorkspace(t, env, "kata")
+	createIssueAs(t, env, pid, "alice", "alice issue")
+	createIssueAs(t, env, pid, "bob", "bob issue")
+	createIssueAs(t, env, pid, "carol", "carol issue")
+
+	q := url.Values{}
+	q.Set("since", rfc3339Offset(-time.Hour))
+	q.Add("actor", "alice")
+	q.Add("actor", "bob")
+	var body digestBody
+	envGetJSON(t, env, projectPath(pid)+"/digest?"+q.Encode(), &body)
+
+	require.Len(t, body.Actors, 2)
+	assert.Equal(t, "alice", body.Actors[0].Actor)
+	assert.Equal(t, "bob", body.Actors[1].Actor)
+}
+
 // TestDigest_CountsCreateTimeLabelsOwnerLinks ensures that initial labels,
 // owner, and links supplied at issue creation are folded into digest totals
 // and per-issue actions. CreateIssue does not emit separate


### PR DESCRIPTION
Repeatable list and ready filters were accepted and emitted as repeated query parameters, but daemon decoding discarded every occurrence after the first. That made the documented AND and exclusion semantics unreliable, including through `next`, and affected repeatable digest actor selection built on the same contract.

Opt the repeated array parameters into Huma exploded query decoding and add end-to-end coverage for label, exclusion, metadata, and actor filters. This preserves values verbatim instead of joining them, which matters for metadata filters that may contain commas.

Closes #189