### PR TITLE
Open issue refs directly in the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ kata create "fix login race"           # prints a short id, e.g. abc4
 kata list                              # see open work
 kata show abc4                         # inspect by short id
 kata tui                               # browse and triage interactively
+kata tui abc4                          # open an issue directly in the TUI
 ```
 
 `kata create` prints each issue's short id; use it in later commands. Close only

--- a/cmd/kata/tui_cmd.go
+++ b/cmd/kata/tui_cmd.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/tui"
 )
+
+var runTUI = tui.Run
 
 // newTUICmd registers the TUI command. --all-projects is intentionally
 // absent today: the daemon has no cross-project list endpoint
@@ -19,16 +22,17 @@ func newTUICmd() *cobra.Command {
 	var uidFormat string
 	var mouse bool
 	cmd := &cobra.Command{
-		Use:   "tui",
+		Use:   "tui [issue-ref]",
 		Short: "open the interactive issue browser",
 		Long: `kata tui opens a Bubble Tea TUI scoped to the current project (per .kata.toml).
+Pass an optional issue ref to open that issue's detail view directly.
 Press ? for help, q to quit.
 
 Mouse support is opt-in. Set [tui] mouse = true in <KATA_HOME>/config.toml
 or pass --mouse for one run. Hold Option (macOS) or Shift (Linux) for native
 terminal text selection while mouse tracking is enabled.`,
-		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if currentOutputMode() == outputAgent {
 				return &cliError{Message: "kata tui does not support --agent; run without output formatting", Kind: kindUsage, ExitCode: ExitUsage}
 			}
@@ -47,12 +51,26 @@ terminal text selection while mouse tracking is enabled.`,
 			if err != nil {
 				return err
 			}
-			return tui.Run(ctx, tui.Options{
+			var initialIssueRef string
+			if len(args) == 1 {
+				initialIssueRef = args[0]
+			}
+			workspace := strings.TrimSpace(flags.Workspace)
+			if workspace != "" {
+				workspace, err = resolveStartPath(workspace)
+				if err != nil {
+					return err
+				}
+			}
+			return runTUI(ctx, tui.Options{
 				Stdout:           cmd.OutOrStdout(),
 				Stderr:           cmd.ErrOrStderr(),
 				DisplayUIDFormat: uidFormat,
 				DaemonName:       flags.Daemon,
 				Mouse:            mouseEnabled,
+				InitialIssueRef:  initialIssueRef,
+				ProjectName:      strings.TrimSpace(flags.Project),
+				Workspace:        workspace,
 			})
 		},
 	}

--- a/cmd/kata/tui_cmd_test.go
+++ b/cmd/kata/tui_cmd_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/tui"
 )
 
 // kata tui needs a TTY, so we exercise the registration via --help;
