### PR TITLE
Use public docs URL in agent guidance

### DIFF
--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -678,7 +678,7 @@ const agentsBlockBody = "## kata issue tracker\n\n" +
 	"- Never `kata delete` or `kata purge` without explicit user authorization.\n\n" +
 	"## kata work.* conventions (agent orchestration)\n\n" +
 	"When working a kata-tracked issue, keep its `work.*` metadata truthful\n" +
-	"(see docs/operations/agent-orchestration.md for the full recipe):\n\n" +
+	"(see https://katatracker.com/operations/agent-orchestration/ for the full recipe):\n\n" +
 	"- On claim/start: `kata meta set <ref> work.attention ok`; if the work has a\n" +
 	"  dedicated branch, stamp it once with `kata meta set <ref> work.branch <branch>`.\n" +
 	"- Signal live state: `kata meta set <ref> work.attention stuck|needs-human|ok`\n" +

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -603,7 +603,8 @@ func TestInit_WithAgents_BlockIncludesWorkConventions(t *testing.T) {
 	assert.Contains(t, got, "## kata work.* conventions")
 	assert.Contains(t, got, "kata meta set <ref> work.attention ok")
 	assert.Contains(t, got, "work.attention_msg")
-	assert.Contains(t, got, "docs/operations/agent-orchestration.md")
+	assert.Contains(t, got, "https://katatracker.com/operations/agent-orchestration/")
+	assert.NotContains(t, got, "docs/operations/agent-orchestration.md")
 }
 
 // oldAgentsBlockBody is the managed-block body kata shipped before the work.*

--- a/docs/operations/agent-orchestration.md
+++ b/docs/operations/agent-orchestration.md
@@ -245,7 +245,7 @@ prose — paste it essentially intact.
 ## Kata `work.*` conventions (agent orchestration)
 
 This repo's kata board uses the `work.*` metadata contract — see kata's
-`docs/operations/agent-orchestration.md` for the full recipe.
+<https://katatracker.com/operations/agent-orchestration/> for the full recipe.
 
 **When you work a kata-tracked issue:**
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -40,6 +40,7 @@
   },
   "overrides": {
     "js-yaml": "4.3.1",
+    "nanoid": "3.3.17",
   },
   "packages": {
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
@@ -544,7 +545,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "packageManager": "bun@1.3.14",
   "overrides": {
-    "js-yaml": "4.3.1"
+    "js-yaml": "4.3.1",
+    "nanoid": "3.3.17"
   },
   "scripts": {
     "generate": "bun run scripts/generate-api.ts",


### PR DESCRIPTION
`kata init --with-agents` writes guidance into consumer repositories, but its orchestration recipe link was relative to Kata’s own docs tree. That leaves generated instructions with a dangling reference outside the Kata checkout.

Point the managed block at the published documentation and align the paste-ready runbook snippet. Existing marker-delimited blocks are refreshed on rerun, so users can repair already initialized repositories without manual editing.

The branch also pins the patched `nanoid` transitive dependency after a newly published high-severity advisory made the strict web audit reject the previous lock resolution.

Closes #210.