### PR TITLE
Keep remote TUI project resolution path-free

### DIFF
--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -18,6 +18,16 @@ import (
 // callers honor it via EnsureRunning.
 type BaseURLKey struct{}
 
+// RunningDaemon identifies the endpoint selected by EnsureRunningTarget and
+// whether it came from configured remote resolution. Callers that need to
+// decide whether client-local filesystem paths are valid must use
+// ConfiguredRemote instead of inferring locality from the endpoint address:
+// a configured remote may be reached through a loopback SSH tunnel.
+type RunningDaemon struct {
+	BaseURL          string
+	ConfiguredRemote bool
+}
+
 const (
 	daemonServiceName       = "kata"
 	skipDaemonVersionEnvVar = "KATA_SKIP_DAEMON_VERSION_CHECK"
@@ -44,7 +54,14 @@ var (
 // EnsureRunningInWorkspace instead so the walk anchors to the
 // targeted workspace.
 func EnsureRunning(ctx context.Context) (string, error) {
-	return EnsureRunningInWorkspace(ctx, "")
+	target, err := EnsureRunningTarget(ctx)
+	return target.BaseURL, err
+}
+
+// EnsureRunningTarget is EnsureRunning with endpoint-source metadata for
+// callers that must distinguish configured remotes from local discovery.
+func EnsureRunningTarget(ctx context.Context) (RunningDaemon, error) {
+	return ensureRunningTargetInWorkspace(ctx, "")
 }
 
 // EnsureRunningInWorkspace is the workspace-aware variant of
@@ -55,15 +72,24 @@ func EnsureRunning(ctx context.Context) (string, error) {
 // outside the repo still picks up /repo/.kata.local.toml's [server]
 // override instead of falling through to local auto-start.
 func EnsureRunningInWorkspace(ctx context.Context, workspaceStart string) (string, error) {
+	target, err := ensureRunningTargetInWorkspace(ctx, workspaceStart)
+	return target.BaseURL, err
+}
+
+func ensureRunningTargetInWorkspace(ctx context.Context, workspaceStart string) (RunningDaemon, error) {
 	if v, ok := ctx.Value(BaseURLKey{}).(string); ok && v != "" {
-		return v, nil
+		return RunningDaemon{BaseURL: v}, nil
 	}
 	if url, ok, err := resolveRemote(ctx, workspaceStart); err != nil {
-		return "", err
+		return RunningDaemon{}, err
 	} else if ok {
-		return url, nil
+		return RunningDaemon{BaseURL: url, ConfiguredRemote: true}, nil
 	}
-	return ensureLocalRunning(ctx)
+	url, err := ensureLocalRunning(ctx)
+	if err != nil {
+		return RunningDaemon{}, err
+	}
+	return RunningDaemon{BaseURL: url}, nil
 }
 
 // EnsureLocalRunning returns a live local daemon's base URL, ignoring

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -70,6 +70,49 @@ func TestEnsureLocalRunningIgnoresRemoteOverride(t *testing.T) {
 	assert.Equal(t, 1, restore.startCalls)
 }
 
+func TestEnsureRunningTargetMarksEnvironmentRemote(t *testing.T) {
+	srv := pingingServer(t)
+	t.Setenv("KATA_SERVER", srv.URL)
+
+	target, err := EnsureRunningTarget(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL, target.BaseURL)
+	assert.True(t, target.ConfiguredRemote)
+}
+
+func TestEnsureRunningTargetMarksWorkspaceConfigRemote(t *testing.T) {
+	srv := pingingServer(t)
+	t.Setenv("KATA_SERVER", "")
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.toml"),
+		[]byte("version = 1\n\n[project]\nidentity = \"example.test/spoke-project\"\nname = \"spoke-project\"\n"),
+		0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
+		[]byte("version = 1\n\n[server]\nurl = \""+srv.URL+"\"\n"),
+		0o600))
+
+	target, err := EnsureRunningTarget(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL, target.BaseURL)
+	assert.True(t, target.ConfiguredRemote)
+}
+
+func TestEnsureRunningTargetMarksLocalDiscovery(t *testing.T) {
+	t.Setenv("KATA_SERVER", "")
+	setupKataEnv(t)
+	restore := patchEnsureHooks(t, currentVersionForEnsure(), "http://local-daemon")
+
+	target, err := EnsureRunningTarget(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, "http://local-daemon", target.BaseURL)
+	assert.False(t, target.ConfiguredRemote)
+	assert.Equal(t, 1, restore.startCalls)
+}
+
 func TestAutoStartUsesKitDetachedStarter(t *testing.T) {
 	setupKataEnv(t)
 	ns, err := daemon.NewNamespace()

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -88,7 +88,7 @@ func TestEnsureRunningTargetMarksWorkspaceConfigRemote(t *testing.T) {
 	t.Chdir(workspace)
 	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.toml"),
 		[]byte("version = 1\n\n[project]\nidentity = \"example.test/spoke-project\"\nname = \"spoke-project\"\n"),
-		0o644))
+		0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
 		[]byte("version = 1\n\n[server]\nurl = \""+srv.URL+"\"\n"),
 		0o600))

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -234,9 +234,29 @@ func (c *Client) EditBody(
 // returns a canonical name that differs from the local .kata.toml, the
 // client rewrites the file in place.
 func (c *Client) ResolveProject(ctx context.Context, startPath string) (*ResolveResp, error) {
+	return c.resolveProject(ctx, startPath, true)
+}
+
+var errPathFreeProjectNotInitialized = errors.New("project not initialized in client workspace")
+
+// ResolveProjectPathFree resolves only wire shapes that a daemon on another
+// host can understand. An unbound non-Git directory returns a local sentinel
+// instead of sending start_path, which belongs to the client's filesystem.
+func (c *Client) ResolveProjectPathFree(ctx context.Context, startPath string) (*ResolveResp, error) {
+	return c.resolveProject(ctx, startPath, false)
+}
+
+func (c *Client) resolveProject(
+	ctx context.Context,
+	startPath string,
+	allowStartPath bool,
+) (*ResolveResp, error) {
 	req, repair, err := buildResolveRequest(ctx, startPath)
 	if err != nil {
 		return nil, err
+	}
+	if _, ok := req["start_path"]; ok && !allowStartPath {
+		return nil, errPathFreeProjectNotInitialized
 	}
 	var resp ResolveResp
 	if err := c.do(ctx, http.MethodPost, "/api/v1/projects/resolve", req, &resp); err != nil {

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -240,8 +240,8 @@ func (c *Client) ResolveProject(ctx context.Context, startPath string) (*Resolve
 var errPathFreeProjectNotInitialized = errors.New("project not initialized in client workspace")
 
 // ResolveProjectPathFree resolves only wire shapes that a daemon on another
-// host can understand. An unbound non-Git directory returns a local sentinel
-// instead of sending start_path, which belongs to the client's filesystem.
+// host can understand. Client filesystem paths, whether represented as
+// start_path or a local:/// alias, never cross the wire.
 func (c *Client) ResolveProjectPathFree(ctx context.Context, startPath string) (*ResolveResp, error) {
 	return c.resolveProject(ctx, startPath, false)
 }
@@ -255,8 +255,10 @@ func (c *Client) resolveProject(
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := req["start_path"]; ok && !allowStartPath {
-		return nil, errPathFreeProjectNotInitialized
+	if !allowStartPath {
+		if err := makeResolveRequestPathFree(req); err != nil {
+			return nil, err
+		}
 	}
 	var resp ResolveResp
 	if err := c.do(ctx, http.MethodPost, "/api/v1/projects/resolve", req, &resp); err != nil {
@@ -268,6 +270,32 @@ func (c *Client) resolveProject(
 		}
 	}
 	return &resp, nil
+}
+
+func makeResolveRequestPathFree(req map[string]any) error {
+	if _, ok := req["start_path"]; ok {
+		return errPathFreeProjectNotInitialized
+	}
+	rawAlias, ok := req["alias"]
+	if !ok {
+		return nil
+	}
+	alias, ok := rawAlias.(map[string]any)
+	if !ok {
+		return errors.New("build path-free resolve request: invalid alias")
+	}
+	switch alias["kind"] {
+	case "git":
+		return nil
+	case "local":
+		if name, ok := req["name"].(string); ok && name != "" {
+			delete(req, "alias")
+			return nil
+		}
+		return errPathFreeProjectNotInitialized
+	default:
+		return fmt.Errorf("build path-free resolve request: invalid alias kind %q", alias["kind"])
+	}
 }
 
 // buildResolveRequest selects the resolve wire shape and returns an

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -1061,6 +1061,21 @@ func TestClient_ResolveProject_FallsBackOnMissingConfig(t *testing.T) {
 	assert.False(t, hasName)
 }
 
+func TestClientResolveProjectPathFreeDoesNotSendStartPath(t *testing.T) {
+	dir := t.TempDir()
+	var called atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called.Add(1)
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL, srv.Client())
+
+	_, err := c.ResolveProjectPathFree(t.Context(), dir)
+
+	require.ErrorIs(t, err, errPathFreeProjectNotInitialized)
+	assert.Zero(t, called.Load(), "path-free resolution must not send a client path to the daemon")
+}
+
 // TestClient_ResolveProject_SendsNameAndAliasForWorkspaceConfig is
 // regression coverage for issue #35: when .kata.toml is readable, the
 // TUI must send {name, alias} so a daemon on another host can resolve

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -1076,6 +1076,68 @@ func TestClientResolveProjectPathFreeDoesNotSendStartPath(t *testing.T) {
 	assert.Zero(t, called.Load(), "path-free resolution must not send a client path to the daemon")
 }
 
+func TestClientResolveProjectPathFreeDoesNotSendLocalGitAlias(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	var called atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"project":{"id":42}}`))
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL, srv.Client())
+
+	_, err := c.ResolveProjectPathFree(t.Context(), dir)
+
+	require.ErrorIs(t, err, errPathFreeProjectNotInitialized)
+	assert.Zero(t, called.Load(), "path-free resolution must not send a local:/// Git alias")
+}
+
+func TestClientResolveProjectPathFreeUsesNameInsteadOfLocalWorkspaceAlias(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, config.WriteProjectConfig(dir, "example-workspace"))
+
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"project":{"id":42,"name":"example-workspace"}}`))
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL, srv.Client())
+
+	_, err := c.ResolveProjectPathFree(t.Context(), dir)
+
+	require.NoError(t, err)
+	assert.Equal(t, "example-workspace", got["name"])
+	assert.NotContains(t, got, "alias")
+	assert.NotContains(t, got, "start_path")
+}
+
+func TestClientResolveProjectPathFreeSendsPortableGitAlias(t *testing.T) {
+	dir := testfix.InitGitRepo(t)
+	testfix.RunGit(t, dir, "remote", "add", "origin", "https://example.com/example/example-workspace.git")
+
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"project":{"id":42,"name":"example-workspace"}}`))
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL, srv.Client())
+
+	_, err := c.ResolveProjectPathFree(t.Context(), dir)
+
+	require.NoError(t, err)
+	assert.NotContains(t, got, "name")
+	assert.NotContains(t, got, "start_path")
+	assert.Equal(t, map[string]any{
+		"identity": "example.com/example/example-workspace",
+		"kind":     "git",
+	}, got["alias"])
+}
+
 // TestClient_ResolveProject_SendsNameAndAliasForWorkspaceConfig is
 // regression coverage for issue #35: when .kata.toml is readable, the
 // TUI must send {name, alias} so a daemon on another host can resolve

--- a/internal/tui/daemon_target.go
+++ b/internal/tui/daemon_target.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -84,8 +85,9 @@ var (
 			},
 			opts)
 	}
-	bootResolveScopeForTUI    = bootResolveScope
-	connectDaemonTargetForTUI = connectDaemonTarget
+	bootResolveScopeForTUI         = bootResolveScope
+	bootResolveScopePathFreeForTUI = bootResolveScopePathFree
+	connectDaemonTargetForTUI      = connectDaemonTarget
 )
 
 func daemonTargetsFromConfig(daemons []config.CatalogDaemonConfig) []daemonTarget {
@@ -203,7 +205,11 @@ func connectResolvedDaemonTarget(ctx context.Context, target daemonTarget, endpo
 		c.setLocalHTTPClientRefresh(localHTTPClientRefreshForTarget(endpoint, target))
 	}
 	cwd, _ := os.Getwd()
-	bi, err := bootResolveScopeForTUI(ctx, c, cwd)
+	resolveScope := bootResolveScopeForTUI
+	if daemonTargetUsesRemoteFilesystem(target, endpoint) {
+		resolveScope = bootResolveScopePathFreeForTUI
+	}
+	bi, err := resolveScope(ctx, c, cwd)
 	if err != nil {
 		return daemonConnection{}, err
 	}
@@ -214,6 +220,21 @@ func connectResolvedDaemonTarget(ctx context.Context, target daemonTarget, endpo
 		target:   target,
 		init:     bi,
 	}, nil
+}
+
+func daemonTargetUsesRemoteFilesystem(target daemonTarget, endpoint string) bool {
+	if target.Local || endpoint == client.UnixBase {
+		return false
+	}
+	if !target.Implicit {
+		return true
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return true
+	}
+	ip := net.ParseIP(u.Hostname())
+	return ip == nil || !ip.IsLoopback()
 }
 
 func localHTTPClientRefreshForTarget(

--- a/internal/tui/daemon_target.go
+++ b/internal/tui/daemon_target.go
@@ -21,6 +21,7 @@ type daemonTarget struct {
 	TokenEnv             string
 	AllowInsecure        bool
 	Implicit             bool
+	ConfiguredRemote     bool
 	UseAuthTokenOverride bool
 }
 
@@ -42,7 +43,7 @@ const (
 
 var (
 	readDaemonConfigForTUI   = config.ReadDaemonConfig
-	ensureRunningForTUI      = client.EnsureRunning
+	ensureRunningForTUI      = client.EnsureRunningTarget
 	ensureLocalRunningForTUI = client.EnsureLocalRunning
 	normalizeRemoteURLForTUI = func(v string, allowInsecure bool) (string, error) {
 		return client.NormalizeRemoteURL(v, allowInsecure)
@@ -148,12 +149,13 @@ func bootDaemonConnection(ctx context.Context, opts Options) (daemonConnection, 
 }
 
 func connectImplicitDaemonTarget(ctx context.Context) (daemonConnection, error) {
-	endpoint, err := ensureRunningForTUI(ctx)
+	running, err := ensureRunningForTUI(ctx)
 	if err != nil {
 		return daemonConnection{}, err
 	}
-	target := implicitDaemonTarget(endpoint)
-	return connectResolvedDaemonTarget(ctx, target, endpoint)
+	target := implicitDaemonTarget(running.BaseURL)
+	target.ConfiguredRemote = running.ConfiguredRemote
+	return connectResolvedDaemonTarget(ctx, target, running.BaseURL)
 }
 
 func connectDaemonTarget(ctx context.Context, target daemonTarget) (daemonConnection, error) {
@@ -225,6 +227,9 @@ func connectResolvedDaemonTarget(ctx context.Context, target daemonTarget, endpo
 func daemonTargetUsesRemoteFilesystem(target daemonTarget, endpoint string) bool {
 	if target.Local || endpoint == client.UnixBase {
 		return false
+	}
+	if target.ConfiguredRemote {
+		return true
 	}
 	if !target.Implicit {
 		return true

--- a/internal/tui/daemon_target_test.go
+++ b/internal/tui/daemon_target_test.go
@@ -200,7 +200,7 @@ func TestConnectImplicitConfiguredLoopbackUsesPathFreeBoot(t *testing.T) {
 				t.Chdir(workspace)
 				require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.toml"),
 					[]byte("version = 1\n\n[project]\nidentity = \"example.test/spoke-project\"\nname = \"spoke-project\"\n"),
-					0o644))
+					0o600))
 				require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
 					[]byte("version = 1\n\n[server]\nurl = \""+srv.URL+"\"\n"),
 					0o600))

--- a/internal/tui/daemon_target_test.go
+++ b/internal/tui/daemon_target_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -77,9 +78,9 @@ func TestConnectDaemonTargetLocalUsesLocalOnlyEnsurePath(t *testing.T) {
 	})
 
 	var ensured bool
-	ensureRunningForTUI = func(context.Context) (string, error) {
+	ensureRunningForTUI = func(context.Context) (clientpkg.RunningDaemon, error) {
 		t.Fatal("explicit local target must not honor remote-aware EnsureRunning")
-		return "", nil
+		return clientpkg.RunningDaemon{}, nil
 	}
 	ensureLocalRunningForTUI = func(context.Context) (string, error) {
 		ensured = true
@@ -174,6 +175,77 @@ func TestConnectResolvedImplicitLoopbackUsesLocalBoot(t *testing.T) {
 	assert.Equal(t, viewEmpty, conn.init.view)
 }
 
+func TestConnectImplicitConfiguredLoopbackUsesPathFreeBoot(t *testing.T) {
+	for _, source := range []string{"environment", "workspace config"} {
+		t.Run(source, func(t *testing.T) {
+			t.Setenv("KATA_HOME", t.TempDir())
+			t.Setenv("KATA_SERVER", "")
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/v1/ping" {
+					http.NotFound(w, r)
+					return
+				}
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"ok":      true,
+					"service": "kata",
+					"version": "test",
+				}))
+			}))
+			t.Cleanup(srv.Close)
+
+			if source == "environment" {
+				t.Setenv("KATA_SERVER", srv.URL)
+			} else {
+				workspace := t.TempDir()
+				t.Chdir(workspace)
+				require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.toml"),
+					[]byte("version = 1\n\n[project]\nidentity = \"example.test/spoke-project\"\nname = \"spoke-project\"\n"),
+					0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
+					[]byte("version = 1\n\n[server]\nurl = \""+srv.URL+"\"\n"),
+					0o600))
+			}
+
+			oldEnsure := ensureRunningForTUI
+			oldNewClient := newHTTPClientForTUI
+			oldBootScope := bootResolveScopeForTUI
+			oldPathFreeBootScope := bootResolveScopePathFreeForTUI
+			t.Cleanup(func() {
+				ensureRunningForTUI = oldEnsure
+				newHTTPClientForTUI = oldNewClient
+				bootResolveScopeForTUI = oldBootScope
+				bootResolveScopePathFreeForTUI = oldPathFreeBootScope
+			})
+
+			ensureRunningForTUI = clientpkg.EnsureRunningTarget
+			newHTTPClientForTUI = func(
+				context.Context,
+				string,
+				daemonTarget,
+				clientOptsKind,
+			) (*http.Client, error) {
+				return &http.Client{}, nil
+			}
+			bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+				t.Fatal("configured loopback daemon must not use start_path-capable boot")
+				return bootInit{}, nil
+			}
+			var called bool
+			bootResolveScopePathFreeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+				called = true
+				return bootInit{view: viewProjects}, nil
+			}
+
+			conn, err := connectImplicitDaemonTarget(t.Context())
+
+			require.NoError(t, err)
+			assert.True(t, called)
+			assert.Equal(t, srv.URL, conn.endpoint)
+			assert.Equal(t, viewProjects, conn.init.view)
+		})
+	}
+}
+
 func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *testing.T) {
 	oldRead := readDaemonConfigForTUI
 	oldEnsure := ensureRunningForTUI
@@ -192,9 +264,9 @@ func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *t
 		return &config.DaemonConfig{}, nil
 	}
 	var ensured bool
-	ensureRunningForTUI = func(context.Context) (string, error) {
+	ensureRunningForTUI = func(context.Context) (clientpkg.RunningDaemon, error) {
 		ensured = true
-		return "http://kata.invalid", nil
+		return clientpkg.RunningDaemon{BaseURL: "http://kata.invalid"}, nil
 	}
 	ensureLocalRunningForTUI = func(context.Context) (string, error) {
 		t.Fatal("implicit default boot must keep existing remote-aware EnsureRunning behavior")
@@ -264,8 +336,11 @@ func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testin
 	readDaemonConfigForTUI = func() (*config.DaemonConfig, error) {
 		return &config.DaemonConfig{}, nil
 	}
-	ensureRunningForTUI = func(context.Context) (string, error) {
-		return "http://100.64.0.5:7777", nil
+	ensureRunningForTUI = func(context.Context) (clientpkg.RunningDaemon, error) {
+		return clientpkg.RunningDaemon{
+			BaseURL:          "https://daemon.example:7777",
+			ConfiguredRemote: true,
+		}, nil
 	}
 	newHTTPClientForTUI = func(_ context.Context, _ string, _ daemonTarget, _ clientOptsKind) (*http.Client, error) {
 		return &http.Client{}, nil
@@ -279,8 +354,8 @@ func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testin
 
 	require.NoError(t, err)
 	assert.False(t, conn.target.Local)
-	assert.Equal(t, "http://100.64.0.5:7777", conn.target.URL)
-	assert.Equal(t, "100.64.0.5:7777", daemonTargetDisplay(conn.target))
+	assert.Equal(t, "https://daemon.example:7777", conn.target.URL)
+	assert.Equal(t, "daemon.example:7777", daemonTargetDisplay(conn.target))
 }
 
 func TestResolvedImplicitRemoteTargetCarriesEnvAllowInsecure(t *testing.T) {

--- a/internal/tui/daemon_target_test.go
+++ b/internal/tui/daemon_target_test.go
@@ -101,6 +101,79 @@ func TestConnectDaemonTargetLocalUsesLocalOnlyEnsurePath(t *testing.T) {
 	assert.Equal(t, viewEmpty, conn.init.view)
 }
 
+func TestConnectResolvedRemoteUsesPathFreeBoot(t *testing.T) {
+	oldNewClient := newHTTPClientForTUI
+	oldBootScope := bootResolveScopeForTUI
+	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
+	t.Cleanup(func() {
+		newHTTPClientForTUI = oldNewClient
+		bootResolveScopeForTUI = oldBootScope
+		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
+	})
+
+	newHTTPClientForTUI = func(
+		context.Context,
+		string,
+		daemonTarget,
+		clientOptsKind,
+	) (*http.Client, error) {
+		return &http.Client{}, nil
+	}
+	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+		t.Fatal("remote daemon must not use start_path-capable boot")
+		return bootInit{}, nil
+	}
+	var called bool
+	bootResolveScopePathFreeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+		called = true
+		return bootInit{view: viewProjects}, nil
+	}
+
+	conn, err := connectResolvedDaemonTarget(t.Context(),
+		daemonTarget{Name: "shared", URL: "https://daemon.example"},
+		"https://daemon.example")
+
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, viewProjects, conn.init.view)
+}
+
+func TestConnectResolvedImplicitLoopbackUsesLocalBoot(t *testing.T) {
+	oldNewClient := newHTTPClientForTUI
+	oldBootScope := bootResolveScopeForTUI
+	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
+	t.Cleanup(func() {
+		newHTTPClientForTUI = oldNewClient
+		bootResolveScopeForTUI = oldBootScope
+		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
+	})
+
+	newHTTPClientForTUI = func(
+		context.Context,
+		string,
+		daemonTarget,
+		clientOptsKind,
+	) (*http.Client, error) {
+		return &http.Client{}, nil
+	}
+	var called bool
+	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+		called = true
+		return bootInit{view: viewEmpty, scope: scope{empty: true}}, nil
+	}
+	bootResolveScopePathFreeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+		t.Fatal("implicit loopback daemon shares the client filesystem")
+		return bootInit{}, nil
+	}
+	endpoint := "http://127.0.0.1:7777"
+
+	conn, err := connectResolvedDaemonTarget(t.Context(), implicitDaemonTarget(endpoint), endpoint)
+
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, viewEmpty, conn.init.view)
+}
+
 func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *testing.T) {
 	oldRead := readDaemonConfigForTUI
 	oldEnsure := ensureRunningForTUI
@@ -179,11 +252,13 @@ func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testin
 	oldEnsure := ensureRunningForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
+	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 	t.Cleanup(func() {
 		readDaemonConfigForTUI = oldRead
 		ensureRunningForTUI = oldEnsure
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
+		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
 	})
 
 	readDaemonConfigForTUI = func() (*config.DaemonConfig, error) {
@@ -198,6 +273,7 @@ func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testin
 	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
 		return bootInit{view: viewEmpty, scope: scope{empty: true}}, nil
 	}
+	bootResolveScopePathFreeForTUI = bootResolveScopeForTUI
 
 	conn, err := bootDaemonConnection(context.Background(), Options{})
 
@@ -402,11 +478,13 @@ func TestConnectDaemonTargetRemoteUsesPerDaemonAuth(t *testing.T) {
 	oldProbe := probeRemoteForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
+	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 	t.Cleanup(func() {
 		normalizeRemoteURLForTUI = oldNormalize
 		probeRemoteForTUI = oldProbe
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
+		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
 	})
 
 	target := daemonTarget{Name: "shared", URL: "http://daemon.internal:7777", Token: "tok", AllowInsecure: true}
@@ -428,6 +506,7 @@ func TestConnectDaemonTargetRemoteUsesPerDaemonAuth(t *testing.T) {
 	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
 		return bootInit{view: viewEmpty, scope: scope{empty: true}}, nil
 	}
+	bootResolveScopePathFreeForTUI = bootResolveScopeForTUI
 
 	conn, err := connectDaemonTarget(context.Background(), target)
 
@@ -445,11 +524,13 @@ func TestConnectDaemonTargetRemoteResolvesTokenEnvOnUse(t *testing.T) {
 	oldProbe := probeRemoteForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
+	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 	t.Cleanup(func() {
 		normalizeRemoteURLForTUI = oldNormalize
 		probeRemoteForTUI = oldProbe
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
+		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
 	})
 	t.Setenv("KATA_WORK_TOKEN", "secret-from-env")
 
@@ -470,6 +551,7 @@ func TestConnectDaemonTargetRemoteResolvesTokenEnvOnUse(t *testing.T) {
 	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
 		return bootInit{view: viewEmpty, scope: scope{empty: true}}, nil
 	}
+	bootResolveScopePathFreeForTUI = bootResolveScopeForTUI
 
 	conn, err := connectDaemonTarget(context.Background(), target)
 
@@ -484,11 +566,13 @@ func TestConnectDaemonTargetRemoteAuthTokenEnvOverridesUnsetTokenEnv(t *testing.
 	oldProbe := probeRemoteForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
+	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 	t.Cleanup(func() {
 		normalizeRemoteURLForTUI = oldNormalize
 		probeRemoteForTUI = oldProbe
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
+		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
 	})
 	t.Setenv("KATA_AUTH_TOKEN", "env-token")
 	t.Setenv("KATA_HOME", t.TempDir())
@@ -511,6 +595,7 @@ func TestConnectDaemonTargetRemoteAuthTokenEnvOverridesUnsetTokenEnv(t *testing.
 	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
 		return bootInit{view: viewEmpty, scope: scope{empty: true}}, nil
 	}
+	bootResolveScopePathFreeForTUI = bootResolveScopeForTUI
 
 	conn, err := connectDaemonTarget(context.Background(), target)
 

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -241,7 +241,20 @@ type bootInit struct {
 //
 // On error, the bootInit is the zero value; callers must check err first.
 func bootResolveScope(ctx context.Context, c *Client, cwd string) (bootInit, error) {
-	rr, err := c.ResolveProject(ctx, cwd)
+	return bootResolveScopeWith(ctx, c, cwd, c.ResolveProject)
+}
+
+func bootResolveScopePathFree(ctx context.Context, c *Client, cwd string) (bootInit, error) {
+	return bootResolveScopeWith(ctx, c, cwd, c.ResolveProjectPathFree)
+}
+
+func bootResolveScopeWith(
+	ctx context.Context,
+	c *Client,
+	cwd string,
+	resolve func(context.Context, string) (*ResolveResp, error),
+) (bootInit, error) {
+	rr, err := resolve(ctx, cwd)
 	if err == nil {
 		return bootInit{
 			scope: scope{
@@ -266,7 +279,8 @@ func bootResolveScope(ctx context.Context, c *Client, cwd string) (bootInit, err
 		}, nil
 	}
 	var apiErr *APIError
-	if !errors.As(err, &apiErr) || apiErr.Code != "project_not_initialized" {
+	if !errors.Is(err, errPathFreeProjectNotInitialized) &&
+		(!errors.As(err, &apiErr) || apiErr.Code != "project_not_initialized") {
 		return bootInit{}, err
 	}
 	rows, err := c.ListProjectsWithStats(ctx)

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -196,6 +196,23 @@ func TestBoot_UnresolvedWithProjects_LandsViewProjects(t *testing.T) {
 	assert.Equal(t, "kata", bi.projects[0].Name)
 }
 
+func TestBootRemoteUnboundPathLandsOnProjects(t *testing.T) {
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects": func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "stats", r.URL.Query().Get("include"))
+			_, _ = w.Write([]byte(`{"projects":[{"id":7,"name":"example-workspace"}]}`))
+		},
+	})
+	c := NewClient(srv.URL, srv.Client())
+
+	bi, err := bootResolveScopePathFree(t.Context(), c, t.TempDir())
+
+	require.NoError(t, err)
+	assert.Equal(t, viewProjects, bi.view)
+	require.Len(t, bi.projects, 1)
+	assert.Equal(t, "example-workspace", bi.projects[0].Name)
+}
+
 // TestBootScopedResolveSeedsProjectUID: a TUI launched inside a project must
 // know that project's UID from the first frame. The adopt-first enroll flow's
 // rejoin detection reads projectUIDByID; before the async project-list fetch


### PR DESCRIPTION
## Why

The TUI could send its current filesystem path while connecting to a daemon that uses a different filesystem. A healthy remote connection then failed during project resolution before the user could select a project.

Remote resolution also treated local-only aliases as portable identities, which could expose a client path and still could not identify the same workspace elsewhere.

## Behavior

- Remote daemon targets resolve only portable project names and Git identities.
- Local-only aliases are omitted when a project name is available and otherwise open the remote project picker without making a resolve request.
- Configured remotes remain path-free even when reached through a loopback tunnel.
- Locally discovered Unix and loopback targets retain filesystem-based discovery.
- Portable Git aliases continue to support cross-host project resolution.