### PR TITLE
Add per-project merge import

### DIFF
--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -21,6 +21,7 @@ func newImportCmd() *cobra.Command {
 	var target string
 	var force bool
 	var newInstance bool
+	var merge bool
 	var sourceFormat string
 	cmd := &cobra.Command{
 		Use:   "import",
@@ -32,7 +33,7 @@ func newImportCmd() *cobra.Command {
 			}
 			switch strings.TrimSpace(format) {
 			case "", "kata":
-				return runKataJSONLImport(cmd, input, target, force, newInstance)
+				return runKataJSONLImport(cmd, input, target, force, newInstance, merge)
 			case "beads":
 				if err := validateBeadsImportFlags(cmd); err != nil {
 					return err
@@ -49,10 +50,12 @@ func newImportCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&sourceFormat, "source-format", "kata", "import source format (kata or beads)")
 	cmd.Flags().StringVar(&input, "input", "", "path to JSONL export")
-	cmd.Flags().StringVar(&target, "target", "", "SQLite database path or Postgres DSN to create")
+	cmd.Flags().StringVar(&target, "target", "", "SQLite database path or Postgres DSN to create or merge into")
 	cmd.Flags().BoolVar(&force, "force", false, "replace existing target database")
 	cmd.Flags().BoolVar(&newInstance, "new-instance", false,
 		"keep the target database's new identity instead of reusing the source identity; useful when restoring into a separate copy")
+	cmd.Flags().BoolVar(&merge, "merge", false,
+		"merge one project snapshot into an existing target database")
 	return cmd
 }
 
@@ -86,7 +89,7 @@ func legacyImportSourceFormat() string {
 }
 
 func validateBeadsImportFlags(cmd *cobra.Command) error {
-	for _, name := range []string{"input", "target", "force", "new-instance"} {
+	for _, name := range []string{"input", "target", "force", "new-instance", "merge"} {
 		if cmd.Flags().Changed(name) {
 			return &cliError{
 				Message:  fmt.Sprintf("--%s is not supported with --source-format beads", name),
@@ -98,7 +101,13 @@ func validateBeadsImportFlags(cmd *cobra.Command) error {
 	return nil
 }
 
-func runKataJSONLImport(cmd *cobra.Command, input, target string, force, newInstance bool) error {
+func runKataJSONLImport(cmd *cobra.Command, input, target string, force, newInstance, merge bool) error {
+	if merge && force {
+		return &cliError{Message: "--force cannot be combined with --merge", Kind: kindValidation, ExitCode: ExitValidation}
+	}
+	if merge && newInstance {
+		return &cliError{Message: "--new-instance cannot be combined with --merge", Kind: kindValidation, ExitCode: ExitValidation}
+	}
 	if input == "" {
 		return &cliError{Message: "import requires --input", Kind: kindValidation, ExitCode: ExitValidation}
 	}
@@ -114,7 +123,13 @@ func runKataJSONLImport(cmd *cobra.Command, input, target string, force, newInst
 		return err
 	}
 	if backend == storeopen.BackendPostgres {
+		if merge {
+			return runPostgresJSONLMerge(cmd, input, target)
+		}
 		return runPostgresJSONLImport(cmd, input, target, force, newInstance)
+	}
+	if merge {
+		return runSQLiteJSONLMerge(cmd, input, target)
 	}
 	targetExists, err := sqliteFileSetExists(target)
 	if err != nil {
@@ -161,6 +176,68 @@ func runKataJSONLImport(cmd *cobra.Command, input, target string, force, newInst
 	}
 	installed = true
 	return writeImportSuccess(cmd, target)
+}
+
+func runSQLiteJSONLMerge(cmd *cobra.Command, input, target string) error {
+	exists, err := sqliteFileSetExists(target)
+	if err != nil {
+		return fmt.Errorf("stat merge target: %w", err)
+	}
+	if !exists {
+		return &cliError{Message: "merge target does not exist", Kind: kindValidation, ExitCode: ExitValidation}
+	}
+	in, err := os.Open(input) //nolint:gosec // import path is user-provided CLI input
+	if err != nil {
+		return fmt.Errorf("open import input: %w", err)
+	}
+	defer func() { _ = in.Close() }()
+	store, err := storeopen.Open(cmd.Context(), target)
+	if err != nil {
+		return err
+	}
+	if err := jsonl.ImportWithOptions(cmd.Context(), in, store, jsonl.ImportOptions{MergeProject: true}); err != nil {
+		_ = store.Close()
+		return err
+	}
+	if err := store.Close(); err != nil {
+		return fmt.Errorf("close merge target: %w", err)
+	}
+	return writeImportSuccess(cmd, target)
+}
+
+func runPostgresJSONLMerge(cmd *cobra.Command, input, target string) error {
+	identity, err := config.CanonicalDSNIdentity(target)
+	if err != nil {
+		return err
+	}
+	pgConfig, err := postgresRestoreConfig(cmd.Context())
+	if err != nil {
+		return err
+	}
+	version, err := pgstore.PeekSchemaVersionWithConfig(cmd.Context(), target, pgConfig)
+	if err != nil {
+		return err
+	}
+	if version == 0 {
+		return &cliError{Message: "merge target does not exist", Kind: kindValidation, ExitCode: ExitValidation}
+	}
+	in, err := os.Open(input) //nolint:gosec // import path is user-provided CLI input
+	if err != nil {
+		return fmt.Errorf("open import input: %w", err)
+	}
+	defer func() { _ = in.Close() }()
+	store, err := pgstore.OpenWithConfig(cmd.Context(), target, pgConfig)
+	if err != nil {
+		return err
+	}
+	if err := jsonl.ImportWithOptions(cmd.Context(), in, store, jsonl.ImportOptions{MergeProject: true}); err != nil {
+		_ = store.Close()
+		return err
+	}
+	if err := store.Close(); err != nil {
+		return fmt.Errorf("close merge target: %w", err)
+	}
+	return writeImportSuccess(cmd, identity)
 }
 
 func runPostgresJSONLImport(cmd *cobra.Command, input, target string, force, newInstance bool) error {

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -179,12 +179,18 @@ func runKataJSONLImport(cmd *cobra.Command, input, target string, force, newInst
 }
 
 func runSQLiteJSONLMerge(cmd *cobra.Command, input, target string) error {
-	exists, err := sqliteFileSetExists(target)
-	if err != nil {
+	if _, err := os.Stat(target); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &cliError{Message: "merge target does not exist", Kind: kindValidation, ExitCode: ExitValidation}
+		}
 		return fmt.Errorf("stat merge target: %w", err)
 	}
-	if !exists {
-		return &cliError{Message: "merge target does not exist", Kind: kindValidation, ExitCode: ExitValidation}
+	version, err := storeopen.PeekSchemaVersion(cmd.Context(), target)
+	if err != nil {
+		return fmt.Errorf("inspect merge target: %w", err)
+	}
+	if version == 0 {
+		return &cliError{Message: "merge target is not initialized", Kind: kindValidation, ExitCode: ExitValidation}
 	}
 	in, err := os.Open(input) //nolint:gosec // import path is user-provided CLI input
 	if err != nil {

--- a/cmd/kata/import_postgres_test.go
+++ b/cmd/kata/import_postgres_test.go
@@ -38,6 +38,9 @@ func TestImportPostgresMergeAfterPurgeAddsOneProjectWithoutChangingExistingProje
 	sourcePurge, err := source.PurgeIssue(ctx, purgedIssue.ID, "fixture-author", nil)
 	require.NoError(t, err)
 	require.NotNil(t, sourcePurge.PurgeResetAfterEventID)
+	_, err = source.ExecContext(ctx, `UPDATE events SET hlc_physical_ms = ?, hlc_counter = ?`,
+		projectMergeHLCSafeBoundary, projectMergeHLCSafeBoundary)
+	require.NoError(t, err)
 	var snapshot bytes.Buffer
 	require.NoError(t, jsonl.Export(ctx, source, &snapshot, jsonl.ExportOptions{
 		ProjectID: importedProject.ID, IncludeDeleted: true,
@@ -108,6 +111,9 @@ func TestImportPostgresMergeAfterPurgeAddsOneProjectWithoutChangingExistingProje
 	require.NoError(t, err)
 	assert.Greater(t, postMergeEvent.ID, mergedSourceReset,
 		"a post-merge event must remain visible beyond the imported purge reset cursor")
+	assert.Equal(t, projectMergeHLCSafeBoundary, postMergeEvent.HLCPhysicalMS)
+	assert.Equal(t, projectMergeHLCSafeBoundary+1, postMergeEvent.HLCCounter,
+		"a post-merge event must advance beyond the imported HLC boundary")
 	postMergeIssue, _, err := merged.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: gotImported.ID, Title: "after merge", Author: "fixture-author",
 	})

--- a/cmd/kata/import_postgres_test.go
+++ b/cmd/kata/import_postgres_test.go
@@ -98,16 +98,22 @@ func TestImportPostgresMergeAfterPurgeAddsOneProjectWithoutChangingExistingProje
 	require.NoError(t, err)
 	require.NotEmpty(t, mergedEvents)
 	assert.Greater(t, mergedEvents[0].ID, int64(3000), "merge events must remain visible beyond the purge reset cursor")
-	var mergedSourceReset int64
+	var mergedPurgedIssueID, mergedSourceReset int64
 	require.NoError(t, admin.QueryRowContext(ctx,
-		`SELECT purge_reset_after_event_id FROM kata.purge_log WHERE issue_uid = $1`, purgedIssue.UID).
-		Scan(&mergedSourceReset))
+		`SELECT purged_issue_id, purge_reset_after_event_id FROM kata.purge_log WHERE issue_uid = $1`, purgedIssue.UID).
+		Scan(&mergedPurgedIssueID, &mergedSourceReset))
 	_, postMergeEvent, err := merged.CreateComment(ctx, db.CreateCommentParams{
 		IssueID: gotImportedIssue.ID, Author: "fixture-author", Body: "after merge",
 	})
 	require.NoError(t, err)
 	assert.Greater(t, postMergeEvent.ID, mergedSourceReset,
 		"a post-merge event must remain visible beyond the imported purge reset cursor")
+	postMergeIssue, _, err := merged.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: gotImported.ID, Title: "after merge", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	assert.Greater(t, postMergeIssue.ID, mergedPurgedIssueID,
+		"a post-merge issue must not reuse the imported tombstone's numeric ID")
 }
 
 func TestImportPostgresTargetCreatesThenAtomicallyReplacesSnapshot(t *testing.T) {

--- a/cmd/kata/import_postgres_test.go
+++ b/cmd/kata/import_postgres_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -13,8 +14,101 @@ import (
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/storeopen"
+	"go.kenn.io/kata/internal/jsonl"
 	"go.kenn.io/kata/internal/testenv"
 )
+
+func TestImportPostgresMergeAfterPurgeAddsOneProjectWithoutChangingExistingProject(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires postgres testcontainer")
+	}
+	home := setupKataEnv(t)
+	ctx := context.Background()
+	source := openKataTestDB(t, filepath.Join(home, "source-merge.db"))
+	importedProject, err := source.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	importedIssue, _, err := source.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: importedProject.ID, Title: "imported issue", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	purgedIssue, _, err := source.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: importedProject.ID, Title: "purged issue", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	sourcePurge, err := source.PurgeIssue(ctx, purgedIssue.ID, "fixture-author", nil)
+	require.NoError(t, err)
+	require.NotNil(t, sourcePurge.PurgeResetAfterEventID)
+	var snapshot bytes.Buffer
+	require.NoError(t, jsonl.Export(ctx, source, &snapshot, jsonl.ExportOptions{
+		ProjectID: importedProject.ID, IncludeDeleted: true,
+	}))
+	require.NoError(t, source.Close())
+	input := filepath.Join(home, "spoke-project.jsonl")
+	require.NoError(t, os.WriteFile(input, snapshot.Bytes(), 0o600))
+
+	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	t.Cleanup(cleanup)
+	target, err := storeopen.Open(ctx, dsn)
+	require.NoError(t, err)
+	existingProject, err := target.CreateProject(ctx, "existing-project")
+	require.NoError(t, err)
+	existingIssue, _, err := target.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: existingProject.ID, Title: "existing issue", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	admin, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.Close() })
+	_, err = admin.ExecContext(ctx, `SELECT setval(pg_get_serial_sequence('kata.issues','id'), 2000, true)`)
+	require.NoError(t, err)
+	_, err = admin.ExecContext(ctx, `
+		INSERT INTO kata.project_purge_log(
+			uid, origin_instance_uid, project_id, project_name,
+			issue_count, event_count, alias_count, comment_count, link_count,
+			label_count, claim_count, pending_claim_request_count,
+			purge_reset_after_event_id, actor
+		) VALUES ($1, $2, $3, $4, 0, 0, 0, 0, 0, 0, 0, 0, 3000, $5)`,
+		"01H00000000000000000000009", target.InstanceUID(), existingProject.ID,
+		existingProject.Name, "fixture-author")
+	require.NoError(t, err)
+	require.NoError(t, target.Close())
+
+	_, err = runCmdOutput(t, nil,
+		"import", "--merge", "--input", input, "--target", dsn)
+	require.NoError(t, err)
+
+	merged, err := storeopen.Open(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = merged.Close() })
+	gotExisting, err := merged.ProjectByUID(ctx, existingProject.UID)
+	require.NoError(t, err)
+	assert.Equal(t, existingProject.Name, gotExisting.Name)
+	_, err = merged.IssueByUID(ctx, existingIssue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	gotImported, err := merged.ProjectByUID(ctx, importedProject.UID)
+	require.NoError(t, err)
+	gotImportedIssue, err := merged.IssueByUID(ctx, importedIssue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	assert.Equal(t, gotImported.ID, gotImportedIssue.ProjectID)
+	assert.Equal(t, importedIssue.ShortID, gotImportedIssue.ShortID)
+	assert.Greater(t, gotImportedIssue.ID, int64(2000), "merge must allocate above the target sequence high-water mark")
+	mergedEvents, err := merged.EventsAfter(ctx, db.EventsAfterParams{
+		ProjectID: gotImported.ID, Limit: 100,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, mergedEvents)
+	assert.Greater(t, mergedEvents[0].ID, int64(3000), "merge events must remain visible beyond the purge reset cursor")
+	var mergedSourceReset int64
+	require.NoError(t, admin.QueryRowContext(ctx,
+		`SELECT purge_reset_after_event_id FROM kata.purge_log WHERE issue_uid = $1`, purgedIssue.UID).
+		Scan(&mergedSourceReset))
+	_, postMergeEvent, err := merged.CreateComment(ctx, db.CreateCommentParams{
+		IssueID: gotImportedIssue.ID, Author: "fixture-author", Body: "after merge",
+	})
+	require.NoError(t, err)
+	assert.Greater(t, postMergeEvent.ID, mergedSourceReset,
+		"a post-merge event must remain visible beyond the imported purge reset cursor")
+}
 
 func TestImportPostgresTargetCreatesThenAtomicallyReplacesSnapshot(t *testing.T) {
 	if testing.Short() {

--- a/cmd/kata/import_postgres_test.go
+++ b/cmd/kata/import_postgres_test.go
@@ -59,10 +59,16 @@ func TestImportPostgresMergeAfterPurgeAddsOneProjectWithoutChangingExistingProje
 		ProjectID: existingProject.ID, Title: "existing issue", Author: "fixture-author",
 	})
 	require.NoError(t, err)
+	_, _, err = target.CreateComment(ctx, db.CreateCommentParams{
+		IssueID: existingIssue.ID, Author: "fixture-author", Body: "existing comment",
+	})
+	require.NoError(t, err)
 	admin, err := sql.Open("pgx", dsn)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = admin.Close() })
 	_, err = admin.ExecContext(ctx, `SELECT setval(pg_get_serial_sequence('kata.issues','id'), 2000, true)`)
+	require.NoError(t, err)
+	_, err = admin.ExecContext(ctx, `SELECT setval(pg_get_serial_sequence('kata.comments','id'), 4000, true)`)
 	require.NoError(t, err)
 	_, err = admin.ExecContext(ctx, `
 		INSERT INTO kata.project_purge_log(
@@ -105,10 +111,12 @@ func TestImportPostgresMergeAfterPurgeAddsOneProjectWithoutChangingExistingProje
 	require.NoError(t, admin.QueryRowContext(ctx,
 		`SELECT purged_issue_id, purge_reset_after_event_id FROM kata.purge_log WHERE issue_uid = $1`, purgedIssue.UID).
 		Scan(&mergedPurgedIssueID, &mergedSourceReset))
-	_, postMergeEvent, err := merged.CreateComment(ctx, db.CreateCommentParams{
+	postMergeComment, postMergeEvent, err := merged.CreateComment(ctx, db.CreateCommentParams{
 		IssueID: gotImportedIssue.ID, Author: "fixture-author", Body: "after merge",
 	})
 	require.NoError(t, err)
+	assert.Greater(t, postMergeComment.ID, int64(4000),
+		"a post-merge comment must not reuse the target sequence's reserved IDs")
 	assert.Greater(t, postMergeEvent.ID, mergedSourceReset,
 		"a post-merge event must remain visible beyond the imported purge reset cursor")
 	assert.Equal(t, projectMergeHLCSafeBoundary, postMergeEvent.HLCPhysicalMS)

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,8 @@ import (
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/jsonl"
 )
+
+const projectMergeHLCSafeBoundary = int64(math.MaxInt64 / 2)
 
 func setupImportTest(t *testing.T) (home, input, target string) {
 	t.Helper()
@@ -187,6 +190,9 @@ func TestImportMergeAfterPurgeAddsOneProjectWithoutChangingExistingProject(t *te
 	sourcePurge, err := source.PurgeIssue(ctx, purgedIssue.ID, "fixture-author", nil)
 	require.NoError(t, err)
 	require.NotNil(t, sourcePurge.PurgeResetAfterEventID)
+	_, err = source.ExecContext(ctx, `UPDATE events SET hlc_physical_ms = ?, hlc_counter = ?`,
+		projectMergeHLCSafeBoundary, projectMergeHLCSafeBoundary)
+	require.NoError(t, err)
 	sourceEvents, err := source.EventsAfter(ctx, db.EventsAfterParams{
 		ProjectID: importedProject.ID, Limit: 100,
 	})
@@ -279,6 +285,9 @@ func TestImportMergeAfterPurgeAddsOneProjectWithoutChangingExistingProject(t *te
 	require.NoError(t, err)
 	assert.Greater(t, postMergeEvent.ID, mergedSourceReset,
 		"a post-merge event must remain visible beyond the imported purge reset cursor")
+	assert.Equal(t, projectMergeHLCSafeBoundary, postMergeEvent.HLCPhysicalMS)
+	assert.Equal(t, projectMergeHLCSafeBoundary+1, postMergeEvent.HLCCounter,
+		"a post-merge event must advance beyond the imported HLC boundary")
 	postMergeIssue, _, err := merged.CreateIssue(ctx, db.CreateIssueParams{
 		ProjectID: gotImported.ID, Title: "after merge", Author: "fixture-author",
 	})

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -109,6 +109,221 @@ func TestImportRejectsExistingTargetWithoutForce(t *testing.T) {
 	assert.Contains(t, ce.Message, "target already exists")
 }
 
+func TestImportMergeRejectsReplacementFlags(t *testing.T) {
+	setupKataEnv(t)
+	for _, incompatible := range []string{"--force", "--new-instance"} {
+		t.Run(incompatible, func(t *testing.T) {
+			_, err := runCmdOutput(t, nil,
+				"import", "--merge", incompatible, "--input", "snapshot.jsonl", "--target", "target.db")
+			ce := requireCLIError(t, err, ExitValidation)
+			assert.Contains(t, ce.Message, incompatible+" cannot be combined with --merge")
+		})
+	}
+}
+
+func TestImportMergeAfterPurgeAddsOneProjectWithoutChangingExistingProject(t *testing.T) {
+	home := setupKataEnv(t)
+	ctx := context.Background()
+
+	sourcePath := filepath.Join(home, "source.db")
+	source := openKataTestDB(t, sourcePath)
+	importedProject, err := source.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	importedIssue, _, err := source.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: importedProject.ID, Title: "imported issue", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	_, _, err = source.CreateComment(ctx, db.CreateCommentParams{
+		IssueID: importedIssue.ID, Author: "fixture-author", Body: "imported comment",
+	})
+	require.NoError(t, err)
+	_, err = source.AddLabel(ctx, importedIssue.ID, "portable", "fixture-author")
+	require.NoError(t, err)
+	purgedIssue, _, err := source.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: importedProject.ID, Title: "purged issue", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	sourcePurge, err := source.PurgeIssue(ctx, purgedIssue.ID, "fixture-author", nil)
+	require.NoError(t, err)
+	require.NotNil(t, sourcePurge.PurgeResetAfterEventID)
+	sourceEvents, err := source.EventsAfter(ctx, db.EventsAfterParams{
+		ProjectID: importedProject.ID, Limit: 100,
+	})
+	require.NoError(t, err)
+	var snapshot bytes.Buffer
+	require.NoError(t, jsonl.Export(ctx, source, &snapshot, jsonl.ExportOptions{
+		ProjectID: importedProject.ID, IncludeDeleted: true,
+	}))
+	require.NoError(t, source.Close())
+	input := filepath.Join(home, "spoke-project.jsonl")
+	require.NoError(t, os.WriteFile(input, snapshot.Bytes(), 0o600))
+
+	target := filepath.Join(home, "target.db")
+	targetStore := openKataTestDB(t, target)
+	existingProject, err := targetStore.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	existingIssue, _, err := targetStore.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: existingProject.ID, Title: "existing issue", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	targetEvents, err := targetStore.EventsAfter(ctx, db.EventsAfterParams{
+		ProjectID: existingProject.ID, Limit: 100,
+	})
+	require.NoError(t, err)
+	_, err = targetStore.ExecContext(ctx, `UPDATE sqlite_sequence SET seq = 2000 WHERE name = 'issues'`)
+	require.NoError(t, err)
+	_, err = targetStore.ExecContext(ctx, `
+		INSERT INTO project_purge_log(
+			uid, origin_instance_uid, project_id, project_name,
+			issue_count, event_count, alias_count, comment_count, link_count,
+			label_count, claim_count, pending_claim_request_count,
+			purge_reset_after_event_id, actor
+		) VALUES (?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, 3000, ?)`,
+		"01H00000000000000000000009", targetStore.InstanceUID(), existingProject.ID,
+		existingProject.Name, "fixture-author")
+	require.NoError(t, err)
+	require.NoError(t, targetStore.Close())
+
+	out, err := runCmdOutput(t, nil,
+		"import", "--merge", "--input", input, "--target", target)
+	require.NoError(t, err)
+	assert.Contains(t, out, target)
+
+	merged := openKataTestDB(t, target)
+	t.Cleanup(func() { _ = merged.Close() })
+	gotExisting, err := merged.ProjectByUID(ctx, existingProject.UID)
+	require.NoError(t, err)
+	assert.Equal(t, existingProject.Name, gotExisting.Name)
+	gotExistingIssue, err := merged.IssueByUID(ctx, existingIssue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	assert.Equal(t, "existing issue", gotExistingIssue.Title)
+	gotImported, err := merged.ProjectByUID(ctx, importedProject.UID)
+	require.NoError(t, err)
+	assert.NotEqual(t, importedProject.ID, gotImported.ID, "colliding numeric project ID must be remapped")
+	assert.Equal(t, "spoke-project-2", gotImported.Name)
+	gotImportedIssue, err := merged.IssueByUID(ctx, importedIssue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	assert.Greater(t, gotImportedIssue.ID, int64(2000), "merge must allocate above the target sequence high-water mark")
+	assert.Equal(t, gotImported.ID, gotImportedIssue.ProjectID)
+	assert.Equal(t, importedIssue.ShortID, gotImportedIssue.ShortID)
+	comments, err := merged.CommentsByIssue(ctx, gotImportedIssue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Equal(t, "imported comment", comments[0].Body)
+	labels, err := merged.LabelsByIssue(ctx, gotImportedIssue.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+	assert.Equal(t, "portable", labels[0].Label)
+	mergedEvents, err := merged.EventsAfter(ctx, db.EventsAfterParams{
+		ProjectID: gotImported.ID, Limit: 100,
+	})
+	require.NoError(t, err)
+	require.Len(t, mergedEvents, len(sourceEvents))
+	for i := range sourceEvents {
+		assert.Equal(t, sourceEvents[i].UID, mergedEvents[i].UID)
+		if i > 0 {
+			assert.Greater(t, mergedEvents[i].ID, mergedEvents[i-1].ID)
+		}
+	}
+	require.NotEmpty(t, targetEvents)
+	assert.Greater(t, mergedEvents[0].ID, targetEvents[len(targetEvents)-1].ID)
+	assert.Greater(t, mergedEvents[0].ID, int64(3000), "merge events must remain visible beyond the purge reset cursor")
+	var mergedSourceReset int64
+	require.NoError(t, merged.QueryRowContext(ctx,
+		`SELECT purge_reset_after_event_id FROM purge_log WHERE issue_uid = ?`, purgedIssue.UID).
+		Scan(&mergedSourceReset))
+	_, postMergeEvent, err := merged.CreateComment(ctx, db.CreateCommentParams{
+		IssueID: gotImportedIssue.ID, Author: "fixture-author", Body: "after merge",
+	})
+	require.NoError(t, err)
+	assert.Greater(t, postMergeEvent.ID, mergedSourceReset,
+		"a post-merge event must remain visible beyond the imported purge reset cursor")
+	require.NoError(t, merged.Close())
+
+	_, err = runCmdOutput(t, nil,
+		"import", "--merge", "--input", input, "--target", target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project UID")
+	assert.Contains(t, err.Error(), "already exists")
+
+	unchanged := openKataTestDB(t, target)
+	t.Cleanup(func() { _ = unchanged.Close() })
+	_, err = unchanged.IssueByUID(ctx, existingIssue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+}
+
+func TestImportMergeRefusesMultiProjectSnapshotWithoutMutation(t *testing.T) {
+	_, input, target := setupImportTest(t)
+	ctx := context.Background()
+	targetStore := openKataTestDB(t, target)
+	existing, err := targetStore.CreateProject(ctx, "existing-project")
+	require.NoError(t, err)
+	require.NoError(t, targetStore.Close())
+
+	_, err = runCmdOutput(t, nil,
+		"import", "--merge", "--input", input, "--target", target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project merge requires one non-system project")
+
+	unchanged := openKataTestDB(t, target)
+	t.Cleanup(func() { _ = unchanged.Close() })
+	got, err := unchanged.ProjectByUID(ctx, existing.UID)
+	require.NoError(t, err)
+	assert.Equal(t, existing.Name, got.Name)
+}
+
+func TestImportMergeSkipsCrossProjectLink(t *testing.T) {
+	home := setupKataEnv(t)
+	ctx := context.Background()
+	source := openKataTestDB(t, filepath.Join(home, "source-links.db"))
+	importedProject, err := source.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	peerProject, err := source.CreateProject(ctx, "hub-project")
+	require.NoError(t, err)
+	importedIssue, _, err := source.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: importedProject.ID, Title: "imported issue", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	peerIssue, _, err := source.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: peerProject.ID, Title: "peer issue", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	_, err = source.CreateLink(ctx, db.CreateLinkParams{
+		FromIssueID: importedIssue.ID, ToIssueID: peerIssue.ID,
+		Type: "blocks", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	var importedSnapshot, peerSnapshot bytes.Buffer
+	require.NoError(t, jsonl.Export(ctx, source, &importedSnapshot, jsonl.ExportOptions{
+		ProjectID: importedProject.ID, IncludeDeleted: true,
+	}))
+	require.NoError(t, jsonl.Export(ctx, source, &peerSnapshot, jsonl.ExportOptions{
+		ProjectID: peerProject.ID, IncludeDeleted: true,
+	}))
+	require.NoError(t, source.Close())
+
+	target := filepath.Join(home, "target-links.db")
+	targetStore := openKataTestDB(t, target)
+	require.NoError(t, jsonl.ImportWithOptions(ctx, bytes.NewReader(peerSnapshot.Bytes()), targetStore,
+		jsonl.ImportOptions{RequireFreshTarget: true}))
+	require.NoError(t, targetStore.Close())
+	input := filepath.Join(home, "spoke-links.jsonl")
+	require.NoError(t, os.WriteFile(input, importedSnapshot.Bytes(), 0o600))
+
+	_, err = runCmdOutput(t, nil,
+		"import", "--merge", "--input", input, "--target", target)
+	require.NoError(t, err)
+
+	merged := openKataTestDB(t, target)
+	t.Cleanup(func() { _ = merged.Close() })
+	gotImported, err := merged.IssueByUID(ctx, importedIssue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	gotPeer, err := merged.IssueByUID(ctx, peerIssue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	_, err = merged.LinkByEndpoints(ctx, gotImported.ID, gotPeer.ID, "blocks")
+	require.ErrorIs(t, err, db.ErrNotFound)
+}
+
 func TestImportRejectsExistingTargetSidecarWithoutForce(t *testing.T) {
 	_, input, target := setupImportTest(t)
 	require.NoError(t, os.WriteFile(target+"-wal", []byte("stale-wal"), 0o600))

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -121,6 +121,47 @@ func TestImportMergeRejectsReplacementFlags(t *testing.T) {
 	}
 }
 
+func TestImportMergeRejectsUninitializedSQLiteTargetsWithoutMutation(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		targetSuffix  string
+		wantErrorText string
+	}{
+		{name: "empty main file", wantErrorText: "merge target is not initialized"},
+		{name: "orphan WAL sidecar", targetSuffix: "-wal", wantErrorText: "merge target does not exist"},
+		{name: "orphan SHM sidecar", targetSuffix: "-shm", wantErrorText: "merge target does not exist"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := setupKataEnv(t)
+			ctx := context.Background()
+			source := openKataTestDB(t, filepath.Join(home, "source.db"))
+			project, err := source.CreateProject(ctx, "spoke-project")
+			require.NoError(t, err)
+			var snapshot bytes.Buffer
+			require.NoError(t, jsonl.Export(ctx, source, &snapshot, jsonl.ExportOptions{ProjectID: project.ID}))
+			require.NoError(t, source.Close())
+			input := filepath.Join(home, "spoke-project.jsonl")
+			require.NoError(t, os.WriteFile(input, snapshot.Bytes(), 0o600))
+			target := filepath.Join(home, "target.db")
+			marker := target + tt.targetSuffix
+			require.NoError(t, os.WriteFile(marker, nil, 0o600))
+
+			_, err = runCmdOutput(t, nil,
+				"import", "--merge", "--input", input, "--target", target)
+			ce := requireCLIError(t, err, ExitValidation)
+			assert.Contains(t, ce.Message, tt.wantErrorText)
+
+			if tt.targetSuffix != "" {
+				_, statErr := os.Stat(target)
+				assert.True(t, os.IsNotExist(statErr), "merge must not create a missing main database file")
+			}
+			info, statErr := os.Stat(marker)
+			require.NoError(t, statErr)
+			assert.Zero(t, info.Size(), "merge must not modify the uninitialized target marker")
+		})
+	}
+}
+
 func TestImportMergeAfterPurgeAddsOneProjectWithoutChangingExistingProject(t *testing.T) {
 	home := setupKataEnv(t)
 	ctx := context.Background()

--- a/cmd/kata/import_test.go
+++ b/cmd/kata/import_test.go
@@ -269,16 +269,22 @@ func TestImportMergeAfterPurgeAddsOneProjectWithoutChangingExistingProject(t *te
 	require.NotEmpty(t, targetEvents)
 	assert.Greater(t, mergedEvents[0].ID, targetEvents[len(targetEvents)-1].ID)
 	assert.Greater(t, mergedEvents[0].ID, int64(3000), "merge events must remain visible beyond the purge reset cursor")
-	var mergedSourceReset int64
+	var mergedPurgedIssueID, mergedSourceReset int64
 	require.NoError(t, merged.QueryRowContext(ctx,
-		`SELECT purge_reset_after_event_id FROM purge_log WHERE issue_uid = ?`, purgedIssue.UID).
-		Scan(&mergedSourceReset))
+		`SELECT purged_issue_id, purge_reset_after_event_id FROM purge_log WHERE issue_uid = ?`, purgedIssue.UID).
+		Scan(&mergedPurgedIssueID, &mergedSourceReset))
 	_, postMergeEvent, err := merged.CreateComment(ctx, db.CreateCommentParams{
 		IssueID: gotImportedIssue.ID, Author: "fixture-author", Body: "after merge",
 	})
 	require.NoError(t, err)
 	assert.Greater(t, postMergeEvent.ID, mergedSourceReset,
 		"a post-merge event must remain visible beyond the imported purge reset cursor")
+	postMergeIssue, _, err := merged.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: gotImported.ID, Title: "after merge", Author: "fixture-author",
+	})
+	require.NoError(t, err)
+	assert.Greater(t, postMergeIssue.ID, mergedPurgedIssueID,
+		"a post-merge issue must not reuse the imported tombstone's numeric ID")
 	require.NoError(t, merged.Close())
 
 	_, err = runCmdOutput(t, nil,

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -3,9 +3,10 @@
 `kata export` writes the host-local database as JSONL. It is an offline storage
 operation, not a remote-daemon API: `KATA_SERVER`, a remote workspace target,
 or `--daemon` makes it fail before opening any local database. Run exports on
-the daemon host with that daemon's storage configuration. `kata import`
-rebuilds a database from that file. Use these commands for backups, machine
-moves, and schema cutovers.
+the daemon host with that daemon's storage configuration. `kata import` can
+rebuild a database from that file or add one scoped project snapshot to an
+existing database. Use these commands for backups, selective project restores,
+machine moves, and schema cutovers.
 
 ## Use JSONL exports
 
@@ -46,8 +47,8 @@ The target must not exist unless `--force` is set. To use the restored
 database, stop the daemon, point `KATA_DSN` or `KATA_DB` at the restored file,
 or move it into `KATA_HOME` as `kata.db`, then restart.
 
-`kata import` is not a merge operation. It creates a target database from the
-input snapshot.
+Without `--merge`, `kata import` creates a target database from the input
+snapshot. It does not add records to an existing database.
 
 For Postgres, pass a DSN as the target:
 
@@ -101,36 +102,60 @@ Use `--project` or `--project-id` to scope an export:
 
 ```sh
 kata daemon stop
-kata --project myproj export --output backups/myproj.jsonl
+kata --project example-project export --output backups/example-project.jsonl
 kata daemon start
 ```
 
 Round-trip into a fresh database:
 
 ```sh
-kata import --input backups/myproj.jsonl --target /tmp/myproj-only.db
+kata import --input backups/example-project.jsonl \
+  --target /tmp/example-project-only.db
 ```
 
 This is useful for archiving one project, handing history to a collaborator who
 will set up a fresh kata install, or moving one project to another host.
 
-Links may span projects, and a scoped export only contains the named
-project's issues — so the envelope can carry a link edge whose peer issue is
-absent. Import skips those links (and any import-mapping records that
-reference them) instead of failing, and prints an aggregate
-`note: skipped N link record(s)…` to stderr. Importing a fuller envelope that
-contains both endpoints later recreates the skipped edges.
+Links may span projects, and a scoped export only contains the named project's
+issues. A fresh restore or project merge skips links whose peer is outside the
+snapshot, along with import-mapping records that reference those links, and
+prints an aggregate `note: skipped N link record(s)…` to stderr. A merge does
+not connect an imported issue to an existing project's issue, even when that
+peer is already in the target. This keeps the scoped import from changing
+another project's dependency graph. A full-database snapshot preserves links
+when it contains both endpoints.
 
-What does not work today:
+## Merge a single-project snapshot
 
-- importing a per-project snapshot into an existing populated database;
-- stitching multiple per-project files into one existing database;
-- re-importing a snapshot on top of itself to refresh incrementally.
+Use `--merge` to add a scoped snapshot to an existing SQLite or Postgres
+database without replacing its other projects:
 
-For multi-project backups, take a full-database export. A per-project merge
-import (applying one project's snapshot to an existing database without
-disturbing other projects) is planned; see
-[kenn-io/kata#42](https://github.com/kenn-io/kata/issues/42).
+```sh
+kata daemon stop
+kata import --merge --input backups/example-project.jsonl \
+  --target ~/.kata/kata.db
+kata daemon start
+```
+
+The target must already exist, and every daemon using it must be stopped. For
+Postgres, pass the initialized database's schema-owner DSN as `--target`.
+`--force` and `--new-instance` cannot be combined with `--merge`.
+
+The merge must contain exactly one non-system project. It runs in one
+transaction, allocates new numeric database IDs, and preserves the project's
+UIDs, issue short IDs, and event identity. Existing projects remain unchanged.
+If another project already has the imported name, kata assigns the next
+available suffix, such as `example-project-2`.
+
+The import is refused without mutation if an imported project or object UID
+already exists. As a result, re-importing the same snapshot is not an
+incremental refresh. Run one merge per scoped snapshot when restoring several
+projects; use a full-database export when cross-project links must also be
+restored.
+
+Imported issue-sync bindings remain disabled until re-enabled locally. Imported
+federation state is discarded so the project must join federation again with
+credentials for the target environment.
 
 ## Beads import
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -700,6 +700,7 @@ kata export [--project NAME] [--project-id N] [--output PATH]
 kata export --allow-running-daemon --output PATH
 
 kata import --input PATH --target PATH_OR_POSTGRES_DSN [--force]
+kata import --merge --input PATH --target PATH_OR_POSTGRES_DSN
 kata import --source-format beads
 ```
 
@@ -707,12 +708,21 @@ Export reads host-local storage directly. It refuses `--daemon` and configured
 remote server targets rather than silently exporting an unrelated local
 database; run it on the daemon host with the intended storage configuration.
 
-The kata-format `import` creates a fresh SQLite database at a target path or a
-fresh Postgres `kata` schema at a Postgres DSN; it is not a merge operation. An
-initialized target requires `--force`, which atomically replaces kata-owned
-state. The `--source-format beads` form is different: it drives the `bd` CLI
-and merges into the current project. See
-[Migrating from Beads](../guide/migrating-from-beads.md).
+Without `--merge`, the kata-format `import` creates a fresh SQLite database at a
+target path or a fresh Postgres `kata` schema at a Postgres DSN. An initialized
+target requires `--force`, which atomically replaces kata-owned state.
+
+`--merge` instead adds exactly one non-system project snapshot to an existing
+SQLite or Postgres target. It remaps numeric database IDs while preserving
+portable identities and leaves unrelated projects unchanged. A multi-project
+snapshot or any imported UID that already exists in the target causes the
+transaction to be refused. Stop every daemon using the target first. See
+[Backup and restore](../operations/backup-restore.md) for name collisions,
+cross-project links, and credential-state handling.
+
+The `--source-format beads` form is different: it drives the `bd` CLI and
+merges into the current project. See [Migrating from
+Beads](../guide/migrating-from-beads.md).
 
 ## Remote and identity tokens
 

--- a/internal/db/import_types.go
+++ b/internal/db/import_types.go
@@ -40,6 +40,10 @@ type ImportOptions struct {
 	// schema cutover; normal JSONL restore leaves restored bindings disabled
 	// until a local operator re-enables them.
 	PreserveIssueSyncBindingEnabled bool
+
+	// MergeProject remaps a single project-scoped replay onto fresh numeric IDs
+	// and inserts it without clearing existing domain state.
+	MergeProject bool
 }
 
 // ImportRecord is one normalized, current-shape import row: a Kind discriminator

--- a/internal/db/pgstore/import_replay.go
+++ b/internal/db/pgstore/import_replay.go
@@ -116,7 +116,7 @@ func (s *Store) importReplayTx(
 			return err
 		}
 	}
-	if err := s.reconcileReplayIdentities(ctx, tx, sequenceFloors); err != nil {
+	if err := s.reconcileReplayIdentities(ctx, tx, sequenceFloors, opts.MergeProject); err != nil {
 		return err
 	}
 	return nil

--- a/internal/db/pgstore/import_replay.go
+++ b/internal/db/pgstore/import_replay.go
@@ -50,9 +50,18 @@ func (s *Store) importReplayTx(
 	records []db.ImportRecord,
 	opts db.ImportOptions,
 ) error {
-	preservedInstanceUID, err := s.pgReplayClearTarget(ctx, tx, opts)
-	if err != nil {
-		return err
+	preservedInstanceUID := s.instanceUID
+	var err error
+	if opts.MergeProject {
+		records, err = s.prepareProjectMergeTx(ctx, tx, records)
+		if err != nil {
+			return err
+		}
+	} else {
+		preservedInstanceUID, err = s.pgReplayClearTarget(ctx, tx, opts)
+		if err != nil {
+			return err
+		}
 	}
 
 	var missingPeers, duplicates, skippedMappings int
@@ -99,11 +108,13 @@ func (s *Store) importReplayTx(
 		preservedInstanceUID); err != nil {
 		return fmt.Errorf("restore target instance_uid: %w", mapSQLError(err, nil))
 	}
-	if err := s.replayAPITokens(ctx, tx); err != nil {
-		return err
-	}
-	if err := pgReplayRecordSchemaVersion(ctx, tx); err != nil {
-		return err
+	if !opts.MergeProject {
+		if err := s.replayAPITokens(ctx, tx); err != nil {
+			return err
+		}
+		if err := pgReplayRecordSchemaVersion(ctx, tx); err != nil {
+			return err
+		}
 	}
 	if err := s.reconcileReplayIdentities(ctx, tx, sequenceFloors); err != nil {
 		return err

--- a/internal/db/pgstore/import_replay_events.go
+++ b/internal/db/pgstore/import_replay_events.go
@@ -287,12 +287,21 @@ func (s *Store) reconcileReplayIdentities(
 	ctx context.Context,
 	tx *sql.Tx,
 	floors map[string]int64,
+	preserveTargetHighWater bool,
 ) error {
 	for _, table := range replayIdentityTables {
 		var maxID int64
-		query := `SELECT COALESCE(MAX(id),0) FROM ` + quoteIdentifier(table)
-		if err := tx.QueryRowContext(ctx, query).Scan(&maxID); err != nil {
-			return fmt.Errorf("max id for %s: %w", table, mapSQLError(err, nil))
+		if preserveTargetHighWater {
+			var err error
+			maxID, err = pgIdentityHighWater(ctx, tx, table)
+			if err != nil {
+				return err
+			}
+		} else {
+			query := `SELECT COALESCE(MAX(id),0) FROM ` + quoteIdentifier(table)
+			if err := tx.QueryRowContext(ctx, query).Scan(&maxID); err != nil {
+				return fmt.Errorf("max id for %s: %w", table, mapSQLError(err, nil))
+			}
 		}
 		floor := floors[table]
 		if maxID > floor {

--- a/internal/db/pgstore/import_replay_merge.go
+++ b/internal/db/pgstore/import_replay_merge.go
@@ -1,0 +1,164 @@
+package pgstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+func (s *Store) prepareProjectMergeTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	records []db.ImportRecord,
+) ([]db.ImportRecord, error) {
+	if err := acquireExclusiveServingLease(ctx, tx, s.schema); err != nil {
+		return nil, fmt.Errorf("quiesce serving daemons for project merge: %w", err)
+	}
+	if err := acquireSchemaMigrationLock(ctx, tx); err != nil {
+		return nil, fmt.Errorf("lock schema migrations for project merge: %w", mapSQLError(err, nil))
+	}
+	tables, err := schemaTableNames(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	quoted := make([]string, len(tables))
+	for i, table := range tables {
+		quoted[i] = quoteIdentifier(table)
+	}
+	if len(quoted) > 0 {
+		if _, err := tx.ExecContext(ctx,
+			`LOCK TABLE `+strings.Join(quoted, ", ")+` IN SHARE ROW EXCLUSIVE MODE`); err != nil {
+			return nil, fmt.Errorf("lock project merge target: %w", mapSQLError(err, nil))
+		}
+	}
+	offsets, err := pgProjectMergeOffsets(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	prepared, err := db.PrepareProjectMergeRecords(records, offsets,
+		func(uid string) (int64, bool, error) {
+			var id int64
+			err := tx.QueryRowContext(ctx, `SELECT id FROM issues WHERE uid=$1`, uid).Scan(&id)
+			if errors.Is(err, sql.ErrNoRows) {
+				return 0, false, nil
+			}
+			return id, err == nil, mapSQLError(err, nil)
+		})
+	if err != nil {
+		return nil, err
+	}
+	if err := refusePGProjectMergeUIDCollisions(ctx, tx, records); err != nil {
+		return nil, err
+	}
+	return prepared, nil
+}
+
+func pgProjectMergeOffsets(ctx context.Context, tx *sql.Tx) (db.ProjectMergeOffsets, error) {
+	var offsets db.ProjectMergeOffsets
+	tables := []struct {
+		name string
+		dest *int64
+	}{
+		{"projects", &offsets.TargetProjectID},
+		{"project_aliases", &offsets.Alias},
+		{"issue_sync_bindings", &offsets.SyncBinding},
+		{"recurrences", &offsets.Recurrence},
+		{"issues", &offsets.Issue},
+		{"comments", &offsets.Comment},
+		{"links", &offsets.Link},
+		{"import_mappings", &offsets.ImportMapping},
+		{"federation_quarantine", &offsets.Quarantine},
+		{"federation_enrollments", &offsets.Enrollment},
+		{"issue_claims", &offsets.Claim},
+		{"pending_claim_requests", &offsets.PendingClaim},
+		{"events", &offsets.Event},
+		{"purge_log", &offsets.PurgeLog},
+		{"project_purge_log", &offsets.ProjectPurgeLog},
+	}
+	for _, table := range tables {
+		highWater, err := pgIdentityHighWater(ctx, tx, table.name)
+		if err != nil {
+			return db.ProjectMergeOffsets{}, err
+		}
+		*table.dest = highWater
+	}
+	if offsets.TargetProjectID == math.MaxInt64 {
+		return db.ProjectMergeOffsets{}, errors.New("project merge project ID overflows")
+	}
+	offsets.TargetProjectID++
+	var resetHighWater int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT GREATEST(
+			COALESCE((SELECT MAX(purge_reset_after_event_id) FROM purge_log), 0),
+			COALESCE((SELECT MAX(purge_reset_after_event_id) FROM project_purge_log), 0)
+		)`).Scan(&resetHighWater); err != nil {
+		return db.ProjectMergeOffsets{}, fmt.Errorf("inspect project merge reset cursor: %w", mapSQLError(err, nil))
+	}
+	if resetHighWater > offsets.Event {
+		offsets.Event = resetHighWater
+	}
+	return offsets, nil
+}
+
+func pgIdentityHighWater(ctx context.Context, tx *sql.Tx, table string) (int64, error) {
+	query := `SELECT GREATEST(
+		(SELECT COALESCE(MAX(id), 0) FROM ` + quoteIdentifier(table) + `),
+		COALESCE((
+			SELECT s.last_value
+			FROM pg_sequences s
+			WHERE s.schemaname = current_schema()
+			  AND to_regclass(format('%I.%I', s.schemaname, s.sequencename)) =
+			      to_regclass(pg_get_serial_sequence(format('%I.%I', current_schema(), $1::text), 'id'))
+		), 0)
+	)`
+	var highWater int64
+	if err := tx.QueryRowContext(ctx, query, table).Scan(&highWater); err != nil {
+		return 0, fmt.Errorf("inspect project merge %s ID range: %w", table, mapSQLError(err, nil))
+	}
+	return highWater, nil
+}
+
+func refusePGProjectMergeUIDCollisions(ctx context.Context, tx *sql.Tx, records []db.ImportRecord) error {
+	type uidCheck struct{ table, column, kind, uid string }
+	checks := make([]uidCheck, 0, len(records))
+	for _, record := range records {
+		switch {
+		case record.Project != nil:
+			checks = append(checks, uidCheck{"projects", "uid", "project", record.Project.UID})
+		case record.Issue != nil:
+			checks = append(checks, uidCheck{"issues", "uid", "issue", record.Issue.UID})
+		case record.Comment != nil:
+			checks = append(checks, uidCheck{"comments", "uid", "comment", record.Comment.UID})
+		case record.Recurrence != nil:
+			checks = append(checks, uidCheck{"recurrences", "uid", "recurrence", record.Recurrence.UID})
+		case record.IssueClaim != nil:
+			checks = append(checks, uidCheck{"issue_claims", "claim_uid", "claim", record.IssueClaim.ClaimUID})
+		case record.PendingClaimRequest != nil:
+			checks = append(checks, uidCheck{"pending_claim_requests", "request_uid", "pending claim", record.PendingClaimRequest.RequestUID})
+		case record.Event != nil:
+			checks = append(checks, uidCheck{"events", "uid", "event", record.Event.UID})
+		case record.PurgeLog != nil:
+			checks = append(checks, uidCheck{"purge_log", "uid", "purge log", record.PurgeLog.UID})
+		}
+	}
+	for _, check := range checks {
+		if check.uid == "" {
+			continue
+		}
+		query := `SELECT EXISTS (SELECT 1 FROM ` + quoteIdentifier(check.table) +
+			` WHERE ` + quoteIdentifier(check.column) + `=$1)`
+		var exists bool
+		if err := tx.QueryRowContext(ctx, query, check.uid).Scan(&exists); err != nil {
+			return fmt.Errorf("check project merge %s UID: %w", check.kind, mapSQLError(err, nil))
+		}
+		if exists {
+			return fmt.Errorf("project merge refused: %s UID %q already exists", check.kind, check.uid)
+		}
+	}
+	return nil
+}

--- a/internal/db/project_merge.go
+++ b/internal/db/project_merge.go
@@ -108,7 +108,7 @@ func PrepareProjectMergeRecords(
 	}
 	projectID := project.ID
 	out := make([]ImportRecord, 0, len(recs)-2)
-	var eventSequenceFloor int64
+	var issueSequenceFloor, eventSequenceFloor int64
 	for _, rec := range recs {
 		if rec.Kind == ImportKindMeta {
 			continue
@@ -230,6 +230,9 @@ func PrepareProjectMergeRecords(
 				if err == nil {
 					cloned.PurgeLog.PurgedIssueID, err = addMergeOffset(cloned.PurgeLog.PurgedIssueID, offsets.Issue, cloned.Kind+" issue")
 				}
+				if err == nil && cloned.PurgeLog.PurgedIssueID > issueSequenceFloor {
+					issueSequenceFloor = cloned.PurgeLog.PurgedIssueID
+				}
 				if err == nil {
 					err = shiftEventPointers(
 						cloned.PurgeLog.EventsDeletedMinID,
@@ -247,14 +250,23 @@ func PrepareProjectMergeRecords(
 			return nil, fmt.Errorf("project merge does not accept project_purge_log records")
 		case ImportKindSQLiteSequence:
 			// Scoped exports carry whole-database sequence floors. They do not
-			// describe this project, and explicit imported IDs advance the
-			// target sequences during replay.
+			// describe this project. Live imported IDs and the derived tombstone
+			// floors below advance target sequences during replay.
 			continue
 		}
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, cloned)
+	}
+	if issueSequenceFloor > 0 {
+		out = append(out, ImportRecord{
+			Kind: ImportKindSQLiteSequence,
+			Sequence: &SequenceExport{
+				Name: "issues",
+				Seq:  issueSequenceFloor,
+			},
+		})
 	}
 	if eventSequenceFloor > 0 {
 		out = append(out, ImportRecord{

--- a/internal/db/project_merge.go
+++ b/internal/db/project_merge.go
@@ -10,6 +10,10 @@ import (
 // far above any practical database size.
 const maxProjectMergeID int64 = math.MaxInt64 / 2
 
+// Imported clocks use the same lower-half limit so a merge cannot exhaust
+// the signed HLC range needed by later target-wide events.
+const maxProjectMergeHLCValue int64 = maxProjectMergeID
+
 // ProjectMergeOffsets reserves fresh numeric ID ranges in an existing target.
 // TargetProjectID is the exact new project ID; every other value is added to
 // source IDs from the project snapshot.
@@ -48,6 +52,8 @@ func PrepareProjectMergeRecords(
 	}
 	var project *ProjectExport
 	importedIssues := make(map[int64]string)
+	importedRecurrencesByID := make(map[int64]string)
+	importedRecurrencesByUID := make(map[string]int64)
 	for _, rec := range recs {
 		if rec.Project != nil {
 			if rec.Project.UID == SystemProjectUID || rec.Project.Name == SystemProjectName {
@@ -61,6 +67,10 @@ func PrepareProjectMergeRecords(
 		}
 		if rec.Issue != nil {
 			importedIssues[rec.Issue.ID] = rec.Issue.UID
+		}
+		if rec.Recurrence != nil {
+			importedRecurrencesByID[rec.Recurrence.ID] = rec.Recurrence.UID
+			importedRecurrencesByUID[rec.Recurrence.UID] = rec.Recurrence.ID
 		}
 	}
 	if project == nil {
@@ -142,6 +152,24 @@ func PrepareProjectMergeRecords(
 			if err = requireMergeProjectID(cloned.Issue.ProjectID, projectID, cloned.Kind); err == nil {
 				cloned.Issue.ID, err = addMergeOffset(cloned.Issue.ID, offsets.Issue, cloned.Kind)
 				cloned.Issue.ProjectID = offsets.TargetProjectID
+				if err == nil && cloned.Issue.RecurrenceUID != nil {
+					sourceRecurrenceID, ok := importedRecurrencesByUID[*cloned.Issue.RecurrenceUID]
+					if !ok {
+						err = fmt.Errorf("project merge issue recurrence UID %q is not part of the imported project",
+							*cloned.Issue.RecurrenceUID)
+					} else if cloned.Issue.RecurrenceID == nil {
+						cloned.Issue.RecurrenceID = &sourceRecurrenceID
+					} else if *cloned.Issue.RecurrenceID != sourceRecurrenceID {
+						err = fmt.Errorf("project merge issue recurrence ID %d does not match recurrence UID %q",
+							*cloned.Issue.RecurrenceID, *cloned.Issue.RecurrenceUID)
+					}
+				}
+				if err == nil && cloned.Issue.RecurrenceID != nil {
+					if _, ok := importedRecurrencesByID[*cloned.Issue.RecurrenceID]; !ok {
+						err = fmt.Errorf("project merge issue recurrence ID %d is not part of the imported project",
+							*cloned.Issue.RecurrenceID)
+					}
+				}
 				if err == nil && cloned.Issue.RecurrenceID != nil {
 					*cloned.Issue.RecurrenceID, err = addMergeOffset(*cloned.Issue.RecurrenceID, offsets.Recurrence, cloned.Kind+" recurrence")
 				}
@@ -210,9 +238,14 @@ func PrepareProjectMergeRecords(
 			}
 		case ImportKindEvent:
 			if err = requireMergeProjectID(cloned.Event.ProjectID, projectID, cloned.Kind); err == nil {
+				if cloned.Event.HLCPhysicalMS > maxProjectMergeHLCValue || cloned.Event.HLCCounter > maxProjectMergeHLCValue {
+					err = fmt.Errorf("project merge event HLC exceeds safe range")
+				}
 				// UID, content hash, and payload form the event's portable
 				// identity. Only target-local numeric columns are remapped.
-				cloned.Event.ID, err = addMergeOffset(cloned.Event.ID, offsets.Event, cloned.Kind)
+				if err == nil {
+					cloned.Event.ID, err = addMergeOffset(cloned.Event.ID, offsets.Event, cloned.Kind)
+				}
 				cloned.Event.ProjectID = offsets.TargetProjectID
 				if err == nil && cloned.Event.IssueID != nil {
 					*cloned.Event.IssueID, err = resolveImportedIssue(
@@ -220,7 +253,13 @@ func PrepareProjectMergeRecords(
 					)
 				}
 				if err == nil && cloned.Event.RelatedIssueID != nil {
-					*cloned.Event.RelatedIssueID, err = resolveIssue(*cloned.Event.RelatedIssueID, mergeStringValue(cloned.Event.RelatedIssueUID))
+					var resolvedID int64
+					resolvedID, err = resolveIssue(*cloned.Event.RelatedIssueID, mergeStringValue(cloned.Event.RelatedIssueUID))
+					if err == nil && resolvedID == 0 {
+						cloned.Event.RelatedIssueID = nil
+					} else if err == nil {
+						*cloned.Event.RelatedIssueID = resolvedID
+					}
 				}
 			}
 		case ImportKindPurgeLog:

--- a/internal/db/project_merge.go
+++ b/internal/db/project_merge.go
@@ -1,0 +1,491 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+
+	katauid "go.kenn.io/kata/internal/uid"
+)
+
+// ProjectMergeOffsets reserves fresh numeric ID ranges in an existing target.
+// TargetProjectID is the exact new project ID; every other value is added to
+// source IDs from the project snapshot.
+type ProjectMergeOffsets struct {
+	TargetProjectID int64
+	Alias           int64
+	SyncBinding     int64
+	Recurrence      int64
+	Issue           int64
+	Comment         int64
+	Link            int64
+	ImportMapping   int64
+	Quarantine      int64
+	Enrollment      int64
+	Claim           int64
+	PendingClaim    int64
+	Event           int64
+	PurgeLog        int64
+	ProjectPurgeLog int64
+}
+
+// ExistingIssueLookup resolves an issue UID already present in the merge
+// target. It is used only for informational event references; merge never
+// creates relationship rows that involve an existing project.
+type ExistingIssueLookup func(uid string) (id int64, found bool, err error)
+
+// PrepareProjectMergeRecords validates a single-project snapshot, clones its
+// records, remaps numeric IDs, and drops whole-database metadata/sequences.
+func PrepareProjectMergeRecords(
+	recs []ImportRecord,
+	offsets ProjectMergeOffsets,
+	lookupExistingIssue ExistingIssueLookup,
+) ([]ImportRecord, error) {
+	if err := ValidateImportRecords(recs); err != nil {
+		return nil, err
+	}
+	var project *ProjectExport
+	importedIssues := make(map[int64]string)
+	for _, rec := range recs {
+		if rec.Project != nil {
+			if rec.Project.UID == SystemProjectUID || rec.Project.Name == SystemProjectName {
+				return nil, fmt.Errorf("project merge requires one non-system project")
+			}
+			if project != nil {
+				return nil, fmt.Errorf("project merge requires exactly one project record")
+			}
+			p := *rec.Project
+			project = &p
+		}
+		if rec.Issue != nil {
+			importedIssues[rec.Issue.ID] = rec.Issue.UID
+		}
+	}
+	if project == nil {
+		return nil, fmt.Errorf("project merge requires exactly one project record")
+	}
+	if offsets.TargetProjectID <= 0 {
+		return nil, fmt.Errorf("project merge target project ID must be positive")
+	}
+
+	resolveIssue := func(sourceID int64, uid string) (int64, error) {
+		if _, ok := importedIssues[sourceID]; ok {
+			return addMergeOffset(sourceID, offsets.Issue, "issue")
+		}
+		if uid == "" || lookupExistingIssue == nil {
+			return 0, nil
+		}
+		id, found, err := lookupExistingIssue(uid)
+		if err != nil {
+			return 0, err
+		}
+		if !found {
+			return 0, nil
+		}
+		return id, nil
+	}
+	resolveImportedIssue := func(sourceID int64, uid, kind string) (int64, error) {
+		importedUID, ok := importedIssues[sourceID]
+		if !ok {
+			return 0, fmt.Errorf("project merge %s issue %d is not part of the imported project", kind, sourceID)
+		}
+		if uid != "" && uid != importedUID {
+			return 0, fmt.Errorf("project merge %s issue UID %q does not match imported issue %d UID %q",
+				kind, uid, sourceID, importedUID)
+		}
+		return addMergeOffset(sourceID, offsets.Issue, kind+" issue")
+	}
+	resolveLinkIssue := func(sourceID int64) (int64, error) {
+		if _, ok := importedIssues[sourceID]; !ok {
+			return 0, nil
+		}
+		return addMergeOffset(sourceID, offsets.Issue, "link issue")
+	}
+	projectID := project.ID
+	out := make([]ImportRecord, 0, len(recs)-2)
+	for _, rec := range recs {
+		if rec.Kind == ImportKindMeta {
+			continue
+		}
+		cloned := cloneImportRecord(rec)
+		var err error
+		switch cloned.Kind {
+		case ImportKindProject:
+			cloned.Project.ID = offsets.TargetProjectID
+		case ImportKindProjectAlias:
+			if err = requireMergeProjectID(cloned.Alias.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.Alias.ID, err = addMergeOffset(cloned.Alias.ID, offsets.Alias, cloned.Kind)
+				cloned.Alias.ProjectID = offsets.TargetProjectID
+			}
+		case ImportKindIssueSyncBinding:
+			if err = requireMergeProjectID(cloned.IssueSyncBinding.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.IssueSyncBinding.ID, err = addMergeOffset(cloned.IssueSyncBinding.ID, offsets.SyncBinding, cloned.Kind)
+				cloned.IssueSyncBinding.ProjectID = offsets.TargetProjectID
+			}
+		case ImportKindIssueSyncStatus:
+			if err = requireMergeProjectID(cloned.IssueSyncStatus.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.IssueSyncStatus.BindingID, err = addMergeOffset(cloned.IssueSyncStatus.BindingID, offsets.SyncBinding, cloned.Kind)
+				cloned.IssueSyncStatus.ProjectID = offsets.TargetProjectID
+			}
+		case ImportKindRecurrence:
+			if err = requireMergeProjectID(cloned.Recurrence.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.Recurrence.ID, err = addMergeOffset(cloned.Recurrence.ID, offsets.Recurrence, cloned.Kind)
+				cloned.Recurrence.ProjectID = offsets.TargetProjectID
+			}
+		case ImportKindIssue:
+			if err = requireMergeProjectID(cloned.Issue.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.Issue.ID, err = addMergeOffset(cloned.Issue.ID, offsets.Issue, cloned.Kind)
+				cloned.Issue.ProjectID = offsets.TargetProjectID
+				if err == nil && cloned.Issue.RecurrenceID != nil {
+					*cloned.Issue.RecurrenceID, err = addMergeOffset(*cloned.Issue.RecurrenceID, offsets.Recurrence, cloned.Kind+" recurrence")
+				}
+			}
+		case ImportKindComment:
+			cloned.Comment.ID, err = addMergeOffset(cloned.Comment.ID, offsets.Comment, cloned.Kind)
+			if err == nil {
+				cloned.Comment.IssueID, err = resolveImportedIssue(cloned.Comment.IssueID, "", "comment")
+			}
+		case ImportKindIssueLabel:
+			cloned.Label.IssueID, err = resolveImportedIssue(cloned.Label.IssueID, "", "label")
+		case ImportKindLink:
+			_, fromImported := importedIssues[cloned.Link.FromIssueID]
+			_, toImported := importedIssues[cloned.Link.ToIssueID]
+			if !fromImported && !toImported {
+				err = fmt.Errorf("project merge link must include an issue from the imported project")
+			}
+			if err == nil {
+				cloned.Link.ID, err = addMergeOffset(cloned.Link.ID, offsets.Link, cloned.Kind)
+			}
+			if err == nil {
+				cloned.Link.FromIssueID, err = resolveLinkIssue(cloned.Link.FromIssueID)
+			}
+			if err == nil {
+				cloned.Link.ToIssueID, err = resolveLinkIssue(cloned.Link.ToIssueID)
+			}
+		case ImportKindImportMapping:
+			if err = requireMergeProjectID(cloned.ImportMapping.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.ImportMapping.ID, err = addMergeOffset(cloned.ImportMapping.ID, offsets.ImportMapping, cloned.Kind)
+				cloned.ImportMapping.ProjectID = offsets.TargetProjectID
+				if err == nil && cloned.ImportMapping.IssueID != nil {
+					*cloned.ImportMapping.IssueID, err = addMergeOffset(*cloned.ImportMapping.IssueID, offsets.Issue, cloned.Kind+" issue")
+				}
+				if err == nil && cloned.ImportMapping.CommentID != nil {
+					*cloned.ImportMapping.CommentID, err = addMergeOffset(*cloned.ImportMapping.CommentID, offsets.Comment, cloned.Kind+" comment")
+				}
+				if err == nil && cloned.ImportMapping.LinkID != nil {
+					*cloned.ImportMapping.LinkID, err = addMergeOffset(*cloned.ImportMapping.LinkID, offsets.Link, cloned.Kind+" link")
+				}
+			}
+		case ImportKindFederationBinding, ImportKindFederationSyncStatus,
+			ImportKindFederationQuarantine, ImportKindFederationEnrollment:
+			// Federation cursors are split between local and remote event ID
+			// spaces, while enrollment token hashes are live credentials. Drop
+			// all federation state so the imported project must rejoin cleanly.
+			continue
+		case ImportKindIssueClaim:
+			if err = requireMergeProjectID(cloned.IssueClaim.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.IssueClaim.ID, err = addMergeOffset(cloned.IssueClaim.ID, offsets.Claim, cloned.Kind)
+				cloned.IssueClaim.ProjectID = offsets.TargetProjectID
+				if err == nil {
+					cloned.IssueClaim.IssueID, err = resolveImportedIssue(
+						cloned.IssueClaim.IssueID, cloned.IssueClaim.IssueUID, "claim",
+					)
+				}
+			}
+		case ImportKindPendingClaimRequest:
+			if err = requireMergeProjectID(cloned.PendingClaimRequest.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.PendingClaimRequest.ID, err = addMergeOffset(cloned.PendingClaimRequest.ID, offsets.PendingClaim, cloned.Kind)
+				cloned.PendingClaimRequest.ProjectID = offsets.TargetProjectID
+				if err == nil {
+					cloned.PendingClaimRequest.IssueID, err = resolveImportedIssue(
+						cloned.PendingClaimRequest.IssueID, cloned.PendingClaimRequest.IssueUID, "pending claim",
+					)
+				}
+			}
+		case ImportKindEvent:
+			if err = requireMergeProjectID(cloned.Event.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.Event.ID, err = addMergeOffset(cloned.Event.ID, offsets.Event, cloned.Kind)
+				cloned.Event.ProjectID = offsets.TargetProjectID
+				if err == nil && cloned.Event.IssueID != nil {
+					*cloned.Event.IssueID, err = resolveImportedIssue(
+						*cloned.Event.IssueID, mergeStringValue(cloned.Event.IssueUID), "event",
+					)
+				}
+				if err == nil && cloned.Event.RelatedIssueID != nil {
+					*cloned.Event.RelatedIssueID, err = resolveIssue(*cloned.Event.RelatedIssueID, mergeStringValue(cloned.Event.RelatedIssueUID))
+				}
+				if err == nil {
+					err = remapMergedEventLinkID(cloned.Event, offsets.Link, project.UID)
+				}
+			}
+		case ImportKindPurgeLog:
+			if err = requireMergeProjectID(cloned.PurgeLog.ProjectID, projectID, cloned.Kind); err == nil {
+				cloned.PurgeLog.ID, err = addMergeOffset(cloned.PurgeLog.ID, offsets.PurgeLog, cloned.Kind)
+				cloned.PurgeLog.ProjectID = offsets.TargetProjectID
+				if err == nil {
+					cloned.PurgeLog.PurgedIssueID, err = addMergeOffset(cloned.PurgeLog.PurgedIssueID, offsets.Issue, cloned.Kind+" issue")
+				}
+				if err == nil {
+					err = shiftEventPointers(
+						cloned.PurgeLog.EventsDeletedMinID,
+						cloned.PurgeLog.EventsDeletedMaxID,
+						cloned.PurgeLog.PurgeResetAfterEventID,
+						offsets.Event,
+					)
+				}
+			}
+		case ImportKindProjectPurgeLog:
+			return nil, fmt.Errorf("project merge does not accept project_purge_log records")
+		case ImportKindSQLiteSequence:
+			var keep bool
+			cloned.Sequence.Seq, keep, err = remapProjectMergeSequence(
+				cloned.Sequence.Name, cloned.Sequence.Seq, projectID, offsets,
+			)
+			if !keep {
+				continue
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, cloned)
+	}
+	return out, nil
+}
+
+func remapProjectMergeSequence(
+	name string,
+	seq int64,
+	sourceProjectID int64,
+	offsets ProjectMergeOffsets,
+) (int64, bool, error) {
+	if seq < 0 {
+		return 0, false, fmt.Errorf("project merge sequence %s has negative floor %d", name, seq)
+	}
+	if name == "projects" {
+		if seq <= sourceProjectID {
+			return offsets.TargetProjectID, true, nil
+		}
+		shifted, err := addSequenceFloor(seq-sourceProjectID, offsets.TargetProjectID, name)
+		return shifted, true, err
+	}
+	offsetByName := map[string]int64{
+		"project_aliases":        offsets.Alias,
+		"issue_sync_bindings":    offsets.SyncBinding,
+		"recurrences":            offsets.Recurrence,
+		"issues":                 offsets.Issue,
+		"comments":               offsets.Comment,
+		"links":                  offsets.Link,
+		"import_mappings":        offsets.ImportMapping,
+		"federation_quarantine":  offsets.Quarantine,
+		"federation_enrollments": offsets.Enrollment,
+		"issue_claims":           offsets.Claim,
+		"pending_claim_requests": offsets.PendingClaim,
+		"events":                 offsets.Event,
+		"purge_log":              offsets.PurgeLog,
+		"project_purge_log":      offsets.ProjectPurgeLog,
+	}
+	offset, ok := offsetByName[name]
+	if !ok {
+		return 0, false, nil
+	}
+	shifted, err := addSequenceFloor(seq, offset, name)
+	return shifted, true, err
+}
+
+func addSequenceFloor(seq, offset int64, name string) (int64, error) {
+	if offset < 0 || offset > math.MaxInt64-seq {
+		return 0, fmt.Errorf("project merge sequence %s floor overflows", name)
+	}
+	return seq + offset, nil
+}
+
+func remapMergedEventLinkID(event *EventExport, offset int64, projectUID string) error {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return fmt.Errorf("project merge event %d payload: %w", event.ID, err)
+	}
+	rawLinkID, ok := payload["link_id"]
+	if !ok {
+		return nil
+	}
+	var linkID int64
+	if err := json.Unmarshal(rawLinkID, &linkID); err != nil {
+		return fmt.Errorf("project merge event %d link_id: %w", event.ID, err)
+	}
+	shifted, err := addMergeOffset(linkID, offset, "event link")
+	if err != nil {
+		return err
+	}
+	payload["link_id"], err = json.Marshal(shifted)
+	if err != nil {
+		return fmt.Errorf("project merge event %d link_id: %w", event.ID, err)
+	}
+	event.Payload, err = json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("project merge event %d payload: %w", event.ID, err)
+	}
+	event.UID, err = katauid.New()
+	if err != nil {
+		return fmt.Errorf("project merge event %d uid: %w", event.ID, err)
+	}
+	event.ContentHash, err = EventContentHash(EventHashInput{
+		UID:               event.UID,
+		OriginInstanceUID: event.OriginInstanceUID,
+		ProjectUID:        projectUID,
+		ProjectName:       event.ProjectName,
+		IssueUID:          event.IssueUID,
+		RelatedIssueUID:   event.RelatedIssueUID,
+		Type:              event.Type,
+		Actor:             event.Actor,
+		HLCPhysicalMS:     event.HLCPhysicalMS,
+		HLCCounter:        event.HLCCounter,
+		CreatedAt:         event.CreatedAt,
+		Payload:           event.Payload,
+	})
+	if err != nil {
+		return fmt.Errorf("project merge event %d content_hash: %w", event.ID, err)
+	}
+	return nil
+}
+
+func requireMergeProjectID(got, want int64, kind string) error {
+	if got != want {
+		return fmt.Errorf("project merge %s references project %d, want %d", kind, got, want)
+	}
+	return nil
+}
+
+func addMergeOffset(id, offset int64, kind string) (int64, error) {
+	if id <= 0 {
+		return 0, fmt.Errorf("project merge %s ID must be positive, got %d", kind, id)
+	}
+	if offset > math.MaxInt64-id {
+		return 0, fmt.Errorf("project merge %s ID overflows", kind)
+	}
+	return offset + id, nil
+}
+
+func shiftEventPointers(first, last, reset *int64, offset int64) error {
+	for _, value := range []*int64{first, last, reset} {
+		if value == nil {
+			continue
+		}
+		shifted, err := addMergeOffset(*value, offset, ImportKindEvent)
+		if err != nil {
+			return err
+		}
+		*value = shifted
+	}
+	return nil
+}
+
+func cloneImportRecord(rec ImportRecord) ImportRecord {
+	out := ImportRecord{Kind: rec.Kind}
+	if rec.Meta != nil {
+		v := *rec.Meta
+		out.Meta = &v
+	}
+	if rec.Project != nil {
+		v := *rec.Project
+		out.Project = &v
+	}
+	if rec.Alias != nil {
+		v := *rec.Alias
+		out.Alias = &v
+	}
+	if rec.IssueSyncBinding != nil {
+		v := *rec.IssueSyncBinding
+		out.IssueSyncBinding = &v
+	}
+	if rec.IssueSyncStatus != nil {
+		v := *rec.IssueSyncStatus
+		out.IssueSyncStatus = &v
+	}
+	if rec.Recurrence != nil {
+		v := *rec.Recurrence
+		out.Recurrence = &v
+	}
+	if rec.Issue != nil {
+		v := *rec.Issue
+		out.Issue = &v
+		out.Issue.RecurrenceID = cloneInt64Ptr(v.RecurrenceID)
+	}
+	if rec.IssueEmbedding != nil {
+		v := *rec.IssueEmbedding
+		out.IssueEmbedding = &v
+	}
+	if rec.Comment != nil {
+		v := *rec.Comment
+		out.Comment = &v
+	}
+	if rec.Label != nil {
+		v := *rec.Label
+		out.Label = &v
+	}
+	if rec.Link != nil {
+		v := *rec.Link
+		out.Link = &v
+	}
+	if rec.ImportMapping != nil {
+		v := *rec.ImportMapping
+		out.ImportMapping = &v
+		out.ImportMapping.IssueID = cloneInt64Ptr(v.IssueID)
+		out.ImportMapping.CommentID = cloneInt64Ptr(v.CommentID)
+		out.ImportMapping.LinkID = cloneInt64Ptr(v.LinkID)
+	}
+	if rec.FederationBinding != nil {
+		v := *rec.FederationBinding
+		out.FederationBinding = &v
+	}
+	if rec.FederationSyncStatus != nil {
+		v := *rec.FederationSyncStatus
+		out.FederationSyncStatus = &v
+	}
+	if rec.FederationQuarantine != nil {
+		v := *rec.FederationQuarantine
+		out.FederationQuarantine = &v
+	}
+	if rec.FederationEnrollment != nil {
+		v := *rec.FederationEnrollment
+		out.FederationEnrollment = &v
+		out.FederationEnrollment.ProjectID = cloneInt64Ptr(v.ProjectID)
+	}
+	if rec.IssueClaim != nil {
+		v := *rec.IssueClaim
+		out.IssueClaim = &v
+	}
+	if rec.PendingClaimRequest != nil {
+		v := *rec.PendingClaimRequest
+		out.PendingClaimRequest = &v
+	}
+	if rec.Event != nil {
+		v := *rec.Event
+		out.Event = &v
+		out.Event.IssueID = cloneInt64Ptr(v.IssueID)
+		out.Event.RelatedIssueID = cloneInt64Ptr(v.RelatedIssueID)
+	}
+	if rec.PurgeLog != nil {
+		v := *rec.PurgeLog
+		out.PurgeLog = &v
+		out.PurgeLog.EventsDeletedMinID = cloneInt64Ptr(v.EventsDeletedMinID)
+		out.PurgeLog.EventsDeletedMaxID = cloneInt64Ptr(v.EventsDeletedMaxID)
+		out.PurgeLog.PurgeResetAfterEventID = cloneInt64Ptr(v.PurgeResetAfterEventID)
+	}
+	if rec.ProjectPurgeLog != nil {
+		v := *rec.ProjectPurgeLog
+		out.ProjectPurgeLog = &v
+	}
+	if rec.Sequence != nil {
+		v := *rec.Sequence
+		out.Sequence = &v
+	}
+	return out
+}
+
+func mergeStringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/db/project_merge.go
+++ b/internal/db/project_merge.go
@@ -83,9 +83,20 @@ func PrepareProjectMergeRecords(
 		return nil, fmt.Errorf("project merge target project ID exceeds safe ID range")
 	}
 
+	resolveImportedIssue := func(sourceID int64, uid, kind string) (int64, error) {
+		importedUID, ok := importedIssues[sourceID]
+		if !ok {
+			return 0, fmt.Errorf("project merge %s issue %d is not part of the imported project", kind, sourceID)
+		}
+		if uid != "" && uid != importedUID {
+			return 0, fmt.Errorf("project merge %s issue UID %q does not match imported issue %d UID %q",
+				kind, uid, sourceID, importedUID)
+		}
+		return addMergeOffset(sourceID, offsets.Issue, kind+" issue")
+	}
 	resolveIssue := func(sourceID int64, uid string) (int64, error) {
 		if _, ok := importedIssues[sourceID]; ok {
-			return addMergeOffset(sourceID, offsets.Issue, "issue")
+			return resolveImportedIssue(sourceID, uid, "event related")
 		}
 		if uid == "" || lookupExistingIssue == nil {
 			return 0, nil
@@ -98,17 +109,6 @@ func PrepareProjectMergeRecords(
 			return 0, nil
 		}
 		return id, nil
-	}
-	resolveImportedIssue := func(sourceID int64, uid, kind string) (int64, error) {
-		importedUID, ok := importedIssues[sourceID]
-		if !ok {
-			return 0, fmt.Errorf("project merge %s issue %d is not part of the imported project", kind, sourceID)
-		}
-		if uid != "" && uid != importedUID {
-			return 0, fmt.Errorf("project merge %s issue UID %q does not match imported issue %d UID %q",
-				kind, uid, sourceID, importedUID)
-		}
-		return addMergeOffset(sourceID, offsets.Issue, kind+" issue")
 	}
 	resolveLinkIssue := func(sourceID int64) (int64, error) {
 		if _, ok := importedIssues[sourceID]; !ok {

--- a/internal/db/project_merge.go
+++ b/internal/db/project_merge.go
@@ -1,12 +1,14 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
-
-	katauid "go.kenn.io/kata/internal/uid"
 )
+
+// Keep imported rows in the lower half of the signed ID range. This leaves
+// ample room for the target's shared sequences after a merge while remaining
+// far above any practical database size.
+const maxProjectMergeID int64 = math.MaxInt64 / 2
 
 // ProjectMergeOffsets reserves fresh numeric ID ranges in an existing target.
 // TargetProjectID is the exact new project ID; every other value is added to
@@ -67,6 +69,9 @@ func PrepareProjectMergeRecords(
 	if offsets.TargetProjectID <= 0 {
 		return nil, fmt.Errorf("project merge target project ID must be positive")
 	}
+	if offsets.TargetProjectID > maxProjectMergeID {
+		return nil, fmt.Errorf("project merge target project ID exceeds safe ID range")
+	}
 
 	resolveIssue := func(sourceID int64, uid string) (int64, error) {
 		if _, ok := importedIssues[sourceID]; ok {
@@ -103,6 +108,7 @@ func PrepareProjectMergeRecords(
 	}
 	projectID := project.ID
 	out := make([]ImportRecord, 0, len(recs)-2)
+	var eventSequenceFloor int64
 	for _, rec := range recs {
 		if rec.Kind == ImportKindMeta {
 			continue
@@ -204,6 +210,8 @@ func PrepareProjectMergeRecords(
 			}
 		case ImportKindEvent:
 			if err = requireMergeProjectID(cloned.Event.ProjectID, projectID, cloned.Kind); err == nil {
+				// UID, content hash, and payload form the event's portable
+				// identity. Only target-local numeric columns are remapped.
 				cloned.Event.ID, err = addMergeOffset(cloned.Event.ID, offsets.Event, cloned.Kind)
 				cloned.Event.ProjectID = offsets.TargetProjectID
 				if err == nil && cloned.Event.IssueID != nil {
@@ -213,9 +221,6 @@ func PrepareProjectMergeRecords(
 				}
 				if err == nil && cloned.Event.RelatedIssueID != nil {
 					*cloned.Event.RelatedIssueID, err = resolveIssue(*cloned.Event.RelatedIssueID, mergeStringValue(cloned.Event.RelatedIssueUID))
-				}
-				if err == nil {
-					err = remapMergedEventLinkID(cloned.Event, offsets.Link, project.UID)
 				}
 			}
 		case ImportKindPurgeLog:
@@ -233,120 +238,34 @@ func PrepareProjectMergeRecords(
 						offsets.Event,
 					)
 				}
+				if err == nil && cloned.PurgeLog.PurgeResetAfterEventID != nil &&
+					*cloned.PurgeLog.PurgeResetAfterEventID > eventSequenceFloor {
+					eventSequenceFloor = *cloned.PurgeLog.PurgeResetAfterEventID
+				}
 			}
 		case ImportKindProjectPurgeLog:
 			return nil, fmt.Errorf("project merge does not accept project_purge_log records")
 		case ImportKindSQLiteSequence:
-			var keep bool
-			cloned.Sequence.Seq, keep, err = remapProjectMergeSequence(
-				cloned.Sequence.Name, cloned.Sequence.Seq, projectID, offsets,
-			)
-			if !keep {
-				continue
-			}
+			// Scoped exports carry whole-database sequence floors. They do not
+			// describe this project, and explicit imported IDs advance the
+			// target sequences during replay.
+			continue
 		}
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, cloned)
 	}
+	if eventSequenceFloor > 0 {
+		out = append(out, ImportRecord{
+			Kind: ImportKindSQLiteSequence,
+			Sequence: &SequenceExport{
+				Name: "events",
+				Seq:  eventSequenceFloor,
+			},
+		})
+	}
 	return out, nil
-}
-
-func remapProjectMergeSequence(
-	name string,
-	seq int64,
-	sourceProjectID int64,
-	offsets ProjectMergeOffsets,
-) (int64, bool, error) {
-	if seq < 0 {
-		return 0, false, fmt.Errorf("project merge sequence %s has negative floor %d", name, seq)
-	}
-	if name == "projects" {
-		if seq <= sourceProjectID {
-			return offsets.TargetProjectID, true, nil
-		}
-		shifted, err := addSequenceFloor(seq-sourceProjectID, offsets.TargetProjectID, name)
-		return shifted, true, err
-	}
-	offsetByName := map[string]int64{
-		"project_aliases":        offsets.Alias,
-		"issue_sync_bindings":    offsets.SyncBinding,
-		"recurrences":            offsets.Recurrence,
-		"issues":                 offsets.Issue,
-		"comments":               offsets.Comment,
-		"links":                  offsets.Link,
-		"import_mappings":        offsets.ImportMapping,
-		"federation_quarantine":  offsets.Quarantine,
-		"federation_enrollments": offsets.Enrollment,
-		"issue_claims":           offsets.Claim,
-		"pending_claim_requests": offsets.PendingClaim,
-		"events":                 offsets.Event,
-		"purge_log":              offsets.PurgeLog,
-		"project_purge_log":      offsets.ProjectPurgeLog,
-	}
-	offset, ok := offsetByName[name]
-	if !ok {
-		return 0, false, nil
-	}
-	shifted, err := addSequenceFloor(seq, offset, name)
-	return shifted, true, err
-}
-
-func addSequenceFloor(seq, offset int64, name string) (int64, error) {
-	if offset < 0 || offset > math.MaxInt64-seq {
-		return 0, fmt.Errorf("project merge sequence %s floor overflows", name)
-	}
-	return seq + offset, nil
-}
-
-func remapMergedEventLinkID(event *EventExport, offset int64, projectUID string) error {
-	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(event.Payload, &payload); err != nil {
-		return fmt.Errorf("project merge event %d payload: %w", event.ID, err)
-	}
-	rawLinkID, ok := payload["link_id"]
-	if !ok {
-		return nil
-	}
-	var linkID int64
-	if err := json.Unmarshal(rawLinkID, &linkID); err != nil {
-		return fmt.Errorf("project merge event %d link_id: %w", event.ID, err)
-	}
-	shifted, err := addMergeOffset(linkID, offset, "event link")
-	if err != nil {
-		return err
-	}
-	payload["link_id"], err = json.Marshal(shifted)
-	if err != nil {
-		return fmt.Errorf("project merge event %d link_id: %w", event.ID, err)
-	}
-	event.Payload, err = json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("project merge event %d payload: %w", event.ID, err)
-	}
-	event.UID, err = katauid.New()
-	if err != nil {
-		return fmt.Errorf("project merge event %d uid: %w", event.ID, err)
-	}
-	event.ContentHash, err = EventContentHash(EventHashInput{
-		UID:               event.UID,
-		OriginInstanceUID: event.OriginInstanceUID,
-		ProjectUID:        projectUID,
-		ProjectName:       event.ProjectName,
-		IssueUID:          event.IssueUID,
-		RelatedIssueUID:   event.RelatedIssueUID,
-		Type:              event.Type,
-		Actor:             event.Actor,
-		HLCPhysicalMS:     event.HLCPhysicalMS,
-		HLCCounter:        event.HLCCounter,
-		CreatedAt:         event.CreatedAt,
-		Payload:           event.Payload,
-	})
-	if err != nil {
-		return fmt.Errorf("project merge event %d content_hash: %w", event.ID, err)
-	}
-	return nil
 }
 
 func requireMergeProjectID(got, want int64, kind string) error {
@@ -360,8 +279,8 @@ func addMergeOffset(id, offset int64, kind string) (int64, error) {
 	if id <= 0 {
 		return 0, fmt.Errorf("project merge %s ID must be positive, got %d", kind, id)
 	}
-	if offset > math.MaxInt64-id {
-		return 0, fmt.Errorf("project merge %s ID overflows", kind)
+	if offset < 0 || offset > maxProjectMergeID || id > maxProjectMergeID-offset {
+		return 0, fmt.Errorf("project merge %s ID exceeds safe ID range", kind)
 	}
 	return offset + id, nil
 }

--- a/internal/db/project_merge_test.go
+++ b/internal/db/project_merge_test.go
@@ -112,6 +112,38 @@ func TestPrepareProjectMergeRecordsRejectsIDsWithoutSequenceHeadroom(t *testing.
 	}
 }
 
+func TestPrepareProjectMergeRecordsRejectsHLCPhysicalValueWithoutHeadroom(t *testing.T) {
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindEvent, Event: &EventExport{
+			ID: 7, UID: "01H00000000000000000000001", ProjectID: 2,
+			HLCPhysicalMS: maxProjectMergeHLCValue + 1,
+		}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Event: 20,
+	}, nil)
+	require.ErrorContains(t, err, "event HLC")
+	require.ErrorContains(t, err, "safe range")
+}
+
+func TestPrepareProjectMergeRecordsRejectsHLCCounterWithoutHeadroom(t *testing.T) {
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindEvent, Event: &EventExport{
+			ID: 7, UID: "01H00000000000000000000001", ProjectID: 2,
+			HLCPhysicalMS: 1, HLCCounter: maxProjectMergeHLCValue + 1,
+		}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Event: 20,
+	}, nil)
+	require.ErrorContains(t, err, "event HLC")
+	require.ErrorContains(t, err, "safe range")
+}
+
 func TestPrepareProjectMergeRecordsRemapsIDs(t *testing.T) {
 	issueID := int64(5)
 	peerID := int64(9)
@@ -144,6 +176,81 @@ func TestPrepareProjectMergeRecordsRemapsIDs(t *testing.T) {
 	assert.Equal(t, peerID, records[4].Link.ToIssueID, "source link must not be mutated")
 }
 
+func TestPrepareProjectMergeRecordsRejectsRecurrenceUIDOutsideImport(t *testing.T) {
+	recurrenceUID := "01H00000000000000000000002"
+	occurrenceKey := "2026-08-20"
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{
+			ID: 5, UID: "01H00000000000000000000001", ProjectID: 2,
+			RecurrenceUID: &recurrenceUID, OccurrenceKey: &occurrenceKey,
+		}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 10, Recurrence: 20,
+	}, nil)
+	require.ErrorContains(t, err, "recurrence UID")
+	require.ErrorContains(t, err, "not part of the imported project")
+}
+
+func TestPrepareProjectMergeRecordsRejectsRecurrenceIdentityMismatch(t *testing.T) {
+	recurrenceID := int64(3)
+	recurrenceUID := "01H00000000000000000000004"
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindRecurrence, Recurrence: &RecurrenceExport{ID: 3, UID: "01H00000000000000000000002", ProjectID: 2}},
+		{Kind: ImportKindRecurrence, Recurrence: &RecurrenceExport{ID: 4, UID: recurrenceUID, ProjectID: 2}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{
+			ID: 5, UID: "01H00000000000000000000001", ProjectID: 2,
+			RecurrenceID: &recurrenceID, RecurrenceUID: &recurrenceUID,
+		}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 10, Recurrence: 20,
+	}, nil)
+	require.ErrorContains(t, err, "recurrence ID 3")
+	require.ErrorContains(t, err, "does not match recurrence UID")
+}
+
+func TestPrepareProjectMergeRecordsRejectsRecurrenceIDOutsideImport(t *testing.T) {
+	recurrenceID := int64(3)
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{
+			ID: 5, UID: "01H00000000000000000000001", ProjectID: 2,
+			RecurrenceID: &recurrenceID,
+		}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 10, Recurrence: 20,
+	}, nil)
+	require.ErrorContains(t, err, "recurrence ID 3")
+	require.ErrorContains(t, err, "not part of the imported project")
+}
+
+func TestPrepareProjectMergeRecordsRemapsRecurrenceUIDWithinImport(t *testing.T) {
+	recurrenceUID := "01H00000000000000000000002"
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindRecurrence, Recurrence: &RecurrenceExport{ID: 3, UID: recurrenceUID, ProjectID: 2}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{
+			ID: 5, UID: "01H00000000000000000000001", ProjectID: 2,
+			RecurrenceUID: &recurrenceUID,
+		}},
+	}
+
+	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 10, Recurrence: 20,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, prepared[2].Issue.RecurrenceID)
+	assert.Equal(t, int64(23), *prepared[2].Issue.RecurrenceID)
+	assert.Nil(t, records[2].Issue.RecurrenceID, "source issue must not be mutated")
+}
+
 func TestPrepareProjectMergeRecordsDoesNotResolveExternalLinkPeer(t *testing.T) {
 	records := []ImportRecord{
 		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
@@ -166,6 +273,28 @@ func TestPrepareProjectMergeRecordsDoesNotResolveExternalLinkPeer(t *testing.T) 
 	assert.Equal(t, int64(15), prepared[2].Link.FromIssueID)
 	assert.Zero(t, prepared[2].Link.ToIssueID)
 	assert.False(t, lookupCalled)
+}
+
+func TestPrepareProjectMergeRecordsClearsUnresolvedEventRelatedIssueID(t *testing.T) {
+	relatedIssueID := int64(9)
+	relatedIssueUID := "01H00000000000000000000002"
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindEvent, Event: &EventExport{
+			ID: 7, UID: "01H00000000000000000000001", ProjectID: 2,
+			RelatedIssueID: &relatedIssueID, RelatedIssueUID: &relatedIssueUID,
+		}},
+	}
+
+	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Event: 20,
+	}, func(string) (int64, bool, error) { return 0, false, nil })
+	require.NoError(t, err)
+	require.Len(t, prepared, 2)
+	assert.Nil(t, prepared[1].Event.RelatedIssueID)
+	require.NotNil(t, prepared[1].Event.RelatedIssueUID)
+	assert.Equal(t, relatedIssueUID, *prepared[1].Event.RelatedIssueUID)
+	assert.Equal(t, int64(9), *records[1].Event.RelatedIssueID, "source event must not be mutated")
 }
 
 func TestPrepareProjectMergeRecordsDropsFederationState(t *testing.T) {

--- a/internal/db/project_merge_test.go
+++ b/internal/db/project_merge_test.go
@@ -1,0 +1,238 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	katauid "go.kenn.io/kata/internal/uid"
+)
+
+func TestPrepareProjectMergeRecordsRemapsEventLinkIDAndContentHash(t *testing.T) {
+	payload := json.RawMessage(`{"link_id":3,"type":"blocks"}`)
+	event := &EventExport{
+		ID: 7, UID: "01H00000000000000000000003", OriginInstanceUID: "01H00000000000000000000004",
+		ProjectID: 2, ProjectName: "spoke-project", Type: "issue.linked", Actor: "fixture-author",
+		Payload: payload, HLCPhysicalMS: 1, ContentHash: "source-hash", CreatedAt: "2026-08-19T00:00:00.000Z",
+	}
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindEvent, Event: event},
+	}
+
+	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 20, Link: 200, Event: 300,
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, prepared, 2)
+
+	var gotPayload struct {
+		LinkID int64 `json:"link_id"`
+	}
+	require.NoError(t, json.Unmarshal(prepared[1].Event.Payload, &gotPayload))
+	assert.Equal(t, int64(203), gotPayload.LinkID)
+	assert.NotEqual(t, event.UID, prepared[1].Event.UID)
+	assert.True(t, katauid.Valid(prepared[1].Event.UID))
+	wantHash, err := EventContentHash(EventHashInput{
+		UID: prepared[1].Event.UID, OriginInstanceUID: event.OriginInstanceUID,
+		ProjectUID: records[0].Project.UID, Type: event.Type, Actor: event.Actor,
+		HLCPhysicalMS: event.HLCPhysicalMS, CreatedAt: event.CreatedAt,
+		Payload: prepared[1].Event.Payload,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, wantHash, prepared[1].Event.ContentHash)
+	assert.JSONEq(t, string(payload), string(event.Payload), "source event payload must not be mutated")
+	assert.Equal(t, "source-hash", event.ContentHash, "source event hash must not be mutated")
+}
+
+func TestPrepareProjectMergeRecordsRemapsSequenceFloors(t *testing.T) {
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "projects", Seq: 9}},
+		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "issues", Seq: 20}},
+		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "events", Seq: 50}},
+		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "api_tokens", Seq: 99}},
+	}
+
+	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 200, Event: 100,
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, prepared, 4)
+	assert.Equal(t, "projects", prepared[1].Sequence.Name)
+	assert.Equal(t, int64(11), prepared[1].Sequence.Seq)
+	assert.Equal(t, "issues", prepared[2].Sequence.Name)
+	assert.Equal(t, int64(220), prepared[2].Sequence.Seq)
+	assert.Equal(t, "events", prepared[3].Sequence.Name)
+	assert.Equal(t, int64(150), prepared[3].Sequence.Seq)
+	assert.Equal(t, int64(9), records[1].Sequence.Seq, "source sequence must not be mutated")
+}
+
+func TestPrepareProjectMergeRecordsRemapsIDs(t *testing.T) {
+	issueID := int64(5)
+	peerID := int64(9)
+	records := []ImportRecord{
+		{Kind: ImportKindMeta, Meta: &MetaKV{Key: "instance_uid", Value: "source"}},
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{ID: issueID, UID: "01H00000000000000000000001", ProjectID: 2}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{ID: peerID, UID: "01H00000000000000000000002", ProjectID: 2}},
+		{Kind: ImportKindLink, Link: &LinkExport{
+			ID: 3, FromIssueID: issueID, FromIssueUID: "01H00000000000000000000001",
+			ToIssueID: peerID, ToIssueUID: "01H00000000000000000000002", Type: "blocks",
+		}},
+		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "issues", Seq: 99}},
+	}
+
+	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 20, Issue: 100, Link: 200,
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, prepared, 5)
+	assert.Equal(t, int64(20), prepared[0].Project.ID)
+	assert.Equal(t, int64(105), prepared[1].Issue.ID)
+	assert.Equal(t, int64(20), prepared[1].Issue.ProjectID)
+	assert.Equal(t, int64(109), prepared[2].Issue.ID)
+	assert.Equal(t, int64(203), prepared[3].Link.ID)
+	assert.Equal(t, int64(105), prepared[3].Link.FromIssueID)
+	assert.Equal(t, int64(109), prepared[3].Link.ToIssueID)
+	assert.Equal(t, "issues", prepared[4].Sequence.Name)
+	assert.Equal(t, int64(199), prepared[4].Sequence.Seq)
+
+	assert.Equal(t, issueID, records[2].Issue.ID, "source records must not be mutated")
+	assert.Equal(t, peerID, records[4].Link.ToIssueID, "source link must not be mutated")
+}
+
+func TestPrepareProjectMergeRecordsDoesNotResolveExternalLinkPeer(t *testing.T) {
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2}},
+		{Kind: ImportKindLink, Link: &LinkExport{
+			ID: 3, FromIssueID: 5, FromIssueUID: "01H00000000000000000000001",
+			ToIssueID: 9, ToIssueUID: "01H00000000000000000000002", Type: "blocks",
+		}},
+	}
+	lookupCalled := false
+
+	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 10, Link: 20,
+	}, func(string) (int64, bool, error) {
+		lookupCalled = true
+		return 77, true, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, prepared, 3)
+	assert.Equal(t, int64(15), prepared[2].Link.FromIssueID)
+	assert.Zero(t, prepared[2].Link.ToIssueID)
+	assert.False(t, lookupCalled)
+}
+
+func TestPrepareProjectMergeRecordsDropsFederationState(t *testing.T) {
+	projectID := int64(2)
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: projectID, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindFederationBinding, FederationBinding: &FederationBindingExport{
+			ProjectID: projectID, Role: "spoke", Enabled: true, PushEnabled: true,
+			ReplayHorizonEventID: 40, PullCursorEventID: 50, PushCursorEventID: 60,
+		}},
+		{Kind: ImportKindFederationSyncStatus, FederationSyncStatus: &FederationSyncStatusExport{ProjectID: projectID}},
+		{Kind: ImportKindFederationQuarantine, FederationQuarantine: &FederationQuarantineExport{
+			ID: 3, ProjectID: projectID, Direction: "pull", FirstEventID: 40, LastEventID: 50,
+		}},
+		{Kind: ImportKindFederationEnrollment, FederationEnrollment: &FederationEnrollmentExport{
+			ID: 4, ProjectID: &projectID, TokenHash: "attacker-controlled", Capabilities: "pull,push",
+		}},
+	}
+
+	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Event: 100, Quarantine: 200,
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, prepared, 1)
+	assert.NotNil(t, prepared[0].Project)
+	for _, record := range prepared {
+		assert.Nil(t, record.FederationBinding)
+		assert.Nil(t, record.FederationSyncStatus)
+		assert.Nil(t, record.FederationQuarantine)
+		assert.Nil(t, record.FederationEnrollment)
+	}
+	assert.True(t, records[1].FederationBinding.Enabled, "source binding must not be mutated")
+}
+
+func TestPrepareProjectMergeRecordsRejectsMultipleProjects(t *testing.T) {
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 3, UID: "01H00000000000000000000001", Name: "hub-project"}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{TargetProjectID: 4}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one project record")
+}
+
+func TestPrepareProjectMergeRecordsDropsWildcardFederationEnrollment(t *testing.T) {
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindFederationEnrollment, FederationEnrollment: &FederationEnrollmentExport{
+			ID: 4, ProjectID: nil,
+		}},
+	}
+
+	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Enrollment: 10,
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, prepared, 1)
+	assert.NotNil(t, prepared[0].Project)
+}
+
+func TestPrepareProjectMergeRecordsRejectsClaimOutsideImportedProject(t *testing.T) {
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2}},
+		{Kind: ImportKindIssueClaim, IssueClaim: &IssueClaimExport{
+			ID: 6, ClaimUID: "01H00000000000000000000002", ProjectID: 2,
+			IssueID: 99, IssueUID: "01H00000000000000000000003",
+		}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 10, Claim: 20,
+	}, func(string) (int64, bool, error) { return 77, true, nil })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "claim issue 99 is not part of the imported project")
+}
+
+func TestPrepareProjectMergeRecordsRejectsClaimIssueUIDMismatch(t *testing.T) {
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2}},
+		{Kind: ImportKindIssueClaim, IssueClaim: &IssueClaimExport{
+			ID: 6, ClaimUID: "01H00000000000000000000002", ProjectID: 2,
+			IssueID: 5, IssueUID: "01H00000000000000000000003",
+		}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 10, Claim: 20,
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "claim issue UID")
+	assert.Contains(t, err.Error(), "does not match imported issue")
+}
+
+func TestPrepareProjectMergeRecordsRejectsLinkBetweenExistingProjects(t *testing.T) {
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindLink, Link: &LinkExport{
+			ID: 3, FromIssueID: 8, FromIssueUID: "01H00000000000000000000001",
+			ToIssueID: 9, ToIssueUID: "01H00000000000000000000002", Type: "blocks",
+		}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Link: 20,
+	}, func(string) (int64, bool, error) { return 77, true, nil })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "link must include an issue from the imported project")
+}

--- a/internal/db/project_merge_test.go
+++ b/internal/db/project_merge_test.go
@@ -51,7 +51,7 @@ func TestPrepareProjectMergeRecordsDropsSequenceFloors(t *testing.T) {
 	assert.Equal(t, int64(9), records[1].Sequence.Seq, "source sequence must not be mutated")
 }
 
-func TestPrepareProjectMergeRecordsDerivesEventFloorFromPurgeCursor(t *testing.T) {
+func TestPrepareProjectMergeRecordsDerivesSequenceFloorsFromPurgeTombstone(t *testing.T) {
 	resetCursor := int64(50)
 	records := []ImportRecord{
 		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
@@ -65,12 +65,17 @@ func TestPrepareProjectMergeRecordsDerivesEventFloorFromPurgeCursor(t *testing.T
 		TargetProjectID: 4, Issue: 100, Event: 200, PurgeLog: 300,
 	}, nil)
 	require.NoError(t, err)
-	require.Len(t, prepared, 3)
+	require.Len(t, prepared, 4)
+	assert.Equal(t, int64(103), prepared[1].PurgeLog.PurgedIssueID)
 	require.NotNil(t, prepared[1].PurgeLog.PurgeResetAfterEventID)
 	assert.Equal(t, int64(250), *prepared[1].PurgeLog.PurgeResetAfterEventID)
 	require.NotNil(t, prepared[2].Sequence)
-	assert.Equal(t, "events", prepared[2].Sequence.Name)
-	assert.Equal(t, int64(250), prepared[2].Sequence.Seq)
+	assert.Equal(t, "issues", prepared[2].Sequence.Name)
+	assert.Equal(t, int64(103), prepared[2].Sequence.Seq)
+	require.NotNil(t, prepared[3].Sequence)
+	assert.Equal(t, "events", prepared[3].Sequence.Name)
+	assert.Equal(t, int64(250), prepared[3].Sequence.Seq)
+	assert.Equal(t, int64(3), records[1].PurgeLog.PurgedIssueID, "source issue ID must not be mutated")
 	assert.Equal(t, int64(50), *records[1].PurgeLog.PurgeResetAfterEventID, "source cursor must not be mutated")
 }
 

--- a/internal/db/project_merge_test.go
+++ b/internal/db/project_merge_test.go
@@ -1,16 +1,15 @@
 package db
 
 import (
-	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	katauid "go.kenn.io/kata/internal/uid"
 )
 
-func TestPrepareProjectMergeRecordsRemapsEventLinkIDAndContentHash(t *testing.T) {
-	payload := json.RawMessage(`{"link_id":3,"type":"blocks"}`)
+func TestPrepareProjectMergeRecordsPreservesEventIdentityAndPayload(t *testing.T) {
+	payload := []byte(`{"link_id":3,"type":"blocks"}`)
 	event := &EventExport{
 		ID: 7, UID: "01H00000000000000000000003", OriginInstanceUID: "01H00000000000000000000004",
 		ProjectID: 2, ProjectName: "spoke-project", Type: "issue.linked", Actor: "fixture-author",
@@ -27,30 +26,18 @@ func TestPrepareProjectMergeRecordsRemapsEventLinkIDAndContentHash(t *testing.T)
 	require.NoError(t, err)
 	require.Len(t, prepared, 2)
 
-	var gotPayload struct {
-		LinkID int64 `json:"link_id"`
-	}
-	require.NoError(t, json.Unmarshal(prepared[1].Event.Payload, &gotPayload))
-	assert.Equal(t, int64(203), gotPayload.LinkID)
-	assert.NotEqual(t, event.UID, prepared[1].Event.UID)
-	assert.True(t, katauid.Valid(prepared[1].Event.UID))
-	wantHash, err := EventContentHash(EventHashInput{
-		UID: prepared[1].Event.UID, OriginInstanceUID: event.OriginInstanceUID,
-		ProjectUID: records[0].Project.UID, Type: event.Type, Actor: event.Actor,
-		HLCPhysicalMS: event.HLCPhysicalMS, CreatedAt: event.CreatedAt,
-		Payload: prepared[1].Event.Payload,
-	})
-	require.NoError(t, err)
-	assert.Equal(t, wantHash, prepared[1].Event.ContentHash)
+	assert.Equal(t, event.UID, prepared[1].Event.UID)
+	assert.Equal(t, event.ContentHash, prepared[1].Event.ContentHash)
+	assert.JSONEq(t, string(payload), string(prepared[1].Event.Payload))
 	assert.JSONEq(t, string(payload), string(event.Payload), "source event payload must not be mutated")
 	assert.Equal(t, "source-hash", event.ContentHash, "source event hash must not be mutated")
 }
 
-func TestPrepareProjectMergeRecordsRemapsSequenceFloors(t *testing.T) {
+func TestPrepareProjectMergeRecordsDropsSequenceFloors(t *testing.T) {
 	records := []ImportRecord{
 		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
 		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "projects", Seq: 9}},
-		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "issues", Seq: 20}},
+		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "issues", Seq: math.MaxInt64}},
 		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "events", Seq: 50}},
 		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "api_tokens", Seq: 99}},
 	}
@@ -59,14 +46,65 @@ func TestPrepareProjectMergeRecordsRemapsSequenceFloors(t *testing.T) {
 		TargetProjectID: 4, Issue: 200, Event: 100,
 	}, nil)
 	require.NoError(t, err)
-	require.Len(t, prepared, 4)
-	assert.Equal(t, "projects", prepared[1].Sequence.Name)
-	assert.Equal(t, int64(11), prepared[1].Sequence.Seq)
-	assert.Equal(t, "issues", prepared[2].Sequence.Name)
-	assert.Equal(t, int64(220), prepared[2].Sequence.Seq)
-	assert.Equal(t, "events", prepared[3].Sequence.Name)
-	assert.Equal(t, int64(150), prepared[3].Sequence.Seq)
+	require.Len(t, prepared, 1)
+	assert.Equal(t, int64(4), prepared[0].Project.ID)
 	assert.Equal(t, int64(9), records[1].Sequence.Seq, "source sequence must not be mutated")
+}
+
+func TestPrepareProjectMergeRecordsDerivesEventFloorFromPurgeCursor(t *testing.T) {
+	resetCursor := int64(50)
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindPurgeLog, PurgeLog: &PurgeLogExport{
+			ID: 1, ProjectID: 2, PurgedIssueID: 3, PurgeResetAfterEventID: &resetCursor,
+		}},
+		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "events", Seq: math.MaxInt64}},
+	}
+
+	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 100, Event: 200, PurgeLog: 300,
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, prepared, 3)
+	require.NotNil(t, prepared[1].PurgeLog.PurgeResetAfterEventID)
+	assert.Equal(t, int64(250), *prepared[1].PurgeLog.PurgeResetAfterEventID)
+	require.NotNil(t, prepared[2].Sequence)
+	assert.Equal(t, "events", prepared[2].Sequence.Name)
+	assert.Equal(t, int64(250), prepared[2].Sequence.Seq)
+	assert.Equal(t, int64(50), *records[1].PurgeLog.PurgeResetAfterEventID, "source cursor must not be mutated")
+}
+
+func TestPrepareProjectMergeRecordsRejectsIDsWithoutSequenceHeadroom(t *testing.T) {
+	project := ImportRecord{Kind: ImportKindProject, Project: &ProjectExport{
+		ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project",
+	}}
+	tests := []struct {
+		name   string
+		record ImportRecord
+	}{
+		{
+			name: "issue",
+			record: ImportRecord{Kind: ImportKindIssue, Issue: &IssueExport{
+				ID: math.MaxInt64, UID: "01H00000000000000000000001", ProjectID: 2,
+			}},
+		},
+		{
+			name: "event",
+			record: ImportRecord{Kind: ImportKindEvent, Event: &EventExport{
+				ID: math.MaxInt64, UID: "01H00000000000000000000002", ProjectID: 2,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := PrepareProjectMergeRecords(
+				[]ImportRecord{project, tt.record},
+				ProjectMergeOffsets{TargetProjectID: 4},
+				nil,
+			)
+			require.ErrorContains(t, err, "safe ID range")
+		})
+	}
 }
 
 func TestPrepareProjectMergeRecordsRemapsIDs(t *testing.T) {
@@ -88,7 +126,7 @@ func TestPrepareProjectMergeRecordsRemapsIDs(t *testing.T) {
 		TargetProjectID: 20, Issue: 100, Link: 200,
 	}, nil)
 	require.NoError(t, err)
-	require.Len(t, prepared, 5)
+	require.Len(t, prepared, 4)
 	assert.Equal(t, int64(20), prepared[0].Project.ID)
 	assert.Equal(t, int64(105), prepared[1].Issue.ID)
 	assert.Equal(t, int64(20), prepared[1].Issue.ProjectID)
@@ -96,8 +134,6 @@ func TestPrepareProjectMergeRecordsRemapsIDs(t *testing.T) {
 	assert.Equal(t, int64(203), prepared[3].Link.ID)
 	assert.Equal(t, int64(105), prepared[3].Link.FromIssueID)
 	assert.Equal(t, int64(109), prepared[3].Link.ToIssueID)
-	assert.Equal(t, "issues", prepared[4].Sequence.Name)
-	assert.Equal(t, int64(199), prepared[4].Sequence.Seq)
 
 	assert.Equal(t, issueID, records[2].Issue.ID, "source records must not be mutated")
 	assert.Equal(t, peerID, records[4].Link.ToIssueID, "source link must not be mutated")

--- a/internal/db/project_merge_test.go
+++ b/internal/db/project_merge_test.go
@@ -297,6 +297,27 @@ func TestPrepareProjectMergeRecordsClearsUnresolvedEventRelatedIssueID(t *testin
 	assert.Equal(t, int64(9), *records[1].Event.RelatedIssueID, "source event must not be mutated")
 }
 
+func TestPrepareProjectMergeRecordsRejectsEventRelatedIssueUIDMismatch(t *testing.T) {
+	relatedIssueID := int64(5)
+	relatedIssueUID := "01H00000000000000000000002"
+	records := []ImportRecord{
+		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2}},
+		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 6, UID: relatedIssueUID, ProjectID: 2}},
+		{Kind: ImportKindEvent, Event: &EventExport{
+			ID: 7, UID: "01H00000000000000000000003", ProjectID: 2,
+			RelatedIssueID: &relatedIssueID, RelatedIssueUID: &relatedIssueUID,
+		}},
+	}
+
+	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
+		TargetProjectID: 4, Issue: 10, Event: 20,
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "event related issue UID")
+	assert.Contains(t, err.Error(), "does not match imported issue 5")
+}
+
 func TestPrepareProjectMergeRecordsDropsFederationState(t *testing.T) {
 	projectID := int64(2)
 	records := []ImportRecord{

--- a/internal/db/sqlitestore/import_replay.go
+++ b/internal/db/sqlitestore/import_replay.go
@@ -49,8 +49,30 @@ func (d *Store) importReplay(ctx context.Context, recs []db.ImportRecord, opts d
 	if _, err := tx.ExecContext(ctx, `PRAGMA defer_foreign_keys=ON`); err != nil {
 		return fmt.Errorf("defer foreign keys: %w", err)
 	}
-	if err := clearReplayTarget(ctx, tx, opts.RequireFreshTarget, d.instanceUID); err != nil {
-		return err
+	if opts.MergeProject {
+		offsets, err := projectMergeOffsets(ctx, tx)
+		if err != nil {
+			return err
+		}
+		recs, err = db.PrepareProjectMergeRecords(recs, offsets,
+			func(uid string) (int64, bool, error) {
+				var id int64
+				err := tx.QueryRowContext(ctx, `SELECT id FROM issues WHERE uid = ?`, uid).Scan(&id)
+				if errors.Is(err, sql.ErrNoRows) {
+					return 0, false, nil
+				}
+				return id, err == nil, err
+			})
+		if err != nil {
+			return err
+		}
+		if err := refuseProjectMergeUIDCollisions(ctx, tx, recs); err != nil {
+			return err
+		}
+	} else {
+		if err := clearReplayTarget(ctx, tx, opts.RequireFreshTarget, d.instanceUID); err != nil {
+			return err
+		}
 	}
 
 	var skippedMissingPeer, skippedDup, skippedMappings int
@@ -90,11 +112,13 @@ func (d *Store) importReplay(ctx context.Context, recs []db.ImportRecord, opts d
 	if err := ensureSystemProject(ctx, tx); err != nil {
 		return err
 	}
-	if err := replayAPITokenProjection(ctx, tx); err != nil {
-		return err
-	}
-	if err := recordImportSchemaVersion(ctx, tx); err != nil {
-		return err
+	if !opts.MergeProject {
+		if err := replayAPITokenProjection(ctx, tx); err != nil {
+			return err
+		}
+		if err := recordImportSchemaVersion(ctx, tx); err != nil {
+			return err
+		}
 	}
 	if err := reconcileSequences(ctx, tx); err != nil {
 		return err
@@ -104,6 +128,82 @@ func (d *Store) importReplay(ctx context.Context, recs []db.ImportRecord, opts d
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit import: %w", err)
+	}
+	return nil
+}
+
+func projectMergeOffsets(ctx context.Context, tx *sql.Tx) (db.ProjectMergeOffsets, error) {
+	var offsets db.ProjectMergeOffsets
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM projects), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='projects'), 0)) + 1,
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM project_aliases), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='project_aliases'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM issue_sync_bindings), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='issue_sync_bindings'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM recurrences), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='recurrences'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM issues), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='issues'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM comments), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='comments'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM links), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='links'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM import_mappings), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='import_mappings'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM federation_quarantine), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='federation_quarantine'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM federation_enrollments), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='federation_enrollments'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM issue_claims), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='issue_claims'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM pending_claim_requests), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='pending_claim_requests'), 0)),
+		 MAX(
+			(SELECT COALESCE(MAX(id), 0) FROM events),
+			COALESCE((SELECT seq FROM sqlite_sequence WHERE name='events'), 0),
+			(SELECT COALESCE(MAX(purge_reset_after_event_id), 0) FROM purge_log),
+			(SELECT COALESCE(MAX(purge_reset_after_event_id), 0) FROM project_purge_log)
+		 ),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM purge_log), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='purge_log'), 0)),
+		 MAX((SELECT COALESCE(MAX(id), 0) FROM project_purge_log), COALESCE((SELECT seq FROM sqlite_sequence WHERE name='project_purge_log'), 0))
+	`).Scan(
+		&offsets.TargetProjectID, &offsets.Alias, &offsets.SyncBinding,
+		&offsets.Recurrence, &offsets.Issue, &offsets.Comment, &offsets.Link,
+		&offsets.ImportMapping, &offsets.Quarantine, &offsets.Enrollment,
+		&offsets.Claim, &offsets.PendingClaim, &offsets.Event,
+		&offsets.PurgeLog, &offsets.ProjectPurgeLog,
+	)
+	if err != nil {
+		return db.ProjectMergeOffsets{}, fmt.Errorf("inspect project merge ID ranges: %w", err)
+	}
+	return offsets, nil
+}
+
+func refuseProjectMergeUIDCollisions(ctx context.Context, tx *sql.Tx, recs []db.ImportRecord) error {
+	type uidCheck struct{ table, column, kind, uid string }
+	checks := make([]uidCheck, 0, len(recs))
+	for _, rec := range recs {
+		switch {
+		case rec.Project != nil:
+			checks = append(checks, uidCheck{"projects", "uid", "project", rec.Project.UID})
+		case rec.Issue != nil:
+			checks = append(checks, uidCheck{"issues", "uid", "issue", rec.Issue.UID})
+		case rec.Comment != nil:
+			checks = append(checks, uidCheck{"comments", "uid", "comment", rec.Comment.UID})
+		case rec.Recurrence != nil:
+			checks = append(checks, uidCheck{"recurrences", "uid", "recurrence", rec.Recurrence.UID})
+		case rec.IssueClaim != nil:
+			checks = append(checks, uidCheck{"issue_claims", "claim_uid", "claim", rec.IssueClaim.ClaimUID})
+		case rec.PendingClaimRequest != nil:
+			checks = append(checks, uidCheck{"pending_claim_requests", "request_uid", "pending claim", rec.PendingClaimRequest.RequestUID})
+		case rec.Event != nil:
+			checks = append(checks, uidCheck{"events", "uid", "event", rec.Event.UID})
+		case rec.PurgeLog != nil:
+			checks = append(checks, uidCheck{"purge_log", "uid", "purge log", rec.PurgeLog.UID})
+		}
+	}
+	for _, check := range checks {
+		if check.uid == "" {
+			continue
+		}
+		var exists bool
+		query := `SELECT EXISTS (SELECT 1 FROM ` + check.table + ` WHERE ` + check.column + ` = ?)`
+		if err := tx.QueryRowContext(ctx, query, check.uid).Scan(&exists); err != nil { //nolint:gosec // identifiers are fixed above
+			return fmt.Errorf("check project merge %s UID: %w", check.kind, err)
+		}
+		if exists {
+			return fmt.Errorf("project merge refused: %s UID %q already exists", check.kind, check.uid)
+		}
 	}
 	return nil
 }

--- a/internal/jsonl/import.go
+++ b/internal/jsonl/import.go
@@ -35,6 +35,10 @@ type ImportOptions struct {
 	// External JSONL restores leave sync bindings disabled until re-enabled
 	// locally so restored provider config cannot use daemon credentials.
 	PreserveIssueSyncBindingEnabled bool
+
+	// MergeProject adds one project-scoped snapshot to an existing database
+	// without replacing unrelated state.
+	MergeProject bool
 }
 
 // Import reads JSONL records from r and inserts them into store.
@@ -48,6 +52,9 @@ func Import(ctx context.Context, r io.Reader, store db.Storage) error {
 // atomically via store.ImportReplay. ImportWithOptions itself holds no SQL or
 // transaction state — the entire atomic insert lives in db.ImportReplay.
 func ImportWithOptions(ctx context.Context, r io.Reader, store db.Storage, opts ImportOptions) error {
+	if opts.MergeProject && (opts.RequireFreshTarget || opts.NewInstance) {
+		return fmt.Errorf("project merge cannot use fresh-target or new-instance restore options")
+	}
 	envs, err := NewDecoder(r).ReadAll(ctx)
 	if err != nil {
 		return err
@@ -90,6 +97,7 @@ func ImportWithOptions(ctx context.Context, r io.Reader, store db.Storage, opts 
 		DedupeLegacyActivePendingClaims: exportVersion < 12,
 		RecomputeEventContentHash:       exportVersion < eventReplayFieldsSchemaVersion,
 		PreserveIssueSyncBindingEnabled: opts.PreserveIssueSyncBindingEnabled,
+		MergeProject:                    opts.MergeProject,
 	})
 }
 


### PR DESCRIPTION
## What changed

- Added `kata import --merge` for one-project JSONL snapshots on existing SQLite and PostgreSQL targets.
- Remaps numeric IDs transactionally while preserving project/object UIDs, short IDs, event identity, and unrelated projects.
- Refuses project and object UID collisions, rejects multi-project snapshots, and keeps imported federation authority disabled.
- Skips cross-project links so a snapshot cannot change another project's dependency graph.

## Why

Per-project exports should be usable for selective restore without replacing every other project in the target database.

## Usage

```sh
kata import --merge --input spoke-project.jsonl --target /path/to/kata.db
```

The target must already exist and its daemon must be stopped.

Closes #42
