### PR TITLE
Make docs deployment hydrate screenshot assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ docs-assets-branch:
 	bash docs/screenshots/update-assets-branch.sh
 
 docs-deploy:
+	bash docs/screenshots/hydrate-assets.sh
 	vercel deploy --prod
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ docs-assets-branch:
 	bash docs/screenshots/update-assets-branch.sh
 
 docs-deploy:
-	bash docs/screenshots/hydrate-assets.sh
+	bash docs/screenshots/hydrate-assets.sh --force
 	vercel deploy --prod
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,10 @@ docs-assets-branch:
 	bash docs/screenshots/update-assets-branch.sh
 
 docs-deploy:
+	@test -n "$${KATA_DOCS_ASSETS_COMMIT:-}" || { \
+		printf 'KATA_DOCS_ASSETS_COMMIT is required for docs deployment\n' >&2; \
+		exit 2; \
+	}
 	bash docs/screenshots/hydrate-assets.sh --force
 	vercel deploy --prod
 

--- a/docs/development/deploying-docs.md
+++ b/docs/development/deploying-docs.md
@@ -102,13 +102,13 @@ make docs-deploy
 The Make target runs:
 
 ```sh
-bash docs/screenshots/hydrate-assets.sh
+bash docs/screenshots/hydrate-assets.sh --force
 vercel deploy --prod
 ```
 
-The hydration step ensures the ignored screenshot assets are included in the
-Vercel upload; Vercel build machines do not have Git metadata to fetch the
-asset branch themselves.
+The forced hydration refreshes the ignored screenshot assets from the
+`docs-assets` branch before upload; Vercel build machines do not have Git
+metadata to fetch that branch themselves.
 
 Useful Vercel references:
 

--- a/docs/development/deploying-docs.md
+++ b/docs/development/deploying-docs.md
@@ -102,8 +102,13 @@ make docs-deploy
 The Make target runs:
 
 ```sh
+bash docs/screenshots/hydrate-assets.sh
 vercel deploy --prod
 ```
+
+The hydration step ensures the ignored screenshot assets are included in the
+Vercel upload; Vercel build machines do not have Git metadata to fetch the
+asset branch themselves.
 
 Useful Vercel references:
 

--- a/docs/development/deploying-docs.md
+++ b/docs/development/deploying-docs.md
@@ -88,27 +88,30 @@ root:
 scripts/update-docs.sh
 ```
 
-The helper regenerates and pushes the `docs-assets` screenshot branch, hydrates
-local screenshots, builds the docs, runs the docs checks, and deploys with
-Vercel. It does not commit source changes; commit or stash non-ignored docs
-edits before running it.
+The helper regenerates and pushes the `docs-assets` screenshot branch, captures
+that immutable commit ID, hydrates local screenshots from that exact commit,
+builds the docs, runs the docs checks, and deploys the same assets with Vercel.
+It does not commit source changes; commit or stash non-ignored docs edits before
+running it.
 
 If you need to run only the Vercel deploy step:
 
 ```sh
-make docs-deploy
+KATA_DOCS_ASSETS_COMMIT=<reviewed-full-commit-id> make docs-deploy
 ```
 
 The Make target runs:
 
 ```sh
