### PR TITLE
Add connector protocol SDK and conformance kit

### DIFF
--- a/cmd/kata/create_test.go
+++ b/cmd/kata/create_test.go
@@ -204,6 +204,7 @@ func TestCreate_ForceNewBypassesLookalike(t *testing.T) {
 // the actual "broken .kata.toml" the user can fix. The fix-it error
 // must surface client-side without ever calling the daemon.
 func TestResolveProjectID_PropagatesParseError(t *testing.T) {
+	resetFlags(t)
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".kata.toml"), //nolint:gosec // test fixture mode matches production
 		[]byte("not = valid = toml ==="), 0o644))
@@ -224,6 +225,7 @@ func TestResolveProjectID_PropagatesParseError(t *testing.T) {
 // through with start_path so the daemon can resolve via its own
 // filesystem walk (local-mode behavior).
 func TestResolveProjectID_FallsBackOnMissingConfig(t *testing.T) {
+	resetFlags(t)
 	dir := t.TempDir() // no .kata.toml
 
 	var got map[string]any
@@ -251,6 +253,7 @@ func TestResolveProjectID_FallsBackOnMissingConfig(t *testing.T) {
 // remote clients (the bug 12ced3a introduced by collapsing the
 // project_identity branch into the always-start_path fallthrough).
 func TestResolveProjectID_SendsNameAndAliasForWorkspaceConfig(t *testing.T) {
+	resetFlags(t)
 	dir := testfix.InitGitRepo(t)
 	require.NoError(t, config.WriteProjectConfig(dir, "project-name"))
 
@@ -281,6 +284,7 @@ func TestResolveProjectID_SendsNameAndAliasForWorkspaceConfig(t *testing.T) {
 // not derive a project name from the git remote and create-by-
 // convention (resolve is strict; init owns that path).
 func TestResolveProjectID_SendsAliasOnlyForGitWorkspaceWithoutKataToml(t *testing.T) {
+	resetFlags(t)
 	dir := testfix.InitGitRepo(t)
 
 	var got map[string]any
@@ -308,11 +312,10 @@ func TestResolveProjectID_SendsAliasOnlyForGitWorkspaceWithoutKataToml(t *testin
 // alias-first repair must not run (it could redirect away from the
 // caller's chosen project). Name-only is the strict-target contract.
 func TestResolveProjectID_ExplicitProjectFlagSendsNameOnly(t *testing.T) {
+	resetFlags(t)
 	dir := testfix.InitGitRepo(t)
 	require.NoError(t, config.WriteProjectConfig(dir, "in-toml"))
 
-	prev := flags.Project
-	t.Cleanup(func() { flags.Project = prev })
 	flags.Project = "explicit"
 
 	var got map[string]any
@@ -386,6 +389,7 @@ func TestCreate_CrossProjectLinkViaQualifiedRef(t *testing.T) {
 // In remote-client mode the daemon cannot reach the client's
 // filesystem, so this repair must happen on the client.
 func TestResolveProjectID_RewritesStaleKataToml(t *testing.T) {
+	resetFlags(t)
 	dir := testfix.InitGitRepo(t)
 	require.NoError(t, config.WriteProjectConfig(dir, "stale-name"))
 

--- a/cmd/kata/show_markdown.go
+++ b/cmd/kata/show_markdown.go
@@ -96,13 +96,20 @@ func (r *externalShowMarkdownRenderer) Render(
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = io.Discard
-	processtree.Prepare(cmd)
+	tree, err := processtree.New(cmd)
+	if err != nil {
+		return "", rendererError(r.argv[0], kind, err)
+	}
+	defer func() { _ = tree.Close() }()
 	cmd.WaitDelay = r.grace
 	cmd.Cancel = func() error {
-		return processtree.TerminateWithGrace(cmd, r.grace)
+		return tree.TerminateWithGrace(r.grace)
 	}
 
-	if err := cmd.Run(); err != nil {
+	if err := tree.Start(); err != nil {
+		return "", rendererError(r.argv[0], kind, err)
+	}
+	if err := tree.Wait(); err != nil {
 		// Prefer the context cause: a killed renderer reports the timeout or
 		// cancellation rather than its incidental exit status.
 		if cause := renderCtx.Err(); cause != nil {

--- a/docs/reference/connector-protocol.md
+++ b/docs/reference/connector-protocol.md
@@ -1,0 +1,153 @@
+---
+last_edited: 2026-08-23
+---
+
+# Connector author contract
+
+Kata external-root connectors are executables that implement the versioned
+`kata.connector.v1` JSON protocol. Provider-specific credentials and APIs stay
+inside the connector.
+
+The current implementation provides the public protocol SDK and conformance kit
+plus internal process-client building blocks. Daemon configuration, durable
+bindings, synchronization, and API/CLI administration are not implemented yet.
+Do not add connector sections to `<KATA_HOME>/config.toml`; the daemon rejects
+unknown configuration keys. Those integration surfaces will be documented when
+they are available.
+
+## Process and framing
+
+Kata starts one fresh connector process for each RPC. It writes exactly one JSON
+request to standard input, closes the request stream, and expects exactly one
+JSON response on standard output. Extra JSON, malformed responses, mismatched
+request IDs, an unsupported protocol version, or output beyond the bounded
+response limit fail the call. Diagnostic output is not part of the protocol.
+
+Every request contains:
+
+```json
+{
+  "protocol": "kata.connector.v1",
+  "id": "opaque-request-id",
+  "method": "read_root",
+  "instance": "notes",
+  "settings": {"workspace": "example-workspace"},
+  "params": {"root_key": "opaque-root-key"}
+}
+```
+
+The response repeats `protocol` and `id`, then returns exactly one of `result`
+or `error`:
+
+```json
+{
+  "protocol": "kata.connector.v1",
+  "id": "opaque-request-id",
+  "error": {
+    "code": "root_unavailable",
+    "message": "The external root is temporarily unavailable"
+  }
+}
+```
+
+Errors must be safe, bounded operator text: a lowercase structured code and a
+message without credentials, absolute paths, command lines, stack traces,
+standard-output/error dumps, or control characters. The process client redacts
+values supplied through its explicit environment mapping, but no daemon
+configuration exists for that mapping yet. The connector remains responsible
+for returning safe errors.
+
+## Methods and capabilities
+
+All handlers implement these methods:
+
+| Method | Purpose |
+| --- | --- |
+| `describe` | Return stable connector/account identity, protocol, capabilities, and optional settings schema. |
+| `resolve_root` | Turn an operator-provided locator into a canonical root. |
+| `read_root` | Read title, body, lifecycle state, revision, timestamps, actor, and optional fields. |
+| `list_comments` | Return the root's canonical comment observations. |
+| `complete_root` | Complete the external root and return verified readback. |
+| `publish_comment` | Publish one comment and return its provider identity and timestamps. |
+| `list_fields` | Discover canonical external field descriptors. |
+| `read_fields` | Read selected canonical field values. |
+| `write_fields` | Write selected fields and return canonical readback. |
+
+`publish_comment` is advertised with the `publish_comment` capability. The
+field methods are advertised with `fields`. A connector may return a structured
+unsupported error for optional methods whose capability it does not advertise.
+
+Each `publish_comment` request includes a nonempty, canonical `operation_id`.
+The caller persists this ID for the logical publication and reuses it when a
+connector process exits after publishing but before returning a response. A
+connector must return the original comment for that retry without creating a
+second provider comment.
+
+Root keys, account identities, connector IDs, actor IDs, comment IDs, field IDs,
+and schema revisions are opaque stable identities. Do not encode Kata issue
+UIDs, refs, project IDs, binding IDs, branches, or other Kata-owned identity
+inside provider metadata. Field descriptor IDs and schema revisions must
+already be canonical: surrounding whitespace is invalid.
+
+Root and comment revisions are opaque change tokens. A revision advances when
+the canonical root or comment changes and remains stable while that observation
+is unchanged; clients compare revisions for equality rather than ordering.
+Timestamps use RFC 3339.
+Field values use the portable `date`, `local_datetime`, `instant`, and `null`
+kinds accepted by the conformance transcripts; a descriptor lists
+the exact kinds it accepts and whether it is nullable and writable.
+
+## Go SDK
+
+Go connectors can implement `pkg/connector.Handler` and serve one request with
+`connector.ServeOne`:
+
+```go
+func main() {
+    if err := connector.ServeOne(context.Background(), os.Stdin, os.Stdout, handler); err != nil {
+        os.Exit(1)
+    }
+}
+```
+
+`connector.InvocationFromContext` returns the configured instance ID and a copy
+of its raw settings for the current call. Treat settings as non-secret operator
+configuration; read credentials from the explicitly mapped child environment.
+
+## Conformance
+
+The public `pkg/connector/conformance` package runs the same behavior against a
+disposable provider root through the connector's real protocol boundary. A
+fixture implements `Exchange`, `Invocation`, `RootLocator`, `Reset`, `ExternalState`,
+`MutateComment`, and `InjectFault`, then
+calls:
+
+```go
+func TestConnectorConformance(t *testing.T) {
+    conformance.Run(t, newConnectorFixture(t))
+}
+```
+
+`Invocation` returns the configured instance ID and raw JSON settings used for
+every transcript request. This lets a fixture exercise settings required by its
+declared configuration schema through the real protocol boundary.
+
+The committed transcripts under
+`pkg/connector/conformance/testdata/protocol-v1/` are language-neutral. Other
+languages should drive those JSON cases against their executable and preserve
+the same identity, mutation, error-safety, ordering, replay, and readback
+invariants. The publication case injects a process exit after the provider
+mutation but before the response, retries the same `operation_id`, and requires
+provider state to change only once. The required-methods case edits an existing
+provider comment and requires its stable ID to keep a changed revision across
+subsequent unchanged reads.
+
+## Current boundaries
+
+- The external root owns title and body while a binding is active.
+- Kata planning-field mappings are limited to `scheduled_on` and `deadline_on`
+  in protocol v1.
+- Kata deliberately uses one process per RPC for isolation and bounded cleanup;
+  a long-lived transport is deferred.
+- The browser UI has no bridge indicator yet. Connector and bridge
+  administration through the daemon API and CLI is also deferred.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -33,6 +33,7 @@ nav = [
     {"Daemon discovery" = "reference/daemon-discovery.md"},
     {"Model Context Protocol" = "reference/mcp.md"},
     {"Configuration" = "reference/configuration.md"},
+    {"Connector author contract" = "reference/connector-protocol.md"},
     {"Metadata" = "reference/metadata.md"},
     {"Agent output format" = "reference/agent-output.md"},
     {"HTTP API schema" = "reference/http-api.md"},

--- a/internal/config/connector_config.go
+++ b/internal/config/connector_config.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	defaultConnectorTimeout = 30 * time.Second
+	maxConnectorTimeout     = 300
+	maxConnectorArgs        = 64
+)
+
+var (
+	connectorIDPattern     = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+	environmentNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+)
+
+// ConnectorConfig is one operator-configured connector process.
+type ConnectorConfig struct {
+	ID             string            `toml:"id"`
+	Command        string            `toml:"command"`
+	Args           []string          `toml:"args"`
+	TimeoutSeconds int               `toml:"timeout_seconds"`
+	Env            map[string]string `toml:"env"`
+	Settings       map[string]any    `toml:"settings"`
+}
+
+// Timeout returns the configured connector-call timeout or its safe default.
+func (c ConnectorConfig) Timeout() time.Duration {
+	if c.TimeoutSeconds == 0 {
+		return defaultConnectorTimeout
+	}
+	return time.Duration(c.TimeoutSeconds) * time.Second
+}
+
+// NormalizeConnectorConfigs validates operator-controlled connector process
+// configuration and returns canonical instance IDs.
+func NormalizeConnectorConfigs(configs []ConnectorConfig) ([]ConnectorConfig, error) {
+	normalized := make([]ConnectorConfig, len(configs))
+	seen := make(map[string]struct{}, len(configs))
+	for i, cfg := range configs {
+		cfg.ID = strings.ToLower(strings.TrimSpace(cfg.ID))
+		cfg.Command = strings.TrimSpace(cfg.Command)
+		if cfg.ID == "" {
+			return nil, fmt.Errorf("connector: id is required")
+		}
+		if !connectorIDPattern.MatchString(cfg.ID) {
+			return nil, fmt.Errorf("connector %q: invalid id", cfg.ID)
+		}
+		if !filepath.IsAbs(cfg.Command) {
+			return nil, fmt.Errorf("connector %q: command must be absolute", cfg.ID)
+		}
+		if len(cfg.Args) > maxConnectorArgs {
+			return nil, fmt.Errorf("connector %q: at most %d args are allowed", cfg.ID, maxConnectorArgs)
+		}
+		if cfg.TimeoutSeconds < 0 || cfg.TimeoutSeconds > maxConnectorTimeout {
+			return nil, fmt.Errorf("connector %q: timeout_seconds must be between 0 and %d", cfg.ID, maxConnectorTimeout)
+		}
+		for target, source := range cfg.Env {
+			if !environmentNamePattern.MatchString(target) || !environmentNamePattern.MatchString(source) {
+				return nil, fmt.Errorf("connector %q: invalid environment name", cfg.ID)
+			}
+		}
+		if _, err := json.Marshal(cfg.Settings); err != nil {
+			return nil, fmt.Errorf("connector %q: settings must be JSON-compatible: %w", cfg.ID, err)
+		}
+		if _, ok := seen[cfg.ID]; ok {
+			return nil, fmt.Errorf("connector %q: duplicate id", cfg.ID)
+		}
+		seen[cfg.ID] = struct{}{}
+		normalized[i] = cfg
+	}
+	return normalized, nil
+}

--- a/internal/config/connector_config_test.go
+++ b/internal/config/connector_config_test.go
@@ -1,0 +1,54 @@
+package config_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+)
+
+func TestConnectorConfigRejectsRelativeCommandAndDuplicateID(t *testing.T) {
+	_, err := config.NormalizeConnectorConfigs([]config.ConnectorConfig{
+		{ID: "notes", Command: "connector"},
+		{ID: "notes", Command: "/opt/connectors/second"},
+	})
+	require.ErrorContains(t, err, `connector "notes": command must be absolute`)
+}
+
+func TestNormalizeConnectorConfigs(t *testing.T) {
+	absoluteCommand := filepath.Join(t.TempDir(), "notes-connector")
+	configs, err := config.NormalizeConnectorConfigs([]config.ConnectorConfig{{
+		ID:             " Notes.Main ",
+		Command:        absoluteCommand,
+		TimeoutSeconds: 12,
+		Env:            map[string]string{"TOKEN": "CONNECTOR_TOKEN"},
+		Settings:       map[string]any{"enabled": true},
+	}})
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "notes.main", configs[0].ID)
+	assert.Equal(t, 12*time.Second, configs[0].Timeout())
+
+	tests := []struct {
+		name string
+		cfg  config.ConnectorConfig
+		want string
+	}{
+		{name: "missing ID", cfg: config.ConnectorConfig{Command: absoluteCommand}, want: "id is required"},
+		{name: "invalid ID", cfg: config.ConnectorConfig{ID: "notes/one", Command: absoluteCommand}, want: "invalid id"},
+		{name: "too many args", cfg: config.ConnectorConfig{ID: "notes", Command: absoluteCommand, Args: make([]string, 65)}, want: "at most 64 args"},
+		{name: "negative timeout", cfg: config.ConnectorConfig{ID: "notes", Command: absoluteCommand, TimeoutSeconds: -1}, want: "timeout_seconds must be between 0 and 300"},
+		{name: "too long timeout", cfg: config.ConnectorConfig{ID: "notes", Command: absoluteCommand, TimeoutSeconds: 301}, want: "timeout_seconds must be between 0 and 300"},
+		{name: "invalid target environment", cfg: config.ConnectorConfig{ID: "notes", Command: absoluteCommand, Env: map[string]string{"bad-name": "SOURCE"}}, want: "invalid environment name"},
+		{name: "invalid source environment", cfg: config.ConnectorConfig{ID: "notes", Command: absoluteCommand, Env: map[string]string{"TOKEN": "bad-name"}}, want: "invalid environment name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := config.NormalizeConnectorConfigs([]config.ConnectorConfig{tt.cfg})
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}

--- a/internal/connector/client.go
+++ b/internal/connector/client.go
@@ -1,0 +1,681 @@
+// Package connector executes configured connector processes.
+package connector
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/processtree"
+	protocol "go.kenn.io/kata/pkg/connector"
+)
+
+const (
+	maxResponseBytes             = 4 << 20
+	connectorProcessCleanupGrace = 100 * time.Millisecond
+)
+
+var (
+	errResponseTooLarge      = errors.New("connector response exceeds 4 MiB")
+	errConnectorChildTimeout = errors.New("connector child timeout")
+	errConnectorCleanupWait  = errors.New("connector process cleanup timed out")
+
+	// ErrProcessFailure marks connector executable startup, transport, or exit
+	// failure without rendering child paths, stderr, or configuration.
+	ErrProcessFailure = errors.New("external connector process failed")
+	// ErrProtocolFailure marks an invalid connector protocol response.
+	ErrProtocolFailure = errors.New("external connector protocol failed")
+	// ErrRequestTimeout marks a configured child timeout while the parent
+	// request context remains live.
+	ErrRequestTimeout = errors.New("external connector request timed out")
+)
+
+type callFailure struct {
+	kind  error
+	cause error
+}
+
+func (e *callFailure) Error() string { return e.kind.Error() }
+
+func (e *callFailure) Unwrap() []error {
+	if e.cause == nil {
+		return []error{e.kind}
+	}
+	return []error{e.kind, e.cause}
+}
+
+func newCallFailure(kind, cause error) error {
+	return &callFailure{kind: kind, cause: cause}
+}
+
+// Client invokes every operation in the external connector protocol.
+type Client interface {
+	Describe(context.Context) (protocol.Description, error)
+	ResolveRoot(context.Context, protocol.ResolveRootParams) (protocol.Root, error)
+	ReadRoot(context.Context, protocol.ReadRootParams) (protocol.Root, error)
+	ListComments(context.Context, protocol.ListCommentsParams) (protocol.ListCommentsResult, error)
+	CompleteRoot(context.Context, protocol.CompleteRootParams) (protocol.Root, error)
+	PublishComment(context.Context, protocol.PublishCommentParams) (protocol.Comment, error)
+	ListFields(context.Context) (protocol.ListFieldsResult, error)
+	ReadFields(context.Context, protocol.ReadFieldsParams) (protocol.ReadFieldsResult, error)
+	WriteFields(context.Context, protocol.WriteFieldsParams) (protocol.WriteFieldsResult, error)
+}
+
+type processClient struct {
+	config config.ConnectorConfig
+}
+
+// NewProcessClient constructs a client for a validated connector config.
+func NewProcessClient(cfg config.ConnectorConfig) Client {
+	return newProcessClient(cfg)
+}
+
+func newProcessClient(cfg config.ConnectorConfig) *processClient {
+	return &processClient{config: cfg}
+}
+
+func (p *processClient) Describe(ctx context.Context) (protocol.Description, error) {
+	return callResult(ctx, p, "describe", protocol.DescribeParams{}, validateDescription)
+}
+
+func (p *processClient) ResolveRoot(ctx context.Context, params protocol.ResolveRootParams) (protocol.Root, error) {
+	return callResult(ctx, p, "resolve_root", params, validateRoot)
+}
+
+func (p *processClient) ReadRoot(ctx context.Context, params protocol.ReadRootParams) (protocol.Root, error) {
+	return callResult(ctx, p, "read_root", params, func(result protocol.Root) error {
+		if err := validateRoot(result); err != nil {
+			return err
+		}
+		if result.Key != params.RootKey {
+			return errors.New("read_root result key does not match request")
+		}
+		return nil
+	})
+}
+
+func (p *processClient) ListComments(ctx context.Context, params protocol.ListCommentsParams) (protocol.ListCommentsResult, error) {
+	return callResult(ctx, p, "list_comments", params, validateComments)
+}
+
+func (p *processClient) CompleteRoot(ctx context.Context, params protocol.CompleteRootParams) (protocol.Root, error) {
+	return callResult(ctx, p, "complete_root", params, func(result protocol.Root) error {
+		if err := validateRoot(result); err != nil {
+			return err
+		}
+		if result.Key != params.RootKey {
+			return errors.New("complete_root result key does not match request")
+		}
+		if result.State != "complete" {
+			return errors.New("complete_root result state is not complete")
+		}
+		return nil
+	})
+}
+
+func (p *processClient) PublishComment(ctx context.Context, params protocol.PublishCommentParams) (protocol.Comment, error) {
+	if !protocol.ValidOperationID(params.OperationID) {
+		return protocol.Comment{}, errors.New("operation_id must be nonempty and canonical")
+	}
+	description, err := p.Describe(ctx)
+	if err != nil {
+		return protocol.Comment{}, err
+	}
+	if !slices.Contains(description.Capabilities, protocol.CapabilityPublishComment) ||
+		!requiredCanonical(description.SelfActorID) {
+		return protocol.Comment{}, invalidResult(errors.New("connector does not advertise a publishing actor"))
+	}
+	return callResult(ctx, p, "publish_comment", params, func(result protocol.Comment) error {
+		if err := validateComment(result); err != nil {
+			return err
+		}
+		if result.Body != params.Body || result.Deleted || result.Author.ID != description.SelfActorID {
+			return errors.New("publish_comment result does not match the requested publication")
+		}
+		return nil
+	})
+}
+
+func (p *processClient) ListFields(ctx context.Context) (protocol.ListFieldsResult, error) {
+	return callResult(ctx, p, "list_fields", protocol.ListFieldsParams{}, validateFields)
+}
+
+func (p *processClient) ReadFields(ctx context.Context, params protocol.ReadFieldsParams) (protocol.ReadFieldsResult, error) {
+	return callResult(ctx, p, "read_fields", params, func(result protocol.ReadFieldsResult) error {
+		return validateReadFields(params, result)
+	})
+}
+
+func (p *processClient) WriteFields(ctx context.Context, params protocol.WriteFieldsParams) (protocol.WriteFieldsResult, error) {
+	for _, value := range params.Fields {
+		if err := protocol.ValidateFieldValue(value); err != nil {
+			return protocol.WriteFieldsResult{}, err
+		}
+	}
+	return callResult(ctx, p, "write_fields", params, func(result protocol.WriteFieldsResult) error {
+		if result.Fields == nil {
+			return errors.New("write_fields result is missing fields")
+		}
+		for _, value := range result.Fields {
+			if err := protocol.ValidateFieldValue(value); err != nil {
+				return err
+			}
+		}
+		if !maps.Equal(result.Fields, params.Fields) {
+			return errors.New("write_fields result does not match requested values")
+		}
+		return nil
+	})
+}
+
+func callResult[R any](ctx context.Context, p *processClient, method string, params any, validate func(R) error) (R, error) {
+	var result R
+	if err := p.call(ctx, method, params, &result); err != nil {
+		return result, err
+	}
+	if err := validate(result); err != nil {
+		return *new(R), invalidResult(err)
+	}
+	return result, nil
+}
+
+func validateReadFields(params protocol.ReadFieldsParams, result protocol.ReadFieldsResult) error {
+	expected := make(map[string]struct{}, len(params.FieldIDs))
+	for _, id := range params.FieldIDs {
+		expected[id] = struct{}{}
+	}
+	if result.Fields == nil || len(result.Fields) != len(expected) {
+		return errors.New("read_fields result does not match requested selectors")
+	}
+	for id := range expected {
+		value, ok := result.Fields[id]
+		if !ok {
+			return errors.New("read_fields result does not match requested selectors")
+		}
+		if err := protocol.ValidateFieldValue(value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateComments(result protocol.ListCommentsResult) error {
+	if result.Comments == nil {
+		return errors.New("list_comments result is missing comments")
+	}
+	seen := make(map[string]struct{}, len(result.Comments))
+	for _, comment := range result.Comments {
+		if err := validateComment(comment); err != nil {
+			return err
+		}
+		if _, ok := seen[comment.ID]; ok {
+			return errors.New("list_comments result contains duplicate comment identity")
+		}
+		seen[comment.ID] = struct{}{}
+	}
+	return nil
+}
+
+func validateFields(result protocol.ListFieldsResult) error {
+	if result.Fields == nil {
+		return errors.New("list_fields result is missing fields")
+	}
+	seen := make(map[string]struct{}, len(result.Fields))
+	for _, descriptor := range result.Fields {
+		if err := validateFieldDescriptor(descriptor); err != nil {
+			return err
+		}
+		if _, ok := seen[descriptor.ID]; ok {
+			return errors.New("list_fields result contains duplicate field identity")
+		}
+		seen[descriptor.ID] = struct{}{}
+	}
+	return nil
+}
+
+func invalidResult(cause error) error {
+	return newCallFailure(ErrProtocolFailure, cause)
+}
+
+func validateDescription(result protocol.Description) error {
+	if !requiredCanonical(result.ConnectorID) || !requiredText(result.DisplayName) || !requiredCanonical(result.AccountIdentity) {
+		return errors.New("describe result is missing required identity")
+	}
+	if result.Protocol != protocol.ProtocolVersion {
+		return errors.New("describe result has unsupported protocol")
+	}
+	if result.Capabilities == nil {
+		return errors.New("describe result is missing capabilities")
+	}
+	if result.SelfActorID != "" && strings.TrimSpace(result.SelfActorID) != result.SelfActorID {
+		return errors.New("describe result has noncanonical self actor identity")
+	}
+	return nil
+}
+
+func validateRoot(result protocol.Root) error {
+	if !requiredCanonical(result.Key) || !requiredCanonical(result.IdentityKey) ||
+		!requiredCanonical(result.State) || !requiredCanonical(result.Revision) {
+		return errors.New("root result is missing required identity")
+	}
+	if result.UpdatedAt.IsZero() || result.ObservedAt.IsZero() {
+		return errors.New("root result is missing required timestamp")
+	}
+	if result.ObservedAt.Before(result.UpdatedAt) {
+		return errors.New("root result observation predates its update")
+	}
+	if result.Actor != nil {
+		if err := validateActor(*result.Actor); err != nil {
+			return err
+		}
+	}
+	for _, value := range result.Fields {
+		if err := protocol.ValidateFieldValue(value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateComment(result protocol.Comment) error {
+	if !requiredCanonical(result.ID) || !requiredCanonical(result.Revision) {
+		return errors.New("comment result is missing required identity")
+	}
+	if err := validateActor(result.Author); err != nil {
+		return err
+	}
+	if result.CreatedAt.IsZero() || result.UpdatedAt.IsZero() {
+		return errors.New("comment result is missing required timestamp")
+	}
+	if result.UpdatedAt.Before(result.CreatedAt) {
+		return errors.New("comment result update predates its creation")
+	}
+	return nil
+}
+
+func validateActor(result protocol.Actor) error {
+	if !requiredCanonical(result.ID) || !requiredText(result.DisplayName) {
+		return errors.New("actor result is missing required identity")
+	}
+	return nil
+}
+
+func validateFieldDescriptor(result protocol.FieldDescriptor) error {
+	if !requiredCanonical(result.ID) || !requiredText(result.DisplayName) || !requiredCanonical(result.SchemaRevision) {
+		return errors.New("field descriptor is missing required identity")
+	}
+	if result.AcceptedKinds == nil {
+		return errors.New("field descriptor is missing accepted kinds")
+	}
+	return nil
+}
+
+func requiredCanonical(value string) bool {
+	return value != "" && strings.TrimSpace(value) == value
+}
+
+func requiredText(value string) bool {
+	return strings.TrimSpace(value) != ""
+}
+
+func (p *processClient) call(ctx context.Context, method string, params any, result any) error {
+	settings := json.RawMessage(`{}`)
+	if p.config.Settings != nil {
+		encodedSettings, err := json.Marshal(p.config.Settings)
+		if err != nil {
+			return fmt.Errorf("connector %q: invalid settings", p.config.ID)
+		}
+		settings = encodedSettings
+	}
+	encodedParams, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("connector %q: invalid request parameters", p.config.ID)
+	}
+	request := protocol.Request{
+		Protocol: protocol.ProtocolVersion,
+		ID:       requestID(),
+		Method:   method,
+		Instance: p.config.ID,
+		Settings: settings,
+		Params:   encodedParams,
+	}
+	input, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("connector %q: encode request", p.config.ID)
+	}
+
+	childEnv, redactions, err := p.environment(settings)
+	if err != nil {
+		return newCallFailure(ErrProcessFailure, err)
+	}
+	commandCtx, cancel := context.WithTimeoutCause(ctx, p.config.Timeout(), errConnectorChildTimeout)
+	defer cancel()
+	command := exec.Command(p.config.Command, p.config.Args...) // #nosec G204 -- executable and args are operator-controlled validated configuration.
+	command.Env = childEnv
+	command.Stdin = bytes.NewReader(input)
+	command.Stderr = io.Discard
+	stdout := &cappedBuffer{limit: maxResponseBytes}
+	command.Stdout = stdout
+	command.WaitDelay = connectorProcessCleanupGrace
+	if commandCtx.Err() != nil {
+		return connectorContextError(ctx, context.Cause(commandCtx))
+	}
+	processTree, err := processtree.New(command)
+	if err != nil {
+		return newCallFailure(ErrProcessFailure, err)
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = processTree.Close()
+		}
+	}()
+	if commandCtx.Err() != nil {
+		return connectorContextError(ctx, context.Cause(commandCtx))
+	}
+	if err := processTree.Start(); err != nil {
+		return newCallFailure(ErrProcessFailure, err)
+	}
+	waitResult := make(chan error, 1)
+	go func() {
+		waitResult <- processTree.Wait()
+	}()
+	runErr, contextCause := awaitCommandOutcome(commandCtx, waitResult, func() error {
+		return processTree.TerminateWithGrace(connectorProcessCleanupGrace)
+	})
+	if contextCause != nil {
+		_ = processTree.Close()
+		closed = true
+		return connectorContextError(ctx, contextCause)
+	}
+	if runErr != nil {
+		_ = processTree.Close()
+		closed = true
+		return newCallFailure(ErrProcessFailure, runErr)
+	}
+	if err := processTree.Close(); err != nil {
+		closed = true
+		return newCallFailure(ErrProcessFailure, err)
+	}
+	closed = true
+	if stdout.exceeded {
+		return newCallFailure(ErrProtocolFailure, errResponseTooLarge)
+	}
+	if !utf8.Valid(stdout.Bytes()) {
+		return newCallFailure(ErrProtocolFailure, errors.New("connector response is not valid UTF-8"))
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(stdout.Bytes()))
+	var response protocol.Response
+	if err := decoder.Decode(&response); err != nil {
+		return newCallFailure(ErrProtocolFailure, err)
+	}
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return newCallFailure(ErrProtocolFailure, errors.New("connector response contains trailing JSON"))
+		}
+		return newCallFailure(ErrProtocolFailure, err)
+	}
+	if response.Protocol != protocol.ProtocolVersion {
+		return newCallFailure(ErrProtocolFailure, errors.New("connector response has unsupported protocol"))
+	}
+	if response.ID != request.ID {
+		return newCallFailure(ErrProtocolFailure, errors.New("connector response ID does not match request"))
+	}
+	if (len(response.Result) == 0) == (response.Error == nil) {
+		return newCallFailure(ErrProtocolFailure, errors.New("connector response must contain exactly one of result or error"))
+	}
+	if response.Error != nil {
+		return redactError(response.Error, redactions)
+	}
+	if bytes.Equal(bytes.TrimSpace(response.Result), []byte("null")) {
+		return newCallFailure(ErrProtocolFailure, errors.New("connector response result must not be null"))
+	}
+	if err := json.Unmarshal(response.Result, result); err != nil {
+		return newCallFailure(ErrProtocolFailure, err)
+	}
+	return nil
+}
+
+func awaitCommandOutcome(
+	ctx context.Context,
+	waitResult <-chan error,
+	kill func() error,
+) (error, error) {
+	select {
+	case runErr := <-waitResult:
+		return runErr, nil
+	default:
+	}
+	select {
+	case runErr := <-waitResult:
+		return runErr, nil
+	case <-ctx.Done():
+		select {
+		case runErr := <-waitResult:
+			return runErr, nil
+		default:
+		}
+		terminationErr := kill()
+		timer := time.NewTimer(connectorProcessCleanupGrace)
+		defer timer.Stop()
+		select {
+		case <-waitResult:
+			if terminationErr != nil {
+				return terminationErr, nil
+			}
+			return nil, context.Cause(ctx)
+		case <-timer.C:
+			return errors.Join(terminationErr, errConnectorCleanupWait), nil
+		}
+	}
+}
+
+func connectorContextError(parent context.Context, cause error) error {
+	if errors.Is(cause, errConnectorChildTimeout) {
+		return newCallFailure(ErrRequestTimeout, context.DeadlineExceeded)
+	}
+	if parentErr := parent.Err(); parentErr != nil {
+		return parentErr
+	}
+	if errors.Is(cause, context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+	return context.Canceled
+}
+
+func redactError(response *protocol.Error, redactions []string) error {
+	safe := *response
+	normalized := normalizeRedactions(redactions)
+	safe.Code = redactErrorField(safe.Code, normalized)
+	safe.Message = redactErrorField(safe.Message, normalized)
+	return &safe
+}
+
+func redactErrorField(field string, redactions []string) string {
+	var decoded string
+	if err := json.Unmarshal([]byte(field), &decoded); err == nil {
+		return replaceRedactions(decoded, redactions)
+	}
+	return replaceRedactions(field, redactions)
+}
+
+func replaceRedactions(value string, redactions []string) string {
+	for _, redaction := range redactions {
+		value = strings.ReplaceAll(value, redaction, "[redacted]")
+		if !strings.Contains(value, `\`) {
+			continue
+		}
+		pattern, err := regexp.Compile(jsonEncodedRedactionPattern(redaction))
+		if err != nil {
+			continue
+		}
+		value = pattern.ReplaceAllString(value, "[redacted]")
+	}
+	return value
+}
+
+func jsonEncodedRedactionPattern(value string) string {
+	var pattern strings.Builder
+	for _, char := range value {
+		alternatives := []string{regexp.QuoteMeta(string(char))}
+		if escaped, ok := simpleJSONEscape(char); ok {
+			alternatives = append(alternatives, regexp.QuoteMeta(escaped))
+		}
+		alternatives = append(alternatives, jsonUnicodeEscapePattern(char))
+		pattern.WriteByte('(')
+		pattern.WriteString(strings.Join(alternatives, "|"))
+		pattern.WriteByte(')')
+	}
+	return pattern.String()
+}
+
+func simpleJSONEscape(char rune) (string, bool) {
+	switch char {
+	case '"':
+		return `\"`, true
+	case '\\':
+		return `\\`, true
+	case '/':
+		return `\/`, true
+	case '\b':
+		return `\b`, true
+	case '\f':
+		return `\f`, true
+	case '\n':
+		return `\n`, true
+	case '\r':
+		return `\r`, true
+	case '\t':
+		return `\t`, true
+	default:
+		return "", false
+	}
+}
+
+func jsonUnicodeEscapePattern(char rune) string {
+	if char <= 0xffff {
+		return jsonUTF16CodeUnitPattern(uint16(char)) // #nosec G115 -- the branch bounds char to one UTF-16 code unit.
+	}
+	value := char - 0x10000
+	high := uint16(0xd800 + (value >> 10)) // #nosec G115 -- valid runes produce a bounded high surrogate.
+	low := uint16(0xdc00 + (value & 0x3ff))
+	return jsonUTF16CodeUnitPattern(high) + jsonUTF16CodeUnitPattern(low)
+}
+
+func jsonUTF16CodeUnitPattern(value uint16) string {
+	hex := fmt.Sprintf("%04x", value)
+	var pattern strings.Builder
+	pattern.WriteString(`\\u`)
+	for _, digit := range hex {
+		if digit >= 'a' && digit <= 'f' {
+			pattern.WriteByte('[')
+			pattern.WriteRune(digit)
+			pattern.WriteRune(digit - ('a' - 'A'))
+			pattern.WriteByte(']')
+			continue
+		}
+		pattern.WriteRune(digit)
+	}
+	return pattern.String()
+}
+
+func normalizeRedactions(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		if len(normalized[i]) == len(normalized[j]) {
+			return normalized[i] < normalized[j]
+		}
+		return len(normalized[i]) > len(normalized[j])
+	})
+	return normalized
+}
+
+func (p *processClient) environment(_ json.RawMessage) ([]string, []string, error) {
+	env := minimalRuntimeEnv(runtime.GOOS)
+	redactions := make([]string, 0, len(p.config.Env))
+	for target, source := range p.config.Env {
+		value, ok := os.LookupEnv(source)
+		if !ok {
+			return nil, nil, fmt.Errorf("connector %q: environment source %q is not set", p.config.ID, source)
+		}
+		env = append(env, target+"="+value)
+		redactions = append(redactions, value)
+	}
+	return env, normalizeRedactions(redactions), nil
+}
+
+func minimalRuntimeEnv(goos string) []string {
+	keys := []string{"HOME", "TMPDIR"}
+	if goos == "windows" {
+		keys = append(keys, "SystemRoot", "ComSpec", "TEMP", "TMP", "USERPROFILE")
+	}
+	env := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if value, ok := os.LookupEnv(key); ok {
+			env = append(env, key+"="+value)
+		}
+	}
+	return env
+}
+
+func requestID() string {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "request"
+	}
+	return hex.EncodeToString(value[:])
+}
+
+type cappedBuffer struct {
+	buffer   bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buffer.Len()
+	if remaining <= 0 {
+		b.exceeded = true
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		_, _ = b.buffer.Write(p[:remaining])
+		b.exceeded = true
+		return len(p), nil
+	}
+	_, err := b.buffer.Write(p)
+	return len(p), err
+}
+
+func (b *cappedBuffer) Bytes() []byte {
+	return b.buffer.Bytes()
+}

--- a/internal/connector/client_process_unix_test.go
+++ b/internal/connector/client_process_unix_test.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package connector
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type processClientHelperObservation int
+
+func observeProcessClientHelper(_ *testing.T, pid int) processClientHelperObservation {
+	return processClientHelperObservation(pid)
+}
+
+func requireProcessClientHelperGone(t *testing.T, observed processClientHelperObservation) {
+	t.Helper()
+	pid := int(observed)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("connector descendant %d survived cancellation", pid)
+}

--- a/internal/connector/client_process_windows_test.go
+++ b/internal/connector/client_process_windows_test.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package connector
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+	"golang.org/x/sys/windows"
+)
+
+func TestProcessClientChildCanUseWindowsNativeTempAndProfile(t *testing.T) {
+	t.Setenv("TEMP", t.TempDir())
+	t.Setenv("TMP", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("HELPER_MODE", "native-runtime-paths")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"MODE": "HELPER_MODE"},
+	})
+
+	_, err := client.Describe(t.Context())
+	require.NoError(t, err)
+}
+
+type processClientHelperObservation struct {
+	process *os.Process
+}
+
+func observeProcessClientHelper(t *testing.T, pid int) processClientHelperObservation {
+	t.Helper()
+	process, err := os.FindProcess(pid)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = process.Release() })
+	return processClientHelperObservation{process: process}
+}
+
+func requireProcessClientHelperGone(t *testing.T, observed processClientHelperObservation) {
+	t.Helper()
+	var waitResult uint32
+	var waitErr error
+	require.NoError(t, observed.process.WithHandle(func(handle uintptr) {
+		waitResult, waitErr = windows.WaitForSingleObject(windows.Handle(handle), 2_000)
+	}))
+	require.NoError(t, waitErr)
+	require.Equal(t, uint32(windows.WAIT_OBJECT_0), waitResult, "connector descendant survived cancellation")
+}

--- a/internal/connector/client_test.go
+++ b/internal/connector/client_test.go
@@ -1,0 +1,1023 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+	protocol "go.kenn.io/kata/pkg/connector"
+)
+
+func TestProcessClientPassesOneRequestAndOnlyAllowedEnvironment(t *testing.T) {
+	t.Setenv("CONNECTOR_SECRET", "sensitive")
+	t.Setenv("UNRELATED_SECRET", "must-not-cross")
+	got, err := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t),
+		Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env:  map[string]string{"TOKEN": "CONNECTOR_SECRET"},
+	}).Describe(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "fake.connector", got.ConnectorID)
+}
+
+func TestProcessClientSendsEmptySettingsObjectWhenUnconfigured(t *testing.T) {
+	t.Setenv("HELPER_MODE", "require-empty-settings")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"MODE": "HELPER_MODE"},
+	})
+
+	_, err := client.Describe(t.Context())
+	require.NoError(t, err)
+}
+
+func TestMinimalRuntimeEnvPreservesWindowsNativePaths(t *testing.T) {
+	t.Setenv("TEMP", `C:\runtime\temp`)
+	t.Setenv("TMP", `C:\runtime\tmp`)
+	t.Setenv("USERPROFILE", `C:\Users\connector`)
+
+	assert.Subset(t, minimalRuntimeEnv("windows"), []string{
+		`TEMP=C:\runtime\temp`,
+		`TMP=C:\runtime\tmp`,
+		`USERPROFILE=C:\Users\connector`,
+	})
+}
+
+func TestProcessClientRejectsUnsafeResponses(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		mode     string
+		wantKind error
+		want     string
+	}{
+		{name: "wrong ID", mode: "wrong-id", wantKind: ErrProtocolFailure, want: "external connector protocol failed"},
+		{name: "unsupported version", mode: "unsupported-version", wantKind: ErrProtocolFailure, want: "external connector protocol failed"},
+		{name: "result and error", mode: "both", wantKind: ErrProtocolFailure, want: "external connector protocol failed"},
+		{name: "no terminal value", mode: "neither", wantKind: ErrProtocolFailure, want: "external connector protocol failed"},
+		{name: "null result", mode: "null-result", wantKind: ErrProtocolFailure, want: "external connector protocol failed"},
+		{name: "malformed JSON", mode: "malformed", wantKind: ErrProtocolFailure, want: "external connector protocol failed"},
+		{name: "invalid UTF-8", mode: "invalid-utf8", wantKind: ErrProtocolFailure, want: "external connector protocol failed"},
+		{name: "trailing JSON", mode: "trailing", wantKind: ErrProtocolFailure, want: "external connector protocol failed"},
+		{name: "oversized response", mode: "oversized", wantKind: ErrProtocolFailure, want: "external connector protocol failed"},
+		{name: "nonzero exit hides stderr", mode: "exit", wantKind: ErrProcessFailure, want: "external connector process failed"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HELPER_MODE", tt.mode)
+			client := newHelperClient(t, config.ConnectorConfig{
+				ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+				Env: map[string]string{"MODE": "HELPER_MODE"},
+			})
+			_, err := client.Describe(t.Context())
+			require.ErrorIs(t, err, tt.wantKind)
+			assert.EqualError(t, err, tt.want)
+			assert.NotContains(t, err.Error(), "sensitive stderr")
+		})
+	}
+}
+
+func TestProcessClientRejectsMethodSpecificResponseViolations(t *testing.T) {
+	validOtherRoot := `{"key":"root-other","identity_key":"account-1","state":"open","revision":"revision-1","updated_at":"2026-08-20T10:00:00Z","observed_at":"2026-08-20T10:01:00Z"}`
+	validOtherCompletedRoot := `{"key":"root-other","identity_key":"account-1","state":"complete","revision":"revision-2","updated_at":"2026-08-20T10:00:00Z","observed_at":"2026-08-20T10:01:00Z"}`
+	validOpenRoot := `{"key":"root-1","identity_key":"account-1","state":"open","revision":"revision-1","updated_at":"2026-08-20T10:00:00Z","observed_at":"2026-08-20T10:01:00Z"}`
+	for _, tt := range []struct {
+		name   string
+		result string
+		call   func(Client) error
+	}{
+		{name: "describe missing identities", result: `{}`, call: func(client Client) error {
+			_, err := client.Describe(t.Context())
+			return err
+		}},
+		{name: "resolve missing identities and timestamps", result: `{}`, call: func(client Client) error {
+			_, err := client.ResolveRoot(t.Context(), protocol.ResolveRootParams{Locator: "root-locator"})
+			return err
+		}},
+		{name: "read root key mismatch", result: validOtherRoot, call: func(client Client) error {
+			_, err := client.ReadRoot(t.Context(), protocol.ReadRootParams{RootKey: "root-1"})
+			return err
+		}},
+		{name: "completion state mismatch", result: validOpenRoot, call: func(client Client) error {
+			_, err := client.CompleteRoot(t.Context(), protocol.CompleteRootParams{RootKey: "root-1"})
+			return err
+		}},
+		{name: "completion root key mismatch", result: validOtherCompletedRoot, call: func(client Client) error {
+			_, err := client.CompleteRoot(t.Context(), protocol.CompleteRootParams{RootKey: "root-1"})
+			return err
+		}},
+		{name: "comment missing identity and timestamps", result: `{"comments":[{}]}`, call: func(client Client) error {
+			_, err := client.ListComments(t.Context(), protocol.ListCommentsParams{RootKey: "root-1"})
+			return err
+		}},
+		{name: "comment missing revision", result: `{"comments":[{"id":"comment-1","body":"Body","author":{"id":"actor-1","display_name":"Actor"},"created_at":"2026-08-20T10:00:00Z","updated_at":"2026-08-20T10:00:00Z"}]}`, call: func(client Client) error {
+			_, err := client.ListComments(t.Context(), protocol.ListCommentsParams{RootKey: "root-1"})
+			return err
+		}},
+		{name: "comment padded revision", result: `{"comments":[{"id":"comment-1","revision":" comment-revision-1 ","body":"Body","author":{"id":"actor-1","display_name":"Actor"},"created_at":"2026-08-20T10:00:00Z","updated_at":"2026-08-20T10:00:00Z"}]}`, call: func(client Client) error {
+			_, err := client.ListComments(t.Context(), protocol.ListCommentsParams{RootKey: "root-1"})
+			return err
+		}},
+		{name: "publication missing identity and timestamps", result: `{}`, call: func(client Client) error {
+			_, err := client.PublishComment(t.Context(), protocol.PublishCommentParams{RootKey: "root-1", Body: "Body", OperationID: "operation-1"})
+			return err
+		}},
+		{name: "field descriptor missing identity", result: `{"fields":[{}]}`, call: func(client Client) error {
+			_, err := client.ListFields(t.Context())
+			return err
+		}},
+		{name: "read field selector mismatch", result: `{"fields":{"field-other":{"kind":"date","value":"2026-08-20"}}}`, call: func(client Client) error {
+			_, err := client.ReadFields(t.Context(), protocol.ReadFieldsParams{RootKey: "root-1", FieldIDs: []string{"field-1"}})
+			return err
+		}},
+		{name: "read field missing kind", result: `{"fields":{"field-1":{}}}`, call: func(client Client) error {
+			_, err := client.ReadFields(t.Context(), protocol.ReadFieldsParams{RootKey: "root-1", FieldIDs: []string{"field-1"}})
+			return err
+		}},
+		{name: "read field invalid date", result: `{"fields":{"field-1":{"kind":"date","value":"tomorrow"}}}`, call: func(client Client) error {
+			_, err := client.ReadFields(t.Context(), protocol.ReadFieldsParams{RootKey: "root-1", FieldIDs: []string{"field-1"}})
+			return err
+		}},
+		{name: "read field noncanonical instant", result: `{"fields":{"field-1":{"kind":"instant","value":"2026-08-20T10:00:00+00:00"}}}`, call: func(client Client) error {
+			_, err := client.ReadFields(t.Context(), protocol.ReadFieldsParams{RootKey: "root-1", FieldIDs: []string{"field-1"}})
+			return err
+		}},
+		{name: "read field invalid local datetime", result: `{"fields":{"field-1":{"kind":"local_datetime","value":"2026-08-20 10:00:00","timezone":"Europe/Paris"}}}`, call: func(client Client) error {
+			_, err := client.ReadFields(t.Context(), protocol.ReadFieldsParams{RootKey: "root-1", FieldIDs: []string{"field-1"}})
+			return err
+		}},
+		{name: "read field invalid timezone", result: `{"fields":{"field-1":{"kind":"local_datetime","value":"2026-08-20T10:00:00","timezone":"Mars/Olympus"}}}`, call: func(client Client) error {
+			_, err := client.ReadFields(t.Context(), protocol.ReadFieldsParams{RootKey: "root-1", FieldIDs: []string{"field-1"}})
+			return err
+		}},
+		{name: "write field readback mismatch", result: `{"fields":{"field-1":{"kind":"date","value":"2026-08-21"}}}`, call: func(client Client) error {
+			_, err := client.WriteFields(t.Context(), protocol.WriteFieldsParams{RootKey: "root-1", Fields: map[string]protocol.FieldValue{
+				"field-1": {Kind: "date", Value: "2026-08-20"},
+			}})
+			return err
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HELPER_MODE", "raw-result")
+			t.Setenv("HELPER_RESULT", tt.result)
+			client := newHelperClient(t, config.ConnectorConfig{
+				ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+				Env: map[string]string{"MODE": "HELPER_MODE", "RESULT": "HELPER_RESULT"},
+			})
+
+			err := tt.call(client)
+			require.ErrorIs(t, err, ErrProtocolFailure)
+			assert.EqualError(t, err, "external connector protocol failed")
+		})
+	}
+}
+
+func TestProcessClientRejectsMismatchedPublishedComment(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		result string
+	}{
+		{name: "body", result: `{"id":"comment-1","revision":"comment-revision-1","body":"Different body","author":{"id":"actor-self","display_name":"Connector Actor"},"created_at":"2026-08-20T10:00:00Z","updated_at":"2026-08-20T10:00:00Z"}`},
+		{name: "deleted", result: `{"id":"comment-1","revision":"comment-revision-1","body":"Body","author":{"id":"actor-self","display_name":"Connector Actor"},"created_at":"2026-08-20T10:00:00Z","updated_at":"2026-08-20T10:00:00Z","deleted":true}`},
+		{name: "author", result: `{"id":"comment-1","revision":"comment-revision-1","body":"Body","author":{"id":"actor-other","display_name":"Other Actor"},"created_at":"2026-08-20T10:00:00Z","updated_at":"2026-08-20T10:00:00Z"}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HELPER_MODE", "publication-result")
+			t.Setenv("HELPER_RESULT", tt.result)
+			client := newHelperClient(t, config.ConnectorConfig{
+				ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+				Env: map[string]string{"MODE": "HELPER_MODE", "RESULT": "HELPER_RESULT"},
+			})
+
+			_, err := client.PublishComment(t.Context(), protocol.PublishCommentParams{
+				RootKey: "root-1", Body: "Body", OperationID: "operation-1",
+			})
+			require.ErrorIs(t, err, ErrProtocolFailure)
+			assert.EqualError(t, err, "external connector protocol failed")
+		})
+	}
+}
+
+func TestProcessClientRejectsInvalidPublicationOperationIDBeforeLaunch(t *testing.T) {
+	for _, operationID := range []string{"", " operation-1 "} {
+		t.Run(strconv.Quote(operationID), func(t *testing.T) {
+			marker := filepath.Join(t.TempDir(), "launched")
+			t.Setenv("HELPER_MODE", "launch-marker")
+			t.Setenv("HELPER_SYNC", marker)
+			client := newHelperClient(t, config.ConnectorConfig{
+				ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+				Env: map[string]string{"MODE": "HELPER_MODE", "SYNC": "HELPER_SYNC"},
+			})
+
+			_, err := client.PublishComment(t.Context(), protocol.PublishCommentParams{
+				RootKey: "root-1", Body: "Body", OperationID: operationID,
+			})
+			require.ErrorContains(t, err, "operation_id")
+			_, statErr := os.Stat(marker)
+			require.ErrorIs(t, statErr, fs.ErrNotExist)
+		})
+	}
+}
+
+func TestProcessClientRejectsInvalidWriteFieldBeforeLaunch(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "launched")
+	t.Setenv("HELPER_MODE", "launch-marker")
+	t.Setenv("HELPER_SYNC", marker)
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"MODE": "HELPER_MODE", "SYNC": "HELPER_SYNC"},
+	})
+
+	_, err := client.WriteFields(t.Context(), protocol.WriteFieldsParams{
+		RootKey: "root-1",
+		Fields:  map[string]protocol.FieldValue{"field-1": {Kind: "date", Value: "tomorrow"}},
+	})
+	require.ErrorContains(t, err, "field value")
+	_, statErr := os.Stat(marker)
+	require.ErrorIs(t, statErr, fs.ErrNotExist)
+}
+
+func TestProcessClientExecutableFailureDoesNotExposePath(t *testing.T) {
+	privatePath := filepath.Join(t.TempDir(), "private-executable-name")
+	client := newHelperClient(t, config.ConnectorConfig{ID: "notes", Command: privatePath})
+
+	_, err := client.Describe(t.Context())
+
+	require.ErrorIs(t, err, ErrProcessFailure)
+	assert.EqualError(t, err, "external connector process failed")
+	assert.NotContains(t, err.Error(), privatePath)
+	assert.NotContains(t, err.Error(), "private-executable-name")
+}
+
+func TestProcessClientFailureCauseIsInspectableButNotRendered(t *testing.T) {
+	t.Setenv("HELPER_MODE", "exit")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"MODE": "HELPER_MODE"},
+	})
+
+	_, err := client.Describe(t.Context())
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.EqualError(t, err, "external connector process failed")
+	assert.NotContains(t, err.Error(), "sensitive stderr")
+}
+
+func TestAwaitCommandOutcomePreservesRecordedProcessResultAfterParentEnds(t *testing.T) {
+	parent, cancel := context.WithCancel(t.Context())
+	waitResult := make(chan error, 1)
+	processErr := errors.New("opaque process failure detail")
+	waitResult <- processErr
+	cancel()
+	killCalls := 0
+
+	runErr, contextCause := awaitCommandOutcome(parent, waitResult, func() error {
+		killCalls++
+		return nil
+	})
+
+	assert.Same(t, processErr, runErr)
+	assert.NoError(t, contextCause)
+	assert.Zero(t, killCalls)
+}
+
+func TestAwaitCommandOutcomeContextWinnerKillsAndWaitsOnce(t *testing.T) {
+	parent, cancel := context.WithCancel(t.Context())
+	waitResult := make(chan error, 1)
+	killed := make(chan struct{}, 1)
+	killCalls := 0
+	type result struct {
+		runErr       error
+		contextCause error
+	}
+	finished := make(chan result, 1)
+	go func() {
+		runErr, contextCause := awaitCommandOutcome(parent, waitResult, func() error {
+			killCalls++
+			killed <- struct{}{}
+			return nil
+		})
+		finished <- result{runErr: runErr, contextCause: contextCause}
+	}()
+
+	cancel()
+	select {
+	case <-killed:
+	case <-time.After(time.Second):
+		t.Fatal("context winner did not kill the child")
+	}
+	select {
+	case <-finished:
+		t.Fatal("context winner returned before the child was reaped")
+	default:
+	}
+	waitResult <- errors.New("synthetic killed process result")
+	got := <-finished
+	assert.NoError(t, got.runErr)
+	assert.ErrorIs(t, got.contextCause, context.Canceled)
+	assert.Equal(t, 1, killCalls)
+}
+
+func TestAwaitCommandOutcomeTerminationFailureIsBounded(t *testing.T) {
+	parent, cancel := context.WithCancel(t.Context())
+	waitResult := make(chan error, 1)
+	terminationErr := errors.New("opaque termination failure")
+	finished := make(chan struct {
+		runErr       error
+		contextCause error
+	}, 1)
+	go func() {
+		runErr, contextCause := awaitCommandOutcome(parent, waitResult, func() error {
+			return terminationErr
+		})
+		finished <- struct {
+			runErr       error
+			contextCause error
+		}{runErr: runErr, contextCause: contextCause}
+	}()
+	cancel()
+
+	select {
+	case result := <-finished:
+		assert.ErrorIs(t, result.runErr, terminationErr)
+		assert.NoError(t, result.contextCause)
+	case <-time.After(3 * connectorProcessCleanupGrace):
+		waitResult <- errors.New("cleanup after failed bounded assertion")
+		t.Fatal("termination failure left connector cleanup waiting indefinitely")
+	}
+}
+
+func TestAwaitCommandOutcomeReapWaitIsBounded(t *testing.T) {
+	parent, cancel := context.WithCancel(t.Context())
+	waitResult := make(chan error, 1)
+	finished := make(chan struct {
+		runErr       error
+		contextCause error
+	}, 1)
+	go func() {
+		runErr, contextCause := awaitCommandOutcome(parent, waitResult, func() error { return nil })
+		finished <- struct {
+			runErr       error
+			contextCause error
+		}{runErr: runErr, contextCause: contextCause}
+	}()
+	cancel()
+
+	select {
+	case result := <-finished:
+		require.Error(t, result.runErr)
+		assert.NoError(t, result.contextCause)
+	case <-time.After(3 * connectorProcessCleanupGrace):
+		waitResult <- errors.New("cleanup after failed bounded assertion")
+		t.Fatal("connector cleanup waited indefinitely for process reap")
+	}
+}
+
+func TestConnectorContextErrorKeepsChildTimeoutAfterParentEnds(t *testing.T) {
+	parent, cancelParent := context.WithCancel(t.Context())
+	commandCtx, cancelCommand := context.WithTimeoutCause(
+		parent, time.Nanosecond, errConnectorChildTimeout,
+	)
+	defer cancelCommand()
+	<-commandCtx.Done()
+	require.ErrorIs(t, context.Cause(commandCtx), errConnectorChildTimeout)
+	cancelParent()
+
+	err := connectorContextError(parent, context.Cause(commandCtx))
+
+	require.ErrorIs(t, err, ErrRequestTimeout)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.EqualError(t, err, "external connector request timed out")
+}
+
+func TestProcessClientAlreadyEndedParentWinsBeforeStart(t *testing.T) {
+	privatePath := filepath.Join(t.TempDir(), "private-executable-name")
+	client := newHelperClient(t, config.ConnectorConfig{ID: "notes", Command: privatePath})
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := client.Describe(ctx)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, ErrProcessFailure)
+	assert.NotErrorIs(t, err, ErrProtocolFailure)
+	assert.NotErrorIs(t, err, ErrRequestTimeout)
+	assert.NotContains(t, err.Error(), privatePath)
+}
+
+func TestProcessClientBoundsTimeoutAndDoesNotExposeSettings(t *testing.T) {
+	t.Setenv("HELPER_MODE", "sleep")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"}, TimeoutSeconds: 1,
+		Env: map[string]string{"MODE": "HELPER_MODE"}, Settings: map[string]any{"private": "not-for-errors"},
+	})
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Millisecond)
+	defer cancel()
+	_, err := client.Describe(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotErrorIs(t, err, ErrRequestTimeout)
+	assert.NotErrorIs(t, err, ErrProcessFailure)
+	assert.NotErrorIs(t, err, ErrProtocolFailure)
+	assert.NotContains(t, err.Error(), "not-for-errors")
+}
+
+func TestProcessClientAppliesConfiguredTimeoutWithoutCallerDeadline(t *testing.T) {
+	t.Setenv("HELPER_MODE", "sleep")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"}, TimeoutSeconds: 1,
+		Env: map[string]string{"MODE": "HELPER_MODE"},
+	})
+
+	started := time.Now()
+	_, err := client.Describe(context.Background())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorIs(t, err, ErrRequestTimeout)
+	assert.EqualError(t, err, "external connector request timed out")
+	assert.Less(t, time.Since(started), 1500*time.Millisecond)
+}
+
+func TestProcessClientConfiguredTimeoutBoundsDescendantHeldStdout(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	t.Setenv("HELPER_MODE", "spawn-stdout-holder")
+	t.Setenv("HELPER_SYNC", readyPath)
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"}, TimeoutSeconds: 1,
+		Env: map[string]string{"MODE": "HELPER_MODE", "SYNC": "HELPER_SYNC"},
+	})
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.Describe(context.Background())
+		errCh <- err
+	}()
+
+	pid := waitForProcessClientHelperPID(t, readyPath)
+	descendant := observeProcessClientHelper(t, pid)
+	t.Cleanup(func() { killProcessClientHelper(pid) })
+	started := time.Now()
+	err := awaitBoundedProcessClientError(t, errCh, pid)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorIs(t, err, ErrRequestTimeout)
+	assert.NotErrorIs(t, err, ErrProcessFailure)
+	assert.NotErrorIs(t, err, ErrProtocolFailure)
+	assert.EqualError(t, err, "external connector request timed out")
+	assert.Less(t, time.Since(started), 3*time.Second)
+	requireProcessClientHelperGone(t, descendant)
+}
+
+func TestProcessClientParentCancellationBoundsDescendantHeldStdout(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	t.Setenv("HELPER_MODE", "spawn-stdout-holder")
+	t.Setenv("HELPER_SYNC", readyPath)
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"}, TimeoutSeconds: 30,
+		Env: map[string]string{"MODE": "HELPER_MODE", "SYNC": "HELPER_SYNC"},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.Describe(ctx)
+		errCh <- err
+	}()
+
+	pid := waitForProcessClientHelperPID(t, readyPath)
+	descendant := observeProcessClientHelper(t, pid)
+	t.Cleanup(func() { killProcessClientHelper(pid) })
+	started := time.Now()
+	cancel()
+	err := awaitBoundedProcessClientError(t, errCh, pid)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, ErrRequestTimeout)
+	assert.NotErrorIs(t, err, ErrProcessFailure)
+	assert.NotErrorIs(t, err, ErrProtocolFailure)
+	assert.EqualError(t, err, context.Canceled.Error())
+	assert.Less(t, time.Since(started), 3*time.Second)
+	requireProcessClientHelperGone(t, descendant)
+}
+
+func TestProcessClientSuccessfulCallCleansBackgroundDescendant(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	t.Setenv("HELPER_MODE", "spawn-background-holder")
+	t.Setenv("HELPER_SYNC", readyPath)
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"}, TimeoutSeconds: 5,
+		Env: map[string]string{"MODE": "HELPER_MODE", "SYNC": "HELPER_SYNC"},
+	})
+
+	_, err := client.Describe(t.Context())
+	require.NoError(t, err)
+	pid := waitForProcessClientHelperPID(t, readyPath)
+	descendant := observeProcessClientHelper(t, pid)
+	t.Cleanup(func() { killProcessClientHelper(pid) })
+	requireProcessClientHelperGone(t, descendant)
+}
+
+func TestProcessClientWaitDelayCleansDescendantHoldingStdout(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	t.Setenv("HELPER_MODE", "spawn-stdout-holder-and-exit")
+	t.Setenv("HELPER_SYNC", readyPath)
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"}, TimeoutSeconds: 5,
+		Env: map[string]string{"MODE": "HELPER_MODE", "SYNC": "HELPER_SYNC"},
+	})
+
+	_, err := client.Describe(t.Context())
+	require.ErrorIs(t, err, ErrProcessFailure)
+	pid := waitForProcessClientHelperPID(t, readyPath)
+	descendant := observeProcessClientHelper(t, pid)
+	t.Cleanup(func() { killProcessClientHelper(pid) })
+	requireProcessClientHelperGone(t, descendant)
+}
+
+func TestProcessClientRejectsMissingEnvironmentSourceWithoutValue(t *testing.T) {
+	const privateSource = "MISSING_CONNECTOR_SECRET"
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"TOKEN": privateSource},
+	})
+	_, err := client.Describe(t.Context())
+	require.ErrorIs(t, err, ErrProcessFailure)
+	assert.EqualError(t, err, "external connector process failed")
+	assert.NotContains(t, err.Error(), privateSource)
+}
+
+func TestProcessClientRedactsMappedEnvironmentValuesFromStructuredErrors(t *testing.T) {
+	t.Setenv("CONNECTOR_SECRET", "sensitive")
+	t.Setenv("HELPER_MODE", "structured-secret")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"TOKEN": "CONNECTOR_SECRET", "MODE": "HELPER_MODE"},
+	})
+	_, err := client.Describe(t.Context())
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "sensitive")
+}
+
+func TestProcessClientPreservesNonSecretConfiguredArgumentsInStructuredErrors(t *testing.T) {
+	const argumentValue = "argument-redaction-value"
+	t.Setenv("HELPER_MODE", "argument-secret")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t),
+		Args: []string{
+			"-test.run=^TestProcessClientHelper$", "--", "--label=" + argumentValue,
+		},
+		Env: map[string]string{"MODE": "HELPER_MODE"},
+	})
+	_, err := client.Describe(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--label="+argumentValue)
+	assert.Contains(t, err.Error(), argumentValue)
+}
+
+func TestProcessClientRedactsEscapedMappedEnvironmentValuesFromStructuredErrors(t *testing.T) {
+	const secret = "line\n\"quote\"\\<>&" // #nosec G101 -- synthetic redaction fixture, not a credential.
+	const encoded = `"line\n\"quote\"\\\u003c\u003e\u0026"`
+	t.Setenv("CONNECTOR_SECRET", secret)
+	t.Setenv("HELPER_MODE", "encoded-structured-secret")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"TOKEN": "CONNECTOR_SECRET", "MODE": "HELPER_MODE"},
+	})
+	_, err := client.Describe(t.Context())
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret)
+	assert.NotContains(t, err.Error(), encoded)
+}
+
+func TestProcessClientRedactsSolidusEscapedMappedEnvironmentValuesFromStructuredErrors(t *testing.T) {
+	const secret = "a/b"
+	const solidusEscaped = `"a\/b"`
+	t.Setenv("CONNECTOR_SECRET", secret)
+	t.Setenv("HELPER_MODE", "solidus-escaped-environment-secret")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"TOKEN": "CONNECTOR_SECRET", "MODE": "HELPER_MODE"},
+	})
+	_, err := client.Describe(t.Context())
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret)
+	assert.NotContains(t, err.Error(), solidusEscaped)
+}
+
+func TestProcessClientRedactsHTMLUnescapedJSONTokenFromStructuredErrors(t *testing.T) {
+	const secret = "line\n\"quote\"\\<>&"           // #nosec G101 -- synthetic redaction fixture, not a credential.
+	const unescapedToken = `"line\n\"quote\"\\<>&"` // #nosec G101 -- encoded form of the synthetic fixture.
+	t.Setenv("CONNECTOR_SECRET", secret)
+	t.Setenv("HELPER_MODE", "html-unescaped-json-token")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"TOKEN": "CONNECTOR_SECRET", "MODE": "HELPER_MODE"},
+	})
+	_, err := client.Describe(t.Context())
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret)
+	assert.NotContains(t, err.Error(), unescapedToken)
+}
+
+func TestProcessClientRedactsEmbeddedJSONEncodedEnvironmentValuesFromStructuredErrors(t *testing.T) {
+	const secret = "line\n\"quote\"\\<>&/tail" // #nosec G101 -- synthetic redaction fixture, not a credential.
+	const escapedBody = `line\n\"quote\"\\\u003c\u003e\u0026\/tail`
+	const htmlUnescapedBody = `line\n\"quote\"\\<>&\/tail`
+	const unicodeSolidusBody = `line\n\"quote\"\\\u003c\u003e\u0026\u002ftail`
+	const unicodeSolidusUpperBody = `line\n\"quote\"\\\u003c\u003e\u0026\u002Ftail`
+	const mixedHTMLBody = `line\n\"quote\"\\\u003C\u003e\u0026\/tail`
+	const partiallyEscapedHTMLBody = `line\n\"quote\"\\\u003c>&\/tail`
+	t.Setenv("CONNECTOR_SECRET", secret)
+	t.Setenv("HELPER_MODE", "embedded-encoded-environment-secret")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"TOKEN": "CONNECTOR_SECRET", "MODE": "HELPER_MODE"},
+	})
+	_, err := client.Describe(t.Context())
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret)
+	assert.NotContains(t, err.Error(), escapedBody)
+	assert.NotContains(t, err.Error(), htmlUnescapedBody)
+	assert.NotContains(t, err.Error(), unicodeSolidusBody)
+	assert.NotContains(t, err.Error(), unicodeSolidusUpperBody)
+	assert.NotContains(t, err.Error(), mixedHTMLBody)
+	assert.NotContains(t, err.Error(), partiallyEscapedHTMLBody)
+	assert.Equal(t, 6, strings.Count(err.Error(), "[redacted]"))
+}
+
+func TestProcessClientRedactsUnicodeSolidusJSONTokensFromStructuredErrors(t *testing.T) {
+	const secret = "a/b"
+	const lowerToken = `"a\u002fb"` // #nosec G101 -- encoded form of the synthetic fixture.
+	const upperToken = `"a\u002Fb"` // #nosec G101 -- encoded form of the synthetic fixture.
+	t.Setenv("CONNECTOR_SECRET", secret)
+	t.Setenv("HELPER_MODE", "unicode-solidus-json-tokens")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"TOKEN": "CONNECTOR_SECRET", "MODE": "HELPER_MODE"},
+	})
+	_, err := client.Describe(t.Context())
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), secret)
+	assert.NotContains(t, err.Error(), lowerToken)
+	assert.NotContains(t, err.Error(), upperToken)
+}
+
+func TestRedactErrorRedactsOverlappingValuesLongestFirst(t *testing.T) {
+	err := redactError(&protocol.Error{Code: "bad", Message: "prefix-suffix"}, []string{"prefix", "prefix-suffix"})
+	assert.NotContains(t, err.Error(), "prefix-suffix")
+	assert.NotContains(t, err.Error(), "suffix")
+}
+
+func TestRedactErrorPreservesUnrelatedEscapeSequences(t *testing.T) {
+	err := redactError(&protocol.Error{Code: "bad", Message: `path C:\temp\notes`}, []string{"other-secret"})
+	assert.EqualError(t, err, `bad: path C:\temp\notes`)
+}
+
+func TestRedactErrorRedactsEmbeddedJSONEncodedAstralSecret(t *testing.T) {
+	err := redactError(
+		&protocol.Error{Code: "bad", Message: `prefix token-\uD83D\uDE00 suffix`},
+		[]string{"token-😀"},
+	)
+	assert.EqualError(t, err, "bad: prefix [redacted] suffix")
+}
+
+func TestProcessClientRedactsEnvironmentSnapshotAfterParentRotation(t *testing.T) {
+	syncPath := filepath.Join(t.TempDir(), "connector-ready")
+	t.Setenv("CONNECTOR_SECRET", "initial-secret")
+	t.Setenv("HELPER_MODE", "delayed-structured-secret")
+	t.Setenv("HELPER_SYNC", syncPath)
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"TOKEN": "CONNECTOR_SECRET", "MODE": "HELPER_MODE", "SYNC": "HELPER_SYNC"},
+	})
+
+	errs := make(chan error, 1)
+	go func() {
+		_, err := client.Describe(t.Context())
+		errs <- err
+	}()
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(syncPath)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+	t.Setenv("CONNECTOR_SECRET", "rotated-secret")
+	err := <-errs
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "initial-secret")
+}
+
+func TestProcessClientPreservesNonSecretSettingsScalarsInStructuredErrors(t *testing.T) {
+	t.Setenv("HELPER_MODE", "settings-secret")
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"MODE": "HELPER_MODE"}, Settings: map[string]any{"enabled": true, "retries": 7},
+	})
+	_, err := client.Describe(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"enabled":true`)
+	assert.Contains(t, err.Error(), `"retries":7`)
+}
+
+func newHelperClient(t *testing.T, cfg config.ConnectorConfig) *processClient {
+	t.Helper()
+	normalized, err := config.NormalizeConnectorConfigs([]config.ConnectorConfig{cfg})
+	require.NoError(t, err)
+	return newProcessClient(normalized[0])
+}
+
+func helperBinary(t *testing.T) string {
+	t.Helper()
+	path, err := os.Executable()
+	require.NoError(t, err)
+	return path
+}
+
+func TestProcessClientStdoutHolderHelper(_ *testing.T) {
+	if !strings.Contains(strings.Join(os.Args, " "), "--connector-stdout-holder") {
+		return
+	}
+	time.Sleep(24 * time.Hour)
+}
+
+func TestProcessClientHelper(_ *testing.T) {
+	if !strings.Contains(strings.Join(os.Args, " "), "TestProcessClientHelper") {
+		return
+	}
+	serveProcessClientHelper()
+	os.Exit(0)
+}
+
+func serveProcessClientHelper() {
+	if os.Getenv("MODE") == "launch-marker" {
+		if err := os.WriteFile(os.Getenv("SYNC"), []byte("launched"), 0o600); err != nil { // #nosec G703 -- test-owned temporary path.
+			os.Exit(11)
+		}
+	}
+	var request protocol.Request
+	if err := json.NewDecoder(os.Stdin).Decode(&request); err != nil {
+		os.Exit(2)
+	}
+	if os.Getenv("MODE") == "sleep" {
+		time.Sleep(time.Second)
+		return
+	}
+	if os.Getenv("MODE") == "spawn-stdout-holder" ||
+		os.Getenv("MODE") == "spawn-stdout-holder-and-exit" ||
+		os.Getenv("MODE") == "spawn-background-holder" {
+		child := exec.Command( // #nosec G204,G702 -- the test starts its own fixed executable and helper arguments.
+			os.Args[0], "-test.run=^TestProcessClientStdoutHolderHelper$", "--", "--connector-stdout-holder",
+		)
+		if os.Getenv("MODE") == "spawn-stdout-holder" || os.Getenv("MODE") == "spawn-stdout-holder-and-exit" {
+			child.Stdout = os.Stdout
+		}
+		if err := child.Start(); err != nil {
+			os.Exit(8)
+		}
+		readyPath := os.Getenv("SYNC")
+		readyTempPath := readyPath + ".tmp"
+		if err := os.WriteFile(readyTempPath, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil { // #nosec G703 -- test-owned temporary path.
+			os.Exit(9)
+		}
+		if err := os.Rename(readyTempPath, readyPath); err != nil { // #nosec G703 -- test-owned temporary paths.
+			os.Exit(10)
+		}
+		if os.Getenv("MODE") == "spawn-stdout-holder" {
+			time.Sleep(24 * time.Hour)
+			return
+		}
+	}
+	if os.Getenv("MODE") == "exit" {
+		_, _ = fmt.Fprintln(os.Stderr, "sensitive stderr")
+		os.Exit(7)
+	}
+	response := protocol.Response{Protocol: protocol.ProtocolVersion, ID: request.ID}
+	observed := observedEnvironment()
+	if !reflect.DeepEqual(observed, expectedEnvironment(os.Getenv("MODE"))) {
+		response.Error = &protocol.Error{Code: "environment", Message: "unexpected connector environment"}
+		_ = json.NewEncoder(os.Stdout).Encode(response)
+		return
+	}
+	switch os.Getenv("MODE") {
+	case "wrong-id":
+		response.ID = "other"
+	case "unsupported-version":
+		response.Protocol = "unsupported.connector.protocol"
+	case "both":
+		response.Result = json.RawMessage(`{}`)
+		response.Error = &protocol.Error{Code: "bad", Message: "bad"}
+	case "neither":
+	case "null-result":
+		response.Result = json.RawMessage(`null`)
+	case "raw-result":
+		response.Result = json.RawMessage(os.Getenv("RESULT"))
+	case "publication-result":
+		if request.Method == "describe" {
+			response.Result = publicationDescriptionResult()
+		} else {
+			response.Result = json.RawMessage(os.Getenv("RESULT"))
+		}
+	case "native-runtime-paths":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			os.Exit(12)
+		}
+		for _, directory := range []string{"", os.Getenv("TEMP"), os.Getenv("TMP"), home} {
+			file, err := os.CreateTemp(directory, "connector-child-")
+			if err != nil {
+				os.Exit(13)
+			}
+			if err := file.Close(); err != nil {
+				os.Exit(14)
+			}
+		}
+		response.Result = describeResult()
+	case "malformed":
+		_, _ = os.Stdout.WriteString("{")
+		return
+	case "invalid-utf8":
+		_, _ = fmt.Fprintf(os.Stdout, `{"protocol":%q,"id":%q,"result":{"connector_id":"fake`, protocol.ProtocolVersion, request.ID)
+		_, _ = os.Stdout.Write([]byte{0xff})
+		_, _ = os.Stdout.WriteString(`connector","display_name":"Fake","protocol":"kata.connector.v1","capabilities":[],"account_identity":"account-1"}}`)
+		return
+	case "require-empty-settings":
+		if string(request.Settings) != `{}` {
+			response.Error = &protocol.Error{Code: "settings", Message: "settings must be an object"}
+			break
+		}
+		response.Result = describeResult()
+	case "trailing":
+		response.Result = describeResult()
+		_ = json.NewEncoder(os.Stdout).Encode(response)
+		_, _ = os.Stdout.WriteString("{}")
+		return
+	case "oversized":
+		response.Result = json.RawMessage(`"` + strings.Repeat("x", 4<<20) + `"`)
+	case "structured-secret":
+		response.Error = &protocol.Error{Code: "bad", Message: os.Getenv("TOKEN")}
+	case "argument-secret":
+		response.Error = &protocol.Error{
+			Code:    "bad",
+			Message: "configured --label=argument-redaction-value value argument-redaction-value",
+		}
+	case "encoded-structured-secret":
+		encoded, err := json.Marshal(os.Getenv("TOKEN"))
+		if err != nil {
+			os.Exit(2)
+		}
+		response.Error = &protocol.Error{Code: "bad", Message: string(encoded)}
+	case "solidus-escaped-environment-secret":
+		if os.Getenv("TOKEN") != "a/b" {
+			os.Exit(2)
+		}
+		response.Error = &protocol.Error{Code: "bad", Message: `"a\/b"`}
+	case "html-unescaped-json-token":
+		if os.Getenv("TOKEN") != "line\n\"quote\"\\<>&" {
+			os.Exit(2)
+		}
+		response.Error = &protocol.Error{Code: "bad", Message: `"line\n\"quote\"\\<>&"`}
+	case "embedded-encoded-environment-secret":
+		if os.Getenv("TOKEN") != "line\n\"quote\"\\<>&/tail" {
+			os.Exit(2)
+		}
+		response.Error = &protocol.Error{
+			Code: `prefix line\n\"quote\"\\\u003c\u003e\u0026\u002ftail middle ` +
+				`line\n\"quote\"\\\u003c\u003e\u0026\u002Ftail middle ` +
+				`line\n\"quote\"\\\u003C\u003e\u0026\/tail suffix`,
+			Message: `prefix line\n\"quote\"\\\u003c\u003e\u0026\/tail middle ` +
+				`line\n\"quote\"\\\u003c>&\/tail middle ` +
+				`line\n\"quote\"\\<>&\/tail suffix`,
+		}
+	case "unicode-solidus-json-tokens":
+		if os.Getenv("TOKEN") != "a/b" {
+			os.Exit(2)
+		}
+		response.Error = &protocol.Error{Code: `"a\u002fb"`, Message: `"a\u002Fb"`}
+	case "delayed-structured-secret":
+		_ = os.WriteFile(os.Getenv("SYNC"), []byte("ready"), 0o600) // #nosec G703 -- the test supplies a private temporary path.
+		time.Sleep(100 * time.Millisecond)
+		response.Error = &protocol.Error{Code: "bad", Message: os.Getenv("TOKEN")}
+	case "settings-secret":
+		response.Error = &protocol.Error{Code: "bad", Message: string(request.Settings)}
+	case "solidus-escaped-settings-secret":
+		if string(request.Settings) != `{"token":"a/b"}` {
+			os.Exit(2)
+		}
+		response.Error = &protocol.Error{Code: "bad", Message: `"a\/b"`}
+	default:
+		response.Result = describeResult()
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(response)
+}
+
+func observedEnvironment() []string {
+	keys := []string{"TOKEN", "CONNECTOR_SECRET", "UNRELATED_SECRET", "MODE", "RESULT", "SYNC"}
+	observed := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if _, ok := os.LookupEnv(key); ok {
+			observed = append(observed, key)
+		}
+	}
+	return observed
+}
+
+func expectedEnvironment(mode string) []string {
+	if mode == "structured-secret" || mode == "encoded-structured-secret" || mode == "solidus-escaped-environment-secret" || mode == "html-unescaped-json-token" || mode == "embedded-encoded-environment-secret" || mode == "unicode-solidus-json-tokens" {
+		return []string{"TOKEN", "MODE"}
+	}
+	if mode == "delayed-structured-secret" {
+		return []string{"TOKEN", "MODE", "SYNC"}
+	}
+	if mode == "raw-result" || mode == "publication-result" {
+		return []string{"MODE", "RESULT"}
+	}
+	if mode == "spawn-stdout-holder" || mode == "spawn-stdout-holder-and-exit" || mode == "spawn-background-holder" || mode == "launch-marker" {
+		return []string{"MODE", "SYNC"}
+	}
+	if mode != "" {
+		return []string{"MODE"}
+	}
+	return []string{"TOKEN"}
+}
+
+func waitForProcessClientHelperPID(t *testing.T, readyPath string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(readyPath) // #nosec G304 -- test-owned temporary path.
+		if err == nil {
+			pid, err := strconv.Atoi(string(data))
+			require.NoError(t, err)
+			return pid
+		}
+		require.ErrorIs(t, err, fs.ErrNotExist)
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("connector helper did not signal readiness")
+	return 0
+}
+
+func awaitBoundedProcessClientError(t *testing.T, errCh <-chan error, descendantPID int) error {
+	t.Helper()
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(3 * time.Second):
+		killProcessClientHelper(descendantPID)
+		select {
+		case <-errCh:
+		case <-time.After(3 * time.Second):
+			t.Fatal("connector call remained blocked after descendant cleanup")
+		}
+		t.Fatal("connector call exceeded its bounded cleanup period")
+		return nil
+	}
+}
+
+func killProcessClientHelper(pid int) {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	_ = process.Kill()
+	_ = process.Release()
+}
+
+func describeResult() json.RawMessage {
+	b, err := json.Marshal(protocol.Description{
+		ConnectorID: "fake.connector", DisplayName: "Fake", Protocol: protocol.ProtocolVersion,
+		Capabilities: []protocol.Capability{}, AccountIdentity: "account-1", ConfigSchema: mustJSON(map[string]any{"type": "object"}),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func publicationDescriptionResult() json.RawMessage {
+	b, err := json.Marshal(protocol.Description{
+		ConnectorID: "fake.connector", DisplayName: "Fake", Protocol: protocol.ProtocolVersion,
+		Capabilities: []protocol.Capability{protocol.CapabilityPublishComment}, SelfActorID: "actor-self",
+		AccountIdentity: "account-1", ConfigSchema: mustJSON(map[string]any{"type": "object"}),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/internal/connector/fakeconnector/audit.go
+++ b/internal/connector/fakeconnector/audit.go
@@ -1,0 +1,41 @@
+package fakeconnector
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.kenn.io/kata/internal/connector/identityaudit"
+)
+
+// AuditExternalSurface validates every raw fake call and mutation against the
+// provider-neutral protocol surface and the supplied local identities.
+func AuditExternalSurface(current State, externalRootKey string, longUIDs, shortIDs []string) error {
+	options := identityaudit.Options{
+		ExternalRootKey: externalRootKey,
+		LongUIDs:        longUIDs,
+		ShortIDs:        shortIDs,
+	}
+	for _, recorded := range recordedExternalParams(current) {
+		if err := identityaudit.Validate(recorded.method, recorded.params, options); err != nil {
+			return fmt.Errorf("%s %q: %w", recorded.kind, recorded.method, err)
+		}
+	}
+	return nil
+}
+
+type recordedParams struct {
+	kind   string
+	method string
+	params json.RawMessage
+}
+
+func recordedExternalParams(current State) []recordedParams {
+	result := make([]recordedParams, 0, len(current.Calls)+len(current.Mutations))
+	for _, call := range current.Calls {
+		result = append(result, recordedParams{kind: "call", method: call.Method, params: call.Params})
+	}
+	for _, mutation := range current.Mutations {
+		result = append(result, recordedParams{kind: "mutation", method: mutation.Method, params: mutation.Params})
+	}
+	return result
+}

--- a/internal/connector/fakeconnector/audit_test.go
+++ b/internal/connector/fakeconnector/audit_test.go
@@ -1,0 +1,33 @@
+package fakeconnector
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAuditExternalSurfaceUsesSharedParameterValidation(t *testing.T) {
+	for _, call := range []Call{
+		{Method: "resolve_root", Params: json.RawMessage(`{"locator":7}`)},
+		{Method: "write_fields", Params: json.RawMessage(`{"root_key":"root-example","fields":{"field-example":{"kind":"null","kataOwnerId":"neutral-forbidden"}}}`)},
+	} {
+		current := State{Calls: []Call{call}}
+		if err := AuditExternalSurface(current, "root-example", nil, nil); err == nil {
+			t.Fatalf("%s invalid params accepted: %s", call.Method, call.Params)
+		}
+	}
+}
+
+func TestAuditExternalSurfaceTreatsReadFieldSelectorsAsOpaque(t *testing.T) {
+	current := State{Calls: []Call{{
+		Method: "read_fields",
+		Params: json.RawMessage(`{"root_key":"root-example","field_ids":["root-short","prefix-01ARZ3NDEKTSV4RRFFQ69G5FAV-suffix","kataOwnerId"]}`),
+	}}}
+	if err := AuditExternalSurface(
+		current,
+		"root-example",
+		[]string{"01ARZ3NDEKTSV4RRFFQ69G5FAV"},
+		[]string{"root-short"},
+	); err != nil {
+		t.Fatalf("opaque field selectors rejected: %v", err)
+	}
+}

--- a/internal/connector/fakeconnector/cmd/main.go
+++ b/internal/connector/fakeconnector/cmd/main.go
@@ -1,0 +1,19 @@
+// Command fakeconnector is the executable wrapper for the shared black-box fixture.
+package main
+
+import (
+	"flag"
+	"os"
+	"strings"
+
+	"go.kenn.io/kata/internal/connector/fakeconnector"
+)
+
+func main() {
+	statePath := flag.String("state", "", "test-owned JSON state")
+	flag.Parse()
+	if strings.TrimSpace(*statePath) == "" {
+		os.Exit(1)
+	}
+	os.Exit(fakeconnector.Run(*statePath, os.Stdin, os.Stdout))
+}

--- a/internal/connector/fakeconnector/conformance_test.go
+++ b/internal/connector/fakeconnector/conformance_test.go
@@ -1,0 +1,132 @@
+package fakeconnector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.kenn.io/kata/pkg/connector"
+	connectorconformance "go.kenn.io/kata/pkg/connector/conformance"
+)
+
+func TestPublicConformance(t *testing.T) {
+	fixture := &conformanceFixture{path: filepath.Join(t.TempDir(), "state.json")}
+	connectorconformance.Run(t, fixture)
+}
+
+type conformanceFixture struct{ path string }
+
+func (f *conformanceFixture) RootLocator() string { return "fixture-root" }
+
+func (f *conformanceFixture) Invocation() connector.Invocation {
+	return connector.Invocation{Instance: "example-instance", Settings: json.RawMessage(`{}`)}
+}
+
+func (f *conformanceFixture) Exchange(_ context.Context, request []byte) ([]byte, error) {
+	var response bytes.Buffer
+	if code := Run(f.path, bytes.NewReader(request), &response); code != 0 {
+		return response.Bytes(), fmt.Errorf("fake connector exited with status %d", code)
+	}
+	return response.Bytes(), nil
+}
+
+func (f *conformanceFixture) InjectFault(_ context.Context, fault connectorconformance.Fault) error {
+	if fault != connectorconformance.FaultPublishCommentCrashAfterMutation {
+		return fmt.Errorf("unsupported fault %q", fault)
+	}
+	return Update(f.path, func(current *State) error {
+		if current.Behavior.CrashAfterMutation == nil {
+			current.Behavior.CrashAfterMutation = make(map[string]int)
+		}
+		current.Behavior.CrashAfterMutation["publish_comment"]++
+		return nil
+	})
+}
+
+func (f *conformanceFixture) MutateComment(_ context.Context, commentID string) error {
+	return Update(f.path, func(current *State) error {
+		for rootIndex := range current.Roots {
+			for commentIndex := range current.Roots[rootIndex].Comments {
+				comment := &current.Roots[rootIndex].Comments[commentIndex]
+				if comment.ID != commentID {
+					continue
+				}
+				comment.Body = "Externally edited comment"
+				comment.UpdatedAt = comment.UpdatedAt.Add(time.Minute)
+				comment.Revision = "comment-revision-after-edit"
+				return nil
+			}
+		}
+		return fmt.Errorf("provider state lacks comment %q", commentID)
+	})
+}
+
+func (f *conformanceFixture) Reset(context.Context) error {
+	observed := time.Now().UTC()
+	updated := observed.Add(-10 * time.Minute)
+	return Write(f.path, State{
+		Description: connector.Description{
+			ConnectorID: "example.connector", DisplayName: "Example Connector", Protocol: connector.ProtocolVersion,
+			Capabilities: []connector.Capability{connector.CapabilityFields, connector.CapabilityPublishComment},
+			ConfigSchema: []byte(`{"type":"object","additionalProperties":false}`), SelfActorID: "actor-self",
+			AccountIdentity: "account-example",
+		},
+		Roots: []StoredRoot{{
+			Locator: "fixture-root",
+			Root: connector.Root{
+				Key: "root-example", IdentityKey: "account-example", Title: "Example root", Body: "Example body",
+				State: "open", Revision: "revision-1", UpdatedAt: updated, ObservedAt: observed,
+				Fields: map[string]connector.FieldValue{
+					"field-date":     {Kind: "date", Value: "2026-08-20"},
+					"field-local":    {Kind: "local_datetime", Value: "2026-08-20T11:30:00", Timezone: "Europe/Paris"},
+					"field-instant":  {Kind: "instant", Value: "2026-08-20T09:30:00Z"},
+					"field-null":     {Kind: "null"},
+					"field-readonly": {Kind: "date", Value: "2026-08-20"},
+				},
+			},
+			Comments: []connector.Comment{
+				{ID: "comment-before", Revision: "comment-revision-1", Body: "Existing comment", Author: connector.Actor{ID: "actor-history", DisplayName: "Historical Reviewer"}, CreatedAt: updated.Add(-time.Minute), UpdatedAt: updated.Add(-time.Minute)},
+				{ID: "comment-active", Revision: "comment-revision-2", Body: "Active comment", Author: connector.Actor{ID: "actor-a", DisplayName: "Reviewer A"}, CreatedAt: updated.Add(time.Minute), UpdatedAt: updated.Add(time.Minute)},
+				{ID: "comment-edited", Revision: "comment-revision-3", Body: "Corrected comment", Author: connector.Actor{ID: "actor-b", DisplayName: "Reviewer B"}, CreatedAt: updated.Add(2 * time.Minute), UpdatedAt: updated.Add(3 * time.Minute)},
+				{ID: "comment-deleted", Revision: "comment-revision-4", Author: connector.Actor{ID: "actor-c", DisplayName: "Reviewer C"}, CreatedAt: updated.Add(4 * time.Minute), UpdatedAt: updated.Add(5 * time.Minute), Deleted: true},
+			},
+			Fields: map[string]connector.FieldValue{
+				"field-date":     {Kind: "date", Value: "2026-08-20"},
+				"field-local":    {Kind: "local_datetime", Value: "2026-08-20T11:30:00", Timezone: "Europe/Paris"},
+				"field-instant":  {Kind: "instant", Value: "2026-08-20T09:30:00Z"},
+				"field-null":     {Kind: "null"},
+				"field-readonly": {Kind: "date", Value: "2026-08-20"},
+			},
+		}},
+		Fields: []connector.FieldDescriptor{
+			{ID: "field-date", DisplayName: "Date", AcceptedKinds: []string{"date"}, Nullable: true, Writable: true, SchemaRevision: "schema-1"},
+			{ID: "field-local", DisplayName: "Local", AcceptedKinds: []string{"local_datetime"}, Nullable: true, Writable: true, SchemaRevision: "schema-1"},
+			{ID: "field-instant", DisplayName: "Instant", AcceptedKinds: []string{"instant"}, Nullable: true, Writable: true, SchemaRevision: "schema-1"},
+			{ID: "field-null", DisplayName: "Nullable", AcceptedKinds: []string{"date", "local_datetime", "instant"}, Nullable: true, Writable: true, SchemaRevision: "schema-1"},
+			{ID: "field-readonly", DisplayName: "Read only", AcceptedKinds: []string{"date"}, Writable: false, SchemaRevision: "schema-1"},
+		},
+		Behavior: Behavior{CrashBeforeReply: map[string]int{}, CrashAfterMutation: map[string]int{}, Errors: map[string]connector.Error{}},
+	})
+}
+
+func (f *conformanceFixture) ExternalState(context.Context) (connectorconformance.RootState, error) {
+	current, err := Load(f.path)
+	if err != nil {
+		return connectorconformance.RootState{}, err
+	}
+	if len(current.Roots) != 1 {
+		return connectorconformance.RootState{}, fmt.Errorf("fake connector roots = %d, want 1", len(current.Roots))
+	}
+	mutations := make([]connectorconformance.Mutation, len(current.Mutations))
+	for index, mutation := range current.Mutations {
+		mutations[index] = connectorconformance.Mutation{Method: mutation.Method, Params: mutation.Params}
+	}
+	return connectorconformance.RootState{
+		Root: current.Roots[0].Root, Comments: current.Roots[0].Comments,
+		Fields: current.Roots[0].Fields, Mutations: mutations,
+	}, nil
+}

--- a/internal/connector/fakeconnector/fakeconnector.go
+++ b/internal/connector/fakeconnector/fakeconnector.go
@@ -1,0 +1,498 @@
+// Package fakeconnector provides a deterministic protocol-v1 implementation
+// for Kata's black-box connector tests.
+package fakeconnector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"go.kenn.io/kata/pkg/connector"
+)
+
+const (
+	exitFailure            = 1
+	exitCrashBeforeReply   = 41
+	exitCrashAfterMutation = 42
+)
+
+// State is the complete test-owned on-disk connector state.
+type State struct {
+	Description  connector.Description        `json:"description"`
+	Roots        []StoredRoot                 `json:"roots"`
+	Fields       []connector.FieldDescriptor  `json:"fields"`
+	Mutations    []Mutation                   `json:"mutations"`
+	Calls        []Call                       `json:"calls"`
+	Behavior     Behavior                     `json:"behavior"`
+	NextComment  int                          `json:"next_comment"`
+	Publications map[string]connector.Comment `json:"publications,omitempty"`
+}
+
+// StoredRoot joins a disposable locator to its provider-side root state.
+type StoredRoot struct {
+	Locator  string                          `json:"locator"`
+	Root     connector.Root                  `json:"root"`
+	Comments []connector.Comment             `json:"comments"`
+	Fields   map[string]connector.FieldValue `json:"fields"`
+}
+
+// Mutation records one provider-side mutation and its raw parameters.
+type Mutation struct {
+	Sequence int             `json:"sequence"`
+	Method   string          `json:"method"`
+	Params   json.RawMessage `json:"params"`
+}
+
+// Call records one protocol request and its raw parameters.
+type Call struct {
+	Sequence int             `json:"sequence"`
+	Method   string          `json:"method"`
+	Params   json.RawMessage `json:"params"`
+}
+
+// Behavior configures deterministic crash and error responses.
+type Behavior struct {
+	CrashBeforeReply   map[string]int             `json:"crash_before_reply,omitempty"`
+	CrashAfterMutation map[string]int             `json:"crash_after_mutation,omitempty"`
+	Errors             map[string]connector.Error `json:"errors,omitempty"`
+	ResponseProtocol   string                     `json:"response_protocol,omitempty"`
+}
+
+type handler struct {
+	path       string
+	params     json.RawMessage
+	crashAfter bool
+}
+
+// NewHandler returns a handler backed by the test-owned state file.
+func NewHandler(path string) connector.Handler { return &handler{path: path} }
+
+// Run serves one complete protocol request using the test-owned state file.
+func Run(path string, in io.Reader, out io.Writer) int {
+	requestBytes, err := io.ReadAll(in)
+	if err != nil {
+		return exitFailure
+	}
+	var request connector.Request
+	if err := json.Unmarshal(requestBytes, &request); err != nil {
+		return exitFailure
+	}
+	crash, err := consumeCounter(path, request.Method, true)
+	if err != nil {
+		return exitFailure
+	}
+	if crash {
+		return exitCrashBeforeReply
+	}
+	if err := Update(path, func(current *State) error {
+		current.Calls = append(current.Calls, Call{
+			Sequence: len(current.Calls) + 1,
+			Method:   request.Method,
+			Params:   append(json.RawMessage(nil), request.Params...),
+		})
+		return nil
+	}); err != nil {
+		return exitFailure
+	}
+
+	h := &handler{path: path, params: append(json.RawMessage(nil), request.Params...)}
+	var response bytes.Buffer
+	if err := connector.ServeOne(context.Background(), bytes.NewReader(requestBytes), &response, h); err != nil {
+		return exitFailure
+	}
+	if h.crashAfter {
+		return exitCrashAfterMutation
+	}
+	current, err := Load(path)
+	if err != nil {
+		return exitFailure
+	}
+	if override := strings.TrimSpace(current.Behavior.ResponseProtocol); override != "" {
+		var decoded connector.Response
+		if err := json.Unmarshal(response.Bytes(), &decoded); err != nil {
+			return exitFailure
+		}
+		decoded.Protocol = override
+		response.Reset()
+		if err := json.NewEncoder(&response).Encode(decoded); err != nil {
+			return exitFailure
+		}
+	}
+	if _, err := io.Copy(out, &response); err != nil {
+		return exitFailure
+	}
+	return 0
+}
+
+func (h *handler) Describe(context.Context, connector.DescribeParams) (connector.Description, *connector.Error) {
+	current, callErr := h.read("describe")
+	if callErr != nil {
+		return connector.Description{}, callErr
+	}
+	description := current.Description
+	description.Capabilities = append([]connector.Capability(nil), description.Capabilities...)
+	description.ConfigSchema = append(json.RawMessage(nil), description.ConfigSchema...)
+	slices.Sort(description.Capabilities)
+	return description, nil
+}
+
+func (h *handler) ResolveRoot(_ context.Context, params connector.ResolveRootParams) (connector.Root, *connector.Error) {
+	current, callErr := h.read("resolve_root")
+	if callErr != nil {
+		return connector.Root{}, callErr
+	}
+	for _, candidate := range current.Roots {
+		if candidate.Locator == params.Locator || candidate.Root.Key == params.Locator {
+			return cloneRoot(candidate.Root), nil
+		}
+	}
+	return connector.Root{}, notFound("root")
+}
+
+func (h *handler) ReadRoot(_ context.Context, params connector.ReadRootParams) (connector.Root, *connector.Error) {
+	current, callErr := h.read("read_root")
+	if callErr != nil {
+		return connector.Root{}, callErr
+	}
+	root, ok := findRoot(&current, params.RootKey)
+	if !ok {
+		return connector.Root{}, notFound("root")
+	}
+	return cloneRoot(root.Root), nil
+}
+
+func (h *handler) ListComments(_ context.Context, params connector.ListCommentsParams) (connector.ListCommentsResult, *connector.Error) {
+	current, callErr := h.read("list_comments")
+	if callErr != nil {
+		return connector.ListCommentsResult{}, callErr
+	}
+	root, ok := findRoot(&current, params.RootKey)
+	if !ok {
+		return connector.ListCommentsResult{}, notFound("root")
+	}
+	comments := append([]connector.Comment(nil), root.Comments...)
+	sort.SliceStable(comments, func(i, j int) bool {
+		if comments[i].CreatedAt.Equal(comments[j].CreatedAt) {
+			return comments[i].ID < comments[j].ID
+		}
+		return comments[i].CreatedAt.Before(comments[j].CreatedAt)
+	})
+	return connector.ListCommentsResult{Comments: comments}, nil
+}
+
+func (h *handler) CompleteRoot(_ context.Context, params connector.CompleteRootParams) (connector.Root, *connector.Error) {
+	var result connector.Root
+	callErr := h.mutate("complete_root", func(current *State) *connector.Error {
+		root, ok := findRoot(current, params.RootKey)
+		if !ok {
+			return notFound("root")
+		}
+		current.record(h.recordedMutation("complete_root", params))
+		if !strings.EqualFold(strings.TrimSpace(root.Root.State), "complete") {
+			root.Root.State = "complete"
+			advanceRoot(&root.Root, len(current.Mutations), nextProviderTime(root))
+		}
+		result = cloneRoot(root.Root)
+		return nil
+	})
+	return result, callErr
+}
+
+func (h *handler) PublishComment(_ context.Context, params connector.PublishCommentParams) (connector.Comment, *connector.Error) {
+	var result connector.Comment
+	callErr := h.mutate("publish_comment", func(current *State) *connector.Error {
+		root, ok := findRoot(current, params.RootKey)
+		if !ok {
+			return notFound("root")
+		}
+		if result, ok = current.Publications[params.OperationID]; ok {
+			return nil
+		}
+		current.NextComment++
+		stamp := nextProviderTime(root)
+		result = connector.Comment{
+			ID: fmt.Sprintf("published-%04d", current.NextComment), Revision: fmt.Sprintf("comment-revision-%04d", current.NextComment), Body: params.Body,
+			Author:    connector.Actor{ID: current.Description.SelfActorID, DisplayName: "Connector Actor"},
+			CreatedAt: stamp, UpdatedAt: stamp,
+		}
+		if current.Publications == nil {
+			current.Publications = make(map[string]connector.Comment)
+		}
+		current.Publications[params.OperationID] = result
+		root.Comments = append(root.Comments, result)
+		current.record(h.recordedMutation("publish_comment", params))
+		return nil
+	})
+	return result, callErr
+}
+
+func (h *handler) ListFields(context.Context, connector.ListFieldsParams) (connector.ListFieldsResult, *connector.Error) {
+	current, callErr := h.read("list_fields")
+	if callErr != nil {
+		return connector.ListFieldsResult{}, callErr
+	}
+	fields := append([]connector.FieldDescriptor(nil), current.Fields...)
+	sort.Slice(fields, func(i, j int) bool { return fields[i].ID < fields[j].ID })
+	for index := range fields {
+		fields[index].AcceptedKinds = append([]string(nil), fields[index].AcceptedKinds...)
+		sort.Strings(fields[index].AcceptedKinds)
+	}
+	return connector.ListFieldsResult{Fields: fields}, nil
+}
+
+func (h *handler) ReadFields(_ context.Context, params connector.ReadFieldsParams) (connector.ReadFieldsResult, *connector.Error) {
+	current, callErr := h.read("read_fields")
+	if callErr != nil {
+		return connector.ReadFieldsResult{}, callErr
+	}
+	root, ok := findRoot(&current, params.RootKey)
+	if !ok {
+		return connector.ReadFieldsResult{}, notFound("root")
+	}
+	fields := make(map[string]connector.FieldValue, len(params.FieldIDs))
+	for _, id := range params.FieldIDs {
+		value, exists := root.Fields[id]
+		if !exists {
+			return connector.ReadFieldsResult{}, notFound("field")
+		}
+		fields[id] = value
+	}
+	return connector.ReadFieldsResult{Fields: fields}, nil
+}
+
+func (h *handler) WriteFields(_ context.Context, params connector.WriteFieldsParams) (connector.WriteFieldsResult, *connector.Error) {
+	result := connector.WriteFieldsResult{Fields: make(map[string]connector.FieldValue, len(params.Fields))}
+	callErr := h.mutate("write_fields", func(current *State) *connector.Error {
+		root, ok := findRoot(current, params.RootKey)
+		if !ok {
+			return notFound("root")
+		}
+		for id, value := range params.Fields {
+			descriptor, exists := findField(current.Fields, id)
+			if !exists {
+				return notFound("field")
+			}
+			if !descriptor.Writable || !acceptedValue(descriptor, value) {
+				return &connector.Error{Code: "invalid_field_value", Message: "field value is not accepted"}
+			}
+		}
+		if root.Fields == nil {
+			root.Fields = make(map[string]connector.FieldValue)
+		}
+		for id, value := range params.Fields {
+			root.Fields[id] = value
+			result.Fields[id] = value
+		}
+		current.record(h.recordedMutation("write_fields", params))
+		return nil
+	})
+	return result, callErr
+}
+
+func (h *handler) read(method string) (State, *connector.Error) {
+	current, err := Load(h.path)
+	if err != nil {
+		return State{}, &connector.Error{Code: "state_unavailable", Message: "fixture state is unavailable"}
+	}
+	if configured, ok := current.Behavior.Errors[method]; ok {
+		cloned := configured
+		return State{}, &cloned
+	}
+	return current, nil
+}
+
+func (h *handler) mutate(method string, apply func(*State) *connector.Error) *connector.Error {
+	var callErr *connector.Error
+	err := Update(h.path, func(current *State) error {
+		if configured, ok := current.Behavior.Errors[method]; ok {
+			cloned := configured
+			callErr = &cloned
+			return nil
+		}
+		if callErr = apply(current); callErr != nil {
+			return nil
+		}
+		if current.Behavior.CrashAfterMutation[method] > 0 {
+			current.Behavior.CrashAfterMutation[method]--
+			h.crashAfter = true
+		}
+		return nil
+	})
+	if err != nil {
+		return &connector.Error{Code: "state_unavailable", Message: "fixture state is unavailable"}
+	}
+	return callErr
+}
+
+func (h *handler) recordedMutation(method string, fallback any) Mutation {
+	params := append(json.RawMessage(nil), h.params...)
+	if len(params) == 0 {
+		params, _ = json.Marshal(fallback)
+	}
+	return Mutation{Method: method, Params: params}
+}
+
+func consumeCounter(path, method string, before bool) (bool, error) {
+	consumed := false
+	err := Update(path, func(current *State) error {
+		counters := current.Behavior.CrashAfterMutation
+		if before {
+			counters = current.Behavior.CrashBeforeReply
+		}
+		if counters[method] > 0 {
+			counters[method]--
+			consumed = true
+		}
+		return nil
+	})
+	return consumed, err
+}
+
+func (s *State) record(value Mutation) {
+	value.Sequence = len(s.Mutations) + 1
+	s.Mutations = append(s.Mutations, value)
+}
+
+func findRoot(current *State, key string) (*StoredRoot, bool) {
+	for index := range current.Roots {
+		if current.Roots[index].Root.Key == key {
+			return &current.Roots[index], true
+		}
+	}
+	return nil, false
+}
+
+func findField(fields []connector.FieldDescriptor, id string) (connector.FieldDescriptor, bool) {
+	for _, descriptor := range fields {
+		if descriptor.ID == id {
+			return descriptor, true
+		}
+	}
+	return connector.FieldDescriptor{}, false
+}
+
+func acceptedValue(descriptor connector.FieldDescriptor, value connector.FieldValue) bool {
+	if value.Kind == "null" {
+		return descriptor.Nullable && value.Value == "" && value.Timezone == ""
+	}
+	return slices.Contains(descriptor.AcceptedKinds, value.Kind) && value.Value != ""
+}
+
+func advanceRoot(root *connector.Root, sequence int, stamp time.Time) {
+	root.Revision = fmt.Sprintf("revision-%04d", sequence)
+	root.UpdatedAt = stamp
+	root.ObservedAt = root.UpdatedAt
+}
+
+func nextProviderTime(root *StoredRoot) time.Time {
+	stamp := time.Now().UTC()
+	providerTimes := []time.Time{root.Root.UpdatedAt, root.Root.ObservedAt}
+	for _, comment := range root.Comments {
+		providerTimes = append(providerTimes, comment.CreatedAt, comment.UpdatedAt)
+	}
+	for _, providerTime := range providerTimes {
+		if !stamp.After(providerTime) {
+			stamp = providerTime.Add(time.Nanosecond)
+		}
+	}
+	return stamp
+}
+
+func cloneRoot(root connector.Root) connector.Root {
+	root.Fields = cloneFields(root.Fields)
+	if root.Actor != nil {
+		actor := *root.Actor
+		root.Actor = &actor
+	}
+	return root
+}
+
+func cloneFields(fields map[string]connector.FieldValue) map[string]connector.FieldValue {
+	if fields == nil {
+		return nil
+	}
+	cloned := make(map[string]connector.FieldValue, len(fields))
+	maps.Copy(cloned, fields)
+	return cloned
+}
+
+func notFound(kind string) *connector.Error {
+	return &connector.Error{Code: kind + "_not_found", Message: kind + " was not found"}
+}
+
+// Load reads the complete test-owned state.
+func Load(path string) (State, error) {
+	data, err := os.ReadFile(path) // #nosec G304,G703 -- path is the explicit test-owned state file supplied by the harness.
+	if err != nil {
+		return State{}, err
+	}
+	var current State
+	if err := json.Unmarshal(data, &current); err != nil {
+		return State{}, err
+	}
+	return current, nil
+}
+
+// Update applies one locked atomic state transition.
+func Update(path string, apply func(*State) error) error {
+	unlock, err := lock(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	current, err := Load(path)
+	if err != nil {
+		return err
+	}
+	if err := apply(&current); err != nil {
+		return err
+	}
+	return Write(path, current)
+}
+
+// Write atomically replaces the test-owned state file.
+func Write(path string, current State) error {
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, ".fake-connector-state-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	remove := true
+	defer func() {
+		if remove {
+			_ = os.Remove(temporaryPath) // #nosec G703 -- temporaryPath was returned by os.CreateTemp in the test-owned state directory.
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	encoder := json.NewEncoder(temporary)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(current); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil { // #nosec G703 -- both paths are confined to the explicit test-owned state directory.
+		return err
+	}
+	remove = false
+	return nil
+}

--- a/internal/connector/fakeconnector/fakeconnector_test.go
+++ b/internal/connector/fakeconnector/fakeconnector_test.go
@@ -1,0 +1,156 @@
+package fakeconnector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func TestPublishCommentRetryAfterCrashCreatesOneComment(t *testing.T) {
+	fixture := &conformanceFixture{path: filepath.Join(t.TempDir(), "state.json")}
+	require.NoError(t, fixture.Reset(t.Context()))
+	require.NoError(t, Update(fixture.path, func(current *State) error {
+		if current.Behavior.CrashAfterMutation == nil {
+			current.Behavior.CrashAfterMutation = make(map[string]int)
+		}
+		current.Behavior.CrashAfterMutation["publish_comment"] = 1
+		return nil
+	}))
+	request, err := json.Marshal(connector.Request{
+		Protocol: connector.ProtocolVersion,
+		ID:       "request-1",
+		Method:   "publish_comment",
+		Instance: "example-instance",
+		Settings: json.RawMessage(`{}`),
+		Params:   json.RawMessage(`{"root_key":"root-example","body":"publish once","operation_id":"publication-1"}`),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, exitCrashAfterMutation, Run(fixture.path, bytes.NewReader(request), &bytes.Buffer{}))
+	assert.Zero(t, Run(fixture.path, bytes.NewReader(request), &bytes.Buffer{}))
+	state, err := Load(fixture.path)
+	require.NoError(t, err)
+	require.Len(t, state.Roots, 1)
+	assert.Len(t, state.Roots[0].Comments, 5)
+	assert.Len(t, state.Mutations, 1)
+	assert.Equal(t, 2, len(state.Calls))
+}
+
+func TestStateLockHonorsContextWhileOwnerIsLive(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "state.lock")
+	release, err := lockContext(context.Background(), lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	secondRelease, err := lockContext(ctx, lockPath)
+	if secondRelease != nil {
+		secondRelease()
+		t.Fatal("second owner acquired a live lock")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second owner error = %v, want context deadline", err)
+	}
+}
+
+func TestStateUpdateDoesNotStealLiveLockAndRecoversAfterKill(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	if err := os.WriteFile(statePath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestKilledStateUpdateProbe$") // #nosec G204,G702 -- the current test executable is fixed by the Go test runner.
+	command.Env = append(os.Environ(), "KATA_FAKE_STATE_PROBE="+statePath, "KATA_FAKE_READY_PROBE="+readyPath)
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if command.Process != nil {
+			_ = command.Process.Kill()
+		}
+		_ = command.Wait()
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("state update probe did not acquire its lock")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	time.Sleep(350 * time.Millisecond)
+	secondResult := make(chan error, 1)
+	go func() {
+		secondResult <- Update(statePath, func(current *State) error {
+			current.NextComment = 2
+			return nil
+		})
+	}()
+	var enteredWhileOwned bool
+	select {
+	case err := <-secondResult:
+		enteredWhileOwned = true
+		if err != nil {
+			t.Fatalf("second update failed while testing live ownership: %v", err)
+		}
+	case <-time.After(350 * time.Millisecond):
+	}
+	if err := command.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Wait(); err == nil {
+		t.Fatal("killed state update exited successfully")
+	}
+
+	if enteredWhileOwned {
+		t.Fatal("second update entered while the live owner still held the lock")
+	}
+	select {
+	case err := <-secondResult:
+		if err != nil {
+			t.Fatalf("waiting update did not acquire after owner death: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waiting update did not acquire promptly after owner death")
+	}
+	current, err := Load(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.NextComment != 2 {
+		t.Fatalf("waiting update result = %d, want 2", current.NextComment)
+	}
+}
+
+func TestKilledStateUpdateProbe(t *testing.T) {
+	statePath := os.Getenv("KATA_FAKE_STATE_PROBE")
+	readyPath := os.Getenv("KATA_FAKE_READY_PROBE")
+	if statePath == "" || readyPath == "" {
+		t.Skip("subprocess probe")
+	}
+	if err := Update(statePath, func(*State) error {
+		if err := os.WriteFile(readyPath, []byte("ready\n"), 0o600); err != nil { // #nosec G703 -- readyPath is a test-owned subprocess synchronization file.
+			return err
+		}
+		<-time.After(24 * time.Hour)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/connector/fakeconnector/lock.go
+++ b/internal/connector/fakeconnector/lock.go
@@ -1,0 +1,17 @@
+package fakeconnector
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	stateLockTimeout = 10 * time.Second
+	stateLockPoll    = 2 * time.Millisecond
+)
+
+func lock(path string) (func(), error) {
+	ctx, cancel := context.WithTimeout(context.Background(), stateLockTimeout)
+	defer cancel()
+	return lockContext(ctx, path+".lock")
+}

--- a/internal/connector/fakeconnector/lock_unix.go
+++ b/internal/connector/fakeconnector/lock_unix.go
@@ -1,0 +1,39 @@
+//go:build linux || darwin
+
+package fakeconnector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockContext(ctx context.Context, path string) (func(), error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600) // #nosec G304,G703 -- path is derived from the explicit test-owned state path.
+	if err != nil {
+		return nil, fmt.Errorf("open fixture state lock: %w", err)
+	}
+	for {
+		err = unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) {
+			_ = file.Close()
+			return nil, fmt.Errorf("acquire fixture state lock: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			_ = file.Close()
+			return nil, fmt.Errorf("acquire fixture state lock: %w", ctx.Err())
+		case <-time.After(stateLockPoll):
+		}
+	}
+}

--- a/internal/connector/fakeconnector/lock_unsupported.go
+++ b/internal/connector/fakeconnector/lock_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin && !windows
+
+package fakeconnector
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+)
+
+func lockContext(context.Context, string) (func(), error) {
+	return nil, fmt.Errorf("fixture state locking is unsupported on %s", runtime.GOOS)
+}

--- a/internal/connector/fakeconnector/lock_windows.go
+++ b/internal/connector/fakeconnector/lock_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package fakeconnector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockContext(ctx context.Context, path string) (func(), error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600) // #nosec G304,G703 -- path is derived from the explicit test-owned state path.
+	if err != nil {
+		return nil, fmt.Errorf("open fixture state lock: %w", err)
+	}
+	handle := windows.Handle(file.Fd())
+	var overlapped windows.Overlapped
+	for {
+		err = windows.LockFileEx(
+			handle,
+			windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+			0,
+			1,
+			0,
+			&overlapped,
+		)
+		if err == nil {
+			return func() {
+				_ = windows.UnlockFileEx(handle, 0, 1, 0, &overlapped)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) && !errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			_ = file.Close()
+			return nil, fmt.Errorf("acquire fixture state lock: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			_ = file.Close()
+			return nil, fmt.Errorf("acquire fixture state lock: %w", ctx.Err())
+		case <-time.After(stateLockPoll):
+		}
+	}
+}

--- a/internal/connector/identityaudit/audit.go
+++ b/internal/connector/identityaudit/audit.go
@@ -1,0 +1,323 @@
+// Package identityaudit validates provider-facing connector parameters for
+// local Kata identity channels.
+package identityaudit
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+
+	"go.kenn.io/kata/pkg/connector"
+)
+
+// Code identifies a connector parameter validation failure.
+type Code string
+
+// Error codes returned by Validate.
+const (
+	CodeInvalidJSON       Code = "invalid_json"
+	CodeTrailingJSON      Code = "trailing_json"
+	CodeForbiddenKey      Code = "forbidden_key"
+	CodeUnsupportedMethod Code = "unsupported_method"
+	CodeMissingParameter  Code = "missing_parameter"
+	CodeUnknownParameter  Code = "unknown_parameter"
+	CodeWrongRoot         Code = "wrong_root"
+	CodeLocalIdentity     Code = "local_identity"
+)
+
+// Error is a structured connector parameter validation failure.
+type Error struct {
+	Code   Code
+	Method string
+	Path   string
+	Cause  error
+}
+
+func (e *Error) Error() string {
+	message := fmt.Sprintf("%s parameter audit failed", e.Method)
+	if e.Path != "" {
+		message += " at " + e.Path
+	}
+	if e.Cause != nil {
+		message += ": " + e.Cause.Error()
+	}
+	return message
+}
+
+// Unwrap returns the underlying JSON or context failure, when present.
+func (e *Error) Unwrap() error { return e.Cause }
+
+// Options supplies the expected external root and local issue identities.
+// Long UIDs are rejected as substrings; short IDs are rejected only as exact
+// string values.
+type Options struct {
+	ExternalRootKey string
+	LongUIDs        []string
+	ShortIDs        []string
+}
+
+// Validate checks one raw protocol parameter object and requires exactly one
+// JSON value followed by EOF.
+func Validate(method string, raw json.RawMessage, options Options) error {
+	var params map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&params); err != nil {
+		return &Error{Code: CodeInvalidJSON, Method: method, Path: "params", Cause: err}
+	}
+	if params == nil {
+		return &Error{Code: CodeInvalidJSON, Method: method, Path: "params", Cause: errors.New("parameters must be a JSON object")}
+	}
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return &Error{Code: CodeTrailingJSON, Method: method, Path: "params", Cause: err}
+	}
+	if path, found := forbiddenPath(params, "params", method); found {
+		return &Error{Code: CodeForbiddenKey, Method: method, Path: path}
+	}
+	allowed, ok := methodParameters[method]
+	if !ok {
+		return &Error{Code: CodeUnsupportedMethod, Method: method}
+	}
+	for required := range allowed {
+		if _, present := params[required]; !present {
+			return &Error{Code: CodeMissingParameter, Method: method, Path: "params." + required}
+		}
+	}
+	for key := range params {
+		if !allowed[key] {
+			return &Error{Code: CodeUnknownParameter, Method: method, Path: "params." + key}
+		}
+	}
+	if err := validateParameterTypes(method, raw, params); err != nil {
+		return err
+	}
+	if rootKey, present := params["root_key"]; present && rootKey != options.ExternalRootKey {
+		return &Error{Code: CodeWrongRoot, Method: method, Path: "params.root_key"}
+	}
+	if path, found := localIdentityPath(params, "params", method, options); found {
+		return &Error{Code: CodeLocalIdentity, Method: method, Path: path}
+	}
+	return nil
+}
+
+func validateParameterTypes(method string, raw json.RawMessage, params map[string]any) error {
+	var target any
+	switch method {
+	case "describe":
+		target = &connector.DescribeParams{}
+	case "resolve_root":
+		target = &connector.ResolveRootParams{}
+	case "read_root":
+		target = &connector.ReadRootParams{}
+	case "list_comments":
+		target = &connector.ListCommentsParams{}
+	case "publish_comment":
+		target = &connector.PublishCommentParams{}
+	case "complete_root":
+		target = &connector.CompleteRootParams{}
+	case "list_fields":
+		target = &connector.ListFieldsParams{}
+	case "read_fields":
+		target = &connector.ReadFieldsParams{}
+	case "write_fields":
+		target = &connector.WriteFieldsParams{}
+	default:
+		return &Error{Code: CodeUnsupportedMethod, Method: method}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return &Error{Code: CodeInvalidJSON, Method: method, Path: "params", Cause: err}
+	}
+
+	invalid := func(path string) error {
+		return &Error{
+			Code:   CodeInvalidJSON,
+			Method: method,
+			Path:   path,
+			Cause:  errors.New("parameter value has wrong JSON type"),
+		}
+	}
+	requireString := func(key string) error {
+		if _, ok := params[key].(string); !ok {
+			return invalid("params." + key)
+		}
+		return nil
+	}
+	switch method {
+	case "resolve_root":
+		return requireString("locator")
+	case "read_root", "list_comments", "complete_root":
+		return requireString("root_key")
+	case "publish_comment":
+		if err := requireString("root_key"); err != nil {
+			return err
+		}
+		if err := requireString("body"); err != nil {
+			return err
+		}
+		return requireString("operation_id")
+	case "read_fields":
+		if err := requireString("root_key"); err != nil {
+			return err
+		}
+		fieldIDs, ok := params["field_ids"].([]any)
+		if !ok {
+			return invalid("params.field_ids")
+		}
+		for index, fieldID := range fieldIDs {
+			if _, ok := fieldID.(string); !ok {
+				return invalid(fmt.Sprintf("params.field_ids[%d]", index))
+			}
+		}
+	case "write_fields":
+		if err := requireString("root_key"); err != nil {
+			return err
+		}
+		fields, ok := params["fields"].(map[string]any)
+		if !ok {
+			return invalid("params.fields")
+		}
+		for fieldID, value := range fields {
+			field, ok := value.(map[string]any)
+			if !ok {
+				return invalid("params.fields." + fieldID)
+			}
+			if _, ok := field["kind"].(string); !ok {
+				return invalid("params.fields." + fieldID + ".kind")
+			}
+			for _, optional := range []string{"value", "timezone"} {
+				if rawValue, present := field[optional]; present {
+					if _, ok := rawValue.(string); !ok {
+						return invalid("params.fields." + fieldID + "." + optional)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+var methodParameters = map[string]map[string]bool{
+	"describe":        {},
+	"resolve_root":    {"locator": true},
+	"read_root":       {"root_key": true},
+	"list_comments":   {"root_key": true},
+	"publish_comment": {"root_key": true, "body": true, "operation_id": true},
+	"complete_root":   {"root_key": true},
+	"list_fields":     {},
+	"read_fields":     {"root_key": true, "field_ids": true},
+	"write_fields":    {"root_key": true, "fields": true},
+}
+
+func forbiddenPath(value any, path, method string) (string, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if method == "write_fields" && path == "params" && key == "fields" {
+				if fields, ok := child.(map[string]any); ok {
+					for fieldID, fieldValue := range fields {
+						if found, ok := forbiddenPath(fieldValue, path+".fields."+fieldID, method); ok {
+							return found, true
+						}
+					}
+					continue
+				}
+			}
+			if method == "read_fields" && path == "params" && key == "field_ids" {
+				continue
+			}
+			if forbiddenSemanticKey(key) {
+				return path + "." + key, true
+			}
+			if found, ok := forbiddenPath(child, path+"."+key, method); ok {
+				return found, true
+			}
+		}
+	case []any:
+		for index, child := range typed {
+			if found, ok := forbiddenPath(child, fmt.Sprintf("%s[%d]", path, index), method); ok {
+				return found, true
+			}
+		}
+	}
+	return "", false
+}
+
+func forbiddenSemanticKey(key string) bool {
+	normalized := normalizeSemanticKey(key)
+	if normalized == "kata" || strings.HasPrefix(normalized, "kata_") {
+		return true
+	}
+	switch normalized {
+	case "issue_id", "issue_uid", "issue_short_id", "child_root", "child_issue", "work_attention", "work_attention_msg":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeSemanticKey(key string) string {
+	runes := []rune(key)
+	var normalized strings.Builder
+	separator := false
+	for index, current := range runes {
+		if !unicode.IsLetter(current) && !unicode.IsDigit(current) {
+			separator = normalized.Len() > 0
+			continue
+		}
+		if unicode.IsUpper(current) && index > 0 {
+			previous := runes[index-1]
+			var next rune
+			if index+1 < len(runes) {
+				next = runes[index+1]
+			}
+			if unicode.IsLower(previous) || unicode.IsDigit(previous) || (unicode.IsUpper(previous) && unicode.IsLower(next)) {
+				separator = true
+			}
+		}
+		if separator && normalized.Len() > 0 {
+			normalized.WriteByte('_')
+		}
+		separator = false
+		normalized.WriteRune(unicode.ToLower(current))
+	}
+	return normalized.String()
+}
+
+func localIdentityPath(value any, path, method string, options Options) (string, bool) {
+	switch typed := value.(type) {
+	case string:
+		for _, uid := range options.LongUIDs {
+			if uid != "" && strings.Contains(typed, uid) {
+				return path, true
+			}
+		}
+		for _, shortID := range options.ShortIDs {
+			if shortID != "" && typed == shortID {
+				return path, true
+			}
+		}
+	case map[string]any:
+		for key, child := range typed {
+			if method == "read_fields" && path == "params" && key == "field_ids" {
+				continue
+			}
+			if found, ok := localIdentityPath(child, path+"."+key, method, options); ok {
+				return found, true
+			}
+		}
+	case []any:
+		for index, child := range typed {
+			if found, ok := localIdentityPath(child, fmt.Sprintf("%s[%d]", path, index), method, options); ok {
+				return found, true
+			}
+		}
+	}
+	return "", false
+}

--- a/internal/connector/identityaudit/audit_test.go
+++ b/internal/connector/identityaudit/audit_test.go
@@ -1,0 +1,170 @@
+package identityaudit
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestValidateRejectsForbiddenKeyVariantsInsideFieldValues(t *testing.T) {
+	for _, key := range []string{
+		"kata_uid", "kataUid", "kata-uid", "kata.uid",
+		"kata_ref", "kataRef", "kata-ref", "kata.ref",
+		"kata_project_id", "kataProjectId", "kata-project-id", "kata.project.id",
+		"kata_binding_id", "kataBindingId", "kata-binding-id", "kata.binding.id",
+		"kata_work_branch", "kataWorkBranch", "kata-work-branch", "kata.work.branch",
+	} {
+		raw, err := json.Marshal(map[string]any{
+			"root_key": "root-example",
+			"fields": map[string]any{
+				"kata_uid": map[string]any{"kind": "date", "value": "2026-08-20", key: "neutral-forbidden"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = Validate("write_fields", raw, Options{ExternalRootKey: "root-example"})
+		var auditErr *Error
+		if !errors.As(err, &auditErr) || auditErr.Code != CodeForbiddenKey {
+			t.Fatalf("key %q error = %#v, want forbidden-key error", key, err)
+		}
+	}
+}
+
+func TestValidateAllowsOpaqueFieldIDs(t *testing.T) {
+	raw := json.RawMessage(`{"root_key":"root-example","fields":{"kata_uid":{"kind":"date","value":"2026-08-20"},"katakana_start":{"kind":"null"}}}`)
+	if err := Validate("write_fields", raw, Options{ExternalRootKey: "root-example"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateRejectsArbitraryStructuralKataKeys(t *testing.T) {
+	for _, key := range []string{"kataOwnerId", "kata-owner-ref", "kata.project.token", "kata"} {
+		raw, err := json.Marshal(map[string]any{
+			"root_key": "root-example",
+			"fields": map[string]any{
+				"katakana_start": map[string]any{"kind": "date", "value": "2026-08-20", key: "neutral-forbidden"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = Validate("write_fields", raw, Options{ExternalRootKey: "root-example"})
+		var auditErr *Error
+		if !errors.As(err, &auditErr) || auditErr.Code != CodeForbiddenKey {
+			t.Fatalf("key %q error = %#v, want forbidden-key error", key, err)
+		}
+	}
+
+	raw := json.RawMessage(`{"root_key":"root-example","fields":{"katakana_start":{"kind":"null"}}}`)
+	if err := Validate("write_fields", raw, Options{ExternalRootKey: "root-example"}); err != nil {
+		t.Fatalf("katakana field rejected: %v", err)
+	}
+}
+
+func TestValidateRejectsWrongParameterTypes(t *testing.T) {
+	tests := []struct {
+		method string
+		raw    json.RawMessage
+	}{
+		{method: "resolve_root", raw: json.RawMessage(`{"locator":7}`)},
+		{method: "read_root", raw: json.RawMessage(`{"root_key":false}`)},
+		{method: "list_comments", raw: json.RawMessage(`{"root_key":[]}`)},
+		{method: "publish_comment", raw: json.RawMessage(`{"root_key":"root-example","body":{},"operation_id":"operation-example"}`)},
+		{method: "publish_comment", raw: json.RawMessage(`{"root_key":3,"body":"example","operation_id":"operation-example"}`)},
+		{method: "publish_comment", raw: json.RawMessage(`{"root_key":"root-example","body":"example","operation_id":3}`)},
+		{method: "complete_root", raw: json.RawMessage(`{"root_key":null}`)},
+		{method: "read_fields", raw: json.RawMessage(`{"root_key":{},"field_ids":[]}`)},
+		{method: "read_fields", raw: json.RawMessage(`{"root_key":"root-example","field_ids":"field-example"}`)},
+		{method: "read_fields", raw: json.RawMessage(`{"root_key":"root-example","field_ids":[3]}`)},
+		{method: "write_fields", raw: json.RawMessage(`{"root_key":true,"fields":{}}`)},
+		{method: "write_fields", raw: json.RawMessage(`{"root_key":"root-example","fields":"field-example"}`)},
+		{method: "write_fields", raw: json.RawMessage(`{"root_key":"root-example","fields":{"field-example":null}}`)},
+		{method: "write_fields", raw: json.RawMessage(`{"root_key":"root-example","fields":{"field-example":{}}}`)},
+		{method: "write_fields", raw: json.RawMessage(`{"root_key":"root-example","fields":{"field-example":{"kind":4}}}`)},
+		{method: "write_fields", raw: json.RawMessage(`{"root_key":"root-example","fields":{"field-example":{"kind":"date","value":{}}}}`)},
+		{method: "write_fields", raw: json.RawMessage(`{"root_key":"root-example","fields":{"field-example":{"kind":"instant","timezone":[]}}}`)},
+		{method: "write_fields", raw: json.RawMessage(`{"root_key":"root-example","fields":{"field-example":{"kind":"null","metadata":"unexpected"}}}`)},
+	}
+	for _, test := range tests {
+		err := Validate(test.method, test.raw, Options{ExternalRootKey: "root-example"})
+		var auditErr *Error
+		if !errors.As(err, &auditErr) || auditErr.Code != CodeInvalidJSON {
+			t.Errorf("%s params %s error = %#v, want invalid-json error", test.method, test.raw, err)
+		}
+	}
+}
+
+func TestValidateTreatsReadFieldSelectorsAsOpaque(t *testing.T) {
+	options := Options{
+		ExternalRootKey: "root-example",
+		LongUIDs:        []string{"01ARZ3NDEKTSV4RRFFQ69G5FAV"},
+		ShortIDs:        []string{"root-short"},
+	}
+	raw := json.RawMessage(`{"root_key":"root-example","field_ids":["root-short","prefix-01ARZ3NDEKTSV4RRFFQ69G5FAV-suffix","kataOwnerId"]}`)
+	if err := Validate("read_fields", raw, options); err != nil {
+		t.Fatalf("opaque field selectors rejected: %v", err)
+	}
+
+	for _, invalid := range []json.RawMessage{
+		json.RawMessage(`{"root_key":"root-short","field_ids":[]}`),
+		json.RawMessage(`{"root_key":"root-example","field_ids":[],"kataOwnerId":"neutral-forbidden"}`),
+	} {
+		if err := Validate("read_fields", invalid, options); err == nil {
+			t.Fatalf("surrounding identity channel accepted: %s", invalid)
+		}
+	}
+}
+
+func TestValidateLocalIdentityMatching(t *testing.T) {
+	options := Options{
+		ExternalRootKey: "root-example",
+		LongUIDs:        []string{"01ARZ3NDEKTSV4RRFFQ69G5FAV", "01ARZ3NDEKTSV4RRFFQ69G5FAW"},
+		ShortIDs:        []string{"root-short", "child-short"},
+	}
+	for _, body := range []string{
+		"prefix-01ARZ3NDEKTSV4RRFFQ69G5FAV-suffix",
+		"prefix-01ARZ3NDEKTSV4RRFFQ69G5FAW-suffix",
+		"root-short",
+		"child-short",
+	} {
+		raw, _ := json.Marshal(map[string]any{"root_key": "root-example", "body": body, "operation_id": "operation-example"})
+		if err := Validate("publish_comment", raw, options); err == nil {
+			t.Fatalf("local identity body %q was accepted", body)
+		}
+	}
+	for _, body := range []string{"prefix-root-short-suffix", "unrelated-01ARZ3NDEKTSV4RRFFQ69G5FAX-suffix"} {
+		raw, _ := json.Marshal(map[string]any{"root_key": "root-example", "body": body, "operation_id": "operation-example"})
+		if err := Validate("publish_comment", raw, options); err != nil {
+			t.Fatalf("safe body %q rejected: %v", body, err)
+		}
+	}
+}
+
+func TestValidateAllMethodShapesAndExactEOF(t *testing.T) {
+	valid := map[string]json.RawMessage{
+		"describe":        json.RawMessage(`{}`),
+		"resolve_root":    json.RawMessage(`{"locator":"fixture-root"}`),
+		"read_root":       json.RawMessage(`{"root_key":"root-example"}`),
+		"list_comments":   json.RawMessage(`{"root_key":"root-example"}`),
+		"publish_comment": json.RawMessage(`{"root_key":"root-example","body":"Example","operation_id":"operation-example"}`),
+		"complete_root":   json.RawMessage(`{"root_key":"root-example"}`),
+		"list_fields":     json.RawMessage(`{}`),
+		"read_fields":     json.RawMessage(`{"root_key":"root-example","field_ids":["field-example"]}`),
+		"write_fields":    json.RawMessage(`{"root_key":"root-example","fields":{"field-example":{"kind":"null"}}}`),
+	}
+	for method, raw := range valid {
+		if err := Validate(method, raw, Options{ExternalRootKey: "root-example"}); err != nil {
+			t.Fatalf("%s valid params rejected: %v", method, err)
+		}
+	}
+	err := Validate("read_root", json.RawMessage(`{"root_key":"root-example"} {}`), Options{ExternalRootKey: "root-example"})
+	var auditErr *Error
+	if !errors.As(err, &auditErr) || auditErr.Code != CodeTrailingJSON {
+		t.Fatalf("trailing JSON error = %#v, want trailing-json error", err)
+	}
+	err = Validate("describe", json.RawMessage(`null`), Options{})
+	if !errors.As(err, &auditErr) || auditErr.Code != CodeInvalidJSON {
+		t.Fatalf("null parameter error = %#v, want invalid-json error", err)
+	}
+}

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -196,9 +196,9 @@ const (
 	completionShutdown
 )
 
-func waitForCompletion(cmd *exec.Cmd, timeout time.Duration, shutdown <-chan struct{}, deps runDeps) (result string, exitCode int) {
+func waitForCompletion(tree *processtree.Tree, timeout time.Duration, shutdown <-chan struct{}, deps runDeps) (result string, exitCode int) {
 	doneCh := make(chan error, 1)
-	go func() { doneCh <- cmd.Wait() }()
+	go func() { doneCh <- tree.Wait() }()
 
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
@@ -208,11 +208,11 @@ func waitForCompletion(cmd *exec.Cmd, timeout time.Duration, shutdown <-chan str
 	case completionDone:
 		return result, exitCode
 	case completionTimeout:
-		killTreeWithGrace(cmd, deps.GraceWindow, deps.DaemonLog)
+		killTreeWithGrace(tree, deps.GraceWindow, deps.DaemonLog)
 		w := <-doneCh
 		return "timed_out", exitCodeOf(w)
 	case completionShutdown:
-		killTreeWithGrace(cmd, deps.GraceWindow, deps.DaemonLog)
+		killTreeWithGrace(tree, deps.GraceWindow, deps.DaemonLog)
 		w := <-doneCh
 		return "daemon_shutdown", exitCodeOf(w)
 	default:
@@ -292,14 +292,19 @@ func runJob(ctx context.Context, shutdown <-chan struct{}, job HookJob, deps run
 	cmd.Stdin = bytes.NewReader(stdinPayload)
 	cmd.Stdout = rc.outFile
 	cmd.Stderr = rc.errFile
-	processtree.Prepare(cmd)
+	tree, err := processtree.New(cmd)
+	if err != nil {
+		rc.finalize("spawn_failed", err.Error(), -1, payloadTruncated)
+		return
+	}
+	defer func() { _ = tree.Close() }()
 
-	if err := cmd.Start(); err != nil {
+	if err := tree.Start(); err != nil {
 		rc.finalize("spawn_failed", err.Error(), -1, payloadTruncated)
 		return
 	}
 
-	result, exitCode := waitForCompletion(cmd, job.Hook.Timeout, shutdown, deps)
+	result, exitCode := waitForCompletion(tree, job.Hook.Timeout, shutdown, deps)
 	rc.finalize(result, "", exitCode, payloadTruncated)
 }
 
@@ -340,8 +345,8 @@ func buildEnv(baseEnv, userEnv []string, evt db.Event, asnap AliasSnapshot, hasA
 	return env
 }
 
-func killTreeWithGrace(cmd *exec.Cmd, grace time.Duration, daemonLog *log.Logger) {
-	if err := processtree.TerminateWithGrace(cmd, grace); err != nil {
+func killTreeWithGrace(tree *processtree.Tree, grace time.Duration, daemonLog *log.Logger) {
+	if err := tree.TerminateWithGrace(grace); err != nil {
 		daemonLog.Printf("hooks: terminate process tree: %v", err)
 	}
 }

--- a/internal/processtree/tree.go
+++ b/internal/processtree/tree.go
@@ -7,28 +7,66 @@ import (
 	"time"
 )
 
-// Prepare configures cmd for process grouping where the platform supports it.
-func Prepare(cmd *exec.Cmd) {
-	prepare(cmd)
+// Tree owns platform process-tree containment for one command.
+type Tree struct {
+	cmd      *exec.Cmd
+	platform platformTree
 }
 
-// TerminateWithGrace sends a graceful signal to cmd's process group on Unix,
-// then force-kills the group if it survives grace. On Windows, it waits for
-// grace and then force-kills only cmd's process if it is still running.
-func TerminateWithGrace(cmd *exec.Cmd, grace time.Duration) error {
-	if cmd.Process == nil {
-		return nil
+// New prepares cmd for a race-free contained start where the platform
+// supports it. Callers must call Close whenever New succeeds, including when
+// Start returns an error.
+func New(cmd *exec.Cmd) (*Tree, error) {
+	platform, err := newPlatformTree(cmd)
+	if err != nil {
+		return nil, err
 	}
+	return &Tree{cmd: cmd, platform: platform}, nil
+}
+
+// Start starts the prepared command and establishes its containment before it
+// can spawn descendants.
+func (t *Tree) Start() error {
+	return t.platform.start(t.cmd)
+}
+
+// Wait waits for the direct process and its configured I/O copying to finish.
+func (t *Tree) Wait() error {
+	return t.cmd.Wait()
+}
+
+// Close releases the platform containment resources. On platforms whose
+// containment is kill-on-close, any remaining descendants are terminated.
+func (t *Tree) Close() error {
+	return t.platform.close()
+}
+
+// TerminateWithGrace terminates the contained process tree after grace.
+func (t *Tree) TerminateWithGrace(grace time.Duration) error {
+	return terminateWithGrace(
+		func() error { return t.platform.terminate(t.cmd) },
+		func() bool { return t.platform.alive(t.cmd) },
+		func() error { return t.platform.kill(t.cmd) },
+		grace,
+	)
+}
+
+func terminateWithGrace(
+	terminate func() error,
+	alive func() bool,
+	kill func() error,
+	grace time.Duration,
+) error {
 	var errs []error
-	if err := terminate(cmd); err != nil {
+	if err := terminate(); err != nil {
 		errs = append(errs, err)
 	}
 	deadline := time.Now().Add(grace)
-	for time.Now().Before(deadline) && alive(cmd) {
+	for time.Now().Before(deadline) && alive() {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if alive(cmd) {
-		if err := kill(cmd); err != nil {
+	if alive() {
+		if err := kill(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/processtree/tree_test.go
+++ b/internal/processtree/tree_test.go
@@ -1,6 +1,7 @@
 package processtree
 
 import (
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -8,7 +9,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTerminateWithGraceNoProcess(t *testing.T) {
+func TestTreeTerminateWithGraceBeforeStart(t *testing.T) {
 	cmd := exec.Command("unused")
-	require.NoError(t, TerminateWithGrace(cmd, time.Millisecond))
+	tree, err := New(cmd)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tree.Close()) })
+	require.NoError(t, tree.TerminateWithGrace(time.Millisecond))
+}
+
+func TestTreeStartsAndWaitsForProcess(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestProcessTreeExitHelper$") // #nosec G204,G702 -- fixed current test executable.
+	cmd.Env = append(os.Environ(), "GO_WANT_PROCESS_TREE_EXIT_HELPER=1")
+	tree, err := New(cmd)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tree.Close()) })
+
+	require.NoError(t, tree.Start())
+	require.NoError(t, tree.Wait())
+}
+
+func TestProcessTreeExitHelper(_ *testing.T) {
+	if os.Getenv("GO_WANT_PROCESS_TREE_EXIT_HELPER") != "1" {
+		return
+	}
+	os.Exit(0)
 }

--- a/internal/processtree/tree_unix.go
+++ b/internal/processtree/tree_unix.go
@@ -8,6 +8,44 @@ import (
 	"syscall"
 )
 
+type platformTree struct {
+	pgid int
+}
+
+func newPlatformTree(cmd *exec.Cmd) (platformTree, error) {
+	prepare(cmd)
+	return platformTree{}, nil
+}
+
+func (t *platformTree) start(cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	t.pgid = cmd.Process.Pid
+	return nil
+}
+
+func (t *platformTree) close() error {
+	if t.pgid == 0 {
+		return nil
+	}
+	pgid := t.pgid
+	t.pgid = 0
+	return signal(-pgid, syscall.SIGKILL)
+}
+
+func (platformTree) terminate(cmd *exec.Cmd) error {
+	return terminate(cmd)
+}
+
+func (platformTree) kill(cmd *exec.Cmd) error {
+	return kill(cmd)
+}
+
+func (platformTree) alive(cmd *exec.Cmd) bool {
+	return alive(cmd)
+}
+
 func prepare(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }

--- a/internal/processtree/tree_unix_test.go
+++ b/internal/processtree/tree_unix_test.go
@@ -10,18 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTerminateWithGraceExitedProcess(t *testing.T) {
+func TestTreeTerminateWithGraceExitedProcess(t *testing.T) {
 	cmd := exec.Command("true")
-	Prepare(cmd)
-	require.NoError(t, cmd.Start())
-	require.NoError(t, cmd.Wait())
+	tree, err := New(cmd)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tree.Close()) })
+	require.NoError(t, tree.Start())
+	require.NoError(t, tree.Wait())
 
-	require.NoError(t, TerminateWithGrace(cmd, time.Millisecond))
+	require.NoError(t, tree.TerminateWithGrace(time.Millisecond))
 }
 
 func TestExitedProcessSignalsAreSuccessful(t *testing.T) {
 	cmd := exec.Command("true")
-	Prepare(cmd)
+	prepare(cmd)
 	require.NoError(t, cmd.Start())
 	require.NoError(t, cmd.Wait())
 

--- a/internal/processtree/tree_windows.go
+++ b/internal/processtree/tree_windows.go
@@ -6,9 +6,133 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"syscall"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
+
+type platformTree struct {
+	job windows.Handle
+}
+
+func newPlatformTree(cmd *exec.Cmd) (platformTree, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return platformTree{}, err
+	}
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)), // #nosec G103 -- Windows requires a pointer to this typed job limit structure.
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return platformTree{}, err
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED
+	return platformTree{job: job}, nil
+}
+
+func (t *platformTree) start(cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return errors.Join(err, t.close())
+	}
+	var assignErr error
+	if err := cmd.Process.WithHandle(func(handle uintptr) {
+		assignErr = windows.AssignProcessToJobObject(t.job, windows.Handle(handle))
+	}); err != nil {
+		return t.failStart(cmd, err)
+	}
+	if assignErr != nil {
+		return t.failStart(cmd, assignErr)
+	}
+	if err := resumeProcess(cmd.Process.Pid); err != nil {
+		return t.failStart(cmd, err)
+	}
+	return nil
+}
+
+func (t *platformTree) failStart(cmd *exec.Cmd, cause error) error {
+	var cleanupErrs []error
+	if t.job != 0 {
+		if err := windows.TerminateJobObject(t.job, 1); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+	}
+	if cmd.Process != nil {
+		if err := kill(cmd); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+		if err := cmd.Wait(); err != nil {
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				cleanupErrs = append(cleanupErrs, err)
+			}
+		}
+	}
+	cleanupErrs = append(cleanupErrs, t.close())
+	return errors.Join(append([]error{cause}, cleanupErrs...)...)
+}
+
+func resumeProcess(pid int) error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(snapshot) //nolint:errcheck // The snapshot is read-only and already exhausted on return.
+
+	entry := windows.ThreadEntry32{Size: uint32(unsafe.Sizeof(windows.ThreadEntry32{}))}
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		return err
+	}
+	for {
+		if entry.OwnerProcessID == uint32(pid) { // #nosec G115 -- Windows process IDs are unsigned 32-bit values.
+			thread, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, entry.ThreadID)
+			if err != nil {
+				return err
+			}
+			_, resumeErr := windows.ResumeThread(thread)
+			closeErr := windows.CloseHandle(thread)
+			return errors.Join(resumeErr, closeErr)
+		}
+		if err := windows.Thread32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				return errors.New("suspended process thread not found")
+			}
+			return err
+		}
+	}
+}
+
+func (t *platformTree) close() error {
+	if t.job == 0 {
+		return nil
+	}
+	job := t.job
+	t.job = 0
+	return windows.CloseHandle(job)
+}
+
+func (*platformTree) terminate(_ *exec.Cmd) error { return nil }
+
+func (t *platformTree) kill(cmd *exec.Cmd) error {
+	err := windows.TerminateJobObject(t.job, 1)
+	if err == nil {
+		return nil
+	}
+	exited, statusErr := processExited(cmd)
+	return killResult(err, exited, statusErr)
+}
+
+func (t *platformTree) alive(_ *exec.Cmd) bool {
+	return t.job != 0
+}
 
 func prepare(_ *exec.Cmd) {}
 

--- a/internal/processtree/tree_windows_test.go
+++ b/internal/processtree/tree_windows_test.go
@@ -71,3 +71,35 @@ func TestKillProcessExitedWithStillActiveCode(t *testing.T) {
 	require.ErrorAs(t, waitErr, &exitErr)
 	require.Equal(t, 259, exitErr.ExitCode())
 }
+
+func TestTreeAttachFailureKillsAndReapsSuspendedProcess(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "exit", "0")
+	tree, err := New(cmd)
+	require.NoError(t, err)
+	require.NoError(t, tree.Close())
+
+	require.Error(t, tree.Start())
+	require.NotNil(t, cmd.ProcessState)
+	require.True(t, cmd.ProcessState.Exited())
+	require.NoError(t, tree.Close())
+}
+
+func TestTreeResumeFailureKillsAndReapsAssignedProcess(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "exit", "0")
+	tree, err := New(cmd)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tree.Close()) })
+	require.NoError(t, cmd.Start())
+	var assignErr error
+	require.NoError(t, cmd.Process.WithHandle(func(handle uintptr) {
+		assignErr = windows.AssignProcessToJobObject(tree.platform.job, windows.Handle(handle))
+	}))
+	require.NoError(t, assignErr)
+	resumeErr := errors.New("synthetic resume failure")
+
+	err = tree.platform.failStart(cmd, resumeErr)
+
+	require.ErrorIs(t, err, resumeErr)
+	require.NotNil(t, cmd.ProcessState)
+	require.True(t, cmd.ProcessState.Exited())
+}

--- a/pkg/connector/conformance/conformance.go
+++ b/pkg/connector/conformance/conformance.go
@@ -1,0 +1,94 @@
+// Package conformance provides the provider-neutral behavioral contract for
+// protocol-v1 external root connector handlers. Adapters need advertise only
+// the lossless field kinds they support; Kata rejects unsupported descriptor
+// kinds when operators configure field mappings.
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"go.kenn.io/kata/internal/connector/identityaudit"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+// Fixture owns one disposable external root and exposes its provider-side
+// state. Reset must restore the same stable connector and root identities.
+type Fixture interface {
+	// Exchange sends one complete JSON request line through the candidate's
+	// own protocol boundary and returns its raw response bytes.
+	Exchange(context.Context, []byte) ([]byte, error)
+	// Invocation supplies the connector instance and raw settings used for
+	// every protocol request in the transcripts.
+	Invocation() connector.Invocation
+	RootLocator() string
+	Reset(context.Context) error
+	ExternalState(context.Context) (RootState, error)
+	// MutateComment edits one existing provider comment, advances its revision,
+	// and preserves its ID.
+	MutateComment(context.Context, string) error
+	// InjectFault arms one controlled failure for the next matching exchange.
+	InjectFault(context.Context, Fault) error
+}
+
+// Fault names a provider-side failure window exercised by the conformance kit.
+type Fault string
+
+const (
+	// FaultPublishCommentCrashAfterMutation exits after persisting a publication
+	// but before returning its protocol response.
+	FaultPublishCommentCrashAfterMutation Fault = "publish_comment_crash_after_mutation"
+)
+
+// RootState is the provider-neutral state a conformance fixture exposes for
+// readback after handler mutations.
+type RootState struct {
+	Root      connector.Root
+	Comments  []connector.Comment
+	Fields    map[string]connector.FieldValue
+	Mutations []Mutation
+}
+
+// Mutation records the unfiltered provider-facing parameters received by a
+// mutating v1 call. Params must preserve every nested key so Run can audit the
+// candidate's actual external mutation surface.
+type Mutation struct {
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+// Run executes the protocol-v1 behavioral contract against a disposable
+// fixture. Maintained Go adapters should call Run from their own test suite.
+func Run(t *testing.T, fixture Fixture) {
+	t.Helper()
+	if fixture == nil {
+		t.Fatal("connector conformance fixture is nil")
+	}
+	if strings.TrimSpace(fixture.RootLocator()) == "" {
+		t.Fatal("connector conformance root locator is empty")
+	}
+	invocation := fixture.Invocation()
+	if invocation.Instance == "" || strings.TrimSpace(invocation.Instance) != invocation.Instance || !utf8.ValidString(invocation.Instance) {
+		t.Fatal("connector conformance instance is empty or noncanonical")
+	}
+	if !utf8.Valid(invocation.Settings) {
+		t.Fatal("connector conformance settings are not valid UTF-8")
+	}
+	settings, err := decodeTranscriptJSON(invocation.Settings)
+	if err != nil {
+		t.Fatalf("decode connector conformance settings: %v", err)
+	}
+	if _, ok := settings.(map[string]any); !ok {
+		t.Fatal("connector conformance settings must be a JSON object")
+	}
+	t.Run("language-neutral protocol transcripts", func(t *testing.T) {
+		runProtocolV1Transcripts(t.Context(), t, fixture, invocation.Instance, settings)
+	})
+}
+
+func auditMutationParams(method string, raw json.RawMessage, rootKey string) error {
+	return identityaudit.Validate(method, raw, identityaudit.Options{ExternalRootKey: rootKey})
+}

--- a/pkg/connector/conformance/conformance_test.go
+++ b/pkg/connector/conformance/conformance_test.go
@@ -1,0 +1,991 @@
+package conformance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func TestRun(t *testing.T) {
+	Run(t, newFixture())
+}
+
+type memoryFixture struct {
+	description             connector.Description
+	root                    connector.Root
+	comments                []connector.Comment
+	providerComments        []connector.Comment
+	descriptors             []connector.FieldDescriptor
+	mutations               []Mutation
+	exchange                func(context.Context, []byte) ([]byte, error)
+	providerFields          map[string]connector.FieldValue
+	discardProviderComment  bool
+	discardProviderFields   bool
+	advanceObservation      bool
+	futureObservation       bool
+	omitPrefrontierComment  bool
+	errorMode               string
+	errorMethod             string
+	errorMessage            string
+	forbiddenMutationKey    string
+	forbiddenFieldValueKey  string
+	wrongMutationType       bool
+	trailingMutation        bool
+	dateOnlyFields          bool
+	unstableDescription     bool
+	unstableResetIdentity   bool
+	describeCalls           int
+	resetCalls              int
+	rootLocator             string
+	invocation              connector.Invocation
+	requireInvocation       bool
+	publications            map[string]connector.Comment
+	noEditedComment         bool
+	noDeletedComment        bool
+	missingCommentTime      bool
+	missingCommentRevision  bool
+	constantCommentRevision bool
+	reverseComments         bool
+	nonIdempotentComplete   bool
+	unchangedCompletionRev  bool
+	rejectFieldKind         string
+	noActionableField       bool
+	paddedFieldID           bool
+	paddedSchemaRevision    bool
+	unreadableReadOnlyField bool
+	fabricatedRootRead      bool
+	fabricatedComments      bool
+	duplicateAfterCrash     bool
+	crashAfterMutation      bool
+	publicationCrashed      bool
+	staleCompletionTime     bool
+	stalePublicationTime    bool
+}
+
+func newFixture() *memoryFixture {
+	fixture := &memoryFixture{invocation: connector.Invocation{Instance: "example-instance", Settings: json.RawMessage(`{}`)}}
+	_ = fixture.Reset(context.Background())
+	return fixture
+}
+
+func (f *memoryFixture) RootLocator() string { return f.rootLocator }
+
+func (f *memoryFixture) Invocation() connector.Invocation {
+	return connector.Invocation{
+		Instance: f.invocation.Instance,
+		Settings: append(json.RawMessage(nil), f.invocation.Settings...),
+	}
+}
+
+func (f *memoryFixture) Exchange(ctx context.Context, request []byte) ([]byte, error) {
+	if f.exchange != nil {
+		return f.exchange(ctx, request)
+	}
+	if f.requireInvocation {
+		var decoded connector.Request
+		if err := json.Unmarshal(request, &decoded); err != nil {
+			return nil, err
+		}
+		if decoded.Instance != f.invocation.Instance || !bytes.Equal(decoded.Settings, f.invocation.Settings) {
+			return nil, fmt.Errorf("connector invocation = %q %s, want %q %s", decoded.Instance, decoded.Settings, f.invocation.Instance, f.invocation.Settings)
+		}
+	}
+	var response bytes.Buffer
+	err := connector.ServeOne(ctx, bytes.NewReader(request), &response, f)
+	if err == nil && f.crashAfterMutation {
+		var decoded connector.Request
+		if decodeErr := json.Unmarshal(request, &decoded); decodeErr != nil {
+			return nil, decodeErr
+		}
+		if decoded.Method == "publish_comment" {
+			f.crashAfterMutation = false
+			f.publicationCrashed = true
+			return nil, errors.New("connector exited after publication")
+		}
+	}
+	return response.Bytes(), err
+}
+
+func TestRunPropagatesFixtureInvocation(t *testing.T) {
+	fixture := newFixture()
+	fixture.invocation = connector.Invocation{
+		Instance: "configured-instance",
+		Settings: json.RawMessage(`{"workspace":"example-workspace"}`),
+	}
+	fixture.requireInvocation = true
+	Run(t, fixture)
+}
+
+func (f *memoryFixture) InjectFault(_ context.Context, fault Fault) error {
+	if fault != FaultPublishCommentCrashAfterMutation {
+		return fmt.Errorf("unsupported fault %q", fault)
+	}
+	f.crashAfterMutation = true
+	return nil
+}
+
+func (f *memoryFixture) MutateComment(_ context.Context, commentID string) error {
+	for index := range f.providerComments {
+		if f.providerComments[index].ID != commentID {
+			continue
+		}
+		updatedAt := f.providerComments[index].UpdatedAt.Add(time.Minute)
+		f.providerComments[index].Body = "Externally edited comment"
+		f.providerComments[index].UpdatedAt = updatedAt
+		f.providerComments[index].Revision = "comment-revision-after-edit"
+		for observedIndex := range f.comments {
+			if f.comments[observedIndex].ID != commentID {
+				continue
+			}
+			f.comments[observedIndex].Body = "Externally edited comment"
+			f.comments[observedIndex].UpdatedAt = updatedAt
+			if !f.constantCommentRevision {
+				f.comments[observedIndex].Revision = "comment-revision-after-edit"
+			}
+			return nil
+		}
+		return fmt.Errorf("connector observation lacks comment %q", commentID)
+	}
+	return fmt.Errorf("provider state lacks comment %q", commentID)
+}
+
+func TestRunRejectsBrokenWireExchanges(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		mode    string
+		subtest string
+	}{
+		{name: "wrong response ID", mode: "wrong-id", subtest: "language-neutral_protocol_transcripts"},
+		{name: "response ID fixed to first request", mode: "fixed-id", subtest: "language-neutral_protocol_transcripts"},
+		{name: "unsupported protocol accepted", mode: "accept-version", subtest: "language-neutral_protocol_transcripts"},
+		{name: "malformed request accepted", mode: "accept-malformed", subtest: "language-neutral_protocol_transcripts"},
+		{name: "trailing response JSON", mode: "trailing-response", subtest: "language-neutral_protocol_transcripts"},
+		{name: "result and error response", mode: "result-and-error", subtest: "language-neutral_protocol_transcripts"},
+		{name: "committed transcript response ID", mode: "wrong-transcript-id", subtest: "language-neutral_protocol_transcripts"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestBrokenWireExchangeProbe$") // #nosec G204,G702 -- the current test executable is fixed by the Go test runner.
+			command.Env = append(os.Environ(), "KATA_CONFORMANCE_WIRE_PROBE="+test.mode)
+			output, err := command.CombinedOutput()
+			if err == nil {
+				t.Fatalf("Run accepted broken exchange %q:\n%s", test.mode, output)
+			}
+			if !strings.Contains(string(output), test.subtest) {
+				t.Fatalf("Run failed outside wire conformance for %q:\n%s", test.mode, output)
+			}
+		})
+	}
+}
+
+func TestBrokenWireExchangeProbe(t *testing.T) {
+	mode := os.Getenv("KATA_CONFORMANCE_WIRE_PROBE")
+	if mode == "" {
+		t.Skip("subprocess probe")
+	}
+	fixture := newFixture()
+	fixture.exchange = func(ctx context.Context, raw []byte) ([]byte, error) {
+		var request connector.Request
+		if err := json.Unmarshal(raw, &request); err != nil {
+			if mode == "accept-malformed" {
+				return []byte(`{"protocol":"kata.connector.v1","id":"accepted","result":{}}` + "\n"), nil
+			}
+			return nil, err
+		}
+		if mode == "accept-version" && request.Protocol != connector.ProtocolVersion {
+			request.Protocol = connector.ProtocolVersion
+			raw, _ = json.Marshal(request)
+		}
+		response, err := fixture.ExchangeWithoutOverride(ctx, raw)
+		if mode == "wrong-id" && err == nil {
+			var decoded connector.Response
+			_ = json.Unmarshal(response, &decoded)
+			decoded.ID = "wrong-response-id"
+			response, _ = json.Marshal(decoded)
+			response = append(response, '\n')
+		}
+		if mode == "fixed-id" && err == nil {
+			var decoded connector.Response
+			_ = json.Unmarshal(response, &decoded)
+			decoded.ID = "request-conformance-1"
+			response, _ = json.Marshal(decoded)
+			response = append(response, '\n')
+		}
+		if mode == "trailing-response" && err == nil {
+			response = append(response, []byte("{}\n")...)
+		}
+		if mode == "result-and-error" && err == nil {
+			var decoded connector.Response
+			_ = json.Unmarshal(response, &decoded)
+			decoded.Error = &connector.Error{Code: "invalid_response", Message: "response is ambiguous"}
+			response, _ = json.Marshal(decoded)
+			response = append(response, '\n')
+		}
+		if mode == "wrong-transcript-id" && err == nil && strings.HasPrefix(request.ID, "transcript-") {
+			var decoded connector.Response
+			_ = json.Unmarshal(response, &decoded)
+			decoded.ID = "wrong-transcript-response-id"
+			response, _ = json.Marshal(decoded)
+			response = append(response, '\n')
+		}
+		return response, err
+	}
+	Run(t, fixture)
+}
+
+func TestProtocolV1TranscriptFixturesAreCommitted(t *testing.T) {
+	entries, err := os.ReadDir("testdata/protocol-v1")
+	if err != nil {
+		t.Fatalf("read protocol-v1 transcript fixtures: %v", err)
+	}
+	jsonFiles := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			jsonFiles++
+		}
+	}
+	if jsonFiles < 3 {
+		t.Fatalf("protocol-v1 transcript fixture count = %d, want at least 3", jsonFiles)
+	}
+}
+
+func TestProtocolV1TranscriptFixturesAreDeclarative(t *testing.T) {
+	entries, err := os.ReadDir("testdata/protocol-v1")
+	if err != nil {
+		t.Fatalf("read protocol-v1 transcript fixtures: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		encoded, err := os.ReadFile("testdata/protocol-v1/" + entry.Name())
+		if err != nil {
+			t.Fatalf("read %s: %v", entry.Name(), err)
+		}
+		var document struct {
+			Schema string `json:"schema"`
+			Steps  []struct {
+				Assert []json.RawMessage `json:"assert"`
+				Expect json.RawMessage   `json:"expect"`
+			} `json:"steps"`
+		}
+		if err := json.Unmarshal(encoded, &document); err != nil {
+			t.Fatalf("decode %s: %v", entry.Name(), err)
+		}
+		if document.Schema != "kata.connector.conformance/v1" {
+			t.Errorf("%s schema = %q, want declarative conformance schema", entry.Name(), document.Schema)
+		}
+		for index, step := range document.Steps {
+			if len(step.Expect) != 0 {
+				t.Errorf("%s step %d uses opaque expectation %s", entry.Name(), index, step.Expect)
+			}
+			if len(step.Assert) == 0 {
+				t.Errorf("%s step %d has no executable assertions", entry.Name(), index)
+			}
+		}
+	}
+}
+
+func TestProtocolV1TranscriptAssertionsRejectMissingOperands(t *testing.T) {
+	err := validateTranscriptAssertion(transcriptAssertion{
+		Op:     "equal",
+		Actual: transcriptValue{Path: "/steps/example/response/result"},
+	})
+	if err == nil {
+		t.Fatal("equal assertion without an expected operand was accepted")
+	}
+}
+
+func TestProtocolV1TranscriptPointersUseRFC6901Syntax(t *testing.T) {
+	if err := validateTranscriptValue(transcriptValue{Path: "/invalid~2escape"}); err == nil {
+		t.Fatal("JSON Pointer with an illegal escape was accepted")
+	}
+	if _, _, err := resolveJSONPointer([]any{"first", "second"}, "/01"); err == nil {
+		t.Fatal("JSON Pointer with a non-canonical array index was accepted")
+	}
+	if err := removeJSONPointer([]any{"first", "second"}, "/01"); err == nil {
+		t.Fatal("excluded JSON Pointer with a non-canonical array index was accepted")
+	}
+}
+
+func TestProtocolV1TranscriptValidUTF8AllowsReplacementCharacter(t *testing.T) {
+	runtime := &transcriptRuntime{root: map[string]any{
+		"legitimate": "�",
+		"invalid":    string([]byte{0xff}),
+	}}
+	legitimate, err := runtime.matches(transcriptAssertion{Op: "valid_utf8", Actual: transcriptValue{Path: "/legitimate"}})
+	if err != nil || !legitimate {
+		t.Fatalf("valid replacement character rejected: matches=%v err=%v", legitimate, err)
+	}
+	invalid, err := runtime.matches(transcriptAssertion{Op: "valid_utf8", Actual: transcriptValue{Path: "/invalid"}})
+	if err != nil {
+		t.Fatalf("validate invalid UTF-8: %v", err)
+	}
+	if invalid {
+		t.Fatal("invalid UTF-8 was accepted")
+	}
+}
+
+func TestProtocolV1TranscriptsRejectEveryRunBehavior(t *testing.T) {
+	for _, mode := range []string{
+		"unstable-description",
+		"unstable-reset-identity",
+		"no-edited-comment",
+		"no-deleted-comment",
+		"missing-comment-time",
+		"missing-comment-revision",
+		"constant-comment-revision",
+		"reverse-comments",
+		"non-idempotent-completion",
+		"unchanged-completion-revision",
+		"reject-local-datetime",
+		"reject-null",
+		"no-actionable-field",
+		"padded-field-id",
+		"padded-schema-revision",
+		"unreadable-read-only-field",
+	} {
+		for _, runner := range []string{"run", "transcripts"} {
+			command := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestBrokenDeclarativeContractProbe$") // #nosec G204,G702 -- the current test executable is fixed by the Go test runner.
+			command.Env = append(os.Environ(), "KATA_CONFORMANCE_DECLARATIVE_PROBE="+mode, "KATA_CONFORMANCE_DECLARATIVE_RUNNER="+runner)
+			output, err := command.CombinedOutput()
+			if err == nil {
+				t.Fatalf("%s accepted broken connector mode %q:\n%s", runner, mode, output)
+			}
+		}
+	}
+}
+
+func TestBrokenDeclarativeContractProbe(t *testing.T) {
+	if os.Getenv("KATA_CONFORMANCE_DECLARATIVE_PROBE") == "" {
+		t.Skip("subprocess probe")
+	}
+	fixture := newFixture()
+	switch os.Getenv("KATA_CONFORMANCE_DECLARATIVE_PROBE") {
+	case "unstable-description":
+		fixture.unstableDescription = true
+	case "unstable-reset-identity":
+		fixture.unstableResetIdentity = true
+	case "no-edited-comment":
+		fixture.noEditedComment = true
+	case "no-deleted-comment":
+		fixture.noDeletedComment = true
+	case "missing-comment-time":
+		fixture.missingCommentTime = true
+	case "missing-comment-revision":
+		fixture.missingCommentRevision = true
+	case "constant-comment-revision":
+		fixture.constantCommentRevision = true
+	case "reverse-comments":
+		fixture.reverseComments = true
+	case "non-idempotent-completion":
+		fixture.nonIdempotentComplete = true
+	case "unchanged-completion-revision":
+		fixture.unchangedCompletionRev = true
+	case "reject-local-datetime":
+		fixture.rejectFieldKind = "local_datetime"
+	case "reject-null":
+		fixture.rejectFieldKind = "null"
+	case "no-actionable-field":
+		fixture.noActionableField = true
+	case "padded-field-id":
+		fixture.paddedFieldID = true
+	case "padded-schema-revision":
+		fixture.paddedSchemaRevision = true
+	case "unreadable-read-only-field":
+		fixture.unreadableReadOnlyField = true
+	default:
+		t.Fatal("unknown declarative contract probe")
+	}
+	if os.Getenv("KATA_CONFORMANCE_DECLARATIVE_RUNNER") == "transcripts" {
+		invocation := fixture.Invocation()
+		settings, err := decodeTranscriptJSON(invocation.Settings)
+		if err != nil {
+			t.Fatalf("decode fixture settings: %v", err)
+		}
+		runProtocolV1Transcripts(t.Context(), t, fixture, invocation.Instance, settings)
+		return
+	}
+	Run(t, fixture)
+}
+
+func TestRunReadsProviderStateAndValidatesFrontiers(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		mode    string
+		subtest string
+	}{
+		{name: "cached publication", mode: "cached-publication", subtest: "language-neutral protocol transcripts"},
+		{name: "cached field write", mode: "cached-field", subtest: "language-neutral protocol transcripts"},
+		{name: "fabricated root read", mode: "fabricated-root", subtest: "language-neutral protocol transcripts"},
+		{name: "fabricated comments", mode: "fabricated-comments", subtest: "language-neutral protocol transcripts"},
+		{name: "duplicate publication after crash", mode: "duplicate-publication-after-crash", subtest: "language-neutral protocol transcripts"},
+		{name: "stale completion timestamp", mode: "stale-completion-time", subtest: "language-neutral protocol transcripts"},
+		{name: "stale publication timestamp", mode: "stale-publication-time", subtest: "language-neutral protocol transcripts"},
+		{name: "future observation", mode: "future-observation", subtest: "language-neutral protocol transcripts"},
+		{name: "no prefrontier comment", mode: "no-prefrontier", subtest: "language-neutral protocol transcripts"},
+		{name: "unsafe multiline diagnostic", mode: "unsafe-error", subtest: "language-neutral protocol transcripts"},
+		{name: "nested forbidden mutation key", mode: "forbidden-mutation", subtest: "language-neutral protocol transcripts"},
+		{name: "camel issue ID", mode: "forbidden-issue-id", subtest: "language-neutral protocol transcripts"},
+		{name: "camel issue UID", mode: "forbidden-issue-uid", subtest: "language-neutral protocol transcripts"},
+		{name: "camel issue short ID", mode: "forbidden-issue-short-id", subtest: "language-neutral protocol transcripts"},
+		{name: "camel child root", mode: "forbidden-child-root", subtest: "language-neutral protocol transcripts"},
+		{name: "camel work attention", mode: "forbidden-work-attention", subtest: "language-neutral protocol transcripts"},
+		{name: "kebab issue ID", mode: "forbidden-kebab-issue-id", subtest: "language-neutral protocol transcripts"},
+		{name: "dotted child root", mode: "forbidden-dotted-child-root", subtest: "language-neutral protocol transcripts"},
+		{name: "camel Kata UID", mode: "forbidden-kata-uid", subtest: "language-neutral protocol transcripts"},
+		{name: "kebab Kata ref", mode: "forbidden-kata-ref", subtest: "language-neutral protocol transcripts"},
+		{name: "dotted Kata project ID", mode: "forbidden-kata-project-id", subtest: "language-neutral protocol transcripts"},
+		{name: "camel Kata binding ID", mode: "forbidden-kata-binding-id", subtest: "language-neutral protocol transcripts"},
+		{name: "camel Kata work branch", mode: "forbidden-kata-work-branch", subtest: "language-neutral protocol transcripts"},
+		{name: "arbitrary Kata owner", mode: "forbidden-arbitrary-kata", subtest: "language-neutral protocol transcripts"},
+		{name: "wrong mutation value type", mode: "wrong-mutation-type", subtest: "language-neutral protocol transcripts"},
+		{name: "trailing mutation JSON", mode: "trailing-mutation", subtest: "language-neutral protocol transcripts"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestBrokenProviderStateProbe$") // #nosec G204,G702 -- the current test executable is fixed by the Go test runner.
+			command.Env = append(os.Environ(), "KATA_CONFORMANCE_STATE_PROBE="+test.mode)
+			output, err := command.CombinedOutput()
+			if err == nil {
+				t.Fatalf("Run accepted broken fixture %q:\n%s", test.mode, output)
+			}
+			if !strings.Contains(string(output), strings.ReplaceAll(test.subtest, " ", "_")) {
+				t.Fatalf("Run failed outside %q for %q:\n%s", test.subtest, test.mode, output)
+			}
+		})
+	}
+}
+
+func TestBrokenProviderStateProbe(t *testing.T) {
+	mode := os.Getenv("KATA_CONFORMANCE_STATE_PROBE")
+	if mode == "" {
+		t.Skip("subprocess probe")
+	}
+	fixture := newFixture()
+	switch mode {
+	case "cached-publication":
+		fixture.discardProviderComment = true
+	case "cached-field":
+		fixture.discardProviderFields = true
+	case "fabricated-root":
+		fixture.fabricatedRootRead = true
+	case "fabricated-comments":
+		fixture.fabricatedComments = true
+	case "duplicate-publication-after-crash":
+		fixture.duplicateAfterCrash = true
+	case "stale-completion-time":
+		fixture.staleCompletionTime = true
+	case "stale-publication-time":
+		fixture.stalePublicationTime = true
+	case "future-observation":
+		fixture.futureObservation = true
+	case "no-prefrontier":
+		fixture.omitPrefrontierComment = true
+	case "unsafe-error":
+		fixture.errorMode = "unsafe"
+	case "forbidden-mutation":
+		fixture.forbiddenMutationKey = "issue_id"
+	case "forbidden-issue-id":
+		fixture.forbiddenMutationKey = "issueId"
+	case "forbidden-issue-uid":
+		fixture.forbiddenMutationKey = "issueUid"
+	case "forbidden-issue-short-id":
+		fixture.forbiddenMutationKey = "issueShortId"
+	case "forbidden-child-root":
+		fixture.forbiddenMutationKey = "childRoot"
+	case "forbidden-work-attention":
+		fixture.forbiddenMutationKey = "workAttention"
+	case "forbidden-kebab-issue-id":
+		fixture.forbiddenMutationKey = "issue-id"
+	case "forbidden-dotted-child-root":
+		fixture.forbiddenMutationKey = "child.root"
+	case "forbidden-kata-uid":
+		fixture.forbiddenFieldValueKey = "kataUid"
+	case "forbidden-kata-ref":
+		fixture.forbiddenFieldValueKey = "kata-ref"
+	case "forbidden-kata-project-id":
+		fixture.forbiddenFieldValueKey = "kata.project.id"
+	case "forbidden-kata-binding-id":
+		fixture.forbiddenFieldValueKey = "kataBindingId"
+	case "forbidden-kata-work-branch":
+		fixture.forbiddenFieldValueKey = "kataWorkBranch"
+	case "forbidden-arbitrary-kata":
+		fixture.forbiddenFieldValueKey = "kataOwnerId"
+	case "wrong-mutation-type":
+		fixture.wrongMutationType = true
+	case "trailing-mutation":
+		fixture.trailingMutation = true
+	default:
+		t.Fatalf("unknown state probe %q", mode)
+	}
+	Run(t, fixture)
+}
+
+func TestRunAllowsAdvancingObservation(t *testing.T) {
+	fixture := newFixture()
+	fixture.advanceObservation = true
+	Run(t, fixture)
+}
+
+func TestRunAllowsHarmlessErrorCode(t *testing.T) {
+	fixture := newFixture()
+	fixture.errorMode = "configuration"
+	Run(t, fixture)
+}
+
+func TestRunAllowsDateOnlyFieldsFixture(t *testing.T) {
+	fixture := newFixture()
+	fixture.dateOnlyFields = true
+	Run(t, fixture)
+}
+
+func TestMutationAuditTreatsFieldIDsAsOpaque(t *testing.T) {
+	raw := json.RawMessage(`{"root_key":"root-example","fields":{"issueId":{"kind":"date","value":"2026-08-26"},"katakana_start":{"kind":"null"},"kata_uid":{"kind":"null"}}}`)
+	if err := auditMutationParams("write_fields", raw, "root-example"); err != nil {
+		t.Fatalf("opaque external field IDs were treated as structural identity channels: %v", err)
+	}
+}
+
+func TestMutationAuditRejectsForbiddenKataKeysInsideFieldValues(t *testing.T) {
+	for _, key := range []string{
+		"kata_uid", "kataUid", "kata-uid", "kata.uid",
+		"kata_ref", "kataRef", "kata-ref", "kata.ref",
+		"kata_project_id", "kataProjectId", "kata-project-id", "kata.project.id",
+		"kata_binding_id", "kataBindingId", "kata-binding-id", "kata.binding.id",
+		"kata_work_branch", "kataWorkBranch", "kata-work-branch", "kata.work.branch",
+	} {
+		raw, err := json.Marshal(map[string]any{
+			"root_key": "root-example",
+			"fields": map[string]any{
+				"kata_uid": map[string]any{"kind": "date", "value": "2026-08-20", key: "neutral-forbidden"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := auditMutationParams("write_fields", raw, "root-example"); err == nil {
+			t.Fatalf("forbidden key variant %q was accepted", key)
+		}
+	}
+}
+
+func TestMutationAuditRejectsWrongTypesAndArbitraryKataChannels(t *testing.T) {
+	for _, raw := range []json.RawMessage{
+		json.RawMessage(`{"root_key":"root-example","body":{}}`),
+		json.RawMessage(`{"root_key":"root-example","fields":"field-example"}`),
+		json.RawMessage(`{"root_key":"root-example","fields":{"katakana_start":{"kind":"date","value":"2026-08-20","kataOwnerId":"neutral-forbidden"}}}`),
+	} {
+		method := "write_fields"
+		if bytes.Contains(raw, []byte(`"body"`)) {
+			method = "publish_comment"
+		}
+		if err := auditMutationParams(method, raw, "root-example"); err == nil {
+			t.Fatalf("%s invalid params accepted: %s", method, raw)
+		}
+	}
+}
+
+func TestRunRejectsUnsafeDiagnosticErrors(t *testing.T) {
+	for _, test := range []struct{ name, method, message string }{
+		{name: "absolute Unix path", method: "resolve_root", message: "/example/runtime/adapter"},
+		{name: "embedded absolute Unix path", method: "resolve_root", message: "open /opt/example-adapter/config.json: permission denied"},
+		{name: "absolute Windows path", method: "read_root", message: `C:\example\runtime\adapter.exe`},
+		{name: "embedded Windows path", method: "read_root", message: `open D:\example-adapter\config.json: permission denied`},
+		{name: "embedded UNC path", method: "read_root", message: `open \\daemon.example\example-share\config.json: permission denied`},
+		{name: "control character", method: "list_comments", message: "adapter failed\nwith details"},
+		{name: "exec whitespace", method: "publish_comment", message: "exec adapter --mode check"},
+		{name: "exec equals mixed case", method: "publish_comment", message: "ExEc = example-adapter --mode check"},
+		{name: "exec colon mixed case", method: "publish_comment", message: "EXEC: example-adapter --mode check"},
+		{name: "command equals", method: "publish_comment", message: "command = example-adapter --mode check"},
+		{name: "stderr colon", method: "read_fields", message: "stderr: adapter unavailable"},
+		{name: "stderr equals mixed case", method: "read_fields", message: "StdErR = adapter unavailable"},
+		{name: "stdout colon", method: "read_fields", message: "stdout: adapter unavailable"},
+		{name: "stdout equals spaced", method: "read_fields", message: "STDOUT  =  adapter unavailable"},
+		{name: "exit status whitespace", method: "write_fields", message: "exit status 17"},
+		{name: "exit status equals mixed case", method: "write_fields", message: "Exit Status = 17"},
+		{name: "config path", method: "complete_root", message: "config path: example/runtime/settings"},
+		{name: "raw config JSON", method: "complete_root", message: `config: {"token":"raw-value"}`},
+		{name: "raw configuration JSON equals", method: "complete_root", message: `CONFIGURATION = ["raw-value"]`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestUnsafeDiagnosticErrorProbe$") // #nosec G204,G702 -- fixed current test executable.
+			command.Env = append(os.Environ(), "KATA_CONFORMANCE_ERROR_METHOD="+test.method, "KATA_CONFORMANCE_ERROR_MESSAGE="+test.message)
+			output, err := command.CombinedOutput()
+			if err == nil {
+				t.Fatalf("Run accepted unsafe diagnostic for %s:\n%s", test.method, output)
+			}
+			if !strings.Contains(string(output), "language-neutral_protocol_transcripts") {
+				t.Fatalf("Run failed outside safe-error conformance for %s:\n%s", test.method, output)
+			}
+		})
+	}
+}
+
+func TestUnsafeDiagnosticErrorProbe(t *testing.T) {
+	method := os.Getenv("KATA_CONFORMANCE_ERROR_METHOD")
+	if method == "" {
+		t.Skip("subprocess probe")
+	}
+	fixture := newFixture()
+	fixture.errorMethod = method
+	fixture.errorMessage = os.Getenv("KATA_CONFORMANCE_ERROR_MESSAGE")
+	Run(t, fixture)
+}
+
+func (f *memoryFixture) ExchangeWithoutOverride(ctx context.Context, request []byte) ([]byte, error) {
+	var response bytes.Buffer
+	err := connector.ServeOne(ctx, bytes.NewReader(request), &response, f)
+	return response.Bytes(), err
+}
+
+func (f *memoryFixture) Reset(context.Context) error {
+	observed := time.Now().UTC()
+	base := observed.Add(-10 * time.Minute)
+	f.resetCalls++
+	f.rootLocator = "fixture-root"
+	f.description = connector.Description{
+		ConnectorID: "example.connector", DisplayName: "Example Connector",
+		Protocol: connector.ProtocolVersion,
+		Capabilities: []connector.Capability{
+			connector.CapabilityFields, connector.CapabilityPublishComment,
+		},
+		ConfigSchema:    []byte(`{"type":"object","additionalProperties":false}`),
+		SelfActorID:     "actor-self",
+		AccountIdentity: "account-example",
+	}
+	f.root = connector.Root{
+		Key: "root-example", IdentityKey: "account-example", Title: "Example root", Body: "Example body",
+		State: "open", Revision: "revision-1", UpdatedAt: base, ObservedAt: observed,
+		Fields: map[string]connector.FieldValue{
+			"katakana_start": {Kind: "date", Value: "2026-08-20"},
+			"field-local":    {Kind: "local_datetime", Value: "2026-08-20T11:30:00", Timezone: "Europe/Paris"},
+			"field-instant":  {Kind: "instant", Value: "2026-08-20T09:30:00Z"},
+			"field-null":     {Kind: "null"},
+			"field-readonly": {Kind: "date", Value: "2026-08-20"},
+		},
+	}
+	if f.unstableResetIdentity {
+		suffix := "-" + strconv.Itoa(f.resetCalls)
+		f.rootLocator += suffix
+		f.description.ConnectorID += suffix
+		f.description.AccountIdentity += suffix
+		f.root.Key += suffix
+		f.root.IdentityKey = f.description.AccountIdentity
+	}
+	f.comments = []connector.Comment{
+		{ID: "comment-before-frontier", Revision: "comment-revision-1", Body: "Existing comment", Author: connector.Actor{ID: "actor-history", DisplayName: "Historical Reviewer"}, CreatedAt: base.Add(-time.Minute), UpdatedAt: base.Add(-time.Minute)},
+		{ID: "comment-active", Revision: "comment-revision-2", Body: "Active comment", Author: connector.Actor{ID: "actor-a", DisplayName: "Reviewer A"}, CreatedAt: base.Add(time.Minute), UpdatedAt: base.Add(time.Minute)},
+		{ID: "comment-edited", Revision: "comment-revision-3", Body: "Corrected comment", Author: connector.Actor{ID: "actor-b", DisplayName: "Reviewer B"}, CreatedAt: base.Add(2 * time.Minute), UpdatedAt: base.Add(3 * time.Minute)},
+		{ID: "comment-deleted", Revision: "comment-revision-4", Author: connector.Actor{ID: "actor-c", DisplayName: "Reviewer C"}, CreatedAt: base.Add(4 * time.Minute), UpdatedAt: base.Add(5 * time.Minute), Deleted: true},
+	}
+	if f.noEditedComment {
+		for index := range f.comments {
+			f.comments[index].UpdatedAt = f.comments[index].CreatedAt
+		}
+	}
+	if f.noDeletedComment {
+		for index := range f.comments {
+			f.comments[index].Deleted = false
+		}
+	}
+	if f.missingCommentTime {
+		f.comments[0].CreatedAt = time.Time{}
+	}
+	if f.missingCommentRevision {
+		f.comments[0].Revision = ""
+	}
+	if f.constantCommentRevision {
+		for index := range f.comments {
+			f.comments[index].Revision = "comment-revision-constant"
+		}
+	}
+	if f.omitPrefrontierComment {
+		f.comments = f.comments[1:]
+		for index := range f.comments {
+			f.comments[index].CreatedAt = observed.Add(time.Duration(index+1) * time.Minute)
+			f.comments[index].UpdatedAt = f.comments[index].CreatedAt
+			if f.comments[index].ID == "comment-edited" {
+				f.comments[index].UpdatedAt = f.comments[index].CreatedAt.Add(time.Minute)
+			}
+		}
+	}
+	if f.futureObservation {
+		f.root.ObservedAt = time.Now().UTC().Add(time.Hour)
+	}
+	if f.dateOnlyFields {
+		f.root.Fields = map[string]connector.FieldValue{
+			"field-date-only": {Kind: "date", Value: "2026-08-20"},
+		}
+	}
+	f.providerComments = append([]connector.Comment(nil), f.comments...)
+	f.providerFields = make(map[string]connector.FieldValue, len(f.root.Fields))
+	maps.Copy(f.providerFields, f.root.Fields)
+	f.descriptors = []connector.FieldDescriptor{
+		{ID: "katakana_start", DisplayName: "Date", AcceptedKinds: []string{"date"}, Nullable: true, Writable: true, SchemaRevision: "schema-1"},
+		{ID: "field-local", DisplayName: "Local", AcceptedKinds: []string{"local_datetime"}, Nullable: true, Writable: true, SchemaRevision: "schema-1"},
+		{ID: "field-instant", DisplayName: "Instant", AcceptedKinds: []string{"instant"}, Nullable: true, Writable: true, SchemaRevision: "schema-1"},
+		{ID: "field-null", DisplayName: "Nullable", AcceptedKinds: []string{"date", "local_datetime", "instant"}, Nullable: true, Writable: true, SchemaRevision: "schema-1"},
+		{ID: "field-readonly", DisplayName: "Read only", AcceptedKinds: []string{"date"}, Writable: false, SchemaRevision: "schema-1"},
+	}
+	if f.noActionableField {
+		f.descriptors = []connector.FieldDescriptor{{
+			ID: "field-inert", DisplayName: "Inert", AcceptedKinds: []string{}, Writable: true, SchemaRevision: "schema-1",
+		}}
+	}
+	if f.dateOnlyFields {
+		f.descriptors = []connector.FieldDescriptor{{
+			ID: "field-date-only", DisplayName: "Date", AcceptedKinds: []string{"date"},
+			Nullable: false, Writable: true, SchemaRevision: "schema-1",
+		}}
+	}
+	if f.paddedFieldID {
+		f.descriptors[0].ID = " " + f.descriptors[0].ID + " "
+	}
+	if f.paddedSchemaRevision {
+		f.descriptors[0].SchemaRevision = " " + f.descriptors[0].SchemaRevision + " "
+	}
+	f.mutations = nil
+	f.publications = make(map[string]connector.Comment)
+	f.describeCalls = 0
+	f.crashAfterMutation = false
+	f.publicationCrashed = false
+	return nil
+}
+
+func (f *memoryFixture) ExternalState(context.Context) (RootState, error) {
+	fields := make(map[string]connector.FieldValue, len(f.providerFields))
+	maps.Copy(fields, f.providerFields)
+	return RootState{
+		Root: f.root, Comments: append([]connector.Comment(nil), f.providerComments...),
+		Fields: fields, Mutations: append([]Mutation(nil), f.mutations...),
+	}, nil
+}
+
+func (f *memoryFixture) Describe(context.Context, connector.DescribeParams) (connector.Description, *connector.Error) {
+	f.describeCalls++
+	description := f.description
+	if f.unstableDescription && f.describeCalls > 1 {
+		description.DisplayName = "Changed connector"
+	}
+	return description, nil
+}
+
+func (f *memoryFixture) ResolveRoot(_ context.Context, params connector.ResolveRootParams) (connector.Root, *connector.Error) {
+	if params.Locator != f.RootLocator() {
+		return connector.Root{}, f.fixtureError("resolve_root")
+	}
+	return f.observedRoot(), nil
+}
+
+func (f *memoryFixture) ReadRoot(_ context.Context, params connector.ReadRootParams) (connector.Root, *connector.Error) {
+	if params.RootKey != f.root.Key {
+		return connector.Root{}, f.fixtureError("read_root")
+	}
+	return f.observedRoot(), nil
+}
+
+func (f *memoryFixture) observedRoot() connector.Root {
+	if f.advanceObservation {
+		now := time.Now().UTC()
+		if !now.After(f.root.ObservedAt) {
+			now = f.root.ObservedAt.Add(time.Nanosecond)
+		}
+		f.root.ObservedAt = now
+	}
+	root := f.root
+	if f.fabricatedRootRead {
+		root.Title = "Fabricated root"
+	}
+	return root
+}
+
+func (f *memoryFixture) ListComments(_ context.Context, params connector.ListCommentsParams) (connector.ListCommentsResult, *connector.Error) {
+	if params.RootKey != f.root.Key {
+		return connector.ListCommentsResult{}, f.fixtureError("list_comments")
+	}
+	comments := append([]connector.Comment(nil), f.comments...)
+	sort.SliceStable(comments, func(i, j int) bool {
+		if comments[i].CreatedAt.Equal(comments[j].CreatedAt) {
+			return comments[i].ID < comments[j].ID
+		}
+		return comments[i].CreatedAt.Before(comments[j].CreatedAt)
+	})
+	if f.reverseComments {
+		for left, right := 0, len(comments)-1; left < right; left, right = left+1, right-1 {
+			comments[left], comments[right] = comments[right], comments[left]
+		}
+	}
+	if f.fabricatedComments {
+		comments[0].Body = "Fabricated comment"
+	}
+	return connector.ListCommentsResult{Comments: comments}, nil
+}
+
+func (f *memoryFixture) CompleteRoot(_ context.Context, params connector.CompleteRootParams) (connector.Root, *connector.Error) {
+	if params.RootKey != f.root.Key {
+		return connector.Root{}, f.fixtureError("complete_root")
+	}
+	f.fabricatedRootRead = false
+	if f.root.State != "complete" {
+		f.root.State = "complete"
+		if !f.unchangedCompletionRev {
+			f.root.Revision = "revision-complete"
+		}
+		if !f.staleCompletionTime {
+			f.root.UpdatedAt = nextMutationTime(f.root.UpdatedAt, f.root.ObservedAt)
+		}
+		f.root.ObservedAt = f.root.UpdatedAt
+	}
+	if f.nonIdempotentComplete {
+		f.root.Revision += "-changed"
+		f.root.UpdatedAt = nextMutationTime(f.root.UpdatedAt, f.root.ObservedAt)
+		f.root.ObservedAt = f.root.UpdatedAt
+	}
+	f.recordMutation("complete_root", params)
+	if f.forbiddenMutationKey != "" {
+		encoded, err := json.Marshal(map[string]any{"root_key": "root-example", "nested": map[string]any{f.forbiddenMutationKey: "neutral-forbidden"}})
+		if err != nil {
+			panic(err)
+		}
+		f.mutations = append(f.mutations, Mutation{
+			Method: "complete_root",
+			Params: encoded,
+		})
+	}
+	if f.trailingMutation {
+		f.mutations = append(f.mutations, Mutation{Method: "complete_root", Params: json.RawMessage(`{"root_key":"root-example"} {"issueId":"neutral-forbidden"}`)})
+	}
+	return f.root, nil
+}
+
+func (f *memoryFixture) PublishComment(_ context.Context, params connector.PublishCommentParams) (connector.Comment, *connector.Error) {
+	if params.RootKey != f.root.Key {
+		return connector.Comment{}, f.fixtureError("publish_comment")
+	}
+	if published, ok := f.publications[params.OperationID]; ok && (!f.duplicateAfterCrash || !f.publicationCrashed) {
+		return published, nil
+	}
+	f.publicationCrashed = false
+	stamp := nextMutationTime(f.root.UpdatedAt, f.root.ObservedAt)
+	for _, comment := range f.providerComments {
+		stamp = nextMutationTime(stamp, comment.CreatedAt, comment.UpdatedAt)
+	}
+	created := connector.Comment{
+		ID: "comment-published", Revision: "comment-revision-published", Body: params.Body,
+		Author:    connector.Actor{ID: f.description.SelfActorID, DisplayName: "Connector Actor"},
+		CreatedAt: stamp, UpdatedAt: stamp,
+	}
+	if f.stalePublicationTime {
+		created.CreatedAt = f.root.UpdatedAt.Add(-time.Hour)
+		created.UpdatedAt = created.CreatedAt
+	}
+	f.comments = append(f.comments, created)
+	f.publications[params.OperationID] = created
+	if !f.discardProviderComment {
+		f.providerComments = append(f.providerComments, created)
+	}
+	f.recordMutation("publish_comment", params)
+	if f.wrongMutationType {
+		f.mutations = append(f.mutations, Mutation{
+			Method: "publish_comment",
+			Params: json.RawMessage(`{"root_key":"root-example","body":{}}`),
+		})
+	}
+	return created, nil
+}
+
+func nextMutationTime(providerTimes ...time.Time) time.Time {
+	stamp := time.Now().UTC()
+	for _, providerTime := range providerTimes {
+		if !stamp.After(providerTime) {
+			stamp = providerTime.Add(time.Nanosecond)
+		}
+	}
+	return stamp
+}
+
+func (f *memoryFixture) ListFields(context.Context, connector.ListFieldsParams) (connector.ListFieldsResult, *connector.Error) {
+	return connector.ListFieldsResult{Fields: append([]connector.FieldDescriptor(nil), f.descriptors...)}, nil
+}
+
+func (f *memoryFixture) ReadFields(_ context.Context, params connector.ReadFieldsParams) (connector.ReadFieldsResult, *connector.Error) {
+	if params.RootKey != f.root.Key {
+		return connector.ReadFieldsResult{}, f.fixtureError("read_fields")
+	}
+	values := make(map[string]connector.FieldValue, len(params.FieldIDs))
+	for _, id := range params.FieldIDs {
+		if f.unreadableReadOnlyField && id == "field-readonly" {
+			return connector.ReadFieldsResult{}, &connector.Error{Code: "field_unreadable", Message: "field cannot be read"}
+		}
+		value, ok := f.root.Fields[id]
+		if !ok {
+			return connector.ReadFieldsResult{}, &connector.Error{Code: "field_not_found", Message: "field was not found"}
+		}
+		values[id] = value
+	}
+	return connector.ReadFieldsResult{Fields: values}, nil
+}
+
+func (f *memoryFixture) WriteFields(_ context.Context, params connector.WriteFieldsParams) (connector.WriteFieldsResult, *connector.Error) {
+	if params.RootKey != f.root.Key {
+		return connector.WriteFieldsResult{}, f.fixtureError("write_fields")
+	}
+	for _, value := range params.Fields {
+		if value.Kind == f.rejectFieldKind {
+			return connector.WriteFieldsResult{}, &connector.Error{Code: "unsupported_field", Message: "field kind is unsupported"}
+		}
+	}
+	for id, value := range params.Fields {
+		f.root.Fields[id] = value
+		if !f.discardProviderFields {
+			f.providerFields[id] = value
+		}
+	}
+	f.recordMutation("write_fields", params)
+	if f.forbiddenFieldValueKey != "" {
+		encoded, err := json.Marshal(map[string]any{
+			"root_key": "root-example",
+			"fields": map[string]any{
+				"kata_uid": map[string]any{"kind": "date", "value": "2026-08-20", f.forbiddenFieldValueKey: "neutral-forbidden"},
+			},
+		})
+		if err != nil {
+			panic(err)
+		}
+		f.mutations = append(f.mutations, Mutation{Method: "write_fields", Params: encoded})
+	}
+	return connector.WriteFieldsResult{Fields: params.Fields}, nil
+}
+
+func (f *memoryFixture) recordMutation(method string, params any) {
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		panic(err)
+	}
+	f.mutations = append(f.mutations, Mutation{Method: method, Params: encoded})
+}
+
+func (f *memoryFixture) fixtureError(method string) *connector.Error {
+	if f.errorMethod == method {
+		return &connector.Error{Code: "root_not_found", Message: f.errorMessage}
+	}
+	switch f.errorMode {
+	case "configuration":
+		return &connector.Error{Code: "configuration_invalid", Message: "configuration requires a valid root"}
+	case "unsafe":
+		return &connector.Error{Code: "root_not_found", Message: "request failed\nstack trace"}
+	default:
+		return &connector.Error{Code: "root_not_found", Message: "root was not found"}
+	}
+}

--- a/pkg/connector/conformance/testdata/protocol-v1/errors.json
+++ b/pkg/connector/conformance/testdata/protocol-v1/errors.json
@@ -1,0 +1,208 @@
+{
+  "schema": "kata.connector.conformance/v1",
+  "protocol": "kata.connector.v1",
+  "name": "framing-and-errors",
+  "steps": [
+    {
+      "name": "describe",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-error-describe", "method": "describe", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/describe/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/describe/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/describe/response/id"}, "expected": {"path": "/steps/describe/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/describe/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/describe/response/error"}}
+      ],
+      "capture": [
+        {"name": "description", "value": {"path": "/steps/describe/response/result"}}
+      ]
+    },
+    {
+      "name": "resolve-root-error",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-error-resolve", "method": "resolve_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"locator": "missing-external-root"}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-error/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-error/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-error/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-error/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-error/response/id"}, "expected": {"path": "/steps/resolve-root-error/request/id"}},
+        {"op": "absent", "actual": {"path": "/steps/resolve-root-error/response/result"}},
+        {"op": "present", "actual": {"path": "/steps/resolve-root-error/response/error"}},
+        {"op": "matches", "actual": {"path": "/steps/resolve-root-error/response/error/code"}, "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+        {"op": "nonempty", "actual": {"path": "/steps/resolve-root-error/response/error/message"}},
+        {"op": "trimmed", "actual": {"path": "/steps/resolve-root-error/response/error/message"}},
+        {"op": "max_length", "actual": {"path": "/steps/resolve-root-error/response/error/message"}, "expected": {"literal": 512}},
+        {"op": "no_control", "actual": {"path": "/steps/resolve-root-error/response/error/message"}},
+        {"op": "valid_utf8", "actual": {"path": "/steps/resolve-root-error/exchange/output"}},
+        {"op": "not_matches", "actual": {"path": "/steps/resolve-root-error/response/error/message"}, "pattern": "(?i)(panic:|stack trace|goroutine |stdout\\s*[:=]|stderr\\s*[:=]|command\\s*[:=]|exec(?:\\s+|\\s*[:=])|exit[\\s_.-]*status|config(?:uration)?\\s+path\\s*[:=]|config(?:uration)?\\s*[:=]\\s*[\\[{])"},
+        {"op": "not_matches", "actual": {"path": "/steps/resolve-root-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])/(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/resolve-root-error/response/error/message"}, "pattern": "(?i)(?:^|[\\s(\"'=\\[{])[a-z]:[\\\\/][^\\s:]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/resolve-root-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])(?:\\\\\\\\)[A-Za-z0-9._-]+\\\\[A-Za-z0-9.$_-]+"}
+      ]
+    },
+    {
+      "name": "read-root-error",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-error-read", "method": "read_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": "missing-external-root"}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/read-root-error/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/read-root-error/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/read-root-error/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/read-root-error/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/read-root-error/response/id"}, "expected": {"path": "/steps/read-root-error/request/id"}},
+        {"op": "absent", "actual": {"path": "/steps/read-root-error/response/result"}},
+        {"op": "present", "actual": {"path": "/steps/read-root-error/response/error"}},
+        {"op": "matches", "actual": {"path": "/steps/read-root-error/response/error/code"}, "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+        {"op": "nonempty", "actual": {"path": "/steps/read-root-error/response/error/message"}},
+        {"op": "trimmed", "actual": {"path": "/steps/read-root-error/response/error/message"}},
+        {"op": "max_length", "actual": {"path": "/steps/read-root-error/response/error/message"}, "expected": {"literal": 512}},
+        {"op": "no_control", "actual": {"path": "/steps/read-root-error/response/error/message"}},
+        {"op": "valid_utf8", "actual": {"path": "/steps/read-root-error/exchange/output"}},
+        {"op": "not_matches", "actual": {"path": "/steps/read-root-error/response/error/message"}, "pattern": "(?i)(panic:|stack trace|goroutine |stdout\\s*[:=]|stderr\\s*[:=]|command\\s*[:=]|exec(?:\\s+|\\s*[:=])|exit[\\s_.-]*status|config(?:uration)?\\s+path\\s*[:=]|config(?:uration)?\\s*[:=]\\s*[\\[{])"},
+        {"op": "not_matches", "actual": {"path": "/steps/read-root-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])/(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/read-root-error/response/error/message"}, "pattern": "(?i)(?:^|[\\s(\"'=\\[{])[a-z]:[\\\\/][^\\s:]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/read-root-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])(?:\\\\\\\\)[A-Za-z0-9._-]+\\\\[A-Za-z0-9.$_-]+"}
+      ]
+    },
+    {
+      "name": "list-comments-error",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-error-comments", "method": "list_comments", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": "missing-external-root"}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/list-comments-error/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-error/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-error/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-error/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-error/response/id"}, "expected": {"path": "/steps/list-comments-error/request/id"}},
+        {"op": "absent", "actual": {"path": "/steps/list-comments-error/response/result"}},
+        {"op": "present", "actual": {"path": "/steps/list-comments-error/response/error"}},
+        {"op": "matches", "actual": {"path": "/steps/list-comments-error/response/error/code"}, "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+        {"op": "nonempty", "actual": {"path": "/steps/list-comments-error/response/error/message"}},
+        {"op": "trimmed", "actual": {"path": "/steps/list-comments-error/response/error/message"}},
+        {"op": "max_length", "actual": {"path": "/steps/list-comments-error/response/error/message"}, "expected": {"literal": 512}},
+        {"op": "no_control", "actual": {"path": "/steps/list-comments-error/response/error/message"}},
+        {"op": "valid_utf8", "actual": {"path": "/steps/list-comments-error/exchange/output"}},
+        {"op": "not_matches", "actual": {"path": "/steps/list-comments-error/response/error/message"}, "pattern": "(?i)(panic:|stack trace|goroutine |stdout\\s*[:=]|stderr\\s*[:=]|command\\s*[:=]|exec(?:\\s+|\\s*[:=])|exit[\\s_.-]*status|config(?:uration)?\\s+path\\s*[:=]|config(?:uration)?\\s*[:=]\\s*[\\[{])"},
+        {"op": "not_matches", "actual": {"path": "/steps/list-comments-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])/(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/list-comments-error/response/error/message"}, "pattern": "(?i)(?:^|[\\s(\"'=\\[{])[a-z]:[\\\\/][^\\s:]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/list-comments-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])(?:\\\\\\\\)[A-Za-z0-9._-]+\\\\[A-Za-z0-9.$_-]+"}
+      ]
+    },
+    {
+      "name": "publish-comment-error",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-error-publish", "method": "publish_comment", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": "missing-external-root", "body": "Example body", "operation_id": "conformance-publication-error"}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-error/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-error/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-error/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-error/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-error/response/id"}, "expected": {"path": "/steps/publish-comment-error/request/id"}},
+        {"op": "absent", "actual": {"path": "/steps/publish-comment-error/response/result"}},
+        {"op": "present", "actual": {"path": "/steps/publish-comment-error/response/error"}},
+        {"op": "matches", "actual": {"path": "/steps/publish-comment-error/response/error/code"}, "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+        {"op": "nonempty", "actual": {"path": "/steps/publish-comment-error/response/error/message"}},
+        {"op": "trimmed", "actual": {"path": "/steps/publish-comment-error/response/error/message"}},
+        {"op": "max_length", "actual": {"path": "/steps/publish-comment-error/response/error/message"}, "expected": {"literal": 512}},
+        {"op": "no_control", "actual": {"path": "/steps/publish-comment-error/response/error/message"}},
+        {"op": "valid_utf8", "actual": {"path": "/steps/publish-comment-error/exchange/output"}},
+        {"op": "not_matches", "actual": {"path": "/steps/publish-comment-error/response/error/message"}, "pattern": "(?i)(panic:|stack trace|goroutine |stdout\\s*[:=]|stderr\\s*[:=]|command\\s*[:=]|exec(?:\\s+|\\s*[:=])|exit[\\s_.-]*status|config(?:uration)?\\s+path\\s*[:=]|config(?:uration)?\\s*[:=]\\s*[\\[{])"},
+        {"op": "not_matches", "actual": {"path": "/steps/publish-comment-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])/(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/publish-comment-error/response/error/message"}, "pattern": "(?i)(?:^|[\\s(\"'=\\[{])[a-z]:[\\\\/][^\\s:]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/publish-comment-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])(?:\\\\\\\\)[A-Za-z0-9._-]+\\\\[A-Za-z0-9.$_-]+"}
+      ]
+    },
+    {
+      "name": "complete-root-error",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-error-complete", "method": "complete_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": "missing-external-root"}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/complete-root-error/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-error/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-error/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-error/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-error/response/id"}, "expected": {"path": "/steps/complete-root-error/request/id"}},
+        {"op": "absent", "actual": {"path": "/steps/complete-root-error/response/result"}},
+        {"op": "present", "actual": {"path": "/steps/complete-root-error/response/error"}},
+        {"op": "matches", "actual": {"path": "/steps/complete-root-error/response/error/code"}, "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+        {"op": "nonempty", "actual": {"path": "/steps/complete-root-error/response/error/message"}},
+        {"op": "trimmed", "actual": {"path": "/steps/complete-root-error/response/error/message"}},
+        {"op": "max_length", "actual": {"path": "/steps/complete-root-error/response/error/message"}, "expected": {"literal": 512}},
+        {"op": "no_control", "actual": {"path": "/steps/complete-root-error/response/error/message"}},
+        {"op": "valid_utf8", "actual": {"path": "/steps/complete-root-error/exchange/output"}},
+        {"op": "not_matches", "actual": {"path": "/steps/complete-root-error/response/error/message"}, "pattern": "(?i)(panic:|stack trace|goroutine |stdout\\s*[:=]|stderr\\s*[:=]|command\\s*[:=]|exec(?:\\s+|\\s*[:=])|exit[\\s_.-]*status|config(?:uration)?\\s+path\\s*[:=]|config(?:uration)?\\s*[:=]\\s*[\\[{])"},
+        {"op": "not_matches", "actual": {"path": "/steps/complete-root-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])/(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/complete-root-error/response/error/message"}, "pattern": "(?i)(?:^|[\\s(\"'=\\[{])[a-z]:[\\\\/][^\\s:]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/complete-root-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])(?:\\\\\\\\)[A-Za-z0-9._-]+\\\\[A-Za-z0-9.$_-]+"}
+      ]
+    },
+    {
+      "name": "read-fields-error",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-error-read-fields", "method": "read_fields", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": "missing-external-root", "field_ids": ["missing-field"]}},
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "fields"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/read-fields-error/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/read-fields-error/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/read-fields-error/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/read-fields-error/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/read-fields-error/response/id"}, "expected": {"path": "/steps/read-fields-error/request/id"}},
+        {"op": "absent", "actual": {"path": "/steps/read-fields-error/response/result"}},
+        {"op": "present", "actual": {"path": "/steps/read-fields-error/response/error"}},
+        {"op": "matches", "actual": {"path": "/steps/read-fields-error/response/error/code"}, "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+        {"op": "nonempty", "actual": {"path": "/steps/read-fields-error/response/error/message"}},
+        {"op": "trimmed", "actual": {"path": "/steps/read-fields-error/response/error/message"}},
+        {"op": "max_length", "actual": {"path": "/steps/read-fields-error/response/error/message"}, "expected": {"literal": 512}},
+        {"op": "no_control", "actual": {"path": "/steps/read-fields-error/response/error/message"}},
+        {"op": "valid_utf8", "actual": {"path": "/steps/read-fields-error/exchange/output"}},
+        {"op": "not_matches", "actual": {"path": "/steps/read-fields-error/response/error/message"}, "pattern": "(?i)(panic:|stack trace|goroutine |stdout\\s*[:=]|stderr\\s*[:=]|command\\s*[:=]|exec(?:\\s+|\\s*[:=])|exit[\\s_.-]*status|config(?:uration)?\\s+path\\s*[:=]|config(?:uration)?\\s*[:=]\\s*[\\[{])"},
+        {"op": "not_matches", "actual": {"path": "/steps/read-fields-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])/(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/read-fields-error/response/error/message"}, "pattern": "(?i)(?:^|[\\s(\"'=\\[{])[a-z]:[\\\\/][^\\s:]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/read-fields-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])(?:\\\\\\\\)[A-Za-z0-9._-]+\\\\[A-Za-z0-9.$_-]+"}
+      ]
+    },
+    {
+      "name": "write-fields-error",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-error-write-fields", "method": "write_fields", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": "missing-external-root", "fields": {"missing-field": {"kind": "null"}}}},
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "fields"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/write-fields-error/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/write-fields-error/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/write-fields-error/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/write-fields-error/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/write-fields-error/response/id"}, "expected": {"path": "/steps/write-fields-error/request/id"}},
+        {"op": "absent", "actual": {"path": "/steps/write-fields-error/response/result"}},
+        {"op": "present", "actual": {"path": "/steps/write-fields-error/response/error"}},
+        {"op": "matches", "actual": {"path": "/steps/write-fields-error/response/error/code"}, "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+        {"op": "nonempty", "actual": {"path": "/steps/write-fields-error/response/error/message"}},
+        {"op": "trimmed", "actual": {"path": "/steps/write-fields-error/response/error/message"}},
+        {"op": "max_length", "actual": {"path": "/steps/write-fields-error/response/error/message"}, "expected": {"literal": 512}},
+        {"op": "no_control", "actual": {"path": "/steps/write-fields-error/response/error/message"}},
+        {"op": "valid_utf8", "actual": {"path": "/steps/write-fields-error/exchange/output"}},
+        {"op": "not_matches", "actual": {"path": "/steps/write-fields-error/response/error/message"}, "pattern": "(?i)(panic:|stack trace|goroutine |stdout\\s*[:=]|stderr\\s*[:=]|command\\s*[:=]|exec(?:\\s+|\\s*[:=])|exit[\\s_.-]*status|config(?:uration)?\\s+path\\s*[:=]|config(?:uration)?\\s*[:=]\\s*[\\[{])"},
+        {"op": "not_matches", "actual": {"path": "/steps/write-fields-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])/(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/write-fields-error/response/error/message"}, "pattern": "(?i)(?:^|[\\s(\"'=\\[{])[a-z]:[\\\\/][^\\s:]+"},
+        {"op": "not_matches", "actual": {"path": "/steps/write-fields-error/response/error/message"}, "pattern": "(?:^|[\\s(\"'=\\[{])(?:\\\\\\\\)[A-Za-z0-9._-]+\\\\[A-Za-z0-9.$_-]+"}
+      ]
+    },
+    {
+      "name": "unsupported-protocol",
+      "request": {"protocol": "unsupported.connector.protocol", "id": "transcript-error-version", "method": "describe", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/unsupported-protocol/exchange/error"}, "expected": {"literal": true}},
+        {"op": "empty", "actual": {"path": "/steps/unsupported-protocol/exchange/output"}},
+        {"op": "equal", "actual": {"path": "/steps/unsupported-protocol/exchange/response_count"}, "expected": {"literal": 0}}
+      ]
+    },
+    {
+      "name": "malformed-json",
+      "raw_request": "{malformed protocol request\n",
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/malformed-json/exchange/error"}, "expected": {"literal": true}},
+        {"op": "empty", "actual": {"path": "/steps/malformed-json/exchange/output"}},
+        {"op": "equal", "actual": {"path": "/steps/malformed-json/exchange/response_count"}, "expected": {"literal": 0}}
+      ]
+    }
+  ]
+}

--- a/pkg/connector/conformance/testdata/protocol-v1/optional.json
+++ b/pkg/connector/conformance/testdata/protocol-v1/optional.json
@@ -1,0 +1,380 @@
+{
+  "schema": "kata.connector.conformance/v1",
+  "protocol": "kata.connector.v1",
+  "name": "optional-capabilities",
+  "field_samples": [
+    {"kind": "date", "value": "2026-08-21"},
+    {"kind": "local_datetime", "value": "2026-08-21T14:45:00", "timezone": "Asia/Tokyo"},
+    {"kind": "instant", "value": "2026-08-21T05:45:00Z"}
+  ],
+  "steps": [
+    {
+      "name": "provider-baseline",
+      "observe": "provider_state",
+      "assert": [
+        {"op": "empty", "actual": {"path": "/steps/provider-baseline/provider/mutations"}}
+      ],
+      "capture": [
+        {"name": "mutation-log", "value": {"path": "/steps/provider-baseline/provider/mutations"}},
+        {"name": "provider-comments", "value": {"path": "/steps/provider-baseline/provider/comments"}},
+        {"name": "provider-field-baseline", "value": {"path": "/steps/provider-baseline/provider/fields"}}
+      ]
+    },
+    {
+      "name": "describe",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-describe", "method": "describe", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/describe/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/describe/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/describe/response/id"}, "expected": {"path": "/steps/describe/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/describe/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/describe/response/error"}}
+      ],
+      "capture": [
+        {"name": "description", "value": {"path": "/steps/describe/response/result"}}
+      ]
+    },
+    {
+      "name": "resolve-root",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-resolve", "method": "resolve_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"locator": {"$ref": "/fixture/root_locator"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/resolve-root/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root/response/id"}, "expected": {"path": "/steps/resolve-root/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/resolve-root/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/resolve-root/response/error"}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root/response/result/identity_key"}, "expected": {"path": "/captures/description/account_identity"}}
+      ],
+      "capture": [
+        {"name": "root", "value": {"path": "/steps/resolve-root/response/result"}}
+      ]
+    },
+    {
+      "name": "arm-publication-crash",
+      "fault": "publish_comment_crash_after_mutation",
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "publish_comment"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/arm-publication-crash/fault"}, "expected": {"literal": "publish_comment_crash_after_mutation"}}
+      ]
+    },
+    {
+      "name": "publish-comment-crash",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-publish-crash", "method": "publish_comment", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}, "body": "connector conformance publication", "operation_id": "conformance-publication-1"}},
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "publish_comment"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-crash/exchange/error"}, "expected": {"literal": true}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-crash/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-crash/exchange/response_count"}, "expected": {"literal": 0}}
+      ]
+    },
+    {
+      "name": "provider-after-publication-crash",
+      "observe": "provider_state",
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "publish_comment"}}
+      ],
+      "assert": [
+        {"op": "array_appended", "actual": {"path": "/steps/provider-after-publication-crash/provider/comments"}, "expected": {"path": "/captures/provider-comments"}},
+        {"op": "array_appended", "actual": {"path": "/steps/provider-after-publication-crash/provider/mutations"}, "expected": {"path": "/captures/mutation-log"}},
+        {"op": "entry_equal", "actual": {"path": "/steps/provider-after-publication-crash/provider/mutations", "last": true}, "key": {"literal": "method"}, "expected": {"literal": "publish_comment"}},
+        {"op": "entry_equal", "actual": {"path": "/steps/provider-after-publication-crash/provider/mutations", "last": true}, "key": {"literal": "params"}, "expected": {"path": "/steps/publish-comment-crash/request/params"}},
+        {"op": "nonempty", "actual": {"path": "/steps/provider-after-publication-crash/provider/comments", "last": true}},
+        {"op": "entry_equal", "actual": {"path": "/steps/provider-after-publication-crash/provider/comments", "last": true}, "key": {"literal": "body"}, "expected": {"path": "/steps/publish-comment-crash/request/params/body"}},
+        {"op": "one", "actual": {"path": "/steps/provider-after-publication-crash/provider/comments"}, "as": "comment", "assert": [
+          {"op": "equal", "actual": {"path": "/vars/comment/body"}, "expected": {"path": "/steps/publish-comment-crash/request/params/body"}},
+          {"op": "nonempty", "actual": {"path": "/vars/comment/revision"}},
+          {"op": "trimmed", "actual": {"path": "/vars/comment/revision"}},
+          {"op": "equal", "actual": {"path": "/vars/comment/author/id"}, "expected": {"path": "/captures/description/self_actor_id"}},
+          {"op": "timestamp", "actual": {"path": "/vars/comment/created_at"}},
+          {"op": "timestamp", "actual": {"path": "/vars/comment/updated_at"}},
+          {"op": "time_gt", "actual": {"path": "/vars/comment/created_at"}, "expected": {"path": "/captures/root/observed_at"}},
+          {"op": "time_gte", "actual": {"path": "/vars/comment/updated_at"}, "expected": {"path": "/vars/comment/created_at"}},
+          {"op": "time_between", "actual": {"path": "/vars/comment/created_at"}, "start": {"path": "/steps/publish-comment-crash/exchange/started_at"}, "end": {"path": "/steps/publish-comment-crash/exchange/finished_at"}, "tolerance_seconds": 120},
+          {"op": "time_between", "actual": {"path": "/vars/comment/updated_at"}, "start": {"path": "/steps/publish-comment-crash/exchange/started_at"}, "end": {"path": "/steps/publish-comment-crash/exchange/finished_at"}, "tolerance_seconds": 120}
+        ]}
+      ],
+      "capture": [
+        {"name": "mutation-log", "value": {"path": "/steps/provider-after-publication-crash/provider/mutations"}},
+        {"name": "published-comments", "value": {"path": "/steps/provider-after-publication-crash/provider/comments"}},
+        {"name": "published-comment", "value": {"path": "/steps/provider-after-publication-crash/provider/comments", "last": true}}
+      ]
+    },
+    {
+      "name": "publish-comment-retry",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-publish-retry", "method": "publish_comment", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}, "body": "connector conformance publication", "operation_id": "conformance-publication-1"}},
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "publish_comment"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-retry/request/params"}, "expected": {"path": "/steps/publish-comment-crash/request/params"}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-retry/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-retry/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-retry/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-retry/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-retry/response/id"}, "expected": {"path": "/steps/publish-comment-retry/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/publish-comment-retry/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/publish-comment-retry/response/error"}},
+        {"op": "nonempty", "actual": {"path": "/steps/publish-comment-retry/response/result/id"}},
+        {"op": "nonempty", "actual": {"path": "/steps/publish-comment-retry/response/result/revision"}},
+        {"op": "trimmed", "actual": {"path": "/steps/publish-comment-retry/response/result/revision"}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-retry/response/result/body"}, "expected": {"path": "/steps/publish-comment-retry/request/params/body"}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-retry/response/result/author/id"}, "expected": {"path": "/captures/description/self_actor_id"}},
+        {"op": "timestamp", "actual": {"path": "/steps/publish-comment-retry/response/result/created_at"}},
+        {"op": "timestamp", "actual": {"path": "/steps/publish-comment-retry/response/result/updated_at"}},
+        {"op": "not_equal", "actual": {"path": "/steps/publish-comment-retry/response/result/created_at"}, "expected": {"literal": "0001-01-01T00:00:00Z"}},
+        {"op": "not_equal", "actual": {"path": "/steps/publish-comment-retry/response/result/updated_at"}, "expected": {"literal": "0001-01-01T00:00:00Z"}},
+        {"op": "time_gte", "actual": {"path": "/steps/publish-comment-retry/response/result/updated_at"}, "expected": {"path": "/steps/publish-comment-retry/response/result/created_at"}},
+        {"op": "equal", "actual": {"path": "/steps/publish-comment-retry/response/result"}, "expected": {"path": "/captures/published-comment"}}
+      ]
+    },
+    {
+      "name": "provider-after-publication-retry",
+      "observe": "provider_state",
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "publish_comment"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/provider-after-publication-retry/provider/comments"}, "expected": {"path": "/captures/published-comments"}},
+        {"op": "equal", "actual": {"path": "/steps/provider-after-publication-retry/provider/mutations"}, "expected": {"path": "/captures/mutation-log"}}
+      ]
+    },
+    {
+      "name": "list-published-comment",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-comment-readback", "method": "list_comments", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}}},
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "publish_comment"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/list-published-comment/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-published-comment/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-published-comment/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/list-published-comment/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/list-published-comment/response/id"}, "expected": {"path": "/steps/list-published-comment/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/list-published-comment/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/list-published-comment/response/error"}},
+        {"op": "one", "actual": {"path": "/steps/list-published-comment/response/result/comments"}, "as": "comment", "assert": [
+          {"op": "equal", "actual": {"path": "/vars/comment"}, "expected": {"path": "/captures/published-comment"}}
+        ]}
+      ]
+    },
+    {
+      "name": "publish-without-capability",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-publish-unsupported", "method": "publish_comment", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}, "body": "connector conformance publication", "operation_id": "conformance-publication-unsupported"}},
+      "when": [
+        {"op": "not_contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "publish_comment"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/publish-without-capability/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/publish-without-capability/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/publish-without-capability/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/publish-without-capability/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/publish-without-capability/response/id"}, "expected": {"path": "/steps/publish-without-capability/request/id"}},
+        {"op": "absent", "actual": {"path": "/steps/publish-without-capability/response/result"}},
+        {"op": "present", "actual": {"path": "/steps/publish-without-capability/response/error"}},
+        {"op": "matches", "actual": {"path": "/steps/publish-without-capability/response/error/code"}, "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+        {"op": "nonempty", "actual": {"path": "/steps/publish-without-capability/response/error/message"}}
+      ]
+    },
+    {
+      "name": "list-fields",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-fields", "method": "list_fields", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {}},
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "fields"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/list-fields/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-fields/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-fields/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/list-fields/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/list-fields/response/id"}, "expected": {"path": "/steps/list-fields/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/list-fields/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/list-fields/response/error"}},
+        {"op": "nonempty", "actual": {"path": "/steps/list-fields/response/result/fields"}},
+        {"op": "unique", "actual": {"path": "/steps/list-fields/response/result/fields"}, "by": ["/id"]},
+        {"op": "all", "actual": {"path": "/steps/list-fields/response/result/fields"}, "as": "descriptor", "assert": [
+          {"op": "nonempty", "actual": {"path": "/vars/descriptor/id"}},
+          {"op": "trimmed", "actual": {"path": "/vars/descriptor/id"}},
+          {"op": "nonempty", "actual": {"path": "/vars/descriptor/display_name"}},
+          {"op": "nonempty", "actual": {"path": "/vars/descriptor/schema_revision"}},
+          {"op": "trimmed", "actual": {"path": "/vars/descriptor/schema_revision"}},
+          {"op": "subset", "actual": {"path": "/vars/descriptor/accepted_kinds"}, "expected": {"literal": ["date", "local_datetime", "instant"]}}
+        ]},
+        {"op": "any", "actual": {"path": "/steps/list-fields/response/result/fields"}, "as": "descriptor", "assert": [
+          {"op": "equal", "actual": {"path": "/vars/descriptor/writable"}, "expected": {"literal": true}},
+          {"op": "or", "assert": [
+            {"op": "nonempty", "actual": {"path": "/vars/descriptor/accepted_kinds"}},
+            {"op": "equal", "actual": {"path": "/vars/descriptor/nullable"}, "expected": {"literal": true}}
+          ]}
+        ]}
+      ],
+      "capture": [
+        {"name": "field-descriptors", "value": {"path": "/steps/list-fields/response/result/fields"}}
+      ]
+    },
+    {
+      "name": "field-round-trips",
+      "repeat": {"over": {"path": "/captures/field-descriptors"}, "as": "descriptor", "steps": [
+        {
+          "name": "read-read-only-field",
+          "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-read-only", "method": "read_fields", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}, "field_ids": [{"$ref": "/vars/descriptor/id"}]}},
+          "when": [
+            {"op": "equal", "actual": {"path": "/vars/descriptor/writable"}, "expected": {"literal": false}}
+          ],
+          "assert": [
+            {"op": "equal", "actual": {"path": "/steps/read-read-only-field/exchange/error"}, "expected": {"literal": false}},
+            {"op": "equal", "actual": {"path": "/steps/read-read-only-field/exchange/decode_error"}, "expected": {"literal": false}},
+            {"op": "equal", "actual": {"path": "/steps/read-read-only-field/exchange/response_count"}, "expected": {"literal": 1}},
+            {"op": "equal", "actual": {"path": "/steps/read-read-only-field/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+            {"op": "equal", "actual": {"path": "/steps/read-read-only-field/response/id"}, "expected": {"path": "/steps/read-read-only-field/request/id"}},
+            {"op": "present", "actual": {"path": "/steps/read-read-only-field/response/result"}},
+            {"op": "absent", "actual": {"path": "/steps/read-read-only-field/response/error"}},
+            {"op": "count", "actual": {"path": "/steps/read-read-only-field/response/result/fields"}, "expected": {"literal": 1}},
+            {"op": "entries_equal", "actual": {"path": "/steps/read-read-only-field/response/result/fields"}, "key": {"path": "/vars/descriptor/id"}, "expected": {"path": "/captures/provider-field-baseline"}}
+          ]
+        },
+        {
+          "name": "advertised-kind-round-trips",
+          "repeat": {"over": {"path": "/contract/field_samples"}, "as": "sample", "steps": [
+            {
+              "name": "write-field",
+              "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-write", "method": "write_fields", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}, "fields": {"$entries": [{"key": {"$ref": "/vars/descriptor/id"}, "value": {"$ref": "/vars/sample"}}]}}},
+              "when": [
+                {"op": "equal", "actual": {"path": "/vars/descriptor/writable"}, "expected": {"literal": true}},
+                {"op": "contains", "actual": {"path": "/vars/descriptor/accepted_kinds"}, "expected": {"path": "/vars/sample/kind"}}
+              ],
+              "assert": [
+                {"op": "equal", "actual": {"path": "/steps/write-field/exchange/error"}, "expected": {"literal": false}},
+                {"op": "equal", "actual": {"path": "/steps/write-field/exchange/decode_error"}, "expected": {"literal": false}},
+                {"op": "equal", "actual": {"path": "/steps/write-field/exchange/response_count"}, "expected": {"literal": 1}},
+                {"op": "equal", "actual": {"path": "/steps/write-field/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+                {"op": "equal", "actual": {"path": "/steps/write-field/response/id"}, "expected": {"path": "/steps/write-field/request/id"}},
+                {"op": "present", "actual": {"path": "/steps/write-field/response/result"}},
+                {"op": "absent", "actual": {"path": "/steps/write-field/response/error"}},
+                {"op": "entry_equal", "actual": {"path": "/steps/write-field/response/result/fields"}, "key": {"path": "/vars/descriptor/id"}, "expected": {"path": "/vars/sample"}}
+              ]
+            },
+            {
+              "name": "provider-after-field",
+              "observe": "provider_state",
+              "when": [
+                {"op": "equal", "actual": {"path": "/vars/descriptor/writable"}, "expected": {"literal": true}},
+                {"op": "contains", "actual": {"path": "/vars/descriptor/accepted_kinds"}, "expected": {"path": "/vars/sample/kind"}}
+              ],
+              "assert": [
+                {"op": "array_appended", "actual": {"path": "/steps/provider-after-field/provider/mutations"}, "expected": {"path": "/captures/mutation-log"}},
+                {"op": "entry_equal", "actual": {"path": "/steps/provider-after-field/provider/mutations", "last": true}, "key": {"literal": "method"}, "expected": {"literal": "write_fields"}},
+                {"op": "entry_equal", "actual": {"path": "/steps/provider-after-field/provider/mutations", "last": true}, "key": {"literal": "params"}, "expected": {"path": "/steps/write-field/request/params"}},
+                {"op": "entry_equal", "actual": {"path": "/steps/provider-after-field/provider/fields"}, "key": {"path": "/vars/descriptor/id"}, "expected": {"path": "/vars/sample"}}
+              ],
+              "capture": [
+                {"name": "mutation-log", "value": {"path": "/steps/provider-after-field/provider/mutations"}}
+              ]
+            },
+            {
+              "name": "read-field",
+              "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-read", "method": "read_fields", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}, "field_ids": [{"$ref": "/vars/descriptor/id"}]}},
+              "when": [
+                {"op": "equal", "actual": {"path": "/vars/descriptor/writable"}, "expected": {"literal": true}},
+                {"op": "contains", "actual": {"path": "/vars/descriptor/accepted_kinds"}, "expected": {"path": "/vars/sample/kind"}}
+              ],
+              "assert": [
+                {"op": "equal", "actual": {"path": "/steps/read-field/exchange/error"}, "expected": {"literal": false}},
+                {"op": "equal", "actual": {"path": "/steps/read-field/exchange/decode_error"}, "expected": {"literal": false}},
+                {"op": "equal", "actual": {"path": "/steps/read-field/exchange/response_count"}, "expected": {"literal": 1}},
+                {"op": "equal", "actual": {"path": "/steps/read-field/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+                {"op": "equal", "actual": {"path": "/steps/read-field/response/id"}, "expected": {"path": "/steps/read-field/request/id"}},
+                {"op": "present", "actual": {"path": "/steps/read-field/response/result"}},
+                {"op": "absent", "actual": {"path": "/steps/read-field/response/error"}},
+                {"op": "count", "actual": {"path": "/steps/read-field/response/result/fields"}, "expected": {"literal": 1}},
+                {"op": "entry_equal", "actual": {"path": "/steps/read-field/response/result/fields"}, "key": {"path": "/vars/descriptor/id"}, "expected": {"path": "/vars/sample"}}
+              ]
+            }
+          ]},
+          "assert": [
+            {"op": "nonempty", "actual": {"path": "/contract/field_samples"}}
+          ]
+        },
+        {
+          "name": "write-null-field",
+          "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-write-null", "method": "write_fields", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}, "fields": {"$entries": [{"key": {"$ref": "/vars/descriptor/id"}, "value": {"kind": "null"}}]}}},
+          "when": [
+            {"op": "equal", "actual": {"path": "/vars/descriptor/writable"}, "expected": {"literal": true}},
+            {"op": "equal", "actual": {"path": "/vars/descriptor/nullable"}, "expected": {"literal": true}}
+          ],
+          "assert": [
+            {"op": "equal", "actual": {"path": "/steps/write-null-field/exchange/error"}, "expected": {"literal": false}},
+            {"op": "equal", "actual": {"path": "/steps/write-null-field/exchange/decode_error"}, "expected": {"literal": false}},
+            {"op": "equal", "actual": {"path": "/steps/write-null-field/exchange/response_count"}, "expected": {"literal": 1}},
+            {"op": "equal", "actual": {"path": "/steps/write-null-field/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+            {"op": "equal", "actual": {"path": "/steps/write-null-field/response/id"}, "expected": {"path": "/steps/write-null-field/request/id"}},
+            {"op": "present", "actual": {"path": "/steps/write-null-field/response/result"}},
+            {"op": "absent", "actual": {"path": "/steps/write-null-field/response/error"}},
+            {"op": "entry_equal", "actual": {"path": "/steps/write-null-field/response/result/fields"}, "key": {"path": "/vars/descriptor/id"}, "expected": {"literal": {"kind": "null"}}}
+          ]
+        },
+        {
+          "name": "provider-after-null-field",
+          "observe": "provider_state",
+          "when": [
+            {"op": "equal", "actual": {"path": "/vars/descriptor/writable"}, "expected": {"literal": true}},
+            {"op": "equal", "actual": {"path": "/vars/descriptor/nullable"}, "expected": {"literal": true}}
+          ],
+          "assert": [
+            {"op": "array_appended", "actual": {"path": "/steps/provider-after-null-field/provider/mutations"}, "expected": {"path": "/captures/mutation-log"}},
+            {"op": "entry_equal", "actual": {"path": "/steps/provider-after-null-field/provider/mutations", "last": true}, "key": {"literal": "method"}, "expected": {"literal": "write_fields"}},
+            {"op": "entry_equal", "actual": {"path": "/steps/provider-after-null-field/provider/mutations", "last": true}, "key": {"literal": "params"}, "expected": {"path": "/steps/write-null-field/request/params"}},
+            {"op": "entry_equal", "actual": {"path": "/steps/provider-after-null-field/provider/fields"}, "key": {"path": "/vars/descriptor/id"}, "expected": {"literal": {"kind": "null"}}}
+          ],
+          "capture": [
+            {"name": "mutation-log", "value": {"path": "/steps/provider-after-null-field/provider/mutations"}}
+          ]
+        },
+        {
+          "name": "read-null-field",
+          "request": {"protocol": "kata.connector.v1", "id": "transcript-optional-read-null", "method": "read_fields", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}, "field_ids": [{"$ref": "/vars/descriptor/id"}]}},
+          "when": [
+            {"op": "equal", "actual": {"path": "/vars/descriptor/writable"}, "expected": {"literal": true}},
+            {"op": "equal", "actual": {"path": "/vars/descriptor/nullable"}, "expected": {"literal": true}}
+          ],
+          "assert": [
+            {"op": "equal", "actual": {"path": "/steps/read-null-field/exchange/error"}, "expected": {"literal": false}},
+            {"op": "equal", "actual": {"path": "/steps/read-null-field/exchange/decode_error"}, "expected": {"literal": false}},
+            {"op": "equal", "actual": {"path": "/steps/read-null-field/exchange/response_count"}, "expected": {"literal": 1}},
+            {"op": "equal", "actual": {"path": "/steps/read-null-field/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+            {"op": "equal", "actual": {"path": "/steps/read-null-field/response/id"}, "expected": {"path": "/steps/read-null-field/request/id"}},
+            {"op": "present", "actual": {"path": "/steps/read-null-field/response/result"}},
+            {"op": "absent", "actual": {"path": "/steps/read-null-field/response/error"}},
+            {"op": "count", "actual": {"path": "/steps/read-null-field/response/result/fields"}, "expected": {"literal": 1}},
+            {"op": "entry_equal", "actual": {"path": "/steps/read-null-field/response/result/fields"}, "key": {"path": "/vars/descriptor/id"}, "expected": {"literal": {"kind": "null"}}}
+          ]
+        }
+      ]},
+      "when": [
+        {"op": "contains", "actual": {"path": "/captures/description/capabilities"}, "expected": {"literal": "fields"}}
+      ],
+      "assert": [
+        {"op": "equal", "actual": {"path": "/contract/field_samples"}, "expected": {"literal": [
+          {"kind": "date", "value": "2026-08-21"},
+          {"kind": "local_datetime", "value": "2026-08-21T14:45:00", "timezone": "Asia/Tokyo"},
+          {"kind": "instant", "value": "2026-08-21T05:45:00Z"}
+        ]}},
+        {"op": "nonempty", "actual": {"path": "/captures/field-descriptors"}}
+      ]
+    },
+    {
+      "name": "provider-final",
+      "observe": "provider_state",
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/provider-final/provider/mutations"}, "expected": {"path": "/captures/mutation-log"}}
+      ]
+    }
+  ]
+}

--- a/pkg/connector/conformance/testdata/protocol-v1/required.json
+++ b/pkg/connector/conformance/testdata/protocol-v1/required.json
@@ -1,0 +1,344 @@
+{
+  "schema": "kata.connector.conformance/v1",
+  "protocol": "kata.connector.v1",
+  "name": "required-methods",
+  "steps": [
+    {
+      "name": "provider-baseline",
+      "observe": "provider_state",
+      "assert": [
+        {"op": "empty", "actual": {"path": "/steps/provider-baseline/provider/mutations"}}
+      ],
+      "capture": [
+        {"name": "provider-root", "value": {"path": "/steps/provider-baseline/provider/root"}},
+        {"name": "provider-comments", "value": {"path": "/steps/provider-baseline/provider/comments"}},
+        {"name": "mutation-log", "value": {"path": "/steps/provider-baseline/provider/mutations"}}
+      ]
+    },
+    {
+      "name": "describe-1",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-describe-1", "method": "describe", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/describe-1/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe-1/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe-1/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/describe-1/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/describe-1/response/id"}, "expected": {"path": "/steps/describe-1/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/describe-1/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/describe-1/response/error"}},
+        {"op": "nonempty", "actual": {"path": "/steps/describe-1/response/result/connector_id"}},
+        {"op": "trimmed", "actual": {"path": "/steps/describe-1/response/result/connector_id"}},
+        {"op": "nonempty", "actual": {"path": "/steps/describe-1/response/result/display_name"}},
+        {"op": "trimmed", "actual": {"path": "/steps/describe-1/response/result/display_name"}},
+        {"op": "nonempty", "actual": {"path": "/steps/describe-1/response/result/account_identity"}},
+        {"op": "trimmed", "actual": {"path": "/steps/describe-1/response/result/account_identity"}},
+        {"op": "equal", "actual": {"path": "/steps/describe-1/response/result/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "unique", "actual": {"path": "/steps/describe-1/response/result/capabilities"}, "by": [""]},
+        {"op": "all", "actual": {"path": "/steps/describe-1/response/result/capabilities"}, "as": "capability", "assert": [
+          {"op": "nonempty", "actual": {"path": "/vars/capability"}},
+          {"op": "trimmed", "actual": {"path": "/vars/capability"}}
+        ]}
+      ],
+      "capture": [
+        {"name": "description", "value": {"path": "/steps/describe-1/response/result"}}
+      ]
+    },
+    {
+      "name": "publication-identity",
+      "repeat": {"over": {"path": "/steps/describe-1/response/result/capabilities"}, "as": "capability", "steps": [
+        {
+          "name": "publication-self-actor",
+          "observe": "provider_state",
+          "when": [
+            {"op": "equal", "actual": {"path": "/vars/capability"}, "expected": {"literal": "publish_comment"}}
+          ],
+          "assert": [
+            {"op": "nonempty", "actual": {"path": "/captures/description/self_actor_id"}},
+            {"op": "trimmed", "actual": {"path": "/captures/description/self_actor_id"}}
+          ]
+        }
+      ]},
+      "assert": [
+        {"op": "present", "actual": {"path": "/captures/description/capabilities"}}
+      ]
+    },
+    {
+      "name": "describe-2",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-describe-27", "method": "describe", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/describe-2/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe-2/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe-2/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/describe-2/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/describe-2/response/id"}, "expected": {"path": "/steps/describe-2/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/describe-2/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/describe-2/response/error"}},
+        {"op": "equal", "actual": {"path": "/steps/describe-2/response/result"}, "expected": {"path": "/captures/description"}}
+      ]
+    },
+    {
+      "name": "describe-3",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-describe-final", "method": "describe", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/describe-3/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe-3/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/describe-3/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/describe-3/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/describe-3/response/id"}, "expected": {"path": "/steps/describe-3/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/describe-3/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/describe-3/response/error"}},
+        {"op": "equal", "actual": {"path": "/steps/describe-3/response/result"}, "expected": {"path": "/captures/description"}}
+      ]
+    },
+    {
+      "name": "resolve-root-1",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-resolve-1", "method": "resolve_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"locator": {"$ref": "/fixture/root_locator"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-1/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-1/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-1/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-1/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-1/response/id"}, "expected": {"path": "/steps/resolve-root-1/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/resolve-root-1/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/resolve-root-1/response/error"}},
+        {"op": "nonempty", "actual": {"path": "/steps/resolve-root-1/response/result/key"}},
+        {"op": "trimmed", "actual": {"path": "/steps/resolve-root-1/response/result/key"}},
+        {"op": "nonempty", "actual": {"path": "/steps/resolve-root-1/response/result/identity_key"}},
+        {"op": "trimmed", "actual": {"path": "/steps/resolve-root-1/response/result/identity_key"}},
+        {"op": "nonempty", "actual": {"path": "/steps/resolve-root-1/response/result/revision"}},
+        {"op": "trimmed", "actual": {"path": "/steps/resolve-root-1/response/result/revision"}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-1/response/result/identity_key"}, "expected": {"path": "/captures/description/account_identity"}},
+        {"op": "timestamp", "actual": {"path": "/steps/resolve-root-1/response/result/updated_at"}},
+        {"op": "timestamp", "actual": {"path": "/steps/resolve-root-1/response/result/observed_at"}},
+        {"op": "not_equal", "actual": {"path": "/steps/resolve-root-1/response/result/updated_at"}, "expected": {"literal": "0001-01-01T00:00:00Z"}},
+        {"op": "not_equal", "actual": {"path": "/steps/resolve-root-1/response/result/observed_at"}, "expected": {"literal": "0001-01-01T00:00:00Z"}},
+        {"op": "equal_except", "actual": {"path": "/steps/resolve-root-1/response/result"}, "expected": {"path": "/captures/provider-root"}, "paths": ["/observed_at"]},
+        {"op": "time_gte", "actual": {"path": "/steps/resolve-root-1/response/result/observed_at"}, "expected": {"path": "/steps/resolve-root-1/response/result/updated_at"}},
+        {"op": "time_between", "actual": {"path": "/steps/resolve-root-1/response/result/observed_at"}, "start": {"path": "/steps/resolve-root-1/exchange/started_at"}, "end": {"path": "/steps/resolve-root-1/exchange/finished_at"}, "tolerance_seconds": 120}
+      ],
+      "capture": [
+        {"name": "root", "value": {"path": "/steps/resolve-root-1/response/result"}}
+      ]
+    },
+    {
+      "name": "resolve-root-2",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-resolve-2", "method": "resolve_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"locator": {"$ref": "/fixture/root_locator"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-2/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-2/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-2/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-2/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/resolve-root-2/response/id"}, "expected": {"path": "/steps/resolve-root-2/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/resolve-root-2/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/resolve-root-2/response/error"}},
+        {"op": "equal_except", "actual": {"path": "/steps/resolve-root-2/response/result"}, "expected": {"path": "/captures/root"}, "paths": ["/observed_at"]},
+        {"op": "time_gte", "actual": {"path": "/steps/resolve-root-2/response/result/observed_at"}, "expected": {"path": "/captures/root/observed_at"}}
+      ],
+      "capture": [
+        {"name": "root-after-resolve", "value": {"path": "/steps/resolve-root-2/response/result"}}
+      ]
+    },
+    {
+      "name": "read-root",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-read", "method": "read_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/read-root/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/read-root/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/read-root/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/read-root/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/read-root/response/id"}, "expected": {"path": "/steps/read-root/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/read-root/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/read-root/response/error"}},
+        {"op": "equal_except", "actual": {"path": "/steps/read-root/response/result"}, "expected": {"path": "/captures/provider-root"}, "paths": ["/observed_at"]},
+        {"op": "time_gte", "actual": {"path": "/steps/read-root/response/result/observed_at"}, "expected": {"path": "/captures/root-after-resolve/observed_at"}},
+        {"op": "time_between", "actual": {"path": "/steps/read-root/response/result/observed_at"}, "start": {"path": "/steps/read-root/exchange/started_at"}, "end": {"path": "/steps/read-root/exchange/finished_at"}, "tolerance_seconds": 120}
+      ]
+    },
+    {
+      "name": "list-comments-1",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-comments-1", "method": "list_comments", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/list-comments-1/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-1/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-1/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-1/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-1/response/id"}, "expected": {"path": "/steps/list-comments-1/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/list-comments-1/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/list-comments-1/response/error"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-1/response/result/comments"}, "expected": {"path": "/captures/provider-comments"}},
+        {"op": "unique", "actual": {"path": "/steps/list-comments-1/response/result/comments"}, "by": ["/id"]},
+        {"op": "ordered", "actual": {"path": "/steps/list-comments-1/response/result/comments"}, "by": ["/created_at", "/id"]},
+        {"op": "all", "actual": {"path": "/steps/list-comments-1/response/result/comments"}, "as": "comment", "assert": [
+          {"op": "nonempty", "actual": {"path": "/vars/comment/id"}},
+          {"op": "trimmed", "actual": {"path": "/vars/comment/id"}},
+          {"op": "nonempty", "actual": {"path": "/vars/comment/revision"}},
+          {"op": "trimmed", "actual": {"path": "/vars/comment/revision"}},
+          {"op": "nonempty", "actual": {"path": "/vars/comment/author/id"}},
+          {"op": "trimmed", "actual": {"path": "/vars/comment/author/id"}},
+          {"op": "nonempty", "actual": {"path": "/vars/comment/author/display_name"}},
+          {"op": "trimmed", "actual": {"path": "/vars/comment/author/display_name"}},
+          {"op": "timestamp", "actual": {"path": "/vars/comment/created_at"}},
+          {"op": "timestamp", "actual": {"path": "/vars/comment/updated_at"}},
+          {"op": "not_equal", "actual": {"path": "/vars/comment/created_at"}, "expected": {"literal": "0001-01-01T00:00:00Z"}},
+          {"op": "not_equal", "actual": {"path": "/vars/comment/updated_at"}, "expected": {"literal": "0001-01-01T00:00:00Z"}},
+          {"op": "time_gte", "actual": {"path": "/vars/comment/updated_at"}, "expected": {"path": "/vars/comment/created_at"}},
+          {"op": "present", "actual": {"path": "/vars/comment/deleted"}}
+        ]},
+        {"op": "any", "actual": {"path": "/steps/list-comments-1/response/result/comments"}, "as": "comment", "assert": [
+          {"op": "time_gt", "actual": {"path": "/vars/comment/updated_at"}, "expected": {"path": "/vars/comment/created_at"}}
+        ]},
+        {"op": "any", "actual": {"path": "/steps/list-comments-1/response/result/comments"}, "as": "comment", "assert": [
+          {"op": "equal", "actual": {"path": "/vars/comment/deleted"}, "expected": {"literal": true}}
+        ]},
+        {"op": "any", "actual": {"path": "/steps/list-comments-1/response/result/comments"}, "as": "comment", "assert": [
+          {"op": "time_lte", "actual": {"path": "/vars/comment/created_at"}, "expected": {"path": "/captures/root/observed_at"}}
+        ]}
+      ],
+      "capture": [
+        {"name": "comments", "value": {"path": "/steps/list-comments-1/response/result"}}
+      ]
+    },
+    {
+      "name": "mutate-comment",
+      "mutate_comment": {"path": "/captures/comments/comments/1/id"},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/mutate-comment/comment_id"}, "expected": {"path": "/captures/comments/comments/1/id"}}
+      ]
+    },
+    {
+      "name": "provider-after-comment-edit",
+      "observe": "provider_state",
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/provider-after-comment-edit/provider/comments/1/id"}, "expected": {"path": "/captures/comments/comments/1/id"}},
+        {"op": "not_equal", "actual": {"path": "/steps/provider-after-comment-edit/provider/comments/1/body"}, "expected": {"path": "/captures/comments/comments/1/body"}},
+        {"op": "not_equal", "actual": {"path": "/steps/provider-after-comment-edit/provider/comments/1/revision"}, "expected": {"path": "/captures/comments/comments/1/revision"}},
+        {"op": "time_gt", "actual": {"path": "/steps/provider-after-comment-edit/provider/comments/1/updated_at"}, "expected": {"path": "/captures/comments/comments/1/updated_at"}}
+      ],
+      "capture": [
+        {"name": "provider-comments-after-edit", "value": {"path": "/steps/provider-after-comment-edit/provider/comments"}}
+      ]
+    },
+    {
+      "name": "list-comments-2",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-comments-2", "method": "list_comments", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/list-comments-2/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-2/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-2/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-2/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-2/response/id"}, "expected": {"path": "/steps/list-comments-2/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/list-comments-2/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/list-comments-2/response/error"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-2/response/result/comments"}, "expected": {"path": "/captures/provider-comments-after-edit"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-2/response/result/comments/1/id"}, "expected": {"path": "/captures/comments/comments/1/id"}},
+        {"op": "not_equal", "actual": {"path": "/steps/list-comments-2/response/result/comments/1/revision"}, "expected": {"path": "/captures/comments/comments/1/revision"}}
+      ]
+    },
+    {
+      "name": "list-comments-3",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-comments-3", "method": "list_comments", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/list-comments-3/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-3/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-3/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-3/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-3/response/id"}, "expected": {"path": "/steps/list-comments-3/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/list-comments-3/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/list-comments-3/response/error"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-3/response/result/comments"}, "expected": {"path": "/captures/provider-comments-after-edit"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-3/response/result/comments/1/id"}, "expected": {"path": "/steps/list-comments-2/response/result/comments/1/id"}},
+        {"op": "equal", "actual": {"path": "/steps/list-comments-3/response/result/comments/1/revision"}, "expected": {"path": "/steps/list-comments-2/response/result/comments/1/revision"}}
+      ]
+    },
+    {
+      "name": "complete-root-1",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-complete-1", "method": "complete_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/complete-root-1/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-1/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-1/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-1/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-1/response/id"}, "expected": {"path": "/steps/complete-root-1/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/complete-root-1/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/complete-root-1/response/error"}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-1/response/result/key"}, "expected": {"path": "/captures/root/key"}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-1/response/result/state"}, "expected": {"literal": "complete"}},
+        {"op": "not_equal", "actual": {"path": "/steps/complete-root-1/response/result/revision"}, "expected": {"path": "/captures/root/revision"}},
+        {"op": "time_gt", "actual": {"path": "/steps/complete-root-1/response/result/updated_at"}, "expected": {"path": "/captures/root/updated_at"}},
+        {"op": "time_gte", "actual": {"path": "/steps/complete-root-1/response/result/observed_at"}, "expected": {"path": "/steps/complete-root-1/response/result/updated_at"}},
+        {"op": "time_between", "actual": {"path": "/steps/complete-root-1/response/result/updated_at"}, "start": {"path": "/steps/complete-root-1/exchange/started_at"}, "end": {"path": "/steps/complete-root-1/exchange/finished_at"}, "tolerance_seconds": 120},
+        {"op": "time_between", "actual": {"path": "/steps/complete-root-1/response/result/observed_at"}, "start": {"path": "/steps/complete-root-1/exchange/started_at"}, "end": {"path": "/steps/complete-root-1/exchange/finished_at"}, "tolerance_seconds": 120}
+      ],
+      "capture": [
+        {"name": "completed-root", "value": {"path": "/steps/complete-root-1/response/result"}}
+      ]
+    },
+    {
+      "name": "provider-after-complete-1",
+      "observe": "provider_state",
+      "assert": [
+        {"op": "array_appended", "actual": {"path": "/steps/provider-after-complete-1/provider/mutations"}, "expected": {"path": "/captures/mutation-log"}},
+        {"op": "entry_equal", "actual": {"path": "/steps/provider-after-complete-1/provider/mutations", "last": true}, "key": {"literal": "method"}, "expected": {"literal": "complete_root"}},
+        {"op": "entry_equal", "actual": {"path": "/steps/provider-after-complete-1/provider/mutations", "last": true}, "key": {"literal": "params"}, "expected": {"path": "/steps/complete-root-1/request/params"}},
+        {"op": "equal_except", "actual": {"path": "/steps/provider-after-complete-1/provider/root"}, "expected": {"path": "/captures/completed-root"}, "paths": ["/observed_at"]}
+      ],
+      "capture": [
+        {"name": "mutation-log", "value": {"path": "/steps/provider-after-complete-1/provider/mutations"}}
+      ]
+    },
+    {
+      "name": "complete-root-2",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-complete-2", "method": "complete_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/complete-root-2/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-2/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-2/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-2/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-2/response/id"}, "expected": {"path": "/steps/complete-root-2/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/complete-root-2/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/complete-root-2/response/error"}},
+        {"op": "equal", "actual": {"path": "/steps/complete-root-2/response/result/revision"}, "expected": {"path": "/captures/completed-root/revision"}},
+        {"op": "equal_except", "actual": {"path": "/steps/complete-root-2/response/result"}, "expected": {"path": "/captures/completed-root"}, "paths": ["/observed_at"]},
+        {"op": "time_gte", "actual": {"path": "/steps/complete-root-2/response/result/observed_at"}, "expected": {"path": "/captures/completed-root/observed_at"}}
+      ],
+      "capture": [
+        {"name": "completed-root-2", "value": {"path": "/steps/complete-root-2/response/result"}}
+      ]
+    },
+    {
+      "name": "provider-after-complete-2",
+      "observe": "provider_state",
+      "assert": [
+        {"op": "array_appended", "actual": {"path": "/steps/provider-after-complete-2/provider/mutations"}, "expected": {"path": "/captures/mutation-log"}},
+        {"op": "entry_equal", "actual": {"path": "/steps/provider-after-complete-2/provider/mutations", "last": true}, "key": {"literal": "method"}, "expected": {"literal": "complete_root"}},
+        {"op": "entry_equal", "actual": {"path": "/steps/provider-after-complete-2/provider/mutations", "last": true}, "key": {"literal": "params"}, "expected": {"path": "/steps/complete-root-2/request/params"}}
+      ],
+      "capture": [
+        {"name": "mutation-log", "value": {"path": "/steps/provider-after-complete-2/provider/mutations"}}
+      ]
+    },
+    {
+      "name": "read-completed-root",
+      "request": {"protocol": "kata.connector.v1", "id": "transcript-required-complete-readback", "method": "read_root", "instance": {"$ref": "/fixture/invocation/instance"}, "settings": {"$ref": "/fixture/invocation/settings"}, "params": {"root_key": {"$ref": "/captures/root/key"}}},
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/read-completed-root/exchange/error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/read-completed-root/exchange/decode_error"}, "expected": {"literal": false}},
+        {"op": "equal", "actual": {"path": "/steps/read-completed-root/exchange/response_count"}, "expected": {"literal": 1}},
+        {"op": "equal", "actual": {"path": "/steps/read-completed-root/response/protocol"}, "expected": {"path": "/contract/protocol"}},
+        {"op": "equal", "actual": {"path": "/steps/read-completed-root/response/id"}, "expected": {"path": "/steps/read-completed-root/request/id"}},
+        {"op": "present", "actual": {"path": "/steps/read-completed-root/response/result"}},
+        {"op": "absent", "actual": {"path": "/steps/read-completed-root/response/error"}},
+        {"op": "equal_except", "actual": {"path": "/steps/read-completed-root/response/result"}, "expected": {"path": "/captures/completed-root-2"}, "paths": ["/observed_at"]},
+        {"op": "time_gte", "actual": {"path": "/steps/read-completed-root/response/result/observed_at"}, "expected": {"path": "/captures/completed-root-2/observed_at"}}
+      ]
+    },
+    {
+      "name": "provider-completed-readback",
+      "observe": "provider_state",
+      "assert": [
+        {"op": "equal", "actual": {"path": "/steps/provider-completed-readback/provider/mutations"}, "expected": {"path": "/captures/mutation-log"}},
+        {"op": "equal_except", "actual": {"path": "/steps/provider-completed-readback/provider/root"}, "expected": {"path": "/steps/read-completed-root/response/result"}, "paths": ["/observed_at"]}
+      ]
+    }
+  ]
+}

--- a/pkg/connector/conformance/transcripts.go
+++ b/pkg/connector/conformance/transcripts.go
@@ -1,0 +1,1214 @@
+package conformance
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"go.kenn.io/kata/pkg/connector"
+)
+
+const protocolTranscriptSchema = "kata.connector.conformance/v1"
+
+//go:embed testdata/protocol-v1/*.json
+var protocolV1TranscriptFiles embed.FS
+
+type protocolTranscript struct {
+	Schema       string                   `json:"schema"`
+	Protocol     string                   `json:"protocol"`
+	Name         string                   `json:"name"`
+	FieldSamples []json.RawMessage        `json:"field_samples,omitempty"`
+	Steps        []protocolTranscriptStep `json:"steps"`
+}
+
+type protocolTranscriptStep struct {
+	Name          string                    `json:"name"`
+	Request       json.RawMessage           `json:"request,omitempty"`
+	RawRequest    string                    `json:"raw_request,omitempty"`
+	Observe       string                    `json:"observe,omitempty"`
+	Fault         Fault                     `json:"fault,omitempty"`
+	MutateComment *transcriptValue          `json:"mutate_comment,omitempty"`
+	When          []transcriptAssertion     `json:"when,omitempty"`
+	Assert        []transcriptAssertion     `json:"assert,omitempty"`
+	Capture       []transcriptCapture       `json:"capture,omitempty"`
+	Repeat        *protocolTranscriptRepeat `json:"repeat,omitempty"`
+}
+
+type protocolTranscriptRepeat struct {
+	Over  transcriptValue          `json:"over"`
+	As    string                   `json:"as"`
+	Steps []protocolTranscriptStep `json:"steps"`
+}
+
+type transcriptCapture struct {
+	Name  string          `json:"name"`
+	Value transcriptValue `json:"value"`
+}
+
+type transcriptAssertion struct {
+	Op               string                `json:"op"`
+	Actual           transcriptValue       `json:"actual,omitzero"`
+	Expected         transcriptValue       `json:"expected,omitzero"`
+	Start            transcriptValue       `json:"start,omitzero"`
+	End              transcriptValue       `json:"end,omitzero"`
+	Key              transcriptValue       `json:"key,omitzero"`
+	Pattern          string                `json:"pattern,omitempty"`
+	Paths            []string              `json:"paths,omitempty"`
+	By               []string              `json:"by,omitempty"`
+	As               string                `json:"as,omitempty"`
+	Assert           []transcriptAssertion `json:"assert,omitempty"`
+	ToleranceSeconds int                   `json:"tolerance_seconds,omitempty"`
+}
+
+type transcriptValue struct {
+	Path    string          `json:"path,omitempty"`
+	Literal json.RawMessage `json:"literal,omitempty"`
+	Last    bool            `json:"last,omitempty"`
+}
+
+type transcriptRuntime struct {
+	fixture Fixture
+	root    map[string]any
+}
+
+type transcriptIdentity struct {
+	connectorID string
+	accountID   string
+	rootLocator string
+	rootKey     string
+}
+
+func runProtocolV1Transcripts(ctx context.Context, t *testing.T, fixture Fixture, instance string, settings any) {
+	t.Helper()
+	transcripts, err := loadProtocolV1Transcripts()
+	if err != nil {
+		t.Fatalf("load protocol-v1 transcripts: %v", err)
+	}
+	var baselineIdentity *transcriptIdentity
+	for _, transcript := range transcripts {
+		t.Run(transcript.Name, func(t *testing.T) {
+			if err := fixture.Reset(ctx); err != nil {
+				t.Fatalf("reset transcript fixture: %v", err)
+			}
+			samples := make([]any, 0, len(transcript.FieldSamples))
+			for index, sample := range transcript.FieldSamples {
+				decoded, err := decodeTranscriptJSON(sample)
+				if err != nil {
+					t.Fatalf("decode field sample %d: %v", index, err)
+				}
+				samples = append(samples, decoded)
+			}
+			runtime := &transcriptRuntime{fixture: fixture, root: map[string]any{
+				"contract": map[string]any{"protocol": transcript.Protocol, "field_samples": samples},
+				"fixture": map[string]any{
+					"root_locator": fixture.RootLocator(),
+					"invocation":   map[string]any{"instance": instance, "settings": cloneJSONValue(settings)},
+				},
+				"steps":    map[string]any{},
+				"captures": map[string]any{},
+				"vars":     map[string]any{},
+			}}
+			runtime.runSteps(ctx, t, transcript.Steps)
+			identity, err := runtime.identity(ctx)
+			if err != nil {
+				t.Fatalf("read stable transcript identity: %v", err)
+			}
+			if baselineIdentity == nil {
+				baselineIdentity = &identity
+			} else if identity != *baselineIdentity {
+				t.Fatalf("connector identity changed across transcript reset: got %+v want %+v", identity, *baselineIdentity)
+			}
+		})
+	}
+}
+
+func (runtime *transcriptRuntime) identity(ctx context.Context) (transcriptIdentity, error) {
+	connectorID, err := runtime.identityString("/captures/description/connector_id")
+	if err != nil {
+		return transcriptIdentity{}, err
+	}
+	accountID, err := runtime.identityString("/captures/description/account_identity")
+	if err != nil {
+		return transcriptIdentity{}, err
+	}
+	state, err := runtime.fixture.ExternalState(ctx)
+	if err != nil {
+		return transcriptIdentity{}, fmt.Errorf("read provider state: %w", err)
+	}
+	return transcriptIdentity{
+		connectorID: connectorID,
+		accountID:   accountID,
+		rootLocator: runtime.fixture.RootLocator(),
+		rootKey:     state.Root.Key,
+	}, nil
+}
+
+func (runtime *transcriptRuntime) identityString(path string) (string, error) {
+	value, err := runtime.resolve(transcriptValue{Path: path})
+	if err != nil {
+		return "", err
+	}
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", fmt.Errorf("identity at %q is %T, want nonempty string", path, value)
+	}
+	return text, nil
+}
+
+func loadProtocolV1Transcripts() ([]protocolTranscript, error) {
+	paths, err := fs.Glob(protocolV1TranscriptFiles, "testdata/protocol-v1/*.json")
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+	transcripts := make([]protocolTranscript, 0, len(paths))
+	for _, path := range paths {
+		encoded, err := protocolV1TranscriptFiles.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		decoder := json.NewDecoder(bytes.NewReader(encoded))
+		decoder.DisallowUnknownFields()
+		var transcript protocolTranscript
+		if err := decoder.Decode(&transcript); err != nil {
+			return nil, fmt.Errorf("decode %s: %w", path, err)
+		}
+		if err := requireTranscriptEOF(decoder); err != nil {
+			return nil, fmt.Errorf("decode %s: %w", path, err)
+		}
+		if transcript.Schema != protocolTranscriptSchema || transcript.Protocol != connector.ProtocolVersion ||
+			strings.TrimSpace(transcript.Name) == "" || len(transcript.Steps) == 0 {
+			return nil, fmt.Errorf("%s: invalid schema, protocol, name, or empty steps", path)
+		}
+		if err := validateTranscriptSteps(transcript.Steps); err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		transcripts = append(transcripts, transcript)
+	}
+	if len(transcripts) < 3 {
+		return nil, fmt.Errorf("protocol-v1 transcript count = %d, want at least 3", len(transcripts))
+	}
+	return transcripts, nil
+}
+
+func validateTranscriptSteps(steps []protocolTranscriptStep) error {
+	for index, step := range steps {
+		if strings.TrimSpace(step.Name) == "" {
+			return fmt.Errorf("step %d lacks a name", index)
+		}
+		actions := 0
+		if len(step.Request) != 0 {
+			actions++
+		}
+		if step.RawRequest != "" {
+			actions++
+		}
+		if step.Observe != "" {
+			actions++
+		}
+		if step.Fault != "" {
+			actions++
+			if step.Fault != FaultPublishCommentCrashAfterMutation {
+				return fmt.Errorf("step %q declares unsupported fault %q", step.Name, step.Fault)
+			}
+		}
+		if step.MutateComment != nil {
+			actions++
+			if err := validateTranscriptValue(*step.MutateComment); err != nil {
+				return fmt.Errorf("step %q mutate_comment: %w", step.Name, err)
+			}
+		}
+		if step.Repeat != nil {
+			actions++
+		}
+		if actions != 1 {
+			return fmt.Errorf("step %q must declare exactly one request, raw_request, observe, fault, mutate_comment, or repeat action", step.Name)
+		}
+		if len(step.Assert) == 0 {
+			return fmt.Errorf("step %q has no executable assertions", step.Name)
+		}
+		for _, assertion := range append(append([]transcriptAssertion(nil), step.When...), step.Assert...) {
+			if err := validateTranscriptAssertion(assertion); err != nil {
+				return fmt.Errorf("step %q: %w", step.Name, err)
+			}
+		}
+		for _, capture := range step.Capture {
+			if strings.TrimSpace(capture.Name) == "" || strings.Contains(capture.Name, "/") {
+				return fmt.Errorf("step %q has an invalid capture name", step.Name)
+			}
+			if err := validateTranscriptValue(capture.Value); err != nil {
+				return fmt.Errorf("step %q capture %q: %w", step.Name, capture.Name, err)
+			}
+		}
+		if step.Repeat != nil {
+			if strings.TrimSpace(step.Repeat.As) == "" || strings.Contains(step.Repeat.As, "/") || len(step.Repeat.Steps) == 0 {
+				return fmt.Errorf("step %q has an invalid repeat", step.Name)
+			}
+			if err := validateTranscriptValue(step.Repeat.Over); err != nil {
+				return fmt.Errorf("step %q repeat: %w", step.Name, err)
+			}
+			if err := validateTranscriptSteps(step.Repeat.Steps); err != nil {
+				return fmt.Errorf("step %q repeat: %w", step.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateTranscriptAssertion(assertion transcriptAssertion) error {
+	known := map[string]bool{
+		"present": true, "absent": true, "empty": true, "nonempty": true, "equal": true,
+		"not_equal": true, "equal_except": true, "type": true, "matches": true, "not_matches": true,
+		"trimmed": true, "max_length": true, "no_control": true, "unique": true, "contains": true,
+		"not_contains": true, "subset": true, "count": true, "ordered": true, "timestamp": true,
+		"time_lte": true, "time_gte": true, "time_gt": true, "time_between": true,
+		"all": true, "any": true, "one": true, "entry_equal": true, "entries_equal": true, "array_appended": true,
+		"or":         true,
+		"valid_utf8": true,
+	}
+	if !known[assertion.Op] {
+		return fmt.Errorf("unsupported generic assertion operation %q", assertion.Op)
+	}
+	if assertion.Op == "or" {
+		if len(assertion.Assert) == 0 {
+			return errors.New("or requires nested assertions")
+		}
+		for _, nested := range assertion.Assert {
+			if err := validateTranscriptAssertion(nested); err != nil {
+				return fmt.Errorf("or nested assertion: %w", err)
+			}
+		}
+		return nil
+	}
+	if err := validateTranscriptValue(assertion.Actual); err != nil {
+		return fmt.Errorf("%s actual: %w", assertion.Op, err)
+	}
+	requiresExpected := map[string]bool{
+		"equal": true, "not_equal": true, "equal_except": true, "type": true, "max_length": true,
+		"contains": true, "not_contains": true, "subset": true, "count": true, "time_lte": true,
+		"time_gte": true, "time_gt": true, "entry_equal": true, "entries_equal": true, "array_appended": true,
+	}
+	if requiresExpected[assertion.Op] {
+		if err := validateTranscriptValue(assertion.Expected); err != nil {
+			return fmt.Errorf("%s expected: %w", assertion.Op, err)
+		}
+	}
+	if assertion.Op == "present" || assertion.Op == "absent" {
+		if assertion.Actual.Path == "" {
+			return fmt.Errorf("%s requires a JSON Pointer actual", assertion.Op)
+		}
+	}
+	if assertion.Op == "equal_except" && len(assertion.Paths) == 0 {
+		return errors.New("equal_except requires at least one excluded pointer")
+	}
+	for _, pointer := range assertion.Paths {
+		if err := validateJSONPointer(pointer, false); err != nil {
+			return fmt.Errorf("%s excluded pointer: %w", assertion.Op, err)
+		}
+	}
+	if assertion.Op == "matches" || assertion.Op == "not_matches" {
+		if assertion.Pattern == "" {
+			return fmt.Errorf("%s requires a pattern", assertion.Op)
+		}
+		if _, err := regexp.Compile(assertion.Pattern); err != nil {
+			return fmt.Errorf("%s pattern: %w", assertion.Op, err)
+		}
+	}
+	if assertion.Op == "unique" && len(assertion.By) != 1 {
+		return errors.New("unique requires exactly one by pointer")
+	}
+	if assertion.Op == "ordered" && len(assertion.By) == 0 {
+		return errors.New("ordered requires at least one by pointer")
+	}
+	for _, pointer := range assertion.By {
+		if err := validateJSONPointer(pointer, true); err != nil {
+			return fmt.Errorf("%s by pointer: %w", assertion.Op, err)
+		}
+	}
+	if assertion.Op == "time_between" {
+		if err := validateTranscriptValue(assertion.Start); err != nil {
+			return fmt.Errorf("time_between start: %w", err)
+		}
+		if err := validateTranscriptValue(assertion.End); err != nil {
+			return fmt.Errorf("time_between end: %w", err)
+		}
+		if assertion.ToleranceSeconds < 0 {
+			return errors.New("time_between tolerance cannot be negative")
+		}
+	}
+	if assertion.Op == "entry_equal" || assertion.Op == "entries_equal" {
+		if err := validateTranscriptValue(assertion.Key); err != nil {
+			return fmt.Errorf("%s key: %w", assertion.Op, err)
+		}
+	}
+	if assertion.Op == "all" || assertion.Op == "any" || assertion.Op == "one" {
+		if strings.TrimSpace(assertion.As) == "" || strings.Contains(assertion.As, "/") || len(assertion.Assert) == 0 {
+			return fmt.Errorf("%s requires a loop variable and nested assertions", assertion.Op)
+		}
+	}
+	for _, nested := range assertion.Assert {
+		if err := validateTranscriptAssertion(nested); err != nil {
+			return fmt.Errorf("%s nested assertion: %w", assertion.Op, err)
+		}
+	}
+	return nil
+}
+
+func validateTranscriptValue(value transcriptValue) error {
+	if (value.Path == "") == (len(value.Literal) == 0) {
+		return errors.New("value must declare exactly one path or literal")
+	}
+	if value.Path != "" {
+		if err := validateJSONPointer(value.Path, false); err != nil {
+			return err
+		}
+	}
+	if len(value.Literal) != 0 && !json.Valid(value.Literal) {
+		return errors.New("literal is not valid JSON")
+	}
+	return nil
+}
+
+func requireTranscriptEOF(decoder *json.Decoder) error {
+	var extra json.RawMessage
+	err := decoder.Decode(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("trailing JSON")
+	}
+	return err
+}
+
+func (runtime *transcriptRuntime) runSteps(ctx context.Context, t *testing.T, steps []protocolTranscriptStep) {
+	t.Helper()
+	for _, step := range steps {
+		t.Run(step.Name, func(t *testing.T) {
+			matches, err := runtime.matchesAll(step.When)
+			if err != nil {
+				t.Fatalf("evaluate condition: %v", err)
+			}
+			if !matches {
+				t.Skip("declarative condition does not match")
+			}
+			if err := runtime.performStep(ctx, step); err != nil {
+				t.Fatalf("perform action: %v", err)
+			}
+			for index, assertion := range step.Assert {
+				matches, err := runtime.matches(assertion)
+				if err != nil {
+					t.Fatalf("assertion %d %q: %v", index, assertion.Op, err)
+				}
+				if !matches {
+					t.Fatalf("assertion %d %q did not match", index, assertion.Op)
+				}
+			}
+			captures := runtime.root["captures"].(map[string]any)
+			for _, capture := range step.Capture {
+				value, err := runtime.resolve(capture.Value)
+				if err != nil {
+					t.Fatalf("capture %q: %v", capture.Name, err)
+				}
+				captures[capture.Name] = cloneJSONValue(value)
+			}
+			if step.Repeat != nil {
+				value, err := runtime.resolve(step.Repeat.Over)
+				if err != nil {
+					t.Fatalf("resolve repeat: %v", err)
+				}
+				items, ok := value.([]any)
+				if !ok {
+					t.Fatalf("repeat value is %T, want array", value)
+				}
+				variables := runtime.root["vars"].(map[string]any)
+				previous, hadPrevious := variables[step.Repeat.As]
+				for index, item := range items {
+					variables[step.Repeat.As] = item
+					t.Run(strconv.Itoa(index), func(t *testing.T) { runtime.runSteps(ctx, t, step.Repeat.Steps) })
+				}
+				if hadPrevious {
+					variables[step.Repeat.As] = previous
+				} else {
+					delete(variables, step.Repeat.As)
+				}
+			}
+		})
+	}
+}
+
+func (runtime *transcriptRuntime) performStep(ctx context.Context, step protocolTranscriptStep) error {
+	stepDocument := map[string]any{}
+	runtime.root["steps"].(map[string]any)[step.Name] = stepDocument
+	switch {
+	case step.Repeat != nil:
+		return nil
+	case step.Fault != "":
+		if err := runtime.fixture.InjectFault(ctx, step.Fault); err != nil {
+			return fmt.Errorf("inject fault %q: %w", step.Fault, err)
+		}
+		stepDocument["fault"] = string(step.Fault)
+		return nil
+	case step.MutateComment != nil:
+		value, err := runtime.resolve(*step.MutateComment)
+		if err != nil {
+			return fmt.Errorf("resolve comment mutation target: %w", err)
+		}
+		commentID, ok := value.(string)
+		if !ok || strings.TrimSpace(commentID) == "" {
+			return fmt.Errorf("comment mutation target is %T, want nonempty string", value)
+		}
+		if err := runtime.fixture.MutateComment(ctx, commentID); err != nil {
+			return fmt.Errorf("mutate provider comment %q: %w", commentID, err)
+		}
+		stepDocument["comment_id"] = commentID
+		return nil
+	case step.Observe != "":
+		if step.Observe != "provider_state" {
+			return fmt.Errorf("unsupported observation %q", step.Observe)
+		}
+		state, err := runtime.fixture.ExternalState(ctx)
+		if err != nil {
+			return fmt.Errorf("read provider state: %w", err)
+		}
+		comments := state.Comments
+		if comments == nil {
+			comments = []connector.Comment{}
+		}
+		mutations := state.Mutations
+		if mutations == nil {
+			mutations = []Mutation{}
+		}
+		normalized, err := normalizeTranscriptJSON(map[string]any{
+			"root": state.Root, "comments": comments, "fields": state.Fields, "mutations": mutations,
+		})
+		if err != nil {
+			return fmt.Errorf("normalize provider state: %w", err)
+		}
+		stepDocument["provider"] = normalized
+		return nil
+	case len(step.Request) != 0 || step.RawRequest != "":
+		return runtime.exchangeStep(ctx, step, stepDocument)
+	default:
+		return errors.New("step has no action")
+	}
+}
+
+func (runtime *transcriptRuntime) exchangeStep(ctx context.Context, step protocolTranscriptStep, stepDocument map[string]any) error {
+	raw := []byte(step.RawRequest)
+	if len(step.Request) != 0 {
+		request, err := decodeTranscriptJSON(step.Request)
+		if err != nil {
+			return fmt.Errorf("decode request template: %w", err)
+		}
+		request, err = runtime.expandTemplate(request)
+		if err != nil {
+			return fmt.Errorf("expand request template: %w", err)
+		}
+		stepDocument["request"] = request
+		encoded, err := json.Marshal(request)
+		if err != nil {
+			return fmt.Errorf("encode request: %w", err)
+		}
+		raw = append(encoded, '\n')
+	} else {
+		stepDocument["raw_request"] = step.RawRequest
+	}
+	started := time.Now().UTC()
+	output, exchangeErr := runtime.fixture.Exchange(ctx, raw)
+	finished := time.Now().UTC()
+	exchange := map[string]any{
+		"error": exchangeErr != nil, "output": strings.TrimSpace(string(output)),
+		"started_at": started.Format(time.RFC3339Nano), "finished_at": finished.Format(time.RFC3339Nano),
+	}
+	if exchangeErr != nil {
+		exchange["error_message"] = exchangeErr.Error()
+	}
+	documents, decodeErr := decodeTranscriptJSONDocuments(output)
+	exchange["response_count"] = json.Number(strconv.Itoa(len(documents)))
+	exchange["decode_error"] = decodeErr != nil
+	if decodeErr != nil {
+		exchange["decode_error_message"] = decodeErr.Error()
+	}
+	stepDocument["exchange"] = exchange
+	if len(documents) > 0 {
+		stepDocument["response"] = documents[0]
+	}
+	return nil
+}
+
+func decodeTranscriptJSON(encoded []byte) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	if err := requireTranscriptEOF(decoder); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func decodeTranscriptJSONDocuments(encoded []byte) ([]any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var documents []any
+	for {
+		var value any
+		err := decoder.Decode(&value)
+		if errors.Is(err, io.EOF) {
+			return documents, nil
+		}
+		if err != nil {
+			return documents, err
+		}
+		documents = append(documents, value)
+	}
+}
+
+func normalizeTranscriptJSON(value any) (any, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return decodeTranscriptJSON(encoded)
+}
+
+func (runtime *transcriptRuntime) expandTemplate(value any) (any, error) {
+	switch typed := value.(type) {
+	case []any:
+		result := make([]any, len(typed))
+		for index, item := range typed {
+			expanded, err := runtime.expandTemplate(item)
+			if err != nil {
+				return nil, err
+			}
+			result[index] = expanded
+		}
+		return result, nil
+	case map[string]any:
+		if len(typed) == 1 {
+			if path, ok := typed["$ref"].(string); ok {
+				resolved, found, err := resolveJSONPointer(runtime.root, path)
+				if err != nil {
+					return nil, err
+				}
+				if !found {
+					return nil, fmt.Errorf("template reference %q does not exist", path)
+				}
+				return cloneJSONValue(resolved), nil
+			}
+			if entries, ok := typed["$entries"].([]any); ok {
+				result := make(map[string]any, len(entries))
+				for _, entry := range entries {
+					entryMap, ok := entry.(map[string]any)
+					if !ok {
+						return nil, errors.New("$entries item is not an object")
+					}
+					key, err := runtime.expandTemplate(entryMap["key"])
+					if err != nil {
+						return nil, err
+					}
+					keyString, ok := key.(string)
+					if !ok || keyString == "" {
+						return nil, errors.New("$entries key is not a nonempty string")
+					}
+					expanded, err := runtime.expandTemplate(entryMap["value"])
+					if err != nil {
+						return nil, err
+					}
+					result[keyString] = expanded
+				}
+				return result, nil
+			}
+		}
+		result := make(map[string]any, len(typed))
+		for key, item := range typed {
+			expanded, err := runtime.expandTemplate(item)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = expanded
+		}
+		return result, nil
+	default:
+		return typed, nil
+	}
+}
+
+func (runtime *transcriptRuntime) matchesAll(assertions []transcriptAssertion) (bool, error) {
+	for _, assertion := range assertions {
+		matches, err := runtime.matches(assertion)
+		if err != nil || !matches {
+			return matches, err
+		}
+	}
+	return true, nil
+}
+
+func (runtime *transcriptRuntime) matches(assertion transcriptAssertion) (bool, error) {
+	if assertion.Op == "or" {
+		for _, nested := range assertion.Assert {
+			matches, err := runtime.matches(nested)
+			if err != nil {
+				return false, err
+			}
+			if matches {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	if assertion.Op == "present" || assertion.Op == "absent" {
+		_, found, err := resolveJSONPointer(runtime.root, assertion.Actual.Path)
+		if err != nil {
+			return false, err
+		}
+		return found == (assertion.Op == "present"), nil
+	}
+	actual, err := runtime.resolve(assertion.Actual)
+	if err != nil {
+		return false, err
+	}
+	switch assertion.Op {
+	case "empty", "nonempty":
+		empty := transcriptEmpty(actual)
+		return empty == (assertion.Op == "empty"), nil
+	case "equal", "not_equal":
+		expected, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		equal := reflect.DeepEqual(actual, expected)
+		return equal == (assertion.Op == "equal"), nil
+	case "equal_except":
+		expected, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		left, right := cloneJSONValue(actual), cloneJSONValue(expected)
+		for _, path := range assertion.Paths {
+			if err := removeJSONPointer(left, path); err != nil {
+				return false, err
+			}
+			if err := removeJSONPointer(right, path); err != nil {
+				return false, err
+			}
+		}
+		return reflect.DeepEqual(left, right), nil
+	case "type":
+		expected, err := runtime.resolve(assertion.Expected)
+		return err == nil && transcriptType(actual) == expected, err
+	case "matches", "not_matches":
+		value, ok := actual.(string)
+		if !ok {
+			return false, fmt.Errorf("%s actual is %T, want string", assertion.Op, actual)
+		}
+		pattern, err := regexp.Compile(assertion.Pattern)
+		if err != nil {
+			return false, err
+		}
+		matched := pattern.MatchString(value)
+		return matched == (assertion.Op == "matches"), nil
+	case "trimmed":
+		value, ok := actual.(string)
+		return ok && strings.TrimSpace(value) == value, nil
+	case "valid_utf8":
+		value, ok := actual.(string)
+		return ok && utf8.ValidString(value), nil
+	case "max_length":
+		value, ok := actual.(string)
+		if !ok {
+			return false, fmt.Errorf("max_length actual is %T, want string", actual)
+		}
+		expected, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		maximum, err := transcriptInteger(expected)
+		return err == nil && len(value) <= maximum, err
+	case "no_control":
+		value, ok := actual.(string)
+		if !ok {
+			return false, fmt.Errorf("no_control actual is %T, want string", actual)
+		}
+		for _, char := range value {
+			if unicode.IsControl(char) {
+				return false, nil
+			}
+		}
+		return true, nil
+	case "contains", "not_contains":
+		expected, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		contains, err := transcriptContains(actual, expected)
+		return err == nil && contains == (assertion.Op == "contains"), err
+	case "subset":
+		expected, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		items, ok := actual.([]any)
+		if !ok {
+			return false, fmt.Errorf("subset actual is %T, want array", actual)
+		}
+		for _, item := range items {
+			contains, err := transcriptContains(expected, item)
+			if err != nil || !contains {
+				return false, err
+			}
+		}
+		return true, nil
+	case "count":
+		expected, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		want, err := transcriptInteger(expected)
+		return err == nil && transcriptLength(actual) == want, err
+	case "unique":
+		items, ok := actual.([]any)
+		if !ok || len(assertion.By) != 1 {
+			return false, fmt.Errorf("unique requires an array and one by pointer")
+		}
+		seen := make(map[string]bool, len(items))
+		for _, item := range items {
+			key, found, err := resolveJSONPointer(item, assertion.By[0])
+			if err != nil || !found {
+				return false, err
+			}
+			encoded, _ := json.Marshal(key)
+			if seen[string(encoded)] {
+				return false, nil
+			}
+			seen[string(encoded)] = true
+		}
+		return true, nil
+	case "ordered":
+		items, ok := actual.([]any)
+		if !ok {
+			return false, fmt.Errorf("ordered actual is %T, want array", actual)
+		}
+		for index := 1; index < len(items); index++ {
+			comparison, err := compareTranscriptItems(items[index-1], items[index], assertion.By)
+			if err != nil {
+				return false, err
+			}
+			if comparison > 0 {
+				return false, nil
+			}
+		}
+		return true, nil
+	case "timestamp":
+		_, err := transcriptTime(actual)
+		return err == nil, err
+	case "time_lte", "time_gte", "time_gt":
+		expected, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		left, err := transcriptTime(actual)
+		if err != nil {
+			return false, err
+		}
+		right, err := transcriptTime(expected)
+		if err != nil {
+			return false, err
+		}
+		if assertion.Op == "time_lte" {
+			return !left.After(right), nil
+		}
+		if assertion.Op == "time_gte" {
+			return !left.Before(right), nil
+		}
+		return left.After(right), nil
+	case "time_between":
+		startValue, err := runtime.resolve(assertion.Start)
+		if err != nil {
+			return false, err
+		}
+		endValue, err := runtime.resolve(assertion.End)
+		if err != nil {
+			return false, err
+		}
+		valueTime, err := transcriptTime(actual)
+		if err != nil {
+			return false, err
+		}
+		startTime, err := transcriptTime(startValue)
+		if err != nil {
+			return false, err
+		}
+		endTime, err := transcriptTime(endValue)
+		if err != nil {
+			return false, err
+		}
+		tolerance := time.Duration(assertion.ToleranceSeconds) * time.Second
+		return !valueTime.Before(startTime.Add(-tolerance)) && !valueTime.After(endTime.Add(tolerance)), nil
+	case "all", "any", "one":
+		items, ok := actual.([]any)
+		if !ok || assertion.As == "" {
+			return false, fmt.Errorf("%s requires an array and loop variable", assertion.Op)
+		}
+		matchCount := 0
+		variables := runtime.root["vars"].(map[string]any)
+		previous, hadPrevious := variables[assertion.As]
+		for _, item := range items {
+			variables[assertion.As] = item
+			matched, err := runtime.matchesAll(assertion.Assert)
+			if err != nil {
+				return false, err
+			}
+			if matched {
+				matchCount++
+			}
+		}
+		if hadPrevious {
+			variables[assertion.As] = previous
+		} else {
+			delete(variables, assertion.As)
+		}
+		if assertion.Op == "all" {
+			return matchCount == len(items), nil
+		}
+		if assertion.Op == "any" {
+			return matchCount > 0, nil
+		}
+		return matchCount == 1, nil
+	case "entry_equal":
+		object, ok := actual.(map[string]any)
+		if !ok {
+			return false, fmt.Errorf("entry_equal actual is %T, want object", actual)
+		}
+		key, err := runtime.resolve(assertion.Key)
+		if err != nil {
+			return false, err
+		}
+		keyString, ok := key.(string)
+		if !ok {
+			return false, fmt.Errorf("entry_equal key is %T, want string", key)
+		}
+		expected, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		value, found := object[keyString]
+		return found && reflect.DeepEqual(value, expected), nil
+	case "entries_equal":
+		object, ok := actual.(map[string]any)
+		if !ok {
+			return false, fmt.Errorf("entries_equal actual is %T, want object", actual)
+		}
+		expected, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		expectedObject, ok := expected.(map[string]any)
+		if !ok {
+			return false, fmt.Errorf("entries_equal expected is %T, want object", expected)
+		}
+		key, err := runtime.resolve(assertion.Key)
+		if err != nil {
+			return false, err
+		}
+		keyString, ok := key.(string)
+		if !ok {
+			return false, fmt.Errorf("entries_equal key is %T, want string", key)
+		}
+		actualValue, actualFound := object[keyString]
+		expectedValue, expectedFound := expectedObject[keyString]
+		return actualFound && expectedFound && reflect.DeepEqual(actualValue, expectedValue), nil
+	case "array_appended":
+		after, ok := actual.([]any)
+		if !ok {
+			return false, fmt.Errorf("array_appended actual is %T, want array", actual)
+		}
+		beforeValue, err := runtime.resolve(assertion.Expected)
+		if err != nil {
+			return false, err
+		}
+		before, ok := beforeValue.([]any)
+		if !ok {
+			return false, fmt.Errorf("array_appended expected is %T, want array", beforeValue)
+		}
+		return len(after) == len(before)+1 && reflect.DeepEqual(after[:len(before)], before), nil
+	default:
+		return false, fmt.Errorf("unsupported operation %q", assertion.Op)
+	}
+}
+
+func (runtime *transcriptRuntime) resolve(reference transcriptValue) (any, error) {
+	if len(reference.Literal) != 0 {
+		return decodeTranscriptJSON(reference.Literal)
+	}
+	value, found, err := resolveJSONPointer(runtime.root, reference.Path)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("JSON Pointer %q does not exist", reference.Path)
+	}
+	if reference.Last {
+		items, ok := value.([]any)
+		if !ok || len(items) == 0 {
+			return nil, fmt.Errorf("JSON Pointer %q is not a nonempty array", reference.Path)
+		}
+		return items[len(items)-1], nil
+	}
+	return value, nil
+}
+
+func resolveJSONPointer(document any, pointer string) (any, bool, error) {
+	if err := validateJSONPointer(pointer, true); err != nil {
+		return nil, false, err
+	}
+	if pointer == "" {
+		return document, true, nil
+	}
+	current := document
+	for rawToken := range strings.SplitSeq(pointer[1:], "/") {
+		token := strings.ReplaceAll(strings.ReplaceAll(rawToken, "~1", "/"), "~0", "~")
+		switch typed := current.(type) {
+		case map[string]any:
+			var ok bool
+			current, ok = typed[token]
+			if !ok {
+				return nil, false, nil
+			}
+		case []any:
+			index, err := parseJSONPointerArrayIndex(token, pointer)
+			if err != nil {
+				return nil, false, err
+			}
+			if index < 0 || index >= len(typed) {
+				return nil, false, nil
+			}
+			current = typed[index]
+		default:
+			return nil, false, nil
+		}
+	}
+	return current, true, nil
+}
+
+func validateJSONPointer(pointer string, allowRoot bool) error {
+	if pointer == "" {
+		if allowRoot {
+			return nil
+		}
+		return errors.New("JSON Pointer cannot select the document root here")
+	}
+	if !strings.HasPrefix(pointer, "/") {
+		return fmt.Errorf("path %q is not an RFC 6901 JSON Pointer", pointer)
+	}
+	for index := 0; index < len(pointer); index++ {
+		if pointer[index] != '~' {
+			continue
+		}
+		if index+1 >= len(pointer) || (pointer[index+1] != '0' && pointer[index+1] != '1') {
+			return fmt.Errorf("path %q contains an invalid RFC 6901 escape", pointer)
+		}
+		index++
+	}
+	return nil
+}
+
+func removeJSONPointer(document any, pointer string) error {
+	if pointer == "" {
+		return errors.New("cannot remove the document root")
+	}
+	separator := strings.LastIndex(pointer, "/")
+	parent, found, err := resolveJSONPointer(document, pointer[:separator])
+	if err != nil || !found {
+		return err
+	}
+	token := strings.ReplaceAll(strings.ReplaceAll(pointer[separator+1:], "~1", "/"), "~0", "~")
+	switch typed := parent.(type) {
+	case map[string]any:
+		delete(typed, token)
+	case []any:
+		index, err := parseJSONPointerArrayIndex(token, pointer)
+		if err != nil || index >= len(typed) {
+			if err == nil {
+				err = fmt.Errorf("JSON Pointer %q has an invalid array index", pointer)
+			}
+			return err
+		}
+		typed[index] = nil
+	default:
+		return fmt.Errorf("pointer parent is not a container")
+	}
+	return nil
+}
+
+func parseJSONPointerArrayIndex(token, pointer string) (int, error) {
+	if token != "0" && (token == "" || token[0] == '0') {
+		return 0, fmt.Errorf("JSON Pointer %q has a non-canonical array index", pointer)
+	}
+	for _, char := range token {
+		if char < '0' || char > '9' {
+			return 0, fmt.Errorf("JSON Pointer %q has a non-numeric array index", pointer)
+		}
+	}
+	index, err := strconv.Atoi(token)
+	if err != nil || index < 0 {
+		return 0, fmt.Errorf("JSON Pointer %q has an invalid array index", pointer)
+	}
+	return index, nil
+}
+
+func cloneJSONValue(value any) any {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	cloned, err := decodeTranscriptJSON(encoded)
+	if err != nil {
+		return value
+	}
+	return cloned
+}
+
+func transcriptEmpty(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case string:
+		return len(typed) == 0
+	case []any:
+		return len(typed) == 0
+	case map[string]any:
+		return len(typed) == 0
+	default:
+		return false
+	}
+}
+
+func transcriptType(value any) string {
+	switch value.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case json.Number:
+		return "number"
+	case string:
+		return "string"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
+	default:
+		return "unknown"
+	}
+}
+
+func transcriptContains(container, candidate any) (bool, error) {
+	switch typed := container.(type) {
+	case []any:
+		for _, item := range typed {
+			if reflect.DeepEqual(item, candidate) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case string:
+		value, ok := candidate.(string)
+		if !ok {
+			return false, fmt.Errorf("string containment candidate is %T", candidate)
+		}
+		return strings.Contains(typed, value), nil
+	default:
+		return false, fmt.Errorf("contains actual is %T, want array or string", container)
+	}
+}
+
+func transcriptLength(value any) int {
+	switch typed := value.(type) {
+	case string:
+		return len(typed)
+	case []any:
+		return len(typed)
+	case map[string]any:
+		return len(typed)
+	default:
+		return -1
+	}
+}
+
+func transcriptInteger(value any) (int, error) {
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("value is %T, want number", value)
+	}
+	integer, err := strconv.Atoi(number.String())
+	if err != nil {
+		return 0, err
+	}
+	return integer, nil
+}
+
+func transcriptTime(value any) (time.Time, error) {
+	text, ok := value.(string)
+	if !ok {
+		return time.Time{}, fmt.Errorf("timestamp is %T, want string", value)
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, text)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse timestamp %q: %w", text, err)
+	}
+	return parsed, nil
+}
+
+func compareTranscriptItems(left, right any, paths []string) (int, error) {
+	for _, path := range paths {
+		leftValue, leftFound, err := resolveJSONPointer(left, path)
+		if err != nil || !leftFound {
+			return 0, fmt.Errorf("ordered left value at %q is unavailable", path)
+		}
+		rightValue, rightFound, err := resolveJSONPointer(right, path)
+		if err != nil || !rightFound {
+			return 0, fmt.Errorf("ordered right value at %q is unavailable", path)
+		}
+		leftString, leftOK := leftValue.(string)
+		rightString, rightOK := rightValue.(string)
+		if !leftOK || !rightOK {
+			return 0, fmt.Errorf("ordered values at %q are not strings", path)
+		}
+		leftTime, leftTimeErr := time.Parse(time.RFC3339Nano, leftString)
+		rightTime, rightTimeErr := time.Parse(time.RFC3339Nano, rightString)
+		if leftTimeErr == nil && rightTimeErr == nil {
+			if leftTime.Before(rightTime) {
+				return -1, nil
+			}
+			if leftTime.After(rightTime) {
+				return 1, nil
+			}
+			continue
+		}
+		if leftString < rightString {
+			return -1, nil
+		}
+		if leftString > rightString {
+			return 1, nil
+		}
+	}
+	return 0, nil
+}

--- a/pkg/connector/invocation_external_test.go
+++ b/pkg/connector/invocation_external_test.go
@@ -1,0 +1,111 @@
+package connector_test
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	connector "go.kenn.io/kata/pkg/connector"
+)
+
+func TestInvocationContextSettingsCannotBeMutatedThroughSafeReflection(t *testing.T) {
+	handler := &immutableInvocationHandler{}
+	var output bytes.Buffer
+	require.NoError(t, connector.ServeOne(
+		t.Context(),
+		bytes.NewBufferString(`{"protocol":"kata.connector.v1","id":"request-1","method":"describe","instance":"notes","settings":{"enabled":true},"params":{}}`),
+		&output,
+		handler,
+	))
+
+	assert.True(t, handler.immutable)
+	assert.JSONEq(t, `{"enabled":true}`, string(handler.after.Settings))
+}
+
+type keyCapturingContext struct {
+	context.Context
+	key any
+}
+
+func (ctx *keyCapturingContext) Value(key any) any {
+	ctx.key = key
+	return ctx.Context.Value(key)
+}
+
+type immutableInvocationHandler struct {
+	immutable bool
+	after     connector.Invocation
+}
+
+func (h *immutableInvocationHandler) Describe(ctx context.Context, _ connector.DescribeParams) (connector.Description, *connector.Error) {
+	forwarding := &keyCapturingContext{Context: ctx}
+	before, ok := connector.InvocationFromContext(forwarding)
+	if !ok {
+		return connector.Description{}, &connector.Error{Code: "missing_invocation", Message: "missing invocation"}
+	}
+
+	mutateFirstByteSlice(reflect.ValueOf(ctx.Value(forwarding.key)))
+	h.after, ok = connector.InvocationFromContext(ctx)
+	h.immutable = ok && bytes.Equal(before.Settings, h.after.Settings)
+	return connector.Description{}, nil
+}
+
+func mutateFirstByteSlice(value reflect.Value) bool {
+	if !value.IsValid() {
+		return false
+	}
+	switch value.Kind() {
+	case reflect.Interface, reflect.Pointer:
+		if value.IsNil() {
+			return false
+		}
+		return mutateFirstByteSlice(value.Elem())
+	case reflect.Struct:
+		for _, field := range value.Fields() {
+			if mutateFirstByteSlice(field) {
+				return true
+			}
+		}
+	case reflect.Slice:
+		if value.Type().Elem().Kind() == reflect.Uint8 && value.Len() > 0 {
+			value.Bytes()[0] = '!'
+			return true
+		}
+	}
+	return false
+}
+
+func (*immutableInvocationHandler) ResolveRoot(context.Context, connector.ResolveRootParams) (connector.Root, *connector.Error) {
+	return connector.Root{}, nil
+}
+
+func (*immutableInvocationHandler) ReadRoot(context.Context, connector.ReadRootParams) (connector.Root, *connector.Error) {
+	return connector.Root{}, nil
+}
+
+func (*immutableInvocationHandler) ListComments(context.Context, connector.ListCommentsParams) (connector.ListCommentsResult, *connector.Error) {
+	return connector.ListCommentsResult{}, nil
+}
+
+func (*immutableInvocationHandler) CompleteRoot(context.Context, connector.CompleteRootParams) (connector.Root, *connector.Error) {
+	return connector.Root{}, nil
+}
+
+func (*immutableInvocationHandler) PublishComment(context.Context, connector.PublishCommentParams) (connector.Comment, *connector.Error) {
+	return connector.Comment{}, nil
+}
+
+func (*immutableInvocationHandler) ListFields(context.Context, connector.ListFieldsParams) (connector.ListFieldsResult, *connector.Error) {
+	return connector.ListFieldsResult{}, nil
+}
+
+func (*immutableInvocationHandler) ReadFields(context.Context, connector.ReadFieldsParams) (connector.ReadFieldsResult, *connector.Error) {
+	return connector.ReadFieldsResult{}, nil
+}
+
+func (*immutableInvocationHandler) WriteFields(context.Context, connector.WriteFieldsParams) (connector.WriteFieldsResult, *connector.Error) {
+	return connector.WriteFieldsResult{}, nil
+}

--- a/pkg/connector/protocol.go
+++ b/pkg/connector/protocol.go
@@ -1,0 +1,264 @@
+// Package connector defines the versioned wire contract for external root connectors.
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// ProtocolVersion is the exact connector wire-protocol version.
+const ProtocolVersion = "kata.connector.v1"
+
+// Capability names an optional connector operation.
+type Capability string
+
+const (
+	// CapabilityPublishComment permits creating external comments.
+	CapabilityPublishComment Capability = "publish_comment"
+	// CapabilityFields permits reading and writing external fields.
+	CapabilityFields Capability = "fields"
+)
+
+// Request is one versioned connector invocation.
+type Request struct {
+	Protocol string          `json:"protocol"`
+	ID       string          `json:"id"`
+	Method   string          `json:"method"`
+	Instance string          `json:"instance"`
+	Settings json.RawMessage `json:"settings,omitempty"`
+	Params   json.RawMessage `json:"params,omitempty"`
+}
+
+// Invocation identifies the configured connector instance and settings for a
+// handler call. Settings is a copy of the request's raw JSON settings.
+type Invocation struct {
+	Instance string
+	Settings json.RawMessage
+}
+
+type invocationContextKey struct{}
+
+type invocationContextValue struct {
+	instance string
+	settings string
+}
+
+// InvocationFromContext returns a copy of the invocation attached by ServeOne
+// for a handler call.
+func InvocationFromContext(ctx context.Context) (Invocation, bool) {
+	stored, ok := ctx.Value(invocationContextKey{}).(invocationContextValue)
+	if !ok {
+		return Invocation{}, false
+	}
+	return Invocation{
+		Instance: stored.instance,
+		Settings: json.RawMessage(stored.settings),
+	}, true
+}
+
+func withInvocation(ctx context.Context, request Request) context.Context {
+	return context.WithValue(ctx, invocationContextKey{}, invocationContextValue{
+		instance: request.Instance,
+		settings: string(request.Settings),
+	})
+}
+
+// Response is one versioned connector result or structured error.
+type Response struct {
+	Protocol string          `json:"protocol"`
+	ID       string          `json:"id"`
+	Result   json.RawMessage `json:"result,omitempty"`
+	Error    *Error          `json:"error,omitempty"`
+}
+
+// Error is a connector-supplied structured protocol error.
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Code == "" {
+		return e.Message
+	}
+	return e.Code + ": " + e.Message
+}
+
+// Description identifies a connector instance and its current capabilities.
+type Description struct {
+	ConnectorID     string          `json:"connector_id"`
+	DisplayName     string          `json:"display_name"`
+	Protocol        string          `json:"protocol"`
+	Capabilities    []Capability    `json:"capabilities"`
+	ConfigSchema    json.RawMessage `json:"config_schema,omitempty"`
+	SelfActorID     string          `json:"self_actor_id,omitempty"`
+	AccountIdentity string          `json:"account_identity"`
+}
+
+// FieldDescriptor describes one externally addressable field.
+type FieldDescriptor struct {
+	ID             string   `json:"id"`
+	DisplayName    string   `json:"display_name"`
+	AcceptedKinds  []string `json:"accepted_kinds"`
+	Nullable       bool     `json:"nullable"`
+	Writable       bool     `json:"writable"`
+	SchemaRevision string   `json:"schema_revision"`
+}
+
+// Root is the connector's canonical observation of one external root.
+type Root struct {
+	Key         string                `json:"key"`
+	IdentityKey string                `json:"identity_key"`
+	Title       string                `json:"title"`
+	Body        string                `json:"body"`
+	State       string                `json:"state"`
+	Revision    string                `json:"revision"`
+	UpdatedAt   time.Time             `json:"updated_at"`
+	ObservedAt  time.Time             `json:"observed_at"`
+	Actor       *Actor                `json:"actor,omitempty"`
+	Fields      map[string]FieldValue `json:"fields,omitempty"`
+}
+
+// Actor identifies an external author without exposing provider credentials.
+type Actor struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+}
+
+// Comment is one external-root comment observation.
+type Comment struct {
+	ID        string    `json:"id"`
+	Revision  string    `json:"revision"`
+	Body      string    `json:"body"`
+	Author    Actor     `json:"author"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Deleted   bool      `json:"deleted"`
+}
+
+// FieldValue is a provider-neutral canonical field value.
+type FieldValue struct {
+	Kind     string `json:"kind"`
+	Value    string `json:"value,omitempty"`
+	Timezone string `json:"timezone,omitempty"`
+}
+
+// ValidateFieldValue rejects values outside the canonical portable field
+// representation used by ProtocolVersion.
+func ValidateFieldValue(value FieldValue) error {
+	switch value.Kind {
+	case "null":
+		if value.Value != "" || value.Timezone != "" {
+			return errors.New("null field value contains a value")
+		}
+	case "date":
+		parsed, err := time.Parse("2006-01-02", value.Value)
+		if err != nil || parsed.Format("2006-01-02") != value.Value || value.Timezone != "" {
+			return errors.New("field value is not a canonical date")
+		}
+	case "instant":
+		parsed, err := time.Parse(time.RFC3339Nano, value.Value)
+		if err != nil || parsed.UTC().Format(time.RFC3339Nano) != value.Value || value.Timezone != "" {
+			return errors.New("field value is not a canonical UTC instant")
+		}
+	case "local_datetime":
+		parsed, err := time.Parse("2006-01-02T15:04:05", value.Value)
+		location, zoneErr := time.LoadLocation(value.Timezone)
+		if err != nil || parsed.Format("2006-01-02T15:04:05") != value.Value ||
+			zoneErr != nil || value.Timezone == "Local" || location.String() != value.Timezone {
+			return errors.New("local datetime field value is incomplete")
+		}
+	default:
+		return errors.New("field value has unsupported kind")
+	}
+	return nil
+}
+
+// DescribeParams carries the empty describe request.
+type DescribeParams struct{}
+
+// ResolveRootParams locates an external root from user input.
+type ResolveRootParams struct {
+	Locator string `json:"locator"`
+}
+
+// ReadRootParams identifies an external root by its stable key.
+type ReadRootParams struct {
+	RootKey string `json:"root_key"`
+}
+
+// ListCommentsParams identifies the external root whose comments are requested.
+type ListCommentsParams struct {
+	RootKey string `json:"root_key"`
+}
+
+// ListCommentsResult contains the current external comment observations.
+type ListCommentsResult struct {
+	Comments []Comment `json:"comments"`
+}
+
+// CompleteRootParams identifies the external root to complete.
+type CompleteRootParams struct {
+	RootKey string `json:"root_key"`
+}
+
+// PublishCommentParams creates a comment on an external root.
+type PublishCommentParams struct {
+	RootKey     string `json:"root_key"`
+	Body        string `json:"body"`
+	OperationID string `json:"operation_id"`
+}
+
+// ValidOperationID reports whether value is a canonical publication idempotency key.
+func ValidOperationID(value string) bool {
+	return value != "" && strings.TrimSpace(value) == value
+}
+
+// ListFieldsParams carries the empty field-discovery request.
+type ListFieldsParams struct{}
+
+// ListFieldsResult contains the connector's current field descriptors.
+type ListFieldsResult struct {
+	Fields []FieldDescriptor `json:"fields"`
+}
+
+// ReadFieldsParams selects fields to read from an external root.
+type ReadFieldsParams struct {
+	RootKey  string   `json:"root_key"`
+	FieldIDs []string `json:"field_ids"`
+}
+
+// ReadFieldsResult contains canonical values keyed by external field ID.
+type ReadFieldsResult struct {
+	Fields map[string]FieldValue `json:"fields"`
+}
+
+// WriteFieldsParams applies canonical field values to an external root.
+type WriteFieldsParams struct {
+	RootKey string                `json:"root_key"`
+	Fields  map[string]FieldValue `json:"fields"`
+}
+
+// WriteFieldsResult contains the connector's canonical readback after writing.
+type WriteFieldsResult struct {
+	Fields map[string]FieldValue `json:"fields"`
+}
+
+// Handler implements all methods in ProtocolVersion.
+type Handler interface {
+	Describe(context.Context, DescribeParams) (Description, *Error)
+	ResolveRoot(context.Context, ResolveRootParams) (Root, *Error)
+	ReadRoot(context.Context, ReadRootParams) (Root, *Error)
+	ListComments(context.Context, ListCommentsParams) (ListCommentsResult, *Error)
+	CompleteRoot(context.Context, CompleteRootParams) (Root, *Error)
+	PublishComment(context.Context, PublishCommentParams) (Comment, *Error)
+	ListFields(context.Context, ListFieldsParams) (ListFieldsResult, *Error)
+	ReadFields(context.Context, ReadFieldsParams) (ReadFieldsResult, *Error)
+	WriteFields(context.Context, WriteFieldsParams) (WriteFieldsResult, *Error)
+}

--- a/pkg/connector/protocol_test.go
+++ b/pkg/connector/protocol_test.go
@@ -1,0 +1,434 @@
+package connector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtocolServeOneRejectsInvalidRequestFraming(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "unknown protocol", input: `{"protocol":"unknown","id":"1","method":"describe"}`, want: "unsupported protocol"},
+		{name: "unknown method", input: `{"protocol":"kata.connector.v1","id":"1","method":"unknown","instance":"notes","settings":{},"params":{}}`, want: "unknown method"},
+		{name: "trailing JSON", input: `{"protocol":"kata.connector.v1","id":"1","method":"describe"} {}`, want: "trailing JSON"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := ServeOne(t.Context(), bytes.NewBufferString(tt.input), &output, protocolTestHandler{})
+			require.ErrorContains(t, err, tt.want)
+			assert.Empty(t, output.String())
+		})
+	}
+}
+
+func TestProtocolServeOneDispatchesDescribe(t *testing.T) {
+	var output bytes.Buffer
+	err := ServeOne(t.Context(), bytes.NewBufferString(`{"protocol":"kata.connector.v1","id":"request-1","method":"describe","instance":"notes","settings":{},"params":{}}`), &output, protocolTestHandler{})
+	require.NoError(t, err)
+
+	var response Response
+	require.NoError(t, json.Unmarshal(output.Bytes(), &response))
+	assert.Equal(t, ProtocolVersion, response.Protocol)
+	assert.Equal(t, "request-1", response.ID)
+	assert.JSONEq(t, `{"connector_id":"example.connector","display_name":"Example","protocol":"kata.connector.v1","capabilities":[],"account_identity":"account-1"}`, string(response.Result))
+}
+
+func TestProtocolServeOneRejectsMalformedEnvelopeBeforeHandler(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		envelope string
+	}{
+		{name: "missing instance", envelope: `"settings":{}`},
+		{name: "empty instance", envelope: `"instance":"","settings":{}`},
+		{name: "padded instance", envelope: `"instance":" notes ","settings":{}`},
+		{name: "missing settings", envelope: `"instance":"notes"`},
+		{name: "null settings", envelope: `"instance":"notes","settings":null`},
+		{name: "array settings", envelope: `"instance":"notes","settings":[]`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handler := &describeCallHandler{}
+			var output bytes.Buffer
+			err := ServeOne(
+				t.Context(),
+				bytes.NewBufferString(`{"protocol":"kata.connector.v1","id":"request-1","method":"describe",`+test.envelope+`,"params":{}}`),
+				&output,
+				handler,
+			)
+			require.ErrorContains(t, err, "connector request")
+			assert.False(t, handler.called)
+			assert.Empty(t, output.String())
+		})
+	}
+}
+
+func TestProtocolServeOneRejectsMalformedParametersBeforeHandler(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		params string
+	}{
+		{name: "missing", params: ""},
+		{name: "null", params: `,"params":null`},
+		{name: "unknown field", params: `,"params":{"root_key":"root-1","unexpected":true}`},
+		{name: "missing root key", params: `,"params":{}`},
+		{name: "empty root key", params: `,"params":{"root_key":""}`},
+		{name: "padded root key", params: `,"params":{"root_key":" root-1 "}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handler := &completeRootCallHandler{}
+			var output bytes.Buffer
+			err := ServeOne(
+				t.Context(),
+				bytes.NewBufferString(`{"protocol":"kata.connector.v1","id":"request-1","method":"complete_root","instance":"notes","settings":{}`+test.params+`}`),
+				&output,
+				handler,
+			)
+			require.ErrorContains(t, err, "decode connector parameters")
+			assert.False(t, handler.called)
+			assert.Empty(t, output.String())
+		})
+	}
+}
+
+func TestProtocolServeOneRejectsInvalidUTF8BeforeHandler(t *testing.T) {
+	request := append(
+		[]byte(`{"protocol":"kata.connector.v1","id":"request-1","method":"complete_root","instance":"notes","settings":{},"params":{"root_key":"root-`),
+		0xff,
+	)
+	request = append(request, []byte(`"}}`)...)
+	handler := &completeRootCallHandler{}
+	var output bytes.Buffer
+	err := ServeOne(t.Context(), bytes.NewReader(request), &output, handler)
+	require.ErrorContains(t, err, "UTF-8")
+	assert.False(t, handler.called)
+	assert.Empty(t, output.String())
+}
+
+func TestProtocolServeOneRejectsInvalidRequiredParameters(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		method string
+		params string
+		want   string
+	}{
+		{name: "blank locator", method: "resolve_root", params: `{"locator":" "}`, want: "locator"},
+		{name: "read root key", method: "read_root", params: `{"root_key":" root-1"}`, want: "root_key"},
+		{name: "list comments root key", method: "list_comments", params: `{"root_key":""}`, want: "root_key"},
+		{name: "publish root key", method: "publish_comment", params: `{"root_key":"root-1 ","body":"hello","operation_id":"operation-1"}`, want: "root_key"},
+		{name: "missing field selectors", method: "read_fields", params: `{"root_key":"root-1"}`, want: "field_ids"},
+		{name: "noncanonical field selector", method: "read_fields", params: `{"root_key":"root-1","field_ids":[" field-1"]}`, want: "field_id"},
+		{name: "missing field values", method: "write_fields", params: `{"root_key":"root-1"}`, want: "fields"},
+		{name: "noncanonical field key", method: "write_fields", params: `{"root_key":"root-1","fields":{"field-1 ":{"kind":"null"}}}`, want: "field_id"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			err := ServeOne(
+				t.Context(),
+				bytes.NewBufferString(`{"protocol":"kata.connector.v1","id":"request-1","method":"`+test.method+`","instance":"notes","settings":{},"params":`+test.params+`}`),
+				&output,
+				protocolTestHandler{},
+			)
+			require.ErrorContains(t, err, test.want)
+			assert.Empty(t, output.String())
+		})
+	}
+}
+
+func TestProtocolServeOneRejectsInvalidFieldValuesBeforeHandler(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value string
+	}{
+		{name: "unsupported kind", value: `{"kind":"text","value":"hello"}`},
+		{name: "malformed date", value: `{"kind":"date","value":"tomorrow"}`},
+		{name: "non-UTC instant", value: `{"kind":"instant","value":"2026-08-20T10:00:00+00:00"}`},
+		{name: "incomplete local datetime", value: `{"kind":"local_datetime","value":"2026-08-20T10:00:00"}`},
+		{name: "nonempty null", value: `{"kind":"null","value":"unexpected"}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handler := &writeFieldsCallHandler{}
+			var output bytes.Buffer
+			err := ServeOne(
+				t.Context(),
+				bytes.NewBufferString(`{"protocol":"kata.connector.v1","id":"request-1","method":"write_fields","instance":"notes","settings":{},"params":{"root_key":"root-1","fields":{"field-1":`+test.value+`}}}`),
+				&output,
+				handler,
+			)
+			require.ErrorContains(t, err, "field value")
+			assert.False(t, handler.called)
+			assert.Empty(t, output.String())
+		})
+	}
+}
+
+func TestProtocolServeOneRequiresCanonicalPublicationOperationID(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		params string
+	}{
+		{name: "missing", params: `{"root_key":"root-1","body":"hello"}`},
+		{name: "empty", params: `{"root_key":"root-1","body":"hello","operation_id":""}`},
+		{name: "padded", params: `{"root_key":"root-1","body":"hello","operation_id":" operation-1 "}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handler := &publicationOperationHandler{}
+			var output bytes.Buffer
+			err := ServeOne(
+				t.Context(),
+				bytes.NewBufferString(`{"protocol":"kata.connector.v1","id":"request-1","method":"publish_comment","instance":"notes","settings":{},"params":`+test.params+`}`),
+				&output,
+				handler,
+			)
+			require.ErrorContains(t, err, "operation_id")
+			assert.False(t, handler.called)
+			assert.Empty(t, output.String())
+		})
+	}
+}
+
+func TestProtocolServeOneDispatchesStablePublicationOperationID(t *testing.T) {
+	handler := &publicationOperationHandler{}
+	var output bytes.Buffer
+	require.NoError(t, ServeOne(
+		t.Context(),
+		bytes.NewBufferString(`{"protocol":"kata.connector.v1","id":"request-1","method":"publish_comment","instance":"notes","settings":{},"params":{"root_key":"root-1","body":"hello","operation_id":"publish-comment-1"}}`),
+		&output,
+		handler,
+	))
+
+	assert.True(t, handler.called)
+	assert.Equal(t, "publish-comment-1", handler.operationID)
+}
+
+func TestProtocolServeOneAttachesImmutableInvocation(t *testing.T) {
+	handler := &invocationTestHandler{}
+	settings := json.RawMessage(`{"enabled":true}`)
+	requests := []string{
+		`{"protocol":"kata.connector.v1","id":"request-1","method":"describe","instance":"notes","settings":{"enabled":true},"params":{}}`,
+		`{"protocol":"kata.connector.v1","id":"request-2","method":"read_root","instance":"notes","settings":{"enabled":true},"params":{"root_key":"root-1"}}`,
+	}
+	for _, request := range requests {
+		var output bytes.Buffer
+		require.NoError(t, ServeOne(t.Context(), bytes.NewBufferString(request), &output, handler))
+	}
+	require.Len(t, handler.invocations, 2)
+	for _, invocation := range handler.invocations {
+		assert.Equal(t, "notes", invocation.Instance)
+		assert.JSONEq(t, string(settings), string(invocation.Settings))
+	}
+	assert.True(t, handler.immutable)
+}
+
+func TestInvocationFromContextRejectsSpoofedPublicInvocation(t *testing.T) {
+	ctx := spoofedInvocationContext{
+		Context: t.Context(),
+		invocation: Invocation{
+			Instance: "spoofed",
+			Settings: json.RawMessage(`{"spoofed":true}`),
+		},
+	}
+
+	invocation, ok := InvocationFromContext(ctx)
+	assert.False(t, ok)
+	assert.Equal(t, Invocation{}, invocation)
+}
+
+func TestProtocolServeOneKeepsInvocationStoragePrivateFromForwardingContext(t *testing.T) {
+	handler := &capturingInvocationHandler{}
+	var output bytes.Buffer
+	require.NoError(t, ServeOne(
+		t.Context(),
+		bytes.NewBufferString(`{"protocol":"kata.connector.v1","id":"request-1","method":"describe","instance":"notes","settings":{"enabled":true},"params":{}}`),
+		&output,
+		handler,
+	))
+
+	assert.False(t, handler.storedAsPublicInvocation)
+	assert.True(t, handler.storageImmutable)
+	assert.Equal(t, "notes", handler.invocation.Instance)
+	assert.JSONEq(t, `{"enabled":true}`, string(handler.invocation.Settings))
+}
+
+type protocolTestHandler struct{}
+
+func (protocolTestHandler) Describe(context.Context, DescribeParams) (Description, *Error) {
+	return Description{ConnectorID: "example.connector", DisplayName: "Example", Protocol: ProtocolVersion, Capabilities: []Capability{}, AccountIdentity: "account-1"}, nil
+}
+
+func (protocolTestHandler) ResolveRoot(context.Context, ResolveRootParams) (Root, *Error) {
+	return Root{}, nil
+}
+func (protocolTestHandler) ReadRoot(context.Context, ReadRootParams) (Root, *Error) {
+	return Root{}, nil
+}
+func (protocolTestHandler) ListComments(context.Context, ListCommentsParams) (ListCommentsResult, *Error) {
+	return ListCommentsResult{}, nil
+}
+func (protocolTestHandler) CompleteRoot(context.Context, CompleteRootParams) (Root, *Error) {
+	return Root{}, nil
+}
+func (protocolTestHandler) PublishComment(context.Context, PublishCommentParams) (Comment, *Error) {
+	return Comment{}, nil
+}
+func (protocolTestHandler) ListFields(context.Context, ListFieldsParams) (ListFieldsResult, *Error) {
+	return ListFieldsResult{}, nil
+}
+func (protocolTestHandler) ReadFields(context.Context, ReadFieldsParams) (ReadFieldsResult, *Error) {
+	return ReadFieldsResult{}, nil
+}
+func (protocolTestHandler) WriteFields(context.Context, WriteFieldsParams) (WriteFieldsResult, *Error) {
+	return WriteFieldsResult{}, nil
+}
+
+type describeCallHandler struct {
+	protocolTestHandler
+	called bool
+}
+
+func (h *describeCallHandler) Describe(context.Context, DescribeParams) (Description, *Error) {
+	h.called = true
+	return h.protocolTestHandler.Describe(context.Background(), DescribeParams{})
+}
+
+type publicationOperationHandler struct {
+	protocolTestHandler
+	called      bool
+	operationID string
+}
+
+type completeRootCallHandler struct {
+	protocolTestHandler
+	called bool
+}
+
+type writeFieldsCallHandler struct {
+	protocolTestHandler
+	called bool
+}
+
+func (h *writeFieldsCallHandler) WriteFields(context.Context, WriteFieldsParams) (WriteFieldsResult, *Error) {
+	h.called = true
+	return WriteFieldsResult{}, nil
+}
+
+func (h *completeRootCallHandler) CompleteRoot(context.Context, CompleteRootParams) (Root, *Error) {
+	h.called = true
+	return Root{}, nil
+}
+
+func (h *publicationOperationHandler) PublishComment(_ context.Context, params PublishCommentParams) (Comment, *Error) {
+	h.called = true
+	h.operationID = params.OperationID
+	return Comment{}, nil
+}
+
+type spoofedInvocationContext struct {
+	context.Context
+	invocation Invocation
+}
+
+func (ctx spoofedInvocationContext) Value(any) any {
+	return ctx.invocation
+}
+
+type invocationKeyCapturingContext struct {
+	context.Context
+	key any
+}
+
+func (ctx *invocationKeyCapturingContext) Value(key any) any {
+	ctx.key = key
+	return ctx.Context.Value(key)
+}
+
+type capturingInvocationHandler struct {
+	protocolTestHandler
+	invocation               Invocation
+	storedAsPublicInvocation bool
+	storageImmutable         bool
+}
+
+func (h *capturingInvocationHandler) Describe(ctx context.Context, _ DescribeParams) (Description, *Error) {
+	forwarding := &invocationKeyCapturingContext{Context: ctx}
+	invocation, ok := InvocationFromContext(forwarding)
+	if !ok {
+		return Description{}, &Error{Code: "missing_invocation", Message: "missing invocation"}
+	}
+	h.invocation = invocation
+
+	stored, public := ctx.Value(forwarding.key).(Invocation)
+	h.storedAsPublicInvocation = public
+	if public && len(stored.Settings) > 0 {
+		stored.Settings[0] = '!'
+	}
+	again, ok := InvocationFromContext(ctx)
+	h.storageImmutable = ok && bytes.Equal(again.Settings, invocation.Settings)
+	return Description{}, nil
+}
+
+type invocationTestHandler struct {
+	invocations []Invocation
+	immutable   bool
+}
+
+func (h *invocationTestHandler) capture(ctx context.Context) *Error {
+	invocation, ok := InvocationFromContext(ctx)
+	if !ok {
+		return &Error{Code: "missing_invocation", Message: "missing invocation"}
+	}
+	h.invocations = append(h.invocations, Invocation{
+		Instance: invocation.Instance,
+		Settings: append(json.RawMessage(nil), invocation.Settings...),
+	})
+	if len(h.invocations) == 1 {
+		h.immutable = true
+	}
+	if len(invocation.Settings) > 0 {
+		invocation.Settings[0] = '!'
+	}
+	again, ok := InvocationFromContext(ctx)
+	h.immutable = h.immutable && ok && bytes.Equal(again.Settings, h.invocations[len(h.invocations)-1].Settings)
+	return nil
+}
+
+func (h *invocationTestHandler) Describe(ctx context.Context, _ DescribeParams) (Description, *Error) {
+	if err := h.capture(ctx); err != nil {
+		return Description{}, err
+	}
+	return Description{}, nil
+}
+
+func (h *invocationTestHandler) ResolveRoot(context.Context, ResolveRootParams) (Root, *Error) {
+	return Root{}, nil
+}
+func (h *invocationTestHandler) ReadRoot(ctx context.Context, _ ReadRootParams) (Root, *Error) {
+	if err := h.capture(ctx); err != nil {
+		return Root{}, err
+	}
+	return Root{}, nil
+}
+func (h *invocationTestHandler) ListComments(context.Context, ListCommentsParams) (ListCommentsResult, *Error) {
+	return ListCommentsResult{}, nil
+}
+func (h *invocationTestHandler) CompleteRoot(context.Context, CompleteRootParams) (Root, *Error) {
+	return Root{}, nil
+}
+func (h *invocationTestHandler) PublishComment(context.Context, PublishCommentParams) (Comment, *Error) {
+	return Comment{}, nil
+}
+func (h *invocationTestHandler) ListFields(context.Context, ListFieldsParams) (ListFieldsResult, *Error) {
+	return ListFieldsResult{}, nil
+}
+func (h *invocationTestHandler) ReadFields(context.Context, ReadFieldsParams) (ReadFieldsResult, *Error) {
+	return ReadFieldsResult{}, nil
+}
+func (h *invocationTestHandler) WriteFields(context.Context, WriteFieldsParams) (WriteFieldsResult, *Error) {
+	return WriteFieldsResult{}, nil
+}

--- a/pkg/connector/serve.go
+++ b/pkg/connector/serve.go
@@ -1,0 +1,191 @@
+package connector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+// ServeOne reads, validates, dispatches, and responds to one protocol request.
+func ServeOne(ctx context.Context, in io.Reader, out io.Writer, handler Handler) error {
+	if handler == nil {
+		return errors.New("connector handler is nil")
+	}
+	encoded, err := io.ReadAll(in)
+	if err != nil {
+		return fmt.Errorf("read connector request: %w", err)
+	}
+	if !utf8.Valid(encoded) {
+		return errors.New("decode connector request: request is not valid UTF-8")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	var request Request
+	if err := decoder.Decode(&request); err != nil {
+		return fmt.Errorf("decode connector request: %w", err)
+	}
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("connector request contains trailing JSON")
+		}
+		return fmt.Errorf("decode connector request trailing JSON: %w", err)
+	}
+	if request.Protocol != ProtocolVersion {
+		return fmt.Errorf("unsupported protocol %q", request.Protocol)
+	}
+	if err := validateRequestEnvelope(request); err != nil {
+		return fmt.Errorf("invalid connector request: %w", err)
+	}
+	ctx = withInvocation(ctx, request)
+
+	result, callErr, err := dispatch(ctx, handler, request)
+	if err != nil {
+		return err
+	}
+	response := Response{Protocol: ProtocolVersion, ID: request.ID, Result: result, Error: callErr}
+	if err := json.NewEncoder(out).Encode(response); err != nil {
+		return fmt.Errorf("encode connector response: %w", err)
+	}
+	return nil
+}
+
+func validateRequestEnvelope(request Request) error {
+	if err := validateCanonicalIdentifier("instance", request.Instance); err != nil {
+		return err
+	}
+	trimmed := bytes.TrimSpace(request.Settings)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return errors.New("settings must be a JSON object")
+	}
+	var settings map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &settings); err != nil || settings == nil {
+		return errors.New("settings must be a JSON object")
+	}
+	return nil
+}
+
+func dispatch(ctx context.Context, handler Handler, request Request) (json.RawMessage, *Error, error) {
+	switch request.Method {
+	case "describe":
+		return call(request.Params, func(params DescribeParams) (Description, *Error) { return handler.Describe(ctx, params) })
+	case "resolve_root":
+		return callValidated(request.Params, validateResolveRootParams, func(params ResolveRootParams) (Root, *Error) { return handler.ResolveRoot(ctx, params) })
+	case "read_root":
+		return callValidated(request.Params, func(params ReadRootParams) error { return validateRootKey(params.RootKey) }, func(params ReadRootParams) (Root, *Error) { return handler.ReadRoot(ctx, params) })
+	case "list_comments":
+		return callValidated(request.Params, func(params ListCommentsParams) error { return validateRootKey(params.RootKey) }, func(params ListCommentsParams) (ListCommentsResult, *Error) { return handler.ListComments(ctx, params) })
+	case "complete_root":
+		return callValidated(request.Params, func(params CompleteRootParams) error { return validateRootKey(params.RootKey) }, func(params CompleteRootParams) (Root, *Error) { return handler.CompleteRoot(ctx, params) })
+	case "publish_comment":
+		return callValidated(request.Params, func(params PublishCommentParams) error {
+			if err := validateRootKey(params.RootKey); err != nil {
+				return err
+			}
+			if !ValidOperationID(params.OperationID) {
+				return errors.New("operation_id must be nonempty and canonical")
+			}
+			return nil
+		}, func(params PublishCommentParams) (Comment, *Error) { return handler.PublishComment(ctx, params) })
+	case "list_fields":
+		return call(request.Params, func(params ListFieldsParams) (ListFieldsResult, *Error) { return handler.ListFields(ctx, params) })
+	case "read_fields":
+		return callValidated(request.Params, validateReadFieldsParams, func(params ReadFieldsParams) (ReadFieldsResult, *Error) { return handler.ReadFields(ctx, params) })
+	case "write_fields":
+		return callValidated(request.Params, validateWriteFieldsParams, func(params WriteFieldsParams) (WriteFieldsResult, *Error) { return handler.WriteFields(ctx, params) })
+	default:
+		return nil, nil, fmt.Errorf("unknown method %q", request.Method)
+	}
+}
+
+func call[P any, R any](raw json.RawMessage, fn func(P) (R, *Error)) (json.RawMessage, *Error, error) {
+	return callValidated(raw, nil, fn)
+}
+
+func callValidated[P any, R any](raw json.RawMessage, validate func(P) error, fn func(P) (R, *Error)) (json.RawMessage, *Error, error) {
+	var params P
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil, errors.New("decode connector parameters: parameters must be a JSON object")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&params); err != nil {
+		return nil, nil, fmt.Errorf("decode connector parameters: %w", err)
+	}
+	if err := decoder.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, nil, errors.New("decode connector parameters: trailing JSON")
+		}
+		return nil, nil, fmt.Errorf("decode connector parameters: trailing JSON: %w", err)
+	}
+	if validate != nil {
+		if err := validate(params); err != nil {
+			return nil, nil, fmt.Errorf("decode connector parameters: %w", err)
+		}
+	}
+	result, callErr := fn(params)
+	if callErr != nil {
+		return nil, callErr, nil
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode connector result: %w", err)
+	}
+	return encoded, nil, nil
+}
+
+func validateResolveRootParams(params ResolveRootParams) error {
+	if strings.TrimSpace(params.Locator) == "" {
+		return errors.New("locator must be nonempty")
+	}
+	return nil
+}
+
+func validateRootKey(rootKey string) error {
+	return validateCanonicalIdentifier("root_key", rootKey)
+}
+
+func validateReadFieldsParams(params ReadFieldsParams) error {
+	if err := validateRootKey(params.RootKey); err != nil {
+		return err
+	}
+	if params.FieldIDs == nil {
+		return errors.New("field_ids must be present")
+	}
+	for _, fieldID := range params.FieldIDs {
+		if err := validateCanonicalIdentifier("field_id", fieldID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateWriteFieldsParams(params WriteFieldsParams) error {
+	if err := validateRootKey(params.RootKey); err != nil {
+		return err
+	}
+	if params.Fields == nil {
+		return errors.New("fields must be present")
+	}
+	for fieldID, value := range params.Fields {
+		if err := validateCanonicalIdentifier("field_id", fieldID); err != nil {
+			return err
+		}
+		if err := ValidateFieldValue(value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCanonicalIdentifier(name, value string) error {
+	if value == "" || strings.TrimSpace(value) != value {
+		return fmt.Errorf("%s must be nonempty and canonical", name)
+	}
+	return nil
+}


### PR DESCRIPTION
## What changed

- define the versioned newline-delimited JSON connector protocol, typed field values, capabilities, structured safe errors, and identity rules
- ship the public Go SDK plus language-neutral conformance transcripts and a reusable conformance suite
- add bounded subprocess invocation, process-tree cleanup, connector auditing, and configuration validation
- redact only secret values explicitly mapped through `connector.env`; command arguments and connector settings remain diagnosable non-secret configuration

## Scope

This is PR 1 of the delivery sequence tracked in #286. It contains only the connector protocol, SDK, runtime boundary, and conformance tooling. Persistence, reconciliation, and daemon/API/CLI integration follow in dependent PRs.

Connector processes are invoked once per bounded RPC in this version. A long-lived transport can be added later without changing the protocol contract.

Part of #286.
