### PR TITLE
Allow originless local session mint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,10 +174,13 @@ authorization service. Review browser changes against these boundaries:
 - **Direct local browser authority trusts the loopback host.** On Unix, the daemon normally
   keeps its API on the owner-only socket and binds a separate ephemeral
   loopback browser listener. A direct tab on that listener creates its own
-  local-web session only when the request arrives directly from loopback, the
-  exact Host and Origin match, no forwarding headers are present, and daemon
-  token/identity/proxy authentication is unconfigured. This matches the
-  established keyless local-web convention; processes and
+  local-web session only when the exact Host matches, the request arrives
+  directly from loopback, no forwarding headers are present, and daemon
+  token/identity/proxy authentication is unconfigured. The mint normally
+  requires the exact Origin. An embedded owner-local browser may omit or send
+  an empty Origin only on this mint; exact Host validation remains the
+  DNS-rebinding boundary, and cross-site Fetch Metadata remains forbidden.
+  This matches the established keyless local-web convention; processes and
   users able to connect from the same host are inside this browser boundary.
   `kata ui` and the URL advertised by `kata daemon status` both open this
   origin directly; no launch credential or CLI authorization ceremony exists.
@@ -239,12 +242,12 @@ authorization service. Review browser changes against these boundaries:
   ordinary API reads with no browser markers. `allowed_hosts` is for explicit
   container/proxy/backend aliases, contains authorities rather than origins,
   and is never inferred from request headers. Browser routes and
-  browser-bearing mutations require the exact configured Origin even when the
-  header would otherwise be absent, while ordinary CLI, health, and federation
-  requests continue through daemon
-  bearer/private-network authentication. A bearer header never bypasses Host
-  validation. Bearer CLI event streams remain CLI traffic. Do not weaken one
-  boundary to make the other client class work.
+  browser-bearing mutations require the exact configured Origin. The sole
+  exception is an absent or empty Origin on the direct-loopback local-session
+  mint under the checks above. Ordinary CLI, health, and federation requests
+  continue through daemon bearer/private-network authentication. A bearer
+  header never bypasses Host validation. Bearer CLI event streams remain CLI
+  traffic. Do not weaken one boundary to make the other client class work.
 - **Plain HTTP is local or explicit private-network trust.** Loopback browser
   origins may use HTTP. A non-loopback HTTP public origin requires the same
   explicit `[auth].trust_private_network` opt-in used for plaintext private

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -126,13 +126,16 @@ and TUI never set `Origin`, so they are unaffected.
 
 The separate browser listener uses the established host-local, keyless-loopback
 trust boundary. A direct-loopback tab can create a local-web
-session only with the exact configured Host and Origin and without forwarding
-headers. All later data requests require both its HttpOnly instance cookie and
-tab-local session header; mutations also require its CSRF value. Configuring
-daemon authentication, a proxy origin, or a non-loopback listener disables the
-direct local bootstrap path. Other processes or users able to connect from the
-same host are inside this ordinary browser-UI boundary; local-web authority does
-not include token administration.
+session only with the exact configured Host and without forwarding headers. The
+mint normally requires the exact Origin; an embedded owner-local browser may
+omit or send an empty Origin only on this endpoint, and cross-site Fetch
+Metadata remains forbidden. Exact Host validation stays ahead of the exception
+as the DNS-rebinding boundary. All later data requests require both the HttpOnly
+instance cookie and tab-local session header; mutations also require its CSRF
+value and exact Origin. Configuring daemon authentication, a proxy origin, or a
+non-loopback listener disables the direct local bootstrap path. Other processes
+or users able to connect from the same host are inside this ordinary browser-UI
+boundary; local-web authority does not include token administration.
 
 **Shared and remote modes** add a network boundary. They require a bearer token
 and an explicit trust opt-in before the daemon will put credentials on a

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -101,9 +101,13 @@ network, authentication, and proxy setup.
 
 The default local experience is intentionally simple: a browser connecting
 directly to the daemon's loopback listener receives a tab-scoped local session.
-Browser requests combine that tab-local credential with an HttpOnly instance
-cookie, and mutations also require same-origin CSRF validation. Restarting the
-daemon invalidates its browser sessions.
+The mint requires the exact listener Host and normally the exact Origin. An
+embedded owner-local browser may omit or send an empty Origin only on this
+direct-loopback mint; cross-site Fetch Metadata, forwarded requests, and
+non-loopback peers remain rejected. Browser requests combine the resulting
+tab-local credential with an HttpOnly instance cookie, and later mutations also
+require exact-origin CSRF validation. Restarting the daemon invalidates its
+browser sessions.
 
 Non-loopback, authenticated, or proxied deployments do not receive local-web
 authority automatically. They require the configured login mechanism and an

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -160,8 +160,13 @@ payloads.
 
 The browser-session routes are deliberately outside the generated client
 contract. A fresh tab on a keyless direct-loopback origin uses
