### PR TITLE
Add host validation for federation credentials

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
           KATA_TEST_POSTGRES_DSN: postgres://kata:kata@127.0.0.1:5432/kata_test?sslmode=disable
         run: >-
           env -u KATA_AUTH_TOKEN go test -count=1 -p 1
+          .
           ./internal/testenv
           ./internal/db/pgstore
           ./internal/db/storeopen

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,10 @@ All notable changes to kata, grouped by release. Versioned releases start with
 - Added project-scoped federation enrollment creation, history, and revocation
   methods to the mountable Go service for hosts that use the restricted
   embedding profile.
+- Added an optional federation-access controller for mounting applications that
+  need to revalidate Kata-authenticated project credentials against outside
+  lifecycle state. Federation mutations share the controller's transaction
+  fence with event or lease writes.
 
 ## 0.12.0
 <small>2026-07-20</small>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,9 @@ All notable changes to kata, grouped by release. Versioned releases start with
 - Added an optional federation-access controller for mounting applications that
   need to revalidate Kata-authenticated project credentials against outside
   lifecycle state. Federation mutations share the controller's transaction
-  fence with event or lease writes.
+  fence with event or lease writes. Conditionally mutating metadata and lease
+  status reads use the same fence, and controller failures return only bounded,
+  generic authorization errors.
 
 ## 0.12.0
 <small>2026-07-20</small>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,7 +18,8 @@ All notable changes to kata, grouped by release. Versioned releases start with
   lifecycle state. Federation mutations share the controller's transaction
   fence with event or lease writes. Conditionally mutating metadata and lease
   status reads use the same fence, and controller failures return only bounded,
-  generic authorization errors.
+  generic authorization errors. Principal and federation fences compose when
+  both apply to one request.
 
 ## 0.12.0
 <small>2026-07-20</small>

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -237,10 +237,25 @@ authorization decisions.
 
 Federation transport and lease routes may authenticate with Kata-managed,
 project-scoped bearer credentials. When such a request has no in-process host
-principal, Kata validates the scoped credential in the route and does not call
-the host controller. The outer server must preserve the `Authorization` header
-on those routes. A request without either an in-process principal or a scoped
-bearer credential remains unauthenticated.
+principal, Kata validates the scoped credential in the route instead of calling
+the ordinary `AccessController`. The outer server must preserve the
+`Authorization` header on those routes. A request without either an in-process
+principal or a scoped bearer credential remains unauthenticated.
+
+Mounting applications that have additional credential-lifecycle rules can set
+`Config.FederationAccess`. Kata calls that controller only after its own token,
+project, and capability checks succeed. The request contains the retained
+enrollment without its token hash, the resolved project, the exact `pull`,
+`push`, or `claim` capability, and the stable operation ID. Returning
+`ErrAccessDenied` makes the otherwise valid credential unusable without
+disclosing which outside condition changed. Standalone behavior is unchanged
+when the controller is absent.
+
+Federation mutations require the controller to return a `TransactionFence`.
+Kata runs it inside the same storage transaction as event ingest or lease state,
+so a concurrent revocation is ordered with the protected write. A missing fence
+fails closed. The callback follows the same retry and transaction rules as the
+ordinary host-access fence described above.
 
 ## Restricted embedding profile
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -254,8 +254,13 @@ when the controller is absent.
 Federation mutations require the controller to return a `TransactionFence`.
 Kata runs it inside the same storage transaction as event ingest or lease state,
 so a concurrent revocation is ordered with the protected write. A missing fence
-fails closed. The callback follows the same retry and transaction rules as the
-ordinary host-access fence described above.
+fails closed. Federation metadata and lease-status requests also require a fence
+because they may refresh baselines, expire claims, or update a spoke's cached
+lease state even though their HTTP method is `GET`. Tokenless lease-status reads
+remain available in explicitly trusted-caller mode; once a bearer credential is
+supplied, Kata authenticates and authorizes that credential. The callback
+follows the same retry and transaction rules as the ordinary host-access fence
+described above.
 
 ## Restricted embedding profile
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -258,7 +258,10 @@ fails closed. Federation metadata and lease-status requests also require a fence
 because they may refresh baselines, expire claims, or update a spoke's cached
 lease state even though their HTTP method is `GET`. Tokenless lease-status reads
 remain available in explicitly trusted-caller mode; once a bearer credential is
-supplied, Kata authenticates and authorizes that credential. The callback
+supplied, Kata authenticates and authorizes that credential. When a request
+carries both an in-process principal and a scoped federation credential, the
+ordinary host-access fence runs first and the federation fence runs only after
+it succeeds; neither authorization layer replaces the other. The callback
 follows the same retry and transaction rules as the ordinary host-access fence
 described above.
 

--- a/federation_access.go
+++ b/federation_access.go
@@ -1,0 +1,49 @@
+package kata
+
+import "context"
+
+// FederationCapability is the transport authority requested by one
+// authenticated federation operation.
+type FederationCapability string
+
+// Federation transport capabilities.
+const (
+	FederationCapabilityPull  FederationCapability = "pull"
+	FederationCapabilityPush  FederationCapability = "push"
+	FederationCapabilityClaim FederationCapability = "claim"
+)
+
+// FederationOperation describes the authenticated transport operation. ID is
+// a stable Kata operation identifier. Mutation is true when the operation can
+// change stored task, cursor, or lease state.
+type FederationOperation struct {
+	ID       string
+	Mutation bool
+}
+
+// FederationAccessRequest contains the Kata-authenticated enrollment and
+// project facts supplied to a mounting application's additional authorization
+// boundary. It never contains the plaintext credential or its stored hash.
+type FederationAccessRequest struct {
+	Enrollment FederationEnrollment
+	Project    Project
+	Capability FederationCapability
+	Operation  FederationOperation
+}
+
+// FederationAccessDecision carries the in-transaction authorization check for
+// a federation mutation. Read-only operations may return the zero value.
+type FederationAccessDecision struct {
+	TransactionFence TransactionFence
+}
+
+// FederationAccessController adds host-owned authorization after Kata has
+// authenticated a project-scoped enrollment. Returning ErrAccessDenied makes
+// the credential unusable without disclosing which outside authority changed.
+// Mutating operations require a TransactionFence in the returned decision.
+type FederationAccessController interface {
+	AuthorizeFederation(
+		context.Context,
+		FederationAccessRequest,
+	) (FederationAccessDecision, error)
+}

