### PR TITLE
ready/next --all: compose with the scoped filters

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6307,6 +6307,34 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: unowned
+          schema:
+            type: boolean
+        - explode: false
+          in: query
+          name: owner
+          schema:
+            type: string
+        - explode: true
+          in: query
+          name: label
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+        - explode: true
+          in: query
+          name: exclude_label
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
       responses:
         "200":
           content:

--- a/cmd/kata/next_test.go
+++ b/cmd/kata/next_test.go
@@ -237,10 +237,6 @@ func TestNext_AllValidationMirrorsReady(t *testing.T) {
 		want string
 	}{
 		{name: "project", args: []string{"--project", "anything", "next", "--all"}, want: "mutually exclusive"},
-		{name: "unowned", args: []string{"next", "--all", "--unowned"}, want: "--all does not support"},
-		{name: "owner", args: []string{"next", "--all", "--owner", "alice"}, want: "--all does not support"},
-		{name: "label", args: []string{"next", "--all", "--label", "bug"}, want: "--all does not support"},
-		{name: "no-label", args: []string{"next", "--all", "--no-label", "wip"}, want: "--all does not support"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -250,6 +246,17 @@ func TestNext_AllValidationMirrorsReady(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.want)
 		})
 	}
+}
+
+func TestNext_AllAcceptsFilterFlags(t *testing.T) {
+	// next shares ready's option validation: the scoped filters compose with
+	// --all so an agent can pick, e.g., the next unowned issue anywhere.
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out, err := runCLICapture(t, env, dir, "next", "--all", "--unowned")
+	require.NoError(t, err)
+	assert.Contains(t, out, "alpha")
 }
 
 func TestNext_UnownedAndOwnerAreMutuallyExclusive(t *testing.T) {

--- a/cmd/kata/ready_client.go
+++ b/cmd/kata/ready_client.go
@@ -50,13 +50,6 @@ func (o readyOptions) validate() error {
 			ExitCode: ExitUsage,
 		}
 	}
-	if o.All && (o.Unowned || o.Owner != "" || len(o.Labels) > 0 || len(o.NoLabels) > 0) {
-		return &cliError{
-			Message:  "--all does not support --unowned, --owner, --label, or --no-label",
-			Kind:     kindUsage,
-			ExitCode: ExitUsage,
-		}
-	}
 	return nil
 }
 

--- a/cmd/kata/ready_test.go
+++ b/cmd/kata/ready_test.go
@@ -384,23 +384,25 @@ func TestReady_AllHumanFooterShowsSummaryAndLegend(t *testing.T) {
 	assert.Contains(t, out, "Status: ○ open")
 }
 
-func TestReady_AllRejectsFilterFlags(t *testing.T) {
-	cases := []struct {
-		name string
-		args []string
-	}{
-		{"unowned", []string{"ready", "--all", "--unowned"}},
-		{"owner", []string{"ready", "--all", "--owner", "alice"}},
-		{"label", []string{"ready", "--all", "--label", "bug"}},
-		{"no-label", []string{"ready", "--all", "--no-label", "wip"}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			env, dir, _ := setupCLIWorkspace(t)
-			args := append([]string{"--workspace", dir}, tc.args...)
-			_, err := runCmdOutput(t, env, args...)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "--all does not support")
-		})
-	}
+func TestReady_AllAcceptsFilterFlags(t *testing.T) {
+	// --all composes with the scoped filters: cross-project queue views like
+	// "every unowned issue labeled X anywhere" are the point of the flag.
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "alpha")
+
+	out, err := runCmdOutput(t, env, "--workspace", dir, "ready", "--all", "--unowned")
+	require.NoError(t, err)
+	assert.Contains(t, out, "alpha")
+
+	out, err = runCmdOutput(t, env, "--workspace", dir, "ready", "--all", "--label", "no-such-label")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "alpha")
+
+	out, err = runCmdOutput(t, env, "--workspace", dir, "ready", "--all", "--no-label", "no-such-label")
+	require.NoError(t, err)
+	assert.Contains(t, out, "alpha")
+
+	out, err = runCmdOutput(t, env, "--workspace", dir, "ready", "--all", "--owner", "somebody-else")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "alpha")
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -291,7 +291,10 @@ kata next [--all] [--full]
 
 `ready` returns open issues that do not have an open blocking predecessor.
 Filters combine with AND logic. `--all` lists ready issues across every
