### PR TITLE
Ignore dotenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ __pycache__/
 # docs Vercel artifacts
 .vercel
 .env*.local
+.env*


### PR DESCRIPTION
Dotenv files often hold credentials and machine-specific settings. The previous ignore rule covered only .env*.local, which left root .env and other dotenv variants easy to add accidentally.

Ignore the full .env* family so local configuration stays out of normal repository changes.