### PR TITLE
Expand native MCP server coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Production Postgres deployments can use separate schema-owner and runtime roles;
 see the [operator ceremony](docs/operations/postgres.md).
 Go applications can instead mount kata's listener-free HTTP service in-process;
 see [Embedding kata in Go](docs/development/embedding.md).
-MCP clients can start Kata's native stdio server with `kata mcp serve`. It can
-use the complete daemon catalog by default, or narrow access to one project or
-a fixed allowlist. Thirteen section loaders progressively expose Kata's typed
+MCP clients can start Kata's native stdio server with `kata mcp serve`. It
+binds the current workspace's project by default, and can serve a fixed
+allowlist or the complete daemon catalog on request. Thirteen section loaders
+progressively expose Kata's typed
 issue, administration, automation, and event workflows. See the [MCP
 reference](docs/reference/mcp.md).
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Production Postgres deployments can use separate schema-owner and runtime roles;
 see the [operator ceremony](docs/operations/postgres.md).
 Go applications can instead mount kata's listener-free HTTP service in-process;
 see [Embedding kata in Go](docs/development/embedding.md).
-MCP clients can start Kata's native, project-bound stdio server with `kata mcp
-serve`; see the [MCP reference](docs/reference/mcp.md).
+MCP clients can start Kata's native stdio server with `kata mcp serve`. It can
+use the complete daemon catalog by default, or narrow access to one project or
+a fixed allowlist. Thirteen section loaders progressively expose Kata's typed
+issue, administration, automation, and event workflows. See the [MCP
+reference](docs/reference/mcp.md).
 
 The documentation in [`docs/`](docs/) is the definitive guide, published with
 Zensical at <https://katatracker.com/>.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -85,6 +85,9 @@ components:
       properties:
         actor:
           type: string
+        event_id:
+          format: int64
+          type: integer
         evidence_types:
           items:
             type: string
@@ -112,6 +115,7 @@ components:
         - actor
         - issue
         - reason
+        - event_id
       type: object
     AuditClosesResponseBody:
       additionalProperties: true

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4237,7 +4237,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.10.0
+  version: 0.11.0
 openapi: 3.1.0
 paths:
   /api/v1/audit/closes:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -417,6 +417,8 @@ components:
       properties:
         incoming:
           type: boolean
+        to_project_uid:
+          type: string
         to_ref:
           type: string
         type:
@@ -2227,6 +2229,10 @@ components:
           type:
             - array
             - "null"
+        expected_project_uids:
+          additionalProperties:
+            type: string
+          type: object
         remove_blocked_by:
           items:
             type: string

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -106,6 +106,8 @@ components:
           type: string
         parent:
           type: string
+        parent_uid:
+          type: string
         reason:
           type: string
         time:

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
   },
   "overrides": {
     "js-yaml": "4.3.1",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
   },
   "packages": {
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
@@ -575,7 +575,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/cmd/kata/api_compat.go
+++ b/cmd/kata/api_compat.go
@@ -12,6 +12,10 @@ import (
 const (
 	apiVersionReadyAndSearchFilters = "0.8.0"
 	apiVersionGlobalListFilters     = "0.9.0"
+	// apiVersionMCPServer is the oldest daemon the native MCP server can
+	// drive: it pins relationship targets with to_project_uid and
+	// expected_project_uids and pages audit rows by event_id.
+	apiVersionMCPServer = "0.11.0"
 )
 
 // requireDaemonAPIVersion fails closed before a request that uses query

--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -3,12 +3,16 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"strings"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/kata/internal/config"
 	mcpserver "go.kenn.io/kata/internal/mcp"
+	"go.kenn.io/kata/internal/storageadmin"
 	"go.kenn.io/kata/internal/version"
 	kataclient "go.kenn.io/kata/pkg/client"
 )
@@ -23,15 +27,46 @@ func newMCPCmd() *cobra.Command {
 }
 
 func newMCPServeCmd() *cobra.Command {
-	return &cobra.Command{
+	var projects []string
+	var storageRoot string
+	var storageTargets []string
+	var enableTokenAdmin bool
+	command := &cobra.Command{
 		Use:   "serve",
-		Short: "serve the bound project over stdio",
+		Short: "serve Kata tools over stdio",
 		Args:  cobra.NoArgs,
 		RunE: func(command *cobra.Command, _ []string) error {
+			if strings.TrimSpace(storageRoot) == "" && len(storageTargets) > 0 {
+				return errors.New("--storage-target requires --storage-root")
+			}
+			if len(projects) > 0 && strings.TrimSpace(flags.Workspace) != "" {
+				return errors.New("--projects cannot be combined with --workspace")
+			}
+			if len(projects) > 0 && strings.TrimSpace(flags.Project) != "" {
+				return errors.New("--projects cannot be combined with --project")
+			}
+			if enableTokenAdmin && (len(projects) > 0 || strings.TrimSpace(flags.Workspace) != "" || strings.TrimSpace(flags.Project) != "") {
+				return errors.New("--enable-token-admin cannot be combined with a narrow project scope")
+			}
 			ctx := command.Context()
-			start, err := resolveStartPath(flags.Workspace)
-			if err != nil {
-				return err
+			var storage *storageadmin.Admin
+			if strings.TrimSpace(storageRoot) != "" {
+				if err := requireHostLocalExport(ctx); err != nil {
+					return fmt.Errorf("enable MCP storage: %w", err)
+				}
+				targets, err := parseMCPStorageTargets(storageTargets)
+				if err != nil {
+					return err
+				}
+				sourceDSN, err := config.KataDSN(ctx)
+				if err != nil {
+					return err
+				}
+				storage, err = storageadmin.New(storageadmin.Config{Root: storageRoot, SourceDSN: sourceDSN, Targets: targets})
+				if err != nil {
+					return fmt.Errorf("configure MCP storage: %w", err)
+				}
+				defer func() { _ = storage.Close() }()
 			}
 			baseURL, err := ensureDaemon(ctx)
 			if err != nil {
@@ -41,21 +76,41 @@ func newMCPServeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			projectID, projectName, err := resolveProjectIDAndNameWithClient(ctx, httpClient, baseURL, start)
-			if err != nil {
-				return err
-			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
 			apiClient, err := kataclient.NewWithHTTPClient(baseURL, httpClient)
 			if err != nil {
 				return err
 			}
+			var scope *mcpserver.Scope
+			var projectID int64
+			var projectName string
+			switch {
+			case len(projects) > 0:
+				scope, err = mcpserver.ResolveAllowlistScope(ctx, apiClient, projects)
+			case strings.TrimSpace(flags.Workspace) != "" || strings.TrimSpace(flags.Project) != "":
+				start, startErr := resolveStartPath(flags.Workspace)
+				if startErr != nil {
+					return startErr
+				}
+				projectID, projectName, err = resolveProjectIDAndNameWithClient(ctx, httpClient, baseURL, start)
+				if err == nil {
+					scope, err = mcpserver.ResolveBoundScope(ctx, apiClient, mcpserver.ProjectIdentity{ID: projectID, Name: projectName})
+				}
+			default:
+				scope = mcpserver.NewAllScope()
+			}
+			if err != nil {
+				return fmt.Errorf("resolve MCP project scope: %w", err)
+			}
 			server, err := mcpserver.New(mcpserver.Options{
-				Client:      apiClient,
-				ProjectID:   projectID,
-				ProjectName: projectName,
-				Actor:       actor,
-				Version:     version.Version,
+				Client:           apiClient,
+				Scope:            scope,
+				ProjectID:        projectID,
+				ProjectName:      projectName,
+				Actor:            actor,
+				Version:          version.Version,
+				StorageAdmin:     storage,
+				EnableTokenAdmin: enableTokenAdmin,
 			})
 			if err != nil {
 				return err
@@ -74,6 +129,27 @@ func newMCPServeCmd() *cobra.Command {
 			return err
 		},
 	}
+	command.Flags().StringSliceVar(&projects, "projects", nil, "serve only these project names")
+	command.Flags().StringVar(&storageRoot, "storage-root", "", "enable host-local JSONL artifacts under this directory")
+	command.Flags().StringArrayVar(&storageTargets, "storage-target", nil, "approved import target alias=path-or-DSN (repeatable)")
+	command.Flags().BoolVar(&enableTokenAdmin, "enable-token-admin", false, "enable daemon token administration tools")
+	return command
+}
+
+func parseMCPStorageTargets(values []string) (map[string]string, error) {
+	targets := make(map[string]string, len(values))
+	for _, value := range values {
+		parts := strings.SplitN(value, "=", 2)
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+			return nil, fmt.Errorf("invalid --storage-target %q; expected alias=path-or-DSN", value)
+		}
+		alias, target := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		if _, exists := targets[alias]; exists {
+			return nil, fmt.Errorf("duplicate --storage-target alias %q", alias)
+		}
+		targets[alias] = target
+	}
+	return targets, nil
 }
 
 func asReadCloser(reader io.Reader) io.ReadCloser {

--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -76,7 +76,11 @@ func newMCPServeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			httpClient, err := httpClientFor(ctx, baseURL)
+			// MCP tools include bounded long-running calls (event waits up
+			// to 300s, sync passes) and SSE streams, so the client carries
+			// no overall timeout; every handler bounds its own work with
+			// request contexts and the SSE handshake header timeout.
+			httpClient, err := streamingClientFor(ctx, baseURL)
 			if err != nil {
 				return err
 			}

--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -27,6 +27,7 @@ func newMCPCmd() *cobra.Command {
 }
 
 func newMCPServeCmd() *cobra.Command {
+	var allProjects bool
 	var projects []string
 	var storageRoot string
 	var storageTargets []string
@@ -39,14 +40,17 @@ func newMCPServeCmd() *cobra.Command {
 			if strings.TrimSpace(storageRoot) == "" && len(storageTargets) > 0 {
 				return errors.New("--storage-target requires --storage-root")
 			}
+			if allProjects && (len(projects) > 0 || strings.TrimSpace(flags.Workspace) != "" || strings.TrimSpace(flags.Project) != "") {
+				return errors.New("--all-projects cannot be combined with --projects, --project, or --workspace")
+			}
 			if len(projects) > 0 && strings.TrimSpace(flags.Workspace) != "" {
 				return errors.New("--projects cannot be combined with --workspace")
 			}
 			if len(projects) > 0 && strings.TrimSpace(flags.Project) != "" {
 				return errors.New("--projects cannot be combined with --project")
 			}
-			if enableTokenAdmin && (len(projects) > 0 || strings.TrimSpace(flags.Workspace) != "" || strings.TrimSpace(flags.Project) != "") {
-				return errors.New("--enable-token-admin cannot be combined with a narrow project scope")
+			if enableTokenAdmin && !allProjects {
+				return errors.New("--enable-token-admin requires --all-projects")
 			}
 			ctx := command.Context()
 			var storage *storageadmin.Admin
@@ -85,19 +89,22 @@ func newMCPServeCmd() *cobra.Command {
 			var projectID int64
 			var projectName string
 			switch {
+			case allProjects:
+				scope = mcpserver.NewAllScope()
 			case len(projects) > 0:
 				scope, err = mcpserver.ResolveAllowlistScope(ctx, apiClient, projects)
-			case strings.TrimSpace(flags.Workspace) != "" || strings.TrimSpace(flags.Project) != "":
+			default:
 				start, startErr := resolveStartPath(flags.Workspace)
 				if startErr != nil {
 					return startErr
 				}
 				projectID, projectName, err = resolveProjectIDAndNameWithClient(ctx, httpClient, baseURL, start)
+				if err != nil && strings.TrimSpace(flags.Workspace) == "" && strings.TrimSpace(flags.Project) == "" {
+					err = fmt.Errorf("%w (run inside a kata workspace, or pass --project, --workspace, --projects, or --all-projects)", err)
+				}
 				if err == nil {
 					scope, err = mcpserver.ResolveBoundScope(ctx, apiClient, mcpserver.ProjectIdentity{ID: projectID, Name: projectName})
 				}
-			default:
-				scope = mcpserver.NewAllScope()
 			}
 			if err != nil {
 				return fmt.Errorf("resolve MCP project scope: %w", err)
@@ -129,6 +136,7 @@ func newMCPServeCmd() *cobra.Command {
 			return err
 		},
 	}
+	command.Flags().BoolVar(&allProjects, "all-projects", false, "serve every project visible to the selected daemon")
 	command.Flags().StringSliceVar(&projects, "projects", nil, "serve only these project names")
 	command.Flags().StringVar(&storageRoot, "storage-root", "", "enable host-local JSONL artifacts under this directory")
 	command.Flags().StringArrayVar(&storageTargets, "storage-target", nil, "approved import target alias=path-or-DSN (repeatable)")

--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -76,18 +76,25 @@ func newMCPServeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// MCP tools include long-running calls whose response headers
-			// arrive only at completion (sync passes) as well as bounded
-			// event waits and SSE streams, so the client carries neither an
-			// overall timeout nor a response-header timeout; every handler
-			// bounds its own work with request contexts, and the events
-			// wait deadline covers its SSE handshake.
-			httpClient, err := longRunningClientFor(ctx, baseURL)
+			// Ordinary daemon calls retain the CLI request timeout so a
+			// stalled daemon cannot consume every MCP tool-call slot.
+			httpClient, err := httpClientFor(ctx, baseURL)
 			if err != nil {
 				return err
 			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
 			apiClient, err := kataclient.NewWithHTTPClient(baseURL, httpClient)
+			if err != nil {
+				return err
+			}
+			// Sync passes, bounded waits, and SSE streams use their own
+			// request contexts and may legitimately outlive the ordinary
+			// request budget or delay response headers until completion.
+			longRunningHTTPClient, err := longRunningClientFor(ctx, baseURL)
+			if err != nil {
+				return err
+			}
+			longRunningAPIClient, err := kataclient.NewWithHTTPClient(baseURL, longRunningHTTPClient)
 			if err != nil {
 				return err
 			}
@@ -116,14 +123,15 @@ func newMCPServeCmd() *cobra.Command {
 				return fmt.Errorf("resolve MCP project scope: %w", err)
 			}
 			server, err := mcpserver.New(mcpserver.Options{
-				Client:           apiClient,
-				Scope:            scope,
-				ProjectID:        projectID,
-				ProjectName:      projectName,
-				Actor:            actor,
-				Version:          version.Version,
-				StorageAdmin:     storage,
-				EnableTokenAdmin: enableTokenAdmin,
+				Client:            apiClient,
+				LongRunningClient: longRunningAPIClient,
+				Scope:             scope,
+				ProjectID:         projectID,
+				ProjectName:       projectName,
+				Actor:             actor,
+				Version:           version.Version,
+				StorageAdmin:      storage,
+				EnableTokenAdmin:  enableTokenAdmin,
 			})
 			if err != nil {
 				return err

--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -146,10 +146,11 @@ func newMCPServeCmd() *cobra.Command {
 
 func parseMCPStorageTargets(values []string) (map[string]string, error) {
 	targets := make(map[string]string, len(values))
-	for _, value := range values {
+	for index, value := range values {
 		parts := strings.SplitN(value, "=", 2)
 		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
-			return nil, fmt.Errorf("invalid --storage-target %q; expected alias=path-or-DSN", value)
+			// Never echo the raw value: a malformed DSN can carry credentials.
+			return nil, fmt.Errorf("invalid --storage-target at position %d; expected alias=path-or-DSN", index+1)
 		}
 		alias, target := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 		if _, exists := targets[alias]; exists {

--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -76,11 +76,13 @@ func newMCPServeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// MCP tools include bounded long-running calls (event waits up
-			// to 300s, sync passes) and SSE streams, so the client carries
-			// no overall timeout; every handler bounds its own work with
-			// request contexts and the SSE handshake header timeout.
-			httpClient, err := streamingClientFor(ctx, baseURL)
+			// MCP tools include long-running calls whose response headers
+			// arrive only at completion (sync passes) as well as bounded
+			// event waits and SSE streams, so the client carries neither an
+			// overall timeout nor a response-header timeout; every handler
+			// bounds its own work with request contexts, and the events
+			// wait deadline covers its SSE handshake.
+			httpClient, err := longRunningClientFor(ctx, baseURL)
 			if err != nil {
 				return err
 			}

--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -82,6 +82,9 @@ func newMCPServeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if err := requireDaemonAPIVersion(ctx, httpClient, baseURL, apiVersionMCPServer, "kata mcp serve"); err != nil {
+				return err
+			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
 			apiClient, err := kataclient.NewWithHTTPClient(baseURL, httpClient)
 			if err != nil {

--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -100,6 +101,81 @@ func TestParseMCPStorageTargets(t *testing.T) {
 }
 
 const currentMCPProtocolVersion = "2026-07-28"
+
+func TestMCPServeEventWaitOutlivesDefaultClientTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("holds an event wait past the 5s default client timeout")
+	}
+	setupKataEnv(t)
+	t.Setenv("KATA_AUTHOR", "example-agent")
+	workspace := t.TempDir()
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects/resolve":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"project":{"id":42,"name":"spoke-project"}}`))
+		case "/api/v1/projects":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"projects":[{"id":42,"uid":"01HAAAAAAAAAAAAAAAAAAAAAAA","name":"spoke-project","metadata":{},"revision":1,"created_at":"2026-08-11T00:00:00Z"}]}`))
+		case "/api/v1/events/stream":
+			// Send SSE headers immediately, then hold the stream open with
+			// no events past the 5s default client timeout.
+			writer.Header().Set("Content-Type", "text/event-stream")
+			writer.WriteHeader(http.StatusOK)
+			writer.(http.Flusher).Flush()
+			<-request.Context().Done()
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	t.Cleanup(daemon.Close)
+
+	command := newRootCmd()
+	inputReader, inputWriter := io.Pipe()
+	outputReader, outputWriter := io.Pipe()
+	command.SetIn(inputReader)
+	command.SetOut(outputWriter)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"--workspace", workspace, "mcp", "serve"})
+	command.SetContext(context.WithValue(t.Context(), internalclient.BaseURLKey{}, daemon.URL))
+
+	done := make(chan error, 1)
+	go func() { done <- command.Execute() }()
+	responses := bufio.NewReader(outputReader)
+	send := func(id int, method string, params map[string]any) map[string]any {
+		t.Helper()
+		requestBytes, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params})
+		require.NoError(t, err)
+		_, err = inputWriter.Write(append(requestBytes, '\n'))
+		require.NoError(t, err)
+		line, err := responses.ReadBytes('\n')
+		require.NoError(t, err)
+		var response map[string]any
+		require.NoError(t, json.Unmarshal(line, &response))
+		require.NotContains(t, response, "error", string(line))
+		return response["result"].(map[string]any)
+	}
+
+	send(1, "server/discover", map[string]any{"_meta": map[string]any{
+		"io.modelcontextprotocol/protocolVersion":    currentMCPProtocolVersion,
+		"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+	}})
+	send(2, "tools/call", map[string]any{"name": "kata.load_activity", "arguments": map[string]any{}})
+	started := time.Now()
+	result := send(3, "tools/call", map[string]any{
+		"name":      "kata.events",
+		"arguments": map[string]any{"mode": "wait", "wait_seconds": 6},
+	})
+	require.GreaterOrEqual(t, time.Since(started), 5500*time.Millisecond,
+		"the wait must outlive the 5s default client timeout")
+	require.NotEqual(t, true, result["isError"], "%v", result)
+	structured := result["structuredContent"].(map[string]any)
+	require.Equal(t, true, structured["timed_out"],
+		"an event wait longer than the default client timeout must reach its own deadline")
+
+	require.NoError(t, inputWriter.Close())
+	require.NoError(t, <-done)
+}
 
 func TestMCPServeBindsProjectAndUsesStdoutOnlyForProtocol(t *testing.T) {
 	setupKataEnv(t)

--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -94,8 +94,9 @@ func TestParseMCPStorageTargets(t *testing.T) {
 
 	_, err = parseMCPStorageTargets([]string{"restore=one.db", "restore=two.db"})
 	require.ErrorContains(t, err, "duplicate")
-	_, err = parseMCPStorageTargets([]string{"missing-separator"})
+	_, err = parseMCPStorageTargets([]string{"postgres://user:hunter2@db.example/kata"})
 	require.Error(t, err)
+	require.NotContains(t, err.Error(), "hunter2", "malformed target values may carry credentials and must not be echoed")
 }
 
 const currentMCPProtocolVersion = "2026-07-28"

--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -102,6 +102,82 @@ func TestParseMCPStorageTargets(t *testing.T) {
 
 const currentMCPProtocolVersion = "2026-07-28"
 
+func TestMCPServeSyncOutlivesHandshakeTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("holds a sync response past the 10s SSE handshake timeout")
+	}
+	setupKataEnv(t)
+	t.Setenv("KATA_AUTHOR", "example-agent")
+	workspace := t.TempDir()
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects/resolve":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"project":{"id":42,"name":"spoke-project"}}`))
+		case "/api/v1/projects":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"projects":[{"id":42,"uid":"01HAAAAAAAAAAAAAAAAAAAAAAA","name":"spoke-project","metadata":{},"revision":1,"created_at":"2026-08-11T00:00:00Z"}]}`))
+		case "/api/v1/projects/42/issue-sync/github/once":
+			// A sync pass writes nothing, headers included, until it
+			// completes; hold past the 10s SSE handshake timeout.
+			select {
+			case <-request.Context().Done():
+				return
+			case <-time.After(10500 * time.Millisecond):
+			}
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{
+				"binding": {"id": 1, "project_id": 42, "provider": "github", "source_key": "github:node", "remote_id": "node", "display_name": "example/repo", "enabled": true, "interval_seconds": 900, "created_at": "2026-08-11T00:00:00Z", "updated_at": "2026-08-11T00:00:00Z"},
+				"import": {"source": "github", "created": 0, "updated": 0, "unchanged": 0, "comments": 0, "links": 0, "errors": [], "items": []},
+				"status": {"binding_id": 1, "project_id": 42, "provider": "github", "state": "idle", "enabled": true, "last_created": 0, "last_updated": 0, "last_unchanged": 0, "last_comments": 0}
+			}`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	t.Cleanup(daemon.Close)
+
+	command := newRootCmd()
+	inputReader, inputWriter := io.Pipe()
+	outputReader, outputWriter := io.Pipe()
+	command.SetIn(inputReader)
+	command.SetOut(outputWriter)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"--workspace", workspace, "mcp", "serve"})
+	command.SetContext(context.WithValue(t.Context(), internalclient.BaseURLKey{}, daemon.URL))
+
+	done := make(chan error, 1)
+	go func() { done <- command.Execute() }()
+	responses := bufio.NewReader(outputReader)
+	send := func(id int, method string, params map[string]any) map[string]any {
+		t.Helper()
+		requestBytes, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params})
+		require.NoError(t, err)
+		_, err = inputWriter.Write(append(requestBytes, '\n'))
+		require.NoError(t, err)
+		line, err := responses.ReadBytes('\n')
+		require.NoError(t, err)
+		var response map[string]any
+		require.NoError(t, json.Unmarshal(line, &response))
+		require.NotContains(t, response, "error", string(line))
+		return response["result"].(map[string]any)
+	}
+
+	send(1, "server/discover", map[string]any{"_meta": map[string]any{
+		"io.modelcontextprotocol/protocolVersion":    currentMCPProtocolVersion,
+		"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+	}})
+	send(2, "tools/call", map[string]any{"name": "kata.load_sync", "arguments": map[string]any{}})
+	result := send(3, "tools/call", map[string]any{"name": "kata.sync_once", "arguments": map[string]any{}})
+	require.NotEqual(t, true, result["isError"],
+		"a sync pass whose headers arrive after 10s must not be aborted by a response-header timeout: %v", result)
+	structured := result["structuredContent"].(map[string]any)
+	require.Equal(t, "idle", structured["status"].(map[string]any)["state"])
+
+	require.NoError(t, inputWriter.Close())
+	require.NoError(t, <-done)
+}
+
 func TestMCPServeEventWaitOutlivesDefaultClientTimeout(t *testing.T) {
 	if testing.Short() {
 		t.Skip("holds an event wait past the 5s default client timeout")

--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -23,7 +23,9 @@ func TestMCPServeProjectModesRejectFlagConflicts(t *testing.T) {
 	}{
 		{name: "allowlist with project", args: []string{"--project", "spoke-project", "mcp", "serve", "--projects", "hub-project"}},
 		{name: "allowlist with workspace", args: []string{"--workspace", t.TempDir(), "mcp", "serve", "--projects", "spoke-project"}},
-		{name: "token administration with project", args: []string{"--project", "spoke-project", "mcp", "serve", "--enable-token-admin"}},
+		{name: "all projects with project", args: []string{"--project", "spoke-project", "mcp", "serve", "--all-projects"}},
+		{name: "all projects with workspace", args: []string{"--workspace", t.TempDir(), "mcp", "serve", "--all-projects"}},
+		{name: "all projects with allowlist", args: []string{"mcp", "serve", "--all-projects", "--projects", "spoke-project"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -35,7 +37,18 @@ func TestMCPServeProjectModesRejectFlagConflicts(t *testing.T) {
 	}
 }
 
-func TestMCPServeDefaultsToDaemonWideScope(t *testing.T) {
+func TestMCPServeTokenAdminRequiresAllProjects(t *testing.T) {
+	for _, args := range [][]string{
+		{"mcp", "serve", "--enable-token-admin"},
+		{"--project", "spoke-project", "mcp", "serve", "--enable-token-admin"},
+	} {
+		command := newRootCmd()
+		command.SetArgs(args)
+		require.ErrorContains(t, command.Execute(), "--enable-token-admin requires --all-projects")
+	}
+}
+
+func TestMCPServeAllProjectsServesDaemonWideScope(t *testing.T) {
 	setupKataEnv(t)
 	t.Setenv("KATA_AUTHOR", "example-agent")
 	var requests int
@@ -49,16 +62,28 @@ func TestMCPServeDefaultsToDaemonWideScope(t *testing.T) {
 	command.SetIn(bytes.NewReader(nil))
 	command.SetOut(io.Discard)
 	command.SetErr(io.Discard)
-	command.SetArgs([]string{"mcp", "serve"})
+	command.SetArgs([]string{"mcp", "serve", "--all-projects"})
 	command.SetContext(context.WithValue(t.Context(), internalclient.BaseURLKey{}, daemon.URL))
 
 	require.NoError(t, command.Execute())
 	require.Zero(t, requests, "daemon-wide startup must not resolve the current workspace")
 }
 
-func TestMCPServeDoesNotExposeAllProjectsFlag(t *testing.T) {
-	command := newMCPServeCmd()
-	require.Nil(t, command.Flags().Lookup("all-projects"))
+func TestMCPServeDefaultRequiresWorkspaceBinding(t *testing.T) {
+	setupKataEnv(t)
+	t.Setenv("KATA_AUTHOR", "example-agent")
+	t.Chdir(t.TempDir())
+	daemon := httptest.NewServer(http.HandlerFunc(http.NotFound))
+	t.Cleanup(daemon.Close)
+
+	command := newRootCmd()
+	command.SetIn(bytes.NewReader(nil))
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"mcp", "serve"})
+	command.SetContext(context.WithValue(t.Context(), internalclient.BaseURLKey{}, daemon.URL))
+
+	require.ErrorContains(t, command.Execute(), "--all-projects")
 }
 
 func TestParseMCPStorageTargets(t *testing.T) {

--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -16,6 +16,63 @@ import (
 	"go.kenn.io/kata/internal/version"
 )
 
+func TestMCPServeProjectModesRejectFlagConflicts(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "allowlist with project", args: []string{"--project", "spoke-project", "mcp", "serve", "--projects", "hub-project"}},
+		{name: "allowlist with workspace", args: []string{"--workspace", t.TempDir(), "mcp", "serve", "--projects", "spoke-project"}},
+		{name: "token administration with project", args: []string{"--project", "spoke-project", "mcp", "serve", "--enable-token-admin"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command := newRootCmd()
+			command.SetArgs(tt.args)
+			err := command.Execute()
+			require.ErrorContains(t, err, "cannot be combined")
+		})
+	}
+}
+
+func TestMCPServeDefaultsToDaemonWideScope(t *testing.T) {
+	setupKataEnv(t)
+	t.Setenv("KATA_AUTHOR", "example-agent")
+	var requests int
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		requests++
+		http.Error(writer, "unexpected project resolution", http.StatusInternalServerError)
+	}))
+	t.Cleanup(daemon.Close)
+
+	command := newRootCmd()
+	command.SetIn(bytes.NewReader(nil))
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"mcp", "serve"})
+	command.SetContext(context.WithValue(t.Context(), internalclient.BaseURLKey{}, daemon.URL))
+
+	require.NoError(t, command.Execute())
+	require.Zero(t, requests, "daemon-wide startup must not resolve the current workspace")
+}
+
+func TestMCPServeDoesNotExposeAllProjectsFlag(t *testing.T) {
+	command := newMCPServeCmd()
+	require.Nil(t, command.Flags().Lookup("all-projects"))
+}
+
+func TestParseMCPStorageTargets(t *testing.T) {
+	targets, err := parseMCPStorageTargets([]string{"restore=restore.db", "archive=postgres://db.example/kata"})
+	require.NoError(t, err)
+	require.Equal(t, "restore.db", targets["restore"])
+	require.Equal(t, "postgres://db.example/kata", targets["archive"])
+
+	_, err = parseMCPStorageTargets([]string{"restore=one.db", "restore=two.db"})
+	require.ErrorContains(t, err, "duplicate")
+	_, err = parseMCPStorageTargets([]string{"missing-separator"})
+	require.Error(t, err)
+}
+
 const currentMCPProtocolVersion = "2026-07-28"
 
 func TestMCPServeBindsProjectAndUsesStdoutOnlyForProtocol(t *testing.T) {
@@ -23,11 +80,19 @@ func TestMCPServeBindsProjectAndUsesStdoutOnlyForProtocol(t *testing.T) {
 	t.Setenv("KATA_AUTHOR", "example-agent")
 	workspace := t.TempDir()
 	var resolved bool
+	var cataloged bool
 	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		require.Equal(t, "/api/v1/projects/resolve", request.URL.Path)
-		resolved = true
 		writer.Header().Set("Content-Type", "application/json")
-		_, _ = writer.Write([]byte(`{"project":{"id":42,"name":"spoke-project"}}`))
+		switch request.URL.Path {
+		case "/api/v1/projects/resolve":
+			resolved = true
+			_, _ = writer.Write([]byte(`{"project":{"id":42,"name":"spoke-project"}}`))
+		case "/api/v1/projects":
+			cataloged = true
+			_, _ = writer.Write([]byte(`{"projects":[{"id":42,"uid":"01HAAAAAAAAAAAAAAAAAAAAAAA","name":"spoke-project","metadata":{},"revision":1,"created_at":"2026-08-11T00:00:00Z"}]}`))
+		default:
+			http.NotFound(writer, request)
+		}
 	}))
 	t.Cleanup(daemon.Close)
 
@@ -66,6 +131,7 @@ func TestMCPServeBindsProjectAndUsesStdoutOnlyForProtocol(t *testing.T) {
 	rest, err := io.ReadAll(outputReader)
 	require.NoError(t, err)
 	require.True(t, resolved)
+	require.True(t, cataloged)
 	require.Empty(t, stderr.String())
 	require.Empty(t, rest, "stdout must contain protocol messages only")
 	var response struct {

--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -253,6 +253,67 @@ func TestMCPServeEventWaitOutlivesDefaultClientTimeout(t *testing.T) {
 	require.NoError(t, <-done)
 }
 
+func TestMCPServeOrdinaryRequestsUseDefaultClientTimeout(t *testing.T) {
+	setupKataEnv(t)
+	t.Setenv("KATA_AUTHOR", "example-agent")
+	t.Setenv("KATA_HTTP_TIMEOUT", "100ms")
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/instance" {
+			http.NotFound(writer, request)
+			return
+		}
+		select {
+		case <-request.Context().Done():
+			return
+		case <-time.After(time.Second):
+			http.Error(writer, "delayed daemon response", http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(daemon.Close)
+
+	command := newRootCmd()
+	inputReader, inputWriter := io.Pipe()
+	outputReader, outputWriter := io.Pipe()
+	command.SetIn(inputReader)
+	command.SetOut(outputWriter)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"mcp", "serve", "--all-projects"})
+	commandContext, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	t.Cleanup(cancel)
+	command.SetContext(context.WithValue(commandContext, internalclient.BaseURLKey{}, daemon.URL))
+
+	done := make(chan error, 1)
+	go func() { done <- command.Execute() }()
+	responses := bufio.NewReader(outputReader)
+	send := func(id int, method string, params map[string]any) map[string]any {
+		t.Helper()
+		requestBytes, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params})
+		require.NoError(t, err)
+		_, err = inputWriter.Write(append(requestBytes, '\n'))
+		require.NoError(t, err)
+		line, err := responses.ReadBytes('\n')
+		require.NoError(t, err)
+		var response map[string]any
+		require.NoError(t, json.Unmarshal(line, &response))
+		require.NotContains(t, response, "error", string(line))
+		return response["result"].(map[string]any)
+	}
+
+	send(1, "server/discover", map[string]any{"_meta": map[string]any{
+		"io.modelcontextprotocol/protocolVersion":    currentMCPProtocolVersion,
+		"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+	}})
+	send(2, "tools/call", map[string]any{"name": "kata.load_system", "arguments": map[string]any{}})
+	started := time.Now()
+	result := send(3, "tools/call", map[string]any{"name": "kata.system", "arguments": map[string]any{}})
+	require.Less(t, time.Since(started), 500*time.Millisecond,
+		"ordinary daemon requests must use the configured client timeout")
+	require.Equal(t, true, result["isError"], "%v", result)
+
+	require.NoError(t, inputWriter.Close())
+	require.NoError(t, <-done)
+}
+
 func TestMCPServeBindsProjectAndUsesStdoutOnlyForProtocol(t *testing.T) {
 	setupKataEnv(t)
 	t.Setenv("KATA_AUTHOR", "example-agent")

--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	internalclient "go.kenn.io/kata/internal/client"
+	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/version"
 )
 
@@ -49,11 +51,25 @@ func TestMCPServeTokenAdminRequiresAllProjects(t *testing.T) {
 	}
 }
 
+// serveMCPTestHealth answers the startup API version handshake as a current
+// daemon so tests can exercise the rest of the fake daemon.
+func serveMCPTestHealth(writer http.ResponseWriter, request *http.Request) bool {
+	if request.URL.Path != "/api/v1/health" {
+		return false
+	}
+	writer.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprintf(writer, `{"ok":true,"api_schema_version":%q}`, daemon.APISchemaVersion)
+	return true
+}
+
 func TestMCPServeAllProjectsServesDaemonWideScope(t *testing.T) {
 	setupKataEnv(t)
 	t.Setenv("KATA_AUTHOR", "example-agent")
 	var requests int
-	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if serveMCPTestHealth(writer, request) {
+			return
+		}
 		requests++
 		http.Error(writer, "unexpected project resolution", http.StatusInternalServerError)
 	}))
@@ -70,11 +86,43 @@ func TestMCPServeAllProjectsServesDaemonWideScope(t *testing.T) {
 	require.Zero(t, requests, "daemon-wide startup must not resolve the current workspace")
 }
 
+func TestMCPServeRejectsDaemonBeforeRelationshipPinning(t *testing.T) {
+	setupKataEnv(t)
+	t.Setenv("KATA_AUTHOR", "example-agent")
+	var otherRequests int
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/v1/health" {
+			_, _ = writer.Write([]byte(`{"ok":true,"api_schema_version":"0.10.0"}`))
+			return
+		}
+		otherRequests++
+		http.NotFound(writer, request)
+	}))
+	t.Cleanup(daemon.Close)
+
+	command := newRootCmd()
+	command.SetIn(bytes.NewReader(nil))
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"mcp", "serve", "--all-projects"})
+	command.SetContext(context.WithValue(t.Context(), internalclient.BaseURLKey{}, daemon.URL))
+
+	err := command.Execute()
+	require.ErrorContains(t, err, "requires daemon API 0.11.0 or newer")
+	require.ErrorContains(t, err, "reports 0.10.0")
+	require.Zero(t, otherRequests, "an incompatible daemon must be rejected before any MCP traffic")
+}
+
 func TestMCPServeDefaultRequiresWorkspaceBinding(t *testing.T) {
 	setupKataEnv(t)
 	t.Setenv("KATA_AUTHOR", "example-agent")
 	t.Chdir(t.TempDir())
-	daemon := httptest.NewServer(http.HandlerFunc(http.NotFound))
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if serveMCPTestHealth(writer, request) {
+			return
+		}
+		http.NotFound(writer, request)
+	}))
 	t.Cleanup(daemon.Close)
 
 	command := newRootCmd()
@@ -110,6 +158,9 @@ func TestMCPServeSyncOutlivesHandshakeTimeout(t *testing.T) {
 	t.Setenv("KATA_AUTHOR", "example-agent")
 	workspace := t.TempDir()
 	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if serveMCPTestHealth(writer, request) {
+			return
+		}
 		switch request.URL.Path {
 		case "/api/v1/projects/resolve":
 			writer.Header().Set("Content-Type", "application/json")
@@ -186,6 +237,9 @@ func TestMCPServeEventWaitOutlivesDefaultClientTimeout(t *testing.T) {
 	t.Setenv("KATA_AUTHOR", "example-agent")
 	workspace := t.TempDir()
 	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if serveMCPTestHealth(writer, request) {
+			return
+		}
 		switch request.URL.Path {
 		case "/api/v1/projects/resolve":
 			writer.Header().Set("Content-Type", "application/json")
@@ -258,6 +312,9 @@ func TestMCPServeOrdinaryRequestsUseDefaultClientTimeout(t *testing.T) {
 	t.Setenv("KATA_AUTHOR", "example-agent")
 	t.Setenv("KATA_HTTP_TIMEOUT", "100ms")
 	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if serveMCPTestHealth(writer, request) {
+			return
+		}
 		if request.URL.Path != "/api/v1/instance" {
 			http.NotFound(writer, request)
 			return
@@ -321,6 +378,9 @@ func TestMCPServeBindsProjectAndUsesStdoutOnlyForProtocol(t *testing.T) {
 	var resolved bool
 	var cataloged bool
 	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if serveMCPTestHealth(writer, request) {
+			return
+		}
 		writer.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
 		case "/api/v1/projects/resolve":

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,9 +34,9 @@ All notable changes to kata, grouped by release. Versioned releases start with
   sidecars, require exact confirmation before replacing an artifact or target,
   and install restores race-safely with owner-only permissions.
 - Gated daemon token administration behind the explicit `--enable-token-admin`
-  capability in daemon-wide scope, kept credential-minting federation
-  enrollment outside MCP entirely, and restricted enabling issue
-  synchronization — which selects the repository the daemon's GitHub
+  capability in daemon-wide scope, kept federation topology changes
+  (enrollment and spoke join) outside MCP entirely, and restricted enabling
+  issue synchronization — which selects the repository the daemon's GitHub
   credentials read — to the daemon-wide scope: scoped servers can only
   disable or run the operator-configured binding.
 - Redacted cross-scope relationship identities, including parent, link,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,14 +17,30 @@ All notable changes to kata, grouped by release. Versioned releases start with
 - Expanded the native MCP server from the original project-bound issue tools
   to complete scoped issue, project, token, federation, synchronization,
   recurrence, import, digest, and live-event workflows.
-- Made MCP follow all projects in the selected daemon by default, with optional
-  one-project and fixed-allowlist boundaries.
+- Scoped `kata mcp serve` to the current workspace project by default, with
+  explicit one-project (`--project`/`--workspace`), fixed-allowlist
+  (`--projects`, pinned by immutable UID and rename-safe), and daemon-wide
+  (`--all-projects`) boundaries. Scoped graph, pagination, token, and
+  federation operations cannot cross their startup boundary, and an allowlist
+  keeps serving its remaining projects when one member is archived or merged
+  away.
 - Added 13 section loaders that progressively disclose the detailed typed MCP
   tools and publish tool-list change notifications.
 - Added first-class MCP scheduling fields, force-create and force-claim, and
   generic metadata support for native markers such as `someday=true`.
 - Added explicit host-local JSONL export and configured-target import tools
-  behind `--storage-root` and startup target aliases.
+  behind `--storage-root` and startup target aliases. Storage operations stay
+  anchored to the configured root, protect active SQLite databases and
+  sidecars, require exact confirmation before replacing an artifact or target,
+  and install restores race-safely with owner-only permissions.
+- Gated daemon token administration behind the explicit `--enable-token-admin`
+  capability in daemon-wide scope, and kept credential-minting federation
+  enrollment outside MCP entirely: scoped status, enrollment revocation, join,
+  phased leave with commit acknowledgement, rebind, and quarantine tools
+  remain, and no MCP tool creates or returns enrollment secrets.
+- Redacted cross-scope relationship identities, including parent, link,
+  relationship-array, moved-project, and audit parent references, from scoped
+  MCP issue, event, and close-audit results.
 
 **Improvements**
 
@@ -32,22 +48,6 @@ All notable changes to kata, grouped by release. Versioned releases start with
   projection rules as `scheduled_on`.
 - Added schedule, deadline, and someday commands to generated agent guidance and
   public workflow documentation.
-
-**Bug fixes**
-
-- Kept fixed MCP scopes intact across project renames and prevented scoped
-  graph, pagination, token, and federation operations from crossing their
-  startup boundary.
-- Protected active and configured SQLite paths from storage export overwrite,
-  and required exact confirmation before replacing an existing artifact.
-- Made token administration an explicit MCP startup capability, made federation
-  leave phases and commit acknowledgement explicit, and made storage restore
-  installation race-safe and rollback-aware.
-- Anchored MCP storage operations to their configured root, protected active
-  SQLite sidecars, preserved owner-only restore permissions, and redacted
-  cross-scope relationship data from issue and event results.
-- Made `kata.next` consider the complete ready set, returned archived projects
-  from the catalog, and rejected partial two-request issue-plus-metadata edits.
 
 ## 0.14.3
 <small>2026-08-10</small>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,6 +54,14 @@ All notable changes to kata, grouped by release. Versioned releases start with
   projection rules as `scheduled_on`.
 - Added schedule, deadline, and someday commands to generated agent guidance and
   public workflow documentation.
+- Added `event_id` to close-audit rows so audit results page with an
+  immutable cursor that purges, merges, and shared timestamps cannot skew.
+
+**Bug fixes**
+
+- Restored the `clear_owner` and `clear_priority` recurrence template fields
+  to the generated Go client; a stale template had silently dropped them from
+  `pkg/client` since their introduction.
 
 ## 0.14.3
 <small>2026-08-10</small>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 ---
 title: Changelog
 description: Release history for kata
-last_edited: 2026-08-12
+last_edited: 2026-08-15
 ---
 
 All notable changes to kata, grouped by release. Versioned releases start with
@@ -58,6 +58,10 @@ All notable changes to kata, grouped by release. Versioned releases start with
 - Added `event_id` and the close-time frozen `parent_uid` to close-audit
   rows so audit results page with an immutable cursor and parent display
   refs carry provable provenance.
+- Bumped the HTTP API schema version to `0.11.0` for the pinned relationship
+  target fields (`to_project_uid`, `expected_project_uids`) and close-audit
+  `event_id`; `kata mcp serve` now checks the daemon API version at startup
+  and refuses older daemons instead of failing later inside tool calls.
 
 **Bug fixes**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -55,8 +55,9 @@ All notable changes to kata, grouped by release. Versioned releases start with
   projection rules as `scheduled_on`.
 - Added schedule, deadline, and someday commands to generated agent guidance and
   public workflow documentation.
-- Added `event_id` to close-audit rows so audit results page with an
-  immutable cursor that purges, merges, and shared timestamps cannot skew.
+- Added `event_id` and the close-time frozen `parent_uid` to close-audit
+  rows so audit results page with an immutable cursor and parent display
+  refs carry provable provenance.
 
 **Bug fixes**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,17 @@ All notable changes to kata, grouped by release. Versioned releases start with
 - Added paired `kata schedule` / `kata deadline` commands and
   `kata.set_schedule` / `kata.set_deadline` MCP tools for first-class planning
   date updates.
+- Expanded the native MCP server from the original project-bound issue tools
+  to complete scoped issue, project, token, federation, synchronization,
+  recurrence, import, digest, and live-event workflows.
+- Made MCP follow all projects in the selected daemon by default, with optional
+  one-project and fixed-allowlist boundaries.
+- Added 13 section loaders that progressively disclose the detailed typed MCP
+  tools and publish tool-list change notifications.
+- Added first-class MCP scheduling fields, force-create and force-claim, and
+  generic metadata support for native markers such as `someday=true`.
+- Added explicit host-local JSONL export and configured-target import tools
+  behind `--storage-root` and startup target aliases.
 
 **Improvements**
 
@@ -21,6 +32,22 @@ All notable changes to kata, grouped by release. Versioned releases start with
   projection rules as `scheduled_on`.
 - Added schedule, deadline, and someday commands to generated agent guidance and
   public workflow documentation.
+
+**Bug fixes**
+
+- Kept fixed MCP scopes intact across project renames and prevented scoped
+  graph, pagination, token, and federation operations from crossing their
+  startup boundary.
+- Protected active and configured SQLite paths from storage export overwrite,
+  and required exact confirmation before replacing an existing artifact.
+- Made token administration an explicit MCP startup capability, made federation
+  leave phases and commit acknowledgement explicit, and made storage restore
+  installation race-safe and rollback-aware.
+- Anchored MCP storage operations to their configured root, protected active
+  SQLite sidecars, preserved owner-only restore permissions, and redacted
+  cross-scope relationship data from issue and event results.
+- Made `kata.next` consider the complete ready set, returned archived projects
+  from the catalog, and rejected partial two-request issue-plus-metadata edits.
 
 ## 0.14.3
 <small>2026-08-10</small>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,10 +35,11 @@ All notable changes to kata, grouped by release. Versioned releases start with
   and install restores race-safely with owner-only permissions.
 - Gated daemon token administration behind the explicit `--enable-token-admin`
   capability in daemon-wide scope, kept federation topology changes
-  (enrollment and spoke join) outside MCP entirely, and restricted enabling
+  (enrollment and spoke join) outside MCP entirely, restricted enabling
   issue synchronization — which selects the repository the daemon's GitHub
-  credentials read — to the daemon-wide scope: scoped servers can only
-  disable or run the operator-configured binding.
+  credentials read — to the daemon-wide scope, and required that same scope
+  for project administration: a scoped server can read its projects but
+  cannot rename, merge, archive, restore, or purge them.
 - Redacted cross-scope relationship identities, including parent, link,
   relationship-array, moved-project, close-evidence, close-throttle, and
   audit parent references, from scoped MCP issue, event, digest, edit-delta,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,14 +34,19 @@ All notable changes to kata, grouped by release. Versioned releases start with
   sidecars, require exact confirmation before replacing an artifact or target,
   and install restores race-safely with owner-only permissions.
 - Gated daemon token administration behind the explicit `--enable-token-admin`
-  capability in daemon-wide scope, and kept credential-minting federation
-  enrollment outside MCP entirely: scoped status, enrollment revocation, join,
-  phased leave with commit acknowledgement, rebind, and quarantine tools
-  remain, and no MCP tool creates or returns enrollment secrets.
+  capability in daemon-wide scope, kept credential-minting federation
+  enrollment outside MCP entirely, and restricted enabling issue
+  synchronization — which selects the repository the daemon's GitHub
+  credentials read — to the daemon-wide scope: scoped servers can only
+  disable or run the operator-configured binding.
 - Redacted cross-scope relationship identities, including parent, link,
-  relationship-array, moved-project, and audit parent references, from scoped
-  MCP issue, event, digest, edit-delta, and close-audit results, and rejected
-  close-audit parent filters that cannot prove startup-scope membership.
+  relationship-array, moved-project, close-evidence, close-throttle, and
+  audit parent references, from scoped MCP issue, event, digest, edit-delta,
+  and close-audit results, and rejected close-audit parent filters that
+  cannot prove startup-scope membership.
+- Compared PostgreSQL storage-import targets with the active daemon storage
+  by persisted instance identity, so equivalent DSN spellings cannot bypass
+  the textual overlap guard.
 
 **Improvements**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -65,6 +65,12 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 **Bug fixes**
 
+- Rejected add-side link targets whose project is archived inside the mutation
+  transaction (initial links, atomic-edit adds and `set_parent`, and link
+  creation) with the same `409 link_target_archived` the preflight returns, so
+  an archival that races the preflight cannot insert a link to an archived
+  project. PostgreSQL share-locks the target project row alongside the issue
+  row; existing links to archived projects stay removable.
 - Restored the `clear_owner` and `clear_priority` recurrence template fields
   to the generated Go client; a stale template had silently dropped them from
   `pkg/client` since their introduction.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,7 +40,8 @@ All notable changes to kata, grouped by release. Versioned releases start with
   remain, and no MCP tool creates or returns enrollment secrets.
 - Redacted cross-scope relationship identities, including parent, link,
   relationship-array, moved-project, and audit parent references, from scoped
-  MCP issue, event, and close-audit results.
+  MCP issue, event, digest, edit-delta, and close-audit results, and rejected
+  close-audit parent filters that cannot prove startup-scope membership.
 
 **Improvements**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,8 +146,8 @@ is a local ledger for the work itself. They coexist. See
 -   [__Concepts__](guide/concepts.md). The data model and how the pieces fit.
 -   [__Web UI__](guide/web-ui.md). Manage projects and issues in the browser.
 -   [__CLI reference__](reference/cli.md). Every command and flag.
--   [__Model Context Protocol__](reference/mcp.md). Connect an MCP agent to one
-    bound Kata project.
+-   [__Model Context Protocol__](reference/mcp.md). Connect an MCP agent to the
+    workspace project, a fixed allowlist, or the whole daemon.
 -   [__Semantic search__](guide/semantic-search.md). Improve issue discovery
     with opt-in embeddings.
 -   [__GitHub sync__](operations/github-sync.md). Bring GitHub issues into kata.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -79,12 +79,14 @@ hooks together.
 ```sh
 kata [--workspace PATH | --project NAME] [--daemon NAME] [--as ACTOR] mcp serve
 kata mcp serve --projects NAME[,NAME...]
-kata mcp serve --enable-token-admin
+kata mcp serve --all-projects [--enable-token-admin]
 ```
 
-`kata mcp serve` starts Kata's native MCP stdio server and follows all projects
-in the selected daemon catalog by default. `--workspace` or `--project` narrows
-the process to one project. `--projects` fixes an allowlist by project UID. The
+`kata mcp serve` starts Kata's native MCP stdio server bound to the current
+workspace's project by default. `--workspace` or `--project` selects one
+explicit project. `--projects` fixes an allowlist of project names, pinned by
+immutable project UID. `--all-projects` follows every project in the selected
+daemon catalog. The
 startup scope and actor apply to every tool call. The initial catalog contains
 13 section loaders that progressively expose the detailed typed tools. Optional
 `--storage-root` and repeatable `--storage-target

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -78,13 +78,20 @@ hooks together.
 
 ```sh
 kata [--workspace PATH | --project NAME] [--daemon NAME] [--as ACTOR] mcp serve
+kata mcp serve --projects NAME[,NAME...]
+kata mcp serve --enable-token-admin
 ```
 
-`kata mcp serve` starts Kata's native, project-bound MCP stdio server. It
-negotiates supported protocol revisions and keeps stdout reserved for
-newline-delimited JSON-RPC. The startup project and actor apply to every tool
-call. See the [MCP reference](mcp.md) for client configuration, the 13-tool
-surface, limits, and deliberate exclusions.
+`kata mcp serve` starts Kata's native MCP stdio server and follows all projects
+in the selected daemon catalog by default. `--workspace` or `--project` narrows
+the process to one project. `--projects` fixes an allowlist by project UID. The
+startup scope and actor apply to every tool call. The initial catalog contains
+13 section loaders that progressively expose the detailed typed tools. Optional
+`--storage-root` and repeatable `--storage-target
+alias=path-or-DSN` enable the otherwise absent host-local JSONL tools. See the
+[MCP reference](mcp.md) for the complete catalog, scheduling formats, safety
+rules, and limits. Daemon-wide token tools are absent unless
+`--enable-token-admin` is explicit.
 
 ## Issue lifecycle
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-08
+last_edited: 2026-08-15
 ---
 
 # HTTP API schema
@@ -42,7 +42,7 @@ The schema carries a version in its `info.version` field
 {
   "ok": true,
   "schema_version": 7,
-  "api_schema_version": "0.10.0",
+  "api_schema_version": "0.11.0",
   "version": "1.4.2",
   "uptime": "5m0s",
   "db_path": "/path/to/kata.db"
@@ -68,7 +68,10 @@ The first-party CLI uses this check before requests where an older daemon
 could ignore a filter and return unfiltered rows. Filtered `search` and
 filtered `ready --all` require API `0.8.0`; filtered `list --all` requires API
 `0.9.0`. The CLI stops before the filtered query and tells the operator to
-upgrade when the daemon is too old.
+upgrade when the daemon is too old. `kata mcp serve` performs the same check
+once at startup and requires API `0.11.0`, because its relationship tools
+always send the pinned-target fields and its close-audit paging relies on
+`event_id`.
 
 The field is **optional in the schema** even though current daemons always send
 it. That is deliberate: a version-detection field has to survive version skew,
@@ -82,6 +85,7 @@ and decline to render issue detail.
 
 | Version | Change |
 | --- | --- |
+| `0.11.0` | Added optional `to_project_uid` on create-time initial links and `expected_project_uids` on edit link deltas so clients can pin resolved relationship targets to immutable project identities inside the mutation transaction. Close-audit rows gain a required `event_id` (stable pagination cursor) and optional `parent_uid`. |
 | `0.10.0` | Added the repeatable `issue_uid` query parameter to UI references so embedding hosts can hydrate summaries by stable issue UID. |
 | `0.9.0` | Added owner, label, exclusion, and metadata filters to the cross-project issue list. Global list rows now include `project_name`. |
 | `0.8.0` | Added repeatable `label` and `exclude_label` query parameters to project-scoped search. It also identifies daemons that support filtered global ready queries. |

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -9,18 +9,21 @@ clients. The server gives typed access to Kata issue data, administration,
 automation, and event workflows.
 
 ```sh
-# Every project visible to the selected daemon (default)
+# The current workspace's project (default)
 kata mcp serve
 
-# Add explicit daemon credential administration
-kata mcp serve --enable-token-admin
-
-# One project
+# One explicit project
 kata --workspace /path/to/repository mcp serve
 kata --project example-project mcp serve
 
 # A fixed project allowlist
 kata mcp serve --projects example-project,shared-project
+
+# Every project visible to the selected daemon
+kata mcp serve --all-projects
+
+# Add explicit daemon credential administration
+kata mcp serve --all-projects --enable-token-admin
 ```
 
 JSON-RPC uses stdin and stdout. Kata writes no status text or logs to stdout.
@@ -44,15 +47,18 @@ private-network checks, and Unix socket discovery.
 
 ## Project scope
 
-The server follows the selected daemon's active project catalog by default.
-This matches a long-lived MCP client's need to use any project that the daemon
-can access. Use startup flags only when the MCP process needs a narrower
-boundary:
+The server binds the current workspace's project by default, so a bare
+`kata mcp serve` never grants an MCP peer more authority than the repository
+it was launched for. Broader boundaries are explicit startup choices:
 
-- `--workspace` or `--project` serves one project. Bare issue references remain
-  valid.
-- Allowlist mode resolves the supplied names once and keeps their immutable
-  project UIDs. A later rename does not change the boundary.
+- `--workspace` or `--project` serves one explicit project. Bare issue
+  references remain valid in one-project mode.
+- `--projects` resolves the supplied names once and keeps their immutable
+  project UIDs. A later rename does not change the boundary, and a member
+  that is later archived or merged away drops out without disabling the
+  remaining allowlist.
+- `--all-projects` follows the selected daemon's active project catalog for
+  long-lived clients that need every project the daemon can access.
 
 Multi-project issue reads and writes use `project#ref`. Project-list tools can
 read all projects in scope. Issue creation and other project-selected writes
@@ -68,7 +74,7 @@ checks, federation trust, claims, and mutation policy.
 The initial catalog contains 13 read-only section loaders. Call the applicable
 loader, then refresh the tool list when the server sends the standard
 `notifications/tools/list_changed` notification. This exposes only the detailed
-typed tools needed for the current task instead of placing all 57 tools in the
+typed tools needed for the current task instead of placing all 56 tools in the
 model context at startup.
 
 | Loader | Detailed tools |
@@ -80,7 +86,7 @@ model context at startup.
 | `kata.load_projects` | `kata.projects`, `kata.project_create`, `kata.project_update`, `kata.project_merge`, `kata.project_remove`, `kata.project_restore`, `kata.project_purge` |
 | `kata.load_tokens` | `kata.tokens`, `kata.token_create`, `kata.token_revoke` when `--enable-token-admin` is set in daemon-wide mode |
 | `kata.load_system` | `kata.system` |
-| `kata.load_federation` | `kata.federation_status`, `kata.federation_enroll`, `kata.federation_enrollment_revoke`, `kata.federation_join`, `kata.federation_rebind`, `kata.federation_leave`, `kata.federation_quarantine` |
+| `kata.load_federation` | `kata.federation_status`, `kata.federation_enrollment_revoke`, `kata.federation_join`, `kata.federation_rebind`, `kata.federation_leave`, `kata.federation_quarantine` |
 | `kata.load_sync` | `kata.sync_status`, `kata.sync_update`, `kata.sync_once` |
 | `kata.load_recurrence` | `kata.recurrences`, `kata.recurrence_update`, `kata.recurrence_delete` |
 | `kata.load_activity` | `kata.digest`, `kata.events` |
@@ -146,10 +152,16 @@ polling. A `sync.reset_required` result returns `reset_after_id`, advances
 
 `kata.token_create` returns the plaintext token once. `kata.tokens`, status
 tools, errors, and later calls never return that secret or its hash. Token
-administration requires both the default daemon-wide startup scope and the
-explicit `--enable-token-admin` startup capability. A normal server, a
-one-project server, and a fixed-allowlist server cannot read, create, or revoke
-global daemon tokens.
+administration requires both the `--all-projects` daemon-wide startup scope and
+the explicit `--enable-token-admin` startup capability. A default workspace
+server, a one-project server, and a fixed-allowlist server cannot read, create,
+or revoke global daemon tokens.
+
+Federation enrollment credentials are never minted through MCP: creating an
+enrollment and reading its token stay CLI/operator workflows.
+`kata.federation_status` lists secret-free enrollment records, and
+`kata.federation_enrollment_revoke` can revoke one, but no MCP tool creates or
+returns enrollment secrets.
 
 Federation leave exposes `preflight`, `prepare`, and `commit` phases so an
 operator can preserve the normal revoke-before-local-teardown order. The phase

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -165,6 +165,12 @@ enrollment and reading its token stay CLI/operator workflows.
 `kata.federation_enrollment_revoke` can revoke one, but no MCP tool creates or
 returns enrollment secrets.
 
+Enabling issue synchronization selects which external repository the daemon's
+configured GitHub credentials read, so `kata.sync_update` with
+`action: "enable"` requires the `--all-projects` daemon-wide scope. Scoped
+servers can still disable the operator-configured binding and run
+`kata.sync_once` against it.
+
 Federation leave exposes `preflight`, `prepare`, and `commit` phases so an
 operator can preserve the normal revoke-before-local-teardown order. The phase
 is required. A commit without external hub revocation also requires

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -72,7 +72,11 @@ cannot alter or destroy the catalog it was bound to.
 
 Tool calls cannot change the startup actor or expand the startup scope. The
 daemon remains authoritative for authentication, attribution, revision
-checks, federation trust, claims, and mutation policy.
+checks, federation trust, claims, and mutation policy. Scoped servers replace
+close-guard refusal messages (`parent_has_open_children`,
+`sibling_throttle`, `duplicate_message`) with scope-safe guidance because
+the daemon prose can name children, siblings, and prior closes in other
+projects.
 
 ## Progressive tool catalog
 
@@ -195,10 +199,15 @@ Quarantine retry and skip require
 JSONL storage access is absent by default. Enable it only on the daemon host:
 
 ```sh
-kata mcp serve \
+kata mcp serve --all-projects \
   --storage-root /srv/kata/exchange \
   --storage-target restore=restore.db
 ```
+
+`kata.storage_export` additionally requires the `--all-projects` daemon-wide
+scope even when a `project` filter is supplied: a project-filtered JSONL
+export still contains cross-project link rows and unredacted event payload
+references that scoped reads deliberately hide.
 
 `--storage-target alias=path-or-DSN` is repeatable. Tool calls select an alias;
 they cannot submit a database path or DSN. Artifact paths are relative to the

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -100,9 +100,10 @@ into a generic command tool.
 
 The tools use structured input and output. List-like results, including
 `kata.audit_closes` rows, default to 20 and are bounded at 100;
-`kata.audit_closes` pages over a stable append-only row order, reporting
-`truncated` and a `next_offset` cursor. `kata.show` returns at most 100
-comments. Create and
+`kata.audit_closes` pages with an immutable close-event-ID cursor
+(`after_event_id` in, `truncated` plus `next_after_event_id` out), so purges,
+merges, and shared timestamps cannot skip or repeat rows. `kata.show` returns
+at most 100 comments. Create and
 comment require idempotency keys. `kata.token_create` and recurrence creation
 have no idempotency key, are annotated non-idempotent, and mint a new record
 on every identical retry. Destructive tools preserve Kata's exact

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -181,8 +181,10 @@ servers can still disable the operator-configured binding and run
 Federation leave exposes `preflight`, `prepare`, and `commit` phases so an
 operator can preserve the normal revoke-before-local-teardown order. The phase
 is required. A commit without external hub revocation also requires
-`COMMIT FEDERATION LEAVE <project>`. Replica credentials stay pinned to the hub
-origin by the daemon. Quarantine retry and skip require
+`COMMIT FEDERATION LEAVE <project>`. The `archive` disposition and
+`kata.federation_rebind` — which routes the replica's enrollment token to the
+selected catalog origin — require the `--all-projects` daemon-wide scope.
+Quarantine retry and skip require
 `RETRY FEDERATION BATCH <id>` or `SKIP FEDERATION BATCH <id>`.
 
 ## Host-storage opt-in

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -100,7 +100,9 @@ into a generic command tool.
 
 The tools use structured input and output. List-like results default to 20 and
 are bounded at 100. `kata.show` returns at most 100 comments. Create and
-comment require idempotency keys. Destructive tools preserve Kata's exact
+comment require idempotency keys. `kata.token_create` and recurrence creation
+have no idempotency key, are annotated non-idempotent, and mint a new record
+on every identical retry. Destructive tools preserve Kata's exact
 confirmation and revision contracts.
 
 Recurrence patch and delete calls require the current positive `revision` and

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -61,7 +61,10 @@ it was launched for. Broader boundaries are explicit startup choices:
   long-lived clients that need every project the daemon can access.
 
 Multi-project issue reads and writes use `project#ref`. Project-list tools can
-read all projects in scope. Issue creation and other project-selected writes
+read all projects in scope. Multi-project results carry a `projects` list and
+omit the singular `project` field; multi-project search interleaves each
+project's own ranking (per-project scores are not comparable) and reports
+`mode: "mixed"` when projects resolve different effective search modes. Issue creation and other project-selected writes
 require an explicit `project` in multi-project mode. Project administration —
 create, rename, metadata, merge, archive, restore, and purge — requires the
 `--all-projects` daemon-wide scope; a scoped server can read its projects but

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -100,10 +100,11 @@ into a generic command tool.
 
 The tools use structured input and output. List-like results, including
 `kata.audit_closes` rows, default to 20 and are bounded at 100;
-`kata.audit_closes` pages with an immutable close-event-ID cursor
-(`after_event_id` in, `truncated` plus `next_after_event_id` out), so purges,
-merges, and shared timestamps cannot skip or repeat rows. `kata.show` returns
-at most 100 comments. Create and
+`kata.audit_closes` pages with an opaque `cursor` (`truncated` plus
+`next_cursor` out) validated against the close history below it, so shared
+timestamps cannot skip or repeat rows and a project merge or issue purge
+during pagination fails the page with a restart error instead of silently
+skewing it. `kata.show` returns at most 100 comments. Create and
 comment require idempotency keys. `kata.token_create` and recurrence creation
 have no idempotency key, are annotated non-idempotent, and mint a new record
 on every identical retry. Destructive tools preserve Kata's exact

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -4,129 +4,200 @@ last_edited: 2026-08-12
 
 # Model Context Protocol server
 
-Kata includes a native stdio server for coding agents and other MCP clients:
+Kata includes a native stdio MCP server for coding agents and other MCP
+clients. The server gives typed access to Kata issue data, administration,
+automation, and event workflows.
 
 ```sh
+# Every project visible to the selected daemon (default)
+kata mcp serve
+
+# Add explicit daemon credential administration
+kata mcp serve --enable-token-admin
+
+# One project
 kata --workspace /path/to/repository mcp serve
+kata --project example-project mcp serve
+
+# A fixed project allowlist
+kata mcp serve --projects example-project,shared-project
 ```
 
-The process binds one Kata project and one actor when it starts. It then serves
-project-scoped issue tools until the client closes stdin. JSON-RPC uses stdin
-and stdout. Kata writes no status text or logs to stdout.
+JSON-RPC uses stdin and stdout. Kata writes no status text or logs to stdout.
+The actor is fixed when the process starts and uses the normal precedence:
+`--as`, `KATA_AUTHOR`, `USER`, Git `user.name`, then `anonymous`.
 
 ## Client configuration
 
-Configure the MCP client to start the Kata binary in the target workspace. A
-typical command configuration has this shape:
+A typical client command has this shape:
 
 ```json
 {
   "command": "kata",
-  "args": ["--workspace", "/path/to/repository", "mcp", "serve"]
+  "args": ["mcp", "serve"]
 }
 ```
 
-You can replace `--workspace` with `--project <name>` when the client should
-bind an explicit project. Use `--daemon <name>` to select a configured daemon.
-The normal Kata client settings also apply, including `KATA_SERVER`, bearer
-authentication, private-network checks, and Unix socket discovery.
+Use `--daemon <name>` to select a configured daemon. The normal client
+settings also apply, including `KATA_SERVER`, bearer authentication,
+private-network checks, and Unix socket discovery.
 
-The actor uses the normal precedence:
+## Project scope
 
-1. `--as`
-2. `KATA_AUTHOR`
-3. `USER`
-4. `git config user.name`
-5. `anonymous`
+The server follows the selected daemon's active project catalog by default.
+This matches a long-lived MCP client's need to use any project that the daemon
+can access. Use startup flags only when the MCP process needs a narrower
+boundary:
 
-The actor and project cannot be changed by a tool call. Start another server
-process to use a different identity or project.
+- `--workspace` or `--project` serves one project. Bare issue references remain
+  valid.
+- Allowlist mode resolves the supplied names once and keeps their immutable
+  project UIDs. A later rename does not change the boundary.
 
-## Protocol contract
+Multi-project issue reads and writes use `project#ref`. Project-list tools can
+read all projects in scope. Issue creation and other project-selected writes
+require an explicit `project` in multi-project mode. Project creation is available
+only in daemon-wide mode.
 
-Kata delegates protocol negotiation to its bundled official Go MCP SDK.
-Current clients can use the stateless `server/discover` flow and per-request
-metadata; handshake-based clients can use `initialize` followed by
-`notifications/initialized`. Both paths expose the same project-bound tools.
+Tool calls cannot change the startup actor or expand the startup scope. The
+daemon remains authoritative for authentication, attribution, revision
+checks, federation trust, claims, and mutation policy.
 
-Unsupported revisions receive the standard MCP negotiation error with the
-revisions supported by the bundled SDK. JSON-RPC batches are rejected. Each
-stdio message must be compact JSON on one line and is limited to 8 MiB.
+## Progressive tool catalog
 
-Kata advertises tools only. It does not advertise prompts, resources, roots,
-logging, sampling, server-to-client requests, subscriptions, or tool-list
-change notifications. Discovery and tool catalogs use a five-minute private
-cache hint when the negotiated revision supports it. Tool execution is limited
-to 20 starts per second with a burst of 20 and at most eight concurrent daemon
-calls per process.
+The initial catalog contains 13 read-only section loaders. Call the applicable
+loader, then refresh the tool list when the server sends the standard
+`notifications/tools/list_changed` notification. This exposes only the detailed
+typed tools needed for the current task instead of placing all 55 tools in the
+model context at startup.
 
-## Tools
-
-| Tool | Behavior |
+| Loader | Detailed tools |
 | --- | --- |
-| `kata.search` | Search issue titles, bodies, and comments. |
-| `kata.list` | List compact issue summaries with project filters. |
-| `kata.show` | Read one issue with bounded comments and relationships. |
-| `kata.ready` | List open issues without an open blocking predecessor. |
-| `kata.labels` | Discover labels already used in the project. |
-| `kata.create` | Create an issue with initial labels, metadata, and relationships. |
-| `kata.edit` | Atomically change issue fields, ownership, priority, and relationship deltas. |
-| `kata.comment` | Append a progress or context comment. |
-| `kata.claim` | Claim an unowned issue for the bound actor. There is no force mode. |
-| `kata.set_deadline` | Set or clear an issue deadline, with an optional revision guard. |
-| `kata.set_label` | Ensure that a label is present or absent. |
-| `kata.set_metadata` | Patch metadata. A JSON `null` value removes a key. |
-| `kata.set_schedule` | Set or clear an issue schedule gate, with an optional revision guard. |
-| `kata.close` | Close completed work with a reason, message, and typed evidence. |
-| `kata.reopen` | Reopen work that needs another change. |
+| `kata.load_issue_discovery` | `kata.search`, `kata.list`, `kata.show`, `kata.ready`, `kata.next`, `kata.labels`, `kata.graph` |
+| `kata.load_issue_mutation` | `kata.create`, `kata.edit`, `kata.comment`, `kata.edit_comment`, `kata.claim`, `kata.set_label`, `kata.set_metadata`, `kata.set_schedule`, `kata.set_deadline`, `kata.move` |
+| `kata.load_issue_lifecycle` | `kata.close`, `kata.reopen`, `kata.delete`, `kata.restore`, `kata.purge`, `kata.wait`, `kata.audit_closes` |
+| `kata.load_leases` | `kata.lease_status`, `kata.lease`, `kata.lease_force_release`, `kata.lease_steal` |
+| `kata.load_projects` | `kata.projects`, `kata.project_create`, `kata.project_update`, `kata.project_merge`, `kata.project_remove`, `kata.project_restore`, `kata.project_purge` |
+| `kata.load_tokens` | `kata.tokens`, `kata.token_create`, `kata.token_revoke` when `--enable-token-admin` is set in daemon-wide mode |
+| `kata.load_system` | `kata.system` |
+| `kata.load_federation` | `kata.federation_status`, `kata.federation_enroll`, `kata.federation_enrollment_revoke`, `kata.federation_join`, `kata.federation_rebind`, `kata.federation_leave`, `kata.federation_quarantine` |
+| `kata.load_sync` | `kata.sync_status`, `kata.sync_update`, `kata.sync_once` |
+| `kata.load_recurrence` | `kata.recurrences`, `kata.recurrence_update`, `kata.recurrence_delete` |
+| `kata.load_activity` | `kata.digest`, `kata.events` |
+| `kata.load_import` | `kata.import_issues` |
+| `kata.load_storage` | `kata.storage_export`, `kata.storage_import` when host storage is enabled |
 
-`kata.create` and `kata.comment` require `idempotency_key` so a client can retry
-without duplicating work. Other writes are idempotent through the daemon's
-natural no-op behavior. Tool results use structured content and include the
-bound project identity. Mutations report whether the state changed. They report
-`reused` only when the daemon confirms an idempotent reuse. Results also include
-the actual event actor when an event exists.
-`kata.edit` includes all ordered events and the relationship changes that the
-daemon applied. Compact issue results omit labels and blocked state when the
-daemon response does not contain those fields; they do not invent empty or
-false values.
+Loaders are idempotent. A loader reports `available=false` when its optional
+startup dependency is absent. Loaded tools keep their individual input and
+output schemas and safety annotations; Kata does not combine unrelated actions
+into a generic command tool.
+
+The tools use structured input and output. List-like results default to 20 and
+are bounded at 100. `kata.show` returns at most 100 comments. Create and
+comment require idempotency keys. Destructive tools preserve Kata's exact
+confirmation and revision contracts.
+
+Recurrence patch and delete calls require the current positive `revision` and
+send it as `If-Match`. Create calls do not use a revision.
+
+`kata.create` supports `force_new`. `kata.claim` supports `force` and returns
+the previous owner when the daemon reports one. `kata.edit` supports field,
+owner, priority, relationship, scheduling, and generic metadata changes. An
+issue-field or relationship change and a metadata change must use separate
+`kata.edit` calls so one failed request cannot leave a partial edit.
+
+## Scheduling and someday
+
+`kata.create` and `kata.edit` have first-class `scheduled_on` and `timezone`
+fields. Accepted `scheduled_on` forms are:
+
+- `YYYY-MM-DD`
+- `YYYY-MM-DDTHH:MM`
+- `YYYY-MM-DDTHH:MM:SS`
+- UTC RFC 3339, such as `2026-09-01T22:00:00Z`
+
+Civil date and time values use the supplied IANA timezone. Numeric offsets are
+rejected. Use `clear_scheduled_on` or `clear_timezone` when editing.
 
 `kata.set_schedule` writes the reserved `scheduled_on` metadata key. Pass
 `schedule` to set a value or `clear_schedule: true` to remove it.
 `kata.set_deadline` writes `deadline_on`; pass `deadline` or
 `clear_deadline: true`. Each pair is mutually exclusive. An optional `revision`
 adds the same conditional-write guard as `kata.set_metadata`. Both tools accept
-`YYYY-MM-DD`, local `YYYY-MM-DDTHH:MM[:SS]`, or an RFC 3339 UTC instant that
-ends in `Z`.
+the same date, local date-time, and UTC-instant forms as `scheduled_on`.
 
-List, search, and ready results omit issue bodies and comments to keep agent
-context small. Their limits default to 20 and cannot exceed 100. `kata.show`
-returns at most 100 comments and defaults to the newest 20.
+Generic metadata supports the native parking marker:
 
-`kata.search` is annotated as open-world because `auto`, `hybrid`, and
-`semantic` modes can use the daemon's configured third-party embedding
-provider. Select `lexical` when a search must stay inside the Kata daemon.
+```json
+{"metadata":{"someday":true}}
+```
 
-## Scope and safety
+Set the key to JSON `null` to remove it. Do not write `someday=false`. The same
+null-removal rule applies to `kata.set_metadata` and other generic metadata
+patches.
 
-Tool inputs do not accept an actor, workspace, project ID, or project name.
-Subject and relationship references must stay inside the bound project. Use a
-separate MCP server process for cross-project work. Relationship inputs reject
-unscoped full UIDs because they do not prove project membership. They also
-reject 26-character short IDs because the daemon wire form cannot distinguish
-them from globally resolved ULIDs after safe project-name canonicalization.
-Use a bare short ID or a shorter short ID qualified with the bound project
-name. Use the Kata CLI for the rare full-length relationship target.
+## Events, tokens, and federation
 
-The baseline server deliberately excludes deletion, purge, restore, project
-administration, token administration, federation, synchronization, import,
-export, recurrence, event streaming, digest, force-create, and force-claim
-operations. It also excludes the CLI's priority-aware `kata next` selection;
-use `kata.ready` to list ready candidates or the Kata CLI when exact `next`
-selection is required. Use the Kata CLI with explicit operator intent for the
-excluded workflows.
+`kata.events` supports immediate `poll` and bounded `wait` modes. It returns a
+resume cursor. Wait mode uses the daemon's SSE stream where one stream can
+enforce the selected scope. Fixed multi-project allowlists use bounded scoped
+polling. A `sync.reset_required` result returns `reset_after_id`, advances
+`next_after_id` to that reset cursor, and returns no stale events.
 
-The daemon remains the authority for authentication, actor policy, claim
-conflicts, revisions, relationship rules, close evidence, and all mutations.
-MCP validation is an additional client boundary; it does not bypass daemon
-policy.
+`kata.token_create` returns the plaintext token once. `kata.tokens`, status
+tools, errors, and later calls never return that secret or its hash. Token
+administration requires both the default daemon-wide startup scope and the
+explicit `--enable-token-admin` startup capability. A normal server, a
+one-project server, and a fixed-allowlist server cannot read, create, or revoke
+global daemon tokens.
+
+Federation leave exposes `preflight`, `prepare`, and `commit` phases so an
+operator can preserve the normal revoke-before-local-teardown order. The phase
+is required. A commit without external hub revocation also requires
+`COMMIT FEDERATION LEAVE <project>`. Replica credentials stay pinned to the hub
+origin by the daemon. Quarantine retry and skip require
+`RETRY FEDERATION BATCH <id>` or `SKIP FEDERATION BATCH <id>`.
+
+## Host-storage opt-in
+
+JSONL storage access is absent by default. Enable it only on the daemon host:
+
+```sh
+kata mcp serve \
+  --storage-root /srv/kata/exchange \
+  --storage-target restore=restore.db
+```
+
+`--storage-target alias=path-or-DSN` is repeatable. Tool calls select an alias;
+they cannot submit a database path or DSN. Artifact paths are relative to the
+storage root. Absolute paths, `..`, symlink traversal, directories, and special
+files are rejected. Storage operations stay anchored to an open root descriptor
+so a directory symlink swap cannot redirect them outside the configured root.
+SQLite target paths are also contained by the root.
+
+Export opens the active storage read-only and atomically installs the JSONL
+artifact. It cannot use the active SQLite database, its sidecar files, or any
+configured SQLite import target as an artifact path. Replacing an existing
+non-storage artifact requires `force=true` and
+`OVERWRITE ARTIFACT <artifact>`. Export includes deleted records unless
+`include_deleted=false` is explicit. Import refuses the active daemon storage.
+Active SQLite sidecars cannot be configured as restore targets. Restored SQLite
+files use owner-only permissions. Replacing an existing SQLite target requires `force=true` and
+`REPLACE STORAGE <alias>`. Force replacement of PostgreSQL storage is not
+available through MCP.
+
+## Protocol contract
+
+Kata delegates protocol negotiation to the official Go MCP SDK. Stateless
+clients can use `server/discover`; session clients can use `initialize` and
+`notifications/initialized`. JSON-RPC batches are rejected. Each compact JSON
+message is limited to 8 MiB.
+
+Kata advertises tools only, including tool-list changes. It does not advertise prompts, resources, roots,
+logging, sampling, subscriptions, or server-to-client requests. Discovery uses
+a five-minute private cache hint. Tool execution allows 20 starts per second,
+a burst of 20, and at most eight concurrent daemon calls per server process.
+
+Host process control stays outside MCP: daemon lifecycle, the TUI and Web UI,
+install/update, database migrations and cutovers, and raw internal replication
+endpoints remain CLI or operator workflows.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -68,7 +68,7 @@ checks, federation trust, claims, and mutation policy.
 The initial catalog contains 13 read-only section loaders. Call the applicable
 loader, then refresh the tool list when the server sends the standard
 `notifications/tools/list_changed` notification. This exposes only the detailed
-typed tools needed for the current task instead of placing all 55 tools in the
+typed tools needed for the current task instead of placing all 57 tools in the
 model context at startup.
 
 | Loader | Detailed tools |

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -62,8 +62,10 @@ it was launched for. Broader boundaries are explicit startup choices:
 
 Multi-project issue reads and writes use `project#ref`. Project-list tools can
 read all projects in scope. Issue creation and other project-selected writes
-require an explicit `project` in multi-project mode. Project creation is available
-only in daemon-wide mode.
+require an explicit `project` in multi-project mode. Project administration —
+create, rename, metadata, merge, archive, restore, and purge — requires the
+`--all-projects` daemon-wide scope; a scoped server can read its projects but
+cannot alter or destroy the catalog it was bound to.
 
 Tool calls cannot change the startup actor or expand the startup scope. The
 daemon remains authoritative for authentication, attribution, revision

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -74,7 +74,7 @@ checks, federation trust, claims, and mutation policy.
 The initial catalog contains 13 read-only section loaders. Call the applicable
 loader, then refresh the tool list when the server sends the standard
 `notifications/tools/list_changed` notification. This exposes only the detailed
-typed tools needed for the current task instead of placing all 56 tools in the
+typed tools needed for the current task instead of placing all 55 tools in the
 model context at startup.
 
 | Loader | Detailed tools |
@@ -86,7 +86,7 @@ model context at startup.
 | `kata.load_projects` | `kata.projects`, `kata.project_create`, `kata.project_update`, `kata.project_merge`, `kata.project_remove`, `kata.project_restore`, `kata.project_purge` |
 | `kata.load_tokens` | `kata.tokens`, `kata.token_create`, `kata.token_revoke` when `--enable-token-admin` is set in daemon-wide mode |
 | `kata.load_system` | `kata.system` |
-| `kata.load_federation` | `kata.federation_status`, `kata.federation_enrollment_revoke`, `kata.federation_join`, `kata.federation_rebind`, `kata.federation_leave`, `kata.federation_quarantine` |
+| `kata.load_federation` | `kata.federation_status`, `kata.federation_enrollment_revoke`, `kata.federation_rebind`, `kata.federation_leave`, `kata.federation_quarantine` |
 | `kata.load_sync` | `kata.sync_status`, `kata.sync_update`, `kata.sync_once` |
 | `kata.load_recurrence` | `kata.recurrences`, `kata.recurrence_update`, `kata.recurrence_delete` |
 | `kata.load_activity` | `kata.digest`, `kata.events` |
@@ -98,8 +98,10 @@ startup dependency is absent. Loaded tools keep their individual input and
 output schemas and safety annotations; Kata does not combine unrelated actions
 into a generic command tool.
 
-The tools use structured input and output. List-like results default to 20 and
-are bounded at 100. `kata.show` returns at most 100 comments. Create and
+The tools use structured input and output. List-like results, including
+`kata.audit_closes` rows, default to 20 and are bounded at 100;
+`kata.audit_closes` reports `truncated` so a caller can advance `since` to
+page further. `kata.show` returns at most 100 comments. Create and
 comment require idempotency keys. `kata.token_create` and recurrence creation
 have no idempotency key, are annotated non-idempotent, and mint a new record
 on every identical retry. Destructive tools preserve Kata's exact
@@ -159,11 +161,11 @@ the explicit `--enable-token-admin` startup capability. A default workspace
 server, a one-project server, and a fixed-allowlist server cannot read, create,
 or revoke global daemon tokens.
 
-Federation enrollment credentials are never minted through MCP: creating an
-enrollment and reading its token stay CLI/operator workflows.
+Federation topology changes stay CLI/operator workflows: MCP has no tool to
+create an enrollment, read its token, or join a hub as a spoke.
 `kata.federation_status` lists secret-free enrollment records, and
-`kata.federation_enrollment_revoke` can revoke one, but no MCP tool creates or
-returns enrollment secrets.
+`kata.federation_enrollment_revoke` can revoke one, but no MCP tool creates,
+accepts, or returns enrollment secrets.
 
 Enabling issue synchronization selects which external repository the daemon's
 configured GitHub credentials read, so `kata.sync_update` with

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -100,8 +100,9 @@ into a generic command tool.
 
 The tools use structured input and output. List-like results, including
 `kata.audit_closes` rows, default to 20 and are bounded at 100;
-`kata.audit_closes` reports `truncated` so a caller can advance `since` to
-page further. `kata.show` returns at most 100 comments. Create and
+`kata.audit_closes` pages over a stable append-only row order, reporting
+`truncated` and a `next_offset` cursor. `kata.show` returns at most 100
+comments. Create and
 comment require idempotency keys. `kata.token_create` and recurrence creation
 have no idempotency key, are annotated non-idempotent, and mint a new record
 on every identical retry. Destructive tools preserve Kata's exact

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-12
+last_edited: 2026-08-15
 ---
 
 # Model Context Protocol server
@@ -43,7 +43,10 @@ A typical client command has this shape:
 
 Use `--daemon <name>` to select a configured daemon. The normal client
 settings also apply, including `KATA_SERVER`, bearer authentication,
-private-network checks, and Unix socket discovery.
+private-network checks, and Unix socket discovery. The server checks the
+daemon's `api_schema_version` once at startup and refuses to serve a daemon
+older than API `0.11.0` (see the [HTTP API version history](http-api.md));
+upgrade the daemon rather than the MCP client in that case.
 
 ## Project scope
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -114,9 +114,11 @@ The tools use structured input and output. List-like results, including
 timestamps cannot skip or repeat rows and a project merge or issue purge
 during pagination fails the page with a restart error instead of silently
 skewing it. `kata.show` returns at most 100 comments. Create and
-comment require idempotency keys. `kata.token_create` and recurrence creation
-have no idempotency key, are annotated non-idempotent, and mint a new record
-on every identical retry. Destructive tools preserve Kata's exact
+comment require idempotency keys. `kata.token_create`, recurrence creation,
+and `kata.storage_import` are annotated non-idempotent: the first two mint a
+new record on every identical retry, and a forced storage import replaces the
+target again, with a fresh instance identity when `new_instance` is set.
+Destructive tools preserve Kata's exact
 confirmation and revision contracts.
 
 Recurrence patch and delete calls require the current positive `revision` and

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -118,11 +118,18 @@ timestamps cannot skip or repeat rows and a project merge or issue purge
 during pagination fails the page with a restart error instead of silently
 skewing it. `kata.show` returns at most 100 comments. Create and
 comment require idempotency keys. `kata.token_create`, recurrence creation,
-and `kata.storage_import` are annotated non-idempotent: the first two mint a
-new record on every identical retry, and a forced storage import replaces the
-target again, with a fresh instance identity when `new_instance` is set.
+`kata.storage_import`, `kata.lease`, and `kata.sync_once` are annotated
+non-idempotent: the first two mint a new record on every identical retry, a
+forced storage import replaces the target again (with a fresh instance
+identity when `new_instance` is set), a lease renewal extends the expiry on
+every call, and each sync pass re-imports from the provider.
+`kata.lease_steal` acquires first and only force-releases a holder that
+denies that acquire, so a retry after a lost response keeps a lease the
+startup principal already holds instead of releasing and re-acquiring it.
 Destructive tools preserve Kata's exact
-confirmation and revision contracts.
+confirmation and revision contracts. `kata.delete` and `kata.purge` confirm
+against `project#short_id` and then address the daemon by the issue's
+immutable UID.
 
 Recurrence patch and delete calls require the current positive `revision` and
 send it as `If-Match`. Create calls do not use a revision.

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -78,17 +78,18 @@ for the recipe.
 
 ## Use Kata through MCP
 
-Agents with an MCP client can start Kata as a project-bound stdio server:
+Agents with an MCP client can start Kata as a daemon-wide stdio server:
 
 ```sh
-kata --workspace /path/to/repository mcp serve
+kata mcp serve
 ```
 
-The MCP server exposes the normal search, list, show, ready, label discovery,
-create, edit, comment, claim, label, metadata, close, and reopen workflows. It
-fixes the project and actor at startup, requires idempotency keys for create and
-comment, and omits administrative and destructive deletion tools. See the
-[MCP reference](../reference/mcp.md) for configuration and exact schemas.
+The server starts with 13 section loaders. An agent loads only the detailed
+issue, project, administration, automation, or event tools needed for its task.
+It can use all projects visible to the selected daemon; pass `--workspace`,
+`--project`, or `--projects` to narrow that scope. The actor stays fixed at
+startup. See the [MCP reference](../reference/mcp.md) for configuration and
+exact schemas.
 
 ## Search before creating
 

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -78,7 +78,8 @@ for the recipe.
 
 ## Use Kata through MCP
 
-Agents with an MCP client can start Kata as a daemon-wide stdio server:
+Agents with an MCP client can start Kata as a stdio server bound to the
+current workspace's project:
 
 ```sh
 kata mcp serve
@@ -86,9 +87,9 @@ kata mcp serve
 
 The server starts with 13 section loaders. An agent loads only the detailed
 issue, project, administration, automation, or event tools needed for its task.
-It can use all projects visible to the selected daemon; pass `--workspace`,
-`--project`, or `--projects` to narrow that scope. The actor stays fixed at
-startup. See the [MCP reference](../reference/mcp.md) for configuration and
+Pass `--workspace` or `--project` for an explicit project, `--projects` for a
+fixed allowlist, or `--all-projects` to use every project visible to the
+selected daemon. The actor stays fixed at startup. See the [MCP reference](../reference/mcp.md) for configuration and
 exact schemas.
 
 ## Search before creating

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1304,12 +1304,15 @@ type AuditClosesRequest struct {
 // evidence items from the close event payload (e.g. "commit", "pr").
 // Message is the close message verbatim. EventID is the close event's
 // immutable ID; rows are ordered by it, so it serves as a stable
-// pagination cursor.
+// pagination cursor. ParentUID is the close-time frozen parent UID when
+// the event recorded one, giving Parent's display ref immutable
+// provenance.
 type AuditCloseRow struct {
 	Time          string   `json:"time"`
 	Actor         string   `json:"actor"`
 	Issue         string   `json:"issue"`
 	Parent        string   `json:"parent,omitempty"`
+	ParentUID     string   `json:"parent_uid,omitempty"`
 	Reason        string   `json:"reason"`
 	EvidenceTypes []string `json:"evidence_types,omitempty"`
 	Flags         []string `json:"flags,omitempty"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -402,13 +402,16 @@ type CreateIssueRequest struct {
 // direction: the new issue is the link's "from" side (e.g. for type=blocks
 // the new issue blocks ToRef). Incoming applies only to type=blocks: when
 // true the link runs from ToRef to the new issue (i.e. the new issue is
-// blocked by ToRef). type=parent rejects Incoming=true with 400 validation
-// (there is no inverse parent form; the child files the link via
-// type=parent). type=related ignores Incoming — the edge is symmetric.
+// blocked by ToRef). ToProjectUID optionally pins the resolved target to an
+// immutable project identity inside the create transaction. type=parent
+// rejects Incoming=true with 400 validation (there is no inverse parent form;
+// the child files the link via type=parent). type=related ignores Incoming —
+// the edge is symmetric.
 type CreateInitialLinkBody struct {
-	Type     string `json:"type" enum:"parent,blocks,related"`
-	ToRef    string `json:"to_ref"`
-	Incoming bool   `json:"incoming,omitempty"`
+	Type         string `json:"type" enum:"parent,blocks,related"`
+	ToRef        string `json:"to_ref"`
+	ToProjectUID string `json:"to_project_uid,omitempty"`
+	Incoming     bool   `json:"incoming,omitempty"`
 }
 
 // MutationResponse is the standard mutation envelope (§4.5). OriginalEvent is
@@ -708,15 +711,19 @@ type EditIssueRequest struct {
 //	set_parent        — set URL issue's parent (replaces existing)
 //	remove_parent     — strict: must equal current parent
 //	remove_blocks/_blocked_by/_related — idempotent
+//
+// ExpectedProjectUIDs optionally maps canonical target issue UIDs to the
+// immutable project UIDs that must still own them in the edit transaction.
 type LinksDelta struct {
-	SetParent       *string  `json:"set_parent,omitempty"`
-	RemoveParent    *string  `json:"remove_parent,omitempty"`
-	AddBlocks       []string `json:"add_blocks,omitempty"`
-	AddBlockedBy    []string `json:"add_blocked_by,omitempty"`
-	AddRelated      []string `json:"add_related,omitempty"`
-	RemoveBlocks    []string `json:"remove_blocks,omitempty"`
-	RemoveBlockedBy []string `json:"remove_blocked_by,omitempty"`
-	RemoveRelated   []string `json:"remove_related,omitempty"`
+	SetParent           *string           `json:"set_parent,omitempty"`
+	RemoveParent        *string           `json:"remove_parent,omitempty"`
+	AddBlocks           []string          `json:"add_blocks,omitempty"`
+	AddBlockedBy        []string          `json:"add_blocked_by,omitempty"`
+	AddRelated          []string          `json:"add_related,omitempty"`
+	RemoveBlocks        []string          `json:"remove_blocks,omitempty"`
+	RemoveBlockedBy     []string          `json:"remove_blocked_by,omitempty"`
+	RemoveRelated       []string          `json:"remove_related,omitempty"`
+	ExpectedProjectUIDs map[string]string `json:"expected_project_uids,omitempty"`
 }
 
 // LinkChanges reports link mutations actually applied. Every entry carries the

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1302,7 +1302,9 @@ type AuditClosesRequest struct {
 // throttle on this issue (sibling-burst or duplicate-message) before
 // the close eventually succeeded. EvidenceTypes lists the typed
 // evidence items from the close event payload (e.g. "commit", "pr").
-// Message is the close message verbatim.
+// Message is the close message verbatim. EventID is the close event's
+// immutable ID; rows are ordered by it, so it serves as a stable
+// pagination cursor.
 type AuditCloseRow struct {
 	Time          string   `json:"time"`
 	Actor         string   `json:"actor"`
@@ -1312,6 +1314,7 @@ type AuditCloseRow struct {
 	EvidenceTypes []string `json:"evidence_types,omitempty"`
 	Flags         []string `json:"flags,omitempty"`
 	Message       string   `json:"message,omitempty"`
+	EventID       int64    `json:"event_id"`
 }
 
 // AuditClosesResponse wraps the AuditCloseRow list. Rows is never nil

--- a/internal/daemon/handlers_audit.go
+++ b/internal/daemon/handlers_audit.go
@@ -218,6 +218,7 @@ func buildAuditRows(
 		}
 		switch {
 		case p.ParentUID != nil && *p.ParentUID != "":
+			row.ParentUID = *p.ParentUID
 			if q, ok := parentQualifiers[*p.ParentUID]; ok {
 				// Same-project parent renders bare; a foreign parent
 				// renders qualified ("project#short_id") so the ref is

--- a/internal/daemon/handlers_audit.go
+++ b/internal/daemon/handlers_audit.go
@@ -211,6 +211,7 @@ func buildAuditRows(
 			Actor:   ev.Actor,
 			Reason:  p.Reason,
 			Message: p.Message,
+			EventID: ev.ID,
 		}
 		if ev.IssueShortID != nil {
 			row.Issue = *ev.IssueShortID

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -152,6 +152,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 				return nil, err
 			}
 		}
+		var archivedTarget *db.LinkTargetArchivedError
 		issue, evt, err := cfg.DB.CreateIssue(ctx, db.CreateIssueParams{
 			ProjectID:              in.ProjectID,
 			Title:                  in.Body.Title,
@@ -177,6 +178,8 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		case errors.Is(err, db.ErrInitialLinkTargetNotFound):
 			return nil, api.NewError(404, "issue_not_found",
 				"initial link target not found", "", nil)
+		case errors.As(err, &archivedTarget):
+			return nil, linkTargetArchivedError(archivedTarget)
 		case errors.Is(err, db.ErrSelfLink):
 			return nil, api.NewError(400, "validation",
 				"cannot link an issue to itself", "", nil)
@@ -553,10 +556,13 @@ func linksDeltaRequestsAnyOp(d *api.LinksDelta) bool {
 // human-readable error messages.
 func mapAtomicEditError(err error, issueShortID string, delta *api.LinksDelta) error {
 	var lt *db.LinkTargetNotFoundError
+	var archivedTarget *db.LinkTargetArchivedError
 	switch {
 	case errors.As(err, &lt):
 		return api.NewError(404, "issue_not_found",
 			"link target not found", "", nil)
+	case errors.As(err, &archivedTarget):
+		return linkTargetArchivedError(archivedTarget)
 	case errors.Is(err, db.ErrNotFound):
 		return api.NewError(404, "issue_not_found",
 			"target issue not found", "", nil)

--- a/internal/daemon/handlers_issues_test.go
+++ b/internal/daemon/handlers_issues_test.go
@@ -555,6 +555,37 @@ func TestEditIssue_LinksDelta_AddBlocks(t *testing.T) {
 	assert.Equal(t, target, show.Links[0].To.ShortID)
 }
 
+func TestEditIssue_LinksDeltaRejectsMovedTargetProjectIdentity(t *testing.T) {
+	h, ts, sourceProjectID, sourceID := bootstrapProjectWithIssue(t)
+	targetProject, err := h.DB().CreateProject(t.Context(), "target-project")
+	require.NoError(t, err)
+	otherProject, err := h.DB().CreateProject(t.Context(), "other-project")
+	require.NoError(t, err)
+	target, _, err := h.DB().CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: targetProject.ID, Title: "Target issue", Author: "example-agent",
+	})
+	require.NoError(t, err)
+	_, err = h.DB().MoveIssueProject(t.Context(), db.MoveIssueProjectIn{
+		IssueID: target.ID, FromProjectID: targetProject.ID, ToProjectID: otherProject.ID,
+		IfMatchRev: target.Revision, Actor: "example-agent",
+	})
+	require.NoError(t, err)
+
+	resp, body := patchJSON(t, ts, issueURL(sourceProjectID, sourceID, ""), map[string]any{
+		"actor": "example-agent",
+		"links_delta": map[string]any{
+			"add_blocks": []string{target.UID},
+			"expected_project_uids": map[string]string{
+				target.UID: targetProject.UID,
+			},
+		},
+	})
+	assertAPIError(t, resp.StatusCode, body, http.StatusNotFound, "issue_not_found")
+	links, err := h.DB().LinksByIssue(t.Context(), sourceID)
+	require.NoError(t, err)
+	require.Empty(t, links)
+}
+
 // TestEditIssue_LinksDelta_PeerCarriesStatus pins that edit-delta LinkPeer
 // entries carry the peer issue's own status (0.9.0), matching the list
 // response's LinkPeer contract — the wire schema marks status required, so

--- a/internal/daemon/handlers_links.go
+++ b/internal/daemon/handlers_links.go
@@ -208,7 +208,10 @@ func createLinkHandler(cfg ServerConfig) func(context.Context, *api.CreateLinkRe
 			Type:        in.Body.Type,
 			Author:      actor,
 		}, linkEv)
+		var archivedTarget *db.LinkTargetArchivedError
 		switch {
+		case errors.As(err, &archivedTarget):
+			return nil, linkTargetArchivedError(archivedTarget)
 		case errors.Is(err, db.ErrLinkExists):
 			// Duplicate (from, to, type) → no-op. Re-fetch and return existing.
 			existing, lookupErr := cfg.DB.LinkByEndpoints(ctx, storageFromID, storageToID, in.Body.Type)

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -16,7 +16,7 @@ import (
 // (info.version). It tracks the HTTP API contract, not the build version, so
 // the committed schema artifact stays stable across builds and is bumped
 // deliberately when the wire contract changes.
-const APISchemaVersion = "0.10.0"
+const APISchemaVersion = "0.11.0"
 
 // OpenAPIDocument builds the daemon's complete OpenAPI model by wiring every
 // route through NewServer with a zero ServerConfig. It binds no listener and

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -242,9 +242,9 @@ func TestOpenAPIDocumentIncludesUIReadContract(t *testing.T) {
 	}
 }
 
-func TestOpenAPISchemaVersionReflectsStableUIReferenceFilters(t *testing.T) {
-	if APISchemaVersion != "0.10.0" {
-		t.Fatalf("APISchemaVersion = %q, want 0.10.0 for stable UI reference filters", APISchemaVersion)
+func TestOpenAPISchemaVersionReflectsPinnedRelationshipTargets(t *testing.T) {
+	if APISchemaVersion != "0.11.0" {
+		t.Fatalf("APISchemaVersion = %q, want 0.11.0 for pinned relationship targets and audit event IDs", APISchemaVersion)
 	}
 }
 

--- a/internal/daemon/resolver.go
+++ b/internal/daemon/resolver.go
@@ -148,12 +148,21 @@ func requireLinkTargetAddable(ctx context.Context, store db.Storage, subjectProj
 		return internalAPIError(err)
 	}
 	if project.DeletedAt != nil {
-		return api.NewError(409, "link_target_archived",
-			fmt.Sprintf("link target %s is in archived project %q",
-				qualifiedID(project.Name, target.ShortID), project.Name),
-			"unarchive the project to add links", nil)
+		return linkTargetArchivedError(&db.LinkTargetArchivedError{
+			Number: target.ID, ShortID: target.ShortID, Project: project.Name,
+		})
 	}
 	return nil
+}
+
+// linkTargetArchivedError is the 409 link_target_archived envelope shared by
+// the pre-transaction gate above and the store's in-transaction re-check,
+// which catches an archival that commits between the two.
+func linkTargetArchivedError(target *db.LinkTargetArchivedError) error {
+	return api.NewError(409, "link_target_archived",
+		fmt.Sprintf("link target %s is in archived project %q",
+			qualifiedID(target.Project, target.ShortID), target.Project),
+		"unarchive the project to add links", nil)
 }
 
 // validateInitialLinkType rejects an initial link whose type the DB layer

--- a/internal/daemon/resolver.go
+++ b/internal/daemon/resolver.go
@@ -211,9 +211,10 @@ func resolveInitialLinks(ctx context.Context, store db.Storage, projectID int64,
 			return nil, nil, err
 		}
 		out = append(out, db.InitialLink{
-			Type:     l.Type,
-			ToNumber: target.ID,
-			Incoming: l.Incoming,
+			Type:               l.Type,
+			ToNumber:           target.ID,
+			ExpectedProjectUID: l.ToProjectUID,
+			Incoming:           l.Incoming,
 		})
 		targets = append(targets, target)
 	}
@@ -252,6 +253,12 @@ func fillLinksDeltaParams(ctx context.Context, store db.Storage, projectID int64
 		}
 		if _, err := authorizeHostProjectScope(ctx, []int64{issue.ProjectID}, nil, false); err != nil {
 			return db.Issue{}, err
+		}
+		if expected, ok := d.ExpectedProjectUIDs[issue.UID]; ok {
+			if params.ExpectedLinkProjectUIDs == nil {
+				params.ExpectedLinkProjectUIDs = make(map[int64]string)
+			}
+			params.ExpectedLinkProjectUIDs[issue.ID] = expected
 		}
 		return issue, nil
 	}

--- a/internal/db/dbtest/conformance.go
+++ b/internal/db/dbtest/conformance.go
@@ -156,6 +156,14 @@ var storageScenarios = []scenario{
 		run: checkLinksAndRelationshipProjections,
 	},
 	{
+		name: "archived link targets",
+		methods: []string{
+			"CreateIssue", "CreateLink", "CreateLinkAndEvent", "CreateProject", "EditIssueAtomic",
+			"IssueByID", "LinksByIssue", "RemoveProject",
+		},
+		run: checkArchivedLinkTargets,
+	},
+	{
 		name: "ready queues and discovery",
 		methods: []string{
 			"AddLabel", "CloseIssue", "CreateComment", "CreateIssue", "CreateLink", "CreateProject", "EditIssue",

--- a/internal/db/dbtest/conformance_archived_links.go
+++ b/internal/db/dbtest/conformance_archived_links.go
@@ -1,0 +1,89 @@
+package dbtest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.kenn.io/kata/internal/db"
+)
+
+// checkArchivedLinkTargets pins the add-side link contract inside the mutation
+// transaction: an initial link, an atomic-edit add or set-parent, and a
+// standalone link insert must all reject a target whose project is archived
+// at commit time, while removals of existing links to archived targets keep
+// working. Daemon handlers gate the same condition before the transaction;
+// the store check catches archival that races that preflight.
+func checkArchivedLinkTargets(t *testing.T, store db.Storage) error {
+	t.Helper()
+	ctx := context.Background()
+	subject, err := createIssueFixture(ctx, store, "archived-link-subject", "subject", "link-author", nil)
+	if err != nil {
+		return err
+	}
+	peer, err := createIssueFixture(ctx, store, "archived-link-peer", "future parent", "link-author", nil)
+	if err != nil {
+		return err
+	}
+	linked, err := createFixtureIssue(ctx, store, peer.Project.ID, "already related", "link-author", nil)
+	if err != nil {
+		return err
+	}
+	if _, err := store.CreateLink(ctx, db.CreateLinkParams{
+		FromIssueID: subject.Issue.ID, ToIssueID: linked.ID, Type: "related", Author: "link-author",
+	}); err != nil {
+		return fmt.Errorf("create pre-archive related link: %w", err)
+	}
+	if _, _, err := store.RemoveProject(ctx, db.RemoveProjectParams{ProjectID: peer.Project.ID, Actor: "link-author", Force: true}); err != nil {
+		return fmt.Errorf("archive peer project: %w", err)
+	}
+
+	var archived *db.LinkTargetArchivedError
+	_, _, err = store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: subject.Project.ID, Title: "links into archived project", Author: "link-author",
+		Links: []db.InitialLink{{Type: "related", ToNumber: peer.Issue.ID}},
+	})
+	if assert.ErrorAs(t, err, &archived, "initial link to archived target") {
+		assert.Equal(t, peer.Issue.ID, archived.Number)
+		assert.Equal(t, peer.Project.Name, archived.Project)
+	}
+
+	title := "edit must roll back"
+	_, err = store.EditIssueAtomic(ctx, db.EditIssueAtomicParams{
+		IssueID: subject.Issue.ID, Actor: "link-author", Title: &title, AddBlocks: []int64{peer.Issue.ID},
+	})
+	assert.ErrorAs(t, err, &archived, "atomic edit add to archived target")
+	_, err = store.EditIssueAtomic(ctx, db.EditIssueAtomicParams{
+		IssueID: subject.Issue.ID, Actor: "link-author", SetParent: &peer.Issue.ID,
+	})
+	assert.ErrorAs(t, err, &archived, "atomic edit set_parent to archived target")
+	afterRollback, err := store.IssueByID(ctx, subject.Issue.ID)
+	if err != nil {
+		return fmt.Errorf("load subject after rejected edits: %w", err)
+	}
+	assert.Equal(t, subject.Issue.Title, afterRollback.Title, "rejected edit must roll back field changes")
+
+	_, _, err = store.CreateLinkAndEvent(ctx, db.CreateLinkParams{
+		FromIssueID: subject.Issue.ID, ToIssueID: peer.Issue.ID, Type: "blocks", Author: "link-author",
+	}, db.LinkEventParams{
+		EventType: "issue.linked", EventIssueID: subject.Issue.ID,
+		FromShortID: subject.Issue.ShortID, FromUID: subject.Issue.UID,
+		ToShortID: peer.Issue.ShortID, ToUID: peer.Issue.UID, Actor: "link-author",
+	})
+	assert.ErrorAs(t, err, &archived, "standalone link insert to archived target")
+
+	result, err := store.EditIssueAtomic(ctx, db.EditIssueAtomicParams{
+		IssueID: subject.Issue.ID, Actor: "link-author", RemoveRelated: []int64{linked.ID},
+	})
+	if err != nil {
+		return fmt.Errorf("remove existing link to archived target: %w", err)
+	}
+	assert.True(t, result.AnyChange, "existing links to archived targets must stay removable")
+	links, err := store.LinksByIssue(ctx, subject.Issue.ID)
+	if err != nil {
+		return fmt.Errorf("links after removal: %w", err)
+	}
+	assert.Empty(t, links)
+	return nil
+}

--- a/internal/db/dbtest/conformance_archived_links.go
+++ b/internal/db/dbtest/conformance_archived_links.go
@@ -44,7 +44,7 @@ func checkArchivedLinkTargets(t *testing.T, store db.Storage) error {
 		ProjectID: subject.Project.ID, Title: "links into archived project", Author: "link-author",
 		Links: []db.InitialLink{{Type: "related", ToNumber: peer.Issue.ID}},
 	})
-	if assert.ErrorAs(t, err, &archived, "initial link to archived target") {
+	if assert.ErrorAs(t, err, &archived, "initial link to archived target") && archived != nil {
 		assert.Equal(t, peer.Issue.ID, archived.Number)
 		assert.Equal(t, peer.Project.Name, archived.Project)
 	}

--- a/internal/db/dbtest/conformance_core.go
+++ b/internal/db/dbtest/conformance_core.go
@@ -903,6 +903,13 @@ func checkIssueCreateEnvelope(t *testing.T, store db.Storage) error {
 	})
 	assert.ErrorIs(t, err, db.ErrInitialLinkTargetNotFound)
 	_, _, err = store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "moved link target", Author: "conformance-agent",
+		Links: []db.InitialLink{{
+			Type: "related", ToNumber: target.ID, ExpectedProjectUID: project.UID + "-other",
+		}},
+	})
+	assert.ErrorIs(t, err, db.ErrInitialLinkTargetNotFound)
+	_, _, err = store.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: project.ID, Title: "bad label", Author: "conformance-agent", Labels: []string{"Bad Label"},
 	})
 	assert.ErrorIs(t, err, db.ErrLabelInvalid)

--- a/internal/db/dbtest/conformance_sync_metadata.go
+++ b/internal/db/dbtest/conformance_sync_metadata.go
@@ -488,6 +488,19 @@ func checkMetadataAndAtomicEdit(t *testing.T, store db.Storage) error {
 		return fmt.Errorf("load issue after rolled-back atomic edit: %w", err)
 	}
 	assert.Equal(t, title, afterRollback.Title)
+	_, err = store.EditIssueAtomic(ctx, db.EditIssueAtomicParams{
+		IssueID: fixture.Issue.ID, Actor: "atomic-editor", Title: &rollbackTitle,
+		AddBlocks: []int64{blocked.ID},
+		ExpectedLinkProjectUIDs: map[int64]string{
+			blocked.ID: fixture.Project.UID + "-other",
+		},
+	})
+	assert.ErrorAs(t, err, &missingTarget)
+	afterIdentityRollback, err := store.IssueByID(ctx, fixture.Issue.ID)
+	if err != nil {
+		return fmt.Errorf("load issue after project identity rollback: %w", err)
+	}
+	assert.Equal(t, title, afterIdentityRollback.Title)
 
 	events, err := store.EventsAfter(ctx, db.EventsAfterParams{ProjectID: fixture.Project.ID, Limit: 100})
 	if err != nil {

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -241,6 +241,23 @@ func (e *LinkTargetNotFoundError) Error() string {
 
 func (e *LinkTargetNotFoundError) Unwrap() error { return ErrNotFound }
 
+// LinkTargetArchivedError is returned when an add-side link mutation (an
+// initial link, an atomic-edit add or set-parent, or a standalone link
+// insert) resolves a target whose project is archived inside the mutation
+// transaction. Removals never raise it: existing links to archived projects
+// stay removable. Handlers gate the same condition before the transaction;
+// this catches an archival that commits between that preflight and the
+// insert. ShortID and Project name the target for the API message.
+type LinkTargetArchivedError struct {
+	Number  int64
+	ShortID string
+	Project string
+}
+
+func (e *LinkTargetArchivedError) Error() string {
+	return fmt.Sprintf("link target %s#%s is in archived project %q", e.Project, e.ShortID, e.Project)
+}
+
 // ProjectHasOpenIssuesError carries the open-issue count alongside the
 // sentinel error so handlers can format the refusal message with the actual
 // number ("3 open issues remain").

--- a/internal/db/fingerprint.go
+++ b/internal/db/fingerprint.go
@@ -177,7 +177,7 @@ func DedupeLinks(in []InitialLink) []InitialLink {
 		if l.Type == "related" {
 			normalized.Incoming = false
 		}
-		k := key(normalized)
+		k := key{Type: normalized.Type, ToNumber: normalized.ToNumber, Incoming: normalized.Incoming}
 		if _, ok := seen[k]; ok {
 			continue
 		}

--- a/internal/db/params.go
+++ b/internal/db/params.go
@@ -22,7 +22,9 @@ const (
 // Methods that take/return these live in the impl files.
 
 // InitialLink describes one of the optional links created in the same TX as
-// the issue itself. The to_number is resolved within the same project.
+// the issue itself. ToNumber is a globally unique issue row ID. When
+// ExpectedProjectUID is non-empty, the transaction verifies that the target
+// still belongs to that immutable project identity.
 //
 // Default direction (Incoming=false): the new issue is the link's "from"
 // side. Incoming=true reverses for type=blocks so the new issue is the
@@ -30,9 +32,10 @@ const (
 // (no inverse parent direction is exposed); meaningless for type=related
 // which is symmetric.
 type InitialLink struct {
-	Type     string // "parent" | "blocks" | "related"
-	ToNumber int64
-	Incoming bool
+	Type               string // "parent" | "blocks" | "related"
+	ToNumber           int64
+	ExpectedProjectUID string
+	Incoming           bool
 }
 
 // CreateIssueParams carries inputs for CreateIssue.
@@ -268,6 +271,11 @@ type EditIssueAtomicParams struct {
 	RemoveBlocks    []int64
 	RemoveBlockedBy []int64
 	RemoveRelated   []int64
+
+	// ExpectedLinkProjectUIDs pins resolved peer rows to their project
+	// identities inside the mutation transaction. Missing entries retain the
+	// legacy unrestricted behavior for non-scoped clients.
+	ExpectedLinkProjectUIDs map[int64]string
 }
 
 // PeerIdentity is the stable identity of a link peer as captured inside

--- a/internal/db/pgstore/atomic_edit.go
+++ b/internal/db/pgstore/atomic_edit.go
@@ -153,6 +153,32 @@ func validateExpectedLinkProjectUIDsTx(ctx context.Context, tx *sql.Tx, expected
 	return nil
 }
 
+// requireAddableLinkTargetTx share-locks an add-side link target and its
+// project row and rejects the add when that project is archived. The daemon
+// gates the same condition before the transaction; the shared project lock
+// serializes against RemoveProject's FOR UPDATE so an archival cannot commit
+// between this check and the link insert. Removals never call it.
+func requireAddableLinkTargetTx(ctx context.Context, tx *sql.Tx, targetID int64) error {
+	var shortID, projectName string
+	var archived bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT i.short_id, p.name, p.deleted_at IS NOT NULL
+		  FROM issues i
+		  JOIN projects p ON p.id = i.project_id
+		 WHERE i.id = $1
+		 FOR SHARE OF i, p`, targetID).Scan(&shortID, &projectName, &archived)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &db.LinkTargetNotFoundError{Number: targetID}
+	}
+	if err != nil {
+		return mapSQLError(err, nil)
+	}
+	if archived {
+		return &db.LinkTargetArchivedError{Number: targetID, ShortID: shortID, Project: projectName}
+	}
+	return nil
+}
+
 func (s *Store) applyAtomicLinkDeltaTx(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -178,6 +204,9 @@ func (s *Store) applyAtomicLinkDeltaTx(
 		}
 		if target.ID == issue.ID {
 			return changed, db.ErrSelfLink
+		}
+		if err := requireAddableLinkTargetTx(ctx, tx, target.ID); err != nil {
+			return changed, err
 		}
 		if err := assertNoParentCycleTx(ctx, tx, issue.ID, target.ID); err != nil {
 			return changed, err
@@ -329,6 +358,9 @@ func atomicAddEdgeTx(
 	}
 	if target.ID == issue.ID {
 		return false, db.PeerIdentity{}, db.ErrSelfLink
+	}
+	if err := requireAddableLinkTargetTx(ctx, tx, target.ID); err != nil {
+		return false, db.PeerIdentity{}, err
 	}
 	fromID, toID := issue.ID, target.ID
 	if reverse {

--- a/internal/db/pgstore/atomic_edit.go
+++ b/internal/db/pgstore/atomic_edit.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"go.kenn.io/kata/internal/db"
@@ -22,6 +23,9 @@ func (s *Store) EditIssueAtomic(ctx context.Context, params db.EditIssueAtomicPa
 			return err
 		}
 		if err := ensureProjectWritableTx(ctx, tx, project.ID); err != nil {
+			return err
+		}
+		if err := validateExpectedLinkProjectUIDsTx(ctx, tx, params.ExpectedLinkProjectUIDs); err != nil {
 			return err
 		}
 		params.Actor, err = effectiveLocalMutationActorTx(ctx, tx, project.ID, params.Actor)
@@ -123,6 +127,30 @@ func (s *Store) EditIssueAtomic(ctx context.Context, params db.EditIssueAtomicPa
 		return err
 	})
 	return result, err
+}
+
+func validateExpectedLinkProjectUIDsTx(ctx context.Context, tx *sql.Tx, expected map[int64]string) error {
+	ids := make([]int64, 0, len(expected))
+	for issueID := range expected {
+		ids = append(ids, issueID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, issueID := range ids {
+		var projectUID string
+		err := tx.QueryRowContext(ctx, `
+			SELECT p.uid
+			  FROM issues i
+			  JOIN projects p ON p.id = i.project_id
+			 WHERE i.id = $1
+			 FOR SHARE OF i`, issueID).Scan(&projectUID)
+		if errors.Is(err, sql.ErrNoRows) || err == nil && projectUID != expected[issueID] {
+			return &db.LinkTargetNotFoundError{Number: issueID}
+		}
+		if err != nil {
+			return mapSQLError(err, nil)
+		}
+	}
+	return nil
 }
 
 func (s *Store) applyAtomicLinkDeltaTx(

--- a/internal/db/pgstore/issues.go
+++ b/internal/db/pgstore/issues.go
@@ -144,14 +144,18 @@ func (s *Store) CreateIssue(ctx context.Context, params db.CreateIssueParams) (d
 		linkPayloads := make([]createdLink, 0, len(links))
 		for _, link := range links {
 			var targetID int64
-			var targetUID, targetShortID, targetProjectUID string
+			var targetUID, targetShortID, targetProjectUID, targetProjectName string
+			var targetProjectArchived bool
+			// Sharing the project row lock serializes against RemoveProject's
+			// FOR UPDATE, so an archival cannot commit between this check and
+			// the link insert.
 			err := tx.QueryRowContext(ctx,
-				`SELECT i.id, i.uid, i.short_id, p.uid
+				`SELECT i.id, i.uid, i.short_id, p.uid, p.name, p.deleted_at IS NOT NULL
 				   FROM issues i
 				   JOIN projects p ON p.id = i.project_id
 				  WHERE i.id = $1 AND i.deleted_at IS NULL
-				  FOR SHARE OF i`, link.ToNumber,
-			).Scan(&targetID, &targetUID, &targetShortID, &targetProjectUID)
+				  FOR SHARE OF i, p`, link.ToNumber,
+			).Scan(&targetID, &targetUID, &targetShortID, &targetProjectUID, &targetProjectName, &targetProjectArchived)
 			if errors.Is(err, sql.ErrNoRows) {
 				return db.ErrInitialLinkTargetNotFound
 			}
@@ -160,6 +164,9 @@ func (s *Store) CreateIssue(ctx context.Context, params db.CreateIssueParams) (d
 			}
 			if link.ExpectedProjectUID != "" && targetProjectUID != link.ExpectedProjectUID {
 				return db.ErrInitialLinkTargetNotFound
+			}
+			if targetProjectArchived {
+				return &db.LinkTargetArchivedError{Number: targetID, ShortID: targetShortID, Project: targetProjectName}
 			}
 			if targetID == issueID {
 				return db.ErrSelfLink

--- a/internal/db/pgstore/issues.go
+++ b/internal/db/pgstore/issues.go
@@ -144,15 +144,22 @@ func (s *Store) CreateIssue(ctx context.Context, params db.CreateIssueParams) (d
 		linkPayloads := make([]createdLink, 0, len(links))
 		for _, link := range links {
 			var targetID int64
-			var targetUID, targetShortID string
+			var targetUID, targetShortID, targetProjectUID string
 			err := tx.QueryRowContext(ctx,
-				`SELECT id, uid, short_id FROM issues WHERE id = $1 AND deleted_at IS NULL`, link.ToNumber,
-			).Scan(&targetID, &targetUID, &targetShortID)
+				`SELECT i.id, i.uid, i.short_id, p.uid
+				   FROM issues i
+				   JOIN projects p ON p.id = i.project_id
+				  WHERE i.id = $1 AND i.deleted_at IS NULL
+				  FOR SHARE OF i`, link.ToNumber,
+			).Scan(&targetID, &targetUID, &targetShortID, &targetProjectUID)
 			if errors.Is(err, sql.ErrNoRows) {
 				return db.ErrInitialLinkTargetNotFound
 			}
 			if err != nil {
 				return mapSQLError(err, nil)
+			}
+			if link.ExpectedProjectUID != "" && targetProjectUID != link.ExpectedProjectUID {
+				return db.ErrInitialLinkTargetNotFound
 			}
 			if targetID == issueID {
 				return db.ErrSelfLink

--- a/internal/db/pgstore/links.go
+++ b/internal/db/pgstore/links.go
@@ -62,6 +62,15 @@ func (s *Store) CreateLinkAndEvent(
 		if err := prepareLinkInsertTx(ctx, tx, params, true); err != nil {
 			return err
 		}
+		// The peer of the event issue is the add-side target; its project
+		// must still be live at commit time.
+		peerID := params.ToIssueID
+		if params.FromIssueID != eventIssue.ID {
+			peerID = params.FromIssueID
+		}
+		if err := requireAddableLinkTargetTx(ctx, tx, peerID); err != nil {
+			return err
+		}
 		link, err = insertLinkTx(ctx, tx, params)
 		if err != nil {
 			return err

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -655,25 +655,27 @@ func (d *Store) createIssue(ctx context.Context, p db.CreateIssueParams) (int64,
 	// to_issue_short_id), excluding soft-deleted targets. Targets may live
 	// in any project (links span projects since storage v16); the daemon
 	// resolves refs and gates archived peer projects before calling in, so
-	// this is the in-tx existence re-check. We surface a typed not-found
-	// rather than letting a constraint failure propagate. The peer UID and
-	// short_id are captured here and folded into the issue.created event
-	// payload: UID is canonical, short_id is the rendered display value
-	// (spec §11).
+	// this is the in-tx existence and project-liveness re-check. We surface
+	// typed errors rather than letting a constraint failure propagate. The
+	// peer UID and short_id are captured here and folded into the
+	// issue.created event payload: UID is canonical, short_id is the
+	// rendered display value (spec §11).
 	resolvedTargets := make([]createdLinkTarget, 0, len(links))
 	for _, l := range links {
 		var (
-			toIssueID      int64
-			toIssueUID     string
-			toIssueShortID string
-			toProjectUID   string
+			toIssueID       int64
+			toIssueUID      string
+			toIssueShortID  string
+			toProjectUID    string
+			toProjectName   string
+			projectArchived bool
 		)
 		err := tx.QueryRowContext(ctx,
-			`SELECT i.id, i.uid, i.short_id, p.uid
+			`SELECT i.id, i.uid, i.short_id, p.uid, p.name, p.deleted_at IS NOT NULL
 			   FROM issues i
 			   JOIN projects p ON p.id = i.project_id
 			  WHERE i.id = ? AND i.deleted_at IS NULL`,
-			l.ToNumber).Scan(&toIssueID, &toIssueUID, &toIssueShortID, &toProjectUID)
+			l.ToNumber).Scan(&toIssueID, &toIssueUID, &toIssueShortID, &toProjectUID, &toProjectName, &projectArchived)
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, db.Event{}, db.ErrInitialLinkTargetNotFound
 		}
@@ -682,6 +684,9 @@ func (d *Store) createIssue(ctx context.Context, p db.CreateIssueParams) (int64,
 		}
 		if l.ExpectedProjectUID != "" && toProjectUID != l.ExpectedProjectUID {
 			return 0, db.Event{}, db.ErrInitialLinkTargetNotFound
+		}
+		if projectArchived {
+			return 0, db.Event{}, &db.LinkTargetArchivedError{Number: toIssueID, ShortID: toIssueShortID, Project: toProjectName}
 		}
 		resolvedTargets = append(resolvedTargets, createdLinkTarget{UID: toIssueUID, ShortID: toIssueShortID})
 		// Canonical ordering is a storage concern: the payload reports the

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -666,16 +666,22 @@ func (d *Store) createIssue(ctx context.Context, p db.CreateIssueParams) (int64,
 			toIssueID      int64
 			toIssueUID     string
 			toIssueShortID string
+			toProjectUID   string
 		)
 		err := tx.QueryRowContext(ctx,
-			`SELECT id, uid, short_id FROM issues
-			 WHERE id = ? AND deleted_at IS NULL`,
-			l.ToNumber).Scan(&toIssueID, &toIssueUID, &toIssueShortID)
+			`SELECT i.id, i.uid, i.short_id, p.uid
+			   FROM issues i
+			   JOIN projects p ON p.id = i.project_id
+			  WHERE i.id = ? AND i.deleted_at IS NULL`,
+			l.ToNumber).Scan(&toIssueID, &toIssueUID, &toIssueShortID, &toProjectUID)
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, db.Event{}, db.ErrInitialLinkTargetNotFound
 		}
 		if err != nil {
 			return 0, db.Event{}, fmt.Errorf("resolve initial link target: %w", err)
+		}
+		if l.ExpectedProjectUID != "" && toProjectUID != l.ExpectedProjectUID {
+			return 0, db.Event{}, db.ErrInitialLinkTargetNotFound
 		}
 		resolvedTargets = append(resolvedTargets, createdLinkTarget{UID: toIssueUID, ShortID: toIssueShortID})
 		// Canonical ordering is a storage concern: the payload reports the
@@ -867,7 +873,7 @@ func dedupeLinks(in []db.InitialLink) []db.InitialLink {
 		if l.Type == "related" {
 			normalized.Incoming = false
 		}
-		k := key(normalized)
+		k := key{Type: normalized.Type, ToNumber: normalized.ToNumber, Incoming: normalized.Incoming}
 		if _, ok := seen[k]; ok {
 			continue
 		}

--- a/internal/db/sqlitestore/queries_edit_atomic.go
+++ b/internal/db/sqlitestore/queries_edit_atomic.go
@@ -233,6 +233,9 @@ func (d *Store) applyLinksDeltaTx(ctx context.Context, tx *sql.Tx, issue db.Issu
 		if target.ID == issue.ID {
 			return changed, db.ErrSelfLink
 		}
+		if err := requireAddableLinkTargetTx(ctx, tx, target.ID); err != nil {
+			return changed, err
+		}
 		if err := assertNoParentCycleTx(ctx, tx, issue.ID, target.ID); err != nil {
 			return changed, err
 		}
@@ -451,6 +454,9 @@ func addEdgeTx(ctx context.Context, tx *sql.Tx, urlIssue db.Issue, targetID int6
 	if target.ID == urlIssue.ID {
 		return false, db.PeerIdentity{}, db.ErrSelfLink
 	}
+	if err := requireAddableLinkTargetTx(ctx, tx, target.ID); err != nil {
+		return false, db.PeerIdentity{}, err
+	}
 	from, to := urlIssue.ID, target.ID
 	if reverseDirection {
 		from, to = to, from
@@ -583,6 +589,31 @@ func insertLinkRowTx(ctx context.Context, tx *sql.Tx, fromID, toID int64, linkTy
 // lookupIssueByIDTx fetches one issue by its row id within a TX,
 // excluding soft-deleted rows. Used by add-link paths that accept
 // cross-project issue IDs (storage v16+).
+// requireAddableLinkTargetTx rejects an add-side link target whose project
+// is archived at commit time. The daemon gates the same condition before the
+// transaction; this catches an archival that commits between that preflight
+// and the insert. Removals never call it. SQLite's single writer serializes
+// the check against RemoveProject.
+func requireAddableLinkTargetTx(ctx context.Context, tx *sql.Tx, targetID int64) error {
+	var shortID, projectName string
+	var archived bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT i.short_id, p.name, p.deleted_at IS NOT NULL
+		  FROM issues i
+		  JOIN projects p ON p.id = i.project_id
+		 WHERE i.id = ?`, targetID).Scan(&shortID, &projectName, &archived)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &db.LinkTargetNotFoundError{Number: targetID}
+	}
+	if err != nil {
+		return fmt.Errorf("check link target project: %w", err)
+	}
+	if archived {
+		return &db.LinkTargetArchivedError{Number: targetID, ShortID: shortID, Project: projectName}
+	}
+	return nil
+}
+
 func lookupIssueByIDTx(ctx context.Context, tx *sql.Tx, id int64) (db.Issue, error) {
 	row := tx.QueryRowContext(ctx, issueSelect+` WHERE i.id = ? AND i.deleted_at IS NULL`, id)
 	return scanIssue(row)

--- a/internal/db/sqlitestore/queries_edit_atomic.go
+++ b/internal/db/sqlitestore/queries_edit_atomic.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 
 	"go.kenn.io/kata/internal/db"
 )
@@ -33,6 +34,9 @@ func (d *Store) editIssueAtomic(ctx context.Context, p db.EditIssueAtomicParams)
 
 	issue, projectName, err := lookupIssueForEvent(ctx, tx, p.IssueID)
 	if err != nil {
+		return db.EditIssueAtomicResult{}, err
+	}
+	if err := validateExpectedLinkProjectUIDsTx(ctx, tx, p.ExpectedLinkProjectUIDs); err != nil {
 		return db.EditIssueAtomicResult{}, err
 	}
 	p.Actor, err = d.effectiveLocalMutationActorTx(ctx, tx, issue.ProjectID, p.Actor)
@@ -173,6 +177,29 @@ func (d *Store) editIssueAtomic(ctx context.Context, p db.EditIssueAtomicParams)
 		Changes:   changes,
 		AnyChange: anyChange,
 	}, nil
+}
+
+func validateExpectedLinkProjectUIDsTx(ctx context.Context, tx *sql.Tx, expected map[int64]string) error {
+	ids := make([]int64, 0, len(expected))
+	for issueID := range expected {
+		ids = append(ids, issueID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, issueID := range ids {
+		var projectUID string
+		err := tx.QueryRowContext(ctx, `
+			SELECT p.uid
+			  FROM issues i
+			  JOIN projects p ON p.id = i.project_id
+			 WHERE i.id = ?`, issueID).Scan(&projectUID)
+		if errors.Is(err, sql.ErrNoRows) || err == nil && projectUID != expected[issueID] {
+			return &db.LinkTargetNotFoundError{Number: issueID}
+		}
+		if err != nil {
+			return fmt.Errorf("validate link target project identity: %w", err)
+		}
+	}
+	return nil
 }
 
 // linksChangedPayload marshals c plus ts into the legacy wire bytes.

--- a/internal/db/sqlitestore/queries_links.go
+++ b/internal/db/sqlitestore/queries_links.go
@@ -733,6 +733,17 @@ func scanLink(r rowScanner) (db.Link, error) {
 // Storage endpoints come from p (canonicalized for related when fromID > toID
 // at the call site); event attribution comes from ev. For parent/blocks the
 // two coincide; for related they may differ when canonicalization swapped.
+// linkPeerID returns the endpoint of a requested link that is not the issue
+// the mutation was requested on.
+func linkPeerID(p db.CreateLinkParams, eventIssueID int64) int64 {
+	if p.FromIssueID == eventIssueID {
+		return p.ToIssueID
+	}
+	return p.FromIssueID
+}
+
+// CreateLinkAndEvent inserts a relationship, records its event, and touches
+// the issue on whose surface the mutation was requested.
 func (d *Store) CreateLinkAndEvent(ctx context.Context, p db.CreateLinkParams, ev db.LinkEventParams) (db.Link, db.Event, error) {
 	return retryWrite2(ctx, d, func() (db.Link, db.Event, error) {
 		return d.createLinkAndEvent(ctx, p, ev)
@@ -769,6 +780,11 @@ func (d *Store) createLinkAndEvent(ctx context.Context, p db.CreateLinkParams, e
 		if err := assertNoParentCycleTx(ctx, tx, p.FromIssueID, p.ToIssueID); err != nil {
 			return db.Link{}, db.Event{}, err
 		}
+	}
+	// The peer of the event issue is the add-side target; its project must
+	// still be live at commit time.
+	if err := requireAddableLinkTargetTx(ctx, tx, linkPeerID(p, ev.EventIssueID)); err != nil {
+		return db.Link{}, db.Event{}, err
 	}
 
 	res, err := tx.ExecContext(ctx,

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -878,20 +878,29 @@ func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 	if strings.TrimSpace(input.Project) == "" && h.options.Scope.Mode() != ScopeBound {
 		return h.waitPollEvents(ctx, input.Project, input.After, limit, waitSeconds)
 	}
+	// The wait deadline bounds the whole call, including the scope lookup
+	// that precedes the stream: the long-running client has no timeout of
+	// its own, so a stalled catalog must still honor wait_seconds.
+	waitContext, cancel := context.WithTimeout(ctx, time.Duration(waitSeconds)*time.Second)
+	defer cancel()
+	timedOut := func() (*sdkmcp.CallToolResult, EventsOutput, error) {
+		return successResult(), withEventsList(EventsOutput{NextAfterID: input.After, TimedOut: true}), nil
+	}
 	var projectID *int64
 	if strings.TrimSpace(input.Project) != "" || h.options.Scope.Mode() == ScopeBound {
-		projects, err := h.activityProjects(ctx, input.Project)
+		projects, err := h.activityProjects(waitContext, input.Project)
 		if err != nil {
+			if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
+				return timedOut()
+			}
 			return nil, EventsOutput{}, err
 		}
 		projectID = &projects[0].ID
 	}
-	waitContext, cancel := context.WithTimeout(ctx, time.Duration(waitSeconds)*time.Second)
-	defer cancel()
 	response, err := h.options.Client.StreamEventsRaw(waitContext, &generated.StreamEventsRequestOptions{Query: &generated.StreamEventsQuery{AfterID: &input.After, ProjectID: projectID}})
 	if err != nil {
 		if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
-			return successResult(), withEventsList(EventsOutput{NextAfterID: input.After, TimedOut: true}), nil
+			return timedOut()
 		}
 		return nil, EventsOutput{}, err
 	}
@@ -899,7 +908,7 @@ func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 	output, err := readEventStream(waitContext, response.Body, input.After, limit)
 	if err != nil {
 		if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
-			return successResult(), withEventsList(EventsOutput{NextAfterID: input.After, TimedOut: true}), nil
+			return timedOut()
 		}
 		return nil, EventsOutput{}, err
 	}

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -578,23 +578,20 @@ func (h toolHandlers) validateAuditParentFilter(ctx context.Context, raw string)
 }
 
 // redactAuditParentsOutsideScope blanks qualified parent references whose
-// project qualifier is not in the startup scope. Live bare parent refs are
-// same-project by the daemon's rendering contract, but a purged parent falls
-// back to its stored short ID, which can be foreign — keep a bare ref only
-// when it still resolves in the audited project.
+// project qualifier is not in the startup scope. Bare parent refs carry no
+// provenance — a purged parent falls back to its stored short ID, which can
+// be foreign and collide with an unrelated in-scope short ID — so a bare ref
+// is kept only when the closed child's current parent link vouches for it
+// with immutable peer identity.
 func (h toolHandlers) redactAuditParentsOutsideScope(ctx context.Context, project ProjectIdentity, rows []generated.AuditCloseRow) ([]generated.AuditCloseRow, error) {
 	if h.options.Scope.Mode() == ScopeAll {
 		return rows, nil
 	}
-	projects, err := h.options.Scope.Projects(ctx, h.options.Client, true)
+	inScope, err := h.scopeProjectNames(ctx)
 	if err != nil {
 		return nil, err
 	}
-	inScope := make(map[string]struct{}, len(projects))
-	for _, scoped := range projects {
-		inScope[scoped.Name] = struct{}{}
-	}
-	resolvedBare := make(map[string]bool)
+	childParents := make(map[string]string)
 	for index := range rows {
 		parent := rows[index].Parent
 		if parent == nil {
@@ -607,39 +604,73 @@ func (h toolHandlers) redactAuditParentsOutsideScope(ctx context.Context, projec
 			}
 			continue
 		}
-		allowed, seen := resolvedBare[*parent]
+		parentShort, seen := childParents[rows[index].Issue]
 		if !seen {
-			allowed, err = h.issueVisibleInProject(ctx, project, *parent)
+			parentShort, err = h.inScopeParentShortID(ctx, project, rows[index].Issue, inScope)
 			if err != nil {
 				return nil, err
 			}
-			resolvedBare[*parent] = allowed
+			childParents[rows[index].Issue] = parentShort
 		}
-		if !allowed {
+		if parentShort == "" || parentShort != *parent {
 			rows[index].Parent = nil
 		}
 	}
 	return rows, nil
 }
 
-// issueVisibleInProject reports whether ref resolves inside project. A
-// transient daemon failure fails closed with a redacted error.
-func (h toolHandlers) issueVisibleInProject(ctx context.Context, project ProjectIdentity, ref string) (bool, error) {
+// inScopeParentShortID returns the short ID of ref's current parent when that
+// parent's project is in scope, or "" when there is no provable parent.
+func (h toolHandlers) inScopeParentShortID(ctx context.Context, project ProjectIdentity, ref string, inScope map[string]struct{}) (string, error) {
+	issueUID, links, found, err := h.issueLinksForVouching(ctx, project, ref)
+	if err != nil || !found {
+		return "", err
+	}
+	for _, link := range links {
+		peer, typeName := linkPeerAndType(issueUID, link)
+		if typeName != "parent" {
+			continue
+		}
+		if _, ok := inScope[peer.Project]; ok {
+			return peer.ShortID, nil
+		}
+	}
+	return "", nil
+}
+
+// issueLinksForVouching reads an issue's current links so display references
+// can be vouched by immutable peer identity. A missing issue is not an error;
+// a transient daemon failure fails closed with a redacted error.
+func (h toolHandlers) issueLinksForVouching(ctx context.Context, project ProjectIdentity, ref string) (string, []generated.LinkOut, bool, error) {
 	includeDeleted := true
-	_, err := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
+	response, err := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
 		PathParams: &generated.ShowIssuePath{ProjectID: project.ID, Ref: ref},
 		Query:      &generated.ShowIssueQuery{IncludeDeleted: &includeDeleted},
 	})
 	if err == nil {
-		return true, nil
+		return response.Issue.UID, response.Links, true, nil
 	}
 	if ctx.Err() != nil {
-		return false, ctx.Err()
+		return "", nil, false, ctx.Err()
 	}
 	if isHTTPStatus(err, http.StatusNotFound) {
-		return false, nil
+		return "", nil, false, nil
 	}
-	return false, errors.New("resolve scoped issue reference: daemon request failed")
+	return "", nil, false, errors.New("resolve scoped issue reference: daemon request failed")
+}
+
+// scopeProjectNames returns the startup scope's current project names,
+// including archived members, for display-reference checks.
+func (h toolHandlers) scopeProjectNames(ctx context.Context) (map[string]struct{}, error) {
+	projects, err := h.options.Scope.Projects(ctx, h.options.Client, true)
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[string]struct{}, len(projects))
+	for _, project := range projects {
+		names[project.Name] = struct{}{}
+	}
+	return names, nil
 }
 
 func (h toolHandlers) digest(ctx context.Context, _ *sdkmcp.CallToolRequest, input DigestInput) (*sdkmcp.CallToolResult, DigestOutput, error) {
@@ -680,14 +711,19 @@ var digestLinkActionPrefixes = map[string]struct{}{
 	"unblocks": {}, "unblocked_by": {}, "unparent": {}, "unrelated": {},
 }
 
-// redactDigestLinkActions drops link action tokens whose peer short ID does
-// not resolve in the digest's project. Cross-project peers of an in-scope
-// issue render as bare short IDs, so resolution is the scope check.
+// redactDigestLinkActions strips the peer short ID from link action tokens
+// unless the digest issue's current links vouch for that peer with immutable
+// in-scope identity. Bare short IDs alone are not provenance: a foreign
+// peer's short ID can collide with an unrelated in-scope short ID.
 func (h toolHandlers) redactDigestLinkActions(ctx context.Context, project ProjectIdentity, digest *generated.DigestResponseBody) error {
-	resolved := make(map[string]bool)
+	inScope, err := h.scopeProjectNames(ctx)
+	if err != nil {
+		return err
+	}
 	for actorIndex := range digest.Actors {
 		for issueIndex := range digest.Actors[actorIndex].Issues {
 			issueActions := &digest.Actors[actorIndex].Issues[issueIndex]
+			var peers map[string]bool
 			kept := make([]string, 0, len(issueActions.Actions))
 			for _, action := range issueActions.Actions {
 				prefix, target, split := strings.Cut(action, ":")
@@ -699,23 +735,39 @@ func (h toolHandlers) redactDigestLinkActions(ctx context.Context, project Proje
 					kept = append(kept, action)
 					continue
 				}
-				allowed, seen := resolved[target]
-				if !seen {
-					var err error
-					allowed, err = h.issueVisibleInProject(ctx, project, target)
+				if peers == nil {
+					peers, err = h.inScopeLinkPeerShortIDs(ctx, project, issueActions.IssueShortID, inScope)
 					if err != nil {
 						return err
 					}
-					resolved[target] = allowed
 				}
-				if allowed {
+				if peers[target] {
 					kept = append(kept, action)
+				} else {
+					kept = append(kept, prefix)
 				}
 			}
 			issueActions.Actions = kept
 		}
 	}
 	return nil
+}
+
+// inScopeLinkPeerShortIDs collects the short IDs of ref's current link peers
+// whose projects are inside the startup scope.
+func (h toolHandlers) inScopeLinkPeerShortIDs(ctx context.Context, project ProjectIdentity, ref string, inScope map[string]struct{}) (map[string]bool, error) {
+	peers := make(map[string]bool)
+	issueUID, links, found, err := h.issueLinksForVouching(ctx, project, ref)
+	if err != nil || !found {
+		return peers, err
+	}
+	for _, link := range links {
+		peer, _ := linkPeerAndType(issueUID, link)
+		if _, ok := inScope[peer.Project]; ok {
+			peers[peer.ShortID] = true
+		}
+	}
+	return peers, nil
 }
 
 func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, input EventsInput) (*sdkmcp.CallToolResult, EventsOutput, error) {

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -498,12 +498,19 @@ func (h toolHandlers) wait(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 	}
 	waitContext, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
+	// The deadline can expire while a lookup is in flight; that is the
+	// documented timeout outcome, not a tool error. States from the last
+	// complete round keep the output honest.
+	lastStates := make([]WaitState, 0)
 	for {
 		states := make([]WaitState, 0, len(input.Refs))
 		matches := 0
 		for _, raw := range input.Refs {
 			project, ref, targetErr := h.options.Scope.IssueTarget(waitContext, h.options.Client, raw, false)
 			if targetErr != nil {
+				if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
+					return successResult(), WaitOutput{Reason: "timeout", States: lastStates}, nil
+				}
 				return nil, WaitOutput{}, targetErr
 			}
 			includeDeleted := true
@@ -512,6 +519,9 @@ func (h toolHandlers) wait(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 				Query:      &generated.ShowIssueQuery{IncludeDeleted: &includeDeleted},
 			})
 			if showErr != nil {
+				if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
+					return successResult(), WaitOutput{Reason: "timeout", States: lastStates}, nil
+				}
 				return nil, WaitOutput{}, showErr
 			}
 			actual := shown.Issue.Status
@@ -527,6 +537,7 @@ func (h toolHandlers) wait(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 		if input.Any && matches > 0 || !input.Any && matches == len(states) {
 			return successResult(), WaitOutput{Reason: "matched", States: states}, nil
 		}
+		lastStates = states
 		select {
 		case <-waitContext.Done():
 			if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
@@ -984,6 +995,9 @@ func (h toolHandlers) waitPollEvents(ctx context.Context, project string, after,
 	for {
 		output, err := h.pollScopedEvents(waitContext, project, after, limit)
 		if err != nil {
+			if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
+				return successResult(), withEventsList(EventsOutput{NextAfterID: after, TimedOut: true}), nil
+			}
 			return nil, EventsOutput{}, err
 		}
 		if output.ResetRequired || len(output.Events) > 0 {

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -775,13 +775,7 @@ func (h toolHandlers) digest(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 	if strings.TrimSpace(input.Since) == "" {
 		return nil, DigestOutput{}, errors.New("since is required")
 	}
-	if strings.TrimSpace(input.Project) == "" && h.options.Scope.Mode() == ScopeAll {
-		response, err := h.options.Client.DigestGlobal(ctx, &generated.DigestGlobalRequestOptions{Query: &generated.DigestGlobalQuery{Since: input.Since, Until: optionalString(input.Until), Actor: input.Actors}})
-		if err != nil {
-			return nil, DigestOutput{}, err
-		}
-		return successResult(), DigestOutput{Digests: []ProjectDigest{{Digest: *response}}}, nil
-	}
+	aggregate := strings.TrimSpace(input.Project) == "" && h.options.Scope.Mode() != ScopeBound
 	projects, err := h.activityProjects(ctx, input.Project)
 	if err != nil {
 		return nil, DigestOutput{}, err
@@ -790,6 +784,9 @@ func (h toolHandlers) digest(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 	for _, project := range projects {
 		response, digestErr := h.options.Client.DigestProject(ctx, &generated.DigestProjectRequestOptions{PathParams: &generated.DigestProjectPath{ProjectID: project.ID}, Query: &generated.DigestProjectQuery{Since: input.Since, Until: optionalString(input.Until), Actor: input.Actors}})
 		if digestErr != nil {
+			if aggregate && isHTTPStatus(digestErr, http.StatusNotFound) {
+				continue
+			}
 			return nil, DigestOutput{}, digestErr
 		}
 		if h.options.Scope.Mode() != ScopeAll {
@@ -867,9 +864,10 @@ func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 		return nil, EventsOutput{}, errors.New("wait_seconds must be between 1 and 300")
 	}
 	h = h.withLongRunningClient()
-	// One stream can filter one project or all projects. A fixed multi-project
-	// allowlist uses bounded polling so events outside its scope never leak.
-	if strings.TrimSpace(input.Project) == "" && h.options.Scope.Mode() == ScopeAllowlist {
+	// One stream can safely filter one active project. Dynamic and fixed
+	// multi-project scopes use bounded per-project polling so archived projects
+	// cannot leak through the daemon-global stream.
+	if strings.TrimSpace(input.Project) == "" && h.options.Scope.Mode() != ScopeBound {
 		return h.waitPollEvents(ctx, input.Project, input.After, limit, waitSeconds)
 	}
 	var projectID *int64
@@ -925,13 +923,7 @@ func (h toolHandlers) activityProjects(ctx context.Context, name string) ([]Proj
 }
 
 func (h toolHandlers) pollScopedEvents(ctx context.Context, projectName string, after, limit int64) (EventsOutput, error) {
-	if strings.TrimSpace(projectName) == "" && h.options.Scope.Mode() == ScopeAll {
-		response, err := h.options.Client.PollEvents(ctx, &generated.PollEventsRequestOptions{Query: &generated.PollEventsQuery{AfterID: &after, Limit: &limit}})
-		if err != nil {
-			return EventsOutput{}, err
-		}
-		return eventsOutput(response), nil
-	}
+	aggregate := strings.TrimSpace(projectName) == "" && h.options.Scope.Mode() != ScopeBound
 	projects, err := h.activityProjects(ctx, projectName)
 	if err != nil {
 		return EventsOutput{}, err
@@ -940,6 +932,9 @@ func (h toolHandlers) pollScopedEvents(ctx context.Context, projectName string, 
 	for _, project := range projects {
 		response, pollErr := h.options.Client.PollProjectEvents(ctx, &generated.PollProjectEventsRequestOptions{PathParams: &generated.PollProjectEventsPath{ProjectID: project.ID}, Query: &generated.PollProjectEventsQuery{AfterID: &after, Limit: &limit}})
 		if pollErr != nil {
+			if aggregate && isHTTPStatus(pollErr, http.StatusNotFound) {
+				continue
+			}
 			return EventsOutput{}, pollErr
 		}
 		if response.ResetRequired {
@@ -992,17 +987,6 @@ func (h toolHandlers) waitPollEvents(ctx context.Context, project string, after,
 		case <-time.After(250 * time.Millisecond):
 		}
 	}
-}
-
-func eventsOutput(response *generated.PollEventsBody) EventsOutput {
-	if response.ResetRequired {
-		return EventsOutput{NextAfterID: response.NextAfterID, ResetRequired: true, ResetAfterID: response.ResetAfterID}
-	}
-	events := make([]StreamEvent, 0, len(response.Events))
-	for _, event := range response.Events {
-		events = append(events, streamEvent(event))
-	}
-	return EventsOutput{Events: events, NextAfterID: response.NextAfterID}
 }
 
 func readEventStream(ctx context.Context, reader io.Reader, after, limit int64) (EventsOutput, error) {

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -542,7 +542,42 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
-	return successResult(), AuditClosesOutput{Project: project, Rows: response.Rows}, nil
+	rows, err := h.redactAuditParentsOutsideScope(ctx, response.Rows)
+	if err != nil {
+		return nil, AuditClosesOutput{}, err
+	}
+	return successResult(), AuditClosesOutput{Project: project, Rows: rows}, nil
+}
+
+// redactAuditParentsOutsideScope blanks qualified parent references whose
+// project qualifier is not in the startup scope. Bare parent refs are
+// same-project by the daemon's rendering contract.
+func (h toolHandlers) redactAuditParentsOutsideScope(ctx context.Context, rows []generated.AuditCloseRow) ([]generated.AuditCloseRow, error) {
+	if h.options.Scope.Mode() == ScopeAll {
+		return rows, nil
+	}
+	projects, err := h.options.Scope.Projects(ctx, h.options.Client, true)
+	if err != nil {
+		return nil, err
+	}
+	inScope := make(map[string]struct{}, len(projects))
+	for _, project := range projects {
+		inScope[project.Name] = struct{}{}
+	}
+	for index := range rows {
+		parent := rows[index].Parent
+		if parent == nil {
+			continue
+		}
+		qualifier, _, qualified := strings.Cut(*parent, "#")
+		if !qualified {
+			continue
+		}
+		if _, ok := inScope[qualifier]; !ok {
+			rows[index].Parent = nil
+		}
+	}
+	return rows, nil
 }
 
 func (h toolHandlers) digest(ctx context.Context, _ *sdkmcp.CallToolRequest, input DigestInput) (*sdkmcp.CallToolResult, DigestOutput, error) {
@@ -814,8 +849,18 @@ func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *Even
 		return err
 	}
 	allowedProjects := make(map[int64]struct{}, len(projects))
+	allowedProjectUIDs := make(map[string]bool, len(projects))
 	for _, project := range projects {
 		allowedProjects[project.ID] = struct{}{}
+		if project.UID != "" {
+			allowedProjectUIDs[project.UID] = true
+		}
+	}
+	// An event's own project passed the scope filter already.
+	for _, event := range output.Events {
+		if event.ProjectUID != "" {
+			allowedProjectUIDs[event.ProjectUID] = true
+		}
 	}
 	peerUIDs := make(map[string]struct{})
 	for _, event := range output.Events {
@@ -846,7 +891,7 @@ func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *Even
 			event.RelatedIssueUID = ""
 			event.RelatedIssueShortID = ""
 		}
-		event.Payload = redactEventPayloadPeers(event.Payload, allowedPeers)
+		event.Payload = redactEventPayloadPeers(event.Payload, allowedPeers, allowedProjectUIDs)
 	}
 	return nil
 }
@@ -861,17 +906,42 @@ func isHTTPStatus(err error, status int) bool {
 }
 
 var eventPeerUIDKeys = map[string]struct{}{
-	"from_uid": {}, "to_uid": {}, "link_from_uid": {}, "link_to_uid": {},
-	"peer_uid": {}, "related_issue_uid": {},
+	"from_uid": {}, "to_uid": {}, "from_issue_uid": {}, "to_issue_uid": {},
+	"link_from_uid": {}, "link_to_uid": {}, "peer_uid": {}, "related_issue_uid": {},
+	"parent_set_uid": {}, "parent_removed_uid": {},
 }
 
-var eventPeerShortIDUIDKeys = map[string]string{
-	"from_short_id":          "from_uid",
-	"to_short_id":            "to_uid",
-	"link_from_short_id":     "link_from_uid",
-	"link_to_short_id":       "link_to_uid",
-	"peer_short_id":          "peer_uid",
-	"related_issue_short_id": "related_issue_uid",
+// A display reference survives only when one of its present UID companions
+// resolves in scope. Move payloads carry short IDs vouched for by a project
+// UID instead of an issue UID, so those keys list a project companion too.
+var eventPeerShortIDUIDKeys = map[string][]string{
+	"from_short_id":          {"from_uid", "from_issue_uid"},
+	"to_short_id":            {"to_uid", "to_issue_uid"},
+	"link_from_short_id":     {"link_from_uid"},
+	"link_to_short_id":       {"link_to_uid"},
+	"peer_short_id":          {"peer_uid"},
+	"related_issue_short_id": {"related_issue_uid"},
+	"parent_set":             {"parent_set_uid"},
+	"parent_removed":         {"parent_removed_uid"},
+}
+
+var eventPeerShortIDProjectUIDKeys = map[string]string{
+	"from_short_id": "from_project_uid",
+	"to_short_id":   "to_project_uid",
+}
+
+// Aggregated relationship deltas store parallel UID and display arrays.
+var eventPeerUIDListKeys = map[string]string{
+	"blocks_added_uids":       "blocks_added",
+	"blocks_removed_uids":     "blocks_removed",
+	"blocked_by_added_uids":   "blocked_by_added",
+	"blocked_by_removed_uids": "blocked_by_removed",
+	"related_added_uids":      "related_added",
+	"related_removed_uids":    "related_removed",
+}
+
+var eventProjectUIDKeys = map[string]struct{}{
+	"from_project_uid": {}, "to_project_uid": {}, "source_uid": {},
 }
 
 func collectEventPeerUIDs(value any, output map[string]struct{}) {
@@ -883,6 +953,15 @@ func collectEventPeerUIDs(value any, output map[string]struct{}) {
 					output[uid] = struct{}{}
 				}
 			}
+			if _, listKey := eventPeerUIDListKeys[key]; listKey {
+				if list, ok := nested.([]any); ok {
+					for _, element := range list {
+						if uid, ok := element.(string); ok && uid != "" {
+							output[uid] = struct{}{}
+						}
+					}
+				}
+			}
 			collectEventPeerUIDs(nested, output)
 		}
 	case []any:
@@ -892,7 +971,7 @@ func collectEventPeerUIDs(value any, output map[string]struct{}) {
 	}
 }
 
-func redactEventPayloadPeers(value any, allowed map[string]bool) any {
+func redactEventPayloadPeers(value any, allowed map[string]bool, allowedProjects map[string]bool) any {
 	switch current := value.(type) {
 	case map[string]any:
 		for key := range current {
@@ -902,23 +981,88 @@ func redactEventPayloadPeers(value any, allowed map[string]bool) any {
 					delete(current, key)
 				}
 			}
+			if _, projectKey := eventProjectUIDKeys[key]; projectKey {
+				uid, ok := current[key].(string)
+				if !ok || !allowedProjects[uid] {
+					delete(current, key)
+				}
+			}
 		}
-		for shortIDKey, uidKey := range eventPeerShortIDUIDKeys {
+		for uidsKey, displayKey := range eventPeerUIDListKeys {
+			redactEventPeerUIDList(current, uidsKey, displayKey, allowed)
+		}
+		for shortIDKey, uidKeys := range eventPeerShortIDUIDKeys {
 			if _, present := current[shortIDKey]; !present {
 				continue
 			}
-			uid, ok := current[uidKey].(string)
-			if !ok || !allowed[uid] {
+			vouched := false
+			for _, uidKey := range uidKeys {
+				if uid, ok := current[uidKey].(string); ok && allowed[uid] {
+					vouched = true
+					break
+				}
+			}
+			if projectKey, paired := eventPeerShortIDProjectUIDKeys[shortIDKey]; paired && !vouched {
+				if uid, ok := current[projectKey].(string); ok && allowedProjects[uid] {
+					vouched = true
+				}
+			}
+			if !vouched {
 				delete(current, shortIDKey)
 			}
 		}
 		for key, nested := range current {
-			current[key] = redactEventPayloadPeers(nested, allowed)
+			current[key] = redactEventPayloadPeers(nested, allowed, allowedProjects)
 		}
 	case []any:
 		for index, nested := range current {
-			current[index] = redactEventPayloadPeers(nested, allowed)
+			current[index] = redactEventPayloadPeers(nested, allowed, allowedProjects)
 		}
 	}
 	return value
+}
+
+func redactEventPeerUIDList(payload map[string]any, uidsKey, displayKey string, allowed map[string]bool) {
+	rawUIDs, present := payload[uidsKey]
+	rawDisplay, displayPresent := payload[displayKey]
+	if !present {
+		// A display array with no UID companion cannot be vouched for.
+		if displayPresent {
+			delete(payload, displayKey)
+		}
+		return
+	}
+	uids, ok := rawUIDs.([]any)
+	if !ok {
+		delete(payload, uidsKey)
+		delete(payload, displayKey)
+		return
+	}
+	display, displayOK := rawDisplay.([]any)
+	pairwise := displayPresent && displayOK && len(display) == len(uids)
+	keptUIDs := make([]any, 0, len(uids))
+	keptDisplay := make([]any, 0, len(uids))
+	for index, element := range uids {
+		uid, isString := element.(string)
+		if !isString || !allowed[uid] {
+			continue
+		}
+		keptUIDs = append(keptUIDs, uid)
+		if pairwise {
+			keptDisplay = append(keptDisplay, display[index])
+		}
+	}
+	if len(keptUIDs) == 0 {
+		delete(payload, uidsKey)
+		delete(payload, displayKey)
+		return
+	}
+	payload[uidsKey] = keptUIDs
+	if displayPresent {
+		if pairwise {
+			payload[displayKey] = keptDisplay
+		} else {
+			delete(payload, displayKey)
+		}
+	}
 }

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -1016,8 +1016,10 @@ func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *Even
 	}
 	allowedProjects := make(map[int64]struct{}, len(projects))
 	allowedProjectUIDs := make(map[string]bool, len(projects))
+	allowedProjectNames := make(map[string]struct{}, len(projects))
 	for _, project := range projects {
 		allowedProjects[project.ID] = struct{}{}
+		allowedProjectNames[project.Name] = struct{}{}
 		if project.UID != "" {
 			allowedProjectUIDs[project.UID] = true
 		}
@@ -1026,6 +1028,9 @@ func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *Even
 	for _, event := range output.Events {
 		if event.ProjectUID != "" {
 			allowedProjectUIDs[event.ProjectUID] = true
+		}
+		if event.ProjectName != "" {
+			allowedProjectNames[event.ProjectName] = struct{}{}
 		}
 	}
 	peerUIDs := make(map[string]struct{})
@@ -1058,8 +1063,69 @@ func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *Even
 			event.RelatedIssueShortID = ""
 		}
 		event.Payload = redactEventPayloadPeers(event.Payload, allowedPeers, allowedProjectUIDs)
+		redactEventTypedDisplayRefs(event, allowedProjectNames)
 	}
 	return nil
+}
+
+// redactEventTypedDisplayRefs removes event-type-specific display references
+// that carry no UID companion: close-throttle cohort refs span projects and
+// close-evidence refs are stored verbatim.
+func redactEventTypedDisplayRefs(event *StreamEvent, inScope map[string]struct{}) {
+	payload, ok := event.Payload.(map[string]any)
+	if !ok {
+		return
+	}
+	switch event.Type {
+	case "close.throttled":
+		for _, key := range []string{"parent", "prior"} {
+			if ref, isString := payload[key].(string); isString && ref != "" && !displayRefInScope(ref, inScope) {
+				delete(payload, key)
+			}
+		}
+		cohort, isList := payload["cohort"].([]any)
+		if !isList {
+			return
+		}
+		kept := make([]any, 0, len(cohort))
+		for _, element := range cohort {
+			ref, isString := element.(string)
+			if isString && displayRefInScope(ref, inScope) {
+				kept = append(kept, ref)
+			}
+		}
+		if len(kept) == 0 {
+			delete(payload, "cohort")
+		} else {
+			payload["cohort"] = kept
+		}
+	case "issue.closed":
+		evidence, isList := payload["evidence"].([]any)
+		if !isList {
+			return
+		}
+		for _, element := range evidence {
+			entry, isMap := element.(map[string]any)
+			if !isMap {
+				continue
+			}
+			if ref, isString := entry["issue_ref"].(string); isString && ref != "" && !displayRefInScope(ref, inScope) {
+				delete(entry, "issue_ref")
+			}
+		}
+	}
+}
+
+// displayRefInScope applies the display-reference rendering contract:
+// qualified refs name their project, bare refs are same-project, and
+// full-length values are globally resolved and unprovable.
+func displayRefInScope(ref string, inScope map[string]struct{}) bool {
+	qualifier, _, qualified := strings.Cut(ref, "#")
+	if qualified {
+		_, ok := inScope[qualifier]
+		return ok
+	}
+	return len(ref) < shortid.MaxLength
 }
 
 func isHTTPStatus(err error, status int) bool {

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -454,7 +454,10 @@ func (h toolHandlers) destructiveTarget(ctx context.Context, rawRef, confirm, ve
 	if err != nil {
 		return ProjectIdentity{}, "", "", err
 	}
-	includeDeleted := verb == "PURGE"
+	// Resolve soft-deleted rows for DELETE as well as PURGE so a retry
+	// after a lost response reaches the daemon's idempotent re-delete
+	// instead of failing this preflight with "not found".
+	includeDeleted := true
 	shown, err := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
 		PathParams: &generated.ShowIssuePath{ProjectID: project.ID, Ref: ref},
 		Query:      &generated.ShowIssueQuery{IncludeDeleted: &includeDeleted},

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -1093,10 +1093,8 @@ func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *Even
 	}
 	allowedProjects := make(map[int64]struct{}, len(projects))
 	allowedProjectUIDs := make(map[string]bool, len(projects))
-	allowedProjectNames := make(map[string]struct{}, len(projects))
 	for _, project := range projects {
 		allowedProjects[project.ID] = struct{}{}
-		allowedProjectNames[project.Name] = struct{}{}
 		if project.UID != "" {
 			allowedProjectUIDs[project.UID] = true
 		}
@@ -1139,27 +1137,19 @@ func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *Even
 			event.RelatedIssueShortID = ""
 		}
 		event.Payload = redactEventPayloadPeers(event.Payload, allowedPeers, allowedProjectUIDs)
-		redactEventTypedDisplayRefs(event, allowedProjectNames, event.ProjectName)
+		redactEventTypedDisplayRefs(event)
 	}
 	return nil
 }
 
 // redactEventTypedDisplayRefs removes event-type-specific display references
 // that carry no UID companion: close-throttle cohort refs span projects and
-// close-evidence refs are stored verbatim. Qualifiers are checked against
-// current scope names plus, at most, this event's own historical project
-// name — never other events' names, which may now belong to foreign projects.
-func redactEventTypedDisplayRefs(event *StreamEvent, inScope map[string]struct{}, eventProjectName string) {
-	if eventProjectName != "" {
-		if _, ok := inScope[eventProjectName]; !ok {
-			scoped := make(map[string]struct{}, len(inScope)+1)
-			for name := range inScope {
-				scoped[name] = struct{}{}
-			}
-			scoped[eventProjectName] = struct{}{}
-			inScope = scoped
-		}
-	}
+// close-evidence refs are stored verbatim. Historical text refs are
+// authorized only against this event's own stamped project name — current
+// scope names are unusable because a scoped project renamed to a previously
+// foreign name would retroactively vouch that foreign project's refs.
+func redactEventTypedDisplayRefs(event *StreamEvent) {
+	eventProjectName := event.ProjectName
 	payload, ok := event.Payload.(map[string]any)
 	if !ok {
 		return
@@ -1167,7 +1157,7 @@ func redactEventTypedDisplayRefs(event *StreamEvent, inScope map[string]struct{}
 	switch event.Type {
 	case "close.throttled":
 		for _, key := range []string{"parent", "prior"} {
-			if ref, isString := payload[key].(string); isString && ref != "" && !displayRefInScope(ref, inScope) {
+			if ref, isString := payload[key].(string); isString && ref != "" && !displayRefInScope(ref, eventProjectName) {
 				delete(payload, key)
 			}
 		}
@@ -1178,7 +1168,7 @@ func redactEventTypedDisplayRefs(event *StreamEvent, inScope map[string]struct{}
 		kept := make([]any, 0, len(cohort))
 		for _, element := range cohort {
 			ref, isString := element.(string)
-			if isString && displayRefInScope(ref, inScope) {
+			if isString && displayRefInScope(ref, eventProjectName) {
 				kept = append(kept, ref)
 			}
 		}
@@ -1197,7 +1187,7 @@ func redactEventTypedDisplayRefs(event *StreamEvent, inScope map[string]struct{}
 			if !isMap {
 				continue
 			}
-			if ref, isString := entry["issue_ref"].(string); isString && ref != "" && !displayRefInScope(ref, inScope) {
+			if ref, isString := entry["issue_ref"].(string); isString && ref != "" && !displayRefInScope(ref, eventProjectName) {
 				delete(entry, "issue_ref")
 			}
 		}
@@ -1205,13 +1195,14 @@ func redactEventTypedDisplayRefs(event *StreamEvent, inScope map[string]struct{}
 }
 
 // displayRefInScope applies the display-reference rendering contract:
-// qualified refs name their project, bare refs are same-project, and
-// full-length values are globally resolved and unprovable.
-func displayRefInScope(ref string, inScope map[string]struct{}) bool {
+// bare refs are same-project and full-length values are globally resolved
+// and unprovable. A qualified ref survives only when it names the event's
+// own stamped project — the one identity that provably matched an in-scope
+// project when the text was written.
+func displayRefInScope(ref, eventProjectName string) bool {
 	qualifier, _, qualified := strings.Cut(ref, "#")
 	if qualified {
-		_, ok := inScope[qualifier]
-		return ok
+		return eventProjectName != "" && qualifier == eventProjectName
 	}
 	return len(ref) < shortid.MaxLength
 }

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -649,7 +649,7 @@ func (h toolHandlers) validateAuditParentFilter(ctx context.Context, project Pro
 		// snapshots, which can name purged foreign parents. Forward a bare
 		// filter only when it resolves in the audited project; otherwise
 		// fail closed instead of exposing a snapshot-matching oracle.
-		_, _, found, probeErr := h.issueLinksForVouching(ctx, project, parsed.ShortID)
+		found, probeErr := h.issueResolvesInProject(ctx, project, parsed.ShortID)
 		if probeErr != nil {
 			return probeErr
 		}
@@ -662,86 +662,102 @@ func (h toolHandlers) validateAuditParentFilter(ctx context.Context, project Pro
 	return err
 }
 
-// redactAuditParentsOutsideScope blanks qualified parent references whose
-// project qualifier is not in the startup scope. Bare parent refs carry no
-// provenance — a purged parent falls back to its stored short ID, which can
-// be foreign and collide with an unrelated in-scope short ID — so a bare ref
-// is kept only when the closed child's current parent link vouches for it
-// with immutable peer identity.
+// redactAuditParentsOutsideScope authorizes parent display refs by the
+// close-time frozen parent UID: a short ID is project-local and mutable, so a
+// purged foreign parent can collide with an unrelated in-scope short ID.
+// Rows whose frozen parent no longer resolves in scope, and legacy rows with
+// no frozen identity behind a bare ref, fail closed. Qualified refs without a
+// UID keep the current-name check because the daemon renders them from
+// currently resolved projects.
 func (h toolHandlers) redactAuditParentsOutsideScope(ctx context.Context, project ProjectIdentity, rows []generated.AuditCloseRow) ([]generated.AuditCloseRow, error) {
 	if h.options.Scope.Mode() == ScopeAll {
 		return rows, nil
 	}
-	inScope, err := h.scopeProjectNames(ctx)
+	projects, err := h.options.Scope.Projects(ctx, h.options.Client, true)
 	if err != nil {
 		return nil, err
 	}
-	childParents := make(map[string]string)
+	inScopeNames := make(map[string]struct{}, len(projects))
+	inScopeIDs := make(map[int64]struct{}, len(projects))
+	for _, scoped := range projects {
+		inScopeNames[scoped.Name] = struct{}{}
+		inScopeIDs[scoped.ID] = struct{}{}
+	}
+	resolved := make(map[string]bool)
+	blank := func(index int) {
+		rows[index].Parent = nil
+		rows[index].ParentUID = nil
+	}
 	for index := range rows {
-		parent := rows[index].Parent
-		if parent == nil {
+		if rows[index].Parent == nil {
+			rows[index].ParentUID = nil
 			continue
 		}
-		qualifier, _, qualified := strings.Cut(*parent, "#")
+		if rows[index].ParentUID != nil && *rows[index].ParentUID != "" {
+			uid := *rows[index].ParentUID
+			allowed, seen := resolved[uid]
+			if !seen {
+				allowed, err = h.issueUIDInScope(ctx, uid, inScopeIDs)
+				if err != nil {
+					return nil, err
+				}
+				resolved[uid] = allowed
+			}
+			if !allowed {
+				blank(index)
+			}
+			continue
+		}
+		qualifier, _, qualified := strings.Cut(*rows[index].Parent, "#")
 		if qualified {
-			if _, ok := inScope[qualifier]; !ok {
-				rows[index].Parent = nil
+			if _, ok := inScopeNames[qualifier]; !ok {
+				blank(index)
 			}
 			continue
 		}
-		parentShort, seen := childParents[rows[index].Issue]
-		if !seen {
-			parentShort, err = h.inScopeParentShortID(ctx, project, rows[index].Issue, inScope)
-			if err != nil {
-				return nil, err
-			}
-			childParents[rows[index].Issue] = parentShort
-		}
-		if parentShort == "" || parentShort != *parent {
-			rows[index].Parent = nil
-		}
+		blank(index)
 	}
 	return rows, nil
 }
 
-// inScopeParentShortID returns the short ID of ref's current parent when that
-// parent's project is in scope, or "" when there is no provable parent.
-func (h toolHandlers) inScopeParentShortID(ctx context.Context, project ProjectIdentity, ref string, inScope map[string]struct{}) (string, error) {
-	issueUID, links, found, err := h.issueLinksForVouching(ctx, project, ref)
-	if err != nil || !found {
-		return "", err
-	}
-	for _, link := range links {
-		peer, typeName := linkPeerAndType(issueUID, link)
-		if typeName != "parent" {
-			continue
+// issueUIDInScope reports whether an issue UID currently resolves inside the
+// startup scope. A transient daemon failure fails closed with a redacted
+// error; a purged UID simply does not resolve.
+func (h toolHandlers) issueUIDInScope(ctx context.Context, uid string, allowedProjects map[int64]struct{}) (bool, error) {
+	response, err := h.options.Client.ShowIssueByUID(ctx, &generated.ShowIssueByUIDRequestOptions{
+		PathParams: &generated.ShowIssueByUIDPath{UID: uid},
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
 		}
-		if _, ok := inScope[peer.Project]; ok {
-			return peer.ShortID, nil
+		if isHTTPStatus(err, http.StatusNotFound) {
+			return false, nil
 		}
+		return false, errors.New("resolve scoped issue reference: daemon request failed")
 	}
-	return "", nil
+	_, ok := allowedProjects[response.Issue.ProjectID]
+	return ok, nil
 }
 
-// issueLinksForVouching reads an issue's current links so display references
-// can be vouched by immutable peer identity. A missing issue is not an error;
-// a transient daemon failure fails closed with a redacted error.
-func (h toolHandlers) issueLinksForVouching(ctx context.Context, project ProjectIdentity, ref string) (string, []generated.LinkOut, bool, error) {
+// issueResolvesInProject reports whether ref resolves in project, including
+// soft-deleted issues. A transient daemon failure fails closed.
+func (h toolHandlers) issueResolvesInProject(ctx context.Context, project ProjectIdentity, ref string) (bool, error) {
 	includeDeleted := true
-	response, err := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
+	_, err := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
 		PathParams: &generated.ShowIssuePath{ProjectID: project.ID, Ref: ref},
 		Query:      &generated.ShowIssueQuery{IncludeDeleted: &includeDeleted},
 	})
 	if err == nil {
-		return response.Issue.UID, response.Links, true, nil
+		return true, nil
 	}
 	if ctx.Err() != nil {
-		return "", nil, false, ctx.Err()
+		return false, ctx.Err()
 	}
 	if isHTTPStatus(err, http.StatusNotFound) {
-		return "", nil, false, nil
+		return false, nil
 	}
-	return "", nil, false, errors.New("resolve scoped issue reference: daemon request failed")
+	return false, errors.New("resolve scoped issue reference: daemon request failed")
 }
 
 // scopeProjectNames returns the startup scope's current project names,
@@ -780,9 +796,7 @@ func (h toolHandlers) digest(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 			return nil, DigestOutput{}, digestErr
 		}
 		if h.options.Scope.Mode() != ScopeAll {
-			if redactErr := h.redactDigestLinkActions(ctx, project, response); redactErr != nil {
-				return nil, DigestOutput{}, redactErr
-			}
+			h.redactDigestLinkActions(response)
 		}
 		projectCopy := project
 		out = append(out, ProjectDigest{Project: &projectCopy, Digest: *response})
@@ -797,18 +811,14 @@ var digestLinkActionPrefixes = map[string]struct{}{
 }
 
 // redactDigestLinkActions strips the peer short ID from link action tokens
-// unless the digest issue's current links vouch for that peer with immutable
-// in-scope identity. Bare short IDs alone are not provenance: a foreign
-// peer's short ID can collide with an unrelated in-scope short ID.
-func (h toolHandlers) redactDigestLinkActions(ctx context.Context, project ProjectIdentity, digest *generated.DigestResponseBody) error {
-	inScope, err := h.scopeProjectNames(ctx)
-	if err != nil {
-		return err
-	}
+// on scoped servers. Tokens carry only project-local short IDs from
+// historical events, and links change over time, so no current-state lookup
+// can prove a target's identity: a historical foreign peer can collide with
+// a current in-scope short ID. The action type survives; the target does not.
+func (h toolHandlers) redactDigestLinkActions(digest *generated.DigestResponseBody) {
 	for actorIndex := range digest.Actors {
 		for issueIndex := range digest.Actors[actorIndex].Issues {
 			issueActions := &digest.Actors[actorIndex].Issues[issueIndex]
-			var peers map[string]bool
 			kept := make([]string, 0, len(issueActions.Actions))
 			for _, action := range issueActions.Actions {
 				prefix, target, split := strings.Cut(action, ":")
@@ -820,39 +830,11 @@ func (h toolHandlers) redactDigestLinkActions(ctx context.Context, project Proje
 					kept = append(kept, action)
 					continue
 				}
-				if peers == nil {
-					peers, err = h.inScopeLinkPeerShortIDs(ctx, project, issueActions.IssueShortID, inScope)
-					if err != nil {
-						return err
-					}
-				}
-				if peers[target] {
-					kept = append(kept, action)
-				} else {
-					kept = append(kept, prefix)
-				}
+				kept = append(kept, prefix)
 			}
 			issueActions.Actions = kept
 		}
 	}
-	return nil
-}
-
-// inScopeLinkPeerShortIDs collects the short IDs of ref's current link peers
-// whose projects are inside the startup scope.
-func (h toolHandlers) inScopeLinkPeerShortIDs(ctx context.Context, project ProjectIdentity, ref string, inScope map[string]struct{}) (map[string]bool, error) {
-	peers := make(map[string]bool)
-	issueUID, links, found, err := h.issueLinksForVouching(ctx, project, ref)
-	if err != nil || !found {
-		return peers, err
-	}
-	for _, link := range links {
-		peer, _ := linkPeerAndType(issueUID, link)
-		if _, ok := inScope[peer.Project]; ok {
-			peers[peer.ShortID] = true
-		}
-	}
-	return peers, nil
 }
 
 func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, input EventsInput) (*sdkmcp.CallToolResult, EventsOutput, error) {
@@ -1119,13 +1101,12 @@ func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *Even
 			allowedProjectUIDs[project.UID] = true
 		}
 	}
-	// An event's own project passed the scope filter already.
+	// An event's own immutable project UID passed the scope filter already.
+	// Names are NOT pooled across the batch: a historical name stamped on an
+	// old event can currently belong to an out-of-scope project.
 	for _, event := range output.Events {
 		if event.ProjectUID != "" {
 			allowedProjectUIDs[event.ProjectUID] = true
-		}
-		if event.ProjectName != "" {
-			allowedProjectNames[event.ProjectName] = struct{}{}
 		}
 	}
 	peerUIDs := make(map[string]struct{})
@@ -1158,15 +1139,27 @@ func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *Even
 			event.RelatedIssueShortID = ""
 		}
 		event.Payload = redactEventPayloadPeers(event.Payload, allowedPeers, allowedProjectUIDs)
-		redactEventTypedDisplayRefs(event, allowedProjectNames)
+		redactEventTypedDisplayRefs(event, allowedProjectNames, event.ProjectName)
 	}
 	return nil
 }
 
 // redactEventTypedDisplayRefs removes event-type-specific display references
 // that carry no UID companion: close-throttle cohort refs span projects and
-// close-evidence refs are stored verbatim.
-func redactEventTypedDisplayRefs(event *StreamEvent, inScope map[string]struct{}) {
+// close-evidence refs are stored verbatim. Qualifiers are checked against
+// current scope names plus, at most, this event's own historical project
+// name — never other events' names, which may now belong to foreign projects.
+func redactEventTypedDisplayRefs(event *StreamEvent, inScope map[string]struct{}, eventProjectName string) {
+	if eventProjectName != "" {
+		if _, ok := inScope[eventProjectName]; !ok {
+			scoped := make(map[string]struct{}, len(inScope)+1)
+			for name := range inScope {
+				scoped[name] = struct{}{}
+			}
+			scoped[eventProjectName] = struct{}{}
+			inScope = scoped
+		}
+	}
 	payload, ok := event.Payload.(map[string]any)
 	if !ok {
 		return

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -134,23 +134,23 @@ type WaitOutput struct {
 
 // AuditClosesInput filters close audit records.
 type AuditClosesInput struct {
-	Project    string `json:"project,omitempty"`
-	Since      string `json:"since,omitempty"`
-	Until      string `json:"until,omitempty"`
-	Actor      string `json:"actor,omitempty"`
-	Parent     string `json:"parent,omitempty"`
-	Reason     string `json:"reason,omitempty"`
-	NoEvidence bool   `json:"no_evidence,omitempty"`
-	Limit      int64  `json:"limit,omitempty" jsonschema:"Maximum rows from 1 through 100; default 20"`
-	Offset     int64  `json:"offset,omitempty" jsonschema:"Rows to skip; pass the previous result's next_offset to continue. Row order is stable and append-only"`
+	Project      string `json:"project,omitempty"`
+	Since        string `json:"since,omitempty"`
+	Until        string `json:"until,omitempty"`
+	Actor        string `json:"actor,omitempty"`
+	Parent       string `json:"parent,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+	NoEvidence   bool   `json:"no_evidence,omitempty"`
+	Limit        int64  `json:"limit,omitempty" jsonschema:"Maximum rows from 1 through 100; default 20"`
+	AfterEventID int64  `json:"after_event_id,omitempty" jsonschema:"Return rows whose event_id is greater than this immutable cursor; pass the previous result's next_after_event_id to continue"`
 }
 
 // AuditClosesOutput contains close audit records for one project.
 type AuditClosesOutput struct {
-	Project    ProjectIdentity           `json:"project"`
-	Rows       []generated.AuditCloseRow `json:"rows"`
-	Truncated  bool                      `json:"truncated,omitempty"`
-	NextOffset *int64                    `json:"next_offset,omitempty"`
+	Project          ProjectIdentity           `json:"project"`
+	Rows             []generated.AuditCloseRow `json:"rows"`
+	Truncated        bool                      `json:"truncated,omitempty"`
+	NextAfterEventID *int64                    `json:"next_after_event_id,omitempty"`
 }
 
 // DigestInput defines an activity digest window.
@@ -552,8 +552,8 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if limit < 1 || limit > maximumResultLimit {
 		return nil, AuditClosesOutput{}, fmt.Errorf("limit must be between 1 and %d", maximumResultLimit)
 	}
-	if input.Offset < 0 {
-		return nil, AuditClosesOutput{}, errors.New("offset must not be negative")
+	if input.AfterEventID < 0 {
+		return nil, AuditClosesOutput{}, errors.New("after_event_id must not be negative")
 	}
 	response, err := h.options.Client.AuditCloses(ctx, &generated.AuditClosesRequestOptions{Query: &generated.AuditClosesQuery{
 		ProjectID: project.ID, Since: optionalString(input.Since), Until: optionalString(input.Until),
@@ -563,21 +563,21 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
-	// The daemon returns rows in stable ascending event order, so an
-	// offset cursor never skips or repeats rows even when many closes
-	// share one timestamp; new rows only append past the end.
-	rows := response.Rows
-	if input.Offset >= int64(len(rows)) {
-		rows = nil
-	} else {
-		rows = rows[input.Offset:]
+	// Rows are ordered by immutable close-event ID, so this cursor never
+	// repeats rows and never skips rows that existed when the page was
+	// requested — even across purges, merges, or shared timestamps.
+	rows := make([]generated.AuditCloseRow, 0, len(response.Rows))
+	for _, row := range response.Rows {
+		if row.EventID > input.AfterEventID {
+			rows = append(rows, row)
+		}
 	}
 	output := AuditClosesOutput{Project: project}
 	if int64(len(rows)) > limit {
 		rows = rows[:limit]
 		output.Truncated = true
-		next := input.Offset + limit
-		output.NextOffset = &next
+		next := rows[len(rows)-1].EventID
+		output.NextAfterEventID = &next
 	}
 	rows, err = h.redactAuditParentsOutsideScope(ctx, project, rows)
 	if err != nil {

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -867,7 +867,7 @@ func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 		if err != nil {
 			return nil, EventsOutput{}, err
 		}
-		return successResult(), output, nil
+		return successResult(), withEventsList(output), nil
 	}
 	waitSeconds := input.WaitSeconds
 	if waitSeconds == 0 {
@@ -894,7 +894,7 @@ func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 	response, err := h.options.Client.StreamEventsRaw(waitContext, &generated.StreamEventsRequestOptions{Query: &generated.StreamEventsQuery{AfterID: &input.After, ProjectID: projectID}})
 	if err != nil {
 		if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
-			return successResult(), EventsOutput{NextAfterID: input.After, TimedOut: true}, nil
+			return successResult(), withEventsList(EventsOutput{NextAfterID: input.After, TimedOut: true}), nil
 		}
 		return nil, EventsOutput{}, err
 	}
@@ -902,14 +902,24 @@ func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 	output, err := readEventStream(waitContext, response.Body, input.After, limit)
 	if err != nil {
 		if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
-			return successResult(), EventsOutput{NextAfterID: input.After, TimedOut: true}, nil
+			return successResult(), withEventsList(EventsOutput{NextAfterID: input.After, TimedOut: true}), nil
 		}
 		return nil, EventsOutput{}, err
 	}
 	if err := h.redactEventsOutsideScope(waitContext, &output); err != nil {
 		return nil, EventsOutput{}, err
 	}
-	return successResult(), output, nil
+	return successResult(), withEventsList(output), nil
+}
+
+// withEventsList upholds the required-collection contract: successful
+// responses, including empty polls, timeouts, and resets, serialize events
+// as an empty array rather than null.
+func withEventsList(output EventsOutput) EventsOutput {
+	if output.Events == nil {
+		output.Events = []StreamEvent{}
+	}
+	return output
 }
 
 func (h toolHandlers) activityProjects(ctx context.Context, name string) ([]ProjectIdentity, error) {
@@ -977,12 +987,12 @@ func (h toolHandlers) waitPollEvents(ctx context.Context, project string, after,
 			return nil, EventsOutput{}, err
 		}
 		if output.ResetRequired || len(output.Events) > 0 {
-			return successResult(), output, nil
+			return successResult(), withEventsList(output), nil
 		}
 		select {
 		case <-waitContext.Done():
 			if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
-				return successResult(), EventsOutput{NextAfterID: after, TimedOut: true}, nil
+				return successResult(), withEventsList(EventsOutput{NextAfterID: after, TimedOut: true}), nil
 			}
 			return nil, EventsOutput{}, waitContext.Err()
 		case <-time.After(250 * time.Millisecond):

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -134,23 +135,23 @@ type WaitOutput struct {
 
 // AuditClosesInput filters close audit records.
 type AuditClosesInput struct {
-	Project      string `json:"project,omitempty"`
-	Since        string `json:"since,omitempty"`
-	Until        string `json:"until,omitempty"`
-	Actor        string `json:"actor,omitempty"`
-	Parent       string `json:"parent,omitempty"`
-	Reason       string `json:"reason,omitempty"`
-	NoEvidence   bool   `json:"no_evidence,omitempty"`
-	Limit        int64  `json:"limit,omitempty" jsonschema:"Maximum rows from 1 through 100; default 20"`
-	AfterEventID int64  `json:"after_event_id,omitempty" jsonschema:"Return rows whose event_id is greater than this immutable cursor; pass the previous result's next_after_event_id to continue"`
+	Project    string `json:"project,omitempty"`
+	Since      string `json:"since,omitempty"`
+	Until      string `json:"until,omitempty"`
+	Actor      string `json:"actor,omitempty"`
+	Parent     string `json:"parent,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+	NoEvidence bool   `json:"no_evidence,omitempty"`
+	Limit      int64  `json:"limit,omitempty" jsonschema:"Maximum rows from 1 through 100; default 20"`
+	Cursor     string `json:"cursor,omitempty" jsonschema:"Opaque pagination cursor from the previous result's next_cursor; keep the other filters identical and omit for the first page"`
 }
 
 // AuditClosesOutput contains close audit records for one project.
 type AuditClosesOutput struct {
-	Project          ProjectIdentity           `json:"project"`
-	Rows             []generated.AuditCloseRow `json:"rows"`
-	Truncated        bool                      `json:"truncated,omitempty"`
-	NextAfterEventID *int64                    `json:"next_after_event_id,omitempty"`
+	Project    ProjectIdentity           `json:"project"`
+	Rows       []generated.AuditCloseRow `json:"rows"`
+	Truncated  bool                      `json:"truncated,omitempty"`
+	NextCursor *string                   `json:"next_cursor,omitempty"`
 }
 
 // DigestInput defines an activity digest window.
@@ -552,9 +553,6 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if limit < 1 || limit > maximumResultLimit {
 		return nil, AuditClosesOutput{}, fmt.Errorf("limit must be between 1 and %d", maximumResultLimit)
 	}
-	if input.AfterEventID < 0 {
-		return nil, AuditClosesOutput{}, errors.New("after_event_id must not be negative")
-	}
 	response, err := h.options.Client.AuditCloses(ctx, &generated.AuditClosesRequestOptions{Query: &generated.AuditClosesQuery{
 		ProjectID: project.ID, Since: optionalString(input.Since), Until: optionalString(input.Until),
 		Actor: optionalString(input.Actor), Parent: optionalString(input.Parent), Reason: optionalString(input.Reason),
@@ -563,21 +561,32 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
-	// Rows are ordered by immutable close-event ID, so this cursor never
-	// repeats rows and never skips rows that existed when the page was
-	// requested — even across purges, merges, or shared timestamps.
-	rows := make([]generated.AuditCloseRow, 0, len(response.Rows))
-	for _, row := range response.Rows {
-		if row.EventID > input.AfterEventID {
-			rows = append(rows, row)
+	// Rows are ordered by immutable close-event ID. The cursor records the
+	// last returned event ID plus the number of rows at or below it, so a
+	// below-cursor change — history merged in from another project or rows
+	// removed by a purge — invalidates pagination explicitly instead of
+	// silently skipping or repeating rows.
+	rows := response.Rows
+	start := 0
+	if input.Cursor != "" {
+		cursorEventID, seen, cursorErr := parseAuditCursor(input.Cursor)
+		if cursorErr != nil {
+			return nil, AuditClosesOutput{}, cursorErr
+		}
+		for start < len(rows) && rows[start].EventID <= cursorEventID {
+			start++
+		}
+		if int64(start) != seen || start == 0 || rows[start-1].EventID != cursorEventID {
+			return nil, AuditClosesOutput{}, errors.New("close history below the pagination cursor changed (project merge or issue purge); restart without a cursor")
 		}
 	}
+	rows = rows[start:]
 	output := AuditClosesOutput{Project: project}
 	if int64(len(rows)) > limit {
 		rows = rows[:limit]
 		output.Truncated = true
-		next := rows[len(rows)-1].EventID
-		output.NextAfterEventID = &next
+		next := encodeAuditCursor(rows[len(rows)-1].EventID, int64(start+len(rows)))
+		output.NextCursor = &next
 	}
 	rows, err = h.redactAuditParentsOutsideScope(ctx, project, rows)
 	if err != nil {
@@ -585,6 +594,26 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	}
 	output.Rows = rows
 	return successResult(), output, nil
+}
+
+func encodeAuditCursor(eventID, seen int64) string {
+	return fmt.Sprintf("v1:%d:%d", eventID, seen)
+}
+
+func parseAuditCursor(raw string) (eventID, seen int64, err error) {
+	var version string
+	parts := strings.Split(raw, ":")
+	if len(parts) == 3 {
+		version = parts[0]
+		eventID, err = strconv.ParseInt(parts[1], 10, 64)
+		if err == nil {
+			seen, err = strconv.ParseInt(parts[2], 10, 64)
+		}
+	}
+	if version != "v1" || err != nil || eventID < 1 || seen < 1 {
+		return 0, 0, errors.New("cursor is not a value returned in next_cursor")
+	}
+	return eventID, seen, nil
 }
 
 // validateAuditParentFilter stops fixed scopes from probing foreign refs

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -141,12 +141,14 @@ type AuditClosesInput struct {
 	Parent     string `json:"parent,omitempty"`
 	Reason     string `json:"reason,omitempty"`
 	NoEvidence bool   `json:"no_evidence,omitempty"`
+	Limit      int64  `json:"limit,omitempty" jsonschema:"Maximum rows from 1 through 100; default 20. When truncated, advance since past the last returned row's time"`
 }
 
 // AuditClosesOutput contains close audit records for one project.
 type AuditClosesOutput struct {
-	Project ProjectIdentity           `json:"project"`
-	Rows    []generated.AuditCloseRow `json:"rows"`
+	Project   ProjectIdentity           `json:"project"`
+	Rows      []generated.AuditCloseRow `json:"rows"`
+	Truncated bool                      `json:"truncated,omitempty"`
 }
 
 // DigestInput defines an activity digest window.
@@ -541,6 +543,13 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if err := h.validateAuditParentFilter(ctx, input.Parent); err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
+	limit := input.Limit
+	if limit == 0 {
+		limit = defaultResultLimit
+	}
+	if limit < 1 || limit > maximumResultLimit {
+		return nil, AuditClosesOutput{}, fmt.Errorf("limit must be between 1 and %d", maximumResultLimit)
+	}
 	response, err := h.options.Client.AuditCloses(ctx, &generated.AuditClosesRequestOptions{Query: &generated.AuditClosesQuery{
 		ProjectID: project.ID, Since: optionalString(input.Since), Until: optionalString(input.Until),
 		Actor: optionalString(input.Actor), Parent: optionalString(input.Parent), Reason: optionalString(input.Reason),
@@ -549,11 +558,16 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
-	rows, err := h.redactAuditParentsOutsideScope(ctx, project, response.Rows)
+	rows := response.Rows
+	truncated := int64(len(rows)) > limit
+	if truncated {
+		rows = rows[:limit]
+	}
+	rows, err = h.redactAuditParentsOutsideScope(ctx, project, rows)
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
-	return successResult(), AuditClosesOutput{Project: project, Rows: rows}, nil
+	return successResult(), AuditClosesOutput{Project: project, Rows: rows, Truncated: truncated}, nil
 }
 
 // validateAuditParentFilter stops fixed scopes from probing foreign refs

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -15,6 +15,7 @@ import (
 	oapiruntime "github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"go.kenn.io/kata/internal/shortid"
 	"go.kenn.io/kata/pkg/client/generated"
 )
 
@@ -534,6 +535,9 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
+	if err := h.validateAuditParentFilter(ctx, input.Parent); err != nil {
+		return nil, AuditClosesOutput{}, err
+	}
 	response, err := h.options.Client.AuditCloses(ctx, &generated.AuditClosesRequestOptions{Query: &generated.AuditClosesQuery{
 		ProjectID: project.ID, Since: optionalString(input.Since), Until: optionalString(input.Until),
 		Actor: optionalString(input.Actor), Parent: optionalString(input.Parent), Reason: optionalString(input.Reason),
@@ -542,17 +546,43 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
-	rows, err := h.redactAuditParentsOutsideScope(ctx, response.Rows)
+	rows, err := h.redactAuditParentsOutsideScope(ctx, project, response.Rows)
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
 	return successResult(), AuditClosesOutput{Project: project, Rows: rows}, nil
 }
 
+// validateAuditParentFilter stops fixed scopes from probing foreign refs
+// through the daemon's global parent-filter resolution.
+func (h toolHandlers) validateAuditParentFilter(ctx context.Context, raw string) error {
+	ref := strings.TrimSpace(raw)
+	if ref == "" || h.options.Scope.Mode() == ScopeAll {
+		return nil
+	}
+	parsed, err := shortid.Parse(ref)
+	if err != nil {
+		return fmt.Errorf("parent filter %q is invalid", ref)
+	}
+	if parsed.ULID != "" {
+		return fmt.Errorf("parent filter %q is an unscoped UID; use a project-qualified short reference", ref)
+	}
+	if len(parsed.ShortID) == shortid.MaxLength {
+		return fmt.Errorf("parent filter %q uses an ambiguous full-length short ID; use a shorter project-qualified reference", ref)
+	}
+	if parsed.Project == "" {
+		return nil
+	}
+	_, err = h.options.Scope.Project(ctx, h.options.Client, parsed.Project, true)
+	return err
+}
+
 // redactAuditParentsOutsideScope blanks qualified parent references whose
-// project qualifier is not in the startup scope. Bare parent refs are
-// same-project by the daemon's rendering contract.
-func (h toolHandlers) redactAuditParentsOutsideScope(ctx context.Context, rows []generated.AuditCloseRow) ([]generated.AuditCloseRow, error) {
+// project qualifier is not in the startup scope. Live bare parent refs are
+// same-project by the daemon's rendering contract, but a purged parent falls
+// back to its stored short ID, which can be foreign — keep a bare ref only
+// when it still resolves in the audited project.
+func (h toolHandlers) redactAuditParentsOutsideScope(ctx context.Context, project ProjectIdentity, rows []generated.AuditCloseRow) ([]generated.AuditCloseRow, error) {
 	if h.options.Scope.Mode() == ScopeAll {
 		return rows, nil
 	}
@@ -561,23 +591,55 @@ func (h toolHandlers) redactAuditParentsOutsideScope(ctx context.Context, rows [
 		return nil, err
 	}
 	inScope := make(map[string]struct{}, len(projects))
-	for _, project := range projects {
-		inScope[project.Name] = struct{}{}
+	for _, scoped := range projects {
+		inScope[scoped.Name] = struct{}{}
 	}
+	resolvedBare := make(map[string]bool)
 	for index := range rows {
 		parent := rows[index].Parent
 		if parent == nil {
 			continue
 		}
 		qualifier, _, qualified := strings.Cut(*parent, "#")
-		if !qualified {
+		if qualified {
+			if _, ok := inScope[qualifier]; !ok {
+				rows[index].Parent = nil
+			}
 			continue
 		}
-		if _, ok := inScope[qualifier]; !ok {
+		allowed, seen := resolvedBare[*parent]
+		if !seen {
+			allowed, err = h.issueVisibleInProject(ctx, project, *parent)
+			if err != nil {
+				return nil, err
+			}
+			resolvedBare[*parent] = allowed
+		}
+		if !allowed {
 			rows[index].Parent = nil
 		}
 	}
 	return rows, nil
+}
+
+// issueVisibleInProject reports whether ref resolves inside project. A
+// transient daemon failure fails closed with a redacted error.
+func (h toolHandlers) issueVisibleInProject(ctx context.Context, project ProjectIdentity, ref string) (bool, error) {
+	includeDeleted := true
+	_, err := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
+		PathParams: &generated.ShowIssuePath{ProjectID: project.ID, Ref: ref},
+		Query:      &generated.ShowIssueQuery{IncludeDeleted: &includeDeleted},
+	})
+	if err == nil {
+		return true, nil
+	}
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if isHTTPStatus(err, http.StatusNotFound) {
+		return false, nil
+	}
+	return false, errors.New("resolve scoped issue reference: daemon request failed")
 }
 
 func (h toolHandlers) digest(ctx context.Context, _ *sdkmcp.CallToolRequest, input DigestInput) (*sdkmcp.CallToolResult, DigestOutput, error) {
@@ -601,10 +663,59 @@ func (h toolHandlers) digest(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 		if digestErr != nil {
 			return nil, DigestOutput{}, digestErr
 		}
+		if h.options.Scope.Mode() != ScopeAll {
+			if redactErr := h.redactDigestLinkActions(ctx, project, response); redactErr != nil {
+				return nil, DigestOutput{}, redactErr
+			}
+		}
 		projectCopy := project
 		out = append(out, ProjectDigest{Project: &projectCopy, Digest: *response})
 	}
 	return successResult(), DigestOutput{Digests: out}, nil
+}
+
+// Digest action tokens that carry a peer issue short ID after the colon.
+var digestLinkActionPrefixes = map[string]struct{}{
+	"blocks": {}, "blocked_by": {}, "parent": {}, "related": {},
+	"unblocks": {}, "unblocked_by": {}, "unparent": {}, "unrelated": {},
+}
+
+// redactDigestLinkActions drops link action tokens whose peer short ID does
+// not resolve in the digest's project. Cross-project peers of an in-scope
+// issue render as bare short IDs, so resolution is the scope check.
+func (h toolHandlers) redactDigestLinkActions(ctx context.Context, project ProjectIdentity, digest *generated.DigestResponseBody) error {
+	resolved := make(map[string]bool)
+	for actorIndex := range digest.Actors {
+		for issueIndex := range digest.Actors[actorIndex].Issues {
+			issueActions := &digest.Actors[actorIndex].Issues[issueIndex]
+			kept := make([]string, 0, len(issueActions.Actions))
+			for _, action := range issueActions.Actions {
+				prefix, target, split := strings.Cut(action, ":")
+				if !split || target == "" {
+					kept = append(kept, action)
+					continue
+				}
+				if _, linkAction := digestLinkActionPrefixes[prefix]; !linkAction {
+					kept = append(kept, action)
+					continue
+				}
+				allowed, seen := resolved[target]
+				if !seen {
+					var err error
+					allowed, err = h.issueVisibleInProject(ctx, project, target)
+					if err != nil {
+						return err
+					}
+					resolved[target] = allowed
+				}
+				if allowed {
+					kept = append(kept, action)
+				}
+			}
+			issueActions.Actions = kept
+		}
+	}
+	return nil
 }
 
 func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, input EventsInput) (*sdkmcp.CallToolResult, EventsOutput, error) {
@@ -908,7 +1019,7 @@ func isHTTPStatus(err error, status int) bool {
 var eventPeerUIDKeys = map[string]struct{}{
 	"from_uid": {}, "to_uid": {}, "from_issue_uid": {}, "to_issue_uid": {},
 	"link_from_uid": {}, "link_to_uid": {}, "peer_uid": {}, "related_issue_uid": {},
-	"parent_set_uid": {}, "parent_removed_uid": {},
+	"parent_uid": {}, "parent_set_uid": {}, "parent_removed_uid": {},
 }
 
 // A display reference survives only when one of its present UID companions
@@ -921,6 +1032,7 @@ var eventPeerShortIDUIDKeys = map[string][]string{
 	"link_to_short_id":       {"link_to_uid"},
 	"peer_short_id":          {"peer_uid"},
 	"related_issue_short_id": {"related_issue_uid"},
+	"parent_short_id":        {"parent_uid"},
 	"parent_set":             {"parent_set_uid"},
 	"parent_removed":         {"parent_removed_uid"},
 }

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -771,20 +771,6 @@ func (h toolHandlers) issueResolvesInProject(ctx context.Context, project Projec
 	return false, errors.New("resolve scoped issue reference: daemon request failed")
 }
 
-// scopeProjectNames returns the startup scope's current project names,
-// including archived members, for display-reference checks.
-func (h toolHandlers) scopeProjectNames(ctx context.Context) (map[string]struct{}, error) {
-	projects, err := h.options.Scope.Projects(ctx, h.options.Client, true)
-	if err != nil {
-		return nil, err
-	}
-	names := make(map[string]struct{}, len(projects))
-	for _, project := range projects {
-		names[project.Name] = struct{}{}
-	}
-	return names, nil
-}
-
 func (h toolHandlers) digest(ctx context.Context, _ *sdkmcp.CallToolRequest, input DigestInput) (*sdkmcp.CallToolResult, DigestOutput, error) {
 	if strings.TrimSpace(input.Since) == "" {
 		return nil, DigestOutput{}, errors.New("since is required")

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -498,6 +498,7 @@ func (h toolHandlers) wait(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 	}
 	waitContext, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
+	h = h.withLongRunningClient()
 	// The deadline can expire while a lookup is in flight; that is the
 	// documented timeout outcome, not a tool error. States from the last
 	// complete round keep the output honest.
@@ -658,8 +659,18 @@ func (h toolHandlers) validateAuditParentFilter(ctx context.Context, project Pro
 		}
 		return nil
 	}
-	_, err = h.options.Scope.Project(ctx, h.options.Client, parsed.Project, true)
-	return err
+	qualifiedProject, err := h.options.Scope.Project(ctx, h.options.Client, parsed.Project, true)
+	if err != nil {
+		return err
+	}
+	found, err := h.issueResolvesInProject(ctx, qualifiedProject, parsed.ShortID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("parent filter %q does not resolve in project %q", ref, qualifiedProject.Name)
+	}
+	return nil
 }
 
 // redactAuditParentsOutsideScope authorizes parent display refs by the
@@ -669,7 +680,7 @@ func (h toolHandlers) validateAuditParentFilter(ctx context.Context, project Pro
 // no frozen identity behind a bare ref, fail closed. Qualified refs without a
 // UID keep the current-name check because the daemon renders them from
 // currently resolved projects.
-func (h toolHandlers) redactAuditParentsOutsideScope(ctx context.Context, project ProjectIdentity, rows []generated.AuditCloseRow) ([]generated.AuditCloseRow, error) {
+func (h toolHandlers) redactAuditParentsOutsideScope(ctx context.Context, _ ProjectIdentity, rows []generated.AuditCloseRow) ([]generated.AuditCloseRow, error) {
 	if h.options.Scope.Mode() == ScopeAll {
 		return rows, nil
 	}
@@ -869,6 +880,7 @@ func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 	if waitSeconds < 1 || waitSeconds > 300 {
 		return nil, EventsOutput{}, errors.New("wait_seconds must be between 1 and 300")
 	}
+	h = h.withLongRunningClient()
 	// One stream can filter one project or all projects. A fixed multi-project
 	// allowlist uses bounded polling so events outside its scope never leak.
 	if strings.TrimSpace(input.Project) == "" && h.options.Scope.Mode() == ScopeAllowlist {

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -1,0 +1,924 @@
+package mcpserver
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	oapiruntime "github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// NextInput selects the highest-priority ready issue.
+type NextInput struct {
+	Project       string   `json:"project,omitempty"`
+	Owner         string   `json:"owner,omitempty"`
+	Unowned       bool     `json:"unowned,omitempty"`
+	Labels        []string `json:"labels,omitempty"`
+	ExcludeLabels []string `json:"exclude_labels,omitempty"`
+}
+
+// NextOutput contains the selected issue when one is ready.
+type NextOutput struct {
+	Issue *IssueSummary `json:"issue,omitempty"`
+}
+
+// EditCommentInput identifies a comment and its replacement body.
+type EditCommentInput struct {
+	Ref        string `json:"ref"`
+	CommentRef string `json:"comment_ref"`
+	Body       string `json:"body"`
+}
+
+// EditCommentOutput reports the edited comment and issue state.
+type EditCommentOutput struct {
+	Project ProjectIdentity `json:"project"`
+	Issue   IssueSummary    `json:"issue"`
+	Comment CommentSummary  `json:"comment"`
+	Changed bool            `json:"changed"`
+	Event   *EventSummary   `json:"event,omitempty"`
+}
+
+// GraphInput selects a bounded relationship graph.
+type GraphInput struct {
+	Ref      string `json:"ref"`
+	Depth    string `json:"depth,omitempty"`
+	HideDone bool   `json:"hide_done,omitempty"`
+}
+
+// GraphOutput contains the reachable issue graph.
+type GraphOutput struct {
+	Project        ProjectIdentity                         `json:"project"`
+	SourceUID      string                                  `json:"source_uid"`
+	Depth          string                                  `json:"depth"`
+	HideDone       bool                                    `json:"hide_done"`
+	Nodes          []IssueSummary                          `json:"nodes"`
+	Edges          []generated.ReachableGraphEdge          `json:"edges"`
+	UnresolvedRefs []generated.ReachableGraphUnresolvedRef `json:"unresolved_refs,omitempty"`
+}
+
+// MoveInput selects an issue and destination project.
+type MoveInput struct {
+	Ref       string `json:"ref"`
+	ToProject string `json:"to_project"`
+	Revision  *int64 `json:"revision,omitempty"`
+}
+
+// MoveOutput reports the issue after a project move.
+type MoveOutput struct {
+	From       ProjectIdentity `json:"from"`
+	To         ProjectIdentity `json:"to"`
+	Issue      IssueSummary    `json:"issue"`
+	Changed    bool            `json:"changed"`
+	EventID    int64           `json:"event_id"`
+	NewShortID string          `json:"new_short_id"`
+}
+
+// DeleteInput carries a soft-delete confirmation.
+type DeleteInput struct {
+	Ref     string `json:"ref"`
+	Confirm string `json:"confirm"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// RestoreInput identifies a soft-deleted issue to restore.
+type RestoreInput struct {
+	Ref string `json:"ref"`
+}
+
+// PurgeInput carries an irreversible purge confirmation.
+type PurgeInput struct {
+	Ref     string `json:"ref"`
+	Confirm string `json:"confirm"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// PurgeOutput reports a completed issue purge.
+type PurgeOutput struct {
+	Project ProjectIdentity    `json:"project"`
+	Ref     string             `json:"ref"`
+	Purged  bool               `json:"purged"`
+	Log     generated.PurgeLog `json:"log"`
+}
+
+// WaitInput defines bounded issue-state wait conditions.
+type WaitInput struct {
+	Refs           []string `json:"refs"`
+	Status         string   `json:"status,omitempty"`
+	Any            bool     `json:"any,omitempty"`
+	TimeoutSeconds int      `json:"timeout_seconds,omitempty"`
+}
+
+// WaitState reports one observed issue state.
+type WaitState struct {
+	Ref     string `json:"ref"`
+	Status  string `json:"status"`
+	Matched bool   `json:"matched"`
+}
+
+// WaitOutput reports why an issue-state wait ended.
+type WaitOutput struct {
+	Reason string      `json:"reason"`
+	States []WaitState `json:"states"`
+}
+
+// AuditClosesInput filters close audit records.
+type AuditClosesInput struct {
+	Project    string `json:"project,omitempty"`
+	Since      string `json:"since,omitempty"`
+	Until      string `json:"until,omitempty"`
+	Actor      string `json:"actor,omitempty"`
+	Parent     string `json:"parent,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+	NoEvidence bool   `json:"no_evidence,omitempty"`
+}
+
+// AuditClosesOutput contains close audit records for one project.
+type AuditClosesOutput struct {
+	Project ProjectIdentity           `json:"project"`
+	Rows    []generated.AuditCloseRow `json:"rows"`
+}
+
+// DigestInput defines an activity digest window.
+type DigestInput struct {
+	Project string   `json:"project,omitempty"`
+	Since   string   `json:"since"`
+	Until   string   `json:"until,omitempty"`
+	Actors  []string `json:"actors,omitempty"`
+}
+
+// ProjectDigest associates one digest with its project scope.
+type ProjectDigest struct {
+	Project *ProjectIdentity             `json:"project,omitempty"`
+	Digest  generated.DigestResponseBody `json:"digest"`
+}
+
+// DigestOutput contains one or more scoped digests.
+type DigestOutput struct {
+	Digests []ProjectDigest `json:"digests"`
+}
+
+// EventsInput defines an immediate poll or bounded stream wait.
+type EventsInput struct {
+	Project     string `json:"project,omitempty"`
+	Mode        string `json:"mode,omitempty"`
+	After       int64  `json:"after,omitempty"`
+	Limit       int64  `json:"limit,omitempty"`
+	WaitSeconds int64  `json:"wait_seconds,omitempty"`
+}
+
+// EventsOutput contains events and the next resume cursor.
+type EventsOutput struct {
+	Events        []StreamEvent `json:"events"`
+	NextAfterID   int64         `json:"next_after_id"`
+	ResetRequired bool          `json:"reset_required"`
+	ResetAfterID  *int64        `json:"reset_after_id,omitempty"`
+	TimedOut      bool          `json:"timed_out,omitempty"`
+}
+
+// StreamEvent is the MCP-safe event envelope.
+type StreamEvent struct {
+	EventID             int64  `json:"event_id"`
+	EventUID            string `json:"event_uid"`
+	Type                string `json:"type"`
+	Actor               string `json:"actor"`
+	CreatedAt           string `json:"created_at"`
+	ProjectID           int64  `json:"project_id"`
+	ProjectUID          string `json:"project_uid"`
+	ProjectName         string `json:"project_name"`
+	IssueUID            string `json:"issue_uid,omitempty"`
+	IssueShortID        string `json:"issue_short_id,omitempty"`
+	RelatedIssueUID     string `json:"related_issue_uid,omitempty"`
+	RelatedIssueShortID string `json:"related_issue_short_id,omitempty"`
+	Payload             any    `json:"payload,omitempty"`
+}
+
+func registerActivityTools(server *sdkmcp.Server, handlers toolHandlers) {
+	read := toolHints(true, false, false)
+	addTool(server, "kata.digest", "Activity digest", "Read an actor-grouped activity digest for an explicit time window.", read, handlers.digest)
+	addTool(server, "kata.events", "Read events", "Poll events or wait on the live event stream with a resumable cursor.", read, handlers.events)
+}
+
+func (h toolHandlers) next(ctx context.Context, _ *sdkmcp.CallToolRequest, input NextInput) (*sdkmcp.CallToolResult, NextOutput, error) {
+	issues, err := h.allReadyIssues(ctx, input)
+	if err != nil {
+		return nil, NextOutput{}, err
+	}
+	if len(issues) == 0 {
+		return successResult(), NextOutput{}, nil
+	}
+	selected := issues[0]
+	for _, candidate := range issues[1:] {
+		if selected.Priority == nil && candidate.Priority != nil ||
+			selected.Priority != nil && candidate.Priority != nil && *candidate.Priority < *selected.Priority {
+			selected = candidate
+		}
+	}
+	return successResult(), NextOutput{Issue: &selected}, nil
+}
+
+func (h toolHandlers) allReadyIssues(ctx context.Context, input NextInput) ([]IssueSummary, error) {
+	if input.Unowned && strings.TrimSpace(input.Owner) != "" {
+		return nil, errors.New("owner and unowned are mutually exclusive")
+	}
+	projects, err := h.readProjects(ctx, input.Project)
+	if err != nil {
+		return nil, err
+	}
+	issues := make([]IssueSummary, 0)
+	query := generated.ReadyIssuesQuery{
+		Unowned: optionalTrue(input.Unowned), Owner: optionalString(input.Owner),
+		Label: compactStrings(input.Labels), ExcludeLabel: compactStrings(input.ExcludeLabels),
+	}
+	if h.options.Scope.Mode() == ScopeAllowlist && strings.TrimSpace(input.Project) == "" {
+		for _, project := range projects {
+			response, readyErr := h.options.Client.ReadyIssues(ctx, &generated.ReadyIssuesRequestOptions{
+				PathParams: &generated.ReadyIssuesPath{ProjectID: project.ID}, Query: &query,
+			})
+			if readyErr != nil {
+				return nil, readyErr
+			}
+			for _, issue := range response.Issues {
+				issues = append(issues, h.summaryFromIssueOut(project, issue))
+			}
+		}
+		sortIssueSummaries(issues)
+		return issues, nil
+	}
+	if len(projects) == 1 && (h.options.Scope.Mode() == ScopeBound || strings.TrimSpace(input.Project) != "") {
+		response, readyErr := h.options.Client.ReadyIssues(ctx, &generated.ReadyIssuesRequestOptions{
+			PathParams: &generated.ReadyIssuesPath{ProjectID: projects[0].ID}, Query: &query,
+		})
+		if readyErr != nil {
+			return nil, readyErr
+		}
+		for _, issue := range response.Issues {
+			issues = append(issues, h.summaryFromIssueOut(projects[0], issue))
+		}
+		return issues, nil
+	}
+	response, err := h.options.Client.ReadyIssuesGlobal(ctx, &generated.ReadyIssuesGlobalRequestOptions{
+		Query: &generated.ReadyIssuesGlobalQuery{
+			Unowned: query.Unowned, Owner: query.Owner, Label: query.Label, ExcludeLabel: query.ExcludeLabel,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	allowed := projectIDSet(projects)
+	for _, issue := range response.Issues {
+		if _, ok := allowed[issue.ProjectID]; ok {
+			issues = append(issues, summaryFromReadyGlobalIssue(issue))
+		}
+	}
+	return issues, nil
+}
+
+func (h toolHandlers) editComment(ctx context.Context, _ *sdkmcp.CallToolRequest, input EditCommentInput) (*sdkmcp.CallToolResult, EditCommentOutput, error) {
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
+	if err != nil {
+		return nil, EditCommentOutput{}, err
+	}
+	if strings.TrimSpace(input.CommentRef) == "" || strings.TrimSpace(input.Body) == "" {
+		return nil, EditCommentOutput{}, errors.New("comment_ref and body are required")
+	}
+	response, err := h.options.Client.EditComment(ctx, &generated.EditCommentRequestOptions{
+		PathParams: &generated.EditCommentPath{ProjectID: project.ID, Ref: ref, CommentRef: input.CommentRef},
+		Body:       &generated.EditCommentBody{Actor: h.options.Actor, Body: input.Body},
+	})
+	if err != nil {
+		return nil, EditCommentOutput{}, err
+	}
+	return successResult(), EditCommentOutput{
+		Project: project, Issue: h.summaryFromIssue(project, response.Issue),
+		Comment: commentSummary(response.Comment), Changed: response.Changed, Event: eventSummary(&response.Event),
+	}, nil
+}
+
+func (h toolHandlers) graph(ctx context.Context, _ *sdkmcp.CallToolRequest, input GraphInput) (*sdkmcp.CallToolResult, GraphOutput, error) {
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, false)
+	if err != nil {
+		return nil, GraphOutput{}, err
+	}
+	depth := strings.TrimSpace(input.Depth)
+	if depth == "" {
+		depth = "full"
+	}
+	response, err := h.options.Client.ReachableIssueGraph(ctx, &generated.ReachableIssueGraphRequestOptions{
+		PathParams: &generated.ReachableIssueGraphPath{ProjectID: project.ID, Ref: ref},
+		Query:      &generated.ReachableIssueGraphQuery{Depth: &depth, HideDone: optionalTrue(input.HideDone)},
+	})
+	if err != nil {
+		return nil, GraphOutput{}, err
+	}
+	allowedProjects := map[int64]struct{}{}
+	if h.options.Scope.Mode() != ScopeAll {
+		projects, scopeErr := h.options.Scope.Projects(ctx, h.options.Client, false)
+		if scopeErr != nil {
+			return nil, GraphOutput{}, scopeErr
+		}
+		allowedProjects = projectIDSet(projects)
+	}
+	nodes := make([]IssueSummary, 0, len(response.Nodes))
+	allowedUIDs := make(map[string]struct{}, len(response.Nodes))
+	for _, node := range response.Nodes {
+		if h.options.Scope.Mode() != ScopeAll {
+			if _, ok := allowedProjects[node.ProjectID]; !ok {
+				continue
+			}
+		}
+		allowedUIDs[node.UID] = struct{}{}
+		nodes = append(nodes, IssueSummary{
+			UID: node.UID, Ref: node.ShortID, QualifiedRef: node.QualifiedID, Title: node.Title,
+			Status: node.Status, Owner: node.Owner, Priority: node.Priority, Revision: node.Revision,
+			UpdatedAt: formatTime(node.UpdatedAt), ScheduledOn: metadataString(node.Metadata, "scheduled_on"),
+			Timezone: metadataString(node.Metadata, "timezone"),
+		})
+	}
+	edges := make([]generated.ReachableGraphEdge, 0, len(response.Edges))
+	for _, edge := range response.Edges {
+		_, fromAllowed := allowedUIDs[edge.FromUID]
+		_, toAllowed := allowedUIDs[edge.ToUID]
+		if h.options.Scope.Mode() == ScopeAll || fromAllowed && toAllowed {
+			edges = append(edges, edge)
+		}
+	}
+	unresolved := make([]generated.ReachableGraphUnresolvedRef, 0, len(response.UnresolvedRefs))
+	for _, ref := range response.UnresolvedRefs {
+		_, uidAllowed := allowedUIDs[ref.UID]
+		_, otherAllowed := allowedUIDs[ref.OtherUID]
+		if h.options.Scope.Mode() == ScopeAll || uidAllowed && otherAllowed {
+			unresolved = append(unresolved, ref)
+		}
+	}
+	return successResult(), GraphOutput{
+		Project: project, SourceUID: response.SourceUID, Depth: response.Depth, HideDone: response.HideDone,
+		Nodes: nodes, Edges: edges, UnresolvedRefs: unresolved,
+	}, nil
+}
+
+func (h toolHandlers) move(ctx context.Context, _ *sdkmcp.CallToolRequest, input MoveInput) (*sdkmcp.CallToolResult, MoveOutput, error) {
+	from, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
+	if err != nil {
+		return nil, MoveOutput{}, err
+	}
+	to, err := h.options.Scope.Project(ctx, h.options.Client, input.ToProject, false)
+	if err != nil {
+		return nil, MoveOutput{}, err
+	}
+	if to.UID == "" {
+		return nil, MoveOutput{}, errors.New("target project UID is required")
+	}
+	revision := input.Revision
+	if revision == nil {
+		shown, showErr := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{PathParams: &generated.ShowIssuePath{ProjectID: from.ID, Ref: ref}})
+		if showErr != nil {
+			return nil, MoveOutput{}, showErr
+		}
+		revision = &shown.Issue.Revision
+	}
+	ifMatch := fmt.Sprintf(`"rev-%d"`, *revision)
+	response, err := h.options.Client.MoveIssue(ctx, &generated.MoveIssueRequestOptions{
+		PathParams: &generated.MoveIssuePath{ProjectID: from.ID, Ref: ref},
+		Body:       &generated.MoveIssueBody{Actor: &h.options.Actor, ToProjectUID: to.UID},
+		Header:     &generated.MoveIssueHeaders{IfMatch: &ifMatch},
+	})
+	if err != nil {
+		return nil, MoveOutput{}, err
+	}
+	return successResult(), MoveOutput{
+		From: from, To: to, Issue: h.summaryFromIssue(to, response.Issue), Changed: response.Changed,
+		EventID: response.EventID, NewShortID: response.NewShortID,
+	}, nil
+}
+
+func (h toolHandlers) deleteIssue(ctx context.Context, _ *sdkmcp.CallToolRequest, input DeleteInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
+	project, ref, qualified, err := h.destructiveTarget(ctx, input.Ref, input.Confirm, "DELETE")
+	if err != nil {
+		return nil, MutationOutput{}, err
+	}
+	response, err := h.options.Client.DeleteIssue(ctx, &generated.DeleteIssueRequestOptions{
+		PathParams: &generated.DeleteIssuePath{ProjectID: project.ID, Ref: ref},
+		Body:       &generated.DeleteIssueBody{Actor: h.options.Actor, Reason: optionalString(input.Reason)},
+		Header:     &generated.DeleteIssueHeaders{XKataConfirm: &qualified},
+	})
+	if err != nil {
+		return nil, MutationOutput{}, err
+	}
+	return successResult(), h.mutation(project, response.Issue, response.Changed, response.Reused, &response.Event), nil
+}
+
+func (h toolHandlers) restoreIssue(ctx context.Context, _ *sdkmcp.CallToolRequest, input RestoreInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
+	if err != nil {
+		return nil, MutationOutput{}, err
+	}
+	response, err := h.options.Client.RestoreIssue(ctx, &generated.RestoreIssueRequestOptions{
+		PathParams: &generated.RestoreIssuePath{ProjectID: project.ID, Ref: ref},
+		Body:       &generated.RestoreIssueBody{Actor: h.options.Actor},
+	})
+	if err != nil {
+		return nil, MutationOutput{}, err
+	}
+	return successResult(), h.mutation(project, response.Issue, response.Changed, response.Reused, &response.Event), nil
+}
+
+func (h toolHandlers) purgeIssue(ctx context.Context, _ *sdkmcp.CallToolRequest, input PurgeInput) (*sdkmcp.CallToolResult, PurgeOutput, error) {
+	project, ref, qualified, err := h.destructiveTarget(ctx, input.Ref, input.Confirm, "PURGE")
+	if err != nil {
+		return nil, PurgeOutput{}, err
+	}
+	response, err := h.options.Client.PurgeIssue(ctx, &generated.PurgeIssueRequestOptions{
+		PathParams: &generated.PurgeIssuePath{ProjectID: project.ID, Ref: ref},
+		Body:       &generated.PurgeIssueBody{Actor: h.options.Actor, Reason: optionalString(input.Reason)},
+		Header:     &generated.PurgeIssueHeaders{XKataConfirm: &qualified},
+	})
+	if err != nil {
+		return nil, PurgeOutput{}, err
+	}
+	return successResult(), PurgeOutput{Project: project, Ref: project.Name + "#" + ref, Purged: true, Log: response.PurgeLog}, nil
+}
+
+func (h toolHandlers) destructiveTarget(ctx context.Context, rawRef, confirm, verb string) (ProjectIdentity, string, string, error) {
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, rawRef, true)
+	if err != nil {
+		return ProjectIdentity{}, "", "", err
+	}
+	includeDeleted := verb == "PURGE"
+	shown, err := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
+		PathParams: &generated.ShowIssuePath{ProjectID: project.ID, Ref: ref},
+		Query:      &generated.ShowIssueQuery{IncludeDeleted: &includeDeleted},
+	})
+	if err != nil {
+		return ProjectIdentity{}, "", "", err
+	}
+	canonical := project.Name + "#" + shown.Issue.ShortID
+	expected := verb + " " + canonical
+	if confirm != expected {
+		return ProjectIdentity{}, "", "", fmt.Errorf("confirm must equal %q", expected)
+	}
+	return project, shown.Issue.ShortID, expected, nil
+}
+
+func (h toolHandlers) wait(ctx context.Context, _ *sdkmcp.CallToolRequest, input WaitInput) (*sdkmcp.CallToolResult, WaitOutput, error) {
+	if len(input.Refs) == 0 || len(input.Refs) > maximumResultLimit {
+		return nil, WaitOutput{}, fmt.Errorf("refs must contain between 1 and %d issue references", maximumResultLimit)
+	}
+	status := strings.TrimSpace(input.Status)
+	if status == "" {
+		status = "closed"
+	}
+	if status != "open" && status != "closed" && status != "deleted" {
+		return nil, WaitOutput{}, errors.New("status must be open, closed, or deleted")
+	}
+	timeout := input.TimeoutSeconds
+	if timeout == 0 {
+		timeout = 30
+	}
+	if timeout < 1 || timeout > 300 {
+		return nil, WaitOutput{}, errors.New("timeout_seconds must be between 1 and 300")
+	}
+	waitContext, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+	for {
+		states := make([]WaitState, 0, len(input.Refs))
+		matches := 0
+		for _, raw := range input.Refs {
+			project, ref, targetErr := h.options.Scope.IssueTarget(waitContext, h.options.Client, raw, false)
+			if targetErr != nil {
+				return nil, WaitOutput{}, targetErr
+			}
+			includeDeleted := true
+			shown, showErr := h.options.Client.ShowIssue(waitContext, &generated.ShowIssueRequestOptions{
+				PathParams: &generated.ShowIssuePath{ProjectID: project.ID, Ref: ref},
+				Query:      &generated.ShowIssueQuery{IncludeDeleted: &includeDeleted},
+			})
+			if showErr != nil {
+				return nil, WaitOutput{}, showErr
+			}
+			actual := shown.Issue.Status
+			if shown.Issue.DeletedAt != nil {
+				actual = "deleted"
+			}
+			matched := actual == status
+			if matched {
+				matches++
+			}
+			states = append(states, WaitState{Ref: project.Name + "#" + shown.Issue.ShortID, Status: actual, Matched: matched})
+		}
+		if input.Any && matches > 0 || !input.Any && matches == len(states) {
+			return successResult(), WaitOutput{Reason: "matched", States: states}, nil
+		}
+		select {
+		case <-waitContext.Done():
+			if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
+				return successResult(), WaitOutput{Reason: "timeout", States: states}, nil
+			}
+			return nil, WaitOutput{}, waitContext.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest, input AuditClosesInput) (*sdkmcp.CallToolResult, AuditClosesOutput, error) {
+	project, err := h.createTarget(ctx, input.Project)
+	if err != nil {
+		return nil, AuditClosesOutput{}, err
+	}
+	response, err := h.options.Client.AuditCloses(ctx, &generated.AuditClosesRequestOptions{Query: &generated.AuditClosesQuery{
+		ProjectID: project.ID, Since: optionalString(input.Since), Until: optionalString(input.Until),
+		Actor: optionalString(input.Actor), Parent: optionalString(input.Parent), Reason: optionalString(input.Reason),
+		NoEvidence: optionalTrue(input.NoEvidence),
+	}})
+	if err != nil {
+		return nil, AuditClosesOutput{}, err
+	}
+	return successResult(), AuditClosesOutput{Project: project, Rows: response.Rows}, nil
+}
+
+func (h toolHandlers) digest(ctx context.Context, _ *sdkmcp.CallToolRequest, input DigestInput) (*sdkmcp.CallToolResult, DigestOutput, error) {
+	if strings.TrimSpace(input.Since) == "" {
+		return nil, DigestOutput{}, errors.New("since is required")
+	}
+	if strings.TrimSpace(input.Project) == "" && h.options.Scope.Mode() == ScopeAll {
+		response, err := h.options.Client.DigestGlobal(ctx, &generated.DigestGlobalRequestOptions{Query: &generated.DigestGlobalQuery{Since: input.Since, Until: optionalString(input.Until), Actor: input.Actors}})
+		if err != nil {
+			return nil, DigestOutput{}, err
+		}
+		return successResult(), DigestOutput{Digests: []ProjectDigest{{Digest: *response}}}, nil
+	}
+	projects, err := h.activityProjects(ctx, input.Project)
+	if err != nil {
+		return nil, DigestOutput{}, err
+	}
+	out := make([]ProjectDigest, 0, len(projects))
+	for _, project := range projects {
+		response, digestErr := h.options.Client.DigestProject(ctx, &generated.DigestProjectRequestOptions{PathParams: &generated.DigestProjectPath{ProjectID: project.ID}, Query: &generated.DigestProjectQuery{Since: input.Since, Until: optionalString(input.Until), Actor: input.Actors}})
+		if digestErr != nil {
+			return nil, DigestOutput{}, digestErr
+		}
+		projectCopy := project
+		out = append(out, ProjectDigest{Project: &projectCopy, Digest: *response})
+	}
+	return successResult(), DigestOutput{Digests: out}, nil
+}
+
+func (h toolHandlers) events(ctx context.Context, _ *sdkmcp.CallToolRequest, input EventsInput) (*sdkmcp.CallToolResult, EventsOutput, error) {
+	mode := strings.TrimSpace(input.Mode)
+	if mode == "" {
+		mode = "poll"
+	}
+	if mode != "poll" && mode != "wait" {
+		return nil, EventsOutput{}, errors.New("mode must be poll or wait")
+	}
+	if input.After < 0 {
+		return nil, EventsOutput{}, errors.New("after must not be negative")
+	}
+	limit := input.Limit
+	if limit == 0 {
+		limit = defaultResultLimit
+	}
+	if limit < 1 || limit > maximumResultLimit {
+		return nil, EventsOutput{}, fmt.Errorf("limit must be between 1 and %d", maximumResultLimit)
+	}
+	if mode == "poll" {
+		output, err := h.pollScopedEvents(ctx, input.Project, input.After, limit)
+		if err != nil {
+			return nil, EventsOutput{}, err
+		}
+		return successResult(), output, nil
+	}
+	waitSeconds := input.WaitSeconds
+	if waitSeconds == 0 {
+		waitSeconds = 30
+	}
+	if waitSeconds < 1 || waitSeconds > 300 {
+		return nil, EventsOutput{}, errors.New("wait_seconds must be between 1 and 300")
+	}
+	// One stream can filter one project or all projects. A fixed multi-project
+	// allowlist uses bounded polling so events outside its scope never leak.
+	if strings.TrimSpace(input.Project) == "" && h.options.Scope.Mode() == ScopeAllowlist {
+		return h.waitPollEvents(ctx, input.Project, input.After, limit, waitSeconds)
+	}
+	var projectID *int64
+	if strings.TrimSpace(input.Project) != "" || h.options.Scope.Mode() == ScopeBound {
+		projects, err := h.activityProjects(ctx, input.Project)
+		if err != nil {
+			return nil, EventsOutput{}, err
+		}
+		projectID = &projects[0].ID
+	}
+	waitContext, cancel := context.WithTimeout(ctx, time.Duration(waitSeconds)*time.Second)
+	defer cancel()
+	response, err := h.options.Client.StreamEventsRaw(waitContext, &generated.StreamEventsRequestOptions{Query: &generated.StreamEventsQuery{AfterID: &input.After, ProjectID: projectID}})
+	if err != nil {
+		if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
+			return successResult(), EventsOutput{NextAfterID: input.After, TimedOut: true}, nil
+		}
+		return nil, EventsOutput{}, err
+	}
+	defer func() { _ = response.Body.Close() }()
+	output, err := readEventStream(waitContext, response.Body, input.After, limit)
+	if err != nil {
+		if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
+			return successResult(), EventsOutput{NextAfterID: input.After, TimedOut: true}, nil
+		}
+		return nil, EventsOutput{}, err
+	}
+	if err := h.redactEventsOutsideScope(waitContext, &output); err != nil {
+		return nil, EventsOutput{}, err
+	}
+	return successResult(), output, nil
+}
+
+func (h toolHandlers) activityProjects(ctx context.Context, name string) ([]ProjectIdentity, error) {
+	if strings.TrimSpace(name) != "" || h.options.Scope.Mode() == ScopeBound {
+		project, err := h.options.Scope.Project(ctx, h.options.Client, name, false)
+		if err != nil {
+			return nil, err
+		}
+		return []ProjectIdentity{project}, nil
+	}
+	return h.options.Scope.Projects(ctx, h.options.Client, false)
+}
+
+func (h toolHandlers) pollScopedEvents(ctx context.Context, projectName string, after, limit int64) (EventsOutput, error) {
+	if strings.TrimSpace(projectName) == "" && h.options.Scope.Mode() == ScopeAll {
+		response, err := h.options.Client.PollEvents(ctx, &generated.PollEventsRequestOptions{Query: &generated.PollEventsQuery{AfterID: &after, Limit: &limit}})
+		if err != nil {
+			return EventsOutput{}, err
+		}
+		return eventsOutput(response), nil
+	}
+	projects, err := h.activityProjects(ctx, projectName)
+	if err != nil {
+		return EventsOutput{}, err
+	}
+	output := EventsOutput{NextAfterID: after}
+	for _, project := range projects {
+		response, pollErr := h.options.Client.PollProjectEvents(ctx, &generated.PollProjectEventsRequestOptions{PathParams: &generated.PollProjectEventsPath{ProjectID: project.ID}, Query: &generated.PollProjectEventsQuery{AfterID: &after, Limit: &limit}})
+		if pollErr != nil {
+			return EventsOutput{}, pollErr
+		}
+		if response.ResetRequired {
+			output.ResetRequired = true
+			output.ResetAfterID = response.ResetAfterID
+			output.NextAfterID = response.NextAfterID
+			if output.NextAfterID == 0 && output.ResetAfterID != nil {
+				output.NextAfterID = *output.ResetAfterID
+			}
+			output.Events = nil
+			return output, nil
+		}
+		for _, event := range response.Events {
+			output.Events = append(output.Events, streamEvent(event))
+		}
+	}
+	sort.Slice(output.Events, func(i, j int) bool { return output.Events[i].EventID < output.Events[j].EventID })
+	if int64(len(output.Events)) > limit {
+		output.Events = output.Events[:limit]
+	}
+	if len(output.Events) > 0 {
+		output.NextAfterID = output.Events[len(output.Events)-1].EventID
+	}
+	if err := h.redactEventsOutsideScope(ctx, &output); err != nil {
+		return EventsOutput{}, err
+	}
+	return output, nil
+}
+
+func (h toolHandlers) waitPollEvents(ctx context.Context, project string, after, limit, waitSeconds int64) (*sdkmcp.CallToolResult, EventsOutput, error) {
+	waitContext, cancel := context.WithTimeout(ctx, time.Duration(waitSeconds)*time.Second)
+	defer cancel()
+	for {
+		output, err := h.pollScopedEvents(waitContext, project, after, limit)
+		if err != nil {
+			return nil, EventsOutput{}, err
+		}
+		if output.ResetRequired || len(output.Events) > 0 {
+			return successResult(), output, nil
+		}
+		select {
+		case <-waitContext.Done():
+			if errors.Is(waitContext.Err(), context.DeadlineExceeded) {
+				return successResult(), EventsOutput{NextAfterID: after, TimedOut: true}, nil
+			}
+			return nil, EventsOutput{}, waitContext.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+func eventsOutput(response *generated.PollEventsBody) EventsOutput {
+	if response.ResetRequired {
+		return EventsOutput{NextAfterID: response.NextAfterID, ResetRequired: true, ResetAfterID: response.ResetAfterID}
+	}
+	events := make([]StreamEvent, 0, len(response.Events))
+	for _, event := range response.Events {
+		events = append(events, streamEvent(event))
+	}
+	return EventsOutput{Events: events, NextAfterID: response.NextAfterID}
+}
+
+func readEventStream(ctx context.Context, reader io.Reader, after, limit int64) (EventsOutput, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64<<10), defaultMaxMessageBytes)
+	output := EventsOutput{NextAfterID: after}
+	eventType := ""
+	data := ""
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "":
+			if eventType == "sync.reset_required" {
+				var reset struct {
+					ResetAfterID int64 `json:"reset_after_id"`
+				}
+				if err := json.Unmarshal([]byte(data), &reset); err != nil {
+					return EventsOutput{}, fmt.Errorf("decode event reset: %w", err)
+				}
+				output.ResetRequired = true
+				output.ResetAfterID = &reset.ResetAfterID
+				output.NextAfterID = reset.ResetAfterID
+				output.Events = nil
+				return output, nil
+			}
+			if data != "" && eventType != "" && eventType != "heartbeat" {
+				var event generated.EventEnvelope
+				if err := json.Unmarshal([]byte(data), &event); err != nil {
+					return EventsOutput{}, fmt.Errorf("decode event stream: %w", err)
+				}
+				output.Events = append(output.Events, streamEvent(event))
+				output.NextAfterID = event.EventID
+				if int64(len(output.Events)) >= limit {
+					return output, nil
+				}
+				// Return the first available stream batch instead of holding an
+				// MCP request open for a future unrelated event.
+				return output, nil
+			}
+			eventType, data = "", ""
+		case strings.HasPrefix(line, "event: "):
+			eventType = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			data = strings.TrimPrefix(line, "data: ")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		if ctx.Err() != nil {
+			return EventsOutput{}, ctx.Err()
+		}
+		return EventsOutput{}, err
+	}
+	return output, nil
+}
+
+func streamEvent(event generated.EventEnvelope) StreamEvent {
+	output := StreamEvent{EventID: event.EventID, EventUID: event.EventUID, Type: event.Type, Actor: event.Actor, CreatedAt: formatTime(event.CreatedAt), ProjectID: event.ProjectID, ProjectUID: event.ProjectUID, ProjectName: event.ProjectName}
+	if event.IssueUID != nil {
+		output.IssueUID = *event.IssueUID
+	}
+	if event.IssueShortID != nil {
+		output.IssueShortID = *event.IssueShortID
+	}
+	if event.RelatedIssueUID != nil {
+		output.RelatedIssueUID = *event.RelatedIssueUID
+	}
+	if event.RelatedIssueShortID != nil {
+		output.RelatedIssueShortID = *event.RelatedIssueShortID
+	}
+	if len(event.Payload) > 0 {
+		var payload any
+		if json.Unmarshal(event.Payload, &payload) == nil {
+			output.Payload = payload
+		}
+	}
+	return output
+}
+
+func (h toolHandlers) redactEventsOutsideScope(ctx context.Context, output *EventsOutput) error {
+	if output == nil || h.options.Scope.Mode() == ScopeAll || len(output.Events) == 0 {
+		return nil
+	}
+	projects, err := h.options.Scope.Projects(ctx, h.options.Client, false)
+	if err != nil {
+		return err
+	}
+	allowedProjects := make(map[int64]struct{}, len(projects))
+	for _, project := range projects {
+		allowedProjects[project.ID] = struct{}{}
+	}
+	peerUIDs := make(map[string]struct{})
+	for _, event := range output.Events {
+		if event.RelatedIssueUID != "" {
+			peerUIDs[event.RelatedIssueUID] = struct{}{}
+		}
+		collectEventPeerUIDs(event.Payload, peerUIDs)
+	}
+	allowedPeers := make(map[string]bool, len(peerUIDs))
+	for uid := range peerUIDs {
+		response, showErr := h.options.Client.ShowIssueByUID(ctx, &generated.ShowIssueByUIDRequestOptions{
+			PathParams: &generated.ShowIssueByUIDPath{UID: uid},
+		})
+		if showErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if isHTTPStatus(showErr, http.StatusNotFound) {
+				continue
+			}
+			return errors.New("resolve event peer: daemon request failed")
+		}
+		_, allowedPeers[uid] = allowedProjects[response.Issue.ProjectID]
+	}
+	for index := range output.Events {
+		event := &output.Events[index]
+		if event.RelatedIssueUID == "" || !allowedPeers[event.RelatedIssueUID] {
+			event.RelatedIssueUID = ""
+			event.RelatedIssueShortID = ""
+		}
+		event.Payload = redactEventPayloadPeers(event.Payload, allowedPeers)
+	}
+	return nil
+}
+
+func isHTTPStatus(err error, status int) bool {
+	var apiError *oapiruntime.ClientAPIError
+	if errors.As(err, &apiError) && apiError != nil {
+		return apiError.StatusCode() == status
+	}
+	var decodeError *oapiruntime.ResponseDecodeError
+	return errors.As(err, &decodeError) && decodeError != nil && decodeError.StatusCode == status
+}
+
+var eventPeerUIDKeys = map[string]struct{}{
+	"from_uid": {}, "to_uid": {}, "link_from_uid": {}, "link_to_uid": {},
+	"peer_uid": {}, "related_issue_uid": {},
+}
+
+var eventPeerShortIDUIDKeys = map[string]string{
+	"from_short_id":          "from_uid",
+	"to_short_id":            "to_uid",
+	"link_from_short_id":     "link_from_uid",
+	"link_to_short_id":       "link_to_uid",
+	"peer_short_id":          "peer_uid",
+	"related_issue_short_id": "related_issue_uid",
+}
+
+func collectEventPeerUIDs(value any, output map[string]struct{}) {
+	switch current := value.(type) {
+	case map[string]any:
+		for key, nested := range current {
+			if _, peerKey := eventPeerUIDKeys[key]; peerKey {
+				if uid, ok := nested.(string); ok && uid != "" {
+					output[uid] = struct{}{}
+				}
+			}
+			collectEventPeerUIDs(nested, output)
+		}
+	case []any:
+		for _, nested := range current {
+			collectEventPeerUIDs(nested, output)
+		}
+	}
+}
+
+func redactEventPayloadPeers(value any, allowed map[string]bool) any {
+	switch current := value.(type) {
+	case map[string]any:
+		for key := range current {
+			if _, peerKey := eventPeerUIDKeys[key]; peerKey {
+				uid, ok := current[key].(string)
+				if !ok || !allowed[uid] {
+					delete(current, key)
+				}
+			}
+		}
+		for shortIDKey, uidKey := range eventPeerShortIDUIDKeys {
+			if _, present := current[shortIDKey]; !present {
+				continue
+			}
+			uid, ok := current[uidKey].(string)
+			if !ok || !allowed[uid] {
+				delete(current, shortIDKey)
+			}
+		}
+		for key, nested := range current {
+			current[key] = redactEventPayloadPeers(nested, allowed)
+		}
+	case []any:
+		for index, nested := range current {
+			current[index] = redactEventPayloadPeers(nested, allowed)
+		}
+	}
+	return value
+}

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -542,7 +542,7 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
-	if err := h.validateAuditParentFilter(ctx, input.Parent); err != nil {
+	if err := h.validateAuditParentFilter(ctx, project, input.Parent); err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
 	limit := input.Limit
@@ -589,7 +589,7 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 
 // validateAuditParentFilter stops fixed scopes from probing foreign refs
 // through the daemon's global parent-filter resolution.
-func (h toolHandlers) validateAuditParentFilter(ctx context.Context, raw string) error {
+func (h toolHandlers) validateAuditParentFilter(ctx context.Context, project ProjectIdentity, raw string) error {
 	ref := strings.TrimSpace(raw)
 	if ref == "" || h.options.Scope.Mode() == ScopeAll {
 		return nil
@@ -605,6 +605,17 @@ func (h toolHandlers) validateAuditParentFilter(ctx context.Context, raw string)
 		return fmt.Errorf("parent filter %q uses an ambiguous full-length short ID; use a shorter project-qualified reference", ref)
 	}
 	if parsed.Project == "" {
+		// The daemon matches unresolved bare filters against stored parent
+		// snapshots, which can name purged foreign parents. Forward a bare
+		// filter only when it resolves in the audited project; otherwise
+		// fail closed instead of exposing a snapshot-matching oracle.
+		_, _, found, probeErr := h.issueLinksForVouching(ctx, project, parsed.ShortID)
+		if probeErr != nil {
+			return probeErr
+		}
+		if !found {
+			return fmt.Errorf("parent filter %q does not resolve in project %q; use a project-qualified reference to an in-scope parent", ref, project.Name)
+		}
 		return nil
 	}
 	_, err = h.options.Scope.Project(ctx, h.options.Client, parsed.Project, true)

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -141,14 +141,16 @@ type AuditClosesInput struct {
 	Parent     string `json:"parent,omitempty"`
 	Reason     string `json:"reason,omitempty"`
 	NoEvidence bool   `json:"no_evidence,omitempty"`
-	Limit      int64  `json:"limit,omitempty" jsonschema:"Maximum rows from 1 through 100; default 20. When truncated, advance since past the last returned row's time"`
+	Limit      int64  `json:"limit,omitempty" jsonschema:"Maximum rows from 1 through 100; default 20"`
+	Offset     int64  `json:"offset,omitempty" jsonschema:"Rows to skip; pass the previous result's next_offset to continue. Row order is stable and append-only"`
 }
 
 // AuditClosesOutput contains close audit records for one project.
 type AuditClosesOutput struct {
-	Project   ProjectIdentity           `json:"project"`
-	Rows      []generated.AuditCloseRow `json:"rows"`
-	Truncated bool                      `json:"truncated,omitempty"`
+	Project    ProjectIdentity           `json:"project"`
+	Rows       []generated.AuditCloseRow `json:"rows"`
+	Truncated  bool                      `json:"truncated,omitempty"`
+	NextOffset *int64                    `json:"next_offset,omitempty"`
 }
 
 // DigestInput defines an activity digest window.
@@ -550,6 +552,9 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if limit < 1 || limit > maximumResultLimit {
 		return nil, AuditClosesOutput{}, fmt.Errorf("limit must be between 1 and %d", maximumResultLimit)
 	}
+	if input.Offset < 0 {
+		return nil, AuditClosesOutput{}, errors.New("offset must not be negative")
+	}
 	response, err := h.options.Client.AuditCloses(ctx, &generated.AuditClosesRequestOptions{Query: &generated.AuditClosesQuery{
 		ProjectID: project.ID, Since: optionalString(input.Since), Until: optionalString(input.Until),
 		Actor: optionalString(input.Actor), Parent: optionalString(input.Parent), Reason: optionalString(input.Reason),
@@ -558,16 +563,28 @@ func (h toolHandlers) auditCloses(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
+	// The daemon returns rows in stable ascending event order, so an
+	// offset cursor never skips or repeats rows even when many closes
+	// share one timestamp; new rows only append past the end.
 	rows := response.Rows
-	truncated := int64(len(rows)) > limit
-	if truncated {
+	if input.Offset >= int64(len(rows)) {
+		rows = nil
+	} else {
+		rows = rows[input.Offset:]
+	}
+	output := AuditClosesOutput{Project: project}
+	if int64(len(rows)) > limit {
 		rows = rows[:limit]
+		output.Truncated = true
+		next := input.Offset + limit
+		output.NextOffset = &next
 	}
 	rows, err = h.redactAuditParentsOutsideScope(ctx, project, rows)
 	if err != nil {
 		return nil, AuditClosesOutput{}, err
 	}
-	return successResult(), AuditClosesOutput{Project: project, Rows: rows, Truncated: truncated}, nil
+	output.Rows = rows
+	return successResult(), output, nil
 }
 
 // validateAuditParentFilter stops fixed scopes from probing foreign refs
@@ -1191,9 +1208,30 @@ var eventProjectUIDKeys = map[string]struct{}{
 	"from_project_uid": {}, "to_project_uid": {}, "source_uid": {},
 }
 
-func collectEventPeerUIDs(value any, output map[string]struct{}) {
-	switch current := value.(type) {
-	case map[string]any:
+// Relationship references appear only in the top-level payload map and in
+// the objects of a top-level "links" array (issue.created / issue.snapshot).
+// Nested subtrees such as "metadata" and "diff" carry opaque user keys and
+// values, so they are never inspected: a user metadata key named source_uid
+// or from_uid is data, not a relationship reference.
+func forEachPeerBearingMap(payload any, visit func(map[string]any)) {
+	root, ok := payload.(map[string]any)
+	if !ok {
+		return
+	}
+	visit(root)
+	links, ok := root["links"].([]any)
+	if !ok {
+		return
+	}
+	for _, element := range links {
+		if link, isMap := element.(map[string]any); isMap {
+			visit(link)
+		}
+	}
+}
+
+func collectEventPeerUIDs(payload any, output map[string]struct{}) {
+	forEachPeerBearingMap(payload, func(current map[string]any) {
 		for key, nested := range current {
 			if _, peerKey := eventPeerUIDKeys[key]; peerKey {
 				if uid, ok := nested.(string); ok && uid != "" {
@@ -1209,18 +1247,12 @@ func collectEventPeerUIDs(value any, output map[string]struct{}) {
 					}
 				}
 			}
-			collectEventPeerUIDs(nested, output)
 		}
-	case []any:
-		for _, nested := range current {
-			collectEventPeerUIDs(nested, output)
-		}
-	}
+	})
 }
 
-func redactEventPayloadPeers(value any, allowed map[string]bool, allowedProjects map[string]bool) any {
-	switch current := value.(type) {
-	case map[string]any:
+func redactEventPayloadPeers(payload any, allowed map[string]bool, allowedProjects map[string]bool) any {
+	forEachPeerBearingMap(payload, func(current map[string]any) {
 		for key := range current {
 			if _, peerKey := eventPeerUIDKeys[key]; peerKey {
 				uid, ok := current[key].(string)
@@ -1258,15 +1290,8 @@ func redactEventPayloadPeers(value any, allowed map[string]bool, allowedProjects
 				delete(current, shortIDKey)
 			}
 		}
-		for key, nested := range current {
-			current[key] = redactEventPayloadPeers(nested, allowed, allowedProjects)
-		}
-	case []any:
-		for index, nested := range current {
-			current[index] = redactEventPayloadPeers(nested, allowed, allowedProjects)
-		}
-	}
-	return value
+	})
+	return payload
 }
 
 func redactEventPeerUIDList(payload map[string]any, uidsKey, displayKey string, allowed map[string]bool) {

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -408,12 +408,12 @@ func (h toolHandlers) move(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 }
 
 func (h toolHandlers) deleteIssue(ctx context.Context, _ *sdkmcp.CallToolRequest, input DeleteInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
-	project, ref, qualified, err := h.destructiveTarget(ctx, input.Ref, input.Confirm, "DELETE")
+	project, target, qualified, err := h.destructiveTarget(ctx, input.Ref, input.Confirm, "DELETE")
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
 	response, err := h.options.Client.DeleteIssue(ctx, &generated.DeleteIssueRequestOptions{
-		PathParams: &generated.DeleteIssuePath{ProjectID: project.ID, Ref: ref},
+		PathParams: &generated.DeleteIssuePath{ProjectID: project.ID, Ref: target.UID},
 		Body:       &generated.DeleteIssueBody{Actor: h.options.Actor, Reason: optionalString(input.Reason)},
 		Header:     &generated.DeleteIssueHeaders{XKataConfirm: &qualified},
 	})
@@ -439,25 +439,33 @@ func (h toolHandlers) restoreIssue(ctx context.Context, _ *sdkmcp.CallToolReques
 }
 
 func (h toolHandlers) purgeIssue(ctx context.Context, _ *sdkmcp.CallToolRequest, input PurgeInput) (*sdkmcp.CallToolResult, PurgeOutput, error) {
-	project, ref, qualified, err := h.destructiveTarget(ctx, input.Ref, input.Confirm, "PURGE")
+	project, target, qualified, err := h.destructiveTarget(ctx, input.Ref, input.Confirm, "PURGE")
 	if err != nil {
 		return nil, PurgeOutput{}, err
 	}
 	response, err := h.options.Client.PurgeIssue(ctx, &generated.PurgeIssueRequestOptions{
-		PathParams: &generated.PurgeIssuePath{ProjectID: project.ID, Ref: ref},
+		PathParams: &generated.PurgeIssuePath{ProjectID: project.ID, Ref: target.UID},
 		Body:       &generated.PurgeIssueBody{Actor: h.options.Actor, Reason: optionalString(input.Reason)},
 		Header:     &generated.PurgeIssueHeaders{XKataConfirm: &qualified},
 	})
 	if err != nil {
 		return nil, PurgeOutput{}, err
 	}
-	return successResult(), PurgeOutput{Project: project, Ref: project.Name + "#" + ref, Purged: true, Log: response.PurgeLog}, nil
+	return successResult(), PurgeOutput{Project: project, Ref: project.Name + "#" + target.ShortID, Purged: true, Log: response.PurgeLog}, nil
 }
 
-func (h toolHandlers) destructiveTarget(ctx context.Context, rawRef, confirm, verb string) (ProjectIdentity, string, string, error) {
+// destructiveIssue is the issue confirmed by a destructive preflight. UID
+// addresses the mutation so a short ID reused after the preflight cannot
+// redirect it; ShortID is the confirmed display reference.
+type destructiveIssue struct {
+	UID     string
+	ShortID string
+}
+
+func (h toolHandlers) destructiveTarget(ctx context.Context, rawRef, confirm, verb string) (ProjectIdentity, destructiveIssue, string, error) {
 	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, rawRef, true)
 	if err != nil {
-		return ProjectIdentity{}, "", "", err
+		return ProjectIdentity{}, destructiveIssue{}, "", err
 	}
 	// Resolve soft-deleted rows for DELETE as well as PURGE so a retry
 	// after a lost response reaches the daemon's idempotent re-delete
@@ -468,14 +476,14 @@ func (h toolHandlers) destructiveTarget(ctx context.Context, rawRef, confirm, ve
 		Query:      &generated.ShowIssueQuery{IncludeDeleted: &includeDeleted},
 	})
 	if err != nil {
-		return ProjectIdentity{}, "", "", err
+		return ProjectIdentity{}, destructiveIssue{}, "", err
 	}
 	canonical := project.Name + "#" + shown.Issue.ShortID
 	expected := verb + " " + canonical
 	if confirm != expected {
-		return ProjectIdentity{}, "", "", fmt.Errorf("confirm must equal %q", expected)
+		return ProjectIdentity{}, destructiveIssue{}, "", fmt.Errorf("confirm must equal %q", expected)
 	}
-	return project, shown.Issue.ShortID, expected, nil
+	return project, destructiveIssue{UID: shown.Issue.UID, ShortID: shown.Issue.ShortID}, expected, nil
 }
 
 func (h toolHandlers) wait(ctx context.Context, _ *sdkmcp.CallToolRequest, input WaitInput) (*sdkmcp.CallToolResult, WaitOutput, error) {

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -1056,7 +1056,14 @@ func readEventStream(ctx context.Context, reader io.Reader, after, limit int64) 
 		}
 		return EventsOutput{}, err
 	}
-	return output, nil
+	// The daemon closes a stream cleanly on overflow disconnect, authority
+	// loss, or an internal read failure. Reaching EOF without an event or
+	// reset is therefore an interrupted wait, not an empty result; the
+	// caller maps a context deadline to the documented timeout first.
+	if ctx.Err() != nil {
+		return EventsOutput{}, ctx.Err()
+	}
+	return EventsOutput{}, errors.New("event stream ended before delivering an event; retry from the same after_id")
 }
 
 func streamEvent(event generated.EventEnvelope) StreamEvent {

--- a/internal/mcp/activity_test.go
+++ b/internal/mcp/activity_test.go
@@ -75,6 +75,8 @@ func TestWorkflowToolsRoundTripAgainstDaemon(t *testing.T) {
 	callWorkflowTool(t, session, "kata.delete", map[string]any{"ref": movedRef, "confirm": "DELETE " + movedRef})
 	callWorkflowTool(t, session, "kata.restore", map[string]any{"ref": movedRef})
 	callWorkflowTool(t, session, "kata.delete", map[string]any{"ref": movedRef, "confirm": "DELETE " + movedRef})
+	redeleted := callWorkflowTool(t, session, "kata.delete", map[string]any{"ref": movedRef, "confirm": "DELETE " + movedRef})
+	require.Equal(t, false, redeleted["changed"], "retrying a committed delete must reach the daemon's idempotent no-op")
 	purged := callWorkflowTool(t, session, "kata.purge", map[string]any{"ref": movedRef, "confirm": "PURGE " + movedRef})
 	require.Equal(t, true, purged["purged"])
 

--- a/internal/mcp/activity_test.go
+++ b/internal/mcp/activity_test.go
@@ -1,0 +1,103 @@
+package mcpserver
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db/sqlitestore"
+	kataclient "go.kenn.io/kata/pkg/client"
+)
+
+func TestWorkflowToolsArePublished(t *testing.T) {
+	session := connectTestServer(t)
+	result, err := session.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+	names := make(map[string]bool, len(result.Tools))
+	for _, tool := range result.Tools {
+		names[tool.Name] = true
+	}
+	for _, name := range []string{
+		"kata.audit_closes", "kata.delete", "kata.edit_comment", "kata.graph",
+		"kata.move", "kata.next", "kata.purge", "kata.restore", "kata.wait",
+	} {
+		require.True(t, names[name], name)
+	}
+}
+
+func TestWorkflowToolsRoundTripAgainstDaemon(t *testing.T) {
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	spoke, err := store.CreateProject(t.Context(), "spoke-project")
+	require.NoError(t, err)
+	hub, err := store.CreateProject(t.Context(), "hub-project")
+	require.NoError(t, err)
+	daemonServer := daemon.NewServer(daemon.ServerConfig{DB: store, StartedAt: time.Now().UTC()})
+	t.Cleanup(func() { require.NoError(t, daemonServer.Close()) })
+	httpServer := httptest.NewServer(daemonServer.Handler())
+	t.Cleanup(httpServer.Close)
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: spoke.ID, UID: spoke.UID, Name: spoke.Name},
+		{ID: hub.ID, UID: hub.UID, Name: hub.Name},
+	})
+	require.NoError(t, err)
+	session := connectTestServerWithOptions(t, Options{Client: client, Scope: scope, Actor: "example-agent", Version: "test-version"})
+
+	created := callWorkflowTool(t, session, "kata.create", map[string]any{
+		"project": "spoke-project", "title": "Workflow issue", "priority": 1, "idempotency_key": "workflow-issue",
+	})
+	qualified := created["issue"].(map[string]any)["qualified_ref"].(string)
+	next := callWorkflowTool(t, session, "kata.next", map[string]any{"project": "spoke-project"})
+	require.Equal(t, qualified, next["issue"].(map[string]any)["qualified_ref"])
+
+	commented := callWorkflowTool(t, session, "kata.comment", map[string]any{
+		"ref": qualified, "body": "Initial note", "idempotency_key": "workflow-note",
+	})
+	commentUID := commented["comment"].(map[string]any)["uid"].(string)
+	edited := callWorkflowTool(t, session, "kata.edit_comment", map[string]any{
+		"ref": qualified, "comment_ref": commentUID, "body": "Updated note",
+	})
+	require.Equal(t, "Updated note", edited["comment"].(map[string]any)["body"])
+	graph := callWorkflowTool(t, session, "kata.graph", map[string]any{"ref": qualified, "depth": "1"})
+	require.NotEmpty(t, graph["nodes"])
+
+	moved := callWorkflowTool(t, session, "kata.move", map[string]any{"ref": qualified, "to_project": "hub-project"})
+	movedRef := moved["issue"].(map[string]any)["qualified_ref"].(string)
+	require.Contains(t, movedRef, "hub-project#")
+	callWorkflowTool(t, session, "kata.delete", map[string]any{"ref": movedRef, "confirm": "DELETE " + movedRef})
+	callWorkflowTool(t, session, "kata.restore", map[string]any{"ref": movedRef})
+	callWorkflowTool(t, session, "kata.delete", map[string]any{"ref": movedRef, "confirm": "DELETE " + movedRef})
+	purged := callWorkflowTool(t, session, "kata.purge", map[string]any{"ref": movedRef, "confirm": "PURGE " + movedRef})
+	require.Equal(t, true, purged["purged"])
+
+	completed := callWorkflowTool(t, session, "kata.create", map[string]any{
+		"project": "spoke-project", "title": "Completed workflow", "idempotency_key": "completed-workflow",
+	})
+	completedRef := completed["issue"].(map[string]any)["qualified_ref"].(string)
+	callWorkflowTool(t, session, "kata.close", map[string]any{
+		"ref": completedRef, "reason": "done", "message": "Completed the workflow behavior with daemon evidence.",
+		"evidence": []any{map[string]any{"type": "test", "command": "go test ./internal/mcp"}},
+	})
+	waited := callWorkflowTool(t, session, "kata.wait", map[string]any{"refs": []any{completedRef}, "status": "closed", "timeout_seconds": 1})
+	require.Equal(t, "matched", waited["reason"])
+	audit := callWorkflowTool(t, session, "kata.audit_closes", map[string]any{"project": "spoke-project"})
+	require.NotEmpty(t, audit["rows"])
+}
+
+func callWorkflowTool(t *testing.T, session *sdkmcp.ClientSession, name string, arguments map[string]any) map[string]any {
+	t.Helper()
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: name, Arguments: arguments})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "%s", mustJSON(t, result))
+	structured, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok, "%T", result.StructuredContent)
+	return structured
+}

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -1,13 +1,9 @@
 package mcpserver
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
 	"time"
 
@@ -88,28 +84,6 @@ type FederationEnrollmentRevokeOutput struct {
 	Revoked bool  `json:"revoked"`
 }
 
-// FederationJoinInput carries one hub enrollment into a spoke join.
-type FederationJoinInput struct {
-	ProjectName            string `json:"project_name"`
-	HubURL                 string `json:"hub_url"`
-	HubProjectID           int64  `json:"hub_project_id"`
-	HubProjectUID          string `json:"hub_project_uid"`
-	ReplayHorizonEventID   int64  `json:"replay_horizon_event_id,omitempty"`
-	BaselineThroughEventID int64  `json:"baseline_through_event_id,omitempty"`
-	Token                  string `json:"token,omitempty"`
-	Capabilities           string `json:"capabilities,omitempty"`
-	AllowInsecure          bool   `json:"allow_insecure,omitempty"`
-	PushEnabled            bool   `json:"push_enabled,omitempty"`
-	AdoptExisting          bool   `json:"adopt_existing,omitempty"`
-}
-
-// FederationJoinOutput reports the created or adopted spoke binding.
-type FederationJoinOutput struct {
-	Project ProjectSummary                 `json:"project"`
-	Binding generated.FederationBindingOut `json:"binding"`
-	Adopted bool                           `json:"adopted,omitempty"`
-}
-
 // FederationRebindInput selects a spoke and configured hub catalog entry.
 type FederationRebindInput struct {
 	Project    string `json:"project"`
@@ -168,10 +142,8 @@ func registerLeaseTools(server *sdkmcp.Server, handlers toolHandlers) {
 func registerFederationTools(server *sdkmcp.Server, handlers toolHandlers) {
 	read := toolHints(true, false, true)
 	mutating := toolHints(false, true, true)
-	additive := toolHints(false, false, true)
 	addTool(server, "kata.federation_status", "Federation status", "Read in-scope federation, enrollment, replica, and quarantine status without secrets.", read, handlers.federationStatus)
 	addTool(server, "kata.federation_enrollment_revoke", "Revoke enrollment", "Revoke a federation enrollment by ID.", mutating, handlers.federationEnrollmentRevoke)
-	addTool(server, "kata.federation_join", "Join federation", "Join or adopt an enrolled hub project as a spoke.", additive, handlers.federationJoin)
 	addTool(server, "kata.federation_rebind", "Rebind federation", "Rebind a spoke to a configured hub catalog entry.", mutating, handlers.federationRebind)
 	addTool(server, "kata.federation_leave", "Leave federation", "Run the preflight, prepare, or commit phase of resumable federation leave.", mutating, handlers.federationLeave)
 	addTool(server, "kata.federation_quarantine", "Resolve quarantine", "Retry or skip a federation quarantine batch after exact confirmation.", mutating, handlers.federationQuarantine)
@@ -371,39 +343,6 @@ func (h toolHandlers) federationEnrollmentRevoke(ctx context.Context, _ *sdkmcp.
 	return successResult(), FederationEnrollmentRevokeOutput{ID: response.ID, Revoked: response.Revoked}, nil
 }
 
-func (h toolHandlers) federationJoin(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationJoinInput) (*sdkmcp.CallToolResult, FederationJoinOutput, error) {
-	projectName := strings.TrimSpace(input.ProjectName)
-	if projectName == "" || strings.TrimSpace(input.HubURL) == "" || input.HubProjectID <= 0 || strings.TrimSpace(input.HubProjectUID) == "" {
-		return nil, FederationJoinOutput{}, errors.New("project_name, hub_url, hub_project_id, and hub_project_uid are required")
-	}
-	if h.options.Scope.Mode() != ScopeAll {
-		if _, err := h.options.Scope.Project(ctx, h.options.Client, projectName, false); err != nil {
-			return nil, FederationJoinOutput{}, err
-		}
-	}
-	body := generated.CreateFederationReplicaRequestBody{
-		Actor: &h.options.Actor, ProjectName: projectName, HubURL: input.HubURL, HubProjectID: input.HubProjectID,
-		HubProjectUID: input.HubProjectUID, ReplayHorizonEventID: input.ReplayHorizonEventID,
-		BaselineThroughEventID: optionalInt64(input.BaselineThroughEventID), Token: optionalString(input.Token),
-		Capabilities: optionalString(input.Capabilities), AllowInsecure: optionalTrue(input.AllowInsecure), PushEnabled: optionalTrue(input.PushEnabled), AdoptExisting: optionalTrue(input.AdoptExisting),
-	}
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return nil, FederationJoinOutput{}, err
-	}
-	response, err := h.options.Client.CreateFederationReplica(ctx, &generated.CreateFederationReplicaRequestOptions{}, func(_ context.Context, request *http.Request) error {
-		request.Body = io.NopCloser(bytes.NewReader(payload))
-		request.ContentLength = int64(len(payload))
-		request.Header.Set("Content-Type", "application/json")
-		return nil
-	})
-	if err != nil {
-		return nil, FederationJoinOutput{}, err
-	}
-	adopted := response.Adopted != nil && *response.Adopted
-	return successResult(), FederationJoinOutput{Project: projectSummaryOut(response.Project), Binding: response.Binding, Adopted: adopted}, nil
-}
-
 func (h toolHandlers) federationRebind(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationRebindInput) (*sdkmcp.CallToolResult, FederationRebindOutput, error) {
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
 	if err != nil {
@@ -482,11 +421,4 @@ func (h toolHandlers) federationQuarantine(ctx context.Context, _ *sdkmcp.CallTo
 
 func federationEnrollmentSummary(enrollment generated.FederationEnrollmentOut) FederationEnrollmentSummary {
 	return FederationEnrollmentSummary{ID: enrollment.ID, ProjectID: enrollment.ProjectID, SpokeInstanceUID: enrollment.SpokeInstanceUID, Capabilities: enrollment.Capabilities, Actor: enrollment.Actor, Revoked: enrollment.RevokedAt != nil}
-}
-
-func optionalInt64(value int64) *int64 {
-	if value == 0 {
-		return nil
-	}
-	return &value
 }

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -131,9 +131,8 @@ type FederationQuarantineOutput struct {
 
 func registerLeaseTools(server *sdkmcp.Server, handlers toolHandlers) {
 	read := toolHints(true, false, false)
-	additive := toolHints(false, false, false)
 	destructive := toolHints(false, true, false)
-	addTool(server, "kata.lease", "Manage lease", "Acquire, renew, or release the startup actor's federation write lease.", additive, handlers.lease)
+	addTool(server, "kata.lease", "Manage lease", "Acquire, renew, or release the startup actor's federation write lease.", destructive, handlers.lease)
 	addTool(server, "kata.lease_force_release", "Force-release lease", "Administratively release another lease with a reason.", destructive, handlers.leaseForceRelease)
 	addTool(server, "kata.lease_status", "Lease status", "Read the current federation write lease for an issue.", read, handlers.leaseStatus)
 	addTool(server, "kata.lease_steal", "Steal lease", "Resumably force-release and acquire a lease as the startup actor.", destructive, handlers.leaseSteal)

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -134,7 +134,7 @@ type FederationQuarantineOutput struct {
 func registerLeaseTools(server *sdkmcp.Server, handlers toolHandlers) {
 	read := toolHints(true, false, false)
 	destructive := toolHints(false, true, false)
-	addTool(server, "kata.lease", "Manage lease", "Acquire, renew, or release the startup actor's federation write lease.", destructive, handlers.lease)
+	addTool(server, "kata.lease", "Manage lease", "Acquire, renew, or release the startup actor's federation write lease; renew extends the expiry on every call.", nonIdempotent(toolHints(false, true, false)), handlers.lease)
 	addTool(server, "kata.lease_force_release", "Force-release lease", "Administratively release another lease with a reason.", destructive, handlers.leaseForceRelease)
 	addTool(server, "kata.lease_status", "Lease status", "Read the current federation write lease for an issue.", read, handlers.leaseStatus)
 	addTool(server, "kata.lease_steal", "Steal lease", "Resumably force-release and acquire a lease as the startup actor.", destructive, handlers.leaseSteal)
@@ -218,29 +218,29 @@ func (h toolHandlers) leaseForceRelease(ctx context.Context, _ *sdkmcp.CallToolR
 	return successResult(), leaseMutationOutput(project, ref, response), nil
 }
 
+// leaseSteal acquires first: the daemon re-grants a lease already held by the
+// startup principal, so a retry after a lost response keeps the lease instead
+// of force-releasing it and racing other claimants. Only a denied acquire
+// force-releases the reported holder before one more acquire attempt.
 func (h toolHandlers) leaseSteal(ctx context.Context, _ *sdkmcp.CallToolRequest, input LeaseStealInput) (*sdkmcp.CallToolResult, LeaseOutput, error) {
-	statusResult, status, err := h.leaseStatus(ctx, nil, LeaseStatusInput{Ref: input.Ref})
-	_ = statusResult
+	acquire := LeaseInput{Ref: input.Ref, Action: "acquire", TTLSeconds: input.TTLSeconds, Purpose: input.Purpose}
+	_, acquired, err := h.lease(ctx, nil, acquire)
 	if err != nil {
 		return nil, LeaseOutput{}, err
 	}
-	previous := status.Holder
-	if status.Held {
-		if _, _, err := h.leaseForceRelease(ctx, nil, LeaseForceReleaseInput{Ref: input.Ref, Reason: input.Reason}); err != nil {
-			return nil, LeaseOutput{}, err
-		}
+	if acquired.Granted || acquired.Pending {
+		return successResult(), acquired, nil
 	}
-	_, acquired, err := h.lease(ctx, nil, LeaseInput{
-		Ref: input.Ref, Action: "acquire", TTLSeconds: input.TTLSeconds, Purpose: input.Purpose,
-	})
+	previous := acquired.Holder
+	if _, _, err := h.leaseForceRelease(ctx, nil, LeaseForceReleaseInput{Ref: input.Ref, Reason: input.Reason}); err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	_, acquired, err = h.lease(ctx, nil, acquire)
 	if err != nil {
 		return nil, LeaseOutput{}, err
 	}
 	acquired.PreviousHolder = previous
 	if !acquired.Granted && !acquired.Pending {
-		if !status.Held {
-			return nil, LeaseOutput{}, fmt.Errorf("lease steal acquisition was denied for %s", acquired.Ref)
-		}
 		return nil, LeaseOutput{}, fmt.Errorf("lease steal force-release succeeded but lease acquisition was denied for %s", acquired.Ref)
 	}
 	return successResult(), acquired, nil

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -363,17 +363,33 @@ func (h toolHandlers) federationEnrollmentRevoke(ctx context.Context, _ *sdkmcp.
 	if input.ID <= 0 {
 		return nil, FederationEnrollmentRevokeOutput{}, errors.New("id must be positive")
 	}
-	// Resolve and scope the enrollment before revocation.
-	_, status, err := h.federationStatus(ctx, nil, FederationStatusInput{})
+	// Archiving a project retains its enrollments and their credentials, so
+	// revocation authorizes against the scope including archived members;
+	// federationStatus lists only active projects. Global enrollments
+	// (project_id 0) stay daemon-wide only.
+	projects, err := h.options.Scope.Projects(ctx, h.options.Client, true)
+	if err != nil {
+		return nil, FederationEnrollmentRevokeOutput{}, err
+	}
+	scoped := make(map[int64]struct{}, len(projects))
+	for _, project := range projects {
+		scoped[project.ID] = struct{}{}
+	}
+	list, err := h.options.Client.ListFederationEnrollments(ctx)
 	if err != nil {
 		return nil, FederationEnrollmentRevokeOutput{}, err
 	}
 	allowed := false
-	for _, enrollment := range status.Enrollments {
-		if enrollment.ID == input.ID {
-			allowed = true
-			break
+	for _, enrollment := range list.Enrollments {
+		if enrollment.ID != input.ID {
+			continue
 		}
+		if enrollment.ProjectID == 0 {
+			allowed = h.options.Scope.Mode() == ScopeAll
+		} else {
+			_, allowed = scoped[enrollment.ProjectID]
+		}
+		break
 	}
 	if !allowed {
 		return nil, FederationEnrollmentRevokeOutput{}, errors.New("enrollment is outside the MCP startup scope")

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -365,16 +365,23 @@ func (h toolHandlers) federationLeave(ctx context.Context, _ *sdkmcp.CallToolReq
 	if phase != "preflight" && phase != "prepare" && phase != "commit" {
 		return nil, FederationLeaveOutput{}, errors.New("phase must be preflight, prepare, or commit")
 	}
-	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
-	if err != nil {
-		return nil, FederationLeaveOutput{}, err
-	}
 	disposition := strings.TrimSpace(input.Disposition)
 	if disposition == "" {
 		disposition = "detach"
 	}
 	if disposition != "detach" && disposition != "archive" {
 		return nil, FederationLeaveOutput{}, errors.New("disposition must be detach or archive")
+	}
+	if disposition == "archive" {
+		// Archiving through leave is project catalog administration; a
+		// scoped server may only detach.
+		if err := h.requireProjectAdminScope("federation leave with the archive disposition"); err != nil {
+			return nil, FederationLeaveOutput{}, err
+		}
+	}
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
+	if err != nil {
+		return nil, FederationLeaveOutput{}, err
 	}
 	if phase == "commit" {
 		expected := "COMMIT FEDERATION LEAVE " + project.Name

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -313,7 +313,35 @@ func (h toolHandlers) federationStatus(ctx context.Context, _ *sdkmcp.CallToolRe
 		}
 		enrollments = append(enrollments, federationEnrollmentSummary(item))
 	}
-	return successResult(), FederationStatusOutput{Statuses: statuses, Enrollments: enrollments}, nil
+	return successResult(), FederationStatusOutput{Statuses: h.redactFederationErrors(statuses), Enrollments: enrollments}, nil
+}
+
+// Federation error text can quote refused events verbatim, including issue
+// references in other projects, so scoped servers replace it with a stable
+// notice instead of the raw daemon prose.
+const scopedFederationErrorNotice = "error detail withheld in scoped MCP mode; inspect with the CLI or a daemon-wide server"
+
+func (h toolHandlers) redactFederationErrors(statuses []generated.FederationProjectStatus) []generated.FederationProjectStatus {
+	if h.options.Scope.Mode() == ScopeAll {
+		return statuses
+	}
+	for index := range statuses {
+		if statuses[index].LastError != nil {
+			notice := scopedFederationErrorNotice
+			statuses[index].LastError = &notice
+		}
+		for quarantine := range statuses[index].ActiveQuarantines {
+			statuses[index].ActiveQuarantines[quarantine].ErrorData = scopedFederationErrorNotice
+		}
+	}
+	return statuses
+}
+
+func (h toolHandlers) redactQuarantineError(summary generated.FederationQuarantineSummary) generated.FederationQuarantineSummary {
+	if h.options.Scope.Mode() != ScopeAll {
+		summary.ErrorData = scopedFederationErrorNotice
+	}
+	return summary
 }
 
 func (h toolHandlers) federationEnrollmentRevoke(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationEnrollmentRevokeInput) (*sdkmcp.CallToolResult, FederationEnrollmentRevokeOutput, error) {
@@ -428,7 +456,7 @@ func (h toolHandlers) federationQuarantine(ctx context.Context, _ *sdkmcp.CallTo
 	if err != nil {
 		return nil, FederationQuarantineOutput{}, err
 	}
-	return successResult(), FederationQuarantineOutput{Project: project, Quarantine: *response}, nil
+	return successResult(), FederationQuarantineOutput{Project: project, Quarantine: h.redactQuarantineError(*response)}, nil
 }
 
 func federationEnrollmentSummary(enrollment generated.FederationEnrollmentOut) FederationEnrollmentSummary {

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -45,6 +45,8 @@ type LeaseOutput struct {
 	Ref            string          `json:"ref"`
 	Held           bool            `json:"held"`
 	Granted        bool            `json:"granted,omitempty"`
+	Pending        bool            `json:"pending,omitempty"`
+	RequestUID     string          `json:"request_uid,omitempty"`
 	Holder         string          `json:"holder,omitempty"`
 	PreviousHolder string          `json:"previous_holder,omitempty"`
 	ClaimKind      string          `json:"claim_kind,omitempty"`
@@ -258,8 +260,15 @@ func (h toolHandlers) leaseActionBody(ttlSeconds int64, purpose string) (*genera
 
 func leaseMutationOutput(project ProjectIdentity, ref string, response *generated.ClaimActionResponseBody) LeaseOutput {
 	output := LeaseOutput{
-		Project: project, Ref: project.Name + "#" + ref, Held: response.Lease != nil,
+		Project: project, Ref: project.Name + "#" + ref,
+		Held:    response.Lease != nil && response.Lease.ReleasedAt == nil,
 		Granted: response.Granted, Holder: response.Holder.Holder, Event: eventSummary(response.Event),
+	}
+	if response.Pending != nil {
+		output.Pending = *response.Pending
+	}
+	if response.RequestUID != nil {
+		output.RequestUID = *response.RequestUID
 	}
 	fillLease(&output, response.Lease)
 	return output

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -77,24 +77,6 @@ type FederationStatusOutput struct {
 	Enrollments []FederationEnrollmentSummary       `json:"enrollments"`
 }
 
-// FederationEnrollInput enables a hub project or creates an enrollment.
-type FederationEnrollInput struct {
-	Action                       string `json:"action,omitempty"`
-	Project                      string `json:"project,omitempty"`
-	SpokeInstanceUID             string `json:"spoke_instance_uid,omitempty"`
-	Capabilities                 string `json:"capabilities,omitempty"`
-	Token                        string `json:"token,omitempty"`
-	AllowAdoptionSnapshotAuthors bool   `json:"allow_adoption_snapshot_authors,omitempty"`
-}
-
-// FederationEnrollOutput reports federation metadata or a new enrollment.
-type FederationEnrollOutput struct {
-	Project    ProjectIdentity                  `json:"project"`
-	Metadata   *generated.ProjectFederationBody `json:"metadata,omitempty"`
-	Enrollment *FederationEnrollmentSummary     `json:"enrollment,omitempty"`
-	Token      string                           `json:"token,omitempty"`
-}
-
 // FederationEnrollmentRevokeInput selects an enrollment to revoke.
 type FederationEnrollmentRevokeInput struct {
 	ID int64 `json:"id"`
@@ -188,7 +170,6 @@ func registerFederationTools(server *sdkmcp.Server, handlers toolHandlers) {
 	mutating := toolHints(false, true, true)
 	additive := toolHints(false, false, true)
 	addTool(server, "kata.federation_status", "Federation status", "Read in-scope federation, enrollment, replica, and quarantine status without secrets.", read, handlers.federationStatus)
-	addTool(server, "kata.federation_enroll", "Federation enrollment", "Enable federation for a project or create a spoke enrollment.", additive, handlers.federationEnroll)
 	addTool(server, "kata.federation_enrollment_revoke", "Revoke enrollment", "Revoke a federation enrollment by ID.", mutating, handlers.federationEnrollmentRevoke)
 	addTool(server, "kata.federation_join", "Join federation", "Join or adopt an enrolled hub project as a spoke.", additive, handlers.federationJoin)
 	addTool(server, "kata.federation_rebind", "Rebind federation", "Rebind a spoke to a configured hub catalog entry.", mutating, handlers.federationRebind)
@@ -362,43 +343,6 @@ func (h toolHandlers) federationStatus(ctx context.Context, _ *sdkmcp.CallToolRe
 		enrollments = append(enrollments, federationEnrollmentSummary(item))
 	}
 	return successResult(), FederationStatusOutput{Statuses: statuses, Enrollments: enrollments}, nil
-}
-
-func (h toolHandlers) federationEnroll(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationEnrollInput) (*sdkmcp.CallToolResult, FederationEnrollOutput, error) {
-	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
-	if err != nil {
-		return nil, FederationEnrollOutput{}, err
-	}
-	action := strings.TrimSpace(input.Action)
-	if action == "" {
-		action = "enroll"
-	}
-	if action == "enable" {
-		response, enableErr := h.options.Client.EnableProjectFederation(ctx, &generated.EnableProjectFederationRequestOptions{PathParams: &generated.EnableProjectFederationPath{ProjectID: project.ID}, Body: &generated.EnableProjectFederationBody{Actor: &h.options.Actor}})
-		if enableErr != nil {
-			return nil, FederationEnrollOutput{}, enableErr
-		}
-		return successResult(), FederationEnrollOutput{Project: project, Metadata: response}, nil
-	}
-	if action != "enroll" {
-		return nil, FederationEnrollOutput{}, errors.New("action must be enable or enroll")
-	}
-	if strings.TrimSpace(input.SpokeInstanceUID) == "" || strings.TrimSpace(input.Capabilities) == "" {
-		return nil, FederationEnrollOutput{}, errors.New("enroll requires spoke_instance_uid and capabilities")
-	}
-	response, err := h.options.Client.CreateFederationEnrollment(ctx, &generated.CreateFederationEnrollmentRequestOptions{Body: &generated.CreateFederationEnrollmentBody{
-		Actor: &h.options.Actor, ProjectID: project.ID, SpokeInstanceUID: input.SpokeInstanceUID,
-		Capabilities: input.Capabilities, Token: optionalString(input.Token), AllowAdoptionSnapshotAuthors: optionalTrue(input.AllowAdoptionSnapshotAuthors),
-	}})
-	if err != nil {
-		return nil, FederationEnrollOutput{}, err
-	}
-	summary := federationEnrollmentSummary(*response)
-	output := FederationEnrollOutput{Project: project, Enrollment: &summary}
-	if response.Token != nil {
-		output.Token = *response.Token
-	}
-	return successResult(), output, nil
 }
 
 func (h toolHandlers) federationEnrollmentRevoke(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationEnrollmentRevokeInput) (*sdkmcp.CallToolResult, FederationEnrollmentRevokeOutput, error) {

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -343,6 +343,12 @@ func (h toolHandlers) federationEnrollmentRevoke(ctx context.Context, _ *sdkmcp.
 }
 
 func (h toolHandlers) federationRebind(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationRebindInput) (*sdkmcp.CallToolResult, FederationRebindOutput, error) {
+	// Rebinding routes the replica's enrollment bearer token to whichever
+	// configured catalog origin the caller selects, so it stays an
+	// operator-tier action.
+	if err := h.requireAllProjectsScope("federation rebind"); err != nil {
+		return nil, FederationRebindOutput{}, err
+	}
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
 	if err != nil {
 		return nil, FederationRebindOutput{}, err
@@ -375,7 +381,7 @@ func (h toolHandlers) federationLeave(ctx context.Context, _ *sdkmcp.CallToolReq
 	if disposition == "archive" {
 		// Archiving through leave is project catalog administration; a
 		// scoped server may only detach.
-		if err := h.requireProjectAdminScope("federation leave with the archive disposition"); err != nil {
+		if err := h.requireAllProjectsScope("federation leave with the archive disposition"); err != nil {
 			return nil, FederationLeaveOutput{}, err
 		}
 	}

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -225,7 +225,7 @@ func (h toolHandlers) leaseSteal(ctx context.Context, _ *sdkmcp.CallToolRequest,
 		return nil, LeaseOutput{}, err
 	}
 	previous := status.Holder
-	if status.Held && status.Holder != h.options.Actor {
+	if status.Held {
 		if _, _, err := h.leaseForceRelease(ctx, nil, LeaseForceReleaseInput{Ref: input.Ref, Reason: input.Reason}); err != nil {
 			return nil, LeaseOutput{}, err
 		}
@@ -237,6 +237,12 @@ func (h toolHandlers) leaseSteal(ctx context.Context, _ *sdkmcp.CallToolRequest,
 		return nil, LeaseOutput{}, err
 	}
 	acquired.PreviousHolder = previous
+	if !acquired.Granted && !acquired.Pending {
+		if !status.Held {
+			return nil, LeaseOutput{}, fmt.Errorf("lease steal acquisition was denied for %s", acquired.Ref)
+		}
+		return nil, LeaseOutput{}, fmt.Errorf("lease steal force-release succeeded but lease acquisition was denied for %s", acquired.Ref)
+	}
 	return successResult(), acquired, nil
 }
 

--- a/internal/mcp/federation.go
+++ b/internal/mcp/federation.go
@@ -1,0 +1,548 @@
+package mcpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// LeaseStatusInput selects an issue lease to inspect.
+type LeaseStatusInput struct {
+	Ref string `json:"ref"`
+}
+
+// LeaseInput selects a lease action for the startup actor.
+type LeaseInput struct {
+	Ref        string `json:"ref"`
+	Action     string `json:"action"`
+	TTLSeconds int64  `json:"ttl_seconds,omitempty"`
+	Purpose    string `json:"purpose,omitempty"`
+}
+
+// LeaseForceReleaseInput selects a lease for administrative release.
+type LeaseForceReleaseInput struct {
+	Ref    string `json:"ref"`
+	Reason string `json:"reason"`
+}
+
+// LeaseStealInput selects a lease for resumable takeover.
+type LeaseStealInput struct {
+	Ref        string `json:"ref"`
+	Reason     string `json:"reason"`
+	TTLSeconds int64  `json:"ttl_seconds,omitempty"`
+	Purpose    string `json:"purpose,omitempty"`
+}
+
+// LeaseOutput reports current lease state.
+type LeaseOutput struct {
+	Project        ProjectIdentity `json:"project"`
+	Ref            string          `json:"ref"`
+	Held           bool            `json:"held"`
+	Granted        bool            `json:"granted,omitempty"`
+	Holder         string          `json:"holder,omitempty"`
+	PreviousHolder string          `json:"previous_holder,omitempty"`
+	ClaimKind      string          `json:"claim_kind,omitempty"`
+	Purpose        string          `json:"purpose,omitempty"`
+	ExpiresAt      string          `json:"expires_at,omitempty"`
+	Revision       int64           `json:"revision,omitempty"`
+	Event          *EventSummary   `json:"event,omitempty"`
+}
+
+// FederationStatusInput requests scoped federation status.
+type FederationStatusInput struct{}
+
+// FederationEnrollmentSummary is a secret-free enrollment record.
+type FederationEnrollmentSummary struct {
+	ID               int64  `json:"id"`
+	ProjectID        int64  `json:"project_id,omitempty"`
+	SpokeInstanceUID string `json:"spoke_instance_uid"`
+	Capabilities     string `json:"capabilities"`
+	Actor            string `json:"actor"`
+	Revoked          bool   `json:"revoked"`
+}
+
+// FederationStatusOutput contains scoped federation status and enrollments.
+type FederationStatusOutput struct {
+	Statuses    []generated.FederationProjectStatus `json:"statuses"`
+	Enrollments []FederationEnrollmentSummary       `json:"enrollments"`
+}
+
+// FederationEnrollInput enables a hub project or creates an enrollment.
+type FederationEnrollInput struct {
+	Action                       string `json:"action,omitempty"`
+	Project                      string `json:"project,omitempty"`
+	SpokeInstanceUID             string `json:"spoke_instance_uid,omitempty"`
+	Capabilities                 string `json:"capabilities,omitempty"`
+	Token                        string `json:"token,omitempty"`
+	AllowAdoptionSnapshotAuthors bool   `json:"allow_adoption_snapshot_authors,omitempty"`
+}
+
+// FederationEnrollOutput reports federation metadata or a new enrollment.
+type FederationEnrollOutput struct {
+	Project    ProjectIdentity                  `json:"project"`
+	Metadata   *generated.ProjectFederationBody `json:"metadata,omitempty"`
+	Enrollment *FederationEnrollmentSummary     `json:"enrollment,omitempty"`
+	Token      string                           `json:"token,omitempty"`
+}
+
+// FederationEnrollmentRevokeInput selects an enrollment to revoke.
+type FederationEnrollmentRevokeInput struct {
+	ID int64 `json:"id"`
+}
+
+// FederationEnrollmentRevokeOutput reports enrollment revocation.
+type FederationEnrollmentRevokeOutput struct {
+	ID      int64 `json:"id"`
+	Revoked bool  `json:"revoked"`
+}
+
+// FederationJoinInput carries one hub enrollment into a spoke join.
+type FederationJoinInput struct {
+	ProjectName            string `json:"project_name"`
+	HubURL                 string `json:"hub_url"`
+	HubProjectID           int64  `json:"hub_project_id"`
+	HubProjectUID          string `json:"hub_project_uid"`
+	ReplayHorizonEventID   int64  `json:"replay_horizon_event_id,omitempty"`
+	BaselineThroughEventID int64  `json:"baseline_through_event_id,omitempty"`
+	Token                  string `json:"token,omitempty"`
+	Capabilities           string `json:"capabilities,omitempty"`
+	AllowInsecure          bool   `json:"allow_insecure,omitempty"`
+	PushEnabled            bool   `json:"push_enabled,omitempty"`
+	AdoptExisting          bool   `json:"adopt_existing,omitempty"`
+}
+
+// FederationJoinOutput reports the created or adopted spoke binding.
+type FederationJoinOutput struct {
+	Project ProjectSummary                 `json:"project"`
+	Binding generated.FederationBindingOut `json:"binding"`
+	Adopted bool                           `json:"adopted,omitempty"`
+}
+
+// FederationRebindInput selects a spoke and configured hub catalog entry.
+type FederationRebindInput struct {
+	Project    string `json:"project"`
+	HubCatalog string `json:"hub_catalog"`
+}
+
+// FederationRebindOutput reports a completed spoke rebind.
+type FederationRebindOutput struct {
+	Result generated.RebindFederationReplicaResponseBody `json:"result"`
+}
+
+// FederationLeaveInput selects one resumable leave phase.
+type FederationLeaveInput struct {
+	Project     string `json:"project"`
+	Phase       string `json:"phase"`
+	Disposition string `json:"disposition,omitempty"`
+	Force       bool   `json:"force,omitempty"`
+	Confirm     string `json:"confirm,omitempty"`
+}
+
+// FederationLeaveOutput reports a federation leave phase.
+type FederationLeaveOutput struct {
+	Project           ProjectSummary                                `json:"project"`
+	Phase             string                                        `json:"phase"`
+	Disposition       string                                        `json:"disposition"`
+	Detached          bool                                          `json:"detached"`
+	Archived          bool                                          `json:"archived,omitempty"`
+	PendingEnrollment *generated.PendingFederationEnrollmentCleanup `json:"pending_enrollment,omitempty"`
+}
+
+// FederationQuarantineInput selects a quarantine resolution action.
+type FederationQuarantineInput struct {
+	Project string `json:"project"`
+	ID      int64  `json:"id"`
+	Action  string `json:"action"`
+	Confirm string `json:"confirm"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// FederationQuarantineOutput reports the updated quarantine batch.
+type FederationQuarantineOutput struct {
+	Project    ProjectIdentity                       `json:"project"`
+	Quarantine generated.FederationQuarantineSummary `json:"quarantine"`
+}
+
+func registerLeaseTools(server *sdkmcp.Server, handlers toolHandlers) {
+	read := toolHints(true, false, false)
+	additive := toolHints(false, false, false)
+	destructive := toolHints(false, true, false)
+	addTool(server, "kata.lease", "Manage lease", "Acquire, renew, or release the startup actor's federation write lease.", additive, handlers.lease)
+	addTool(server, "kata.lease_force_release", "Force-release lease", "Administratively release another lease with a reason.", destructive, handlers.leaseForceRelease)
+	addTool(server, "kata.lease_status", "Lease status", "Read the current federation write lease for an issue.", read, handlers.leaseStatus)
+	addTool(server, "kata.lease_steal", "Steal lease", "Resumably force-release and acquire a lease as the startup actor.", destructive, handlers.leaseSteal)
+}
+
+func registerFederationTools(server *sdkmcp.Server, handlers toolHandlers) {
+	read := toolHints(true, false, true)
+	mutating := toolHints(false, true, true)
+	additive := toolHints(false, false, true)
+	addTool(server, "kata.federation_status", "Federation status", "Read in-scope federation, enrollment, replica, and quarantine status without secrets.", read, handlers.federationStatus)
+	addTool(server, "kata.federation_enroll", "Federation enrollment", "Enable federation for a project or create a spoke enrollment.", additive, handlers.federationEnroll)
+	addTool(server, "kata.federation_enrollment_revoke", "Revoke enrollment", "Revoke a federation enrollment by ID.", mutating, handlers.federationEnrollmentRevoke)
+	addTool(server, "kata.federation_join", "Join federation", "Join or adopt an enrolled hub project as a spoke.", additive, handlers.federationJoin)
+	addTool(server, "kata.federation_rebind", "Rebind federation", "Rebind a spoke to a configured hub catalog entry.", mutating, handlers.federationRebind)
+	addTool(server, "kata.federation_leave", "Leave federation", "Run the preflight, prepare, or commit phase of resumable federation leave.", mutating, handlers.federationLeave)
+	addTool(server, "kata.federation_quarantine", "Resolve quarantine", "Retry or skip a federation quarantine batch after exact confirmation.", mutating, handlers.federationQuarantine)
+}
+
+func (h toolHandlers) leaseStatus(ctx context.Context, _ *sdkmcp.CallToolRequest, input LeaseStatusInput) (*sdkmcp.CallToolResult, LeaseOutput, error) {
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, false)
+	if err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	response, err := h.options.Client.GetIssueLeaseStatus(ctx, &generated.GetIssueLeaseStatusRequestOptions{
+		PathParams: &generated.GetIssueLeaseStatusPath{ProjectID: project.ID, Ref: ref},
+	})
+	if err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	output := LeaseOutput{Project: project, Ref: project.Name + "#" + ref, Held: response.Held, Holder: response.Holder.Holder}
+	fillLease(&output, response.Lease)
+	return successResult(), output, nil
+}
+
+func (h toolHandlers) lease(ctx context.Context, _ *sdkmcp.CallToolRequest, input LeaseInput) (*sdkmcp.CallToolResult, LeaseOutput, error) {
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
+	if err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	body, err := h.leaseActionBody(input.TTLSeconds, input.Purpose)
+	if err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	var response *generated.ClaimActionResponseBody
+	switch input.Action {
+	case "acquire":
+		response, err = h.options.Client.AcquireIssueLease(ctx, &generated.AcquireIssueLeaseRequestOptions{
+			PathParams: &generated.AcquireIssueLeasePath{ProjectID: project.ID, Ref: ref}, Body: body,
+		})
+	case "renew":
+		response, err = h.options.Client.RenewIssueLease(ctx, &generated.RenewIssueLeaseRequestOptions{
+			PathParams: &generated.RenewIssueLeasePath{ProjectID: project.ID, Ref: ref}, Body: body,
+		})
+	case "release":
+		response, err = h.options.Client.ReleaseIssueLease(ctx, &generated.ReleaseIssueLeaseRequestOptions{
+			PathParams: &generated.ReleaseIssueLeasePath{ProjectID: project.ID, Ref: ref}, Body: body,
+		})
+	default:
+		return nil, LeaseOutput{}, errors.New("action must be acquire, renew, or release")
+	}
+	if err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	return successResult(), leaseMutationOutput(project, ref, response), nil
+}
+
+func (h toolHandlers) leaseForceRelease(ctx context.Context, _ *sdkmcp.CallToolRequest, input LeaseForceReleaseInput) (*sdkmcp.CallToolResult, LeaseOutput, error) {
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
+	if err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	reason := strings.TrimSpace(input.Reason)
+	if reason == "" {
+		return nil, LeaseOutput{}, errors.New("reason is required")
+	}
+	clientKind := "mcp"
+	response, err := h.options.Client.ForceReleaseIssueLease(ctx, &generated.ForceReleaseIssueLeaseRequestOptions{
+		PathParams: &generated.ForceReleaseIssueLeasePath{ProjectID: project.ID, Ref: ref},
+		Body:       &generated.ForceReleaseIssueLeaseBody{Actor: &h.options.Actor, Reason: &reason, ClientKind: &clientKind},
+	})
+	if err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	return successResult(), leaseMutationOutput(project, ref, response), nil
+}
+
+func (h toolHandlers) leaseSteal(ctx context.Context, _ *sdkmcp.CallToolRequest, input LeaseStealInput) (*sdkmcp.CallToolResult, LeaseOutput, error) {
+	statusResult, status, err := h.leaseStatus(ctx, nil, LeaseStatusInput{Ref: input.Ref})
+	_ = statusResult
+	if err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	previous := status.Holder
+	if status.Held && status.Holder != h.options.Actor {
+		if _, _, err := h.leaseForceRelease(ctx, nil, LeaseForceReleaseInput{Ref: input.Ref, Reason: input.Reason}); err != nil {
+			return nil, LeaseOutput{}, err
+		}
+	}
+	_, acquired, err := h.lease(ctx, nil, LeaseInput{
+		Ref: input.Ref, Action: "acquire", TTLSeconds: input.TTLSeconds, Purpose: input.Purpose,
+	})
+	if err != nil {
+		return nil, LeaseOutput{}, err
+	}
+	acquired.PreviousHolder = previous
+	return successResult(), acquired, nil
+}
+
+func (h toolHandlers) leaseActionBody(ttlSeconds int64, purpose string) (*generated.ClaimActionBody, error) {
+	if ttlSeconds != 0 && (ttlSeconds < 60 || ttlSeconds > int64((24*time.Hour)/time.Second)) {
+		return nil, errors.New("ttl_seconds must be between 60 and 86400 when set")
+	}
+	holder := h.options.Actor
+	clientKind := "mcp"
+	claimKind := "hard"
+	var ttl *int64
+	if ttlSeconds > 0 {
+		claimKind = "timed"
+		ttl = &ttlSeconds
+	}
+	return &generated.ClaimActionBody{
+		Holder: &holder, ClientKind: &clientKind, ClaimKind: &claimKind,
+		TTLSeconds: ttl, Purpose: optionalString(purpose),
+	}, nil
+}
+
+func leaseMutationOutput(project ProjectIdentity, ref string, response *generated.ClaimActionResponseBody) LeaseOutput {
+	output := LeaseOutput{
+		Project: project, Ref: project.Name + "#" + ref, Held: response.Lease != nil,
+		Granted: response.Granted, Holder: response.Holder.Holder, Event: eventSummary(response.Event),
+	}
+	fillLease(&output, response.Lease)
+	return output
+}
+
+func fillLease(output *LeaseOutput, lease *generated.IssueClaimOut) {
+	if lease == nil {
+		return
+	}
+	output.Holder = lease.Holder
+	output.ClaimKind = lease.ClaimKind
+	output.Purpose = lease.Purpose
+	output.Revision = lease.Revision
+	if lease.ExpiresAt != nil {
+		output.ExpiresAt = formatTime(*lease.ExpiresAt)
+	}
+}
+
+func (h toolHandlers) federationStatus(ctx context.Context, _ *sdkmcp.CallToolRequest, _ FederationStatusInput) (*sdkmcp.CallToolResult, FederationStatusOutput, error) {
+	projects, err := h.options.Scope.Projects(ctx, h.options.Client, false)
+	if err != nil {
+		return nil, FederationStatusOutput{}, err
+	}
+	allowed := make(map[int64]struct{}, len(projects))
+	for _, project := range projects {
+		allowed[project.ID] = struct{}{}
+	}
+	status, err := h.options.Client.GetFederationStatus(ctx, &generated.GetFederationStatusRequestOptions{})
+	if err != nil {
+		return nil, FederationStatusOutput{}, err
+	}
+	statuses := make([]generated.FederationProjectStatus, 0, len(status.Statuses))
+	for _, item := range status.Statuses {
+		if _, ok := allowed[item.ProjectID]; ok {
+			statuses = append(statuses, item)
+		}
+	}
+	list, err := h.options.Client.ListFederationEnrollments(ctx)
+	if err != nil {
+		return nil, FederationStatusOutput{}, err
+	}
+	enrollments := make([]FederationEnrollmentSummary, 0, len(list.Enrollments))
+	for _, item := range list.Enrollments {
+		if item.ProjectID == 0 && h.options.Scope.Mode() != ScopeAll {
+			continue
+		}
+		if item.ProjectID != 0 {
+			if _, ok := allowed[item.ProjectID]; !ok {
+				continue
+			}
+		}
+		enrollments = append(enrollments, federationEnrollmentSummary(item))
+	}
+	return successResult(), FederationStatusOutput{Statuses: statuses, Enrollments: enrollments}, nil
+}
+
+func (h toolHandlers) federationEnroll(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationEnrollInput) (*sdkmcp.CallToolResult, FederationEnrollOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
+	if err != nil {
+		return nil, FederationEnrollOutput{}, err
+	}
+	action := strings.TrimSpace(input.Action)
+	if action == "" {
+		action = "enroll"
+	}
+	if action == "enable" {
+		response, enableErr := h.options.Client.EnableProjectFederation(ctx, &generated.EnableProjectFederationRequestOptions{PathParams: &generated.EnableProjectFederationPath{ProjectID: project.ID}, Body: &generated.EnableProjectFederationBody{Actor: &h.options.Actor}})
+		if enableErr != nil {
+			return nil, FederationEnrollOutput{}, enableErr
+		}
+		return successResult(), FederationEnrollOutput{Project: project, Metadata: response}, nil
+	}
+	if action != "enroll" {
+		return nil, FederationEnrollOutput{}, errors.New("action must be enable or enroll")
+	}
+	if strings.TrimSpace(input.SpokeInstanceUID) == "" || strings.TrimSpace(input.Capabilities) == "" {
+		return nil, FederationEnrollOutput{}, errors.New("enroll requires spoke_instance_uid and capabilities")
+	}
+	response, err := h.options.Client.CreateFederationEnrollment(ctx, &generated.CreateFederationEnrollmentRequestOptions{Body: &generated.CreateFederationEnrollmentBody{
+		Actor: &h.options.Actor, ProjectID: project.ID, SpokeInstanceUID: input.SpokeInstanceUID,
+		Capabilities: input.Capabilities, Token: optionalString(input.Token), AllowAdoptionSnapshotAuthors: optionalTrue(input.AllowAdoptionSnapshotAuthors),
+	}})
+	if err != nil {
+		return nil, FederationEnrollOutput{}, err
+	}
+	summary := federationEnrollmentSummary(*response)
+	output := FederationEnrollOutput{Project: project, Enrollment: &summary}
+	if response.Token != nil {
+		output.Token = *response.Token
+	}
+	return successResult(), output, nil
+}
+
+func (h toolHandlers) federationEnrollmentRevoke(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationEnrollmentRevokeInput) (*sdkmcp.CallToolResult, FederationEnrollmentRevokeOutput, error) {
+	if input.ID <= 0 {
+		return nil, FederationEnrollmentRevokeOutput{}, errors.New("id must be positive")
+	}
+	// Resolve and scope the enrollment before revocation.
+	_, status, err := h.federationStatus(ctx, nil, FederationStatusInput{})
+	if err != nil {
+		return nil, FederationEnrollmentRevokeOutput{}, err
+	}
+	allowed := false
+	for _, enrollment := range status.Enrollments {
+		if enrollment.ID == input.ID {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return nil, FederationEnrollmentRevokeOutput{}, errors.New("enrollment is outside the MCP startup scope")
+	}
+	response, err := h.options.Client.RevokeFederationEnrollment(ctx, &generated.RevokeFederationEnrollmentRequestOptions{PathParams: &generated.RevokeFederationEnrollmentPath{EnrollmentID: input.ID}})
+	if err != nil {
+		return nil, FederationEnrollmentRevokeOutput{}, err
+	}
+	return successResult(), FederationEnrollmentRevokeOutput{ID: response.ID, Revoked: response.Revoked}, nil
+}
+
+func (h toolHandlers) federationJoin(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationJoinInput) (*sdkmcp.CallToolResult, FederationJoinOutput, error) {
+	projectName := strings.TrimSpace(input.ProjectName)
+	if projectName == "" || strings.TrimSpace(input.HubURL) == "" || input.HubProjectID <= 0 || strings.TrimSpace(input.HubProjectUID) == "" {
+		return nil, FederationJoinOutput{}, errors.New("project_name, hub_url, hub_project_id, and hub_project_uid are required")
+	}
+	if h.options.Scope.Mode() != ScopeAll {
+		if _, err := h.options.Scope.Project(ctx, h.options.Client, projectName, false); err != nil {
+			return nil, FederationJoinOutput{}, err
+		}
+	}
+	body := generated.CreateFederationReplicaRequestBody{
+		Actor: &h.options.Actor, ProjectName: projectName, HubURL: input.HubURL, HubProjectID: input.HubProjectID,
+		HubProjectUID: input.HubProjectUID, ReplayHorizonEventID: input.ReplayHorizonEventID,
+		BaselineThroughEventID: optionalInt64(input.BaselineThroughEventID), Token: optionalString(input.Token),
+		Capabilities: optionalString(input.Capabilities), AllowInsecure: optionalTrue(input.AllowInsecure), PushEnabled: optionalTrue(input.PushEnabled), AdoptExisting: optionalTrue(input.AdoptExisting),
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, FederationJoinOutput{}, err
+	}
+	response, err := h.options.Client.CreateFederationReplica(ctx, &generated.CreateFederationReplicaRequestOptions{}, func(_ context.Context, request *http.Request) error {
+		request.Body = io.NopCloser(bytes.NewReader(payload))
+		request.ContentLength = int64(len(payload))
+		request.Header.Set("Content-Type", "application/json")
+		return nil
+	})
+	if err != nil {
+		return nil, FederationJoinOutput{}, err
+	}
+	adopted := response.Adopted != nil && *response.Adopted
+	return successResult(), FederationJoinOutput{Project: projectSummaryOut(response.Project), Binding: response.Binding, Adopted: adopted}, nil
+}
+
+func (h toolHandlers) federationRebind(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationRebindInput) (*sdkmcp.CallToolResult, FederationRebindOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
+	if err != nil {
+		return nil, FederationRebindOutput{}, err
+	}
+	if strings.TrimSpace(input.HubCatalog) == "" {
+		return nil, FederationRebindOutput{}, errors.New("hub_catalog is required")
+	}
+	response, err := h.options.Client.RebindFederationReplica(ctx, &generated.RebindFederationReplicaRequestOptions{PathParams: &generated.RebindFederationReplicaPath{ProjectID: project.ID}, Body: &generated.RebindFederationReplicaBody{HubCatalog: input.HubCatalog}})
+	if err != nil {
+		return nil, FederationRebindOutput{}, err
+	}
+	return successResult(), FederationRebindOutput{Result: *response}, nil
+}
+
+func (h toolHandlers) federationLeave(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationLeaveInput) (*sdkmcp.CallToolResult, FederationLeaveOutput, error) {
+	phase := strings.TrimSpace(input.Phase)
+	if phase == "" {
+		return nil, FederationLeaveOutput{}, errors.New("phase is required")
+	}
+	if phase != "preflight" && phase != "prepare" && phase != "commit" {
+		return nil, FederationLeaveOutput{}, errors.New("phase must be preflight, prepare, or commit")
+	}
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
+	if err != nil {
+		return nil, FederationLeaveOutput{}, err
+	}
+	disposition := strings.TrimSpace(input.Disposition)
+	if disposition == "" {
+		disposition = "detach"
+	}
+	if disposition != "detach" && disposition != "archive" {
+		return nil, FederationLeaveOutput{}, errors.New("disposition must be detach or archive")
+	}
+	if phase == "commit" {
+		expected := "COMMIT FEDERATION LEAVE " + project.Name
+		if input.Confirm != expected {
+			return nil, FederationLeaveOutput{}, fmt.Errorf("confirm must equal %q", expected)
+		}
+	}
+	preflight, prepare := phase == "preflight", phase == "prepare"
+	response, err := h.options.Client.LeaveFederationReplica(ctx, &generated.LeaveFederationReplicaRequestOptions{PathParams: &generated.LeaveFederationReplicaPath{ProjectID: project.ID}, Body: &generated.LeaveFederationReplicaBody{Actor: &h.options.Actor, Disposition: &disposition, Force: optionalTrue(input.Force), Preflight: optionalTrue(preflight), Prepare: optionalTrue(prepare)}})
+	if err != nil {
+		return nil, FederationLeaveOutput{}, err
+	}
+	archived := response.Archived != nil && *response.Archived
+	return successResult(), FederationLeaveOutput{Project: projectSummaryOut(response.Project), Phase: phase, Disposition: response.Disposition, Detached: response.Detached, Archived: archived, PendingEnrollment: response.PendingEnrollment}, nil
+}
+
+func (h toolHandlers) federationQuarantine(ctx context.Context, _ *sdkmcp.CallToolRequest, input FederationQuarantineInput) (*sdkmcp.CallToolResult, FederationQuarantineOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
+	if err != nil {
+		return nil, FederationQuarantineOutput{}, err
+	}
+	if input.ID <= 0 {
+		return nil, FederationQuarantineOutput{}, errors.New("id must be positive")
+	}
+	expected := strings.ToUpper(input.Action) + fmt.Sprintf(" FEDERATION BATCH %d", input.ID)
+	if input.Action != "retry" && input.Action != "skip" {
+		return nil, FederationQuarantineOutput{}, errors.New("action must be retry or skip")
+	}
+	if input.Confirm != expected {
+		return nil, FederationQuarantineOutput{}, fmt.Errorf("confirm must equal %q", expected)
+	}
+	var response *generated.FederationQuarantineSummary
+	if input.Action == "retry" {
+		response, err = h.options.Client.RetryFederationQuarantine(ctx, &generated.RetryFederationQuarantineRequestOptions{PathParams: &generated.RetryFederationQuarantinePath{ProjectID: project.ID, QuarantineID: input.ID}, Body: &generated.RetryFederationQuarantineBody{Actor: h.options.Actor, Reason: optionalString(input.Reason)}, Header: &generated.RetryFederationQuarantineHeaders{XKataConfirm: &expected}})
+	} else {
+		response, err = h.options.Client.SkipFederationQuarantine(ctx, &generated.SkipFederationQuarantineRequestOptions{PathParams: &generated.SkipFederationQuarantinePath{ProjectID: project.ID, QuarantineID: input.ID}, Body: &generated.SkipFederationQuarantineBody{Actor: h.options.Actor, Reason: optionalString(input.Reason)}, Header: &generated.SkipFederationQuarantineHeaders{XKataConfirm: &expected}})
+	}
+	if err != nil {
+		return nil, FederationQuarantineOutput{}, err
+	}
+	return successResult(), FederationQuarantineOutput{Project: project, Quarantine: *response}, nil
+}
+
+func federationEnrollmentSummary(enrollment generated.FederationEnrollmentOut) FederationEnrollmentSummary {
+	return FederationEnrollmentSummary{ID: enrollment.ID, ProjectID: enrollment.ProjectID, SpokeInstanceUID: enrollment.SpokeInstanceUID, Capabilities: enrollment.Capabilities, Actor: enrollment.Actor, Revoked: enrollment.RevokedAt != nil}
+}
+
+func optionalInt64(value int64) *int64 {
+	if value == 0 {
+		return nil
+	}
+	return &value
+}

--- a/internal/mcp/federation_test.go
+++ b/internal/mcp/federation_test.go
@@ -87,19 +87,152 @@ func TestLeaseQueuedAcquireReportsPendingRequest(t *testing.T) {
 	require.Equal(t, requestUID, fields["request_uid"])
 }
 
+func TestLeaseStealForceReleasesHeldLeaseForSameActorDifferentClient(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	forced := false
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "/lease"):
+			writeJSON(writer, generated.ClaimStatusBody{
+				Held: true, HubNow: now,
+				Holder: generated.ClaimPrincipalOut{
+					Holder: "example-agent", HolderInstanceUID: "01HCCCCCCCCCCCCCCCCCCCCCCC", ClientKind: "cli",
+				},
+				Lease: leaseRecord("example-agent", "cli", nil),
+			})
+		case strings.HasSuffix(request.URL.Path, "/actions/force_release"):
+			forced = true
+			writeJSON(writer, releasedLeaseResponse(now))
+		case strings.HasSuffix(request.URL.Path, "/actions/acquire"):
+			if !forced {
+				writeJSON(writer, generated.ClaimActionResponseBody{
+					Granted: false,
+					Holder: generated.ClaimPrincipalOut{
+						Holder: "example-agent", HolderInstanceUID: "01HCCCCCCCCCCCCCCCCCCCCCCC", ClientKind: "cli",
+					},
+					Lease: leaseRecord("example-agent", "cli", nil),
+				})
+				return
+			}
+			writeJSON(writer, generated.ClaimActionResponseBody{
+				Granted: true,
+				Holder: generated.ClaimPrincipalOut{
+					Holder: "example-agent", HolderInstanceUID: "01HMMMMMMMMMMMMMMMMMMMMMMM", ClientKind: "mcp",
+				},
+				Lease: leaseRecord("example-agent", "mcp", nil),
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+
+	_, output, err := handlers.leaseSteal(t.Context(), nil, LeaseStealInput{
+		Ref: "abc4", Reason: "switch clients",
+	})
+	require.NoError(t, err)
+	require.True(t, forced)
+	require.True(t, output.Granted)
+	require.True(t, output.Held)
+	require.Equal(t, "example-agent", output.PreviousHolder)
+}
+
+func TestLeaseStealRejectsNonPendingDeniedAcquire(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	pending := false
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "/lease"):
+			writeJSON(writer, generated.ClaimStatusBody{
+				Held: false, HubNow: now,
+				Holder: generated.ClaimPrincipalOut{
+					Holder: "user-a", HolderInstanceUID: "01HUUUUUUUUUUUUUUUUUUUUUUU", ClientKind: "cli",
+				},
+			})
+		case strings.HasSuffix(request.URL.Path, "/actions/acquire"):
+			writeJSON(writer, generated.ClaimActionResponseBody{
+				Granted: false, Pending: &pending,
+				Holder: generated.ClaimPrincipalOut{
+					Holder: "user-b", HolderInstanceUID: "01HBBBBBBBBBBBBBBBBBBBBBBB", ClientKind: "cli",
+				},
+				Lease: leaseRecord("user-b", "cli", nil),
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+
+	_, _, err = handlers.leaseSteal(t.Context(), nil, LeaseStealInput{
+		Ref: "abc4", Reason: "operator handoff",
+	})
+	require.ErrorContains(t, err, "lease steal acquisition was denied")
+}
+
+func TestLeaseStealAllowsPendingAcquire(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	pending := true
+	requestUID := "01HQQQQQQQQQQQQQQQQQQQQQQQ"
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "/lease"):
+			writeJSON(writer, generated.ClaimStatusBody{
+				Held: true, HubNow: now,
+				Holder: generated.ClaimPrincipalOut{
+					Holder: "user-a", HolderInstanceUID: "01HUUUUUUUUUUUUUUUUUUUUUUU", ClientKind: "cli",
+				},
+				Lease: leaseRecord("user-a", "cli", nil),
+			})
+		case strings.HasSuffix(request.URL.Path, "/actions/force_release"):
+			writeJSON(writer, releasedLeaseResponse(now))
+		case strings.HasSuffix(request.URL.Path, "/actions/acquire"):
+			writeJSON(writer, generated.ClaimActionResponseBody{
+				Granted: false, Pending: &pending, RequestUID: &requestUID,
+				Holder: generated.ClaimPrincipalOut{
+					Holder: "example-agent", HolderInstanceUID: "01HMMMMMMMMMMMMMMMMMMMMMMM", ClientKind: "mcp",
+				},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+
+	_, output, err := handlers.leaseSteal(t.Context(), nil, LeaseStealInput{
+		Ref: "abc4", Reason: "operator handoff",
+	})
+	require.NoError(t, err)
+	require.True(t, output.Pending)
+	require.Equal(t, requestUID, output.RequestUID)
+	require.False(t, output.Granted)
+}
+
 func releasedLeaseResponse(releasedAt time.Time) generated.ClaimActionResponseBody {
-	lease := &generated.IssueClaimOut{
-		AcquiredAt: time.Date(2026, 8, 14, 11, 0, 0, 0, time.UTC),
-		ClaimKind:  "hard", ClaimUID: "01HCCCCCCCCCCCCCCCCCCCCCCC", ClientKind: "mcp",
-		Holder: "example-agent", HolderInstanceUID: "01HIIIIIIIIIIIIIIIIIIIIIII",
-		IssueUID: "01HSSSSSSSSSSSSSSSSSSSSSSS", ProjectID: 1, Purpose: "work",
-		ReleasedAt: &releasedAt, Revision: 2, UpdatedAt: releasedAt,
-	}
+	lease := leaseRecord("example-agent", "mcp", &releasedAt)
+	lease.Revision = 2
+	lease.UpdatedAt = releasedAt
 	return generated.ClaimActionResponseBody{
 		Granted: true,
 		Holder: generated.ClaimPrincipalOut{
 			Holder: "example-agent", HolderInstanceUID: "01HIIIIIIIIIIIIIIIIIIIIIII", ClientKind: "mcp",
 		},
 		Lease: lease,
+	}
+}
+
+func leaseRecord(holder, clientKind string, releasedAt *time.Time) *generated.IssueClaimOut {
+	return &generated.IssueClaimOut{
+		AcquiredAt: time.Date(2026, 8, 14, 11, 0, 0, 0, time.UTC),
+		ClaimKind:  "hard", ClaimUID: "01HCCCCCCCCCCCCCCCCCCCCCCC", ClientKind: clientKind,
+		Holder: holder, HolderInstanceUID: "01HIIIIIIIIIIIIIIIIIIIIIII",
+		IssueUID: "01HSSSSSSSSSSSSSSSSSSSSSSS", ProjectID: 1, Purpose: "work",
+		ReleasedAt: releasedAt, Revision: 1,
+		UpdatedAt: time.Date(2026, 8, 14, 11, 0, 0, 0, time.UTC),
 	}
 }

--- a/internal/mcp/federation_test.go
+++ b/internal/mcp/federation_test.go
@@ -1,0 +1,20 @@
+package mcpserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaseToolsArePublished(t *testing.T) {
+	session := connectTestServer(t)
+	result, err := session.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, tool := range result.Tools {
+		names[tool.Name] = true
+	}
+	for _, name := range []string{"kata.lease", "kata.lease_force_release", "kata.lease_status", "kata.lease_steal"} {
+		require.True(t, names[name], name)
+	}
+}

--- a/internal/mcp/federation_test.go
+++ b/internal/mcp/federation_test.go
@@ -142,16 +142,15 @@ func TestLeaseStealForceReleasesHeldLeaseForSameActorDifferentClient(t *testing.
 func TestLeaseStealRejectsNonPendingDeniedAcquire(t *testing.T) {
 	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
 	pending := false
+	var forced, acquires int
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		switch {
-		case request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "/lease"):
-			writeJSON(writer, generated.ClaimStatusBody{
-				Held: false, HubNow: now,
-				Holder: generated.ClaimPrincipalOut{
-					Holder: "user-a", HolderInstanceUID: "01HUUUUUUUUUUUUUUUUUUUUUUU", ClientKind: "cli",
-				},
-			})
+		case strings.HasSuffix(request.URL.Path, "/actions/force_release"):
+			forced++
+			writeJSON(writer, releasedLeaseResponse(now))
 		case strings.HasSuffix(request.URL.Path, "/actions/acquire"):
+			acquires++
+			// A racing claimant wins both before and after the force-release.
 			writeJSON(writer, generated.ClaimActionResponseBody{
 				Granted: false, Pending: &pending,
 				Holder: generated.ClaimPrincipalOut{
@@ -170,7 +169,46 @@ func TestLeaseStealRejectsNonPendingDeniedAcquire(t *testing.T) {
 	_, _, err = handlers.leaseSteal(t.Context(), nil, LeaseStealInput{
 		Ref: "abc4", Reason: "operator handoff",
 	})
-	require.ErrorContains(t, err, "lease steal acquisition was denied")
+	require.ErrorContains(t, err, "force-release succeeded but lease acquisition was denied")
+	require.Equal(t, 1, forced)
+	require.Equal(t, 2, acquires)
+}
+
+// TestLeaseStealRetryKeepsOwnLease covers a retry after a lost response: the
+// startup principal already holds the lease, so the steal must re-grant it
+// without a force-release that would open a window for another claimant.
+func TestLeaseStealRetryKeepsOwnLease(t *testing.T) {
+	var forced int
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case strings.HasSuffix(request.URL.Path, "/actions/force_release"):
+			forced++
+			http.Error(writer, "must not force-release an owned lease", http.StatusInternalServerError)
+		case strings.HasSuffix(request.URL.Path, "/actions/acquire"):
+			// The daemon re-grants an acquire from the principal that already holds it.
+			writeJSON(writer, generated.ClaimActionResponseBody{
+				Granted: true,
+				Holder: generated.ClaimPrincipalOut{
+					Holder: "example-agent", HolderInstanceUID: "01HIIIIIIIIIIIIIIIIIIIIIII", ClientKind: "mcp",
+				},
+				Lease: leaseRecord("example-agent", "mcp", nil),
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+
+	_, output, err := handlers.leaseSteal(t.Context(), nil, LeaseStealInput{
+		Ref: "abc4", Reason: "operator handoff",
+	})
+	require.NoError(t, err)
+	require.Zero(t, forced, "a lease already held by the startup principal must not be released")
+	require.True(t, output.Granted)
+	require.True(t, output.Held)
+	require.Empty(t, output.PreviousHolder, "no holder was displaced")
 }
 
 func TestLeaseStealAllowsPendingAcquire(t *testing.T) {

--- a/internal/mcp/federation_test.go
+++ b/internal/mcp/federation_test.go
@@ -1,9 +1,15 @@
 package mcpserver
 
 import (
+	"encoding/json"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/pkg/client/generated"
 )
 
 func TestLeaseToolsArePublished(t *testing.T) {
@@ -16,5 +22,84 @@ func TestLeaseToolsArePublished(t *testing.T) {
 	}
 	for _, name := range []string{"kata.lease", "kata.lease_force_release", "kata.lease_status", "kata.lease_steal"} {
 		require.True(t, names[name], name)
+	}
+}
+
+func TestLeaseReleaseResponsesReportNotHeld(t *testing.T) {
+	releasedAt := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		require.True(t,
+			strings.HasSuffix(request.URL.Path, "/actions/release") ||
+				strings.HasSuffix(request.URL.Path, "/actions/force_release"),
+			request.URL.Path,
+		)
+		writeJSON(writer, releasedLeaseResponse(releasedAt))
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+
+	t.Run("release", func(t *testing.T) {
+		_, output, callErr := handlers.lease(t.Context(), nil, LeaseInput{Ref: "abc4", Action: "release"})
+		require.NoError(t, callErr)
+		require.False(t, output.Held)
+		require.Equal(t, "example-agent", output.Holder)
+		require.EqualValues(t, 2, output.Revision)
+	})
+	t.Run("force release", func(t *testing.T) {
+		_, output, callErr := handlers.leaseForceRelease(t.Context(), nil, LeaseForceReleaseInput{
+			Ref: "abc4", Reason: "operator handoff",
+		})
+		require.NoError(t, callErr)
+		require.False(t, output.Held)
+		require.Equal(t, "example-agent", output.Holder)
+		require.EqualValues(t, 2, output.Revision)
+	})
+}
+
+func TestLeaseQueuedAcquireReportsPendingRequest(t *testing.T) {
+	requestUID := "01HQQQQQQQQQQQQQQQQQQQQQQQ"
+	pending := true
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		require.True(t, strings.HasSuffix(request.URL.Path, "/actions/acquire"), request.URL.Path)
+		writeJSON(writer, generated.ClaimActionResponseBody{
+			Granted:    false,
+			Pending:    &pending,
+			RequestUID: &requestUID,
+			Holder: generated.ClaimPrincipalOut{
+				Holder: "example-agent", HolderInstanceUID: "01HIIIIIIIIIIIIIIIIIIIIIII", ClientKind: "mcp",
+			},
+		})
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+
+	_, output, err := handlers.lease(t.Context(), nil, LeaseInput{Ref: "abc4", Action: "acquire"})
+	require.NoError(t, err)
+	require.False(t, output.Held)
+	require.False(t, output.Granted)
+	encoded, err := json.Marshal(output)
+	require.NoError(t, err)
+	var fields map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &fields))
+	require.Equal(t, true, fields["pending"])
+	require.Equal(t, requestUID, fields["request_uid"])
+}
+
+func releasedLeaseResponse(releasedAt time.Time) generated.ClaimActionResponseBody {
+	lease := &generated.IssueClaimOut{
+		AcquiredAt: time.Date(2026, 8, 14, 11, 0, 0, 0, time.UTC),
+		ClaimKind:  "hard", ClaimUID: "01HCCCCCCCCCCCCCCCCCCCCCCC", ClientKind: "mcp",
+		Holder: "example-agent", HolderInstanceUID: "01HIIIIIIIIIIIIIIIIIIIIIII",
+		IssueUID: "01HSSSSSSSSSSSSSSSSSSSSSSS", ProjectID: 1, Purpose: "work",
+		ReleasedAt: &releasedAt, Revision: 2, UpdatedAt: releasedAt,
+	}
+	return generated.ClaimActionResponseBody{
+		Granted: true,
+		Holder: generated.ClaimPrincipalOut{
+			Holder: "example-agent", HolderInstanceUID: "01HIIIIIIIIIIIIIIIIIIIIIII", ClientKind: "mcp",
+		},
+		Lease: lease,
 	}
 }

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -2,14 +2,18 @@ package mcpserver
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/sync/errgroup"
 
+	"go.kenn.io/kata/internal/metadata"
 	"go.kenn.io/kata/internal/shortid"
 	"go.kenn.io/kata/pkg/client/generated"
 )
@@ -41,44 +45,86 @@ func (h toolHandlers) search(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 		}
 		mode = &value
 	}
-	limit64 := int64(limit + 1)
-	response, err := h.options.Client.SearchIssues(ctx, &generated.SearchIssuesRequestOptions{
-		PathParams: &generated.SearchIssuesPath{ProjectID: h.options.ProjectID},
-		Query: &generated.SearchIssuesQuery{
-			Q:            query,
-			Limit:        &limit64,
-			Mode:         mode,
-			Label:        compactStrings(input.Labels),
-			ExcludeLabel: compactStrings(input.ExcludeLabels),
-		},
-	})
+	projects, err := h.readProjects(ctx, input.Project)
 	if err != nil {
 		return nil, SearchOutput{}, err
 	}
-	truncated := len(response.Results) > limit
-	hits := response.Results
-	if truncated {
-		hits = hits[:limit]
+	type projectSearch struct {
+		response *generated.SearchIssuesResponse
+		err      error
 	}
-	results := make([]SearchHit, 0, len(hits))
-	for _, hit := range hits {
-		results = append(results, SearchHit{
-			Issue:     h.summaryFromIssue(hit.Issue),
-			Score:     hit.Score,
-			MatchedIn: nonNilStrings(hit.MatchedIn),
+	searches := make([]projectSearch, len(projects))
+	group, groupContext := errgroup.WithContext(ctx)
+	group.SetLimit(toolCallConcurrency)
+	for index := range projects {
+		index := index
+		group.Go(func() error {
+			limit64 := int64(limit + 1)
+			response, searchErr := h.options.Client.SearchIssues(groupContext, &generated.SearchIssuesRequestOptions{
+				PathParams: &generated.SearchIssuesPath{ProjectID: projects[index].ID},
+				Query: &generated.SearchIssuesQuery{
+					Q:            query,
+					Limit:        &limit64,
+					Mode:         mode,
+					Label:        compactStrings(input.Labels),
+					ExcludeLabel: compactStrings(input.ExcludeLabels),
+				},
+			})
+			searches[index] = projectSearch{response: response, err: searchErr}
+			if searchErr != nil {
+				return fmt.Errorf("search project %q: %w", projects[index].Name, searchErr)
+			}
+			return nil
 		})
 	}
-	degraded := response.Degraded != nil && *response.Degraded
-	degradedReason := ""
-	if response.DegradedReason != nil {
-		degradedReason = *response.DegradedReason
+	if err := group.Wait(); err != nil {
+		return nil, SearchOutput{}, err
 	}
+	results := make([]SearchHit, 0)
+	truncated := false
+	degraded := false
+	degradedReasons := make([]string, 0)
+	effectiveMode := ""
+	for index, search := range searches {
+		response := search.response
+		if effectiveMode == "" {
+			effectiveMode = response.Mode
+		}
+		if len(response.Results) > limit {
+			truncated = true
+		}
+		for _, hit := range response.Results {
+			results = append(results, SearchHit{
+				Issue:     h.summaryFromIssue(projects[index], hit.Issue),
+				Score:     hit.Score,
+				MatchedIn: nonNilStrings(hit.MatchedIn),
+			})
+		}
+		if response.Degraded != nil && *response.Degraded {
+			degraded = true
+		}
+		if response.DegradedReason != nil && *response.DegradedReason != "" {
+			degradedReasons = append(degradedReasons, projects[index].Name+": "+*response.DegradedReason)
+		}
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		return results[i].Issue.QualifiedRef < results[j].Issue.QualifiedRef
+	})
+	if len(results) > limit {
+		results = results[:limit]
+		truncated = true
+	}
+	project, outputProjects := outputProjectScope(projects)
 	return successResult(), SearchOutput{
-		Project:        h.project(),
-		Query:          response.Query,
-		Mode:           response.Mode,
+		Project:        project,
+		Projects:       outputProjects,
+		Query:          query,
+		Mode:           effectiveMode,
 		Degraded:       degraded,
-		DegradedReason: degradedReason,
+		DegradedReason: strings.Join(degradedReasons, "; "),
 		Results:        results,
 		Truncated:      truncated,
 	}, nil
@@ -93,12 +139,15 @@ func (h toolHandlers) list(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 		return nil, IssueListOutput{}, errors.New("owner and unowned are mutually exclusive")
 	}
 	var status *generated.ListIssuesQueryStatus
+	var globalStatus *generated.ListAllIssuesQueryStatus
 	if input.Status != "" {
 		value := generated.ListIssuesQueryStatus(input.Status)
 		if err := value.Validate(); err != nil {
 			return nil, IssueListOutput{}, fmt.Errorf("status: %w", err)
 		}
 		status = &value
+		globalValue := generated.ListAllIssuesQueryStatus(input.Status)
+		globalStatus = &globalValue
 	}
 	priority, err := priorityQuery(input.Priority)
 	if err != nil {
@@ -108,37 +157,79 @@ func (h toolHandlers) list(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 	if err != nil {
 		return nil, IssueListOutput{}, err
 	}
-	limit64 := int64(limit + 1)
-	owner := optionalString(input.Owner)
-	unowned := optionalTrue(input.Unowned)
-	response, err := h.options.Client.ListIssues(ctx, &generated.ListIssuesRequestOptions{
-		PathParams: &generated.ListIssuesPath{ProjectID: h.options.ProjectID},
-		Query: &generated.ListIssuesQuery{
-			Status:       status,
-			Priority:     priority,
-			MaxPriority:  maxPriority,
-			Limit:        &limit64,
-			Unowned:      unowned,
-			Owner:        owner,
-			Label:        compactStrings(input.Labels),
-			ExcludeLabel: compactStrings(input.ExcludeLabels),
-			Meta:         compactStrings(input.Metadata),
-		},
-	})
+	projects, err := h.readProjects(ctx, input.Project)
 	if err != nil {
 		return nil, IssueListOutput{}, err
 	}
-	truncated := len(response.Issues) > limit
-	responseIssues := response.Issues
-	if truncated {
-		responseIssues = responseIssues[:limit]
+	limit64 := int64(limit + 1)
+	owner := optionalString(input.Owner)
+	unowned := optionalTrue(input.Unowned)
+	issues := make([]IssueSummary, 0)
+	truncated := false
+	if h.options.Scope.Mode() == ScopeAllowlist && strings.TrimSpace(input.Project) == "" {
+		for _, project := range projects {
+			response, listErr := h.options.Client.ListIssues(ctx, &generated.ListIssuesRequestOptions{
+				PathParams: &generated.ListIssuesPath{ProjectID: project.ID},
+				Query: &generated.ListIssuesQuery{
+					Status: status, Priority: priority, MaxPriority: maxPriority, Limit: &limit64,
+					Unowned: unowned, Owner: owner, Label: compactStrings(input.Labels),
+					ExcludeLabel: compactStrings(input.ExcludeLabels), Meta: compactStrings(input.Metadata),
+				},
+			})
+			if listErr != nil {
+				return nil, IssueListOutput{}, listErr
+			}
+			if len(response.Issues) > limit {
+				truncated = true
+			}
+			for _, issue := range response.Issues {
+				issues = append(issues, h.summaryFromIssueOut(project, issue))
+			}
+		}
+		sortIssueSummaries(issues)
+		truncated = truncated || len(issues) > limit
+	} else if len(projects) == 1 && (h.options.Scope.Mode() == ScopeBound || strings.TrimSpace(input.Project) != "") {
+		response, listErr := h.options.Client.ListIssues(ctx, &generated.ListIssuesRequestOptions{
+			PathParams: &generated.ListIssuesPath{ProjectID: projects[0].ID},
+			Query: &generated.ListIssuesQuery{
+				Status: status, Priority: priority, MaxPriority: maxPriority, Limit: &limit64,
+				Unowned: unowned, Owner: owner, Label: compactStrings(input.Labels),
+				ExcludeLabel: compactStrings(input.ExcludeLabels), Meta: compactStrings(input.Metadata),
+			},
+		})
+		if listErr != nil {
+			return nil, IssueListOutput{}, listErr
+		}
+		truncated = len(response.Issues) > limit
+		for _, issue := range response.Issues {
+			issues = append(issues, h.summaryFromIssueOut(projects[0], issue))
+		}
+	} else {
+		response, listErr := h.options.Client.ListAllIssues(ctx, &generated.ListAllIssuesRequestOptions{
+			Query: &generated.ListAllIssuesQuery{
+				Status: globalStatus, Priority: priority, MaxPriority: maxPriority, Limit: &limit64,
+				Unowned: unowned, Owner: owner, Label: compactStrings(input.Labels),
+				ExcludeLabel: compactStrings(input.ExcludeLabels), Meta: compactStrings(input.Metadata),
+			},
+		})
+		if listErr != nil {
+			return nil, IssueListOutput{}, listErr
+		}
+		allowed := projectIDSet(projects)
+		for _, issue := range response.Issues {
+			if _, ok := allowed[issue.ProjectID]; ok {
+				issues = append(issues, summaryFromGlobalIssue(issue))
+			}
+		}
+		truncated = len(response.Issues) > limit || len(issues) > limit
 	}
-	issues := make([]IssueSummary, 0, len(responseIssues))
-	for _, issue := range responseIssues {
-		issues = append(issues, h.summaryFromIssueOut(issue))
+	if len(issues) > limit {
+		issues = issues[:limit]
 	}
+	project, outputProjects := outputProjectScope(projects)
 	return successResult(), IssueListOutput{
-		Project:   h.project(),
+		Project:   project,
+		Projects:  outputProjects,
 		Issues:    issues,
 		Truncated: truncated,
 	}, nil
@@ -152,52 +243,116 @@ func (h toolHandlers) ready(ctx context.Context, _ *sdkmcp.CallToolRequest, inpu
 	if input.Unowned && strings.TrimSpace(input.Owner) != "" {
 		return nil, IssueListOutput{}, errors.New("owner and unowned are mutually exclusive")
 	}
-	limit64 := int64(limit + 1)
-	response, err := h.options.Client.ReadyIssues(ctx, &generated.ReadyIssuesRequestOptions{
-		PathParams: &generated.ReadyIssuesPath{ProjectID: h.options.ProjectID},
-		Query: &generated.ReadyIssuesQuery{
-			Limit:        &limit64,
-			Unowned:      optionalTrue(input.Unowned),
-			Owner:        optionalString(input.Owner),
-			Label:        compactStrings(input.Labels),
-			ExcludeLabel: compactStrings(input.ExcludeLabels),
-		},
-	})
+	projects, err := h.readProjects(ctx, input.Project)
 	if err != nil {
 		return nil, IssueListOutput{}, err
 	}
-	truncated := len(response.Issues) > limit
-	responseIssues := response.Issues
-	if truncated {
-		responseIssues = responseIssues[:limit]
+	limit64 := int64(limit + 1)
+	issues := make([]IssueSummary, 0)
+	truncated := false
+	if h.options.Scope.Mode() == ScopeAllowlist && strings.TrimSpace(input.Project) == "" {
+		for _, project := range projects {
+			response, readyErr := h.options.Client.ReadyIssues(ctx, &generated.ReadyIssuesRequestOptions{
+				PathParams: &generated.ReadyIssuesPath{ProjectID: project.ID},
+				Query: &generated.ReadyIssuesQuery{
+					Limit: &limit64, Unowned: optionalTrue(input.Unowned), Owner: optionalString(input.Owner),
+					Label: compactStrings(input.Labels), ExcludeLabel: compactStrings(input.ExcludeLabels),
+				},
+			})
+			if readyErr != nil {
+				return nil, IssueListOutput{}, readyErr
+			}
+			if len(response.Issues) > limit {
+				truncated = true
+			}
+			for _, issue := range response.Issues {
+				issues = append(issues, h.summaryFromIssueOut(project, issue))
+			}
+		}
+		sortIssueSummaries(issues)
+		truncated = truncated || len(issues) > limit
+	} else if len(projects) == 1 && (h.options.Scope.Mode() == ScopeBound || strings.TrimSpace(input.Project) != "") {
+		response, readyErr := h.options.Client.ReadyIssues(ctx, &generated.ReadyIssuesRequestOptions{
+			PathParams: &generated.ReadyIssuesPath{ProjectID: projects[0].ID},
+			Query: &generated.ReadyIssuesQuery{
+				Limit: &limit64, Unowned: optionalTrue(input.Unowned), Owner: optionalString(input.Owner),
+				Label: compactStrings(input.Labels), ExcludeLabel: compactStrings(input.ExcludeLabels),
+			},
+		})
+		if readyErr != nil {
+			return nil, IssueListOutput{}, readyErr
+		}
+		truncated = len(response.Issues) > limit
+		for _, issue := range response.Issues {
+			issues = append(issues, h.summaryFromIssueOut(projects[0], issue))
+		}
+	} else {
+		response, readyErr := h.options.Client.ReadyIssuesGlobal(ctx, &generated.ReadyIssuesGlobalRequestOptions{
+			Query: &generated.ReadyIssuesGlobalQuery{
+				Limit: &limit64, Unowned: optionalTrue(input.Unowned), Owner: optionalString(input.Owner),
+				Label: compactStrings(input.Labels), ExcludeLabel: compactStrings(input.ExcludeLabels),
+			},
+		})
+		if readyErr != nil {
+			return nil, IssueListOutput{}, readyErr
+		}
+		allowed := projectIDSet(projects)
+		for _, issue := range response.Issues {
+			if _, ok := allowed[issue.ProjectID]; ok {
+				issues = append(issues, summaryFromReadyGlobalIssue(issue))
+			}
+		}
+		truncated = len(response.Issues) > limit || len(issues) > limit
 	}
-	issues := make([]IssueSummary, 0, len(responseIssues))
-	for _, issue := range responseIssues {
-		issues = append(issues, h.summaryFromIssueOut(issue))
+	if len(issues) > limit {
+		issues = issues[:limit]
 	}
+	project, outputProjects := outputProjectScope(projects)
 	return successResult(), IssueListOutput{
-		Project:   h.project(),
+		Project:   project,
+		Projects:  outputProjects,
 		Issues:    issues,
 		Truncated: truncated,
 	}, nil
 }
 
-func (h toolHandlers) labels(ctx context.Context, _ *sdkmcp.CallToolRequest, _ LabelsInput) (*sdkmcp.CallToolResult, LabelsOutput, error) {
-	response, err := h.options.Client.ListLabels(ctx, &generated.ListLabelsRequestOptions{
-		PathParams: &generated.ListLabelsPath{ProjectID: h.options.ProjectID},
+func sortIssueSummaries(issues []IssueSummary) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		if issues[i].UpdatedAt != issues[j].UpdatedAt {
+			return issues[i].UpdatedAt > issues[j].UpdatedAt
+		}
+		return issues[i].QualifiedRef < issues[j].QualifiedRef
 	})
+}
+
+func (h toolHandlers) labels(ctx context.Context, _ *sdkmcp.CallToolRequest, input LabelsInput) (*sdkmcp.CallToolResult, LabelsOutput, error) {
+	projects, err := h.readProjects(ctx, input.Project)
 	if err != nil {
 		return nil, LabelsOutput{}, err
 	}
-	labels := make([]LabelCount, 0, len(response.Labels))
-	for _, label := range response.Labels {
-		labels = append(labels, LabelCount{Label: label.Label, Count: label.Count})
+	counts := make(map[string]int64)
+	for _, project := range projects {
+		response, listErr := h.options.Client.ListLabels(ctx, &generated.ListLabelsRequestOptions{
+			PathParams: &generated.ListLabelsPath{ProjectID: project.ID},
+		})
+		if listErr != nil {
+			return nil, LabelsOutput{}, fmt.Errorf("list labels for project %q: %w", project.Name, listErr)
+		}
+		for _, label := range response.Labels {
+			counts[label.Label] += label.Count
+		}
 	}
-	return successResult(), LabelsOutput{Project: h.project(), Labels: labels}, nil
+	labels := make([]LabelCount, 0, len(counts))
+	for label, count := range counts {
+		labels = append(labels, LabelCount{Label: label, Count: count})
+	}
+	sort.Slice(labels, func(i, j int) bool { return labels[i].Label < labels[j].Label })
+	project, outputProjects := outputProjectScope(projects)
+	return successResult(), LabelsOutput{Project: project, Projects: outputProjects, Labels: labels}, nil
 }
 
 func (h toolHandlers) show(ctx context.Context, _ *sdkmcp.CallToolRequest, input ShowInput) (*sdkmcp.CallToolResult, ShowOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, false)
 	if err != nil {
 		return nil, ShowOutput{}, err
 	}
@@ -209,7 +364,7 @@ func (h toolHandlers) show(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 		return nil, ShowOutput{}, fmt.Errorf("comment_limit must be between 1 and %d when set", maximumResultLimit)
 	}
 	response, err := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
-		PathParams: &generated.ShowIssuePath{ProjectID: h.options.ProjectID, Ref: ref},
+		PathParams: &generated.ShowIssuePath{ProjectID: project.ID, Ref: ref},
 	})
 	if err != nil {
 		return nil, ShowOutput{}, err
@@ -228,16 +383,33 @@ func (h toolHandlers) show(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 		labels = append(labels, label.Label)
 	}
 	links := make([]LinkSummary, 0, len(response.Links))
+	var allowedLinkProjects map[string]struct{}
+	if h.options.Scope.Mode() != ScopeAll {
+		projects, scopeErr := h.options.Scope.Projects(ctx, h.options.Client, false)
+		if scopeErr != nil {
+			return nil, ShowOutput{}, scopeErr
+		}
+		allowedLinkProjects = make(map[string]struct{}, len(projects))
+		for _, allowedProject := range projects {
+			allowedLinkProjects[allowedProject.Name] = struct{}{}
+		}
+	}
 	for _, link := range response.Links {
+		peer, _ := linkPeerAndType(response.Issue.UID, link)
+		if allowedLinkProjects != nil {
+			if _, allowed := allowedLinkProjects[peer.Project]; !allowed {
+				continue
+			}
+		}
 		links = append(links, linkSummary(response.Issue.UID, link))
 	}
-	summary := h.summaryFromIssue(response.Issue)
+	summary := h.summaryFromIssue(project, response.Issue)
 	metadata := response.Issue.Metadata
 	if metadata == nil {
 		metadata = map[string]any{}
 	}
 	return successResult(), ShowOutput{
-		Project: h.project(),
+		Project: project,
 		Issue: IssueDetail{
 			IssueSummary: summary,
 			Labels:       labels,
@@ -263,7 +435,15 @@ func (h toolHandlers) create(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 	if err := validatePriority(input.Priority); err != nil {
 		return nil, MutationOutput{}, err
 	}
-	links, err := h.createLinks(input)
+	project, err := h.createTarget(ctx, input.Project)
+	if err != nil {
+		return nil, MutationOutput{}, err
+	}
+	links, err := h.createLinks(ctx, project, input)
+	if err != nil {
+		return nil, MutationOutput{}, err
+	}
+	issueMetadata, err := createMetadata(input)
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
@@ -272,8 +452,9 @@ func (h toolHandlers) create(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 		Title:    title,
 		Labels:   compactStrings(input.Labels),
 		Links:    links,
-		Metadata: input.Metadata,
+		Metadata: issueMetadata,
 		Priority: input.Priority,
+		ForceNew: optionalTrue(input.ForceNew),
 	}
 	if input.Body != "" {
 		body.Body = &input.Body
@@ -282,18 +463,18 @@ func (h toolHandlers) create(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 		body.Owner = &input.Owner
 	}
 	response, err := h.options.Client.CreateIssue(ctx, &generated.CreateIssueRequestOptions{
-		PathParams: &generated.CreateIssuePath{ProjectID: h.options.ProjectID},
+		PathParams: &generated.CreateIssuePath{ProjectID: project.ID},
 		Body:       &body,
 		Header:     &generated.CreateIssueHeaders{IdempotencyKey: &key},
 	})
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
-	return successResult(), h.mutation(response.Issue, response.Changed, response.Reused, &response.Event), nil
+	return successResult(), h.mutation(project, response.Issue, response.Changed, response.Reused, &response.Event), nil
 }
 
 func (h toolHandlers) edit(ctx context.Context, _ *sdkmcp.CallToolRequest, input EditInput) (*sdkmcp.CallToolResult, EditOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
 	if err != nil {
 		return nil, EditOutput{}, err
 	}
@@ -312,7 +493,11 @@ func (h toolHandlers) edit(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 	if err := validatePriority(input.Priority); err != nil {
 		return nil, EditOutput{}, err
 	}
-	delta, err := h.linksDelta(input)
+	delta, err := h.linksDelta(ctx, project, input)
+	if err != nil {
+		return nil, EditOutput{}, err
+	}
+	metadataPatch, err := editMetadata(input)
 	if err != nil {
 		return nil, EditOutput{}, err
 	}
@@ -329,35 +514,64 @@ func (h toolHandlers) edit(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 		empty := ""
 		body.Owner = &empty
 	}
-	if body.Title == nil && body.Body == nil && body.Owner == nil && body.SetPriority == nil && body.ClearPriority == nil && body.LinksDelta == nil {
+	hasIssueEdit := body.Title != nil || body.Body != nil || body.Owner != nil || body.SetPriority != nil || body.ClearPriority != nil || body.LinksDelta != nil
+	if !hasIssueEdit && len(metadataPatch) == 0 {
 		return nil, EditOutput{}, errors.New("edit requires at least one change")
 	}
-	response, err := h.options.Client.EditIssue(ctx, &generated.EditIssueRequestOptions{
-		PathParams: &generated.EditIssuePath{ProjectID: h.options.ProjectID, Ref: ref},
-		Body:       &body,
-	})
-	if err != nil {
-		return nil, EditOutput{}, err
+	if hasIssueEdit && len(metadataPatch) > 0 {
+		return nil, EditOutput{}, errors.New("issue fields and metadata must be changed in separate calls")
 	}
-	events := make([]EventSummary, 0, len(response.Events))
-	for index := range response.Events {
-		if event := eventSummary(&response.Events[index]); event != nil {
+	var issue generated.Issue
+	var changed bool
+	var mainEvent *EventSummary
+	var changes *LinkChangesSummary
+	events := make([]EventSummary, 0)
+	if hasIssueEdit {
+		response, editErr := h.options.Client.EditIssue(ctx, &generated.EditIssueRequestOptions{
+			PathParams: &generated.EditIssuePath{ProjectID: project.ID, Ref: ref},
+			Body:       &body,
+		})
+		if editErr != nil {
+			return nil, EditOutput{}, editErr
+		}
+		issue = response.Issue
+		changed = response.Changed
+		mainEvent = eventSummary(&response.Event)
+		changes = linkChangesSummary(response.Changes)
+		for index := range response.Events {
+			if event := eventSummary(&response.Events[index]); event != nil {
+				events = append(events, *event)
+			}
+		}
+	}
+	if len(metadataPatch) > 0 {
+		response, patchErr := h.options.Client.PatchIssueMetadata(ctx, &generated.PatchIssueMetadataRequestOptions{
+			PathParams: &generated.PatchIssueMetadataPath{ProjectID: project.ID, Ref: ref},
+			Body:       &generated.PatchIssueMetadataBody{Actor: &h.options.Actor, Patch: metadataPatch},
+		})
+		if patchErr != nil {
+			return nil, EditOutput{}, patchErr
+		}
+		issue = response.Issue
+		changed = changed || response.Changed
+		if event := eventSummary(response.Event); event != nil {
+			mainEvent = event
 			events = append(events, *event)
 		}
 	}
 	return successResult(), EditOutput{
-		Project: h.project(),
-		Issue:   h.summaryFromIssue(response.Issue),
-		Changed: response.Changed,
+		Project: project,
+		Issue:   h.summaryFromIssue(project, issue),
+		Changed: changed,
 		Reused:  nil,
-		Event:   eventSummary(&response.Event),
+		Event:   mainEvent,
 		Events:  events,
-		Changes: linkChangesSummary(response.Changes),
+		Changes: changes,
 	}, nil
 }
 
 func (h toolHandlers) comment(ctx context.Context, _ *sdkmcp.CallToolRequest, input CommentInput) (*sdkmcp.CallToolResult, CommentOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
 	if err != nil {
 		return nil, CommentOutput{}, err
 	}
@@ -369,7 +583,7 @@ func (h toolHandlers) comment(ctx context.Context, _ *sdkmcp.CallToolRequest, in
 		return nil, CommentOutput{}, errors.New("idempotency_key must not be empty")
 	}
 	response, err := h.options.Client.CreateComment(ctx, &generated.CreateCommentRequestOptions{
-		PathParams: &generated.CreateCommentPath{ProjectID: h.options.ProjectID, Ref: ref},
+		PathParams: &generated.CreateCommentPath{ProjectID: project.ID, Ref: ref},
 		Body:       &generated.CreateCommentBody{Actor: &h.options.Actor, Body: input.Body},
 		Header:     &generated.CreateCommentHeaders{IdempotencyKey: &key},
 	})
@@ -377,8 +591,8 @@ func (h toolHandlers) comment(ctx context.Context, _ *sdkmcp.CallToolRequest, in
 		return nil, CommentOutput{}, err
 	}
 	return successResult(), CommentOutput{
-		Project: h.project(),
-		Issue:   h.summaryFromIssue(response.Issue),
+		Project: project,
+		Issue:   h.summaryFromIssue(project, response.Issue),
 		Comment: commentSummary(response.Comment),
 		Changed: response.Changed,
 		Reused:  optionalTrue(!response.Changed),
@@ -387,22 +601,24 @@ func (h toolHandlers) comment(ctx context.Context, _ *sdkmcp.CallToolRequest, in
 }
 
 func (h toolHandlers) claim(ctx context.Context, _ *sdkmcp.CallToolRequest, input ClaimInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
 	response, err := h.options.Client.ClaimIssue(ctx, &generated.ClaimIssueRequestOptions{
-		PathParams: &generated.ClaimIssuePath{ProjectID: h.options.ProjectID, Ref: ref},
-		Body:       &generated.ClaimIssueBody{Actor: h.options.Actor},
+		PathParams: &generated.ClaimIssuePath{ProjectID: project.ID, Ref: ref},
+		Body:       &generated.ClaimIssueBody{Actor: h.options.Actor, Force: optionalTrue(input.Force)},
 	})
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
-	return successResult(), h.mutation(response.Issue, response.Changed, nil, response.Event), nil
+	output := h.mutation(project, response.Issue, response.Changed, nil, response.Event)
+	output.PreviousOwner = response.PreviousOwner
+	return successResult(), output, nil
 }
 
 func (h toolHandlers) setLabel(ctx context.Context, _ *sdkmcp.CallToolRequest, input SetLabelInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
@@ -412,26 +628,26 @@ func (h toolHandlers) setLabel(ctx context.Context, _ *sdkmcp.CallToolRequest, i
 	}
 	if input.Present {
 		response, err := h.options.Client.AddLabel(ctx, &generated.AddLabelRequestOptions{
-			PathParams: &generated.AddLabelPath{ProjectID: h.options.ProjectID, Ref: ref},
+			PathParams: &generated.AddLabelPath{ProjectID: project.ID, Ref: ref},
 			Body:       &generated.AddLabelBody{Actor: &h.options.Actor, Label: label},
 		})
 		if err != nil {
 			return nil, MutationOutput{}, err
 		}
-		return successResult(), h.mutation(response.Issue, response.Changed, nil, &response.Event), nil
+		return successResult(), h.mutation(project, response.Issue, response.Changed, nil, &response.Event), nil
 	}
 	response, err := h.options.Client.RemoveLabel(ctx, &generated.RemoveLabelRequestOptions{
-		PathParams: &generated.RemoveLabelPath{ProjectID: h.options.ProjectID, Ref: ref, Label: label},
+		PathParams: &generated.RemoveLabelPath{ProjectID: project.ID, Ref: ref, Label: label},
 		Query:      &generated.RemoveLabelQuery{Actor: &h.options.Actor},
 	})
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
-	return successResult(), h.mutation(response.Issue, response.Changed, response.Reused, &response.Event), nil
+	return successResult(), h.mutation(project, response.Issue, response.Changed, response.Reused, &response.Event), nil
 }
 
 func (h toolHandlers) setDeadline(ctx context.Context, _ *sdkmcp.CallToolRequest, input SetDeadlineInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
@@ -445,11 +661,11 @@ func (h toolHandlers) setDeadline(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if input.Deadline != nil {
 		value = *input.Deadline
 	}
-	return h.patchMetadata(ctx, ref, map[string]any{"deadline_on": value}, input.Revision)
+	return h.patchMetadata(ctx, project, ref, map[string]any{"deadline_on": value}, input.Revision)
 }
 
 func (h toolHandlers) setSchedule(ctx context.Context, _ *sdkmcp.CallToolRequest, input SetScheduleInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
@@ -463,11 +679,11 @@ func (h toolHandlers) setSchedule(ctx context.Context, _ *sdkmcp.CallToolRequest
 	if input.Schedule != nil {
 		value = *input.Schedule
 	}
-	return h.patchMetadata(ctx, ref, map[string]any{"scheduled_on": value}, input.Revision)
+	return h.patchMetadata(ctx, project, ref, map[string]any{"scheduled_on": value}, input.Revision)
 }
 
 func (h toolHandlers) setMetadata(ctx context.Context, _ *sdkmcp.CallToolRequest, input SetMetadataInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
@@ -479,10 +695,10 @@ func (h toolHandlers) setMetadata(ctx context.Context, _ *sdkmcp.CallToolRequest
 			return nil, MutationOutput{}, errors.New("metadata keys must not be empty")
 		}
 	}
-	return h.patchMetadata(ctx, ref, input.Patch, input.Revision)
+	return h.patchMetadata(ctx, project, ref, input.Patch, input.Revision)
 }
 
-func (h toolHandlers) patchMetadata(ctx context.Context, ref string, patch map[string]any, revision *int64) (*sdkmcp.CallToolResult, MutationOutput, error) {
+func (h toolHandlers) patchMetadata(ctx context.Context, project ProjectIdentity, ref string, patch map[string]any, revision *int64) (*sdkmcp.CallToolResult, MutationOutput, error) {
 	var headers *generated.PatchIssueMetadataHeaders
 	if revision != nil {
 		if *revision < 0 {
@@ -492,18 +708,18 @@ func (h toolHandlers) patchMetadata(ctx context.Context, ref string, patch map[s
 		headers = &generated.PatchIssueMetadataHeaders{IfMatch: &ifMatch}
 	}
 	response, err := h.options.Client.PatchIssueMetadata(ctx, &generated.PatchIssueMetadataRequestOptions{
-		PathParams: &generated.PatchIssueMetadataPath{ProjectID: h.options.ProjectID, Ref: ref},
+		PathParams: &generated.PatchIssueMetadataPath{ProjectID: project.ID, Ref: ref},
 		Body:       &generated.PatchIssueMetadataBody{Actor: &h.options.Actor, Patch: patch},
 		Header:     headers,
 	})
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
-	return successResult(), h.mutation(response.Issue, response.Changed, nil, response.Event), nil
+	return successResult(), h.mutation(project, response.Issue, response.Changed, nil, response.Event), nil
 }
 
 func (h toolHandlers) close(ctx context.Context, _ *sdkmcp.CallToolRequest, input CloseInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
@@ -516,14 +732,14 @@ func (h toolHandlers) close(ctx context.Context, _ *sdkmcp.CallToolRequest, inpu
 	}
 	evidence := make([]generated.Evidence, 0, len(input.Evidence))
 	for index, item := range input.Evidence {
-		converted, err := h.convertEvidence(item)
+		converted, err := h.convertEvidence(ctx, project, item)
 		if err != nil {
 			return nil, MutationOutput{}, fmt.Errorf("evidence %d: %w", index+1, err)
 		}
 		evidence = append(evidence, converted)
 	}
 	response, err := h.options.Client.CloseIssue(ctx, &generated.CloseIssueRequestOptions{
-		PathParams: &generated.CloseIssuePath{ProjectID: h.options.ProjectID, Ref: ref},
+		PathParams: &generated.CloseIssuePath{ProjectID: project.ID, Ref: ref},
 		Body: &generated.CloseIssueBody{
 			Actor:    &h.options.Actor,
 			Reason:   &reason,
@@ -535,28 +751,28 @@ func (h toolHandlers) close(ctx context.Context, _ *sdkmcp.CallToolRequest, inpu
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
-	return successResult(), h.mutation(response.Issue, response.Changed, response.Reused, &response.Event), nil
+	return successResult(), h.mutation(project, response.Issue, response.Changed, response.Reused, &response.Event), nil
 }
 
 func (h toolHandlers) reopen(ctx context.Context, _ *sdkmcp.CallToolRequest, input ReopenInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
-	ref, err := h.boundRef(input.Ref)
+	project, ref, err := h.options.Scope.IssueTarget(ctx, h.options.Client, input.Ref, true)
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
 	response, err := h.options.Client.ReopenIssue(ctx, &generated.ReopenIssueRequestOptions{
-		PathParams: &generated.ReopenIssuePath{ProjectID: h.options.ProjectID, Ref: ref},
+		PathParams: &generated.ReopenIssuePath{ProjectID: project.ID, Ref: ref},
 		Body:       &generated.ReopenIssueBody{Actor: &h.options.Actor},
 	})
 	if err != nil {
 		return nil, MutationOutput{}, err
 	}
-	return successResult(), h.mutation(response.Issue, response.Changed, response.Reused, &response.Event), nil
+	return successResult(), h.mutation(project, response.Issue, response.Changed, response.Reused, &response.Event), nil
 }
 
-func (h toolHandlers) createLinks(input CreateInput) ([]generated.CreateInitialLinkBody, error) {
+func (h toolHandlers) createLinks(ctx context.Context, project ProjectIdentity, input CreateInput) ([]generated.CreateInitialLinkBody, error) {
 	links := make([]generated.CreateInitialLinkBody, 0, 1+len(input.Blocks)+len(input.BlockedBy)+len(input.Related))
 	add := func(ref string, linkType generated.CreateInitialLinkBodyType, incoming bool) error {
-		bound, err := h.boundRelationshipRef(ref)
+		bound, err := h.relationshipRef(ctx, project, ref)
 		if err != nil {
 			return err
 		}
@@ -590,11 +806,11 @@ func (h toolHandlers) createLinks(input CreateInput) ([]generated.CreateInitialL
 	return links, nil
 }
 
-func (h toolHandlers) linksDelta(input EditInput) (*generated.LinksDelta, error) {
+func (h toolHandlers) linksDelta(ctx context.Context, project ProjectIdentity, input EditInput) (*generated.LinksDelta, error) {
 	delta := &generated.LinksDelta{}
 	var changed bool
 	setOne := func(target **string, raw string) error {
-		ref, err := h.boundRelationshipRef(raw)
+		ref, err := h.relationshipRef(ctx, project, raw)
 		if err != nil {
 			return err
 		}
@@ -604,7 +820,7 @@ func (h toolHandlers) linksDelta(input EditInput) (*generated.LinksDelta, error)
 	}
 	setMany := func(target *[]string, raw []string) error {
 		for _, item := range raw {
-			ref, err := h.boundRelationshipRef(item)
+			ref, err := h.relationshipRef(ctx, project, item)
 			if err != nil {
 				return err
 			}
@@ -641,17 +857,6 @@ func (h toolHandlers) linksDelta(input EditInput) (*generated.LinksDelta, error)
 	return delta, nil
 }
 
-func (h toolHandlers) boundRef(raw string) (string, error) {
-	ref := strings.TrimSpace(raw)
-	if ref == "" {
-		return "", errors.New("issue reference must not be empty")
-	}
-	if project, _, qualified := strings.Cut(ref, "#"); qualified && project != h.options.ProjectName {
-		return "", fmt.Errorf("issue reference %q is outside bound project %q", ref, h.options.ProjectName)
-	}
-	return ref, nil
-}
-
 func (h toolHandlers) boundRelationshipRef(raw string) (string, error) {
 	ref := strings.TrimSpace(raw)
 	if ref == "" {
@@ -673,28 +878,173 @@ func (h toolHandlers) boundRelationshipRef(raw string) (string, error) {
 	return parsed.ShortID, nil
 }
 
-func (h toolHandlers) project() ProjectIdentity {
-	return ProjectIdentity{ID: h.options.ProjectID, Name: h.options.ProjectName}
+func (h toolHandlers) readProjects(ctx context.Context, selector string) ([]ProjectIdentity, error) {
+	if strings.TrimSpace(selector) != "" {
+		project, err := h.options.Scope.Project(ctx, h.options.Client, selector, false)
+		if err != nil {
+			return nil, err
+		}
+		return []ProjectIdentity{project}, nil
+	}
+	return h.options.Scope.Projects(ctx, h.options.Client, false)
 }
 
-func (h toolHandlers) summaryFromIssue(issue generated.Issue) IssueSummary {
+func (h toolHandlers) createTarget(ctx context.Context, selector string) (ProjectIdentity, error) {
+	selector = strings.TrimSpace(selector)
+	if h.options.Scope.Mode() != ScopeBound && selector == "" {
+		return ProjectIdentity{}, errors.New("multi-project creates require project")
+	}
+	return h.options.Scope.Project(ctx, h.options.Client, selector, false)
+}
+
+func createMetadata(input CreateInput) (map[string]any, error) {
+	patch := copyMetadata(input.Metadata)
+	if input.ScheduledOn != "" {
+		if _, exists := patch["scheduled_on"]; exists {
+			return nil, errors.New("scheduled_on is present in both the dedicated field and metadata")
+		}
+		patch["scheduled_on"] = input.ScheduledOn
+	}
+	if input.Timezone != "" {
+		if _, exists := patch["timezone"]; exists {
+			return nil, errors.New("timezone is present in both the dedicated field and metadata")
+		}
+		patch["timezone"] = input.Timezone
+	}
+	for key, value := range patch {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("metadata %q: %w", key, err)
+		}
+		if err := metadata.ValidateCreateValue(metadata.IssueRegistry, key, raw); err != nil {
+			return nil, fmt.Errorf("metadata %q: %w", key, err)
+		}
+	}
+	if len(patch) == 0 {
+		return nil, nil
+	}
+	return patch, nil
+}
+
+func editMetadata(input EditInput) (map[string]any, error) {
+	patch := copyMetadata(input.Metadata)
+	if input.ScheduledOn != nil && input.ClearScheduledOn {
+		return nil, errors.New("scheduled_on and clear_scheduled_on are mutually exclusive")
+	}
+	if input.Timezone != nil && input.ClearTimezone {
+		return nil, errors.New("timezone and clear_timezone are mutually exclusive")
+	}
+	if input.ScheduledOn != nil || input.ClearScheduledOn {
+		if _, exists := patch["scheduled_on"]; exists {
+			return nil, errors.New("scheduled_on is present in both the dedicated field and metadata")
+		}
+		if input.ClearScheduledOn {
+			patch["scheduled_on"] = nil
+		} else {
+			patch["scheduled_on"] = *input.ScheduledOn
+		}
+	}
+	if input.Timezone != nil || input.ClearTimezone {
+		if _, exists := patch["timezone"]; exists {
+			return nil, errors.New("timezone is present in both the dedicated field and metadata")
+		}
+		if input.ClearTimezone {
+			patch["timezone"] = nil
+		} else {
+			patch["timezone"] = *input.Timezone
+		}
+	}
+	for key, value := range patch {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("metadata %q: %w", key, err)
+		}
+		if err := metadata.Validate(metadata.IssueRegistry, key, raw); err != nil {
+			return nil, fmt.Errorf("metadata %q: %w", key, err)
+		}
+	}
+	if len(patch) == 0 {
+		return nil, nil
+	}
+	return patch, nil
+}
+
+func copyMetadata(source map[string]any) map[string]any {
+	if len(source) == 0 {
+		return make(map[string]any)
+	}
+	result := make(map[string]any, len(source)+2)
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}
+
+func (h toolHandlers) relationshipRef(ctx context.Context, source ProjectIdentity, raw string) (string, error) {
+	ref := strings.TrimSpace(raw)
+	if ref == "" {
+		return "", errors.New("relationship reference must not be empty")
+	}
+	parsed, err := shortid.Parse(ref)
+	if err != nil {
+		return "", fmt.Errorf("relationship reference %q is invalid", ref)
+	}
+	if parsed.ULID != "" {
+		return "", fmt.Errorf("relationship reference %q is an unscoped UID; use a project-qualified short reference", ref)
+	}
+	if len(parsed.ShortID) == shortid.MaxLength {
+		return "", fmt.Errorf("relationship reference %q uses an ambiguous full-length short ID; use a shorter project-qualified reference", ref)
+	}
+	if h.options.Scope.Mode() == ScopeBound {
+		if parsed.Project != "" && parsed.Project != source.Name {
+			return "", fmt.Errorf("relationship reference %q is outside bound project %q", ref, source.Name)
+		}
+		return parsed.ShortID, nil
+	}
+	if parsed.Project == "" {
+		return "", errors.New("multi-project relationships require project#ref")
+	}
+	if _, err := h.options.Scope.Project(ctx, h.options.Client, parsed.Project, false); err != nil {
+		return "", err
+	}
+	return parsed.Project + "#" + parsed.ShortID, nil
+}
+
+func outputProjectScope(projects []ProjectIdentity) (ProjectIdentity, []ProjectIdentity) {
+	if len(projects) == 1 {
+		return projects[0], nil
+	}
+	return ProjectIdentity{}, projects
+}
+
+func projectIDSet(projects []ProjectIdentity) map[int64]struct{} {
+	result := make(map[int64]struct{}, len(projects))
+	for _, project := range projects {
+		result[project.ID] = struct{}{}
+	}
+	return result
+}
+
+func (h toolHandlers) summaryFromIssue(project ProjectIdentity, issue generated.Issue) IssueSummary {
 	return IssueSummary{
 		UID:          issue.UID,
 		Ref:          issue.ShortID,
-		QualifiedRef: h.options.ProjectName + "#" + issue.ShortID,
+		QualifiedRef: project.Name + "#" + issue.ShortID,
 		Title:        issue.Title,
 		Status:       issue.Status,
 		Owner:        issue.Owner,
 		Priority:     issue.Priority,
 		Revision:     issue.Revision,
 		UpdatedAt:    formatTime(issue.UpdatedAt),
+		ScheduledOn:  metadataString(issue.Metadata, "scheduled_on"),
+		Timezone:     metadataString(issue.Metadata, "timezone"),
 	}
 }
 
-func (h toolHandlers) summaryFromIssueOut(issue generated.IssueOut) IssueSummary {
+func (h toolHandlers) summaryFromIssueOut(project ProjectIdentity, issue generated.IssueOut) IssueSummary {
 	qualified := issue.QualifiedID
 	if qualified == "" {
-		qualified = h.options.ProjectName + "#" + issue.ShortID
+		qualified = project.Name + "#" + issue.ShortID
 	}
 	return IssueSummary{
 		UID:          issue.UID,
@@ -708,13 +1058,43 @@ func (h toolHandlers) summaryFromIssueOut(issue generated.IssueOut) IssueSummary
 		Blocked:      issue.Blocked,
 		Revision:     issue.Revision,
 		UpdatedAt:    formatTime(issue.UpdatedAt),
+		ScheduledOn:  metadataString(issue.Metadata, "scheduled_on"),
+		Timezone:     metadataString(issue.Metadata, "timezone"),
 	}
 }
 
-func (h toolHandlers) mutation(issue generated.Issue, changed bool, reused *bool, event *generated.Event) MutationOutput {
+func summaryFromGlobalIssue(issue generated.ListGlobalIssueOut) IssueSummary {
+	return IssueSummary{
+		UID: issue.UID, Ref: issue.ShortID, QualifiedRef: issue.QualifiedID,
+		Title: issue.Title, Status: issue.Status, Owner: issue.Owner, Priority: issue.Priority,
+		Labels: stringSlicePointer(nonNilStrings(issue.Labels)), Blocked: issue.Blocked,
+		Revision: issue.Revision, UpdatedAt: formatTime(issue.UpdatedAt),
+		ScheduledOn: metadataString(issue.Metadata, "scheduled_on"), Timezone: metadataString(issue.Metadata, "timezone"),
+	}
+}
+
+func summaryFromReadyGlobalIssue(issue generated.ReadyGlobalIssueOut) IssueSummary {
+	return IssueSummary{
+		UID: issue.UID, Ref: issue.ShortID, QualifiedRef: issue.QualifiedID,
+		Title: issue.Title, Status: issue.Status, Owner: issue.Owner, Priority: issue.Priority,
+		Labels: stringSlicePointer(nonNilStrings(issue.Labels)), Blocked: issue.Blocked,
+		Revision: issue.Revision, UpdatedAt: formatTime(issue.UpdatedAt),
+		ScheduledOn: metadataString(issue.Metadata, "scheduled_on"), Timezone: metadataString(issue.Metadata, "timezone"),
+	}
+}
+
+func metadataString(values map[string]any, key string) *string {
+	value, ok := values[key].(string)
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+func (h toolHandlers) mutation(project ProjectIdentity, issue generated.Issue, changed bool, reused *bool, event *generated.Event) MutationOutput {
 	return MutationOutput{
-		Project: h.project(),
-		Issue:   h.summaryFromIssue(issue),
+		Project: project,
+		Issue:   h.summaryFromIssue(project, issue),
 		Changed: changed,
 		Reused:  reused,
 		Event:   eventSummary(event),
@@ -738,6 +1118,15 @@ func commentSummary(comment generated.Comment) CommentSummary {
 }
 
 func linkSummary(issueUID string, link generated.LinkOut) LinkSummary {
+	peer, typeName := linkPeerAndType(issueUID, link)
+	return LinkSummary{
+		Type:         typeName,
+		QualifiedRef: peer.QualifiedID,
+		Status:       peer.Status,
+	}
+}
+
+func linkPeerAndType(issueUID string, link generated.LinkOut) (generated.LinkPeer, string) {
 	peer := link.To
 	typeName := link.Type
 	if link.To.UID == issueUID {
@@ -749,11 +1138,7 @@ func linkSummary(issueUID string, link generated.LinkOut) LinkSummary {
 			typeName = "child"
 		}
 	}
-	return LinkSummary{
-		Type:         typeName,
-		QualifiedRef: peer.QualifiedID,
-		Status:       peer.Status,
-	}
+	return peer, typeName
 }
 
 func linkChangesSummary(changes *generated.LinkChanges) *LinkChangesSummary {
@@ -795,7 +1180,7 @@ func linkPeerSummary(peer *generated.LinkPeer) *LinkPeerSummary {
 	}
 }
 
-func (h toolHandlers) convertEvidence(input Evidence) (generated.Evidence, error) {
+func (h toolHandlers) convertEvidence(ctx context.Context, project ProjectIdentity, input Evidence) (generated.Evidence, error) {
 	typeName := strings.TrimSpace(input.Type)
 	allowed := map[string]bool{
 		"commit": true, "pr": true, "test": true, "reviewed-paths": true,
@@ -811,7 +1196,7 @@ func (h toolHandlers) convertEvidence(input Evidence) (generated.Evidence, error
 	result.Command = optionalString(input.Command)
 	result.Rationale = optionalString(input.Rationale)
 	if input.IssueRef != "" {
-		ref, err := h.boundRelationshipRef(input.IssueRef)
+		ref, err := h.relationshipRef(ctx, project, input.IssueRef)
 		if err != nil {
 			return generated.Evidence{}, err
 		}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -28,6 +28,13 @@ type toolHandlers struct {
 	options Options
 }
 
+func (h toolHandlers) withLongRunningClient() toolHandlers {
+	if h.options.LongRunningClient != nil {
+		h.options.Client = h.options.LongRunningClient
+	}
+	return h
+}
+
 func (h toolHandlers) search(ctx context.Context, _ *sdkmcp.CallToolRequest, input SearchInput) (*sdkmcp.CallToolResult, SearchOutput, error) {
 	query := strings.TrimSpace(input.Query)
 	if query == "" {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -345,8 +346,8 @@ func (h toolHandlers) ready(ctx context.Context, _ *sdkmcp.CallToolRequest, inpu
 
 func sortIssueSummaries(issues []IssueSummary) {
 	sort.SliceStable(issues, func(i, j int) bool {
-		if issues[i].UpdatedAt != issues[j].UpdatedAt {
-			return issues[i].UpdatedAt > issues[j].UpdatedAt
+		if !issues[i].updatedAt.Equal(issues[j].updatedAt) {
+			return issues[i].updatedAt.After(issues[j].updatedAt)
 		}
 		return issues[i].QualifiedRef < issues[j].QualifiedRef
 	})
@@ -520,7 +521,7 @@ func (h toolHandlers) edit(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 	if err := validatePriority(input.Priority); err != nil {
 		return nil, EditOutput{}, err
 	}
-	delta, err := h.linksDelta(ctx, project, input)
+	delta, linksRequested, err := h.linksDelta(ctx, project, input)
 	if err != nil {
 		return nil, EditOutput{}, err
 	}
@@ -542,10 +543,10 @@ func (h toolHandlers) edit(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 		body.Owner = &empty
 	}
 	hasIssueEdit := body.Title != nil || body.Body != nil || body.Owner != nil || body.SetPriority != nil || body.ClearPriority != nil || body.LinksDelta != nil
-	if !hasIssueEdit && len(metadataPatch) == 0 {
+	if !hasIssueEdit && !linksRequested && len(metadataPatch) == 0 {
 		return nil, EditOutput{}, errors.New("edit requires at least one change")
 	}
-	if hasIssueEdit && len(metadataPatch) > 0 {
+	if (hasIssueEdit || linksRequested) && len(metadataPatch) > 0 {
 		return nil, EditOutput{}, errors.New("issue fields and metadata must be changed in separate calls")
 	}
 	var issue generated.Issue
@@ -553,6 +554,15 @@ func (h toolHandlers) edit(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 	var mainEvent *EventSummary
 	var changes *LinkChangesSummary
 	events := make([]EventSummary, 0)
+	if !hasIssueEdit && linksRequested {
+		response, showErr := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
+			PathParams: &generated.ShowIssuePath{ProjectID: project.ID, Ref: ref},
+		})
+		if showErr != nil {
+			return nil, EditOutput{}, showErr
+		}
+		issue = response.Issue
+	}
 	if hasIssueEdit {
 		response, editErr := h.options.Client.EditIssue(ctx, &generated.EditIssueRequestOptions{
 			PathParams: &generated.EditIssuePath{ProjectID: project.ID, Ref: ref},
@@ -826,7 +836,7 @@ func (h toolHandlers) reopen(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 func (h toolHandlers) createLinks(ctx context.Context, project ProjectIdentity, input CreateInput) ([]generated.CreateInitialLinkBody, error) {
 	links := make([]generated.CreateInitialLinkBody, 0, 1+len(input.Blocks)+len(input.BlockedBy)+len(input.Related))
 	add := func(ref string, linkType generated.CreateInitialLinkBodyType, incoming bool) error {
-		bound, err := h.relationshipRef(ctx, project, ref)
+		target, err := h.relationshipRef(ctx, project, ref)
 		if err != nil {
 			return err
 		}
@@ -834,7 +844,9 @@ func (h toolHandlers) createLinks(ctx context.Context, project ProjectIdentity, 
 		if incoming {
 			incomingPointer = &incoming
 		}
-		links = append(links, generated.CreateInitialLinkBody{Type: linkType, ToRef: bound, Incoming: incomingPointer})
+		links = append(links, generated.CreateInitialLinkBody{
+			Type: linkType, ToRef: target.IssueUID, ToProjectUID: &target.ProjectUID, Incoming: incomingPointer,
+		})
 		return nil
 	}
 	if input.Parent != "" {
@@ -860,55 +872,75 @@ func (h toolHandlers) createLinks(ctx context.Context, project ProjectIdentity, 
 	return links, nil
 }
 
-func (h toolHandlers) linksDelta(ctx context.Context, project ProjectIdentity, input EditInput) (*generated.LinksDelta, error) {
+func (h toolHandlers) linksDelta(ctx context.Context, project ProjectIdentity, input EditInput) (*generated.LinksDelta, bool, error) {
 	delta := &generated.LinksDelta{}
 	var changed bool
+	var requested bool
+	addExpectedProject := func(target relationshipTarget) {
+		if delta.ExpectedProjectUids == nil {
+			delta.ExpectedProjectUids = make(map[string]string)
+		}
+		delta.ExpectedProjectUids[target.IssueUID] = target.ProjectUID
+	}
 	setOne := func(target **string, raw string) error {
-		ref, err := h.relationshipRef(ctx, project, raw)
+		requested = true
+		resolved, err := h.relationshipRef(ctx, project, raw)
 		if err != nil {
 			return err
 		}
-		*target = &ref
+		*target = &resolved.IssueUID
+		addExpectedProject(resolved)
 		changed = true
 		return nil
 	}
-	setMany := func(target *[]string, raw []string) error {
+	setMany := func(target *[]string, raw []string, tolerateMissing bool) error {
 		for _, item := range raw {
-			ref, err := h.relationshipRef(ctx, project, item)
+			requested = true
+			resolved, err := h.relationshipRef(ctx, project, item)
 			if err != nil {
+				if tolerateMissing && isHTTPStatus(err, http.StatusNotFound) {
+					continue
+				}
 				return err
 			}
-			*target = append(*target, ref)
+			*target = append(*target, resolved.IssueUID)
+			addExpectedProject(resolved)
 			changed = true
 		}
 		return nil
 	}
 	if input.Parent != nil {
 		if err := setOne(&delta.SetParent, *input.Parent); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 	if input.RemoveParent != nil {
 		if err := setOne(&delta.RemoveParent, *input.RemoveParent); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 	for target, refs := range map[*[]string][]string{
-		&delta.AddBlocks:       input.AddBlocks,
+		&delta.AddBlocks:    input.AddBlocks,
+		&delta.AddBlockedBy: input.AddBlockedBy,
+		&delta.AddRelated:   input.AddRelated,
+	} {
+		if err := setMany(target, refs, false); err != nil {
+			return nil, false, err
+		}
+	}
+	for target, refs := range map[*[]string][]string{
 		&delta.RemoveBlocks:    input.RemoveBlocks,
-		&delta.AddBlockedBy:    input.AddBlockedBy,
 		&delta.RemoveBlockedBy: input.RemoveBlockedBy,
-		&delta.AddRelated:      input.AddRelated,
 		&delta.RemoveRelated:   input.RemoveRelated,
 	} {
-		if err := setMany(target, refs); err != nil {
-			return nil, err
+		if err := setMany(target, refs, true); err != nil {
+			return nil, false, err
 		}
 	}
 	if !changed {
-		return nil, nil
+		return nil, requested, nil
 	}
-	return delta, nil
+	return delta, requested, nil
 }
 
 func (h toolHandlers) boundRelationshipRef(raw string) (string, error) {
@@ -1034,34 +1066,57 @@ func copyMetadata(source map[string]any) map[string]any {
 	return result
 }
 
-func (h toolHandlers) relationshipRef(ctx context.Context, source ProjectIdentity, raw string) (string, error) {
+type relationshipTarget struct {
+	IssueUID   string
+	ProjectUID string
+}
+
+func (h toolHandlers) relationshipRef(ctx context.Context, source ProjectIdentity, raw string) (relationshipTarget, error) {
 	ref := strings.TrimSpace(raw)
 	if ref == "" {
-		return "", errors.New("relationship reference must not be empty")
+		return relationshipTarget{}, errors.New("relationship reference must not be empty")
 	}
 	parsed, err := shortid.Parse(ref)
 	if err != nil {
-		return "", fmt.Errorf("relationship reference %q is invalid", ref)
+		return relationshipTarget{}, fmt.Errorf("relationship reference %q is invalid", ref)
 	}
 	if parsed.ULID != "" {
-		return "", fmt.Errorf("relationship reference %q is an unscoped UID; use a project-qualified short reference", ref)
+		return relationshipTarget{}, fmt.Errorf("relationship reference %q is an unscoped UID; use a project-qualified short reference", ref)
 	}
 	if len(parsed.ShortID) == shortid.MaxLength {
-		return "", fmt.Errorf("relationship reference %q uses an ambiguous full-length short ID; use a shorter project-qualified reference", ref)
+		return relationshipTarget{}, fmt.Errorf("relationship reference %q uses an ambiguous full-length short ID; use a shorter project-qualified reference", ref)
 	}
+	targetProject := source
 	if h.options.Scope.Mode() == ScopeBound {
 		if parsed.Project != "" && parsed.Project != source.Name {
-			return "", fmt.Errorf("relationship reference %q is outside bound project %q", ref, source.Name)
+			return relationshipTarget{}, fmt.Errorf("relationship reference %q is outside bound project %q", ref, source.Name)
 		}
-		return parsed.ShortID, nil
+	} else {
+		if parsed.Project == "" {
+			return relationshipTarget{}, errors.New("multi-project relationships require project#ref")
+		}
+		targetProject, err = h.options.Scope.Project(ctx, h.options.Client, parsed.Project, false)
+		if err != nil {
+			return relationshipTarget{}, err
+		}
 	}
-	if parsed.Project == "" {
-		return "", errors.New("multi-project relationships require project#ref")
+	shown, err := h.options.Client.ShowIssue(ctx, &generated.ShowIssueRequestOptions{
+		PathParams: &generated.ShowIssuePath{ProjectID: targetProject.ID, Ref: parsed.ShortID},
+	})
+	if err != nil {
+		return relationshipTarget{}, err
 	}
-	if _, err := h.options.Scope.Project(ctx, h.options.Client, parsed.Project, false); err != nil {
-		return "", err
+	projectUID := ""
+	if shown.Issue.ProjectUID != nil {
+		projectUID = *shown.Issue.ProjectUID
 	}
-	return parsed.Project + "#" + parsed.ShortID, nil
+	if targetProject.UID != "" && projectUID != targetProject.UID {
+		return relationshipTarget{}, fmt.Errorf("relationship reference %q resolved outside the MCP startup scope", ref)
+	}
+	if shown.Issue.UID == "" || projectUID == "" {
+		return relationshipTarget{}, fmt.Errorf("relationship reference %q did not resolve to immutable identity", ref)
+	}
+	return relationshipTarget{IssueUID: shown.Issue.UID, ProjectUID: projectUID}, nil
 }
 
 // outputProjectScope returns the singular project only when exactly one
@@ -1095,6 +1150,7 @@ func (h toolHandlers) summaryFromIssue(project ProjectIdentity, issue generated.
 		UpdatedAt:    formatTime(issue.UpdatedAt),
 		ScheduledOn:  metadataString(issue.Metadata, "scheduled_on"),
 		Timezone:     metadataString(issue.Metadata, "timezone"),
+		updatedAt:    issue.UpdatedAt,
 	}
 }
 
@@ -1117,6 +1173,7 @@ func (h toolHandlers) summaryFromIssueOut(project ProjectIdentity, issue generat
 		UpdatedAt:    formatTime(issue.UpdatedAt),
 		ScheduledOn:  metadataString(issue.Metadata, "scheduled_on"),
 		Timezone:     metadataString(issue.Metadata, "timezone"),
+		updatedAt:    issue.UpdatedAt,
 	}
 }
 
@@ -1127,6 +1184,7 @@ func summaryFromGlobalIssue(issue generated.ListGlobalIssueOut) IssueSummary {
 		Labels: stringSlicePointer(nonNilStrings(issue.Labels)), Blocked: issue.Blocked,
 		Revision: issue.Revision, UpdatedAt: formatTime(issue.UpdatedAt),
 		ScheduledOn: metadataString(issue.Metadata, "scheduled_on"), Timezone: metadataString(issue.Metadata, "timezone"),
+		updatedAt: issue.UpdatedAt,
 	}
 }
 
@@ -1137,6 +1195,7 @@ func summaryFromReadyGlobalIssue(issue generated.ReadyGlobalIssueOut) IssueSumma
 		Labels: stringSlicePointer(nonNilStrings(issue.Labels)), Blocked: issue.Blocked,
 		Revision: issue.Revision, UpdatedAt: formatTime(issue.UpdatedAt),
 		ScheduledOn: metadataString(issue.Metadata, "scheduled_on"), Timezone: metadataString(issue.Metadata, "timezone"),
+		updatedAt: issue.UpdatedAt,
 	}
 }
 
@@ -1328,11 +1387,11 @@ func (h toolHandlers) convertEvidence(ctx context.Context, project ProjectIdenti
 	result.Command = optionalString(input.Command)
 	result.Rationale = optionalString(input.Rationale)
 	if input.IssueRef != "" {
-		ref, err := h.relationshipRef(ctx, project, input.IssueRef)
+		target, err := h.relationshipRef(ctx, project, input.IssueRef)
 		if err != nil {
 			return generated.Evidence{}, err
 		}
-		result.IssueRef = &ref
+		result.IssueRef = &target.IssueUID
 	}
 	switch typeName {
 	case "commit":

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -773,9 +773,33 @@ func (h toolHandlers) close(ctx context.Context, _ *sdkmcp.CallToolRequest, inpu
 		},
 	})
 	if err != nil {
-		return nil, MutationOutput{}, err
+		return nil, MutationOutput{}, h.scopedCloseError(err)
 	}
 	return successResult(), h.mutation(project, response.Issue, response.Changed, response.Reused, &response.Event), nil
+}
+
+// Close-guard refusals render child, sibling-cohort, and prior-close
+// identities that can live outside the startup scope (parent links span
+// projects), so scoped servers replace those messages with scope-safe
+// guidance instead of forwarding the daemon prose verbatim.
+var crossScopeCloseGuardMessages = map[string]string{
+	"parent_has_open_children": "issue still has open children; close, move, or detach them first (child identities outside the MCP startup scope are not listed)",
+	"sibling_throttle":         "close refused by the sibling close-burst throttle; wait before closing more children of this parent (sibling identities outside the MCP startup scope are not listed)",
+	"duplicate_message":        "close refused because the message matches your recent close of a sibling; write a message specific to this issue or close as duplicate-of/superseded-by",
+}
+
+func (h toolHandlers) scopedCloseError(err error) error {
+	if h.options.Scope.Mode() == ScopeAll {
+		return err
+	}
+	var envelope generated.ErrorEnvelope
+	if !errors.As(err, &envelope) {
+		return err
+	}
+	if message, guarded := crossScopeCloseGuardMessages[envelope.ErrorData.Code]; guarded {
+		return fmt.Errorf("%s: %s", envelope.ErrorData.Code, message)
+	}
+	return err
 }
 
 func (h toolHandlers) reopen(ctx context.Context, _ *sdkmcp.CallToolRequest, input ReopenInput) (*sdkmcp.CallToolResult, MutationOutput, error) {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -537,7 +537,11 @@ func (h toolHandlers) edit(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 		issue = response.Issue
 		changed = response.Changed
 		mainEvent = eventSummary(&response.Event)
-		changes = linkChangesSummary(response.Changes)
+		scopedChanges, changesErr := h.scopedLinkChanges(ctx, response.Changes)
+		if changesErr != nil {
+			return nil, EditOutput{}, changesErr
+		}
+		changes = linkChangesSummary(scopedChanges)
 		for index := range response.Events {
 			if event := eventSummary(&response.Events[index]); event != nil {
 				events = append(events, *event)
@@ -1139,6 +1143,53 @@ func linkPeerAndType(issueUID string, link generated.LinkOut) (generated.LinkPee
 		}
 	}
 	return peer, typeName
+}
+
+// scopedLinkChanges removes relationship-change peers in projects outside
+// the startup scope, such as a replaced parent that lived in a foreign
+// project, before the deltas reach the client.
+func (h toolHandlers) scopedLinkChanges(ctx context.Context, changes *generated.LinkChanges) (*generated.LinkChanges, error) {
+	if changes == nil || h.options.Scope.Mode() == ScopeAll {
+		return changes, nil
+	}
+	projects, err := h.options.Scope.Projects(ctx, h.options.Client, true)
+	if err != nil {
+		return nil, err
+	}
+	inScope := make(map[string]struct{}, len(projects))
+	for _, project := range projects {
+		inScope[project.Name] = struct{}{}
+	}
+	keep := func(peers []generated.LinkPeer) []generated.LinkPeer {
+		kept := make([]generated.LinkPeer, 0, len(peers))
+		for _, peer := range peers {
+			if _, ok := inScope[peer.Project]; ok {
+				kept = append(kept, peer)
+			}
+		}
+		if len(kept) == 0 {
+			return nil
+		}
+		return kept
+	}
+	keepOne := func(peer *generated.LinkPeer) *generated.LinkPeer {
+		if peer == nil {
+			return nil
+		}
+		if _, ok := inScope[peer.Project]; !ok {
+			return nil
+		}
+		return peer
+	}
+	changes.BlockedByAdded = keep(changes.BlockedByAdded)
+	changes.BlockedByRemoved = keep(changes.BlockedByRemoved)
+	changes.BlocksAdded = keep(changes.BlocksAdded)
+	changes.BlocksRemoved = keep(changes.BlocksRemoved)
+	changes.ParentRemoved = keepOne(changes.ParentRemoved)
+	changes.ParentSet = keepOne(changes.ParentSet)
+	changes.RelatedAdded = keep(changes.RelatedAdded)
+	changes.RelatedRemoved = keep(changes.RelatedRemoved)
+	return changes, nil
 }
 
 func linkChangesSummary(changes *generated.LinkChanges) *LinkChangesSummary {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1199,46 +1199,78 @@ func linkPeerAndType(issueUID string, link generated.LinkOut) (generated.LinkPee
 	return peer, typeName
 }
 
-// scopedLinkChanges removes relationship-change peers in projects outside
-// the startup scope, such as a replaced parent that lived in a foreign
-// project, before the deltas reach the client.
+// scopedLinkChanges removes relationship-change peers outside the active
+// startup scope before the deltas reach the client. Live edit responses must
+// not retain archived allowlist members, and peer UIDs must resolve into an
+// active project authorized by immutable project identity.
 func (h toolHandlers) scopedLinkChanges(ctx context.Context, changes *generated.LinkChanges) (*generated.LinkChanges, error) {
 	if changes == nil || h.options.Scope.Mode() == ScopeAll {
 		return changes, nil
 	}
-	inScope, err := h.scopeProjectNames(ctx)
+	projects, err := h.options.Scope.Projects(ctx, h.options.Client, false)
 	if err != nil {
 		return nil, err
 	}
-	keep := func(peers []generated.LinkPeer) []generated.LinkPeer {
+	activeProjectIDs := make(map[int64]struct{}, len(projects))
+	for _, project := range projects {
+		activeProjectIDs[project.ID] = struct{}{}
+	}
+	resolved := make(map[string]bool)
+	allowed := func(peer generated.LinkPeer) (bool, error) {
+		if cached, ok := resolved[peer.UID]; ok {
+			return cached, nil
+		}
+		inProject, resolveErr := h.issueUIDInScope(ctx, peer.UID, activeProjectIDs)
+		if resolveErr != nil {
+			return false, resolveErr
+		}
+		resolved[peer.UID] = inProject
+		return inProject, nil
+	}
+	keep := func(peers []generated.LinkPeer) ([]generated.LinkPeer, error) {
 		kept := make([]generated.LinkPeer, 0, len(peers))
 		for _, peer := range peers {
-			if _, ok := inScope[peer.Project]; ok {
+			ok, allowErr := allowed(peer)
+			if allowErr != nil {
+				return nil, allowErr
+			}
+			if ok {
 				kept = append(kept, peer)
 			}
 		}
 		if len(kept) == 0 {
-			return nil
+			return nil, nil
 		}
-		return kept
+		return kept, nil
 	}
-	keepOne := func(peer *generated.LinkPeer) *generated.LinkPeer {
+	keepOne := func(peer *generated.LinkPeer) (*generated.LinkPeer, error) {
 		if peer == nil {
-			return nil
+			return nil, nil
 		}
-		if _, ok := inScope[peer.Project]; !ok {
-			return nil
+		ok, allowErr := allowed(*peer)
+		if allowErr != nil || !ok {
+			return nil, allowErr
 		}
-		return peer
+		return peer, nil
 	}
-	changes.BlockedByAdded = keep(changes.BlockedByAdded)
-	changes.BlockedByRemoved = keep(changes.BlockedByRemoved)
-	changes.BlocksAdded = keep(changes.BlocksAdded)
-	changes.BlocksRemoved = keep(changes.BlocksRemoved)
-	changes.ParentRemoved = keepOne(changes.ParentRemoved)
-	changes.ParentSet = keepOne(changes.ParentSet)
-	changes.RelatedAdded = keep(changes.RelatedAdded)
-	changes.RelatedRemoved = keep(changes.RelatedRemoved)
+	for _, peers := range []*[]generated.LinkPeer{
+		&changes.BlockedByAdded, &changes.BlockedByRemoved,
+		&changes.BlocksAdded, &changes.BlocksRemoved,
+		&changes.RelatedAdded, &changes.RelatedRemoved,
+	} {
+		filtered, filterErr := keep(*peers)
+		if filterErr != nil {
+			return nil, filterErr
+		}
+		*peers = filtered
+	}
+	for _, peer := range []**generated.LinkPeer{&changes.ParentRemoved, &changes.ParentSet} {
+		filtered, filterErr := keepOne(*peer)
+		if filterErr != nil {
+			return nil, filterErr
+		}
+		*peer = filtered
+	}
 	return changes, nil
 }
 

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -410,26 +410,20 @@ func (h toolHandlers) show(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 	for _, label := range response.Labels {
 		labels = append(labels, label.Label)
 	}
-	links := make([]LinkSummary, 0, len(response.Links))
-	var allowedLinkProjects map[string]struct{}
-	if h.options.Scope.Mode() != ScopeAll {
-		projects, scopeErr := h.options.Scope.Projects(ctx, h.options.Client, false)
-		if scopeErr != nil {
-			return nil, ShowOutput{}, scopeErr
-		}
-		allowedLinkProjects = make(map[string]struct{}, len(projects))
-		for _, allowedProject := range projects {
-			allowedLinkProjects[allowedProject.Name] = struct{}{}
-		}
+	peerAllowed, err := h.linkPeerScopeFilter(ctx)
+	if err != nil {
+		return nil, ShowOutput{}, err
 	}
+	links := make([]LinkSummary, 0, len(response.Links))
 	for _, link := range response.Links {
 		peer, _ := linkPeerAndType(response.Issue.UID, link)
-		if allowedLinkProjects != nil {
-			if _, allowed := allowedLinkProjects[peer.Project]; !allowed {
-				continue
-			}
+		allowed, allowErr := peerAllowed(peer)
+		if allowErr != nil {
+			return nil, ShowOutput{}, allowErr
 		}
-		links = append(links, linkSummary(response.Issue.UID, link))
+		if allowed {
+			links = append(links, linkSummary(response.Issue.UID, link))
+		}
 	}
 	summary := h.summaryFromIssue(project, response.Issue)
 	metadata := response.Issue.Metadata
@@ -1257,13 +1251,15 @@ func linkPeerAndType(issueUID string, link generated.LinkOut) (generated.LinkPee
 	return peer, typeName
 }
 
-// scopedLinkChanges removes relationship-change peers outside the active
-// startup scope before the deltas reach the client. Live edit responses must
-// not retain archived allowlist members, and peer UIDs must resolve into an
-// active project authorized by immutable project identity.
-func (h toolHandlers) scopedLinkChanges(ctx context.Context, changes *generated.LinkChanges) (*generated.LinkChanges, error) {
-	if changes == nil || h.options.Scope.Mode() == ScopeAll {
-		return changes, nil
+// linkPeerScopeFilter returns a predicate reporting whether a relationship
+// peer may be published. Daemon-wide scope allows every peer. Otherwise the
+// peer's UID must resolve into an active project authorized by immutable
+// project identity; the peer's display project name is never consulted
+// because a concurrent rename can reuse an in-scope name. Lookups are cached
+// per predicate, so callers should build one per response.
+func (h toolHandlers) linkPeerScopeFilter(ctx context.Context) (func(generated.LinkPeer) (bool, error), error) {
+	if h.options.Scope.Mode() == ScopeAll {
+		return func(generated.LinkPeer) (bool, error) { return true, nil }, nil
 	}
 	projects, err := h.options.Scope.Projects(ctx, h.options.Client, false)
 	if err != nil {
@@ -1274,7 +1270,7 @@ func (h toolHandlers) scopedLinkChanges(ctx context.Context, changes *generated.
 		activeProjectIDs[project.ID] = struct{}{}
 	}
 	resolved := make(map[string]bool)
-	allowed := func(peer generated.LinkPeer) (bool, error) {
+	return func(peer generated.LinkPeer) (bool, error) {
 		if cached, ok := resolved[peer.UID]; ok {
 			return cached, nil
 		}
@@ -1284,6 +1280,20 @@ func (h toolHandlers) scopedLinkChanges(ctx context.Context, changes *generated.
 		}
 		resolved[peer.UID] = inProject
 		return inProject, nil
+	}, nil
+}
+
+// scopedLinkChanges removes relationship-change peers outside the active
+// startup scope before the deltas reach the client. Live edit responses must
+// not retain archived allowlist members, and peer UIDs must resolve into an
+// active project authorized by immutable project identity.
+func (h toolHandlers) scopedLinkChanges(ctx context.Context, changes *generated.LinkChanges) (*generated.LinkChanges, error) {
+	if changes == nil || h.options.Scope.Mode() == ScopeAll {
+		return changes, nil
+	}
+	allowed, err := h.linkPeerScopeFilter(ctx)
+	if err != nil {
+		return nil, err
 	}
 	keep := func(peers []generated.LinkPeer) ([]generated.LinkPeer, error) {
 		kept := make([]generated.LinkPeer, 0, len(peers))

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1152,13 +1152,9 @@ func (h toolHandlers) scopedLinkChanges(ctx context.Context, changes *generated.
 	if changes == nil || h.options.Scope.Mode() == ScopeAll {
 		return changes, nil
 	}
-	projects, err := h.options.Scope.Projects(ctx, h.options.Client, true)
+	inScope, err := h.scopeProjectNames(ctx)
 	if err != nil {
 		return nil, err
-	}
-	inScope := make(map[string]struct{}, len(projects))
-	for _, project := range projects {
-		inScope[project.Name] = struct{}{}
 	}
 	keep := func(peers []generated.LinkPeer) []generated.LinkPeer {
 		kept := make([]generated.LinkPeer, 0, len(peers))

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -80,25 +80,34 @@ func (h toolHandlers) search(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 	if err := group.Wait(); err != nil {
 		return nil, SearchOutput{}, err
 	}
-	results := make([]SearchHit, 0)
+	type rankedHit struct {
+		hit  SearchHit
+		rank int
+	}
+	ranked := make([]rankedHit, 0)
 	truncated := false
 	degraded := false
 	degradedReasons := make([]string, 0)
 	effectiveMode := ""
 	for index, search := range searches {
 		response := search.response
-		if effectiveMode == "" {
+		switch {
+		case effectiveMode == "":
 			effectiveMode = response.Mode
+		case effectiveMode != response.Mode:
+			// Auto mode can fall back per project; a single mode label
+			// would misdescribe the merged results.
+			effectiveMode = "mixed"
 		}
 		if len(response.Results) > limit {
 			truncated = true
 		}
-		for _, hit := range response.Results {
-			results = append(results, SearchHit{
+		for rank, hit := range response.Results {
+			ranked = append(ranked, rankedHit{rank: rank, hit: SearchHit{
 				Issue:     h.summaryFromIssue(projects[index], hit.Issue),
 				Score:     hit.Score,
 				MatchedIn: nonNilStrings(hit.MatchedIn),
-			})
+			}})
 		}
 		if response.Degraded != nil && *response.Degraded {
 			degraded = true
@@ -107,12 +116,23 @@ func (h toolHandlers) search(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 			degradedReasons = append(degradedReasons, projects[index].Name+": "+*response.DegradedReason)
 		}
 	}
-	sort.SliceStable(results, func(i, j int) bool {
-		if results[i].Score != results[j].Score {
-			return results[i].Score > results[j].Score
+	// Scores from independent per-project searches are request-local
+	// (hybrid uses reciprocal-rank values and auto can fall back per
+	// project), so fuse by each project's own ranking instead of
+	// comparing raw scores across projects.
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if ranked[i].rank != ranked[j].rank {
+			return ranked[i].rank < ranked[j].rank
 		}
-		return results[i].Issue.QualifiedRef < results[j].Issue.QualifiedRef
+		if ranked[i].hit.Score != ranked[j].hit.Score {
+			return ranked[i].hit.Score > ranked[j].hit.Score
+		}
+		return ranked[i].hit.Issue.QualifiedRef < ranked[j].hit.Issue.QualifiedRef
 	})
+	results := make([]SearchHit, 0, len(ranked))
+	for _, entry := range ranked {
+		results = append(results, entry.hit)
+	}
 	if len(results) > limit {
 		results = results[:limit]
 		truncated = true
@@ -1014,11 +1034,14 @@ func (h toolHandlers) relationshipRef(ctx context.Context, source ProjectIdentit
 	return parsed.Project + "#" + parsed.ShortID, nil
 }
 
-func outputProjectScope(projects []ProjectIdentity) (ProjectIdentity, []ProjectIdentity) {
+// outputProjectScope returns the singular project only when exactly one
+// project was queried; multi-project responses carry the projects list and
+// omit the singular field instead of populating an invalid zero identity.
+func outputProjectScope(projects []ProjectIdentity) (*ProjectIdentity, []ProjectIdentity) {
 	if len(projects) == 1 {
-		return projects[0], nil
+		return &projects[0], nil
 	}
-	return ProjectIdentity{}, projects
+	return nil, projects
 }
 
 func projectIDSet(projects []ProjectIdentity) map[int64]struct{} {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -565,10 +565,9 @@ func (h toolHandlers) edit(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 		changed = response.Changed
 		mainEvent = eventSummary(&response.Event)
 		scopedChanges, changesErr := h.scopedLinkChanges(ctx, response.Changes)
-		if changesErr != nil {
-			return nil, EditOutput{}, changesErr
+		if changesErr == nil {
+			changes = linkChangesSummary(scopedChanges)
 		}
-		changes = linkChangesSummary(scopedChanges)
 		for index := range response.Events {
 			if event := eventSummary(&response.Events[index]); event != nil {
 				events = append(events, *event)

--- a/internal/mcp/imports.go
+++ b/internal/mcp/imports.go
@@ -1,0 +1,50 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// ImportIssuesInput carries a bounded structured issue batch.
+type ImportIssuesInput struct {
+	Project string                       `json:"project,omitempty"`
+	Source  string                       `json:"source"`
+	Items   []generated.ImportIssueInput `json:"items"`
+}
+
+// ImportIssuesOutput reports structured issue import results.
+type ImportIssuesOutput struct {
+	Project ProjectIdentity             `json:"project"`
+	Result  generated.ImportBatchResult `json:"result"`
+}
+
+func registerImportTools(server *sdkmcp.Server, handlers toolHandlers) {
+	addTool(server, "kata.import_issues", "Import issues", "Import a bounded structured issue batch into an in-scope project.", toolHints(false, false, true), handlers.importIssues)
+}
+
+func (h toolHandlers) importIssues(ctx context.Context, _ *sdkmcp.CallToolRequest, input ImportIssuesInput) (*sdkmcp.CallToolResult, ImportIssuesOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
+	if err != nil {
+		return nil, ImportIssuesOutput{}, err
+	}
+	if strings.TrimSpace(input.Source) == "" {
+		return nil, ImportIssuesOutput{}, errors.New("source is required")
+	}
+	if len(input.Items) == 0 || len(input.Items) > maximumResultLimit {
+		return nil, ImportIssuesOutput{}, fmt.Errorf("items must contain between 1 and %d issues", maximumResultLimit)
+	}
+	response, err := h.options.Client.ImportIssues(ctx, &generated.ImportIssuesRequestOptions{
+		PathParams: &generated.ImportIssuesPath{ProjectID: project.ID},
+		Body:       &generated.ImportIssuesBody{Actor: h.options.Actor, Source: input.Source, Items: input.Items},
+	})
+	if err != nil {
+		return nil, ImportIssuesOutput{}, err
+	}
+	return successResult(), ImportIssuesOutput{Project: project, Result: *response}, nil
+}

--- a/internal/mcp/imports.go
+++ b/internal/mcp/imports.go
@@ -25,7 +25,7 @@ type ImportIssuesOutput struct {
 }
 
 func registerImportTools(server *sdkmcp.Server, handlers toolHandlers) {
-	addTool(server, "kata.import_issues", "Import issues", "Import a bounded structured issue batch into an in-scope project.", toolHints(false, false, true), handlers.importIssues)
+	addTool(server, "kata.import_issues", "Import issues", "Import a bounded structured issue batch into an in-scope project; existing external_id matches are updated in place.", toolHints(false, true, true), handlers.importIssues)
 }
 
 func (h toolHandlers) importIssues(ctx context.Context, _ *sdkmcp.CallToolRequest, input ImportIssuesInput) (*sdkmcp.CallToolResult, ImportIssuesOutput, error) {

--- a/internal/mcp/issues_test.go
+++ b/internal/mcp/issues_test.go
@@ -1,0 +1,333 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	kataclient "go.kenn.io/kata/pkg/client"
+)
+
+func TestMultiProjectListWithoutProjectReturnsBothProjects(t *testing.T) {
+	session, _ := connectMultiProjectServer(t, nil)
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.list", Arguments: map[string]any{"limit": 20}})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "%s", mustJSON(t, result))
+	issues := result.StructuredContent.(map[string]any)["issues"].([]any)
+	require.Equal(t, []string{"hub-project#hbb1", "spoke-project#spk1"}, []string{
+		issues[0].(map[string]any)["qualified_ref"].(string),
+		issues[1].(map[string]any)["qualified_ref"].(string),
+	})
+}
+
+func TestMultiProjectReadyWithoutProjectReturnsBothProjects(t *testing.T) {
+	session, _ := connectMultiProjectServer(t, nil)
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.ready", Arguments: map[string]any{"limit": 20}})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "%s", mustJSON(t, result))
+	issues := result.StructuredContent.(map[string]any)["issues"].([]any)
+	require.Len(t, issues, 2)
+}
+
+func TestMultiProjectIssueWritesRequireQualifiedReference(t *testing.T) {
+	session, requests := connectMultiProjectServer(t, nil)
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.claim", Arguments: map[string]any{"ref": "spk1"}})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Empty(t, *requests)
+}
+
+func TestMultiProjectCreateRequiresExplicitInScopeProject(t *testing.T) {
+	session, requests := connectMultiProjectServer(t, nil)
+
+	for _, arguments := range []map[string]any{
+		{"title": "Unscoped", "idempotency_key": "unscoped"},
+		{"project": "spoke-project", "title": "Bad relationship", "blocked_by": []any{"other-project#abcd"}, "idempotency_key": "outside"},
+	} {
+		result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.create", Arguments: arguments})
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+	}
+	require.Empty(t, *requests)
+}
+
+func TestMultiProjectShowRoutesQualifiedReference(t *testing.T) {
+	session, requests := connectMultiProjectServer(t, nil)
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.show", Arguments: map[string]any{"ref": "hub-project#hbb1"}})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "%s", mustJSON(t, result))
+	require.Contains(t, *requests, "/api/v1/projects/2/issues/hbb1")
+}
+
+func TestSearchFanoutUsesStableGlobalOrdering(t *testing.T) {
+	session, _ := connectMultiProjectServer(t, func(writer http.ResponseWriter, request *http.Request) bool {
+		if !strings.HasSuffix(request.URL.Path, "/search") {
+			return false
+		}
+		projectName := "spoke-project"
+		shortID := "spk1"
+		if strings.Contains(request.URL.Path, "/projects/2/") {
+			projectName = "hub-project"
+			shortID = "hbb1"
+		}
+		writeJSON(writer, map[string]any{
+			"query": "shared", "mode": "lexical",
+			"results": []any{map[string]any{"issue": issueJSON(1, projectName, shortID), "score": 2.0, "matched_in": []string{"title"}}},
+		})
+		return true
+	})
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.search", Arguments: map[string]any{"query": "shared", "limit": 20}})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	hits := result.StructuredContent.(map[string]any)["results"].([]any)
+	require.Equal(t, "hub-project#hbb1", hits[0].(map[string]any)["issue"].(map[string]any)["qualified_ref"])
+	require.Equal(t, "spoke-project#spk1", hits[1].(map[string]any)["issue"].(map[string]any)["qualified_ref"])
+}
+
+func TestSearchFanoutReturnsNoPartialResultWhenOneProjectFails(t *testing.T) {
+	session, _ := connectMultiProjectServer(t, func(writer http.ResponseWriter, request *http.Request) bool {
+		if !strings.HasSuffix(request.URL.Path, "/search") {
+			return false
+		}
+		if strings.Contains(request.URL.Path, "/projects/2/") {
+			writer.WriteHeader(http.StatusServiceUnavailable)
+			writeJSON(writer, map[string]any{"status": 503, "error": map[string]any{"code": "unavailable", "message": "search unavailable"}})
+			return true
+		}
+		writeJSON(writer, map[string]any{
+			"query": "shared", "mode": "lexical",
+			"results": []any{map[string]any{"issue": issueJSON(1, "spoke-project", "spk1"), "score": 2.0, "matched_in": []string{"title"}}},
+		})
+		return true
+	})
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.search", Arguments: map[string]any{"query": "shared"}})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Nil(t, result.StructuredContent)
+}
+
+func TestSchedulingAndForceInputsAreFirstClass(t *testing.T) {
+	create := CreateInput{
+		ScheduledOn: "2026-09-01T15:00", Timezone: "America/Los_Angeles", ForceNew: true,
+	}
+	edit := EditInput{
+		ScheduledOn: stringPointer("2026-09-01T15:00:30"), Timezone: stringPointer("America/Los_Angeles"),
+		ClearScheduledOn: false, ClearTimezone: false,
+	}
+	claim := ClaimInput{Force: true}
+	require.True(t, create.ForceNew)
+	require.NotNil(t, edit.ScheduledOn)
+	require.True(t, claim.Force)
+}
+
+func TestSchedulingMetadataAcceptsCivilTimeFormatsAndSomeday(t *testing.T) {
+	for _, scheduledOn := range []string{
+		"2026-09-01",
+		"2026-09-01T15:00",
+		"2026-09-01T15:00:30",
+		"2026-09-01T22:00:00Z",
+	} {
+		metadata, err := createMetadata(CreateInput{
+			ScheduledOn: scheduledOn,
+			Timezone:    "America/Los_Angeles",
+			Metadata:    map[string]any{"someday": true},
+		})
+		require.NoError(t, err, scheduledOn)
+		require.Equal(t, true, metadata["someday"])
+	}
+
+	patch, err := editMetadata(EditInput{Metadata: map[string]any{"someday": nil}, ClearScheduledOn: true})
+	require.NoError(t, err)
+	require.Contains(t, patch, "someday")
+	require.Nil(t, patch["someday"])
+	require.Nil(t, patch["scheduled_on"])
+}
+
+func TestEditSchedulingRejectsSetClearAndMetadataCollisions(t *testing.T) {
+	value := "2026-09-01"
+	zone := "UTC"
+	for _, input := range []EditInput{
+		{ScheduledOn: &value, ClearScheduledOn: true},
+		{Timezone: &zone, ClearTimezone: true},
+		{ScheduledOn: &value, Metadata: map[string]any{"scheduled_on": "2026-09-02"}},
+	} {
+		_, err := editMetadata(input)
+		require.Error(t, err)
+	}
+}
+
+func TestCreateRejectsNumericScheduleOffsetAndDedicatedCollision(t *testing.T) {
+	session := connectTestServer(t)
+	for _, arguments := range []map[string]any{
+		{"title": "Bad offset", "scheduled_on": "2026-09-01T15:00:00-07:00", "idempotency_key": "bad-offset"},
+		{"title": "Collision", "scheduled_on": "2026-09-01", "metadata": map[string]any{"scheduled_on": "2026-09-02"}, "idempotency_key": "collision"},
+		{"title": "Bad zone", "timezone": "Not/AZone", "idempotency_key": "bad-zone"},
+	} {
+		result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.create", Arguments: arguments})
+		require.NoError(t, err)
+		require.True(t, result.IsError, "%s", mustJSON(t, result))
+	}
+}
+
+func TestCreateSendsSchedulingSomedayAndForceNew(t *testing.T) {
+	requestSeen := make(chan capturedRequest, 1)
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		requestSeen <- capturedRequest{Path: request.URL.Path, Body: body}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write(daemonResponse(request))
+	}))
+	t.Cleanup(daemon.Close)
+	client, err := kataclient.NewWithHTTPClient(daemon.URL, daemon.Client())
+	require.NoError(t, err)
+	session := connectTestServerWithClient(t, client)
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.create", Arguments: map[string]any{
+		"title": "Timed work", "scheduled_on": "2026-09-01T15:00", "timezone": "America/Los_Angeles",
+		"metadata": map[string]any{"someday": true}, "force_new": true, "idempotency_key": "timed-work",
+	}})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "%s", mustJSON(t, result))
+	request := <-requestSeen
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(request.Body, &body))
+	require.Equal(t, true, body["force_new"])
+	require.Equal(t, map[string]any{
+		"scheduled_on": "2026-09-01T15:00", "timezone": "America/Los_Angeles", "someday": true,
+	}, body["metadata"])
+}
+
+func TestEditSchedulingClearUsesOneMetadataPatch(t *testing.T) {
+	requestSeen := make(chan capturedRequest, 1)
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		requestSeen <- capturedRequest{Path: request.URL.Path, Body: body}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write(daemonResponse(request))
+	}))
+	t.Cleanup(daemon.Close)
+	client, err := kataclient.NewWithHTTPClient(daemon.URL, daemon.Client())
+	require.NoError(t, err)
+	session := connectTestServerWithClient(t, client)
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.edit", Arguments: map[string]any{
+		"ref": "abc1", "scheduled_on": "2026-09-01T22:00:00Z", "clear_timezone": true,
+	}})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "%s", mustJSON(t, result))
+	request := <-requestSeen
+	require.Equal(t, "/api/v1/projects/42/issues/abc1/metadata", request.Path)
+	var body struct {
+		Patch map[string]any `json:"patch"`
+	}
+	require.NoError(t, json.Unmarshal(request.Body, &body))
+	require.Equal(t, map[string]any{"scheduled_on": "2026-09-01T22:00:00Z", "timezone": nil}, body.Patch)
+}
+
+func TestForceClaimReportsPreviousOwner(t *testing.T) {
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		response := map[string]any{}
+		require.NoError(t, json.Unmarshal(daemonResponse(request), &response))
+		response["previous_owner"] = "other-agent"
+		writeJSON(writer, response)
+	}))
+	t.Cleanup(daemon.Close)
+	client, err := kataclient.NewWithHTTPClient(daemon.URL, daemon.Client())
+	require.NoError(t, err)
+	session := connectTestServerWithClient(t, client)
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: "kata.claim", Arguments: map[string]any{"ref": "abc1", "force": true}})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "%s", mustJSON(t, result))
+	require.Equal(t, "other-agent", result.StructuredContent.(map[string]any)["previous_owner"])
+}
+
+func stringPointer(value string) *string { return &value }
+
+func connectMultiProjectServer(t *testing.T, override func(http.ResponseWriter, *http.Request) bool) (*sdkmcp.ClientSession, *[]string) {
+	t.Helper()
+	var mu sync.Mutex
+	requests := []string{}
+	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/projects" {
+			mu.Lock()
+			requests = append(requests, request.URL.Path)
+			mu.Unlock()
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		if override != nil && override(writer, request) {
+			return
+		}
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "hub-project"),
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case "/api/v1/issues", "/api/v1/ready":
+			writeJSON(writer, map[string]any{"issues": []any{
+				globalIssueJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "hub-project", "hbb1"),
+				globalIssueJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project", "spk1"),
+			}})
+		case "/api/v1/projects/1/issues", "/api/v1/projects/1/ready":
+			writeJSON(writer, map[string]any{"issues": []any{issueJSON(1, "spoke-project", "spk1")}})
+		case "/api/v1/projects/2/issues", "/api/v1/projects/2/ready":
+			issue := issueJSON(2, "hub-project", "hbb1")
+			issue["project_uid"] = "01HBBBBBBBBBBBBBBBBBBBBBBB"
+			writeJSON(writer, map[string]any{"issues": []any{issue}})
+		case "/api/v1/projects/2/issues/hbb1":
+			writeJSON(writer, map[string]any{"issue": issueJSON(2, "hub-project", "hbb1"), "labels": []any{}, "links": []any{}, "comments": []any{}})
+		default:
+			http.Error(writer, `{"status":404,"error":{"code":"not_found","message":"not found"}}`, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(daemon.Close)
+	client, err := kataclient.NewWithHTTPClient(daemon.URL, daemon.Client())
+	require.NoError(t, err)
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"},
+		{ID: 2, UID: "01HBBBBBBBBBBBBBBBBBBBBBBB", Name: "hub-project"},
+	})
+	require.NoError(t, err)
+	return connectTestServerWithOptions(t, Options{Client: client, Scope: scope, Actor: "example-agent", Version: "test-version"}), &requests
+}
+
+func projectJSON(id int64, uid, name string) map[string]any {
+	return map[string]any{"id": id, "uid": uid, "name": name, "metadata": map[string]any{}, "revision": 1, "created_at": "2026-08-11T00:00:00Z"}
+}
+
+func issueJSON(projectID int64, projectName, shortID string) map[string]any {
+	return map[string]any{
+		"id": projectID, "uid": "01ARZ3NDEKTSV4RRFFQ69G5FAV", "project_id": projectID,
+		"project_uid": "01HAAAAAAAAAAAAAAAAAAAAAAA", "short_id": shortID,
+		"qualified_id": projectName + "#" + shortID, "title": "Shared issue", "body": "Issue body",
+		"status": "open", "author": "example-agent", "metadata": map[string]any{}, "revision": 1,
+		"created_at": "2026-08-11T00:00:00Z", "updated_at": "2026-08-11T00:00:00Z",
+	}
+}
+
+func globalIssueJSON(projectID int64, projectUID, projectName, shortID string) map[string]any {
+	issue := issueJSON(projectID, projectName, shortID)
+	issue["project_uid"] = projectUID
+	issue["project_name"] = projectName
+	issue["labels"] = []any{}
+	return issue
+}
+
+func writeJSON(writer http.ResponseWriter, value any) {
+	_ = json.NewEncoder(writer).Encode(value)
+}

--- a/internal/mcp/projects.go
+++ b/internal/mcp/projects.go
@@ -158,10 +158,15 @@ func (h toolHandlers) projects(ctx context.Context, _ *sdkmcp.CallToolRequest, i
 		result = append(result, projectSummaryOut(project))
 	}
 	if name != "" && len(result) == 0 {
+		for _, startup := range h.options.Scope.projects {
+			if startup.Name == name {
+				return nil, ProjectsOutput{}, fmt.Errorf("project %q in the MCP startup scope is no longer available", name)
+			}
+		}
 		return nil, ProjectsOutput{}, fmt.Errorf("project %q is outside the MCP startup scope", name)
 	}
-	if h.options.Scope.Mode() != ScopeAll && name == "" && len(result) != len(h.options.Scope.projects) {
-		return nil, ProjectsOutput{}, errors.New("one or more projects in the MCP startup scope are no longer available")
+	if h.options.Scope.Mode() != ScopeAll && name == "" && len(result) == 0 {
+		return nil, ProjectsOutput{}, errors.New("no projects in the MCP startup scope are available")
 	}
 	return successResult(), ProjectsOutput{Projects: result}, nil
 }

--- a/internal/mcp/projects.go
+++ b/internal/mcp/projects.go
@@ -180,10 +180,10 @@ func (h toolHandlers) projectInFixedScope(project generated.ProjectOut) bool {
 	return false
 }
 
-// requireProjectAdminScope keeps catalog mutations a daemon-wide operator
-// action: a scoped server may read its projects but not rename, merge,
-// archive, restore, or purge them.
-func (h toolHandlers) requireProjectAdminScope(operation string) error {
+// requireAllProjectsScope keeps operator-tier operations — project catalog
+// mutations, archive-disposition federation leave, and credential-routing
+// federation rebind — out of scoped servers.
+func (h toolHandlers) requireAllProjectsScope(operation string) error {
 	if h.options.Scope.Mode() != ScopeAll {
 		return fmt.Errorf("%s requires the --all-projects daemon-wide scope", operation)
 	}
@@ -191,7 +191,7 @@ func (h toolHandlers) requireProjectAdminScope(operation string) error {
 }
 
 func (h toolHandlers) projectCreate(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectCreateInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
-	if err := h.requireProjectAdminScope("project creation"); err != nil {
+	if err := h.requireAllProjectsScope("project creation"); err != nil {
 		return nil, ProjectMutationOutput{}, err
 	}
 	name := strings.TrimSpace(input.Name)
@@ -206,7 +206,7 @@ func (h toolHandlers) projectCreate(ctx context.Context, _ *sdkmcp.CallToolReque
 }
 
 func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectUpdateInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
-	if err := h.requireProjectAdminScope("project update"); err != nil {
+	if err := h.requireAllProjectsScope("project update"); err != nil {
 		return nil, ProjectMutationOutput{}, err
 	}
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
@@ -274,7 +274,7 @@ func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolReque
 }
 
 func (h toolHandlers) projectMerge(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectMergeInput) (*sdkmcp.CallToolResult, ProjectMergeOutput, error) {
-	if err := h.requireProjectAdminScope("project merge"); err != nil {
+	if err := h.requireAllProjectsScope("project merge"); err != nil {
 		return nil, ProjectMergeOutput{}, err
 	}
 	source, err := h.options.Scope.Project(ctx, h.options.Client, input.Source, false)
@@ -296,7 +296,7 @@ func (h toolHandlers) projectMerge(ctx context.Context, _ *sdkmcp.CallToolReques
 }
 
 func (h toolHandlers) projectRemove(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectRemoveInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
-	if err := h.requireProjectAdminScope("project removal"); err != nil {
+	if err := h.requireAllProjectsScope("project removal"); err != nil {
 		return nil, ProjectMutationOutput{}, err
 	}
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
@@ -314,7 +314,7 @@ func (h toolHandlers) projectRemove(ctx context.Context, _ *sdkmcp.CallToolReque
 }
 
 func (h toolHandlers) projectRestore(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectRestoreInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
-	if err := h.requireProjectAdminScope("project restore"); err != nil {
+	if err := h.requireAllProjectsScope("project restore"); err != nil {
 		return nil, ProjectMutationOutput{}, err
 	}
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
@@ -332,7 +332,7 @@ func (h toolHandlers) projectRestore(ctx context.Context, _ *sdkmcp.CallToolRequ
 }
 
 func (h toolHandlers) projectPurge(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectPurgeInput) (*sdkmcp.CallToolResult, ProjectPurgeOutput, error) {
-	if err := h.requireProjectAdminScope("project purge"); err != nil {
+	if err := h.requireAllProjectsScope("project purge"); err != nil {
 		return nil, ProjectPurgeOutput{}, err
 	}
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)

--- a/internal/mcp/projects.go
+++ b/internal/mcp/projects.go
@@ -255,7 +255,11 @@ func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolReque
 		if rewriteErr != nil {
 			return nil, ProjectMutationOutput{}, rewriteErr
 		}
-		return successResult(), ProjectMutationOutput{Project: ProjectSummary{ID: project.ID, UID: project.UID, Name: project.Name}, Changed: response.Changed, Event: eventSummary(response.Event), Details: map[string]any{"total": response.Total, "issue_authors": response.IssueAuthors, "issue_owners": response.IssueOwners, "comment_authors": response.CommentAuthors, "link_authors": response.LinkAuthors}}, nil
+		current, showErr := h.projectSummaryByID(ctx, project.ID)
+		if showErr != nil {
+			return nil, ProjectMutationOutput{}, showErr
+		}
+		return successResult(), ProjectMutationOutput{Project: current, Changed: response.Changed, Event: eventSummary(response.Event), Details: map[string]any{"total": response.Total, "issue_authors": response.IssueAuthors, "issue_owners": response.IssueOwners, "comment_authors": response.CommentAuthors, "link_authors": response.LinkAuthors}}, nil
 	case "detach_alias":
 		if input.AliasID <= 0 {
 			return nil, ProjectMutationOutput{}, errors.New("detach_alias requires alias_id")
@@ -267,7 +271,11 @@ func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolReque
 		if detachErr != nil {
 			return nil, ProjectMutationOutput{}, detachErr
 		}
-		return successResult(), ProjectMutationOutput{Project: ProjectSummary{ID: project.ID, UID: project.UID, Name: project.Name}, Changed: true, Event: eventSummary(&response.Event), Details: map[string]any{"alias_id": response.Alias.ID, "alias_kind": response.Alias.AliasKind}}, nil
+		current, showErr := h.projectSummaryByID(ctx, project.ID)
+		if showErr != nil {
+			return nil, ProjectMutationOutput{}, showErr
+		}
+		return successResult(), ProjectMutationOutput{Project: current, Changed: true, Event: eventSummary(&response.Event), Details: map[string]any{"alias_id": response.Alias.ID, "alias_kind": response.Alias.AliasKind}}, nil
 	default:
 		return nil, ProjectMutationOutput{}, errors.New("action must be rename, metadata, rewrite_author, or detach_alias")
 	}
@@ -372,6 +380,16 @@ func projectSummaryOut(project generated.ProjectOut) ProjectSummary {
 		result.DeletedAt = formatTime(*project.DeletedAt)
 	}
 	return result
+}
+
+func (h toolHandlers) projectSummaryByID(ctx context.Context, projectID int64) (ProjectSummary, error) {
+	response, err := h.options.Client.ShowProject(ctx, &generated.ShowProjectRequestOptions{
+		PathParams: &generated.ShowProjectPath{ProjectID: projectID},
+	})
+	if err != nil {
+		return ProjectSummary{}, err
+	}
+	return projectSummaryOut(response.Project), nil
 }
 
 func projectSummary(project generated.Project) ProjectSummary {

--- a/internal/mcp/projects.go
+++ b/internal/mcp/projects.go
@@ -248,6 +248,10 @@ func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolReque
 		if strings.TrimSpace(input.From) == "" || strings.TrimSpace(input.To) == "" {
 			return nil, ProjectMutationOutput{}, errors.New("rewrite_author requires from and to")
 		}
+		current, showErr := h.projectSummaryByID(ctx, project.ID)
+		if showErr != nil {
+			return nil, ProjectMutationOutput{}, showErr
+		}
 		response, rewriteErr := h.options.Client.RewriteAuthorIdentity(ctx, &generated.RewriteAuthorIdentityRequestOptions{
 			PathParams: &generated.RewriteAuthorIdentityPath{ProjectID: project.ID},
 			Body:       &generated.RewriteAuthorIdentityBody{Actor: &h.options.Actor, From: input.From, To: input.To},
@@ -255,14 +259,14 @@ func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolReque
 		if rewriteErr != nil {
 			return nil, ProjectMutationOutput{}, rewriteErr
 		}
-		current, showErr := h.projectSummaryByID(ctx, project.ID)
-		if showErr != nil {
-			return nil, ProjectMutationOutput{}, showErr
-		}
 		return successResult(), ProjectMutationOutput{Project: current, Changed: response.Changed, Event: eventSummary(response.Event), Details: map[string]any{"total": response.Total, "issue_authors": response.IssueAuthors, "issue_owners": response.IssueOwners, "comment_authors": response.CommentAuthors, "link_authors": response.LinkAuthors}}, nil
 	case "detach_alias":
 		if input.AliasID <= 0 {
 			return nil, ProjectMutationOutput{}, errors.New("detach_alias requires alias_id")
+		}
+		current, showErr := h.projectSummaryByID(ctx, project.ID)
+		if showErr != nil {
+			return nil, ProjectMutationOutput{}, showErr
 		}
 		response, detachErr := h.options.Client.DetachProjectAlias(ctx, &generated.DetachProjectAliasRequestOptions{
 			PathParams: &generated.DetachProjectAliasPath{ProjectID: project.ID, AliasID: input.AliasID},
@@ -270,10 +274,6 @@ func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolReque
 		})
 		if detachErr != nil {
 			return nil, ProjectMutationOutput{}, detachErr
-		}
-		current, showErr := h.projectSummaryByID(ctx, project.ID)
-		if showErr != nil {
-			return nil, ProjectMutationOutput{}, showErr
 		}
 		return successResult(), ProjectMutationOutput{Project: current, Changed: true, Event: eventSummary(&response.Event), Details: map[string]any{"alias_id": response.Alias.ID, "alias_kind": response.Alias.AliasKind}}, nil
 	default:
@@ -395,7 +395,7 @@ func (h toolHandlers) projectSummaryByID(ctx context.Context, projectID int64) (
 			return projectSummaryOut(project), nil
 		}
 	}
-	return ProjectSummary{}, fmt.Errorf("project ID %d was not found after mutation", projectID)
+	return ProjectSummary{}, fmt.Errorf("project ID %d was not found in the project catalog", projectID)
 }
 
 func projectSummary(project generated.Project) ProjectSummary {

--- a/internal/mcp/projects.go
+++ b/internal/mcp/projects.go
@@ -383,13 +383,19 @@ func projectSummaryOut(project generated.ProjectOut) ProjectSummary {
 }
 
 func (h toolHandlers) projectSummaryByID(ctx context.Context, projectID int64) (ProjectSummary, error) {
-	response, err := h.options.Client.ShowProject(ctx, &generated.ShowProjectRequestOptions{
-		PathParams: &generated.ShowProjectPath{ProjectID: projectID},
+	include := "archived"
+	response, err := h.options.Client.ListProjects(ctx, &generated.ListProjectsRequestOptions{
+		Query: &generated.ListProjectsQuery{Include: &include},
 	})
 	if err != nil {
 		return ProjectSummary{}, err
 	}
-	return projectSummaryOut(response.Project), nil
+	for _, project := range response.Projects {
+		if project.ID == projectID {
+			return projectSummaryOut(project), nil
+		}
+	}
+	return ProjectSummary{}, fmt.Errorf("project ID %d was not found after mutation", projectID)
 }
 
 func projectSummary(project generated.Project) ProjectSummary {

--- a/internal/mcp/projects.go
+++ b/internal/mcp/projects.go
@@ -1,0 +1,353 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// ProjectsInput selects project records in the startup scope.
+type ProjectsInput struct {
+	Project         string `json:"project,omitempty"`
+	IncludeArchived bool   `json:"include_archived,omitempty"`
+}
+
+// ProjectSummary is the compact MCP project representation.
+type ProjectSummary struct {
+	ID        int64          `json:"id"`
+	UID       string         `json:"uid"`
+	Name      string         `json:"name"`
+	Revision  int64          `json:"revision"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+	Archived  bool           `json:"archived"`
+	CreatedAt string         `json:"created_at"`
+	DeletedAt string         `json:"deleted_at,omitempty"`
+}
+
+// ProjectsOutput contains project summaries.
+type ProjectsOutput struct {
+	Projects []ProjectSummary `json:"projects"`
+}
+
+// ProjectCreateInput names a path-free project to create.
+type ProjectCreateInput struct {
+	Name string `json:"name"`
+}
+
+// ProjectUpdateInput selects one supported project update action.
+type ProjectUpdateInput struct {
+	Project  string         `json:"project"`
+	Action   string         `json:"action"`
+	Name     string         `json:"name,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+	Revision *int64         `json:"revision,omitempty"`
+	From     string         `json:"from,omitempty"`
+	To       string         `json:"to,omitempty"`
+	AliasID  int64          `json:"alias_id,omitempty"`
+	Force    bool           `json:"force,omitempty"`
+}
+
+// ProjectMutationOutput reports a project mutation.
+type ProjectMutationOutput struct {
+	Project ProjectSummary `json:"project"`
+	Changed bool           `json:"changed"`
+	Event   *EventSummary  `json:"event,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// ProjectMergeInput selects source and target projects.
+type ProjectMergeInput struct {
+	Source     string `json:"source"`
+	Target     string `json:"target"`
+	TargetName string `json:"target_name,omitempty"`
+}
+
+// ProjectMergeOutput reports project merge counts and identities.
+type ProjectMergeOutput struct {
+	Source            ProjectSummary                    `json:"source"`
+	Target            ProjectSummary                    `json:"target"`
+	IssuesMoved       int64                             `json:"issues_moved"`
+	EventsMoved       int64                             `json:"events_moved"`
+	AliasesMoved      int64                             `json:"aliases_moved"`
+	PurgeLogsMoved    int64                             `json:"purge_logs_moved"`
+	ShortIDExtensions []generated.MergeShortIDExtension `json:"short_id_extensions,omitempty"`
+}
+
+// ProjectRemoveInput selects a project to archive.
+type ProjectRemoveInput struct {
+	Project string `json:"project"`
+	Force   bool   `json:"force,omitempty"`
+}
+
+// ProjectRestoreInput selects an archived project to restore.
+type ProjectRestoreInput struct {
+	Project string `json:"project"`
+}
+
+// ProjectPurgeInput carries an irreversible project purge confirmation.
+type ProjectPurgeInput struct {
+	Project string `json:"project"`
+	Confirm string `json:"confirm"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// ProjectPurgeOutput reports a completed project purge.
+type ProjectPurgeOutput struct {
+	Project string                    `json:"project"`
+	Purged  bool                      `json:"purged"`
+	Log     generated.ProjectPurgeLog `json:"log"`
+}
+
+// SystemInput requests redacted daemon information.
+type SystemInput struct{}
+
+// SystemOutput contains redacted daemon identity and version information.
+type SystemOutput struct {
+	InstanceUID        string `json:"instance_uid"`
+	Version            string `json:"version"`
+	SchemaVersion      int64  `json:"schema_version"`
+	AuthKind           string `json:"auth_kind"`
+	AuthenticatedActor string `json:"authenticated_actor,omitempty"`
+}
+
+func registerProjectTools(server *sdkmcp.Server, handlers toolHandlers) {
+	read := toolHints(true, false, false)
+	mutating := toolHints(false, true, false)
+	additive := toolHints(false, false, false)
+	addTool(server, "kata.project_create", "Create project", "Create a path-free project in daemon-wide mode.", additive, handlers.projectCreate)
+	addTool(server, "kata.project_merge", "Merge projects", "Merge one in-scope project into another.", mutating, handlers.projectMerge)
+	addTool(server, "kata.project_purge", "Purge project", "Irreversibly purge an archived project after exact confirmation.", mutating, handlers.projectPurge)
+	addTool(server, "kata.project_remove", "Archive project", "Archive an in-scope project.", mutating, handlers.projectRemove)
+	addTool(server, "kata.project_restore", "Restore project", "Restore an archived in-scope project.", additive, handlers.projectRestore)
+	addTool(server, "kata.project_update", "Update project", "Rename, patch metadata, rewrite authors, or detach an alias.", mutating, handlers.projectUpdate)
+	addTool(server, "kata.projects", "List projects", "List or select projects inside the startup scope.", read, handlers.projects)
+}
+
+func registerSystemTools(server *sdkmcp.Server, handlers toolHandlers) {
+	read := toolHints(true, false, false)
+	addTool(server, "kata.system", "System information", "Read redacted daemon instance and version information.", read, handlers.system)
+}
+
+func (h toolHandlers) projects(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectsInput) (*sdkmcp.CallToolResult, ProjectsOutput, error) {
+	var include *string
+	if input.IncludeArchived {
+		value := "archived"
+		include = &value
+	}
+	response, err := h.options.Client.ListProjects(ctx, &generated.ListProjectsRequestOptions{
+		Query: &generated.ListProjectsQuery{Include: include},
+	})
+	if err != nil {
+		return nil, ProjectsOutput{}, err
+	}
+	name := strings.TrimSpace(input.Project)
+	result := make([]ProjectSummary, 0, len(response.Projects))
+	for _, project := range response.Projects {
+		if h.options.Scope.Mode() != ScopeAll && !h.projectInFixedScope(project) {
+			continue
+		}
+		if name != "" && project.Name != name {
+			continue
+		}
+		result = append(result, projectSummaryOut(project))
+	}
+	if name != "" && len(result) == 0 {
+		return nil, ProjectsOutput{}, fmt.Errorf("project %q is outside the MCP startup scope", name)
+	}
+	if h.options.Scope.Mode() != ScopeAll && name == "" && len(result) != len(h.options.Scope.projects) {
+		return nil, ProjectsOutput{}, errors.New("one or more projects in the MCP startup scope are no longer available")
+	}
+	return successResult(), ProjectsOutput{Projects: result}, nil
+}
+
+func (h toolHandlers) projectInFixedScope(project generated.ProjectOut) bool {
+	for _, allowed := range h.options.Scope.projects {
+		if allowed.UID != "" && allowed.UID == project.UID || allowed.UID == "" && allowed.ID == project.ID {
+			return true
+		}
+	}
+	return false
+}
+
+func (h toolHandlers) projectCreate(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectCreateInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
+	if h.options.Scope.Mode() != ScopeAll {
+		return nil, ProjectMutationOutput{}, errors.New("project creation requires daemon-wide scope")
+	}
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return nil, ProjectMutationOutput{}, errors.New("name is required")
+	}
+	response, err := h.options.Client.InitProject(ctx, &generated.InitProjectRequestOptions{Body: &generated.InitProjectBody{Actor: &h.options.Actor, Name: &name}})
+	if err != nil {
+		return nil, ProjectMutationOutput{}, err
+	}
+	return successResult(), ProjectMutationOutput{Project: projectSummaryOut(response.Project), Changed: response.Created}, nil
+}
+
+func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectUpdateInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
+	if err != nil {
+		return nil, ProjectMutationOutput{}, err
+	}
+	switch input.Action {
+	case "rename":
+		name := strings.TrimSpace(input.Name)
+		if name == "" {
+			return nil, ProjectMutationOutput{}, errors.New("rename requires name")
+		}
+		response, renameErr := h.options.Client.RenameProject(ctx, &generated.RenameProjectRequestOptions{
+			PathParams: &generated.RenameProjectPath{ProjectID: project.ID},
+			Body:       &generated.RenameProjectBody{Actor: &h.options.Actor, Name: name},
+		})
+		if renameErr != nil {
+			return nil, ProjectMutationOutput{}, renameErr
+		}
+		return successResult(), ProjectMutationOutput{Project: projectSummaryOut(response.Project), Changed: true}, nil
+	case "metadata":
+		if len(input.Metadata) == 0 {
+			return nil, ProjectMutationOutput{}, errors.New("metadata action requires metadata")
+		}
+		var headers *generated.PatchProjectMetadataHeaders
+		if input.Revision != nil {
+			ifMatch := `"rev-` + strconv.FormatInt(*input.Revision, 10) + `"`
+			headers = &generated.PatchProjectMetadataHeaders{IfMatch: &ifMatch}
+		}
+		response, patchErr := h.options.Client.PatchProjectMetadata(ctx, &generated.PatchProjectMetadataRequestOptions{
+			PathParams: &generated.PatchProjectMetadataPath{ProjectID: project.ID},
+			Body:       &generated.PatchProjectMetadataBody{Actor: h.options.Actor, Patch: input.Metadata}, Header: headers,
+		})
+		if patchErr != nil {
+			return nil, ProjectMutationOutput{}, patchErr
+		}
+		return successResult(), ProjectMutationOutput{Project: projectSummary(response.Project), Changed: response.Changed, Event: eventSummary(response.Event)}, nil
+	case "rewrite_author":
+		if strings.TrimSpace(input.From) == "" || strings.TrimSpace(input.To) == "" {
+			return nil, ProjectMutationOutput{}, errors.New("rewrite_author requires from and to")
+		}
+		response, rewriteErr := h.options.Client.RewriteAuthorIdentity(ctx, &generated.RewriteAuthorIdentityRequestOptions{
+			PathParams: &generated.RewriteAuthorIdentityPath{ProjectID: project.ID},
+			Body:       &generated.RewriteAuthorIdentityBody{Actor: &h.options.Actor, From: input.From, To: input.To},
+		})
+		if rewriteErr != nil {
+			return nil, ProjectMutationOutput{}, rewriteErr
+		}
+		return successResult(), ProjectMutationOutput{Project: ProjectSummary{ID: project.ID, UID: project.UID, Name: project.Name}, Changed: response.Changed, Event: eventSummary(response.Event), Details: map[string]any{"total": response.Total, "issue_authors": response.IssueAuthors, "issue_owners": response.IssueOwners, "comment_authors": response.CommentAuthors, "link_authors": response.LinkAuthors}}, nil
+	case "detach_alias":
+		if input.AliasID <= 0 {
+			return nil, ProjectMutationOutput{}, errors.New("detach_alias requires alias_id")
+		}
+		response, detachErr := h.options.Client.DetachProjectAlias(ctx, &generated.DetachProjectAliasRequestOptions{
+			PathParams: &generated.DetachProjectAliasPath{ProjectID: project.ID, AliasID: input.AliasID},
+			Query:      &generated.DetachProjectAliasQuery{Actor: h.options.Actor, Force: optionalTrue(input.Force)},
+		})
+		if detachErr != nil {
+			return nil, ProjectMutationOutput{}, detachErr
+		}
+		return successResult(), ProjectMutationOutput{Project: ProjectSummary{ID: project.ID, UID: project.UID, Name: project.Name}, Changed: true, Event: eventSummary(&response.Event), Details: map[string]any{"alias_id": response.Alias.ID, "alias_kind": response.Alias.AliasKind}}, nil
+	default:
+		return nil, ProjectMutationOutput{}, errors.New("action must be rename, metadata, rewrite_author, or detach_alias")
+	}
+}
+
+func (h toolHandlers) projectMerge(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectMergeInput) (*sdkmcp.CallToolResult, ProjectMergeOutput, error) {
+	source, err := h.options.Scope.Project(ctx, h.options.Client, input.Source, false)
+	if err != nil {
+		return nil, ProjectMergeOutput{}, err
+	}
+	target, err := h.options.Scope.Project(ctx, h.options.Client, input.Target, false)
+	if err != nil {
+		return nil, ProjectMergeOutput{}, err
+	}
+	response, err := h.options.Client.MergeProject(ctx, &generated.MergeProjectRequestOptions{
+		PathParams: &generated.MergeProjectPath{ProjectID: target.ID},
+		Body:       &generated.MergeProjectBody{Actor: &h.options.Actor, SourceProjectID: source.ID, TargetName: optionalString(input.TargetName)},
+	})
+	if err != nil {
+		return nil, ProjectMergeOutput{}, err
+	}
+	return successResult(), ProjectMergeOutput{Source: projectSummaryOut(response.Source), Target: projectSummaryOut(response.Target), IssuesMoved: response.IssuesMoved, EventsMoved: response.EventsMoved, AliasesMoved: response.AliasesMoved, PurgeLogsMoved: response.PurgeLogsMoved, ShortIDExtensions: response.ShortIDExtensions}, nil
+}
+
+func (h toolHandlers) projectRemove(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectRemoveInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
+	if err != nil {
+		return nil, ProjectMutationOutput{}, err
+	}
+	response, err := h.options.Client.RemoveProject(ctx, &generated.RemoveProjectRequestOptions{
+		PathParams: &generated.RemoveProjectPath{ProjectID: project.ID},
+		Query:      &generated.RemoveProjectQuery{Actor: h.options.Actor, Force: optionalTrue(input.Force)},
+	})
+	if err != nil {
+		return nil, ProjectMutationOutput{}, err
+	}
+	return successResult(), ProjectMutationOutput{Project: projectSummaryOut(response.Project), Changed: true, Event: eventSummary(&response.Event)}, nil
+}
+
+func (h toolHandlers) projectRestore(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectRestoreInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
+	if err != nil {
+		return nil, ProjectMutationOutput{}, err
+	}
+	response, err := h.options.Client.RestoreProject(ctx, &generated.RestoreProjectRequestOptions{
+		PathParams: &generated.RestoreProjectPath{ProjectID: project.ID},
+		Query:      &generated.RestoreProjectQuery{Actor: h.options.Actor},
+	})
+	if err != nil {
+		return nil, ProjectMutationOutput{}, err
+	}
+	return successResult(), ProjectMutationOutput{Project: projectSummaryOut(response.Project), Changed: response.Changed, Event: eventSummary(&response.Event)}, nil
+}
+
+func (h toolHandlers) projectPurge(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectPurgeInput) (*sdkmcp.CallToolResult, ProjectPurgeOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
+	if err != nil {
+		return nil, ProjectPurgeOutput{}, err
+	}
+	expected := "PURGE " + project.Name
+	if input.Confirm != expected {
+		return nil, ProjectPurgeOutput{}, fmt.Errorf("confirm must equal %q", expected)
+	}
+	response, err := h.options.Client.PurgeProject(ctx, &generated.PurgeProjectRequestOptions{
+		PathParams: &generated.PurgeProjectPath{ProjectID: project.ID},
+		Body:       &generated.PurgeProjectBody{Actor: h.options.Actor, Reason: optionalString(input.Reason)},
+		Header:     &generated.PurgeProjectHeaders{XKataConfirm: &expected},
+	})
+	if err != nil {
+		return nil, ProjectPurgeOutput{}, err
+	}
+	return successResult(), ProjectPurgeOutput{Project: project.Name, Purged: true, Log: response.ProjectPurgeLog}, nil
+}
+
+func (h toolHandlers) system(ctx context.Context, _ *sdkmcp.CallToolRequest, _ SystemInput) (*sdkmcp.CallToolResult, SystemOutput, error) {
+	response, err := h.options.Client.Instance(ctx)
+	if err != nil {
+		return nil, SystemOutput{}, err
+	}
+	actor := ""
+	if response.Auth.Actor != nil {
+		actor = *response.Auth.Actor
+	}
+	return successResult(), SystemOutput{InstanceUID: response.InstanceUID, Version: response.Version, SchemaVersion: response.SchemaVersion, AuthKind: response.Auth.Kind, AuthenticatedActor: actor}, nil
+}
+
+func projectSummaryOut(project generated.ProjectOut) ProjectSummary {
+	result := ProjectSummary{ID: project.ID, UID: project.UID, Name: project.Name, Revision: project.Revision, Metadata: project.Metadata, CreatedAt: formatTime(project.CreatedAt), Archived: project.DeletedAt != nil}
+	if project.DeletedAt != nil {
+		result.DeletedAt = formatTime(*project.DeletedAt)
+	}
+	return result
+}
+
+func projectSummary(project generated.Project) ProjectSummary {
+	result := ProjectSummary{ID: project.ID, UID: project.UID, Name: project.Name, Revision: project.Revision, Metadata: project.Metadata, CreatedAt: formatTime(project.CreatedAt), Archived: project.DeletedAt != nil}
+	if project.DeletedAt != nil {
+		result.DeletedAt = formatTime(*project.DeletedAt)
+	}
+	return result
+}

--- a/internal/mcp/projects.go
+++ b/internal/mcp/projects.go
@@ -180,9 +180,19 @@ func (h toolHandlers) projectInFixedScope(project generated.ProjectOut) bool {
 	return false
 }
 
-func (h toolHandlers) projectCreate(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectCreateInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
+// requireProjectAdminScope keeps catalog mutations a daemon-wide operator
+// action: a scoped server may read its projects but not rename, merge,
+// archive, restore, or purge them.
+func (h toolHandlers) requireProjectAdminScope(operation string) error {
 	if h.options.Scope.Mode() != ScopeAll {
-		return nil, ProjectMutationOutput{}, errors.New("project creation requires daemon-wide scope")
+		return fmt.Errorf("%s requires the --all-projects daemon-wide scope", operation)
+	}
+	return nil
+}
+
+func (h toolHandlers) projectCreate(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectCreateInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
+	if err := h.requireProjectAdminScope("project creation"); err != nil {
+		return nil, ProjectMutationOutput{}, err
 	}
 	name := strings.TrimSpace(input.Name)
 	if name == "" {
@@ -196,6 +206,9 @@ func (h toolHandlers) projectCreate(ctx context.Context, _ *sdkmcp.CallToolReque
 }
 
 func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectUpdateInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
+	if err := h.requireProjectAdminScope("project update"); err != nil {
+		return nil, ProjectMutationOutput{}, err
+	}
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
 	if err != nil {
 		return nil, ProjectMutationOutput{}, err
@@ -261,6 +274,9 @@ func (h toolHandlers) projectUpdate(ctx context.Context, _ *sdkmcp.CallToolReque
 }
 
 func (h toolHandlers) projectMerge(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectMergeInput) (*sdkmcp.CallToolResult, ProjectMergeOutput, error) {
+	if err := h.requireProjectAdminScope("project merge"); err != nil {
+		return nil, ProjectMergeOutput{}, err
+	}
 	source, err := h.options.Scope.Project(ctx, h.options.Client, input.Source, false)
 	if err != nil {
 		return nil, ProjectMergeOutput{}, err
@@ -280,6 +296,9 @@ func (h toolHandlers) projectMerge(ctx context.Context, _ *sdkmcp.CallToolReques
 }
 
 func (h toolHandlers) projectRemove(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectRemoveInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
+	if err := h.requireProjectAdminScope("project removal"); err != nil {
+		return nil, ProjectMutationOutput{}, err
+	}
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
 	if err != nil {
 		return nil, ProjectMutationOutput{}, err
@@ -295,6 +314,9 @@ func (h toolHandlers) projectRemove(ctx context.Context, _ *sdkmcp.CallToolReque
 }
 
 func (h toolHandlers) projectRestore(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectRestoreInput) (*sdkmcp.CallToolResult, ProjectMutationOutput, error) {
+	if err := h.requireProjectAdminScope("project restore"); err != nil {
+		return nil, ProjectMutationOutput{}, err
+	}
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
 	if err != nil {
 		return nil, ProjectMutationOutput{}, err
@@ -310,6 +332,9 @@ func (h toolHandlers) projectRestore(ctx context.Context, _ *sdkmcp.CallToolRequ
 }
 
 func (h toolHandlers) projectPurge(ctx context.Context, _ *sdkmcp.CallToolRequest, input ProjectPurgeInput) (*sdkmcp.CallToolResult, ProjectPurgeOutput, error) {
+	if err := h.requireProjectAdminScope("project purge"); err != nil {
+		return nil, ProjectPurgeOutput{}, err
+	}
 	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, true)
 	if err != nil {
 		return nil, ProjectPurgeOutput{}, err

--- a/internal/mcp/projects_test.go
+++ b/internal/mcp/projects_test.go
@@ -12,6 +12,7 @@ import (
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db/sqlitestore"
 	kataclient "go.kenn.io/kata/pkg/client"
+	"go.kenn.io/kata/pkg/client/generated"
 )
 
 func TestAdministrationToolsArePublished(t *testing.T) {
@@ -25,9 +26,10 @@ func TestAdministrationToolsArePublished(t *testing.T) {
 	for _, tool := range result.Tools {
 		names[tool.Name] = true
 	}
+	require.False(t, names["kata.federation_enroll"], "credential-minting enrollment must stay outside MCP")
 	for _, name := range []string{
 		"kata.digest", "kata.events", "kata.import_issues",
-		"kata.federation_enroll", "kata.federation_enrollment_revoke", "kata.federation_join",
+		"kata.federation_enrollment_revoke", "kata.federation_join",
 		"kata.federation_leave", "kata.federation_quarantine", "kata.federation_rebind", "kata.federation_status",
 		"kata.project_create", "kata.project_merge", "kata.project_purge", "kata.project_remove",
 		"kata.project_restore", "kata.project_update", "kata.projects", "kata.system",
@@ -82,12 +84,21 @@ func TestAdministrationToolsRoundTripAgainstDaemon(t *testing.T) {
 	system := callAdministrationTool(t, session, "kata.system", map[string]any{})
 	require.NotEmpty(t, system["instance_uid"])
 	require.NotContains(t, system, "db_path")
-	callAdministrationTool(t, session, "kata.federation_enroll", map[string]any{"action": "enable", "project": "renamed-project"})
-	enrollment := callAdministrationTool(t, session, "kata.federation_enroll", map[string]any{
-		"project": "renamed-project", "spoke_instance_uid": system["instance_uid"], "capabilities": "pull",
+	// Enrollment credentials are minted through the CLI/daemon, never MCP.
+	renamed, err := store.ProjectByName(t.Context(), "renamed-project")
+	require.NoError(t, err)
+	actor := "example-agent"
+	_, err = client.EnableProjectFederation(t.Context(), &generated.EnableProjectFederationRequestOptions{
+		PathParams: &generated.EnableProjectFederationPath{ProjectID: renamed.ID},
+		Body:       &generated.EnableProjectFederationBody{Actor: &actor},
 	})
-	require.NotEmpty(t, enrollment["token"])
-	enrollmentID := enrollment["enrollment"].(map[string]any)["id"]
+	require.NoError(t, err)
+	enrolled, err := client.CreateFederationEnrollment(t.Context(), &generated.CreateFederationEnrollmentRequestOptions{Body: &generated.CreateFederationEnrollmentBody{
+		Actor: &actor, ProjectID: renamed.ID,
+		SpokeInstanceUID: system["instance_uid"].(string), Capabilities: "pull",
+	}})
+	require.NoError(t, err)
+	enrollmentID := enrolled.ID
 	federation := callAdministrationTool(t, session, "kata.federation_status", map[string]any{})
 	require.NotEmpty(t, federation["enrollments"])
 	require.NotContains(t, federation["enrollments"].([]any)[0].(map[string]any), "token")

--- a/internal/mcp/projects_test.go
+++ b/internal/mcp/projects_test.go
@@ -1,0 +1,116 @@
+package mcpserver
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db/sqlitestore"
+	kataclient "go.kenn.io/kata/pkg/client"
+)
+
+func TestAdministrationToolsArePublished(t *testing.T) {
+	session := connectTestServerWithOptions(t, Options{
+		Client: &kataclient.Client{}, Scope: NewAllScope(), EnableTokenAdmin: true,
+		Actor: "example-agent", Version: "test-version",
+	})
+	result, err := session.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, tool := range result.Tools {
+		names[tool.Name] = true
+	}
+	for _, name := range []string{
+		"kata.digest", "kata.events", "kata.import_issues",
+		"kata.federation_enroll", "kata.federation_enrollment_revoke", "kata.federation_join",
+		"kata.federation_leave", "kata.federation_quarantine", "kata.federation_rebind", "kata.federation_status",
+		"kata.project_create", "kata.project_merge", "kata.project_purge", "kata.project_remove",
+		"kata.project_restore", "kata.project_update", "kata.projects", "kata.system",
+		"kata.recurrence_delete", "kata.recurrence_update", "kata.recurrences",
+		"kata.sync_once", "kata.sync_status", "kata.sync_update",
+		"kata.token_create", "kata.token_revoke", "kata.tokens",
+	} {
+		require.True(t, names[name], name)
+	}
+}
+
+func TestAdministrationToolsRoundTripAgainstDaemon(t *testing.T) {
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	_, err = store.CreateProject(t.Context(), "initial-project")
+	require.NoError(t, err)
+	daemonServer := daemon.NewServer(daemon.ServerConfig{DB: store, StartedAt: time.Now().UTC()})
+	t.Cleanup(func() { require.NoError(t, daemonServer.Close()) })
+	httpServer := httptest.NewServer(daemonServer.Handler())
+	t.Cleanup(httpServer.Close)
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	session := connectTestServerWithOptions(t, Options{Client: client, Scope: NewAllScope(), EnableTokenAdmin: true, Actor: "example-agent", Version: "test-version"})
+
+	created := callAdministrationTool(t, session, "kata.project_create", map[string]any{"name": "created-project"})
+	require.Equal(t, "created-project", created["project"].(map[string]any)["name"])
+	updated := callAdministrationTool(t, session, "kata.project_update", map[string]any{"project": "created-project", "action": "rename", "name": "renamed-project"})
+	require.Equal(t, "renamed-project", updated["project"].(map[string]any)["name"])
+
+	recurrence := callAdministrationTool(t, session, "kata.recurrence_update", map[string]any{
+		"project": "renamed-project", "action": "create", "dtstart": "2026-09-01", "rrule": "FREQ=WEEKLY", "timezone": "UTC",
+		"template": map[string]any{"title": "Weekly review"},
+	})["recurrence"].(map[string]any)
+	uid := recurrence["uid"].(string)
+	listed := callAdministrationTool(t, session, "kata.recurrences", map[string]any{"project": "renamed-project"})
+	require.Len(t, listed["recurrences"], 1)
+	callAdministrationTool(t, session, "kata.recurrence_delete", map[string]any{"project": "renamed-project", "uid": uid, "revision": recurrence["revision"]})
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	imported := callAdministrationTool(t, session, "kata.import_issues", map[string]any{
+		"project": "renamed-project", "source": "example-source", "items": []any{map[string]any{
+			"external_id": "example-1", "title": "Imported task", "author": "example-agent", "status": "open", "created_at": now, "updated_at": now,
+		}},
+	})
+	require.EqualValues(t, 1, imported["result"].(map[string]any)["created"])
+
+	digest := callAdministrationTool(t, session, "kata.digest", map[string]any{"project": "renamed-project", "since": time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)})
+	require.NotEmpty(t, digest["digests"])
+	events := callAdministrationTool(t, session, "kata.events", map[string]any{"project": "renamed-project", "mode": "poll", "after": 0, "limit": 100})
+	require.NotEmpty(t, events["events"])
+	system := callAdministrationTool(t, session, "kata.system", map[string]any{})
+	require.NotEmpty(t, system["instance_uid"])
+	require.NotContains(t, system, "db_path")
+	callAdministrationTool(t, session, "kata.federation_enroll", map[string]any{"action": "enable", "project": "renamed-project"})
+	enrollment := callAdministrationTool(t, session, "kata.federation_enroll", map[string]any{
+		"project": "renamed-project", "spoke_instance_uid": system["instance_uid"], "capabilities": "pull",
+	})
+	require.NotEmpty(t, enrollment["token"])
+	enrollmentID := enrollment["enrollment"].(map[string]any)["id"]
+	federation := callAdministrationTool(t, session, "kata.federation_status", map[string]any{})
+	require.NotEmpty(t, federation["enrollments"])
+	require.NotContains(t, federation["enrollments"].([]any)[0].(map[string]any), "token")
+	callAdministrationTool(t, session, "kata.federation_enrollment_revoke", map[string]any{"id": enrollmentID})
+	token := callAdministrationTool(t, session, "kata.token_create", map[string]any{"token_actor": "automation-agent", "name": "automation"})
+	require.NotEmpty(t, token["token"])
+	tokenID := token["record"].(map[string]any)["id"]
+	tokens := callAdministrationTool(t, session, "kata.tokens", map[string]any{})
+	require.NotEmpty(t, tokens["tokens"])
+	require.NotContains(t, tokens["tokens"].([]any)[0].(map[string]any), "token")
+	callAdministrationTool(t, session, "kata.token_revoke", map[string]any{"id": tokenID})
+	callAdministrationTool(t, session, "kata.project_create", map[string]any{"name": "lifecycle-project"})
+	callAdministrationTool(t, session, "kata.project_remove", map[string]any{"project": "lifecycle-project"})
+	callAdministrationTool(t, session, "kata.project_restore", map[string]any{"project": "lifecycle-project"})
+	callAdministrationTool(t, session, "kata.project_remove", map[string]any{"project": "lifecycle-project"})
+	purged := callAdministrationTool(t, session, "kata.project_purge", map[string]any{"project": "lifecycle-project", "confirm": "PURGE lifecycle-project"})
+	require.Equal(t, true, purged["purged"])
+}
+
+func callAdministrationTool(t *testing.T, session *sdkmcp.ClientSession, name string, arguments map[string]any) map[string]any {
+	t.Helper()
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: name, Arguments: arguments})
+	require.NoError(t, err)
+	require.False(t, result.IsError, "%s: %s", name, mustJSON(t, result))
+	return result.StructuredContent.(map[string]any)
+}

--- a/internal/mcp/projects_test.go
+++ b/internal/mcp/projects_test.go
@@ -29,7 +29,7 @@ func TestAdministrationToolsArePublished(t *testing.T) {
 	require.False(t, names["kata.federation_enroll"], "credential-minting enrollment must stay outside MCP")
 	for _, name := range []string{
 		"kata.digest", "kata.events", "kata.import_issues",
-		"kata.federation_enrollment_revoke", "kata.federation_join",
+		"kata.federation_enrollment_revoke",
 		"kata.federation_leave", "kata.federation_quarantine", "kata.federation_rebind", "kata.federation_status",
 		"kata.project_create", "kata.project_merge", "kata.project_purge", "kata.project_remove",
 		"kata.project_restore", "kata.project_update", "kata.projects", "kata.system",

--- a/internal/mcp/projects_test.go
+++ b/internal/mcp/projects_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/sqlitestore"
 	kataclient "go.kenn.io/kata/pkg/client"
 	"go.kenn.io/kata/pkg/client/generated"
@@ -163,6 +164,42 @@ func TestProjectUpdateActionsReturnCompleteProjectSummary(t *testing.T) {
 		"project": project.Name, "action": "detach_alias", "alias_id": alias.ID, "force": true,
 	})
 	requireCompleteProject(detached)
+}
+
+func TestProjectUpdateDetachAliasReturnsArchivedProjectSummary(t *testing.T) {
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	project, err := store.CreateProject(t.Context(), "archived-project")
+	require.NoError(t, err)
+	archived, _, err := store.RemoveProject(t.Context(), db.RemoveProjectParams{
+		ProjectID: project.ID, Actor: "example-agent",
+	})
+	require.NoError(t, err)
+	alias, err := store.AttachAlias(t.Context(), project.ID, "host-a.example/archived-repository", "git")
+	require.NoError(t, err)
+
+	daemonServer := daemon.NewServer(daemon.ServerConfig{DB: store, StartedAt: time.Now().UTC()})
+	t.Cleanup(func() { require.NoError(t, daemonServer.Close()) })
+	httpServer := httptest.NewServer(daemonServer.Handler())
+	t.Cleanup(httpServer.Close)
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	session := connectTestServerWithOptions(t, Options{
+		Client: client, Scope: NewAllScope(), Actor: "example-agent", Version: "test-version",
+	})
+
+	detached := callAdministrationTool(t, session, "kata.project_update", map[string]any{
+		"project": archived.Name, "action": "detach_alias", "alias_id": alias.ID, "force": true,
+	})
+	summary := detached["project"].(map[string]any)
+	require.EqualValues(t, archived.ID, summary["id"])
+	require.Equal(t, archived.UID, summary["uid"])
+	require.Equal(t, archived.Name, summary["name"])
+	require.EqualValues(t, archived.Revision, summary["revision"])
+	require.Equal(t, formatTime(archived.CreatedAt), summary["created_at"])
+	require.Equal(t, true, summary["archived"])
+	require.Equal(t, formatTime(*archived.DeletedAt), summary["deleted_at"])
 }
 
 func callAdministrationTool(t *testing.T, session *sdkmcp.ClientSession, name string, arguments map[string]any) map[string]any {

--- a/internal/mcp/projects_test.go
+++ b/internal/mcp/projects_test.go
@@ -62,12 +62,18 @@ func TestAdministrationToolsRoundTripAgainstDaemon(t *testing.T) {
 
 	recurrence := callAdministrationTool(t, session, "kata.recurrence_update", map[string]any{
 		"project": "renamed-project", "action": "create", "dtstart": "2026-09-01", "rrule": "FREQ=WEEKLY", "timezone": "UTC",
-		"template": map[string]any{"title": "Weekly review"},
+		"template": map[string]any{"title": "Weekly review", "owner": "example-agent"},
 	})["recurrence"].(map[string]any)
 	uid := recurrence["uid"].(string)
+	require.Equal(t, "example-agent", recurrence["template_owner"])
+	cleared := callAdministrationTool(t, session, "kata.recurrence_update", map[string]any{
+		"project": "renamed-project", "action": "patch", "uid": uid, "revision": recurrence["revision"],
+		"template_patch": map[string]any{"clear_owner": true},
+	})["recurrence"].(map[string]any)
+	require.NotContains(t, cleared, "template_owner", "template_patch clear_owner must reach the daemon")
 	listed := callAdministrationTool(t, session, "kata.recurrences", map[string]any{"project": "renamed-project"})
 	require.Len(t, listed["recurrences"], 1)
-	callAdministrationTool(t, session, "kata.recurrence_delete", map[string]any{"project": "renamed-project", "uid": uid, "revision": recurrence["revision"]})
+	callAdministrationTool(t, session, "kata.recurrence_delete", map[string]any{"project": "renamed-project", "uid": uid, "revision": cleared["revision"]})
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	imported := callAdministrationTool(t, session, "kata.import_issues", map[string]any{

--- a/internal/mcp/projects_test.go
+++ b/internal/mcp/projects_test.go
@@ -124,6 +124,47 @@ func TestAdministrationToolsRoundTripAgainstDaemon(t *testing.T) {
 	require.Equal(t, true, purged["purged"])
 }
 
+func TestProjectUpdateActionsReturnCompleteProjectSummary(t *testing.T) {
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	project, err := store.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	alias, err := store.AttachAlias(t.Context(), project.ID, "host-a.example/repository", "git")
+	require.NoError(t, err)
+
+	daemonServer := daemon.NewServer(daemon.ServerConfig{DB: store, StartedAt: time.Now().UTC()})
+	t.Cleanup(func() { require.NoError(t, daemonServer.Close()) })
+	httpServer := httptest.NewServer(daemonServer.Handler())
+	t.Cleanup(httpServer.Close)
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	session := connectTestServerWithOptions(t, Options{
+		Client: client, Scope: NewAllScope(), Actor: "example-agent", Version: "test-version",
+	})
+
+	requireCompleteProject := func(output map[string]any) {
+		t.Helper()
+		summary := output["project"].(map[string]any)
+		require.EqualValues(t, project.ID, summary["id"])
+		require.Equal(t, project.UID, summary["uid"])
+		require.Equal(t, project.Name, summary["name"])
+		require.EqualValues(t, project.Revision, summary["revision"])
+		require.Equal(t, formatTime(project.CreatedAt), summary["created_at"])
+		require.Equal(t, false, summary["archived"])
+	}
+
+	rewritten := callAdministrationTool(t, session, "kata.project_update", map[string]any{
+		"project": project.Name, "action": "rewrite_author", "from": "user-a", "to": "user-b",
+	})
+	requireCompleteProject(rewritten)
+
+	detached := callAdministrationTool(t, session, "kata.project_update", map[string]any{
+		"project": project.Name, "action": "detach_alias", "alias_id": alias.ID, "force": true,
+	})
+	requireCompleteProject(detached)
+}
+
 func callAdministrationTool(t *testing.T, session *sdkmcp.ClientSession, name string, arguments map[string]any) map[string]any {
 	t.Helper()
 	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: name, Arguments: arguments})

--- a/internal/mcp/projects_test.go
+++ b/internal/mcp/projects_test.go
@@ -1,8 +1,10 @@
 package mcpserver
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -200,6 +202,73 @@ func TestProjectUpdateDetachAliasReturnsArchivedProjectSummary(t *testing.T) {
 	require.Equal(t, formatTime(archived.CreatedAt), summary["created_at"])
 	require.Equal(t, true, summary["archived"])
 	require.Equal(t, formatTime(*archived.DeletedAt), summary["deleted_at"])
+}
+
+func TestProjectUpdateDoesNotReadProjectAfterMutationCommit(t *testing.T) {
+	for _, action := range []string{"rewrite_author", "detach_alias"} {
+		t.Run(action, func(t *testing.T) {
+			store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			project, err := store.CreateProject(t.Context(), "example-project")
+			require.NoError(t, err)
+			issue, _, err := store.CreateIssue(t.Context(), db.CreateIssueParams{
+				ProjectID: project.ID, Title: "Example issue", Author: "user-a",
+			})
+			require.NoError(t, err)
+			alias, err := store.AttachAlias(t.Context(), project.ID, "host-a.example/repository", "git")
+			require.NoError(t, err)
+
+			daemonServer := daemon.NewServer(daemon.ServerConfig{DB: store, StartedAt: time.Now().UTC()})
+			t.Cleanup(func() { require.NoError(t, daemonServer.Close()) })
+			var mutationCommitted atomic.Bool
+			var postMutationReads atomic.Int32
+			daemonHandler := daemonServer.Handler()
+			httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if mutationCommitted.Load() && request.Method == http.MethodGet && request.URL.Path == "/api/v1/projects" {
+					postMutationReads.Add(1)
+					http.Error(writer, "project catalog unavailable", http.StatusInternalServerError)
+					return
+				}
+				daemonHandler.ServeHTTP(writer, request)
+				if request.Method == http.MethodPost || request.Method == http.MethodDelete {
+					mutationCommitted.Store(true)
+				}
+			}))
+			t.Cleanup(httpServer.Close)
+			client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+			require.NoError(t, err)
+			session := connectTestServerWithOptions(t, Options{
+				Client: client, Scope: NewAllScope(), Actor: "example-agent", Version: "test-version",
+			})
+
+			arguments := map[string]any{"project": project.Name, "action": action}
+			if action == "rewrite_author" {
+				arguments["from"] = "user-a"
+				arguments["to"] = "user-b"
+			} else {
+				arguments["alias_id"] = alias.ID
+				arguments["force"] = true
+			}
+			output := callAdministrationTool(t, session, "kata.project_update", arguments)
+			require.True(t, mutationCommitted.Load())
+			require.Zero(t, postMutationReads.Load())
+			summary := output["project"].(map[string]any)
+			require.EqualValues(t, project.ID, summary["id"])
+			require.Equal(t, project.UID, summary["uid"])
+			require.EqualValues(t, project.Revision, summary["revision"])
+			require.Equal(t, formatTime(project.CreatedAt), summary["created_at"])
+			if action == "rewrite_author" {
+				require.Equal(t, true, output["changed"])
+				updated, showErr := store.IssueByID(t.Context(), issue.ID)
+				require.NoError(t, showErr)
+				require.Equal(t, "user-b", updated.Author)
+			} else {
+				_, aliasErr := store.AliasByID(t.Context(), alias.ID)
+				require.ErrorIs(t, aliasErr, db.ErrNotFound)
+			}
+		})
+	}
 }
 
 func callAdministrationTool(t *testing.T, session *sdkmcp.ClientSession, name string, arguments map[string]any) map[string]any {

--- a/internal/mcp/recurrences.go
+++ b/internal/mcp/recurrences.go
@@ -1,0 +1,138 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// RecurrencesInput lists recurrences or selects one UID.
+type RecurrencesInput struct {
+	Project string `json:"project,omitempty"`
+	UID     string `json:"uid,omitempty"`
+}
+
+// RecurrencesOutput contains scoped recurrence records.
+type RecurrencesOutput struct {
+	Project     ProjectIdentity        `json:"project"`
+	Recurrences []generated.Recurrence `json:"recurrences"`
+}
+
+// RecurrenceUpdateInput creates or patches a recurrence.
+type RecurrenceUpdateInput struct {
+	Project         string                                   `json:"project,omitempty"`
+	Action          string                                   `json:"action"`
+	UID             string                                   `json:"uid,omitempty"`
+	Revision        *int64                                   `json:"revision,omitempty"`
+	DTStart         string                                   `json:"dtstart,omitempty"`
+	RRule           string                                   `json:"rrule,omitempty"`
+	Timezone        string                                   `json:"timezone,omitempty"`
+	InitialIssueRef string                                   `json:"initial_issue_ref,omitempty"`
+	Template        *generated.RecurrenceTemplateInput       `json:"template,omitempty"`
+	TemplatePatch   *generated.RecurrenceTemplateUpdateInput `json:"template_patch,omitempty"`
+}
+
+// RecurrenceUpdateOutput reports the current recurrence record.
+type RecurrenceUpdateOutput struct {
+	Project    ProjectIdentity      `json:"project"`
+	Recurrence generated.Recurrence `json:"recurrence"`
+	Changed    bool                 `json:"changed"`
+}
+
+// RecurrenceDeleteInput selects a recurrence at a visible revision.
+type RecurrenceDeleteInput struct {
+	Project  string `json:"project,omitempty"`
+	UID      string `json:"uid"`
+	Revision int64  `json:"revision"`
+}
+
+// RecurrenceDeleteOutput reports a completed recurrence deletion.
+type RecurrenceDeleteOutput struct {
+	Project ProjectIdentity `json:"project"`
+	UID     string          `json:"uid"`
+	Deleted bool            `json:"deleted"`
+}
+
+func registerRecurrenceTools(server *sdkmcp.Server, handlers toolHandlers) {
+	addTool(server, "kata.recurrences", "Read recurrences", "List recurrences or show one recurrence in an in-scope project.", toolHints(true, false, false), handlers.recurrences)
+	addTool(server, "kata.recurrence_update", "Update recurrence", "Create a recurrence or patch one at its required visible revision.", toolHints(false, false, false), handlers.recurrenceUpdate)
+	addTool(server, "kata.recurrence_delete", "Delete recurrence", "Delete a recurrence at its visible revision.", toolHints(false, true, false), handlers.recurrenceDelete)
+}
+
+func (h toolHandlers) recurrences(ctx context.Context, _ *sdkmcp.CallToolRequest, input RecurrencesInput) (*sdkmcp.CallToolResult, RecurrencesOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
+	if err != nil {
+		return nil, RecurrencesOutput{}, err
+	}
+	if uid := strings.TrimSpace(input.UID); uid != "" {
+		response, showErr := h.options.Client.ShowRecurrence(ctx, &generated.ShowRecurrenceRequestOptions{PathParams: &generated.ShowRecurrencePath{ProjectID: project.ID, RecurrenceUID: uid}})
+		if showErr != nil {
+			return nil, RecurrencesOutput{}, showErr
+		}
+		return successResult(), RecurrencesOutput{Project: project, Recurrences: []generated.Recurrence{response.Recurrence}}, nil
+	}
+	response, err := h.options.Client.ListRecurrences(ctx, &generated.ListRecurrencesRequestOptions{PathParams: &generated.ListRecurrencesPath{ProjectID: project.ID}})
+	if err != nil {
+		return nil, RecurrencesOutput{}, err
+	}
+	return successResult(), RecurrencesOutput{Project: project, Recurrences: response.Recurrences}, nil
+}
+
+func (h toolHandlers) recurrenceUpdate(ctx context.Context, _ *sdkmcp.CallToolRequest, input RecurrenceUpdateInput) (*sdkmcp.CallToolResult, RecurrenceUpdateOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
+	if err != nil {
+		return nil, RecurrenceUpdateOutput{}, err
+	}
+	switch input.Action {
+	case "create":
+		if input.Template == nil {
+			return nil, RecurrenceUpdateOutput{}, errors.New("create requires template")
+		}
+		response, createErr := h.options.Client.CreateRecurrence(ctx, &generated.CreateRecurrenceRequestOptions{
+			PathParams: &generated.CreateRecurrencePath{ProjectID: project.ID},
+			Body:       &generated.CreateRecurrenceBody{Actor: &h.options.Actor, Dtstart: input.DTStart, Rrule: input.RRule, Timezone: input.Timezone, InitialIssueRef: optionalString(input.InitialIssueRef), Template: *input.Template},
+		})
+		if createErr != nil {
+			return nil, RecurrenceUpdateOutput{}, createErr
+		}
+		return successResult(), RecurrenceUpdateOutput{Project: project, Recurrence: response.Recurrence, Changed: true}, nil
+	case "patch":
+		uid := strings.TrimSpace(input.UID)
+		if uid == "" || input.Revision == nil || *input.Revision < 1 {
+			return nil, RecurrenceUpdateOutput{}, errors.New("patch requires uid and a positive revision")
+		}
+		etag := `"rev-` + strconv.FormatInt(*input.Revision, 10) + `"`
+		headers := &generated.PatchRecurrenceHeaders{IfMatch: &etag}
+		body := &generated.PatchRecurrenceBody{Actor: &h.options.Actor, Dtstart: optionalString(input.DTStart), Rrule: optionalString(input.RRule), Timezone: optionalString(input.Timezone), Template: input.TemplatePatch}
+		response, patchErr := h.options.Client.PatchRecurrence(ctx, &generated.PatchRecurrenceRequestOptions{PathParams: &generated.PatchRecurrencePath{ProjectID: project.ID, RecurrenceUID: uid}, Body: body, Header: headers})
+		if patchErr != nil {
+			return nil, RecurrenceUpdateOutput{}, patchErr
+		}
+		return successResult(), RecurrenceUpdateOutput{Project: project, Recurrence: response.Recurrence, Changed: response.Changed}, nil
+	default:
+		return nil, RecurrenceUpdateOutput{}, errors.New("action must be create or patch")
+	}
+}
+
+func (h toolHandlers) recurrenceDelete(ctx context.Context, _ *sdkmcp.CallToolRequest, input RecurrenceDeleteInput) (*sdkmcp.CallToolResult, RecurrenceDeleteOutput, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
+	if err != nil {
+		return nil, RecurrenceDeleteOutput{}, err
+	}
+	uid := strings.TrimSpace(input.UID)
+	if uid == "" || input.Revision < 1 {
+		return nil, RecurrenceDeleteOutput{}, errors.New("uid and a positive revision are required")
+	}
+	etag := fmt.Sprintf(`"rev-%d"`, input.Revision)
+	_, err = h.options.Client.DeleteRecurrence(ctx, &generated.DeleteRecurrenceRequestOptions{PathParams: &generated.DeleteRecurrencePath{ProjectID: project.ID, RecurrenceUID: uid}, Query: &generated.DeleteRecurrenceQuery{Actor: &h.options.Actor}, Header: &generated.DeleteRecurrenceHeaders{IfMatch: etag}})
+	if err != nil {
+		return nil, RecurrenceDeleteOutput{}, err
+	}
+	return successResult(), RecurrenceDeleteOutput{Project: project, UID: uid, Deleted: true}, nil
+}

--- a/internal/mcp/recurrences.go
+++ b/internal/mcp/recurrences.go
@@ -61,7 +61,7 @@ type RecurrenceDeleteOutput struct {
 
 func registerRecurrenceTools(server *sdkmcp.Server, handlers toolHandlers) {
 	addTool(server, "kata.recurrences", "Read recurrences", "List recurrences or show one recurrence in an in-scope project.", toolHints(true, false, false), handlers.recurrences)
-	addTool(server, "kata.recurrence_update", "Update recurrence", "Create a recurrence or patch one at its required visible revision.", toolHints(false, false, false), handlers.recurrenceUpdate)
+	addTool(server, "kata.recurrence_update", "Update recurrence", "Create a recurrence or patch one at its required visible revision.", nonIdempotent(toolHints(false, false, false)), handlers.recurrenceUpdate)
 	addTool(server, "kata.recurrence_delete", "Delete recurrence", "Delete a recurrence at its visible revision.", toolHints(false, true, false), handlers.recurrenceDelete)
 }
 

--- a/internal/mcp/recurrences.go
+++ b/internal/mcp/recurrences.go
@@ -61,7 +61,7 @@ type RecurrenceDeleteOutput struct {
 
 func registerRecurrenceTools(server *sdkmcp.Server, handlers toolHandlers) {
 	addTool(server, "kata.recurrences", "Read recurrences", "List recurrences or show one recurrence in an in-scope project.", toolHints(true, false, false), handlers.recurrences)
-	addTool(server, "kata.recurrence_update", "Update recurrence", "Create a recurrence or patch one at its required visible revision.", nonIdempotent(toolHints(false, false, false)), handlers.recurrenceUpdate)
+	addTool(server, "kata.recurrence_update", "Update recurrence", "Create a recurrence or patch one at its required visible revision.", nonIdempotent(toolHints(false, true, false)), handlers.recurrenceUpdate)
 	addTool(server, "kata.recurrence_delete", "Delete recurrence", "Delete a recurrence at its visible revision.", toolHints(false, true, false), handlers.recurrenceDelete)
 }
 

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/kata/internal/storageadmin"
 	kataclient "go.kenn.io/kata/pkg/client"
 	"go.kenn.io/kata/pkg/client/generated"
 )
@@ -420,6 +421,70 @@ func TestEventsResponsesSerializeEmptyCollections(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, timedOut.TimedOut)
 	require.Contains(t, string(mustJSON(t, timedOut)), `"events":[]`, "timeouts must serialize an array, not null")
+}
+
+func TestScopedCloseGuardErrorsHideForeignIdentities(t *testing.T) {
+	daemonMessage := `refusing close: 2 open children remain:
+  other-project#zz9  Secret roadmap item
+  abc1  Local child`
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case strings.HasSuffix(request.URL.Path, "/actions/close"):
+			writer.WriteHeader(http.StatusConflict)
+			writeJSON(writer, map[string]any{
+				"status": http.StatusConflict,
+				"error":  map[string]any{"code": "parent_has_open_children", "message": daemonMessage},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	scoped := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+
+	_, _, err = scoped.close(t.Context(), nil, CloseInput{
+		Ref: "spoke-project#par1", Reason: "done", Message: "Completed all child work and verified the results.",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parent_has_open_children")
+	require.NotContains(t, err.Error(), "other-project", "foreign child refs must not leak through guard errors")
+	require.NotContains(t, err.Error(), "Secret roadmap item", "foreign child titles must not leak through guard errors")
+
+	wide := toolHandlers{options: Options{Client: client, Scope: NewAllScope(), Actor: "example-agent"}}
+	_, _, err = wide.close(t.Context(), nil, CloseInput{
+		Ref: "spoke-project#par1", Reason: "done", Message: "Completed all child work and verified the results.",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Secret roadmap item", "daemon-wide servers keep the actionable daemon message")
+}
+
+func TestScopedStorageExportRequiresDaemonWideScope(t *testing.T) {
+	admin, err := storageadmin.New(storageadmin.Config{Root: t.TempDir(), SourceDSN: "source.db"})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		http.NotFound(writer, request)
+	})
+	bound, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	allowlist, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+
+	for name, scope := range map[string]*Scope{"bound": bound, "allowlist": allowlist} {
+		handlers := toolHandlers{options: Options{Client: client, Scope: scope, StorageAdmin: admin}}
+		_, _, err := handlers.storageExport(t.Context(), nil, StorageExportInput{Artifact: "backup.jsonl"})
+		require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope",
+			"%s scope must not export cross-project link and payload data", name)
+	}
 }
 
 func TestProjectsListingSurvivesMissingAllowlistMember(t *testing.T) {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -227,13 +227,20 @@ func TestDigestRedactsForeignLinkActionTargets(t *testing.T) {
 					"issues": []any{map[string]any{
 						"issue_uid": "01HCCCCCCCCCCCCCCCCCCCCCCC", "issue_short_id": "abc1",
 						"project_id": 1, "project_name": "spoke-project",
-						"actions": []any{"created", "labeled:bug", "blocks:def2", "unparent:zz9", "commented:2"},
+						"actions": []any{"created", "labeled:bug", "blocks:def2", "unparent:zz9", "related:xyz9", "commented:2"},
 					}},
 				}},
 			})
-		case "/api/v1/projects/1/issues/def2":
+		case "/api/v1/projects/1/issues/abc1":
+			issue := issueJSON(1, "spoke-project", "abc1")
+			issue["uid"] = "01HCCCCCCCCCCCCCCCCCCCCCCC"
 			writeJSON(writer, map[string]any{
-				"issue": issueJSON(1, "spoke-project", "def2"), "labels": []any{}, "comments": []any{}, "links": []any{},
+				"issue": issue, "labels": []any{}, "comments": []any{},
+				"links": []any{map[string]any{
+					"id": 1, "type": "blocks", "author": "example-agent", "created_at": "2026-08-11T00:00:00Z",
+					"from": linkPeerJSON("spoke-project", "abc1", "01HCCCCCCCCCCCCCCCCCCCCCCC"),
+					"to":   linkPeerJSON("spoke-project", "def2", "01HEEEEEEEEEEEEEEEEEEEEEEE"),
+				}},
 			})
 		default:
 			http.NotFound(writer, request)
@@ -249,7 +256,41 @@ func TestDigestRedactsForeignLinkActionTargets(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, output.Digests, 1)
 	actions := output.Digests[0].Digest.Actors[0].Issues[0].Actions
-	require.Equal(t, []string{"created", "labeled:bug", "blocks:def2", "commented:2"}, actions)
+	require.Equal(t, []string{"created", "labeled:bug", "blocks:def2", "unparent", "related", "commented:2"}, actions,
+		"link-vouched peer survives; unvouched targets are stripped to their action type even when a same-short-ID issue exists")
+}
+
+func TestProjectsListingSurvivesMissingAllowlistMember(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/v1/projects" {
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+			return
+		}
+		http.NotFound(writer, request)
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"},
+		{ID: 2, UID: "01HBBBBBBBBBBBBBBBBBBBBBBB", Name: "hub-project"},
+	})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.projects(t.Context(), nil, ProjectsInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Projects, 1)
+	require.Equal(t, "spoke-project", output.Projects[0].Name)
+
+	_, _, err = handlers.projects(t.Context(), nil, ProjectsInput{Project: "hub-project"})
+	require.EqualError(t, err, `project "hub-project" in the MCP startup scope is no longer available`)
+}
+
+func linkPeerJSON(project, shortID, uid string) map[string]any {
+	return map[string]any{
+		"project": project, "qualified_id": project + "#" + shortID,
+		"short_id": shortID, "status": "open", "uid": uid,
+	}
 }
 
 func TestEditFiltersLinkChangePeersOutsideScope(t *testing.T) {
@@ -352,9 +393,16 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "def2", "parent": "ghi3"},
 				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "jkl4", "parent": "gone5"},
 			}})
-		case "/api/v1/projects/1/issues/ghi3":
+		case "/api/v1/projects/1/issues/def2":
+			issue := issueJSON(1, "spoke-project", "def2")
+			issue["uid"] = "01HCCCCCCCCCCCCCCCCCCCCCCC"
 			writeJSON(writer, map[string]any{
-				"issue": issueJSON(1, "spoke-project", "ghi3"), "labels": []any{}, "comments": []any{}, "links": []any{},
+				"issue": issue, "labels": []any{}, "comments": []any{},
+				"links": []any{map[string]any{
+					"id": 1, "type": "parent", "author": "example-agent", "created_at": "2026-08-11T00:00:00Z",
+					"from": linkPeerJSON("spoke-project", "def2", "01HCCCCCCCCCCCCCCCCCCCCCCC"),
+					"to":   linkPeerJSON("spoke-project", "ghi3", "01HEEEEEEEEEEEEEEEEEEEEEEE"),
+				}},
 			})
 		default:
 			http.NotFound(writer, request)
@@ -370,9 +418,9 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, output.Rows, 3)
 	require.Nil(t, output.Rows[0].Parent, "foreign qualified parent must be blanked")
-	require.NotNil(t, output.Rows[1].Parent)
+	require.NotNil(t, output.Rows[1].Parent, "parent vouched by the child's current in-scope parent link survives")
 	require.Equal(t, "ghi3", *output.Rows[1].Parent)
-	require.Nil(t, output.Rows[2].Parent, "bare parent that no longer resolves in the project must be blanked")
+	require.Nil(t, output.Rows[2].Parent, "bare parent without link provenance must be blanked")
 
 	// Foreign or unprovable parent filters are rejected before any request.
 	before := auditRequests

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -819,6 +819,13 @@ func TestScopedFederationLeaveCannotArchive(t *testing.T) {
 		})
 		require.NoError(t, err, "%s scope keeps the detach disposition", name)
 		require.Equal(t, before+1, mutations)
+
+		_, _, err = handlers.federationRebind(t.Context(), nil, FederationRebindInput{
+			Project: "spoke-project", HubCatalog: "other-hub",
+		})
+		require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope",
+			"%s scope must not route the enrollment token to a caller-selected catalog", name)
+		require.Equal(t, before+1, mutations)
 	}
 }
 

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -599,7 +599,7 @@ func TestEventDisplayRefsUseOnlyOwnHistoricalProjectName(t *testing.T) {
 	// project.
 	output := EventsOutput{Events: []StreamEvent{
 		{Type: "close.throttled", ProjectUID: "01HAAAAAAAAAAAAAAAAAAAAAAA", ProjectName: "former-name",
-			Payload: map[string]any{"reason": "sibling-burst", "parent": "former-name#zz9"}},
+			Payload: map[string]any{"reason": "sibling-burst", "parent": "former-name#zz9", "prior": "spoke-project#abc9"}},
 		{Type: "issue.closed", ProjectUID: "01HAAAAAAAAAAAAAAAAAAAAAAA", ProjectName: "spoke-project",
 			Payload: map[string]any{"reason": "duplicate", "evidence": []any{
 				map[string]any{"type": "duplicate-of", "issue_ref": "former-name#abc2"},
@@ -610,6 +610,8 @@ func TestEventDisplayRefsUseOnlyOwnHistoricalProjectName(t *testing.T) {
 	first := output.Events[0].Payload.(map[string]any)
 	require.Equal(t, "former-name#zz9", first["parent"],
 		"an event's own historical project name vouches its refs")
+	require.NotContains(t, first, "prior",
+		"a current in-scope name must not vouch an older event's ref: when the historical text was written, that name could have belonged to a foreign project")
 	evidence := output.Events[1].Payload.(map[string]any)["evidence"].([]any)
 	require.NotContains(t, evidence[0].(map[string]any), "issue_ref",
 		"another event's historical name must not vouch this event's refs; the name may now be foreign")

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -260,6 +260,52 @@ func TestDigestRedactsForeignLinkActionTargets(t *testing.T) {
 		"link-vouched peer survives; unvouched targets are stripped to their action type even when a same-short-ID issue exists")
 }
 
+func TestAuditPaginationInvalidatesWhenHistoryBelowCursorChanges(t *testing.T) {
+	auditRow := func(eventID int, issue string) map[string]any {
+		return map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": issue, "event_id": eventID}
+	}
+	merged := false
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case "/api/v1/audit/closes":
+			rows := []any{auditRow(11, "abc1"), auditRow(14, "def2"), auditRow(15, "ghi3")}
+			if merged {
+				// A project merge rehomed an older close event whose ID
+				// falls below the first page's cursor.
+				rows = []any{auditRow(11, "abc1"), auditRow(12, "hij4"), auditRow(14, "def2"), auditRow(15, "ghi3")}
+			}
+			writeJSON(writer, map[string]any{"rows": rows})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, first, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2})
+	require.NoError(t, err)
+	require.True(t, first.Truncated)
+	require.NotNil(t, first.NextCursor)
+
+	merged = true
+	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2, Cursor: *first.NextCursor})
+	require.ErrorContains(t, err, "restart without a cursor",
+		"history merged in below the cursor must invalidate pagination, not be skipped")
+
+	merged = false
+	_, resumed, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2, Cursor: *first.NextCursor})
+	require.NoError(t, err, "an unchanged prefix keeps the cursor valid")
+	require.Len(t, resumed.Rows, 1)
+	require.Equal(t, "ghi3", resumed.Rows[0].Issue)
+}
+
 func TestProjectsListingSurvivesMissingAllowlistMember(t *testing.T) {
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/projects" {
@@ -542,22 +588,23 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 	require.Nil(t, output.Rows[2].Parent, "bare parent without link provenance must be blanked")
 
 	// A bounded limit truncates before the result can exceed the transport
-	// message cap; the immutable event-ID cursor pages without skipping
-	// or repeating rows even when every row shares one timestamp.
+	// message cap; the event-ID cursor pages without skipping or repeating
+	// rows even when every row shares one timestamp.
 	_, limited, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2})
 	require.NoError(t, err)
 	require.Len(t, limited.Rows, 2)
 	require.True(t, limited.Truncated)
-	require.NotNil(t, limited.NextAfterEventID)
-	require.EqualValues(t, 12, *limited.NextAfterEventID)
-	_, page, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2, AfterEventID: *limited.NextAfterEventID})
+	require.NotNil(t, limited.NextCursor)
+	_, page, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2, Cursor: *limited.NextCursor})
 	require.NoError(t, err)
 	require.Len(t, page.Rows, 1)
 	require.False(t, page.Truncated)
-	require.Nil(t, page.NextAfterEventID)
+	require.Nil(t, page.NextCursor)
 	require.Equal(t, "jkl4", page.Rows[0].Issue)
 	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 101})
 	require.ErrorContains(t, err, "limit must be between 1 and 100")
+	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Cursor: "not-a-cursor"})
+	require.ErrorContains(t, err, "cursor is not a value returned in next_cursor")
 
 	// Foreign or unprovable parent filters are rejected before any request.
 	before := auditRequests

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -1818,6 +1818,56 @@ func TestFixedScopeCannotSeeOrRevokeWildcardFederationEnrollment(t *testing.T) {
 	require.Zero(t, revokeRequests.Load())
 }
 
+// TestEnrollmentRevokeCoversArchivedScopeProjects pins that an enrollment on
+// an archived allowlist member stays revocable (archiving retains enrollment
+// credentials) while enrollments outside the startup scope remain rejected.
+func TestEnrollmentRevokeCoversArchivedScopeProjects(t *testing.T) {
+	var revoked []string
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/projects":
+			projects := []any{projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project")}
+			if request.URL.Query().Get("include") == "archived" {
+				archived := projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "archived-project")
+				archived["deleted_at"] = "2026-08-12T00:00:00Z"
+				projects = append(projects, archived)
+			}
+			writeJSON(writer, map[string]any{"projects": projects})
+		case request.URL.Path == "/api/v1/federation/enrollments" && request.Method == http.MethodGet:
+			enrollment := func(id, projectID int64) map[string]any {
+				return map[string]any{
+					"id": id, "project_id": projectID, "spoke_instance_uid": "01HCCCCCCCCCCCCCCCCCCCCCCC",
+					"capabilities": "pull", "actor": "example-agent",
+					"created_at": "2026-08-11T00:00:00Z", "updated_at": "2026-08-11T00:00:00Z",
+				}
+			}
+			writeJSON(writer, map[string]any{"enrollments": []any{enrollment(9, 2), enrollment(10, 3), enrollment(11, 0)}})
+		case strings.Contains(request.URL.Path, "/federation/enrollments/"):
+			revoked = append(revoked, request.URL.Path)
+			writeJSON(writer, map[string]any{"id": 9, "revoked": true})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"},
+		{ID: 2, UID: "01HBBBBBBBBBBBBBBBBBBBBBBB", Name: "archived-project"},
+	})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.federationEnrollmentRevoke(t.Context(), nil, FederationEnrollmentRevokeInput{ID: 9})
+	require.NoError(t, err, "an enrollment on an archived allowlist member must stay revocable")
+	require.True(t, output.Revoked)
+	_, _, err = handlers.federationEnrollmentRevoke(t.Context(), nil, FederationEnrollmentRevokeInput{ID: 10})
+	require.ErrorContains(t, err, "outside the MCP startup scope")
+	_, _, err = handlers.federationEnrollmentRevoke(t.Context(), nil, FederationEnrollmentRevokeInput{ID: 11})
+	require.ErrorContains(t, err, "outside the MCP startup scope", "global enrollments stay daemon-wide only")
+	_, _, err = handlers.federationEnrollmentRevoke(t.Context(), nil, FederationEnrollmentRevokeInput{ID: 12})
+	require.ErrorContains(t, err, "outside the MCP startup scope", "unknown enrollments are rejected")
+	require.Len(t, revoked, 1)
+}
+
 func TestRecurrencePatchRequiresPositiveRevisionBeforeRequest(t *testing.T) {
 	var requests atomic.Int64
 	client := reviewClient(t, func(writer http.ResponseWriter, _ *http.Request) {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -506,6 +506,15 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 	require.Equal(t, "ghi3", *output.Rows[1].Parent)
 	require.Nil(t, output.Rows[2].Parent, "bare parent without link provenance must be blanked")
 
+	// A bounded limit truncates before the result can exceed the transport
+	// message cap, and truncation is reported so callers can page by time.
+	_, limited, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, limited.Rows, 2)
+	require.True(t, limited.Truncated)
+	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 101})
+	require.ErrorContains(t, err, "limit must be between 1 and 100")
+
 	// Foreign or unprovable parent filters are rejected before any request.
 	before := auditRequests
 	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "other-project#abc9"})

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -832,6 +832,53 @@ func TestEditFiltersArchivedLinkChangePeerOutsideActiveScope(t *testing.T) {
 	require.Nil(t, output.Changes.ParentRemoved, "archived relationship peer must not leak through edit changes")
 }
 
+func TestEditReportsCommittedMutationWhenLinkChangeScopingFails(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case request.Method == http.MethodPatch:
+			writeJSON(writer, map[string]any{
+				"changed": true, "issue": issueJSON(1, "spoke-project", "abc1"),
+				"event": map[string]any{
+					"event_id": 7, "event_uid": "01HEEEEEEEEEEEEEEEEEEEEEE7", "type": "issue.links_changed",
+					"actor": "example-agent", "content_hash": "hash", "created_at": "2026-08-12T00:00:00Z",
+					"origin_instance_uid": "01HFFFFFFFFFFFFFFFFFFFFFFF", "payload": "{}",
+					"project_id": 1, "project_name": "spoke-project", "project_uid": "01HAAAAAAAAAAAAAAAAAAAAAAA",
+				},
+				"changes": map[string]any{
+					"related_added": []any{map[string]any{
+						"project": "spoke-project", "qualified_id": "spoke-project#def2",
+						"short_id": "def2", "status": "open", "uid": "01HCCCCCCCCCCCCCCCCCCCCCCC",
+					}},
+				},
+			})
+		case strings.HasPrefix(request.URL.Path, "/api/v1/issues/"):
+			writer.WriteHeader(http.StatusInternalServerError)
+			writeJSON(writer, map[string]any{
+				"status": http.StatusInternalServerError,
+				"error":  map[string]any{"code": "internal_error", "message": "try again"},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	parent := "spoke-project#def2"
+	_, output, err := handlers.edit(t.Context(), nil, EditInput{Ref: "spoke-project#abc1", Parent: &parent})
+	require.NoError(t, err)
+	require.True(t, output.Changed)
+	require.Equal(t, "spoke-project#abc1", output.Issue.QualifiedRef)
+	require.Nil(t, output.Changes, "unresolved supplemental changes must be omitted after commit")
+}
+
 func TestEventRedactionPreservesOpaqueMetadataAndDiffValues(t *testing.T) {
 	var issueLookups int
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -1283,27 +1283,14 @@ func TestShowFiltersLinksOutsideFixedProjectScope(t *testing.T) {
 				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "other-project"),
 			}})
 		case "/api/v1/projects/1/issues/spk1":
-			issue := issueJSON(1, "spoke-project", "spk1")
-			peer := func(project, ref, uid string) map[string]any {
-				return map[string]any{
-					"project": project, "qualified_id": project + "#" + ref,
-					"short_id": ref, "status": "open", "uid": uid,
-				}
-			}
-			link := func(id int, to map[string]any) map[string]any {
-				return map[string]any{
-					"id": id, "type": "related", "author": "example-agent",
-					"created_at": "2026-08-11T00:00:00Z",
-					"from":       peer("spoke-project", "spk1", issue["uid"].(string)), "to": to,
-				}
-			}
-			writeJSON(writer, map[string]any{
-				"issue": issue, "labels": []any{}, "comments": []any{},
-				"links": []any{
-					link(1, peer("spoke-project", "in1", "01HCCCCCCCCCCCCCCCCCCCCCCC")),
-					link(2, peer("other-project", "out1", "01HDDDDDDDDDDDDDDDDDDDDDDD")),
-				},
-			})
+			writeJSON(writer, showLinksJSON(
+				showLinkPeerJSON("spoke-project", "in1", "01HCCCCCCCCCCCCCCCCCCCCCCC"),
+				showLinkPeerJSON("other-project", "out1", "01HDDDDDDDDDDDDDDDDDDDDDDD"),
+			))
+		case "/api/v1/issues/01HCCCCCCCCCCCCCCCCCCCCCCC":
+			writeJSON(writer, showByUIDJSON(1, "spoke-project", "in1", "01HCCCCCCCCCCCCCCCCCCCCCCC"))
+		case "/api/v1/issues/01HDDDDDDDDDDDDDDDDDDDDDDD":
+			writeJSON(writer, showByUIDJSON(2, "other-project", "out1", "01HDDDDDDDDDDDDDDDDDDDDDDD"))
 		default:
 			http.NotFound(writer, request)
 		}
@@ -1317,6 +1304,98 @@ func TestShowFiltersLinksOutsideFixedProjectScope(t *testing.T) {
 	_, output, err := handlers.show(t.Context(), nil, ShowInput{Ref: "spoke-project#spk1"})
 	require.NoError(t, err)
 	require.Equal(t, []LinkSummary{{Type: "related", QualifiedRef: "spoke-project#in1", Status: "open"}}, output.Issue.Links)
+}
+
+// TestShowAuthorizesLinkPeersByImmutableProjectIdentity covers a project
+// rename that reuses a name between the show response and the scope catalog:
+// the peer whose display name matches an in-scope project but whose UID lives
+// in an out-of-scope project must be dropped, and the peer whose in-scope
+// project was renamed after the catalog was cached must be kept.
+func TestShowAuthorizesLinkPeersByImmutableProjectIdentity(t *testing.T) {
+	const reusedNamePeer = "01HCCCCCCCCCCCCCCCCCCCCCCC"
+	const renamedScopePeer = "01HDDDDDDDDDDDDDDDDDDDDDDD"
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "other-project"),
+			}})
+		case "/api/v1/projects/1/issues/spk1":
+			writeJSON(writer, showLinksJSON(
+				showLinkPeerJSON("spoke-project", "out1", reusedNamePeer),
+				showLinkPeerJSON("renamed-project", "in1", renamedScopePeer),
+			))
+		case "/api/v1/issues/" + reusedNamePeer:
+			writeJSON(writer, showByUIDJSON(2, "spoke-project", "out1", reusedNamePeer))
+		case "/api/v1/issues/" + renamedScopePeer:
+			writeJSON(writer, showByUIDJSON(1, "renamed-project", "in1", renamedScopePeer))
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.show(t.Context(), nil, ShowInput{Ref: "spoke-project#spk1"})
+	require.NoError(t, err)
+	require.Equal(t, []LinkSummary{{Type: "related", QualifiedRef: "renamed-project#in1", Status: "open"}}, output.Issue.Links,
+		"link peers must be authorized by the immutable project that owns the peer UID, not by display name")
+}
+
+func TestShowFailsClosedWhenLinkPeerScopeLookupFails(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case "/api/v1/projects/1/issues/spk1":
+			writeJSON(writer, showLinksJSON(showLinkPeerJSON("spoke-project", "in1", "01HCCCCCCCCCCCCCCCCCCCCCCC")))
+		default:
+			http.Error(writer, "daemon unavailable", http.StatusInternalServerError)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, _, err = handlers.show(t.Context(), nil, ShowInput{Ref: "spoke-project#spk1"})
+	require.Error(t, err, "a transient peer lookup failure must not silently publish or drop links")
+	require.NotContains(t, err.Error(), "daemon unavailable", "daemon error bodies must stay redacted")
+}
+
+func showLinkPeerJSON(project, ref, uid string) map[string]any {
+	return map[string]any{
+		"project": project, "qualified_id": project + "#" + ref,
+		"short_id": ref, "status": "open", "uid": uid,
+	}
+}
+
+// showLinksJSON builds a spoke-project#spk1 show response whose issue has one
+// related link to each peer.
+func showLinksJSON(peers ...map[string]any) map[string]any {
+	issue := issueJSON(1, "spoke-project", "spk1")
+	links := make([]any, 0, len(peers))
+	for index, peer := range peers {
+		links = append(links, map[string]any{
+			"id": index + 1, "type": "related", "author": "example-agent",
+			"created_at": "2026-08-11T00:00:00Z",
+			"from":       showLinkPeerJSON("spoke-project", "spk1", issue["uid"].(string)), "to": peer,
+		})
+	}
+	return map[string]any{"issue": issue, "labels": []any{}, "comments": []any{}, "links": links}
+}
+
+func showByUIDJSON(projectID int64, projectName, shortID, uid string) map[string]any {
+	issue := issueJSON(projectID, projectName, shortID)
+	issue["uid"] = uid
+	return map[string]any{"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{}}
 }
 
 func TestTokenAdministrationRequiresDaemonWideScope(t *testing.T) {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -487,6 +487,109 @@ func TestScopedStorageExportRequiresDaemonWideScope(t *testing.T) {
 	}
 }
 
+func TestWaitDeadlineDuringLookupReturnsTimeout(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/v1/projects" {
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+			return
+		}
+		// Hold every issue lookup past the wait deadline.
+		select {
+		case <-request.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+		http.NotFound(writer, request)
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.wait(t.Context(), nil, WaitInput{
+		Refs: []string{"spoke-project#abc1"}, Status: "closed", TimeoutSeconds: 1,
+	})
+	require.NoError(t, err, "a deadline expiring mid-lookup is the documented timeout outcome, not a tool error")
+	require.Equal(t, "timeout", output.Reason)
+	require.NotNil(t, output.States)
+}
+
+func TestEventsWaitDeadlineDuringPollReturnsTimeout(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/v1/projects" {
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "hub-project"),
+			}})
+			return
+		}
+		select {
+		case <-request.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+		http.NotFound(writer, request)
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"},
+		{ID: 2, UID: "01HBBBBBBBBBBBBBBBBBBBBBBB", Name: "hub-project"},
+	})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.events(t.Context(), nil, EventsInput{Mode: "wait", WaitSeconds: 1})
+	require.NoError(t, err, "a deadline expiring mid-poll is the documented timeout outcome, not a tool error")
+	require.True(t, output.TimedOut)
+	require.Contains(t, string(mustJSON(t, output)), `"events":[]`)
+}
+
+func TestScopedFederationStatusRedactsErrorText(t *testing.T) {
+	foreignUID := "01HDDDDDDDDDDDDDDDDDDDDDDD"
+	quarantineError := "apply batch: issue.linked references unknown issue " + foreignUID
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case "/api/v1/federation/status":
+			writeJSON(writer, map[string]any{"statuses": []any{map[string]any{
+				"project_id": 1, "enabled": true, "enrollment_count": 0,
+				"active_quarantine_count": 1,
+				"last_error":              "push failed: " + foreignUID,
+				"active_quarantines": []any{map[string]any{
+					"id": 4, "direction": "pull", "error": quarantineError,
+					"created_at": "2026-08-13T00:00:00Z", "first_event_id": 1, "last_event_id": 2,
+				}},
+			}}})
+		case "/api/v1/federation/enrollments":
+			writeJSON(writer, map[string]any{"enrollments": []any{}})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	scoped := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := scoped.federationStatus(t.Context(), nil, FederationStatusInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Statuses, 1)
+	serialized := string(mustJSON(t, output))
+	require.NotContains(t, serialized, foreignUID, "stored federation errors must not leak foreign issue references to scoped servers")
+	require.Equal(t, scopedFederationErrorNotice, *output.Statuses[0].LastError)
+	require.Equal(t, scopedFederationErrorNotice, output.Statuses[0].ActiveQuarantines[0].ErrorData)
+
+	wide := toolHandlers{options: Options{Client: client, Scope: NewAllScope()}}
+	_, wideOutput, err := wide.federationStatus(t.Context(), nil, FederationStatusInput{})
+	require.NoError(t, err)
+	require.Equal(t, quarantineError, wideOutput.Statuses[0].ActiveQuarantines[0].ErrorData,
+		"daemon-wide servers keep the raw diagnostic")
+}
+
 func TestProjectsListingSurvivesMissingAllowlistMember(t *testing.T) {
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/projects" {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -329,6 +329,99 @@ func TestScopedServersCannotAdministerProjects(t *testing.T) {
 	require.Zero(t, requests, "scoped project administration must fail before any daemon request")
 }
 
+func TestMultiProjectSearchFusesByRankAndOmitsSingularProject(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "hub-project"),
+			}})
+		case "/api/v1/projects/1/search":
+			// Hybrid mode: request-local reciprocal-rank scores.
+			writeJSON(writer, map[string]any{"query": "work", "mode": "hybrid", "results": []any{
+				map[string]any{"issue": issueJSON(1, "spoke-project", "spk1"), "score": 0.03, "matched_in": []string{"title"}},
+				map[string]any{"issue": issueJSON(1, "spoke-project", "spk2"), "score": 0.02, "matched_in": []string{"title"}},
+			}})
+		case "/api/v1/projects/2/search":
+			// Lexical fallback: large corpus-local scores.
+			writeJSON(writer, map[string]any{"query": "work", "mode": "lexical", "results": []any{
+				map[string]any{"issue": issueJSON(2, "hub-project", "hub1"), "score": 9.0, "matched_in": []string{"title"}},
+				map[string]any{"issue": issueJSON(2, "hub-project", "hub2"), "score": 5.0, "matched_in": []string{"title"}},
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"},
+		{ID: 2, UID: "01HBBBBBBBBBBBBBBBBBBBBBBB", Name: "hub-project"},
+	})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.search(t.Context(), nil, SearchInput{Query: "work"})
+	require.NoError(t, err)
+	refs := make([]string, 0, len(output.Results))
+	for _, hit := range output.Results {
+		refs = append(refs, hit.Issue.QualifiedRef)
+	}
+	require.Equal(t, []string{"hub-project#hub1", "spoke-project#spk1", "hub-project#hub2", "spoke-project#spk2"}, refs,
+		"per-project ranks interleave instead of comparing request-local scores globally")
+	require.Equal(t, "mixed", output.Mode, "differing effective modes must not be mislabeled")
+	require.Nil(t, output.Project, "multi-project responses omit the singular project")
+	require.Len(t, output.Projects, 2)
+	serialized := mustJSON(t, output)
+	require.NotContains(t, string(serialized), `"project":{"id":0`)
+
+	_, single, err := handlers.search(t.Context(), nil, SearchInput{Query: "work", Project: "spoke-project"})
+	require.NoError(t, err)
+	require.NotNil(t, single.Project)
+	require.Equal(t, "spoke-project", single.Project.Name)
+	require.Equal(t, "hybrid", single.Mode)
+}
+
+func TestEventsResponsesSerializeEmptyCollections(t *testing.T) {
+	reset := false
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case "/api/v1/projects/1/events":
+			if reset {
+				writeJSON(writer, map[string]any{"events": []any{}, "next_after_id": 0, "reset_required": true, "reset_after_id": 7})
+				return
+			}
+			writeJSON(writer, map[string]any{"events": []any{}, "next_after_id": 0})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, empty, err := handlers.events(t.Context(), nil, EventsInput{Project: "spoke-project", Mode: "poll"})
+	require.NoError(t, err)
+	require.Contains(t, string(mustJSON(t, empty)), `"events":[]`, "empty poll must serialize an array, not null")
+
+	reset = true
+	_, resetOutput, err := handlers.events(t.Context(), nil, EventsInput{Project: "spoke-project", Mode: "poll"})
+	require.NoError(t, err)
+	require.True(t, resetOutput.ResetRequired)
+	require.Contains(t, string(mustJSON(t, resetOutput)), `"events":[]`, "reset responses must serialize an array, not null")
+
+	reset = false
+	_, timedOut, err := handlers.events(t.Context(), nil, EventsInput{Mode: "wait", WaitSeconds: 1})
+	require.NoError(t, err)
+	require.True(t, timedOut.TimedOut)
+	require.Contains(t, string(mustJSON(t, timedOut)), `"events":[]`, "timeouts must serialize an array, not null")
+}
+
 func TestProjectsListingSurvivesMissingAllowlistMember(t *testing.T) {
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/projects" {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -118,6 +118,126 @@ func TestEventPeerRedactionPropagatesTransientLookupFailure(t *testing.T) {
 	require.Equal(t, peerUID, output.Events[0].Payload.(map[string]any)["link_to_uid"])
 }
 
+func TestEventPeerRedactionCoversParentLinkAndArrayShapes(t *testing.T) {
+	allowedUID := "01HCCCCCCCCCCCCCCCCCCCCCCC"
+	foreignUID := "01HDDDDDDDDDDDDDDDDDDDDDDD"
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case strings.HasPrefix(request.URL.Path, "/api/v1/issues/"):
+			uid := strings.TrimPrefix(request.URL.Path, "/api/v1/issues/")
+			projectID, projectName := int64(1), "spoke-project"
+			if uid == foreignUID {
+				projectID, projectName = 2, "other-project"
+			}
+			issue := issueJSON(projectID, projectName, "peer1")
+			issue["uid"] = uid
+			writeJSON(writer, map[string]any{
+				"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	output := EventsOutput{Events: []StreamEvent{
+		{Payload: map[string]any{
+			"parent_set": "in1", "parent_set_uid": allowedUID,
+			"blocks_added": []any{"in1", "out1"}, "blocks_added_uids": []any{allowedUID, foreignUID},
+			"links": []any{map[string]any{"type": "blocks", "to_short_id": "out1", "to_issue_uid": foreignUID}},
+		}},
+		{Payload: map[string]any{
+			"parent_removed": "out1", "parent_removed_uid": foreignUID,
+			"related_added": []any{"out1"}, "related_added_uids": []any{foreignUID},
+		}},
+	}}
+
+	require.NoError(t, handlers.redactEventsOutsideScope(t.Context(), &output))
+	first := output.Events[0].Payload.(map[string]any)
+	require.Equal(t, allowedUID, first["parent_set_uid"])
+	require.Equal(t, "in1", first["parent_set"])
+	require.Equal(t, []any{allowedUID}, first["blocks_added_uids"])
+	require.Equal(t, []any{"in1"}, first["blocks_added"])
+	link := first["links"].([]any)[0].(map[string]any)
+	require.NotContains(t, link, "to_issue_uid")
+	require.NotContains(t, link, "to_short_id")
+	second := output.Events[1].Payload.(map[string]any)
+	require.NotContains(t, second, "parent_removed_uid")
+	require.NotContains(t, second, "parent_removed")
+	require.NotContains(t, second, "related_added_uids")
+	require.NotContains(t, second, "related_added")
+}
+
+func TestEventRedactionScopesMovedProjectReferences(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/v1/projects" {
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+			return
+		}
+		http.NotFound(writer, request)
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	output := EventsOutput{Events: []StreamEvent{{
+		ProjectUID: "01HAAAAAAAAAAAAAAAAAAAAAAA",
+		Payload: map[string]any{
+			"from_project_uid": "01HEEEEEEEEEEEEEEEEEEEEEEE", "from_short_id": "old1",
+			"to_project_uid": "01HAAAAAAAAAAAAAAAAAAAAAAA", "to_short_id": "new1",
+			"source_uid": "01HEEEEEEEEEEEEEEEEEEEEEEE",
+		},
+	}}}
+
+	require.NoError(t, handlers.redactEventsOutsideScope(t.Context(), &output))
+	payload := output.Events[0].Payload.(map[string]any)
+	require.NotContains(t, payload, "from_project_uid")
+	require.NotContains(t, payload, "from_short_id")
+	require.NotContains(t, payload, "source_uid")
+	require.Equal(t, "01HAAAAAAAAAAAAAAAAAAAAAAA", payload["to_project_uid"])
+	require.Equal(t, "new1", payload["to_short_id"])
+}
+
+func TestAuditClosesRedactsForeignQualifiedParents(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case "/api/v1/audit/closes":
+			writeJSON(writer, map[string]any{"rows": []any{
+				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "abc1", "parent": "other-project#zz9"},
+				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "def2", "parent": "ghi3"},
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project"})
+	require.NoError(t, err)
+	require.Len(t, output.Rows, 2)
+	require.Nil(t, output.Rows[0].Parent)
+	require.NotNil(t, output.Rows[1].Parent)
+	require.Equal(t, "ghi3", *output.Rows[1].Parent)
+}
+
 func TestEventPeerRedactionDropsShortIDsWithoutUIDs(t *testing.T) {
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/projects" {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -306,6 +306,29 @@ func TestAuditPaginationInvalidatesWhenHistoryBelowCursorChanges(t *testing.T) {
 	require.Equal(t, "ghi3", resumed.Rows[0].Issue)
 }
 
+func TestScopedServersCannotAdministerProjects(t *testing.T) {
+	var requests int
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		http.NotFound(writer, request)
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, _, err = handlers.projectRemove(t.Context(), nil, ProjectRemoveInput{Project: "spoke-project"})
+	require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+	_, _, err = handlers.projectPurge(t.Context(), nil, ProjectPurgeInput{Project: "spoke-project", Confirm: "PURGE spoke-project"})
+	require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+	_, _, err = handlers.projectUpdate(t.Context(), nil, ProjectUpdateInput{Project: "spoke-project", Action: "rename", Name: "renamed"})
+	require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+	_, _, err = handlers.projectMerge(t.Context(), nil, ProjectMergeInput{Source: "spoke-project", Target: "spoke-project"})
+	require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+	_, _, err = handlers.projectRestore(t.Context(), nil, ProjectRestoreInput{Project: "spoke-project"})
+	require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+	require.Zero(t, requests, "scoped project administration must fail before any daemon request")
+}
+
 func TestProjectsListingSurvivesMissingAllowlistMember(t *testing.T) {
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/projects" {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -565,7 +565,14 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 	require.ErrorContains(t, err, "outside the MCP startup scope")
 	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "01HDDDDDDDDDDDDDDDDDDDDDDD"})
 	require.ErrorContains(t, err, "unscoped UID")
+	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "fed9"})
+	require.ErrorContains(t, err, "does not resolve in project", "unresolved bare filters must not probe stored parent snapshots")
 	require.Equal(t, before, auditRequests, "rejected parent filters must not reach the daemon")
+
+	// A bare filter that resolves in the audited project is forwarded.
+	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "def2"})
+	require.NoError(t, err)
+	require.Equal(t, before+1, auditRequests)
 }
 
 func TestEventPeerRedactionDropsShortIDsWithoutUIDs(t *testing.T) {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -1,6 +1,7 @@
 package mcpserver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1942,4 +1943,22 @@ func TestDestructiveActionsAddressIssueByUID(t *testing.T) {
 	require.True(t, purged.Purged)
 	require.Equal(t, "spoke-project#abc4", purged.Ref, "display refs keep the confirmed short id")
 	require.Zero(t, shortIDMutations)
+}
+
+// TestReadEventStreamRejectsCleanCloseBeforeEvent covers the daemon closing
+// a stream cleanly (overflow disconnect, authority loss, internal failure)
+// before delivering an event or reset: that must surface as an error, not as
+// a successful empty batch a caller could mistake for "nothing happened".
+func TestReadEventStreamRejectsCleanCloseBeforeEvent(t *testing.T) {
+	_, err := readEventStream(t.Context(), strings.NewReader(": keepalive\n\nevent: heartbeat\ndata: {}\n\n"), 7, 10)
+	require.ErrorContains(t, err, "ended before delivering an event")
+
+	output, err := readEventStream(t.Context(), strings.NewReader("event: sync.reset_required\ndata: {\"reset_after_id\":3}\n\n"), 7, 10)
+	require.NoError(t, err)
+	require.True(t, output.ResetRequired)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = readEventStream(ctx, strings.NewReader(""), 7, 10)
+	require.ErrorIs(t, err, context.Canceled, "a cancelled context wins over the stream-ended error")
 }

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -175,6 +175,135 @@ func TestEventPeerRedactionCoversParentLinkAndArrayShapes(t *testing.T) {
 	require.NotContains(t, second, "related_added")
 }
 
+func TestEventRedactionCoversClosedParentFields(t *testing.T) {
+	foreignUID := "01HDDDDDDDDDDDDDDDDDDDDDDD"
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case strings.HasPrefix(request.URL.Path, "/api/v1/issues/"):
+			issue := issueJSON(2, "other-project", "peer1")
+			issue["uid"] = foreignUID
+			writeJSON(writer, map[string]any{
+				"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	output := EventsOutput{Events: []StreamEvent{{
+		Type:    "issue.closed",
+		Payload: map[string]any{"reason": "done", "parent_uid": foreignUID, "parent_short_id": "p1"},
+	}}}
+
+	require.NoError(t, handlers.redactEventsOutsideScope(t.Context(), &output))
+	payload := output.Events[0].Payload.(map[string]any)
+	require.NotContains(t, payload, "parent_uid")
+	require.NotContains(t, payload, "parent_short_id")
+	require.Equal(t, "done", payload["reason"])
+}
+
+func TestDigestRedactsForeignLinkActionTargets(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case "/api/v1/projects/1/digest":
+			writeJSON(writer, map[string]any{
+				"project_id": 1, "event_count": 2,
+				"since": "2026-08-11T00:00:00Z", "until": "2026-08-12T00:00:00Z",
+				"totals": map[string]any{},
+				"actors": []any{map[string]any{
+					"actor": "example-agent", "totals": map[string]any{},
+					"issues": []any{map[string]any{
+						"issue_uid": "01HCCCCCCCCCCCCCCCCCCCCCCC", "issue_short_id": "abc1",
+						"project_id": 1, "project_name": "spoke-project",
+						"actions": []any{"created", "labeled:bug", "blocks:def2", "unparent:zz9", "commented:2"},
+					}},
+				}},
+			})
+		case "/api/v1/projects/1/issues/def2":
+			writeJSON(writer, map[string]any{
+				"issue": issueJSON(1, "spoke-project", "def2"), "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.digest(t.Context(), nil, DigestInput{Project: "spoke-project", Since: "2026-08-11T00:00:00Z"})
+	require.NoError(t, err)
+	require.Len(t, output.Digests, 1)
+	actions := output.Digests[0].Digest.Actors[0].Issues[0].Actions
+	require.Equal(t, []string{"created", "labeled:bug", "blocks:def2", "commented:2"}, actions)
+}
+
+func TestEditFiltersLinkChangePeersOutsideScope(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case request.Method == http.MethodPatch:
+			issue := issueJSON(1, "spoke-project", "abc1")
+			writeJSON(writer, map[string]any{
+				"changed": true, "issue": issue,
+				"event": map[string]any{
+					"event_id": 7, "event_uid": "01HEEEEEEEEEEEEEEEEEEEEEE7", "type": "issue.links_changed",
+					"actor": "example-agent", "content_hash": "hash", "created_at": "2026-08-12T00:00:00Z",
+					"origin_instance_uid": "01HFFFFFFFFFFFFFFFFFFFFFFF", "payload": "{}",
+					"project_id": 1, "project_name": "spoke-project", "project_uid": "01HAAAAAAAAAAAAAAAAAAAAAAA",
+				},
+				"changes": map[string]any{
+					"parent_removed": map[string]any{
+						"project": "other-project", "qualified_id": "other-project#zz9",
+						"short_id": "zz9", "status": "open", "uid": "01HDDDDDDDDDDDDDDDDDDDDDDD",
+					},
+					"parent_set": map[string]any{
+						"project": "spoke-project", "qualified_id": "spoke-project#def2",
+						"short_id": "def2", "status": "open", "uid": "01HCCCCCCCCCCCCCCCCCCCCCCC",
+					},
+					"related_added": []any{map[string]any{
+						"project": "other-project", "qualified_id": "other-project#yy8",
+						"short_id": "yy8", "status": "open", "uid": "01HGGGGGGGGGGGGGGGGGGGGGGG",
+					}},
+				},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	parent := "spoke-project#def2"
+	_, output, err := handlers.edit(t.Context(), nil, EditInput{Ref: "spoke-project#abc1", Parent: &parent})
+	require.NoError(t, err)
+	require.NotNil(t, output.Changes)
+	require.Nil(t, output.Changes.ParentRemoved, "removed foreign parent must not leak")
+	require.NotNil(t, output.Changes.ParentSet)
+	require.Equal(t, "spoke-project#def2", output.Changes.ParentSet.QualifiedRef)
+	require.Empty(t, output.Changes.RelatedAdded)
+}
+
 func TestEventRedactionScopesMovedProjectReferences(t *testing.T) {
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/projects" {
@@ -208,7 +337,8 @@ func TestEventRedactionScopesMovedProjectReferences(t *testing.T) {
 	require.Equal(t, "new1", payload["to_short_id"])
 }
 
-func TestAuditClosesRedactsForeignQualifiedParents(t *testing.T) {
+func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
+	var auditRequests int
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
 		case "/api/v1/projects":
@@ -216,10 +346,16 @@ func TestAuditClosesRedactsForeignQualifiedParents(t *testing.T) {
 				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
 			}})
 		case "/api/v1/audit/closes":
+			auditRequests++
 			writeJSON(writer, map[string]any{"rows": []any{
 				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "abc1", "parent": "other-project#zz9"},
 				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "def2", "parent": "ghi3"},
+				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "jkl4", "parent": "gone5"},
 			}})
+		case "/api/v1/projects/1/issues/ghi3":
+			writeJSON(writer, map[string]any{
+				"issue": issueJSON(1, "spoke-project", "ghi3"), "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
 		default:
 			http.NotFound(writer, request)
 		}
@@ -232,10 +368,19 @@ func TestAuditClosesRedactsForeignQualifiedParents(t *testing.T) {
 
 	_, output, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project"})
 	require.NoError(t, err)
-	require.Len(t, output.Rows, 2)
-	require.Nil(t, output.Rows[0].Parent)
+	require.Len(t, output.Rows, 3)
+	require.Nil(t, output.Rows[0].Parent, "foreign qualified parent must be blanked")
 	require.NotNil(t, output.Rows[1].Parent)
 	require.Equal(t, "ghi3", *output.Rows[1].Parent)
+	require.Nil(t, output.Rows[2].Parent, "bare parent that no longer resolves in the project must be blanked")
+
+	// Foreign or unprovable parent filters are rejected before any request.
+	before := auditRequests
+	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "other-project#abc9"})
+	require.ErrorContains(t, err, "outside the MCP startup scope")
+	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "01HDDDDDDDDDDDDDDDDDDDDDDD"})
+	require.ErrorContains(t, err, "unscoped UID")
+	require.Equal(t, before, auditRequests, "rejected parent filters must not reach the daemon")
 }
 
 func TestEventPeerRedactionDropsShortIDsWithoutUIDs(t *testing.T) {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -734,6 +734,12 @@ func TestEditFiltersLinkChangePeersOutsideScope(t *testing.T) {
 			writeJSON(writer, map[string]any{"projects": []any{
 				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
 			}})
+		case request.URL.Path == "/api/v1/issues/01HCCCCCCCCCCCCCCCCCCCCCCC":
+			issue := issueJSON(1, "spoke-project", "def2")
+			issue["uid"] = "01HCCCCCCCCCCCCCCCCCCCCCCC"
+			writeJSON(writer, map[string]any{
+				"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
 		case request.Method == http.MethodPatch:
 			issue := issueJSON(1, "spoke-project", "abc1")
 			writeJSON(writer, map[string]any{
@@ -777,6 +783,53 @@ func TestEditFiltersLinkChangePeersOutsideScope(t *testing.T) {
 	require.NotNil(t, output.Changes.ParentSet)
 	require.Equal(t, "spoke-project#def2", output.Changes.ParentSet.QualifiedRef)
 	require.Empty(t, output.Changes.RelatedAdded)
+}
+
+func TestEditFiltersArchivedLinkChangePeerOutsideActiveScope(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/projects":
+			projects := []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}
+			if request.URL.Query().Get("include") == "archived" {
+				archived := projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "archived-project")
+				archived["deleted_at"] = "2026-08-12T00:00:00Z"
+				projects = append(projects, archived)
+			}
+			writeJSON(writer, map[string]any{"projects": projects})
+		case request.Method == http.MethodPatch:
+			writeJSON(writer, map[string]any{
+				"changed": true, "issue": issueJSON(1, "spoke-project", "abc1"),
+				"event": map[string]any{
+					"event_id": 7, "event_uid": "01HEEEEEEEEEEEEEEEEEEEEEE7", "type": "issue.links_changed",
+					"actor": "example-agent", "content_hash": "hash", "created_at": "2026-08-12T00:00:00Z",
+					"origin_instance_uid": "01HFFFFFFFFFFFFFFFFFFFFFFF", "payload": "{}",
+					"project_id": 1, "project_name": "spoke-project", "project_uid": "01HAAAAAAAAAAAAAAAAAAAAAAA",
+				},
+				"changes": map[string]any{
+					"parent_removed": map[string]any{
+						"project": "archived-project", "qualified_id": "archived-project#old1",
+						"short_id": "old1", "status": "closed", "uid": "01HCCCCCCCCCCCCCCCCCCCCCCC",
+					},
+				},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"},
+		{ID: 2, UID: "01HBBBBBBBBBBBBBBBBBBBBBBB", Name: "archived-project"},
+	})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	parent := "spoke-project#def2"
+	_, output, err := handlers.edit(t.Context(), nil, EditInput{Ref: "spoke-project#abc1", Parent: &parent})
+	require.NoError(t, err)
+	require.NotNil(t, output.Changes)
+	require.Nil(t, output.Changes.ParentRemoved, "archived relationship peer must not leak through edit changes")
 }
 
 func TestEventRedactionPreservesOpaqueMetadataAndDiffValues(t *testing.T) {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -777,6 +777,51 @@ func TestFederationLeaveRequiresPhaseAndCommitConfirmation(t *testing.T) {
 	require.Zero(t, requests.Load())
 }
 
+func TestScopedFederationLeaveCannotArchive(t *testing.T) {
+	var mutations int
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case "/api/v1/federation/replicas/1/actions/leave":
+			mutations++
+			writeJSON(writer, map[string]any{
+				"project":     projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+				"disposition": "detach", "detached": false,
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	bound, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	allowlist, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+
+	for name, scope := range map[string]*Scope{"bound": bound, "allowlist": allowlist} {
+		handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+		before := mutations
+		for _, phase := range []string{"preflight", "prepare", "commit"} {
+			_, _, err := handlers.federationLeave(t.Context(), nil, FederationLeaveInput{
+				Project: "spoke-project", Phase: phase, Disposition: "archive",
+				Confirm: "COMMIT FEDERATION LEAVE spoke-project",
+			})
+			require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope", "%s %s", name, phase)
+		}
+		require.Equal(t, before, mutations, "scoped archive leave must fail before any daemon mutation")
+
+		_, _, err := handlers.federationLeave(t.Context(), nil, FederationLeaveInput{
+			Project: "spoke-project", Phase: "preflight", Disposition: "detach",
+		})
+		require.NoError(t, err, "%s scope keeps the detach disposition", name)
+		require.Equal(t, before+1, mutations)
+	}
+}
+
 func TestFederationLeaveResolvesArchivedProjectForRetry(t *testing.T) {
 	var sawArchivedCatalog atomic.Bool
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -1866,3 +1866,56 @@ func reviewClient(t *testing.T, handler http.HandlerFunc) *kataclient.Client {
 	require.NoError(t, err)
 	return client
 }
+
+// TestDestructiveActionsAddressIssueByUID pins the delete and purge requests
+// to the immutable UID resolved during the confirmation preflight so a short
+// ID reused between preflight and mutation cannot redirect the action.
+func TestDestructiveActionsAddressIssueByUID(t *testing.T) {
+	const issueUID = "01HCCCCCCCCCCCCCCCCCCCCCCC"
+	var shortIDMutations int
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects/1/issues/abc4":
+			issue := issueJSON(1, "spoke-project", "abc4")
+			issue["uid"] = issueUID
+			writeJSON(writer, map[string]any{"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{}})
+		case "/api/v1/projects/1/issues/abc4/actions/delete", "/api/v1/projects/1/issues/abc4/actions/purge":
+			shortIDMutations++
+			http.Error(writer, "mutation addressed by mutable short id", http.StatusInternalServerError)
+		case "/api/v1/projects/1/issues/" + issueUID + "/actions/delete":
+			require.Equal(t, "DELETE spoke-project#abc4", request.Header.Get("X-Kata-Confirm"))
+			issue := issueJSON(1, "spoke-project", "abc4")
+			issue["uid"] = issueUID
+			issue["status"] = "deleted"
+			writeJSON(writer, map[string]any{
+				"changed": true, "issue": issue,
+				"event": map[string]any{
+					"event_id": 7, "event_uid": "01HEEEEEEEEEEEEEEEEEEEEEE7", "type": "issue.deleted",
+					"actor": "example-agent", "content_hash": "hash", "created_at": "2026-08-12T00:00:00Z",
+					"origin_instance_uid": "01HFFFFFFFFFFFFFFFFFFFFFFF", "payload": "{}",
+					"project_id": 1, "project_name": "spoke-project", "project_uid": "01HAAAAAAAAAAAAAAAAAAAAAAA",
+				},
+			})
+		case "/api/v1/projects/1/issues/" + issueUID + "/actions/purge":
+			require.Equal(t, "PURGE spoke-project#abc4", request.Header.Get("X-Kata-Confirm"))
+			writeJSON(writer, map[string]any{"purge_log": map[string]any{
+				"id": 1, "project_id": 1, "issue_uid": issueUID, "actor": "example-agent",
+				"purged_at": "2026-08-12T00:00:00Z",
+			}})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+
+	_, deleted, err := handlers.deleteIssue(t.Context(), nil, DeleteInput{Ref: "abc4", Confirm: "DELETE spoke-project#abc4"})
+	require.NoError(t, err)
+	require.Equal(t, "spoke-project#abc4", deleted.Issue.QualifiedRef)
+	_, purged, err := handlers.purgeIssue(t.Context(), nil, PurgeInput{Ref: "abc4", Confirm: "PURGE spoke-project#abc4"})
+	require.NoError(t, err)
+	require.True(t, purged.Purged)
+	require.Equal(t, "spoke-project#abc4", purged.Ref, "display refs keep the confirmed short id")
+	require.Zero(t, shortIDMutations)
+}

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -286,6 +286,90 @@ func TestProjectsListingSurvivesMissingAllowlistMember(t *testing.T) {
 	require.EqualError(t, err, `project "hub-project" in the MCP startup scope is no longer available`)
 }
 
+func TestScopedSyncEnableRequiresDaemonWideScope(t *testing.T) {
+	var syncRequests []string
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case strings.Contains(request.URL.Path, "/issue-sync/"):
+			syncRequests = append(syncRequests, request.URL.Path)
+			writeJSON(writer, map[string]any{"status": map[string]any{"binding_id": 1, "enabled": false, "last_comments": 0, "last_created": 0}})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	scoped := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, _, err = scoped.syncUpdate(t.Context(), nil, SyncUpdateInput{
+		Project: "spoke-project", Action: "enable",
+		Config: map[string]any{"owner": "victim-org", "repo": "private-repo"},
+	})
+	require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+	require.Empty(t, syncRequests, "scoped enable must not reach the daemon")
+
+	_, _, err = scoped.syncUpdate(t.Context(), nil, SyncUpdateInput{Project: "spoke-project", Action: "disable"})
+	require.NoError(t, err, "scoped disable of the operator-configured binding stays allowed")
+
+	wide := toolHandlers{options: Options{Client: client, Scope: NewAllScope()}}
+	_, _, err = wide.syncUpdate(t.Context(), nil, SyncUpdateInput{
+		Project: "spoke-project", Action: "enable",
+		Config: map[string]any{"owner": "example-org", "repo": "example-repo"},
+	})
+	require.NoError(t, err, "daemon-wide enable remains an operator action")
+	require.Len(t, syncRequests, 2)
+}
+
+func TestEventRedactionCoversThrottleAndEvidenceDisplayRefs(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/v1/projects" {
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+			return
+		}
+		http.NotFound(writer, request)
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	output := EventsOutput{Events: []StreamEvent{
+		{Type: "close.throttled", ProjectName: "spoke-project", Payload: map[string]any{
+			"reason": "sibling-burst",
+			"parent": "other-project#zz9",
+			"prior":  "hub-project#abc4",
+			"cohort": []any{"abc1", "other-project#def2", "01HDDDDDDDDDDDDDDDDDDDDDDD"},
+		}},
+		{Type: "issue.closed", ProjectName: "spoke-project", Payload: map[string]any{
+			"reason": "duplicate",
+			"evidence": []any{
+				map[string]any{"type": "duplicate-of", "issue_ref": "other-project#ghi3"},
+				map[string]any{"type": "duplicate-of", "issue_ref": "def2"},
+				map[string]any{"type": "commit", "sha": "abc1234"},
+			},
+		}},
+	}}
+
+	require.NoError(t, handlers.redactEventsOutsideScope(t.Context(), &output))
+	throttled := output.Events[0].Payload.(map[string]any)
+	require.NotContains(t, throttled, "parent", "foreign qualified throttle parent must be blanked")
+	require.NotContains(t, throttled, "prior")
+	require.Equal(t, []any{"abc1"}, throttled["cohort"], "bare same-project cohort refs survive; foreign and full-length refs do not")
+	closed := output.Events[1].Payload.(map[string]any)
+	evidence := closed["evidence"].([]any)
+	require.NotContains(t, evidence[0].(map[string]any), "issue_ref", "foreign qualified evidence ref must be blanked")
+	require.Equal(t, "def2", evidence[1].(map[string]any)["issue_ref"], "bare same-project evidence ref survives")
+	require.Equal(t, "abc1234", evidence[2].(map[string]any)["sha"], "non-ref evidence is untouched")
+}
+
 func linkPeerJSON(project, shortID, uid string) map[string]any {
 	return map[string]any{
 		"project": project, "qualified_id": project + "#" + shortID,

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -1,0 +1,552 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	kataclient "go.kenn.io/kata/pkg/client"
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+func TestReadEventStreamAcceptsLargeEvents(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"body": strings.Repeat("x", 70<<10), "link_to_uid": "foreign-uid", "type": "related",
+	})
+	require.NoError(t, err)
+	event := generated.EventEnvelope{
+		EventID: 1, EventUID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Type: "links_changed",
+		Actor: "example-agent", CreatedAt: time.Date(2026, 8, 11, 0, 0, 0, 0, time.UTC),
+		ProjectID: 1, ProjectUID: "01HBBBBBBBBBBBBBBBBBBBBBBB", ProjectName: "spoke-project",
+		Payload: payload, RelatedIssueUID: optionalString("foreign-uid"), RelatedIssueShortID: optionalString("out1"),
+	}
+	encoded, err := json.Marshal(event)
+	require.NoError(t, err)
+	stream := "event: links_changed\ndata: " + string(encoded) + "\n\n"
+
+	output, err := readEventStream(t.Context(), strings.NewReader(stream), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, output.Events, 1)
+	require.Equal(t, "foreign-uid", output.Events[0].RelatedIssueUID)
+	decoded := output.Events[0].Payload.(map[string]any)
+	require.Len(t, decoded["body"], 70<<10)
+}
+
+func TestEventPeerRedactionPreservesAllowedPeers(t *testing.T) {
+	allowedUID := "01HCCCCCCCCCCCCCCCCCCCCCCC"
+	foreignUID := "01HDDDDDDDDDDDDDDDDDDDDDDD"
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "other-project"),
+			}})
+		case strings.HasPrefix(request.URL.Path, "/api/v1/issues/"):
+			uid := strings.TrimPrefix(request.URL.Path, "/api/v1/issues/")
+			projectID, projectName := int64(1), "spoke-project"
+			if uid == foreignUID {
+				projectID, projectName = 2, "other-project"
+			}
+			issue := issueJSON(projectID, projectName, "peer1")
+			issue["uid"] = uid
+			writeJSON(writer, map[string]any{
+				"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	output := EventsOutput{Events: []StreamEvent{
+		{RelatedIssueUID: allowedUID, RelatedIssueShortID: "in1", Payload: map[string]any{"link_to_uid": allowedUID}},
+		{RelatedIssueUID: foreignUID, RelatedIssueShortID: "out1", Payload: map[string]any{"link_to_uid": foreignUID}},
+	}}
+
+	require.NoError(t, handlers.redactEventsOutsideScope(t.Context(), &output))
+	require.Equal(t, allowedUID, output.Events[0].RelatedIssueUID)
+	require.Equal(t, allowedUID, output.Events[0].Payload.(map[string]any)["link_to_uid"])
+	require.Empty(t, output.Events[1].RelatedIssueUID)
+	require.Empty(t, output.Events[1].RelatedIssueShortID)
+	require.NotContains(t, output.Events[1].Payload.(map[string]any), "link_to_uid")
+}
+
+func TestEventPeerRedactionPropagatesTransientLookupFailure(t *testing.T) {
+	peerUID := "01HCCCCCCCCCCCCCCCCCCCCCCC"
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case "/api/v1/issues/" + peerUID:
+			writer.WriteHeader(http.StatusInternalServerError)
+			writeJSON(writer, map[string]any{
+				"status": http.StatusInternalServerError,
+				"error":  map[string]any{"code": "internal_error", "message": "try again"},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	output := EventsOutput{Events: []StreamEvent{{
+		RelatedIssueUID: peerUID, RelatedIssueShortID: "in1",
+		Payload: map[string]any{"link_to_uid": peerUID},
+	}}}
+
+	err = handlers.redactEventsOutsideScope(t.Context(), &output)
+	require.ErrorContains(t, err, "resolve event peer")
+	require.NotContains(t, err.Error(), peerUID)
+	require.NotContains(t, err.Error(), "try again")
+	require.Equal(t, peerUID, output.Events[0].RelatedIssueUID)
+	require.Equal(t, peerUID, output.Events[0].Payload.(map[string]any)["link_to_uid"])
+}
+
+func TestEventPeerRedactionDropsShortIDsWithoutUIDs(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/v1/projects" {
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+			return
+		}
+		http.NotFound(writer, request)
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	output := EventsOutput{Events: []StreamEvent{{
+		RelatedIssueShortID: "out1",
+		Payload: map[string]any{
+			"from_short_id": "from1", "to_short_id": "to1",
+			"peer_short_id": "peer1", "related_issue_short_id": "related1",
+		},
+	}}}
+
+	require.NoError(t, handlers.redactEventsOutsideScope(t.Context(), &output))
+	require.Empty(t, output.Events[0].RelatedIssueShortID)
+	payload := output.Events[0].Payload.(map[string]any)
+	require.NotContains(t, payload, "from_short_id")
+	require.NotContains(t, payload, "to_short_id")
+	require.NotContains(t, payload, "peer_short_id")
+	require.NotContains(t, payload, "related_issue_short_id")
+}
+
+func TestShowFiltersLinksOutsideFixedProjectScope(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "other-project"),
+			}})
+		case "/api/v1/projects/1/issues/spk1":
+			issue := issueJSON(1, "spoke-project", "spk1")
+			peer := func(project, ref, uid string) map[string]any {
+				return map[string]any{
+					"project": project, "qualified_id": project + "#" + ref,
+					"short_id": ref, "status": "open", "uid": uid,
+				}
+			}
+			link := func(id int, to map[string]any) map[string]any {
+				return map[string]any{
+					"id": id, "type": "related", "author": "example-agent",
+					"created_at": "2026-08-11T00:00:00Z",
+					"from":       peer("spoke-project", "spk1", issue["uid"].(string)), "to": to,
+				}
+			}
+			writeJSON(writer, map[string]any{
+				"issue": issue, "labels": []any{}, "comments": []any{},
+				"links": []any{
+					link(1, peer("spoke-project", "in1", "01HCCCCCCCCCCCCCCCCCCCCCCC")),
+					link(2, peer("other-project", "out1", "01HDDDDDDDDDDDDDDDDDDDDDDD")),
+				},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.show(t.Context(), nil, ShowInput{Ref: "spoke-project#spk1"})
+	require.NoError(t, err)
+	require.Equal(t, []LinkSummary{{Type: "related", QualifiedRef: "spoke-project#in1", Status: "open"}}, output.Issue.Links)
+}
+
+func TestTokenAdministrationRequiresDaemonWideScope(t *testing.T) {
+	var requests atomic.Int64
+	client := reviewClient(t, func(writer http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(writer, "unexpected request", http.StatusInternalServerError)
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent", EnableTokenAdmin: true}}
+
+	_, _, err = handlers.tokens(t.Context(), nil, TokensInput{})
+	require.ErrorContains(t, err, "daemon-wide scope")
+	_, _, err = handlers.tokenCreate(t.Context(), nil, TokenCreateInput{TokenActor: "example-agent"})
+	require.ErrorContains(t, err, "daemon-wide scope")
+	_, _, err = handlers.tokenRevoke(t.Context(), nil, TokenRevokeInput{ID: 1})
+	require.ErrorContains(t, err, "daemon-wide scope")
+	require.Zero(t, requests.Load())
+}
+
+func TestTokenAdministrationRequiresExplicitCapability(t *testing.T) {
+	var requests atomic.Int64
+	client := reviewClient(t, func(writer http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(writer, "unexpected request", http.StatusInternalServerError)
+	})
+	handlers := toolHandlers{options: Options{
+		Client: client, Scope: NewAllScope(), Actor: "example-agent",
+	}}
+
+	_, _, err := handlers.tokens(t.Context(), nil, TokensInput{})
+	require.ErrorContains(t, err, "explicit startup capability")
+	_, _, err = handlers.tokenCreate(t.Context(), nil, TokenCreateInput{TokenActor: "example-agent"})
+	require.ErrorContains(t, err, "explicit startup capability")
+	_, _, err = handlers.tokenRevoke(t.Context(), nil, TokenRevokeInput{ID: 1})
+	require.ErrorContains(t, err, "explicit startup capability")
+	require.Zero(t, requests.Load())
+}
+
+func TestFederationLeaveRequiresPhaseAndCommitConfirmation(t *testing.T) {
+	var requests atomic.Int64
+	client := reviewClient(t, func(writer http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(writer, "unexpected request", http.StatusInternalServerError)
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope, Actor: "example-agent"}}
+
+	_, _, err = handlers.federationLeave(t.Context(), nil, FederationLeaveInput{Project: "spoke-project"})
+	require.ErrorContains(t, err, "phase is required")
+	_, _, err = handlers.federationLeave(t.Context(), nil, FederationLeaveInput{Project: "spoke-project", Phase: "commit"})
+	require.ErrorContains(t, err, `confirm must equal "COMMIT FEDERATION LEAVE spoke-project"`)
+	require.Zero(t, requests.Load())
+}
+
+func TestFederationLeaveResolvesArchivedProjectForRetry(t *testing.T) {
+	var sawArchivedCatalog atomic.Bool
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			sawArchivedCatalog.Store(request.URL.Query().Get("include") == "archived")
+			project := projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project")
+			project["deleted_at"] = "2026-08-11T00:00:00Z"
+			writeJSON(writer, map[string]any{"projects": []any{project}})
+		case "/api/v1/federation/replicas/1/actions/leave":
+			writeJSON(writer, map[string]any{
+				"project":     projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+				"disposition": "archive", "detached": true, "archived": true,
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	handlers := toolHandlers{options: Options{
+		Client: client, Scope: NewAllScope(), Actor: "example-agent",
+	}}
+
+	_, output, err := handlers.federationLeave(t.Context(), nil, FederationLeaveInput{
+		Project: "spoke-project", Phase: "commit", Disposition: "archive",
+		Confirm: "COMMIT FEDERATION LEAVE spoke-project",
+	})
+	require.NoError(t, err)
+	require.True(t, sawArchivedCatalog.Load())
+	require.True(t, output.Detached)
+}
+
+func TestAllowlistListAndReadyApplyLimitAfterScopedFanout(t *testing.T) {
+	for _, ready := range []bool{false, true} {
+		t.Run(map[bool]string{false: "list", true: "ready"}[ready], func(t *testing.T) {
+			var globalRequests atomic.Int64
+			client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+				switch request.URL.Path {
+				case "/api/v1/projects":
+					writeJSON(writer, map[string]any{"projects": []any{
+						projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+						projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "hub-project"),
+					}})
+				case "/api/v1/projects/1/issues", "/api/v1/projects/1/ready":
+					issue := issueJSON(1, "spoke-project", "spk1")
+					issue["updated_at"] = "2026-08-10T00:00:00Z"
+					writeJSON(writer, map[string]any{"issues": []any{issue}})
+				case "/api/v1/projects/2/issues", "/api/v1/projects/2/ready":
+					issue := issueJSON(2, "hub-project", "hub1")
+					issue["project_uid"] = "01HBBBBBBBBBBBBBBBBBBBBBBB"
+					issue["updated_at"] = "2026-08-11T00:00:00Z"
+					writeJSON(writer, map[string]any{"issues": []any{issue}})
+				default:
+					globalRequests.Add(1)
+					http.Error(writer, "unexpected global request", http.StatusInternalServerError)
+				}
+			})
+			scope, err := NewAllowlistScope([]ProjectIdentity{
+				{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"},
+				{ID: 2, UID: "01HBBBBBBBBBBBBBBBBBBBBBBB", Name: "hub-project"},
+			})
+			require.NoError(t, err)
+			handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+			var output IssueListOutput
+			if ready {
+				_, output, err = handlers.ready(t.Context(), nil, ReadyInput{Limit: 1})
+			} else {
+				_, output, err = handlers.list(t.Context(), nil, ListInput{Limit: 1})
+			}
+			require.NoError(t, err)
+			require.True(t, output.Truncated)
+			require.Equal(t, "hub-project#hub1", output.Issues[0].QualifiedRef)
+			require.Zero(t, globalRequests.Load())
+		})
+	}
+}
+
+func TestNextExaminesAllReadyIssues(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project")}})
+		case "/api/v1/ready":
+			count := 101
+			if request.URL.Query().Has("limit") {
+				count = 100
+			}
+			issues := make([]any, 0, count)
+			for index := 0; index < count; index++ {
+				issue := globalIssueJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project", fmt.Sprintf("i%03d", index))
+				issue["uid"] = fmt.Sprintf("01ARZ3NDEKTSV4RRFFQ69G%04d", index)
+				issue["priority"] = 4
+				if index == 100 {
+					issue["priority"] = 0
+				}
+				issues = append(issues, issue)
+			}
+			writeJSON(writer, map[string]any{"issues": issues})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	handlers := toolHandlers{options: Options{Client: client, Scope: NewAllScope()}}
+
+	_, output, err := handlers.next(t.Context(), nil, NextInput{})
+	require.NoError(t, err)
+	require.NotNil(t, output.Issue)
+	require.Equal(t, "spoke-project#i100", output.Issue.QualifiedRef)
+}
+
+func TestAllowlistNextPreservesMergedReadyOrderingForEqualPriority(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "hub-project"),
+			}})
+		case "/api/v1/projects/1/ready":
+			issue := issueJSON(1, "spoke-project", "spk1")
+			issue["priority"] = 1
+			issue["updated_at"] = "2026-08-11T00:00:00Z"
+			writeJSON(writer, map[string]any{"issues": []any{issue}})
+		case "/api/v1/projects/2/ready":
+			issue := issueJSON(2, "hub-project", "hub1")
+			issue["project_uid"] = "01HBBBBBBBBBBBBBBBBBBBBBBB"
+			issue["priority"] = 1
+			issue["updated_at"] = "2026-08-10T00:00:00Z"
+			writeJSON(writer, map[string]any{"issues": []any{issue}})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"},
+		{ID: 2, UID: "01HBBBBBBBBBBBBBBBBBBBBBBB", Name: "hub-project"},
+	})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.next(t.Context(), nil, NextInput{})
+	require.NoError(t, err)
+	require.NotNil(t, output.Issue)
+	require.Equal(t, "spoke-project#spk1", output.Issue.QualifiedRef)
+}
+
+func TestGraphFiltersNodesEdgesAndUnresolvedReferencesToScope(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "hub-project"),
+			}})
+		case "/api/v1/projects/1/issues/spk1/graph":
+			allowed := issueJSON(1, "spoke-project", "spk1")
+			allowed["uid"] = "allowed-uid"
+			denied := issueJSON(2, "hub-project", "hub1")
+			denied["uid"] = "denied-uid"
+			writeJSON(writer, map[string]any{
+				"source_uid": "allowed-uid", "depth": "full", "hide_done": false,
+				"nodes":           []any{allowed, denied},
+				"edges":           []any{map[string]any{"from_uid": "allowed-uid", "to_uid": "denied-uid", "kind": "blocks", "layout": true}},
+				"unresolved_refs": []any{map[string]any{"uid": "allowed-uid", "other_uid": "denied-uid", "kind": "blocks", "side": "to"}},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.graph(t.Context(), nil, GraphInput{Ref: "spoke-project#spk1"})
+	require.NoError(t, err)
+	require.Len(t, output.Nodes, 1)
+	require.Equal(t, "allowed-uid", output.Nodes[0].UID)
+	require.Empty(t, output.Edges)
+	require.Empty(t, output.UnresolvedRefs)
+}
+
+func TestEditRejectsMixedIssueAndMetadataChangesBeforeMutation(t *testing.T) {
+	var requests atomic.Int64
+	client := reviewClient(t, func(writer http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(writer, "unexpected request", http.StatusInternalServerError)
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	title := "Changed"
+	scheduledOn := "2026-09-01"
+
+	_, _, err = handlers.edit(t.Context(), nil, EditInput{Ref: "spk1", Title: &title, ScheduledOn: &scheduledOn})
+	require.ErrorContains(t, err, "separate calls")
+	require.Zero(t, requests.Load())
+}
+
+func TestProjectsListsArchivedRecordsWithoutShowRequest(t *testing.T) {
+	var showRequests atomic.Int64
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/projects" {
+			showRequests.Add(1)
+			http.Error(writer, "archived project cannot be shown", http.StatusNotFound)
+			return
+		}
+		archived := projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "archived-project")
+		archived["deleted_at"] = "2026-08-11T00:00:00Z"
+		writeJSON(writer, map[string]any{"projects": []any{
+			projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"), archived,
+		}})
+	})
+	handlers := toolHandlers{options: Options{Client: client, Scope: NewAllScope()}}
+
+	_, output, err := handlers.projects(t.Context(), nil, ProjectsInput{IncludeArchived: true})
+	require.NoError(t, err)
+	require.Len(t, output.Projects, 2)
+	require.True(t, output.Projects[0].Archived || output.Projects[1].Archived)
+	require.Zero(t, showRequests.Load())
+}
+
+func TestFixedScopeCannotSeeOrRevokeWildcardFederationEnrollment(t *testing.T) {
+	var revokeRequests atomic.Int64
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/api/v1/federation/status":
+			writeJSON(writer, map[string]any{"statuses": []any{}})
+		case request.URL.Path == "/api/v1/federation/enrollments" && request.Method == http.MethodGet:
+			writeJSON(writer, map[string]any{"enrollments": []any{map[string]any{
+				"id": 9, "project_id": 0, "spoke_instance_uid": "01HCCCCCCCCCCCCCCCCCCCCCCC",
+				"capabilities": "pull", "actor": "example-agent",
+				"created_at": "2026-08-11T00:00:00Z", "updated_at": "2026-08-11T00:00:00Z",
+			}}})
+		case strings.Contains(request.URL.Path, "/federation/enrollments/"):
+			revokeRequests.Add(1)
+			writeJSON(writer, map[string]any{"id": 9, "revoked": true})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, status, err := handlers.federationStatus(t.Context(), nil, FederationStatusInput{})
+	require.NoError(t, err)
+	require.Empty(t, status.Enrollments)
+	_, _, err = handlers.federationEnrollmentRevoke(t.Context(), nil, FederationEnrollmentRevokeInput{ID: 9})
+	require.ErrorContains(t, err, "outside the MCP startup scope")
+	require.Zero(t, revokeRequests.Load())
+}
+
+func TestRecurrencePatchRequiresPositiveRevisionBeforeRequest(t *testing.T) {
+	var requests atomic.Int64
+	client := reviewClient(t, func(writer http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(writer, "unexpected request", http.StatusInternalServerError)
+	})
+	scope, err := NewBoundScope(ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, _, err = handlers.recurrenceUpdate(t.Context(), nil, RecurrenceUpdateInput{Action: "patch", UID: "recurrence-uid"})
+	require.ErrorContains(t, err, "positive revision")
+	require.Zero(t, requests.Load())
+}
+
+func TestAllowlistEventResetAdvancesToResetCursor(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project")}})
+		case "/api/v1/projects/1/events":
+			writeJSON(writer, map[string]any{
+				"events": []any{}, "next_after_id": 42, "reset_required": true, "reset_after_id": 42,
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	output, err := handlers.pollScopedEvents(t.Context(), "", 7, 20)
+	require.NoError(t, err)
+	require.True(t, output.ResetRequired)
+	require.EqualValues(t, 42, output.NextAfterID)
+	require.NotNil(t, output.ResetAfterID)
+	require.EqualValues(t, 42, *output.ResetAfterID)
+}
+
+func reviewClient(t *testing.T, handler http.HandlerFunc) *kataclient.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := kataclient.NewWithHTTPClient(server.URL, server.Client())
+	require.NoError(t, err)
+	return client
+}

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -727,13 +727,6 @@ func TestEventRedactionCoversThrottleAndEvidenceDisplayRefs(t *testing.T) {
 	require.Equal(t, "abc1234", evidence[2].(map[string]any)["sha"], "non-ref evidence is untouched")
 }
 
-func linkPeerJSON(project, shortID, uid string) map[string]any {
-	return map[string]any{
-		"project": project, "qualified_id": project + "#" + shortID,
-		"short_id": shortID, "status": "open", "uid": uid,
-	}
-}
-
 func TestEditFiltersLinkChangePeersOutsideScope(t *testing.T) {
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		switch {
@@ -927,12 +920,16 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 	require.ErrorContains(t, err, "unscoped UID")
 	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "fed9"})
 	require.ErrorContains(t, err, "does not resolve in project", "unresolved bare filters must not probe stored parent snapshots")
+	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "spoke-project#fed9"})
+	require.ErrorContains(t, err, "does not resolve in project", "unresolved qualified filters must not probe stored parent snapshots")
 	require.Equal(t, before, auditRequests, "rejected parent filters must not reach the daemon")
 
-	// A bare filter that resolves in the audited project is forwarded.
+	// Bare and qualified filters that resolve in the nominated project are forwarded.
 	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "def2"})
 	require.NoError(t, err)
-	require.Equal(t, before+1, auditRequests)
+	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Parent: "spoke-project#def2"})
+	require.NoError(t, err)
+	require.Equal(t, before+2, auditRequests)
 }
 
 func TestEventPeerRedactionDropsShortIDsWithoutUIDs(t *testing.T) {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -429,6 +429,41 @@ func TestEditFiltersLinkChangePeersOutsideScope(t *testing.T) {
 	require.Empty(t, output.Changes.RelatedAdded)
 }
 
+func TestEventRedactionPreservesOpaqueMetadataAndDiffValues(t *testing.T) {
+	var issueLookups int
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/v1/projects" {
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+			return
+		}
+		issueLookups++
+		http.NotFound(writer, request)
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	diff := map[string]any{
+		"from_uid":   map[string]any{"from": nil, "to": "user-value"},
+		"source_uid": map[string]any{"from": nil, "to": "build-123"},
+	}
+	metadata := map[string]any{"source_uid": "build-123", "to_short_id": "deploy-7"}
+	output := EventsOutput{Events: []StreamEvent{
+		{Type: "issue.metadata_updated", Payload: map[string]any{"diff": diff, "revision_new": float64(2)}},
+		{Type: "issue.created", Payload: map[string]any{"short_id": "abc1", "metadata": metadata}},
+	}}
+
+	require.NoError(t, handlers.redactEventsOutsideScope(t.Context(), &output))
+	updated := output.Events[0].Payload.(map[string]any)
+	require.Equal(t, diff, updated["diff"], "user metadata diff keys and values are opaque data")
+	created := output.Events[1].Payload.(map[string]any)
+	require.Equal(t, metadata, created["metadata"], "user metadata keys named like relationship fields survive")
+	require.Zero(t, issueLookups, "opaque values must not trigger peer resolution")
+}
+
 func TestEventRedactionScopesMovedProjectReferences(t *testing.T) {
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/projects" {
@@ -507,11 +542,20 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 	require.Nil(t, output.Rows[2].Parent, "bare parent without link provenance must be blanked")
 
 	// A bounded limit truncates before the result can exceed the transport
-	// message cap, and truncation is reported so callers can page by time.
+	// message cap; the offset cursor pages the stable row order without
+	// skipping or repeating rows that share one timestamp.
 	_, limited, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2})
 	require.NoError(t, err)
 	require.Len(t, limited.Rows, 2)
 	require.True(t, limited.Truncated)
+	require.NotNil(t, limited.NextOffset)
+	require.EqualValues(t, 2, *limited.NextOffset)
+	_, page, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2, Offset: *limited.NextOffset})
+	require.NoError(t, err)
+	require.Len(t, page.Rows, 1)
+	require.False(t, page.Truncated)
+	require.Nil(t, page.NextOffset)
+	require.Equal(t, "jkl4", page.Rows[0].Issue)
 	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 101})
 	require.ErrorContains(t, err, "limit must be between 1 and 100")
 

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -657,6 +657,30 @@ func TestEventsWaitDeadlineDuringPollReturnsTimeout(t *testing.T) {
 	require.Contains(t, string(mustJSON(t, output)), `"events":[]`)
 }
 
+// TestEventsWaitDeadlineBoundsScopeResolution covers a stalled project
+// catalog: the wait_seconds deadline must bound the scope lookup that
+// precedes the stream, not only the stream itself.
+func TestEventsWaitDeadlineBoundsScopeResolution(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		select {
+		case <-request.Context().Done():
+		case <-time.After(10 * time.Second):
+		}
+		http.NotFound(writer, request)
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, LongRunningClient: client, Scope: scope}}
+
+	started := time.Now()
+	_, output, err := handlers.events(t.Context(), nil, EventsInput{Mode: "wait", Project: "spoke-project", WaitSeconds: 1})
+	require.NoError(t, err, "a deadline expiring during scope resolution is the documented timeout outcome")
+	require.True(t, output.TimedOut)
+	require.Less(t, time.Since(started), 5*time.Second, "wait_seconds must bound the scope lookup")
+}
+
 func TestScopedFederationStatusRedactsErrorText(t *testing.T) {
 	foreignUID := "01HDDDDDDDDDDDDDDDDDDDDDDD"
 	quarantineError := "apply batch: issue.linked references unknown issue " + foreignUID

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -232,17 +232,6 @@ func TestDigestRedactsForeignLinkActionTargets(t *testing.T) {
 					}},
 				}},
 			})
-		case "/api/v1/projects/1/issues/abc1":
-			issue := issueJSON(1, "spoke-project", "abc1")
-			issue["uid"] = "01HCCCCCCCCCCCCCCCCCCCCCCC"
-			writeJSON(writer, map[string]any{
-				"issue": issue, "labels": []any{}, "comments": []any{},
-				"links": []any{map[string]any{
-					"id": 1, "type": "blocks", "author": "example-agent", "created_at": "2026-08-11T00:00:00Z",
-					"from": linkPeerJSON("spoke-project", "abc1", "01HCCCCCCCCCCCCCCCCCCCCCCC"),
-					"to":   linkPeerJSON("spoke-project", "def2", "01HEEEEEEEEEEEEEEEEEEEEEEE"),
-				}},
-			})
 		default:
 			http.NotFound(writer, request)
 		}
@@ -257,8 +246,8 @@ func TestDigestRedactsForeignLinkActionTargets(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, output.Digests, 1)
 	actions := output.Digests[0].Digest.Actors[0].Issues[0].Actions
-	require.Equal(t, []string{"created", "labeled:bug", "blocks:def2", "unparent", "related", "commented:2"}, actions,
-		"link-vouched peer survives; unvouched targets are stripped to their action type even when a same-short-ID issue exists")
+	require.Equal(t, []string{"created", "labeled:bug", "blocks", "unparent", "related", "commented:2"}, actions,
+		"historical link tokens carry no provable identity, so every target is stripped to its action type; a current same-short-ID link must not vouch a historical peer")
 }
 
 func TestAuditPaginationInvalidatesWhenHistoryBelowCursorChanges(t *testing.T) {
@@ -590,6 +579,42 @@ func TestScopedFederationStatusRedactsErrorText(t *testing.T) {
 		"daemon-wide servers keep the raw diagnostic")
 }
 
+func TestEventDisplayRefsUseOnlyOwnHistoricalProjectName(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/v1/projects" {
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+			return
+		}
+		http.NotFound(writer, request)
+	})
+	scope, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+	// Both events belong to the in-scope project; the first was stamped
+	// before a rename, and "former-name" may now belong to a foreign
+	// project.
+	output := EventsOutput{Events: []StreamEvent{
+		{Type: "close.throttled", ProjectUID: "01HAAAAAAAAAAAAAAAAAAAAAAA", ProjectName: "former-name",
+			Payload: map[string]any{"reason": "sibling-burst", "parent": "former-name#zz9"}},
+		{Type: "issue.closed", ProjectUID: "01HAAAAAAAAAAAAAAAAAAAAAAA", ProjectName: "spoke-project",
+			Payload: map[string]any{"reason": "duplicate", "evidence": []any{
+				map[string]any{"type": "duplicate-of", "issue_ref": "former-name#abc2"},
+			}}},
+	}}
+
+	require.NoError(t, handlers.redactEventsOutsideScope(t.Context(), &output))
+	first := output.Events[0].Payload.(map[string]any)
+	require.Equal(t, "former-name#zz9", first["parent"],
+		"an event's own historical project name vouches its refs")
+	evidence := output.Events[1].Payload.(map[string]any)["evidence"].([]any)
+	require.NotContains(t, evidence[0].(map[string]any), "issue_ref",
+		"another event's historical name must not vouch this event's refs; the name may now be foreign")
+}
+
 func TestProjectsListingSurvivesMissingAllowlistMember(t *testing.T) {
 	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/api/v1/projects" {
@@ -839,21 +864,21 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 			auditRequests++
 			writeJSON(writer, map[string]any{"rows": []any{
 				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "abc1", "parent": "other-project#zz9", "event_id": 11},
-				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "def2", "parent": "ghi3", "event_id": 12},
-				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "jkl4", "parent": "gone5", "event_id": 13},
+				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "def2", "parent": "ghi3", "parent_uid": "01HEEEEEEEEEEEEEEEEEEEEEEE", "event_id": 12},
+				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "jkl4", "parent": "ghi3", "parent_uid": "01HDDDDDDDDDDDDDDDDDDDDDDD", "event_id": 13},
 			}})
-		case "/api/v1/projects/1/issues/def2":
-			issue := issueJSON(1, "spoke-project", "def2")
-			issue["uid"] = "01HCCCCCCCCCCCCCCCCCCCCCCC"
+		case "/api/v1/issues/01HEEEEEEEEEEEEEEEEEEEEEEE":
+			issue := issueJSON(1, "spoke-project", "ghi3")
+			issue["uid"] = "01HEEEEEEEEEEEEEEEEEEEEEEE"
 			writeJSON(writer, map[string]any{
-				"issue": issue, "labels": []any{}, "comments": []any{},
-				"links": []any{map[string]any{
-					"id": 1, "type": "parent", "author": "example-agent", "created_at": "2026-08-11T00:00:00Z",
-					"from": linkPeerJSON("spoke-project", "def2", "01HCCCCCCCCCCCCCCCCCCCCCCC"),
-					"to":   linkPeerJSON("spoke-project", "ghi3", "01HEEEEEEEEEEEEEEEEEEEEEEE"),
-				}},
+				"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
+		case "/api/v1/projects/1/issues/def2":
+			writeJSON(writer, map[string]any{
+				"issue": issueJSON(1, "spoke-project", "def2"), "labels": []any{}, "comments": []any{}, "links": []any{},
 			})
 		default:
+			// The purged frozen parent UID resolves nowhere.
 			http.NotFound(writer, request)
 		}
 	})
@@ -866,10 +891,12 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 	_, output, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project"})
 	require.NoError(t, err)
 	require.Len(t, output.Rows, 3)
-	require.Nil(t, output.Rows[0].Parent, "foreign qualified parent must be blanked")
-	require.NotNil(t, output.Rows[1].Parent, "parent vouched by the child's current in-scope parent link survives")
+	require.Nil(t, output.Rows[0].Parent, "foreign qualified parent without frozen identity must be blanked")
+	require.NotNil(t, output.Rows[1].Parent, "parent whose frozen UID resolves in scope survives")
 	require.Equal(t, "ghi3", *output.Rows[1].Parent)
-	require.Nil(t, output.Rows[2].Parent, "bare parent without link provenance must be blanked")
+	require.Nil(t, output.Rows[2].Parent,
+		"a purged frozen parent must be blanked even when its display short ID collides with an in-scope parent")
+	require.Nil(t, output.Rows[2].ParentUID)
 
 	// A bounded limit truncates before the result can exceed the transport
 	// message cap; the event-ID cursor pages without skipping or repeating

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -254,6 +254,126 @@ func TestDigestRedactsForeignLinkActionTargets(t *testing.T) {
 		"historical link tokens carry no provable identity, so every target is stripped to its action type; a current same-short-ID link must not vouch a historical peer")
 }
 
+func TestAllProjectActivityUsesOnlyActiveProjectEndpoints(t *testing.T) {
+	const (
+		activeProjectUID   = "01HAAAAAAAAAAAAAAAAAAAAAAA"
+		archivedProjectUID = "01HBBBBBBBBBBBBBBBBBBBBBBB"
+	)
+	activeEvent := reviewActivityEventJSON(7, 1, activeProjectUID, "active-project")
+	archivedEvent := reviewActivityEventJSON(8, 2, archivedProjectUID, "archived-project")
+	archivedStreamEvent, err := json.Marshal(archivedEvent)
+	require.NoError(t, err)
+	var globalRequests atomic.Int64
+	var projectDigestRequests atomic.Int64
+	var projectEventRequests atomic.Int64
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, activeProjectUID, "active-project"),
+			}})
+		case "/api/v1/projects/1/digest":
+			projectDigestRequests.Add(1)
+			writeJSON(writer, reviewDigestBodyJSON(1, "active-project"))
+		case "/api/v1/projects/1/events":
+			projectEventRequests.Add(1)
+			writeJSON(writer, map[string]any{"events": []any{activeEvent}, "next_after_id": 7, "reset_required": false})
+		case "/api/v1/digest":
+			globalRequests.Add(1)
+			writeJSON(writer, reviewDigestBodyJSON(2, "archived-project"))
+		case "/api/v1/events":
+			globalRequests.Add(1)
+			writeJSON(writer, map[string]any{"events": []any{archivedEvent}, "next_after_id": 8, "reset_required": false})
+		case "/api/v1/events/stream":
+			globalRequests.Add(1)
+			writer.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprintf(writer, "event: issue.edited\ndata: %s\n\n", archivedStreamEvent)
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	handlers := toolHandlers{options: Options{Client: client, LongRunningClient: client, Scope: NewAllScope()}}
+
+	_, digest, err := handlers.digest(t.Context(), nil, DigestInput{Since: "2026-08-11T00:00:00Z"})
+	require.NoError(t, err)
+	require.Len(t, digest.Digests, 1)
+	require.NotNil(t, digest.Digests[0].Project)
+	require.Equal(t, "active-project", digest.Digests[0].Project.Name)
+	require.Equal(t, "active-project", digest.Digests[0].Digest.Actors[0].Issues[0].ProjectName)
+
+	_, polled, err := handlers.events(t.Context(), nil, EventsInput{Mode: "poll"})
+	require.NoError(t, err)
+	require.Len(t, polled.Events, 1)
+	require.Equal(t, activeProjectUID, polled.Events[0].ProjectUID)
+
+	_, waited, err := handlers.events(t.Context(), nil, EventsInput{Mode: "wait", WaitSeconds: 1})
+	require.NoError(t, err)
+	require.Len(t, waited.Events, 1)
+	require.Equal(t, activeProjectUID, waited.Events[0].ProjectUID)
+	require.Zero(t, globalRequests.Load(), "all-project activity must not use archive-inclusive global endpoints")
+	require.EqualValues(t, 1, projectDigestRequests.Load())
+	require.EqualValues(t, 2, projectEventRequests.Load())
+}
+
+func TestAllProjectEventPollToleratesProjectArchivedAfterCatalogRead(t *testing.T) {
+	const activeProjectUID = "01HAAAAAAAAAAAAAAAAAAAAAAA"
+	activeEvent := reviewActivityEventJSON(7, 1, activeProjectUID, "active-project")
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, activeProjectUID, "active-project"),
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "soon-archived-project"),
+			}})
+		case "/api/v1/projects/1/events":
+			writeJSON(writer, map[string]any{"events": []any{activeEvent}, "next_after_id": 7, "reset_required": false})
+		case "/api/v1/projects/2/events":
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusNotFound)
+			writeJSON(writer, map[string]any{
+				"status": 404, "error": map[string]any{"code": "project_not_found", "message": "project was archived"},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	handlers := toolHandlers{options: Options{Client: client, Scope: NewAllScope()}}
+
+	output, err := handlers.pollScopedEvents(t.Context(), "", 0, 20)
+	require.NoError(t, err)
+	require.Len(t, output.Events, 1)
+	require.Equal(t, activeProjectUID, output.Events[0].ProjectUID)
+}
+
+func TestAllProjectDigestToleratesProjectArchivedAfterCatalogRead(t *testing.T) {
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "active-project"),
+				projectJSON(2, "01HBBBBBBBBBBBBBBBBBBBBBBB", "soon-archived-project"),
+			}})
+		case "/api/v1/projects/1/digest":
+			writeJSON(writer, reviewDigestBodyJSON(1, "active-project"))
+		case "/api/v1/projects/2/digest":
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusNotFound)
+			writeJSON(writer, map[string]any{
+				"status": 404, "error": map[string]any{"code": "project_not_found", "message": "project was archived"},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	handlers := toolHandlers{options: Options{Client: client, Scope: NewAllScope()}}
+
+	_, output, err := handlers.digest(t.Context(), nil, DigestInput{Since: "2026-08-11T00:00:00Z"})
+	require.NoError(t, err)
+	require.Len(t, output.Digests, 1)
+	require.NotNil(t, output.Digests[0].Project)
+	require.Equal(t, "active-project", output.Digests[0].Project.Name)
+}
+
 func TestAuditPaginationInvalidatesWhenHistoryBelowCursorChanges(t *testing.T) {
 	auditRow := func(eventID int, issue string) map[string]any {
 		return map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": issue, "event_id": eventID}
@@ -1632,6 +1752,31 @@ func TestAllowlistEventResetAdvancesToResetCursor(t *testing.T) {
 	require.EqualValues(t, 42, output.NextAfterID)
 	require.NotNil(t, output.ResetAfterID)
 	require.EqualValues(t, 42, *output.ResetAfterID)
+}
+
+func reviewActivityEventJSON(eventID, projectID int64, projectUID, projectName string) map[string]any {
+	return map[string]any{
+		"actor": "example-agent", "content_hash": "hash", "created_at": "2026-08-12T00:00:00Z",
+		"event_id": eventID, "event_uid": fmt.Sprintf("event-%d", eventID), "hlc_counter": 0,
+		"hlc_physical_ms": 1, "origin_instance_uid": "01HCCCCCCCCCCCCCCCCCCCCCCC",
+		"payload": map[string]any{"body": projectName + " body"}, "project_id": projectID,
+		"project_name": projectName, "project_uid": projectUID, "type": "issue.edited",
+	}
+}
+
+func reviewDigestBodyJSON(projectID int64, projectName string) map[string]any {
+	return map[string]any{
+		"project_id": projectID, "event_count": 1,
+		"since": "2026-08-11T00:00:00Z", "until": "2026-08-12T00:00:00Z",
+		"totals": map[string]any{},
+		"actors": []any{map[string]any{
+			"actor": "example-agent", "totals": map[string]any{},
+			"issues": []any{map[string]any{
+				"issue_uid": "01HDDDDDDDDDDDDDDDDDDDDDDD", "issue_short_id": "abc1",
+				"project_id": projectID, "project_name": projectName, "actions": []any{"edited"},
+			}},
+		}},
+	}
 }
 
 func reviewClient(t *testing.T, handler http.HandlerFunc) *kataclient.Client {

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -508,9 +508,9 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 		case "/api/v1/audit/closes":
 			auditRequests++
 			writeJSON(writer, map[string]any{"rows": []any{
-				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "abc1", "parent": "other-project#zz9"},
-				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "def2", "parent": "ghi3"},
-				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "jkl4", "parent": "gone5"},
+				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "abc1", "parent": "other-project#zz9", "event_id": 11},
+				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "def2", "parent": "ghi3", "event_id": 12},
+				map[string]any{"time": "2026-08-12T00:00:00Z", "actor": "example-agent", "reason": "done", "issue": "jkl4", "parent": "gone5", "event_id": 13},
 			}})
 		case "/api/v1/projects/1/issues/def2":
 			issue := issueJSON(1, "spoke-project", "def2")
@@ -542,19 +542,19 @@ func TestAuditClosesRedactsForeignAndUnresolvedParents(t *testing.T) {
 	require.Nil(t, output.Rows[2].Parent, "bare parent without link provenance must be blanked")
 
 	// A bounded limit truncates before the result can exceed the transport
-	// message cap; the offset cursor pages the stable row order without
-	// skipping or repeating rows that share one timestamp.
+	// message cap; the immutable event-ID cursor pages without skipping
+	// or repeating rows even when every row shares one timestamp.
 	_, limited, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2})
 	require.NoError(t, err)
 	require.Len(t, limited.Rows, 2)
 	require.True(t, limited.Truncated)
-	require.NotNil(t, limited.NextOffset)
-	require.EqualValues(t, 2, *limited.NextOffset)
-	_, page, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2, Offset: *limited.NextOffset})
+	require.NotNil(t, limited.NextAfterEventID)
+	require.EqualValues(t, 12, *limited.NextAfterEventID)
+	_, page, err := handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 2, AfterEventID: *limited.NextAfterEventID})
 	require.NoError(t, err)
 	require.Len(t, page.Rows, 1)
 	require.False(t, page.Truncated)
-	require.Nil(t, page.NextOffset)
+	require.Nil(t, page.NextAfterEventID)
 	require.Equal(t, "jkl4", page.Rows[0].Issue)
 	_, _, err = handlers.auditCloses(t.Context(), nil, AuditClosesInput{Project: "spoke-project", Limit: 101})
 	require.ErrorContains(t, err, "limit must be between 1 and 100")

--- a/internal/mcp/review_fixes_test.go
+++ b/internal/mcp/review_fixes_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -12,6 +13,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/sqlitestore"
 	"go.kenn.io/kata/internal/storageadmin"
 	kataclient "go.kenn.io/kata/pkg/client"
 	"go.kenn.io/kata/pkg/client/generated"
@@ -740,6 +744,12 @@ func TestEditFiltersLinkChangePeersOutsideScope(t *testing.T) {
 			writeJSON(writer, map[string]any{
 				"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{},
 			})
+		case request.URL.Path == "/api/v1/projects/1/issues/def2":
+			issue := issueJSON(1, "spoke-project", "def2")
+			issue["uid"] = "01HCCCCCCCCCCCCCCCCCCCCCCC"
+			writeJSON(writer, map[string]any{
+				"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
 		case request.Method == http.MethodPatch:
 			issue := issueJSON(1, "spoke-project", "abc1")
 			writeJSON(writer, map[string]any{
@@ -798,6 +808,12 @@ func TestEditFiltersArchivedLinkChangePeerOutsideActiveScope(t *testing.T) {
 				projects = append(projects, archived)
 			}
 			writeJSON(writer, map[string]any{"projects": projects})
+		case request.URL.Path == "/api/v1/projects/1/issues/def2":
+			issue := issueJSON(1, "spoke-project", "def2")
+			issue["uid"] = "01HCCCCCCCCCCCCCCCCCCCCCCC"
+			writeJSON(writer, map[string]any{
+				"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
 		case request.Method == http.MethodPatch:
 			writeJSON(writer, map[string]any{
 				"changed": true, "issue": issueJSON(1, "spoke-project", "abc1"),
@@ -839,6 +855,12 @@ func TestEditReportsCommittedMutationWhenLinkChangeScopingFails(t *testing.T) {
 			writeJSON(writer, map[string]any{"projects": []any{
 				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
 			}})
+		case request.URL.Path == "/api/v1/projects/1/issues/def2":
+			issue := issueJSON(1, "spoke-project", "def2")
+			issue["uid"] = "01HCCCCCCCCCCCCCCCCCCCCCCC"
+			writeJSON(writer, map[string]any{
+				"issue": issue, "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
 		case request.Method == http.MethodPatch:
 			writeJSON(writer, map[string]any{
 				"changed": true, "issue": issueJSON(1, "spoke-project", "abc1"),
@@ -877,6 +899,74 @@ func TestEditReportsCommittedMutationWhenLinkChangeScopingFails(t *testing.T) {
 	require.True(t, output.Changed)
 	require.Equal(t, "spoke-project#abc1", output.Issue.QualifiedRef)
 	require.Nil(t, output.Changes, "unresolved supplemental changes must be omitted after commit")
+}
+
+func TestEditRelationshipTargetSurvivesScopedProjectNameReuse(t *testing.T) {
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	sourceProject, err := store.CreateProject(t.Context(), "source-project")
+	require.NoError(t, err)
+	targetProject, err := store.CreateProject(t.Context(), "target-project")
+	require.NoError(t, err)
+	foreignProject, err := store.CreateProject(t.Context(), "other-project")
+	require.NoError(t, err)
+	source, _, err := store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: sourceProject.ID, Title: "Source issue", Author: "example-agent",
+	})
+	require.NoError(t, err)
+	target, _, err := store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: targetProject.ID, UID: "01ARZ3NDEKTSV4RRFFQ69GABC1", ShortIDOverride: "abc1",
+		Title: "Scoped target", Author: "example-agent",
+	})
+	require.NoError(t, err)
+	foreign, _, err := store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: foreignProject.ID, UID: "01BRZ3NDEKTSV4RRFFQ69GABC1", ShortIDOverride: "abc1",
+		Title: "Foreign target", Author: "example-agent",
+	})
+	require.NoError(t, err)
+
+	daemonServer := daemon.NewServer(daemon.ServerConfig{DB: store, StartedAt: time.Now().UTC()})
+	t.Cleanup(func() { require.NoError(t, daemonServer.Close()) })
+	var namesReused atomic.Bool
+	daemonHandler := daemonServer.Handler()
+	httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodPatch && namesReused.CompareAndSwap(false, true) {
+			if _, renameErr := store.RenameProject(request.Context(), targetProject.ID, "renamed-target"); renameErr != nil {
+				http.Error(writer, renameErr.Error(), http.StatusInternalServerError)
+				return
+			}
+			if _, renameErr := store.RenameProject(request.Context(), foreignProject.ID, "target-project"); renameErr != nil {
+				http.Error(writer, renameErr.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+		daemonHandler.ServeHTTP(writer, request)
+	}))
+	t.Cleanup(httpServer.Close)
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: sourceProject.ID, UID: sourceProject.UID, Name: sourceProject.Name},
+		{ID: targetProject.ID, UID: targetProject.UID, Name: targetProject.Name},
+	})
+	require.NoError(t, err)
+	session := connectTestServerWithOptions(t, Options{
+		Client: client, Scope: scope, Actor: "example-agent", Version: "test-version",
+	})
+
+	callWorkflowTool(t, session, "kata.edit", map[string]any{
+		"ref": sourceProject.Name + "#" + source.ShortID,
+		"add_blocks": []any{
+			targetProject.Name + "#" + target.ShortID,
+		},
+	})
+	require.True(t, namesReused.Load())
+	links, err := store.LinksByIssue(t.Context(), source.ID)
+	require.NoError(t, err)
+	require.Len(t, links, 1)
+	require.Equal(t, target.ID, links[0].ToIssueID)
+	require.NotEqual(t, foreign.ID, links[0].ToIssueID)
 }
 
 func TestEventRedactionPreservesOpaqueMetadataAndDiffValues(t *testing.T) {
@@ -1260,12 +1350,12 @@ func TestAllowlistListAndReadyApplyLimitAfterScopedFanout(t *testing.T) {
 					}})
 				case "/api/v1/projects/1/issues", "/api/v1/projects/1/ready":
 					issue := issueJSON(1, "spoke-project", "spk1")
-					issue["updated_at"] = "2026-08-10T00:00:00Z"
+					issue["updated_at"] = "2026-08-11T00:00:00Z"
 					writeJSON(writer, map[string]any{"issues": []any{issue}})
 				case "/api/v1/projects/2/issues", "/api/v1/projects/2/ready":
 					issue := issueJSON(2, "hub-project", "hub1")
 					issue["project_uid"] = "01HBBBBBBBBBBBBBBBBBBBBBBB"
-					issue["updated_at"] = "2026-08-11T00:00:00Z"
+					issue["updated_at"] = "2026-08-11T00:00:00.1Z"
 					writeJSON(writer, map[string]any{"issues": []any{issue}})
 				default:
 					globalRequests.Add(1)
@@ -1337,13 +1427,13 @@ func TestAllowlistNextPreservesMergedReadyOrderingForEqualPriority(t *testing.T)
 		case "/api/v1/projects/1/ready":
 			issue := issueJSON(1, "spoke-project", "spk1")
 			issue["priority"] = 1
-			issue["updated_at"] = "2026-08-11T00:00:00Z"
+			issue["updated_at"] = "2026-08-11T00:00:00.1Z"
 			writeJSON(writer, map[string]any{"issues": []any{issue}})
 		case "/api/v1/projects/2/ready":
 			issue := issueJSON(2, "hub-project", "hub1")
 			issue["project_uid"] = "01HBBBBBBBBBBBBBBBBBBBBBBB"
 			issue["priority"] = 1
-			issue["updated_at"] = "2026-08-10T00:00:00Z"
+			issue["updated_at"] = "2026-08-11T00:00:00Z"
 			writeJSON(writer, map[string]any{"issues": []any{issue}})
 		default:
 			http.NotFound(writer, request)
@@ -1412,6 +1502,42 @@ func TestEditRejectsMixedIssueAndMetadataChangesBeforeMutation(t *testing.T) {
 	_, _, err = handlers.edit(t.Context(), nil, EditInput{Ref: "spk1", Title: &title, ScheduledOn: &scheduledOn})
 	require.ErrorContains(t, err, "separate calls")
 	require.Zero(t, requests.Load())
+}
+
+func TestEditMissingRelationshipRemovalRemainsIdempotent(t *testing.T) {
+	var patchRequests atomic.Int64
+	client := reviewClient(t, func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/api/v1/projects":
+			writeJSON(writer, map[string]any{"projects": []any{
+				projectJSON(1, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+		case request.Method == http.MethodGet && request.URL.Path == "/api/v1/projects/1/issues/abc1":
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusNotFound)
+			writeJSON(writer, map[string]any{"status": 404, "error": map[string]any{"code": "issue_not_found", "message": "not found"}})
+		case request.Method == http.MethodGet && request.URL.Path == "/api/v1/projects/1/issues/src1":
+			writeJSON(writer, map[string]any{
+				"issue": issueJSON(1, "spoke-project", "src1"), "labels": []any{}, "comments": []any{}, "links": []any{},
+			})
+		case request.Method == http.MethodPatch:
+			patchRequests.Add(1)
+			http.Error(writer, "unexpected mutation", http.StatusInternalServerError)
+		default:
+			http.NotFound(writer, request)
+		}
+	})
+	scope, err := NewBoundScope(ProjectIdentity{
+		ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, Scope: scope}}
+
+	_, output, err := handlers.edit(t.Context(), nil, EditInput{Ref: "src1", RemoveBlocks: []string{"abc1"}})
+	require.NoError(t, err)
+	require.False(t, output.Changed)
+	require.Equal(t, "src1", output.Issue.Ref)
+	require.Zero(t, patchRequests.Load(), "a missing idempotent removal must not be forwarded as a mutable reference")
 }
 
 func TestProjectsListsArchivedRecordsWithoutShowRequest(t *testing.T) {

--- a/internal/mcp/scope.go
+++ b/internal/mcp/scope.go
@@ -164,8 +164,8 @@ func (s *Scope) Projects(ctx context.Context, client *kataclient.Client, include
 			projects = append(projects, project)
 		}
 	}
-	if len(projects) != len(allowed) {
-		return nil, errors.New("one or more projects in the MCP startup scope are no longer available")
+	if len(projects) == 0 {
+		return nil, errors.New("no projects in the MCP startup scope are available")
 	}
 	return projects, nil
 }
@@ -183,6 +183,11 @@ func (s *Scope) Project(ctx context.Context, client *kataclient.Client, name str
 	for _, project := range projects {
 		if project.Name == name {
 			return project, nil
+		}
+	}
+	for _, startup := range s.projects {
+		if startup.Name == name {
+			return ProjectIdentity{}, fmt.Errorf("project %q in the MCP startup scope is no longer available", name)
 		}
 	}
 	return ProjectIdentity{}, fmt.Errorf("project %q is outside the MCP startup scope", name)

--- a/internal/mcp/scope.go
+++ b/internal/mcp/scope.go
@@ -1,0 +1,254 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.kenn.io/kata/internal/shortid"
+	kataclient "go.kenn.io/kata/pkg/client"
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// ScopeMode identifies how the MCP server selected its projects at startup.
+type ScopeMode string
+
+const (
+	// ScopeBound fixes one project.
+	ScopeBound ScopeMode = "bound"
+	// ScopeAllowlist fixes a set of project UIDs.
+	ScopeAllowlist ScopeMode = "allowlist"
+	// ScopeAll follows the selected daemon's active project catalog.
+	ScopeAll ScopeMode = "all"
+)
+
+// Scope keeps the startup authorization boundary. Fixed scopes store project
+// UIDs so a later rename does not remove or broaden authority.
+type Scope struct {
+	mode     ScopeMode
+	projects []ProjectIdentity
+}
+
+// NewBoundScope creates the compatible one-project scope.
+func NewBoundScope(project ProjectIdentity) (*Scope, error) {
+	if err := validateProjectIdentity(project, false); err != nil {
+		return nil, err
+	}
+	return &Scope{mode: ScopeBound, projects: []ProjectIdentity{project}}, nil
+}
+
+// ResolveBoundScope resolves one project ID and stores its immutable UID.
+func ResolveBoundScope(ctx context.Context, client *kataclient.Client, resolved ProjectIdentity) (*Scope, error) {
+	if client == nil {
+		return nil, errors.New("kata API client is required")
+	}
+	if err := validateProjectIdentity(resolved, false); err != nil {
+		return nil, err
+	}
+	catalog, err := loadScopeProjects(ctx, client, false)
+	if err != nil {
+		return nil, err
+	}
+	for _, project := range catalog {
+		if project.ID == resolved.ID {
+			return NewBoundScope(project)
+		}
+	}
+	return nil, fmt.Errorf("MCP project ID %d was not found", resolved.ID)
+}
+
+// NewAllowlistScope creates a fixed UID allowlist.
+func NewAllowlistScope(projects []ProjectIdentity) (*Scope, error) {
+	if len(projects) == 0 {
+		return nil, errors.New("at least one MCP project is required")
+	}
+	copyProjects := append([]ProjectIdentity(nil), projects...)
+	seenNames := make(map[string]struct{}, len(copyProjects))
+	seenUIDs := make(map[string]struct{}, len(copyProjects))
+	for _, project := range copyProjects {
+		if err := validateProjectIdentity(project, true); err != nil {
+			return nil, err
+		}
+		if _, exists := seenNames[project.Name]; exists {
+			return nil, fmt.Errorf("duplicate MCP project %q", project.Name)
+		}
+		if _, exists := seenUIDs[project.UID]; exists {
+			return nil, fmt.Errorf("duplicate MCP project UID %q", project.UID)
+		}
+		seenNames[project.Name] = struct{}{}
+		seenUIDs[project.UID] = struct{}{}
+	}
+	return &Scope{mode: ScopeAllowlist, projects: copyProjects}, nil
+}
+
+// NewAllScope creates a daemon-wide dynamic project scope.
+func NewAllScope() *Scope {
+	return &Scope{mode: ScopeAll}
+}
+
+// ResolveAllowlistScope resolves names once and stores their immutable UIDs.
+func ResolveAllowlistScope(ctx context.Context, client *kataclient.Client, names []string) (*Scope, error) {
+	if client == nil {
+		return nil, errors.New("kata API client is required")
+	}
+	seen := make(map[string]struct{}, len(names))
+	clean := make([]string, 0, len(names))
+	for _, raw := range names {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			return nil, errors.New("MCP project name must not be empty")
+		}
+		if _, exists := seen[name]; exists {
+			return nil, fmt.Errorf("duplicate MCP project %q", name)
+		}
+		seen[name] = struct{}{}
+		clean = append(clean, name)
+	}
+	if len(clean) == 0 {
+		return nil, errors.New("at least one MCP project is required")
+	}
+	catalog, err := loadScopeProjects(ctx, client, false)
+	if err != nil {
+		return nil, err
+	}
+	byName := make(map[string]ProjectIdentity, len(catalog))
+	for _, project := range catalog {
+		byName[project.Name] = project
+	}
+	projects := make([]ProjectIdentity, 0, len(clean))
+	for _, name := range clean {
+		project, ok := byName[name]
+		if !ok {
+			return nil, fmt.Errorf("MCP project %q was not found", name)
+		}
+		projects = append(projects, project)
+	}
+	return NewAllowlistScope(projects)
+}
+
+// Mode returns the immutable startup mode.
+func (s *Scope) Mode() ScopeMode {
+	if s == nil {
+		return ""
+	}
+	return s.mode
+}
+
+// Projects returns current project identities within the startup boundary.
+func (s *Scope) Projects(ctx context.Context, client *kataclient.Client, includeArchived bool) ([]ProjectIdentity, error) {
+	if s == nil {
+		return nil, errors.New("MCP project scope is required")
+	}
+	if s.mode == ScopeBound && (client == nil || s.projects[0].UID == "") {
+		return append([]ProjectIdentity(nil), s.projects...), nil
+	}
+	if client == nil {
+		return append([]ProjectIdentity(nil), s.projects...), nil
+	}
+	catalog, err := loadScopeProjects(ctx, client, includeArchived)
+	if err != nil {
+		return nil, err
+	}
+	if s.mode == ScopeAll {
+		return catalog, nil
+	}
+	allowed := make(map[string]struct{}, len(s.projects))
+	for _, project := range s.projects {
+		allowed[project.UID] = struct{}{}
+	}
+	projects := make([]ProjectIdentity, 0, len(allowed))
+	for _, project := range catalog {
+		if _, ok := allowed[project.UID]; ok {
+			projects = append(projects, project)
+		}
+	}
+	if len(projects) != len(allowed) {
+		return nil, errors.New("one or more projects in the MCP startup scope are no longer available")
+	}
+	return projects, nil
+}
+
+// Project resolves a current project name within the startup boundary.
+func (s *Scope) Project(ctx context.Context, client *kataclient.Client, name string, includeArchived bool) (ProjectIdentity, error) {
+	name = strings.TrimSpace(name)
+	projects, err := s.Projects(ctx, client, includeArchived)
+	if err != nil {
+		return ProjectIdentity{}, err
+	}
+	if name == "" && s.mode == ScopeBound {
+		return projects[0], nil
+	}
+	for _, project := range projects {
+		if project.Name == name {
+			return project, nil
+		}
+	}
+	return ProjectIdentity{}, fmt.Errorf("project %q is outside the MCP startup scope", name)
+}
+
+// IssueTarget resolves a qualified issue reference and enforces scope.
+func (s *Scope) IssueTarget(ctx context.Context, client *kataclient.Client, raw string, write bool) (ProjectIdentity, string, error) {
+	ref := strings.TrimSpace(raw)
+	if ref == "" {
+		return ProjectIdentity{}, "", errors.New("issue reference must not be empty")
+	}
+	parsed, err := shortid.Parse(ref)
+	if err != nil {
+		return ProjectIdentity{}, "", fmt.Errorf("issue reference %q is invalid", ref)
+	}
+	if s.mode != ScopeBound && parsed.Project == "" {
+		if write {
+			return ProjectIdentity{}, "", errors.New("multi-project writes require project#ref")
+		}
+		return ProjectIdentity{}, "", errors.New("multi-project issue reads require project#ref")
+	}
+	projectName := parsed.Project
+	if s.mode == ScopeBound && projectName == "" {
+		projects, projectErr := s.Projects(ctx, client, false)
+		if projectErr != nil {
+			return ProjectIdentity{}, "", projectErr
+		}
+		project := projects[0]
+		return project, ref, nil
+	}
+	project, err := s.Project(ctx, client, projectName, false)
+	if err != nil {
+		return ProjectIdentity{}, "", err
+	}
+	return project, parsed.ShortID, nil
+}
+
+func loadScopeProjects(ctx context.Context, client *kataclient.Client, includeArchived bool) ([]ProjectIdentity, error) {
+	var include *string
+	if includeArchived {
+		value := "archived"
+		include = &value
+	}
+	response, err := client.ListProjects(ctx, &generated.ListProjectsRequestOptions{
+		Query: &generated.ListProjectsQuery{Include: include},
+	})
+	if err != nil {
+		return nil, err
+	}
+	projects := make([]ProjectIdentity, 0, len(response.Projects))
+	for _, project := range response.Projects {
+		projects = append(projects, ProjectIdentity{ID: project.ID, UID: project.UID, Name: project.Name})
+	}
+	sort.Slice(projects, func(i, j int) bool { return projects[i].Name < projects[j].Name })
+	return projects, nil
+}
+
+func validateProjectIdentity(project ProjectIdentity, requireUID bool) error {
+	if project.ID <= 0 {
+		return errors.New("kata project ID is required")
+	}
+	if strings.TrimSpace(project.Name) == "" {
+		return errors.New("kata project name is required")
+	}
+	if requireUID && strings.TrimSpace(project.UID) == "" {
+		return errors.New("kata project UID is required")
+	}
+	return nil
+}

--- a/internal/mcp/scope_test.go
+++ b/internal/mcp/scope_test.go
@@ -1,0 +1,75 @@
+package mcpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	kataclient "go.kenn.io/kata/pkg/client"
+)
+
+func TestScopeIssueTargetRequiresQualificationInMultiProjectMode(t *testing.T) {
+	scope, err := NewAllowlistScope([]ProjectIdentity{{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"}})
+	require.NoError(t, err)
+
+	_, _, err = scope.IssueTarget(t.Context(), nil, "abc4", true)
+	require.EqualError(t, err, "multi-project writes require project#ref")
+}
+
+func TestScopeIssueTargetRejectsProjectOutsideAllowlist(t *testing.T) {
+	scope, err := NewAllowlistScope([]ProjectIdentity{{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"}})
+	require.NoError(t, err)
+
+	_, _, err = scope.IssueTarget(t.Context(), nil, "hub-project#abc4", true)
+	require.EqualError(t, err, `project "hub-project" is outside the MCP startup scope`)
+}
+
+func TestAllowlistScopeRetainsAuthorityByUIDAfterRename(t *testing.T) {
+	client := projectCatalogClient(t, `{"projects":[{"id":1,"uid":"01HAAAAAAAAAAAAAAAAAAAAAAA","name":"renamed-project","metadata":{},"revision":2,"created_at":"2026-08-11T00:00:00Z"}]}`)
+	scope, err := NewAllowlistScope([]ProjectIdentity{{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"}})
+	require.NoError(t, err)
+
+	project, err := scope.Project(t.Context(), client, "renamed-project", false)
+	require.NoError(t, err)
+	require.Equal(t, "renamed-project", project.Name)
+	require.Equal(t, "01HAAAAAAAAAAAAAAAAAAAAAAA", project.UID)
+}
+
+func TestResolveBoundScopeRetainsAuthorityByUIDAfterRename(t *testing.T) {
+	client := projectCatalogClient(t, `{"projects":[
+		{"id":1,"uid":"01HAAAAAAAAAAAAAAAAAAAAAAA","name":"renamed-project","metadata":{},"revision":2,"created_at":"2026-08-11T00:00:00Z"},
+		{"id":2,"uid":"01HBBBBBBBBBBBBBBBBBBBBBBB","name":"spoke-project","metadata":{},"revision":1,"created_at":"2026-08-11T00:00:00Z"}
+	]}`)
+	scope, err := ResolveBoundScope(t.Context(), client, ProjectIdentity{ID: 1, Name: "spoke-project"})
+	require.NoError(t, err)
+
+	project, err := scope.Project(t.Context(), client, "", false)
+	require.NoError(t, err)
+	require.Equal(t, "renamed-project", project.Name)
+	require.Equal(t, "01HAAAAAAAAAAAAAAAAAAAAAAA", project.UID)
+}
+
+func TestResolveAllowlistScopeRejectsDuplicateAndMissingProjects(t *testing.T) {
+	client := projectCatalogClient(t, `{"projects":[{"id":1,"uid":"01HAAAAAAAAAAAAAAAAAAAAAAA","name":"spoke-project","metadata":{},"revision":1,"created_at":"2026-08-11T00:00:00Z"}]}`)
+
+	_, err := ResolveAllowlistScope(t.Context(), client, []string{"spoke-project", "spoke-project"})
+	require.EqualError(t, err, `duplicate MCP project "spoke-project"`)
+
+	_, err = ResolveAllowlistScope(t.Context(), client, []string{"missing-project"})
+	require.EqualError(t, err, `MCP project "missing-project" was not found`)
+}
+
+func projectCatalogClient(t *testing.T, response string) *kataclient.Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		require.Equal(t, "/api/v1/projects", request.URL.Path)
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(response))
+	}))
+	t.Cleanup(server.Close)
+	client, err := kataclient.NewWithHTTPClient(server.URL, server.Client())
+	require.NoError(t, err)
+	return client
+}

--- a/internal/mcp/scope_test.go
+++ b/internal/mcp/scope_test.go
@@ -61,6 +61,34 @@ func TestResolveAllowlistScopeRejectsDuplicateAndMissingProjects(t *testing.T) {
 	require.EqualError(t, err, `MCP project "missing-project" was not found`)
 }
 
+func TestAllowlistScopeServesRemainingProjectsWhenOneIsMissing(t *testing.T) {
+	client := projectCatalogClient(t, `{"projects":[{"id":1,"uid":"01HAAAAAAAAAAAAAAAAAAAAAAA","name":"spoke-project","metadata":{},"revision":1,"created_at":"2026-08-11T00:00:00Z"}]}`)
+	scope, err := NewAllowlistScope([]ProjectIdentity{
+		{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"},
+		{ID: 2, UID: "01HBBBBBBBBBBBBBBBBBBBBBBB", Name: "hub-project"},
+	})
+	require.NoError(t, err)
+
+	projects, err := scope.Projects(t.Context(), client, false)
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+	require.Equal(t, "spoke-project", projects[0].Name)
+
+	_, err = scope.Project(t.Context(), client, "spoke-project", false)
+	require.NoError(t, err)
+	_, err = scope.Project(t.Context(), client, "hub-project", false)
+	require.EqualError(t, err, `project "hub-project" in the MCP startup scope is no longer available`)
+}
+
+func TestScopeProjectsFailWhenNoMembersRemain(t *testing.T) {
+	client := projectCatalogClient(t, `{"projects":[]}`)
+	scope, err := NewAllowlistScope([]ProjectIdentity{{ID: 1, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project"}})
+	require.NoError(t, err)
+
+	_, err = scope.Projects(t.Context(), client, false)
+	require.EqualError(t, err, "no projects in the MCP startup scope are available")
+}
+
 func projectCatalogClient(t *testing.T, response string) *kataclient.Client {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {

--- a/internal/mcp/sections.go
+++ b/internal/mcp/sections.go
@@ -64,8 +64,8 @@ func toolSections(storageAvailable, tokenAdminAvailable bool) []toolSection {
 		},
 		{
 			loader: "kata.load_federation", section: "federation", title: "Load federation tools",
-			description: "Load typed federation status, enrollment revocation, replica, leave, and quarantine tools, then refresh the MCP tool list.",
-			tools:       []string{"kata.federation_enrollment_revoke", "kata.federation_join", "kata.federation_leave", "kata.federation_quarantine", "kata.federation_rebind", "kata.federation_status"},
+			description: "Load typed federation status, enrollment revocation, rebind, leave, and quarantine tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.federation_enrollment_revoke", "kata.federation_leave", "kata.federation_quarantine", "kata.federation_rebind", "kata.federation_status"},
 			available:   true, register: registerFederationTools,
 		},
 		{

--- a/internal/mcp/sections.go
+++ b/internal/mcp/sections.go
@@ -64,8 +64,8 @@ func toolSections(storageAvailable, tokenAdminAvailable bool) []toolSection {
 		},
 		{
 			loader: "kata.load_federation", section: "federation", title: "Load federation tools",
-			description: "Load typed federation enrollment, replica, leave, and quarantine tools, then refresh the MCP tool list.",
-			tools:       []string{"kata.federation_enroll", "kata.federation_enrollment_revoke", "kata.federation_join", "kata.federation_leave", "kata.federation_quarantine", "kata.federation_rebind", "kata.federation_status"},
+			description: "Load typed federation status, enrollment revocation, replica, leave, and quarantine tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.federation_enrollment_revoke", "kata.federation_join", "kata.federation_leave", "kata.federation_quarantine", "kata.federation_rebind", "kata.federation_status"},
 			available:   true, register: registerFederationTools,
 		},
 		{

--- a/internal/mcp/sections.go
+++ b/internal/mcp/sections.go
@@ -1,0 +1,133 @@
+package mcpserver
+
+import (
+	"context"
+	"sync"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ToolSectionInput loads one section's typed tools into the MCP catalog.
+type ToolSectionInput struct{}
+
+// ToolSectionOutput reports the tools available through one section.
+type ToolSectionOutput struct {
+	Section   string   `json:"section"`
+	Available bool     `json:"available"`
+	Loaded    bool     `json:"loaded"`
+	Tools     []string `json:"tools"`
+}
+
+type toolSection struct {
+	loader      string
+	section     string
+	title       string
+	description string
+	tools       []string
+	available   bool
+	register    func(*sdkmcp.Server, toolHandlers)
+}
+
+func registerSectionLoaders(server *sdkmcp.Server, options Options) {
+	handlers := toolHandlers{options: options}
+	sections := toolSections(
+		options.StorageAdmin != nil,
+		options.EnableTokenAdmin && options.Scope.Mode() == ScopeAll,
+	)
+	loaded := make(map[string]bool, len(sections))
+	var mutex sync.Mutex
+	for _, definition := range sections {
+		definition := definition
+		addTool(server, definition.loader, definition.title, definition.description,
+			toolHints(true, false, false),
+			func(_ context.Context, _ *sdkmcp.CallToolRequest, _ ToolSectionInput) (*sdkmcp.CallToolResult, ToolSectionOutput, error) {
+				mutex.Lock()
+				defer mutex.Unlock()
+				if definition.available && !loaded[definition.section] {
+					definition.register(server, handlers)
+					loaded[definition.section] = true
+				}
+				return successResult(), ToolSectionOutput{
+					Section: definition.section, Available: definition.available,
+					Loaded: loaded[definition.section], Tools: append([]string(nil), definition.tools...),
+				}, nil
+			})
+	}
+}
+
+func toolSections(storageAvailable, tokenAdminAvailable bool) []toolSection {
+	return []toolSection{
+		{
+			loader: "kata.load_activity", section: "activity", title: "Load activity tools",
+			description: "Load typed digest and event-stream tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.digest", "kata.events"}, available: true, register: registerActivityTools,
+		},
+		{
+			loader: "kata.load_federation", section: "federation", title: "Load federation tools",
+			description: "Load typed federation enrollment, replica, leave, and quarantine tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.federation_enroll", "kata.federation_enrollment_revoke", "kata.federation_join", "kata.federation_leave", "kata.federation_quarantine", "kata.federation_rebind", "kata.federation_status"},
+			available:   true, register: registerFederationTools,
+		},
+		{
+			loader: "kata.load_import", section: "import", title: "Load import tools",
+			description: "Load the typed structured issue-import tool, then refresh the MCP tool list.",
+			tools:       []string{"kata.import_issues"}, available: true, register: registerImportTools,
+		},
+		{
+			loader: "kata.load_issue_discovery", section: "issue_discovery", title: "Load issue discovery tools",
+			description: "Load typed issue search, list, show, ready, next, label, and graph tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.graph", "kata.labels", "kata.list", "kata.next", "kata.ready", "kata.search", "kata.show"},
+			available:   true, register: registerIssueDiscoveryTools,
+		},
+		{
+			loader: "kata.load_issue_lifecycle", section: "issue_lifecycle", title: "Load issue lifecycle tools",
+			description: "Load typed close, reopen, delete, restore, purge, wait, and close-audit tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.audit_closes", "kata.close", "kata.delete", "kata.purge", "kata.reopen", "kata.restore", "kata.wait"},
+			available:   true, register: registerIssueLifecycleTools,
+		},
+		{
+			loader: "kata.load_issue_mutation", section: "issue_mutation", title: "Load issue mutation tools",
+			description: "Load typed issue creation, edit, comment, claim, label, metadata, planning-date, and move tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.claim", "kata.comment", "kata.create", "kata.edit", "kata.edit_comment", "kata.move", "kata.set_deadline", "kata.set_label", "kata.set_metadata", "kata.set_schedule"},
+			available:   true, register: registerIssueMutationTools,
+		},
+		{
+			loader: "kata.load_leases", section: "leases", title: "Load lease tools",
+			description: "Load typed federation lease status and mutation tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.lease", "kata.lease_force_release", "kata.lease_status", "kata.lease_steal"},
+			available:   true, register: registerLeaseTools,
+		},
+		{
+			loader: "kata.load_projects", section: "projects", title: "Load project tools",
+			description: "Load typed project discovery and administration tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.project_create", "kata.project_merge", "kata.project_purge", "kata.project_remove", "kata.project_restore", "kata.project_update", "kata.projects"},
+			available:   true, register: registerProjectTools,
+		},
+		{
+			loader: "kata.load_recurrence", section: "recurrence", title: "Load recurrence tools",
+			description: "Load typed recurrence discovery and administration tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.recurrence_delete", "kata.recurrence_update", "kata.recurrences"},
+			available:   true, register: registerRecurrenceTools,
+		},
+		{
+			loader: "kata.load_storage", section: "storage", title: "Load storage tools",
+			description: "Load typed JSONL storage tools when host storage was enabled at startup, then refresh the MCP tool list.",
+			tools:       []string{"kata.storage_export", "kata.storage_import"}, available: storageAvailable, register: registerStorageTools,
+		},
+		{
+			loader: "kata.load_sync", section: "sync", title: "Load synchronization tools",
+			description: "Load typed GitHub synchronization tools, then refresh the MCP tool list.",
+			tools:       []string{"kata.sync_once", "kata.sync_status", "kata.sync_update"}, available: true, register: registerSyncTools,
+		},
+		{
+			loader: "kata.load_system", section: "system", title: "Load system tools",
+			description: "Load the typed redacted daemon system-information tool, then refresh the MCP tool list.",
+			tools:       []string{"kata.system"}, available: true, register: registerSystemTools,
+		},
+		{
+			loader: "kata.load_tokens", section: "tokens", title: "Load token tools",
+			description: "Load typed token administration tools when explicitly enabled at startup, then refresh the MCP tool list.",
+			tools:       []string{"kata.token_create", "kata.token_revoke", "kata.tokens"}, available: tokenAdminAvailable, register: registerTokenTools,
+		},
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -338,10 +338,7 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 		setStringBounds("ref", 1, 256)
 	case "kata.audit_closes":
 		setNumberBounds("limit", 1, maximumResultLimit)
-		if field := property("after_event_id"); field != nil {
-			minimum := float64(0)
-			field.Minimum = &minimum
-		}
+		setStringBounds("cursor", 1, 64)
 	}
 	return schema
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -338,6 +338,10 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 		setStringBounds("ref", 1, 256)
 	case "kata.audit_closes":
 		setNumberBounds("limit", 1, maximumResultLimit)
+		if field := property("offset"); field != nil {
+			minimum := float64(0)
+			field.Minimum = &minimum
+		}
 	}
 	return schema
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -13,6 +13,7 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"golang.org/x/time/rate"
 
+	"go.kenn.io/kata/internal/storageadmin"
 	kataclient "go.kenn.io/kata/pkg/client"
 )
 
@@ -24,25 +25,37 @@ const (
 	toolCallConcurrency = 8
 )
 
-// Options binds one Kata daemon project and actor to an MCP server process.
+// Options fixes the Kata daemon scope and actor for one MCP process.
 type Options struct {
-	Client      *kataclient.Client
-	ProjectID   int64
-	ProjectName string
-	Actor       string
-	Version     string
+	Client           *kataclient.Client
+	Scope            *Scope
+	ProjectID        int64
+	ProjectName      string
+	Actor            string
+	Version          string
+	StorageAdmin     *storageadmin.Admin
+	EnableTokenAdmin bool
 }
 
-// New creates a tools-only MCP server for one bound Kata project.
+// New creates a tools-only MCP server for one startup project scope.
 func New(options Options) (*sdkmcp.Server, error) {
 	if options.Client == nil {
 		return nil, errors.New("kata API client is required")
 	}
-	if options.ProjectID <= 0 {
-		return nil, errors.New("kata project ID is required")
+	if options.Scope == nil {
+		scope, err := NewBoundScope(ProjectIdentity{ID: options.ProjectID, Name: options.ProjectName})
+		if err != nil {
+			return nil, err
+		}
+		options.Scope = scope
 	}
-	if strings.TrimSpace(options.ProjectName) == "" {
-		return nil, errors.New("kata project name is required")
+	if options.Scope.Mode() == ScopeBound {
+		projects, err := options.Scope.Projects(context.Background(), nil, false)
+		if err != nil {
+			return nil, err
+		}
+		options.ProjectID = projects[0].ID
+		options.ProjectName = projects[0].Name
 	}
 	if strings.TrimSpace(options.Actor) == "" {
 		return nil, errors.New("kata actor is required")
@@ -51,15 +64,19 @@ func New(options Options) (*sdkmcp.Server, error) {
 		return nil, errors.New("kata server version is required")
 	}
 
+	scopeDescription := "startup project scope"
+	if options.Scope.Mode() == ScopeBound {
+		scopeDescription = "project " + options.ProjectName
+	}
 	server := sdkmcp.NewServer(&sdkmcp.Implementation{
 		Name:        "kata",
 		Title:       "Kata issue tracker",
-		Description: "Project-bound issue tracking tools for coding agents.",
+		Description: "Scoped Kata data and administration tools for coding agents.",
 		Version:     options.Version,
 	}, &sdkmcp.ServerOptions{
-		Instructions: "Use Kata to search before creating work, claim actionable issues, record progress, and close only with evidence. All tools are fixed to project " + options.ProjectName + " and actor " + options.Actor + ".",
+		Instructions: "Use Kata to search before creating work, claim actionable issues, record progress, and close only with evidence. All tools are fixed to " + scopeDescription + " and actor " + options.Actor + ".",
 		Capabilities: &sdkmcp.ServerCapabilities{
-			Tools: &sdkmcp.ToolCapabilities{},
+			Tools: &sdkmcp.ToolCapabilities{ListChanged: true},
 		},
 	})
 	server.AddReceivingMiddleware(toolAdmissionMiddleware(
@@ -67,7 +84,7 @@ func New(options Options) (*sdkmcp.Server, error) {
 		make(chan struct{}, toolCallConcurrency),
 	))
 	server.AddReceivingMiddleware(cacheHintsMiddleware)
-	registerTools(server, options)
+	registerSectionLoaders(server, options)
 	return server, nil
 }
 
@@ -109,28 +126,44 @@ func cacheHintsMiddleware(next sdkmcp.MethodHandler) sdkmcp.MethodHandler {
 	}
 }
 
-func registerTools(server *sdkmcp.Server, options Options) {
+func registerIssueDiscoveryTools(server *sdkmcp.Server, handlers toolHandlers) {
 	read := toolHints(true, false, false)
 	searchRead := toolHints(true, false, true)
+	addTool(server, "kata.graph", "Issue graph", "Read the bounded reachable relationship graph for one issue.", read, handlers.graph)
+	addTool(server, "kata.labels", "List labels", "List labels already used in the selected project scope with issue counts.", read, handlers.labels)
+	addTool(server, "kata.list", "List issues", "List compact issue summaries in the selected project scope with bounded filters.", read, handlers.list)
+	addTool(server, "kata.next", "Next issue", "Select the highest-priority ready issue.", read, handlers.next)
+	addTool(server, "kata.ready", "List ready issues", "List open issues with no open blocking predecessor in the selected project scope.", read, handlers.ready)
+	addTool(server, "kata.search", "Search issues", "Search titles, bodies, and comments before creating duplicate work.", searchRead, handlers.search)
+	addTool(server, "kata.show", "Show issue", "Read one issue with its body, metadata, relationships, and a bounded comment history.", read, handlers.show)
+}
+
+func registerIssueMutationTools(server *sdkmcp.Server, handlers toolHandlers) {
 	additive := toolHints(false, false, false)
 	mutating := toolHints(false, true, false)
-	handlers := toolHandlers{options: options}
-
 	addTool(server, "kata.claim", "Claim issue", "Claim an unowned issue for the bound actor. The call fails when another owner already holds it.", additive, handlers.claim)
-	addTool(server, "kata.close", "Close issue", "Close a completed issue with a reason, substantive message, and typed evidence.", mutating, handlers.close)
 	addTool(server, "kata.comment", "Add comment", "Append a progress or context comment using a required idempotency key.", additive, handlers.comment)
 	addTool(server, "kata.create", "Create issue", "Create project work after searching for duplicates. A stable idempotency key is required.", additive, handlers.create)
 	addTool(server, "kata.edit", "Edit issue", "Edit issue fields, ownership, priority, and relationship deltas atomically.", mutating, handlers.edit)
-	addTool(server, "kata.labels", "List labels", "List labels already used in the bound project with issue counts.", read, handlers.labels)
-	addTool(server, "kata.list", "List issues", "List compact issue summaries in the bound project with bounded filters.", read, handlers.list)
-	addTool(server, "kata.ready", "List ready issues", "List open issues with no open blocking predecessor in the bound project.", read, handlers.ready)
-	addTool(server, "kata.reopen", "Reopen issue", "Reopen a closed issue when new work is required.", mutating, handlers.reopen)
-	addTool(server, "kata.search", "Search issues", "Search titles, bodies, and comments before creating duplicate work.", searchRead, handlers.search)
+	addTool(server, "kata.edit_comment", "Edit comment", "Replace one comment body as the startup actor.", mutating, handlers.editComment)
+	addTool(server, "kata.move", "Move issue", "Move an issue to another in-scope project while preserving its UID and relationships.", mutating, handlers.move)
 	addTool(server, "kata.set_deadline", "Set deadline", "Set or clear an issue deadline. Values accept a date, local date-time, or RFC 3339 UTC instant ending in Z.", mutating, handlers.setDeadline)
 	addTool(server, "kata.set_label", "Set label presence", "Ensure that a label is present or absent on an issue.", mutating, handlers.setLabel)
 	addTool(server, "kata.set_metadata", "Patch metadata", "Patch issue metadata; JSON null removes a key. An optional revision makes the write conditional.", mutating, handlers.setMetadata)
 	addTool(server, "kata.set_schedule", "Set schedule", "Set or clear an issue schedule gate. Values accept a date, local date-time, or RFC 3339 UTC instant ending in Z.", mutating, handlers.setSchedule)
-	addTool(server, "kata.show", "Show issue", "Read one issue with its body, metadata, relationships, and a bounded comment history.", read, handlers.show)
+}
+
+func registerIssueLifecycleTools(server *sdkmcp.Server, handlers toolHandlers) {
+	read := toolHints(true, false, false)
+	additive := toolHints(false, false, false)
+	mutating := toolHints(false, true, false)
+	addTool(server, "kata.audit_closes", "Audit closes", "List close records with bounded project and time filters.", read, handlers.auditCloses)
+	addTool(server, "kata.close", "Close issue", "Close a completed issue with a reason, substantive message, and typed evidence.", mutating, handlers.close)
+	addTool(server, "kata.delete", "Delete issue", "Soft-delete an issue after exact confirmation.", mutating, handlers.deleteIssue)
+	addTool(server, "kata.purge", "Purge issue", "Irreversibly purge a soft-deleted issue after exact confirmation.", mutating, handlers.purgeIssue)
+	addTool(server, "kata.reopen", "Reopen issue", "Reopen a closed issue when new work is required.", mutating, handlers.reopen)
+	addTool(server, "kata.restore", "Restore issue", "Restore a soft-deleted issue.", additive, handlers.restoreIssue)
+	addTool(server, "kata.wait", "Wait for issues", "Wait for issue status conditions with a bounded timeout.", read, handlers.wait)
 }
 
 func addTool[In, Out any](
@@ -227,6 +260,8 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 		setNumberBounds("priority", 0, 4)
 		forbidTrueWith("clear_owner", "owner")
 		forbidTrueWith("clear_priority", "priority")
+		forbidTrueWith("clear_scheduled_on", "scheduled_on")
+		forbidTrueWith("clear_timezone", "timezone")
 		forbidTogether("parent", "remove_parent")
 	case "kata.comment":
 		setStringBounds("ref", 1, 256)
@@ -264,6 +299,35 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 			field.Minimum = &minimum
 		}
 		schema.OneOf = planningDateSchemas("schedule", "clear_schedule")
+	case "kata.recurrence_update":
+		setEnum("action", "create", "patch")
+		if field := property("revision"); field != nil {
+			minimum := float64(1)
+			field.Minimum = &minimum
+		}
+		patchAction := any("patch")
+		schema.AllOf = append(schema.AllOf, &jsonschema.Schema{
+			If: &jsonschema.Schema{
+				Required: []string{"action"},
+				Properties: map[string]*jsonschema.Schema{
+					"action": {Const: &patchAction},
+				},
+			},
+			Then: &jsonschema.Schema{Required: []string{"uid", "revision"}},
+		})
+	case "kata.federation_leave":
+		setEnum("phase", "preflight", "prepare", "commit")
+		setEnum("disposition", "detach", "archive")
+		commit := any("commit")
+		schema.AllOf = append(schema.AllOf, &jsonschema.Schema{
+			If: &jsonschema.Schema{
+				Required: []string{"phase"},
+				Properties: map[string]*jsonschema.Schema{
+					"phase": {Const: &commit},
+				},
+			},
+			Then: &jsonschema.Schema{Required: []string{"confirm"}},
+		})
 	case "kata.close":
 		setStringBounds("ref", 1, 256)
 		setStringBounds("message", 1, 1<<20)
@@ -396,6 +460,7 @@ func toolHints(readOnly, destructive, openWorld bool) *sdkmcp.ToolAnnotations {
 
 // SearchInput selects matching issues without returning large issue bodies.
 type SearchInput struct {
+	Project       string   `json:"project,omitempty" jsonschema:"Project name; omit to search every project in scope"`
 	Query         string   `json:"query" jsonschema:"Non-empty text to search for"`
 	Mode          string   `json:"mode,omitempty" jsonschema:"Search mode: auto, lexical, hybrid, or semantic"`
 	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum results from 1 through 100; default 20"`
@@ -405,6 +470,7 @@ type SearchInput struct {
 
 // ListInput filters project issues. Empty status means open and closed.
 type ListInput struct {
+	Project       string   `json:"project,omitempty" jsonschema:"Project name; omit to list every project in scope"`
 	Status        string   `json:"status,omitempty" jsonschema:"Issue status: open, closed, or empty for both"`
 	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum results from 1 through 100; default 20"`
 	Priority      *int64   `json:"priority,omitempty" jsonschema:"Exact priority from 0 through 4"`
@@ -418,6 +484,7 @@ type ListInput struct {
 
 // ReadyInput filters unblocked open work.
 type ReadyInput struct {
+	Project       string   `json:"project,omitempty" jsonschema:"Project name; omit to list ready work in every project in scope"`
 	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum results from 1 through 100; default 20"`
 	Owner         string   `json:"owner,omitempty" jsonschema:"Only issues owned by this actor"`
 	Unowned       bool     `json:"unowned,omitempty" jsonschema:"Only issues with no owner"`
@@ -425,8 +492,10 @@ type ReadyInput struct {
 	ExcludeLabels []string `json:"exclude_labels,omitempty" jsonschema:"Labels that issues must not have"`
 }
 
-// LabelsInput has no project selector because the server is project-bound.
-type LabelsInput struct{}
+// LabelsInput selects one project or aggregates across the startup scope.
+type LabelsInput struct {
+	Project string `json:"project,omitempty" jsonschema:"Project name; omit to list labels in every project in scope"`
+}
 
 // ShowInput selects one bound-project issue.
 type ShowInput struct {
@@ -436,12 +505,16 @@ type ShowInput struct {
 
 // CreateInput creates one issue and its initial relationships.
 type CreateInput struct {
+	Project        string         `json:"project,omitempty" jsonschema:"Target project; required in multi-project modes"`
 	Title          string         `json:"title" jsonschema:"Concise issue title"`
 	Body           string         `json:"body,omitempty" jsonschema:"Issue context, reason, and acceptance details"`
 	Owner          string         `json:"owner,omitempty" jsonschema:"Initial owner"`
 	Priority       *int64         `json:"priority,omitempty" jsonschema:"Priority from 0 through 4"`
 	Labels         []string       `json:"labels,omitempty" jsonschema:"Initial project labels"`
 	Metadata       map[string]any `json:"metadata,omitempty" jsonschema:"Initial issue metadata"`
+	ScheduledOn    string         `json:"scheduled_on,omitempty" jsonschema:"Schedule as YYYY-MM-DD, local YYYY-MM-DDTHH:MM[:SS], or an RFC 3339 UTC instant ending in Z"`
+	Timezone       string         `json:"timezone,omitempty" jsonschema:"IANA timezone for date-only and local scheduled_on values"`
+	ForceNew       bool           `json:"force_new,omitempty" jsonschema:"Create even when Kata finds a likely duplicate"`
 	Parent         string         `json:"parent,omitempty" jsonschema:"Parent issue reference"`
 	Blocks         []string       `json:"blocks,omitempty" jsonschema:"Issues this new issue blocks"`
 	BlockedBy      []string       `json:"blocked_by,omitempty" jsonschema:"Issues that block this new issue"`
@@ -451,38 +524,44 @@ type CreateInput struct {
 
 // EditInput applies issue field and relationship deltas atomically.
 type EditInput struct {
-	Ref             string   `json:"ref" jsonschema:"Issue reference in the bound project"`
-	Title           *string  `json:"title,omitempty" jsonschema:"Replacement title"`
-	Body            *string  `json:"body,omitempty" jsonschema:"Replacement body"`
-	Owner           *string  `json:"owner,omitempty" jsonschema:"Replacement owner"`
-	ClearOwner      bool     `json:"clear_owner,omitempty" jsonschema:"Remove the current owner"`
-	Priority        *int64   `json:"priority,omitempty" jsonschema:"Replacement priority from 0 through 4"`
-	ClearPriority   bool     `json:"clear_priority,omitempty" jsonschema:"Remove the current priority"`
-	Parent          *string  `json:"parent,omitempty" jsonschema:"Replacement parent reference"`
-	RemoveParent    *string  `json:"remove_parent,omitempty" jsonschema:"Current parent reference to remove strictly"`
-	AddBlocks       []string `json:"add_blocks,omitempty" jsonschema:"Issue references to add as blocked by this issue"`
-	RemoveBlocks    []string `json:"remove_blocks,omitempty" jsonschema:"Blocking relationships to remove"`
-	AddBlockedBy    []string `json:"add_blocked_by,omitempty" jsonschema:"Issue references that block this issue"`
-	RemoveBlockedBy []string `json:"remove_blocked_by,omitempty" jsonschema:"Blocked-by relationships to remove"`
-	AddRelated      []string `json:"add_related,omitempty" jsonschema:"Related issue references to add"`
-	RemoveRelated   []string `json:"remove_related,omitempty" jsonschema:"Related issue references to remove"`
+	Ref              string         `json:"ref" jsonschema:"Issue reference; use project#ref in multi-project mode"`
+	Title            *string        `json:"title,omitempty" jsonschema:"Replacement title"`
+	Body             *string        `json:"body,omitempty" jsonschema:"Replacement body"`
+	Owner            *string        `json:"owner,omitempty" jsonschema:"Replacement owner"`
+	ClearOwner       bool           `json:"clear_owner,omitempty" jsonschema:"Remove the current owner"`
+	Priority         *int64         `json:"priority,omitempty" jsonschema:"Replacement priority from 0 through 4"`
+	ClearPriority    bool           `json:"clear_priority,omitempty" jsonschema:"Remove the current priority"`
+	Metadata         map[string]any `json:"metadata,omitempty" jsonschema:"Issue metadata merge patch; JSON null removes a key"`
+	ScheduledOn      *string        `json:"scheduled_on,omitempty" jsonschema:"Schedule as YYYY-MM-DD, local YYYY-MM-DDTHH:MM[:SS], or an RFC 3339 UTC instant ending in Z"`
+	Timezone         *string        `json:"timezone,omitempty" jsonschema:"IANA timezone for date-only and local scheduled_on values"`
+	ClearScheduledOn bool           `json:"clear_scheduled_on,omitempty" jsonschema:"Remove scheduled_on"`
+	ClearTimezone    bool           `json:"clear_timezone,omitempty" jsonschema:"Remove timezone"`
+	Parent           *string        `json:"parent,omitempty" jsonschema:"Replacement parent reference"`
+	RemoveParent     *string        `json:"remove_parent,omitempty" jsonschema:"Current parent reference to remove strictly"`
+	AddBlocks        []string       `json:"add_blocks,omitempty" jsonschema:"Issue references to add as blocked by this issue"`
+	RemoveBlocks     []string       `json:"remove_blocks,omitempty" jsonschema:"Blocking relationships to remove"`
+	AddBlockedBy     []string       `json:"add_blocked_by,omitempty" jsonschema:"Issue references that block this issue"`
+	RemoveBlockedBy  []string       `json:"remove_blocked_by,omitempty" jsonschema:"Blocked-by relationships to remove"`
+	AddRelated       []string       `json:"add_related,omitempty" jsonschema:"Related issue references to add"`
+	RemoveRelated    []string       `json:"remove_related,omitempty" jsonschema:"Related issue references to remove"`
 }
 
 // CommentInput appends an idempotent comment.
 type CommentInput struct {
-	Ref            string `json:"ref" jsonschema:"Issue reference in the bound project"`
+	Ref            string `json:"ref" jsonschema:"Issue reference; use project#ref in multi-project mode"`
 	Body           string `json:"body" jsonschema:"Comment body"`
 	IdempotencyKey string `json:"idempotency_key" jsonschema:"Stable unique key for safe retries"`
 }
 
-// ClaimInput claims an issue without a force path.
+// ClaimInput claims an issue, optionally replacing its current owner.
 type ClaimInput struct {
-	Ref string `json:"ref" jsonschema:"Issue reference in the bound project"`
+	Ref   string `json:"ref" jsonschema:"Issue reference; use project#ref in multi-project mode"`
+	Force bool   `json:"force,omitempty" jsonschema:"Replace a different current owner"`
 }
 
 // SetLabelInput makes label presence explicit and naturally idempotent.
 type SetLabelInput struct {
-	Ref     string `json:"ref" jsonschema:"Issue reference in the bound project"`
+	Ref     string `json:"ref" jsonschema:"Issue reference; use project#ref in multi-project mode"`
 	Label   string `json:"label" jsonschema:"Project label"`
 	Present bool   `json:"present" jsonschema:"True to add the label; false to remove it"`
 }
@@ -505,7 +584,7 @@ type SetScheduleInput struct {
 
 // SetMetadataInput patches several keys in one operation.
 type SetMetadataInput struct {
-	Ref      string         `json:"ref" jsonschema:"Issue reference in the bound project"`
+	Ref      string         `json:"ref" jsonschema:"Issue reference; use project#ref in multi-project mode"`
 	Patch    map[string]any `json:"patch" jsonschema:"Metadata values to set; JSON null removes a key"`
 	Revision *int64         `json:"revision,omitempty" jsonschema:"Required current issue revision for a conditional write"`
 }
@@ -523,7 +602,7 @@ type Evidence struct {
 
 // CloseInput makes the completion assertion explicit.
 type CloseInput struct {
-	Ref      string     `json:"ref" jsonschema:"Issue reference in the bound project"`
+	Ref      string     `json:"ref" jsonschema:"Issue reference; use project#ref in multi-project mode"`
 	Reason   string     `json:"reason" jsonschema:"Close reason: done, wontfix, duplicate, superseded, or audit-no-change"`
 	Message  string     `json:"message" jsonschema:"Substantive completion message"`
 	Evidence []Evidence `json:"evidence" jsonschema:"Typed evidence that supports the close"`
@@ -532,12 +611,13 @@ type CloseInput struct {
 
 // ReopenInput reactivates closed work.
 type ReopenInput struct {
-	Ref string `json:"ref" jsonschema:"Issue reference in the bound project"`
+	Ref string `json:"ref" jsonschema:"Issue reference; use project#ref in multi-project mode"`
 }
 
 // ProjectIdentity identifies the immutable startup project.
 type ProjectIdentity struct {
 	ID   int64  `json:"id"`
+	UID  string `json:"uid,omitempty"`
 	Name string `json:"name"`
 }
 
@@ -554,13 +634,16 @@ type IssueSummary struct {
 	Blocked      *bool     `json:"blocked,omitempty"`
 	Revision     int64     `json:"revision"`
 	UpdatedAt    string    `json:"updated_at"`
+	ScheduledOn  *string   `json:"scheduled_on,omitempty"`
+	Timezone     *string   `json:"timezone,omitempty"`
 }
 
 // IssueListOutput is a bounded collection without issue bodies or comments.
 type IssueListOutput struct {
-	Project   ProjectIdentity `json:"project"`
-	Issues    []IssueSummary  `json:"issues"`
-	Truncated bool            `json:"truncated"`
+	Project   ProjectIdentity   `json:"project"`
+	Projects  []ProjectIdentity `json:"projects,omitempty"`
+	Issues    []IssueSummary    `json:"issues"`
+	Truncated bool              `json:"truncated"`
 }
 
 // SearchHit adds relevance information to a compact issue.
@@ -572,13 +655,14 @@ type SearchHit struct {
 
 // SearchOutput reports the effective mode and any semantic fallback.
 type SearchOutput struct {
-	Project        ProjectIdentity `json:"project"`
-	Query          string          `json:"query"`
-	Mode           string          `json:"mode"`
-	Degraded       bool            `json:"degraded"`
-	DegradedReason string          `json:"degraded_reason,omitempty"`
-	Results        []SearchHit     `json:"results"`
-	Truncated      bool            `json:"truncated"`
+	Project        ProjectIdentity   `json:"project"`
+	Projects       []ProjectIdentity `json:"projects,omitempty"`
+	Query          string            `json:"query"`
+	Mode           string            `json:"mode"`
+	Degraded       bool              `json:"degraded"`
+	DegradedReason string            `json:"degraded_reason,omitempty"`
+	Results        []SearchHit       `json:"results"`
+	Truncated      bool              `json:"truncated"`
 }
 
 // LabelCount reports project label reuse.
@@ -589,8 +673,9 @@ type LabelCount struct {
 
 // LabelsOutput is the project label catalog.
 type LabelsOutput struct {
-	Project ProjectIdentity `json:"project"`
-	Labels  []LabelCount    `json:"labels"`
+	Project  ProjectIdentity   `json:"project"`
+	Projects []ProjectIdentity `json:"projects,omitempty"`
+	Labels   []LabelCount      `json:"labels"`
 }
 
 // CommentSummary is a bounded comment representation.
@@ -655,11 +740,12 @@ type LinkChangesSummary struct {
 
 // MutationOutput is the common mutation result.
 type MutationOutput struct {
-	Project ProjectIdentity `json:"project"`
-	Issue   IssueSummary    `json:"issue"`
-	Changed bool            `json:"changed"`
-	Reused  *bool           `json:"reused,omitempty"`
-	Event   *EventSummary   `json:"event,omitempty"`
+	Project       ProjectIdentity `json:"project"`
+	Issue         IssueSummary    `json:"issue"`
+	Changed       bool            `json:"changed"`
+	Reused        *bool           `json:"reused,omitempty"`
+	Event         *EventSummary   `json:"event,omitempty"`
+	PreviousOwner *string         `json:"previous_owner,omitempty"`
 }
 
 // EditOutput preserves every ordered event and applied relationship change.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -141,7 +141,7 @@ func registerIssueDiscoveryTools(server *sdkmcp.Server, handlers toolHandlers) {
 func registerIssueMutationTools(server *sdkmcp.Server, handlers toolHandlers) {
 	additive := toolHints(false, false, false)
 	mutating := toolHints(false, true, false)
-	addTool(server, "kata.claim", "Claim issue", "Claim an unowned issue for the bound actor. The call fails when another owner already holds it.", additive, handlers.claim)
+	addTool(server, "kata.claim", "Claim issue", "Claim an issue for the bound actor. Without force the call fails when another owner already holds it; force replaces that owner.", mutating, handlers.claim)
 	addTool(server, "kata.comment", "Add comment", "Append a progress or context comment using a required idempotency key.", additive, handlers.comment)
 	addTool(server, "kata.create", "Create issue", "Create project work after searching for duplicates. A stable idempotency key is required.", additive, handlers.create)
 	addTool(server, "kata.edit", "Edit issue", "Edit issue fields, ownership, priority, and relationship deltas atomically.", mutating, handlers.edit)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -27,20 +27,24 @@ const (
 
 // Options fixes the Kata daemon scope and actor for one MCP process.
 type Options struct {
-	Client           *kataclient.Client
-	Scope            *Scope
-	ProjectID        int64
-	ProjectName      string
-	Actor            string
-	Version          string
-	StorageAdmin     *storageadmin.Admin
-	EnableTokenAdmin bool
+	Client            *kataclient.Client
+	LongRunningClient *kataclient.Client
+	Scope             *Scope
+	ProjectID         int64
+	ProjectName       string
+	Actor             string
+	Version           string
+	StorageAdmin      *storageadmin.Admin
+	EnableTokenAdmin  bool
 }
 
 // New creates a tools-only MCP server for one startup project scope.
 func New(options Options) (*sdkmcp.Server, error) {
 	if options.Client == nil {
 		return nil, errors.New("kata API client is required")
+	}
+	if options.LongRunningClient == nil {
+		options.LongRunningClient = options.Client
 	}
 	if options.Scope == nil {
 		scope, err := NewBoundScope(ProjectIdentity{ID: options.ProjectID, Name: options.ProjectName})

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -650,6 +650,7 @@ type IssueSummary struct {
 	UpdatedAt    string    `json:"updated_at"`
 	ScheduledOn  *string   `json:"scheduled_on,omitempty"`
 	Timezone     *string   `json:"timezone,omitempty"`
+	updatedAt    time.Time
 }
 
 // IssueListOutput is a bounded collection without issue bodies or comments.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -650,7 +650,7 @@ type IssueSummary struct {
 
 // IssueListOutput is a bounded collection without issue bodies or comments.
 type IssueListOutput struct {
-	Project   ProjectIdentity   `json:"project"`
+	Project   *ProjectIdentity  `json:"project,omitempty"`
 	Projects  []ProjectIdentity `json:"projects,omitempty"`
 	Issues    []IssueSummary    `json:"issues"`
 	Truncated bool              `json:"truncated"`
@@ -665,7 +665,7 @@ type SearchHit struct {
 
 // SearchOutput reports the effective mode and any semantic fallback.
 type SearchOutput struct {
-	Project        ProjectIdentity   `json:"project"`
+	Project        *ProjectIdentity  `json:"project,omitempty"`
 	Projects       []ProjectIdentity `json:"projects,omitempty"`
 	Query          string            `json:"query"`
 	Mode           string            `json:"mode"`
@@ -683,7 +683,7 @@ type LabelCount struct {
 
 // LabelsOutput is the project label catalog.
 type LabelsOutput struct {
-	Project  ProjectIdentity   `json:"project"`
+	Project  *ProjectIdentity  `json:"project,omitempty"`
 	Projects []ProjectIdentity `json:"projects,omitempty"`
 	Labels   []LabelCount      `json:"labels"`
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -336,6 +336,8 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 		schema.OneOf = closeReasonSchemas()
 	case "kata.reopen":
 		setStringBounds("ref", 1, 256)
+	case "kata.audit_closes":
+		setNumberBounds("limit", 1, maximumResultLimit)
 	}
 	return schema
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -458,6 +458,13 @@ func toolHints(readOnly, destructive, openWorld bool) *sdkmcp.ToolAnnotations {
 	}
 }
 
+// nonIdempotent marks a creation tool whose identical retry mints a new
+// record because no idempotency key or natural unique key deduplicates it.
+func nonIdempotent(hints *sdkmcp.ToolAnnotations) *sdkmcp.ToolAnnotations {
+	hints.IdempotentHint = false
+	return hints
+}
+
 // SearchInput selects matching issues without returning large issue bodies.
 type SearchInput struct {
 	Project       string   `json:"project,omitempty" jsonschema:"Project name; omit to search every project in scope"`

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -338,7 +338,7 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 		setStringBounds("ref", 1, 256)
 	case "kata.audit_closes":
 		setNumberBounds("limit", 1, maximumResultLimit)
-		if field := property("offset"); field != nil {
+		if field := property("after_event_id"); field != nil {
 			minimum := float64(0)
 			field.Minimum = &minimum
 		}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -465,8 +465,10 @@ func toolHints(readOnly, destructive, openWorld bool) *sdkmcp.ToolAnnotations {
 	}
 }
 
-// nonIdempotent marks a creation tool whose identical retry mints a new
-// record because no idempotency key or natural unique key deduplicates it.
+// nonIdempotent marks a tool whose identical retry has additional effects:
+// a creation with no idempotency key or natural unique key mints a new
+// record, a lease renewal extends the expiry again, and a sync pass
+// re-imports from the provider.
 func nonIdempotent(hints *sdkmcp.ToolAnnotations) *sdkmcp.ToolAnnotations {
 	hints.IdempotentHint = false
 	return hints

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -551,6 +551,11 @@ func TestToolsUseBoundDaemonProjectAndActor(t *testing.T) {
 				require.Len(t, changes["related_added"], 1)
 			}
 
+			if tt.tool == "kata.edit" {
+				resolution := <-requests
+				require.Equal(t, http.MethodGet, resolution.Method)
+				require.Equal(t, "/api/v1/projects/42/issues/def2", resolution.Path)
+			}
 			request := <-requests
 			require.Equal(t, tt.wantMethod, request.Method)
 			require.Equal(t, tt.wantPath, request.Path)
@@ -570,7 +575,10 @@ func TestToolsUseBoundDaemonProjectAndActor(t *testing.T) {
 				require.NotContains(t, body, "project")
 				if tt.tool == "kata.edit" {
 					links := body["links_delta"].(map[string]any)
-					require.Equal(t, []any{"def2"}, links["add_related"])
+					require.Equal(t, []any{"01ARZ3NDEKTSV4RRFFQ69G5FAV"}, links["add_related"])
+					require.Equal(t, map[string]any{
+						"01ARZ3NDEKTSV4RRFFQ69G5FAV": "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+					}, links["expected_project_uids"])
 				}
 				if tt.tool == "kata.set_deadline" {
 					require.Equal(t, map[string]any{"deadline_on": "2026-09-01T09:30"}, body["patch"])

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -151,7 +151,6 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 		"kata.edit_comment",
 		"kata.events",
 		"kata.federation_enrollment_revoke",
-		"kata.federation_join",
 		"kata.federation_leave",
 		"kata.federation_quarantine",
 		"kata.federation_rebind",
@@ -210,7 +209,7 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 	}
 	openWorld := map[string]bool{
 		"kata.federation_enrollment_revoke": true,
-		"kata.federation_join":              true, "kata.federation_leave": true, "kata.federation_quarantine": true,
+		"kata.federation_leave":             true, "kata.federation_quarantine": true,
 		"kata.federation_rebind": true, "kata.federation_status": true, "kata.import_issues": true,
 		"kata.search": true, "kata.sync_once": true, "kata.sync_status": true, "kata.sync_update": true,
 	}
@@ -274,8 +273,8 @@ func TestServerToolAnnotationsMatchMutationRisk(t *testing.T) {
 	}
 	additive := map[string]bool{
 		"kata.claim": true, "kata.comment": true, "kata.create": true,
-		"kata.federation_join": true, "kata.import_issues": true,
-		"kata.lease": true, "kata.project_create": true, "kata.project_restore": true,
+		"kata.import_issues": true,
+		"kata.lease":         true, "kata.project_create": true, "kata.project_restore": true,
 		"kata.recurrence_update": true, "kata.restore": true, "kata.sync_once": true,
 		"kata.token_create": true,
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -283,6 +283,10 @@ func TestServerToolAnnotationsMatchMutationRisk(t *testing.T) {
 		// unique key deduplicates these creations.
 		"kata.token_create":      true,
 		"kata.recurrence_update": true,
+		// Identical retries produce additional effects: renew extends the
+		// lease expiry again and a sync pass re-imports from the provider.
+		"kata.lease":     true,
+		"kata.sync_once": true,
 	}
 	for _, tool := range result.Tools {
 		annotations := tool.Annotations

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -271,11 +271,13 @@ func TestServerToolAnnotationsMatchMutationRisk(t *testing.T) {
 	for _, name := range sectionLoaderNames {
 		readOnly[name] = true
 	}
+	// Mixed-mode tools with any overwriting or removing input (forced
+	// claims, lease release, recurrence patch) advertise destructive.
 	additive := map[string]bool{
-		"kata.claim": true, "kata.comment": true, "kata.create": true,
-		"kata.import_issues": true,
-		"kata.lease":         true, "kata.project_create": true, "kata.project_restore": true,
-		"kata.recurrence_update": true, "kata.restore": true, "kata.sync_once": true,
+		"kata.comment": true, "kata.create": true,
+		"kata.import_issues":  true,
+		"kata.project_create": true, "kata.project_restore": true,
+		"kata.restore": true, "kata.sync_once": true,
 		"kata.token_create": true,
 	}
 	nonIdempotentTools := map[string]bool{

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -275,10 +275,8 @@ func TestServerToolAnnotationsMatchMutationRisk(t *testing.T) {
 	// claims, lease release, recurrence patch) advertise destructive.
 	additive := map[string]bool{
 		"kata.comment": true, "kata.create": true,
-		"kata.import_issues":  true,
 		"kata.project_create": true, "kata.project_restore": true,
-		"kata.restore": true, "kata.sync_once": true,
-		"kata.token_create": true,
+		"kata.restore": true, "kata.token_create": true,
 	}
 	nonIdempotentTools := map[string]bool{
 		// Identical retries mint new records: no idempotency key or natural

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -150,7 +150,6 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 		"kata.edit",
 		"kata.edit_comment",
 		"kata.events",
-		"kata.federation_enroll",
 		"kata.federation_enrollment_revoke",
 		"kata.federation_join",
 		"kata.federation_leave",
@@ -201,7 +200,7 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 	gotNames := make([]string, 0, len(result.Tools))
 	projectSelectors := map[string]bool{
 		"kata.audit_closes": true,
-		"kata.create":       true, "kata.digest": true, "kata.events": true, "kata.federation_enroll": true,
+		"kata.create":       true, "kata.digest": true, "kata.events": true,
 		"kata.federation_leave": true, "kata.federation_quarantine": true, "kata.federation_rebind": true,
 		"kata.import_issues": true, "kata.labels": true, "kata.list": true, "kata.next": true,
 		"kata.project_purge": true, "kata.project_remove": true, "kata.project_restore": true,
@@ -210,8 +209,8 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 		"kata.search": true, "kata.sync_once": true, "kata.sync_status": true, "kata.sync_update": true,
 	}
 	openWorld := map[string]bool{
-		"kata.federation_enroll": true, "kata.federation_enrollment_revoke": true,
-		"kata.federation_join": true, "kata.federation_leave": true, "kata.federation_quarantine": true,
+		"kata.federation_enrollment_revoke": true,
+		"kata.federation_join":              true, "kata.federation_leave": true, "kata.federation_quarantine": true,
 		"kata.federation_rebind": true, "kata.federation_status": true, "kata.import_issues": true,
 		"kata.search": true, "kata.sync_once": true, "kata.sync_status": true, "kata.sync_update": true,
 	}
@@ -275,7 +274,7 @@ func TestServerToolAnnotationsMatchMutationRisk(t *testing.T) {
 	}
 	additive := map[string]bool{
 		"kata.claim": true, "kata.comment": true, "kata.create": true,
-		"kata.federation_enroll": true, "kata.federation_join": true, "kata.import_issues": true,
+		"kata.federation_join": true, "kata.import_issues": true,
 		"kata.lease": true, "kata.project_create": true, "kata.project_restore": true,
 		"kata.recurrence_update": true, "kata.restore": true, "kata.sync_once": true,
 		"kata.token_create": true,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -279,10 +279,16 @@ func TestServerToolAnnotationsMatchMutationRisk(t *testing.T) {
 		"kata.recurrence_update": true, "kata.restore": true, "kata.sync_once": true,
 		"kata.token_create": true,
 	}
+	nonIdempotentTools := map[string]bool{
+		// Identical retries mint new records: no idempotency key or natural
+		// unique key deduplicates these creations.
+		"kata.token_create":      true,
+		"kata.recurrence_update": true,
+	}
 	for _, tool := range result.Tools {
 		annotations := tool.Annotations
 		require.Equal(t, readOnly[tool.Name], annotations.ReadOnlyHint, tool.Name)
-		require.True(t, annotations.IdempotentHint, tool.Name)
+		require.Equal(t, !nonIdempotentTools[tool.Name], annotations.IdempotentHint, tool.Name)
 		require.NotNil(t, annotations.DestructiveHint, tool.Name)
 		if readOnly[tool.Name] || additive[tool.Name] {
 			require.False(t, *annotations.DestructiveHint, tool.Name)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -27,8 +27,100 @@ import (
 	"go.kenn.io/kata/pkg/client/generated"
 )
 
+var sectionLoaderNames = []string{
+	"kata.load_activity",
+	"kata.load_federation",
+	"kata.load_import",
+	"kata.load_issue_discovery",
+	"kata.load_issue_lifecycle",
+	"kata.load_issue_mutation",
+	"kata.load_leases",
+	"kata.load_projects",
+	"kata.load_recurrence",
+	"kata.load_storage",
+	"kata.load_sync",
+	"kata.load_system",
+	"kata.load_tokens",
+}
+
+func TestServerPublishesOnlySectionLoadersInitially(t *testing.T) {
+	session := connectRawTestServerWithOptions(t, Options{
+		Client: &kataclient.Client{}, ProjectID: 42, ProjectName: "spoke-project",
+		Actor: "example-agent", Version: "test-version",
+	})
+
+	require.True(t, session.InitializeResult().Capabilities.Tools.ListChanged)
+	result, err := session.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+	require.Equal(t, sectionLoaderNames, toolNames(result.Tools))
+	for _, tool := range result.Tools {
+		require.True(t, tool.Annotations.ReadOnlyHint, tool.Name)
+		require.False(t, *tool.Annotations.DestructiveHint, tool.Name)
+	}
+}
+
+func TestSectionLoaderActivatesOnlyItsTypedToolsAndIsIdempotent(t *testing.T) {
+	session := connectRawTestServerWithOptions(t, Options{
+		Client: &kataclient.Client{}, ProjectID: 42, ProjectName: "spoke-project",
+		Actor: "example-agent", Version: "test-version",
+	})
+
+	for range 2 {
+		result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+			Name: "kata.load_activity", Arguments: map[string]any{},
+		})
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		var output ToolSectionOutput
+		require.NoError(t, json.Unmarshal(mustJSON(t, result.StructuredContent), &output))
+		require.Equal(t, ToolSectionOutput{
+			Section: "activity", Available: true, Loaded: true,
+			Tools: []string{"kata.digest", "kata.events"},
+		}, output)
+	}
+
+	result, err := session.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+	want := append(append([]string(nil), sectionLoaderNames...), "kata.digest", "kata.events")
+	sort.Strings(want)
+	require.Equal(t, want, toolNames(result.Tools))
+}
+
+func TestTokenSectionRequiresExplicitStartupCapability(t *testing.T) {
+	session := connectRawTestServerWithOptions(t, Options{
+		Client: &kataclient.Client{}, Scope: NewAllScope(),
+		Actor: "example-agent", Version: "test-version",
+	})
+
+	result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.load_tokens", Arguments: map[string]any{},
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	var output ToolSectionOutput
+	require.NoError(t, json.Unmarshal(mustJSON(t, result.StructuredContent), &output))
+	require.False(t, output.Available)
+	require.False(t, output.Loaded)
+
+	enabled := connectRawTestServerWithOptions(t, Options{
+		Client: &kataclient.Client{}, Scope: NewAllScope(), EnableTokenAdmin: true,
+		Actor: "example-agent", Version: "test-version",
+	})
+	result, err = enabled.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.load_tokens", Arguments: map[string]any{},
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.NoError(t, json.Unmarshal(mustJSON(t, result.StructuredContent), &output))
+	require.True(t, output.Available)
+	require.True(t, output.Loaded)
+}
+
 func TestServerPublishesCurrentToolsOnly(t *testing.T) {
-	session := connectTestServer(t)
+	session := connectTestServerWithOptions(t, Options{
+		Client: &kataclient.Client{}, Scope: NewAllScope(), EnableTokenAdmin: true,
+		Actor: "example-agent", Version: "test-version",
+	})
 
 	initialized := session.InitializeResult()
 	require.Equal(t, currentProtocolVersion, initialized.ProtocolVersion)
@@ -36,7 +128,7 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 	require.Equal(t, "kata", initialized.ServerInfo.Name)
 	require.Equal(t, "test-version", initialized.ServerInfo.Version)
 	require.NotNil(t, initialized.Capabilities.Tools)
-	require.False(t, initialized.Capabilities.Tools.ListChanged)
+	require.True(t, initialized.Capabilities.Tools.ListChanged)
 	require.Nil(t, initialized.Capabilities.Prompts)
 	require.Nil(t, initialized.Capabilities.Resources)
 	capabilities := string(mustJSON(t, initialized.Capabilities))
@@ -48,23 +140,81 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 	require.Equal(t, "private", result.CacheScope)
 
 	wantNames := []string{
+		"kata.audit_closes",
 		"kata.claim",
 		"kata.close",
 		"kata.comment",
 		"kata.create",
+		"kata.delete",
+		"kata.digest",
 		"kata.edit",
+		"kata.edit_comment",
+		"kata.events",
+		"kata.federation_enroll",
+		"kata.federation_enrollment_revoke",
+		"kata.federation_join",
+		"kata.federation_leave",
+		"kata.federation_quarantine",
+		"kata.federation_rebind",
+		"kata.federation_status",
+		"kata.graph",
+		"kata.import_issues",
 		"kata.labels",
+		"kata.lease",
+		"kata.lease_force_release",
+		"kata.lease_status",
+		"kata.lease_steal",
 		"kata.list",
+		"kata.move",
+		"kata.next",
+		"kata.project_create",
+		"kata.project_merge",
+		"kata.project_purge",
+		"kata.project_remove",
+		"kata.project_restore",
+		"kata.project_update",
+		"kata.projects",
+		"kata.purge",
 		"kata.ready",
+		"kata.recurrence_delete",
+		"kata.recurrence_update",
+		"kata.recurrences",
 		"kata.reopen",
+		"kata.restore",
 		"kata.search",
 		"kata.set_deadline",
 		"kata.set_label",
 		"kata.set_metadata",
 		"kata.set_schedule",
 		"kata.show",
+		"kata.sync_once",
+		"kata.sync_status",
+		"kata.sync_update",
+		"kata.system",
+		"kata.token_create",
+		"kata.token_revoke",
+		"kata.tokens",
+		"kata.wait",
 	}
+	wantNames = append(wantNames, sectionLoaderNames...)
+	sort.Strings(wantNames)
 	gotNames := make([]string, 0, len(result.Tools))
+	projectSelectors := map[string]bool{
+		"kata.audit_closes": true,
+		"kata.create":       true, "kata.digest": true, "kata.events": true, "kata.federation_enroll": true,
+		"kata.federation_leave": true, "kata.federation_quarantine": true, "kata.federation_rebind": true,
+		"kata.import_issues": true, "kata.labels": true, "kata.list": true, "kata.next": true,
+		"kata.project_purge": true, "kata.project_remove": true, "kata.project_restore": true,
+		"kata.project_update": true, "kata.projects": true, "kata.ready": true,
+		"kata.recurrence_delete": true, "kata.recurrence_update": true, "kata.recurrences": true,
+		"kata.search": true, "kata.sync_once": true, "kata.sync_status": true, "kata.sync_update": true,
+	}
+	openWorld := map[string]bool{
+		"kata.federation_enroll": true, "kata.federation_enrollment_revoke": true,
+		"kata.federation_join": true, "kata.federation_leave": true, "kata.federation_quarantine": true,
+		"kata.federation_rebind": true, "kata.federation_status": true, "kata.import_issues": true,
+		"kata.search": true, "kata.sync_once": true, "kata.sync_status": true, "kata.sync_update": true,
+	}
 	for _, tool := range result.Tools {
 		gotNames = append(gotNames, tool.Name)
 		require.NotEmpty(t, tool.Title, tool.Name)
@@ -76,36 +226,59 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 		require.Equal(t, "object", input["type"], tool.Name)
 		require.Equal(t, false, input["additionalProperties"], tool.Name)
 		properties, _ := input["properties"].(map[string]any)
-		require.NotContains(t, properties, "actor", tool.Name)
-		require.NotContains(t, properties, "project", tool.Name)
+		if tool.Name != "kata.audit_closes" {
+			require.NotContains(t, properties, "actor", tool.Name)
+		}
+		require.Equal(t, projectSelectors[tool.Name], properties["project"] != nil, tool.Name)
 		require.NotContains(t, properties, "project_id", tool.Name)
 		require.NotContains(t, properties, "workspace", tool.Name)
 
 		annotations := tool.Annotations
 		require.NotNil(t, annotations, tool.Name)
 		require.NotNil(t, annotations.OpenWorldHint, tool.Name)
-		require.Equal(t, tool.Name == "kata.search", *annotations.OpenWorldHint, tool.Name)
+		require.Equal(t, openWorld[tool.Name], *annotations.OpenWorldHint, tool.Name)
 	}
 	require.Equal(t, wantNames, gotNames)
 	require.True(t, sort.StringsAreSorted(gotNames))
 }
 
 func TestServerToolAnnotationsMatchMutationRisk(t *testing.T) {
-	session := connectTestServer(t)
+	session := connectTestServerWithOptions(t, Options{
+		Client: &kataclient.Client{}, Scope: NewAllScope(), EnableTokenAdmin: true,
+		Actor: "example-agent", Version: "test-version",
+	})
 	result, err := session.ListTools(t.Context(), nil)
 	require.NoError(t, err)
 
 	readOnly := map[string]bool{
-		"kata.labels": true,
-		"kata.list":   true,
-		"kata.ready":  true,
-		"kata.search": true,
-		"kata.show":   true,
+		"kata.audit_closes":      true,
+		"kata.digest":            true,
+		"kata.events":            true,
+		"kata.federation_status": true,
+		"kata.graph":             true,
+		"kata.labels":            true,
+		"kata.lease_status":      true,
+		"kata.list":              true,
+		"kata.next":              true,
+		"kata.projects":          true,
+		"kata.ready":             true,
+		"kata.recurrences":       true,
+		"kata.search":            true,
+		"kata.show":              true,
+		"kata.sync_status":       true,
+		"kata.system":            true,
+		"kata.tokens":            true,
+		"kata.wait":              true,
+	}
+	for _, name := range sectionLoaderNames {
+		readOnly[name] = true
 	}
 	additive := map[string]bool{
-		"kata.claim":   true,
-		"kata.comment": true,
-		"kata.create":  true,
+		"kata.claim": true, "kata.comment": true, "kata.create": true,
+		"kata.federation_enroll": true, "kata.federation_join": true, "kata.import_issues": true,
+		"kata.lease": true, "kata.project_create": true, "kata.project_restore": true,
+		"kata.recurrence_update": true, "kata.restore": true, "kata.sync_once": true,
+		"kata.token_create": true,
 	}
 	for _, tool := range result.Tools {
 		annotations := tool.Annotations
@@ -229,7 +402,7 @@ func TestCreateAndCommentRequireIdempotencyKeys(t *testing.T) {
 
 	require.Len(t, schemaObject(t, byName["kata.list"].InputSchema)["allOf"], 1)
 	require.Len(t, schemaObject(t, byName["kata.ready"].InputSchema)["allOf"], 1)
-	require.Len(t, schemaObject(t, byName["kata.edit"].InputSchema)["allOf"], 3)
+	require.Len(t, schemaObject(t, byName["kata.edit"].InputSchema)["allOf"], 5)
 
 	labelProperties := schemaObject(t, byName["kata.set_label"].InputSchema)["properties"].(map[string]any)
 	require.EqualValues(t, 64, labelProperties["label"].(map[string]any)["maxLength"])
@@ -295,6 +468,14 @@ func TestSetScheduleInputSchemaRequiresOneMutation(t *testing.T) {
 	require.Error(t, schema.Validate(map[string]any{"ref": "abc1"}))
 	require.Error(t, schema.Validate(map[string]any{"ref": "abc1", "schedule": "2026-09-01", "clear_schedule": true}))
 	require.Error(t, schema.Validate(map[string]any{"ref": "abc1", "clear_schedule": false}))
+}
+
+func TestRecurrencePatchSchemaRequiresRevision(t *testing.T) {
+	schema, err := inputSchemaFor[RecurrenceUpdateInput]("kata.recurrence_update").Resolve(nil)
+	require.NoError(t, err)
+	require.Error(t, schema.Validate(map[string]any{"action": "patch", "uid": "recurrence-uid"}))
+	require.NoError(t, schema.Validate(map[string]any{"action": "patch", "uid": "recurrence-uid", "revision": 1}))
+	require.NoError(t, schema.Validate(map[string]any{"action": "create", "template": map[string]any{"title": "Review"}}))
 }
 
 func TestToolsUseBoundDaemonProjectAndActor(t *testing.T) {
@@ -784,6 +965,17 @@ func connectTestServerWithClient(t *testing.T, apiClient *kataclient.Client) *sd
 }
 
 func connectTestServerWithOptions(t *testing.T, options Options) *sdkmcp.ClientSession {
+	t.Helper()
+	session := connectRawTestServerWithOptions(t, options)
+	for _, name := range sectionLoaderNames {
+		result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{Name: name, Arguments: map[string]any{}})
+		require.NoError(t, err)
+		require.False(t, result.IsError, "%s: %s", name, mustJSON(t, result))
+	}
+	return session
+}
+
+func connectRawTestServerWithOptions(t *testing.T, options Options) *sdkmcp.ClientSession {
 	t.Helper()
 	server, err := New(options)
 	require.NoError(t, err)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -579,6 +579,11 @@ func TestToolsUseBoundDaemonProjectAndActor(t *testing.T) {
 					require.Equal(t, map[string]any{"scheduled_on": "2026-09-01T09:30"}, body["patch"])
 				}
 			}
+			if tt.tool == "kata.edit" {
+				scopeRequest := <-requests
+				require.Equal(t, http.MethodGet, scopeRequest.Method)
+				require.Equal(t, "/api/v1/issues/01ARZ3NDEKTSV4RRFFQ69G5FAW", scopeRequest.Path)
+			}
 		})
 	}
 }

--- a/internal/mcp/storage.go
+++ b/internal/mcp/storage.go
@@ -54,17 +54,20 @@ func (h toolHandlers) storageExport(ctx context.Context, _ *sdkmcp.CallToolReque
 	if h.options.StorageAdmin == nil {
 		return nil, StorageExportOutput{}, errors.New("storage administration is not enabled")
 	}
+	// A project-filtered JSONL export still contains cross-project link
+	// rows and unredacted event payload references, so exporting is a
+	// daemon-wide operator action regardless of the project filter.
+	if err := h.requireAllProjectsScope("storage export"); err != nil {
+		return nil, StorageExportOutput{}, err
+	}
 	projectID := int64(0)
 	projectName := ""
-	switch {
-	case strings.TrimSpace(input.Project) != "" || h.options.Scope.Mode() == ScopeBound:
+	if strings.TrimSpace(input.Project) != "" {
 		project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
 		if err != nil {
 			return nil, StorageExportOutput{}, err
 		}
 		projectID, projectName = project.ID, project.Name
-	case h.options.Scope.Mode() == ScopeAllowlist:
-		return nil, StorageExportOutput{}, errors.New("allowlist storage export requires an explicit project")
 	}
 	result, err := h.options.StorageAdmin.Export(ctx, storageadmin.ExportOptions{
 		Artifact: input.Artifact, ProjectID: projectID, IncludeDeleted: input.includeDeleted(),

--- a/internal/mcp/storage.go
+++ b/internal/mcp/storage.go
@@ -46,7 +46,7 @@ func registerStorageTools(server *sdkmcp.Server, handlers toolHandlers) {
 	if handlers.options.StorageAdmin == nil {
 		return
 	}
-	addTool(server, "kata.storage_export", "Export storage", "Export Kata JSONL to an artifact under the operator-approved storage root.", toolHints(false, false, false), handlers.storageExport)
+	addTool(server, "kata.storage_export", "Export storage", "Export Kata JSONL to an artifact under the operator-approved storage root; force overwrites an existing artifact.", toolHints(false, true, false), handlers.storageExport)
 	addTool(server, "kata.storage_import", "Import storage", "Restore Kata JSONL to a startup-configured storage target alias.", toolHints(false, true, false), handlers.storageImport)
 }
 

--- a/internal/mcp/storage.go
+++ b/internal/mcp/storage.go
@@ -1,0 +1,92 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/kata/internal/storageadmin"
+)
+
+// StorageExportInput selects a root-contained JSONL artifact.
+type StorageExportInput struct {
+	Artifact       string `json:"artifact"`
+	Project        string `json:"project,omitempty"`
+	IncludeDeleted *bool  `json:"include_deleted,omitempty"`
+	Force          bool   `json:"force,omitempty"`
+	Confirm        string `json:"confirm,omitempty"`
+}
+
+// StorageExportOutput reports an installed JSONL artifact.
+type StorageExportOutput struct {
+	Artifact string `json:"artifact"`
+	Bytes    int64  `json:"bytes"`
+	Project  string `json:"project,omitempty"`
+}
+
+// StorageImportInput selects an artifact and configured target alias.
+type StorageImportInput struct {
+	Artifact    string `json:"artifact"`
+	Target      string `json:"target"`
+	Force       bool   `json:"force,omitempty"`
+	Confirm     string `json:"confirm,omitempty"`
+	NewInstance bool   `json:"new_instance,omitempty"`
+}
+
+// StorageImportOutput reports a completed storage restore.
+type StorageImportOutput struct {
+	Artifact string `json:"artifact"`
+	Target   string `json:"target"`
+	Backend  string `json:"backend"`
+}
+
+func registerStorageTools(server *sdkmcp.Server, handlers toolHandlers) {
+	if handlers.options.StorageAdmin == nil {
+		return
+	}
+	addTool(server, "kata.storage_export", "Export storage", "Export Kata JSONL to an artifact under the operator-approved storage root.", toolHints(false, false, false), handlers.storageExport)
+	addTool(server, "kata.storage_import", "Import storage", "Restore Kata JSONL to a startup-configured storage target alias.", toolHints(false, true, false), handlers.storageImport)
+}
+
+func (h toolHandlers) storageExport(ctx context.Context, _ *sdkmcp.CallToolRequest, input StorageExportInput) (*sdkmcp.CallToolResult, StorageExportOutput, error) {
+	if h.options.StorageAdmin == nil {
+		return nil, StorageExportOutput{}, errors.New("storage administration is not enabled")
+	}
+	projectID := int64(0)
+	projectName := ""
+	switch {
+	case strings.TrimSpace(input.Project) != "" || h.options.Scope.Mode() == ScopeBound:
+		project, err := h.options.Scope.Project(ctx, h.options.Client, input.Project, false)
+		if err != nil {
+			return nil, StorageExportOutput{}, err
+		}
+		projectID, projectName = project.ID, project.Name
+	case h.options.Scope.Mode() == ScopeAllowlist:
+		return nil, StorageExportOutput{}, errors.New("allowlist storage export requires an explicit project")
+	}
+	result, err := h.options.StorageAdmin.Export(ctx, storageadmin.ExportOptions{
+		Artifact: input.Artifact, ProjectID: projectID, IncludeDeleted: input.includeDeleted(),
+		Force: input.Force, Confirm: input.Confirm,
+	})
+	if err != nil {
+		return nil, StorageExportOutput{}, err
+	}
+	return successResult(), StorageExportOutput{Artifact: result.Artifact, Bytes: result.Bytes, Project: projectName}, nil
+}
+
+func (input StorageExportInput) includeDeleted() bool {
+	return input.IncludeDeleted == nil || *input.IncludeDeleted
+}
+
+func (h toolHandlers) storageImport(ctx context.Context, _ *sdkmcp.CallToolRequest, input StorageImportInput) (*sdkmcp.CallToolResult, StorageImportOutput, error) {
+	if h.options.StorageAdmin == nil {
+		return nil, StorageImportOutput{}, errors.New("storage administration is not enabled")
+	}
+	result, err := h.options.StorageAdmin.Import(ctx, storageadmin.ImportOptions{Artifact: input.Artifact, Target: input.Target, Force: input.Force, Confirm: input.Confirm, NewInstance: input.NewInstance})
+	if err != nil {
+		return nil, StorageImportOutput{}, err
+	}
+	return successResult(), StorageImportOutput{Artifact: result.Artifact, Target: result.Target, Backend: result.Backend}, nil
+}

--- a/internal/mcp/storage.go
+++ b/internal/mcp/storage.go
@@ -47,7 +47,7 @@ func registerStorageTools(server *sdkmcp.Server, handlers toolHandlers) {
 		return
 	}
 	addTool(server, "kata.storage_export", "Export storage", "Export Kata JSONL to an artifact under the operator-approved storage root; force overwrites an existing artifact.", toolHints(false, true, false), handlers.storageExport)
-	addTool(server, "kata.storage_import", "Import storage", "Restore Kata JSONL to a startup-configured storage target alias.", toolHints(false, true, false), handlers.storageImport)
+	addTool(server, "kata.storage_import", "Import storage", "Restore Kata JSONL to a startup-configured storage target alias; a forced retry replaces the target again, and new_instance mints a fresh instance identity each run.", nonIdempotent(toolHints(false, true, false)), handlers.storageImport)
 }
 
 func (h toolHandlers) storageExport(ctx context.Context, _ *sdkmcp.CallToolRequest, input StorageExportInput) (*sdkmcp.CallToolResult, StorageExportOutput, error) {

--- a/internal/mcp/storage_test.go
+++ b/internal/mcp/storage_test.go
@@ -26,12 +26,19 @@ func TestStorageToolsRequireStartupOptIn(t *testing.T) {
 	require.Contains(t, toolNames(tools.Tools), "kata.storage_export")
 	require.Contains(t, toolNames(tools.Tools), "kata.storage_import")
 	for _, tool := range tools.Tools {
-		if tool.Name != "kata.storage_export" {
-			continue
+		switch tool.Name {
+		case "kata.storage_export":
+			properties := schemaObject(t, tool.InputSchema)["properties"].(map[string]any)
+			require.Contains(t, properties, "force")
+			require.Contains(t, properties, "confirm")
+			require.True(t, *tool.Annotations.DestructiveHint, tool.Name)
+			require.True(t, tool.Annotations.IdempotentHint, tool.Name)
+		case "kata.storage_import":
+			// A forced retry replaces the target again, and new_instance
+			// mints a fresh instance identity on every run.
+			require.True(t, *tool.Annotations.DestructiveHint, tool.Name)
+			require.False(t, tool.Annotations.IdempotentHint, tool.Name)
 		}
-		properties := schemaObject(t, tool.InputSchema)["properties"].(map[string]any)
-		require.Contains(t, properties, "force")
-		require.Contains(t, properties, "confirm")
 	}
 }
 

--- a/internal/mcp/storage_test.go
+++ b/internal/mcp/storage_test.go
@@ -1,0 +1,52 @@
+package mcpserver
+
+import (
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/storageadmin"
+	kataclient "go.kenn.io/kata/pkg/client"
+)
+
+func TestStorageToolsRequireStartupOptIn(t *testing.T) {
+	without := connectTestServer(t)
+	tools, err := without.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+	require.NotContains(t, toolNames(tools.Tools), "kata.storage_export")
+	require.NotContains(t, toolNames(tools.Tools), "kata.storage_import")
+
+	admin, err := storageadmin.New(storageadmin.Config{Root: t.TempDir(), SourceDSN: "source.db", Targets: map[string]string{"restore": "restore.db"}})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+	with := connectTestServerWithOptions(t, Options{Client: &kataclient.Client{}, ProjectID: 42, ProjectName: "spoke-project", Actor: "example-agent", Version: "test-version", StorageAdmin: admin})
+	tools, err = with.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+	require.Contains(t, toolNames(tools.Tools), "kata.storage_export")
+	require.Contains(t, toolNames(tools.Tools), "kata.storage_import")
+	for _, tool := range tools.Tools {
+		if tool.Name != "kata.storage_export" {
+			continue
+		}
+		properties := schemaObject(t, tool.InputSchema)["properties"].(map[string]any)
+		require.Contains(t, properties, "force")
+		require.Contains(t, properties, "confirm")
+	}
+}
+
+func TestStorageExportIncludesDeletedByDefault(t *testing.T) {
+	require.True(t, StorageExportInput{}.includeDeleted())
+	include := true
+	require.True(t, (StorageExportInput{IncludeDeleted: &include}).includeDeleted())
+	include = false
+	require.False(t, (StorageExportInput{IncludeDeleted: &include}).includeDeleted())
+}
+
+func toolNames(tools []*sdkmcp.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}

--- a/internal/mcp/sync.go
+++ b/internal/mcp/sync.go
@@ -85,6 +85,13 @@ func (h toolHandlers) syncUpdate(ctx context.Context, _ *sdkmcp.CallToolRequest,
 	var response *generated.IssueSyncBody
 	switch input.Action {
 	case "enable":
+		// Enabling sync selects which external repository the daemon's
+		// globally configured credentials read, so it stays a daemon-wide
+		// operator action. Scoped sessions may only disable or run the
+		// operator-configured binding.
+		if h.options.Scope.Mode() != ScopeAll {
+			return nil, SyncStatusOutput{}, errors.New("enabling issue synchronization requires the --all-projects daemon-wide scope; scoped MCP can only disable or run the operator-configured binding")
+		}
 		response, err = h.options.Client.EnableIssueSync(ctx, &generated.EnableIssueSyncRequestOptions{PathParams: &generated.EnableIssueSyncPath{ProjectID: project.ID, Provider: provider}, Body: &generated.EnableIssueSyncBody{Config: input.Config, Interval: optionalString(input.Interval), IntervalSeconds: input.IntervalSeconds}})
 	case "disable":
 		empty := generated.DisableIssueSyncBody{}

--- a/internal/mcp/sync.go
+++ b/internal/mcp/sync.go
@@ -62,7 +62,7 @@ type SyncOnceOutput struct {
 func registerSyncTools(server *sdkmcp.Server, handlers toolHandlers) {
 	addTool(server, "kata.sync_status", "Sync status", "Read issue synchronization state without returning credentials.", toolHints(true, false, true), handlers.syncStatus)
 	addTool(server, "kata.sync_update", "Update sync", "Enable or disable issue synchronization for one project.", toolHints(false, true, true), handlers.syncUpdate)
-	addTool(server, "kata.sync_once", "Run sync", "Run one issue synchronization pass; imported changes overwrite synced issue fields.", toolHints(false, true, true), handlers.syncOnce)
+	addTool(server, "kata.sync_once", "Run sync", "Run one issue synchronization pass; imported changes overwrite synced issue fields.", nonIdempotent(toolHints(false, true, true)), handlers.syncOnce)
 }
 
 func (h toolHandlers) syncStatus(ctx context.Context, _ *sdkmcp.CallToolRequest, input SyncStatusInput) (*sdkmcp.CallToolResult, SyncStatusOutput, error) {

--- a/internal/mcp/sync.go
+++ b/internal/mcp/sync.go
@@ -111,7 +111,8 @@ func (h toolHandlers) syncOnce(ctx context.Context, _ *sdkmcp.CallToolRequest, i
 		return nil, SyncOnceOutput{}, err
 	}
 	empty := generated.RunIssueSyncOnceBody{}
-	response, err := h.options.Client.RunIssueSyncOnce(ctx, &generated.RunIssueSyncOnceRequestOptions{PathParams: &generated.RunIssueSyncOncePath{ProjectID: project.ID, Provider: provider}, Body: &empty})
+	longRunning := h.withLongRunningClient()
+	response, err := longRunning.options.Client.RunIssueSyncOnce(ctx, &generated.RunIssueSyncOnceRequestOptions{PathParams: &generated.RunIssueSyncOncePath{ProjectID: project.ID, Provider: provider}, Body: &empty})
 	if err != nil {
 		return nil, SyncOnceOutput{}, err
 	}

--- a/internal/mcp/sync.go
+++ b/internal/mcp/sync.go
@@ -1,0 +1,137 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// SyncStatusInput selects an issue synchronization binding.
+type SyncStatusInput struct {
+	Project  string `json:"project,omitempty"`
+	Provider string `json:"provider,omitempty"`
+}
+
+// SyncBindingSummary is a credential-free synchronization binding.
+type SyncBindingSummary struct {
+	ID              int64  `json:"id"`
+	ProjectID       int64  `json:"project_id"`
+	Provider        string `json:"provider"`
+	SourceKey       string `json:"source_key"`
+	RemoteID        string `json:"remote_id"`
+	DisplayName     string `json:"display_name"`
+	Enabled         bool   `json:"enabled"`
+	IntervalSeconds int64  `json:"interval_seconds"`
+}
+
+// SyncStatusOutput reports a synchronization binding and run state.
+type SyncStatusOutput struct {
+	Project ProjectIdentity              `json:"project"`
+	Binding *SyncBindingSummary          `json:"binding,omitempty"`
+	Status  generated.IssueSyncStatusOut `json:"status"`
+}
+
+// SyncUpdateInput enables or disables issue synchronization.
+type SyncUpdateInput struct {
+	Project         string         `json:"project,omitempty"`
+	Provider        string         `json:"provider,omitempty"`
+	Action          string         `json:"action"`
+	Config          map[string]any `json:"config,omitempty"`
+	Interval        string         `json:"interval,omitempty"`
+	IntervalSeconds *int64         `json:"interval_seconds,omitempty"`
+}
+
+// SyncOnceInput selects a synchronization pass.
+type SyncOnceInput struct {
+	Project  string `json:"project,omitempty"`
+	Provider string `json:"provider,omitempty"`
+}
+
+// SyncOnceOutput reports one completed synchronization pass.
+type SyncOnceOutput struct {
+	Project ProjectIdentity              `json:"project"`
+	Binding SyncBindingSummary           `json:"binding"`
+	Import  generated.ImportBatchResult  `json:"import"`
+	Status  generated.IssueSyncStatusOut `json:"status"`
+}
+
+func registerSyncTools(server *sdkmcp.Server, handlers toolHandlers) {
+	addTool(server, "kata.sync_status", "Sync status", "Read issue synchronization state without returning credentials.", toolHints(true, false, true), handlers.syncStatus)
+	addTool(server, "kata.sync_update", "Update sync", "Enable or disable issue synchronization for one project.", toolHints(false, true, true), handlers.syncUpdate)
+	addTool(server, "kata.sync_once", "Run sync", "Run one issue synchronization pass.", toolHints(false, false, true), handlers.syncOnce)
+}
+
+func (h toolHandlers) syncStatus(ctx context.Context, _ *sdkmcp.CallToolRequest, input SyncStatusInput) (*sdkmcp.CallToolResult, SyncStatusOutput, error) {
+	project, provider, err := h.syncTarget(ctx, input.Project, input.Provider)
+	if err != nil {
+		return nil, SyncStatusOutput{}, err
+	}
+	response, err := h.options.Client.GetIssueSyncStatus(ctx, &generated.GetIssueSyncStatusRequestOptions{PathParams: &generated.GetIssueSyncStatusPath{ProjectID: project.ID, Provider: provider}})
+	if err != nil {
+		return nil, SyncStatusOutput{}, err
+	}
+	return successResult(), syncStatusOutput(project, response), nil
+}
+
+func (h toolHandlers) syncUpdate(ctx context.Context, _ *sdkmcp.CallToolRequest, input SyncUpdateInput) (*sdkmcp.CallToolResult, SyncStatusOutput, error) {
+	project, provider, err := h.syncTarget(ctx, input.Project, input.Provider)
+	if err != nil {
+		return nil, SyncStatusOutput{}, err
+	}
+	var response *generated.IssueSyncBody
+	switch input.Action {
+	case "enable":
+		response, err = h.options.Client.EnableIssueSync(ctx, &generated.EnableIssueSyncRequestOptions{PathParams: &generated.EnableIssueSyncPath{ProjectID: project.ID, Provider: provider}, Body: &generated.EnableIssueSyncBody{Config: input.Config, Interval: optionalString(input.Interval), IntervalSeconds: input.IntervalSeconds}})
+	case "disable":
+		empty := generated.DisableIssueSyncBody{}
+		response, err = h.options.Client.DisableIssueSync(ctx, &generated.DisableIssueSyncRequestOptions{PathParams: &generated.DisableIssueSyncPath{ProjectID: project.ID, Provider: provider}, Body: &empty})
+	default:
+		return nil, SyncStatusOutput{}, errors.New("action must be enable or disable")
+	}
+	if err != nil {
+		return nil, SyncStatusOutput{}, err
+	}
+	return successResult(), syncStatusOutput(project, response), nil
+}
+
+func (h toolHandlers) syncOnce(ctx context.Context, _ *sdkmcp.CallToolRequest, input SyncOnceInput) (*sdkmcp.CallToolResult, SyncOnceOutput, error) {
+	project, provider, err := h.syncTarget(ctx, input.Project, input.Provider)
+	if err != nil {
+		return nil, SyncOnceOutput{}, err
+	}
+	empty := generated.RunIssueSyncOnceBody{}
+	response, err := h.options.Client.RunIssueSyncOnce(ctx, &generated.RunIssueSyncOnceRequestOptions{PathParams: &generated.RunIssueSyncOncePath{ProjectID: project.ID, Provider: provider}, Body: &empty})
+	if err != nil {
+		return nil, SyncOnceOutput{}, err
+	}
+	return successResult(), SyncOnceOutput{Project: project, Binding: syncBinding(response.Binding), Import: response.Import, Status: response.Status}, nil
+}
+
+func (h toolHandlers) syncTarget(ctx context.Context, projectName, provider string) (ProjectIdentity, string, error) {
+	project, err := h.options.Scope.Project(ctx, h.options.Client, projectName, false)
+	if err != nil {
+		return ProjectIdentity{}, "", err
+	}
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		provider = "github"
+	}
+	return project, provider, nil
+}
+
+func syncStatusOutput(project ProjectIdentity, body *generated.IssueSyncBody) SyncStatusOutput {
+	output := SyncStatusOutput{Project: project, Status: body.Status}
+	if body.Binding != nil {
+		binding := syncBinding(*body.Binding)
+		output.Binding = &binding
+	}
+	return output
+}
+
+func syncBinding(binding generated.IssueSyncBindingOut) SyncBindingSummary {
+	return SyncBindingSummary{ID: binding.ID, ProjectID: binding.ProjectID, Provider: binding.Provider, SourceKey: binding.SourceKey, RemoteID: binding.RemoteID, DisplayName: binding.DisplayName, Enabled: binding.Enabled, IntervalSeconds: binding.IntervalSeconds}
+}

--- a/internal/mcp/sync.go
+++ b/internal/mcp/sync.go
@@ -62,7 +62,7 @@ type SyncOnceOutput struct {
 func registerSyncTools(server *sdkmcp.Server, handlers toolHandlers) {
 	addTool(server, "kata.sync_status", "Sync status", "Read issue synchronization state without returning credentials.", toolHints(true, false, true), handlers.syncStatus)
 	addTool(server, "kata.sync_update", "Update sync", "Enable or disable issue synchronization for one project.", toolHints(false, true, true), handlers.syncUpdate)
-	addTool(server, "kata.sync_once", "Run sync", "Run one issue synchronization pass.", toolHints(false, false, true), handlers.syncOnce)
+	addTool(server, "kata.sync_once", "Run sync", "Run one issue synchronization pass; imported changes overwrite synced issue fields.", toolHints(false, true, true), handlers.syncOnce)
 }
 
 func (h toolHandlers) syncStatus(ctx context.Context, _ *sdkmcp.CallToolRequest, input SyncStatusInput) (*sdkmcp.CallToolResult, SyncStatusOutput, error) {

--- a/internal/mcp/tokens.go
+++ b/internal/mcp/tokens.go
@@ -1,0 +1,130 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// TokensInput requests redacted token records.
+type TokensInput struct{}
+
+// TokenSummary is a secret-free token record.
+type TokenSummary struct {
+	ID         int64  `json:"id"`
+	Actor      string `json:"actor"`
+	Name       string `json:"name,omitempty"`
+	CreatedAt  string `json:"created_at"`
+	LastUsedAt string `json:"last_used_at,omitempty"`
+	RevokedAt  string `json:"revoked_at,omitempty"`
+}
+
+// TokensOutput contains redacted token records.
+type TokensOutput struct {
+	Tokens []TokenSummary `json:"tokens"`
+}
+
+// TokenCreateInput identifies the actor subject for a new token.
+type TokenCreateInput struct {
+	TokenActor string `json:"token_actor"`
+	Name       string `json:"name,omitempty"`
+}
+
+// TokenCreateOutput returns the one-time plaintext and its record.
+type TokenCreateOutput struct {
+	Token  string       `json:"token"`
+	Record TokenSummary `json:"record"`
+}
+
+// TokenRevokeInput selects a token record to revoke.
+type TokenRevokeInput struct {
+	ID int64 `json:"id"`
+}
+
+// TokenRevokeOutput reports the revoked token record.
+type TokenRevokeOutput struct {
+	Record TokenSummary  `json:"record"`
+	Event  *EventSummary `json:"event,omitempty"`
+}
+
+func registerTokenTools(server *sdkmcp.Server, handlers toolHandlers) {
+	read := toolHints(true, false, false)
+	mutating := toolHints(false, true, false)
+	additive := toolHints(false, false, false)
+	addTool(server, "kata.token_create", "Create token", "Create a daemon token; the plaintext appears only in this result.", additive, handlers.tokenCreate)
+	addTool(server, "kata.token_revoke", "Revoke token", "Revoke one daemon token by ID.", mutating, handlers.tokenRevoke)
+	addTool(server, "kata.tokens", "List tokens", "List redacted daemon token records without secrets or hashes.", read, handlers.tokens)
+}
+
+func (h toolHandlers) tokens(ctx context.Context, _ *sdkmcp.CallToolRequest, _ TokensInput) (*sdkmcp.CallToolResult, TokensOutput, error) {
+	if err := h.requireDaemonWideScope("token administration"); err != nil {
+		return nil, TokensOutput{}, err
+	}
+	response, err := h.options.Client.ListTokens(ctx)
+	if err != nil {
+		return nil, TokensOutput{}, err
+	}
+	tokens := make([]TokenSummary, 0, len(response.Tokens))
+	for _, token := range response.Tokens {
+		tokens = append(tokens, tokenSummary(token))
+	}
+	return successResult(), TokensOutput{Tokens: tokens}, nil
+}
+
+func (h toolHandlers) tokenCreate(ctx context.Context, _ *sdkmcp.CallToolRequest, input TokenCreateInput) (*sdkmcp.CallToolResult, TokenCreateOutput, error) {
+	if err := h.requireDaemonWideScope("token administration"); err != nil {
+		return nil, TokenCreateOutput{}, err
+	}
+	actor := strings.TrimSpace(input.TokenActor)
+	if actor == "" {
+		return nil, TokenCreateOutput{}, errors.New("token_actor is required")
+	}
+	response, err := h.options.Client.CreateToken(ctx, &generated.CreateTokenRequestOptions{Body: &generated.CreateTokenBody{Actor: actor, Name: optionalString(input.Name)}})
+	if err != nil {
+		return nil, TokenCreateOutput{}, err
+	}
+	return successResult(), TokenCreateOutput{Token: response.Plaintext, Record: tokenSummary(response.Token)}, nil
+}
+
+func (h toolHandlers) tokenRevoke(ctx context.Context, _ *sdkmcp.CallToolRequest, input TokenRevokeInput) (*sdkmcp.CallToolResult, TokenRevokeOutput, error) {
+	if err := h.requireDaemonWideScope("token administration"); err != nil {
+		return nil, TokenRevokeOutput{}, err
+	}
+	if input.ID <= 0 {
+		return nil, TokenRevokeOutput{}, errors.New("id must be positive")
+	}
+	response, err := h.options.Client.RevokeToken(ctx, &generated.RevokeTokenRequestOptions{PathParams: &generated.RevokeTokenPath{ID: input.ID}})
+	if err != nil {
+		return nil, TokenRevokeOutput{}, err
+	}
+	return successResult(), TokenRevokeOutput{Record: tokenSummary(response.Token), Event: eventSummary(&response.Event)}, nil
+}
+
+func (h toolHandlers) requireDaemonWideScope(operation string) error {
+	if !h.options.EnableTokenAdmin {
+		return fmt.Errorf("%s requires an explicit startup capability", operation)
+	}
+	if h.options.Scope.Mode() != ScopeAll {
+		return fmt.Errorf("%s requires daemon-wide scope", operation)
+	}
+	return nil
+}
+
+func tokenSummary(token generated.TokenOut) TokenSummary {
+	result := TokenSummary{ID: token.ID, Actor: token.Actor, CreatedAt: formatTime(token.CreatedAt)}
+	if token.Name != nil {
+		result.Name = *token.Name
+	}
+	if token.LastUsedAt != nil {
+		result.LastUsedAt = formatTime(*token.LastUsedAt)
+	}
+	if token.RevokedAt != nil {
+		result.RevokedAt = formatTime(*token.RevokedAt)
+	}
+	return result
+}

--- a/internal/mcp/tokens.go
+++ b/internal/mcp/tokens.go
@@ -56,7 +56,7 @@ func registerTokenTools(server *sdkmcp.Server, handlers toolHandlers) {
 	read := toolHints(true, false, false)
 	mutating := toolHints(false, true, false)
 	additive := toolHints(false, false, false)
-	addTool(server, "kata.token_create", "Create token", "Create a daemon token; the plaintext appears only in this result.", additive, handlers.tokenCreate)
+	addTool(server, "kata.token_create", "Create token", "Create a daemon token; the plaintext appears only in this result.", nonIdempotent(additive), handlers.tokenCreate)
 	addTool(server, "kata.token_revoke", "Revoke token", "Revoke one daemon token by ID.", mutating, handlers.tokenRevoke)
 	addTool(server, "kata.tokens", "List tokens", "List redacted daemon token records without secrets or hashes.", read, handlers.tokens)
 }

--- a/internal/mcp/wire_test.go
+++ b/internal/mcp/wire_test.go
@@ -34,7 +34,7 @@ func TestWireDiscoveryPublishesNegotiatedToolsCapability(t *testing.T) {
 	require.EqualValues(t, 5*time.Minute.Milliseconds(), result["ttlMs"])
 	require.NotEmpty(t, result["resultType"])
 	capabilities := result["capabilities"].(map[string]any)
-	require.Equal(t, map[string]any{"tools": map[string]any{}}, capabilities)
+	require.Equal(t, map[string]any{"tools": map[string]any{"listChanged": true}}, capabilities)
 	meta := result["_meta"].(map[string]any)
 	serverInfo := meta["io.modelcontextprotocol/serverInfo"].(map[string]any)
 	require.Equal(t, "kata", serverInfo["name"])
@@ -124,6 +124,12 @@ func TestWireCancellationSuppressesLateToolResponse(t *testing.T) {
 	apiClient, err := kataclient.NewWithHTTPClient(daemon.URL, daemon.Client())
 	require.NoError(t, err)
 	connection, reader := rawServerConnectionWithClient(t, apiClient)
+	writeWireRequest(t, connection, 0, "tools/call", map[string]any{
+		"name": "kata.load_issue_discovery", "arguments": map[string]any{}, "_meta": currentMeta(),
+	})
+	loadResponse := readWireResponse(t, reader)
+	require.Nil(t, loadResponse.Error)
+	require.EqualValues(t, 0, loadResponse.ID)
 
 	writeWireRequest(t, connection, 1, "tools/call", map[string]any{
 		"name": "kata.search", "arguments": map[string]any{"query": "slow"}, "_meta": currentMeta(),

--- a/internal/storageadmin/storage.go
+++ b/internal/storageadmin/storage.go
@@ -1,0 +1,690 @@
+// Package storageadmin implements explicitly enabled, root-contained JSONL
+// export and restore operations for the MCP server.
+package storageadmin
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/db/storeopen"
+	"go.kenn.io/kata/internal/jsonl"
+)
+
+// Config defines the storage root, active source, and approved targets.
+type Config struct {
+	Root      string
+	SourceDSN string
+	Targets   map[string]string
+}
+
+// Admin enforces the startup storage boundary.
+type Admin struct {
+	root      string
+	files     *os.Root
+	sourceDSN string
+	targets   map[string]string
+}
+
+// ExportOptions selects a root-contained artifact and optional project.
+type ExportOptions struct {
+	Artifact       string
+	ProjectID      int64
+	IncludeDeleted bool
+	Force          bool
+	Confirm        string
+}
+
+// ExportResult reports an installed JSONL artifact.
+type ExportResult struct {
+	Artifact string `json:"artifact"`
+	Bytes    int64  `json:"bytes"`
+}
+
+// ImportOptions selects an artifact and approved restore target.
+type ImportOptions struct {
+	Artifact    string
+	Target      string
+	Force       bool
+	Confirm     string
+	NewInstance bool
+}
+
+// ImportResult reports a completed JSONL restore.
+type ImportResult struct {
+	Artifact string `json:"artifact"`
+	Target   string `json:"target"`
+	Backend  string `json:"backend"`
+}
+
+// New validates and fixes the storage administration boundary.
+func New(config Config) (*Admin, error) {
+	root := strings.TrimSpace(config.Root)
+	if root == "" {
+		return nil, errors.New("storage root is required")
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve storage root: %w", err)
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return nil, fmt.Errorf("resolve storage root: %w", err)
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return nil, fmt.Errorf("stat storage root: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, errors.New("storage root must be a directory")
+	}
+	files, err := os.OpenRoot(canonical)
+	if err != nil {
+		return nil, fmt.Errorf("open storage root: %w", err)
+	}
+	targets := make(map[string]string, len(config.Targets))
+	for rawAlias, rawTarget := range config.Targets {
+		alias := strings.TrimSpace(rawAlias)
+		target := strings.TrimSpace(rawTarget)
+		if alias == "" || target == "" {
+			_ = files.Close()
+			return nil, errors.New("storage target aliases and values must not be empty")
+		}
+		if _, exists := targets[alias]; exists {
+			_ = files.Close()
+			return nil, fmt.Errorf("duplicate storage target alias %q", alias)
+		}
+		targets[alias] = target
+	}
+	admin := &Admin{root: canonical, files: files, sourceDSN: strings.TrimSpace(config.SourceDSN), targets: targets}
+	if err := admin.validateSQLiteTargets(); err != nil {
+		_ = files.Close()
+		return nil, err
+	}
+	return admin, nil
+}
+
+// Close releases the descriptor that anchors storage operations to the
+// configured root.
+func (a *Admin) Close() error {
+	if a == nil || a.files == nil {
+		return nil
+	}
+	return a.files.Close()
+}
+
+// ResolveArtifact resolves a safe relative artifact under the configured root.
+func (a *Admin) ResolveArtifact(name string, mustExist bool) (string, error) {
+	name, err := a.resolveArtifactName(name, mustExist)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(a.root, name), nil
+}
+
+func (a *Admin) resolveArtifactName(name string, mustExist bool) (string, error) {
+	if a == nil || a.root == "" || a.files == nil {
+		return "", errors.New("storage administration is not configured")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", errors.New("artifact is required")
+	}
+	if filepath.IsAbs(name) {
+		return "", errors.New("artifact must be relative to the storage root")
+	}
+	clean := filepath.Clean(name)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", errors.New("artifact escapes the storage root")
+	}
+	current := "."
+	parts := strings.Split(clean, string(filepath.Separator))
+	for index, part := range parts {
+		current = filepath.Join(current, part)
+		info, statErr := a.files.Lstat(current)
+		if errors.Is(statErr, os.ErrNotExist) {
+			if mustExist || index < len(parts)-1 {
+				return "", fmt.Errorf("artifact path does not exist: %s", filepath.Join(parts[:index+1]...))
+			}
+			continue
+		}
+		if statErr != nil {
+			return "", fmt.Errorf("inspect artifact path: %w", statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", errors.New("artifact path must not contain a symbolic link")
+		}
+		if index < len(parts)-1 && !info.IsDir() {
+			return "", errors.New("artifact parent must be a directory")
+		}
+		if index == len(parts)-1 && !info.Mode().IsRegular() {
+			return "", errors.New("artifact must be a regular file")
+		}
+	}
+	return clean, nil
+}
+
+// Export writes an atomic JSONL artifact from the active storage.
+func (a *Admin) Export(ctx context.Context, options ExportOptions) (ExportResult, error) {
+	if a.sourceDSN == "" {
+		return ExportResult{}, errors.New("active storage source is not configured")
+	}
+	outputName, err := a.resolveArtifactName(options.Artifact, false)
+	if err != nil {
+		return ExportResult{}, err
+	}
+	output := filepath.Join(a.root, outputName)
+	protected, err := a.protectedExportPaths()
+	if err != nil {
+		return ExportResult{}, err
+	}
+	caseInsensitive := runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+	for _, path := range protected {
+		if storagePathsEquivalent(output, path, caseInsensitive) {
+			return ExportResult{}, errors.New("export artifact is a protected storage path")
+		}
+	}
+	_, statErr := a.files.Lstat(outputName)
+	exists := statErr == nil
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return ExportResult{}, fmt.Errorf("inspect export artifact: %w", statErr)
+	}
+	if exists && !options.Force {
+		return ExportResult{}, errors.New("export artifact exists; force and exact confirmation are required")
+	}
+	if exists {
+		expected := "OVERWRITE ARTIFACT " + filepath.Clean(strings.TrimSpace(options.Artifact))
+		if options.Confirm != expected {
+			return ExportResult{}, fmt.Errorf("confirm must equal %q", expected)
+		}
+	}
+	store, err := storeopen.OpenReadOnly(ctx, a.sourceDSN)
+	if err != nil {
+		return ExportResult{}, err
+	}
+	defer func() { _ = store.Close() }()
+	file, temporaryName, err := a.createTempArtifact(filepath.Dir(outputName), filepath.Base(outputName))
+	if err != nil {
+		return ExportResult{}, fmt.Errorf("create export artifact: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = file.Close()
+			_ = a.files.Remove(temporaryName)
+		}
+	}()
+	writer := bufio.NewWriter(file)
+	if err := jsonl.Export(ctx, store, writer, jsonl.ExportOptions{ProjectID: options.ProjectID, IncludeDeleted: options.IncludeDeleted}); err != nil {
+		return ExportResult{}, err
+	}
+	if err := writer.Flush(); err != nil {
+		return ExportResult{}, fmt.Errorf("flush export artifact: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return ExportResult{}, fmt.Errorf("sync export artifact: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return ExportResult{}, fmt.Errorf("close export artifact: %w", err)
+	}
+	if exists {
+		if err := a.files.Rename(temporaryName, outputName); err != nil {
+			return ExportResult{}, fmt.Errorf("replace export artifact: %w", err)
+		}
+	} else {
+		if err := a.files.Link(temporaryName, outputName); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				return ExportResult{}, errors.New("export artifact appeared concurrently; force and exact confirmation are required")
+			}
+			return ExportResult{}, fmt.Errorf("install export artifact without replacement: %w", err)
+		}
+		if err := a.files.Remove(temporaryName); err != nil {
+			return ExportResult{}, fmt.Errorf("remove temporary export artifact: %w", err)
+		}
+	}
+	committed = true
+	info, err := a.files.Stat(outputName)
+	if err != nil {
+		return ExportResult{}, err
+	}
+	return ExportResult{Artifact: options.Artifact, Bytes: info.Size()}, nil
+}
+
+func (a *Admin) createTempArtifact(directory, base string) (*os.File, string, error) {
+	for range 100 {
+		name, err := temporaryArtifactName(directory, base)
+		if err != nil {
+			return nil, "", err
+		}
+		file, err := a.files.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return nil, "", err
+		}
+		return file, name, nil
+	}
+	return nil, "", errors.New("create temporary artifact: name collisions exhausted")
+}
+
+func temporaryArtifactName(directory, base string) (string, error) {
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate temporary artifact name: %w", err)
+	}
+	return filepath.Join(directory, "."+base+".tmp-"+hex.EncodeToString(random)), nil
+}
+
+func (a *Admin) stageSQLiteSet(source, directory, base string) (string, error) {
+	suffixes := []string{"", "-wal", "-shm", "-journal"}
+	for range 100 {
+		name, err := temporaryArtifactName(directory, base)
+		if err != nil {
+			return "", err
+		}
+		staged := false
+		collision := false
+		created := make([]string, 0, len(suffixes))
+		cleanupCreated := func() {
+			for _, suffix := range created {
+				_ = a.files.Remove(name + suffix)
+			}
+		}
+		for _, suffix := range suffixes {
+			sourcePath := source + suffix
+			sourceFile, openErr := os.Open(sourcePath) //nolint:gosec // source is a private temporary directory
+			if errors.Is(openErr, os.ErrNotExist) {
+				if suffix == "" {
+					return "", errors.New("imported SQLite file set has no main database")
+				}
+				continue
+			}
+			if openErr != nil {
+				cleanupCreated()
+				return "", openErr
+			}
+			destination, createErr := a.files.OpenFile(name+suffix, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+			if errors.Is(createErr, os.ErrExist) {
+				_ = sourceFile.Close()
+				collision = true
+				break
+			}
+			if createErr != nil {
+				_ = sourceFile.Close()
+				cleanupCreated()
+				return "", createErr
+			}
+			created = append(created, suffix)
+			_, copyErr := io.Copy(destination, sourceFile)
+			syncErr := destination.Sync()
+			closeDestinationErr := destination.Close()
+			closeSourceErr := sourceFile.Close()
+			if copyErr != nil || syncErr != nil || closeDestinationErr != nil || closeSourceErr != nil {
+				cleanupCreated()
+				return "", errors.Join(copyErr, syncErr, closeDestinationErr, closeSourceErr)
+			}
+			staged = true
+		}
+		if collision {
+			cleanupCreated()
+			continue
+		}
+		if staged {
+			return name, nil
+		}
+	}
+	return "", errors.New("stage imported SQLite file set: name collisions exhausted")
+}
+
+func (a *Admin) protectedExportPaths() ([]string, error) {
+	protected := make([]string, 0, 4*(len(a.targets)+1))
+	addSQLiteSet := func(path string) {
+		path = filepath.Clean(path)
+		for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+			protected = append(protected, path+suffix)
+		}
+	}
+	active, sqlite, err := a.activeSQLitePath()
+	if err != nil {
+		return nil, err
+	}
+	if sqlite {
+		addSQLiteSet(active)
+	}
+	for alias, targetValue := range a.targets {
+		targetBackend, targetErr := storeopen.BackendForDSN(targetValue)
+		if targetErr != nil {
+			return nil, fmt.Errorf("resolve storage target %q: %w", alias, targetErr)
+		}
+		if targetBackend != storeopen.BackendSQLite {
+			continue
+		}
+		targetName, targetErr := sqliteTargetName(targetValue)
+		if targetErr != nil {
+			return nil, fmt.Errorf("resolve storage target %q: %w", alias, targetErr)
+		}
+		target, targetErr := a.ResolveArtifact(targetName, false)
+		if targetErr != nil {
+			return nil, fmt.Errorf("resolve storage target %q: %w", alias, targetErr)
+		}
+		addSQLiteSet(target)
+	}
+	return protected, nil
+}
+
+func sqliteTargetName(value string) (string, error) {
+	identity, err := config.CanonicalDSNIdentity(value)
+	if err != nil {
+		return "", err
+	}
+	return identity, nil
+}
+
+func storagePathsEquivalent(left, right string, caseInsensitive bool) bool {
+	left = filepath.Clean(left)
+	right = filepath.Clean(right)
+	if left == right || caseInsensitive && strings.EqualFold(left, right) {
+		return true
+	}
+	leftInfo, leftErr := os.Stat(left)
+	rightInfo, rightErr := os.Stat(right)
+	return leftErr == nil && rightErr == nil && os.SameFile(leftInfo, rightInfo)
+}
+
+func (a *Admin) activeSQLitePath() (string, bool, error) {
+	backend, err := storeopen.BackendForDSN(a.sourceDSN)
+	if err != nil {
+		return "", false, err
+	}
+	if backend != storeopen.BackendSQLite {
+		return "", false, nil
+	}
+	identity, err := config.CanonicalDSNIdentity(a.sourceDSN)
+	if err != nil {
+		return "", false, err
+	}
+	absolute, err := filepath.Abs(identity)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve active storage path: %w", err)
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err == nil {
+		absolute = canonical
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", false, fmt.Errorf("canonicalize active storage path: %w", err)
+	}
+	return filepath.Clean(absolute), true, nil
+}
+
+func (a *Admin) validateSQLiteTargets() error {
+	active, sourceIsSQLite, err := a.activeSQLitePath()
+	if err != nil || !sourceIsSQLite {
+		return err
+	}
+	caseInsensitive := runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+	for alias, targetValue := range a.targets {
+		backend, backendErr := storeopen.BackendForDSN(targetValue)
+		if backendErr != nil {
+			return fmt.Errorf("resolve storage target %q: %w", alias, backendErr)
+		}
+		if backend != storeopen.BackendSQLite {
+			continue
+		}
+		targetName, targetErr := sqliteTargetName(targetValue)
+		if targetErr != nil {
+			return fmt.Errorf("resolve storage target %q: %w", alias, targetErr)
+		}
+		target, targetErr := a.ResolveArtifact(targetName, false)
+		if targetErr != nil {
+			return fmt.Errorf("resolve storage target %q: %w", alias, targetErr)
+		}
+		if sqliteFileSetsOverlap(target, active, caseInsensitive) {
+			return fmt.Errorf("storage target %q overlaps active SQLite storage", alias)
+		}
+	}
+	return nil
+}
+
+func sqliteFileSetsOverlap(left, right string, caseInsensitive bool) bool {
+	suffixes := []string{"", "-wal", "-shm", "-journal"}
+	for _, leftSuffix := range suffixes {
+		for _, rightSuffix := range suffixes {
+			if storagePathsEquivalent(left+leftSuffix, right+rightSuffix, caseInsensitive) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Import restores a JSONL artifact into an approved target.
+func (a *Admin) Import(ctx context.Context, options ImportOptions) (ImportResult, error) {
+	inputName, err := a.resolveArtifactName(options.Artifact, true)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	input, err := a.files.Open(inputName)
+	if err != nil {
+		return ImportResult{}, fmt.Errorf("open import artifact: %w", err)
+	}
+	defer func() { _ = input.Close() }()
+	targetValue, ok := a.targets[strings.TrimSpace(options.Target)]
+	if !ok {
+		return ImportResult{}, fmt.Errorf("storage target alias %q is not configured", options.Target)
+	}
+	backend, err := storeopen.BackendForDSN(targetValue)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	if backend == storeopen.BackendPostgres {
+		if config.DBHash(a.sourceDSN) == config.DBHash(targetValue) {
+			return ImportResult{}, errors.New("storage import target must differ from the active daemon storage")
+		}
+		if options.Force {
+			return ImportResult{}, errors.New("force replacement of PostgreSQL storage is not available through MCP")
+		}
+		return a.importFresh(ctx, input, targetValue, options, "postgres")
+	}
+	targetName, err := sqliteTargetName(targetValue)
+	if err != nil {
+		return ImportResult{}, fmt.Errorf("resolve storage target %q: %w", options.Target, err)
+	}
+	targetName, err = a.resolveArtifactName(targetName, false)
+	if err != nil {
+		return ImportResult{}, fmt.Errorf("resolve storage target %q: %w", options.Target, err)
+	}
+	target := filepath.Join(a.root, targetName)
+	active, sourceIsSQLite, activeErr := a.activeSQLitePath()
+	if activeErr != nil {
+		return ImportResult{}, activeErr
+	}
+	caseInsensitive := runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+	if (sourceIsSQLite && sqliteFileSetsOverlap(target, active, caseInsensitive)) ||
+		config.DBHash(a.sourceDSN) == config.DBHash(target) {
+		return ImportResult{}, errors.New("storage import target must differ from the active daemon storage")
+	}
+	_, statErr := a.files.Lstat(targetName)
+	exists := statErr == nil
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return ImportResult{}, statErr
+	}
+	if exists && !options.Force {
+		return ImportResult{}, errors.New("storage target exists; force and exact confirmation are required")
+	}
+	if options.Force {
+		expected := "REPLACE STORAGE " + options.Target
+		if options.Confirm != expected {
+			return ImportResult{}, fmt.Errorf("confirm must equal %q", expected)
+		}
+	}
+	privateDirectory, err := os.MkdirTemp("", "kata-mcp-import-*")
+	if err != nil {
+		return ImportResult{}, err
+	}
+	defer func() { _ = os.RemoveAll(privateDirectory) }() //nolint:gosec // directory was created above
+	temporary := filepath.Join(privateDirectory, "restore.db")
+	result, err := a.importFresh(ctx, input, temporary, options, "sqlite")
+	if err != nil {
+		return ImportResult{}, err
+	}
+	temporaryName, err := a.stageSQLiteSet(temporary, filepath.Dir(targetName), filepath.Base(targetName)+".import")
+	if err != nil {
+		return ImportResult{}, err
+	}
+	installed := false
+	defer func() {
+		if !installed {
+			_ = a.cleanupSQLiteSet(temporaryName)
+		}
+	}()
+	backupName := targetName + ".mcp-import-backup"
+	if exists {
+		if _, err := a.files.Lstat(backupName); !errors.Is(err, os.ErrNotExist) {
+			return ImportResult{}, errors.New("storage target backup already exists")
+		}
+		if err := a.moveSQLiteSet(targetName, backupName); err != nil {
+			return ImportResult{}, err
+		}
+	}
+	if err := a.moveSQLiteSet(temporaryName, targetName); err != nil {
+		if exists {
+			restoreErr := a.moveSQLiteSet(backupName, targetName)
+			if restoreErr != nil {
+				return ImportResult{}, errors.Join(err, fmt.Errorf(
+					"restore original SQLite target from %s: %w", backupName, restoreErr,
+				))
+			}
+		}
+		return ImportResult{}, err
+	}
+	installed = true
+	if exists {
+		if err := a.cleanupSQLiteSet(backupName); err != nil {
+			return ImportResult{}, fmt.Errorf("replacement succeeded but cleanup of retained backup %s failed: %w", backupName, err)
+		}
+	}
+	result.Target = options.Target
+	return result, nil
+}
+
+func (a *Admin) importFresh(ctx context.Context, input io.Reader, target string, options ImportOptions, backend string) (ImportResult, error) {
+	store, err := storeopen.Open(ctx, target)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	installedFreshPostgres := storeopen.InstalledFreshPostgresSchema(store)
+	instanceUID := store.InstanceUID()
+	if err := jsonl.ImportWithOptions(ctx, input, store, jsonl.ImportOptions{RequireFreshTarget: true, NewInstance: options.NewInstance}); err != nil {
+		closeErr := store.Close()
+		if installedFreshPostgres {
+			cleanupContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+			defer cancel()
+			cleanupErr := storeopen.RemoveFreshPostgresTarget(cleanupContext, target, instanceUID)
+			return ImportResult{}, errors.Join(err, closeErr, cleanupErr)
+		}
+		return ImportResult{}, errors.Join(err, closeErr)
+	}
+	if err := store.Close(); err != nil {
+		return ImportResult{}, err
+	}
+	return ImportResult{Artifact: options.Artifact, Target: options.Target, Backend: backend}, nil
+}
+
+func moveSQLiteSetWithLink(from, to string, link func(string, string) error) error {
+	return moveSQLiteSetWithOps(from, to, sqliteSetOps{
+		lstat:  os.Lstat,
+		link:   link,
+		remove: os.Remove,
+	})
+}
+
+type sqliteSetOps struct {
+	lstat  func(string) (os.FileInfo, error)
+	link   func(string, string) error
+	remove func(string) error
+}
+
+func (a *Admin) moveSQLiteSet(from, to string) error {
+	return moveSQLiteSetWithOps(from, to, sqliteSetOps{
+		lstat:  a.files.Lstat,
+		link:   a.files.Link,
+		remove: a.files.Remove,
+	})
+}
+
+func moveSQLiteSetWithOps(from, to string, operations sqliteSetOps) error {
+	suffixes := []string{"", "-wal", "-shm", "-journal"}
+	sources := make([]string, 0, len(suffixes))
+	for _, suffix := range suffixes {
+		path := from + suffix
+		if _, err := operations.lstat(path); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return err
+		}
+		sources = append(sources, suffix)
+	}
+	if len(sources) == 0 || sources[0] != "" {
+		return errors.New("SQLite file set has no main database")
+	}
+	for _, suffix := range suffixes {
+		if _, err := operations.lstat(to + suffix); err == nil {
+			return fmt.Errorf("SQLite destination already exists: %s", filepath.Base(to+suffix))
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	moved := make([]string, 0, len(sources))
+	rollback := func(cause error) error {
+		errorsOut := []error{cause}
+		for index := len(moved) - 1; index >= 0; index-- {
+			suffix := moved[index]
+			oldPath, newPath := from+suffix, to+suffix
+			if err := operations.link(newPath, oldPath); err != nil {
+				errorsOut = append(errorsOut, fmt.Errorf("restore SQLite source %s: %w", filepath.Base(oldPath), err))
+				continue
+			}
+			if err := operations.remove(newPath); err != nil {
+				errorsOut = append(errorsOut, fmt.Errorf("remove rolled-back SQLite destination %s: %w", filepath.Base(newPath), err))
+			}
+		}
+		return errors.Join(errorsOut...)
+	}
+	for _, suffix := range sources {
+		oldPath, newPath := from+suffix, to+suffix
+		if err := operations.link(oldPath, newPath); err != nil {
+			return rollback(fmt.Errorf("install SQLite file %s without replacement: %w", filepath.Base(newPath), err))
+		}
+		if err := operations.remove(oldPath); err != nil {
+			cleanupErr := operations.remove(newPath)
+			return rollback(errors.Join(
+				fmt.Errorf("remove SQLite source %s: %w", filepath.Base(oldPath), err),
+				cleanupErr,
+			))
+		}
+		moved = append(moved, suffix)
+	}
+	return nil
+}
+
+func (a *Admin) cleanupSQLiteSet(path string) error {
+	var cleanupErrors []error
+	for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+		name := path + suffix
+		if err := a.files.Remove(name); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove SQLite file %s: %w", filepath.Base(name), err))
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}

--- a/internal/storageadmin/storage.go
+++ b/internal/storageadmin/storage.go
@@ -514,6 +514,12 @@ func (a *Admin) Import(ctx context.Context, options ImportOptions) (ImportResult
 		config.DBHash(a.sourceDSN) == config.DBHash(target) {
 		return ImportResult{}, errors.New("storage import target must differ from the active daemon storage")
 	}
+	// Forced replacement moves the target set through a backup and deletes
+	// it; an artifact overlapping the target would destroy the only JSONL
+	// copy under a confirmation that covers target replacement only.
+	if sqliteFileSetsOverlap(target, filepath.Join(a.root, inputName), caseInsensitive) {
+		return ImportResult{}, errors.New("storage import artifact must differ from the SQLite target and its sidecar paths")
+	}
 	_, statErr := a.files.Lstat(targetName)
 	exists := statErr == nil
 	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {

--- a/internal/storageadmin/storage.go
+++ b/internal/storageadmin/storage.go
@@ -585,20 +585,54 @@ func (a *Admin) importFresh(ctx context.Context, input io.Reader, target string,
 	}
 	installedFreshPostgres := storeopen.InstalledFreshPostgresSchema(store)
 	instanceUID := store.InstanceUID()
-	if err := jsonl.ImportWithOptions(ctx, input, store, jsonl.ImportOptions{RequireFreshTarget: true, NewInstance: options.NewInstance}); err != nil {
+	fail := func(importErr error) (ImportResult, error) {
 		closeErr := store.Close()
 		if installedFreshPostgres {
 			cleanupContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 			defer cancel()
 			cleanupErr := storeopen.RemoveFreshPostgresTarget(cleanupContext, target, instanceUID)
-			return ImportResult{}, errors.Join(err, closeErr, cleanupErr)
+			return ImportResult{}, errors.Join(importErr, closeErr, cleanupErr)
 		}
-		return ImportResult{}, errors.Join(err, closeErr)
+		return ImportResult{}, errors.Join(importErr, closeErr)
+	}
+	if backend == "postgres" {
+		// The DSN-hash guard is textual; equivalent DSNs (localhost vs
+		// 127.0.0.1) hash differently, so compare the persisted instance
+		// identity of the opened target with the active source store.
+		sourceUID, sourceErr := a.sourceInstanceUID(ctx)
+		if sourceErr != nil {
+			return fail(sourceErr)
+		}
+		if sourceUID != "" && sourceUID == instanceUID {
+			return fail(errors.New("storage import target must differ from the active daemon storage"))
+		}
+	}
+	if err := jsonl.ImportWithOptions(ctx, input, store, jsonl.ImportOptions{RequireFreshTarget: true, NewInstance: options.NewInstance}); err != nil {
+		return fail(err)
 	}
 	if err := store.Close(); err != nil {
 		return ImportResult{}, err
 	}
 	return ImportResult{Artifact: options.Artifact, Target: options.Target, Backend: backend}, nil
+}
+
+// sourceInstanceUID reads the active daemon storage's persisted instance
+// identity so an import target can be compared by identity, not DSN text.
+func (a *Admin) sourceInstanceUID(ctx context.Context) (string, error) {
+	source, err := storeopen.OpenReadOnly(ctx, a.sourceDSN)
+	if err != nil {
+		return "", fmt.Errorf("open active storage identity: %w", err)
+	}
+	defer func() { _ = source.Close() }()
+	uid := source.InstanceUID()
+	if uid == "" {
+		// A read-only handle may not have cached the identity; a refresh
+		// failure means no persisted identity exists yet.
+		if refreshErr := source.RefreshInstanceUID(ctx); refreshErr == nil {
+			uid = source.InstanceUID()
+		}
+	}
+	return uid, nil
 }
 
 func moveSQLiteSetWithLink(from, to string, link func(string, string) error) error {

--- a/internal/storageadmin/storage.go
+++ b/internal/storageadmin/storage.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/pgstore"
 	"go.kenn.io/kata/internal/db/storeopen"
 	"go.kenn.io/kata/internal/jsonl"
 )
@@ -513,7 +515,29 @@ func (a *Admin) Import(ctx context.Context, options ImportOptions) (ImportResult
 		if options.Force {
 			return ImportResult{}, errors.New("force replacement of PostgreSQL storage is not available through MCP")
 		}
-		return a.importFresh(ctx, input, targetValue, options, "postgres")
+		pgConfig, err := postgresRestoreConfig(ctx)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		// Preflight without mutation: an initialized target is rejected
+		// before any schema work can touch it, and a missing schema is
+		// created under the explicit restore bootstrap configuration
+		// rather than the daemon's ambient schema mode.
+		version, err := pgstore.PeekSchemaVersionWithConfig(ctx, targetValue, pgConfig)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		if version != 0 {
+			same, sameErr := a.targetIsActiveStorage(ctx, targetValue)
+			if sameErr != nil {
+				return ImportResult{}, sameErr
+			}
+			if same {
+				return ImportResult{}, errors.New("storage import target must differ from the active daemon storage")
+			}
+			return ImportResult{}, errors.New("storage target already contains a Kata schema; PostgreSQL restore requires a fresh target")
+		}
+		return a.importFresh(ctx, input, targetValue, options, "postgres", &pgConfig)
 	}
 	targetName, err := sqliteTargetName(targetValue)
 	if err != nil {
@@ -559,7 +583,7 @@ func (a *Admin) Import(ctx context.Context, options ImportOptions) (ImportResult
 	}
 	defer func() { _ = os.RemoveAll(privateDirectory) }() //nolint:gosec // directory was created above
 	temporary := filepath.Join(privateDirectory, "restore.db")
-	result, err := a.importFresh(ctx, input, temporary, options, "sqlite")
+	result, err := a.importFresh(ctx, input, temporary, options, "sqlite", nil)
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -603,8 +627,14 @@ func (a *Admin) Import(ctx context.Context, options ImportOptions) (ImportResult
 	return result, nil
 }
 
-func (a *Admin) importFresh(ctx context.Context, input io.Reader, target string, options ImportOptions, backend string) (ImportResult, error) {
-	store, err := storeopen.Open(ctx, target)
+func (a *Admin) importFresh(ctx context.Context, input io.Reader, target string, options ImportOptions, backend string, pgConfig *pgstore.Config) (ImportResult, error) {
+	var store db.Storage
+	var err error
+	if pgConfig != nil {
+		store, err = pgstore.OpenWithConfig(ctx, target, *pgConfig)
+	} else {
+		store, err = storeopen.Open(ctx, target)
+	}
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -612,25 +642,13 @@ func (a *Admin) importFresh(ctx context.Context, input io.Reader, target string,
 	instanceUID := store.InstanceUID()
 	fail := func(importErr error) (ImportResult, error) {
 		closeErr := store.Close()
-		if installedFreshPostgres {
+		if installedFreshPostgres && pgConfig != nil {
 			cleanupContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 			defer cancel()
-			cleanupErr := storeopen.RemoveFreshPostgresTarget(cleanupContext, target, instanceUID)
+			cleanupErr := pgstore.RemoveFreshSchemaWithConfig(cleanupContext, target, instanceUID, *pgConfig)
 			return ImportResult{}, errors.Join(importErr, closeErr, cleanupErr)
 		}
 		return ImportResult{}, errors.Join(importErr, closeErr)
-	}
-	if backend == "postgres" {
-		// The DSN-hash guard is textual; equivalent DSNs (localhost vs
-		// 127.0.0.1) hash differently, so compare the persisted instance
-		// identity of the opened target with the active source store.
-		sourceUID, sourceErr := a.sourceInstanceUID(ctx)
-		if sourceErr != nil {
-			return fail(sourceErr)
-		}
-		if sourceUID != "" && sourceUID == instanceUID {
-			return fail(errors.New("storage import target must differ from the active daemon storage"))
-		}
 	}
 	if err := jsonl.ImportWithOptions(ctx, input, store, jsonl.ImportOptions{RequireFreshTarget: true, NewInstance: options.NewInstance}); err != nil {
 		return fail(err)
@@ -641,20 +659,51 @@ func (a *Admin) importFresh(ctx context.Context, input io.Reader, target string,
 	return ImportResult{Artifact: options.Artifact, Target: options.Target, Backend: backend}, nil
 }
 
-// sourceInstanceUID reads the active daemon storage's persisted instance
-// identity so an import target can be compared by identity, not DSN text.
-func (a *Admin) sourceInstanceUID(ctx context.Context) (string, error) {
-	source, err := storeopen.OpenReadOnly(ctx, a.sourceDSN)
+// postgresRestoreConfig mirrors the CLI import flow: restore is an explicit
+// schema-owner operation that must prepare a fresh target even when the
+// daemon runtime is validation-only.
+func postgresRestoreConfig(ctx context.Context) (pgstore.Config, error) {
+	storageConfig, err := config.KataPostgresStorageConfig(ctx)
 	if err != nil {
-		return "", fmt.Errorf("open active storage identity: %w", err)
+		return pgstore.Config{}, err
 	}
-	defer func() { _ = source.Close() }()
-	uid := source.InstanceUID()
+	pgConfig := pgstore.ConfigFromValues(
+		storageConfig.Schema, storageConfig.Mode, storageConfig.SchemaOwner,
+		storageConfig.AllowInsecure,
+	)
+	pgConfig.SchemaMode = pgstore.SchemaModeBootstrap
+	return pgConfig, nil
+}
+
+// targetIsActiveStorage compares persisted instance identities so an
+// equivalent DSN spelling of the active database is named as such. Both
+// handles open read-only; nothing is mutated.
+func (a *Admin) targetIsActiveStorage(ctx context.Context, target string) (bool, error) {
+	sourceUID, err := instanceUIDOf(ctx, a.sourceDSN)
+	if err != nil || sourceUID == "" {
+		return false, err
+	}
+	targetUID, err := instanceUIDOf(ctx, target)
+	if err != nil {
+		return false, err
+	}
+	return targetUID != "" && targetUID == sourceUID, nil
+}
+
+// instanceUIDOf reads a storage target's persisted instance identity over a
+// read-only handle.
+func instanceUIDOf(ctx context.Context, dsn string) (string, error) {
+	store, err := storeopen.OpenReadOnly(ctx, dsn)
+	if err != nil {
+		return "", fmt.Errorf("open storage identity: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+	uid := store.InstanceUID()
 	if uid == "" {
 		// A read-only handle may not have cached the identity; a refresh
 		// failure means no persisted identity exists yet.
-		if refreshErr := source.RefreshInstanceUID(ctx); refreshErr == nil {
-			uid = source.InstanceUID()
+		if refreshErr := store.RefreshInstanceUID(ctx); refreshErr == nil {
+			uid = store.InstanceUID()
 		}
 	}
 	return uid, nil

--- a/internal/storageadmin/storage.go
+++ b/internal/storageadmin/storage.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -429,19 +430,25 @@ func (a *Admin) activeSQLitePath() (string, bool, error) {
 
 func (a *Admin) validateSQLiteTargets() error {
 	active, sourceIsSQLite, err := a.activeSQLitePath()
-	if err != nil || !sourceIsSQLite {
+	if err != nil {
 		return err
 	}
 	caseInsensitive := runtime.GOOS == "windows" || runtime.GOOS == "darwin"
-	for alias, targetValue := range a.targets {
-		backend, backendErr := storeopen.BackendForDSN(targetValue)
+	aliases := make([]string, 0, len(a.targets))
+	for alias := range a.targets {
+		aliases = append(aliases, alias)
+	}
+	sort.Strings(aliases)
+	resolved := make(map[string]string, len(aliases))
+	for _, alias := range aliases {
+		backend, backendErr := storeopen.BackendForDSN(a.targets[alias])
 		if backendErr != nil {
 			return fmt.Errorf("resolve storage target %q: %w", alias, backendErr)
 		}
 		if backend != storeopen.BackendSQLite {
 			continue
 		}
-		targetName, targetErr := sqliteTargetName(targetValue)
+		targetName, targetErr := sqliteTargetName(a.targets[alias])
 		if targetErr != nil {
 			return fmt.Errorf("resolve storage target %q: %w", alias, targetErr)
 		}
@@ -449,9 +456,21 @@ func (a *Admin) validateSQLiteTargets() error {
 		if targetErr != nil {
 			return fmt.Errorf("resolve storage target %q: %w", alias, targetErr)
 		}
-		if sqliteFileSetsOverlap(target, active, caseInsensitive) {
+		if sourceIsSQLite && sqliteFileSetsOverlap(target, active, caseInsensitive) {
 			return fmt.Errorf("storage target %q overlaps active SQLite storage", alias)
 		}
+		// Force-importing one alias moves and deletes the target's whole
+		// sidecar set, so two aliases may not share any of those paths.
+		for _, otherAlias := range aliases {
+			other, seen := resolved[otherAlias]
+			if !seen {
+				continue
+			}
+			if sqliteFileSetsOverlap(target, other, caseInsensitive) {
+				return fmt.Errorf("storage targets %q and %q overlap", otherAlias, alias)
+			}
+		}
+		resolved[alias] = target
 	}
 	return nil
 }

--- a/internal/storageadmin/storage_test.go
+++ b/internal/storageadmin/storage_test.go
@@ -1,0 +1,321 @@
+package storageadmin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/storeopen"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+func TestResolveArtifactRejectsPathEscape(t *testing.T) {
+	admin, err := New(Config{Root: t.TempDir(), SourceDSN: "source.db"})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	for _, name := range []string{"../outside.jsonl", "/tmp/outside.jsonl", "a/../../outside.jsonl"} {
+		_, err := admin.ResolveArtifact(name, false)
+		require.Error(t, err, name)
+	}
+}
+
+func TestExportImportRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.db")
+	store, err := storeopen.Open(t.Context(), source)
+	require.NoError(t, err)
+	project, err := store.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	_, _, err = store.CreateIssue(t.Context(), db.CreateIssueParams{ProjectID: project.ID, Title: "Imported issue", Author: "example-agent"})
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	admin, err := New(Config{Root: root, SourceDSN: source, Targets: map[string]string{"restore": "restore.db"}})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+	exported, err := admin.Export(t.Context(), ExportOptions{Artifact: "backup.jsonl", IncludeDeleted: true})
+	require.NoError(t, err)
+	require.Positive(t, exported.Bytes)
+	imported, err := admin.Import(t.Context(), ImportOptions{Artifact: "backup.jsonl", Target: "restore"})
+	require.NoError(t, err)
+	require.Equal(t, "sqlite", imported.Backend)
+
+	restored, err := storeopen.OpenReadOnly(context.Background(), filepath.Join(root, "restore.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = restored.Close() })
+	restoredProject, err := restored.ProjectByName(t.Context(), "example-project")
+	require.NoError(t, err)
+	issues, err := restored.ListIssues(t.Context(), db.ListIssuesParams{ProjectID: restoredProject.ID})
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	require.Equal(t, "Imported issue", issues[0].Title)
+	restoredInfo, err := os.Stat(filepath.Join(root, "restore.db"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), restoredInfo.Mode().Perm())
+
+	_, err = New(Config{Root: root, SourceDSN: "sqlite://" + source, Targets: map[string]string{"active": "source.db"}})
+	require.ErrorContains(t, err, "active SQLite storage")
+}
+
+func TestNewRejectsImportTargetOverlappingActiveSQLiteSidecar(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.db")
+	store, err := storeopen.Open(t.Context(), source)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	_, err = New(Config{
+		Root: root, SourceDSN: source,
+		Targets: map[string]string{"sidecar": "source.db-wal"},
+	})
+	require.ErrorContains(t, err, "active SQLite storage")
+}
+
+func TestResolveArtifactRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.Symlink(outside, root+"/escape"))
+	admin, err := New(Config{Root: root, SourceDSN: "source.db"})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	_, err = admin.ResolveArtifact("escape/data.jsonl", false)
+	require.ErrorContains(t, err, "symbolic link")
+}
+
+func TestRootAnchoredOperationRejectsDirectorySymlinkSwap(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "exchange"), 0o700))
+	outside := t.TempDir()
+	admin, err := New(Config{Root: root, SourceDSN: "source.db"})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	name, err := admin.resolveArtifactName(filepath.Join("exchange", "artifact.jsonl"), false)
+	require.NoError(t, err)
+	require.NoError(t, os.Rename(filepath.Join(root, "exchange"), filepath.Join(root, "moved")))
+	require.NoError(t, os.Symlink(outside, filepath.Join(root, "exchange")))
+
+	file, err := admin.files.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if file != nil {
+		_ = file.Close()
+	}
+	require.Error(t, err)
+	require.NoFileExists(t, filepath.Join(outside, "artifact.jsonl"))
+}
+
+func TestImportRejectsConfiguredTargetDirectorySymlinkSwap(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "exchange"), 0o700))
+	outside := t.TempDir()
+	source := filepath.Join(root, "source.db")
+	store, err := storeopen.Open(t.Context(), source)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+	admin, err := New(Config{
+		Root: root, SourceDSN: source,
+		Targets: map[string]string{"restore": filepath.Join("exchange", "restore.db")},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+	_, err = admin.Export(t.Context(), ExportOptions{Artifact: "backup.jsonl", IncludeDeleted: true})
+	require.NoError(t, err)
+
+	require.NoError(t, os.Rename(filepath.Join(root, "exchange"), filepath.Join(root, "moved")))
+	require.NoError(t, os.Symlink(outside, filepath.Join(root, "exchange")))
+	_, err = admin.Import(t.Context(), ImportOptions{Artifact: "backup.jsonl", Target: "restore"})
+	require.Error(t, err)
+	require.NoFileExists(t, filepath.Join(outside, "restore.db"))
+}
+
+func TestExportRejectsProtectedStoragePathsAndRequiresOverwriteConfirmation(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.db")
+	store, err := storeopen.Open(t.Context(), source)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+	require.NoError(t, os.Link(source, filepath.Join(root, "source-alias.db")))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "restore.db"), []byte("target"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "backup.jsonl"), []byte("old"), 0o600))
+
+	admin, err := New(Config{
+		Root: root, SourceDSN: source,
+		Targets: map[string]string{"restore": "restore.db"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	for _, artifact := range []string{"source.db", "source-alias.db", "source.db-wal", "restore.db"} {
+		_, err := admin.Export(t.Context(), ExportOptions{Artifact: artifact, Force: true, Confirm: "OVERWRITE ARTIFACT " + artifact})
+		require.ErrorContains(t, err, "protected storage path", artifact)
+	}
+	_, err = admin.Export(t.Context(), ExportOptions{Artifact: "backup.jsonl"})
+	require.ErrorContains(t, err, "force and exact confirmation")
+	_, err = admin.Export(t.Context(), ExportOptions{Artifact: "backup.jsonl", Force: true, Confirm: "wrong"})
+	require.ErrorContains(t, err, `confirm must equal "OVERWRITE ARTIFACT backup.jsonl"`)
+	exported, err := admin.Export(t.Context(), ExportOptions{Artifact: "backup.jsonl", Force: true, Confirm: "OVERWRITE ARTIFACT backup.jsonl"})
+	require.NoError(t, err)
+	require.Positive(t, exported.Bytes)
+}
+
+func TestStoragePathsEquivalentWithCaseFolding(t *testing.T) {
+	require.True(t, storagePathsEquivalent(
+		filepath.Join("root", "Source.db"), filepath.Join("root", "source.db"), true,
+	))
+	require.False(t, storagePathsEquivalent(
+		filepath.Join("root", "Source.db"), filepath.Join("root", "source.db"), false,
+	))
+}
+
+func TestStorageProtectionCanonicalizesActiveSQLiteDirectory(t *testing.T) {
+	realRoot := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "storage-alias")
+	if err := os.Symlink(realRoot, alias); err != nil {
+		t.Skipf("create directory symlink: %v", err)
+	}
+	source := filepath.Join(alias, "source.db")
+	store, err := storeopen.Open(t.Context(), source)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+	admin, err := New(Config{
+		Root:      alias,
+		SourceDSN: "sqlite://" + source,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	_, err = admin.Export(t.Context(), ExportOptions{
+		Artifact: "source.db-wal",
+		Force:    true,
+		Confirm:  "OVERWRITE ARTIFACT source.db-wal",
+	})
+	require.ErrorContains(t, err, "protected storage path")
+
+	_, err = New(Config{
+		Root:      alias,
+		SourceDSN: "sqlite://" + source,
+		Targets:   map[string]string{"active": "source.db"},
+	})
+	require.ErrorContains(t, err, "active SQLite storage")
+}
+
+func TestConcurrentExportsCannotReplaceUnconfirmedArtifact(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "source.db")
+	store, err := storeopen.Open(t.Context(), source)
+	require.NoError(t, err)
+	project, err := store.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	for index := 0; index < 200; index++ {
+		_, _, err = store.CreateIssue(t.Context(), db.CreateIssueParams{
+			ProjectID: project.ID, Title: "Concurrent export fixture", Author: "example-agent",
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, store.Close())
+	admin, err := New(Config{Root: root, SourceDSN: source})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	start := make(chan struct{})
+	errors := make(chan error, 2)
+	var group sync.WaitGroup
+	for range 2 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			_, exportErr := admin.Export(t.Context(), ExportOptions{Artifact: "concurrent.jsonl"})
+			errors <- exportErr
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(errors)
+
+	succeeded := 0
+	failed := 0
+	for exportErr := range errors {
+		if exportErr == nil {
+			succeeded++
+		} else {
+			failed++
+		}
+	}
+	require.Equal(t, 1, succeeded)
+	require.Equal(t, 1, failed)
+}
+
+func TestMoveSQLiteSetDoesNotReplaceConcurrentDestinationAndRollsBack(t *testing.T) {
+	root := t.TempDir()
+	from := filepath.Join(root, "from.db")
+	to := filepath.Join(root, "to.db")
+	require.NoError(t, os.WriteFile(from, []byte("source-main"), 0o600))
+	require.NoError(t, os.WriteFile(from+"-wal", []byte("source-wal"), 0o600))
+
+	links := 0
+	err := moveSQLiteSetWithLink(from, to, func(oldPath, newPath string) error {
+		links++
+		if links == 2 {
+			require.NoError(t, os.WriteFile(newPath, []byte("concurrent"), 0o600))
+		}
+		return os.Link(oldPath, newPath)
+	})
+	require.Error(t, err)
+	require.FileExists(t, from)
+	require.FileExists(t, from+"-wal")
+	require.NoFileExists(t, to)
+	concurrent, readErr := os.ReadFile(to + "-wal") //nolint:gosec // test-local path
+	require.NoError(t, readErr)
+	require.Equal(t, "concurrent", string(concurrent))
+}
+
+func TestStageSQLiteSetCleansMainFileWhenSidecarOpenFails(t *testing.T) {
+	root := t.TempDir()
+	sourceRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "restore.db")
+	require.NoError(t, os.WriteFile(source, []byte("database"), 0o600))
+	if err := os.Symlink("restore.db-wal", source+"-wal"); err != nil {
+		t.Skipf("create sidecar symlink loop: %v", err)
+	}
+	admin, err := New(Config{Root: root, SourceDSN: source})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	_, err = admin.stageSQLiteSet(source, ".", "staged")
+	require.Error(t, err)
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func TestFailedPostgresImportRemovesFreshSchema(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires postgres testcontainer")
+	}
+	dsn, cleanup := testenv.NewPostgresContainer(t, t.Context())
+	t.Cleanup(cleanup)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_POSTGRES_SCHEMA", "mcp_restore_cleanup")
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "invalid.jsonl"), []byte("not-json\n"), 0o600))
+	admin, err := New(Config{
+		Root: root, SourceDSN: filepath.Join(root, "active.db"),
+		Targets: map[string]string{"restore": dsn},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	_, err = admin.Import(t.Context(), ImportOptions{Artifact: "invalid.jsonl", Target: "restore"})
+	require.Error(t, err)
+	version, err := storeopen.PeekSchemaVersion(t.Context(), dsn)
+	require.NoError(t, err)
+	require.Zero(t, version)
+}

--- a/internal/storageadmin/storage_test.go
+++ b/internal/storageadmin/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -55,9 +56,12 @@ func TestExportImportRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, issues, 1)
 	require.Equal(t, "Imported issue", issues[0].Title)
-	restoredInfo, err := os.Stat(filepath.Join(root, "restore.db"))
-	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0o600), restoredInfo.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		// Owner-only Unix modes are not meaningful on Windows (ACL-based).
+		restoredInfo, err := os.Stat(filepath.Join(root, "restore.db"))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), restoredInfo.Mode().Perm())
+	}
 
 	_, err = New(Config{Root: root, SourceDSN: "sqlite://" + source, Targets: map[string]string{"active": "source.db"}})
 	require.ErrorContains(t, err, "active SQLite storage")

--- a/internal/storageadmin/storage_test.go
+++ b/internal/storageadmin/storage_test.go
@@ -301,6 +301,27 @@ func TestStageSQLiteSetCleansMainFileWhenSidecarOpenFails(t *testing.T) {
 	require.Empty(t, entries)
 }
 
+func TestImportRejectsArtifactOverlappingSQLiteTarget(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "backup.jsonl"), []byte("{}\n"), 0o600))
+	admin, err := New(Config{
+		Root: root, SourceDSN: filepath.Join(t.TempDir(), "active.db"),
+		Targets: map[string]string{"restore": "backup.jsonl", "sidecar": "backup.jsonl-wal"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	for _, target := range []string{"restore", "sidecar"} {
+		_, err = admin.Import(t.Context(), ImportOptions{
+			Artifact: "backup.jsonl", Target: target,
+			Force: true, Confirm: "REPLACE STORAGE " + target,
+		})
+		require.ErrorContains(t, err, "artifact must differ from the SQLite target", target)
+	}
+	_, err = os.Stat(filepath.Join(root, "backup.jsonl"))
+	require.NoError(t, err, "the artifact must survive the refused import")
+}
+
 func TestFailedPostgresImportRemovesFreshSchema(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires postgres testcontainer")

--- a/internal/storageadmin/storage_test.go
+++ b/internal/storageadmin/storage_test.go
@@ -304,22 +304,41 @@ func TestStageSQLiteSetCleansMainFileWhenSidecarOpenFails(t *testing.T) {
 func TestImportRejectsArtifactOverlappingSQLiteTarget(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "backup.jsonl"), []byte("{}\n"), 0o600))
+	for _, targetValue := range []string{"backup.jsonl", "backup.jsonl-wal"} {
+		admin, err := New(Config{
+			Root: root, SourceDSN: filepath.Join(t.TempDir(), "active.db"),
+			Targets: map[string]string{"restore": targetValue},
+		})
+		require.NoError(t, err)
+		_, err = admin.Import(t.Context(), ImportOptions{
+			Artifact: "backup.jsonl", Target: "restore",
+			Force: true, Confirm: "REPLACE STORAGE restore",
+		})
+		require.ErrorContains(t, err, "artifact must differ from the SQLite target", targetValue)
+		require.NoError(t, admin.Close())
+	}
+	_, err := os.Stat(filepath.Join(root, "backup.jsonl"))
+	require.NoError(t, err, "the artifact must survive the refused import")
+}
+
+func TestNewRejectsPairwiseOverlappingSQLiteTargets(t *testing.T) {
+	root := t.TempDir()
+	// Pairwise overlap is enforced even when the active source is not
+	// SQLite, since force-importing one alias moves and deletes the whole
+	// sidecar set of its target.
+	for _, source := range []string{filepath.Join(t.TempDir(), "active.db"), "postgres://db.example/kata"} {
+		_, err := New(Config{
+			Root: root, SourceDSN: source,
+			Targets: map[string]string{"primary": "restore.db", "secondary": "restore.db-wal"},
+		})
+		require.ErrorContains(t, err, `storage targets "primary" and "secondary" overlap`, source)
+	}
 	admin, err := New(Config{
 		Root: root, SourceDSN: filepath.Join(t.TempDir(), "active.db"),
-		Targets: map[string]string{"restore": "backup.jsonl", "sidecar": "backup.jsonl-wal"},
+		Targets: map[string]string{"primary": "restore.db", "secondary": "other.db"},
 	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, admin.Close()) })
-
-	for _, target := range []string{"restore", "sidecar"} {
-		_, err = admin.Import(t.Context(), ImportOptions{
-			Artifact: "backup.jsonl", Target: target,
-			Force: true, Confirm: "REPLACE STORAGE " + target,
-		})
-		require.ErrorContains(t, err, "artifact must differ from the SQLite target", target)
-	}
-	_, err = os.Stat(filepath.Join(root, "backup.jsonl"))
-	require.NoError(t, err, "the artifact must survive the refused import")
+	require.NoError(t, err, "distinct targets remain accepted")
+	require.NoError(t, admin.Close())
 }
 
 func TestFailedPostgresImportRemovesFreshSchema(t *testing.T) {

--- a/internal/storageadmin/storage_test.go
+++ b/internal/storageadmin/storage_test.go
@@ -2,6 +2,7 @@ package storageadmin
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/storeopen"
 	"go.kenn.io/kata/internal/testenv"
@@ -322,4 +324,63 @@ func TestFailedPostgresImportRemovesFreshSchema(t *testing.T) {
 	version, err := storeopen.PeekSchemaVersion(t.Context(), dsn)
 	require.NoError(t, err)
 	require.Zero(t, version)
+}
+
+func TestPostgresImportRefusesActiveDatabaseByIdentity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires postgres testcontainer")
+	}
+	dsn, cleanup := testenv.NewPostgresContainer(t, t.Context())
+	t.Cleanup(cleanup)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_POSTGRES_SCHEMA", "mcp_restore_identity")
+
+	alias, swappable := swapPostgresHost(t, dsn)
+	if !swappable {
+		t.Skip("container DSN has no swappable localhost/127.0.0.1 host")
+	}
+	require.NotEqual(t, config.DBHash(dsn), config.DBHash(alias),
+		"equivalent DSNs must hash differently for this test to exercise the identity guard")
+
+	// Give the active source a persisted instance identity, then confirm
+	// the alias spelling reaches the same server.
+	active, err := storeopen.Open(t.Context(), dsn)
+	require.NoError(t, err)
+	require.NoError(t, active.Close())
+	probe, probeErr := storeopen.OpenReadOnly(t.Context(), alias)
+	if probeErr != nil {
+		t.Skipf("alias host is not reachable in this environment: %v", probeErr)
+	}
+	require.NoError(t, probe.Close())
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "backup.jsonl"), []byte("{}\n"), 0o600))
+	admin, err := New(Config{Root: root, SourceDSN: dsn, Targets: map[string]string{"restore": alias}})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	_, err = admin.Import(t.Context(), ImportOptions{Artifact: "backup.jsonl", Target: "restore"})
+	require.ErrorContains(t, err, "must differ from the active daemon storage")
+	version, err := storeopen.PeekSchemaVersion(t.Context(), dsn)
+	require.NoError(t, err)
+	require.NotZero(t, version, "identity refusal must not remove the active schema")
+}
+
+func swapPostgresHost(t *testing.T, dsn string) (string, bool) {
+	t.Helper()
+	parsed, err := url.Parse(dsn)
+	require.NoError(t, err)
+	port := parsed.Port()
+	switch parsed.Hostname() {
+	case "localhost":
+		parsed.Host = "127.0.0.1"
+	case "127.0.0.1":
+		parsed.Host = "localhost"
+	default:
+		return "", false
+	}
+	if port != "" {
+		parsed.Host += ":" + port
+	}
+	return parsed.String(), true
 }

--- a/internal/storageadmin/storage_test.go
+++ b/internal/storageadmin/storage_test.go
@@ -366,6 +366,41 @@ func TestFailedPostgresImportRemovesFreshSchema(t *testing.T) {
 	require.Zero(t, version)
 }
 
+func TestPostgresImportRejectsInitializedTargetWithoutMutation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires postgres testcontainer")
+	}
+	dsn, cleanup := testenv.NewPostgresContainer(t, t.Context())
+	t.Cleanup(cleanup)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_POSTGRES_SCHEMA", "mcp_restore_initialized")
+
+	// Initialize the target so it is a real, non-fresh Kata database that
+	// is not the active source.
+	initialized, err := storeopen.Open(t.Context(), dsn)
+	require.NoError(t, err)
+	require.NoError(t, initialized.Close())
+	version, err := storeopen.PeekSchemaVersion(t.Context(), dsn)
+	require.NoError(t, err)
+	require.NotZero(t, version)
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "backup.jsonl"), []byte("{}\n"), 0o600))
+	sourcePath := filepath.Join(t.TempDir(), "active.db")
+	source, err := storeopen.Open(t.Context(), sourcePath)
+	require.NoError(t, err)
+	require.NoError(t, source.Close())
+	admin, err := New(Config{Root: root, SourceDSN: sourcePath, Targets: map[string]string{"restore": dsn}})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+
+	_, err = admin.Import(t.Context(), ImportOptions{Artifact: "backup.jsonl", Target: "restore"})
+	require.ErrorContains(t, err, "already contains a Kata schema")
+	after, err := storeopen.PeekSchemaVersion(t.Context(), dsn)
+	require.NoError(t, err)
+	require.Equal(t, version, after, "the preflight rejection must not touch the initialized schema")
+}
+
 func TestPostgresImportRefusesActiveDatabaseByIdentity(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires postgres testcontainer")

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "packageManager": "bun@1.3.14",
   "overrides": {
     "js-yaml": "4.3.1",
-    "nanoid": "3.3.17"
+    "nanoid": "3.3.18"
   }
 }

--- a/packages/kata-ui/README.md
+++ b/packages/kata-ui/README.md
@@ -35,7 +35,7 @@ only Kata wire data and host-supplied actions.
 {/if}
 ```
 
-`supportsKataAPISchema` accepts Kata API schemas `>=0.9.0 <0.11.0`. A missing
+`supportsKataAPISchema` accepts Kata API schemas `>=0.9.0 <0.12.0`. A missing
 or empty `api_schema_version` is incompatible for an embedding host. Read the
 version from `GET /api/v1/health`; issue-detail responses do not carry it.
 The embedding host must fetch health and issue data through its authenticated

--- a/packages/kata-ui/src/compatibility.test.ts
+++ b/packages/kata-ui/src/compatibility.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { supportsKataAPISchema } from './compatibility.js'
 
 describe('supportsKataAPISchema', () => {
-  it.each(['0.9.0', '0.9.8', '0.10.0', '0.10.4'])('accepts %s', (version) => {
+  it.each(['0.9.0', '0.9.8', '0.10.0', '0.10.4', '0.11.0', '0.11.3'])('accepts %s', (version) => {
     expect(supportsKataAPISchema(version)).toBe(true)
   })
 
-  it.each(['', '0.8.9', '0.11.0', '1.0.0', 'not-semver'])('rejects %s', (version) => {
+  it.each(['', '0.8.9', '0.12.0', '1.0.0', 'not-semver'])('rejects %s', (version) => {
     expect(supportsKataAPISchema(version)).toBe(false)
   })
 })

--- a/packages/kata-ui/src/compatibility.ts
+++ b/packages/kata-ui/src/compatibility.ts
@@ -4,5 +4,5 @@ export function supportsKataAPISchema(version: string): boolean {
 
   const major = Number(match[1])
   const minor = Number(match[2])
-  return major === 0 && (minor === 9 || minor === 10)
+  return major === 0 && minor >= 9 && minor <= 11
 }

--- a/pkg/client/generated/templates/type_def.tmpl
+++ b/pkg/client/generated/templates/type_def.tmpl
@@ -65,12 +65,14 @@
     {{ else if eq $td.Name "RecurrenceTemplateUpdateInput" }}
     {{ if not $config.Generate.OmitDescription}}{{ toGoComment $td.Schema.Description $td.Name }}{{ end }}
     type RecurrenceTemplateUpdateInput struct {
-        Body     *string         `json:"body,omitempty"`
-        Labels   *[]string       `json:"labels,omitempty"`
-        Metadata *map[string]any `json:"metadata,omitempty"`
-        Owner    *string         `json:"owner,omitempty"`
-        Priority *int64          `json:"priority,omitempty"`
-        Title    *string         `json:"title,omitempty"`
+        Body          *string         `json:"body,omitempty"`
+        ClearOwner    bool            `json:"clear_owner,omitempty"`
+        ClearPriority bool            `json:"clear_priority,omitempty"`
+        Labels        *[]string       `json:"labels,omitempty"`
+        Metadata      *map[string]any `json:"metadata,omitempty"`
+        Owner         *string         `json:"owner,omitempty"`
+        Priority      *int64          `json:"priority,omitempty"`
+        Title         *string         `json:"title,omitempty"`
     }
     {{ else }}
     {{ if not $config.Generate.OmitDescription}}{{ toGoComment $td.Schema.Description $td.Name }}{{ end }}

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -559,9 +559,10 @@ func (c CreateFederationReplicaRequestBody) Validate() error {
 }
 
 type CreateInitialLinkBody struct {
-	Incoming *bool                     `json:"incoming,omitempty"`
-	ToRef    string                    `json:"to_ref" validate:"required"`
-	Type     CreateInitialLinkBodyType `json:"type" validate:"required"`
+	Incoming     *bool                     `json:"incoming,omitempty"`
+	ToProjectUID *string                   `json:"to_project_uid,omitempty"`
+	ToRef        string                    `json:"to_ref" validate:"required"`
+	Type         CreateInitialLinkBodyType `json:"type" validate:"required"`
 }
 
 func (c CreateInitialLinkBody) Validate() error {
@@ -2030,14 +2031,15 @@ func (l LinkPeer) Validate() error {
 }
 
 type LinksDelta struct {
-	AddBlockedBy    []string `json:"add_blocked_by,omitempty"`
-	AddBlocks       []string `json:"add_blocks,omitempty"`
-	AddRelated      []string `json:"add_related,omitempty"`
-	RemoveBlockedBy []string `json:"remove_blocked_by,omitempty"`
-	RemoveBlocks    []string `json:"remove_blocks,omitempty"`
-	RemoveParent    *string  `json:"remove_parent,omitempty"`
-	RemoveRelated   []string `json:"remove_related,omitempty"`
-	SetParent       *string  `json:"set_parent,omitempty"`
+	AddBlockedBy        []string          `json:"add_blocked_by,omitempty"`
+	AddBlocks           []string          `json:"add_blocks,omitempty"`
+	AddRelated          []string          `json:"add_related,omitempty"`
+	ExpectedProjectUids map[string]string `json:"expected_project_uids,omitempty"`
+	RemoveBlockedBy     []string          `json:"remove_blocked_by,omitempty"`
+	RemoveBlocks        []string          `json:"remove_blocks,omitempty"`
+	RemoveParent        *string           `json:"remove_parent,omitempty"`
+	RemoveRelated       []string          `json:"remove_related,omitempty"`
+	SetParent           *string           `json:"set_parent,omitempty"`
 }
 
 type ListAllIssuesResponseBody struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -116,6 +116,7 @@ type AuditCloseRow struct {
 	Issue         string   `json:"issue" validate:"required"`
 	Message       *string  `json:"message,omitempty"`
 	Parent        *string  `json:"parent,omitempty"`
+	ParentUID     *string  `json:"parent_uid,omitempty"`
 	Reason        string   `json:"reason" validate:"required"`
 	Time          string   `json:"time" validate:"required"`
 }

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -110,6 +110,7 @@ func (a AssignRequestBody) Validate() error {
 
 type AuditCloseRow struct {
 	Actor         string   `json:"actor" validate:"required"`
+	EventID       int64    `json:"event_id"`
 	EvidenceTypes []string `json:"evidence_types,omitempty"`
 	Flags         []string `json:"flags,omitempty"`
 	Issue         string   `json:"issue" validate:"required"`
@@ -3110,12 +3111,14 @@ func (r RecurrenceTemplateInput) Validate() error {
 }
 
 type RecurrenceTemplateUpdateInput struct {
-	Body     *string         `json:"body,omitempty"`
-	Labels   *[]string       `json:"labels,omitempty"`
-	Metadata *map[string]any `json:"metadata,omitempty"`
-	Owner    *string         `json:"owner,omitempty"`
-	Priority *int64          `json:"priority,omitempty"`
-	Title    *string         `json:"title,omitempty"`
+	Body          *string         `json:"body,omitempty"`
+	ClearOwner    bool            `json:"clear_owner,omitempty"`
+	ClearPriority bool            `json:"clear_priority,omitempty"`
+	Labels        *[]string       `json:"labels,omitempty"`
+	Metadata      *map[string]any `json:"metadata,omitempty"`
+	Owner         *string         `json:"owner,omitempty"`
+	Priority      *int64          `json:"priority,omitempty"`
+	Title         *string         `json:"title,omitempty"`
 }
 
 type RemoveProjectResponseBody struct {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -399,6 +399,8 @@ components:
       properties:
         incoming:
           type: boolean
+        to_project_uid:
+          type: string
         to_ref:
           type: string
         type:
@@ -2133,6 +2135,10 @@ components:
             type: string
           nullable: true
           type: array
+        expected_project_uids:
+          additionalProperties:
+            type: string
+          type: object
         remove_blocked_by:
           items:
             type: string

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -4021,7 +4021,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.10.0
+  version: 0.11.0
 openapi: 3.0.3
 paths:
   /api/v1/audit/closes:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -101,6 +101,8 @@ components:
           type: string
         parent:
           type: string
+        parent_uid:
+          type: string
         reason:
           type: string
         time:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -82,6 +82,9 @@ components:
       properties:
         actor:
           type: string
+        event_id:
+          format: int64
+          type: integer
         evidence_types:
           items:
             type: string
@@ -107,6 +110,7 @@ components:
         - actor
         - issue
         - reason
+        - event_id
       type: object
     AuditClosesResponseBody:
       properties:

--- a/web/src/lib/api/schema.d.ts
+++ b/web/src/lib/api/schema.d.ts
@@ -1293,6 +1293,8 @@ export interface components {
     }
     AuditCloseRow: {
       actor: string
+      /** Format: int64 */
+      event_id: number
       evidence_types?: string[] | null
       flags?: string[] | null
       issue: string

--- a/web/src/lib/api/schema.d.ts
+++ b/web/src/lib/api/schema.d.ts
@@ -1455,6 +1455,7 @@ export interface components {
     }
     CreateInitialLinkBody: {
       incoming?: boolean
+      to_project_uid?: string
       to_ref: string
       /** @enum {string} */
       type: 'parent' | 'blocks' | 'related'
@@ -2297,6 +2298,9 @@ export interface components {
       add_blocked_by?: string[] | null
       add_blocks?: string[] | null
       add_related?: string[] | null
+      expected_project_uids?: {
+        [key: string]: string
+      }
       remove_blocked_by?: string[] | null
       remove_blocks?: string[] | null
       remove_parent?: string

--- a/web/src/lib/api/schema.d.ts
+++ b/web/src/lib/api/schema.d.ts
@@ -1300,6 +1300,7 @@ export interface components {
       issue: string
       message?: string
       parent?: string
+      parent_uid?: string
       reason: string
       time: string
     } & {


### PR DESCRIPTION
## What changed

- Makes bare `kata mcp serve` follow every project visible to the selected daemon. `--workspace`, `--project`, and `--projects` remain available when a client needs a narrower boundary; the redundant `--all-projects` setting is gone.
- Starts with 13 read-only section loaders instead of placing all 53 detailed tools in the initial model context. Loading a section registers its typed tools and publishes the standard tool-list change notification, while each operation keeps its own schema and safety annotations.
- Expands coverage across issue workflows, project and token administration, federation, GitHub sync, recurrence, import, digest, and events. Two JSONL storage tools remain conditional on operator startup configuration.
- Adds first-class `scheduled_on` and timezone inputs, `someday=true` parking with null removal, force-create, and force-claim support.
- Preserves daemon authorization, revision checks, destructive confirmations, origin-pinned credentials, bounded results, and secret redaction. This adds no database schema or migration change, and host process control remains outside MCP.

## Why

MCP was the only Kata client surface fixed to one project, and it exposed only a small part of the daemon. Assistant clients had to start one server per project and carry dozens of unrelated tool definitions before they could do normal administration or workflow work.

The daemon already defines the accessible project catalog. The MCP process now follows that catalog by default, while progressive section loading keeps the initial tool surface small without replacing typed operations with a generic command tool.

## Usage

```sh
# Every project visible to the selected daemon
kata mcp serve

# One project
kata --workspace /path/to/repository mcp serve

# Fixed project allowlist
kata mcp serve --projects example-project,shared-project
```

Call the applicable `kata.load_*` section tool before using its detailed tools. Multi-project issue references use `example-project#abc4`. Scheduling accepts a date, a local date-time with an IANA timezone, or a UTC RFC 3339 value ending in `Z`. Native parking uses `{"metadata":{"someday":true}}`; set the key to JSON `null` to remove it.

Host-storage import and export stay disabled unless the operator opts in:

```sh
kata mcp serve \
  --storage-root /srv/kata/exchange \
  --storage-target restore=restore.db
```

Closes #257
