### PR TITLE
Restrict TUI close bypass to local transports

### DIFF
--- a/cmd/kata/close_reopen_test.go
+++ b/cmd/kata/close_reopen_test.go
@@ -289,11 +289,11 @@ func TestCloseCmd_ErrorTextNamesAlternative(t *testing.T) {
 	assert.Contains(t, stderr, "needs-review")
 }
 
-// TestCloseAPI_TUISourceBypassesSubstanceAndEvidence pins that a
-// close posted with source="tui" succeeds without --message or
-// --evidence, so the interactive close keystroke isn't broken by the
-// CLI substance/evidence gate. Posts directly to the daemon endpoint
-// to mirror the wire shape internal/tui/client.Close uses.
+// TestCloseAPI_TUISourceBypassesSubstanceAndEvidence pins that an
+// owner-local close posted with source="tui" succeeds without --message
+// or --evidence, so the interactive close keystroke isn't broken by the
+// CLI substance/evidence gate. Posts directly to the loopback daemon
+// endpoint to mirror the wire shape internal/tui/client.Close uses.
 func TestCloseAPI_TUISourceBypassesSubstanceAndEvidence(t *testing.T) {
 	env, _, pid, ref := setupWorkspaceWithIssue(t, "issue one")
 	body, err := json.Marshal(map[string]any{

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-19
+last_edited: 2026-08-20
 ---
 
 # Configuration
@@ -472,10 +472,10 @@ resolved window.
 Normal CLI and API close paths still run the parent-completeness refusal,
 message-substance checks, and evidence checks. The TUI close path skips the
 message-substance and evidence checks only when the daemon accepts the request
-over an owner-local Unix socket or direct loopback TCP connection, because an
-interactive human confirms each close. Users of a non-loopback TUI must close
-through the normal evidence-bearing CLI or API flow. Structural guards still
-apply to every transport.
+over an owner-local Unix socket or direct loopback TCP connection with no
+forwarding headers, because an interactive human confirms each close. Users of
+a forwarded or non-loopback TUI must close through the normal evidence-bearing
+CLI or API flow. Structural guards still apply to every transport.
 
 ## Semantic search
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-19
+---
+
 # Configuration
 
 kata configuration is split between environment variables, committed workspace
@@ -467,8 +471,11 @@ resolved window.
 
 Normal CLI and API close paths still run the parent-completeness refusal,
 message-substance checks, and evidence checks. The TUI close path skips the
-message-substance and evidence checks because an interactive human confirms each
-close; the structural guards still apply.
+message-substance and evidence checks only when the daemon accepts the request
+over an owner-local Unix socket or direct loopback TCP connection, because an
+interactive human confirms each close. Users of a non-loopback TUI must close
+through the normal evidence-bearing CLI or API flow. Structural guards still
+apply to every transport.
 
 ## Semantic search
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -808,9 +808,10 @@ type ActionRequest struct {
 		// Source signals the caller's UI surface. "tui" relaxes the
 		// substance / evidence validation so an interactive human close
 		// is one keystroke, but only over an owner-local Unix socket or
-		// direct loopback TCP connection. Non-loopback TCP and
-		// identity-backed, trusted-proxy, or browser principals get full
-		// validation even when they send source="tui". Structural guards
+		// direct, unforwarded loopback TCP connection. Forwarded TCP,
+		// non-loopback TCP, and identity-backed, trusted-proxy, or browser
+		// principals get full validation even when they send source="tui".
+		// Structural guards
 		// (parent-close, sibling throttle) always apply. Empty string means
 		// "agent / CLI" and gets full validation.
 		Source   string     `json:"source,omitempty" enum:"tui,"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -807,11 +807,12 @@ type ActionRequest struct {
 		Message string `json:"message,omitempty"`
 		// Source signals the caller's UI surface. "tui" relaxes the
 		// substance / evidence validation so an interactive human close
-		// is one keystroke. Structural guards (parent-close, sibling
-		// throttle) still apply. Empty string means "agent / CLI" and
-		// gets the full validation. In token identity mode the daemon
-		// only honors this bypass when the request actor matches the
-		// authenticated token actor; otherwise full validation applies.
+		// is one keystroke, but only over an owner-local Unix socket or
+		// direct loopback TCP connection. Non-loopback TCP and
+		// identity-backed, trusted-proxy, or browser principals get full
+		// validation even when they send source="tui". Structural guards
+		// (parent-close, sibling throttle) always apply. Empty string means
+		// "agent / CLI" and gets full validation.
 		Source   string     `json:"source,omitempty" enum:"tui,"`
 		Evidence []Evidence `json:"evidence,omitempty"`
 		DryRun   bool       `json:"dry_run,omitempty"`

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -12,6 +14,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/testenv"
 )
@@ -23,6 +27,42 @@ type throttledEventRecord struct {
 	Actor        string          `json:"actor"`
 	IssueShortID *string         `json:"issue_short_id"`
 	Payload      json.RawMessage `json:"payload"`
+}
+
+func TestCloseIssue_NonLoopbackStaticTokenCannotForgeTUIBypass(t *testing.T) {
+	d := openTestDB(t)
+	project, err := d.db.CreateProject(context.Background(), "example-workspace")
+	require.NoError(t, err)
+	issue, _, err := d.db.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "close me",
+		Author:    "setup",
+	})
+	require.NoError(t, err)
+
+	server := daemon.NewServer(daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+		Auth:      config.AuthConfig{Token: "static-token"},
+	})
+	t.Cleanup(func() { _ = server.Close() })
+
+	request := httptest.NewRequest(http.MethodPost,
+		issuePathRef(project.ID, issue.ShortID, "actions/close"),
+		strings.NewReader(`{"actor":"agent","source":"tui","reason":"done"}`))
+	request.Header.Set("Authorization", "Bearer static-token")
+	request.Header.Set("Content-Type", "application/json")
+	request = request.WithContext(context.WithValue(request.Context(),
+		http.LocalAddrContextKey,
+		net.Addr(&net.TCPAddr{IP: net.ParseIP("100.64.0.5"), Port: 7777})))
+	response := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(response, request)
+
+	assertAPIError(t, response.Code, response.Body.Bytes(), http.StatusBadRequest, "validation")
+	got, err := d.db.IssueByID(context.Background(), issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "open", got.Status)
 }
 
 func TestCloseIssue_IdentityModeDoesNotTrustBodySourceTUI(t *testing.T) {

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -52,6 +52,7 @@ func TestCloseIssue_NonLoopbackStaticTokenCannotForgeTUIBypass(t *testing.T) {
 		strings.NewReader(`{"actor":"agent","source":"tui","reason":"done"}`))
 	request.Header.Set("Authorization", "Bearer static-token")
 	request.Header.Set("Content-Type", "application/json")
+	request.RemoteAddr = "127.0.0.1:40123"
 	request = request.WithContext(context.WithValue(request.Context(),
 		http.LocalAddrContextKey,
 		net.Addr(&net.TCPAddr{IP: net.ParseIP("100.64.0.5"), Port: 7777})))
@@ -125,6 +126,7 @@ func TestCloseIssue_LoopbackStaticTokenPreservesTUIBypass(t *testing.T) {
 		strings.NewReader(`{"actor":"agent","source":"tui","reason":"done"}`))
 	request.Header.Set("Authorization", "Bearer static-token")
 	request.Header.Set("Content-Type", "application/json")
+	request.RemoteAddr = "127.0.0.1:40123"
 	request = request.WithContext(context.WithValue(request.Context(),
 		http.LocalAddrContextKey,
 		net.Addr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7777})))
@@ -136,6 +138,44 @@ func TestCloseIssue_LoopbackStaticTokenPreservesTUIBypass(t *testing.T) {
 	got, err := d.db.IssueByID(context.Background(), issue.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "closed", got.Status)
+}
+
+func TestCloseIssue_ForwardedLoopbackStaticTokenCannotForgeTUIBypass(t *testing.T) {
+	d := openTestDB(t)
+	project, err := d.db.CreateProject(context.Background(), "example-workspace")
+	require.NoError(t, err)
+	issue, _, err := d.db.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "close me",
+		Author:    "setup",
+	})
+	require.NoError(t, err)
+
+	server := daemon.NewServer(daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+		Auth:      config.AuthConfig{Token: "static-token"},
+	})
+	t.Cleanup(func() { _ = server.Close() })
+
+	request := httptest.NewRequest(http.MethodPost,
+		issuePathRef(project.ID, issue.ShortID, "actions/close"),
+		strings.NewReader(`{"actor":"agent","source":"tui","reason":"done"}`))
+	request.Header.Set("Authorization", "Bearer static-token")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Forwarded-For", "192.0.2.10")
+	request.RemoteAddr = "127.0.0.1:40123"
+	request = request.WithContext(context.WithValue(request.Context(),
+		http.LocalAddrContextKey,
+		net.Addr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7777})))
+	response := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(response, request)
+
+	assertAPIError(t, response.Code, response.Body.Bytes(), http.StatusBadRequest, "validation")
+	got, err := d.db.IssueByID(context.Background(), issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "open", got.Status)
 }
 
 func TestCloseIssue_IdentityModeDoesNotTrustBodySourceTUI(t *testing.T) {

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -65,6 +65,79 @@ func TestCloseIssue_NonLoopbackStaticTokenCannotForgeTUIBypass(t *testing.T) {
 	assert.Equal(t, "open", got.Status)
 }
 
+func TestCloseIssue_NonLoopbackUnauthenticatedWritesCannotForgeTUIBypass(t *testing.T) {
+	d := openTestDB(t)
+	project, err := d.db.CreateProject(context.Background(), "example-workspace")
+	require.NoError(t, err)
+	issue, _, err := d.db.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "close me",
+		Author:    "setup",
+	})
+	require.NoError(t, err)
+
+	server := daemon.NewServer(daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+		Auth: config.AuthConfig{
+			AllowUnauthenticatedPrivateNetworkWrites: true,
+		},
+	})
+	t.Cleanup(func() { _ = server.Close() })
+
+	request := httptest.NewRequest(http.MethodPost,
+		issuePathRef(project.ID, issue.ShortID, "actions/close"),
+		strings.NewReader(`{"actor":"agent","source":"tui","reason":"done"}`))
+	request.Header.Set("Content-Type", "application/json")
+	request = request.WithContext(context.WithValue(request.Context(),
+		http.LocalAddrContextKey,
+		net.Addr(&net.TCPAddr{IP: net.ParseIP("100.64.0.5"), Port: 7777})))
+	response := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(response, request)
+
+	assertAPIError(t, response.Code, response.Body.Bytes(), http.StatusBadRequest, "validation")
+	got, err := d.db.IssueByID(context.Background(), issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "open", got.Status)
+}
+
+func TestCloseIssue_LoopbackStaticTokenPreservesTUIBypass(t *testing.T) {
+	d := openTestDB(t)
+	project, err := d.db.CreateProject(context.Background(), "example-workspace")
+	require.NoError(t, err)
+	issue, _, err := d.db.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "close me",
+		Author:    "setup",
+	})
+	require.NoError(t, err)
+
+	server := daemon.NewServer(daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+		Auth:      config.AuthConfig{Token: "static-token"},
+	})
+	t.Cleanup(func() { _ = server.Close() })
+
+	request := httptest.NewRequest(http.MethodPost,
+		issuePathRef(project.ID, issue.ShortID, "actions/close"),
+		strings.NewReader(`{"actor":"agent","source":"tui","reason":"done"}`))
+	request.Header.Set("Authorization", "Bearer static-token")
+	request.Header.Set("Content-Type", "application/json")
+	request = request.WithContext(context.WithValue(request.Context(),
+		http.LocalAddrContextKey,
+		net.Addr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7777})))
+	response := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	got, err := d.db.IssueByID(context.Background(), issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "closed", got.Status)
+}
+
 func TestCloseIssue_IdentityModeDoesNotTrustBodySourceTUI(t *testing.T) {
 	env := testenv.New(t, testenv.WithAuthToken("bootstrap-token"), testenv.WithRequireTokenIdentity())
 	pid := mkProject(t, env, "github.com/test/a", "a")

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -140,6 +140,57 @@ func TestCloseIssue_LoopbackStaticTokenPreservesTUIBypass(t *testing.T) {
 	assert.Equal(t, "closed", got.Status)
 }
 
+func TestCloseIssue_StaticTokenBrowserSessionCannotForgeTUIBypass(t *testing.T) {
+	d := openTestDB(t)
+	project, err := d.db.CreateProject(context.Background(), "example-workspace")
+	require.NoError(t, err)
+	issue, _, err := d.db.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "close me",
+		Author:    "setup",
+	})
+	require.NoError(t, err)
+
+	manager, err := daemon.NewWebSessionManager(daemon.WebSessionManagerConfig{
+		Origin: "http://127.0.0.1:27123", InstanceID: "instance_a",
+		Writable: true, Updates: "sse", Auth: config.AuthConfig{Token: "static-token"}, DB: d.db,
+	})
+	require.NoError(t, err)
+	issued, err := manager.IssueSession(daemon.Principal{Kind: daemon.PrincipalStaticToken}, "/kata")
+	require.NoError(t, err)
+	server := daemon.NewServer(daemon.ServerConfig{
+		DB: d.db, StartedAt: d.now, WebSessions: manager,
+		Auth: config.AuthConfig{Token: "static-token"},
+	})
+	t.Cleanup(func() { _ = server.Close() })
+	handler, err := server.HandlerFor(daemon.ListenerPolicy{
+		Kind: daemon.ListenerBrowser, Origin: "http://127.0.0.1:27123", RequireBrowserSession: true,
+	})
+	require.NoError(t, err)
+
+	request := httptest.NewRequest(http.MethodPost,
+		"http://127.0.0.1:27123"+issuePathRef(project.ID, issue.ShortID, "actions/close"),
+		strings.NewReader(`{"actor":"forged","source":"tui","reason":"done"}`))
+	request.Host = "127.0.0.1:27123"
+	request.RemoteAddr = "127.0.0.1:40123"
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Origin", "http://127.0.0.1:27123")
+	request.Header.Set("X-Kata-Web-Session", issued.Session)
+	request.Header.Set("X-Kata-CSRF", issued.CSRF)
+	request.AddCookie(manager.Cookie(issued.Cookie))
+	request = request.WithContext(context.WithValue(request.Context(),
+		http.LocalAddrContextKey,
+		net.Addr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 27123})))
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	assertAPIError(t, response.Code, response.Body.Bytes(), http.StatusBadRequest, "validation")
+	got, err := d.db.IssueByID(context.Background(), issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "open", got.Status)
+}
+
 func TestCloseIssue_HostPrincipalCannotForgeTUIBypass(t *testing.T) {
 	d := openTestDB(t)
 	project, err := d.db.CreateProject(context.Background(), "example-workspace")

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -140,6 +140,44 @@ func TestCloseIssue_LoopbackStaticTokenPreservesTUIBypass(t *testing.T) {
 	assert.Equal(t, "closed", got.Status)
 }
 
+func TestCloseIssue_HostPrincipalCannotForgeTUIBypass(t *testing.T) {
+	d := openTestDB(t)
+	project, err := d.db.CreateProject(context.Background(), "example-workspace")
+	require.NoError(t, err)
+	issue, _, err := d.db.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "close me",
+		Author:    "setup",
+	})
+	require.NoError(t, err)
+
+	server := daemon.NewServer(daemon.ServerConfig{
+		DB:        d.db,
+		StartedAt: d.now,
+	})
+	t.Cleanup(func() { _ = server.Close() })
+
+	request := httptest.NewRequest(http.MethodPost,
+		issuePathRef(project.ID, issue.ShortID, "actions/close"),
+		strings.NewReader(`{"actor":"forged","source":"tui","reason":"done"}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.RemoteAddr = "127.0.0.1:40123"
+	request = request.WithContext(daemon.WithPrincipal(request.Context(), daemon.Principal{
+		Kind: daemon.PrincipalHost, Subject: "mounted-service", Actor: "host-actor",
+	}))
+	request = request.WithContext(context.WithValue(request.Context(),
+		http.LocalAddrContextKey,
+		net.Addr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7777})))
+	response := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(response, request)
+
+	assertAPIError(t, response.Code, response.Body.Bytes(), http.StatusBadRequest, "validation")
+	got, err := d.db.IssueByID(context.Background(), issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "open", got.Status)
+}
+
 func TestCloseIssue_MultiValueForwardedLoopbackCannotForgeTUIBypass(t *testing.T) {
 	d := openTestDB(t)
 	project, err := d.db.CreateProject(context.Background(), "example-workspace")

--- a/internal/daemon/close_guards_test.go
+++ b/internal/daemon/close_guards_test.go
@@ -140,7 +140,7 @@ func TestCloseIssue_LoopbackStaticTokenPreservesTUIBypass(t *testing.T) {
 	assert.Equal(t, "closed", got.Status)
 }
 
-func TestCloseIssue_ForwardedLoopbackStaticTokenCannotForgeTUIBypass(t *testing.T) {
+func TestCloseIssue_MultiValueForwardedLoopbackCannotForgeTUIBypass(t *testing.T) {
 	d := openTestDB(t)
 	project, err := d.db.CreateProject(context.Background(), "example-workspace")
 	require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestCloseIssue_ForwardedLoopbackStaticTokenCannotForgeTUIBypass(t *testing.
 		strings.NewReader(`{"actor":"agent","source":"tui","reason":"done"}`))
 	request.Header.Set("Authorization", "Bearer static-token")
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("X-Forwarded-For", "192.0.2.10")
+	request.Header["X-Forwarded-For"] = []string{"", "192.0.2.10"}
 	request.RemoteAddr = "127.0.0.1:40123"
 	request = request.WithContext(context.WithValue(request.Context(),
 		http.LocalAddrContextKey,

--- a/internal/daemon/handlers_actions.go
+++ b/internal/daemon/handlers_actions.go
@@ -26,11 +26,12 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
-		// TUI closes bypass substance / evidence validation: the
-		// interactive human path is "press x to close" and a 40-char
-		// rationale prompt would just annoy the user. Structural
-		// guards (parent-close, throttle, repeated-message) still
-		// apply, so the audit trail still gates lazy parent-closes
+		// Owner-local TUI closes bypass substance / evidence validation:
+		// the interactive human path is "press x to close" and a 40-char
+		// rationale prompt would just annoy the user. Non-loopback TCP
+		// callers cannot assert this exception through the request body.
+		// Structural guards (parent-close, throttle, repeated-message)
+		// still apply, so the audit trail still gates lazy parent-closes
 		// and reviewers can spot the no-evidence rows.
 		//
 		// Reason defaulting is handled here, at the handler boundary,

--- a/internal/daemon/handlers_actions.go
+++ b/internal/daemon/handlers_actions.go
@@ -28,8 +28,9 @@ func registerActionsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		}
 		// Owner-local TUI closes bypass substance / evidence validation:
 		// the interactive human path is "press x to close" and a 40-char
-		// rationale prompt would just annoy the user. Non-loopback TCP
-		// callers cannot assert this exception through the request body.
+		// rationale prompt would just annoy the user. Forwarded and
+		// non-loopback TCP callers cannot assert this exception through
+		// the request body.
 		// Structural guards (parent-close, throttle, repeated-message)
 		// still apply, so the audit trail still gates lazy parent-closes
 		// and reviewers can spot the no-evidence rows.

--- a/internal/daemon/handlers_ui_daemons.go
+++ b/internal/daemon/handlers_ui_daemons.go
@@ -159,6 +159,9 @@ func (g *webDaemonGateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if rejected {
 		return
 	}
+	if rejectWebDaemonTUIClose(w, r) {
+		return
+	}
 	if isMutation(r.Method) && !readOnlyProjectRequest && !policy.writable {
 		writeWebDaemonError(w, http.StatusForbidden, "read_only")
 		return
@@ -211,6 +214,33 @@ func (g *webDaemonGateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Header.Del("Accept-Encoding")
 	}
 	proxy.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), webDaemonSourcePolicyKey{}, policy)))
+}
+
+func rejectWebDaemonTUIClose(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/actions/close") || r.Body == nil {
+		return false
+	}
+	const maxCloseRequest = 1 << 20
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCloseRequest+1))
+	if err != nil {
+		writeWebDaemonError(w, http.StatusBadRequest, "invalid_close_request")
+		return true
+	}
+	_ = r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	if len(body) > maxCloseRequest {
+		writeWebDaemonError(w, http.StatusRequestEntityTooLarge, "close_request_too_large")
+		return true
+	}
+	var input struct {
+		Source string `json:"source"`
+	}
+	if json.Unmarshal(body, &input) == nil && input.Source == "tui" {
+		writeWebDaemonError(w, http.StatusForbidden, "web_daemon_operation_forbidden")
+		return true
+	}
+	return false
 }
 
 func classifyWebDaemonProjectRequest(w http.ResponseWriter, r *http.Request) (readOnly, rejected bool) {

--- a/internal/daemon/handlers_ui_daemons.go
+++ b/internal/daemon/handlers_ui_daemons.go
@@ -235,8 +235,10 @@ func rejectWebDaemonTUIClose(w http.ResponseWriter, r *http.Request) bool {
 	}
 	var input struct {
 		Source string `json:"source"`
+		Reason string `json:"reason"`
 	}
-	if json.Unmarshal(body, &input) == nil && input.Source == "tui" {
+	if json.Unmarshal(body, &input) == nil && input.Source == "tui" &&
+		(input.Reason == "" || input.Reason == "done") {
 		writeWebDaemonError(w, http.StatusForbidden, "web_daemon_operation_forbidden")
 		return true
 	}

--- a/internal/daemon/handlers_ui_daemons_authorization_test.go
+++ b/internal/daemon/handlers_ui_daemons_authorization_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/api"
 	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/db"
 )
 
 func TestWebDaemonGatewayAppliesWebLocalProjectPolicyBeforeForwarding(t *testing.T) {
@@ -216,6 +218,52 @@ func TestWebDaemonGatewayChecksTargetAuthorityBeforeMutation(t *testing.T) {
 			assert.Equal(t, test.wantMutation, mutationCalls)
 		})
 	}