-non-archived project and cannot be combined with those filters or `--project`.
+non-archived project; the scoped filters (`--unowned`, `--owner`, `--label`,
+`--no-label`) compose with it, so a cross-project queue view such as "every
+unowned ready issue labeled `handoff-to:example-host`" is a single query.
+`--all` cannot be combined with `--project`.
 
 `next` selects one issue from the same ready candidates. Selection is
 deterministic: any explicitly prioritized candidate beats every unprioritized
@@ -302,8 +305,8 @@ priorities retain the ready API's order. If no candidate has a priority,
 
 The scoped `--unowned`, `--owner`, `--label`, and `--no-label` filters have the
 same meaning for `next` as for `ready`; `--unowned` and `--owner` are mutually
-exclusive. `next --all` searches all non-archived projects and, like
-`ready --all`, cannot be combined with `--project` or any scoped filter.
+exclusive. `next --all` searches all non-archived projects; like `ready --all`
+it composes with the scoped filters but cannot be combined with `--project`.
 `next` has no `--limit` flag because its result cardinality is always zero or
 one. Because there is no summary or footer to suppress, `--quiet` does not
 change either the selected record or the empty result.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -999,7 +999,11 @@ type ReadyResponse struct {
 // ReadyGlobalRequest is GET /api/v1/ready (no project_id; spans every
 // non-archived project).
 type ReadyGlobalRequest struct {
-	Limit int `query:"limit,omitempty"`
+	Limit         int      `query:"limit,omitempty"`
+	Unowned       bool     `query:"unowned,omitempty"`
+	Owner         string   `query:"owner,omitempty"`
+	Labels        []string `query:"label,explode"`
+	ExcludeLabels []string `query:"exclude_label,explode"`
 }
 
 // ReadyGlobalIssueOut is one cross-project ready row: a hydrated IssueOut

--- a/internal/daemon/handlers_ready.go
+++ b/internal/daemon/handlers_ready.go
@@ -47,7 +47,18 @@ func registerReadyHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Method:      "GET",
 		Path:        "/api/v1/ready",
 	}, func(ctx context.Context, in *api.ReadyGlobalRequest) (*api.ReadyGlobalResponse, error) {
-		issues, err := cfg.DB.ReadyIssuesGlobal(ctx, in.Limit)
+		// Validate mutual exclusion (mirrors the per-project endpoint)
+		if in.Unowned && in.Owner != "" {
+			return nil, api.NewError(400, "validation",
+				"--unowned and --owner are mutually exclusive", "", nil)
+		}
+		filter := db.ReadyIssuesFilter{
+			Unowned:       in.Unowned,
+			Owner:         in.Owner,
+			Labels:        in.Labels,
+			ExcludeLabels: in.ExcludeLabels,
+		}
+		issues, err := cfg.DB.ReadyIssuesGlobal(ctx, in.Limit, filter)
 		if err != nil {
 			return nil, internalAPIError(err)
 		}

--- a/internal/db/dbtest/conformance_content.go
+++ b/internal/db/dbtest/conformance_content.go
@@ -742,7 +742,7 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	}
 	require.Len(t, limited, 1)
 
-	global, err := store.ReadyIssuesGlobal(ctx, 0)
+	global, err := store.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{})
 	if err != nil {
 		return fmt.Errorf("global ready issues: %w", err)
 	}
@@ -755,6 +755,38 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 			assert.Equal(t, other.Project.Name, row.ProjectName)
 		}
 	}
