### PR TITLE
Add due date CLI and MCP parity

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3903,6 +3903,8 @@ components:
         created_at:
           format: date-time
           type: string
+        deadline_on_date:
+          type: string
         deleted_at:
           format: date-time
           type: string

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -676,6 +676,16 @@ const agentsBlockBody = "## kata issue tracker\n\n" +
 	"- Close only verified work: `kata close <ref> --done --message \"<scope + verification>\" --commit <sha>`.\n" +
 	"- If work is incomplete, label `needs-review` and comment what remains rather than closing.\n" +
 	"- Never `kata delete` or `kata purge` without explicit user authorization.\n\n" +
+	"## kata planning dates\n\n" +
+	"- Park work until a date or time with `kata schedule <ref> <date-or-time>`;\n" +
+	"  clear it with `kata schedule <ref> -`. This maps to `scheduled_on`; a future value excludes the issue\n" +
+	"  from `ready` and `next` until its gate opens.\n" +
+	"- Set a deadline with `kata deadline <ref> <date-or-time>`; clear it with `kata deadline <ref> -`.\n" +
+	"  This maps to `deadline_on`; a deadline does not park the issue.\n" +
+	"- Park work with no date by running `kata meta set <ref> someday true --json-value`;\n" +
+	"  return it to the queue with `kata meta unset <ref> someday` (do not store `false`).\n" +
+	"- Date and time values accept `YYYY-MM-DD`, local `YYYY-MM-DDTHH:MM[:SS]`, or an\n" +
+	"  RFC 3339 UTC instant ending in `Z`.\n\n" +
 	"## kata work.* conventions (agent orchestration)\n\n" +
 	"When working a kata-tracked issue, keep its `work.*` metadata truthful\n" +
 	"(see https://katatracker.com/operations/agent-orchestration/ for the full recipe):\n\n" +

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -607,6 +607,27 @@ func TestInit_WithAgents_BlockIncludesWorkConventions(t *testing.T) {
 	assert.NotContains(t, got, "docs/operations/agent-orchestration.md")
 }
 
+func TestInit_WithAgents_BlockIncludesScheduleDueAndSomedayConventions(t *testing.T) {
+	env := testenv.New(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/example/example-project.git")
+
+	flags.JSON = true
+	t.Cleanup(func() { flags.JSON = false })
+
+	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
+	require.NoError(t, err)
+	got := string(content)
+	assert.Contains(t, got, "kata schedule <ref> <date-or-time>")
+	assert.Contains(t, got, "kata deadline <ref> <date-or-time>")
+	assert.Contains(t, got, "kata meta set <ref> someday true --json-value")
+	assert.Contains(t, got, "kata meta unset <ref> someday")
+}
+
 // oldAgentsBlockBody is the managed-block body kata shipped before the work.*
 // conventions section was added. A repo initialized with an older kata carries
 // this verbatim between the markers; re-running --with-agents must upgrade it in

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -87,6 +87,8 @@ func newRootCmd() *cobra.Command {
 		newShowCmd(),
 		newListCmd(),
 		newEditCmd(),
+		newScheduleCmd(),
+		newDeadlineCmd(),
 		newMetaCmd(),
 		newMoveCmd(),
 		newCommentCmd(),

--- a/cmd/kata/planning_date.go
+++ b/cmd/kata/planning_date.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/cobra"
+)
+
+func newDeadlineCmd() *cobra.Command {
+	return newPlanningDateCmd("deadline", "deadline_on", "deadline")
+}
+
+func newScheduleCmd() *cobra.Command {
+	return newPlanningDateCmd("schedule", "scheduled_on", "schedule")
+}
+
+func newPlanningDateCmd(name, metadataKey, noun string) *cobra.Command {
+	var ifMatch string
+	cmd := &cobra.Command{
+		Use:   name + " <issue-ref> <date-or-time|->",
+		Short: "set or clear an issue " + noun,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateMetaIfMatchFlag(cmd, ifMatch); err != nil {
+				return err
+			}
+			value := json.RawMessage("null")
+			verb := "unset"
+			if args[1] != "-" {
+				encoded, err := json.Marshal(args[1])
+				if err != nil {
+					return err
+				}
+				value = encoded
+				verb = "set"
+			}
+			return runMetaPatch(cmd, args[0], metadataKey, value, ifMatch, verb)
+		},
+	}
+	cmd.Flags().StringVar(&ifMatch, "if-match", "", "expected issue revision (N or rev-N)")
+	return cmd
+}

--- a/cmd/kata/planning_date_test.go
+++ b/cmd/kata/planning_date_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeadlineSetsTimedDeadlineAndClearsIt(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "timed deadline issue")
+
+	out := runCLI(t, env, dir, "deadline", ref, "2026-09-01T09:30")
+	assert.Contains(t, out, "deadline_on")
+	issue := fetchMetaIssueViaHTTP(t, env, pid, ref)
+	require.JSONEq(t, `{"deadline_on":"2026-09-01T09:30"}`, string(issue.Issue.Metadata))
+
+	out = runCLI(t, env, dir, "deadline", ref, "-")
+	assert.Contains(t, out, "deadline_on")
+	issue = fetchMetaIssueViaHTTP(t, env, pid, ref)
+	require.JSONEq(t, `{}`, string(issue.Issue.Metadata))
+}
+
+func TestDeadlineAcceptsUTCInstantAndRejectsNumericOffset(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "deadline instant issue")
+
+	runCLI(t, env, dir, "deadline", ref, "2026-09-01T16:30:00Z")
+	issue := fetchMetaIssueViaHTTP(t, env, pid, ref)
+	require.JSONEq(t, `{"deadline_on":"2026-09-01T16:30:00Z"}`, string(issue.Issue.Metadata))
+
+	_, stderr, err := runCLIWithErr(t, env, dir, "deadline", ref, "2026-09-01T09:30:00-07:00")
+	ce := requireCLIError(t, err, ExitValidation)
+	assert.Equal(t, kindValidation, ce.Kind)
+	assert.Contains(t, stderr, "invalid_metadata_value")
+}
+
+func TestDeadlineHonorsIfMatch(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "conditional deadline issue")
+
+	_, stderr, err := runCLIWithErr(t, env, dir, "deadline", "--if-match", "rev-99", ref, "2026-09-01")
+	ce := requireCLIError(t, err, ExitConfirm)
+	assert.Equal(t, kindConfirm, ce.Kind)
+	assert.Contains(t, stderr, "revision conflict")
+
+	runCLI(t, env, dir, "deadline", "--if-match", "1", ref, "2026-09-01")
+	issue := fetchMetaIssueViaHTTP(t, env, pid, ref)
+	require.JSONEq(t, `{"deadline_on":"2026-09-01"}`, string(issue.Issue.Metadata))
+}
+
+func TestScheduleSetsTimedGateAndClearsIt(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "timed schedule issue")
+
+	out := runCLI(t, env, dir, "schedule", ref, "2026-09-01T09:30")
+	assert.Contains(t, out, "scheduled_on")
+	issue := fetchMetaIssueViaHTTP(t, env, pid, ref)
+	require.JSONEq(t, `{"scheduled_on":"2026-09-01T09:30"}`, string(issue.Issue.Metadata))
+
+	out = runCLI(t, env, dir, "schedule", ref, "-")
+	assert.Contains(t, out, "scheduled_on")
+	issue = fetchMetaIssueViaHTTP(t, env, pid, ref)
+	require.JSONEq(t, `{}`, string(issue.Issue.Metadata))
+}
+
+func TestScheduleHonorsIfMatch(t *testing.T) {
+	env, dir, pid := setupCLIWorkspace(t)
+	ref := createIssue(t, env, pid, "conditional schedule issue")
+
+	_, stderr, err := runCLIWithErr(t, env, dir, "schedule", "--if-match", "rev-99", ref, "2026-09-01")
+	ce := requireCLIError(t, err, ExitConfirm)
+	assert.Equal(t, kindConfirm, ce.Kind)
+	assert.Contains(t, stderr, "revision conflict")
+
+	runCLI(t, env, dir, "schedule", "--if-match", "1", ref, "2026-09-01")
+	issue := fetchMetaIssueViaHTTP(t, env, pid, ref)
+	require.JSONEq(t, `{"scheduled_on":"2026-09-01"}`, string(issue.Issue.Metadata))
+}

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -97,7 +97,25 @@ Use kata as the shared issue ledger for this workspace.
    # Release ownership
    kata unassign <ref>
 
-7. Use relationships deliberately. They live as flags on create + edit and
+7. Use native planning dates deliberately:
+
+   # Park until a date or time; a future value excludes the issue from ready/next.
+   # This is the first-class form of setting or clearing scheduled_on.
+   kata schedule <ref> <date-or-time>
+   kata schedule <ref> -
+
+   # Set or clear deadline_on. A deadline does not park the issue.
+   kata deadline <ref> <date-or-time>
+   kata deadline <ref> -
+
+   # Park with no date. Remove the marker to return; do not store false.
+   kata meta set <ref> someday true --json-value
+   kata meta unset <ref> someday
+
+   Date and time values accept YYYY-MM-DD, local YYYY-MM-DDTHH:MM[:SS],
+   or an RFC 3339 UTC instant ending in Z.
+
+8. Use relationships deliberately. They live as flags on create + edit and
    are framed from the operating issue's POV — no argument-order traps:
 
    parent      = this issue is a sub-task of a larger issue
@@ -112,13 +130,13 @@ Use kata as the shared issue ledger for this workspace.
    fail loudly. Read parent before asserting a removal. The other
    --remove-* flags are idempotent (no-op when the link is already gone).
 
-8. To leave context alongside a mutation, pass --comment TEXT on
+9. To leave context alongside a mutation, pass --comment TEXT on
    close, reopen, edit, assign, unassign, or label add/rm. The
    mutation lands first; the comment is appended in a follow-up call.
    If the comment call fails, the error names the issue so you can
    retry with kata comment <ref> --body ...
 
-9. Do not run delete or purge unless the user explicitly asks for that exact
+10. Do not run delete or purge unless the user explicitly asks for that exact
    destructive action and issue ref.
 
 For long-running agents, poll events:

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -24,6 +24,16 @@ func TestQuickstart_PrintsAgentInstructions(t *testing.T) {
 	assert.Contains(t, out, `kata events --after 0 --limit 100 --agent`)
 }
 
