### PR TITLE
Expose federation enrollment lifecycle to mounted services

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 ## Unreleased
 
+**New features**
+
+- Added project-scoped federation enrollment creation, history, and revocation
+  methods to the mountable Go service for hosts that use the restricted
+  embedding profile.
+
 ## 0.12.0
 <small>2026-07-20</small>
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -309,10 +309,11 @@ created, err := service.CreateFederationEnrollment(ctx, kata.FederationEnrollmen
 })
 ```
 
-Creation enables hub federation for the active project when necessary. Kata
-generates the bearer secret, stores only its hash, and returns the plaintext in
-`created.Token` exactly once. `ListFederationEnrollments` returns retained
-history for one stable project UID without either form of the secret.
+Creation atomically enables hub federation for the active project when
+necessary. Kata generates the bearer secret, stores only its hash, and returns
+the plaintext in `created.Token` exactly once. `ListFederationEnrollments`
+returns retained history for one stable project UID without either form of the
+secret.
 `RevokeFederationEnrollment` requires both the project UID and enrollment ID,
 so an ID from another project is not accepted; repeating an exact revocation is
 harmless. History remains listable and credentials remain revocable after a

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -293,6 +293,35 @@ requires an actor for the retained event history. These methods are in-process
 application methods: they do not authenticate a network caller and should be
 invoked only after the host has authorized its own catalog lifecycle change.
 
+## Host-managed federation enrollments
+
+Restricted embedding keeps Kata's scoped federation transport routes but
+removes its native enrollment-administration routes. After applying its own
+authorization policy, a host can issue a project-scoped transport credential
+directly through the service:
+
+```go
+created, err := service.CreateFederationEnrollment(ctx, kata.FederationEnrollmentSpec{
+	ProjectUID:       "01HZNQ7VFPK1XGD8R5MABCD4EX",
+	SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4EA",
+	Capabilities:     "pull,push,claim",
+	Actor:            "Example Operator",
+})
+```
+
+Creation enables hub federation for the active project when necessary. Kata
+generates the bearer secret, stores only its hash, and returns the plaintext in
+`created.Token` exactly once. `ListFederationEnrollments` returns retained
+history for one stable project UID without either form of the secret.
+`RevokeFederationEnrollment` requires both the project UID and enrollment ID,
+so an ID from another project is not accepted; repeating an exact revocation is
+harmless. History remains listable and credentials remain revocable after a
+project is archived, but archived projects cannot receive new enrollments.
+
+Like the project lifecycle methods, these are trusted in-process application
+methods rather than network authentication boundaries. The embedding host must
+authorize create, list, and revoke operations before calling them.
+
 ## Storage and PostgreSQL policy
 
 `Config.DSN` is required and accepts a bare SQLite path, a `sqlite://` URL, or a