-`POST /api/v1/ui/session/local`; Host, Origin, peer address, forwarding-header,
+`POST /api/v1/ui/session/local`. Exact Host, peer address, forwarding-header,
 and daemon-auth policy gate that endpoint before it issues a local-web session.
+The mint normally requires the exact Origin; an embedded owner-local browser
+may omit or send an empty Origin only on this endpoint, while cross-site Fetch
+Metadata remains forbidden. Exact Host validation runs first and remains the
+DNS-rebinding boundary.
+
 The URL reported by `kata daemon status` and local `kata ui` both open that
 loopback origin directly. Configured origins exchange a bearer or identity
 token at `POST /api/v1/ui/session/login`. Logout is
@@ -177,12 +182,12 @@ browser origin. Request `Host`, `Origin`, and forwarding headers never supply
 authority, and origins with credentials, path prefixes, query strings, or
 fragments are unavailable rather than rewritten.
 
-Every browser data request requires both the instance cookie and
-`X-Kata-Web-Session`. Mutations additionally require the exact `Origin` and
-`X-Kata-CSRF`; the protected event stream carries the session header and
-`Last-Event-ID` through `fetch`. In unauthenticated `--insecure-readonly` mode,
-the UI advertises read-only authority and polls snapshots because the event
-stream remains protected.
+After session creation, every browser data request requires both the instance
+cookie and `X-Kata-Web-Session`. Browser data mutations additionally require
+the exact `Origin` and `X-Kata-CSRF`; the protected event stream carries the
+session header and `Last-Event-ID` through `fetch`. In unauthenticated
+`--insecure-readonly` mode, the UI advertises read-only authority and polls
+snapshots because the event stream remains protected.
 
 ## Federation Enrollment and Health Endpoints
 

--- a/internal/daemon/listener_policy.go
+++ b/internal/daemon/listener_policy.go
@@ -70,8 +70,7 @@ func ApplyListenerPolicy(next http.Handler, policy ListenerPolicy) (http.Handler
 				return
 			}
 			if policy.Kind == ListenerBrowser || isBrowserRequest(r) {
-				originHeader := r.Header.Get("Origin")
-				if isMutation(r.Method) && originHeader != policy.Origin {
+				if isMutation(r.Method) && !browserMutationOriginAllowed(r, policy.Origin) {
 					api.WriteEnvelope(w, http.StatusForbidden, "origin_forbidden", "Origin header does not match browser origin")
 					return
 				}
@@ -99,6 +98,17 @@ func restrictLocalSession(next http.Handler, policy ListenerPolicy) http.Handler
 
 func isLocalSessionRequest(r *http.Request) bool {
 	return r.Method == http.MethodPost && r.URL.Path == "/api/v1/ui/session/local"
+}
+
+func browserMutationOriginAllowed(r *http.Request, expectedOrigin string) bool {
+	origin := r.Header.Get("Origin")
+	if origin != "" {
+		return origin == expectedOrigin
+	}
+	if !isLocalSessionRequest(r) {
+		return false
+	}
+	return !strings.EqualFold(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")), "cross-site")
 }
 
 func directLoopbackSessionAllowed(r *http.Request, policy ListenerPolicy) bool {

--- a/internal/daemon/listener_policy_test.go
+++ b/internal/daemon/listener_policy_test.go
@@ -95,43 +95,106 @@ func TestBrowserOriginPolicy(t *testing.T) {
 }
 
 func TestLocalUISessionPolicyRequiresDirectLoopback(t *testing.T) {
-	newHandler := func(t *testing.T, allow bool) http.Handler {
-		t.Helper()
-		handler, err := ApplyListenerPolicy(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusNoContent)
-		}), ListenerPolicy{
-			Kind: ListenerBrowser, Origin: "http://127.0.0.1:27123", AllowLocalSession: allow,
-		})
-		require.NoError(t, err)
-		return handler
+	tests := []struct {
+		name       string
+		allow      bool
+		host       string
+		remoteAddr string
+		headers    map[string]string
+		want       int
+	}{
+		{
+			name: "matching origin", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"Origin": "http://127.0.0.1:27123"}, want: http.StatusNoContent,
+		},
+		{
+			name: "absent origin", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123", want: http.StatusNoContent,
+		},
+		{
+			name: "empty origin", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"Origin": ""}, want: http.StatusNoContent,
+		},
+		{
+			name: "foreign host", allow: true,
+			host: "attacker.example:27123", remoteAddr: "127.0.0.1:40123", want: http.StatusBadRequest,
+		},
+		{
+			name: "mismatched origin", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"Origin": "https://attacker.example"}, want: http.StatusForbidden,
+		},
+		{
+			name: "opaque origin", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"Origin": "null"}, want: http.StatusForbidden,
+		},
+		{
+			name: "local sessions disabled",
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123", want: http.StatusNotFound,
+		},
+		{
+			name: "non-loopback peer", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "192.0.2.10:40123", want: http.StatusNotFound,
+		},
+		{
+			name: "Forwarded header", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"Forwarded": "for=192.0.2.10"}, want: http.StatusNotFound,
+		},
+		{
+			name: "X-Forwarded-For header", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"X-Forwarded-For": "192.0.2.10"}, want: http.StatusNotFound,
+		},
+		{
+			name: "X-Forwarded-Host header", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"X-Forwarded-Host": "daemon.example"}, want: http.StatusNotFound,
+		},
+		{
+			name: "X-Forwarded-Proto header", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"X-Forwarded-Proto": "https"}, want: http.StatusNotFound,
+		},
+		{
+			name: "X-Real-IP header", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"X-Real-IP": "192.0.2.10"}, want: http.StatusNotFound,
+		},
+		{
+			name: "cross-site fetch", allow: true,
+			host: "127.0.0.1:27123", remoteAddr: "127.0.0.1:40123",
+			headers: map[string]string{"Sec-Fetch-Site": "cross-site"}, want: http.StatusForbidden,
+		},
 	}
