### PR TITLE
Add conventional kata --version flag

### DIFF
--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -27,6 +27,7 @@ type globalFlags struct {
 	Workspace    string
 	Project      string
 	Daemon       string
+	Version      bool
 }
 
 var flags globalFlags
@@ -46,6 +47,25 @@ func newRootCmd() *cobra.Command {
 		Short:         "kata — lightweight issue tracker for agents",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		// The root is runnable only to serve the conventional `--version`
+		// flag; with no flag it falls back to printing help. Registering
+		// the flag ourselves (rather than setting cobra's Version field)
+		// keeps --json/--agent working, because cobra's built-in version
+		// flag short-circuits before PersistentPreRunE resolves the output
+		// mode.
+		//
+		// A runnable root also means PersistentPreRunE now runs for a bare
+		// `kata`, where cobra previously short-circuited to help before it.
+		// Plain `kata` still prints help and exits zero, but invalid or
+		// conflicting global output flags are now a usage error on the root
+		// instead of being silently ignored, matching every subcommand.
+		// TestRoot_NoArgsValidatesGlobalOutputFlags pins that contract.
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if flags.Version {
+				return writeVersion(cmd.OutOrStdout(), currentOutputMode())
+			}
+			return cmd.Help()
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			runEEntered = true
 			errorCommandName = commandLeaf(cmd)
@@ -69,6 +89,11 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.Workspace, "workspace", "", "path used for project resolution (default: cwd)")
 	cmd.PersistentFlags().StringVar(&flags.Project, "project", "", "project name for project-scoped commands")
 	cmd.PersistentFlags().StringVar(&flags.Daemon, "daemon", "", "named daemon catalog entry to target for this command")
+	// Root-local, not persistent: `kata --version` is the conventional
+	// spelling, while `kata list --version` should stay an unknown flag.
+	// No `-v` shorthand: that spelling conventionally means verbose, and
+	// reclaiming it after release would break callers.
+	cmd.Flags().BoolVar(&flags.Version, "version", false, "print version information")
 	// Catch the cobra/pflag pitfall where a positional that looks like
 	// a negative integer (kata show -1, kata delete -1) is parsed as
 	// a flag and produces "unknown shorthand flag: '1' in -1" — useless

--- a/cmd/kata/version.go
+++ b/cmd/kata/version.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"runtime"
 
 	"go.kenn.io/kata/internal/version"
@@ -16,41 +17,47 @@ func newVersionCmd() *cobra.Command {
 		Short: "print version information",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			out := cmd.OutOrStdout()
-			switch currentOutputMode() {
-			case outputAgent:
-				_, err := fmt.Fprintf(out, "OK version version=%s agent_format=%d\n",
-					agentValue(version.Version), agentFormatVersion)
-				return err
-			case outputJSON:
-				var buf bytes.Buffer
-				payload := map[string]any{
-					"name":         "kata",
-					"version":      version.Version,
-					"commit":       version.Commit,
-					"built":        version.BuildDate,
-					"distribution": version.Distribution,
-					"go":           runtime.Version(),
-					"os":           runtime.GOOS,
-					"arch":         runtime.GOARCH,
-					"agent_format": agentFormatVersion,
-				}
-				if err := emitJSON(&buf, payload); err != nil {
-					return err
-				}
-				_, err := fmt.Fprint(out, buf.String())
-				return err
-			}
-			_, err := fmt.Fprintf(out,
-				"kata %s\n"+
-					"  commit:  %s\n"+
-					"  built:   %s\n"+
-					"  go:      %s\n"+
-					"  os/arch: %s/%s\n",
-				version.Version, version.Commit, version.BuildDate,
-				runtime.Version(), runtime.GOOS, runtime.GOARCH,
-			)
-			return err
+			return writeVersion(cmd.OutOrStdout(), currentOutputMode())
 		},
 	}
