### PR TITLE
list: add cross-project filters and guard version skew

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2244,6 +2244,18 @@ components:
         set_parent:
           type: string
       type: object
+    ListAllIssuesResponseBody:
+      additionalProperties: true
+      properties:
+        issues:
+          items:
+            $ref: "#/components/schemas/ListGlobalIssueOut"
+          type:
+            - array
+            - "null"
+      required:
+        - issues
+      type: object
     ListFederationEnrollmentsBody:
       additionalProperties: true
       properties:
@@ -2255,6 +2267,109 @@ components:
             - "null"
       required:
         - enrollments
+      type: object
+    ListGlobalIssueOut:
+      additionalProperties: true
+      properties:
+        author:
+          type: string
+        blocked:
+          type: boolean
+        blocked_by:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        blocks:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        body:
+          type: string
+        child_counts:
+          $ref: "#/components/schemas/ChildCounts"
+        closed_at:
+          format: date-time
+          type: string
+        closed_reason:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        metadata:
+          additionalProperties: true
+          type: object
+        occurrence_key:
+          type: string
+        owner:
+          type: string
+        parent:
+          $ref: "#/components/schemas/LinkPeer"
+        priority:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        qualified_id:
+          type: string
+        recurrence_id:
+          format: int64
+          type: integer
+        related:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          type:
+            - array
+            - "null"
+        revision:
+          format: int64
+          type: integer
+        short_id:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - project_name
+        - qualified_id
+        - id
+        - uid
+        - project_id
+        - short_id
+        - title
+        - body
+        - status
+        - author
+        - metadata
+        - revision
+        - created_at
+        - updated_at
       type: object
     ListIssuesResponseBody:
       additionalProperties: true
@@ -4091,7 +4206,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.8.0
+  version: 0.9.0
 openapi: 3.1.0
 paths:
   /api/v1/audit/closes:
@@ -4521,12 +4636,49 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: unowned
+          schema:
+            type: boolean
+        - explode: false
+          in: query
+          name: owner
+          schema:
+            type: string
+        - explode: true
+          in: query
+          name: label
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+        - explode: true
+          in: query
+          name: exclude_label
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+        - explode: true
+          in: query
+          name: meta
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListIssuesResponseBody"
+                $ref: "#/components/schemas/ListAllIssuesResponseBody"
           description: OK
         default:
           content:

--- a/cmd/kata/api_compat.go
+++ b/cmd/kata/api_compat.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const (
+	apiVersionReadyAndSearchFilters = "0.8.0"
+	apiVersionGlobalListFilters     = "0.9.0"
+)
+
+// requireDaemonAPIVersion fails closed before a request that uses query
+// parameters older daemons silently ignored. The health endpoint predates the
+// filtered global queries, so it is safe to use as the capability handshake.
+func requireDaemonAPIVersion(
+	ctx context.Context,
+	client *http.Client,
+	baseURL, required, feature string,
+) error {
+	status, body, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/health", nil)
+	if err != nil {
+		return err
+	}
+	if status >= http.StatusBadRequest {
+		return apiErrFromBody(status, body)
+	}
+	var health struct {
+		APISchemaVersion string `json:"api_schema_version"`
+	}
+	if err := json.Unmarshal(body, &health); err != nil {
+		return fmt.Errorf("decode daemon API version: %w", err)
+	}
+	reported := strings.TrimSpace(health.APISchemaVersion)
+	compatible, valid := apiVersionAtLeast(reported, required)
+	if valid && compatible {
+		return nil
+	}
+	if reported == "" {
+		reported = "no api_schema_version"
+	}
+	return &cliError{
+		Message: fmt.Sprintf(
+			"%s requires daemon API %s or newer; this daemon reports %s; upgrade the daemon",
+			feature, required, reported),
+		Kind:     kindValidation,
+		Code:     "daemon_api_too_old",
+		ExitCode: ExitValidation,
+	}
+}
+
+func apiVersionAtLeast(reported, required string) (atLeast, valid bool) {
+	reportedParts, ok := parseAPIVersion(reported)
+	if !ok {
+		return false, false
+	}
+	requiredParts, ok := parseAPIVersion(required)
+	if !ok {
+		return false, false
+	}
+	for i := range reportedParts {
+		if reportedParts[i] != requiredParts[i] {
+			return reportedParts[i] > requiredParts[i], true
+		}
+	}
+	return true, true
+}
+
+func parseAPIVersion(value string) ([3]int, bool) {
+	var out [3]int
+	value = strings.TrimSpace(value)
+	if suffix := strings.IndexAny(value, "-+"); suffix >= 0 {
+		value = value[:suffix]
+	}
+	parts := strings.Split(value, ".")
+	if len(parts) != len(out) {
+		return out, false
+	}
+	for i, part := range parts {
+		parsed, err := strconv.Atoi(part)
+		if err != nil || parsed < 0 {
+			return out, false
+		}
+		out[i] = parsed
+	}
+	return out, true
+}