+	globalByLabel, err := store.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{Labels: []string{"BUG"}})
+	if err != nil {
+		return fmt.Errorf("global ready issues by label: %w", err)
+	}
+	require.Len(t, globalByLabel, 1)
+	assert.Equal(t, primary.Issue.ID, globalByLabel[0].ID)
+	globalUnowned, err := store.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{Unowned: true})
+	if err != nil {
+		return fmt.Errorf("global ready unowned issues: %w", err)
+	}
+	globalUnownedIDs := readyGlobalIssueIDs(globalUnowned)
+	assert.Contains(t, globalUnownedIDs, blocker.ID)
+	assert.Contains(t, globalUnownedIDs, other.Issue.ID)
+	assert.NotContains(t, globalUnownedIDs, primary.Issue.ID)
+	globalByOwner, err := store.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{Owner: "alice"})
+	if err != nil {
+		return fmt.Errorf("global ready issues by owner: %w", err)
+	}
+	require.Len(t, globalByOwner, 1)
+	assert.Equal(t, primary.Issue.ID, globalByOwner[0].ID)
+	globalWithoutBug, err := store.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{ExcludeLabels: []string{"bug"}})
+	if err != nil {
+		return fmt.Errorf("global ready issues excluding label: %w", err)
+	}
+	globalWithoutBugIDs := readyGlobalIssueIDs(globalWithoutBug)
+	assert.NotContains(t, globalWithoutBugIDs, primary.Issue.ID)
+	assert.Contains(t, globalWithoutBugIDs, other.Issue.ID)
+	globalLimited, err := store.ReadyIssuesGlobal(ctx, 1, db.ReadyIssuesFilter{Unowned: true})
+	if err != nil {
+		return fmt.Errorf("global ready issues limited: %w", err)
+	}
+	require.Len(t, globalLimited, 1)
 	_, _, _, err = store.CloseIssue(ctx, blocker.ID, "done", "discovery-author", "", nil)
 	if err != nil {
 		return fmt.Errorf("close readiness blocker: %w", err)

--- a/internal/db/pgstore/discovery.go
+++ b/internal/db/pgstore/discovery.go
@@ -77,8 +77,9 @@ func (s *Store) ReadyIssues(
 }
 
 // ReadyIssuesGlobal returns ready issues from all active projects along with
-// the project name needed to render a qualified reference.
-func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int) ([]db.ReadyGlobalIssue, error) {
+// the project name needed to render a qualified reference. Filter semantics
+// match ReadyIssues.
+func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.ReadyIssuesFilter) ([]db.ReadyGlobalIssue, error) {
 	query := `SELECT i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status,
        i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision, i.recurrence_id,
        i.occurrence_key, i.created_at, i.updated_at, i.closed_at, i.deleted_at, p.name
@@ -97,12 +98,30 @@ func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int) ([]db.ReadyGlo
         AND blocker.status = 'open'
         AND blocker.deleted_at IS NULL
         AND blocker_project.deleted_at IS NULL
-   )
- ORDER BY i.updated_at DESC, i.id DESC`
+   )`
 	args := []any{}
+	addArg := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+	if filter.Unowned {
+		query += ` AND i.owner IS NULL`
+	} else if filter.Owner != "" {
+		query += ` AND i.owner = ` + addArg(filter.Owner)
+	}
+	for _, label := range filter.Labels {
+		query += ` AND EXISTS (
+          SELECT 1 FROM issue_labels il
+           WHERE il.issue_id = i.id AND il.label = ` + addArg(strings.ToLower(label)) + `)`
+	}
+	for _, label := range filter.ExcludeLabels {
+		query += ` AND NOT EXISTS (
+          SELECT 1 FROM issue_labels il
+           WHERE il.issue_id = i.id AND il.label = ` + addArg(strings.ToLower(label)) + `)`
+	}
+	query += ` ORDER BY i.updated_at DESC, i.id DESC`
 	if limit > 0 {
-		query += ` LIMIT $1`
-		args = append(args, limit)
+		query += ` LIMIT ` + addArg(limit)
 	}
 	rows, err := s.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -2006,8 +2006,9 @@ func (d *Store) ReadyIssues(ctx context.Context, projectID int64, limit int, fil
 // not soft-deleted, and not blocked by an open `blocks` predecessor in an
 // active project. Issues from archived projects (projects.deleted_at IS NOT
 // NULL) are excluded, and an open blocker in an archived project does not
-// gate readiness. Ordering matches ReadyIssues so behavior is consistent.
-func (d *Store) ReadyIssuesGlobal(ctx context.Context, limit int) ([]db.ReadyGlobalIssue, error) {
+// gate readiness. Ordering and filter semantics match ReadyIssues so
+// behavior is consistent.
+func (d *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.ReadyIssuesFilter) ([]db.ReadyGlobalIssue, error) {
 	// issueSelect ends with "FROM issues i JOIN projects p ON p.id = i.project_id"
 	// We need to add p.name before FROM, so we build the SELECT from scratch.
 	q := `SELECT i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status, i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision, i.recurrence_id, i.occurrence_key, i.created_at, i.updated_at, i.closed_at, i.deleted_at, p.name AS project_name FROM issues i JOIN projects p ON p.id = i.project_id
