### PR TITLE
Fix local Kata UI access and narrow layouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,10 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Install frozen web dependencies and Chromium
+      - name: Install frozen web dependencies and browsers
         run: |
           make web-install
-          cd web && bun x playwright install --with-deps chromium
+          cd web && bun x playwright install --with-deps chromium firefox
 
       - name: Run isolated browser tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,10 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Install frozen web dependencies and browsers
+      - name: Install frozen web dependencies and Chromium
         run: |
           make web-install
-          cd web && bun x playwright install --with-deps chromium firefox
+          cd web && bun x playwright install --with-deps chromium
 
       - name: Run isolated browser tests
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@
   skill (including `roborev-fix` or `roborev-design-review-branch`) unless the
   user explicitly asks for that skill.
 - Test First: Write a failing test before the implementation, then make it pass, then refactor (red, green, refactor). Don't add production code without a failing test that requires it.
+- Evidence-Gated Regression Tests: Before writing a regression test, reproduce
+  the failure or name the explicit product contract it exercises. Do not encode
+  an inferred cause or hypothetical failure. Browser-specific coverage requires
+  a reproduced browser-specific failure; otherwise use the default test browser.
 - Explicit Database Change Consent: Do not add, remove, or modify a production
   database migration or persisted database schema without the user's explicit
   consent in the current conversation. This includes canonical/bootstrap DDL,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,8 @@ authorization service. Review browser changes against these boundaries:
   loopback browser listener. A direct tab on that listener creates its own
   local-web session only when the exact Host matches, the request arrives
   directly from loopback, no forwarding headers are present, and daemon
-  token/identity/proxy authentication is unconfigured. The mint normally
+  identity/proxy authentication is unconfigured. A static daemon token does
+  not disable this owner-local browser path. The mint normally
   requires the exact Origin. An embedded owner-local browser may omit or send
   an empty Origin only on this mint; exact Host validation remains the
   DNS-rebinding boundary, and cross-site Fetch Metadata remains forbidden.
@@ -209,7 +210,7 @@ authorization service. Review browser changes against these boundaries:
   owner filesystem paths or aliases. Configured logins retain their token principal;
   in identity mode the bootstrap principal remains non-writable. A browser 401
   clears tab-local credentials, fences accepted snapshots and drafts from
-  further writes. A keyless loopback tab attempts one transparent local-session
+  further writes. A direct loopback tab attempts one transparent local-session
   renewal; authenticated deployments return to their explicit token-login
   mechanism. An explicit login waits for token exchange before reading
   authority. Every mutation path, including project creation, uses that

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -2392,7 +2392,7 @@ func TestDaemonRuntimeWebMetadata(t *testing.T) {
 	}
 }
 
