### PR TITLE
Recommend Homebrew in the macOS quickstart

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -1,22 +1,34 @@
 # Quickstart
 
-Install kata, enter a workspace, bind it to a kata project, and create your
-first issue:
+Install kata on macOS with the official Homebrew tap:
+
+```sh
+brew install kenn-io/tap/kata
+```
+
+On Linux, install the release binary with:
 
 ```sh
 curl -fsSL https://katatracker.com/install.sh | bash
-
-cd your-repo
-kata init
-kata create "fix login race"
-kata list
-kata show abc4
 ```
 
 On Windows PowerShell, install the release binary with:
 
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://katatracker.com/install.ps1 | iex"
+```
+
+See [Install](install.md) for package upgrades and alternative installation
+methods.
+
+Then enter a workspace, bind it to a kata project, and create your first issue:
+
+```sh
+cd your-repo
+kata init
+kata create "fix login race"
+kata list
+kata show abc4
 ```
 
 `kata create` prints the issue's short ID. Use that short ID in later commands.


### PR DESCRIPTION
## Why

The quickstart is a common first stop for new users, but it still directed macOS readers to the generic release installer after the official Homebrew tap became available. That made the preferred macOS installation route easy to miss.

## What reviewers should know

The quickstart now recommends `brew install kenn-io/tap/kata` on macOS. Linux and Windows keep their existing release installers, and the full install guide remains the source for upgrade instructions and alternatives. This documents the current tap route without implying that the unqualified Homebrew Core formula has landed.

Advances #213.