### PR TITLE
docs: finalize 0.15.0 release notes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 ---
 title: Changelog
 description: Release history for kata
-last_edited: 2026-08-15
+last_edited: 2026-08-16
 ---
 
 All notable changes to kata, grouped by release. Versioned releases start with
@@ -9,71 +9,62 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 ## Unreleased
 
+## 0.15.0
+<small>2026-08-16</small>
+
+kata 0.15.0 expands the native Model Context Protocol (MCP) server into a
+full agent-facing workflow, adds first-class planning dates and dynamic agent
+guidance, and makes local daemon and browser integrations easier to diagnose
+and embed safely.
+
 **New features**
 
+- Expanded the native MCP server from the original project-bound issue tools
+  to scoped issue, project, activity, recurrence, federation, synchronization,
+  import, token, and storage workflows. Thirteen section loaders can
+  progressively expose up to 55 typed tools without placing the full catalog
+  in an agent's initial context.
 - Added paired `kata schedule` / `kata deadline` commands and
   `kata.set_schedule` / `kata.set_deadline` MCP tools for first-class planning
-  date updates.
-- Expanded the native MCP server from the original project-bound issue tools
-  to complete scoped issue, project, token, federation, synchronization,
-  recurrence, import, digest, and live-event workflows.
-- Scoped `kata mcp serve` to the current workspace project by default, with
-  explicit one-project (`--project`/`--workspace`), fixed-allowlist
-  (`--projects`, pinned by immutable UID and rename-safe), and daemon-wide
-  (`--all-projects`) boundaries. Scoped graph, pagination, token, and
-  federation operations cannot cross their startup boundary, and an allowlist
-  keeps serving its remaining projects when one member is archived or merged
-  away.
-- Added 13 section loaders that progressively disclose the detailed typed MCP
-  tools and publish tool-list change notifications.
-- Added first-class MCP scheduling fields, force-create and force-claim, and
-  generic metadata support for native markers such as `someday=true`.
-- Added explicit host-local JSONL export and configured-target import tools
-  behind `--storage-root` and startup target aliases. Storage operations stay
-  anchored to the configured root, protect active SQLite databases and
-  sidecars, require exact confirmation before replacing an artifact or target,
-  and install restores race-safely with owner-only permissions.
-- Gated daemon token administration behind the explicit `--enable-token-admin`
-  capability in daemon-wide scope, kept federation topology changes
-  (enrollment and spoke join) outside MCP entirely, restricted enabling
-  issue synchronization — which selects the repository the daemon's GitHub
-  credentials read — to the daemon-wide scope, and required that same scope
-  for project administration: a scoped server can read its projects but
-  cannot rename, merge, archive, restore, or purge them.
-- Redacted cross-scope relationship identities, including parent, link,
-  relationship-array, moved-project, close-evidence, close-throttle, and
-  audit parent references, from scoped MCP issue, event, digest, edit-delta,
-  and close-audit results, and rejected close-audit parent filters that
-  cannot prove startup-scope membership.
-- Compared PostgreSQL storage-import targets with the active daemon storage
-  by persisted instance identity, so equivalent DSN spellings cannot bypass
-  the textual overlap guard.
+  dates. A future schedule parks work; a deadline does not.
+- Added `kata quickstart --format contract` as a marker-free, non-mutating
+  agent briefing generated from the same canonical text as
+  `kata init --with-agents`. `kata init --with-codex-hooks` now injects that
+  contract on startup, resume, clear, and compaction.
+- Added the conventional `kata --version` root flag with the same human, JSON,
+  and agent output as `kata version`.
 
 **Improvements**
 
-- Gave deadlines the same date, local date-time, UTC-instant, and timezone
-  projection rules as `scheduled_on`.
-- Added schedule, deadline, and someday commands to generated agent guidance and
-  public workflow documentation.
-- Added `event_id` and the close-time frozen `parent_uid` to close-audit
-  rows so audit results page with an immutable cursor and parent display
-  refs carry provable provenance.
-- Bumped the HTTP API schema version to `0.11.0` for the pinned relationship
-  target fields (`to_project_uid`, `expected_project_uids`) and close-audit
-  `event_id`; `kata mcp serve` now checks the daemon API version at startup
-  and refuses older daemons instead of failing later inside tool calls.
+- Allowed an embedded owner-local browser to omit or send an empty `Origin`
+  only when minting a direct-loopback local Web UI session. Exact Host,
+  loopback, forwarding-header, and cross-site Fetch Metadata checks remain in
+  force.
+- Allowed legacy bindings that predate binding-level `allow_insecure`
+  persistence, with the opt-in retained only in the same-endpoint credential,
+  to rebind to their validated HTTPS endpoint.
+- Removed durability flushes from both SQLite stores when the test-only
+  `KATA_TEST_FAST_SQLITE` mode is enabled. Production durability is unchanged.
 
 **Bug fixes**
 
