### PR TITLE
Add idle shutdown for auto-started daemons

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1436,6 +1436,8 @@ components:
           $ref: "#/components/schemas/EmbeddingsHealth"
         federation_config:
           $ref: "#/components/schemas/FederationConfigHealth"
+        idle_shutdown:
+          $ref: "#/components/schemas/IdleShutdownHealth"
         ok:
           type: boolean
         schema_version:
@@ -1455,6 +1457,25 @@ components:
         - version
         - uptime
         - started_at
+      type: object
+    IdleShutdownHealth:
+      additionalProperties: true
+      properties:
+        deadline:
+          format: date-time
+          type: string
+        state:
+          enum:
+            - armed
+            - foreground
+            - blocked
+            - stopping
+          type: string
+        timeout:
+          type: string
+      required:
+        - timeout
+        - state
       type: object
     ImportBatchResult:
       additionalProperties: true
@@ -4237,7 +4258,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.11.0
+  version: 0.12.0
 openapi: 3.1.0
 paths:
   /api/v1/audit/closes:

--- a/cmd/kata/api_compat.go
+++ b/cmd/kata/api_compat.go
@@ -18,6 +18,13 @@ const (
 	apiVersionMCPServer = "0.11.0"
 )
 
+type daemonAPIHealth struct {
+	APISchemaVersion string `json:"api_schema_version"`
+	IdleShutdown     *struct {
+		Timeout string `json:"timeout"`
+	} `json:"idle_shutdown,omitempty"`
+}
+
 // requireDaemonAPIVersion fails closed before a request that uses query
 // parameters older daemons silently ignored. The health endpoint predates the
 // filtered global queries, so it is safe to use as the capability handshake.
