### PR TITLE
Add exact active federation enrollment lookup

### DIFF
--- a/internal/db/dbtest/conformance.go
+++ b/internal/db/dbtest/conformance.go
@@ -282,7 +282,7 @@ var storageScenarios = []scenario{
 			"CreateIssue", "CreateLink", "CreateProject", "EnableFederationPush", "ExportFederationBindings",
 			"ExportFederationEnrollments", "ExportFederationQuarantine", "ExportFederationSyncStatus",
 			"FederationBindingByProject", "FederationEnrollmentTransactionFence",
-			"FederationSyncStatusByProject", "ListFederationBindings",
+			"FederationSyncStatusByProject", "FindActiveFederationEnrollment", "ListFederationBindings",
 			"ListFederationEnrollments", "LinkByEndpoints", "PurgeIssue", "RecordFederationQuarantine", "RecordFederationSyncError",
 			"RecordFederationSyncPullStarted", "RecordFederationSyncPullSuccess",
 			"RecordFederationSyncPushStarted", "RecordFederationSyncPushSuccess",

--- a/internal/db/dbtest/conformance_federation.go
+++ b/internal/db/dbtest/conformance_federation.go
@@ -230,6 +230,29 @@ func checkFederationControlLifecycle(t *testing.T, store db.Storage) error {
 	assert.NotEqual(t, created.Token, created.Enrollment.TokenHash)
 	assert.Equal(t, db.FederationTokenHash(created.Token), created.Enrollment.TokenHash)
 	assert.Equal(t, "pull,push", created.Enrollment.Capabilities)
+	foundEnrollment, err := store.FindActiveFederationEnrollment(
+		ctx,
+		db.ActiveFederationEnrollmentParams{
+			ProjectID:        hub.ID,
+			SpokeInstanceUID: spokeUID,
+			Capabilities:     "pull,push",
+			Actor:            "member",
+		},
+	)
+	if err != nil {
+		return err
+	}
+	assert.Equal(t, created.Enrollment, foundEnrollment)
+	_, err = store.FindActiveFederationEnrollment(
+		ctx,
+		db.ActiveFederationEnrollmentParams{
+			ProjectID:        hub.ID,
+			SpokeInstanceUID: spokeUID,
+			Capabilities:     "pull,push",
+			Actor:            "different member",
+		},
+	)
+	assert.ErrorIs(t, err, db.ErrNotFound)
 	wildcard, err := store.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{
 		Token: "wildcard-enrollment-secret", SpokeInstanceUID: spokeUID,
 		Capabilities: "pull", Actor: "member",
@@ -305,6 +328,16 @@ func checkFederationControlLifecycle(t *testing.T, store db.Storage) error {
 	if err := store.RevokeFederationEnrollment(ctx, created.Enrollment.ID); err != nil {
 		return err
 	}
+	_, err = store.FindActiveFederationEnrollment(
+		ctx,
+		db.ActiveFederationEnrollmentParams{
+			ProjectID:        hub.ID,
+			SpokeInstanceUID: spokeUID,
+			Capabilities:     "pull,push",
+			Actor:            "member",
+		},
+	)
+	assert.ErrorIs(t, err, db.ErrNotFound)
 	_, err = store.AuthorizeFederationToken(ctx, created.Token, hub.ID, "pull")
 	assert.ErrorIs(t, err, db.ErrNotFound)
 	revokedFence := store.FederationEnrollmentTransactionFence(created.Enrollment, hub.ID, "pull")

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -655,6 +655,16 @@ type CreateFederationEnrollmentParams struct {
 	AllowAdoptionSnapshotAuthors bool
 }
 
+// ActiveFederationEnrollmentParams identifies an active enrollment without
+// using its secret. All fields are matched exactly.
+type ActiveFederationEnrollmentParams struct {
+	ProjectID                    int64
+	SpokeInstanceUID             string
+	Capabilities                 string
+	Actor                        string
+	AllowAdoptionSnapshotAuthors bool
+}
+
 // CreatedFederationEnrollment returns the created row plus the plaintext token
 // so callers can display generated credentials exactly once.
 type CreatedFederationEnrollment struct {

--- a/internal/db/pgstore/federation_control.go
+++ b/internal/db/pgstore/federation_control.go
@@ -322,6 +322,25 @@ func (s *Store) ListFederationEnrollments(ctx context.Context) ([]db.FederationE
 	return output, mapSQLError(rows.Err(), nil)
 }
 
+// FindActiveFederationEnrollment returns the newest active enrollment whose
+// public correlation fields exactly match the request.
+func (s *Store) FindActiveFederationEnrollment(
+	ctx context.Context,
+	p db.ActiveFederationEnrollmentParams,
+) (db.FederationEnrollment, error) {
+	return scanFederationEnrollment(s.QueryRowContext(ctx, federationEnrollmentSelect+`
+WHERE project_id=$1
+  AND spoke_instance_uid=$2
+  AND capabilities=$3
+  AND bound_actor=$4
+  AND allow_adoption_snapshot_authors=$5
+  AND revoked_at IS NULL
+ORDER BY id DESC
+LIMIT 1`,
+		p.ProjectID, p.SpokeInstanceUID, p.Capabilities, p.Actor,
+		boolNumber(p.AllowAdoptionSnapshotAuthors)))
+}
+
 // RevokeFederationEnrollment marks an enrollment inactive without changing its first revocation time.
 func (s *Store) RevokeFederationEnrollment(ctx context.Context, id int64) error {
 	result, err := s.ExecContext(ctx, `UPDATE federation_enrollments SET

--- a/internal/db/pgstore/stubgen/main.go
+++ b/internal/db/pgstore/stubgen/main.go
@@ -62,6 +62,7 @@ var alreadyImplemented = map[string]bool{
 	"FederationBindingByProject":           true, // federation_control.go
 	"FederationEnrollmentTransactionFence": true, // federation_control.go
 	"FederationSyncStatusByProject":        true, // federation_control.go
+	"FindActiveFederationEnrollment":       true, // federation_control.go
 	"ListFederationBindings":               true, // federation_control.go
 	"ListFederationEnrollments":            true, // federation_control.go
 	"LeaveFederationReplica":               true, // federation_projection.go

--- a/internal/db/pgstore/stubgen/main_test.go
+++ b/internal/db/pgstore/stubgen/main_test.go
@@ -38,7 +38,7 @@ type Storage interface { Only(context.Context) error }
 func TestStorageMethodInventoryClassifiesEveryMethod(t *testing.T) {
 	methods, err := CollectStorageMethodInventory("../../storage.go")
 	require.NoError(t, err)
-	require.Len(t, methods, 211)
+	require.Len(t, methods, 212)
 
 	var implemented []string
 	var stubbed []string
@@ -142,6 +142,7 @@ func TestStorageMethodInventoryClassifiesEveryMethod(t *testing.T) {
 		"FederationBindingByProject",
 		"FederationEnrollmentTransactionFence",
 		"FederationSyncStatusByProject",
+		"FindActiveFederationEnrollment",
 		"ForceReleaseClaim",
 		"GetRecurrenceByID",
 		"GetRecurrenceByUID",

--- a/internal/db/sqlitestore/federation_enrollments.go
+++ b/internal/db/sqlitestore/federation_enrollments.go
@@ -134,6 +134,25 @@ func (d *Store) ListFederationEnrollments(ctx context.Context) ([]db.FederationE
 	return out, rows.Err()
 }
 
+// FindActiveFederationEnrollment returns the newest active enrollment whose
+// public correlation fields exactly match the request.
+func (d *Store) FindActiveFederationEnrollment(
+	ctx context.Context,
+	p db.ActiveFederationEnrollmentParams,
+) (db.FederationEnrollment, error) {
+	return scanFederationEnrollment(d.QueryRowContext(ctx, federationEnrollmentSelect+`
+		 WHERE project_id = ?
+		   AND spoke_instance_uid = ?
+		   AND capabilities = ?
+		   AND bound_actor = ?
+		   AND allow_adoption_snapshot_authors = ?
+		   AND revoked_at IS NULL
+		 ORDER BY id DESC
+		 LIMIT 1`,
+		p.ProjectID, p.SpokeInstanceUID, p.Capabilities, p.Actor,
+		p.AllowAdoptionSnapshotAuthors))
+}
+
 // RevokeFederationEnrollment marks an enrollment inactive. Revocation is
 // one-way; repeated calls leave the original revoked_at intact.
 func (d *Store) RevokeFederationEnrollment(ctx context.Context, id int64) error {

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -243,6 +243,7 @@ type Storage interface {
 	// federation: enrollments
 	CreateFederationEnrollment(ctx context.Context, p CreateFederationEnrollmentParams) (CreatedFederationEnrollment, error)
 	CreateProjectFederationEnrollment(ctx context.Context, p CreateFederationEnrollmentParams) (CreatedFederationEnrollment, error)
+	FindActiveFederationEnrollment(ctx context.Context, p ActiveFederationEnrollmentParams) (FederationEnrollment, error)
 	ListFederationEnrollments(ctx context.Context) ([]FederationEnrollment, error)
 	RevokeFederationEnrollment(ctx context.Context, id int64) error
 	AuthorizeFederationToken(ctx context.Context, token string, projectID int64, capability string) (FederationEnrollment, error)

--- a/service_federation_enrollments.go
+++ b/service_federation_enrollments.go
@@ -124,6 +124,52 @@ func (s *Service) ListFederationEnrollments(
 	return result, nil
 }
 
+// FindActiveFederationEnrollment finds an active project credential by its
+// public correlation fields without scanning retained enrollment history.
+// Plaintext credentials and their stored hashes are never returned.
+func (s *Service) FindActiveFederationEnrollment(
+	ctx context.Context,
+	spec FederationEnrollmentSpec,
+) (FederationEnrollment, bool, error) {
+	capabilities, actor, err := validateFederationEnrollmentSpec(spec)
+	if err != nil {
+		return FederationEnrollment{}, false, err
+	}
+	callCtx, done, err := s.beginHostCall(ctx)
+	if err != nil {
+		return FederationEnrollment{}, false, err
+	}
+	defer done()
+
+	project, found, err := s.projectByUID(callCtx, spec.ProjectUID)
+	if err != nil {
+		return FederationEnrollment{}, false, err
+	}
+	if !found {
+		return FederationEnrollment{}, false, ErrProjectNotFound
+	}
+	enrollment, err := s.store.FindActiveFederationEnrollment(
+		callCtx,
+		db.ActiveFederationEnrollmentParams{
+			ProjectID:                    project.ID,
+			SpokeInstanceUID:             spec.SpokeInstanceUID,
+			Capabilities:                 capabilities,
+			Actor:                        actor,
+			AllowAdoptionSnapshotAuthors: spec.AllowAdoptionSnapshotAuthors,
+		},
+	)
+	if errors.Is(err, db.ErrNotFound) {
+		return FederationEnrollment{}, false, nil
+	}
+	if err != nil {
+		return FederationEnrollment{}, false, fmt.Errorf(
+			"kata: find active federation enrollment: %w",
+			err,
+		)
+	}
+	return publicFederationEnrollment(enrollment, project.UID), true, nil
+}
+
 // RevokeFederationEnrollment permanently revokes one credential belonging to
 // the requested project. Repeating an exact revocation is harmless.
 func (s *Service) RevokeFederationEnrollment(

--- a/service_federation_enrollments_test.go
+++ b/service_federation_enrollments_test.go
@@ -45,6 +45,32 @@ func TestServiceFederationEnrollmentLifecycleIsProjectScoped(t *testing.T) {
 	assert.True(t, created.Enrollment.AllowAdoptionSnapshotAuthors)
 	assert.Nil(t, created.Enrollment.RevokedAt)
 
+	foundEnrollment, found, err := service.FindActiveFederationEnrollment(
+		context.Background(),
+		kata.FederationEnrollmentSpec{
+			ProjectUID:                   firstProject.UID,
+			SpokeInstanceUID:             created.Enrollment.SpokeInstanceUID,
+			Capabilities:                 created.Enrollment.Capabilities,
+			Actor:                        created.Enrollment.Actor,
+			AllowAdoptionSnapshotAuthors: created.Enrollment.AllowAdoptionSnapshotAuthors,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, created.Enrollment, foundEnrollment)
+
+	_, found, err = service.FindActiveFederationEnrollment(
+		context.Background(),
+		kata.FederationEnrollmentSpec{
+			ProjectUID:       firstProject.UID,
+			SpokeInstanceUID: created.Enrollment.SpokeInstanceUID,
+			Capabilities:     created.Enrollment.Capabilities,
+			Actor:            "Different Operator",
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, found)
+
 	firstHistory, err := service.ListFederationEnrollments(context.Background(), firstProject.UID)
 	require.NoError(t, err)
 	require.Len(t, firstHistory, 1)
@@ -69,6 +95,18 @@ func TestServiceFederationEnrollmentLifecycleIsProjectScoped(t *testing.T) {
 		context.Background(), firstProject.UID, created.Enrollment.ID,
 	), "exact revocation retries must be harmless")
 	assertFederationTokenStatus(t, service, firstProject.ID, created.Token, http.StatusForbidden)
+	_, found, err = service.FindActiveFederationEnrollment(
+		context.Background(),
+		kata.FederationEnrollmentSpec{
+			ProjectUID:                   firstProject.UID,
+			SpokeInstanceUID:             created.Enrollment.SpokeInstanceUID,
+			Capabilities:                 created.Enrollment.Capabilities,
+			Actor:                        created.Enrollment.Actor,
+			AllowAdoptionSnapshotAuthors: created.Enrollment.AllowAdoptionSnapshotAuthors,
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, found)
 
 	firstHistory, err = service.ListFederationEnrollments(context.Background(), firstProject.UID)
 	require.NoError(t, err)


### PR DESCRIPTION
Mounted services may need to recover after credential creation committed but the caller did not receive the result. The existing list API requires loading all retained enrollment history, so recovery cost grows with every revoked credential.

This adds a narrow, project-scoped lookup by the enrollment’s non-secret correlation fields. SQLite and PostgreSQL query only active rows and return no plaintext secret or stored hash. The standalone HTTP surface and database schema are unchanged.