### PR TITLE
Reconcile external root bridges

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -3,6 +3,16 @@ display_name = "kata"
 review_guidelines = """
 Latest stable Go. Be pragmatic — theoretical findings produce churn.
 
+## Stacked delivery boundaries
+
+Kata may land a cumulative delivery sequence as separate protocol, storage,
+reconciliation, and runtime-integration pull requests. Review each pull request
+against the scope and dependency boundary stated in its description. Missing
+later-layer daemon or CLI wiring is not a finding when the current pull request
+is an internally usable lower layer and explicitly assigns that wiring to a
+subsequent pull request. Still flag missing wiring when the current pull request
+claims production availability or leaves its own declared layer unusable.
+
 ## Module path
 
 The Go module path is `go.kenn.io/kata`, not `github.com/wesm/kata`.

--- a/cmd/kata/show_markdown_windows_test.go
+++ b/cmd/kata/show_markdown_windows_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
 )
 
 func TestExternalShowMarkdownRendererTimeoutBoundsInheritedDescendantStdout(t *testing.T) {
@@ -77,7 +79,9 @@ func waitForWindowsHelperPID(t *testing.T, readyPath string) int {
 			require.NoError(t, err)
 			return pid
 		}
-		require.ErrorIs(t, err, fs.ErrNotExist)
+		if !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+			require.NoError(t, err)
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("renderer helper did not signal readiness")

--- a/internal/connector/client_test.go
+++ b/internal/connector/client_test.go
@@ -350,6 +350,30 @@ func TestProcessClientSendsConditionalWriteWithAdvertisedCapability(t *testing.T
 	assert.Equal(t, "describe\nwrite_fields\n", string(methods))
 }
 
+func TestProcessClientSendsMinutePrecisionLocalDateTime(t *testing.T) {
+	methodsPath := filepath.Join(t.TempDir(), "methods")
+	t.Setenv("HELPER_MODE", "conditional-fields-supported")
+	t.Setenv("HELPER_SYNC", methodsPath)
+	client := newHelperClient(t, config.ConnectorConfig{
+		ID: "notes", Command: helperBinary(t), Args: []string{"-test.run=^TestProcessClientHelper$"},
+		Env: map[string]string{"MODE": "HELPER_MODE", "SYNC": "HELPER_SYNC"},
+	})
+	value := protocol.FieldValue{
+		Kind: "local_datetime", Value: "2026-08-20T09:30", Timezone: "Europe/Paris",
+	}
+
+	result, err := client.WriteFields(t.Context(), protocol.WriteFieldsParams{
+		RootKey: "root-1",
+		Fields:  map[string]protocol.FieldValue{"field-1": value},
+		Expected: map[string]protocol.FieldValue{
+			"field-1": {Kind: "local_datetime", Value: "2026-08-20T09:15", Timezone: "Europe/Paris"},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, value, result.Fields["field-1"])
+}
+
 func TestProcessClientRejectsMissingRequiredResultProperties(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/connector/fakeconnector/fakeconnector_test.go
+++ b/internal/connector/fakeconnector/fakeconnector_test.go
@@ -46,6 +46,23 @@ func TestPublishCommentRetryAfterCrashCreatesOneComment(t *testing.T) {
 	assert.Equal(t, 2, len(state.Calls))
 }
 
+func TestAdvanceRootDoesNotRegressProviderTimestamp(t *testing.T) {
+	future := time.Date(2027, 1, 2, 3, 4, 5, 0, time.UTC)
+	stored := &StoredRoot{Root: connector.Root{Revision: "before", UpdatedAt: future, ObservedAt: future}}
+
+	advanceRoot(&stored.Root, 1, nextProviderTime(stored))
+
+	if stored.Root.Revision != "revision-0001" {
+		t.Fatalf("revision = %q, want revision-0001", stored.Root.Revision)
+	}
+	if !stored.Root.UpdatedAt.After(future) {
+		t.Fatalf("updated_at = %v, want after %v", stored.Root.UpdatedAt, future)
+	}
+	if !stored.Root.ObservedAt.Equal(stored.Root.UpdatedAt) {
+		t.Fatalf("observed_at = %v, want %v", stored.Root.ObservedAt, stored.Root.UpdatedAt)
+	}
+}
+
 func TestStateLockHonorsContextWhileOwnerIsLive(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "state.lock")
 	release, err := lockContext(context.Background(), lockPath)

--- a/internal/daemon/federation_replica_service.go
+++ b/internal/daemon/federation_replica_service.go
@@ -1163,6 +1163,9 @@ func adoptExistingReplica(
 							"",
 						)
 					}
+					if errors.Is(err, db.ErrExternalRootFederationConflict) {
+						return db.AdoptProjectIntoFederationResult{}, false, externalRootFederationReplicaError()
+					}
 					return db.AdoptProjectIntoFederationResult{}, false,
 						fmt.Errorf("adopt existing federation replica: %w", err)
 				}

--- a/internal/daemon/handlers_federation_test.go
+++ b/internal/daemon/handlers_federation_test.go
@@ -438,40 +438,56 @@ func TestFederationReplicaRejectsIssueSyncedLocalProject(t *testing.T) {
 }
 
 func TestFederationReplicaRejectsExternalRootLocalProject(t *testing.T) {
-	env := testenv.New(t)
-	ctx := context.Background()
-	project, err := env.DB.CreateProject(ctx, "spoke-project")
-	require.NoError(t, err)
-	issue, _, err := env.DB.CreateIssue(ctx, db.CreateIssueParams{
-		ProjectID: project.ID, Title: "Externally rooted issue", Author: "tester",
-	})
-	require.NoError(t, err)
-	issueID := issue.ID
-	_, err = env.DB.UpsertImportMapping(ctx, db.ImportMappingParams{
-		Source: "connector:notes", ExternalID: "root-one", ObjectType: "issue",
-		ProjectID: project.ID, IssueID: &issueID,
-	})
-	require.NoError(t, err)
-	_, _, err = env.DB.CreateExternalRootBinding(ctx, db.CreateExternalRootBindingParams{
-		ProjectID: project.ID, IssueID: issue.ID,
-		ConnectorInstance: "notes", ExternalRootKey: "root-one",
-		ExternalAccountKey: "opaque-account", Actor: "tester",
-		ReceiveCommentsAfter: time.Now().UTC(),
-	})
-	require.NoError(t, err)
+	for _, test := range []struct {
+		name          string
+		adoptExisting bool
+	}{
+		{name: "binding"},
+		{name: "adoption", adoptExisting: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			env := testenv.New(t)
+			ctx := context.Background()
+			project, err := env.DB.CreateProject(ctx, "spoke-project")
+			require.NoError(t, err)
+			issue, _, err := env.DB.CreateIssue(ctx, db.CreateIssueParams{
+				ProjectID: project.ID, Title: "Externally rooted issue", Author: "tester",
+			})
+			require.NoError(t, err)
+			issueID := issue.ID
+			_, err = env.DB.UpsertImportMapping(ctx, db.ImportMappingParams{
+				Source: "connector:notes", ExternalID: "root-one", ObjectType: "issue",
+				ProjectID: project.ID, IssueID: &issueID,
+			})
+			require.NoError(t, err)
+			_, _, err = env.DB.CreateExternalRootBinding(ctx, db.CreateExternalRootBindingParams{
+				ProjectID: project.ID, IssueID: issue.ID,
+				ConnectorInstance: "notes", ExternalRootKey: "root-one",
+				ExternalAccountKey: "opaque-account", Actor: "tester",
+				ReceiveCommentsAfter: time.Now().UTC(),
+			})
+			require.NoError(t, err)
 
-	resp, raw := envDoRaw(t, env, http.MethodPost, "/api/v1/federation/replicas", map[string]any{
-		"hub_url":                 "http://127.0.0.1:7373",
-		"hub_project_id":          42,
-		"hub_project_uid":         project.UID,
-		"project_name":            project.Name,
-		"replay_horizon_event_id": 9,
-		"actor":                   "tester",
-	}, nil)
+			body := map[string]any{
+				"hub_url":                 "http://127.0.0.1:7373",
+				"hub_project_id":          42,
+				"hub_project_uid":         project.UID,
+				"project_name":            project.Name,
+				"replay_horizon_event_id": 9,
+				"actor":                   "tester",
+				"adopt_existing":          test.adoptExisting,
+			}
+			if test.adoptExisting {
+				body["push_enabled"] = true
+				body["capabilities"] = "pull,push"
+			}
+			resp, raw := envDoRaw(t, env, http.MethodPost, "/api/v1/federation/replicas", body, nil)
 
-	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "external_root_federation_conflict")
-	assert.Contains(t, string(raw), "external root")
-	assert.Contains(t, string(raw), "read-only spoke")
+			assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "external_root_federation_conflict")
+			assert.Contains(t, string(raw), "external root")
+			assert.Contains(t, string(raw), "read-only spoke")
+		})
+	}
 }
 
 func TestFederationReplicaSetupIsIdempotentAndUsesJSONTags(t *testing.T) {

--- a/internal/db/dbtest/conformance.go
+++ b/internal/db/dbtest/conformance.go
@@ -413,7 +413,7 @@ var storageScenarios = []scenario{
 		name: "federation project adoption",
 		methods: []string{
 			"AcquireClaim", "AdoptProjectIntoFederation", "CountLiveClaims", "CountPendingClaims",
-			"CreateComment", "CreateIssue", "CreateProject", "EnqueuePendingClaim", "EventsAfter",
+			"CreateComment", "CreateExternalRootBinding", "CreateIssue", "CreateProject", "EnqueuePendingClaim", "EventsAfter",
 			"FederationBindingByProject", "IssueByUID", "PatchProjectMetadata",
 			"PendingFederationPushStats", "ProjectByID", "RemoveProject",
 		},

--- a/internal/db/dbtest/conformance_federation.go
+++ b/internal/db/dbtest/conformance_federation.go
@@ -2161,6 +2161,35 @@ func federationEnrollmentByID(
 func checkFederationProjectAdoption(t *testing.T, store db.Storage) error {
 	t.Helper()
 	ctx := context.Background()
+	conflictedProject, err := store.CreateProject(ctx, "federation-adoption-external-root")
+	if err != nil {
+		return err
+	}
+	conflictedIssue, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: conflictedProject.ID, Title: "Externally owned", Author: "alice",
+	})
+	if err != nil {
+		return err
+	}
+	_, _, err = store.CreateExternalRootBinding(ctx, db.CreateExternalRootBindingParams{
+		ProjectID: conflictedProject.ID, IssueID: conflictedIssue.ID,
+		ConnectorInstance: "notes", ExternalRootKey: "root-adoption-conflict",
+		ExternalAccountKey: "account-adoption-conflict", Actor: "alice",
+		ReceiveCommentsAfter: time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		return err
+	}
+	conflictHubUID, err := uid.New()
+	if err != nil {
+		return err
+	}
+	_, err = store.AdoptProjectIntoFederation(ctx, db.AdoptProjectIntoFederationParams{
+		ProjectID: conflictedProject.ID, HubURL: "https://hub.example", HubProjectID: 41,
+		HubProjectUID: conflictHubUID, ReplayHorizonEventID: 1, Actor: "adoption-agent",
+	})
+	assert.ErrorIs(t, err, db.ErrExternalRootFederationConflict)
+
 	project, err := store.CreateProject(ctx, "federation-adoption-project")
 	if err != nil {
 		return err

--- a/internal/db/dbtest/conformance_federation.go
+++ b/internal/db/dbtest/conformance_federation.go
@@ -2338,16 +2338,30 @@ func checkFederationProjectAdoption(t *testing.T, store db.Storage) error {
 	assert.Equal(t, "bob", comments[0].Author)
 	assert.Equal(t, "current historical comment", comments[0].Body)
 
+	_, _, err = store.CreateExternalRootBinding(ctx, db.CreateExternalRootBindingParams{
+		ProjectID: project.ID, IssueID: first.ID,
+		ConnectorInstance: "notes", ExternalRootKey: "root-after-adoption",
+		ExternalAccountKey: "account-adoption-conflict", Actor: "adoption-agent",
+		ReceiveCommentsAfter: time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		return err
+	}
+	beforeRepeatedAdoption, err := store.MaxEventID(ctx)
+	if err != nil {
+		return err
+	}
+
 	repeated, err := store.AdoptProjectIntoFederation(ctx, params)
 	if err != nil {
 		return err
 	}
 	assert.Zero(t, repeated.AdoptionSnapshotCount)
-	repeatedEvents, err := store.EventsAfter(ctx, db.EventsAfterParams{ProjectID: project.ID, Limit: 100})
+	afterRepeatedAdoption, err := store.MaxEventID(ctx)
 	if err != nil {
 		return err
 	}
-	assert.Len(t, repeatedEvents, 3)
+	assert.Equal(t, beforeRepeatedAdoption, afterRepeatedAdoption)
 	binding, err := store.FederationBindingByProject(ctx, project.ID)
 	if err != nil {
 		return err

--- a/internal/db/pgstore/federation_adoption.go
+++ b/internal/db/pgstore/federation_adoption.go
@@ -38,7 +38,7 @@ func (s *Store) AdoptProjectIntoFederation(
 		if project.DeletedAt != nil {
 			return fmt.Errorf("adopt project into federation: project %d is archived", params.ProjectID)
 		}
-		if err := rejectIssueSyncedFederationProject(ctx, tx, params.ProjectID); err != nil {
+		if err := rejectFederationSpokeProjectConflicts(ctx, tx, params.ProjectID); err != nil {
 			return err
 		}
 
@@ -202,4 +202,20 @@ WHERE project_id=$1 AND enabled=1 FOR UPDATE`, projectID).Scan(&id)
 		return nil
 	}
 	return fmt.Errorf("check federation issue sync binding: %w", mapSQLError(err, nil))
+}
+
+func rejectFederationSpokeProjectConflicts(ctx context.Context, tx *sql.Tx, projectID int64) error {
+	if err := rejectIssueSyncedFederationProject(ctx, tx, projectID); err != nil {
+		return err
+	}
+	var id int64
+	err := tx.QueryRowContext(ctx, `SELECT id FROM external_root_bindings
+WHERE project_id=$1 AND active=1 LIMIT 1 FOR UPDATE`, projectID).Scan(&id)
+	if err == nil {
+		return db.ErrExternalRootFederationConflict
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	return fmt.Errorf("check federation external root binding: %w", mapSQLError(err, nil))
 }

--- a/internal/db/pgstore/federation_adoption.go
+++ b/internal/db/pgstore/federation_adoption.go
@@ -38,10 +38,6 @@ func (s *Store) AdoptProjectIntoFederation(
 		if project.DeletedAt != nil {
 			return fmt.Errorf("adopt project into federation: project %d is archived", params.ProjectID)
 		}
-		if err := rejectFederationSpokeProjectConflicts(ctx, tx, params.ProjectID); err != nil {
-			return err
-		}
-
 		existing, err := scanFederationBinding(tx.QueryRowContext(ctx,
 			federationBindingSelect+` WHERE project_id=$1 FOR UPDATE`, params.ProjectID))
 		if err == nil {
@@ -52,6 +48,9 @@ func (s *Store) AdoptProjectIntoFederation(
 			return fmt.Errorf("project %d already has %q federation binding", params.ProjectID, existing.Role)
 		}
 		if !errors.Is(err, db.ErrNotFound) {
+			return err
+		}
+		if err := rejectFederationSpokeProjectConflicts(ctx, tx, params.ProjectID); err != nil {
 			return err
 		}
 

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -2576,6 +2576,9 @@ func (d *Store) adoptProjectIntoFederation(
 	if err := rejectIssueSyncedFederationProject(ctx, tx, p.ProjectID); err != nil {
 		return db.AdoptProjectIntoFederationResult{}, err
 	}
+	if err := rejectExternalRootFederationProject(ctx, tx, p.ProjectID); err != nil {
+		return db.AdoptProjectIntoFederationResult{}, err
+	}
 
 	existing, err := scanFederationBinding(tx.QueryRowContext(ctx,
 		federationBindingSelect+` WHERE project_id = ?`, p.ProjectID))

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -2573,13 +2573,6 @@ func (d *Store) adoptProjectIntoFederation(
 		return db.AdoptProjectIntoFederationResult{}, fmt.Errorf("adopt project into federation: project %d is archived", p.ProjectID)
 	}
 
-	if err := rejectIssueSyncedFederationProject(ctx, tx, p.ProjectID); err != nil {
-		return db.AdoptProjectIntoFederationResult{}, err
-	}
-	if err := rejectExternalRootFederationProject(ctx, tx, p.ProjectID); err != nil {
-		return db.AdoptProjectIntoFederationResult{}, err
-	}
-
 	existing, err := scanFederationBinding(tx.QueryRowContext(ctx,
 		federationBindingSelect+` WHERE project_id = ?`, p.ProjectID))
 	if err == nil {
@@ -2595,6 +2588,12 @@ func (d *Store) adoptProjectIntoFederation(
 		return db.AdoptProjectIntoFederationResult{}, fmt.Errorf("project %d already has %q federation binding", p.ProjectID, existing.Role)
 	}
 	if !errors.Is(err, db.ErrNotFound) {
+		return db.AdoptProjectIntoFederationResult{}, err
+	}
+	if err := rejectIssueSyncedFederationProject(ctx, tx, p.ProjectID); err != nil {
+		return db.AdoptProjectIntoFederationResult{}, err
+	}
+	if err := rejectExternalRootFederationProject(ctx, tx, p.ProjectID); err != nil {
 		return db.AdoptProjectIntoFederationResult{}, err
 	}
 

--- a/internal/rootbridge/client_boundary.go
+++ b/internal/rootbridge/client_boundary.go
@@ -1,0 +1,141 @@
+package rootbridge
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+// ErrConnectorCall marks a transport or protocol failure at the configured
+// connector boundary. Its fixed message is safe for durable failure state.
+var ErrConnectorCall = errors.New("external connector request failed")
+
+type connectorCallError struct {
+	cause error
+}
+
+func (e *connectorCallError) Error() string { return safeConnectorCallMessage(e.cause) }
+
+func (e *connectorCallError) Unwrap() []error {
+	return []error{ErrConnectorCall, e.cause}
+}
+
+func safeConnectorCallMessage(err error) string {
+	switch {
+	case errors.Is(err, connectorclient.ErrRequestTimeout):
+		return connectorclient.ErrRequestTimeout.Error()
+	case errors.Is(err, connectorclient.ErrProtocolFailure):
+		return connectorclient.ErrProtocolFailure.Error()
+	case errors.Is(err, connectorclient.ErrProcessFailure):
+		return connectorclient.ErrProcessFailure.Error()
+	default:
+		return ErrConnectorCall.Error()
+	}
+}
+
+func connectorProtocolFailure() error {
+	return &connectorCallError{cause: connectorclient.ErrProtocolFailure}
+}
+
+type boundaryClient struct {
+	client connectorclient.Client
+}
+
+func wrapConnectorClient(client connectorclient.Client) connectorclient.Client {
+	return &boundaryClient{client: client}
+}
+
+func connectorBoundaryError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if hasConnectorCategory(err) || errors.Is(err, ErrConnectorCall) {
+		return &connectorCallError{cause: err}
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if _, ok := errors.AsType[*connector.Error](err); ok {
+		return err
+	}
+	return &connectorCallError{cause: err}
+}
+
+func parentContextEnded(ctx context.Context, err error) bool {
+	if hasConnectorFailureProvenance(err) {
+		return false
+	}
+	ctxErr := ctx.Err()
+	return ctxErr != nil && errors.Is(err, ctxErr)
+}
+
+func hasConnectorFailureProvenance(err error) bool {
+	if errors.Is(err, ErrConnectorCall) || hasConnectorCategory(err) {
+		return true
+	}
+	_, ok := errors.AsType[*connector.Error](err)
+	return ok
+}
+
+func hasConnectorCategory(err error) bool {
+	return errors.Is(err, connectorclient.ErrRequestTimeout) ||
+		errors.Is(err, connectorclient.ErrProtocolFailure) ||
+		errors.Is(err, connectorclient.ErrProcessFailure)
+}
+
+func (c *boundaryClient) Describe(ctx context.Context) (connector.Description, error) {
+	result, err := c.client.Describe(ctx)
+	return result, connectorBoundaryError(ctx, err)
+}
+
+func (c *boundaryClient) ResolveRoot(ctx context.Context, params connector.ResolveRootParams) (connector.Root, error) {
+	result, err := c.client.ResolveRoot(ctx, params)
+	return result, connectorBoundaryError(ctx, err)
+}
+
+func (c *boundaryClient) ReadRoot(ctx context.Context, params connector.ReadRootParams) (connector.Root, error) {
+	result, err := c.client.ReadRoot(ctx, params)
+	return result, connectorBoundaryError(ctx, err)
+}
+
+func (c *boundaryClient) ListComments(ctx context.Context, params connector.ListCommentsParams) (connector.ListCommentsResult, error) {
+	result, err := c.client.ListComments(ctx, params)
+	return result, connectorBoundaryError(ctx, err)
+}
+
+func (c *boundaryClient) CompleteRoot(ctx context.Context, params connector.CompleteRootParams) (connector.Root, error) {
+	result, err := c.client.CompleteRoot(ctx, params)
+	return result, connectorBoundaryError(ctx, err)
+}
+
+func (c *boundaryClient) PublishComment(ctx context.Context, params connector.PublishCommentParams) (connector.Comment, error) {
+	result, err := c.client.PublishComment(ctx, params)
+	return result, connectorBoundaryError(ctx, err)
+}
+
+func (c *boundaryClient) ListFields(ctx context.Context) (connector.ListFieldsResult, error) {
+	result, err := c.client.ListFields(ctx)
+	if err := connectorBoundaryError(ctx, err); err != nil {
+		return result, err
+	}
+	for _, descriptor := range result.Fields {
+		if descriptor.ID == "" || strings.TrimSpace(descriptor.ID) != descriptor.ID ||
+			descriptor.SchemaRevision == "" || strings.TrimSpace(descriptor.SchemaRevision) != descriptor.SchemaRevision {
+			return connector.ListFieldsResult{}, connectorProtocolFailure()
+		}
+	}
+	return result, nil
+}
+
+func (c *boundaryClient) ReadFields(ctx context.Context, params connector.ReadFieldsParams) (connector.ReadFieldsResult, error) {
+	result, err := c.client.ReadFields(ctx, params)
+	return result, connectorBoundaryError(ctx, err)
+}
+
+func (c *boundaryClient) WriteFields(ctx context.Context, params connector.WriteFieldsParams) (connector.WriteFieldsResult, error) {
+	result, err := c.client.WriteFields(ctx, params)
+	return result, connectorBoundaryError(ctx, err)
+}

--- a/internal/rootbridge/codecs.go
+++ b/internal/rootbridge/codecs.go
@@ -1,0 +1,320 @@
+// Package rootbridge translates planning fields between Kata metadata and a
+// connector's typed field values.
+package rootbridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/metadata"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+const (
+	fieldKindNull          = "null"
+	fieldKindDate          = "date"
+	fieldKindLocalDateTime = "local_datetime"
+	fieldKindInstant       = "instant"
+
+	localMinuteLayout = "2006-01-02T15:04"
+	localSecondLayout = "2006-01-02T15:04:05"
+)
+
+// FieldCodec translates one Kata planning field to and from connector values.
+type FieldCodec interface {
+	KataField() string
+	ReadKata(db.Issue) (connector.FieldValue, error)
+	KataPatch(db.Issue, connector.FieldValue) (map[string]json.RawMessage, error)
+	ValidateExternalDescriptor(connector.FieldDescriptor) error
+}
+
+var fieldCodecs = map[string]FieldCodec{
+	"scheduled_on": scheduleCodec{key: "scheduled_on"},
+	"deadline_on":  scheduleCodec{key: "deadline_on"},
+}
+
+type scheduleCodec struct {
+	key string
+}
+
+func (c scheduleCodec) KataField() string {
+	return c.key
+}
+
+func (c scheduleCodec) ReadKata(issue db.Issue) (connector.FieldValue, error) {
+	values, err := metadataObject(issue.Metadata)
+	if err != nil {
+		return connector.FieldValue{}, err
+	}
+	raw, ok := values[c.key]
+	if !ok || string(raw) == "null" {
+		return nullFieldValue(), nil
+	}
+	if err := metadata.Validate(metadata.IssueRegistry, c.key, raw); err != nil {
+		return connector.FieldValue{}, fmt.Errorf("validate %s: %w", c.key, err)
+	}
+
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return connector.FieldValue{}, fmt.Errorf("decode %s: %w", c.key, err)
+	}
+	field, err := kataScheduleFieldValue(value, values)
+	if err != nil {
+		return connector.FieldValue{}, fmt.Errorf("decode %s: %w", c.key, err)
+	}
+	return field, nil
+}
+
+func (c scheduleCodec) KataPatch(issue db.Issue, value connector.FieldValue) (map[string]json.RawMessage, error) {
+	return c.kataPatch(issue, value, "")
+}
+
+func (c scheduleCodec) kataPatch(
+	issue db.Issue,
+	value connector.FieldValue,
+	coordinatedTimezone string,
+) (map[string]json.RawMessage, error) {
+	canonical, err := canonicalFieldValue(value)
+	if err != nil {
+		return nil, err
+	}
+	patch := map[string]json.RawMessage{c.key: mustJSON(canonicalScheduleValue(canonical))}
+	if canonical.Kind != fieldKindLocalDateTime {
+		return patch, nil
+	}
+
+	values, err := metadataObject(issue.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	otherKey := "scheduled_on"
+	if c.key == otherKey {
+		otherKey = "deadline_on"
+	}
+	if other, err := kataScheduleFieldValueFromMetadata(otherKey, values); err != nil {
+		return nil, err
+	} else if other.Kind == fieldKindLocalDateTime {
+		if other.Timezone != canonical.Timezone && coordinatedTimezone != canonical.Timezone {
+			return nil, fmt.Errorf("%s local timezone %q conflicts with %s timezone %q", c.key, canonical.Timezone, otherKey, other.Timezone)
+		}
+	} else if other.Kind == fieldKindDate {
+		timezone, present, err := optionalMetadataTimezone(values)
+		if err != nil {
+			return nil, fmt.Errorf("read %s timezone: %w", otherKey, err)
+		}
+		if present && timezone != canonical.Timezone && coordinatedTimezone != canonical.Timezone {
+			return nil, fmt.Errorf("%s local timezone %q conflicts with %s timezone %q", c.key, canonical.Timezone, otherKey, timezone)
+		}
+	}
+	patch["timezone"] = mustJSON(canonical.Timezone)
+	return patch, nil
+}
+
+func kataPatchWithCoordinatedTimezone(
+	codec FieldCodec,
+	issue db.Issue,
+	value connector.FieldValue,
+	coordinatedTimezone string,
+) (map[string]json.RawMessage, error) {
+	if schedule, ok := codec.(scheduleCodec); ok {
+		return schedule.kataPatch(issue, value, coordinatedTimezone)
+	}
+	return codec.KataPatch(issue, value)
+}
+
+func (c scheduleCodec) ValidateExternalDescriptor(descriptor connector.FieldDescriptor) error {
+	if strings.TrimSpace(descriptor.ID) == "" || strings.TrimSpace(descriptor.DisplayName) == "" || strings.TrimSpace(descriptor.SchemaRevision) == "" {
+		return fmt.Errorf("field descriptor identity is required")
+	}
+	if !descriptor.Nullable || !descriptor.Writable {
+		return fmt.Errorf("field descriptor must be nullable and writable")
+	}
+	if len(descriptor.AcceptedKinds) == 0 {
+		return fmt.Errorf("field descriptor accepted kinds are required")
+	}
+	seen := make(map[string]struct{}, len(descriptor.AcceptedKinds))
+	for _, kind := range descriptor.AcceptedKinds {
+		canonicalKind := strings.TrimSpace(kind)
+		if kind != canonicalKind {
+			return fmt.Errorf("external field kind %q is not canonical", kind)
+		}
+		kind = canonicalKind
+		switch kind {
+		case fieldKindDate, fieldKindLocalDateTime, fieldKindInstant:
+		default:
+			return fmt.Errorf("unsupported external field kind %q", kind)
+		}
+		if _, duplicate := seen[kind]; duplicate {
+			return fmt.Errorf("duplicate external field kind %q", kind)
+		}
+		seen[kind] = struct{}{}
+	}
+	return nil
+}
+
+func metadataObject(raw db.JSONBlob) (map[string]json.RawMessage, error) {
+	if raw == "" {
+		return map[string]json.RawMessage{}, nil
+	}
+	var values map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil, fmt.Errorf("decode issue metadata: %w", err)
+	}
+	if values == nil {
+		return map[string]json.RawMessage{}, nil
+	}
+	return values, nil
+}
+
+func kataScheduleFieldValue(value string, metadataValues map[string]json.RawMessage) (connector.FieldValue, error) {
+	field := connector.FieldValue{Value: value}
+	switch scheduleKind(value) {
+	case fieldKindDate:
+		field.Kind = fieldKindDate
+	case fieldKindInstant:
+		field.Kind = fieldKindInstant
+	case fieldKindLocalDateTime:
+		timezone, err := metadataTimezone(metadataValues)
+		if err != nil {
+			return connector.FieldValue{}, err
+		}
+		field.Kind = fieldKindLocalDateTime
+		field.Timezone = timezone
+	default:
+		return connector.FieldValue{}, fmt.Errorf("invalid schedule value %q", value)
+	}
+	return canonicalFieldValue(field)
+}
+
+func kataScheduleFieldValueFromMetadata(key string, values map[string]json.RawMessage) (connector.FieldValue, error) {
+	raw, ok := values[key]
+	if !ok || string(raw) == "null" {
+		return nullFieldValue(), nil
+	}
+	if err := metadata.Validate(metadata.IssueRegistry, key, raw); err != nil {
+		return connector.FieldValue{}, fmt.Errorf("validate %s: %w", key, err)
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return connector.FieldValue{}, fmt.Errorf("decode %s: %w", key, err)
+	}
+	return kataScheduleFieldValue(value, values)
+}
+
+func metadataTimezone(values map[string]json.RawMessage) (string, error) {
+	timezone, present, err := optionalMetadataTimezone(values)
+	if err != nil {
+		return "", err
+	}
+	if !present {
+		return "", fmt.Errorf("local date-time requires issue timezone")
+	}
+	return timezone, nil
+}
+
+func optionalMetadataTimezone(values map[string]json.RawMessage) (string, bool, error) {
+	raw, ok := values["timezone"]
+	if !ok || string(raw) == "null" {
+		return "", false, nil
+	}
+	if err := metadata.Validate(metadata.IssueRegistry, "timezone", raw); err != nil {
+		return "", false, err
+	}
+	var timezone string
+	if err := json.Unmarshal(raw, &timezone); err != nil {
+		return "", false, fmt.Errorf("decode timezone: %w", err)
+	}
+	return timezone, true, nil
+}
+
+func canonicalFieldValue(value connector.FieldValue) (connector.FieldValue, error) {
+	if value.Kind == "" || value.Kind == fieldKindNull {
+		if value.Value != "" || value.Timezone != "" {
+			return connector.FieldValue{}, fmt.Errorf("null field value must not contain a value or timezone")
+		}
+		return nullFieldValue(), nil
+	}
+	switch value.Kind {
+	case fieldKindDate:
+		if value.Timezone != "" {
+			return connector.FieldValue{}, fmt.Errorf("date field value must not contain a timezone")
+		}
+		parsed, err := time.Parse(time.DateOnly, value.Value)
+		if err != nil || parsed.Format(time.DateOnly) != value.Value {
+			return connector.FieldValue{}, fmt.Errorf("date field value %q must use YYYY-MM-DD", value.Value)
+		}
+		return connector.FieldValue{Kind: fieldKindDate, Value: parsed.Format(time.DateOnly)}, nil
+	case fieldKindLocalDateTime:
+		layout := localScheduleLayout(value.Value)
+		if layout == "" {
+			return connector.FieldValue{}, fmt.Errorf("local date-time %q must use minute or second precision", value.Value)
+		}
+		if value.Timezone == "" {
+			return connector.FieldValue{}, fmt.Errorf("local date-time requires timezone")
+		}
+		if _, err := time.LoadLocation(value.Timezone); err != nil {
+			return connector.FieldValue{}, fmt.Errorf("load timezone %q: %w", value.Timezone, err)
+		}
+		return connector.FieldValue{Kind: fieldKindLocalDateTime, Value: value.Value, Timezone: value.Timezone}, nil
+	case fieldKindInstant:
+		if value.Timezone != "" {
+			return connector.FieldValue{}, fmt.Errorf("instant field value must not contain a timezone")
+		}
+		if !strings.HasSuffix(value.Value, "Z") {
+			return connector.FieldValue{}, fmt.Errorf("instant %q must use UTC Z", value.Value)
+		}
+		parsed, err := time.Parse(time.RFC3339Nano, value.Value)
+		if err != nil {
+			return connector.FieldValue{}, fmt.Errorf("parse instant %q: %w", value.Value, err)
+		}
+		return connector.FieldValue{Kind: fieldKindInstant, Value: parsed.UTC().Format(time.RFC3339Nano)}, nil
+	default:
+		return connector.FieldValue{}, fmt.Errorf("unsupported field value kind %q", value.Kind)
+	}
+}
+
+func scheduleKind(value string) string {
+	if parsed, err := time.Parse(time.DateOnly, value); err == nil && parsed.Format(time.DateOnly) == value {
+		return fieldKindDate
+	}
+	if localScheduleLayout(value) != "" {
+		return fieldKindLocalDateTime
+	}
+	if strings.HasSuffix(value, "Z") {
+		if _, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return fieldKindInstant
+		}
+	}
+	return ""
+}
+
+func localScheduleLayout(value string) string {
+	for _, layout := range []string{localMinuteLayout, localSecondLayout} {
+		if parsed, err := time.Parse(layout, value); err == nil && parsed.Format(layout) == value {
+			return layout
+		}
+	}
+	return ""
+}
+
+func canonicalScheduleValue(value connector.FieldValue) any {
+	if value.Kind == fieldKindNull {
+		return nil
+	}
+	return value.Value
+}
+
+func nullFieldValue() connector.FieldValue {
+	return connector.FieldValue{Kind: fieldKindNull}
+}
+
+func mustJSON(value any) json.RawMessage {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}

--- a/internal/rootbridge/codecs_test.go
+++ b/internal/rootbridge/codecs_test.go
@@ -1,0 +1,193 @@
+package rootbridge
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func TestScheduleCodecsAreRegistered(t *testing.T) {
+	for _, key := range []string{"scheduled_on", "deadline_on"} {
+		codec, ok := fieldCodecs[key]
+		require.True(t, ok)
+		assert.Equal(t, key, codec.KataField())
+	}
+}
+
+func TestScheduleCodecReadKataCanonicalizesValues(t *testing.T) {
+	codec := fieldCodecs["scheduled_on"]
+	cases := []struct {
+		name string
+		meta string
+		want connector.FieldValue
+	}{
+		{"empty", `{}`, nullValue()},
+		{"date", `{"scheduled_on":"2026-08-20"}`, date("2026-08-20")},
+		{"local minute", `{"scheduled_on":"2026-08-20T09:30","timezone":"America/New_York"}`, connector.FieldValue{Kind: "local_datetime", Value: "2026-08-20T09:30", Timezone: "America/New_York"}},
+		{"local second", `{"scheduled_on":"2026-08-20T09:30:45","timezone":"America/New_York"}`, connector.FieldValue{Kind: "local_datetime", Value: "2026-08-20T09:30:45", Timezone: "America/New_York"}},
+		{"utc instant", `{"scheduled_on":"2026-08-20T09:30:45.120000000Z"}`, connector.FieldValue{Kind: "instant", Value: "2026-08-20T09:30:45.12Z"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := codec.ReadKata(db.Issue{Metadata: db.JSONBlob(tc.meta)})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestScheduleCodecReadKataRejectsInvalidTimezone(t *testing.T) {
+	_, err := fieldCodecs["scheduled_on"].ReadKata(db.Issue{Metadata: db.JSONBlob(`{"scheduled_on":"2026-08-20T09:30","timezone":"Invalid/Zone"}`)})
+	require.Error(t, err)
+}
+
+func TestScheduleCodecKataPatchPreservesCivilTimesAcrossDST(t *testing.T) {
+	codec := fieldCodecs["scheduled_on"]
+	for _, value := range []connector.FieldValue{
+		{Kind: "local_datetime", Value: "2026-03-08T02:30", Timezone: "America/New_York"},
+		{Kind: "local_datetime", Value: "2026-11-01T01:30:45", Timezone: "America/New_York"},
+	} {
+		patch, err := codec.KataPatch(db.Issue{}, value)
+		require.NoError(t, err)
+		assert.JSONEq(t, `"`+value.Value+`"`, string(patch["scheduled_on"]))
+		assert.JSONEq(t, `"America/New_York"`, string(patch["timezone"]))
+	}
+}
+
+func TestScheduleCodecKataPatchRejectsIncompatibleMappedLocalTimezone(t *testing.T) {
+	issue := db.Issue{Metadata: db.JSONBlob(`{"deadline_on":"2026-08-20T09:30","timezone":"America/New_York"}`)}
+	_, err := fieldCodecs["scheduled_on"].KataPatch(issue, connector.FieldValue{Kind: "local_datetime", Value: "2026-08-20T09:30", Timezone: "America/Los_Angeles"})
+	require.Error(t, err)
+}
+
+func TestScheduleCodecKataPatchRejectsIncompatibleTimezoneWithOtherDate(t *testing.T) {
+	cases := []struct {
+		name     string
+		codec    string
+		metadata string
+	}{
+		{
+			name:     "scheduled date pins deadline local timezone",
+			codec:    "deadline_on",
+			metadata: `{"scheduled_on":"2026-08-20","timezone":"America/New_York"}`,
+		},
+		{
+			name:     "deadline date pins scheduled local timezone",
+			codec:    "scheduled_on",
+			metadata: `{"deadline_on":"2026-08-20","timezone":"America/New_York"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := fieldCodecs[tc.codec].KataPatch(
+				db.Issue{Metadata: db.JSONBlob(tc.metadata)},
+				connector.FieldValue{Kind: "local_datetime", Value: "2026-08-20T09:30", Timezone: "America/Los_Angeles"},
+			)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestScheduleCodecKataPatchAdoptsTimezoneWithOtherDateWithoutTimezone(t *testing.T) {
+	cases := []struct {
+		name     string
+		codec    string
+		metadata string
+		want     string
+	}{
+		{
+			name:     "scheduled date permits first deadline local timezone",
+			codec:    "deadline_on",
+			metadata: `{"scheduled_on":"2026-08-20"}`,
+			want:     `{"deadline_on":"2026-08-20T09:30","timezone":"America/Los_Angeles"}`,
+		},
+		{
+			name:     "deadline date permits first scheduled local timezone",
+			codec:    "scheduled_on",
+			metadata: `{"deadline_on":"2026-08-20"}`,
+			want:     `{"scheduled_on":"2026-08-20T09:30","timezone":"America/Los_Angeles"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			patch, err := fieldCodecs[tc.codec].KataPatch(
+				db.Issue{Metadata: db.JSONBlob(tc.metadata)},
+				connector.FieldValue{Kind: "local_datetime", Value: "2026-08-20T09:30", Timezone: "America/Los_Angeles"},
+			)
+			require.NoError(t, err)
+			got, err := json.Marshal(patch)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+func TestScheduleCodecKataPatchRejectsTimezoneWithOtherLocalWithoutTimezone(t *testing.T) {
+	cases := []struct {
+		name     string
+		codec    string
+		metadata string
+	}{
+		{
+			name:     "scheduled local blocks deadline local timezone",
+			codec:    "deadline_on",
+			metadata: `{"scheduled_on":"2026-08-20T09:30"}`,
+		},
+		{
+			name:     "deadline local blocks scheduled local timezone",
+			codec:    "scheduled_on",
+			metadata: `{"deadline_on":"2026-08-20T09:30"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := fieldCodecs[tc.codec].KataPatch(
+				db.Issue{Metadata: db.JSONBlob(tc.metadata)},
+				connector.FieldValue{Kind: "local_datetime", Value: "2026-08-20T10:30", Timezone: "America/Los_Angeles"},
+			)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestScheduleCodecKataPatchCanonicalizesAndClears(t *testing.T) {
+	codec := fieldCodecs["deadline_on"]
+	cases := []struct {
+		name  string
+		value connector.FieldValue
+		want  string
+	}{
+		{"date", date("2026-08-20"), `{"deadline_on":"2026-08-20"}`},
+		{"instant", connector.FieldValue{Kind: "instant", Value: "2026-08-20T09:30:45.120000000Z"}, `{"deadline_on":"2026-08-20T09:30:45.12Z"}`},
+		{"clear", nullValue(), `{"deadline_on":null}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			patch, err := codec.KataPatch(db.Issue{}, tc.value)
+			require.NoError(t, err)
+			got, err := json.Marshal(patch)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+func TestScheduleCodecValidatesExternalDescriptor(t *testing.T) {
+	codec := fieldCodecs["scheduled_on"]
+	valid := connector.FieldDescriptor{ID: "field-id", DisplayName: "Plan date", AcceptedKinds: []string{"date", "local_datetime", "instant"}, Nullable: true, Writable: true, SchemaRevision: "v1"}
+	require.NoError(t, codec.ValidateExternalDescriptor(valid))
+
+	for _, descriptor := range []connector.FieldDescriptor{
+		{ID: "field-id", DisplayName: "Plan date", AcceptedKinds: []string{"date"}, Nullable: true, Writable: true},
+		{ID: "field-id", DisplayName: "Plan date", AcceptedKinds: []string{"date"}, Nullable: false, Writable: true, SchemaRevision: "v1"},
+		{ID: "field-id", DisplayName: "Plan date", AcceptedKinds: []string{"date"}, Nullable: true, Writable: false, SchemaRevision: "v1"},
+		{ID: "field-id", DisplayName: "Plan date", AcceptedKinds: []string{"date", "date"}, Nullable: true, Writable: true, SchemaRevision: "v1"},
+		{ID: "field-id", DisplayName: "Plan date", AcceptedKinds: []string{"text"}, Nullable: true, Writable: true, SchemaRevision: "v1"},
+	} {
+		assert.Error(t, codec.ValidateExternalDescriptor(descriptor))
+	}
+}

--- a/internal/rootbridge/comments.go
+++ b/internal/rootbridge/comments.go
@@ -1,0 +1,312 @@
+package rootbridge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func (r *Reconciler) applyInboundComments(
+	ctx context.Context,
+	snapshot reconcileSnapshot,
+	claimToken string,
+	result RunResult,
+) (RunResult, error) {
+	if !snapshot.binding.ReceiveComments {
+		return result, nil
+	}
+	mapped := make(map[string]bool, len(snapshot.mappings))
+	for _, mapping := range snapshot.mappings {
+		if mapping.ObjectType == "comment" {
+			mapped[mapping.ExternalID] = true
+		}
+	}
+	published := make(map[string]db.ImportMapping, len(snapshot.publishedCommentMappings))
+	for _, mapping := range snapshot.publishedCommentMappings {
+		if mapping.ObjectType == "comment" {
+			published[mapping.ExternalID] = mapping
+		}
+	}
+	pendingCommentsToWithhold := pendingExternalCommentsToWithhold(snapshot)
+	comments := append([]connector.Comment(nil), snapshot.comments...)
+	sort.SliceStable(comments, func(left, right int) bool {
+		if comments[left].CreatedAt.Equal(comments[right].CreatedAt) {
+			return comments[left].ID < comments[right].ID
+		}
+		return comments[left].CreatedAt.Before(comments[right].CreatedAt)
+	})
+	for _, comment := range comments {
+		if pendingCommentsToWithhold[comment.ID] {
+			continue
+		}
+		if !comment.Deleted && strings.TrimSpace(comment.Body) == "" {
+			return result, connectorProtocolFailure()
+		}
+		if strings.TrimSpace(comment.Revision) == "" || strings.TrimSpace(comment.Revision) != comment.Revision {
+			return result, connectorProtocolFailure()
+		}
+		revisionID := db.ExternalCommentRevisionMappingExternalID(comment.ID, comment.Revision)
+		if snapshot.seenCommentRevisions[revisionID] && !mapped[comment.ID] {
+			continue
+		}
+		if !snapshot.commentIdentityFrontier && snapshot.binding.ReceiveCommentsAfter != nil &&
+			!comment.CreatedAt.After(*snapshot.binding.ReceiveCommentsAfter) {
+			continue
+		}
+		updatedAt := comment.UpdatedAt
+		if updatedAt.IsZero() {
+			updatedAt = comment.CreatedAt
+		}
+		if !snapshot.commentIdentityFrontier && !mapped[comment.ID] {
+			if publication, ok := published[comment.ID]; ok && publication.SourceUpdatedAt != nil &&
+				!updatedAt.After(*publication.SourceUpdatedAt) {
+				continue
+			}
+		}
+		_, event, changed, err := r.store.UpsertExternalCommentProjection(ctx, db.ExternalCommentProjectionParams{
+			BindingID: snapshot.binding.ID, ClaimToken: claimToken,
+			ExternalID: comment.ID, ExternalRevision: comment.Revision, Body: comment.Body,
+			ExternalActorID: comment.Author.ID, ExternalActorName: comment.Author.DisplayName,
+			ExternalCreatedAt: comment.CreatedAt, ExternalUpdatedAt: updatedAt,
+			Deleted: comment.Deleted, IntegrationActor: integrationActor(snapshot.binding),
+		})
+		if err != nil {
+			return result, err
+		}
+		if changed {
+			if mapped[comment.ID] {
+				result.CommentsEdited++
+			} else {
+				result.CommentsCreated++
+			}
+		}
+		mapped[comment.ID] = true
+		snapshot.seenCommentRevisions[revisionID] = true
+		if event != nil {
+			result.retainEvents(*event)
+		}
+	}
+	return result, nil
+}
+
+func (r *Reconciler) applyOutboundComments(
+	ctx context.Context,
+	snapshot reconcileSnapshot,
+	claimToken string,
+	result RunResult,
+) (RunResult, error) {
+	if !snapshot.binding.PublishComments {
+		return result, nil
+	}
+	if !snapshot.publishReady {
+		if snapshot.binding.PendingCommentUID != "" {
+			return result, errors.Join(ErrCommentPublishingUnavailable, ErrPendingCommentResolutionRequired)
+		}
+		return result, ErrCommentPublishingUnavailable
+	}
+	if snapshot.binding.PendingCommentUID != "" {
+		return r.resolvePendingComment(ctx, snapshot, claimToken, result)
+	}
+	if snapshot.binding.PublishCommentsAfter == nil {
+		return result, fmt.Errorf("%w: publish-comments frontier is missing", db.ErrExternalRootValidation)
+	}
+	for _, comment := range snapshot.kataComments {
+		if comment.IssueID != snapshot.binding.IssueID || snapshot.mappedComments[comment.ID] {
+			continue
+		}
+		if comment.CreatedAt.Before(*snapshot.binding.PublishCommentsAfter) {
+			continue
+		}
+		pendingAt := r.timestamp()
+		if _, err := r.store.SetPendingExternalComment(ctx, db.SetPendingExternalCommentParams{
+			BindingID: snapshot.binding.ID, ClaimToken: claimToken,
+			CommentUID: comment.UID, At: pendingAt,
+		}); err != nil {
+			return result, err
+		}
+		if err := r.renewBeforeExternalCall(ctx, snapshot.binding.ID, claimToken); err != nil {
+			return result, err
+		}
+		published, err := snapshot.client.PublishComment(ctx, connector.PublishCommentParams{
+			RootKey:     snapshot.binding.ExternalRootKey,
+			Body:        comment.Body,
+			OperationID: publicationOperationID(snapshot.binding, comment),
+		})
+		if err != nil {
+			return result, err
+		}
+		if err := validatePublishedComment(comment, published, snapshot.description.SelfActorID); err != nil {
+			return result, err
+		}
+		mapping, err := externalCommentMapping(snapshot.binding, comment, published)
+		if err != nil {
+			return result, err
+		}
+		_, event, err := r.store.ClearPendingExternalComment(ctx, db.ClearPendingExternalCommentParams{
+			BindingID: snapshot.binding.ID, ClaimToken: claimToken, CommentUID: comment.UID,
+			ExpectedBody: comment.Body, Action: "published", Actor: integrationActor(snapshot.binding), At: r.timestamp(), Mapping: &mapping,
+			ExternalRevision: published.Revision,
+		})
+		if err != nil {
+			return result, err
+		}
+		result.retainEvents(event)
+		snapshot.mappedComments[comment.ID] = true
+	}
+	return result, nil
+}
+
+func validatePublishedComment(
+	local db.Comment,
+	published connector.Comment,
+	selfActorID string,
+) error {
+	valid := strings.TrimSpace(published.ID) != "" &&
+		strings.TrimSpace(published.Revision) != "" && strings.TrimSpace(published.Revision) == published.Revision &&
+		published.Body == local.Body &&
+		strings.TrimSpace(selfActorID) != "" &&
+		published.Author.ID == selfActorID &&
+		!published.Deleted &&
+		!published.CreatedAt.IsZero() &&
+		!published.UpdatedAt.IsZero() &&
+		!published.UpdatedAt.Before(published.CreatedAt)
+	if !valid {
+		return connectorProtocolFailure()
+	}
+	return nil
+}
+
+func (r *Reconciler) resolvePendingComment(
+	ctx context.Context,
+	snapshot reconcileSnapshot,
+	claimToken string,
+	result RunResult,
+) (RunResult, error) {
+	local, ok := pendingKataComment(snapshot)
+	if !ok {
+		return result, ErrPendingCommentResolutionRequired
+	}
+	if strings.TrimSpace(snapshot.description.SelfActorID) == "" {
+		return result, errors.Join(ErrCommentPublishingUnavailable, ErrPendingCommentResolutionRequired)
+	}
+	if err := r.renewBeforeExternalCall(ctx, snapshot.binding.ID, claimToken); err != nil {
+		return result, err
+	}
+	published, err := snapshot.client.PublishComment(ctx, connector.PublishCommentParams{
+		RootKey:     snapshot.binding.ExternalRootKey,
+		Body:        local.Body,
+		OperationID: publicationOperationID(snapshot.binding, local),
+	})
+	if err != nil {
+		return result, err
+	}
+	if err := validatePublishedComment(local, published, snapshot.description.SelfActorID); err != nil {
+		return result, err
+	}
+	mapping, err := externalCommentMapping(snapshot.binding, local, published)
+	if err != nil {
+		return result, err
+	}
+	_, event, err := r.store.ClearPendingExternalComment(ctx, db.ClearPendingExternalCommentParams{
+		BindingID: snapshot.binding.ID, ClaimToken: claimToken, CommentUID: local.UID,
+		ExpectedBody: local.Body, Action: "published", Actor: integrationActor(snapshot.binding), At: r.timestamp(), Mapping: &mapping,
+		ExternalRevision: published.Revision,
+	})
+	if err != nil {
+		return result, err
+	}
+	result.retainEvents(event)
+	return result, nil
+}
+
+func pendingExternalCommentsToWithhold(snapshot reconcileSnapshot) map[string]bool {
+	withheld := make(map[string]bool)
+	local, ok := pendingKataComment(snapshot)
+	if !ok {
+		return withheld
+	}
+	mapped := make(map[string]bool, len(snapshot.mappings)+len(snapshot.publishedCommentMappings))
+	for _, mapping := range snapshot.mappings {
+		if mapping.ObjectType == "comment" {
+			mapped[mapping.ExternalID] = true
+		}
+	}
+	for _, mapping := range snapshot.publishedCommentMappings {
+		if mapping.ObjectType == "comment" {
+			mapped[mapping.ExternalID] = true
+		}
+	}
+	for _, external := range snapshot.comments {
+		if mapped[external.ID] || external.ID == "" || external.Deleted || external.Body != local.Body {
+			continue
+		}
+		if selfActorID := strings.TrimSpace(snapshot.description.SelfActorID); selfActorID != "" &&
+			external.Author.ID != selfActorID {
+			continue
+		}
+		withheld[external.ID] = true
+	}
+	return withheld
+}
+
+func pendingKataComment(snapshot reconcileSnapshot) (db.Comment, bool) {
+	for _, comment := range snapshot.kataComments {
+		if comment.UID == snapshot.binding.PendingCommentUID {
+			return comment, true
+		}
+	}
+	return db.Comment{}, false
+}
+
+func matchesManualPendingExternalComment(external connector.Comment, selfActorID string) bool {
+	return external.ID != "" && !external.Deleted && external.Author.ID == selfActorID
+}
+
+func externalCommentMapping(
+	binding db.ExternalRootBinding,
+	local db.Comment,
+	external connector.Comment,
+) (db.ImportMappingParams, error) {
+	if strings.TrimSpace(external.ID) == "" {
+		return db.ImportMappingParams{}, fmt.Errorf("%w: published comment identity is missing", db.ErrExternalRootValidation)
+	}
+	issueID, commentID := binding.IssueID, local.ID
+	mapping := db.ImportMappingParams{
+		Source: db.ExternalRootPublishedCommentMappingSource(binding), ExternalID: external.ID,
+		ObjectType: "comment", ProjectID: binding.ProjectID,
+		IssueID: &issueID, CommentID: &commentID,
+	}
+	updatedAt := external.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = external.CreatedAt
+	}
+	if !updatedAt.IsZero() {
+		updatedAt = updatedAt.UTC()
+		mapping.SourceUpdatedAt = &updatedAt
+	}
+	return mapping, nil
+}
+
+func skippedCommentMapping(
+	binding db.ExternalRootBinding,
+	local db.Comment,
+) db.ImportMappingParams {
+	issueID, commentID := binding.IssueID, local.ID
+	return db.ImportMappingParams{
+		Source: "connector-skip:" + binding.ConnectorInstance, ExternalID: local.UID,
+		ObjectType: "comment", ProjectID: binding.ProjectID,
+		IssueID: &issueID, CommentID: &commentID,
+	}
+}
+
+func publicationOperationID(binding db.ExternalRootBinding, comment db.Comment) string {
+	digest := sha256.Sum256([]byte("kata.external-comment.v1\x00" + binding.UID + "\x00" + comment.UID))
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/rootbridge/comments.go
+++ b/internal/rootbridge/comments.go
@@ -46,11 +46,8 @@ func (r *Reconciler) applyInboundComments(
 		if pendingCommentsToWithhold[comment.ID] {
 			continue
 		}
-		if !comment.Deleted && strings.TrimSpace(comment.Body) == "" {
-			return result, connectorProtocolFailure()
-		}
-		if strings.TrimSpace(comment.Revision) == "" || strings.TrimSpace(comment.Revision) != comment.Revision {
-			return result, connectorProtocolFailure()
+		if err := validateInboundComment(comment); err != nil {
+			return result, err
 		}
 		revisionID := db.ExternalCommentRevisionMappingExternalID(comment.ID, comment.Revision)
 		if snapshot.seenCommentRevisions[revisionID] && !mapped[comment.ID] {
@@ -94,6 +91,16 @@ func (r *Reconciler) applyInboundComments(
 		}
 	}
 	return result, nil
+}
+
+func validateInboundComment(comment connector.Comment) error {
+	if !comment.Deleted && strings.TrimSpace(comment.Body) == "" {
+		return connectorProtocolFailure()
+	}
+	if strings.TrimSpace(comment.Revision) == "" || strings.TrimSpace(comment.Revision) != comment.Revision {
+		return connectorProtocolFailure()
+	}
+	return nil
 }
 
 func (r *Reconciler) applyOutboundComments(

--- a/internal/rootbridge/comments_test.go
+++ b/internal/rootbridge/comments_test.go
@@ -1,0 +1,1036 @@
+package rootbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func TestPublicationOperationIDIsStableForBindingAndComment(t *testing.T) {
+	binding := db.ExternalRootBinding{UID: "01JEXAMPLEBINDING000000000"}
+	comment := db.Comment{UID: "01JEXAMPLECOMMENT000000000"}
+
+	first := publicationOperationID(binding, comment)
+	second := publicationOperationID(binding, comment)
+
+	assert.NotEmpty(t, first)
+	assert.Equal(t, first, second)
+	assert.NotEqual(t, first, publicationOperationID(
+		db.ExternalRootBinding{UID: "01JOTHERBINDING0000000000"}, comment,
+	))
+	assert.NotEqual(t, first, publicationOperationID(
+		binding, db.Comment{UID: "01JOTHERCOMMENT0000000000"},
+	))
+}
+
+func TestReconcileQuietModeDoesNotPublishLocalComments(t *testing.T) {
+	h := newReconcileHarness(t)
+	local := h.createLocalComment(t, "Keep this local")
+
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Zero(t, h.client.publishCalls)
+	binding := h.requireBinding(t)
+	assert.Empty(t, binding.PendingCommentUID)
+	assertNoCommentMapping(t, h.store, h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding), local.ID)
+}
+
+func TestReconcilePublishesEligibleCommentExactlyOnceWithoutMarkers(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Ship this exact body\n\nwithout a marker")
+	h.client.read.Title = "External title applied first"
+	h.client.read.Revision = "root-revision-2"
+	h.client.read.UpdatedAt = h.now
+	h.client.read.ObservedAt = h.client.read.UpdatedAt
+	h.client.beforePublish = func() {
+		issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "External title applied first", issue.Title)
+	}
+	createdAt := h.now.Add(time.Minute)
+	h.client.publishResult = connector.Comment{
+		ID: "external-comment-9", Revision: "published-revision-9", Body: local.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: createdAt, UpdatedAt: createdAt,
+	}
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Len(t, h.client.publishParams, 1)
+	assert.Equal(t, "root-1", h.client.publishParams[0].RootKey)
+	assert.Equal(t, local.Body, h.client.publishParams[0].Body)
+	assert.NotEmpty(t, h.client.publishParams[0].OperationID)
+	assert.NotContains(t, h.client.publishParams[0].OperationID, local.UID)
+	assert.NotContains(t, h.client.publishParams[0].OperationID, h.binding.UID)
+	binding := h.requireBinding(t)
+	assert.Empty(t, binding.PendingCommentUID)
+	mapping := requireCommentMapping(t, h.store, h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding), "external-comment-9")
+	require.NotNil(t, mapping.CommentID)
+	assert.Equal(t, local.ID, *mapping.CommentID)
+	assert.Contains(t, eventTypes(first.Events), "issue.external_comment_resolved")
+
+	_, _, _, err = h.store.EditComment(t.Context(), db.EditCommentParams{
+		IssueID: h.issue.ID, CommentUID: local.UID, Actor: "tester", Body: "Edited after delivery",
+	})
+	require.NoError(t, err)
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, h.client.publishCalls)
+}
+
+func TestReconcileExternalEditOfPublishedCommentPreservesLocalAuthorship(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createComment(t, h.issue.ID, "local-operator", "Original local body")
+	published := publishedComment(h, "published-comment", local.Body)
+	h.client.publishResult = published
+
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	h.client.comments = []connector.Comment{published}
+	unchanged, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Zero(t, unchanged.CommentsCreated)
+	assert.Zero(t, unchanged.CommentsEdited)
+	comments, err := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+
+	published.Body = "Edited by an external collaborator"
+	published.Revision = "published-comment-revision-2"
+	published.Author = connector.Actor{ID: "external-collaborator", DisplayName: "External collaborator"}
+	published.UpdatedAt = published.UpdatedAt.Add(time.Minute)
+	h.client.comments = []connector.Comment{published}
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.CommentsCreated)
+	assert.Zero(t, result.CommentsEdited)
+	comments, err = h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 2)
+	byID := make(map[int64]db.Comment, len(comments))
+	for _, comment := range comments {
+		byID[comment.ID] = comment
+	}
+	assert.Equal(t, "local-operator", byID[local.ID].Author)
+	assert.Equal(t, "Original local body", byID[local.ID].Body)
+	for _, comment := range comments {
+		if comment.ID != local.ID {
+			assert.Equal(t, "connector:notes", comment.Author)
+			assert.Equal(t, "Edited by an external collaborator", comment.Body)
+		}
+	}
+}
+
+func TestReconcilePublishesUnmappedLocalActorWithConnectorPrefix(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createComment(t, h.issue.ID, "connector:local-operator", "Locally authored body")
+	h.client.publishResult = publishedComment(h, "published-prefixed-actor", local.Body)
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, h.client.publishCalls)
+	assert.Contains(t, eventTypes(result.Events), "issue.external_comment_resolved")
+}
+
+func TestReconcileRejectsMalformedPublishedCommentAndKeepsPending(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*reconcileHarness, *connector.Comment)
+	}{
+		{name: "missing ID", mutate: func(_ *reconcileHarness, comment *connector.Comment) {
+			comment.ID = ""
+		}},
+		{name: "missing revision", mutate: func(_ *reconcileHarness, comment *connector.Comment) {
+			comment.Revision = ""
+		}},
+		{name: "body mismatch", mutate: func(_ *reconcileHarness, comment *connector.Comment) {
+			comment.Body = "Different provider body"
+		}},
+		{name: "wrong author", mutate: func(_ *reconcileHarness, comment *connector.Comment) {
+			comment.Author.ID = "different-actor"
+		}},
+		{name: "deleted", mutate: func(_ *reconcileHarness, comment *connector.Comment) {
+			comment.Deleted = true
+		}},
+		{name: "missing created timestamp", mutate: func(_ *reconcileHarness, comment *connector.Comment) {
+			comment.CreatedAt = time.Time{}
+		}},
+		{name: "missing updated timestamp", mutate: func(_ *reconcileHarness, comment *connector.Comment) {
+			comment.UpdatedAt = time.Time{}
+		}},
+		{name: "updated before creation", mutate: func(_ *reconcileHarness, comment *connector.Comment) {
+			comment.UpdatedAt = comment.CreatedAt.Add(-time.Second)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newPublishingReconcileHarness(t)
+			local := h.createLocalComment(t, "Publish exactly this body")
+			published := publishedComment(h, "external-malformed", local.Body)
+			test.mutate(h, &published)
+			h.client.publishResult = published
+
+			_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, connectorclient.ErrProtocolFailure)
+			assert.Equal(t, connectorclient.ErrProtocolFailure.Error(), err.Error())
+			binding := h.requireBinding(t)
+			assert.Equal(t, local.UID, binding.PendingCommentUID)
+			assert.Equal(t, connectorclient.ErrProtocolFailure.Error(), binding.LastError)
+			assertNoCommentMapping(
+				t, h.store, h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding), local.ID,
+			)
+		})
+	}
+}
+
+func TestReconcileAcceptsCoarsePublishedCommentTimestamp(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Publish through a coarse-clock provider")
+	published := publishedComment(h, "external-coarse-timestamp", local.Body)
+	published.CreatedAt = h.now.Add(-time.Minute).Truncate(time.Minute)
+	published.UpdatedAt = published.CreatedAt
+	h.client.publishResult = published
+
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Empty(t, h.requireBinding(t).PendingCommentUID)
+	mapping := requireCommentMapping(
+		t, h.store, h.project.ID,
+		db.ExternalRootPublishedCommentMappingSource(h.binding), published.ID,
+	)
+	require.NotNil(t, mapping.CommentID)
+	assert.Equal(t, local.ID, *mapping.CommentID)
+}
+
+func TestReconcilePublishesSameProviderCommentIDForDifferentRoots(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	firstLocal := h.createLocalComment(t, "First root comment")
+	h.client.publishResult = publishedComment(h, "root-local-comment-id", firstLocal.Body)
+
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+
+	secondIssue, _, err := h.store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: h.project.ID, Title: "Second local plan", Body: "Second local body", Author: "tester",
+	})
+	require.NoError(t, err)
+	secondBinding, _, err := h.store.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: h.project.ID, IssueID: secondIssue.ID,
+		ConnectorInstance: "notes", ExternalRootKey: "root-2", ExternalAccountKey: "account-1",
+		Actor: "tester", ReceiveCommentsAfter: h.boundAt,
+		PublishComments: true, PublishCommentsAfter: &h.boundAt,
+	})
+	require.NoError(t, err)
+	secondLocal := h.createComment(t, secondIssue.ID, "tester", "Second root comment")
+	h.client.read = connector.Root{
+		Key: "root-2", IdentityKey: "account-1", Title: secondIssue.Title, Body: secondIssue.Body,
+		State: "open", Revision: "root-2-revision-1", UpdatedAt: h.now, ObservedAt: h.now,
+	}
+	h.client.publishResult = publishedComment(h, "root-local-comment-id", secondLocal.Body)
+
+	_, err = h.reconciler.Run(t.Context(), secondBinding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, h.client.publishCalls)
+
+	for _, item := range []struct {
+		binding db.ExternalRootBinding
+		comment db.Comment
+	}{
+		{binding: h.binding, comment: firstLocal},
+		{binding: secondBinding, comment: secondLocal},
+	} {
+		mapping := requireCommentMapping(
+			t, h.store, h.project.ID,
+			db.ExternalRootPublishedCommentMappingSource(item.binding),
+			"root-local-comment-id",
+		)
+		require.NotNil(t, mapping.CommentID)
+		assert.Equal(t, item.comment.ID, *mapping.CommentID)
+	}
+}
+
+func TestReconcilePublishesOnlyUnmappedRootCommentsFromFrontier(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	eligible := h.createLocalComment(t, "Eligible root comment")
+	imported := h.createLocalComment(t, "Imported comment")
+	child, _, err := h.store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: h.project.ID, Title: "Child work", Author: "tester",
+	})
+	require.NoError(t, err)
+	_, err = h.store.CreateLink(t.Context(), db.CreateLinkParams{
+		FromIssueID: child.ID, ToIssueID: h.issue.ID, Type: "parent", Author: "tester",
+	})
+	require.NoError(t, err)
+	childComment := h.createComment(t, child.ID, "tester", "Child comment")
+	issueID, importedID := h.issue.ID, imported.ID
+	_, err = h.store.UpsertImportMapping(t.Context(), db.ImportMappingParams{
+		Source: "import:fixture", ExternalID: "imported-comment", ObjectType: "comment",
+		ProjectID: h.project.ID, IssueID: &issueID, CommentID: &importedID,
+	})
+	require.NoError(t, err)
+	createdAt := h.now.Add(time.Minute)
+	h.client.publishResult = connector.Comment{
+		ID: "external-eligible", Revision: "revision-external-eligible", Body: eligible.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: createdAt, UpdatedAt: createdAt,
+	}
+
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Len(t, h.client.publishParams, 1)
+	assert.Equal(t, eligible.Body, h.client.publishParams[0].Body)
+	assertNoCommentMapping(t, h.store, h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding), childComment.ID)
+}
+
+func TestReconcilePublishingRequiresCurrentCapabilityAndSelfActor(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*connector.Description)
+	}{
+		{name: "capability removed", mutate: func(description *connector.Description) {
+			description.Capabilities = nil
+		}},
+		{name: "self actor removed", mutate: func(description *connector.Description) {
+			description.SelfActorID = ""
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newPublishingReconcileHarness(t)
+			local := h.createLocalComment(t, "Retain locally")
+			h.client.read.Title = "Inbound title remains available"
+			h.client.read.State = "complete"
+			h.client.read.Revision = "root-revision-inbound"
+			h.client.read.UpdatedAt = h.now
+			h.client.read.ObservedAt = h.client.read.UpdatedAt
+			providerTime := h.boundAt.Add(time.Minute)
+			h.client.comments = []connector.Comment{{
+				ID: "inbound-comment", Body: "Inbound comment remains available",
+				Author:    connector.Actor{ID: "external-author", DisplayName: "Contributor"},
+				CreatedAt: providerTime, UpdatedAt: providerTime,
+			}}
+			test.mutate(&h.client.description)
+
+			result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+			assert.ErrorIs(t, err, ErrCommentPublishingUnavailable)
+			assert.Zero(t, h.client.publishCalls)
+			assert.True(t, result.RootUpdated)
+			assert.Equal(t, 1, result.CommentsCreated)
+			assert.Equal(t, 1, result.CompletionRequests)
+			assert.Contains(t, eventTypes(result.Events), "issue.updated")
+			assert.Contains(t, eventTypes(result.Events), "issue.commented")
+			assert.Contains(t, eventTypes(result.Events), "issue.labeled")
+			issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, "Inbound title remains available", issue.Title)
+			mapping := requireCommentMapping(
+				t, h.store, h.project.ID, db.ExternalRootCommentMappingSource(h.binding), "inbound-comment",
+			)
+			require.NotNil(t, mapping.CommentID)
+			comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			assert.Len(t, comments, 3)
+			hasReview, readErr := h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+			require.NoError(t, readErr)
+			assert.True(t, hasReview)
+			assert.Empty(t, h.requireBinding(t).PendingCommentUID)
+			assertNoCommentMapping(
+				t, h.store, h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding), local.ID,
+			)
+		})
+	}
+}
+
+func TestCompleteExternalWaitsForOutboundPublication(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		configure     func(*reconcileHarness) []error
+		wantPublishes int
+	}{
+		{
+			name: "publishing capability unavailable",
+			configure: func(h *reconcileHarness) []error {
+				h.client.description.Capabilities = nil
+				return []error{ErrCommentPublishingUnavailable}
+			},
+		},
+		{
+			name: "publish transport failure",
+			configure: func(h *reconcileHarness) []error {
+				publishErr := &connector.Error{Code: "temporarily_unavailable", Message: "publish unavailable"}
+				h.client.publishErr = publishErr
+				return []error{publishErr}
+			},
+			wantPublishes: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newPublishingReconcileHarness(t)
+			h.createLocalComment(t, "Attempt before completion")
+			_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+			require.NoError(t, err)
+			h.client.read.Title = "Projected before outbound failure"
+			h.client.read.Revision = "root-before-outbound-failure"
+			h.client.read.UpdatedAt = h.now
+			h.client.read.ObservedAt = h.client.read.UpdatedAt
+			h.client.completeReadback = completedRoot(h.client.read, "completed-after-outbound-failure")
+			wantErrors := test.configure(h)
+
+			result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+			for _, wantErr := range wantErrors {
+				assert.ErrorIs(t, err, wantErr)
+			}
+			assert.Zero(t, h.client.completeCalls)
+			assert.Equal(t, test.wantPublishes, h.client.publishCalls)
+			assert.Contains(t, eventTypes(result.Events), "issue.updated")
+			binding := h.requireBinding(t)
+			assert.Nil(t, binding.LastSuccessAt)
+			assert.Equal(t, 1, binding.ConsecutiveFailures)
+			assert.Empty(t, binding.ClaimToken)
+		})
+	}
+}
+
+func TestCompleteExternalWaitsForPendingReplay(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Pending before completion")
+	claimed, acquired, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, "pending-before-completion", h.now, h.now.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	_, err = h.store.SetPendingExternalComment(t.Context(), db.SetPendingExternalCommentParams{
+		BindingID: h.binding.ID, ClaimToken: claimed.ClaimToken, CommentUID: local.UID, At: h.now,
+	})
+	require.NoError(t, err)
+	_, err = h.store.RecordExternalRootError(t.Context(), db.ExternalRootErrorParams{
+		BindingID: h.binding.ID, ClaimToken: claimed.ClaimToken,
+		At: h.now, NextAttemptAt: h.now, Error: "publication result uncertain",
+	})
+	require.NoError(t, err)
+	_, _, _, err = h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.read.Title = "Projected before pending resolution"
+	h.client.read.Revision = "root-before-pending-resolution"
+	h.client.read.UpdatedAt = h.now
+	h.client.read.ObservedAt = h.client.read.UpdatedAt
+	h.client.completeReadback = completedRoot(h.client.read, "completed-with-pending-comment")
+	publishErr := &connector.Error{Code: "temporarily_unavailable", Message: "publish unavailable"}
+	h.client.publishErr = publishErr
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	assert.ErrorIs(t, err, publishErr)
+	assert.Zero(t, h.client.completeCalls)
+	assert.Equal(t, 1, h.client.publishCalls)
+	assert.Contains(t, eventTypes(result.Events), "issue.updated")
+	binding := h.requireBinding(t)
+	assert.Equal(t, local.UID, binding.PendingCommentUID)
+	assert.Nil(t, binding.LastSuccessAt)
+	assert.Equal(t, 2, binding.ConsecutiveFailures)
+	assert.Empty(t, binding.ClaimToken)
+}
+
+func TestCompletionRunsAfterOutboundRetrySucceeds(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Publish after completion retry")
+	_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.completeReadback = completedRoot(h.client.read, "completed-during-outbound-error")
+	h.client.description.Capabilities = nil
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	assert.ErrorIs(t, err, ErrCommentPublishingUnavailable)
+	assert.Zero(t, first.CompletionRequests)
+	assert.Zero(t, first.ReopenRequests)
+	assert.Zero(t, h.client.completeCalls)
+	failed := h.requireBinding(t)
+	assert.Nil(t, failed.LastSuccessAt)
+	assert.Equal(t, 1, failed.ConsecutiveFailures)
+	assert.Empty(t, failed.LastExternalState)
+	assert.Empty(t, failed.LastExternalRevision)
+
+	h.client.description.Capabilities = []connector.Capability{connector.CapabilityPublishComment}
+	h.client.description.SelfActorID = "connector-self"
+	h.client.publishResult = publishedComment(h, "published-after-completion-retry", local.Body)
+	second, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Zero(t, second.CompletionRequests)
+	assert.Zero(t, second.ReopenRequests)
+	assert.Equal(t, 1, h.client.completeCalls)
+	comments, err := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Len(t, comments, 1)
+	hasReview, err := h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+	require.NoError(t, err)
+	assert.False(t, hasReview)
+	succeeded := h.requireBinding(t)
+	require.NotNil(t, succeeded.LastSuccessAt)
+	assert.Equal(t, "complete", succeeded.LastExternalState)
+	assert.Equal(t, "completed-during-outbound-error", succeeded.LastExternalRevision)
+
+	h.client.read.State = "open"
+	h.client.read.Revision = "reopened-after-completion"
+	h.client.read.UpdatedAt = h.client.read.UpdatedAt.Add(time.Minute)
+	h.client.read.ObservedAt = h.client.read.ObservedAt.Add(time.Minute)
+	h.client.completeReadback = completedRoot(h.client.read, "recompleted-after-reopen")
+	third, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Zero(t, third.CompletionRequests)
+	assert.Equal(t, 1, third.ReopenRequests)
+	hasReview, err = h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+	require.NoError(t, err)
+	assert.True(t, hasReview)
+}
+
+func TestReconcileWithoutSelfIdentityWithholdsPlausiblePendingCommentFromInbound(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Uncertain external creation")
+	claimed, acquired, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, "pending-setup-claim", h.now, h.now.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	_, err = h.store.SetPendingExternalComment(t.Context(), db.SetPendingExternalCommentParams{
+		BindingID: h.binding.ID, ClaimToken: claimed.ClaimToken, CommentUID: local.UID, At: h.now,
+	})
+	require.NoError(t, err)
+	_, err = h.store.RecordExternalRootError(t.Context(), db.ExternalRootErrorParams{
+		BindingID: h.binding.ID, ClaimToken: claimed.ClaimToken,
+		At: h.now, NextAttemptAt: h.now, Error: "publication result uncertain",
+	})
+	require.NoError(t, err)
+	h.client.description.SelfActorID = ""
+	h.client.read.Title = "Inbound root still applies"
+	h.client.read.Revision = "root-revision-after-pending"
+	h.client.read.UpdatedAt = h.now.Add(time.Minute)
+	h.client.read.ObservedAt = h.client.read.UpdatedAt
+	h.client.comments = []connector.Comment{{
+		ID: "plausible-pending-comment", Body: local.Body,
+		Author:    connector.Actor{ID: "unknown-current-actor"},
+		CreatedAt: h.now.Add(time.Minute), UpdatedAt: h.now.Add(time.Minute),
+	}}
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	assert.ErrorIs(t, err, ErrCommentPublishingUnavailable)
+	assert.ErrorIs(t, err, ErrPendingCommentResolutionRequired)
+	assert.True(t, result.RootUpdated)
+	assert.Zero(t, result.CommentsCreated)
+	assert.Zero(t, h.client.publishCalls)
+	issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "Inbound root still applies", issue.Title)
+	comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	require.Len(t, comments, 1)
+	assert.Equal(t, local.ID, comments[0].ID)
+	_, readErr = h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, db.ExternalRootCommentMappingSource(h.binding), "comment", "plausible-pending-comment",
+	)
+	assert.ErrorIs(t, readErr, db.ErrNotFound)
+	retained := h.requireBinding(t)
+	assert.Equal(t, local.UID, retained.PendingCommentUID)
+	assert.Empty(t, retained.ClaimToken)
+}
+
+func TestResolvePendingCommentRejectsBlankSelfIdentityAtAutomaticAdoptionBoundary(t *testing.T) {
+	for _, selfActorID := range []string{"", "   "} {
+		name := "empty"
+		if selfActorID != "" {
+			name = "whitespace"
+		}
+		t.Run(name, func(t *testing.T) {
+			h := newPublishingReconcileHarness(t)
+			local := h.createLocalComment(t, "Withhold this plausible uncertain create")
+			claimed, acquired, err := h.store.ClaimExternalRootBinding(
+				t.Context(), h.binding.ID, "direct-pending-claim", h.now, h.now.Add(-time.Minute),
+			)
+			require.NoError(t, err)
+			require.True(t, acquired)
+			_, err = h.store.SetPendingExternalComment(t.Context(), db.SetPendingExternalCommentParams{
+				BindingID: h.binding.ID, ClaimToken: claimed.ClaimToken, CommentUID: local.UID, At: h.now,
+			})
+			require.NoError(t, err)
+			h.client.description.SelfActorID = selfActorID
+			h.client.comments = []connector.Comment{{
+				ID: "plausible-without-self", Body: local.Body,
+				Author:    connector.Actor{ID: "unaccepted-actor"},
+				CreatedAt: h.now, UpdatedAt: h.now,
+			}}
+			snapshot, err := h.reconciler.readCurrent(t.Context(), claimed, claimed.ClaimToken)
+			require.NoError(t, err)
+
+			result, err := h.reconciler.resolvePendingComment(
+				t.Context(), snapshot, claimed.ClaimToken, RunResult{},
+			)
+			assert.ErrorIs(t, err, ErrPendingCommentResolutionRequired)
+			assert.Empty(t, result.Events)
+			assert.Zero(t, h.client.publishCalls)
+			_, mappingErr := h.store.ImportMappingBySource(
+				t.Context(), h.project.ID, db.ExternalRootCommentMappingSource(h.binding), "comment", "plausible-without-self",
+			)
+			assert.ErrorIs(t, mappingErr, db.ErrNotFound)
+			retained := h.requireBinding(t)
+			assert.Equal(t, local.UID, retained.PendingCommentUID)
+
+			_, outboundErr := h.reconciler.applyOutboundComments(
+				t.Context(), snapshot, claimed.ClaimToken, RunResult{},
+			)
+			assert.ErrorIs(t, outboundErr, ErrCommentPublishingUnavailable)
+			assert.ErrorIs(t, outboundErr, ErrPendingCommentResolutionRequired)
+			assert.Zero(t, h.client.publishCalls)
+		})
+	}
+}
+
+func TestBindPublishingUsesDurableLocalCommentIdentityFrontier(t *testing.T) {
+	h := newServiceHarness(t)
+	old := h.createServiceComment(t, "Existing local comment")
+	h.client.read.UpdatedAt = testObservedAt
+	reconciler := NewReconciler(h.observed, h.registry, ReconcilerConfig{})
+	h.service.immediateClaimedReconcile = func(ctx context.Context, bindingID int64, claimToken string) ([]db.Event, error) {
+		result, err := reconciler.Run(ctx, bindingID, RunOptions{ClaimToken: claimToken})
+		return result.Events, err
+	}
+
+	binding, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester", PublishComments: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, binding.PublishCommentsAfter)
+	after := h.createServiceComment(t, "Created after publishing was enabled")
+	_, err = h.store.ExecContext(t.Context(), `UPDATE comments SET created_at=? WHERE id=?`,
+		old.CreatedAt.Add(-time.Hour).Format(time.RFC3339Nano), after.ID)
+	require.NoError(t, err)
+	h.client.publishResult = connector.Comment{
+		ID: "external-after-enable", Revision: "revision-external-after-enable", Body: after.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: binding.PublishCommentsAfter.Add(time.Minute), UpdatedAt: binding.PublishCommentsAfter.Add(time.Minute),
+	}
+
+	_, err = reconciler.Run(t.Context(), binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Len(t, h.client.publishParams, 1)
+	assert.Equal(t, after.Body, h.client.publishParams[0].Body)
+	assertNoCommentMapping(t, h.store, h.project.ID, db.ExternalRootPublishedCommentMappingSource(binding), old.ID)
+}
+
+func TestPublishMappingFailureRetriesSameOperationAndResolves(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Ship it")
+	h.client.read.Title = "Committed before publication"
+	h.client.read.Revision = "root-revision-2"
+	h.client.read.UpdatedAt = h.now
+	h.client.read.ObservedAt = h.client.read.UpdatedAt
+	h.client.publishResult = publishedComment(h, "external-comment-9", local.Body)
+	postCreateErr := errors.New("durable mapping unavailable")
+	h.reconciler.store = &failPublishedCommentClearOnceStorage{Storage: h.store, err: postCreateErr}
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.ErrorIs(t, err, postCreateErr)
+	assert.Contains(t, eventTypes(result.Events), "issue.updated")
+	issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "Committed before publication", issue.Title)
+	result, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Len(t, h.client.publishParams, 2)
+	assert.Equal(t, h.client.publishParams[0].OperationID, h.client.publishParams[1].OperationID)
+	assert.Empty(t, h.requireBinding(t).PendingCommentUID)
+	mapping := requireCommentMapping(t, h.store, h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding), "external-comment-9")
+	require.NotNil(t, mapping.CommentID)
+	assert.Equal(t, local.ID, *mapping.CommentID)
+	assert.Contains(t, eventTypes(result.Events), "issue.external_comment_resolved")
+}
+
+func TestPendingReplayDoesNotUseListCommentTimestampMatches(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Recover through the publication operation")
+	original := publishedComment(h, "external-comment-original", local.Body)
+	h.client.publishResult = original
+	h.reconciler.store = &failPublishedCommentClearOnceStorage{
+		Storage: h.store, err: errors.New("durable mapping unavailable"),
+	}
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.Error(t, err)
+	listed := publishedComment(h, "unrelated-exact-body-comment", local.Body)
+	listed.CreatedAt = h.now.Add(-24 * time.Hour).Truncate(time.Minute)
+	listed.UpdatedAt = listed.CreatedAt
+	h.client.comments = []connector.Comment{listed}
+
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, h.client.publishCalls)
+	assert.Empty(t, h.requireBinding(t).PendingCommentUID)
+	mapping := requireCommentMapping(
+		t, h.store, h.project.ID,
+		db.ExternalRootPublishedCommentMappingSource(h.binding), original.ID,
+	)
+	require.NotNil(t, mapping.CommentID)
+	assert.Equal(t, local.ID, *mapping.CommentID)
+	comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Len(t, comments, 1)
+}
+
+func TestPendingReplayRejectsMismatchedConnectorResult(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Recover only the original publication")
+	h.client.publishResult = publishedComment(h, "external-comment-original", local.Body)
+	h.reconciler.store = &failPublishedCommentClearOnceStorage{
+		Storage: h.store, err: errors.New("durable mapping unavailable"),
+	}
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.Error(t, err)
+	h.client.publishResult = publishedComment(h, "external-comment-mismatch", "Different provider body")
+
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	assert.ErrorIs(t, err, connectorclient.ErrProtocolFailure)
+	assert.Equal(t, 2, h.client.publishCalls)
+	assert.Equal(t, local.UID, h.requireBinding(t).PendingCommentUID)
+}
+
+func TestConcurrentReconcileWakesPublishOnce(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Publish once")
+	h.client.publishResult = publishedComment(h, "external-comment-13", local.Body)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.client.beforePublish = func() { close(entered); <-release }
+
+	type runResult struct{ err error }
+	results := make(chan runResult, 2)
+	go func() {
+		_, err := h.reconciler.Run(context.Background(), h.binding.ID, RunOptions{})
+		results <- runResult{err: err}
+	}()
+	<-entered
+	go func() {
+		_, err := h.reconciler.Run(context.Background(), h.binding.ID, RunOptions{})
+		results <- runResult{err: err}
+	}()
+	second := <-results
+	require.NoError(t, second.err)
+	close(release)
+	first := <-results
+	require.NoError(t, first.err)
+	assert.Equal(t, 1, h.client.publishCalls)
+}
+
+func TestOutboundCommentEditDuringPublicationLeavesResolutionPending(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Body selected for publication")
+	h.client.publishResult = publishedComment(h, "external-comment-edited-race", local.Body)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.client.beforePublish = func() {
+		close(entered)
+		<-release
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.reconciler.Run(context.Background(), h.binding.ID, RunOptions{})
+		done <- err
+	}()
+	<-entered
+	_, _, changed, err := h.store.EditComment(t.Context(), db.EditCommentParams{
+		IssueID: h.issue.ID, CommentUID: local.UID, Body: "Edited while publishing", Actor: "operator",
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+	close(release)
+
+	require.ErrorIs(t, <-done, db.ErrExternalRootValidation)
+	retained := h.requireBinding(t)
+	assert.Equal(t, local.UID, retained.PendingCommentUID)
+	_, err = h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding),
+		"comment", "external-comment-edited-race",
+	)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}
+
+type failPublishedCommentClearOnceStorage struct {
+	db.Storage
+	err  error
+	once sync.Once
+}
+
+func (s *failPublishedCommentClearOnceStorage) ClearPendingExternalComment(
+	ctx context.Context,
+	params db.ClearPendingExternalCommentParams,
+) (db.ExternalRootBinding, db.Event, error) {
+	failed := false
+	if params.Action == "published" {
+		s.once.Do(func() { failed = true })
+	}
+	if failed {
+		return db.ExternalRootBinding{}, db.Event{}, s.err
+	}
+	return s.Storage.ClearPendingExternalComment(ctx, params)
+}
+
+func (h *reconcileHarness) createLocalComment(t *testing.T, body string) db.Comment {
+	t.Helper()
+	return h.createComment(t, h.issue.ID, "tester", body)
+}
+
+func (h *reconcileHarness) createComment(t *testing.T, issueID int64, author, body string) db.Comment {
+	t.Helper()
+	comment, _, err := h.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: issueID, Author: author, Body: body,
+	})
+	require.NoError(t, err)
+	return comment
+}
+
+func (h *serviceHarness) createServiceComment(t *testing.T, body string) db.Comment {
+	t.Helper()
+	comment, _, err := h.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: h.issue.ID, Author: "tester", Body: body,
+	})
+	require.NoError(t, err)
+	return comment
+}
+
+func (h *reconcileHarness) requireBinding(t *testing.T) db.ExternalRootBinding {
+	t.Helper()
+	binding, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	return binding
+}
+
+func publishedComment(h *reconcileHarness, externalID, body string) connector.Comment {
+	createdAt := h.now.Add(time.Minute)
+	return connector.Comment{
+		ID: externalID, Revision: "revision-" + externalID, Body: body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: createdAt, UpdatedAt: createdAt,
+	}
+}
+
+func requireCommentMapping(
+	t *testing.T,
+	store db.Storage,
+	projectID int64,
+	source string,
+	externalID string,
+) db.ImportMapping {
+	t.Helper()
+	mapping, err := store.ImportMappingBySource(t.Context(), projectID, source, "comment", externalID)
+	require.NoError(t, err)
+	return mapping
+}
+
+func assertNoCommentMapping(t *testing.T, store db.Storage, projectID int64, source string, commentID int64) {
+	t.Helper()
+	for mapping, err := range store.ExportImportMappings(t.Context(), db.ExportFilter{ProjectID: &projectID}) {
+		require.NoError(t, err)
+		if mapping.Source == source && mapping.ObjectType == "comment" && mapping.CommentID != nil {
+			assert.NotEqual(t, commentID, *mapping.CommentID)
+		}
+	}
+}
+
+func TestReconcileInboundCommentIsNativeDeduplicatedAndAttributed(t *testing.T) {
+	h := newReconcileHarness(t)
+	createdAt := h.boundAt.Add(time.Minute)
+	h.client.comments = []connector.Comment{{
+		ID: "comment-7", Revision: "opaque-comment-revision-7", Body: "Please check this",
+		Author:    connector.Actor{ID: "actor-4", DisplayName: "local-operator"},
+		CreatedAt: createdAt, UpdatedAt: createdAt,
+	}}
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	second, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, first.CommentsCreated)
+	assert.Equal(t, 0, second.CommentsCreated)
+	comments, err := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Equal(t, "connector:notes", comments[0].Author)
+	assert.Equal(t, createdAt, comments[0].CreatedAt)
+
+	event := requireEventType(t, first.Events, "issue.commented")
+	assert.Equal(t, "connector:notes", event.Actor)
+	var payload struct {
+		Author string `json:"author"`
+		Source struct {
+			ConnectorInstance string `json:"connector_instance"`
+			ExternalCommentID string `json:"external_comment_id"`
+			ExternalRevision  string `json:"external_revision"`
+			ActorID           string `json:"actor_id"`
+			ActorName         string `json:"actor_name"`
+			CreatedAt         string `json:"created_at"`
+			UpdatedAt         string `json:"updated_at"`
+		} `json:"source"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(event.Payload), &payload))
+	assert.Equal(t, "connector:notes", payload.Author)
+	assert.Equal(t, "notes", payload.Source.ConnectorInstance)
+	assert.Equal(t, "comment-7", payload.Source.ExternalCommentID)
+	assert.Equal(t, "opaque-comment-revision-7", payload.Source.ExternalRevision)
+	assert.Equal(t, "actor-4", payload.Source.ActorID)
+	assert.Equal(t, "local-operator", payload.Source.ActorName)
+	assert.Equal(t, createdAt.Format(time.RFC3339Nano), payload.Source.CreatedAt)
+	assert.Equal(t, createdAt.Format(time.RFC3339Nano), payload.Source.UpdatedAt)
+}
+
+func TestReconcileRejectsBlankLiveExternalComment(t *testing.T) {
+	h := newReconcileHarness(t)
+	createdAt := h.boundAt.Add(time.Minute)
+	h.client.comments = []connector.Comment{{
+		ID: "comment-blank", Revision: "comment-blank-revision-1", Body: " \t\n",
+		Author:    connector.Actor{ID: "actor-4", DisplayName: "Contributor"},
+		CreatedAt: createdAt, UpdatedAt: createdAt,
+	}}
+
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	assert.ErrorIs(t, err, connectorclient.ErrProtocolFailure)
+	comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, comments)
+}
+
+func TestReconcileImportsSameProviderCommentIDForDifferentRoots(t *testing.T) {
+	h := newReconcileHarness(t)
+	providerTime := h.boundAt.Add(time.Minute)
+	h.client.comments = []connector.Comment{{
+		ID: "root-local-comment-id", Body: "First root comment",
+		Author:    connector.Actor{ID: "actor-1", DisplayName: "Contributor"},
+		CreatedAt: providerTime, UpdatedAt: providerTime,
+	}}
+
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+
+	secondIssue, _, err := h.store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: h.project.ID, Title: "Second local plan", Body: "Second local body", Author: "tester",
+	})
+	require.NoError(t, err)
+	secondBinding, _, err := h.store.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: h.project.ID, IssueID: secondIssue.ID,
+		ConnectorInstance: "notes", ExternalRootKey: "root-2", ExternalAccountKey: "account-1",
+		Actor: "tester", ReceiveCommentsAfter: h.boundAt,
+	})
+	require.NoError(t, err)
+	h.client.read = connector.Root{
+		Key: "root-2", IdentityKey: "account-1", Title: secondIssue.Title, Body: secondIssue.Body,
+		State: "open", Revision: "root-2-revision-1", UpdatedAt: h.now, ObservedAt: h.now,
+	}
+	h.client.comments = []connector.Comment{{
+		ID: "root-local-comment-id", Body: "Second root comment",
+		Author:    connector.Actor{ID: "actor-2", DisplayName: "Reviewer"},
+		CreatedAt: providerTime, UpdatedAt: providerTime,
+	}}
+
+	second, err := h.reconciler.Run(t.Context(), secondBinding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, second.CommentsCreated)
+	comments, err := h.store.CommentsByIssue(t.Context(), secondIssue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Equal(t, "Second root comment", comments[0].Body)
+}
+
+func TestReconcileInboundCommentEditAndDeletionRedactInPlace(t *testing.T) {
+	h := newReconcileHarness(t)
+	createdAt := h.boundAt.Add(time.Minute)
+	h.client.comments = []connector.Comment{{
+		ID: "comment-8", Revision: "comment-8-revision-1", Body: "Initial body",
+		Author:    connector.Actor{ID: "actor-5", DisplayName: "Contributor"},
+		CreatedAt: createdAt, UpdatedAt: createdAt,
+	}}
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.CommentsCreated)
+
+	h.client.comments[0].Body = "Corrected body"
+	h.client.comments[0].Revision = "comment-8-revision-2"
+	edited, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, edited.CommentsEdited)
+	comments, err := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Equal(t, "Corrected body", comments[0].Body)
+	editEvent := requireEventType(t, edited.Events, "issue.comment_edited")
+	var editPayload inboundCommentEventPayload
+	require.NoError(t, json.Unmarshal([]byte(editEvent.Payload), &editPayload))
+	assert.Equal(t, "actor-5", editPayload.Source.ActorID)
+	assert.Equal(t, "Contributor", editPayload.Source.ActorName)
+	assert.Equal(t, createdAt.Format(time.RFC3339Nano), editPayload.Source.CreatedAt)
+	assert.Equal(t, createdAt.Format(time.RFC3339Nano), editPayload.Source.UpdatedAt)
+	assert.False(t, editPayload.Source.Deleted)
+
+	h.client.comments[0].Deleted = true
+	h.client.comments[0].Revision = "comment-8-revision-3"
+	redacted, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, redacted.CommentsEdited)
+	comments, err = h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Equal(t, "[deleted externally]", comments[0].Body)
+	deleteEvent := requireEventType(t, redacted.Events, "issue.comment_edited")
+	var deletePayload inboundCommentEventPayload
+	require.NoError(t, json.Unmarshal([]byte(deleteEvent.Payload), &deletePayload))
+	assert.Equal(t, "actor-5", deletePayload.Source.ActorID)
+	assert.Equal(t, "Contributor", deletePayload.Source.ActorName)
+	assert.Equal(t, createdAt.Format(time.RFC3339Nano), deletePayload.Source.CreatedAt)
+	assert.Equal(t, createdAt.Format(time.RFC3339Nano), deletePayload.Source.UpdatedAt)
+	assert.True(t, deletePayload.Source.Deleted)
+	mapping, err := h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, db.ExternalRootCommentMappingSource(h.binding), "comment", "comment-8",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mapping.CommentID)
+	assert.Equal(t, comments[0].ID, *mapping.CommentID)
+}
+
+type inboundCommentEventPayload struct {
+	Source struct {
+		ActorID   string `json:"actor_id"`
+		ActorName string `json:"actor_name"`
+		CreatedAt string `json:"created_at"`
+		UpdatedAt string `json:"updated_at"`
+		Deleted   bool   `json:"deleted"`
+	} `json:"source"`
+}
+
+func TestReconcileExcludesCommentsAtOrBeforeBindFrontier(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.client.comments = []connector.Comment{
+		{ID: "comment-before", Body: "Earlier", Author: connector.Actor{DisplayName: "Reviewer"}, CreatedAt: h.boundAt.Add(-time.Second), UpdatedAt: h.boundAt.Add(time.Minute)},
+		{ID: "comment-at", Body: "At frontier", Author: connector.Actor{DisplayName: "Reviewer"}, CreatedAt: h.boundAt, UpdatedAt: h.boundAt},
+	}
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Zero(t, result.CommentsCreated)
+	comments, err := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Empty(t, comments)
+}

--- a/internal/rootbridge/e2e_test.go
+++ b/internal/rootbridge/e2e_test.go
@@ -1,0 +1,871 @@
+package rootbridge
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/internal/connector/fakeconnector"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/pgstore"
+	"go.kenn.io/kata/internal/db/sqlitestore"
+	"go.kenn.io/kata/internal/jsonl"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func TestExternalRootBridgeEndToEnd(t *testing.T) {
+	executable := buildFakeConnector(t)
+	backends := []e2eBackend{{name: "sqlite", open: openSQLiteE2E}}
+	if dsn := strings.TrimSpace(os.Getenv("KATA_TEST_POSTGRES_DSN")); dsn != "" {
+		backends = append(backends, e2eBackend{
+			name: "postgres",
+			open: func(t *testing.T) *e2eDatabase { return openPostgresE2E(t, dsn) },
+		})
+	}
+	for _, backend := range backends {
+		t.Run(backend.name, func(t *testing.T) {
+			t.Run("restart inbound quiet completion and reopen", func(t *testing.T) {
+				testE2ERestartInboundCompletion(t, executable, backend)
+			})
+			t.Run("pending publication recovery actions", func(t *testing.T) {
+				testE2EPendingPublication(t, executable, backend)
+			})
+			t.Run("planning field conflict and completion isolation", func(t *testing.T) {
+				testE2EPlanningFields(t, executable, backend)
+			})
+			t.Run("planning field wire shapes", func(t *testing.T) {
+				testE2EPlanningFieldShapes(t, executable, backend)
+			})
+			t.Run("restore requires identity reconfirmation", func(t *testing.T) {
+				testE2ERestorePause(t, executable, backend)
+			})
+			t.Run("process and protocol failure isolation", func(t *testing.T) {
+				testE2EFailureIsolation(t, executable, backend)
+			})
+		})
+	}
+}
+
+func TestRecordedExternalSurfaceRejectsLocalIdentityValues(t *testing.T) {
+	for _, test := range []struct {
+		localIdentity string
+		long          bool
+	}{
+		{localIdentity: "01ARZ3NDEKTSV4RRFFQ69G5FAV", long: true},
+		{localIdentity: "root-short"},
+		{localIdentity: "01ARZ3NDEKTSV4RRFFQ69G5FAW", long: true},
+		{localIdentity: "child-short"},
+	} {
+		current := fakeconnector.State{Calls: []fakeconnector.Call{{
+			Method: "publish_comment",
+			Params: json.RawMessage(`{"root_key":"root-example","body":` + strconv.Quote(test.localIdentity) + `}`),
+		}}}
+		if test.long {
+			require.Error(t, fakeconnector.AuditExternalSurface(current, "root-example", []string{test.localIdentity}, nil))
+		} else {
+			require.Error(t, fakeconnector.AuditExternalSurface(current, "root-example", nil, []string{test.localIdentity}))
+		}
+	}
+}
+
+func TestRecordedExternalSurfaceRejectsEmbeddedLongUIDsOnly(t *testing.T) {
+	rootUID := "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+	childUID := "01ARZ3NDEKTSV4RRFFQ69G5FAW"
+	for _, uid := range []string{rootUID, childUID} {
+		current := fakeconnector.State{Calls: []fakeconnector.Call{{
+			Method: "publish_comment",
+			Params: json.RawMessage(`{"root_key":"root-example","body":` + strconv.Quote("prefix-"+uid+"-suffix") + `,"operation_id":"operation-example"}`),
+		}}}
+		require.Error(t, fakeconnector.AuditExternalSurface(current, "root-example", []string{uid}, nil))
+	}
+
+	for _, body := range []string{
+		"prefix-root-short-suffix",
+		"unrelated-01ARZ3NDEKTSV4RRFFQ69G5FAX-suffix",
+	} {
+		current := fakeconnector.State{Calls: []fakeconnector.Call{{
+			Method: "publish_comment",
+			Params: json.RawMessage(`{"root_key":"root-example","body":` + strconv.Quote(body) + `,"operation_id":"operation-example"}`),
+		}}}
+		require.NoError(t, fakeconnector.AuditExternalSurface(current, "root-example", []string{rootUID, childUID}, []string{"root-short"}))
+	}
+}
+
+func TestRecordedExternalSurfaceRejectsForbiddenKataKeysInsideFieldValues(t *testing.T) {
+	for _, key := range []string{
+		"kata_uid", "kataUid", "kata-uid", "kata.uid",
+		"kata_ref", "kataRef", "kata-ref", "kata.ref",
+		"kata_project_id", "kataProjectId", "kata-project-id", "kata.project.id",
+		"kata_binding_id", "kataBindingId", "kata-binding-id", "kata.binding.id",
+		"kata_work_branch", "kataWorkBranch", "kata-work-branch", "kata.work.branch",
+	} {
+		params, err := json.Marshal(map[string]any{
+			"root_key": "root-example",
+			"fields": map[string]any{
+				"kata_uid": map[string]any{"kind": "date", "value": "2026-08-20", key: "neutral-forbidden"},
+			},
+		})
+		require.NoError(t, err)
+		current := fakeconnector.State{Calls: []fakeconnector.Call{{Method: "write_fields", Params: params}}}
+		require.Error(t, fakeconnector.AuditExternalSurface(current, "root-example", nil, nil), key)
+	}
+}
+
+func testE2ERestartInboundCompletion(t *testing.T, executable string, backend e2eBackend) {
+	h := newE2EHarness(t, executable, backend, false)
+	child, _, err := h.database.store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: h.project.ID, Title: "Child title", Body: "Child body", Author: "operator",
+	})
+	require.NoError(t, err)
+	for _, uid := range []string{h.issue.UID, child.UID} {
+		params, marshalErr := json.Marshal(map[string]any{
+			"root_key": "root-example",
+			"body":     "embedded-" + uid + "-identity",
+		})
+		require.NoError(t, marshalErr)
+		probe := fakeconnector.State{Calls: []fakeconnector.Call{{Method: "publish_comment", Params: params}}}
+		require.Error(t, fakeconnector.AuditExternalSurface(probe, "root-example", []string{uid}, nil))
+	}
+	_, err = h.database.store.CreateLink(t.Context(), db.CreateLinkParams{
+		FromIssueID: child.ID, ToIssueID: h.issue.ID, Type: "parent", Author: "operator",
+	})
+	require.NoError(t, err)
+	_, _, err = h.database.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: child.ID, Author: "operator", Body: "Child-only note",
+	})
+	require.NoError(t, err)
+	_, err = h.database.store.PatchIssueMetadata(t.Context(), db.PatchIssueMetadataIn{
+		IssueID: child.ID, Actor: "operator", Patch: map[string]json.RawMessage{
+			"work.attention": json.RawMessage(`"ok"`),
+		},
+	})
+	require.NoError(t, err)
+	_, _, _, err = h.database.store.CloseIssue(
+		t.Context(), child.ID, "done", "verifier", "Verified child independently.",
+		[]db.Evidence{{Type: "test", Command: "go test ./internal/rootbridge"}},
+	)
+	require.NoError(t, err)
+	childBefore, err := h.database.store.IssueByID(t.Context(), child.ID)
+	require.NoError(t, err)
+	childCommentsBefore, err := h.database.store.CommentsByIssue(t.Context(), child.ID)
+	require.NoError(t, err)
+
+	issue, err := h.database.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "External title", issue.Title)
+	assert.Equal(t, "External body", issue.Body)
+	comments, err := h.database.store.CommentsByIssue(t.Context(), issue.ID)
+	require.NoError(t, err)
+	assert.Empty(t, comments, "pre-bind native comments must remain external")
+
+	_, _, err = h.database.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: issue.ID, Author: "operator", Body: "Quiet local note",
+	})
+	require.NoError(t, err)
+	externalComment := connector.Comment{
+		ID: "comment-after-bind", Revision: "revision-comment-after-bind", Body: "Please verify the result",
+		Author:    connector.Actor{ID: "actor-reviewer", DisplayName: "Reviewer"},
+		CreatedAt: h.base.Add(time.Minute), UpdatedAt: h.base.Add(time.Minute),
+	}
+	h.mutateState(func(current *fakeconnector.State) {
+		current.Roots[0].Comments = append(current.Roots[0].Comments, externalComment)
+	})
+	h.restart(t)
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err)
+	second, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, first.CommentsCreated)
+	assert.Zero(t, second.CommentsCreated)
+	comments, err = h.database.store.CommentsByIssue(t.Context(), issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 2)
+	var imported db.Comment
+	for _, comment := range comments {
+		if comment.Author == "connector:example" {
+			imported = comment
+		}
+	}
+	require.NotZero(t, imported.ID)
+	assert.Equal(t, externalComment.Body, imported.Body)
+	assert.Equal(t, externalComment.CreatedAt, imported.CreatedAt)
+
+	event := requireEventType(t, first.Events, "issue.commented")
+	var payload struct {
+		Source db.ExternalProjectionSource `json:"source"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(event.Payload), &payload))
+	assert.Equal(t, "example", payload.Source.ConnectorInstance)
+	assert.Equal(t, externalComment.ID, payload.Source.ExternalCommentID)
+	assert.Equal(t, externalComment.Author.ID, payload.Source.ActorID)
+	assert.Equal(t, externalComment.Author.DisplayName, payload.Source.ActorName)
+
+	_, _, _, err = h.database.store.CloseIssue(
+		t.Context(), issue.ID, "done", "verifier", "Verified completion.",
+		[]db.Evidence{{Type: "test", Command: "go test ./internal/rootbridge"}},
+	)
+	require.NoError(t, err)
+	closedRun, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err)
+	assert.Zero(t, closedRun.CompletionRequests)
+	state := h.readState(t)
+	assert.Equal(t, "complete", state.Roots[0].Root.State)
+	assert.Len(t, state.Roots, 1, "bridge must not create child roots")
+	assert.Equal(t, 0, mutationCount(state, "publish_comment"), "quiet mode must not publish comments")
+	assert.Equal(t, 1, mutationCount(state, "complete_root"))
+
+	h.mutateState(func(current *fakeconnector.State) {
+		root := &current.Roots[0].Root
+		root.State = "open"
+		root.Revision = "revision-reopened"
+		root.UpdatedAt = h.base.Add(2 * time.Minute)
+		root.ObservedAt = root.UpdatedAt
+		root.Actor = &connector.Actor{ID: "actor-coordinator", DisplayName: "Coordinator"}
+	})
+	reopened, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, reopened.ReopenRequests)
+	issue, err = h.database.store.IssueByID(t.Context(), issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "closed", issue.Status, "external lifecycle never reopens Kata")
+	state = h.readState(t)
+	assert.Equal(t, "complete", state.Roots[0].Root.State, "verified Kata close re-completes an externally reopened root")
+	assert.Len(t, state.Roots, 1)
+	assertExternalCallsContainNoKataOrChildIdentity(
+		t, state,
+		[]string{h.issue.UID, child.UID},
+		[]string{h.issue.ShortID, child.ShortID},
+	)
+	childAfter, err := h.database.store.IssueByID(t.Context(), child.ID)
+	require.NoError(t, err)
+	assert.Equal(t, childBefore.Revision, childAfter.Revision)
+	assert.Equal(t, childBefore.Title, childAfter.Title)
+	assert.Equal(t, childBefore.Body, childAfter.Body)
+	assert.JSONEq(t, string(childBefore.Metadata), string(childAfter.Metadata))
+	childCommentsAfter, err := h.database.store.CommentsByIssue(t.Context(), child.ID)
+	require.NoError(t, err)
+	assert.Equal(t, childCommentsBefore, childCommentsAfter)
+	encodedCalls, err := json.Marshal(state.Calls)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encodedCalls), child.UID)
+	assert.NotContains(t, string(encodedCalls), child.ShortID)
+}
+
+func testE2EPendingPublication(t *testing.T, executable string, backend e2eBackend) {
+	t.Run("crash before reply does not mutate external state", func(t *testing.T) {
+		h := newE2EHarness(t, executable, backend, true)
+		h.createLocalComment(t, "Retry a request that never mutated")
+		h.mutateState(func(current *fakeconnector.State) {
+			current.Behavior.CrashBeforeReply["publish_comment"] = 1
+		})
+		_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+		require.Error(t, err)
+		state := h.readState(t)
+		assert.Zero(t, mutationCount(state, "publish_comment"))
+		require.Len(t, state.Roots[0].Comments, 1, "crash-before must not create a native comment")
+		h.restart(t)
+		_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+		require.NoError(t, err)
+		state = h.readState(t)
+		assert.Equal(t, 1, callCount(state, "publish_comment"))
+		assert.Equal(t, 1, mutationCount(state, "publish_comment"))
+	})
+
+	t.Run("crash after mutation replays the stable operation after restart", func(t *testing.T) {
+		h := newE2EHarness(t, executable, backend, true)
+		local := h.createLocalComment(t, "Publish once after restart")
+		h.mutateState(func(current *fakeconnector.State) {
+			current.Behavior.CrashAfterMutation["publish_comment"] = 1
+		})
+		_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+		require.Error(t, err)
+		binding, readErr := h.database.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+		require.NoError(t, readErr)
+		assert.Equal(t, local.UID, binding.PendingCommentUID)
+		assert.NotEmpty(t, binding.LastError)
+		state := h.readState(t)
+		assert.Equal(t, 1, mutationCount(state, "publish_comment"))
+		require.Len(t, state.Roots[0].Comments, 2)
+
+		h.restart(t)
+		binding, err = h.database.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+		require.NoError(t, err)
+		assert.Equal(t, local.UID, binding.PendingCommentUID, "pending uncertainty must survive store restart")
+		result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+		require.NoError(t, err)
+		assert.Contains(t, eventTypes(result.Events), "issue.external_comment_resolved")
+		binding, err = h.database.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+		require.NoError(t, err)
+		assert.Empty(t, binding.PendingCommentUID)
+		mapping, err := h.database.store.ImportMappingBySource(
+			t.Context(), h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding), "comment", "published-0001",
+		)
+		require.NoError(t, err)
+		require.NotNil(t, mapping.CommentID)
+		assert.Equal(t, local.ID, *mapping.CommentID)
+		state = h.readState(t)
+		assert.Equal(t, 2, callCount(state, "publish_comment"))
+		assert.Equal(t, 1, mutationCount(state, "publish_comment"))
+		require.Len(t, state.Roots[0].Comments, 2)
+	})
+
+	for _, action := range []string{"adopt", "retry", "skip"} {
+		t.Run("manual "+action, func(t *testing.T) {
+			h := newE2EHarness(t, executable, backend, true)
+			h.createLocalComment(t, "Resolve ambiguous publication")
+			h.mutateState(func(current *fakeconnector.State) {
+				current.Behavior.CrashAfterMutation["publish_comment"] = 1
+			})
+			_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+			require.Error(t, err)
+			h.mutateState(func(current *fakeconnector.State) {
+				first := current.Roots[0].Comments[len(current.Roots[0].Comments)-1]
+				first.ID = "published-ambiguous"
+				first.CreatedAt = first.CreatedAt.Add(time.Second)
+				first.UpdatedAt = first.CreatedAt
+				current.Roots[0].Comments = append(current.Roots[0].Comments, first)
+				current.Behavior.Errors["publish_comment"] = connector.Error{
+					Code: "temporary_unavailable", Message: "hold publication pending for manual resolution",
+				}
+			})
+			h.restart(t)
+			_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+			var structured *connector.Error
+			require.ErrorAs(t, err, &structured)
+			assert.Equal(t, "temporary_unavailable", structured.Code)
+			h.mutateState(func(current *fakeconnector.State) {
+				delete(current.Behavior.Errors, "publish_comment")
+			})
+
+			params := ResolvePendingCommentParams{IssueID: h.issue.ID, Actor: "operator", Action: action}
+			if action == "adopt" {
+				params.ExternalCommentID = "published-0001"
+			}
+			resolved, _, err := h.service.ResolvePendingComment(t.Context(), params)
+			require.NoError(t, err)
+			if action == "retry" {
+				assert.NotEmpty(t, resolved.PendingCommentUID)
+			} else {
+				assert.Empty(t, resolved.PendingCommentUID)
+			}
+			before := mutationCount(h.readState(t), "publish_comment")
+			_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+			require.NoError(t, err)
+			binding, readErr := h.database.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+			require.NoError(t, readErr)
+			assert.Empty(t, binding.PendingCommentUID)
+			after := mutationCount(h.readState(t), "publish_comment")
+			assert.Equal(t, before, after)
+		})
+	}
+}
+
+func testE2EPlanningFields(t *testing.T, executable string, backend e2eBackend) {
+	h := newE2EHarness(t, executable, backend, false)
+	_, err := h.service.MapField(t.Context(), MapFieldParams{
+		ConnectorInstance: "example", KataField: "scheduled_on", ExternalField: "field-schedule",
+	})
+	require.NoError(t, err)
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err)
+	assert.Zero(t, first.FieldConflicts)
+	issue, err := h.database.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"scheduled_on":"2026-08-21T09:00:00","timezone":"Europe/Paris"}`, string(issue.Metadata))
+
+	_, err = h.database.store.PatchIssueMetadata(t.Context(), db.PatchIssueMetadataIn{
+		IssueID: h.issue.ID, Actor: "operator", Patch: map[string]json.RawMessage{
+			"scheduled_on": json.RawMessage(`"2026-08-22T09:00:00"`),
+			"timezone":     json.RawMessage(`"Europe/Paris"`),
+		},
+	})
+	require.NoError(t, err)
+	h.mutateState(func(current *fakeconnector.State) {
+		current.Roots[0].Fields["field-schedule"] = connector.FieldValue{
+			Kind: "local_datetime", Value: "2026-08-23T09:00:00", Timezone: "Europe/Paris",
+		}
+	})
+	conflicted, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, conflicted.FieldConflicts)
+	states, err := h.database.store.ExternalFieldStates(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	assert.True(t, states[0].Conflicted)
+
+	_, _, _, err = h.database.store.CloseIssue(
+		t.Context(), h.issue.ID, "done", "verifier", "Verified with field conflict.",
+		[]db.Evidence{{Type: "test", Command: "go test ./internal/rootbridge"}},
+	)
+	require.NoError(t, err)
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FieldConflicts)
+	assert.Equal(t, "complete", h.readState(t).Roots[0].Root.State, "field conflict must not block completion")
+
+	resolved, _, err := h.service.ResolveFieldConflict(t.Context(), h.issue.ID, "scheduled_on", "external", "operator")
+	require.NoError(t, err)
+	assert.False(t, resolved.Conflicted)
+	issue, err = h.database.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"scheduled_on":"2026-08-23T09:00:00","timezone":"Europe/Paris"}`, string(issue.Metadata))
+}
+
+func testE2EPlanningFieldShapes(t *testing.T, executable string, backend e2eBackend) {
+	for _, test := range []struct {
+		kataField string
+		kind      string
+		external  connector.FieldValue
+		metadata  string
+	}{
+		{kataField: "scheduled_on", kind: "date", external: connector.FieldValue{Kind: "date", Value: "2026-08-24"}, metadata: `{"scheduled_on":"2026-08-24"}`},
+		{kataField: "scheduled_on", kind: "local", external: connector.FieldValue{Kind: "local_datetime", Value: "2026-08-24T09:30:00", Timezone: "Europe/Paris"}, metadata: `{"scheduled_on":"2026-08-24T09:30:00","timezone":"Europe/Paris"}`},
+		{kataField: "scheduled_on", kind: "instant", external: connector.FieldValue{Kind: "instant", Value: "2026-08-24T07:30:00.12Z"}, metadata: `{"scheduled_on":"2026-08-24T07:30:00.12Z"}`},
+		{kataField: "deadline_on", kind: "date", external: connector.FieldValue{Kind: "date", Value: "2026-08-25"}, metadata: `{"deadline_on":"2026-08-25"}`},
+		{kataField: "deadline_on", kind: "local", external: connector.FieldValue{Kind: "local_datetime", Value: "2026-08-25T10:45:00", Timezone: "Europe/Paris"}, metadata: `{"deadline_on":"2026-08-25T10:45:00","timezone":"Europe/Paris"}`},
+		{kataField: "deadline_on", kind: "instant", external: connector.FieldValue{Kind: "instant", Value: "2026-08-25T08:45:00.12Z"}, metadata: `{"deadline_on":"2026-08-25T08:45:00.12Z"}`},
+	} {
+		t.Run(test.kataField+" "+test.kind, func(t *testing.T) {
+			h := newE2EHarness(t, executable, backend, false)
+			h.mutateState(func(current *fakeconnector.State) {
+				current.Roots[0].Fields["field-schedule"] = test.external
+			})
+			_, err := h.service.MapField(t.Context(), MapFieldParams{
+				ConnectorInstance: "example", KataField: test.kataField, ExternalField: "field-schedule",
+			})
+			require.NoError(t, err)
+			_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+			require.NoError(t, err)
+			issue, err := h.database.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, err)
+			assert.JSONEq(t, test.metadata, string(issue.Metadata))
+
+			patch := map[string]json.RawMessage{test.kataField: json.RawMessage("null")}
+			if test.kind == "local" {
+				patch["timezone"] = json.RawMessage("null")
+			}
+			_, err = h.database.store.PatchIssueMetadata(t.Context(), db.PatchIssueMetadataIn{
+				IssueID: h.issue.ID, Actor: "operator", Patch: patch,
+			})
+			require.NoError(t, err)
+			_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+			require.NoError(t, err)
+			assert.Equal(t, connector.FieldValue{Kind: "null"}, h.readState(t).Roots[0].Fields["field-schedule"])
+		})
+	}
+}
+
+func testE2ERestorePause(t *testing.T, executable string, backend e2eBackend) {
+	source := newE2EHarness(t, executable, backend, true)
+	var exported bytes.Buffer
+	require.NoError(t, jsonl.Export(t.Context(), source.database.store, &exported, jsonl.ExportOptions{IncludeDeleted: true}))
+
+	target := backend.open(t)
+	t.Cleanup(func() { target.close(t) })
+	require.NoError(t, jsonl.Import(t.Context(), bytes.NewReader(exported.Bytes()), target.store))
+	binding, err := target.store.ExternalRootBindingByIssue(t.Context(), source.issue.ID)
+	require.NoError(t, err)
+	assert.False(t, binding.Enabled)
+	assert.Equal(t, "restore_reconfirmation_required", binding.PausedReason)
+
+	stateBefore := source.readState(t)
+	_, reconciler, service := wireE2E(t, target.store, executable, source.statePath, source.now)
+	_, err = reconciler.Run(t.Context(), binding.ID, RunOptions{Manual: true})
+	require.ErrorIs(t, err, db.ErrExternalRootClaimLost)
+	stateAfter := source.readState(t)
+	assert.Equal(t, len(stateBefore.Calls), len(stateAfter.Calls), "paused restore must not call the connector")
+
+	source.mutateState(func(current *fakeconnector.State) {
+		current.Description.AccountIdentity = "account-drifted"
+	})
+	_, _, err = service.Resume(t.Context(), binding.IssueID, "operator")
+	require.ErrorIs(t, err, ErrConnectorIdentityChanged)
+	stillPaused, err := target.store.ExternalRootBindingByID(t.Context(), binding.ID)
+	require.NoError(t, err)
+	assert.False(t, stillPaused.Enabled)
+
+	source.mutateState(func(current *fakeconnector.State) {
+		current.Description.AccountIdentity = "account-example"
+		current.Description.Capabilities = []connector.Capability{
+			connector.CapabilityFields, connector.CapabilityConditionalFields,
+		}
+	})
+	_, _, err = service.Resume(t.Context(), binding.IssueID, "operator")
+	require.ErrorIs(t, err, ErrCommentPublishingUnavailable)
+	stillPaused, err = target.store.ExternalRootBindingByID(t.Context(), binding.ID)
+	require.NoError(t, err)
+	assert.False(t, stillPaused.Enabled)
+
+	source.mutateState(func(current *fakeconnector.State) {
+		current.Description.Capabilities = []connector.Capability{
+			connector.CapabilityFields, connector.CapabilityConditionalFields, connector.CapabilityPublishComment,
+		}
+	})
+	resumed, _, err := service.Resume(t.Context(), binding.IssueID, "operator")
+	require.NoError(t, err)
+	assert.True(t, resumed.Enabled)
+	assert.Empty(t, resumed.PausedReason)
+	_, err = reconciler.Run(t.Context(), binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err)
+}
+
+func testE2EFailureIsolation(t *testing.T, executable string, backend e2eBackend) {
+	h := newE2EHarness(t, executable, backend, false)
+	h.mutateState(func(current *fakeconnector.State) {
+		current.Behavior.CrashBeforeReply["read_root"] = 1
+	})
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.ErrorIs(t, err, ErrConnectorCall)
+	require.ErrorIs(t, err, connectorclient.ErrProcessFailure)
+	assert.Equal(t, "external connector process failed", err.Error())
+	binding, readErr := h.database.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "external connector process failed", binding.LastError)
+	assert.NotContains(t, binding.LastError, h.statePath)
+	h.restart(t)
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err, "one connector process crash must not stop later reconciliation")
+
+	h.mutateState(func(current *fakeconnector.State) {
+		current.Behavior.ResponseProtocol = "unsupported.connector.protocol"
+	})
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.ErrorIs(t, err, ErrConnectorCall)
+	require.ErrorIs(t, err, connectorclient.ErrProtocolFailure)
+	assert.Equal(t, "external connector protocol failed", err.Error())
+	binding, readErr = h.database.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "external connector protocol failed", binding.LastError)
+	assert.NotContains(t, binding.LastError, "unsupported.connector.protocol")
+	h.mutateState(func(current *fakeconnector.State) {
+		current.Behavior.ResponseProtocol = ""
+		current.Behavior.Errors["read_root"] = connector.Error{
+			Code: "temporary_unavailable", Message: "synthetic external failure",
+		}
+	})
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	var structured *connector.Error
+	require.ErrorAs(t, err, &structured)
+	assert.Equal(t, "temporary_unavailable", structured.Code)
+	assert.Equal(t, "synthetic external failure", structured.Message)
+	h.mutateState(func(current *fakeconnector.State) {
+		delete(current.Behavior.Errors, "read_root")
+	})
+	h.restart(t)
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.NoError(t, err)
+	binding, err = h.database.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	assert.Empty(t, binding.ClaimToken)
+	assert.NotNil(t, binding.LastSuccessAt)
+}
+
+type e2eBackend struct {
+	name string
+	open func(*testing.T) *e2eDatabase
+}
+
+type e2eDatabase struct {
+	store   db.Storage
+	reopen  func(context.Context) (db.Storage, error)
+	cleanup func(context.Context) error
+}
+
+func (d *e2eDatabase) restart(t *testing.T) {
+	t.Helper()
+	require.NoError(t, closeStorage(d.store))
+	store, err := d.reopen(t.Context())
+	require.NoError(t, err)
+	d.store = store
+}
+
+func (d *e2eDatabase) close(t *testing.T) {
+	t.Helper()
+	if d.store != nil {
+		require.NoError(t, closeStorage(d.store))
+		d.store = nil
+	}
+	if d.cleanup != nil {
+		require.NoError(t, d.cleanup(context.Background()))
+		d.cleanup = nil
+	}
+}
+
+func closeStorage(store db.Storage) error {
+	if closer, ok := store.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+func openSQLiteE2E(t *testing.T) *e2eDatabase {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kata.db")
+	open := func(ctx context.Context) (db.Storage, error) { return sqlitestore.Open(ctx, path) }
+	store, err := open(t.Context())
+	require.NoError(t, err)
+	return &e2eDatabase{store: store, reopen: open}
+}
+
+func TestPostgresE2ESchemaNamesAndQuoting(t *testing.T) {
+	const total = 512
+	seen := make(map[string]struct{}, total)
+	for range total {
+		name, err := newPostgresE2ESchema()
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(name, "rootbridge_e2e_"))
+		require.Len(t, name, len("rootbridge_e2e_")+32)
+		_, err = hex.DecodeString(strings.TrimPrefix(name, "rootbridge_e2e_"))
+		require.NoError(t, err)
+		_, duplicate := seen[name]
+		require.False(t, duplicate, "duplicate PostgreSQL schema %q", name)
+		seen[name] = struct{}{}
+	}
+	assert.Equal(t, `"rootbridge_e2e_example"`, quotePostgresIdentifier("rootbridge_e2e_example"))
+	assert.Equal(t, `"rootbridge_e2e_""example"`, quotePostgresIdentifier(`rootbridge_e2e_"example`))
+}
+
+func newPostgresE2ESchema() (string, error) {
+	var random [16]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return "", fmt.Errorf("generate PostgreSQL test schema suffix: %w", err)
+	}
+	return "rootbridge_e2e_" + hex.EncodeToString(random[:]), nil
+}
+
+func quotePostgresIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
+func openPostgresE2E(t *testing.T, dsn string) *e2eDatabase {
+	t.Helper()
+	schema, err := newPostgresE2ESchema()
+	require.NoError(t, err)
+	open := func(ctx context.Context) (db.Storage, error) {
+		return pgstore.OpenWithConfig(ctx, dsn, pgstore.Config{Schema: schema, SchemaMode: pgstore.SchemaModeBootstrap})
+	}
+	store, err := open(t.Context())
+	require.NoError(t, err)
+	cleanup := func(ctx context.Context) error {
+		admin, err := sql.Open("pgx", dsn)
+		if err != nil {
+			return fmt.Errorf("open PostgreSQL cleanup connection: %w", err)
+		}
+		defer func() { _ = admin.Close() }()
+		if _, err := admin.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+quotePostgresIdentifier(schema)+` CASCADE`); err != nil {
+			return fmt.Errorf("drop test-owned PostgreSQL schema: %w", err)
+		}
+		return nil
+	}
+	return &e2eDatabase{store: store, reopen: open, cleanup: cleanup}
+}
+
+type e2eHarness struct {
+	t          *testing.T
+	executable string
+	backend    e2eBackend
+	database   *e2eDatabase
+	statePath  string
+	base       time.Time
+	now        time.Time
+	registry   *Registry
+	reconciler *Reconciler
+	service    *Service
+	project    db.Project
+	issue      db.Issue
+	binding    db.ExternalRootBinding
+}
+
+func newE2EHarness(t *testing.T, executable string, backend e2eBackend, publish bool) *e2eHarness {
+	t.Helper()
+	base := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	statePath := filepath.Join(t.TempDir(), "connector-state.json")
+	writeE2EState(t, statePath, initialE2EState(base))
+	database := backend.open(t)
+	h := &e2eHarness{
+		t: t, executable: executable, backend: backend, database: database,
+		statePath: statePath, base: base, now: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC),
+	}
+	t.Cleanup(func() { database.close(t) })
+	h.wire(t)
+	project, err := database.store.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := database.store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "Local title", Body: "Local body", Author: "operator",
+	})
+	require.NoError(t, err)
+	binding, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: project.ID, IssueID: issue.ID, ConnectorInstance: "example",
+		Locator: "fixture-root", Actor: "operator", PublishComments: publish,
+	})
+	require.NoError(t, err)
+	h.project, h.issue, h.binding = project, issue, binding
+	return h
+}
+
+func (h *e2eHarness) wire(t *testing.T) {
+	t.Helper()
+	h.registry, h.reconciler, h.service = wireE2E(t, h.database.store, h.executable, h.statePath, h.now)
+}
+
+func wireE2E(
+	t *testing.T,
+	store db.Storage,
+	executable string,
+	statePath string,
+	now time.Time,
+) (*Registry, *Reconciler, *Service) {
+	t.Helper()
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "example", Command: executable, Args: []string{"--state", statePath}, TimeoutSeconds: 10,
+	}}, nil)
+	require.NoError(t, err)
+	reconciler := NewReconciler(store, registry, ReconcilerConfig{Now: func() time.Time { return now }})
+	service := NewService(store, registry, func(ctx context.Context, bindingID int64, claimToken string) ([]db.Event, error) {
+		result, err := reconciler.Run(ctx, bindingID, RunOptions{ClaimToken: claimToken})
+		return result.Events, err
+	})
+	return registry, reconciler, service
+}
+
+func (h *e2eHarness) restart(t *testing.T) {
+	t.Helper()
+	h.database.restart(t)
+	h.wire(t)
+}
+
+func (h *e2eHarness) createLocalComment(t *testing.T, body string) db.Comment {
+	t.Helper()
+	comment, _, err := h.database.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: h.issue.ID, Author: "operator", Body: body,
+	})
+	require.NoError(t, err)
+	return comment
+}
+
+func (h *e2eHarness) readState(t *testing.T) fakeconnector.State {
+	t.Helper()
+	current, err := fakeconnector.Load(h.statePath)
+	require.NoError(t, err)
+	require.NoError(t, fakeconnector.AuditExternalSurface(
+		current, "root-example", []string{h.issue.UID}, []string{h.issue.ShortID},
+	))
+	return current
+}
+
+func (h *e2eHarness) mutateState(apply func(*fakeconnector.State)) {
+	h.t.Helper()
+	current := h.readState(h.t)
+	if current.Behavior.CrashBeforeReply == nil {
+		current.Behavior.CrashBeforeReply = make(map[string]int)
+	}
+	if current.Behavior.CrashAfterMutation == nil {
+		current.Behavior.CrashAfterMutation = make(map[string]int)
+	}
+	if current.Behavior.Errors == nil {
+		current.Behavior.Errors = make(map[string]connector.Error)
+	}
+	apply(&current)
+	writeE2EState(h.t, h.statePath, current)
+}
+
+func initialE2EState(base time.Time) fakeconnector.State {
+	return fakeconnector.State{
+		Description: connector.Description{
+			ConnectorID: "example.connector", DisplayName: "Example Connector", Protocol: connector.ProtocolVersion,
+			Capabilities: []connector.Capability{
+				connector.CapabilityFields, connector.CapabilityConditionalFields, connector.CapabilityPublishComment,
+			},
+			ConfigSchema: []byte(`{"type":"object","additionalProperties":false}`), SelfActorID: "actor-self",
+			AccountIdentity: "account-example",
+		},
+		Roots: []fakeconnector.StoredRoot{{
+			Locator: "fixture-root",
+			Root: connector.Root{
+				Key: "root-example", IdentityKey: "account-example", Title: "External title", Body: "External body",
+				State: "open", Revision: "revision-initial", UpdatedAt: base, ObservedAt: base,
+			},
+			Comments: []connector.Comment{{
+				ID: "comment-before-bind", Revision: "revision-comment-before-bind", Body: "Historical external note",
+				Author:    connector.Actor{ID: "actor-history", DisplayName: "Historical Reviewer"},
+				CreatedAt: base.Add(-time.Minute), UpdatedAt: base.Add(-time.Minute),
+			}},
+			Fields: map[string]connector.FieldValue{
+				"field-schedule": {Kind: "local_datetime", Value: "2026-08-21T09:00:00", Timezone: "Europe/Paris"},
+			},
+		}},
+		Fields: []connector.FieldDescriptor{{
+			ID: "field-schedule", DisplayName: "Schedule", AcceptedKinds: []string{"date", "instant", "local_datetime"},
+			Nullable: true, Writable: true, SchemaRevision: "schema-1",
+		}},
+		Behavior: fakeconnector.Behavior{
+			CrashBeforeReply: make(map[string]int), CrashAfterMutation: make(map[string]int),
+			Errors: make(map[string]connector.Error),
+		},
+	}
+}
+
+func writeE2EState(t *testing.T, path string, current fakeconnector.State) {
+	t.Helper()
+	require.NoError(t, fakeconnector.Write(path, current))
+}
+
+func buildFakeConnector(t *testing.T) string {
+	t.Helper()
+	executable := filepath.Join(t.TempDir(), "fake-connector")
+	if runtime.GOOS == "windows" {
+		executable += ".exe"
+	}
+	command := exec.Command("go", "build", "-o", executable, "../connector/fakeconnector/cmd") // #nosec G204 -- fixed test tool and package; only the test-owned output path varies.
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	return executable
+}
+
+func mutationCount(current fakeconnector.State, method string) int {
+	count := 0
+	for _, mutation := range current.Mutations {
+		if mutation.Method == method {
+			count++
+		}
+	}
+	return count
+}
+
+func callCount(current fakeconnector.State, method string) int {
+	count := 0
+	for _, call := range current.Calls {
+		if call.Method == method {
+			count++
+		}
+	}
+	return count
+}
+
+func assertExternalCallsContainNoKataOrChildIdentity(
+	t *testing.T,
+	current fakeconnector.State,
+	longUIDs []string,
+	shortIDs []string,
+) {
+	t.Helper()
+	require.NotEmpty(t, current.Calls, "fixture must record the executable request surface")
+	require.NoError(t, fakeconnector.AuditExternalSurface(current, "root-example", longUIDs, shortIDs))
+}

--- a/internal/rootbridge/fields.go
+++ b/internal/rootbridge/fields.go
@@ -1,0 +1,195 @@
+package rootbridge
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+type invalidExternalFieldReadError struct {
+	cause error
+}
+
+func (e *invalidExternalFieldReadError) Error() string { return e.cause.Error() }
+func (e *invalidExternalFieldReadError) Unwrap() error { return e.cause }
+
+func isInvalidExternalFieldRead(err error) bool {
+	var invalid *invalidExternalFieldReadError
+	return errors.As(err, &invalid)
+}
+
+// MergeAction describes the reconciliation work needed for one mapped field.
+type MergeAction string
+
+const (
+	// MergeAccept records a shared value without writing either side.
+	MergeAccept MergeAction = "accept"
+	// MergeWriteKata applies the external value to Kata.
+	MergeWriteKata MergeAction = "write_kata"
+	// MergeWriteExternal applies the Kata value to the external root.
+	MergeWriteExternal MergeAction = "write_external"
+	// MergeConflict records divergent changes for explicit resolution.
+	MergeConflict MergeAction = "conflict"
+)
+
+// MergeDecision retains the canonical values used to make a field decision.
+// A conflict deliberately leaves Baseline unchanged while retaining both
+// candidates for explicit resolution.
+type MergeDecision struct {
+	Action   MergeAction
+	Baseline connector.FieldValue
+	Kata     connector.FieldValue
+	External connector.FieldValue
+}
+
+// DecideInitialFieldMerge reconciles a field before a stored baseline exists.
+func DecideInitialFieldMerge(kata, external connector.FieldValue) MergeDecision {
+	kata = canonicalForMerge(kata)
+	external = canonicalForMerge(external)
+	if fieldValuesEqual(kata, external) {
+		return MergeDecision{Action: MergeAccept, Baseline: kata, Kata: kata, External: external}
+	}
+	if isNull(kata) {
+		return MergeDecision{Action: MergeWriteKata, Baseline: external, Kata: kata, External: external}
+	}
+	if isNull(external) {
+		return MergeDecision{Action: MergeWriteExternal, Baseline: kata, Kata: kata, External: external}
+	}
+	return MergeDecision{Action: MergeConflict, Baseline: nullFieldValue(), Kata: kata, External: external}
+}
+
+// DecideFieldMerge compares the two current values with their stored baseline.
+func DecideFieldMerge(baseline, kata, external connector.FieldValue) MergeDecision {
+	baseline = canonicalForMerge(baseline)
+	kata = canonicalForMerge(kata)
+	external = canonicalForMerge(external)
+	if fieldValuesEqual(kata, external) {
+		return MergeDecision{Action: MergeAccept, Baseline: kata, Kata: kata, External: external}
+	}
+	if fieldValuesEqual(kata, baseline) {
+		return MergeDecision{Action: MergeWriteKata, Baseline: external, Kata: kata, External: external}
+	}
+	if fieldValuesEqual(external, baseline) {
+		return MergeDecision{Action: MergeWriteExternal, Baseline: kata, Kata: kata, External: external}
+	}
+	return MergeDecision{Action: MergeConflict, Baseline: baseline, Kata: kata, External: external}
+}
+
+func canonicalForMerge(value connector.FieldValue) connector.FieldValue {
+	canonical, err := canonicalFieldValue(value)
+	if err != nil {
+		return value
+	}
+	return canonical
+}
+
+func fieldValuesEqual(left, right connector.FieldValue) bool {
+	leftJSON, err := json.Marshal(left)
+	if err != nil {
+		return false
+	}
+	rightJSON, err := json.Marshal(right)
+	if err != nil {
+		return false
+	}
+	return string(leftJSON) == string(rightJSON)
+}
+
+func isNull(value connector.FieldValue) bool {
+	return value.Kind == "null"
+}
+
+func validateLiveFieldDescriptor(
+	codec FieldCodec,
+	mapping db.ExternalFieldMapping,
+	fields []connector.FieldDescriptor,
+) (connector.FieldDescriptor, error) {
+	matches := make([]connector.FieldDescriptor, 0, 1)
+	for _, field := range fields {
+		if field.ID == mapping.ExternalFieldID {
+			matches = append(matches, field)
+		}
+	}
+	if len(matches) != 1 {
+		return connector.FieldDescriptor{}, fmt.Errorf("mapped external field identity changed")
+	}
+	descriptor := matches[0]
+	if err := codec.ValidateExternalDescriptor(descriptor); err != nil {
+		return connector.FieldDescriptor{}, err
+	}
+	liveKinds := append([]string(nil), descriptor.AcceptedKinds...)
+	sort.Strings(liveKinds)
+	mappedKinds := append([]string(nil), mapping.AcceptedKinds...)
+	sort.Strings(mappedKinds)
+	if descriptor.SchemaRevision != mapping.SchemaRevision || descriptor.Nullable != mapping.Nullable ||
+		descriptor.Writable != mapping.Writable || !stringSlicesEqual(liveKinds, mappedKinds) {
+		return connector.FieldDescriptor{}, fmt.Errorf("mapped external field schema changed")
+	}
+	return descriptor, nil
+}
+
+func canonicalMappedFieldValue(
+	value connector.FieldValue,
+	mapping db.ExternalFieldMapping,
+) (connector.FieldValue, error) {
+	if value.Kind == "" {
+		return connector.FieldValue{}, fmt.Errorf("mapped external field kind is required")
+	}
+	canonical, err := canonicalFieldValue(value)
+	if err != nil {
+		return connector.FieldValue{}, err
+	}
+	if canonical.Kind == fieldKindNull {
+		if !mapping.Nullable {
+			return connector.FieldValue{}, fmt.Errorf("mapped external field is not nullable")
+		}
+		return canonical, nil
+	}
+	if slices.Contains(mapping.AcceptedKinds, canonical.Kind) {
+		return canonical, nil
+	}
+	return connector.FieldValue{}, fmt.Errorf("mapped external field does not accept %q", canonical.Kind)
+}
+
+func decodeCanonicalStoredFieldValue(
+	raw json.RawMessage,
+	mapping db.ExternalFieldMapping,
+) (connector.FieldValue, bool, error) {
+	if len(raw) == 0 {
+		return connector.FieldValue{}, false, nil
+	}
+	var value connector.FieldValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return connector.FieldValue{}, false, err
+	}
+	canonical, err := canonicalMappedFieldValue(value, mapping)
+	if err != nil {
+		return connector.FieldValue{}, false, err
+	}
+	return canonical, true, nil
+}
+
+func marshalCanonicalFieldValue(value connector.FieldValue) (json.RawMessage, error) {
+	canonical, err := canonicalFieldValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(canonical)
+}
+
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/rootbridge/fields_test.go
+++ b/internal/rootbridge/fields_test.go
@@ -1,0 +1,88 @@
+package rootbridge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func TestDecideFieldMerge(t *testing.T) {
+	cases := []struct {
+		name                     string
+		baseline, kata, external connector.FieldValue
+		want                     MergeAction
+	}{
+		{"unchanged", date("2026-08-20"), date("2026-08-20"), date("2026-08-20"), MergeAccept},
+		{"kata only", date("2026-08-20"), date("2026-08-21"), date("2026-08-20"), MergeWriteExternal},
+		{"external only", date("2026-08-20"), date("2026-08-20"), date("2026-08-22"), MergeWriteKata},
+		{"same change", date("2026-08-20"), date("2026-08-22"), date("2026-08-22"), MergeAccept},
+		{"divergent", date("2026-08-20"), date("2026-08-21"), date("2026-08-22"), MergeConflict},
+		{"clear versus change", date("2026-08-20"), nullValue(), date("2026-08-22"), MergeConflict},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, DecideFieldMerge(tc.baseline, tc.kata, tc.external).Action)
+		})
+	}
+}
+
+func TestDecideInitialFieldMerge(t *testing.T) {
+	cases := []struct {
+		name           string
+		kata, external connector.FieldValue
+		want           MergeAction
+	}{
+		{"both empty", connector.FieldValue{}, nullValue(), MergeAccept},
+		{"same date", date("2026-08-20"), date("2026-08-20"), MergeAccept},
+		{"kata only", date("2026-08-20"), nullValue(), MergeWriteExternal},
+		{"external only", nullValue(), date("2026-08-20"), MergeWriteKata},
+		{"different non-empty", date("2026-08-20"), date("2026-08-21"), MergeConflict},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, DecideInitialFieldMerge(tc.kata, tc.external).Action)
+		})
+	}
+}
+
+func TestDecideFieldMergeKeepsBaselineAndCandidatesOnConflict(t *testing.T) {
+	baseline := date("2026-08-20")
+	kata := date("2026-08-21")
+	external := date("2026-08-22")
+
+	got := DecideFieldMerge(baseline, kata, external)
+
+	assert.Equal(t, MergeConflict, got.Action)
+	assert.Equal(t, baseline, got.Baseline)
+	assert.Equal(t, kata, got.Kata)
+	assert.Equal(t, external, got.External)
+}
+
+func TestLiveFieldDescriptorComparisonTreatsAcceptedKindsAsASet(t *testing.T) {
+	mapping := db.ExternalFieldMapping{
+		ExternalFieldID: "start-date", SchemaRevision: "schema-1",
+		AcceptedKinds: []string{fieldKindDate, fieldKindInstant, fieldKindLocalDateTime},
+		Nullable:      true, Writable: true,
+	}
+	descriptor := connector.FieldDescriptor{
+		ID: "start-date", DisplayName: "Start date", SchemaRevision: "schema-1",
+		AcceptedKinds: []string{fieldKindLocalDateTime, fieldKindDate, fieldKindInstant},
+		Nullable:      true, Writable: true,
+	}
+
+	got, err := validateLiveFieldDescriptor(fieldCodecs["scheduled_on"], mapping, []connector.FieldDescriptor{descriptor})
+
+	require.NoError(t, err)
+	assert.Equal(t, descriptor, got)
+}
+
+func date(value string) connector.FieldValue {
+	return connector.FieldValue{Kind: "date", Value: value}
+}
+
+func nullValue() connector.FieldValue {
+	return connector.FieldValue{Kind: "null"}
+}

--- a/internal/rootbridge/reconciler.go
+++ b/internal/rootbridge/reconciler.go
@@ -1,0 +1,1084 @@
+package rootbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/internal/db"
+	katauid "go.kenn.io/kata/internal/uid"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+const (
+	defaultExternalRootClaimStaleAfter = db.ExternalRootClaimStaleAfter
+	externalRootFinalizationTimeout    = 10 * time.Second
+)
+
+// ReconcilerConfig supplies clock, claim, and retry policies.
+type ReconcilerConfig struct {
+	Now             func() time.Time
+	ClaimStaleAfter time.Duration
+	RetryAt         func(db.ExternalRootBinding, time.Time) time.Time
+}
+
+// Reconciler synchronizes one durable external-root binding at a time.
+type Reconciler struct {
+	store           db.Storage
+	registry        *Registry
+	now             func() time.Time
+	claimStaleAfter time.Duration
+	retryAt         func(db.ExternalRootBinding, time.Time) time.Time
+}
+
+type externalRootClaimLease struct {
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	done   <-chan error
+	once   sync.Once
+	err    error
+}
+
+func (l *externalRootClaimLease) stop() error {
+	if l == nil {
+		return nil
+	}
+	l.once.Do(func() {
+		l.cancel(nil)
+		l.err = <-l.done
+	})
+	return l.err
+}
+
+// RunResult summarizes one reconciliation and retains its committed events.
+type RunResult struct {
+	RootUpdated        bool       `json:"root_updated"`
+	CommentsCreated    int        `json:"comments_created"`
+	CommentsEdited     int        `json:"comments_edited"`
+	FieldConflicts     int        `json:"field_conflicts"`
+	CompletionRequests int        `json:"completion_requests"`
+	ReopenRequests     int        `json:"reopen_requests"`
+	Paused             bool       `json:"paused"`
+	Events             []db.Event `json:"events,omitempty"`
+	eventSink          func(db.Event)
+}
+
+func (r *RunResult) retainEvents(events ...db.Event) {
+	for _, event := range events {
+		if event.ID == 0 {
+			continue
+		}
+		if r.eventSink != nil {
+			r.eventSink(event)
+		}
+		r.Events = append(r.Events, event)
+	}
+}
+
+type reconcileSnapshot struct {
+	binding                  db.ExternalRootBinding
+	issue                    db.Issue
+	description              connector.Description
+	client                   connectorclient.Client
+	root                     connector.Root
+	comments                 []connector.Comment
+	kataComments             []db.Comment
+	mappings                 []db.ImportMapping
+	publishedCommentMappings []db.ImportMapping
+	commentIdentityFrontier  bool
+	seenCommentRevisions     map[string]bool
+	mappedComments           map[int64]bool
+	fieldMappings            []db.ExternalFieldMapping
+	fieldStates              []db.ExternalFieldState
+	fieldIssue               db.Issue
+	coordinatedTimezone      string
+	publishReady             bool
+}
+
+type pauseExternalRootError struct {
+	reason string
+	cause  error
+}
+
+func (e *pauseExternalRootError) Error() string { return e.cause.Error() }
+func (e *pauseExternalRootError) Unwrap() error { return e.cause }
+
+// NewReconciler constructs an external-root reconciler.
+func NewReconciler(store db.Storage, registry *Registry, config ReconcilerConfig) *Reconciler {
+	now := config.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	claimStaleAfter := config.ClaimStaleAfter
+	if claimStaleAfter <= 0 {
+		claimStaleAfter = defaultExternalRootClaimStaleAfter
+	}
+	retryAt := config.RetryAt
+	if retryAt == nil {
+		retryAt = func(_ db.ExternalRootBinding, now time.Time) time.Time { return now }
+	}
+	return &Reconciler{store: store, registry: registry, now: now, claimStaleAfter: claimStaleAfter, retryAt: retryAt}
+}
+
+// RunOptions selects the claim path and optional immediate event delivery for
+// one reconciliation. The zero value acquires the ordinary due-time claim.
+type RunOptions struct {
+	Manual     bool
+	ClaimToken string
+	EventSink  func(db.Event)
+}
+
+// Run reconciles one binding through the claim path selected by options.
+// Manual bypasses only the durable due time. ClaimToken enters with a claim
+// already committed by the caller, as required by the bind path.
+func (r *Reconciler) Run(ctx context.Context, bindingID int64, options RunOptions) (RunResult, error) {
+	if strings.TrimSpace(options.ClaimToken) != "" {
+		return r.runClaimedByID(ctx, bindingID, options.ClaimToken, options.EventSink)
+	}
+	if options.Manual {
+		return r.runManual(ctx, bindingID, options.EventSink)
+	}
+	return r.runOnce(ctx, bindingID, options.EventSink)
+}
+
+func (r *Reconciler) runOnce(
+	ctx context.Context,
+	bindingID int64,
+	eventSink func(db.Event),
+) (RunResult, error) {
+	if r == nil || r.store == nil {
+		return RunResult{}, errors.New("external root reconciler storage is unavailable")
+	}
+	token, err := katauid.New()
+	if err != nil {
+		return RunResult{}, fmt.Errorf("generate external root claim token: %w", err)
+	}
+	now := r.timestamp()
+	binding, claimed, err := r.store.ClaimExternalRootBinding(
+		ctx, bindingID, token, now, now.Add(-r.claimStaleAfter),
+	)
+	if err != nil || !claimed {
+		return RunResult{}, err
+	}
+	return r.runClaimed(ctx, binding, token, eventSink)
+}
+
+func (r *Reconciler) runManual(
+	ctx context.Context,
+	bindingID int64,
+	eventSink func(db.Event),
+) (RunResult, error) {
+	if r == nil || r.store == nil {
+		return RunResult{}, errors.New("external root reconciler storage is unavailable")
+	}
+	token, err := katauid.New()
+	if err != nil {
+		return RunResult{}, fmt.Errorf("generate external root claim token: %w", err)
+	}
+	now := r.timestamp()
+	binding, claimed, err := r.store.ClaimExternalRootBindingForManualReconcile(
+		ctx, bindingID, token, now, now.Add(-r.claimStaleAfter),
+	)
+	if err != nil || !claimed {
+		if err == nil {
+			err = db.ErrExternalRootClaimLost
+		}
+		return RunResult{}, err
+	}
+	return r.runClaimed(ctx, binding, token, eventSink)
+}
+
+func (r *Reconciler) runClaimedByID(
+	ctx context.Context,
+	bindingID int64,
+	claimToken string,
+	eventSink func(db.Event),
+) (RunResult, error) {
+	if r == nil || r.store == nil {
+		return RunResult{}, errors.New("external root reconciler storage is unavailable")
+	}
+	validationCtx, validationCancel := r.finalizationContext(ctx)
+	binding, err := r.store.ExternalRootBindingByID(validationCtx, bindingID)
+	validationCancel()
+	if err != nil {
+		return RunResult{}, err
+	}
+	if strings.TrimSpace(claimToken) == "" || binding.ClaimToken != claimToken || !binding.Active || !binding.Enabled {
+		return RunResult{}, db.ErrExternalRootClaimLost
+	}
+	return r.runClaimed(ctx, binding, claimToken, eventSink)
+}
+
+func (r *Reconciler) runClaimed(
+	ctx context.Context,
+	binding db.ExternalRootBinding,
+	claimToken string,
+	eventSink func(db.Event),
+) (result RunResult, returnErr error) {
+	result.eventSink = eventSink
+	parentCtx := ctx
+	claimHeld := true
+	var lease *externalRootClaimLease
+	defer func() {
+		if lease != nil {
+			_ = lease.stop()
+		}
+		if recovered := recover(); recovered != nil {
+			panicErr := errors.New("external connector panicked")
+			if leaseErr := lease.stop(); leaseErr != nil {
+				panicErr = errors.Join(panicErr, leaseErr)
+			}
+			returnErr = errors.Join(returnErr, r.recordFailure(parentCtx, binding, claimToken, panicErr, nil, &claimHeld))
+		}
+		if !claimHeld {
+			return
+		}
+		finalizeCtx, finalizeCancel := r.finalizationContext(parentCtx)
+		defer finalizeCancel()
+		_, releaseErr := r.store.ReleaseExternalRootClaim(finalizeCtx, binding.ID, claimToken)
+		if releaseErr != nil && !errors.Is(releaseErr, db.ErrExternalRootClaimLost) {
+			returnErr = errors.Join(returnErr, fmt.Errorf("release external root claim: %w", releaseErr))
+		}
+	}()
+	var err error
+	lease, err = r.startClaimLease(ctx, binding.ID, claimToken)
+	if err != nil {
+		return result, r.recordFailure(parentCtx, binding, claimToken, err, nil, &claimHeld)
+	}
+	ctx = lease.ctx
+	finishLease := func(cause error) error {
+		if leaseErr := lease.stop(); leaseErr != nil {
+			return errors.Join(cause, leaseErr)
+		}
+		return cause
+	}
+	fail := func(cause error, verifiedRoot *connector.Root) error {
+		return r.recordFailure(parentCtx, binding, claimToken, finishLease(cause), verifiedRoot, &claimHeld)
+	}
+
+	snapshot, err := r.readCurrent(ctx, binding, claimToken)
+	if err != nil {
+		if pauseErr, ok := errors.AsType[*pauseExternalRootError](err); ok {
+			err = finishLease(err)
+			finalizeCtx, finalizeCancel := r.finalizationContext(parentCtx)
+			_, event, pauseWriteErr := r.store.PauseExternalRootBinding(finalizeCtx, db.ExternalRootActionParams{
+				BindingID: binding.ID, ClaimToken: claimToken,
+				Actor: integrationActor(binding), Reason: pauseErr.reason,
+			})
+			finalizeCancel()
+			if pauseWriteErr != nil {
+				return result, r.recordFailure(parentCtx, binding, claimToken, errors.Join(err, pauseWriteErr), nil, &claimHeld)
+			}
+			claimHeld = false
+			result.Paused = true
+			result.retainEvents(event)
+			return result, nil
+		}
+		return result, fail(err, nil)
+	}
+
+	result, err = r.applyInbound(ctx, snapshot, claimToken, result)
+	if err != nil {
+		return result, fail(err, nil)
+	}
+	result, err = r.applyFields(ctx, &snapshot, claimToken, result)
+	if err != nil {
+		return result, fail(err, nil)
+	}
+	result, outboundErr := r.applyOutboundComments(ctx, snapshot, claimToken, result)
+	if outboundErr != nil {
+		return result, fail(outboundErr, nil)
+	}
+	result, completionErr := r.completeExternal(ctx, &snapshot, claimToken, result)
+	if completionErr != nil {
+		var verifiedRoot *connector.Root
+		if externalRootComplete(snapshot.root.State) {
+			verifiedRoot = &snapshot.root
+		}
+		return result, fail(completionErr, verifiedRoot)
+	}
+	if leaseErr := finishLease(nil); leaseErr != nil {
+		return result, r.recordFailure(parentCtx, binding, claimToken, leaseErr, &snapshot.root, &claimHeld)
+	}
+	now := r.timestamp()
+	finalizeCtx, finalizeCancel := r.finalizationContext(parentCtx)
+	_, err = r.store.RecordExternalRootSuccess(finalizeCtx, db.ExternalRootSuccessParams{
+		BindingID: binding.ID, ClaimToken: claimToken, At: now, NextAttemptAt: now,
+		ExternalState: snapshot.root.State, ExternalRevision: snapshot.root.Revision,
+	})
+	finalizeCancel()
+	if err != nil {
+		return result, r.recordFailure(parentCtx, binding, claimToken, err, &snapshot.root, &claimHeld)
+	}
+	claimHeld = false
+	return result, nil
+}
+
+func (r *Reconciler) startClaimLease(
+	ctx context.Context,
+	bindingID int64,
+	claimToken string,
+) (*externalRootClaimLease, error) {
+	return startExternalRootClaimLease(
+		ctx, r.store, bindingID, claimToken, r.claimStaleAfter, r.timestamp,
+	)
+}
+
+func startExternalRootClaimLease(
+	ctx context.Context,
+	store db.Storage,
+	bindingID int64,
+	claimToken string,
+	staleAfter time.Duration,
+	now func() time.Time,
+) (*externalRootClaimLease, error) {
+	if _, err := store.RenewExternalRootClaim(ctx, bindingID, claimToken, now()); err != nil {
+		return nil, err
+	}
+	leaseCtx, cancel := context.WithCancelCause(ctx)
+	done := make(chan error, 1)
+	interval := staleAfter / 3
+	if interval <= 0 {
+		interval = time.Millisecond
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-leaseCtx.Done():
+				done <- nil
+				return
+			case <-ticker.C:
+				if _, err := store.RenewExternalRootClaim(
+					leaseCtx, bindingID, claimToken, now(),
+				); err != nil {
+					if leaseCtx.Err() != nil {
+						done <- nil
+						return
+					}
+					renewErr := fmt.Errorf("renew external root claim: %w", err)
+					cancel(renewErr)
+					done <- renewErr
+					return
+				}
+			}
+		}
+	}()
+	return &externalRootClaimLease{ctx: leaseCtx, cancel: cancel, done: done}, nil
+}
+
+func (r *Reconciler) renewBeforeExternalCall(
+	ctx context.Context,
+	bindingID int64,
+	claimToken string,
+) error {
+	return renewExternalRootClaimBeforeCall(ctx, r.store, bindingID, claimToken, r.timestamp())
+}
+
+func renewExternalRootClaimBeforeCall(
+	ctx context.Context,
+	store db.Storage,
+	bindingID int64,
+	claimToken string,
+	now time.Time,
+) error {
+	_, err := store.RenewExternalRootClaim(ctx, bindingID, claimToken, now)
+	return err
+}
+
+func (r *Reconciler) completeExternal(
+	ctx context.Context,
+	snapshot *reconcileSnapshot,
+	claimToken string,
+	result RunResult,
+) (RunResult, error) {
+	if snapshot.issue.Status != "closed" || !snapshot.binding.CompleteExternal || externalRootComplete(snapshot.root.State) {
+		return result, nil
+	}
+	issue, err := r.store.IssueByID(ctx, snapshot.binding.IssueID)
+	if err != nil {
+		return result, err
+	}
+	if issue.Status != "closed" {
+		return result, nil
+	}
+	binding, err := r.store.ExternalRootBindingByID(ctx, snapshot.binding.ID)
+	if err != nil {
+		return result, err
+	}
+	if !sameExternalRootCompletionAuthority(snapshot.binding, binding, claimToken) {
+		return result, db.ErrExternalRootClaimLost
+	}
+	if !binding.CompleteExternal {
+		return result, nil
+	}
+	if err := r.renewBeforeExternalCall(ctx, binding.ID, claimToken); err != nil {
+		return result, err
+	}
+	if _, err := snapshot.client.CompleteRoot(ctx, connector.CompleteRootParams{
+		RootKey: binding.ExternalRootKey,
+	}); err != nil {
+		return result, err
+	}
+	readback, err := snapshot.client.ReadRoot(ctx, connector.ReadRootParams{
+		RootKey: binding.ExternalRootKey,
+	})
+	if err != nil {
+		return result, err
+	}
+	if readback.Key != snapshot.binding.ExternalRootKey ||
+		readback.IdentityKey != snapshot.binding.ExternalAccountKey {
+		return result, fmt.Errorf("%w: external completion readback identity changed", db.ErrExternalRootValidation)
+	}
+	if !externalRootComplete(readback.State) {
+		return result, fmt.Errorf("%w: external completion could not be verified", db.ErrExternalRootValidation)
+	}
+	if strings.TrimSpace(readback.Revision) == "" || readback.UpdatedAt.IsZero() || readback.ObservedAt.IsZero() {
+		return result, fmt.Errorf("%w: external completion readback revision and timestamps are required", db.ErrExternalRootValidation)
+	}
+	snapshot.root = readback
+	return result, nil
+}
+
+func sameExternalRootCompletionAuthority(
+	expected db.ExternalRootBinding,
+	current db.ExternalRootBinding,
+	claimToken string,
+) bool {
+	return current.ID == expected.ID &&
+		current.UID == expected.UID &&
+		current.ProjectID == expected.ProjectID &&
+		current.IssueID == expected.IssueID &&
+		current.RootMappingID == expected.RootMappingID &&
+		current.ConnectorInstance == expected.ConnectorInstance &&
+		current.ExternalRootKey == expected.ExternalRootKey &&
+		current.ExternalAccountKey == expected.ExternalAccountKey &&
+		current.Active && current.Enabled && current.ClaimToken == claimToken
+}
+
+func (r *Reconciler) applyFields(
+	ctx context.Context,
+	snapshot *reconcileSnapshot,
+	claimToken string,
+	result RunResult,
+) (RunResult, error) {
+	active := make([]db.ExternalFieldMapping, 0, len(snapshot.fieldMappings))
+	for _, mapping := range snapshot.fieldMappings {
+		if mapping.Active {
+			active = append(active, mapping)
+		}
+	}
+	if len(active) == 0 {
+		return result, nil
+	}
+	if !descriptionSupportsFields(snapshot.description) {
+		return result, ErrFieldSynchronizationUnavailable
+	}
+	listed, err := snapshot.client.ListFields(ctx)
+	if err != nil {
+		return result, err
+	}
+	states := make(map[int64]db.ExternalFieldState, len(snapshot.fieldStates))
+	for _, state := range snapshot.fieldStates {
+		states[state.MappingID] = state
+	}
+	snapshot.fieldIssue = snapshot.issue
+	snapshot.coordinatedTimezone = ""
+	for _, mapping := range active {
+		state, hasState := states[mapping.ID]
+		result, err = r.reconcileField(ctx, snapshot, listed.Fields, mapping, state, hasState, claimToken, result)
+		if err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func (r *Reconciler) reconcileField(
+	ctx context.Context,
+	snapshot *reconcileSnapshot,
+	liveFields []connector.FieldDescriptor,
+	mapping db.ExternalFieldMapping,
+	state db.ExternalFieldState,
+	hasState bool,
+	claimToken string,
+	result RunResult,
+) (RunResult, error) {
+	baseline, hasBaseline, baselineErr := decodeCanonicalStoredFieldValue(state.Baseline, mapping)
+	if baselineErr != nil {
+		hasBaseline = false
+		baseline = nullFieldValue()
+	}
+	codec, ok := fieldCodecs[mapping.KataField]
+	if !ok {
+		return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, nullFieldValue(), nullFieldValue(), claimToken, result)
+	}
+	if _, err := validateLiveFieldDescriptor(codec, mapping, liveFields); err != nil {
+		kata := baseline
+		if current, readErr := readCanonicalKataField(codec, snapshot.issue, mapping); readErr == nil {
+			kata = current
+		}
+		return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, kata, baseline, claimToken, result)
+	}
+
+	fieldIssue := snapshot.issue
+	if snapshot.coordinatedTimezone != "" {
+		fieldIssue = snapshot.fieldIssue
+	}
+	kata, err := readCanonicalKataField(codec, fieldIssue, mapping)
+	if err != nil {
+		external := baseline
+		if current, readErr := readMappedExternalField(ctx, snapshot, mapping); readErr == nil {
+			external = current
+		} else if !isInvalidExternalFieldRead(readErr) {
+			return result, readErr
+		}
+		return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, baseline, external, claimToken, result)
+	}
+	external, observedExternal, err := readMappedExternalFieldObserved(ctx, snapshot, mapping)
+	if err != nil {
+		if !isInvalidExternalFieldRead(err) {
+			return result, err
+		}
+		return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, kata, baseline, claimToken, result)
+	}
+	if baselineErr != nil {
+		return r.storeFieldConflict(ctx, snapshot, mapping, state, false, kata, external, claimToken, result)
+	}
+	if hasState && state.Conflicted {
+		return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, kata, external, claimToken, result)
+	}
+
+	var decision MergeDecision
+	if hasState && hasBaseline {
+		decision = DecideFieldMerge(baseline, kata, external)
+	} else {
+		decision = DecideInitialFieldMerge(kata, external)
+	}
+	switch decision.Action {
+	case MergeConflict:
+		return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, kata, external, claimToken, result)
+	case MergeWriteKata:
+		coordinatedTimezone := snapshot.coordinatedTimezone
+		if coordinatedTimezone == "" {
+			coordinatedTimezone = r.coordinatedTimezoneForField(
+				ctx, snapshot, liveFields, mapping, decision, external,
+			)
+			if coordinatedTimezone != "" {
+				snapshot.coordinatedTimezone = coordinatedTimezone
+			}
+		}
+		patch, patchErr := kataPatchWithCoordinatedTimezone(
+			codec, snapshot.issue, decision.Baseline, coordinatedTimezone,
+		)
+		if patchErr != nil {
+			return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, kata, external, claimToken, result)
+		}
+		projected, event, _, projectionErr := r.store.ApplyExternalFieldProjection(ctx, db.ExternalFieldProjectionParams{
+			BindingID: snapshot.binding.ID, MappingID: mapping.ID, ClaimToken: claimToken,
+			KataField: mapping.KataField, Patch: patch, ExpectedIssueRevision: snapshot.issue.Revision,
+			IntegrationActor: integrationActor(snapshot.binding),
+		})
+		if projectionErr != nil {
+			return result, projectionErr
+		}
+		if event != nil {
+			result.retainEvents(*event)
+		}
+		snapshot.issue = projected
+		readback, readErr := readCanonicalKataField(codec, snapshot.issue, mapping)
+		if readErr != nil || !fieldValuesEqual(readback, decision.Baseline) {
+			if readErr != nil {
+				readback = kata
+			}
+			return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, readback, external, claimToken, result)
+		}
+	case MergeWriteExternal:
+		if err := r.renewBeforeExternalCall(ctx, snapshot.binding.ID, claimToken); err != nil {
+			return result, err
+		}
+		_, writeErr := snapshot.client.WriteFields(ctx, connector.WriteFieldsParams{
+			RootKey:  snapshot.binding.ExternalRootKey,
+			Fields:   map[string]connector.FieldValue{mapping.ExternalFieldID: decision.Baseline},
+			Expected: map[string]connector.FieldValue{mapping.ExternalFieldID: observedExternal},
+		})
+		if writeErr != nil {
+			return result, writeErr
+		}
+		readback, readErr := readMappedExternalField(ctx, snapshot, mapping)
+		if readErr != nil {
+			if !isInvalidExternalFieldRead(readErr) {
+				return result, readErr
+			}
+			return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, kata, external, claimToken, result)
+		}
+		if !fieldValuesEqual(readback, decision.Baseline) {
+			return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, kata, readback, claimToken, result)
+		}
+	case MergeAccept:
+	default:
+		return result, fmt.Errorf("unsupported field merge action %q", decision.Action)
+	}
+
+	baselineJSON, err := marshalCanonicalFieldValue(decision.Baseline)
+	if err != nil {
+		return result, err
+	}
+	_, event, err := r.store.UpsertExternalFieldState(ctx, db.ExternalFieldStateParams{
+		BindingID: snapshot.binding.ID, MappingID: mapping.ID, ClaimToken: claimToken,
+		Baseline: baselineJSON, At: r.timestamp(), Actor: integrationActor(snapshot.binding),
+	})
+	if err != nil {
+		return result, err
+	}
+	if event != nil {
+		result.retainEvents(*event)
+	}
+	return result, nil
+}
+
+func (r *Reconciler) coordinatedTimezoneForField(
+	ctx context.Context,
+	snapshot *reconcileSnapshot,
+	liveFields []connector.FieldDescriptor,
+	mapping db.ExternalFieldMapping,
+	decision MergeDecision,
+	external connector.FieldValue,
+) string {
+	if decision.Action != MergeWriteKata || external.Kind != fieldKindLocalDateTime || external.Timezone == "" {
+		return ""
+	}
+	currentCodec, ok := fieldCodecs[mapping.KataField]
+	if !ok {
+		return ""
+	}
+	currentKata, err := readCanonicalKataField(currentCodec, snapshot.issue, mapping)
+	if err != nil || currentKata.Kind != fieldKindLocalDateTime || currentKata.Timezone == external.Timezone {
+		return ""
+	}
+	states := make(map[int64]db.ExternalFieldState, len(snapshot.fieldStates))
+	for _, state := range snapshot.fieldStates {
+		states[state.MappingID] = state
+	}
+	foundSibling := false
+	for _, sibling := range snapshot.fieldMappings {
+		if !sibling.Active || sibling.ID == mapping.ID {
+			continue
+		}
+		codec, ok := fieldCodecs[sibling.KataField]
+		if !ok {
+			return ""
+		}
+		siblingKata, err := readCanonicalKataField(codec, snapshot.issue, sibling)
+		if err != nil || siblingKata.Kind != fieldKindLocalDateTime || siblingKata.Timezone != currentKata.Timezone {
+			return ""
+		}
+		if _, err := validateLiveFieldDescriptor(codec, sibling, liveFields); err != nil {
+			return ""
+		}
+		siblingExternal, err := readMappedExternalField(ctx, snapshot, sibling)
+		if err != nil || siblingExternal.Kind != fieldKindLocalDateTime || siblingExternal.Timezone != external.Timezone {
+			return ""
+		}
+		state, ok := states[sibling.ID]
+		if !ok || state.Conflicted {
+			return ""
+		}
+		baseline, hasBaseline, err := decodeCanonicalStoredFieldValue(state.Baseline, sibling)
+		if err != nil || !hasBaseline {
+			return ""
+		}
+		siblingDecision := DecideFieldMerge(baseline, siblingKata, siblingExternal)
+		if siblingDecision.Action != MergeWriteKata && siblingDecision.Action != MergeAccept {
+			return ""
+		}
+		foundSibling = true
+	}
+	if !foundSibling {
+		return ""
+	}
+	return external.Timezone
+}
+
+func (r *Reconciler) storeFieldConflict(
+	ctx context.Context,
+	snapshot *reconcileSnapshot,
+	mapping db.ExternalFieldMapping,
+	state db.ExternalFieldState,
+	hasBaseline bool,
+	kata connector.FieldValue,
+	external connector.FieldValue,
+	claimToken string,
+	result RunResult,
+) (RunResult, error) {
+	kata = canonicalConflictCandidate(kata)
+	external = canonicalConflictCandidate(external)
+	kataJSON, err := marshalCanonicalFieldValue(kata)
+	if err != nil {
+		return result, err
+	}
+	externalJSON, err := marshalCanonicalFieldValue(external)
+	if err != nil {
+		return result, err
+	}
+	var baselineJSON json.RawMessage
+	if hasBaseline {
+		baselineJSON = append(json.RawMessage(nil), state.Baseline...)
+	}
+	_, event, err := r.store.UpsertExternalFieldState(ctx, db.ExternalFieldStateParams{
+		BindingID: snapshot.binding.ID, MappingID: mapping.ID, ClaimToken: claimToken,
+		Baseline: baselineJSON, ConflictKata: kataJSON, ConflictExternal: externalJSON,
+		Conflicted: true, At: r.timestamp(), Actor: integrationActor(snapshot.binding),
+	})
+	if err != nil {
+		return result, err
+	}
+	result.FieldConflicts++
+	if event != nil {
+		result.retainEvents(*event)
+	}
+	return result, nil
+}
+
+func readCanonicalKataField(
+	codec FieldCodec,
+	issue db.Issue,
+	mapping db.ExternalFieldMapping,
+) (connector.FieldValue, error) {
+	value, err := codec.ReadKata(issue)
+	if err != nil {
+		return connector.FieldValue{}, err
+	}
+	return canonicalMappedFieldValue(value, mapping)
+}
+
+func readMappedExternalField(
+	ctx context.Context,
+	snapshot *reconcileSnapshot,
+	mapping db.ExternalFieldMapping,
+) (connector.FieldValue, error) {
+	canonical, _, err := readMappedExternalFieldObserved(ctx, snapshot, mapping)
+	return canonical, err
+}
+
+func readMappedExternalFieldObserved(
+	ctx context.Context,
+	snapshot *reconcileSnapshot,
+	mapping db.ExternalFieldMapping,
+) (connector.FieldValue, connector.FieldValue, error) {
+	read, err := snapshot.client.ReadFields(ctx, connector.ReadFieldsParams{
+		RootKey: snapshot.binding.ExternalRootKey, FieldIDs: []string{mapping.ExternalFieldID},
+	})
+	if err != nil {
+		return connector.FieldValue{}, connector.FieldValue{}, err
+	}
+	if len(read.Fields) != 1 {
+		return connector.FieldValue{}, connector.FieldValue{}, &invalidExternalFieldReadError{cause: errors.New("mapped external field read returned the wrong identity")}
+	}
+	value, ok := read.Fields[mapping.ExternalFieldID]
+	if !ok {
+		return connector.FieldValue{}, connector.FieldValue{}, &invalidExternalFieldReadError{cause: errors.New("mapped external field read omitted the stable identity")}
+	}
+	canonical, err := canonicalMappedFieldValue(value, mapping)
+	if err != nil {
+		return connector.FieldValue{}, connector.FieldValue{}, &invalidExternalFieldReadError{cause: err}
+	}
+	return canonical, value, nil
+}
+
+func canonicalConflictCandidate(value connector.FieldValue) connector.FieldValue {
+	canonical, err := canonicalFieldValue(value)
+	if err != nil {
+		return nullFieldValue()
+	}
+	return canonical
+}
+
+func (r *Reconciler) readCurrent(
+	ctx context.Context,
+	claimed db.ExternalRootBinding,
+	claimToken string,
+) (reconcileSnapshot, error) {
+	binding, err := r.store.ExternalRootBindingByID(ctx, claimed.ID)
+	if err != nil {
+		return reconcileSnapshot{}, err
+	}
+	if binding.ClaimToken != claimToken || !binding.Active || !binding.Enabled {
+		return reconcileSnapshot{}, db.ErrExternalRootClaimLost
+	}
+	snapshot := reconcileSnapshot{binding: binding}
+	snapshot.issue, err = r.store.IssueByID(ctx, binding.IssueID)
+	if err != nil {
+		return snapshot, err
+	}
+	if r.registry == nil {
+		return snapshot, pauseRoot("external_connector_missing", ErrConnectorInstanceNotFound)
+	}
+	instance, ok := r.registry.instance(binding.ConnectorInstance)
+	if !ok {
+		return snapshot, pauseRoot("external_connector_missing", ErrConnectorInstanceNotFound)
+	}
+	description, err := instance.Client.Describe(ctx)
+	if err != nil {
+		if !parentContextEnded(ctx, err) {
+			r.registry.recordDescribeHealthError(binding.ConnectorInstance, err)
+		}
+		return snapshot, err
+	}
+	if err := r.registry.acceptDescription(binding.ConnectorInstance, description); err != nil {
+		if errors.Is(err, ErrConnectorIdentityChanged) {
+			return snapshot, pauseRoot("external_root_identity_changed", err)
+		}
+		return snapshot, err
+	}
+	if description.AccountIdentity != binding.ExternalAccountKey {
+		return snapshot, pauseRoot("external_root_identity_changed", ErrConnectorIdentityChanged)
+	}
+	snapshot.description = description
+	snapshot.client = instance.Client
+	snapshot.publishReady = descriptionSupportsPublishing(description)
+	snapshot.root, err = instance.Client.ReadRoot(ctx, connector.ReadRootParams{RootKey: binding.ExternalRootKey})
+	if err != nil {
+		if isMissingExternalRoot(err) {
+			return snapshot, pauseRoot("external_root_missing", err)
+		}
+		return snapshot, err
+	}
+	if strings.EqualFold(strings.TrimSpace(snapshot.root.State), "deleted") {
+		return snapshot, pauseRoot("external_root_deleted", errors.New("external root is deleted"))
+	}
+	if snapshot.root.Key != binding.ExternalRootKey || snapshot.root.IdentityKey != binding.ExternalAccountKey {
+		return snapshot, pauseRoot("external_root_identity_changed", ErrConnectorIdentityChanged)
+	}
+	if strings.TrimSpace(snapshot.root.Revision) == "" || snapshot.root.UpdatedAt.IsZero() || snapshot.root.ObservedAt.IsZero() {
+		return snapshot, fmt.Errorf("%w: external root revision and timestamps are required", db.ErrExternalRootValidation)
+	}
+	listed, err := instance.Client.ListComments(ctx, connector.ListCommentsParams{RootKey: binding.ExternalRootKey})
+	if err != nil {
+		return snapshot, err
+	}
+	snapshot.comments = append([]connector.Comment(nil), listed.Comments...)
+	snapshot.kataComments, err = r.store.CommentsByIssue(ctx, binding.IssueID)
+	if err != nil {
+		return snapshot, err
+	}
+	snapshot.mappings, err = r.store.ImportMappingsByProjectSource(
+		ctx, binding.ProjectID, db.ExternalRootCommentMappingSource(binding),
+	)
+	if err != nil {
+		return snapshot, err
+	}
+	snapshot.publishedCommentMappings, err = r.store.ImportMappingsByProjectSource(
+		ctx, binding.ProjectID, db.ExternalRootPublishedCommentMappingSource(binding),
+	)
+	if err != nil {
+		return snapshot, err
+	}
+	revisionMappings, err := r.store.ImportMappingsByProjectSource(
+		ctx, binding.ProjectID, db.ExternalRootCommentRevisionMappingSource(binding),
+	)
+	if err != nil {
+		return snapshot, err
+	}
+	snapshot.seenCommentRevisions = make(map[string]bool, len(revisionMappings))
+	for _, mapping := range revisionMappings {
+		if mapping.ObjectType != db.ExternalRevisionAnchorObjectType {
+			continue
+		}
+		if mapping.ExternalID == db.ExternalCommentFrontierExternalID {
+			snapshot.commentIdentityFrontier = true
+		} else {
+			snapshot.seenCommentRevisions[mapping.ExternalID] = true
+		}
+	}
+	snapshot.mappedComments = make(map[int64]bool)
+	commentMappings, err := r.store.ImportCommentMappingsByIssue(ctx, binding.IssueID)
+	if err != nil {
+		return snapshot, err
+	}
+	for _, mapping := range commentMappings {
+		if mapping.CommentID != nil {
+			snapshot.mappedComments[*mapping.CommentID] = true
+		}
+	}
+	snapshot.fieldMappings, err = r.store.ListExternalFieldMappings(ctx, binding.ConnectorInstance)
+	if err != nil {
+		return snapshot, err
+	}
+	snapshot.fieldStates, err = r.store.ExternalFieldStates(ctx, binding.ID)
+	if err != nil {
+		return snapshot, err
+	}
+	return snapshot, nil
+}
+
+func (r *Reconciler) applyInbound(
+	ctx context.Context,
+	snapshot reconcileSnapshot,
+	claimToken string,
+	result RunResult,
+) (RunResult, error) {
+	actor := integrationActor(snapshot.binding)
+	_, event, changed, err := r.store.ApplyExternalRootProjection(ctx, db.ExternalRootProjectionParams{
+		BindingID: snapshot.binding.ID, ClaimToken: claimToken,
+		Title: snapshot.root.Title, Body: snapshot.root.Body,
+		ExternalRevision:  snapshot.root.Revision,
+		ExternalUpdatedAt: snapshot.root.UpdatedAt, ExternalObservedAt: snapshot.root.ObservedAt,
+		IntegrationActor: actor,
+		ExternalActorID:  actorID(snapshot.root.Actor), ExternalActorName: actorName(snapshot.root.Actor),
+	})
+	if err != nil {
+		return result, err
+	}
+	result.RootUpdated = changed
+	if event != nil {
+		result.retainEvents(*event)
+	}
+	result, err = r.applyInboundComments(ctx, snapshot, claimToken, result)
+	if err != nil {
+		return result, err
+	}
+	return r.applyLifecycleRequest(ctx, snapshot, claimToken, result)
+}
+
+func (r *Reconciler) applyLifecycleRequest(
+	ctx context.Context,
+	snapshot reconcileSnapshot,
+	claimToken string,
+	result RunResult,
+) (RunResult, error) {
+	currentComplete := externalRootComplete(snapshot.root.State)
+	previousComplete := externalRootComplete(snapshot.binding.LastExternalState)
+	isInitialCompletion := currentComplete && snapshot.binding.LastExternalState == ""
+	isCompletionTransition := currentComplete && !previousComplete
+	isReopenTransition := !currentComplete && previousComplete
+	if !isInitialCompletion && !isCompletionTransition && !isReopenTransition {
+		return result, nil
+	}
+
+	state := "complete"
+	body := completionRequestBody(snapshot.root.Actor)
+	if isReopenTransition {
+		state = "open"
+		body = reopenRequestBody(snapshot.root.Actor)
+	}
+	providerTime := snapshot.root.UpdatedAt
+	_, events, changed, err := r.store.EnsureExternalRootLifecycleRequest(ctx, db.ExternalCommentProjectionParams{
+		BindingID: snapshot.binding.ID, ClaimToken: claimToken,
+		ExternalID:       "lifecycle:" + snapshot.binding.UID + ":" + state + ":" + snapshot.root.Revision,
+		ExternalRevision: snapshot.root.Revision, LifecycleState: state, Body: body,
+		ExternalActorID: actorID(snapshot.root.Actor), ExternalActorName: actorName(snapshot.root.Actor),
+		ExternalCreatedAt: providerTime, ExternalUpdatedAt: providerTime,
+		IntegrationActor: integrationActor(snapshot.binding),
+	})
+	if err != nil {
+		return result, err
+	}
+	if changed {
+		if isReopenTransition {
+			result.ReopenRequests++
+		} else {
+			result.CompletionRequests++
+		}
+	}
+	result.retainEvents(events...)
+	return result, nil
+}
+
+func (r *Reconciler) recordFailure(
+	ctx context.Context,
+	binding db.ExternalRootBinding,
+	claimToken string,
+	cause error,
+	verifiedRoot *connector.Root,
+	claimHeld *bool,
+) error {
+	if errors.Is(cause, db.ErrExternalRootClaimLost) {
+		return cause
+	}
+	now := r.timestamp()
+	finalizeCtx, finalizeCancel := r.finalizationContext(ctx)
+	defer finalizeCancel()
+	params := db.ExternalRootErrorParams{
+		BindingID: binding.ID, ClaimToken: claimToken, At: now, NextAttemptAt: r.retryAt(binding, now),
+		Error: cause.Error(),
+	}
+	if verifiedRoot != nil && strings.TrimSpace(verifiedRoot.State) != "" &&
+		strings.TrimSpace(verifiedRoot.Revision) != "" {
+		params.ExternalState = verifiedRoot.State
+		params.ExternalRevision = verifiedRoot.Revision
+	}
+	_, err := r.store.RecordExternalRootError(finalizeCtx, params)
+	if err == nil {
+		*claimHeld = false
+		return cause
+	}
+	return errors.Join(cause, fmt.Errorf("record external root error: %w", err))
+}
+
+func (r *Reconciler) finalizationContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), externalRootFinalizationTimeout)
+}
+
+func (r *Reconciler) timestamp() time.Time {
+	return r.now().UTC().Truncate(time.Millisecond)
+}
+
+func pauseRoot(reason string, cause error) error {
+	return &pauseExternalRootError{reason: reason, cause: cause}
+}
+
+func isMissingExternalRoot(err error) bool {
+	var connectorErr *connector.Error
+	if !errors.As(err, &connectorErr) {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(connectorErr.Code)) {
+	case "not_found", "root_not_found", "deleted", "gone":
+		return true
+	default:
+		return false
+	}
+}
+
+func integrationActor(binding db.ExternalRootBinding) string {
+	return "connector:" + binding.ConnectorInstance
+}
+
+func externalRootComplete(state string) bool {
+	return strings.EqualFold(strings.TrimSpace(state), "complete")
+}
+
+func actorID(actor *connector.Actor) string {
+	if actor == nil {
+		return ""
+	}
+	return actor.ID
+}
+
+func actorName(actor *connector.Actor) string {
+	if actor == nil {
+		return ""
+	}
+	return actor.DisplayName
+}
+
+func completionRequestBody(actor *connector.Actor) string {
+	if name := strings.TrimSpace(actorName(actor)); name != "" {
+		return fmt.Sprintf("External completion was requested by %s. Please verify completion before closing this Kata issue.", name)
+	}
+	return "The external root is complete. Please verify completion before closing this Kata issue."
+}
+
+func reopenRequestBody(actor *connector.Actor) string {
+	if name := strings.TrimSpace(actorName(actor)); name != "" {
+		return fmt.Sprintf("External reopening was requested by %s. Please review reopening before changing this Kata issue.", name)
+	}
+	return "The external root was reopened. Please review reopening before changing this Kata issue."
+}

--- a/internal/rootbridge/reconciler_test.go
+++ b/internal/rootbridge/reconciler_test.go
@@ -1,0 +1,1858 @@
+package rootbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/sqlitestore"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func TestReconcileInboundRootUsesNativeEventAndPreservesAttention(t *testing.T) {
+	h := newReconcileHarness(t)
+	metadataBefore := h.setAttention(t)
+	h.client.read.Title = "External plan"
+	h.client.read.Body = "External body"
+	h.client.read.Revision = "root-revision-2"
+	h.client.read.UpdatedAt = h.boundAt.Add(2 * time.Minute)
+	h.client.read.ObservedAt = h.client.read.UpdatedAt
+	h.client.read.Actor = &connector.Actor{ID: "actor-4", DisplayName: "Reviewer"}
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.True(t, result.RootUpdated)
+
+	issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "External plan", issue.Title)
+	assert.Equal(t, "External body", issue.Body)
+	assert.JSONEq(t, string(metadataBefore), string(issue.Metadata))
+
+	event := requireEventType(t, result.Events, "issue.updated")
+	assert.Equal(t, "connector:notes", event.Actor)
+	var payload struct {
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		Source struct {
+			ConnectorInstance string `json:"connector_instance"`
+			ExternalRevision  string `json:"external_revision"`
+			ActorID           string `json:"actor_id"`
+			ActorName         string `json:"actor_name"`
+			UpdatedAt         string `json:"updated_at"`
+			ObservedAt        string `json:"observed_at"`
+		} `json:"source"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(event.Payload), &payload))
+	assert.Equal(t, "External plan", payload.Title)
+	assert.Equal(t, "External body", payload.Body)
+	assert.Equal(t, "notes", payload.Source.ConnectorInstance)
+	assert.Equal(t, "root-revision-2", payload.Source.ExternalRevision)
+	assert.Equal(t, "actor-4", payload.Source.ActorID)
+	assert.Equal(t, "Reviewer", payload.Source.ActorName)
+	assert.Equal(t, h.client.read.UpdatedAt.Format(time.RFC3339Nano), payload.Source.UpdatedAt)
+	assert.Equal(t, h.client.read.ObservedAt.Format(time.RFC3339Nano), payload.Source.ObservedAt)
+	h.requireSuccessfulClaim(t, "open", "root-revision-2")
+}
+
+func TestReconcileRenewsClaimDuringLongConnectorCall(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	comment, _, err := h.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: h.issue.ID, Author: "tester", Body: "Wait for publication",
+	})
+	require.NoError(t, err)
+	h.client.publishResult = publishedComment(h, "long-call-comment", comment.Body)
+	publishedAt := time.Now().UTC().Add(time.Minute)
+	h.client.publishResult.CreatedAt = publishedAt
+	h.client.publishResult.UpdatedAt = publishedAt
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.client.beforePublish = func() {
+		close(entered)
+		<-release
+	}
+	const staleAfter = 120 * time.Millisecond
+	h.reconciler = NewReconciler(h.store, h.registry, ReconcilerConfig{ClaimStaleAfter: staleAfter})
+	type outcome struct {
+		result RunResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, runErr := h.reconciler.Run(context.Background(), h.binding.ID, RunOptions{})
+		done <- outcome{result: result, err: runErr}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "publication did not start")
+	}
+	time.Sleep(3 * staleAfter)
+	now := time.Now().UTC()
+	_, acquired, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, "competing-long-call", now, now.Add(-staleAfter),
+	)
+	require.NoError(t, err)
+	assert.False(t, acquired, "a valid long connector call must retain its exclusive claim")
+	close(release)
+	completed := <-done
+	require.NoError(t, completed.err)
+	assert.Equal(t, 1, h.client.publishCalls)
+}
+
+func TestReconcileRejectsStaleRootBeforeContentOrLifecycleProjection(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.client.read.Title = "Current external plan"
+	h.client.read.Body = "Current external body"
+	h.client.read.State = "complete"
+	h.client.read.Revision = "revision-current"
+	h.client.read.UpdatedAt = h.boundAt.Add(2 * time.Minute)
+	h.client.read.ObservedAt = h.boundAt.Add(3 * time.Minute)
+
+	current, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, current.CompletionRequests)
+
+	h.client.read.Title = "Stale external plan"
+	h.client.read.Body = "Stale external body"
+	h.client.read.State = "open"
+	h.client.read.Revision = "revision-stale"
+	h.client.read.UpdatedAt = h.boundAt.Add(time.Minute)
+	h.client.read.ObservedAt = h.boundAt.Add(4 * time.Minute)
+
+	stale, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.ErrorIs(t, err, db.ErrExternalRootValidation)
+	assert.Zero(t, stale.RootUpdated)
+	assert.Zero(t, stale.ReopenRequests)
+	issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "Current external plan", issue.Title)
+	assert.Equal(t, "Current external body", issue.Body)
+	comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Len(t, comments, 1)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "complete", binding.LastExternalState)
+	assert.Equal(t, "revision-current", binding.LastExternalRevision)
+}
+
+func TestCompleteExternalClosedKataUsesNativeStateWithoutPublishingComment(t *testing.T) {
+	for _, reason := range []string{"done", "wontfix", "duplicate", "superseded", "audit-no-change"} {
+		t.Run(reason, func(t *testing.T) {
+			h := newReconcileHarness(t)
+			_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, reason, "verifier", "", nil)
+			require.NoError(t, err)
+			h.client.completeReadback = completedRoot(h.client.read, "completed-by-kata")
+
+			result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+			require.NoError(t, err)
+			assert.Equal(t, 1, h.client.completeCalls)
+			assert.Zero(t, h.client.publishCalls)
+			assert.Empty(t, result.Events)
+			comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			assert.Empty(t, comments)
+			h.requireSuccessfulClaim(t, "complete", "completed-by-kata")
+		})
+	}
+}
+
+func TestCompleteExternalAlreadyCompleteIsIdempotent(t *testing.T) {
+	h := newReconcileHarness(t)
+	_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.read = completedRoot(h.client.read, "already-complete")
+
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Zero(t, h.client.completeCalls)
+	h.requireSuccessfulClaim(t, "complete", "already-complete")
+}
+
+func TestCompleteExternalDisabledSuppressesConnectorCall(t *testing.T) {
+	h := newReconcileHarness(t)
+	closed, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	snapshot := reconcileSnapshot{
+		binding: h.binding,
+		issue:   closed,
+		client:  h.client,
+		root:    h.client.read,
+	}
+	snapshot.binding.CompleteExternal = false
+
+	_, err = h.reconciler.completeExternal(t.Context(), &snapshot, "unused-claim", RunResult{})
+
+	require.NoError(t, err)
+	assert.Zero(t, h.client.completeCalls)
+}
+
+func TestCompleteExternalFencesReopenBeforeConnectorCall(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local, _, err := h.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: h.issue.ID, Author: "tester", Body: "Published before reopen",
+	})
+	require.NoError(t, err)
+	h.client.publishResult = publishedComment(h, "published-before-reopen", local.Body)
+	_, _, _, err = h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.completeReadback = completedRoot(h.client.read, "must-not-complete")
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.reconciler.store = &afterPublishedCommentBarrierStorage{
+		Storage: h.store, entered: entered, release: release,
+	}
+	type outcome struct {
+		result RunResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, runErr := h.reconciler.Run(context.Background(), h.binding.ID, RunOptions{})
+		done <- outcome{result: result, err: runErr}
+	}()
+
+	<-entered
+	_, _, changed, reopenErr := h.store.ReopenIssue(t.Context(), h.issue.ID, "operator")
+	close(release)
+	require.ErrorIs(t, reopenErr, db.ErrExternalRootClaimActive)
+	require.False(t, changed)
+	got := <-done
+
+	require.NoError(t, got.err)
+	assert.Equal(t, 1, h.client.completeCalls)
+	assert.Contains(t, eventTypes(got.result.Events), "issue.external_comment_resolved")
+	_, _, changed, reopenErr = h.store.ReopenIssue(t.Context(), h.issue.ID, "operator")
+	require.NoError(t, reopenErr)
+	require.True(t, changed)
+	stored, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "open", stored.Status)
+}
+
+func TestCompleteExternalRevalidatesClaimBeforeConnectorCall(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local, _, err := h.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: h.issue.ID, Author: "tester", Body: "Published before pause",
+	})
+	require.NoError(t, err)
+	h.client.publishResult = publishedComment(h, "published-before-pause", local.Body)
+	_, _, _, err = h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.completeReadback = completedRoot(h.client.read, "must-not-complete")
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.reconciler.store = &afterPublishedCommentBarrierStorage{
+		Storage: h.store, entered: entered, release: release,
+	}
+	type outcome struct {
+		result RunResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, runErr := h.reconciler.Run(context.Background(), h.binding.ID, RunOptions{})
+		done <- outcome{result: result, err: runErr}
+	}()
+
+	<-entered
+	claimed, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	paused, _, pauseErr := h.store.PauseExternalRootBinding(t.Context(), db.ExternalRootActionParams{
+		BindingID: h.binding.ID, ClaimToken: claimed.ClaimToken,
+		Actor: "operator", Reason: "operator_pause",
+	})
+	close(release)
+	require.NoError(t, pauseErr)
+	got := <-done
+
+	assert.ErrorIs(t, got.err, db.ErrExternalRootClaimLost)
+	assert.Zero(t, h.client.completeCalls)
+	assert.Contains(t, eventTypes(got.result.Events), "issue.external_comment_resolved")
+	assert.True(t, paused.Active)
+	assert.False(t, paused.Enabled)
+	assert.Empty(t, paused.ClaimToken)
+}
+
+func TestCompleteExternalRevalidatesBindingIdentityBeforeConnectorCall(t *testing.T) {
+	h := newReconcileHarness(t)
+	_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.completeReadback = completedRoot(h.client.read, "must-not-complete")
+	h.reconciler.store = &mutateCompletionBindingReadStorage{Storage: h.store}
+
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	assert.ErrorIs(t, err, db.ErrExternalRootClaimLost)
+	assert.Zero(t, h.client.completeCalls)
+}
+
+func TestCompleteExternalRevalidatesLiveDisableBeforeConnectorCall(t *testing.T) {
+	h := newReconcileHarness(t)
+	_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.completeReadback = completedRoot(h.client.read, "must-not-complete")
+	h.reconciler.store = &mutateCompletionBindingReadStorage{
+		Storage: h.store,
+		mutate: func(binding *db.ExternalRootBinding) {
+			binding.CompleteExternal = false
+		},
+	}
+
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Zero(t, h.client.completeCalls)
+}
+
+func TestCompleteExternalRequiresVerifiedReadbackAndRetries(t *testing.T) {
+	h := newReconcileHarness(t)
+	_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.completeReadback = h.client.read
+
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, h.client.completeCalls)
+	closed, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "closed", closed.Status)
+	failed, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, 1, failed.ConsecutiveFailures)
+	assert.Empty(t, failed.ClaimToken)
+
+	h.client.completeReadback = completedRoot(h.client.read, "completed-on-retry")
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, h.client.completeCalls)
+	h.requireSuccessfulClaim(t, "complete", "completed-on-retry")
+}
+
+func TestCompleteExternalRejectsInvalidLiveReadback(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		configure func(*reconcileHarness)
+	}{
+		{
+			name: "transport failure",
+			configure: func(h *reconcileHarness) {
+				h.client.beforeComplete = func() {
+					h.client.readErr = &connector.Error{Code: "temporarily_unavailable", Message: "readback unavailable"}
+				}
+			},
+		},
+		{
+			name: "identity changed",
+			configure: func(h *reconcileHarness) {
+				h.client.completeReadback = completedRoot(h.client.read, "wrong-identity")
+				h.client.completeReadback.IdentityKey = "other-account"
+			},
+		},
+		{
+			name: "missing proof",
+			configure: func(h *reconcileHarness) {
+				h.client.completeReadback = completedRoot(h.client.read, "missing-proof")
+				h.client.completeReadback.ObservedAt = time.Time{}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newReconcileHarness(t)
+			_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+			require.NoError(t, err)
+			test.configure(h)
+
+			_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+			require.Error(t, err)
+			assert.Equal(t, 1, h.client.completeCalls)
+			failed, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, 1, failed.ConsecutiveFailures)
+			assert.Empty(t, failed.ClaimToken)
+		})
+	}
+}
+
+func TestCompleteExternalFailureLeavesKataClosedAndRetryable(t *testing.T) {
+	h := newReconcileHarness(t)
+	_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	connectorErr := &connector.Error{Code: "temporarily_unavailable", Message: "completion unavailable"}
+	h.client.completeErr = connectorErr
+
+	_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	assert.ErrorIs(t, err, connectorErr)
+	closed, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "closed", closed.Status)
+	failed, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, 1, failed.ConsecutiveFailures)
+	assert.Empty(t, failed.ClaimToken)
+}
+
+func TestCompleteExternalReopenRequestPrecedesRecompletion(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.client.read = completedRoot(h.client.read, "complete-before-close")
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	_, _, _, err = h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.read.State = "open"
+	h.client.read.Revision = "reopened-externally"
+	h.client.read.UpdatedAt = h.boundAt.Add(3 * time.Minute)
+	h.client.read.ObservedAt = h.client.read.UpdatedAt
+	h.client.completeReadback = completedRoot(h.client.read, "recompleted-by-kata")
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ReopenRequests)
+	assert.Equal(t, 1, h.client.completeCalls)
+	comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	require.Len(t, comments, 2)
+	assert.Contains(t, comments[1].Body, "review reopening")
+	h.requireSuccessfulClaim(t, "complete", "recompleted-by-kata")
+}
+
+func TestCompleteExternalFieldConflictContinuesButFieldTransportFailureBlocks(t *testing.T) {
+	t.Run("conflict continues", func(t *testing.T) {
+		h := newReconcileHarness(t)
+		h.mapField(t, "scheduled_on", "start-date")
+		h.seedBaseline(t, "scheduled_on", date("2026-08-20"))
+		h.setKataField(t, "scheduled_on", date("2026-08-21"))
+		h.client.fieldValues["start-date"] = date("2026-08-22")
+		_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+		require.NoError(t, err)
+		h.client.completeReadback = completedRoot(h.client.read, "complete-after-conflict")
+
+		result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.FieldConflicts)
+		assert.Equal(t, 1, h.client.completeCalls)
+	})
+
+	t.Run("transport failure blocks", func(t *testing.T) {
+		h := newReconcileHarness(t)
+		h.mapField(t, "scheduled_on", "start-date")
+		h.client.readFieldsErr = map[string]error{
+			"start-date": &connector.Error{Code: "temporarily_unavailable", Message: "field unavailable"},
+		}
+		_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+		require.NoError(t, err)
+		h.client.completeReadback = completedRoot(h.client.read, "must-not-complete")
+
+		_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+		require.Error(t, err)
+		assert.Zero(t, h.client.completeCalls)
+	})
+}
+
+func TestCompleteExternalLateFailurePreservesCommittedStagesAndFinalizesClaim(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		failed error
+		cancel bool
+	}{
+		{name: "connector failure", failed: errors.New("completion failed")},
+		{name: "cancellation", failed: context.Canceled, cancel: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newPublishingReconcileHarness(t)
+			h.client.read.Title = "Projected before completion"
+			h.client.read.Revision = "root-before-completion"
+			h.client.read.UpdatedAt = h.boundAt.Add(2 * time.Minute)
+			h.client.read.ObservedAt = h.client.read.UpdatedAt
+			h.client.comments = []connector.Comment{{
+				ID: "comment-before-completion", Body: "Inbound before completion",
+				Author:    connector.Actor{ID: "actor-7", DisplayName: "Reviewer"},
+				CreatedAt: h.boundAt.Add(time.Minute), UpdatedAt: h.boundAt.Add(time.Minute),
+			}}
+			h.mapField(t, "scheduled_on", "start-date")
+			h.client.fieldValues["start-date"] = date("2026-08-21")
+			local, _, err := h.store.CreateComment(t.Context(), db.CreateCommentParams{
+				IssueID: h.issue.ID, Author: "tester", Body: "Outbound before completion",
+			})
+			require.NoError(t, err)
+			h.client.publishResult = publishedComment(h, "published-before-completion", local.Body)
+			_, _, _, err = h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+			require.NoError(t, err)
+			ctx := t.Context()
+			if test.cancel {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				h.client.beforeComplete = cancel
+			}
+			h.client.completeErr = test.failed
+
+			result, err := h.reconciler.Run(ctx, h.binding.ID, RunOptions{})
+
+			require.ErrorIs(t, err, test.failed)
+			assert.Contains(t, eventTypes(result.Events), "issue.updated")
+			assert.Contains(t, eventTypes(result.Events), "issue.commented")
+			assert.Contains(t, eventTypes(result.Events), "issue.metadata_updated")
+			assert.Equal(t, 1, result.CommentsCreated)
+			assert.Equal(t, 1, h.client.publishCalls)
+			_, readErr := h.store.ImportMappingBySource(
+				t.Context(), h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding), "comment", "published-before-completion",
+			)
+			require.NoError(t, readErr)
+			stored, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, "closed", stored.Status)
+			assert.Equal(t, "Projected before completion", stored.Title)
+			field, readErr := fieldCodecs["scheduled_on"].ReadKata(stored)
+			require.NoError(t, readErr)
+			assert.Equal(t, date("2026-08-21"), field)
+			binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+			require.NoError(t, readErr)
+			assert.Empty(t, binding.ClaimToken)
+			assert.Equal(t, 1, binding.ConsecutiveFailures)
+			assert.NotEmpty(t, binding.LastError)
+		})
+	}
+}
+
+func completedRoot(root connector.Root, revision string) connector.Root {
+	root.State = "complete"
+	root.Revision = revision
+	root.UpdatedAt = root.UpdatedAt.Add(time.Minute)
+	root.ObservedAt = root.ObservedAt.Add(time.Minute)
+	return root
+}
+
+type afterPublishedCommentBarrierStorage struct {
+	db.Storage
+	entered chan struct{}
+	release chan struct{}
+}
+
+type mutateCompletionBindingReadStorage struct {
+	db.Storage
+	reads  int
+	mutate func(*db.ExternalRootBinding)
+}
+
+func (s *mutateCompletionBindingReadStorage) ExternalRootBindingByID(
+	ctx context.Context,
+	bindingID int64,
+) (db.ExternalRootBinding, error) {
+	binding, err := s.Storage.ExternalRootBindingByID(ctx, bindingID)
+	s.reads++
+	if err == nil && s.reads > 1 {
+		if s.mutate != nil {
+			s.mutate(&binding)
+		} else {
+			binding.ExternalRootKey = "other-root"
+		}
+	}
+	return binding, err
+}
+
+func (s *afterPublishedCommentBarrierStorage) ClearPendingExternalComment(
+	ctx context.Context,
+	params db.ClearPendingExternalCommentParams,
+) (db.ExternalRootBinding, db.Event, error) {
+	binding, event, err := s.Storage.ClearPendingExternalComment(ctx, params)
+	if err == nil && params.Action == "published" {
+		close(s.entered)
+		<-s.release
+	}
+	return binding, event, err
+}
+
+func TestReconcileCompletionAndReopeningRequestsAreDeduplicatedAndAdditive(t *testing.T) {
+	h := newReconcileHarness(t)
+	metadataBefore := h.setAttention(t)
+	h.client.read.State = "complete"
+	h.client.read.Revision = "complete-revision-1"
+	h.client.read.Actor = &connector.Actor{ID: "actor-8", DisplayName: "Verifier"}
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	second, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, first.CompletionRequests)
+	assert.Equal(t, 0, second.CompletionRequests)
+
+	issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "open", issue.Status)
+	assert.JSONEq(t, string(metadataBefore), string(issue.Metadata))
+	hasReview, err := h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+	require.NoError(t, err)
+	assert.True(t, hasReview)
+	comments, err := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Contains(t, comments[0].Body, "Verifier")
+	assert.Contains(t, comments[0].Body, "verify completion")
+	_, err = h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, db.ExternalRootLifecycleMappingSource(h.binding), "comment",
+		"lifecycle:"+h.binding.UID+":complete:complete-revision-1",
+	)
+	require.NoError(t, err)
+
+	_, _, _, err = h.store.CloseIssue(t.Context(), h.issue.ID, "done", "tester", "Verified externally requested completion.", nil)
+	require.NoError(t, err)
+	h.client.read.State = "open"
+	h.client.read.Revision = "open-revision-2"
+	h.client.read.Actor = &connector.Actor{ID: "actor-9", DisplayName: "Coordinator"}
+	h.client.completeReadback = completedRoot(h.client.read, "recompleted-after-review")
+	reopened, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	duplicate, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, reopened.ReopenRequests)
+	assert.Equal(t, 0, duplicate.ReopenRequests)
+	assert.Equal(t, 1, h.client.completeCalls)
+
+	issue, err = h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "closed", issue.Status)
+	assert.JSONEq(t, string(metadataBefore), string(issue.Metadata))
+	hasReview, err = h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+	require.NoError(t, err)
+	assert.True(t, hasReview)
+	comments, err = h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 2)
+	assert.Contains(t, comments[1].Body, "Coordinator")
+	assert.Contains(t, comments[1].Body, "review reopening")
+}
+
+func TestReconcileLifecycleRequestIdentityIsScopedToBinding(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.client.read.State = "complete"
+	h.client.read.Revision = "shared-provider-revision"
+	h.client.read.UpdatedAt = h.boundAt.Add(time.Minute)
+	h.client.read.ObservedAt = h.boundAt.Add(time.Minute)
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.CompletionRequests)
+
+	secondIssue, _, err := h.store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: h.project.ID, Title: "Second local plan", Author: "tester",
+	})
+	require.NoError(t, err)
+	secondBinding, _, err := h.store.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: h.project.ID, IssueID: secondIssue.ID,
+		ConnectorInstance: "notes", ExternalRootKey: "root-2", ExternalAccountKey: "account-1",
+		Actor: "tester", ReceiveCommentsAfter: h.boundAt,
+	})
+	require.NoError(t, err)
+	h.client.read.Key = "root-2"
+
+	second, err := h.reconciler.Run(t.Context(), secondBinding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, second.CompletionRequests)
+	comments, err := h.store.CommentsByIssue(t.Context(), secondIssue.ID)
+	require.NoError(t, err)
+	assert.Len(t, comments, 1)
+	_, err = h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, db.ExternalRootLifecycleMappingSource(secondBinding), "comment",
+		"lifecycle:"+secondBinding.UID+":complete:shared-provider-revision",
+	)
+	require.NoError(t, err)
+}
+
+func TestReconcileLifecycleTransitionSurvivesLaterFailureAndRevisionChange(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	h.client.read.State = "complete"
+	h.client.read.Revision = "complete-revision-1"
+	h.client.read.UpdatedAt = h.boundAt.Add(time.Minute)
+	h.client.read.ObservedAt = h.boundAt.Add(time.Minute)
+	h.client.listFieldsErr = &connector.Error{Code: "temporarily_unavailable", Message: "fields unavailable"}
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, first.CompletionRequests)
+	failed := h.requireBinding(t)
+	assert.Equal(t, "complete", failed.LastExternalState)
+	assert.Equal(t, "complete-revision-1", failed.LastExternalRevision)
+
+	h.client.listFieldsErr = nil
+	h.client.read.Revision = "complete-revision-2"
+	h.client.read.UpdatedAt = h.client.read.UpdatedAt.Add(time.Minute)
+	h.client.read.ObservedAt = h.client.read.ObservedAt.Add(time.Minute)
+
+	second, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Zero(t, second.CompletionRequests)
+	comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Len(t, comments, 1)
+}
+
+func TestFieldReconcileInitialAndSteadyMatrix(t *testing.T) {
+	cases := []struct {
+		name          string
+		baseline      *connector.FieldValue
+		kata          connector.FieldValue
+		external      connector.FieldValue
+		want          connector.FieldValue
+		wantConflict  bool
+		wantKataWrite bool
+		wantExtWrite  bool
+	}{
+		{name: "initial same", kata: date("2026-08-20"), external: date("2026-08-20"), want: date("2026-08-20")},
+		{name: "initial Kata only", kata: date("2026-08-20"), external: nullValue(), want: date("2026-08-20"), wantExtWrite: true},
+		{name: "initial external only", kata: nullValue(), external: date("2026-08-20"), want: date("2026-08-20"), wantKataWrite: true},
+		{name: "initial divergent", kata: date("2026-08-20"), external: date("2026-08-21"), wantConflict: true},
+		{name: "steady unchanged", baseline: new(date("2026-08-20")), kata: date("2026-08-20"), external: date("2026-08-20"), want: date("2026-08-20")},
+		{name: "steady Kata only", baseline: new(date("2026-08-20")), kata: date("2026-08-21"), external: date("2026-08-20"), want: date("2026-08-21"), wantExtWrite: true},
+		{name: "steady external only", baseline: new(date("2026-08-20")), kata: date("2026-08-20"), external: date("2026-08-21"), want: date("2026-08-21"), wantKataWrite: true},
+		{name: "steady same change", baseline: new(date("2026-08-20")), kata: date("2026-08-21"), external: date("2026-08-21"), want: date("2026-08-21")},
+		{name: "steady divergent", baseline: new(date("2026-08-20")), kata: date("2026-08-21"), external: date("2026-08-22"), wantConflict: true},
+		{name: "Kata clear", baseline: new(date("2026-08-20")), kata: nullValue(), external: date("2026-08-20"), want: nullValue(), wantExtWrite: true},
+		{name: "external clear", baseline: new(date("2026-08-20")), kata: date("2026-08-20"), external: nullValue(), want: nullValue(), wantKataWrite: true},
+		{name: "clear versus change", baseline: new(date("2026-08-20")), kata: nullValue(), external: date("2026-08-22"), wantConflict: true},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			h := newReconcileHarness(t)
+			h.mapField(t, "scheduled_on", "start-date")
+			h.setKataField(t, "scheduled_on", test.kata)
+			h.client.fieldValues["start-date"] = test.external
+			if test.baseline != nil {
+				h.seedBaseline(t, "scheduled_on", *test.baseline)
+			}
+
+			result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+			require.NoError(t, err)
+			if test.wantConflict {
+				assert.Equal(t, 1, result.FieldConflicts)
+				state := h.fieldState(t, "scheduled_on")
+				assert.True(t, state.Conflicted)
+				assert.Equal(t, test.kata, decodeStoredFieldValue(t, state.ConflictKata))
+				assert.Equal(t, test.external, decodeStoredFieldValue(t, state.ConflictExternal))
+				return
+			}
+
+			assert.Zero(t, result.FieldConflicts)
+			state := h.fieldState(t, "scheduled_on")
+			assert.False(t, state.Conflicted)
+			assert.Equal(t, test.want, decodeStoredFieldValue(t, state.Baseline))
+			issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			kataValue, readErr := fieldCodecs["scheduled_on"].ReadKata(issue)
+			require.NoError(t, readErr)
+			assert.Equal(t, test.want, kataValue)
+			assert.Equal(t, test.want, h.client.fieldValues["start-date"])
+			assert.Equal(t, test.wantExtWrite, len(h.client.writeFieldCalls) == 1)
+			if test.wantExtWrite {
+				assert.Equal(t, map[string]connector.FieldValue{"start-date": test.external}, h.client.writeFieldCalls[0].Expected)
+			}
+			assert.Equal(t, test.wantKataWrite, containsEventType(result.Events, "issue.metadata_updated"))
+		})
+	}
+}
+
+func TestFieldReconcileRejectsConcurrentLocalMetadataEdit(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	h.setKataField(t, "scheduled_on", date("2026-08-20"))
+	h.seedBaseline(t, "scheduled_on", date("2026-08-20"))
+	h.client.fieldValues["start-date"] = date("2026-08-21")
+	storage := &editBeforeFieldProjectionStorage{Storage: h.store, issueID: h.issue.ID}
+	h.reconciler.store = storage
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	var revisionConflict *db.RevisionConflictError
+	require.ErrorAs(t, err, &revisionConflict)
+	assert.NotContains(t, eventTypes(result.Events), "issue.metadata_updated")
+	issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	value, readErr := fieldCodecs["scheduled_on"].ReadKata(issue)
+	require.NoError(t, readErr)
+	assert.Equal(t, date("2026-08-22"), value)
+	state := h.fieldState(t, "scheduled_on")
+	assert.Equal(t, date("2026-08-20"), decodeStoredFieldValue(t, state.Baseline))
+	assert.False(t, state.Conflicted)
+}
+
+func TestFieldReconcileFailsWhenMappedCapabilityIsRemoved(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	h.client.description.Capabilities = nil
+	listCalls := h.client.listFieldsCalls
+	h.client.read.Title = "Inbound projection still runs"
+	h.client.read.State = "complete"
+	h.client.read.Revision = "complete-without-fields-capability"
+	h.client.read.UpdatedAt = h.now
+	h.client.read.ObservedAt = h.now
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.ErrorIs(t, err, ErrFieldSynchronizationUnavailable)
+	assert.True(t, result.RootUpdated)
+	assert.Equal(t, 1, result.CompletionRequests)
+	assert.Equal(t, listCalls, h.client.listFieldsCalls)
+	assert.Empty(t, h.client.readFieldCalls)
+	assert.Empty(t, h.client.writeFieldCalls)
+	issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "Inbound projection still runs", issue.Title)
+	binding := h.requireBinding(t)
+	assert.Nil(t, binding.LastSuccessAt)
+	assert.Equal(t, 1, binding.ConsecutiveFailures)
+}
+
+func TestFieldConflictPausesOnlyThatField(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	h.mapField(t, "deadline_on", "due-date")
+	h.seedBaseline(t, "scheduled_on", date("2026-08-20"))
+	h.setKataField(t, "scheduled_on", date("2026-08-21"))
+	h.client.fieldValues["start-date"] = date("2026-08-22")
+	h.client.fieldValues["due-date"] = date("2026-08-23")
+	h.client.comments = []connector.Comment{{
+		ID: "comment-8", Body: "External comment",
+		Author:    connector.Actor{ID: "actor-8", DisplayName: "Reviewer"},
+		CreatedAt: h.boundAt.Add(time.Minute), UpdatedAt: h.boundAt.Add(time.Minute),
+	}}
+	h.client.read.State = "complete"
+	h.client.read.Revision = "complete-with-field-conflict"
+	h.client.read.UpdatedAt = h.boundAt.Add(2 * time.Minute)
+	h.client.read.ObservedAt = h.client.read.UpdatedAt
+	local, _, err := h.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: h.issue.ID, Author: "tester", Body: "Local outbound comment",
+	})
+	require.NoError(t, err)
+	h.client.publishResult = publishedComment(h, "published-field-conflict", local.Body)
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FieldConflicts)
+	assert.Equal(t, 1, result.CommentsCreated)
+	assert.Equal(t, 1, result.CompletionRequests)
+	assert.Equal(t, 1, h.client.publishCalls)
+	_, err = h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, db.ExternalRootPublishedCommentMappingSource(h.binding), "comment", "published-field-conflict",
+	)
+	require.NoError(t, err)
+	assert.True(t, h.fieldState(t, "scheduled_on").Conflicted)
+	assert.False(t, h.fieldState(t, "deadline_on").Conflicted)
+	issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	deadline, err := fieldCodecs["deadline_on"].ReadKata(issue)
+	require.NoError(t, err)
+	assert.Equal(t, date("2026-08-23"), deadline)
+	binding, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	assert.True(t, binding.Enabled)
+	assert.Empty(t, binding.PausedReason)
+}
+
+func TestFieldConflictIsIdempotentAndRefreshesCandidatesWithoutAnotherEvent(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	h.seedBaseline(t, "scheduled_on", date("2026-08-20"))
+	h.setKataField(t, "scheduled_on", date("2026-08-21"))
+	h.client.fieldValues["start-date"] = date("2026-08-22")
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.FieldConflicts)
+	firstState := h.fieldState(t, "scheduled_on")
+	h.setKataField(t, "scheduled_on", date("2026-08-23"))
+	h.client.fieldValues["start-date"] = date("2026-08-24")
+	second, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, second.FieldConflicts)
+	assert.NotContains(t, eventTypes(second.Events), "issue.external_field_conflicted")
+	secondState := h.fieldState(t, "scheduled_on")
+	assert.NotEqual(t, string(firstState.ConflictKata), string(secondState.ConflictKata))
+	assert.NotEqual(t, string(firstState.ConflictExternal), string(secondState.ConflictExternal))
+	assert.Equal(t, date("2026-08-23"), decodeStoredFieldValue(t, secondState.ConflictKata))
+	assert.Equal(t, date("2026-08-24"), decodeStoredFieldValue(t, secondState.ConflictExternal))
+}
+
+func TestFieldReconcileDescriptorAndValueDriftBecomeSafeConflicts(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*reconcileHarness)
+	}{
+		{name: "schema revision", mutate: func(h *reconcileHarness) { h.client.fields[0].SchemaRevision = "schema-2" }},
+		{name: "accepted kinds", mutate: func(h *reconcileHarness) { h.client.fields[0].AcceptedKinds = []string{fieldKindDate} }},
+		{name: "nullability", mutate: func(h *reconcileHarness) { h.client.fields[0].Nullable = false }},
+		{name: "writability", mutate: func(h *reconcileHarness) { h.client.fields[0].Writable = false }},
+		{name: "missing stable id", mutate: func(h *reconcileHarness) { h.client.fields[0].ID = "different-id" }},
+		{name: "invalid external value", mutate: func(h *reconcileHarness) {
+			h.client.fieldValues["start-date"] = connector.FieldValue{Kind: "text", Value: "untrusted-raw-value"}
+		}},
+		{name: "missing external value kind", mutate: func(h *reconcileHarness) {
+			h.client.fieldValues["start-date"] = connector.FieldValue{}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newReconcileHarness(t)
+			h.mapField(t, "scheduled_on", "start-date")
+			h.seedBaseline(t, "scheduled_on", date("2026-08-20"))
+			h.setKataField(t, "scheduled_on", date("2026-08-21"))
+			h.client.fieldValues["start-date"] = date("2026-08-20")
+			test.mutate(h)
+
+			result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.FieldConflicts)
+			state := h.fieldState(t, "scheduled_on")
+			assert.True(t, state.Conflicted)
+			assert.Equal(t, date("2026-08-21"), decodeStoredFieldValue(t, state.ConflictKata))
+			assert.Equal(t, date("2026-08-20"), decodeStoredFieldValue(t, state.ConflictExternal))
+			assert.NotContains(t, string(state.ConflictExternal), "untrusted-raw-value")
+			assert.Empty(t, h.client.writeFieldCalls)
+			if test.name != "invalid external value" && test.name != "missing external value kind" {
+				assert.Empty(t, h.client.readFieldCalls)
+			}
+		})
+	}
+}
+
+func TestFieldReconcileRejectsNonCanonicalLiveDescriptorIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*reconcileHarness)
+	}{
+		{name: "padded field ID", mutate: func(h *reconcileHarness) { h.client.fields[0].ID = " start-date " }},
+		{name: "padded schema revision", mutate: func(h *reconcileHarness) { h.client.fields[0].SchemaRevision = " schema-1 " }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newReconcileHarness(t)
+			h.mapField(t, "scheduled_on", "start-date")
+			test.mutate(h)
+
+			result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+			require.ErrorIs(t, err, connectorclient.ErrProtocolFailure)
+			assert.Zero(t, result.FieldConflicts)
+			assert.Empty(t, h.client.readFieldCalls)
+			assert.Empty(t, h.client.writeFieldCalls)
+			binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, "external connector protocol failed", binding.LastError)
+			assert.Empty(t, binding.ClaimToken)
+		})
+	}
+}
+
+func TestFieldReconcileMissingCodecRetainsEstablishedBaseline(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	seeded := h.seedBaseline(t, "scheduled_on", date("2026-08-20"))
+	codec := fieldCodecs["scheduled_on"]
+	delete(fieldCodecs, "scheduled_on")
+	t.Cleanup(func() { fieldCodecs["scheduled_on"] = codec })
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, first.FieldConflicts)
+	assert.Contains(t, eventTypes(first.Events), "issue.external_field_conflicted")
+	stored := h.fieldState(t, "scheduled_on")
+	assert.True(t, stored.Conflicted)
+	assert.Equal(t, string(seeded.Baseline), string(stored.Baseline))
+	assert.Equal(t, nullFieldValue(), decodeStoredFieldValue(t, stored.ConflictKata))
+	assert.Equal(t, nullFieldValue(), decodeStoredFieldValue(t, stored.ConflictExternal))
+
+	second, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, second.FieldConflicts)
+	assert.NotContains(t, eventTypes(second.Events), "issue.external_field_conflicted")
+	repeated := h.fieldState(t, "scheduled_on")
+	assert.Equal(t, string(seeded.Baseline), string(repeated.Baseline))
+	binding, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	assert.True(t, binding.Active)
+	assert.True(t, binding.Enabled)
+}
+
+func TestFieldReconcileRefreshesEachMappedDescriptorIndependently(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	h.mapField(t, "deadline_on", "due-date")
+	h.client.fields[0].SchemaRevision = "schema-2"
+	h.client.fieldValues["start-date"] = date("2026-08-21")
+	h.client.fieldValues["due-date"] = date("2026-08-22")
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FieldConflicts)
+	assert.True(t, h.fieldState(t, "scheduled_on").Conflicted)
+	assert.False(t, h.fieldState(t, "deadline_on").Conflicted)
+	assert.Len(t, h.client.readFieldCalls, 1)
+	assert.Equal(t, []string{"due-date"}, h.client.readFieldCalls[0].FieldIDs)
+}
+
+func TestFieldReconcileLossyWriteReadbackDoesNotAdvanceBaseline(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	h.setKataField(t, "scheduled_on", date("2026-08-21"))
+	h.client.fieldValues["start-date"] = nullValue()
+	h.client.writeFieldResult = func(_ string, _ connector.FieldValue) connector.FieldValue {
+		return date("2026-08-22")
+	}
+
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FieldConflicts)
+	state := h.fieldState(t, "scheduled_on")
+	assert.True(t, state.Conflicted)
+	assert.Empty(t, state.Baseline)
+	assert.Equal(t, date("2026-08-21"), decodeStoredFieldValue(t, state.ConflictKata))
+	assert.Equal(t, date("2026-08-22"), decodeStoredFieldValue(t, state.ConflictExternal))
+}
+
+func TestFieldReconcilePreservesConnectorErrorsWithoutAdvancingBaseline(t *testing.T) {
+	t.Run("read", func(t *testing.T) {
+		h := newReconcileHarness(t)
+		h.mapField(t, "scheduled_on", "start-date")
+		connectorErr := &connector.Error{Code: "temporarily_unavailable", Message: "field read unavailable"}
+		h.client.readFieldsErr = map[string]error{"start-date": connectorErr}
+
+		_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+		assert.ErrorIs(t, err, connectorErr)
+		states, readErr := h.store.ExternalFieldStates(t.Context(), h.binding.ID)
+		require.NoError(t, readErr)
+		assert.Empty(t, states)
+	})
+
+	t.Run("write", func(t *testing.T) {
+		h := newReconcileHarness(t)
+		h.mapField(t, "scheduled_on", "start-date")
+		h.setKataField(t, "scheduled_on", date("2026-08-21"))
+		h.client.fieldValues["start-date"] = nullValue()
+		connectorErr := &connector.Error{Code: "temporarily_unavailable", Message: "field write unavailable"}
+		h.client.writeFieldsErr = connectorErr
+
+		_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+		assert.ErrorIs(t, err, connectorErr)
+		states, readErr := h.store.ExternalFieldStates(t.Context(), h.binding.ID)
+		require.NoError(t, readErr)
+		assert.Empty(t, states)
+	})
+}
+
+func TestFieldReconcilePreservesTimezoneAndRejectsIncompatibleLocalSiblings(t *testing.T) {
+	t.Run("date instant and clear preserve issue timezone", func(t *testing.T) {
+		for _, value := range []connector.FieldValue{
+			date("2026-08-21"),
+			{Kind: fieldKindInstant, Value: "2026-08-21T10:30:00Z"},
+			nullValue(),
+		} {
+			h := newReconcileHarness(t)
+			h.mapField(t, "scheduled_on", "start-date")
+			h.seedBaseline(t, "scheduled_on", date("2026-08-20"))
+			_, err := h.store.PatchIssueMetadata(t.Context(), db.PatchIssueMetadataIn{
+				IssueID: h.issue.ID, Actor: "tester", Patch: map[string]json.RawMessage{
+					"scheduled_on": json.RawMessage(`"2026-08-20"`),
+					"timezone":     json.RawMessage(`"America/New_York"`),
+				},
+			})
+			require.NoError(t, err)
+			h.client.fieldValues["start-date"] = value
+
+			_, err = h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+			require.NoError(t, err)
+			issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, err)
+			values, err := metadataObject(issue.Metadata)
+			require.NoError(t, err)
+			assert.JSONEq(t, `"America/New_York"`, string(values["timezone"]))
+		}
+	})
+
+	t.Run("UTC and null sibling do not pin a new local timezone", func(t *testing.T) {
+		for _, sibling := range []connector.FieldValue{
+			{Kind: fieldKindInstant, Value: "2026-08-21T10:30:00Z"},
+			nullValue(),
+		} {
+			h := newReconcileHarness(t)
+			h.mapField(t, "scheduled_on", "start-date")
+			h.setKataField(t, "deadline_on", sibling)
+			_, err := h.store.PatchIssueMetadata(t.Context(), db.PatchIssueMetadataIn{
+				IssueID: h.issue.ID, Actor: "tester", Patch: map[string]json.RawMessage{
+					"timezone": json.RawMessage(`"America/New_York"`),
+				},
+			})
+			require.NoError(t, err)
+			h.client.fieldValues["start-date"] = connector.FieldValue{
+				Kind: fieldKindLocalDateTime, Value: "2026-08-21T09:30", Timezone: "America/Los_Angeles",
+			}
+
+			result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+			require.NoError(t, err)
+			assert.Zero(t, result.FieldConflicts)
+			issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, err)
+			values, err := metadataObject(issue.Metadata)
+			require.NoError(t, err)
+			assert.JSONEq(t, `"America/Los_Angeles"`, string(values["timezone"]))
+		}
+	})
+
+	t.Run("two local fields with different zones remain independent", func(t *testing.T) {
+		h := newReconcileHarness(t)
+		h.mapField(t, "scheduled_on", "start-date")
+		h.mapField(t, "deadline_on", "due-date")
+		h.client.fieldValues["start-date"] = connector.FieldValue{
+			Kind: fieldKindLocalDateTime, Value: "2026-08-21T09:30", Timezone: "America/New_York",
+		}
+		h.client.fieldValues["due-date"] = connector.FieldValue{
+			Kind: fieldKindLocalDateTime, Value: "2026-08-21T10:30", Timezone: "America/Los_Angeles",
+		}
+
+		result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.FieldConflicts)
+		assert.False(t, h.fieldState(t, "scheduled_on").Conflicted)
+		assert.True(t, h.fieldState(t, "deadline_on").Conflicted)
+	})
+
+	t.Run("two mapped local fields move to one new timezone together", func(t *testing.T) {
+		h := newReconcileHarness(t)
+		h.mapField(t, "scheduled_on", "start-date")
+		h.mapField(t, "deadline_on", "due-date")
+		oldStart := connector.FieldValue{
+			Kind: fieldKindLocalDateTime, Value: "2026-08-21T09:30", Timezone: "America/New_York",
+		}
+		oldDue := connector.FieldValue{
+			Kind: fieldKindLocalDateTime, Value: "2026-08-21T10:30", Timezone: "America/New_York",
+		}
+		h.setKataField(t, "scheduled_on", oldStart)
+		h.setKataField(t, "deadline_on", oldDue)
+		h.seedBaseline(t, "scheduled_on", oldStart)
+		h.seedBaseline(t, "deadline_on", oldDue)
+		newStart := connector.FieldValue{
+			Kind: fieldKindLocalDateTime, Value: "2026-08-22T09:30", Timezone: "America/Los_Angeles",
+		}
+		newDue := connector.FieldValue{
+			Kind: fieldKindLocalDateTime, Value: "2026-08-22T10:30", Timezone: "America/Los_Angeles",
+		}
+		h.client.fieldValues["start-date"] = newStart
+		h.client.fieldValues["due-date"] = newDue
+
+		result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+		require.NoError(t, err)
+		assert.Zero(t, result.FieldConflicts)
+		issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+		require.NoError(t, readErr)
+		values, readErr := metadataObject(issue.Metadata)
+		require.NoError(t, readErr)
+		assert.JSONEq(t, `"2026-08-22T09:30"`, string(values["scheduled_on"]))
+		assert.JSONEq(t, `"2026-08-22T10:30"`, string(values["deadline_on"]))
+		assert.JSONEq(t, `"America/Los_Angeles"`, string(values["timezone"]))
+		assert.Equal(t, newStart, decodeStoredFieldValue(t, h.fieldState(t, "scheduled_on").Baseline))
+		assert.Equal(t, newDue, decodeStoredFieldValue(t, h.fieldState(t, "deadline_on").Baseline))
+	})
+}
+
+func TestReconcileFirstBindOfCompleteRootUsesReservedClaim(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.resolved.State = "complete"
+	h.client.resolved.Revision = "complete-on-bind"
+	h.client.resolved.UpdatedAt = testObservedAt
+	h.client.resolved.Actor = &connector.Actor{ID: "actor-3", DisplayName: "Verifier"}
+	h.client.read = h.client.resolved
+	reconciler := NewReconciler(h.observed, h.registry, ReconcilerConfig{Now: func() time.Time {
+		return testObservedAt.Add(time.Minute)
+	}})
+	h.service.immediateClaimedReconcile = func(ctx context.Context, bindingID int64, claimToken string) ([]db.Event, error) {
+		result, err := reconciler.Run(ctx, bindingID, RunOptions{ClaimToken: claimToken})
+		return result.Events, err
+	}
+
+	binding, events, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, binding.ClaimToken)
+	assert.NotNil(t, binding.LastSuccessAt)
+	assert.Contains(t, eventTypes(events), "issue.updated")
+	assert.Contains(t, eventTypes(events), "issue.commented")
+	assert.Contains(t, eventTypes(events), "issue.labeled")
+	issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "open", issue.Status)
+}
+
+func TestReconcileClaimedRejectsWrongTokenWithoutMutation(t *testing.T) {
+	h := newReconcileHarnessWithInitialClaim(t, "reserved-claim")
+	h.client.read.Title = "Must not project"
+
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{ClaimToken: "wrong-claim"})
+	assert.ErrorIs(t, err, db.ErrExternalRootClaimLost)
+	issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, h.issue.Title, issue.Title)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "reserved-claim", binding.ClaimToken)
+}
+
+func TestReconcileClaimedPreCanceledContextFinalizesReservedClaim(t *testing.T) {
+	h := newReconcileHarnessWithInitialClaim(t, "reserved-claim")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := h.reconciler.Run(ctx, h.binding.ID, RunOptions{ClaimToken: "reserved-claim"})
+
+	require.ErrorIs(t, err, context.Canceled)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+	assert.Equal(t, 1, binding.ConsecutiveFailures)
+	assert.Contains(t, binding.LastError, context.Canceled.Error())
+}
+
+func TestReconcileDeletedMissingAndIdentityChangedRootsPauseWithoutIssueMutation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		reason string
+		mutate func(*reconcileHarness)
+	}{
+		{name: "deleted", reason: "external_root_deleted", mutate: func(h *reconcileHarness) {
+			h.client.read.State = "deleted"
+		}},
+		{name: "missing", reason: "external_root_missing", mutate: func(h *reconcileHarness) {
+			h.client.readErr = &connector.Error{Code: "not_found", Message: "root unavailable"}
+		}},
+		{name: "identity changed", reason: "external_root_identity_changed", mutate: func(h *reconcileHarness) {
+			h.client.read.IdentityKey = "different-account"
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newReconcileHarness(t)
+			metadataBefore := h.setAttention(t)
+			h.client.read.Title = "Must not project"
+			test.mutate(h)
+
+			result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+			require.NoError(t, err)
+			assert.True(t, result.Paused)
+			issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, h.issue.Title, issue.Title)
+			assert.Equal(t, h.issue.Body, issue.Body)
+			assert.JSONEq(t, string(metadataBefore), string(issue.Metadata))
+			comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			assert.Empty(t, comments)
+			hasReview, readErr := h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+			require.NoError(t, readErr)
+			assert.False(t, hasReview)
+			binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+			require.NoError(t, readErr)
+			assert.False(t, binding.Enabled)
+			assert.Empty(t, binding.ClaimToken)
+			assert.Equal(t, test.reason, binding.PausedReason)
+		})
+	}
+}
+
+func TestReconcileFailureRecordsSafeErrorAndReleasesClaim(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.client.readErr = errors.New("connector unavailable")
+
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.Error(t, err)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.True(t, binding.Enabled)
+	assert.Empty(t, binding.ClaimToken)
+	assert.Equal(t, 1, binding.ConsecutiveFailures)
+	assert.Equal(t, "external connector request failed", binding.LastError)
+}
+
+func TestReconcileFailureFinalizationIgnoresCallerCancellation(t *testing.T) {
+	h := newReconcileHarness(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	h.client.beforeReadReturn = cancel
+	h.client.readErr = context.Canceled
+
+	_, err := h.reconciler.Run(ctx, h.binding.ID, RunOptions{})
+
+	require.ErrorIs(t, err, context.Canceled)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+	assert.Equal(t, 1, binding.ConsecutiveFailures)
+	assert.Equal(t, context.Canceled.Error(), binding.LastError)
+}
+
+func TestReconcileParentCancellationDuringDescribeDoesNotMutateRegistryHealth(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.registry.recordDescribeHealthError("notes", ErrConnectorCall)
+	wantHealth, ok := h.registry.Snapshot("notes")
+	require.True(t, ok)
+	require.NotEmpty(t, wantHealth.HealthError)
+	ctx, cancel := context.WithCancel(t.Context())
+	h.client.beforeDescribeReturn = cancel
+	h.client.describeErr = errors.New("opaque connector cancellation detail")
+
+	_, err := h.reconciler.Run(ctx, h.binding.ID, RunOptions{})
+
+	require.ErrorIs(t, err, context.Canceled)
+	snapshot, ok := h.registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Equal(t, wantHealth.HealthError, snapshot.HealthError)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+	assert.Equal(t, 1, binding.ConsecutiveFailures)
+	assert.Equal(t, context.Canceled.Error(), binding.LastError)
+}
+
+func TestReconcileConnectorFailureRemainsHealthWhenParentExpiresAfterBoundary(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.client.describeErr = errors.Join(connectorclient.ErrRequestTimeout, context.DeadlineExceeded)
+	ctx := newControlledEndContext(t.Context())
+	h.registry.mu.Lock()
+	instance := h.registry.instances["notes"]
+	instance.Client = &boundaryReturnHookClient{
+		Client: instance.Client,
+		afterDescribe: func() {
+			ctx.end(context.DeadlineExceeded)
+		},
+	}
+	h.registry.instances["notes"] = instance
+	h.registry.mu.Unlock()
+
+	_, err := h.reconciler.Run(ctx, h.binding.ID, RunOptions{})
+
+	require.ErrorIs(t, err, ErrConnectorCall)
+	require.ErrorIs(t, err, connectorclient.ErrRequestTimeout)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	snapshot, ok := h.registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Equal(t, "external connector request timed out", snapshot.HealthError)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+	assert.Equal(t, 1, binding.ConsecutiveFailures)
+	assert.Equal(t, "external connector request timed out", binding.LastError)
+}
+
+func TestReconcileFailureFinalizationIgnoresMalformedVerifiedRoot(t *testing.T) {
+	h := newReconcileHarness(t)
+	const claimToken = "malformed-verified-root" // #nosec G101 -- synthetic claim fixture, not a credential.
+	_, acquired, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, claimToken, h.now, h.now.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	claimHeld := true
+	failure := errors.New("outbound publication failed")
+
+	err = h.reconciler.recordFailure(
+		t.Context(), h.binding, claimToken, failure,
+		&connector.Root{State: "complete"}, &claimHeld,
+	)
+
+	assert.ErrorIs(t, err, failure)
+	assert.NotErrorIs(t, err, db.ErrExternalRootValidation)
+	assert.False(t, claimHeld)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+	assert.Equal(t, 1, binding.ConsecutiveFailures)
+	assert.Equal(t, failure.Error(), binding.LastError)
+	assert.Equal(t, &h.now, binding.LastAttemptAt)
+	assert.Equal(t, &h.now, binding.NextAttemptAt)
+	assert.Nil(t, binding.LastSuccessAt)
+}
+
+func TestReconcileTypedConnectorErrorAfterCallerCancellationUsesCancellationPath(t *testing.T) {
+	h := newReconcileHarness(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	h.client.beforeReadReturn = cancel
+	h.client.readErr = &connector.Error{Code: "not_found", Message: "root unavailable"}
+
+	result, err := h.reconciler.Run(ctx, h.binding.ID, RunOptions{})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, result.Paused)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+	assert.True(t, binding.Enabled)
+	assert.Equal(t, 1, binding.ConsecutiveFailures)
+	assert.Equal(t, context.Canceled.Error(), binding.LastError)
+}
+
+func TestReconcileSuccessFinalizationIgnoresCancellationAfterCommittedProjection(t *testing.T) {
+	h := newReconcileHarness(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	store := &cancelAfterRootProjectionStorage{Storage: h.store, cancel: cancel}
+	h.reconciler.store = store
+	h.client.read.Title = "Projected before cancellation"
+	h.client.read.Revision = "root-revision-2"
+	h.client.read.UpdatedAt = h.boundAt.Add(time.Minute)
+	h.client.read.ObservedAt = h.client.read.UpdatedAt
+
+	result, err := h.reconciler.Run(ctx, h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.True(t, result.RootUpdated)
+	assert.NoError(t, store.successCtxErr)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+	assert.NotNil(t, binding.LastSuccessAt)
+	assert.Equal(t, "root-revision-2", binding.LastExternalRevision)
+}
+
+func TestFieldReconcileCancellationAfterNativeProjectionPreservesEventAndFinalizesClaim(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	h.client.fieldValues["start-date"] = date("2026-08-21")
+	ctx, cancel := context.WithCancel(t.Context())
+	store := &cancelAfterFieldProjectionStorage{Storage: h.store, cancel: cancel}
+	h.reconciler.store = store
+
+	result, err := h.reconciler.Run(ctx, h.binding.ID, RunOptions{})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Contains(t, eventTypes(result.Events), "issue.metadata_updated")
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+	assert.Equal(t, 1, binding.ConsecutiveFailures)
+	issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	value, readErr := fieldCodecs["scheduled_on"].ReadKata(issue)
+	require.NoError(t, readErr)
+	assert.Equal(t, date("2026-08-21"), value)
+}
+
+func TestReconcileSteadyCompleteDoesNotRestoreVerifierRemovedReviewLabel(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.client.read.State = "complete"
+	h.client.read.Revision = "complete-revision-1"
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.CompletionRequests)
+	_, err = h.store.RemoveLabelAndEvent(t.Context(), h.issue.ID, db.LabelEventParams{
+		EventType: "issue.unlabeled", Label: "needs-review", Actor: "verifier",
+	})
+	require.NoError(t, err)
+
+	steady, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Zero(t, steady.CompletionRequests)
+	assert.NotContains(t, eventTypes(steady.Events), "issue.labeled")
+	hasReview, err := h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+	require.NoError(t, err)
+	assert.False(t, hasReview)
+	comments, err := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Len(t, comments, 1)
+}
+
+func TestReconcileLifecycleRetryDoesNotRestoreVerifierRemovedReviewLabel(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.client.read.State = "complete"
+	h.client.read.Revision = "complete-revision-1"
+	terminalErr := errors.New("record terminal success")
+	h.reconciler.store = &failExternalRootSuccessOnceStorage{Storage: h.store, err: terminalErr}
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.ErrorIs(t, err, terminalErr)
+	require.Equal(t, 1, first.CompletionRequests)
+	_, err = h.store.RemoveLabelAndEvent(t.Context(), h.issue.ID, db.LabelEventParams{
+		EventType: "issue.unlabeled", Label: "needs-review", Actor: "verifier",
+	})
+	require.NoError(t, err)
+
+	retry, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Zero(t, retry.CompletionRequests)
+	assert.NotContains(t, eventTypes(retry.Events), "issue.labeled")
+	hasReview, err := h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+	require.NoError(t, err)
+	assert.False(t, hasReview)
+	comments, err := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Len(t, comments, 1)
+}
+
+func TestReconcileLocalCompletionRetryPreservesVerifiedRootAfterSuccessWriteFailure(t *testing.T) {
+	h := newReconcileHarness(t)
+	_, _, _, err := h.store.CloseIssue(t.Context(), h.issue.ID, "done", "verifier", "", nil)
+	require.NoError(t, err)
+	h.client.completeReadback = completedRoot(h.client.read, "completed-by-kata")
+	terminalErr := errors.New("record terminal success")
+	h.reconciler.store = &failExternalRootSuccessOnceStorage{Storage: h.store, err: terminalErr}
+
+	first, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.ErrorIs(t, err, terminalErr)
+	assert.Zero(t, first.CompletionRequests)
+	assert.Equal(t, 1, h.client.completeCalls)
+	failed, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, "complete", failed.LastExternalState)
+	assert.Equal(t, "completed-by-kata", failed.LastExternalRevision)
+	assert.Equal(t, 1, failed.ConsecutiveFailures)
+	assert.Nil(t, failed.LastSuccessAt)
+
+	retry, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+
+	require.NoError(t, err)
+	assert.Zero(t, retry.CompletionRequests)
+	assert.Equal(t, 1, h.client.completeCalls)
+	comments, readErr := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, comments)
+	hasReview, readErr := h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+	require.NoError(t, readErr)
+	assert.False(t, hasReview)
+}
+
+type failExternalRootSuccessOnceStorage struct {
+	db.Storage
+	err    error
+	failed bool
+}
+
+func (s *failExternalRootSuccessOnceStorage) RecordExternalRootSuccess(
+	ctx context.Context,
+	params db.ExternalRootSuccessParams,
+) (db.ExternalRootBinding, error) {
+	if !s.failed {
+		s.failed = true
+		return db.ExternalRootBinding{}, s.err
+	}
+	return s.Storage.RecordExternalRootSuccess(ctx, params)
+}
+
+type cancelAfterRootProjectionStorage struct {
+	db.Storage
+	cancel        context.CancelFunc
+	successCtxErr error
+}
+
+type cancelAfterFieldProjectionStorage struct {
+	db.Storage
+	cancel context.CancelFunc
+}
+
+type editBeforeFieldProjectionStorage struct {
+	db.Storage
+	issueID int64
+	edited  bool
+}
+
+func (s *editBeforeFieldProjectionStorage) ApplyExternalFieldProjection(
+	ctx context.Context,
+	params db.ExternalFieldProjectionParams,
+) (db.Issue, *db.Event, bool, error) {
+	if !s.edited {
+		s.edited = true
+		if _, err := s.PatchIssueMetadata(ctx, db.PatchIssueMetadataIn{
+			IssueID: s.issueID, Actor: "local-operator", Patch: map[string]json.RawMessage{
+				"scheduled_on": json.RawMessage(`"2026-08-22"`),
+			},
+		}); err != nil {
+			return db.Issue{}, nil, false, err
+		}
+	}
+	return s.Storage.ApplyExternalFieldProjection(ctx, params)
+}
+
+func (s *cancelAfterFieldProjectionStorage) ApplyExternalFieldProjection(
+	ctx context.Context,
+	params db.ExternalFieldProjectionParams,
+) (db.Issue, *db.Event, bool, error) {
+	issue, event, changed, err := s.Storage.ApplyExternalFieldProjection(ctx, params)
+	if err == nil {
+		s.cancel()
+	}
+	return issue, event, changed, err
+}
+
+func (s *cancelAfterRootProjectionStorage) ApplyExternalRootProjection(
+	ctx context.Context,
+	params db.ExternalRootProjectionParams,
+) (db.Issue, *db.Event, bool, error) {
+	issue, event, changed, err := s.Storage.ApplyExternalRootProjection(ctx, params)
+	if err == nil {
+		s.cancel()
+	}
+	return issue, event, changed, err
+}
+
+func (s *cancelAfterRootProjectionStorage) RecordExternalRootSuccess(
+	ctx context.Context,
+	params db.ExternalRootSuccessParams,
+) (db.ExternalRootBinding, error) {
+	s.successCtxErr = ctx.Err()
+	return s.Storage.RecordExternalRootSuccess(ctx, params)
+}
+
+type reconcileHarness struct {
+	store      *sqlitestore.Store
+	project    db.Project
+	issue      db.Issue
+	binding    db.ExternalRootBinding
+	client     *fakeConnectorClient
+	registry   *Registry
+	reconciler *Reconciler
+	boundAt    time.Time
+	now        time.Time
+	fields     map[string]db.ExternalFieldMapping
+}
+
+func newReconcileHarness(t *testing.T) *reconcileHarness {
+	t.Helper()
+	return newReconcileHarnessWithOptions(t, "", false)
+}
+
+func newReconcileHarnessWithInitialClaim(t *testing.T, initialClaim string) *reconcileHarness {
+	t.Helper()
+	return newReconcileHarnessWithOptions(t, initialClaim, false)
+}
+
+func newPublishingReconcileHarness(t *testing.T) *reconcileHarness {
+	t.Helper()
+	return newReconcileHarnessWithOptions(t, "", true)
+}
+
+func newReconcileHarnessWithOptions(t *testing.T, initialClaim string, publishComments bool) *reconcileHarness {
+	t.Helper()
+	t.Setenv("KATA_HOME", t.TempDir())
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	project, err := store.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "Local plan", Body: "Local body", Author: "tester",
+	})
+	require.NoError(t, err)
+	boundAt := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	now := boundAt.Add(10 * time.Minute)
+	client := &fakeConnectorClient{
+		description: testDescription("account-1"),
+		read: connector.Root{
+			Key: "root-1", IdentityKey: "account-1", Title: "Local plan", Body: "Local body",
+			State: "open", Revision: "root-revision-1", UpdatedAt: boundAt, ObservedAt: boundAt,
+		},
+	}
+	if publishComments {
+		client.description.Capabilities = []connector.Capability{connector.CapabilityPublishComment}
+		client.description.SelfActorID = "connector-self"
+	}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	params := db.CreateExternalRootBindingParams{
+		ProjectID: project.ID, IssueID: issue.ID,
+		ConnectorInstance: "notes", ExternalRootKey: "root-1", ExternalAccountKey: "account-1",
+		Actor: "tester", ReceiveCommentsAfter: boundAt,
+	}
+	if publishComments {
+		params.PublishComments = true
+		params.PublishCommentsAfter = &boundAt
+	}
+	if initialClaim != "" {
+		params.InitialClaimToken = initialClaim
+		params.InitialClaimStartedAt = now
+	}
+	binding, _, err := store.CreateExternalRootBinding(t.Context(), params)
+	require.NoError(t, err)
+	reconciler := NewReconciler(store, registry, ReconcilerConfig{Now: func() time.Time { return now }})
+	return &reconcileHarness{
+		store: store, project: project, issue: issue, binding: binding,
+		client: client, registry: registry, reconciler: reconciler, boundAt: boundAt, now: now,
+		fields: make(map[string]db.ExternalFieldMapping),
+	}
+}
+
+func (h *reconcileHarness) setAttention(t *testing.T) db.JSONBlob {
+	t.Helper()
+	out, err := h.store.PatchIssueMetadata(t.Context(), db.PatchIssueMetadataIn{
+		IssueID: h.issue.ID, Actor: "tester", Patch: map[string]json.RawMessage{
+			"work.attention":     json.RawMessage(`"ok"`),
+			"work.attention_msg": json.RawMessage(`"Continue implementation"`),
+		},
+	})
+	require.NoError(t, err)
+	h.issue = out.Issue
+	return out.Issue.Metadata
+}
+
+func (h *reconcileHarness) mapField(t *testing.T, kataField, externalFieldID string) db.ExternalFieldMapping {
+	t.Helper()
+	return h.mapFieldDescriptor(t, kataField, connector.FieldDescriptor{
+		ID: externalFieldID, DisplayName: externalFieldID,
+		AcceptedKinds: []string{fieldKindDate, fieldKindLocalDateTime, fieldKindInstant},
+		Nullable:      true, Writable: true, SchemaRevision: "schema-1",
+	})
+}
+
+func (h *reconcileHarness) mapFieldDescriptor(
+	t *testing.T,
+	kataField string,
+	descriptor connector.FieldDescriptor,
+) db.ExternalFieldMapping {
+	t.Helper()
+	hasFields := false
+	hasConditionalFields := false
+	for _, capability := range h.client.description.Capabilities {
+		if capability == connector.CapabilityFields {
+			hasFields = true
+		}
+		if capability == connector.CapabilityConditionalFields {
+			hasConditionalFields = true
+		}
+	}
+	if !hasFields {
+		h.client.description.Capabilities = append(h.client.description.Capabilities, connector.CapabilityFields)
+	}
+	if !hasConditionalFields {
+		h.client.description.Capabilities = append(h.client.description.Capabilities, connector.CapabilityConditionalFields)
+	}
+	h.client.fields = append(h.client.fields, descriptor)
+	service := NewService(h.store, h.registry, nil)
+	mapping, err := service.MapField(t.Context(), MapFieldParams{
+		ConnectorInstance: h.binding.ConnectorInstance,
+		KataField:         kataField,
+		ExternalField:     descriptor.ID,
+	})
+	require.NoError(t, err)
+	h.fields[kataField] = mapping
+	if h.client.fieldValues == nil {
+		h.client.fieldValues = make(map[string]connector.FieldValue)
+	}
+	return mapping
+}
+
+func (h *reconcileHarness) setKataField(t *testing.T, kataField string, value connector.FieldValue) {
+	t.Helper()
+	issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	patch, err := fieldCodecs[kataField].KataPatch(issue, value)
+	require.NoError(t, err)
+	out, err := h.store.PatchIssueMetadata(t.Context(), db.PatchIssueMetadataIn{
+		IssueID: h.issue.ID, Actor: "tester", Patch: patch,
+	})
+	require.NoError(t, err)
+	h.issue = out.Issue
+}
+
+func (h *reconcileHarness) seedBaseline(
+	t *testing.T,
+	kataField string,
+	value connector.FieldValue,
+) db.ExternalFieldState {
+	t.Helper()
+	mapping, ok := h.fields[kataField]
+	require.True(t, ok)
+	claimToken := "seed-" + kataField
+	_, claimed, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, claimToken, h.now, h.now.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, claimed)
+	baseline, err := json.Marshal(value)
+	require.NoError(t, err)
+	state, event, err := h.store.UpsertExternalFieldState(t.Context(), db.ExternalFieldStateParams{
+		BindingID: h.binding.ID, MappingID: mapping.ID, ClaimToken: claimToken,
+		Baseline: baseline, At: h.now, Actor: integrationActor(h.binding),
+	})
+	require.NoError(t, err)
+	assert.Nil(t, event)
+	_, err = h.store.ReleaseExternalRootClaim(t.Context(), h.binding.ID, claimToken)
+	require.NoError(t, err)
+	return state
+}
+
+func (h *reconcileHarness) fieldState(t *testing.T, kataField string) db.ExternalFieldState {
+	t.Helper()
+	mapping, ok := h.fields[kataField]
+	require.True(t, ok)
+	states, err := h.store.ExternalFieldStates(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	for _, state := range states {
+		if state.MappingID == mapping.ID {
+			return state
+		}
+	}
+	require.FailNow(t, "field state missing", "field state for %s was not stored", kataField)
+	return db.ExternalFieldState{}
+}
+
+func (h *reconcileHarness) requireSuccessfulClaim(t *testing.T, state, revision string) {
+	t.Helper()
+	binding, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	assert.Empty(t, binding.ClaimToken)
+	assert.NotNil(t, binding.LastSuccessAt)
+	assert.Equal(t, state, binding.LastExternalState)
+	assert.Equal(t, revision, binding.LastExternalRevision)
+}
+
+func requireEventType(t *testing.T, events []db.Event, eventType string) db.Event {
+	t.Helper()
+	for _, event := range events {
+		if event.Type == eventType {
+			return event
+		}
+	}
+	require.FailNow(t, "event type missing", "event type %q not found in %v", eventType, eventTypes(events))
+	return db.Event{}
+}
+
+func eventTypes(events []db.Event) []string {
+	types := make([]string, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.Type)
+	}
+	return types
+}
+
+func decodeStoredFieldValue(t *testing.T, raw json.RawMessage) connector.FieldValue {
+	t.Helper()
+	var value connector.FieldValue
+	require.NoError(t, json.Unmarshal(raw, &value))
+	return value
+}
+
+func containsEventType(events []db.Event, eventType string) bool {
+	for _, event := range events {
+		if event.Type == eventType {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rootbridge/registry.go
+++ b/internal/rootbridge/registry.go
@@ -1,0 +1,268 @@
+package rootbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"go.kenn.io/kata/internal/config"
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+var (
+	// ErrConnectorInstanceNotFound reports an unknown configured instance ID.
+	ErrConnectorInstanceNotFound = errors.New("connector instance not found")
+	// ErrConnectorIdentityChanged reports drift from the accepted connector identity.
+	ErrConnectorIdentityChanged = errors.New("connector identity changed")
+)
+
+// ClientFactory constructs one process client from validated configuration.
+type ClientFactory func(config.ConnectorConfig) connectorclient.Client
+
+// Instance is the live internal representation of one configured connector.
+// Callers serving API responses must use InstanceSnapshot instead.
+type Instance struct {
+	Config                 config.ConnectorConfig
+	Client                 connectorclient.Client
+	Description            connector.Description
+	descriptionHealthError string
+	fieldHealthError       string
+}
+
+// InstanceSnapshot is the API-safe connector health and identity view.
+type InstanceSnapshot struct {
+	ID              string                 `json:"id"`
+	ConnectorID     string                 `json:"connector_id,omitempty"`
+	DisplayName     string                 `json:"display_name,omitempty"`
+	Protocol        string                 `json:"protocol,omitempty"`
+	AccountIdentity string                 `json:"account_identity,omitempty"`
+	Capabilities    []connector.Capability `json:"capabilities,omitempty"`
+	HealthError     string                 `json:"health_error,omitempty"`
+}
+
+// Registry owns validated connector instances and their last known health.
+type Registry struct {
+	mu        sync.RWMutex
+	instances map[string]Instance
+}
+
+// NewRegistry validates all configuration before constructing clients. It does
+// not contact external processes; callers refresh instances after startup.
+func NewRegistry(_ context.Context, configs []config.ConnectorConfig, factory ClientFactory) (*Registry, error) {
+	normalized, err := config.NormalizeConnectorConfigs(configs)
+	if err != nil {
+		return nil, err
+	}
+	if factory == nil {
+		factory = connectorclient.NewProcessClient
+	}
+	registry := &Registry{instances: make(map[string]Instance, len(normalized))}
+	for _, cfg := range normalized {
+		registry.instances[cfg.ID] = Instance{Config: cfg, Client: wrapConnectorClient(factory(cfg))}
+	}
+	return registry, nil
+}
+
+// Refresh probes one live connector and records either its validated
+// description or a credential-scrubbed health error.
+func (r *Registry) Refresh(ctx context.Context, id string) (InstanceSnapshot, error) {
+	instance, ok := r.instance(id)
+	if !ok {
+		return InstanceSnapshot{}, fmt.Errorf("%w: %s", ErrConnectorInstanceNotFound, strings.TrimSpace(id))
+	}
+	description, err := instance.Client.Describe(ctx)
+	if err != nil {
+		if !parentContextEnded(ctx, err) {
+			r.recordDescribeHealthError(instance.Config.ID, err)
+		}
+		snapshot, _ := r.Snapshot(instance.Config.ID)
+		return snapshot, err
+	}
+	if err := r.acceptDescription(instance.Config.ID, description); err != nil {
+		snapshot, _ := r.Snapshot(instance.Config.ID)
+		return snapshot, err
+	}
+	snapshot, _ := r.Snapshot(instance.Config.ID)
+	return snapshot, nil
+}
+
+// Snapshot returns one API-safe connector view.
+func (r *Registry) Snapshot(id string) (InstanceSnapshot, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	instance, ok := r.instances[strings.TrimSpace(id)]
+	if !ok {
+		return InstanceSnapshot{}, false
+	}
+	return snapshotOf(instance), true
+}
+
+// Snapshots returns API-safe connector views ordered by configured ID.
+func (r *Registry) Snapshots() []InstanceSnapshot {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]string, 0, len(r.instances))
+	for id := range r.instances {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	snapshots := make([]InstanceSnapshot, 0, len(ids))
+	for _, id := range ids {
+		snapshots = append(snapshots, snapshotOf(r.instances[id]))
+	}
+	return snapshots
+}
+
+// RefreshSnapshots probes every configured connector concurrently and returns
+// the resulting safe snapshots in configured-ID order. One unavailable
+// connector records its own health without failing the complete list.
+func (r *Registry) RefreshSnapshots(ctx context.Context) []InstanceSnapshot {
+	snapshots := r.Snapshots()
+	var wait sync.WaitGroup
+	for index := range snapshots {
+		wait.Go(func() {
+			refreshed, err := r.Refresh(ctx, snapshots[index].ID)
+			if err == nil {
+				snapshots[index] = refreshed
+				return
+			}
+			if current, ok := r.Snapshot(snapshots[index].ID); ok {
+				snapshots[index] = current
+			}
+		})
+	}
+	wait.Wait()
+	return snapshots
+}
+
+// Fields returns the live provider-neutral descriptor list and updates the
+// instance health snapshot without exposing executable configuration.
+func (r *Registry) Fields(ctx context.Context, id string) ([]connector.FieldDescriptor, error) {
+	instance, ok := r.instance(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrConnectorInstanceNotFound, strings.TrimSpace(id))
+	}
+	if instance.Description.ConnectorID == "" {
+		if _, err := r.Refresh(ctx, id); err != nil {
+			return nil, err
+		}
+		instance, _ = r.instance(id)
+	}
+	if !descriptionSupportsFields(instance.Description) {
+		return nil, ErrFieldSynchronizationUnavailable
+	}
+	listed, err := instance.Client.ListFields(ctx)
+	if err != nil {
+		if !parentContextEnded(ctx, err) {
+			r.recordFieldHealthError(instance.Config.ID, err)
+		}
+		return nil, err
+	}
+	r.clearFieldHealthError(instance.Config.ID)
+	fields := append([]connector.FieldDescriptor(nil), listed.Fields...)
+	return fields, nil
+}
+
+func (r *Registry) instance(id string) (Instance, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	instance, ok := r.instances[strings.TrimSpace(id)]
+	if !ok {
+		return Instance{}, false
+	}
+	instance.Description = cloneDescription(instance.Description)
+	return instance, true
+}
+
+func (r *Registry) acceptDescription(id string, description connector.Description) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	instance := r.instances[id]
+	if instance.Description.ConnectorID != "" &&
+		(description.ConnectorID != instance.Description.ConnectorID || description.Protocol != instance.Description.Protocol) {
+		instance.descriptionHealthError = db.SafeExternalRootError(ErrConnectorIdentityChanged.Error())
+		r.instances[id] = instance
+		return fmt.Errorf("%w: connector ID or protocol does not match", ErrConnectorIdentityChanged)
+	}
+	if err := validateDescription(description); err != nil {
+		instance.descriptionHealthError = db.SafeExternalRootError(err.Error())
+		r.instances[id] = instance
+		return err
+	}
+	instance.Description = cloneDescription(description)
+	instance.descriptionHealthError = ""
+	r.instances[id] = instance
+	return nil
+}
+
+func (r *Registry) recordDescribeHealthError(id string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	instance, ok := r.instances[id]
+	if !ok {
+		return
+	}
+	instance.descriptionHealthError = db.SafeExternalRootError(err.Error())
+	r.instances[id] = instance
+}
+
+func (r *Registry) recordFieldHealthError(id string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	instance, ok := r.instances[id]
+	if !ok {
+		return
+	}
+	instance.fieldHealthError = db.SafeExternalRootError(err.Error())
+	r.instances[id] = instance
+}
+
+func (r *Registry) clearFieldHealthError(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	instance, ok := r.instances[id]
+	if !ok {
+		return
+	}
+	instance.fieldHealthError = ""
+	r.instances[id] = instance
+}
+
+func snapshotOf(instance Instance) InstanceSnapshot {
+	healthError := instance.descriptionHealthError
+	if healthError == "" {
+		healthError = instance.fieldHealthError
+	}
+	return InstanceSnapshot{
+		ID: instance.Config.ID, ConnectorID: instance.Description.ConnectorID,
+		DisplayName: instance.Description.DisplayName, Protocol: instance.Description.Protocol,
+		AccountIdentity: instance.Description.AccountIdentity,
+		Capabilities:    append([]connector.Capability(nil), instance.Description.Capabilities...),
+		HealthError:     healthError,
+	}
+}
+
+func cloneDescription(description connector.Description) connector.Description {
+	description.Capabilities = append([]connector.Capability(nil), description.Capabilities...)
+	description.ConfigSchema = append(json.RawMessage(nil), description.ConfigSchema...)
+	return description
+}
+
+func validateDescription(description connector.Description) error {
+	if strings.TrimSpace(description.ConnectorID) == "" || strings.TrimSpace(description.AccountIdentity) == "" {
+		return errors.New("connector description is invalid")
+	}
+	if description.Protocol != connector.ProtocolVersion {
+		return errors.New("connector description is invalid")
+	}
+	if len(description.ConfigSchema) != 0 && !json.Valid(description.ConfigSchema) {
+		return errors.New("connector description is invalid")
+	}
+	return nil
+}

--- a/internal/rootbridge/registry_test.go
+++ b/internal/rootbridge/registry_test.go
@@ -1,0 +1,924 @@
+package rootbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func TestRegistryConstructionDoesNotProbeBlockingConnector(t *testing.T) {
+	client := &blockingDescribeClient{entered: make(chan struct{}), release: make(chan struct{})}
+	type result struct {
+		registry *Registry
+		err      error
+	}
+	finished := make(chan result, 1)
+	go func() {
+		registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+			ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+		}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+		finished <- result{registry: registry, err: err}
+	}()
+
+	select {
+	case <-client.entered:
+		close(client.release)
+		<-finished
+		t.Fatal("registry construction called Describe")
+	case got := <-finished:
+		require.NoError(t, got.err)
+		require.NotNil(t, got.registry)
+		assert.Zero(t, client.calls.Load())
+	}
+}
+
+func TestRegistryExplicitRefreshRetainsOnlySafeHealth(t *testing.T) {
+	client := &fakeConnectorClient{describeErr: errors.New("request failed: token=private-value")}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+
+	initial, ok := registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Empty(t, initial.HealthError)
+	_, err = registry.Refresh(t.Context(), "notes")
+	require.Error(t, err)
+	snapshot, ok := registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Empty(t, snapshot.ConnectorID)
+	assert.Equal(t, "external connector request failed", snapshot.HealthError)
+	assert.NotContains(t, snapshot.HealthError, "token=")
+	assert.NotContains(t, snapshot.HealthError, "private-value")
+}
+
+func TestRegistryRetainsSafeConnectorFailureDiagnostics(t *testing.T) {
+	const rawDiagnostic = "private executable path and credential detail"
+	for _, tc := range []struct {
+		name    string
+		failure error
+		kind    error
+		want    string
+	}{
+		{
+			name: "process", failure: errors.Join(connectorclient.ErrProcessFailure, errors.New(rawDiagnostic)),
+			kind: connectorclient.ErrProcessFailure, want: "external connector process failed",
+		},
+		{
+			name: "protocol", failure: errors.Join(connectorclient.ErrProtocolFailure, errors.New(rawDiagnostic)),
+			kind: connectorclient.ErrProtocolFailure, want: "external connector protocol failed",
+		},
+		{
+			name:    "child timeout",
+			failure: errors.Join(connectorclient.ErrRequestTimeout, context.DeadlineExceeded, errors.New(rawDiagnostic)),
+			kind:    connectorclient.ErrRequestTimeout, want: "external connector request timed out",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeConnectorClient{describeErr: tc.failure}
+			registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+				ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+			}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+			require.NoError(t, err)
+
+			_, err = registry.Refresh(t.Context(), "notes")
+
+			require.ErrorIs(t, err, ErrConnectorCall)
+			require.ErrorIs(t, err, tc.kind)
+			assert.EqualError(t, err, tc.want)
+			assert.NotContains(t, err.Error(), rawDiagnostic)
+			snapshot, ok := registry.Snapshot("notes")
+			require.True(t, ok)
+			assert.Equal(t, tc.want, snapshot.HealthError)
+			assert.NotContains(t, snapshot.HealthError, rawDiagnostic)
+		})
+	}
+}
+
+func TestRegistryExplicitConnectorCategoryWinsParentEndBeforeBoundary(t *testing.T) {
+	const rawDiagnostic = "opaque process path and stderr detail"
+	for _, tc := range []struct {
+		name     string
+		category error
+		want     string
+	}{
+		{
+			name: "process", category: connectorclient.ErrProcessFailure,
+			want: "external connector process failed",
+		},
+		{
+			name: "protocol", category: connectorclient.ErrProtocolFailure,
+			want: "external connector protocol failed",
+		},
+		{
+			name: "child timeout", category: connectorclient.ErrRequestTimeout,
+			want: "external connector request timed out",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			client := &fakeConnectorClient{
+				description:          testDescription("account-1"),
+				describeErr:          errors.Join(tc.category, errors.New(rawDiagnostic)),
+				beforeDescribeReturn: cancel,
+			}
+			registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+				ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+			}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+			require.NoError(t, err)
+
+			_, err = registry.Refresh(ctx, "notes")
+
+			require.ErrorIs(t, err, ErrConnectorCall)
+			require.ErrorIs(t, err, tc.category)
+			assert.EqualError(t, err, tc.want)
+			assert.NotContains(t, err.Error(), rawDiagnostic)
+			snapshot, ok := registry.Snapshot("notes")
+			require.True(t, ok)
+			assert.Equal(t, tc.want, snapshot.HealthError)
+		})
+	}
+}
+
+func TestRegistryRefreshReplacesHealthWithDescription(t *testing.T) {
+	client := &fakeConnectorClient{describeErr: errors.New("connector unavailable")}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	_, err = registry.Refresh(t.Context(), "notes")
+	require.Error(t, err)
+
+	client.describeErr = nil
+	client.description = testDescription("account-1")
+	got, err := registry.Refresh(t.Context(), "notes")
+	require.NoError(t, err)
+	assert.Equal(t, "example.connector", got.ConnectorID)
+	assert.Empty(t, got.HealthError)
+}
+
+func TestRegistryFieldsSuccessClearsStaleHealthWithoutChangingIdentity(t *testing.T) {
+	description := testDescription("account-1")
+	client := &fakeConnectorClient{description: description}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	want, err := registry.Refresh(t.Context(), "notes")
+	require.NoError(t, err)
+
+	client.listFieldsErr = errors.New("synthetic connector failure")
+	_, err = registry.Fields(t.Context(), "notes")
+	require.Error(t, err)
+	unhealthy, ok := registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.NotEmpty(t, unhealthy.HealthError)
+
+	client.listFieldsErr = nil
+	client.fields = []connector.FieldDescriptor{{
+		ID: "schedule", DisplayName: "Schedule", AcceptedKinds: []string{"date"},
+		Nullable: true, Writable: true, SchemaRevision: "schema-1",
+	}}
+	fields, err := registry.Fields(t.Context(), "notes")
+	require.NoError(t, err)
+	require.Len(t, fields, 1)
+	healthy, ok := registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Empty(t, healthy.HealthError)
+	want.HealthError = ""
+	assert.Equal(t, want, healthy)
+}
+
+func TestRegistryFieldsRequiresAcceptedCapabilityBeforeDiscovery(t *testing.T) {
+	description := testDescription("account-1")
+	description.Capabilities = nil
+	client := &fakeConnectorClient{description: description}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+
+	_, err = registry.Fields(t.Context(), "notes")
+
+	assert.ErrorIs(t, err, ErrFieldSynchronizationUnavailable)
+	assert.Zero(t, client.listFieldsCalls)
+}
+
+func TestRegistryFieldsSuccessDoesNotClearIdentityDriftHealth(t *testing.T) {
+	client := &fakeConnectorClient{description: testDescription("account-1")}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	_, err = registry.Refresh(t.Context(), "notes")
+	require.NoError(t, err)
+
+	client.description.ConnectorID = "changed.connector"
+	identitySnapshot, err := registry.Refresh(t.Context(), "notes")
+	require.ErrorIs(t, err, ErrConnectorIdentityChanged)
+	require.NotEmpty(t, identitySnapshot.HealthError)
+	client.fields = []connector.FieldDescriptor{{
+		ID: "schedule", DisplayName: "Schedule", AcceptedKinds: []string{"date"},
+		Nullable: true, Writable: true, SchemaRevision: "schema-1",
+	}}
+	_, err = registry.Fields(t.Context(), "notes")
+	require.NoError(t, err)
+
+	got, ok := registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Equal(t, identitySnapshot.HealthError, got.HealthError)
+	client.description = testDescription("account-1")
+	recovered, err := registry.Refresh(t.Context(), "notes")
+	require.NoError(t, err)
+	assert.Empty(t, recovered.HealthError)
+}
+
+func TestRegistryFieldsFailureDoesNotReplaceIdentityHealth(t *testing.T) {
+	client := &fakeConnectorClient{description: testDescription("account-1")}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	_, err = registry.Refresh(t.Context(), "notes")
+	require.NoError(t, err)
+
+	client.description.ConnectorID = "changed.connector"
+	identitySnapshot, err := registry.Refresh(t.Context(), "notes")
+	require.ErrorIs(t, err, ErrConnectorIdentityChanged)
+	client.listFieldsErr = errors.New("synthetic field probe failure")
+	_, err = registry.Fields(t.Context(), "notes")
+	require.Error(t, err)
+
+	got, ok := registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Equal(t, identitySnapshot.HealthError, got.HealthError)
+	assert.NotContains(t, got.HealthError, "field probe")
+}
+
+func TestRegistryMissingHealthWriteDoesNotCreatePhantomInstance(t *testing.T) {
+	registry, err := NewRegistry(t.Context(), nil, nil)
+	require.NoError(t, err)
+
+	registry.recordDescribeHealthError("missing", errors.New("synthetic probe failure"))
+	registry.recordFieldHealthError("missing", errors.New("synthetic field failure"))
+	registry.clearFieldHealthError("missing")
+
+	assert.Empty(t, registry.Snapshots())
+	_, ok := registry.Snapshot("missing")
+	assert.False(t, ok)
+}
+
+func TestRegistryWrapsEveryConnectorClientBoundary(t *testing.T) {
+	const rawDiagnostic = "opaque child-process detail"
+	client := &allMethodsErrorConnectorClient{err: errors.New(rawDiagnostic)}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	instance, ok := registry.instance("notes")
+	require.True(t, ok)
+	calls := []struct {
+		name string
+		call func(context.Context, connectorclient.Client) error
+	}{
+		{name: "describe", call: func(ctx context.Context, client connectorclient.Client) error {
+			_, err := client.Describe(ctx)
+			return err
+		}},
+		{name: "resolve root", call: func(ctx context.Context, client connectorclient.Client) error {
+			_, err := client.ResolveRoot(ctx, connector.ResolveRootParams{})
+			return err
+		}},
+		{name: "read root", call: func(ctx context.Context, client connectorclient.Client) error {
+			_, err := client.ReadRoot(ctx, connector.ReadRootParams{})
+			return err
+		}},
+		{name: "list comments", call: func(ctx context.Context, client connectorclient.Client) error {
+			_, err := client.ListComments(ctx, connector.ListCommentsParams{})
+			return err
+		}},
+		{name: "complete root", call: func(ctx context.Context, client connectorclient.Client) error {
+			_, err := client.CompleteRoot(ctx, connector.CompleteRootParams{})
+			return err
+		}},
+		{name: "publish comment", call: func(ctx context.Context, client connectorclient.Client) error {
+			_, err := client.PublishComment(ctx, connector.PublishCommentParams{})
+			return err
+		}},
+		{name: "list fields", call: func(ctx context.Context, client connectorclient.Client) error {
+			_, err := client.ListFields(ctx)
+			return err
+		}},
+		{name: "read fields", call: func(ctx context.Context, client connectorclient.Client) error {
+			_, err := client.ReadFields(ctx, connector.ReadFieldsParams{})
+			return err
+		}},
+		{name: "write fields", call: func(ctx context.Context, client connectorclient.Client) error {
+			_, err := client.WriteFields(ctx, connector.WriteFieldsParams{})
+			return err
+		}},
+	}
+	for _, call := range calls {
+		t.Run(call.name, func(t *testing.T) {
+			err := call.call(t.Context(), instance.Client)
+			require.ErrorIs(t, err, ErrConnectorCall)
+			assert.NotContains(t, err.Error(), rawDiagnostic)
+		})
+	}
+}
+
+func TestRegistryConnectorBoundaryRejectsNonCanonicalFieldDescriptors(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		descriptor connector.FieldDescriptor
+	}{
+		{
+			name: "padded field ID",
+			descriptor: connector.FieldDescriptor{
+				ID: " field-1 ", DisplayName: "Start", AcceptedKinds: []string{"date"},
+				Nullable: true, Writable: true, SchemaRevision: "schema-1",
+			},
+		},
+		{
+			name: "padded schema revision",
+			descriptor: connector.FieldDescriptor{
+				ID: "field-1", DisplayName: "Start", AcceptedKinds: []string{"date"},
+				Nullable: true, Writable: true, SchemaRevision: " schema-1 ",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := &fakeConnectorClient{
+				description: testDescription("account-1"), fields: []connector.FieldDescriptor{test.descriptor},
+			}
+			registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+				ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+			}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+			require.NoError(t, err)
+			instance, ok := registry.instance("notes")
+			require.True(t, ok)
+
+			_, err = instance.Client.ListFields(t.Context())
+			require.ErrorIs(t, err, connectorclient.ErrProtocolFailure)
+			assert.EqualError(t, err, "external connector protocol failed")
+		})
+	}
+}
+
+func TestRegistryConnectorBoundaryPreservesTypedAndContextErrors(t *testing.T) {
+	client := &allMethodsErrorConnectorClient{}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	instance, ok := registry.instance("notes")
+	require.True(t, ok)
+
+	typed := &connector.Error{Code: "remote_failed", Message: "safe external failure"}
+	client.err = typed
+	_, err = instance.Client.Describe(t.Context())
+	assert.Same(t, typed, err)
+	assert.NotErrorIs(t, err, ErrConnectorCall)
+
+	client.err = errors.New("opaque cancellation detail")
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = instance.Client.Describe(canceledCtx)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, ErrConnectorCall)
+	deadlineCtx, deadlineCancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer deadlineCancel()
+	_, err = instance.Client.Describe(deadlineCtx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotErrorIs(t, err, ErrConnectorCall)
+
+	client.err = context.DeadlineExceeded
+	_, err = instance.Client.Describe(t.Context())
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.ErrorIs(t, err, ErrConnectorCall)
+}
+
+func TestRegistryParentContextEndDoesNotMutateProbeHealth(t *testing.T) {
+	contextCases := []struct {
+		name string
+		new  func(*testing.T) (context.Context, error)
+	}{
+		{
+			name: "canceled",
+			new: func(t *testing.T) (context.Context, error) {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx, context.Canceled
+			},
+		},
+		{
+			name: "deadline",
+			new: func(t *testing.T) (context.Context, error) {
+				ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+				t.Cleanup(cancel)
+				return ctx, context.DeadlineExceeded
+			},
+		},
+	}
+	probeCases := []struct {
+		name   string
+		setErr func(*fakeConnectorClient, error)
+		call   func(context.Context, *Registry) error
+	}{
+		{
+			name:   "describe",
+			setErr: func(client *fakeConnectorClient, err error) { client.describeErr = err },
+			call: func(ctx context.Context, registry *Registry) error {
+				_, err := registry.Refresh(ctx, "notes")
+				return err
+			},
+		},
+		{
+			name:   "fields",
+			setErr: func(client *fakeConnectorClient, err error) { client.listFieldsErr = err },
+			call: func(ctx context.Context, registry *Registry) error {
+				_, err := registry.Fields(ctx, "notes")
+				return err
+			},
+		},
+	}
+	for _, contextCase := range contextCases {
+		for _, probeCase := range probeCases {
+			for _, priorHealth := range []bool{false, true} {
+				name := contextCase.name + "/" + probeCase.name
+				if priorHealth {
+					name += "/prior-health"
+				} else {
+					name += "/fresh"
+				}
+				t.Run(name, func(t *testing.T) {
+					client := &fakeConnectorClient{description: testDescription("account-1")}
+					registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+						ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+					}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+					require.NoError(t, err)
+					wantHealth := ""
+					if priorHealth {
+						probeCase.setErr(client, errors.New("synthetic prior probe failure"))
+						require.Error(t, probeCase.call(t.Context(), registry))
+						snapshot, ok := registry.Snapshot("notes")
+						require.True(t, ok)
+						require.NotEmpty(t, snapshot.HealthError)
+						wantHealth = snapshot.HealthError
+					}
+
+					probeCase.setErr(client, errors.New("opaque canceled probe detail"))
+					ctx, wantErr := contextCase.new(t)
+					err = probeCase.call(ctx, registry)
+					require.ErrorIs(t, err, wantErr)
+					snapshot, ok := registry.Snapshot("notes")
+					require.True(t, ok)
+					assert.Equal(t, wantHealth, snapshot.HealthError)
+				})
+			}
+		}
+	}
+}
+
+func TestRegistryLiveParentProbeFailuresRecordHealth(t *testing.T) {
+	probeCases := []struct {
+		name   string
+		setErr func(*fakeConnectorClient, error)
+		call   func(context.Context, *Registry) error
+	}{
+		{
+			name:   "describe",
+			setErr: func(client *fakeConnectorClient, err error) { client.describeErr = err },
+			call: func(ctx context.Context, registry *Registry) error {
+				_, err := registry.Refresh(ctx, "notes")
+				return err
+			},
+		},
+		{
+			name:   "fields",
+			setErr: func(client *fakeConnectorClient, err error) { client.listFieldsErr = err },
+			call: func(ctx context.Context, registry *Registry) error {
+				_, err := registry.Fields(ctx, "notes")
+				return err
+			},
+		},
+	}
+	errorCases := []struct {
+		name      string
+		err       error
+		wantError error
+	}{
+		{name: "child deadline", err: context.DeadlineExceeded, wantError: ErrConnectorCall},
+		{name: "typed connector error", err: &connector.Error{Code: "remote_failed", Message: "safe external failure"}},
+	}
+	for _, probeCase := range probeCases {
+		for _, errorCase := range errorCases {
+			t.Run(probeCase.name+"/"+errorCase.name, func(t *testing.T) {
+				client := &fakeConnectorClient{description: testDescription("account-1")}
+				probeCase.setErr(client, errorCase.err)
+				registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+					ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+				}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+				require.NoError(t, err)
+
+				err = probeCase.call(t.Context(), registry)
+				require.Error(t, err)
+				if errorCase.wantError != nil {
+					assert.ErrorIs(t, err, errorCase.wantError)
+				} else {
+					assert.Same(t, errorCase.err, err)
+				}
+				snapshot, ok := registry.Snapshot("notes")
+				require.True(t, ok)
+				assert.NotEmpty(t, snapshot.HealthError)
+			})
+		}
+	}
+}
+
+func TestRegistryConnectorFailureRemainsHealthWhenParentExpiresAfterBoundary(t *testing.T) {
+	probeCases := []struct {
+		name   string
+		setErr func(*fakeConnectorClient, error)
+		hook   func(*boundaryReturnHookClient, func())
+		call   func(context.Context, *Registry) error
+	}{
+		{
+			name:   "describe",
+			setErr: func(client *fakeConnectorClient, err error) { client.describeErr = err },
+			hook: func(client *boundaryReturnHookClient, after func()) {
+				client.afterDescribe = after
+			},
+			call: func(ctx context.Context, registry *Registry) error {
+				_, err := registry.Refresh(ctx, "notes")
+				return err
+			},
+		},
+		{
+			name:   "fields",
+			setErr: func(client *fakeConnectorClient, err error) { client.listFieldsErr = err },
+			hook: func(client *boundaryReturnHookClient, after func()) {
+				client.afterListFields = after
+			},
+			call: func(ctx context.Context, registry *Registry) error {
+				_, err := registry.Fields(ctx, "notes")
+				return err
+			},
+		},
+	}
+	typedFailure := &connector.Error{Code: "remote_failed", Message: "safe external failure"}
+	errorCases := []struct {
+		name        string
+		err         error
+		assertError func(*testing.T, error)
+		wantHealth  string
+	}{
+		{
+			name: "child deadline", err: errors.Join(connectorclient.ErrRequestTimeout, context.DeadlineExceeded),
+			assertError: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, ErrConnectorCall)
+				require.ErrorIs(t, err, connectorclient.ErrRequestTimeout)
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+			},
+			wantHealth: "external connector request timed out",
+		},
+		{
+			name: "typed connector error", err: errors.Join(typedFailure, context.DeadlineExceeded),
+			assertError: func(t *testing.T, err error) {
+				var gotTyped *connector.Error
+				require.ErrorAs(t, err, &gotTyped)
+				assert.Same(t, typedFailure, gotTyped)
+				assert.ErrorIs(t, err, context.DeadlineExceeded)
+				assert.NotErrorIs(t, err, ErrConnectorCall)
+			},
+		},
+	}
+	for _, probeCase := range probeCases {
+		for _, errorCase := range errorCases {
+			t.Run(probeCase.name+"/"+errorCase.name, func(t *testing.T) {
+				rawClient := &fakeConnectorClient{description: testDescription("account-1")}
+				probeCase.setErr(rawClient, errorCase.err)
+				registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+					ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+				}}, func(config.ConnectorConfig) connectorclient.Client { return rawClient })
+				require.NoError(t, err)
+				ctx := newControlledEndContext(t.Context())
+				registry.mu.Lock()
+				instance := registry.instances["notes"]
+				hookedClient := &boundaryReturnHookClient{Client: instance.Client}
+				probeCase.hook(hookedClient, func() { ctx.end(context.DeadlineExceeded) })
+				instance.Client = hookedClient
+				registry.instances["notes"] = instance
+				registry.mu.Unlock()
+
+				err = probeCase.call(ctx, registry)
+
+				errorCase.assertError(t, err)
+				snapshot, ok := registry.Snapshot("notes")
+				require.True(t, ok)
+				if errorCase.wantHealth != "" {
+					assert.Equal(t, errorCase.wantHealth, snapshot.HealthError)
+				} else {
+					assert.NotEmpty(t, snapshot.HealthError)
+				}
+			})
+		}
+	}
+}
+
+func TestRegistryRefreshRejectsChangedStableConnectorIdentity(t *testing.T) {
+	client := &fakeConnectorClient{description: testDescription("account-1")}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	_, err = registry.Refresh(t.Context(), "notes")
+	require.NoError(t, err)
+
+	client.description.ConnectorID = "changed.connector"
+	got, err := registry.Refresh(t.Context(), "notes")
+	assert.ErrorIs(t, err, ErrConnectorIdentityChanged)
+	assert.Equal(t, "example.connector", got.ConnectorID)
+	assert.NotEmpty(t, got.HealthError)
+}
+
+func TestRegistryConcurrentFirstRefreshPinsExactlyOneConnectorIdentity(t *testing.T) {
+	client := &concurrentDescribeClient{
+		entered: make(chan struct{}, 2), release: make(chan struct{}),
+		descriptions: [2]connector.Description{
+			testDescription("account-1"), testDescription("account-1"),
+		},
+	}
+	client.descriptions[1].ConnectorID = "alternate.connector"
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := registry.Refresh(context.Background(), "notes")
+			results <- err
+		}()
+	}
+	<-client.entered
+	<-client.entered
+	close(client.release)
+	var accepted, rejected int
+	for range 2 {
+		err := <-results
+		if err == nil {
+			accepted++
+		} else if errors.Is(err, ErrConnectorIdentityChanged) {
+			rejected++
+		} else {
+			require.NoError(t, err)
+		}
+	}
+	assert.Equal(t, 1, accepted)
+	assert.Equal(t, 1, rejected)
+	snapshot, ok := registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Contains(t, []string{"example.connector", "alternate.connector"}, snapshot.ConnectorID)
+	assert.NotEmpty(t, snapshot.HealthError)
+}
+
+func TestRegistrySnapshotOmitsPrivateDescriptionAndValidationValues(t *testing.T) {
+	const (
+		accountIdentity = "account-reference-42"
+		opaqueValue     = "opaque-7f3c2a"
+	)
+	description := testDescription(accountIdentity)
+	description.SelfActorID = opaqueValue + "-actor"
+	description.ConfigSchema = json.RawMessage(`{"default":"` + opaqueValue + `-schema"}`)
+	client := &fakeConnectorClient{description: description}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	snapshot, err := registry.Refresh(t.Context(), "notes")
+	require.NoError(t, err)
+	assert.Equal(t, "example.connector", snapshot.ConnectorID)
+	assert.Equal(t, "Example Connector", snapshot.DisplayName)
+	assert.Equal(t, connector.ProtocolVersion, snapshot.Protocol)
+	assert.Equal(t, accountIdentity, snapshot.AccountIdentity)
+	encoded := assertJSON(t, snapshot)
+	assert.Contains(t, encoded, accountIdentity)
+	assert.NotContains(t, encoded, opaqueValue)
+
+	invalid := testDescription("account-1")
+	invalid.Protocol = opaqueValue + "-protocol"
+	invalidRegistry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "invalid", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client {
+		return &fakeConnectorClient{description: invalid}
+	})
+	require.NoError(t, err)
+	snapshot, err = invalidRegistry.Refresh(t.Context(), "invalid")
+	require.Error(t, err)
+	assert.NotContains(t, assertJSON(t, snapshot), opaqueValue)
+	assert.Equal(t, "connector description is invalid", snapshot.HealthError)
+}
+
+func TestRegistrySnapshotsExcludeProcessConfiguration(t *testing.T) {
+	client := &fakeConnectorClient{description: testDescription("account-1")}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+		Args: []string{"--private"}, Env: map[string]string{"TOKEN": "PRIVATE_SOURCE"},
+		Settings: map[string]any{"credential": "private-value"},
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	_, err = registry.Refresh(t.Context(), "notes")
+	require.NoError(t, err)
+
+	snapshots := registry.Snapshots()
+	require.Len(t, snapshots, 1)
+	encoded := assertJSON(t, snapshots)
+	assert.NotContains(t, encoded, "--private")
+	assert.NotContains(t, encoded, "PRIVATE_SOURCE")
+	assert.NotContains(t, encoded, "private-value")
+}
+
+func TestRegistryRefreshSnapshotsIsOrderedAndKeepsFailuresLocal(t *testing.T) {
+	clients := map[string]*fakeConnectorClient{
+		"alpha": {description: testDescription("account-alpha")},
+		"zeta": {
+			describeErr: errors.Join(
+				connectorclient.ErrProcessFailure,
+				errors.New("private connector diagnostic"),
+			),
+		},
+	}
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{
+		{ID: "zeta", Command: filepath.Join(t.TempDir(), "zeta-connector")},
+		{ID: "alpha", Command: filepath.Join(t.TempDir(), "alpha-connector")},
+	}, func(cfg config.ConnectorConfig) connectorclient.Client { return clients[cfg.ID] })
+	require.NoError(t, err)
+
+	snapshots := registry.RefreshSnapshots(t.Context())
+
+	require.Len(t, snapshots, 2)
+	assert.Equal(t, "alpha", snapshots[0].ID)
+	assert.Equal(t, "example.connector", snapshots[0].ConnectorID)
+	assert.Empty(t, snapshots[0].HealthError)
+	assert.Equal(t, "zeta", snapshots[1].ID)
+	assert.Empty(t, snapshots[1].ConnectorID)
+	assert.Equal(t, "external connector process failed", snapshots[1].HealthError)
+	assert.NotContains(t, snapshots[1].HealthError, "private")
+}
+
+func TestRegistryRejectsInvalidConfigurationBeforeConstructingClients(t *testing.T) {
+	constructed := 0
+	_, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: "relative-connector",
+	}}, func(config.ConnectorConfig) connectorclient.Client {
+		constructed++
+		return &fakeConnectorClient{}
+	})
+	require.Error(t, err)
+	assert.Zero(t, constructed)
+}
+
+func testDescription(account string) connector.Description {
+	return connector.Description{
+		ConnectorID: "example.connector", DisplayName: "Example Connector",
+		Protocol: connector.ProtocolVersion, AccountIdentity: account,
+		Capabilities: []connector.Capability{connector.CapabilityFields, connector.CapabilityConditionalFields},
+	}
+}
+
+func assertJSON(t *testing.T, value any) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(raw)
+}
+
+type blockingDescribeClient struct {
+	fakeConnectorClient
+	entered chan struct{}
+	release chan struct{}
+	calls   atomic.Int64
+}
+
+func (c *blockingDescribeClient) Describe(context.Context) (connector.Description, error) {
+	c.calls.Add(1)
+	close(c.entered)
+	<-c.release
+	return connector.Description{}, errors.New("connector unavailable")
+}
+
+type concurrentDescribeClient struct {
+	fakeConnectorClient
+	entered      chan struct{}
+	release      chan struct{}
+	next         atomic.Int64
+	descriptions [2]connector.Description
+}
+
+type allMethodsErrorConnectorClient struct {
+	err error
+}
+
+type controlledEndContext struct {
+	context.Context
+	done chan struct{}
+	mu   sync.RWMutex
+	err  error
+}
+
+func newControlledEndContext(parent context.Context) *controlledEndContext {
+	return &controlledEndContext{Context: parent, done: make(chan struct{})}
+}
+
+func (c *controlledEndContext) Done() <-chan struct{} { return c.done }
+
+func (c *controlledEndContext) Err() error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.err
+}
+
+func (c *controlledEndContext) end(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.err = err
+	close(c.done)
+}
+
+type boundaryReturnHookClient struct {
+	connectorclient.Client
+	afterDescribe   func()
+	afterListFields func()
+}
+
+func (c *boundaryReturnHookClient) Describe(ctx context.Context) (connector.Description, error) {
+	result, err := c.Client.Describe(ctx)
+	if c.afterDescribe != nil {
+		c.afterDescribe()
+	}
+	return result, err
+}
+
+func (c *boundaryReturnHookClient) ListFields(ctx context.Context) (connector.ListFieldsResult, error) {
+	result, err := c.Client.ListFields(ctx)
+	if c.afterListFields != nil {
+		c.afterListFields()
+	}
+	return result, err
+}
+
+func (c *allMethodsErrorConnectorClient) Describe(context.Context) (connector.Description, error) {
+	return connector.Description{}, c.err
+}
+
+func (c *allMethodsErrorConnectorClient) ResolveRoot(context.Context, connector.ResolveRootParams) (connector.Root, error) {
+	return connector.Root{}, c.err
+}
+
+func (c *allMethodsErrorConnectorClient) ReadRoot(context.Context, connector.ReadRootParams) (connector.Root, error) {
+	return connector.Root{}, c.err
+}
+
+func (c *allMethodsErrorConnectorClient) ListComments(context.Context, connector.ListCommentsParams) (connector.ListCommentsResult, error) {
+	return connector.ListCommentsResult{}, c.err
+}
+
+func (c *allMethodsErrorConnectorClient) CompleteRoot(context.Context, connector.CompleteRootParams) (connector.Root, error) {
+	return connector.Root{}, c.err
+}
+
+func (c *allMethodsErrorConnectorClient) PublishComment(context.Context, connector.PublishCommentParams) (connector.Comment, error) {
+	return connector.Comment{}, c.err
+}
+
+func (c *allMethodsErrorConnectorClient) ListFields(context.Context) (connector.ListFieldsResult, error) {
+	return connector.ListFieldsResult{}, c.err
+}
+
+func (c *allMethodsErrorConnectorClient) ReadFields(context.Context, connector.ReadFieldsParams) (connector.ReadFieldsResult, error) {
+	return connector.ReadFieldsResult{}, c.err
+}
+
+func (c *allMethodsErrorConnectorClient) WriteFields(context.Context, connector.WriteFieldsParams) (connector.WriteFieldsResult, error) {
+	return connector.WriteFieldsResult{}, c.err
+}
+
+func (c *concurrentDescribeClient) Describe(context.Context) (connector.Description, error) {
+	index := c.next.Add(1) - 1
+	c.entered <- struct{}{}
+	<-c.release
+	return c.descriptions[index], nil
+}

--- a/internal/rootbridge/runner.go
+++ b/internal/rootbridge/runner.go
@@ -1,0 +1,224 @@
+package rootbridge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+const (
+	defaultExternalRootScanInterval = 30 * time.Second
+	defaultExternalRootBatchLimit   = 100
+	defaultExternalRootConcurrency  = 4
+	maxExternalRootRetryDelay       = 30 * time.Minute
+	externalRootWakeBuffer          = 100
+)
+
+// RetryJitter returns an adjustment to the exponential retry delay.
+// ExternalRootRetryDelay clamps it to ten percent and caps the final delay at 30m.
+type RetryJitter func(bindingID int64, failures int, base time.Duration) time.Duration
+
+// Runner polls and wakes external-root bindings with bounded concurrency.
+type Runner struct {
+	Store         db.Storage
+	Reconciler    *Reconciler
+	Interval      time.Duration
+	WakeCh        chan int64
+	MaxConcurrent int
+	Now           func() time.Time
+	EventSink     func(db.Event)
+	ErrorSink     func(error)
+
+	reconcileFn func(context.Context, int64) (RunResult, error)
+
+	once    sync.Once
+	mu      sync.Mutex
+	pending map[int64]struct{}
+}
+
+func (r *Runner) initialize() {
+	r.once.Do(func() {
+		if r.WakeCh == nil {
+			r.WakeCh = make(chan int64, externalRootWakeBuffer)
+		}
+		r.pending = make(map[int64]struct{})
+	})
+}
+
+// Wake schedules one binding without blocking its producer. Duplicate queued
+// or in-flight work coalesces; a saturated queue drops the wake and polling
+// remains the correctness path.
+func (r *Runner) Wake(bindingID int64) {
+	if r == nil || bindingID <= 0 {
+		return
+	}
+	r.initialize()
+	r.mu.Lock()
+	if _, exists := r.pending[bindingID]; exists {
+		r.mu.Unlock()
+		return
+	}
+	r.pending[bindingID] = struct{}{}
+	r.mu.Unlock()
+	select {
+	case r.WakeCh <- bindingID:
+	default:
+		r.finished(bindingID)
+	}
+}
+
+// Run processes wakes and periodic due scans until ctx ends.
+func (r *Runner) Run(ctx context.Context) error {
+	if r == nil {
+		return errors.New("external root runner is unavailable")
+	}
+	r.initialize()
+	interval := r.Interval
+	if interval <= 0 {
+		interval = defaultExternalRootScanInterval
+	}
+	concurrency := r.MaxConcurrent
+	if concurrency <= 0 || concurrency > defaultExternalRootConcurrency {
+		concurrency = defaultExternalRootConcurrency
+	}
+	if r.reconcileFn == nil && (r.Store == nil || r.Reconciler == nil) {
+		return errors.New("external root runner dependencies are unavailable")
+	}
+	sem := make(chan struct{}, concurrency)
+	var workers sync.WaitGroup
+	launch := func(bindingID int64) {
+		select {
+		case sem <- struct{}{}:
+			workers.Go(func() {
+				defer func() {
+					if recover() != nil {
+						r.reportReconcileError(ctx, bindingID, errors.New("external root reconciliation panicked"))
+					}
+					<-sem
+					r.finished(bindingID)
+				}()
+				result, deliveredInline, err := r.reconcile(ctx, bindingID)
+				if !deliveredInline && r.EventSink != nil {
+					for _, event := range result.Events {
+						r.EventSink(event)
+					}
+				}
+				r.reportReconcileError(ctx, bindingID, err)
+			})
+		case <-ctx.Done():
+			r.finished(bindingID)
+		}
+	}
+	scan := func() error {
+		if r.Store == nil {
+			return nil
+		}
+		now := time.Now().UTC()
+		if r.Now != nil {
+			now = r.Now().UTC()
+		}
+		staleAfter := defaultExternalRootClaimStaleAfter
+		if r.Reconciler != nil {
+			staleAfter = r.Reconciler.claimStaleAfter
+		}
+		bindings, err := r.Store.ListDueExternalRootBindings(ctx, now, now.Add(-staleAfter), defaultExternalRootBatchLimit)
+		if err != nil {
+			return err
+		}
+		for _, binding := range bindings {
+			r.Wake(binding.ID)
+		}
+		return nil
+	}
+	reportScanError := func(err error) {
+		if ctx.Err() == nil && r.ErrorSink != nil {
+			r.ErrorSink(fmt.Errorf("scan due external root bindings: %w", err))
+		}
+	}
+	if err := scan(); err != nil {
+		reportScanError(err)
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	defer workers.Wait()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case bindingID := <-r.WakeCh:
+			launch(bindingID)
+		case <-ticker.C:
+			if err := scan(); err != nil {
+				reportScanError(err)
+			}
+		}
+	}
+}
+
+func (r *Runner) reconcile(ctx context.Context, bindingID int64) (RunResult, bool, error) {
+	if r.reconcileFn != nil {
+		result, err := r.reconcileFn(ctx, bindingID)
+		return result, false, err
+	}
+	result, err := r.Reconciler.Run(ctx, bindingID, RunOptions{EventSink: r.EventSink})
+	return result, true, err
+}
+
+func (r *Runner) reportReconcileError(ctx context.Context, bindingID int64, err error) {
+	if err == nil || ctx.Err() != nil || errors.Is(err, context.Canceled) || r.ErrorSink == nil {
+		return
+	}
+	r.ErrorSink(fmt.Errorf("reconcile external root binding %d: %w", bindingID, err))
+}
+
+func (r *Runner) finished(bindingID int64) {
+	r.mu.Lock()
+	delete(r.pending, bindingID)
+	r.mu.Unlock()
+}
+
+// ExternalRootRetryDelay returns the capped exponential delay for a binding.
+func ExternalRootRetryDelay(bindingID int64, failures int, jitter RetryJitter) time.Duration {
+	if failures < 0 {
+		failures = 0
+	}
+	base := 30 * time.Second
+	for i := 0; i < failures && base < maxExternalRootRetryDelay; i++ {
+		base *= 2
+		if base > maxExternalRootRetryDelay {
+			base = maxExternalRootRetryDelay
+		}
+	}
+	adjustment := deterministicExternalRootJitter(bindingID, failures, base)
+	if jitter != nil {
+		adjustment = jitter(bindingID, failures, base)
+	}
+	bound := base / 10
+	if adjustment > bound {
+		adjustment = bound
+	} else if adjustment < -bound {
+		adjustment = -bound
+	}
+	delay := base + adjustment
+	if delay > maxExternalRootRetryDelay {
+		return maxExternalRootRetryDelay
+	}
+	return delay
+}
+
+// ExternalRootRetryAt builds the immutable retry-time strategy shared by
+// background and manual reconciliations.
+func ExternalRootRetryAt(jitter RetryJitter) func(db.ExternalRootBinding, time.Time) time.Time {
+	return func(binding db.ExternalRootBinding, now time.Time) time.Time {
+		return now.Add(ExternalRootRetryDelay(binding.ID, binding.ConsecutiveFailures, jitter))
+	}
+}
+
+func deterministicExternalRootJitter(bindingID int64, failures int, base time.Duration) time.Duration {
+	percent := (bindingID+int64(failures)*17)%21 - 10
+	return time.Duration(int64(base) * percent / 100)
+}

--- a/internal/rootbridge/runner_test.go
+++ b/internal/rootbridge/runner_test.go
@@ -1,0 +1,490 @@
+package rootbridge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+)
+
+func TestRunnerDeliversRetainedEventsExactlyOnceWhenReconcileReturnsError(t *testing.T) {
+	want := db.Event{ID: 101, Type: "issue.updated", Actor: "connector:notes"}
+	delivered := make(chan db.Event, 2)
+	runner := &Runner{
+		Interval: time.Hour,
+		reconcileFn: func(context.Context, int64) (RunResult, error) {
+			return RunResult{Events: []db.Event{want}}, errors.New("terminal connector failure")
+		},
+		EventSink: func(event db.Event) { delivered <- event },
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	runner.Wake(1)
+
+	select {
+	case got := <-delivered:
+		assert.Equal(t, want, got)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retained runner event")
+	}
+	select {
+	case duplicate := <-delivered:
+		t.Fatalf("runner delivered event twice: %#v", duplicate)
+	case <-time.After(50 * time.Millisecond):
+	}
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunnerReportsBindingReconcileError(t *testing.T) {
+	reported := make(chan error, 1)
+	runner := &Runner{
+		Interval: time.Hour,
+		reconcileFn: func(context.Context, int64) (RunResult, error) {
+			return RunResult{}, errors.New("terminal connector failure")
+		},
+		ErrorSink: func(err error) { reported <- err },
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	runner.Wake(41)
+
+	select {
+	case err := <-reported:
+		assert.EqualError(t, err, "reconcile external root binding 41: terminal connector failure")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconciliation error")
+	}
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunnerDoesNotReportBindingCancellation(t *testing.T) {
+	reported := make(chan error, 1)
+	started := make(chan struct{})
+	runner := &Runner{
+		Interval: time.Hour,
+		reconcileFn: func(ctx context.Context, _ int64) (RunResult, error) {
+			close(started)
+			<-ctx.Done()
+			return RunResult{}, ctx.Err()
+		},
+		ErrorSink: func(err error) { reported <- err },
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	runner.Wake(42)
+	<-started
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	select {
+	case err := <-reported:
+		t.Fatalf("runner reported cancellation as a reconciliation failure: %v", err)
+	default:
+	}
+}
+
+func TestRunnerDeliversCommittedProjectionBeforeLaterConnectorCallReturns(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	h.client.read.Title = "Committed external title"
+	h.client.read.Revision = "root-revision-with-event"
+	h.client.read.UpdatedAt = h.now.Add(time.Minute)
+	h.client.read.ObservedAt = h.client.read.UpdatedAt
+	local := h.createLocalComment(t, "Block after the inbound transaction")
+	h.client.publishResult = publishedComment(h, "published-after-event", local.Body)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.client.beforePublish = func() {
+		close(entered)
+		<-release
+	}
+	delivered := make(chan db.Event, 8)
+	runner := &Runner{
+		Store: h.store, Reconciler: h.reconciler, Interval: time.Hour,
+		EventSink: func(event db.Event) { delivered <- event },
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	runner.Wake(h.binding.ID)
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		cancel()
+		require.FailNow(t, "later connector call did not start")
+	}
+	var eventBeforeRelease db.Event
+	select {
+	case eventBeforeRelease = <-delivered:
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(release)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	require.NotZero(t, eventBeforeRelease.ID, "committed projection event was buffered behind connector work")
+	assert.Equal(t, "issue.updated", eventBeforeRelease.Type)
+}
+
+type transientDueScanStore struct {
+	db.Storage
+	calls atomic.Int64
+}
+
+func (s *transientDueScanStore) ListDueExternalRootBindings(
+	ctx context.Context,
+	now, staleBefore time.Time,
+	limit int,
+) ([]db.ExternalRootBinding, error) {
+	if s.calls.Add(1) == 1 {
+		return nil, errors.New("transient due scan failure")
+	}
+	return s.Storage.ListDueExternalRootBindings(ctx, now, staleBefore, limit)
+}
+
+func TestRunnerRetriesTransientDueScanErrorOnNextTick(t *testing.T) {
+	h := newReconcileHarness(t)
+	store := &transientDueScanStore{Storage: h.store}
+	var reconciles atomic.Int64
+	var reported atomic.Int64
+	runner := &Runner{
+		Store: store, Interval: 5 * time.Millisecond,
+		reconcileFn: func(context.Context, int64) (RunResult, error) {
+			reconciles.Add(1)
+			return RunResult{}, nil
+		},
+		ErrorSink: func(error) { reported.Add(1) },
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return store.calls.Load() >= 2 && reconciles.Load() >= 1
+	}, time.Second, time.Millisecond)
+	assert.Equal(t, int64(1), reported.Load())
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunnerDoesNotReportDueScanErrorAfterCancellation(t *testing.T) {
+	h := newReconcileHarness(t)
+	store := &transientDueScanStore{Storage: h.store}
+	store.calls.Store(-1)
+	var reported atomic.Int64
+	runner := &Runner{Store: store, Reconciler: h.reconciler, ErrorSink: func(error) { reported.Add(1) }}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := runner.Run(ctx)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, reported.Load())
+}
+
+func TestRunnerDuplicateWakeAndPollConvergeOnce(t *testing.T) {
+	h := newReconcileHarness(t)
+	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runner := &Runner{
+		Store: h.store, Reconciler: h.reconciler, Interval: 5 * time.Millisecond,
+		reconcileFn: func(ctx context.Context, _ int64) (RunResult, error) {
+			calls.Add(1)
+			close(started)
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return RunResult{}, nil
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+
+	runner.Wake(h.binding.ID)
+	runner.Wake(h.binding.ID)
+	<-started
+	runner.Wake(h.binding.ID)
+	close(release)
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, 10*time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestExternalRootRetryDelayCapsAndUsesDeterministicJitter(t *testing.T) {
+	jitter := func(bindingID int64, _ int, base time.Duration) time.Duration {
+		assert.Equal(t, int64(42), bindingID)
+		return base / 10
+	}
+	assert.Equal(t, 33*time.Second, ExternalRootRetryDelay(42, 0, jitter))
+	assert.Equal(t, 30*time.Minute, ExternalRootRetryDelay(42, 20, jitter))
+}
+
+func TestRunnerStartupPreservesConfiguredRetryStrategyForManualReconcile(t *testing.T) {
+	h := newReconcileHarness(t)
+	wantRetryAt := h.now.Add(47 * time.Minute)
+	h.reconciler = NewReconciler(h.store, h.registry, ReconcilerConfig{
+		Now:     func() time.Time { return h.now },
+		RetryAt: func(db.ExternalRootBinding, time.Time) time.Time { return wantRetryAt },
+	})
+	started := make(chan struct{})
+	runner := &Runner{
+		Reconciler: h.reconciler,
+		Interval:   time.Hour,
+		reconcileFn: func(context.Context, int64) (RunResult, error) {
+			close(started)
+			return RunResult{}, nil
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	runner.Wake(99)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not start")
+	}
+
+	h.client.readErr = errors.New("synthetic connector failure")
+	_, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{Manual: true})
+	require.Error(t, err)
+	binding, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	require.NotNil(t, binding.NextAttemptAt)
+	assert.Equal(t, wantRetryAt, *binding.NextAttemptAt)
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunnerRecoversBindingPanicAndContinues(t *testing.T) {
+	var calls atomic.Int64
+	reported := make(chan error, 1)
+	runner := &Runner{Interval: time.Hour, ErrorSink: func(err error) { reported <- err }, reconcileFn: func(context.Context, int64) (RunResult, error) {
+		if calls.Add(1) == 1 {
+			panic("private connector diagnostic")
+		}
+		return RunResult{}, nil
+	}}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	runner.Wake(1)
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, 10*time.Millisecond)
+	select {
+	case err := <-reported:
+		assert.EqualError(t, err, "reconcile external root binding 1: external root reconciliation panicked")
+		assert.NotContains(t, err.Error(), "private connector diagnostic")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for recovered panic report")
+	}
+	runner.Wake(2)
+	require.Eventually(t, func() bool { return calls.Load() == 2 }, time.Second, 10*time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunnerConnectorPanicPersistsRetryBeforeReleasingClaim(t *testing.T) {
+	h := newReconcileHarness(t)
+	h.client.beforeReadReturn = func() { panic("private connector diagnostic") }
+	h.reconciler = NewReconciler(h.store, h.registry, ReconcilerConfig{
+		Now: func() time.Time { return h.now },
+		RetryAt: ExternalRootRetryAt(func(_ int64, _ int, base time.Duration) time.Duration {
+			return base / 10
+		}),
+	})
+	runner := &Runner{
+		Store: h.store, Reconciler: h.reconciler, Interval: time.Hour,
+		Now: func() time.Time { return h.now },
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	require.Eventually(t, func() bool {
+		binding, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+		return err == nil && binding.ConsecutiveFailures == 1
+	}, time.Second, 10*time.Millisecond)
+	binding, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	assert.Empty(t, binding.ClaimToken)
+	assert.Equal(t, "external connector panicked", binding.LastError)
+	require.NotNil(t, binding.NextAttemptAt)
+	assert.Equal(t, h.now.Add(33*time.Second), *binding.NextAttemptAt)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunnerLimitsConcurrencyToFour(t *testing.T) {
+	h := newReconcileHarness(t)
+	for i := 2; i <= 6; i++ {
+		createRunnerBinding(t, h, i)
+	}
+	var active atomic.Int64
+	var maximum atomic.Int64
+	started := make(chan struct{}, 6)
+	release := make(chan struct{})
+	runner := &Runner{Store: h.store, Interval: time.Hour, MaxConcurrent: 5, reconcileFn: func(ctx context.Context, _ int64) (RunResult, error) {
+		current := active.Add(1)
+		for {
+			prior := maximum.Load()
+			if current <= prior || maximum.CompareAndSwap(prior, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		active.Add(-1)
+		return RunResult{}, nil
+	}}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	for range 4 {
+		<-started
+	}
+	assert.Equal(t, int64(4), maximum.Load())
+	select {
+	case <-started:
+		t.Fatal("runner exceeded four concurrent reconciliations")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	require.Eventually(t, func() bool { return active.Load() == 0 }, time.Second, 10*time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunnerWakeQueueSaturationNeverBlocksProducer(t *testing.T) {
+	runner := &Runner{WakeCh: make(chan int64, 1)}
+	started := time.Now()
+	for i := int64(1); i <= 1000; i++ {
+		runner.Wake(i)
+	}
+	assert.Less(t, time.Since(started), 100*time.Millisecond)
+	assert.Len(t, runner.WakeCh, 1)
+	// The retained item remains coalesced; repeated duplicate wakes do not grow
+	// the queue or block either.
+	for range 1000 {
+		runner.Wake(1)
+	}
+	assert.Len(t, runner.WakeCh, 1)
+}
+
+func TestRunnerPollFallbackExcludesPausedBinding(t *testing.T) {
+	h := newReconcileHarness(t)
+	_, _, err := h.store.PauseExternalRootBinding(t.Context(), db.ExternalRootActionParams{
+		BindingID: h.binding.ID, Actor: "operator", Reason: "operator_pause",
+	})
+	require.NoError(t, err)
+	var calls atomic.Int64
+	runner := &Runner{Store: h.store, Interval: 5 * time.Millisecond, reconcileFn: func(context.Context, int64) (RunResult, error) {
+		calls.Add(1)
+		return RunResult{}, nil
+	}}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	time.Sleep(30 * time.Millisecond)
+	assert.Zero(t, calls.Load())
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+
+	_, _, err = h.store.ResumeExternalRootBinding(t.Context(), db.ExternalRootActionParams{BindingID: h.binding.ID, Actor: "operator"})
+	require.NoError(t, err)
+	ctx, cancel = context.WithCancel(t.Context())
+	done = make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	require.Eventually(t, func() bool { return calls.Load() > 0 }, time.Second, 10*time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunnerPollRecoversStaleClaim(t *testing.T) {
+	h := newReconcileHarness(t)
+	old := h.now.Add(-10 * time.Minute)
+	_, ok, err := h.store.ClaimExternalRootBinding(t.Context(), h.binding.ID, "stale-claim", old, old.Add(-5*time.Minute))
+	require.NoError(t, err)
+	require.True(t, ok)
+	runner := &Runner{Store: h.store, Reconciler: h.reconciler, Interval: time.Hour, Now: func() time.Time { return h.now }}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+	require.Eventually(t, func() bool {
+		binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+		return readErr == nil && binding.LastSuccessAt != nil
+	}, time.Second, 10*time.Millisecond)
+	binding, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	assert.Empty(t, binding.ClaimToken)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func createRunnerBinding(t *testing.T, h *reconcileHarness, index int) db.ExternalRootBinding {
+	t.Helper()
+	issue, _, err := h.store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: h.project.ID, Title: fmt.Sprintf("Root %d", index), Author: "tester",
+	})
+	require.NoError(t, err)
+	binding, _, err := h.store.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: h.project.ID, IssueID: issue.ID, ConnectorInstance: "notes",
+		ExternalRootKey: fmt.Sprintf("root-%d", index), ExternalAccountKey: "account-1",
+		Actor: "tester", ReceiveCommentsAfter: h.boundAt,
+	})
+	require.NoError(t, err)
+	return binding
+}
+
+func TestManualReconcileBypassesDueButNotEnabledOrClaim(t *testing.T) {
+	h := newReconcileHarness(t)
+	next := h.now.Add(time.Hour)
+	claimedForFailure, ok, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, "failure-claim", h.now, h.now.Add(-5*time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, err = h.store.RecordExternalRootError(t.Context(), db.ExternalRootErrorParams{
+		BindingID: claimedForFailure.ID, ClaimToken: claimedForFailure.ClaimToken,
+		At: h.now, NextAttemptAt: next, Error: "temporary failure",
+	})
+	require.NoError(t, err)
+	claimed, ok, err := h.store.ClaimExternalRootBindingForManualReconcile(
+		t.Context(), h.binding.ID, "manual-claim", h.now, h.now.Add(-5*time.Minute),
+	)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "manual-claim", claimed.ClaimToken)
+	assert.Equal(t, &next, claimed.NextAttemptAt)
+
+	_, ok, err = h.store.ClaimExternalRootBindingForManualReconcile(
+		t.Context(), h.binding.ID, "other-claim", h.now, h.now.Add(-5*time.Minute),
+	)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	_, err = h.store.ReleaseExternalRootClaim(t.Context(), h.binding.ID, "manual-claim")
+	require.NoError(t, err)
+	_, _, err = h.store.PauseExternalRootBinding(t.Context(), db.ExternalRootActionParams{
+		BindingID: h.binding.ID, Actor: "operator", Reason: "operator_pause",
+	})
+	require.NoError(t, err)
+	_, ok, err = h.store.ClaimExternalRootBindingForManualReconcile(
+		t.Context(), h.binding.ID, "paused-claim", h.now, h.now.Add(-5*time.Minute),
+	)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/internal/rootbridge/service.go
+++ b/internal/rootbridge/service.go
@@ -1,0 +1,905 @@
+package rootbridge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"go.kenn.io/kata/internal/db"
+	katauid "go.kenn.io/kata/internal/uid"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+var (
+	// ErrExternalFieldNotFound reports an unknown external field selector.
+	ErrExternalFieldNotFound = errors.New("external field not found")
+	// ErrExternalFieldAmbiguous reports a selector that matches multiple fields.
+	ErrExternalFieldAmbiguous = errors.New("external field is ambiguous")
+	// ErrImmediateReconcileUnavailable reports a missing bind-time reconcile hook.
+	ErrImmediateReconcileUnavailable = errors.New("immediate claimed reconciliation is unavailable")
+	// ErrCommentPublishingUnavailable reports an instance without safe publishing support.
+	ErrCommentPublishingUnavailable = errors.New("connector comment publishing is unavailable")
+	// ErrFieldSynchronizationUnavailable reports an instance without field synchronization support.
+	ErrFieldSynchronizationUnavailable = errors.New("connector field synchronization is unavailable")
+	// ErrPendingCommentResolutionRequired reports a pending publication requiring an operator decision.
+	ErrPendingCommentResolutionRequired = errors.New("pending external comment requires explicit resolution")
+	// ErrFieldConflictChanged reports candidates that drifted before resolution.
+	ErrFieldConflictChanged = errors.New("external field conflict changed")
+)
+
+// ImmediateClaimedReconcileFunc is the bind-time handoff to the reconciler.
+// The binding is already reserved with claimToken when this function starts;
+// implementations use that token to complete one reconciliation before
+// returning instead of claiming again.
+type ImmediateClaimedReconcileFunc func(context.Context, int64, string) ([]db.Event, error)
+
+// Service coordinates connector validation with durable binding state.
+type Service struct {
+	store                     db.Storage
+	registry                  *Registry
+	immediateClaimedReconcile ImmediateClaimedReconcileFunc
+	claimStaleAfter           time.Duration
+	eventSink                 func(db.Event)
+}
+
+// NewService constructs the external-root lifecycle service.
+func NewService(store db.Storage, registry *Registry, reconcile ImmediateClaimedReconcileFunc) *Service {
+	return NewServiceWithEventSink(store, registry, reconcile, nil)
+}
+
+// NewServiceWithEventSink constructs the lifecycle service and delivers each
+// committed service event before any later connector work begins.
+func NewServiceWithEventSink(
+	store db.Storage,
+	registry *Registry,
+	reconcile ImmediateClaimedReconcileFunc,
+	eventSink func(db.Event),
+) *Service {
+	return &Service{
+		store: store, registry: registry, immediateClaimedReconcile: reconcile,
+		claimStaleAfter: defaultExternalRootClaimStaleAfter, eventSink: eventSink,
+	}
+}
+
+func (s *Service) emitEvents(events ...db.Event) {
+	if s == nil || s.eventSink == nil {
+		return
+	}
+	for _, event := range events {
+		if event.ID != 0 {
+			s.eventSink(event)
+		}
+	}
+}
+
+// BindParams selects a Kata issue and external root to bind.
+type BindParams struct {
+	ProjectID         int64
+	IssueID           int64
+	ConnectorInstance string
+	Locator           string
+	Actor             string
+	PublishComments   bool
+}
+
+// ResolvePendingCommentParams selects an operator action for a pending publish.
+type ResolvePendingCommentParams struct {
+	IssueID           int64
+	Actor             string
+	Action            string
+	ExternalCommentID string
+}
+
+// ResolvePendingComment adopts, retries, or durably skips one pending publish.
+func (s *Service) ResolvePendingComment(
+	ctx context.Context,
+	params ResolvePendingCommentParams,
+) (resolved db.ExternalRootBinding, event db.Event, returnErr error) {
+	params.Actor = strings.TrimSpace(params.Actor)
+	params.Action = strings.TrimSpace(params.Action)
+	if params.IssueID <= 0 || params.Actor == "" {
+		return resolved, event, fmt.Errorf("%w: issue and actor are required", db.ErrExternalRootValidation)
+	}
+	switch params.Action {
+	case "adopt":
+		if strings.TrimSpace(params.ExternalCommentID) == "" {
+			return resolved, event, fmt.Errorf("%w: adopt requires an external comment ID", db.ErrExternalRootValidation)
+		}
+	case "retry", "skip":
+		if params.ExternalCommentID != "" {
+			return resolved, event, fmt.Errorf("%w: external comment ID is only valid for adopt", db.ErrExternalRootValidation)
+		}
+	default:
+		return resolved, event, fmt.Errorf("%w: unsupported pending comment action", db.ErrExternalRootValidation)
+	}
+	binding, err := s.store.ExternalRootBindingByIssue(ctx, params.IssueID)
+	if err != nil {
+		return resolved, event, err
+	}
+	if !binding.Active || !binding.PublishComments || binding.PendingCommentUID == "" ||
+		binding.PendingCommentStartedAt == nil {
+		return resolved, event, ErrPendingCommentResolutionRequired
+	}
+	claimToken, err := katauid.New()
+	if err != nil {
+		return resolved, event, fmt.Errorf("generate pending comment claim token: %w", err)
+	}
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	claimed, acquired, err := s.store.ClaimExternalRootBindingForManualAction(
+		ctx, binding.ID, claimToken, now, now.Add(-defaultExternalRootClaimStaleAfter),
+	)
+	if err != nil {
+		return resolved, event, err
+	}
+	if !acquired {
+		return resolved, event, db.ErrExternalRootClaimLost
+	}
+	parentCtx := ctx
+	var lease *externalRootClaimLease
+	defer func() {
+		if lease != nil {
+			if leaseErr := lease.stop(); leaseErr != nil {
+				returnErr = errors.Join(returnErr, leaseErr)
+			}
+		}
+		finalizeCtx, finalizeCancel := context.WithTimeout(
+			context.WithoutCancel(parentCtx), externalRootFinalizationTimeout,
+		)
+		defer finalizeCancel()
+		released, releaseErr := s.store.ReleaseExternalRootClaim(finalizeCtx, binding.ID, claimToken)
+		if releaseErr != nil && !errors.Is(releaseErr, db.ErrExternalRootClaimLost) {
+			returnErr = errors.Join(returnErr, fmt.Errorf("release pending comment claim: %w", releaseErr))
+			return
+		}
+		if releaseErr == nil {
+			resolved = released
+		}
+	}()
+	lease, err = startExternalRootClaimLease(
+		ctx, s.store, claimed.ID, claimToken, s.claimStaleAfter,
+		func() time.Time { return time.Now().UTC().Truncate(time.Millisecond) },
+	)
+	if err != nil {
+		return resolved, event, err
+	}
+	ctx = lease.ctx
+
+	comments, err := s.store.CommentsByIssue(ctx, claimed.IssueID)
+	if err != nil {
+		return resolved, event, err
+	}
+	var local db.Comment
+	for _, comment := range comments {
+		if comment.UID == claimed.PendingCommentUID {
+			local = comment
+			break
+		}
+	}
+	if local.ID == 0 {
+		return resolved, event, ErrPendingCommentResolutionRequired
+	}
+	var mapping *db.ImportMappingParams
+	externalRevision := ""
+	if params.Action == "adopt" {
+		instance, instanceErr := s.requireInstance(claimed.ConnectorInstance)
+		if instanceErr != nil {
+			return resolved, event, instanceErr
+		}
+		description, describeErr := s.describe(ctx, instance)
+		if describeErr != nil {
+			return resolved, event, describeErr
+		}
+		if !descriptionSupportsPublishing(description) {
+			return resolved, event, ErrCommentPublishingUnavailable
+		}
+		root, readErr := instance.Client.ReadRoot(ctx, connector.ReadRootParams{RootKey: claimed.ExternalRootKey})
+		if readErr != nil {
+			return resolved, event, readErr
+		}
+		if root.Key != claimed.ExternalRootKey || root.IdentityKey != claimed.ExternalAccountKey ||
+			description.AccountIdentity != claimed.ExternalAccountKey {
+			return resolved, event, fmt.Errorf("%w: account or root does not match binding", ErrConnectorIdentityChanged)
+		}
+		listed, listErr := instance.Client.ListComments(ctx, connector.ListCommentsParams{RootKey: claimed.ExternalRootKey})
+		if listErr != nil {
+			return resolved, event, listErr
+		}
+		var matched *connector.Comment
+		for index := range listed.Comments {
+			candidate := &listed.Comments[index]
+			if candidate.ID != params.ExternalCommentID {
+				continue
+			}
+			if matched != nil || !matchesManualPendingExternalComment(*candidate, description.SelfActorID) {
+				return resolved, event, ErrPendingCommentResolutionRequired
+			}
+			matched = candidate
+		}
+		if matched == nil {
+			return resolved, event, ErrPendingCommentResolutionRequired
+		}
+		if strings.TrimSpace(matched.Revision) == "" || strings.TrimSpace(matched.Revision) != matched.Revision {
+			return resolved, event, ErrPendingCommentResolutionRequired
+		}
+		built, mappingErr := externalCommentMapping(claimed, local, *matched)
+		if mappingErr != nil {
+			return resolved, event, ErrPendingCommentResolutionRequired
+		}
+		mapping = &built
+		externalRevision = matched.Revision
+	} else if params.Action == "skip" {
+		built := skippedCommentMapping(claimed, local)
+		mapping = &built
+	}
+	resolved, event, err = s.store.ClearPendingExternalComment(ctx, db.ClearPendingExternalCommentParams{
+		BindingID: claimed.ID, ClaimToken: claimToken, CommentUID: claimed.PendingCommentUID,
+		ExpectedBody: local.Body, Action: params.Action, Actor: params.Actor, At: time.Now().UTC(), Mapping: mapping,
+		ExternalRevision: externalRevision,
+	})
+	if err != nil {
+		return resolved, event, err
+	}
+	s.emitEvents(event)
+	return resolved, event, nil
+}
+
+// Bind validates an external root, creates its binding, and reconciles it once.
+func (s *Service) Bind(ctx context.Context, params BindParams) (db.ExternalRootBinding, []db.Event, error) {
+	params.ConnectorInstance = strings.TrimSpace(params.ConnectorInstance)
+	params.Locator = strings.TrimSpace(params.Locator)
+	params.Actor = strings.TrimSpace(params.Actor)
+	if params.ProjectID <= 0 || params.IssueID <= 0 || params.ConnectorInstance == "" || params.Locator == "" || params.Actor == "" {
+		return db.ExternalRootBinding{}, nil, fmt.Errorf("%w: project, issue, connector, locator, and actor are required", db.ErrExternalRootValidation)
+	}
+	if s.immediateClaimedReconcile == nil {
+		return db.ExternalRootBinding{}, nil, ErrImmediateReconcileUnavailable
+	}
+	instance, err := s.requireInstance(params.ConnectorInstance)
+	if err != nil {
+		return db.ExternalRootBinding{}, nil, err
+	}
+	description, err := s.describe(ctx, instance)
+	if err != nil {
+		return db.ExternalRootBinding{}, nil, err
+	}
+	if params.PublishComments && !descriptionSupportsPublishing(description) {
+		return db.ExternalRootBinding{}, nil, ErrCommentPublishingUnavailable
+	}
+	root, err := instance.Client.ResolveRoot(ctx, connector.ResolveRootParams{Locator: params.Locator})
+	if err != nil {
+		return db.ExternalRootBinding{}, nil, err
+	}
+	if err := validateResolvedRoot(root); err != nil {
+		return db.ExternalRootBinding{}, nil, err
+	}
+	if description.AccountIdentity != root.IdentityKey {
+		return db.ExternalRootBinding{}, nil, fmt.Errorf("%w: description and root account differ", ErrConnectorIdentityChanged)
+	}
+	listedComments, err := instance.Client.ListComments(ctx, connector.ListCommentsParams{RootKey: root.Key})
+	if err != nil {
+		return db.ExternalRootBinding{}, nil, err
+	}
+	initialCommentRevisions := make([]db.ExternalCommentRevision, 0, len(listedComments.Comments))
+	for _, comment := range listedComments.Comments {
+		initialCommentRevisions = append(initialCommentRevisions, db.ExternalCommentRevision{
+			ExternalID: comment.ID, Revision: comment.Revision,
+		})
+	}
+	claimToken, err := katauid.New()
+	if err != nil {
+		return db.ExternalRootBinding{}, nil, fmt.Errorf("generate initial external root claim: %w", err)
+	}
+	claimStartedAt := time.Now().UTC()
+
+	create := db.CreateExternalRootBindingParams{
+		ProjectID: params.ProjectID, IssueID: params.IssueID,
+		ConnectorInstance: params.ConnectorInstance, ExternalRootKey: root.Key,
+		ExternalAccountKey: root.IdentityKey, Actor: params.Actor,
+		ReceiveCommentsAfter: root.ObservedAt, PublishComments: params.PublishComments,
+		UseLocalPublishFrontier:    params.PublishComments,
+		UseCommentIdentityFrontier: true,
+		InitialCommentRevisions:    initialCommentRevisions,
+		InitialClaimToken:          claimToken,
+		InitialClaimStartedAt:      claimStartedAt,
+	}
+	binding, bound, err := s.store.CreateExternalRootBinding(ctx, create)
+	if err != nil {
+		return db.ExternalRootBinding{}, nil, err
+	}
+	s.emitEvents(bound)
+	events := []db.Event{bound}
+	reconciled, err := s.immediateClaimedReconcile(ctx, binding.ID, binding.ClaimToken)
+	events = append(events, reconciled...)
+	if err != nil {
+		return binding, events, fmt.Errorf("immediate reconcile external root: %w", err)
+	}
+	if _, err := s.store.IssueByID(ctx, params.IssueID); err != nil {
+		return binding, events, fmt.Errorf("read reconciled issue: %w", err)
+	}
+	binding, err = s.store.ExternalRootBindingByID(ctx, binding.ID)
+	if err != nil {
+		return db.ExternalRootBinding{}, events, fmt.Errorf("read reconciled binding: %w", err)
+	}
+	return binding, events, nil
+}
+
+func descriptionSupportsPublishing(description connector.Description) bool {
+	if strings.TrimSpace(description.SelfActorID) == "" {
+		return false
+	}
+	return descriptionHasCapability(description, connector.CapabilityPublishComment)
+}
+
+func descriptionSupportsFields(description connector.Description) bool {
+	return descriptionHasCapability(description, connector.CapabilityFields) &&
+		descriptionHasCapability(description, connector.CapabilityConditionalFields)
+}
+
+func descriptionHasCapability(description connector.Description, want connector.Capability) bool {
+	return slices.Contains(description.Capabilities, want)
+}
+
+// Pause disables reconciliation for an issue's active binding.
+func (s *Service) Pause(ctx context.Context, issueID int64, actor, reason string) (db.ExternalRootBinding, db.Event, error) {
+	binding, err := s.store.ExternalRootBindingByIssue(ctx, issueID)
+	if err != nil {
+		return db.ExternalRootBinding{}, db.Event{}, err
+	}
+	paused, event, err := s.store.PauseExternalRootBinding(ctx, db.ExternalRootActionParams{
+		BindingID: binding.ID, Actor: actor, Reason: reason,
+		StaleBefore: time.Now().UTC().Add(-s.claimStaleAfter),
+	})
+	if err == nil {
+		s.emitEvents(event)
+	}
+	return paused, event, err
+}
+
+// Resume revalidates connector identity before enabling a paused binding.
+func (s *Service) Resume(ctx context.Context, issueID int64, actor string) (db.ExternalRootBinding, db.Event, error) {
+	binding, err := s.store.ExternalRootBindingByIssue(ctx, issueID)
+	if err != nil {
+		return db.ExternalRootBinding{}, db.Event{}, err
+	}
+	instance, err := s.requireInstance(binding.ConnectorInstance)
+	if err != nil {
+		return db.ExternalRootBinding{}, db.Event{}, err
+	}
+	description, err := s.describe(ctx, instance)
+	if err != nil {
+		return db.ExternalRootBinding{}, db.Event{}, err
+	}
+	if binding.PublishComments && !descriptionSupportsPublishing(description) {
+		return db.ExternalRootBinding{}, db.Event{}, ErrCommentPublishingUnavailable
+	}
+	root, err := instance.Client.ReadRoot(ctx, connector.ReadRootParams{RootKey: binding.ExternalRootKey})
+	if err != nil {
+		return db.ExternalRootBinding{}, db.Event{}, err
+	}
+	if root.Key != binding.ExternalRootKey || root.IdentityKey != binding.ExternalAccountKey ||
+		description.AccountIdentity != binding.ExternalAccountKey {
+		return db.ExternalRootBinding{}, db.Event{}, fmt.Errorf("%w: account or root does not match binding", ErrConnectorIdentityChanged)
+	}
+	resumed, event, err := s.store.ResumeExternalRootBinding(
+		ctx, db.ExternalRootActionParams{BindingID: binding.ID, Actor: actor},
+	)
+	if err == nil {
+		s.emitEvents(event)
+	}
+	return resumed, event, err
+}
+
+// Unbind permanently detaches an issue from its external root.
+func (s *Service) Unbind(ctx context.Context, issueID int64, actor string) (db.ExternalRootBinding, db.Event, error) {
+	binding, err := s.store.ExternalRootBindingByIssue(ctx, issueID)
+	if err != nil {
+		return db.ExternalRootBinding{}, db.Event{}, err
+	}
+	unbound, event, err := s.store.UnbindExternalRootBinding(ctx, db.ExternalRootActionParams{
+		BindingID: binding.ID, Actor: actor,
+		StaleBefore: time.Now().UTC().Add(-s.claimStaleAfter),
+	})
+	if err == nil {
+		s.emitEvents(event)
+	}
+	return unbound, event, err
+}
+
+// MapFieldParams selects one Kata planning field and one external field.
+type MapFieldParams struct {
+	ConnectorInstance string
+	KataField         string
+	ExternalField     string
+}
+
+// MapField validates and persists one connector-level field mapping.
+func (s *Service) MapField(ctx context.Context, params MapFieldParams) (db.ExternalFieldMapping, error) {
+	params.ConnectorInstance = strings.TrimSpace(params.ConnectorInstance)
+	params.KataField = strings.TrimSpace(params.KataField)
+	params.ExternalField = strings.TrimSpace(params.ExternalField)
+	codec, ok := fieldCodecs[params.KataField]
+	if !ok {
+		return db.ExternalFieldMapping{}, fmt.Errorf("%w: unsupported Kata field", db.ErrExternalFieldMappingValidation)
+	}
+	instance, err := s.requireInstance(params.ConnectorInstance)
+	if err != nil {
+		return db.ExternalFieldMapping{}, err
+	}
+	description, err := s.describe(ctx, instance)
+	if err != nil {
+		return db.ExternalFieldMapping{}, err
+	}
+	if !descriptionSupportsFields(description) {
+		return db.ExternalFieldMapping{}, ErrFieldSynchronizationUnavailable
+	}
+	listed, err := instance.Client.ListFields(ctx)
+	if err != nil {
+		return db.ExternalFieldMapping{}, err
+	}
+	descriptor, err := resolveExternalField(listed.Fields, params.ExternalField)
+	if err != nil {
+		return db.ExternalFieldMapping{}, err
+	}
+	if err := codec.ValidateExternalDescriptor(descriptor); err != nil {
+		return db.ExternalFieldMapping{}, fmt.Errorf("%w: validate external field %q: %w", db.ErrExternalFieldMappingValidation, descriptor.ID, err)
+	}
+	return s.store.UpsertExternalFieldMapping(ctx, db.ExternalFieldMappingParams{
+		ConnectorInstance: params.ConnectorInstance, KataField: params.KataField,
+		ExternalFieldID: descriptor.ID, ExternalFieldName: descriptor.DisplayName,
+		AcceptedKinds: append([]string(nil), descriptor.AcceptedKinds...),
+		Nullable:      descriptor.Nullable, Writable: descriptor.Writable,
+		SchemaRevision: descriptor.SchemaRevision,
+	})
+}
+
+// UnmapField removes one connector-level field mapping.
+func (s *Service) UnmapField(ctx context.Context, connectorInstance, kataField string) (db.ExternalFieldMapping, error) {
+	connectorInstance = strings.TrimSpace(connectorInstance)
+	kataField = strings.TrimSpace(kataField)
+	if _, ok := fieldCodecs[kataField]; !ok {
+		return db.ExternalFieldMapping{}, fmt.Errorf("%w: unsupported Kata field", db.ErrExternalFieldMappingValidation)
+	}
+	if _, err := s.requireInstance(connectorInstance); err != nil {
+		return db.ExternalFieldMapping{}, err
+	}
+	return s.store.UnmapExternalField(ctx, connectorInstance, kataField)
+}
+
+// ResolveFieldConflict applies one chosen candidate and clears the conflict.
+func (s *Service) ResolveFieldConflict(
+	ctx context.Context,
+	issueID int64,
+	kataField string,
+	use string,
+	actor string,
+) (resolved db.ExternalFieldState, events []db.Event, returnErr error) {
+	kataField = strings.TrimSpace(kataField)
+	use = strings.TrimSpace(use)
+	actor = strings.TrimSpace(actor)
+	codec, ok := fieldCodecs[kataField]
+	if issueID <= 0 || !ok || actor == "" {
+		return resolved, events, fmt.Errorf("%w: issue, supported Kata field, and actor are required", db.ErrExternalRootValidation)
+	}
+	if use != "kata" && use != "external" {
+		return resolved, events, fmt.Errorf("%w: field conflict resolution must use kata or external", db.ErrExternalRootValidation)
+	}
+	binding, err := s.store.ExternalRootBindingByIssue(ctx, issueID)
+	if err != nil {
+		return resolved, events, err
+	}
+	if !binding.Active || !binding.Enabled {
+		return resolved, events, db.ErrExternalRootClaimLost
+	}
+	mappings, err := s.store.ListExternalFieldMappings(ctx, binding.ConnectorInstance)
+	if err != nil {
+		return resolved, events, err
+	}
+	var mapping db.ExternalFieldMapping
+	for _, candidate := range mappings {
+		if !candidate.Active || candidate.KataField != kataField {
+			continue
+		}
+		if mapping.ID != 0 {
+			return resolved, events, fmt.Errorf("%w: multiple active mappings for %s", db.ErrExternalRootValidation, kataField)
+		}
+		mapping = candidate
+	}
+	if mapping.ID == 0 {
+		return resolved, events, fmt.Errorf("%w: %s", ErrExternalFieldNotFound, kataField)
+	}
+	states, err := s.store.ExternalFieldStates(ctx, binding.ID)
+	if err != nil {
+		return resolved, events, err
+	}
+	var conflicted db.ExternalFieldState
+	for _, candidate := range states {
+		if candidate.MappingID == mapping.ID {
+			conflicted = candidate
+			break
+		}
+	}
+	if !conflicted.Conflicted {
+		return resolved, events, db.ErrExternalFieldNotConflicted
+	}
+
+	claimToken, err := katauid.New()
+	if err != nil {
+		return resolved, events, fmt.Errorf("generate field conflict claim token: %w", err)
+	}
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	claimed, acquired, err := s.store.ClaimExternalRootBindingForManualReconcile(
+		ctx, binding.ID, claimToken, now, now.Add(-defaultExternalRootClaimStaleAfter),
+	)
+	if err != nil {
+		return resolved, events, err
+	}
+	if !acquired {
+		return resolved, events, db.ErrExternalRootClaimLost
+	}
+	parentCtx := ctx
+	var lease *externalRootClaimLease
+	defer func() {
+		if lease != nil {
+			if leaseErr := lease.stop(); leaseErr != nil {
+				returnErr = errors.Join(returnErr, leaseErr)
+			}
+		}
+		finalizeCtx, finalizeCancel := context.WithTimeout(
+			context.WithoutCancel(parentCtx), externalRootFinalizationTimeout,
+		)
+		defer finalizeCancel()
+		_, releaseErr := s.store.ReleaseExternalRootClaim(finalizeCtx, claimed.ID, claimToken)
+		if releaseErr != nil && !errors.Is(releaseErr, db.ErrExternalRootClaimLost) {
+			returnErr = errors.Join(returnErr, fmt.Errorf("release field conflict claim: %w", releaseErr))
+		}
+	}()
+	lease, err = startExternalRootClaimLease(
+		ctx, s.store, claimed.ID, claimToken, s.claimStaleAfter,
+		func() time.Time { return time.Now().UTC().Truncate(time.Millisecond) },
+	)
+	if err != nil {
+		return resolved, events, err
+	}
+	ctx = lease.ctx
+	claimedMappings, err := s.store.ListExternalFieldMappings(ctx, claimed.ConnectorInstance)
+	if err != nil {
+		return resolved, events, err
+	}
+	var claimedMapping db.ExternalFieldMapping
+	for _, candidate := range claimedMappings {
+		if !candidate.Active || candidate.KataField != kataField {
+			continue
+		}
+		if candidate.ID != mapping.ID || claimedMapping.ID != 0 {
+			return resolved, events, ErrFieldConflictChanged
+		}
+		claimedMapping = candidate
+	}
+	if claimedMapping.ID == 0 {
+		return resolved, events, ErrFieldConflictChanged
+	}
+	mapping = claimedMapping
+	claimedStates, err := s.store.ExternalFieldStates(ctx, claimed.ID)
+	if err != nil {
+		return resolved, events, err
+	}
+	conflicted = db.ExternalFieldState{}
+	for _, candidate := range claimedStates {
+		if candidate.MappingID == mapping.ID {
+			conflicted = candidate
+			break
+		}
+	}
+	if !conflicted.Conflicted {
+		return resolved, events, ErrFieldConflictChanged
+	}
+
+	instance, err := s.requireInstance(claimed.ConnectorInstance)
+	if err != nil {
+		return resolved, events, err
+	}
+	description, err := s.describe(ctx, instance)
+	if err != nil {
+		return resolved, events, err
+	}
+	if !descriptionSupportsFields(description) {
+		return resolved, events, ErrFieldSynchronizationUnavailable
+	}
+	root, err := instance.Client.ReadRoot(ctx, connector.ReadRootParams{RootKey: claimed.ExternalRootKey})
+	if err != nil {
+		return resolved, events, err
+	}
+	if description.AccountIdentity != claimed.ExternalAccountKey || root.Key != claimed.ExternalRootKey ||
+		root.IdentityKey != claimed.ExternalAccountKey {
+		return resolved, events, fmt.Errorf("%w: account or root does not match binding", ErrConnectorIdentityChanged)
+	}
+	listed, err := instance.Client.ListFields(ctx)
+	if err != nil {
+		return resolved, events, err
+	}
+	if _, err := validateLiveFieldDescriptor(codec, mapping, listed.Fields); err != nil {
+		return resolved, events, ErrFieldConflictChanged
+	}
+	issue, err := s.store.IssueByID(ctx, claimed.IssueID)
+	if err != nil {
+		return resolved, events, err
+	}
+	kataValue, err := readCanonicalKataField(codec, issue, mapping)
+	if err != nil {
+		return resolved, events, ErrFieldConflictChanged
+	}
+	snapshot := reconcileSnapshot{binding: claimed, client: instance.Client}
+	externalValue, observedExternal, err := readMappedExternalFieldObserved(ctx, &snapshot, mapping)
+	if err != nil {
+		if isInvalidExternalFieldRead(err) {
+			return resolved, events, ErrFieldConflictChanged
+		}
+		return resolved, events, err
+	}
+	storedKata, hasKata, err := decodeCanonicalStoredFieldValue(conflicted.ConflictKata, mapping)
+	if err != nil || !hasKata {
+		return resolved, events, ErrFieldConflictChanged
+	}
+	storedExternal, hasExternal, err := decodeCanonicalStoredFieldValue(conflicted.ConflictExternal, mapping)
+	if err != nil || !hasExternal {
+		return resolved, events, ErrFieldConflictChanged
+	}
+	selected := storedKata
+	coordinatedTimezone := ""
+	if use == "external" {
+		selected = storedExternal
+		coordinatedTimezone = coordinatedConflictTimezone(
+			issue, mapping, claimedMappings, claimedStates, selected,
+		)
+	}
+	kataCandidateStable := fieldValuesEqual(kataValue, storedKata)
+	if use == "external" && !kataCandidateStable {
+		kataCandidateStable = fieldValuesEqual(kataValue, selected) || coordinatedConflictKataDriftAllowed(
+			issue, mapping, claimedMappings, claimedStates, storedKata, kataValue, storedExternal,
+		)
+	}
+	externalCandidateStable := fieldValuesEqual(externalValue, storedExternal)
+	if use == "kata" && !externalCandidateStable {
+		externalCandidateStable = fieldValuesEqual(externalValue, selected)
+	}
+	if !kataCandidateStable || !externalCandidateStable {
+		return resolved, events, ErrFieldConflictChanged
+	}
+	projected := issue
+	if !fieldValuesEqual(kataValue, selected) {
+		patch, patchErr := kataPatchWithCoordinatedTimezone(codec, issue, selected, coordinatedTimezone)
+		if patchErr != nil {
+			return resolved, events, patchErr
+		}
+		var event *db.Event
+		projected, event, _, err = s.store.ApplyExternalFieldProjection(ctx, db.ExternalFieldProjectionParams{
+			BindingID: claimed.ID, MappingID: mapping.ID, ClaimToken: claimToken,
+			KataField: kataField, Patch: patch, ExpectedIssueRevision: issue.Revision,
+			IntegrationActor: integrationActor(claimed),
+		})
+		if err != nil {
+			return resolved, events, err
+		}
+		if event != nil {
+			s.emitEvents(*event)
+			events = append(events, *event)
+		}
+	}
+	if use == "kata" && !fieldValuesEqual(externalValue, selected) {
+		if err := renewExternalRootClaimBeforeCall(
+			ctx, s.store, claimed.ID, claimToken, time.Now().UTC().Truncate(time.Millisecond),
+		); err != nil {
+			return resolved, events, err
+		}
+		_, err = instance.Client.WriteFields(ctx, connector.WriteFieldsParams{
+			RootKey:  claimed.ExternalRootKey,
+			Fields:   map[string]connector.FieldValue{mapping.ExternalFieldID: selected},
+			Expected: map[string]connector.FieldValue{mapping.ExternalFieldID: observedExternal},
+		})
+		if err != nil {
+			return resolved, events, err
+		}
+	}
+	projected, err = s.store.IssueByID(ctx, projected.ID)
+	if err != nil {
+		return resolved, events, err
+	}
+	kataReadback, err := readCanonicalKataField(codec, projected, mapping)
+	if err != nil {
+		return resolved, events, ErrFieldConflictChanged
+	}
+	if !fieldValuesEqual(kataReadback, selected) {
+		return resolved, events, ErrFieldConflictChanged
+	}
+	if use == "kata" {
+		externalReadback, err := readMappedExternalField(ctx, &snapshot, mapping)
+		if err != nil {
+			if isInvalidExternalFieldRead(err) {
+				return resolved, events, ErrFieldConflictChanged
+			}
+			return resolved, events, err
+		}
+		if !fieldValuesEqual(externalReadback, selected) {
+			return resolved, events, ErrFieldConflictChanged
+		}
+	}
+	baseline, err := marshalCanonicalFieldValue(selected)
+	if err != nil {
+		return resolved, events, err
+	}
+	resolved, resolvedEvent, err := s.store.ResolveExternalFieldConflict(ctx, db.ResolveExternalFieldConflictParams{
+		BindingID: claimed.ID, MappingID: mapping.ID, ClaimToken: claimToken,
+		Baseline: baseline, Actor: actor, At: time.Now().UTC(),
+	})
+	if err != nil {
+		return resolved, events, err
+	}
+	s.emitEvents(resolvedEvent)
+	events = append(events, resolvedEvent)
+	return resolved, events, nil
+}
+
+func coordinatedConflictTimezone(
+	issue db.Issue,
+	mapping db.ExternalFieldMapping,
+	mappings []db.ExternalFieldMapping,
+	states []db.ExternalFieldState,
+	selected connector.FieldValue,
+) string {
+	if selected.Kind != fieldKindLocalDateTime || selected.Timezone == "" {
+		return ""
+	}
+	codec, ok := fieldCodecs[mapping.KataField]
+	if !ok {
+		return ""
+	}
+	current, err := readCanonicalKataField(codec, issue, mapping)
+	if err != nil || current.Kind != fieldKindLocalDateTime || current.Timezone == selected.Timezone {
+		return ""
+	}
+	stateByMapping := make(map[int64]db.ExternalFieldState, len(states))
+	for _, state := range states {
+		stateByMapping[state.MappingID] = state
+	}
+	foundSibling := false
+	for _, sibling := range mappings {
+		if !sibling.Active || sibling.ID == mapping.ID {
+			continue
+		}
+		siblingCodec, ok := fieldCodecs[sibling.KataField]
+		if !ok {
+			return ""
+		}
+		siblingKata, err := readCanonicalKataField(siblingCodec, issue, sibling)
+		if err != nil || siblingKata.Kind != fieldKindLocalDateTime || siblingKata.Timezone != current.Timezone {
+			return ""
+		}
+		siblingState, ok := stateByMapping[sibling.ID]
+		if !ok || !siblingState.Conflicted {
+			return ""
+		}
+		siblingExternal, ok, err := decodeCanonicalStoredFieldValue(siblingState.ConflictExternal, sibling)
+		if err != nil || !ok || siblingExternal.Kind != fieldKindLocalDateTime || siblingExternal.Timezone != selected.Timezone {
+			return ""
+		}
+		foundSibling = true
+	}
+	if !foundSibling {
+		return ""
+	}
+	return selected.Timezone
+}
+
+func coordinatedConflictKataDriftAllowed(
+	issue db.Issue,
+	mapping db.ExternalFieldMapping,
+	mappings []db.ExternalFieldMapping,
+	states []db.ExternalFieldState,
+	storedKata connector.FieldValue,
+	currentKata connector.FieldValue,
+	selectedExternal connector.FieldValue,
+) bool {
+	if storedKata.Kind != fieldKindLocalDateTime || currentKata.Kind != fieldKindLocalDateTime ||
+		selectedExternal.Kind != fieldKindLocalDateTime || storedKata.Value != currentKata.Value ||
+		storedKata.Timezone == currentKata.Timezone || currentKata.Timezone != selectedExternal.Timezone {
+		return false
+	}
+	stateByMapping := make(map[int64]db.ExternalFieldState, len(states))
+	for _, state := range states {
+		stateByMapping[state.MappingID] = state
+	}
+	foundSibling := false
+	for _, sibling := range mappings {
+		if !sibling.Active || sibling.ID == mapping.ID {
+			continue
+		}
+		siblingCodec, ok := fieldCodecs[sibling.KataField]
+		if !ok {
+			return false
+		}
+		siblingKata, err := readCanonicalKataField(siblingCodec, issue, sibling)
+		if err != nil || siblingKata.Kind != fieldKindLocalDateTime || siblingKata.Timezone != selectedExternal.Timezone {
+			return false
+		}
+		siblingState, ok := stateByMapping[sibling.ID]
+		if !ok || siblingState.Conflicted {
+			return false
+		}
+		siblingBaseline, ok, err := decodeCanonicalStoredFieldValue(siblingState.Baseline, sibling)
+		if err != nil || !ok || siblingBaseline.Kind != fieldKindLocalDateTime ||
+			siblingBaseline.Timezone != selectedExternal.Timezone || !fieldValuesEqual(siblingBaseline, siblingKata) {
+			return false
+		}
+		foundSibling = true
+	}
+	return foundSibling
+}
+
+func (s *Service) requireInstance(id string) (Instance, error) {
+	if s.registry == nil {
+		return Instance{}, fmt.Errorf("%w: %s", ErrConnectorInstanceNotFound, strings.TrimSpace(id))
+	}
+	instance, ok := s.registry.instance(id)
+	if !ok {
+		return Instance{}, fmt.Errorf("%w: %s", ErrConnectorInstanceNotFound, strings.TrimSpace(id))
+	}
+	return instance, nil
+}
+
+func (s *Service) describe(ctx context.Context, instance Instance) (connector.Description, error) {
+	description, err := instance.Client.Describe(ctx)
+	if err != nil {
+		if !parentContextEnded(ctx, err) {
+			s.registry.recordDescribeHealthError(instance.Config.ID, err)
+		}
+		return connector.Description{}, err
+	}
+	if err := s.registry.acceptDescription(instance.Config.ID, description); err != nil {
+		return connector.Description{}, err
+	}
+	return description, nil
+}
+
+func validateResolvedRoot(root connector.Root) error {
+	if strings.TrimSpace(root.Key) == "" || strings.TrimSpace(root.Key) != root.Key ||
+		strings.TrimSpace(root.IdentityKey) == "" || strings.TrimSpace(root.IdentityKey) != root.IdentityKey {
+		return fmt.Errorf("%w: root and account identities must be nonempty and canonical", db.ErrExternalRootValidation)
+	}
+	if root.ObservedAt.IsZero() {
+		return fmt.Errorf("%w: root observation time is required", db.ErrExternalRootValidation)
+	}
+	return nil
+}
+
+func resolveExternalField(fields []connector.FieldDescriptor, selector string) (connector.FieldDescriptor, error) {
+	selector = strings.TrimSpace(selector)
+	byID := make([]connector.FieldDescriptor, 0, 1)
+	for _, field := range fields {
+		if field.ID == selector {
+			byID = append(byID, field)
+		}
+	}
+	if len(byID) == 1 {
+		return byID[0], nil
+	}
+	if len(byID) > 1 {
+		return connector.FieldDescriptor{}, fmt.Errorf("%w: stable ID %q", ErrExternalFieldAmbiguous, selector)
+	}
+	byName := make([]connector.FieldDescriptor, 0, 1)
+	for _, field := range fields {
+		if field.DisplayName == selector {
+			byName = append(byName, field)
+		}
+	}
+	switch len(byName) {
+	case 0:
+		return connector.FieldDescriptor{}, fmt.Errorf("%w: %s", ErrExternalFieldNotFound, selector)
+	case 1:
+		return byName[0], nil
+	default:
+		return connector.FieldDescriptor{}, fmt.Errorf("%w: display name %q", ErrExternalFieldAmbiguous, selector)
+	}
+}

--- a/internal/rootbridge/service.go
+++ b/internal/rootbridge/service.go
@@ -284,6 +284,9 @@ func (s *Service) Bind(ctx context.Context, params BindParams) (db.ExternalRootB
 	}
 	initialCommentRevisions := make([]db.ExternalCommentRevision, 0, len(listedComments.Comments))
 	for _, comment := range listedComments.Comments {
+		if err := validateInboundComment(comment); err != nil {
+			return db.ExternalRootBinding{}, nil, err
+		}
 		initialCommentRevisions = append(initialCommentRevisions, db.ExternalCommentRevision{
 			ExternalID: comment.ID, Revision: comment.Revision,
 		})
@@ -867,6 +870,9 @@ func validateResolvedRoot(root connector.Root) error {
 	if strings.TrimSpace(root.Key) == "" || strings.TrimSpace(root.Key) != root.Key ||
 		strings.TrimSpace(root.IdentityKey) == "" || strings.TrimSpace(root.IdentityKey) != root.IdentityKey {
 		return fmt.Errorf("%w: root and account identities must be nonempty and canonical", db.ErrExternalRootValidation)
+	}
+	if strings.TrimSpace(root.Title) == "" {
+		return fmt.Errorf("%w: root title is required", db.ErrExternalRootValidation)
 	}
 	if root.ObservedAt.IsZero() {
 		return fmt.Errorf("%w: root observation time is required", db.ErrExternalRootValidation)

--- a/internal/rootbridge/service_test.go
+++ b/internal/rootbridge/service_test.go
@@ -1,0 +1,1929 @@
+package rootbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/db/sqlitestore"
+	katauid "go.kenn.io/kata/internal/uid"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+var testObservedAt = time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+
+func TestBindResolvesExistingRootWithoutExternalMutation(t *testing.T) {
+	h := newServiceHarness(t)
+
+	got, events, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "https://external.example/root/1", Actor: "tester",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "root-1", got.ExternalRootKey)
+	assert.Equal(t, &testObservedAt, got.ReceiveCommentsAfter)
+	assert.Len(t, events, 1)
+	assert.Equal(t, 1, h.client.resolveCalls)
+	assert.Equal(t, 1, h.client.listCommentCalls)
+	assert.Zero(t, h.client.publishCalls)
+	assert.Zero(t, h.client.completeCalls)
+
+	mapping, err := h.store.ImportMappingBySource(t.Context(), h.project.ID, "connector:notes", "issue", "root-1")
+	require.NoError(t, err)
+	require.NotNil(t, mapping.IssueID)
+	assert.Equal(t, h.issue.ID, *mapping.IssueID)
+}
+
+func TestBindUsesExistingCommentRevisionsAsInboundFrontier(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.resolved.UpdatedAt = testObservedAt
+	h.client.read.UpdatedAt = testObservedAt
+	providerCommentAt := testObservedAt.Add(time.Minute)
+	h.client.comments = []connector.Comment{{
+		ID: "existing-comment", Revision: "existing-comment-revision-1", Body: "Existing provider comment",
+		Author:    connector.Actor{ID: "reviewer", DisplayName: "Reviewer"},
+		CreatedAt: providerCommentAt, UpdatedAt: providerCommentAt,
+	}}
+
+	binding, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+	require.NoError(t, err)
+	reconciler := NewReconciler(h.observed, h.registry, ReconcilerConfig{
+		Now: func() time.Time { return testObservedAt.Add(2 * time.Minute) },
+	})
+
+	initial, err := reconciler.Run(t.Context(), binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Zero(t, initial.CommentsCreated)
+	comments, err := h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Empty(t, comments)
+
+	h.client.comments[0].Revision = "existing-comment-revision-2"
+	h.client.comments[0].Body = "Provider comment edited after binding"
+	edited, err := reconciler.Run(t.Context(), binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, edited.CommentsCreated)
+	comments, err = h.store.CommentsByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Equal(t, "Provider comment edited after binding", comments[0].Body)
+}
+
+func TestBindPublishingMarksExistingCommentsAsSkipped(t *testing.T) {
+	h := newServiceHarness(t)
+	oldObservation := time.Date(2000, 1, 2, 3, 4, 5, 0, time.UTC)
+	h.client.resolved.ObservedAt = oldObservation
+	comment, _, err := h.store.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: h.issue.ID, Author: "tester", Body: "Existing local comment",
+	})
+	require.NoError(t, err)
+	storedCommentAt := time.Date(2036, 4, 5, 6, 7, 8, 321_000_000, time.UTC)
+	_, err = h.store.ExecContext(t.Context(),
+		`UPDATE comments SET created_at=? WHERE id=?`, storedCommentAt.Format(time.RFC3339Nano), comment.ID)
+	require.NoError(t, err)
+	comment.CreatedAt = storedCommentAt
+
+	binding, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester", PublishComments: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, binding.ReceiveCommentsAfter)
+	require.NotNil(t, binding.PublishCommentsAfter)
+	assert.Equal(t, oldObservation, *binding.ReceiveCommentsAfter)
+	assert.True(t, binding.PublishCommentsAfter.IsZero())
+	mapping, err := h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, db.ExternalRootSkippedCommentMappingSource("notes"), "comment", comment.UID,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mapping.CommentID)
+	assert.Equal(t, comment.ID, *mapping.CommentID)
+}
+
+func TestBindPublishingRequiresConnectorCapabilityBeforeMutation(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.description.Capabilities = nil
+
+	_, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester", PublishComments: true,
+	})
+	assert.ErrorIs(t, err, ErrCommentPublishingUnavailable)
+	_, bindingErr := h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+	assert.ErrorIs(t, bindingErr, db.ErrNotFound)
+	_, mappingErr := h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, "connector:notes", "issue", "root-1",
+	)
+	assert.ErrorIs(t, mappingErr, db.ErrNotFound)
+	assert.Zero(t, h.client.publishCalls)
+}
+
+func TestBindPublishingRequiresSelfActorBeforeMutation(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.description.SelfActorID = " \t "
+
+	_, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester", PublishComments: true,
+	})
+	assert.ErrorIs(t, err, ErrCommentPublishingUnavailable)
+	_, bindingErr := h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+	assert.ErrorIs(t, bindingErr, db.ErrNotFound)
+	_, mappingErr := h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, "connector:notes", "issue", "root-1",
+	)
+	assert.ErrorIs(t, mappingErr, db.ErrNotFound)
+	assert.Zero(t, h.client.publishCalls)
+}
+
+func TestBindWaitsForImmediateReconcileAndReadsIssueAndBindingAfterward(t *testing.T) {
+	h := newServiceHarness(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.observed.hookFinished = false
+	h.service.immediateClaimedReconcile = func(ctx context.Context, bindingID int64, claimToken string) ([]db.Event, error) {
+		close(entered)
+		<-release
+		_, event, _, err := h.store.ApplyExternalRootProjection(ctx, db.ExternalRootProjectionParams{
+			BindingID: bindingID, ClaimToken: claimToken,
+			Title: h.client.resolved.Title, Body: h.client.resolved.Body,
+			ExternalRevision:  h.client.resolved.Revision,
+			ExternalUpdatedAt: testObservedAt, ExternalObservedAt: testObservedAt,
+			IntegrationActor: "connector:notes",
+		})
+		h.observed.hookFinished = true
+		if err != nil || event == nil {
+			return nil, err
+		}
+		return []db.Event{*event}, nil
+	}
+
+	type result struct {
+		binding db.ExternalRootBinding
+		events  []db.Event
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		binding, events, err := h.service.Bind(context.Background(), BindParams{
+			ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+			Locator: "root-1", Actor: "tester",
+		})
+		done <- result{binding: binding, events: events, err: err}
+	}()
+	<-entered
+	select {
+	case <-done:
+		t.Fatal("bind returned before immediate reconciliation completed")
+	default:
+	}
+	close(release)
+	got := <-done
+	require.NoError(t, got.err)
+	assert.Len(t, got.events, 2)
+	assert.True(t, h.observed.issueReadAfterHook)
+	assert.True(t, h.observed.bindingReadAfterHook)
+	issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "External plan", issue.Title)
+	assert.Equal(t, "External body", issue.Body)
+}
+
+func TestBindDeliversCommittedBindingBeforeImmediateReconcileReturns(t *testing.T) {
+	h := newServiceHarness(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	delivered := make(chan db.Event, 2)
+	h.service = NewServiceWithEventSink(
+		h.observed,
+		h.registry,
+		func(context.Context, int64, string) ([]db.Event, error) {
+			close(entered)
+			<-release
+			return nil, nil
+		},
+		func(event db.Event) { delivered <- event },
+	)
+	type outcome struct {
+		events []db.Event
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		_, events, err := h.service.Bind(context.Background(), BindParams{
+			ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+			Locator: "root-1", Actor: "tester",
+		})
+		done <- outcome{events: events, err: err}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "immediate reconciliation did not start")
+	}
+	var eventBeforeRelease db.Event
+	select {
+	case eventBeforeRelease = <-delivered:
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(release)
+	got := <-done
+	require.NoError(t, got.err)
+	require.NotZero(t, eventBeforeRelease.ID, "binding event was buffered behind immediate reconciliation")
+	assert.Equal(t, "issue.external_root_bound", eventBeforeRelease.Type)
+	assert.Len(t, got.events, 1)
+}
+
+func TestBindCommitsReservedClaimBeforeImmediateReconcile(t *testing.T) {
+	h := newServiceHarness(t)
+	var receivedToken string
+	h.service.immediateClaimedReconcile = func(
+		ctx context.Context,
+		bindingID int64,
+		claimToken string,
+	) ([]db.Event, error) {
+		stored, err := h.store.ExternalRootBindingByID(ctx, bindingID)
+		if err != nil {
+			return nil, err
+		}
+		if stored.ClaimToken != claimToken || stored.ClaimStartedAt == nil {
+			return nil, errors.New("reserved claim was not committed before reconciliation")
+		}
+		receivedToken = claimToken
+		_, acquired, err := h.store.ClaimExternalRootBinding(
+			ctx,
+			bindingID,
+			"competing-claim",
+			stored.ClaimStartedAt.Add(time.Second),
+			stored.ClaimStartedAt.Add(-time.Minute),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if acquired {
+			return nil, errors.New("competing reconcile acquired the reserved binding")
+		}
+		return nil, nil
+	}
+
+	binding, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+	require.NoError(t, err)
+	assert.True(t, katauid.Valid(receivedToken))
+	assert.Equal(t, receivedToken, binding.ClaimToken)
+	require.NotNil(t, binding.ClaimStartedAt)
+}
+
+func TestBindCompleteRootDelegatesLaterReviewWithoutClosingKata(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.resolved.State = "complete"
+	h.service.immediateClaimedReconcile = func(ctx context.Context, _ int64, _ string) ([]db.Event, error) {
+		_, labelEvent, err := h.store.AddLabelAndEvent(ctx, h.issue.ID, db.LabelEventParams{
+			EventType: "issue.labeled", Label: "needs-review", Actor: "connector:notes",
+		})
+		if err != nil {
+			return nil, err
+		}
+		_, commentEvent, err := h.store.CreateComment(ctx, db.CreateCommentParams{
+			IssueID: h.issue.ID, Author: "connector:notes", Body: "Review external completion.",
+		})
+		return []db.Event{labelEvent, commentEvent}, err
+	}
+
+	_, events, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+	require.NoError(t, err)
+	assert.Len(t, events, 3)
+	issue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "open", issue.Status)
+	hasReview, err := h.store.HasLabel(t.Context(), h.issue.ID, "needs-review")
+	require.NoError(t, err)
+	assert.True(t, hasReview)
+	assert.Zero(t, h.client.completeCalls)
+}
+
+func TestBindDoesNotPropagateToChildren(t *testing.T) {
+	h := newServiceHarness(t)
+	child, _, err := h.store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: h.project.ID, Title: "Child", Author: "tester",
+	})
+	require.NoError(t, err)
+	_, err = h.store.CreateLink(t.Context(), db.CreateLinkParams{
+		FromIssueID: child.ID, ToIssueID: h.issue.ID, Type: "parent", Author: "tester",
+	})
+	require.NoError(t, err)
+
+	_, _, err = h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+	require.NoError(t, err)
+	_, err = h.store.ExternalRootBindingByIssue(t.Context(), child.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}
+
+func TestBindRejectsIdentityMismatchWithoutChangingState(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.resolved.IdentityKey = "account-2"
+
+	_, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+	assert.ErrorIs(t, err, ErrConnectorIdentityChanged)
+	_, err = h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}
+
+func TestBindRejectsNoncanonicalResolvedIdentityWithoutChangingState(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*connector.Root)
+	}{
+		{name: "root key", mutate: func(root *connector.Root) { root.Key = " " + root.Key }},
+		{name: "account identity", mutate: func(root *connector.Root) { root.IdentityKey += " " }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newServiceHarness(t)
+			test.mutate(&h.client.resolved)
+
+			_, _, err := h.service.Bind(t.Context(), BindParams{
+				ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+				Locator: "root-1", Actor: "tester",
+			})
+
+			assert.ErrorIs(t, err, db.ErrExternalRootValidation)
+			_, err = h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+			assert.ErrorIs(t, err, db.ErrNotFound)
+		})
+	}
+}
+
+func TestBindMissingInstanceDoesNotChangeState(t *testing.T) {
+	h := newServiceHarness(t)
+	_, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "missing",
+		Locator: "root-1", Actor: "tester",
+	})
+	assert.ErrorIs(t, err, ErrConnectorInstanceNotFound)
+	_, err = h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}
+
+func TestBindLeavesParentCancellationOutsideConnectorFailure(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.resolveErr = errors.New("opaque connector cancellation detail")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := h.service.Bind(ctx, BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, ErrConnectorCall)
+	assert.NotContains(t, err.Error(), "opaque connector cancellation detail")
+	_, bindingErr := h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+	assert.ErrorIs(t, bindingErr, db.ErrNotFound)
+}
+
+func TestBindParentCancellationDuringDescribeDoesNotMutateRegistryHealth(t *testing.T) {
+	h := newServiceHarness(t)
+	h.registry.recordDescribeHealthError("notes", ErrConnectorCall)
+	wantHealth, ok := h.registry.Snapshot("notes")
+	require.True(t, ok)
+	require.NotEmpty(t, wantHealth.HealthError)
+	ctx, cancel := context.WithCancel(t.Context())
+	h.client.beforeDescribeReturn = cancel
+	h.client.describeErr = errors.New("opaque connector cancellation detail")
+
+	_, _, err := h.service.Bind(ctx, BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	snapshot, ok := h.registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Equal(t, wantHealth.HealthError, snapshot.HealthError)
+	_, bindingErr := h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+	assert.ErrorIs(t, bindingErr, db.ErrNotFound)
+}
+
+func TestBindConnectorFailureRemainsHealthWhenParentExpiresAfterBoundary(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.describeErr = errors.Join(connectorclient.ErrRequestTimeout, context.DeadlineExceeded)
+	ctx := newControlledEndContext(t.Context())
+	h.registry.mu.Lock()
+	instance := h.registry.instances["notes"]
+	instance.Client = &boundaryReturnHookClient{
+		Client: instance.Client,
+		afterDescribe: func() {
+			ctx.end(context.DeadlineExceeded)
+		},
+	}
+	h.registry.instances["notes"] = instance
+	h.registry.mu.Unlock()
+
+	_, _, err := h.service.Bind(ctx, BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+
+	require.ErrorIs(t, err, ErrConnectorCall)
+	require.ErrorIs(t, err, connectorclient.ErrRequestTimeout)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	snapshot, ok := h.registry.Snapshot("notes")
+	require.True(t, ok)
+	assert.Equal(t, "external connector request timed out", snapshot.HealthError)
+	_, bindingErr := h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+	assert.ErrorIs(t, bindingErr, db.ErrNotFound)
+}
+
+func TestResumeVerifiesDescriptorAccountAndRootBeforeEnabling(t *testing.T) {
+	h := newServiceHarness(t)
+	_, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+	require.NoError(t, err)
+	_, _, err = h.service.Pause(t.Context(), h.issue.ID, "tester", "operator_pause")
+	require.NoError(t, err)
+	h.client.description.AccountIdentity = "account-2"
+
+	_, _, err = h.service.Resume(t.Context(), h.issue.ID, "tester")
+	assert.ErrorIs(t, err, ErrConnectorIdentityChanged)
+	got, err := h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	assert.False(t, got.Enabled)
+}
+
+func TestResumePublishingRequiresCurrentCapabilityAndSelfActor(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*connector.Description)
+	}{
+		{
+			name: "publish capability removed",
+			mutate: func(description *connector.Description) {
+				description.Capabilities = nil
+			},
+		},
+		{
+			name: "self actor removed",
+			mutate: func(description *connector.Description) {
+				description.SelfActorID = " \t "
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newServiceHarness(t)
+			_, _, err := h.service.Bind(t.Context(), BindParams{
+				ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+				Locator: "root-1", Actor: "tester", PublishComments: true,
+			})
+			require.NoError(t, err)
+			paused, _, err := h.service.Pause(t.Context(), h.issue.ID, "tester", "operator_pause")
+			require.NoError(t, err)
+			require.False(t, paused.Enabled)
+			cursor, err := h.store.MaxEventID(t.Context())
+			require.NoError(t, err)
+
+			test.mutate(&h.client.description)
+			_, _, err = h.service.Resume(t.Context(), h.issue.ID, "tester")
+			assert.ErrorIs(t, err, ErrCommentPublishingUnavailable)
+			assert.Zero(t, h.client.readCalls)
+			stored, readErr := h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			assert.False(t, stored.Enabled)
+			assert.Equal(t, "operator_pause", stored.PausedReason)
+			events, eventsErr := h.store.EventsAfter(t.Context(), db.EventsAfterParams{
+				AfterID: cursor,
+				Limit:   10,
+			})
+			require.NoError(t, eventsErr)
+			assert.Empty(t, events)
+		})
+	}
+}
+
+func TestResumeVerifiesConnectorIDProtocolAndRootKey(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*fakeConnectorClient)
+	}{
+		{name: "connector id", mutate: func(c *fakeConnectorClient) { c.description.ConnectorID = "changed.connector" }},
+		{name: "protocol", mutate: func(c *fakeConnectorClient) { c.description.Protocol = "changed.protocol" }},
+		{name: "root key", mutate: func(c *fakeConnectorClient) { c.read.Key = "root-2" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newServiceHarness(t)
+			_, _, err := h.service.Bind(t.Context(), BindParams{
+				ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+				Locator: "root-1", Actor: "tester",
+			})
+			require.NoError(t, err)
+			_, _, err = h.service.Pause(t.Context(), h.issue.ID, "tester", "operator_pause")
+			require.NoError(t, err)
+			test.mutate(h.client)
+			_, _, err = h.service.Resume(t.Context(), h.issue.ID, "tester")
+			assert.ErrorIs(t, err, ErrConnectorIdentityChanged)
+			binding, getErr := h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+			require.NoError(t, getErr)
+			assert.False(t, binding.Enabled)
+		})
+	}
+}
+
+func TestPauseResumeAndUnbindPreserveStorageEvents(t *testing.T) {
+	h := newServiceHarness(t)
+	_, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+	require.NoError(t, err)
+	paused, event, err := h.service.Pause(t.Context(), h.issue.ID, "tester", "operator_pause")
+	require.NoError(t, err)
+	assert.False(t, paused.Enabled)
+	assert.Equal(t, "issue.external_root_paused", event.Type)
+	resumed, event, err := h.service.Resume(t.Context(), h.issue.ID, "tester")
+	require.NoError(t, err)
+	assert.True(t, resumed.Enabled)
+	assert.Equal(t, "issue.external_root_resumed", event.Type)
+	unbound, event, err := h.service.Unbind(t.Context(), h.issue.ID, "tester")
+	require.NoError(t, err)
+	assert.False(t, unbound.Active)
+	assert.Equal(t, "issue.external_root_unbound", event.Type)
+}
+
+func TestPauseAndUnbindRejectLiveWorkerClaim(t *testing.T) {
+	h := newServiceHarness(t)
+	binding, _, err := h.service.Bind(t.Context(), BindParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+		Locator: "root-1", Actor: "tester",
+	})
+	require.NoError(t, err)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	claimed, acquired, err := h.store.ClaimExternalRootBinding(
+		t.Context(), binding.ID, "active-worker", now, now.Add(-h.service.claimStaleAfter),
+	)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	_, _, err = h.service.Pause(t.Context(), h.issue.ID, "tester", "operator_pause")
+	assert.ErrorIs(t, err, db.ErrExternalRootClaimActive)
+	_, _, err = h.service.Unbind(t.Context(), h.issue.ID, "tester")
+	assert.ErrorIs(t, err, db.ErrExternalRootClaimActive)
+	retained, readErr := h.store.ExternalRootBindingByID(t.Context(), binding.ID)
+	require.NoError(t, readErr)
+	assert.True(t, retained.Active)
+	assert.True(t, retained.Enabled)
+	assert.Equal(t, claimed.ClaimToken, retained.ClaimToken)
+}
+
+func TestMappingUsesStableFieldIDAndRefreshesDescriptor(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.fields = []connector.FieldDescriptor{
+		{ID: "field-1", DisplayName: "Start", AcceptedKinds: []string{"date"}, Nullable: true, Writable: true, SchemaRevision: "1"},
+		{ID: "field-2", DisplayName: "field-1", AcceptedKinds: []string{"date"}, Nullable: true, Writable: true, SchemaRevision: "1"},
+	}
+	first, err := h.service.MapField(t.Context(), MapFieldParams{
+		ConnectorInstance: "notes", KataField: "scheduled_on", ExternalField: "field-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "field-1", first.ExternalFieldID)
+	assert.Equal(t, "Start", first.ExternalFieldName)
+
+	h.client.fields[0].DisplayName = "Start date"
+	h.client.fields[0].SchemaRevision = "2"
+	second, err := h.service.MapField(t.Context(), MapFieldParams{
+		ConnectorInstance: "notes", KataField: "scheduled_on", ExternalField: "field-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "field-1", second.ExternalFieldID)
+	assert.Equal(t, "Start date", second.ExternalFieldName)
+	assert.Equal(t, "2", second.SchemaRevision)
+	assert.NotEqual(t, first.ID, second.ID)
+	mappings, err := h.store.ListExternalFieldMappings(t.Context(), "notes")
+	require.NoError(t, err)
+	require.Len(t, mappings, 2)
+	assert.False(t, mappings[0].Active)
+	assert.True(t, mappings[1].Active)
+}
+
+func TestMappingRequiresUniqueDisplayNameAndValidCodecDescriptor(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.fields = []connector.FieldDescriptor{
+		{ID: "field-1", DisplayName: "Start", AcceptedKinds: []string{"date"}, Nullable: true, Writable: true, SchemaRevision: "1"},
+		{ID: "field-2", DisplayName: "Start", AcceptedKinds: []string{"instant"}, Nullable: true, Writable: true, SchemaRevision: "1"},
+	}
+	_, err := h.service.MapField(t.Context(), MapFieldParams{ConnectorInstance: "notes", KataField: "scheduled_on", ExternalField: "Start"})
+	assert.ErrorIs(t, err, ErrExternalFieldAmbiguous)
+
+	h.client.fields = []connector.FieldDescriptor{{
+		ID: "field-1", DisplayName: "Start", AcceptedKinds: []string{"text"}, Nullable: true, Writable: true, SchemaRevision: "1",
+	}}
+	_, err = h.service.MapField(t.Context(), MapFieldParams{ConnectorInstance: "notes", KataField: "scheduled_on", ExternalField: "field-1"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unsupported external field kind")
+}
+
+func TestMappingRejectsNonCanonicalFieldDescriptorIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		descriptor connector.FieldDescriptor
+		protocol   bool
+	}{
+		{
+			name: "padded field ID",
+			descriptor: connector.FieldDescriptor{
+				ID: " field-1 ", DisplayName: "Start", AcceptedKinds: []string{"date"},
+				Nullable: true, Writable: true, SchemaRevision: "schema-1",
+			},
+			protocol: true,
+		},
+		{
+			name: "padded schema revision",
+			descriptor: connector.FieldDescriptor{
+				ID: "field-1", DisplayName: "Start", AcceptedKinds: []string{"date"},
+				Nullable: true, Writable: true, SchemaRevision: " schema-1 ",
+			},
+			protocol: true,
+		},
+		{
+			name: "padded accepted kind",
+			descriptor: connector.FieldDescriptor{
+				ID: "field-1", DisplayName: "Start", AcceptedKinds: []string{" date "},
+				Nullable: true, Writable: true, SchemaRevision: "schema-1",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newServiceHarness(t)
+			h.client.fields = []connector.FieldDescriptor{test.descriptor}
+
+			_, err := h.service.MapField(t.Context(), MapFieldParams{
+				ConnectorInstance: "notes", KataField: "scheduled_on", ExternalField: "Start",
+			})
+			if test.protocol {
+				require.ErrorIs(t, err, connectorclient.ErrProtocolFailure)
+			} else {
+				require.Error(t, err)
+			}
+			mappings, listErr := h.store.ListExternalFieldMappings(t.Context(), "notes")
+			require.NoError(t, listErr)
+			assert.Empty(t, mappings)
+		})
+	}
+}
+
+func TestMappingRequiresFieldCapabilitiesBeforeDiscovery(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		capabilities []connector.Capability
+	}{
+		{name: "fields unavailable", capabilities: []connector.Capability{connector.CapabilityConditionalFields}},
+		{name: "conditional writes unavailable", capabilities: []connector.Capability{connector.CapabilityFields}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newServiceHarness(t)
+			h.client.description.Capabilities = test.capabilities
+			h.client.fields = []connector.FieldDescriptor{{
+				ID: "field-1", DisplayName: "Start", AcceptedKinds: []string{"date"},
+				Nullable: true, Writable: true, SchemaRevision: "1",
+			}}
+
+			_, err := h.service.MapField(t.Context(), MapFieldParams{
+				ConnectorInstance: "notes", KataField: "scheduled_on", ExternalField: "field-1",
+			})
+
+			assert.ErrorIs(t, err, ErrFieldSynchronizationUnavailable)
+			assert.Zero(t, h.client.listFieldsCalls)
+		})
+	}
+}
+
+func TestUnmapFieldDeactivatesMappingAndRetainsHistory(t *testing.T) {
+	h := newServiceHarness(t)
+	h.client.fields = []connector.FieldDescriptor{{
+		ID: "field-1", DisplayName: "Start", AcceptedKinds: []string{"date"}, Nullable: true, Writable: true, SchemaRevision: "1",
+	}}
+	mapped, err := h.service.MapField(t.Context(), MapFieldParams{ConnectorInstance: "notes", KataField: "scheduled_on", ExternalField: "field-1"})
+	require.NoError(t, err)
+	unmapped, err := h.service.UnmapField(t.Context(), "notes", "scheduled_on")
+	require.NoError(t, err)
+	assert.Equal(t, mapped.ID, unmapped.ID)
+	assert.False(t, unmapped.Active)
+	mappings, err := h.store.ListExternalFieldMappings(t.Context(), "notes")
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	assert.False(t, mappings[0].Active)
+}
+
+func TestResolveFieldConflictWritesOnlyTheSelectedSideAndClearsCandidates(t *testing.T) {
+	for _, use := range []string{"kata", "external"} {
+		t.Run(use, func(t *testing.T) {
+			h, service := prepareFieldConflict(t)
+			beforeWrites := len(h.client.writeFieldCalls)
+
+			state, events, err := service.ResolveFieldConflict(
+				t.Context(), h.issue.ID, "scheduled_on", use, "operator",
+			)
+			require.NoError(t, err)
+			assert.False(t, state.Conflicted)
+			assert.Empty(t, state.ConflictKata)
+			assert.Empty(t, state.ConflictExternal)
+			want := date("2026-08-21")
+			if use == "external" {
+				want = date("2026-08-22")
+			}
+			assert.Equal(t, want, decodeStoredFieldValue(t, state.Baseline))
+			if use == "kata" {
+				assert.Equal(t, beforeWrites+1, len(h.client.writeFieldCalls))
+			} else {
+				assert.Equal(t, beforeWrites, len(h.client.writeFieldCalls))
+			}
+			assert.Equal(t, want, h.client.fieldValues["start-date"])
+			issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			kataValue, readErr := fieldCodecs["scheduled_on"].ReadKata(issue)
+			require.NoError(t, readErr)
+			assert.Equal(t, want, kataValue)
+			resolved := requireEventType(t, events, "issue.external_field_resolved")
+			assert.Equal(t, "operator", resolved.Actor)
+			assert.NotContains(t, resolved.Payload, "2026-08-21")
+			assert.NotContains(t, resolved.Payload, "2026-08-22")
+			assert.NotContains(t, resolved.Payload, h.binding.ExternalAccountKey)
+			binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+			require.NoError(t, readErr)
+			assert.Empty(t, binding.ClaimToken)
+		})
+	}
+}
+
+type failFieldConflictResolutionOnceStorage struct {
+	db.Storage
+	err    error
+	failed bool
+}
+
+func (s *failFieldConflictResolutionOnceStorage) ResolveExternalFieldConflict(
+	ctx context.Context,
+	params db.ResolveExternalFieldConflictParams,
+) (db.ExternalFieldState, db.Event, error) {
+	if !s.failed {
+		s.failed = true
+		return db.ExternalFieldState{}, db.Event{}, s.err
+	}
+	return s.Storage.ResolveExternalFieldConflict(ctx, params)
+}
+
+func TestResolveFieldConflictResumesAfterSelectedSideWasAlreadyApplied(t *testing.T) {
+	for _, use := range []string{"kata", "external"} {
+		t.Run(use, func(t *testing.T) {
+			h, service := prepareFieldConflict(t)
+			postWriteErr := errors.New("synthetic conflict finalization failure")
+			store := &failFieldConflictResolutionOnceStorage{Storage: h.store, err: postWriteErr}
+			service.store = store
+
+			_, _, err := service.ResolveFieldConflict(
+				t.Context(), h.issue.ID, "scheduled_on", use, "operator",
+			)
+			require.ErrorIs(t, err, postWriteErr)
+			issueAfterWrite, err := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, err)
+			writesAfterFirst := len(h.client.writeFieldCalls)
+
+			state, events, err := service.ResolveFieldConflict(
+				t.Context(), h.issue.ID, "scheduled_on", use, "operator",
+			)
+			require.NoError(t, err)
+			assert.False(t, state.Conflicted)
+			assert.Contains(t, eventTypes(events), "issue.external_field_resolved")
+			issueAfterRetry, err := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, err)
+			assert.Equal(t, issueAfterWrite.Revision, issueAfterRetry.Revision)
+			assert.Len(t, h.client.writeFieldCalls, writesAfterFirst)
+		})
+	}
+}
+
+func TestResolveFieldConflictAllowsCoordinatedLocalTimezoneTransition(t *testing.T) {
+	h := newReconcileHarness(t)
+	startMapping := h.mapField(t, "scheduled_on", "start-date")
+	dueMapping := h.mapField(t, "deadline_on", "due-date")
+	oldStart := connector.FieldValue{
+		Kind: fieldKindLocalDateTime, Value: "2026-08-21T09:30", Timezone: "America/New_York",
+	}
+	oldDue := connector.FieldValue{
+		Kind: fieldKindLocalDateTime, Value: "2026-08-21T10:30", Timezone: "America/New_York",
+	}
+	h.setKataField(t, "scheduled_on", oldStart)
+	h.setKataField(t, "deadline_on", oldDue)
+	h.seedBaseline(t, "scheduled_on", oldStart)
+	h.seedBaseline(t, "deadline_on", oldDue)
+	newStart := connector.FieldValue{
+		Kind: fieldKindLocalDateTime, Value: "2026-08-22T09:30", Timezone: "America/Los_Angeles",
+	}
+	newDue := connector.FieldValue{
+		Kind: fieldKindLocalDateTime, Value: "2026-08-22T10:30", Timezone: "America/Los_Angeles",
+	}
+	h.client.fieldValues["start-date"] = newStart
+	h.client.fieldValues["due-date"] = newDue
+	claimToken := "seed-coordinated-conflicts"
+	_, acquired, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, claimToken, h.now, h.now.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	for _, pair := range []struct {
+		mapping  db.ExternalFieldMapping
+		baseline connector.FieldValue
+		external connector.FieldValue
+	}{
+		{mapping: startMapping, baseline: oldStart, external: newStart},
+		{mapping: dueMapping, baseline: oldDue, external: newDue},
+	} {
+		baseline, marshalErr := json.Marshal(pair.baseline)
+		require.NoError(t, marshalErr)
+		external, marshalErr := json.Marshal(pair.external)
+		require.NoError(t, marshalErr)
+		_, _, err = h.store.UpsertExternalFieldState(t.Context(), db.ExternalFieldStateParams{
+			BindingID: h.binding.ID, MappingID: pair.mapping.ID, ClaimToken: claimToken,
+			Baseline: baseline, ConflictKata: baseline, ConflictExternal: external,
+			Conflicted: true, At: h.now, Actor: integrationActor(h.binding),
+		})
+		require.NoError(t, err)
+	}
+	_, err = h.store.ReleaseExternalRootClaim(t.Context(), h.binding.ID, claimToken)
+	require.NoError(t, err)
+	service := NewService(h.store, h.registry, nil)
+
+	state, events, err := service.ResolveFieldConflict(
+		t.Context(), h.issue.ID, "scheduled_on", "external", "operator",
+	)
+
+	require.NoError(t, err)
+	assert.False(t, state.Conflicted)
+	assert.Equal(t, newStart, decodeStoredFieldValue(t, state.Baseline))
+	assert.Contains(t, eventTypes(events), "issue.external_field_resolved")
+	assert.True(t, h.fieldState(t, "deadline_on").Conflicted)
+	issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	values, readErr := metadataObject(issue.Metadata)
+	require.NoError(t, readErr)
+	assert.JSONEq(t, `"2026-08-22T09:30"`, string(values["scheduled_on"]))
+	assert.JSONEq(t, `"America/Los_Angeles"`, string(values["timezone"]))
+
+	dueState, dueEvents, err := service.ResolveFieldConflict(
+		t.Context(), h.issue.ID, "deadline_on", "external", "operator",
+	)
+	require.NoError(t, err)
+	assert.False(t, dueState.Conflicted)
+	assert.Equal(t, newDue, decodeStoredFieldValue(t, dueState.Baseline))
+	assert.Contains(t, eventTypes(dueEvents), "issue.external_field_resolved")
+	issue, readErr = h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	values, readErr = metadataObject(issue.Metadata)
+	require.NoError(t, readErr)
+	assert.JSONEq(t, `"2026-08-22T10:30"`, string(values["deadline_on"]))
+	assert.JSONEq(t, `"America/Los_Angeles"`, string(values["timezone"]))
+}
+
+func TestResolveFieldConflictRequiresCurrentFieldsCapability(t *testing.T) {
+	h, service := prepareFieldConflict(t)
+	h.client.description.Capabilities = []connector.Capability{connector.CapabilityPublishComment}
+	listCalls := h.client.listFieldsCalls
+	readCalls := len(h.client.readFieldCalls)
+	writeCalls := len(h.client.writeFieldCalls)
+
+	_, _, err := service.ResolveFieldConflict(
+		t.Context(), h.issue.ID, "scheduled_on", "kata", "operator",
+	)
+
+	assert.ErrorIs(t, err, ErrFieldSynchronizationUnavailable)
+	assert.Equal(t, listCalls, h.client.listFieldsCalls)
+	assert.Len(t, h.client.readFieldCalls, readCalls)
+	assert.Len(t, h.client.writeFieldCalls, writeCalls)
+	retained := h.fieldState(t, "scheduled_on")
+	assert.True(t, retained.Conflicted)
+	assert.Empty(t, h.requireBinding(t).ClaimToken)
+}
+
+func TestResolveFieldConflictBypassesFutureNextAttempt(t *testing.T) {
+	h, service := prepareFieldConflict(t)
+	at := time.Now().UTC().Truncate(time.Millisecond)
+	nextAttemptAt := at.Add(time.Hour)
+	claimed, acquired, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, "failed-attempt", at, at.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	_, err = h.store.RecordExternalRootError(t.Context(), db.ExternalRootErrorParams{
+		BindingID: claimed.ID, ClaimToken: claimed.ClaimToken,
+		At: at, NextAttemptAt: nextAttemptAt, Error: "temporary failure",
+	})
+	require.NoError(t, err)
+	backedOff, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	require.NotNil(t, backedOff.NextAttemptAt)
+	assert.Equal(t, nextAttemptAt, *backedOff.NextAttemptAt)
+	before := h.fieldState(t, "scheduled_on")
+	require.True(t, before.Conflicted)
+
+	state, events, err := service.ResolveFieldConflict(
+		t.Context(), h.issue.ID, "scheduled_on", "kata", "operator",
+	)
+
+	require.NoError(t, err)
+	assert.False(t, state.Conflicted)
+	assert.Equal(t, date("2026-08-21"), decodeStoredFieldValue(t, state.Baseline))
+	assert.Contains(t, eventTypes(events), "issue.external_field_resolved")
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+	require.NotNil(t, binding.NextAttemptAt)
+	assert.Equal(t, nextAttemptAt, *binding.NextAttemptAt)
+}
+
+func TestResolveFieldConflictRenewsClaimDuringLongConnectorWrite(t *testing.T) {
+	h, service := prepareFieldConflict(t)
+	const staleAfter = 120 * time.Millisecond
+	service.claimStaleAfter = staleAfter
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.client.beforeWriteFields = func() {
+		close(entered)
+		<-release
+	}
+	type outcome struct {
+		state  db.ExternalFieldState
+		events []db.Event
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		state, events, err := service.ResolveFieldConflict(
+			context.Background(), h.issue.ID, "scheduled_on", "kata", "operator",
+		)
+		done <- outcome{state: state, events: events, err: err}
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "field write did not start")
+	}
+	time.Sleep(3 * staleAfter)
+	now := time.Now().UTC()
+	_, acquired, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, "competing-field-resolution", now, now.Add(-staleAfter),
+	)
+	require.NoError(t, err)
+	close(release)
+	completed := <-done
+
+	assert.False(t, acquired, "a valid manual field resolution must retain its exclusive claim")
+	require.NoError(t, completed.err)
+	assert.False(t, completed.state.Conflicted)
+	assert.Contains(t, eventTypes(completed.events), "issue.external_field_resolved")
+}
+
+func TestResolveFieldConflictRejectsProviderDriftDuringWrite(t *testing.T) {
+	h, service := prepareFieldConflict(t)
+	h.client.beforeWriteFields = func() {
+		h.client.fieldValues["start-date"] = date("2026-08-24")
+	}
+
+	_, events, err := service.ResolveFieldConflict(
+		t.Context(), h.issue.ID, "scheduled_on", "kata", "operator",
+	)
+
+	var connectorErr *connector.Error
+	require.ErrorAs(t, err, &connectorErr)
+	assert.Equal(t, "field_conflict", connectorErr.Code)
+	assert.Empty(t, events)
+	assert.Equal(t, date("2026-08-24"), h.client.fieldValues["start-date"])
+	state := h.fieldState(t, "scheduled_on")
+	assert.True(t, state.Conflicted)
+	assert.Equal(t, date("2026-08-21"), decodeStoredFieldValue(t, state.ConflictKata))
+	assert.Equal(t, date("2026-08-22"), decodeStoredFieldValue(t, state.ConflictExternal))
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+}
+
+func TestResolveFieldConflictRejectsDriftWithoutMutation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, *reconcileHarness)
+	}{
+		{name: "Kata candidate changed", mutate: func(t *testing.T, h *reconcileHarness) {
+			h.setKataField(t, "scheduled_on", date("2026-08-23"))
+		}},
+		{name: "external candidate changed", mutate: func(_ *testing.T, h *reconcileHarness) {
+			h.client.fieldValues["start-date"] = date("2026-08-24")
+		}},
+		{name: "external candidate invalid", mutate: func(_ *testing.T, h *reconcileHarness) {
+			h.client.fieldValues["start-date"] = connector.FieldValue{Kind: "text", Value: "invalid-value"}
+		}},
+		{name: "descriptor changed", mutate: func(_ *testing.T, h *reconcileHarness) {
+			h.client.fields[0].SchemaRevision = "schema-2"
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h, service := prepareFieldConflict(t)
+			test.mutate(t, h)
+			beforeIssue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, err)
+			beforeWrites := len(h.client.writeFieldCalls)
+
+			_, events, err := service.ResolveFieldConflict(
+				t.Context(), h.issue.ID, "scheduled_on", "kata", "operator",
+			)
+			assert.ErrorIs(t, err, ErrFieldConflictChanged)
+			assert.Empty(t, events)
+			assert.Equal(t, beforeWrites, len(h.client.writeFieldCalls))
+			afterIssue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, beforeIssue.Revision, afterIssue.Revision)
+			state := h.fieldState(t, "scheduled_on")
+			assert.True(t, state.Conflicted)
+			assert.Equal(t, date("2026-08-21"), decodeStoredFieldValue(t, state.ConflictKata))
+			assert.Equal(t, date("2026-08-22"), decodeStoredFieldValue(t, state.ConflictExternal))
+			binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+			require.NoError(t, readErr)
+			assert.Empty(t, binding.ClaimToken)
+		})
+	}
+}
+
+func TestResolveFieldConflictRechecksStoredCandidatesAfterClaim(t *testing.T) {
+	h, service := prepareFieldConflict(t)
+	state := h.fieldState(t, "scheduled_on")
+	refreshedKata, err := marshalCanonicalFieldValue(date("2026-08-23"))
+	require.NoError(t, err)
+	refreshedExternal, err := marshalCanonicalFieldValue(date("2026-08-24"))
+	require.NoError(t, err)
+	service.store = &refreshConflictAfterClaimStorage{
+		Storage: h.store, mappingID: state.MappingID, baseline: state.Baseline,
+		kata: refreshedKata, external: refreshedExternal,
+	}
+	beforeIssue, err := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, err)
+	beforeWrites := len(h.client.writeFieldCalls)
+
+	_, events, err := service.ResolveFieldConflict(
+		t.Context(), h.issue.ID, "scheduled_on", "kata", "operator",
+	)
+
+	assert.ErrorIs(t, err, ErrFieldConflictChanged)
+	assert.Empty(t, events)
+	assert.Equal(t, beforeWrites, len(h.client.writeFieldCalls))
+	afterIssue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, beforeIssue.Revision, afterIssue.Revision)
+	refreshed := h.fieldState(t, "scheduled_on")
+	assert.True(t, refreshed.Conflicted)
+	assert.Equal(t, date("2026-08-23"), decodeStoredFieldValue(t, refreshed.ConflictKata))
+	assert.Equal(t, date("2026-08-24"), decodeStoredFieldValue(t, refreshed.ConflictExternal))
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+}
+
+func TestResolveFieldConflictRequiresExplicitCandidateAndConflict(t *testing.T) {
+	h, service := prepareFieldConflict(t)
+	_, _, err := service.ResolveFieldConflict(
+		t.Context(), h.issue.ID, "scheduled_on", "newest", "operator",
+	)
+	assert.ErrorIs(t, err, db.ErrExternalRootValidation)
+
+	h.mapField(t, "deadline_on", "due-date")
+	_, _, err = service.ResolveFieldConflict(
+		t.Context(), h.issue.ID, "deadline_on", "kata", "operator",
+	)
+	assert.ErrorIs(t, err, db.ErrExternalFieldNotConflicted)
+}
+
+func TestResolveFieldConflictFinalizesClaimAfterCancellationFollowingCommit(t *testing.T) {
+	h, service := prepareFieldConflict(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	store := &cancelAfterFieldResolutionStorage{Storage: h.store, cancel: cancel}
+	service.store = store
+
+	state, events, err := service.ResolveFieldConflict(
+		ctx, h.issue.ID, "scheduled_on", "kata", "operator",
+	)
+
+	require.NoError(t, err)
+	assert.False(t, state.Conflicted)
+	assert.Contains(t, eventTypes(events), "issue.external_field_resolved")
+	assert.NoError(t, store.releaseCtxErr)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+}
+
+func TestResolveFieldConflictUsingExternalValueDoesNotDependOnProviderWrite(t *testing.T) {
+	h, service := prepareFieldConflict(t)
+	connectorErr := &connector.Error{Code: "temporarily_unavailable", Message: "field write unavailable"}
+	h.client.writeFieldsErr = connectorErr
+	beforeWrites := len(h.client.writeFieldCalls)
+	beforeReads := len(h.client.readFieldCalls)
+
+	resolved, events, err := service.ResolveFieldConflict(
+		t.Context(), h.issue.ID, "scheduled_on", "external", "operator",
+	)
+
+	require.NoError(t, err)
+	assert.False(t, resolved.Conflicted)
+	assert.Equal(t, beforeWrites, len(h.client.writeFieldCalls))
+	assert.Equal(t, beforeReads+1, len(h.client.readFieldCalls))
+	assert.Contains(t, eventTypes(events), "issue.metadata_updated")
+	assert.Contains(t, eventTypes(events), "issue.external_field_resolved")
+	state := h.fieldState(t, "scheduled_on")
+	assert.False(t, state.Conflicted)
+	assert.Equal(t, date("2026-08-22"), decodeStoredFieldValue(t, state.Baseline))
+	issue, readErr := h.store.IssueByID(t.Context(), h.issue.ID)
+	require.NoError(t, readErr)
+	value, readErr := fieldCodecs["scheduled_on"].ReadKata(issue)
+	require.NoError(t, readErr)
+	assert.Equal(t, date("2026-08-22"), value)
+	binding, readErr := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, binding.ClaimToken)
+}
+
+func TestResolvePendingCommentAllowsPausedBindingUnderExclusiveActionClaim(t *testing.T) {
+	h := newPublishingReconcileHarness(t)
+	local := h.createLocalComment(t, "Adopt after pause")
+	claimed, ok, err := h.store.ClaimExternalRootBinding(
+		t.Context(), h.binding.ID, "setup-claim", h.now, h.now.Add(-5*time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, err = h.store.SetPendingExternalComment(t.Context(), db.SetPendingExternalCommentParams{
+		BindingID: claimed.ID, ClaimToken: claimed.ClaimToken, CommentUID: local.UID, At: h.now,
+	})
+	require.NoError(t, err)
+	_, _, err = h.store.PauseExternalRootBinding(t.Context(), db.ExternalRootActionParams{
+		BindingID: h.binding.ID, Actor: "operator", Reason: "operator_pause",
+	})
+	require.NoError(t, err)
+	pausedBeforeAction, err := h.store.ExternalRootBindingByID(t.Context(), h.binding.ID)
+	require.NoError(t, err)
+	h.client.comments = []connector.Comment{{
+		ID: "external-comment-1", Body: local.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: h.now.Add(time.Second), UpdatedAt: h.now.Add(time.Second),
+	}}
+
+	resolved, event, err := NewService(h.store, h.registry, nil).ResolvePendingComment(
+		t.Context(), ResolvePendingCommentParams{
+			IssueID: h.issue.ID, Actor: "operator", Action: "adopt",
+			ExternalCommentID: "external-comment-1",
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, resolved.Enabled)
+	assert.True(t, resolved.Active)
+	assert.Empty(t, resolved.ClaimToken)
+	assert.Empty(t, resolved.PendingCommentUID)
+	assert.Equal(t, pausedBeforeAction.LastAttemptAt, resolved.LastAttemptAt)
+	assert.Equal(t, "issue.external_comment_resolved", event.Type)
+}
+
+type cancelAfterFieldResolutionStorage struct {
+	db.Storage
+	cancel        context.CancelFunc
+	releaseCtxErr error
+}
+
+type refreshConflictAfterClaimStorage struct {
+	db.Storage
+	mappingID int64
+	baseline  json.RawMessage
+	kata      json.RawMessage
+	external  json.RawMessage
+}
+
+func (s *refreshConflictAfterClaimStorage) ClaimExternalRootBindingForManualReconcile(
+	ctx context.Context,
+	bindingID int64,
+	token string,
+	now time.Time,
+	staleBefore time.Time,
+) (db.ExternalRootBinding, bool, error) {
+	binding, acquired, err := s.Storage.ClaimExternalRootBindingForManualReconcile(ctx, bindingID, token, now, staleBefore)
+	if err != nil || !acquired {
+		return binding, acquired, err
+	}
+	_, _, err = s.UpsertExternalFieldState(ctx, db.ExternalFieldStateParams{
+		BindingID: binding.ID, MappingID: s.mappingID, ClaimToken: token,
+		Baseline: s.baseline, ConflictKata: s.kata, ConflictExternal: s.external,
+		Conflicted: true, At: now, Actor: "connector:notes",
+	})
+	return binding, acquired, err
+}
+
+func (s *cancelAfterFieldResolutionStorage) ResolveExternalFieldConflict(
+	ctx context.Context,
+	params db.ResolveExternalFieldConflictParams,
+) (db.ExternalFieldState, db.Event, error) {
+	state, event, err := s.Storage.ResolveExternalFieldConflict(ctx, params)
+	if err == nil {
+		s.cancel()
+	}
+	return state, event, err
+}
+
+func (s *cancelAfterFieldResolutionStorage) ReleaseExternalRootClaim(
+	ctx context.Context,
+	bindingID int64,
+	token string,
+) (db.ExternalRootBinding, error) {
+	s.releaseCtxErr = ctx.Err()
+	return s.Storage.ReleaseExternalRootClaim(ctx, bindingID, token)
+}
+
+func prepareFieldConflict(t *testing.T) (*reconcileHarness, *Service) {
+	t.Helper()
+	h := newReconcileHarness(t)
+	h.mapField(t, "scheduled_on", "start-date")
+	h.seedBaseline(t, "scheduled_on", date("2026-08-20"))
+	h.setKataField(t, "scheduled_on", date("2026-08-21"))
+	h.client.fieldValues["start-date"] = date("2026-08-22")
+	result, err := h.reconciler.Run(t.Context(), h.binding.ID, RunOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.FieldConflicts)
+	return h, NewService(h.store, h.registry, nil)
+}
+
+func TestResolvePendingCommentAdoptsExactSuppliedExternalComment(t *testing.T) {
+	h := newServiceHarness(t)
+	binding, local, pendingAt := h.preparePendingComment(t, "Already created externally")
+	external := connector.Comment{
+		ID: "external-comment-21", Body: local.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: pendingAt.Add(time.Second), UpdatedAt: pendingAt.Add(time.Second),
+	}
+	h.client.comments = []connector.Comment{external, {
+		ID: "external-comment-22", Body: local.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: pendingAt.Add(2 * time.Second), UpdatedAt: pendingAt.Add(2 * time.Second),
+	}}
+
+	resolved, event, err := h.service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+		IssueID: h.issue.ID, Actor: "tester", Action: "adopt", ExternalCommentID: external.ID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, binding.ID, resolved.ID)
+	assert.Empty(t, resolved.PendingCommentUID)
+	assert.Empty(t, resolved.ClaimToken)
+	mapping, err := h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, db.ExternalRootPublishedCommentMappingSource(binding), "comment", external.ID,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mapping.CommentID)
+	assert.Equal(t, local.ID, *mapping.CommentID)
+	assert.Equal(t, "issue.external_comment_resolved", event.Type)
+	assert.Equal(t, "tester", event.Actor)
+	var payload db.ExternalRootAuditPayload
+	require.NoError(t, json.Unmarshal([]byte(event.Payload), &payload))
+	assert.Equal(t, "adopt", payload.Action)
+	assert.Equal(t, local.UID, payload.PendingCommentUID)
+	assert.NotContains(t, event.Payload, external.ID)
+	assert.NotContains(t, event.Payload, local.Body)
+	assert.NotContains(t, event.Payload, h.client.description.SelfActorID)
+	assert.NotContains(t, event.Payload, binding.ExternalAccountKey)
+}
+
+type countingClaimRenewalStorage struct {
+	db.Storage
+	renewals atomic.Int64
+}
+
+func (s *countingClaimRenewalStorage) RenewExternalRootClaim(
+	ctx context.Context,
+	bindingID int64,
+	token string,
+	now time.Time,
+) (db.ExternalRootBinding, error) {
+	s.renewals.Add(1)
+	return s.Storage.RenewExternalRootClaim(ctx, bindingID, token, now)
+}
+
+func TestResolvePendingCommentAdoptRenewsClaimDuringConnectorCalls(t *testing.T) {
+	h := newServiceHarness(t)
+	_, local, pendingAt := h.preparePendingComment(t, "Already created externally")
+	external := connector.Comment{
+		ID: "external-comment-slow", Body: local.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: pendingAt, UpdatedAt: pendingAt,
+	}
+	h.client.comments = []connector.Comment{external}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.client.beforeDescribeReturn = func() {
+		close(entered)
+		<-release
+	}
+	store := &countingClaimRenewalStorage{Storage: h.observed}
+	service := NewService(store, h.registry, nil)
+	service.claimStaleAfter = 30 * time.Millisecond
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+			IssueID: h.issue.ID, Actor: "tester", Action: "adopt", ExternalCommentID: external.ID,
+		})
+		done <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("adoption did not enter the connector call")
+	}
+	require.Eventually(t, func() bool { return store.renewals.Load() >= 2 }, time.Second, time.Millisecond)
+	close(release)
+	require.NoError(t, <-done)
+}
+
+func TestResolvePendingCommentAdoptsExplicitSelfCommentDespiteBodyOrTimeVariance(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		localBody string
+		mutate    func(*connector.Comment, time.Time)
+	}{
+		{name: "normalized body", localBody: "Line one\r\nLine two", mutate: func(comment *connector.Comment, _ time.Time) {
+			comment.Body = "Line one\nLine two"
+		}},
+		{name: "different body", localBody: "Local pending body", mutate: func(comment *connector.Comment, _ time.Time) {
+			comment.Body = "Provider body differs"
+		}},
+		{name: "provider clock far behind", localBody: "Pending body", mutate: func(comment *connector.Comment, pendingAt time.Time) {
+			comment.CreatedAt = pendingAt.Add(-24 * time.Hour)
+			comment.UpdatedAt = comment.CreatedAt
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newServiceHarness(t)
+			binding, local, pendingAt := h.preparePendingComment(t, test.localBody)
+			external := connector.Comment{
+				ID: "external-comment-explicit", Body: local.Body,
+				Author:    connector.Actor{ID: h.client.description.SelfActorID},
+				CreatedAt: pendingAt, UpdatedAt: pendingAt,
+			}
+			test.mutate(&external, pendingAt)
+			h.client.comments = []connector.Comment{external}
+
+			resolved, event, err := h.service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+				IssueID: h.issue.ID, Actor: "tester", Action: "adopt", ExternalCommentID: external.ID,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, binding.ID, resolved.ID)
+			assert.Empty(t, resolved.PendingCommentUID)
+			assert.Equal(t, "adopt", pendingResolutionAction(t, event))
+			mapping, err := h.store.ImportMappingBySource(
+				t.Context(), h.project.ID, db.ExternalRootPublishedCommentMappingSource(binding), "comment", external.ID,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, mapping.CommentID)
+			assert.Equal(t, local.ID, *mapping.CommentID)
+		})
+	}
+}
+
+func TestResolvePendingCommentAdoptDoesNotStealExistingExternalMapping(t *testing.T) {
+	h := newServiceHarness(t)
+	binding, local, pendingAt := h.preparePendingComment(t, "Already created externally")
+	other := h.createServiceComment(t, "Existing mapped comment")
+	issueID, otherID := h.issue.ID, other.ID
+	_, err := h.store.UpsertImportMapping(t.Context(), db.ImportMappingParams{
+		Source: db.ExternalRootCommentMappingSource(binding), ExternalID: "external-comment-mapped", ObjectType: "comment",
+		ProjectID: h.project.ID, IssueID: &issueID, CommentID: &otherID,
+	})
+	require.NoError(t, err)
+	h.client.comments = []connector.Comment{{
+		ID: "external-comment-mapped", Body: local.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: pendingAt, UpdatedAt: pendingAt,
+	}}
+
+	_, _, err = h.service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+		IssueID: h.issue.ID, Actor: "tester", Action: "adopt", ExternalCommentID: "external-comment-mapped",
+	})
+	assert.ErrorIs(t, err, db.ErrExternalRootValidation)
+	retained, readErr := h.store.ExternalRootBindingByID(t.Context(), binding.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, local.UID, retained.PendingCommentUID)
+	assert.Empty(t, retained.ClaimToken)
+	mapping, readErr := h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, db.ExternalRootCommentMappingSource(binding), "comment", "external-comment-mapped",
+	)
+	require.NoError(t, readErr)
+	require.NotNil(t, mapping.CommentID)
+	assert.Equal(t, other.ID, *mapping.CommentID)
+}
+
+func TestResolvePendingCommentRetryAllowsLaterPublication(t *testing.T) {
+	h := newServiceHarness(t)
+	binding, local, pendingAt := h.preparePendingComment(t, "Try publication again")
+
+	resolved, event, err := h.service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+		IssueID: h.issue.ID, Actor: "tester", Action: "retry",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, local.UID, resolved.PendingCommentUID)
+	require.NotNil(t, resolved.PendingCommentStartedAt)
+	assert.Empty(t, resolved.ClaimToken)
+	assert.Equal(t, "retry", pendingResolutionAction(t, event))
+	assert.Zero(t, h.client.publishCalls)
+
+	createdAt := pendingAt.Add(3 * time.Minute)
+	h.client.publishResult = connector.Comment{
+		ID: "external-comment-23", Revision: "revision-external-comment-23", Body: local.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: createdAt, UpdatedAt: createdAt,
+	}
+	reconciler := NewReconciler(h.store, h.registry, ReconcilerConfig{Now: func() time.Time {
+		return pendingAt.Add(3 * time.Minute)
+	}})
+	_, err = reconciler.Run(t.Context(), binding.ID, RunOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, h.client.publishCalls)
+}
+
+func TestResolvePendingCommentSkipClearsWithClosedAuditAndNoPublish(t *testing.T) {
+	h := newServiceHarness(t)
+	binding, local, pendingAt := h.preparePendingComment(t, "Do not publish this")
+
+	resolved, event, err := h.service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+		IssueID: h.issue.ID, Actor: "tester", Action: "skip",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resolved.PendingCommentUID)
+	assert.Empty(t, resolved.ClaimToken)
+	assert.Equal(t, "skip", pendingResolutionAction(t, event))
+	assert.Zero(t, h.client.publishCalls)
+	assert.NotContains(t, event.Payload, local.Body)
+	suppression, err := h.store.ImportMappingBySource(
+		t.Context(), h.project.ID, "connector-skip:notes", "comment", local.UID,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, suppression.CommentID)
+	assert.Equal(t, local.ID, *suppression.CommentID)
+
+	createdAt := pendingAt.Add(2 * time.Minute)
+	h.client.publishResult = connector.Comment{
+		ID: "must-not-publish", Revision: "revision-must-not-publish", Body: local.Body,
+		Author:    connector.Actor{ID: h.client.description.SelfActorID},
+		CreatedAt: createdAt, UpdatedAt: createdAt,
+	}
+	reconciler := NewReconciler(h.store, h.registry, ReconcilerConfig{Now: func() time.Time {
+		return pendingAt.Add(3 * time.Minute)
+	}})
+	for range 2 {
+		_, err = reconciler.Run(t.Context(), binding.ID, RunOptions{})
+		require.NoError(t, err)
+	}
+	assert.Zero(t, h.client.publishCalls)
+}
+
+func TestResolvePendingCommentSkipAndRetryDoNotRequireConnector(t *testing.T) {
+	for _, action := range []string{"skip", "retry"} {
+		t.Run(action, func(t *testing.T) {
+			h := newServiceHarness(t)
+			binding, local, _ := h.preparePendingComment(t, "Resolve without connector")
+			service := NewService(h.store, nil, nil)
+
+			resolved, event, err := service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+				IssueID: h.issue.ID, Actor: "tester", Action: action,
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, binding.ID, resolved.ID)
+			if action == "retry" {
+				assert.Equal(t, local.UID, resolved.PendingCommentUID)
+			} else {
+				assert.Empty(t, resolved.PendingCommentUID)
+			}
+			assert.Empty(t, resolved.ClaimToken)
+			assert.Equal(t, action, pendingResolutionAction(t, event))
+			assert.Zero(t, h.client.describeCalls)
+			assert.Zero(t, h.client.readCalls)
+			assert.Zero(t, h.client.listCommentCalls)
+			if action == "skip" {
+				mapping, readErr := h.store.ImportMappingBySource(
+					t.Context(), h.project.ID, "connector-skip:notes", "comment", local.UID,
+				)
+				require.NoError(t, readErr)
+				require.NotNil(t, mapping.CommentID)
+				assert.Equal(t, local.ID, *mapping.CommentID)
+			}
+		})
+	}
+}
+
+func TestResolvePendingCommentAdoptRejectsNonExactExternalComment(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		suppliedID string
+		mutate     func(*connector.Comment, time.Time)
+	}{
+		{name: "nonexact supplied ID", suppliedID: " external-comment-24 ", mutate: func(_ *connector.Comment, _ time.Time) {}},
+		{name: "missing supplied ID", mutate: func(comment *connector.Comment, _ time.Time) {
+			comment.ID = "different-comment"
+		}},
+		{name: "different author", mutate: func(comment *connector.Comment, _ time.Time) {
+			comment.Author.ID = "different-actor"
+		}},
+		{name: "deleted", mutate: func(comment *connector.Comment, _ time.Time) {
+			comment.Deleted = true
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newServiceHarness(t)
+			binding, local, pendingAt := h.preparePendingComment(t, "Exact pending body")
+			external := connector.Comment{
+				ID: "external-comment-24", Body: local.Body,
+				Author:    connector.Actor{ID: h.client.description.SelfActorID},
+				CreatedAt: pendingAt, UpdatedAt: pendingAt,
+			}
+			test.mutate(&external, pendingAt)
+			h.client.comments = []connector.Comment{external}
+			suppliedID := test.suppliedID
+			if suppliedID == "" {
+				suppliedID = "external-comment-24"
+			}
+
+			_, _, err := h.service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+				IssueID: h.issue.ID, Actor: "tester", Action: "adopt", ExternalCommentID: suppliedID,
+			})
+			assert.ErrorIs(t, err, ErrPendingCommentResolutionRequired)
+			retained, readErr := h.store.ExternalRootBindingByID(t.Context(), binding.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, local.UID, retained.PendingCommentUID)
+			assert.Empty(t, retained.ClaimToken)
+		})
+	}
+}
+
+func TestResolvePendingCommentRevalidatesPublishingIdentityUnderClaim(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		mutate  func(*serviceHarness)
+		wantErr error
+	}{
+		{name: "publishing removed", mutate: func(h *serviceHarness) {
+			h.client.description.Capabilities = nil
+		}, wantErr: ErrCommentPublishingUnavailable},
+		{name: "self actor removed", mutate: func(h *serviceHarness) {
+			h.client.description.SelfActorID = ""
+		}, wantErr: ErrCommentPublishingUnavailable},
+		{name: "root identity changed", mutate: func(h *serviceHarness) {
+			h.client.read.IdentityKey = "different-account"
+		}, wantErr: ErrConnectorIdentityChanged},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newServiceHarness(t)
+			binding, local, pendingAt := h.preparePendingComment(t, "Retain pending")
+			h.client.comments = []connector.Comment{{
+				ID: "external-comment-revalidated", Body: local.Body,
+				Author:    connector.Actor{ID: h.client.description.SelfActorID},
+				CreatedAt: pendingAt, UpdatedAt: pendingAt,
+			}}
+			test.mutate(h)
+
+			_, _, err := h.service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+				IssueID: h.issue.ID, Actor: "tester", Action: "adopt",
+				ExternalCommentID: "external-comment-revalidated",
+			})
+			assert.ErrorIs(t, err, test.wantErr)
+			retained, readErr := h.store.ExternalRootBindingByID(t.Context(), binding.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, local.UID, retained.PendingCommentUID)
+			assert.Empty(t, retained.ClaimToken)
+		})
+	}
+}
+
+func TestResolvePendingCommentRejectsInvalidActionBeforeConnectorCalls(t *testing.T) {
+	h := newServiceHarness(t)
+	_, _, _ = h.preparePendingComment(t, "Retain pending")
+	describeCalls, readCalls := h.client.describeCalls, h.client.readCalls
+
+	_, _, err := h.service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+		IssueID: h.issue.ID, Actor: "tester", Action: "unknown",
+	})
+	assert.ErrorIs(t, err, db.ErrExternalRootValidation)
+	assert.Equal(t, describeCalls, h.client.describeCalls)
+	assert.Equal(t, readCalls, h.client.readCalls)
+}
+
+func TestResolvePendingCommentReleasesClaimAfterCallerCancellation(t *testing.T) {
+	h := newServiceHarness(t)
+	binding, local, _ := h.preparePendingComment(t, "Retain after cancellation")
+	ctx, cancel := context.WithCancel(t.Context())
+	h.client.beforeReadReturn = cancel
+	h.client.readErr = context.Canceled
+
+	_, _, err := h.service.ResolvePendingComment(ctx, ResolvePendingCommentParams{
+		IssueID: h.issue.ID, Actor: "tester", Action: "adopt",
+		ExternalCommentID: "external-comment-canceled",
+	})
+	assert.ErrorIs(t, err, context.Canceled)
+	retained, readErr := h.store.ExternalRootBindingByID(t.Context(), binding.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, local.UID, retained.PendingCommentUID)
+	assert.Empty(t, retained.ClaimToken)
+}
+
+func TestResolvePendingCommentReturnsCommittedEventWhenClaimReleaseReportsError(t *testing.T) {
+	h := newServiceHarness(t)
+	binding, _, _ := h.preparePendingComment(t, "Skip with release error")
+	releaseErr := errors.New("claim release result unavailable")
+	h.service.store = &releaseThenFailStorage{Storage: h.store, err: releaseErr}
+
+	resolved, event, err := h.service.ResolvePendingComment(t.Context(), ResolvePendingCommentParams{
+		IssueID: h.issue.ID, Actor: "tester", Action: "skip",
+	})
+	assert.ErrorIs(t, err, releaseErr)
+	assert.Equal(t, binding.ID, resolved.ID)
+	assert.Equal(t, "issue.external_comment_resolved", event.Type)
+	stored, readErr := h.store.ExternalRootBindingByID(t.Context(), binding.ID)
+	require.NoError(t, readErr)
+	assert.Empty(t, stored.PendingCommentUID)
+	assert.Empty(t, stored.ClaimToken)
+}
+
+type releaseThenFailStorage struct {
+	db.Storage
+	err error
+}
+
+func (s *releaseThenFailStorage) ReleaseExternalRootClaim(
+	ctx context.Context,
+	bindingID int64,
+	token string,
+) (db.ExternalRootBinding, error) {
+	binding, err := s.Storage.ReleaseExternalRootClaim(ctx, bindingID, token)
+	if err != nil {
+		return binding, err
+	}
+	return binding, s.err
+}
+
+func (h *serviceHarness) preparePendingComment(
+	t *testing.T,
+	body string,
+) (db.ExternalRootBinding, db.Comment, time.Time) {
+	t.Helper()
+	h.client.read.UpdatedAt = testObservedAt
+	frontier := testObservedAt
+	binding, _, err := h.store.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: h.project.ID, IssueID: h.issue.ID,
+		ConnectorInstance: "notes", ExternalRootKey: "root-1", ExternalAccountKey: "account-1",
+		Actor: "tester", ReceiveCommentsAfter: testObservedAt,
+		PublishComments: true, PublishCommentsAfter: &frontier,
+	})
+	require.NoError(t, err)
+	local := h.createServiceComment(t, body)
+	pendingAt := time.Now().UTC().Truncate(time.Millisecond).Add(-time.Minute)
+	claimed, acquired, err := h.store.ClaimExternalRootBinding(
+		t.Context(), binding.ID, "pending-setup-claim", pendingAt, pendingAt.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	_, err = h.store.SetPendingExternalComment(t.Context(), db.SetPendingExternalCommentParams{
+		BindingID: binding.ID, ClaimToken: claimed.ClaimToken, CommentUID: local.UID, At: pendingAt,
+	})
+	require.NoError(t, err)
+	_, err = h.store.RecordExternalRootError(t.Context(), db.ExternalRootErrorParams{
+		BindingID: binding.ID, ClaimToken: claimed.ClaimToken,
+		At: pendingAt, NextAttemptAt: pendingAt, Error: "publication result uncertain",
+	})
+	require.NoError(t, err)
+	return binding, local, pendingAt
+}
+
+func pendingResolutionAction(t *testing.T, event db.Event) string {
+	t.Helper()
+	var payload db.ExternalRootAuditPayload
+	require.NoError(t, json.Unmarshal([]byte(event.Payload), &payload))
+	return payload.Action
+}
+
+type serviceHarness struct {
+	store    *sqlitestore.Store
+	observed *observingStorage
+	project  db.Project
+	issue    db.Issue
+	client   *fakeConnectorClient
+	registry *Registry
+	service  *Service
+}
+
+func newServiceHarness(t *testing.T) *serviceHarness {
+	t.Helper()
+	t.Setenv("KATA_HOME", t.TempDir())
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	project, err := store.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "Local plan", Body: "Local body", Author: "tester",
+	})
+	require.NoError(t, err)
+	client := &fakeConnectorClient{
+		description: testDescription("account-1"),
+		resolved:    connector.Root{Key: "root-1", IdentityKey: "account-1", Title: "External plan", Body: "External body", State: "open", Revision: "7", ObservedAt: testObservedAt},
+		read:        connector.Root{Key: "root-1", IdentityKey: "account-1", Title: "External plan", Body: "External body", State: "open", Revision: "7", ObservedAt: testObservedAt},
+	}
+	client.description.Capabilities = []connector.Capability{
+		connector.CapabilityPublishComment,
+		connector.CapabilityFields,
+		connector.CapabilityConditionalFields,
+	}
+	client.description.SelfActorID = "connector-self"
+	registry, err := NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "notes", Command: filepath.Join(t.TempDir(), "connector"),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	observed := &observingStorage{Storage: store}
+	service := NewService(observed, registry, func(ctx context.Context, bindingID int64, claimToken string) ([]db.Event, error) {
+		_, err := store.ReleaseExternalRootClaim(ctx, bindingID, claimToken)
+		return nil, err
+	})
+	return &serviceHarness{store: store, observed: observed, project: project, issue: issue, client: client, registry: registry, service: service}
+}
+
+type observingStorage struct {
+	db.Storage
+	hookFinished         bool
+	issueReadAfterHook   bool
+	bindingReadAfterHook bool
+}
+
+func (s *observingStorage) IssueByID(ctx context.Context, issueID int64) (db.Issue, error) {
+	if s.hookFinished {
+		s.issueReadAfterHook = true
+	}
+	return s.Storage.IssueByID(ctx, issueID)
+}
+
+func (s *observingStorage) ExternalRootBindingByID(ctx context.Context, bindingID int64) (db.ExternalRootBinding, error) {
+	if s.hookFinished {
+		s.bindingReadAfterHook = true
+	}
+	return s.Storage.ExternalRootBindingByID(ctx, bindingID)
+}
+
+type fakeConnectorClient struct {
+	description          connector.Description
+	describeErr          error
+	beforeDescribeReturn func()
+	resolved             connector.Root
+	resolveErr           error
+	read                 connector.Root
+	readErr              error
+	beforeReadReturn     func()
+	comments             []connector.Comment
+	fields               []connector.FieldDescriptor
+	fieldValues          map[string]connector.FieldValue
+	listFieldsErr        error
+	readFieldsErr        map[string]error
+	writeFieldsErr       error
+	writeFieldResult     func(string, connector.FieldValue) connector.FieldValue
+	beforeWriteFields    func()
+	listFieldsCalls      int
+	readFieldCalls       []connector.ReadFieldsParams
+	writeFieldCalls      []connector.WriteFieldsParams
+	describeCalls        int
+	resolveCalls         int
+	readCalls            int
+	listCommentCalls     int
+	publishCalls         int
+	publishParams        []connector.PublishCommentParams
+	publishResult        connector.Comment
+	publishErr           error
+	beforePublish        func()
+	completeCalls        int
+	completeErr          error
+	completeReadback     connector.Root
+	beforeComplete       func()
+}
+
+func (c *fakeConnectorClient) Describe(context.Context) (connector.Description, error) {
+	c.describeCalls++
+	if c.beforeDescribeReturn != nil {
+		c.beforeDescribeReturn()
+	}
+	return c.description, c.describeErr
+}
+func (c *fakeConnectorClient) ResolveRoot(context.Context, connector.ResolveRootParams) (connector.Root, error) {
+	c.resolveCalls++
+	return c.resolved, c.resolveErr
+}
+func (c *fakeConnectorClient) ReadRoot(context.Context, connector.ReadRootParams) (connector.Root, error) {
+	c.readCalls++
+	if c.beforeReadReturn != nil {
+		c.beforeReadReturn()
+	}
+	return c.read, c.readErr
+}
+func (c *fakeConnectorClient) ListComments(context.Context, connector.ListCommentsParams) (connector.ListCommentsResult, error) {
+	c.listCommentCalls++
+	comments := append([]connector.Comment(nil), c.comments...)
+	for index := range comments {
+		if comments[index].Revision == "" {
+			comments[index].Revision = fmt.Sprintf("test-comment-revision-%d", index)
+		}
+	}
+	return connector.ListCommentsResult{Comments: comments}, nil
+}
+func (c *fakeConnectorClient) CompleteRoot(context.Context, connector.CompleteRootParams) (connector.Root, error) {
+	c.completeCalls++
+	if c.beforeComplete != nil {
+		c.beforeComplete()
+	}
+	if c.completeErr != nil {
+		return connector.Root{}, c.completeErr
+	}
+	if c.completeReadback.Key != "" {
+		c.read = c.completeReadback
+	}
+	return c.read, nil
+}
+func (c *fakeConnectorClient) PublishComment(_ context.Context, params connector.PublishCommentParams) (connector.Comment, error) {
+	c.publishCalls++
+	c.publishParams = append(c.publishParams, params)
+	if c.beforePublish != nil {
+		c.beforePublish()
+	}
+	return c.publishResult, c.publishErr
+}
+func (c *fakeConnectorClient) ListFields(context.Context) (connector.ListFieldsResult, error) {
+	c.listFieldsCalls++
+	return connector.ListFieldsResult{Fields: c.fields}, c.listFieldsErr
+}
+func (c *fakeConnectorClient) ReadFields(_ context.Context, params connector.ReadFieldsParams) (connector.ReadFieldsResult, error) {
+	c.readFieldCalls = append(c.readFieldCalls, params)
+	result := connector.ReadFieldsResult{Fields: make(map[string]connector.FieldValue, len(params.FieldIDs))}
+	for _, fieldID := range params.FieldIDs {
+		if err := c.readFieldsErr[fieldID]; err != nil {
+			return connector.ReadFieldsResult{}, err
+		}
+		if value, ok := c.fieldValues[fieldID]; ok {
+			result.Fields[fieldID] = value
+		}
+	}
+	return result, nil
+}
+func (c *fakeConnectorClient) WriteFields(_ context.Context, params connector.WriteFieldsParams) (connector.WriteFieldsResult, error) {
+	c.writeFieldCalls = append(c.writeFieldCalls, params)
+	if c.beforeWriteFields != nil {
+		c.beforeWriteFields()
+	}
+	if c.writeFieldsErr != nil {
+		return connector.WriteFieldsResult{}, c.writeFieldsErr
+	}
+	if c.fieldValues == nil {
+		c.fieldValues = make(map[string]connector.FieldValue)
+	}
+	for fieldID := range params.Fields {
+		if expected, ok := params.Expected[fieldID]; !ok || c.fieldValues[fieldID] != expected {
+			return connector.WriteFieldsResult{}, &connector.Error{Code: "field_conflict", Message: "field changed before write"}
+		}
+	}
+	result := connector.WriteFieldsResult{Fields: make(map[string]connector.FieldValue, len(params.Fields))}
+	for fieldID, value := range params.Fields {
+		stored := value
+		if c.writeFieldResult != nil {
+			stored = c.writeFieldResult(fieldID, value)
+		}
+		c.fieldValues[fieldID] = stored
+		result.Fields[fieldID] = stored
+	}
+	return result, nil
+}

--- a/internal/rootbridge/service_test.go
+++ b/internal/rootbridge/service_test.go
@@ -378,6 +378,52 @@ func TestBindRejectsNoncanonicalResolvedIdentityWithoutChangingState(t *testing.
 	}
 }
 
+func TestBindRejectsUnreconcilableConnectorDataWithoutChangingState(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		mutate    func(*fakeConnectorClient)
+		wantError error
+	}{
+		{
+			name: "blank root title",
+			mutate: func(client *fakeConnectorClient) {
+				client.resolved.Title = " \t "
+			},
+			wantError: db.ErrExternalRootValidation,
+		},
+		{
+			name: "blank live comment body",
+			mutate: func(client *fakeConnectorClient) {
+				client.comments = []connector.Comment{{
+					ID: "comment-1", Revision: "revision-1", Body: " \t ",
+					Author:    connector.Actor{ID: "reviewer", DisplayName: "Reviewer"},
+					CreatedAt: testObservedAt, UpdatedAt: testObservedAt,
+				}}
+			},
+			wantError: connectorclient.ErrProtocolFailure,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := newServiceHarness(t)
+			test.mutate(h.client)
+			before, err := h.store.MaxEventID(t.Context())
+			require.NoError(t, err)
+
+			_, _, err = h.service.Bind(t.Context(), BindParams{
+				ProjectID: h.project.ID, IssueID: h.issue.ID, ConnectorInstance: "notes",
+				Locator: "root-1", Actor: "tester",
+			})
+
+			assert.ErrorIs(t, err, test.wantError)
+			_, bindingErr := h.store.ExternalRootBindingByIssue(t.Context(), h.issue.ID)
+			assert.ErrorIs(t, bindingErr, db.ErrNotFound)
+			after, eventErr := h.store.MaxEventID(t.Context())
+			require.NoError(t, eventErr)
+			assert.Equal(t, before, after)
+		})
+	}
+}
+
 func TestBindMissingInstanceDoesNotChangeState(t *testing.T) {
 	h := newServiceHarness(t)
 	_, _, err := h.service.Bind(t.Context(), BindParams{

--- a/pkg/connector/protocol.go
+++ b/pkg/connector/protocol.go
@@ -179,9 +179,16 @@ func ValidateFieldValue(value FieldValue) error {
 			return errors.New("field value is not a canonical UTC instant")
 		}
 	case "local_datetime":
-		parsed, err := time.Parse("2006-01-02T15:04:05", value.Value)
+		canonical := false
+		for _, layout := range []string{"2006-01-02T15:04", "2006-01-02T15:04:05"} {
+			parsed, err := time.Parse(layout, value.Value)
+			if err == nil && parsed.Format(layout) == value.Value {
+				canonical = true
+				break
+			}
+		}
 		location, zoneErr := time.LoadLocation(value.Timezone)
-		if err != nil || parsed.Format("2006-01-02T15:04:05") != value.Value ||
+		if !canonical ||
 			zoneErr != nil || value.Timezone == "Local" || location.String() != value.Timezone {
 			return errors.New("local datetime field value is incomplete")
 		}


### PR DESCRIPTION
## What changed

- reconcile external-root title, body, comments, lifecycle, and mapped planning fields through one `Reconciler.Run` entry point with explicit run options
- pin connector/account identity, preserve retry claims, recover ambiguous outbound comment publication by replaying stable operation IDs without depending on provider timestamp precision, and verify external completion
- support inbound comments and lifecycle by default while keeping outbound comment publication opt-in
- keep planning reconciliation deliberately limited to `scheduled_on` and `deadline_on`

## Intent decisions

The bound external root owns title and body. Kata imports those values and rejects local edits with a `kata bridge unbind <issue-ref>` recovery hint. A third planning field is not accepted implicitly because it requires an explicit storage migration and reconciliation contract.

The current implementation performs bounded subprocess RPCs per reconciliation operation. A long-lived connector transport is deferred.

## Scope and dependency

This is PR 3 of the delivery sequence tracked in #286 and depends on #287 and #291. The branch is cumulative so it builds before those PRs merge; after they land, the review diff narrows to `internal/rootbridge`.

Daemon/API/CLI integration follows in the final PR. A web UI binding indicator is out of scope for this series.

Part of #286.