@@ -26,28 +33,35 @@ func requireDaemonAPIVersion(
 	client *http.Client,
 	baseURL, required, feature string,
 ) error {
+	_, err := requireDaemonAPIVersionHealth(ctx, client, baseURL, required, feature)
+	return err
+}
+
+func requireDaemonAPIVersionHealth(
+	ctx context.Context,
+	client *http.Client,
+	baseURL, required, feature string,
+) (daemonAPIHealth, error) {
 	status, body, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/health", nil)
 	if err != nil {
-		return err
+		return daemonAPIHealth{}, err
 	}
 	if status >= http.StatusBadRequest {
-		return apiErrFromBody(status, body)
+		return daemonAPIHealth{}, apiErrFromBody(status, body)
 	}
-	var health struct {
-		APISchemaVersion string `json:"api_schema_version"`
-	}
+	var health daemonAPIHealth
 	if err := json.Unmarshal(body, &health); err != nil {
-		return fmt.Errorf("decode daemon API version: %w", err)
+		return daemonAPIHealth{}, fmt.Errorf("decode daemon API version: %w", err)
 	}
 	reported := strings.TrimSpace(health.APISchemaVersion)
 	compatible, valid := apiVersionAtLeast(reported, required)
 	if valid && compatible {
-		return nil
+		return health, nil
 	}
 	if reported == "" {
 		reported = "no api_schema_version"
 	}
-	return &cliError{
+	return daemonAPIHealth{}, &cliError{
 		Message: fmt.Sprintf(
 			"%s requires daemon API %s or newer; this daemon reports %s; upgrade the daemon",
 			feature, required, reported),

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -83,11 +85,12 @@ func newConfiguredGitHubSyncFetcher(cfg config.GitHubSyncConfig) githubsync.Fetc
 }
 
 type daemonStartOutput struct {
-	Action  string `json:"action"`
-	PID     int    `json:"pid"`
-	Address string `json:"address"`
-	DBPath  string `json:"db_path,omitempty"`
-	WebURL  string `json:"web_url,omitempty"`
+	Action      string `json:"action"`
+	PID         int    `json:"pid"`
+	ReplacedPID int    `json:"replaced_pid,omitempty"`
+	Address     string `json:"address"`
+	DBPath      string `json:"db_path,omitempty"`
+	WebURL      string `json:"web_url,omitempty"`
 }
 
 type daemonLocateOutput struct {
@@ -168,8 +171,9 @@ func locateDaemon(ctx context.Context) (daemonLocateOutput, error) {
 }
 
 var (
-	startDetachedDaemon = defaultStartDetachedDaemon
-	runDaemonForeground = runDaemonWithListen
+	startDetachedDaemon  = defaultStartDetachedDaemon
+	runDaemonForeground  = runDaemonWithListen
+	launchDetachedDaemon = defaultLaunchDetachedDaemon
 )
 
 func daemonStartCmd() *cobra.Command {
@@ -204,6 +208,10 @@ func daemonStartCmd() *cobra.Command {
 			switch out.Action {
 			case "already_running":
 				_, err = fmt.Fprintf(cmd.OutOrStdout(), "daemon already running pid=%d address=%s\n", out.PID, out.Address)
+			case "replaced":
+				_, err = fmt.Fprintf(cmd.OutOrStdout(),
+					"replaced auto-started daemon pid=%d; started pid=%d address=%s\n",
+					out.ReplacedPID, out.PID, out.Address)
 			default:
 				_, err = fmt.Fprintf(cmd.OutOrStdout(), "started pid=%d address=%s\n", out.PID, out.Address)
 			}
@@ -237,14 +245,67 @@ func defaultStartDetachedDaemon(ctx context.Context, listen string, insecureRead
 	if err != nil {
 		return daemonStartOutput{}, err
 	}
+	replacedPID := 0
 	if rec, ok := liveDaemonRecord(ns.DataDir, 0); ok {
 		address := rec.Endpoint().ConfigAddress()
 		if effectiveListen != "" && address != effectiveListen {
 			return daemonStartOutput{}, fmt.Errorf("daemon already running at %s; stop it before starting with listener %s", address, effectiveListen)
 		}
-		return daemonStartOutputFromRecord("already_running", rec), nil
+		// An explicit start means "keep a daemon resident". An auto-started
+		// daemon with idle shutdown armed would exit later, so replace it
+		// with an explicit process instead of reporting it as running.
+		if !daemonRecordAdvertisesIdleShutdown(ctx, rec) {
+			return daemonStartOutputFromRecord("already_running", rec), nil
+		}
+		if err := daemon.SignalDaemonStop(rec, ns.DBHash); err != nil {
+			return daemonStartOutput{}, fmt.Errorf("stop auto-started daemon pid %d: %w", rec.PID, err)
+		}
+		if err := waitForDaemonProcesses(ctx, []int{rec.PID}, daemonRestartProcessWaitTimeout); err != nil {
+			return daemonStartOutput{}, fmt.Errorf("stop auto-started daemon pid %d: %w", rec.PID, err)
+		}
+		replacedPID = rec.PID
 	}
+	out, err := launchDetachedDaemon(ctx, ns.DataDir, listen, insecureReadonly)
+	if err != nil {
+		return daemonStartOutput{}, err
+	}
+	if replacedPID != 0 {
+		out.Action = "replaced"
+		out.ReplacedPID = replacedPID
+	}
+	return out, nil
+}
 
+// daemonRecordAdvertisesIdleShutdown reports whether the live daemon behind
+// rec is an owner-local process that will stop itself when idle. Remote
+// records are never idle-eligible, and an unreachable daemon is treated as
+// resident so an explicit start does not signal a process it cannot inspect.
+func daemonRecordAdvertisesIdleShutdown(ctx context.Context, rec kitdaemon.RuntimeRecord) bool {
+	endpoint := rec.Endpoint()
+	if !endpoint.IsUnix() {
+		host, _, err := net.SplitHostPort(endpoint.Address)
+		if err != nil {
+			return false
+		}
+		if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+			return false
+		}
+	}
+	httpClient, baseURL := client.LocalHTTPClient(endpoint.ConfigAddress())
+	status, body, err := httpDoJSON(ctx, httpClient, http.MethodGet, baseURL+"/api/v1/health", nil)
+	if err != nil || status >= http.StatusBadRequest {
+		return false
+	}
+	var health daemonAPIHealth
+	if err := json.Unmarshal(body, &health); err != nil {
+		return false
+	}
+	return health.IdleShutdown != nil
+}
+
+func defaultLaunchDetachedDaemon(
+	ctx context.Context, dataDir, listen string, insecureReadonly bool,
+) (daemonStartOutput, error) {
 	args := []string{"daemon", "start", "--foreground"}
 	if listen != "" {
 		args = append(args, "--listen", listen)
@@ -257,7 +318,7 @@ func defaultStartDetachedDaemon(ctx context.Context, listen string, insecureRead
 		Env:             os.Environ(),
 		RefuseEphemeral: true,
 	}
-	if logw := client.DaemonLogWriter(ns.DataDir); logw != nil {
+	if logw := client.DaemonLogWriter(dataDir); logw != nil {
 		opts.Stdout = logw
 		opts.Stderr = logw
 		defer func() { _ = logw.Close() }()
@@ -278,7 +339,7 @@ func defaultStartDetachedDaemon(ctx context.Context, listen string, insecureRead
 	defer tick.Stop()
 
 	for {
-		if rec, ok := liveDaemonRecord(ns.DataDir, pid); ok {
+		if rec, ok := liveDaemonRecord(dataDir, pid); ok {
 			return daemonStartOutputFromRecord("started", rec), nil
 		}
 		select {
@@ -291,7 +352,7 @@ func defaultStartDetachedDaemon(ctx context.Context, listen string, insecureRead
 			if childProcess != nil {
 				_ = childProcess.Kill()
 			}
-			return daemonStartOutput{}, daemonStartTimeoutError(ns.DataDir)
+			return daemonStartOutput{}, daemonStartTimeoutError(dataDir)
 		case <-tick.C:
 		}
 	}
@@ -815,7 +876,7 @@ func newAutostartIdleController(
 	autostart bool,
 	daemonEndpoint kitdaemon.Endpoint,
 	webEndpoint daemon.WebEndpoint,
-	cancel context.CancelFunc,
+	onIdle func(timeout time.Duration),
 ) (*daemon.IdleController, bool, error) {
 	timeout, err := dcfg.AutostartIdleTimeoutDuration()
 	if err != nil {
@@ -827,7 +888,14 @@ func newAutostartIdleController(
 	if !daemon.AutostartIdleShutdownEligible(daemonEndpoint, webEndpoint, dcfg) {
 		return nil, true, nil
 	}
-	return daemon.NewIdleController(timeout, cancel), false, nil
+	return daemon.NewIdleController(timeout, func() { onIdle(timeout) }), false, nil
+}
+
+// announceIdleShutdown records why an auto-started daemon is exiting. The
+// detached daemon's stderr is its daemon.log, so this is the only trace of an
+// idle exit an operator can find later.
+func announceIdleShutdown(w io.Writer, timeout time.Duration) {
+	_, _ = fmt.Fprintf(w, "kata daemon: idle shutdown after %s without client activity\n", timeout)
 }
 
 // runDaemonWithListen is the variant used by `kata daemon start --foreground --listen`.
@@ -901,7 +969,10 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		os.Getenv(daemon.AutoStartMarkerEnv) == "1",
 		runtimeEndpoint,
 		webEndpoint,
-		shutdownTrigger.Call,
+		func(timeout time.Duration) {
+			announceIdleShutdown(os.Stderr, timeout)
+			shutdownTrigger.Call()
+		},
 	)
 	if err != nil {
 		return err
@@ -911,12 +982,10 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 			"kata daemon: auto-start idle shutdown disabled because the daemon is not owner-local")
 	}
 	var acquireHookDrain hooks.AcquireActivity
-	var foregroundAdmission activity.Admission
 	var waitableDrainAdmission activity.WaitableAdmission
 	if idleController != nil {
 		acquireHookDrain = idleController.DrainAdmission()
 		waitableDrainAdmission = idleController.WaitableDrainAdmission()
-		foregroundAdmission = idleController.ForegroundAdmission()
 	}
 
 	disp, daemonLog, err := setupHooks(
@@ -1007,7 +1076,7 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	// daemon_signaling_{unix,windows}.go.
 	sigs, reloadCleanup := installReloadSource(ctx, ns.DBHash)
 	workers.Go(func() {
-		runReloadLoop(ctx, sigs, hookCfgPath, disp, daemonLog, foregroundAdmission)
+		runReloadLoop(ctx, sigs, hookCfgPath, disp, daemonLog)
 	})
 	federationWake := startFederationRunner(
 		ctx, workers, waitableDrainAdmission, store, broadcaster, disp, daemonLog,

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/client"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
@@ -41,9 +42,14 @@ func newDaemonCmd() *cobra.Command {
 
 const daemonTelemetryHeartbeatInterval = 24 * time.Hour
 
-// daemonRestartShutdownTimeout covers the sequential 10-second HTTP and hook
-// shutdown budgets, plus a small allowance for the remaining process cleanup.
-const daemonRestartShutdownTimeout = 25 * time.Second
+const (
+	// daemonShutdownDrainTimeout is the shared budget for draining HTTP
+	// handlers, daemon workers, hooks, and platform cleanup.
+	daemonShutdownDrainTimeout = 25 * time.Second
+	// daemonRestartProcessWaitTimeout leaves time after the internal drain
+	// deadline for final cleanup and observable process exit.
+	daemonRestartProcessWaitTimeout = daemonShutdownDrainTimeout + 5*time.Second
+)
 
 var newTelemetryReporter = func(opts telemetry.Options) telemetry.Client {
 	return telemetry.NewReporterOrDisabled(opts)
@@ -58,6 +64,17 @@ var newGitHubSyncDaemonRunner = func(config githubsync.RunnerConfig) githubSyncD
 }
 
 var newGitHubSyncHTTPFetcher = githubsync.NewHTTPFetcher
+
+var openEmbeddingVectorIndex = func(
+	ctx context.Context,
+	store db.Storage,
+	vectorsPath string,
+) (*vector.Index, error) {
+	if postgresStore, ok := store.(*pgstore.Store); ok {
+		return vector.OpenPostgres(ctx, postgresStore.DB)
+	}
+	return vector.Open(ctx, vectorsPath)
+}
 
 func newConfiguredGitHubSyncFetcher(cfg config.GitHubSyncConfig) githubsync.Fetcher {
 	return newGitHubSyncHTTPFetcher(githubsync.HTTPFetcherConfig{
@@ -536,7 +553,7 @@ func daemonRestartCmd() *cobra.Command {
 				}
 				pids = append(pids, rec.PID)
 			}
-			if err := waitForDaemonProcesses(cmd.Context(), pids, daemonRestartShutdownTimeout); err != nil {
+			if err := waitForDaemonProcesses(cmd.Context(), pids, daemonRestartProcessWaitTimeout); err != nil {
 				return err
 			}
 			out, err := startDetachedDaemon(cmd.Context(), listen, insecureReadonly)
@@ -793,12 +810,32 @@ func redactRuntimeDSN(dsn string) string {
 	return dsn
 }
 
+func newAutostartIdleController(
+	dcfg config.DaemonConfig,
+	autostart bool,
+	daemonEndpoint kitdaemon.Endpoint,
+	webEndpoint daemon.WebEndpoint,
+	cancel context.CancelFunc,
+) (*daemon.IdleController, bool, error) {
+	timeout, err := dcfg.AutostartIdleTimeoutDuration()
+	if err != nil {
+		return nil, false, err
+	}
+	if !autostart || timeout == 0 {
+		return nil, false, nil
+	}
+	if !daemon.AutostartIdleShutdownEligible(daemonEndpoint, webEndpoint, dcfg) {
+		return nil, true, nil
+	}
+	return daemon.NewIdleController(timeout, cancel), false, nil
+}
+
 // runDaemonWithListen is the variant used by `kata daemon start --foreground --listen`.
 // An empty listen string uses the platform default unless
 // <KATA_HOME>/config.toml has a `listen = "..."` entry, in which case the
 // config value is used. CLI flag always wins over config.
 // insecureReadonly is the dev escape hatch from --insecure-readonly.
-func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bool) error {
+func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bool) (returnErr error) {
 	startup, err := preflightDaemonStartup(ctx, listen, insecureReadonly)
 	if err != nil {
 		return err
@@ -823,64 +860,19 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	// process by main.go's signal.NotifyContext already cancels ctx.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	stopCleanup := installStopWatcher(ns.DBHash, cancel)
-	defer stopCleanup()
+	shutdownTrigger := newDaemonShutdownTrigger(cancel)
+	workers := newDaemonWorkerGroup()
+	closeDependencies := true
+	hooksClosed := false
 
 	dbPath := startup.DBPath
 	store, err := storeopen.OpenWithConfig(ctx, dbPath, startup.StoreConfig, db.Serving())
 	if err != nil {
 		return err
 	}
-	defer func() { _ = store.Close() }()
-
-	disp, daemonLog, err := setupHooks(store, ns.DBHash, startup.KataHome, startup.HookConfig)
-	if err != nil {
-		return err
-	}
-	defer shutdownHooks(disp)
-	hookCfgPath := startup.HookConfigPath
-
-	telemetryReporter := newDaemonTelemetryReporter(store)
 	defer func() {
-		if err := telemetryReporter.Close(); err != nil {
-			daemonLog.Printf("telemetry: close: %v", err)
-		}
-	}()
-	captureDaemonStartedTelemetry(ctx, store, telemetryReporter)
-	startDaemonTelemetryHeartbeat(ctx, store, telemetryReporter)
-
-	// installReloadSource is platform-specific: SIGHUP delivery on Unix,
-	// a named reload event pumped onto the channel on Windows. See
-	// daemon_signaling_{unix,windows}.go.
-	sigs, reloadCleanup := installReloadSource(ctx, ns.DBHash)
-	defer reloadCleanup()
-	go runReloadLoop(ctx, sigs, hookCfgPath, disp, daemonLog)
-	broadcaster := daemon.NewEventBroadcaster()
-	federationWake := startFederationRunner(ctx, store, broadcaster, disp, daemonLog)
-	federationConfigHealth := startFederationConfigReconciler(
-		ctx, dcfg, store, federationWake, func(event db.Event) {
-			broadcaster.Broadcast(daemon.StreamMsg{
-				Kind: "event", Event: &event, ProjectID: event.ProjectID,
-			})
-			disp.Enqueue(event)
-		}, daemonLog,
-	)
-	gitHubSyncFetcher := newConfiguredGitHubSyncFetcher(dcfg.GitHubSync)
-	gitHubSyncWake := startGitHubSyncRunner(ctx, store, gitHubSyncFetcher, broadcaster, disp, daemonLog)
-	closeThrottleWindow, err := dcfg.Close.Throttle.ThrottleWindow()
-	if err != nil {
-		return err
-	}
-
-	embedder, vectorIndex, reconcilerHealth, err := startEmbeddingReconciler(
-		ctx, dcfg.Search.Embeddings, startup.Embedder, startup.VectorsPath, store, broadcaster, daemonLog,
-	)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if vectorIndex != nil {
-			_ = vectorIndex.Close()
+		if closeDependencies {
+			_ = store.Close()
 		}
 	}()
 
@@ -904,6 +896,59 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	if webEndpoint.Listener != nil {
 		defer func() { _ = webEndpoint.Listener.Close() }()
 	}
+	idleController, idleIneligible, err := newAutostartIdleController(
+		*dcfg,
+		os.Getenv(daemon.AutoStartMarkerEnv) == "1",
+		runtimeEndpoint,
+		webEndpoint,
+		shutdownTrigger.Call,
+	)
+	if err != nil {
+		return err
+	}
+	if idleIneligible {
+		fmt.Fprintln(os.Stderr,
+			"kata daemon: auto-start idle shutdown disabled because the daemon is not owner-local")
+	}
+	var acquireHookDrain hooks.AcquireActivity
+	var foregroundAdmission activity.Admission
+	var waitableDrainAdmission activity.WaitableAdmission
+	if idleController != nil {
+		acquireHookDrain = idleController.DrainAdmission()
+		waitableDrainAdmission = idleController.WaitableDrainAdmission()
+		foregroundAdmission = idleController.ForegroundAdmission()
+	}
+
+	disp, daemonLog, err := setupHooks(
+		store, ns.DBHash, startup.KataHome, startup.HookConfig, acquireHookDrain,
+		withoutEnvironmentKey(os.Environ(), daemon.AutoStartMarkerEnv),
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeDependencies && !hooksClosed {
+			fallbackCtx, fallbackCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer fallbackCancel()
+			_ = disp.Shutdown(fallbackCtx)
+		}
+	}()
+	hookCfgPath := startup.HookConfigPath
+
+	telemetryReporter := newDaemonTelemetryReporter(store)
+	defer func() {
+		if !closeDependencies {
+			return
+		}
+		if err := telemetryReporter.Close(); err != nil {
+			daemonLog.Printf("telemetry: close: %v", err)
+		}
+	}()
+	closeThrottleWindow, err := dcfg.Close.Throttle.ThrottleWindow()
+	if err != nil {
+		return err
+	}
+
 	allowLocalSession := webEndpoint.AllowsLocalSession(dcfg.Auth)
 	allowTrustedProxySession := webEndpoint.AllowsTrustedProxySession(dcfg.Auth)
 	updates := "sse"
@@ -934,6 +979,57 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	if err != nil {
 		return err
 	}
+	rec := kitdaemon.NewRuntimeRecord("kata", version.Version, runtimeEndpoint)
+	rec.Address = runtimeEndpoint.ConfigAddress()
+	rec.Metadata = map[string]string{"db_path": redactRuntimeDSN(dbPath)}
+	for key, value := range webRuntime.Metadata() {
+		rec.Metadata[key] = value
+	}
+
+	broadcaster := daemon.NewEventBroadcaster()
+	embedder, vectorIndex, reconcilerHealth, err := startEmbeddingReconciler(
+		ctx, workers, waitableDrainAdmission, dcfg.Search.Embeddings, startup.Embedder, startup.VectorsPath, store, broadcaster, daemonLog,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeDependencies && vectorIndex != nil {
+			_ = vectorIndex.Close()
+		}
+	}()
+
+	captureDaemonStartedTelemetry(ctx, store, telemetryReporter)
+	startDaemonTelemetryHeartbeat(ctx, workers, store, telemetryReporter)
+	stopCleanup := installStopWatcher(ns.DBHash, shutdownTrigger.Call)
+	// installReloadSource is platform-specific: SIGHUP delivery on Unix,
+	// a named reload event pumped onto the channel on Windows. See
+	// daemon_signaling_{unix,windows}.go.
+	sigs, reloadCleanup := installReloadSource(ctx, ns.DBHash)
+	workers.Go(func() {
+		runReloadLoop(ctx, sigs, hookCfgPath, disp, daemonLog, foregroundAdmission)
+	})
+	federationWake := startFederationRunner(
+		ctx, workers, waitableDrainAdmission, store, broadcaster, disp, daemonLog,
+	)
+	federationConfigHealth := startFederationConfigReconciler(
+		ctx, workers, waitableDrainAdmission, dcfg, store, federationWake, func(event db.Event, fork activity.Admission) {
+			broadcaster.Broadcast(daemon.StreamMsg{
+				Kind: "event", Event: &event, ProjectID: event.ProjectID,
+			})
+			hooks.EnqueueFrom(disp, event, fork)
+		}, daemonLog,
+	)
+	gitHubSyncFetcher := newConfiguredGitHubSyncFetcher(dcfg.GitHubSync)
+	gitHubSyncWake := startGitHubSyncRunner(
+		ctx, workers, waitableDrainAdmission, store, gitHubSyncFetcher, broadcaster, disp, daemonLog,
+	)
+	var idleHealth func() daemon.IdleSnapshot
+	var idleAdmission daemon.IdleForegroundAdmission
+	if idleController != nil {
+		idleHealth = idleController.Snapshot
+		idleAdmission = idleController
+	}
 	srv := daemon.NewServer(daemon.ServerConfig{
 		DB:                store,
 		DefaultTimezone:   dcfg.Timezone,
@@ -959,23 +1055,37 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		VectorIndex:            vectorIndex,
 		ReconcilerHealth:       reconcilerHealth,
 		FederationConfigHealth: federationConfigHealth,
+		IdleAdmission:          idleAdmission,
+		IdleShutdownHealth:     idleHealth,
 	})
 	defer func() { _ = srv.Close() }()
-	rec := kitdaemon.NewRuntimeRecord("kata", version.Version, runtimeEndpoint)
-	rec.Address = runtimeEndpoint.ConfigAddress()
-	rec.Metadata = map[string]string{"db_path": redactRuntimeDSN(dbPath)}
-	for key, value := range webRuntime.Metadata() {
-		rec.Metadata[key] = value
+	var stopAdmission func()
+	if idleController != nil {
+		stopAdmission = idleController.Stop
 	}
-	if _, err := runtimeStore.Write(rec); err != nil {
-		return err
-	}
-	runtimeFile := filepath.Join(ns.DataDir, fmt.Sprintf("daemon.%d.json", os.Getpid()))
-	defer func() { _ = os.Remove(runtimeFile) }()
-
-	if listen != "" {
-		fmt.Fprintf(os.Stderr, "kata daemon: listening on %s\n", rec.Endpoint().ConfigAddress())
-	}
+	shutdown := startDaemonShutdownCoordinator(
+		ctx,
+		cancel,
+		workers,
+		disp,
+		stopAdmission,
+		daemonShutdownDrainTimeout,
+		stopCleanup,
+		reloadCleanup,
+	)
+	shutdownTrigger.Set(shutdown.Trigger)
+	httpHandlersJoined := true
+	defer func() {
+		shutdown.HTTPHandlersDone(httpHandlersJoined)
+		shutdown.Trigger()
+		result := shutdown.Wait()
+		if result.SafeToCloseDependencies() {
+			hooksClosed = true
+		} else {
+			closeDependencies = false
+		}
+		returnErr = errors.Join(returnErr, result.Err())
+	}()
 
 	mainPolicy := daemon.ListenerPolicy{Kind: daemon.ListenerSocket}
 	bindings := []daemon.ListenerBinding{{Listener: listener, Policy: mainPolicy}}
@@ -1001,7 +1111,43 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 			},
 		})
 	}
-	return srv.ServeListeners(ctx, bindings...)
+	var runtimeFile string
+	defer func() {
+		if runtimeFile != "" {
+			_ = os.Remove(runtimeFile)
+		}
+	}()
+	onReady := func() error {
+		return shutdown.PublishReady(ctx, func() error {
+			path, err := runtimeStore.Write(rec)
+			if err != nil {
+				return err
+			}
+			runtimeFile = path
+			if idleController != nil {
+				idleController.Start()
+			}
+			if listen != "" {
+				fmt.Fprintf(os.Stderr, "kata daemon: listening on %s\n", rec.Endpoint().ConfigAddress())
+			}
+			return nil
+		})
+	}
+	httpHandlersJoined = false
+	serveErr := srv.ServeListenersWithLifecycle(ctx, onReady, shutdown.Trigger, bindings...)
+	httpHandlersJoined = !errors.Is(serveErr, daemon.ErrHTTPHandlersUnjoined)
+	shutdown.HTTPHandlersDone(httpHandlersJoined)
+	shutdown.Trigger()
+	if runtimeFile != "" {
+		_ = os.Remove(runtimeFile)
+	}
+	if errors.Is(serveErr, daemon.ErrHTTPHandlersUnjoined) {
+		closeDependencies = false
+	}
+	if errors.Is(serveErr, errDaemonStoppingBeforeReady) {
+		return nil
+	}
+	return serveErr
 }
 
 func webAuthenticationMode(
@@ -1036,15 +1182,20 @@ func captureDaemonStartedTelemetry(ctx context.Context, store db.Storage, report
 	captureDaemonTelemetryEvent(ctx, store, reporter, "daemon_started")
 }
 
-func startDaemonTelemetryHeartbeat(ctx context.Context, store db.Storage, reporter telemetry.Client) {
+func startDaemonTelemetryHeartbeat(
+	ctx context.Context,
+	workers *daemonWorkerGroup,
+	store db.Storage,
+	reporter telemetry.Client,
+) {
 	if reporter == nil || !reporter.Enabled() {
 		return
 	}
-	go func() {
+	workers.Go(func() {
 		runDaemonTelemetryHeartbeat(ctx, func(ctx context.Context) {
 			captureDaemonTelemetryEvent(ctx, store, reporter, "daemon_active")
 		})
-	}()
+	})
 }
 
 func runDaemonTelemetryHeartbeat(ctx context.Context, capture func(context.Context)) {
@@ -1088,6 +1239,8 @@ func captureDaemonTelemetryEvent(ctx context.Context, store db.Storage, reporter
 
 func startFederationRunner(
 	ctx context.Context,
+	workers *daemonWorkerGroup,
+	drainAdmission activity.WaitableAdmission,
 	store db.Storage,
 	bcast *daemon.EventBroadcaster,
 	hookSink hooks.Sink,
@@ -1101,7 +1254,7 @@ func startFederationRunner(
 		}
 	}
 	sub := bcast.Subscribe(daemon.SubFilter{})
-	go func() {
+	workers.Go(func() {
 		defer sub.Unsub()
 		for {
 			select {
@@ -1117,36 +1270,38 @@ func startFederationRunner(
 				wakeRunner()
 			}
 		}
-	}()
+	})
 	runner := &federation.Runner{
-		DB:       store,
-		Interval: federationRunnerInterval(),
-		Wake:     wake,
+		DB:             store,
+		Interval:       federationRunnerInterval(),
+		Wake:           wake,
+		DrainAdmission: drainAdmission,
 		OnError: func(err error) {
 			daemonLog.Printf("federation: %v", err)
 		},
-		OnPulledEvents: func(projectID int64, events []db.Event) {
+		OnPulledEventsFrom: func(projectID int64, events []db.Event, fork activity.Admission) {
 			for i := range events {
 				event := events[i]
 				bcast.Broadcast(daemon.StreamMsg{Kind: "event", Event: &event, ProjectID: projectID})
-				hookSink.Enqueue(event)
+				hooks.EnqueueFrom(hookSink, event, fork)
 			}
 		},
 	}
-	go func() {
+	workers.Go(func() {
 		if err := runner.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			daemonLog.Printf("federation: %v", err)
 		}
-	}()
+	})
 	sweeper := daemon.NewTimedClaimSweeper(store, bcast, hookSink)
+	sweeper.IdleAdmission = drainAdmission
 	sweeper.OnError = func(err error) {
 		daemonLog.Printf("claim sweeper: %v", err)
 	}
-	go func() {
+	workers.Go(func() {
 		if err := sweeper.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			daemonLog.Printf("claim sweeper: %v", err)
 		}
-	}()
+	})
 	return wakeRunner
 }
 
@@ -1210,6 +1365,8 @@ func preflightEmbeddingStartup(
 // lifetime and must close it on shutdown.
 func startEmbeddingReconciler(
 	ctx context.Context,
+	workers *daemonWorkerGroup,
+	drainAdmission activity.WaitableAdmission,
 	ec config.EmbeddingsConfig,
 	embedder *embedding.Client,
 	vectorsPath string,
@@ -1220,23 +1377,20 @@ func startEmbeddingReconciler(
 	if embedder == nil {
 		return nil, nil, nil, nil
 	}
-	var idx *vector.Index
-	var err error
-	if postgresStore, ok := store.(*pgstore.Store); ok {
-		idx, err = vector.OpenPostgres(ctx, postgresStore.DB)
-	} else {
-		idx, err = vector.Open(ctx, vectorsPath)
-	}
+	idx, err := openEmbeddingVectorIndex(ctx, store, vectorsPath)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("embedding index: %w", err)
 	}
-	reconciler := daemon.NewReconciler(store, idx, embedder, daemon.ReconcilerConfig{BatchSize: ec.BatchSize})
-	go func() {
+	reconciler := daemon.NewReconciler(store, idx, embedder, daemon.ReconcilerConfig{
+		BatchSize:      ec.BatchSize,
+		DrainAdmission: drainAdmission,
+	})
+	workers.Go(func() {
 		if err := reconciler.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			daemonLog.Printf("reconciler: %v", err)
 		}
-	}()
-	startEmbeddingNudge(ctx, bcast, reconciler)
+	})
+	startEmbeddingNudge(ctx, workers, bcast, reconciler)
 	reconciler.Wake() // initial backfill sweep
 	return embedder, idx, reconciler.Health, nil
 }
@@ -1245,9 +1399,14 @@ func startEmbeddingReconciler(
 // every committed event so new/edited issues are embedded promptly. The
 // goroutine exits when ctx is cancelled or the subscription channel closes, and
 // always releases the subscription via Unsub.
-func startEmbeddingNudge(ctx context.Context, bcast *daemon.EventBroadcaster, r *daemon.Reconciler) {
+func startEmbeddingNudge(
+	ctx context.Context,
+	workers *daemonWorkerGroup,
+	bcast *daemon.EventBroadcaster,
+	r *daemon.Reconciler,
+) {
 	sub := bcast.Subscribe(daemon.SubFilter{})
-	go func() {
+	workers.Go(func() {
 		defer sub.Unsub()
 		for {
 			select {
@@ -1262,7 +1421,7 @@ func startEmbeddingNudge(ctx context.Context, bcast *daemon.EventBroadcaster, r 
 				}
 			}
 		}
-	}()
+	})
 }
 
 func federationRunnerInterval() time.Duration {
@@ -1279,6 +1438,8 @@ func federationRunnerInterval() time.Duration {
 
 func startGitHubSyncRunner(
 	ctx context.Context,
+	workers *daemonWorkerGroup,
+	drainAdmission activity.WaitableAdmission,
 	store db.Storage,
 	fetcher githubsync.Fetcher,
 	bcast *daemon.EventBroadcaster,
@@ -1306,21 +1467,27 @@ func startGitHubSyncRunner(
 		logger = slog.New(slog.NewTextHandler(daemonLog.Writer(), nil))
 	}
 	runner := newGitHubSyncDaemonRunner(githubsync.RunnerConfig{
-		Store:    store,
-		Fetcher:  fetcher,
-		Logger:   logger,
-		Interval: githubSyncRunnerInterval(),
-		Wake:     wake,
-		EventSink: func(_ context.Context, projectID int64, events []db.Event) error {
+		Store:          store,
+		Fetcher:        fetcher,
+		Logger:         logger,
+		Interval:       githubSyncRunnerInterval(),
+		Wake:           wake,
+		DrainAdmission: drainAdmission,
+		EventSinkFrom: func(
+			_ context.Context,
+			projectID int64,
+			events []db.Event,
+			fork activity.Admission,
+		) error {
 			for i := range events {
 				event := events[i]
 				bcast.Broadcast(daemon.StreamMsg{Kind: "event", Event: &event, ProjectID: projectID})
-				hookSink.Enqueue(event)
+				hooks.EnqueueFrom(hookSink, event, fork)
 			}
 			return nil
 		},
 	})
-	go func() {
+	workers.Go(func() {
 		if err := runner.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			if daemonLog != nil {
 				daemonLog.Printf("github sync: %v", err)
@@ -1328,7 +1495,7 @@ func startGitHubSyncRunner(
 				slog.Warn("github sync", "err", err)
 			}
 		}
-	}()
+	})
 	return wakeRunner
 }
 
@@ -1425,6 +1592,8 @@ func setupHooks(
 	dbHash string,
 	home string,
 	loaded hooks.LoadedConfig,
+	acquireDrain hooks.AcquireActivity,
+	environment []string,
 ) (*hooks.Dispatcher, *log.Logger, error) {
 	if err := os.MkdirAll(home, 0o700); err != nil {
 		return nil, nil, err
@@ -1440,6 +1609,8 @@ func setupHooks(
 		ProjectResolver: makeProjectResolver(store),
 		Now:             time.Now,
 		GraceWindow:     5 * time.Second,
+		AcquireDrain:    acquireDrain,
+		Environment:     environment,
 	}
 	disp, err := hooks.New(loaded, deps)
 	if err != nil {
@@ -1448,12 +1619,14 @@ func setupHooks(
 	return disp, daemonLog, nil
 }
 
-// shutdownHooks drives the dispatcher's Shutdown with a 10s ceiling.
-// Errors (timeout, in-flight jobs) are not returned: the daemon exit
-// path proceeds either way, with the dispatcher's own log capturing
-// the timeout reason.
-func shutdownHooks(disp *hooks.Dispatcher) {
-	sctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	_ = disp.Shutdown(sctx)
+func withoutEnvironmentKey(environment []string, key string) []string {
+	filtered := make([]string, 0, len(environment))
+	for _, entry := range environment {
+		name, _, hasValue := strings.Cut(entry, "=")
+		if hasValue && strings.EqualFold(name, key) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -793,6 +793,120 @@ func TestDaemonStartOutputFromRecordIncludesWebURL(t *testing.T) {
 	assert.Equal(t, "http://127.0.0.1:28888", out.WebURL)
 }
 
+func writeIdleDaemonHealthServer(t *testing.T, idleShutdown bool) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/api/v1/health":
+			if idleShutdown {
+				_, _ = fmt.Fprintf(writer,
+					`{"ok":true,"api_schema_version":%q,"idle_shutdown":{"timeout":"15m0s","state":"armed"}}`,
+					daemon.APISchemaVersion)
+				return
+			}
+			_, _ = fmt.Fprintf(writer, `{"ok":true,"api_schema_version":%q}`, daemon.APISchemaVersion)
+		case "/api/v1/ping":
+			_, _ = writer.Write([]byte(`{"ok":true,"service":"kata"}`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func writeRuntimeRecordFor(t *testing.T, home, addr string, pid int) {
+	t.Helper()
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	require.NoError(t, ns.EnsureDirs())
+	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
+		PID:       pid,
+		Address:   addr,
+		Metadata:  map[string]string{"db_path": filepath.Join(home, "kata.db")},
+		StartedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+}
+
+func TestDaemonStart_ReplacesIdleAutostartDaemon(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the test helper does not install the Windows daemon stop event watcher")
+	}
+	resetFlags(t)
+	home := setupKataEnv(t)
+	child := startSleepProcess(t)
+	exited := make(chan struct{})
+	go func() {
+		_ = child.Wait()
+		close(exited)
+	}()
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		<-exited
+	})
+	server := writeIdleDaemonHealthServer(t, true)
+	writeRuntimeRecordFor(t, home, strings.TrimPrefix(server.URL, "http://"), child.Process.Pid)
+
+	orig := launchDetachedDaemon
+	t.Cleanup(func() { launchDetachedDaemon = orig })
+	launchDetachedDaemon = func(context.Context, string, string, bool) (daemonStartOutput, error) {
+		select {
+		case <-exited:
+			return daemonStartOutput{Action: "started", PID: 4243, Address: "127.0.0.1:7777"}, nil
+		default:
+			return daemonStartOutput{}, errors.New("replacement started before the idle daemon stopped")
+		}
+	}
+
+	out, err := defaultStartDetachedDaemon(context.Background(), "", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, "replaced", out.Action)
+	assert.Equal(t, 4243, out.PID)
+	assert.Equal(t, child.Process.Pid, out.ReplacedPID)
+}
+
+func TestDaemonStart_KeepsResidentDaemonWithoutIdleShutdown(t *testing.T) {
+	resetFlags(t)
+	home := setupKataEnv(t)
+	server := writeIdleDaemonHealthServer(t, false)
+	address := strings.TrimPrefix(server.URL, "http://")
+	writeRuntimeRecordFor(t, home, address, os.Getpid())
+
+	orig := launchDetachedDaemon
+	t.Cleanup(func() { launchDetachedDaemon = orig })
+	launchDetachedDaemon = func(context.Context, string, string, bool) (daemonStartOutput, error) {
+		return daemonStartOutput{}, errors.New("resident daemon must not be replaced")
+	}
+
+	out, err := defaultStartDetachedDaemon(context.Background(), "", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, "already_running", out.Action)
+	assert.Equal(t, os.Getpid(), out.PID)
+	assert.Equal(t, address, out.Address)
+}
+
+func TestDaemonStart_ReportsReplacedDaemon(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+	oldStart := startDetachedDaemon
+	t.Cleanup(func() { startDetachedDaemon = oldStart })
+	startDetachedDaemon = func(context.Context, string, bool) (daemonStartOutput, error) {
+		return daemonStartOutput{
+			Action: "replaced", PID: 1234, ReplacedPID: 1111, Address: "127.0.0.1:7777",
+		}, nil
+	}
+
+	stdout, stderr, err := executeRootCapture(t, context.Background(), "daemon", "start")
+
+	require.NoError(t, err)
+	assert.Equal(t, "replaced auto-started daemon pid=1111; started pid=1234 address=127.0.0.1:7777\n", stdout)
+	assert.Empty(t, stderr)
+}
+
 func TestDaemonStart_ListenConflictWithExistingDaemon(t *testing.T) {
 	resetFlags(t)
 	home := setupKataEnv(t)
@@ -1682,7 +1796,7 @@ func TestAutostartIdleControllerRequiresMarkerAndOwnerLocalExposure(t *testing.T
 	configured := config.DaemonConfig{AutostartIdleTimeout: "15m"}
 
 	controller, ineligible, err := newAutostartIdleController(
-		configured, false, localDaemon, localWeb, func() {},
+		configured, false, localDaemon, localWeb, func(time.Duration) {},
 	)
 	require.NoError(t, err)
 	require.Nil(t, controller)
@@ -1691,19 +1805,27 @@ func TestAutostartIdleControllerRequiresMarkerAndOwnerLocalExposure(t *testing.T
 	controller, ineligible, err = newAutostartIdleController(
 		configured, true,
 		kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "100.64.0.5:7777"},
-		localWeb, func() {},
+		localWeb, func(time.Duration) {},
 	)
 	require.NoError(t, err)
 	require.Nil(t, controller)
 	require.True(t, ineligible)
 
 	controller, ineligible, err = newAutostartIdleController(
-		configured, true, localDaemon, localWeb, func() {},
+		configured, true, localDaemon, localWeb, func(time.Duration) {},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, controller)
 	require.False(t, ineligible)
 	require.Equal(t, 15*time.Minute, controller.Snapshot().Timeout)
+}
+
+func TestAnnounceIdleShutdownNamesTheTimeout(t *testing.T) {
+	var out bytes.Buffer
+
+	announceIdleShutdown(&out, 15*time.Minute)
+
+	assert.Equal(t, "kata daemon: idle shutdown after 15m0s without client activity\n", out.String())
 }
 
 func TestWithoutEnvironmentKeyRemovesOnlyAutostartMarker(t *testing.T) {

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -36,6 +36,7 @@ import (
 	"go.kenn.io/kata/internal/hooks"
 	"go.kenn.io/kata/internal/telemetry"
 	"go.kenn.io/kata/internal/testenv"
+	"go.kenn.io/kata/internal/vector"
 	kitdaemon "go.kenn.io/kit/daemon"
 )
 
@@ -558,6 +559,122 @@ func TestDaemonStart_RuntimeRecordSerializesTCPAddressAsHostPort(t *testing.T) {
 	assert.NotContains(t, got.Address, "://")
 }
 
+func TestAutostartDaemonPublishesRuntimeThenExitsAfterIdleTimeout(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+	t.Setenv("PORT", "")
+	t.Setenv(daemon.AutoStartMarkerEnv, "1")
+	t.Setenv("KATA_AUTOSTART_IDLE_TIMEOUT", "10s")
+
+	orig := newTelemetryReporter
+	newTelemetryReporter = func(telemetry.Options) telemetry.Client {
+		return &fakeTelemetryReporter{}
+	}
+	t.Cleanup(func() { newTelemetryReporter = orig })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	exited := make(chan struct{})
+	go func() {
+		defer close(exited)
+		done <- runDaemonWithListen(ctx, "", false)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-exited:
+		case <-time.After(3 * time.Second):
+			t.Error("daemon did not stop during test cleanup")
+		}
+	})
+
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	runtimePath, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Path(os.Getpid())
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(runtimePath)
+		return statErr == nil
+	}, 3*time.Second, 10*time.Millisecond, "daemon did not publish its runtime record")
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("auto-started daemon did not exit after its idle timeout")
+	}
+	_, err = os.Stat(runtimePath)
+	require.ErrorIs(t, err, os.ErrNotExist, "idle exit left a discoverable runtime record")
+}
+
+func TestDaemonDoesNotPublishRuntimeBeforeEmbeddingInitializationCompletes(t *testing.T) {
+	resetFlags(t)
+	home := setupKataEnv(t)
+	t.Setenv("PORT", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[search.embeddings]
+base_url = "http://127.0.0.1:1"
+model = "example-model"
+`), 0o600))
+
+	originalTelemetry := newTelemetryReporter
+	newTelemetryReporter = func(telemetry.Options) telemetry.Client {
+		return &fakeTelemetryReporter{}
+	}
+	t.Cleanup(func() { newTelemetryReporter = originalTelemetry })
+
+	originalOpen := openEmbeddingVectorIndex
+	initializing := make(chan struct{})
+	releaseInitialization := make(chan struct{})
+	var releaseOnce sync.Once
+	openEmbeddingVectorIndex = func(context.Context, db.Storage, string) (*vector.Index, error) {
+		close(initializing)
+		<-releaseInitialization
+		return nil, errors.New("test embedding index failure")
+	}
+	t.Cleanup(func() { openEmbeddingVectorIndex = originalOpen })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	exited := make(chan struct{})
+	go func() {
+		defer close(exited)
+		done <- runDaemonWithListen(ctx, "127.0.0.1:0", false)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		releaseOnce.Do(func() { close(releaseInitialization) })
+		select {
+		case <-exited:
+		case <-time.After(3 * time.Second):
+			t.Error("daemon did not stop during test cleanup")
+		}
+	})
+
+	select {
+	case <-initializing:
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon did not begin embedding initialization")
+	}
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	runtimePath, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Path(os.Getpid())
+	require.NoError(t, err)
+	_, err = os.Stat(runtimePath)
+	require.ErrorIs(t, err, os.ErrNotExist,
+		"daemon advertised readiness while embedding initialization was blocked")
+
+	releaseOnce.Do(func() { close(releaseInitialization) })
+	select {
+	case runErr := <-done:
+		require.ErrorContains(t, runErr, "test embedding index failure")
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon did not return after embedding initialization failed")
+	}
+	_, err = os.Stat(runtimePath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 type daemonRuntimeRecordJSON struct {
 	Network string `json:"network"`
 	Address string `json:"address"`
@@ -992,6 +1109,10 @@ func TestDaemonRestart_AllowsFullGracefulShutdownBudget(t *testing.T) {
 	out := executeRoot(t, newRootCmd(), "daemon", "restart")
 
 	assert.Equal(t, "restarted pid=4244 address=127.0.0.1:7777\n", string(out))
+}
+
+func TestDaemonRestartReservesProcessExitMarginBeyondDrainBudget(t *testing.T) {
+	require.Equal(t, 5*time.Second, daemonRestartProcessWaitTimeout-daemonShutdownDrainTimeout)
 }
 
 func TestDaemonRestart_JSONReportsStartedDaemon(t *testing.T) {
@@ -1552,6 +1673,54 @@ func TestListenFromPortEnv(t *testing.T) {
 	})
 }
 
+func TestAutostartIdleControllerRequiresMarkerAndOwnerLocalExposure(t *testing.T) {
+	localDaemon := kitdaemon.Endpoint{Network: kitdaemon.NetworkUnix, Address: "/tmp/kata.sock"}
+	localWeb := daemon.WebEndpoint{
+		Endpoint: kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "127.0.0.1:27123"},
+		Origin:   "http://127.0.0.1:27123",
+	}
+	configured := config.DaemonConfig{AutostartIdleTimeout: "15m"}
+
+	controller, ineligible, err := newAutostartIdleController(
+		configured, false, localDaemon, localWeb, func() {},
+	)
+	require.NoError(t, err)
+	require.Nil(t, controller)
+	require.False(t, ineligible)
+
+	controller, ineligible, err = newAutostartIdleController(
+		configured, true,
+		kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "100.64.0.5:7777"},
+		localWeb, func() {},
+	)
+	require.NoError(t, err)
+	require.Nil(t, controller)
+	require.True(t, ineligible)
+
+	controller, ineligible, err = newAutostartIdleController(
+		configured, true, localDaemon, localWeb, func() {},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+	require.False(t, ineligible)
+	require.Equal(t, 15*time.Minute, controller.Snapshot().Timeout)
+}
+
+func TestWithoutEnvironmentKeyRemovesOnlyAutostartMarker(t *testing.T) {
+	got := withoutEnvironmentKey([]string{
+		"PATH=/example/bin",
+		daemon.AutoStartMarkerEnv + "=1",
+		"kata_autostart=1",
+		"Kata_Autostart=1",
+		"KATA_AUTOSTART_IDLE_TIMEOUT=15m",
+	}, daemon.AutoStartMarkerEnv)
+
+	assert.Equal(t, []string{
+		"PATH=/example/bin",
+		"KATA_AUTOSTART_IDLE_TIMEOUT=15m",
+	}, got)
+}
+
 // TestDaemonStart_PortEnvBindsWildcard verifies that when the platform
 // injects PORT and the daemon is started explicitly in the foreground (no auto-start
 // marker), with no --listen flag and no config value, the bind address
@@ -1894,7 +2063,7 @@ func TestDaemonStartGitHubSyncRunnerCreatesOneRunnerWithDaemonDBAndFetcher(t *te
 	t.Cleanup(func() { newGitHubSyncDaemonRunner = orig })
 
 	ctx, cancel := context.WithCancel(context.Background())
-	wake := startGitHubSyncRunner(ctx, store, fetcher, bcast, hooks.NewNoop(), log.New(io.Discard, "", 0))
+	wake := startGitHubSyncRunner(ctx, newDaemonWorkerGroup(), nil, store, fetcher, bcast, hooks.NewNoop(), log.New(io.Discard, "", 0))
 	defer cancel()
 
 	require.Eventually(t, func() bool {
@@ -1905,7 +2074,7 @@ func TestDaemonStartGitHubSyncRunnerCreatesOneRunnerWithDaemonDBAndFetcher(t *te
 	assert.Same(t, fetcher, configs[0].Fetcher)
 	assert.Equal(t, 25*time.Millisecond, configs[0].Interval)
 	assert.NotNil(t, configs[0].Wake)
-	assert.NotNil(t, configs[0].EventSink)
+	assert.NotNil(t, configs[0].EventSinkFrom)
 	assert.NotNil(t, configs[0].Logger)
 	require.NotNil(t, wake)
 	require.NotPanics(t, wake)
@@ -1926,7 +2095,7 @@ func TestDaemonStartGitHubSyncRunnerNilFetcherUsesHTTPFetcher(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	startGitHubSyncRunner(ctx, store, nil, daemon.NewEventBroadcaster(), hooks.NewNoop(), log.New(io.Discard, "", 0))
+	startGitHubSyncRunner(ctx, newDaemonWorkerGroup(), nil, store, nil, daemon.NewEventBroadcaster(), hooks.NewNoop(), log.New(io.Discard, "", 0))
 
 	require.Eventually(t, func() bool {
 		return runner.wasRun()
@@ -1944,7 +2113,7 @@ func TestDaemonGitHubSyncRunnerTickerSyncsDueBindingWithoutManualOnce(t *testing
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	startGitHubSyncRunner(ctx, store, fetcher, bcast, hooks.NewNoop(), log.New(io.Discard, "", 0))
+	startGitHubSyncRunner(ctx, newDaemonWorkerGroup(), nil, store, fetcher, bcast, hooks.NewNoop(), log.New(io.Discard, "", 0))
 
 	require.Eventually(t, func() bool {
 		got, err := store.IssueSyncBindingByID(context.Background(), binding.ID)
@@ -1968,7 +2137,7 @@ func TestDaemonGitHubSyncRunnerBroadcastsNativeImportEvents(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	startGitHubSyncRunner(ctx, store, fetcher, bcast, hookSink, log.New(io.Discard, "", 0))
+	startGitHubSyncRunner(ctx, newDaemonWorkerGroup(), nil, store, fetcher, bcast, hookSink, log.New(io.Discard, "", 0))
 
 	var msg daemon.StreamMsg
 	select {
@@ -1998,7 +2167,7 @@ func TestDaemonGitHubSyncRunnerDoesNotOverlapWakeWhileBindingIsInFlight(t *testi
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	wake := startGitHubSyncRunner(ctx, store, fetcher, daemon.NewEventBroadcaster(), hooks.NewNoop(), log.New(io.Discard, "", 0))
+	wake := startGitHubSyncRunner(ctx, newDaemonWorkerGroup(), nil, store, fetcher, daemon.NewEventBroadcaster(), hooks.NewNoop(), log.New(io.Discard, "", 0))
 
 	select {
 	case <-fetcher.blockRepository:

--- a/cmd/kata/daemon_federation_reconciler.go
+++ b/cmd/kata/daemon_federation_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/api"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/db"
@@ -23,10 +24,12 @@ var newFederationConfigReconciler = func(
 
 func startFederationConfigReconciler(
 	ctx context.Context,
+	workers *daemonWorkerGroup,
+	drainAdmission activity.WaitableAdmission,
 	daemonConfig *config.DaemonConfig,
 	store db.Storage,
 	federationWake func(),
-	projectEventSink func(db.Event),
+	projectEventSink func(db.Event, activity.Admission),
 	daemonLog *log.Logger,
 ) func() api.FederationConfigHealth {
 	if len(daemonConfig.Federation.Projects) == 0 {
@@ -50,13 +53,14 @@ func startFederationConfigReconciler(
 		) (federation.Hub, error) {
 			return federation.NewHubClient(ctx, catalog)
 		},
-		Wake:             federationWake,
-		ProjectEventSink: projectEventSink,
-		Logger:           daemonLog,
+		Wake:                 federationWake,
+		ProjectEventSinkFrom: projectEventSink,
+		DrainAdmission:       drainAdmission,
+		Logger:               daemonLog,
 	})
-	go func() {
+	workers.Go(func() {
 		_ = reconciler.Run(ctx)
-	}()
+	})
 	return func() api.FederationConfigHealth {
 		health := reconciler.Health()
 		return api.FederationConfigHealth{

--- a/cmd/kata/daemon_reload_loop.go
+++ b/cmd/kata/daemon_reload_loop.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 
-	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/hooks"
 )
 
@@ -32,33 +31,18 @@ func runReloadLoop(
 	configPath string,
 	disp reloadable,
 	lg loopLogger,
-	foregroundAdmission activity.Admission,
 ) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-sigs:
-			var lease *activity.Lease
-			if foregroundAdmission != nil {
-				var admitted bool
-				lease, admitted = foregroundAdmission()
-				if !admitted {
-					<-ctx.Done()
-					return
-				}
+			loaded, err := hooks.LoadReload(configPath, disp.CurrentConfig())
+			if err != nil {
+				lg.Printf("hooks reload failed: %v (keeping previous config)", err)
+				continue
 			}
-			func() {
-				if lease != nil {
-					defer lease.Release()
-				}
-				loaded, err := hooks.LoadReload(configPath, disp.CurrentConfig())
-				if err != nil {
-					lg.Printf("hooks reload failed: %v (keeping previous config)", err)
-					return
-				}
-				disp.Reload(loaded)
-			}()
+			disp.Reload(loaded)
 		}
 	}
 }

--- a/cmd/kata/daemon_reload_loop.go
+++ b/cmd/kata/daemon_reload_loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/hooks"
 )
 
@@ -31,18 +32,33 @@ func runReloadLoop(
 	configPath string,
 	disp reloadable,
 	lg loopLogger,
+	foregroundAdmission activity.Admission,
 ) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-sigs:
-			loaded, err := hooks.LoadReload(configPath, disp.CurrentConfig())
-			if err != nil {
-				lg.Printf("hooks reload failed: %v (keeping previous config)", err)
-				continue
+			var lease *activity.Lease
+			if foregroundAdmission != nil {
+				var admitted bool
+				lease, admitted = foregroundAdmission()
+				if !admitted {
+					<-ctx.Done()
+					return
+				}
 			}
-			disp.Reload(loaded)
+			func() {
+				if lease != nil {
+					defer lease.Release()
+				}
+				loaded, err := hooks.LoadReload(configPath, disp.CurrentConfig())
+				if err != nil {
+					lg.Printf("hooks reload failed: %v (keeping previous config)", err)
+					return
+				}
+				disp.Reload(loaded)
+			}()
 		}
 	}
 }

--- a/cmd/kata/daemon_reload_loop_test.go
+++ b/cmd/kata/daemon_reload_loop_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/hooks"
 )
 
@@ -56,7 +55,7 @@ command = "true"
 
 	done := make(chan struct{})
 	go func() {
-		runReloadLoop(ctx, sigs, path, rec, nopLogger{}, nil)
+		runReloadLoop(ctx, sigs, path, rec, nopLogger{})
 		close(done)
 	}()
 
@@ -73,29 +72,4 @@ command = "true"
 	defer rec.mu.Unlock()
 	require.Len(t, rec.reloadCalls, 1)
 	require.Len(t, rec.reloadCalls[0].Snapshot.Hooks, 1, "expected one hook in reloaded snapshot")
-}
-
-func TestRunReloadLoopSkipsReloadWhenForegroundAdmissionIsClosed(t *testing.T) {
-	rec := &recordingDispatcher{}
-	sigs := make(chan os.Signal, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	attempted := make(chan struct{}, 1)
-	done := make(chan struct{})
-	go func() {
-		runReloadLoop(ctx, sigs, "unused", rec, nopLogger{}, func() (*activity.Lease, bool) {
-			attempted <- struct{}{}
-			return nil, false
-		})
-		close(done)
-	}()
-
-	sigs <- os.Interrupt
-	select {
-	case <-attempted:
-	case <-time.After(time.Second):
-		t.Fatal("reload loop did not attempt foreground admission")
-	}
-	cancel()
-	<-done
-	require.Empty(t, rec.reloadCalls)
 }

--- a/cmd/kata/daemon_reload_loop_test.go
+++ b/cmd/kata/daemon_reload_loop_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/hooks"
 )
 
@@ -55,7 +56,7 @@ command = "true"
 
 	done := make(chan struct{})
 	go func() {
-		runReloadLoop(ctx, sigs, path, rec, nopLogger{})
+		runReloadLoop(ctx, sigs, path, rec, nopLogger{}, nil)
 		close(done)
 	}()
 
@@ -72,4 +73,29 @@ command = "true"
 	defer rec.mu.Unlock()
 	require.Len(t, rec.reloadCalls, 1)
 	require.Len(t, rec.reloadCalls[0].Snapshot.Hooks, 1, "expected one hook in reloaded snapshot")
+}
+
+func TestRunReloadLoopSkipsReloadWhenForegroundAdmissionIsClosed(t *testing.T) {
+	rec := &recordingDispatcher{}
+	sigs := make(chan os.Signal, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	attempted := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		runReloadLoop(ctx, sigs, "unused", rec, nopLogger{}, func() (*activity.Lease, bool) {
+			attempted <- struct{}{}
+			return nil, false
+		})
+		close(done)
+	}()
+
+	sigs <- os.Interrupt
+	select {
+	case <-attempted:
+	case <-time.After(time.Second):
+		t.Fatal("reload loop did not attempt foreground admission")
+	}
+	cancel()
+	<-done
+	require.Empty(t, rec.reloadCalls)
 }

--- a/cmd/kata/daemon_signaling_unix.go
+++ b/cmd/kata/daemon_signaling_unix.go
@@ -13,12 +13,17 @@ import (
 // already wrapped with signal.NotifyContext(SIGINT, SIGTERM) in main.go,
 // so external `kata daemon stop` (which sends SIGTERM) drives shutdown
 // without any extra plumbing.
-func installStopWatcher(_ string, _ context.CancelFunc) func() { return func() {} }
+func installStopWatcher(_ string, _ context.CancelFunc) daemonPlatformCleanup {
+	return func(context.Context) bool { return true }
+}
 
 // installReloadSource hooks the existing SIGHUP delivery onto a channel
 // the reload loop reads from. Cleanup detaches the signal handler.
-func installReloadSource(_ context.Context, _ string) (<-chan os.Signal, func()) {
+func installReloadSource(_ context.Context, _ string) (<-chan os.Signal, daemonPlatformCleanup) {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGHUP)
-	return sigs, func() { signal.Stop(sigs) }
+	return sigs, func(context.Context) bool {
+		signal.Stop(sigs)
+		return true
+	}
 }

--- a/cmd/kata/daemon_signaling_windows.go
+++ b/cmd/kata/daemon_signaling_windows.go
@@ -25,14 +25,14 @@ import (
 // installStopWatcher creates the stop event for this daemon process and
 // spawns a goroutine that waits on it. When the event fires (and we are
 // not already cleaning up) it cancels the daemon's context.
-func installStopWatcher(dbhash string, cancel context.CancelFunc) func() {
+func installStopWatcher(dbhash string, cancel context.CancelFunc) daemonPlatformCleanup {
 	namePtr, err := windows.UTF16PtrFromString(daemon.StopEventName(dbhash, os.Getpid()))
 	if err != nil {
-		return func() {}
+		return func(context.Context) bool { return true }
 	}
 	h, err := windows.CreateEvent(nil, 1, 0, namePtr) // manual reset, not signaled
 	if err != nil {
-		return func() {}
+		return func(context.Context) bool { return true }
 	}
 	closing := make(chan struct{})
 	done := make(chan struct{})
@@ -46,11 +46,16 @@ func installStopWatcher(dbhash string, cancel context.CancelFunc) func() {
 			cancel()
 		}
 	}()
-	return func() {
+	return func(ctx context.Context) bool {
 		close(closing)
 		_ = windows.SetEvent(h) // unblock the waiter so it can observe `closing`
-		<-done
-		_ = windows.CloseHandle(h)
+		select {
+		case <-done:
+			_ = windows.CloseHandle(h)
+			return true
+		case <-ctx.Done():
+			return false
+		}
 	}
 }
 
@@ -62,15 +67,15 @@ func (syntheticReloadSignal) Signal()        {}
 // installReloadSource creates the reload event and pumps a private synthetic
 // signal onto the returned channel each time it fires, so the existing
 // runReloadLoop machinery works unchanged.
-func installReloadSource(ctx context.Context, dbhash string) (<-chan os.Signal, func()) {
+func installReloadSource(ctx context.Context, dbhash string) (<-chan os.Signal, daemonPlatformCleanup) {
 	sigs := make(chan os.Signal, 1)
 	namePtr, err := windows.UTF16PtrFromString(daemon.ReloadEventName(dbhash, os.Getpid()))
 	if err != nil {
-		return sigs, func() {}
+		return sigs, func(context.Context) bool { return true }
 	}
 	h, err := windows.CreateEvent(nil, 1, 0, namePtr)
 	if err != nil {
-		return sigs, func() {}
+		return sigs, func(context.Context) bool { return true }
 	}
 	closing := make(chan struct{})
 	done := make(chan struct{})
@@ -95,10 +100,15 @@ func installReloadSource(ctx context.Context, dbhash string) (<-chan os.Signal, 
 			}
 		}
 	}()
-	return sigs, func() {
+	return sigs, func(cleanupCtx context.Context) bool {
 		close(closing)
 		_ = windows.SetEvent(h)
-		<-done
-		_ = windows.CloseHandle(h)
+		select {
+		case <-done:
+			_ = windows.CloseHandle(h)
+			return true
+		case <-cleanupCtx.Done():
+			return false
+		}
 	}
 }

--- a/cmd/kata/daemon_supervisor.go
+++ b/cmd/kata/daemon_supervisor.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// daemonWorkerGroup owns every background goroutine that can touch daemon
+// dependencies. Workers are registered during startup and joined after root
+// cancellation before those dependencies are closed.
+type daemonWorkerGroup struct {
+	mu       sync.Mutex
+	wg       sync.WaitGroup
+	stopping bool
+}
+
+type daemonShutdownTrigger struct {
+	mu      sync.RWMutex
+	trigger func()
+}
+
+func newDaemonShutdownTrigger(trigger func()) *daemonShutdownTrigger {
+	return &daemonShutdownTrigger{trigger: trigger}
+}
+
+func (t *daemonShutdownTrigger) Set(trigger func()) {
+	t.mu.Lock()
+	t.trigger = trigger
+	t.mu.Unlock()
+}
+
+func (t *daemonShutdownTrigger) Call() {
+	t.mu.RLock()
+	trigger := t.trigger
+	t.mu.RUnlock()
+	if trigger != nil {
+		trigger()
+	}
+}
+
+func newDaemonWorkerGroup() *daemonWorkerGroup {
+	return &daemonWorkerGroup{}
+}
+
+func (g *daemonWorkerGroup) Go(worker func()) bool {
+	if g == nil || worker == nil {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.stopping {
+		return false
+	}
+	g.wg.Add(1)
+	go func() {
+		defer g.wg.Done()
+		worker()
+	}()
+	return true
+}
+
+func (g *daemonWorkerGroup) Wait(ctx context.Context) bool {
+	if g == nil {
+		return true
+	}
+	g.mu.Lock()
+	g.stopping = true
+	g.mu.Unlock()
+	done := make(chan struct{})
+	go func() {
+		g.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+type daemonHookShutdown interface {
+	BeginProducerDrain()
+	Shutdown(context.Context) error
+}
+
+type daemonPlatformCleanup func(context.Context) bool
+
+type daemonShutdownResult struct {
+	workerErr   error
+	httpErr     error
+	hookErr     error
+	platformErr error
+}
+
+func (r daemonShutdownResult) Err() error {
+	return errors.Join(r.workerErr, r.httpErr, r.hookErr, r.platformErr)
+}
+
+func (r daemonShutdownResult) SafeToCloseDependencies() bool {
+	return r.workerErr == nil && r.httpErr == nil && r.hookErr == nil && r.platformErr == nil
+}
+
+type daemonShutdownCoordinator struct {
+	rootCancel    context.CancelFunc
+	stopAdmission func()
+	hooks         daemonHookShutdown
+	timeout       time.Duration
+	stateMu       sync.Mutex
+	stopping      bool
+	triggerOnce   sync.Once
+	triggered     chan struct{}
+	httpDoneOnce  sync.Once
+	httpDone      chan bool
+	deadline      time.Time
+	done          chan struct{}
+	result        daemonShutdownResult
+}
+
+var errDaemonStoppingBeforeReady = errors.New("kata daemon: shutdown started before readiness")
+
+func startDaemonShutdownCoordinator(
+	ctx context.Context,
+	rootCancel context.CancelFunc,
+	workers *daemonWorkerGroup,
+	hooks daemonHookShutdown,
+	stopAdmission func(),
+	timeout time.Duration,
+	platformCleanups ...daemonPlatformCleanup,
+) *daemonShutdownCoordinator {
+	coordinator := &daemonShutdownCoordinator{
+		rootCancel:    rootCancel,
+		stopAdmission: stopAdmission,
+		hooks:         hooks,
+		timeout:       timeout,
+		triggered:     make(chan struct{}),
+		httpDone:      make(chan bool, 1),
+		done:          make(chan struct{}),
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			coordinator.Trigger()
+		case <-coordinator.triggered:
+		}
+	}()
+	go func() {
+		defer close(coordinator.done)
+		<-coordinator.triggered
+		// Root cancellation starts shutdown, so retain its values without
+		// inheriting the cancellation that the bounded drain must outlive.
+		shutdownCtx, cancel := context.WithDeadline(context.WithoutCancel(ctx), coordinator.deadline)
+		defer cancel()
+
+		workerDone := make(chan bool, 1)
+		go func() { workerDone <- workers.Wait(shutdownCtx) }()
+		platformDone := make(chan bool, len(platformCleanups))
+		for _, cleanup := range platformCleanups {
+			go func(cleanup daemonPlatformCleanup) {
+				platformDone <- cleanup == nil || cleanup(shutdownCtx)
+			}(cleanup)
+		}
+
+		if joined := <-workerDone; !joined {
+			coordinator.result.workerErr = fmt.Errorf(
+				"kata daemon: background workers did not stop within %s: %w",
+				coordinator.timeout,
+				context.DeadlineExceeded,
+			)
+		}
+		select {
+		case joined := <-coordinator.httpDone:
+			if !joined {
+				<-shutdownCtx.Done()
+				coordinator.result.httpErr = fmt.Errorf(
+					"kata daemon: HTTP handlers did not stop within the shutdown deadline: %w",
+					context.DeadlineExceeded,
+				)
+			}
+		case <-shutdownCtx.Done():
+			coordinator.result.httpErr = fmt.Errorf(
+				"kata daemon: HTTP handlers did not report shutdown completion: %w",
+				shutdownCtx.Err(),
+			)
+		}
+
+		producersJoined := coordinator.result.workerErr == nil && coordinator.result.httpErr == nil
+		if producersJoined && coordinator.hooks != nil {
+			if hookErr := coordinator.hooks.Shutdown(shutdownCtx); hookErr != nil {
+				coordinator.result.hookErr = fmt.Errorf("kata daemon: hooks did not stop: %w", hookErr)
+			}
+		}
+		for range platformCleanups {
+			if joined := <-platformDone; !joined {
+				cause := shutdownCtx.Err()
+				if cause == nil {
+					cause = errors.New("cleanup reported incomplete")
+				}
+				coordinator.result.platformErr = errors.Join(
+					coordinator.result.platformErr,
+					fmt.Errorf("kata daemon: platform cleanup did not stop: %w", cause),
+				)
+			}
+		}
+	}()
+	return coordinator
+}
+
+// HTTPHandlersDone reports whether every request handler joined. Hook shutdown
+// waits for this signal and for background workers because both can enqueue
+// post-commit hook jobs.
+func (c *daemonShutdownCoordinator) HTTPHandlersDone(joined bool) {
+	if c == nil {
+		return
+	}
+	c.httpDoneOnce.Do(func() { c.httpDone <- joined })
+}
+
+func (c *daemonShutdownCoordinator) Trigger() {
+	if c == nil {
+		return
+	}
+	c.triggerOnce.Do(func() {
+		c.stateMu.Lock()
+		c.stopping = true
+		c.deadline = time.Now().Add(c.timeout)
+		c.stateMu.Unlock()
+		// Producers may commit work after cancellation. Keep their hook handoff
+		// path open before sealing top-level idle admission.
+		if c.hooks != nil {
+			c.hooks.BeginProducerDrain()
+		}
+		if c.stopAdmission != nil {
+			c.stopAdmission()
+		}
+		if c.rootCancel != nil {
+			c.rootCancel()
+		}
+		close(c.triggered)
+	})
+}
+
+// PublishReady serializes readiness publication with shutdown. If shutdown
+// wins the lifecycle gate, publish is not called; if publication wins, a later
+// shutdown observes a daemon that was legitimately ready first. The callback
+// runs under the lifecycle lock and must remain bounded and non-reentrant.
+func (c *daemonShutdownCoordinator) PublishReady(ctx context.Context, publish func() error) error {
+	if c == nil || publish == nil {
+		return nil
+	}
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	if c.stopping || ctx.Err() != nil {
+		return errDaemonStoppingBeforeReady
+	}
+	return publish()
+}
+
+func (c *daemonShutdownCoordinator) Wait() daemonShutdownResult {
+	if c == nil {
+		return daemonShutdownResult{}
+	}
+	<-c.done
+	return c.result
+}

--- a/cmd/kata/daemon_supervisor_test.go
+++ b/cmd/kata/daemon_supervisor_test.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDaemonWorkerGroupJoinsCancelledWorkers(t *testing.T) {
+	group := newDaemonWorkerGroup()
+	workerCtx, cancel := context.WithCancel(context.Background())
+	exited := make(chan struct{})
+	group.Go(func() {
+		<-workerCtx.Done()
+		close(exited)
+	})
+
+	cancel()
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+	defer waitCancel()
+	require.True(t, group.Wait(waitCtx))
+	select {
+	case <-exited:
+	default:
+		t.Fatal("Wait returned before worker exited")
+	}
+}
+
+func TestDaemonWorkerGroupReportsUnjoinedWorker(t *testing.T) {
+	group := newDaemonWorkerGroup()
+	release := make(chan struct{})
+	group.Go(func() { <-release })
+
+	waitCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.False(t, group.Wait(waitCtx))
+	close(release)
+}
+
+type testHookShutdown struct {
+	started  chan struct{}
+	release  chan struct{}
+	draining atomic.Bool
+}
+
+func (s *testHookShutdown) BeginProducerDrain() { s.draining.Store(true) }
+
+func (s *testHookShutdown) Shutdown(ctx context.Context) error {
+	close(s.started)
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestDaemonShutdownCoordinatorDrainsHookProducersBeforeStoppingHooks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	workers := newDaemonWorkerGroup()
+	workerCanceled := make(chan struct{})
+	releaseWorker := make(chan struct{})
+	workerExited := make(chan struct{})
+	require.True(t, workers.Go(func() {
+		<-ctx.Done()
+		close(workerCanceled)
+		<-releaseWorker
+		close(workerExited)
+	}))
+	hooks := &testHookShutdown{started: make(chan struct{}), release: make(chan struct{})}
+	var admissionStopped atomic.Bool
+	var producerDrainStartedBeforeAdmissionStop atomic.Bool
+	shutdown := startDaemonShutdownCoordinator(
+		ctx, cancel, workers, hooks, func() {
+			producerDrainStartedBeforeAdmissionStop.Store(hooks.draining.Load())
+			admissionStopped.Store(true)
+		}, time.Second,
+	)
+
+	shutdown.Trigger()
+	require.True(t, admissionStopped.Load(), "Trigger must synchronously stop admission")
+	require.True(t, producerDrainStartedBeforeAdmissionStop.Load(), "hook handoffs must remain open before idle admission stops")
+	select {
+	case <-workerCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not observe root cancellation")
+	}
+	shutdown.HTTPHandlersDone(true)
+	select {
+	case <-hooks.started:
+		t.Fatal("hook shutdown started before background producers drained")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseWorker)
+	select {
+	case <-hooks.started:
+	case <-time.After(time.Second):
+		t.Fatal("hook shutdown did not start after all producers drained")
+	}
+	close(hooks.release)
+	result := shutdown.Wait()
+	require.NoError(t, result.Err())
+	select {
+	case <-workerExited:
+	default:
+		t.Fatal("shutdown completed before worker exit")
+	}
+}
+
+func TestDaemonShutdownCoordinatorWaitsForHTTPHandlersBeforeStoppingHooks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	hooks := &testHookShutdown{started: make(chan struct{}), release: make(chan struct{})}
+	shutdown := startDaemonShutdownCoordinator(
+		ctx, cancel, newDaemonWorkerGroup(), hooks, nil, time.Second,
+	)
+
+	shutdown.Trigger()
+	select {
+	case <-hooks.started:
+		t.Fatal("hook shutdown started before HTTP handlers drained")
+	case <-time.After(20 * time.Millisecond):
+	}
+	shutdown.HTTPHandlersDone(true)
+	select {
+	case <-hooks.started:
+	case <-time.After(time.Second):
+		t.Fatal("hook shutdown did not start after HTTP handlers drained")
+	}
+	close(hooks.release)
+	require.NoError(t, shutdown.Wait().Err())
+}
+
+func TestDaemonShutdownCoordinatorRejectsReadinessAfterShutdownStarts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	shutdown := startDaemonShutdownCoordinator(
+		ctx,
+		cancel,
+		newDaemonWorkerGroup(),
+		nil,
+		nil,
+		time.Second,
+	)
+
+	shutdown.Trigger()
+	shutdown.HTTPHandlersDone(true)
+	published := false
+	err := shutdown.PublishReady(ctx, func() error {
+		published = true
+		return nil
+	})
+
+	require.ErrorIs(t, err, errDaemonStoppingBeforeReady)
+	require.False(t, published)
+	require.NoError(t, shutdown.Wait().Err())
+}
+
+func TestDaemonShutdownCoordinatorLetsInFlightReadinessWinBeforeShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	shutdown := startDaemonShutdownCoordinator(
+		ctx,
+		cancel,
+		newDaemonWorkerGroup(),
+		nil,
+		nil,
+		time.Second,
+	)
+
+	publishStarted := make(chan struct{})
+	releasePublish := make(chan struct{})
+	publishDone := make(chan error, 1)
+	go func() {
+		publishDone <- shutdown.PublishReady(ctx, func() error {
+			close(publishStarted)
+			<-releasePublish
+			return nil
+		})
+	}()
+	select {
+	case <-publishStarted:
+	case <-time.After(time.Second):
+		t.Fatal("readiness publication did not start")
+	}
+
+	triggerDone := make(chan struct{})
+	go func() {
+		shutdown.Trigger()
+		close(triggerDone)
+	}()
+	select {
+	case <-ctx.Done():
+		t.Fatal("shutdown overtook readiness publication inside the lifecycle gate")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releasePublish)
+	require.NoError(t, <-publishDone)
+	select {
+	case <-triggerDone:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not continue after readiness publication")
+	}
+	shutdown.HTTPHandlersDone(true)
+	require.NoError(t, shutdown.Wait().Err())
+}
+
+func TestDaemonShutdownCoordinatorSkipsHookShutdownWhenWorkerRemainsUnjoined(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	workers := newDaemonWorkerGroup()
+	workerRelease := make(chan struct{})
+	require.True(t, workers.Go(func() { <-workerRelease }))
+	hooks := &testHookShutdown{started: make(chan struct{}), release: make(chan struct{})}
+	cleanupStarted := make(chan struct{})
+	shutdown := startDaemonShutdownCoordinator(
+		ctx,
+		cancel,
+		workers,
+		hooks,
+		nil,
+		20*time.Millisecond,
+		func(cleanupCtx context.Context) bool {
+			close(cleanupStarted)
+			<-cleanupCtx.Done()
+			return false
+		},
+	)
+
+	shutdown.Trigger()
+	shutdown.HTTPHandlersDone(true)
+	result := shutdown.Wait()
+	require.False(t, result.SafeToCloseDependencies())
+	require.ErrorContains(t, result.Err(), "background workers")
+	require.ErrorContains(t, result.Err(), "platform cleanup")
+	require.True(t, errors.Is(result.Err(), context.DeadlineExceeded))
+	select {
+	case <-hooks.started:
+		t.Fatal("hook shutdown must not seal the queue while a producer remains unjoined")
+	default:
+	}
+	select {
+	case <-cleanupStarted:
+	default:
+		t.Fatal("platform cleanup did not start under the shared deadline")
+	}
+	close(workerRelease)
+}
+
+func TestDaemonShutdownCoordinatorSkipsHookShutdownWhenHTTPRemainsUnjoined(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	hooks := &testHookShutdown{started: make(chan struct{}), release: make(chan struct{})}
+	shutdown := startDaemonShutdownCoordinator(
+		ctx,
+		cancel,
+		newDaemonWorkerGroup(),
+		hooks,
+		nil,
+		20*time.Millisecond,
+	)
+
+	shutdown.Trigger()
+	shutdown.HTTPHandlersDone(false)
+	result := shutdown.Wait()
+	require.False(t, result.SafeToCloseDependencies())
+	require.ErrorContains(t, result.Err(), "HTTP handlers")
+	select {
+	case <-hooks.started:
+		t.Fatal("hook shutdown must not seal the queue while an HTTP producer remains unjoined")
+	default:
+	}
+}

--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
+	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
 
 	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
 	mcpserver "go.kenn.io/kata/internal/mcp"
 	"go.kenn.io/kata/internal/storageadmin"
 	"go.kenn.io/kata/internal/version"
@@ -89,9 +92,14 @@ func newMCPServeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := requireDaemonAPIVersion(ctx, httpClient, baseURL, apiVersionMCPServer, "kata mcp serve"); err != nil {
+			health, err := requireDaemonAPIVersionHealth(
+				ctx, httpClient, baseURL, apiVersionMCPServer, "kata mcp serve",
+			)
+			if err != nil {
 				return err
 			}
+			stopKeepalive := startMCPIdleKeepalive(ctx, httpClient, baseURL, health)
+			defer stopKeepalive()
 			actor, _ := resolveActor(ctx, flags.As, nil)
 			apiClient, err := kataclient.NewWithHTTPClient(baseURL, httpClient)
 			if err != nil {
@@ -172,6 +180,63 @@ func newMCPServeCmd() *cobra.Command {
 	command.Flags().StringVar(&httpTokenEnv, "http-token-env", "", "require an inbound bearer read from this environment variable")
 	command.Flags().BoolVar(&trustPrivateNetwork, "trust-private-network", false, "trust plaintext MCP HTTP on a non-loopback private network")
 	return command
+}
+
+func startMCPIdleKeepalive(
+	ctx context.Context,
+	client *http.Client,
+	baseURL string,
+	health daemonAPIHealth,
+) context.CancelFunc {
+	if health.IdleShutdown == nil {
+		return func() {}
+	}
+	timeout, err := time.ParseDuration(strings.TrimSpace(health.IdleShutdown.Timeout))
+	if err != nil || timeout < config.MinAutostartIdleTimeout {
+		return func() {}
+	}
+	return startMCPIdleKeepaliveLoop(ctx, client, baseURL, timeout/2)
+}
+
+func startMCPIdleKeepaliveLoop(
+	ctx context.Context,
+	client *http.Client,
+	baseURL string,
+	interval time.Duration,
+) context.CancelFunc {
+	if interval <= 0 {
+		return func() {}
+	}
+	keepaliveCtx, cancel := context.WithCancel(ctx)
+	sendMCPIdleKeepalive(keepaliveCtx, client, baseURL)
+	go func() {
+		timer := time.NewTimer(interval)
+		defer timer.Stop()
+		for {
+			select {
+			case <-keepaliveCtx.Done():
+				return
+			case <-timer.C:
+				sendMCPIdleKeepalive(keepaliveCtx, client, baseURL)
+				timer.Reset(interval)
+			}
+		}
+	}()
+	return cancel
+}
+
+func sendMCPIdleKeepalive(ctx context.Context, client *http.Client, baseURL string) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/ping", nil)
+	if err != nil {
+		return
+	}
+	request.Header.Set(daemon.IdleKeepaliveHeader, "1")
+	response, err := client.Do(request)
+	if err != nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
 }
 
 func parseMCPStorageTargets(values []string) (map[string]string, error) {

--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -433,6 +435,78 @@ func TestMCPServeAllProjectsServesDaemonWideScope(t *testing.T) {
 
 	require.NoError(t, command.Execute())
 	require.Zero(t, requests, "daemon-wide startup must not resolve the current workspace")
+}
+
+func TestMCPServeRenewsAdvertisedAutostartDaemon(t *testing.T) {
+	setupKataEnv(t)
+	t.Setenv("KATA_AUTHOR", "example-agent")
+	keepalive := make(chan struct{}, 1)
+	daemonServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/health":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(writer,
+				`{"ok":true,"api_schema_version":%q,"idle_shutdown":{"timeout":"15m0s","state":"armed"}}`,
+				daemon.APISchemaVersion,
+			)
+		case "/api/v1/ping":
+			require.Equal(t, "1", request.Header.Get(daemon.IdleKeepaliveHeader))
+			keepalive <- struct{}{}
+			_, _ = writer.Write([]byte(`{"ok":true}`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	t.Cleanup(daemonServer.Close)
+
+	command := newRootCmd()
+	command.SetIn(bytes.NewReader(nil))
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"mcp", "serve", "--all-projects"})
+	command.SetContext(context.WithValue(t.Context(), internalclient.BaseURLKey{}, daemonServer.URL))
+
+	require.NoError(t, command.Execute())
+	select {
+	case <-keepalive:
+	case <-time.After(5 * time.Second):
+		t.Fatal("MCP did not send an immediate marked idle keepalive")
+	}
+}
+
+func TestMCPIdleKeepaliveWaitsAFullIntervalAfterSlowFailure(t *testing.T) {
+	var requests atomic.Int32
+	var mu sync.Mutex
+	var secondCompleted time.Time
+	thirdStarted := make(chan time.Time, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		switch requests.Add(1) {
+		case 2:
+			time.Sleep(60 * time.Millisecond)
+			mu.Lock()
+			secondCompleted = time.Now()
+			mu.Unlock()
+			http.Error(writer, "temporary failure", http.StatusServiceUnavailable)
+		case 3:
+			thirdStarted <- time.Now()
+			writer.WriteHeader(http.StatusNoContent)
+		default:
+			writer.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cancel := startMCPIdleKeepaliveLoop(t.Context(), server.Client(), server.URL, 25*time.Millisecond)
+	t.Cleanup(cancel)
+	select {
+	case started := <-thirdStarted:
+		mu.Lock()
+		completed := secondCompleted
+		mu.Unlock()
+		require.GreaterOrEqual(t, started.Sub(completed), 20*time.Millisecond)
+	case <-time.After(time.Second):
+		t.Fatal("third keepalive did not arrive")
+	}
 }
 
 func TestMCPServeRejectsDaemonBeforeRelationshipPinning(t *testing.T) {

--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	internalclient "go.kenn.io/kata/internal/client"
@@ -450,7 +451,7 @@ func TestMCPServeRenewsAdvertisedAutostartDaemon(t *testing.T) {
 				daemon.APISchemaVersion,
 			)
 		case "/api/v1/ping":
-			require.Equal(t, "1", request.Header.Get(daemon.IdleKeepaliveHeader))
+			assert.Equal(t, "1", request.Header.Get(daemon.IdleKeepaliveHeader))
 			keepalive <- struct{}{}
 			_, _ = writer.Write([]byte(`{"ok":true}`))
 		default:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,15 @@ All notable changes to kata, grouped by release. Versioned releases start with
 - Added opt-in idle shutdown for implicitly started owner-local daemons. Active
   requests and finite background work drain safely, while running stdio or
   streamable-HTTP MCP server processes renew the advertised timeout
-  automatically.
+  automatically. The daemon logs the idle exit, and `kata daemon start`
+  replaces an idle-eligible auto-started daemon with an explicit resident one.
+
+**Improvements**
+
+- Daemon stop now drains accepted hook jobs instead of dropping them, and
+  cancels in-flight hooks early enough to exit cleanly inside the 25-second
+  shutdown budget. `kata daemon restart` waits up to 30 seconds for the old
+  process to exit.
 
 ## 0.15.1
 <small>2026-08-20</small>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,13 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 ## Unreleased
 
+**New features**
+
+- Added opt-in idle shutdown for implicitly started owner-local daemons. Active
+  requests and finite background work drain safely, while running stdio or
+  streamable-HTTP MCP server processes renew the advertised timeout
+  automatically.
+
 ## 0.15.1
 <small>2026-08-20</small>
 

--- a/docs/design/autostart-idle-shutdown.md
+++ b/docs/design/autostart-idle-shutdown.md
@@ -1,0 +1,129 @@
+# Auto-start daemon idle shutdown
+
+Kata clients automatically start a local daemon when no compatible local
+daemon is reachable. Auto-start is convenient for short CLI and agent
+sessions, but a process that remains resident indefinitely is surprising on a
+developer workstation. `autostart_idle_timeout` lets that narrowly scoped
+daemon exit after foreground use stops without weakening the explicit-daemon
+contract used by services, remote clients, federation hubs, or hosted
+deployments.
+
+This note records the lifecycle invariants behind the feature. User-facing
+configuration is documented in [Configuration](../reference/configuration.md).
+
+## Eligibility is process-local
+
+The configured timeout is effective only when all of these conditions hold:
+
+- the process carries Kata's private auto-start marker;
+- every daemon and browser listener is a Unix socket or loopback address;
+- `web.public_origin` does not describe a non-loopback origin;
+- trusted-proxy and shared-listener host aliases do not expose the process.
+
+An explicit `kata daemon start`, service-managed process, configured remote,
+or locally bound listener behind a public proxy remains long-running. Listener
+scope is checked after configuration and command-line overrides are resolved,
+because a loopback socket alone does not prove that the effective service is
+private.
+
+The auto-start marker is removed from hook subprocess environments. This keeps
+an explicitly launched daemon command from inheriting the parent daemon's
+auto-start provenance. An ordinary Kata client in a hook still uses normal
+discovery and may auto-start a newly marked daemon when none is reachable.
+
+## Activity classes
+
+The idle controller distinguishes work by what it means for residency:
+
+| Activity | Moves the deadline | Blocks shutdown while active |
+| --- | --- | --- |
+| CLI, TUI, browser request, or SSE stream | Yes, after completion | Yes |
+| Marked MCP keepalive | Yes | Yes |
+| Queued or running hook | No | Yes |
+| Embedding reconciliation | No | Yes |
+| GitHub or federation synchronization | No | Yes |
+| Federation configuration reconciliation | No | Yes |
+| Timed-claim sweep | No | Yes |
+| Scheduler wait, backoff, telemetry, or watcher | No | No |
+| Health, ping, or instance probe | No | No; HTTP shutdown joins the handler |
+
+Foreground activity starts a complete new idle interval when the final
+foreground lease releases. Drain activity preserves already-admitted finite
+work but never moves the foreground deadline. This prevents periodic
+maintenance from keeping an otherwise unused process alive forever.
+
+Classification follows the request that reaches the daemon. If a hook invokes
+`kata` or sends an ordinary API request, that new request is foreground work;
+arbitrary subprocesses do not carry reliable causal metadata.
+
+## Controller and admission
+
+The controller exposes admission rather than unconditional acquisition. Once
+terminal shutdown begins, HTTP receives `503` and background workers skip new
+resource-using work. The observable states are:
+
+- `armed`: an idle deadline is running;
+- `foreground`: client work suspends the deadline;
+- `blocked`: the deadline elapsed while finite drain work remained;
+- `stopping`: admission is closed and shutdown is committed.
+
+When expiration is blocked, unrelated top-level drains are denied. An admitted
+drain may fork one generation of child leases before releasing its own lease.
+That finite handoff lets a database or synchronization operation protect hook
+jobs it caused without allowing recursive background work to derive an
+unbounded lifetime.
+
+Blocked expiration is reversible while drain work remains: a foreground
+request clears the expired state and reopens admission. Long-lived schedulers
+receive a retry channel atomically with a reversible denial. Foreground revival
+closes that channel; terminal stop also closes outstanding waiters. This avoids
+both missed wakeups and polling while ensuring schedulers do not become stuck
+when a foreground request revives the daemon.
+
+All admission, expiration, revival, fork, and release transitions serialize
+under the controller mutex. Releases are idempotent, timer callbacks carry a
+generation, and cancellation callbacks run outside the mutex so they may
+safely inspect controller state.
+
+## MCP process keepalive
+
+`kata mcp serve` reads the effective timeout from daemon health rather than
+local configuration. When idle shutdown is effective, it sends a marked ping
+immediately and then waits half the timeout after each completed attempt.
+Ordinary probes remain observational; only the marked MCP ping counts as
+foreground activity. The marker is recognized only on `GET /api/v1/ping`,
+after all applicable listener, session, and authentication policies accept the
+request. Rejected requests do not reach idle admission.
+
+The keepalive belongs to the MCP server process, in both stdio and
+streamable-HTTP modes. A quiet stdio connection therefore remains usable, and
+an HTTP bridge remains ready for future clients for as long as its process is
+running. Session-aware HTTP residency would require a different connection
+lifecycle and is not inferred from individual tool calls.
+
+## Root shutdown and dependency safety
+
+The first shutdown source establishes one absolute deadline, preserves hook
+handoffs from admitted producers, closes top-level idle admission, and cancels
+the daemon root context. Idle expiration, listener failure, explicit stop,
+parent cancellation, and platform stop events converge on that coordinator.
+
+HTTP handlers and daemon workers finish as hook producers before the dispatcher
+stops accepting and drains hook jobs with the time remaining in the same
+bounded budget. Platform event pumps join concurrently. The runtime discovery
+record is removed after listeners stop serving and the HTTP drain completes or
+times out, before waiting for any remaining background work. If any producer
+remains unjoined at the deadline, the dedicated daemon exits without sealing
+the hook queue or closing dependencies underneath that work; process exit
+reclaims them.
+
+`kata daemon restart` waits longer than the internal drain budget so final
+cleanup and observable process exit do not race the operator-facing timeout.
+
+## Operational consequence
+
+Scheduled work is opportunistic on an idle-enabled auto-start daemon. Durable
+cursors, pending rows, and reconciliation state resume the next time a client
+starts the process, but a future timer does not keep it resident. Operators who
+need continuous GitHub synchronization, federation, timed claims, embeddings,
+or hooks should run an explicit daemon under a service manager.

--- a/docs/design/autostart-idle-shutdown.md
+++ b/docs/design/autostart-idle-shutdown.md
@@ -26,6 +26,13 @@ scope is checked after configuration and command-line overrides are resolved,
 because a loopback socket alone does not prove that the effective service is
 private.
 
+Because the marker is read once at process start, residency cannot change
+under a running process. `kata daemon start` therefore inspects the live
+daemon's health: when it advertises `idle_shutdown`, the command stops that
+process and starts an explicit replacement rather than reporting it as already
+running. `kata daemon restart` always produces an explicit daemon. An idle exit
+writes one line to the daemon log so the disappearance is diagnosable.
+
 The auto-start marker is removed from hook subprocess environments. This keeps
 an explicitly launched daemon command from inheriting the parent daemon's
 auto-start provenance. An ordinary Kata client in a hook still uses normal
@@ -110,7 +117,10 @@ parent cancellation, and platform stop events converge on that coordinator.
 
 HTTP handlers and daemon workers finish as hook producers before the dispatcher
 stops accepting and drains hook jobs with the time remaining in the same
-bounded budget. Platform event pumps join concurrently. The runtime discovery
+bounded budget. The dispatcher cancels in-flight hooks two grace windows before
+that deadline so a hook slower than the budget is terminated, killed, and
+reaped while a clean join is still possible; only work that survives that is
+reported as unjoined. Platform event pumps join concurrently. The runtime discovery
 record is removed after listeners stop serving and the HTTP drain completes or
 times out, before waiting for any remaining background work. If any producer
 remains unjoined at the deadline, the dedicated daemon exits without sealing

--- a/docs/design/hosted-mode.md
+++ b/docs/design/hosted-mode.md
@@ -30,8 +30,8 @@ suitable for platform liveness / readiness probes.
 
 ## Shutdown
 
-The daemon handles SIGTERM gracefully (up to 10s for in-flight
-requests).
+The daemon handles SIGTERM gracefully. HTTP handlers receive up to 10s to
+drain, within a shared 25s budget for handlers, background workers, and hooks.
 
 ## Single-instance assumption
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -10,6 +10,7 @@ constraints that are too detailed for the main documentation.
 ## Available notes
 
 - [Architecture and design principles](architecture.md)
+- [Auto-start daemon idle shutdown](autostart-idle-shutdown.md)
 - [Data model and durability](data-model.md)
 - [Federation technical notes](federation.md)
 - [GitHub sync](github-sync.md)

--- a/docs/operations/hosted-mode.md
+++ b/docs/operations/hosted-mode.md
@@ -63,8 +63,9 @@ Both are unauthenticated.
 
 ## Shutdown
 
-The daemon handles `SIGTERM` gracefully, with up to 10 seconds for in-flight
-requests.
+The daemon handles `SIGTERM` gracefully. HTTP handlers receive up to 10 seconds
+to drain, within a shared 25-second budget for handlers, background workers, and
+hooks before the process exits.
 
 ## Single-instance assumption
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -643,7 +643,10 @@ the update client; upgrade through Homebrew or the owning system package
 manager instead. Ordinary archives retain the self-installing update behavior.
 
 Local commands auto-start the daemon when appropriate. `daemon start` starts a
-background daemon and returns after startup is confirmed. Use
+background daemon and returns after startup is confirmed. If the running local
+daemon was auto-started with `autostart_idle_timeout` in effect, `daemon start`
+stops it and starts an explicit daemon in its place, reporting the replaced
+PID; a resident daemon is reported as already running. Use
 `daemon start --foreground` for service managers, hosted deployments, and any
 setup where the daemon process should stay attached to the terminal. `daemon
 restart` gracefully stops any running local daemon, waits for it to exit, and

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -241,7 +241,11 @@ database path still apply.
 after a period without client activity. It is off by default. The setting is
 ignored for explicit daemon starts and for daemons exposed through non-loopback
 listeners, a public web origin, trusted-proxy configuration, or shared-listener
-host aliases. Active requests and already-admitted finite background work
+host aliases. `kata daemon start` replaces a running idle-eligible auto-started
+daemon with an explicit one so it stays resident, and `kata daemon restart`
+always starts an explicit daemon. The daemon writes one
+`kata daemon: idle shutdown after ...` line to its log when it exits for this
+reason. Active requests and already-admitted finite background work
 receive a bounded drain before process exit, so exit can occur after the
 configured interval. Ordinary health probes do not renew the timeout. A running
 `kata mcp serve` process discovers the effective timeout from `/health` and

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -26,6 +26,7 @@ bindings, local per-machine overrides, and daemon config.
 | `KATA_ALLOW_INSECURE` | Set to `1` or `true` to allow a configured remote daemon hostname over plain HTTP. Federation uses `kata federation enroll --allow-insecure` and `kata federation join --allow-insecure` instead because enrollment credentials are stored separately. |
 | `KATA_TELEMETRY_ENABLED` | Set to `0` to disable anonymous PostHog telemetry. |
 | `KATA_HTTP_TIMEOUT` | Timeout for configured-remote connectivity probes and non-streaming CLI requests, such as `30s` or `2m`. Defaults to `5s`; raise it for bulk imports. It also overrides the federation sync client's separate 60-second request budget. Larger values increase how long an unreachable remote can delay a command or sync attempt. |
+| `KATA_AUTOSTART_IDLE_TIMEOUT` | Overrides `autostart_idle_timeout`. Empty or `0` disables idle shutdown; positive values must be at least `10s`. |
 | `KATA_GITHUB_TOKEN` | Default explicit token source for GitHub sync when no matching `[[github_sync.app]]` credential is configured. It is scoped to `github.com` unless `[github_sync].token_host` names a different host. `[github_sync].token_env` can name a different env var. |
 | `KATA_GITHUB_SYNC_ALLOWED_HOSTS` | Comma-separated exact GitHub Enterprise hostnames trusted for GitHub sync and git-remote inference. `github.com` is always trusted. |
 | `KATA_FEDERATION_PULL_INTERVAL_MS` | Federation runner poll interval for tests or latency-sensitive private deployments. |
@@ -221,6 +222,13 @@ installation_id = 67890
 private_key_path = "/var/lib/kata/github-app.pem"
 ```
 
+Idle shutdown is intended for the default owner-local daemon rather than the
+shared-daemon configuration above. Its minimal configuration is:
+
+```toml
+autostart_idle_timeout = "15m"
+```
+
 The `kata daemon start --listen <host:port>` flag wins over the config file.
 Plain `kata daemon start` starts the daemon in the background and returns after
 startup is confirmed; use `kata daemon start --foreground` for service-manager
@@ -228,6 +236,20 @@ and hosted deployments. Auto-started daemons also read the config-file listener
 value.
 An empty `[storage].dsn` means "no storage override"; env vars or the default
 database path still apply.
+
+`autostart_idle_timeout` lets an implicitly started, owner-local daemon exit
+after a period without client activity. It is off by default. The setting is
+ignored for explicit daemon starts and for daemons exposed through non-loopback
+listeners, a public web origin, trusted-proxy configuration, or shared-listener
+host aliases. Active requests and already-admitted finite background work
+receive a bounded drain before process exit, so exit can occur after the
+configured interval. Ordinary health probes do not renew the timeout. A running
+`kata mcp serve` process discovers the effective timeout from `/health` and
+sends marked `GET /api/v1/ping` keepalives after applicable listener policy
+checks in both stdio and streamable-HTTP modes so the bridge remains usable for
+its full lifetime. Use an explicit daemon service when
+GitHub sync, federation, or timed-claim maintenance must remain continuously
+scheduled without a client present.
 
 The optional top-level `timezone` is the IANA timezone for date-only and local
 date-time `scheduled_on` values that do not have an issue-level `timezone`. If

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -45,12 +45,31 @@ The schema carries a version in its `info.version` field
 {
   "ok": true,
   "schema_version": 7,
-  "api_schema_version": "0.11.0",
+  "api_schema_version": "0.12.0",
   "version": "1.4.2",
   "uptime": "5m0s",
-  "db_path": "/path/to/kata.db"
+  "db_path": "/path/to/kata.db",
+  "idle_shutdown": {
+    "timeout": "15m0s",
+    "state": "armed",
+    "deadline": "2026-08-17T17:15:00Z"
+  }
 }
 ```
+
+`idle_shutdown` is present only when this process is an implicitly started,
+owner-local daemon with an effective timeout. Its state is one of:
+
+| State | Meaning |
+| --- | --- |
+| `armed` | No foreground request is active; `deadline` is the next eligible shutdown time. |
+| `foreground` | Client work is active and the idle deadline is suspended. |
+| `blocked` | The prior deadline elapsed, but already-admitted finite background work is still draining. |
+| `stopping` | New work is no longer admitted and root shutdown has started. |
+
+`deadline` is present for `armed` and `blocked`, and absent while foreground
+work suspends the deadline or shutdown is already committed. Monitoring reads
+of health, ping, and instance state do not renew the deadline.
 
 Three distinct version fields appear here; they answer different questions:
 
@@ -88,6 +107,7 @@ and decline to render issue detail.
 
 | Version | Change |
 | --- | --- |
+| `0.12.0` | Added the optional `idle_shutdown` health block for effective auto-start idle shutdown state and capability discovery. |
 | `0.11.0` | Added optional `to_project_uid` on create-time initial links and `expected_project_uids` on edit link deltas so clients can pin resolved relationship targets to immutable project identities inside the mutation transaction. Close-audit rows gain a required `event_id` (stable pagination cursor) and optional `parent_uid`. |
 | `0.10.0` | Added the repeatable `issue_uid` query parameter to UI references so embedding hosts can hydrate summaries by stable issue UID. |
 | `0.9.0` | Added owner, label, exclusion, and metadata filters to the cross-project issue list. Global list rows now include `project_name`. |

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -85,6 +85,17 @@ daemon's `api_schema_version` once at startup and refuses to serve a daemon
 older than API `0.11.0` (see the [HTTP API version history](http-api.md));
 upgrade the daemon rather than the MCP client in that case.
 
+When the selected daemon advertises effective auto-start idle shutdown in its
+health response, the MCP server sends a marked liveness ping immediately and
+then waits half of the advertised timeout after each completed attempt. The
+marked keepalive uses `GET /api/v1/ping` and runs for the lifetime of the
+`kata mcp serve` process in both stdio and `--http` modes. This keeps a quiet
+stdio session usable and keeps a
+streamable-HTTP bridge ready for future clients without relying on the MCP
+process's local Kata configuration.
+Stop the MCP server process when that bridge should no longer keep the selected
+daemon resident.
+
 ## Project scope
 
 The server binds the current workspace's project by default, so a bare

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -53,6 +53,7 @@ nav = [
   {"Design" = [
     {"Design notes" = "design/index.md"},
     {"Architecture" = "design/architecture.md"},
+    {"Auto-start daemon idle shutdown" = "design/autostart-idle-shutdown.md"},
     {"Data model and durability" = "design/data-model.md"},
     {"Federation technical notes" = "design/federation.md"},
     {"Hosted mode technical notes" = "design/hosted-mode.md"},

--- a/internal/activity/lease.go
+++ b/internal/activity/lease.go
@@ -1,0 +1,59 @@
+// Package activity defines the small lease contract shared by daemon-owned
+// background workers without coupling those packages to the idle controller.
+package activity
+
+import "sync"
+
+// Admission admits one finite unit of background work.
+type Admission func() (*Lease, bool)
+
+// WaitableAdmission admits one finite unit of background work. A reversible
+// denial returns a retry channel that closes when admission should be attempted
+// again. A nil retry channel means the denial is terminal.
+type WaitableAdmission func() (*Lease, bool, <-chan struct{})
+
+// Lease protects one finite unit until Release. An optional fork source can
+// transfer that protection to first-generation child work.
+type Lease struct {
+	mu       sync.Mutex
+	release  func()
+	fork     Admission
+	released bool
+}
+
+// NewLease creates finite-work protection with optional first-generation
+// child admission.
+func NewLease(release func(), fork Admission) *Lease {
+	return &Lease{release: release, fork: fork}
+}
+
+// Release completes the protected work. Repeated calls are harmless.
+func (l *Lease) Release() {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	if l.released {
+		l.mu.Unlock()
+		return
+	}
+	l.released = true
+	release := l.release
+	l.mu.Unlock()
+	if release != nil {
+		release()
+	}
+}
+
+// Fork admits one child operation while the parent remains active.
+func (l *Lease) Fork() (*Lease, bool) {
+	if l == nil {
+		return nil, false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.released || l.fork == nil {
+		return nil, false
+	}
+	return l.fork()
+}

--- a/internal/activity/lease_test.go
+++ b/internal/activity/lease_test.go
@@ -1,0 +1,33 @@
+package activity
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaseReleaseIsIdempotentAndForkIsExplicit(t *testing.T) {
+	var parentReleased atomic.Int32
+	var childReleased atomic.Int32
+	parent := NewLease(func() { parentReleased.Add(1) }, func() (*Lease, bool) {
+		return NewLease(func() { childReleased.Add(1) }, nil), true
+	})
+
+	child, admitted := parent.Fork()
+	require.True(t, admitted)
+	parent.Release()
+	parent.Release()
+	child.Release()
+	child.Release()
+
+	require.Equal(t, int32(1), parentReleased.Load())
+	require.Equal(t, int32(1), childReleased.Load())
+}
+
+func TestLeaseWithoutForkSourceCannotFork(t *testing.T) {
+	lease := NewLease(func() {}, nil)
+	child, admitted := lease.Fork()
+	require.False(t, admitted)
+	require.Nil(t, child)
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -41,7 +41,16 @@ type HealthResponse struct {
 		StartedAt        time.Time               `json:"started_at"`
 		Embeddings       *EmbeddingsHealth       `json:"embeddings,omitempty"`
 		FederationConfig *FederationConfigHealth `json:"federation_config,omitempty"`
+		IdleShutdown     *IdleShutdownHealth     `json:"idle_shutdown,omitempty"`
 	}
+}
+
+// IdleShutdownHealth advertises effective auto-start idle shutdown behavior. The
+// entire block is absent when this daemon will not stop itself when idle.
+type IdleShutdownHealth struct {
+	Timeout  string     `json:"timeout"`
+	State    string     `json:"state" enum:"armed,foreground,blocked,stopping"`
+	Deadline *time.Time `json:"deadline,omitempty"`
 }
 
 // UILocalSessionRequest starts a browser session on a direct loopback listener.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -123,22 +123,21 @@ func probeAddress(ctx context.Context, address string) (string, PingInfo, bool) 
 }
 
 func probeAddressWithError(ctx context.Context, address string) (string, PingInfo, error) {
-	if strings.HasPrefix(address, "unix://") {
-		path := strings.TrimPrefix(address, "unix://")
-		client := &http.Client{Transport: UnixTransport(path), Timeout: 1 * time.Second}
-		info, err := Probe(ctx, client, UnixBase)
-		if err == nil {
-			return UnixBase, info, nil
-		}
+	client, base := LocalHTTPClient(address)
+	info, err := Probe(ctx, client, base)
+	if err != nil {
 		return "", PingInfo{}, err
 	}
-	url := "http://" + address
-	client := &http.Client{Timeout: 1 * time.Second}
-	info, err := Probe(ctx, client, url)
-	if err == nil {
-		return url, info, nil
+	return base, info, nil
+}
+
+// LocalHTTPClient returns a short-timeout client and request base for a local
+// daemon runtime address: a `unix://` socket path or a plain host:port.
+func LocalHTTPClient(address string) (*http.Client, string) {
+	if path, ok := strings.CutPrefix(address, "unix://"); ok {
+		return &http.Client{Transport: UnixTransport(path), Timeout: 1 * time.Second}, UnixBase
 	}
-	return "", PingInfo{}, err
+	return &http.Client{Timeout: 1 * time.Second}, "http://" + address
 }
 
 // Ping is true when GET base+/api/v1/ping returns 200.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,17 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalHTTPClientSelectsTransportByAddress(t *testing.T) {
+	unixClient, unixBase := LocalHTTPClient("unix:///tmp/example.sock")
+	require.Equal(t, UnixBase, unixBase)
+	require.NotNil(t, unixClient.Transport, "unix addresses need the socket transport")
+
+	tcpClient, tcpBase := LocalHTTPClient("127.0.0.1:7777")
+	require.Equal(t, "http://127.0.0.1:7777", tcpBase)
+	require.Nil(t, tcpClient.Transport)
+}

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -29,6 +29,9 @@ type DaemonConfig struct {
 	// An empty value (or a missing file) means the platform default:
 	// Unix socket on Unix platforms, loopback TCP on Windows.
 	Listen string `toml:"listen"`
+	// AutostartIdleTimeout stops implicitly auto-started local daemons after
+	// foreground inactivity. Empty or zero disables idle shutdown.
+	AutostartIdleTimeout string `toml:"autostart_idle_timeout"`
 	// ActiveDaemon names the daemon catalog entry selected by default.
 	// Empty preserves the legacy implicit endpoint resolution.
 	ActiveDaemon string `toml:"active_daemon"`
@@ -57,6 +60,34 @@ type DaemonConfig struct {
 	// GitHubSync carries daemon-owned GitHub API credential settings for
 	// background synchronization.
 	GitHubSync GitHubSyncConfig `toml:"github_sync"`
+}
+
+// MinAutostartIdleTimeout leaves enough time for detached startup discovery
+// and avoids impractically tight keepalive loops.
+const MinAutostartIdleTimeout = 10 * time.Second
+
+// AutostartIdleTimeoutDuration parses the configured auto-start daemon idle
+// timeout. Empty and zero values disable idle shutdown.
+func (c DaemonConfig) AutostartIdleTimeoutDuration() (time.Duration, error) {
+	raw := strings.TrimSpace(c.AutostartIdleTimeout)
+	if raw == "" {
+		return 0, nil
+	}
+	duration, err := time.ParseDuration(raw)
+	if err != nil || duration < 0 {
+		return 0, fmt.Errorf(
+			"autostart_idle_timeout must be a non-negative duration: %q",
+			c.AutostartIdleTimeout,
+		)
+	}
+	if duration > 0 && duration < MinAutostartIdleTimeout {
+		return 0, fmt.Errorf(
+			"autostart_idle_timeout must be 0 or at least %s: %q",
+			MinAutostartIdleTimeout,
+			c.AutostartIdleTimeout,
+		)
+	}
+	return duration, nil
 }
 
 // SearchConfig is the [search] block of <KATA_HOME>/config.toml. Today it only
@@ -326,6 +357,7 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 		}
 		cfg.Timezone = strings.TrimSpace(cfg.Timezone)
 		cfg.Listen = strings.TrimSpace(cfg.Listen)
+		cfg.AutostartIdleTimeout = strings.TrimSpace(cfg.AutostartIdleTimeout)
 		cfg.Auth.Token = strings.TrimSpace(cfg.Auth.Token)
 		cfg.Auth.Proxy.TrustedActorHeader = strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader)
 		cfg.Web.Listen = strings.TrimSpace(cfg.Web.Listen)
@@ -346,6 +378,9 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 	applyDaemonConfigEnv(&cfg)
+	if _, err := cfg.AutostartIdleTimeoutDuration(); err != nil {
+		return nil, err
+	}
 	if cfg.Timezone != "" {
 		if _, err := time.LoadLocation(cfg.Timezone); err != nil {
 			return nil, fmt.Errorf("timezone %q is not a valid IANA timezone: %w", cfg.Timezone, err)
@@ -648,6 +683,9 @@ func validateEmbeddings(e EmbeddingsConfig) error {
 }
 
 func applyDaemonConfigEnv(cfg *DaemonConfig) {
+	if raw, ok := os.LookupEnv("KATA_AUTOSTART_IDLE_TIMEOUT"); ok {
+		cfg.AutostartIdleTimeout = strings.TrimSpace(raw)
+	}
 	if v := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN")); v != "" &&
 		(!cfg.Auth.RequireTokenIdentity || !EnvTruthy("KATA_AUTOSTART")) {
 		cfg.Auth.Token = v

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -139,6 +139,44 @@ func TestReadDaemonConfig_ReadsListen(t *testing.T) {
 	assert.Equal(t, "100.64.0.5:7777", cfg.Listen)
 }
 
+func TestReadDaemonConfigReadsAutostartIdleTimeout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("autostart_idle_timeout = \"15m\"\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	timeout, err := cfg.AutostartIdleTimeoutDuration()
+	require.NoError(t, err)
+	assert.Equal(t, 15*time.Minute, timeout)
+}
+
+func TestReadDaemonConfigAutostartIdleTimeoutEnvironmentOverridesFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTOSTART_IDLE_TIMEOUT", "45s")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("autostart_idle_timeout = \"15m\"\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	timeout, err := cfg.AutostartIdleTimeoutDuration()
+	require.NoError(t, err)
+	assert.Equal(t, 45*time.Second, timeout)
+}
+
+func TestReadDaemonConfigRejectsTooShortAutostartIdleTimeout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("autostart_idle_timeout = \"9s\"\n"), 0o600))
+
+	_, err := config.ReadDaemonConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 10s")
+}
+
 func TestReadDaemonConfigReadsTimezone(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)

--- a/internal/daemon/claims_sweeper.go
+++ b/internal/daemon/claims_sweeper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/hooks"
 )
@@ -17,12 +18,13 @@ const (
 // TimedClaimSweeper expires authoritative hub timed claims and fans emitted
 // claim.expired events out through the daemon's normal event surfaces.
 type TimedClaimSweeper struct {
-	DB          db.Storage
-	Broadcaster *EventBroadcaster
-	Hooks       hooks.Sink
-	Interval    time.Duration
-	Limit       int
-	OnError     func(error)
+	DB            db.Storage
+	Broadcaster   *EventBroadcaster
+	Hooks         hooks.Sink
+	Interval      time.Duration
+	Limit         int
+	OnError       func(error)
+	IdleAdmission activity.WaitableAdmission
 }
 
 // NewTimedClaimSweeper creates a timed-claim sweeper with default event sinks.
@@ -38,9 +40,24 @@ func NewTimedClaimSweeper(store db.Storage, broadcaster *EventBroadcaster, sink 
 
 // RunOnce expires timed claims for all enabled hub bindings once.
 func (s *TimedClaimSweeper) RunOnce(ctx context.Context, now time.Time) error {
+	_, _, err := s.runOnce(ctx, now)
+	return err
+}
+
+func (s *TimedClaimSweeper) runOnce(ctx context.Context, now time.Time) (<-chan struct{}, bool, error) {
+	var idleLease *activity.Lease
+	if s.IdleAdmission != nil {
+		var admitted bool
+		var retry <-chan struct{}
+		idleLease, admitted, retry = s.IdleAdmission()
+		if !admitted {
+			return retry, true, nil
+		}
+		defer idleLease.Release()
+	}
 	bindings, err := s.DB.ListFederationBindings(ctx)
 	if err != nil {
-		return err
+		return nil, false, err
 	}
 	limit := s.Limit
 	if limit <= 0 {
@@ -66,10 +83,10 @@ func (s *TimedClaimSweeper) RunOnce(ctx context.Context, now time.Time) error {
 		}
 		for _, event := range events {
 			s.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &event, ProjectID: event.ProjectID})
-			s.Hooks.Enqueue(event)
+			enqueueHookWithDrain(s.Hooks, event, idleLease)
 		}
 	}
-	return errors.Join(errs...)
+	return nil, false, errors.Join(errs...)
 }
 
 // Run expires timed claims on a ticker until the context is canceled.
@@ -81,13 +98,26 @@ func (s *TimedClaimSweeper) Run(ctx context.Context) error {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
-		if err := s.RunOnce(ctx, time.Now().UTC()); err != nil {
+		retry, denied, err := s.runOnce(ctx, time.Now().UTC())
+		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return err
 			}
 			if s.OnError != nil {
 				s.OnError(err)
 			}
+		}
+		if denied && retry != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-retry:
+				continue
+			}
+		}
+		if denied {
+			<-ctx.Done()
+			return ctx.Err()
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/daemon/claims_sweeper_idle_test.go
+++ b/internal/daemon/claims_sweeper_idle_test.go
@@ -1,0 +1,75 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/activity"
+	"go.kenn.io/kata/internal/db/sqlitestore"
+)
+
+func TestTimedClaimSweeperSkipsPassWhenDrainAdmissionIsClosed(t *testing.T) {
+	controller := NewIdleController(time.Minute, nil)
+	controller.Start()
+	controller.Stop()
+	sweeper := NewTimedClaimSweeper(nil, nil, nil)
+	sweeper.IdleAdmission = controller.WaitableDrainAdmission()
+
+	require.NoError(t, sweeper.RunOnce(context.Background(), time.Now()))
+}
+
+func TestTimedClaimSweeperRetriesImmediatelyWhenDrainAdmissionReopens(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store, err := sqlitestore.Open(ctx, filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	reopened := make(chan struct{})
+	completed := make(chan struct{})
+	var attempts atomic.Int32
+	sweeper := NewTimedClaimSweeper(store, nil, nil)
+	sweeper.Interval = time.Hour
+	sweeper.IdleAdmission = func() (*activity.Lease, bool, <-chan struct{}) {
+		if attempts.Add(1) == 1 {
+			return nil, false, reopened
+		}
+		return activity.NewLease(func() { close(completed) }, nil), true, nil
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- sweeper.Run(ctx) }()
+	require.Eventually(t, func() bool { return attempts.Load() == 1 }, time.Second, time.Millisecond)
+
+	close(reopened)
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("timed-claim sweep did not complete after drain admission reopened")
+	}
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestTimedClaimSweeperWaitsForCancellationAfterTerminalDrainDenial(t *testing.T) {
+	var attempts atomic.Int32
+	sweeper := NewTimedClaimSweeper(nil, nil, nil)
+	sweeper.Interval = 5 * time.Millisecond
+	sweeper.IdleAdmission = func() (*activity.Lease, bool, <-chan struct{}) {
+		attempts.Add(1)
+		return nil, false, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- sweeper.Run(ctx) }()
+	require.Eventually(t, func() bool { return attempts.Load() >= 1 }, time.Second, time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int32(1), attempts.Load(), "terminal denial must not be polled")
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}

--- a/internal/daemon/handlers_health.go
+++ b/internal/daemon/handlers_health.go
@@ -65,6 +65,20 @@ func registerHealthHandlers(humaAPI huma.API, cfg ServerConfig) {
 			health := cfg.FederationConfigHealth()
 			out.Body.FederationConfig = &health
 		}
+		if cfg.IdleShutdownHealth != nil {
+			snapshot := cfg.IdleShutdownHealth()
+			if snapshot.Timeout > 0 && snapshot.State != IdleStateDisabled {
+				idle := api.IdleShutdownHealth{
+					Timeout: snapshot.Timeout.String(),
+					State:   string(snapshot.State),
+				}
+				if !snapshot.Deadline.IsZero() {
+					deadline := snapshot.Deadline
+					idle.Deadline = &deadline
+				}
+				out.Body.IdleShutdown = &idle
+			}
+		}
 		return out, nil
 	})
 }

--- a/internal/daemon/handlers_health_test.go
+++ b/internal/daemon/handlers_health_test.go
@@ -33,6 +33,44 @@ func TestHealth_ReportsSchemaAndUptime(t *testing.T) {
 	assert.NotEmpty(t, body.DBPath)
 }
 
+func TestHealthIncludesEffectiveIdleShutdownCapability(t *testing.T) {
+	d := openTestDB(t)
+	deadline := time.Date(2026, 8, 17, 17, 15, 0, 0, time.UTC)
+	ts := startTestServer(t, daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+		IdleShutdownHealth: func() daemon.IdleSnapshot {
+			return daemon.IdleSnapshot{
+				Timeout:  15 * time.Minute,
+				State:    daemon.IdleStateArmed,
+				Deadline: deadline,
+			}
+		},
+	})
+
+	var body struct {
+		IdleShutdown *api.IdleShutdownHealth `json:"idle_shutdown"`
+		LegacyIdle   json.RawMessage         `json:"idle"`
+	}
+	getAndUnmarshal(t, ts, "/api/v1/health", http.StatusOK, &body)
+	require.NotNil(t, body.IdleShutdown)
+	assert.Nil(t, body.LegacyIdle)
+	assert.Equal(t, "15m0s", body.IdleShutdown.Timeout)
+	assert.Equal(t, "armed", body.IdleShutdown.State)
+	require.NotNil(t, body.IdleShutdown.Deadline)
+	assert.True(t, body.IdleShutdown.Deadline.Equal(deadline))
+}
+
+func TestHealthOmitsIdleShutdownWhenIneffective(t *testing.T) {
+	ts, _ := startDefaultTestServer(t)
+
+	var body struct {
+		IdleShutdown *api.IdleShutdownHealth `json:"idle_shutdown"`
+	}
+	getAndUnmarshal(t, ts, "/api/v1/health", http.StatusOK, &body)
+	assert.Nil(t, body.IdleShutdown)
+}
+
 func TestHealth_OmitsEmbeddingsWhenUnconfigured(t *testing.T) {
 	ts, _ := startDefaultTestServer(t)
 

--- a/internal/daemon/idle_controller.go
+++ b/internal/daemon/idle_controller.go
@@ -1,0 +1,377 @@
+package daemon
+
+import (
+	"sync"
+	"time"
+
+	"go.kenn.io/kata/internal/activity"
+)
+
+type idleTimer interface {
+	Stop() bool
+}
+
+// DrainAdmission adapts the controller to the shared finite-work contract.
+func (c *IdleController) DrainAdmission() activity.Admission {
+	return func() (*activity.Lease, bool) {
+		lease, admitted := c.TryDrain()
+		if !admitted {
+			return nil, false
+		}
+		return activityLeaseFromIdle(lease), true
+	}
+}
+
+// WaitableDrainAdmission adapts reversible blocked-expiration denials for
+// long-lived schedulers that must resume if foreground activity revives the
+// daemon.
+func (c *IdleController) WaitableDrainAdmission() activity.WaitableAdmission {
+	return func() (*activity.Lease, bool, <-chan struct{}) {
+		lease, admitted, retry := c.TryDrainWaitable()
+		if !admitted {
+			return nil, false, retry
+		}
+		return activityLeaseFromIdle(lease), true, nil
+	}
+}
+
+// ForegroundAdmission adapts explicit client work to the shared lease shape.
+func (c *IdleController) ForegroundAdmission() activity.Admission {
+	return func() (*activity.Lease, bool) {
+		lease, admitted := c.TryForeground()
+		if !admitted {
+			return nil, false
+		}
+		return activity.NewLease(lease.Release, nil), true
+	}
+}
+
+func activityLeaseFromIdle(lease *IdleLease) *activity.Lease {
+	if lease == nil {
+		return nil
+	}
+	return activity.NewLease(lease.Release, func() (*activity.Lease, bool) {
+		child, admitted := lease.Fork()
+		if !admitted {
+			return nil, false
+		}
+		return activityLeaseFromIdle(child), true
+	})
+}
+
+type idleClock interface {
+	Now() time.Time
+	AfterFunc(time.Duration, func()) idleTimer
+}
+
+type wallIdleClock struct{}
+
+func (wallIdleClock) Now() time.Time {
+	return time.Now()
+}
+
+func (wallIdleClock) AfterFunc(delay time.Duration, callback func()) idleTimer {
+	return time.AfterFunc(delay, callback)
+}
+
+// IdleController requests daemon shutdown after a period without foreground
+// activity. Call Start once daemon startup and runtime publication complete.
+type IdleController struct {
+	mu         sync.Mutex
+	timeout    time.Duration
+	onIdle     func()
+	clock      idleClock
+	timer      idleTimer
+	deadline   time.Time
+	generation uint64
+	started    bool
+	stopping   bool
+	foreground int
+	drains     int
+	expired    bool
+	drainRetry chan struct{}
+}
+
+// IdleState describes the controller's observable lifecycle phase.
+type IdleState string
+
+const (
+	// IdleStateDisabled means idle shutdown is not active.
+	IdleStateDisabled IdleState = "disabled"
+	// IdleStateArmed means the daemon is awaiting its idle deadline.
+	IdleStateArmed IdleState = "armed"
+	// IdleStateForeground means explicit client work is active.
+	IdleStateForeground IdleState = "foreground"
+	// IdleStateBlocked means the deadline elapsed while drain work remains.
+	IdleStateBlocked IdleState = "blocked"
+	// IdleStateStopping means admission is closed and shutdown has started.
+	IdleStateStopping IdleState = "stopping"
+)
+
+// IdleSnapshot is a read-only view suitable for health reporting.
+type IdleSnapshot struct {
+	Timeout  time.Duration
+	State    IdleState
+	Deadline time.Time
+}
+
+type idleLeaseKind uint8
+
+const (
+	idleLeaseForeground idleLeaseKind = iota
+	idleLeaseDrain
+)
+
+// IdleLease protects admitted daemon work until Release is called.
+type IdleLease struct {
+	controller *IdleController
+	kind       idleLeaseKind
+	released   bool
+	forkable   bool
+}
+
+// NewIdleController constructs a controller backed by the wall clock.
+func NewIdleController(timeout time.Duration, onIdle func()) *IdleController {
+	return newIdleControllerWithClock(timeout, onIdle, wallIdleClock{})
+}
+
+func newIdleControllerWithClock(
+	timeout time.Duration, onIdle func(), clock idleClock,
+) *IdleController {
+	return &IdleController{timeout: timeout, onIdle: onIdle, clock: clock}
+}
+
+// Snapshot returns the controller's current effective state.
+func (c *IdleController) Snapshot() IdleSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	snapshot := IdleSnapshot{Timeout: c.timeout, Deadline: c.deadline}
+	switch {
+	case c.stopping:
+		snapshot.State = IdleStateStopping
+		snapshot.Deadline = time.Time{}
+	case !c.started || c.timeout <= 0:
+		snapshot.State = IdleStateDisabled
+	case c.foreground > 0:
+		snapshot.State = IdleStateForeground
+		snapshot.Deadline = time.Time{}
+	case c.expired:
+		snapshot.State = IdleStateBlocked
+	default:
+		snapshot.State = IdleStateArmed
+	}
+	return snapshot
+}
+
+// TryForeground admits client activity unless shutdown has started.
+func (c *IdleController) TryForeground() (*IdleLease, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stopping {
+		return nil, false
+	}
+	c.foreground++
+	if c.expired {
+		c.wakeDrainRetryLocked()
+	}
+	c.expired = false
+	c.generation++
+	if c.timer != nil {
+		c.timer.Stop()
+	}
+	return &IdleLease{controller: c, kind: idleLeaseForeground}, true
+}
+
+// TryDrain admits a top-level background operation before the idle deadline.
+func (c *IdleController) TryDrain() (*IdleLease, bool) {
+	lease, admitted, _ := c.TryDrainWaitable()
+	return lease, admitted
+}
+
+// TryDrainWaitable admits finite background work and, for a reversible
+// blocked-expiration denial, atomically returns a channel closed when
+// foreground activity reopens admission. A nil retry channel means shutdown
+// is terminal and callers should wait only for root cancellation.
+func (c *IdleController) TryDrainWaitable() (*IdleLease, bool, <-chan struct{}) {
+	c.mu.Lock()
+	if c.stopping {
+		c.mu.Unlock()
+		return nil, false, nil
+	}
+	if c.expired {
+		retry := c.drainRetryLocked()
+		c.mu.Unlock()
+		return nil, false, retry
+	}
+	if c.started && c.foreground == 0 && !c.clock.Now().Before(c.deadline) {
+		c.expired = true
+		shouldStop := c.drains == 0
+		var retry <-chan struct{}
+		if shouldStop {
+			c.stopping = true
+			c.generation++
+			c.wakeDrainRetryLocked()
+		} else {
+			retry = c.drainRetryLocked()
+		}
+		onIdle := c.onIdle
+		c.mu.Unlock()
+		if shouldStop && onIdle != nil {
+			onIdle()
+		}
+		return nil, false, retry
+	}
+	c.drains++
+	c.mu.Unlock()
+	return &IdleLease{controller: c, kind: idleLeaseDrain, forkable: true}, true, nil
+}
+
+// Release completes admitted work. It is safe to call more than once.
+func (l *IdleLease) Release() {
+	if l == nil {
+		return
+	}
+	l.controller.release(l)
+}
+
+// Fork transfers protection from an admitted top-level drain operation to one
+// finite child operation. Child leases cannot fork again.
+func (l *IdleLease) Fork() (*IdleLease, bool) {
+	if l == nil || l.controller == nil {
+		return nil, false
+	}
+	c := l.controller
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stopping || l.released || l.kind != idleLeaseDrain || !l.forkable {
+		return nil, false
+	}
+	c.drains++
+	return &IdleLease{controller: c, kind: idleLeaseDrain}, true
+}
+
+func (c *IdleController) release(lease *IdleLease) {
+	c.mu.Lock()
+	if lease.released {
+		c.mu.Unlock()
+		return
+	}
+	lease.released = true
+	if c.stopping {
+		c.mu.Unlock()
+		return
+	}
+	switch lease.kind {
+	case idleLeaseForeground:
+		c.foreground--
+		if c.started && c.foreground == 0 {
+			c.armLocked(c.clock.Now().Add(c.timeout))
+		}
+		c.mu.Unlock()
+	case idleLeaseDrain:
+		c.drains--
+		shouldStop := c.expired && c.drains == 0 && c.foreground == 0
+		if shouldStop {
+			c.stopping = true
+			c.generation++
+			c.wakeDrainRetryLocked()
+		}
+		onIdle := c.onIdle
+		c.mu.Unlock()
+		if shouldStop && onIdle != nil {
+			onIdle()
+		}
+	default:
+		c.mu.Unlock()
+	}
+}
+
+// Start begins the initial idle interval. Repeated calls are harmless.
+func (c *IdleController) Start() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.started || c.stopping || c.timeout <= 0 {
+		return
+	}
+	c.started = true
+	if c.foreground > 0 {
+		return
+	}
+	c.armLocked(c.clock.Now().Add(c.timeout))
+}
+
+// Stop disables idle shutdown. Repeated calls are harmless.
+func (c *IdleController) Stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stopping {
+		return
+	}
+	c.stopping = true
+	c.generation++
+	c.wakeDrainRetryLocked()
+	if c.timer != nil {
+		c.timer.Stop()
+	}
+}
+
+func (c *IdleController) armLocked(deadline time.Time) {
+	if c.expired {
+		c.wakeDrainRetryLocked()
+	}
+	c.generation++
+	generation := c.generation
+	c.deadline = deadline
+	c.expired = false
+	if c.timer != nil {
+		c.timer.Stop()
+	}
+	delay := deadline.Sub(c.clock.Now())
+	if delay < 0 {
+		delay = 0
+	}
+	c.timer = c.clock.AfterFunc(delay, func() {
+		c.expire(generation)
+	})
+}
+
+func (c *IdleController) expire(generation uint64) {
+	c.mu.Lock()
+	if c.stopping || generation != c.generation {
+		c.mu.Unlock()
+		return
+	}
+	if now := c.clock.Now(); now.Before(c.deadline) {
+		c.armLocked(c.deadline)
+		c.mu.Unlock()
+		return
+	}
+	if c.drains > 0 {
+		c.expired = true
+		c.mu.Unlock()
+		return
+	}
+	c.stopping = true
+	c.generation++
+	c.wakeDrainRetryLocked()
+	onIdle := c.onIdle
+	c.mu.Unlock()
+	if onIdle != nil {
+		onIdle()
+	}
+}
+
+func (c *IdleController) drainRetryLocked() <-chan struct{} {
+	if c.drainRetry == nil {
+		c.drainRetry = make(chan struct{})
+	}
+	return c.drainRetry
+}
+
+func (c *IdleController) wakeDrainRetryLocked() {
+	if c.drainRetry == nil {
+		return
+	}
+	close(c.drainRetry)
+	c.drainRetry = nil
+}

--- a/internal/daemon/idle_controller.go
+++ b/internal/daemon/idle_controller.go
@@ -35,17 +35,6 @@ func (c *IdleController) WaitableDrainAdmission() activity.WaitableAdmission {
 	}
 }
 
-// ForegroundAdmission adapts explicit client work to the shared lease shape.
-func (c *IdleController) ForegroundAdmission() activity.Admission {
-	return func() (*activity.Lease, bool) {
-		lease, admitted := c.TryForeground()
-		if !admitted {
-			return nil, false
-		}
-		return activity.NewLease(lease.Release, nil), true
-	}
-}
-
 func activityLeaseFromIdle(lease *IdleLease) *activity.Lease {
 	if lease == nil {
 		return nil

--- a/internal/daemon/idle_controller_test.go
+++ b/internal/daemon/idle_controller_test.go
@@ -1,0 +1,406 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdleControllerStopsAfterInitialTimeout(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 1)
+	controller := newIdleControllerWithClock(time.Minute, func() {
+		idle <- struct{}{}
+	}, clock)
+
+	controller.Start()
+	clock.Advance(time.Minute)
+
+	select {
+	case <-idle:
+	default:
+		t.Fatal("idle callback was not invoked at the initial deadline")
+	}
+}
+
+func TestIdleControllerForegroundActivityStartsFreshIntervalAfterRelease(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 1)
+	controller := newIdleControllerWithClock(time.Minute, func() {
+		idle <- struct{}{}
+	}, clock)
+	controller.Start()
+	clock.Advance(45 * time.Second)
+
+	lease, admitted := controller.TryForeground()
+	require.True(t, admitted)
+	clock.Advance(30 * time.Second)
+	requireNoIdleCallback(t, idle)
+
+	lease.Release()
+	clock.Advance(59 * time.Second)
+	requireNoIdleCallback(t, idle)
+	clock.Advance(time.Second)
+
+	select {
+	case <-idle:
+	default:
+		t.Fatal("idle callback was not invoked after the post-activity interval")
+	}
+}
+
+func TestIdleControllerDrainBlocksExpiredShutdownWithoutResettingDeadline(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 1)
+	controller := newIdleControllerWithClock(time.Minute, func() {
+		idle <- struct{}{}
+	}, clock)
+	controller.Start()
+
+	lease, admitted := controller.TryDrain()
+	require.True(t, admitted)
+	clock.Advance(time.Minute)
+	requireNoIdleCallback(t, idle)
+
+	lease.Release()
+	select {
+	case <-idle:
+	default:
+		t.Fatal("idle callback was not invoked when the expired drain completed")
+	}
+}
+
+func TestIdleControllerBlockedDrainCanForkOneFiniteChild(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 1)
+	controller := newIdleControllerWithClock(time.Minute, func() {
+		idle <- struct{}{}
+	}, clock)
+	controller.Start()
+
+	parent, admitted := controller.TryDrain()
+	require.True(t, admitted)
+	clock.Advance(time.Minute)
+
+	_, admitted = controller.TryDrain()
+	require.False(t, admitted, "expired controller admitted unrelated scheduled work")
+	child, admitted := parent.Fork()
+	require.True(t, admitted)
+	_, admitted = child.Fork()
+	require.False(t, admitted, "child drain lease admitted recursive derivation")
+
+	parent.Release()
+	requireNoIdleCallback(t, idle)
+	child.Release()
+	select {
+	case <-idle:
+	default:
+		t.Fatal("idle callback was not invoked after the finite child completed")
+	}
+}
+
+func TestIdleControllerPreservesForegroundLeaseAcquiredBeforeStart(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 1)
+	controller := newIdleControllerWithClock(time.Minute, func() {
+		idle <- struct{}{}
+	}, clock)
+
+	lease, admitted := controller.TryForeground()
+	require.True(t, admitted)
+	controller.Start()
+	clock.Advance(time.Minute)
+	requireNoIdleCallback(t, idle)
+
+	lease.Release()
+	clock.Advance(time.Minute)
+	select {
+	case <-idle:
+	default:
+		t.Fatal("idle callback was not invoked after the pre-start activity completed")
+	}
+}
+
+func TestIdleControllerSnapshotReportsEffectiveLifecycleState(t *testing.T) {
+	start := time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC)
+	clock := newIdleTestClock(start)
+	controller := newIdleControllerWithClock(time.Minute, nil, clock)
+	controller.Start()
+
+	snapshot := controller.Snapshot()
+	require.Equal(t, IdleStateArmed, snapshot.State)
+	require.Equal(t, time.Minute, snapshot.Timeout)
+	require.Equal(t, start.Add(time.Minute), snapshot.Deadline)
+
+	drain, admitted := controller.TryDrain()
+	require.True(t, admitted)
+	clock.Advance(time.Minute)
+	snapshot = controller.Snapshot()
+	require.Equal(t, IdleStateBlocked, snapshot.State)
+	require.Equal(t, start.Add(time.Minute), snapshot.Deadline)
+	drain.Release()
+	snapshot = controller.Snapshot()
+	require.Equal(t, IdleStateStopping, snapshot.State)
+	require.True(t, snapshot.Deadline.IsZero())
+}
+
+func TestIdleControllerForegroundRevivesBlockedExpiration(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 1)
+	controller := newIdleControllerWithClock(time.Minute, func() { idle <- struct{}{} }, clock)
+	controller.Start()
+
+	drain, admitted := controller.TryDrain()
+	require.True(t, admitted)
+	clock.Advance(time.Minute)
+	require.Equal(t, IdleStateBlocked, controller.Snapshot().State)
+
+	foreground, admitted := controller.TryForeground()
+	require.True(t, admitted)
+	foreground.Release()
+	drain.Release()
+	requireNoIdleCallback(t, idle)
+	clock.Advance(time.Minute)
+	select {
+	case <-idle:
+	default:
+		t.Fatal("revived controller did not observe the fresh foreground interval")
+	}
+}
+
+func TestIdleControllerWaitableDrainDenialWakesOnForegroundRevival(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	controller := newIdleControllerWithClock(time.Minute, nil, clock)
+	controller.Start()
+
+	drain, admitted := controller.TryDrain()
+	require.True(t, admitted)
+	clock.Advance(time.Minute)
+
+	_, admitted, retry := controller.TryDrainWaitable()
+	require.False(t, admitted)
+	require.NotNil(t, retry)
+	select {
+	case <-retry:
+		t.Fatal("blocked drain retry woke before foreground revival")
+	default:
+	}
+
+	foreground, admitted := controller.TryForeground()
+	require.True(t, admitted)
+	select {
+	case <-retry:
+	case <-time.After(time.Second):
+		t.Fatal("foreground revival did not wake blocked drain retry")
+	}
+	foreground.Release()
+	drain.Release()
+}
+
+func TestIdleControllerReleasedPreStartLeaseDoesNotDelayInitialDeadline(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 1)
+	controller := newIdleControllerWithClock(time.Minute, func() { idle <- struct{}{} }, clock)
+	lease, admitted := controller.TryForeground()
+	require.True(t, admitted)
+	lease.Release()
+
+	controller.Start()
+	clock.Advance(time.Minute)
+	select {
+	case <-idle:
+	default:
+		t.Fatal("released pre-start lease delayed the initial deadline")
+	}
+}
+
+func TestIdleControllerConcurrentDuplicateReleaseIsHarmless(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 2)
+	controller := newIdleControllerWithClock(time.Minute, func() { idle <- struct{}{} }, clock)
+	controller.Start()
+	lease, admitted := controller.TryForeground()
+	require.True(t, admitted)
+
+	var releases sync.WaitGroup
+	for range 16 {
+		releases.Add(1)
+		go func() {
+			defer releases.Done()
+			lease.Release()
+		}()
+	}
+	releases.Wait()
+	clock.Advance(time.Minute)
+	require.Len(t, idle, 1)
+}
+
+func TestIdleControllerAdmissionRacingExpirationRemainsConsistent(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 2)
+	controller := newIdleControllerWithClock(time.Minute, func() { idle <- struct{}{} }, clock)
+	controller.Start()
+	clock.mu.Lock()
+	timer := clock.timers[0]
+	clock.now = clock.now.Add(time.Minute)
+	clock.mu.Unlock()
+
+	start := make(chan struct{})
+	leaseResult := make(chan *IdleLease, 1)
+	var racers sync.WaitGroup
+	racers.Add(2)
+	go func() {
+		defer racers.Done()
+		<-start
+		timer.ForceFire()
+	}()
+	go func() {
+		defer racers.Done()
+		<-start
+		lease, admitted := controller.TryForeground()
+		if admitted {
+			leaseResult <- lease
+		}
+	}()
+	close(start)
+	racers.Wait()
+	close(leaseResult)
+
+	if lease := <-leaseResult; lease != nil {
+		requireNoIdleCallback(t, idle)
+		lease.Release()
+		clock.Advance(time.Minute)
+	}
+	require.LessOrEqual(t, len(idle), 1)
+	require.Equal(t, IdleStateStopping, controller.Snapshot().State)
+}
+
+func TestIdleControllerStopRacingExpirationInvokesCallbackAtMostOnce(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 2)
+	controller := newIdleControllerWithClock(time.Minute, func() { idle <- struct{}{} }, clock)
+	controller.Start()
+	clock.mu.Lock()
+	timer := clock.timers[0]
+	clock.now = clock.now.Add(time.Minute)
+	clock.mu.Unlock()
+
+	var racers sync.WaitGroup
+	racers.Add(2)
+	go func() {
+		defer racers.Done()
+		timer.ForceFire()
+	}()
+	go func() {
+		defer racers.Done()
+		controller.Stop()
+	}()
+	racers.Wait()
+	require.LessOrEqual(t, len(idle), 1)
+	require.Equal(t, IdleStateStopping, controller.Snapshot().State)
+}
+
+func TestIdleControllerCallbackMayReenterController(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	done := make(chan struct{})
+	var controller *IdleController
+	controller = newIdleControllerWithClock(time.Minute, func() {
+		_ = controller.Snapshot()
+		controller.Stop()
+		close(done)
+	}, clock)
+	controller.Start()
+	clock.Advance(time.Minute)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("idle callback deadlocked while reentering the controller")
+	}
+}
+
+type idleTestClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*idleTestTimer
+}
+
+func newIdleTestClock(now time.Time) *idleTestClock {
+	return &idleTestClock{now: now}
+}
+
+func (c *idleTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *idleTestClock) AfterFunc(delay time.Duration, callback func()) idleTimer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	timer := &idleTestTimer{deadline: c.now.Add(delay), callback: callback}
+	c.timers = append(c.timers, timer)
+	return timer
+}
+
+func (c *idleTestClock) Advance(delay time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(delay)
+	now := c.now
+	timers := append([]*idleTestTimer(nil), c.timers...)
+	c.mu.Unlock()
+
+	for _, timer := range timers {
+		timer.FireIfDue(now)
+	}
+}
+
+type idleTestTimer struct {
+	mu       sync.Mutex
+	deadline time.Time
+	callback func()
+	stopped  bool
+	fired    bool
+}
+
+func (t *idleTestTimer) Stop() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	wasActive := !t.stopped && !t.fired
+	t.stopped = true
+	return wasActive
+}
+
+func (t *idleTestTimer) FireIfDue(now time.Time) {
+	t.mu.Lock()
+	if t.stopped || t.fired || now.Before(t.deadline) {
+		t.mu.Unlock()
+		return
+	}
+	t.fired = true
+	callback := t.callback
+	t.mu.Unlock()
+	callback()
+}
+
+func (t *idleTestTimer) ForceFire() {
+	t.mu.Lock()
+	if t.fired {
+		t.mu.Unlock()
+		return
+	}
+	t.fired = true
+	callback := t.callback
+	t.mu.Unlock()
+	callback()
+}
+
+func requireNoIdleCallback(t *testing.T, idle <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-idle:
+		require.FailNow(t, "unexpected idle callback")
+	default:
+	}
+}

--- a/internal/daemon/idle_eligibility.go
+++ b/internal/daemon/idle_eligibility.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"go.kenn.io/kata/internal/config"
+	kitdaemon "go.kenn.io/kit/daemon"
+)
+
+// AutostartIdleShutdownEligible reports whether every effective daemon
+// exposure remains owner-local. Auto-start provenance is checked by the caller.
+func AutostartIdleShutdownEligible(
+	daemonEndpoint kitdaemon.Endpoint,
+	webEndpoint WebEndpoint,
+	cfg config.DaemonConfig,
+) bool {
+	if !idleLocalEndpoint(daemonEndpoint) || !idleLocalEndpoint(webEndpoint.Endpoint) {
+		return false
+	}
+	if strings.TrimSpace(cfg.Auth.Proxy.TrustedActorHeader) != "" ||
+		len(cfg.Auth.Proxy.TrustedProxyListeners) != 0 {
+		return false
+	}
+	if webEndpoint.Shared && len(cfg.Web.AllowedHosts) != 0 {
+		return false
+	}
+	origin, err := url.Parse(webEndpoint.Origin)
+	if err != nil || (origin.Scheme != "http" && origin.Scheme != "https") {
+		return false
+	}
+	return isLoopbackHost(origin.Hostname())
+}
+
+func idleLocalEndpoint(endpoint kitdaemon.Endpoint) bool {
+	if endpoint.Network == kitdaemon.NetworkUnix {
+		return true
+	}
+	if endpoint.Network != kitdaemon.NetworkTCP {
+		return false
+	}
+	host, _, err := net.SplitHostPort(endpoint.Address)
+	return err == nil && isLoopbackHost(host)
+}

