### PR TITLE
Fix scheduled_on timezone and civil-time semantics

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3940,6 +3940,8 @@ components:
         revision:
           format: int64
           type: integer
+        scheduled_on_date:
+          type: string
         short_id:
           type: string
         status:

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -859,6 +859,7 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	}
 	srv := daemon.NewServer(daemon.ServerConfig{
 		DB:                store,
+		DefaultTimezone:   dcfg.Timezone,
 		StartedAt:         time.Now().UTC(),
 		Endpoint:          &endpoint,
 		Hooks:             disp,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -341,10 +341,12 @@ kata next [--all] [--full]
 ```
 
 `ready` returns open issues that do not have an open blocking predecessor. It
-also excludes parked issues: `someday=true` and a `scheduled_on` date after the
-current UTC date are not actionable. Today, past, unset, and `someday=false`
-values remain eligible. The browser ready collection follows the same rule and
-rolls scheduled work in at UTC midnight.
+also excludes parked issues: `someday=true` and a future `scheduled_on` value
+are not actionable. A date or local date-time uses the issue `timezone`, then
+the daemon's configured `timezone`, then UTC. An RFC 3339 timestamp ending in
+`Z` becomes ready at that exact instant. Numeric offsets are not accepted. Past
+and unset values remain eligible. The browser ready collection follows the
+same rule.
 
 Filters combine with AND logic. `--all` lists ready issues across every
 non-archived project; the scoped filters (`--unowned`, `--owner`, `--label`,

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -187,6 +187,7 @@ named daemon targets:
 ```toml
 listen = "100.64.0.5:7777"
 active_daemon = "shared"
+timezone = "America/Los_Angeles"
 
 [[daemon]]
 name = "shared"
@@ -223,6 +224,11 @@ and hosted deployments. Auto-started daemons also read the config-file listener
 value.
 An empty `[storage].dsn` means "no storage override"; env vars or the default
 database path still apply.
+
+The optional top-level `timezone` is the IANA timezone for date-only and local
+date-time `scheduled_on` values that do not have an issue-level `timezone`. If
+both are unset, Kata uses UTC. RFC 3339 `scheduled_on` values ending in `Z` are
+UTC instants and do not use this setting.
 
 The web UI's daemon selector lists these `[[daemon]]` entries. A plain
 `kata ui` starts or discovers the local browser gateway and initially selects

--- a/docs/reference/metadata.md
+++ b/docs/reference/metadata.md
@@ -40,12 +40,22 @@ rejected. Everything else is stored verbatim.
 
 | Key | Applies to | Type |
 | --- | --- | --- |
-| `scheduled_on` | Issue | Date (`YYYY-MM-DD`) |
+| `scheduled_on` | Issue | Date, local date-time, or UTC timestamp |
 | `deadline_on` | Issue | Date (`YYYY-MM-DD`) |
 | `someday` | Issue | Boolean |
 | `checklist` | Issue | Checklist structure |
 | `timezone` | Issue | IANA timezone name |
 | `area` | Project | String |
+
+A date-only `scheduled_on` value becomes ready on that calendar day. A local
+date-time (`YYYY-MM-DDTHH:MM` or `YYYY-MM-DDTHH:MM:SS`) becomes ready at that
+wall-clock time. Both use the issue `timezone`, then the daemon's top-level
+`timezone`, then UTC. An RFC 3339 value ending in `Z` is an exact UTC instant
+and does not use those timezones. If a local time repeats during a daylight
+saving transition, the first occurrence opens the gate. If a local time does
+not exist, the gate opens at the first valid instant after the gap. Numeric
+offsets are rejected because they pin an instant while duplicating the named
+timezone. `deadline_on` remains date-only.
 
 All other keys are accepted opaquely by design: consumers carry their own
 metadata without a daemon release. When an opaque key later needs query

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -21,6 +21,9 @@ import (
 // TUI preferences and the named daemon catalog. Workspace-local remote
 // overrides (KATA_SERVER, .kata.local.toml) live in their own resolution path.
 type DaemonConfig struct {
+	// Timezone is the IANA timezone used for civil issue schedules that do not
+	// set their own timezone. Empty preserves the UTC default.
+	Timezone string `toml:"timezone"`
 	// Listen is the bind address used by `kata daemon start` when no
 	// --listen flag is supplied. Same syntax as the flag (host:port).
 	// An empty value (or a missing file) means the platform default:
@@ -321,6 +324,7 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 				return nil, fmt.Errorf("parse %s: unknown key(s): %s", path, strings.Join(keys, ", "))
 			}
 		}
+		cfg.Timezone = strings.TrimSpace(cfg.Timezone)
 		cfg.Listen = strings.TrimSpace(cfg.Listen)
 		cfg.Auth.Token = strings.TrimSpace(cfg.Auth.Token)
 		cfg.Auth.Proxy.TrustedActorHeader = strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
@@ -342,6 +346,11 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 	applyDaemonConfigEnv(&cfg)
+	if cfg.Timezone != "" {
+		if _, err := time.LoadLocation(cfg.Timezone); err != nil {
+			return nil, fmt.Errorf("timezone %q is not a valid IANA timezone: %w", cfg.Timezone, err)
+		}
+	}
 	if err := normalizeWebConfig(&cfg.Web, cfg.Auth.TrustPrivateNetwork); err != nil {
 		return nil, err
 	}

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -139,6 +139,28 @@ func TestReadDaemonConfig_ReadsListen(t *testing.T) {
 	assert.Equal(t, "100.64.0.5:7777", cfg.Listen)
 }
 
+func TestReadDaemonConfigReadsTimezone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("timezone = \"  America/Los_Angeles  \"\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "America/Los_Angeles", cfg.Timezone)
+}
+
+func TestReadDaemonConfigRejectsInvalidTimezone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("timezone = \"Not/AZone\"\n"), 0o600))
+
+	_, err := config.ReadDaemonConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timezone")
+}
+
 func TestReadDaemonConfig_TrimsWhitespace(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)