@@ -29,6 +30,9 @@ func TestTUI_CommandRegistered(t *testing.T) {
 	}
 	if !strings.Contains(out, "--mouse") {
 		t.Fatalf("--mouse missing from help: %s", out)
+	}
+	if !strings.Contains(out, "kata tui [issue-ref]") {
+		t.Fatalf("optional issue ref missing from help: %s", out)
 	}
 	for _, banned := range []string{"--all-projects", "--include-deleted"} {
 		if strings.Contains(out, banned) {
@@ -66,18 +70,53 @@ func TestTUI_RejectsAgentOutputBeforeLaunch(t *testing.T) {
 	}
 }
 
-// TestTUI_RejectsExtraArgs guards the cobra.NoArgs constraint: a typo'd
-// positional must error out before RunE so the user sees a usage
-// failure (and the TTY check in tui.Run is never reached, which would
-// be inappropriate for an arg-parse failure).
-func TestTUI_RejectsExtraArgs(t *testing.T) {
-	_, err := runCmdOutput(t, nil, "tui", "extra-positional")
+func TestTUI_AcceptsOptionalIssueRef(t *testing.T) {
+	var got tui.Options
+	old := runTUI
+	runTUI = func(_ context.Context, opts tui.Options) error {
+		got = opts
+		return nil
+	}
+	t.Cleanup(func() { runTUI = old })
+
+	_, err := runCmdOutput(t, nil, "tui", "abc4")
+	require.NoError(t, err)
+	assert.Equal(t, "abc4", got.InitialIssueRef)
+}
+
+func TestTUI_ThreadsProjectAndWorkspaceSelectors(t *testing.T) {
+	var got tui.Options
+	old := runTUI
+	runTUI = func(_ context.Context, opts tui.Options) error {
+		got = opts
+		return nil
+	}
+	t.Cleanup(func() { runTUI = old })
+	workspace := t.TempDir()
+
+	_, err := runCmdOutput(
+		t, nil,
+		"--project", "project-b",
+		"--workspace", workspace,
+		"tui", "abc4",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "project-b", got.ProjectName)
+	assert.Equal(t, workspace, got.Workspace)
+	assert.Equal(t, "abc4", got.InitialIssueRef)
+}
+
+// TestTUI_RejectsMoreThanOneIssueRef guards the one-ref CLI contract:
+// accepting two refs would make the direct-open target ambiguous.
+func TestTUI_RejectsMoreThanOneIssueRef(t *testing.T) {
+	_, err := runCmdOutput(t, nil, "tui", "abc4", "def5")
 	if err == nil {
-		t.Fatal("expected error for extra positional arg")
+		t.Fatal("expected error for more than one issue ref")
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, "unknown command") &&
-		!strings.Contains(msg, "accepts no args") {
+		!strings.Contains(msg, "accepts at most 1 arg") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -36,6 +36,13 @@ Open the TUI when a human wants to browse or triage:
 kata tui
 ```
 
+Pass an issue ref to open its detail view directly. The optional ref accepts
+the same bare short ID, qualified short ID, and full UID forms as `kata show`:
+
+```sh
+kata tui abc4
+```
+
 In the issue list, press `v` to switch between nested and flat views. Nested
 view groups children under parents; flat view shows matching issues as peers in
 list order, which is useful when recently updated child issues should not be

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -424,7 +424,7 @@ kata health
 kata whoami
 kata quickstart
 kata version [--json]
-kata tui
+kata tui [issue-ref]
 ```
 
 `kata version --json` is a local-only machine-readable version check. It does
@@ -466,13 +466,17 @@ For TCP listener auth modes, including trusted private-network bearer auth,
 read-only experiments, and explicit tokenless private-network writes, see
 [Remote daemon](../operations/remote-daemon.md).
 
-`kata tui` opens the interactive issue browser. In the issue list, `v` toggles
-between nested and flat views: nested groups children under parents, while flat
-shows matching issues as peers in list order. Returning from flat to nested
-starts with parents collapsed. In nested view, `space` or right arrow expands
-the selected parent, left arrow collapses it, and `E` toggles every parent in
-the current list. `E` expands all when any parent is collapsed, then collapses
-all when every parent is already expanded.
+`kata tui` opens the interactive issue browser. Pass an optional issue ref,
+such as `kata tui abc4`, to open that issue's detail view directly. The ref
+accepts the same bare short ID, qualified short ID, and full UID forms as
+`kata show`.
+
+In the issue list, `v` toggles between nested and flat views: nested groups
+children under parents, while flat shows matching issues as peers in list
+order. Returning from flat to nested starts with parents collapsed. In nested
+view, `space` or right arrow expands the selected parent, left arrow collapses
+it, and `E` toggles every parent in the current list. `E` expands all when any
+parent is collapsed, then collapses all when every parent is already expanded.
 
 `PgUp` and `PgDn` page by the visible issue-list window. When a page lands on
 the first or final page, the cursor keeps its screen row; pressing the same page

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -64,6 +64,15 @@ func EnsureRunningTarget(ctx context.Context) (RunningDaemon, error) {
 	return ensureRunningTargetInWorkspace(ctx, "")
 }
 
+// EnsureRunningTargetInWorkspace is the workspace-aware form of
+// EnsureRunningTarget. It preserves endpoint-source metadata while anchoring
+// .kata.local.toml discovery to workspaceStart.
+func EnsureRunningTargetInWorkspace(
+	ctx context.Context, workspaceStart string,
+) (RunningDaemon, error) {
+	return ensureRunningTargetInWorkspace(ctx, workspaceStart)
+}
+
 // EnsureRunningInWorkspace is the workspace-aware variant of
 // EnsureRunning. workspaceStart is the absolute path to begin the
 // .kata.local.toml walk from; pass "" to fall back to CWD. Empty is

--- a/internal/tui/daemon_target.go
+++ b/internal/tui/daemon_target.go
@@ -23,6 +23,8 @@ type daemonTarget struct {
 	Implicit             bool
 	ConfiguredRemote     bool
 	UseAuthTokenOverride bool
+	workspaceStart       string
+	skipInitialScope     bool
 }
 
 type daemonConnection struct {
@@ -43,7 +45,7 @@ const (
 
 var (
 	readDaemonConfigForTUI   = config.ReadDaemonConfig
-	ensureRunningForTUI      = client.EnsureRunningTarget
+	ensureRunningForTUI      = client.EnsureRunningTargetInWorkspace
 	ensureLocalRunningForTUI = client.EnsureLocalRunning
 	normalizeRemoteURLForTUI = func(v string, allowInsecure bool) (string, error) {
 		return client.NormalizeRemoteURL(v, allowInsecure)
@@ -58,10 +60,11 @@ var (
 		kind clientOptsKind,
 	) (*http.Client, error) {
 		opts := optsForKind(kind)
+		opts.WorkspaceStart = target.workspaceStart
 		if target.Local || target.Implicit {
 			if target.Implicit {
 				opts.AllowInsecure = target.AllowInsecure ||
-					client.RemoteAllowInsecureForBaseURL(endpoint, "")
+					client.RemoteAllowInsecureForBaseURL(endpoint, target.workspaceStart)
 			}
 			if target.Token != "" {
 				return client.NewHTTPClientWithBearer(ctx, endpoint, target.Token, opts)
@@ -119,11 +122,17 @@ func activeDaemonTarget(targets []daemonTarget, active string) (daemonTarget, bo
 }
 
 func bootDaemonConnection(ctx context.Context, opts Options) (daemonConnection, error) {
+	workspaceStart, skipInitialScope, err := initialScopeDirective(opts)
+	if err != nil {
+		return daemonConnection{}, err
+	}
 	cfg, err := readDaemonConfigForTUI()
 	if err != nil {
 		return daemonConnection{}, err
 	}
-	catalog := daemonTargetsFromConfig(cfg.Daemons)
+	catalog := daemonTargetsWithLaunchSelectors(
+		daemonTargetsFromConfig(cfg.Daemons), opts,
+	)
 	targetName := cfg.ActiveDaemon
 	if strings.TrimSpace(opts.DaemonName) != "" {
 		targetName = strings.TrimSpace(opts.DaemonName)
@@ -133,13 +142,15 @@ func bootDaemonConnection(ctx context.Context, opts Options) (daemonConnection, 
 		if targetName != "" {
 			return daemonConnection{}, fmt.Errorf("daemon %q is not in daemon catalog", targetName)
 		}
-		conn, err := connectImplicitDaemonTarget(ctx)
+		conn, err := connectImplicitDaemonTarget(ctx, workspaceStart, skipInitialScope)
 		if err != nil {
 			return daemonConnection{}, err
 		}
 		conn.catalog = catalog
 		return conn, nil
 	}
+	target.workspaceStart = workspaceStart
+	target.skipInitialScope = skipInitialScope
 	conn, err := connectDaemonTargetForTUI(ctx, target)
 	if err != nil {
 		return daemonConnection{}, err
@@ -148,14 +159,43 @@ func bootDaemonConnection(ctx context.Context, opts Options) (daemonConnection, 
 	return conn, nil
 }
 
-func connectImplicitDaemonTarget(ctx context.Context) (daemonConnection, error) {
-	running, err := ensureRunningForTUI(ctx)
+func daemonTargetsWithLaunchSelectors(
+	targets []daemonTarget, opts Options,
+) []daemonTarget {
+	out := make([]daemonTarget, 0, len(targets))
+	for _, target := range targets {
+		out = append(out, daemonTargetWithLaunchSelectors(target, opts))
+	}
+	return out
+}
+
+func daemonTargetWithLaunchSelectors(target daemonTarget, opts Options) daemonTarget {
+	target.workspaceStart = strings.TrimSpace(opts.Workspace)
+	target.skipInitialScope = strings.TrimSpace(opts.ProjectName) != ""
+	return target
+}
+
+func connectImplicitDaemonTarget(
+	ctx context.Context, workspaceStart string, skipInitialScope bool,
+) (daemonConnection, error) {
+	running, err := ensureRunningForTUI(ctx, workspaceStart)
 	if err != nil {
 		return daemonConnection{}, err
 	}
 	target := implicitDaemonTarget(running.BaseURL)
 	target.ConfiguredRemote = running.ConfiguredRemote
+	target.workspaceStart = workspaceStart
+	target.skipInitialScope = skipInitialScope
 	return connectResolvedDaemonTarget(ctx, target, running.BaseURL)
+}
+
+func initialScopeDirective(opts Options) (string, bool, error) {
+	qualified, err := initialIssueRefIsQualified(opts.InitialIssueRef)
+	if err != nil {
+		return "", false, err
+	}
+	skipInitialScope := qualified || strings.TrimSpace(opts.ProjectName) != ""
+	return strings.TrimSpace(opts.Workspace), skipInitialScope, nil
 }
 
 func connectDaemonTarget(ctx context.Context, target daemonTarget) (daemonConnection, error) {
@@ -206,14 +246,20 @@ func connectResolvedDaemonTarget(ctx context.Context, target daemonTarget, endpo
 	if endpoint == client.UnixBase {
 		c.setLocalHTTPClientRefresh(localHTTPClientRefreshForTarget(endpoint, target))
 	}
-	cwd, _ := os.Getwd()
-	resolveScope := bootResolveScopeForTUI
-	if daemonTargetUsesRemoteFilesystem(target, endpoint) {
-		resolveScope = bootResolveScopePathFreeForTUI
-	}
-	bi, err := resolveScope(ctx, c, cwd)
-	if err != nil {
-		return daemonConnection{}, err
+	var bi bootInit
+	if !target.skipInitialScope {
+		startPath := target.workspaceStart
+		if startPath == "" {
+			startPath, _ = os.Getwd()
+		}
+		resolveScope := bootResolveScopeForTUI
+		if daemonTargetUsesRemoteFilesystem(target, endpoint) {
+			resolveScope = bootResolveScopePathFreeForTUI
+		}
+		bi, err = resolveScope(ctx, c, startPath)
+		if err != nil {
+			return daemonConnection{}, err
+		}
 	}
 	return daemonConnection{
 		api:      c,
@@ -278,7 +324,9 @@ func resolvedDaemonTarget(target daemonTarget, endpoint string) daemonTarget {
 	if target.Local {
 		target.URL = ""
 	} else if target.Implicit {
-		target.AllowInsecure = client.RemoteAllowInsecureForBaseURL(endpoint, "")
+		target.AllowInsecure = client.RemoteAllowInsecureForBaseURL(
+			endpoint, target.workspaceStart,
+		)
 	}
 	if (target.Local || target.Implicit) && target.Token == "" {
 		target.Token = effectiveGlobalAuthTokenForTUI()

--- a/internal/tui/daemon_target_test.go
+++ b/internal/tui/daemon_target_test.go
@@ -78,7 +78,7 @@ func TestConnectDaemonTargetLocalUsesLocalOnlyEnsurePath(t *testing.T) {
 	})
 
 	var ensured bool
-	ensureRunningForTUI = func(context.Context) (clientpkg.RunningDaemon, error) {
+	ensureRunningForTUI = func(context.Context, string) (clientpkg.RunningDaemon, error) {
 		t.Fatal("explicit local target must not honor remote-aware EnsureRunning")
 		return clientpkg.RunningDaemon{}, nil
 	}
@@ -217,7 +217,7 @@ func TestConnectImplicitConfiguredLoopbackUsesPathFreeBoot(t *testing.T) {
 				bootResolveScopePathFreeForTUI = oldPathFreeBootScope
 			})
 
-			ensureRunningForTUI = clientpkg.EnsureRunningTarget
+			ensureRunningForTUI = clientpkg.EnsureRunningTargetInWorkspace
 			newHTTPClientForTUI = func(
 				context.Context,
 				string,
@@ -236,7 +236,7 @@ func TestConnectImplicitConfiguredLoopbackUsesPathFreeBoot(t *testing.T) {
 				return bootInit{view: viewProjects}, nil
 			}
 
-			conn, err := connectImplicitDaemonTarget(t.Context())
+			conn, err := connectImplicitDaemonTarget(t.Context(), "", false)
 
 			require.NoError(t, err)
 			assert.True(t, called)
@@ -244,6 +244,53 @@ func TestConnectImplicitConfiguredLoopbackUsesPathFreeBoot(t *testing.T) {
 			assert.Equal(t, viewProjects, conn.init.view)
 		})
 	}
+}
+
+func TestConnectImplicitWorkspaceRemoteThreadsPlaintextAuthOptions(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "workspace-token")
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	workspace := t.TempDir()
+	require.NoError(t, config.WriteProjectConfig(workspace, "spoke-project"))
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
+		[]byte(`version = 1
+
+[server]
+url = "http://daemon.internal:7777"
+allow_insecure = true
+`), 0o600))
+
+	oldEnsure := ensureRunningForTUI
+	oldBootScope := bootResolveScopeForTUI
+	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
+	t.Cleanup(func() {
+		ensureRunningForTUI = oldEnsure
+		bootResolveScopeForTUI = oldBootScope
+		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
+	})
+	ensureRunningForTUI = func(_ context.Context, gotWorkspace string) (clientpkg.RunningDaemon, error) {
+		assert.Equal(t, workspace, gotWorkspace)
+		return clientpkg.RunningDaemon{
+			BaseURL:          "http://daemon.internal:7777",
+			ConfiguredRemote: true,
+		}, nil
+	}
+	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+		t.Fatal("workspace-configured remote must use path-free boot")
+		return bootInit{}, nil
+	}
+	bootResolveScopePathFreeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+		return bootInit{view: viewProjects}, nil
+	}
+
+	conn, err := connectImplicitDaemonTarget(t.Context(), workspace, false)
+
+	require.NoError(t, err)
+	assert.True(t, conn.target.AllowInsecure)
+	require.NotNil(t, conn.api)
+	require.NotNil(t, conn.sseHC)
 }
 
 func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *testing.T) {
@@ -263,9 +310,11 @@ func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *t
 	readDaemonConfigForTUI = func() (*config.DaemonConfig, error) {
 		return &config.DaemonConfig{}, nil
 	}
-	var ensured bool
-	ensureRunningForTUI = func(context.Context) (clientpkg.RunningDaemon, error) {
-		ensured = true
+	t.Chdir(t.TempDir())
+	workspace := t.TempDir()
+	var ensuredWorkspace string
+	ensureRunningForTUI = func(_ context.Context, workspace string) (clientpkg.RunningDaemon, error) {
+		ensuredWorkspace = workspace
 		return clientpkg.RunningDaemon{BaseURL: "http://kata.invalid"}, nil
 	}
 	ensureLocalRunningForTUI = func(context.Context) (string, error) {
@@ -275,17 +324,57 @@ func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *t
 	newHTTPClientForTUI = func(_ context.Context, _ string, _ daemonTarget, _ clientOptsKind) (*http.Client, error) {
 		return &http.Client{}, nil
 	}
-	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+	var resolvedWorkspace string
+	bootResolveScopeForTUI = func(_ context.Context, _ *Client, start string) (bootInit, error) {
+		resolvedWorkspace = start
 		return bootInit{view: viewEmpty, scope: scope{empty: true}}, nil
 	}
 
-	conn, err := bootDaemonConnection(context.Background(), Options{})
+	conn, err := bootDaemonConnection(
+		context.Background(), Options{Workspace: workspace},
+	)
 
 	require.NoError(t, err)
-	assert.True(t, ensured, "implicit daemon must use existing EnsureRunning path")
+	assert.Equal(t, workspace, ensuredWorkspace)
+	assert.Equal(t, workspace, resolvedWorkspace)
 	assert.Equal(t, "http://kata.invalid", conn.endpoint)
 	assert.Equal(t, "local", daemonTargetDisplay(conn.target))
 	assert.Equal(t, viewEmpty, conn.init.view)
+}
+
+func TestBootDaemonConnectionDefinitiveTargetSkipsCWDResolution(t *testing.T) {
+	oldRead := readDaemonConfigForTUI
+	oldEnsure := ensureRunningForTUI
+	oldNewClient := newHTTPClientForTUI
+	oldBootScope := bootResolveScopeForTUI
+	t.Cleanup(func() {
+		readDaemonConfigForTUI = oldRead
+		ensureRunningForTUI = oldEnsure
+		newHTTPClientForTUI = oldNewClient
+		bootResolveScopeForTUI = oldBootScope
+	})
+	readDaemonConfigForTUI = func() (*config.DaemonConfig, error) {
+		return &config.DaemonConfig{}, nil
+	}
+	ensureRunningForTUI = func(context.Context, string) (clientpkg.RunningDaemon, error) {
+		return clientpkg.RunningDaemon{BaseURL: clientpkg.UnixBase}, nil
+	}
+	newHTTPClientForTUI = func(_ context.Context, _ string, _ daemonTarget, _ clientOptsKind) (*http.Client, error) {
+		return &http.Client{}, nil
+	}
+	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+		return bootInit{}, errors.New("malformed cwd binding")
+	}
+
+	for name, opts := range map[string]Options{
+		"qualified ref":    {InitialIssueRef: "other-project#abc4"},
+		"explicit project": {ProjectName: "other-project"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := bootDaemonConnection(t.Context(), opts)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestBootDaemonConnectionOptionsDaemonNameOverridesActiveDaemon(t *testing.T) {
@@ -310,13 +399,24 @@ func TestBootDaemonConnectionOptionsDaemonNameOverridesActiveDaemon(t *testing.T
 		got = target
 		return daemonConnection{target: target}, nil
 	}
+	workspace := t.TempDir()
 
-	conn, err := bootDaemonConnection(context.Background(), Options{DaemonName: "selected"})
+	conn, err := bootDaemonConnection(context.Background(), Options{
+		DaemonName:  "selected",
+		ProjectName: "project-b",
+		Workspace:   workspace,
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, "selected", got.Name)
+	assert.Equal(t, workspace, got.workspaceStart)
+	assert.True(t, got.skipInitialScope)
 	assert.Equal(t, "selected", conn.target.Name)
 	require.Len(t, conn.catalog, 2)
+	for _, target := range conn.catalog {
+		assert.Equal(t, workspace, target.workspaceStart)
+		assert.True(t, target.skipInitialScope)
+	}
 }
 
 func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testing.T) {
@@ -336,7 +436,7 @@ func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testin
 	readDaemonConfigForTUI = func() (*config.DaemonConfig, error) {
 		return &config.DaemonConfig{}, nil
 	}
-	ensureRunningForTUI = func(context.Context) (clientpkg.RunningDaemon, error) {
+	ensureRunningForTUI = func(context.Context, string) (clientpkg.RunningDaemon, error) {
 		return clientpkg.RunningDaemon{
 			BaseURL:          "https://daemon.example:7777",
 			ConfiguredRemote: true,

--- a/internal/tui/daemon_view.go
+++ b/internal/tui/daemon_view.go
@@ -55,14 +55,25 @@ func (m Model) routeDaemonsViewKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 			return m, nil
 		}
 		m.daemonSwitchAttempt++
-		return m, switchDaemonCmd(rows[m.daemonCursor].target, m.daemonSwitchAttempt)
+		return m, switchDaemonCmd(
+			rows[m.daemonCursor].target, m.daemonSwitchAttempt, m.opts,
+		)
 	}
 	return m, nil
 }
 
-func switchDaemonCmd(target daemonTarget, attempt uint64) tea.Cmd {
+func switchDaemonCmd(target daemonTarget, attempt uint64, opts Options) tea.Cmd {
 	return func() tea.Msg {
-		conn, err := connectDaemonTargetForTUI(context.Background(), target)
+		ctx := context.Background()
+		target = daemonTargetWithLaunchSelectors(target, opts)
+		conn, err := connectDaemonTargetForTUI(ctx, target)
+		if err == nil {
+			scopeOpts := Options{
+				ProjectName: opts.ProjectName,
+				Workspace:   opts.Workspace,
+			}
+			conn.init, err = applyInitialScopeSelectors(ctx, conn.api, conn.init, scopeOpts)
+		}
 		return daemonSwitchResultMsg{attempt: attempt, conn: conn, target: target, err: err}
 	}
 }

--- a/internal/tui/daemon_view_test.go
+++ b/internal/tui/daemon_view_test.go
@@ -402,6 +402,60 @@ func TestDaemonSwitchResetsProjectsGeneration(t *testing.T) {
 	assert.Equal(t, uint64(0), out.projectsGen)
 }
 
+func TestSwitchDaemonCmdReappliesProjectSelector(t *testing.T) {
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects": func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"projects":[{"id":9,"name":"project-b"}]}`))
+		},
+	})
+	client := NewClient(srv.URL, srv.Client())
+	oldConnect := connectDaemonTargetForTUI
+	t.Cleanup(func() { connectDaemonTargetForTUI = oldConnect })
+	connectDaemonTargetForTUI = func(_ context.Context, target daemonTarget) (daemonConnection, error) {
+		return daemonConnection{api: client, target: target}, nil
+	}
+
+	msg := switchDaemonCmd(
+		daemonTarget{Name: "shared", URL: "https://daemon.example"},
+		1,
+		Options{ProjectName: "project-b"},
+	)()
+	result, ok := msg.(daemonSwitchResultMsg)
+	require.True(t, ok)
+	require.NoError(t, result.err)
+	assert.True(t, result.target.skipInitialScope)
+	assert.Equal(t, int64(9), result.conn.init.scope.projectID)
+	assert.Equal(t, "project-b", result.conn.init.scope.projectName)
+}
+
+func TestSwitchDaemonCmdPreservesWorkspaceSelector(t *testing.T) {
+	workspace := t.TempDir()
+	oldConnect := connectDaemonTargetForTUI
+	t.Cleanup(func() { connectDaemonTargetForTUI = oldConnect })
+	connectDaemonTargetForTUI = func(_ context.Context, target daemonTarget) (daemonConnection, error) {
+		assert.Equal(t, workspace, target.workspaceStart)
+		assert.False(t, target.skipInitialScope)
+		return daemonConnection{
+			api:    &Client{},
+			target: target,
+			init: bootInit{
+				view:  viewList,
+				scope: homedScope(9, "project-b"),
+			},
+		}, nil
+	}
+
+	msg := switchDaemonCmd(
+		daemonTarget{Name: "shared", URL: "https://daemon.example"},
+		1,
+		Options{Workspace: workspace},
+	)()
+	result, ok := msg.(daemonSwitchResultMsg)
+	require.True(t, ok)
+	require.NoError(t, result.err)
+	assert.Equal(t, int64(9), result.conn.init.scope.projectID)
+}
+
 func setupDaemonViewSource() Model {
 	m := initialModel(Options{})
 	m.view = viewList

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -283,6 +283,9 @@ func (m Model) Init() tea.Cmd {
 		cmds = append(cmds, m.fetchProjects())
 	default:
 		cmds = append(cmds, m.fetchInitial(), m.fetchProjects())
+		if m.view == viewDetail && m.detail.issue != nil {
+			cmds = append(cmds, m.fetchOpenDetail())
+		}
 	}
 	return tea.Batch(cmds...)
 }
@@ -2600,7 +2603,14 @@ func (m Model) routeModalKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 // model so detail-side mutations carry the resolved identity rather
 // than the empty string.
 func (m Model) handleOpenDetail(msg openDetailMsg) (tea.Model, tea.Cmd) {
-	iss := msg.issue
+	m = m.seedOpenDetail(msg.issue)
+	if m.api == nil {
+		return m, nil
+	}
+	return m, m.fetchOpenDetail()
+}
+
+func (m Model) seedOpenDetail(iss Issue) Model {
 	pid := detailProjectID(iss, m.scope)
 	m.nextGen++
 	// Reset on open is the spec — no per-issue scroll memory.
@@ -2626,17 +2636,22 @@ func (m Model) handleOpenDetail(msg openDetailMsg) (tea.Model, tea.Cmd) {
 	if m.layout == layoutSplit {
 		m.focus = focusDetail
 	}
-	if m.api == nil {
-		return m, nil
+	return m
+}
+
+func (m Model) fetchOpenDetail() tea.Cmd {
+	if m.api == nil || m.detail.issue == nil {
+		return nil
 	}
+	iss := *m.detail.issue
+	pid := m.detail.scopePID
 	gen := m.detail.gen
-	cmds := []tea.Cmd{
+	return tea.Batch(
 		fetchIssue(m.api, pid, iss.ShortID, gen),
 		fetchComments(m.api, pid, iss.ShortID, gen),
 		fetchEvents(m.api, pid, iss.ShortID, gen),
 		fetchLinks(m.api, pid, iss.ShortID, gen),
-	}
-	return m, tea.Batch(cmds...)
+	)
 }
 
 // handleJumpDetail performs an Enter-jump from the detail view to a

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -4,13 +4,16 @@ package tui
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"go.kenn.io/kata/internal/shortid"
 	"golang.org/x/term"
 )
 
@@ -87,6 +90,9 @@ type Options struct {
 	DisplayUIDFormat string    // none, short, or full
 	DaemonName       string    // named daemon catalog entry for this run
 	Mouse            bool      // opt-in mouse capture and mouse-driven navigation
+	InitialIssueRef  string    // optional issue ref to open directly
+	ProjectName      string    // optional explicit project selector
+	Workspace        string    // optional workspace path for project and daemon resolution
 }
 
 // Run starts the TUI. Blocks until the user quits or ctx is cancelled.
@@ -152,6 +158,9 @@ func buildRunModel(opts Options, c *Client, bi bootInit, conns ...daemonConnecti
 		}
 		m.projectsCursor = cursorForScope(projectsRows(m.projectsByID, m.projectIdentByID, m.projectStats), bi.scope)
 	}
+	if bi.initialIssue != nil {
+		m = m.seedOpenDetail(*bi.initialIssue)
+	}
 	return m
 }
 
@@ -190,11 +199,133 @@ func sseProjectScope(_ scope) *int64 {
 // We re-use NewHTTPClient with ResponseHeaderTimeout instead of building
 // a bespoke transport so unix-socket dialing stays in one place.
 func bootClient(ctx context.Context, opts Options) (*Client, *http.Client, bootInit, string, daemonConnection, error) {
-	conn, err := bootDaemonConnection(ctx, opts)
+	conn, err := bootDaemonConnectionForTUI(ctx, opts)
+	if err != nil {
+		return nil, nil, bootInit{}, "", daemonConnection{}, err
+	}
+	conn.init, err = applyInitialScopeSelectors(ctx, conn.api, conn.init, opts)
+	if err != nil {
+		return nil, nil, bootInit{}, "", daemonConnection{}, err
+	}
+	conn.init, err = resolveInitialIssue(ctx, conn.api, conn.init, opts.InitialIssueRef)
 	if err != nil {
 		return nil, nil, bootInit{}, "", daemonConnection{}, err
 	}
 	return conn.api, conn.sseHC, conn.init, conn.endpoint, conn, nil
+}
+
+var bootDaemonConnectionForTUI = bootDaemonConnection
+
+type initialIssueAPI interface {
+	GetIssueDetail(context.Context, int64, string) (*IssueDetail, error)
+	ListProjects(context.Context) ([]ProjectSummary, error)
+}
+
+func resolveInitialIssue(
+	ctx context.Context, api initialIssueAPI, bi bootInit, ref string,
+) (bootInit, error) {
+	if ref == "" {
+		return bi, nil
+	}
+	parsed, err := shortid.Parse(ref)
+	if err != nil {
+		return bootInit{}, fmt.Errorf("%q is not a valid issue ref: %w", ref, err)
+	}
+	projectID, apiRef, err := resolveInitialIssueTarget(ctx, api, &bi, parsed)
+	if err != nil {
+		return bootInit{}, err
+	}
+	detail, err := api.GetIssueDetail(ctx, projectID, apiRef)
+	if err != nil {
+		return bootInit{}, err
+	}
+	if detail == nil || detail.Issue == nil {
+		return bootInit{}, fmt.Errorf("kata tui %q returned an empty issue response", ref)
+	}
+	bi.initialIssue = detail.Issue
+	return bi, nil
+}
+
+func resolveInitialIssueTarget(
+	ctx context.Context, api initialIssueAPI, bi *bootInit, ref shortid.Ref,
+) (int64, string, error) {
+	if ref.Project != "" {
+		project, err := findProjectByName(ctx, api, ref.Project)
+		if err != nil {
+			return 0, "", err
+		}
+		selectInitialProject(bi, project)
+		return project.ID, ref.ShortID, nil
+	}
+	if bi.scope.projectID == 0 || bi.scope.empty || bi.scope.allProjects {
+		return 0, "", fmt.Errorf(
+			"no project bound to this workspace; use a qualified ref (e.g. kata#abc4)",
+		)
+	}
+	if ref.ULID != "" {
+		return bi.scope.projectID, ref.ULID, nil
+	}
+	return bi.scope.projectID, ref.ShortID, nil
+}
+
+func applyInitialScopeSelectors(
+	ctx context.Context, api initialIssueAPI, bi bootInit, opts Options,
+) (bootInit, error) {
+	qualified, err := initialIssueRefIsQualified(opts.InitialIssueRef)
+	if err != nil {
+		return bootInit{}, err
+	}
+	if qualified {
+		return bi, nil
+	}
+	projectName := strings.TrimSpace(opts.ProjectName)
+	if projectName == "" {
+		return bi, nil
+	}
+	project, err := findProjectByName(ctx, api, projectName)
+	if err != nil {
+		return bootInit{}, err
+	}
+	selectInitialProject(&bi, project)
+	return bi, nil
+}
+
+func initialIssueRefIsQualified(ref string) (bool, error) {
+	if ref == "" {
+		return false, nil
+	}
+	parsed, err := shortid.Parse(ref)
+	if err != nil {
+		return false, fmt.Errorf("%q is not a valid issue ref: %w", ref, err)
+	}
+	return parsed.Project != "", nil
+}
+
+func selectInitialProject(bi *bootInit, project ProjectSummary) {
+	bi.scope = scope{
+		projectID:       project.ID,
+		projectName:     project.Name,
+		workspace:       bi.scope.workspace,
+		homeProjectID:   project.ID,
+		homeProjectName: project.Name,
+	}
+	bi.view = viewList
+	bi.projects = []ProjectSummaryWithStats{{ProjectSummary: project}}
+}
+
+func findProjectByName(
+	ctx context.Context, api initialIssueAPI, name string,
+) (ProjectSummary, error) {
+	projects, err := api.ListProjects(ctx)
+	if err != nil {
+		return ProjectSummary{}, err
+	}
+	for _, project := range projects {
+		if project.Name == name {
+			return project, nil
+		}
+	}
+	return ProjectSummary{}, fmt.Errorf("project %q not found", name)
 }
 
 // scope describes the issue-set the TUI is browsing. Exactly one of
@@ -221,9 +352,10 @@ type scope struct {
 // the first frame can render with stats — no second roundtrip. For
 // viewList and viewEmpty, projects is nil.
 type bootInit struct {
-	scope    scope
-	view     viewID
-	projects []ProjectSummaryWithStats
+	scope        scope
+	view         viewID
+	projects     []ProjectSummaryWithStats
+	initialIssue *Issue
 }
 
 // bootResolveScope picks the initial scope + view from cwd. Spec §4.2:

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -120,6 +120,336 @@ func TestInitialFilter_ZeroValueByDefault(t *testing.T) {
 	}
 }
 
+type fakeInitialIssueAPI struct {
+	detail       *IssueDetail
+	err          error
+	projects     []ProjectSummary
+	listErr      error
+	listProjects int
+	projectID    int64
+	ref          string
+}
+
+func (f *fakeInitialIssueAPI) GetIssueDetail(
+	_ context.Context, projectID int64, ref string,
+) (*IssueDetail, error) {
+	f.projectID = projectID
+	f.ref = ref
+	return f.detail, f.err
+}
+
+func (f *fakeInitialIssueAPI) ListProjects(context.Context) ([]ProjectSummary, error) {
+	f.listProjects++
+	return f.projects, f.listErr
+}
+
+func TestResolveInitialIssue_FetchesBareRefInWorkspaceProject(t *testing.T) {
+	api := &fakeInitialIssueAPI{
+		detail: &IssueDetail{
+			Issue: &Issue{
+				ProjectID: 7,
+				UID:       "01TEST00000000000000000001",
+				ShortID:   "abc4",
+				Title:     "Target",
+			},
+		},
+	}
+	bi := bootInit{scope: scope{projectID: 7}, view: viewList}
+
+	got, err := resolveInitialIssue(t.Context(), api, bi, "abc4")
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), api.projectID)
+	assert.Equal(t, "abc4", api.ref)
+	assert.Zero(t, api.listProjects)
+	require.NotNil(t, got.initialIssue)
+	assert.Equal(t, "abc4", got.initialIssue.ShortID)
+}
+
+func TestResolveInitialIssue_QualifiedRefSelectsNamedProject(t *testing.T) {
+	api := &fakeInitialIssueAPI{
+		projects: []ProjectSummary{
+			{ID: 7, Name: "workspace"},
+			{ID: 9, Name: "other-project", UID: "01TARGETPROJECT000000000000"},
+		},
+		detail: &IssueDetail{
+			Issue: &Issue{
+				ProjectID: 9,
+				UID:       "01TEST00000000000000000001",
+				ShortID:   "abc4",
+				Title:     "Target",
+			},
+		},
+	}
+	bi := bootInit{
+		scope: scope{projectID: 7, projectName: "workspace", workspace: "/tmp/workspace"},
+		view:  viewList,
+	}
+
+	got, err := resolveInitialIssue(t.Context(), api, bi, "other-project#abc4")
+	require.NoError(t, err)
+	assert.Equal(t, 1, api.listProjects)
+	assert.Equal(t, int64(9), api.projectID)
+	assert.Equal(t, "abc4", api.ref)
+	assert.Equal(t, int64(9), got.scope.projectID)
+	assert.Equal(t, "other-project", got.scope.projectName)
+	assert.Equal(t, int64(9), got.scope.homeProjectID)
+	assert.Equal(t, "other-project", got.scope.homeProjectName)
+	assert.Equal(t, viewList, got.view)
+	require.Len(t, got.projects, 1)
+	assert.Equal(t, int64(9), got.projects[0].ID)
+}
+
+func TestResolveInitialIssue_QualifiedRefDoesNotRequireWorkspaceScope(t *testing.T) {
+	api := &fakeInitialIssueAPI{
+		projects: []ProjectSummary{{ID: 9, Name: "other-project"}},
+		detail: &IssueDetail{
+			Issue: &Issue{
+				ProjectID: 9,
+				UID:       "01TEST00000000000000000001",
+				ShortID:   "abc4",
+				Title:     "Target",
+			},
+		},
+	}
+
+	got, err := resolveInitialIssue(
+		t.Context(), api, bootInit{view: viewProjects}, "other-project#abc4",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), got.scope.projectID)
+	assert.False(t, got.scope.empty)
+	assert.Equal(t, viewList, got.view)
+	require.NotNil(t, got.initialIssue)
+	assert.Equal(t, "abc4", got.initialIssue.ShortID)
+}
+
+func TestResolveInitialIssue_EmptyRefDoesNotFetch(t *testing.T) {
+	api := &fakeInitialIssueAPI{}
+	bi := bootInit{scope: scope{projectID: 7}, view: viewList}
+
+	got, err := resolveInitialIssue(t.Context(), api, bi, "")
+	require.NoError(t, err)
+	assert.Empty(t, api.ref)
+	assert.Nil(t, got.initialIssue)
+}
+
+func TestResolveInitialIssue_PropagatesLookupError(t *testing.T) {
+	want := errors.New("issue not found")
+	api := &fakeInitialIssueAPI{err: want}
+	bi := bootInit{scope: scope{projectID: 7}, view: viewList}
+
+	_, err := resolveInitialIssue(t.Context(), api, bi, "abcd")
+	assert.ErrorIs(t, err, want)
+}
+
+func TestResolveInitialIssue_RequiresProjectScope(t *testing.T) {
+	api := &fakeInitialIssueAPI{}
+
+	_, err := resolveInitialIssue(t.Context(), api, bootInit{view: viewProjects}, "abc4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no project bound to this workspace")
+	assert.Empty(t, api.ref)
+}
+
+func TestBootClient_ResolvesRequestedIssueBeforeReturning(t *testing.T) {
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects/7/issues/abc4": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issue": map[string]any{
+					"id": 1, "project_id": 7,
+					"uid": "01TEST00000000000000000001", "short_id": "abc4",
+					"title": "Target", "status": "open",
+				},
+				"children": []map[string]any{},
+			})
+		},
+	})
+	client := NewClient(srv.URL, srv.Client())
+	old := bootDaemonConnectionForTUI
+	bootDaemonConnectionForTUI = func(context.Context, Options) (daemonConnection, error) {
+		return daemonConnection{
+			api:      client,
+			sseHC:    srv.Client(),
+			endpoint: srv.URL,
+			init: bootInit{
+				scope: scope{projectID: 7, projectName: "example-project"},
+				view:  viewList,
+			},
+		}, nil
+	}
+	t.Cleanup(func() { bootDaemonConnectionForTUI = old })
+
+	_, _, bi, _, _, err := bootClient(t.Context(), Options{InitialIssueRef: "abc4"})
+
+	require.NoError(t, err)
+	require.NotNil(t, bi.initialIssue)
+	assert.Equal(t, "abc4", bi.initialIssue.ShortID)
+}
+
+func TestBootClient_QualifiedRefUsesNamedProjectOverWorkspace(t *testing.T) {
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects": func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"projects":[
+				{"id":7,"name":"workspace"},
+				{"id":9,"uid":"01TARGETPROJECT000000000000","name":"other-project"}
+			]}`))
+		},
+		"/api/v1/projects/9/issues/abc4": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issue": map[string]any{
+					"id": 1, "project_id": 9,
+					"uid": "01TEST00000000000000000001", "short_id": "abc4",
+					"title": "Target", "status": "open",
+				},
+				"children": []map[string]any{},
+			})
+		},
+	})
+	client := NewClient(srv.URL, srv.Client())
+	old := bootDaemonConnectionForTUI
+	bootDaemonConnectionForTUI = func(context.Context, Options) (daemonConnection, error) {
+		return daemonConnection{
+			api:      client,
+			sseHC:    srv.Client(),
+			endpoint: srv.URL,
+			init: bootInit{
+				scope: scope{projectID: 7, projectName: "workspace"},
+				view:  viewList,
+			},
+		}, nil
+	}
+	t.Cleanup(func() { bootDaemonConnectionForTUI = old })
+
+	_, _, bi, _, _, err := bootClient(
+		t.Context(), Options{
+			ProjectName:     "missing-project",
+			InitialIssueRef: "other-project#abc4",
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), bi.scope.projectID)
+	assert.Equal(t, "other-project", bi.scope.projectName)
+	require.NotNil(t, bi.initialIssue)
+	assert.Equal(t, int64(9), bi.initialIssue.ProjectID)
+}
+
+func TestBootClient_ProjectSelectorScopesBareRef(t *testing.T) {
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects": func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"projects":[
+				{"id":7,"name":"workspace"},
+				{"id":9,"name":"project-b"}
+			]}`))
+		},
+		"/api/v1/projects/9/issues/abc4": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issue": map[string]any{
+					"id": 1, "project_id": 9,
+					"uid": "01TEST00000000000000000001", "short_id": "abc4",
+					"title": "Target", "status": "open",
+				},
+				"children": []map[string]any{},
+			})
+		},
+	})
+	client := NewClient(srv.URL, srv.Client())
+	old := bootDaemonConnectionForTUI
+	bootDaemonConnectionForTUI = func(context.Context, Options) (daemonConnection, error) {
+		return daemonConnection{
+			api:  client,
+			init: bootInit{scope: scope{projectID: 7, projectName: "workspace"}, view: viewList},
+		}, nil
+	}
+	t.Cleanup(func() { bootDaemonConnectionForTUI = old })
+
+	_, _, bi, _, _, err := bootClient(t.Context(), Options{
+		ProjectName:     "project-b",
+		InitialIssueRef: "abc4",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), bi.scope.projectID)
+	require.NotNil(t, bi.initialIssue)
+	assert.Equal(t, int64(9), bi.initialIssue.ProjectID)
+}
+
+func TestBootClient_WorkspaceSelectorScopesBareRef(t *testing.T) {
+	workspace := t.TempDir()
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects/9/issues/abc4": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issue": map[string]any{
+					"id": 1, "project_id": 9,
+					"uid": "01TEST00000000000000000001", "short_id": "abc4",
+					"title": "Target", "status": "open",
+				},
+				"children": []map[string]any{},
+			})
+		},
+	})
+	client := NewClient(srv.URL, srv.Client())
+	old := bootDaemonConnectionForTUI
+	bootDaemonConnectionForTUI = func(context.Context, Options) (daemonConnection, error) {
+		return daemonConnection{
+			api:  client,
+			init: bootInit{scope: scope{projectID: 9, projectName: "project-b"}, view: viewList},
+		}, nil
+	}
+	t.Cleanup(func() { bootDaemonConnectionForTUI = old })
+
+	_, _, bi, _, _, err := bootClient(t.Context(), Options{
+		Workspace:       workspace,
+		InitialIssueRef: "abc4",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), bi.scope.projectID)
+	require.NotNil(t, bi.initialIssue)
+	assert.Equal(t, int64(9), bi.initialIssue.ProjectID)
+}
+
+func TestBootClient_QualifiedRefWorksFromUnboundWorkspace(t *testing.T) {
+	srv := mockDaemon(t, map[string]http.HandlerFunc{
+		"/api/v1/projects": func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(
+				`{"projects":[{"id":9,"name":"other-project"}]}`,
+			))
+		},
+		"/api/v1/projects/9/issues/abc4": func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issue": map[string]any{
+					"id": 1, "project_id": 9,
+					"uid": "01TEST00000000000000000001", "short_id": "abc4",
+					"title": "Target", "status": "open",
+				},
+				"children": []map[string]any{},
+			})
+		},
+	})
+	client := NewClient(srv.URL, srv.Client())
+	old := bootDaemonConnectionForTUI
+	bootDaemonConnectionForTUI = func(context.Context, Options) (daemonConnection, error) {
+		return daemonConnection{
+			api:      client,
+			sseHC:    srv.Client(),
+			endpoint: srv.URL,
+			init:     bootInit{view: viewProjects},
+		}, nil
+	}
+	t.Cleanup(func() { bootDaemonConnectionForTUI = old })
+
+	_, _, bi, _, _, err := bootClient(
+		t.Context(), Options{InitialIssueRef: "other-project#abc4"},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), bi.scope.projectID)
+	assert.Equal(t, viewList, bi.view)
+	require.NotNil(t, bi.initialIssue)
+	assert.Equal(t, "abc4", bi.initialIssue.ShortID)
+}
+
 // TestOutputIsTerminal_RejectsNonFile confirms a non-*os.File writer
 // (e.g., bytes.Buffer in tests) is treated as a non-terminal so Run
 // surfaces errNotATTY instead of writing alt-screen control sequences