+func TestQuickstart_IncludesScheduleDeadlineAndSomedayCommands(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newQuickstartCmd()))
+
+	assert.Contains(t, out, "kata schedule <ref> <date-or-time>")
+	assert.Contains(t, out, "kata deadline <ref> <date-or-time>")
+	assert.Contains(t, out, "kata meta set <ref> someday true --json-value")
+	assert.Contains(t, out, "kata meta unset <ref> someday")
+}
+
 func TestQuickstart_PromotesCloseStep(t *testing.T) {
 	resetFlags(t)
 	out := string(executeRoot(t, newQuickstartCmd()))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,26 @@
 ---
 title: Changelog
 description: Release history for kata
+last_edited: 2026-08-12
 ---
 
 All notable changes to kata, grouped by release. Versioned releases start with
 0.5.0; earlier entries are a retroactive project history grouped by ISO week.
+
+## Unreleased
+
+**New features**
+
+- Added paired `kata schedule` / `kata deadline` commands and
+  `kata.set_schedule` / `kata.set_deadline` MCP tools for first-class planning
+  date updates.
+
+**Improvements**
+
+- Gave deadlines the same date, local date-time, UTC-instant, and timezone
+  projection rules as `scheduled_on`.
+- Added schedule, deadline, and someday commands to generated agent guidance and
+  public workflow documentation.
 
 ## 0.14.3
 <small>2026-08-10</small>

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-12
+---
+
 # Quickstart
 
 Install kata on macOS from Homebrew Core:
@@ -149,6 +153,18 @@ kata comment abc4 --body "Reproduced on macOS."
 
 Priorities run from `0` to `4`; `0` is highest. Omit priority when it is not
 useful.
+
+Set a schedule, deadline, or undated parking marker with these commands:
+
+```sh
+kata schedule abc4 2026-09-01T09:30
+kata deadline abc4 2026-09-01T17:00
+kata meta set abc4 someday true --json-value
+```
+
+A future `scheduled_on` value and `someday=true` keep the issue out of `ready`
+and `next`. A deadline does not. Clear these values with `kata schedule abc4 -`,
+`kata deadline abc4 -`, and `kata meta unset abc4 someday`.
 
 Human `kata list` output groups fetched children beneath their fetched parents
 with tree connectors. A child remains a top-level row when its parent is outside

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-12
+---
+
 # CLI reference
 
 This page summarizes the command surface. Run `kata <command> --help` for the
@@ -299,6 +303,8 @@ issue is already owned by someone else unless `--force` is used.
 ## Issue metadata
 
 ```sh
+kata schedule <ref> <date-or-time|-> [--if-match <rev>]
+kata deadline <ref> <date-or-time|-> [--if-match <rev>]
 kata meta set <ref> <key> <value> [--json-value] [--if-match <rev>]
 kata meta unset <ref> <key> [--if-match <rev>]
 kata meta get <ref> [key]
@@ -311,7 +317,27 @@ takes the same guard. `kata meta unset` clears a key (null merge-patch). `kata m
 metadata object or one key, and honors the global `--json` and `--agent`
 flags.
 
-See the [metadata conventions](metadata.md) for standard `work.*` keys.
+`kata schedule` sets the reserved `scheduled_on` value, and `kata deadline`
+sets `deadline_on`. Pass `-` to either command to clear its value. A date or
+time can use `YYYY-MM-DD`, local `YYYY-MM-DDTHH:MM[:SS]`, or an RFC 3339 UTC
+instant that ends in `Z`. A local value uses the issue timezone, then the daemon
+timezone, then UTC. Numeric offsets are not accepted. `--if-match` has the same
+revision behavior as the metadata commands.
+
+Use `scheduled_on` to keep an issue out of `ready` and `next` until a date or
+time. Use `someday=true` to park it with no date. A deadline value is only a
+deadline; it does not park the issue:
+
+```sh
+kata schedule abc4 2026-09-01T09:30
+kata schedule abc4 -
+kata deadline abc4 2026-09-01T17:00
+kata deadline abc4 -
+kata meta set abc4 someday true --json-value
+kata meta unset abc4 someday
+```
+
+See the [metadata conventions](metadata.md) for all reserved and standard keys.
 
 ## Coordination and wait
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-12
+---
+
 # Model Context Protocol server
 
 Kata includes a native stdio server for coding agents and other MCP clients:
@@ -69,8 +73,10 @@ calls per process.
 | `kata.edit` | Atomically change issue fields, ownership, priority, and relationship deltas. |
 | `kata.comment` | Append a progress or context comment. |
 | `kata.claim` | Claim an unowned issue for the bound actor. There is no force mode. |
+| `kata.set_deadline` | Set or clear an issue deadline, with an optional revision guard. |
 | `kata.set_label` | Ensure that a label is present or absent. |
 | `kata.set_metadata` | Patch metadata. A JSON `null` value removes a key. |
+| `kata.set_schedule` | Set or clear an issue schedule gate, with an optional revision guard. |
 | `kata.close` | Close completed work with a reason, message, and typed evidence. |
 | `kata.reopen` | Reopen work that needs another change. |
 
@@ -84,6 +90,14 @@ the actual event actor when an event exists.
 daemon applied. Compact issue results omit labels and blocked state when the
 daemon response does not contain those fields; they do not invent empty or
 false values.
+
+`kata.set_schedule` writes the reserved `scheduled_on` metadata key. Pass
+`schedule` to set a value or `clear_schedule: true` to remove it.
+`kata.set_deadline` writes `deadline_on`; pass `deadline` or
+`clear_deadline: true`. Each pair is mutually exclusive. An optional `revision`
+adds the same conditional-write guard as `kata.set_metadata`. Both tools accept
+`YYYY-MM-DD`, local `YYYY-MM-DDTHH:MM[:SS]`, or an RFC 3339 UTC instant that
+ends in `Z`.
 
 List, search, and ready results omit issue bodies and comments to keep agent
 context small. Their limits default to 20 and cannot exceed 100. `kata.show`

--- a/docs/reference/metadata.md
+++ b/docs/reference/metadata.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-12
+---
+
 # Metadata
 
 Every kata issue (and every project) carries a free-form JSON `metadata` object.
@@ -41,7 +45,7 @@ rejected. Everything else is stored verbatim.
 | Key | Applies to | Type |
 | --- | --- | --- |
 | `scheduled_on` | Issue | Date, local date-time, or UTC timestamp |
-| `deadline_on` | Issue | Date (`YYYY-MM-DD`) |
+| `deadline_on` | Issue | Date, local date-time, or UTC timestamp |
 | `someday` | Issue | Boolean |
 | `checklist` | Issue | Checklist structure |
 | `timezone` | Issue | IANA timezone name |
@@ -55,7 +59,8 @@ and does not use those timezones. If a local time repeats during a daylight
 saving transition, the first occurrence opens the gate. If a local time does
 not exist, the gate opens at the first valid instant after the gap. Numeric
 offsets are rejected because they pin an instant while duplicating the named
-timezone. `deadline_on` remains date-only.
+timezone. `deadline_on` accepts the same three forms and uses the same timezone
+rules. It is a deadline only; it does not control `ready` or `next`.
 
 All other keys are accepted opaquely by design: consumers carry their own
 metadata without a daemon release. When an opaque key later needs query
@@ -79,6 +84,8 @@ concurrency; it accepts either the bare revision (`7`) or the ETag form
 
 ```sh
 kata meta set abc4 work.branch "agent/task-slug"
+kata schedule abc4 "2026-09-01T09:30"
+kata deadline abc4 "2026-09-01T17:00"
 kata meta set abc4 someday true --json-value
 kata meta set abc4 work.attention needs-human --if-match rev-7
 ```
@@ -88,6 +95,11 @@ kata meta set abc4 work.attention needs-human --if-match rev-7
 ```sh
 kata meta unset <ref> <key>
 ```
+
+Use `kata schedule <ref> <date-or-time>` as the first-class form for setting
+`scheduled_on`, and `kata deadline <ref> <date-or-time>` for `deadline_on`.
+Pass `-` to either command to clear its value. The generic `kata meta set` and
+`kata meta unset` forms remain available for both keys.
 
 Sends a `null` merge patch, clearing the key. Accepts `--if-match <rev>` for
 optimistic concurrency, same as `kata meta set`.

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-08
+last_edited: 2026-08-12
 ---
 
 # Agent workflows
@@ -29,8 +29,8 @@ Default to `--agent` for ordinary reads and mutations in agent logs. Use
 To make a workspace self-documenting for agents, run `kata init --with-agents`
 once. It writes a marker-delimited kata briefing into existing real `AGENTS.md`
 and `CLAUDE.md` files, or creates `AGENTS.md` when neither exists. The block
-points back at `kata quickstart` and carries a short `work.*` attention
-conventions section (see
+points back at `kata quickstart` and carries short planning-date and `work.*`
+conventions (see
 [agent orchestration](../operations/agent-orchestration.md)); re-running
 refreshes only kata's block, so a repo initialized before that section shipped
 gains it on the next run. If a target file still carries a Beads integration
@@ -39,6 +39,22 @@ and writes a `<file>.kata-proposed` sidecar to adopt or discard — see
 [`--with-agents`](../get-started/quickstart.md#initialize-a-workspace). If
 `AGENTS.md` is a symlink, kata refuses to manage it before reading the target;
 replace it with a regular file before using `--with-agents`.
+
+The generated block gives agents exact commands for native planning state:
+
+```sh
+# A future schedule parks work until its gate opens.
+kata schedule <ref> <date-or-time>
+kata schedule <ref> -
+
+# A deadline does not park work.
+kata deadline <ref> <date-or-time>
+kata deadline <ref> -
+
+# Someday parks work with no date. Remove the key to return it to the queue.
+kata meta set <ref> someday true --json-value
+kata meta unset <ref> someday
+```
 
 Guidance files produce tendency, not contract: an agent can still end a session
 without updating its issue. For Claude Code workspaces,

--- a/internal/api/ui.go
+++ b/internal/api/ui.go
@@ -7,7 +7,7 @@ import (
 )
 
 // UISnapshotContractVersion identifies the browser snapshot wire contract.
-const UISnapshotContractVersion = "1"
+const UISnapshotContractVersion = "2"
 
 // UICapabilities describes the browser behavior authorized for this request.
 type UICapabilities struct {

--- a/internal/client/webui_test.go
+++ b/internal/client/webui_test.go
@@ -93,7 +93,7 @@ func TestOpenWebUIRemoteReadonlyOpensWithoutLogin(t *testing.T) {
 		assert.Empty(t, r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
-			"contract_version": "1",
+			"contract_version": "2",
 			"cursor":           1,
 			"capabilities": map[string]any{
 				"writable": false, "updates": "poll", "actor_policy": "request",

--- a/internal/daemon/handlers_instance_test.go
+++ b/internal/daemon/handlers_instance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/kata/internal/api"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/sqlitestore"
@@ -31,7 +32,7 @@ func TestInstance_ReturnsLocalUID(t *testing.T) {
 	getAndUnmarshal(t, ts, "/api/v1/instance", http.StatusOK, &body)
 	assert.Equal(t, d.db.InstanceUID(), body.InstanceUID)
 	assert.True(t, uid.Valid(body.InstanceUID), "instance_uid %q invalid", body.InstanceUID)
-	assert.Equal(t, "1", body.WebUIContractVersion)
+	assert.Equal(t, api.UISnapshotContractVersion, body.WebUIContractVersion)
 }
 
 // TestInstance_503WhenUIDUnset covers spec §8.8 second bullet: the handler

--- a/internal/daemon/handlers_ui.go
+++ b/internal/daemon/handlers_ui.go
@@ -342,7 +342,6 @@ func normalizeUISnapshotIntent(in *api.UISnapshotRequest) (normalizedUISnapshotI
 		}
 	} else {
 		localDate = ""
-		timeZone = ""
 	}
 	return normalizedUISnapshotIntent{
 		View: view, ProjectUID: projectUID,

--- a/internal/daemon/handlers_ui_daemons_test.go
+++ b/internal/daemon/handlers_ui_daemons_test.go
@@ -23,7 +23,8 @@ func TestWebDaemonRosterIsSanitizedAndReportsHealth(t *testing.T) {
 		assert.Equal(t, "/api/v1/instance", r.URL.Path)
 		assert.Equal(t, "Bearer target-token", r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"instance_uid":"01J00000000000000000000001","web_ui_contract_version":"1"}`)
+		_, _ = fmt.Fprintf(w, `{"instance_uid":"01J00000000000000000000001","web_ui_contract_version":%q}`,
+			api.UISnapshotContractVersion)
 	}))
 	t.Cleanup(connected.Close)
 	authRequired := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -98,6 +99,36 @@ func TestWebDaemonRosterReportsTargetsWithoutWebUIContract(t *testing.T) {
 	assert.Equal(t, "daemon does not support the Kata web UI", roster.Daemons[1].Hint)
 }
 
+func TestWebDaemonRosterRejectsPreviousSnapshotContract(t *testing.T) {
+	previous := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w,
+			`{"instance_uid":"01J00000000000000000000001","web_ui_contract_version":"1"}`)
+	}))
+	t.Cleanup(previous.Close)
+
+	d := openTestDB(t)
+	server := startTestServer(t, daemon.ServerConfig{
+		DB: d.db, StartedAt: d.now,
+		WebDaemons: []config.CatalogDaemonConfig{
+			{Name: "example-local", Local: true},
+			{Name: "example-remote", URL: previous.URL, AllowInsecure: true},
+		},
+	})
+
+	response, err := http.Get(server.URL + "/api/v1/ui/daemons")
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	var roster struct {
+		Daemons []struct {
+			Health string `json:"health"`
+		} `json:"daemons"`
+	}
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&roster))
+	require.Len(t, roster.Daemons, 2)
+	assert.Equal(t, "upgrade_required", roster.Daemons[1].Health)
+}
+
 func TestAnonymousReadonlyRosterHidesConfiguredCredentialTargetsBeforeProbing(t *testing.T) {
 	var calls atomic.Int64
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -157,7 +188,8 @@ func TestWebDaemonProxyPinsTargetAndStripsBrowserCredentials(t *testing.T) {
 		assert.Equal(t, "application/json", r.Header.Get("Accept"))
 		w.Header().Set("Set-Cookie", "upstream=secret")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"contract_version":"1","cursor":7,"capabilities":{"writable":true,"updates":"sse","actor_policy":"request"}}`)
+		_, _ = fmt.Fprintf(w, `{"contract_version":%q,"cursor":7,"capabilities":{"writable":true,"updates":"sse","actor_policy":"request"}}`,
+			api.UISnapshotContractVersion)
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -185,7 +217,8 @@ func TestWebDaemonProxyPinsTargetAndStripsBrowserCredentials(t *testing.T) {
 	body, err := io.ReadAll(response.Body)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, response.StatusCode, string(body))
-	assert.JSONEq(t, `{"contract_version":"1","cursor":7,"capabilities":{"writable":true,"updates":"poll","actor_policy":"request"}}`, string(body))
+	assert.JSONEq(t, fmt.Sprintf(`{"contract_version":%q,"cursor":7,"capabilities":{"writable":true,"updates":"poll","actor_policy":"request"}}`,
+		api.UISnapshotContractVersion), string(body))
 	assert.Empty(t, response.Header.Get("Set-Cookie"))
 }
 

--- a/internal/daemon/handlers_ui_test.go
+++ b/internal/daemon/handlers_ui_test.go
@@ -246,12 +246,14 @@ func TestUISnapshotTemporalIntent(t *testing.T) {
 	for _, view := range []string{"inbox", "all-open", "logbook"} {
 		t.Run(view, func(t *testing.T) {
 			first, _ := getUISnapshot(t, ts, url.Values{
-				"view": {view}, "local_date": {"2026-08-01"}, "time_zone": {"America/Chicago"},
+				"view": {view}, "time_zone": {"America/Chicago"},
 			}, "")
+			require.Equal(t, "America/Chicago", store.lastSnapshot.TimeZone)
+			require.Empty(t, store.lastSnapshot.LocalDate)
 			second, _ := getUISnapshot(t, ts, url.Values{
-				"view": {view}, "local_date": {"2026-08-02"}, "time_zone": {"America/New_York"},
+				"view": {view}, "time_zone": {"America/New_York"},
 			}, "")
-			require.Equal(t, first.Header.Get("ETag"), second.Header.Get("ETag"))
+			require.NotEqual(t, first.Header.Get("ETag"), second.Header.Get("ETag"))
 		})
 	}
 }

--- a/internal/db/dbtest/ui_contract.go
+++ b/internal/db/dbtest/ui_contract.go
@@ -398,6 +398,141 @@ func RunUISnapshotViewScopeContract(t *testing.T, open func(*testing.T) db.Stora
 		require.Equal(t, "2026-08-01", upcoming.Issues[0].ScheduledOnDate)
 	})
 
+	t.Run("timed deadlines use the browser calendar before limit", func(t *testing.T) {
+		store := open(t)
+		uiStore := store.(db.UIStore)
+		ctx := context.Background()
+		project := createCursorProject(ctx, t, store)
+		previousDay, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID, Title: "Previous browser deadline", Author: "user-a",
+			Metadata: map[string]json.RawMessage{
+				"deadline_on": json.RawMessage(`"2026-08-01T00:30:00Z"`),
+			},
+		})
+		require.NoError(t, err)
+		_, _, err = store.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID, Title: "Next browser deadline", Author: "user-a",
+			Metadata: map[string]json.RawMessage{
+				"deadline_on": json.RawMessage(`"2026-08-01T07:30:00Z"`),
+			},
+		})
+		require.NoError(t, err)
+
+		today, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+			View: "today", LocalDate: "2026-07-31", TimeZone: "America/Los_Angeles", Limit: 1,
+		})
+		require.NoError(t, err)
+		require.Len(t, today.Issues, 1)
+		require.Equal(t, previousDay.UID, today.Issues[0].UID)
+		require.Equal(t, "2026-07-31", today.Issues[0].DeadlineOnDate)
+	})
+
+	t.Run("deadline projection does not inherit a recurrence timezone", func(t *testing.T) {
+		store := open(t)
+		uiStore := store.(db.UIStore)
+		ctx := context.Background()
+		project := createCursorProject(ctx, t, store)
+		issue, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID, Title: "Recurrence deadline", Author: "user-a",
+			Metadata: map[string]json.RawMessage{
+				"deadline_on": json.RawMessage(`"2026-08-01T23:30"`),
+			},
+		})
+		require.NoError(t, err)
+		_, err = store.CreateRecurrenceForIssue(ctx, db.CreateRecurrenceForIssueIn{
+			IssueID: issue.ID,
+			Recurrence: db.CreateRecurrenceIn{
+				ProjectID: project.ID, Actor: "user-a", Rule: "FREQ=DAILY;COUNT=2",
+				DTStart: "2026-08-01", Timezone: "America/Los_Angeles",
+				Template: db.RecurrenceTemplate{Title: issue.Title},
+			},
+		})
+		require.NoError(t, err)
+		_, err = store.PatchIssueMetadata(ctx, db.PatchIssueMetadataIn{
+			IssueID: issue.ID, Actor: "user-a",
+			Patch: map[string]json.RawMessage{
+				"scheduled_on": json.RawMessage(`null`),
+				"timezone":     json.RawMessage(`null`),
+			},
+		})
+		require.NoError(t, err)
+
+		snapshot, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+			ProjectUID: project.UID, View: "deadlines", LocalDate: "2026-08-01",
+			TimeZone: "UTC", DefaultTimezone: "UTC",
+		})
+		require.NoError(t, err)
+		require.Len(t, snapshot.Issues, 1)
+		require.Equal(t, "2026-08-01", snapshot.Issues[0].DeadlineOnDate)
+
+		today, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+			ProjectUID: project.UID, View: "today", LocalDate: "2026-08-01",
+			TimeZone: "UTC", DefaultTimezone: "UTC",
+		})
+		require.NoError(t, err)
+		require.Len(t, today.Issues, 1,
+			"Today must evaluate the deadline with the daemon timezone, not the recurrence timezone")
+		require.Equal(t, issue.UID, today.Issues[0].UID)
+	})
+
+	t.Run("non-calendar views project deadline dates", func(t *testing.T) {
+		store := open(t)
+		uiStore := store.(db.UIStore)
+		ctx := context.Background()
+		project := createCursorProject(ctx, t, store)
+		issue, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+			ProjectID: project.ID, Title: "All-open deadline", Author: "user-a",
+			Metadata: map[string]json.RawMessage{
+				"deadline_on": json.RawMessage(`"2026-09-01T00:30:00Z"`),
+			},
+		})
+		require.NoError(t, err)
+
+		snapshot, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+			ProjectUID: project.UID, View: "all-open", TimeZone: "America/Los_Angeles",
+			DefaultTimezone: "UTC",
+		})
+		require.NoError(t, err)
+		require.Len(t, snapshot.Issues, 1)
+		require.Equal(t, issue.UID, snapshot.Issues[0].UID)
+		require.Equal(t, "2026-08-31", snapshot.Issues[0].DeadlineOnDate)
+	})
+
+	t.Run("selected issues project timed deadline dates", func(t *testing.T) {
+		for _, test := range []struct {
+			name     string
+			metadata map[string]json.RawMessage
+		}{
+			{name: "UTC instant", metadata: map[string]json.RawMessage{
+				"deadline_on": json.RawMessage(`"2026-09-01T00:30:00Z"`),
+			}},
+			{name: "local time", metadata: map[string]json.RawMessage{
+				"deadline_on": json.RawMessage(`"2026-09-01T09:00"`),
+				"timezone":    json.RawMessage(`"Asia/Tokyo"`),
+			}},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				store := open(t)
+				uiStore := store.(db.UIStore)
+				ctx := context.Background()
+				project := createCursorProject(ctx, t, store)
+				issue, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+					ProjectID: project.ID, Title: "Selected deadline", Author: "user-a",
+					Metadata: test.metadata,
+				})
+				require.NoError(t, err)
+
+				snapshot, err := uiStore.ReadUISnapshot(ctx, db.UISnapshotQuery{
+					ProjectUID: project.UID, View: "all-open", SelectedIssueUID: issue.UID,
+					TimeZone: "America/Los_Angeles", DefaultTimezone: "UTC",
+				})
+				require.NoError(t, err)
+				require.NotNil(t, snapshot.SelectedIssue)
+				require.Equal(t, "2026-08-31", snapshot.SelectedIssue.DeadlineOnDate)
+			})
+		}
+	})
+
 	t.Run("ready uses linked recurrence timezone for legacy issues", func(t *testing.T) {
 		store := open(t)
 		uiStore := store.(db.UIStore)

--- a/internal/db/pgstore/ui.go
+++ b/internal/db/pgstore/ui.go
@@ -81,6 +81,11 @@ func (s *Store) ReadUISnapshot(ctx context.Context, query db.UISnapshotQuery) (d
 				return db.UISnapshotData{}, err
 			}
 		} else {
+			if err := db.ProjectUIDeadlineDate(&selected, query); err != nil {
+				return db.UISnapshotData{}, fmt.Errorf(
+					"read UI selected issue %s deadline: %w", selected.UID, err,
+				)
+			}
 			data.SelectedState = "available"
 			data.SelectedIssue = &selected
 			data.Comments, err = readUIComments(ctx, tx, selected.ID)
@@ -413,7 +418,7 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 		}
 	}
 	filterReadySchedules := false