--- a/internal/daemon/idle_eligibility_test.go
+++ b/internal/daemon/idle_eligibility_test.go
@@ -1,0 +1,68 @@
+package daemon_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
+	kitdaemon "go.kenn.io/kit/daemon"
+)
+
+func TestAutostartIdleShutdownRequiresOwnerLocalExposure(t *testing.T) {
+	localDaemon := kitdaemon.Endpoint{Network: kitdaemon.NetworkUnix, Address: "/tmp/kata.sock"}
+	localWeb := daemon.WebEndpoint{
+		Endpoint: kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "127.0.0.1:27123"},
+		Origin:   "http://127.0.0.1:27123",
+	}
+
+	tests := []struct {
+		name     string
+		daemon   kitdaemon.Endpoint
+		web      daemon.WebEndpoint
+		config   config.DaemonConfig
+		eligible bool
+	}{
+		{name: "unix and loopback listeners", daemon: localDaemon, web: localWeb, eligible: true},
+		{
+			name:   "private network daemon listener",
+			daemon: kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "100.64.0.5:7777"},
+			web:    localWeb,
+		},
+		{
+			name:   "externally published loopback listener",
+			daemon: localDaemon,
+			web: daemon.WebEndpoint{
+				Endpoint: localWeb.Endpoint,
+				Origin:   "https://daemon.example",
+			},
+		},
+		{
+			name:   "trusted proxy exposure",
+			daemon: localDaemon,
+			web:    localWeb,
+			config: config.DaemonConfig{Auth: config.AuthConfig{Proxy: config.ProxyConfig{
+				TrustedActorHeader:    "X-Actor",
+				TrustedProxyListeners: []string{"127.0.0.1:27123"},
+			}}},
+		},
+		{
+			name:   "shared listener with proxy host aliases",
+			daemon: localDaemon,
+			web: daemon.WebEndpoint{
+				Endpoint: localWeb.Endpoint,
+				Origin:   localWeb.Origin,
+				Shared:   true,
+			},
+			config: config.DaemonConfig{Web: config.WebConfig{
+				AllowedHosts: []string{"backend.example:7777"},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.eligible, daemon.AutostartIdleShutdownEligible(tt.daemon, tt.web, tt.config))
+		})
+	}
+}

