### PR TITLE
Pin GoReleaser to the requested release tag

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -105,6 +105,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.validate.outputs.tag_name }}
           KATA_HOME: ${{ runner.temp }}/kata-web-release/home
           KATA_DB: ${{ runner.temp }}/kata-web-release/home/kata.db
           KATA_WORKSPACE: ${{ runner.temp }}/kata-web-release/workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ needs.validate-tag.outputs.tag_name }}
           KATA_HOME: ${{ runner.temp }}/kata-web-release/home
           KATA_DB: ${{ runner.temp }}/kata-web-release/home/kata.db
           KATA_WORKSPACE: ${{ runner.temp }}/kata-web-release/workspace


### PR DESCRIPTION
## Why

The `v0.14.2` stable tag shares its commit with `v0.14.2-rc.2`. GoReleaser inferred the release-candidate tag during the stable workflow, attempted to upload the existing RC assets again, and left the stable GitHub release empty.

## What reviewers should know

Both automatic and manual publishers now pass their already-validated tag to GoReleaser. This keeps artifact names and the upload destination aligned with the workflow trigger. After this merges, the manual publisher can append the missing assets to the existing `v0.14.2` release without moving either tag or replacing the RC release.