### PR TITLE
Exclude parked issues from ready queues

### DIFF
--- a/cmd/kata/next_test.go
+++ b/cmd/kata/next_test.go
@@ -55,6 +55,20 @@ func TestNext_HumanSelectsP0AndPrintsOneReadyRow(t *testing.T) {
 	assert.NotContains(t, out, "Ready:")
 }
 
+func TestNext_SkipsParkedMetadata(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	actionable := createIssue(t, env, pid, "actionable candidate")
+	someday := createIssue(t, env, pid, "someday parked")
+	future := createIssue(t, env, pid, "future parked")
+	runCLI(t, env, dir, "meta", "set", "--json-value", someday, "someday", "true")
+	runCLI(t, env, dir, "meta", "set", future, "scheduled_on", "2100-01-01")
+
+	out := runCLI(t, env, dir, "next")
+	assert.Contains(t, out, actionable)
+	assert.NotContains(t, out, someday)
+	assert.NotContains(t, out, future)
+}
+
 func TestNext_AgentOutputIsOneLine(t *testing.T) {
 	env, dir, pid := setupCLIWorkspace(t)
 	p0 := int64(0)

--- a/cmd/kata/ready_test.go
+++ b/cmd/kata/ready_test.go
@@ -43,6 +43,24 @@ func TestReady_FiltersBlocked(t *testing.T) {
 		"blocked is hidden while blocker is open")
 }
 