--- a/internal/daemon/claims_auth.go
+++ b/internal/daemon/claims_auth.go
@@ -27,47 +27,50 @@ func resolveClaimPrincipal(
 	projectID int64,
 	authz string,
 	body api.ClaimActionBody,
+	operation HostFederationOperation,
 	allowEnrollment bool,
 	requireMutationLocal bool,
-) (claimPrincipal, error) {
+) (context.Context, claimPrincipal, error) {
 	if cfg.HostAccess != nil {
 		if requestPrincipal, ok := PrincipalFromContext(ctx); ok {
 			if !validHostPrincipal(requestPrincipal) {
-				return claimPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
+				return ctx, claimPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
 					"valid host principal required", "", nil)
 			}
-			return hostClaimPrincipal(cfg, body, requestPrincipal.Subject), nil
+			return ctx, hostClaimPrincipal(cfg, body, requestPrincipal.Subject), nil
 		}
 		if allowEnrollment && hasBearerHeader(authz) {
-			return resolveEnrollmentClaimPrincipal(ctx, cfg, projectID, authz, body)
+			return resolveEnrollmentClaimPrincipal(ctx, cfg, projectID, authz, body, operation)
 		}
-		return claimPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
+		return ctx, claimPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
 			"host principal or scoped federation bearer required", "", nil)
 	}
 	if cfg.Auth.Token != "" {
 		if principal, ok, err := resolveLocalClaimPrincipal(ctx, cfg, authz, body, false); ok || err != nil {
-			return principal, err
+			return ctx, principal, err
 		}
 		if allowEnrollment && hasBearerHeader(authz) {
-			return resolveEnrollmentClaimPrincipal(ctx, cfg, projectID, authz, body)
+			return resolveEnrollmentClaimPrincipal(ctx, cfg, projectID, authz, body, operation)
 		}
-		return claimPrincipal{}, localAuthError(cfg, authz)
+		return ctx, claimPrincipal{}, localAuthError(cfg, authz)
 	}
 
 	if allowEnrollment && hasBearerHeader(authz) {
-		principal, err := resolveEnrollmentClaimPrincipal(ctx, cfg, projectID, authz, body)
+		authorizedCtx, principal, err := resolveEnrollmentClaimPrincipal(
+			ctx, cfg, projectID, authz, body, operation,
+		)
 		if err == nil {
-			return principal, nil
+			return authorizedCtx, principal, nil
 		}
-		if cfg.InsecureReadonly {
-			return claimPrincipal{}, err
+		if cfg.InsecureReadonly || cfg.HostFederationAccess != nil {
+			return ctx, claimPrincipal{}, err
 		}
 	}
 
 	if requireMutationLocal && cfg.InsecureReadonly {
-		return claimPrincipal{}, localAuthError(cfg, authz)
+		return ctx, claimPrincipal{}, localAuthError(cfg, authz)
 	}
-	return localClaimPrincipal(cfg, body), nil
+	return ctx, localClaimPrincipal(cfg, body), nil
 }
 
 func hostClaimPrincipal(cfg ServerConfig, body api.ClaimActionBody, subject string) claimPrincipal {
@@ -88,12 +91,14 @@ func resolveEnrollmentClaimPrincipal(
 	projectID int64,
 	authz string,
 	body api.ClaimActionBody,
-) (claimPrincipal, error) {
-	fed, err := authorizeFederationRequest(ctx, cfg.DB, authz, projectID, "claim")
+	operation HostFederationOperation,
+) (context.Context, claimPrincipal, error) {
+	authorizedCtx, fed, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
+		operation)
 	if err != nil {
-		return claimPrincipal{}, err
+		return ctx, claimPrincipal{}, err
 	}
-	return claimPrincipal{ClaimPrincipal: db.ClaimPrincipal{
+	return authorizedCtx, claimPrincipal{ClaimPrincipal: db.ClaimPrincipal{
 		HolderInstanceUID: fed.SpokeInstanceUID,
 		Holder:            fed.Actor,
 		ClientKind:        strings.TrimSpace(body.ClientKind),
@@ -105,37 +110,40 @@ func authorizeClaimStatusRead(
 	cfg ServerConfig,
 	projectID int64,
 	authz string,
-) error {
+) (context.Context, error) {
 	if cfg.HostAccess != nil {
 		if requestPrincipal, ok := PrincipalFromContext(ctx); ok {
 			if validHostPrincipal(requestPrincipal) {
-				return nil
+				return ctx, nil
 			}
-			return api.NewError(http.StatusUnauthorized, "auth_required",
+			return ctx, api.NewError(http.StatusUnauthorized, "auth_required",
 				"valid host principal required", "", nil)
 		}
 		if hasBearerHeader(authz) {
-			_, err := authorizeFederationRequest(ctx, cfg.DB, authz, projectID, "claim")
-			return err
+			authorizedCtx, _, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
+				HostFederationOperation{ID: "getIssueLeaseStatus"})
+			return authorizedCtx, err
 		}
-		return api.NewError(http.StatusUnauthorized, "auth_required",
+		return ctx, api.NewError(http.StatusUnauthorized, "auth_required",
 			"host principal or scoped federation bearer required", "", nil)
 	}
 	if cfg.Auth.Token == "" {
 		if cfg.InsecureReadonly {
 			if !hasBearerHeader(authz) {
-				return localAuthError(cfg, authz)
+				return ctx, localAuthError(cfg, authz)
 			}
-			_, err := authorizeFederationRequest(ctx, cfg.DB, authz, projectID, "claim")
-			return err
+			authorizedCtx, _, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
+				HostFederationOperation{ID: "getIssueLeaseStatus"})
+			return authorizedCtx, err
 		}
-		return nil
+		return ctx, nil
 	}
 	if _, ok, err := resolveLocalClaimPrincipal(ctx, cfg, authz, api.ClaimActionBody{}, true); ok || err != nil {
-		return err
+		return ctx, err
 	}
-	_, err := authorizeFederationRequest(ctx, cfg.DB, authz, projectID, "claim")
-	return err
+	authorizedCtx, _, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
+		HostFederationOperation{ID: "getIssueLeaseStatus"})
+	return authorizedCtx, err
 }
 
 func resolveLocalClaimPrincipal(

--- a/internal/daemon/claims_auth.go
+++ b/internal/daemon/claims_auth.go
@@ -121,20 +121,20 @@ func authorizeClaimStatusRead(
 		}
 		if hasBearerHeader(authz) {
 			authorizedCtx, _, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
-				HostFederationOperation{ID: "getIssueLeaseStatus"})
+				HostFederationOperation{ID: "getIssueLeaseStatus", Mutation: true})
 			return authorizedCtx, err
 		}
 		return ctx, api.NewError(http.StatusUnauthorized, "auth_required",
 			"host principal or scoped federation bearer required", "", nil)
 	}
 	if cfg.Auth.Token == "" {
-		if cfg.InsecureReadonly {
-			if !hasBearerHeader(authz) {
-				return ctx, localAuthError(cfg, authz)
-			}
+		if hasBearerHeader(authz) {
 			authorizedCtx, _, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
-				HostFederationOperation{ID: "getIssueLeaseStatus"})
+				HostFederationOperation{ID: "getIssueLeaseStatus", Mutation: true})
 			return authorizedCtx, err
+		}
+		if cfg.InsecureReadonly {
+			return ctx, localAuthError(cfg, authz)
 		}
 		return ctx, nil
 	}
@@ -142,7 +142,7 @@ func authorizeClaimStatusRead(
 		return ctx, err
 	}
 	authorizedCtx, _, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
-		HostFederationOperation{ID: "getIssueLeaseStatus"})
+		HostFederationOperation{ID: "getIssueLeaseStatus", Mutation: true})
 	return authorizedCtx, err
 }
 