--- a/internal/db/dbtest/conformance.go
+++ b/internal/db/dbtest/conformance.go
@@ -278,6 +278,7 @@ var storageScenarios = []scenario{
 			"ActiveFederationQuarantine", "ActiveFederationQuarantinesByProject",
 			"AdvanceFederationPullCursor", "AdvanceFederationPushCursor", "AuthorizeFederationToken",
 			"ClearFederationSyncError", "CloseIssueWithEvents", "CountActiveFederationEnrollments", "CreateFederationEnrollment",
+			"CreateProjectFederationEnrollment",
 			"CreateIssue", "CreateLink", "CreateProject", "EnableFederationPush", "ExportFederationBindings",
 			"ExportFederationEnrollments", "ExportFederationQuarantine", "ExportFederationSyncStatus",
 			"FederationBindingByProject", "FederationSyncStatusByProject", "ListFederationBindings",

--- a/internal/db/dbtest/conformance_federation.go
+++ b/internal/db/dbtest/conformance_federation.go
@@ -238,6 +238,39 @@ func checkFederationControlLifecycle(t *testing.T, store db.Storage) error {
 		return err
 	}
 	assert.Equal(t, "wildcard-enrollment-secret", wildcard.Token)
+	rollbackProject, err := store.CreateProject(ctx, "atomic-enrollment-rollback")
+	if err != nil {
+		return err
+	}
+	if _, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: rollbackProject.ID, Title: "must not become a baseline", Author: "member",
+	}); err != nil {
+		return err
+	}
+	eventsBeforeFailure, err := store.EventsAfter(ctx, db.EventsAfterParams{
+		ProjectID: rollbackProject.ID, Limit: 100,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = store.CreateProjectFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{
+		Token: "wildcard-enrollment-secret", SpokeInstanceUID: spokeUID,
+		ProjectID: &rollbackProject.ID, Capabilities: "pull", Actor: "member",
+	})
+	require.Error(t, err, "duplicate token must fail after federation enablement begins")
+	_, err = store.FederationBindingByProject(ctx, rollbackProject.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+	eventsAfterFailure, err := store.EventsAfter(ctx, db.EventsAfterParams{
+		ProjectID: rollbackProject.ID, Limit: 100,
+	})
+	if err != nil {
+		return err
+	}
+	assert.Equal(t, eventsBeforeFailure, eventsAfterFailure,
+		"failed enrollment must roll back federation baseline events")
+	_, err = store.AuthorizeFederationToken(ctx, wildcard.Token, rollbackProject.ID, "pull")
+	assert.ErrorIs(t, err, db.ErrNotFound,
+		"failed enrollment must not expose the project to an existing wildcard credential")
 	authorized, err := store.AuthorizeFederationToken(ctx, created.Token, hub.ID, "pull")
 	if err != nil {
 		return err

--- a/internal/db/federation_policy.go
+++ b/internal/db/federation_policy.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+
+	katauid "go.kenn.io/kata/internal/uid"
 )
 
 // NewFederationToken returns a cryptographically random enrollment secret.
@@ -14,6 +16,41 @@ func NewFederationToken() (string, error) {
 		return "", fmt.Errorf("generate federation token: %w", err)
 	}
 	return base64.RawURLEncoding.EncodeToString(value[:]), nil
+}
+
+// PrepareFederationEnrollmentParams generates missing secret material and
+// normalizes the backend-neutral enrollment contract before any transaction
+// mutates federation state.
+func PrepareFederationEnrollmentParams(
+	input CreateFederationEnrollmentParams,
+) (CreateFederationEnrollmentParams, error) {
+	if input.Token == "" {
+		token, err := NewFederationToken()
+		if err != nil {
+			return CreateFederationEnrollmentParams{}, err
+		}
+		input.Token = token
+	}
+	if !katauid.Valid(input.SpokeInstanceUID) {
+		return CreateFederationEnrollmentParams{}, fmt.Errorf(
+			"invalid spoke instance uid %q", input.SpokeInstanceUID,
+		)
+	}
+	capabilities, err := CanonicalFederationCapabilities(input.Capabilities)
+	if err != nil {
+		return CreateFederationEnrollmentParams{}, err
+	}
+	input.Capabilities = capabilities
+	input.Actor = strings.TrimSpace(input.Actor)
+	if err := ValidateTokenActor(input.Actor); err != nil {
+		return CreateFederationEnrollmentParams{}, fmt.Errorf("federation enrollment actor: %w", err)
+	}
+	if input.AllowAdoptionSnapshotAuthors && input.ProjectID == nil {
+		return CreateFederationEnrollmentParams{}, fmt.Errorf(
+			"allow adoption snapshot authors requires project-scoped enrollment",
+		)
+	}
+	return input, nil
 }
 
 // ValidateFederationQuarantine validates the portable poisoned-batch shape.

--- a/internal/db/pgstore/federation_control.go
+++ b/internal/db/pgstore/federation_control.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"go.kenn.io/kata/internal/db"
-	katauid "go.kenn.io/kata/internal/uid"
 )
 
 const federationBindingSelect = `SELECT project_id, role, hub_url, hub_project_id,
@@ -239,52 +238,70 @@ func (s *Store) CreateFederationEnrollment(
 	ctx context.Context,
 	input db.CreateFederationEnrollmentParams,
 ) (db.CreatedFederationEnrollment, error) {
-	if input.Token == "" {
-		token, err := db.NewFederationToken()
-		if err != nil {
-			return db.CreatedFederationEnrollment{}, err
-		}
-		input.Token = token
-	}
-	if !katauid.Valid(input.SpokeInstanceUID) {
-		return db.CreatedFederationEnrollment{}, fmt.Errorf("invalid spoke instance uid %q", input.SpokeInstanceUID)
-	}
-	capabilities, err := db.CanonicalFederationCapabilities(input.Capabilities)
+	prepared, err := db.PrepareFederationEnrollmentParams(input)
 	if err != nil {
 		return db.CreatedFederationEnrollment{}, err
-	}
-	actor := strings.TrimSpace(input.Actor)
-	if err := db.ValidateTokenActor(actor); err != nil {
-		return db.CreatedFederationEnrollment{}, fmt.Errorf("federation enrollment actor: %w", err)
-	}
-	if input.AllowAdoptionSnapshotAuthors && input.ProjectID == nil {
-		return db.CreatedFederationEnrollment{}, fmt.Errorf("allow adoption snapshot authors requires project-scoped enrollment")
-	}
-	var projectID any
-	if input.ProjectID != nil {
-		projectID = *input.ProjectID
 	}
 	var output db.CreatedFederationEnrollment
 	err = s.withSerializableTx(ctx, func(tx *sql.Tx) error {
 		output = db.CreatedFederationEnrollment{}
-		var id int64
-		err := tx.QueryRowContext(ctx, `INSERT INTO federation_enrollments(
+		var err error
+		output, err = createFederationEnrollmentTx(ctx, tx, prepared)
+		return err
+	})
+	return output, err
+}
+
+// CreateProjectFederationEnrollment enables one hub project and creates its
+// scoped enrollment in the same transaction.
+func (s *Store) CreateProjectFederationEnrollment(
+	ctx context.Context,
+	input db.CreateFederationEnrollmentParams,
+) (db.CreatedFederationEnrollment, error) {
+	prepared, err := db.PrepareFederationEnrollmentParams(input)
+	if err != nil {
+		return db.CreatedFederationEnrollment{}, err
+	}
+	if prepared.ProjectID == nil || *prepared.ProjectID <= 0 {
+		return db.CreatedFederationEnrollment{}, fmt.Errorf("project-scoped federation enrollment requires project id")
+	}
+	var output db.CreatedFederationEnrollment
+	err = s.withSerializableTx(ctx, func(tx *sql.Tx) error {
+		output = db.CreatedFederationEnrollment{}
+		if _, err := s.enableProjectFederationTx(ctx, tx, *prepared.ProjectID, prepared.Actor); err != nil {
+			return err
+		}
+		var err error
+		output, err = createFederationEnrollmentTx(ctx, tx, prepared)
+		return err
+	})
+	return output, err
+}
+
+func createFederationEnrollmentTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	input db.CreateFederationEnrollmentParams,
+) (db.CreatedFederationEnrollment, error) {
+	var projectID any
+	if input.ProjectID != nil {
+		projectID = *input.ProjectID
+	}
+	var id int64
+	err := tx.QueryRowContext(ctx, `INSERT INTO federation_enrollments(
   token_hash,spoke_instance_uid,project_id,capabilities,bound_actor,
   allow_adoption_snapshot_authors
 ) VALUES($1,$2,$3,$4,$5,$6) RETURNING id`, db.FederationTokenHash(input.Token),
-			input.SpokeInstanceUID, projectID, capabilities, actor,
-			boolNumber(input.AllowAdoptionSnapshotAuthors)).Scan(&id)
-		if err != nil {
-			return mapSQLError(err, nil)
-		}
-		enrollment, err := federationEnrollmentByIDTx(ctx, tx, id, false)
-		if err != nil {
-			return err
-		}
-		output = db.CreatedFederationEnrollment{Enrollment: enrollment, Token: input.Token}
-		return nil
-	})
-	return output, err
+		input.SpokeInstanceUID, projectID, input.Capabilities, input.Actor,
+		boolNumber(input.AllowAdoptionSnapshotAuthors)).Scan(&id)
+	if err != nil {
+		return db.CreatedFederationEnrollment{}, mapSQLError(err, nil)
+	}
+	enrollment, err := federationEnrollmentByIDTx(ctx, tx, id, false)
+	if err != nil {
+		return db.CreatedFederationEnrollment{}, err
+	}
+	return db.CreatedFederationEnrollment{Enrollment: enrollment, Token: input.Token}, nil
 }
 
 // ListFederationEnrollments returns enrollment history in identity order.