--- a/internal/daemon/handlers_ready.go
+++ b/internal/daemon/handlers_ready.go
@@ -24,10 +24,11 @@ func registerReadyHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, err
 		}
 		filter := db.ReadyIssuesFilter{
-			Unowned:       in.Unowned,
-			Owner:         in.Owner,
-			Labels:        in.Labels,
-			ExcludeLabels: in.ExcludeLabels,
+			Unowned:         in.Unowned,
+			Owner:           in.Owner,
+			Labels:          in.Labels,
+			ExcludeLabels:   in.ExcludeLabels,
+			DefaultTimezone: cfg.DefaultTimezone,
 		}
 		issues, err := cfg.DB.ReadyIssues(ctx, in.ProjectID, in.Limit, filter)
 		if err != nil {
@@ -53,10 +54,11 @@ func registerReadyHandlers(humaAPI huma.API, cfg ServerConfig) {
 				"--unowned and --owner are mutually exclusive", "", nil)
 		}
 		filter := db.ReadyIssuesFilter{
-			Unowned:       in.Unowned,
-			Owner:         in.Owner,
-			Labels:        in.Labels,
-			ExcludeLabels: in.ExcludeLabels,
+			Unowned:         in.Unowned,
+			Owner:           in.Owner,
+			Labels:          in.Labels,
+			ExcludeLabels:   in.ExcludeLabels,
+			DefaultTimezone: cfg.DefaultTimezone,
 		}
 		issues, err := cfg.DB.ReadyIssuesGlobal(ctx, in.Limit, filter)
 		if err != nil {

--- a/internal/daemon/handlers_ui.go
+++ b/internal/daemon/handlers_ui.go
@@ -37,7 +37,8 @@ type normalizedUISnapshotIntent struct {
 	IncludeHistory   bool     `json:"include_history"`
 	LocalDate        string   `json:"local_date,omitempty"`
 	TimeZone         string   `json:"time_zone,omitempty"`
-	ReadyDate        string   `json:"ready_date,omitempty"`
+	ReadyAt          string   `json:"ready_at,omitempty"`
+	DefaultTimezone  string   `json:"default_timezone,omitempty"`
 	Limit            int      `json:"limit"`
 }
 
@@ -50,7 +51,8 @@ func (in normalizedUISnapshotIntent) storeQuery() db.UISnapshotQuery {
 		Relationships: append([]string(nil), in.Relationships...),
 		Text:          in.Text, SelectedIssueUID: in.SelectedIssueUID,
 		IncludeGraph: in.IncludeGraph, IncludeHistory: in.IncludeHistory,
-		LocalDate: in.LocalDate, TimeZone: in.TimeZone, ReadyDate: in.ReadyDate, Limit: in.Limit,
+		LocalDate: in.LocalDate, TimeZone: in.TimeZone, ReadyAt: in.ReadyAt,
+		DefaultTimezone: in.DefaultTimezone, Limit: in.Limit,
 	}
 	if len(in.Statuses) == 1 {
 		query.Status = in.Statuses[0]
@@ -129,7 +131,8 @@ func registerUIHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if err != nil {
 				return nil, err
 			}
-			intent.ReadyDate = effectiveUIReadyDate(intent.Statuses, cfg.UIClock)
+			intent.ReadyAt = effectiveUIReadyAt(intent.Statuses, cfg.UIClock)
+			intent.DefaultTimezone = cfg.DefaultTimezone
 			policy := effectiveUIPolicy(ctx, cfg)
 			var observedCursor *int64
 			if in.IfNoneMatch != "" {
@@ -389,7 +392,7 @@ func dateSensitiveUIView(view string) bool {
 	}
 }
 
-func effectiveUIReadyDate(statuses []string, clock func() time.Time) string {
+func effectiveUIReadyAt(statuses []string, clock func() time.Time) string {
 	ready := false
 	for _, status := range statuses {
 		switch status {
@@ -405,7 +408,7 @@ func effectiveUIReadyDate(statuses []string, clock func() time.Time) string {
 	if clock == nil {
 		clock = time.Now
 	}
-	return clock().UTC().Format(time.DateOnly)
+	return clock().UTC().Format(time.RFC3339Nano)
 }
 
 func uiValidationError(field, message string, data map[string]any) error {

--- a/internal/daemon/handlers_ui_test.go
+++ b/internal/daemon/handlers_ui_test.go
@@ -94,7 +94,7 @@ func newUISnapshotServerWithClock(
 	return ts
 }
 
-func TestUISnapshotReadyDateRolloverInvalidatesETagAndAuthorityCache(t *testing.T) {
+func TestUISnapshotReadyTimeAdvanceInvalidatesETagAndAuthorityCache(t *testing.T) {
 	store := &countingUIStore{cursor: 41, snapshotCursor: 41}
 	now := time.Date(2026, 8, 8, 23, 59, 0, 0, time.UTC)
 	ts := newUISnapshotServerWithClock(t, store, true, func() time.Time { return now })
@@ -102,14 +102,14 @@ func TestUISnapshotReadyDateRolloverInvalidatesETagAndAuthorityCache(t *testing.
 
 	first, _ := getUISnapshot(t, ts, query, "")
 	require.Equal(t, http.StatusOK, first.StatusCode)
-	require.Equal(t, "2026-08-08", store.lastSnapshot.ReadyDate)
+	require.Equal(t, "2026-08-08T23:59:00Z", store.lastSnapshot.ReadyAt)
 	require.Equal(t, 1, store.snapshotReads)
 
 	now = now.Add(2 * time.Minute)
 	second, body := getUISnapshot(t, ts, query, first.Header.Get("ETag"))
 	require.Equal(t, http.StatusOK, second.StatusCode, string(body))
 	require.NotEqual(t, first.Header.Get("ETag"), second.Header.Get("ETag"))
-	require.Equal(t, "2026-08-09", store.lastSnapshot.ReadyDate)
+	require.Equal(t, "2026-08-09T00:01:00Z", store.lastSnapshot.ReadyAt)
 	require.Equal(t, 2, store.snapshotReads)
 }
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -36,9 +36,12 @@ type ServerConfig struct {
 	// UIStore supplies coherent browser projections. Nil defaults to DB when
 	// the configured storage backend implements db.UIStore.
 	UIStore db.UIStore
-	// UIClock supplies the current time for date-sensitive browser readiness.
-	// Nil uses time.Now. Tests inject it to verify UTC date rollover.
-	UIClock                       func() time.Time
+	// UIClock supplies the current time for browser readiness.
+	// Nil uses time.Now. Tests inject it to verify timed schedule transitions.
+	UIClock func() time.Time
+	// DefaultTimezone applies to civil schedules without an issue-level
+	// timezone. Empty preserves the UTC default.
+	DefaultTimezone               string
 	StartedAt                     time.Time
 	Endpoint                      *kitdaemon.Endpoint
 	Broadcaster                   *EventBroadcaster

--- a/internal/db/dbtest/conformance_automation.go
+++ b/internal/db/dbtest/conformance_automation.go
@@ -208,6 +208,10 @@ func checkRecurrences(t *testing.T, store db.Storage) error {
 	assert.Equal(t, attached.Recurrence.ID, *linkedIssue.RecurrenceID)
 	require.NotNil(t, linkedIssue.OccurrenceKey)
 	assert.Equal(t, "2026-08-03", *linkedIssue.OccurrenceKey)
+	var linkedMetadata map[string]any
+	require.NoError(t, json.Unmarshal([]byte(linkedIssue.Metadata), &linkedMetadata))
+	assert.Equal(t, "2026-08-03", linkedMetadata["scheduled_on"])
+	assert.Equal(t, "UTC", linkedMetadata["timezone"])
 	require.NotNil(t, attached.Recurrence.NextOccurrenceKey)
 	assert.Equal(t, "2026-08-10", *attached.Recurrence.NextOccurrenceKey)
 	exhaustedRule := "FREQ=DAILY;COUNT=1"
@@ -259,6 +263,15 @@ func checkRecurrences(t *testing.T, store db.Storage) error {
 	assert.Nil(t, localSchedule.Recurrence.NextOccurrenceKey)
 	owner := "alice"
 	priority := int64(2)
+	_, _, err = store.CreateRecurrence(ctx, db.CreateRecurrenceIn{
+		ProjectID: project.ID, Actor: "scheduler", Rule: "FREQ=WEEKLY", DTStart: "2026-05-11",
+		Timezone: "America/New_York", Template: db.RecurrenceTemplate{
+			Title: "Invalid template", Metadata: json.RawMessage(`{"timezone":"Not/AZone"}`),
+		},
+	})
+	if err == nil {
+		return fmt.Errorf("create recurrence accepted invalid reserved template metadata")
+	}
 	rec, createdEvent, err := store.CreateRecurrence(ctx, db.CreateRecurrenceIn{
 		ProjectID: project.ID,
 		Actor:     "scheduler",
@@ -302,6 +315,14 @@ func checkRecurrences(t *testing.T, store db.Storage) error {
 	}
 	require.Len(t, listed, 1)
 	assert.Equal(t, rec.ID, listed[0].ID)
+	invalidMetadata := json.RawMessage(`{"timezone":"Not/AZone"}`)
+	_, err = store.PatchRecurrence(ctx, db.PatchRecurrenceIn{
+		RecurrenceID: rec.ID, IfMatchRev: rec.Revision, Actor: "scheduler",
+		Update: db.RecurrenceUpdate{TemplateMetadata: &invalidMetadata},
+	})
+	if err == nil {
+		return fmt.Errorf("patch recurrence accepted invalid reserved template metadata")
+	}
 
 	noChange, err := store.PatchRecurrence(ctx, db.PatchRecurrenceIn{
 		RecurrenceID: rec.ID, IfMatchRev: rec.Revision, Actor: "scheduler",
@@ -375,6 +396,7 @@ func checkRecurrences(t *testing.T, store db.Storage) error {
 	require.NoError(t, json.Unmarshal([]byte(issue.Metadata), &issueMetadata))
 	assert.Equal(t, "weekly", issueMetadata["kind"])
 	assert.Equal(t, materialized.OccurrenceKey, issueMetadata["scheduled_on"])
+	assert.Equal(t, "America/New_York", issueMetadata["timezone"])
 	labels, err := store.LabelsForIssue(ctx, issue.ID)
 	if err != nil {
 		return fmt.Errorf("labels for materialized issue: %w", err)

--- a/internal/db/dbtest/conformance_content.go
+++ b/internal/db/dbtest/conformance_content.go
@@ -731,6 +731,46 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	if err != nil {
 		return err
 	}
+	westScheduled, err := createFixtureIssue(ctx, store, primary.Project.ID, "west scheduled", "discovery-author", nil)
+	if err != nil {
+		return err
+	}
+	eastScheduled, err := createFixtureIssue(ctx, store, primary.Project.ID, "east scheduled", "discovery-author", nil)
+	if err != nil {
+		return err
+	}
+	pastInstant, err := createFixtureIssue(ctx, store, primary.Project.ID, "past instant", "discovery-author", nil)
+	if err != nil {
+		return err
+	}
+	futureInstant, err := createFixtureIssue(ctx, store, primary.Project.ID, "future instant", "discovery-author", nil)
+	if err != nil {
+		return err
+	}
+	legacyRecurrenceIssue, err := createFixtureIssue(
+		ctx, store, primary.Project.ID, "legacy recurrence timezone", "discovery-author", nil,
+	)
+	if err != nil {
+		return err
+	}
+	_, err = store.CreateRecurrenceForIssue(ctx, db.CreateRecurrenceForIssueIn{
+		IssueID: legacyRecurrenceIssue.ID,
+		Recurrence: db.CreateRecurrenceIn{
+			ProjectID: primary.Project.ID, Actor: "discovery-author", Rule: "FREQ=DAILY;COUNT=2",
+			DTStart: "2026-09-01", Timezone: "America/Los_Angeles",
+			Template: db.RecurrenceTemplate{Title: "legacy recurrence timezone"},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("attach legacy recurrence issue: %w", err)
+	}
+	_, err = store.PatchIssueMetadata(ctx, db.PatchIssueMetadataIn{
+		IssueID: legacyRecurrenceIssue.ID, Actor: "discovery-author",
+		Patch: map[string]json.RawMessage{"timezone": json.RawMessage(`null`)},
+	})
+	if err != nil {
+		return fmt.Errorf("remove legacy recurrence issue timezone: %w", err)
+	}
 	patchMetadata := func(issue db.Issue, patch map[string]json.RawMessage) error {
 		_, patchErr := store.PatchIssueMetadata(ctx, db.PatchIssueMetadataIn{
 			IssueID: issue.ID,
@@ -739,7 +779,8 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 		})
 		return patchErr
 	}
-	today := time.Now().UTC()
+	now := time.Date(2026, 9, 1, 0, 30, 0, 0, time.UTC)
+	today := now.UTC()
 	if err := patchMetadata(someday, map[string]json.RawMessage{"someday": json.RawMessage(`true`)}); err != nil {
 		return fmt.Errorf("park someday issue: %w", err)
 	}
@@ -761,8 +802,30 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	}); err != nil {
 		return fmt.Errorf("schedule past issue: %w", err)
 	}
+	if err := patchMetadata(westScheduled, map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T09:00"`),
+		"timezone":     json.RawMessage(`"America/Los_Angeles"`),
+	}); err != nil {
+		return fmt.Errorf("schedule west-zone issue: %w", err)
+	}
+	if err := patchMetadata(eastScheduled, map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T09:00"`),
+		"timezone":     json.RawMessage(`"Asia/Tokyo"`),
+	}); err != nil {
+		return fmt.Errorf("schedule east-zone issue: %w", err)
+	}
+	if err := patchMetadata(pastInstant, map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T00:30:00Z"`),
+	}); err != nil {
+		return fmt.Errorf("schedule due instant: %w", err)
+	}
+	if err := patchMetadata(futureInstant, map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T00:31:00Z"`),
+	}); err != nil {
+		return fmt.Errorf("schedule future instant: %w", err)
+	}
 
-	ready, err := store.ReadyIssues(ctx, primary.Project.ID, 0, db.ReadyIssuesFilter{})
+	ready, err := store.ReadyIssues(ctx, primary.Project.ID, 0, db.ReadyIssuesFilter{At: now})
 	if err != nil {
 		return fmt.Errorf("ready issues: %w", err)
 	}
@@ -776,6 +839,21 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	assert.Contains(t, issueIDs(ready), somedayFalse.ID)
 	assert.Contains(t, issueIDs(ready), todayScheduled.ID)
 	assert.Contains(t, issueIDs(ready), pastScheduled.ID)
+	assert.NotContains(t, issueIDs(ready), westScheduled.ID)
+	assert.Contains(t, issueIDs(ready), eastScheduled.ID)
+	assert.Contains(t, issueIDs(ready), pastInstant.ID)
+	assert.NotContains(t, issueIDs(ready), futureInstant.ID)
+	assert.NotContains(t, issueIDs(ready), legacyRecurrenceIssue.ID,
+		"a linked recurrence timezone must precede the daemon or UTC fallback")
+	defaultZoneReady, err := store.ReadyIssues(ctx, primary.Project.ID, 0, db.ReadyIssuesFilter{
+		At: now, DefaultTimezone: "America/Los_Angeles",
+	})
+	if err != nil {
+		return fmt.Errorf("ready issues with default timezone: %w", err)
+	}
+	assert.NotContains(t, issueIDs(defaultZoneReady), todayScheduled.ID)
+	assert.Contains(t, issueIDs(defaultZoneReady), eastScheduled.ID,
+		"an issue timezone must override the daemon default")
 	owned, err := store.ReadyIssues(ctx, primary.Project.ID, 0, db.ReadyIssuesFilter{Owner: "alice"})
 	if err != nil {
 		return fmt.Errorf("ready issues by owner: %w", err)
@@ -802,13 +880,14 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 		return fmt.Errorf("ready issues excluding labels: %w", err)
 	}
 	assert.NotContains(t, issueIDs(withoutBug), primary.Issue.ID)
-	limited, err := store.ReadyIssues(ctx, primary.Project.ID, 1, db.ReadyIssuesFilter{})
+	limited, err := store.ReadyIssues(ctx, primary.Project.ID, 1, db.ReadyIssuesFilter{At: now})
 	if err != nil {
 		return fmt.Errorf("limited ready issues: %w", err)
 	}
 	require.Len(t, limited, 1)
+	assert.NotEqual(t, futureInstant.ID, limited[0].ID, "a parked first row must not consume the limit")
 
-	global, err := store.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{})
+	global, err := store.ReadyIssuesGlobal(ctx, 0, db.ReadyIssuesFilter{At: now})
 	if err != nil {
 		return fmt.Errorf("global ready issues: %w", err)
 	}
@@ -821,6 +900,11 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	assert.Contains(t, globalIDs, somedayFalse.ID)
 	assert.Contains(t, globalIDs, todayScheduled.ID)
 	assert.Contains(t, globalIDs, pastScheduled.ID)
+	assert.NotContains(t, globalIDs, westScheduled.ID)
+	assert.Contains(t, globalIDs, eastScheduled.ID)
+	assert.Contains(t, globalIDs, pastInstant.ID)
+	assert.NotContains(t, globalIDs, futureInstant.ID)
+	assert.NotContains(t, globalIDs, legacyRecurrenceIssue.ID)
 	for _, row := range global {
 		if row.ID == other.Issue.ID {
 			assert.Equal(t, other.Project.Name, row.ProjectName)
@@ -889,7 +973,7 @@ func checkReadyQueuesAndDiscovery(t *testing.T, store db.Storage) error {
 	if err != nil {
 		return fmt.Errorf("close readiness blocker: %w", err)
 	}
-	ready, err = store.ReadyIssues(ctx, primary.Project.ID, 0, db.ReadyIssuesFilter{})
+	ready, err = store.ReadyIssues(ctx, primary.Project.ID, 0, db.ReadyIssuesFilter{At: now})
 	if err != nil {
 		return fmt.Errorf("ready issues after blocker close: %w", err)
 	}

--- a/internal/db/dbtest/ui_contract.go
+++ b/internal/db/dbtest/ui_contract.go
@@ -222,7 +222,7 @@ func RunUISnapshotCollectionContract(t *testing.T, open func(*testing.T) db.Stor
 	require.True(t, changed)
 
 	ready, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
-		View: "all-open", Statuses: []string{"ready"}, ReadyDate: today.Format(time.DateOnly),
+		View: "all-open", Statuses: []string{"ready"}, ReadyAt: today.Format(time.RFC3339Nano),
 	})
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{
@@ -233,11 +233,58 @@ func RunUISnapshotCollectionContract(t *testing.T, open func(*testing.T) db.Stor
 
 	rolled, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
 		View: "all-open", Statuses: []string{"ready"},
-		ReadyDate: today.AddDate(0, 0, 1).Format(time.DateOnly),
+		ReadyAt: today.AddDate(0, 0, 1).Format(time.RFC3339Nano),
 	})
 	require.NoError(t, err)
 	require.Contains(t, uiIssueUIDs(rolled.Issues), futureScheduled.UID)
 	require.NotContains(t, uiIssueUIDs(rolled.Issues), someday.UID)
+
+	readyAt := time.Date(2026, 9, 1, 0, 30, 0, 0, time.UTC)
+	westScheduled := createWithMetadata("West-zone scheduled issue", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T09:00"`),
+		"timezone":     json.RawMessage(`"America/Los_Angeles"`),
+	})
+	eastScheduled := createWithMetadata("East-zone scheduled issue", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T09:00"`),
+		"timezone":     json.RawMessage(`"Asia/Tokyo"`),
+	})
+	dueInstant := createWithMetadata("Due instant", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T00:30:00Z"`),
+	})
+	futureInstant := createWithMetadata("Future instant", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T00:31:00Z"`),
+	})
+	timed, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+		View: "all-open", Statuses: []string{"ready"}, ReadyAt: readyAt.Format(time.RFC3339Nano),
+	})
+	require.NoError(t, err)
+	require.NotContains(t, uiIssueUIDs(timed.Issues), westScheduled.UID)
+	require.Contains(t, uiIssueUIDs(timed.Issues), eastScheduled.UID)
+	require.Contains(t, uiIssueUIDs(timed.Issues), dueInstant.UID)
+	require.NotContains(t, uiIssueUIDs(timed.Issues), futureInstant.UID)
+	defaultScheduled := createWithMetadata("Default-zone scheduled issue", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01"`),
+	})
+	defaultZoned, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+		View: "all-open", Statuses: []string{"ready"}, ReadyAt: readyAt.Format(time.RFC3339Nano),
+		DefaultTimezone: "America/Los_Angeles",
+	})
+	require.NoError(t, err)
+	require.NotContains(t, uiIssueUIDs(defaultZoned.Issues), defaultScheduled.UID)
+	require.Contains(t, uiIssueUIDs(defaultZoned.Issues), eastScheduled.UID,
+		"an issue timezone must override the daemon default")
+
+	limitDue := createWithMetadata("Limit due issue", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T00:30:00Z"`),
+	})
+	createWithMetadata("Limit parked issue", map[string]json.RawMessage{
+		"scheduled_on": json.RawMessage(`"2026-09-01T00:31:00Z"`),
+	})
+	limited, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+		View: "all-open", Statuses: []string{"ready"}, ReadyAt: readyAt.Format(time.RFC3339Nano), Limit: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{limitDue.UID}, uiIssueUIDs(limited.Issues))
 
 	parents, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
 		View: "all-open", Relationships: []string{"child"},
@@ -313,6 +360,73 @@ func RunUISnapshotViewScopeContract(t *testing.T, open func(*testing.T) db.Stora
 			require.Equal(t, []string{matching.UID}, uiIssueUIDs(snapshot.Issues))
 		})
 	}
+
+	t.Run("timed schedules use the browser calendar before limit", func(t *testing.T) {
+		store := open(t)
+		uiStore := store.(db.UIStore)
+		ctx := context.Background()
+		project := createCursorProject(ctx, t, store)
+		previousDay, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID, Title: "Previous browser day", Author: "user-a",
+			Metadata: map[string]json.RawMessage{
+				"scheduled_on": json.RawMessage(`"2026-08-01T00:30:00Z"`),
+			},
+		})
+		require.NoError(t, err)
+		nextDay, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID, Title: "Next browser day", Author: "user-a",
+			Metadata: map[string]json.RawMessage{
+				"scheduled_on": json.RawMessage(`"2026-08-01T07:30:00Z"`),
+			},
+		})
+		require.NoError(t, err)
+
+		today, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+			View: "today", LocalDate: "2026-07-31", TimeZone: "America/Los_Angeles", Limit: 1,
+		})
+		require.NoError(t, err)
+		require.Len(t, today.Issues, 1)
+		require.Equal(t, previousDay.UID, today.Issues[0].UID)
+		require.Equal(t, "2026-07-31", today.Issues[0].ScheduledOnDate)
+
+		upcoming, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+			View: "upcoming", LocalDate: "2026-07-31", TimeZone: "America/Los_Angeles", Limit: 1,
+		})
+		require.NoError(t, err)
+		require.Len(t, upcoming.Issues, 1)
+		require.Equal(t, nextDay.UID, upcoming.Issues[0].UID)
+		require.Equal(t, "2026-08-01", upcoming.Issues[0].ScheduledOnDate)
+	})
+
+	t.Run("ready uses linked recurrence timezone for legacy issues", func(t *testing.T) {
+		store := open(t)
+		uiStore := store.(db.UIStore)
+		ctx := context.Background()
+		project := createCursorProject(ctx, t, store)
+		issue := createCursorIssue(ctx, t, store, project.ID, "Legacy recurrence issue")
+		_, err := store.CreateRecurrenceForIssue(ctx, db.CreateRecurrenceForIssueIn{
+			IssueID: issue.ID,
+			Recurrence: db.CreateRecurrenceIn{
+				ProjectID: project.ID, Actor: "user-a", Rule: "FREQ=DAILY;COUNT=2",
+				DTStart: "2026-08-01", Timezone: "America/Los_Angeles",
+				Template: db.RecurrenceTemplate{Title: issue.Title},
+			},
+		})
+		require.NoError(t, err)
+		_, err = store.PatchIssueMetadata(ctx, db.PatchIssueMetadataIn{
+			IssueID: issue.ID, Actor: "user-a",
+			Patch: map[string]json.RawMessage{"timezone": json.RawMessage(`null`)},
+		})
+		require.NoError(t, err)
+
+		snapshot, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+			ProjectUID: project.UID, Status: "ready",
+			ReadyAt: "2026-08-01T00:30:00Z", DefaultTimezone: "UTC",
+		})
+		require.NoError(t, err)
+		require.Empty(t, snapshot.Issues,
+			"Los Angeles is still on the previous date when the UTC fallback date opens")
+	})
 
 	t.Run("inbox filters before limit", func(t *testing.T) {
 		store := open(t)

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -215,6 +215,10 @@ type ReadyIssuesFilter struct {
 	Owner         string   // only issues where owner = this value (empty = no filter)
 	Labels        []string // issues must have ALL these labels (AND logic)
 	ExcludeLabels []string // issues must NOT have any of these labels
+	At            time.Time
+	// DefaultTimezone applies to civil schedules without issue timezone.
+	// Empty means UTC.
+	DefaultTimezone string
 }
 
 // SearchFTSParams parameterizes full-text search candidate retrieval. The

--- a/internal/db/pgstore/discovery.go
+++ b/internal/db/pgstore/discovery.go
@@ -2,24 +2,27 @@ package pgstore
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"time"
 
 	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/metadata"
 )
 
 // ReadyIssues returns actionable open issues that have no active blocker.
-// Issues marked someday=true or scheduled after today's UTC date are parked
-// and excluded. Optional owner and label filters are composed here so the same
-// query remains useful to the CLI's different ready views.
+// Issues marked someday=true or scheduled after their effective local date or
+// instant are parked and excluded. Optional owner and label filters are
+// composed here so the same query remains useful to the CLI's different ready
+// views.
 func (s *Store) ReadyIssues(
 	ctx context.Context,
 	projectID int64,
 	limit int,
 	filter db.ReadyIssuesFilter,
 ) ([]db.Issue, error) {
-	query := issueSelect + `
+	query := scheduledIssueSelect + `
  WHERE i.project_id = $1
    AND i.status = 'open'
    AND i.deleted_at IS NULL
@@ -40,8 +43,6 @@ func (s *Store) ReadyIssues(
 		return fmt.Sprintf("$%d", len(args))
 	}
 	query += ` AND COALESCE((i.metadata::jsonb ->> 'someday')::boolean, false) = false`
-	query += ` AND (i.metadata::jsonb ->> 'scheduled_on' IS NULL OR i.metadata::jsonb ->> 'scheduled_on' <= ` +
-		addArg(time.Now().UTC().Format(time.DateOnly)) + `)`
 	if filter.Unowned {
 		query += ` AND i.owner IS NULL`
 	} else if filter.Owner != "" {
@@ -58,22 +59,34 @@ func (s *Store) ReadyIssues(
            WHERE il.issue_id = i.id AND il.label = ` + addArg(strings.ToLower(label)) + `)`
 	}
 	query += ` ORDER BY i.updated_at DESC, i.id DESC`
-	if limit > 0 {
-		query += ` LIMIT ` + addArg(limit)
-	}
-
 	rows, err := s.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("ready issues: %w", mapSQLError(err, nil))
 	}
 	defer func() { _ = rows.Close() }()
 	var issues []db.Issue
+	at := filter.At
+	if at.IsZero() {
+		at = time.Now()
+	}
 	for rows.Next() {
-		issue, err := scanIssue(rows)
+		issue, recurrenceTimezone, err := scanScheduledIssue(rows)
 		if err != nil {
 			return nil, err
 		}
+		due, err := metadata.ScheduledOnDue(
+			string(issue.Metadata), at, scheduleDefaultTimezone(recurrenceTimezone, filter.DefaultTimezone),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("ready issue %s schedule: %w", issue.UID, err)
+		}
+		if !due {
+			continue
+		}
 		issues = append(issues, issue)
+		if limit > 0 && len(issues) == limit {
+			break
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate ready issues: %w", mapSQLError(err, nil))
@@ -85,11 +98,10 @@ func (s *Store) ReadyIssues(
 // along with the project name needed to render a qualified reference. Filter
 // and parked-item semantics match ReadyIssues.
 func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.ReadyIssuesFilter) ([]db.ReadyGlobalIssue, error) {
-	query := `SELECT i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status,
-       i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision, i.recurrence_id,
-       i.occurrence_key, i.created_at, i.updated_at, i.closed_at, i.deleted_at, p.name
+	query := `SELECT ` + issueColumns + `, p.name, schedule_recurrence.timezone
   FROM issues i
   JOIN projects p ON p.id = i.project_id
+	LEFT JOIN recurrences schedule_recurrence ON schedule_recurrence.id = i.recurrence_id
  WHERE i.status = 'open'
    AND i.deleted_at IS NULL
    AND p.deleted_at IS NULL
@@ -110,8 +122,6 @@ func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.Read
 		return fmt.Sprintf("$%d", len(args))
 	}
 	query += ` AND COALESCE((i.metadata::jsonb ->> 'someday')::boolean, false) = false`
-	query += ` AND (i.metadata::jsonb ->> 'scheduled_on' IS NULL OR i.metadata::jsonb ->> 'scheduled_on' <= ` +
-		addArg(time.Now().UTC().Format(time.DateOnly)) + `)`
 	if filter.Unowned {
 		query += ` AND i.owner IS NULL`
 	} else if filter.Owner != "" {
@@ -128,9 +138,6 @@ func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.Read
            WHERE il.issue_id = i.id AND il.label = ` + addArg(strings.ToLower(label)) + `)`
 	}
 	query += ` ORDER BY i.updated_at DESC, i.id DESC`
-	if limit > 0 {
-		query += ` LIMIT ` + addArg(limit)
-	}
 	rows, err := s.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("ready issues global: %w", mapSQLError(err, nil))
@@ -138,10 +145,15 @@ func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.Read
 	defer func() { _ = rows.Close() }()
 
 	var issues []db.ReadyGlobalIssue
+	at := filter.At
+	if at.IsZero() {
+		at = time.Now()
+	}
 	for rows.Next() {
 		var buffer issueScanBuffer
 		var projectName string
-		destinations := append(buffer.destinations(), &projectName)
+		var recurrenceTimezone sql.NullString
+		destinations := append(buffer.destinations(), &projectName, &recurrenceTimezone)
 		if err := rows.Scan(destinations...); err != nil {
 			return nil, fmt.Errorf("scan ready global issue: %w", mapSQLError(err, nil))
 		}
@@ -149,12 +161,32 @@ func (s *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.Read
 		if err != nil {
 			return nil, err
 		}
+		due, err := metadata.ScheduledOnDue(
+			string(issue.Metadata), at,
+			scheduleDefaultTimezone(recurrenceTimezone.String, filter.DefaultTimezone),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("ready global issue %s schedule: %w", issue.UID, err)
+		}
+		if !due {
+			continue
+		}
 		issues = append(issues, db.ReadyGlobalIssue{Issue: issue, ProjectName: projectName})
+		if limit > 0 && len(issues) == limit {
+			break
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate ready global issues: %w", mapSQLError(err, nil))
 	}
 	return issues, nil
+}
+
+func scheduleDefaultTimezone(recurrenceTimezone, daemonTimezone string) string {
+	if recurrenceTimezone != "" {
+		return recurrenceTimezone
+	}
+	return daemonTimezone
 }
 
 // IssueQualifiersByUIDs resolves stable issue UIDs to their current project

--- a/internal/db/pgstore/issues.go
+++ b/internal/db/pgstore/issues.go
@@ -15,10 +15,17 @@ import (
 	katauid "go.kenn.io/kata/internal/uid"
 )
 
-const issueSelect = `SELECT i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status,
+const issueColumns = `i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status,
        i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision, i.recurrence_id,
-       i.occurrence_key, i.created_at, i.updated_at, i.closed_at, i.deleted_at
+       i.occurrence_key, i.created_at, i.updated_at, i.closed_at, i.deleted_at`
+
+const issueSelect = `SELECT ` + issueColumns + `
   FROM issues i JOIN projects p ON p.id = i.project_id`
+
+const scheduledIssueSelect = `SELECT ` + issueColumns + `, schedule_recurrence.timezone
+  FROM issues i
+  JOIN projects p ON p.id = i.project_id
+  LEFT JOIN recurrences schedule_recurrence ON schedule_recurrence.id = i.recurrence_id`
 
 type issueCreatedPayload struct {
 	UID                    string                 `json:"uid"`
@@ -501,6 +508,21 @@ func scanIssue(row rowScanner) (db.Issue, error) {
 		return db.Issue{}, mapSQLError(err, nil)
 	}
 	return buffer.value()
+}
+
+func scanScheduledIssue(row rowScanner) (db.Issue, string, error) {
+	var buffer issueScanBuffer
+	var recurrenceTimezone sql.NullString
+	destinations := append(buffer.destinations(), &recurrenceTimezone)
+	err := row.Scan(destinations...)
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.Issue{}, "", db.ErrNotFound
+	}
+	if err != nil {
+		return db.Issue{}, "", mapSQLError(err, nil)
+	}
+	issue, err := buffer.value()
+	return issue, recurrenceTimezone.String, err
 }
 
 type issueScanBuffer struct {

--- a/internal/db/pgstore/recurrences.go
+++ b/internal/db/pgstore/recurrences.go
@@ -213,18 +213,11 @@ func (s *Store) CreateRecurrenceForIssue(
 		if err != nil {
 			return fmt.Errorf("walk after initial occurrence: %w", err)
 		}
-		var issueMetadata map[string]json.RawMessage
-		if err := json.Unmarshal([]byte(issue.Metadata), &issueMetadata); err != nil {
-			return fmt.Errorf("parse issue metadata: %w", err)
-		}
-		if issueMetadata == nil {
-			issueMetadata = make(map[string]json.RawMessage)
-		}
-		scheduledOn, _ := json.Marshal(*firstOccurrence)
-		issueMetadata["scheduled_on"] = scheduledOn
-		updatedMetadata, err := json.Marshal(issueMetadata)
+		updatedMetadata, err := db.ComposeRecurrenceIssueMetadata(
+			json.RawMessage(issue.Metadata), *firstOccurrence, create.Timezone,
+		)
 		if err != nil {
-			return fmt.Errorf("marshal issue metadata: %w", err)
+			return fmt.Errorf("compose initial recurrence issue metadata: %w", err)
 		}
 		updatedAt := nowStoredTimestamp()
 		if _, err := tx.ExecContext(ctx, `UPDATE issues SET recurrence_id=$1, occurrence_key=$2,
@@ -582,18 +575,11 @@ func (s *Store) materializeOccurrenceTx(
 	occurrenceKey string,
 	actor string,
 ) (db.MaterializeNextOut, error) {
-	var metadata map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(current.TemplateMetadata), &metadata); err != nil {
-		return db.MaterializeNextOut{}, fmt.Errorf("parse template_metadata: %w", err)
-	}
-	if metadata == nil {
-		metadata = make(map[string]json.RawMessage)
-	}
-	scheduledOn, _ := json.Marshal(occurrenceKey)
-	metadata["scheduled_on"] = scheduledOn
-	issueMetadata, err := json.Marshal(metadata)
+	issueMetadata, err := db.ComposeRecurrenceIssueMetadata(
+		json.RawMessage(current.TemplateMetadata), occurrenceKey, current.Timezone,
+	)
 	if err != nil {
-		return db.MaterializeNextOut{}, fmt.Errorf("marshal issue metadata: %w", err)
+		return db.MaterializeNextOut{}, fmt.Errorf("compose recurrence issue metadata: %w", err)
 	}
 	issueUID, err := katauid.New()
 	if err != nil {

--- a/internal/db/pgstore/ui.go
+++ b/internal/db/pgstore/ui.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/metadata"
 )
 
 var _ db.UIStore = (*Store)(nil)
@@ -356,7 +357,7 @@ func readUIProjectStats(ctx context.Context, tx *sql.Tx) (map[int64]db.ProjectSt
 func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 	projectNames map[int64]string,
 ) ([]db.UIIssue, error) {
-	statement := issueSelect + ` WHERE i.deleted_at IS NULL AND p.deleted_at IS NULL AND p.name <> $1`
+	statement := scheduledIssueSelect + ` WHERE i.deleted_at IS NULL AND p.deleted_at IS NULL AND p.name <> $1`
 	args := []any{db.SystemProjectName}
 	if query.ProjectUID != "" {
 		args = append(args, query.ProjectUID)
@@ -371,21 +372,18 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 			statuses = []string{"closed"}
 		}
 	}
+	filterReadySchedules := false
+	filterCalendarSchedules := query.View == "today" || query.View == "upcoming"
 	if len(statuses) > 0 && !slices.Contains(statuses, "all") {
 		statusPredicates := []string{}
 		persistedStatuses := []string{}
+		readyRequested := false
 		for _, status := range statuses {
 			if status == "ready" {
-				readyDate := query.ReadyDate
-				if readyDate == "" {
-					readyDate = time.Now().UTC().Format(time.DateOnly)
-				}
-				args = append(args, readyDate)
-				statusPredicates = append(statusPredicates, fmt.Sprintf(`(
+				readyRequested = true
+				statusPredicates = append(statusPredicates, `(
 					i.status = 'open'
 					AND COALESCE((i.metadata::jsonb ->> 'someday')::boolean, false) = false
-					AND (i.metadata::jsonb ->> 'scheduled_on' IS NULL
-						OR i.metadata::jsonb ->> 'scheduled_on' <= $%d)
 					AND NOT EXISTS (
 						SELECT 1 FROM links ready_link
 						JOIN issues blocker ON blocker.id = ready_link.from_issue_id
@@ -394,11 +392,12 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 						AND blocker.status = 'open' AND blocker.deleted_at IS NULL
 						AND blocker_project.deleted_at IS NULL
 					)
-				)`, len(args)))
+				)`)
 			} else {
 				persistedStatuses = append(persistedStatuses, status)
 			}
 		}
+		filterReadySchedules = readyRequested && !slices.Contains(persistedStatuses, "open")
 		if len(persistedStatuses) > 0 {
 			statusPredicates = append(statusPredicates, `i.status IN (`+uiPostgresArgs(&args, persistedStatuses)+`)`)
 		}
@@ -408,12 +407,11 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 	case "inbox":
 		statement += ` AND p.metadata::jsonb ->> 'role' = 'inbox'`
 	case "today":
-		args = append(args, query.LocalDate, query.LocalDate)
-		statement += fmt.Sprintf(` AND (LEFT(i.metadata::jsonb ->> 'scheduled_on', 10) <= $%d`+
-			` OR LEFT(i.metadata::jsonb ->> 'deadline_on', 10) <= $%d)`, len(args)-1, len(args))
-	case "upcoming":
 		args = append(args, query.LocalDate)
-		statement += fmt.Sprintf(` AND LEFT(i.metadata::jsonb ->> 'scheduled_on', 10) > $%d`, len(args))
+		statement += fmt.Sprintf(` AND (i.metadata::jsonb ->> 'scheduled_on' IS NOT NULL`+
+			` OR LEFT(i.metadata::jsonb ->> 'deadline_on', 10) <= $%d)`, len(args))
+	case "upcoming":
+		statement += ` AND i.metadata::jsonb ->> 'scheduled_on' IS NOT NULL`
 	case "deadlines":
 		statement += ` AND i.metadata::jsonb ->> 'deadline_on' IS NOT NULL`
 	}
@@ -441,7 +439,7 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 		limit = 1000
 	}
 	statement += ` ORDER BY i.updated_at DESC, i.id DESC`
-	if limit > 0 {
+	if limit > 0 && !filterReadySchedules && !filterCalendarSchedules {
 		args = append(args, limit)
 		statement += fmt.Sprintf(` LIMIT $%d`, len(args)) // #nosec G202 -- only a generated placeholder number is interpolated.
 	}
@@ -450,13 +448,53 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 		return nil, fmt.Errorf("read UI issues: %w", mapSQLError(err, nil))
 	}
 	issues := []db.UIIssue{}
+	readyAt := time.Now()
+	if filterReadySchedules && query.ReadyAt != "" {
+		var err error
+		readyAt, err = time.Parse(time.RFC3339Nano, query.ReadyAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse UI ready_at: %w", err)
+		}
+	}
 	for rows.Next() {
-		issue, err := scanIssue(rows)
+		issue, recurrenceTimezone, err := scanScheduledIssue(rows)
 		if err != nil {
 			_ = rows.Close()
 			return nil, err
 		}
-		issues = append(issues, makeUIIssue(issue, projectNames[issue.ProjectID], nil))
+		if filterReadySchedules && issue.Status == "open" {
+			due, err := metadata.ScheduledOnDue(
+				string(issue.Metadata), readyAt,
+				scheduleDefaultTimezone(recurrenceTimezone, query.DefaultTimezone),
+			)
+			if err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("read UI issue %s schedule: %w", issue.UID, err)
+			}
+			if !due {
+				continue
+			}
+		}
+		scheduledOnDate := ""
+		if filterCalendarSchedules {
+			var matches bool
+			scheduleQuery := query
+			scheduleQuery.DefaultTimezone = scheduleDefaultTimezone(recurrenceTimezone, query.DefaultTimezone)
+			scheduledOnDate, matches, err = db.MatchUICalendarView(string(issue.Metadata), scheduleQuery)
+			if err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("read UI issue %s calendar schedule: %w", issue.UID, err)
+			}
+			if !matches {
+				continue
+			}
+		}
+		uiIssue := makeUIIssue(issue, projectNames[issue.ProjectID], nil)
+		uiIssue.ScheduledOnDate = scheduledOnDate
+		issues = append(issues, uiIssue)
+		if limit > 0 && len(issues) == limit {
+			break
+		}
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()

--- a/internal/db/recurrence.go
+++ b/internal/db/recurrence.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"go.kenn.io/kata/internal/metadata"
 	"go.kenn.io/kata/internal/recurrence"
 )
 
@@ -39,15 +40,81 @@ func ValidateRecurrenceTemplate(title string, metadata json.RawMessage) error {
 	if strings.TrimSpace(title) == "" {
 		return fmt.Errorf("%w: template_title must be non-empty", ErrInvalidRecurrence)
 	}
-	if len(metadata) == 0 {
-		return nil
+	_, err := validatedRecurrenceTemplateMetadata(metadata)
+	return err
+}
+
+// ComposeRecurrenceIssueMetadata stamps the occurrence's civil date and
+// authoritative IANA timezone before validating the resulting issue metadata.
+// The order preserves compatibility with templates written by older versions:
+// obsolete values in these two generated fields cannot block materialization.
+func ComposeRecurrenceIssueMetadata(
+	templateMetadata json.RawMessage,
+	occurrenceKey string,
+	timezone string,
+) (json.RawMessage, error) {
+	object, err := decodeRecurrenceTemplateMetadata(templateMetadata)
+	if err != nil {
+		return nil, err
+	}
+	scheduledOn, err := json.Marshal(occurrenceKey)
+	if err != nil {
+		return nil, fmt.Errorf("marshal recurrence scheduled_on: %w", err)
+	}
+	timezoneValue, err := json.Marshal(timezone)
+	if err != nil {
+		return nil, fmt.Errorf("marshal recurrence timezone: %w", err)
+	}
+	object["scheduled_on"] = scheduledOn
+	object["timezone"] = timezoneValue
+	if err := validateRecurrenceTemplateMetadataObject(object); err != nil {
+		return nil, err
+	}
+	value, err := json.Marshal(object)
+	if err != nil {
+		return nil, fmt.Errorf("marshal recurrence issue metadata: %w", err)
+	}
+	return value, nil
+}
+
+func validatedRecurrenceTemplateMetadata(value json.RawMessage) (map[string]json.RawMessage, error) {
+	object, err := decodeRecurrenceTemplateMetadata(value)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRecurrenceTemplateMetadataObject(object); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+func decodeRecurrenceTemplateMetadata(value json.RawMessage) (map[string]json.RawMessage, error) {
+	if len(value) == 0 {
+		return map[string]json.RawMessage{}, nil
 	}
 	var object map[string]json.RawMessage
-	if err := json.Unmarshal(metadata, &object); err != nil {
-		return fmt.Errorf("%w: template_metadata must be a JSON object: %v", ErrInvalidRecurrence, err)
+	if err := json.Unmarshal(value, &object); err != nil {
+		return nil, fmt.Errorf("%w: template_metadata must be a JSON object: %v", ErrInvalidRecurrence, err)
 	}
 	if object == nil {
-		return fmt.Errorf("%w: template_metadata must be a JSON object, got null", ErrInvalidRecurrence)
+		return nil, fmt.Errorf("%w: template_metadata must be a JSON object, got null", ErrInvalidRecurrence)
+	}
+	return object, nil
+}
+
+func validateRecurrenceTemplateMetadataObject(object map[string]json.RawMessage) error {
+	keys := make([]string, 0, len(object))
+	for key := range object {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if _, reserved := metadata.IssueRegistry[key]; !reserved {
+			continue
+		}
+		if err := metadata.ValidateCreateValue(metadata.IssueRegistry, key, object[key]); err != nil {
+			return fmt.Errorf("%w: template_metadata %q: %v", ErrInvalidRecurrence, key, err)
+		}
 	}
 	return nil
 }

--- a/internal/db/recurrence_test.go
+++ b/internal/db/recurrence_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRecurrenceTemplateValidatesReservedMetadata(t *testing.T) {
+	err := ValidateRecurrenceTemplate("Review", json.RawMessage(`{"timezone":"Not/AZone"}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidRecurrence)
+	assert.Contains(t, err.Error(), `template_metadata "timezone"`)
+
+	assert.NoError(t, ValidateRecurrenceTemplate(
+		"Review",
+		json.RawMessage(`{"timezone":"America/New_York","custom":{"enabled":true}}`),
+	))
+}
+
+func TestComposeRecurrenceIssueMetadataStampsScheduleTimezone(t *testing.T) {
+	value, err := ComposeRecurrenceIssueMetadata(
+		json.RawMessage(`{"kind":"weekly","timezone":"Not/AZone","scheduled_on":"not-a-date"}`),
+		"2026-05-18",
+		"America/New_York",
+	)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"kind":"weekly",
+		"scheduled_on":"2026-05-18",
+		"timezone":"America/New_York"
+	}`, string(value))
+}
+
+func TestComposeRecurrenceIssueMetadataDefensivelyRejectsInvalidReservedValue(t *testing.T) {
+	_, err := ComposeRecurrenceIssueMetadata(
+		json.RawMessage(`{"deadline_on":"not-a-date"}`),
+		"2026-05-18",
+		"America/New_York",
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidRecurrence)
+}

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -1809,7 +1809,14 @@ func lookupIssueForEvent(ctx context.Context, tx *sql.Tx, issueID int64) (db.Iss
 	return i, projectName, nil
 }
 
-const issueSelect = `SELECT i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status, i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision, i.recurrence_id, i.occurrence_key, i.created_at, i.updated_at, i.closed_at, i.deleted_at FROM issues i JOIN projects p ON p.id = i.project_id`
+const issueColumns = `i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status, i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision, i.recurrence_id, i.occurrence_key, i.created_at, i.updated_at, i.closed_at, i.deleted_at`
+
+const issueSelect = `SELECT ` + issueColumns + ` FROM issues i JOIN projects p ON p.id = i.project_id`
+
+const scheduledIssueSelect = `SELECT ` + issueColumns + `, schedule_recurrence.timezone
+	FROM issues i
+	JOIN projects p ON p.id = i.project_id
+	LEFT JOIN recurrences schedule_recurrence ON schedule_recurrence.id = i.recurrence_id`
 
 func scanIssue(r rowScanner) (db.Issue, error) {
 	var i db.Issue
@@ -1821,6 +1828,19 @@ func scanIssue(r rowScanner) (db.Issue, error) {
 		return db.Issue{}, fmt.Errorf("scan issue: %w", err)
 	}
 	return i, nil
+}
+
+func scanScheduledIssue(r rowScanner) (db.Issue, string, error) {
+	var i db.Issue
+	var recurrenceTimezone sql.NullString
+	err := r.Scan(&i.ID, &i.UID, &i.ProjectID, &i.ProjectUID, &i.ShortID, &i.Title, &i.Body, &i.Status, &i.ClosedReason, &i.Owner, &i.Priority, &i.Author, &i.Metadata, &i.Revision, &i.RecurrenceID, &i.OccurrenceKey, &i.CreatedAt, &i.UpdatedAt, &i.ClosedAt, &i.DeletedAt, &recurrenceTimezone)
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.Issue{}, "", db.ErrNotFound
+	}
+	if err != nil {
+		return db.Issue{}, "", fmt.Errorf("scan scheduled issue: %w", err)
+	}
+	return i, recurrenceTimezone.String, nil
 }
 
 // eventInsert is the tx-internal payload used by insertEventTx.
@@ -2041,17 +2061,16 @@ func (d *Store) claimOwner(ctx context.Context, issueID int64, actor string, for
 
 // ReadyIssues returns actionable open issues with no open `blocks` predecessor,
 // ordered by updated_at DESC. Issues marked someday=true or scheduled after
-// today's UTC date are parked and excluded. limit==0 means no limit. Blockers
-// may live in another project (links span projects, storage v16), but a blocker
-// whose project is archived (projects.deleted_at IS NOT NULL) does not gate
-// readiness — mirroring the child/close queries' archived-project exclusion,
-// so an active issue is not stranded behind hidden archived work.
+// their effective local date or instant are parked and excluded. limit==0 means
+// no limit. Blockers may live in another project (links span projects, storage
+// v16), but a blocker whose project is archived (projects.deleted_at IS NOT
+// NULL) does not gate readiness — mirroring the child/close queries'
+// archived-project exclusion, so an active issue is not stranded behind hidden
+// archived work.
 func (d *Store) ReadyIssues(ctx context.Context, projectID int64, limit int, filter db.ReadyIssuesFilter) ([]db.Issue, error) {
-	q := issueSelect + `
+	q := scheduledIssueSelect + `
 		WHERE i.project_id = ? AND i.status = 'open' AND i.deleted_at IS NULL
 		  AND COALESCE(json_extract(i.metadata, '$.someday'), 0) != 1
-		  AND (json_extract(i.metadata, '$.scheduled_on') IS NULL
-		       OR json_extract(i.metadata, '$.scheduled_on') <= ?)
 		  AND NOT EXISTS (
 		    SELECT 1 FROM links l
 		    JOIN issues blocker ON blocker.id = l.from_issue_id
@@ -2060,7 +2079,7 @@ func (d *Store) ReadyIssues(ctx context.Context, projectID int64, limit int, fil
 		      AND blocker.status = 'open' AND blocker.deleted_at IS NULL
 		      AND bp.deleted_at IS NULL
 		  )`
-	args := []any{projectID, time.Now().UTC().Format(time.DateOnly)}
+	args := []any{projectID}
 
 	// Apply owner filters
 	if filter.Unowned {
@@ -2083,21 +2102,34 @@ func (d *Store) ReadyIssues(ctx context.Context, projectID int64, limit int, fil
 	}
 
 	q += ` ORDER BY i.updated_at DESC, i.id DESC`
-	if limit > 0 {
-		q += fmt.Sprintf(` LIMIT %d`, limit)
-	}
 	rows, err := d.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("ready issues: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	var out []db.Issue
+	at := filter.At
+	if at.IsZero() {
+		at = time.Now()
+	}
 	for rows.Next() {
-		i, err := scanIssue(rows)
+		i, recurrenceTimezone, err := scanScheduledIssue(rows)
 		if err != nil {
 			return nil, err
 		}
+		due, err := metadata.ScheduledOnDue(
+			string(i.Metadata), at, scheduleDefaultTimezone(recurrenceTimezone, filter.DefaultTimezone),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("ready issue %s schedule: %w", i.UID, err)
+		}
+		if !due {
+			continue
+		}
 		out = append(out, i)
+		if limit > 0 && len(out) == limit {
+			break
+		}
 	}
 	return out, rows.Err()
 }
@@ -2110,14 +2142,15 @@ func (d *Store) ReadyIssues(ctx context.Context, projectID int64, limit int, fil
 // readiness. Ordering and filter semantics match ReadyIssues so behavior is
 // consistent.
 func (d *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.ReadyIssuesFilter) ([]db.ReadyGlobalIssue, error) {
-	// issueSelect ends with "FROM issues i JOIN projects p ON p.id = i.project_id"
-	// We need to add p.name before FROM, so we build the SELECT from scratch.
-	q := `SELECT i.id, i.uid, i.project_id, p.uid, i.short_id, i.title, i.body, i.status, i.closed_reason, i.owner, i.priority, i.author, i.metadata, i.revision, i.recurrence_id, i.occurrence_key, i.created_at, i.updated_at, i.closed_at, i.deleted_at, p.name AS project_name FROM issues i JOIN projects p ON p.id = i.project_id
+	// The global row also carries the project name and linked recurrence
+	// timezone, so build this projection from the shared issue columns.
+	q := `SELECT ` + issueColumns + `, p.name AS project_name, schedule_recurrence.timezone
+		FROM issues i
+		JOIN projects p ON p.id = i.project_id
+		LEFT JOIN recurrences schedule_recurrence ON schedule_recurrence.id = i.recurrence_id
 		WHERE i.status = 'open' AND i.deleted_at IS NULL
 		  AND p.deleted_at IS NULL
 		  AND COALESCE(json_extract(i.metadata, '$.someday'), 0) != 1
-		  AND (json_extract(i.metadata, '$.scheduled_on') IS NULL
-		       OR json_extract(i.metadata, '$.scheduled_on') <= ?)
 		  AND NOT EXISTS (
 		    SELECT 1 FROM links l
 		    JOIN issues blocker ON blocker.id = l.from_issue_id
@@ -2126,7 +2159,7 @@ func (d *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.Read
 		      AND blocker.status = 'open' AND blocker.deleted_at IS NULL
 		      AND bp.deleted_at IS NULL
 		  )`
-	args := []any{time.Now().UTC().Format(time.DateOnly)}
+	args := []any{}
 
 	// Apply owner filters (same semantics as ReadyIssues)
 	if filter.Unowned {
@@ -2149,30 +2182,51 @@ func (d *Store) ReadyIssuesGlobal(ctx context.Context, limit int, filter db.Read
 	}
 
 	q += ` ORDER BY i.updated_at DESC, i.id DESC`
-	if limit > 0 {
-		q += fmt.Sprintf(` LIMIT %d`, limit)
-	}
 	rows, err := d.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("ready issues global: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	var out []db.ReadyGlobalIssue
+	at := filter.At
+	if at.IsZero() {
+		at = time.Now()
+	}
 	for rows.Next() {
 		var r db.ReadyGlobalIssue
+		var recurrenceTimezone sql.NullString
 		if err := rows.Scan(
 			&r.ID, &r.UID, &r.ProjectID, &r.ProjectUID,
 			&r.ShortID, &r.Title, &r.Body, &r.Status,
 			&r.ClosedReason, &r.Owner, &r.Priority, &r.Author,
 			&r.Metadata, &r.Revision, &r.RecurrenceID, &r.OccurrenceKey,
 			&r.CreatedAt, &r.UpdatedAt, &r.ClosedAt, &r.DeletedAt,
-			&r.ProjectName,
+			&r.ProjectName, &recurrenceTimezone,
 		); err != nil {
 			return nil, fmt.Errorf("scan ready global issue: %w", err)
 		}
+		due, err := metadata.ScheduledOnDue(
+			string(r.Metadata), at, scheduleDefaultTimezone(recurrenceTimezone.String, filter.DefaultTimezone),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("ready global issue %s schedule: %w", r.UID, err)
+		}
+		if !due {
+			continue
+		}
 		out = append(out, r)
+		if limit > 0 && len(out) == limit {
+			break
+		}
 	}
 	return out, rows.Err()
+}
+
+func scheduleDefaultTimezone(recurrenceTimezone, daemonTimezone string) string {
+	if recurrenceTimezone != "" {
+		return recurrenceTimezone
+	}
+	return daemonTimezone
 }
 
 func (d *Store) insertEventTx(ctx context.Context, tx *sql.Tx, in eventInsert) (db.Event, error) {

--- a/internal/db/sqlitestore/queries_ready_test.go
+++ b/internal/db/sqlitestore/queries_ready_test.go
@@ -2,13 +2,44 @@ package sqlitestore_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/sqlitestore"
 )
+
+func TestReadyIssuesAppliesScheduleBeforeLimit(t *testing.T) {
+	d, ctx, p := setupTestProject(t)
+	due := makeIssue(t, ctx, d, p.ID, "due in Tokyo", "tester")
+	parked := makeIssue(t, ctx, d, p.ID, "parked in Los Angeles", "tester")
+	for _, fixture := range []struct {
+		issueID int64
+		raw     string
+	}{
+		{issueID: due.ID, raw: `{"scheduled_on":"2026-09-01T09:00","timezone":"Asia/Tokyo"}`},
+		{issueID: parked.ID, raw: `{"scheduled_on":"2026-09-01T09:00","timezone":"America/Los_Angeles"}`},
+	} {
+		var patch map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(fixture.raw), &patch))
+		_, err := d.PatchIssueMetadata(ctx, db.PatchIssueMetadataIn{
+			IssueID: fixture.issueID,
+			Actor:   "tester",
+			Patch:   patch,
+		})
+		require.NoError(t, err)
+	}
+
+	rows, err := d.ReadyIssues(ctx, p.ID, 1, db.ReadyIssuesFilter{
+		At: time.Date(2026, 9, 1, 0, 30, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, due.ID, rows[0].ID)
+}
 
 func TestReadyIssues_FiltersOutClosed(t *testing.T) {
 	d, ctx, p := setupTestProject(t)

--- a/internal/db/sqlitestore/store_recurrences.go
+++ b/internal/db/sqlitestore/store_recurrences.go
@@ -211,18 +211,11 @@ func (d *Store) createRecurrenceForIssue(
 	if err != nil {
 		return out, fmt.Errorf("walk after initial occurrence: %w", err)
 	}
-	var issueMetadata map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(metadataJSON), &issueMetadata); err != nil {
-		return out, fmt.Errorf("parse issue metadata: %w", err)
-	}
-	if issueMetadata == nil {
-		issueMetadata = map[string]json.RawMessage{}
-	}
-	scheduledOn, _ := json.Marshal(*requireFirst)
-	issueMetadata["scheduled_on"] = scheduledOn
-	updatedMetadata, err := json.Marshal(issueMetadata)
+	updatedMetadata, err := db.ComposeRecurrenceIssueMetadata(
+		json.RawMessage(metadataJSON), *requireFirst, rec.Timezone,
+	)
 	if err != nil {
-		return out, fmt.Errorf("marshal issue metadata: %w", err)
+		return out, fmt.Errorf("compose initial recurrence issue metadata: %w", err)
 	}
 	updatedAt := nowTimestamp()
 	if _, err := tx.ExecContext(ctx, `UPDATE issues
@@ -779,19 +772,11 @@ func (d *Store) materializeNextTx(
 	}
 	nextKey := *next
 
-	// Compose new issue metadata: template_metadata merged with scheduled_on.
-	var tmplMeta map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(r.TemplateMetadata), &tmplMeta); err != nil {
-		return out, fmt.Errorf("parse template_metadata: %w", err)
-	}
-	if tmplMeta == nil {
-		tmplMeta = map[string]json.RawMessage{}
-	}
-	scheduledJSON, _ := json.Marshal(nextKey)
-	tmplMeta["scheduled_on"] = scheduledJSON
-	issueMetadata, err := json.Marshal(tmplMeta)
+	issueMetadata, err := db.ComposeRecurrenceIssueMetadata(
+		json.RawMessage(r.TemplateMetadata), nextKey, r.Timezone,
+	)
 	if err != nil {
-		return out, fmt.Errorf("marshal issue metadata: %w", err)
+		return out, fmt.Errorf("compose recurrence issue metadata: %w", err)
 	}
 
 	newUID, err := katauid.New()

--- a/internal/db/sqlitestore/store_recurrences_test.go
+++ b/internal/db/sqlitestore/store_recurrences_test.go
@@ -335,3 +335,28 @@ func TestMaterializeNext_NormalizesLegacyDuplicateLabels(t *testing.T) {
 	assert.Equal(t, rec.UID, payload.RecurrenceUID)
 	assert.Equal(t, "2026-05-22", payload.OccurrenceKey)
 }
+
+func TestMaterializeNext_ReplacesLegacyGeneratedMetadataBeforeValidation(t *testing.T) {
+	d, ctx, p, rec := setupRecurrence(t, db.CreateRecurrenceIn{
+		Rule: "FREQ=WEEKLY", DTStart: "2026-05-15", Timezone: "America/New_York",
+		Template: db.RecurrenceTemplate{Title: "legacy template"},
+	})
+	_, err := d.ExecContext(ctx,
+		`UPDATE recurrences SET template_metadata = ? WHERE id = ?`,
+		`{"scheduled_on":"not-a-date","timezone":"Not/AZone","kind":"weekly"}`, rec.ID)
+	require.NoError(t, err)
+
+	firstID, _ := seedRecurrenceInstance(t, d, p.ID, rec.ID, "2026-05-15", "legacy template")
+	_, _, _, err = d.CloseIssue(ctx, firstID, "done", "tester", "", nil)
+	require.NoError(t, err)
+
+	var rawMetadata string
+	require.NoError(t, d.QueryRowContext(ctx, `
+		SELECT metadata FROM issues WHERE recurrence_id = ? AND occurrence_key = ?`,
+		rec.ID, "2026-05-22").Scan(&rawMetadata))
+	assert.JSONEq(t, `{
+		"scheduled_on":"2026-05-22",
+		"timezone":"America/New_York",
+		"kind":"weekly"
+	}`, rawMetadata)
+}

--- a/internal/db/sqlitestore/ui.go
+++ b/internal/db/sqlitestore/ui.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/metadata"
 )
 
 var _ db.UIStore = (*Store)(nil)
@@ -349,7 +350,7 @@ func readUIIssues(
 	query db.UISnapshotQuery,
 	projectNames map[int64]string,
 ) ([]db.UIIssue, error) {
-	statement := issueSelect + ` WHERE i.deleted_at IS NULL AND p.deleted_at IS NULL AND p.name <> ?`
+	statement := scheduledIssueSelect + ` WHERE i.deleted_at IS NULL AND p.deleted_at IS NULL AND p.name <> ?`
 	args := []any{db.SystemProjectName}
 	if query.ProjectUID != "" {
 		statement += ` AND p.uid = ?`
@@ -364,21 +365,18 @@ func readUIIssues(
 			statuses = []string{"closed"}
 		}
 	}
+	filterReadySchedules := false
+	filterCalendarSchedules := query.View == "today" || query.View == "upcoming"
 	if len(statuses) > 0 && !slices.Contains(statuses, "all") {
 		statusPredicates := []string{}
 		persistedStatuses := []string{}
+		readyRequested := false
 		for _, status := range statuses {
 			if status == "ready" {
-				readyDate := query.ReadyDate
-				if readyDate == "" {
-					readyDate = time.Now().UTC().Format(time.DateOnly)
-				}
-				args = append(args, readyDate)
+				readyRequested = true
 				statusPredicates = append(statusPredicates, `(
 					i.status = 'open'
 					AND COALESCE(json_extract(i.metadata, '$.someday'), 0) != 1
-					AND (json_extract(i.metadata, '$.scheduled_on') IS NULL
-						OR json_extract(i.metadata, '$.scheduled_on') <= ?)
 					AND NOT EXISTS (
 						SELECT 1 FROM links ready_link
 						JOIN issues blocker ON blocker.id = ready_link.from_issue_id
@@ -392,6 +390,7 @@ func readUIIssues(
 				persistedStatuses = append(persistedStatuses, status)
 			}
 		}
+		filterReadySchedules = readyRequested && !slices.Contains(persistedStatuses, "open")
 		if len(persistedStatuses) > 0 {
 			statusPredicates = append(statusPredicates, `i.status IN (`+uiSQLitePlaceholders(len(persistedStatuses))+`)`)
 			for _, status := range persistedStatuses {
@@ -404,12 +403,11 @@ func readUIIssues(
 	case "inbox":
 		statement += ` AND json_extract(p.metadata, '$.role') = 'inbox'`
 	case "today":
-		statement += ` AND (substr(json_extract(i.metadata, '$.scheduled_on'), 1, 10) <= ?` +
+		statement += ` AND (json_extract(i.metadata, '$.scheduled_on') IS NOT NULL` +
 			` OR substr(json_extract(i.metadata, '$.deadline_on'), 1, 10) <= ?)`
-		args = append(args, query.LocalDate, query.LocalDate)
-	case "upcoming":
-		statement += ` AND substr(json_extract(i.metadata, '$.scheduled_on'), 1, 10) > ?`
 		args = append(args, query.LocalDate)
+	case "upcoming":
+		statement += ` AND json_extract(i.metadata, '$.scheduled_on') IS NOT NULL`
 	case "deadlines":
 		statement += ` AND json_extract(i.metadata, '$.deadline_on') IS NOT NULL`
 	}
@@ -444,7 +442,7 @@ func readUIIssues(
 		limit = 1000
 	}
 	statement += ` ORDER BY i.updated_at DESC, i.id DESC`
-	if limit > 0 {
+	if limit > 0 && !filterReadySchedules && !filterCalendarSchedules {
 		statement += ` LIMIT ?`
 		args = append(args, limit)
 	}
@@ -454,12 +452,50 @@ func readUIIssues(
 	}
 	defer func() { _ = rows.Close() }()
 	issues := []db.UIIssue{}
+	readyAt := time.Now()
+	if filterReadySchedules && query.ReadyAt != "" {
+		var err error
+		readyAt, err = time.Parse(time.RFC3339Nano, query.ReadyAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse UI ready_at: %w", err)
+		}
+	}
 	for rows.Next() {
-		issue, err := scanIssue(rows)
+		issue, recurrenceTimezone, err := scanScheduledIssue(rows)
 		if err != nil {
 			return nil, err
 		}
-		issues = append(issues, makeUIIssue(issue, projectNames[issue.ProjectID], nil))
+		if filterReadySchedules && issue.Status == "open" {
+			due, err := metadata.ScheduledOnDue(
+				string(issue.Metadata), readyAt,
+				scheduleDefaultTimezone(recurrenceTimezone, query.DefaultTimezone),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("read UI issue %s schedule: %w", issue.UID, err)
+			}
+			if !due {
+				continue
+			}
+		}
+		scheduledOnDate := ""
+		if filterCalendarSchedules {
+			var matches bool
+			scheduleQuery := query
+			scheduleQuery.DefaultTimezone = scheduleDefaultTimezone(recurrenceTimezone, query.DefaultTimezone)
+			scheduledOnDate, matches, err = db.MatchUICalendarView(string(issue.Metadata), scheduleQuery)
+			if err != nil {
+				return nil, fmt.Errorf("read UI issue %s calendar schedule: %w", issue.UID, err)
+			}
+			if !matches {
+				continue
+			}
+		}
+		uiIssue := makeUIIssue(issue, projectNames[issue.ProjectID], nil)
+		uiIssue.ScheduledOnDate = scheduledOnDate
+		issues = append(issues, uiIssue)
+		if limit > 0 && len(issues) == limit {
+			break
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate UI issues: %w", err)

--- a/internal/db/ui.go
+++ b/internal/db/ui.go
@@ -1,6 +1,12 @@
 package db
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"go.kenn.io/kata/internal/metadata"
+)
 
 // UIStore is the narrow coherent-read contract used by the browser API.
 type UIStore interface {
@@ -26,11 +32,12 @@ type UISnapshotQuery struct {
 	IncludeHistory   bool
 	LocalDate        string
 	TimeZone         string
-	// ReadyDate is the daemon-selected UTC date used by the synthetic ready
-	// status. It is part of the snapshot cache identity so ready membership can
-	// change at midnight without a database event.
-	ReadyDate string
-	Limit     int
+	// ReadyAt is the daemon-selected time used by the synthetic ready status.
+	// It is part of the snapshot cache identity so timed readiness can change
+	// without a database event.
+	ReadyAt         string
+	DefaultTimezone string
+	Limit           int
 	// ReuseAuthorityCursor asks the store to omit catalog and collection rows
 	// only when its consistent read observes this exact durable cursor.
 	ReuseAuthorityCursor *int64
@@ -45,9 +52,38 @@ type UIProject struct {
 // UIIssue is an issue plus the display identity and labels needed by the SPA.
 type UIIssue struct {
 	Issue
-	ProjectName string   `json:"project_name"`
-	QualifiedID string   `json:"qualified_id"`
-	Labels      []string `json:"labels"`
+	ProjectName     string   `json:"project_name"`
+	QualifiedID     string   `json:"qualified_id"`
+	Labels          []string `json:"labels"`
+	ScheduledOnDate string   `json:"scheduled_on_date,omitempty"`
+}
+
+// MatchUICalendarView evaluates date-sensitive browser collection predicates
+// after a schedule has been projected into the browser timezone. The returned
+// date is also the canonical grouping key sent to the browser.
+func MatchUICalendarView(raw string, query UISnapshotQuery) (string, bool, error) {
+	scheduledDate, scheduled, err := metadata.ScheduledOnCalendarDate(
+		raw, query.TimeZone, query.DefaultTimezone,
+	)
+	if err != nil {
+		return "", false, err
+	}
+	switch query.View {
+	case "upcoming":
+		return scheduledDate, scheduled && scheduledDate > query.LocalDate, nil
+	case "today":
+		var values struct {
+			DeadlineOn string `json:"deadline_on"`
+		}
+		if err := json.Unmarshal([]byte(raw), &values); err != nil {
+			return "", false, fmt.Errorf("decode UI calendar metadata: %w", err)
+		}
+		scheduleDue := scheduled && scheduledDate <= query.LocalDate
+		deadlineDue := values.DeadlineOn != "" && values.DeadlineOn <= query.LocalDate
+		return scheduledDate, scheduleDue || deadlineDue, nil
+	default:
+		return "", true, nil
+	}
 }
 
 // UILink enriches a stored link with stable display references for each end.

--- a/internal/metadata/registry.go
+++ b/internal/metadata/registry.go
@@ -23,6 +23,7 @@ const (
 	TypeString                   // free-form string
 	TypeChecklist                // array of {id: ULID, text: string, done: bool}
 	TypeTimezoneIANA             // IANA timezone string
+	TypeSchedule                 // date, local date-time, or UTC instant
 )
 
 // Entry describes one server-reserved metadata key.
@@ -33,7 +34,7 @@ type Entry struct {
 // IssueRegistry is the set of server-reserved keys for issues.metadata.
 // Keys outside this set are accepted opaquely by Validate.
 var IssueRegistry = map[string]Entry{
-	"scheduled_on": {Type: TypeDate},
+	"scheduled_on": {Type: TypeSchedule},
 	"deadline_on":  {Type: TypeDate},
 	"someday":      {Type: TypeBool},
 	"checklist":    {Type: TypeChecklist},

--- a/internal/metadata/scheduled.go
+++ b/internal/metadata/scheduled.go
@@ -1,0 +1,225 @@
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type scheduledOnKind int
+
+const (
+	scheduledOnDate scheduledOnKind = iota
+	scheduledOnLocalTime
+	scheduledOnInstant
+)
+
+const (
+	localMinuteLayout = "2006-01-02T15:04"
+	localSecondLayout = "2006-01-02T15:04:05"
+)
+
+type scheduleMetadata struct {
+	ScheduledOn *string `json:"scheduled_on"`
+	Timezone    string  `json:"timezone"`
+}
+
+// ScheduledOnDue reports whether metadata's scheduled_on gate has opened.
+// A date or local date-time uses the issue timezone, then the daemon timezone,
+// then UTC. A UTC value ending in Z is an instant and ignores those zones.
+func ScheduledOnDue(raw string, now time.Time, defaultTimezone string) (bool, error) {
+	if len(raw) == 0 {
+		return true, nil
+	}
+	values, err := decodeScheduleMetadata(raw)
+	if err != nil {
+		return false, err
+	}
+	if values.ScheduledOn == nil {
+		return true, nil
+	}
+
+	scheduledOn := *values.ScheduledOn
+	kind, layout, instant, err := classifyScheduledOn(scheduledOn)
+	if err != nil {
+		return false, err
+	}
+	if kind == scheduledOnDate || kind == scheduledOnLocalTime {
+		location, err := loadScheduleLocation(values.Timezone, defaultTimezone)
+		if err != nil {
+			return false, err
+		}
+		if kind == scheduledOnDate {
+			return scheduledOn <= now.In(location).Format(layout), nil
+		}
+		resolved, err := resolveLocalSchedule(scheduledOn, layout, location)
+		if err != nil {
+			return false, err
+		}
+		return !now.Before(resolved), nil
+	}
+	return !now.Before(instant), nil
+}
+
+// ScheduledOnCalendarDate returns the display calendar date for scheduled_on.
+// Date-only values keep their written civil date. Local date-times are first
+// resolved in the issue or daemon timezone, while UTC values are already
+// instants; both timed forms are then projected into displayTimezone.
+func ScheduledOnCalendarDate(
+	raw string,
+	displayTimezone string,
+	defaultTimezone string,
+) (string, bool, error) {
+	if len(raw) == 0 {
+		return "", false, nil
+	}
+	values, err := decodeScheduleMetadata(raw)
+	if err != nil {
+		return "", false, err
+	}
+	if values.ScheduledOn == nil {
+		return "", false, nil
+	}
+
+	scheduledOn := *values.ScheduledOn
+	kind, layout, instant, err := classifyScheduledOn(scheduledOn)
+	if err != nil {
+		return "", false, err
+	}
+	if kind == scheduledOnDate {
+		return scheduledOn, true, nil
+	}
+	if kind == scheduledOnLocalTime {
+		location, err := loadScheduleLocation(values.Timezone, defaultTimezone)
+		if err != nil {
+			return "", false, err
+		}
+		instant, err = resolveLocalSchedule(scheduledOn, layout, location)
+		if err != nil {
+			return "", false, err
+		}
+	}
+	if displayTimezone == "" {
+		displayTimezone = "UTC"
+	}
+	displayLocation, err := time.LoadLocation(displayTimezone)
+	if err != nil {
+		return "", false, fmt.Errorf("load display timezone %q: %w", displayTimezone, err)
+	}
+	return instant.In(displayLocation).Format(time.DateOnly), true, nil
+}
+
+func decodeScheduleMetadata(raw string) (scheduleMetadata, error) {
+	var values scheduleMetadata
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return scheduleMetadata{}, fmt.Errorf("decode schedule metadata: %w", err)
+	}
+	return values, nil
+}
+
+func loadScheduleLocation(issueTimezone, defaultTimezone string) (*time.Location, error) {
+	zone := issueTimezone
+	if zone == "" {
+		zone = defaultTimezone
+	}
+	if zone == "" {
+		zone = "UTC"
+	}
+	location, err := time.LoadLocation(zone)
+	if err != nil {
+		return nil, fmt.Errorf("load schedule timezone %q: %w", zone, err)
+	}
+	return location, nil
+}
+
+// resolveLocalSchedule maps a civil date-time to one instant. During a
+// fall-back overlap it chooses the first occurrence. During a spring-forward
+// gap it chooses the first valid instant after the gap. Both choices keep the
+// readiness gate monotonic once it opens.
+func resolveLocalSchedule(value, layout string, location *time.Location) (time.Time, error) {
+	wall, err := time.Parse(layout, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse local scheduled_on %q: %w", value, err)
+	}
+
+	// time.Date returns one side of a skipped or repeated local time, but does
+	// not specify which side. Use it only to find the adjacent zone boundaries,
+	// then evaluate both offsets and choose a deterministic result below.
+	seed := time.Date(
+		wall.Year(), wall.Month(), wall.Day(),
+		wall.Hour(), wall.Minute(), wall.Second(), wall.Nanosecond(),
+		location,
+	)
+	intervalStart, intervalEnd := seed.ZoneBounds()
+	transitions := make([]time.Time, 0, 2)
+	for _, transition := range []time.Time{intervalStart, intervalEnd} {
+		if !transition.IsZero() {
+			transitions = append(transitions, transition)
+		}
+	}
+
+	offsets := make(map[int]struct{}, 3)
+	addOffset := func(instant time.Time) {
+		_, offset := instant.In(location).Zone()
+		offsets[offset] = struct{}{}
+	}
+	addOffset(seed)
+	for _, transition := range transitions {
+		addOffset(transition.Add(-time.Nanosecond))
+		addOffset(transition)
+	}
+
+	var earliest time.Time
+	for offset := range offsets {
+		candidate := wall.Add(-time.Duration(offset) * time.Second)
+		if candidate.In(location).Format(layout) != value {
+			continue
+		}
+		if earliest.IsZero() || candidate.Before(earliest) {
+			earliest = candidate
+		}
+	}
+	if !earliest.IsZero() {
+		return earliest, nil
+	}
+
+	for _, transition := range transitions {
+		before := wallClock(transition.Add(-time.Nanosecond), location)
+		after := wallClock(transition, location)
+		if after.After(before) && wall.After(before) && wall.Before(after) {
+			return transition, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("resolve local scheduled_on %q in %q", value, location)
+}
+
+func wallClock(instant time.Time, location *time.Location) time.Time {
+	local := instant.In(location)
+	return time.Date(
+		local.Year(), local.Month(), local.Day(),
+		local.Hour(), local.Minute(), local.Second(), local.Nanosecond(),
+		time.UTC,
+	)
+}
+
+func classifyScheduledOn(value string) (scheduledOnKind, string, time.Time, error) {
+	if _, err := time.Parse(time.DateOnly, value); err == nil {
+		return scheduledOnDate, time.DateOnly, time.Time{}, nil
+	}
+	for _, layout := range []string{localMinuteLayout, localSecondLayout} {
+		if _, err := time.Parse(layout, value); err == nil {
+			return scheduledOnLocalTime, layout, time.Time{}, nil
+		}
+	}
+	if strings.HasSuffix(value, "Z") {
+		if instant, err := time.Parse(time.RFC3339, value); err == nil {
+			return scheduledOnInstant, "", instant, nil
+		}
+	}
+	return 0, "", time.Time{}, fmt.Errorf(
+		"scheduled_on %q must match YYYY-MM-DD, local YYYY-MM-DDTHH:MM[:SS], or RFC 3339 UTC with Z",
+		value,
+	)
+}

--- a/internal/metadata/scheduled_test.go
+++ b/internal/metadata/scheduled_test.go
@@ -1,0 +1,188 @@
+package metadata
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduledOnDueDateUsesIssueTimezone(t *testing.T) {
+	now := time.Date(2026, 9, 1, 0, 30, 0, 0, time.UTC)
+
+	due, err := ScheduledOnDue(`{"scheduled_on":"2026-09-01","timezone":"America/Los_Angeles"}`, now, "")
+	require.NoError(t, err)
+	assert.False(t, due, "the scheduled local day has not started west of UTC")
+
+	due, err = ScheduledOnDue(`{"scheduled_on":"2026-09-01","timezone":"Asia/Tokyo"}`, now, "")
+	require.NoError(t, err)
+	assert.True(t, due, "the scheduled local day has started east of UTC")
+}
+
+func TestScheduledOnDueDateUsesDaemonTimezoneThenUTC(t *testing.T) {
+	now := time.Date(2026, 9, 1, 0, 30, 0, 0, time.UTC)
+	metadata := `{"scheduled_on":"2026-09-01"}`
+
+	due, err := ScheduledOnDue(metadata, now, "America/Los_Angeles")
+	require.NoError(t, err)
+	assert.False(t, due)
+
+	due, err = ScheduledOnDue(metadata, now, "")
+	require.NoError(t, err)
+	assert.True(t, due)
+}
+
+func TestScheduledOnDueLocalTimeUsesTimezone(t *testing.T) {
+	now := time.Date(2026, 9, 1, 0, 30, 0, 0, time.UTC)
+
+	due, err := ScheduledOnDue(`{"scheduled_on":"2026-09-01T09:00","timezone":"Asia/Tokyo"}`, now, "")
+	require.NoError(t, err)
+	assert.True(t, due)
+
+	due, err = ScheduledOnDue(
+		`{"scheduled_on":"2026-09-01T09:00","timezone":"America/Los_Angeles"}`,
+		now,
+		"",
+	)
+	require.NoError(t, err)
+	assert.False(t, due)
+}
+
+func TestScheduledOnDueLocalTimeUsesFirstInstantAfterDSTGap(t *testing.T) {
+	metadata := `{"scheduled_on":"2026-03-08T02:30","timezone":"America/New_York"}`
+
+	due, err := ScheduledOnDue(metadata, time.Date(2026, 3, 8, 6, 59, 59, 0, time.UTC), "")
+	require.NoError(t, err)
+	assert.False(t, due)
+
+	// 02:30 does not exist on this day. The gate opens at 03:00 EDT, the first
+	// valid instant after the gap.
+	due, err = ScheduledOnDue(metadata, time.Date(2026, 3, 8, 7, 0, 0, 0, time.UTC), "")
+	require.NoError(t, err)
+	assert.True(t, due)
+}
+
+func TestScheduledOnDueLocalTimeStaysDueAcrossDSTOverlap(t *testing.T) {
+	metadata := `{"scheduled_on":"2026-11-01T01:30","timezone":"America/New_York"}`
+
+	tests := []struct {
+		name string
+		now  time.Time
+		due  bool
+	}{
+		{name: "before first occurrence", now: time.Date(2026, 11, 1, 5, 29, 59, 0, time.UTC), due: false},
+		{name: "at first occurrence", now: time.Date(2026, 11, 1, 5, 30, 0, 0, time.UTC), due: true},
+		{name: "after clock repeats", now: time.Date(2026, 11, 1, 6, 0, 0, 0, time.UTC), due: true},
+		{name: "at second occurrence", now: time.Date(2026, 11, 1, 6, 30, 0, 0, time.UTC), due: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			due, err := ScheduledOnDue(metadata, tt.now, "")
+			require.NoError(t, err)
+			assert.Equal(t, tt.due, due)
+		})
+	}
+}
+
+func TestScheduledOnDueLocalTimeUsesFirstInstantAfterSkippedDay(t *testing.T) {
+	metadata := `{"scheduled_on":"2011-12-30T12:00","timezone":"Pacific/Apia"}`
+
+	due, err := ScheduledOnDue(metadata, time.Date(2011, 12, 30, 9, 59, 59, 0, time.UTC), "")
+	require.NoError(t, err)
+	assert.False(t, due)
+
+	due, err = ScheduledOnDue(metadata, time.Date(2011, 12, 30, 10, 0, 0, 0, time.UTC), "")
+	require.NoError(t, err)
+	assert.True(t, due)
+}
+
+func TestScheduledOnDueUTCInstant(t *testing.T) {
+	now := time.Date(2026, 9, 1, 0, 30, 0, 500_000_000, time.UTC)
+
+	tests := []struct {
+		name      string
+		value     string
+		timezone  string
+		wantReady bool
+	}{
+		{name: "same instant", value: "2026-09-01T00:30:00.500Z", wantReady: true},
+		{name: "future instant", value: "2026-09-01T00:30:01Z", wantReady: false},
+		{name: "timezone ignored for instant", value: "2026-09-01T00:30:00Z", timezone: "Pacific/Apia", wantReady: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := json.Marshal(map[string]string{"scheduled_on": tt.value, "timezone": tt.timezone})
+			require.NoError(t, err)
+			due, err := ScheduledOnDue(string(raw), now, "America/Los_Angeles")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReady, due)
+		})
+	}
+}
+
+func TestScheduledOnDueRejectsNumericOffset(t *testing.T) {
+	_, err := ScheduledOnDue(
+		`{"scheduled_on":"2026-09-01T14:30:00+14:00"}`,
+		time.Date(2026, 9, 1, 0, 30, 0, 0, time.UTC),
+		"UTC",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UTC with Z")
+}
+
+func TestScheduledOnDueRejectsInvalidExplicitTimezone(t *testing.T) {
+	_, err := ScheduledOnDue(
+		`{"scheduled_on":"2026-09-01","timezone":"Not/AZone"}`,
+		time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC),
+		"UTC",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Not/AZone")
+}
+
+func TestScheduledOnDueWithoutScheduleIsDue(t *testing.T) {
+	due, err := ScheduledOnDue(`{"timezone":"America/Los_Angeles"}`, time.Now(), "")
+	require.NoError(t, err)
+	assert.True(t, due)
+}
+
+func TestScheduledOnCalendarDateUsesDisplayTimezoneForTimedValues(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "UTC instant moves to previous browser day",
+			raw:  `{"scheduled_on":"2026-09-01T00:30:00Z"}`,
+			want: "2026-08-31",
+		},
+		{
+			name: "local time resolves before browser projection",
+			raw:  `{"scheduled_on":"2026-09-01T09:00","timezone":"Asia/Tokyo"}`,
+			want: "2026-08-31",
+		},
+		{
+			name: "date keeps its civil day",
+			raw:  `{"scheduled_on":"2026-09-01","timezone":"Asia/Tokyo"}`,
+			want: "2026-09-01",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, present, err := ScheduledOnCalendarDate(tt.raw, "America/Los_Angeles", "UTC")
+			require.NoError(t, err)
+			assert.True(t, present)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestScheduledOnCalendarDateWithoutSchedule(t *testing.T) {
+	date, present, err := ScheduledOnCalendarDate(`{"deadline_on":"2026-09-01"}`, "UTC", "")
+	require.NoError(t, err)
+	assert.False(t, present)
+	assert.Empty(t, date)
+}

--- a/internal/metadata/validate.go
+++ b/internal/metadata/validate.go
@@ -57,9 +57,22 @@ func Validate(registry map[string]Entry, key string, raw json.RawMessage) error 
 		return validateChecklist(raw)
 	case TypeTimezoneIANA:
 		return validateTimezoneIANA(raw)
+	case TypeSchedule:
+		return validateSchedule(raw)
 	default:
 		return fmt.Errorf("no validator for type %d", entry.Type)
 	}
+}
+
+func validateSchedule(raw json.RawMessage) error {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return fmt.Errorf("%w: schedule must be a JSON string: %v", ErrInvalidValue, err)
+	}
+	if _, _, _, err := classifyScheduledOn(s); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidValue, err)
+	}
+	return nil
 }
 
 func validateDate(raw json.RawMessage) error {

--- a/internal/metadata/validate_test.go
+++ b/internal/metadata/validate_test.go
@@ -37,9 +37,15 @@ func TestValidateCreateValue_DelegatesToValidate(t *testing.T) {
 
 func TestValidateDate(t *testing.T) {
 	assert.NoError(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20"`)))
+	assert.NoError(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20T15:30"`)))
+	assert.NoError(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20T15:30:45"`)))
+	assert.NoError(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20T22:30:00Z"`)))
+	assert.Error(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20T15:30:00-07:00"`)))
 	assert.Error(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"not-a-date"`)))
 	assert.Error(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-13-01"`)))
 	assert.Error(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`123`)))
+	assert.Error(t, Validate(IssueRegistry, "deadline_on", json.RawMessage(`"2026-05-20T22:30:00Z"`)),
+		"deadline_on remains date-only")
 }
 
 func TestValidateBool(t *testing.T) {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -3635,29 +3635,30 @@ func (u UIGraphUnresolvedRef) Validate() error {
 }
 
 type UIIssue struct {
-	Author        string         `json:"author" validate:"required"`
-	Body          string         `json:"body" validate:"required"`
-	ClosedAt      *time.Time     `json:"closed_at,omitempty"`
-	ClosedReason  *string        `json:"closed_reason,omitempty"`
-	CreatedAt     time.Time      `json:"created_at" validate:"required"`
-	DeletedAt     *time.Time     `json:"deleted_at,omitempty"`
-	ID            int64          `json:"id"`
-	Labels        []string       `json:"labels,omitempty" validate:"required"`
-	Metadata      map[string]any `json:"metadata"`
-	OccurrenceKey *string        `json:"occurrence_key,omitempty"`
-	Owner         *string        `json:"owner,omitempty"`
-	Priority      *int64         `json:"priority,omitempty"`
-	ProjectID     int64          `json:"project_id"`
-	ProjectName   string         `json:"project_name" validate:"required"`
-	ProjectUID    *string        `json:"project_uid,omitempty"`
-	QualifiedID   string         `json:"qualified_id" validate:"required"`
-	RecurrenceID  *int64         `json:"recurrence_id,omitempty"`
-	Revision      int64          `json:"revision"`
-	ShortID       string         `json:"short_id" validate:"required"`
-	Status        string         `json:"status" validate:"required"`
-	Title         string         `json:"title" validate:"required"`
-	UID           string         `json:"uid" validate:"required"`
-	UpdatedAt     time.Time      `json:"updated_at" validate:"required"`
+	Author          string         `json:"author" validate:"required"`
+	Body            string         `json:"body" validate:"required"`
+	ClosedAt        *time.Time     `json:"closed_at,omitempty"`
+	ClosedReason    *string        `json:"closed_reason,omitempty"`
+	CreatedAt       time.Time      `json:"created_at" validate:"required"`
+	DeletedAt       *time.Time     `json:"deleted_at,omitempty"`
+	ID              int64          `json:"id"`
+	Labels          []string       `json:"labels,omitempty" validate:"required"`
+	Metadata        map[string]any `json:"metadata"`
+	OccurrenceKey   *string        `json:"occurrence_key,omitempty"`
+	Owner           *string        `json:"owner,omitempty"`
+	Priority        *int64         `json:"priority,omitempty"`
+	ProjectID       int64          `json:"project_id"`
+	ProjectName     string         `json:"project_name" validate:"required"`
+	ProjectUID      *string        `json:"project_uid,omitempty"`
+	QualifiedID     string         `json:"qualified_id" validate:"required"`
+	RecurrenceID    *int64         `json:"recurrence_id,omitempty"`
+	Revision        int64          `json:"revision"`
+	ScheduledOnDate *string        `json:"scheduled_on_date,omitempty"`
+	ShortID         string         `json:"short_id" validate:"required"`
+	Status          string         `json:"status" validate:"required"`
+	Title           string         `json:"title" validate:"required"`
+	UID             string         `json:"uid" validate:"required"`
+	UpdatedAt       time.Time      `json:"updated_at" validate:"required"`
 }
 
 func (u UIIssue) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -3744,6 +3744,8 @@ components:
         revision:
           format: int64
           type: integer
+        scheduled_on_date:
+          type: string
         short_id:
           type: string
         status:

--- a/service.go
+++ b/service.go
@@ -101,6 +101,9 @@ type Config struct {
 	Postgres   PostgresConfig
 	Auth       AuthConfig
 	GitHubSync GitHubSyncConfig
+	// DefaultTimezone applies to civil schedules without issue timezone.
+	// Empty means UTC.
+	DefaultTimezone string
 	// Access selects host-supplied in-process authentication and authorization.
 	// It is mutually exclusive with Auth.
 	Access AccessController
@@ -165,6 +168,12 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 	}
 	if cfg.Profile != EmbeddingProfileStandalone && cfg.Profile != EmbeddingProfileRestricted {
 		return nil, fmt.Errorf("kata: unknown embedding profile %q", cfg.Profile)
+	}
+	cfg.DefaultTimezone = strings.TrimSpace(cfg.DefaultTimezone)
+	if cfg.DefaultTimezone != "" {
+		if _, err := time.LoadLocation(cfg.DefaultTimezone); err != nil {
+			return nil, fmt.Errorf("kata: default timezone %q is not a valid IANA timezone: %w", cfg.DefaultTimezone, err)
+		}
 	}
 	usesAccess := cfg.Access != nil
 	usesToken := strings.TrimSpace(cfg.Auth.Token) != ""
@@ -247,6 +256,7 @@ func newService(ctx context.Context, cfg Config, deps serviceDeps) (*Service, er
 	}
 	server := daemon.NewServer(daemon.ServerConfig{
 		DB:                      store,
+		DefaultTimezone:         cfg.DefaultTimezone,
 		StartedAt:               startedAt,
 		Broadcaster:             broadcaster,
 		FederationWake:          wakeFederation,

--- a/service_test.go
+++ b/service_test.go
@@ -78,6 +78,18 @@ func TestNewRejectsMissingAuthenticationPolicy(t *testing.T) {
 	assert.EqualError(t, err, "kata: auth token is required unless caller authentication is explicitly trusted")
 }
 
+func TestNewRejectsInvalidDefaultTimezone(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:             filepath.Join(t.TempDir(), "service.db"),
+		DefaultTimezone: "Not/AZone",
+		Auth:            kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+
+	assert.Nil(t, service)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `default timezone "Not/AZone" is not a valid IANA timezone`)
+}
+
 func TestNewRejectsAmbiguousAuthenticationPolicy(t *testing.T) {
 	service, err := kata.New(context.Background(), kata.Config{
 		DSN: filepath.Join(t.TempDir(), "service.db"),

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -132,6 +132,8 @@
     openEvents: () => {
       if (authority?.snapshot) stream.start(authority.cursor)
     },
+    wallClockSensitive: () =>
+      route.kind !== 'route-error' && route.filters.status.includes('ready'),
   })
   const unsubscribe = snapshots.subscribe((state) => {
     authority = { ...state }

--- a/web/src/lib/api/schema.d.ts
+++ b/web/src/lib/api/schema.d.ts
@@ -3070,6 +3070,7 @@ export interface components {
       recurrence_id?: number
       /** Format: int64 */
       revision: number
+      scheduled_on_date?: string
       short_id: string
       status: string
       title: string

--- a/web/src/lib/events/controller.test.ts
+++ b/web/src/lib/events/controller.test.ts
@@ -200,6 +200,33 @@ describe('snapshot refresh scheduling', () => {
     scheduler.stop()
   })
 
+  it('refreshes wall-clock-sensitive SSE views every fifteen seconds', async () => {
+    const refresh = vi.fn(async () => undefined)
+    const openEvents = vi.fn()
+    let wallClockSensitive = false
+    const scheduler = new RefreshScheduler({
+      refresh,
+      openEvents,
+      wallClockSensitive: () => wallClockSensitive,
+    })
+    scheduler.start('sse')
+
+    vi.advanceTimersByTime(15_000)
+    await Promise.resolve()
+    expect(refresh).not.toHaveBeenCalled()
+
+    wallClockSensitive = true
+    vi.advanceTimersByTime(15_000)
+    await Promise.resolve()
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(openEvents).toHaveBeenCalledOnce()
+
+    scheduler.stop()
+    vi.advanceTimersByTime(15_000)
+    await Promise.resolve()
+    expect(refresh).toHaveBeenCalledOnce()
+  })
+
   it('refreshes on visibility, focus, timezone change, and local midnight', async () => {
     const refresh = vi.fn(async () => undefined)
     let zone = 'America/Chicago'

--- a/web/src/lib/events/controller.ts
+++ b/web/src/lib/events/controller.ts
@@ -189,6 +189,7 @@ interface RefreshSchedulerOptions {
   openEvents: () => void
   now?: () => Date
   timeZone?: () => string
+  wallClockSensitive?: () => boolean
 }
 
 export class RefreshScheduler {
@@ -196,8 +197,10 @@ export class RefreshScheduler {
   readonly #openEvents: () => void
   readonly #now: () => Date
   readonly #timeZone: () => string
+  readonly #wallClockSensitive: () => boolean
   #pollTimer: ReturnType<typeof setTimeout> | undefined
   #midnightTimer: ReturnType<typeof setTimeout> | undefined
+  #wallClockTimer: ReturnType<typeof setTimeout> | undefined
   #updates: 'sse' | 'poll' = 'poll'
   #visible = true
   #lastTimeZone = ''
@@ -208,6 +211,7 @@ export class RefreshScheduler {
     this.#openEvents = options.openEvents
     this.#now = options.now ?? (() => new Date())
     this.#timeZone = options.timeZone ?? (() => Intl.DateTimeFormat().resolvedOptions().timeZone)
+    this.#wallClockSensitive = options.wallClockSensitive ?? (() => false)
   }
 
   start(updates: 'sse' | 'poll'): void {
@@ -215,8 +219,10 @@ export class RefreshScheduler {
     this.#stopped = false
     this.#updates = updates
     this.#lastTimeZone = this.#timeZone()
-    if (updates === 'sse') this.#openEvents()
-    else this.#schedulePoll()
+    if (updates === 'sse') {
+      this.#openEvents()
+      this.#scheduleWallClock()
+    } else this.#schedulePoll()
     this.#scheduleMidnight()
   }
 
@@ -224,8 +230,10 @@ export class RefreshScheduler {
     this.#stopped = true
     if (this.#pollTimer !== undefined) clearTimeout(this.#pollTimer)
     if (this.#midnightTimer !== undefined) clearTimeout(this.#midnightTimer)
+    if (this.#wallClockTimer !== undefined) clearTimeout(this.#wallClockTimer)
     this.#pollTimer = undefined
     this.#midnightTimer = undefined
+    this.#wallClockTimer = undefined
   }
 
   visibilityChanged(visible: boolean): void {
@@ -273,6 +281,15 @@ export class RefreshScheduler {
       },
       Math.max(1, next.getTime() - now.getTime()),
     )
+  }
+
+  #scheduleWallClock(): void {
+    if (this.#stopped || this.#updates !== 'sse') return
+    this.#wallClockTimer = setTimeout(() => {
+      this.#wallClockTimer = undefined
+      if (this.#visible && this.#wallClockSensitive()) this.#refreshNow()
+      this.#scheduleWallClock()
+    }, 15_000)
   }
 
   #refreshNow(): void {

--- a/web/src/lib/kata/projection.ts
+++ b/web/src/lib/kata/projection.ts
@@ -305,6 +305,7 @@ function normalizeIssue(
     project_uid: issue.project_uid ?? project?.uid ?? '',
     project_name:
       issue.project_name || project?.name || projectNameFromQualifiedID(issue.qualified_id),
+    scheduled_on_date: issue.scheduled_on_date,
     metadata: { ...issue.metadata },
     revision: issue.revision,
     owner: issue.owner,

--- a/web/src/lib/kata/types.ts
+++ b/web/src/lib/kata/types.ts
@@ -56,6 +56,7 @@ export interface KataTaskSummary {
   status: 'open' | 'closed'
   project_uid: string
   project_name: string
+  scheduled_on_date?: string | undefined
   metadata: KataTaskMetadata
   revision: number
   owner?: string | undefined

--- a/web/src/lib/kata/view.test.ts
+++ b/web/src/lib/kata/view.test.ts
@@ -159,6 +159,43 @@ describe('kata task view builder', () => {
     ])
   })
 
+  test('uses the server-projected browser date for timed schedules', () => {
+    const previousBrowserDay = {
+      ...issue('issue-1', 'Previous browser day', 'project-health', {
+        scheduled_on: '2026-09-01T00:30:00Z',
+      }),
+      scheduled_on_date: '2026-08-31',
+    }
+    const nextBrowserDay = {
+      ...issue('issue-2', 'Next browser day', 'project-workspace', {
+        scheduled_on: '2026-09-01T07:30:00Z',
+      }),
+      scheduled_on_date: '2026-09-01',
+    }
+
+    const todayView = buildKataTaskView({
+      view: 'today',
+      issues: [previousBrowserDay, nextBrowserDay],
+      projects,
+      today: '2026-08-31',
+      fetched_at: fetchedAt,
+    })
+    expect(todayView.groups.flatMap((group) => group.issues.map((item) => item.title))).toEqual([
+      'Previous browser day',
+    ])
+
+    const upcomingView = buildKataTaskView({
+      view: 'upcoming',
+      issues: [previousBrowserDay, nextBrowserDay],
+      projects,
+      today: '2026-08-31',
+      fetched_at: fetchedAt,
+    })
+    expect(upcomingView.groups.map((group) => [group.id, group.issues[0]?.title])).toEqual([
+      ['2026-09-01', 'Next browser day'],
+    ])
+  })
+
   test('builds Inbox only from task inbox projects', () => {
     const view = buildKataTaskView({
       view: 'inbox',

--- a/web/src/lib/kata/view.ts
+++ b/web/src/lib/kata/view.ts
@@ -21,6 +21,10 @@ function issueDate(value: string | undefined): string | undefined {
   return value?.slice(0, 10)
 }
 
+function scheduledDate(issue: KataTaskSummary): string | undefined {
+  return issue.scheduled_on_date ?? issueDate(issue.metadata.scheduled_on)
+}
+
 function compareIssues(a: KataTaskSummary, b: KataTaskSummary): number {
   const ap = a.priority ?? Number.MAX_SAFE_INTEGER
   const bp = b.priority ?? Number.MAX_SAFE_INTEGER
@@ -91,7 +95,7 @@ function buildToday(issues: KataTaskSummary[], today: string): KataTaskGroup[] {
 
   for (const issue of issues) {
     if (issue.status !== 'open') continue
-    const scheduledOn = issueDate(issue.metadata.scheduled_on)
+    const scheduledOn = scheduledDate(issue)
     const deadlineOn = issueDate(issue.metadata.deadline_on)
     const scheduledDue = scheduledOn !== undefined && scheduledOn <= today
     const deadlineDue = deadlineOn !== undefined && deadlineOn <= today
@@ -118,7 +122,7 @@ function buildUpcoming(issues: KataTaskSummary[], today: string): KataTaskGroup[
   const groups = new Map<string, KataTaskGroup>()
   for (const issue of issues) {
     if (issue.status !== 'open') continue
-    const scheduledOn = issueDate(issue.metadata.scheduled_on)
+    const scheduledOn = scheduledDate(issue)
     if (!scheduledOn || scheduledOn <= today) continue
 
     const group = groups.get(scheduledOn) ?? { id: scheduledOn, title: scheduledOn, issues: [] }


### PR DESCRIPTION
Fixes #243

scheduled_on now preserves three distinct intents:

- a whole local day
- a local wall-clock time resolved through the issue timezone, daemon default, then UTC
- a fixed UTC instant ending in Z

Readiness now uses one shared Go predicate across SQLite, PostgreSQL, the embedded service, and browser snapshots. Filtering happens before result limits, and numeric offsets are rejected so named timezone intent stays explicit.

The browser ready view also refreshes clock-sensitive SSE sessions without requiring a database event.

This keeps the stored value readable and avoids a schema migration or backend-specific timezone SQL.