--- a/internal/daemon/idle_hooks.go
+++ b/internal/daemon/idle_hooks.go
@@ -1,0 +1,15 @@
+package daemon
+
+import (
+	"go.kenn.io/kata/internal/activity"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/hooks"
+)
+
+func enqueueHookWithDrain(sink hooks.Sink, event db.Event, parent *activity.Lease) {
+	if parent == nil {
+		sink.Enqueue(event)
+		return
+	}
+	hooks.EnqueueFrom(sink, event, parent.Fork)
+}

--- a/internal/daemon/idle_hooks_test.go
+++ b/internal/daemon/idle_hooks_test.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/hooks"
+)
+
+type parentForkSink struct {
+	admitted bool
+}
+
+func (*parentForkSink) Enqueue(db.Event) {}
+
+func (s *parentForkSink) EnqueueFrom(_ db.Event, acquire hooks.AcquireActivity) {
+	lease, admitted := acquire()
+	s.admitted = admitted
+	if lease != nil {
+		lease.Release()
+	}
+}
+
+func TestBlockedIdleDrainCanHandProtectionToCausedHook(t *testing.T) {
+	clock := newIdleTestClock(time.Date(2026, time.August, 17, 12, 0, 0, 0, time.UTC))
+	idle := make(chan struct{}, 1)
+	controller := newIdleControllerWithClock(time.Minute, func() { idle <- struct{}{} }, clock)
+	controller.Start()
+	parent, admitted := controller.TryDrain()
+	require.True(t, admitted)
+	clock.Advance(time.Minute)
+	require.Equal(t, IdleStateBlocked, controller.Snapshot().State)
+
+	sink := &parentForkSink{}
+	enqueueHookWithDrain(sink, db.Event{ID: 1, Type: "issue.created"}, activityLeaseFromIdle(parent))
+	require.True(t, sink.admitted)
+	requireNoIdleCallback(t, idle)
+	parent.Release()
+	select {
+	case <-idle:
+	default:
+		t.Fatal("idle callback did not run after parent and caused hook released")
+	}
+}