+test -n "$KATA_DOCS_ASSETS_COMMIT"
 bash docs/screenshots/hydrate-assets.sh --force
 vercel deploy --prod
 ```
 
-The forced hydration refreshes the ignored screenshot assets from the
-`docs-assets` branch before upload; Vercel build machines do not have Git
-metadata to fetch that branch themselves.
+The required commit ID must already exist in the local repository. Hydration
+archives that immutable object without refreshing the mutable `docs-assets`
+branch, so Vercel uploads the same assets that were reviewed and validated.
+Vercel build machines do not have Git metadata to fetch the branch themselves.
 
 Useful Vercel references:
 

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -35,8 +35,10 @@ docs/screenshots/update-assets-branch.sh \
 The `docs-assets` branch is intentionally an orphan branch with one commit.
 Generated images stay out of `main`; docs pages reference them through
 `/assets/screenshots/...`. Local preview reads the ignored generated files.
-Production builds run `docs/screenshots/hydrate-assets.sh`, which force-fetches
-and validates the branch before replacing the ignored screenshot directory.
+The deployment helper pins the generated asset commit in
+`KATA_DOCS_ASSETS_COMMIT`, then `docs/screenshots/hydrate-assets.sh` validates
+and archives that exact object before replacing the ignored screenshot
+directory. Vercel builds consume those pre-hydrated files without Git access.
 
 Pass `--push` only after reviewing the generated files and source changes when
 you intend to replace the remote orphan branch.

--- a/docs/screenshots/hydrate-assets.sh
+++ b/docs/screenshots/hydrate-assets.sh
@@ -7,12 +7,28 @@ docs_root="$(cd "$script_dir/.." && pwd)"
 repo_root="$(cd "$docs_root/.." && pwd)"
 assets_branch="${KATA_DOCS_ASSETS_BRANCH:-docs-assets}"
 target="$docs_root/assets/screenshots"
+force=false
+case "${1:-}" in
+  "")
+    ;;
+  --force)
+    force=true
+    ;;
+  -h|--help)
+    printf 'usage: %s [--force]\n' "${0##*/}"
+    exit 0
+    ;;
+  *)
+    printf 'usage: %s [--force]\n' "${0##*/}" >&2
+    exit 2
+    ;;
+esac
 
 # shellcheck source-path=SCRIPTDIR
 # shellcheck source=assets.sh
 . "$script_dir/assets.sh"
 
-if kata_docs_validate_assets "$target" >/dev/null 2>&1; then
+if [[ "$force" == false ]] && kata_docs_validate_assets "$target" >/dev/null 2>&1; then
   exit 0
 fi
 

--- a/docs/screenshots/hydrate-assets.sh
+++ b/docs/screenshots/hydrate-assets.sh
@@ -37,15 +37,21 @@ if ! git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 1
 fi
 
-if git -C "$repo_root" rev-parse --verify --quiet "refs/heads/$assets_branch" >/dev/null; then
-  asset_ref="refs/heads/$assets_branch"
+fetch_remote_assets() {
+	if ! git -C "$repo_root" fetch --force --depth=1 origin \
+		"+refs/heads/$assets_branch:refs/remotes/origin/$assets_branch" >/dev/null; then
+		printf 'docs screenshots not hydrated: failed to fetch origin/%s\n' "$assets_branch" >&2
+		exit 1
+	fi
+	asset_ref="refs/remotes/origin/$assets_branch"
+}
+
+if [[ "$force" == true ]]; then
+	fetch_remote_assets
+elif git -C "$repo_root" rev-parse --verify --quiet "refs/heads/$assets_branch" >/dev/null; then
+	asset_ref="refs/heads/$assets_branch"
 else
-  if ! git -C "$repo_root" fetch --force --depth=1 origin \
-    "+refs/heads/$assets_branch:refs/remotes/origin/$assets_branch" >/dev/null; then
-    printf 'docs screenshots not hydrated: failed to fetch origin/%s\n' "$assets_branch" >&2
-    exit 1
-  fi
-  asset_ref="refs/remotes/origin/$assets_branch"
+	fetch_remote_assets
 fi
 
 if ! git -C "$repo_root" rev-parse --verify --quiet "$asset_ref" >/dev/null; then

--- a/docs/screenshots/hydrate-assets.sh
+++ b/docs/screenshots/hydrate-assets.sh
@@ -6,6 +6,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 docs_root="$(cd "$script_dir/.." && pwd)"
 repo_root="$(cd "$docs_root/.." && pwd)"
 assets_branch="${KATA_DOCS_ASSETS_BRANCH:-docs-assets}"
+pinned_commit="${KATA_DOCS_ASSETS_COMMIT:-}"
 target="$docs_root/assets/screenshots"
 force=false
 case "${1:-}" in
@@ -28,7 +29,7 @@ esac
 # shellcheck source=assets.sh
 . "$script_dir/assets.sh"
 
-if [[ "$force" == false ]] && kata_docs_validate_assets "$target" >/dev/null 2>&1; then
+if [[ "$force" == false && -z "$pinned_commit" ]] && kata_docs_validate_assets "$target" >/dev/null 2>&1; then
   exit 0
 fi
 
@@ -38,20 +39,27 @@ if ! git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 fetch_remote_assets() {
-	if ! git -C "$repo_root" fetch --force --depth=1 origin \
-		"+refs/heads/$assets_branch:refs/remotes/origin/$assets_branch" >/dev/null; then
-		printf 'docs screenshots not hydrated: failed to fetch origin/%s\n' "$assets_branch" >&2
-		exit 1
-	fi
-	asset_ref="refs/remotes/origin/$assets_branch"
+  if ! git -C "$repo_root" fetch --force --depth=1 origin \
+    "+refs/heads/$assets_branch:refs/remotes/origin/$assets_branch" >/dev/null; then
+    printf 'docs screenshots not hydrated: failed to fetch origin/%s\n' "$assets_branch" >&2
+    exit 1
+  fi
+  asset_ref="refs/remotes/origin/$assets_branch"
 }
 
-if [[ "$force" == true ]]; then
-	fetch_remote_assets
+if [[ -n "$pinned_commit" ]]; then
+  if [[ ! "$pinned_commit" =~ ^[0-9a-f]{40}$ ]] ||
+    ! git -C "$repo_root" rev-parse --verify --quiet "$pinned_commit^{commit}" >/dev/null; then
+    printf 'docs screenshots not hydrated: KATA_DOCS_ASSETS_COMMIT must name an available full commit ID\n' >&2
+    exit 1
+  fi
+  asset_ref="$pinned_commit"
+elif [[ "$force" == true ]]; then
+  fetch_remote_assets
 elif git -C "$repo_root" rev-parse --verify --quiet "refs/heads/$assets_branch" >/dev/null; then
-	asset_ref="refs/heads/$assets_branch"
+  asset_ref="refs/heads/$assets_branch"
 else
-	fetch_remote_assets
+  fetch_remote_assets
 fi
 
 if ! git -C "$repo_root" rev-parse --verify --quiet "$asset_ref" >/dev/null; then

--- a/scripts/docs_assets_test.go
+++ b/scripts/docs_assets_test.go
@@ -209,6 +209,7 @@ func TestDocsAssetHydratorForceFetchesAndValidatesRemoteBranch(t *testing.T) {
 	oldCommit := commitAssetTree(t, remote, oldSource, "old docs assets")
 	gitBare(t, remote, "update-ref", "refs/heads/docs-assets", oldCommit)
 	git(t, repo, "fetch", "origin", "docs-assets:refs/remotes/origin/docs-assets")
+	git(t, repo, "branch", "docs-assets", "refs/remotes/origin/docs-assets")
 	hydrator := installDocsScript(t, repo, "hydrate-assets.sh")
 	cmd := exec.Command("bash", hydrator) //nolint:gosec // test-owned script installed under TempDir
 	cmd.Dir = repo

--- a/scripts/docs_assets_test.go
+++ b/scripts/docs_assets_test.go
@@ -209,19 +209,26 @@ func TestDocsAssetHydratorForceFetchesAndValidatesRemoteBranch(t *testing.T) {
 	oldCommit := commitAssetTree(t, remote, oldSource, "old docs assets")
 	gitBare(t, remote, "update-ref", "refs/heads/docs-assets", oldCommit)
 	git(t, repo, "fetch", "origin", "docs-assets:refs/remotes/origin/docs-assets")
+	hydrator := installDocsScript(t, repo, "hydrate-assets.sh")
+	cmd := exec.Command("bash", hydrator) //nolint:gosec // test-owned script installed under TempDir
+	cmd.Dir = repo
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	hydrated, err := os.ReadFile(filepath.Join(repo, "docs", "assets", "screenshots", "web-ui", "workspace.png")) //nolint:gosec // test-owned path under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, "old\n", string(hydrated))
 
 	newSource := filepath.Join(tempDir, "new")
 	writeDocsAssets(t, newSource, "new")
 	newCommit := commitAssetTree(t, remote, newSource, "new docs assets")
 	gitBare(t, remote, "update-ref", "refs/heads/docs-assets", newCommit)
 
-	hydrator := installDocsScript(t, repo, "hydrate-assets.sh")
-	cmd := exec.Command("bash", hydrator) //nolint:gosec // test-owned script installed under TempDir
+	cmd = exec.Command("bash", hydrator, "--force") //nolint:gosec // test-owned script installed under TempDir
 	cmd.Dir = repo
-	output, err := cmd.CombinedOutput()
+	output, err = cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
-	hydrated, err := os.ReadFile(filepath.Join(repo, "docs", "assets", "screenshots", "web-ui", "workspace.png")) //nolint:gosec // test-owned path under TempDir
+	hydrated, err = os.ReadFile(filepath.Join(repo, "docs", "assets", "screenshots", "web-ui", "workspace.png")) //nolint:gosec // test-owned path under TempDir
 	require.NoError(t, err)
 	assert.Equal(t, "new\n", string(hydrated))
 	assert.Equal(t, newCommit, gitOutput(t, repo, "rev-parse", "origin/docs-assets"))

--- a/scripts/docs_assets_test.go
+++ b/scripts/docs_assets_test.go
@@ -235,6 +235,41 @@ func TestDocsAssetHydratorForceFetchesAndValidatesRemoteBranch(t *testing.T) {
 	assert.Equal(t, newCommit, gitOutput(t, repo, "rev-parse", "origin/docs-assets"))
 }
 
+func TestDocsAssetHydratorUsesPinnedCommitWithoutRefreshingRemote(t *testing.T) {
+	requireDocsScriptTools(t)
+
+	tempDir := t.TempDir()
+	remote := filepath.Join(tempDir, "remote.git")
+	repo := filepath.Join(tempDir, "repo")
+	git(t, tempDir, "init", "--bare", remote)
+	initDocsTestRepo(t, repo)
+	git(t, repo, "remote", "add", "origin", remote)
+
+	pinnedSource := filepath.Join(tempDir, "pinned")
+	writeDocsAssets(t, pinnedSource, "pinned")
+	pinnedCommit := commitAssetTree(t, remote, pinnedSource, "pinned docs assets")
+	gitBare(t, remote, "update-ref", "refs/heads/docs-assets", pinnedCommit)
+	git(t, repo, "fetch", "origin", "docs-assets:refs/remotes/origin/docs-assets")
+
+	replacementSource := filepath.Join(tempDir, "replacement")
+	writeDocsAssets(t, replacementSource, "replacement")
+	replacementCommit := commitAssetTree(t, remote, replacementSource, "replacement docs assets")
+	gitBare(t, remote, "update-ref", "refs/heads/docs-assets", replacementCommit)
+
+	hydrator := installDocsScript(t, repo, "hydrate-assets.sh")
+	cmd := exec.Command("bash", hydrator, "--force") //nolint:gosec // test-owned script installed under TempDir
+	cmd.Dir = repo
+	cmd.Env = append(envWithout("KATA_DOCS_ASSETS_COMMIT"), "KATA_DOCS_ASSETS_COMMIT="+pinnedCommit)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	hydrated, err := os.ReadFile(filepath.Join(repo, "docs", "assets", "screenshots", "web-ui", "workspace.png")) //nolint:gosec // test-owned path under TempDir
+	require.NoError(t, err)
+	assert.Equal(t, "pinned\n", string(hydrated))
+	assert.Equal(t, pinnedCommit, gitOutput(t, repo, "rev-parse", "origin/docs-assets"))
+	assert.Equal(t, replacementCommit, gitBareOutput(t, remote, nil, "rev-parse", "refs/heads/docs-assets"))
+}
+
 func TestWebScreenshotGeneratorRunsFocusedCapture(t *testing.T) {
 	requireDocsScriptTools(t)
 

--- a/scripts/update-docs.sh
+++ b/scripts/update-docs.sh
@@ -73,10 +73,15 @@ fi
 
 run make docs-install
 run bash docs/screenshots/update-assets-branch.sh --push
-# hydrate-assets.sh exits early when screenshots exist, so clear local ignored
-# assets before hydrating from the newly pushed docs-assets branch.
-run rm -rf docs/assets/screenshots
-run bash docs/screenshots/hydrate-assets.sh
+assets_branch="${KATA_DOCS_ASSETS_BRANCH:-docs-assets}"
+if [[ "$DRY_RUN" == false ]]; then
+  assets_commit="$(git rev-parse --verify "refs/heads/$assets_branch^{commit}")"
+  printf '+ pin docs assets %s\n' "$assets_commit"
+else
+  assets_commit="<generated-$assets_branch-commit>"
+  printf '+ pin docs assets to the generated %s commit\n' "$assets_branch"
+fi
+run env "KATA_DOCS_ASSETS_COMMIT=$assets_commit" bash docs/screenshots/hydrate-assets.sh --force
 run make docs-build
 run make docs-check
-run make docs-deploy
+run env "KATA_DOCS_ASSETS_COMMIT=$assets_commit" make docs-deploy


### PR DESCRIPTION
Direct docs deployments could fail before the docs build when the ignored screenshot directory had not been hydrated locally. The Vercel build environment has no Git worktree, so it cannot recover the asset branch after upload.\n\nMake docs-deploy hydrate and validate the screenshot assets before Vercel packages the source. This keeps generated binaries out of main while making the documented standalone deployment path reliable, and the deployment guide now explains the constraint.