### PR TITLE
Add a contract output mode for agent guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ kata close abc4 --done \
 For agent-heavy workspaces, `kata init --with-agents` also writes a managed kata
 briefing into agent guidance files. It refreshes existing real `AGENTS.md` and
 `CLAUDE.md` files, or creates `AGENTS.md` when neither exists, without
-overwriting the rest of either file.
+overwriting the rest of either file. Codex-only workspaces can instead use
+`kata init --with-codex-hooks` to install dynamic contract context and the
+`work.attention` SessionStart lifecycle into `.codex/hooks.json`.
 
 ## Why kata
 
@@ -176,6 +178,47 @@ contract: search before creating, pass an idempotency key on create, prefer
 verified. Close each verified issue promptly with valid evidence and a
 substantive message. [Agent workflows](docs/workflows/agents.md) is the same
 contract in long form.
+
+Agent harnesses can load the shorter managed briefing without changing the
+repository:
+
+```sh
+kata quickstart --format contract
+# equivalent alias; selectors are accepted for user-local integrations
+kata agent-instructions --format contract --workspace /path/to/workspace
+kata quickstart --format contract --project spoke-project
+```
+
+Contract output is marker-free, has no terminal framing, works without an
+initialized workspace, and performs no workspace mutation. It is rendered from
+the same canonical body that `kata init --with-agents` places between its
+managed markers, so static and session-injected guidance cannot drift.
+
+For example, a user-level Claude Code SessionStart hook can remain inert outside
+Kata workspaces while injecting the installed Kata version's contract:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if test -f \"$CLAUDE_PROJECT_DIR/.kata.toml\"; then kata quickstart --format contract --workspace \"$CLAUDE_PROJECT_DIR\"; fi"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Codex SessionStart hooks require structured JSON rather than plain contract
+stdout. `kata init --with-codex-hooks` installs Kata's structured adapter for
+startup, resume, clear, and compaction while keeping attention reset limited to
+startup, resume, and clear.
 
 ## Contributing
 

--- a/cmd/kata/agent_contract.go
+++ b/cmd/kata/agent_contract.go
@@ -1,0 +1,68 @@
+package main
+
+// agentsBlockBegin and agentsBlockEnd delimit the section kata manages inside
+// an agent guidance file. They let init refresh kata's guidance in place across
+// re-runs without disturbing anything else a project keeps in that file.
+const (
+	agentsBlockBegin = "<!-- BEGIN KATA (managed by `kata init --with-agents`) -->"
+	agentsBlockEnd   = "<!-- END KATA -->"
+)
+
+// agentContractText is the canonical marker-free briefing shared by dynamic
+// session injection and repository-managed agent guidance.
+const agentContractText = "Kata is the system of record for intent.\n\n" +
+	"- Never `kata delete` or `kata purge` without explicit user authorization.\n\n" +
+	`~~~dot
+digraph kata {
+  rankdir=TB; node [shape=box];
+
+  arrive   [shape=diamond label="Work arrives"];
+  search   [label="Search first; reuse an open issue\nor create one"];
+  route    [shape=diamond label="Work it, or delegate it?"];
+
+  subgraph cluster_work {
+    label="Working a kata-tracked issue";
+    claim  [label="On claim or start, mark it actively tracked:\nkata meta set <ref> work.attention ok\nIn-flight work becomes visible to coordinators\nand dashboards from the moment it is grabbed."];
+    branch [label="If the work happens on a dedicated branch, stamp it once:\nkata meta set <ref> work.branch <branch>\nor bind at creation:\nkata create ... --meta work.branch=<branch> --idempotency-key <key>"];
+    live   [label="Keep your live state truthful on the issue:\nkata meta set <ref> work.attention stuck|needs-human|ok\nwith a one-line kata meta set <ref> work.attention_msg \"<why>\"\nRaise stuck when you cannot proceed, needs-human when you want\ninput or review (you may keep working), and clear back to ok\nwhen unblocked."];
+    claim -> branch -> live;
+  }
+
+  subgraph cluster_delegate {
+    label="Delegating work as separate issues (fan-out/join)";
+    fanout [label="Create each sub-issue with --meta work.branch=...\nand an idempotency key; capture refs from --json\n(.issue.short_id)"];
+    join   [label="Join with kata wait <refs> --until attention --any\nMatches needs-human or stuck; a close also completes the wait,\nand the reported reason distinguishes which. Use --timeout so a\nwrapper can tell timeout from satisfaction."];
+    coord  [label="As coordinator you read work.* —\nyou never write it on issues you delegated."];
+    fanout -> join -> coord;
+  }
+
+  done     [shape=diamond label="Verified complete?"];
+  close    [label="kata close <ref> --done\nwith a message and evidence"];
+  review   [label="kata label add <ref> needs-review\nplus a comment on what remains"];
+  park     [shape=diamond label="Park it?"];
+  schedule [label="kata schedule <ref> <date-or-time>\nsets scheduled_on; clear with -"];
+  someday  [label="kata meta set <ref> someday true --json-value\nclear with kata meta unset <ref> someday"];
+
+  arrive -> search -> route;
+  route -> claim   [label="work it"];
+  route -> fanout  [label="delegate it"];
+  route -> park    [label="record only"];
+  live  -> done;
+  coord -> done;
+  done -> close    [label="yes"];
+  done -> park     [label="no, stopping"];
+  park -> schedule [label="start date known"];
+  park -> someday  [label="no date"];
+  park -> review   [label="no"];
+
+  always [shape=note label="Always: one writer per key. work.* on closed issues is meaningless —\nnever write it there, ignore it when reading. Never end a session with\nthe signal stale: before stopping, either close the issue or set the\nattention pair to reflect the hand-off."];
+
+  gate [shape=note label="A future scheduled_on or someday=true keeps an issue\nout of ready and next. kata deadline <ref> <date-or-time>\nsets deadline_on, which never gates either."];
+}
+~~~
+`
+
+// agentsManagedBlock returns the full marker-delimited block kata writes.
+func agentsManagedBlock() string {
+	return agentsBlockBegin + "\n" + agentContractText + agentsBlockEnd
+}