@@ -2020,12 +2021,34 @@ func (d *Store) ReadyIssuesGlobal(ctx context.Context, limit int) ([]db.ReadyGlo
 		    WHERE l.type = 'blocks' AND l.to_issue_id = i.id
 		      AND blocker.status = 'open' AND blocker.deleted_at IS NULL
 		      AND bp.deleted_at IS NULL
-		  )
-		ORDER BY i.updated_at DESC, i.id DESC`
+		  )`
+	var args []any
+
+	// Apply owner filters (same semantics as ReadyIssues)
+	if filter.Unowned {
+		q += ` AND i.owner IS NULL`
+	} else if filter.Owner != "" {
+		q += ` AND i.owner = ?`
+		args = append(args, filter.Owner)
+	}
+
+	// Apply label filters (must have ALL these labels)
+	for _, label := range filter.Labels {
+		q += ` AND EXISTS (SELECT 1 FROM issue_labels il WHERE il.issue_id = i.id AND il.label = ?)`
+		args = append(args, strings.ToLower(label))
+	}
+
+	// Apply exclude label filters (must NOT have any of these labels)
+	for _, label := range filter.ExcludeLabels {
+		q += ` AND NOT EXISTS (SELECT 1 FROM issue_labels il WHERE il.issue_id = i.id AND il.label = ?)`
+		args = append(args, strings.ToLower(label))
+	}
+
+	q += ` ORDER BY i.updated_at DESC, i.id DESC`
 	if limit > 0 {
 		q += fmt.Sprintf(` LIMIT %d`, limit)
 	}
-	rows, err := d.QueryContext(ctx, q)
+	rows, err := d.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("ready issues global: %w", err)
 	}

--- a/internal/db/sqlitestore/queries_ready_test.go
+++ b/internal/db/sqlitestore/queries_ready_test.go
@@ -235,7 +235,7 @@ func TestReadyIssuesGlobal_ReturnsIssuesAcrossProjects(t *testing.T) {
 	a := makeIssue(t, ctx, d, p1.ID, "in p1", "tester")
 	b := makeIssue(t, ctx, d, p2.ID, "in p2", "tester")
 
-	rows, err := d.ReadyIssuesGlobal(ctx, 0)
+	rows, err := d.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{})
 	require.NoError(t, err)
 
 	got := map[string]string{}
@@ -261,7 +261,7 @@ func TestReadyIssuesGlobal_ExcludesArchivedProjects(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rows, err := d.ReadyIssuesGlobal(ctx, 0)
+	rows, err := d.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{})
 	require.NoError(t, err)
 
 	got := map[string]bool{}
