### PR TITLE
Expose standard daemon pprof endpoints

### DIFF
--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -30,6 +30,31 @@ set once.
 Run the daemon under a process manager such as launchd, systemd, or a container
 runtime on the host that owns the SQLite database.
 
+## Runtime profiling
+
+The daemon exposes Go's standard `net/http/pprof` handlers under
+`/debug/pprof/` on its existing listener. The same listener and authentication
+policy protect profiling requests; a token-protected TCP daemon requires its
+normal bearer token.
+
+Capture and inspect CPU and heap profiles with standard Go tools:
+
+```sh
+curl -H "Authorization: Bearer $KATA_AUTH_TOKEN" \
+  'http://100.64.0.5:7777/debug/pprof/profile?seconds=30' \
+  -o kata.cpu.pprof
+go tool pprof kata.cpu.pprof
+
+curl -H "Authorization: Bearer $KATA_AUTH_TOKEN" \
+  'http://100.64.0.5:7777/debug/pprof/heap' \
+  -o kata.heap.pprof
+go tool pprof kata.heap.pprof
+```
+
+The index also links the goroutine, allocation, mutex-contention, blocking,
+thread-creation, command-line, symbol, and execution-trace endpoints. Capture
+`/debug/pprof/trace?seconds=5` and open it with `go tool trace`.
+
 ## Client setup
 
 Point clients at the daemon:

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"strings"
 	"time"
 
@@ -218,6 +219,7 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 	registerWebDaemonHandlers(mux, cfg)
 	registerOpenAPIYAML(mux, cfg.HostAccess)
+	registerPprofHandlers(mux)
 	webHandler, err := kataweb.NewEmbeddedHandler()
 	if err != nil {
 		panic(fmt.Errorf("build embedded web handler: %w", err))
@@ -294,6 +296,14 @@ func registerOpenAPIYAML(mux *http.ServeMux, hostAccess HostAccessController) {
 		w.Header().Set("Content-Type", "application/openapi+yaml")
 		_, _ = w.Write(out)
 	})
+}
+
+func registerPprofHandlers(mux *http.ServeMux) {
+	mux.HandleFunc(http.MethodGet+" /debug/pprof/", pprof.Index)
+	mux.HandleFunc(http.MethodGet+" /debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc(http.MethodGet+" /debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc(http.MethodGet+" /debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc(http.MethodGet+" /debug/pprof/trace", pprof.Trace)
 }
 
 // Run listens on the configured endpoint until ctx is cancelled. The caller is

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -3,6 +3,7 @@ package daemon_test
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -16,6 +17,72 @@ func TestServer_PingReturnsOK(t *testing.T) {
 	resp, body := getStatusBody(t, ts, "/api/v1/ping")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, string(body), `"ok":true`)
+}
+
+func TestServer_ExposesStandardPprofHandlers(t *testing.T) {
+	ts, _ := startDefaultTestServer(t)
+
+	for _, tc := range []struct {
+		path               string
+		wantContentType    string
+		wantDisposition    string
+		wantBodySubstring  string
+		cancelBeforeHandle bool
+	}{
+		{
+			path:              "/debug/pprof/",
+			wantContentType:   "text/html; charset=utf-8",
+			wantBodySubstring: "Types of profiles available:",
+		},
+		{
+			path:            "/debug/pprof/heap",
+			wantContentType: "application/octet-stream",
+			wantDisposition: `attachment; filename="heap"`,
+		},
+		{
+			path:              "/debug/pprof/cmdline",
+			wantContentType:   "text/plain; charset=utf-8",
+			wantBodySubstring: "daemon.test",
+		},
+		{
+			path:              "/debug/pprof/symbol",
+			wantContentType:   "text/plain; charset=utf-8",
+			wantBodySubstring: "num_symbols:",
+		},
+		{
+			path:               "/debug/pprof/profile?seconds=1",
+			wantContentType:    "application/octet-stream",
+			wantDisposition:    `attachment; filename="profile"`,
+			cancelBeforeHandle: true,
+		},
+		{
+			path:               "/debug/pprof/trace?seconds=1",
+			wantContentType:    "application/octet-stream",
+			wantDisposition:    `attachment; filename="trace"`,
+			cancelBeforeHandle: true,
+		},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if tc.cancelBeforeHandle {
+				ctx, cancel := context.WithCancel(req.Context())
+				cancel()
+				req = req.WithContext(ctx)
+			}
+			recorder := httptest.NewRecorder()
+
+			ts.Config.Handler.ServeHTTP(recorder, req)
+
+			resp := recorder.Result()
+			defer func() { _ = resp.Body.Close() }()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, tc.wantContentType, resp.Header.Get("Content-Type"))
+			assert.Equal(t, tc.wantDisposition, resp.Header.Get("Content-Disposition"))
+			if tc.wantBodySubstring != "" {
+				assert.Contains(t, recorder.Body.String(), tc.wantBodySubstring)
+			}
+		})
+	}
 }
 
 func TestServer_RejectsNonEmptyOrigin(t *testing.T) {


### PR DESCRIPTION
## Summary

Kata operators need a supported way to inspect CPU, memory, goroutine, mutex, blocking, and trace behavior in a running daemon with standard Go tooling.

This exposes the standard `net/http/pprof` handlers through the daemon's existing listener and documents profile capture for remote daemon operators. The profiling surface is intentionally available without Kata API or browser-session authentication; listener reachability is its access boundary.

<sup>generated by a clanker</sup>