### PR TITLE
Keep generated Homebrew formulae style-clean

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -191,6 +191,6 @@ brews:
     skip_upload: true
     test: |
       info = shell_output("#{bin}/kata version --json")
-      assert_match %Q("distribution":"homebrew"), info
+      assert_match '"distribution":"homebrew"', info
       system bin/"kata", "_web-assets-check"
       assert_match "brew upgrade kata", shell_output("#{bin}/kata update --yes 2>&1", 2)

--- a/internal/release/source_archive_test.go
+++ b/internal/release/source_archive_test.go
@@ -170,9 +170,30 @@ func TestRenderHomebrewCoreFormula_ProducesValidRuby(t *testing.T) {
 		Version: "0.14.2", SHA256: strings.Repeat("a", 64), BuildDate: "2026-08-08T01:02:03Z",
 	}
 	require.NoError(t, RenderHomebrewCoreFormula(templatePath, output, meta))
+	formula, err := os.ReadFile(output) //nolint:gosec // test-owned temporary path
+	require.NoError(t, err)
+	assert.Contains(t, string(formula), `assert_match '"distribution":"homebrew"', info`)
+	assert.NotContains(t, string(formula), `%Q("distribution":"homebrew")`)
 	cmd := exec.Command(ruby, "-c", output) //nolint:gosec // fixed test tool and generated fixture path
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", out)
+}
+
+func TestRenderHomebrewCoreFormula_OrdersLivecheckBeforeDependencies(t *testing.T) {
+	templatePath := filepath.Join("..", "..", "packaging", "homebrew-core", "kata.rb.tmpl")
+	output := filepath.Join(t.TempDir(), "kata.rb")
+	meta := SourceArchiveMetadata{
+		Version: "0.14.2", SHA256: strings.Repeat("a", 64), BuildDate: "2026-08-08T01:02:03Z",
+	}
+	require.NoError(t, RenderHomebrewCoreFormula(templatePath, output, meta))
+	formula, err := os.ReadFile(output) //nolint:gosec // test-owned temporary path
+	require.NoError(t, err)
+
+	livecheck := strings.Index(string(formula), "  livecheck do")
+	dependency := strings.Index(string(formula), `  depends_on "go" => :build`)
+	require.NotEqual(t, -1, livecheck)
+	require.NotEqual(t, -1, dependency)
+	assert.Less(t, livecheck, dependency)
 }
 
 type archiveTestEntry struct {

--- a/packaging/homebrew-core/kata.rb.tmpl
+++ b/packaging/homebrew-core/kata.rb.tmpl
@@ -5,12 +5,12 @@ class Kata < Formula
   sha256 "{{ .SHA256 }}"
   license "MIT"
 
-  depends_on "go" => :build
-
   livecheck do
     url :stable
     strategy :github_latest
   end
+
+  depends_on "go" => :build
 
   def install
     ENV["CGO_ENABLED"] = "0"
@@ -26,7 +26,7 @@ class Kata < Formula
   test do
     info = shell_output("#{bin}/kata version --json")
     assert_match %Q("version":"v#{version}"), info
-    assert_match %Q("distribution":"homebrew"), info
+    assert_match '"distribution":"homebrew"', info
     system bin/"kata", "_web-assets-check"
     assert_match "brew upgrade kata", shell_output("#{bin}/kata update --yes 2>&1", 2)
   end


### PR DESCRIPTION
## Why

The first 0.14.2 release candidate reached Homebrew's real style checks and exposed two blockers before stable publication. The generated binary formula used an unnecessary percent literal for a fixed JSON marker, and the Core source formula placed `livecheck` after its build dependency.

## What reviewers should know

This keeps both generated formula paths compatible with Homebrew's style rules. It does not change Kata runtime behavior or the release artifact contract. A second release candidate can validate the corrected generated artifacts after this lands.
