### PR TITLE
docs: finalize 0.15.1 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ Production Postgres deployments can use separate schema-owner and runtime roles;
 see the [operator ceremony](docs/operations/postgres.md).
 Go applications can instead mount kata's listener-free HTTP service in-process;
 see [Embedding kata in Go](docs/development/embedding.md).
-MCP clients can start Kata's native stdio server with `kata mcp serve`. It
-binds the current workspace's project by default, and can serve a fixed
-allowlist or the complete daemon catalog on request. Thirteen section loaders
-progressively expose Kata's typed
-issue, administration, automation, and event workflows. See the [MCP
-reference](docs/reference/mcp.md).
+MCP clients can start Kata's native server over stdio or Streamable HTTP with
+`kata mcp serve`. It binds the current workspace's project by default, and can
+serve a fixed allowlist or the complete daemon catalog on request. Thirteen
+section loaders progressively expose Kata's typed issue, administration,
+automation, and event workflows. See the [MCP reference](docs/reference/mcp.md).
 
 The documentation in [`docs/`](docs/) is the definitive guide, published with
 Zensical at <https://katatracker.com/>.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,52 @@
 ---
 title: Changelog
 description: Release history for kata
-last_edited: 2026-08-16
+last_edited: 2026-08-20
 ---
 
 All notable changes to kata, grouped by release. Versioned releases start with
 0.5.0; earlier entries are a retroactive project history grouped by ISO week.
 
 ## Unreleased
