### PR TITLE
Bound federation ingest cost and sync timeout

### DIFF
--- a/internal/db/federation_links.go
+++ b/internal/db/federation_links.go
@@ -1,0 +1,32 @@
+package db
+
+// FederationEventAffectsLinks reports whether an event type can change
+// federated link state, or the issue-to-project endpoint resolution that link
+// reconciliation depends on.
+//
+// Link reconciliation folds every event of every federated project in the
+// binding group, so its cost scales with the whole group rather than with the
+// batch being ingested. A batch whose events cannot touch link state leaves the
+// reconciled result identical, so that fold can be skipped for it.
+//
+// The set is deliberately conservative: it covers the fold cases that write
+// FoldProjection.Links (issue creation/snapshot payloads carry links, the
+// explicit link events, and the author rewrite that restamps link authors) plus
+// the issue lifecycle events that move an issue between projects or change
+// whether its endpoint resolves at all.
+func FederationEventAffectsLinks(eventType string) bool {
+	switch eventType {
+	case "issue.created",
+		"issue.snapshot",
+		"issue.linked",
+		"issue.unlinked",
+		"issue.links_changed",
+		"issue.moved",
+		"issue.soft_deleted",
+		"issue.restored",
+		"project.author_rewritten":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/db/federation_links_test.go
+++ b/internal/db/federation_links_test.go
@@ -1,0 +1,58 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+// The event types here are the complete set handled by FoldProjection.apply.
+// Keeping this exhaustive means a new fold case cannot be added without a
+// deliberate decision about whether it affects link reconciliation.
+func TestFederationEventAffectsLinks(t *testing.T) {
+	affects := []string{
+		"issue.created",
+		"issue.snapshot",
+		"issue.linked",
+		"issue.unlinked",
+		"issue.links_changed",
+		"issue.moved",
+		"issue.soft_deleted",
+		"issue.restored",
+		"project.author_rewritten",
+	}
+	for _, eventType := range affects {
+		t.Run(eventType+" affects links", func(t *testing.T) {
+			assert.True(t, db.FederationEventAffectsLinks(eventType))
+		})
+	}
+
+	unaffected := []string{
+		"issue.updated",
+		"issue.assigned",
+		"issue.unassigned",
+		"issue.priority_set",
+		"issue.priority_cleared",
+		"issue.closed",
+		"issue.reopened",
+		"issue.commented",
+		"issue.comment_edited",
+		"issue.labeled",
+		"issue.unlabeled",
+		"issue.metadata_updated",
+		"project.metadata_updated",
+		"project.federation_enabled",
+		"claim.acquired",
+		"claim.released",
+		"claim.expired",
+		"claim.force_released",
+		"claim.violated",
+	}
+	for _, eventType := range unaffected {
+		t.Run(eventType+" does not affect links", func(t *testing.T) {
+			assert.False(t, db.FederationEventAffectsLinks(eventType))
+		})
+	}
+}

--- a/internal/db/pgstore/federation_ingest.go
+++ b/internal/db/pgstore/federation_ingest.go
@@ -139,6 +139,7 @@ func (s *Store) IngestFederationEvents(
 				sourceEventID: input.SourceEventID, event: event,
 			})
 		}