--- a/cmd/kata/agent_contract_hook.go
+++ b/cmd/kata/agent_contract_hook.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/cobra"
+)
+
+const agentContractHookSource = "kata-agent-contract-hook"
+
+// newAgentContractHookCmd adapts the canonical plain-text contract to Codex's
+// structured SessionStart hook response. It is launcher plumbing installed by
+// init --with-codex-hooks, not a user-facing contract format.
+func newAgentContractHookCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:                "agent-contract-hook",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 || args[0] != "--source" || args[1] != agentContractHookSource {
+				return nil
+			}
+			response := struct {
+				HookSpecificOutput struct {
+					HookEventName     string `json:"hookEventName"`
+					AdditionalContext string `json:"additionalContext"`
+				} `json:"hookSpecificOutput"`
+			}{}
+			response.HookSpecificOutput.HookEventName = "SessionStart"
+			response.HookSpecificOutput.AdditionalContext = agentContractText
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(response)
+		},
+	}
+}

--- a/cmd/kata/agent_contract_hook_test.go
+++ b/cmd/kata/agent_contract_hook_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentContractHook_EmitsCodexSessionStartContext(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	stdout, stderr, err := executeRootCapture(t, context.Background(),
+		"agent-contract-hook", "--source", "kata-agent-contract-hook")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope))
+	require.Len(t, envelope, 1, "Codex rejects unknown top-level hook response fields")
+	var specific struct {
+		HookEventName     string `json:"hookEventName"`
+		AdditionalContext string `json:"additionalContext"`
+	}
+	require.NoError(t, json.Unmarshal(envelope["hookSpecificOutput"], &specific))
+	assert.Equal(t, "SessionStart", specific.HookEventName)
+	assert.Equal(t, agentContractText, specific.AdditionalContext)
+}
+
+func TestAgentContractHook_IgnoresUnmanagedInvocation(t *testing.T) {
+	for name, args := range map[string][]string{
+		"missing source": {"agent-contract-hook"},
+		"wrong source":   {"agent-contract-hook", "--source", "user-command"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetRunEEntered(t)
+			resetFlags(t)
+			stdout, stderr, err := executeRootCapture(t, context.Background(), args...)
+			require.NoError(t, err)
+			assert.Empty(t, stdout)
+			assert.Empty(t, stderr)
+		})
+	}
+}

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -148,7 +148,7 @@ get committed.`,
 	cmd.Flags().BoolVar(&opts.Reassign, "reassign", false, "move an existing alias to this project")
 	cmd.Flags().BoolVar(&opts.WithAgents, "with-agents", false, "write kata agent guidance into AGENTS.md/CLAUDE.md in the workspace")
 	cmd.Flags().BoolVar(&opts.WithHooks, "with-hooks", false, "install work.attention harness hooks into the workspace's Claude Code config (.claude/)")
-	cmd.Flags().BoolVar(&opts.WithCodexHooks, "with-codex-hooks", false, "install Codex CLI work.attention hook wiring (.codex/hooks.json)")
+	cmd.Flags().BoolVar(&opts.WithCodexHooks, "with-codex-hooks", false, "install Codex CLI contract and work.attention hooks (.codex/hooks.json)")
 
 	return cmd
 }
@@ -642,14 +642,6 @@ func ensureGitignoreEntry(dir, entry string) (bool, error) {
 	}
 }
 
-// agentsBlockBegin and agentsBlockEnd delimit the section kata manages inside
-// an agent guidance file. They let init refresh kata's guidance in place across
-// re-runs without disturbing anything else a project keeps in that file.
-const (
-	agentsBlockBegin = "<!-- BEGIN KATA (managed by `kata init --with-agents`) -->"
-	agentsBlockEnd   = "<!-- END KATA -->"
-)
-
 // beadsBlockBeginPrefix and beadsBlockEnd match the integration block Beads
 // writes into AGENTS.md/CLAUDE.md. The begin marker carries a trailing
 // version/profile/hash, so we match on its prefix and scan to the end marker.
@@ -662,47 +654,6 @@ const (
 // file in place because it still carries a beads integration block. The user
 // reviews it and moves it over the original when ready.
 const agentsProposalSuffix = ".kata-proposed"
-
-// agentsBlockBody is the guidance kata injects between the markers. It mirrors
-// the contract `kata quickstart` prints, kept short so it complements rather
-// than duplicates the full quickstart text.
-const agentsBlockBody = "## kata issue tracker\n\n" +
-	"This project uses [kata](https://github.com/kenn-io/kata) as its shared issue\n" +
-	"ledger. Run `kata quickstart` at the start of each session for the full agent\n" +
-	"contract. The short version:\n\n" +
-	"- Search before creating: `kata search \"<keywords>\" --agent`.\n" +
-	"- Prefer updating existing issues over duplicates (`kata comment`, `kata label add`, `kata edit`).\n" +
-	"- Default to `--agent` for ordinary reads and mutations; use `--json` only when a script needs structured data.\n" +
-	"- Close only verified work: `kata close <ref> --done --message \"<scope + verification>\" --commit <sha>`.\n" +
-	"- If work is incomplete, label `needs-review` and comment what remains rather than closing.\n" +
-	"- Never `kata delete` or `kata purge` without explicit user authorization.\n\n" +
-	"## kata planning dates\n\n" +
-	"- Park work until a date or time with `kata schedule <ref> <date-or-time>`;\n" +
-	"  clear it with `kata schedule <ref> -`. This maps to `scheduled_on`; a future value excludes the issue\n" +
-	"  from `ready` and `next` until its gate opens.\n" +
-	"- Set a deadline with `kata deadline <ref> <date-or-time>`; clear it with `kata deadline <ref> -`.\n" +
-	"  This maps to `deadline_on`; a deadline does not park the issue.\n" +
-	"- Park work with no date by running `kata meta set <ref> someday true --json-value`;\n" +
-	"  return it to the queue with `kata meta unset <ref> someday` (do not store `false`).\n" +
-	"- Date and time values accept `YYYY-MM-DD`, local `YYYY-MM-DDTHH:MM[:SS]`, or an\n" +
-	"  RFC 3339 UTC instant ending in `Z`.\n\n" +
-	"## kata work.* conventions (agent orchestration)\n\n" +
-	"When working a kata-tracked issue, keep its `work.*` metadata truthful\n" +
-	"(see https://katatracker.com/operations/agent-orchestration/ for the full recipe):\n\n" +
-	"- On claim/start: `kata meta set <ref> work.attention ok`; if the work has a\n" +
-	"  dedicated branch, stamp it once with `kata meta set <ref> work.branch <branch>`.\n" +
-	"- Signal live state: `kata meta set <ref> work.attention stuck|needs-human|ok`\n" +
-	"  plus a one-line `work.attention_msg` saying why. Raise `stuck` when you cannot\n" +
-	"  proceed, `needs-human` when you want review; clear back to `ok` when unblocked.\n" +
-	"- Never stop with the signal stale: close the issue, or leave the attention\n" +
-	"  pair reflecting the hand-off.\n" +
-	"- Coordinators read `work.*` on issues they delegated; only the working agent\n" +
-	"  writes them. `work.*` on closed issues is meaningless.\n"
-
-// agentsManagedBlock returns the full marker-delimited block kata writes.
-func agentsManagedBlock() string {
-	return agentsBlockBegin + "\n" + agentsBlockBody + agentsBlockEnd
-}
 
 // applyAgentGuidance is the entry point for `--with-agents`. It writes kata's
 // block into existing real agent guidance files (AGENTS.md and CLAUDE.md), or