+}
+
+// writeVersion renders the build identity for the given output mode. It backs
+// both `kata version` and the conventional root `--version` flag so the two
+// spellings can never drift.
+func writeVersion(out io.Writer, mode outputMode) error {
+	switch mode {
+	case outputAgent:
+		_, err := fmt.Fprintf(out, "OK version version=%s agent_format=%d\n",
+			agentValue(version.Version), agentFormatVersion)
+		return err
+	case outputJSON:
+		var buf bytes.Buffer
+		payload := map[string]any{
+			"name":         "kata",
+			"version":      version.Version,
+			"commit":       version.Commit,
+			"built":        version.BuildDate,
+			"distribution": version.Distribution,
+			"go":           runtime.Version(),
+			"os":           runtime.GOOS,
+			"arch":         runtime.GOARCH,
+			"agent_format": agentFormatVersion,
+		}
+		if err := emitJSON(&buf, payload); err != nil {
+			return err
+		}
+		_, err := fmt.Fprint(out, buf.String())
+		return err
+	}
+	_, err := fmt.Fprintf(out,
+		"kata %s\n"+
+			"  commit:  %s\n"+
+			"  built:   %s\n"+
+			"  go:      %s\n"+
+			"  os/arch: %s/%s\n",
+		version.Version, version.Commit, version.BuildDate,
+		runtime.Version(), runtime.GOOS, runtime.GOARCH,
+	)
+	return err
 }

--- a/cmd/kata/version_test.go
+++ b/cmd/kata/version_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"runtime"
@@ -105,4 +106,105 @@ func TestVersion_IsWiredOnRoot(t *testing.T) {
 		}
 	}
 	t.Fatal("version subcommand not registered on root")