+		linksAffected := false
 		for _, input := range prepared {
 			if input.duplicate {
 				continue
@@ -154,6 +155,9 @@ func (s *Store) IngestFederationEvents(
 				continue
 			}
 			result.Accepted++
+			if db.FederationEventAffectsLinks(input.event.Type) {
+				linksAffected = true
+			}
 			result.InsertedEventUIDs = append(result.InsertedEventUIDs, input.event.EventUID)
 			auditEvents, err := s.annotateFederationIngestClaimWorkTx(
 				ctx, tx, params.ProjectID, input.event,
@@ -166,7 +170,10 @@ func (s *Store) IngestFederationEvents(
 			}
 		}
 		if result.Accepted > 0 {
-			if err := s.materializeFederatedProjectTx(ctx, tx, params.ProjectID); err != nil {
+			// The generated claim audit events are never link-bearing, so the
+			// accepted batch alone decides whether the binding-group link fold
+			// has any work to do.
+			if err := s.materializeFederatedProjectTx(ctx, tx, params.ProjectID, linksAffected); err != nil {
 				return err
 			}
 			if !adoptionState.shouldDeferMarker {

--- a/internal/db/pgstore/federation_projection.go
+++ b/internal/db/pgstore/federation_projection.go
@@ -363,11 +363,20 @@ func federationIssueRecurrenceUID(ctx context.Context, tx *sql.Tx, recurrenceID 
 // MaterializeFederatedProject rebuilds one project's read model from portable events.
 func (s *Store) MaterializeFederatedProject(ctx context.Context, projectID int64) error {
 	return s.withSerializableTx(ctx, func(tx *sql.Tx) error {
-		return s.materializeFederatedProjectTx(ctx, tx, projectID)
+		return s.materializeFederatedProjectTx(ctx, tx, projectID, true)
 	})
 }
 
-func (s *Store) materializeFederatedProjectTx(ctx context.Context, tx *sql.Tx, projectID int64) error {
+// materializeFederatedProjectTx rebuilds the project's projection from its
+// event log. reconcileLinks controls the binding-group link pass, whose cost
+// scales with every federated project in the group rather than with this
+// project; callers that know their events cannot affect link state pass false.
+func (s *Store) materializeFederatedProjectTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectID int64,
+	reconcileLinks bool,
+) error {
 	binding, err := scanFederationBinding(tx.QueryRowContext(ctx,
 		federationBindingSelect+` WHERE project_id=$1 FOR UPDATE`, projectID))
 	if err != nil {
@@ -388,12 +397,14 @@ func (s *Store) materializeFederatedProjectTx(ctx context.Context, tx *sql.Tx, p
 	if err := reconcileFederatedLabels(ctx, tx, projectID, issueIDs, projection); err != nil {
 		return err
 	}
-	projectIDs, err := federationBindingGroupProjectIDs(ctx, tx, binding)
-	if err != nil {
-		return err
-	}
-	if err := reconcileFederatedLinkGroup(ctx, tx, projectIDs, projectID, issueIDs); err != nil {
-		return err
+	if reconcileLinks {
+		projectIDs, err := federationBindingGroupProjectIDs(ctx, tx, binding)
+		if err != nil {
+			return err
+		}
+		if err := reconcileFederatedLinkGroup(ctx, tx, projectIDs, projectID, issueIDs); err != nil {
+			return err
+		}
 	}
 	if err := pruneFederatedIssues(ctx, tx, projectID, issueIDs); err != nil {
 		return err

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -1034,7 +1034,7 @@ func (d *Store) materializeFederatedProject(ctx context.Context, projectID int64
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if err := d.materializeFederatedProjectTx(ctx, tx, projectID); err != nil {
+	if err := d.materializeFederatedProjectTx(ctx, tx, projectID, true); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {
@@ -1043,7 +1043,16 @@ func (d *Store) materializeFederatedProject(ctx context.Context, projectID int64
 	return nil
 }
 
-func (d *Store) materializeFederatedProjectTx(ctx context.Context, tx *sql.Tx, projectID int64) error {
+// materializeFederatedProjectTx rebuilds the project's projection from its
+// event log. reconcileLinks controls the binding-group link pass, whose cost
+// scales with every federated project in the group rather than with this
+// project; callers that know their events cannot affect link state pass false.
+func (d *Store) materializeFederatedProjectTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectID int64,
+	reconcileLinks bool,
+) error {
 	binding, err := scanFederationBinding(tx.QueryRowContext(ctx,
 		federationBindingSelect+` WHERE project_id = ?`, projectID))
 	if err != nil {
@@ -1065,8 +1074,10 @@ func (d *Store) materializeFederatedProjectTx(ctx context.Context, tx *sql.Tx, p
 	if err := reconcileFederatedLabels(ctx, tx, projectID, issueIDs, projection); err != nil {
 		return err
 	}
-	if err := reconcileFederatedLinks(ctx, tx, binding, projectID, issueIDs); err != nil {
-		return err
+	if reconcileLinks {
+		if err := reconcileFederatedLinks(ctx, tx, binding, projectID, issueIDs); err != nil {
+			return err
+		}
 	}
 	if err := pruneFederatedIssues(ctx, tx, projectID, issueIDs); err != nil {
 		return err

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -157,6 +157,7 @@ func (d *Store) ingestFederationEventsOnce(
 		})
 	}
 
+	linksAffected := false
 	for _, in := range prepared {
 		if in.Duplicate {
 			continue
@@ -178,13 +179,19 @@ func (d *Store) ingestFederationEventsOnce(
 			return db.FederationIngestResult{}, err
 		}
 		result.Accepted++
+		if db.FederationEventAffectsLinks(ev.Type) {
+			linksAffected = true
+		}
 		result.InsertedEventUIDs = append(result.InsertedEventUIDs, ev.EventUID)
 		for _, auditEvent := range auditEvents {
 			result.InsertedEventUIDs = append(result.InsertedEventUIDs, auditEvent.UID)
 		}
 	}
 	if result.Accepted > 0 {
-		if err := d.materializeFederatedProjectTx(ctx, tx, p.ProjectID); err != nil {
+		// The generated claim audit events are never link-bearing, so the
+		// accepted batch alone decides whether the binding-group link fold has
+		// any work to do.
+		if err := d.materializeFederatedProjectTx(ctx, tx, p.ProjectID, linksAffected); err != nil {
 			return db.FederationIngestResult{}, err
 		}
 		if !adoptionSnapshotAuthorState.shouldDeferMarker {

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -5540,3 +5540,52 @@ func TestSyncStatusWritersNoOpWithoutBinding(t *testing.T) {
 		t.Fatalf("expected no sync_status row without a binding, got %d", n)
 	}
 }
+
+// A batch with no link-affecting event skips the binding-group link fold. The
+// materialized link state must be left exactly as it was, and the rest of the
+// projection must still be rebuilt.
+func TestIngestWithoutLinkAffectingEventsPreservesMaterializedLinks(t *testing.T) {
+	d := openTestDB(t)
+	ctx := context.Background()
+	project := createProject(ctx, t, d, "spoke-project")
+	firstIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "first",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	secondIssue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "second",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	_, err = d.EnableProjectFederation(ctx, project.ID, "tester")
+	require.NoError(t, err)
+
+	const linkCount = `SELECT count(*) FROM links
+		  WHERE from_issue_uid = ? AND to_issue_uid = ? AND type = 'blocks'`
+
+	spokeUID := newTestUID(t)
+	link := ingestEventWithPayload(t, project.UID, project.Name, spokeUID,
+		&firstIssue.UID, &secondIssue.UID, "issue.linked", 100,
+		`{"issue_uid":"`+firstIssue.UID+`","from_uid":"`+firstIssue.UID+
+			`","to_uid":"`+secondIssue.UID+`","type":"blocks"}`)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(project.ID, spokeUID, link))
+	require.NoError(t, err)
+	assertRowCount(ctx, t, d, 1, "link-affecting event materializes the link",
+		linkCount, firstIssue.UID, secondIssue.UID)
+
+	comment := ingestEventWithPayload(t, project.UID, project.Name, spokeUID,
+		&firstIssue.UID, nil, "issue.commented", 101,
+		`{"issue_uid":"`+firstIssue.UID+`","comment_uid":"`+newTestUID(t)+
+			`","author":"tester","body":"follow-up","created_at":"2026-05-23T12:00:00.000Z"}`)
+	_, err = d.IngestFederationEvents(ctx, ingestParams(project.ID, spokeUID, comment))
+	require.NoError(t, err)
+
+	assertRowCount(ctx, t, d, 1, "comment-only ingest leaves materialized links intact",
+		linkCount, firstIssue.UID, secondIssue.UID)
+	assertRowCount(ctx, t, d, 1, "comment-only ingest still rebuilds the rest of the projection",
+		`SELECT count(*) FROM comments WHERE issue_id = ? AND body = 'follow-up'`,
+		firstIssue.ID)
+}

--- a/internal/federation/federation_sync.go
+++ b/internal/federation/federation_sync.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -27,7 +28,14 @@ const maxFederationPushIngestBodyBytes = 768 << 10
 // unsplittable event under the hub's configured federation ingest cap.
 const maxFederationHubIngestBodyBytes = 64 << 20
 
-const defaultClientTimeout = 5 * time.Second
+// defaultFederationClientTimeout is the per-request budget for federation sync
+// calls. These are bulk operations rather than interactive ones: a push ingests
+// a whole batch and a poll can return federationPollLimit events, and the hub's
+// per-request work grows with the size of the federated data rather than with
+// the request. A budget sized for interactive calls turns a hub that is merely
+// slow into a permanently stuck spoke, because every attempt is cancelled at the
+// same point and retried from the start. KATA_HTTP_TIMEOUT overrides this.
+const defaultFederationClientTimeout = 60 * time.Second
 
 // ErrFederationResetRequired reports a hub that still requires reset after the
 // spoke refreshed federation metadata and replayed from the new horizon.
@@ -749,7 +757,11 @@ func (r *Runner) clientOpts() clientpkg.Opts {
 
 func clientOptsWithDefault(opts clientpkg.Opts) clientpkg.Opts {
 	if opts.Timeout == 0 {
-		opts.Timeout = defaultClientTimeout
+		// An unparseable value falls back to the default; the CLI already warns
+		// about that on stderr and the sync runner has no interactive channel.
+		timeout, _ := clientpkg.ParseHTTPTimeout(
+			os.Getenv(clientpkg.HTTPTimeoutEnvVar), defaultFederationClientTimeout)
+		opts.Timeout = timeout
 	}
 	return opts
 }

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -116,7 +116,7 @@ func TestClientOptsForCredentialPreservesAllowInsecureOptIn(t *testing.T) {
 	})
 
 	assert.True(t, opts.AllowInsecure)
-	assert.Equal(t, defaultClientTimeout, opts.Timeout)
+	assert.Equal(t, defaultFederationClientTimeout, opts.Timeout)
 }
 
 func TestFederationRunnerUsesBindingEndpointWithStaleCredentialMetadata(t *testing.T) {
@@ -4306,4 +4306,36 @@ func openDaemonclientTestDB(t *testing.T) (*sqlitestore.Store, string) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 	return store, path
+}
+
+func TestClientOptsWithDefaultUsesFederationTimeout(t *testing.T) {
+	opts := clientOptsWithDefault(clientpkg.Opts{})
+
+	assert.Equal(t, defaultFederationClientTimeout, opts.Timeout)
+	assert.Greater(t, defaultFederationClientTimeout, clientpkg.DefaultHTTPTimeout,
+		"federation pushes and polls are bulk operations and need a larger budget than interactive calls")
+}
+
+func TestClientOptsWithDefaultHonorsHTTPTimeoutEnv(t *testing.T) {
+	t.Setenv(clientpkg.HTTPTimeoutEnvVar, "90s")
+
+	opts := clientOptsWithDefault(clientpkg.Opts{})
+
+	assert.Equal(t, 90*time.Second, opts.Timeout)
+}
+
+func TestClientOptsWithDefaultIgnoresUnparseableHTTPTimeoutEnv(t *testing.T) {
+	t.Setenv(clientpkg.HTTPTimeoutEnvVar, "30")
+
+	opts := clientOptsWithDefault(clientpkg.Opts{})
+
+	assert.Equal(t, defaultFederationClientTimeout, opts.Timeout)
+}
+
+func TestClientOptsWithDefaultKeepsExplicitTimeout(t *testing.T) {
+	t.Setenv(clientpkg.HTTPTimeoutEnvVar, "90s")
+
+	opts := clientOptsWithDefault(clientpkg.Opts{Timeout: 7 * time.Second})
+
+	assert.Equal(t, 7*time.Second, opts.Timeout)
 }


### PR DESCRIPTION
Federation ingest rebuilt the binding group's link projection on every accepted batch. `reconcileFederatedLinks` folds every event of every federated project in the group, so a spoke pushing a single small event paid for folding the whole group's history — a cost that grows with the federation and has nothing to do with the batch being ingested.

That pass is now skipped when no accepted event can affect link state. Link reconciliation is driven by the fold's `Links` map plus the issue-to-project endpoint resolution, so a batch of only metadata, comment, label, status, or claim events produces an identical result. Batches that can affect links still reconcile exactly as before, including multi-chunk adoption baselines, since those carry `issue.snapshot`. `FederationEventAffectsLinks` is deliberately conservative: alongside the events that write `Links`, it includes the issue lifecycle events that move an issue between projects or change whether its endpoint resolves. It is unit-tested against the complete set of fold cases so a new event type cannot be added without a decision about link reconciliation.

The second half is the sync client's request budget. Pushes and polls are bulk operations whose hub-side work scales with the federated data rather than with the request, but they used the budget sized for interactive CLI calls. A hub that legitimately needed longer than that could not be waited for: every attempt was cancelled at the same point and retried from the start, so a spoke made no progress indefinitely, and no configuration helped because `KATA_HTTP_TIMEOUT` reached only the CLI client. Sync now has its own default and honors that env var.

Both backends are updated so hub behavior does not diverge by store.

Worth noting for reviewers: the remaining per-ingest group fold is unchanged for link-affecting batches, so its cost still scales with the whole binding group. Narrowing the group itself would change cross-project link semantics and is left alone here.