--- a/internal/daemon/idle_http.go
+++ b/internal/daemon/idle_http.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"net/http"
+
+	"go.kenn.io/kata/internal/api"
+)
+
+// IdleKeepaliveHeader marks a liveness request as foreground activity. It is
+// a lifecycle hint, not an authorization mechanism.
+const IdleKeepaliveHeader = "X-Kata-Idle-Keepalive"
+
+// IdleForegroundAdmission is the narrow lifecycle seam used by HTTP serving.
+type IdleForegroundAdmission interface {
+	TryForeground() (*IdleLease, bool)
+}
+
+func withIdleAdmission(admission IdleForegroundAdmission, next http.Handler) http.Handler {
+	if admission == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Browser preflight is validation traffic, not use of the daemon. It may
+		// reach this inner layer on public probe routes that intentionally bypass
+		// session and bearer requirements.
+		if r.Method == http.MethodOptions || isObservationalProbe(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		lease, admitted := admission.TryForeground()
+		if !admitted {
+			api.WriteEnvelope(w, http.StatusServiceUnavailable, "daemon_stopping",
+				"daemon is stopping")
+			return
+		}
+		defer lease.Release()
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isObservationalProbe(r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		return false
+	}
+	switch r.URL.Path {
+	case "/api/v1/ping":
+		return !isMarkedIdleKeepalive(r)
+	case "/api/v1/health", "/api/v1/instance":
+		return true
+	default:
+		return false
+	}
+}
+
+func isMarkedIdleKeepalive(r *http.Request) bool {
+	return r.Method == http.MethodGet && r.URL.Path == "/api/v1/ping" &&
+		r.Header.Get(IdleKeepaliveHeader) != ""
+}

--- a/internal/daemon/idle_http_test.go
+++ b/internal/daemon/idle_http_test.go
@@ -1,0 +1,232 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/config"
+)
+
+type rejectingIdleAdmission struct {
+	calls atomic.Int32
+}
+
+func (a *rejectingIdleAdmission) TryForeground() (*IdleLease, bool) {
+	a.calls.Add(1)
+	return nil, false
+}
+
+func TestIdleHTTPAdmissionClassifiesRequests(t *testing.T) {
+	t.Parallel()
+
+	clock := newIdleTestClock(time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC))
+	controller := newIdleControllerWithClock(time.Minute, nil, clock)
+	controller.Start()
+	initialDeadline := controller.Snapshot().Deadline
+
+	var states []IdleState
+	handler := withIdleAdmission(controller, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		states = append(states, controller.Snapshot().State)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	clock.Advance(10 * time.Second)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil))
+	require.Equal(t, []IdleState{IdleStateArmed}, states)
+	require.Equal(t, initialDeadline, controller.Snapshot().Deadline)
+
+	clock.Advance(10 * time.Second)
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil)
+	request.Header.Set(IdleKeepaliveHeader, "1")
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+	require.Equal(t, []IdleState{IdleStateArmed, IdleStateForeground}, states)
+	require.Equal(t, clock.Now().Add(time.Minute), controller.Snapshot().Deadline)
+
+	clock.Advance(10 * time.Second)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil))
+	require.Equal(t, []IdleState{IdleStateArmed, IdleStateForeground, IdleStateForeground}, states)
+	require.Equal(t, clock.Now().Add(time.Minute), controller.Snapshot().Deadline)
+}
+
+func TestIdleHTTPAdmissionRejectsRequestsAfterStopping(t *testing.T) {
+	t.Parallel()
+
+	controller := NewIdleController(time.Minute, nil)
+	controller.Start()
+	controller.Stop()
+	called := false
+	handler := withIdleAdmission(controller, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	require.False(t, called)
+	require.Contains(t, recorder.Body.String(), `"code":"daemon_stopping"`)
+}
+
+func TestIdleHTTPAdmissionLeavesObservationalProbesUnleased(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{"/api/v1/ping", "/api/v1/health", "/api/v1/instance"} {
+		t.Run(path, func(t *testing.T) {
+			controller := NewIdleController(time.Minute, nil)
+			controller.Start()
+			controller.Stop()
+			called := false
+			handler := withIdleAdmission(controller, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+
+			require.Equal(t, http.StatusNoContent, recorder.Code)
+			require.True(t, called)
+		})
+	}
+}
+
+func TestIdleKeepaliveMarkerOnlyUpgradesGetPing(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		want   bool
+	}{
+		{name: "get ping", method: http.MethodGet, path: "/api/v1/ping", want: true},
+		{name: "post ping", method: http.MethodPost, path: "/api/v1/ping"},
+		{name: "get health", method: http.MethodGet, path: "/api/v1/health"},
+		{name: "get instance", method: http.MethodGet, path: "/api/v1/instance"},
+		{name: "get data", method: http.MethodGet, path: "/api/v1/projects"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := httptest.NewRequest(tc.method, tc.path, nil)
+			request.Header.Set(IdleKeepaliveHeader, "1")
+			require.Equal(t, tc.want, isMarkedIdleKeepalive(request))
+		})
+	}
+}
+
+func TestServerIdleAdmissionRunsAfterRequestValidation(t *testing.T) {
+	t.Parallel()
+
+	newServer := func(t *testing.T, admission IdleForegroundAdmission) *Server {
+		t.Helper()
+		return NewServer(ServerConfig{
+			Auth:          config.AuthConfig{Token: "expected-token"},
+			IdleAdmission: admission,
+		})
+	}
+
+	t.Run("missing bearer", func(t *testing.T) {
+		admission := &rejectingIdleAdmission{}
+		recorder := httptest.NewRecorder()
+		newServer(t, admission).Handler().ServeHTTP(
+			recorder, httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil))
+
+		require.Equal(t, http.StatusUnauthorized, recorder.Code)
+		require.Zero(t, admission.calls.Load())
+	})
+
+	t.Run("cross origin socket request", func(t *testing.T) {
+		admission := &rejectingIdleAdmission{}
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil)
+		request.Header.Set("Origin", "https://attacker.example")
+		recorder := httptest.NewRecorder()
+		newServer(t, admission).Handler().ServeHTTP(recorder, request)
+
+		require.Equal(t, http.StatusForbidden, recorder.Code)
+		require.Zero(t, admission.calls.Load())
+	})
+
+	t.Run("cross origin preflight", func(t *testing.T) {
+		admission := &rejectingIdleAdmission{}
+		request := httptest.NewRequest(http.MethodOptions, "/api/v1/projects", nil)
+		request.Header.Set("Origin", "https://attacker.example")
+		request.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		recorder := httptest.NewRecorder()
+		newServer(t, admission).Handler().ServeHTTP(recorder, request)
+
+		require.Equal(t, http.StatusForbidden, recorder.Code)
+		require.Zero(t, admission.calls.Load())
+	})
+
+	t.Run("browser preflight reaching the route stack", func(t *testing.T) {
+		admission := &rejectingIdleAdmission{}
+		server := newServer(t, admission)
+		handler, err := server.HandlerFor(ListenerPolicy{
+			Kind:   ListenerBrowser,
+			Origin: "https://kata.example",
+		})
+		require.NoError(t, err)
+		request := httptest.NewRequest(http.MethodOptions, "https://kata.example/api/v1/ping", nil)
+		request.Host = "kata.example"
+		request.Header.Set("Origin", "https://attacker.example")
+		request.Header.Set("Access-Control-Request-Method", http.MethodGet)
+		request.Header.Set("Access-Control-Request-Headers", IdleKeepaliveHeader)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+
+		require.NotEqual(t, http.StatusServiceUnavailable, recorder.Code)
+		require.Zero(t, admission.calls.Load())
+	})
+
+	t.Run("invalid browser host", func(t *testing.T) {
+		admission := &rejectingIdleAdmission{}
+		server := newServer(t, admission)
+		handler, err := server.HandlerFor(ListenerPolicy{
+			Kind:   ListenerBrowser,
+			Origin: "https://kata.example",
+		})
+		require.NoError(t, err)
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil)
+		request.Host = "attacker.example"
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+		require.Zero(t, admission.calls.Load())
+	})
+
+	t.Run("missing browser session", func(t *testing.T) {
+		admission := &rejectingIdleAdmission{}
+		manager := newDeterministicSessionManager(t, "https://kata.example", "idle_test")
+		server := NewServer(ServerConfig{WebSessions: manager, IdleAdmission: admission})
+		handler, err := server.HandlerFor(ListenerPolicy{
+			Kind:                  ListenerBrowser,
+			Origin:                "https://kata.example",
+			RequireBrowserSession: true,
+		})
+		require.NoError(t, err)
+		request := httptest.NewRequest(http.MethodGet, "https://kata.example/api/v1/projects", nil)
+		request.Host = "kata.example"
+		request.Header.Set("Origin", "https://kata.example")
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+
+		require.Equal(t, http.StatusUnauthorized, recorder.Code)
+		require.Zero(t, admission.calls.Load())
+	})
+
+	t.Run("validated bearer request", func(t *testing.T) {
+		admission := &rejectingIdleAdmission{}
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil)
+		request.Header.Set("Authorization", "Bearer expected-token")
+		recorder := httptest.NewRecorder()
+		newServer(t, admission).Handler().ServeHTTP(recorder, request)
+
+		require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+		require.Equal(t, int32(1), admission.calls.Load())
+	})
+}

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -16,7 +16,7 @@ import (
 // (info.version). It tracks the HTTP API contract, not the build version, so
 // the committed schema artifact stays stable across builds and is bumped
 // deliberately when the wire contract changes.
-const APISchemaVersion = "0.11.0"
+const APISchemaVersion = "0.12.0"
 
 // OpenAPIDocument builds the daemon's complete OpenAPI model by wiring every
 // route through NewServer with a zero ServerConfig. It binds no listener and

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -242,10 +242,26 @@ func TestOpenAPIDocumentIncludesUIReadContract(t *testing.T) {
 	}
 }
 
