### PR TITLE
Report restricted daemon autostart environments

### DIFF
--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -82,6 +82,7 @@ var (
 	stopRunningDaemonsForEnsure  = stopRunningDaemons
 	signalDaemonStopForEnsure    = daemon.SignalDaemonStop
 	discoverDaemonForAutoStart   = discoverForEnsureWithError
+	checkDaemonStateForEnsure    = checkDaemonStateWritable
 )
 
 // EnsureRunning returns a live daemon's base URL, auto-starting the daemon
@@ -284,6 +285,16 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 	// to a daemon.log file under the data dir; if that can't be opened, leave
 	// them nil so exec connects the child to the null device. Either way we
 	// never hand the daemon the caller's stderr.
+	if err := checkDaemonStateForEnsure(dataDir); err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return "", fmt.Errorf(
+				"auto-start daemon: cannot write Kata state directory %s: %w; "+
+					"this may be caused by a sandbox or restricted environment; grant access to the Kata state directory and retry",
+				dataDir, err,
+			)
+		}
+		return "", fmt.Errorf("auto-start daemon: cannot write Kata state directory %s: %w", dataDir, err)
+	}
 	if logw := daemonLogWriter(dataDir); logw != nil {
 		defer func() { _ = logw.Close() }() // child keeps its own handle after Start
 		opts.Stdout = logw
@@ -315,6 +326,22 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 		return "", unreachable
 	}
 	return "", fmt.Errorf("daemon failed to start within %s; inspect kata daemon status and kata daemon logs", daemonStartupWait)
+}
+
+// checkDaemonStateWritable verifies that an auto-started daemon can write its
+// runtime record before spawning it. Without this check, a sandboxed child can
+// fail silently and leave the caller waiting for the full readiness deadline.
+func checkDaemonStateWritable(dataDir string) error {
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(dataDir, ".kata-write-check-*")
+	if err != nil {
+		return err
+	}
+	path := f.Name()
+	defer func() { _ = os.Remove(path) }()
+	return f.Close()
 }
 
 // daemonLogWriter opens <dataDir>/daemon.log for the auto-started daemon's

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -289,7 +289,7 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 		if errors.Is(err, os.ErrPermission) {
 			return "", fmt.Errorf(
 				"auto-start daemon: cannot write Kata state directory %s: %w; "+
-					"this may be caused by a sandbox or restricted environment; grant access to the Kata state directory and retry",
+					"check filesystem permissions or sandbox access and retry",
 				dataDir, err,
 			)
 		}

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -174,6 +174,31 @@ func TestAutoStartUsesKitDetachedStarter(t *testing.T) {
 	assert.Contains(t, string(logData), "daemon stderr")
 }
 
+func TestAutoStartReportsRestrictedStateDirectoryBeforeSpawn(t *testing.T) {
+	dataDir := setupKataEnv(t)
+	originalCheckState := checkDaemonStateForEnsure
+	originalStart := startDetachedDaemonForEnsure
+	checkDaemonStateForEnsure = func(string) error {
+		return os.ErrPermission
+	}
+	started := false
+	startDetachedDaemonForEnsure = func(context.Context, kitdaemon.StartDetachedOptions) error {
+		started = true
+		return nil
+	}
+	t.Cleanup(func() {
+		checkDaemonStateForEnsure = originalCheckState
+		startDetachedDaemonForEnsure = originalStart
+	})
+
+	_, err := autoStart(t.Context(), dataDir)
+
+	require.ErrorIs(t, err, os.ErrPermission)
+	assert.Contains(t, err.Error(), "sandbox or restricted environment")
+	assert.Contains(t, err.Error(), dataDir)
+	assert.False(t, started, "daemon should not be spawned when its state directory is inaccessible")
+}
+
 func TestAutoStartAllowsDaemonStartupBeyondFiveSeconds(t *testing.T) {
 	dataDir := setupKataEnv(t)
 	originalStart := startDetachedDaemonForEnsure

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -194,7 +194,7 @@ func TestAutoStartReportsRestrictedStateDirectoryBeforeSpawn(t *testing.T) {
 	_, err := autoStart(t.Context(), dataDir)
 
 	require.ErrorIs(t, err, os.ErrPermission)
-	assert.Contains(t, err.Error(), "sandbox or restricted environment")
+	assert.Contains(t, err.Error(), "check filesystem permissions or sandbox access and retry")
 	assert.Contains(t, err.Error(), dataDir)
 	assert.False(t, started, "daemon should not be spawned when its state directory is inaccessible")
 }


### PR DESCRIPTION
## Summary

- verify the local daemon state directory is writable before detached autostart
- fail immediately when a restricted environment prevents daemon state creation
- identify permission failures as possible sandbox restrictions without relying on tool-specific environment markers

## Motivation

This failure was observed when Codex invoked Kata from its filesystem sandbox. Kata’s state directory was readable but outside the sandbox’s writable roots, so the detached daemon could not create its runtime state.

The detached child then exited without publishing a runtime record, while the caller waited for the full readiness deadline and ultimately reported only a generic startup timeout.

Failing before the spawn preserves the underlying permission error, avoids starting a child that cannot initialize, and gives the agent enough context to retry the original command with the required access.