-func TestDaemonRuntimeWebMetadata_TokenProtectedReadonlyRequiresLogin(t *testing.T) {
+func TestDaemonRuntimeWebMetadata_TokenProtectedReadonlyAllowsLoopbackSession(t *testing.T) {
 	resetFlags(t)
 	setupKataEnv(t)
 	t.Setenv("PORT", "")
@@ -2420,7 +2420,7 @@ func TestDaemonRuntimeWebMetadata_TokenProtectedReadonlyRequiresLogin(t *testing
 			record.Metadata["web_origin"] != ""
 	}, 3*time.Second, 10*time.Millisecond)
 
-	assert.Equal(t, "login,poll", record.Metadata["web_capabilities"])
+	assert.Equal(t, "loopback,poll", record.Metadata["web_capabilities"])
 
 	cancel()
 	select {

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -124,7 +124,7 @@ HTTP server rejects any non-empty `Origin` header, requires
 `Content-Type: application/json` on mutations, and emits no CORS headers. The CLI
 and TUI never set `Origin`, so they are unaffected.
 
-The separate browser listener uses the established host-local, keyless-loopback
+The separate browser listener uses the established host-local, direct-loopback
 trust boundary. A direct-loopback tab can create a local-web
 session only with the exact configured Host and without forwarding headers. The
 mint normally requires the exact Origin; an embedded owner-local browser may
@@ -132,10 +132,11 @@ omit or send an empty Origin only on this endpoint, and cross-site Fetch
 Metadata remains forbidden. Exact Host validation stays ahead of the exception
 as the DNS-rebinding boundary. All later data requests require both the HttpOnly
 instance cookie and tab-local session header; mutations also require its CSRF
-value and exact Origin. Configuring daemon authentication, a proxy origin, or a
-non-loopback listener disables the direct local bootstrap path. Other processes
-or users able to connect from the same host are inside this ordinary browser-UI
-boundary; local-web authority does not include token administration.
+value and exact Origin. A static daemon token does not disable this path;
+identity authentication, proxy authentication, a proxy origin, or a non-loopback
+listener does. Other processes or users able to connect from the same host are
+inside this ordinary browser-UI boundary; local-web authority does not include
+token administration.
 
 **Shared and remote modes** add a network boundary. They require a bearer token
 and an explicit trust opt-in before the daemon will put credentials on a

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -109,9 +109,11 @@ tab-local credential with an HttpOnly instance cookie, and later mutations also
 require exact-origin CSRF validation. Restarting the daemon invalidates its
 browser sessions.
 
-Non-loopback, authenticated, or proxied deployments do not receive local-web
-authority automatically. They require the configured login mechanism and an
-exact public origin. Plain HTTP outside loopback is limited to an explicitly
+Non-loopback, identity-authenticated, or proxied deployments do not receive
+local-web authority automatically. They require the configured login mechanism
+and an exact public origin. A static daemon token does not disable the direct
+loopback session, so `kata ui` remains local and passwordless when that token is
+also used by API clients. Plain HTTP outside loopback is limited to an explicitly
 trusted private network; otherwise terminate HTTPS at the same origin.
 `--insecure-readonly` can serve an anonymous browser but never grants mutation
 authority.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -547,15 +547,15 @@ kata ui 01HZNQ7VFPK1XGD8R5MABCD4EX
 ```
 
 Kata resolves the ref before launching and opens the stable
-`/kata?scope=<project-uid>&issue=<issue-uid>` route. A default keyless loopback
-daemon opens directly; the browser transparently creates its local-web session
-on that origin.
+`/kata?scope=<project-uid>&issue=<issue-uid>` route. A default loopback daemon
+opens directly; the browser transparently creates its local-web session on that
+origin, including when the daemon also has a static API token.
 
 The remaining browser-session authority is split between an HttpOnly cookie
 and same-tab session storage. Reloading that tab preserves the session. A fresh
-tab on the default keyless loopback UI transparently creates its own local-web
+tab on the default loopback UI transparently creates its own local-web
 session, so the URL reported by `kata daemon status` can be opened directly.
-Authenticated, proxied, and non-loopback origins require token login.
+Identity-authenticated, proxied, and non-loopback origins require login.
 Daemon restart invalidates the process-scoped session. Presentation
 preferences survive only when the browser origin remains the same.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -278,11 +278,12 @@ behavior; set a nonzero port when a fixed browser origin is required. The
 top-level `listen` remains the daemon API listener and is shared with the
 browser when it is TCP (including Windows and hosted mode).
 
-On a keyless direct-loopback origin, a fresh browser tab transparently receives
-a local-web session. Kata disables this local convenience when the listener or
-public origin is non-loopback, a forwarding header is present, or daemon token,
-identity, or trusted-proxy authentication is configured. Authenticated browser
-requests still require both the HttpOnly cookie and tab-local session header.
+On a direct-loopback origin, a fresh browser tab transparently receives a
+local-web session. A static daemon token does not disable this owner-local path.
+Kata disables it when the listener or public origin is non-loopback, a forwarding
+header is present, or identity or trusted-proxy authentication is configured.
+Authenticated browser requests still require both the HttpOnly cookie and
+tab-local session header.
 If the browser listener is itself named in
 `[auth.proxy].trusted_proxy_listeners`, the browser transparently exchanges the
 proxy-asserted actor for that tab-scoped session instead of showing token login.

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -186,13 +186,14 @@ refreshes the snapshot instead of constructing a second authority from event
 payloads.
 
 The browser-session routes are deliberately outside the generated client
-contract. A fresh tab on a keyless direct-loopback origin uses
+contract. A fresh tab on a direct-loopback origin uses
 `POST /api/v1/ui/session/local`. Exact Host, peer address, forwarding-header,
-and daemon-auth policy gate that endpoint before it issues a local-web session.
-The mint normally requires the exact Origin; an embedded owner-local browser
-may omit or send an empty Origin only on this endpoint, while cross-site Fetch
-Metadata remains forbidden. Exact Host validation runs first and remains the
-DNS-rebinding boundary.
+and identity/proxy authentication policy gate that endpoint before it issues a
+local-web session. A static daemon token does not disable this owner-local path.
+The mint normally requires the exact Origin; an embedded owner-local browser may
+omit or send an empty Origin only on this endpoint, while cross-site Fetch Metadata
+remains forbidden. Exact Host validation runs first and remains the DNS-rebinding
+boundary.
 
 The URL reported by `kata daemon status` and local `kata ui` both open that
 loopback origin directly. Configured origins exchange a bearer or identity
@@ -201,7 +202,7 @@ token at `POST /api/v1/ui/session/login`. Logout is
 Session-authentication errors advertise the canonical browser origin in
 `X-Kata-Web-Origin` and its `loopback` or `login` mode in
 `X-Kata-Web-Authentication`, allowing `kata ui` to distinguish a configured
-keyless loopback URL from an authenticated deployment without carrying a
+direct loopback URL from a login-only deployment without carrying a
 launch credential.
 
 The launch-target URL is derived only from the daemon's configured canonical

--- a/internal/client/webui.go
+++ b/internal/client/webui.go
@@ -137,7 +137,7 @@ func discoverWebRuntimeForBaseURL(ctx context.Context, dataDir, baseURL string) 
 	return DiscoveredWebRuntime{}, errors.New("live daemon did not publish matching browser runtime metadata")
 }
 
-// OpenWebUI opens keyless loopback targets directly and selects login for
+// OpenWebUI opens owner-local loopback targets directly and selects login for
 // authenticated browser listeners.
 func OpenWebUI(
 	ctx context.Context,

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -35,7 +35,7 @@ const (
 	// adapter. It never comes from a network header.
 	PrincipalHost PrincipalKind = "host"
 	// PrincipalWebLocal is issued through the owner-local launch proof or the
-	// direct keyless-loopback browser boundary. It permits ordinary attributed
+	// direct owner-local loopback browser boundary. It permits ordinary attributed
 	// writes without granting bearer-token administration authority.
 	PrincipalWebLocal PrincipalKind = "web_local"
 )

--- a/internal/daemon/web_endpoint.go
+++ b/internal/daemon/web_endpoint.go
@@ -30,10 +30,10 @@ type WebEndpoint struct {
 	Shared       bool
 }
 
-// AllowsLocalSession reports whether this endpoint uses the direct, keyless
+// AllowsLocalSession reports whether this endpoint uses the direct, owner-local
 // loopback trust boundary for ordinary browser UI access.
 func (e WebEndpoint) AllowsLocalSession(auth config.AuthConfig) bool {
-	if strings.TrimSpace(auth.Token) != "" || auth.RequireTokenIdentity ||
+	if auth.RequireTokenIdentity ||
 		strings.TrimSpace(auth.Proxy.TrustedActorHeader) != "" || len(auth.Proxy.TrustedProxyListeners) != 0 {
 		return false
 	}

--- a/internal/daemon/web_endpoint_test.go
+++ b/internal/daemon/web_endpoint_test.go
@@ -89,13 +89,13 @@ func TestResolveWebEndpointSharesTCPListener(t *testing.T) {
 	assert.True(t, resolved.OriginStable)
 }
 
-func TestWebEndpointAllowsLocalSessionOnlyForKeylessDirectLoopback(t *testing.T) {
+func TestWebEndpointAllowsLocalSessionForDirectLoopback(t *testing.T) {
 	loopback := WebEndpoint{
 		Endpoint: kitdaemon.Endpoint{Network: kitdaemon.NetworkTCP, Address: "127.0.0.1:27123"},
 		Origin:   "http://127.0.0.1:27123",
 	}
 	assert.True(t, loopback.AllowsLocalSession(config.AuthConfig{}))
-	assert.False(t, loopback.AllowsLocalSession(config.AuthConfig{Token: "configured-token"}))
+	assert.True(t, loopback.AllowsLocalSession(config.AuthConfig{Token: "configured-token"}))
 	assert.False(t, loopback.AllowsLocalSession(config.AuthConfig{RequireTokenIdentity: true}))
 	assert.False(t, loopback.AllowsLocalSession(config.AuthConfig{
 		Proxy: config.ProxyConfig{TrustedActorHeader: "X-Example-Actor"},

--- a/packages/kata-ui/package.json
+++ b/packages/kata-ui/package.json
@@ -29,7 +29,8 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "check:svelte": "svelte-check --tsconfig ./tsconfig.json --fail-on-warnings",
-    "check": "bun run typecheck && bun run check:svelte"
+    "check": "bun run typecheck && bun run check:svelte && bun run check:usage",
+    "check:usage": "kit-ui-check src && bun run scripts/check-kit-ui-usage.ts src"
   },
   "dependencies": {
     "@kenn-io/kit-ui": "github:kenn-io/kit-ui#97be355ef25a02ce96de6da4f3627ed5b922c4c3"

--- a/packages/kata-ui/scripts/check-kit-ui-usage.test.ts
+++ b/packages/kata-ui/scripts/check-kit-ui-usage.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { findRawButtons } from './check-kit-ui-usage'
+
+describe('Kata UI usage check', () => {
+  it('rejects raw buttons and accepts the kit Button component', () => {
+    expect(findRawButtons('<button type="button">Save</button>')).toEqual([
+      {
+        line: 1,
+        message: 'raw <button> element; use Button from @kenn-io/kit-ui',
+      },
+    ])
+
+    expect(
+      findRawButtons(`
+        <script>
+          import { Button } from '@kenn-io/kit-ui'
+        </script>
+        <Button type="button" label="Save" />
+      `),
+    ).toEqual([])
+  })
+})

--- a/packages/kata-ui/scripts/check-kit-ui-usage.ts
+++ b/packages/kata-ui/scripts/check-kit-ui-usage.ts
@@ -1,0 +1,75 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+import { parse } from 'svelte/compiler'
+
+interface Finding {
+  line: number
+  message: string
+}
+
+export function findRawButtons(source: string): Finding[] {
+  const findings: Finding[] = []
+  const seen = new Set<object>()
+
+  function visit(value: unknown): void {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item)
+      return
+    }
+    if (typeof value !== 'object' || value === null || seen.has(value)) return
+    seen.add(value)
+
+    const node = value as Record<string, unknown>
+    if (node.type === 'RegularElement' && node.name === 'button') {
+      const start = typeof node.start === 'number' ? node.start : 0
+      findings.push({
+        line: source.slice(0, start).split('\n').length,
+        message: 'raw <button> element; use Button from @kenn-io/kit-ui',
+      })
+    }
+
+    for (const child of Object.values(node)) visit(child)
+  }
+
+  visit(parse(source, { modern: true }))
+  return findings
+}
+
+function* svelteFiles(path: string): Generator<string> {
+  const stats = statSync(path)
+  if (stats.isFile()) {
+    if (path.endsWith('.svelte')) yield path
+    return
+  }
+
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue
+    const child = join(path, entry.name)
+    if (entry.isDirectory()) yield* svelteFiles(child)
+    else if (entry.name.endsWith('.svelte')) yield child
+  }
+}
+
+if (import.meta.main) {
+  const roots = process.argv.slice(2)
+  if (roots.length === 0) roots.push('src')
+
+  let findingCount = 0
+  let fileCount = 0
+  for (const root of roots) {
+    for (const file of svelteFiles(root)) {
+      fileCount += 1
+      const findings = findRawButtons(readFileSync(file, 'utf8'))
+      findingCount += findings.length
+      for (const finding of findings) {
+        console.error(
+          `${relative(process.cwd(), file)}:${finding.line} [raw-button] ${finding.message}`,
+        )
+      }
+    }
+  }
+
+  console.log(`kata-ui usage check: ${findingCount} finding(s) in ${fileCount} file(s)`)
+  if (findingCount > 0) process.exitCode = 1
+}

--- a/packages/kata-ui/src/IssueDetail.svelte
+++ b/packages/kata-ui/src/IssueDetail.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   /* eslint-disable svelte/no-at-html-tags -- kit-ui sanitizes rendered markdown. */
+  import { Button } from '@kenn-io/kit-ui'
   import { renderMarkdownSync } from '@kenn-io/kit-ui/utils/markdown'
 
   import IssueChecklist from './components/IssueChecklist.svelte'
@@ -25,14 +26,12 @@
     {#if actions.length > 0}
       <div class="host-actions">
         {#each actions as action (action.id)}
-          <button
-            type="button"
-            disabled={action.disabled || action.busy}
-            aria-busy={action.busy ?? false}
+          <Button
+            size="sm"
+            disabled={Boolean(action.disabled || action.busy)}
+            label={action.busy ? `${action.label}…` : action.label}
             onclick={() => invoke(action)}
-          >
-            {action.busy ? `${action.label}…` : action.label}
-          </button>
+          />
         {/each}
       </div>
     {/if}
@@ -68,7 +67,7 @@
 <style>
   .kata-issue-detail {
     display: grid;
-    gap: 18px;
+    gap: var(--space-6, 16px);
     min-width: 0;
     color: var(--text-primary, #202124);
   }
@@ -107,21 +106,6 @@
     gap: 8px;
   }
 
-  button {
-    border: 1px solid var(--border-default, #d5d7dc);
-    border-radius: 6px;
-    padding: 6px 10px;
-    background: var(--surface-interactive, #fff);
-    color: inherit;
-    font: inherit;
-    cursor: pointer;
-  }
-
-  button:disabled {
-    cursor: default;
-    opacity: 0.55;
-  }
-
   .claim-state > span {
     border: 1px solid var(--border-muted, #e2e4e8);
     border-radius: 999px;
@@ -150,7 +134,7 @@
     margin-bottom: 0;
   }
 
-  @media (max-width: 560px) {
+  @media (max-width: 640px) {
     .detail-header {
       display: grid;
     }

--- a/packages/kata-ui/src/IssueDetail.test.ts
+++ b/packages/kata-ui/src/IssueDetail.test.ts
@@ -91,7 +91,10 @@ describe('IssueDetail', () => {
       },
     })
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Open in Kata' }))
+    const action = screen.getByRole('button', { name: 'Open in Kata' })
+    expect(action.classList.contains('kit-button')).toBe(true)
+
+    await fireEvent.click(action)
     expect(invoke).toHaveBeenCalledOnce()
   })
 })

--- a/packages/kata-ui/tsconfig.json
+++ b/packages/kata-ui/tsconfig.json
@@ -12,5 +12,5 @@
     "target": "ES2023",
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/**/*.ts", "src/**/*.svelte"]
+  "include": ["src/**/*.ts", "src/**/*.svelte", "scripts/**/*.ts"]
 }

--- a/packages/kata-ui/vitest.config.ts
+++ b/packages/kata-ui/vitest.config.ts
@@ -9,4 +9,7 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['@kenn-io/kit-ui'],
   },
+  ssr: {
+    noExternal: ['@kenn-io/kit-ui', '@lucide/svelte'],
+  },
 })

--- a/web/src/components/AppShell.svelte
+++ b/web/src/components/AppShell.svelte
@@ -688,6 +688,8 @@
     flex-direction: column;
     overflow: hidden;
     background: var(--bg-primary);
+    container-type: inline-size;
+    container-name: list-pane;
   }
 
   .detail-column {

--- a/web/src/components/AppShell.svelte
+++ b/web/src/components/AppShell.svelte
@@ -722,7 +722,7 @@
     font-size: var(--font-size-sm);
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 700px) {
     .kata-layout {
       grid-template-columns: 1fr;
       grid-template-rows: auto minmax(0, 1fr);

--- a/web/src/components/AppShell.svelte
+++ b/web/src/components/AppShell.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { IconButton, type TypeaheadOption } from '@kenn-io/kit-ui'
+  import { DetailDrawer, IconButton, type TypeaheadOption } from '@kenn-io/kit-ui'
   import LayoutPanelLeftIcon from '@lucide/svelte/icons/layout-panel-left'
   import LayoutPanelTopIcon from '@lucide/svelte/icons/layout-panel-top'
   import MonitorIcon from '@lucide/svelte/icons/monitor'
+  import MenuIcon from '@lucide/svelte/icons/menu'
   import MoonIcon from '@lucide/svelte/icons/moon'
   import PlusIcon from '@lucide/svelte/icons/plus'
   import SunIcon from '@lucide/svelte/icons/sun'
@@ -131,6 +132,7 @@
 
   let captureOpen = $state(false)
   let inboxChooserOpen = $state(false)
+  let mobileNavigationOpen = $state(false)
   let linkFilters = $state(createKataLinkFilters('all'))
   let navigationGeneration = $state(0)
   let graphSelectedUID = $derived<string | null>(
@@ -167,6 +169,7 @@
   }
 
   function openView(name: KataTaskViewName): void {
+    mobileNavigationOpen = false
     navigate({
       kind: 'kata',
       view: systemViewName(name),
@@ -176,6 +179,7 @@
   }
 
   function openProject(projectUID: string): void {
+    mobileNavigationOpen = false
     navigate({
       kind: 'kata',
       projectUID,
@@ -341,6 +345,27 @@
   }
 </script>
 
+{#snippet navigationSidebar()}
+  <Sidebar
+    {areas}
+    projects={projection.projects}
+    currentView={{
+      name: currentView.view,
+      groups: currentView.groups,
+      fetched_at: currentView.fetched_at,
+    }}
+    {searchFilters}
+    projectCreationDisabled={!canMutate || mutationPending}
+    {draftFenceGeneration}
+    inboxProjectUID={inboxProject?.uid}
+    inboxDesignationDisabled={!canMutate || mutationPending}
+    onOpenView={openView}
+    onOpenProject={openProject}
+    {onCreateProject}
+    {onDesignateInbox}
+  />
+{/snippet}
+
 <section class="kata-feature" aria-label="Kata workspace">
   <header class="kata-header">
     <div class="kata-header-title">
@@ -366,6 +391,17 @@
       {/if}
     </div>
     <div class="kata-header-actions">
+      <span class="mobile-navigation-trigger">
+        <IconButton
+          ariaLabel="Open navigation"
+          title="Open navigation"
+          onclick={() => {
+            mobileNavigationOpen = true
+          }}
+        >
+          <MenuIcon size={15} strokeWidth={1.8} aria-hidden="true" />
+        </IconButton>
+      </span>
       <IconButton ariaLabel={`Theme: ${themeLabel()}`} title="Change theme" onclick={cycleTheme}>
         {#if preferences.theme === 'light'}
           <SunIcon size={15} strokeWidth={1.8} aria-hidden="true" />
@@ -414,24 +450,9 @@
     </aside>
   {/if}
   <div class="kata-layout" aria-busy={loading}>
-    <Sidebar
-      {areas}
-      projects={projection.projects}
-      currentView={{
-        name: currentView.view,
-        groups: currentView.groups,
-        fetched_at: currentView.fetched_at,
-      }}
-      {searchFilters}
-      projectCreationDisabled={!canMutate || mutationPending}
-      {draftFenceGeneration}
-      inboxProjectUID={inboxProject?.uid}
-      inboxDesignationDisabled={!canMutate || mutationPending}
-      onOpenView={openView}
-      onOpenProject={openProject}
-      {onCreateProject}
-      {onDesignateInbox}
-    />
+    <div class="desktop-navigation">
+      {@render navigationSidebar()}
+    </div>
 
     <div class="kata-main">
       {#if mutationMessage}
@@ -455,6 +476,18 @@
     </div>
   </div>
 </section>
+
+{#if mobileNavigationOpen}
+  <DetailDrawer
+    title="Kata navigation"
+    width="min(320px, calc(100vw - 40px))"
+    onclose={() => {
+      mobileNavigationOpen = false
+    }}
+  >
+    {@render navigationSidebar()}
+  </DetailDrawer>
+{/if}
 
 {#snippet listPane()}
   <div class="list-column kata-list">
@@ -672,6 +705,16 @@
     grid-template-columns: 240px minmax(0, 1fr);
   }
 
+  .desktop-navigation {
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+  }
+
+  .mobile-navigation-trigger {
+    display: none;
+  }
+
   .kata-main {
     min-width: 0;
     min-height: 0;
@@ -725,7 +768,14 @@
   @media (max-width: 700px) {
     .kata-layout {
       grid-template-columns: 1fr;
-      grid-template-rows: auto minmax(0, 1fr);
+    }
+
+    .desktop-navigation {
+      display: none;
+    }
+
+    .mobile-navigation-trigger {
+      display: inline-flex;
     }
   }
 </style>

--- a/web/src/components/IssueFilters.svelte
+++ b/web/src/components/IssueFilters.svelte
@@ -212,7 +212,7 @@
     width: 92px;
   }
 
-  @media (max-width: 900px) {
+  @container list-pane (max-width: 900px) {
     .kata-search-toolbar {
       flex-wrap: wrap;
     }

--- a/web/src/components/LoginView.svelte
+++ b/web/src/components/LoginView.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { Button } from '@kenn-io/kit-ui'
+
   interface Props {
     returnPath: string
     onLogin: (token: string, returnPath: string) => Promise<void>
@@ -25,14 +27,60 @@
   }
 </script>
 
-<section aria-labelledby="login-heading">
+<section class="login-view" aria-labelledby="login-heading">
   <h2 id="login-heading">Log in to Kata</h2>
   <form aria-label="Log in to Kata" onsubmit={submit}>
     <label for="kata-token">Token</label>
     <input id="kata-token" type="password" autocomplete="current-password" bind:value={token} />
-    <button type="submit" disabled={!token || submitting}>
-      {submitting ? 'Logging in…' : 'Log in'}
-    </button>
+    <Button
+      type="submit"
+      tone="info"
+      surface="solid"
+      class="login-submit"
+      label={submitting ? 'Logging in…' : 'Log in'}
+      disabled={!token || submitting}
+    />
   </form>
   {#if error}<p role="alert">{error}</p>{/if}
 </section>
+
+<style>
+  .login-view {
+    display: grid;
+    width: min(calc(100vw - var(--space-8)), 360px);
+    gap: var(--space-6);
+    text-align: left;
+  }
+
+  h2 {
+    font-size: var(--font-size-xl);
+    line-height: 1.25;
+    text-align: center;
+  }
+
+  form {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  label {
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  input {
+    width: 100%;
+    min-height: 36px;
+  }
+
+  form :global(.login-submit) {
+    width: 100%;
+    margin-top: var(--space-2);
+  }
+
+  [role='alert'] {
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+</style>

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -252,6 +252,7 @@
     --sidebar-row-padding: 6px 10px;
 
     display: flex;
+    flex: 1 1 auto;
     flex-direction: column;
     min-width: 0;
     min-height: 0;
@@ -366,18 +367,5 @@
     outline: none;
     border-color: var(--accent-blue);
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue) 18%, transparent);
-  }
-
-  @media (max-width: 700px) {
-    .kata-sidebar {
-      border-right: 0;
-      border-bottom: 1px solid var(--border-default);
-      max-height: 220px;
-    }
-
-    .kata-nav {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      padding: 8px;
-    }
   }
 </style>

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -368,11 +368,16 @@
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue) 18%, transparent);
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 700px) {
     .kata-sidebar {
       border-right: 0;
       border-bottom: 1px solid var(--border-default);
       max-height: 220px;
+    }
+
+    .kata-nav {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      padding: 8px;
     }
   }
 </style>

--- a/web/src/lib/daemons/client.ts
+++ b/web/src/lib/daemons/client.ts
@@ -30,7 +30,10 @@ export function createDaemonFetch(
     target.pathname = daemonProxyPrefix + target.pathname
     const headers = new Headers(request.headers)
     headers.set(daemonHeader, daemonID)
-    const body = request.body === null ? undefined : await request.arrayBuffer()
+    const body =
+      request.method === 'GET' || request.method === 'HEAD' || request.body === null
+        ? undefined
+        : await request.arrayBuffer()
     return upstream(target, {
       method: request.method,
       headers,

--- a/web/tests/firefox-auth.spec.ts
+++ b/web/tests/firefox-auth.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from './fixtures'
+
+test.use({ browserName: 'firefox', trace: 'off' })
+
+test('direct loopback tab loads the workspace snapshot', async ({ page, kata }) => {
+  await page.goto(`${kata.origin}/kata?view=all-open`)
+  await expect(page.getByRole('button', { name: 'New task' })).toBeVisible()
+})

--- a/web/tests/fixtures.ts
+++ b/web/tests/fixtures.ts
@@ -131,7 +131,7 @@ token = "example-remote-token"
       workspace,
       database: join(home, 'kata.db'),
     }),
-    KATA_AUTH_TOKEN: '',
+    KATA_AUTH_TOKEN: 'example-local-token',
     KATA_SERVER: '',
   }
   const remoteEnvironment = {
@@ -167,7 +167,7 @@ token = "example-remote-token"
     'version = 1\n\n[project]\nname = "example-project"\n',
   )
 
-  const project = await discoverProject(origin, home)
+  const project = await discoverProject(origin, home, 'example-local-token')
 
   const fixture: KataFixture = {
     origin,
@@ -331,12 +331,16 @@ async function runtimeRecords(root: string): Promise<string[]> {
   return found
 }
 
-async function discoverProject(origin: string, home: string): Promise<{ id: number; uid: string }> {
+async function discoverProject(
+  origin: string,
+  home: string,
+  token: string,
+): Promise<{ id: number; uid: string }> {
   await waitForRuntime(home, origin)
-  const sessionResponse = await fetch(`${origin}/api/v1/ui/session/local`, {
+  const sessionResponse = await fetch(`${origin}/api/v1/ui/session/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Origin: origin },
-    body: JSON.stringify({ return_path: '/kata?view=all-open' }),
+    body: JSON.stringify({ token, return_path: '/kata?view=all-open' }),
   })
   const cookie = sessionResponse.headers.get('set-cookie')?.split(';', 1)[0]
   const credentials = (await sessionResponse.json()) as { session: string; csrf: string }

