### PR TITLE
Add supported daemon discovery output

### DIFF
--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -35,7 +35,7 @@ import (
 
 func newDaemonCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "daemon", Short: "manage the kata daemon"}
-	cmd.AddCommand(daemonStartCmd(), daemonStatusCmd(), daemonStopCmd(), daemonRestartCmd(), daemonReloadCmd(), daemonLogsCmd())
+	cmd.AddCommand(daemonStartCmd(), daemonStatusCmd(), daemonLocateCmd(), daemonStopCmd(), daemonRestartCmd(), daemonReloadCmd(), daemonLogsCmd())
 	return cmd
 }
 
@@ -71,6 +71,83 @@ type daemonStartOutput struct {
 	Address string `json:"address"`
 	DBPath  string `json:"db_path,omitempty"`
 	WebURL  string `json:"web_url,omitempty"`
+}
+
+type daemonLocateOutput struct {
+	Source         string `json:"source"`
+	Kind           string `json:"kind"`
+	Network        string `json:"network"`
+	Scheme         string `json:"scheme"`
+	Address        string `json:"address"`
+	RequestBaseURL string `json:"request_base_url,omitempty"`
+}
+
+func daemonLocateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "locate",
+		Short: "print or start the selected daemon endpoint",
+		Long: "Print the daemon endpoint selected by Kata, starting it when the selection is local and stopped. Resolution order is " +
+			"--daemon, KATA_SERVER, .kata.local.toml [server].url walking up from " +
+			"--workspace or the current directory, active_daemon, then the local daemon. " +
+			"Local addresses use unix:///path for Unix sockets or host:port for HTTP over TCP; " +
+			"configured remotes use their canonical HTTP(S) URL. Output never includes authentication credentials.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := locateDaemon(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if currentOutputMode() == outputJSON {
+				return emitJSON(cmd.OutOrStdout(), out)
+			}
+			if currentOutputMode() == outputAgent {
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK daemon source=%s kind=%s network=%s scheme=%s address=%s",
+					agentValue(out.Source), agentValue(out.Kind), agentValue(out.Network),
+					agentValue(out.Scheme), agentValue(out.Address))
+				if err == nil && out.RequestBaseURL != "" {
+					_, err = fmt.Fprintf(cmd.OutOrStdout(), " request_base_url=%s", agentValue(out.RequestBaseURL))
+				}
+				if err == nil {
+					_, err = fmt.Fprintln(cmd.OutOrStdout())
+				}
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), out.Address)
+			return err
+		},
+	}
+}
+
+func locateDaemon(ctx context.Context) (daemonLocateOutput, error) {
+	var (
+		target client.RunningDaemon
+		source = "configured"
+		err    error
+	)
+	if flags.Daemon != "" {
+		target, err = client.LocateNamedRunningTarget(ctx, flags.Daemon)
+		source = "daemon_flag"
+	} else {
+		target, err = client.LocateRunningTargetInWorkspace(ctx, workspaceStartForRemote())
+	}
+	if err != nil {
+		return daemonLocateOutput{}, cliDaemonTargetError(err)
+	}
+	kind := "remote"
+	if !target.ConfiguredRemote {
+		kind = "local"
+		if flags.Daemon == "" {
+			source = "local_default"
+		}
+	}
+	requestBaseURL := target.BaseURL
+	if target.Network == "unix" {
+		requestBaseURL = ""
+	}
+	return daemonLocateOutput{
+		Source: source, Kind: kind, Network: target.Network, Scheme: target.Scheme,
+		Address: target.Address, RequestBaseURL: requestBaseURL,
+	}, nil
 }
 
 var (

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -47,6 +47,232 @@ func TestDaemonStatus_NoDaemonReportsAbsent(t *testing.T) {
 	assert.Equal(t, "No kata daemon is running.\n", string(out))
 }
 
+func TestDaemonLocate_JSONReportsConfiguredRemoteWithoutSecrets(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+	addr, cleanup := pipeServer(t)
+	t.Cleanup(cleanup)
+	t.Setenv("KATA_SERVER", "http://"+addr)
+	t.Setenv("KATA_AUTH_TOKEN", "secret-that-must-not-be-emitted")
+
+	out := executeRoot(t, newRootCmd(), "daemon", "locate", "--json")
+
+	var got struct {
+		KataAPIVersion int    `json:"kata_api_version"`
+		Source         string `json:"source"`
+		Kind           string `json:"kind"`
+		Network        string `json:"network"`
+		Scheme         string `json:"scheme"`
+		Address        string `json:"address"`
+		RequestBaseURL string `json:"request_base_url"`
+	}
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, 1, got.KataAPIVersion)
+	assert.Equal(t, "configured", got.Source)
+	assert.Equal(t, "remote", got.Kind)
+	assert.Equal(t, "tcp", got.Network)
+	assert.Equal(t, "http", got.Scheme)
+	assert.Equal(t, "http://"+addr, got.Address)
+	assert.Equal(t, "http://"+addr, got.RequestBaseURL)
+	assert.NotContains(t, string(out), "secret-that-must-not-be-emitted")
+}
+
+func TestDaemonLocate_JSONReportsNamedRemoteWithoutCatalogToken(t *testing.T) {
+	resetFlags(t)
+	home := setupKataEnv(t)
+	addr, cleanup := pipeServer(t)
+	t.Cleanup(cleanup)
+	t.Setenv("KATA_EXAMPLE_REMOTE_TOKEN", "catalog-secret-that-must-not-be-emitted")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(fmt.Sprintf(`
+[[daemon]]
+name = "example-remote"
+url = "http://%s"
+allow_insecure = true
+token_env = "KATA_EXAMPLE_REMOTE_TOKEN"
+`, addr)), 0o600))
+
+	out := executeRoot(t, newRootCmd(),
+		"--daemon", "example-remote", "daemon", "locate", "--json")
+
+	var got daemonLocateOutput
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, "daemon_flag", got.Source)
+	assert.Equal(t, "remote", got.Kind)
+	assert.Equal(t, "tcp", got.Network)
+	assert.Equal(t, "http", got.Scheme)
+	assert.Equal(t, "http://"+addr, got.Address)
+	assert.NotContains(t, string(out), "catalog-secret-that-must-not-be-emitted")
+}
+
+func TestDaemonLocate_JSONReportsActiveRemoteWithoutResolvingCatalogToken(t *testing.T) {
+	resetFlags(t)
+	home := setupKataEnv(t)
+	addr, cleanup := pipeServer(t)
+	t.Cleanup(cleanup)
+	t.Setenv("KATA_MISSING_REMOTE_TOKEN", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(fmt.Sprintf(`
+active_daemon = "example-remote"
+
+[[daemon]]
+name = "example-remote"
+url = "http://%s"
+allow_insecure = true
+token_env = "KATA_MISSING_REMOTE_TOKEN"
+`, addr)), 0o600))
+
+	out := executeRoot(t, newRootCmd(), "daemon", "locate", "--json")
+
+	var got daemonLocateOutput
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, "configured", got.Source)
+	assert.Equal(t, "remote", got.Kind)
+	assert.Equal(t, "http://"+addr, got.Address)
+}
+
+func TestDaemonLocate_ErrorRedactsConfiguredURLUserInfo(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+	t.Setenv("KATA_SERVER", "http://fixture-user:fixture-secret@127.0.0.1:7777")
+
+	_, stderr, err := executeRootCapture(t, t.Context(), "daemon", "locate")
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "fixture-user")
+	assert.NotContains(t, err.Error(), "fixture-secret")
+	assert.NotContains(t, stderr, "fixture-user")
+	assert.NotContains(t, stderr, "fixture-secret")
+}
+
+func TestDaemonLocate_ErrorRedactsMalformedConfiguredURLUserInfo(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+	t.Setenv("KATA_SERVER", "http://fixture-user:fixture-secret@127.0.0.1:bad")
+
+	_, stderr, err := executeRootCapture(t, t.Context(), "daemon", "locate")
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "fixture-user")
+	assert.NotContains(t, err.Error(), "fixture-secret")
+	assert.NotContains(t, stderr, "fixture-user")
+	assert.NotContains(t, stderr, "fixture-secret")
+}
+
+func TestDaemonLocate_ErrorRedactsConfiguredURLPathQueryAndFragment(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+	t.Setenv("KATA_SERVER", "http://public.example/secret-path?token=secret-query#secret-fragment")
+
+	_, stderr, err := executeRootCapture(t, t.Context(), "daemon", "locate")
+
+	require.Error(t, err)
+	for _, secret := range []string{"secret-path", "secret-query", "secret-fragment"} {
+		assert.NotContains(t, err.Error(), secret)
+		assert.NotContains(t, stderr, secret)
+	}
+}
+
+func TestDaemonLocate_JSONReportsLocalTCPConfigAddress(t *testing.T) {
+	resetFlags(t)
+	home := setupKataEnv(t)
+	t.Setenv("KATA_SERVER", "")
+	addr, cleanup := pipeServer(t)
+	t.Cleanup(cleanup)
+	require.NoError(t, writeRuntimeFor(home, addr))
+
+	out := executeRoot(t, newRootCmd(), "daemon", "locate", "--json")
+
+	var got daemonLocateOutput
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, "local_default", got.Source)
+	assert.Equal(t, "local", got.Kind)
+	assert.Equal(t, "tcp", got.Network)
+	assert.Equal(t, "http", got.Scheme)
+	assert.Equal(t, addr, got.Address)
+	assert.Equal(t, "http://"+addr, got.RequestBaseURL)
+}
+
+func TestDaemonLocate_JSONReportsLocalUnixConfigAddress(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are unavailable on Windows")
+	}
+	resetFlags(t)
+	setupKataEnv(t)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "1")
+	socketDir := filepath.Join(t.TempDir(), "socket dir")
+	require.NoError(t, os.Mkdir(socketDir, 0o700))
+	socketPath := filepath.Join(socketDir, "kata.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/ping", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	})
+	go func() { _ = http.Serve(listener, mux) }() //nolint:gosec // test-only Unix socket
+
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	require.NoError(t, ns.EnsureDirs())
+	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
+		PID: os.Getpid(), Network: "unix", Address: socketPath,
+	})
+	require.NoError(t, err)
+
+	out := executeRoot(t, newRootCmd(), "daemon", "locate", "--json")
+
+	var got daemonLocateOutput
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, "local_default", got.Source)
+	assert.Equal(t, "local", got.Kind)
+	assert.Equal(t, "unix", got.Network)
+	assert.Equal(t, "http", got.Scheme)
+	assert.Equal(t, "unix://"+socketPath, got.Address)
+	assert.Empty(t, got.RequestBaseURL)
+
+	agent := executeRoot(t, newRootCmd(), "--agent", "daemon", "locate")
+	assert.Equal(t,
+		"OK daemon source=local_default kind=local network=unix scheme=http address="+
+			agentValue("unix://"+socketPath)+"\n",
+		string(agent))
+}
+
+func TestDaemonLocate_HumanAndAgentOutput(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+	addr, cleanup := pipeServer(t)
+	t.Cleanup(cleanup)
+	t.Setenv("KATA_SERVER", "http://"+addr)
+
+	human := executeRoot(t, newRootCmd(), "daemon", "locate")
+	assert.Equal(t, "http://"+addr+"\n", string(human))
+
+	agent := executeRoot(t, newRootCmd(), "--agent", "daemon", "locate")
+	assert.Equal(t,
+		"OK daemon source=configured kind=remote network=tcp scheme=http address=http://"+addr+
+			" request_base_url=http://"+addr+"\n",
+		string(agent))
+}
+
+func TestDaemonLocate_HelpDocumentsResolutionOrder(t *testing.T) {
+	root := newRootCmd()
+	cmd, _, err := root.Find([]string{"daemon", "locate"})
+	require.NoError(t, err)
+
+	wantInOrder := []string{
+		"--daemon", "KATA_SERVER", ".kata.local.toml", "active_daemon", "local daemon",
+	}
+	last := -1
+	for _, want := range wantInOrder {
+		index := strings.Index(cmd.Long, want)
+		assert.Greater(t, index, last, "%q should follow the prior resolution source", want)
+		last = index
+	}
+	assert.Contains(t, cmd.Long, "unix:///path")
+	assert.Contains(t, cmd.Long, "host:port")
+	assert.Contains(t, cmd.Long, "never includes authentication credentials")
+}
+
 func TestDaemonStatus_HumanReportsLifecycleDetails(t *testing.T) {
 	resetFlags(t)
 	setupKataEnv(t)

--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -80,6 +80,19 @@ If none of those are set, clients next honor `active_daemon` in
 `<KATA_HOME>/config.toml`; otherwise they use local daemon discovery or
 auto-start.
 
+To inspect the endpoint selected by those rules, including its transport and
+canonical request URL, run:
+
+```sh
+kata daemon locate --json
+```
+
+The command probes configured remotes without printing or resolving their
+tokens. External clients should use this supported output instead of
+reimplementing the selection order. See
+[Daemon discovery](../reference/daemon-discovery.md) for the schema and Unix
+socket address form.
+
 ## Browser access
 
 `kata ui` follows the same daemon selection order. A configured remote opens

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -586,6 +586,7 @@ after login. Kata never puts a remote token or another credential in the URL.
 ```sh
 kata daemon start [--foreground] [--listen <host:port>] [--insecure-readonly]
 kata daemon status
+kata daemon locate [--json | --agent]
 kata daemon stop
 kata daemon restart [--listen <host:port>] [--insecure-readonly]
 kata daemon reload
@@ -649,6 +650,11 @@ transient startup overrides. Background start and restart output reports the
 resolved web UI URL on its own line after the daemon transport address.
 `daemon status` reports the running daemon's address, web UI URL, PID, version,
 and uptime.
+`daemon locate` selects the same endpoint as ordinary CLI commands, starts a
+stopped local selection, and prints connection metadata without exposing
+credentials. Its JSON form is the supported discovery interface for external
+clients; see [Daemon discovery](daemon-discovery.md) for precedence, address
+forms, and the output schema.
 When a live local daemon record exists but its endpoint cannot be reached,
 client commands report the PID, endpoint, and underlying connection error
 instead of treating the daemon as stopped or attempting to start another one.

--- a/docs/reference/daemon-discovery.md
+++ b/docs/reference/daemon-discovery.md
@@ -1,0 +1,110 @@
+# Daemon discovery
+
+External clients can use `kata daemon locate` to select the same daemon as the
+Kata CLI without reimplementing configuration precedence or local runtime
+discovery.
+
+Use JSON output for integrations:
+
+```sh
+kata daemon locate --json
+kata --daemon example-remote daemon locate --json
+```
+
+The command probes the selected endpoint and starts it when the selection is a
+local daemon that is not running. It does not start configured remote daemons.
+An unavailable configured remote produces an error instead of falling back to
+the local daemon.
+
+## Selection order
+
+Kata checks these sources in order:
+
+1. `--daemon <name>`, which selects that `[[daemon]]` catalog entry for this
+   invocation and ignores the remaining sources.
+2. `KATA_SERVER`.
+3. `[server].url` in the nearest `.kata.local.toml`, walking upward from
+   `--workspace` when provided or from the current directory otherwise.
+4. The `active_daemon` catalog entry in `<KATA_HOME>/config.toml` when it names
+   a remote daemon.
+5. The default local daemon.
+
+A named local catalog entry and the default local selection both use Kata's
+normal local runtime discovery and auto-start behavior. A named remote,
+`KATA_SERVER`, workspace override, or active remote is normalized and probed
+but never replaced with another target.
+
+The JSON `source` field groups the selected source as follows:
+
+| `source` | Selection |
+| --- | --- |
+| `daemon_flag` | An explicit `--daemon <name>` entry. |
+| `configured` | `KATA_SERVER`, `.kata.local.toml`, or a remote `active_daemon`. |
+| `local_default` | The default local daemon. |
+
+## Output contract
+
+Without an output flag, the command prints only the selected transport
+address:
+
+```text
+unix:///path/to/kata.sock
+```
+
+`--json` emits the complete machine-readable contract. A configured remote
+looks like this:
+
+```json
+{
+  "kata_api_version": 1,
+  "source": "configured",
+  "kind": "remote",
+  "network": "tcp",
+  "scheme": "https",
+  "address": "https://daemon.example",
+  "request_base_url": "https://daemon.example"
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `kata_api_version` | Version of the JSON schema. Consumers should ignore additional fields they do not recognize. |
+| `source` | Selection group described above. |
+| `kind` | `local` or `remote`. |
+| `network` | `unix` or `tcp`. |
+| `scheme` | HTTP request scheme, `http` or `https`. Unix sockets use HTTP over the socket and therefore report `http`. |
+| `address` | Transport address: `unix:///path` for a Unix socket, `host:port` for local TCP, or a canonical HTTP(S) origin for a configured remote. |
+| `request_base_url` | Base URL for HTTP requests over TCP. This field is omitted for Unix sockets. |
+
+The address forms are:
+
+| Target | `network` | `address` | `request_base_url` |
+| --- | --- | --- | --- |
+| Local Unix socket | `unix` | `unix:///path/to/kata.sock` | Omitted |
+| Local TCP daemon | `tcp` | `127.0.0.1:7777` | `http://127.0.0.1:7777` |
+| Configured remote | `tcp` | `https://daemon.example` | `https://daemon.example` |
+
+For TCP, append API paths to `request_base_url`. For Unix sockets, parse the
+`unix://` address, connect to its path component, and issue ordinary HTTP
+requests over that connection. The [HTTP API schema](http-api.md) documents
+the available request and response types.
+
+Agent output carries the same endpoint metadata on one line. It omits the
+JSON-only `kata_api_version` field:
+
+```text
+OK daemon source=configured kind=remote network=tcp scheme=https address=https://daemon.example request_base_url=https://daemon.example
+```
+
+See [Agent output format](agent-output.md) for quoting and parsing rules.
+
+## Credentials
+
+Discovery reports location and transport metadata only. It does not resolve or
+emit bearer tokens from the environment or daemon catalog. Configured remote
+URLs are reduced to their canonical origin, and errors do not echo URL user
+info, paths, queries, or fragments that could contain secrets.
+
+Clients must obtain any required credential separately and apply it to API
+requests. See [Remote daemon](../operations/remote-daemon.md) for the supported
+authentication and transport configurations.

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-15
+last_edited: 2026-08-19
 ---
 
 # HTTP API schema
@@ -7,6 +7,9 @@ last_edited: 2026-08-15
 The daemon exposes an HTTP API (used by the CLI, TUI, and remote clients). Its
 shape is published as an OpenAPI 3.1 document so out-of-process clients can
 generate typed clients instead of hand-copying wire structs.
+
+Use [`kata daemon locate`](daemon-discovery.md) to discover the endpoint and
+transport for those requests with the same selection rules as the CLI.
 
 ## Getting the schema
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -30,6 +30,7 @@ nav = [
   ]},
   {"Reference" = [
     {"CLI" = "reference/cli.md"},
+    {"Daemon discovery" = "reference/daemon-discovery.md"},
     {"Model Context Protocol" = "reference/mcp.md"},
     {"Configuration" = "reference/configuration.md"},
     {"Metadata" = "reference/metadata.md"},

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -66,6 +66,9 @@ type BaseURLKey struct{}
 // a configured remote may be reached through a loopback SSH tunnel.
 type RunningDaemon struct {
 	BaseURL          string
+	Address          string
+	Network          string
+	Scheme           string
 	ConfiguredRemote bool
 }
 
@@ -81,7 +84,7 @@ var (
 	startDetachedDaemonForEnsure = kitdaemon.StartDetached
 	stopRunningDaemonsForEnsure  = stopRunningDaemons
 	signalDaemonStopForEnsure    = daemon.SignalDaemonStop
-	discoverDaemonForAutoStart   = discoverForEnsureWithError
+	discoverDaemonForAutoStart   = discoverTargetForEnsureWithError
 	checkDaemonStateForEnsure    = func(dataDir string) error {
 		return (kitdaemon.RuntimeStore{Dir: dataDir}).CheckWritable()
 	}
@@ -132,19 +135,26 @@ func EnsureRunningInWorkspace(ctx context.Context, workspaceStart string) (strin
 }
 
 func ensureRunningTargetInWorkspace(ctx context.Context, workspaceStart string) (RunningDaemon, error) {
+	return runningTargetInWorkspace(ctx, workspaceStart, true)
+}
+
+// LocateRunningTargetInWorkspace selects and probes the same endpoint as
+// EnsureRunningTargetInWorkspace without resolving bearer credentials. Local
+// selections are still started when necessary.
+func LocateRunningTargetInWorkspace(ctx context.Context, workspaceStart string) (RunningDaemon, error) {
+	return runningTargetInWorkspace(ctx, workspaceStart, false)
+}
+
+func runningTargetInWorkspace(ctx context.Context, workspaceStart string, resolveCredentials bool) (RunningDaemon, error) {
 	if v, ok := ctx.Value(BaseURLKey{}).(string); ok && v != "" {
-		return RunningDaemon{BaseURL: v}, nil
+		return remoteRunningDaemon(v, false), nil
 	}
-	if url, ok, err := resolveRemote(ctx, workspaceStart); err != nil {
+	if url, ok, err := resolveRemoteEndpoint(ctx, workspaceStart, resolveCredentials); err != nil {
 		return RunningDaemon{}, err
 	} else if ok {
-		return RunningDaemon{BaseURL: url, ConfiguredRemote: true}, nil
+		return remoteRunningDaemon(url, true), nil
 	}
-	url, err := ensureLocalRunning(ctx)
-	if err != nil {
-		return RunningDaemon{}, err
-	}
-	return RunningDaemon{BaseURL: url}, nil
+	return ensureLocalRunningTarget(ctx)
 }
 
 // EnsureLocalRunning returns a live local daemon's base URL, ignoring
@@ -158,21 +168,35 @@ func EnsureLocalRunning(ctx context.Context) (string, error) {
 	return ensureLocalRunning(ctx)
 }
 
+// EnsureLocalRunningTarget is EnsureLocalRunning with the exact selected
+// runtime endpoint retained for callers that must publish or reuse it.
+func EnsureLocalRunningTarget(ctx context.Context) (RunningDaemon, error) {
+	if v, ok := ctx.Value(BaseURLKey{}).(string); ok && v != "" {
+		return remoteRunningDaemon(v, false), nil
+	}
+	return ensureLocalRunningTarget(ctx)
+}
+
 func ensureLocalRunning(ctx context.Context) (string, error) {
+	target, err := ensureLocalRunningTarget(ctx)
+	return target.BaseURL, err
+}
+
+func ensureLocalRunningTarget(ctx context.Context) (RunningDaemon, error) {
 	ns, err := daemon.NewNamespace()
 	if err != nil {
-		return "", err
+		return RunningDaemon{}, err
 	}
-	url, compatible, ok, err := discoverForEnsureWithError(ctx, ns.DataDir)
+	target, compatible, ok, err := discoverTargetForEnsureWithError(ctx, ns.DataDir)
 	if err != nil {
-		return "", err
+		return RunningDaemon{}, err
 	}
 	if ok {
 		if compatible {
-			return url, nil
+			return target, nil
 		}
 		if err := stopRunningDaemonsForEnsure(ctx, ns.DataDir, ns.DBHash); err != nil {
-			return "", err
+			return RunningDaemon{}, err
 		}
 		return startDaemonForEnsure(ctx, ns.DataDir)
 	}
@@ -180,11 +204,16 @@ func ensureLocalRunning(ctx context.Context) (string, error) {
 }
 
 func discoverForEnsureWithError(ctx context.Context, dataDir string) (string, bool, bool, error) {
+	target, compatible, ok, err := discoverTargetForEnsureWithError(ctx, dataDir)
+	return target.BaseURL, compatible, ok, err
+}
+
+func discoverTargetForEnsureWithError(ctx context.Context, dataDir string) (RunningDaemon, bool, bool, error) {
 	recs, err := (kitdaemon.RuntimeStore{Dir: dataDir}).List()
 	if err != nil {
-		return "", false, false, err
+		return RunningDaemon{}, false, false, err
 	}
-	var staleURL string
+	var staleTarget RunningDaemon
 	var unreachable error
 	for _, r := range recs {
 		if !daemon.RuntimeProcessAlive(r) {
@@ -194,7 +223,7 @@ func discoverForEnsureWithError(ctx context.Context, dataDir string) (string, bo
 		url, info, probeErr := probeAddressWithError(ctx, address)
 		if probeErr != nil {
 			if err := ctx.Err(); err != nil {
-				return "", false, false, err
+				return RunningDaemon{}, false, false, err
 			}
 			if unreachable == nil {
 				unreachable = &localDaemonUnreachableError{
@@ -205,20 +234,21 @@ func discoverForEnsureWithError(ctx context.Context, dataDir string) (string, bo
 			}
 			continue
 		}
+		target := localRunningDaemon(url, address)
 		if daemonVersionCheckSkipped() || daemonVersionCompatible(info) {
-			return url, true, true, nil
+			return target, true, true, nil
 		}
-		if staleURL == "" {
-			staleURL = url
+		if staleTarget.BaseURL == "" {
+			staleTarget = target
 		}
 	}
 	if unreachable != nil {
-		return "", false, false, unreachable
+		return RunningDaemon{}, false, false, unreachable
 	}
-	if staleURL != "" {
-		return staleURL, false, true, nil
+	if staleTarget.BaseURL != "" {
+		return staleTarget, false, true, nil
 	}
-	return "", false, false, nil
+	return RunningDaemon{}, false, false, nil
 }
 
 func daemonVersionCheckSkipped() bool {
@@ -274,7 +304,7 @@ func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
 	return errors.New("old daemon did not stop within 3s")
 }
 
-func autoStart(ctx context.Context, dataDir string) (string, error) {
+func autoStart(ctx context.Context, dataDir string) (RunningDaemon, error) {
 	opts := kitdaemon.StartDetachedOptions{
 		Args:            []string{"daemon", "start", "--foreground"},
 		Env:             append(os.Environ(), daemon.AutoStartMarkerEnv+"=1"),
@@ -289,13 +319,13 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 	// never hand the daemon the caller's stderr.
 	if err := checkDaemonStateForEnsure(dataDir); err != nil {
 		if errors.Is(err, os.ErrPermission) {
-			return "", fmt.Errorf(
+			return RunningDaemon{}, fmt.Errorf(
 				"auto-start daemon: cannot write Kata state directory %s: %w; "+
 					"check filesystem permissions or sandbox access and retry",
 				dataDir, err,
 			)
 		}
-		return "", fmt.Errorf("auto-start daemon: cannot write Kata state directory %s: %w", dataDir, err)
+		return RunningDaemon{}, fmt.Errorf("auto-start daemon: cannot write Kata state directory %s: %w", dataDir, err)
 	}
 	if logw := daemonLogWriter(dataDir); logw != nil {
 		defer func() { _ = logw.Close() }() // child keeps its own handle after Start
@@ -303,31 +333,52 @@ func autoStart(ctx context.Context, dataDir string) (string, error) {
 		opts.Stderr = logw
 	}
 	if err := startDetachedDaemonForEnsure(ctx, opts); err != nil {
-		return "", fmt.Errorf("auto-start daemon: %w", err)
+		return RunningDaemon{}, fmt.Errorf("auto-start daemon: %w", err)
 	}
 	deadline := time.Now().Add(daemonStartupWait)
 	var unreachable error
 	for time.Now().Before(deadline) {
-		url, compatible, ok, err := discoverDaemonForAutoStart(ctx, dataDir)
+		target, compatible, ok, err := discoverDaemonForAutoStart(ctx, dataDir)
 		if err != nil && !errors.Is(err, ErrLocalDaemonUnreachable) {
-			return "", err
+			return RunningDaemon{}, err
 		}
 		if errors.Is(err, ErrLocalDaemonUnreachable) {
 			unreachable = err
 		}
 		if ok && compatible {
-			return url, nil
+			return target, nil
 		}
 		select {
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return RunningDaemon{}, ctx.Err()
 		case <-time.After(50 * time.Millisecond):
 		}
 	}
 	if unreachable != nil {
-		return "", unreachable
+		return RunningDaemon{}, unreachable
 	}
-	return "", fmt.Errorf("daemon failed to start within %s; inspect kata daemon status and kata daemon logs", daemonStartupWait)
+	return RunningDaemon{}, fmt.Errorf("daemon failed to start within %s; inspect kata daemon status and kata daemon logs", daemonStartupWait)
+}
+
+func localRunningDaemon(baseURL, address string) RunningDaemon {
+	network := "tcp"
+	if strings.HasPrefix(address, "unix://") {
+		network = "unix"
+	}
+	return RunningDaemon{
+		BaseURL: baseURL, Address: address, Network: network, Scheme: "http",
+	}
+}
+
+func remoteRunningDaemon(baseURL string, configured bool) RunningDaemon {
+	scheme := "http"
+	if parsed, err := url.Parse(baseURL); err == nil && parsed.Scheme != "" {
+		scheme = parsed.Scheme
+	}
+	return RunningDaemon{
+		BaseURL: baseURL, Address: baseURL, Network: "tcp", Scheme: scheme,
+		ConfiguredRemote: configured,
+	}
 }
 
 // daemonLogWriter opens <dataDir>/daemon.log for the auto-started daemon's

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -114,6 +114,23 @@ func TestEnsureRunningTargetMarksLocalDiscovery(t *testing.T) {
 	assert.Equal(t, 1, restore.startCalls)
 }
 
+func TestEnsureRunningTargetRetainsSelectedLocalEndpoint(t *testing.T) {
+	t.Setenv("KATA_SERVER", "")
+	home := setupKataEnv(t)
+	_, addr := startMockDaemonPing(t, map[string]any{
+		"ok": true, "service": "kata", "version": currentVersionForEnsure(),
+	})
+	require.NoError(t, writeRuntimeRecord(t, home, addr))
+
+	target, err := EnsureRunningTarget(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, addr, target.Address)
+	assert.Equal(t, "tcp", target.Network)
+	assert.Equal(t, "http", target.Scheme)
+	assert.Equal(t, "http://"+addr, target.BaseURL)
+}
+
 func TestDiscoverWebRuntime(t *testing.T) {
 	record := kitdaemon.RuntimeRecord{
 		PID: 4242,
@@ -160,10 +177,11 @@ func TestAutoStartUsesKitDetachedStarter(t *testing.T) {
 	}
 	t.Cleanup(func() { startDetachedDaemonForEnsure = orig })
 
-	url, err := autoStart(context.Background(), ns.DataDir)
+	target, err := autoStart(context.Background(), ns.DataDir)
 
 	require.NoError(t, err)
-	assert.Equal(t, "http://"+addr, url)
+	assert.Equal(t, "http://"+addr, target.BaseURL)
+	assert.Equal(t, addr, target.Address)
 	assert.Equal(t, []string{"daemon", "start", "--foreground"}, got.Args)
 	assert.True(t, got.RefuseEphemeral)
 	assert.Contains(t, got.Env, daemon.AutoStartMarkerEnv+"=1")
@@ -213,17 +231,17 @@ func TestAutoStartAllowsDaemonStartupBeyondFiveSeconds(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		startedAt := time.Now()
-		discoverDaemonForAutoStart = func(context.Context, string) (string, bool, bool, error) {
+		discoverDaemonForAutoStart = func(context.Context, string) (RunningDaemon, bool, bool, error) {
 			if time.Since(startedAt) < 6*time.Second {
-				return "", false, false, nil
+				return RunningDaemon{}, false, false, nil
 			}
-			return "http://127.0.0.1:27123", true, true, nil
+			return remoteRunningDaemon("http://127.0.0.1:27123", false), true, true, nil
 		}
 
-		url, err := autoStart(t.Context(), dataDir)
+		target, err := autoStart(t.Context(), dataDir)
 
 		require.NoError(t, err)
-		assert.Equal(t, "http://127.0.0.1:27123", url)
+		assert.Equal(t, "http://127.0.0.1:27123", target.BaseURL)
 	})
 }
 
@@ -241,17 +259,17 @@ func TestAutoStartWaitsForUnreachableSpawnedDaemonToBecomeReady(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		startedAt := time.Now()
-		discoverDaemonForAutoStart = func(context.Context, string) (string, bool, bool, error) {
+		discoverDaemonForAutoStart = func(context.Context, string) (RunningDaemon, bool, bool, error) {
 			if time.Since(startedAt) < 6*time.Second {
-				return "", false, false, fmt.Errorf("%w: listener not ready", ErrLocalDaemonUnreachable)
+				return RunningDaemon{}, false, false, fmt.Errorf("%w: listener not ready", ErrLocalDaemonUnreachable)
 			}
-			return "http://127.0.0.1:27123", true, true, nil
+			return remoteRunningDaemon("http://127.0.0.1:27123", false), true, true, nil
 		}
 
-		url, err := autoStart(t.Context(), dataDir)
+		target, err := autoStart(t.Context(), dataDir)
 
 		require.NoError(t, err)
-		assert.Equal(t, "http://127.0.0.1:27123", url)
+		assert.Equal(t, "http://127.0.0.1:27123", target.BaseURL)
 	})
 }
 
@@ -269,8 +287,8 @@ func TestAutoStartReportsPersistentUnreachableDaemonAfterReadinessDeadline(t *te
 
 	synctest.Test(t, func(t *testing.T) {
 		probeErr := fmt.Errorf("%w: daemon pid 123 at unix:///tmp/kata.sock", ErrLocalDaemonUnreachable)
-		discoverDaemonForAutoStart = func(context.Context, string) (string, bool, bool, error) {
-			return "", false, false, probeErr
+		discoverDaemonForAutoStart = func(context.Context, string) (RunningDaemon, bool, bool, error) {
+			return RunningDaemon{}, false, false, probeErr
 		}
 
 		_, err := autoStart(t.Context(), dataDir)
@@ -607,9 +625,9 @@ func patchEnsureHooks(t *testing.T, version, startedURL string) *ensurePatchStat
 		state.stopCalls++
 		return nil
 	}
-	startDaemonForEnsure = func(context.Context, string) (string, error) {
+	startDaemonForEnsure = func(context.Context, string) (RunningDaemon, error) {
 		state.startCalls++
-		return startedURL, nil
+		return remoteRunningDaemon(startedURL, false), nil
 	}
 	t.Cleanup(func() {
 		currentVersionForEnsure = origCurrent

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -83,6 +83,39 @@ func EnsureNamedRunning(ctx context.Context, name string) (string, error) {
 	return target.BaseURL, nil
 }
 
+// LocateNamedRunningTarget ensures a named local daemon is running or probes a
+// named remote, returning sanitized connection metadata without resolving its
+// authentication credential.
+func LocateNamedRunningTarget(ctx context.Context, name string) (RunningDaemon, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return RunningDaemon{}, fmt.Errorf("%w: empty name", ErrNamedDaemonNotFound)
+	}
+	cfg, err := config.ReadDaemonConfig()
+	if err != nil {
+		return RunningDaemon{}, err
+	}
+	for _, daemon := range cfg.Daemons {
+		if daemon.Name != name {
+			continue
+		}
+		if daemon.Local {
+			return EnsureLocalRunningTarget(ctx)
+		}
+		baseURL, err := normalizeRemoteURL(daemon.URL, daemon.AllowInsecure)
+		if err != nil {
+			return RunningDaemon{}, fmt.Errorf("%s daemon %q url %q: %w",
+				daemonConfigSource(), daemon.Name, remoteURLForError(daemon.URL), err)
+		}
+		if !probeRemote(ctx, baseURL) {
+			return RunningDaemon{}, fmt.Errorf("%w: %s (%s daemon %q)",
+				ErrRemoteUnavailable, baseURL, daemonConfigSource(), daemon.Name)
+		}
+		return remoteRunningDaemon(baseURL, true), nil
+	}
+	return RunningDaemon{}, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, name)
+}
+
 // NormalizeRemoteURL exposes kata's remote URL validation/canonicalization
 // for TUI daemon-catalog entries. It returns scheme://host[:port] with path
 // and query stripped, and applies the same allow_insecure semantics used by
@@ -136,10 +169,14 @@ func RemoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 // CWD; otherwise running from outside the repo with `--workspace`
 // would silently miss the workspace's local override.
 func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, error) {
+	return resolveRemoteEndpoint(ctx, workspaceStart, true)
+}
+
+func resolveRemoteEndpoint(ctx context.Context, workspaceStart string, resolveCredentials bool) (string, bool, error) {
 	if v := os.Getenv(remoteServerEnvVar); v != "" {
 		u, err := normalizeRemoteURL(v, envAllowInsecure())
 		if err != nil {
-			return "", false, fmt.Errorf("KATA_SERVER %q: %w", v, err)
+			return "", false, fmt.Errorf("KATA_SERVER %q: %w", remoteURLForError(v), err)
 		}
 		if !probeRemote(ctx, u) {
 			return "", false, fmt.Errorf("%w: %s (KATA_SERVER)", ErrRemoteUnavailable, u)
@@ -151,7 +188,7 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 		return "", false, err
 	}
 	if !ok {
-		return resolveActiveRemote(ctx)
+		return resolveActiveRemote(ctx, resolveCredentials)
 	}
 	cfg, err := config.ReadLocalConfig(root)
 	if err != nil {
@@ -161,11 +198,11 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 		return "", false, fmt.Errorf("read %s: %w", path, err)
 	}
 	if cfg.Server.URL == "" {
-		return resolveActiveRemote(ctx)
+		return resolveActiveRemote(ctx, resolveCredentials)
 	}
 	u, err := normalizeRemoteURL(cfg.Server.URL, cfg.Server.AllowInsecure)
 	if err != nil {
-		return "", false, fmt.Errorf("%s server.url %q: %w", path, cfg.Server.URL, err)
+		return "", false, fmt.Errorf("%s server.url %q: %w", path, remoteURLForError(cfg.Server.URL), err)
 	}
 	if !probeRemote(ctx, u) {
 		return "", false, fmt.Errorf("%w: %s (%s)", ErrRemoteUnavailable, u, path)
@@ -173,12 +210,12 @@ func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, er
 	return u, true, nil
 }
 
-func resolveActiveRemote(ctx context.Context) (string, bool, error) {
+func resolveActiveRemote(ctx context.Context, resolveCredentials bool) (string, bool, error) {
 	target, ok, err := activeRemoteFromConfig()
 	if err != nil || !ok {
 		return "", false, err
 	}
-	if !globalAuthTokenOverrideSet() {
+	if resolveCredentials && !globalAuthTokenOverrideSet() {
 		_, err = resolveActiveRemoteTargetToken(target)
 	}
 	if err != nil {
@@ -300,7 +337,7 @@ func namedDaemonTargetFromCatalog(
 		baseURL, err = normalizeRemoteURL(daemon.URL, daemon.AllowInsecure)
 		if err != nil {
 			return namedDaemonTarget{}, fmt.Errorf("%s daemon %q url %q: %w",
-				daemonConfigSource(), daemon.Name, daemon.URL, err)
+				daemonConfigSource(), daemon.Name, remoteURLForError(daemon.URL), err)
 		}
 	}
 	target := activeRemoteTarget{
@@ -346,7 +383,7 @@ func activeRemoteFromConfig() (activeRemoteTarget, bool, error) {
 		if err != nil {
 			return activeRemoteTarget{}, false,
 				fmt.Errorf("%s daemon %q url %q: %w",
-					daemonConfigSource(), daemon.Name, daemon.URL, err)
+					daemonConfigSource(), daemon.Name, remoteURLForError(daemon.URL), err)
 		}
 		return activeRemoteTarget{
 			Name:          daemon.Name,
@@ -709,7 +746,7 @@ func localConfigTrackState(root string) (tracked, determined bool) {
 func normalizeRemoteURL(v string, allowInsecure bool) (string, error) {
 	u, err := url.Parse(v)
 	if err != nil {
-		return "", fmt.Errorf("parse url: %w", err)
+		return "", errors.New("invalid URL syntax")
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return "", fmt.Errorf("scheme must be http or https, got %q", u.Scheme)
@@ -737,6 +774,14 @@ func requireSecureOrPrivate(u *url.URL, allowInsecure bool) error {
 		return fmt.Errorf("plain http to %q is not allowed: %w; use https or set allow_insecure (env KATA_ALLOW_INSECURE=1, or [server].allow_insecure=true in .kata.local.toml)", host, err)
 	}
 	return nil
+}
+
+func remoteURLForError(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "<invalid-url>"
+	}
+	return (&url.URL{Scheme: strings.ToLower(parsed.Scheme), Host: parsed.Host}).String()
 }
 
 // probeRemote checks an explicitly configured remote using the normal


### PR DESCRIPTION
## What changed

- Added `kata daemon locate` with human, JSON, and agent output.
- Reports the selected endpoint, locality, transport, scheme, and request base URL without exposing credentials.
- Uses Kata's existing remote precedence and exact local runtime selection, including named and active daemons.

## Why

External clients need a supported way to find the same daemon as the CLI without reimplementing config walking, active-daemon selection, or Unix/TCP discovery.

## Usage

```sh
kata daemon locate --json
kata --agent daemon locate
kata --daemon example-remote daemon locate --json
```

Closes #102
