### PR TITLE
Expose bounded federation ingest admission

### DIFF
--- a/federation_access.go
+++ b/federation_access.go
@@ -1,6 +1,14 @@
 package kata
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrFederationAdmissionLimited asks Kata to reject an authenticated
+// federation request with 429 before reading a large request body. Embedding
+// hosts may return it when their bounded request admission is full.
+var ErrFederationAdmissionLimited = errors.New("kata: federation request admission limited")
 
 // FederationCapability is the transport authority requested by one
 // authenticated federation operation.

--- a/internal/daemon/federation_access.go
+++ b/internal/daemon/federation_access.go
@@ -9,6 +9,10 @@ import (
 
 var errHostFederationAccessUnavailable = errors.New("host federation access unavailable")
 
+// ErrHostFederationAdmissionLimited is the internal adapter form of a host's
+// bounded authenticated-request admission signal.
+var ErrHostFederationAdmissionLimited = errors.New("host federation request admission limited")
+
 // HostFederationOperation identifies one authenticated transport operation.
 type HostFederationOperation struct {
 	ID       string

--- a/internal/daemon/federation_auth.go
+++ b/internal/daemon/federation_auth.go
@@ -91,6 +91,10 @@ func evaluateFederationRequest(
 		if errors.Is(accessErr, ErrHostAccessDenied) {
 			return federationAuthorization{}, federationCredentialDenied()
 		}
+		if errors.Is(accessErr, ErrHostFederationAdmissionLimited) {
+			return federationAuthorization{}, api.NewError(http.StatusTooManyRequests,
+				"admission_limited", "federation request admission is full", "", nil)
+		}
 		if accessErr != nil {
 			return federationAuthorization{}, api.NewError(http.StatusServiceUnavailable,
 				"access_unavailable", "federation credential authorization is unavailable", "", nil)

--- a/internal/daemon/federation_auth.go
+++ b/internal/daemon/federation_auth.go
@@ -24,6 +24,16 @@ type federationAuthorization struct {
 	transactionFence db.TransactionFence
 }
 
+type federationAuthorizationContextKey struct{}
+
+type cachedFederationAuthorization struct {
+	authHeader    string
+	projectID     int64
+	capability    string
+	operation     HostFederationOperation
+	authorization federationAuthorization
+}
+
 func authorizeFederationRequest(
 	ctx context.Context,
 	cfg ServerConfig,
@@ -32,14 +42,49 @@ func authorizeFederationRequest(
 	capability string,
 	operation HostFederationOperation,
 ) (context.Context, federationPrincipal, error) {
-	authorization, err := evaluateFederationRequest(
-		ctx, cfg, authHeader, projectID, capability, operation,
+	authorization, ok := federationAuthorizationFromContext(
+		ctx, authHeader, projectID, capability, operation,
 	)
-	if err != nil {
-		return ctx, federationPrincipal{}, err
+	if !ok {
+		var err error
+		authorization, err = evaluateFederationRequest(
+			ctx, cfg, authHeader, projectID, capability, operation,
+		)
+		if err != nil {
+			return ctx, federationPrincipal{}, err
+		}
 	}
 	return db.WithAdditionalTransactionFence(ctx, authorization.transactionFence),
 		authorization.principal, nil
+}
+
+func withFederationAuthorization(
+	ctx context.Context,
+	authHeader string,
+	projectID int64,
+	capability string,
+	operation HostFederationOperation,
+	authorization federationAuthorization,
+) context.Context {
+	return context.WithValue(ctx, federationAuthorizationContextKey{}, cachedFederationAuthorization{
+		authHeader: authHeader, projectID: projectID, capability: capability,
+		operation: operation, authorization: authorization,
+	})
+}
+
+func federationAuthorizationFromContext(
+	ctx context.Context,
+	authHeader string,
+	projectID int64,
+	capability string,
+	operation HostFederationOperation,
+) (federationAuthorization, bool) {
+	cached, ok := ctx.Value(federationAuthorizationContextKey{}).(cachedFederationAuthorization)
+	if !ok || cached.authHeader != authHeader || cached.projectID != projectID ||
+		cached.capability != capability || cached.operation != operation {
+		return federationAuthorization{}, false
+	}
+	return cached.authorization, true
 }
 
 func evaluateFederationRequest(

--- a/internal/daemon/federation_preauth.go
+++ b/internal/daemon/federation_preauth.go
@@ -110,6 +110,9 @@ func federationIngestProjectID(method, path string) (projectID int64, matched, v
 func writeFederationPreauthorizationError(w http.ResponseWriter, err error) {
 	var apiErr *api.APIError
 	if errors.As(err, &apiErr) {
+		if apiErr.Status == http.StatusTooManyRequests {
+			w.Header().Set("Retry-After", "5")
+		}
 		api.WriteEnvelope(w, apiErr.Status, apiErr.Code, apiErr.Message)
 		return
 	}

--- a/internal/daemon/federation_preauth.go
+++ b/internal/daemon/federation_preauth.go
@@ -31,13 +31,17 @@ func withFederationIngestPreauthorization(cfg ServerConfig, next http.Handler) h
 			writeFederationPreauthorizationError(w, err)
 			return
 		}
-		_, err = evaluateFederationRequest(
-			ctx, cfg, r.Header.Get("Authorization"), projectID, "push", operation,
+		authHeader := r.Header.Get("Authorization")
+		authorization, err := evaluateFederationRequest(
+			ctx, cfg, authHeader, projectID, "push", operation,
 		)
 		if err != nil {
 			writeFederationPreauthorizationError(w, err)
 			return
 		}
+		ctx = withFederationAuthorization(
+			ctx, authHeader, projectID, "push", operation, authorization,
+		)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/service.go
+++ b/service.go
@@ -359,6 +359,9 @@ func (a hostFederationAccessControllerAdapter) AuthorizeFederation(
 	if errors.Is(err, ErrAccessDenied) {
 		return daemon.HostFederationAccessDecision{}, daemon.ErrHostAccessDenied
 	}
+	if errors.Is(err, ErrFederationAdmissionLimited) {
+		return daemon.HostFederationAccessDecision{}, daemon.ErrHostFederationAdmissionLimited
+	}
 	if err != nil {
 		return daemon.HostFederationAccessDecision{}, err
 	}

--- a/service_federation_access_test.go
+++ b/service_federation_access_test.go
@@ -127,6 +127,29 @@ func TestServiceFederationAccessAdmissionLimitStopsIngestBeforeBodyRead(t *testi
 	}, controller.snapshot()[0].Operation)
 }
 
+func TestServiceFederationIngestUsesAdmissionDecisionOnce(t *testing.T) {
+	var calls int
+	controller := &recordingFederationAccessController{
+		decide: func(request kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+			calls++
+			if calls > 1 {
+				return kata.FederationAccessDecision{}, kata.ErrFederationAdmissionLimited
+			}
+			return allowFederationMutation(request)
+		},
+	}
+	service, project, enrollment, databasePath := newComposedFederationAccessService(
+		t, nil, controller,
+	)
+
+	response := ingestFederationIssueAsPrincipal(t, service, project, enrollment.Token)
+
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	assert.Equal(t, 1, calls)
+	assert.Len(t, controller.snapshot(), 1)
+	assert.Equal(t, 1, storedFederationIssueCount(t, databasePath))
+}
+
 type readTrackingBody struct {
 	content []byte
 	reads   int
@@ -423,7 +446,7 @@ func TestServiceFederationIngestDenialRollsBackMutation(t *testing.T) {
 	assert.Zero(t, storedFederationIssueCount(t, databasePath))
 }
 
-func TestServiceFederationIngestReauthenticatesAfterBodyRead(t *testing.T) {
+func TestServiceFederationIngestOrdersNativeRevocationWithMutation(t *testing.T) {
 	federation := &recordingFederationAccessController{decide: allowFederationMutation}
 	service, project, enrollment, databasePath := newComposedFederationAccessService(t, nil, federation)
 	body := &revokeEnrollmentOnRead{
@@ -443,6 +466,7 @@ func TestServiceFederationIngestReauthenticatesAfterBodyRead(t *testing.T) {
 	require.NoError(t, body.err)
 	assert.Equal(t, http.StatusForbidden, response.Code, response.Body.String())
 	assert.Contains(t, response.Body.String(), "auth_invalid")
+	assert.Len(t, federation.snapshot(), 1)
 	assert.Zero(t, storedFederationIssueCount(t, databasePath))
 }
 
@@ -464,35 +488,6 @@ func TestServiceFederationIngestHostDenialPrecedesFederationAuthorization(t *tes
 
 	assert.Equal(t, http.StatusNotFound, response.Code, response.Body.String())
 	assert.Empty(t, federation.snapshot(), "host denial must precede federation authorization")
-	assert.Zero(t, storedFederationIssueCount(t, databasePath))
-}
-
-func TestServiceFederationIngestOrdersNativeRevocationWithMutation(t *testing.T) {
-	var (
-		service    *kata.Service
-		project    kata.Project
-		enrollment kata.CreatedFederationEnrollment
-		calls      int
-		revokeErr  error
-	)
-	federation := &recordingFederationAccessController{
-		decide: func(request kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
-			calls++
-			if calls == 2 {
-				revokeErr = service.RevokeFederationEnrollment(
-					t.Context(), project.UID, enrollment.Enrollment.ID,
-				)
-			}
-			return allowFederationMutation(request)
-		},
-	}
-	var databasePath string
-	service, project, enrollment, databasePath = newComposedFederationAccessService(t, nil, federation)
-
-	response := ingestFederationIssueAsPrincipal(t, service, project, enrollment.Token)
-
-	require.NoError(t, revokeErr)
-	assert.Equal(t, http.StatusForbidden, response.Code, response.Body.String())
 	assert.Zero(t, storedFederationIssueCount(t, databasePath))
 }
 

--- a/service_federation_access_test.go
+++ b/service_federation_access_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -99,6 +100,46 @@ func TestServiceFederationAccessRejectsInvalidCredentialBeforeHostDecision(t *te
 
 	assert.Equal(t, http.StatusForbidden, response.Code)
 	assert.Empty(t, controller.snapshot())
+}
+
+func TestServiceFederationAccessAdmissionLimitStopsIngestBeforeBodyRead(t *testing.T) {
+	controller := &recordingFederationAccessController{
+		decide: func(kata.FederationAccessRequest) (kata.FederationAccessDecision, error) {
+			return kata.FederationAccessDecision{}, kata.ErrFederationAdmissionLimited
+		},
+	}
+	service, project, enrollment := newFederationAccessService(t, controller)
+	body := &readTrackingBody{content: []byte(`{"events":[]}`)}
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/projects/"+
+		strconv.FormatInt(project.ID, 10)+"/federation/events:ingest", body)
+	request.Header.Set("Authorization", "Bearer "+enrollment.Token)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	service.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusTooManyRequests, response.Code, response.Body.String())
+	assert.Equal(t, "5", response.Header().Get("Retry-After"))
+	assert.Zero(t, body.reads)
+	require.Len(t, controller.snapshot(), 1)
+	assert.Equal(t, kata.FederationOperation{
+		ID: "ingestFederationProjectEvents", Mutation: true,
+	}, controller.snapshot()[0].Operation)
+}
+
+type readTrackingBody struct {
+	content []byte
+	reads   int
+}
+
+func (b *readTrackingBody) Read(p []byte) (int, error) {
+	b.reads++
+	if len(b.content) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, b.content)
+	b.content = b.content[n:]
+	return n, nil
 }
 
 func TestServiceFederationAccessChecksBearerOnLeaseStatus(t *testing.T) {


### PR DESCRIPTION
Large federation ingest bodies are authenticated before decoding, but an embedding host still needs to bound how many authenticated uploads enter the shared process at once. Without a typed admission result, hosts must either duplicate Kata credential validation or report saturation as an unrelated authorization failure.

This adds a product-neutral host admission signal. Kata maps it to a bounded `429` response with `Retry-After` during ingest preauthorization, before the request body is read. Existing standalone and embedded behavior is unchanged unless a host returns the new signal.