--- a/internal/db/pgstore/federation_projection.go
+++ b/internal/db/pgstore/federation_projection.go
@@ -23,55 +23,68 @@ func (s *Store) EnableProjectFederation(
 	var output db.FederationBinding
 	err := s.withSerializableTx(ctx, func(tx *sql.Tx) error {
 		output = db.FederationBinding{}
-		project, err := scanProject(tx.QueryRowContext(ctx,
-			projectSelect+` WHERE id=$1 AND deleted_at IS NULL FOR UPDATE`, projectID))
-		if err != nil {
-			return err
+		var err error
+		output, err = s.enableProjectFederationTx(ctx, tx, projectID, actor)
+		return err
+	})
+	return output, err
+}
+
+func (s *Store) enableProjectFederationTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectID int64,
+	actor string,
+) (db.FederationBinding, error) {
+	project, err := scanProject(tx.QueryRowContext(ctx,
+		projectSelect+` WHERE id=$1 AND deleted_at IS NULL FOR UPDATE`, projectID))
+	if err != nil {
+		return db.FederationBinding{}, err
+	}
+	existing, err := scanFederationBinding(tx.QueryRowContext(ctx,
+		federationBindingSelect+` WHERE project_id=$1 FOR UPDATE`, projectID))
+	if err == nil {
+		if existing.Role != db.FederationRoleHub {
+			return db.FederationBinding{}, fmt.Errorf("project %d already has %q federation binding", projectID, existing.Role)
 		}
-		existing, err := scanFederationBinding(tx.QueryRowContext(ctx,
-			federationBindingSelect+` WHERE project_id=$1 FOR UPDATE`, projectID))
-		if err == nil {
-			if existing.Role != db.FederationRoleHub {
-				return fmt.Errorf("project %d already has %q federation binding", projectID, existing.Role)
+		if existing.Enabled {
+			projectIDs, err := federationBindingGroupProjectIDs(ctx, tx, existing)
+			if err != nil {
+				return db.FederationBinding{}, err
 			}
-			if existing.Enabled {
-				projectIDs, err := federationBindingGroupProjectIDs(ctx, tx, existing)
-				if err != nil {
-					return err
-				}
-				if err := reconcileFederatedLinkGroup(ctx, tx, projectIDs, 0, nil); err != nil {
-					return err
-				}
+			if err := reconcileFederatedLinkGroup(ctx, tx, projectIDs, 0, nil); err != nil {
+				return db.FederationBinding{}, err
 			}
-			output = existing
-			return nil
 		}
-		if !errors.Is(err, db.ErrNotFound) {
-			return err
-		}
-		enableEvent, err := s.insertFederationBaselineEventsTx(ctx, tx, project, actor)
-		if err != nil {
-			return err
-		}
-		pullCursor := enableEvent.ID - 1
-		if pullCursor < 0 {
-			pullCursor = 0
-		}
-		if _, err := tx.ExecContext(ctx, `INSERT INTO federation_bindings(
+		return existing, nil
+	}
+	if !errors.Is(err, db.ErrNotFound) {
+		return db.FederationBinding{}, err
+	}
+	enableEvent, err := s.insertFederationBaselineEventsTx(ctx, tx, project, actor)
+	if err != nil {
+		return db.FederationBinding{}, err
+	}
+	pullCursor := enableEvent.ID - 1
+	if pullCursor < 0 {
+		pullCursor = 0
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO federation_bindings(
 project_id,role,hub_url,hub_project_id,hub_project_uid,
 replay_horizon_event_id,pull_cursor_event_id,enabled
 ) VALUES($1,$2,'',0,$3,$4,$5,1)`, project.ID, string(db.FederationRoleHub),
-			project.UID, enableEvent.ID, pullCursor); err != nil {
-			return mapSQLError(err, nil)
-		}
-		output, err = scanFederationBinding(tx.QueryRowContext(ctx,
-			federationBindingSelect+` WHERE project_id=$1`, project.ID))
-		if err != nil {
-			return err
-		}
-		return reconcileFederationBindingTransitionLinks(ctx, tx, nil, output)
-	})
-	return output, err
+		project.UID, enableEvent.ID, pullCursor); err != nil {
+		return db.FederationBinding{}, mapSQLError(err, nil)
+	}
+	binding, err := scanFederationBinding(tx.QueryRowContext(ctx,
+		federationBindingSelect+` WHERE project_id=$1`, project.ID))
+	if err != nil {
+		return db.FederationBinding{}, err
+	}
+	if err := reconcileFederationBindingTransitionLinks(ctx, tx, nil, binding); err != nil {
+		return db.FederationBinding{}, err
+	}
+	return binding, nil
 }
 
 // RefreshProjectFederationBaseline writes a new baseline for an enabled hub binding.

--- a/internal/db/pgstore/stubgen/main.go
+++ b/internal/db/pgstore/stubgen/main.go
@@ -52,6 +52,7 @@ var alreadyImplemented = map[string]bool{
 	"ClearFederationSyncError":             true, // federation_control.go
 	"CountActiveFederationEnrollments":     true, // federation_control.go
 	"CreateFederationEnrollment":           true, // federation_control.go
+	"CreateProjectFederationEnrollment":    true, // federation_control.go
 	"EnableFederationPush":                 true, // federation_control.go
 	"EnableProjectFederation":              true, // federation_projection.go
 	"ExportFederationBindings":             true, // export.go

--- a/internal/db/pgstore/stubgen/main_test.go
+++ b/internal/db/pgstore/stubgen/main_test.go
@@ -38,7 +38,7 @@ type Storage interface { Only(context.Context) error }
 func TestStorageMethodInventoryClassifiesEveryMethod(t *testing.T) {
 	methods, err := CollectStorageMethodInventory("../../storage.go")
 	require.NoError(t, err)
-	require.Len(t, methods, 209)
+	require.Len(t, methods, 210)
 
 	var implemented []string
 	var stubbed []string
@@ -99,6 +99,7 @@ func TestStorageMethodInventoryClassifiesEveryMethod(t *testing.T) {
 		"CreateLink",
 		"CreateLinkAndEvent",
 		"CreateProject",
+		"CreateProjectFederationEnrollment",
 		"CreateProjectWithUID",
 		"CreateRecurrence",
 		"DeleteLinkAndEvent",

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -738,7 +738,22 @@ func (d *Store) enableProjectFederation(ctx context.Context, projectID int64, ac
 		return db.FederationBinding{}, fmt.Errorf("begin federation enable: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	binding, err := d.enableProjectFederationTx(ctx, tx, projectID, actor)
+	if err != nil {
+		return db.FederationBinding{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return db.FederationBinding{}, fmt.Errorf("commit federation enable: %w", err)
+	}
+	return binding, nil
+}
 
+func (d *Store) enableProjectFederationTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectID int64,
+	actor string,
+) (db.FederationBinding, error) {
 	project, err := scanProject(tx.QueryRowContext(ctx,
 		projectSelect+` WHERE id = ? AND deleted_at IS NULL`, projectID))
 	if err != nil {
@@ -759,9 +774,6 @@ func (d *Store) enableProjectFederation(ctx context.Context, projectID int64, ac
 			if err := reconcileFederatedLinkGroup(ctx, tx, groupProjectIDs, groupProjectIDs, 0, nil); err != nil {
 				return db.FederationBinding{}, err
 			}
-		}
-		if err := tx.Commit(); err != nil {
-			return db.FederationBinding{}, fmt.Errorf("commit existing federation binding: %w", err)
 		}
 		return existing, nil
 	}
@@ -794,9 +806,6 @@ func (d *Store) enableProjectFederation(ctx context.Context, projectID int64, ac
 	}
 	if err := reconcileFederationBindingTransitionLinks(ctx, tx, nil, binding); err != nil {
 		return db.FederationBinding{}, err
-	}
-	if err := tx.Commit(); err != nil {
-		return db.FederationBinding{}, fmt.Errorf("commit federation enable: %w", err)
 	}
 	return binding, nil
 }

--- a/internal/db/sqlitestore/federation_enrollments.go
+++ b/internal/db/sqlitestore/federation_enrollments.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"go.kenn.io/kata/internal/db"
-	katauid "go.kenn.io/kata/internal/uid"
 )
 
 // CreateFederationEnrollment inserts an active enrollment. When p.Token is
@@ -16,15 +15,30 @@ func (d *Store) CreateFederationEnrollment(
 	ctx context.Context,
 	p db.CreateFederationEnrollmentParams,
 ) (db.CreatedFederationEnrollment, error) {
-	if p.Token == "" {
-		token, err := db.NewFederationToken()
-		if err != nil {
-			return db.CreatedFederationEnrollment{}, err
-		}
-		p.Token = token
+	prepared, err := db.PrepareFederationEnrollmentParams(p)
+	if err != nil {
+		return db.CreatedFederationEnrollment{}, err
 	}
 	return retryWrite1(ctx, d, func() (db.CreatedFederationEnrollment, error) {
-		return d.createFederationEnrollment(ctx, p)
+		return d.createFederationEnrollment(ctx, prepared)
+	})
+}
+
+// CreateProjectFederationEnrollment enables one hub project and creates its
+// scoped enrollment in the same transaction.
+func (d *Store) CreateProjectFederationEnrollment(
+	ctx context.Context,
+	p db.CreateFederationEnrollmentParams,
+) (db.CreatedFederationEnrollment, error) {
+	prepared, err := db.PrepareFederationEnrollmentParams(p)
+	if err != nil {
+		return db.CreatedFederationEnrollment{}, err
+	}
+	if prepared.ProjectID == nil || *prepared.ProjectID <= 0 {
+		return db.CreatedFederationEnrollment{}, fmt.Errorf("project-scoped federation enrollment requires project id")
+	}
+	return retryWrite1(ctx, d, func() (db.CreatedFederationEnrollment, error) {
+		return d.createProjectFederationEnrollment(ctx, prepared)
 	})
 }
 
@@ -32,29 +46,52 @@ func (d *Store) createFederationEnrollment(
 	ctx context.Context,
 	p db.CreateFederationEnrollmentParams,
 ) (db.CreatedFederationEnrollment, error) {
-	if !katauid.Valid(p.SpokeInstanceUID) {
-		return db.CreatedFederationEnrollment{}, fmt.Errorf("invalid spoke instance uid %q", p.SpokeInstanceUID)
-	}
-	capabilities, err := db.CanonicalFederationCapabilities(p.Capabilities)
-	if err != nil {
-		return db.CreatedFederationEnrollment{}, err
-	}
-	actor := strings.TrimSpace(p.Actor)
-	if err := db.ValidateTokenActor(actor); err != nil {
-		return db.CreatedFederationEnrollment{}, fmt.Errorf("federation enrollment actor: %w", err)
-	}
-	if p.AllowAdoptionSnapshotAuthors && p.ProjectID == nil {
-		return db.CreatedFederationEnrollment{}, fmt.Errorf("allow adoption snapshot authors requires project-scoped enrollment")
-	}
-	var projectID any
-	if p.ProjectID != nil {
-		projectID = *p.ProjectID
-	}
 	tx, err := d.BeginTx(ctx, nil)
 	if err != nil {
 		return db.CreatedFederationEnrollment{}, err
 	}
 	defer func() { _ = tx.Rollback() }()
+	created, err := createFederationEnrollmentTx(ctx, tx, p)
+	if err != nil {
+		return db.CreatedFederationEnrollment{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return db.CreatedFederationEnrollment{}, err
+	}
+	return created, nil
+}
+
+func (d *Store) createProjectFederationEnrollment(
+	ctx context.Context,
+	p db.CreateFederationEnrollmentParams,
+) (db.CreatedFederationEnrollment, error) {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return db.CreatedFederationEnrollment{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := d.enableProjectFederationTx(ctx, tx, *p.ProjectID, p.Actor); err != nil {
+		return db.CreatedFederationEnrollment{}, err
+	}
+	created, err := createFederationEnrollmentTx(ctx, tx, p)
+	if err != nil {
+		return db.CreatedFederationEnrollment{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return db.CreatedFederationEnrollment{}, err
+	}
+	return created, nil
+}
+
+func createFederationEnrollmentTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	p db.CreateFederationEnrollmentParams,
+) (db.CreatedFederationEnrollment, error) {
+	var projectID any
+	if p.ProjectID != nil {
+		projectID = *p.ProjectID
+	}
 
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO federation_enrollments(
@@ -62,7 +99,7 @@ func (d *Store) createFederationEnrollment(
 		  allow_adoption_snapshot_authors
 		)
 		VALUES(?, ?, ?, ?, ?, ?)`,
-		db.FederationTokenHash(p.Token), p.SpokeInstanceUID, projectID, capabilities, actor,
+		db.FederationTokenHash(p.Token), p.SpokeInstanceUID, projectID, p.Capabilities, p.Actor,
 		p.AllowAdoptionSnapshotAuthors)
 	if err != nil {
 		return db.CreatedFederationEnrollment{}, fmt.Errorf("create federation enrollment: %w", err)
@@ -73,9 +110,6 @@ func (d *Store) createFederationEnrollment(
 	}
 	enrollment, err := federationEnrollmentByIDTx(ctx, tx, id)
 	if err != nil {
-		return db.CreatedFederationEnrollment{}, err
-	}
-	if err := tx.Commit(); err != nil {
 		return db.CreatedFederationEnrollment{}, err
 	}
 	return db.CreatedFederationEnrollment{Enrollment: enrollment, Token: p.Token}, nil

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -242,6 +242,7 @@ type Storage interface {
 
 	// federation: enrollments
 	CreateFederationEnrollment(ctx context.Context, p CreateFederationEnrollmentParams) (CreatedFederationEnrollment, error)
+	CreateProjectFederationEnrollment(ctx context.Context, p CreateFederationEnrollmentParams) (CreatedFederationEnrollment, error)
 	ListFederationEnrollments(ctx context.Context) ([]FederationEnrollment, error)
 	RevokeFederationEnrollment(ctx context.Context, id int64) error
 	AuthorizeFederationToken(ctx context.Context, token string, projectID int64, capability string) (FederationEnrollment, error)

--- a/service_federation_enrollments.go
+++ b/service_federation_enrollments.go
@@ -70,19 +70,16 @@ func (s *Service) CreateFederationEnrollment(
 	if !found || project.DeletedAt != nil {
 		return CreatedFederationEnrollment{}, ErrProjectNotFound
 	}
-	if _, err := s.store.EnableProjectFederation(callCtx, project.ID, actor); err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			return CreatedFederationEnrollment{}, ErrProjectNotFound
-		}
-		return CreatedFederationEnrollment{}, fmt.Errorf("kata: enable project federation: %w", err)
-	}
-	created, err := s.store.CreateFederationEnrollment(callCtx, db.CreateFederationEnrollmentParams{
+	created, err := s.store.CreateProjectFederationEnrollment(callCtx, db.CreateFederationEnrollmentParams{
 		SpokeInstanceUID:             spec.SpokeInstanceUID,
 		ProjectID:                    &project.ID,
 		Capabilities:                 capabilities,
 		Actor:                        actor,
 		AllowAdoptionSnapshotAuthors: spec.AllowAdoptionSnapshotAuthors,
 	})
+	if errors.Is(err, db.ErrNotFound) {
+		return CreatedFederationEnrollment{}, ErrProjectNotFound
+	}
 	if err != nil {
 		return CreatedFederationEnrollment{}, fmt.Errorf("kata: create federation enrollment: %w", err)
 	}

--- a/service_federation_enrollments.go
+++ b/service_federation_enrollments.go
@@ -1,0 +1,213 @@
+package kata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/kata/internal/db"
+	katauid "go.kenn.io/kata/internal/uid"
+)
+
+// ErrFederationEnrollmentNotFound reports that an enrollment does not belong
+// to the requested project or does not exist.
+var ErrFederationEnrollmentNotFound = errors.New("kata: federation enrollment not found")
+
+// FederationEnrollmentSpec describes a project-scoped transport credential.
+// Kata generates the plaintext token and returns it only from creation.
+type FederationEnrollmentSpec struct {
+	ProjectUID                   string
+	SpokeInstanceUID             string
+	Capabilities                 string
+	Actor                        string
+	AllowAdoptionSnapshotAuthors bool
+}
+
+// FederationEnrollment is the host-visible enrollment history. It omits the
+// stored token hash and never contains the plaintext credential.
+type FederationEnrollment struct {
+	ID                           int64
+	ProjectUID                   string
+	SpokeInstanceUID             string
+	Capabilities                 string
+	Actor                        string
+	AllowAdoptionSnapshotAuthors bool
+	CreatedAt                    time.Time
+	UpdatedAt                    time.Time
+	RevokedAt                    *time.Time
+}
+
+// CreatedFederationEnrollment contains a new enrollment and its one-time
+// plaintext credential.
+type CreatedFederationEnrollment struct {
+	Enrollment FederationEnrollment
+	Token      string
+}
+
+// CreateFederationEnrollment enables hub federation for the project when
+// necessary and creates a project-scoped transport credential. It is an
+// in-process application method; the caller must authorize the operation.
+func (s *Service) CreateFederationEnrollment(
+	ctx context.Context,
+	spec FederationEnrollmentSpec,
+) (CreatedFederationEnrollment, error) {
+	capabilities, actor, err := validateFederationEnrollmentSpec(spec)
+	if err != nil {
+		return CreatedFederationEnrollment{}, err
+	}
+	callCtx, done, err := s.beginHostCall(ctx)
+	if err != nil {
+		return CreatedFederationEnrollment{}, err
+	}
+	defer done()
+
+	project, found, err := s.projectByUID(callCtx, spec.ProjectUID)
+	if err != nil {
+		return CreatedFederationEnrollment{}, err
+	}
+	if !found || project.DeletedAt != nil {
+		return CreatedFederationEnrollment{}, ErrProjectNotFound
+	}
+	if _, err := s.store.EnableProjectFederation(callCtx, project.ID, actor); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return CreatedFederationEnrollment{}, ErrProjectNotFound
+		}
+		return CreatedFederationEnrollment{}, fmt.Errorf("kata: enable project federation: %w", err)
+	}
+	created, err := s.store.CreateFederationEnrollment(callCtx, db.CreateFederationEnrollmentParams{
+		SpokeInstanceUID:             spec.SpokeInstanceUID,
+		ProjectID:                    &project.ID,
+		Capabilities:                 capabilities,
+		Actor:                        actor,
+		AllowAdoptionSnapshotAuthors: spec.AllowAdoptionSnapshotAuthors,
+	})
+	if err != nil {
+		return CreatedFederationEnrollment{}, fmt.Errorf("kata: create federation enrollment: %w", err)
+	}
+	return CreatedFederationEnrollment{
+		Enrollment: publicFederationEnrollment(created.Enrollment, project.UID),
+		Token:      created.Token,
+	}, nil
+}
+
+// ListFederationEnrollments returns retained enrollment history for one stable
+// project identity. Plaintext credentials and their stored hashes are omitted.
+func (s *Service) ListFederationEnrollments(
+	ctx context.Context,
+	projectUID string,
+) ([]FederationEnrollment, error) {
+	if !validHostProjectUID(projectUID) {
+		return nil, ErrProjectNotFound
+	}
+	callCtx, done, err := s.beginHostCall(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
+	project, found, err := s.projectByUID(callCtx, projectUID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, ErrProjectNotFound
+	}
+	enrollments, err := s.store.ListFederationEnrollments(callCtx)
+	if err != nil {
+		return nil, fmt.Errorf("kata: list federation enrollments: %w", err)
+	}
+	result := make([]FederationEnrollment, 0)
+	for _, enrollment := range enrollments {
+		if enrollment.ProjectID != nil && *enrollment.ProjectID == project.ID {
+			result = append(result, publicFederationEnrollment(enrollment, project.UID))
+		}
+	}
+	return result, nil
+}
+
+// RevokeFederationEnrollment permanently revokes one credential belonging to
+// the requested project. Repeating an exact revocation is harmless.
+func (s *Service) RevokeFederationEnrollment(
+	ctx context.Context,
+	projectUID string,
+	enrollmentID int64,
+) error {
+	if !validHostProjectUID(projectUID) || enrollmentID <= 0 {
+		return ErrFederationEnrollmentNotFound
+	}
+	callCtx, done, err := s.beginHostCall(ctx)
+	if err != nil {
+		return err
+	}
+	defer done()
+
+	project, found, err := s.projectByUID(callCtx, projectUID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return ErrProjectNotFound
+	}
+	enrollments, err := s.store.ListFederationEnrollments(callCtx)
+	if err != nil {
+		return fmt.Errorf("kata: find federation enrollment: %w", err)
+	}
+	for _, enrollment := range enrollments {
+		if enrollment.ID != enrollmentID || enrollment.ProjectID == nil ||
+			*enrollment.ProjectID != project.ID {
+			continue
+		}
+		if enrollment.RevokedAt != nil {
+			return nil
+		}
+		if err := s.store.RevokeFederationEnrollment(callCtx, enrollmentID); err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return ErrFederationEnrollmentNotFound
+			}
+			return fmt.Errorf("kata: revoke federation enrollment: %w", err)
+		}
+		return nil
+	}
+	return ErrFederationEnrollmentNotFound
+}
+
+func validateFederationEnrollmentSpec(spec FederationEnrollmentSpec) (string, string, error) {
+	if !validHostProjectUID(spec.ProjectUID) {
+		return "", "", ErrProjectNotFound
+	}
+	if !katauid.Valid(spec.SpokeInstanceUID) {
+		return "", "", errors.New("kata: invalid spoke instance UID")
+	}
+	capabilities, err := db.CanonicalFederationCapabilities(spec.Capabilities)
+	if err != nil {
+		return "", "", fmt.Errorf("kata: invalid federation capabilities: %w", err)
+	}
+	actor := strings.TrimSpace(spec.Actor)
+	if err := db.ValidateTokenActor(actor); err != nil {
+		return "", "", fmt.Errorf("kata: invalid federation enrollment actor: %w", err)
+	}
+	return capabilities, actor, nil
+}
+
+func validHostProjectUID(projectUID string) bool {
+	return katauid.Valid(projectUID) && projectUID != db.SystemProjectUID
+}
+
+func publicFederationEnrollment(
+	enrollment db.FederationEnrollment,
+	projectUID string,
+) FederationEnrollment {
+	return FederationEnrollment{
+		ID:                           enrollment.ID,
+		ProjectUID:                   projectUID,
+		SpokeInstanceUID:             enrollment.SpokeInstanceUID,
+		Capabilities:                 enrollment.Capabilities,
+		Actor:                        enrollment.Actor,
+		AllowAdoptionSnapshotAuthors: enrollment.AllowAdoptionSnapshotAuthors,
+		CreatedAt:                    enrollment.CreatedAt,
+		UpdatedAt:                    enrollment.UpdatedAt,
+		RevokedAt:                    enrollment.RevokedAt,
+	}
+}

--- a/service_federation_enrollments_test.go
+++ b/service_federation_enrollments_test.go
@@ -1,0 +1,165 @@
+package kata_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata"
+)
+
+func TestServiceFederationEnrollmentLifecycleIsProjectScoped(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:     filepath.Join(t.TempDir(), "service.db"),
+		Auth:    kata.AuthConfig{TrustCallerAuthentication: true},
+		Profile: kata.EmbeddingProfileRestricted,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	firstProject := ensureEnrollmentTestProject(
+		t, service, "01HZNQ7VFPK1XGD8R5MABCD4EX", "first-project",
+	)
+	secondProject := ensureEnrollmentTestProject(
+		t, service, "01HZNQ7VFPK1XGD8R5MABCD4EY", "second-project",
+	)
+
+	created, err := service.CreateFederationEnrollment(context.Background(), kata.FederationEnrollmentSpec{
+		ProjectUID:                   firstProject.UID,
+		SpokeInstanceUID:             "01HZNQ7VFPK1XGD8R5MABCD4EA",
+		Capabilities:                 "push, pull,claim,pull",
+		Actor:                        "Example Operator",
+		AllowAdoptionSnapshotAuthors: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, created.Token, 43)
+	assert.Positive(t, created.Enrollment.ID)
+	assert.Equal(t, firstProject.UID, created.Enrollment.ProjectUID)
+	assert.Equal(t, "claim,pull,push", created.Enrollment.Capabilities)
+	assert.Equal(t, "Example Operator", created.Enrollment.Actor)
+	assert.True(t, created.Enrollment.AllowAdoptionSnapshotAuthors)
+	assert.Nil(t, created.Enrollment.RevokedAt)
+
+	firstHistory, err := service.ListFederationEnrollments(context.Background(), firstProject.UID)
+	require.NoError(t, err)
+	require.Len(t, firstHistory, 1)
+	assert.Equal(t, created.Enrollment, firstHistory[0])
+
+	secondHistory, err := service.ListFederationEnrollments(context.Background(), secondProject.UID)
+	require.NoError(t, err)
+	assert.Empty(t, secondHistory)
+
+	assertFederationTokenStatus(t, service, firstProject.ID, created.Token, http.StatusOK)
+
+	err = service.RevokeFederationEnrollment(
+		context.Background(), secondProject.UID, created.Enrollment.ID,
+	)
+	require.ErrorIs(t, err, kata.ErrFederationEnrollmentNotFound)
+	assertFederationTokenStatus(t, service, firstProject.ID, created.Token, http.StatusOK)
+
+	require.NoError(t, service.RevokeFederationEnrollment(
+		context.Background(), firstProject.UID, created.Enrollment.ID,
+	))
+	require.NoError(t, service.RevokeFederationEnrollment(
+		context.Background(), firstProject.UID, created.Enrollment.ID,
+	), "exact revocation retries must be harmless")
+	assertFederationTokenStatus(t, service, firstProject.ID, created.Token, http.StatusForbidden)
+
+	firstHistory, err = service.ListFederationEnrollments(context.Background(), firstProject.UID)
+	require.NoError(t, err)
+	require.Len(t, firstHistory, 1)
+	assert.NotNil(t, firstHistory[0].RevokedAt)
+}
+
+func TestServiceFederationEnrollmentRejectsInvalidOrArchivedProjects(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	project := ensureEnrollmentTestProject(
+		t, service, "01HZNQ7VFPK1XGD8R5MABCD4EX", "archived-project",
+	)
+	_, err = service.ArchiveProject(context.Background(), project.UID, "Example Operator")
+	require.NoError(t, err)
+
+	for _, projectUID := range []string{"not-a-uid", "01HZNQ7VFPK1XGD8R5MABCD4EY", project.UID} {
+		_, createErr := service.CreateFederationEnrollment(
+			context.Background(),
+			kata.FederationEnrollmentSpec{
+				ProjectUID:       projectUID,
+				SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4EA",
+				Capabilities:     "pull",
+				Actor:            "Example Operator",
+			},
+		)
+		require.ErrorIs(t, createErr, kata.ErrProjectNotFound, projectUID)
+	}
+}
+
+func TestServiceInvalidEnrollmentDoesNotEnableFederation(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	project := ensureEnrollmentTestProject(
+		t, service, "01HZNQ7VFPK1XGD8R5MABCD4EX", "inactive-project",
+	)
+	_, err = service.CreateFederationEnrollment(context.Background(), kata.FederationEnrollmentSpec{
+		ProjectUID:       project.UID,
+		SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4EA",
+		Capabilities:     "pull,unknown",
+		Actor:            "Example Operator",
+	})
+	require.ErrorContains(t, err, "unknown federation capability")
+
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/projects/"+strconv.FormatInt(project.ID, 10)+"/federation",
+		nil,
+	)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	assert.Equal(t, http.StatusNotFound, response.Code)
+}
+
+func ensureEnrollmentTestProject(
+	t *testing.T,
+	service *kata.Service,
+	uid string,
+	name string,
+) kata.Project {
+	t.Helper()
+	result, err := service.EnsureProject(context.Background(), kata.ProjectSpec{UID: uid, Name: name})
+	require.NoError(t, err)
+	return result.Project
+}
+
+func assertFederationTokenStatus(
+	t *testing.T,
+	service *kata.Service,
+	projectID int64,
+	token string,
+	want int,
+) {
+	t.Helper()
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/federation/metadata",
+		nil,
+	)
+	request.Header.Set("Authorization", "Bearer "+token)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	assert.Equal(t, want, response.Code)
+}


### PR DESCRIPTION
Restricted embedding deliberately removes native federation-administration routes so the mounting application can own authorization and operator workflow. Until now, that also removed the only supported way to issue transport credentials, leaving embedders to reopen those routes or reach into Kata-owned storage.

This adds a small in-process lifecycle for project-scoped federation enrollments. Kata atomically enables hub federation and creates the enrollment, generates and hashes the bearer secret, returns plaintext only at creation, and keeps retained history free of both plaintext and stored hashes. Listing and revocation require the stable project UID, so an enrollment ID cannot silently select another project. Existing credentials remain auditable and revocable after archival, while archived projects cannot receive new credentials.

The standalone HTTP surface and persisted schema are unchanged.