### PR TITLE
test: remove flaky hook shutdown stopwatch

### DIFF
--- a/internal/hooks/dispatcher_test.go
+++ b/internal/hooks/dispatcher_test.go
@@ -321,12 +321,9 @@ func TestDispatcher_Shutdown_CancelsInFlightBeforeDeadlineAndJoins(t *testing.T)
 	const budget = 600 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
-	started := time.Now()
 	err := d.Shutdown(ctx)
-	elapsed := time.Since(started)
 
 	require.NoError(t, err, "in-flight hook must be cancelled inside the budget so workers join cleanly")
-	require.Less(t, elapsed, budget, "shutdown must finish before the budget expires")
 	data, readErr := os.ReadFile(runsPath) //nolint:gosec // G304: test-controlled path under t.TempDir()
 	require.NoError(t, readErr)
 	require.Contains(t, string(data), `"result":"daemon_shutdown"`)

--- a/internal/hooks/dispatcher_test.go
+++ b/internal/hooks/dispatcher_test.go
@@ -18,6 +18,8 @@ import (
 	"go.kenn.io/kata/internal/db"
 )
 
+const dispatcherTestGraceWindow = 250 * time.Millisecond
+
 // mustNewDispatcher builds a Dispatcher rooted at a fresh temp KataHome with
 // no-op resolvers and returns the dispatcher, a buffer capturing the daemon
 // log, and the absolute path to the runs.jsonl appender for that DB.
@@ -35,7 +37,7 @@ func mustNewDispatcher(t *testing.T, hooks []ResolvedHook, cfg Config) (*Dispatc
 		CommentResolver: func(_ context.Context, _ int64) (CommentSnapshot, error) { return CommentSnapshot{}, nil },
 		ProjectResolver: func(_ context.Context, _ int64) (ProjectSnapshot, error) { return ProjectSnapshot{}, nil },
 		Now:             time.Now,
-		GraceWindow:     50 * time.Millisecond,
+		GraceWindow:     dispatcherTestGraceWindow,
 	}
 	loaded := LoadedConfig{Snapshot: Snapshot{Hooks: hooks}, Config: cfg}
 	d, err := New(loaded, deps)
@@ -318,7 +320,7 @@ func TestDispatcher_Shutdown_CancelsInFlightBeforeDeadlineAndJoins(t *testing.T)
 	enqueueEvents(d, "issue.created", 500, 1)
 	waitForInflight(t, d, 1, 5*time.Second)
 
-	const budget = 600 * time.Millisecond
+	const budget = 5 * dispatcherTestGraceWindow
 	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 	err := d.Shutdown(ctx)


### PR DESCRIPTION
On Windows, hook shutdown consumes the test's full process grace period before a forced kill. The test compressed production's 5-second grace to 50 ms, leaving only another 50 ms for kill and reap work before its context expired under CI load.

This uses a 250 ms test grace with the same 5:1 shutdown-budget ratio as production and removes the duplicate elapsed-time assertion. The test still requires a successful worker join and a `daemon_shutdown` run record, so shutdown regressions remain covered.

Observed in the [main failure](https://github.com/kenn-io/kata/actions/runs/32513404285) and reproduced by the [first PR run](https://github.com/kenn-io/kata/actions/runs/32520520663).
