### PR TITLE
Allow legacy federation bindings to rebind

### DIFF
--- a/internal/daemon/federation_rebind_service.go
+++ b/internal/daemon/federation_rebind_service.go
@@ -424,8 +424,11 @@ func classifyFederationRebindState(
 			state.sourceInsecure = credential.AllowInsecure
 		} else {
 			sourceURL, sourceErr := canonicalFederationRebindBaseURL(state.sourceHubURL)
+			// Pre-persistence bindings keep their same-endpoint plaintext opt-in
+			// only in the credential; federation transport already honors it.
+			legacyCredentialOnlyInsecure := !state.sourceInsecure && credential.AllowInsecure
 			if sourceErr != nil || sourceURL != credentialURL ||
-				state.sourceInsecure != credential.AllowInsecure {
+				(state.sourceInsecure != credential.AllowInsecure && !legacyCredentialOnlyInsecure) {
 				return federationRebindLocalState{}, federationReplicaError(
 					ErrFederationReplicaBindingConflict,
 					"binding and credential disagree on the current federation endpoint",

--- a/internal/daemon/federation_rebind_service_test.go
+++ b/internal/daemon/federation_rebind_service_test.go
@@ -466,6 +466,37 @@ func TestRebindFederationReplicaConvergesEveryDurableState(t *testing.T) {
 	}
 }
 
+func TestRebindFederationReplicaConvergesLegacyCredentialOnlyInsecureState(t *testing.T) {
+	ctx := context.Background()
+	store, project, binding := prepareFederationRebind(t, rebindSourceURL)
+	binding.AllowInsecure = false
+	_, err := store.UpsertFederationBinding(ctx, binding)
+	require.NoError(t, err)
+	credentials := newReplicaCredentialStore()
+	credentials.put(project.UID, rebindCredential(rebindSourceURL, false, false))
+
+	result, err := daemon.RebindFederationReplica(
+		ctx, store, credentials,
+		daemon.RebindFederationReplicaParams{
+			ProjectID:  project.ID,
+			HubCatalog: config.CatalogDaemonConfig{Name: "primary-hub", URL: rebindTargetURL},
+			FetchMetadata: func(context.Context, string, string, int64) (api.ProjectFederationBody, error) {
+				return api.ProjectFederationBody{ProjectID: 42, ProjectUID: project.UID}, nil
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, daemon.FederationRebindStateRebound, result.State)
+	assert.Equal(t, rebindTargetURL, result.Binding.HubURL)
+	assert.False(t, result.Binding.AllowInsecure)
+	credential, found, err := credentials.FederationCredential(ctx, project.UID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, rebindTargetURL, credential.HubURL)
+	assert.False(t, credential.AllowInsecure)
+}
+
 func TestRebindFederationReplicaRemoteValidationFailureLeavesLocalStateUnchanged(t *testing.T) {
 	for _, tc := range []struct {
 		name     string


### PR DESCRIPTION
## Why

Federation spokes enrolled before `allow_insecure` was persisted on bindings can validly carry that plaintext opt-in only in their same-endpoint credential. Kata already honors this state for transport and status, but endpoint rebind classified it as conflicting local state and blocked the HTTPS cutover intended to retire the legacy endpoint.

## What reviewers should know

The exception is limited to the known pre-persistence direction: the credential opts into plaintext while the same-endpoint binding does not. URL disagreement and the opposite policy mismatch remain conflicts. A service-level regression test reproduces the legacy state and verifies that rebind converges both records to the validated HTTPS target with plaintext disabled. The full Go suite, lint, and vet pass locally.