--- a/web/tests/local-session.spec.ts
+++ b/web/tests/local-session.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from './fixtures'
 
-test.use({ browserName: 'firefox', trace: 'off' })
+test.use({ trace: 'off' })
 
-test('direct loopback tab loads the workspace snapshot', async ({ page, kata }) => {
+test('token-configured direct loopback tab loads the workspace snapshot', async ({ page, kata }) => {
   await page.goto(`${kata.origin}/kata?view=all-open`)
   await expect(page.getByRole('button', { name: 'New task' })).toBeVisible()
 })

--- a/web/tests/local-session.spec.ts
+++ b/web/tests/local-session.spec.ts
@@ -2,7 +2,10 @@ import { expect, test } from './fixtures'
 
 test.use({ trace: 'off' })
 
-test('token-configured direct loopback tab loads the workspace snapshot', async ({ page, kata }) => {
+test('token-configured direct loopback tab loads the workspace snapshot', async ({
+  page,
+  kata,
+}) => {
   await page.goto(`${kata.origin}/kata?view=all-open`)
   await expect(page.getByRole('button', { name: 'New task' })).toBeVisible()
 })

--- a/web/tests/login.spec.ts
+++ b/web/tests/login.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test'
+
+test('token login presents its controls as a vertical form', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'dark' })
+  await page.route('**/api/v1/ui/session/local', async (route) => {
+    await route.fulfill({ status: 404 })
+  })
+  await page.route('**/api/v1/ui/daemons', async (route) => {
+    await route.fulfill({
+      status: 401,
+      headers: { 'X-Kata-Web-Authentication': 'login' },
+    })
+  })
+
+  await page.goto('/kata')
+
+  const label = page.getByText('Token', { exact: true })
+  const input = page.getByLabel('Token')
+  const button = page.getByRole('button', { name: 'Log in' })
+  await expect(button).toBeVisible()
+
+  const [labelBox, inputBox, buttonBox] = await Promise.all([
+    label.boundingBox(),
+    input.boundingBox(),
+    button.boundingBox(),
+  ])
+  expect(labelBox).not.toBeNull()
+  expect(inputBox).not.toBeNull()
+  expect(buttonBox).not.toBeNull()
+  expect(labelBox!.y + labelBox!.height).toBeLessThan(inputBox!.y)
+  expect(inputBox!.y + inputBox!.height).toBeLessThan(buttonBox!.y)
+})

--- a/web/tests/responsive.spec.ts
+++ b/web/tests/responsive.spec.ts
@@ -19,21 +19,28 @@ test('system views stay beside the list until the mobile layout', async ({ page,
   expect(layout).toEqual({ sameRow: true, sidebarBeforeMain: true })
 })
 
-test('system views wrap into compact rows in the mobile layout', async ({ page, kata }) => {
+test('mobile navigation stays out of the task flow until opened', async ({ page, kata }) => {
   await page.setViewportSize({ width: 600, height: 684 })
   await kata.launch(page)
 
-  const layout = await page.getByRole('navigation', { name: 'System views' }).evaluate((nav) => {
-    const bounds = nav.getBoundingClientRect()
-    const buttons = Array.from(nav.querySelectorAll('button'), (button) =>
-      button.getBoundingClientRect(),
-    )
-    const rows = new Set(buttons.map((button) => Math.round(button.top)))
-    return { height: bounds.height, rows: rows.size }
+  const layout = await page.locator('.kata-feature').evaluate((element) => {
+    const header = element.querySelector('.kata-header')?.getBoundingClientRect()
+    const main = element.querySelector('.kata-main')?.getBoundingClientRect()
+    if (!header || !main) throw new Error('Kata header or main pane is missing')
+    return {
+      headerBottom: Math.round(header.bottom),
+      mainTop: Math.round(main.top),
+    }
   })
 
-  expect(layout.rows).toBe(2)
-  expect(layout.height).toBeLessThan(100)
+  expect(layout.mainTop).toBe(layout.headerBottom)
+
+  await page.getByRole('button', { name: 'Open navigation' }).click()
+  const navigation = page.getByRole('dialog', { name: 'Kata navigation' })
+  await expect(navigation).toBeVisible()
+  await navigation.getByRole('button', { name: 'Today' }).click()
+  await expect(navigation).toBeHidden()
+  await expect(page).toHaveURL(/view=today/)
 })
 
 test('task filters stay inside a narrow list pane without overlapping', async ({ page, kata }) => {

--- a/web/tests/responsive.spec.ts
+++ b/web/tests/responsive.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from './fixtures'
+
+test.use({ trace: 'off' })
+
+test('task filters stay inside a narrow list pane without overlapping', async ({ page, kata }) => {
+  await page.setViewportSize({ width: 1440, height: 800 })
+  const credentials = await kata.launch(page)
+  const issue = await kata.seedIssue(page, credentials, { title: 'Narrow pane example' })
+  await page.goto(`${kata.origin}/kata?view=all-open&issue=${issue.uid}`)
+  await page.getByRole('button', { name: 'Switch to side-by-side layout' }).click()
+
+  const layout = await page.locator('.kata-search-toolbar').evaluate((toolbar) => {
+    const container = toolbar.getBoundingClientRect()
+    const controls = Array.from(toolbar.querySelectorAll('input, button'), (element) => {
+      const rect = element.getBoundingClientRect()
+      return { left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom }
+    })
+    const overlaps = controls.some((control, index) =>
+      controls
+        .slice(index + 1)
+        .some(
+          (other) =>
+            control.left < other.right &&
+            control.right > other.left &&
+            control.top < other.bottom &&
+            control.bottom > other.top,
+        ),
+    )
+    return {
+      height: container.height,
+      contained: controls.every(
+        (control) => control.left >= container.left && control.right <= container.right,
+      ),
+      overlaps,
+    }
+  })
+
+  expect(layout).toEqual({ height: expect.any(Number), contained: true, overlaps: false })
+  expect(layout.height).toBeGreaterThan(30)
+})

--- a/web/tests/responsive.spec.ts
+++ b/web/tests/responsive.spec.ts
@@ -2,6 +2,40 @@ import { expect, test } from './fixtures'
 
 test.use({ trace: 'off' })
 
+test('system views stay beside the list until the mobile layout', async ({ page, kata }) => {
+  await page.setViewportSize({ width: 853, height: 684 })
+  await kata.launch(page)
+
+  const layout = await page.locator('.kata-layout').evaluate((element) => {
+    const sidebar = element.querySelector('.kata-sidebar')?.getBoundingClientRect()
+    const main = element.querySelector('.kata-main')?.getBoundingClientRect()
+    if (!sidebar || !main) throw new Error('Kata layout panes are missing')
+    return {
+      sameRow: Math.round(sidebar.top) === Math.round(main.top),
+      sidebarBeforeMain: Math.round(sidebar.right) <= Math.round(main.left),
+    }
+  })
+
+  expect(layout).toEqual({ sameRow: true, sidebarBeforeMain: true })
+})
+
+test('system views wrap into compact rows in the mobile layout', async ({ page, kata }) => {
+  await page.setViewportSize({ width: 600, height: 684 })
+  await kata.launch(page)
+
+  const layout = await page.getByRole('navigation', { name: 'System views' }).evaluate((nav) => {
+    const bounds = nav.getBoundingClientRect()
+    const buttons = Array.from(nav.querySelectorAll('button'), (button) =>
+      button.getBoundingClientRect(),
+    )
+    const rows = new Set(buttons.map((button) => Math.round(button.top)))
+    return { height: bounds.height, rows: rows.size }
+  })
+
+  expect(layout.rows).toBe(2)
+  expect(layout.height).toBeLessThan(100)
+})
+
 test('task filters stay inside a narrow list pane without overlapping', async ({ page, kata }) => {
   await page.setViewportSize({ width: 1440, height: 800 })
   const credentials = await kata.launch(page)


### PR DESCRIPTION
Local `kata ui` tabs now use owner-local loopback sessions even when the daemon has a static API token, so local browser use no longer falls into token login. Identity-authenticated, proxied, and non-loopback deployments keep their existing login requirements. The daemon gateway also omits bodies from GET and HEAD requests so Firefox can load the initial snapshot.

At narrow widths, the task list remains primary. Desktop navigation stays beside it until 700px, then moves into a Kit UI drawer. Filter controls wrap based on the list pane width, including side-by-side detail layouts.

Shared issue-detail and login actions now use themed Kit UI buttons. The Kata UI package runs the upstream Kit UI checker and a parser-backed rule that rejects raw `<button>` elements in the shared package.

The branch adds focused coverage for static-token loopback sessions, token login layout, Firefox startup, drawer behavior, and non-overlapping narrow filters.