+}
+
+// The conventional `--version` entry point must produce exactly what the
+// `version` subcommand produces, so tooling that probes either spelling gets
+// the same answer.
+func TestVersion_RootFlagMatchesSubcommand(t *testing.T) {
+	stubVersionInfo(t, "v0.0.1-test", "abc1234", "2026-05-12T11:17:12Z")
+
+	want := string(executeRoot(t, newRootCmd(), "version"))
+	require.Contains(t, want, "kata v0.0.1-test")
+	assert.Equal(t, want, string(executeRoot(t, newRootCmd(), "--version")))
+}
+
+// --version deliberately has no shorthand: -v conventionally means verbose,
+// and reclaiming it after release would be a breaking change.
+func TestVersion_RootFlagHasNoShorthand(t *testing.T) {
+	assert.Empty(t, newRootCmd().Flags().Lookup("version").Shorthand)
+
+	_, _, err := executeRootCapture(t, context.Background(), "-v")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown shorthand flag: 'v'")
+}
+
+func TestVersion_RootFlagHonorsOutputMode(t *testing.T) {
+	stubVersionInfo(t, "v0.0.1-test", "abc1234", "2026-05-12T11:17:12Z")
+
+	out := executeRoot(t, newRootCmd(), "--version", "--json")
+	var got struct {
+		APIVersion int    `json:"kata_api_version"`
+		Name       string `json:"name"`
+		Version    string `json:"version"`
+	}
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, 1, got.APIVersion)
+	assert.Equal(t, "kata", got.Name)
+	assert.Equal(t, "v0.0.1-test", got.Version)
+
+	agentOut := string(executeRoot(t, newRootCmd(), "--version", "--agent"))
+	assert.Contains(t, agentOut, "OK version version=v0.0.1-test")
+	assert.Contains(t, agentOut, "agent_format=1")
+}
+
+// Wiring RunE onto the root command to serve --version must not swallow the
+// default no-args behavior: bare `kata` still prints help and exits zero.
+func TestRoot_NoArgsPrintsHelp(t *testing.T) {
+	for _, args := range [][]string{nil, {"--json"}} {
+		out := string(executeRoot(t, newRootCmd(), args...))
+		assert.Contains(t, out, "lightweight issue tracker")
+		assert.Contains(t, out, "Available Commands:")
+	}
+}
+
+// A runnable root runs PersistentPreRunE for a bare `kata`, which cobra
+// previously skipped by short-circuiting to help. Global output-mode
+// validation therefore now applies to the root itself; pin that contract so
+// it stays deliberate rather than incidental.
+func TestRoot_NoArgsValidatesGlobalOutputFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "conflicting modes", args: []string{"--json", "--agent"}, want: "conflicting output modes"},
+		{name: "unsupported format", args: []string{"--format", "bogus"}, want: `unsupported output format "bogus"`},
+		// With --version present, PersistentPreRunE fails before flags.Mode
+		// is set, so emitRootError re-scans raw argv. That scan must treat
+		// --version as a valueless bool; if it ever consumed a value it
+		// would swallow the following --format value here.
+		{name: "conflicting modes with flag", args: []string{"--version", "--json", "--agent"}, want: "conflicting output modes"},
+		{name: "unsupported format with flag", args: []string{"--version", "--format", "bogus"}, want: `unsupported output format "bogus"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, stderr, err := executeRootCapture(t, context.Background(), tc.args...)
+			require.Error(t, err)
+			var cli *cliError
+			require.ErrorAs(t, err, &cli)
+			assert.Equal(t, ExitUsage, cli.ExitCode)
+			assert.Contains(t, stderr, tc.want)
+		})
+	}
+}
+
+// The root --version flag must stay root-local. `kata openapi --version 3.0`
+// is a documented release step whose own --version takes a value, so a
+// persistent root flag would silently break it.
+func TestVersion_RootFlagDoesNotShadowSubcommandFlag(t *testing.T) {
+	out := string(executeRoot(t, newRootCmd(), "openapi", "--version", "3.0", "--format", "yaml"))
+	assert.Contains(t, out, "openapi: 3.0.3")
+
+	_, _, err := executeRootCapture(t, context.Background(), "list", "--version")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown flag: --version")
+}
+
+// An unknown command must stay a usage error rather than falling through to
+// the root's --version handler.
+func TestRoot_UnknownCommandStillFails(t *testing.T) {
+	_, _, err := executeRootCapture(t, context.Background(), "definitely-not-a-command")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -97,6 +97,12 @@ federation, and daemon operations safer and more observable.
 
 **Improvements**
 
+- Added the conventional `kata --version` root flag, which prints the same
+  build identity as `kata version` and honors `--json` and `--agent`.
+  As a result, global output flags are now validated on the bare `kata`
+  invocation too: `kata --json --agent` and `kata --format bogus` exit `2` with
+  a usage error instead of silently printing help. Plain `kata` still prints
+  help and exits `0`.
 - Centralized Claude Code and Codex hook configuration on kit's shared
   agent-hook manager while preserving the existing init flags, lifecycle
   matchers, attention behavior, unrelated configuration, and workspace

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -103,7 +103,7 @@ Go writes the binary to `$(go env GOBIN)` when set, otherwise to
 Check the install:
 
 ```sh
-kata version
+kata version   # or kata --version
 kata --help
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,6 +20,10 @@ current flag list in your installed binary.
 | `--format human|json|agent` | Select output mode explicitly. |
 | `--quiet` | Suppress non-essential output. |
 
+`kata --version` prints the same build identity as the `version` command below
+and honors `--json`/`--agent`. It is a root-level flag, so it is not accepted
+on subcommands. There is no `-v` shorthand.
+
 ## Workspace initialization
 
 ```sh
@@ -566,6 +570,7 @@ kata health
 kata whoami
 kata quickstart
 kata version [--json]
+kata --version
 kata update [--check] [--force] [--yes]
 kata tui [issue-ref]
 ```
@@ -597,6 +602,8 @@ describe the build runtime and target. `agent_format` is the version of the
 agent-readable text contract. Consumers should use
 `kata_api_version` to select the JSON schema and ignore additional fields they
 do not recognize. Plain `kata version` retains its human-readable output.
+`kata --version` is an equivalent spelling of the same command and accepts the
+same output-mode flags.
 
 `kata update --check` checks Kata's GitHub release feed without installing.
 Its JSON result includes `distribution` and `package_release_may_lag`, plus an


### PR DESCRIPTION
## What changed

- `kata --version` prints the same build identity as `kata version` and honors `--json` and `--agent`.
- No `-v` shorthand, so that spelling stays free for a future `--verbose` alongside the existing `-q` / `--quiet`.

## Why

`kata --version` is the first thing a person or a script tries when it needs to know which binary is installed, and it failed with `unknown flag: --version` and exit 2. That reads like a broken binary rather than a different spelling, and it breaks install checks, CI pins, and agents that identify a tool before using it. `kata version` already carried the full answer; this makes the conventional spelling reach it.

## Usage

Real output from a build of this branch:

```console
$ kata --version
kata v0.14.1-1-g983f7ca
  commit:  983f7ca
  built:   2026-08-14T13:30:20-07:00
  go:      go1.26.6
  os/arch: darwin/arm64

$ kata --version --json
{"kata_api_version":1,"agent_format":1,"arch":"arm64","built":"2026-08-14T13:30:20-07:00","commit":"983f7ca","go":"go1.26.6","name":"kata","os":"darwin","version":"v0.14.1-1-g983f7ca"}

$ kata --version --agent
OK version version=v0.14.1-1-g983f7ca agent_format=1
```

`kata version` is unchanged.

Cobra's built-in `Version` field is deliberately not used: its generated flag short-circuits before `PersistentPreRunE` resolves the output mode, which would leave `kata --version --json` printing human text.

Closes #269
