### PR TITLE
test: align MCP HTTP cleanup timeout

### DIFF
--- a/cmd/kata/mcp_test.go
+++ b/cmd/kata/mcp_test.go
@@ -120,7 +120,9 @@ func startMCPHTTPTestServer(t *testing.T, daemonURL string, extraArgs ...string)
 		select {
 		case err := <-done:
 			require.NoError(t, err)
-		case <-time.After(5 * time.Second):
+		// Let the server report its own bounded shutdown error instead of
+		// racing a shorter test deadline under load.
+		case <-time.After(mcpHTTPShutdownTimeout + 5*time.Second):
 			t.Error("MCP HTTP server did not stop after context cancellation")
 		}
 		_ = stderrReader.Close()


### PR DESCRIPTION
The MCP HTTP test helper could declare cleanup failure after five seconds even
though the server allows ten seconds for bounded graceful shutdown. Under CI
load, that shorter deadline caused intermittent failures while the server was
still within its shutdown contract.

The helper now waits beyond the server deadline. A real stalled shutdown still
fails with the server's own bounded error, while production behavior remains
unchanged.

This change is intentionally limited to the test harness.