+
+## 0.15.1
+<small>2026-08-20</small>
+
+kata 0.15.1 is a bugfix release that tightens daemon and remote TUI behavior,
+while adding Streamable HTTP access for MCP clients and clearer daemon
+discovery and autostart diagnostics.
+
+**New features**
+
+- Added Streamable HTTP transport for MCP clients. The listener requires an
+  environment-sourced bearer token and keeps the existing project scope,
+  actor, daemon authorization, and tool safeguards.
+
+**Improvements**
+
+- Added a supported `kata daemon locate` interface that reports the selected
+  daemon's locality, transport, scheme, and request base URL without exposing
+  credentials.
+- Made CLI errors identify runtime-store permission failures before daemon
+  autostart and explain when a restricted environment might be responsible.
+
+**Bug fixes**
+
+- Limited the TUI close-policy exception to owner-local Unix sockets and
+  direct, unforwarded loopback connections. Remote TUI clients must now meet
+  the daemon's normal close message and evidence safeguards.
+- Delegated runtime-store writability checks to kit's shared validation so
+  symlink, ownership, and private-directory failures are detected consistently.
+
+**Acknowledgements**
+
+- Thanks to [Rusty Shackleford](https://github.com/salmonumbrella) for the
+  Streamable HTTP MCP transport, support-aware daemon discovery, and remote
+  TUI close safeguard.
+- Thanks to [codyw912](https://github.com/codyw912) for clear daemon autostart
+  errors in restricted environments.
+- Thanks to [Wes McKinney](https://github.com/wesm) for the shared
+  runtime-store writability check and the release documentation.
 
 ## 0.15.0
 <small>2026-08-16</small>

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,8 +146,9 @@ is a local ledger for the work itself. They coexist. See
 -   [__Concepts__](guide/concepts.md). The data model and how the pieces fit.
 -   [__Web UI__](guide/web-ui.md). Manage projects and issues in the browser.
 -   [__CLI reference__](reference/cli.md). Every command and flag.
--   [__Model Context Protocol__](reference/mcp.md). Connect an MCP agent to the
-    workspace project, a fixed allowlist, or the whole daemon.
+-   [__Model Context Protocol__](reference/mcp.md). Connect an MCP client over
+    stdio or Streamable HTTP to the workspace project, a fixed allowlist, or
+    the whole daemon.
 -   [__Semantic search__](guide/semantic-search.md). Improve issue discovery
     with opt-in embeddings.
 -   [__GitHub sync__](operations/github-sync.md). Bring GitHub issues into kata.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-16
+last_edited: 2026-08-20
 ---
 
 # CLI reference
@@ -99,20 +99,23 @@ the other output modes.
 kata [--workspace PATH | --project NAME] [--daemon NAME] [--as ACTOR] mcp serve
 kata mcp serve --projects NAME[,NAME...]
 kata mcp serve --all-projects [--enable-token-admin]
+kata mcp serve --http HOST:PORT --http-token-env ENV_NAME
 ```
 
-`kata mcp serve` starts Kata's native MCP stdio server bound to the current
-workspace's project by default. `--workspace` or `--project` selects one
-explicit project. `--projects` fixes an allowlist of project names, pinned by
-immutable project UID. `--all-projects` follows every project in the selected
-daemon catalog. The
-startup scope and actor apply to every tool call. The initial catalog contains
-13 section loaders that progressively expose the detailed typed tools. Optional
-`--storage-root` and repeatable `--storage-target
+`kata mcp serve` starts Kata's native MCP server over stdio by default.
+`--http` selects Streamable HTTP instead; every HTTP listener requires an
+inbound bearer from `--http-token-env`, and non-loopback binds also require
+`--trust-private-network`. The server binds to the current workspace's project
+by default. `--workspace` or `--project` selects one explicit project.
+`--projects` fixes an allowlist of project names, pinned by immutable project
+UID. `--all-projects` follows every project in the selected daemon catalog.
+The startup scope and actor apply to every tool call. The initial catalog
+contains 13 section loaders that progressively expose the detailed typed
+tools. Optional `--storage-root` and repeatable `--storage-target
 alias=path-or-DSN` enable the otherwise absent host-local JSONL tools. See the
-[MCP reference](mcp.md) for the complete catalog, scheduling formats, safety
-rules, and limits. Daemon-wide token tools are absent unless
-`--enable-token-admin` is explicit.
+[MCP reference](mcp.md) for transport configuration, the complete catalog,
+scheduling formats, safety rules, and limits. Daemon-wide token tools are
+absent unless `--enable-token-admin` is explicit.
 
 ## Issue lifecycle
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -1,12 +1,13 @@
 ---
-last_edited: 2026-08-15
+last_edited: 2026-08-20
 ---
 
 # Model Context Protocol server
 
-Kata includes a native stdio MCP server for coding agents and other MCP
-clients. The server gives typed access to Kata issue data, administration,
-automation, and event workflows.
+Kata includes a native Model Context Protocol (MCP) server for coding agents
+and other MCP clients. It supports stdio and Streamable HTTP transport and
+gives typed access to Kata issue data, administration, automation, and event
+workflows.
 
 ```sh
 # The current workspace's project (default)
@@ -26,13 +27,49 @@ kata mcp serve --all-projects
 kata mcp serve --all-projects --enable-token-admin
 ```
 
-JSON-RPC uses stdin and stdout. Kata writes no status text or logs to stdout.
-The actor is fixed when the process starts and uses the normal precedence:
-`--as`, `KATA_AUTHOR`, `USER`, Git `user.name`, then `anonymous`.
+With the default stdio transport, JSON-RPC uses stdin and stdout. Kata writes
+no status text or logs to stdout. The actor is fixed when the process starts
+and uses the normal precedence: `--as`, `KATA_AUTHOR`, `USER`, Git `user.name`,
+then `anonymous`.
+
+## Transport
+
+The default transport is stdio. Use `--http` to run a Streamable HTTP listener
+instead:
+
+```sh
+export KATA_MCP_HTTP_TOKEN='<random bearer token>'
+kata mcp serve --all-projects \
+  --http 127.0.0.1:8080 \
+  --http-token-env KATA_MCP_HTTP_TOKEN
+```
+
+Configure the MCP client with `http://127.0.0.1:8080/mcp` and the same bearer
+token. `--http-token-env` names the environment variable that the Kata process
+reads; the token value does not appear in the process arguments. Every HTTP
+listener requires this inbound bearer, including a loopback listener. This
+credential protects the MCP listener and is separate from the daemon
+credential that the Kata process uses for its own API calls.
+
+Loopback listeners require the exact configured Host and reject cross-origin
+requests. A non-loopback listener additionally requires
+`--trust-private-network` and a literal non-public IP or wildcard bind:
+
+```sh
+kata mcp serve --all-projects \
+  --http 0.0.0.0:8080 \
+  --http-token-env KATA_MCP_HTTP_TOKEN \
+  --trust-private-network
+```
+
+Use that plaintext mode only on an operator-trusted private network or behind
+an HTTPS reverse proxy. Public IPs and DNS hostnames are rejected. The
+listener also serves unauthenticated `GET` and `HEAD` requests at `/healthz`;
+the probe returns only readiness text and disables caching.
 
 ## Client configuration
 
-A typical client command has this shape:
+A typical stdio client command has this shape:
 
 ```json
 {

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-16
+last_edited: 2026-08-20
 ---
 
 # Agent workflows
@@ -92,19 +92,29 @@ for the recipe.
 
 ## Use Kata through MCP
 
-Agents with an MCP client can start Kata as a stdio server bound to the
-current workspace's project:
+Agents with an MCP client can start Kata as a stdio server bound to the current
+workspace's project:
 
 ```sh
 kata mcp serve
+```
+
+Clients that cannot launch a stdio subprocess can connect through Streamable
+HTTP. The listener requires an environment-sourced bearer token:
+
+```sh
+export KATA_MCP_HTTP_TOKEN='<random bearer token>'
+kata mcp serve \
+  --http 127.0.0.1:8080 \
+  --http-token-env KATA_MCP_HTTP_TOKEN
 ```
 
 The server starts with 13 section loaders. An agent loads only the detailed
 issue, project, administration, automation, or event tools needed for its task.
 Pass `--workspace` or `--project` for an explicit project, `--projects` for a
 fixed allowlist, or `--all-projects` to use every project visible to the
-selected daemon. The actor stays fixed at startup. See the [MCP reference](../reference/mcp.md) for configuration and
-exact schemas.
+selected daemon. The actor stays fixed at startup. See the [MCP
+reference](../reference/mcp.md) for transport configuration and exact schemas.
 
 ## Search before creating
 


### PR DESCRIPTION
Finalizes the public documentation for the 0.15.1 bugfix release. The
changelog records the shipped Streamable HTTP transport, daemon discovery and
autostart improvements, remote TUI close safeguard, and runtime-store fix. It
also thanks Rusty Shackleford, codyw912, and Wes McKinney for their release
contributions.

The MCP reference now explains how stdio and Streamable HTTP differ. It
documents the inbound bearer, loopback Host and cross-origin checks,
private-network opt-in, and health probe. The README, CLI reference, agent
workflow guide, and docs overview point readers to the shipped transport.

This PR is limited to behavior already shipped in 0.15.1.