+}
+
+func TestWebDaemonGatewayCannotProxyTUIBypassToLoopbackTarget(t *testing.T) {
+	targetStore := openAuthTestDB(t)
+	project, err := targetStore.CreateProject(t.Context(), "example-workspace")
+	require.NoError(t, err)
+	issue, _, err := targetStore.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID,
+		Title:     "close me",
+		Author:    "setup",
+	})
+	require.NoError(t, err)
+	targetDaemon := NewServer(ServerConfig{
+		DB: targetStore, StartedAt: time.Now().UTC(),
+		Auth: config.AuthConfig{Token: "target-token"},
+	})
+	t.Cleanup(func() { _ = targetDaemon.Close() })
+	target := httptest.NewServer(targetDaemon.Handler())
+	t.Cleanup(target.Close)
+
+	handler, manager := newAuthorizedWebDaemonGateway(t, false, true, config.CatalogDaemonConfig{
+		Name: "example-remote", URL: target.URL, Token: "target-token", AllowInsecure: true,
+	})
+	issued, err := manager.IssueSession(Principal{Kind: PrincipalWebLocal}, "/kata")
+	require.NoError(t, err)
+	body := bytes.NewBufferString(`{"actor":"forged","source":"tui","reason":"done"}`)
+	request := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("http://127.0.0.1:27123/api/v1/ui/proxy/api/v1/projects/%d/issues/%s/actions/close",
+			project.ID, issue.ShortID), body)
+	request.Host = "127.0.0.1:27123"
+	request.RemoteAddr = "127.0.0.1:40123"
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set(webDaemonHeaderName, "example-remote")
+	request.Header.Set(webSessionHeader, issued.Session)
+	request.Header.Set(webCSRFHeader, issued.CSRF)
+	request.Header.Set("Origin", "http://127.0.0.1:27123")
+	request.AddCookie(manager.Cookie(issued.Cookie))
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusForbidden, response.Code, response.Body.String())
+	assert.Contains(t, response.Body.String(), "web_daemon_operation_forbidden")
+	got, err := targetStore.IssueByID(t.Context(), issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "open", got.Status)
 }
 
 func TestWebDaemonGatewayBoundsTargetAuthorityCheck(t *testing.T) {

--- a/internal/daemon/handlers_ui_daemons_authorization_test.go
+++ b/internal/daemon/handlers_ui_daemons_authorization_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -264,6 +265,65 @@ func TestWebDaemonGatewayCannotProxyTUIBypassToLoopbackTarget(t *testing.T) {
 	got, err := targetStore.IssueByID(t.Context(), issue.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "open", got.Status)
+}
+
+func TestWebDaemonGatewayForwardsNonBypassCloseBodiesUnchanged(t *testing.T) {
+	var forwardedBodies []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/instance" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"web_ui_contract_version": api.UISnapshotContractVersion,
+				"web_ui_capabilities": api.UICapabilities{
+					Writable: true, Updates: "poll", ActorPolicy: "request",
+				},
+			})
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		forwardedBodies = append(forwardedBodies, string(body))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler, manager := newAuthorizedWebDaemonGateway(t, false, true, config.CatalogDaemonConfig{
+		Name: "example-remote", URL: upstream.URL, Token: "target-token", AllowInsecure: true,
+	})
+	issued, err := manager.IssueSession(Principal{Kind: PrincipalWebLocal}, "/kata")
+	require.NoError(t, err)
+	bodies := []string{
+		`{"actor":"agent","reason":"done","message":"A substantive close message that remains intact."}`,
+		`{"actor":"agent","source":"tui","reason":"wontfix","message":"A valid non-bypass TUI close remains intact."}`,
+	}
+	for _, body := range bodies {
+		response := authorizedGatewayRequest(t, handler, manager, issued, http.MethodPost,
+			"/api/v1/projects/7/issues/abcd/actions/close", strings.NewReader(body), "")
+		assert.Equal(t, http.StatusNoContent, response.Code, response.Body.String())
+	}
+	assert.Equal(t, bodies, forwardedBodies)
+}
+
+func TestWebDaemonGatewayRejectsOversizedCloseBeforeContactingTarget(t *testing.T) {
+	var targetCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetCalls++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(upstream.Close)
+
+	handler, manager := newAuthorizedWebDaemonGateway(t, false, true, config.CatalogDaemonConfig{
+		Name: "example-remote", URL: upstream.URL, Token: "target-token", AllowInsecure: true,
+	})
+	issued, err := manager.IssueSession(Principal{Kind: PrincipalWebLocal}, "/kata")
+	require.NoError(t, err)
+	body := `{"message":"` + strings.Repeat("x", (1<<20)+1) + `"}`
+	response := authorizedGatewayRequest(t, handler, manager, issued, http.MethodPost,
+		"/api/v1/projects/7/issues/abcd/actions/close", strings.NewReader(body), "")
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, response.Code, response.Body.String())
+	assert.Contains(t, response.Body.String(), "close_request_too_large")
+	assert.Equal(t, 0, targetCalls)
 }
 
 func TestWebDaemonGatewayBoundsTargetAuthorityCheck(t *testing.T) {
@@ -578,6 +638,9 @@ func authorizedGatewayRequest(
 	request.Header.Set(webCSRFHeader, issued.CSRF)
 	request.Header.Set("Origin", "http://127.0.0.1:27123")
 	request.Header.Set("If-None-Match", ifNoneMatch)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
 	request.AddCookie(manager.Cookie(issued.Cookie))
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -138,7 +138,7 @@ func tuiBypassAllowed(ctx context.Context, source, reason string) bool {
 	}
 	if p, ok := PrincipalFromContext(ctx); ok {
 		switch p.Kind {
-		case PrincipalDBToken, PrincipalTrustedProxy, PrincipalTrustedProxyAbsent, PrincipalWebLocal:
+		case PrincipalDBToken, PrincipalTrustedProxy, PrincipalTrustedProxyAbsent, PrincipalHost, PrincipalWebLocal:
 			return false
 		}
 	}

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -130,6 +130,8 @@ func tokenAdminAuditActor(ctx context.Context, fallback string) string {
 	return fallback
 }
 
+type ownerLocalTransportContextKey struct{}
+
 func tuiBypassAllowed(ctx context.Context, source, reason string) bool {
 	if source != "tui" || reason != "done" {
 		return false
@@ -143,14 +145,26 @@ func tuiBypassAllowed(ctx context.Context, source, reason string) bool {
 	return ownerLocalTransport(ctx)
 }
 
-// ownerLocalTransport recognizes the daemon transports that stay inside the
-// owner-local host boundary. net/http supplies LocalAddrContextKey from the
-// accepted listener, so a request body or forwarding header cannot claim this
-// state. Loopback TCP remains local for Windows, where the default daemon
-// transport is not a Unix socket. Missing and unknown address types fail
-// closed.
-func ownerLocalTransport(ctx context.Context) bool {
-	addr, ok := ctx.Value(http.LocalAddrContextKey).(net.Addr)
+// withOwnerLocalTransport derives the local TUI trust fact from the accepted
+// listener and the live HTTP request before Huma projects the request onto a
+// context.Context handler.
+func withOwnerLocalTransport(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), ownerLocalTransportContextKey{}, ownerLocalRequest(r))
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ownerLocalRequest recognizes daemon requests that stay inside the
+// owner-local host boundary. Unix sockets are owner-local by construction.
+// Loopback TCP additionally requires a direct loopback peer and no forwarding
+// headers, preserving the Windows TUI while excluding reverse-proxy requests.
+// Missing and unknown address types fail closed.
+func ownerLocalRequest(r *http.Request) bool {
+	if requestHasForwardingHeaders(r) {
+		return false
+	}
+	addr, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr)
 	if !ok || addr == nil {
 		return false
 	}
@@ -158,10 +172,15 @@ func ownerLocalTransport(ctx context.Context) bool {
 	case *net.UnixAddr:
 		return true
 	case *net.TCPAddr:
-		return local.IP.IsLoopback()
+		return local.IP.IsLoopback() && requestPeerIsLoopback(r)
 	default:
 		return false
 	}
+}
+
+func ownerLocalTransport(ctx context.Context) bool {
+	trusted, _ := ctx.Value(ownerLocalTransportContextKey{}).(bool)
+	return trusted
 }
 
 func principalFromAPIToken(tok db.APIToken) Principal {

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"context"
+	"net"
+	"net/http"
 	"strings"
 
 	"go.kenn.io/kata/internal/api"
@@ -138,7 +140,28 @@ func tuiBypassAllowed(ctx context.Context, source, reason string) bool {
 			return false
 		}
 	}
-	return true
+	return ownerLocalTransport(ctx)
+}
+
+// ownerLocalTransport recognizes the daemon transports that stay inside the
+// owner-local host boundary. net/http supplies LocalAddrContextKey from the
+// accepted listener, so a request body or forwarding header cannot claim this
+// state. Loopback TCP remains local for Windows, where the default daemon
+// transport is not a Unix socket. Missing and unknown address types fail
+// closed.
+func ownerLocalTransport(ctx context.Context) bool {
+	addr, ok := ctx.Value(http.LocalAddrContextKey).(net.Addr)
+	if !ok || addr == nil {
+		return false
+	}
+	switch local := addr.(type) {
+	case *net.UnixAddr:
+		return true
+	case *net.TCPAddr:
+		return local.IP.IsLoopback()
+	default:
+		return false
+	}
 }
 
 func principalFromAPIToken(tok db.APIToken) Principal {

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -136,6 +136,9 @@ func tuiBypassAllowed(ctx context.Context, source, reason string) bool {
 	if source != "tui" || reason != "done" {
 		return false
 	}
+	if webSessionAuthenticated(ctx) {
+		return false
+	}
 	if p, ok := PrincipalFromContext(ctx); ok {
 		switch p.Kind {
 		case PrincipalDBToken, PrincipalTrustedProxy, PrincipalTrustedProxyAbsent, PrincipalHost, PrincipalWebLocal:

--- a/internal/daemon/identity_test.go
+++ b/internal/daemon/identity_test.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"context"
+	"net"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,4 +85,42 @@ func TestPrincipalWebLocalAllowsOrdinaryWritesButNotTokenAdministration(t *testi
 	require.ErrorAs(t, err, &apiErr)
 	assert.Equal(t, 403, apiErr.Status)
 	assert.Equal(t, "token_admin_forbidden", apiErr.Code)
+}
+
+func TestTUIBypassAllowed_RequiresOwnerLocalTransport(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.Addr
+		want bool
+	}{
+		{
+			name: "unix socket",
+			addr: &net.UnixAddr{Name: "/run/user/1000/kata.sock", Net: "unix"},
+			want: true,
+		},
+		{
+			name: "loopback TCP",
+			addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7777},
+			want: true,
+		},
+		{
+			name: "private network TCP",
+			addr: &net.TCPAddr{IP: net.ParseIP("100.64.0.5"), Port: 7777},
+			want: false,
+		},
+		{
+			name: "missing transport metadata",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.addr != nil {
+				ctx = context.WithValue(ctx, http.LocalAddrContextKey, tt.addr)
+			}
+			assert.Equal(t, tt.want, tuiBypassAllowed(ctx, "tui", "done"))
+		})
+	}
 }

--- a/internal/daemon/identity_test.go
+++ b/internal/daemon/identity_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,9 +90,11 @@ func TestPrincipalWebLocalAllowsOrdinaryWritesButNotTokenAdministration(t *testi
 
 func TestTUIBypassAllowed_RequiresOwnerLocalTransport(t *testing.T) {
 	tests := []struct {
-		name string
-		addr net.Addr
-		want bool
+		name       string
+		addr       net.Addr
+		remoteAddr string
+		headers    map[string]string
+		want       bool
 	}{
 		{
 			name: "unix socket",
@@ -99,9 +102,29 @@ func TestTUIBypassAllowed_RequiresOwnerLocalTransport(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "loopback TCP",
-			addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7777},
-			want: true,
+			name:    "forwarded unix socket",
+			addr:    &net.UnixAddr{Name: "/run/user/1000/kata.sock", Net: "unix"},
+			headers: map[string]string{"Forwarded": "for=192.0.2.10"},
+			want:    false,
+		},
+		{
+			name:       "direct loopback TCP",
+			addr:       &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7777},
+			remoteAddr: "127.0.0.1:40123",
+			want:       true,
+		},
+		{
+			name:       "non-loopback peer on loopback TCP",
+			addr:       &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7777},
+			remoteAddr: "192.0.2.10:40123",
+			want:       false,
+		},
+		{
+			name:       "forwarded loopback TCP",
+			addr:       &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7777},
+			remoteAddr: "127.0.0.1:40123",
+			headers:    map[string]string{"X-Forwarded-For": "192.0.2.10"},
+			want:       false,
 		},
 		{
 			name: "private network TCP",
@@ -116,11 +139,21 @@ func TestTUIBypassAllowed_RequiresOwnerLocalTransport(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			request := httptest.NewRequest(http.MethodPost, "/api/v1/actions/close", nil)
+			request.RemoteAddr = tt.remoteAddr
 			if tt.addr != nil {
-				ctx = context.WithValue(ctx, http.LocalAddrContextKey, tt.addr)
+				request = request.WithContext(context.WithValue(request.Context(), http.LocalAddrContextKey, tt.addr))
 			}
-			assert.Equal(t, tt.want, tuiBypassAllowed(ctx, "tui", "done"))
+			for name, value := range tt.headers {
+				request.Header.Set(name, value)
+			}
+
+			var got bool
+			withOwnerLocalTransport(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				got = tuiBypassAllowed(r.Context(), "tui", "done")
+			})).ServeHTTP(httptest.NewRecorder(), request)
+
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/daemon/listener_policy.go
+++ b/internal/daemon/listener_policy.go
@@ -120,7 +120,7 @@ func directLoopbackSessionAllowed(r *http.Request, policy ListenerPolicy) bool {
 
 func requestHasForwardingHeaders(r *http.Request) bool {
 	for _, header := range []string{"Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "X-Real-IP"} {
-		if r.Header.Get(header) != "" {
+		if _, present := r.Header[http.CanonicalHeaderKey(header)]; present {
 			return true
 		}
 	}

--- a/internal/daemon/listener_policy.go
+++ b/internal/daemon/listener_policy.go
@@ -115,11 +115,19 @@ func directLoopbackSessionAllowed(r *http.Request, policy ListenerPolicy) bool {
 	if !policy.AllowLocalSession {
 		return false
 	}
+	return !requestHasForwardingHeaders(r) && requestPeerIsLoopback(r)
+}
+
+func requestHasForwardingHeaders(r *http.Request) bool {
 	for _, header := range []string{"Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "X-Real-IP"} {
 		if r.Header.Get(header) != "" {
-			return false
+			return true
 		}
 	}
+	return false
+}
+
+func requestPeerIsLoopback(r *http.Request) bool {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return false

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -234,9 +234,9 @@ func NewServer(cfg ServerConfig) *Server {
 	applyErrorEnvelopeResponses(humaAPI.OpenAPI())
 	applyJSONBlobSchemaOverrides(humaAPI.OpenAPI())
 
-	s.baseHandler = withGzip(requireBearer(cfg.authPolicy(), cfg.DB)(
+	s.baseHandler = withOwnerLocalTransport(withGzip(requireBearer(cfg.authPolicy(), cfg.DB)(
 		withTrustedProxyActor(cfg)(withFederationIngestPreauthorization(cfg, mux)),
-	))
+	)))
 	s.handler, _ = ApplyListenerPolicy(s.baseHandler, ListenerPolicy{Kind: ListenerSocket})
 	return s
 }

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -121,9 +121,9 @@ func (c *Client) CreateIssue(
 
 // Close transitions the issue to status=closed. source=tui asks an
 // owner-local daemon to skip the substance and evidence checks that gate
-// CLI-side closes; non-loopback daemons reject that exemption. The structural
-// guards (parent-close completeness, sibling throttle, repeated-message)
-// still apply.
+// CLI-side closes; forwarded and non-loopback requests reject that exemption.
+// The structural guards (parent-close completeness, sibling throttle,
+// repeated-message) still apply.
 func (c *Client) Close(
 	ctx context.Context, projectID int64, ref, actor string,
 ) (*MutationResp, error) {

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -119,10 +119,11 @@ func (c *Client) CreateIssue(
 	return &resp, nil
 }
 
-// Close transitions the issue to status=closed. source=tui signals the
-// daemon to skip the substance and evidence checks that gate CLI-side
-// closes; the structural guards (parent-close completeness, sibling
-// throttle, repeated-message) still apply.
+// Close transitions the issue to status=closed. source=tui asks an
+// owner-local daemon to skip the substance and evidence checks that gate
+// CLI-side closes; non-loopback daemons reject that exemption. The structural
+// guards (parent-close completeness, sibling throttle, repeated-message)
+// still apply.
 func (c *Client) Close(
 	ctx context.Context, projectID int64, ref, actor string,
 ) (*MutationResp, error) {


### PR DESCRIPTION
## What changed

- honor the `source: "tui"` close-policy exception only on owner-local Unix sockets and direct, unforwarded loopback TCP
- preserve one-key local TUI closes and the existing identity-token, trusted-proxy, and browser-principal validation boundaries
- require normal close messages and typed evidence from forwarded or non-loopback TCP callers, including static-token and explicitly writable private-network deployments
- add policy and handler regression coverage and document the transport boundary
- no database schema or migration change

## Why

`source` is a caller-controlled request field. A remote HTTP client could claim `source: "tui"` and skip the close substance and evidence gate even though it was not an interactive local TUI. The daemon now derives eligibility from the accepted local transport instead of trusting that field alone.

## Usage

Local TUI closes remain one keystroke. When using a TUI against a non-loopback daemon, close through the normal evidence-bearing CLI or API flow instead:

```sh
kata close <ref> --done \
  --message "Completed the requested change and reviewed the result." \
  --commit <sha>
```

Closes #38