@@ -260,4 +590,50 @@ func TestBuildRunModel_SeedsViewProjectsCacheFromBoot(t *testing.T) {
 	require.Contains(t, m.projectStats, int64(7))
 	assert.Equal(t, 3, m.projectStats[7].Open)
 	assert.Equal(t, 1, m.projectStats[7].Closed)
+}
+
+func TestBuildRunModel_SeedsInitialIssue(t *testing.T) {
+	bi := bootInit{
+		scope: scope{projectID: 7, projectName: "example-project"},
+		view:  viewList,
+		initialIssue: &Issue{
+			ProjectID: 7,
+			UID:       "01TEST00000000000000000001",
+			ShortID:   "abc4",
+			Title:     "Target",
+		},
+	}
+
+	m := buildRunModel(Options{InitialIssueRef: "abc4"}, &Client{}, bi)
+
+	assert.Equal(t, viewDetail, m.view)
+	require.NotNil(t, m.detail.issue)
+	assert.Equal(t, "abc4", m.detail.issue.ShortID)
+	assert.Equal(t, int64(7), m.detail.scopePID)
+}
+
+func TestInitialDetail_InitAddsFourDetailFetches(t *testing.T) {
+	baseInit := bootInit{
+		scope: scope{projectID: 7, projectName: "example-project"},
+		view:  viewList,
+	}
+	directInit := baseInit
+	directInit.initialIssue = &Issue{
+		ProjectID: 7,
+		UID:       "01TEST00000000000000000001",
+		ShortID:   "abc4",
+		Title:     "Target",
+	}
+
+	baseBatch, ok := buildRunModel(Options{}, &Client{}, baseInit).Init()().(tea.BatchMsg)
+	require.True(t, ok)
+	directBatch, ok := buildRunModel(
+		Options{InitialIssueRef: "abc4"}, &Client{}, directInit,
+	).Init()().(tea.BatchMsg)
+	require.True(t, ok)
+	require.Len(t, directBatch, len(baseBatch)+1)
+
+	detailBatch, ok := directBatch[len(directBatch)-1]().(tea.BatchMsg)
+	require.True(t, ok)
+	assert.Len(t, detailBatch, 4, "initial detail must fetch issue, comments, events, and links")
 }


### PR DESCRIPTION
## Why

`kata tui` always opens the issue browser. Workflows that already have an issue ref from `kata list`, `kata create`, or another command still need an extra search and selection step to reach its details.

## Behavior

- `kata tui <issue-ref>` resolves the exact ref before Bubble Tea starts and opens the existing detail view directly.
- Bare short IDs, qualified short IDs, and full UIDs match the forms accepted by `kata show`.
- Lookup errors return before the alternate screen opens, and the issue list still loads behind the detail view for normal back navigation.
- CLI help, the README, quickstart, and CLI reference document the optional ref.

Closes #208