+func TestReady_ExcludesParkedMetadata(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	someday := createIssue(t, env, pid, "someday parked")
+	future := createIssue(t, env, pid, "future parked")
+	falseSomeday := createIssue(t, env, pid, "false someday actionable")
+	past := createIssue(t, env, pid, "past scheduled actionable")
+	runCLI(t, env, dir, "meta", "set", "--json-value", someday, "someday", "true")
+	runCLI(t, env, dir, "meta", "set", future, "scheduled_on", "2100-01-01")
+	runCLI(t, env, dir, "meta", "set", "--json-value", falseSomeday, "someday", "false")
+	runCLI(t, env, dir, "meta", "set", past, "scheduled_on", "2000-01-01")
+
+	out := runCLI(t, env, dir, "ready")
+	assert.NotContains(t, out, "someday parked")
+	assert.NotContains(t, out, "future parked")
+	assert.Contains(t, out, "false someday actionable")
+	assert.Contains(t, out, "past scheduled actionable")
+}
+
 func TestReady_RepeatedLabelFiltersRequireEveryLabel(t *testing.T) {
 	env, dir, pid := setupCLIWorkspace(t)
 	alphaOnly := createIssue(t, env, pid, "alpha only")

--- a/internal/daemon/handlers_ui.go
+++ b/internal/daemon/handlers_ui.go
@@ -37,6 +37,7 @@ type normalizedUISnapshotIntent struct {
 	IncludeHistory   bool     `json:"include_history"`
 	LocalDate        string   `json:"local_date,omitempty"`
 	TimeZone         string   `json:"time_zone,omitempty"`
+	ReadyDate        string   `json:"ready_date,omitempty"`
 	Limit            int      `json:"limit"`
 }
 
@@ -49,7 +50,7 @@ func (in normalizedUISnapshotIntent) storeQuery() db.UISnapshotQuery {
 		Relationships: append([]string(nil), in.Relationships...),
 		Text:          in.Text, SelectedIssueUID: in.SelectedIssueUID,
 		IncludeGraph: in.IncludeGraph, IncludeHistory: in.IncludeHistory,
-		LocalDate: in.LocalDate, TimeZone: in.TimeZone, Limit: in.Limit,
+		LocalDate: in.LocalDate, TimeZone: in.TimeZone, ReadyDate: in.ReadyDate, Limit: in.Limit,
 	}
 	if len(in.Statuses) == 1 {
 		query.Status = in.Statuses[0]
@@ -128,6 +129,7 @@ func registerUIHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if err != nil {
 				return nil, err
 			}
+			intent.ReadyDate = effectiveUIReadyDate(intent.Statuses, cfg.UIClock)
 			policy := effectiveUIPolicy(ctx, cfg)
 			var observedCursor *int64
 			if in.IfNoneMatch != "" {
@@ -385,6 +387,25 @@ func dateSensitiveUIView(view string) bool {
 	default:
 		return false
 	}
+}
+
+func effectiveUIReadyDate(statuses []string, clock func() time.Time) string {
+	ready := false
+	for _, status := range statuses {
+		switch status {
+		case "all":
+			return ""
+		case "ready":
+			ready = true
+		}
+	}
+	if !ready {
+		return ""
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	return clock().UTC().Format(time.DateOnly)
 }
 
 func uiValidationError(field, message string, data map[string]any) error {

--- a/internal/daemon/handlers_ui_test.go
+++ b/internal/daemon/handlers_ui_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -60,6 +61,15 @@ func (s *countingUIStore) ReadUIReferences(_ context.Context, query db.UIReferen
 }
 
 func newUISnapshotServer(t *testing.T, uiStore db.UIStore, writable bool) *httptest.Server {
+	return newUISnapshotServerWithClock(t, uiStore, writable, time.Now)
+}
+
+func newUISnapshotServerWithClock(
+	t *testing.T,
+	uiStore db.UIStore,
+	writable bool,
+	clock func() time.Time,
+) *httptest.Server {
 	t.Helper()
 	dbh := openTestDB(t)
 	manager, err := daemon.NewWebSessionManager(daemon.WebSessionManagerConfig{
@@ -75,12 +85,32 @@ func newUISnapshotServer(t *testing.T, uiStore db.UIStore, writable bool) *httpt
 	server := daemon.NewServer(daemon.ServerConfig{
 		DB:          dbh.db,
 		UIStore:     uiStore,
+		UIClock:     clock,
 		StartedAt:   dbh.now,
 		WebSessions: manager,
 	})
 	ts := httptest.NewServer(server.Handler())
 	t.Cleanup(ts.Close)
 	return ts
+}
+
+func TestUISnapshotReadyDateRolloverInvalidatesETagAndAuthorityCache(t *testing.T) {
+	store := &countingUIStore{cursor: 41, snapshotCursor: 41}
+	now := time.Date(2026, 8, 8, 23, 59, 0, 0, time.UTC)
+	ts := newUISnapshotServerWithClock(t, store, true, func() time.Time { return now })
+	query := url.Values{"view": {"all-open"}, "status": {"ready"}}
+
+	first, _ := getUISnapshot(t, ts, query, "")
+	require.Equal(t, http.StatusOK, first.StatusCode)
+	require.Equal(t, "2026-08-08", store.lastSnapshot.ReadyDate)
+	require.Equal(t, 1, store.snapshotReads)
+
+	now = now.Add(2 * time.Minute)
+	second, body := getUISnapshot(t, ts, query, first.Header.Get("ETag"))
+	require.Equal(t, http.StatusOK, second.StatusCode, string(body))
+	require.NotEqual(t, first.Header.Get("ETag"), second.Header.Get("ETag"))
+	require.Equal(t, "2026-08-09", store.lastSnapshot.ReadyDate)
+	require.Equal(t, 2, store.snapshotReads)
 }
 
 func getUISnapshot(t *testing.T, ts *httptest.Server, query url.Values, etag string) (*http.Response, []byte) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -35,7 +35,10 @@ type ServerConfig struct {
 	DB db.Storage
 	// UIStore supplies coherent browser projections. Nil defaults to DB when
 	// the configured storage backend implements db.UIStore.
-	UIStore                       db.UIStore
+	UIStore db.UIStore
+	// UIClock supplies the current time for date-sensitive browser readiness.
+	// Nil uses time.Now. Tests inject it to verify UTC date rollover.
+	UIClock                       func() time.Time
 	StartedAt                     time.Time
 	Endpoint                      *kitdaemon.Endpoint
 	Broadcaster                   *EventBroadcaster

--- a/internal/db/dbtest/conformance.go
+++ b/internal/db/dbtest/conformance.go
@@ -159,7 +159,7 @@ var storageScenarios = []scenario{
 		name: "ready queues and discovery",
 		methods: []string{
 			"AddLabel", "CloseIssue", "CreateComment", "CreateIssue", "CreateLink", "CreateProject", "EditIssue",
-			"IssueQualifiersByUIDs", "ListIssueContent", "ReadyIssues", "ReadyIssuesGlobal", "SearchFTS",
+			"IssueQualifiersByUIDs", "ListIssueContent", "PatchIssueMetadata", "ReadyIssues", "ReadyIssuesGlobal", "SearchFTS",
 			"SearchFTSAny", "SoftDeleteIssue",
 		},
 		run: checkReadyQueuesAndDiscovery,

--- a/internal/db/dbtest/conformance_content.go
+++ b/internal/db/dbtest/conformance_content.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -700,6 +701,56 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	if err != nil {
 		return err
 	}
+	someday, err := createFixtureIssue(ctx, store, primary.Project.ID, "someday parked", "discovery-author", nil)
+	if err != nil {
+		return err
+	}
+	somedayFalse, err := createFixtureIssue(ctx, store, primary.Project.ID, "someday false", "discovery-author", nil)
+	if err != nil {
+		return err
+	}
+	futureScheduled, err := createFixtureIssue(ctx, store, primary.Project.ID, "future scheduled", "discovery-author", nil)
+	if err != nil {
+		return err
+	}
+	todayScheduled, err := createFixtureIssue(ctx, store, primary.Project.ID, "today scheduled", "discovery-author", nil)
+	if err != nil {
+		return err
+	}
+	pastScheduled, err := createFixtureIssue(ctx, store, primary.Project.ID, "past scheduled", "discovery-author", nil)
+	if err != nil {
+		return err
+	}
+	patchMetadata := func(issue db.Issue, patch map[string]json.RawMessage) error {
+		_, patchErr := store.PatchIssueMetadata(ctx, db.PatchIssueMetadataIn{
+			IssueID: issue.ID,
+			Actor:   "discovery-author",
+			Patch:   patch,
+		})
+		return patchErr
+	}
+	today := time.Now().UTC()
+	if err := patchMetadata(someday, map[string]json.RawMessage{"someday": json.RawMessage(`true`)}); err != nil {
+		return fmt.Errorf("park someday issue: %w", err)
+	}
+	if err := patchMetadata(somedayFalse, map[string]json.RawMessage{"someday": json.RawMessage(`false`)}); err != nil {
+		return fmt.Errorf("set false someday metadata: %w", err)
+	}
+	if err := patchMetadata(futureScheduled, map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(fmt.Sprintf("%q", today.AddDate(1, 0, 0).Format(time.DateOnly))),
+	}); err != nil {
+		return fmt.Errorf("schedule future issue: %w", err)
+	}
+	if err := patchMetadata(todayScheduled, map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(fmt.Sprintf("%q", today.Format(time.DateOnly))),
+	}); err != nil {
+		return fmt.Errorf("schedule today issue: %w", err)
+	}
+	if err := patchMetadata(pastScheduled, map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(fmt.Sprintf("%q", today.AddDate(-1, 0, 0).Format(time.DateOnly))),
+	}); err != nil {
+		return fmt.Errorf("schedule past issue: %w", err)
+	}
 
 	ready, err := store.ReadyIssues(ctx, primary.Project.ID, 0, db.ReadyIssuesFilter{})
 	if err != nil {
@@ -710,6 +761,11 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	assert.NotContains(t, issueIDs(ready), blocked.ID)
 	assert.NotContains(t, issueIDs(ready), closed.ID)
 	assert.NotContains(t, issueIDs(ready), deleted.ID)
+	assert.NotContains(t, issueIDs(ready), someday.ID)
+	assert.NotContains(t, issueIDs(ready), futureScheduled.ID)
+	assert.Contains(t, issueIDs(ready), somedayFalse.ID)
+	assert.Contains(t, issueIDs(ready), todayScheduled.ID)
+	assert.Contains(t, issueIDs(ready), pastScheduled.ID)
 	owned, err := store.ReadyIssues(ctx, primary.Project.ID, 0, db.ReadyIssuesFilter{Owner: "alice"})
 	if err != nil {
 		return fmt.Errorf("ready issues by owner: %w", err)
@@ -750,6 +806,11 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	assert.Contains(t, globalIDs, primary.Issue.ID)
 	assert.Contains(t, globalIDs, other.Issue.ID)
 	assert.NotContains(t, globalIDs, blocked.ID)
+	assert.NotContains(t, globalIDs, someday.ID)
+	assert.NotContains(t, globalIDs, futureScheduled.ID)
+	assert.Contains(t, globalIDs, somedayFalse.ID)
+	assert.Contains(t, globalIDs, todayScheduled.ID)
+	assert.Contains(t, globalIDs, pastScheduled.ID)
 	for _, row := range global {
 		if row.ID == other.Issue.ID {
 			assert.Equal(t, other.Project.Name, row.ProjectName)

--- a/internal/db/dbtest/ui_contract.go
+++ b/internal/db/dbtest/ui_contract.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/db"
@@ -190,6 +191,29 @@ func RunUISnapshotCollectionContract(t *testing.T, open func(*testing.T) db.Stor
 	blocker := createCursorIssue(ctx, t, store, project.ID, "Blocker issue")
 	blocked := createCursorIssue(ctx, t, store, project.ID, "Blocked issue")
 	removed := createCursorIssue(ctx, t, store, project.ID, "Removed child issue")
+	createWithMetadata := func(title string, metadata map[string]json.RawMessage) db.Issue {
+		issue, _, createErr := store.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID, Title: title, Author: "user-a", Metadata: metadata,
+		})
+		require.NoError(t, createErr)
+		return issue
+	}
+	today := time.Now().UTC()
+	someday := createWithMetadata("Someday issue", map[string]json.RawMessage{
+		"someday": json.RawMessage(`true`),
+	})
+	futureScheduled := createWithMetadata("Future scheduled issue", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(fmt.Sprintf("%q", today.AddDate(0, 0, 1).Format(time.DateOnly))),
+	})
+	somedayFalse := createWithMetadata("Someday false issue", map[string]json.RawMessage{
+		"someday": json.RawMessage(`false`),
+	})
+	todayScheduled := createWithMetadata("Today scheduled issue", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(fmt.Sprintf("%q", today.Format(time.DateOnly))),
+	})
+	pastScheduled := createWithMetadata("Past scheduled issue", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(fmt.Sprintf("%q", today.AddDate(-1, 0, 0).Format(time.DateOnly))),
+	})
 	createCursorLink(ctx, t, store, child, parent, "parent")
 	createCursorLink(ctx, t, store, blocker, blocked, "blocks")
 	createCursorLink(ctx, t, store, removed, parent, "parent")
@@ -198,10 +222,22 @@ func RunUISnapshotCollectionContract(t *testing.T, open func(*testing.T) db.Stor
 	require.True(t, changed)
 
 	ready, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
-		View: "all-open", Statuses: []string{"ready"},
+		View: "all-open", Statuses: []string{"ready"}, ReadyDate: today.Format(time.DateOnly),
 	})
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{parent.UID, child.UID, blocker.UID}, uiIssueUIDs(ready.Issues))
+	require.ElementsMatch(t, []string{
+		parent.UID, child.UID, blocker.UID, somedayFalse.UID, todayScheduled.UID, pastScheduled.UID,
+	}, uiIssueUIDs(ready.Issues))
+	require.NotContains(t, uiIssueUIDs(ready.Issues), someday.UID)
+	require.NotContains(t, uiIssueUIDs(ready.Issues), futureScheduled.UID)
+
+	rolled, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+		View: "all-open", Statuses: []string{"ready"},
+		ReadyDate: today.AddDate(0, 0, 1).Format(time.DateOnly),
+	})
+	require.NoError(t, err)
+	require.Contains(t, uiIssueUIDs(rolled.Issues), futureScheduled.UID)
+	require.NotContains(t, uiIssueUIDs(rolled.Issues), someday.UID)
 
 	parents, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
 		View: "all-open", Relationships: []string{"child"},

--- a/internal/db/pgstore/discovery.go
+++ b/internal/db/pgstore/discovery.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.kenn.io/kata/internal/db"
 )
 
