### PR TITLE
Bootstrap reusable CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_call:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
## Summary

- make the existing CI workflow callable from a later main-pinned dispatcher
- retain the current pull-request trigger and GitHub-hosted execution during the bootstrap phase

This preserves full pull-request validation while the runner-routing change is reviewed and landed separately.