--- a/cmd/kata/api_compat_test.go
+++ b/cmd/kata/api_compat_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilteredReadyAllRejectsOldDaemonBeforeQuery(t *testing.T) {
+	var readyCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
+		case "/api/v1/ready":
+			readyCalls.Add(1)
+			_, _ = w.Write([]byte(`{"issues":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, err := executeRootCapture(t,
+		contextWithBaseURL(context.Background(), server.URL),
+		"ready", "--all", "--label", "handoff")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires daemon API 0.8.0 or newer")
+	assert.Contains(t, err.Error(), "reports 0.7.0")
+	assert.Contains(t, err.Error(), "upgrade the daemon")
+	assert.Zero(t, readyCalls.Load(), "the unfiltered old endpoint must not be queried")
+}
+
+func TestFilteredSearchRejectsOldDaemonBeforeQuery(t *testing.T) {
+	var searchCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
+		case "/api/v1/projects/resolve":
+			_, _ = w.Write([]byte(`{"project":{"id":1,"name":"example-project"}}`))
+		case "/api/v1/projects/1/search":
+			searchCalls.Add(1)
+			_, _ = w.Write([]byte(`{"query":"handoff","mode":"lexical","results":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, err := executeRootCapture(t,
+		contextWithBaseURL(context.Background(), server.URL),
+		"--project", "example-project", "search", "handoff", "--no-label", "parked")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires daemon API 0.8.0 or newer")
+	assert.Contains(t, err.Error(), "reports 0.7.0")
+	assert.Zero(t, searchCalls.Load(), "the unfiltered old endpoint must not be queried")
+}
+
+func TestFilteredListAllRejectsDaemonBeforeGlobalListFilters(t *testing.T) {
+	var listCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.8.0"}`))
+		case "/api/v1/issues":
+			listCalls.Add(1)
+			_, _ = w.Write([]byte(`{"issues":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, err := executeRootCapture(t,
+		contextWithBaseURL(context.Background(), server.URL),
+		"list", "--all", "--unowned")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires daemon API 0.9.0 or newer")
+	assert.Contains(t, err.Error(), "reports 0.8.0")
+	assert.Zero(t, listCalls.Load(), "the unfiltered old endpoint must not be queried")
+}
+
+func TestListAllDefaultsToUnlimited(t *testing.T) {
+	var sentLimit atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/issues" {
+			http.NotFound(w, r)
+			return
+		}
+		sentLimit.Store(r.URL.Query().Has("limit"))
+		_, _ = w.Write([]byte(`{"issues":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, err := executeRootCapture(t,
+		contextWithBaseURL(context.Background(), server.URL), "list", "--all")
+	require.NoError(t, err)
+	assert.False(t, sentLimit.Load(), "list --all must not silently cap a fleet scan at 200 rows")
+}
+
+func TestAPIVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		reported string
+		required string
+		want     bool
+		valid    bool
+	}{
+		{reported: "0.8.0", required: "0.8.0", want: true, valid: true},
+		{reported: "0.9.0", required: "0.8.0", want: true, valid: true},
+		{reported: "1.0.0", required: "0.9.0", want: true, valid: true},
+		{reported: "0.7.9", required: "0.8.0", want: false, valid: true},
+		{reported: "0.9.0-dev", required: "0.9.0", want: true, valid: true},
+		{reported: "", required: "0.8.0", want: false, valid: false},
+		{reported: "not-semver", required: "0.8.0", want: false, valid: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.reported+"_requires_"+tt.required, func(t *testing.T) {
+			got, valid := apiVersionAtLeast(tt.reported, tt.required)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.valid, valid)
+		})
+	}
+}

--- a/cmd/kata/list.go
+++ b/cmd/kata/list.go
@@ -22,12 +22,13 @@ func newListCmd() *cobra.Command {
 	var labels []string
 	var noLabels []string
 	var meta []string
+	var all bool
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "list issues in this project",
+		Short: "list issues",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if limit <= 0 {
-				return &cliError{Message: "--limit must be a positive integer", Kind: kindValidation, ExitCode: ExitValidation}
+			if limit < 0 {
+				return &cliError{Message: "--limit must be non-negative", Kind: kindValidation, ExitCode: ExitValidation}
 			}
 			if cmd.Flags().Changed("priority") && (priority < 0 || priority > 4) {
 				return &cliError{Message: "--priority must be between 0 and 4", Kind: kindValidation, ExitCode: ExitValidation}
@@ -38,16 +39,11 @@ func newListCmd() *cobra.Command {
 			if unowned && owner != "" {
 				return &cliError{Message: "--unowned and --owner are mutually exclusive", Kind: kindValidation, ExitCode: ExitValidation}
 			}
+			if all && strings.TrimSpace(flags.Project) != "" {
+				return &cliError{Message: "--project and --all are mutually exclusive", Kind: kindUsage, ExitCode: ExitUsage}
+			}
 			ctx := cmd.Context()
-			start, err := resolveStartPath(flags.Workspace)
-			if err != nil {
-				return err
-			}
 			baseURL, err := ensureDaemon(ctx)
-			if err != nil {
-				return err
-			}
-			pid, err := resolveProjectID(ctx, baseURL, start)
 			if err != nil {
 				return err
 			}
@@ -55,19 +51,41 @@ func newListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if all && (unowned || owner != "" || len(labels) > 0 || len(noLabels) > 0 || len(meta) > 0) {
+				if err := requireDaemonAPIVersion(ctx, client, baseURL,
+					apiVersionGlobalListFilters, "filtered list --all"); err != nil {
+					return err
+				}
+			}
 			// "all" is a CLI sentinel meaning "no filter"; the server expects
 			// an empty status to return both open and closed.
 			apiStatus := status
 			if apiStatus == "all" {
 				apiStatus = ""
 			}
-			// Build base URL
-			getURL := fmt.Sprintf("%s/api/v1/projects/%d/issues", baseURL, pid)
+			requestLimit := limit
+			if all && !cmd.Flags().Changed("limit") {
+				requestLimit = 0
+			}
+			getURL := baseURL + "/api/v1/issues"
+			if !all {
+				start, err := resolveStartPath(flags.Workspace)
+				if err != nil {
+					return err
+				}
+				pid, err := resolveProjectID(ctx, baseURL, start)
+				if err != nil {
+					return err
+				}
+				getURL = fmt.Sprintf("%s/api/v1/projects/%d/issues", baseURL, pid)
+			}
 
 			// Build query parameters
 			params := url.Values{}
 			params.Set("status", apiStatus)
-			params.Set("limit", fmt.Sprintf("%d", limit))
+			if requestLimit > 0 {
+				params.Set("limit", fmt.Sprintf("%d", requestLimit))
+			}
 			if cmd.Flags().Changed("priority") {
 				params.Set("priority", fmt.Sprintf("%d", priority))
 			}
@@ -114,6 +132,7 @@ func newListCmd() *cobra.Command {
 				Issues []struct {
 					ShortID     string   `json:"short_id"`
 					QualifiedID string   `json:"qualified_id"`
+					ProjectName string   `json:"project_name"`
 					Title       string   `json:"title"`
 					Status      string   `json:"status"`
 					Owner       *string  `json:"owner"`
@@ -134,8 +153,12 @@ func newListCmd() *cobra.Command {
 					return err
 				}
 				for _, i := range b.Issues {
+					ref := i.ShortID
+					if all {
+						ref = i.QualifiedID
+					}
 					if err := writeAgentKVRow(out,
-						agentRowField("issue", i.ShortID),
+						agentRowField("issue", ref),
 						agentRowField("status", i.Status),
 						agentRowIntField("priority", i.Priority),
 						agentOptionalRowField("owner", i.Owner),
@@ -172,6 +195,9 @@ func newListCmd() *cobra.Command {
 					Blocked:  i.Blocked,
 					Labels:   i.Labels,
 				}
+				if all {
+					rows[idx].ID = i.QualifiedID
+				}
 				keys[idx] = i.QualifiedID
 				if i.Parent != nil {
 					parents[idx] = i.Parent.QualifiedID
@@ -187,7 +213,7 @@ func newListCmd() *cobra.Command {
 			// project has exactly --limit issues, which we accept as a
 			// much smaller harm than silently reporting a total that
 			// isn't one.
-			truncated := len(b.Issues) == limit
+			truncated := requestLimit > 0 && len(b.Issues) == requestLimit
 			if !flags.Quiet && len(rows) > 0 {
 				if err := renderer.renderListFooter(cmd.OutOrStdout(), rows, truncated); err != nil {
 					return err
@@ -197,7 +223,7 @@ func newListCmd() *cobra.Command {
 			// (kata list | grep ...). Quiet suppresses it.
 			if !flags.Quiet && truncated {
 				if _, err := fmt.Fprintf(cmd.ErrOrStderr(),
-					"... showing %d (raise --limit to see more)\n", limit); err != nil {
+					"... showing %d (raise --limit to see more)\n", requestLimit); err != nil {
 					return err
 				}
 			}
@@ -205,7 +231,8 @@ func newListCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&status, "status", "open", "filter by status: open|closed|all")
-	cmd.Flags().IntVar(&limit, "limit", 200, "max rows")
+	cmd.Flags().IntVar(&limit, "limit", 200, "max rows (0 = no limit; --all defaults to 0)")
+	cmd.Flags().BoolVar(&all, "all", false, "list issues across all non-archived projects")
 	cmd.Flags().IntVar(&priority, "priority", 0, "exact priority filter (0..4); 0 = highest")
 	cmd.Flags().IntVar(&maxPriority, "max-priority", 0, "include only priority <= this value (0..4)")
 	cmd.Flags().BoolVar(&unowned, "unowned", false, "only issues with no owner")

--- a/cmd/kata/list_test.go
+++ b/cmd/kata/list_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/testenv"
 )
 
 // TestList_OutputsShortIDNotNumber pins the JSON wire shape: each issue
@@ -42,6 +43,80 @@ func TestList_DefaultsToOpenIssuesInProject(t *testing.T) {
 	out := runCLI(t, env, dir, "list")
 	assert.Contains(t, out, "alpha")
 	assert.Contains(t, out, "beta")
+}
+
+func TestList_AllFiltersAcrossProjectsAndUsesQualifiedRefs(t *testing.T) {
+	env, dir, primaryID := setupCLIWorkspace(t)
+	secondary, err := env.DB.CreateProject(t.Context(), "spoke-project")
+	require.NoError(t, err)
+
+	primaryMatch := createIssue(t, env, primaryID, "primary handoff")
+	secondaryMatch := createIssue(t, env, secondary.ID, "secondary handoff")
+	secondaryOther := createIssue(t, env, secondary.ID, "secondary unrelated")
+	for projectID, ref := range map[int64]string{
+		primaryID:    primaryMatch,
+		secondary.ID: secondaryMatch,
+	} {
+		postJSONOK(t,
+			env.URL+"/api/v1/projects/"+itoa(projectID)+"/issues/"+ref+"/labels",
+			map[string]any{"actor": "tester", "label": "handoff"})
+	}
+
+	out := runCLI(t, env, dir, "--agent", "list", "--all", "--label", "HANDOFF", "--limit", "0")
+	assert.Contains(t, out, "issue=kata#"+primaryMatch)
+	assert.Contains(t, out, "issue=spoke-project#"+secondaryMatch)
+	assert.NotContains(t, out, secondaryOther)
+}
+
+func TestList_AllJSONIncludesProjectName(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	createIssue(t, env, pid, "global row")
+
+	out := runCLI(t, env, dir, "--json", "list", "--all")
+	var got struct {
+		Issues []map[string]any `json:"issues"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.NotEmpty(t, got.Issues)
+	assert.Equal(t, "kata", got.Issues[0]["project_name"])
+	assert.Equal(t, "kata#"+got.Issues[0]["short_id"].(string), got.Issues[0]["qualified_id"])
+}
+
+func TestList_AllDoesNotRequireWorkspaceProject(t *testing.T) {
+	env := testenv.New(t)
+	project, err := env.DB.CreateProject(t.Context(), "spoke-project")
+	require.NoError(t, err)
+	ref := createIssue(t, env, project.ID, "global without workspace")
+
+	out, err := runCmdOutput(t, env, "--agent", "list", "--all")
+	require.NoError(t, err)
+	assert.Contains(t, out, "issue=spoke-project#"+ref)
+}
+
+func TestList_AllAndProjectAreMutuallyExclusive(t *testing.T) {
+	env, dir, _ := setupCLIWorkspace(t)
+
+	_, err := runCmdOutput(t, env, "--workspace", dir,
+		"--project", "spoke-project", "list", "--all")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestList_LimitZeroMeansUnlimited(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	for _, title := range []string{"first", "second", "third"} {
+		createIssue(t, env, pid, title)
+	}
+
+	out := runCLI(t, env, dir, "list", "--limit", "0")
+	for _, title := range []string{"first", "second", "third"} {
+		assert.Contains(t, out, title)
+	}
+}
+
+func TestList_RejectsNegativeLimit(t *testing.T) {
+	_, err := runCmdOutput(t, nil, "list", "--limit", "-1")
+	_ = requireCLIError(t, err, ExitValidation)
 }
 
 func TestList_RepeatedLabelFiltersRequireEveryLabel(t *testing.T) {

--- a/cmd/kata/ready_client.go
+++ b/cmd/kata/ready_client.go
@@ -87,6 +87,12 @@ func (o readyOptions) fetch(cmd *cobra.Command) (readyResultForCLI, error) {
 	if err != nil {
 		return readyResultForCLI{}, err
 	}
+	if o.All && (o.Unowned || o.Owner != "" || len(o.Labels) > 0 || len(o.NoLabels) > 0) {
+		if err := requireDaemonAPIVersion(ctx, client, baseURL,
+			apiVersionReadyAndSearchFilters, "filtered ready --all"); err != nil {
+			return readyResultForCLI{}, err
+		}
+	}
 
 	getURL, err := o.endpoint(ctx, baseURL)
 	if err != nil {

--- a/cmd/kata/search.go
+++ b/cmd/kata/search.go
@@ -76,6 +76,12 @@ func newSearchCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if len(labels) > 0 || len(noLabels) > 0 {
+				if err := requireDaemonAPIVersion(ctx, client, baseURL,
+					apiVersionReadyAndSearchFilters, "filtered search"); err != nil {
+					return err
+				}
+			}
 			searchURL := buildSearchURL(searchURLParams{
 				BaseURL:        baseURL,
 				PID:            pid,

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-08
+---
+
 # HTTP API schema
 
 The daemon exposes an HTTP API (used by the CLI, TUI, and remote clients). Its
@@ -38,7 +42,7 @@ The schema carries a version in its `info.version` field
 {
   "ok": true,
   "schema_version": 7,
-  "api_schema_version": "0.8.0",
+  "api_schema_version": "0.9.0",
   "version": "1.4.2",
   "uptime": "5m0s",
   "db_path": "/path/to/kata.db"
@@ -53,12 +57,18 @@ Three distinct version fields appear here; they answer different questions:
 | `schema_version` | The database/storage schema version (`meta.schema_version`), an internal storage concern. |
 | `version` | The daemon build version. |
 
-A client can read `api_schema_version` once at startup and decide whether it
-recognizes the daemon's API before issuing further calls. Compare it for
-equality against the `info.version` of the schema the client was generated
-from: the value is semver-shaped, but no ordering semantics are defined, so
-treat any other value as "verify compatibility" rather than inferring safety
-from an unchanged major or minor component.
+A client can read `api_schema_version` before it uses a versioned request
+feature. Versions increase in semantic-version order, so a client can compare
+the daemon version with the first version that contains the feature. This
+minimum-version check proves that the request field exists; it does not prove
+that every part of a generated client matches a different schema version.
+Generated clients should still use the schema from their target release.
+
+The first-party CLI uses this check before requests where an older daemon
+could ignore a filter and return unfiltered rows. Filtered `search` and
+filtered `ready --all` require API `0.8.0`; filtered `list --all` requires API
+`0.9.0`. The CLI stops before the filtered query and tells the operator to
+upgrade when the daemon is too old.
 
 The field is **optional in the schema** even though current daemons always send
 it. That is deliberate: a version-detection field has to survive version skew,
@@ -70,7 +80,8 @@ response of an older daemon that predates it. Treat an **absent or empty**
 
 | Version | Change |
 | --- | --- |
-| `0.8.0` | Added repeatable `label` and `exclude_label` query parameters to project-scoped search. |
+| `0.9.0` | Added owner, label, exclusion, and metadata filters to the cross-project issue list. Global list rows now include `project_name`. |
+| `0.8.0` | Added repeatable `label` and `exclude_label` query parameters to project-scoped search. It also identifies daemons that support filtered global ready queries. |
 | `0.7.0` | Added transactional federation enrollment rotation, idempotent replay semantics for caller-supplied enrollment tokens, and the optional `federation_config` health block used by startup reconciliation. |
 | `0.6.0` | Ready responses now return fully hydrated issues. Project-scoped ready rows are `IssueOut` instead of the slimmer `Issue` projection, and global ready rows (`ReadyGlobalIssueOut`, renamed from `ReadyGlobalIssue`) embed `IssueOut` plus `project_name` — so both gain `labels`, `qualified_id` (required), link peers (`parent`, `blocks`, `blocked_by`, `related`), `blocked`, and `child_counts`. Clients regenerated from the schema see the new component name; the shipped Go client keeps `ReadyGlobalIssue` as a deprecated alias. |
 | `0.5.0` | Added metadata patch endpoints for issues and projects, issue create metadata, and metadata-key filters on project issue lists. Generated clients can patch metadata with `If-Match` revisions, send initial metadata in create requests, and request selected metadata keys with the `meta` query parameter. |

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-08
+---
+
 # Agent workflows
 
 kata is designed to survive the parts of agent work that chat does not: context
@@ -98,6 +102,13 @@ issue:
 
 ```sh
 kata ready --unowned --label bug --no-label blocked --agent
+```
+
+Use the global list when waiting or blocked work must stay visible across
+projects. Unlike `ready`, `list` does not remove issues with active blockers:
+
+```bash
+kata list --all --status open --label handoff --no-label parked --agent
 ```
 
 Release ownership only when you are intentionally giving the work back:

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -450,11 +450,16 @@ type ListIssuesRequest struct {
 // that want one trip through this surface; omit it for the all-projects feed.
 // Priority/MaxPriority are encoded the same way as ListIssuesRequest.
 type ListAllIssuesRequest struct {
-	ProjectID   int64  `query:"project_id,omitempty"`
-	Status      string `query:"status,omitempty" enum:"open,closed,"`
-	Priority    string `query:"priority,omitempty" doc:"exact priority filter (0..4); empty = no filter"`
-	MaxPriority string `query:"max_priority,omitempty" doc:"include only priority <= this value (0..4); empty = no filter"`
-	Limit       int    `query:"limit,omitempty"`
+	ProjectID     int64    `query:"project_id,omitempty"`
+	Status        string   `query:"status,omitempty" enum:"open,closed,"`
+	Priority      string   `query:"priority,omitempty" doc:"exact priority filter (0..4); empty = no filter"`
+	MaxPriority   string   `query:"max_priority,omitempty" doc:"include only priority <= this value (0..4); empty = no filter"`
+	Limit         int      `query:"limit,omitempty"`
+	Unowned       bool     `query:"unowned,omitempty"`
+	Owner         string   `query:"owner,omitempty"`
+	Labels        []string `query:"label,explode"`
+	ExcludeLabels []string `query:"exclude_label,explode"`
+	Meta          []string `query:"meta,explode"`
 
 	// Deprecated query params kept on the struct only to surface a 400 if a
 	// stale client still sends them — the daemon used to honor view= /
@@ -509,6 +514,20 @@ type IssueOut struct {
 type ListIssuesResponse struct {
 	Body struct {
 		Issues []IssueOut `json:"issues"`
+	}
+}
+
+// ListGlobalIssueOut is one cross-project list row. ProjectName is explicit
+// so structured clients do not need to split QualifiedID to recover scope.
+type ListGlobalIssueOut struct {
+	IssueOut
+	ProjectName string `json:"project_name"`
+}
+
+// ListAllIssuesResponse is the cross-project list response.
+type ListAllIssuesResponse struct {
+	Body struct {
+		Issues []ListGlobalIssueOut `json:"issues"`
 	}
 }
 

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -255,7 +255,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		OperationID: "listAllIssues",
 		Method:      "GET",
 		Path:        "/api/v1/issues",
-	}, func(ctx context.Context, in *api.ListAllIssuesRequest) (*api.ListIssuesResponse, error) {
+	}, func(ctx context.Context, in *api.ListAllIssuesRequest) (*api.ListAllIssuesResponse, error) {
 		if in.DeprecatedView != "" || in.DeprecatedArea != "" ||
 			in.DeprecatedOffset != "" || in.DeprecatedClientTZ != "" {
 			return nil, api.NewError(400, "removed_param",
@@ -266,6 +266,10 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if in.ProjectID < 0 {
 			return nil, api.NewError(400, "validation",
 				"project_id must be a positive integer", "", nil)
+		}
+		if in.Unowned && in.Owner != "" {
+			return nil, api.NewError(400, "validation",
+				"--unowned and --owner are mutually exclusive", "", nil)
 		}
 		var projectIDs []int64
 		if in.ProjectID > 0 {
@@ -289,12 +293,21 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
+		metaFilters, err := parseMetaFilters(in.Meta)
+		if err != nil {
+			return nil, err
+		}
 		issues, err := cfg.DB.ListAllIssues(ctx, db.ListAllIssuesParams{
-			ProjectID:   in.ProjectID,
-			Status:      in.Status,
-			Priority:    priority,
-			MaxPriority: maxPriority,
-			Limit:       in.Limit,
+			ProjectID:     in.ProjectID,
+			Status:        in.Status,
+			Priority:      priority,
+			MaxPriority:   maxPriority,
+			Limit:         in.Limit,
+			Unowned:       in.Unowned,
+			Owner:         in.Owner,
+			Labels:        in.Labels,
+			ExcludeLabels: in.ExcludeLabels,
+			Meta:          metaFilters,
 		})
 		if err != nil {
 			return nil, internalAPIError(err)
@@ -303,8 +316,19 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, internalAPIError(err)
 		}
-		out := &api.ListIssuesResponse{}
-		out.Body.Issues = issueOuts
+		out := &api.ListAllIssuesResponse{}
+		out.Body.Issues = make([]api.ListGlobalIssueOut, len(issueOuts))
+		names := projectNames{store: cfg.DB, byID: map[int64]string{}}
+		for i, issueOut := range issueOuts {
+			projectName, err := names.name(ctx, issueOut.ProjectID)
+			if err != nil {
+				return nil, internalAPIError(err)
+			}
+			out.Body.Issues[i] = api.ListGlobalIssueOut{
+				IssueOut:    issueOut,
+				ProjectName: projectName,
+			}
+		}
 		return out, nil
 	})
 

--- a/internal/daemon/handlers_issues_test.go
+++ b/internal/daemon/handlers_issues_test.go
@@ -2404,6 +2404,58 @@ func TestListAllIssues_HydratesLabelsAcrossProjects(t *testing.T) {
 		labelsByKey[strconv.FormatInt(pidB, 10)+"/"+b1Short])
 }
 
+func TestListAllIssues_ComposesOwnerLabelAndMetadataFilters(t *testing.T) {
+	env := testenv.New(t)
+	pidA := initWorkspaceViaHTTP(t, env, "https://example.com/spoke-project.git")
+	pidB := initWorkspaceViaHTTP(t, env, "https://example.com/hub-project.git")
+
+	var wanted struct {
+		Issue struct {
+			ID      int64  `json:"id"`
+			ShortID string `json:"short_id"`
+		} `json:"issue"`
+	}
+	envPostJSON(t, env, projectPath(pidA)+"/issues", map[string]any{
+		"actor": "tester", "title": "wanted", "owner": "agent-a",
+		"labels":   []string{"handoff", "urgent"},
+		"metadata": map[string]string{"lane": "deploy"},
+	}, &wanted)
+	envPostJSON(t, env, projectPath(pidB)+"/issues", map[string]any{
+		"actor": "tester", "title": "wrong owner", "owner": "agent-b",
+		"labels":   []string{"handoff", "urgent"},
+		"metadata": map[string]string{"lane": "deploy"},
+	}, nil)
+	envPostJSON(t, env, projectPath(pidB)+"/issues", map[string]any{
+		"actor": "tester", "title": "excluded label", "owner": "agent-a",
+		"labels":   []string{"handoff", "urgent", "parked"},
+		"metadata": map[string]string{"lane": "deploy"},
+	}, nil)
+	envPostJSON(t, env, projectPath(pidB)+"/issues", map[string]any{
+		"actor": "tester", "title": "wrong metadata", "owner": "agent-a",
+		"labels":   []string{"handoff", "urgent"},
+		"metadata": map[string]string{"lane": "review"},
+	}, nil)
+
+	var out struct {
+		Issues []struct {
+			ShortID     string `json:"short_id"`
+			ProjectName string `json:"project_name"`
+		} `json:"issues"`
+	}
+	envGetJSON(t, env,
+		"/api/v1/issues?status=open&owner=agent-a&label=HANDOFF&label=urgent&exclude_label=parked&meta=lane%3Ddeploy&limit=1",
+		&out)
+	require.Len(t, out.Issues, 1)
+	assert.Equal(t, wanted.Issue.ShortID, out.Issues[0].ShortID)
+	assert.Equal(t, "spoke-project", out.Issues[0].ProjectName)
+}
+
+func TestListAllIssues_UnownedAndOwnerMutuallyExclusive(t *testing.T) {
+	env := testenv.New(t)
+	resp, bs := envGetRaw(t, env, "/api/v1/issues?unowned=true&owner=agent-a")
+	assertAPIError(t, resp.StatusCode, bs, http.StatusBadRequest, "validation")
+}
+
 func TestShowIssue_IncludesLinksAndLabels(t *testing.T) {
 	env := testenv.New(t)
 	pid, parent, child := setupTwoIssues(t, env)

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -16,7 +16,7 @@ import (
 // (info.version). It tracks the HTTP API contract, not the build version, so
 // the committed schema artifact stays stable across builds and is bumped
 // deliberately when the wire contract changes.
-const APISchemaVersion = "0.8.0"
+const APISchemaVersion = "0.9.0"
 
 // OpenAPIDocument builds the daemon's complete OpenAPI model by wiring every
 // route through NewServer with a zero ServerConfig. It binds no listener and

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -212,9 +212,9 @@ func TestOpenAPIDocumentIncludesUIReadContract(t *testing.T) {
 	}
 }
 
-func TestOpenAPISchemaVersionReflectsSearchLabelFilters(t *testing.T) {
-	if APISchemaVersion != "0.8.0" {
-		t.Fatalf("APISchemaVersion = %q, want 0.8.0 for search label query parameters", APISchemaVersion)
+func TestOpenAPISchemaVersionReflectsGlobalListFilters(t *testing.T) {
+	if APISchemaVersion != "0.9.0" {
+		t.Fatalf("APISchemaVersion = %q, want 0.9.0 for global list query parameters", APISchemaVersion)
 	}
 }
 
@@ -358,6 +358,29 @@ func TestOpenAPIDocumentArrayQueryParamsExplode(t *testing.T) {
 		}
 		if param.Explode == nil || !*param.Explode {
 			t.Fatalf("search %s explode = %v, want true", name, param.Explode)
+		}
+	}
+
+	globalList := doc.Paths["/api/v1/issues"].Get
+	if globalList == nil {
+		t.Fatal("missing GET /api/v1/issues")
+	}
+	for _, name := range []string{"label", "exclude_label", "meta"} {
+		var param *huma.Param
+		for _, p := range globalList.Parameters {
+			if p.Name == name && p.In == "query" {
+				param = p
+				break
+			}
+		}
+		if param == nil {
+			t.Fatalf("missing global list %s query parameter", name)
+		}
+		if param.Schema == nil || param.Schema.Type != huma.TypeArray {
+			t.Fatalf("global list %s schema = %+v, want array", name, param.Schema)
+		}
+		if param.Explode == nil || !*param.Explode {
+			t.Fatalf("global list %s explode = %v, want true", name, param.Explode)
 		}
 	}
 }

--- a/internal/db/dbtest/conformance.go
+++ b/internal/db/dbtest/conformance.go
@@ -159,7 +159,7 @@ var storageScenarios = []scenario{
 		name: "ready queues and discovery",
 		methods: []string{
 			"AddLabel", "CloseIssue", "CreateComment", "CreateIssue", "CreateLink", "CreateProject", "EditIssue",
-			"IssueQualifiersByUIDs", "ListIssueContent", "PatchIssueMetadata", "ReadyIssues", "ReadyIssuesGlobal", "SearchFTS",
+			"IssueQualifiersByUIDs", "ListAllIssues", "ListIssueContent", "PatchIssueMetadata", "ReadyIssues", "ReadyIssuesGlobal", "SearchFTS",
 			"SearchFTSAny", "SoftDeleteIssue",
 		},
 		run: checkReadyQueuesAndDiscovery,

--- a/internal/db/dbtest/conformance_content.go
+++ b/internal/db/dbtest/conformance_content.go
@@ -667,6 +667,16 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	if err != nil {
 		return fmt.Errorf("add priority label: %w", err)
 	}
+	_, err = store.PatchIssueMetadata(ctx, db.PatchIssueMetadataIn{
+		IssueID: primary.Issue.ID,
+		Actor:   "discovery-author",
+		Patch: map[string]json.RawMessage{
+			"lane": json.RawMessage(`"deploy"`),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("add discovery metadata: %w", err)
+	}
 	blocker, err := createFixtureIssue(ctx, store, primary.Project.ID, "open dependency", "discovery-author", nil)
 	if err != nil {
 		return err
@@ -848,6 +858,33 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 		return fmt.Errorf("global ready issues limited: %w", err)
 	}
 	require.Len(t, globalLimited, 1)
+	globalListByOwnerAndLabels, err := store.ListAllIssues(ctx, db.ListAllIssuesParams{
+		Status: "open", Owner: "alice", Labels: []string{"BUG", "p0"},
+	})
+	if err != nil {
+		return fmt.Errorf("global list issues by owner and labels: %w", err)
+	}
+	require.Len(t, globalListByOwnerAndLabels, 1)
+	assert.Equal(t, primary.Issue.ID, globalListByOwnerAndLabels[0].ID)
+	globalListUnowned, err := store.ListAllIssues(ctx, db.ListAllIssuesParams{Unowned: true})
+	if err != nil {
+		return fmt.Errorf("global list unowned issues: %w", err)
+	}
+	assert.NotContains(t, issueIDs(globalListUnowned), primary.Issue.ID)
+	globalListWithoutBug, err := store.ListAllIssues(ctx, db.ListAllIssuesParams{ExcludeLabels: []string{"BUG"}})
+	if err != nil {
+		return fmt.Errorf("global list issues excluding label: %w", err)
+	}
+	assert.NotContains(t, issueIDs(globalListWithoutBug), primary.Issue.ID)
+	assert.Contains(t, issueIDs(globalListWithoutBug), other.Issue.ID)
+	globalListByMetadata, err := store.ListAllIssues(ctx, db.ListAllIssuesParams{
+		Meta: []db.MetaFilter{{Key: "lane", Value: "deploy", HasValue: true}},
+	})
+	if err != nil {
+		return fmt.Errorf("global list issues by metadata: %w", err)
+	}
+	require.Len(t, globalListByMetadata, 1)
+	assert.Equal(t, primary.Issue.ID, globalListByMetadata[0].ID)
 	_, _, _, err = store.CloseIssue(ctx, blocker.ID, "done", "discovery-author", "", nil)
 	if err != nil {
 		return fmt.Errorf("close readiness blocker: %w", err)

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -107,13 +107,18 @@ type MetaFilter struct {
 
 // ListAllIssuesParams filters cross-project list output. ProjectID==0 means
 // "every project"; >0 narrows to a single project. Status="" → all statuses.
-// Priority and MaxPriority work the same as ListIssuesParams.
+// All other filters use the same semantics as ListIssuesParams.
 type ListAllIssuesParams struct {
-	ProjectID   int64
-	Status      string
-	Priority    *int64
-	MaxPriority *int64
-	Limit       int
+	ProjectID     int64
+	Status        string
+	Priority      *int64
+	MaxPriority   *int64
+	Limit         int
+	Unowned       bool
+	Owner         string
+	Labels        []string
+	ExcludeLabels []string
+	Meta          []MetaFilter
 }
 
 // CreateCommentParams carries inputs for CreateComment.

--- a/internal/db/pgstore/issues.go
+++ b/internal/db/pgstore/issues.go
@@ -334,6 +334,31 @@ func (s *Store) ListAllIssues(ctx context.Context, params db.ListAllIssuesParams
 	if params.MaxPriority != nil {
 		add("i.priority IS NOT NULL AND i.priority <= $%d", *params.MaxPriority)
 	}
+	if params.Unowned {
+		conditions = append(conditions, "i.owner IS NULL")
+	} else if params.Owner != "" {
+		add("i.owner = $%d", params.Owner)
+	}
+	for _, label := range params.Labels {
+		add("EXISTS (SELECT 1 FROM issue_labels il WHERE il.issue_id = i.id AND il.label = $%d)", strings.ToLower(label))
+	}
+	for _, label := range params.ExcludeLabels {
+		add("NOT EXISTS (SELECT 1 FROM issue_labels il WHERE il.issue_id = i.id AND il.label = $%d)", strings.ToLower(label))
+	}
+	for _, filter := range params.Meta {
+		args = append(args, filter.Key)
+		keyPosition := len(args)
+		if filter.HasValue {
+			args = append(args, filter.Value)
+			conditions = append(conditions, fmt.Sprintf(
+				`EXISTS (SELECT 1 FROM jsonb_each(i.metadata::jsonb) entry
+                  WHERE entry.key = $%d AND jsonb_typeof(entry.value) = 'string'
+                    AND entry.value #>> '{}' = $%d)`,
+				keyPosition, len(args)))
+		} else {
+			conditions = append(conditions, fmt.Sprintf(`i.metadata::jsonb ? $%d`, keyPosition))
+		}
+	}
 	query := issueSelect + ` WHERE ` + strings.Join(conditions, " AND ") + ` ORDER BY i.created_at DESC, i.id DESC`
 	if params.Limit > 0 {
 		args = append(args, params.Limit)

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -1095,6 +1095,29 @@ func (d *Store) ListAllIssues(ctx context.Context, p db.ListAllIssuesParams) ([]
 		q += ` AND i.priority IS NOT NULL AND i.priority <= ?`
 		args = append(args, *p.MaxPriority)
 	}
+	if p.Unowned {
+		q += ` AND i.owner IS NULL`
+	} else if p.Owner != "" {
+		q += ` AND i.owner = ?`
+		args = append(args, p.Owner)
+	}
+	for _, label := range p.Labels {
+		q += ` AND EXISTS (SELECT 1 FROM issue_labels il WHERE il.issue_id = i.id AND il.label = ?)`
+		args = append(args, strings.ToLower(label))
+	}
+	for _, label := range p.ExcludeLabels {
+		q += ` AND NOT EXISTS (SELECT 1 FROM issue_labels il WHERE il.issue_id = i.id AND il.label = ?)`
+		args = append(args, strings.ToLower(label))
+	}
+	for _, mf := range p.Meta {
+		if mf.HasValue {
+			q += ` AND EXISTS (SELECT 1 FROM json_each(i.metadata) je WHERE je.key = ? AND je.value = ?)`
+			args = append(args, mf.Key, mf.Value)
+		} else {
+			q += ` AND EXISTS (SELECT 1 FROM json_each(i.metadata) je WHERE je.key = ?)`
+			args = append(args, mf.Key)
+		}
+	}
 	q += ` ORDER BY i.created_at DESC, i.id DESC`
 	if p.Limit > 0 {
 		q += fmt.Sprintf(` LIMIT %d`, p.Limit)

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -1275,9 +1275,11 @@ func (c *Client) ListAllIssues(ctx context.Context, options *ListAllIssuesReques
 	queryEncoding := map[string]runtime.QueryEncoding{
 		"limit":        {Style: "form", Explode: &[]bool{false}[0]},
 		"max_priority": {Style: "form", Explode: &[]bool{false}[0]},
+		"owner":        {Style: "form", Explode: &[]bool{false}[0]},
 		"priority":     {Style: "form", Explode: &[]bool{false}[0]},
 		"project_id":   {Style: "form", Explode: &[]bool{false}[0]},
 		"status":       {Style: "form", Explode: &[]bool{false}[0]},
+		"unowned":      {Style: "form", Explode: &[]bool{false}[0]},
 	}
 	reqParams := runtime.RequestOptionsParameters{
 		RequestURL:    c.apiClient.GetBaseURL() + "/api/v1/issues",

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -59,8 +59,13 @@ type ListAllIssuesQuery struct {
 	Priority *string `json:"priority,omitempty"`
 
 	// MaxPriority include only priority <= this value (0..4); empty = no filter
-	MaxPriority *string `json:"max_priority,omitempty"`
-	Limit       *int64  `json:"limit,omitempty"`
+	MaxPriority  *string  `json:"max_priority,omitempty"`
+	Limit        *int64   `json:"limit,omitempty"`
+	Unowned      *bool    `json:"unowned,omitempty"`
+	Owner        *string  `json:"owner,omitempty"`
+	Label        []string `json:"label,omitempty"`
+	ExcludeLabel []string `json:"exclude_label,omitempty"`
+	Meta         []string `json:"meta,omitempty"`
 }
 
 func (l ListAllIssuesQuery) Validate() error {

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -61,7 +61,7 @@ type InstanceResponse = InstanceResponseBody
 
 type InstanceErrorResponse = ErrorEnvelope
 
-type ListAllIssuesResponse = ListIssuesResponseBody
+type ListAllIssuesResponse = ListAllIssuesResponseBody
 
 type ListAllIssuesErrorResponse = ErrorEnvelope
 

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -2038,6 +2038,25 @@ type LinksDelta struct {
 	SetParent       *string  `json:"set_parent,omitempty"`
 }
 
+type ListAllIssuesResponseBody struct {
+	Issues []ListGlobalIssueOut `json:"issues,omitempty" validate:"required"`
+}
+
+func (l ListAllIssuesResponseBody) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range l.Issues {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Issues[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type ListFederationEnrollmentsBody struct {
 	Enrollments []FederationEnrollmentOut `json:"enrollments,omitempty" validate:"required"`
 }
@@ -2050,6 +2069,111 @@ func (l ListFederationEnrollmentsBody) Validate() error {
 				errors = errors.Append(fmt.Sprintf("Enrollments[%d]", i), err)
 			}
 		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ListGlobalIssueOut struct {
+	Author        string         `json:"author" validate:"required"`
+	Blocked       *bool          `json:"blocked,omitempty"`
+	BlockedBy     []LinkPeer     `json:"blocked_by,omitempty"`
+	Blocks        []LinkPeer     `json:"blocks,omitempty"`
+	Body          string         `json:"body" validate:"required"`
+	ChildCounts   *ChildCounts   `json:"child_counts,omitempty"`
+	ClosedAt      *time.Time     `json:"closed_at,omitempty"`
+	ClosedReason  *string        `json:"closed_reason,omitempty"`
+	CreatedAt     time.Time      `json:"created_at" validate:"required"`
+	DeletedAt     *time.Time     `json:"deleted_at,omitempty"`
+	ID            int64          `json:"id"`
+	Labels        []string       `json:"labels,omitempty"`
+	Metadata      map[string]any `json:"metadata"`
+	OccurrenceKey *string        `json:"occurrence_key,omitempty"`
+	Owner         *string        `json:"owner,omitempty"`
+	Parent        *LinkPeer      `json:"parent,omitempty"`
+	Priority      *int64         `json:"priority,omitempty"`
+	ProjectID     int64          `json:"project_id"`
+	ProjectName   string         `json:"project_name" validate:"required"`
+	ProjectUID    *string        `json:"project_uid,omitempty"`
+	QualifiedID   string         `json:"qualified_id" validate:"required"`
+	RecurrenceID  *int64         `json:"recurrence_id,omitempty"`
+	Related       []LinkPeer     `json:"related,omitempty"`
+	Revision      int64          `json:"revision"`
+	ShortID       string         `json:"short_id" validate:"required"`
+	Status        string         `json:"status" validate:"required"`
+	Title         string         `json:"title" validate:"required"`
+	UID           string         `json:"uid" validate:"required"`
+	UpdatedAt     time.Time      `json:"updated_at" validate:"required"`
+}
+
+func (l ListGlobalIssueOut) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(l.Author, "required"); err != nil {
+		errors = errors.Append("Author", err)
+	}
+	for i, item := range l.BlockedBy {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("BlockedBy[%d]", i), err)
+			}
+		}
+	}
+	for i, item := range l.Blocks {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Blocks[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(l.Body, "required"); err != nil {
+		errors = errors.Append("Body", err)
+	}
+	if l.ChildCounts != nil {
+		if v, ok := any(l.ChildCounts).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("ChildCounts", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(l.CreatedAt, "required"); err != nil {
+		errors = errors.Append("CreatedAt", err)
+	}
+	if l.Parent != nil {
+		if v, ok := any(l.Parent).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Parent", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(l.ProjectName, "required"); err != nil {
+		errors = errors.Append("ProjectName", err)
+	}
+	if err := typesValidator.Var(l.QualifiedID, "required"); err != nil {
+		errors = errors.Append("QualifiedID", err)
+	}
+	for i, item := range l.Related {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Related[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(l.ShortID, "required"); err != nil {
+		errors = errors.Append("ShortID", err)
+	}
+	if err := typesValidator.Var(l.Status, "required"); err != nil {
+		errors = errors.Append("Status", err)
+	}
+	if err := typesValidator.Var(l.Title, "required"); err != nil {
+		errors = errors.Append("Title", err)
+	}
+	if err := typesValidator.Var(l.UID, "required"); err != nil {
+		errors = errors.Append("UID", err)
+	}
+	if err := typesValidator.Var(l.UpdatedAt, "required"); err != nil {
+		errors = errors.Append("UpdatedAt", err)
 	}
 	if len(errors) == 0 {
 		return nil

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2147,6 +2147,16 @@ components:
         set_parent:
           type: string
       type: object
+    ListAllIssuesResponseBody:
+      properties:
+        issues:
+          items:
+            $ref: "#/components/schemas/ListGlobalIssueOut"
+          nullable: true
+          type: array
+      required:
+        - issues
+      type: object
     ListFederationEnrollmentsBody:
       properties:
         enrollments:
@@ -2156,6 +2166,104 @@ components:
           type: array
       required:
         - enrollments
+      type: object
+    ListGlobalIssueOut:
+      properties:
+        author:
+          type: string
+        blocked:
+          type: boolean
+        blocked_by:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          nullable: true
+          type: array
+        blocks:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          nullable: true
+          type: array
+        body:
+          type: string
+        child_counts:
+          $ref: "#/components/schemas/ChildCounts"
+        closed_at:
+          format: date-time
+          type: string
+        closed_reason:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        deleted_at:
+          format: date-time
+          type: string
+        id:
+          format: int64
+          type: integer
+        labels:
+          items:
+            type: string
+          nullable: true
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        occurrence_key:
+          type: string
+        owner:
+          type: string
+        parent:
+          $ref: "#/components/schemas/LinkPeer"
+        priority:
+          format: int64
+          type: integer
+        project_id:
+          format: int64
+          type: integer
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        qualified_id:
+          type: string
+        recurrence_id:
+          format: int64
+          type: integer
+        related:
+          items:
+            $ref: "#/components/schemas/LinkPeer"
+          nullable: true
+          type: array
+        revision:
+          format: int64
+          type: integer
+        short_id:
+          type: string
+        status:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - project_name
+        - qualified_id
+        - id
+        - uid
+        - project_id
+        - short_id
+        - title
+        - body
+        - status
+        - author
+        - metadata
+        - revision
+        - created_at
+        - updated_at
       type: object
     ListIssuesResponseBody:
       properties:
@@ -3883,7 +3991,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.8.0
+  version: 0.9.0
 openapi: 3.0.3
 paths:
   /api/v1/audit/closes:
@@ -4312,12 +4420,46 @@ paths:
           schema:
             format: int64
             type: integer
+        - explode: false
+          in: query
+          name: unowned
+          schema:
+            type: boolean
+        - explode: false
+          in: query
+          name: owner
+          schema:
+            type: string
+        - explode: true
+          in: query
+          name: label
+          schema:
+            items:
+              type: string
+            nullable: true
+            type: array
+        - explode: true
+          in: query
+          name: exclude_label
+          schema:
+            items:
+              type: string
+            nullable: true
+            type: array
+        - explode: true
+          in: query
+          name: meta
+          schema:
+            items:
+              type: string
+            nullable: true
+            type: array
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListIssuesResponseBody"
+                $ref: "#/components/schemas/ListAllIssuesResponseBody"
           description: OK
         default:
           content:

--- a/web/src/lib/api/schema.d.ts
+++ b/web/src/lib/api/schema.d.ts
@@ -2283,8 +2283,57 @@ export interface components {
       remove_related?: string[] | null
       set_parent?: string
     }
+    ListAllIssuesResponseBody: {
+      issues: components['schemas']['ListGlobalIssueOut'][] | null
+    } & {
+      [key: string]: unknown
+    }
     ListFederationEnrollmentsBody: {
       enrollments: components['schemas']['FederationEnrollmentOut'][] | null
+    } & {
+      [key: string]: unknown
+    }
+    ListGlobalIssueOut: {
+      author: string
+      blocked?: boolean
+      blocked_by?: components['schemas']['LinkPeer'][] | null
+      blocks?: components['schemas']['LinkPeer'][] | null
+      body: string
+      child_counts?: components['schemas']['ChildCounts']
+      /** Format: date-time */
+      closed_at?: string
+      closed_reason?: string
+      /** Format: date-time */
+      created_at: string
+      /** Format: date-time */
+      deleted_at?: string
+      /** Format: int64 */
+      id: number
+      labels?: string[] | null
+      metadata: {
+        [key: string]: unknown
+      }
+      occurrence_key?: string
+      owner?: string
+      parent?: components['schemas']['LinkPeer']
+      /** Format: int64 */
+      priority?: number
+      /** Format: int64 */
+      project_id: number
+      project_name: string
+      project_uid?: string
+      qualified_id: string
+      /** Format: int64 */
+      recurrence_id?: number
+      related?: components['schemas']['LinkPeer'][] | null
+      /** Format: int64 */
+      revision: number
+      short_id: string
+      status: string
+      title: string
+      uid: string
+      /** Format: date-time */
+      updated_at: string
     } & {
       [key: string]: unknown
     }
@@ -3596,6 +3645,11 @@ export interface operations {
         /** @description include only priority <= this value (0..4); empty = no filter */
         max_priority?: string
         limit?: number
+        unowned?: boolean
+        owner?: string
+        label?: string[] | null
+        exclude_label?: string[] | null
+        meta?: string[] | null
       }
       header?: never
       path?: never
@@ -3609,7 +3663,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['ListIssuesResponseBody']
+          'application/json': components['schemas']['ListAllIssuesResponseBody']
         }
       }
       /** @description Error */


### PR DESCRIPTION
Closes #221.
Closes #222.

`ready --all` and filtered search can send query parameters that older daemons silently ignore, while `list` has no cross-project queue scan. That makes fleet work queues either incomplete or silently unfiltered.

## What changed

- Add `kata list --all` over the existing global issue feed, with status, priority, owner/unowned, repeatable label, exclusion, and metadata filters composing in one request.
- Return qualified issue refs in human and agent output, and include `project_name` in global JSON rows.
- Make `--limit 0` mean unlimited and leave `list --all` unlimited by default, while preserving the per-project default of 200.
- Push the same filter semantics through SQLite and PostgreSQL, including case-insensitive label matching and AND composition.
- Bump the API schema to `0.9.0` and regenerate the Go and browser clients for the new global response shape.
- Preflight filtered global ready/next, filtered search, and filtered global list requests against the daemon API version so old daemons fail closed with an upgrade message.