### PR TITLE
Report unreachable local daemon errors

### DIFF
--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -56,17 +56,10 @@ func ensureDaemon(ctx context.Context) (string, error) {
 	}
 	workspaceStart := workspaceStartForRemote()
 	baseURL, err := client.EnsureRunningInWorkspace(ctx, workspaceStart)
-	if err == nil {
-		return baseURL, nil
+	if err != nil {
+		return "", cliDaemonTargetError(err)
 	}
-	if errors.Is(err, client.ErrRemoteUnavailable) {
-		return "", &cliError{
-			Message:  err.Error(),
-			Kind:     kindDaemonUnavail,
-			ExitCode: ExitDaemonUnavail,
-		}
-	}
-	return "", err
+	return baseURL, nil
 }
 
 // workspaceStartForRemote returns the absolute --workspace path when
@@ -134,7 +127,9 @@ func discoverDaemon(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if url, ok := client.Discover(ctx, ns.DataDir); ok {
+	if url, ok, err := client.Discover(ctx, ns.DataDir); err != nil {
+		return "", cliDaemonTargetError(err)
+	} else if ok {
 		return url, nil
 	}
 	return "", noDaemonRunningError()
@@ -156,7 +151,8 @@ func cliDaemonTargetError(err error) error {
 			ExitCode: ExitValidation,
 		}
 	}
-	if errors.Is(err, client.ErrRemoteUnavailable) {
+	if errors.Is(err, client.ErrRemoteUnavailable) ||
+		errors.Is(err, client.ErrLocalDaemonUnreachable) {
 		return &cliError{
 			Message:  err.Error(),
 			Kind:     kindDaemonUnavail,

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -254,7 +254,7 @@ func liveDaemonRecord(dataDir string, pid int) (kitdaemon.RuntimeRecord, bool) {
 		if pid != 0 && rec.PID != pid {
 			continue
 		}
-		if kitdaemon.ProcessAlive(rec.PID) {
+		if daemon.RuntimeProcessAlive(rec) {
 			return rec, true
 		}
 	}
@@ -296,7 +296,7 @@ func daemonStatusCmd() *cobra.Command {
 			}
 			out := daemonStatusOutput{Daemons: make([]daemonStatusEntry, 0, len(recs))}
 			for _, r := range recs {
-				if kitdaemon.ProcessAlive(r.PID) {
+				if daemon.RuntimeProcessAlive(r) {
 					out.Daemons = append(out.Daemons, daemonStatusEntry{
 						PID:       r.PID,
 						Version:   daemonRuntimeVersion(r),
@@ -386,7 +386,7 @@ func daemonStopCmd() *cobra.Command {
 			mode := currentOutputMode()
 			pids := make([]int, 0, len(recs))
 			for _, r := range recs {
-				if !kitdaemon.ProcessAlive(r.PID) {
+				if !daemon.RuntimeProcessAlive(r) {
 					continue
 				}
 				// SignalDaemonStop is platform-specific: SIGTERM on Unix,
@@ -451,7 +451,7 @@ func daemonRestartCmd() *cobra.Command {
 			}
 			pids := make([]int, 0, len(recs))
 			for _, rec := range recs {
-				if !kitdaemon.ProcessAlive(rec.PID) {
+				if !daemon.RuntimeProcessAlive(rec) {
 					continue
 				}
 				if err := daemon.SignalDaemonStop(rec, ns.DBHash); err != nil {
@@ -660,7 +660,7 @@ func daemonReloadCmd() *cobra.Command {
 				return err
 			}
 			for _, r := range recs {
-				if !kitdaemon.ProcessAlive(r.PID) {
+				if !daemon.RuntimeProcessAlive(r) {
 					continue
 				}
 				// SignalDaemonReload is platform-specific: SIGHUP on Unix,

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -175,6 +175,17 @@ func TestDaemonStatus_AgentReportsStopped(t *testing.T) {
 	assert.Equal(t, "OK daemon status=stopped\n", string(out))
 }
 
+func TestDaemonStatus_IgnoresRuntimeRecordWhosePIDWasReused(t *testing.T) {
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	child := startSleepProcess(t)
+	writeReusedRuntimePID(t, tmp, child.Process.Pid)
+
+	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "status")
+
+	assert.Equal(t, "OK daemon status=stopped\n", string(out))
+}
+
 func TestDaemonStatus_AgentReportsWebURL(t *testing.T) {
 	resetFlags(t)
 	setupKataEnv(t)
@@ -562,6 +573,18 @@ func TestDaemonStop_AgentNoDaemonReportsNoop(t *testing.T) {
 	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "stop")
 
 	assert.Equal(t, "OK daemon action=stop stopped=0\n", string(out))
+}
+
+func TestDaemonStop_DoesNotSignalRuntimeRecordWhosePIDWasReused(t *testing.T) {
+	resetFlags(t)
+	tmp := setupKataEnv(t)
+	child := startSleepProcess(t)
+	writeReusedRuntimePID(t, tmp, child.Process.Pid)
+
+	out := executeRoot(t, newRootCmd(), "--agent", "daemon", "stop")
+
+	assert.Equal(t, "OK daemon action=stop stopped=0\n", string(out))
+	assert.True(t, kitdaemon.ProcessAlive(child.Process.Pid))
 }
 
 func TestDaemonStop_JSONReportsStoppedPIDs(t *testing.T) {
@@ -2202,4 +2225,27 @@ func writeRuntimePID(t *testing.T, home string, pid int) {
 	// A faked daemon PID has none, so create them here; no-op on Unix, where
 	// stop/reload deliver SIGTERM/SIGHUP straight to the PID.
 	registerDaemonSignalEndpoints(t, ns.DBHash, pid)
+}
+
+func writeReusedRuntimePID(t *testing.T, home string, pid int) {
+	t.Helper()
+	identity, ok := kitdaemon.ReadProcessIdentity(pid)
+	require.True(t, ok)
+	encoded := string(identity)
+	replacement := byte('0')
+	if encoded[len(encoded)-1] == replacement {
+		replacement = '1'
+	}
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	require.NoError(t, ns.EnsureDirs())
+	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
+		PID:               pid,
+		ProcessIdentity:   identity,
+		ProcessIdentityV2: kitdaemon.ProcessIdentity(encoded[:len(encoded)-1] + string(replacement)),
+		Network:           "unix",
+		Address:           filepath.Join(home, "daemon.sock"),
+		StartedAt:         time.Now().UTC(),
+	})
+	require.NoError(t, err)
 }

--- a/cmd/kata/export.go
+++ b/cmd/kata/export.go
@@ -182,7 +182,11 @@ func refuseRunningDaemonWithMessage(ctx context.Context, message string) error {
 	if err != nil {
 		return err
 	}
-	if _, ok := client.Discover(ctx, ns.DataDir); ok {
+	_, ok, err := client.Discover(ctx, ns.DataDir)
+	if err != nil {
+		return cliDaemonTargetError(err)
+	}
+	if ok {
 		return &cliError{
 			Message:  message,
 			Kind:     kindValidation,

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -502,6 +502,26 @@ func TestHealth_DoesNotAutoStartDaemon(t *testing.T) {
 		"hint must point the user at the right action")
 }
 
+func TestHealthReportsLiveUnreachableDaemon(t *testing.T) {
+	resetFlags(t)
+	home := setupKataEnv(t)
+	t.Setenv("KATA_SERVER", "")
+	address := "unix://" + filepath.Join(home, "missing.sock")
+	require.NoError(t, writeRuntimeFor(home, address))
+
+	_, err := discoverDaemon(context.Background())
+
+	require.Error(t, err)
+	var ce *cliError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, ExitDaemonUnavail, ce.ExitCode)
+	assert.Equal(t, kindDaemonUnavail, ce.Kind)
+	assert.Contains(t, ce.Message, "daemon pid")
+	assert.Contains(t, ce.Message, address)
+	assert.Contains(t, ce.Message, "missing.sock")
+	assert.NotContains(t, ce.Message, "no daemon running")
+}
+
 func TestHealth_NamedLocalDaemonDoesNotAutoStart(t *testing.T) {
 	resetFlags(t)
 	home := t.TempDir()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -592,6 +592,9 @@ transient startup overrides. Background start and restart output reports the
 resolved web UI URL on its own line after the daemon transport address.
 `daemon status` reports the running daemon's address, web UI URL, PID, version,
 and uptime.
+When a live local daemon record exists but its endpoint cannot be reached,
+client commands report the PID, endpoint, and underlying connection error
+instead of treating the daemon as stopped or attempting to start another one.
 `kata agent-instructions` is an alias for `kata quickstart`.
 For TCP listener auth modes, including trusted private-network bearer auth,
 read-only experiments, and explicit tokenless private-network writes, see

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/teambition/rrule-go v1.8.2
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
-	go.kenn.io/kit v0.19.1
+	go.kenn.io/kit v0.20.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.kenn.io/kit v0.19.1 h1:sZKU8DILmtNMn5jtgNKswRi8i72aytf5vJYEkGhlqEk=
-go.kenn.io/kit v0.19.1/go.mod h1:Cg1V5dG+XaSDYr/nE0tvmCxotfpYtW1vPhyc+Ph9Ny0=
+go.kenn.io/kit v0.20.0 h1:vviC9r/QRWN7Sh09ISh+7xlYVoKvCKVoqFLcUkGutL4=
+go.kenn.io/kit v0.20.0/go.mod h1:Cg1V5dG+XaSDYr/nE0tvmCxotfpYtW1vPhyc+Ph9Ny0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/bridges/prometheus v0.69.0 h1:saQoWg5845Q8TojpqeVStS7zGwVZ6bc5W2PJavTPiBM=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -95,7 +95,7 @@ func Discover(ctx context.Context, dataDir string) (string, bool, error) {
 	}
 	var unreachable error
 	for _, r := range recs {
-		if !runtimeRecordProcessAlive(r) {
+		if !daemon.RuntimeProcessAlive(r) {
 			continue
 		}
 		address := r.Endpoint().ConfigAddress()
@@ -115,14 +115,6 @@ func Discover(ctx context.Context, dataDir string) (string, bool, error) {
 		}
 	}
 	return "", false, unreachable
-}
-
-func runtimeRecordProcessAlive(record kitdaemon.RuntimeRecord) bool {
-	if !kitdaemon.ProcessAlive(record.PID) {
-		return false
-	}
-	return kitdaemon.CompareRuntimeProcessIdentity(record) !=
-		kitdaemon.ProcessIdentityMismatch
 }
 
 func probeAddress(ctx context.Context, address string) (string, PingInfo, bool) {
@@ -348,7 +340,7 @@ func unixClientFromRuntime(ctx context.Context, opts Opts) (*http.Client, error)
 		return nil, err
 	}
 	for _, r := range recs {
-		if !kitdaemon.ProcessAlive(r.PID) {
+		if !daemon.RuntimeProcessAlive(r) {
 			continue
 		}
 		ep := r.Endpoint()

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -60,52 +60,85 @@ type PingInfo struct {
 	PID     int    `json:"pid,omitempty"`
 }
 
+// ErrLocalDaemonUnreachable identifies a live local daemon process whose
+// recorded endpoint could not be reached.
+var ErrLocalDaemonUnreachable = errors.New("local daemon is unreachable")
+
+type localDaemonUnreachableError struct {
+	pid     int
+	address string
+	cause   error
+}
+
+func (e *localDaemonUnreachableError) Error() string {
+	return fmt.Sprintf("daemon pid %d is running at %s but is unreachable: %v",
+		e.pid, e.address, e.cause)
+}
+
+func (e *localDaemonUnreachableError) Unwrap() error {
+	return e.cause
+}
+
+func (e *localDaemonUnreachableError) Is(target error) bool {
+	return target == ErrLocalDaemonUnreachable
+}
+
 // Discover scans the namespace's runtime files and returns the base URL of
-// the first daemon that passes /api/v1/ping. The bool is false when none
-// respond — auto-start logic lives separately in EnsureRunning so callers
-// that should never spawn (e.g. health probes) can opt out.
-func Discover(ctx context.Context, dataDir string) (string, bool) {
+// the first daemon that passes /api/v1/ping. The bool is false when no live
+// runtime record exists. A live process whose endpoint cannot be reached
+// returns ErrLocalDaemonUnreachable so callers do not mistake a permission or
+// transport failure for an absent daemon.
+func Discover(ctx context.Context, dataDir string) (string, bool, error) {
 	recs, err := (kitdaemon.RuntimeStore{Dir: dataDir}).List()
 	if err != nil {
-		return "", false
+		return "", false, err
 	}
+	var unreachable error
 	for _, r := range recs {
 		if !kitdaemon.ProcessAlive(r.PID) {
 			continue
 		}
-		if url, ok := pingAddress(ctx, r.Endpoint().ConfigAddress()); ok {
-			return url, true
+		address := r.Endpoint().ConfigAddress()
+		url, _, probeErr := probeAddressWithError(ctx, address)
+		if probeErr == nil {
+			return url, true, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", false, err
+		}
+		if unreachable == nil {
+			unreachable = &localDaemonUnreachableError{
+				pid:     r.PID,
+				address: address,
+				cause:   probeErr,
+			}
 		}
 	}
-	return "", false
-}
-
-// pingAddress probes /api/v1/ping at a runtime-file address. Returns the
-// base URL the caller should use to reach the daemon. Version/service
-// compatibility is enforced by EnsureRunning; plain Discover only needs
-// the endpoint to answer the kata liveness shape.
-func pingAddress(ctx context.Context, address string) (string, bool) {
-	url, _, ok := probeAddress(ctx, address)
-	return url, ok
+	return "", false, unreachable
 }
 
 func probeAddress(ctx context.Context, address string) (string, PingInfo, bool) {
+	url, info, err := probeAddressWithError(ctx, address)
+	return url, info, err == nil
+}
+
+func probeAddressWithError(ctx context.Context, address string) (string, PingInfo, error) {
 	if strings.HasPrefix(address, "unix://") {
 		path := strings.TrimPrefix(address, "unix://")
 		client := &http.Client{Transport: UnixTransport(path), Timeout: 1 * time.Second}
 		info, err := Probe(ctx, client, UnixBase)
 		if err == nil {
-			return UnixBase, info, true
+			return UnixBase, info, nil
 		}
-		return "", PingInfo{}, false
+		return "", PingInfo{}, err
 	}
 	url := "http://" + address
 	client := &http.Client{Timeout: 1 * time.Second}
 	info, err := Probe(ctx, client, url)
 	if err == nil {
-		return url, info, true
+		return url, info, nil
 	}
-	return "", PingInfo{}, false
+	return "", PingInfo{}, err
 }
 
 // Ping is true when GET base+/api/v1/ping returns 200.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -95,7 +95,7 @@ func Discover(ctx context.Context, dataDir string) (string, bool, error) {
 	}
 	var unreachable error
 	for _, r := range recs {
-		if !kitdaemon.ProcessAlive(r.PID) {
+		if !runtimeRecordProcessAlive(r) {
 			continue
 		}
 		address := r.Endpoint().ConfigAddress()
@@ -115,6 +115,14 @@ func Discover(ctx context.Context, dataDir string) (string, bool, error) {
 		}
 	}
 	return "", false, unreachable
+}
+
+func runtimeRecordProcessAlive(record kitdaemon.RuntimeRecord) bool {
+	if !kitdaemon.ProcessAlive(record.PID) {
+		return false
+	}
+	return kitdaemon.CompareProcessIdentity(record.PID, record.ProcessIdentity) !=
+		kitdaemon.ProcessIdentityMismatch
 }
 
 func probeAddress(ctx context.Context, address string) (string, PingInfo, bool) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -121,7 +121,7 @@ func runtimeRecordProcessAlive(record kitdaemon.RuntimeRecord) bool {
 	if !kitdaemon.ProcessAlive(record.PID) {
 		return false
 	}
-	return kitdaemon.CompareProcessIdentity(record.PID, record.ProcessIdentity) !=
+	return kitdaemon.CompareRuntimeProcessIdentity(record) !=
 		kitdaemon.ProcessIdentityMismatch
 }
 

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -286,10 +286,14 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 		return "", fmt.Errorf("auto-start daemon: %w", err)
 	}
 	deadline := time.Now().Add(daemonStartupWait)
+	var unreachable error
 	for time.Now().Before(deadline) {
 		url, compatible, ok, err := discoverDaemonForAutoStart(ctx, dataDir)
-		if err != nil {
+		if err != nil && !errors.Is(err, ErrLocalDaemonUnreachable) {
 			return "", err
+		}
+		if errors.Is(err, ErrLocalDaemonUnreachable) {
+			unreachable = err
 		}
 		if ok && compatible {
 			return url, nil
@@ -299,6 +303,9 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 			return "", ctx.Err()
 		case <-time.After(50 * time.Millisecond):
 		}
+	}
+	if unreachable != nil {
+		return "", unreachable
 	}
 	return "", fmt.Errorf("daemon failed to start within %s; inspect kata daemon status and kata daemon logs", daemonStartupWait)
 }

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -176,11 +176,6 @@ func ensureLocalRunning(ctx context.Context) (string, error) {
 	return startDaemonForEnsure(ctx, ns.DataDir)
 }
 
-func discoverForEnsure(ctx context.Context, dataDir string) (string, bool, bool) {
-	url, compatible, ok, _ := discoverForEnsureWithError(ctx, dataDir)
-	return url, compatible, ok
-}
-
 func discoverForEnsureWithError(ctx context.Context, dataDir string) (string, bool, bool, error) {
 	recs, err := (kitdaemon.RuntimeStore{Dir: dataDir}).List()
 	if err != nil {
@@ -214,10 +209,13 @@ func discoverForEnsureWithError(ctx context.Context, dataDir string) (string, bo
 			staleURL = url
 		}
 	}
+	if unreachable != nil {
+		return "", false, false, unreachable
+	}
 	if staleURL != "" {
 		return staleURL, false, true, nil
 	}
-	return "", false, false, unreachable
+	return "", false, false, nil
 }
 
 func daemonVersionCheckSkipped() bool {
@@ -233,6 +231,7 @@ func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
 	if err != nil {
 		return err
 	}
+	signaled := false
 	for _, r := range recs {
 		if !kitdaemon.ProcessAlive(r.PID) {
 			continue
@@ -248,11 +247,19 @@ func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
 		if err := signalDaemonStopForEnsure(r, dbhash); err != nil {
 			return fmt.Errorf("stop old daemon pid %d: %w", r.PID, err)
 		}
+		signaled = true
+	}
+	if !signaled {
+		return nil
 	}
 
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if _, _, ok := discoverForEnsure(ctx, dataDir); !ok {
+		_, _, ok, err := discoverForEnsureWithError(ctx, dataDir)
+		if err != nil {
+			return err
+		}
+		if !ok {
 			return nil
 		}
 		select {

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -81,7 +81,7 @@ var (
 	startDetachedDaemonForEnsure = kitdaemon.StartDetached
 	stopRunningDaemonsForEnsure  = stopRunningDaemons
 	signalDaemonStopForEnsure    = daemon.SignalDaemonStop
-	discoverDaemonForAutoStart   = discoverForEnsure
+	discoverDaemonForAutoStart   = discoverForEnsureWithError
 )
 
 // EnsureRunning returns a live daemon's base URL, auto-starting the daemon
@@ -160,7 +160,11 @@ func ensureLocalRunning(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if url, compatible, ok := discoverForEnsure(ctx, ns.DataDir); ok {
+	url, compatible, ok, err := discoverForEnsureWithError(ctx, ns.DataDir)
+	if err != nil {
+		return "", err
+	}
+	if ok {
 		if compatible {
 			return url, nil
 		}
@@ -173,30 +177,47 @@ func ensureLocalRunning(ctx context.Context) (string, error) {
 }
 
 func discoverForEnsure(ctx context.Context, dataDir string) (string, bool, bool) {
+	url, compatible, ok, _ := discoverForEnsureWithError(ctx, dataDir)
+	return url, compatible, ok
+}
+
+func discoverForEnsureWithError(ctx context.Context, dataDir string) (string, bool, bool, error) {
 	recs, err := (kitdaemon.RuntimeStore{Dir: dataDir}).List()
 	if err != nil {
-		return "", false, false
+		return "", false, false, err
 	}
 	var staleURL string
+	var unreachable error
 	for _, r := range recs {
 		if !kitdaemon.ProcessAlive(r.PID) {
 			continue
 		}
-		url, info, ok := probeAddress(ctx, r.Endpoint().ConfigAddress())
-		if !ok {
+		address := r.Endpoint().ConfigAddress()
+		url, info, probeErr := probeAddressWithError(ctx, address)
+		if probeErr != nil {
+			if err := ctx.Err(); err != nil {
+				return "", false, false, err
+			}
+			if unreachable == nil {
+				unreachable = &localDaemonUnreachableError{
+					pid:     r.PID,
+					address: address,
+					cause:   probeErr,
+				}
+			}
 			continue
 		}
 		if daemonVersionCheckSkipped() || daemonVersionCompatible(info) {
-			return url, true, true
+			return url, true, true, nil
 		}
 		if staleURL == "" {
 			staleURL = url
 		}
 	}
 	if staleURL != "" {
-		return staleURL, false, true
+		return staleURL, false, true, nil
 	}
-	return "", false, false
+	return "", false, false, unreachable
 }
 
 func daemonVersionCheckSkipped() bool {
@@ -266,7 +287,11 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 	}
 	deadline := time.Now().Add(daemonStartupWait)
 	for time.Now().Before(deadline) {
-		if url, compatible, ok := discoverDaemonForAutoStart(ctx, dataDir); ok && compatible {
+		url, compatible, ok, err := discoverDaemonForAutoStart(ctx, dataDir)
+		if err != nil {
+			return "", err
+		}
+		if ok && compatible {
 			return url, nil
 		}
 		select {

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -184,7 +184,7 @@ func discoverForEnsureWithError(ctx context.Context, dataDir string) (string, bo
 	var staleURL string
 	var unreachable error
 	for _, r := range recs {
-		if !runtimeRecordProcessAlive(r) {
+		if !daemon.RuntimeProcessAlive(r) {
 			continue
 		}
 		address := r.Endpoint().ConfigAddress()
@@ -233,7 +233,7 @@ func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
 	}
 	signaled := false
 	for _, r := range recs {
-		if !kitdaemon.ProcessAlive(r.PID) {
+		if !daemon.RuntimeProcessAlive(r) {
 			continue
 		}
 		address := r.Endpoint().ConfigAddress()

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -189,7 +189,7 @@ func discoverForEnsureWithError(ctx context.Context, dataDir string) (string, bo
 	var staleURL string
 	var unreachable error
 	for _, r := range recs {
-		if !kitdaemon.ProcessAlive(r.PID) {
+		if !runtimeRecordProcessAlive(r) {
 			continue
 		}
 		address := r.Endpoint().ConfigAddress()

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -334,6 +334,34 @@ func TestStopRunningDaemonsSignalsVerifiedIncompatibleRuntime(t *testing.T) {
 	assert.Equal(t, ns.DBHash, signaledDBHash)
 }
 
+func TestStopRunningDaemonsReportsUnreachableDaemonRemainingAfterSignal(t *testing.T) {
+	t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
+	tmp := setupKataEnv(t)
+	child, _ := startLongLivedTestProcess(t)
+	_, addr := startMockDaemonPing(t, map[string]any{
+		"ok":      true,
+		"service": "kata",
+		"version": "old-version",
+		"pid":     child.Process.Pid,
+	})
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, child.Process.Pid, addr))
+	unreachableAddress := "unix://" + filepath.Join(tmp, "missing.sock")
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), unreachableAddress))
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+
+	origSignal := signalDaemonStopForEnsure
+	signalDaemonStopForEnsure = func(rec kitdaemon.RuntimeRecord, _ string) error {
+		return os.Remove(filepath.Join(ns.DataDir, fmt.Sprintf("daemon.%d.json", rec.PID)))
+	}
+	t.Cleanup(func() { signalDaemonStopForEnsure = origSignal })
+
+	err = stopRunningDaemons(context.Background(), ns.DataDir, ns.DBHash)
+
+	require.ErrorIs(t, err, ErrLocalDaemonUnreachable)
+	assert.Contains(t, err.Error(), unreachableAddress)
+}
+
 func TestStopRunningDaemonsReturnsSignalError(t *testing.T) {
 	t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
 	tmp := setupKataEnv(t)
@@ -393,6 +421,29 @@ func TestEnsureRunningReportsLiveUnreachableDaemonWithoutAutoStart(t *testing.T)
 	assert.Contains(t, err.Error(), fmt.Sprintf("daemon pid %d is running", os.Getpid()))
 	assert.Contains(t, err.Error(), address)
 	assert.Contains(t, err.Error(), "missing.sock")
+	assert.Zero(t, restore.startCalls)
+}
+
+func TestEnsureRunningPrioritizesUnreachableDaemonOverIncompatibleDaemon(t *testing.T) {
+	t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
+	tmp := setupKataEnv(t)
+	child, _ := startLongLivedTestProcess(t)
+	_, addr := startMockDaemonPing(t, map[string]any{
+		"ok":      true,
+		"service": "kata",
+		"version": "old-version",
+		"pid":     child.Process.Pid,
+	})
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, child.Process.Pid, addr))
+	unreachableAddress := "unix://" + filepath.Join(tmp, "missing.sock")
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), unreachableAddress))
+	restore := patchEnsureHooks(t, currentVersionForEnsure(), "http://new-daemon")
+
+	_, err := EnsureRunning(context.Background())
+
+	require.ErrorIs(t, err, ErrLocalDaemonUnreachable)
+	assert.Contains(t, err.Error(), unreachableAddress)
+	assert.Zero(t, restore.stopCalls)
 	assert.Zero(t, restore.startCalls)
 }
 

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -188,17 +188,37 @@ func TestAutoStartAllowsDaemonStartupBeyondFiveSeconds(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		startedAt := time.Now()
-		discoverDaemonForAutoStart = func(context.Context, string) (string, bool, bool) {
+		discoverDaemonForAutoStart = func(context.Context, string) (string, bool, bool, error) {
 			if time.Since(startedAt) < 6*time.Second {
-				return "", false, false
+				return "", false, false, nil
 			}
-			return "http://127.0.0.1:27123", true, true
+			return "http://127.0.0.1:27123", true, true, nil
 		}
 
 		url, err := autoStart(t.Context(), dataDir)
 
 		require.NoError(t, err)
 		assert.Equal(t, "http://127.0.0.1:27123", url)
+	})
+}
+
+func TestAutoStartReportsUnreachableSpawnedDaemonWithoutWaiting(t *testing.T) {
+	home := setupKataEnv(t)
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	address := "unix://" + filepath.Join(home, "missing.sock")
+	originalStart := startDetachedDaemonForEnsure
+	startDetachedDaemonForEnsure = func(context.Context, kitdaemon.StartDetachedOptions) error {
+		return writeRuntimeRecord(t, home, address)
+	}
+	t.Cleanup(func() { startDetachedDaemonForEnsure = originalStart })
+
+	synctest.Test(t, func(t *testing.T) {
+		_, err := autoStart(t.Context(), ns.DataDir)
+
+		require.ErrorIs(t, err, ErrLocalDaemonUnreachable)
+		assert.Contains(t, err.Error(), address)
+		assert.NotContains(t, err.Error(), "failed to start within")
 	})
 }
 
@@ -324,6 +344,34 @@ func TestStopRunningDaemonsErrorsOnUnverifiableIncompatibleRuntime(t *testing.T)
 
 	_, err = os.Stat(filepath.Join(ns.DataDir, fmt.Sprintf("daemon.%d.json", os.Getpid())))
 	assert.NoError(t, err, "unverifiable reachable daemon runtime file should be preserved")
+}
+
+func TestEnsureRunningReportsLiveUnreachableDaemonWithoutAutoStart(t *testing.T) {
+	tmp := setupKataEnv(t)
+	address := "unix://" + filepath.Join(tmp, "missing.sock")
+	require.NoError(t, writeRuntimeRecord(t, tmp, address))
+	restore := patchEnsureHooks(t, currentVersionForEnsure(), "http://new-daemon")
+
+	_, err := EnsureRunning(context.Background())
+
+	require.ErrorIs(t, err, ErrLocalDaemonUnreachable)
+	assert.Contains(t, err.Error(), fmt.Sprintf("daemon pid %d is running", os.Getpid()))
+	assert.Contains(t, err.Error(), address)
+	assert.Contains(t, err.Error(), "missing.sock")
+	assert.Zero(t, restore.startCalls)
+}
+
+func TestEnsureRunningAutoStartsWhenRuntimePIDIsDead(t *testing.T) {
+	tmp := setupKataEnv(t)
+	address := "unix://" + filepath.Join(tmp, "missing.sock")
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, 1<<30, address))
+	restore := patchEnsureHooks(t, currentVersionForEnsure(), "http://new-daemon")
+
+	url, err := EnsureRunning(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, "http://new-daemon", url)
+	assert.Equal(t, 1, restore.startCalls)
 }
 
 // setupKataEnv points KATA_HOME and KATA_DB at a fresh temp dir so the test

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -396,6 +396,46 @@ func TestEnsureRunningReportsLiveUnreachableDaemonWithoutAutoStart(t *testing.T)
 	assert.Zero(t, restore.startCalls)
 }
 
+func TestDiscoverIgnoresRuntimeRecordWhosePIDWasReused(t *testing.T) {
+	tmp := setupKataEnv(t)
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	require.NoError(t, ns.EnsureDirs())
+	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
+		PID:             os.Getpid(),
+		ProcessIdentity: kitdaemon.ProcessIdentity("1"),
+		Address:         "unix://" + filepath.Join(tmp, "missing.sock"),
+		StartedAt:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	_, ok, err := Discover(context.Background(), ns.DataDir)
+
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestEnsureRunningAutoStartsWhenRuntimePIDWasReused(t *testing.T) {
+	tmp := setupKataEnv(t)
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	require.NoError(t, ns.EnsureDirs())
+	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
+		PID:             os.Getpid(),
+		ProcessIdentity: kitdaemon.ProcessIdentity("1"),
+		Address:         "unix://" + filepath.Join(tmp, "missing.sock"),
+		StartedAt:       time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	restore := patchEnsureHooks(t, currentVersionForEnsure(), "http://new-daemon")
+
+	url, err := EnsureRunning(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, "http://new-daemon", url)
+	assert.Equal(t, 1, restore.startCalls)
+}
+
 func TestEnsureRunningAutoStartsWhenRuntimePIDIsDead(t *testing.T) {
 	tmp := setupKataEnv(t)
 	address := "unix://" + filepath.Join(tmp, "missing.sock")

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -401,18 +401,32 @@ func TestDiscoverIgnoresRuntimeRecordWhosePIDWasReused(t *testing.T) {
 	ns, err := daemon.NewNamespace()
 	require.NoError(t, err)
 	require.NoError(t, ns.EnsureDirs())
+	identity, ok := kitdaemon.ReadProcessIdentity(os.Getpid())
+	require.True(t, ok)
 	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
-		PID:             os.Getpid(),
-		ProcessIdentity: kitdaemon.ProcessIdentity("1"),
-		Address:         "unix://" + filepath.Join(tmp, "missing.sock"),
-		StartedAt:       time.Now().UTC(),
+		PID:               os.Getpid(),
+		ProcessIdentity:   identity,
+		ProcessIdentityV2: mismatchedProcessIdentity(t, identity),
+		Address:           "unix://" + filepath.Join(tmp, "missing.sock"),
+		StartedAt:         time.Now().UTC(),
 	})
 	require.NoError(t, err)
 
-	_, ok, err := Discover(context.Background(), ns.DataDir)
+	_, ok, err = Discover(context.Background(), ns.DataDir)
 
 	require.NoError(t, err)
 	assert.False(t, ok)
+}
+
+func mismatchedProcessIdentity(t *testing.T, identity kitdaemon.ProcessIdentity) kitdaemon.ProcessIdentity {
+	t.Helper()
+	encoded := string(identity)
+	last := encoded[len(encoded)-1]
+	replacement := byte('0')
+	if last == replacement {
+		replacement = '1'
+	}
+	return kitdaemon.ProcessIdentity(encoded[:len(encoded)-1] + string(replacement))
 }
 
 func TestEnsureRunningAutoStartsWhenRuntimePIDWasReused(t *testing.T) {
@@ -420,11 +434,14 @@ func TestEnsureRunningAutoStartsWhenRuntimePIDWasReused(t *testing.T) {
 	ns, err := daemon.NewNamespace()
 	require.NoError(t, err)
 	require.NoError(t, ns.EnsureDirs())
+	identity, ok := kitdaemon.ReadProcessIdentity(os.Getpid())
+	require.True(t, ok)
 	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
-		PID:             os.Getpid(),
-		ProcessIdentity: kitdaemon.ProcessIdentity("1"),
-		Address:         "unix://" + filepath.Join(tmp, "missing.sock"),
-		StartedAt:       time.Now().UTC(),
+		PID:               os.Getpid(),
+		ProcessIdentity:   identity,
+		ProcessIdentityV2: mismatchedProcessIdentity(t, identity),
+		Address:           "unix://" + filepath.Join(tmp, "missing.sock"),
+		StartedAt:         time.Now().UTC(),
 	})
 	require.NoError(t, err)
 	restore := patchEnsureHooks(t, currentVersionForEnsure(), "http://new-daemon")

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -202,22 +202,57 @@ func TestAutoStartAllowsDaemonStartupBeyondFiveSeconds(t *testing.T) {
 	})
 }
 
-func TestAutoStartReportsUnreachableSpawnedDaemonWithoutWaiting(t *testing.T) {
-	home := setupKataEnv(t)
-	ns, err := daemon.NewNamespace()
-	require.NoError(t, err)
-	address := "unix://" + filepath.Join(home, "missing.sock")
+func TestAutoStartWaitsForUnreachableSpawnedDaemonToBecomeReady(t *testing.T) {
+	dataDir := setupKataEnv(t)
 	originalStart := startDetachedDaemonForEnsure
+	originalDiscover := discoverDaemonForAutoStart
 	startDetachedDaemonForEnsure = func(context.Context, kitdaemon.StartDetachedOptions) error {
-		return writeRuntimeRecord(t, home, address)
+		return nil
 	}
-	t.Cleanup(func() { startDetachedDaemonForEnsure = originalStart })
+	t.Cleanup(func() {
+		startDetachedDaemonForEnsure = originalStart
+		discoverDaemonForAutoStart = originalDiscover
+	})
 
 	synctest.Test(t, func(t *testing.T) {
-		_, err := autoStart(t.Context(), ns.DataDir)
+		startedAt := time.Now()
+		discoverDaemonForAutoStart = func(context.Context, string) (string, bool, bool, error) {
+			if time.Since(startedAt) < 6*time.Second {
+				return "", false, false, fmt.Errorf("%w: listener not ready", ErrLocalDaemonUnreachable)
+			}
+			return "http://127.0.0.1:27123", true, true, nil
+		}
+
+		url, err := autoStart(t.Context(), dataDir)
+
+		require.NoError(t, err)
+		assert.Equal(t, "http://127.0.0.1:27123", url)
+	})
+}
+
+func TestAutoStartReportsPersistentUnreachableDaemonAfterReadinessDeadline(t *testing.T) {
+	dataDir := setupKataEnv(t)
+	originalStart := startDetachedDaemonForEnsure
+	originalDiscover := discoverDaemonForAutoStart
+	startDetachedDaemonForEnsure = func(context.Context, kitdaemon.StartDetachedOptions) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		startDetachedDaemonForEnsure = originalStart
+		discoverDaemonForAutoStart = originalDiscover
+	})
+
+	synctest.Test(t, func(t *testing.T) {
+		probeErr := fmt.Errorf("%w: daemon pid 123 at unix:///tmp/kata.sock", ErrLocalDaemonUnreachable)
+		discoverDaemonForAutoStart = func(context.Context, string) (string, bool, bool, error) {
+			return "", false, false, probeErr
+		}
+
+		_, err := autoStart(t.Context(), dataDir)
 
 		require.ErrorIs(t, err, ErrLocalDaemonUnreachable)
-		assert.Contains(t, err.Error(), address)
+		assert.ErrorIs(t, err, probeErr)
+		assert.Contains(t, err.Error(), "daemon pid 123")
 		assert.NotContains(t, err.Error(), "failed to start within")
 	})
 }

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -209,7 +209,10 @@ func discoverNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTar
 			if err != nil {
 				return namedDaemonTarget{}, false, err
 			}
-			baseURL, ok := Discover(ctx, ns.DataDir)
+			baseURL, ok, err := Discover(ctx, ns.DataDir)
+			if err != nil {
+				return namedDaemonTarget{}, false, err
+			}
 			if !ok {
 				return namedDaemonTarget{}, false, nil
 			}

--- a/internal/client/webui.go
+++ b/internal/client/webui.go
@@ -121,7 +121,7 @@ func discoverWebRuntimeForBaseURL(ctx context.Context, dataDir, baseURL string) 
 		return DiscoveredWebRuntime{}, fmt.Errorf("list daemon runtime records: %w", err)
 	}
 	for _, record := range records {
-		if !kitdaemon.ProcessAlive(record.PID) {
+		if !daemon.RuntimeProcessAlive(record) {
 			continue
 		}
 		candidate, _, ok := probeAddress(ctx, record.Endpoint().ConfigAddress())

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -597,7 +597,7 @@ func newClaimHubHTTPClient(ctx context.Context, baseURL string) (*http.Client, e
 		return nil, fmt.Errorf("%w: %v", errClaimHubTransportUnavailable, err)
 	}
 	for _, rec := range recs {
-		if !kitdaemon.ProcessAlive(rec.PID) {
+		if !RuntimeProcessAlive(rec) {
 			continue
 		}
 		ep := rec.Endpoint()

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1,0 +1,13 @@
+package daemon
+
+import kitdaemon "go.kenn.io/kit/daemon"
+
+// RuntimeProcessAlive reports whether a runtime record still identifies the
+// process that created it. Records without a verifiable identity retain the
+// legacy PID-only behavior; a definite identity mismatch is stale.
+func RuntimeProcessAlive(record kitdaemon.RuntimeRecord) bool {
+	if !kitdaemon.ProcessAlive(record.PID) {
+		return false
+	}
+	return kitdaemon.CompareRuntimeProcessIdentity(record) != kitdaemon.ProcessIdentityMismatch
+}

--- a/internal/daemon/runtime_test.go
+++ b/internal/daemon/runtime_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/daemon"
 	kitdaemon "go.kenn.io/kit/daemon"
 )
 
@@ -71,4 +72,21 @@ func TestRuntimeFile_AtomicViaTempRename(t *testing.T) {
 func TestProcessAlive_TrueForSelfFalseForGarbagePID(t *testing.T) {
 	assert.True(t, kitdaemon.ProcessAlive(os.Getpid()))
 	assert.False(t, kitdaemon.ProcessAlive(99999999))
+}
+
+func TestRuntimeProcessAliveRejectsReusedPID(t *testing.T) {
+	identity, ok := kitdaemon.ReadProcessIdentity(os.Getpid())
+	require.True(t, ok)
+	encoded := string(identity)
+	replacement := byte('0')
+	if encoded[len(encoded)-1] == replacement {
+		replacement = '1'
+	}
+	record := kitdaemon.RuntimeRecord{
+		PID:               os.Getpid(),
+		ProcessIdentity:   identity,
+		ProcessIdentityV2: kitdaemon.ProcessIdentity(encoded[:len(encoded)-1] + string(replacement)),
+	}
+
+	assert.False(t, daemon.RuntimeProcessAlive(record))
 }


### PR DESCRIPTION
## Summary

- preserve local daemon probe errors when a live runtime PID exists
- avoid starting a redundant daemon when the recorded endpoint is inaccessible
- report the PID, endpoint, and underlying connection failure to the caller

## Motivation

A sandboxed client can sometimes read the daemon runtime metadata while being
unable to access its Unix socket. Previously, health checks reported that no
daemon was running and normal commands could attempt another start, eventually
reporting a startup timeout.

This distinguishes an absent daemon from a live but unreachable one while
preserving the existing `daemon_unavailable` CLI error category.