-	filterCalendarSchedules := query.View == "today" || query.View == "upcoming"
+	filterCalendarSchedules := query.View == "today" || query.View == "upcoming" || query.View == "deadlines"
 	if len(statuses) > 0 && !slices.Contains(statuses, "all") {
 		statusPredicates := []string{}
 		persistedStatuses := []string{}
@@ -447,9 +452,8 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 	case "inbox":
 		statement += ` AND p.metadata::jsonb ->> 'role' = 'inbox'`
 	case "today":
-		args = append(args, query.LocalDate)
-		statement += fmt.Sprintf(` AND (i.metadata::jsonb ->> 'scheduled_on' IS NOT NULL`+
-			` OR LEFT(i.metadata::jsonb ->> 'deadline_on', 10) <= $%d)`, len(args))
+		statement += ` AND (i.metadata::jsonb ->> 'scheduled_on' IS NOT NULL` +
+			` OR i.metadata::jsonb ->> 'deadline_on' IS NOT NULL)`
 	case "upcoming":
 		statement += ` AND i.metadata::jsonb ->> 'scheduled_on' IS NOT NULL`
 	case "deadlines":
@@ -516,11 +520,13 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 			}
 		}
 		scheduledOnDate := ""
+		deadlineOnDate := ""
 		if filterCalendarSchedules {
 			var matches bool
-			scheduleQuery := query
-			scheduleQuery.DefaultTimezone = scheduleDefaultTimezone(recurrenceTimezone, query.DefaultTimezone)
-			scheduledOnDate, matches, err = db.MatchUICalendarView(string(issue.Metadata), scheduleQuery)
+			scheduledOnDate, deadlineOnDate, matches, err = db.MatchUICalendarView(
+				string(issue.Metadata), query,
+				scheduleDefaultTimezone(recurrenceTimezone, query.DefaultTimezone),
+			)
 			if err != nil {
 				_ = rows.Close()
 				return nil, fmt.Errorf("read UI issue %s calendar schedule: %w", issue.UID, err)
@@ -528,9 +534,18 @@ func readUIIssues(ctx context.Context, tx *sql.Tx, query db.UISnapshotQuery,
 			if !matches {
 				continue
 			}
+		} else {
+			deadlineOnDate, _, err = metadata.DeadlineOnCalendarDate(
+				string(issue.Metadata), query.TimeZone, query.DefaultTimezone,
+			)
+			if err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("read UI issue %s deadline: %w", issue.UID, err)
+			}
 		}
 		uiIssue := makeUIIssue(issue, projectNames[issue.ProjectID], nil)
 		uiIssue.ScheduledOnDate = scheduledOnDate
+		uiIssue.DeadlineOnDate = deadlineOnDate
 		issues = append(issues, uiIssue)
 		if limit > 0 && len(issues) == limit {
 			break

--- a/internal/db/sqlitestore/ui.go
+++ b/internal/db/sqlitestore/ui.go
@@ -84,6 +84,11 @@ func (d *Store) ReadUISnapshot(ctx context.Context, query db.UISnapshotQuery) (d
 				return db.UISnapshotData{}, err
 			}
 		} else {
+			if err := db.ProjectUIDeadlineDate(&selected, query); err != nil {
+				return db.UISnapshotData{}, fmt.Errorf(
+					"read UI selected issue %s deadline: %w", selected.UID, err,
+				)
+			}
 			data.SelectedState = "available"
 			data.SelectedIssue = &selected
 			data.Comments, err = readUIComments(ctx, tx, selected.ID)
@@ -406,7 +411,7 @@ func readUIIssues(
 		}
 	}
 	filterReadySchedules := false
-	filterCalendarSchedules := query.View == "today" || query.View == "upcoming"
+	filterCalendarSchedules := query.View == "today" || query.View == "upcoming" || query.View == "deadlines"
 	if len(statuses) > 0 && !slices.Contains(statuses, "all") {
 		statusPredicates := []string{}
 		persistedStatuses := []string{}
@@ -444,8 +449,7 @@ func readUIIssues(
 		statement += ` AND json_extract(p.metadata, '$.role') = 'inbox'`
 	case "today":
 		statement += ` AND (json_extract(i.metadata, '$.scheduled_on') IS NOT NULL` +
-			` OR substr(json_extract(i.metadata, '$.deadline_on'), 1, 10) <= ?)`
-		args = append(args, query.LocalDate)
+			` OR json_extract(i.metadata, '$.deadline_on') IS NOT NULL)`
 	case "upcoming":
 		statement += ` AND json_extract(i.metadata, '$.scheduled_on') IS NOT NULL`
 	case "deadlines":
@@ -518,20 +522,30 @@ func readUIIssues(
 			}
 		}
 		scheduledOnDate := ""
+		deadlineOnDate := ""
 		if filterCalendarSchedules {
 			var matches bool
-			scheduleQuery := query
-			scheduleQuery.DefaultTimezone = scheduleDefaultTimezone(recurrenceTimezone, query.DefaultTimezone)
-			scheduledOnDate, matches, err = db.MatchUICalendarView(string(issue.Metadata), scheduleQuery)
+			scheduledOnDate, deadlineOnDate, matches, err = db.MatchUICalendarView(
+				string(issue.Metadata), query,
+				scheduleDefaultTimezone(recurrenceTimezone, query.DefaultTimezone),
+			)
 			if err != nil {
 				return nil, fmt.Errorf("read UI issue %s calendar schedule: %w", issue.UID, err)
 			}
 			if !matches {
 				continue
 			}
+		} else {
+			deadlineOnDate, _, err = metadata.DeadlineOnCalendarDate(
+				string(issue.Metadata), query.TimeZone, query.DefaultTimezone,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("read UI issue %s deadline: %w", issue.UID, err)
+			}
 		}
 		uiIssue := makeUIIssue(issue, projectNames[issue.ProjectID], nil)
 		uiIssue.ScheduledOnDate = scheduledOnDate
+		uiIssue.DeadlineOnDate = deadlineOnDate
 		issues = append(issues, uiIssue)
 		if limit > 0 && len(issues) == limit {
 			break

--- a/internal/db/ui.go
+++ b/internal/db/ui.go
@@ -2,8 +2,6 @@ package db
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"go.kenn.io/kata/internal/metadata"
 )
@@ -57,34 +55,55 @@ type UIIssue struct {
 	QualifiedID     string   `json:"qualified_id"`
 	Labels          []string `json:"labels"`
 	ScheduledOnDate string   `json:"scheduled_on_date,omitempty"`
+	DeadlineOnDate  string   `json:"deadline_on_date,omitempty"`
 }
 
 // MatchUICalendarView evaluates date-sensitive browser collection predicates
-// after a schedule has been projected into the browser timezone. The returned
-// date is also the canonical grouping key sent to the browser.
-func MatchUICalendarView(raw string, query UISnapshotQuery) (string, bool, error) {
+// after planning dates have been projected into the browser timezone.
+// scheduledDefaultTimezone can include the legacy recurrence fallback;
+// deadlines always use the daemon default from query.
+func MatchUICalendarView(
+	raw string,
+	query UISnapshotQuery,
+	scheduledDefaultTimezone string,
+) (string, string, bool, error) {
 	scheduledDate, scheduled, err := metadata.ScheduledOnCalendarDate(
+		raw, query.TimeZone, scheduledDefaultTimezone,
+	)
+	if err != nil {
+		return "", "", false, err
+	}
+	deadlineDate, deadline, err := metadata.DeadlineOnCalendarDate(
 		raw, query.TimeZone, query.DefaultTimezone,
 	)
 	if err != nil {
-		return "", false, err
+		return "", "", false, err
 	}
 	switch query.View {
 	case "upcoming":
-		return scheduledDate, scheduled && scheduledDate > query.LocalDate, nil
+		return scheduledDate, deadlineDate, scheduled && scheduledDate > query.LocalDate, nil
 	case "today":
-		var values struct {
-			DeadlineOn string `json:"deadline_on"`
-		}
-		if err := json.Unmarshal([]byte(raw), &values); err != nil {
-			return "", false, fmt.Errorf("decode UI calendar metadata: %w", err)
-		}
 		scheduleDue := scheduled && scheduledDate <= query.LocalDate
-		deadlineDue := values.DeadlineOn != "" && values.DeadlineOn <= query.LocalDate
-		return scheduledDate, scheduleDue || deadlineDue, nil
+		deadlineDue := deadline && deadlineDate <= query.LocalDate
+		return scheduledDate, deadlineDate, scheduleDue || deadlineDue, nil
+	case "deadlines":
+		return "", deadlineDate, true, nil
 	default:
-		return "", true, nil
+		return scheduledDate, deadlineDate, true, nil
 	}
+}
+
+// ProjectUIDeadlineDate gives a selected issue the same browser-calendar
+// deadline projection as collection rows.
+func ProjectUIDeadlineDate(issue *UIIssue, query UISnapshotQuery) error {
+	deadlineDate, _, err := metadata.DeadlineOnCalendarDate(
+		string(issue.Metadata), query.TimeZone, query.DefaultTimezone,
+	)
+	if err != nil {
+		return err
+	}
+	issue.DeadlineOnDate = deadlineDate
+	return nil
 }
 
 // UILink enriches a stored link with stable display references for each end.

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -430,6 +430,42 @@ func (h toolHandlers) setLabel(ctx context.Context, _ *sdkmcp.CallToolRequest, i
 	return successResult(), h.mutation(response.Issue, response.Changed, response.Reused, &response.Event), nil
 }
 
+func (h toolHandlers) setDeadline(ctx context.Context, _ *sdkmcp.CallToolRequest, input SetDeadlineInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
+	ref, err := h.boundRef(input.Ref)
+	if err != nil {
+		return nil, MutationOutput{}, err
+	}
+	if input.Deadline != nil && input.ClearDeadline {
+		return nil, MutationOutput{}, errors.New("deadline and clear_deadline are mutually exclusive")
+	}
+	if input.Deadline == nil && !input.ClearDeadline {
+		return nil, MutationOutput{}, errors.New("set_deadline requires deadline or clear_deadline")
+	}
+	value := any(nil)
+	if input.Deadline != nil {
+		value = *input.Deadline
+	}
+	return h.patchMetadata(ctx, ref, map[string]any{"deadline_on": value}, input.Revision)
+}
+
+func (h toolHandlers) setSchedule(ctx context.Context, _ *sdkmcp.CallToolRequest, input SetScheduleInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
+	ref, err := h.boundRef(input.Ref)
+	if err != nil {
+		return nil, MutationOutput{}, err
+	}
+	if input.Schedule != nil && input.ClearSchedule {
+		return nil, MutationOutput{}, errors.New("schedule and clear_schedule are mutually exclusive")
+	}
+	if input.Schedule == nil && !input.ClearSchedule {
+		return nil, MutationOutput{}, errors.New("set_schedule requires schedule or clear_schedule")
+	}
+	value := any(nil)
+	if input.Schedule != nil {
+		value = *input.Schedule
+	}
+	return h.patchMetadata(ctx, ref, map[string]any{"scheduled_on": value}, input.Revision)
+}
+
 func (h toolHandlers) setMetadata(ctx context.Context, _ *sdkmcp.CallToolRequest, input SetMetadataInput) (*sdkmcp.CallToolResult, MutationOutput, error) {
 	ref, err := h.boundRef(input.Ref)
 	if err != nil {
@@ -443,17 +479,21 @@ func (h toolHandlers) setMetadata(ctx context.Context, _ *sdkmcp.CallToolRequest
 			return nil, MutationOutput{}, errors.New("metadata keys must not be empty")
 		}
 	}
+	return h.patchMetadata(ctx, ref, input.Patch, input.Revision)
+}
+
+func (h toolHandlers) patchMetadata(ctx context.Context, ref string, patch map[string]any, revision *int64) (*sdkmcp.CallToolResult, MutationOutput, error) {
 	var headers *generated.PatchIssueMetadataHeaders
-	if input.Revision != nil {
-		if *input.Revision < 0 {
+	if revision != nil {
+		if *revision < 0 {
 			return nil, MutationOutput{}, errors.New("revision must not be negative")
 		}
-		ifMatch := `"rev-` + strconv.FormatInt(*input.Revision, 10) + `"`
+		ifMatch := `"rev-` + strconv.FormatInt(*revision, 10) + `"`
 		headers = &generated.PatchIssueMetadataHeaders{IfMatch: &ifMatch}
 	}
 	response, err := h.options.Client.PatchIssueMetadata(ctx, &generated.PatchIssueMetadataRequestOptions{
 		PathParams: &generated.PatchIssueMetadataPath{ProjectID: h.options.ProjectID, Ref: ref},
-		Body:       &generated.PatchIssueMetadataBody{Actor: &h.options.Actor, Patch: input.Patch},
+		Body:       &generated.PatchIssueMetadataBody{Actor: &h.options.Actor, Patch: patch},
 		Header:     headers,
 	})
 	if err != nil {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -126,8 +126,10 @@ func registerTools(server *sdkmcp.Server, options Options) {
 	addTool(server, "kata.ready", "List ready issues", "List open issues with no open blocking predecessor in the bound project.", read, handlers.ready)
 	addTool(server, "kata.reopen", "Reopen issue", "Reopen a closed issue when new work is required.", mutating, handlers.reopen)
 	addTool(server, "kata.search", "Search issues", "Search titles, bodies, and comments before creating duplicate work.", searchRead, handlers.search)
+	addTool(server, "kata.set_deadline", "Set deadline", "Set or clear an issue deadline. Values accept a date, local date-time, or RFC 3339 UTC instant ending in Z.", mutating, handlers.setDeadline)
 	addTool(server, "kata.set_label", "Set label presence", "Ensure that a label is present or absent on an issue.", mutating, handlers.setLabel)
 	addTool(server, "kata.set_metadata", "Patch metadata", "Patch issue metadata; JSON null removes a key. An optional revision makes the write conditional.", mutating, handlers.setMetadata)
+	addTool(server, "kata.set_schedule", "Set schedule", "Set or clear an issue schedule gate. Values accept a date, local date-time, or RFC 3339 UTC instant ending in Z.", mutating, handlers.setSchedule)
 	addTool(server, "kata.show", "Show issue", "Read one issue with its body, metadata, relationships, and a bounded comment history.", read, handlers.show)
 }
 
@@ -236,6 +238,14 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 		setStringBounds("ref", 1, 256)
 		setStringBounds("label", 1, 64)
 		property("label").Pattern = `^[a-z0-9._:-]+$`
+	case "kata.set_deadline":
+		setStringBounds("ref", 1, 256)
+		setStringBounds("deadline", 1, 64)
+		if field := property("revision"); field != nil {
+			minimum := float64(0)
+			field.Minimum = &minimum
+		}
+		schema.OneOf = planningDateSchemas("deadline", "clear_deadline")
 	case "kata.set_metadata":
 		setStringBounds("ref", 1, 256)
 		if field := property("revision"); field != nil {
@@ -246,6 +256,14 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 			minimum := 1
 			field.MinProperties = &minimum
 		}
+	case "kata.set_schedule":
+		setStringBounds("ref", 1, 256)
+		setStringBounds("schedule", 1, 64)
+		if field := property("revision"); field != nil {
+			minimum := float64(0)
+			field.Minimum = &minimum
+		}
+		schema.OneOf = planningDateSchemas("schedule", "clear_schedule")
 	case "kata.close":
 		setStringBounds("ref", 1, 256)
 		setStringBounds("message", 1, 1<<20)
@@ -256,6 +274,23 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 		setStringBounds("ref", 1, 256)
 	}
 	return schema
+}
+
+func planningDateSchemas(valueField, clearField string) []*jsonschema.Schema {
+	trueValue := any(true)
+	return []*jsonschema.Schema{
+		{
+			Required: []string{valueField},
+			Not:      &jsonschema.Schema{Required: []string{clearField}},
+		},
+		{
+			Required: []string{clearField},
+			Properties: map[string]*jsonschema.Schema{
+				clearField: {Const: &trueValue},
+			},
+			Not: &jsonschema.Schema{Required: []string{valueField}},
+		},
+	}
 }
 
 func evidenceVariant(kind string) *jsonschema.Schema {
@@ -450,6 +485,22 @@ type SetLabelInput struct {
 	Ref     string `json:"ref" jsonschema:"Issue reference in the bound project"`
 	Label   string `json:"label" jsonschema:"Project label"`
 	Present bool   `json:"present" jsonschema:"True to add the label; false to remove it"`
+}
+
+// SetDeadlineInput sets or clears the deadline_on metadata primitive.
+type SetDeadlineInput struct {
+	Ref           string  `json:"ref" jsonschema:"Issue reference in the bound project"`
+	Deadline      *string `json:"deadline,omitempty" jsonschema:"Deadline date, local date-time, or RFC 3339 UTC instant ending in Z"`
+	ClearDeadline bool    `json:"clear_deadline,omitempty" jsonschema:"Remove the current deadline"`
+	Revision      *int64  `json:"revision,omitempty" jsonschema:"Required current issue revision for a conditional write"`
+}
+
+// SetScheduleInput sets or clears the scheduled_on metadata primitive.
+type SetScheduleInput struct {
+	Ref           string  `json:"ref" jsonschema:"Issue reference in the bound project"`
+	Schedule      *string `json:"schedule,omitempty" jsonschema:"Schedule date, local date-time, or RFC 3339 UTC instant ending in Z"`
+	ClearSchedule bool    `json:"clear_schedule,omitempty" jsonschema:"Remove the current schedule gate"`
+	Revision      *int64  `json:"revision,omitempty" jsonschema:"Required current issue revision for a conditional write"`
 }
 
 // SetMetadataInput patches several keys in one operation.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -58,8 +58,10 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 		"kata.ready",
 		"kata.reopen",
 		"kata.search",
+		"kata.set_deadline",
 		"kata.set_label",
 		"kata.set_metadata",
+		"kata.set_schedule",
 		"kata.show",
 	}
 	gotNames := make([]string, 0, len(result.Tools))
@@ -273,6 +275,28 @@ func TestCloseInputSchemaMirrorsDaemonEvidenceMatrix(t *testing.T) {
 	}
 }
 
+func TestSetDeadlineInputSchemaRequiresOneMutation(t *testing.T) {
+	schema, err := inputSchemaFor[SetDeadlineInput]("kata.set_deadline").Resolve(nil)
+	require.NoError(t, err)
+
+	require.NoError(t, schema.Validate(map[string]any{"ref": "abc1", "deadline": "2026-09-01T09:30"}))
+	require.NoError(t, schema.Validate(map[string]any{"ref": "abc1", "clear_deadline": true}))
+	require.Error(t, schema.Validate(map[string]any{"ref": "abc1"}))
+	require.Error(t, schema.Validate(map[string]any{"ref": "abc1", "deadline": "2026-09-01", "clear_deadline": true}))
+	require.Error(t, schema.Validate(map[string]any{"ref": "abc1", "clear_deadline": false}))
+}
+
+func TestSetScheduleInputSchemaRequiresOneMutation(t *testing.T) {
+	schema, err := inputSchemaFor[SetScheduleInput]("kata.set_schedule").Resolve(nil)
+	require.NoError(t, err)
+
+	require.NoError(t, schema.Validate(map[string]any{"ref": "abc1", "schedule": "2026-09-01T09:30"}))
+	require.NoError(t, schema.Validate(map[string]any{"ref": "abc1", "clear_schedule": true}))
+	require.Error(t, schema.Validate(map[string]any{"ref": "abc1"}))
+	require.Error(t, schema.Validate(map[string]any{"ref": "abc1", "schedule": "2026-09-01", "clear_schedule": true}))
+	require.Error(t, schema.Validate(map[string]any{"ref": "abc1", "clear_schedule": false}))
+}
+
 func TestToolsUseBoundDaemonProjectAndActor(t *testing.T) {
 	requests := make(chan capturedRequest, 20)
 	daemon := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -313,6 +337,8 @@ func TestToolsUseBoundDaemonProjectAndActor(t *testing.T) {
 		{name: "edit", tool: "kata.edit", arguments: map[string]any{"ref": "abc1", "title": "Updated title", "add_related": []string{"spoke-project#def2"}}, wantMethod: http.MethodPatch, wantPath: "/api/v1/projects/42/issues/abc1", wantActor: true, wantMatch: "abc1"},
 		{name: "comment", tool: "kata.comment", arguments: map[string]any{"ref": "abc1", "body": "Progress note", "idempotency_key": "comment-1"}, wantMethod: http.MethodPost, wantPath: "/api/v1/projects/42/issues/abc1/comments", wantActor: true, wantKey: "comment-1", wantMatch: "Progress note"},
 		{name: "claim", tool: "kata.claim", arguments: map[string]any{"ref": "abc1"}, wantMethod: http.MethodPost, wantPath: "/api/v1/projects/42/issues/abc1/actions/claim", wantActor: true, wantMatch: "abc1"},
+		{name: "set deadline", tool: "kata.set_deadline", arguments: map[string]any{"ref": "abc1", "deadline": "2026-09-01T09:30", "revision": 7}, wantMethod: http.MethodPost, wantPath: "/api/v1/projects/42/issues/abc1/metadata", wantActor: true, wantMatch: "abc1"},
+		{name: "set schedule", tool: "kata.set_schedule", arguments: map[string]any{"ref": "abc1", "schedule": "2026-09-01T09:30", "revision": 7}, wantMethod: http.MethodPost, wantPath: "/api/v1/projects/42/issues/abc1/metadata", wantActor: true, wantMatch: "abc1"},
 		{name: "add label", tool: "kata.set_label", arguments: map[string]any{"ref": "abc1", "label": "bug", "present": true}, wantMethod: http.MethodPost, wantPath: "/api/v1/projects/42/issues/abc1/labels", wantActor: true, wantMatch: "abc1"},
 		{name: "patch metadata", tool: "kata.set_metadata", arguments: map[string]any{"ref": "abc1", "patch": map[string]any{"work.attention": "ok"}, "revision": 7}, wantMethod: http.MethodPost, wantPath: "/api/v1/projects/42/issues/abc1/metadata", wantActor: true, wantMatch: "abc1"},
 		{name: "close", tool: "kata.close", arguments: map[string]any{"ref": "abc1", "reason": "done", "message": "Completed the requested work and verified its behavior.", "evidence": []map[string]any{{"type": "test", "command": "go test ./..."}}}, wantMethod: http.MethodPost, wantPath: "/api/v1/projects/42/issues/abc1/actions/close", wantActor: true, wantMatch: "abc1"},
@@ -349,7 +375,7 @@ func TestToolsUseBoundDaemonProjectAndActor(t *testing.T) {
 			if tt.wantKey != "" {
 				require.Equal(t, tt.wantKey, request.Header.Get("Idempotency-Key"))
 			}
-			if tt.tool == "kata.set_metadata" {
+			if tt.tool == "kata.set_metadata" || tt.tool == "kata.set_deadline" || tt.tool == "kata.set_schedule" {
 				require.Equal(t, `"rev-7"`, request.Header.Get("If-Match"))
 			}
 			if tt.wantActor {
@@ -360,6 +386,12 @@ func TestToolsUseBoundDaemonProjectAndActor(t *testing.T) {
 				if tt.tool == "kata.edit" {
 					links := body["links_delta"].(map[string]any)
 					require.Equal(t, []any{"def2"}, links["add_related"])
+				}
+				if tt.tool == "kata.set_deadline" {
+					require.Equal(t, map[string]any{"deadline_on": "2026-09-01T09:30"}, body["patch"])
+				}
+				if tt.tool == "kata.set_schedule" {
+					require.Equal(t, map[string]any{"scheduled_on": "2026-09-01T09:30"}, body["patch"])
 				}
 			}
 		})
@@ -451,6 +483,58 @@ func TestToolsRoundTripAgainstRealDaemon(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, conflict.IsError)
 	require.Contains(t, string(mustJSON(t, conflict.Content)), "revision")
+
+	deadlineSet, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.set_deadline", Arguments: map[string]any{"ref": ref, "deadline": "2026-09-01T16:30:00Z"},
+	})
+	require.NoError(t, err)
+	require.False(t, deadlineSet.IsError, deadlineSet.Content)
+
+	shown, err = session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.show", Arguments: map[string]any{"ref": ref},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "2026-09-01T16:30:00Z",
+		shown.StructuredContent.(map[string]any)["issue"].(map[string]any)["metadata"].(map[string]any)["deadline_on"])
+
+	deadlineCleared, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.set_deadline", Arguments: map[string]any{"ref": ref, "clear_deadline": true},
+	})
+	require.NoError(t, err)
+	require.False(t, deadlineCleared.IsError, deadlineCleared.Content)
+
+	shown, err = session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.show", Arguments: map[string]any{"ref": ref},
+	})
+	require.NoError(t, err)
+	require.NotContains(t,
+		shown.StructuredContent.(map[string]any)["issue"].(map[string]any)["metadata"].(map[string]any), "deadline_on")
+
+	scheduleSet, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.set_schedule", Arguments: map[string]any{"ref": ref, "schedule": "2026-09-02T09:30"},
+	})
+	require.NoError(t, err)
+	require.False(t, scheduleSet.IsError, scheduleSet.Content)
+
+	shown, err = session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.show", Arguments: map[string]any{"ref": ref},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "2026-09-02T09:30",
+		shown.StructuredContent.(map[string]any)["issue"].(map[string]any)["metadata"].(map[string]any)["scheduled_on"])
+
+	scheduleCleared, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.set_schedule", Arguments: map[string]any{"ref": ref, "clear_schedule": true},
+	})
+	require.NoError(t, err)
+	require.False(t, scheduleCleared.IsError, scheduleCleared.Content)
+
+	shown, err = session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+		Name: "kata.show", Arguments: map[string]any{"ref": ref},
+	})
+	require.NoError(t, err)
+	require.NotContains(t,
+		shown.StructuredContent.(map[string]any)["issue"].(map[string]any)["metadata"].(map[string]any), "scheduled_on")
 }
 
 func assertSummaryHydration(t *testing.T, tool string, structured map[string]any) {
@@ -574,6 +658,10 @@ func TestToolValidationStopsBeforeDaemonRequest(t *testing.T) {
 		{name: "oversize limit", tool: "kata.list", arguments: map[string]any{"limit": 101}},
 		{name: "empty idempotency key", tool: "kata.comment", arguments: map[string]any{"ref": "abc1", "body": "note", "idempotency_key": " "}},
 		{name: "edit conflict", tool: "kata.edit", arguments: map[string]any{"ref": "abc1", "priority": 1, "clear_priority": true}},
+		{name: "missing deadline mutation", tool: "kata.set_deadline", arguments: map[string]any{"ref": "abc1"}},
+		{name: "conflicting deadline mutation", tool: "kata.set_deadline", arguments: map[string]any{"ref": "abc1", "deadline": "2026-09-01", "clear_deadline": true}},
+		{name: "missing schedule mutation", tool: "kata.set_schedule", arguments: map[string]any{"ref": "abc1"}},
+		{name: "conflicting schedule mutation", tool: "kata.set_schedule", arguments: map[string]any{"ref": "abc1", "schedule": "2026-09-01", "clear_schedule": true}},
 		{name: "empty metadata patch", tool: "kata.set_metadata", arguments: map[string]any{"ref": "abc1", "patch": map[string]any{}}},
 		{name: "invalid close reason", tool: "kata.close", arguments: map[string]any{"ref": "abc1", "reason": "finished", "message": "done", "evidence": []any{}}},
 		{name: "incomplete close evidence", tool: "kata.close", arguments: map[string]any{"ref": "abc1", "reason": "done", "message": "done", "evidence": []any{map[string]any{"type": "commit"}}}},

--- a/internal/metadata/registry.go
+++ b/internal/metadata/registry.go
@@ -35,7 +35,7 @@ type Entry struct {
 // Keys outside this set are accepted opaquely by Validate.
 var IssueRegistry = map[string]Entry{
 	"scheduled_on": {Type: TypeSchedule},
-	"deadline_on":  {Type: TypeDate},
+	"deadline_on":  {Type: TypeSchedule},
 	"someday":      {Type: TypeBool},
 	"checklist":    {Type: TypeChecklist},
 	"timezone":     {Type: TypeTimezoneIANA},

--- a/internal/metadata/scheduled.go
+++ b/internal/metadata/scheduled.go
@@ -22,6 +22,7 @@ const (
 
 type scheduleMetadata struct {
 	ScheduledOn *string `json:"scheduled_on"`
+	DeadlineOn  *string `json:"deadline_on"`
 	Timezone    string  `json:"timezone"`
 }
 
@@ -71,6 +72,26 @@ func ScheduledOnCalendarDate(
 	displayTimezone string,
 	defaultTimezone string,
 ) (string, bool, error) {
+	return metadataCalendarDate(raw, "scheduled_on", displayTimezone, defaultTimezone)
+}
+
+// DeadlineOnCalendarDate returns the display calendar date for deadline_on.
+// It uses the same date, local date-time, and UTC-instant rules as
+// ScheduledOnCalendarDate.
+func DeadlineOnCalendarDate(
+	raw string,
+	displayTimezone string,
+	defaultTimezone string,
+) (string, bool, error) {
+	return metadataCalendarDate(raw, "deadline_on", displayTimezone, defaultTimezone)
+}
+
+func metadataCalendarDate(
+	raw string,
+	key string,
+	displayTimezone string,
+	defaultTimezone string,
+) (string, bool, error) {
 	if len(raw) == 0 {
 		return "", false, nil
 	}
@@ -78,24 +99,28 @@ func ScheduledOnCalendarDate(
 	if err != nil {
 		return "", false, err
 	}
-	if values.ScheduledOn == nil {
+	value := values.ScheduledOn
+	if key == "deadline_on" {
+		value = values.DeadlineOn
+	}
+	if value == nil {
 		return "", false, nil
 	}
 
-	scheduledOn := *values.ScheduledOn
-	kind, layout, instant, err := classifyScheduledOn(scheduledOn)
+	scheduleValue := *value
+	kind, layout, instant, err := classifyScheduledOn(scheduleValue)
 	if err != nil {
 		return "", false, err
 	}
 	if kind == scheduledOnDate {
-		return scheduledOn, true, nil
+		return scheduleValue, true, nil
 	}
 	if kind == scheduledOnLocalTime {
 		location, err := loadScheduleLocation(values.Timezone, defaultTimezone)
 		if err != nil {
 			return "", false, err
 		}
-		instant, err = resolveLocalSchedule(scheduledOn, layout, location)
+		instant, err = resolveLocalSchedule(scheduleValue, layout, location)
 		if err != nil {
 			return "", false, err
 		}

--- a/internal/metadata/scheduled_test.go
+++ b/internal/metadata/scheduled_test.go
@@ -186,3 +186,42 @@ func TestScheduledOnCalendarDateWithoutSchedule(t *testing.T) {
 	assert.False(t, present)
 	assert.Empty(t, date)
 }
+
+func TestDeadlineOnCalendarDateUsesDisplayTimezoneForTimedValues(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "UTC instant moves to previous browser day",
+			raw:  `{"deadline_on":"2026-09-01T00:30:00Z"}`,
+			want: "2026-08-31",
+		},
+		{
+			name: "local time resolves before browser projection",
+			raw:  `{"deadline_on":"2026-09-01T09:00","timezone":"Asia/Tokyo"}`,
+			want: "2026-08-31",
+		},
+		{
+			name: "date keeps its civil day",
+			raw:  `{"deadline_on":"2026-09-01","timezone":"Asia/Tokyo"}`,
+			want: "2026-09-01",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, present, err := DeadlineOnCalendarDate(tt.raw, "America/Los_Angeles", "UTC")
+			require.NoError(t, err)
+			assert.True(t, present)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDeadlineOnCalendarDateWithoutDeadline(t *testing.T) {
+	date, present, err := DeadlineOnCalendarDate(`{"scheduled_on":"2026-09-01"}`, "UTC", "")
+	require.NoError(t, err)
+	assert.False(t, present)
+	assert.Empty(t, date)
+}

--- a/internal/metadata/validate_test.go
+++ b/internal/metadata/validate_test.go
@@ -35,17 +35,19 @@ func TestValidateCreateValue_DelegatesToValidate(t *testing.T) {
 	assert.NoError(t, ValidateCreateValue(IssueRegistry, "weird_consumer_field", json.RawMessage(`"hi"`)))
 }
 
-func TestValidateDate(t *testing.T) {
-	assert.NoError(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20"`)))
-	assert.NoError(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20T15:30"`)))
-	assert.NoError(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20T15:30:45"`)))
-	assert.NoError(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20T22:30:00Z"`)))
-	assert.Error(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-05-20T15:30:00-07:00"`)))
-	assert.Error(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"not-a-date"`)))
-	assert.Error(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`"2026-13-01"`)))
-	assert.Error(t, Validate(IssueRegistry, "scheduled_on", json.RawMessage(`123`)))
-	assert.Error(t, Validate(IssueRegistry, "deadline_on", json.RawMessage(`"2026-05-20T22:30:00Z"`)),
-		"deadline_on remains date-only")
+func TestValidateScheduleValues(t *testing.T) {
+	for _, key := range []string{"scheduled_on", "deadline_on"} {
+		t.Run(key, func(t *testing.T) {
+			assert.NoError(t, Validate(IssueRegistry, key, json.RawMessage(`"2026-05-20"`)))
+			assert.NoError(t, Validate(IssueRegistry, key, json.RawMessage(`"2026-05-20T15:30"`)))
+			assert.NoError(t, Validate(IssueRegistry, key, json.RawMessage(`"2026-05-20T15:30:45"`)))
+			assert.NoError(t, Validate(IssueRegistry, key, json.RawMessage(`"2026-05-20T22:30:00Z"`)))
+			assert.Error(t, Validate(IssueRegistry, key, json.RawMessage(`"2026-05-20T15:30:00-07:00"`)))
+			assert.Error(t, Validate(IssueRegistry, key, json.RawMessage(`"not-a-date"`)))
+			assert.Error(t, Validate(IssueRegistry, key, json.RawMessage(`"2026-13-01"`)))
+			assert.Error(t, Validate(IssueRegistry, key, json.RawMessage(`123`)))
+		})
+	}
 }
 
 func TestValidateBool(t *testing.T) {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -3640,6 +3640,7 @@ type UIIssue struct {
 	ClosedAt        *time.Time     `json:"closed_at,omitempty"`
 	ClosedReason    *string        `json:"closed_reason,omitempty"`
 	CreatedAt       time.Time      `json:"created_at" validate:"required"`
+	DeadlineOnDate  *string        `json:"deadline_on_date,omitempty"`
 	DeletedAt       *time.Time     `json:"deleted_at,omitempty"`
 	ID              int64          `json:"id"`
 	Labels          []string       `json:"labels,omitempty" validate:"required"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -3708,6 +3708,8 @@ components:
         created_at:
           format: date-time
           type: string
+        deadline_on_date:
+          type: string
         deleted_at:
           format: date-time
           type: string

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -75,6 +75,7 @@
   let references = $state<components['schemas']['UIReferencesResponseBody'] | undefined>()
   let mutationPending = $state(false)
   let mutationState = $state<MutationState>({ kind: 'idle' })
+  let draftFenceGeneration = $state(0)
   let pendingCreate: { title: string; key: string } | undefined
   let pendingComment: { issueUID: string; body: string; key: string } | undefined
   let automaticSessionAttempted: 'loopback' | 'proxy' | undefined
@@ -693,6 +694,7 @@
 
   function rejectCredentialsAndRequireAuthentication(): boolean {
     clearSessionCredentials()
+    draftFenceGeneration += 1
     return requireAuthentication()
   }
 
@@ -970,6 +972,7 @@
         {mutationPending}
         mutationMessage={mutationMessage(mutationState)}
         draftResetGeneration={authority.cursor}
+        {draftFenceGeneration}
         {preferences}
         daemons={daemonInfos}
         {activeDaemonID}

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -1672,6 +1672,7 @@ describe('App', () => {
       },
     }
     let commentRejected = false
+    let renewedSnapshotAccepted = false
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1701,6 +1702,9 @@ describe('App', () => {
         if (target.pathname.endsWith('/api/v1/ui/references')) {
           return Response.json({ issues: [], labels: [], owners: [], projects: [] })
         }
+        if (request.headers.get('X-Kata-Web-Session') === 'renewed-session') {
+          renewedSnapshotAccepted = true
+        }
         return Response.json(accepted, { headers: { ETag: '"snapshot-1"' } })
       }),
     )
@@ -1716,6 +1720,20 @@ describe('App', () => {
       expect((screen.getByRole('textbox', { name: 'Comment' }) as HTMLTextAreaElement).value).toBe(
         'Keep this draft',
       ),
+    )
+    await waitFor(() =>
+      expect(sessionStorage.getItem('kata.web.session.v1')).toContain('renewed-session'),
+    )
+    await waitFor(() => expect(renewedSnapshotAccepted).toBe(true))
+    await waitFor(() =>
+      expect((screen.getByRole('button', { name: 'New task' }) as HTMLButtonElement).disabled).toBe(
+        false,
+      ),
+    )
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('button', { name: 'Add comment' }) as HTMLButtonElement).disabled,
+      ).toBe(true),
     )
   })
 
@@ -1845,7 +1863,7 @@ describe('App', () => {
 
 function snapshot() {
   return {
-    contract_version: '1',
+    contract_version: '2',
     cursor: 12,
     capabilities: { writable: true, updates: 'poll', actor_policy: 'identity' },
     origin: 'https://daemon.example',

--- a/web/src/components/AppShell.svelte
+++ b/web/src/components/AppShell.svelte
@@ -46,6 +46,7 @@
     mutationPending: boolean
     mutationMessage?: string | undefined
     draftResetGeneration: number
+    draftFenceGeneration?: number | undefined
     ownerOptions: TypeaheadOption[]
     preferences?: Preferences | undefined
     daemons?: WebDaemonInfo[] | undefined
@@ -94,6 +95,7 @@
     mutationPending,
     mutationMessage = undefined,
     draftResetGeneration,
+    draftFenceGeneration = 0,
     ownerOptions,
     preferences = defaultPreferences,
     daemons = [],
@@ -422,6 +424,7 @@
       }}
       {searchFilters}
       projectCreationDisabled={!canMutate || mutationPending}
+      {draftFenceGeneration}
       inboxProjectUID={inboxProject?.uid}
       inboxDesignationDisabled={!canMutate || mutationPending}
       onOpenView={openView}
@@ -517,6 +520,7 @@
         actionsDisabled={!canMutate || mutationPending}
         authorityBlocked={!canMutate}
         {draftResetGeneration}
+        {draftFenceGeneration}
         movePending={mutationPending}
         {onMoveIssue}
         {onPatchMetadata}
@@ -549,6 +553,7 @@
 <QuickCapture
   open={captureOpen}
   disabled={!canMutate || mutationPending}
+  {draftFenceGeneration}
   onClose={() => {
     captureOpen = false
   }}

--- a/web/src/components/AppShell.test.ts
+++ b/web/src/components/AppShell.test.ts
@@ -611,7 +611,7 @@ function mutationProps(overrides: Record<string, unknown> = {}) {
 
 function snapshot(): UISnapshot {
   return {
-    contract_version: '1',
+    contract_version: '2',
     cursor: 12,
     capabilities: { writable: true, updates: 'sse', actor_policy: 'identity' },
     origin: 'https://daemon.example',

--- a/web/src/components/Checklist.svelte
+++ b/web/src/components/Checklist.svelte
@@ -11,6 +11,7 @@
     revealed: boolean
     disabled?: boolean
     draftResetGeneration?: number
+    draftFenceGeneration?: number
     onPatchMetadata: (uid: string, patch: Record<string, unknown>) => boolean | Promise<boolean>
     onReveal: () => void
   }
@@ -20,6 +21,7 @@
     revealed,
     disabled = false,
     draftResetGeneration = 0,
+    draftFenceGeneration = 0,
     onPatchMetadata,
     onReveal,
   }: Props = $props()
@@ -29,6 +31,7 @@
   let checklistInput: HTMLInputElement | null = $state(null)
   let trackedUID = $state<string | null>(null)
   let lastDraftResetGeneration = $state<number | null>(null)
+  let lastDraftFenceGeneration = $state<number | null>(null)
   let pendingDraftResetUID = $state<string | null>(null)
   let pendingDraftResetGeneration = $state<number | null>(null)
 
@@ -46,6 +49,17 @@
     checklistPending = false
     pendingDraftResetUID = null
     pendingDraftResetGeneration = null
+  })
+
+  $effect(() => {
+    const nextGeneration = draftFenceGeneration
+    if (lastDraftFenceGeneration === null) {
+      lastDraftFenceGeneration = nextGeneration
+      return
+    }
+    if (nextGeneration === lastDraftFenceGeneration) return
+    lastDraftFenceGeneration = nextGeneration
+    resetChecklistDraft()
   })
 
   $effect(() => {

--- a/web/src/components/Checklist.test.ts
+++ b/web/src/components/Checklist.test.ts
@@ -165,6 +165,25 @@ describe('Checklist', () => {
     )
   })
 
+  it('resets the add-item draft after authentication authority changes', async () => {
+    const view = render(Checklist, {
+      props: {
+        issue: makeIssue(),
+        revealed: true,
+        draftFenceGeneration: 0,
+        onPatchMetadata: vi.fn(async () => true),
+        onReveal: vi.fn(),
+      },
+    })
+
+    await fireEvent.input(screen.getByLabelText('New checklist item'), {
+      target: { value: 'Old authority item' },
+    })
+    await view.rerender({ draftFenceGeneration: 1 })
+
+    expect((screen.getByLabelText('New checklist item') as HTMLInputElement).value).toBe('')
+  })
+
   it('keeps checklist mutations disabled while the owning snapshot is stale', async () => {
     const onPatchMetadata = vi.fn(async () => true)
     render(Checklist, {

--- a/web/src/components/Comments.svelte
+++ b/web/src/components/Comments.svelte
@@ -18,6 +18,7 @@
     searchReferences: (query: string) => Promise<Reference[]>
     actionsDisabled?: boolean | undefined
     draftResetGeneration?: number | undefined
+    draftFenceGeneration?: number | undefined
     onAddComment: (uid: string, body: string) => boolean | Promise<boolean>
   }
 
@@ -33,10 +34,12 @@
     searchReferences,
     actionsDisabled = false,
     draftResetGeneration = 0,
+    draftFenceGeneration = 0,
     onAddComment,
   }: Props = $props()
 
   let commentDraft = $state('')
+  let commentDraftGeneration = $state(0)
   let commentDraftRevision = 0
   let lastDraftResetGeneration = $state<number | null>(null)
   let pendingCommentReset = $state<PendingDraftReset | null>(null)
@@ -50,6 +53,9 @@
       return tb - ta
     })
   })
+  const commentDraftFenced = $derived(
+    commentDraft.trim() !== '' && commentDraftGeneration !== draftFenceGeneration,
+  )
 
   $effect(() => {
     const nextGeneration = draftResetGeneration
@@ -73,11 +79,12 @@
 
   function updateCommentDraft(value: string): void {
     commentDraft = value
+    if (!actionsDisabled) commentDraftGeneration = draftFenceGeneration
     commentDraftRevision += 1
   }
 
   async function submitComment(): Promise<void> {
-    if (actionsDisabled) return
+    if (actionsDisabled || commentDraftFenced) return
     const draft = commentDraft
     const body = draft.trim()
     if (!body) return
@@ -136,7 +143,7 @@
       size="sm"
       class="comment-submit"
       label="Add comment"
-      disabled={actionsDisabled || commentDraft.trim() === ''}
+      disabled={actionsDisabled || commentDraftFenced || commentDraft.trim() === ''}
     />
   </form>
   {#if sortedComments.length === 0}

--- a/web/src/components/Comments.test.ts
+++ b/web/src/components/Comments.test.ts
@@ -33,6 +33,38 @@ describe('Comments', () => {
     expect((screen.getByLabelText('Comment') as HTMLTextAreaElement).value).toBe('')
   })
 
+  it('fences an old-authority draft until the user edits it under current authority', async () => {
+    const onAddComment = vi.fn(async () => true)
+    const view = renderComments({ onAddComment, draftFenceGeneration: 0 })
+
+    const composer = screen.getByLabelText('Comment') as HTMLTextAreaElement
+    await fireEvent.input(composer, { target: { value: 'Old authority draft' } })
+    await view.rerender({ draftFenceGeneration: 1 })
+
+    expect(
+      (screen.getByRole('button', { name: 'Add comment' }) as HTMLButtonElement).disabled,
+    ).toBe(true)
+
+    await fireEvent.input(composer, { target: { value: 'Old authority draft, reviewed' } })
+    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }))
+
+    expect(onAddComment).toHaveBeenCalledWith('issue-1', 'Old authority draft, reviewed')
+  })
+
+  it('does not accept draft edits made while replacement authority is pending', async () => {
+    const view = renderComments({ draftFenceGeneration: 0 })
+    const composer = screen.getByLabelText('Comment') as HTMLTextAreaElement
+
+    await fireEvent.input(composer, { target: { value: 'Old authority draft' } })
+    await view.rerender({ actionsDisabled: true, draftFenceGeneration: 1 })
+    await fireEvent.input(composer, { target: { value: 'Edited during renewal' } })
+    await view.rerender({ actionsDisabled: false })
+
+    expect(
+      (screen.getByRole('button', { name: 'Add comment' }) as HTMLButtonElement).disabled,
+    ).toBe(true)
+  })
+
   it('inserts short references and qualifies duplicate names', async () => {
     const searchReferences = vi.fn(
       async (): Promise<Reference[]> => [

--- a/web/src/components/IssueCollection.svelte
+++ b/web/src/components/IssueCollection.svelte
@@ -944,6 +944,7 @@
 {#snippet row(issue: KataTaskSummary, depth = 0)}
   {@const priority = priorityLabel(issue.priority)}
   {@const labels = issue.labels?.join(' · ') ?? ''}
+  {@const deadline = issue.deadline_on_date ?? issue.metadata.deadline_on}
   {@const expandable = hasChildren(issue)}
   {@const isExpanded = expanded[issue.uid] === true}
   {@const titleId = `kata-issue-title-${issue.uid}`}
@@ -990,8 +991,8 @@
         </span>
       {/if}
       {#if columnVisibility.due}
-        <span class="cell cell-due" title={issue.metadata.deadline_on ?? ''}>
-          {#if issue.metadata.deadline_on}{shortDate(issue.metadata.deadline_on)}{/if}
+        <span class="cell cell-due" title={deadline ?? ''}>
+          {#if deadline}{shortDate(deadline)}{/if}
         </span>
       {/if}
       {#if columnVisibility.owner}<span class="cell cell-owner">{issue.owner ?? ''}</span>{/if}
@@ -1002,9 +1003,7 @@
       {/if}
       <span class="kit-sr-only">
         <span>project: {issue.project_name}</span>
-        {#if issue.metadata.deadline_on}<span>
-            · Due {shortDate(issue.metadata.deadline_on)}</span
-          >{/if}
+        {#if deadline}<span> · Due {shortDate(deadline)}</span>{/if}
         {#if issue.owner}<span> · owner: {issue.owner}</span>{/if}
         {#if issue.priority !== undefined}<span> · priority: {issue.priority}</span>{/if}
       </span>

--- a/web/src/components/IssueCollection.test.ts
+++ b/web/src/components/IssueCollection.test.ts
@@ -161,6 +161,25 @@ describe('IssueCollection', () => {
     expect(within(row).getByText('user-a')).toBeTruthy()
   })
 
+  it('renders the projected deadline date in the due column and accessible text', () => {
+    const issue = task({
+      title: 'Timed deadline',
+      metadata: { deadline_on: '2026-09-01T00:30:00Z' },
+      deadline_on_date: '2026-08-31',
+    })
+    const { container } = render(IssueCollection, {
+      props: {
+        currentView: viewWithIssues([issue]),
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: () => {},
+      },
+    })
+
+    expect(container.querySelector('.cell-due')?.textContent?.trim()).toBe('Aug 31')
+    expect(screen.getByRole('button', { name: /Due Aug 31/ })).toBeTruthy()
+  })
+
   it('renders only authoritative ready rows even though other tasks are open', () => {
     const closed = task({
       ...baseIssues[1]!,

--- a/web/src/components/IssueDetail.test.ts
+++ b/web/src/components/IssueDetail.test.ts
@@ -245,6 +245,25 @@ describe('IssueDetail', () => {
     ).toBe('Draft on the newer task')
   })
 
+  it('resets title and description drafts after authentication authority changes', async () => {
+    const view = renderDetail({ draftFenceGeneration: 0 })
+    await openEditor()
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit title' }))
+    await fireEvent.input(screen.getByLabelText('Edit title'), {
+      target: { value: 'Old authority title' },
+    })
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit description' }))
+    await fireEvent.input(screen.getByLabelText('Edit description'), {
+      target: { value: 'Old authority body' },
+    })
+
+    await view.rerender({ draftFenceGeneration: 1 })
+
+    expect(screen.queryByRole('textbox', { name: 'Edit title' })).toBeNull()
+    expect(screen.queryByRole('textbox', { name: 'Edit description' })).toBeNull()
+  })
+
   it('moves the issue from the task actions menu', async () => {
     const onMoveIssue = vi.fn(async () => true)
     renderDetail({ onMoveIssue })
@@ -270,6 +289,24 @@ describe('IssueDetail', () => {
     expect(screen.queryByRole('region', { name: 'Recurrences' })).toBeNull()
     await fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
     expect(screen.queryByRole('menuitem', { name: 'Create recurrence...' })).toBeNull()
+  })
+
+  it('closes a recurrence draft after authentication authority changes', async () => {
+    const view = renderDetail({
+      issue: makeIssue({ metadata: {} }),
+      selectedRecurrences: [],
+      draftFenceGeneration: 0,
+    })
+    await openEditor()
+    await fireEvent.click(screen.getByRole('button', { name: /\+ New recurrence/ }))
+    const recurrenceDialog = screen.getByRole('dialog')
+    await fireEvent.input(within(recurrenceDialog).getByLabelText(/Title/i), {
+      target: { value: 'Old authority recurrence' },
+    })
+
+    await view.rerender({ draftFenceGeneration: 1 })
+
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('composes the ported checklist, recurrence, comments, links, and history sections', async () => {

--- a/web/src/components/IssueEditor.svelte
+++ b/web/src/components/IssueEditor.svelte
@@ -57,6 +57,7 @@
     actionsDisabled?: boolean | undefined
     authorityBlocked?: boolean | undefined
     draftResetGeneration?: number | undefined
+    draftFenceGeneration?: number | undefined
     movePending?: boolean | undefined
     onMoveIssue: (toProjectUID: string) => boolean | Promise<boolean>
     onPatchMetadata: (uid: string, patch: Record<string, unknown>) => boolean | Promise<boolean>
@@ -95,6 +96,7 @@
     actionsDisabled = false,
     authorityBlocked = undefined,
     draftResetGeneration = 0,
+    draftFenceGeneration = 0,
     movePending = false,
     onMoveIssue,
     onPatchMetadata,
@@ -127,6 +129,7 @@
   let cancelingTitle = $state(false)
   let lastIssueUID = $state<string | null>(null)
   let lastDraftResetGeneration = $state<number | null>(null)
+  let lastDraftFenceGeneration = $state<number | null>(null)
   let pendingTitleResetUID = $state<string | null>(null)
   let pendingTitleResetGeneration = $state<number | null>(null)
   let pendingBodyResetUID = $state<string | null>(null)
@@ -136,6 +139,7 @@
     openCreateRecurrence: () => void
     openEditRecurrence: (recurrence: KataRecurrence) => void
     openDeleteRecurrence: (recurrence: KataRecurrence) => void
+    closeAll: () => void
   } | null = $state(null)
 
   const detailInert = $derived(authorityBlocked ?? actionsDisabled)
@@ -165,6 +169,20 @@
     pendingBodyResetUID = null
     pendingBodyResetGeneration = null
     checklistRevealed = false
+  })
+
+  $effect(() => {
+    const nextGeneration = draftFenceGeneration
+    if (lastDraftFenceGeneration === null) {
+      lastDraftFenceGeneration = nextGeneration
+      return
+    }
+    if (nextGeneration === lastDraftFenceGeneration) return
+    lastDraftFenceGeneration = nextGeneration
+    resetTitleDraft()
+    resetBodyDraft()
+    checklistRevealed = false
+    recurrenceDialogs?.closeAll()
   })
 
   $effect(() => {
@@ -375,20 +393,22 @@
             <NetworkIcon size={14} strokeWidth={1.9} aria-hidden="true" />
           </button>
         {/if}
-        <MoveIssueDialog
-          {issue}
-          {projects}
-          hasChecklist={(issue.issue.metadata.checklist ?? []).length > 0 || checklistRevealed}
-          hasRecurrence={!canCreateRecurrence}
-          {movePending}
-          {onMoveIssue}
-          onAddChecklist={() => {
-            checklistRevealed = true
-          }}
-          onCreateRecurrence={() => recurrenceDialogs?.openCreateRecurrence()}
-          {onDeleteIssue}
-        />
-        <IssueStateDialog {issue} {onCloseIssue} {onReopenIssue} />
+        {#key draftFenceGeneration}
+          <MoveIssueDialog
+            {issue}
+            {projects}
+            hasChecklist={(issue.issue.metadata.checklist ?? []).length > 0 || checklistRevealed}
+            hasRecurrence={!canCreateRecurrence}
+            {movePending}
+            {onMoveIssue}
+            onAddChecklist={() => {
+              checklistRevealed = true
+            }}
+            onCreateRecurrence={() => recurrenceDialogs?.openCreateRecurrence()}
+            {onDeleteIssue}
+          />
+          <IssueStateDialog {issue} {onCloseIssue} {onReopenIssue} />
+        {/key}
       </div>
     </div>
 
@@ -459,6 +479,7 @@
     {ownerOptions}
     {actionsDisabled}
     {draftResetGeneration}
+    {draftFenceGeneration}
     {onPatchMetadata}
     {onAssignOwner}
     {onUnassignOwner}
@@ -473,6 +494,7 @@
       revealed={checklistRevealed}
       disabled={actionsDisabled}
       {draftResetGeneration}
+      {draftFenceGeneration}
       {onPatchMetadata}
       onReveal={() => {
         checklistRevealed = true
@@ -500,10 +522,18 @@
       {onLinkFiltersChange}
       {actionsDisabled}
       {draftResetGeneration}
+      {draftFenceGeneration}
       {onEditIssue}
       {onSelectIssue}
     />
-    <Comments {issue} {searchReferences} {actionsDisabled} {draftResetGeneration} {onAddComment} />
+    <Comments
+      {issue}
+      {searchReferences}
+      {actionsDisabled}
+      {draftResetGeneration}
+      {draftFenceGeneration}
+      {onAddComment}
+    />
     <IssueHistory {events} />
   {/key}
 </section>
@@ -514,6 +544,7 @@
   recurrences={selectedRecurrences}
   actor=""
   disabled={actionsDisabled}
+  {draftFenceGeneration}
   onCreate={onCreateRecurrence}
   onPatch={onPatchRecurrence}
   onDelete={onDeleteRecurrence}

--- a/web/src/components/IssueLinks.svelte
+++ b/web/src/components/IssueLinks.svelte
@@ -28,6 +28,7 @@
     onLinkFiltersChange: (next: KataLinkFilters) => void
     actionsDisabled?: boolean | undefined
     draftResetGeneration?: number | undefined
+    draftFenceGeneration?: number | undefined
     onEditIssue: (uid: string, patch: KataTaskEditPatch) => boolean | Promise<boolean>
     onSelectIssue: (target: IssueNavigationTarget) => void | Promise<void>
   }
@@ -46,6 +47,7 @@
     onLinkFiltersChange,
     actionsDisabled = false,
     draftResetGeneration = 0,
+    draftFenceGeneration = 0,
     onEditIssue,
     onSelectIssue,
   }: Props = $props()
@@ -53,6 +55,7 @@
   let relatedDraft = $state('')
   let relatedDraftRevision = 0
   let lastDraftResetGeneration = $state<number | null>(null)
+  let lastDraftFenceGeneration = $state<number | null>(null)
   let pendingRelatedReset = $state<PendingDraftReset | null>(null)
 
   const visibleLinks = $derived(
@@ -79,6 +82,18 @@
         relatedDraft = ''
       }
     }
+    pendingRelatedReset = null
+  })
+
+  $effect(() => {
+    const nextGeneration = draftFenceGeneration
+    if (lastDraftFenceGeneration === null) {
+      lastDraftFenceGeneration = nextGeneration
+      return
+    }
+    if (nextGeneration === lastDraftFenceGeneration) return
+    lastDraftFenceGeneration = nextGeneration
+    relatedDraft = ''
     pendingRelatedReset = null
   })
 

--- a/web/src/components/IssueLinks.test.ts
+++ b/web/src/components/IssueLinks.test.ts
@@ -37,6 +37,17 @@ describe('IssueLinks', () => {
     expect((screen.getByLabelText('Related issue') as HTMLInputElement).value).toBe('')
   })
 
+  it('resets a related-link draft after authentication authority changes', async () => {
+    const view = renderLinks({ draftFenceGeneration: 0 })
+    await fireEvent.input(screen.getByLabelText('Related issue'), {
+      target: { value: 'old-authority-ref' },
+    })
+
+    await view.rerender({ draftFenceGeneration: 1 })
+
+    expect((screen.getByLabelText('Related issue') as HTMLInputElement).value).toBe('')
+  })
+
   it('navigates resolved peers by their stable identity', async () => {
     const onSelectIssue = vi.fn()
     renderLinks({ onSelectIssue })

--- a/web/src/components/IssueProperties.svelte
+++ b/web/src/components/IssueProperties.svelte
@@ -14,6 +14,7 @@
     ownerOptions: TypeaheadOption[]
     actionsDisabled?: boolean | undefined
     draftResetGeneration?: number | undefined
+    draftFenceGeneration?: number | undefined
     onPatchMetadata: (uid: string, patch: Record<string, unknown>) => boolean | Promise<boolean>
     onAssignOwner: (uid: string, owner: string) => boolean | Promise<boolean>
     onUnassignOwner: (uid: string) => boolean | Promise<boolean>
@@ -27,6 +28,7 @@
     ownerOptions,
     actionsDisabled = false,
     draftResetGeneration = 0,
+    draftFenceGeneration = 0,
     onPatchMetadata,
     onAssignOwner,
     onUnassignOwner,
@@ -67,6 +69,7 @@
   let ownerEditorGeneration = $state(0)
   let trackedUID = $state<string | null>(null)
   let lastDraftResetGeneration = $state<number | null>(null)
+  let lastDraftFenceGeneration = $state<number | null>(null)
   let pendingDraftReset = $state.raw<PendingDraftReset | null>(null)
 
   $effect(() => {
@@ -85,6 +88,19 @@
     ownerEditorGeneration += 1
     pendingDraftReset = null
     lastDraftResetGeneration = draftResetGeneration
+  })
+
+  $effect(() => {
+    const nextGeneration = draftFenceGeneration
+    if (lastDraftFenceGeneration === null) {
+      lastDraftFenceGeneration = nextGeneration
+      return
+    }
+    if (nextGeneration === lastDraftFenceGeneration) return
+    lastDraftFenceGeneration = nextGeneration
+    for (const key of ['scheduled', 'due', 'priority', 'owner', 'label'] as const) resetDraft(key)
+    editingLabels = false
+    pendingDraftReset = null
   })
 
   $effect(() => {
@@ -171,8 +187,12 @@
   }
 
   function dueLabel(): string {
-    const value = issue.issue.metadata.deadline_on
+    const value = deadlineDate()
     return value ? formatDate(value) : 'No due date'
+  }
+
+  function deadlineDate(): string {
+    return issue.issue.deadline_on_date ?? issue.issue.metadata.deadline_on ?? ''
   }
 
   function priorityLabel(): string {
@@ -186,7 +206,7 @@
     if (property === 'scheduled') {
       scheduledDraft = issue.issue.metadata.scheduled_on ?? ''
     } else if (property === 'due') {
-      dueDraft = issue.issue.metadata.deadline_on ?? ''
+      dueDraft = deadlineDate()
     } else {
       priorityDraft =
         issue.issue.priority === undefined || issue.issue.priority === null
@@ -209,6 +229,10 @@
     if (actionsDisabled) return
     const property = 'due'
     dueDraft = value
+    if (value !== '' && value === deadlineDate()) {
+      resetDraft(property)
+      return
+    }
     const mutationUID = uid()
     const generation = draftResetGeneration
     const ok = await onPatchMetadata(mutationUID, { deadline_on: value === '' ? null : value })

--- a/web/src/components/IssueProperties.test.ts
+++ b/web/src/components/IssueProperties.test.ts
@@ -53,6 +53,7 @@ function renderProperties(
     ownerOptions: typeof ownerOptions
     actionsDisabled: boolean
     draftResetGeneration: number
+    draftFenceGeneration: number
     onPatchMetadata: (uid: string, patch: Record<string, unknown>) => boolean | Promise<boolean>
     onAssignOwner: (uid: string, owner: string) => boolean | Promise<boolean>
     onUnassignOwner: (uid: string) => boolean | Promise<boolean>
@@ -152,6 +153,18 @@ describe('IssueProperties', () => {
     expect((screen.getByLabelText('New label') as HTMLInputElement).value).toBe('urgent')
   })
 
+  it('resets a label draft after authentication authority changes', async () => {
+    const view = renderProperties({ draftFenceGeneration: 0 })
+    await fireEvent.click(screen.getByRole('button', { name: 'Add label' }))
+    await fireEvent.input(screen.getByLabelText('New label'), {
+      target: { value: 'old-authority-label' },
+    })
+
+    await view.rerender({ draftFenceGeneration: 1 })
+
+    expect(screen.queryByLabelText('New label')).toBeNull()
+  })
+
   it('persists due date and priority changes', async () => {
     const onPatchMetadata = vi.fn(async () => true)
     const onSetPriority = vi.fn(async () => true)
@@ -180,6 +193,27 @@ describe('IssueProperties', () => {
     await fireEvent.click(screen.getByRole('option', { name: 'P1' }))
 
     expect(onSetPriority).toHaveBeenCalledWith('issue-1', 1)
+  })
+
+  it.each([
+    ['UTC instant', '2026-09-01T00:30:00Z'],
+    ['local time', '2026-09-01T09:00'],
+  ])('uses the projected date for a timed %s deadline without replacing it', async (_, raw) => {
+    const onPatchMetadata = vi.fn(async () => true)
+    renderProperties({
+      issue: makeIssue({
+        deadline_on_date: '2026-08-31',
+        metadata: { deadline_on: raw },
+      }),
+      onPatchMetadata,
+    })
+
+    expect(screen.getByRole('button', { name: 'Edit due date' }).textContent).toContain('Aug 31')
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit due date' }))
+    await fireEvent.click(screen.getByRole('button', { name: /Due:/ }))
+    await fireEvent.click(screen.getByRole('button', { name: /Aug 31, 2026/ }))
+
+    expect(onPatchMetadata).not.toHaveBeenCalled()
   })
 
   it('patches scheduled and due dates and closes editors on accepted replacement', async () => {

--- a/web/src/components/QuickCapture.svelte
+++ b/web/src/components/QuickCapture.svelte
@@ -6,20 +6,34 @@
   interface Props {
     open: boolean
     disabled?: boolean | undefined
+    draftFenceGeneration?: number | undefined
     onClose: () => void
     onSubmit: (title: string) => void | Promise<void>
   }
 
-  let { open, disabled = false, onClose, onSubmit }: Props = $props()
+  let { open, disabled = false, draftFenceGeneration = 0, onClose, onSubmit }: Props = $props()
 
   let title = $state('')
   let pending = $state(false)
+  let lastDraftFenceGeneration = $state<number | null>(null)
 
   $effect(() => {
     if (!open) {
       title = ''
       pending = false
     }
+  })
+
+  $effect(() => {
+    const nextGeneration = draftFenceGeneration
+    if (lastDraftFenceGeneration === null) {
+      lastDraftFenceGeneration = nextGeneration
+      return
+    }
+    if (nextGeneration === lastDraftFenceGeneration) return
+    lastDraftFenceGeneration = nextGeneration
+    title = ''
+    pending = false
   })
 
   async function submit(): Promise<void> {

--- a/web/src/components/QuickCapture.test.ts
+++ b/web/src/components/QuickCapture.test.ts
@@ -1,0 +1,28 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import QuickCapture from './QuickCapture.svelte'
+
+describe('QuickCapture', () => {
+  afterEach(cleanup)
+
+  it('resets a task draft after authentication authority changes', async () => {
+    const view = render(QuickCapture, {
+      props: {
+        open: true,
+        draftFenceGeneration: 0,
+        onClose: vi.fn(),
+        onSubmit: vi.fn(),
+      },
+    })
+    await fireEvent.input(screen.getByRole('textbox', { name: 'Quick capture' }), {
+      target: { value: 'Old authority task' },
+    })
+
+    await view.rerender({ draftFenceGeneration: 1 })
+
+    expect((screen.getByRole('textbox', { name: 'Quick capture' }) as HTMLInputElement).value).toBe(
+      '',
+    )
+  })
+})

--- a/web/src/components/RecurrenceDialogs.svelte
+++ b/web/src/components/RecurrenceDialogs.svelte
@@ -13,6 +13,7 @@
     recurrences: readonly KataRecurrence[]
     actor: string
     disabled?: boolean | undefined
+    draftFenceGeneration?: number | undefined
     onCreate: (projectID: number, input: KataCreateRecurrenceInput) => Promise<void>
     onPatch: (id: number, input: KataPatchRecurrenceInput, etag: string) => Promise<void>
     onDelete: (recurrence: KataRecurrence) => Promise<boolean>
@@ -23,6 +24,7 @@
     recurrences,
     actor,
     disabled = false,
+    draftFenceGeneration = 0,
     onCreate,
     onPatch,
     onDelete,
@@ -38,9 +40,23 @@
     recurrence: null,
   })
   let deletingRecurrence = $state(false)
+  let lastDraftFenceGeneration = $state<number | null>(null)
 
   $effect(() => {
     reconcileRecurrences(recurrences)
+  })
+
+  $effect(() => {
+    const nextGeneration = draftFenceGeneration
+    if (lastDraftFenceGeneration === null) {
+      lastDraftFenceGeneration = nextGeneration
+      return
+    }
+    if (nextGeneration === lastDraftFenceGeneration) return
+    lastDraftFenceGeneration = nextGeneration
+    recurrenceDialog = { open: false, mode: 'create', recurrence: null, etag: '' }
+    recurrenceDelete = { open: false, recurrence: null }
+    deletingRecurrence = false
   })
 
   export function openCreateRecurrence(): void {

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -24,6 +24,7 @@
     currentView: KataCurrentView
     searchFilters: KataTaskSearchFilters
     projectCreationDisabled: boolean
+    draftFenceGeneration?: number | undefined
     inboxProjectUID?: string | undefined
     inboxDesignationDisabled: boolean
     onOpenView: (name: KataTaskViewName) => void | Promise<void>
@@ -38,6 +39,7 @@
     currentView,
     searchFilters,
     projectCreationDisabled,
+    draftFenceGeneration = 0,
     inboxProjectUID,
     inboxDesignationDisabled,
     onOpenView,
@@ -65,11 +67,23 @@
   let createInput: HTMLInputElement | null = $state(null)
   let collapsedAreas = $state<string[]>([])
   let inboxError = $state('')
+  let lastDraftFenceGeneration = $state<number | null>(null)
   const inboxOptions = $derived.by<TypeaheadOption[]>(() =>
     projects
       .map((project) => ({ name: project.uid, label: project.name }))
       .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })),
   )
+
+  $effect(() => {
+    const nextGeneration = draftFenceGeneration
+    if (lastDraftFenceGeneration === null) {
+      lastDraftFenceGeneration = nextGeneration
+      return
+    }
+    if (nextGeneration === lastDraftFenceGeneration) return
+    lastDraftFenceGeneration = nextGeneration
+    cancelCreatingProject()
+  })
 
   function toggleArea(name: string): void {
     collapsedAreas = collapsedAreas.includes(name)

--- a/web/src/components/Sidebar.test.ts
+++ b/web/src/components/Sidebar.test.ts
@@ -187,6 +187,18 @@ describe('Sidebar', () => {
     await fireEvent.submit(input.closest('form')!)
     expect(onCreateProject).not.toHaveBeenCalled()
   })
+
+  it('resets a project draft after authentication authority changes', async () => {
+    const view = renderSidebar({ draftFenceGeneration: 0 })
+    await fireEvent.click(screen.getByRole('button', { name: 'New project' }))
+    await fireEvent.input(screen.getByRole('textbox', { name: 'New project name' }), {
+      target: { value: 'Old authority project' },
+    })
+
+    await view.rerender({ draftFenceGeneration: 1 })
+
+    expect(screen.queryByRole('textbox', { name: 'New project name' })).toBeNull()
+  })
 })
 
 function project(overrides: Partial<KataProjectSummary>): KataProjectSummary {

--- a/web/src/lib/api/schema.d.ts
+++ b/web/src/lib/api/schema.d.ts
@@ -3066,6 +3066,7 @@ export interface components {
       closed_reason?: string
       /** Format: date-time */
       created_at: string
+      deadline_on_date?: string
       /** Format: date-time */
       deleted_at?: string
       /** Format: int64 */

--- a/web/src/lib/kata/projection.test.ts
+++ b/web/src/lib/kata/projection.test.ts
@@ -112,6 +112,21 @@ describe('normalizeKataUISnapshot', () => {
     )
   })
 
+  test('preserves the server-projected browser date for timed deadlines', () => {
+    const source = snapshot()
+    source.collection![0]!.metadata = { deadline_on: '2026-09-01T00:30:00Z' }
+    source.collection![0]!.deadline_on_date = '2026-08-31'
+
+    const projection = normalizeKataUISnapshot(source)
+
+    expect(projection.issues[0]).toEqual(
+      expect.objectContaining({
+        deadline_on_date: '2026-08-31',
+        metadata: { deadline_on: '2026-09-01T00:30:00Z' },
+      }),
+    )
+  })
+
   test('preserves selected-link endpoint authority outside the filtered collection', () => {
     const authority = snapshot()
     authority.collection = authority.collection!.filter((issue) => issue.uid !== 'issue-parent')
@@ -135,7 +150,7 @@ describe('normalizeKataUISnapshot', () => {
 
 function snapshot(): UISnapshot {
   return {
-    contract_version: '1',
+    contract_version: '2',
     cursor: 12,
     capabilities: { writable: true, updates: 'sse', actor_policy: 'identity' },
     origin: 'https://daemon.example',

--- a/web/src/lib/kata/projection.ts
+++ b/web/src/lib/kata/projection.ts
@@ -306,6 +306,7 @@ function normalizeIssue(
     project_name:
       issue.project_name || project?.name || projectNameFromQualifiedID(issue.qualified_id),
     scheduled_on_date: issue.scheduled_on_date,
+    deadline_on_date: issue.deadline_on_date,
     metadata: { ...issue.metadata },
     revision: issue.revision,
     owner: issue.owner,

--- a/web/src/lib/kata/types.ts
+++ b/web/src/lib/kata/types.ts
@@ -57,6 +57,7 @@ export interface KataTaskSummary {
   project_uid: string
   project_name: string
   scheduled_on_date?: string | undefined
+  deadline_on_date?: string | undefined
   metadata: KataTaskMetadata
   revision: number
   owner?: string | undefined

--- a/web/src/lib/kata/view.test.ts
+++ b/web/src/lib/kata/view.test.ts
@@ -196,6 +196,44 @@ describe('kata task view builder', () => {
     ])
   })
 
+  test('uses the server-projected browser date for timed deadlines', () => {
+    const previousBrowserDay = {
+      ...issue('issue-1', 'Previous browser deadline', 'project-health', {
+        deadline_on: '2026-09-01T00:30:00Z',
+      }),
+      deadline_on_date: '2026-08-31',
+    }
+    const nextBrowserDay = {
+      ...issue('issue-2', 'Next browser deadline', 'project-workspace', {
+        deadline_on: '2026-09-01T07:30:00Z',
+      }),
+      deadline_on_date: '2026-09-01',
+    }
+
+    const todayView = buildKataTaskView({
+      view: 'today',
+      issues: [previousBrowserDay, nextBrowserDay],
+      projects,
+      today: '2026-08-31',
+      fetched_at: fetchedAt,
+    })
+    expect(todayView.groups.flatMap((group) => group.issues.map((item) => item.title))).toEqual([
+      'Previous browser deadline',
+    ])
+
+    const deadlinesView = buildKataTaskView({
+      view: 'deadlines',
+      issues: [previousBrowserDay, nextBrowserDay],
+      projects,
+      today: '2026-08-31',
+      fetched_at: fetchedAt,
+    })
+    expect(deadlinesView.groups.map((group) => [group.id, group.issues[0]?.title])).toEqual([
+      ['today', 'Previous browser deadline'],
+      ['2026-09-01', 'Next browser deadline'],
+    ])
+  })
+
   test('builds Inbox only from task inbox projects', () => {
     const view = buildKataTaskView({
       view: 'inbox',

--- a/web/src/lib/kata/view.ts
+++ b/web/src/lib/kata/view.ts
@@ -25,6 +25,10 @@ function scheduledDate(issue: KataTaskSummary): string | undefined {
   return issue.scheduled_on_date ?? issueDate(issue.metadata.scheduled_on)
 }
 
+function deadlineDate(issue: KataTaskSummary): string | undefined {
+  return issue.deadline_on_date ?? issueDate(issue.metadata.deadline_on)
+}
+
 function compareIssues(a: KataTaskSummary, b: KataTaskSummary): number {
   const ap = a.priority ?? Number.MAX_SAFE_INTEGER
   const bp = b.priority ?? Number.MAX_SAFE_INTEGER
@@ -35,8 +39,8 @@ function compareIssues(a: KataTaskSummary, b: KataTaskSummary): number {
 }
 
 function compareByDeadline(a: KataTaskSummary, b: KataTaskSummary): number {
-  const ad = issueDate(a.metadata.deadline_on) ?? ''
-  const bd = issueDate(b.metadata.deadline_on) ?? ''
+  const ad = deadlineDate(a) ?? ''
+  const bd = deadlineDate(b) ?? ''
   if (ad !== bd) return ad.localeCompare(bd)
   return compareIssues(a, b)
 }
@@ -96,7 +100,7 @@ function buildToday(issues: KataTaskSummary[], today: string): KataTaskGroup[] {
   for (const issue of issues) {
     if (issue.status !== 'open') continue
     const scheduledOn = scheduledDate(issue)
-    const deadlineOn = issueDate(issue.metadata.deadline_on)
+    const deadlineOn = deadlineDate(issue)
     const scheduledDue = scheduledOn !== undefined && scheduledOn <= today
     const deadlineDue = deadlineOn !== undefined && deadlineOn <= today
     if (!scheduledDue && !deadlineDue) continue
@@ -156,7 +160,7 @@ function buildDeadlines(issues: KataTaskSummary[], today: string): KataTaskGroup
 
   for (const issue of issues) {
     if (issue.status !== 'open') continue
-    const deadlineOn = issueDate(issue.metadata.deadline_on)
+    const deadlineOn = deadlineDate(issue)
     if (!deadlineOn) continue
 
     if (deadlineOn < today) {

--- a/web/src/lib/state/snapshot.test.ts
+++ b/web/src/lib/state/snapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { SnapshotController, type SnapshotRequest } from './snapshot'
+import { parseRoute } from '../router'
+import { SnapshotController, snapshotIntentForRoute, type SnapshotRequest } from './snapshot'
 
 interface TestIntent {
   key: string
@@ -127,6 +128,22 @@ describe('SnapshotController', () => {
       loading: false,
       canMutate: false,
     })
+  })
+})
+
+describe('snapshotIntentForRoute', () => {
+  it('includes the browser timezone for non-calendar collections', () => {
+    const route = parseRoute(new URL('https://daemon.example/kata?view=all-open'))
+    if (route.kind === 'route-error') throw new Error('expected a Kata route')
+
+    const intent = snapshotIntentForRoute(
+      route,
+      new Date('2026-09-01T00:30:00Z'),
+      'America/Los_Angeles',
+    )
+
+    expect(intent.timeZone).toBe('America/Los_Angeles')
+    expect(intent.localDate).toBeUndefined()
   })
 })
 

--- a/web/src/lib/state/snapshot.ts
+++ b/web/src/lib/state/snapshot.ts
@@ -232,13 +232,13 @@ export function snapshotIntentForRoute(
     relationships: [...route.filters.relationship],
     includeGraph: Boolean(route.issueUID) && route.graph,
     includeHistory: Boolean(route.issueUID),
+    timeZone,
   }
   if (route.projectUID) intent.projectUID = route.projectUID
   if (route.issueUID) intent.selectedIssueUID = route.issueUID
   if (route.filters.text) intent.text = route.filters.text
   if (['today', 'upcoming', 'deadlines'].includes(intent.view)) {
     intent.localDate = localDate(now, timeZone)
-    intent.timeZone = timeZone
   }
   return intent
 }


### PR DESCRIPTION
## What changed

- Adds paired `kata schedule` / `kata deadline` commands and `kata.set_schedule` / `kata.set_deadline` MCP tools.
- Keeps `scheduled_on` and `deadline_on` as the stored metadata keys while giving agents concise first-class actions.
- Accepts dates, local date-times, and UTC instants for both actions, with optional revision guards.
- Projects timed deadlines to the correct browser calendar date in collection and selected-issue views on SQLite and PostgreSQL. The browser snapshot contract advances so mixed daemon versions fail safely.
- Fences browser drafts after credential rejection. Comment drafts stay visible until reviewed under renewed authority; other mutation drafts and open editors reset.
- Updates generated AGENTS guidance, quickstart output, and public references. There is no persisted database schema or migration change.

## Why

Agents had to know internal metadata keys and construct generic metadata patches for common planning actions. The paired commands make scheduling and deadlines discoverable without hiding the underlying metadata model.

`scheduled_on` remains a queue gate: a future value keeps an issue out of `ready` and `next`. `deadline_on` remains informational and does not park the issue.

## Usage

```sh
kata schedule abc4 2026-09-01T09:30
kata schedule abc4 -

kata deadline abc4 2026-09-01T17:00
kata deadline abc4 -
```

For MCP, call `kata.set_schedule` with `{"ref":"abc4","schedule":"2026-09-01"}` or `{"ref":"abc4","clear_schedule":true}`. Call `kata.set_deadline` with `{"ref":"abc4","deadline":"2026-09-01"}` or `{"ref":"abc4","clear_deadline":true}`.

Closes #263