--- a/cmd/kata/init_hooks_codex.go
+++ b/cmd/kata/init_hooks_codex.go
@@ -14,7 +14,10 @@ import (
 // `kata init --with-codex-hooks` wires the work.attention lifecycle into a
 // Codex CLI workspace. Kit owns config parsing, hook ownership, and updates.
 
-const codexSessionStartMatcher = "startup|resume|clear"
+const (
+	codexSessionStartMatcher         = "startup|resume|clear"
+	codexContractSessionStartMatcher = "startup|resume|clear|compact"
+)
 
 func applyCodexHooks(dir string) (bool, []string, error) {
 	root, err := os.OpenRoot(dir)
@@ -55,7 +58,7 @@ func applyCodexHooks(dir string) (bool, []string, error) {
 	if err != nil {
 		return false, nil, err
 	}
-	result, err := agenthook.Install(agenthook.AgentCodex, agenthook.InstallOptions{
+	attentionResult, err := agenthook.Install(agenthook.AgentCodex, agenthook.InstallOptions{
 		ConfigPath: configPath,
 		Executable: "kata",
 		Arguments:  []string{"attention-hook", "start", "--source", attentionHookSource + "start"},
@@ -69,7 +72,21 @@ func applyCodexHooks(dir string) (bool, []string, error) {
 	if err != nil {
 		return false, nil, err
 	}
-	return migrated || result.Changed, codexConfigHooksWarnings(root), nil
+	contractResult, err := agenthook.Install(agenthook.AgentCodex, agenthook.InstallOptions{
+		ConfigPath: configPath,
+		Executable: "kata",
+		Arguments:  []string{"agent-contract-hook", "--source", agentContractHookSource},
+		Marker:     "--source " + agentContractHookSource,
+		Hooks: []agenthook.Hook{{
+			Event:   agenthook.EventSessionStart,
+			Matcher: codexContractSessionStartMatcher,
+			Timeout: 10 * time.Second,
+		}},
+	})
+	if err != nil {
+		return false, nil, err
+	}
+	return migrated || attentionResult.Changed || contractResult.Changed, codexConfigHooksWarnings(root), nil
 }
 
 // codexConfigHooksWarnings warns when Codex also has TOML-managed hooks.

--- a/cmd/kata/init_hooks_codex_test.go
+++ b/cmd/kata/init_hooks_codex_test.go
@@ -31,6 +31,28 @@ func expectedCodexHandler() map[string]any {
 	}
 }
 
+func expectedCodexContractHandler() map[string]any {
+	return map[string]any{
+		"type":           "command",
+		"command":        "kata agent-contract-hook --source kata-agent-contract-hook",
+		"commandWindows": "kata agent-contract-hook --source kata-agent-contract-hook",
+		"timeout":        json.Number("10"),
+	}
+}
+
+func expectedCodexSessionStartGroups() []any {
+	return []any{
+		map[string]any{
+			"matcher": codexSessionStartMatcher,
+			"hooks":   []any{expectedCodexHandler()},
+		},
+		map[string]any{
+			"matcher": codexContractSessionStartMatcher,
+			"hooks":   []any{expectedCodexContractHandler()},
+		},
+	}
+}
+
 func TestApplyCodexHooks_AdoptsPreviousCommand(t *testing.T) {
 	dir := t.TempDir()
 	codexDir := filepath.Join(dir, ".codex")
@@ -44,12 +66,24 @@ func TestApplyCodexHooks_AdoptsPreviousCommand(t *testing.T) {
 	assert.Empty(t, warnings)
 	assert.Equal(t, map[string]any{
 		"hooks": map[string]any{
-			"SessionStart": []any{map[string]any{
-				"matcher": codexSessionStartMatcher,
-				"hooks":   []any{expectedCodexHandler()},
-			}},
+			"SessionStart": expectedCodexSessionStartGroups(),
 		},
 	}, readCodexHooks(t, dir))
+}
+
+func TestApplyCodexHooks_UpgradesCurrentAttentionOnlyInstall(t *testing.T) {
+	dir := t.TempDir()
+	codexDir := filepath.Join(dir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+	current := `{"hooks":{"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"kata attention-hook start --source kata-agent-hook-start","commandWindows":"kata attention-hook start --source kata-agent-hook-start","timeout":10}]}]}}`
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(current), 0o644)) //nolint:gosec // test fixture under TempDir
+
+	changed, warnings, err := applyCodexHooks(dir)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Empty(t, warnings)
+	assert.Equal(t, expectedCodexSessionStartGroups(),
+		readCodexHooks(t, dir)["hooks"].(map[string]any)["SessionStart"])
 }
 
 func TestApplyCodexHooks_PreservesLegacyCommandWithExplicitNonScopedMatcher(t *testing.T) {
@@ -84,7 +118,7 @@ func TestApplyCodexHooks_PreservesLegacyCommandWithExplicitNonScopedMatcher(t *t
 			require.NoError(t, err)
 			hooks := readCodexHooks(t, dir)["hooks"].(map[string]any)
 			groups := hooks["SessionStart"].([]any)
-			require.Len(t, groups, 2)
+			require.Len(t, groups, 3)
 			assert.Equal(t, tt.matcher, groups[0].(map[string]any)["matcher"])
 			assert.Equal(t, []any{legacyHandler}, groups[0].(map[string]any)["hooks"])
 		})

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -452,7 +452,7 @@ func TestInit_WithAgents_WritesAgentsFileWhenAbsent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(content), agentsBlockBegin)
 	assert.Contains(t, string(content), agentsBlockEnd)
-	assert.Contains(t, string(content), "kata quickstart")
+	assert.Contains(t, string(content), "Kata is the system of record for intent.")
 }
 
 func TestInit_WithoutFlag_DoesNotWriteAgents(t *testing.T) {
@@ -577,15 +577,15 @@ func TestInit_WithAgents_RefreshesStaleBlock(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	assert.NotContains(t, string(content), "old kata guidance that should be replaced")
-	assert.Contains(t, string(content), "kata quickstart")
+	assert.Contains(t, string(content), "Kata is the system of record for intent.")
 	assert.Contains(t, string(content), "# House rules", "content outside the markers must survive")
 	assert.Equal(t, 1, strings.Count(string(content), agentsBlockBegin))
 }
 
-// TestInit_WithAgents_BlockIncludesWorkConventions pins the work.* conventions
-// section kata appends to its managed block, so an agent working a kata-tracked
-// issue finds the attention-signal recipe without leaving the guidance file.
-func TestInit_WithAgents_BlockIncludesWorkConventions(t *testing.T) {
+// TestInit_WithAgents_BlockIncludesWorkflowConventions pins the distinction
+// between incomplete work, attention state, and delegation in the managed
+// briefing installed for agents.
+func TestInit_WithAgents_BlockIncludesWorkflowConventions(t *testing.T) {
 	env := testenv.New(t)
 	dir := t.TempDir()
 	runGit(t, dir, "init", "--quiet")
@@ -600,11 +600,10 @@ func TestInit_WithAgents_BlockIncludesWorkConventions(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	got := string(content)
-	assert.Contains(t, got, "## kata work.* conventions")
-	assert.Contains(t, got, "kata meta set <ref> work.attention ok")
-	assert.Contains(t, got, "work.attention_msg")
-	assert.Contains(t, got, "https://katatracker.com/operations/agent-orchestration/")
-	assert.NotContains(t, got, "docs/operations/agent-orchestration.md")
+	assert.Contains(t, got, "Never `kata delete` or `kata purge` without explicit user authorization.")
+	assert.Contains(t, got, "kata meta set <ref> work.attention stuck|needs-human|ok")
+	assert.Contains(t, got, "kata close <ref> --done")
+	assert.Contains(t, got, "kata label add <ref> needs-review")
 }
 
 func TestInit_WithAgents_BlockIncludesScheduleDueAndSomedayConventions(t *testing.T) {
@@ -668,8 +667,9 @@ func TestInit_WithAgents_RefreshesPreWorkConventionsBlock(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md")) //nolint:gosec // test fixture under TempDir
 	require.NoError(t, err)
 	got := string(content)
-	assert.Contains(t, got, "## kata work.* conventions", "refresh must add the work.* section to an older block")
-	assert.Contains(t, got, "kata meta set <ref> work.attention ok")
+	assert.Contains(t, got, "Kata is the system of record for intent.",
+		"refresh must install the current intent workflow over an older block")
+	assert.Contains(t, got, "digraph kata {")
 	assert.Contains(t, got, "# House rules", "content before the markers must survive")
 	assert.Contains(t, got, "Keep this line.")
 	assert.Contains(t, got, "## Trailing section", "content after the markers must survive")
@@ -714,7 +714,7 @@ func TestInit_WithAgents_BeadsBlockInAgents_WritesSidecar(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(proposed), "Legacy notes.")
 	assert.Contains(t, string(proposed), agentsBlockBegin)
-	assert.Contains(t, string(proposed), "kata quickstart")
+	assert.Contains(t, string(proposed), "Kata is the system of record for intent.")
 	assert.NotContains(t, string(proposed), beadsBlockBeginPrefix)
 	assert.NotContains(t, string(proposed), beadsBlockEnd)
 

--- a/cmd/kata/init_with_agents_e2e_test.go
+++ b/cmd/kata/init_with_agents_e2e_test.go
@@ -34,10 +34,24 @@ func TestE2E_InitWithAgents_NewEmptyRepo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(content), agentsBlockBegin)
 	assert.Contains(t, string(content), agentsBlockEnd)
-	assert.Contains(t, string(content), "kata quickstart")
+	assert.Contains(t, string(content), "Kata is the system of record for intent.")
 
 	// kata writes AGENTS.md only; it does not invent a CLAUDE.md.
 	assert.NoFileExists(t, filepath.Join(dir, "CLAUDE.md"))
+}
+
+func TestE2E_QuickstartContractDoesNotInitializeWorkspace(t *testing.T) {
+	resetFlags(t)
+	env := testenv.New(t)
+	dir := t.TempDir()
+
+	out, err := runCLICapture(t, env, dir,
+		"quickstart", "--format", "contract", "--workspace", dir)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Kata is the system of record for intent.")
+	assert.NoFileExists(t, filepath.Join(dir, ".kata.toml"))
+	assert.NoFileExists(t, filepath.Join(dir, "AGENTS.md"))
+	assert.NoDirExists(t, filepath.Join(dir, ".codex"))
 }
 
 // TestE2E_InitWithAgents_PreservesExistingAgentDocs runs init in a repo that
@@ -71,7 +85,7 @@ func TestE2E_InitWithAgents_PreservesExistingAgentDocs(t *testing.T) {
 	assert.Contains(t, got, "Run `make build` before pushing.")
 	assert.Contains(t, got, "Tabs, not spaces.")
 	assert.Contains(t, got, agentsBlockBegin)
-	assert.Contains(t, got, "kata quickstart")
+	assert.Contains(t, got, "Kata is the system of record for intent.")
 }
 
 // TestE2E_InitWithAgents_ThenBeadsImport walks the realistic migration: a repo
@@ -107,5 +121,5 @@ func TestE2E_InitWithAgents_ThenBeadsImport(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "Legacy notes from the Beads era.")
 	assert.Contains(t, string(content), agentsBlockBegin)
-	assert.Contains(t, string(content), "kata quickstart")
+	assert.Contains(t, string(content), "Kata is the system of record for intent.")
 }

--- a/cmd/kata/init_with_codex_hooks_e2e_test.go
+++ b/cmd/kata/init_with_codex_hooks_e2e_test.go
@@ -28,10 +28,7 @@ func TestE2E_InitWithCodexHooks(t *testing.T) {
 	assert.FileExists(t, filepath.Join(dir, ".kata.toml"))
 	assert.Equal(t, map[string]any{
 		"hooks": map[string]any{
-			"SessionStart": []any{map[string]any{
-				"matcher": "startup|resume|clear",
-				"hooks":   []any{expectedCodexHandler()},
-			}},
+			"SessionStart": expectedCodexSessionStartGroups(),
 		},
 	}, readCodexHooks(t, dir))
 }
@@ -69,10 +66,7 @@ func TestE2E_InitWithCodexHooks_ComposesWithAgentsAndHooks(t *testing.T) {
 	codexPath := filepath.Join(dir, ".codex", "hooks.json")
 	assert.Equal(t, map[string]any{
 		"hooks": map[string]any{
-			"SessionStart": []any{map[string]any{
-				"matcher": "startup|resume|clear",
-				"hooks":   []any{expectedCodexHandler()},
-			}},
+			"SessionStart": expectedCodexSessionStartGroups(),
 		},
 	}, readCodexHooks(t, dir))
 

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -81,7 +81,7 @@ func newRootCmd() *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().Var(outputFormatFlag{value: &flags.Format, values: &flags.FormatValues},
-		"format", "output format: human|json|agent")
+		"format", "output format: human|json|agent; contract for quickstart")
 	cmd.PersistentFlags().BoolVar(&flags.JSON, "json", false, "emit machine-readable JSON")
 	cmd.PersistentFlags().BoolVar(&flags.Agent, "agent", false, "emit concise agent-readable text")
 	cmd.PersistentFlags().BoolVarP(&flags.Quiet, "quiet", "q", false, "suppress non-essential output")
@@ -129,6 +129,7 @@ func newRootCmd() *cobra.Command {
 		newUnassignCmd(),
 		newClaimCmd(),
 		newAttentionHookCmd(),
+		newAgentContractHookCmd(),
 		newReadyCmd(),
 		newNextCmd(),
 		newWaitCmd(),

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -214,6 +214,14 @@ func TestRoot_QuickstartAdvertised(t *testing.T) {
 	assert.Contains(t, quickstart.Aliases, "agent-instructions")
 }
 
+func TestHelp_DescribesAgentContractSurfaces(t *testing.T) {
+	rootHelp := string(executeRoot(t, newRootCmd(), "--help"))
+	assert.Contains(t, rootHelp, "human|json|agent; contract for quickstart")
+
+	initHelp := string(executeRoot(t, newRootCmd(), "init", "--help"))
+	assert.Contains(t, initHelp, "Codex CLI contract and work.attention hooks")
+}
+
 func TestHelp_RefFlagsDoNotAdvertiseLegacyNumbers(t *testing.T) {
 	for _, args := range [][]string{
 		{"create", "--help"},
@@ -340,6 +348,59 @@ func TestOutputMode_RepeatedFormatConflicts(t *testing.T) {
 	require.Error(t, err)
 	assert.Empty(t, stdout)
 	assert.Contains(t, stderr, "conflicting output modes")
+}
+
+func TestOutputMode_ContractAcceptedOnlyForQuickstart(t *testing.T) {
+	for _, command := range []string{"quickstart", "agent-instructions"} {
+		t.Run(command, func(t *testing.T) {
+			resetRunEEntered(t)
+			resetFlags(t)
+			stdout, stderr, err := executeRootCapture(t, context.Background(),
+				"--format", "contract", command)
+			require.NoError(t, err)
+			assert.NotEmpty(t, stdout)
+			assert.Empty(t, stderr)
+		})
+	}
+}
+
+func TestOutputMode_ContractRejectedForUnrelatedCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"--format", "contract", "version"},
+		{"--format", "contract", "list"},
+		{"--format", "contract"},
+	} {
+		resetRunEEntered(t)
+		resetFlags(t)
+		stdout, stderr, err := executeRootCapture(t, context.Background(), args...)
+		require.Error(t, err)
+		assert.Empty(t, stdout)
+		assert.Contains(t, stderr, `unsupported output format "contract"`)
+	}
+}
+
+func TestOutputMode_QuickstartUsageListsContractFormat(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	stdout, stderr, err := executeRootCapture(t, context.Background(),
+		"--format", "bogus", "quickstart")
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "want human, json, agent, or contract")
+}
+
+func TestOutputMode_ContractConflictsWithAgentAndJSON(t *testing.T) {
+	for _, flag := range []string{"--agent", "--json"} {
+		t.Run(flag, func(t *testing.T) {
+			resetRunEEntered(t)
+			resetFlags(t)
+			stdout, stderr, err := executeRootCapture(t, context.Background(),
+				"--format", "contract", flag, "quickstart")
+			require.Error(t, err)
+			assert.Empty(t, stdout)
+			assert.Contains(t, stderr, "conflicting output modes")
+		})
+	}
 }
 
 func TestEmitError_RawModeScanParsesJSONTrueValue(t *testing.T) {

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -17,9 +17,10 @@ import (
 type outputMode string
 
 const (
-	outputHuman outputMode = "human"
-	outputJSON  outputMode = "json"
-	outputAgent outputMode = "agent"
+	outputHuman    outputMode = "human"
+	outputJSON     outputMode = "json"
+	outputAgent    outputMode = "agent"
+	outputContract outputMode = "contract"
 
 	agentFormatVersion = 1
 )
@@ -114,9 +115,19 @@ func printAgentMutationDecoded(
 	return nil
 }
 
-func resolveOutputModeFormats(formats []string, fallback string, importLegacy bool, jsonFlag, agentFlag bool) (outputMode, error) {
+func resolveOutputModeFormats(
+	formats []string,
+	fallback string,
+	importLegacy bool,
+	contractAllowed bool,
+	jsonFlag, agentFlag bool,
+) (outputMode, error) {
 	if len(formats) == 0 && fallback != "" {
 		formats = []string{fallback}
+	}
+	wanted := "human, json, or agent"
+	if contractAllowed {
+		wanted = "human, json, agent, or contract"
 	}
 	var selected []outputMode
 	for _, format := range formats {
@@ -127,9 +138,15 @@ func resolveOutputModeFormats(formats []string, fallback string, importLegacy bo
 		switch outputMode(format) {
 		case outputHuman, outputJSON, outputAgent:
 			selected = append(selected, outputMode(format))
+		case outputContract:
+			if contractAllowed {
+				selected = append(selected, outputContract)
+				continue
+			}
+			fallthrough
 		default:
 			return "", &cliError{
-				Message:  "unsupported output format " + strconv.Quote(format) + " (want human, json, or agent)",
+				Message:  "unsupported output format " + strconv.Quote(format) + " (want " + wanted + ")",
 				Kind:     kindUsage,
 				ExitCode: ExitUsage,
 			}
@@ -154,7 +171,7 @@ func resolveOutputModeFormats(formats []string, fallback string, importLegacy bo
 }
 
 func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMode, error) {
-	return resolveOutputModeFormats(nil, format, false, jsonFlag, agentFlag)
+	return resolveOutputModeFormats(nil, format, false, false, jsonFlag, agentFlag)
 }
 
 func currentOutputMode() outputMode {
@@ -175,7 +192,14 @@ func resolveOutputModeForCommand(cmd *cobra.Command) (outputMode, error) {
 	if isImportCommand(cmd) && isImportLegacySourceFormat(format) {
 		format = ""
 	}
-	return resolveOutputModeFormats(flags.FormatValues, format, isImportCommand(cmd), flags.JSON, flags.Agent)
+	return resolveOutputModeFormats(
+		flags.FormatValues,
+		format,
+		isImportCommand(cmd),
+		supportsContractOutput(cmd),
+		flags.JSON,
+		flags.Agent,
+	)
 }
 
 func resolveOutputModeArgs(args []string, format string, jsonFlag, agentFlag bool) (outputMode, error) {
@@ -195,7 +219,9 @@ func resolveOutputModeArgsForCommand(
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
-			return resolveOutputModeFormats(formats, format, importLegacy, jsonFlag, agentFlag)
+			return resolveOutputModeFormats(
+				formats, format, importLegacy, supportsContractOutput(cmd), jsonFlag, agentFlag,
+			)
 		}
 		name, value, hasValue, ok := splitLongFlag(arg)
 		if !ok {
@@ -249,7 +275,9 @@ func resolveOutputModeArgsForCommand(
 			}
 		}
 	}
-	return resolveOutputModeFormats(formats, format, importLegacy, jsonFlag, agentFlag)
+	return resolveOutputModeFormats(
+		formats, format, importLegacy, supportsContractOutput(cmd), jsonFlag, agentFlag,
+	)
 }
 
 func splitLongFlag(arg string) (name, value string, hasValue bool, ok bool) {
@@ -327,6 +355,10 @@ func outputFormatValue(format string, importLegacy bool) string {
 
 func isImportCommand(cmd *cobra.Command) bool {
 	return cmd != nil && cmd.Name() == "import"
+}
+
+func supportsContractOutput(cmd *cobra.Command) bool {
+	return cmd != nil && cmd.Name() == "quickstart"
 }
 
 func isImportLegacySourceFormat(format string) bool {

--- a/cmd/kata/quickstart.go
+++ b/cmd/kata/quickstart.go
@@ -198,6 +198,9 @@ func newQuickstartCmd() *cobra.Command {
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			switch currentOutputMode() {
+			case outputContract:
+				_, err := fmt.Fprint(cmd.OutOrStdout(), agentContractText)
+				return err
 			case outputJSON:
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, map[string]string{

--- a/cmd/kata/quickstart_test.go
+++ b/cmd/kata/quickstart_test.go
@@ -79,6 +79,78 @@ func TestQuickstart_AgentOutput(t *testing.T) {
 	assert.Contains(t, out, "Close each verified issue promptly; valid evidence keeps sibling close bursts admissible by default.")
 }
 
+func TestQuickstart_ContractPrintsManagedWorkflowWithoutMarkers(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newRootCmd(), "quickstart", "--format", "contract"))
+
+	assert.True(t, strings.HasPrefix(out, "Kata is the system of record for intent."))
+	assert.Contains(t, out, "Never `kata delete` or `kata purge` without explicit user authorization.")
+	assert.Contains(t, out, "~~~dot\ndigraph kata {")
+	assert.Contains(t, out, "}\n~~~\n")
+	assert.Contains(t, out, "kata meta set <ref> work.attention ok")
+	assert.Contains(t, out, "kata meta set <ref> work.branch <branch>")
+	assert.Contains(t, out, "kata create ... --meta work.branch=<branch> --idempotency-key <key>")
+	assert.Contains(t, out, "kata meta set <ref> work.attention stuck|needs-human|ok")
+	assert.Contains(t, out, `kata meta set <ref> work.attention_msg \"<why>\"`)
+	assert.Contains(t, out, "kata wait <refs> --until attention --any")
+	assert.Contains(t, out, ".issue.short_id")
+	assert.Contains(t, out, "kata close <ref> --done")
+	assert.Contains(t, out, "kata label add <ref> needs-review")
+	assert.Contains(t, out, "kata schedule <ref> <date-or-time>")
+	assert.Contains(t, out, "kata meta set <ref> someday true --json-value")
+	assert.Contains(t, out, "kata meta unset <ref> someday")
+	assert.Contains(t, out, "kata deadline <ref> <date-or-time>")
+	assert.NotContains(t, out, "20z0", "a universal contract cannot use a project-scoped issue ref")
+	assert.NotContains(t, out, agentsBlockBegin)
+	assert.NotContains(t, out, agentsBlockEnd)
+	assert.NotContains(t, out, "# kata agent quickstart")
+}
+
+// The contract is rendered into other projects' AGENTS.md files, so it must
+// describe kata itself rather than any single workspace's local conventions.
+func TestQuickstart_ContractOmitsNonKataConcepts(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newRootCmd(), "quickstart", "--format", "contract"))
+
+	for _, absent := range []string{
+		"projects/<slug>", // labeling convention kata does not define
+		"waiting.for",     // no such metadata key in kata
+		"waiting.since",
+		"tickler",
+		"friction",
+	} {
+		assert.NotContains(t, out, absent)
+	}
+}
+
+func TestQuickstart_ContractMatchesManagedBlockBody(t *testing.T) {
+	resetFlags(t)
+	out := string(executeRoot(t, newRootCmd(), "--format", "contract", "quickstart"))
+	managed := agentsManagedBlock()
+
+	require.True(t, strings.HasPrefix(managed, agentsBlockBegin+"\n"))
+	require.True(t, strings.HasSuffix(managed, agentsBlockEnd))
+	body := strings.TrimPrefix(managed, agentsBlockBegin+"\n")
+	body = strings.TrimSuffix(body, agentsBlockEnd)
+	assert.Equal(t, out, body)
+}
+
+func TestQuickstart_ContractAliasAndSelectorsPreserveOutput(t *testing.T) {
+	resetFlags(t)
+	want := string(executeRoot(t, newRootCmd(), "--format", "contract", "quickstart"))
+
+	for name, args := range map[string][]string{
+		"alias":              {"agent-instructions", "--format", "contract"},
+		"workspace selector": {"--workspace", "/path/that/does/not/exist", "quickstart", "--format", "contract"},
+		"project selector":   {"quickstart", "--project", "spoke-project", "--format", "contract"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetFlags(t)
+			assert.Equal(t, want, string(executeRoot(t, newRootCmd(), args...)))
+		})
+	}
+}
+
 func TestQuickstart_AgentInstructionsAliasMentionsAgentOutput(t *testing.T) {
 	resetFlags(t)
 	out := string(executeRoot(t, newRootCmd(), "agent-instructions"))


### PR DESCRIPTION
## What changed

- Injects a graphviz DOT diagram into context.
- `kata quickstart --format contract` prints the managed agent briefing marker-free, with no terminal framing and no workspace mutation. It works in a directory that was never `kata init`ed, since this is policy text rather than project state.
- The `agent-instructions` alias and the existing `--project` and `--workspace` selectors all work with it, so a harness can point at an explicitly selected workspace.
- `contract` is scoped to `quickstart`. Every other command still rejects it with exit 2, and it conflicts with `--json` and `--agent` the same way the other modes do.
- The block body that `kata init --with-agents` writes between its markers moved into a single constant that both surfaces render, so the committed briefing and the injected one cannot drift.
- A hidden `agent-contract-hook` wraps that same text in Codex's structured SessionStart response, and `kata init --with-codex-hooks` now installs it next to the existing `work.attention` hook.

## Why

Adopting Kata in a shared repo currently means committing to `AGENTS.md` or `CLAUDE.md`, which signals that every collaborator should install Kata. The alternative is keeping a hand-maintained copy of Kata's operating policy in a user-level hook, and that copy drifts from the installed version the moment either one changes.

Claude Code, Codex, and OpenCode all have user-local ways to load instructions at session start. They just need a stable command that prints the briefing. This gives them one, and it stays correct because it is the same constant `--with-agents` writes.

## What gets injected

```mermaid
flowchart TB
  arrive{"Work arrives"} --> search["Search first; reuse an open issue<br/>or create one"]
  search --> route{"Work it, or delegate it?"}

  subgraph workside["Working a kata-tracked issue"]
    direction TB
    claim["On claim or start, mark it actively tracked:<br/>kata meta set #60;ref#62; work.attention ok"]
    branch["If the work happens on a dedicated branch, stamp it once:<br/>kata meta set #60;ref#62; work.branch #60;branch#62;<br/>or bind at creation:<br/>kata create ... --meta work.branch=#60;branch#62; --idempotency-key #60;key#62;"]
    live["Keep your live state truthful on the issue:<br/>kata meta set #60;ref#62; work.attention stuck#124;needs-human#124;ok<br/>with a one-line kata meta set #60;ref#62; work.attention_msg #34;#60;why#62;#34;<br/>Raise stuck when you cannot proceed, needs-human when you want<br/>input or review (you may keep working), and clear back to ok when unblocked"]
    claim --> branch --> live
  end

  subgraph delegateside["Delegating work as separate issues (fan-out/join)"]
    direction TB
    fanout["Create each sub-issue with --meta work.branch=...<br/>and an idempotency key; capture refs from --json (.issue.short_id)"]
    join["Join with kata wait #60;refs#62; --until attention --any<br/>Matches needs-human or stuck; a close also completes the wait,<br/>and the reported reason distinguishes which. Use --timeout so a<br/>wrapper can tell timeout from satisfaction."]
    coord["As coordinator you read work.* —<br/>you never write it on issues you delegated."]
    fanout --> join --> coord
  end

  route -->|work it| claim
  route -->|delegate it| fanout
  route -->|record only| park
  live --> done
  coord --> done

  done{"Verified complete?"}
  done -->|yes| close["kata close #60;ref#62; --done<br/>with a message and evidence"]
  done -->|"no, stopping"| park{"Park it?"}
  park -->|start date known| schedule["kata schedule #60;ref#62; #60;date-or-time#62;<br/>sets scheduled_on; clear with -"]
  park -->|no date| someday["kata meta set #60;ref#62; someday true --json-value<br/>clear with kata meta unset #60;ref#62; someday"]
  park -->|no| review["kata label add #60;ref#62; needs-review<br/>plus a comment on what remains"]
```

A user-level Claude Code hook can be installed globally and stay inert outside Kata workspaces:

```json
{
  "hooks": {
    "SessionStart": [
      {
        "matcher": "startup|resume|clear|compact",
        "hooks": [
          {
            "type": "command",
            "command": "if test -f \"$CLAUDE_PROJECT_DIR/.kata.toml\"; then kata quickstart --format contract --workspace \"$CLAUDE_PROJECT_DIR\"; fi"
          }
        ]
      }
    ]
  }
}
```

Codex needs structured JSON rather than plain stdout, so `kata init --with-codex-hooks` covers that case instead. Its contract hook matches `startup|resume|clear|compact`; attention reset stays on `startup|resume|clear`, since resetting attention on compaction would be wrong.

Closes #267

Worth a close look in review: consolidating on one canonical body changes what `--with-agents` writes. The block is now a short prose header plus a DOT flow, rather than the previous prose-and-headings block. The content is stated in kata's own primitives — `needs-review` as a label, `needs-human` as a `work.attention` value, the `work.*` orchestration pair, the fan-out/join coordinator path, and the three parking keys. Existing managed blocks get rewritten in place on the next `kata init --with-agents`, and nothing outside the markers is touched. If you would rather keep the prose form as the committed briefing and render only a subset for injection, say so and I will split them, though that reintroduces the drift this is meant to close.

No schema or migration change.
