### PR TITLE
Bound workspace config discovery to git roots

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -88,9 +88,12 @@ workspace explicitly, never inferred from wherever a command happens to run.
 
 A **project** is the namespace for issues, numbering, links, labels, and events.
 A workspace declares its project through a committed `.kata.toml` file. Resolution
-walks up from the start path to find that file and the enclosing git root, then
-resolves the project. Outside a bound workspace, and without an explicit
-`--project`, every command except `kata init` fails with `project_not_initialized`.
+walks up from the start path to find that file and the enclosing git root. In a
+git workspace the config walk stops at that root, so a binding outside the
+repository cannot capture it; non-git workspaces walk to the filesystem root.
+Resolution then resolves the project. Outside a bound workspace, and without
+an explicit `--project`, every command except `kata init` fails with
+`project_not_initialized`.
 kata never silently namespaces issues to a random directory, and `kata init` is
 the only command that creates a project row. Auto-creation on first read or write
 is deliberately excluded — it is exactly how agents end up writing into the wrong

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -66,8 +66,10 @@ kata init
 ```
 
 `kata init` writes `.kata.toml` with a project binding. In a git workspace,
-kata derives the default project name from the git remote. For a non-git
-workspace or an explicit shared project name:
+kata derives the default project name from the git remote and keeps config
+discovery within that repository. A `.kata.toml` above the git root does not
+bind the repository. For a non-git workspace or an explicit shared project
+name:
 
 ```sh
 kata init --project product

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -80,29 +80,27 @@ func ReadProjectConfig(workspaceRoot string) (*ProjectConfig, error) {
 
 // FindProjectConfig walks upward from startPath looking for a readable
 // .kata.toml. Returns the parsed config and the directory it was found
-// in. Returns ErrProjectConfigMissing if no .kata.toml is found at any
-// ancestor directory. Stops at the filesystem root.
+// in. Returns ErrProjectConfigMissing if no .kata.toml is found. In a git
+// workspace, discovery stops at the git root; otherwise it stops at the
+// filesystem root.
 //
 // This is the discovery counterpart to ReadProjectConfig. Callers that
 // know the exact workspace root should use ReadProjectConfig directly;
 // callers running from arbitrary cwds inside a workspace (CLI, TUI)
 // use this to find the binding without forcing the user to `cd` first.
 func FindProjectConfig(startPath string) (*ProjectConfig, string, error) {
-	dir := startPath
-	for {
-		cfg, err := ReadProjectConfig(dir)
-		if err == nil {
-			return cfg, dir, nil
-		}
-		if !errors.Is(err, ErrProjectConfigMissing) {
-			return nil, "", err
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return nil, "", ErrProjectConfigMissing
-		}
-		dir = parent
+	disc, err := DiscoverPaths(startPath)
+	if err != nil {
+		return nil, "", err
 	}
+	if disc.WorkspaceRoot == "" {
+		return nil, "", ErrProjectConfigMissing
+	}
+	cfg, err := ReadProjectConfig(disc.WorkspaceRoot)
+	if err != nil {
+		return nil, "", err
+	}
+	return cfg, disc.WorkspaceRoot, nil
 }
 
 // WriteProjectConfig writes a v1 .kata.toml at <workspaceRoot>/.kata.toml.

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/testfix"
 )
 
 func setupKataProjectDir(t *testing.T, body string) string {
@@ -192,6 +193,22 @@ name = "kata"
 	require.NoError(t, err)
 	assert.Equal(t, root, foundDir)
 	assert.Equal(t, "kata", cfg.Project.Name)
+}
+
+func TestFindProjectConfig_DoesNotCrossGitRoot(t *testing.T) {
+	outer := setupKataProjectDir(t, `version = 1
+
+[project]
+name = "example-project"
+`)
+	repo := filepath.Join(outer, "repo-a")
+	require.NoError(t, os.MkdirAll(repo, 0o755)) //nolint:gosec // test fixture under TempDir
+	testfix.MkDotGit(t, repo)
+
+	cfg, foundDir, err := config.FindProjectConfig(repo)
+	assert.Nil(t, cfg)
+	assert.Empty(t, foundDir)
+	assert.ErrorIs(t, err, config.ErrProjectConfigMissing)
 }
 
 func TestFindProjectConfig_MissingReturnsSentinel(t *testing.T) {

--- a/internal/config/project_identity.go
+++ b/internal/config/project_identity.go
@@ -150,39 +150,48 @@ func DiscoverPaths(startPath string) (DiscoveredPaths, error) {
 		physicalWalkRoot = filepath.Dir(resolved)
 	}
 	d := DiscoveredPaths{}
-	if d.GitRoot, err = walkUp(physicalWalkRoot, ".git", true, ""); err != nil {
+	physicalGitRoot, err := walkUp(physicalWalkRoot, ".git", true, "")
+	if err != nil {
 		return DiscoveredPaths{}, fmt.Errorf("discover .git: %w", err)
 	}
-	if d.GitRoot == "" {
+	if physicalGitRoot == "" {
 		if d.WorkspaceRoot, err = walkUp(lexicalWalkRoot, ProjectConfigFilename, false, ""); err != nil {
 			return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
 		}
 		return d, nil
 	}
-	if d.WorkspaceRoot, err = walkUp(physicalWalkRoot, ProjectConfigFilename, false, d.GitRoot); err != nil {
+	if lexicalGitRoot, ok := matchingLexicalAncestor(lexicalWalkRoot, physicalGitRoot); ok {
+		d.GitRoot = lexicalGitRoot
+		if d.WorkspaceRoot, err = walkUp(lexicalWalkRoot, ProjectConfigFilename, false, lexicalGitRoot); err != nil {
+			return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
+		}
+		return d, nil
+	}
+	d.GitRoot = physicalGitRoot
+	if d.WorkspaceRoot, err = walkUp(physicalWalkRoot, ProjectConfigFilename, false, physicalGitRoot); err != nil {
 		return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
 	}
-	d.GitRoot = matchingLexicalAncestor(lexicalWalkRoot, d.GitRoot)
-	d.WorkspaceRoot = matchingLexicalAncestor(lexicalWalkRoot, d.WorkspaceRoot)
+	if lexicalWorkspaceRoot, ok := matchingLexicalAncestor(lexicalWalkRoot, d.WorkspaceRoot); ok {
+		d.WorkspaceRoot = lexicalWorkspaceRoot
+	}
 	return d, nil
 }
 
 // matchingLexicalAncestor preserves the caller's path spelling when one of
-// its lexical ancestors resolves to the discovered physical root. A root above
-// an explicit symlink target has no such representation and remains physical.
-func matchingLexicalAncestor(start, physicalRoot string) string {
+// its lexical ancestors resolves to the discovered physical root.
+func matchingLexicalAncestor(start, physicalRoot string) (string, bool) {
 	if physicalRoot == "" {
-		return ""
+		return "", false
 	}
 	dir := start
 	for {
 		resolved, err := filepath.EvalSymlinks(dir)
 		if err == nil && resolved == physicalRoot {
-			return dir
+			return dir, true
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return physicalRoot
+			return "", false
 		}
 		dir = parent
 	}

--- a/internal/config/project_identity.go
+++ b/internal/config/project_identity.go
@@ -118,8 +118,11 @@ type AliasInfo struct {
 	Kind     string // "git" | "local"
 }
 
-// DiscoverPaths walks upward from startPath looking for .kata.toml (W) and
-// .git (G). Both lookups are independent and inclusive of startPath itself.
+// DiscoverPaths walks upward from startPath looking for .git (G), then for
+// .kata.toml (W). Both lookups are inclusive of startPath itself. When a git
+// root exists, it bounds the .kata.toml lookup so configuration outside the
+// repository cannot capture paths within it. Git ancestry follows symlinks;
+// non-git workspaces retain lexical ancestor discovery.
 // startPath must point at an existing file or directory; a missing start path
 // is reported as a resolution error so a typo like `--workspace /no/such/dir`
 // fails loud instead of silently resolving an unrelated ancestor.
@@ -134,27 +137,63 @@ func DiscoverPaths(startPath string) (DiscoveredPaths, error) {
 	if err != nil {
 		return DiscoveredPaths{}, fmt.Errorf("stat %s: %w", abs, err)
 	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return DiscoveredPaths{}, fmt.Errorf("resolve symlinks %s: %w", abs, err)
+	}
 	// If the start path is a file, walk from its parent directory so we don't
 	// stat <file>/.kata.toml (which fails with ENOTDIR rather than not-found).
-	walkRoot := abs
+	lexicalWalkRoot := abs
+	physicalWalkRoot := resolved
 	if !info.IsDir() {
-		walkRoot = filepath.Dir(abs)
+		lexicalWalkRoot = filepath.Dir(abs)
+		physicalWalkRoot = filepath.Dir(resolved)
 	}
 	d := DiscoveredPaths{}
-	if d.WorkspaceRoot, err = walkUp(walkRoot, ProjectConfigFilename, false); err != nil {
-		return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
-	}
-	if d.GitRoot, err = walkUp(walkRoot, ".git", true); err != nil {
+	if d.GitRoot, err = walkUp(physicalWalkRoot, ".git", true, ""); err != nil {
 		return DiscoveredPaths{}, fmt.Errorf("discover .git: %w", err)
 	}
+	if d.GitRoot == "" {
+		if d.WorkspaceRoot, err = walkUp(lexicalWalkRoot, ProjectConfigFilename, false, ""); err != nil {
+			return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
+		}
+		return d, nil
+	}
+	if d.WorkspaceRoot, err = walkUp(physicalWalkRoot, ProjectConfigFilename, false, d.GitRoot); err != nil {
+		return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
+	}
+	d.GitRoot = matchingLexicalAncestor(lexicalWalkRoot, d.GitRoot)
+	d.WorkspaceRoot = matchingLexicalAncestor(lexicalWalkRoot, d.WorkspaceRoot)
 	return d, nil
 }
 
+// matchingLexicalAncestor preserves the caller's path spelling when one of
+// its lexical ancestors resolves to the discovered physical root. A root above
+// an explicit symlink target has no such representation and remains physical.
+func matchingLexicalAncestor(start, physicalRoot string) string {
+	if physicalRoot == "" {
+		return ""
+	}
+	dir := start
+	for {
+		resolved, err := filepath.EvalSymlinks(dir)
+		if err == nil && resolved == physicalRoot {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return physicalRoot
+		}
+		dir = parent
+	}
+}
+
 // walkUp returns the first ancestor (inclusive) containing the named entry,
-// or "" if none. allowDir lets the entry be either a file or directory.
+// or "" if none. stop is an inclusive traversal boundary; an empty stop walks
+// to the filesystem root. allowDir lets the entry be either a file or directory.
 // os.IsNotExist failures are normal during traversal; other errors surface so
 // callers see e.g. permission-denied instead of treating it as "not found".
-func walkUp(start, entry string, allowDir bool) (string, error) {
+func walkUp(start, entry string, allowDir bool, stop string) (string, error) {
 	dir := start
 	for {
 		path := filepath.Join(dir, entry)
@@ -170,6 +209,9 @@ func walkUp(start, entry string, allowDir bool) (string, error) {
 			}
 		case !os.IsNotExist(err):
 			return "", fmt.Errorf("stat %s: %w", path, err)
+		}
+		if dir == stop {
+			return "", nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {

--- a/internal/config/project_identity.go
+++ b/internal/config/project_identity.go
@@ -121,7 +121,8 @@ type AliasInfo struct {
 // DiscoverPaths walks upward from startPath looking for .git (G), then for
 // .kata.toml (W). Both lookups are inclusive of startPath itself. When a git
 // root exists, it bounds the .kata.toml lookup so configuration outside the
-// repository cannot capture paths within it. Git ancestry follows symlinks;
+// repository cannot capture paths within it. Git ancestry follows symlinks,
+// with a lexical Git boundary retained when a symlink escapes the repository;
 // non-git workspaces retain lexical ancestor discovery.
 // startPath must point at an existing file or directory; a missing start path
 // is reported as a resolution error so a typo like `--workspace /no/such/dir`
@@ -155,7 +156,10 @@ func DiscoverPaths(startPath string) (DiscoveredPaths, error) {
 		return DiscoveredPaths{}, fmt.Errorf("discover .git: %w", err)
 	}
 	if physicalGitRoot == "" {
-		if d.WorkspaceRoot, err = walkUp(lexicalWalkRoot, ProjectConfigFilename, false, ""); err != nil {
+		if d.GitRoot, err = walkUp(lexicalWalkRoot, ".git", true, ""); err != nil {
+			return DiscoveredPaths{}, fmt.Errorf("discover .git: %w", err)
+		}
+		if d.WorkspaceRoot, err = walkUp(lexicalWalkRoot, ProjectConfigFilename, false, d.GitRoot); err != nil {
 			return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
 		}
 		return d, nil

--- a/internal/config/project_identity.go
+++ b/internal/config/project_identity.go
@@ -121,9 +121,11 @@ type AliasInfo struct {
 // DiscoverPaths walks upward from startPath looking for .git (G), then for
 // .kata.toml (W). Both lookups are inclusive of startPath itself. When a git
 // root exists, it bounds the .kata.toml lookup so configuration outside the
-// repository cannot capture paths within it. Git ancestry follows symlinks,
-// with a lexical Git boundary retained when a symlink escapes the repository;
-// non-git workspaces retain lexical ancestor discovery.
+// repository cannot capture paths within it. Lexical traversal is used only
+// when its nearest Git root resolves to the physical Git root; differing roots
+// stay on the physical repository side. A lexical Git boundary is retained
+// when a symlink escapes all physical repositories, while non-git workspaces
+// retain lexical ancestor discovery.
 // startPath must point at an existing file or directory; a missing start path
 // is reported as a resolution error so a typo like `--workspace /no/such/dir`
 // fails loud instead of silently resolving an unrelated ancestor.
@@ -151,20 +153,23 @@ func DiscoverPaths(startPath string) (DiscoveredPaths, error) {
 		physicalWalkRoot = filepath.Dir(resolved)
 	}
 	d := DiscoveredPaths{}
+	lexicalGitRoot, err := walkUp(lexicalWalkRoot, ".git", true, "")
+	if err != nil {
+		return DiscoveredPaths{}, fmt.Errorf("discover .git: %w", err)
+	}
 	physicalGitRoot, err := walkUp(physicalWalkRoot, ".git", true, "")
 	if err != nil {
 		return DiscoveredPaths{}, fmt.Errorf("discover .git: %w", err)
 	}
 	if physicalGitRoot == "" {
-		if d.GitRoot, err = walkUp(lexicalWalkRoot, ".git", true, ""); err != nil {
-			return DiscoveredPaths{}, fmt.Errorf("discover .git: %w", err)
-		}
+		d.GitRoot = lexicalGitRoot
 		if d.WorkspaceRoot, err = walkUp(lexicalWalkRoot, ProjectConfigFilename, false, d.GitRoot); err != nil {
 			return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
 		}
 		return d, nil
 	}
-	if lexicalGitRoot, ok := matchingLexicalAncestor(lexicalWalkRoot, physicalGitRoot); ok {
+	resolvedLexicalGitRoot, resolveErr := filepath.EvalSymlinks(lexicalGitRoot)
+	if resolveErr == nil && resolvedLexicalGitRoot == physicalGitRoot {
 		d.GitRoot = lexicalGitRoot
 		if d.WorkspaceRoot, err = walkUp(lexicalWalkRoot, ProjectConfigFilename, false, lexicalGitRoot); err != nil {
 			return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
@@ -175,30 +180,7 @@ func DiscoverPaths(startPath string) (DiscoveredPaths, error) {
 	if d.WorkspaceRoot, err = walkUp(physicalWalkRoot, ProjectConfigFilename, false, physicalGitRoot); err != nil {
 		return DiscoveredPaths{}, fmt.Errorf("discover %s: %w", ProjectConfigFilename, err)
 	}
-	if lexicalWorkspaceRoot, ok := matchingLexicalAncestor(lexicalWalkRoot, d.WorkspaceRoot); ok {
-		d.WorkspaceRoot = lexicalWorkspaceRoot
-	}
 	return d, nil
-}
-
-// matchingLexicalAncestor preserves the caller's path spelling when one of
-// its lexical ancestors resolves to the discovered physical root.
-func matchingLexicalAncestor(start, physicalRoot string) (string, bool) {
-	if physicalRoot == "" {
-		return "", false
-	}
-	dir := start
-	for {
-		resolved, err := filepath.EvalSymlinks(dir)
-		if err == nil && resolved == physicalRoot {
-			return dir, true
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", false
-		}
-		dir = parent
-	}
 }
 
 // walkUp returns the first ancestor (inclusive) containing the named entry,

--- a/internal/config/project_identity_test.go
+++ b/internal/config/project_identity_test.go
@@ -73,6 +73,24 @@ func TestDiscoverPaths_SymlinkIntoGitIgnoresLexicalAncestorConfig(t *testing.T) 
 	assert.Equal(t, physicalRepo, config.WriteDestination(d, link))
 }
 
+func TestDiscoverPaths_SymlinkWithinGitKeepsNestedLexicalWorkspace(t *testing.T) {
+	repo := t.TempDir()
+	testfix.MkDotGit(t, repo)
+	workspace := filepath.Join(repo, "workspace")
+	require.NoError(t, os.Mkdir(workspace, 0o755)) //nolint:gosec // test fixture under TempDir.
+	testfix.WriteKataToml(t, workspace, "example-project")
+	target := filepath.Join(repo, "target")
+	require.NoError(t, os.Mkdir(target, 0o755)) //nolint:gosec // test fixture under TempDir.
+	link := filepath.Join(workspace, "link")
+	require.NoError(t, os.Symlink(target, link))
+
+	d, err := config.DiscoverPaths(link)
+	require.NoError(t, err)
+	assert.Equal(t, workspace, d.WorkspaceRoot)
+	assert.Equal(t, repo, d.GitRoot)
+	assert.Equal(t, workspace, config.WriteDestination(d, link))
+}
+
 func TestDiscoverPaths_SymlinkedNonGitWorkspaceKeepsLexicalAncestorConfig(t *testing.T) {
 	outer := t.TempDir()
 	testfix.WriteKataToml(t, outer, "example-project")

--- a/internal/config/project_identity_test.go
+++ b/internal/config/project_identity_test.go
@@ -38,6 +38,54 @@ func TestDiscoverPaths_KataTomlInSubdirOfGit(t *testing.T) {
 	assert.Equal(t, root, d.GitRoot)
 }
 
+func TestDiscoverPaths_KataTomlAboveGitRoot(t *testing.T) {
+	outer := t.TempDir()
+	testfix.WriteKataToml(t, outer, "example-project")
+
+	repo := filepath.Join(outer, "repo-a")
+	require.NoError(t, os.MkdirAll(repo, 0o755)) //nolint:gosec // test fixture under TempDir.
+	testfix.MkDotGit(t, repo)
+
+	d, err := config.DiscoverPaths(repo)
+	require.NoError(t, err)
+	assert.Empty(t, d.WorkspaceRoot)
+	assert.Equal(t, repo, d.GitRoot)
+	assert.Equal(t, repo, config.WriteDestination(d, repo))
+}
+
+func TestDiscoverPaths_SymlinkIntoGitIgnoresLexicalAncestorConfig(t *testing.T) {
+	repo := t.TempDir()
+	testfix.MkDotGit(t, repo)
+	nested := filepath.Join(repo, "nested")
+	require.NoError(t, os.Mkdir(nested, 0o755)) //nolint:gosec // test fixture under TempDir.
+
+	outer := t.TempDir()
+	testfix.WriteKataToml(t, outer, "example-project")
+	link := filepath.Join(outer, "linked-workspace")
+	require.NoError(t, os.Symlink(nested, link))
+
+	d, err := config.DiscoverPaths(link)
+	require.NoError(t, err)
+	physicalRepo, err := filepath.EvalSymlinks(repo)
+	require.NoError(t, err)
+	assert.Empty(t, d.WorkspaceRoot)
+	assert.Equal(t, physicalRepo, d.GitRoot)
+	assert.Equal(t, physicalRepo, config.WriteDestination(d, link))
+}
+
+func TestDiscoverPaths_SymlinkedNonGitWorkspaceKeepsLexicalAncestorConfig(t *testing.T) {
+	outer := t.TempDir()
+	testfix.WriteKataToml(t, outer, "example-project")
+	target := t.TempDir()
+	link := filepath.Join(outer, "linked-workspace")
+	require.NoError(t, os.Symlink(target, link))
+
+	d, err := config.DiscoverPaths(link)
+	require.NoError(t, err)
+	assert.Equal(t, outer, d.WorkspaceRoot)
+	assert.Empty(t, d.GitRoot)
+}
+
 func TestDiscoverPaths_NeitherFound(t *testing.T) {
 	d, err := config.DiscoverPaths(t.TempDir())
 	require.NoError(t, err)

--- a/internal/config/project_identity_test.go
+++ b/internal/config/project_identity_test.go
@@ -91,6 +91,23 @@ func TestDiscoverPaths_SymlinkWithinGitKeepsNestedLexicalWorkspace(t *testing.T)
 	assert.Equal(t, workspace, config.WriteDestination(d, link))
 }
 
+func TestDiscoverPaths_SymlinkOutOfGitIgnoresLexicalAncestorConfig(t *testing.T) {
+	outer := t.TempDir()
+	testfix.WriteKataToml(t, outer, "example-project")
+	repo := filepath.Join(outer, "repo")
+	require.NoError(t, os.Mkdir(repo, 0o755)) //nolint:gosec // test fixture under TempDir.
+	testfix.MkDotGit(t, repo)
+	target := t.TempDir()
+	link := filepath.Join(repo, "escaped-workspace")
+	require.NoError(t, os.Symlink(target, link))
+
+	d, err := config.DiscoverPaths(link)
+	require.NoError(t, err)
+	assert.Empty(t, d.WorkspaceRoot)
+	assert.Equal(t, repo, d.GitRoot)
+	assert.Equal(t, repo, config.WriteDestination(d, link))
+}
+
 func TestDiscoverPaths_SymlinkedNonGitWorkspaceKeepsLexicalAncestorConfig(t *testing.T) {
 	outer := t.TempDir()
 	testfix.WriteKataToml(t, outer, "example-project")

--- a/internal/config/project_identity_test.go
+++ b/internal/config/project_identity_test.go
@@ -108,6 +108,28 @@ func TestDiscoverPaths_SymlinkOutOfGitIgnoresLexicalAncestorConfig(t *testing.T)
 	assert.Equal(t, repo, config.WriteDestination(d, link))
 }
 
+func TestDiscoverPaths_SymlinkFromNestedGitUsesPhysicalRepository(t *testing.T) {
+	parentRepo := t.TempDir()
+	testfix.MkDotGit(t, parentRepo)
+	testfix.WriteKataToml(t, parentRepo, "parent-project")
+	nestedRepo := filepath.Join(parentRepo, "nested")
+	require.NoError(t, os.Mkdir(nestedRepo, 0o755)) //nolint:gosec // test fixture under TempDir.
+	testfix.MkDotGit(t, nestedRepo)
+	testfix.WriteKataToml(t, nestedRepo, "nested-project")
+	target := filepath.Join(parentRepo, "target")
+	require.NoError(t, os.Mkdir(target, 0o755)) //nolint:gosec // test fixture under TempDir.
+	link := filepath.Join(nestedRepo, "parent-workspace")
+	require.NoError(t, os.Symlink(target, link))
+
+	d, err := config.DiscoverPaths(link)
+	require.NoError(t, err)
+	physicalParentRepo, err := filepath.EvalSymlinks(parentRepo)
+	require.NoError(t, err)
+	assert.Equal(t, physicalParentRepo, d.WorkspaceRoot)
+	assert.Equal(t, physicalParentRepo, d.GitRoot)
+	assert.Equal(t, physicalParentRepo, config.WriteDestination(d, link))
+}
+
 func TestDiscoverPaths_SymlinkedNonGitWorkspaceKeepsLexicalAncestorConfig(t *testing.T) {
 	outer := t.TempDir()
 	testfix.WriteKataToml(t, outer, "example-project")


### PR DESCRIPTION
An out-of-repository `.kata.toml` could silently bind nested Git repositories to the wrong project and redirect `kata init` artifacts outside the repository. That made a successful initialization indistinguishable from a no-op and allowed unrelated repositories to share one project by filesystem ancestry.

This treats the nearest Git root as an inclusive boundary for both discovery paths, including workspaces entered through symlinked paths. Non-Git workspaces keep lexical ancestor discovery, while bindings at or below the repository root remain valid.

Fixes #217.