-// ReadyIssues returns open issues that have no active blocker. Optional owner
-// and label filters are composed here so the same query remains useful to the
-// CLI's different ready views.
+// ReadyIssues returns actionable open issues that have no active blocker.
+// Issues marked someday=true or scheduled after today's UTC date are parked
+// and excluded. Optional owner and label filters are composed here so the same
+// query remains useful to the CLI's different ready views.
 func (s *Store) ReadyIssues(
 	ctx context.Context,
 	projectID int64,
@@ -37,6 +39,9 @@ func (s *Store) ReadyIssues(
 		args = append(args, value)
 		return fmt.Sprintf("$%d", len(args))
 	}
+	query += ` AND COALESCE((i.metadata::jsonb ->> 'someday')::boolean, false) = false`
+	query += ` AND (i.metadata::jsonb ->> 'scheduled_on' IS NULL OR i.metadata::jsonb ->> 'scheduled_on' <= ` +
+		addArg(time.Now().UTC().Format(time.DateOnly)) + `)`
 	if filter.Unowned {
 		query += ` AND i.owner IS NULL`
 	} else if filter.Owner != "" {
@@ -76,9 +81,9 @@ func (s *Store) ReadyIssues(
 	return issues, nil
 }
 
-// ReadyIssuesGlobal returns ready issues from all active projects along with
-// the project name needed to render a qualified reference. Filter semantics
-// match ReadyIssues.
+// ReadyIssuesGlobal returns actionable ready issues from all active projects
+// along with the project name needed to render a qualified reference. Filter
+// and parked-item semantics match ReadyIssues.
 func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.ReadyIssuesFilter) ([]db.ReadyGlobalIssue, error) {
 	query := `SELECT i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status,
        i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision, i.recurrence_id,
@@ -104,6 +109,9 @@ func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.Read
 		args = append(args, value)
 		return fmt.Sprintf("$%d", len(args))
 	}
+	query += ` AND COALESCE((i.metadata::jsonb ->> 'someday')::boolean, false) = false`
+	query += ` AND (i.metadata::jsonb ->> 'scheduled_on' IS NULL OR i.metadata::jsonb ->> 'scheduled_on' <= ` +
+		addArg(time.Now().UTC().Format(time.DateOnly)) + `)`
 	if filter.Unowned {
 		query += ` AND i.owner IS NULL`
 	} else if filter.Owner != "" {

--- a/internal/db/pgstore/ui.go
+++ b/internal/db/pgstore/ui.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"go.kenn.io/kata/internal/db"
 )
@@ -375,8 +376,17 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 		persistedStatuses := []string{}
 		for _, status := range statuses {
 			if status == "ready" {
-				statusPredicates = append(statusPredicates, `(
-					i.status = 'open' AND NOT EXISTS (
+				readyDate := query.ReadyDate
+				if readyDate == "" {
+					readyDate = time.Now().UTC().Format(time.DateOnly)
+				}
+				args = append(args, readyDate)
+				statusPredicates = append(statusPredicates, fmt.Sprintf(`(
+					i.status = 'open'
+					AND COALESCE((i.metadata::jsonb ->> 'someday')::boolean, false) = false
+					AND (i.metadata::jsonb ->> 'scheduled_on' IS NULL
+						OR i.metadata::jsonb ->> 'scheduled_on' <= $%d)
+					AND NOT EXISTS (
 						SELECT 1 FROM links ready_link
 						JOIN issues blocker ON blocker.id = ready_link.from_issue_id
 						JOIN projects blocker_project ON blocker_project.id = blocker.project_id
@@ -384,7 +394,7 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 						AND blocker.status = 'open' AND blocker.deleted_at IS NULL
 						AND blocker_project.deleted_at IS NULL
 					)
-				)`)
+				)`, len(args)))
 			} else {
 				persistedStatuses = append(persistedStatuses, status)
 			}

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -2016,15 +2016,19 @@ func (d *Store) claimOwner(ctx context.Context, issueID int64, actor string, for
 	}, nil
 }
 
-// ReadyIssues returns open, non-deleted issues with no open `blocks` predecessor,
-// ordered by updated_at DESC. limit==0 means no limit. Blockers may live in
-// another project (links span projects, storage v16), but a blocker whose
-// project is archived (projects.deleted_at IS NOT NULL) does not gate
+// ReadyIssues returns actionable open issues with no open `blocks` predecessor,
+// ordered by updated_at DESC. Issues marked someday=true or scheduled after
+// today's UTC date are parked and excluded. limit==0 means no limit. Blockers
+// may live in another project (links span projects, storage v16), but a blocker
+// whose project is archived (projects.deleted_at IS NOT NULL) does not gate
 // readiness — mirroring the child/close queries' archived-project exclusion,
 // so an active issue is not stranded behind hidden archived work.
 func (d *Store) ReadyIssues(ctx context.Context, projectID int64, limit int, filter db.ReadyIssuesFilter) ([]db.Issue, error) {
 	q := issueSelect + `
 		WHERE i.project_id = ? AND i.status = 'open' AND i.deleted_at IS NULL
+		  AND COALESCE(json_extract(i.metadata, '$.someday'), 0) != 1
+		  AND (json_extract(i.metadata, '$.scheduled_on') IS NULL
+		       OR json_extract(i.metadata, '$.scheduled_on') <= ?)
 		  AND NOT EXISTS (
 		    SELECT 1 FROM links l
 		    JOIN issues blocker ON blocker.id = l.from_issue_id
@@ -2033,7 +2037,7 @@ func (d *Store) ReadyIssues(ctx context.Context, projectID int64, limit int, fil
 		      AND blocker.status = 'open' AND blocker.deleted_at IS NULL
 		      AND bp.deleted_at IS NULL
 		  )`
-	args := []any{projectID}
+	args := []any{projectID, time.Now().UTC().Format(time.DateOnly)}
 
 	// Apply owner filters
 	if filter.Unowned {
@@ -2076,18 +2080,21 @@ func (d *Store) ReadyIssues(ctx context.Context, projectID int64, limit int, fil
 }
 
 // ReadyIssuesGlobal returns ready issues across every non-archived project,
-// each paired with its project name. "Ready" matches ReadyIssues: open,
-// not soft-deleted, and not blocked by an open `blocks` predecessor in an
-// active project. Issues from archived projects (projects.deleted_at IS NOT
-// NULL) are excluded, and an open blocker in an archived project does not
-// gate readiness. Ordering and filter semantics match ReadyIssues so
-// behavior is consistent.
+// each paired with its project name. "Ready" matches ReadyIssues: actionable,
+// open, not soft-deleted, and not blocked by an open `blocks` predecessor in
+// an active project. Issues from archived projects (projects.deleted_at IS NOT
+// NULL) are excluded, and an open blocker in an archived project does not gate
+// readiness. Ordering and filter semantics match ReadyIssues so behavior is
+// consistent.
 func (d *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.ReadyIssuesFilter) ([]db.ReadyGlobalIssue, error) {
 	// issueSelect ends with "FROM issues i JOIN projects p ON p.id = i.project_id"
 	// We need to add p.name before FROM, so we build the SELECT from scratch.
 	q := `SELECT i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status, i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision, i.recurrence_id, i.occurrence_key, i.created_at, i.updated_at, i.closed_at, i.deleted_at, p.name AS project_name FROM issues i JOIN projects p ON p.id = i.project_id
 		WHERE i.status = 'open' AND i.deleted_at IS NULL
 		  AND p.deleted_at IS NULL
+		  AND COALESCE(json_extract(i.metadata, '$.someday'), 0) != 1
+		  AND (json_extract(i.metadata, '$.scheduled_on') IS NULL
+		       OR json_extract(i.metadata, '$.scheduled_on') <= ?)
 		  AND NOT EXISTS (
 		    SELECT 1 FROM links l
 		    JOIN issues blocker ON blocker.id = l.from_issue_id
@@ -2096,7 +2103,7 @@ func (d *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.Read
 		      AND blocker.status = 'open' AND blocker.deleted_at IS NULL
 		      AND bp.deleted_at IS NULL
 		  )`
-	var args []any
+	args := []any{time.Now().UTC().Format(time.DateOnly)}
 
 	// Apply owner filters (same semantics as ReadyIssues)
 	if filter.Unowned {

--- a/internal/db/sqlitestore/ui.go
+++ b/internal/db/sqlitestore/ui.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"go.kenn.io/kata/internal/db"
 )
@@ -368,8 +369,17 @@ func readUIIssues(
 		persistedStatuses := []string{}
 		for _, status := range statuses {
 			if status == "ready" {
+				readyDate := query.ReadyDate
+				if readyDate == "" {
+					readyDate = time.Now().UTC().Format(time.DateOnly)
+				}
+				args = append(args, readyDate)
 				statusPredicates = append(statusPredicates, `(
-					i.status = 'open' AND NOT EXISTS (
+					i.status = 'open'
+					AND COALESCE(json_extract(i.metadata, '$.someday'), 0) != 1
+					AND (json_extract(i.metadata, '$.scheduled_on') IS NULL
+						OR json_extract(i.metadata, '$.scheduled_on') <= ?)
+					AND NOT EXISTS (
 						SELECT 1 FROM links ready_link
 						JOIN issues blocker ON blocker.id = ready_link.from_issue_id
 						JOIN projects blocker_project ON blocker_project.id = blocker.project_id

--- a/internal/db/ui.go
+++ b/internal/db/ui.go
@@ -26,7 +26,11 @@ type UISnapshotQuery struct {
 	IncludeHistory   bool
 	LocalDate        string
 	TimeZone         string
-	Limit            int
+	// ReadyDate is the daemon-selected UTC date used by the synthetic ready
+	// status. It is part of the snapshot cache identity so ready membership can
+	// change at midnight without a database event.
+	ReadyDate string
+	Limit     int
 	// ReuseAuthorityCursor asks the store to omit catalog and collection rows
 	// only when its consistent read observes this exact durable cursor.
 	ReuseAuthorityCursor *int64


### PR DESCRIPTION
## Why

`kata ready` and `kata next` treated every unblocked open issue as actionable, even when reserved metadata parked it with `someday=true` or a future `scheduled_on` date. That left parked work in scoped and global queues and in the browser ready view.

## Behavior

- Scoped and global `ready`/`next` omit issues with `someday=true` or `scheduled_on` after the current UTC date.
- `someday=false`, today, past, and unset values remain actionable.
- Browser snapshots apply the same readiness rules in SQLite and PostgreSQL.
- Ready snapshot identity includes the effective UTC date, so scheduled work becomes ready at midnight without another database event.
- No persisted schema or migration changes.

Closes #231