-	newRequest := func() *http.Request {
-		request := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:27123/api/v1/ui/session/local", nil)
-		request.Host = "127.0.0.1:27123"
-		request.RemoteAddr = "127.0.0.1:40123"
-		request.Header.Set("Origin", "http://127.0.0.1:27123")
-		return request
+
+	for _, kind := range []ListenerKind{ListenerBrowser, ListenerSharedTCP} {
+		for _, tt := range tests {
+			t.Run(string(kind)+"/"+tt.name, func(t *testing.T) {
+				handler, err := ApplyListenerPolicy(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNoContent)
+				}), ListenerPolicy{
+					Kind: kind, Origin: "http://127.0.0.1:27123", AllowLocalSession: tt.allow,
+				})
+				require.NoError(t, err)
+
+				request := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:27123/api/v1/ui/session/local", nil)
+				request.Host = tt.host
+				request.RemoteAddr = tt.remoteAddr
+				for name, value := range tt.headers {
+					request.Header.Set(name, value)
+				}
+				response := httptest.NewRecorder()
+
+				handler.ServeHTTP(response, request)
+
+				assert.Equal(t, tt.want, response.Code)
+			})
+		}
 	}
-
-	response := httptest.NewRecorder()
-	newHandler(t, true).ServeHTTP(response, newRequest())
-	assert.Equal(t, http.StatusNoContent, response.Code)
-
-	response = httptest.NewRecorder()
-	newHandler(t, false).ServeHTTP(response, newRequest())
-	assert.Equal(t, http.StatusNotFound, response.Code)
-
-	request := newRequest()
-	request.RemoteAddr = "192.0.2.10:40123"
-	response = httptest.NewRecorder()
-	newHandler(t, true).ServeHTTP(response, request)
-	assert.Equal(t, http.StatusNotFound, response.Code)
-
-	request = newRequest()
-	request.Header.Set("Forwarded", "for=192.0.2.10")
-	response = httptest.NewRecorder()
-	newHandler(t, true).ServeHTTP(response, request)
-	assert.Equal(t, http.StatusNotFound, response.Code)
 }
 
 func TestBrowserOriginPolicySharedTCPPreservesCLI(t *testing.T) {


### PR DESCRIPTION
Some owner-local embedded browser hosts omit `Origin` when minting a tab-scoped local-web session. The listener previously treated that request like any other originless mutation and denied the browser bootstrap.

This change permits an absent or empty `Origin` only on `POST /api/v1/ui/session/local`. Exact Host validation still runs first. The request must still arrive directly from loopback, contain no forwarding or real-client-IP headers, and use a listener with local sessions enabled. Explicit mismatched origins, the literal `Origin: null`, and cross-site Fetch Metadata remain forbidden.

Exact Host validation remains the DNS-rebinding boundary for this path. All later browser mutations continue to require the exact configured Origin and cross-site request forgery protection.