@@ -278,7 +278,7 @@ func TestReadyIssuesGlobal_ExcludesBlockedIssues(t *testing.T) {
 	blocked := makeIssue(t, ctx, d, p.ID, "blocked", "tester")
 	makeLink(ctx, t, d, blocker.ID, blocked.ID, "blocks")
 
-	rows, err := d.ReadyIssuesGlobal(ctx, 0)
+	rows, err := d.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{})
 	require.NoError(t, err)
 	got := map[string]bool{}
 	for _, r := range rows {
@@ -318,7 +318,7 @@ func TestReadyIssuesGlobal_IgnoresBlockerInArchivedProject(t *testing.T) {
 	makeLink(ctx, t, d, blocker.ID, blocked.ID, "blocks")
 	archiveProjectByID(ctx, t, d, p2.ID)
 
-	rows, err := d.ReadyIssuesGlobal(ctx, 0)
+	rows, err := d.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{})
 	require.NoError(t, err)
 	got := map[string]bool{}
 	for _, r := range rows {

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -63,7 +63,7 @@ type Storage interface {
 	ListIssues(ctx context.Context, p ListIssuesParams) ([]Issue, error)
 	ListAllIssues(ctx context.Context, p ListAllIssuesParams) ([]Issue, error)
 	ReadyIssues(ctx context.Context, projectID int64, limit int, filter ReadyIssuesFilter) ([]Issue, error)
-	ReadyIssuesGlobal(ctx context.Context, limit int) ([]ReadyGlobalIssue, error)
+	ReadyIssuesGlobal(ctx context.Context, limit int, filter ReadyIssuesFilter) ([]ReadyGlobalIssue, error)
 	ChildrenOfIssue(ctx context.Context, parentIssueID int64) ([]Issue, error)
 	OpenChildrenOf(ctx context.Context, parentIssueID int64, limit int) ([]Issue, int, error)
 	EditIssue(ctx context.Context, p EditIssueParams) (Issue, *Event, bool, error)

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -5418,7 +5418,9 @@ func (c *Client) ReadyIssuesGlobal(ctx context.Context, options *ReadyIssuesGlob
 	var err error
 
 	queryEncoding := map[string]runtime.QueryEncoding{
-		"limit": {Style: "form", Explode: &[]bool{false}[0]},
+		"limit":   {Style: "form", Explode: &[]bool{false}[0]},
+		"owner":   {Style: "form", Explode: &[]bool{false}[0]},
+		"unowned": {Style: "form", Explode: &[]bool{false}[0]},
 	}
 	reqParams := runtime.RequestOptionsParameters{
 		RequestURL:    c.apiClient.GetBaseURL() + "/api/v1/ready",

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -229,5 +229,9 @@ func (s SearchIssuesQuery) Validate() error {
 }
 
 type ReadyIssuesGlobalQuery struct {
-	Limit *int64 `json:"limit,omitempty"`
+	Limit        *int64   `json:"limit,omitempty"`
+	Unowned      *bool    `json:"unowned,omitempty"`
+	Owner        *string  `json:"owner,omitempty"`
+	Label        []string `json:"label,omitempty"`
+	ExcludeLabel []string `json:"exclude_label,omitempty"`
 }

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -6124,6 +6124,32 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: unowned
+          schema:
+            type: boolean
+        - explode: false
+          in: query
+          name: owner
+          schema:
+            type: string
+        - explode: true
+          in: query
+          name: label
+          schema:
+            items:
+              type: string
+            nullable: true
+            type: array
+        - explode: true
+          in: query
+          name: exclude_label
+          schema:
+            items:
+              type: string
+            nullable: true
+            type: array
       responses:
         "200":
           content:


### PR DESCRIPTION
Closes #219.

`kata ready --all` listed ready issues across every project but rejected `--unowned`, `--owner`, `--label`, and `--no-label`, so a cross-project filtered queue view — e.g. every unowned ready issue labeled `handoff-to:example-host`, anywhere — required one `ready` call per project. With ~40 projects on a daemon that is 40 round-trips for one queue scan.

## What changed

- `ReadyGlobalRequest` gains `unowned`, `owner`, `label`, and `exclude_label` query parameters; the global handler validates `unowned`/`owner` mutual exclusion exactly like the per-project endpoint and passes a `ReadyIssuesFilter` through.
- `ReadyIssuesGlobal` in both stores extends the cross-project query with the same filter clauses as `ReadyIssues` (AND logic, case-insensitive labels), keeping ordering and readiness semantics identical.
- The client-side guard is removed; `next --all` inherits the filters through the shared options. `--all` remains mutually exclusive with `--project`.
- Store conformance exercises the filters against both backends across two projects; OpenAPI artifacts and the generated client are refreshed via `make api-generate`; `docs/reference/cli.md` reflects the composed behavior.

Context, for the curious: this serves an agent task-handoff lane where kata is the shared ledger for a multi-machine fleet and a chat channel mirrors claim state — described in #219. With this change the dedicated single-project queue workaround can collapse into labels on the work items themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)