### PR TITLE
Fold only link-affecting events for the link group

### DIFF
--- a/internal/db/federation_links.go
+++ b/internal/db/federation_links.go
@@ -1,5 +1,7 @@
 package db
 
+import "sort"
+
 // FederationEventAffectsLinks reports whether an event type can change
 // federated link state, or the issue-to-project endpoint resolution that link
 // reconciliation depends on.
@@ -15,18 +17,35 @@ package db
 // the issue lifecycle events that move an issue between projects or change
 // whether its endpoint resolves at all.
 func FederationEventAffectsLinks(eventType string) bool {
-	switch eventType {
-	case "issue.created",
-		"issue.snapshot",
-		"issue.linked",
-		"issue.unlinked",
-		"issue.links_changed",
-		"issue.moved",
-		"issue.soft_deleted",
-		"issue.restored",
-		"project.author_rewritten":
-		return true
-	default:
-		return false
+	_, ok := federationLinkAffectingEventTypes[eventType]
+	return ok
+}
+
+var federationLinkAffectingEventTypes = map[string]struct{}{
+	"issue.created":            {},
+	"issue.snapshot":           {},
+	"issue.linked":             {},
+	"issue.unlinked":           {},
+	"issue.links_changed":      {},
+	"issue.moved":              {},
+	"issue.soft_deleted":       {},
+	"issue.restored":           {},
+	"project.author_rewritten": {},
+}
+
+// FederationLinkAffectingEventTypes returns the event types FederationEventAffectsLinks
+// accepts, sorted so the result is stable for query construction.
+//
+// A fold restricted to these types produces the same FoldProjection.Links as a
+// fold over every event: no other case writes Links, the issue state that link
+// author rewriting consults is established by the creation and move events that
+// are included, and everything excluded touches only issue, comment, and label
+// state that link reconciliation never reads.
+func FederationLinkAffectingEventTypes() []string {
+	out := make([]string, 0, len(federationLinkAffectingEventTypes))
+	for eventType := range federationLinkAffectingEventTypes {
+		out = append(out, eventType)
 	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/db/federation_links_test.go
+++ b/internal/db/federation_links_test.go
@@ -1,9 +1,11 @@
 package db_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/kata/internal/db"
 )
@@ -55,4 +57,61 @@ func TestFederationEventAffectsLinks(t *testing.T) {
 			assert.False(t, db.FederationEventAffectsLinks(eventType))
 		})
 	}
+}
+
+// Link reconciliation reads only FoldProjection.Links, and the group fold is
+// restricted to FederationLinkAffectingEventTypes for cost. That restriction is
+// only sound if it cannot change Links, so assert the two folds agree over a
+// stream that mixes link-bearing and unrelated events.
+func TestFoldingOnlyLinkAffectingEventsPreservesLinks(t *testing.T) {
+	const projectUID = "01HZNQ7VFPK1XGD8R5MABCD4EY"
+	child := "01HZNQ7VFPK1XGD8R5MABCD4EA"
+	parent := "01HZNQ7VFPK1XGD8R5MABCD4EB"
+	peer := "01HZNQ7VFPK1XGD8R5MABCD4EC"
+
+	event := func(clock int64, eventType, issueUID, relatedUID, payload string) db.FoldEvent {
+		return db.FoldEvent{
+			UID:               "01HZNQ7VFPK1XGD8R5MABCD" + string(rune('A'+clock%26)) + "Z",
+			OriginInstanceUID: projectUID,
+			ProjectUID:        projectUID,
+			IssueUID:          issueUID,
+			RelatedIssueUID:   relatedUID,
+			Type:              eventType,
+			Actor:             "tester",
+			HLCPhysicalMS:     clock,
+			CreatedAt:         "2026-05-23T12:00:00.000Z",
+			Payload:           json.RawMessage(payload),
+		}
+	}
+
+	all := []db.FoldEvent{
+		event(1, "issue.created", child, "",
+			`{"uid":"`+child+`","title":"child","author":"tester","status":"open",`+
+				`"links":[{"from_uid":"`+child+`","to_uid":"`+peer+`","type":"blocks","author":"tester"}]}`),
+		event(2, "issue.created", parent, "", `{"uid":"`+parent+`","title":"parent","author":"tester","status":"open"}`),
+		event(3, "issue.updated", child, "", `{"issue_uid":"`+child+`","diff":{"title":{"to":"renamed"}}}`),
+		event(4, "issue.linked", child, parent,
+			`{"issue_uid":"`+child+`","from_uid":"`+child+`","to_uid":"`+parent+`","type":"parent"}`),
+		event(5, "issue.commented", child, "",
+			`{"issue_uid":"`+child+`","comment_uid":"01HZNQ7VFPK1XGD8R5MABCD4ED","author":"tester","body":"note"}`),
+		event(6, "issue.labeled", child, "", `{"issue_uid":"`+child+`","label":"bug"}`),
+		event(7, "issue.unlinked", child, peer,
+			`{"issue_uid":"`+child+`","from_uid":"`+child+`","to_uid":"`+peer+`","type":"blocks"}`),
+		event(8, "project.metadata_updated", "", "", `{"diff":{"area":{"from":null,"to":"docs"}}}`),
+		event(9, "issue.closed", child, "", `{"issue_uid":"`+child+`"}`),
+	}
+
+	var linkAffecting []db.FoldEvent
+	for _, ev := range all {
+		if db.FederationEventAffectsLinks(ev.Type) {
+			linkAffecting = append(linkAffecting, ev)
+		}
+	}
+	require.Less(t, len(linkAffecting), len(all), "stream must include events that are filtered out")
+
+	full := db.FoldEvents(all)
+	restricted := db.FoldEvents(linkAffecting)
+
+	require.NotEmpty(t, full.Links, "stream must produce link state to compare")
+	assert.Equal(t, full.Links, restricted.Links)
 }

