### PR TITLE
Make Homebrew tap publication pull-based

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -105,7 +105,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           KATA_HOME: ${{ runner.temp }}/kata-web-release/home
           KATA_DB: ${{ runner.temp }}/kata-web-release/home/kata.db
           KATA_WORKSPACE: ${{ runner.temp }}/kata-web-release/workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           KATA_HOME: ${{ runner.temp }}/kata-web-release/home
           KATA_DB: ${{ runner.temp }}/kata-web-release/home/kata.db
           KATA_WORKSPACE: ${{ runner.temp }}/kata-web-release/workspace

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -178,15 +178,17 @@ brews:
   - name: kata
     ids:
       - kata-homebrew
+    # Pinned GoReleaser v2.16.0 skips formula generation when repository.name
+    # is absent, even with upload disabled. These fields select no credential
+    # and are retained only so snapshot and release runs render the candidate.
     repository:
       owner: kenn-io
       name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
     homepage: https://katatracker.com
     description: Git-native issue tracking for agentic development
     license: MIT
-    skip_upload: auto
+    skip_upload: true
     test: |
       info = shell_output("#{bin}/kata version --json")
       assert_match %Q("distribution":"homebrew"), info

--- a/docs/development/packaging.md
+++ b/docs/development/packaging.md
@@ -75,9 +75,21 @@ events and excluded data.
 
 ## Official tap publishing
 
-Stable release workflows publish the generated formula to
-`kenn-io/homebrew-tap`. Configure the Kata repository Actions secret
-`HOMEBREW_TAP_GITHUB_TOKEN` with a fine-grained GitHub PAT scoped only to that
-tap repository and grant it repository contents write permission. The normal
-workflow `GITHUB_TOKEN` remains responsible for Kata release assets and does
-not need cross-repository access.
+Kata release workflows publish artifacts but never write to
+`kenn-io/homebrew-tap`. The tap's hourly workflow reads Kata's latest stable
+release, validates it, and opens a same-repository formula update pull request
+with the tap repository's short-lived `GITHUB_TOKEN`.
+
+The release repository and tap updater share this exact archive-name contract:
+
+```text
+kata_<version>_homebrew_darwin_amd64.tar.gz
+kata_<version>_homebrew_darwin_arm64.tar.gz
+kata_<version>_homebrew_linux_amd64.tar.gz
+kata_<version>_homebrew_linux_arm64.tar.gz
+```
+
+Renaming any of these archives requires a coordinated tap updater change before
+the release. A missing or renamed archive fails the scheduled tap workflow;
+the red workflow run and GitHub's failed scheduled-workflow notification are
+the maintainer alert for a broken cross-repository contract.


### PR DESCRIPTION
## Why

Kata releases should not depend on a durable credential with write access to another repository. The tap should own stable formula updates and pull the public release artifacts after they exist, so a permissions problem in the tap cannot break a Kata release.

## What reviewers should know

GoReleaser still renders the Homebrew formula candidate for release validation, but never uploads it. The maintained packaging contract names the four Homebrew archives consumed by the tap updater and makes v0.14.2 the first eligible stable release.

This is the Kata half of the pull-based rollout for #213; the companion tap change adds the stable-release poller, fail-closed asset validation, and formula update PR.