--- a/internal/daemon/federation_access.go
+++ b/internal/daemon/federation_access.go
@@ -2,9 +2,12 @@ package daemon
 
 import (
 	"context"
+	"errors"
 
 	"go.kenn.io/kata/internal/db"
 )
+
+var errHostFederationAccessUnavailable = errors.New("host federation access unavailable")
 
 // HostFederationOperation identifies one authenticated transport operation.
 type HostFederationOperation struct {

--- a/internal/daemon/federation_access.go
+++ b/internal/daemon/federation_access.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"context"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+// HostFederationOperation identifies one authenticated transport operation.
+type HostFederationOperation struct {
+	ID       string
+	Mutation bool
+}
+
+// HostFederationAccessRequest carries native credential and project facts to
+// the public service adapter.
+type HostFederationAccessRequest struct {
+	Enrollment db.FederationEnrollment
+	Project    db.Project
+	Capability string
+	Operation  HostFederationOperation
+}
+
+// HostFederationAccessDecision contains an optional mutation fence.
+type HostFederationAccessDecision struct {
+	TransactionFence db.TransactionFence
+}
+
+// HostFederationAccessController adapts the public service hook without
+// exposing daemon or storage packages to callers.
+type HostFederationAccessController interface {
+	AuthorizeFederation(
+		context.Context,
+		HostFederationAccessRequest,
+	) (HostFederationAccessDecision, error)
+}

--- a/internal/daemon/federation_auth.go
+++ b/internal/daemon/federation_auth.go
@@ -70,7 +70,7 @@ func authorizeFederationRequest(
 			return ctx, federationPrincipal{}, api.NewError(http.StatusServiceUnavailable,
 				"access_unavailable", "federation transaction access decision unavailable", "", nil)
 		}
-		ctx = db.WithTransactionFence(ctx, sanitizeFederationTransactionFence(decision.TransactionFence))
+		ctx = db.WithAdditionalTransactionFence(ctx, sanitizeFederationTransactionFence(decision.TransactionFence))
 	}
 	return ctx, federationPrincipal{
 		EnrollmentID:                 enrollment.ID,

--- a/internal/daemon/federation_auth.go
+++ b/internal/daemon/federation_auth.go
@@ -70,7 +70,7 @@ func authorizeFederationRequest(
 			return ctx, federationPrincipal{}, api.NewError(http.StatusServiceUnavailable,
 				"access_unavailable", "federation transaction access decision unavailable", "", nil)
 		}
-		ctx = db.WithTransactionFence(ctx, decision.TransactionFence)
+		ctx = db.WithTransactionFence(ctx, sanitizeFederationTransactionFence(decision.TransactionFence))
 	}
 	return ctx, federationPrincipal{
 		EnrollmentID:                 enrollment.ID,
@@ -80,6 +80,23 @@ func authorizeFederationRequest(
 		AllowAdoptionSnapshotAuthors: enrollment.AllowAdoptionSnapshotAuthors,
 		AllowAdoptionBaseline:        enrollment.AllowAdoptionSnapshotAuthors || enrollment.AdoptionBaselineOpen,
 	}, nil
+}
+
+func sanitizeFederationTransactionFence(fence db.TransactionFence) db.TransactionFence {
+	if fence == nil {
+		return nil
+	}
+	return func(ctx context.Context, transaction db.Transaction) error {
+		err := fence(ctx, transaction)
+		switch {
+		case err == nil:
+			return nil
+		case errors.Is(err, ErrHostAccessDenied):
+			return ErrHostAccessDenied
+		default:
+			return errHostFederationAccessUnavailable
+		}
+	}
 }
 
 func federationCredentialDenied() error {

--- a/internal/daemon/federation_auth.go
+++ b/internal/daemon/federation_auth.go
@@ -21,30 +21,58 @@ type federationPrincipal struct {
 
 func authorizeFederationRequest(
 	ctx context.Context,
-	store db.Storage,
+	cfg ServerConfig,
 	authHeader string,
 	projectID int64,
 	capability string,
-) (federationPrincipal, error) {
+	operation HostFederationOperation,
+) (context.Context, federationPrincipal, error) {
 	if !strings.HasPrefix(authHeader, authBearerPrefix) {
-		return federationPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
+		return ctx, federationPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
 			"Authorization bearer required", "", nil)
 	}
 	token := strings.TrimPrefix(authHeader, authBearerPrefix)
 	if token == "" {
-		return federationPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
+		return ctx, federationPrincipal{}, api.NewError(http.StatusUnauthorized, "auth_required",
 			"Authorization bearer required", "", nil)
 	}
 
-	enrollment, err := store.AuthorizeFederationToken(ctx, token, projectID, capability)
+	enrollment, err := cfg.DB.AuthorizeFederationToken(ctx, token, projectID, capability)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
-			return federationPrincipal{}, api.NewError(http.StatusForbidden, "auth_invalid",
+			return ctx, federationPrincipal{}, api.NewError(http.StatusForbidden, "auth_invalid",
 				"federation token is invalid for this project or capability", "", nil)
 		}
-		return federationPrincipal{}, internalAPIError(err)
+		return ctx, federationPrincipal{}, internalAPIError(err)
 	}
-	return federationPrincipal{
+	project, err := activeProjectByID(ctx, cfg.DB, projectID)
+	if err != nil {
+		return ctx, federationPrincipal{}, err
+	}
+	if cfg.HostFederationAccess != nil {
+		decision, accessErr := cfg.HostFederationAccess.AuthorizeFederation(
+			ctx,
+			HostFederationAccessRequest{
+				Enrollment: enrollment,
+				Project:    project,
+				Capability: capability,
+				Operation:  operation,
+			},
+		)
+		if errors.Is(accessErr, ErrHostAccessDenied) {
+			return ctx, federationPrincipal{}, federationCredentialDenied()
+		}
+		if accessErr != nil {
+			return ctx, federationPrincipal{}, api.NewError(http.StatusServiceUnavailable,
+				"access_unavailable", "federation credential authorization is unavailable", "", nil)
+		}
+		if operation.Mutation && decision.TransactionFence == nil {
+			return ctx, federationPrincipal{}, api.NewError(http.StatusServiceUnavailable,
+				"access_unavailable", "federation transaction access decision unavailable", "", nil)
+		}
+		ctx = db.WithTransactionFence(ctx, decision.TransactionFence)
+	}
+	return ctx, federationPrincipal{
 		EnrollmentID:                 enrollment.ID,
 		SpokeInstanceUID:             enrollment.SpokeInstanceUID,
 		Capabilities:                 enrollment.Capabilities,
@@ -52,4 +80,9 @@ func authorizeFederationRequest(
 		AllowAdoptionSnapshotAuthors: enrollment.AllowAdoptionSnapshotAuthors,
 		AllowAdoptionBaseline:        enrollment.AllowAdoptionSnapshotAuthors || enrollment.AdoptionBaselineOpen,
 	}, nil
+}
+
+func federationCredentialDenied() error {
+	return api.NewError(http.StatusForbidden, "auth_invalid",
+		"federation credential is not currently authorized", "", nil)
 }

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -29,7 +29,8 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      http.MethodPost,
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/lease/actions/acquire",
 	}, func(ctx context.Context, in *api.ClaimActionRequest) (*api.ClaimActionResponse, error) {
-		principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body, true, true)
+		ctx, principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body,
+			HostFederationOperation{ID: "acquireIssueLease", Mutation: true}, true, true)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +46,8 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      http.MethodPost,
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/lease/actions/renew",
 	}, func(ctx context.Context, in *api.ClaimActionRequest) (*api.ClaimActionResponse, error) {
-		principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body, true, true)
+		ctx, principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body,
+			HostFederationOperation{ID: "renewIssueLease", Mutation: true}, true, true)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +63,8 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      http.MethodPost,
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/lease/actions/release",
 	}, func(ctx context.Context, in *api.ClaimActionRequest) (*api.ClaimActionResponse, error) {
-		principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body, true, true)
+		ctx, principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body,
+			HostFederationOperation{ID: "releaseIssueLease", Mutation: true}, true, true)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +80,8 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      http.MethodPost,
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/lease/actions/force_release",
 	}, func(ctx context.Context, in *api.ClaimActionRequest) (*api.ClaimActionResponse, error) {
-		principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body, false, true)
+		ctx, principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body,
+			HostFederationOperation{ID: "forceReleaseIssueLease", Mutation: true}, false, true)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +122,9 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      http.MethodGet,
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/lease",
 	}, func(ctx context.Context, in *api.ClaimStatusRequest) (*api.ClaimStatusResponse, error) {
-		if err := authorizeClaimStatusRead(ctx, cfg, in.ProjectID, in.Authorization); err != nil {
+		var err error
+		ctx, err = authorizeClaimStatusRead(ctx, cfg, in.ProjectID, in.Authorization)
+		if err != nil {
 			return nil, err
 		}
 		body, err := handleClaimStatus(ctx, cfg, in.ProjectID, in.Ref)
@@ -717,6 +723,8 @@ func ttlDuration(seconds int64) time.Duration {
 
 func claimAPIError(err error) error {
 	switch {
+	case errors.Is(err, ErrHostAccessDenied):
+		return federationCredentialDenied()
 	case errors.Is(err, db.ErrClaimDenied):
 		return api.NewError(http.StatusConflict, "claim_denied", err.Error(), "", nil)
 	case errors.Is(err, db.ErrClaimRequired):

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -143,7 +143,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 	}, func(ctx context.Context, in *api.FederationProjectMetadataRequest) (*api.ProjectFederationResponse, error) {
 		var err error
 		ctx, _, err = authorizeFederationRequest(ctx, cfg, in.Authorization, in.ProjectID, "pull",
-			HostFederationOperation{ID: "getFederationProjectMetadata"})
+			HostFederationOperation{ID: "getFederationProjectMetadata", Mutation: true})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -141,7 +141,10 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      "GET",
 		Path:        "/api/v1/projects/{project_id}/federation/metadata",
 	}, func(ctx context.Context, in *api.FederationProjectMetadataRequest) (*api.ProjectFederationResponse, error) {
-		if _, err := authorizeFederationRequest(ctx, cfg.DB, in.Authorization, in.ProjectID, "pull"); err != nil {
+		var err error
+		ctx, _, err = authorizeFederationRequest(ctx, cfg, in.Authorization, in.ProjectID, "pull",
+			HostFederationOperation{ID: "getFederationProjectMetadata"})
+		if err != nil {
 			return nil, err
 		}
 		body, err := projectFederationBody(ctx, cfg.DB, in.ProjectID)
@@ -437,7 +440,10 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      "GET",
 		Path:        "/api/v1/projects/{project_id}/federation/events",
 	}, func(ctx context.Context, in *api.FederationPollEventsRequest) (*api.PollEventsResponse, error) {
-		if _, err := authorizeFederationRequest(ctx, cfg.DB, in.Authorization, in.ProjectID, "pull"); err != nil {
+		var err error
+		ctx, _, err = authorizeFederationRequest(ctx, cfg, in.Authorization, in.ProjectID, "pull",
+			HostFederationOperation{ID: "pollFederationProjectEvents"})
+		if err != nil {
 			return nil, err
 		}
 		if in.ProjectID <= 0 {
@@ -455,7 +461,8 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Path:         "/api/v1/projects/{project_id}/federation/events:ingest",
 		MaxBodyBytes: 64 << 20,
 	}, func(ctx context.Context, in *api.FederationIngestEventsRequest) (*api.FederationIngestEventsResponse, error) {
-		principal, err := authorizeFederationRequest(ctx, cfg.DB, in.Authorization, in.ProjectID, "push")
+		ctx, principal, err := authorizeFederationRequest(ctx, cfg, in.Authorization, in.ProjectID, "push",
+			HostFederationOperation{ID: "ingestFederationProjectEvents", Mutation: true})
 		if err != nil {
 			return nil, err
 		}
@@ -563,6 +570,8 @@ func federationIngestEventsToDB(events []api.FederationIngestEventEnvelope) []db
 
 func federationIngestError(err error) error {
 	switch {
+	case errors.Is(err, ErrHostAccessDenied):
+		return federationCredentialDenied()
 	case errors.Is(err, db.ErrRemoteEventConflict):
 		return api.NewError(http.StatusConflict, "remote_event_conflict", err.Error(), "", nil)
 	case errors.Is(err, db.ErrRemoteEventHashMismatch), errors.Is(err, db.ErrFederationIngestValidation):

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -371,5 +371,12 @@ func internalAPIError(err error) error {
 	if errors.As(err, &apiErr) {
 		return apiErr
 	}
+	if errors.Is(err, ErrHostAccessDenied) {
+		return federationCredentialDenied()
+	}
+	if errors.Is(err, errHostFederationAccessUnavailable) {
+		return api.NewError(http.StatusServiceUnavailable, "access_unavailable",
+			"federation credential authorization is unavailable", "", nil)
+	}
 	return api.NewError(http.StatusInternalServerError, "internal", err.Error(), "", nil)
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -78,6 +78,10 @@ type ServerConfig struct {
 	// by a mounting application. It is nil for the standalone daemon.
 	HostAccess HostAccessController
 
+	// HostFederationAccess optionally adds host-owned authorization after Kata
+	// authenticates a project-scoped federation enrollment.
+	HostFederationAccess HostFederationAccessController
+
 	// EmbeddingProfile removes native administrative routes when their
 	// lifecycle is owned by a mounting application. The standalone daemon uses
 	// the zero value and retains every route.

--- a/internal/db/transaction_fence.go
+++ b/internal/db/transaction_fence.go
@@ -27,6 +27,25 @@ func WithTransactionFence(ctx context.Context, fence TransactionFence) context.C
 	return context.WithValue(ctx, transactionFenceContextKey{}, fence)
 }
 
+// WithAdditionalTransactionFence appends fence after any fence already carried
+// by ctx. The existing fence runs first and a rejection prevents the additional
+// fence and domain mutation from running.
+func WithAdditionalTransactionFence(ctx context.Context, fence TransactionFence) context.Context {
+	if fence == nil {
+		return ctx
+	}
+	existing, _ := ctx.Value(transactionFenceContextKey{}).(TransactionFence)
+	if existing == nil {
+		return WithTransactionFence(ctx, fence)
+	}
+	return WithTransactionFence(ctx, func(fenceCtx context.Context, transaction Transaction) error {
+		if err := existing(fenceCtx, transaction); err != nil {
+			return err
+		}
+		return fence(fenceCtx, transaction)
+	})
+}
+
 // ApplyTransactionFence invokes the request fence, if any, against tx.
 func ApplyTransactionFence(ctx context.Context, tx Transaction) error {
 	fence, _ := ctx.Value(transactionFenceContextKey{}).(TransactionFence)

--- a/service.go
+++ b/service.go
@@ -101,6 +101,10 @@ type Config struct {
 	// Access selects host-supplied in-process authentication and authorization.
 	// It is mutually exclusive with Auth.
 	Access AccessController
+	// FederationAccess optionally adds host-owned authorization after Kata has
+	// authenticated a project-scoped federation credential. It does not replace
+	// Kata's credential authentication.
+	FederationAccess FederationAccessController
 	// WorkerTransactionFence revalidates host authority from inside every
 	// background-worker writable storage transaction. It is required when
 	// Access is set.
@@ -232,6 +236,12 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 	if cfg.Access != nil {
 		hostAccess = hostAccessControllerAdapter{controller: cfg.Access}
 	}
+	var hostFederationAccess daemon.HostFederationAccessController
+	if cfg.FederationAccess != nil {
+		hostFederationAccess = hostFederationAccessControllerAdapter{
+			controller: cfg.FederationAccess,
+		}
+	}
 	server := daemon.NewServer(daemon.ServerConfig{
 		DB:                    store,
 		StartedAt:             startedAt,
@@ -244,6 +254,7 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 		Hooks:                 hookSink,
 		Auth:                  config.AuthConfig{Token: cfg.Auth.Token},
 		HostAccess:            hostAccess,
+		HostFederationAccess:  hostFederationAccess,
 		EmbeddingProfile:      daemon.EmbeddingProfile(cfg.Profile),
 		Logger:                logger,
 	})
@@ -324,6 +335,44 @@ func boolCount(values ...bool) int {
 
 type hostAccessControllerAdapter struct {
 	controller AccessController
+}
+
+type hostFederationAccessControllerAdapter struct {
+	controller FederationAccessController
+}
+
+func (a hostFederationAccessControllerAdapter) AuthorizeFederation(
+	ctx context.Context,
+	request daemon.HostFederationAccessRequest,
+) (daemon.HostFederationAccessDecision, error) {
+	if a.controller == nil {
+		return daemon.HostFederationAccessDecision{}, nil
+	}
+	decision, err := a.controller.AuthorizeFederation(ctx, FederationAccessRequest{
+		Enrollment: publicFederationEnrollment(request.Enrollment, request.Project.UID),
+		Project:    publicProject(request.Project),
+		Capability: FederationCapability(request.Capability),
+		Operation: FederationOperation{
+			ID: request.Operation.ID, Mutation: request.Operation.Mutation,
+		},
+	})
+	if errors.Is(err, ErrAccessDenied) {
+		return daemon.HostFederationAccessDecision{}, daemon.ErrHostAccessDenied
+	}
+	if err != nil {
+		return daemon.HostFederationAccessDecision{}, err
+	}
+	var transactionFence db.TransactionFence
+	if decision.TransactionFence != nil {
+		transactionFence = func(ctx context.Context, transaction db.Transaction) error {
+			err := decision.TransactionFence(ctx, transaction)
+			if errors.Is(err, ErrAccessDenied) {
+				return daemon.ErrHostAccessDenied
+			}
+			return err
+		}
+	}
+	return daemon.HostFederationAccessDecision{TransactionFence: transactionFence}, nil
 }
 
 func (a hostAccessControllerAdapter) Authorize(

--- a/service_federation_access_postgres_test.go
+++ b/service_federation_access_postgres_test.go
@@ -1,0 +1,76 @@
+package kata_test
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+func TestServicePostgresFederationAccessFenceRollsBackClaimMutation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	t.Cleanup(cleanup)
+
+	controller := &recordingFederationAccessController{
+		decide: func(request kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+			decision := kata.FederationAccessDecision{}
+			if request.Operation.Mutation {
+				decision.TransactionFence = func(ctx context.Context, tx kata.Transaction) error {
+					if _, err := tx.ExecContext(ctx,
+						`INSERT INTO kata.federation_fence_markers(attempt) VALUES($1)`, 1); err != nil {
+						return err
+					}
+					return kata.ErrAccessDenied
+				}
+			}
+			return decision, nil
+		},
+	}
+	service, err := kata.New(ctx, kata.Config{
+		DSN: dsn,
+		Postgres: kata.PostgresConfig{
+			Schema: "kata", SchemaMode: kata.PostgresSchemaBootstrap,
+		},
+		Auth:             kata.AuthConfig{TrustCallerAuthentication: true},
+		FederationAccess: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	project := ensureEnrollmentTestProject(
+		t, service, "01HZNQ7VFPK1XGD8R5MABCD4EX", "example-project",
+	)
+	enrollment, err := service.CreateFederationEnrollment(ctx, kata.FederationEnrollmentSpec{
+		ProjectUID:       project.UID,
+		SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4EA",
+		Capabilities:     "claim",
+		Actor:            "Example Operator",
+	})
+	require.NoError(t, err)
+	issue := createFederationAccessIssue(t, service, project.ID)
+
+	inspection, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inspection.Close()) })
+	_, err = inspection.ExecContext(ctx,
+		`CREATE TABLE kata.federation_fence_markers (attempt BIGINT NOT NULL)`)
+	require.NoError(t, err)
+
+	response := acquireFederationAccessClaim(t, service, project.ID, issue, enrollment.Token)
+	assert.Equal(t, http.StatusForbidden, response.Code, response.Body.String())
+
+	var markers, claims int
+	require.NoError(t, inspection.QueryRowContext(ctx,
+		`SELECT count(*) FROM kata.federation_fence_markers`).Scan(&markers))
+	require.NoError(t, inspection.QueryRowContext(ctx,
+		`SELECT count(*) FROM kata.issue_claims`).Scan(&claims))
+	assert.Zero(t, markers)
+	assert.Zero(t, claims)
+}

--- a/service_federation_access_test.go
+++ b/service_federation_access_test.go
@@ -1,0 +1,211 @@
+package kata_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata"
+)
+
+type recordingFederationAccessController struct {
+	mu       sync.Mutex
+	requests []kata.FederationAccessRequest
+	decide   func(kata.FederationAccessRequest) (kata.FederationAccessDecision, error)
+}
+
+func (c *recordingFederationAccessController) AuthorizeFederation(
+	_ context.Context,
+	request kata.FederationAccessRequest,
+) (kata.FederationAccessDecision, error) {
+	c.mu.Lock()
+	c.requests = append(c.requests, request)
+	c.mu.Unlock()
+	if c.decide != nil {
+		return c.decide(request)
+	}
+	return kata.FederationAccessDecision{}, nil
+}
+
+func (c *recordingFederationAccessController) snapshot() []kata.FederationAccessRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]kata.FederationAccessRequest(nil), c.requests...)
+}
+
+func TestServiceFederationAccessReceivesAuthenticatedEnrollment(t *testing.T) {
+	controller := &recordingFederationAccessController{}
+	service, project, enrollment := newFederationAccessService(t, controller)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(project.ID, 10)+"/federation/metadata", nil)
+	request.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	require.Len(t, controller.snapshot(), 1)
+	assert.Equal(t, kata.FederationAccessRequest{
+		Enrollment: enrollment.Enrollment,
+		Project:    project,
+		Capability: kata.FederationCapabilityPull,
+		Operation: kata.FederationOperation{
+			ID: "getFederationProjectMetadata", Mutation: false,
+		},
+	}, controller.snapshot()[0])
+}
+
+func TestServiceFederationAccessDenialDoesNotUseValidCredential(t *testing.T) {
+	controller := &recordingFederationAccessController{
+		decide: func(kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+			return kata.FederationAccessDecision{}, kata.ErrAccessDenied
+		},
+	}
+	service, project, enrollment := newFederationAccessService(t, controller)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(project.ID, 10)+"/federation/metadata", nil)
+	request.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusForbidden, response.Code)
+	assert.JSONEq(t,
+		`{"status":403,"error":{"code":"auth_invalid","message":"federation credential is not currently authorized"}}`,
+		response.Body.String())
+}
+
+func TestServiceFederationAccessRejectsInvalidCredentialBeforeHostDecision(t *testing.T) {
+	controller := &recordingFederationAccessController{}
+	service, project, _ := newFederationAccessService(t, controller)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(project.ID, 10)+"/federation/metadata", nil)
+	request.Header.Set("Authorization", "Bearer invalid-credential")
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusForbidden, response.Code)
+	assert.Empty(t, controller.snapshot())
+}
+
+func TestServiceFederationAccessMutationRequiresTransactionFence(t *testing.T) {
+	controller := &recordingFederationAccessController{}
+	service, project, enrollment := newFederationAccessService(t, controller)
+	issue := createFederationAccessIssue(t, service, project.ID)
+
+	response := acquireFederationAccessClaim(t, service, project.ID, issue, enrollment.Token)
+
+	assert.Equal(t, http.StatusServiceUnavailable, response.Code, response.Body.String())
+	assert.JSONEq(t,
+		`{"status":503,"error":{"code":"access_unavailable","message":"federation transaction access decision unavailable"}}`,
+		response.Body.String())
+	require.Len(t, controller.snapshot(), 1)
+	assert.Equal(t, kata.FederationCapabilityClaim, controller.snapshot()[0].Capability)
+	assert.Equal(t, kata.FederationOperation{
+		ID: "acquireIssueLease", Mutation: true,
+	}, controller.snapshot()[0].Operation)
+}
+
+func TestServiceFederationAccessFenceRollsBackClaimMutation(t *testing.T) {
+	controller := &recordingFederationAccessController{
+		decide: func(request kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+			decision := kata.FederationAccessDecision{}
+			if request.Operation.Mutation {
+				decision.TransactionFence = func(context.Context, kata.Transaction) error {
+					return kata.ErrAccessDenied
+				}
+			}
+			return decision, nil
+		},
+	}
+	service, project, enrollment := newFederationAccessService(t, controller)
+	issue := createFederationAccessIssue(t, service, project.ID)
+
+	response := acquireFederationAccessClaim(t, service, project.ID, issue, enrollment.Token)
+
+	assert.Equal(t, http.StatusForbidden, response.Code, response.Body.String())
+
+	controller.decide = nil
+	statusRequest := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(project.ID, 10)+"/issues/"+issue+"/lease", nil)
+	statusRequest.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	statusResponse := httptest.NewRecorder()
+	service.Handler().ServeHTTP(statusResponse, statusRequest)
+	require.Equal(t, http.StatusOK, statusResponse.Code, statusResponse.Body.String())
+	var status struct {
+		Held bool `json:"held"`
+	}
+	require.NoError(t, json.Unmarshal(statusResponse.Body.Bytes(), &status))
+	assert.False(t, status.Held)
+}
+
+func acquireFederationAccessClaim(
+	t *testing.T,
+	service *kata.Service,
+	projectID int64,
+	issue string,
+	token string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/projects/"+
+		strconv.FormatInt(projectID, 10)+"/issues/"+issue+"/lease/actions/acquire",
+		bytes.NewBufferString(`{"holder":"worker-1","claim_kind":"timed","ttl_seconds":300}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+token)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	return response
+}
+
+func newFederationAccessService(
+	t *testing.T,
+	controller kata.FederationAccessController,
+) (*kata.Service, kata.Project, kata.CreatedFederationEnrollment) {
+	t.Helper()
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:              filepath.Join(t.TempDir(), "service.db"),
+		Auth:             kata.AuthConfig{TrustCallerAuthentication: true},
+		FederationAccess: controller,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	project := ensureEnrollmentTestProject(
+		t, service, "01HZNQ7VFPK1XGD8R5MABCD4EX", "example-project",
+	)
+	enrollment, err := service.CreateFederationEnrollment(context.Background(), kata.FederationEnrollmentSpec{
+		ProjectUID:       project.UID,
+		SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4EA",
+		Capabilities:     "claim,pull,push",
+		Actor:            "Example Operator",
+	})
+	require.NoError(t, err)
+	return service, project, enrollment
+}
+
+func createFederationAccessIssue(t *testing.T, service *kata.Service, projectID int64) string {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/projects/"+
+		strconv.FormatInt(projectID, 10)+"/issues",
+		bytes.NewBufferString(`{"actor":"Example Operator","title":"claim fence"}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	var body struct {
+		Issue struct {
+			ShortID string `json:"short_id"`
+		} `json:"issue"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+	require.NotEmpty(t, body.Issue.ShortID)
+	return body.Issue.ShortID
+}

--- a/service_federation_access_test.go
+++ b/service_federation_access_test.go
@@ -3,6 +3,7 @@ package kata_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -251,6 +252,139 @@ func TestServiceFederationAccessSanitizesFenceFailure(t *testing.T) {
 		`{"status":503,"error":{"code":"access_unavailable","message":"federation credential authorization is unavailable"}}`,
 		response.Body.String())
 	assert.NotContains(t, response.Body.String(), "private controller detail")
+}
+
+func TestServiceFederationAccessPreservesOrdinaryMutationFence(t *testing.T) {
+	tests := []struct {
+		name       string
+		access     *recordingAccessController
+		wantStatus int
+	}{
+		{
+			name:       "missing ordinary fence",
+			access:     &recordingAccessController{omitTransactionFence: true},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "denying ordinary fence",
+			access: &recordingAccessController{transactionFence: func(context.Context, kata.Transaction) error {
+				return kata.ErrAccessDenied
+			}},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var federationFenceCalls int
+			federation := &recordingFederationAccessController{
+				decide: func(request kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+					decision := kata.FederationAccessDecision{}
+					if request.Operation.Mutation {
+						decision.TransactionFence = func(context.Context, kata.Transaction) error {
+							federationFenceCalls++
+							return nil
+						}
+					}
+					return decision, nil
+				},
+			}
+			service, project, enrollment, databasePath := newComposedFederationAccessService(t, tt.access, federation)
+			forceFederationBaselineRefresh(t, databasePath, project)
+
+			response := getFederationMetadataAsPrincipal(t, service, project.ID, enrollment.Token)
+
+			assert.Equal(t, tt.wantStatus, response.Code, response.Body.String())
+			assert.Zero(t, federationFenceCalls, "federation fence must not run after ordinary access rejects")
+		})
+	}
+}
+
+func TestServiceFederationAccessRunsBothMutationFencesInOrder(t *testing.T) {
+	var calls []string
+	access := &recordingAccessController{transactionFence: func(context.Context, kata.Transaction) error {
+		calls = append(calls, "ordinary")
+		return nil
+	}}
+	federation := &recordingFederationAccessController{
+		decide: func(request kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+			decision := kata.FederationAccessDecision{}
+			if request.Operation.Mutation {
+				decision.TransactionFence = func(context.Context, kata.Transaction) error {
+					calls = append(calls, "federation")
+					return nil
+				}
+			}
+			return decision, nil
+		},
+	}
+	service, project, enrollment, databasePath := newComposedFederationAccessService(t, access, federation)
+	forceFederationBaselineRefresh(t, databasePath, project)
+
+	response := getFederationMetadataAsPrincipal(t, service, project.ID, enrollment.Token)
+
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	assert.Equal(t, []string{"ordinary", "federation"}, calls)
+}
+
+func newComposedFederationAccessService(
+	t *testing.T,
+	access kata.AccessController,
+	federation kata.FederationAccessController,
+) (*kata.Service, kata.Project, kata.CreatedFederationEnrollment, string) {
+	t.Helper()
+	databasePath := filepath.Join(t.TempDir(), "service.db")
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN: databasePath, Access: access, FederationAccess: federation,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+	project := ensureEnrollmentTestProject(
+		t, service, "01HZNQ7VFPK1XGD8R5MABCD4EX", "example-project",
+	)
+	enrollment, err := service.CreateFederationEnrollment(context.Background(), kata.FederationEnrollmentSpec{
+		ProjectUID:       project.UID,
+		SpokeInstanceUID: "01HZNQ7VFPK1XGD8R5MABCD4EA",
+		Capabilities:     "pull,push",
+		Actor:            "Example Operator",
+	})
+	require.NoError(t, err)
+	return service, project, enrollment, databasePath
+}
+
+func forceFederationBaselineRefresh(t *testing.T, databasePath string, project kata.Project) {
+	t.Helper()
+	inspection, err := sql.Open("sqlite", databasePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inspection.Close()) })
+	_, err = inspection.Exec(`
+		INSERT INTO purge_log(
+			uid, origin_instance_uid, project_id, purged_issue_id,
+			project_uid, project_name, issue_title, issue_author,
+			comment_count, link_count, label_count, event_count,
+			purge_reset_after_event_id, short_id, actor
+		) VALUES(?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, ?, ?, ?)`,
+		"01HZNQ7VFPK1XGD8R5MABCD4EB", "01HZNQ7VFPK1XGD8R5MABCD4EC",
+		project.ID, 999, project.UID, project.Name, "purged issue", "Example User",
+		999999, "d4eb", "Example User")
+	require.NoError(t, err)
+}
+
+func getFederationMetadataAsPrincipal(
+	t *testing.T,
+	service *kata.Service,
+	projectID int64,
+	token string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(projectID, 10)+"/federation/metadata", nil)
+	request.Header.Set("Authorization", "Bearer "+token)
+	request = request.WithContext(kata.WithPrincipal(request.Context(), kata.Principal{
+		Subject: "user-123", Actor: "Example User",
+	}))
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+	return response
 }
 
 func acquireFederationAccessClaim(

--- a/service_federation_access_test.go
+++ b/service_federation_access_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -42,7 +43,7 @@ func (c *recordingFederationAccessController) snapshot() []kata.FederationAccess
 }
 
 func TestServiceFederationAccessReceivesAuthenticatedEnrollment(t *testing.T) {
-	controller := &recordingFederationAccessController{}
+	controller := &recordingFederationAccessController{decide: allowFederationMutation}
 	service, project, enrollment := newFederationAccessService(t, controller)
 
 	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
@@ -58,7 +59,7 @@ func TestServiceFederationAccessReceivesAuthenticatedEnrollment(t *testing.T) {
 		Project:    project,
 		Capability: kata.FederationCapabilityPull,
 		Operation: kata.FederationOperation{
-			ID: "getFederationProjectMetadata", Mutation: false,
+			ID: "getFederationProjectMetadata", Mutation: true,
 		},
 	}, controller.snapshot()[0])
 }
@@ -95,6 +96,78 @@ func TestServiceFederationAccessRejectsInvalidCredentialBeforeHostDecision(t *te
 
 	assert.Equal(t, http.StatusForbidden, response.Code)
 	assert.Empty(t, controller.snapshot())
+}
+
+func TestServiceFederationAccessChecksBearerOnLeaseStatus(t *testing.T) {
+	controller := &recordingFederationAccessController{
+		decide: func(kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+			return kata.FederationAccessDecision{}, kata.ErrAccessDenied
+		},
+	}
+	service, project, enrollment := newFederationAccessService(t, controller)
+	issue := createFederationAccessIssue(t, service, project.ID)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(project.ID, 10)+"/issues/"+issue+"/lease", nil)
+	request.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusForbidden, response.Code, response.Body.String())
+	require.Len(t, controller.snapshot(), 1)
+	assert.Equal(t, kata.FederationOperation{
+		ID: "getIssueLeaseStatus", Mutation: true,
+	}, controller.snapshot()[0].Operation)
+}
+
+func TestServiceFederationAccessRejectsInvalidLeaseStatusCredentialBeforeHostDecision(t *testing.T) {
+	controller := &recordingFederationAccessController{}
+	service, project, _ := newFederationAccessService(t, controller)
+	issue := createFederationAccessIssue(t, service, project.ID)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(project.ID, 10)+"/issues/"+issue+"/lease", nil)
+	request.Header.Set("Authorization", "Bearer invalid-credential")
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusForbidden, response.Code, response.Body.String())
+	assert.Empty(t, controller.snapshot())
+}
+
+func TestServiceFederationAccessKeepsTokenlessTrustedLeaseStatus(t *testing.T) {
+	controller := &recordingFederationAccessController{
+		decide: func(kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+			return kata.FederationAccessDecision{}, kata.ErrAccessDenied
+		},
+	}
+	service, project, _ := newFederationAccessService(t, controller)
+	issue := createFederationAccessIssue(t, service, project.ID)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(project.ID, 10)+"/issues/"+issue+"/lease", nil)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	assert.Empty(t, controller.snapshot())
+}
+
+func TestServiceFederationAccessMetadataRequiresTransactionFence(t *testing.T) {
+	controller := &recordingFederationAccessController{}
+	service, project, enrollment := newFederationAccessService(t, controller)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
+		strconv.FormatInt(project.ID, 10)+"/federation/metadata", nil)
+	request.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	response := httptest.NewRecorder()
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusServiceUnavailable, response.Code, response.Body.String())
+	require.Len(t, controller.snapshot(), 1)
+	assert.Equal(t, kata.FederationOperation{
+		ID: "getFederationProjectMetadata", Mutation: true,
+	}, controller.snapshot()[0].Operation)
 }
 
 func TestServiceFederationAccessMutationRequiresTransactionFence(t *testing.T) {
@@ -134,7 +207,7 @@ func TestServiceFederationAccessFenceRollsBackClaimMutation(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, response.Code, response.Body.String())
 
-	controller.decide = nil
+	controller.decide = allowFederationMutation
 	statusRequest := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+
 		strconv.FormatInt(project.ID, 10)+"/issues/"+issue+"/lease", nil)
 	statusRequest.Header.Set("Authorization", "Bearer "+enrollment.Token)
@@ -146,6 +219,38 @@ func TestServiceFederationAccessFenceRollsBackClaimMutation(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(statusResponse.Body.Bytes(), &status))
 	assert.False(t, status.Held)
+}
+
+func allowFederationMutation(request kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+	decision := kata.FederationAccessDecision{}
+	if request.Operation.Mutation {
+		decision.TransactionFence = func(context.Context, kata.Transaction) error { return nil }
+	}
+	return decision, nil
+}
+
+func TestServiceFederationAccessSanitizesFenceFailure(t *testing.T) {
+	controller := &recordingFederationAccessController{
+		decide: func(request kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+			decision := kata.FederationAccessDecision{}
+			if request.Operation.Mutation {
+				decision.TransactionFence = func(context.Context, kata.Transaction) error {
+					return errors.New("private controller detail")
+				}
+			}
+			return decision, nil
+		},
+	}
+	service, project, enrollment := newFederationAccessService(t, controller)
+	issue := createFederationAccessIssue(t, service, project.ID)
+
+	response := acquireFederationAccessClaim(t, service, project.ID, issue, enrollment.Token)
+
+	assert.Equal(t, http.StatusServiceUnavailable, response.Code, response.Body.String())
+	assert.JSONEq(t,
+		`{"status":503,"error":{"code":"access_unavailable","message":"federation credential authorization is unavailable"}}`,
+		response.Body.String())
+	assert.NotContains(t, response.Body.String(), "private controller detail")
 }
 
 func acquireFederationAccessClaim(


### PR DESCRIPTION
Mounted services may revoke the outside authority behind a Kata federation enrollment while the Kata credential itself is still valid. Kata's native token checks cannot observe that lifecycle, so mounts need a narrow way to deny an otherwise valid credential without replacing Kata authentication.

This adds an optional, product-neutral federation access controller. Kata still authenticates the credential and validates its project and capability first. The host can then approve or deny the exact enrollment, and mutations must carry a transaction fence so authority is rechecked in the same transaction as event ingest or lease state. Metadata and lease-status GETs use the same fence because they may maintain baselines, expire claims, or update cached lease state.

When an in-process principal and scoped credential are both present, their transaction fences are cumulative: ordinary host access runs first, followed by federation revalidation. Either layer can stop the mutation. Bearer-backed lease status always follows the scoped credential path, while tokenless trusted-caller behavior remains unchanged. Controller failures are returned as bounded 403 or 503 responses without exposing host details. Standalone behavior is unchanged when no controller is configured.