--- a/internal/db/pgstore/federation_links.go
+++ b/internal/db/pgstore/federation_links.go
@@ -250,9 +250,14 @@ func federationGroupFoldProjection(
 	tx *sql.Tx,
 	projectIDs []int64,
 ) (db.FoldProjection, error) {
+	// Only Links is read from this projection, so the fold is restricted to the
+	// events that can affect it. Everything else in the group's history stays
+	// out of the query, which is what keeps a single ingest from reading every
+	// federated project's full event payloads.
+	linkEventTypes := db.FederationLinkAffectingEventTypes()
 	var events []db.FoldEvent
 	for _, projectID := range projectIDs {
-		projectEvents, err := federationFoldEvents(ctx, tx, projectID)
+		projectEvents, err := federationFoldEventsOfTypes(ctx, tx, projectID, linkEventTypes)
 		if err != nil {
 			return db.FoldProjection{}, err
 		}
@@ -262,9 +267,34 @@ func federationGroupFoldProjection(
 }
 
 func federationFoldEvents(ctx context.Context, tx *sql.Tx, projectID int64) ([]db.FoldEvent, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT e.uid,e.origin_instance_uid,p.uid,e.issue_uid,
+	return federationFoldEventsOfTypes(ctx, tx, projectID, nil)
+}
+
+// federationFoldEventsOfTypes lists a project's fold events in event order,
+// limited to eventTypes when it is non-empty. Restricting the types keeps the
+// payload of every irrelevant event out of the query and out of the fold, which
+// matters because the caller may run this across a whole binding group.
+func federationFoldEventsOfTypes(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectID int64,
+	eventTypes []string,
+) ([]db.FoldEvent, error) {
+	query := `SELECT e.uid,e.origin_instance_uid,p.uid,e.issue_uid,
 e.related_issue_uid,e.type,e.actor,e.payload,e.hlc_physical_ms,e.hlc_counter,e.created_at
-FROM events e JOIN projects p ON p.id=e.project_id WHERE e.project_id=$1 ORDER BY e.id ASC`, projectID)
+FROM events e JOIN projects p ON p.id=e.project_id WHERE e.project_id=$1`
+	args := []any{projectID}
+	if len(eventTypes) > 0 {
+		placeholders := make([]string, 0, len(eventTypes))
+		for i, eventType := range eventTypes {
+			placeholders = append(placeholders, fmt.Sprintf("$%d", i+2))
+			args = append(args, eventType)
+		}
+		//nolint:gosec // G202: generated $N placeholders only; values are bound separately.
+		query += " AND e.type IN (" + strings.Join(placeholders, ",") + ")"
+	}
+	query += " ORDER BY e.id ASC"
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, mapSQLError(err, nil)
 	}

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -1486,12 +1486,36 @@ func federationIssueRecurrenceUID(ctx context.Context, tx *sql.Tx, recurrenceID 
 }
 
 func federationFoldEvents(ctx context.Context, tx *sql.Tx, projectID int64) ([]db.FoldEvent, error) {
-	rows, err := tx.QueryContext(ctx, `
+	return federationFoldEventsOfTypes(ctx, tx, projectID, nil)
+}
+
+// federationFoldEventsOfTypes lists a project's fold events in event order,
+// limited to eventTypes when it is non-empty. Restricting the types keeps the
+// payload of every irrelevant event out of the query and out of the fold, which
+// matters because the caller may run this across a whole binding group.
+func federationFoldEventsOfTypes(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectID int64,
+	eventTypes []string,
+) ([]db.FoldEvent, error) {
+	query := `
 		SELECT uid, origin_instance_uid, project_name, issue_uid, related_issue_uid,
 		       type, actor, payload, hlc_physical_ms, hlc_counter, created_at
 		  FROM events
-		 WHERE project_id = ?
-		 ORDER BY id ASC`, projectID)
+		 WHERE project_id = ?`
+	args := []any{projectID}
+	if len(eventTypes) > 0 {
+		placeholders := make([]string, 0, len(eventTypes))
+		for _, eventType := range eventTypes {
+			placeholders = append(placeholders, "?")
+			args = append(args, eventType)
+		}
+		//nolint:gosec // G202: generated ? placeholders only; values are bound separately.
+		query += " AND type IN (" + strings.Join(placeholders, ",") + ")"
+	}
+	query += " ORDER BY id ASC"
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list federated events: %w", err)
 	}
@@ -2258,9 +2282,14 @@ func federationGroupFoldProjection(
 	tx *sql.Tx,
 	projectIDs []int64,
 ) (db.FoldProjection, error) {
+	// Only Links is read from this projection, so the fold is restricted to the
+	// events that can affect it. Everything else in the group's history stays
+	// out of the query, which is what keeps a single ingest from reading every
+	// federated project's full event payloads.
+	linkEventTypes := db.FederationLinkAffectingEventTypes()
 	var events []db.FoldEvent
 	for _, projectID := range projectIDs {
-		projectEvents, err := federationFoldEvents(ctx, tx, projectID)
+		projectEvents, err := federationFoldEventsOfTypes(ctx, tx, projectID, linkEventTypes)
 		if err != nil {
 			return db.FoldProjection{}, err
 		}


### PR DESCRIPTION
Stacked on #223; review that one first.

`reconcileFederatedLinkGroup` reads only `FoldProjection.Links`, but it built that projection by folding every event of every federated project in the binding group, and `federationFoldEvents` selects each event's full `payload`. One ingest therefore read and parsed the group's entire history, the overwhelming majority of which cannot contribute link state.

The group fold is now restricted to `FederationLinkAffectingEventTypes`. The resulting `Links` is identical, and the reasoning is worth checking closely since it is the whole basis of the change: no other fold case writes `Links`; the issue state that link author rewriting consults is established by the creation and move events that remain included; and every excluded case touches only issue, comment, and label state that link reconciliation never reads. A test folds a mixed stream both ways and asserts the `Links` maps are equal, and the existing cross-project membership tests cover the deferred-link convergence behaviour.

This deliberately narrows the constant rather than the scaling — the fold still visits every project in the group, so #3s88 stays open. Narrowing group membership itself turned out to be a bigger change than it first looks, for two reasons worth recording:

A cross-project link can be *pending*, with no row in `links` yet, and reconciliation is expected to converge on it when the peer is later enabled. A membership filter derived from materialised rows would strand it permanently.

`issue.snapshot` carries its links inside the payload JSON rather than in `related_issue_uid`, so a filter derived from event columns would miss exactly the adoption-baseline case that matters most.

Both are covered by existing tests, which is how they surfaced. A correct membership filter needs to account for pending links and payload-carried endpoints, and that deserves its own change rather than riding along here.