-func TestOpenAPISchemaVersionReflectsPinnedRelationshipTargets(t *testing.T) {
-	if APISchemaVersion != "0.11.0" {
-		t.Fatalf("APISchemaVersion = %q, want 0.11.0 for pinned relationship targets and audit event IDs", APISchemaVersion)
+func TestOpenAPISchemaVersionReflectsIdleShutdownCapability(t *testing.T) {
+	if APISchemaVersion != "0.12.0" {
+		t.Fatalf("APISchemaVersion = %q, want 0.12.0 for the idle shutdown health capability", APISchemaVersion)
 	}
+}
+
+func TestOpenAPIDocumentDefinesIdleShutdownHealthStates(t *testing.T) {
+	doc := OpenAPIDocument()
+	health := doc.Components.Schemas.Map()["HealthResponseBody"]
+	require.NotNil(t, health)
+	require.Contains(t, health.Properties, "idle_shutdown")
+	require.NotContains(t, health.Properties, "idle")
+	require.False(t, slices.Contains(health.Required, "idle_shutdown"))
+
+	idle := doc.Components.Schemas.Map()["IdleShutdownHealth"]
+	require.NotNil(t, idle)
+	require.Equal(t,
+		[]any{"armed", "foreground", "blocked", "stopping"},
+		idle.Properties["state"].Enum,
+	)
 }
 
 func TestOpenAPIDocumentIncludesConfigDrivenFederationContract(t *testing.T) {

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/embedding"
 	"go.kenn.io/kata/internal/vector"
@@ -23,11 +24,12 @@ type embedder interface {
 
 // ReconcilerConfig tunes the reconciler.
 type ReconcilerConfig struct {
-	BatchSize  int
-	SweepEvery time.Duration // periodic safety sweep; default 5m
-	MinBackoff time.Duration // default 1s
-	MaxBackoff time.Duration // default 5m
-	Now        func() time.Time
+	BatchSize      int
+	SweepEvery     time.Duration // periodic safety sweep; default 5m
+	MinBackoff     time.Duration // default 1s
+	MaxBackoff     time.Duration // default 5m
+	Now            func() time.Time
+	DrainAdmission activity.WaitableAdmission
 }
 
 // ReconcilerHealth is the operator-visible state surfaced in /health.
@@ -187,10 +189,21 @@ func (r *Reconciler) runLeader(ctx context.Context) error {
 		case <-r.wake:
 		case <-timer.C:
 		}
-		if err := r.reconcileOnce(ctx); err == nil {
+		attempted, err := r.reconcileAdmitted(ctx)
+		if !attempted {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			timer.Reset(0)
+			continue
+		}
+		if err == nil {
 			backoff = r.cfg.MinBackoff
 			timer.Reset(r.cfg.SweepEvery)
 		} else {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			if leaseErr := r.idx.ValidateReconcilerLease(ctx); leaseErr != nil {
 				return errors.Join(err, leaseErr)
 			}
@@ -198,6 +211,27 @@ func (r *Reconciler) runLeader(ctx context.Context) error {
 			timer.Reset(backoff)
 		}
 	}
+}
+
+func (r *Reconciler) reconcileAdmitted(ctx context.Context) (bool, error) {
+	if r.cfg.DrainAdmission == nil {
+		return true, r.reconcileOnce(ctx)
+	}
+	lease, admitted, retry := r.cfg.DrainAdmission()
+	if !admitted {
+		if retry == nil {
+			<-ctx.Done()
+			return false, ctx.Err()
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-retry:
+			return false, nil
+		}
+	}
+	defer lease.Release()
+	return true, r.reconcileOnce(ctx)
 }
 
 func (r *Reconciler) nextBackoff(cur time.Duration, err error) time.Duration {

--- a/internal/daemon/reconciler_test.go
+++ b/internal/daemon/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/sqlitestore"
 	"go.kenn.io/kata/internal/embedding"
@@ -29,6 +30,62 @@ func newReconcilerTestStore(t *testing.T) *sqlitestore.Store {
 	}
 	t.Cleanup(func() { _ = d.Close() })
 	return d
+}
+
+func TestReconcilerLeaderRetriesWhenDrainAdmissionReopens(t *testing.T) {
+	retry := make(chan struct{})
+	attempted := make(chan int, 2)
+	released := make(chan struct{})
+	calls := 0
+	store := newReconcilerTestStore(t)
+	r := NewReconciler(
+		store,
+		openTestVectorIndex(t),
+		&fakeEmbedder{model: "m1", dims: 2},
+		ReconcilerConfig{
+			MinBackoff: time.Millisecond,
+			SweepEvery: time.Hour,
+			DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+				calls++
+				attempted <- calls
+				if calls == 1 {
+					return nil, false, retry
+				}
+				return activity.NewLease(func() { close(released) }, nil), true, nil
+			},
+		},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.runLeader(ctx) }()
+
+	select {
+	case attempt := <-attempted:
+		require.Equal(t, 1, attempt)
+	case <-time.After(time.Second):
+		t.Fatal("reconciler did not attempt drain admission")
+	}
+	select {
+	case attempt := <-attempted:
+		t.Fatalf("reconciler retried before admission reopened: attempt %d", attempt)
+	default:
+	}
+
+	close(retry)
+	select {
+	case attempt := <-attempted:
+		require.Equal(t, 2, attempt)
+	case <-time.After(time.Second):
+		t.Fatal("reconciler did not retry after admission reopened")
+	}
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("reconciler did not finish the admitted cycle")
+	}
+	require.NotNil(t, r.Health().LastSuccessAt)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
 }
 
 // openTestVectorIndex opens a fresh vector.Index at a temp path and registers

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -112,6 +113,13 @@ type ServerConfig struct {
 	// authenticates a project-scoped federation enrollment.
 	HostFederationAccess HostFederationAccessController
 
+	// IdleAdmission admits ordinary HTTP requests as foreground daemon work.
+	// Nil disables idle lifecycle handling.
+	IdleAdmission IdleForegroundAdmission
+	// IdleShutdownHealth snapshots effective idle state for /health. Nil omits the
+	// capability, including on explicit or remotely exposed daemons.
+	IdleShutdownHealth func() IdleSnapshot
+
 	// EmbeddingProfile removes native administrative routes when their
 	// lifecycle is owned by a mounting application. The standalone daemon uses
 	// the zero value and retains every route.
@@ -178,7 +186,13 @@ type Server struct {
 	baseHandler http.Handler
 	handler     http.Handler
 	api         huma.API
+
+	shutdownTimeout time.Duration
 }
+
+// ErrHTTPHandlersUnjoined means graceful HTTP shutdown exhausted its deadline
+// while one or more handlers could still be using daemon dependencies.
+var ErrHTTPHandlersUnjoined = errors.New("server: HTTP handlers did not drain")
 
 // ListenerBinding associates an owned listener with its request policy.
 type ListenerBinding struct {
@@ -234,10 +248,8 @@ func NewServer(cfg ServerConfig) *Server {
 	applyErrorEnvelopeResponses(humaAPI.OpenAPI())
 	applyJSONBlobSchemaOverrides(humaAPI.OpenAPI())
 
-	s.baseHandler = withOwnerLocalTransport(withGzip(requireBearer(cfg.authPolicy(), cfg.DB)(
-		withTrustedProxyActor(cfg)(withFederationIngestPreauthorization(cfg, mux)),
-	)))
-	s.handler, _ = ApplyListenerPolicy(s.baseHandler, ListenerPolicy{Kind: ListenerSocket})
+	s.baseHandler = mux
+	s.handler, _ = s.HandlerFor(ListenerPolicy{Kind: ListenerSocket})
 	return s
 }
 
@@ -269,6 +281,13 @@ func (s *Server) HandlerFor(policy ListenerPolicy) (http.Handler, error) {
 	base := s.baseHandler
 	if base == nil {
 		base = s.handler
+	} else {
+		base = withIdleAdmission(s.cfg.IdleAdmission, base)
+		base = withFederationIngestPreauthorization(s.cfg, base)
+		base = withTrustedProxyActor(s.cfg)(base)
+		base = requireBearer(s.cfg.authPolicy(), s.cfg.DB)(base)
+		base = withGzip(base)
+		base = withOwnerLocalTransport(base)
 	}
 	if policy.RequireBrowserSession {
 		if s.cfg.WebSessions == nil {
@@ -276,7 +295,11 @@ func (s *Server) HandlerFor(policy ListenerPolicy) (http.Handler, error) {
 		}
 		base = requireBrowserSession(s.cfg.WebSessions, policy, base)
 	}
-	return ApplyListenerPolicy(base, policy)
+	handler, err := ApplyListenerPolicy(base, policy)
+	if err != nil {
+		return nil, err
+	}
+	return handler, nil
 }
 
 // API returns the underlying huma.API for handler registration in tests.
@@ -329,39 +352,99 @@ func (s *Server) Run(ctx context.Context) error {
 // Useful for tests that bind their own loopback listener (avoiding the
 // listener-close-then-reopen TOCTOU window).
 func (s *Server) Serve(ctx context.Context, l net.Listener) error {
-	return s.serve(ctx, l, s.handler)
+	return s.serve(ctx, l, s.handler, nil)
 }
 
-func (s *Server) serve(ctx context.Context, l net.Listener, handler http.Handler) error {
+func (s *Server) serve(
+	ctx context.Context,
+	l net.Listener,
+	handler http.Handler,
+	onExit func(error),
+) error {
+	serveCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	httpSrv := &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 		// BaseContext roots every request in the daemon ctx so long-lived
 		// SSE handlers exit on Shutdown via r.Context().Done().
-		BaseContext: func(net.Listener) context.Context { return ctx },
+		BaseContext: func(net.Listener) context.Context { return serveCtx },
 	}
+	shutdownDone := make(chan error, 1)
 	go func() {
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		defer cancel()
-		_ = httpSrv.Shutdown(shutdownCtx)
+		<-serveCtx.Done()
+		shutdownCtx, shutdownCancel := context.WithTimeout(
+			context.WithoutCancel(serveCtx), s.httpShutdownTimeout(),
+		)
+		defer shutdownCancel()
+		shutdownDone <- httpSrv.Shutdown(shutdownCtx)
 	}()
-	if err := httpSrv.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		return err
+	serveErr := httpSrv.Serve(l)
+	if errors.Is(serveErr, http.ErrServerClosed) {
+		serveErr = nil
 	}
-	return nil
+	if onExit != nil {
+		onExit(serveErr)
+	}
+	cancel()
+	shutdownErr := <-shutdownDone
+	// A sibling listener or the lifecycle coordinator may close this listener
+	// while Shutdown is doing the same work. The listener is already quiesced;
+	// net.ErrClosed does not mean handlers failed to drain.
+	if errors.Is(shutdownErr, net.ErrClosed) {
+		shutdownErr = nil
+	}
+	if shutdownErr != nil {
+		closeErr := httpSrv.Close()
+		return errors.Join(
+			serveErr,
+			fmt.Errorf("%w: %v", ErrHTTPHandlersUnjoined, shutdownErr),
+			closeErr,
+		)
+	}
+	return serveErr
+}
+
+func (s *Server) httpShutdownTimeout() time.Duration {
+	if s.shutdownTimeout > 0 {
+		return s.shutdownTimeout
+	}
+	return 10 * time.Second
 }
 
 // ServeListeners serves all listener bindings under one lifecycle. A failure
 // on either listener cancels and closes every sibling listener.
 func (s *Server) ServeListeners(ctx context.Context, bindings ...ListenerBinding) error {
+	return s.ServeListenersWithStop(ctx, nil, bindings...)
+}
+
+// ServeListenersWithStop is ServeListeners with an immediate notification
+// when any listener exits. The callback may cancel the daemon root while this
+// method continues joining HTTP handlers.
+func (s *Server) ServeListenersWithStop(
+	ctx context.Context,
+	onStopping func(),
+	bindings ...ListenerBinding,
+) error {
+	return s.ServeListenersWithLifecycle(ctx, nil, onStopping, bindings...)
+}
+
+// ServeListenersWithLifecycle is ServeListenersWithStop with a readiness
+// callback. Readiness is reported only after every listener binding has been
+// validated and its handler has been prepared, immediately before serving.
+func (s *Server) ServeListenersWithLifecycle(
+	ctx context.Context,
+	onReady func() error,
+	onStopping func(),
+	bindings ...ListenerBinding,
+) error {
 	if len(bindings) == 0 {
 		return errors.New("server: at least one listener is required")
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	results := make(chan error, len(bindings))
-	for _, binding := range bindings {
+	handlers := make([]http.Handler, len(bindings))
+	for i, binding := range bindings {
 		if binding.Listener == nil {
 			return errors.New("server: listener is required")
 		}
@@ -369,26 +452,49 @@ func (s *Server) ServeListeners(ctx context.Context, bindings ...ListenerBinding
 		if err != nil {
 			return err
 		}
+		handlers[i] = handler
+	}
+	if onReady != nil {
+		if err := onReady(); err != nil {
+			return err
+		}
+	}
+	var stopOnce sync.Once
+	var firstCause error
+	stopAll := func(cause error) {
+		stopOnce.Do(func() {
+			firstCause = cause
+			if onStopping != nil {
+				onStopping()
+			}
+			cancel()
+			for _, binding := range bindings {
+				_ = binding.Listener.Close()
+			}
+		})
+	}
+	results := make(chan error, len(bindings))
+	for i, binding := range bindings {
+		handler := handlers[i]
 		go func(binding ListenerBinding, handler http.Handler) {
-			results <- s.serve(runCtx, binding.Listener, handler)
+			results <- s.serve(runCtx, binding.Listener, handler, stopAll)
 		}(binding, handler)
 	}
 
-	firstErr := <-results
-	cancel()
-	for _, binding := range bindings {
-		_ = binding.Listener.Close()
-	}
-	for range len(bindings) - 1 {
-		err := <-results
-		if firstErr == nil && err != nil {
-			firstErr = err
+	var serveErrs []error
+	for range len(bindings) {
+		if err := <-results; err != nil {
+			serveErrs = append(serveErrs, err)
 		}
+	}
+	serveErr := errors.Join(serveErrs...)
+	if errors.Is(serveErr, ErrHTTPHandlersUnjoined) || firstCause != nil {
+		return serveErr
 	}
 	if ctx.Err() != nil {
 		return nil
 	}
-	return firstErr
+	return serveErr
 }
 
 // withCSRFGuards rejects browser-borne requests and enforces JSON content type

--- a/internal/daemon/server_lifecycle_test.go
+++ b/internal/daemon/server_lifecycle_test.go
@@ -1,0 +1,232 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeWaitsForActiveHandlerDuringShutdown(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(entered)
+		<-release
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := &Server{handler: handler}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- server.Serve(ctx, listener) }()
+
+	responseDone := make(chan error, 1)
+	go func() {
+		response, err := http.Get("http://" + listener.Addr().String())
+		if err == nil {
+			_ = response.Body.Close()
+		}
+		responseDone <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("request did not enter handler")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		t.Fatalf("Serve returned before active handler completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return after active handler completed")
+	}
+	require.NoError(t, <-responseDone)
+}
+
+type closeErrorListener struct {
+	net.Listener
+}
+
+func (l closeErrorListener) Close() error {
+	_ = l.Listener.Close()
+	return net.ErrClosed
+}
+
+func TestServeTreatsConcurrentListenerCloseAsDrained(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	server := &Server{handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(entered)
+		<-release
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- server.Serve(ctx, closeErrorListener{Listener: listener}) }()
+
+	responseDone := make(chan error, 1)
+	go func() {
+		response, requestErr := http.Get("http://" + listener.Addr().String())
+		if requestErr == nil {
+			_ = response.Body.Close()
+		}
+		responseDone <- requestErr
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("request did not enter handler")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		t.Fatalf("Serve returned before active handler completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not return after context cancellation")
+	}
+	require.NoError(t, <-responseDone)
+}
+
+func TestServeReportsHandlerThatOutlivesShutdownTimeout(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(entered)
+		<-release
+	})
+	server := &Server{handler: handler, shutdownTimeout: 20 * time.Millisecond}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- server.Serve(ctx, listener) }()
+	go func() {
+		response, requestErr := http.Get("http://" + listener.Addr().String())
+		if requestErr == nil {
+			_ = response.Body.Close()
+		}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("request did not enter handler")
+	}
+	cancel()
+	select {
+	case serveErr := <-done:
+		require.ErrorIs(t, serveErr, ErrHTTPHandlersUnjoined)
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not report the unjoined handler")
+	}
+	select {
+	case <-release:
+		t.Fatal("handler release channel unexpectedly closed")
+	default:
+	}
+	close(release)
+}
+
+func TestServeListenersNotifiesAtFirstListenerExitBeforeHandlerDrain(t *testing.T) {
+	first, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	second, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(entered)
+		<-release
+	})
+	server := &Server{handler: handler}
+	stopping := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- server.ServeListenersWithStop(context.Background(), func() {
+			close(stopping)
+		},
+			ListenerBinding{Listener: first, Policy: ListenerPolicy{Kind: ListenerSocket}},
+			ListenerBinding{Listener: second, Policy: ListenerPolicy{Kind: ListenerSocket}},
+		)
+	}()
+	go func() {
+		response, requestErr := http.Get("http://" + second.Addr().String())
+		if requestErr == nil {
+			_ = response.Body.Close()
+		}
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("request did not enter sibling handler")
+	}
+
+	require.NoError(t, first.Close())
+	select {
+	case <-stopping:
+	case <-time.After(time.Second):
+		t.Fatal("listener exit did not notify root shutdown")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("ServeListeners returned before sibling handler drained: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	require.True(t, errors.Is(<-done, net.ErrClosed))
+}
+
+func TestServeListenersDoesNotNotifyReadyBeforeHandlerValidation(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	server := &Server{handler: http.NotFoundHandler()}
+	ready := false
+	err = server.ServeListenersWithLifecycle(
+		context.Background(),
+		func() error {
+			ready = true
+			return nil
+		},
+		nil,
+		ListenerBinding{
+			Listener: listener,
+			Policy: ListenerPolicy{
+				Kind:                  ListenerBrowser,
+				RequireBrowserSession: true,
+			},
+		},
+	)
+
+	require.ErrorContains(t, err, "requires a web session manager")
+	require.False(t, ready)
+}

--- a/internal/federation/config_reconciler.go
+++ b/internal/federation/config_reconciler.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
@@ -72,7 +73,11 @@ type ReconcilerConfig struct {
 	Clock            Clock
 	Wake             func()
 	ProjectEventSink func(db.Event)
-	Logger           *log.Logger
+	// ProjectEventSinkFrom takes precedence over ProjectEventSink when set.
+	// Its fork source is nil when the attempt has no parent activity lease.
+	ProjectEventSinkFrom func(db.Event, activity.Admission)
+	DrainAdmission       activity.WaitableAdmission
+	Logger               *log.Logger
 }
 
 // Health is the sanitized aggregate state of configured federation mappings.
@@ -100,14 +105,16 @@ type reconciliationState struct {
 // Reconciler serially reconciles due mappings while maintaining independent
 // retry state for each mapping.
 type Reconciler struct {
-	store            db.Storage
-	credentials      config.FederationCredentialStore
-	targets          []Target
-	hubFactory       HubFactory
-	clock            Clock
-	wake             func()
-	projectEventSink func(db.Event)
-	logger           *log.Logger
+	store                db.Storage
+	credentials          config.FederationCredentialStore
+	targets              []Target
+	hubFactory           HubFactory
+	clock                Clock
+	wake                 func()
+	projectEventSink     func(db.Event)
+	projectEventSinkFrom func(db.Event, activity.Admission)
+	drainAdmission       activity.WaitableAdmission
+	logger               *log.Logger
 
 	mu     sync.Mutex
 	states []reconciliationState
@@ -122,15 +129,17 @@ func NewReconciler(cfg ReconcilerConfig) *Reconciler {
 	}
 	targets := append([]Target(nil), cfg.Targets...)
 	return &Reconciler{
-		store:            cfg.Store,
-		credentials:      cfg.Credentials,
-		targets:          targets,
-		hubFactory:       cfg.HubFactory,
-		clock:            clock,
-		wake:             cfg.Wake,
-		projectEventSink: cfg.ProjectEventSink,
-		logger:           cfg.Logger,
-		states:           make([]reconciliationState, len(targets)),
+		store:                cfg.Store,
+		credentials:          cfg.Credentials,
+		targets:              targets,
+		hubFactory:           cfg.HubFactory,
+		clock:                clock,
+		wake:                 cfg.Wake,
+		projectEventSink:     cfg.ProjectEventSink,
+		projectEventSinkFrom: cfg.ProjectEventSinkFrom,
+		drainAdmission:       cfg.DrainAdmission,
+		logger:               cfg.Logger,
+		states:               make([]reconciliationState, len(targets)),
 	}
 }
 
@@ -139,6 +148,7 @@ func (r *Reconciler) Run(ctx context.Context) error {
 	for {
 		now := r.clock.Now()
 		attempted := false
+		admissionReopened := false
 		for i := range r.targets {
 			if !r.due(i, now) {
 				continue
@@ -146,14 +156,37 @@ func (r *Reconciler) Run(ctx context.Context) error {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
+			var drain *activity.Lease
+			if r.drainAdmission != nil {
+				var admitted bool
+				var retry <-chan struct{}
+				drain, admitted, retry = r.drainAdmission()
+				if !admitted {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-retry:
+						admissionReopened = true
+					}
+					break
+				}
+			}
 			attempted = true
 			attemptAt := r.clock.Now()
 			r.markAttemptStarted(i, attemptAt)
-			err := r.reconcile(ctx, r.targets[i])
+			err := func() error {
+				if drain != nil {
+					defer drain.Release()
+				}
+				return r.reconcile(ctx, r.targets[i], drain)
+			}()
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return ctxErr
 			}
 			r.recordAttempt(i, attemptAt, err)
+		}
+		if admissionReopened {
+			continue
 		}
 		if attempted {
 			continue
@@ -208,7 +241,7 @@ func (r *Reconciler) Health() Health {
 	return health
 }
 
-func (r *Reconciler) reconcile(ctx context.Context, target Target) error {
+func (r *Reconciler) reconcile(ctx context.Context, target Target, drain *activity.Lease) error {
 	if r.hubFactory == nil {
 		return reconcileError(ErrConfigurationConflict, "missing federation hub factory")
 	}
@@ -216,9 +249,19 @@ func (r *Reconciler) reconcile(ctx context.Context, target Target) error {
 	if err != nil {
 		return err
 	}
+	projectEventSink := r.projectEventSink
+	if r.projectEventSinkFrom != nil {
+		projectEventSink = func(event db.Event) {
+			var fork activity.Admission
+			if drain != nil {
+				fork = drain.Fork
+			}
+			r.projectEventSinkFrom(event, fork)
+		}
+	}
 	return reconcileMapping(
 		ctx, r.store, r.credentials, hub, target.Catalog, target.Mapping, r.wake,
-		r.projectEventSink,
+		projectEventSink,
 	)
 }
 

--- a/internal/federation/config_reconciler_test.go
+++ b/internal/federation/config_reconciler_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
@@ -28,6 +29,65 @@ const (
 	hubProjectUID       = "01HZNQ7VFPK1XGD8R5MABCD4EX"
 	recreatedProjectUID = "01HZNQ7VFPK1XGD8R5MABCD4EY"
 )
+
+func TestConfigReconcilerRetriesWhenDrainAdmissionReopens(t *testing.T) {
+	retry := make(chan struct{})
+	attempted := make(chan int, 2)
+	factoryCalled := make(chan struct{}, 1)
+	released := make(chan struct{})
+	calls := 0
+	reconciler := federation.NewReconciler(federation.ReconcilerConfig{
+		Targets: []federation.Target{{}},
+		HubFactory: func(context.Context, config.CatalogDaemonConfig) (federation.Hub, error) {
+			factoryCalled <- struct{}{}
+			return nil, errors.New("hub unavailable")
+		},
+		DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+			calls++
+			attempted <- calls
+			if calls == 1 {
+				return nil, false, retry
+			}
+			return activity.NewLease(func() { close(released) }, nil), true, nil
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- reconciler.Run(ctx) }()
+
+	select {
+	case attempt := <-attempted:
+		require.Equal(t, 1, attempt)
+	case <-time.After(time.Second):
+		t.Fatal("reconciler did not attempt drain admission")
+	}
+	require.Nil(t, reconciler.Health().LastAttemptAt)
+	select {
+	case <-factoryCalled:
+		t.Fatal("reconciler contacted the hub before drain admission reopened")
+	default:
+	}
+
+	close(retry)
+	select {
+	case attempt := <-attempted:
+		require.Equal(t, 2, attempt)
+	case <-time.After(time.Second):
+		t.Fatal("reconciler did not retry after drain admission reopened")
+	}
+	select {
+	case <-factoryCalled:
+	case <-time.After(time.Second):
+		t.Fatal("reconciler did not attempt work after admission reopened")
+	}
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("reconciler did not release the admitted drain")
+	}
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
 
 type fakeHub struct {
 	mu                sync.Mutex
@@ -2193,9 +2253,12 @@ func TestFederationConfigReconcilerDeliversExactCreatedProjectEvent(t *testing.T
 	type delivery struct {
 		event     db.Event
 		persisted []db.Event
+		forked    bool
 		err       error
 	}
 	events := make(chan delivery, 1)
+	parentReleased := make(chan struct{})
+	childReleased := make(chan struct{})
 	reconciler := federation.NewReconciler(federation.ReconcilerConfig{
 		Store:       store,
 		Credentials: newFakeCredentialStore(),
@@ -2203,11 +2266,20 @@ func TestFederationConfigReconcilerDeliversExactCreatedProjectEvent(t *testing.T
 		HubFactory: func(context.Context, config.CatalogDaemonConfig) (federation.Hub, error) {
 			return newFakeHub(), nil
 		},
-		ProjectEventSink: func(event db.Event) {
+		DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+			return activity.NewLease(func() { close(parentReleased) }, func() (*activity.Lease, bool) {
+				return activity.NewLease(func() { close(childReleased) }, nil), true
+			}), true, nil
+		},
+		ProjectEventSinkFrom: func(event db.Event, fork activity.Admission) {
+			require.NotNil(t, fork)
+			child, admitted := fork()
+			require.True(t, admitted)
+			child.Release()
 			persisted, err := store.EventsAfter(context.Background(), db.EventsAfterParams{
 				ProjectID: event.ProjectID, Limit: 10,
 			})
-			events <- delivery{event: event, persisted: persisted, err: err}
+			events <- delivery{event: event, persisted: persisted, forked: true, err: err}
 		},
 		Logger: ioDiscardLogger(),
 	})
@@ -2225,8 +2297,19 @@ func TestFederationConfigReconcilerDeliversExactCreatedProjectEvent(t *testing.T
 		require.NoError(t, delivered.err)
 		require.Len(t, delivered.persisted, 1)
 		assert.Equal(t, event, delivered.persisted[0])
+		assert.True(t, delivered.forked)
 	case <-time.After(time.Second):
 		t.Fatal("project creation event was not delivered")
+	}
+	select {
+	case <-childReleased:
+	case <-time.After(time.Second):
+		t.Fatal("child hook lease was not released")
+	}
+	select {
+	case <-parentReleased:
+	case <-time.After(time.Second):
+		t.Fatal("parent reconciliation lease was not released")
 	}
 
 	cancel()

--- a/internal/federation/federation_sync.go
+++ b/internal/federation/federation_sync.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/api"
 	clientpkg "go.kenn.io/kata/internal/client"
 	"go.kenn.io/kata/internal/config"
@@ -744,6 +745,11 @@ type Runner struct {
 	Debounce       time.Duration
 	OnError        func(error)
 	OnPulledEvents func(projectID int64, events []db.Event)
+	// OnPulledEventsFrom takes precedence over OnPulledEvents and receives the
+	// fork source for hook jobs caused by this admitted spoke pass. The source
+	// is nil when the pass has no parent activity lease.
+	OnPulledEventsFrom func(projectID int64, events []db.Event, fork activity.Admission)
+	DrainAdmission     activity.WaitableAdmission
 }
 
 type runnerLeaseStore interface {
@@ -774,33 +780,52 @@ type activeSpokeBinding struct {
 // RunOnce executes one pull pass. With no spoke bindings it returns without
 // reading credentials or making network requests.
 func (r *Runner) RunOnce(ctx context.Context) error {
-	return r.runOnce(ctx, nil)
+	_, _, err := r.runOnce(ctx, nil)
+	return err
 }
 
-func (r *Runner) runOnce(ctx context.Context, validateLease func(context.Context) error) error {
-	bindings, err := r.DB.ListFederationBindings(ctx)
-	if err != nil {
-		return err
+func (r *Runner) runOnce(
+	ctx context.Context,
+	validateLease func(context.Context) error,
+) (<-chan struct{}, bool, error) {
+	var scan *activity.Lease
+	if r.DrainAdmission != nil {
+		var admitted bool
+		var retry <-chan struct{}
+		scan, admitted, retry = r.DrainAdmission()
+		if !admitted {
+			return retry, true, nil
+		}
 	}
-	spokes := make([]activeSpokeBinding, 0, len(bindings))
-	for _, binding := range bindings {
-		if !binding.Enabled || binding.Role != db.FederationRoleSpoke {
-			continue
+	spokes, err := func() ([]activeSpokeBinding, error) {
+		if scan != nil {
+			defer scan.Release()
 		}
-		project, err := r.DB.ProjectByID(ctx, binding.ProjectID)
+		bindings, err := r.DB.ListFederationBindings(ctx)
 		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				return err
+			return nil, err
+		}
+		active := make([]activeSpokeBinding, 0, len(bindings))
+		for _, binding := range bindings {
+			if !binding.Enabled || binding.Role != db.FederationRoleSpoke {
+				continue
 			}
-			return err
+			project, err := r.DB.ProjectByID(ctx, binding.ProjectID)
+			if err != nil {
+				return nil, err
+			}
+			if project.DeletedAt != nil {
+				continue
+			}
+			active = append(active, activeSpokeBinding{binding: binding, project: project})
 		}
-		if project.DeletedAt != nil {
-			continue
-		}
-		spokes = append(spokes, activeSpokeBinding{binding: binding, project: project})
+		return active, nil
+	}()
+	if err != nil {
+		return nil, false, err
 	}
 	if len(spokes) == 0 {
-		return nil
+		return nil, false, nil
 	}
 	credentialStore := r.Credentials
 	if credentialStore == nil {
@@ -808,74 +833,92 @@ func (r *Runner) runOnce(ctx context.Context, validateLease func(context.Context
 	}
 	var errs []error
 	for _, spoke := range spokes {
+		var drain *activity.Lease
+		if r.DrainAdmission != nil {
+			var admitted bool
+			var retry <-chan struct{}
+			drain, admitted, retry = r.DrainAdmission()
+			if !admitted {
+				return retry, true, errors.Join(errs...)
+			}
+		}
+		spokeErr := func() error {
+			if drain != nil {
+				defer drain.Release()
+			}
+			return r.runSpoke(ctx, spoke, credentialStore, validateLease, drain)
+		}()
+		if errors.Is(spokeErr, context.Canceled) || errors.Is(spokeErr, errFederationRunnerLeaseInvalid) {
+			return nil, false, spokeErr
+		}
+		if spokeErr != nil {
+			errs = append(errs, spokeErr)
+		}
+	}
+	return nil, false, errors.Join(errs...)
+}
+
+func (r *Runner) runSpoke(
+	ctx context.Context,
+	spoke activeSpokeBinding,
+	credentialStore config.FederationCredentialStore,
+	validateLease func(context.Context) error,
+	drain *activity.Lease,
+) error {
+	if err := validateFederationRunnerLease(ctx, validateLease); err != nil {
+		return err
+	}
+	finishSync, err := federationcoord.BeginSync(ctx,
+		federationcoord.Key(r.DB.InstanceUID(), spoke.binding.ProjectID), r.DB, spoke.binding.ProjectID)
+	if err != nil {
+		return fmt.Errorf("coordinate federation sync: %w", err)
+	}
+	defer finishSync()
+	binding, err := r.DB.FederationBindingByProject(ctx, spoke.binding.ProjectID)
+	if err != nil {
+		return err
+	}
+	if !binding.Enabled || binding.Role != db.FederationRoleSpoke {
+		return nil
+	}
+	cred, _, err := credentialStore.FederationCredential(ctx, spoke.project.UID)
+	if err != nil {
+		return errors.Join(err, r.DB.RecordFederationSyncError(ctx, binding.ProjectID, err, time.Now().UTC()))
+	}
+	cred = config.FederationTransportCredential(
+		binding.HubURL, binding.HubProjectID, binding.AllowInsecure, cred,
+	)
+	opts := r.clientOpts()
+	var errs []error
+	if err := retryPendingClaimsOnceWithFence(ctx, r.DB, binding, cred, opts, validateLease); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, errFederationRunnerLeaseInvalid) {
+			return err
+		}
+		errs = append(errs, err)
+	}
+	onPulledEvents := r.OnPulledEvents
+	if r.OnPulledEventsFrom != nil {
+		onPulledEvents = func(projectID int64, events []db.Event) {
+			var fork activity.Admission
+			if drain != nil {
+				fork = drain.Fork
+			}
+			r.OnPulledEventsFrom(projectID, events, fork)
+		}
+	}
+	if err := syncFederationOnceWithFence(ctx, r.DB, binding, cred, opts, onPulledEvents, validateLease); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, errFederationRunnerLeaseInvalid) {
+			return err
+		}
+		errs = append(errs, err)
+	}
+	if len(errs) == 0 {
 		if err := validateFederationRunnerLease(ctx, validateLease); err != nil {
 			return err
 		}
-		finishSync, coordinationErr := federationcoord.BeginSync(
-			ctx,
-			federationcoord.Key(r.DB.InstanceUID(), spoke.binding.ProjectID),
-			r.DB,
-			spoke.binding.ProjectID,
-		)
-		if coordinationErr != nil {
-			if errors.Is(coordinationErr, context.Canceled) {
-				return coordinationErr
-			}
-			errs = append(errs, fmt.Errorf("coordinate federation sync: %w", coordinationErr))
-			continue
-		}
-		binding, bindingReadErr := r.DB.FederationBindingByProject(ctx, spoke.binding.ProjectID)
-		if bindingReadErr != nil {
-			finishSync()
-			if errors.Is(bindingReadErr, context.Canceled) {
-				return bindingReadErr
-			}
-			errs = append(errs, bindingReadErr)
-			continue
-		}
-		if !binding.Enabled || binding.Role != db.FederationRoleSpoke {
-			finishSync()
-			continue
-		}
-		bindingErrs := len(errs)
-		project := spoke.project
-		cred, _, credentialErr := credentialStore.FederationCredential(ctx, project.UID)
-		if credentialErr != nil {
-			errs = append(errs, credentialErr)
-			if recordErr := r.DB.RecordFederationSyncError(ctx, binding.ProjectID, credentialErr, time.Now().UTC()); recordErr != nil {
-				errs = append(errs, recordErr)
-			}
-			finishSync()
-			continue
-		}
-		cred = config.FederationTransportCredential(
-			binding.HubURL, binding.HubProjectID, binding.AllowInsecure, cred,
-		)
-		opts := r.clientOpts()
-		if err := retryPendingClaimsOnceWithFence(ctx, r.DB, binding, cred, opts, validateLease); err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, errFederationRunnerLeaseInvalid) {
-				finishSync()
-				return err
-			}
+		if err := r.DB.ClearFederationSyncError(ctx, binding.ProjectID); err != nil {
 			errs = append(errs, err)
 		}
-		if err := syncFederationOnceWithFence(ctx, r.DB, binding, cred, opts, r.OnPulledEvents, validateLease); err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, errFederationRunnerLeaseInvalid) {
-				finishSync()
-				return err
-			}
-			errs = append(errs, err)
-		}
-		if len(errs) == bindingErrs {
-			if err := validateFederationRunnerLease(ctx, validateLease); err != nil {
-				finishSync()
-				return err
-			}
-			if err := r.DB.ClearFederationSyncError(ctx, binding.ProjectID); err != nil {
-				errs = append(errs, err)
-			}
-		}
-		finishSync()
 	}
 	return errors.Join(errs...)
 }
@@ -1155,13 +1198,26 @@ func (r *Runner) run(ctx context.Context, validateLease func(context.Context) er
 				return err
 			}
 		}
-		if err := r.runOnce(ctx, validateLease); err != nil {
+		retry, denied, err := r.runOnce(ctx, validateLease)
+		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, errFederationRunnerLeaseInvalid) {
 				return err
 			}
 			if r.OnError != nil {
 				r.OnError(err)
 			}
+		}
+		if denied && retry != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-retry:
+				continue
+			}
+		}
+		if denied {
+			<-ctx.Done()
+			return ctx.Err()
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/api"
 	clientpkg "go.kenn.io/kata/internal/client"
 	"go.kenn.io/kata/internal/config"
@@ -157,6 +158,78 @@ func TestFederationRunnerUsesBindingEndpointWithStaleCredentialMetadata(t *testi
 	require.NoError(t, (&Runner{DB: spoke.DB}).RunOnce(ctx))
 	assert.Zero(t, oldHubRequests.Load(), "sync used the stale credential endpoint")
 	assert.Equal(t, int64(1), targetHubRequests.Load())
+}
+
+func TestFederationRunnerMakesParentDrainAvailableToPulledEventSink(t *testing.T) {
+	ctx := context.Background()
+	hub := testenv.New(t)
+	spoke := testenv.New(t)
+	t.Setenv("KATA_HOME", spoke.Home)
+	hubProject, err := hub.DB.CreateProject(ctx, "hub")
+	require.NoError(t, err)
+	_, _, err = hub.DB.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: hubProject.ID,
+		Title:     "from hub",
+		Author:    "tester",
+	})
+	require.NoError(t, err)
+	var meta api.ProjectFederationBody
+	postJSON(t, hub.URL, "/api/v1/projects/"+strconv.FormatInt(hubProject.ID, 10)+"/federation/enable",
+		map[string]any{"actor": "tester"}, &meta)
+	created, err := hub.DB.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{
+		Token:            "runner-pull-token",
+		SpokeInstanceUID: spoke.DB.InstanceUID(),
+		ProjectID:        &hubProject.ID,
+		Capabilities:     "pull",
+		Actor:            "tester",
+	})
+	require.NoError(t, err)
+	spokeProject, err := spoke.DB.CreateProjectWithUID(ctx, "hub", hubProject.UID)
+	require.NoError(t, err)
+	_, err = spoke.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            spokeProject.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               hub.URL,
+		HubProjectID:         hubProject.ID,
+		HubProjectUID:        hubProject.UID,
+		ReplayHorizonEventID: 1,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, config.WriteFederationCredential(spokeProject.UID, config.FederationCredential{
+		HubURL:       hub.URL,
+		HubProjectID: hubProject.ID,
+		Token:        created.Token,
+	}))
+
+	var acquired atomic.Int32
+	var released atomic.Int32
+	var childReleased atomic.Int32
+	var delivered atomic.Bool
+	runner := &Runner{
+		DB: spoke.DB,
+		DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+			acquired.Add(1)
+			return activity.NewLease(func() { released.Add(1) }, func() (*activity.Lease, bool) {
+				return activity.NewLease(func() { childReleased.Add(1) }, nil), true
+			}), true, nil
+		},
+		OnPulledEventsFrom: func(projectID int64, events []db.Event, fork activity.Admission) {
+			require.Equal(t, spokeProject.ID, projectID)
+			require.NotEmpty(t, events)
+			require.NotNil(t, fork)
+			child, admitted := fork()
+			require.True(t, admitted)
+			child.Release()
+			delivered.Store(true)
+		},
+	}
+
+	require.NoError(t, runner.RunOnce(ctx))
+	assert.True(t, delivered.Load())
+	assert.Equal(t, int32(2), acquired.Load(), "scan and spoke pass should each acquire a lease")
+	assert.Equal(t, acquired.Load(), released.Load())
+	assert.Equal(t, int32(1), childReleased.Load())
 }
 
 func TestSyncFederationOnceDuplicateOnlyPullMaterializesStaleProjection(t *testing.T) {
@@ -3024,6 +3097,110 @@ func TestFederationRunnerNoBindingsMakesNoRequests(t *testing.T) {
 	runner := &Runner{DB: store}
 
 	require.NoError(t, runner.RunOnce(context.Background()))
+}
+
+func TestFederationRunnerSkipsSpokeWhenDrainAdmissionIsClosed(t *testing.T) {
+	runner := &Runner{
+		DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+			return nil, false, nil
+		},
+	}
+
+	// A denied scan must return before touching even a nil store.
+	require.NoError(t, runner.RunOnce(context.Background()))
+}
+
+func TestFederationRunnerRetriesImmediatelyWhenDrainAdmissionReopens(t *testing.T) {
+	store, _ := openDaemonclientTestDB(t)
+	reopened := make(chan struct{})
+	completed := make(chan struct{})
+	var attempts atomic.Int32
+	runner := &Runner{
+		DB:       store,
+		Interval: time.Hour,
+		DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+			if attempts.Add(1) == 1 {
+				return nil, false, reopened
+			}
+			return activity.NewLease(func() { close(completed) }, nil), true, nil
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	require.Eventually(t, func() bool { return attempts.Load() == 1 }, time.Second, time.Millisecond)
+
+	close(reopened)
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("federation scan did not complete after drain admission reopened")
+	}
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestFederationRunnerRetriesWhenSpokeAdmissionReopens(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	spoke := testenv.New(t)
+	project, err := spoke.DB.CreateProject(ctx, "spoke")
+	require.NoError(t, err)
+	_, err = spoke.DB.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            project.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               "http://127.0.0.1:1",
+		HubProjectID:         42,
+		HubProjectUID:        project.UID,
+		ReplayHorizonEventID: 1,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+
+	reopened := make(chan struct{})
+	var attempts atomic.Int32
+	runner := &Runner{
+		DB:       spoke.DB,
+		Interval: time.Hour,
+		DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+			switch attempts.Add(1) {
+			case 1, 3:
+				return activity.NewLease(func() {}, nil), true, nil // scans
+			case 2:
+				return nil, false, reopened // first spoke attempt
+			default:
+				return nil, false, nil // prove retry without making a request
+			}
+		},
+	}
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	require.Eventually(t, func() bool { return attempts.Load() == 2 }, time.Second, time.Millisecond)
+
+	close(reopened)
+	require.Eventually(t, func() bool { return attempts.Load() == 4 }, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestFederationRunnerWaitsForCancellationAfterTerminalDrainDenial(t *testing.T) {
+	var attempts atomic.Int32
+	runner := &Runner{
+		Interval: 5 * time.Millisecond,
+		DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+			attempts.Add(1)
+			return nil, false, nil
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	require.Eventually(t, func() bool { return attempts.Load() >= 1 }, time.Second, time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int32(1), attempts.Load(), "terminal denial must not be polled")
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
 }
 
 func TestFederationRunnerNoBindingsNoNetwork(t *testing.T) {

--- a/internal/githubsync/runner.go
+++ b/internal/githubsync/runner.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/db"
 )
 
@@ -31,15 +32,19 @@ type Runner struct {
 
 // RunnerConfig configures a GitHub sync runner.
 type RunnerConfig struct {
-	Store            db.Storage
-	Fetcher          Fetcher
-	Clock            func() time.Time
-	EventSink        func(context.Context, int64, []db.Event) error
+	Store     db.Storage
+	Fetcher   Fetcher
+	Clock     func() time.Time
+	EventSink func(context.Context, int64, []db.Event) error
+	// EventSinkFrom takes precedence over EventSink when set. Its fork source
+	// is nil when the pass has no parent activity lease.
+	EventSinkFrom    func(context.Context, int64, []db.Event, activity.Admission) error
 	Logger           *slog.Logger
 	Interval         time.Duration
 	Wake             <-chan struct{}
 	StaleLockTTL     time.Duration
 	InitialBatchSize int
+	DrainAdmission   activity.WaitableAdmission
 }
 
 // RunResult summarizes one completed sync attempt.
@@ -68,6 +73,14 @@ func NewRunner(config RunnerConfig) *Runner {
 
 // RunOnce syncs one binding if it can claim the binding lock.
 func (r *Runner) RunOnce(ctx context.Context, bindingID int64) (RunResult, error) {
+	return r.runOnce(ctx, bindingID, nil)
+}
+
+func (r *Runner) runOnce(
+	ctx context.Context,
+	bindingID int64,
+	eventFork activity.Admission,
+) (RunResult, error) {
 	if err := r.validate(); err != nil {
 		return RunResult{}, err
 	}
@@ -80,7 +93,7 @@ func (r *Runner) RunOnce(ctx context.Context, bindingID int64) (RunResult, error
 		return RunResult{Binding: binding}, db.ErrIssueSyncAlreadyRunning
 	}
 
-	result, err := r.runClaimed(ctx, binding, syncStartedAt)
+	result, err := r.runClaimed(ctx, binding, syncStartedAt, eventFork)
 	if err != nil {
 		return result, err
 	}
@@ -88,22 +101,45 @@ func (r *Runner) RunOnce(ctx context.Context, bindingID int64) (RunResult, error
 }
 
 // Run processes currently due bindings serially, then repeats on Interval when
-// configured. With Interval <= 0 it performs one due scan and returns.
+// configured. With Interval <= 0 it performs one admitted due scan and returns;
+// reversible admission denial waits for reopening before that one scan.
 func (r *Runner) Run(ctx context.Context) error {
 	if err := r.validate(); err != nil {
 		return err
 	}
-	if r.config.Interval <= 0 {
-		return r.runDue(ctx)
+	var ticker *time.Ticker
+	if r.config.Interval > 0 {
+		ticker = time.NewTicker(r.config.Interval)
+		defer ticker.Stop()
 	}
-	ticker := time.NewTicker(r.config.Interval)
-	defer ticker.Stop()
 	for {
-		if err := r.runDue(ctx); err != nil {
+		retry, denied, err := r.runDue(ctx)
+		if err != nil {
 			if isContextError(err) {
 				return err
 			}
+			if ticker == nil {
+				return err
+			}
 			r.config.Logger.Warn("github sync due pass failed", "error", err)
+		}
+		if denied && retry != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-retry:
+				continue
+			}
+		}
+		if denied {
+			if ticker == nil {
+				return nil
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		if ticker == nil {
+			return nil
 		}
 		select {
 		case <-ctx.Done():
@@ -114,34 +150,72 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 }
 
-func (r *Runner) runDue(ctx context.Context) error {
+func (r *Runner) runDue(ctx context.Context) (<-chan struct{}, bool, error) {
+	var scan *activity.Lease
+	if r.config.DrainAdmission != nil {
+		var admitted bool
+		var retry <-chan struct{}
+		scan, admitted, retry = r.config.DrainAdmission()
+		if !admitted {
+			return retry, true, nil
+		}
+	}
 	now := r.now()
-	bindings, err := r.config.Store.ListDueIssueSyncBindings(ctx, "github", now, now.Add(-r.staleLockTTL()), runnerDueLimit)
+	bindings, err := func() ([]db.IssueSyncBinding, error) {
+		if scan != nil {
+			defer scan.Release()
+		}
+		return r.config.Store.ListDueIssueSyncBindings(
+			ctx, "github", now, now.Add(-r.staleLockTTL()), runnerDueLimit,
+		)
+	}()
 	if err != nil {
-		return err
+		return nil, false, err
 	}
 	var errs []error
 	for _, binding := range bindings {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, false, ctx.Err()
 		default:
 		}
-		if _, err := r.RunOnce(ctx, binding.ID); err != nil {
+		var drain *activity.Lease
+		if r.config.DrainAdmission != nil {
+			var admitted bool
+			var retry <-chan struct{}
+			drain, admitted, retry = r.config.DrainAdmission()
+			if !admitted {
+				return retry, true, errors.Join(errs...)
+			}
+		}
+		_, runErr := func() (RunResult, error) {
+			if drain != nil {
+				defer drain.Release()
+				return r.runOnce(ctx, binding.ID, drain.Fork)
+			}
+			return r.runOnce(ctx, binding.ID, nil)
+		}()
+		if runErr != nil {
+			err := runErr
 			if errorsIsAlreadyRunning(err) {
 				continue
 			}
 			if isContextError(err) {
-				return err
+				return nil, false, err
 			}
 			r.config.Logger.Warn("github sync binding failed", "binding_id", binding.ID, "error", err)
 			errs = append(errs, err)
 		}
 	}
-	return errors.Join(errs...)
+	return nil, false, errors.Join(errs...)
 }
 
-func (r *Runner) runClaimed(ctx context.Context, binding db.IssueSyncBinding, syncStartedAt time.Time) (RunResult, error) {
+func (r *Runner) runClaimed(
+	ctx context.Context,
+	binding db.IssueSyncBinding,
+	syncStartedAt time.Time,
+	eventFork activity.Admission,
+) (RunResult, error) {
 	if binding.Provider != "github" {
 		err := fmt.Errorf("github sync runner cannot run provider %q", binding.Provider)
 		return r.recordError(ctx, binding, syncStartedAt, err, db.ImportBatchResult{})
@@ -217,7 +291,7 @@ func (r *Runner) runClaimed(ctx context.Context, binding db.IssueSyncBinding, sy
 		Provider:  "github",
 		StartedAt: syncStartedAt,
 	}
-	importResult, err := r.importChunks(ctx, binding, batch)
+	importResult, err := r.importChunks(ctx, binding, batch, eventFork)
 	if err != nil {
 		return r.recordError(ctx, binding, syncStartedAt, err, importResult)
 	}
@@ -440,7 +514,12 @@ func markParentLinkNonAuthoritative(item *db.ImportItem) {
 	item.LinkTypesAuthoritative["parent"] = false
 }
 
-func (r *Runner) importChunks(ctx context.Context, binding db.IssueSyncBinding, batch db.ImportBatchParams) (db.ImportBatchResult, error) {
+func (r *Runner) importChunks(
+	ctx context.Context,
+	binding db.IssueSyncBinding,
+	batch db.ImportBatchParams,
+	eventFork activity.Admission,
+) (db.ImportBatchResult, error) {
 	chunkSize := r.initialBatchSize()
 	aggregate := db.ImportBatchResult{Source: batch.Source, Errors: []string{}}
 	if len(batch.Items) == 0 {
@@ -449,7 +528,7 @@ func (r *Runner) importChunks(ctx context.Context, binding db.IssueSyncBinding, 
 			return aggregate, err
 		}
 		mergeImportResult(&aggregate, res)
-		r.emitEvents(ctx, binding.ProjectID, events)
+		r.emitEvents(ctx, binding.ProjectID, events, eventFork)
 		return aggregate, nil
 	}
 	for start := 0; start < len(batch.Items); start += chunkSize {
@@ -464,16 +543,27 @@ func (r *Runner) importChunks(ctx context.Context, binding db.IssueSyncBinding, 
 			return aggregate, err
 		}
 		mergeImportResult(&aggregate, res)
-		r.emitEvents(ctx, binding.ProjectID, events)
+		r.emitEvents(ctx, binding.ProjectID, events, eventFork)
 	}
 	return aggregate, nil
 }
 
-func (r *Runner) emitEvents(ctx context.Context, projectID int64, events []db.Event) {
-	if r.config.EventSink == nil || len(events) == 0 {
+func (r *Runner) emitEvents(
+	ctx context.Context,
+	projectID int64,
+	events []db.Event,
+	eventFork activity.Admission,
+) {
+	if len(events) == 0 {
 		return
 	}
-	if err := r.config.EventSink(ctx, projectID, events); err != nil {
+	var err error
+	if r.config.EventSinkFrom != nil {
+		err = r.config.EventSinkFrom(ctx, projectID, events, eventFork)
+	} else if r.config.EventSink != nil {
+		err = r.config.EventSink(ctx, projectID, events)
+	}
+	if err != nil {
 		r.config.Logger.Warn("github sync event sink failed", "error", err)
 	}
 }

--- a/internal/githubsync/runner_test.go
+++ b/internal/githubsync/runner_test.go
@@ -7,11 +7,13 @@ import (
 	"log/slog"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/db/sqlitestore"
 )
@@ -854,6 +856,133 @@ func TestRunnerRunAttemptsLaterDueBindingsAfterBindingFailure(t *testing.T) {
 	assert.Contains(t, status.LastError, "github unavailable")
 }
 
+func TestRunnerRunAdmitsEachDueBindingAsFiniteDrainWork(t *testing.T) {
+	var acquired atomic.Int32
+	var released atomic.Int32
+	h := newRunnerHarness(t, withDrainAdmission(func() (*activity.Lease, bool) {
+		acquired.Add(1)
+		return activity.NewLease(func() { released.Add(1) }, nil), true
+	}))
+	h.fetcher.issues = []Issue{testIssue(101, 1, "first issue", h.now.Add(-time.Hour))}
+
+	require.NoError(t, h.runner.Run(h.ctx))
+	require.Equal(t, int32(2), acquired.Load())
+	require.Equal(t, int32(2), released.Load())
+}
+
+func TestRunnerPassMakesParentDrainAvailableToEventSink(t *testing.T) {
+	h := newRunnerHarness(t, withDrainAdmission(func() (*activity.Lease, bool) {
+		return activity.NewLease(func() {}, func() (*activity.Lease, bool) {
+			return activity.NewLease(func() {}, nil), true
+		}), true
+	}))
+	h.fetcher.issues = []Issue{testIssue(101, 1, "first issue", h.now.Add(-time.Hour))}
+	var forked bool
+	h.runner.config.EventSinkFrom = func(
+		_ context.Context, _ int64, _ []db.Event, fork activity.Admission,
+	) error {
+		require.NotNil(t, fork)
+		child, admitted := fork()
+		require.True(t, admitted)
+		child.Release()
+		forked = true
+		return nil
+	}
+
+	require.NoError(t, h.runner.Run(h.ctx))
+	require.True(t, forked)
+}
+
+func TestRunnerRunSkipsDueBindingWhenDrainAdmissionIsClosed(t *testing.T) {
+	var acquired atomic.Int32
+	h := newRunnerHarness(t, withDrainAdmission(func() (*activity.Lease, bool) {
+		acquired.Add(1)
+		return nil, false
+	}))
+
+	require.NoError(t, h.runner.Run(h.ctx))
+	require.Equal(t, int32(1), acquired.Load())
+	require.Zero(t, h.fetcher.repoCallCount())
+}
+
+func TestRunnerRunRetriesImmediatelyWhenDrainAdmissionReopens(t *testing.T) {
+	reopened := make(chan struct{})
+	var attempts atomic.Int32
+	h := newRunnerHarness(t, withWaitableDrainAdmission(func() (*activity.Lease, bool, <-chan struct{}) {
+		if attempts.Add(1) == 1 {
+			return nil, false, reopened
+		}
+		return activity.NewLease(func() {}, nil), true, nil
+	}))
+	h.fetcher.issues = []Issue{testIssue(101, 1, "first issue", h.now.Add(-time.Hour))}
+
+	done := make(chan error, 1)
+	go func() { done <- h.runner.Run(h.ctx) }()
+	require.Eventually(t, func() bool { return attempts.Load() == 1 }, time.Second, time.Millisecond)
+	require.Zero(t, h.fetcher.repoCallCount())
+
+	close(reopened)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("runner did not retry after drain admission reopened")
+	}
+	require.GreaterOrEqual(t, attempts.Load(), int32(3), "retry should admit the scan and due binding")
+	require.Equal(t, 1, h.fetcher.repoCallCount())
+}
+
+func TestRunnerRunRetriesWhenBindingAdmissionReopens(t *testing.T) {
+	reopened := make(chan struct{})
+	var attempts atomic.Int32
+	h := newRunnerHarness(t, withWaitableDrainAdmission(func() (*activity.Lease, bool, <-chan struct{}) {
+		switch attempts.Add(1) {
+		case 1:
+			return activity.NewLease(func() {}, nil), true, nil // first scan
+		case 2:
+			return nil, false, reopened // first binding
+		default:
+			return activity.NewLease(func() {}, nil), true, nil
+		}
+	}))
+	h.fetcher.issues = []Issue{testIssue(101, 1, "first issue", h.now.Add(-time.Hour))}
+
+	done := make(chan error, 1)
+	go func() { done <- h.runner.Run(h.ctx) }()
+	require.Eventually(t, func() bool { return attempts.Load() == 2 }, time.Second, time.Millisecond)
+	require.Zero(t, h.fetcher.repoCallCount())
+
+	close(reopened)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("runner did not retry after binding admission reopened")
+	}
+	require.GreaterOrEqual(t, attempts.Load(), int32(4), "retry should readmit the scan and binding")
+	require.Equal(t, 1, h.fetcher.repoCallCount())
+}
+
+func TestRunnerRunWaitsForCancellationAfterTerminalDrainDenial(t *testing.T) {
+	var attempts atomic.Int32
+	h := newRunnerHarness(t,
+		withInterval(5*time.Millisecond),
+		withWaitableDrainAdmission(func() (*activity.Lease, bool, <-chan struct{}) {
+			attempts.Add(1)
+			return nil, false, nil
+		}),
+	)
+	ctx, cancel := context.WithCancel(h.ctx)
+	done := make(chan error, 1)
+	go func() { done <- h.runner.Run(ctx) }()
+	require.Eventually(t, func() bool { return attempts.Load() >= 1 }, time.Second, time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int32(1), attempts.Load(), "terminal denial must not be polled")
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
 func TestRunnerIntervalModeLogsBindingFailuresAndKeepsRunning(t *testing.T) {
 	h := newRunnerHarness(t, withInterval(time.Hour))
 	secondBinding := h.mustCreateBinding("hub-project", "R_second_repo", "second-repo", 202)
@@ -993,6 +1122,21 @@ func withInterval(interval time.Duration) runnerOption {
 func withWake(wake <-chan struct{}) runnerOption {
 	return func(config *RunnerConfig) {
 		config.Wake = wake
+	}
+}
+
+func withDrainAdmission(admission activity.Admission) runnerOption {
+	return func(config *RunnerConfig) {
+		config.DrainAdmission = func() (*activity.Lease, bool, <-chan struct{}) {
+			lease, admitted := admission()
+			return lease, admitted, nil
+		}
+	}
+}
+
+func withWaitableDrainAdmission(admission activity.WaitableAdmission) runnerOption {
+	return func(config *RunnerConfig) {
+		config.DrainAdmission = admission
 	}
 }
 

--- a/internal/hooks/dispatcher.go
+++ b/internal/hooks/dispatcher.go
@@ -219,10 +219,16 @@ func (d *Dispatcher) enqueue(evt db.Event, acquire AcquireActivity) {
 		}
 		var lease *ActivityLease
 		if acquire != nil {
+			// acquire may decide the daemon is idle and invoke the shutdown
+			// trigger while enqueueMu is read-locked. That trigger must not
+			// call Shutdown synchronously, because Shutdown takes the write
+			// lock; it only seals admission and cancels the root context.
 			var admitted bool
 			lease, admitted = acquire()
 			if !admitted {
 				if !d.producerDrain.Load() {
+					d.dropped.Add(1)
+					d.maybeLogAdmissionDenied()
 					continue
 				}
 				lease = nil
@@ -243,13 +249,23 @@ func (d *Dispatcher) enqueue(evt db.Event, acquire AcquireActivity) {
 }
 
 func (d *Dispatcher) maybeLogQueueFull() {
+	d.maybeLogDrop("hook_queue_full")
+}
+
+func (d *Dispatcher) maybeLogAdmissionDenied() {
+	d.maybeLogDrop("hook_admission_denied")
+}
+
+// maybeLogDrop prints one rate-limited line per QueueFullLogInterval for any
+// reason a matching hook job was not accepted.
+func (d *Dispatcher) maybeLogDrop(reason string) {
 	now := d.deps.Now().UnixNano()
 	last := d.lastFullLog.Load()
 	if now-last < int64(d.cfg.QueueFullLogInterval) {
 		return
 	}
 	if d.lastFullLog.CompareAndSwap(last, now) {
-		d.deps.DaemonLog.Printf("hooks: hook_queue_full (dropped=%d)", d.dropped.Load())
+		d.deps.DaemonLog.Printf("hooks: %s (dropped=%d)", reason, d.dropped.Load())
 	}
 }
 
@@ -284,13 +300,14 @@ func (d *Dispatcher) Reload(loaded LoadedConfig) {
 	d.deps.DaemonLog.Printf("hooks reload ok: %d hook(s) active", len(loaded.Snapshot.Hooks))
 }
 
-// Shutdown seals the queue, drains accepted jobs, and waits for workers up to
-// ctx before closing the runs appender. If ctx expires, it closes done to
-// cancel in-flight work and drops any queue remainder. Later calls share the
-// same `waited` channel
-// so a retry after the first call timed out blocks until completion
-// (or its own ctx expires) — never spuriously returns nil while
-// workers are still running.
+// Shutdown seals the queue, drains accepted jobs, and waits for workers
+// before closing the runs appender. When ctx carries a deadline, in-flight
+// work is cancelled early enough that killTreeWithGrace can finish inside the
+// budget, so a slow hook still yields a clean join. If workers are still
+// running when ctx expires, Shutdown returns an error and leaves the appender
+// open. Later calls share the same `waited` channel so a retry after the first
+// call timed out blocks until completion (or its own ctx expires) — never
+// spuriously returns nil while workers are still running.
 func (d *Dispatcher) Shutdown(ctx context.Context) error {
 	if d.stopped.CompareAndSwap(false, true) {
 		d.enqueueMu.Lock()
@@ -301,20 +318,57 @@ func (d *Dispatcher) Shutdown(ctx context.Context) error {
 			close(d.waited)
 		}()
 	}
+	abort, stopAbort := d.inFlightAbortSignal(ctx)
+	defer stopAbort()
 	select {
 	case <-d.waited:
-		d.releaseQueued()
-		// Close appender once; appender.Close is itself idempotent.
-		_ = d.appender.Close()
-		return nil
+		return d.finishShutdown()
+	case <-abort:
+		d.abortInFlight("deadline approaching")
+		select {
+		case <-d.waited:
+			return d.finishShutdown()
+		case <-ctx.Done():
+		}
 	case <-ctx.Done():
-		d.abortOnce.Do(func() { close(d.done) })
-		d.releaseQueued()
-		d.deps.DaemonLog.Printf("hooks shutdown timed out: %d in-flight", d.inflight.Load())
-		// Drain best-effort: don't close appender — workers may still
-		// be writing. Caller proceeds with daemon shutdown anyway.
-		return fmt.Errorf("hooks shutdown timed out: %w", ctx.Err())
+		d.abortInFlight("budget exhausted")
 	}
+	d.deps.DaemonLog.Printf("hooks shutdown timed out: %d in-flight", d.inflight.Load())
+	// Drain best-effort: don't close appender — workers may still
+	// be writing. Caller proceeds with daemon shutdown anyway.
+	return fmt.Errorf("hooks shutdown timed out: %w", ctx.Err())
+}
+
+// inFlightAbortSignal fires far enough before ctx's deadline that a cancelled
+// hook can be terminated, killed after GraceWindow, and reaped inside the
+// remaining budget. Without a deadline it never fires.
+func (d *Dispatcher) inFlightAbortSignal(ctx context.Context) (<-chan time.Time, func()) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return nil, func() {}
+	}
+	delay := time.Until(deadline) - 2*d.deps.GraceWindow
+	if delay < 0 {
+		delay = 0
+	}
+	timer := time.NewTimer(delay)
+	return timer.C, func() { timer.Stop() }
+}
+
+func (d *Dispatcher) abortInFlight(reason string) {
+	d.abortOnce.Do(func() {
+		close(d.done)
+		d.deps.DaemonLog.Printf("hooks shutdown: cancelling %d in-flight, dropping %d queued (%s)",
+			d.inflight.Load(), len(d.queue), reason)
+	})
+	d.releaseQueued()
+}
+
+func (d *Dispatcher) finishShutdown() error {
+	d.releaseQueued()
+	// Close appender once; appender.Close is itself idempotent.
+	_ = d.appender.Close()
+	return nil
 }
 
 // worker pops one HookJob at a time and runs it. Graceful shutdown closes the

--- a/internal/hooks/dispatcher.go
+++ b/internal/hooks/dispatcher.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/db"
 )
 
@@ -19,6 +20,13 @@ import (
 type Sink interface {
 	Enqueue(evt db.Event)
 }
+
+// ActivityLease retains the dispatcher-facing lease name while sharing the
+// common finite-work contract with other daemon workers.
+type ActivityLease = activity.Lease
+
+// AcquireActivity admits finite dispatcher work.
+type AcquireActivity = activity.Admission
 
 // DispatcherDeps wires the dispatcher to its environment. Resolvers
 // are pluggable so tests can inject deterministic snapshots without
@@ -33,18 +41,23 @@ type DispatcherDeps struct {
 	ProjectResolver func(ctx context.Context, projectID int64) (ProjectSnapshot, error)
 	Now             func() time.Time
 	GraceWindow     time.Duration
+	AcquireDrain    AcquireActivity
+	Environment     []string
 }
 
-// Dispatcher is the live hook runtime. The exported API is
-// Enqueue/Reload/CurrentConfig/Shutdown; unexported state is held
-// by-value (no need for a separate state struct).
+// Dispatcher is the live hook runtime. BeginProducerDrain is a daemon-lifecycle
+// handoff used before Shutdown; unexported state is held by-value (no need for
+// a separate state struct).
 type Dispatcher struct {
 	deps                     DispatcherDeps
 	cfg                      Config
-	queue                    chan HookJob
+	queue                    chan queuedHookJob
 	done                     chan struct{}
 	waited                   chan struct{} // closed when wg.Wait returns; shared by all Shutdown callers
 	stopped                  atomic.Bool
+	producerDrain            atomic.Bool
+	abortOnce                sync.Once
+	enqueueMu                sync.RWMutex
 	wg                       sync.WaitGroup
 	snapshot                 atomic.Pointer[Snapshot]
 	dropped                  atomic.Int64
@@ -59,6 +72,11 @@ type Dispatcher struct {
 	// finishing job's pruner.AddRun never unlinks a peer worker's
 	// in-progress capture.
 	active sync.Map
+}
+
+type queuedHookJob struct {
+	HookJob
+	lease *ActivityLease
 }
 
 // noopSink is the unexported implementation of Sink returned by
@@ -96,7 +114,7 @@ func New(loaded LoadedConfig, deps DispatcherDeps) (*Dispatcher, error) {
 	d := &Dispatcher{
 		deps:      deps,
 		cfg:       loaded.Config,
-		queue:     make(chan HookJob, loaded.Config.QueueCap),
+		queue:     make(chan queuedHookJob, loaded.Config.QueueCap),
 		done:      make(chan struct{}),
 		waited:    make(chan struct{}),
 		appender:  app,
@@ -130,12 +148,58 @@ func applyDispatcherDefaults(deps DispatcherDeps) DispatcherDeps {
 	if deps.DaemonLog == nil {
 		deps.DaemonLog = log.New(os.Stderr, "", log.LstdFlags)
 	}
+	if deps.Environment == nil {
+		deps.Environment = os.Environ()
+	} else {
+		deps.Environment = append([]string(nil), deps.Environment...)
+	}
 	return deps
 }
 
 // Enqueue is the Sink-side fan-out point. Non-blocking by contract: a
 // full queue increments dropped and rate-limit-logs.
 func (d *Dispatcher) Enqueue(evt db.Event) {
+	d.enqueue(evt, d.deps.AcquireDrain)
+}
+
+// EnqueueFrom uses a parent operation's fork source for jobs caused by
+// already-admitted background work. This preserves delivery after the idle
+// deadline blocks unrelated top-level drains.
+func (d *Dispatcher) EnqueueFrom(evt db.Event, acquire AcquireActivity) {
+	d.enqueue(evt, acquire)
+}
+
+// BeginProducerDrain keeps the dispatcher open for handoffs from already
+// admitted producers after daemon-wide idle admission closes. Jobs accepted in
+// this phase need no idle lease because the shutdown coordinator joins the
+// dispatcher explicitly after every producer exits.
+func (d *Dispatcher) BeginProducerDrain() {
+	d.producerDrain.Store(true)
+}
+
+// EnqueueFrom routes an event through a parent activity source when the sink
+// supports it, falling back to the ordinary Sink contract for lightweight
+// test and disabled implementations.
+func EnqueueFrom(sink Sink, evt db.Event, acquire AcquireActivity) {
+	if acquire == nil {
+		sink.Enqueue(evt)
+		return
+	}
+	if aware, ok := sink.(interface {
+		EnqueueFrom(db.Event, AcquireActivity)
+	}); ok {
+		aware.EnqueueFrom(evt, acquire)
+		return
+	}
+	sink.Enqueue(evt)
+}
+
+func (d *Dispatcher) enqueue(evt db.Event, acquire AcquireActivity) {
+	if d.stopped.Load() {
+		return
+	}
+	d.enqueueMu.RLock()
+	defer d.enqueueMu.RUnlock()
 	if d.stopped.Load() {
 		return
 	}
@@ -153,10 +217,25 @@ func (d *Dispatcher) Enqueue(evt db.Event) {
 			return
 		default:
 		}
-		job := HookJob{Event: evt, Hook: h, EnqueuedAt: d.deps.Now()}
+		var lease *ActivityLease
+		if acquire != nil {
+			var admitted bool
+			lease, admitted = acquire()
+			if !admitted {
+				if !d.producerDrain.Load() {
+					continue
+				}
+				lease = nil
+			}
+		}
+		job := queuedHookJob{
+			HookJob: HookJob{Event: evt, Hook: h, EnqueuedAt: d.deps.Now()},
+			lease:   lease,
+		}
 		select {
 		case d.queue <- job:
 		default:
+			releaseActivity(lease)
 			d.dropped.Add(1)
 			d.maybeLogQueueFull()
 		}
@@ -205,15 +284,18 @@ func (d *Dispatcher) Reload(loaded LoadedConfig) {
 	d.deps.DaemonLog.Printf("hooks reload ok: %d hook(s) active", len(loaded.Snapshot.Hooks))
 }
 
-// Shutdown closes the done channel, waits for workers up to ctx, and
-// closes the runs appender. The first call closes d.done and starts
-// the wg.Wait goroutine; later calls share the same `waited` channel
+// Shutdown seals the queue, drains accepted jobs, and waits for workers up to
+// ctx before closing the runs appender. If ctx expires, it closes done to
+// cancel in-flight work and drops any queue remainder. Later calls share the
+// same `waited` channel
 // so a retry after the first call timed out blocks until completion
 // (or its own ctx expires) — never spuriously returns nil while
 // workers are still running.
 func (d *Dispatcher) Shutdown(ctx context.Context) error {
 	if d.stopped.CompareAndSwap(false, true) {
-		close(d.done)
+		d.enqueueMu.Lock()
+		close(d.queue)
+		d.enqueueMu.Unlock()
 		go func() {
 			d.wg.Wait()
 			close(d.waited)
@@ -221,10 +303,13 @@ func (d *Dispatcher) Shutdown(ctx context.Context) error {
 	}
 	select {
 	case <-d.waited:
+		d.releaseQueued()
 		// Close appender once; appender.Close is itself idempotent.
 		_ = d.appender.Close()
 		return nil
 	case <-ctx.Done():
+		d.abortOnce.Do(func() { close(d.done) })
+		d.releaseQueued()
 		d.deps.DaemonLog.Printf("hooks shutdown timed out: %d in-flight", d.inflight.Load())
 		// Drain best-effort: don't close appender — workers may still
 		// be writing. Caller proceeds with daemon shutdown anyway.
@@ -232,11 +317,9 @@ func (d *Dispatcher) Shutdown(ctx context.Context) error {
 	}
 }
 
-// worker pops one HookJob at a time and runs it. The two-phase select
-// pattern (re-check done after pop) ensures that a job sitting in the
-// queue at Shutdown time is not started — Go's select chooses cases
-// uniformly among ready ones, so the post-pop check drops at most one
-// just-popped job per worker.
+// worker pops one HookJob at a time and runs it. Graceful shutdown closes the
+// queue so workers drain every accepted job. Forced shutdown closes done; the
+// post-pop check then drops at most one just-popped job per worker.
 func (d *Dispatcher) worker() {
 	defer d.wg.Done()
 	rd := d.runDeps()
@@ -250,6 +333,7 @@ func (d *Dispatcher) worker() {
 			}
 			select {
 			case <-d.done:
+				releaseActivity(job.lease)
 				return // drop the just-popped job; do not start runJob
 			default:
 			}
@@ -263,7 +347,9 @@ func (d *Dispatcher) worker() {
 // alive and the counters accurate so Shutdown's "in-flight" log
 // doesn't drift, and so the pruner's isActive predicate never strands
 // a stale "still writing" entry.
-func (d *Dispatcher) runOne(rd runDeps, job HookJob) {
+func (d *Dispatcher) runOne(rd runDeps, queued queuedHookJob) {
+	defer releaseActivity(queued.lease)
+	job := queued.HookJob
 	key := groupKey{eventID: job.Event.ID, hookIndex: job.Hook.Index}
 	d.active.Store(key, struct{}{})
 	d.inflight.Add(1)
@@ -279,6 +365,26 @@ func (d *Dispatcher) runOne(rd runDeps, job HookJob) {
 	ctx, cancel := contextFromShutdown(d.done)
 	defer cancel()
 	runJob(ctx, d.done, job, rd)
+}
+
+func releaseActivity(lease *ActivityLease) {
+	if lease != nil {
+		lease.Release()
+	}
+}
+
+func (d *Dispatcher) releaseQueued() {
+	for {
+		select {
+		case job, ok := <-d.queue:
+			if !ok {
+				return
+			}
+			releaseActivity(job.lease)
+		default:
+			return
+		}
+	}
 }
 
 // contextFromShutdown returns a context that is canceled the moment
@@ -305,6 +411,7 @@ func (d *Dispatcher) runDeps() runDeps {
 		DaemonLog:   d.deps.DaemonLog,
 		Now:         d.deps.Now,
 		GraceWindow: d.deps.GraceWindow,
+		Environment: append([]string(nil), d.deps.Environment...),
 		Project:     d.deps.ProjectResolver,
 		Issue:       d.deps.IssueResolver,
 		Comment:     d.deps.CommentResolver,

--- a/internal/hooks/dispatcher_test.go
+++ b/internal/hooks/dispatcher_test.go
@@ -8,9 +8,13 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/db"
 )
 
@@ -38,12 +42,24 @@ func mustNewDispatcher(t *testing.T, hooks []ResolvedHook, cfg Config) (*Dispatc
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_ = d.Shutdown(ctx)
-	})
+	t.Cleanup(func() { cleanupDispatcher(t, d) })
 	return d, logBuf, filepath.Join(root, "hooks", dbHash, "runs.jsonl")
+}
+
+// cleanupDispatcher first allows a graceful drain, then waits for the forced
+// cancellation path to finish before TempDir cleanup removes runs.jsonl. The
+// second wait matters on Windows, where an open appender prevents unlinking.
+func cleanupDispatcher(t *testing.T, d *Dispatcher) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	err := d.Shutdown(ctx)
+	cancel()
+	if err == nil {
+		return
+	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer waitCancel()
+	require.NoError(t, d.Shutdown(waitCtx))
 }
 
 // newTestHook builds a ResolvedHook that runs the hookprobe binary with the
@@ -104,6 +120,79 @@ func TestDispatcher_Enqueue_RoutesToMatchingHooks(t *testing.T) {
 	}
 }
 
+func TestDispatcherEnqueueLeasesEachAcceptedHookJob(t *testing.T) {
+	hookA := newTestHook(t, "*", "exit", "0")
+	hookB := newTestHook(t, "*", "exit", "0")
+	hookB.Index = 1
+	cfg := defaultConfig()
+	cfg.PoolSize = 2
+	cfg.QueueCap = 4
+	d, _, runsPath := mustNewDispatcher(t, []ResolvedHook{hookA, hookB}, cfg)
+	var acquired atomic.Int32
+	var released atomic.Int32
+	d.deps.AcquireDrain = func() (*ActivityLease, bool) {
+		acquired.Add(1)
+		return activity.NewLease(func() { released.Add(1) }, nil), true
+	}
+
+	d.Enqueue(db.Event{ID: 1, Type: "issue.created", ProjectID: 1, ProjectName: "x"})
+	require.True(t, waitForLines(t, runsPath, 2, 5*time.Second))
+	require.Eventually(t, func() bool { return released.Load() == 2 }, time.Second, time.Millisecond)
+	require.Equal(t, int32(2), acquired.Load())
+}
+
+func TestDispatcherEnqueueFromUsesAdmittedParentFork(t *testing.T) {
+	hook := newTestHook(t, "*", "exit", "0")
+	cfg := defaultConfig()
+	cfg.PoolSize = 1
+	cfg.QueueCap = 1
+	d, _, runsPath := mustNewDispatcher(t, []ResolvedHook{hook}, cfg)
+	d.deps.AcquireDrain = func() (*ActivityLease, bool) { return nil, false }
+	var released atomic.Int32
+
+	EnqueueFrom(d, db.Event{ID: 1, Type: "issue.created", ProjectID: 1}, func() (*ActivityLease, bool) {
+		return activity.NewLease(func() { released.Add(1) }, nil), true
+	})
+
+	require.True(t, waitForLines(t, runsPath, 1, 5*time.Second))
+	require.Eventually(t, func() bool { return released.Load() == 1 }, time.Second, time.Millisecond)
+}
+
+func TestDispatcherAttemptsAdmissionForEachMatchingHook(t *testing.T) {
+	hookA := newTestHook(t, "*", "exit", "0")
+	hookB := newTestHook(t, "*", "exit", "0")
+	hookB.Index = 1
+	cfg := defaultConfig()
+	d, _, runsPath := mustNewDispatcher(t, []ResolvedHook{hookA, hookB}, cfg)
+	var attempts atomic.Int32
+	d.deps.AcquireDrain = func() (*ActivityLease, bool) {
+		attempts.Add(1)
+		return nil, false
+	}
+
+	d.Enqueue(db.Event{ID: 1, Type: "issue.created", ProjectID: 1})
+	require.Equal(t, int32(2), attempts.Load())
+	require.Zero(t, countJSONLLines(runsPath))
+}
+
+func TestDispatcherReleasesActivityWhenHookExecutionPanics(t *testing.T) {
+	hook := newTestHook(t, "*", "exit", "0")
+	cfg := defaultConfig()
+	d, _, _ := mustNewDispatcher(t, []ResolvedHook{hook}, cfg)
+	rd := d.runDeps()
+	rd.Alias = func(context.Context, db.Event) (AliasSnapshot, bool, error) {
+		panic("resolver panic")
+	}
+	var released atomic.Int32
+
+	d.runOne(rd, queuedHookJob{
+		HookJob: HookJob{Event: db.Event{ID: 1, Type: "issue.created"}, Hook: hook},
+		lease:   activity.NewLease(func() { released.Add(1) }, nil),
+	})
+
+	require.Equal(t, int32(1), released.Load())
+}
+
 func TestDispatcher_Enqueue_RoutesProjectAndRecurrenceExactAndWildcardHooks(t *testing.T) {
 	projectHook := newTestHook(t, "project.created", "exit", "0")
 	recurrenceHook := newTestHook(t, "recurrence.created", "exit", "0")
@@ -133,11 +222,21 @@ func TestDispatcher_Enqueue_QueueFullDropsAndCounts(t *testing.T) {
 	cfg.QueueCap = 1
 	cfg.QueueFullLogInterval = 10 * time.Millisecond
 	d, _, _ := mustNewDispatcher(t, []ResolvedHook{slow}, cfg)
+	var acquired atomic.Int32
+	var released atomic.Int32
+	d.deps.AcquireDrain = func() (*ActivityLease, bool) {
+		acquired.Add(1)
+		return activity.NewLease(func() { released.Add(1) }, nil), true
+	}
 	enqueueEvents(d, "issue.created", 200, 10)
 	// At least N-2 should drop (1 in queue + 1 in flight + N-2 dropped).
 	if got := d.dropped.Load(); got < 5 {
 		t.Fatalf("dropped=%d, want >=5", got)
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, d.Shutdown(ctx))
+	require.Equal(t, acquired.Load(), released.Load(), "every accepted or dropped job must release its lease")
 }
 
 func TestDispatcher_Enqueue_AfterShutdown_NoOp(t *testing.T) {
@@ -183,12 +282,18 @@ func TestDispatcher_Shutdown_Timeout_ReportsInflight(t *testing.T) {
 	}
 }
 
-func TestDispatcher_Shutdown_DropsQueued(t *testing.T) {
-	hold := newTestHook(t, "*", "sleep", "500ms")
+func TestDispatcher_Shutdown_DrainsQueued(t *testing.T) {
+	hold := newTestHook(t, "*", "sleep", "20ms")
 	cfg := defaultConfig()
 	cfg.PoolSize = 1
-	cfg.QueueCap = 4
+	cfg.QueueCap = 5
 	d, _, runsPath := mustNewDispatcher(t, []ResolvedHook{hold}, cfg)
+	var acquired atomic.Int32
+	var released atomic.Int32
+	d.deps.AcquireDrain = func() (*ActivityLease, bool) {
+		acquired.Add(1)
+		return activity.NewLease(func() { released.Add(1) }, nil), true
+	}
 	enqueueEvents(d, "issue.created", 400, 5)
 	time.Sleep(50 * time.Millisecond) // worker has popped one
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -197,11 +302,27 @@ func TestDispatcher_Shutdown_DropsQueued(t *testing.T) {
 		t.Fatal(err)
 	}
 	lines := countJSONLLines(runsPath)
-	// Only the in-flight job should have produced a line. (4xx all
-	// completing would be > 1.) Allow <=2 to tolerate edge timing.
-	if lines > 2 {
-		t.Fatalf("expected <=2 runs after shutdown, got %d", lines)
-	}
+	require.Equal(t, 5, lines, "graceful shutdown must drain every accepted hook")
+	require.Equal(t, acquired.Load(), released.Load(), "shutdown must release in-flight and queued leases")
+}
+
+func TestDispatcher_ProducerDrainAcceptsHandoffsAfterIdleAdmissionCloses(t *testing.T) {
+	hook := newTestHook(t, "*", "exit", "0")
+	cfg := defaultConfig()
+	d, _, runsPath := mustNewDispatcher(t, []ResolvedHook{hook}, cfg)
+	d.deps.AcquireDrain = func() (*ActivityLease, bool) { return nil, false }
+
+	d.Enqueue(db.Event{ID: 1, Type: "issue.created"})
+	d.BeginProducerDrain()
+	d.Enqueue(db.Event{ID: 2, Type: "issue.created"})
+	d.EnqueueFrom(db.Event{ID: 3, Type: "issue.created"}, func() (*ActivityLease, bool) {
+		return nil, false
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, d.Shutdown(ctx))
+	require.Equal(t, 2, countJSONLLines(runsPath))
 }
 
 func TestDispatcher_Reload_AtomicWithEnqueue(t *testing.T) {
@@ -258,6 +379,7 @@ func TestDispatcher_AliasResolverContext_CancelsOnShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { cleanupDispatcher(t, d) })
 
 	enqueueEvents(d, "issue.created", 500, 1)
 	// Wait briefly for the worker to invoke the resolver.
@@ -286,6 +408,9 @@ func TestDispatcher_AliasResolverContext_CancelsOnShutdown(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("alias resolver context did not cancel after Shutdown")
 	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer waitCancel()
+	require.NoError(t, d.Shutdown(waitCtx))
 }
 
 func waitForLines(t *testing.T, path string, n int, timeout time.Duration) bool {

--- a/internal/hooks/dispatcher_test.go
+++ b/internal/hooks/dispatcher_test.go
@@ -163,7 +163,7 @@ func TestDispatcherAttemptsAdmissionForEachMatchingHook(t *testing.T) {
 	hookB := newTestHook(t, "*", "exit", "0")
 	hookB.Index = 1
 	cfg := defaultConfig()
-	d, _, runsPath := mustNewDispatcher(t, []ResolvedHook{hookA, hookB}, cfg)
+	d, logBuf, runsPath := mustNewDispatcher(t, []ResolvedHook{hookA, hookB}, cfg)
 	var attempts atomic.Int32
 	d.deps.AcquireDrain = func() (*ActivityLease, bool) {
 		attempts.Add(1)
@@ -173,6 +173,8 @@ func TestDispatcherAttemptsAdmissionForEachMatchingHook(t *testing.T) {
 	d.Enqueue(db.Event{ID: 1, Type: "issue.created", ProjectID: 1})
 	require.Equal(t, int32(2), attempts.Load())
 	require.Zero(t, countJSONLLines(runsPath))
+	require.Equal(t, int64(2), d.dropped.Load(), "denied admission must count as a dropped job")
+	require.Contains(t, logBuf.String(), "hook_admission_denied")
 }
 
 func TestDispatcherReleasesActivityWhenHookExecutionPanics(t *testing.T) {
@@ -304,6 +306,30 @@ func TestDispatcher_Shutdown_DrainsQueued(t *testing.T) {
 	lines := countJSONLLines(runsPath)
 	require.Equal(t, 5, lines, "graceful shutdown must drain every accepted hook")
 	require.Equal(t, acquired.Load(), released.Load(), "shutdown must release in-flight and queued leases")
+}
+
+func TestDispatcher_Shutdown_CancelsInFlightBeforeDeadlineAndJoins(t *testing.T) {
+	slow := newTestHook(t, "*", "sleep", "10s")
+	slow.Timeout = 10 * time.Second
+	cfg := defaultConfig()
+	cfg.PoolSize = 1
+	cfg.QueueCap = 4
+	d, _, runsPath := mustNewDispatcher(t, []ResolvedHook{slow}, cfg)
+	enqueueEvents(d, "issue.created", 500, 1)
+	waitForInflight(t, d, 1, 5*time.Second)
+
+	const budget = 600 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+	started := time.Now()
+	err := d.Shutdown(ctx)
+	elapsed := time.Since(started)
+
+	require.NoError(t, err, "in-flight hook must be cancelled inside the budget so workers join cleanly")
+	require.Less(t, elapsed, budget, "shutdown must finish before the budget expires")
+	data, readErr := os.ReadFile(runsPath) //nolint:gosec // G304: test-controlled path under t.TempDir()
+	require.NoError(t, readErr)
+	require.Contains(t, string(data), `"result":"daemon_shutdown"`)
 }
 
 func TestDispatcher_ProducerDrainAcceptsHandoffsAfterIdleAdmissionCloses(t *testing.T) {

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -45,6 +45,7 @@ type runDeps struct {
 	DaemonLog   *log.Logger
 	Now         func() time.Time
 	GraceWindow time.Duration
+	Environment []string
 	Project     projectResolver
 	Issue       issueResolver
 	Comment     commentResolver
@@ -283,7 +284,11 @@ func runJob(ctx context.Context, shutdown <-chan struct{}, job HookJob, deps run
 
 	cmd := exec.Command(job.Hook.Command, job.Hook.Args...) //nolint:gosec // G204: command validated at config load
 	cmd.Dir = job.Hook.WorkingDir
-	cmd.Env = buildEnv(job.Hook.UserEnv, job.Event, asnap, useAlias)
+	baseEnv := deps.Environment
+	if baseEnv == nil {
+		baseEnv = os.Environ()
+	}
+	cmd.Env = buildEnv(baseEnv, job.Hook.UserEnv, job.Event, asnap, useAlias)
 	cmd.Stdin = bytes.NewReader(stdinPayload)
 	cmd.Stdout = rc.outFile
 	cmd.Stderr = rc.errFile
@@ -309,12 +314,12 @@ func exitCodeOf(err error) int {
 	return -1
 }
 
-// buildEnv composes the child process's environment from os.Environ ⊕
+// buildEnv composes the child process's environment from baseEnv ⊕
 // the hook's user-defined env ⊕ the KATA_* contract vars. Alias-related
 // env is fed by the caller (runJob) which resolved it once for both
 // the stdin payload and this env slice.
-func buildEnv(userEnv []string, evt db.Event, asnap AliasSnapshot, hasAlias bool) []string {
-	env := append([]string{}, os.Environ()...)
+func buildEnv(baseEnv, userEnv []string, evt db.Event, asnap AliasSnapshot, hasAlias bool) []string {
+	env := append([]string{}, baseEnv...)
 	env = append(env, userEnv...)
 	env = append(env,
 		"KATA_HOOK_VERSION=1",

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -307,9 +307,6 @@ func TestBuildEnvUsesTheConfiguredDaemonChildEnvironment(t *testing.T) {
 			t.Fatalf("environment missing %q: %v", want, env)
 		}
 	}
-	if strings.Contains(joined, "KATA_AUTOSTART=1") {
-		t.Fatalf("environment retained internal auto-start marker: %v", env)
-	}
 }
 
 func TestRunner_EnvUserOverridable_NotForKata(t *testing.T) {

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -292,6 +292,26 @@ func TestRunner_EnvKataVars(t *testing.T) {
 	}
 }
 
+func TestBuildEnvUsesTheConfiguredDaemonChildEnvironment(t *testing.T) {
+	env := buildEnv(
+		[]string{"PATH=/example/bin", "KATA_HOME=/example/home"},
+		nil,
+		db.Event{ID: 1, Type: "issue.created"},
+		AliasSnapshot{},
+		false,
+	)
+
+	joined := strings.Join(env, "\n")
+	for _, want := range []string{"PATH=/example/bin", "KATA_HOME=/example/home"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("environment missing %q: %v", want, env)
+		}
+	}
+	if strings.Contains(joined, "KATA_AUTOSTART=1") {
+		t.Fatalf("environment retained internal auto-start marker: %v", env)
+	}
+}
+
 func TestRunner_EnvUserOverridable_NotForKata(t *testing.T) {
 	rs := newRunnerSetup(t)
 	got := rs.runProbe(func(h *ResolvedHook) {

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -82,6 +82,25 @@ func (c CreateLinkRequestBodyType) Validate() error {
 	}
 }
 
+type IdleShutdownHealthState string
+
+const (
+	Armed      IdleShutdownHealthState = "armed"
+	Blocked    IdleShutdownHealthState = "blocked"
+	Foreground IdleShutdownHealthState = "foreground"
+	Stopping   IdleShutdownHealthState = "stopping"
+)
+
+// Validate checks if the IdleShutdownHealthState value is valid
+func (i IdleShutdownHealthState) Validate() error {
+	switch i {
+	case Armed, Blocked, Foreground, Stopping:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid IdleShutdownHealthState value, got: %v", i))
+	}
+}
+
 type ImportIssueInputClosedReason string
 
 const (

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -1299,6 +1299,7 @@ type HealthResponseBody struct {
 	DBPath           string                  `json:"db_path" validate:"required"`
 	Embeddings       *EmbeddingsHealth       `json:"embeddings,omitempty"`
 	FederationConfig *FederationConfigHealth `json:"federation_config,omitempty"`
+	IdleShutdown     *IdleShutdownHealth     `json:"idle_shutdown,omitempty"`
 	Ok               bool                    `json:"ok"`
 	SchemaVersion    int64                   `json:"schema_version"`
 	StartedAt        time.Time               `json:"started_at" validate:"required"`
@@ -1325,6 +1326,13 @@ func (h HealthResponseBody) Validate() error {
 			}
 		}
 	}
+	if h.IdleShutdown != nil {
+		if v, ok := any(h.IdleShutdown).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("IdleShutdown", err)
+			}
+		}
+	}
 	if err := typesValidator.Var(h.StartedAt, "required"); err != nil {
 		errors = errors.Append("StartedAt", err)
 	}
@@ -1333,6 +1341,28 @@ func (h HealthResponseBody) Validate() error {
 	}
 	if err := typesValidator.Var(h.Version, "required"); err != nil {
 		errors = errors.Append("Version", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type IdleShutdownHealth struct {
+	Deadline *time.Time              `json:"deadline,omitempty"`
+	State    IdleShutdownHealthState `json:"state" validate:"required"`
+	Timeout  string                  `json:"timeout" validate:"required"`
+}
+
+func (i IdleShutdownHealth) Validate() error {
+	var errors runtime.ValidationErrors
+	if v, ok := any(i.State).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("State", err)
+		}
+	}
+	if err := typesValidator.Var(i.Timeout, "required"); err != nil {
+		errors = errors.Append("Timeout", err)
 	}
 	if len(errors) == 0 {
 		return nil

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -1381,6 +1381,8 @@ components:
           $ref: "#/components/schemas/EmbeddingsHealth"
         federation_config:
           $ref: "#/components/schemas/FederationConfigHealth"
+        idle_shutdown:
+          $ref: "#/components/schemas/IdleShutdownHealth"
         ok:
           type: boolean
         schema_version:
@@ -1400,6 +1402,24 @@ components:
         - version
         - uptime
         - started_at
+      type: object
+    IdleShutdownHealth:
+      properties:
+        deadline:
+          format: date-time
+          type: string
+        state:
+          enum:
+            - armed
+            - foreground
+            - blocked
+            - stopping
+          type: string
+        timeout:
+          type: string
+      required:
+        - timeout
+        - state
       type: object
     ImportBatchResult:
       properties:
@@ -4021,7 +4041,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.11.0
+  version: 0.12.0
 openapi: 3.0.3
 paths:
   /api/v1/audit/closes:

--- a/web/src/lib/api/schema.d.ts
+++ b/web/src/lib/api/schema.d.ts
@@ -1944,6 +1944,7 @@ export interface components {
       db_path: string
       embeddings?: components['schemas']['EmbeddingsHealth']
       federation_config?: components['schemas']['FederationConfigHealth']
+      idle_shutdown?: components['schemas']['IdleShutdownHealth']
       ok: boolean
       /** Format: int64 */
       schema_version: number
@@ -1951,6 +1952,15 @@ export interface components {
       started_at: string
       uptime: string
       version: string
+    } & {
+      [key: string]: unknown
+    }
+    IdleShutdownHealth: {
+      /** Format: date-time */
+      deadline?: string
+      /** @enum {string} */
+      state: 'armed' | 'foreground' | 'blocked' | 'stopping'
+      timeout: string
     } & {
       [key: string]: unknown
     }


### PR DESCRIPTION
## Summary

Add opt-in idle shutdown for implicitly started, owner-local daemons.

`autostart_idle_timeout` and `KATA_AUTOSTART_IDLE_TIMEOUT` configure the timeout, with a minimum of 10 seconds. The feature is disabled by default and does not affect explicit daemon starts, remote daemons, public listeners, trusted-proxy deployments, or other shared configurations.

This is intended for short-lived CLI and agent sessions where automatic startup is useful, but leaving the daemon resident indefinitely is unnecessary.

## Behavior

- Foreground requests suspend the idle timer and receive a complete new interval when the final request finishes.
- Already-admitted hooks, synchronization passes, reconciliation work, and claim sweeps may drain without extending the foreground deadline.
- Health, ping, and instance probes remain observational and do not renew the timeout. A SIGHUP hook reload does not renew it either.
- Expiration waits for active finite work, while denying unrelated new background work. A hook job refused by idle admission is counted and logged as dropped.
- Foreground activity can safely revive an expiration blocked by drain work without leaving schedulers stuck.
- Scheduled durable work resumes the next time a client starts the daemon.
- An idle exit writes one `kata daemon: idle shutdown after ...` line to the daemon log.
- `kata daemon start` against a running auto-started daemon that advertises `idle_shutdown` stops it and starts an explicit replacement (reported as `replaced` with `replaced_pid`), so an explicit start always yields a resident daemon. A resident daemon is still reported as `already_running`. `kata daemon restart` always produces an explicit daemon.

The effective capability is advertised through the optional `idle_shutdown` health response. `kata mcp serve` uses that daemon-reported state to send marked keepalives for the lifetime of both stdio and streamable-HTTP MCP servers.

## Safety

Idle expiration, explicit stop, listener failure, parent cancellation, and platform stop events converge on one bounded shutdown coordinator. HTTP handlers, background workers, hook jobs, and platform event pumps drain before their dependencies close.

Daemon stop now drains accepted hook jobs instead of dropping them. The dispatcher cancels in-flight hooks two grace windows before the shutdown deadline so a hook slower than the budget is terminated, killed, and reaped while a clean exit is still possible. If work still cannot join within the shutdown budget, the dedicated process exits without closing database or vector resources underneath still-running work. Restart allows additional time for final cleanup and observable process exit.

Continuous GitHub synchronization, federation, timed-claim maintenance, embeddings, or hook processing should continue to use an explicitly managed daemon.

The change includes generated API clients, browser schema updates, operator documentation, and a durable design note.
