### PR TITLE
Recommend Homebrew Core for macOS installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Linux, or macOS without Homebrew:
 curl -fsSL https://katatracker.com/install.sh | bash
 ```
 
+Linux and WSL 2 users who already use
+[Homebrew](https://docs.brew.sh/Homebrew-on-Linux) can also run
+`brew install kata`.
+
 Windows PowerShell:
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Zensical at <https://katatracker.com/>.
 
 ## Install
 
-macOS or Linux:
+macOS:
 
 ```sh
-brew install kenn-io/tap/kata
+brew install kata
 ```
 
-Or use the release installer:
+Linux, or macOS without Homebrew:
 
 ```sh
 curl -fsSL https://katatracker.com/install.sh | bash

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -32,6 +32,14 @@ an ordinary release archive on macOS instead:
 curl -fsSL https://katatracker.com/install.sh | bash
 ```
 
+Linux and WSL 2 users who already use
+[Homebrew](https://docs.brew.sh/Homebrew-on-Linux) can install from Core
+instead:
+
+```sh
+brew install kata
+```
+
 On Windows PowerShell:
 
 ```powershell

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -12,10 +12,10 @@ GitHub release binaries are available starting with `v0.5.0`. Since v0.14.0,
 kata publishes stable releases that preserve backward compatibility across
 upgrades.
 
-The recommended path on macOS or Linux is the official Homebrew tap:
+The recommended path on macOS is Homebrew Core:
 
 ```sh
-brew install kenn-io/tap/kata
+brew install kata
 ```
 
 Homebrew owns this binary. Check Kata's release feed with `kata update --check`,
@@ -25,8 +25,8 @@ and install packaged updates with:
 brew upgrade kata
 ```
 
-The formula may trail a newly published GitHub release. To install an ordinary
-release archive on macOS or Linux instead:
+The formula may trail a newly published GitHub release. On Linux, or to install
+an ordinary release archive on macOS instead:
 
 ```sh
 curl -fsSL https://katatracker.com/install.sh | bash

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -12,6 +12,10 @@ On Linux, install the release binary with:
 curl -fsSL https://katatracker.com/install.sh | bash
 ```
 
+If you already use
+[Homebrew on Linux or WSL 2](https://docs.brew.sh/Homebrew-on-Linux), you can
+install Kata with `brew install kata` instead.
+
 On Windows PowerShell, install the release binary with:
 
 ```powershell

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -1,9 +1,9 @@
 # Quickstart
 
-Install kata on macOS with the official Homebrew tap:
+Install kata on macOS from Homebrew Core:
 
 ```sh
-brew install kenn-io/tap/kata
+brew install kata
 ```
 
 On Linux, install the release binary with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,13 @@ issue editing, relationships, recurrences, and configured-daemon switching.
     curl -fsSL https://katatracker.com/install.sh | bash
     ```
 
+    If you already use
+    [Homebrew on Linux or WSL 2](https://docs.brew.sh/Homebrew-on-Linux):
+
+    ```sh
+    brew install kata
+    ```
+
 === "Windows (PowerShell)"
 
     ```powershell

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,13 +37,19 @@ issue editing, relationships, recurrences, and configured-daemon switching.
 
 ## Install
 
-=== "macOS / Linux"
+=== "macOS"
 
     ```sh
-    brew install kenn-io/tap/kata
+    brew install kata
     ```
 
     Or install the ordinary release archive:
+
+    ```sh
+    curl -fsSL https://katatracker.com/install.sh | bash
+    ```
+
+=== "Linux"
 
     ```sh
     curl -fsSL https://katatracker.com/install.sh | bash
@@ -55,9 +61,9 @@ issue editing, relationships, recurrences, and configured-daemon switching.
     powershell -ExecutionPolicy ByPass -c "irm https://katatracker.com/install.ps1 | iex"
     ```
 
-The installer detects your OS and CPU architecture, downloads the latest GitHub
-release archive, and verifies it against `SHA256SUMS` before installing. Confirm
-the install with:
+The release installers detect your OS and CPU architecture, download the latest
+GitHub release archive, and verify it against `SHA256SUMS` before installing.
+Confirm the install with:
 
 ```sh
 kata version


### PR DESCRIPTION
## Why

Kata is now available directly from Homebrew Core. macOS users no longer need the tap-qualified formula name, so the public installation path should use the shorter Core command.

## What reviewers should know

The README and website now recommend `brew install kata` on macOS. Linux keeps the release installer as its primary path, and Windows remains unchanged. Historical release notes and the packager-facing tap contract remain intact.

Closes #213.