-- Rejected add-side link targets whose project is archived inside the mutation
-  transaction (initial links, atomic-edit adds and `set_parent`, and link
-  creation) with the same `409 link_target_archived` the preflight returns, so
-  an archival that races the preflight cannot insert a link to an archived
-  project. PostgreSQL share-locks the target project row alongside the issue
-  row; existing links to archived projects stay removable.
-- Restored the `clear_owner` and `clear_priority` recurrence template fields
-  to the generated Go client; a stale template had silently dropped them from
-  `pkg/client` since their introduction.
+- Reported the recorded PID, endpoint, and underlying connection failure when
+  a live local daemon cannot be reached, instead of treating it as stopped and
+  attempting to start another daemon.
+
+**Acknowledgements**
+
+- Thanks to [Rusty Shackleford](https://github.com/salmonumbrella) for the
+  expanded MCP server, planning-date workflows, agent contract output, and
+  conventional version flag.
+- Thanks to [Wes McKinney](https://github.com/wesm) for originless embedded
+  local sessions, legacy federation rebinding, and the release documentation.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for removing durability
+  flushes from SQLite fast mode.
+- Thanks to [codyw912](https://github.com/codyw912) for clear unreachable
+  local-daemon errors.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the Go
+  1.26.6 toolchain security update included in this release.
 
 ## 0.14.3
 <small>2026-08-10</small>
@@ -150,12 +141,6 @@ federation, and daemon operations safer and more observable.
 
 **Improvements**
 
-- Added the conventional `kata --version` root flag, which prints the same
-  build identity as `kata version` and honors `--json` and `--agent`.
-  As a result, global output flags are now validated on the bare `kata`
-  invocation too: `kata --json --agent` and `kata --format bogus` exit `2` with
-  a usage error instead of silently printing help. Plain `kata` still prints
-  help and exits `0`.
 - Centralized Claude Code and Codex hook configuration on kit's shared
   agent-hook manager while preserving the existing init flags, lifecycle
   matchers, attention behavior, unrelated configuration, and workspace

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-12
+last_edited: 2026-08-16
 ---
 
 # Quickstart
@@ -248,7 +248,10 @@ kata list --agent
 kata list --json | jq .
 ```
 
-`--format human|json|agent` is equivalent to the dedicated switches.
+`--format human|json|agent` is equivalent to the dedicated switches. For agent
+harness injection, `kata quickstart --format contract` prints the shorter
+canonical managed briefing without mutating the workspace; see
+[Agent contract output](../reference/cli.md#agent-contract-output).
 
 ## Close with evidence
 

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -123,7 +123,7 @@ consumer expects newline-delimited JSON or a full response envelope.
 
 ## Output modes
 
-kata supports three output modes:
+kata supports three general output modes:
 
 | Mode | Use |
 | --- | --- |
@@ -132,6 +132,11 @@ kata supports three output modes:
 | JSON | Complete machine-readable response for scripts. |
 
 Use `--agent`, `--json`, or `--format human|agent|json`.
+
+`kata quickstart` and its `agent-instructions` alias also accept the
+command-scoped `--format contract` mode. It prints the canonical managed agent
+briefing for dynamic harness injection; see
+[Agent contract output](../reference/cli.md#agent-contract-output).
 
 ## Close discipline
 

--- a/docs/operations/agent-orchestration.md
+++ b/docs/operations/agent-orchestration.md
@@ -123,10 +123,11 @@ change independently. Re-running the command is a no-op, and symlinked
 `.claude` or `settings.json` paths are refused. Kit's shared agent-hook manager
 owns the additive config mutation and preserves unrelated hook entries.
 
-For Codex CLI workspaces, `kata init --with-codex-hooks` installs the
-start half of the same wiring into `.codex/hooks.json`: a `SessionStart`
-command hook runs `kata attention-hook start` for new, resumed, and cleared
-sessions, but not context compaction, using the same launcher-provided
+For Codex CLI workspaces, `kata init --with-codex-hooks` installs two
+`SessionStart` hooks in `.codex/hooks.json`. The contract hook injects the
+canonical marker-free agent briefing on startup, resume, clear, and context
+compaction. The attention hook runs `kata attention-hook start` on startup,
+resume, and clear, but not compaction, using the same launcher-provided
 `KATA_REF` and hidden subcommand as the Claude Code wiring. Codex prompts to
 trust project-layer hooks the first time it loads them, so expect one
 interactive confirmation on first run. Re-running the command is a no-op, and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-12
+last_edited: 2026-08-16
 ---
 
 # CLI reference
@@ -17,7 +17,7 @@ current flag list in your installed binary.
 | `--as <actor>` | Override the actor for this command. |
 | `--agent` | Emit concise agent-readable text. |
 | `--json` | Emit machine-readable JSON. |
-| `--format human|json|agent` | Select output mode explicitly. |
+| `--format <mode>` | Select an output mode explicitly. General commands accept `human`, `json`, or `agent`; `quickstart` also accepts `contract`. |
 | `--quiet` | Suppress non-essential output. |
 
 `kata --version` prints the same build identity as the `version` command below
@@ -64,19 +64,34 @@ Everything else in `settings.json` is preserved, re-running is a no-op, and a
 symlinked `settings.json` or `.claude` directory is refused. Hook ownership and
 config mutation use kit's shared agent-hook manager.
 
-Pass `--with-codex-hooks` to install the start half of the same
-[attention harness hooks](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
-into the workspace's Codex CLI config. It additively installs one command
-hook entry in `.codex/hooks.json`: `SessionStart` runs `kata attention-hook
-start` for new, resumed, and cleared sessions, but not context compaction,
-using the launcher-provided `KATA_REF` and intentionally doing nothing when it
-is absent. Codex has no stable session-end hook event yet, so this flag does
-not install an end hook; pair it with a launcher wrapper that runs `kata
-attention-hook end` after the `codex` invocation exits. Everything else in
-`hooks.json` is preserved, re-running is a no-op, a symlinked `hooks.json` or
-`.codex` directory is refused, and a pre-existing `[hooks]` table in
-`.codex/config.toml` produces a non-fatal warning since Codex loads both files'
-hooks together.
+Pass `--with-codex-hooks` to install two additive `SessionStart` hooks in the
+workspace's `.codex/hooks.json`. The contract hook injects the same canonical
+briefing as `kata quickstart --format contract` on startup, resume, clear, and
+context compaction. The
+[attention harness](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
+runs `kata attention-hook start` on startup, resume, and clear, but not
+compaction; it uses the launcher-provided `KATA_REF` and does nothing when the
+variable is absent. Codex has no stable session-end hook event yet, so pair the
+attention hook with a launcher wrapper that runs `kata attention-hook end`
+after Codex exits. Everything else in `hooks.json` is preserved, re-running is
+a no-op, a symlinked `hooks.json` or `.codex` directory is refused, and a
+pre-existing `[hooks]` table in `.codex/config.toml` produces a non-fatal
+warning because Codex loads both files' hooks together.
+
+## Agent contract output
+
+```sh
+kata quickstart --format contract
+kata agent-instructions --format contract --workspace /path/to/workspace
+kata quickstart --format contract --project example-project
+```
+
+The `contract` format prints kata's managed agent briefing without guidance-file
+markers or terminal framing. It works outside an initialized workspace, does
+not mutate workspace files, and comes from the same canonical text that
+`kata init --with-agents` writes. `contract` is valid only for `quickstart` and
+its `agent-instructions` alias; it conflicts with `--json` and `--agent` like
+the other output modes.
 
 ## Model Context Protocol
 

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-12
+last_edited: 2026-08-16
 ---
 
 # Agent workflows
@@ -25,6 +25,20 @@ kata whoami --agent
 
 Default to `--agent` for ordinary reads and mutations in agent logs. Use
 `--json` only when the script needs full structured data.
+
+Agent harnesses can load kata's shorter managed briefing dynamically without
+changing a repository:
+
+```sh
+kata quickstart --format contract
+# Equivalent alias; selectors are available for user-local integrations.
+kata agent-instructions --format contract --workspace /path/to/workspace
+```
+
+Contract output is marker-free, has no terminal framing, works without an
+initialized workspace, and performs no workspace mutation. It comes from the
+same canonical body that `kata init --with-agents` writes, so static and
+session-injected guidance stay aligned.
 
 To make a workspace self-documenting for agents, run `kata init --with-agents`
 once. It writes a marker-delimited kata briefing into existing real `AGENTS.md`
@@ -66,13 +80,13 @@ start` for new, resumed, and cleared sessions (but not context compaction), and
 than clear/resume transitions. Both use the
 launcher-provided `KATA_REF` and intentionally do nothing when it is absent.
 
-For Codex CLI workspaces, `kata init --with-codex-hooks` installs the start
-half of the same wiring into `.codex/hooks.json`: a `SessionStart` command
-hook runs `kata attention-hook start` for new, resumed, and cleared sessions
-(but not context compaction), using the same launcher-provided `KATA_REF`.
-Codex has no stable session-end hook event yet, so pair this with a launcher
-wrapper that runs `kata attention-hook end` after the `codex` invocation exits
-— see
+For Codex CLI workspaces, `kata init --with-codex-hooks` installs two
+`SessionStart` hooks in `.codex/hooks.json`. One injects the canonical agent
+contract on startup, resume, clear, and context compaction. The other runs
+`kata attention-hook start` on startup, resume, and clear (but not compaction),
+using the same launcher-provided `KATA_REF`. Codex has no stable session-end
+hook event yet, so pair the attention hook with a launcher wrapper that runs
+`kata attention-hook end` after the Codex invocation exits — see
 [agent orchestration](../operations/agent-orchestration.md#keep-attention-truthful-with-hooks)
 for the recipe.
 


### PR DESCRIPTION
Finalizes the public docs for the 0.15.0 release so the release history and
agent setup match the tagged behavior.

The changelog now records the shipped MCP expansion, planning dates, agent
contract output, version flag, embedded-browser and federation improvements,
SQLite fast mode, and clearer local-daemon errors. It credits each release
contributor and moves the version flag out of the 0.14.1 history.

The Zensical guide now distinguishes the command-scoped contract format from
the three general output modes. It also documents the split Codex SessionStart
behavior: contract injection includes compaction, while attention reset does
not. This PR is limited to documenting behavior already shipped in 0.15.0.
