### PR TITLE
Make fast SQLite mode eliminate durability flushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
         shell: bash
         env:
           KATA_TEST_FAST_SQLITE: "1"
-        run: env -u KATA_AUTH_TOKEN go test -p 4 -vet=off ./...
+        run: env -u KATA_AUTH_TOKEN go test -timeout=20m -p 4 -vet=off ./...
 
   lint:
     name: golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
         shell: bash
         env:
           KATA_TEST_FAST_SQLITE: "1"
-        run: env -u KATA_AUTH_TOKEN go test -timeout=20m -p 4 -vet=off ./...
+        run: env -u KATA_AUTH_TOKEN go test -p 4 -vet=off ./...
 
   lint:
     name: golangci-lint

--- a/internal/db/sqlitestore/store.go
+++ b/internal/db/sqlitestore/store.go
@@ -11,8 +11,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -20,6 +18,7 @@ import (
 	_ "modernc.org/sqlite" // pure-Go SQLite driver registered as "sqlite"
 
 	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/sqliteconfig"
 	katauid "go.kenn.io/kata/internal/uid"
 )
 
@@ -62,14 +61,14 @@ type readQuerier interface {
 var _ db.Storage = (*Store)(nil)
 
 // Open opens (and if needed initializes) the kata SQLite database at path.
-// PRAGMAs are applied for every connection via the connection string. Fresh
-// databases are bootstrapped from schema.sql inside a transaction; older
-// databases return ErrSchemaCutoverRequired so the storeopen path can run
-// JSONL cutover before reopening; newer databases are an unrecoverable state
-// for this binary. Open is the single authoritative writer of
-// meta.instance_uid outside an import transaction: after bootstrap, if the
-// row is absent it generates one via uid.New(). The cached value is exposed
-// via InstanceUID for insert paths.
+// Connection-local PRAGMAs are applied via the connection string; WAL is
+// enabled once during setup. Fresh databases are bootstrapped from schema.sql
+// inside a transaction. Older databases return ErrSchemaCutoverRequired so
+// storeopen can run JSONL cutover before reopening; newer databases are an
+// unrecoverable state for this binary. Open is the single authoritative
+// writer of meta.instance_uid outside an import transaction. After bootstrap,
+// if the row is absent it generates one via uid.New(). The cached value is
+// exposed via InstanceUID for insert paths.
 //
 // Pass db.ReadOnly() to open an existing database without bootstrapping or
 // PRAGMA writes. The cutover and preflight paths use this to inspect an old
@@ -79,12 +78,12 @@ func Open(ctx context.Context, path string, opts ...db.OpenOption) (*Store, erro
 	if cfg.ReadOnly {
 		return openReadOnly(ctx, path)
 	}
+	fast := sqliteconfig.FastTestMode()
 	synchronous := "NORMAL"
 	pragmas := []string{
 		"_pragma=foreign_keys(1)",
-		"_pragma=journal_mode(WAL)",
 	}
-	if fastSQLiteForTestHarness() {
+	if fast {
 		synchronous = "OFF"
 		pragmas = append(pragmas, "_pragma=temp_store(MEMORY)")
 	}
@@ -98,9 +97,9 @@ func Open(ctx context.Context, path string, opts ...db.OpenOption) (*Store, erro
 		return nil, fmt.Errorf("open %s: %w", path, err)
 	}
 	// Single writer is fine for v1; SetMaxOpenConns left at default for reads.
-	if err := sdb.PingContext(ctx); err != nil {
+	if err := sqliteconfig.ConfigureWAL(ctx, sdb, fast); err != nil {
 		_ = sdb.Close()
-		return nil, fmt.Errorf("ping %s: %w", path, err)
+		return nil, fmt.Errorf("configure %s: %w", path, err)
 	}
 	d := &Store{DB: sdb, path: path, idempotencyLocks: newIdempotencyLockSet()}
 	d.readQ = sdb
@@ -357,21 +356,6 @@ func retryWrite3[A, B, C any](ctx context.Context, d *Store, op func() (A, B, C,
 		return err
 	})
 	return a, b, c, err
-}
-
-// testFastSQLiteEnv opts test binaries into reduced-durability PRAGMAs
-// (synchronous=OFF, temp_store=MEMORY). Production binaries ignore it; the
-// guard requires the env *and* an os.Args[0] basename ending in .test or
-// .test.exe so a flag accidentally exported into a production shell can't
-// degrade real-database durability.
-const testFastSQLiteEnv = "KATA_TEST_FAST_SQLITE"
-
-func fastSQLiteForTestHarness() bool {
-	if os.Getenv(testFastSQLiteEnv) != "1" {
-		return false
-	}
-	bin := strings.ToLower(filepath.Base(os.Args[0]))
-	return strings.HasSuffix(bin, ".test") || strings.HasSuffix(bin, ".test.exe")
 }
 
 // PeekSchemaVersion reads meta.schema_version without bootstrapping the DB.

--- a/internal/sqliteconfig/config.go
+++ b/internal/sqliteconfig/config.go
@@ -1,0 +1,54 @@
+// Package sqliteconfig contains SQLite setup shared by kata's canonical and
+// derived-state databases.
+package sqliteconfig
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const testFastSQLiteEnv = "KATA_TEST_FAST_SQLITE"
+
+// FastTestMode reports whether a Go test binary explicitly requested
+// reduced-durability SQLite settings. Production binaries ignore the
+// environment variable so an exported test setting cannot weaken real data.
+func FastTestMode() bool {
+	if os.Getenv(testFastSQLiteEnv) != "1" {
+		return false
+	}
+	bin := strings.ToLower(filepath.Base(os.Args[0]))
+	return strings.HasSuffix(bin, ".test") || strings.HasSuffix(bin, ".test.exe")
+}
+
+// ConfigureWAL enables WAL only after reduced-durability test settings have
+// taken effect on the same connection. Drivers also receive synchronous=OFF
+// in their DSNs so later pooled connections retain the durability setting.
+func ConfigureWAL(ctx context.Context, db *sql.DB, fast bool) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	if fast {
+		if _, err := conn.ExecContext(ctx, "PRAGMA synchronous=OFF"); err != nil {
+			return fmt.Errorf("disable synchronous writes: %w", err)
+		}
+		if _, err := conn.ExecContext(ctx, "PRAGMA temp_store=MEMORY"); err != nil {
+			return fmt.Errorf("configure temporary storage: %w", err)
+		}
+	}
+
+	var mode string
+	if err := conn.QueryRowContext(ctx, "PRAGMA journal_mode(WAL)").Scan(&mode); err != nil {
+		return fmt.Errorf("enable WAL: %w", err)
+	}
+	if !strings.EqualFold(mode, "wal") {
+		return fmt.Errorf("enable WAL: SQLite selected journal mode %q", mode)
+	}
+	return nil
+}

--- a/internal/vector/driver_cgo.go
+++ b/internal/vector/driver_cgo.go
@@ -15,11 +15,15 @@ import (
 // substitutes the pure-Go modernc driver instead.
 const sidecarDriver = "sqlite3"
 
-// sidecarDSN builds the mattn/go-sqlite3 DSN for the sidecar: WAL journal
-// mode and a 5s busy timeout, expressed as mattn's `_`-prefixed query
-// params.
-func sidecarDSN(path string) string {
-	return path + "?_journal_mode=WAL&_busy_timeout=5000"
+// sidecarDSN builds the mattn/go-sqlite3 DSN for the sidecar. Connection-local
+// settings live here so every pooled connection receives them; ConfigureWAL
+// enables WAL separately after fast-mode settings take effect.
+func sidecarDSN(path string, fast bool) string {
+	dsn := path + "?_busy_timeout=5000"
+	if fast {
+		dsn += "&_synchronous=OFF"
+	}
+	return dsn
 }
 
 func sidecarVectorValue(vector kitvec.Vector) (string, any, error) {

--- a/internal/vector/driver_modernc.go
+++ b/internal/vector/driver_modernc.go
@@ -18,12 +18,18 @@ import (
 // build. driver_cgo.go substitutes mattn/go-sqlite3 on cgo Unix builds.
 const sidecarDriver = "sqlite"
 
-// sidecarDSN builds the modernc "sqlite" DSN for the sidecar, matching the
-// pragmas driver_cgo.go sets through mattn's `_`-prefixed params: WAL
-// journal mode and a 5s busy timeout. modernc expresses connection pragmas
-// as repeated `_pragma=name(value)` params.
-func sidecarDSN(path string) string {
-	return path + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+// sidecarDSN builds the modernc "sqlite" DSN for the sidecar. Connection-local
+// settings live here so every pooled connection receives them; ConfigureWAL
+// enables WAL separately after fast-mode settings take effect.
+func sidecarDSN(path string, fast bool) string {
+	pragmas := []string{"_pragma=busy_timeout(5000)"}
+	if fast {
+		pragmas = append(pragmas,
+			"_pragma=synchronous(OFF)",
+			"_pragma=temp_store(MEMORY)",
+		)
+	}
+	return path + "?" + strings.Join(pragmas, "&")
 }
 
 func sidecarVectorValue(vector kitvec.Vector) (string, any, error) {

--- a/internal/vector/index.go
+++ b/internal/vector/index.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 
+	"go.kenn.io/kata/internal/sqliteconfig"
 	kitvec "go.kenn.io/kit/vector"
 	"go.kenn.io/kit/vector/sqlitevec"
 )
@@ -42,7 +43,7 @@ type Index struct {
 // mismatch deletes and recreates the file: the sidecar is derived state and
 // re-embedding is the supported rebuild path.
 func Open(ctx context.Context, path string) (*Index, error) {
-	db, err := openSidecar(path)
+	db, err := openSidecar(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func Open(ctx context.Context, path string) (*Index, error) {
 		if err := removeSidecar(path); err != nil {
 			return nil, err
 		}
-		if db, err = openSidecar(path); err != nil {
+		if db, err = openSidecar(ctx, path); err != nil {
 			return nil, err
 		}
 	}
@@ -97,11 +98,16 @@ func (ix *Index) Close() error {
 	return ix.db.Close()
 }
 
-func openSidecar(path string) (*sql.DB, error) {
+func openSidecar(ctx context.Context, path string) (*sql.DB, error) {
 	sqlitevec.Register() // no-op on modernc builds; required on cgo builds
-	db, err := sql.Open(sidecarDriver, sidecarDSN(path))
+	fast := sqliteconfig.FastTestMode()
+	db, err := sql.Open(sidecarDriver, sidecarDSN(path, fast))
 	if err != nil {
 		return nil, fmt.Errorf("vector: open sidecar %s: %w", path, err)
+	}
+	if err := sqliteconfig.ConfigureWAL(ctx, db, fast); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("vector: configure sidecar %s: %w", path, err)
 	}
 	return db, nil
 }

--- a/internal/vector/index_test.go
+++ b/internal/vector/index_test.go
@@ -4,7 +4,32 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestOpenUsesFastSQLitePragmasWhenTestHarnessRequestsIt(t *testing.T) {
+	t.Setenv("KATA_TEST_FAST_SQLITE", "1")
+
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "vectors.db")
+	ix, err := Open(ctx, path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ix.Close() })
+
+	var mode string
+	require.NoError(t, ix.db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&mode))
+	assert.Equal(t, "wal", mode)
+
+	var sync int
+	require.NoError(t, ix.db.QueryRowContext(ctx, "PRAGMA synchronous").Scan(&sync))
+	assert.Zero(t, sync)
+
+	var tempStore int
+	require.NoError(t, ix.db.QueryRowContext(ctx, "PRAGMA temp_store").Scan(&tempStore))
+	assert.Equal(t, 2, tempStore)
+}
 
 func TestOpenCreatesAndReopens(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
Windows tests still performed SQLite durability flushes with `KATA_TEST_FAST_SQLITE` enabled. The main database entered WAL before `synchronous=OFF`, while the vector sidecar ignored the setting.

This applies the guarded test settings before WAL in both stores and adds a vector regression test. No timeout increase is included.

Production binaries continue to ignore the environment variable and retain their existing durability behavior.
