### PR TITLE
Expose external root bridges through daemon, CLI, and MCP

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -141,6 +141,21 @@ components:
       required:
         - kind
       type: object
+    BindExternalRootRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        connector:
+          type: string
+        external:
+          type: string
+        publish_comments:
+          type: boolean
+      required:
+        - connector
+        - external
+      type: object
     ChildCounts:
       additionalProperties: true
       properties:
@@ -335,6 +350,57 @@ components:
         - comment
         - event
         - changed
+      type: object
+    ConnectorFieldsResponseBody:
+      additionalProperties: true
+      properties:
+        fields:
+          items:
+            $ref: "#/components/schemas/FieldDescriptor"
+          type:
+            - array
+            - "null"
+      required:
+        - fields
+      type: object
+    ConnectorListResponseBody:
+      additionalProperties: true
+      properties:
+        connectors:
+          items:
+            $ref: "#/components/schemas/ConnectorOut"
+          type:
+            - array
+            - "null"
+      required:
+        - connectors
+      type: object
+    ConnectorOut:
+      additionalProperties: true
+      properties:
+        account_identity:
+          type: string
+        capabilities:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        connector_id:
+          type: string
+        display_name:
+          type: string
+        health_error:
+          type: string
+        healthy:
+          type: boolean
+        instance_id:
+          type: string
+        protocol:
+          type: string
+      required:
+        - instance_id
+        - healthy
       type: object
     CreateFederationEnrollmentRequestBody:
       additionalProperties: false
@@ -1006,6 +1072,176 @@ components:
       required:
         - type
       type: object
+    ExternalFieldCandidateOut:
+      additionalProperties: true
+      properties:
+        kind:
+          type: string
+        timezone:
+          type: string
+        value:
+          type: string
+      required:
+        - kind
+      type: object
+    ExternalFieldConflictOut:
+      additionalProperties: true
+      properties:
+        conflict_at:
+          format: date-time
+          type: string
+        external_candidate:
+          $ref: "#/components/schemas/ExternalFieldCandidateOut"
+        kata_candidate:
+          $ref: "#/components/schemas/ExternalFieldCandidateOut"
+        kata_field:
+          type: string
+      required:
+        - kata_field
+      type: object
+    ExternalFieldMappingOut:
+      additionalProperties: true
+      properties:
+        accepted_kinds:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        active:
+          type: boolean
+        external_field_id:
+          type: string
+        external_field_name:
+          type: string
+        kata_field:
+          type: string
+        nullable:
+          type: boolean
+        schema_revision:
+          type: string
+        writable:
+          type: boolean
+      required:
+        - kata_field
+        - external_field_id
+        - external_field_name
+        - accepted_kinds
+        - nullable
+        - writable
+        - schema_revision
+        - active
+      type: object
+    ExternalRootActionRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        reason:
+          type: string
+      type: object
+    ExternalRootBridgeOut:
+      additionalProperties: true
+      properties:
+        active:
+          type: boolean
+        complete_external:
+          type: boolean
+        connector_instance:
+          type: string
+        consecutive_failures:
+          format: int64
+          type: integer
+        enabled:
+          type: boolean
+        field_conflicts:
+          items:
+            $ref: "#/components/schemas/ExternalFieldConflictOut"
+          type:
+            - array
+            - "null"
+        id:
+          format: int64
+          type: integer
+        issue_id:
+          format: int64
+          type: integer
+        last_attempt_at:
+          format: date-time
+          type: string
+        last_error:
+          type: string
+        last_error_at:
+          format: date-time
+          type: string
+        last_external_state:
+          type: string
+        last_success_at:
+          format: date-time
+          type: string
+        next_attempt_at:
+          format: date-time
+          type: string
+        paused_reason:
+          type: string
+        pending_comment_uid:
+          type: string
+        project_id:
+          format: int64
+          type: integer
+        publish_comments:
+          type: boolean
+        receive_comments:
+          type: boolean
+        uid:
+          type: string
+      required:
+        - id
+        - uid
+        - project_id
+        - issue_id
+        - connector_instance
+        - active
+        - enabled
+        - receive_comments
+        - publish_comments
+        - complete_external
+        - consecutive_failures
+      type: object
+    ExternalRootRunOut:
+      additionalProperties: true
+      properties:
+        bridge:
+          $ref: "#/components/schemas/ExternalRootBridgeOut"
+        comments_created:
+          format: int64
+          type: integer
+        comments_edited:
+          format: int64
+          type: integer
+        completion_requests:
+          format: int64
+          type: integer
+        field_conflicts:
+          format: int64
+          type: integer
+        paused:
+          type: boolean
+        reopen_requests:
+          format: int64
+          type: integer
+        root_updated:
+          type: boolean
+      required:
+        - bridge
+        - root_updated
+        - comments_created
+        - comments_edited
+        - field_conflicts
+        - completion_requests
+        - reopen_requests
+        - paused
+      type: object
     FederationBindingOut:
       additionalProperties: true
       properties:
@@ -1424,6 +1660,33 @@ components:
         - event_uid
         - issue_uid
         - at
+      type: object
+    FieldDescriptor:
+      additionalProperties: true
+      properties:
+        accepted_kinds:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        display_name:
+          type: string
+        id:
+          type: string
+        nullable:
+          type: boolean
+        schema_revision:
+          type: string
+        writable:
+          type: boolean
+      required:
+        - id
+        - display_name
+        - accepted_kinds
+        - nullable
+        - writable
+        - schema_revision
       type: object
     HealthResponseBody:
       additionalProperties: true
@@ -2452,6 +2715,14 @@ components:
       required:
         - tokens
       type: object
+    MapConnectorFieldRequestBody:
+      additionalProperties: false
+      properties:
+        external_field:
+          type: string
+      required:
+        - external_field
+      type: object
     MergeProjectRequestBody:
       additionalProperties: false
       properties:
@@ -3364,6 +3635,14 @@ components:
         - new_origin
         - state
       type: object
+    ReconcileExternalRootByKeyRequestBody:
+      additionalProperties: false
+      properties:
+        root_key:
+          type: string
+      required:
+        - root_key
+      type: object
     Recurrence:
       additionalProperties: true
       properties:
@@ -3501,6 +3780,31 @@ components:
           type: string
       required:
         - name
+      type: object
+    ResolveExternalCommentRequestBody:
+      additionalProperties: false
+      properties:
+        action:
+          type: string
+        actor:
+          type: string
+        external_comment_id:
+          type: string
+      required:
+        - action
+      type: object
+    ResolveExternalFieldRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        kata_field:
+          type: string
+        use:
+          type: string
+      required:
+        - kata_field
+        - use
       type: object
     ResolveProjectRequestBody:
       additionalProperties: false
@@ -4314,6 +4618,153 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuditClosesResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors:
+    get:
+      operationId: listConnectors
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorListResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors/{instance}:
+    get:
+      operationId: getConnectorStatus
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors/{instance}/actions/reconcile-root:
+    post:
+      operationId: reconcileExternalRootByKey
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReconcileExternalRootByKeyRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootRunOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors/{instance}/fields:
+    get:
+      operationId: listConnectorFields
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorFieldsResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors/{instance}/fields/{kata_field}:
+    delete:
+      operationId: unmapConnectorField
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: kata_field
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalFieldMappingOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    put:
+      operationId: mapConnectorField
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: kata_field
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MapConnectorFieldRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalFieldMappingOut"
           description: OK
         default:
           content:
@@ -6057,6 +6508,274 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge:
+    delete:
+      operationId: unbindExternalRoot
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: actor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    get:
+      operationId: getExternalRootBridge
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: actor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    post:
+      operationId: bindExternalRoot
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BindExternalRootRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/pause:
+    post:
+      operationId: pauseExternalRootBridge
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExternalRootActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/reconcile:
+    post:
+      operationId: reconcileExternalRootBridge
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExternalRootActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootRunOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-comment:
+    post:
+      operationId: resolveExternalComment
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResolveExternalCommentRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-field:
+    post:
+      operationId: resolveExternalField
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResolveExternalFieldRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resume:
+    post:
+      operationId: resumeExternalRootBridge
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExternalRootActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
           description: OK
         default:
           content:

--- a/cmd/kata/bridge.go
+++ b/cmd/kata/bridge.go
@@ -1,0 +1,496 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kata/internal/textsafe"
+	kataclient "go.kenn.io/kata/pkg/client"
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+func newBridgeCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "bridge", Short: "manage issue bindings to external roots"}
+	cmd.AddCommand(
+		newBridgeBindCmd(),
+		newBridgeShowCmd(),
+		newBridgeReconcileCmd(),
+		newBridgePauseCmd(),
+		newBridgeResumeCmd(),
+		newBridgeResolveFieldCmd(),
+		newBridgeResolveCommentCmd(),
+		newBridgeUnbindCmd(),
+	)
+	return cmd
+}
+
+func newBridgeBindCmd() *cobra.Command {
+	var connectorInstance, external string
+	var publishComments bool
+	cmd := &cobra.Command{
+		Use:   "bind <issue>",
+		Short: "bind an issue to an existing external root",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(connectorInstance) == "" {
+				return externalCLIValidation("--connector is required")
+			}
+			if strings.TrimSpace(external) == "" {
+				return externalCLIValidation("--external is required")
+			}
+			resolved, err := resolveBridgeTarget(cmd, args[0], true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := resolved.client.BindExternalRootWithResponse(resolved.ctx, &generated.BindExternalRootRequestOptions{
+				PathParams: &generated.BindExternalRootPath{ProjectID: resolved.projectID, Ref: resolved.issue.RefForAPI},
+				Body: &generated.BindExternalRootBody{
+					Actor: &resolved.actor, Connector: connectorInstance, External: external, PublishComments: &publishComments,
+				},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			return printBridgeResponse(cmd, resp.Body, resp.JSON200, "bound", nil)
+		},
+	}
+	cmd.Flags().StringVar(&connectorInstance, "connector", "", "configured connector instance")
+	cmd.Flags().StringVar(&external, "external", "", "external root locator")
+	cmd.Flags().BoolVar(&publishComments, "publish-comments", false, "publish new Kata root comments externally")
+	return cmd
+}
+
+func newBridgeShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <issue>",
+		Short: "show bridge policy and status",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := resolveBridgeTarget(cmd, args[0], false)
+			if err != nil {
+				return err
+			}
+			resp, callErr := resolved.client.GetExternalRootBridgeWithResponse(resolved.ctx, &generated.GetExternalRootBridgeRequestOptions{
+				PathParams: &generated.GetExternalRootBridgePath{ProjectID: resolved.projectID, Ref: resolved.issue.RefForAPI},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			return printBridgeResponse(cmd, resp.Body, resp.JSON200, "show", nil)
+		},
+	}
+}
+
+func newBridgeReconcileCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reconcile <issue>",
+		Short: "reconcile a bridge now",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := resolveBridgeTarget(cmd, args[0], true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := resolved.client.ReconcileExternalRootBridgeWithResponse(resolved.ctx, &generated.ReconcileExternalRootBridgeRequestOptions{
+				PathParams: &generated.ReconcileExternalRootBridgePath{ProjectID: resolved.projectID, Ref: resolved.issue.RefForAPI},
+				Body:       &generated.ReconcileExternalRootBridgeBody{Actor: &resolved.actor},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			if resp.JSON200 == nil {
+				return fmt.Errorf("bridge reconcile: empty response")
+			}
+			return printBridgeRun(cmd, resp.Body, *resp.JSON200)
+		},
+	}
+}
+
+func newBridgePauseCmd() *cobra.Command {
+	var reason string
+	cmd := &cobra.Command{
+		Use:   "pause <issue>",
+		Short: "pause bridge reconciliation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := resolveBridgeTarget(cmd, args[0], false)
+			if err != nil {
+				return err
+			}
+			body := generated.PauseExternalRootBridgeBody{Actor: &resolved.actor}
+			if cmd.Flags().Changed("reason") {
+				body.Reason = &reason
+			}
+			resp, callErr := resolved.client.PauseExternalRootBridgeWithResponse(resolved.ctx, &generated.PauseExternalRootBridgeRequestOptions{
+				PathParams: &generated.PauseExternalRootBridgePath{ProjectID: resolved.projectID, Ref: resolved.issue.RefForAPI},
+				Body:       &body,
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			return printBridgeResponse(cmd, resp.Body, resp.JSON200, "paused", nil)
+		},
+	}
+	cmd.Flags().StringVar(&reason, "reason", "", "safe operator pause reason")
+	return cmd
+}
+
+func newBridgeResumeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "resume <issue>",
+		Short: "validate and resume bridge reconciliation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := resolveBridgeTarget(cmd, args[0], true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := resolved.client.ResumeExternalRootBridgeWithResponse(resolved.ctx, &generated.ResumeExternalRootBridgeRequestOptions{
+				PathParams: &generated.ResumeExternalRootBridgePath{ProjectID: resolved.projectID, Ref: resolved.issue.RefForAPI},
+				Body:       &generated.ResumeExternalRootBridgeBody{Actor: &resolved.actor},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			return printBridgeResponse(cmd, resp.Body, resp.JSON200, "resumed", nil)
+		},
+	}
+}
+
+func newBridgeResolveFieldCmd() *cobra.Command {
+	var use string
+	cmd := &cobra.Command{
+		Use:   "resolve-field <issue> <kata-field>",
+		Short: "resolve a changed field conflict explicitly",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if use != "kata" && use != "external" {
+				return externalCLIValidation("--use must be kata or external")
+			}
+			resolved, err := resolveBridgeTarget(cmd, args[0], true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := resolved.client.ResolveExternalFieldWithResponse(resolved.ctx, &generated.ResolveExternalFieldRequestOptions{
+				PathParams: &generated.ResolveExternalFieldPath{ProjectID: resolved.projectID, Ref: resolved.issue.RefForAPI},
+				Body:       &generated.ResolveExternalFieldBody{Actor: &resolved.actor, KataField: args[1], Use: use},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			return printBridgeResponse(cmd, resp.Body, resp.JSON200, "field resolved", map[string]string{"field": args[1], "use": use})
+		},
+	}
+	cmd.Flags().StringVar(&use, "use", "", "winning value: kata or external")
+	return cmd
+}
+
+func newBridgeResolveCommentCmd() *cobra.Command {
+	var adopt string
+	var retry, skip bool
+	cmd := &cobra.Command{
+		Use:   "resolve-comment <issue>",
+		Short: "resolve uncertain outbound comment delivery",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			adoptSelected := cmd.Flags().Changed("adopt")
+			selected := 0
+			if adoptSelected {
+				selected++
+			}
+			if retry {
+				selected++
+			}
+			if skip {
+				selected++
+			}
+			if selected != 1 {
+				return externalCLIValidation("exactly one of --adopt, --retry, or --skip is required")
+			}
+			if adoptSelected && adopt == "" {
+				return externalCLIValidation("--adopt requires a non-empty external comment ID")
+			}
+			action := "adopt"
+			var externalCommentID *string
+			switch {
+			case retry:
+				action = "retry"
+			case skip:
+				action = "skip"
+			default:
+				externalCommentID = &adopt
+			}
+			resolved, err := resolveBridgeTargetWithOptions(cmd, args[0], true, true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := resolved.client.ResolveExternalCommentWithResponse(resolved.ctx, &generated.ResolveExternalCommentRequestOptions{
+				PathParams: &generated.ResolveExternalCommentPath{ProjectID: resolved.projectID, Ref: resolved.issue.RefForAPI},
+				Body: &generated.ResolveExternalCommentBody{
+					Action: action, Actor: &resolved.actor, ExternalCommentID: externalCommentID,
+				},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			return printBridgeResponse(cmd, resp.Body, resp.JSON200, "comment resolved", map[string]string{"resolution": action})
+		},
+	}
+	cmd.Flags().StringVar(&adopt, "adopt", "", "adopt the exact external comment ID")
+	cmd.Flags().BoolVar(&retry, "retry", false, "retry outbound comment publication")
+	cmd.Flags().BoolVar(&skip, "skip", false, "skip the pending comment")
+	return cmd
+}
+
+func newBridgeUnbindCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unbind <issue>",
+		Short: "stop reconciliation while preserving history",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved, err := resolveBridgeTargetWithOptions(cmd, args[0], false, true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := resolved.client.UnbindExternalRootWithResponse(resolved.ctx, &generated.UnbindExternalRootRequestOptions{
+				PathParams: &generated.UnbindExternalRootPath{ProjectID: resolved.projectID, Ref: resolved.issue.RefForAPI},
+				Query:      &generated.UnbindExternalRootQuery{Actor: &resolved.actor},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			return printBridgeResponse(cmd, resp.Body, resp.JSON200, "unbound", nil)
+		},
+	}
+}
+
+type bridgeTarget struct {
+	ctx       context.Context
+	client    *kataclient.Client
+	projectID int64
+	issue     resolvedIssueRef
+	actor     string
+}
+
+func resolveBridgeTarget(cmd *cobra.Command, rawRef string, longRunning bool) (bridgeTarget, error) {
+	return resolveBridgeTargetWithOptions(cmd, rawRef, longRunning, false)
+}
+
+func resolveBridgeTargetWithOptions(
+	cmd *cobra.Command,
+	rawRef string,
+	longRunning, includeArchivedProject bool,
+) (bridgeTarget, error) {
+	ctx, baseURL, projectID, issue, err := resolveIssueRefForCommandWithOptions(
+		cmd, rawRef, includeArchivedProject,
+	)
+	if err != nil {
+		return bridgeTarget{}, err
+	}
+	actor, _ := resolveActor(ctx, flags.As, nil)
+	var httpClient *http.Client
+	if longRunning {
+		httpClient, err = longRunningClientFor(ctx, baseURL)
+	} else {
+		httpClient, err = httpClientFor(ctx, baseURL)
+	}
+	if err != nil {
+		return bridgeTarget{}, err
+	}
+	apiClient, err := kataclient.NewWithHTTPClient(baseURL, httpClient)
+	if err != nil {
+		return bridgeTarget{}, err
+	}
+	return bridgeTarget{ctx: ctx, client: apiClient, projectID: projectID, issue: issue, actor: actor}, nil
+}
+
+func printBridgeResponse(cmd *cobra.Command, raw []byte, bridge *generated.ExternalRootBridgeOut, action string, extra map[string]string) error {
+	if currentOutputMode() == outputJSON {
+		return emitJSON(cmd.OutOrStdout(), json.RawMessage(raw))
+	}
+	if bridge == nil {
+		return fmt.Errorf("bridge %s: empty response", action)
+	}
+	if flags.Quiet {
+		return nil
+	}
+	if currentOutputMode() == outputAgent {
+		return printBridgeAgent(cmd, *bridge, extra)
+	}
+	if action != "show" {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Bridge %s.\n", textsafe.Line(action)); err != nil {
+			return err
+		}
+	}
+	if len(extra) > 0 {
+		keys := make([]string, 0, len(extra))
+		for key := range extra {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", humanExternalLabel(key), textsafe.Line(extra[key])); err != nil {
+				return err
+			}
+		}
+	}
+	return printBridgeHuman(cmd, *bridge)
+}
+
+func printBridgeHuman(cmd *cobra.Command, bridge generated.ExternalRootBridgeOut) error {
+	w := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(w,
+		"Connector: %s\nState: %s\nReceive comments: %t\nPublish comments: %t\nComplete external: %t\nPaused reason: %s\nLast success: %s\nLast error: %s\nPending comment: %s\n",
+		textsafe.Line(bridge.ConnectorInstance), bridgeState(bridge), bridge.ReceiveComments, bridge.PublishComments,
+		bridge.CompleteExternal, textsafe.Line(optionalExternalString(bridge.PausedReason)),
+		externalTime(bridge.LastSuccessAt), textsafe.Line(optionalExternalString(bridge.LastError)),
+		textsafe.Line(optionalExternalString(bridge.PendingCommentUID))); err != nil {
+		return err
+	}
+	conflicts := sortedBridgeConflicts(bridge.FieldConflicts)
+	for _, conflict := range conflicts {
+		if _, err := fmt.Fprintf(w, "Field conflict: %s\n  Kata: %s\n  External: %s\n",
+			textsafe.Line(conflict.KataField), externalCandidateHuman(conflict.KataCandidate),
+			externalCandidateHuman(conflict.ExternalCandidate)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printBridgeAgent(cmd *cobra.Command, bridge generated.ExternalRootBridgeOut, extra map[string]string) error {
+	w := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(w, "instance=%s state=%s receive_comments=%t publish_comments=%t pending_comment=%s last_error=%s",
+		agentValue(bridge.ConnectorInstance), bridgeState(bridge), bridge.ReceiveComments, bridge.PublishComments,
+		agentValue(optionalExternalString(bridge.PendingCommentUID)), agentValue(optionalExternalString(bridge.LastError))); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(extra))
+	for key := range extra {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if _, err := fmt.Fprintf(w, " %s=%s", key, agentValue(extra[key])); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	for _, conflict := range sortedBridgeConflicts(bridge.FieldConflicts) {
+		if _, err := fmt.Fprintf(w, "field=%s %s %s\n", agentValue(conflict.KataField),
+			externalCandidateAgent("kata", conflict.KataCandidate),
+			externalCandidateAgent("external", conflict.ExternalCandidate)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printBridgeRun(cmd *cobra.Command, raw []byte, run generated.ExternalRootRunOut) error {
+	if currentOutputMode() == outputJSON {
+		return emitJSON(cmd.OutOrStdout(), json.RawMessage(raw))
+	}
+	if flags.Quiet {
+		return nil
+	}
+	if currentOutputMode() == outputAgent {
+		if err := printBridgeAgent(cmd, run.Bridge, map[string]string{
+			"comments_created": fmt.Sprint(run.CommentsCreated), "comments_edited": fmt.Sprint(run.CommentsEdited),
+			"completion_requests": fmt.Sprint(run.CompletionRequests), "field_conflicts": fmt.Sprint(run.FieldConflicts),
+			"paused": fmt.Sprint(run.Paused), "reopen_requests": fmt.Sprint(run.ReopenRequests),
+			"root_updated": fmt.Sprint(run.RootUpdated),
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(),
+		"Reconciled bridge.\nRoot updated: %t\nComments created: %d\nComments edited: %d\nField conflicts: %d\nCompletion requests: %d\nReopen requests: %d\nPaused: %t\n",
+		run.RootUpdated, run.CommentsCreated, run.CommentsEdited, run.FieldConflicts,
+		run.CompletionRequests, run.ReopenRequests, run.Paused); err != nil {
+		return err
+	}
+	return printBridgeHuman(cmd, run.Bridge)
+}
+
+func bridgeState(bridge generated.ExternalRootBridgeOut) string {
+	switch {
+	case !bridge.Active:
+		return "unbound"
+	case bridge.Enabled:
+		return "enabled"
+	default:
+		return "paused"
+	}
+}
+
+func externalTime(value *time.Time) string {
+	if value == nil {
+		return "-"
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func sortedBridgeConflicts(conflicts []generated.ExternalFieldConflictOut) []generated.ExternalFieldConflictOut {
+	out := append([]generated.ExternalFieldConflictOut(nil), conflicts...)
+	sort.Slice(out, func(i, j int) bool { return out[i].KataField < out[j].KataField })
+	return out
+}
+
+func externalCandidateHuman(candidate *generated.ExternalFieldCandidateOut) string {
+	if candidate == nil {
+		return "kind=- value=- timezone=-"
+	}
+	return fmt.Sprintf("kind=%s value=%s timezone=%s", textsafe.Line(candidate.Kind),
+		textsafe.Line(optionalExternalString(candidate.Value)), textsafe.Line(optionalExternalString(candidate.Timezone)))
+}
+
+func externalCandidateAgent(prefix string, candidate *generated.ExternalFieldCandidateOut) string {
+	if candidate == nil {
+		return fmt.Sprintf("%s_kind=- %s_value=- %s_timezone=-", prefix, prefix, prefix)
+	}
+	return fmt.Sprintf("%s_kind=%s %s_value=%s %s_timezone=%s", prefix, agentValue(candidate.Kind),
+		prefix, agentValue(optionalExternalString(candidate.Value)), prefix, agentValue(optionalExternalString(candidate.Timezone)))
+}
+
+func humanExternalLabel(key string) string {
+	parts := strings.Split(key, "_")
+	for i := range parts {
+		if parts[i] != "" {
+			parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+		}
+	}
+	return strings.Join(parts, " ")
+}

--- a/cmd/kata/bridge_test.go
+++ b/cmd/kata/bridge_test.go
@@ -1,0 +1,381 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+func timeAfterForExternalCLITest() <-chan time.Time { return time.After(750 * time.Millisecond) }
+
+func bridgeFixtureForRequest(r *http.Request, requestBody map[string]any) map[string]any {
+	bridge := map[string]any{
+		"id": 7, "uid": "01JBRIDGE00000000000000000", "project_id": 42, "issue_id": 9,
+		"connector_instance": "example-connector", "active": true, "enabled": true,
+		"receive_comments": true, "publish_comments": false, "complete_external": true,
+		"consecutive_failures": 1, "last_success_at": "2026-08-20T12:00:00Z",
+		"last_error": "safe connector failure", "pending_comment_uid": "01JCOMMENT0000000000000000",
+		"field_conflicts": []any{map[string]any{
+			"kata_field":         "scheduled_on",
+			"kata_candidate":     map[string]any{"kind": "date", "value": "2026-08-21"},
+			"external_candidate": map[string]any{"kind": "local_datetime", "value": "2026-08-22T09:30:00", "timezone": "Etc/UTC"},
+		}},
+	}
+	if r.Method == http.MethodDelete {
+		bridge["active"] = false
+		bridge["enabled"] = false
+	}
+	if publish, ok := requestBody["publish_comments"].(bool); ok {
+		bridge["publish_comments"] = publish
+	}
+	if strings.HasSuffix(r.URL.Path, "/actions/pause") {
+		bridge["enabled"] = false
+		bridge["paused_reason"] = "operator pause"
+	}
+	if strings.HasSuffix(r.URL.Path, "/actions/reconcile") {
+		return map[string]any{
+			"bridge": bridge, "root_updated": true, "comments_created": 2, "comments_edited": 1,
+			"field_conflicts": 1, "completion_requests": 0, "reopen_requests": 0, "paused": false,
+		}
+	}
+	return bridge
+}
+
+func TestBridgeRootHelpRegistersEveryCommand(t *testing.T) {
+	root := newRootCmd()
+	bridge, _, err := root.Find([]string{"bridge"})
+	require.NoError(t, err)
+	assert.Equal(t, "bridge", bridge.Name())
+	for _, name := range []string{"bind", "show", "reconcile", "pause", "resume", "resolve-field", "resolve-comment", "unbind"} {
+		child, _, findErr := root.Find([]string{"bridge", name})
+		require.NoErrorf(t, findErr, "bridge %s", name)
+		assert.Equal(t, name, child.Name())
+	}
+	help := string(executeRoot(t, newRootCmd(), "bridge", "--help"))
+	for _, name := range []string{"bind", "show", "reconcile", "pause", "resume", "resolve-field", "resolve-comment", "unbind"} {
+		assert.Contains(t, help, name)
+	}
+}
+
+func TestBridgeBindDefaultsToQuietOutboundComments(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	out, err := runExternalCLI(context.Background(), t, f, "--agent", "--as", "operator", "bridge", "bind", "example-project#abc4", "--connector", "example-connector", "--external", "root-locator")
+	require.NoError(t, err)
+	assert.Contains(t, out, "receive_comments=true")
+	assert.Contains(t, out, "publish_comments=false")
+	assert.NotContains(t, out, "root-locator")
+	requests := f.snapshotRequests()
+	require.Len(t, requests, 2)
+	assert.Equal(t, map[string]any{"name": "example-project"}, requests[0].Body)
+	assert.Equal(t, map[string]any{
+		"actor": "operator", "connector": "example-connector", "external": "root-locator", "publish_comments": false,
+	}, requests[1].Body)
+
+	for _, mode := range []struct {
+		flag string
+		want string
+	}{
+		{want: "Publish comments: true"},
+		{flag: "--json", want: `"publish_comments":true`},
+		{flag: "--agent", want: "publish_comments=true"},
+	} {
+		f.resetRequests()
+		args := []string{"--as", "operator", "bridge", "bind", "example-project#abc4", "--connector", "example-connector", "--external", "root-locator", "--publish-comments"}
+		if mode.flag != "" {
+			args = append([]string{mode.flag}, args...)
+		}
+		out, err = runExternalCLI(context.Background(), t, f, args...)
+		require.NoError(t, err)
+		assert.Contains(t, out, mode.want)
+		requests = f.snapshotRequests()
+		require.Len(t, requests, 2)
+		assert.Equal(t, true, requests[1].Body["publish_comments"])
+	}
+}
+
+func TestBridgeEveryCommandRendersHumanJSONAndAgent(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	tests := []struct {
+		name      string
+		args      []string
+		humanWant []string
+		agentWant []string
+		jsonWant  []string
+	}{
+		{name: "bind", args: []string{"bridge", "bind", "example-project#abc4", "--connector", "example-connector", "--external", "root-locator"}, humanWant: []string{"example-connector", "enabled", "Receive comments: true", "Publish comments: false"}, agentWant: []string{"instance=example-connector", "state=enabled", "receive_comments=true", "publish_comments=false"}, jsonWant: []string{`"connector_instance":"example-connector"`, `"receive_comments":true`}},
+		{name: "show", args: []string{"bridge", "show", "example-project#abc4"}, humanWant: []string{"Pending comment: 01JCOMMENT0000000000000000", "scheduled_on", "kind=date", "value=2026-08-21", "timezone=Etc/UTC"}, agentWant: []string{"instance=example-connector", "state=enabled", "pending_comment=01JCOMMENT0000000000000000", "field=scheduled_on", "kata_value=2026-08-21", "external_timezone=Etc/UTC"}, jsonWant: []string{`"pending_comment_uid":"01JCOMMENT0000000000000000"`, `"kata_candidate"`}},
+		{name: "reconcile", args: []string{"bridge", "reconcile", "example-project#abc4"}, humanWant: []string{"Reconciled", "Comments created: 2", "Root updated: true"}, agentWant: []string{"state=enabled", "comments_created=2", "root_updated=true"}, jsonWant: []string{`"comments_created":2`, `"root_updated":true`}},
+		{name: "pause", args: []string{"bridge", "pause", "example-project#abc4", "--reason", "operator pause"}, humanWant: []string{"paused", "operator pause"}, agentWant: []string{"state=paused", "instance=example-connector"}, jsonWant: []string{`"enabled":false`, `"paused_reason":"operator pause"`}},
+		{name: "resume", args: []string{"bridge", "resume", "example-project#abc4"}, humanWant: []string{"enabled", "example-connector"}, agentWant: []string{"state=enabled", "instance=example-connector"}, jsonWant: []string{`"enabled":true`}},
+		{name: "resolve-field", args: []string{"bridge", "resolve-field", "example-project#abc4", "scheduled_on", "--use", "kata"}, humanWant: []string{"scheduled_on", "kata", "enabled"}, agentWant: []string{"field=scheduled_on", "use=kata", "state=enabled"}, jsonWant: []string{`"connector_instance":"example-connector"`}},
+		{name: "resolve-comment-adopt", args: []string{"bridge", "resolve-comment", "example-project#abc4", "--adopt", "opaque comment/id"}, humanWant: []string{"comment", "adopt", "enabled"}, agentWant: []string{"resolution=adopt", "state=enabled"}, jsonWant: []string{`"connector_instance":"example-connector"`}},
+		{name: "resolve-comment-retry", args: []string{"bridge", "resolve-comment", "example-project#abc4", "--retry"}, humanWant: []string{"comment", "retry", "enabled"}, agentWant: []string{"resolution=retry", "state=enabled"}, jsonWant: []string{`"connector_instance":"example-connector"`}},
+		{name: "resolve-comment-skip", args: []string{"bridge", "resolve-comment", "example-project#abc4", "--skip"}, humanWant: []string{"comment", "skip", "enabled"}, agentWant: []string{"resolution=skip", "state=enabled"}, jsonWant: []string{`"connector_instance":"example-connector"`}},
+		{name: "unbind", args: []string{"bridge", "unbind", "example-project#abc4"}, humanWant: []string{"unbound", "example-connector"}, agentWant: []string{"state=unbound", "instance=example-connector"}, jsonWant: []string{`"active":false`}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, mode := range []struct {
+				flag string
+				want []string
+			}{{want: test.humanWant}, {flag: "--json", want: test.jsonWant}, {flag: "--agent", want: test.agentWant}} {
+				args := append([]string{"--as", "operator"}, test.args...)
+				if mode.flag != "" {
+					args = append([]string{mode.flag}, args...)
+				}
+				out, err := runExternalCLI(context.Background(), t, f, args...)
+				require.NoError(t, err)
+				for _, want := range mode.want {
+					assert.Contains(t, out, want)
+				}
+				if mode.flag == "--json" {
+					assert.Contains(t, out, `"kata_api_version":1`)
+				}
+			}
+		})
+	}
+}
+
+func TestBridgeOutputSortsConflictsAndRendersMissingValuesNeutrally(t *testing.T) {
+	resetFlags(t)
+	bridge := generated.ExternalRootBridgeOut{
+		Active: true, Enabled: true, ConnectorInstance: "example-connector",
+		FieldConflicts: []generated.ExternalFieldConflictOut{
+			{KataField: "scheduled_on"},
+			{KataField: "deadline_on", KataCandidate: &generated.ExternalFieldCandidateOut{Kind: "date"}},
+		},
+	}
+	cmd := newBridgeShowCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	require.NoError(t, printBridgeResponse(cmd, nil, &bridge, "show", nil))
+	human := out.String()
+	assert.Contains(t, human, "Last success: -")
+	assert.Contains(t, human, "Last error: -")
+	assert.Contains(t, human, "Pending comment: -")
+	assert.Contains(t, human, "Kata: kind=date value=- timezone=-")
+	assert.Contains(t, human, "External: kind=- value=- timezone=-")
+	assert.Less(t, strings.Index(human, "Field conflict: deadline_on"), strings.Index(human, "Field conflict: scheduled_on"))
+
+	flags.Agent = true
+	out.Reset()
+	require.NoError(t, printBridgeResponse(cmd, nil, &bridge, "show", nil))
+	agent := out.String()
+	assert.Contains(t, agent, "pending_comment=- last_error=-")
+	assert.Contains(t, agent, "kata_kind=date kata_value=- kata_timezone=-")
+	assert.Contains(t, agent, "external_kind=- external_value=- external_timezone=-")
+	assert.Less(t, strings.Index(agent, "field=deadline_on"), strings.Index(agent, "field=scheduled_on"))
+}
+
+func TestBridgeResolveCommentRequiresExactlyOneModeBeforeHTTP(t *testing.T) {
+	for _, args := range [][]string{
+		{"bridge", "resolve-comment", "example-project#abc4"},
+		{"bridge", "resolve-comment", "example-project#abc4", "--retry", "--skip"},
+		{"bridge", "resolve-comment", "example-project#abc4", "--adopt", "external-1", "--retry"},
+	} {
+		_, _, err := executeRootCapture(t, context.Background(), args...)
+		require.Error(t, err)
+		var cli *cliError
+		require.ErrorAs(t, err, &cli)
+		assert.Equal(t, kindValidation, cli.Kind)
+		assert.Contains(t, cli.Message, "exactly one")
+	}
+}
+
+func TestBridgeResolveCommentPreservesOpaqueAdoptID(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	const opaque = "opaque ID/with spaces:%25"
+	_, err := runExternalCLI(context.Background(), t, f, "--as", "operator", "bridge", "resolve-comment", "example-project#abc4", "--adopt", opaque)
+	require.NoError(t, err)
+	requests := f.snapshotRequests()
+	require.Len(t, requests, 2)
+	assert.Equal(t, map[string]any{"action": "adopt", "actor": "operator", "external_comment_id": opaque}, requests[1].Body)
+}
+
+func TestBridgeResolveFieldRejectsInvalidChoiceBeforeHTTP(t *testing.T) {
+	_, _, err := executeRootCapture(t, context.Background(), "bridge", "resolve-field", "example-project#abc4", "scheduled_on", "--use", "newest")
+	require.Error(t, err)
+	var cli *cliError
+	require.ErrorAs(t, err, &cli)
+	assert.Equal(t, kindValidation, cli.Kind)
+	assert.Contains(t, cli.Message, "kata or external")
+}
+
+func TestBridgeQualifiedRefUsesConfiguredRemoteDaemon(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	home := setupKataEnv(t)
+	t.Setenv("KATA_SERVER", f.server.URL)
+	t.Setenv("KATA_HOME", home)
+	out, _, err := executeRootCapture(t, context.Background(), "--agent", "bridge", "show", "example-project#abc4")
+	require.NoError(t, err)
+	assert.Contains(t, out, "instance=example-connector")
+	requests := f.snapshotRequests()
+	assert.Condition(t, func() bool {
+		for _, request := range requests {
+			if request.Path == "/api/v1/projects/42/issues/abc4/bridge" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestBridgeBareRefUsesExplicitProjectContext(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	out, err := runExternalCLI(context.Background(), t, f, "--agent", "--project", "example-project", "bridge", "show", "abc4")
+	require.NoError(t, err)
+	assert.Contains(t, out, "instance=example-connector")
+	requests := f.snapshotRequests()
+	require.Len(t, requests, 2)
+	assert.Equal(t, map[string]any{"name": "example-project"}, requests[0].Body)
+	assert.Equal(t, "/api/v1/projects/42/issues/abc4/bridge", requests[1].Path)
+}
+
+func TestBridgeExternalCallsUseLongRunningClient(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	f.delay = true
+	t.Setenv("KATA_HTTP_TIMEOUT", "500ms")
+	tests := [][]string{
+		{"bridge", "bind", "example-project#abc4", "--connector", "example-connector", "--external", "root-locator"},
+		{"bridge", "reconcile", "example-project#abc4"},
+		{"bridge", "resume", "example-project#abc4"},
+		{"bridge", "resolve-field", "example-project#abc4", "scheduled_on", "--use", "external"},
+		{"bridge", "resolve-comment", "example-project#abc4", "--retry"},
+	}
+	for _, args := range tests {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_, err := runExternalCLI(ctx, t, f, args...)
+		cancel()
+		require.NoErrorf(t, err, "%v", args)
+	}
+}
+
+func TestBridgeLongRunningClientHonorsCancellation(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	f.delay = true
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	_, err := runExternalCLI(ctx, t, f, "bridge", "reconcile", "example-project#abc4")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestBridgeCommandsSendExactQualifiedRefRequests(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	tests := []struct {
+		name   string
+		args   []string
+		method string
+		path   string
+		query  string
+		body   map[string]any
+	}{
+		{name: "show", args: []string{"bridge", "show", "example-project#abc4"}, method: http.MethodGet, path: "/api/v1/projects/42/issues/abc4/bridge"},
+		{name: "reconcile", args: []string{"bridge", "reconcile", "example-project#abc4"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/reconcile", body: map[string]any{"actor": "operator"}},
+		{name: "pause without reason", args: []string{"bridge", "pause", "example-project#abc4"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/pause", body: map[string]any{"actor": "operator"}},
+		{name: "pause", args: []string{"bridge", "pause", "example-project#abc4", "--reason", "operator pause"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/pause", body: map[string]any{"actor": "operator", "reason": "operator pause"}},
+		{name: "resume", args: []string{"bridge", "resume", "example-project#abc4"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/resume", body: map[string]any{"actor": "operator"}},
+		{name: "resolve-field", args: []string{"bridge", "resolve-field", "example-project#abc4", "scheduled_on", "--use", "external"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/resolve-field", body: map[string]any{"actor": "operator", "kata_field": "scheduled_on", "use": "external"}},
+		{name: "resolve-comment adopt", args: []string{"bridge", "resolve-comment", "example-project#abc4", "--adopt", "opaque ID/with spaces:%25"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/resolve-comment", body: map[string]any{"action": "adopt", "actor": "operator", "external_comment_id": "opaque ID/with spaces:%25"}},
+		{name: "resolve-comment", args: []string{"bridge", "resolve-comment", "example-project#abc4", "--retry"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/resolve-comment", body: map[string]any{"action": "retry", "actor": "operator"}},
+		{name: "resolve-comment skip", args: []string{"bridge", "resolve-comment", "example-project#abc4", "--skip"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/resolve-comment", body: map[string]any{"action": "skip", "actor": "operator"}},
+		{name: "unbind", args: []string{"bridge", "unbind", "example-project#abc4"}, method: http.MethodDelete, path: "/api/v1/projects/42/issues/abc4/bridge", query: "actor=operator"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f.resetRequests()
+			args := append([]string{"--as", "operator"}, test.args...)
+			_, err := runExternalCLI(context.Background(), t, f, args...)
+			require.NoError(t, err)
+			requests := f.snapshotRequests()
+			require.Len(t, requests, 2)
+			assert.Equal(t, map[string]any{"name": "example-project"}, requests[0].Body)
+			assert.Equal(t, test.method, requests[1].Method)
+			assert.Equal(t, test.path, requests[1].Path)
+			assert.Equal(t, test.query, requests[1].Query)
+			assert.Equal(t, test.body, requests[1].Body)
+		})
+	}
+}
+
+func TestBridgeUnbindResolvesArchivedQualifiedProject(t *testing.T) {
+	var requests []externalCLIRequest
+	f := &externalCLIFixture{t: t}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, externalCLIRequest{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery})
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /api/v1/projects/resolve":
+			w.WriteHeader(http.StatusNotFound)
+			writeExternalCLITestJSON(t, w, map[string]any{"error": map[string]any{
+				"code": "project_not_initialized", "message": "project is not active",
+			}})
+		case "GET /api/v1/projects":
+			require.Equal(t, "archived", r.URL.Query().Get("include"))
+			writeExternalCLITestJSON(t, w, map[string]any{"projects": []any{map[string]any{
+				"id": 42, "uid": "01HAAAAAAAAAAAAAAAAAAAAAAA", "name": "archived-project",
+				"deleted_at": "2026-08-22T12:00:00.000Z",
+			}}})
+		case "DELETE /api/v1/projects/42/issues/abc4/bridge":
+			writeExternalCLITestJSON(t, w, bridgeFixtureForRequest(r, nil))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(f.server.Close)
+
+	_, err := runExternalCLI(context.Background(), t, f,
+		"--as", "operator", "bridge", "unbind", "archived-project#abc4")
+	require.NoError(t, err)
+	require.Equal(t, []externalCLIRequest{
+		{Method: http.MethodPost, Path: "/api/v1/projects/resolve"},
+		{Method: http.MethodGet, Path: "/api/v1/projects", Query: "include=archived"},
+		{Method: http.MethodDelete, Path: "/api/v1/projects/42/issues/abc4/bridge", Query: "actor=operator"},
+	}, requests)
+}
+
+func TestBridgeErrorsKeepStableSafeEnvelopes(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		method  string
+		path    string
+		status  int
+		code    string
+		message string
+		kind    errKind
+		exit    int
+	}{
+		{name: "missing binding", args: []string{"bridge", "show", "example-project#abc4"}, method: http.MethodGet, path: "/api/v1/projects/42/issues/abc4/bridge", status: http.StatusNotFound, code: "bridge_not_found", message: "external root bridge not found", kind: kindNotFound, exit: ExitNotFound},
+		{name: "validation", args: []string{"bridge", "resolve-field", "example-project#abc4", "scheduled_on", "--use", "kata"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/resolve-field", status: http.StatusBadRequest, code: "validation", message: "external root request is invalid", kind: kindValidation, exit: ExitValidation},
+		{name: "field changed", args: []string{"bridge", "resolve-field", "example-project#abc4", "scheduled_on", "--use", "kata"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/resolve-field", status: http.StatusConflict, code: "external_field_conflict", message: "external field conflict changed", kind: kindConflict, exit: ExitConflict},
+		{name: "pending comment", args: []string{"bridge", "resolve-comment", "example-project#abc4", "--skip"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/resolve-comment", status: http.StatusConflict, code: "external_comment_pending", message: "external comment requires explicit resolution", kind: kindConflict, exit: ExitConflict},
+		{name: "capability conflict", args: []string{"bridge", "reconcile", "example-project#abc4"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/reconcile", status: http.StatusConflict, code: "external_root_conflict", message: "external root operation conflicts with connector capabilities", kind: kindConflict, exit: ExitConflict},
+		{name: "claim loss", args: []string{"bridge", "resume", "example-project#abc4"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/resume", status: http.StatusConflict, code: "external_root_claim_lost", message: "external root bridge is busy or unavailable", kind: kindConflict, exit: ExitConflict},
+		{name: "connector failure", args: []string{"bridge", "reconcile", "example-project#abc4"}, method: http.MethodPost, path: "/api/v1/projects/42/issues/abc4/bridge/actions/reconcile", status: http.StatusBadGateway, code: "connector_error", message: "external connector request failed", kind: kindInternal, exit: ExitInternal},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := newExternalCLIFixture(t)
+			f.fail(test.method, test.path, test.status, map[string]any{
+				"error": map[string]any{"code": test.code, "message": test.message, "detail": "diagnostic-sentinel"},
+			})
+			_, err := runExternalCLI(context.Background(), t, f, append([]string{"--as", "operator"}, test.args...)...)
+			require.Error(t, err)
+			var cli *cliError
+			require.ErrorAs(t, err, &cli)
+			assert.Equal(t, test.code, cli.Code)
+			assert.Equal(t, test.message, cli.Message)
+			assert.Equal(t, test.kind, cli.Kind)
+			assert.Equal(t, test.exit, cli.ExitCode)
+			assert.NotContains(t, cli.Error(), "diagnostic-sentinel")
+		})
+	}
+}

--- a/cmd/kata/connector.go
+++ b/cmd/kata/connector.go
@@ -1,0 +1,358 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kata/internal/textsafe"
+	kataclient "go.kenn.io/kata/pkg/client"
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+func newConnectorCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "connector",
+		Short: "inspect and configure external connectors",
+	}
+	cmd.AddCommand(
+		newConnectorListCmd(),
+		newConnectorStatusCmd(),
+		newConnectorFieldCmd(),
+	)
+	return cmd
+}
+
+func newConnectorFieldCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "field",
+		Short: "inspect and configure bidirectional field mappings",
+	}
+	cmd.AddCommand(
+		newConnectorFieldListCmd(),
+		newConnectorFieldMapCmd(),
+		newConnectorFieldUnmapCmd(),
+	)
+	return cmd
+}
+
+func newConnectorListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "list configured connector instances",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			apiClient, err := connectorAPIClient(ctx, true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := apiClient.ListConnectorsWithResponse(ctx)
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			if resp.JSON200 == nil {
+				return fmt.Errorf("connector list: empty response")
+			}
+			return printConnectorList(cmd, resp.Body, resp.JSON200.Connectors)
+		},
+	}
+}
+
+func newConnectorStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status <instance>",
+		Short: "show safe connector status",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			apiClient, err := connectorAPIClient(ctx, true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := apiClient.GetConnectorStatusWithResponse(ctx, &generated.GetConnectorStatusRequestOptions{
+				PathParams: &generated.GetConnectorStatusPath{Instance: args[0]},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			if resp.JSON200 == nil {
+				return fmt.Errorf("connector status: empty response")
+			}
+			return printConnector(cmd, resp.Body, *resp.JSON200, false)
+		},
+	}
+}
+
+func newConnectorFieldListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list <instance>",
+		Short: "list public connector field descriptors",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			apiClient, err := connectorAPIClient(ctx, true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := apiClient.ListConnectorFieldsWithResponse(ctx, &generated.ListConnectorFieldsRequestOptions{
+				PathParams: &generated.ListConnectorFieldsPath{Instance: args[0]},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			if resp.JSON200 == nil {
+				return fmt.Errorf("connector fields: empty response")
+			}
+			return printConnectorFields(cmd, resp.Body, args[0], resp.JSON200.Fields)
+		},
+	}
+}
+
+func newConnectorFieldMapCmd() *cobra.Command {
+	var external string
+	cmd := &cobra.Command{
+		Use:   "map <instance> <kata-field>",
+		Short: "map a connector field bidirectionally",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("external") || strings.TrimSpace(external) == "" {
+				return externalCLIValidation("--external is required")
+			}
+			ctx := cmd.Context()
+			apiClient, err := connectorAPIClient(ctx, true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := apiClient.MapConnectorFieldWithResponse(ctx, &generated.MapConnectorFieldRequestOptions{
+				PathParams: &generated.MapConnectorFieldPath{Instance: args[0], KataField: args[1]},
+				Body:       &generated.MapConnectorFieldBody{ExternalField: external},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			if resp.JSON200 == nil {
+				return fmt.Errorf("map connector field: empty response")
+			}
+			return printConnectorMapping(cmd, resp.Body, args[0], *resp.JSON200)
+		},
+	}
+	cmd.Flags().StringVar(&external, "external", "", "external field selector")
+	return cmd
+}
+
+func newConnectorFieldUnmapCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unmap <instance> <kata-field>",
+		Short: "disable a connector field mapping",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			apiClient, err := connectorAPIClient(ctx, true)
+			if err != nil {
+				return err
+			}
+			resp, callErr := apiClient.UnmapConnectorFieldWithResponse(ctx, &generated.UnmapConnectorFieldRequestOptions{
+				PathParams: &generated.UnmapConnectorFieldPath{Instance: args[0], KataField: args[1]},
+			})
+			if err := externalCLITransportError(resp, callErr); err != nil {
+				return err
+			}
+			if err := externalCLIResponseError(resp.StatusCode, resp.Body, callErr); err != nil {
+				return err
+			}
+			if resp.JSON200 == nil {
+				return fmt.Errorf("unmap connector field: empty response")
+			}
+			return printConnectorMapping(cmd, resp.Body, args[0], *resp.JSON200)
+		},
+	}
+}
+
+func connectorAPIClient(ctx context.Context, longRunning bool) (*kataclient.Client, error) {
+	baseURL, err := ensureDaemon(ctx)
+	if err != nil {
+		return nil, err
+	}
+	httpClientForRequest := httpClientFor
+	if longRunning {
+		httpClientForRequest = longRunningClientFor
+	}
+	httpClient, err := httpClientForRequest(ctx, baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return kataclient.NewWithHTTPClient(baseURL, httpClient)
+}
+
+func externalCLITransportError[T any](resp *T, callErr error) error {
+	if resp != nil {
+		return nil
+	}
+	if callErr != nil {
+		return callErr
+	}
+	return &cliError{
+		Message: "external root request returned no response", Kind: kindInternal, ExitCode: ExitInternal,
+	}
+}
+
+func externalCLIResponseError(status int, body []byte, callErr error) error {
+	if status >= http.StatusBadRequest {
+		var envelope struct {
+			Error struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error.Code != "" && envelope.Error.Message != "" {
+			return apiErrFromBody(status, body)
+		}
+		message := fmt.Sprintf("external root request failed (HTTP %d)", status)
+		if statusText := http.StatusText(status); statusText != "" {
+			message = fmt.Sprintf("external root request failed (HTTP %d %s)", status, statusText)
+		}
+		return &cliError{
+			Message: message, Kind: kindForStatus(status), ExitCode: mapStatusToExit(status, ""),
+		}
+	}
+	return callErr
+}
+
+func externalCLIValidation(message string) error {
+	return &cliError{Message: message, Kind: kindValidation, ExitCode: ExitValidation}
+}
+
+func printConnectorList(cmd *cobra.Command, raw []byte, connectors []generated.ConnectorOut) error {
+	if currentOutputMode() == outputJSON {
+		return emitJSON(cmd.OutOrStdout(), json.RawMessage(raw))
+	}
+	if flags.Quiet {
+		return nil
+	}
+	items := append([]generated.ConnectorOut(nil), connectors...)
+	sort.Slice(items, func(i, j int) bool { return items[i].InstanceID < items[j].InstanceID })
+	for _, item := range items {
+		if err := printConnector(cmd, nil, item, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printConnector(cmd *cobra.Command, raw []byte, connector generated.ConnectorOut, compact bool) error {
+	if currentOutputMode() == outputJSON {
+		return emitJSON(cmd.OutOrStdout(), json.RawMessage(raw))
+	}
+	if flags.Quiet {
+		return nil
+	}
+	capabilities := append([]string(nil), connector.Capabilities...)
+	sort.Strings(capabilities)
+	state := "unhealthy"
+	if connector.Healthy {
+		state = "healthy"
+	}
+	w := cmd.OutOrStdout()
+	if currentOutputMode() == outputAgent {
+		_, err := fmt.Fprintf(w, "instance=%s state=%s connector_id=%s display_name=%s protocol=%s capabilities=%s health_error=%s\n",
+			agentValue(connector.InstanceID), state, agentValue(optionalExternalString(connector.ConnectorID)),
+			agentValue(optionalExternalString(connector.DisplayName)), agentValue(optionalExternalString(connector.Protocol)),
+			agentValue(optionalExternalList(capabilities)), agentValue(optionalExternalString(connector.HealthError)))
+		return err
+	}
+	if compact {
+		_, err := fmt.Fprintf(w, "%s  %s  connector=%s  capabilities=%s\n",
+			textsafe.Line(connector.InstanceID), state, textsafe.Line(optionalExternalString(connector.ConnectorID)),
+			textsafe.Line(optionalExternalList(capabilities)))
+		return err
+	}
+	_, err := fmt.Fprintf(w, "Connector: %s\nInstance: %s\nState: %s\nConnector ID: %s\nProtocol: %s\nCapabilities: %s\nHealth error: %s\n",
+		textsafe.Line(optionalExternalString(connector.DisplayName)), textsafe.Line(connector.InstanceID), state,
+		textsafe.Line(optionalExternalString(connector.ConnectorID)), textsafe.Line(optionalExternalString(connector.Protocol)),
+		textsafe.Line(optionalExternalList(capabilities)), textsafe.Line(optionalExternalString(connector.HealthError)))
+	return err
+}
+
+func printConnectorFields(cmd *cobra.Command, raw []byte, instance string, fields []generated.FieldDescriptor) error {
+	if currentOutputMode() == outputJSON {
+		return emitJSON(cmd.OutOrStdout(), json.RawMessage(raw))
+	}
+	if flags.Quiet {
+		return nil
+	}
+	items := append([]generated.FieldDescriptor(nil), fields...)
+	sort.Slice(items, func(i, j int) bool { return items[i].ID < items[j].ID })
+	for _, field := range items {
+		kinds := append([]string(nil), field.AcceptedKinds...)
+		sort.Strings(kinds)
+		kindList := optionalExternalList(kinds)
+		if currentOutputMode() == outputAgent {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "instance=%s field=%s name=%s kinds=%s nullable=%t writable=%t schema=%s\n",
+				agentValue(instance), agentValue(field.ID), agentValue(field.DisplayName), agentValue(kindList),
+				field.Nullable, field.Writable, agentValue(field.SchemaRevision)); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s  %s  kinds=%s nullable=%t writable=%t schema=%s\n",
+			textsafe.Line(field.ID), textsafe.Line(field.DisplayName), textsafe.Line(kindList),
+			field.Nullable, field.Writable, textsafe.Line(field.SchemaRevision)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printConnectorMapping(cmd *cobra.Command, raw []byte, instance string, mapping generated.ExternalFieldMappingOut) error {
+	if currentOutputMode() == outputJSON {
+		return emitJSON(cmd.OutOrStdout(), json.RawMessage(raw))
+	}
+	if flags.Quiet {
+		return nil
+	}
+	state := "inactive"
+	if mapping.Active {
+		state = "active"
+	}
+	if currentOutputMode() == outputAgent {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "instance=%s field=%s external_field=%s external_name=%s active=%t\n",
+			agentValue(instance), agentValue(mapping.KataField), agentValue(mapping.ExternalFieldID),
+			agentValue(mapping.ExternalFieldName), mapping.Active)
+		return err
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s mapped to %s (%s): %s\n",
+		textsafe.Line(mapping.KataField), textsafe.Line(mapping.ExternalFieldName),
+		textsafe.Line(mapping.ExternalFieldID), state)
+	return err
+}
+
+func optionalExternalString(value *string) string {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return "-"
+	}
+	return *value
+}
+
+func optionalExternalList(values []string) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	return strings.Join(values, ",")
+}

--- a/cmd/kata/connector_test.go
+++ b/cmd/kata/connector_test.go
@@ -1,0 +1,437 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+type externalCLIRequest struct {
+	Method string
+	Path   string
+	Query  string
+	Body   map[string]any
+}
+
+type externalCLIFixture struct {
+	t              *testing.T
+	server         *httptest.Server
+	mu             sync.Mutex
+	requests       []externalCLIRequest
+	delay          bool
+	connectorDelay bool
+	failures       map[string]externalCLIFailure
+}
+
+type externalCLIFailure struct {
+	status int
+	body   map[string]any
+	raw    []byte
+}
+
+func newExternalCLIFixture(t *testing.T) *externalCLIFixture {
+	t.Helper()
+	f := &externalCLIFixture{t: t}
+	f.server = httptest.NewServer(http.HandlerFunc(f.serveHTTP))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *externalCLIFixture) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	delayBridge := f.delay && (strings.Contains(r.URL.Path, "/bridge/actions/") || r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/bridge"))
+	delayConnector := f.connectorDelay && (r.URL.Path == "/api/v1/connectors" ||
+		r.URL.Path == "/api/v1/connectors/example-connector" ||
+		r.URL.Path == "/api/v1/connectors/example-connector/fields" ||
+		r.Method == http.MethodPut && r.URL.Path == "/api/v1/connectors/example-connector/fields/scheduled_on")
+	if delayBridge || delayConnector {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-timeAfterForExternalCLITest():
+		}
+	}
+	var body map[string]any
+	if r.Body != nil {
+		data, err := io.ReadAll(r.Body)
+		require.NoError(f.t, err)
+		if len(data) > 0 {
+			require.NoError(f.t, json.Unmarshal(data, &body))
+		}
+	}
+	f.mu.Lock()
+	f.requests = append(f.requests, externalCLIRequest{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Body: body})
+	f.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	if failure, ok := f.failures[r.Method+" "+r.URL.Path]; ok {
+		w.WriteHeader(failure.status)
+		if len(failure.raw) > 0 {
+			_, _ = w.Write(failure.raw)
+			return
+		}
+		writeExternalCLITestJSON(f.t, w, failure.body)
+		return
+	}
+	switch {
+	case r.URL.Path == "/api/v1/ping":
+		writeExternalCLITestJSON(f.t, w, map[string]any{"ok": true, "service": "kata", "version": "test"})
+	case r.URL.Path == "/api/v1/projects/resolve":
+		writeExternalCLITestJSON(f.t, w, map[string]any{"project": map[string]any{"id": 42, "name": "example-project"}})
+	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/connectors":
+		writeExternalCLITestJSON(f.t, w, connectorListFixture())
+	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/connectors/example-connector":
+		writeExternalCLITestJSON(f.t, w, connectorFixture())
+	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/connectors/example-connector/fields":
+		writeExternalCLITestJSON(f.t, w, connectorFieldsFixture())
+	case r.Method == http.MethodPut && r.URL.Path == "/api/v1/connectors/example-connector/fields/scheduled_on":
+		writeExternalCLITestJSON(f.t, w, connectorMappingFixture(true))
+	case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/connectors/example-connector/fields/scheduled_on":
+		writeExternalCLITestJSON(f.t, w, connectorMappingFixture(false))
+	case strings.HasPrefix(r.URL.Path, "/api/v1/projects/42/issues/abc4/bridge"):
+		writeExternalCLITestJSON(f.t, w, bridgeFixtureForRequest(r, body))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		writeExternalCLITestJSON(f.t, w, map[string]any{"error": map[string]any{"code": "not_found", "message": "safe resource not found"}})
+	}
+}
+
+func (f *externalCLIFixture) snapshotRequests() []externalCLIRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]externalCLIRequest(nil), f.requests...)
+}
+
+func (f *externalCLIFixture) resetRequests() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requests = nil
+}
+
+func (f *externalCLIFixture) fail(method, path string, status int, body map[string]any) {
+	f.t.Helper()
+	if f.failures == nil {
+		f.failures = make(map[string]externalCLIFailure)
+	}
+	f.failures[method+" "+path] = externalCLIFailure{status: status, body: body}
+}
+
+func (f *externalCLIFixture) failRaw(method, path string, status int, body string) {
+	f.t.Helper()
+	if f.failures == nil {
+		f.failures = make(map[string]externalCLIFailure)
+	}
+	f.failures[method+" "+path] = externalCLIFailure{status: status, raw: []byte(body)}
+}
+
+func runExternalCLI(ctx context.Context, t *testing.T, f *externalCLIFixture, args ...string) (string, error) {
+	t.Helper()
+	resetFlags(t)
+	cmd := newRootCmd()
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs(args)
+	cmd.SetContext(contextWithBaseURL(ctx, f.server.URL))
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func runExternalCLIWithErrorOutput(ctx context.Context, t *testing.T, f *externalCLIFixture, args ...string) (string, string, error) {
+	t.Helper()
+	resetFlags(t)
+	cmd := newRootCmd()
+	var stdout, stderr strings.Builder
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+	cmd.SetContext(contextWithBaseURL(ctx, f.server.URL))
+	err := cmd.Execute()
+	if err != nil {
+		emitRootError(&stderr, cmd, args, err, runEEntered)
+	}
+	return stdout.String(), stderr.String(), err
+}
+
+func writeExternalCLITestJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	require.NoError(t, json.NewEncoder(w).Encode(value))
+}
+
+func connectorFixture() map[string]any {
+	return map[string]any{
+		"instance_id": "example-connector", "connector_id": "generic.connector", "display_name": "Generic connector",
+		"protocol": "kata.connector/v1", "account_identity": "example-account",
+		"capabilities": []string{"publish_comment", "fields"}, "healthy": true,
+	}
+}
+
+func connectorListFixture() map[string]any {
+	return map[string]any{"connectors": []any{connectorFixture()}}
+}
+
+func connectorFieldsFixture() map[string]any {
+	return map[string]any{"fields": []any{map[string]any{
+		"id": "start-date", "display_name": "Start date", "accepted_kinds": []string{"date", "local_datetime"},
+		"nullable": true, "writable": true, "schema_revision": "schema-v1",
+	}}}
+}
+
+func connectorMappingFixture(active bool) map[string]any {
+	return map[string]any{
+		"kata_field": "scheduled_on", "external_field_id": "start-date", "external_field_name": "Start date",
+		"accepted_kinds": []string{"date", "local_datetime"}, "nullable": true, "writable": true,
+		"schema_revision": "schema-v1", "active": active,
+	}
+}
+
+func TestConnectorRootHelpRegistersEveryCommand(t *testing.T) {
+	root := newRootCmd()
+	rootHelp := string(executeRoot(t, newRootCmd(), "--help"))
+	assert.Contains(t, rootHelp, "connector")
+	assert.Contains(t, rootHelp, "bridge")
+
+	connector, _, err := root.Find([]string{"connector"})
+	require.NoError(t, err)
+	assert.Equal(t, "connector", connector.Name())
+	for _, path := range [][]string{{"connector", "list"}, {"connector", "status"}, {"connector", "field"}, {"connector", "field", "list"}, {"connector", "field", "map"}, {"connector", "field", "unmap"}} {
+		child, _, findErr := root.Find(path)
+		name := path[len(path)-1]
+		require.NoErrorf(t, findErr, "connector %s", name)
+		assert.Equal(t, name, child.Name())
+	}
+	help := string(executeRoot(t, newRootCmd(), "connector", "--help"))
+	for _, name := range []string{"list", "status", "field"} {
+		assert.Contains(t, help, name)
+	}
+	fieldHelp := string(executeRoot(t, newRootCmd(), "connector", "field", "--help"))
+	for _, name := range []string{"list", "map", "unmap"} {
+		assert.Contains(t, fieldHelp, name)
+	}
+	for _, obsolete := range []string{"fields", "map-field", "unmap-field"} {
+		found, remaining, findErr := root.Find([]string{"connector", obsolete})
+		require.NoError(t, findErr)
+		assert.NotEqual(t, obsolete, found.Name())
+		assert.Contains(t, remaining, obsolete)
+	}
+}
+
+func TestConnectorMapFieldUsesExactBidirectionalPayload(t *testing.T) {
+	root := newRootCmd()
+	cmd, _, err := root.Find([]string{"connector", "field", "map"})
+	require.NoError(t, err)
+	assert.Nil(t, cmd.Flags().Lookup("direction"))
+
+	f := newExternalCLIFixture(t)
+	out, err := runExternalCLI(context.Background(), t, f, "--agent", "connector", "field", "map", "example-connector", "scheduled_on", "--external", "start-date")
+	require.NoError(t, err)
+	assert.Contains(t, out, "instance=example-connector")
+	assert.Contains(t, out, "field=scheduled_on")
+	requests := f.snapshotRequests()
+	require.Len(t, requests, 1)
+	assert.Equal(t, http.MethodPut, requests[0].Method)
+	assert.Equal(t, "/api/v1/connectors/example-connector/fields/scheduled_on", requests[0].Path)
+	assert.Equal(t, map[string]any{"external_field": "start-date"}, requests[0].Body)
+
+	f.resetRequests()
+	_, err = runExternalCLI(context.Background(), t, f, "connector", "field", "unmap", "example-connector", "scheduled_on")
+	require.NoError(t, err)
+	requests = f.snapshotRequests()
+	require.Len(t, requests, 1)
+	assert.Equal(t, http.MethodDelete, requests[0].Method)
+	assert.Equal(t, "/api/v1/connectors/example-connector/fields/scheduled_on", requests[0].Path)
+	assert.Empty(t, requests[0].Query)
+	assert.Nil(t, requests[0].Body)
+}
+
+func TestConnectorProcessCallsUseLongRunningClient(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	f.connectorDelay = true
+	t.Setenv("KATA_HTTP_TIMEOUT", "500ms")
+	for _, args := range [][]string{
+		{"connector", "list"},
+		{"connector", "status", "example-connector"},
+		{"connector", "field", "list", "example-connector"},
+		{"connector", "field", "map", "example-connector", "scheduled_on", "--external", "start-date"},
+		{"connector", "field", "unmap", "example-connector", "scheduled_on"},
+	} {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_, err := runExternalCLI(ctx, t, f, args...)
+		cancel()
+		require.NoErrorf(t, err, "%v", args)
+	}
+}
+
+func TestConnectorEveryCommandRendersHumanJSONAndAgent(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	tests := []struct {
+		name      string
+		args      []string
+		humanWant []string
+		agentWant []string
+		jsonWant  []string
+	}{
+		{name: "list", args: []string{"connector", "list"}, humanWant: []string{"example-connector", "healthy", "generic.connector"}, agentWant: []string{"instance=example-connector", "state=healthy", "connector_id=generic.connector"}, jsonWant: []string{`"connectors"`, `"instance_id":"example-connector"`, `"account_identity":"example-account"`}},
+		{name: "status", args: []string{"connector", "status", "example-connector"}, humanWant: []string{"Generic connector", "healthy", "publish_comment"}, agentWant: []string{"instance=example-connector", "state=healthy", "connector_id=generic.connector"}, jsonWant: []string{`"instance_id":"example-connector"`, `"healthy":true`, `"account_identity":"example-account"`}},
+		{name: "field-list", args: []string{"connector", "field", "list", "example-connector"}, humanWant: []string{"Start date", "date", "local_datetime"}, agentWant: []string{"instance=example-connector", "field=start-date", "writable=true"}, jsonWant: []string{`"fields"`, `"id":"start-date"`}},
+		{name: "field-map", args: []string{"connector", "field", "map", "example-connector", "scheduled_on", "--external", "start-date"}, humanWant: []string{"scheduled_on", "Start date", "active"}, agentWant: []string{"instance=example-connector", "field=scheduled_on", "active=true"}, jsonWant: []string{`"kata_field":"scheduled_on"`, `"active":true`}},
+		{name: "field-unmap", args: []string{"connector", "field", "unmap", "example-connector", "scheduled_on"}, humanWant: []string{"scheduled_on", "inactive"}, agentWant: []string{"instance=example-connector", "field=scheduled_on", "active=false"}, jsonWant: []string{`"kata_field":"scheduled_on"`, `"active":false`}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, mode := range []struct {
+				flag string
+				want []string
+			}{{want: test.humanWant}, {flag: "--json", want: test.jsonWant}, {flag: "--agent", want: test.agentWant}} {
+				args := append([]string(nil), test.args...)
+				if mode.flag != "" {
+					args = append([]string{mode.flag}, args...)
+				}
+				out, err := runExternalCLI(context.Background(), t, f, args...)
+				require.NoError(t, err)
+				for _, want := range mode.want {
+					assert.Contains(t, out, want)
+				}
+				if mode.flag == "--json" {
+					assert.Contains(t, out, `"kata_api_version":1`)
+				}
+			}
+		})
+	}
+}
+
+func TestConnectorHumanOutputContainsOnlyPublicStatus(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	for _, mode := range []string{"", "--agent"} {
+		for _, command := range [][]string{{"connector", "list"}, {"connector", "status", "example-connector"}} {
+			args := append([]string(nil), command...)
+			if mode != "" {
+				args = append([]string{mode}, args...)
+			}
+			out, err := runExternalCLI(context.Background(), t, f, args...)
+			require.NoError(t, err)
+			for _, forbidden := range []string{"settings", "command", "arguments", "environment", "account_identity", "example-account"} {
+				assert.NotContains(t, out, forbidden)
+			}
+		}
+	}
+}
+
+func TestConnectorMissingInstanceKeepsSafeDaemonError(t *testing.T) {
+	f := newExternalCLIFixture(t)
+	f.fail(http.MethodGet, "/api/v1/connectors/example-connector", http.StatusNotFound, map[string]any{
+		"error": map[string]any{"code": "connector_not_found", "message": "connector instance was not found", "detail": "diagnostic-sentinel"},
+	})
+	_, err := runExternalCLI(context.Background(), t, f, "connector", "status", "example-connector")
+	require.Error(t, err)
+	var cli *cliError
+	require.ErrorAs(t, err, &cli)
+	assert.Equal(t, kindNotFound, cli.Kind)
+	assert.Equal(t, ExitNotFound, cli.ExitCode)
+	assert.Equal(t, "connector_not_found", cli.Code)
+	assert.Equal(t, "connector instance was not found", cli.Message)
+	assert.NotContains(t, cli.Error(), "diagnostic-sentinel")
+}
+
+func TestExternalCommandsRedactMalformedErrorBodiesInEveryOutputMode(t *testing.T) {
+	const rawDiagnostic = "upstream private diagnostic: credential=diagnostic-sentinel root_binding=opaque-private-value"
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		status  int
+		body    string
+		args    []string
+		message string
+		kind    errKind
+		exit    int
+	}{
+		{
+			name: "connector", method: http.MethodGet, path: "/api/v1/connectors/example-connector", status: http.StatusBadGateway,
+			body: `{"error":{"message":"` + rawDiagnostic,
+			args: []string{"connector", "status", "example-connector"}, message: "external root request failed (HTTP 502 Bad Gateway)",
+			kind: kindInternal, exit: ExitInternal,
+		},
+		{
+			name: "bridge", method: http.MethodGet, path: "/api/v1/projects/42/issues/abc4/bridge", status: http.StatusNotFound,
+			body: rawDiagnostic,
+			args: []string{"bridge", "show", "example-project#abc4"}, message: "external root request failed (HTTP 404 Not Found)",
+			kind: kindNotFound, exit: ExitNotFound,
+		},
+	}
+	for _, test := range tests {
+		for _, mode := range []string{"", "--json", "--agent"} {
+			t.Run(test.name+"/"+mode, func(t *testing.T) {
+				f := newExternalCLIFixture(t)
+				f.failRaw(test.method, test.path, test.status, test.body)
+				args := append([]string(nil), test.args...)
+				if mode != "" {
+					args = append([]string{mode}, args...)
+				}
+				stdout, stderr, err := runExternalCLIWithErrorOutput(context.Background(), t, f, args...)
+				assert.Empty(t, stdout)
+				cli := requireCLIError(t, err, test.exit)
+				assert.Equal(t, test.kind, cli.Kind)
+				assert.Empty(t, cli.Code)
+				assert.Equal(t, test.message, cli.Message)
+				assert.Contains(t, stderr, test.message)
+				for _, forbidden := range []string{rawDiagnostic, "credential=", "root_binding=", "diagnostic-sentinel", "opaque-private-value"} {
+					assert.NotContains(t, stderr, forbidden)
+					assert.NotContains(t, cli.Error(), forbidden)
+				}
+				if mode == "--json" {
+					envelope := parseErrorEnvelope(t, []byte(stderr))
+					assert.Equal(t, string(test.kind), envelope.Error.Kind)
+					assert.Equal(t, test.message, envelope.Error.Message)
+					assert.Equal(t, test.exit, envelope.Error.ExitCode)
+				}
+			})
+		}
+	}
+}
+
+func TestExternalCLIResponseErrorPreservesTransportError(t *testing.T) {
+	transportErr := errors.New("transport-sentinel")
+	assert.Same(t, transportErr, externalCLIResponseError(0, nil, transportErr))
+}
+
+func TestExternalCLITransportGuardAndConcreteEnvelopeHandling(t *testing.T) {
+	transportErr := errors.New("transport-sentinel")
+	assert.Same(t, transportErr, externalCLITransportError((*generated.GetConnectorStatusResp)(nil), transportErr))
+
+	err := externalCLITransportError((*generated.GetExternalRootBridgeResp)(nil), nil)
+	cli := requireCLIError(t, err, ExitInternal)
+	assert.Equal(t, kindInternal, cli.Kind)
+	assert.Equal(t, "external root request returned no response", cli.Message)
+
+	generatedStatusErr := errors.New("generated status error")
+	connectorResp := &generated.GetConnectorStatusResp{
+		StatusCode: http.StatusNotFound,
+		Body:       []byte(`{"error":{"code":"connector_not_found","message":"connector instance was not found"}}`),
+	}
+	require.NoError(t, externalCLITransportError(connectorResp, generatedStatusErr))
+	connectorErr := externalCLIResponseError(connectorResp.StatusCode, connectorResp.Body, generatedStatusErr)
+	connectorCLI := requireCLIError(t, connectorErr, ExitNotFound)
+	assert.Equal(t, kindNotFound, connectorCLI.Kind)
+	assert.Equal(t, "connector_not_found", connectorCLI.Code)
+	assert.Equal(t, "connector instance was not found", connectorCLI.Message)
+
+	bridgeResp := &generated.GetExternalRootBridgeResp{
+		StatusCode: http.StatusConflict,
+		Body:       []byte(`{"error":{"code":"external_root_claim_lost","message":"external root bridge is busy or unavailable"}}`),
+	}
+	require.NoError(t, externalCLITransportError(bridgeResp, generatedStatusErr))
+	bridgeErr := externalCLIResponseError(bridgeResp.StatusCode, bridgeResp.Body, generatedStatusErr)
+	bridgeCLI := requireCLIError(t, bridgeErr, ExitConflict)
+	assert.Equal(t, kindConflict, bridgeCLI.Kind)
+	assert.Equal(t, "external_root_claim_lost", bridgeCLI.Code)
+	assert.Equal(t, "external root bridge is busy or unavailable", bridgeCLI.Message)
+}

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -32,6 +32,7 @@ import (
 	"go.kenn.io/kata/internal/federation"
 	"go.kenn.io/kata/internal/githubsync"
 	"go.kenn.io/kata/internal/hooks"
+	"go.kenn.io/kata/internal/rootbridge"
 	"go.kenn.io/kata/internal/telemetry"
 	"go.kenn.io/kata/internal/vector"
 	"go.kenn.io/kata/internal/version"
@@ -57,6 +58,10 @@ const (
 
 var newTelemetryReporter = func(opts telemetry.Options) telemetry.Client {
 	return telemetry.NewReporterOrDisabled(opts)
+}
+
+var runExternalRootRunner = func(ctx context.Context, runner *rootbridge.Runner) error {
+	return runner.Run(ctx)
 }
 
 type githubSyncDaemonRunner interface {
@@ -1085,6 +1090,47 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	gitHubSyncWake := startGitHubSyncRunner(
 		ctx, workers, waitableDrainAdmission, store, gitHubSyncFetcher, publisher, daemonLog,
 	)
+	externalRootRegistry, err := rootbridge.NewRegistry(ctx, dcfg.Connectors, nil)
+	if err != nil {
+		return err
+	}
+	externalRootReconciler := rootbridge.NewReconciler(store, externalRootRegistry, rootbridge.ReconcilerConfig{
+		RetryAt:         rootbridge.ExternalRootRetryAt(nil),
+		DefaultTimezone: dcfg.Timezone,
+	})
+	externalRootEventSinkFrom := func(event db.Event, fork activity.Admission) {
+		broadcaster.Broadcast(daemon.StreamMsg{Kind: "event", Event: &event, ProjectID: event.ProjectID})
+		hooks.EnqueueFrom(disp, event, fork)
+	}
+	externalRootEventSink := func(event db.Event) { externalRootEventSinkFrom(event, nil) }
+	externalRootService := rootbridge.NewServiceWithEventSinkAndDefaultTimezone(
+		store,
+		externalRootRegistry,
+		func(ctx context.Context, bindingID int64, claimToken string) ([]db.Event, error) {
+			result, err := externalRootReconciler.Run(ctx, bindingID, rootbridge.RunOptions{
+				ClaimToken: claimToken,
+				EventSink:  externalRootEventSink,
+			})
+			return result.Events, err
+		},
+		externalRootEventSink,
+		dcfg.Timezone,
+	)
+	externalRootRunner := &rootbridge.Runner{
+		Store: store, Reconciler: externalRootReconciler,
+		EventSinkFrom:  externalRootEventSinkFrom,
+		DrainAdmission: waitableDrainAdmission,
+		ErrorSink: func(err error) {
+			daemonLog.Printf("external roots: %s", db.SafeExternalRootError(err.Error()))
+		},
+	}
+	externalRootWake := externalRootRunner.Wake
+	workers.Go(func() {
+		if err := runExternalRootRunner(ctx, externalRootRunner); err != nil && !errors.Is(err, context.Canceled) {
+			daemonLog.Printf("external roots: %s", db.SafeExternalRootError(err.Error()))
+		}
+	})
+	startExternalRootEventWake(ctx, workers, store, broadcaster, externalRootWake)
 	var idleHealth func() daemon.IdleSnapshot
 	var idleAdmission daemon.IdleForegroundAdmission
 	if idleController != nil {
@@ -1092,19 +1138,23 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		idleAdmission = idleController
 	}
 	srv := daemon.NewServer(daemon.ServerConfig{
-		DB:                store,
-		DefaultTimezone:   dcfg.Timezone,
-		StartedAt:         time.Now().UTC(),
-		Endpoint:          &endpoint,
-		Hooks:             disp,
-		Broadcaster:       broadcaster,
-		FederationWake:    federationWake,
-		FederationCatalog: append([]config.CatalogDaemonConfig(nil), dcfg.Daemons...),
-		WebDaemons:        append([]config.CatalogDaemonConfig(nil), dcfg.Daemons...),
-		ActiveWebDaemon:   dcfg.ActiveDaemon,
-		GitHubSyncFetcher: gitHubSyncFetcher,
-		GitHubSyncConfig:  dcfg.GitHubSync,
-		GitHubSyncWake:    gitHubSyncWake,
+		DB:                     store,
+		DefaultTimezone:        dcfg.Timezone,
+		StartedAt:              time.Now().UTC(),
+		Endpoint:               &endpoint,
+		Hooks:                  disp,
+		Broadcaster:            broadcaster,
+		FederationWake:         federationWake,
+		FederationCatalog:      append([]config.CatalogDaemonConfig(nil), dcfg.Daemons...),
+		WebDaemons:             append([]config.CatalogDaemonConfig(nil), dcfg.Daemons...),
+		ActiveWebDaemon:        dcfg.ActiveDaemon,
+		GitHubSyncFetcher:      gitHubSyncFetcher,
+		GitHubSyncConfig:       dcfg.GitHubSync,
+		GitHubSyncWake:         gitHubSyncWake,
+		ExternalRootRegistry:   externalRootRegistry,
+		ExternalRootService:    externalRootService,
+		ExternalRootReconciler: externalRootReconciler,
+		ExternalRootWake:       externalRootWake,
 		CloseThrottle: daemon.CloseThrottlePolicy{
 			SiblingBurstEnabled: dcfg.Close.Throttle.ThrottleEnabled(),
 			SiblingBurstWindow:  closeThrottleWindow,
@@ -1209,6 +1259,70 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		return nil
 	}
 	return serveErr
+}
+
+func startExternalRootEventWake(
+	ctx context.Context,
+	workers *daemonWorkerGroup,
+	store db.Storage,
+	bcast *daemon.EventBroadcaster,
+	wake func(int64),
+) {
+	if workers == nil || store == nil || bcast == nil || wake == nil {
+		return
+	}
+	wakeTypes := map[string]bool{
+		"issue.commented": true, "issue.comment_edited": true, "issue.updated": true,
+		"issue.metadata_updated": true, "issue.closed": true, "issue.reopened": true,
+	}
+	sub := bcast.Subscribe(daemon.SubFilter{})
+	workers.Go(func() {
+		defer sub.Unsub()
+		for ctx.Err() == nil {
+			closed := false
+			for !closed {
+				select {
+				case <-ctx.Done():
+					sub.Unsub()
+					return
+				case msg, ok := <-sub.Ch:
+					if !ok {
+						closed = true
+						continue
+					}
+					if msg.Kind == "reset" {
+						closed = true
+						continue
+					}
+					if msg.Kind != "event" || msg.Event == nil || msg.Event.IssueID == nil ||
+						!wakeTypes[msg.Event.Type] {
+						continue
+					}
+					binding, err := store.ExternalRootBindingByIssue(ctx, *msg.Event.IssueID)
+					if err == nil && binding.Active && binding.Enabled &&
+						!isExternalRootProjectionEvent(*msg.Event, binding) {
+						wake(binding.ID)
+					}
+				}
+			}
+			sub.Unsub()
+			if ctx.Err() == nil {
+				sub = bcast.Subscribe(daemon.SubFilter{})
+			}
+		}
+	})
+}
+
+func isExternalRootProjectionEvent(event db.Event, binding db.ExternalRootBinding) bool {
+	var payload struct {
+		Source struct {
+			ConnectorInstance string `json:"connector_instance"`
+		} `json:"source"`
+	}
+	if json.Unmarshal([]byte(event.Payload), &payload) != nil {
+		return false
+	}
+	return payload.Source.ConnectorInstance == binding.ConnectorInstance
 }
 
 func webAuthenticationMode(

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -35,6 +35,7 @@ import (
 	"go.kenn.io/kata/internal/federation"
 	"go.kenn.io/kata/internal/githubsync"
 	"go.kenn.io/kata/internal/hooks"
+	"go.kenn.io/kata/internal/rootbridge"
 	"go.kenn.io/kata/internal/telemetry"
 	"go.kenn.io/kata/internal/testenv"
 	"go.kenn.io/kata/internal/vector"
@@ -2762,4 +2763,362 @@ func writeReusedRuntimePID(t *testing.T, home string, pid int) {
 		StartedAt:         time.Now().UTC(),
 	})
 	require.NoError(t, err)
+}
+
+func TestExternalRootEventWakeUsesActualNativeEventsAndSkipsProjectionLoops(t *testing.T) {
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	project, err := store.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "External root", Author: "tester",
+	})
+	require.NoError(t, err)
+	binding, _, err := store.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: project.ID, IssueID: issue.ID, ConnectorInstance: "example-connector",
+		ExternalRootKey: "root-1", ExternalAccountKey: "account-1", Actor: "tester",
+		ReceiveCommentsAfter: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	broadcaster := daemon.NewEventBroadcaster()
+	wakes := make(chan int64, 10)
+	ctx, cancel := context.WithCancel(t.Context())
+	workers := newDaemonWorkerGroup()
+	t.Cleanup(func() {
+		cancel()
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+		defer waitCancel()
+		require.True(t, workers.Wait(waitCtx))
+	})
+	startExternalRootEventWake(ctx, workers, store, broadcaster, func(id int64) { wakes <- id })
+	for _, eventType := range []string{
+		"issue.commented", "issue.comment_edited", "issue.updated",
+		"issue.metadata_updated", "issue.closed", "issue.reopened",
+	} {
+		issueID := issue.ID
+		broadcaster.Broadcast(daemon.StreamMsg{Kind: "event", ProjectID: project.ID, Event: &db.Event{
+			Type: eventType, IssueID: &issueID, Actor: "operator",
+		}})
+	}
+	issueID := issue.ID
+	broadcaster.Broadcast(daemon.StreamMsg{Kind: "event", ProjectID: project.ID, Event: &db.Event{
+		Type: "issue.metadata_changed", IssueID: &issueID, Actor: "operator",
+	}})
+	broadcaster.Broadcast(daemon.StreamMsg{Kind: "event", ProjectID: project.ID, Event: &db.Event{
+		Type: "issue.updated", IssueID: &issueID, Actor: "connector:local-operator",
+	}})
+	broadcaster.Broadcast(daemon.StreamMsg{Kind: "event", ProjectID: project.ID, Event: &db.Event{
+		Type: "issue.updated", IssueID: &issueID, Actor: "connector:example-connector",
+		Payload: `{"source":{"connector_instance":"example-connector"}}`,
+	}})
+
+	for range 7 {
+		select {
+		case got := <-wakes:
+			assert.Equal(t, binding.ID, got)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for external root wake")
+		}
+	}
+	select {
+	case extra := <-wakes:
+		t.Fatalf("unexpected wake %d", extra)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestExternalRootEventWakeReconnectsAfterBroadcasterOverflow(t *testing.T) {
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	project, err := store.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "External root", Author: "tester",
+	})
+	require.NoError(t, err)
+	binding, _, err := store.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: project.ID, IssueID: issue.ID, ConnectorInstance: "example-connector",
+		ExternalRootKey: "root-1", ExternalAccountKey: "account-1", Actor: "tester",
+		ReceiveCommentsAfter: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	broadcaster := daemon.NewEventBroadcaster()
+	firstWake := make(chan struct{})
+	release := make(chan struct{})
+	var wakeCount atomic.Int64
+	ctx, cancel := context.WithCancel(t.Context())
+	workers := newDaemonWorkerGroup()
+	t.Cleanup(func() {
+		cancel()
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+		defer waitCancel()
+		require.True(t, workers.Wait(waitCtx))
+	})
+	startExternalRootEventWake(ctx, workers, store, broadcaster, func(id int64) {
+		if id != binding.ID {
+			return
+		}
+		if wakeCount.Add(1) == 1 {
+			close(firstWake)
+			<-release
+		}
+	})
+	issueID := issue.ID
+	msg := daemon.StreamMsg{Kind: "event", ProjectID: project.ID, Event: &db.Event{
+		Type: "issue.updated", IssueID: &issueID, Actor: "operator",
+	}}
+	broadcaster.Broadcast(msg)
+	select {
+	case <-firstWake:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocked external root wake")
+	}
+	for range 300 {
+		broadcaster.Broadcast(msg)
+	}
+	close(release)
+	require.Eventually(t, func() bool { return wakeCount.Load() >= 257 }, 5*time.Second, time.Millisecond)
+
+	before := wakeCount.Load()
+	require.Eventually(t, func() bool {
+		broadcaster.Broadcast(msg)
+		return wakeCount.Load() > before
+	}, time.Second, time.Millisecond, "event wake subscriber did not reconnect after overflow")
+}
+
+func TestExternalRootEventWakeReconnectsAndDiscardsQueuedEventsAfterReset(t *testing.T) {
+	store, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	project, err := store.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := store.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "External root", Author: "tester",
+	})
+	require.NoError(t, err)
+	binding, _, err := store.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: project.ID, IssueID: issue.ID, ConnectorInstance: "example-connector",
+		ExternalRootKey: "root-1", ExternalAccountKey: "account-1", Actor: "tester",
+		ReceiveCommentsAfter: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	broadcaster := daemon.NewEventBroadcaster()
+	firstWake := make(chan struct{})
+	release := make(chan struct{})
+	var wakeCount atomic.Int64
+	ctx, cancel := context.WithCancel(t.Context())
+	workers := newDaemonWorkerGroup()
+	t.Cleanup(func() {
+		cancel()
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+		defer waitCancel()
+		require.True(t, workers.Wait(waitCtx))
+	})
+	startExternalRootEventWake(ctx, workers, store, broadcaster, func(id int64) {
+		if id != binding.ID {
+			return
+		}
+		if wakeCount.Add(1) == 1 {
+			close(firstWake)
+			<-release
+		}
+	})
+	issueID := issue.ID
+	msg := daemon.StreamMsg{Kind: "event", ProjectID: project.ID, Event: &db.Event{
+		Type: "issue.updated", IssueID: &issueID, Actor: "operator",
+	}}
+	broadcaster.Broadcast(msg)
+	select {
+	case <-firstWake:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocked external root wake")
+	}
+	broadcaster.Broadcast(daemon.StreamMsg{Kind: "reset", ResetID: 101, ProjectID: project.ID})
+	broadcaster.Broadcast(msg)
+	close(release)
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int64(1), wakeCount.Load(), "queued pre-reset event must not cross the reset boundary")
+
+	require.Eventually(t, func() bool {
+		broadcaster.Broadcast(msg)
+		return wakeCount.Load() == 2
+	}, time.Second, time.Millisecond, "event wake subscriber did not reconnect after reset")
+}
+
+func TestDaemonStartupFailureStopsExternalRootRunnerBeforeReturning(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+	t.Setenv("PORT", "")
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, occupied.Close()) })
+	originalTelemetry := newTelemetryReporter
+	newTelemetryReporter = func(telemetry.Options) telemetry.Client { return &fakeTelemetryReporter{} }
+	t.Cleanup(func() { newTelemetryReporter = originalTelemetry })
+
+	started := time.Now()
+	err = runDaemonWithListen(context.Background(), occupied.Addr().String(), false)
+	require.Error(t, err)
+	assert.Less(t, time.Since(started), 3*time.Second,
+		"runner shutdown must cancel before waiting when startup returns with a live parent context")
+}
+
+func TestDaemonAutoStartWiresExternalRootRunnerDrainAdmission(t *testing.T) {
+	resetFlags(t)
+	setupKataEnv(t)
+	t.Setenv("PORT", "")
+	t.Setenv(daemon.AutoStartMarkerEnv, "1")
+	t.Setenv("KATA_AUTOSTART_IDLE_TIMEOUT", "10s")
+	originalTelemetry := newTelemetryReporter
+	newTelemetryReporter = func(telemetry.Options) telemetry.Client { return &fakeTelemetryReporter{} }
+	t.Cleanup(func() { newTelemetryReporter = originalTelemetry })
+
+	originalRun := runExternalRootRunner
+	captured := make(chan *rootbridge.Runner, 1)
+	runExternalRootRunner = func(ctx context.Context, runner *rootbridge.Runner) error {
+		captured <- runner
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	t.Cleanup(func() { runExternalRootRunner = originalRun })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runDaemonWithListen(ctx, "127.0.0.1:0", false) }()
+
+	select {
+	case runner := <-captured:
+		require.NotNil(t, runner.DrainAdmission)
+		require.NotNil(t, runner.EventSinkFrom)
+	case <-time.After(3 * time.Second):
+		cancel()
+		t.Fatal("external root runner was not started")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("daemon did not stop after context cancellation")
+	}
+}
+
+func TestDaemonWithoutConnectorsStartsExternalRootRunnerForDurableBindings(t *testing.T) {
+	resetFlags(t)
+	home := setupKataEnv(t)
+	t.Setenv("PORT", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_REQUIRE_TOKEN_IDENTITY", "")
+	originalTelemetry := newTelemetryReporter
+	newTelemetryReporter = func(telemetry.Options) telemetry.Client { return &fakeTelemetryReporter{} }
+	t.Cleanup(func() { newTelemetryReporter = originalTelemetry })
+
+	dbPath := filepath.Join(home, "kata.db")
+	seed := openKataTestDB(t, dbPath)
+	project, err := seed.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := seed.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "Durable external root", Author: "tester",
+	})
+	require.NoError(t, err)
+	binding, _, err := seed.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: project.ID, IssueID: issue.ID, ConnectorInstance: "example-connector",
+		ExternalRootKey: "root-1", ExternalAccountKey: "account-1", Actor: "tester",
+		ReceiveCommentsAfter: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, seed.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runDaemonWithListen(ctx, "127.0.0.1:0", false) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case runErr := <-done:
+			if runErr != nil && !errors.Is(runErr, context.Canceled) {
+				t.Errorf("daemon did not stop cleanly: %v", runErr)
+			}
+		case <-time.After(3 * time.Second):
+			t.Error("daemon did not stop after context cancellation")
+		}
+	})
+
+	namespace, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	runtimePath, err := (kitdaemon.RuntimeStore{Dir: namespace.DataDir}).Path(os.Getpid())
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(runtimePath)
+		return statErr == nil
+	}, 3*time.Second, 10*time.Millisecond)
+
+	inspect := openKataTestDB(t, dbPath)
+	t.Cleanup(func() { require.NoError(t, inspect.Close()) })
+	require.Eventually(t, func() bool {
+		stored, readErr := inspect.ExternalRootBindingByID(t.Context(), binding.ID)
+		return readErr == nil && stored.Active && !stored.Enabled &&
+			stored.PausedReason == "external_connector_missing"
+	}, 3*time.Second, 10*time.Millisecond,
+		"durable binding was not paused when its connector configuration was absent")
+}
+
+func TestDaemonStartsWithUnavailableConnectorAndServesRedactedStatus(t *testing.T) {
+	resetFlags(t)
+	home := setupKataEnv(t)
+	t.Setenv("PORT", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_REQUIRE_TOKEN_IDENTITY", "")
+	t.Setenv(daemon.AutoStartMarkerEnv, "1")
+	missingCommand := filepath.Join(t.TempDir(), "example-missing-connector")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(fmt.Sprintf(`
+[[connector]]
+id = "example-connector"
+command = %q
+`, missingCommand)), 0o600))
+	originalTelemetry := newTelemetryReporter
+	newTelemetryReporter = func(telemetry.Options) telemetry.Client { return &fakeTelemetryReporter{} }
+	t.Cleanup(func() { newTelemetryReporter = originalTelemetry })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runDaemonWithListen(ctx, "127.0.0.1:0", false) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case runErr := <-done:
+			if runErr != nil && !errors.Is(runErr, context.Canceled) {
+				t.Errorf("daemon did not stop cleanly: %v", runErr)
+			}
+		case <-time.After(3 * time.Second):
+			t.Error("daemon did not stop after context cancellation")
+		}
+	})
+
+	namespace, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	runtimePath, err := (kitdaemon.RuntimeStore{Dir: namespace.DataDir}).Path(os.Getpid())
+	require.NoError(t, err)
+	var record daemonRuntimeRecordJSON
+	require.Eventually(t, func() bool {
+		body, readErr := os.ReadFile(runtimePath) //nolint:gosec // test-owned KATA_HOME
+		return readErr == nil && json.Unmarshal(body, &record) == nil && record.Address != ""
+	}, 3*time.Second, 10*time.Millisecond)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+record.Address+"/api/v1/connectors/example-connector", nil)
+	require.NoError(t, err)
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, response.Body.Close()) }()
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode, string(body))
+	assert.Contains(t, string(body), `"healthy":false`)
+	assert.NotContains(t, string(body), "example-missing-connector")
 }

--- a/cmd/kata/issue_ref_cli.go
+++ b/cmd/kata/issue_ref_cli.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -28,6 +29,14 @@ import (
 // from their subsequent hydrateRefWithQualified call with includeDeleted=true;
 // resolving the positional ref itself needs no destructive-command option.
 func resolveIssueRefForCommand(cmd *cobra.Command, ref string) (context.Context, string, int64, resolvedIssueRef, error) {
+	return resolveIssueRefForCommandWithOptions(cmd, ref, false)
+}
+
+func resolveIssueRefForCommandWithOptions(
+	cmd *cobra.Command,
+	ref string,
+	includeArchivedProject bool,
+) (context.Context, string, int64, resolvedIssueRef, error) {
 	ctx := cmd.Context()
 	start, err := resolveStartPath(flags.Workspace)
 	if err != nil {
@@ -54,7 +63,9 @@ func resolveIssueRefForCommand(cmd *cobra.Command, ref string) (context.Context,
 			ExitCode: ExitValidation,
 		}
 	}
-	pid, projectName, err := resolveProjectIDAndNameForRef(ctx, baseURL, start, parsed.ProjectName)
+	pid, projectName, err := resolveProjectIDAndNameForRef(
+		ctx, baseURL, start, parsed.ProjectName, includeArchivedProject,
+	)
 	if err != nil {
 		return nil, "", 0, resolvedIssueRef{}, err
 	}
@@ -69,14 +80,34 @@ func resolveIssueRefForCommand(cmd *cobra.Command, ref string) (context.Context,
 // pins the project name; a bare ref / ULID inherits the workspace binding.
 // The canonical name is used by destructive verbs to format the
 // X-Kata-Confirm header value ("DELETE <project>#<short_id>").
-func resolveProjectIDAndNameForRef(ctx context.Context, baseURL, startPath, refProjectName string) (int64, string, error) {
+func resolveProjectIDAndNameForRef(
+	ctx context.Context,
+	baseURL, startPath, refProjectName string,
+	includeArchived bool,
+) (int64, string, error) {
 	if strings.TrimSpace(refProjectName) == "" {
 		return resolveProjectIDAndName(ctx, baseURL, startPath)
 	}
 	saved := flags.Project
 	flags.Project = refProjectName
 	defer func() { flags.Project = saved }()
-	return resolveProjectIDAndName(ctx, baseURL, startPath)
+	projectID, projectName, err := resolveProjectIDAndName(ctx, baseURL, startPath)
+	if err == nil || !includeArchived {
+		return projectID, projectName, err
+	}
+	var cliErr *cliError
+	if !errors.As(err, &cliErr) || cliErr.Kind != kindNotFound {
+		return 0, "", err
+	}
+	client, err := httpClientFor(ctx, baseURL)
+	if err != nil {
+		return 0, "", err
+	}
+	project, err := resolveProjectSelectorIncludingArchived(ctx, client, baseURL, refProjectName)
+	if err != nil {
+		return 0, "", err
+	}
+	return project.ID, project.Name, nil
 }
 
 // hydrateRefWithQualified does a daemon GET to resolve the issue's short_id

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -106,6 +106,8 @@ func newRootCmd() *cobra.Command {
 
 	subs := []*cobra.Command{
 		newDaemonCmd(),
+		newConnectorCmd(),
+		newBridgeCmd(),
 		newMCPCmd(),
 		newStorageCmd(),
 		newInitCmd(),

--- a/internal/api/external_roots.go
+++ b/internal/api/external_roots.go
@@ -1,0 +1,197 @@
+package api //nolint:revive // package name is the stable wire-types layout.
+
+import (
+	"time"
+
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+// ConnectorOut is the secret-free status of one configured connector instance.
+type ConnectorOut struct {
+	InstanceID      string                 `json:"instance_id"`
+	ConnectorID     string                 `json:"connector_id,omitempty"`
+	DisplayName     string                 `json:"display_name,omitempty"`
+	Protocol        string                 `json:"protocol,omitempty"`
+	AccountIdentity string                 `json:"account_identity,omitempty"`
+	Capabilities    []connector.Capability `json:"capabilities,omitempty"`
+	Healthy         bool                   `json:"healthy"`
+	HealthError     string                 `json:"health_error,omitempty"`
+}
+
+// ConnectorListResponse returns all configured connector instances.
+type ConnectorListResponse struct {
+	Body struct {
+		Connectors []ConnectorOut `json:"connectors"`
+	}
+}
+
+// ConnectorPathRequest selects one connector instance by path.
+type ConnectorPathRequest struct {
+	Instance string `path:"instance"`
+}
+
+// ConnectorResponse returns one configured connector instance.
+type ConnectorResponse struct{ Body ConnectorOut }
+
+// ConnectorFieldsResponse returns the live fields advertised by a connector.
+type ConnectorFieldsResponse struct {
+	Body struct {
+		Fields []connector.FieldDescriptor `json:"fields"`
+	}
+}
+
+// MapConnectorFieldRequest maps one Kata planning field to an external field.
+type MapConnectorFieldRequest struct {
+	Instance  string `path:"instance"`
+	KataField string `path:"kata_field"`
+	Body      struct {
+		ExternalField string `json:"external_field"`
+	}
+}
+
+// UnmapConnectorFieldRequest removes one connector field mapping.
+type UnmapConnectorFieldRequest struct {
+	Instance  string `path:"instance"`
+	KataField string `path:"kata_field"`
+}
+
+// ConnectorFieldMappingResponse returns one connector field mapping.
+type ConnectorFieldMappingResponse struct{ Body ExternalFieldMappingOut }
+
+// ExternalFieldMappingOut describes an active connector field mapping.
+type ExternalFieldMappingOut struct {
+	KataField         string   `json:"kata_field"`
+	ExternalFieldID   string   `json:"external_field_id"`
+	ExternalFieldName string   `json:"external_field_name"`
+	AcceptedKinds     []string `json:"accepted_kinds"`
+	Nullable          bool     `json:"nullable"`
+	Writable          bool     `json:"writable"`
+	SchemaRevision    string   `json:"schema_revision"`
+	Active            bool     `json:"active"`
+}
+
+// ExternalRootIssueRequest selects one issue bridge and its attributed actor.
+type ExternalRootIssueRequest struct {
+	ProjectID int64  `path:"project_id"`
+	Ref       string `path:"ref"`
+	Actor     string `query:"actor,omitempty"`
+}
+
+// BindExternalRootRequest creates a bridge for one Kata issue.
+type BindExternalRootRequest struct {
+	ProjectID int64  `path:"project_id"`
+	Ref       string `path:"ref"`
+	Body      struct {
+		Connector       string `json:"connector"`
+		External        string `json:"external"`
+		Actor           string `json:"actor,omitempty"`
+		PublishComments bool   `json:"publish_comments,omitempty"`
+	}
+}
+
+// ExternalRootActionRequest applies an operator action to one issue bridge.
+type ExternalRootActionRequest struct {
+	ProjectID int64  `path:"project_id"`
+	Ref       string `path:"ref"`
+	Body      struct {
+		Actor  string `json:"actor,omitempty"`
+		Reason string `json:"reason,omitempty"`
+	}
+}
+
+// ReconcileExternalRootByKeyRequest reconciles one connector-owned root key.
+type ReconcileExternalRootByKeyRequest struct {
+	Instance string `path:"instance"`
+	Body     struct {
+		RootKey string `json:"root_key"`
+	}
+}
+
+// ResolveExternalFieldRequest resolves one planning-field conflict.
+type ResolveExternalFieldRequest struct {
+	ProjectID int64  `path:"project_id"`
+	Ref       string `path:"ref"`
+	Body      struct {
+		KataField string `json:"kata_field"`
+		Use       string `json:"use"`
+		Actor     string `json:"actor,omitempty"`
+	}
+}
+
+// ResolveExternalCommentRequest resolves one uncertain published comment.
+type ResolveExternalCommentRequest struct {
+	ProjectID int64  `path:"project_id"`
+	Ref       string `path:"ref"`
+	Body      struct {
+		Action            string `json:"action"`
+		ExternalCommentID string `json:"external_comment_id,omitempty"`
+		Actor             string `json:"actor,omitempty"`
+	}
+}
+
+// ExternalRootBridgeResponse returns one bridge snapshot.
+type ExternalRootBridgeResponse struct{ Body ExternalRootBridgeOut }
+
+// ExternalRootRunResponse returns one reconciliation result.
+type ExternalRootRunResponse struct{ Body ExternalRootRunOut }
+
+// ExternalRootBridgeOut is the secret-free status of one issue bridge.
+type ExternalRootBridgeOut struct {
+	ID                  int64                      `json:"id"`
+	UID                 string                     `json:"uid"`
+	ProjectID           int64                      `json:"project_id"`
+	IssueID             int64                      `json:"issue_id"`
+	ConnectorInstance   string                     `json:"connector_instance"`
+	Active              bool                       `json:"active"`
+	Enabled             bool                       `json:"enabled"`
+	ReceiveComments     bool                       `json:"receive_comments"`
+	PublishComments     bool                       `json:"publish_comments"`
+	CompleteExternal    bool                       `json:"complete_external"`
+	PausedReason        string                     `json:"paused_reason,omitempty"`
+	LastAttemptAt       *time.Time                 `json:"last_attempt_at,omitempty"`
+	LastSuccessAt       *time.Time                 `json:"last_success_at,omitempty"`
+	LastErrorAt         *time.Time                 `json:"last_error_at,omitempty"`
+	LastError           string                     `json:"last_error,omitempty"`
+	ConsecutiveFailures int                        `json:"consecutive_failures"`
+	NextAttemptAt       *time.Time                 `json:"next_attempt_at,omitempty"`
+	LastExternalState   string                     `json:"last_external_state,omitempty"`
+	PendingCommentUID   string                     `json:"pending_comment_uid,omitempty"`
+	FieldConflicts      []ExternalFieldConflictOut `json:"field_conflicts,omitempty"`
+}
+
+// ExternalFieldConflictOut describes unresolved canonical field candidates.
+type ExternalFieldConflictOut struct {
+	KataField         string                     `json:"kata_field"`
+	KataCandidate     *ExternalFieldCandidateOut `json:"kata_candidate,omitempty"`
+	ExternalCandidate *ExternalFieldCandidateOut `json:"external_candidate,omitempty"`
+	ConflictAt        *time.Time                 `json:"conflict_at,omitempty"`
+}
+
+// ExternalFieldCandidateOut is one provider-neutral planning-field value.
+type ExternalFieldCandidateOut struct {
+	Kind     string `json:"kind"`
+	Value    string `json:"value,omitempty"`
+	Timezone string `json:"timezone,omitempty"`
+}
+
+// ExternalRootRunOut summarizes committed effects from one reconciliation.
+type ExternalRootRunOut struct {
+	Bridge             ExternalRootBridgeOut `json:"bridge"`
+	RootUpdated        bool                  `json:"root_updated"`
+	CommentsCreated    int                   `json:"comments_created"`
+	CommentsEdited     int                   `json:"comments_edited"`
+	FieldConflicts     int                   `json:"field_conflicts"`
+	CompletionRequests int                   `json:"completion_requests"`
+	ReopenRequests     int                   `json:"reopen_requests"`
+	Paused             bool                  `json:"paused"`
+}
+
+// ExternalFieldMappingFromDB converts a stored mapping to its wire form.
+func ExternalFieldMappingFromDB(mapping db.ExternalFieldMapping) ExternalFieldMappingOut {
+	return ExternalFieldMappingOut{
+		KataField: mapping.KataField, ExternalFieldID: mapping.ExternalFieldID,
+		ExternalFieldName: mapping.ExternalFieldName, AcceptedKinds: append([]string(nil), mapping.AcceptedKinds...),
+		Nullable: mapping.Nullable, Writable: mapping.Writable, SchemaRevision: mapping.SchemaRevision, Active: mapping.Active,
+	}
+}

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -60,6 +60,8 @@ type DaemonConfig struct {
 	// GitHubSync carries daemon-owned GitHub API credential settings for
 	// background synchronization.
 	GitHubSync GitHubSyncConfig `toml:"github_sync"`
+	// Connectors declares operator-controlled external root connector processes.
+	Connectors []ConnectorConfig `toml:"connector"`
 }
 
 // MinAutostartIdleTimeout leaves enough time for detached startup discovery
@@ -401,6 +403,11 @@ func ReadDaemonConfig() (*DaemonConfig, error) {
 	if err := validateGitHubSync(cfg.GitHubSync); err != nil {
 		return nil, err
 	}
+	connectors, err := NormalizeConnectorConfigs(cfg.Connectors)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Connectors = connectors
 	if err := normalizeDaemonCatalog(&cfg); err != nil {
 		return nil, err
 	}

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,30 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/config"
 )
+
+func TestReadDaemonConfigNormalizesConnectors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	absoluteCommand := filepath.Join(t.TempDir(), "example-connector-connector")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(fmt.Sprintf(`
+[[connector]]
+id = " Example-Connector "
+command = %q
+args = ["--quiet"]
+timeout_seconds = 5
+
+[connector.env]
+TOKEN = "CONNECTOR_TOKEN"
+
+[connector.settings]
+enabled = true
+`, absoluteCommand)), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	require.Len(t, cfg.Connectors, 1)
+	assert.Equal(t, "example-connector", cfg.Connectors[0].ID)
+}
 
 func TestReadDisplayConfigPreservesRendererArgv(t *testing.T) {
 	home := t.TempDir()

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -89,6 +89,9 @@ func requireBearer(p authPolicy, tokenStores ...db.Storage) func(http.Handler) h
 					return
 				}
 				if !p.InsecureReadonly {
+					if p.AllowUnauthenticatedPrivateNetworkWrites {
+						r = r.WithContext(withUnauthenticatedPrivateNetworkRequest(r.Context()))
+					}
 					next.ServeHTTP(w, r)
 					return
 				}

--- a/internal/daemon/handlers_comments.go
+++ b/internal/daemon/handlers_comments.go
@@ -118,6 +118,11 @@ func registerCommentsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if errors.Is(err, db.ErrNotFound) {
 			return nil, api.NewError(404, "comment_not_found", "comment not found", "", nil)
 		}
+		if errors.Is(err, db.ErrExternalCommentContentOwned) {
+			return nil, api.NewError(409, "external_comment_content_owned",
+				"the comment body is owned by an active external root binding",
+				"edit the comment at its external source or unbind the external root before editing it locally", nil)
+		}
 		if err != nil {
 			if apiErr := federationReadOnlyError(err); apiErr != nil {
 				return nil, apiErr

--- a/internal/daemon/handlers_comments_test.go
+++ b/internal/daemon/handlers_comments_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
 )
 
 func TestCommentEndpoint_AppendsAndEmitsEvent(t *testing.T) {
@@ -88,6 +90,35 @@ func TestCommentEndpoint_EditsCommentAndEmitsEvent(t *testing.T) {
 	assert.Contains(t, string(editBS), `"body":"[redacted]"`)
 	assert.Contains(t, string(editBS), `"type":"issue.comment_edited"`)
 	assert.NotContains(t, string(editBS), "token=leaked")
+}
+
+func TestCommentEndpoint_RejectsEditingExternallyOwnedComment(t *testing.T) {
+	h, ts, pid, issueID := bootstrapProjectWithIssue(t)
+	observedAt := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	binding, _, err := h.DB().CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: pid, IssueID: issueID, ConnectorInstance: "example-connector",
+		ExternalRootKey: "external-root", ExternalAccountKey: "external-account",
+		Actor: "connector:example-connector", ReceiveCommentsAfter: observedAt,
+	})
+	require.NoError(t, err)
+	claimed, acquired, err := h.DB().ClaimExternalRootBinding(
+		t.Context(), binding.ID, "projection-claim", observedAt, observedAt.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	comment, _, _, err := h.DB().UpsertExternalCommentProjection(t.Context(), db.ExternalCommentProjectionParams{
+		BindingID: claimed.ID, ClaimToken: claimed.ClaimToken,
+		ExternalID: "external-comment", ExternalRevision: "revision-1",
+		Body: "Provider-owned comment", ExternalActorID: "external-actor",
+		ExternalActorName: "External author", ExternalCreatedAt: observedAt,
+		ExternalUpdatedAt: observedAt, IntegrationActor: "connector:example-connector",
+	})
+	require.NoError(t, err)
+
+	resp, body := patchJSON(t, ts, issueURL(pid, issueID, "comments/"+comment.UID),
+		map[string]any{"actor": "redactor", "body": "local replacement"})
+
+	assertAPIError(t, resp.StatusCode, body, 409, "external_comment_content_owned")
 }
 
 func TestActionsClose_ReopenRoundtrip(t *testing.T) {

--- a/internal/daemon/handlers_destructive.go
+++ b/internal/daemon/handlers_destructive.go
@@ -47,6 +47,9 @@ func registerDestructiveHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if errors.Is(err, db.ErrFederatedReadOnly) {
 			return nil, federationReadOnlyError(err)
 		}
+		if errors.Is(err, db.ErrExternalRootContentOwned) {
+			return nil, externalRootContentOwnedAPIError()
+		}
 		if err != nil {
 			return nil, internalAPIError(err)
 		}
@@ -136,6 +139,9 @@ func registerDestructiveHandlers(humaAPI huma.API, cfg ServerConfig) {
 				return nil, api.NewError(409, "federated_admin_required", err.Error(), "", nil)
 			}
 			return nil, federationReadOnlyError(err)
+		}
+		if errors.Is(err, db.ErrExternalRootContentOwned) {
+			return nil, externalRootContentOwnedAPIError()
 		}
 		if err != nil {
 			return nil, internalAPIError(err)

--- a/internal/daemon/handlers_destructive_test.go
+++ b/internal/daemon/handlers_destructive_test.go
@@ -58,6 +58,31 @@ func TestDelete_AcceptsCorrectConfirmAndSoftDeletes(t *testing.T) {
 	require.Equal(t, 404, respShow.StatusCode, string(bs))
 }
 
+func TestDelete_RequiresAdministratorToUnbindExternalRootFirst(t *testing.T) {
+	h, ts, pid, num := bootstrapProjectWithIssue(t)
+	issue, err := h.DB().IssueByID(t.Context(), num)
+	require.NoError(t, err)
+	binding, _, err := h.DB().CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: pid, IssueID: issue.ID,
+		ConnectorInstance: "example", ExternalRootKey: "root-delete-guard",
+		ExternalAccountKey: "example-account", Actor: "integration-admin",
+		ReceiveCommentsAfter: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	resp := postWithHeader(t, ts, issueURL(pid, num, "actions/delete"),
+		map[string]string{"X-Kata-Confirm": confirmHeader(t, h, pid, num, "DELETE")},
+		map[string]any{"actor": "agent"})
+
+	assertAPIError(t, resp.status, resp.body, 409, "external_root_content_owned")
+	retainedIssue, err := h.DB().IssueByID(t.Context(), issue.ID)
+	require.NoError(t, err)
+	assert.Nil(t, retainedIssue.DeletedAt)
+	retainedBinding, err := h.DB().ExternalRootBindingByID(t.Context(), binding.ID)
+	require.NoError(t, err)
+	assert.True(t, retainedBinding.Active)
+}
+
 func TestDelete_AlreadyDeletedIsNoOp(t *testing.T) {
 	h, ts, pid, num := bootstrapProjectWithIssue(t)
 	hdr := confirmHeader(t, h, pid, num, "DELETE")
@@ -121,6 +146,30 @@ func TestPurge_RequiresConfirmHeaderAndRemovesAllRows(t *testing.T) {
 	// Subsequent show 404s — issue is gone.
 	respShow, _ := getStatusBody(t, ts, issueURL(pid, num, "")+"?include_deleted=true")
 	assert.Equal(t, 404, respShow.StatusCode)
+}
+
+func TestPurge_RequiresAdministratorToUnbindExternalRootFirst(t *testing.T) {
+	h, ts, pid, num := bootstrapProjectWithIssue(t)
+	issue, err := h.DB().IssueByID(t.Context(), num)
+	require.NoError(t, err)
+	binding, _, err := h.DB().CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: pid, IssueID: issue.ID,
+		ConnectorInstance: "example", ExternalRootKey: "root-purge-guard",
+		ExternalAccountKey: "example-account", Actor: "integration-admin",
+		ReceiveCommentsAfter: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	resp := postWithHeader(t, ts, issueURL(pid, num, "actions/purge"),
+		map[string]string{"X-Kata-Confirm": confirmHeader(t, h, pid, num, "PURGE")},
+		map[string]any{"actor": "agent"})
+
+	assertAPIError(t, resp.status, resp.body, 409, "external_root_content_owned")
+	_, err = h.DB().IssueByID(t.Context(), issue.ID)
+	require.NoError(t, err)
+	retainedBinding, err := h.DB().ExternalRootBindingByID(t.Context(), binding.ID)
+	require.NoError(t, err)
+	assert.True(t, retainedBinding.Active)
 }
 
 func TestPurge_FederatedSpokeRequiresHubAdmin(t *testing.T) {

--- a/internal/daemon/handlers_external_roots.go
+++ b/internal/daemon/handlers_external_roots.go
@@ -1,0 +1,542 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"go.kenn.io/kata/internal/api"
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/rootbridge"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+var externalRootOperationIDs = map[string]bool{
+	"listConnectors": true, "getConnectorStatus": true, "listConnectorFields": true,
+	"mapConnectorField": true, "unmapConnectorField": true, "bindExternalRoot": true,
+	"getExternalRootBridge": true, "reconcileExternalRootBridge": true,
+	"reconcileExternalRootByKey": true, "pauseExternalRootBridge": true,
+	"resumeExternalRootBridge": true, "resolveExternalField": true,
+	"resolveExternalComment": true, "unbindExternalRoot": true,
+}
+
+func withExternalRootAdministration(humaAPI huma.API) {
+	humaAPI.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+		operation := ctx.Operation()
+		if operation == nil || !externalRootOperationIDs[operation.OperationID] {
+			next(ctx)
+			return
+		}
+		if err := ensureExternalRootAdministrationAllowed(ctx.Context()); err != nil {
+			writeHostAccessError(ctx, http.StatusForbidden, "integration_administration_forbidden", "connector administration is unavailable to this principal")
+			return
+		}
+		next(ctx)
+	})
+}
+
+func ensureExternalRootAdministrationAllowed(ctx context.Context) error {
+	if webSessionAuthenticated(ctx) || insecureReadonlyRequest(ctx) || unauthenticatedPrivateNetworkRequest(ctx) {
+		return api.NewError(http.StatusForbidden, "integration_administration_forbidden", "connector administration is unavailable to this principal", "", nil)
+	}
+	if principal, ok := PrincipalFromContext(ctx); ok {
+		switch principal.Kind {
+		case PrincipalDBToken, PrincipalBootstrap, PrincipalTrustedProxy,
+			PrincipalTrustedProxyAbsent, PrincipalWebLocal:
+			return api.NewError(http.StatusForbidden, "integration_administration_forbidden", "connector administration is unavailable to this principal", "", nil)
+		}
+	}
+	return nil
+}
+
+func registerExternalRootHandlers(humaAPI huma.API, cfg ServerConfig) {
+	huma.Register(humaAPI, huma.Operation{OperationID: "listConnectors", Method: http.MethodGet, Path: "/api/v1/connectors"},
+		func(ctx context.Context, _ *struct{}) (*api.ConnectorListResponse, error) {
+			response := &api.ConnectorListResponse{}
+			if cfg.ExternalRootRegistry == nil {
+				response.Body.Connectors = []api.ConnectorOut{}
+				return response, nil
+			}
+			for _, snapshot := range cfg.ExternalRootRegistry.RefreshSnapshots(ctx) {
+				response.Body.Connectors = append(response.Body.Connectors, connectorOut(snapshot))
+			}
+			return response, nil
+		})
+
+	huma.Register(humaAPI, huma.Operation{OperationID: "getConnectorStatus", Method: http.MethodGet, Path: "/api/v1/connectors/{instance}"},
+		func(ctx context.Context, in *api.ConnectorPathRequest) (*api.ConnectorResponse, error) {
+			if cfg.ExternalRootRegistry == nil {
+				return nil, externalRootHandlerError(rootbridge.ErrConnectorInstanceNotFound)
+			}
+			snapshot, err := cfg.ExternalRootRegistry.Refresh(ctx, in.Instance)
+			if err != nil {
+				if safe, ok := cfg.ExternalRootRegistry.Snapshot(in.Instance); ok {
+					return &api.ConnectorResponse{Body: connectorOut(safe)}, nil
+				}
+				return nil, externalRootHandlerError(err)
+			}
+			return &api.ConnectorResponse{Body: connectorOut(snapshot)}, nil
+		})
+
+	huma.Register(humaAPI, huma.Operation{OperationID: "listConnectorFields", Method: http.MethodGet, Path: "/api/v1/connectors/{instance}/fields"},
+		func(ctx context.Context, in *api.ConnectorPathRequest) (*api.ConnectorFieldsResponse, error) {
+			if cfg.ExternalRootRegistry == nil {
+				return nil, externalRootHandlerError(rootbridge.ErrConnectorInstanceNotFound)
+			}
+			fields, err := cfg.ExternalRootRegistry.Fields(ctx, in.Instance)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return &api.ConnectorFieldsResponse{Body: struct {
+				Fields []connector.FieldDescriptor `json:"fields"`
+			}{Fields: fields}}, nil
+		})
+
+	huma.Register(humaAPI, huma.Operation{OperationID: "mapConnectorField", Method: http.MethodPut, Path: "/api/v1/connectors/{instance}/fields/{kata_field}"},
+		func(ctx context.Context, in *api.MapConnectorFieldRequest) (*api.ConnectorFieldMappingResponse, error) {
+			if err := ensureAttributedWriteAllowed(ctx); err != nil {
+				return nil, err
+			}
+			if cfg.ExternalRootService == nil {
+				return nil, externalRootUnavailable()
+			}
+			mapping, err := cfg.ExternalRootService.MapField(ctx, rootbridge.MapFieldParams{
+				ConnectorInstance: in.Instance, KataField: in.KataField, ExternalField: in.Body.ExternalField,
+			})
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return &api.ConnectorFieldMappingResponse{Body: api.ExternalFieldMappingFromDB(mapping)}, nil
+		})
+
+	huma.Register(humaAPI, huma.Operation{OperationID: "unmapConnectorField", Method: http.MethodDelete, Path: "/api/v1/connectors/{instance}/fields/{kata_field}"},
+		func(ctx context.Context, in *api.UnmapConnectorFieldRequest) (*api.ConnectorFieldMappingResponse, error) {
+			if err := ensureAttributedWriteAllowed(ctx); err != nil {
+				return nil, err
+			}
+			if cfg.ExternalRootService == nil {
+				return nil, externalRootUnavailable()
+			}
+			mapping, err := cfg.ExternalRootService.UnmapField(ctx, in.Instance, in.KataField)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return &api.ConnectorFieldMappingResponse{Body: api.ExternalFieldMappingFromDB(mapping)}, nil
+		})
+
+	huma.Register(humaAPI, huma.Operation{OperationID: "bindExternalRoot", Method: http.MethodPost, Path: "/api/v1/projects/{project_id}/issues/{ref}/bridge"},
+		func(ctx context.Context, in *api.BindExternalRootRequest) (*api.ExternalRootBridgeResponse, error) {
+			if err := ensureAttributedWriteAllowed(ctx); err != nil {
+				return nil, err
+			}
+			if cfg.ExternalRootService == nil {
+				return nil, externalRootUnavailable()
+			}
+			issue, err := activeIssueByRef(ctx, cfg.DB, in.ProjectID, in.Ref, db.IncludeDeletedNo)
+			if err != nil {
+				return nil, err
+			}
+			actor, err := attributedActor(ctx, in.Body.Actor)
+			if err != nil {
+				return nil, err
+			}
+			binding, _, callErr := cfg.ExternalRootService.Bind(ctx, rootbridge.BindParams{
+				ProjectID: in.ProjectID, IssueID: issue.ID, ConnectorInstance: in.Body.Connector,
+				Locator: in.Body.External, Actor: actor, PublishComments: in.Body.PublishComments,
+			})
+			if binding.ID != 0 && cfg.ExternalRootWake != nil {
+				cfg.ExternalRootWake(binding.ID)
+			}
+			if callErr != nil {
+				return nil, externalRootHandlerError(callErr)
+			}
+			out, err := externalRootBridgeOut(ctx, cfg.DB, binding)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return &api.ExternalRootBridgeResponse{Body: out}, nil
+		})
+
+	huma.Register(humaAPI, huma.Operation{OperationID: "getExternalRootBridge", Method: http.MethodGet, Path: "/api/v1/projects/{project_id}/issues/{ref}/bridge"},
+		func(ctx context.Context, in *api.ExternalRootIssueRequest) (*api.ExternalRootBridgeResponse, error) {
+			issue, err := activeIssueByRef(ctx, cfg.DB, in.ProjectID, in.Ref, db.IncludeDeletedNo)
+			if err != nil {
+				return nil, err
+			}
+			binding, err := cfg.DB.ExternalRootBindingByIssue(ctx, issue.ID)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			out, err := externalRootBridgeOut(ctx, cfg.DB, binding)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return &api.ExternalRootBridgeResponse{Body: out}, nil
+		})
+
+	registerExternalRootManualReconcile(humaAPI, cfg)
+	registerExternalRootActions(humaAPI, cfg)
+}
+
+func registerExternalRootManualReconcile(humaAPI huma.API, cfg ServerConfig) {
+	run := func(ctx context.Context, binding db.ExternalRootBinding) (*api.ExternalRootRunResponse, error) {
+		if cfg.ExternalRootReconciler == nil {
+			return nil, externalRootUnavailable()
+		}
+		result, runErr := cfg.ExternalRootReconciler.Run(ctx, binding.ID, rootbridge.RunOptions{
+			Manual: true,
+			EventSink: func(event db.Event) {
+				deliverExternalRootEvents(cfg, []db.Event{event})
+			},
+		})
+		if runErr != nil {
+			return nil, externalRootHandlerError(runErr)
+		}
+		current, err := cfg.DB.ExternalRootBindingByID(ctx, binding.ID)
+		if err != nil {
+			return nil, externalRootHandlerError(err)
+		}
+		out, err := externalRootBridgeOut(ctx, cfg.DB, current)
+		if err != nil {
+			return nil, externalRootHandlerError(err)
+		}
+		return &api.ExternalRootRunResponse{Body: runResultOut(out, result)}, nil
+	}
+	huma.Register(humaAPI, huma.Operation{OperationID: "reconcileExternalRootBridge", Method: http.MethodPost, Path: "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/reconcile"},
+		func(ctx context.Context, in *api.ExternalRootActionRequest) (*api.ExternalRootRunResponse, error) {
+			if err := ensureAttributedWriteAllowed(ctx); err != nil {
+				return nil, err
+			}
+			issue, err := activeIssueByRef(ctx, cfg.DB, in.ProjectID, in.Ref, db.IncludeDeletedNo)
+			if err != nil {
+				return nil, err
+			}
+			binding, err := cfg.DB.ExternalRootBindingByIssue(ctx, issue.ID)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return run(ctx, binding)
+		})
+	huma.Register(humaAPI, huma.Operation{OperationID: "reconcileExternalRootByKey", Method: http.MethodPost, Path: "/api/v1/connectors/{instance}/actions/reconcile-root"},
+		func(ctx context.Context, in *api.ReconcileExternalRootByKeyRequest) (*api.ExternalRootRunResponse, error) {
+			if err := ensureAttributedWriteAllowed(ctx); err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(in.Body.RootKey) == "" {
+				return nil, api.NewError(http.StatusBadRequest, "validation", "root key is required", "", nil)
+			}
+			binding, err := cfg.DB.ExternalRootBindingByExternalKey(ctx, in.Instance, in.Body.RootKey)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return run(ctx, binding)
+		})
+}
+
+func registerExternalRootActions(humaAPI huma.API, cfg ServerConfig) {
+	issueBinding := func(ctx context.Context, projectID int64, ref string) (db.Issue, db.ExternalRootBinding, error) {
+		issue, err := activeIssueByRef(ctx, cfg.DB, projectID, ref, db.IncludeDeletedNo)
+		if err != nil {
+			return db.Issue{}, db.ExternalRootBinding{}, err
+		}
+		binding, err := cfg.DB.ExternalRootBindingByIssue(ctx, issue.ID)
+		if err != nil {
+			return db.Issue{}, db.ExternalRootBinding{}, externalRootHandlerError(err)
+		}
+		if binding.ProjectID != projectID || binding.IssueID != issue.ID {
+			return db.Issue{}, db.ExternalRootBinding{}, api.NewError(http.StatusNotFound, "bridge_not_found", "external root bridge not found", "", nil)
+		}
+		return issue, binding, nil
+	}
+	registerAction := func(operationID, path string, action func(context.Context, int64, string, string) (db.ExternalRootBinding, db.Event, error)) {
+		huma.Register(humaAPI, huma.Operation{OperationID: operationID, Method: http.MethodPost, Path: path},
+			func(ctx context.Context, in *api.ExternalRootActionRequest) (*api.ExternalRootBridgeResponse, error) {
+				if err := ensureAttributedWriteAllowed(ctx); err != nil {
+					return nil, err
+				}
+				if cfg.ExternalRootService == nil {
+					return nil, externalRootUnavailable()
+				}
+				issue, _, err := issueBinding(ctx, in.ProjectID, in.Ref)
+				if err != nil {
+					return nil, err
+				}
+				actor, err := attributedActor(ctx, in.Body.Actor)
+				if err != nil {
+					return nil, err
+				}
+				binding, _, err := action(ctx, issue.ID, actor, in.Body.Reason)
+				if err != nil {
+					return nil, externalRootHandlerError(err)
+				}
+				if cfg.ExternalRootWake != nil {
+					cfg.ExternalRootWake(binding.ID)
+				}
+				out, err := externalRootBridgeOut(ctx, cfg.DB, binding)
+				if err != nil {
+					return nil, externalRootHandlerError(err)
+				}
+				return &api.ExternalRootBridgeResponse{Body: out}, nil
+			})
+	}
+	registerAction("pauseExternalRootBridge", "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/pause",
+		func(ctx context.Context, issueID int64, actor, reason string) (db.ExternalRootBinding, db.Event, error) {
+			return cfg.ExternalRootService.Pause(ctx, issueID, actor, reason)
+		})
+	registerAction("resumeExternalRootBridge", "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resume",
+		func(ctx context.Context, issueID int64, actor, _ string) (db.ExternalRootBinding, db.Event, error) {
+			return cfg.ExternalRootService.Resume(ctx, issueID, actor)
+		})
+
+	huma.Register(humaAPI, huma.Operation{OperationID: "resolveExternalField", Method: http.MethodPost, Path: "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-field"},
+		func(ctx context.Context, in *api.ResolveExternalFieldRequest) (*api.ExternalRootBridgeResponse, error) {
+			if err := ensureAttributedWriteAllowed(ctx); err != nil {
+				return nil, err
+			}
+			if cfg.ExternalRootService == nil {
+				return nil, externalRootUnavailable()
+			}
+			issue, binding, err := issueBinding(ctx, in.ProjectID, in.Ref)
+			if err != nil {
+				return nil, err
+			}
+			actor, err := attributedActor(ctx, in.Body.Actor)
+			if err != nil {
+				return nil, err
+			}
+			_, _, callErr := cfg.ExternalRootService.ResolveFieldConflict(ctx, issue.ID, in.Body.KataField, in.Body.Use, actor)
+			if callErr != nil {
+				return nil, externalRootHandlerError(callErr)
+			}
+			if cfg.ExternalRootWake != nil {
+				cfg.ExternalRootWake(binding.ID)
+			}
+			current, err := cfg.DB.ExternalRootBindingByID(ctx, binding.ID)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			out, err := externalRootBridgeOut(ctx, cfg.DB, current)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return &api.ExternalRootBridgeResponse{Body: out}, nil
+		})
+
+	huma.Register(humaAPI, huma.Operation{OperationID: "resolveExternalComment", Method: http.MethodPost, Path: "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-comment"},
+		func(ctx context.Context, in *api.ResolveExternalCommentRequest) (*api.ExternalRootBridgeResponse, error) {
+			if err := ensureAttributedWriteAllowed(ctx); err != nil {
+				return nil, err
+			}
+			if cfg.ExternalRootService == nil {
+				return nil, externalRootUnavailable()
+			}
+			// Pending-comment resolution is lifecycle cleanup, exactly like
+			// unbind: it must remain available after project archival so an
+			// operator can clear the pending state, unbind, and satisfy the
+			// project-purge guard without restoring the project.
+			issue, err := resolveIssueRef(ctx, cfg.DB, in.ProjectID, in.Ref, db.IncludeDeletedNo)
+			if err != nil {
+				return nil, err
+			}
+			binding, err := cfg.DB.ExternalRootBindingByIssue(ctx, issue.ID)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			if binding.ProjectID != in.ProjectID || binding.IssueID != issue.ID {
+				return nil, api.NewError(http.StatusNotFound, "bridge_not_found", "external root bridge not found", "", nil)
+			}
+			actor, err := attributedActor(ctx, in.Body.Actor)
+			if err != nil {
+				return nil, err
+			}
+			_, _, callErr := cfg.ExternalRootService.ResolvePendingComment(ctx, rootbridge.ResolvePendingCommentParams{
+				IssueID: issue.ID, Actor: actor, Action: in.Body.Action, ExternalCommentID: in.Body.ExternalCommentID,
+			})
+			if callErr != nil {
+				return nil, externalRootHandlerError(callErr)
+			}
+			if cfg.ExternalRootWake != nil {
+				cfg.ExternalRootWake(binding.ID)
+			}
+			current, err := cfg.DB.ExternalRootBindingByID(ctx, binding.ID)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			out, err := externalRootBridgeOut(ctx, cfg.DB, current)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return &api.ExternalRootBridgeResponse{Body: out}, nil
+		})
+
+	huma.Register(humaAPI, huma.Operation{OperationID: "unbindExternalRoot", Method: http.MethodDelete, Path: "/api/v1/projects/{project_id}/issues/{ref}/bridge"},
+		func(ctx context.Context, in *api.ExternalRootIssueRequest) (*api.ExternalRootBridgeResponse, error) {
+			if err := ensureAttributedWriteAllowed(ctx); err != nil {
+				return nil, err
+			}
+			if cfg.ExternalRootService == nil {
+				return nil, externalRootUnavailable()
+			}
+			// Unbind is lifecycle cleanup and must remain available after project
+			// archival so an operator can satisfy the project-purge guard.
+			issue, err := resolveIssueRef(ctx, cfg.DB, in.ProjectID, in.Ref, db.IncludeDeletedNo)
+			if err != nil {
+				return nil, err
+			}
+			binding, err := cfg.DB.ExternalRootBindingByIssue(ctx, issue.ID)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			if binding.ProjectID != in.ProjectID || binding.IssueID != issue.ID {
+				return nil, api.NewError(http.StatusNotFound, "bridge_not_found", "external root bridge not found", "", nil)
+			}
+			actor, err := attributedActor(ctx, in.Actor)
+			if err != nil {
+				return nil, err
+			}
+			binding, _, err = cfg.ExternalRootService.Unbind(ctx, issue.ID, actor)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			out, err := externalRootBridgeOut(ctx, cfg.DB, binding)
+			if err != nil {
+				return nil, externalRootHandlerError(err)
+			}
+			return &api.ExternalRootBridgeResponse{Body: out}, nil
+		})
+}
+
+func connectorOut(snapshot rootbridge.InstanceSnapshot) api.ConnectorOut {
+	return api.ConnectorOut{
+		InstanceID: snapshot.ID, ConnectorID: snapshot.ConnectorID, DisplayName: snapshot.DisplayName,
+		Protocol: snapshot.Protocol, AccountIdentity: snapshot.AccountIdentity,
+		Capabilities: append([]connector.Capability(nil), snapshot.Capabilities...),
+		Healthy:      snapshot.HealthError == "" && snapshot.ConnectorID != "", HealthError: snapshot.HealthError,
+	}
+}
+
+func externalRootBridgeOut(ctx context.Context, store db.Storage, binding db.ExternalRootBinding) (api.ExternalRootBridgeOut, error) {
+	out := api.ExternalRootBridgeOut{
+		ID: binding.ID, UID: binding.UID, ProjectID: binding.ProjectID, IssueID: binding.IssueID,
+		ConnectorInstance: binding.ConnectorInstance, Active: binding.Active, Enabled: binding.Enabled,
+		ReceiveComments: binding.ReceiveComments, PublishComments: binding.PublishComments,
+		CompleteExternal: binding.CompleteExternal, PausedReason: binding.PausedReason,
+		LastAttemptAt: binding.LastAttemptAt, LastSuccessAt: binding.LastSuccessAt,
+		LastErrorAt: binding.LastErrorAt, LastError: db.SafeExternalRootError(binding.LastError),
+		ConsecutiveFailures: binding.ConsecutiveFailures, NextAttemptAt: binding.NextAttemptAt,
+		LastExternalState: binding.LastExternalState, PendingCommentUID: binding.PendingCommentUID,
+	}
+	states, err := store.ExternalFieldStates(ctx, binding.ID)
+	if err != nil {
+		return api.ExternalRootBridgeOut{}, err
+	}
+	mappings, err := store.ListExternalFieldMappings(ctx, binding.ConnectorInstance)
+	if err != nil {
+		return api.ExternalRootBridgeOut{}, err
+	}
+	byID := make(map[int64]string, len(mappings))
+	for _, mapping := range mappings {
+		if mapping.Active {
+			byID[mapping.ID] = mapping.KataField
+		}
+	}
+	for _, state := range states {
+		kataField, active := byID[state.MappingID]
+		if !state.Conflicted || !active {
+			continue
+		}
+		kataCandidate, err := externalFieldCandidateOut(state.ConflictKata)
+		if err != nil {
+			return api.ExternalRootBridgeOut{}, err
+		}
+		externalCandidate, err := externalFieldCandidateOut(state.ConflictExternal)
+		if err != nil {
+			return api.ExternalRootBridgeOut{}, err
+		}
+		out.FieldConflicts = append(out.FieldConflicts, api.ExternalFieldConflictOut{
+			KataField: kataField, KataCandidate: kataCandidate,
+			ExternalCandidate: externalCandidate, ConflictAt: state.ConflictAt,
+		})
+	}
+	return out, nil
+}
+
+func externalFieldCandidateOut(raw json.RawMessage) (*api.ExternalFieldCandidateOut, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var candidate api.ExternalFieldCandidateOut
+	if err := json.Unmarshal(raw, &candidate); err != nil || strings.TrimSpace(candidate.Kind) == "" {
+		return nil, fmt.Errorf("decode external field conflict candidate")
+	}
+	return &candidate, nil
+}
+
+func runResultOut(bridge api.ExternalRootBridgeOut, result rootbridge.RunResult) api.ExternalRootRunOut {
+	return api.ExternalRootRunOut{
+		Bridge: bridge, RootUpdated: result.RootUpdated, CommentsCreated: result.CommentsCreated,
+		CommentsEdited: result.CommentsEdited, FieldConflicts: result.FieldConflicts,
+		CompletionRequests: result.CompletionRequests, ReopenRequests: result.ReopenRequests, Paused: result.Paused,
+	}
+}
+
+func deliverExternalRootEvents(cfg ServerConfig, events []db.Event) {
+	for i := range events {
+		event := events[i]
+		cfg.Broadcaster.Broadcast(StreamMsg{Kind: "event", Event: &event, ProjectID: event.ProjectID})
+		cfg.Hooks.Enqueue(event)
+	}
+}
+
+func externalRootUnavailable() error {
+	return api.NewError(http.StatusServiceUnavailable, "connector_unavailable", "external root connector service is unavailable", "", nil)
+}
+
+func externalRootHandlerError(err error) error {
+	switch {
+	case errors.Is(err, db.ErrNotFound), errors.Is(err, rootbridge.ErrConnectorInstanceNotFound):
+		return api.NewError(http.StatusNotFound, "bridge_not_found", "external root bridge not found", "", nil)
+	case errors.Is(err, db.ErrExternalRootValidation), errors.Is(err, db.ErrExternalFieldMappingValidation):
+		return api.NewError(http.StatusBadRequest, "validation", "external root request is invalid", "", nil)
+	case errors.Is(err, rootbridge.ErrExternalFieldAmbiguous):
+		return api.NewError(http.StatusBadRequest, "validation", "external root request is invalid", "", nil)
+	case errors.Is(err, rootbridge.ErrExternalFieldNotFound):
+		return api.NewError(http.StatusNotFound, "external_field_not_found", "external field was not found", "", nil)
+	case errors.Is(err, db.ErrFederatedReadOnly):
+		return federationReadOnlyError(db.ErrFederatedReadOnly)
+	case errors.Is(err, db.ErrExternalRootIssueAlreadyBound),
+		errors.Is(err, db.ErrExternalRootAlreadyBound),
+		errors.Is(err, db.ErrExternalRootIssueSyncConflict),
+		errors.Is(err, db.ErrExternalRootClaimActive),
+		errors.Is(err, rootbridge.ErrConnectorIdentityChanged):
+		return api.NewError(http.StatusConflict, "external_root_conflict", "external root operation conflicts with an existing binding or connector identity", "", nil)
+	case errors.Is(err, db.ErrExternalRootClaimLost):
+		return api.NewError(http.StatusConflict, "external_root_claim_lost", "external root bridge is busy or unavailable", "", nil)
+	case errors.Is(err, rootbridge.ErrPendingCommentResolutionRequired), errors.Is(err, db.ErrExternalCommentPending):
+		return api.NewError(http.StatusConflict, "external_comment_pending", "external comment requires explicit resolution", "", nil)
+	case errors.Is(err, rootbridge.ErrFieldConflictChanged), errors.Is(err, db.ErrExternalFieldNotConflicted):
+		return api.NewError(http.StatusConflict, "external_field_conflict", "external field conflict changed", "", nil)
+	case errors.Is(err, rootbridge.ErrCommentPublishingUnavailable),
+		errors.Is(err, rootbridge.ErrFieldSynchronizationUnavailable):
+		return api.NewError(http.StatusConflict, "external_root_conflict", "external root operation conflicts with connector capabilities", "", nil)
+	case errors.Is(err, connectorclient.ErrRequestTimeout):
+		return api.NewError(http.StatusBadGateway, "connector_error", connectorclient.ErrRequestTimeout.Error(), "", nil)
+	case errors.Is(err, connectorclient.ErrProtocolFailure):
+		return api.NewError(http.StatusBadGateway, "connector_error", connectorclient.ErrProtocolFailure.Error(), "", nil)
+	case errors.Is(err, connectorclient.ErrProcessFailure):
+		return api.NewError(http.StatusBadGateway, "connector_error", connectorclient.ErrProcessFailure.Error(), "", nil)
+	case errors.Is(err, rootbridge.ErrConnectorCall):
+		return api.NewError(http.StatusBadGateway, "connector_error", "external connector request failed", "", nil)
+	default:
+		if _, ok := errors.AsType[*connector.Error](err); ok {
+			return api.NewError(http.StatusBadGateway, "connector_error", "external connector request failed", "", nil)
+		}
+		return api.NewError(http.StatusInternalServerError, "internal", "internal server error", "", nil)
+	}
+}

--- a/internal/daemon/handlers_external_roots_functional_test.go
+++ b/internal/daemon/handlers_external_roots_functional_test.go
@@ -1,0 +1,716 @@
+package daemon_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/config"
+	connectorclient "go.kenn.io/kata/internal/connector"
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/rootbridge"
+	"go.kenn.io/kata/pkg/connector"
+)
+
+func testExternalRootCommand(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "example-connector")
+}
+
+func TestExternalRootHandlersFullLifecycleAndDelivery(t *testing.T) {
+	database := openTestDB(t)
+	project, err := database.db.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := database.db.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "Local title", Body: "Local body", Author: "tester",
+	})
+	require.NoError(t, err)
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	client := &daemonExternalRootClient{
+		description: connector.Description{
+			ConnectorID: "example.connector", DisplayName: "Example connector",
+			Protocol: connector.ProtocolVersion, AccountIdentity: "account-1",
+			Capabilities: []connector.Capability{
+				connector.CapabilityPublishComment,
+				connector.CapabilityFields,
+				connector.CapabilityConditionalFields,
+			},
+			SelfActorID: "self-1",
+		},
+		root: connector.Root{
+			Key: "root-1", IdentityKey: "account-1", Title: "External title", Body: "External body",
+			State: "open", Revision: "revision-1", UpdatedAt: now, ObservedAt: now,
+		},
+		fields: []connector.FieldDescriptor{{
+			ID: "start-date", DisplayName: "Start date", AcceptedKinds: []string{"date"},
+			Nullable: true, Writable: true, SchemaRevision: "schema-1",
+		}},
+		fieldValues: map[string]connector.FieldValue{},
+	}
+	registry, err := rootbridge.NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "example-connector", Command: testExternalRootCommand(t), Args: []string{"--mode", "private-arg"},
+		Settings: map[string]any{"token": "private-setting"}, Env: map[string]string{"TOKEN": "PRIVATE_ENV"},
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	reconciler := rootbridge.NewReconciler(database.db, registry, rootbridge.ReconcilerConfig{Now: func() time.Time { return now }})
+	broadcaster := daemon.NewEventBroadcaster()
+	sub := broadcaster.Subscribe(daemon.SubFilter{ProjectID: project.ID})
+	t.Cleanup(sub.Unsub)
+	hookSink := &recordingSink{}
+	eventSink := func(event db.Event) {
+		broadcaster.Broadcast(daemon.StreamMsg{Kind: "event", Event: &event, ProjectID: event.ProjectID})
+		hookSink.Enqueue(event)
+	}
+	service := rootbridge.NewServiceWithEventSink(
+		database.db,
+		registry,
+		func(ctx context.Context, bindingID int64, claimToken string) ([]db.Event, error) {
+			result, err := reconciler.Run(ctx, bindingID, rootbridge.RunOptions{
+				ClaimToken: claimToken,
+				EventSink:  eventSink,
+			})
+			return result.Events, err
+		},
+		eventSink,
+	)
+	var wakeMu sync.Mutex
+	var wakes []int64
+	committedAtWake := true
+	wake := func(bindingID int64) {
+		wakeMu.Lock()
+		defer wakeMu.Unlock()
+		wakes = append(wakes, bindingID)
+		binding, readErr := database.db.ExternalRootBindingByID(t.Context(), bindingID)
+		if readErr != nil || binding.ClaimToken != "" {
+			committedAtWake = false
+		}
+	}
+	ts := startTestServer(t, daemon.ServerConfig{
+		DB: database.db, StartedAt: now, Broadcaster: broadcaster, Hooks: hookSink,
+		ExternalRootRegistry: registry, ExternalRootService: service,
+		ExternalRootReconciler: reconciler, ExternalRootWake: wake,
+	})
+
+	status, body := requestExternalRootJSON(t, ts.URL, http.MethodGet, "/api/v1/connectors", nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.Contains(t, string(body), `"instance_id":"example-connector"`)
+	assert.Contains(t, string(body), `"connector_id":"example.connector"`)
+	assert.Contains(t, string(body), `"healthy":true`)
+	assert.NotContains(t, string(body), "private-setting")
+	assert.NotContains(t, string(body), "private-arg")
+	assert.NotContains(t, string(body), "PRIVATE_ENV")
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodGet, "/api/v1/connectors/example-connector", nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.Contains(t, string(body), `"connector_id":"example.connector"`)
+	assert.NotContains(t, string(body), "private-setting")
+	assert.NotContains(t, string(body), "private-arg")
+	assert.NotContains(t, string(body), "PRIVATE_ENV")
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodGet, "/api/v1/connectors/example-connector/fields", nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.Contains(t, string(body), `"id":"start-date"`)
+
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPut, "/api/v1/connectors/example-connector/fields/scheduled_on", map[string]any{"external_field": "start-date"})
+	require.Equal(t, http.StatusOK, status, string(body))
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodDelete, "/api/v1/connectors/example-connector/fields/scheduled_on", nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+
+	bridgePath := fmt.Sprintf("/api/v1/projects/%d/issues/%s/bridge", project.ID, issue.ShortID)
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath, map[string]any{
+		"connector": "example-connector", "external": "opaque-locator", "actor": "operator", "publish_comments": true,
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.NotContains(t, string(body), "account-1")
+	assert.NotContains(t, string(body), "root-1")
+	binding, err := database.db.ExternalRootBindingByIssue(t.Context(), issue.ID)
+	require.NoError(t, err)
+	wakeMu.Lock()
+	assert.Contains(t, wakes, binding.ID)
+	assert.True(t, committedAtWake)
+	wakeMu.Unlock()
+	assert.Contains(t, eventTypesFromSink(hookSink.snapshot()), "issue.external_root_bound")
+	require.Eventually(t, func() bool {
+		select {
+		case msg := <-sub.Ch:
+			return msg.Event != nil && msg.Event.Type == "issue.external_root_bound"
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodGet, bridgePath, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	client.readStarted = make(chan struct{})
+	client.readRelease = make(chan struct{})
+	type manualResponse struct {
+		status int
+		body   []byte
+		err    error
+	}
+	manualDone := make(chan manualResponse, 1)
+	go func() {
+		encoded := bytes.NewBufferString(`{"actor":"operator"}`)
+		request, requestErr := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+bridgePath+"/actions/reconcile", encoded)
+		if requestErr != nil {
+			manualDone <- manualResponse{err: requestErr}
+			return
+		}
+		request.Header.Set("Content-Type", "application/json")
+		response, requestErr := http.DefaultClient.Do(request)
+		if requestErr != nil {
+			manualDone <- manualResponse{err: requestErr}
+			return
+		}
+		defer func() { _ = response.Body.Close() }()
+		responseBody, readErr := io.ReadAll(response.Body)
+		manualDone <- manualResponse{status: response.StatusCode, body: responseBody, err: readErr}
+	}()
+	select {
+	case <-client.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("manual reconcile did not reach connector read")
+	}
+	select {
+	case early := <-manualDone:
+		t.Fatalf("long-running manual reconcile returned before connector completed: %#v", early)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(client.readRelease)
+	manual := <-manualDone
+	require.NoError(t, manual.err)
+	require.Equal(t, http.StatusOK, manual.status, string(manual.body))
+	client.readStarted = nil
+	client.readRelease = nil
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, "/api/v1/connectors/example-connector/actions/reconcile-root", map[string]any{"root_key": "root-1"})
+	require.Equal(t, http.StatusOK, status, string(body))
+	status, missingBody := requestExternalRootJSON(t, ts.URL, http.MethodPost, "/api/v1/connectors/other/actions/reconcile-root", map[string]any{"root_key": "root-1"})
+	require.Equal(t, http.StatusNotFound, status, string(missingBody))
+	status, otherMissingBody := requestExternalRootJSON(t, ts.URL, http.MethodPost, "/api/v1/connectors/example-connector/actions/reconcile-root", map[string]any{"root_key": "missing-root"})
+	require.Equal(t, http.StatusNotFound, status, string(otherMissingBody))
+	assert.Equal(t, string(missingBody), string(otherMissingBody))
+
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPut, "/api/v1/connectors/example-connector/fields/scheduled_on", map[string]any{"external_field": "start-date"})
+	require.Equal(t, http.StatusOK, status, string(body))
+	beforeRetained := len(hookSink.snapshot())
+	client.root.Title = "External title after retry"
+	client.root.Revision = "revision-2"
+	client.listFieldsErr = errors.New("opaque connector diagnostic")
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath+"/actions/reconcile", map[string]any{"actor": "operator"})
+	require.Equal(t, http.StatusBadGateway, status, string(body))
+	assert.NotContains(t, string(body), "opaque connector diagnostic")
+	require.Greater(t, len(hookSink.snapshot()), beforeRetained, "committed projection events must survive a later connector error")
+	client.listFieldsErr = nil
+	_, err = database.db.PatchIssueMetadata(t.Context(), db.PatchIssueMetadataIn{
+		IssueID: issue.ID, Actor: "operator", Patch: map[string]json.RawMessage{"scheduled_on": json.RawMessage(`"2026-08-21"`)},
+	})
+	require.NoError(t, err)
+	client.fieldValues["start-date"] = connector.FieldValue{Kind: "date", Value: "2026-08-22"}
+	mappings, err := database.db.ListExternalFieldMappings(t.Context(), "example-connector")
+	require.NoError(t, err)
+	activeMapping := mappings[len(mappings)-1]
+	claimed, ok, err := database.db.ClaimExternalRootBindingForManualReconcile(t.Context(), binding.ID, "field-claim", now, now.Add(-5*time.Minute))
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, _, err = database.db.UpsertExternalFieldState(t.Context(), db.ExternalFieldStateParams{
+		BindingID: binding.ID, MappingID: activeMapping.ID, ClaimToken: claimed.ClaimToken,
+		Baseline:         json.RawMessage(`{"kind":"date","value":"2026-08-20"}`),
+		ConflictKata:     json.RawMessage(`{"kind":"date","value":"2026-08-21"}`),
+		ConflictExternal: json.RawMessage(`{"kind":"date","value":"2026-08-22"}`),
+		Conflicted:       true, At: now, Actor: "connector:example-connector",
+	})
+	require.NoError(t, err)
+	_, err = database.db.ReleaseExternalRootClaim(t.Context(), binding.ID, claimed.ClaimToken)
+	require.NoError(t, err)
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodGet, bridgePath, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.Contains(t, string(body), `"kata_candidate":{"kind":"date","value":"2026-08-21"}`)
+	assert.Contains(t, string(body), `"external_candidate":{"kind":"date","value":"2026-08-22"}`)
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodDelete, "/api/v1/connectors/example-connector/fields/scheduled_on", nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodGet, bridgePath, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.NotContains(t, string(body), `"field_conflicts"`, "unmapping must hide historical conflicts")
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPut, "/api/v1/connectors/example-connector/fields/scheduled_on", map[string]any{"external_field": "start-date"})
+	require.Equal(t, http.StatusOK, status, string(body))
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodGet, bridgePath, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.NotContains(t, string(body), `"field_conflicts"`, "remapping must not expose a prior revision's conflict")
+	mappings, err = database.db.ListExternalFieldMappings(t.Context(), "example-connector")
+	require.NoError(t, err)
+	activeMapping = mappings[len(mappings)-1]
+	claimed, ok, err = database.db.ClaimExternalRootBindingForManualReconcile(t.Context(), binding.ID, "remapped-field-claim", now, now.Add(-5*time.Minute))
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, _, err = database.db.UpsertExternalFieldState(t.Context(), db.ExternalFieldStateParams{
+		BindingID: binding.ID, MappingID: activeMapping.ID, ClaimToken: claimed.ClaimToken,
+		Baseline:         json.RawMessage(`{"kind":"date","value":"2026-08-20"}`),
+		ConflictKata:     json.RawMessage(`{"kind":"date","value":"2026-08-21"}`),
+		ConflictExternal: json.RawMessage(`{"kind":"date","value":"2026-08-22"}`),
+		Conflicted:       true, At: now, Actor: "connector:example-connector",
+	})
+	require.NoError(t, err)
+	_, err = database.db.ReleaseExternalRootClaim(t.Context(), binding.ID, claimed.ClaimToken)
+	require.NoError(t, err)
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath+"/actions/resolve-field", map[string]any{
+		"kata_field": "scheduled_on", "use": "kata", "actor": "operator",
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.Equal(t, "2026-08-21", client.fieldValues["start-date"].Value)
+
+	local, _, err := database.db.CreateComment(t.Context(), db.CreateCommentParams{IssueID: issue.ID, Author: "operator", Body: "Adopt me"})
+	require.NoError(t, err)
+	claimed, ok, err = database.db.ClaimExternalRootBindingForManualReconcile(t.Context(), binding.ID, "pending-claim", now, now.Add(-5*time.Minute))
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, err = database.db.SetPendingExternalComment(t.Context(), db.SetPendingExternalCommentParams{
+		BindingID: binding.ID, ClaimToken: claimed.ClaimToken, CommentUID: local.UID, At: now,
+	})
+	require.NoError(t, err)
+	_, _, err = database.db.PauseExternalRootBinding(t.Context(), db.ExternalRootActionParams{BindingID: binding.ID, Actor: "operator", Reason: "operator_pause"})
+	require.NoError(t, err)
+	client.comments = []connector.Comment{{
+		ID: "external-comment-1", Revision: "comment-revision-1", Body: local.Body,
+		Author:    connector.Actor{ID: "self-1"},
+		CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second),
+	}}
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath+"/actions/resolve-comment", map[string]any{
+		"action": "adopt", "external_comment_id": "external-comment-1", "actor": "operator",
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.Contains(t, string(body), `"enabled":false`)
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath+"/actions/resume", map[string]any{"actor": "operator"})
+	require.Equal(t, http.StatusOK, status, string(body))
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath+"/actions/pause", map[string]any{"actor": "operator", "reason": "operator_pause"})
+	require.Equal(t, http.StatusOK, status, string(body))
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath+"/actions/resume", map[string]any{"actor": "operator"})
+	require.Equal(t, http.StatusOK, status, string(body))
+	_, _, err = database.db.RemoveProject(t.Context(), db.RemoveProjectParams{
+		ProjectID: project.ID, Actor: "operator", Force: true,
+	})
+	require.NoError(t, err)
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodDelete, bridgePath+"?actor=operator", nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+	assert.Contains(t, string(body), `"active":false`)
+}
+
+func TestExternalRootHandlersClassifyFieldAndPublishingErrors(t *testing.T) {
+	database := openTestDB(t)
+	project, err := database.db.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := database.db.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "Local title", Author: "tester",
+	})
+	require.NoError(t, err)
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	client := &daemonExternalRootClient{
+		description: connector.Description{
+			ConnectorID: "example.connector", DisplayName: "Example connector",
+			Protocol: connector.ProtocolVersion, AccountIdentity: "account-1",
+			Capabilities: []connector.Capability{
+				connector.CapabilityPublishComment,
+				connector.CapabilityFields,
+				connector.CapabilityConditionalFields,
+			},
+			SelfActorID: "self-1",
+		},
+		root: connector.Root{
+			Key: "root-1", IdentityKey: "account-1", Title: "External title", State: "open",
+			Revision: "revision-1", UpdatedAt: now, ObservedAt: now,
+		},
+		fields: []connector.FieldDescriptor{
+			{ID: "start-date", DisplayName: "Start date", AcceptedKinds: []string{"date"}, Nullable: true, Writable: true, SchemaRevision: "schema-1"},
+			{ID: "readonly-text", DisplayName: "Read only", AcceptedKinds: []string{"string"}, Nullable: false, Writable: false, SchemaRevision: "schema-1"},
+		},
+		fieldValues: map[string]connector.FieldValue{},
+	}
+	registry, err := rootbridge.NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "example-connector", Command: testExternalRootCommand(t),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	reconciler := rootbridge.NewReconciler(database.db, registry, rootbridge.ReconcilerConfig{Now: func() time.Time { return now }})
+	service := rootbridge.NewService(database.db, registry,
+		func(ctx context.Context, bindingID int64, claimToken string) ([]db.Event, error) {
+			result, err := reconciler.Run(ctx, bindingID, rootbridge.RunOptions{ClaimToken: claimToken})
+			return result.Events, err
+		})
+	ts := startTestServer(t, daemon.ServerConfig{
+		DB: database.db, StartedAt: now, ExternalRootRegistry: registry,
+		ExternalRootService: service, ExternalRootReconciler: reconciler,
+	})
+
+	status, body := requestExternalRootJSON(t, ts.URL, http.MethodPut,
+		"/api/v1/connectors/example-connector/fields/scheduled_on", map[string]any{"external_field": "missing-private-selector"})
+	assert.Equal(t, http.StatusNotFound, status, string(body))
+	assert.Contains(t, string(body), `"code":"external_field_not_found"`)
+	assert.NotContains(t, string(body), "missing-private-selector")
+
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPut,
+		"/api/v1/connectors/example-connector/fields/unsupported_field", map[string]any{"external_field": "start-date"})
+	assert.Equal(t, http.StatusBadRequest, status, string(body))
+	assert.Contains(t, string(body), `"code":"validation"`)
+	assert.NotContains(t, string(body), "unsupported_field")
+
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPut,
+		"/api/v1/connectors/example-connector/fields/scheduled_on", map[string]any{"external_field": "readonly-text"})
+	assert.Equal(t, http.StatusBadRequest, status, string(body))
+	assert.Contains(t, string(body), `"code":"validation"`)
+	assert.NotContains(t, string(body), "readonly-text")
+
+	bridgePath := fmt.Sprintf("/api/v1/projects/%d/issues/%s/bridge", project.ID, issue.ShortID)
+	client.description.Capabilities = []connector.Capability{
+		connector.CapabilityFields,
+		connector.CapabilityConditionalFields,
+	}
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath, map[string]any{
+		"connector": "example-connector", "external": "opaque-private-locator", "actor": "operator", "publish_comments": true,
+	})
+	assert.Equal(t, http.StatusConflict, status, string(body))
+	assert.Contains(t, string(body), `"code":"external_root_conflict"`)
+	assert.NotContains(t, string(body), "opaque-private-locator")
+
+	client.description.Capabilities = []connector.Capability{
+		connector.CapabilityPublishComment,
+		connector.CapabilityFields,
+		connector.CapabilityConditionalFields,
+	}
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath, map[string]any{
+		"connector": "example-connector", "external": "opaque-locator", "actor": "operator", "publish_comments": true,
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath+"/actions/pause", map[string]any{
+		"actor": "operator", "reason": "operator_pause",
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+	client.description.Capabilities = []connector.Capability{
+		connector.CapabilityFields,
+		connector.CapabilityConditionalFields,
+	}
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodPost, bridgePath+"/actions/resume", map[string]any{"actor": "operator"})
+	assert.Equal(t, http.StatusConflict, status, string(body))
+	assert.Contains(t, string(body), `"code":"external_root_conflict"`)
+}
+
+func TestExternalRootHandlersClassifyConnectorAndInternalFailures(t *testing.T) {
+	const rawDiagnostic = "opaque child path stderr credential detail"
+	for _, tc := range []struct {
+		name    string
+		err     error
+		message string
+	}{
+		{
+			name:    "typed connector error",
+			err:     &connector.Error{Code: "remote_failed", Message: rawDiagnostic},
+			message: "external connector request failed",
+		},
+		{
+			name:    "process execution error",
+			err:     errors.Join(connectorclient.ErrProcessFailure, errors.New(rawDiagnostic)),
+			message: "external connector process failed",
+		},
+		{
+			name:    "unsupported protocol",
+			err:     errors.Join(connectorclient.ErrProtocolFailure, errors.New(rawDiagnostic)),
+			message: "external connector protocol failed",
+		},
+		{
+			name:    "child timeout",
+			err:     errors.Join(connectorclient.ErrRequestTimeout, context.DeadlineExceeded, errors.New(rawDiagnostic)),
+			message: "external connector request timed out",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database := openTestDB(t)
+			client := &daemonExternalRootClient{
+				description: connector.Description{
+					ConnectorID: "example.connector", DisplayName: "Example connector",
+					Protocol: connector.ProtocolVersion, AccountIdentity: "account-1",
+					Capabilities: []connector.Capability{
+						connector.CapabilityFields,
+						connector.CapabilityConditionalFields,
+					},
+				},
+				listFieldsErr: tc.err,
+			}
+			registry, err := rootbridge.NewRegistry(t.Context(), []config.ConnectorConfig{{
+				ID: "example-connector", Command: testExternalRootCommand(t),
+			}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+			require.NoError(t, err)
+			ts := startTestServer(t, daemon.ServerConfig{
+				DB: database.db, StartedAt: database.now, ExternalRootRegistry: registry,
+			})
+
+			status, body := requestExternalRootJSON(t, ts.URL, http.MethodGet, "/api/v1/connectors/example-connector/fields", nil)
+			assertAPIError(t, status, body, http.StatusBadGateway, "connector_error")
+			assert.Contains(t, string(body), `"message":"`+tc.message+`"`)
+			assert.NotContains(t, string(body), rawDiagnostic)
+			assert.NotContains(t, string(body), "opaque")
+		})
+	}
+
+	for _, tc := range []struct {
+		name      string
+		states    []db.ExternalFieldState
+		statesErr error
+		private   string
+	}{
+		{name: "projection storage error", statesErr: errors.New("opaque storage detail"), private: "opaque storage detail"},
+		{name: "context cancellation", statesErr: context.Canceled},
+		{
+			name: "malformed persisted field candidate",
+			states: []db.ExternalFieldState{{
+				BindingID: 1, MappingID: 1, Conflicted: true,
+				ConflictKata: json.RawMessage(`{"kind":`),
+			}},
+			private: `{"kind":`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database := openTestDB(t)
+			project, err := database.db.CreateProject(t.Context(), "example-project")
+			require.NoError(t, err)
+			issue, _, err := database.db.CreateIssue(t.Context(), db.CreateIssueParams{
+				ProjectID: project.ID, Title: "Local title", Author: "tester",
+			})
+			require.NoError(t, err)
+			binding, _, err := database.db.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+				ProjectID: project.ID, IssueID: issue.ID, ConnectorInstance: "example-connector",
+				ExternalRootKey: "root-1", ExternalAccountKey: "account-1", Actor: "tester",
+				ReceiveCommentsAfter: database.now,
+			})
+			require.NoError(t, err)
+			states := append([]db.ExternalFieldState(nil), tc.states...)
+			if len(states) > 0 {
+				mapping, mapErr := database.db.UpsertExternalFieldMapping(t.Context(), db.ExternalFieldMappingParams{
+					ConnectorInstance: "example-connector", KataField: "scheduled_on",
+					ExternalFieldID: "schedule", ExternalFieldName: "Schedule",
+					AcceptedKinds: []string{"date"}, Nullable: true, Writable: true, SchemaRevision: "schema-1",
+				})
+				require.NoError(t, mapErr)
+				for i := range states {
+					states[i].MappingID = mapping.ID
+				}
+			}
+			for i := range states {
+				states[i].BindingID = binding.ID
+			}
+			store := &externalRootProjectionFailureStore{
+				Storage: database.db, states: states, err: tc.statesErr,
+			}
+			ts := startTestServer(t, daemon.ServerConfig{DB: store, StartedAt: database.now})
+			path := fmt.Sprintf("/api/v1/projects/%d/issues/%s/bridge", project.ID, issue.ShortID)
+
+			status, body := requestExternalRootJSON(t, ts.URL, http.MethodGet, path, nil)
+			assertAPIError(t, status, body, http.StatusInternalServerError, "internal")
+			if tc.private != "" {
+				assert.NotContains(t, string(body), tc.private)
+			}
+		})
+	}
+}
+
+func requestExternalRootJSON(t *testing.T, baseURL, method, path string, body any) (int, []byte) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequestWithContext(t.Context(), method, baseURL+path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, response.Body.Close()) }()
+	responseBody, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	return response.StatusCode, responseBody
+}
+
+func eventTypesFromSink(events []db.Event) []string {
+	types := make([]string, len(events))
+	for i := range events {
+		types[i] = events[i].Type
+	}
+	return types
+}
+
+type daemonExternalRootClient struct {
+	description   connector.Description
+	root          connector.Root
+	comments      []connector.Comment
+	fields        []connector.FieldDescriptor
+	fieldValues   map[string]connector.FieldValue
+	listFieldsErr error
+	readStarted   chan struct{}
+	readRelease   chan struct{}
+	readOnce      sync.Once
+}
+
+type externalRootProjectionFailureStore struct {
+	db.Storage
+	states []db.ExternalFieldState
+	err    error
+}
+
+func (s *externalRootProjectionFailureStore) ExternalFieldStates(
+	context.Context,
+	int64,
+) ([]db.ExternalFieldState, error) {
+	return append([]db.ExternalFieldState(nil), s.states...), s.err
+}
+
+func (c *daemonExternalRootClient) Describe(context.Context) (connector.Description, error) {
+	return c.description, nil
+}
+func (c *daemonExternalRootClient) ResolveRoot(context.Context, connector.ResolveRootParams) (connector.Root, error) {
+	return c.root, nil
+}
+
+func (c *daemonExternalRootClient) ReadRoot(ctx context.Context, _ connector.ReadRootParams) (connector.Root, error) {
+	if c.readRelease != nil {
+		c.readOnce.Do(func() {
+			if c.readStarted != nil {
+				close(c.readStarted)
+			}
+		})
+		select {
+		case <-c.readRelease:
+		case <-ctx.Done():
+			return connector.Root{}, ctx.Err()
+		}
+	}
+	return c.root, nil
+}
+func (c *daemonExternalRootClient) ListComments(context.Context, connector.ListCommentsParams) (connector.ListCommentsResult, error) {
+	return connector.ListCommentsResult{Comments: c.comments}, nil
+}
+func (c *daemonExternalRootClient) CompleteRoot(context.Context, connector.CompleteRootParams) (connector.Root, error) {
+	c.root.State = "complete"
+	return c.root, nil
+}
+func (c *daemonExternalRootClient) PublishComment(context.Context, connector.PublishCommentParams) (connector.Comment, error) {
+	return connector.Comment{}, nil
+}
+func (c *daemonExternalRootClient) ListFields(context.Context) (connector.ListFieldsResult, error) {
+	return connector.ListFieldsResult{Fields: c.fields}, c.listFieldsErr
+}
+func (c *daemonExternalRootClient) ReadFields(_ context.Context, params connector.ReadFieldsParams) (connector.ReadFieldsResult, error) {
+	result := connector.ReadFieldsResult{Fields: map[string]connector.FieldValue{}}
+	for _, id := range params.FieldIDs {
+		if value, ok := c.fieldValues[id]; ok {
+			result.Fields[id] = value
+		}
+	}
+	return result, nil
+}
+func (c *daemonExternalRootClient) WriteFields(_ context.Context, params connector.WriteFieldsParams) (connector.WriteFieldsResult, error) {
+	maps.Copy(c.fieldValues, params.Fields)
+	return connector.WriteFieldsResult{Fields: params.Fields}, nil
+}
+
+// TestArchivedProjectPendingCommentCleanupCoversPurge exercises the full
+// cleanup chain after project archival: a pending publication must be
+// resolvable, the bridge unbindable, and the project purgeable, all without
+// restoring the project.
+func TestArchivedProjectPendingCommentCleanupCoversPurge(t *testing.T) {
+	database := openTestDB(t)
+	project, err := database.db.CreateProject(t.Context(), "archived-cleanup")
+	require.NoError(t, err)
+	issue, _, err := database.db.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "Archived cleanup", Author: "tester",
+	})
+	require.NoError(t, err)
+	comment, _, err := database.db.CreateComment(t.Context(), db.CreateCommentParams{
+		IssueID: issue.ID, Author: "tester", Body: "Pending publication",
+	})
+	require.NoError(t, err)
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	client := &daemonExternalRootClient{
+		description: connector.Description{
+			ConnectorID: "example.connector", DisplayName: "Example connector",
+			Protocol: connector.ProtocolVersion, AccountIdentity: "account-1",
+			Capabilities: []connector.Capability{connector.CapabilityPublishComment},
+			SelfActorID:  "self-1",
+		},
+	}
+	registry, err := rootbridge.NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "example-connector", Command: testExternalRootCommand(t),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	service := rootbridge.NewServiceWithEventSink(
+		database.db,
+		registry,
+		func(_ context.Context, _ int64, _ string) ([]db.Event, error) {
+			return nil, nil
+		},
+		func(db.Event) {},
+	)
+	ts := startTestServer(t, daemon.ServerConfig{
+		DB: database.db, StartedAt: now,
+		ExternalRootRegistry: registry, ExternalRootService: service,
+	})
+
+	binding, _, err := database.db.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: project.ID, IssueID: issue.ID,
+		ConnectorInstance: "example-connector",
+		ExternalRootKey:   "root-1", ExternalAccountKey: "account-1",
+		Actor: "tester", ReceiveCommentsAfter: now,
+		PublishComments: true, PublishCommentsAfter: &now,
+	})
+	require.NoError(t, err)
+	claimed, ok, err := database.db.ClaimExternalRootBinding(
+		t.Context(), binding.ID, "cleanup-claim", now, now.Add(-time.Minute),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, err = database.db.SetPendingExternalComment(t.Context(), db.SetPendingExternalCommentParams{
+		BindingID: binding.ID, ClaimToken: claimed.ClaimToken,
+		CommentUID: comment.UID, At: now,
+	})
+	require.NoError(t, err)
+
+	_, _, err = database.db.RemoveProject(t.Context(), db.RemoveProjectParams{
+		ProjectID: project.ID, Actor: "tester", Force: true,
+	})
+	require.NoError(t, err)
+
+	resolvePath := fmt.Sprintf("/api/v1/projects/%d/issues/%s/bridge/actions/resolve-comment",
+		project.ID, issue.ShortID)
+	status, body := requestExternalRootJSON(t, ts.URL, http.MethodPost, resolvePath, map[string]any{
+		"action": "skip", "actor": "tester",
+	})
+	require.Equalf(t, http.StatusOK, status, "archived resolve-comment: %s", string(body))
+
+	unbindPath := fmt.Sprintf("/api/v1/projects/%d/issues/%s/bridge", project.ID, issue.ShortID)
+	status, body = requestExternalRootJSON(t, ts.URL, http.MethodDelete, unbindPath+"?actor=tester", nil)
+	require.Equalf(t, http.StatusOK, status, "archived unbind: %s", string(body))
+
+	purgePath := fmt.Sprintf("/api/v1/projects/%d/actions/purge", project.ID)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+purgePath,
+		strings.NewReader(`{"actor":"tester"}`))
+	req.Header.Set("Content-Type", "application/json")
+	require.NoError(t, err)
+	req.Header.Set("X-Kata-Confirm", "PURGE archived-cleanup")
+	resp, err := ts.Client().Do(req) //nolint:gosec // G704: test request to httptest server URL
+	require.NoError(t, err)
+	purgeBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "archived purge: %s", string(purgeBody))
+}

--- a/internal/daemon/handlers_external_roots_test.go
+++ b/internal/daemon/handlers_external_roots_test.go
@@ -1,0 +1,169 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/api"
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/rootbridge"
+)
+
+func splitRoute(t *testing.T, route string) (string, string) {
+	t.Helper()
+	parts := strings.SplitN(route, " ", 2)
+	require.Len(t, parts, 2)
+	return parts[0], parts[1]
+}
+
+func operationForMethod(item *huma.PathItem, method string) *huma.Operation {
+	switch method {
+	case http.MethodGet:
+		return item.Get
+	case http.MethodPut:
+		return item.Put
+	case http.MethodPost:
+		return item.Post
+	case http.MethodDelete:
+		return item.Delete
+	default:
+		return nil
+	}
+}
+
+func TestExternalRootRoutesRegisterExactOperationIDs(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+	want := map[string]string{
+		"GET /api/v1/connectors":                                                         "listConnectors",
+		"GET /api/v1/connectors/{instance}":                                              "getConnectorStatus",
+		"GET /api/v1/connectors/{instance}/fields":                                       "listConnectorFields",
+		"PUT /api/v1/connectors/{instance}/fields/{kata_field}":                          "mapConnectorField",
+		"DELETE /api/v1/connectors/{instance}/fields/{kata_field}":                       "unmapConnectorField",
+		"POST /api/v1/projects/{project_id}/issues/{ref}/bridge":                         "bindExternalRoot",
+		"GET /api/v1/projects/{project_id}/issues/{ref}/bridge":                          "getExternalRootBridge",
+		"POST /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/reconcile":       "reconcileExternalRootBridge",
+		"POST /api/v1/connectors/{instance}/actions/reconcile-root":                      "reconcileExternalRootByKey",
+		"POST /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/pause":           "pauseExternalRootBridge",
+		"POST /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resume":          "resumeExternalRootBridge",
+		"POST /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-field":   "resolveExternalField",
+		"POST /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-comment": "resolveExternalComment",
+		"DELETE /api/v1/projects/{project_id}/issues/{ref}/bridge":                       "unbindExternalRoot",
+	}
+	for route, operationID := range want {
+		method, path := splitRoute(t, route)
+		item := srv.API().OpenAPI().Paths[path]
+		require.NotNil(t, item, route)
+		operation := operationForMethod(item, method)
+		require.NotNil(t, operation, route)
+		assert.Equal(t, operationID, operation.OperationID)
+	}
+}
+
+func TestExternalRootOperationsAreRestrictedIntegrationAdministration(t *testing.T) {
+	for _, operationID := range []string{
+		"listConnectors", "getConnectorStatus", "listConnectorFields", "mapConnectorField", "unmapConnectorField",
+		"bindExternalRoot", "getExternalRootBridge", "reconcileExternalRootBridge", "reconcileExternalRootByKey",
+		"pauseExternalRootBridge", "resumeExternalRootBridge", "resolveExternalField", "resolveExternalComment", "unbindExternalRoot",
+	} {
+		policy, ok := hostOperationPolicy(operationID)
+		require.True(t, ok, operationID)
+		assert.Equal(t, hostOperationIntegrationAdministration, policy.Kind, operationID)
+		assert.True(t, policy.restricted, operationID)
+		if operationID != "listConnectors" && operationID != "getConnectorStatus" && operationID != "listConnectorFields" && operationID != "getExternalRootBridge" {
+			assert.True(t, policy.Mutation, operationID)
+		}
+	}
+}
+
+func TestListConnectorsResponseDoesNotExposeExecutableConfiguration(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/connectors", nil))
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "command")
+	assert.NotContains(t, rr.Body.String(), "settings")
+	assert.NotContains(t, rr.Body.String(), "environment")
+}
+
+func TestExternalRootAdministrationRejectsBrowserAndReadonlyPrincipals(t *testing.T) {
+	for _, ctx := range []context.Context{
+		withWebSession(context.Background(), Principal{Kind: PrincipalWebLocal, Actor: "operator"}),
+		withWebSession(context.Background(), Principal{Kind: PrincipalDBToken, Actor: "operator", TokenID: 7}),
+		WithPrincipal(context.Background(), Principal{Kind: PrincipalWebLocal, Actor: "operator"}),
+		WithPrincipal(context.Background(), Principal{Kind: PrincipalDBToken, Actor: "operator", TokenID: 7}),
+		WithPrincipal(context.Background(), Principal{Kind: PrincipalBootstrap}),
+		WithPrincipal(context.Background(), Principal{Kind: PrincipalTrustedProxy, Actor: "operator"}),
+		WithPrincipal(context.Background(), Principal{Kind: PrincipalTrustedProxyAbsent}),
+		withInsecureReadonlyRequest(context.Background()),
+	} {
+		err := ensureExternalRootAdministrationAllowed(ctx)
+		require.Error(t, err)
+		var apiErr interface{ GetStatus() int }
+		if errors.As(err, &apiErr) {
+			assert.Equal(t, http.StatusForbidden, apiErr.GetStatus())
+		}
+	}
+}
+
+func TestExternalRootAdministrationAllowsOwnerAndIntegrationPrincipals(t *testing.T) {
+	for _, ctx := range []context.Context{
+		context.Background(),
+		WithPrincipal(context.Background(), Principal{Kind: PrincipalStaticToken}),
+		WithPrincipal(context.Background(), Principal{Kind: PrincipalHost, Subject: "example-service"}),
+	} {
+		require.NoError(t, ensureExternalRootAdministrationAllowed(ctx))
+	}
+}
+
+func TestExternalRootHandlerErrorClassifiesExpectedConflicts(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "issue already bound", err: db.ErrExternalRootIssueAlreadyBound, code: "external_root_conflict"},
+		{name: "root already bound", err: db.ErrExternalRootAlreadyBound, code: "external_root_conflict"},
+		{name: "issue sync owns content", err: db.ErrExternalRootIssueSyncConflict, code: "external_root_conflict"},
+		{name: "bridge worker is active", err: db.ErrExternalRootClaimActive, code: "external_root_conflict"},
+		{name: "connector identity changed", err: rootbridge.ErrConnectorIdentityChanged, code: "external_root_conflict"},
+		{name: "fields capability unavailable", err: rootbridge.ErrFieldSynchronizationUnavailable, code: "external_root_conflict"},
+		{name: "federated spoke is read only", err: db.ErrFederatedReadOnly, code: "federated_read_only"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			classified := externalRootHandlerError(errors.Join(test.err, errors.New("private cause")))
+			var apiErr *api.APIError
+			require.ErrorAs(t, classified, &apiErr)
+			assert.Equal(t, http.StatusConflict, apiErr.Status)
+			assert.Equal(t, test.code, apiErr.Code)
+			assert.NotContains(t, apiErr.Message, "private cause")
+		})
+	}
+}
+
+func TestExternalRootAdministrationRejectsUnauthenticatedPrivateNetworkClient(t *testing.T) {
+	srv := NewServer(ServerConfig{Auth: config.AuthConfig{AllowUnauthenticatedPrivateNetworkWrites: true}})
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+	handler, err := srv.HandlerFor(ListenerPolicy{
+		Kind: ListenerSharedTCP, Origin: "http://100.64.0.5:7777", BackendAuthority: "100.64.0.5:7777",
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, "http://100.64.0.5:7777/api/v1/connectors", nil)
+	req.Host = "100.64.0.5:7777"
+	req.RemoteAddr = "100.64.0.10:23456"
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"integration_administration_forbidden"`)
+}

--- a/internal/daemon/handlers_imports.go
+++ b/internal/daemon/handlers_imports.go
@@ -75,6 +75,8 @@ func registerImportsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			Items:     items,
 		})
 		switch {
+		case errors.Is(err, db.ErrExternalRootContentOwned):
+			return nil, externalRootContentOwnedAPIError()
 		case errors.Is(err, db.ErrImportValidation):
 			return nil, api.NewError(400, "validation", err.Error(), "", nil)
 		case errors.Is(err, db.ErrFederatedReadOnly):

--- a/internal/daemon/handlers_imports_test.go
+++ b/internal/daemon/handlers_imports_test.go
@@ -171,6 +171,64 @@ func TestImportEndpoint_SourceNewerUpdatesIssue(t *testing.T) {
 	assert.Equal(t, "done", *issue.ClosedReason)
 }
 
+func TestImportEndpoint_ExternalRootContentOwnedReturnsNeutralConflict(t *testing.T) {
+	env := testenv.New(t)
+	project := createImportTestProject(t, env, "", "example-project")
+	initial := map[string]any{
+		"actor":  "importer",
+		"source": "example-import",
+		"items": []map[string]any{importEndpointItem(map[string]any{
+			"external_id": "bound-root",
+			"title":       "External root",
+			"body":        "External body",
+		})},
+	}
+	envPostJSON(t, env, importEndpointPath(project.ID), initial, &struct{}{})
+	mapping, err := env.DB.ImportMappingBySource(
+		context.Background(), project.ID, "example-import", "issue", "bound-root",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, mapping.IssueID)
+	issue, err := env.DB.IssueByID(context.Background(), *mapping.IssueID)
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateExternalRootBinding(context.Background(), db.CreateExternalRootBindingParams{
+		ProjectID: project.ID, IssueID: issue.ID, ConnectorInstance: "example-connector",
+		ExternalRootKey: "opaque-root-key", ExternalAccountKey: "opaque-account-key",
+		Actor: "tester", ReceiveCommentsAfter: time.Date(2026, 8, 20, 8, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	beforeEventID, err := env.DB.MaxEventID(context.Background())
+	require.NoError(t, err)
+
+	priority := int64(2)
+	changed := map[string]any{
+		"actor":  "importer",
+		"source": "example-import",
+		"items": []map[string]any{importEndpointItem(map[string]any{
+			"external_id": "bound-root",
+			"title":       "Forbidden imported title",
+			"body":        "Forbidden imported body",
+			"priority":    priority,
+			"updated_at":  "2026-05-01T11:00:00Z",
+		})},
+	}
+	resp, raw := envDoRaw(t, env, http.MethodPost, importEndpointPath(project.ID), changed, nil)
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "external_root_content_owned")
+	assert.Contains(t, string(raw), "kata bridge unbind")
+	assert.NotContains(t, string(raw), "example-connector")
+	assert.NotContains(t, string(raw), "opaque-root-key")
+	after, readErr := env.DB.IssueByID(context.Background(), issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, issue.Title, after.Title)
+	assert.Equal(t, issue.Body, after.Body)
+	assert.Equal(t, issue.Priority, after.Priority)
+	assert.Equal(t, issue.Revision, after.Revision)
+	afterEventID, readErr := env.DB.MaxEventID(context.Background())
+	require.NoError(t, readErr)
+	assert.Equal(t, beforeEventID, afterEventID)
+}
+
 func TestImportEndpoint_FederatedExistingIssueAllowsUnclaimedUpdate(t *testing.T) {
 	ctx := context.Background()
 	env := testenv.New(t)

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -579,11 +579,19 @@ func mapAtomicEditError(err error, issueShortID string, delta *api.LinksDelta) e
 		// Should not surface from the atomic path (set_parent replaces),
 		// but map cleanly if it ever does.
 		return api.NewError(409, "parent_already_set", err.Error(), "", nil)
+	case errors.Is(err, db.ErrExternalRootContentOwned):
+		return externalRootContentOwnedAPIError()
 	case errors.Is(err, db.ErrFederatedReadOnly):
 		return federationReadOnlyError(err)
 	default:
 		return internalAPIError(err)
 	}
+}
+
+func externalRootContentOwnedAPIError() error {
+	return api.NewError(409, "external_root_content_owned",
+		"the issue title and body are owned by an active external root binding",
+		"edit the external root or run kata bridge unbind <issue-ref> before editing title or body", nil)
 }
 
 // validateLinksDelta rejects deltas that are internally contradictory before

--- a/internal/daemon/handlers_issues_test.go
+++ b/internal/daemon/handlers_issues_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -439,6 +440,46 @@ func TestIssues_PatchEditTitleAndBody(t *testing.T) {
 		map[string]any{"actor": "x", "title": "new"})
 	require.Equal(t, 200, resp.StatusCode, string(bs))
 	assert.Contains(t, string(bs), `"title":"new"`)
+}
+
+func TestEditIssueExternalRootContentOwnedReturnsNeutralConflict(t *testing.T) {
+	env := testenv.New(t)
+	projectID := mkProject(t, env, "https://daemon.example/example-project", "example-project")
+	issue, _, err := env.DB.CreateIssue(context.Background(), db.CreateIssueParams{
+		ProjectID: projectID, Title: "External root", Body: "External body", Author: "tester",
+	})
+	require.NoError(t, err)
+	_, _, err = env.DB.CreateExternalRootBinding(context.Background(), db.CreateExternalRootBindingParams{
+		ProjectID: projectID, IssueID: issue.ID, ConnectorInstance: "example-connector",
+		ExternalRootKey: "opaque-root-key", ExternalAccountKey: "opaque-account-key",
+		Actor: "tester", ReceiveCommentsAfter: time.Date(2026, 8, 20, 8, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+
+	resp, raw := envDoRaw(t, env, http.MethodPatch,
+		projectPath(projectID)+"/issues/"+issue.ShortID,
+		map[string]any{"actor": "tester", "title": "Local replacement", "set_priority": 2}, nil)
+
+	assertAPIError(t, resp.StatusCode, raw, http.StatusConflict, "external_root_content_owned")
+	var envelope struct {
+		Error struct {
+			Hint string `json:"hint"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &envelope))
+	assert.Contains(t, envelope.Error.Hint, "kata bridge unbind <issue-ref>")
+	assert.NotContains(t, string(raw), "example-connector")
+	assert.NotContains(t, string(raw), "opaque-root-key")
+	stored, readErr := env.DB.IssueByID(context.Background(), issue.ID)
+	require.NoError(t, readErr)
+	assert.Equal(t, issue.Title, stored.Title)
+	assert.Nil(t, stored.Priority)
+	assert.Equal(t, issue.Revision, stored.Revision)
+
+	resp, raw = envDoRaw(t, env, http.MethodPatch,
+		projectPath(projectID)+"/issues/"+issue.ShortID,
+		map[string]any{"actor": "tester", "set_priority": 2}, nil)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "priority edit: %s", string(raw))
 }
 
 // TestEditIssue_FieldOnlyResponseOmitsChanges pins the wire contract that

--- a/internal/daemon/handlers_move_test.go
+++ b/internal/daemon/handlers_move_test.go
@@ -69,6 +69,54 @@ func TestMoveIssue_HappyPath(t *testing.T) {
 	assert.Equal(t, out.NewShortID, stored.ShortID)
 }
 
+// TestMoveIssue_ImportMappingCollisionReturns409 returns a move-specific
+// conflict that identifies the colliding source identity.
+func TestMoveIssue_ImportMappingCollisionReturns409(t *testing.T) {
+	env := testenv.New(t, testenv.WithAuthToken("tok"))
+	src, tgt, iss := seedMovePair(t, env)
+	tgtIssue, _, err := env.DB.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: tgt.ID, Title: "existing mapped issue", Author: "tester",
+	})
+	require.NoError(t, err)
+
+	_, err = env.DB.UpsertImportMapping(t.Context(), db.ImportMappingParams{
+		Source: "connector", ExternalID: "same", ObjectType: "issue", ProjectID: src.ID, IssueID: &iss.ID,
+	})
+	require.NoError(t, err)
+	_, err = env.DB.UpsertImportMapping(t.Context(), db.ImportMappingParams{
+		Source: "connector", ExternalID: "same", ObjectType: "issue", ProjectID: tgt.ID, IssueID: &tgtIssue.ID,
+	})
+	require.NoError(t, err)
+
+	body := fmt.Sprintf(`{"actor":"tester","to_project_uid":%q}`, tgt.UID)
+	ifMatch := fmt.Sprintf(`"rev-%d"`, iss.Revision)
+	resp := doPostWithIfMatch(t, env, moveURL(env, src.ID, iss.ShortID), body, ifMatch)
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var envelope struct {
+		Status int `json:"status"`
+		Error  struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Hint    string `json:"hint"`
+			Data    struct {
+				Mappings []db.ProjectMergeImportMappingCollision `json:"mappings"`
+			} `json:"data"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &envelope))
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+	require.Equal(t, http.StatusConflict, envelope.Status)
+	require.Equal(t, "issue_move_import_mapping_collision", envelope.Error.Code)
+	require.Equal(t, "issue has import mappings that already exist in the target project", envelope.Error.Message)
+	require.Equal(t, "resolve import mapping collisions before moving", envelope.Error.Hint)
+	require.Equal(t, []db.ProjectMergeImportMappingCollision{{
+		Source: "connector", ExternalID: "same", ObjectType: "issue",
+	}}, envelope.Error.Data.Mappings)
+}
+
 func TestMoveIssue_StaleIfMatch_412(t *testing.T) {
 	env := testenv.New(t, testenv.WithAuthToken("tok"))
 	src, tgt, iss := seedMovePair(t, env)

--- a/internal/daemon/handlers_project_purge_test.go
+++ b/internal/daemon/handlers_project_purge_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/rootbridge"
 )
 
 func purgeProjectPath(projectID int64) string {
@@ -117,6 +119,47 @@ func TestPurgeProjectHandler_PurgesArchived(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.body, &envelope), string(resp.body))
 		assert.Equal(t, "hub", envelope.Error.Data["role"])
 	})
+}
+
+func TestPurgeProjectHandler_RequiresExternalRootsToBeUnboundFirst(t *testing.T) {
+	h, pid := bootstrapProject(t, func(cfg *daemon.ServerConfig) {
+		cfg.ExternalRootService = rootbridge.NewService(cfg.DB, nil, nil)
+	})
+	ts := h.ts.(*httptest.Server)
+	issue, _, err := h.DB().CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: pid, Title: "Bound issue", Author: "tester",
+	})
+	require.NoError(t, err)
+	binding, _, err := h.DB().CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
+		ProjectID: pid, IssueID: issue.ID,
+		ConnectorInstance: "example", ExternalRootKey: "root-project-purge-guard",
+		ExternalAccountKey: "example-account", Actor: "integration-admin",
+		ReceiveCommentsAfter: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	archiveProject(t, h, pid, true)
+
+	resp := postWithHeader(t, ts, purgeProjectPath(pid),
+		map[string]string{"X-Kata-Confirm": "PURGE kata"},
+		map[string]any{"actor": "tester"})
+
+	assertAPIError(t, resp.status, resp.body, 409, "external_root_content_owned")
+	_, err = h.DB().ProjectByID(t.Context(), pid)
+	require.NoError(t, err)
+	retainedBinding, err := h.DB().ExternalRootBindingByID(t.Context(), binding.ID)
+	require.NoError(t, err)
+	assert.True(t, retainedBinding.Active)
+
+	bridgePath := fmt.Sprintf("/api/v1/projects/%d/issues/%s/bridge?actor=tester", pid, issue.ShortID)
+	unbindStatus, unbindBody := requestExternalRootJSON(t, ts.URL, http.MethodDelete, bridgePath, nil)
+	require.Equal(t, http.StatusOK, unbindStatus, string(unbindBody))
+
+	resp = postWithHeader(t, ts, purgeProjectPath(pid),
+		map[string]string{"X-Kata-Confirm": "PURGE kata"},
+		map[string]any{"actor": "tester"})
+	require.Equal(t, http.StatusOK, resp.status, string(resp.body))
+	_, err = h.DB().ProjectByID(t.Context(), pid)
+	assert.ErrorIs(t, err, db.ErrNotFound)
 }
 
 // TestPurgeProjectHandler_BroadcastsResetToScopedSubscribers locks in the

--- a/internal/daemon/handlers_projects.go
+++ b/internal/daemon/handlers_projects.go
@@ -333,6 +333,11 @@ func registerProjectsHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, api.NewError(409, "project_federated",
 				fedErr.Error(), hint, map[string]any{"role": string(fedErr.Role)})
 		}
+		if errors.Is(err, db.ErrExternalRootContentOwned) {
+			return nil, api.NewError(409, "external_root_content_owned",
+				"the project contains an active external root binding",
+				"run `kata bridge unbind <issue-ref>` for every bound issue before purging the project", nil)
+		}
 		if err != nil {
 			return nil, internalAPIError(err)
 		}

--- a/internal/daemon/host_operation_policy_projects.go
+++ b/internal/daemon/host_operation_policy_projects.go
@@ -28,4 +28,15 @@ func registerProjectOperationPolicies(policies map[string]HostOperationPolicy) {
 		Kind: hostOperationIntegrationAdministration, Capability: hostCapabilityManage,
 		Mutation: true, restricted: true,
 	}, "enableIssueSync", "disableIssueSync", "runIssueSyncOnce")
+
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationIntegrationAdministration, Capability: hostCapabilityManage,
+		restricted: true,
+	}, "listConnectors", "getConnectorStatus", "listConnectorFields", "getExternalRootBridge")
+	registerHostOperations(policies, HostOperationPolicy{
+		Kind: hostOperationIntegrationAdministration, Capability: hostCapabilityManage,
+		Mutation: true, restricted: true,
+	}, "mapConnectorField", "unmapConnectorField", "bindExternalRoot", "reconcileExternalRootBridge",
+		"reconcileExternalRootByKey", "pauseExternalRootBridge", "resumeExternalRootBridge",
+		"resolveExternalField", "resolveExternalComment", "unbindExternalRoot")
 }

--- a/internal/daemon/identity.go
+++ b/internal/daemon/identity.go
@@ -51,6 +51,7 @@ type Principal struct {
 
 type principalContextKey struct{}
 type insecureReadonlyContextKey struct{}
+type unauthenticatedPrivateNetworkContextKey struct{}
 
 // WithPrincipal attaches an authenticated request principal to ctx.
 func WithPrincipal(ctx context.Context, p Principal) context.Context {
@@ -75,6 +76,15 @@ func withInsecureReadonlyRequest(ctx context.Context) context.Context {
 
 func insecureReadonlyRequest(ctx context.Context) bool {
 	v, _ := ctx.Value(insecureReadonlyContextKey{}).(bool)
+	return v
+}
+
+func withUnauthenticatedPrivateNetworkRequest(ctx context.Context) context.Context {
+	return context.WithValue(ctx, unauthenticatedPrivateNetworkContextKey{}, true)
+}
+
+func unauthenticatedPrivateNetworkRequest(ctx context.Context) bool {
+	v, _ := ctx.Value(unauthenticatedPrivateNetworkContextKey{}).(bool)
 	return v
 }
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -23,6 +23,7 @@ import (
 	"go.kenn.io/kata/internal/embedding"
 	"go.kenn.io/kata/internal/githubsync"
 	"go.kenn.io/kata/internal/hooks"
+	"go.kenn.io/kata/internal/rootbridge"
 	"go.kenn.io/kata/internal/vector"
 	kataweb "go.kenn.io/kata/internal/web"
 )
@@ -59,6 +60,10 @@ type ServerConfig struct {
 	GitHubSyncRunnerFactory  GitHubSyncRunnerFactory
 	GitHubSyncWake           func()
 	Hooks                    hooks.Sink
+	ExternalRootRegistry     *rootbridge.Registry
+	ExternalRootService      *rootbridge.Service
+	ExternalRootReconciler   *rootbridge.Reconciler
+	ExternalRootWake         func(int64)
 	// CloseThrottle controls whether the opt-in sibling-burst and repeated-
 	// message guards run on close. Zero-value means "guards off".
 	CloseThrottle CloseThrottlePolicy
@@ -239,6 +244,7 @@ func NewServer(cfg ServerConfig) *Server {
 	humaAPI := huma.NewAPI(humaConfig, api.WrapErrorAdapter(humago.NewAdapter(mux, "")))
 	withEmbeddingProfile(humaAPI, cfg.EmbeddingProfile)
 	withHostAccess(humaAPI, cfg.HostAccess)
+	withExternalRootAdministration(humaAPI)
 
 	s := &Server{cfg: cfg, api: humaAPI}
 	registerRoutes(humaAPI, mux, cfg)
@@ -576,6 +582,7 @@ func registerRoutes(humaAPI huma.API, mux *http.ServeMux, cfg ServerConfig) {
 	registerEventsHandlers(humaAPI, mux, cfg)
 	registerFederationHandlers(humaAPI, cfg)
 	registerIssueSyncHandlers(humaAPI, cfg)
+	registerExternalRootHandlers(humaAPI, cfg)
 	registerClaimHandlers(humaAPI, cfg)
 	registerDigestHandlers(humaAPI, cfg)
 	registerAuditHandlers(humaAPI, cfg)

--- a/internal/db/pgstore/external_roots.go
+++ b/internal/db/pgstore/external_roots.go
@@ -1474,7 +1474,13 @@ func (d *Store) externalRootAction(
 			(current.ClaimToken != params.ClaimToken || !current.Active || !current.Enabled) {
 			return db.ExternalRootBinding{}, db.Event{}, db.ErrExternalRootClaimLost
 		}
-		issue, projectName, err := externalRootIssueForEvent(ctx, tx, current.IssueID)
+		var issue db.Issue
+		var projectName string
+		if action == "unbound" {
+			issue, projectName, err = externalRootIssueForCleanupEvent(ctx, tx, current.IssueID)
+		} else {
+			issue, projectName, err = externalRootIssueForEvent(ctx, tx, current.IssueID)
+		}
 		if err != nil {
 			return db.ExternalRootBinding{}, db.Event{}, err
 		}
@@ -1733,7 +1739,7 @@ func (d *Store) ClearPendingExternalComment(
 		if err != nil {
 			return db.ExternalRootBinding{}, db.Event{}, err
 		}
-		issue, projectName, err := externalRootIssueForEvent(ctx, tx, binding.IssueID)
+		issue, projectName, err := externalRootIssueForCleanupEvent(ctx, tx, binding.IssueID)
 		if err != nil {
 			return db.ExternalRootBinding{}, db.Event{}, err
 		}
@@ -1758,6 +1764,27 @@ func (d *Store) ClearPendingExternalComment(
 		}
 		return binding, event, nil
 	})
+}
+
+func externalRootIssueForCleanupEvent(
+	ctx context.Context,
+	tx *sql.Tx,
+	issueID int64,
+) (db.Issue, string, error) {
+	issue, err := scanIssue(tx.QueryRowContext(ctx,
+		issueSelect+` WHERE i.id = $1 AND i.deleted_at IS NULL FOR UPDATE OF i`, issueID))
+	if err != nil {
+		return db.Issue{}, "", err
+	}
+	project, err := scanProject(tx.QueryRowContext(ctx,
+		projectSelect+` WHERE id = $1 FOR SHARE`, issue.ProjectID))
+	if err != nil {
+		return db.Issue{}, "", err
+	}
+	if err := ensureProjectWritableTx(ctx, tx, project.ID); err != nil {
+		return db.Issue{}, "", err
+	}
+	return issue, project.Name, nil
 }
 
 func upsertPendingExternalCommentMappingTx(

--- a/internal/db/pgstore/project_lifecycle.go
+++ b/internal/db/pgstore/project_lifecycle.go
@@ -254,6 +254,9 @@ func (s *Store) PurgeProject(ctx context.Context, params db.PurgeProjectParams) 
 		if !errors.Is(err, sql.ErrNoRows) {
 			return mapSQLError(err, nil)
 		}
+		if err := rejectActiveExternalRootProjectPurge(ctx, tx, project.ID); err != nil {
+			return err
+		}
 
 		counts, err := countProjectPurgeTx(ctx, tx, project.ID)
 		if err != nil {

--- a/internal/db/pgstore/purge.go
+++ b/internal/db/pgstore/purge.go
@@ -32,6 +32,9 @@ func (s *Store) PurgeIssue(ctx context.Context, issueID int64, actor string, rea
 		if err := ensureProjectWritableTx(ctx, tx, issue.ProjectID); err != nil {
 			return err
 		}
+		if err := rejectActiveExternalRootIssuePurge(ctx, tx, issue.ID); err != nil {
+			return err
+		}
 
 		var minEventID, maxEventID sql.NullInt64
 		if err := tx.QueryRowContext(ctx, `SELECT MIN(id), MAX(id) FROM events
@@ -131,6 +134,36 @@ WHERE id = $1 AND last_materialized_uid = $4`,
 		return err
 	})
 	return result, err
+}
+
+func rejectActiveExternalRootIssuePurge(ctx context.Context, tx *sql.Tx, issueID int64) error {
+	var active int
+	err := tx.QueryRowContext(ctx,
+		`SELECT 1 FROM external_root_bindings WHERE issue_id = $1 AND active = 1 LIMIT 1`,
+		issueID,
+	).Scan(&active)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return mapSQLError(err, nil)
+	}
+	return db.ErrExternalRootContentOwned
+}
+
+func rejectActiveExternalRootProjectPurge(ctx context.Context, tx *sql.Tx, projectID int64) error {
+	var active int
+	err := tx.QueryRowContext(ctx,
+		`SELECT 1 FROM external_root_bindings WHERE project_id = $1 AND active = 1 LIMIT 1`,
+		projectID,
+	).Scan(&active)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return mapSQLError(err, nil)
+	}
+	return db.ErrExternalRootContentOwned
 }
 
 // PurgeResetCheck reports the newest reserved cursor beyond afterID.

--- a/internal/db/sqlitestore/external_roots.go
+++ b/internal/db/sqlitestore/external_roots.go
@@ -1353,7 +1353,13 @@ func (d *Store) externalRootAction(
 			(current.ClaimToken != params.ClaimToken || !current.Active || !current.Enabled) {
 			return db.ExternalRootBinding{}, db.Event{}, db.ErrExternalRootClaimLost
 		}
-		issue, projectName, err := lookupIssueForEvent(ctx, tx, current.IssueID)
+		var issue db.Issue
+		var projectName string
+		if action == "unbound" {
+			issue, projectName, err = externalRootIssueForCleanupEvent(ctx, tx, current.IssueID)
+		} else {
+			issue, projectName, err = lookupIssueForEvent(ctx, tx, current.IssueID)
+		}
 		if err != nil {
 			return db.ExternalRootBinding{}, db.Event{}, err
 		}
@@ -1607,7 +1613,7 @@ func (d *Store) ClearPendingExternalComment(
 		if err != nil {
 			return db.ExternalRootBinding{}, db.Event{}, err
 		}
-		issue, projectName, err := lookupIssueForEvent(ctx, tx, binding.IssueID)
+		issue, projectName, err := externalRootIssueForCleanupEvent(ctx, tx, binding.IssueID)
 		if err != nil {
 			return db.ExternalRootBinding{}, db.Event{}, err
 		}
@@ -1631,6 +1637,30 @@ func (d *Store) ClearPendingExternalComment(
 		}
 		return binding, event, nil
 	})
+}
+
+func externalRootIssueForCleanupEvent(
+	ctx context.Context,
+	tx *sql.Tx,
+	issueID int64,
+) (db.Issue, string, error) {
+	issue, err := scanIssue(tx.QueryRowContext(ctx,
+		issueSelect+` WHERE i.id = ? AND i.deleted_at IS NULL`, issueID))
+	if err != nil {
+		return db.Issue{}, "", err
+	}
+	var projectName string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT name FROM projects WHERE id = ?`, issue.ProjectID).Scan(&projectName); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.Issue{}, "", db.ErrNotFound
+		}
+		return db.Issue{}, "", fmt.Errorf("lookup external root cleanup project: %w", err)
+	}
+	if err := ensureProjectWritableTx(ctx, tx, issue.ProjectID); err != nil {
+		return db.Issue{}, "", err
+	}
+	return issue, projectName, nil
 }
 
 func upsertPendingExternalCommentMapping(

--- a/internal/db/sqlitestore/queries_delete.go
+++ b/internal/db/sqlitestore/queries_delete.go
@@ -227,6 +227,9 @@ func (d *Store) purgeIssue(ctx context.Context, issueID int64, actor string, rea
 	if err := ensureFederatedSpokeUnsupportedTx(ctx, conn, issue.ProjectID); err != nil {
 		return db.PurgeLog{}, err
 	}
+	if err := rejectActiveExternalRootIssuePurge(ctx, conn, issue.ID); err != nil {
+		return db.PurgeLog{}, err
+	}
 
 	purgeLogID, err := purgeCascade(ctx, conn, issue, projectName, actor, reason, d.instanceUID)
 	if err != nil {
@@ -250,6 +253,36 @@ func (d *Store) purgeIssue(ctx context.Context, issueID int64, actor string, rea
 type connExec interface {
 	sqlReader
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+func rejectActiveExternalRootIssuePurge(ctx context.Context, q sqlReader, issueID int64) error {
+	var active int
+	err := q.QueryRowContext(ctx,
+		`SELECT 1 FROM external_root_bindings WHERE issue_id = ? AND active = 1 LIMIT 1`,
+		issueID,
+	).Scan(&active)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check active external root binding: %w", err)
+	}
+	return db.ErrExternalRootContentOwned
+}
+
+func rejectActiveExternalRootProjectPurge(ctx context.Context, q sqlReader, projectID int64) error {
+	var active int
+	err := q.QueryRowContext(ctx,
+		`SELECT 1 FROM external_root_bindings WHERE project_id = ? AND active = 1 LIMIT 1`,
+		projectID,
+	).Scan(&active)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check active external root binding: %w", err)
+	}
+	return db.ErrExternalRootContentOwned
 }
 
 // purgeCascade is steps 2-7 of PurgeIssue. It runs inside the BEGIN IMMEDIATE

--- a/internal/db/sqlitestore/queries_projects_purge.go
+++ b/internal/db/sqlitestore/queries_projects_purge.go
@@ -56,6 +56,9 @@ func (d *Store) purgeProject(ctx context.Context, p db.PurgeProjectParams) (db.P
 	if role != "" {
 		return db.ProjectPurgeLog{}, &db.ProjectFederatedError{Role: db.FederationRole(role)}
 	}
+	if err := rejectActiveExternalRootProjectPurge(ctx, conn, project.ID); err != nil {
+		return db.ProjectPurgeLog{}, err
+	}
 
 	plID, err := purgeProjectCascade(ctx, conn, project, p.Actor, p.Reason, d.instanceUID)
 	if err != nil {

--- a/internal/mcp/external_roots.go
+++ b/internal/mcp/external_roots.go
@@ -1,0 +1,367 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+// ConnectorsInput optionally selects one configured connector instance.
+type ConnectorsInput struct {
+	Instance string `json:"instance,omitempty"`
+}
+
+// ConnectorsOutput contains secret-free connector status records.
+type ConnectorsOutput struct {
+	Connectors []generated.ConnectorOut `json:"connectors"`
+}
+
+// ConnectorFieldsInput selects one configured connector instance.
+type ConnectorFieldsInput struct {
+	Instance string `json:"instance"`
+}
+
+// ConnectorFieldsOutput contains one connector's canonical field descriptors.
+type ConnectorFieldsOutput struct {
+	Instance string                      `json:"instance"`
+	Fields   []generated.FieldDescriptor `json:"fields"`
+}
+
+// ConnectorFieldMapInput maps one Kata planning field to an external field.
+type ConnectorFieldMapInput struct {
+	Instance      string `json:"instance"`
+	KataField     string `json:"kata_field"`
+	ExternalField string `json:"external_field"`
+}
+
+// ConnectorFieldUnmapInput disables one connector planning-field mapping.
+type ConnectorFieldUnmapInput struct {
+	Instance  string `json:"instance"`
+	KataField string `json:"kata_field"`
+}
+
+// ConnectorFieldMappingOutput reports the connector-wide mapping state.
+type ConnectorFieldMappingOutput struct {
+	Instance string                            `json:"instance"`
+	Mapping  generated.ExternalFieldMappingOut `json:"mapping"`
+}
+
+// BridgeInput selects one issue bridge inside the startup scope.
+type BridgeInput struct {
+	Ref string `json:"ref"`
+}
+
+// BridgeBindInput binds an issue to an existing external root.
+type BridgeBindInput struct {
+	Ref             string `json:"ref"`
+	Connector       string `json:"connector"`
+	External        string `json:"external"`
+	PublishComments bool   `json:"publish_comments,omitempty"`
+}
+
+// BridgePauseInput pauses an issue bridge with an optional safe reason.
+type BridgePauseInput struct {
+	Ref    string `json:"ref"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// BridgeResolveFieldInput selects the winner for one planning-field conflict.
+type BridgeResolveFieldInput struct {
+	Ref       string `json:"ref"`
+	KataField string `json:"kata_field"`
+	Use       string `json:"use"`
+}
+
+// BridgeResolveCommentInput resolves uncertain outbound comment delivery.
+type BridgeResolveCommentInput struct {
+	Ref               string `json:"ref"`
+	Action            string `json:"action"`
+	ExternalCommentID string `json:"external_comment_id,omitempty"`
+}
+
+// BridgeOutput reports one issue bridge inside its current project.
+type BridgeOutput struct {
+	Project ProjectIdentity                 `json:"project"`
+	Bridge  generated.ExternalRootBridgeOut `json:"bridge"`
+}
+
+// BridgeReconcileOutput reports one completed reconciliation pass.
+type BridgeReconcileOutput struct {
+	Project ProjectIdentity              `json:"project"`
+	Result  generated.ExternalRootRunOut `json:"result"`
+}
+
+func registerExternalRootTools(server *sdkmcp.Server, handlers toolHandlers) {
+	read := toolHints(true, false, false)
+	openWorldRead := toolHints(true, false, true)
+	mutating := toolHints(false, true, false)
+	openWorld := toolHints(false, true, true)
+	addTool(server, "kata.connectors", "Connectors", "List configured external connectors or read one secret-free status; requires daemon-wide scope.", openWorldRead, handlers.connectors)
+	addTool(server, "kata.connector_fields", "Connector fields", "Read canonical external field descriptors for one configured connector; requires daemon-wide scope.", openWorldRead, handlers.connectorFields)
+	addTool(server, "kata.connector_field_map", "Map connector field", "Map one Kata planning field to a canonical external field; requires daemon-wide scope.", openWorld, handlers.connectorFieldMap)
+	addTool(server, "kata.connector_field_unmap", "Unmap connector field", "Disable one connector planning-field mapping; requires daemon-wide scope.", openWorld, handlers.connectorFieldUnmap)
+	addTool(server, "kata.bridge_show", "Show bridge", "Read external-root bridge status for one issue.", read, handlers.bridgeShow)
+	addTool(server, "kata.bridge_bind", "Bind bridge", "Bind one issue to an existing external root; requires daemon-wide scope.", openWorld, handlers.bridgeBind)
+	addTool(server, "kata.bridge_reconcile", "Reconcile bridge", "Run one external-root reconciliation pass.", nonIdempotent(toolHints(false, true, true)), handlers.bridgeReconcile)
+	addTool(server, "kata.bridge_pause", "Pause bridge", "Pause external-root reconciliation for one issue.", mutating, handlers.bridgePause)
+	addTool(server, "kata.bridge_resume", "Resume bridge", "Validate and resume external-root reconciliation for one issue.", openWorld, handlers.bridgeResume)
+	addTool(server, "kata.bridge_resolve_field", "Resolve bridge field", "Choose the Kata or external candidate for one planning-field conflict.", openWorld, handlers.bridgeResolveField)
+	addTool(server, "kata.bridge_resolve_comment", "Resolve bridge comment", "Adopt, retry, or skip uncertain outbound comment delivery.", openWorld, handlers.bridgeResolveComment)
+	addTool(server, "kata.bridge_unbind", "Unbind bridge", "Deactivate one issue bridge while preserving its history.", mutating, handlers.bridgeUnbind)
+}
+
+func (h toolHandlers) connectors(ctx context.Context, _ *sdkmcp.CallToolRequest, input ConnectorsInput) (*sdkmcp.CallToolResult, ConnectorsOutput, error) {
+	if err := h.requireAllProjectsScope("connector metadata"); err != nil {
+		return nil, ConnectorsOutput{}, err
+	}
+	h = h.withLongRunningClient()
+	instance := strings.TrimSpace(input.Instance)
+	if instance == "" {
+		response, err := h.options.Client.ListConnectors(ctx)
+		if err != nil {
+			return nil, ConnectorsOutput{}, err
+		}
+		return successResult(), ConnectorsOutput{Connectors: response.Connectors}, nil
+	}
+	response, err := h.options.Client.GetConnectorStatus(ctx, &generated.GetConnectorStatusRequestOptions{
+		PathParams: &generated.GetConnectorStatusPath{Instance: instance},
+	})
+	if err != nil {
+		return nil, ConnectorsOutput{}, err
+	}
+	return successResult(), ConnectorsOutput{Connectors: []generated.ConnectorOut{*response}}, nil
+}
+
+func (h toolHandlers) connectorFields(ctx context.Context, _ *sdkmcp.CallToolRequest, input ConnectorFieldsInput) (*sdkmcp.CallToolResult, ConnectorFieldsOutput, error) {
+	if err := h.requireAllProjectsScope("connector field metadata"); err != nil {
+		return nil, ConnectorFieldsOutput{}, err
+	}
+	h = h.withLongRunningClient()
+	instance := strings.TrimSpace(input.Instance)
+	if instance == "" {
+		return nil, ConnectorFieldsOutput{}, errors.New("connector instance must not be empty")
+	}
+	response, err := h.options.Client.ListConnectorFields(ctx, &generated.ListConnectorFieldsRequestOptions{
+		PathParams: &generated.ListConnectorFieldsPath{Instance: instance},
+	})
+	if err != nil {
+		return nil, ConnectorFieldsOutput{}, err
+	}
+	return successResult(), ConnectorFieldsOutput{Instance: instance, Fields: response.Fields}, nil
+}
+
+func (h toolHandlers) connectorFieldMap(ctx context.Context, _ *sdkmcp.CallToolRequest, input ConnectorFieldMapInput) (*sdkmcp.CallToolResult, ConnectorFieldMappingOutput, error) {
+	if err := h.requireAllProjectsScope("connector field mapping"); err != nil {
+		return nil, ConnectorFieldMappingOutput{}, err
+	}
+	instance, kataField, err := connectorMappingTarget(input.Instance, input.KataField)
+	if err != nil {
+		return nil, ConnectorFieldMappingOutput{}, err
+	}
+	externalField := strings.TrimSpace(input.ExternalField)
+	if externalField == "" {
+		return nil, ConnectorFieldMappingOutput{}, errors.New("external field must not be empty")
+	}
+	h = h.withLongRunningClient()
+	response, err := h.options.Client.MapConnectorField(ctx, &generated.MapConnectorFieldRequestOptions{
+		PathParams: &generated.MapConnectorFieldPath{Instance: instance, KataField: kataField},
+		Body:       &generated.MapConnectorFieldBody{ExternalField: externalField},
+	})
+	if err != nil {
+		return nil, ConnectorFieldMappingOutput{}, err
+	}
+	return successResult(), ConnectorFieldMappingOutput{Instance: instance, Mapping: *response}, nil
+}
+
+func (h toolHandlers) connectorFieldUnmap(ctx context.Context, _ *sdkmcp.CallToolRequest, input ConnectorFieldUnmapInput) (*sdkmcp.CallToolResult, ConnectorFieldMappingOutput, error) {
+	if err := h.requireAllProjectsScope("connector field unmapping"); err != nil {
+		return nil, ConnectorFieldMappingOutput{}, err
+	}
+	instance, kataField, err := connectorMappingTarget(input.Instance, input.KataField)
+	if err != nil {
+		return nil, ConnectorFieldMappingOutput{}, err
+	}
+	h = h.withLongRunningClient()
+	response, err := h.options.Client.UnmapConnectorField(ctx, &generated.UnmapConnectorFieldRequestOptions{
+		PathParams: &generated.UnmapConnectorFieldPath{Instance: instance, KataField: kataField},
+	})
+	if err != nil {
+		return nil, ConnectorFieldMappingOutput{}, err
+	}
+	return successResult(), ConnectorFieldMappingOutput{Instance: instance, Mapping: *response}, nil
+}
+
+func connectorMappingTarget(rawInstance, rawKataField string) (string, string, error) {
+	instance := strings.TrimSpace(rawInstance)
+	kataField := strings.TrimSpace(rawKataField)
+	if instance == "" {
+		return "", "", errors.New("connector instance must not be empty")
+	}
+	if kataField != "scheduled_on" && kataField != "deadline_on" {
+		return "", "", errors.New("kata field must be scheduled_on or deadline_on")
+	}
+	return instance, kataField, nil
+}
+
+func (h toolHandlers) bridgeShow(ctx context.Context, _ *sdkmcp.CallToolRequest, input BridgeInput) (*sdkmcp.CallToolResult, BridgeOutput, error) {
+	project, ref, err := h.bridgeTarget(ctx, input.Ref, false)
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	response, err := h.options.Client.GetExternalRootBridge(ctx, &generated.GetExternalRootBridgeRequestOptions{
+		PathParams: &generated.GetExternalRootBridgePath{ProjectID: project.ID, Ref: ref},
+	})
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	return successResult(), BridgeOutput{Project: project, Bridge: *response}, nil
+}
+
+func (h toolHandlers) bridgeBind(ctx context.Context, _ *sdkmcp.CallToolRequest, input BridgeBindInput) (*sdkmcp.CallToolResult, BridgeOutput, error) {
+	if err := h.requireAllProjectsScope("external-root bridge binding"); err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	project, ref, err := h.bridgeTarget(ctx, input.Ref, true)
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	connectorInstance := strings.TrimSpace(input.Connector)
+	external := strings.TrimSpace(input.External)
+	if connectorInstance == "" || external == "" {
+		return nil, BridgeOutput{}, errors.New("connector and external root must not be empty")
+	}
+	h = h.withLongRunningClient()
+	response, err := h.options.Client.BindExternalRoot(ctx, &generated.BindExternalRootRequestOptions{
+		PathParams: &generated.BindExternalRootPath{ProjectID: project.ID, Ref: ref},
+		Body: &generated.BindExternalRootBody{
+			Actor: &h.options.Actor, Connector: connectorInstance, External: external, PublishComments: &input.PublishComments,
+		},
+	})
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	return successResult(), BridgeOutput{Project: project, Bridge: *response}, nil
+}
+
+func (h toolHandlers) bridgeReconcile(ctx context.Context, _ *sdkmcp.CallToolRequest, input BridgeInput) (*sdkmcp.CallToolResult, BridgeReconcileOutput, error) {
+	project, ref, err := h.bridgeTarget(ctx, input.Ref, true)
+	if err != nil {
+		return nil, BridgeReconcileOutput{}, err
+	}
+	h = h.withLongRunningClient()
+	response, err := h.options.Client.ReconcileExternalRootBridge(ctx, &generated.ReconcileExternalRootBridgeRequestOptions{
+		PathParams: &generated.ReconcileExternalRootBridgePath{ProjectID: project.ID, Ref: ref},
+		Body:       &generated.ReconcileExternalRootBridgeBody{Actor: &h.options.Actor},
+	})
+	if err != nil {
+		return nil, BridgeReconcileOutput{}, err
+	}
+	return successResult(), BridgeReconcileOutput{Project: project, Result: *response}, nil
+}
+
+func (h toolHandlers) bridgePause(ctx context.Context, _ *sdkmcp.CallToolRequest, input BridgePauseInput) (*sdkmcp.CallToolResult, BridgeOutput, error) {
+	project, ref, err := h.bridgeTarget(ctx, input.Ref, true)
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	response, err := h.options.Client.PauseExternalRootBridge(ctx, &generated.PauseExternalRootBridgeRequestOptions{
+		PathParams: &generated.PauseExternalRootBridgePath{ProjectID: project.ID, Ref: ref},
+		Body:       &generated.PauseExternalRootBridgeBody{Actor: &h.options.Actor, Reason: optionalString(input.Reason)},
+	})
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	return successResult(), BridgeOutput{Project: project, Bridge: *response}, nil
+}
+
+func (h toolHandlers) bridgeResume(ctx context.Context, _ *sdkmcp.CallToolRequest, input BridgeInput) (*sdkmcp.CallToolResult, BridgeOutput, error) {
+	project, ref, err := h.bridgeTarget(ctx, input.Ref, true)
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	h = h.withLongRunningClient()
+	response, err := h.options.Client.ResumeExternalRootBridge(ctx, &generated.ResumeExternalRootBridgeRequestOptions{
+		PathParams: &generated.ResumeExternalRootBridgePath{ProjectID: project.ID, Ref: ref},
+		Body:       &generated.ResumeExternalRootBridgeBody{Actor: &h.options.Actor},
+	})
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	return successResult(), BridgeOutput{Project: project, Bridge: *response}, nil
+}
+
+func (h toolHandlers) bridgeResolveField(ctx context.Context, _ *sdkmcp.CallToolRequest, input BridgeResolveFieldInput) (*sdkmcp.CallToolResult, BridgeOutput, error) {
+	project, ref, err := h.bridgeTarget(ctx, input.Ref, true)
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	kataField := strings.TrimSpace(input.KataField)
+	use := strings.TrimSpace(input.Use)
+	if kataField != "scheduled_on" && kataField != "deadline_on" {
+		return nil, BridgeOutput{}, errors.New("kata field must be scheduled_on or deadline_on")
+	}
+	if use != "kata" && use != "external" {
+		return nil, BridgeOutput{}, errors.New("use must be kata or external")
+	}
+	h = h.withLongRunningClient()
+	response, err := h.options.Client.ResolveExternalField(ctx, &generated.ResolveExternalFieldRequestOptions{
+		PathParams: &generated.ResolveExternalFieldPath{ProjectID: project.ID, Ref: ref},
+		Body:       &generated.ResolveExternalFieldBody{Actor: &h.options.Actor, KataField: kataField, Use: use},
+	})
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	return successResult(), BridgeOutput{Project: project, Bridge: *response}, nil
+}
+
+func (h toolHandlers) bridgeResolveComment(ctx context.Context, _ *sdkmcp.CallToolRequest, input BridgeResolveCommentInput) (*sdkmcp.CallToolResult, BridgeOutput, error) {
+	project, ref, err := h.options.Scope.IssueTargetIncludingArchived(ctx, h.options.Client, input.Ref, true)
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	action := strings.TrimSpace(input.Action)
+	externalCommentID := strings.TrimSpace(input.ExternalCommentID)
+	if action != "adopt" && action != "retry" && action != "skip" {
+		return nil, BridgeOutput{}, errors.New("action must be adopt, retry, or skip")
+	}
+	if action == "adopt" && externalCommentID == "" {
+		return nil, BridgeOutput{}, errors.New("adopt requires external_comment_id")
+	}
+	if action != "adopt" && externalCommentID != "" {
+		return nil, BridgeOutput{}, errors.New("external_comment_id is only valid with adopt")
+	}
+	h = h.withLongRunningClient()
+	response, err := h.options.Client.ResolveExternalComment(ctx, &generated.ResolveExternalCommentRequestOptions{
+		PathParams: &generated.ResolveExternalCommentPath{ProjectID: project.ID, Ref: ref},
+		Body: &generated.ResolveExternalCommentBody{
+			Action: action, Actor: &h.options.Actor, ExternalCommentID: optionalString(externalCommentID),
+		},
+	})
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	return successResult(), BridgeOutput{Project: project, Bridge: *response}, nil
+}
+
+func (h toolHandlers) bridgeUnbind(ctx context.Context, _ *sdkmcp.CallToolRequest, input BridgeInput) (*sdkmcp.CallToolResult, BridgeOutput, error) {
+	project, ref, err := h.options.Scope.IssueTargetIncludingArchived(ctx, h.options.Client, input.Ref, true)
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	response, err := h.options.Client.UnbindExternalRoot(ctx, &generated.UnbindExternalRootRequestOptions{
+		PathParams: &generated.UnbindExternalRootPath{ProjectID: project.ID, Ref: ref},
+		Query:      &generated.UnbindExternalRootQuery{Actor: &h.options.Actor},
+	})
+	if err != nil {
+		return nil, BridgeOutput{}, err
+	}
+	return successResult(), BridgeOutput{Project: project, Bridge: *response}, nil
+}
+
+func (h toolHandlers) bridgeTarget(ctx context.Context, rawRef string, write bool) (ProjectIdentity, string, error) {
+	return h.options.Scope.IssueTarget(ctx, h.options.Client, rawRef, write)
+}

--- a/internal/mcp/external_roots_test.go
+++ b/internal/mcp/external_roots_test.go
@@ -1,0 +1,460 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	kataclient "go.kenn.io/kata/pkg/client"
+)
+
+type externalRootRequest struct {
+	Method string
+	Path   string
+	Query  string
+	Body   map[string]any
+}
+
+var externalRootToolNames = []string{
+	"kata.bridge_bind",
+	"kata.bridge_pause",
+	"kata.bridge_reconcile",
+	"kata.bridge_resolve_comment",
+	"kata.bridge_resolve_field",
+	"kata.bridge_resume",
+	"kata.bridge_show",
+	"kata.bridge_unbind",
+	"kata.connector_field_map",
+	"kata.connector_field_unmap",
+	"kata.connector_fields",
+	"kata.connectors",
+}
+
+func TestExternalRootSectionPublishesTypedTools(t *testing.T) {
+	session := connectRawTestServerWithOptions(t, Options{
+		Client: &kataclient.Client{}, ProjectID: 42, ProjectName: "spoke-project",
+		Actor: "example-agent", Version: "test-version",
+	})
+
+	for range 2 {
+		result, err := session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+			Name: "kata.load_external_roots", Arguments: map[string]any{},
+		})
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		var output ToolSectionOutput
+		require.NoError(t, json.Unmarshal(mustJSON(t, result.StructuredContent), &output))
+		require.Equal(t, ToolSectionOutput{
+			Section: "external_roots", Available: true, Loaded: true,
+			Tools: externalRootToolNames,
+		}, output)
+	}
+
+	result, err := session.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+	want := append(append([]string(nil), sectionLoaderNames...), externalRootToolNames...)
+	require.ElementsMatch(t, want, toolNames(result.Tools))
+}
+
+func TestExternalRootInputSchemasBoundEnumsAndCommentModes(t *testing.T) {
+	session := connectTestServerWithOptions(t, Options{
+		Client: &kataclient.Client{}, Scope: NewAllScope(), Actor: "example-agent", Version: "test-version",
+	})
+	result, err := session.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+	byName := make(map[string]*sdkmcp.Tool, len(result.Tools))
+	for _, tool := range result.Tools {
+		byName[tool.Name] = tool
+	}
+
+	mapProperties := schemaObject(t, byName["kata.connector_field_map"].InputSchema)["properties"].(map[string]any)
+	require.ElementsMatch(t, []any{"scheduled_on", "deadline_on"}, mapProperties["kata_field"].(map[string]any)["enum"])
+	require.EqualValues(t, 256, mapProperties["external_field"].(map[string]any)["maxLength"])
+	resolveProperties := schemaObject(t, byName["kata.bridge_resolve_field"].InputSchema)["properties"].(map[string]any)
+	require.ElementsMatch(t, []any{"kata", "external"}, resolveProperties["use"].(map[string]any)["enum"])
+	require.Len(t, schemaObject(t, byName["kata.bridge_resolve_comment"].InputSchema)["allOf"], 1)
+
+	for _, arguments := range []map[string]any{
+		{"ref": "spoke-project#abc4", "action": "adopt"},
+		{"ref": "spoke-project#abc4", "action": "retry", "external_comment_id": "unexpected"},
+	} {
+		called, callErr := session.CallTool(t.Context(), &sdkmcp.CallToolParams{
+			Name: "kata.bridge_resolve_comment", Arguments: arguments,
+		})
+		require.NoError(t, callErr)
+		require.True(t, called.IsError)
+		require.Contains(t, string(mustJSON(t, called)), "validating")
+	}
+}
+
+func TestConnectorToolsUseTypedDaemonRoutes(t *testing.T) {
+	requests := make([]externalRootRequest, 0, 5)
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if r.Body != nil {
+			data, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			if len(data) != 0 {
+				require.NoError(t, json.Unmarshal(data, &body))
+			}
+		}
+		requests = append(requests, externalRootRequest{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Body: body})
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/connectors":
+			writeExternalRootJSON(t, w, map[string]any{"connectors": []any{externalConnectorFixture()}})
+		case "GET /api/v1/connectors/example-connector":
+			writeExternalRootJSON(t, w, externalConnectorFixture())
+		case "GET /api/v1/connectors/example-connector/fields":
+			writeExternalRootJSON(t, w, map[string]any{"fields": []any{map[string]any{
+				"id": "start-date", "display_name": "Start date", "accepted_kinds": []string{"date", "local_datetime"},
+				"nullable": true, "writable": true, "schema_revision": "schema-v1",
+			}}})
+		case "PUT /api/v1/connectors/example-connector/fields/scheduled_on":
+			writeExternalRootJSON(t, w, externalMappingFixture(true))
+		case "DELETE /api/v1/connectors/example-connector/fields/scheduled_on":
+			writeExternalRootJSON(t, w, externalMappingFixture(false))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(httpServer.Close)
+
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	session := connectTestServerWithOptions(t, Options{
+		Client: client, Scope: NewAllScope(), Actor: "example-agent", Version: "test-version",
+	})
+
+	listed := callWorkflowTool(t, session, "kata.connectors", map[string]any{})
+	require.Len(t, listed["connectors"], 1)
+	status := callWorkflowTool(t, session, "kata.connectors", map[string]any{"instance": " example-connector "})
+	require.Len(t, status["connectors"], 1)
+	fields := callWorkflowTool(t, session, "kata.connector_fields", map[string]any{"instance": "example-connector"})
+	require.Equal(t, "example-connector", fields["instance"])
+	require.Len(t, fields["fields"], 1)
+	mapped := callWorkflowTool(t, session, "kata.connector_field_map", map[string]any{
+		"instance": "example-connector", "kata_field": "scheduled_on", "external_field": "start-date",
+	})
+	require.Equal(t, "example-connector", mapped["instance"])
+	unmapped := callWorkflowTool(t, session, "kata.connector_field_unmap", map[string]any{
+		"instance": "example-connector", "kata_field": "scheduled_on",
+	})
+	require.Equal(t, "example-connector", unmapped["instance"])
+
+	require.Equal(t, []externalRootRequest{
+		{Method: http.MethodGet, Path: "/api/v1/connectors"},
+		{Method: http.MethodGet, Path: "/api/v1/connectors/example-connector"},
+		{Method: http.MethodGet, Path: "/api/v1/connectors/example-connector/fields"},
+		{Method: http.MethodPut, Path: "/api/v1/connectors/example-connector/fields/scheduled_on", Body: map[string]any{"external_field": "start-date"}},
+		{Method: http.MethodDelete, Path: "/api/v1/connectors/example-connector/fields/scheduled_on"},
+	}, requests)
+}
+
+func TestBridgeToolsUseScopedIssueRoutesAndServerActor(t *testing.T) {
+	requests := make([]externalRootRequest, 0, 8)
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if r.Body != nil {
+			data, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			if len(data) != 0 {
+				require.NoError(t, json.Unmarshal(data, &body))
+			}
+		}
+		requests = append(requests, externalRootRequest{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Body: body})
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/projects/42/issues/abc4/bridge/actions/reconcile" {
+			writeExternalRootJSON(t, w, externalRunFixture())
+			return
+		}
+		if r.URL.Path == "/api/v1/projects/42/issues/abc4/bridge" ||
+			strings.HasPrefix(r.URL.Path, "/api/v1/projects/42/issues/abc4/bridge/actions/") {
+			writeExternalRootJSON(t, w, externalBridgeFixture())
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(httpServer.Close)
+
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	scope, err := NewBoundScope(ProjectIdentity{ID: 42, Name: "spoke-project"})
+	require.NoError(t, err)
+	session := connectTestServerWithOptions(t, Options{
+		Client: client, LongRunningClient: client, Scope: scope, Actor: "example-agent", Version: "test-version",
+	})
+
+	for _, call := range []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "kata.bridge_show", args: map[string]any{"ref": "abc4"}},
+		{name: "kata.bridge_reconcile", args: map[string]any{"ref": "abc4"}},
+		{name: "kata.bridge_pause", args: map[string]any{"ref": "abc4", "reason": "operator pause"}},
+		{name: "kata.bridge_resume", args: map[string]any{"ref": "abc4"}},
+		{name: "kata.bridge_resolve_field", args: map[string]any{"ref": "abc4", "kata_field": "scheduled_on", "use": "external"}},
+		{name: "kata.bridge_resolve_comment", args: map[string]any{"ref": "abc4", "action": "adopt", "external_comment_id": "opaque ID/with spaces:%25"}},
+		{name: "kata.bridge_unbind", args: map[string]any{"ref": "abc4"}},
+	} {
+		output := callWorkflowTool(t, session, call.name, call.args)
+		require.Equal(t, "spoke-project", output["project"].(map[string]any)["name"])
+	}
+
+	path := "/api/v1/projects/42/issues/abc4/bridge"
+	require.Equal(t, []externalRootRequest{
+		{Method: http.MethodGet, Path: path},
+		{Method: http.MethodPost, Path: path + "/actions/reconcile", Body: map[string]any{"actor": "example-agent"}},
+		{Method: http.MethodPost, Path: path + "/actions/pause", Body: map[string]any{"actor": "example-agent", "reason": "operator pause"}},
+		{Method: http.MethodPost, Path: path + "/actions/resume", Body: map[string]any{"actor": "example-agent"}},
+		{Method: http.MethodPost, Path: path + "/actions/resolve-field", Body: map[string]any{"actor": "example-agent", "kata_field": "scheduled_on", "use": "external"}},
+		{Method: http.MethodPost, Path: path + "/actions/resolve-comment", Body: map[string]any{"action": "adopt", "actor": "example-agent", "external_comment_id": "opaque ID/with spaces:%25"}},
+		{Method: http.MethodDelete, Path: path, Query: "actor=example-agent"},
+	}, requests)
+}
+
+func TestBridgeUnbindResolvesArchivedProjectWithinStartupScope(t *testing.T) {
+	requests := make([]externalRootRequest, 0, 2)
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, externalRootRequest{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery})
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/v1/projects":
+			require.Equal(t, "archived", r.URL.Query().Get("include"))
+			archived := projectJSON(42, "01HAAAAAAAAAAAAAAAAAAAAAAA", "archived-project")
+			archived["deleted_at"] = "2026-08-22T12:00:00.000Z"
+			writeExternalRootJSON(t, w, map[string]any{"projects": []any{archived}})
+		case "DELETE /api/v1/projects/42/issues/abc4/bridge":
+			writeExternalRootJSON(t, w, externalBridgeFixture())
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(httpServer.Close)
+
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	scope, err := NewBoundScope(ProjectIdentity{
+		ID: 42, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "archived-project",
+	})
+	require.NoError(t, err)
+	session := connectTestServerWithOptions(t, Options{
+		Client: client, Scope: scope, Actor: "example-agent", Version: "test-version",
+	})
+
+	output := callWorkflowTool(t, session, "kata.bridge_unbind", map[string]any{"ref": "abc4"})
+	require.Equal(t, "archived-project", output["project"].(map[string]any)["name"])
+	require.Equal(t, []externalRootRequest{
+		{Method: http.MethodGet, Path: "/api/v1/projects", Query: "include=archived"},
+		{Method: http.MethodDelete, Path: "/api/v1/projects/42/issues/abc4/bridge", Query: "actor=example-agent"},
+	}, requests)
+}
+
+func TestExternalRootMutationsKeepStartupScope(t *testing.T) {
+	bound, err := NewBoundScope(ProjectIdentity{ID: 42, Name: "spoke-project"})
+	require.NoError(t, err)
+	boundHandlers := toolHandlers{options: Options{Client: &kataclient.Client{}, Scope: bound, Actor: "example-agent"}}
+
+	_, _, err = boundHandlers.connectorFieldMap(t.Context(), nil, ConnectorFieldMapInput{
+		Instance: "example-connector", KataField: "scheduled_on", ExternalField: "start-date",
+	})
+	require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+	_, _, err = boundHandlers.connectorFieldUnmap(t.Context(), nil, ConnectorFieldUnmapInput{
+		Instance: "example-connector", KataField: "scheduled_on",
+	})
+	require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+
+	allowlist, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 42, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+	allowlistHandlers := toolHandlers{options: Options{Client: &kataclient.Client{}, Scope: allowlist, Actor: "example-agent"}}
+	_, _, err = allowlistHandlers.bridgePause(t.Context(), nil, BridgePauseInput{Ref: "abc4"})
+	require.ErrorContains(t, err, "multi-project writes require project#ref")
+}
+
+func TestConnectorMetadataRequiresAllProjectsScopeBeforeDaemonRequest(t *testing.T) {
+	var requests atomic.Int64
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		writeExternalRootJSON(t, w, map[string]any{"connectors": []any{externalConnectorFixture()}})
+	}))
+	t.Cleanup(httpServer.Close)
+
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	bound, err := NewBoundScope(ProjectIdentity{ID: 42, Name: "spoke-project"})
+	require.NoError(t, err)
+	allowlist, err := NewAllowlistScope([]ProjectIdentity{{
+		ID: 42, UID: "01HAAAAAAAAAAAAAAAAAAAAAAA", Name: "spoke-project",
+	}})
+	require.NoError(t, err)
+
+	for name, scope := range map[string]*Scope{"bound": bound, "allowlist": allowlist} {
+		t.Run(name, func(t *testing.T) {
+			handlers := toolHandlers{options: Options{Client: client, LongRunningClient: client, Scope: scope}}
+			_, _, err := handlers.connectors(t.Context(), nil, ConnectorsInput{})
+			require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+			_, _, err = handlers.connectorFields(t.Context(), nil, ConnectorFieldsInput{Instance: "example-connector"})
+			require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+		})
+	}
+	require.Zero(t, requests.Load(), "scoped connector metadata reads must fail before any daemon request")
+}
+
+func TestBridgeBindRequiresAllProjectsScopeBeforeUsingConnectorCredentials(t *testing.T) {
+	var requests atomic.Int64
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		writeExternalRootJSON(t, w, externalBridgeFixture())
+	}))
+	t.Cleanup(httpServer.Close)
+
+	client, err := kataclient.NewWithHTTPClient(httpServer.URL, httpServer.Client())
+	require.NoError(t, err)
+	bound, err := NewBoundScope(ProjectIdentity{ID: 42, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{Client: client, LongRunningClient: client, Scope: bound, Actor: "example-agent"}}
+
+	_, _, err = handlers.bridgeBind(t.Context(), nil, BridgeBindInput{
+		Ref: "abc4", Connector: "example-connector", External: "root-locator",
+	})
+	require.ErrorContains(t, err, "requires the --all-projects daemon-wide scope")
+	require.Zero(t, requests.Load())
+}
+
+func TestExternalConnectorCallsUseLongRunningClient(t *testing.T) {
+	var defaultRequests atomic.Int64
+	defaultServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defaultRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/projects" {
+			writeExternalRootJSON(t, w, map[string]any{"projects": []any{
+				projectJSON(42, "01HAAAAAAAAAAAAAAAAAAAAAAA", "spoke-project"),
+			}})
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/api/v1/connectors/") {
+			writeExternalRootJSON(t, w, externalMappingFixture(false))
+			return
+		}
+		writeExternalRootJSON(t, w, externalBridgeFixture())
+	}))
+	t.Cleanup(defaultServer.Close)
+	defaultClient, err := kataclient.NewWithHTTPClient(defaultServer.URL, defaultServer.Client())
+	require.NoError(t, err)
+
+	var longRequests atomic.Int64
+	longServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		longRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/connectors":
+			writeExternalRootJSON(t, w, map[string]any{"connectors": []any{externalConnectorFixture()}})
+		case r.URL.Path == "/api/v1/connectors/example-connector":
+			writeExternalRootJSON(t, w, externalConnectorFixture())
+		case r.URL.Path == "/api/v1/connectors/example-connector/fields" && r.Method == http.MethodGet:
+			writeExternalRootJSON(t, w, map[string]any{"fields": []any{}})
+		case r.URL.Path == "/api/v1/connectors/example-connector/fields/scheduled_on":
+			writeExternalRootJSON(t, w, externalMappingFixture(true))
+		case strings.HasSuffix(r.URL.Path, "/actions/reconcile"):
+			writeExternalRootJSON(t, w, externalRunFixture())
+		default:
+			writeExternalRootJSON(t, w, externalBridgeFixture())
+		}
+	}))
+	t.Cleanup(longServer.Close)
+	longClient, err := kataclient.NewWithHTTPClient(longServer.URL, longServer.Client())
+	require.NoError(t, err)
+
+	scope, err := NewBoundScope(ProjectIdentity{ID: 42, Name: "spoke-project"})
+	require.NoError(t, err)
+	handlers := toolHandlers{options: Options{
+		Client: defaultClient, LongRunningClient: longClient, Scope: scope, Actor: "example-agent",
+	}}
+	wideHandlers := handlers
+	wideHandlers.options.Scope = NewAllScope()
+	_, _, err = wideHandlers.connectors(t.Context(), nil, ConnectorsInput{})
+	require.NoError(t, err)
+	_, _, err = wideHandlers.connectors(t.Context(), nil, ConnectorsInput{Instance: "example-connector"})
+	require.NoError(t, err)
+	_, _, err = wideHandlers.connectorFields(t.Context(), nil, ConnectorFieldsInput{Instance: "example-connector"})
+	require.NoError(t, err)
+	_, _, err = wideHandlers.connectorFieldMap(t.Context(), nil, ConnectorFieldMapInput{
+		Instance: "example-connector", KataField: "scheduled_on", ExternalField: "start-date",
+	})
+	require.NoError(t, err)
+	_, _, err = wideHandlers.bridgeBind(t.Context(), nil, BridgeBindInput{
+		Ref: "spoke-project#abc4", Connector: "example-connector", External: "root-locator",
+	})
+	require.NoError(t, err)
+	_, _, err = handlers.bridgeReconcile(t.Context(), nil, BridgeInput{Ref: "abc4"})
+	require.NoError(t, err)
+	_, _, err = handlers.bridgeResume(t.Context(), nil, BridgeInput{Ref: "abc4"})
+	require.NoError(t, err)
+	_, _, err = handlers.bridgeResolveField(t.Context(), nil, BridgeResolveFieldInput{
+		Ref: "abc4", KataField: "scheduled_on", Use: "external",
+	})
+	require.NoError(t, err)
+	_, _, err = handlers.bridgeResolveComment(t.Context(), nil, BridgeResolveCommentInput{
+		Ref: "abc4", Action: "retry",
+	})
+	require.NoError(t, err)
+	_, _, err = wideHandlers.connectorFieldUnmap(t.Context(), nil, ConnectorFieldUnmapInput{
+		Instance: "example-connector", KataField: "scheduled_on",
+	})
+	require.NoError(t, err)
+	_, _, err = handlers.bridgeShow(t.Context(), nil, BridgeInput{Ref: "abc4"})
+	require.NoError(t, err)
+	_, _, err = handlers.bridgePause(t.Context(), nil, BridgePauseInput{Ref: "abc4"})
+	require.NoError(t, err)
+	_, _, err = handlers.bridgeUnbind(t.Context(), nil, BridgeInput{Ref: "abc4"})
+	require.NoError(t, err)
+	require.EqualValues(t, 4, defaultRequests.Load())
+	require.EqualValues(t, 10, longRequests.Load())
+}
+
+func writeExternalRootJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	require.NoError(t, json.NewEncoder(w).Encode(value))
+}
+
+func externalConnectorFixture() map[string]any {
+	return map[string]any{
+		"instance_id": "example-connector", "connector_id": "generic.connector", "display_name": "Generic connector",
+		"protocol": "kata.connector/v1", "capabilities": []string{"fields"}, "healthy": true,
+	}
+}
+
+func externalMappingFixture(active bool) map[string]any {
+	return map[string]any{
+		"kata_field": "scheduled_on", "external_field_id": "start-date", "external_field_name": "Start date",
+		"accepted_kinds": []string{"date", "local_datetime"}, "nullable": true, "writable": true,
+		"schema_revision": "schema-v1", "active": active,
+	}
+}
+
+func externalBridgeFixture() map[string]any {
+	return map[string]any{
+		"id": 7, "uid": "01JBRIDGE00000000000000000", "project_id": 42, "issue_id": 9,
+		"connector_instance": "example-connector", "active": true, "enabled": true,
+		"receive_comments": true, "publish_comments": false, "complete_external": true,
+		"consecutive_failures": 0,
+	}
+}
+
+func externalRunFixture() map[string]any {
+	return map[string]any{
+		"bridge": externalBridgeFixture(), "root_updated": true, "comments_created": 1,
+		"comments_edited": 0, "field_conflicts": 0, "completion_requests": 0, "reopen_requests": 0, "paused": false,
+	}
+}

--- a/internal/mcp/scope.go
+++ b/internal/mcp/scope.go
@@ -195,6 +195,26 @@ func (s *Scope) Project(ctx context.Context, client *kataclient.Client, name str
 
 // IssueTarget resolves a qualified issue reference and enforces scope.
 func (s *Scope) IssueTarget(ctx context.Context, client *kataclient.Client, raw string, write bool) (ProjectIdentity, string, error) {
+	return s.issueTarget(ctx, client, raw, write, false)
+}
+
+// IssueTargetIncludingArchived resolves an issue reference within the startup
+// boundary while retaining archived projects for lifecycle cleanup operations.
+func (s *Scope) IssueTargetIncludingArchived(
+	ctx context.Context,
+	client *kataclient.Client,
+	raw string,
+	write bool,
+) (ProjectIdentity, string, error) {
+	return s.issueTarget(ctx, client, raw, write, true)
+}
+
+func (s *Scope) issueTarget(
+	ctx context.Context,
+	client *kataclient.Client,
+	raw string,
+	write, includeArchived bool,
+) (ProjectIdentity, string, error) {
 	ref := strings.TrimSpace(raw)
 	if ref == "" {
 		return ProjectIdentity{}, "", errors.New("issue reference must not be empty")
@@ -211,14 +231,14 @@ func (s *Scope) IssueTarget(ctx context.Context, client *kataclient.Client, raw 
 	}
 	projectName := parsed.Project
 	if s.mode == ScopeBound && projectName == "" {
-		projects, projectErr := s.Projects(ctx, client, false)
+		projects, projectErr := s.Projects(ctx, client, includeArchived)
 		if projectErr != nil {
 			return ProjectIdentity{}, "", projectErr
 		}
 		project := projects[0]
 		return project, ref, nil
 	}
-	project, err := s.Project(ctx, client, projectName, false)
+	project, err := s.Project(ctx, client, projectName, includeArchived)
 	if err != nil {
 		return ProjectIdentity{}, "", err
 	}

--- a/internal/mcp/sections.go
+++ b/internal/mcp/sections.go
@@ -62,6 +62,17 @@ func toolSections(storageAvailable, tokenAdminAvailable bool) []toolSection {
 			tools:       []string{"kata.digest", "kata.events"}, available: true, register: registerActivityTools,
 		},
 		{
+			loader: "kata.load_external_roots", section: "external_roots", title: "Load external-root tools",
+			description: "Load typed connector discovery, field mapping, and issue bridge tools, then refresh the MCP tool list.",
+			tools: []string{
+				"kata.bridge_bind", "kata.bridge_pause", "kata.bridge_reconcile",
+				"kata.bridge_resolve_comment", "kata.bridge_resolve_field", "kata.bridge_resume",
+				"kata.bridge_show", "kata.bridge_unbind", "kata.connector_field_map",
+				"kata.connector_field_unmap", "kata.connector_fields", "kata.connectors",
+			},
+			available: true, register: registerExternalRootTools,
+		},
+		{
 			loader: "kata.load_federation", section: "federation", title: "Load federation tools",
 			description: "Load typed federation status, enrollment revocation, rebind, leave, and quarantine tools, then refresh the MCP tool list.",
 			tools:       []string{"kata.federation_enrollment_revoke", "kata.federation_leave", "kata.federation_quarantine", "kata.federation_rebind", "kata.federation_status"},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -239,6 +239,48 @@ func inputSchemaFor[T any](toolName string) *jsonschema.Schema {
 	}
 
 	switch toolName {
+	case "kata.connectors":
+		setStringBounds("instance", 1, 128)
+	case "kata.connector_fields":
+		setStringBounds("instance", 1, 128)
+	case "kata.connector_field_map":
+		setStringBounds("instance", 1, 128)
+		setStringBounds("kata_field", 1, 64)
+		setStringBounds("external_field", 1, 256)
+		setEnum("kata_field", "scheduled_on", "deadline_on")
+	case "kata.connector_field_unmap":
+		setStringBounds("instance", 1, 128)
+		setStringBounds("kata_field", 1, 64)
+		setEnum("kata_field", "scheduled_on", "deadline_on")
+	case "kata.bridge_show", "kata.bridge_reconcile", "kata.bridge_resume", "kata.bridge_unbind":
+		setStringBounds("ref", 1, 256)
+	case "kata.bridge_bind":
+		setStringBounds("ref", 1, 256)
+		setStringBounds("connector", 1, 128)
+		setStringBounds("external", 1, 4096)
+	case "kata.bridge_pause":
+		setStringBounds("ref", 1, 256)
+		setStringBounds("reason", 1, 4096)
+	case "kata.bridge_resolve_field":
+		setStringBounds("ref", 1, 256)
+		setStringBounds("kata_field", 1, 64)
+		setEnum("kata_field", "scheduled_on", "deadline_on")
+		setEnum("use", "kata", "external")
+	case "kata.bridge_resolve_comment":
+		setStringBounds("ref", 1, 256)
+		setEnum("action", "adopt", "retry", "skip")
+		setStringBounds("external_comment_id", 1, 4096)
+		adopt := any("adopt")
+		schema.AllOf = append(schema.AllOf, &jsonschema.Schema{
+			If: &jsonschema.Schema{
+				Required: []string{"action"},
+				Properties: map[string]*jsonschema.Schema{
+					"action": {Const: &adopt},
+				},
+			},
+			Then: &jsonschema.Schema{Required: []string{"external_comment_id"}},
+			Else: &jsonschema.Schema{Not: &jsonschema.Schema{Required: []string{"external_comment_id"}}},
+		})
 	case "kata.search":
 		setStringBounds("query", 1, 4096)
 		setNumberBounds("limit", 1, maximumResultLimit)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -29,6 +29,7 @@ import (
 
 var sectionLoaderNames = []string{
 	"kata.load_activity",
+	"kata.load_external_roots",
 	"kata.load_federation",
 	"kata.load_import",
 	"kata.load_issue_discovery",
@@ -141,9 +142,21 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 
 	wantNames := []string{
 		"kata.audit_closes",
+		"kata.bridge_bind",
+		"kata.bridge_pause",
+		"kata.bridge_reconcile",
+		"kata.bridge_resolve_comment",
+		"kata.bridge_resolve_field",
+		"kata.bridge_resume",
+		"kata.bridge_show",
+		"kata.bridge_unbind",
 		"kata.claim",
 		"kata.close",
 		"kata.comment",
+		"kata.connector_field_map",
+		"kata.connector_field_unmap",
+		"kata.connector_fields",
+		"kata.connectors",
 		"kata.create",
 		"kata.delete",
 		"kata.digest",
@@ -208,6 +221,15 @@ func TestServerPublishesCurrentToolsOnly(t *testing.T) {
 		"kata.search": true, "kata.sync_once": true, "kata.sync_status": true, "kata.sync_update": true,
 	}
 	openWorld := map[string]bool{
+		"kata.bridge_bind":                  true,
+		"kata.bridge_reconcile":             true,
+		"kata.bridge_resolve_comment":       true,
+		"kata.bridge_resolve_field":         true,
+		"kata.bridge_resume":                true,
+		"kata.connector_field_map":          true,
+		"kata.connector_field_unmap":        true,
+		"kata.connector_fields":             true,
+		"kata.connectors":                   true,
 		"kata.federation_enrollment_revoke": true,
 		"kata.federation_leave":             true, "kata.federation_quarantine": true,
 		"kata.federation_rebind": true, "kata.federation_status": true, "kata.import_issues": true,
@@ -250,6 +272,9 @@ func TestServerToolAnnotationsMatchMutationRisk(t *testing.T) {
 
 	readOnly := map[string]bool{
 		"kata.audit_closes":      true,
+		"kata.bridge_show":       true,
+		"kata.connector_fields":  true,
+		"kata.connectors":        true,
 		"kata.digest":            true,
 		"kata.events":            true,
 		"kata.federation_status": true,
@@ -285,8 +310,9 @@ func TestServerToolAnnotationsMatchMutationRisk(t *testing.T) {
 		"kata.recurrence_update": true,
 		// Identical retries produce additional effects: renew extends the
 		// lease expiry again and a sync pass re-imports from the provider.
-		"kata.lease":     true,
-		"kata.sync_once": true,
+		"kata.lease":            true,
+		"kata.bridge_reconcile": true,
+		"kata.sync_once":        true,
 	}
 	for _, tool := range result.Tools {
 		annotations := tool.Annotations

--- a/internal/rootbridge/codecs.go
+++ b/internal/rootbridge/codecs.go
@@ -31,13 +31,22 @@ type FieldCodec interface {
 	ValidateExternalDescriptor(connector.FieldDescriptor) error
 }
 
-var fieldCodecs = map[string]FieldCodec{
-	"scheduled_on": scheduleCodec{key: "scheduled_on"},
-	"deadline_on":  scheduleCodec{key: "deadline_on"},
+var fieldCodecs = fieldCodecsForTimezone("")
+
+func fieldCodecsForTimezone(defaultTimezone string) map[string]FieldCodec {
+	defaultTimezone = strings.TrimSpace(defaultTimezone)
+	if defaultTimezone == "" {
+		defaultTimezone = "UTC"
+	}
+	return map[string]FieldCodec{
+		"scheduled_on": scheduleCodec{key: "scheduled_on", defaultTimezone: defaultTimezone},
+		"deadline_on":  scheduleCodec{key: "deadline_on", defaultTimezone: defaultTimezone},
+	}
 }
 
 type scheduleCodec struct {
-	key string
+	key             string
+	defaultTimezone string
 }
 
 func (c scheduleCodec) KataField() string {
@@ -61,7 +70,7 @@ func (c scheduleCodec) ReadKata(issue db.Issue) (connector.FieldValue, error) {
 	if err := json.Unmarshal(raw, &value); err != nil {
 		return connector.FieldValue{}, fmt.Errorf("decode %s: %w", c.key, err)
 	}
-	field, err := kataScheduleFieldValue(value, values)
+	field, err := kataScheduleFieldValue(value, values, c.defaultTimezone)
 	if err != nil {
 		return connector.FieldValue{}, fmt.Errorf("decode %s: %w", c.key, err)
 	}
@@ -94,7 +103,7 @@ func (c scheduleCodec) kataPatch(
 	if c.key == otherKey {
 		otherKey = "deadline_on"
 	}
-	if other, err := kataScheduleFieldValueFromMetadata(otherKey, values); err != nil {
+	if other, err := kataScheduleFieldValueFromMetadata(otherKey, values, c.defaultTimezone); err != nil {
 		return nil, err
 	} else if other.Kind == fieldKindLocalDateTime {
 		if other.Timezone != canonical.Timezone && coordinatedTimezone != canonical.Timezone {
@@ -169,7 +178,11 @@ func metadataObject(raw db.JSONBlob) (map[string]json.RawMessage, error) {
 	return values, nil
 }
 
-func kataScheduleFieldValue(value string, metadataValues map[string]json.RawMessage) (connector.FieldValue, error) {
+func kataScheduleFieldValue(
+	value string,
+	metadataValues map[string]json.RawMessage,
+	defaultTimezone string,
+) (connector.FieldValue, error) {
 	field := connector.FieldValue{Value: value}
 	switch scheduleKind(value) {
 	case fieldKindDate:
@@ -177,7 +190,7 @@ func kataScheduleFieldValue(value string, metadataValues map[string]json.RawMess
 	case fieldKindInstant:
 		field.Kind = fieldKindInstant
 	case fieldKindLocalDateTime:
-		timezone, err := metadataTimezone(metadataValues)
+		timezone, err := metadataTimezone(metadataValues, defaultTimezone)
 		if err != nil {
 			return connector.FieldValue{}, err
 		}
@@ -189,7 +202,11 @@ func kataScheduleFieldValue(value string, metadataValues map[string]json.RawMess
 	return canonicalFieldValue(field)
 }
 
-func kataScheduleFieldValueFromMetadata(key string, values map[string]json.RawMessage) (connector.FieldValue, error) {
+func kataScheduleFieldValueFromMetadata(
+	key string,
+	values map[string]json.RawMessage,
+	defaultTimezone string,
+) (connector.FieldValue, error) {
 	raw, ok := values[key]
 	if !ok || string(raw) == "null" {
 		return nullFieldValue(), nil
@@ -201,16 +218,20 @@ func kataScheduleFieldValueFromMetadata(key string, values map[string]json.RawMe
 	if err := json.Unmarshal(raw, &value); err != nil {
 		return connector.FieldValue{}, fmt.Errorf("decode %s: %w", key, err)
 	}
-	return kataScheduleFieldValue(value, values)
+	return kataScheduleFieldValue(value, values, defaultTimezone)
 }
 
-func metadataTimezone(values map[string]json.RawMessage) (string, error) {
+func metadataTimezone(values map[string]json.RawMessage, defaultTimezone string) (string, error) {
 	timezone, present, err := optionalMetadataTimezone(values)
 	if err != nil {
 		return "", err
 	}
 	if !present {
-		return "", fmt.Errorf("local date-time requires issue timezone")
+		defaultTimezone = strings.TrimSpace(defaultTimezone)
+		if defaultTimezone == "" {
+			return "UTC", nil
+		}
+		return defaultTimezone, nil
 	}
 	return timezone, nil
 }

--- a/internal/rootbridge/codecs_test.go
+++ b/internal/rootbridge/codecs_test.go
@@ -45,6 +45,35 @@ func TestScheduleCodecReadKataRejectsInvalidTimezone(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestScheduleCodecReadKataUsesConfiguredAndUTCFallbacks(t *testing.T) {
+	issue := db.Issue{Metadata: db.JSONBlob(`{"scheduled_on":"2026-08-20T09:30"}`)}
+
+	configured, err := (scheduleCodec{
+		key: "scheduled_on", defaultTimezone: "America/Chicago",
+	}).ReadKata(issue)
+	require.NoError(t, err)
+	assert.Equal(t, connector.FieldValue{
+		Kind: "local_datetime", Value: "2026-08-20T09:30", Timezone: "America/Chicago",
+	}, configured)
+
+	utc, err := fieldCodecs["scheduled_on"].ReadKata(issue)
+	require.NoError(t, err)
+	assert.Equal(t, "UTC", utc.Timezone)
+}
+
+func TestBridgeConstructorsCarryConfiguredTimezoneToCodecs(t *testing.T) {
+	issue := db.Issue{Metadata: db.JSONBlob(`{"scheduled_on":"2026-08-20T09:30"}`)}
+	reconciler := NewReconciler(nil, nil, ReconcilerConfig{DefaultTimezone: "Europe/Paris"})
+	service := NewServiceWithEventSinkAndDefaultTimezone(nil, nil, nil, nil, "Europe/Paris")
+
+	reconciled, err := reconciler.fieldCodecs["scheduled_on"].ReadKata(issue)
+	require.NoError(t, err)
+	resolved, err := service.fieldCodecs["scheduled_on"].ReadKata(issue)
+	require.NoError(t, err)
+	assert.Equal(t, "Europe/Paris", reconciled.Timezone)
+	assert.Equal(t, "Europe/Paris", resolved.Timezone)
+}
+
 func TestScheduleCodecKataPatchPreservesCivilTimesAcrossDST(t *testing.T) {
 	codec := fieldCodecs["scheduled_on"]
 	for _, value := range []connector.FieldValue{

--- a/internal/rootbridge/reconciler.go
+++ b/internal/rootbridge/reconciler.go
@@ -25,6 +25,7 @@ type ReconcilerConfig struct {
 	Now             func() time.Time
 	ClaimStaleAfter time.Duration
 	RetryAt         func(db.ExternalRootBinding, time.Time) time.Time
+	DefaultTimezone string
 }
 
 // Reconciler synchronizes one durable external-root binding at a time.
@@ -34,6 +35,7 @@ type Reconciler struct {
 	now             func() time.Time
 	claimStaleAfter time.Duration
 	retryAt         func(db.ExternalRootBinding, time.Time) time.Time
+	fieldCodecs     map[string]FieldCodec
 }
 
 type externalRootClaimLease struct {
@@ -122,7 +124,14 @@ func NewReconciler(store db.Storage, registry *Registry, config ReconcilerConfig
 	if retryAt == nil {
 		retryAt = func(_ db.ExternalRootBinding, now time.Time) time.Time { return now }
 	}
-	return &Reconciler{store: store, registry: registry, now: now, claimStaleAfter: claimStaleAfter, retryAt: retryAt}
+	codecs := fieldCodecs
+	if strings.TrimSpace(config.DefaultTimezone) != "" {
+		codecs = fieldCodecsForTimezone(config.DefaultTimezone)
+	}
+	return &Reconciler{
+		store: store, registry: registry, now: now, claimStaleAfter: claimStaleAfter,
+		retryAt: retryAt, fieldCodecs: codecs,
+	}
 }
 
 // RunOptions selects the claim path and optional immediate event delivery for
@@ -515,7 +524,7 @@ func (r *Reconciler) reconcileField(
 		hasBaseline = false
 		baseline = nullFieldValue()
 	}
-	codec, ok := fieldCodecs[mapping.KataField]
+	codec, ok := r.fieldCodecs[mapping.KataField]
 	if !ok {
 		return r.storeFieldConflict(ctx, snapshot, mapping, state, hasBaseline, nullFieldValue(), nullFieldValue(), claimToken, result)
 	}
@@ -654,7 +663,7 @@ func (r *Reconciler) coordinatedTimezoneForField(
 	if decision.Action != MergeWriteKata || external.Kind != fieldKindLocalDateTime || external.Timezone == "" {
 		return ""
 	}
-	currentCodec, ok := fieldCodecs[mapping.KataField]
+	currentCodec, ok := r.fieldCodecs[mapping.KataField]
 	if !ok {
 		return ""
 	}
@@ -671,7 +680,7 @@ func (r *Reconciler) coordinatedTimezoneForField(
 		if !sibling.Active || sibling.ID == mapping.ID {
 			continue
 		}
-		codec, ok := fieldCodecs[sibling.KataField]
+		codec, ok := r.fieldCodecs[sibling.KataField]
 		if !ok {
 			return ""
 		}

--- a/internal/rootbridge/runner.go
+++ b/internal/rootbridge/runner.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/db"
 )
 
@@ -31,7 +32,11 @@ type Runner struct {
 	MaxConcurrent int
 	Now           func() time.Time
 	EventSink     func(db.Event)
-	ErrorSink     func(error)
+	// EventSinkFrom takes precedence over EventSink and receives the admitted
+	// binding lease's fork source for hook work caused by reconciliation.
+	EventSinkFrom  func(db.Event, activity.Admission)
+	ErrorSink      func(error)
+	DrainAdmission activity.WaitableAdmission
 
 	reconcileFn func(context.Context, int64) (RunResult, error)
 
@@ -90,32 +95,63 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	sem := make(chan struct{}, concurrency)
 	var workers sync.WaitGroup
-	launch := func(bindingID int64) {
+	launch := func(bindingID int64) (<-chan struct{}, bool) {
 		select {
 		case sem <- struct{}{}:
-			workers.Go(func() {
-				defer func() {
-					if recover() != nil {
-						r.reportReconcileError(ctx, bindingID, errors.New("external root reconciliation panicked"))
-					}
-					<-sem
-					r.finished(bindingID)
-				}()
-				result, deliveredInline, err := r.reconcile(ctx, bindingID)
-				if !deliveredInline && r.EventSink != nil {
-					for _, event := range result.Events {
-						r.EventSink(event)
-					}
-				}
-				r.reportReconcileError(ctx, bindingID, err)
-			})
 		case <-ctx.Done():
 			r.finished(bindingID)
+			return nil, false
 		}
+		var drain *activity.Lease
+		if r.DrainAdmission != nil {
+			var admitted bool
+			var retry <-chan struct{}
+			drain, admitted, retry = r.DrainAdmission()
+			if !admitted {
+				<-sem
+				return retry, true
+			}
+		}
+		workers.Go(func() {
+			defer func() {
+				if recover() != nil {
+					r.reportReconcileError(ctx, bindingID, errors.New("external root reconciliation panicked"))
+				}
+				if drain != nil {
+					drain.Release()
+				}
+				<-sem
+				r.finished(bindingID)
+			}()
+			var eventFork activity.Admission
+			if drain != nil {
+				eventFork = drain.Fork
+			}
+			result, deliveredInline, err := r.reconcile(ctx, bindingID, eventFork)
+			if !deliveredInline {
+				for _, event := range result.Events {
+					r.emitEvent(event, eventFork)
+				}
+			}
+			r.reportReconcileError(ctx, bindingID, err)
+		})
+		return nil, false
 	}
-	scan := func() error {
+	scan := func() (<-chan struct{}, bool, error) {
 		if r.Store == nil {
-			return nil
+			return nil, false, nil
+		}
+		var drain *activity.Lease
+		if r.DrainAdmission != nil {
+			var admitted bool
+			var retry <-chan struct{}
+			drain, admitted, retry = r.DrainAdmission()
+			if !admitted {
+				return retry, true, nil
+			}
+		}
+		if drain != nil {
+			defer drain.Release()
 		}
 		now := time.Now().UTC()
 		if r.Now != nil {
@@ -127,19 +163,57 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 		bindings, err := r.Store.ListDueExternalRootBindings(ctx, now, now.Add(-staleAfter), defaultExternalRootBatchLimit)
 		if err != nil {
-			return err
+			return nil, false, err
 		}
 		for _, binding := range bindings {
 			r.Wake(binding.ID)
 		}
-		return nil
+		return nil, false, nil
 	}
 	reportScanError := func(err error) {
 		if ctx.Err() == nil && r.ErrorSink != nil {
 			r.ErrorSink(fmt.Errorf("scan due external root bindings: %w", err))
 		}
 	}
-	if err := scan(); err != nil {
+	waitForAdmission := func(retry <-chan struct{}) bool {
+		if retry == nil {
+			<-ctx.Done()
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-retry:
+			return true
+		}
+	}
+	runScan := func() error {
+		for {
+			retry, denied, err := scan()
+			if !denied {
+				return err
+			}
+			if !waitForAdmission(retry) {
+				return ctx.Err()
+			}
+		}
+	}
+	launchWhenAdmitted := func(bindingID int64) error {
+		for {
+			retry, denied := launch(bindingID)
+			if !denied {
+				return nil
+			}
+			if !waitForAdmission(retry) {
+				r.finished(bindingID)
+				return ctx.Err()
+			}
+		}
+	}
+	if err := runScan(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		reportScanError(err)
 	}
 	ticker := time.NewTicker(interval)
@@ -150,22 +224,45 @@ func (r *Runner) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case bindingID := <-r.WakeCh:
-			launch(bindingID)
+			if err := launchWhenAdmitted(bindingID); err != nil {
+				return err
+			}
 		case <-ticker.C:
-			if err := scan(); err != nil {
+			if err := runScan(); err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				reportScanError(err)
 			}
 		}
 	}
 }
 
-func (r *Runner) reconcile(ctx context.Context, bindingID int64) (RunResult, bool, error) {
+func (r *Runner) reconcile(
+	ctx context.Context,
+	bindingID int64,
+	eventFork activity.Admission,
+) (RunResult, bool, error) {
 	if r.reconcileFn != nil {
 		result, err := r.reconcileFn(ctx, bindingID)
 		return result, false, err
 	}
-	result, err := r.Reconciler.Run(ctx, bindingID, RunOptions{EventSink: r.EventSink})
+	eventSink := r.EventSink
+	if r.EventSinkFrom != nil {
+		eventSink = func(event db.Event) { r.EventSinkFrom(event, eventFork) }
+	}
+	result, err := r.Reconciler.Run(ctx, bindingID, RunOptions{EventSink: eventSink})
 	return result, true, err
+}
+
+func (r *Runner) emitEvent(event db.Event, fork activity.Admission) {
+	if r.EventSinkFrom != nil {
+		r.EventSinkFrom(event, fork)
+		return
+	}
+	if r.EventSink != nil {
+		r.EventSink(event)
+	}
 }
 
 func (r *Runner) reportReconcileError(ctx context.Context, bindingID int64, err error) {

--- a/internal/rootbridge/runner_test.go
+++ b/internal/rootbridge/runner_test.go
@@ -10,11 +10,103 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/activity"
 	"go.kenn.io/kata/internal/db"
 )
 
+type observedDueScanStore struct {
+	db.Storage
+	calls atomic.Int64
+}
+
+func (s *observedDueScanStore) ListDueExternalRootBindings(
+	ctx context.Context,
+	now, staleBefore time.Time,
+	limit int,
+) ([]db.ExternalRootBinding, error) {
+	s.calls.Add(1)
+	return s.Storage.ListDueExternalRootBindings(ctx, now, staleBefore, limit)
+}
+
+func TestRunnerRetriesDueScanWhenDrainAdmissionReopens(t *testing.T) {
+	h := newReconcileHarness(t)
+	store := &observedDueScanStore{Storage: h.store}
+	retry := make(chan struct{})
+	var admissions atomic.Int64
+	runner := &Runner{
+		Store: store, Reconciler: h.reconciler, Interval: time.Hour,
+		DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+			if admissions.Add(1) == 1 {
+				return nil, false, retry
+			}
+			return activity.NewLease(nil, nil), true, nil
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+
+	time.Sleep(30 * time.Millisecond)
+	assert.Zero(t, store.calls.Load(), "denied scans must not read durable work")
+	close(retry)
+	require.Eventually(t, func() bool { return store.calls.Load() == 1 }, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunnerBindingDrainProtectsReconcileAndForksEventDelivery(t *testing.T) {
+	h := newReconcileHarness(t)
+	want := db.Event{ID: 101, Type: "issue.updated", Actor: "connector:example-connector"}
+	var admissions atomic.Int64
+	var scanReleased atomic.Bool
+	var bindingReleased atomic.Bool
+	var forkAdmitted atomic.Bool
+	delivered := make(chan db.Event, 1)
+	runner := &Runner{
+		Store: h.store, Interval: time.Hour,
+		reconcileFn: func(context.Context, int64) (RunResult, error) {
+			assert.False(t, bindingReleased.Load(), "binding lease released during reconciliation")
+			return RunResult{Events: []db.Event{want}}, nil
+		},
+		DrainAdmission: func() (*activity.Lease, bool, <-chan struct{}) {
+			if admissions.Add(1) == 1 {
+				return activity.NewLease(func() { scanReleased.Store(true) }, nil), true, nil
+			}
+			fork := func() (*activity.Lease, bool) {
+				forkAdmitted.Store(true)
+				return activity.NewLease(nil, nil), true
+			}
+			return activity.NewLease(func() { bindingReleased.Store(true) }, fork), true, nil
+		},
+		EventSinkFrom: func(event db.Event, fork activity.Admission) {
+			assert.False(t, bindingReleased.Load(), "binding lease released before event delivery")
+			child, admitted := fork()
+			forkAdmitted.Store(admitted)
+			if child != nil {
+				child.Release()
+			}
+			delivered <- event
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- runner.Run(ctx) }()
+
+	select {
+	case got := <-delivered:
+		assert.Equal(t, want, got)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for drain-aware event delivery")
+	}
+	require.Eventually(t, bindingReleased.Load, time.Second, time.Millisecond)
+	assert.True(t, scanReleased.Load())
+	assert.True(t, forkAdmitted.Load())
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
 func TestRunnerDeliversRetainedEventsExactlyOnceWhenReconcileReturnsError(t *testing.T) {
-	want := db.Event{ID: 101, Type: "issue.updated", Actor: "connector:notes"}
+	want := db.Event{ID: 101, Type: "issue.updated", Actor: "connector:example-connector"}
 	delivered := make(chan db.Event, 2)
 	runner := &Runner{
 		Interval: time.Hour,
@@ -442,7 +534,7 @@ func createRunnerBinding(t *testing.T, h *reconcileHarness, index int) db.Extern
 	})
 	require.NoError(t, err)
 	binding, _, err := h.store.CreateExternalRootBinding(t.Context(), db.CreateExternalRootBindingParams{
-		ProjectID: h.project.ID, IssueID: issue.ID, ConnectorInstance: "notes",
+		ProjectID: h.project.ID, IssueID: issue.ID, ConnectorInstance: "example-connector",
 		ExternalRootKey: fmt.Sprintf("root-%d", index), ExternalAccountKey: "account-1",
 		Actor: "tester", ReceiveCommentsAfter: h.boundAt,
 	})

--- a/internal/rootbridge/service.go
+++ b/internal/rootbridge/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	immediateClaimedReconcile ImmediateClaimedReconcileFunc
 	claimStaleAfter           time.Duration
 	eventSink                 func(db.Event)
+	fieldCodecs               map[string]FieldCodec
 }
 
 // NewService constructs the external-root lifecycle service.
@@ -58,9 +59,26 @@ func NewServiceWithEventSink(
 	reconcile ImmediateClaimedReconcileFunc,
 	eventSink func(db.Event),
 ) *Service {
+	return NewServiceWithEventSinkAndDefaultTimezone(store, registry, reconcile, eventSink, "")
+}
+
+// NewServiceWithEventSinkAndDefaultTimezone constructs the lifecycle service
+// with the daemon's civil-time fallback for planning-field synchronization.
+func NewServiceWithEventSinkAndDefaultTimezone(
+	store db.Storage,
+	registry *Registry,
+	reconcile ImmediateClaimedReconcileFunc,
+	eventSink func(db.Event),
+	defaultTimezone string,
+) *Service {
+	codecs := fieldCodecs
+	if strings.TrimSpace(defaultTimezone) != "" {
+		codecs = fieldCodecsForTimezone(defaultTimezone)
+	}
 	return &Service{
 		store: store, registry: registry, immediateClaimedReconcile: reconcile,
 		claimStaleAfter: defaultExternalRootClaimStaleAfter, eventSink: eventSink,
+		fieldCodecs: codecs,
 	}
 }
 
@@ -423,7 +441,7 @@ func (s *Service) MapField(ctx context.Context, params MapFieldParams) (db.Exter
 	params.ConnectorInstance = strings.TrimSpace(params.ConnectorInstance)
 	params.KataField = strings.TrimSpace(params.KataField)
 	params.ExternalField = strings.TrimSpace(params.ExternalField)
-	codec, ok := fieldCodecs[params.KataField]
+	codec, ok := s.fieldCodecs[params.KataField]
 	if !ok {
 		return db.ExternalFieldMapping{}, fmt.Errorf("%w: unsupported Kata field", db.ErrExternalFieldMappingValidation)
 	}
@@ -462,7 +480,7 @@ func (s *Service) MapField(ctx context.Context, params MapFieldParams) (db.Exter
 func (s *Service) UnmapField(ctx context.Context, connectorInstance, kataField string) (db.ExternalFieldMapping, error) {
 	connectorInstance = strings.TrimSpace(connectorInstance)
 	kataField = strings.TrimSpace(kataField)
-	if _, ok := fieldCodecs[kataField]; !ok {
+	if _, ok := s.fieldCodecs[kataField]; !ok {
 		return db.ExternalFieldMapping{}, fmt.Errorf("%w: unsupported Kata field", db.ErrExternalFieldMappingValidation)
 	}
 	if _, err := s.requireInstance(connectorInstance); err != nil {
@@ -482,7 +500,7 @@ func (s *Service) ResolveFieldConflict(
 	kataField = strings.TrimSpace(kataField)
 	use = strings.TrimSpace(use)
 	actor = strings.TrimSpace(actor)
-	codec, ok := fieldCodecs[kataField]
+	codec, ok := s.fieldCodecs[kataField]
 	if issueID <= 0 || !ok || actor == "" {
 		return resolved, events, fmt.Errorf("%w: issue, supported Kata field, and actor are required", db.ErrExternalRootValidation)
 	}
@@ -655,13 +673,13 @@ func (s *Service) ResolveFieldConflict(
 	if use == "external" {
 		selected = storedExternal
 		coordinatedTimezone = coordinatedConflictTimezone(
-			issue, mapping, claimedMappings, claimedStates, selected,
+			s.fieldCodecs, issue, mapping, claimedMappings, claimedStates, selected,
 		)
 	}
 	kataCandidateStable := fieldValuesEqual(kataValue, storedKata)
 	if use == "external" && !kataCandidateStable {
 		kataCandidateStable = fieldValuesEqual(kataValue, selected) || coordinatedConflictKataDriftAllowed(
-			issue, mapping, claimedMappings, claimedStates, storedKata, kataValue, storedExternal,
+			s.fieldCodecs, issue, mapping, claimedMappings, claimedStates, storedKata, kataValue, storedExternal,
 		)
 	}
 	externalCandidateStable := fieldValuesEqual(externalValue, storedExternal)
@@ -746,6 +764,7 @@ func (s *Service) ResolveFieldConflict(
 }
 
 func coordinatedConflictTimezone(
+	codecs map[string]FieldCodec,
 	issue db.Issue,
 	mapping db.ExternalFieldMapping,
 	mappings []db.ExternalFieldMapping,
@@ -755,7 +774,7 @@ func coordinatedConflictTimezone(
 	if selected.Kind != fieldKindLocalDateTime || selected.Timezone == "" {
 		return ""
 	}
-	codec, ok := fieldCodecs[mapping.KataField]
+	codec, ok := codecs[mapping.KataField]
 	if !ok {
 		return ""
 	}
@@ -772,7 +791,7 @@ func coordinatedConflictTimezone(
 		if !sibling.Active || sibling.ID == mapping.ID {
 			continue
 		}
-		siblingCodec, ok := fieldCodecs[sibling.KataField]
+		siblingCodec, ok := codecs[sibling.KataField]
 		if !ok {
 			return ""
 		}
@@ -797,6 +816,7 @@ func coordinatedConflictTimezone(
 }
 
 func coordinatedConflictKataDriftAllowed(
+	codecs map[string]FieldCodec,
 	issue db.Issue,
 	mapping db.ExternalFieldMapping,
 	mappings []db.ExternalFieldMapping,
@@ -819,7 +839,7 @@ func coordinatedConflictKataDriftAllowed(
 		if !sibling.Active || sibling.ID == mapping.ID {
 			continue
 		}
-		siblingCodec, ok := fieldCodecs[sibling.KataField]
+		siblingCodec, ok := codecs[sibling.KataField]
 		if !ok {
 			return false
 		}

--- a/pkg/client/external_roots_test.go
+++ b/pkg/client/external_roots_test.go
@@ -1,0 +1,32 @@
+package client_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/pkg/client/generated"
+)
+
+func TestGeneratedExternalFieldConflictCandidatesRoundTrip(t *testing.T) {
+	input := []byte(`{
+		"kata_field":"scheduled_on",
+		"kata_candidate":{"kind":"date","value":"2026-08-21"},
+		"external_candidate":{"kind":"date","value":"2026-08-22"}
+	}`)
+	var conflict generated.ExternalFieldConflictOut
+	require.NoError(t, json.Unmarshal(input, &conflict))
+	require.NotNil(t, conflict.KataCandidate)
+	require.NotNil(t, conflict.ExternalCandidate)
+	assert.Equal(t, "date", conflict.KataCandidate.Kind)
+	require.NotNil(t, conflict.KataCandidate.Value)
+	assert.Equal(t, "2026-08-21", *conflict.KataCandidate.Value)
+	assert.Equal(t, "date", conflict.ExternalCandidate.Kind)
+	require.NotNil(t, conflict.ExternalCandidate.Value)
+	assert.Equal(t, "2026-08-22", *conflict.ExternalCandidate.Value)
+
+	encoded, err := json.Marshal(conflict)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(input), string(encoded))
+}

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -120,6 +120,24 @@ type ClientInterface interface {
 	AuditCloses(ctx context.Context, options *AuditClosesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AuditClosesResponse, error)
 	AuditClosesWithResponse(ctx context.Context, options *AuditClosesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*AuditClosesResp, error)
 
+	ListConnectors(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListConnectorsResponse, error)
+	ListConnectorsWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListConnectorsResp, error)
+
+	GetConnectorStatus(ctx context.Context, options *GetConnectorStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetConnectorStatusResponse, error)
+	GetConnectorStatusWithResponse(ctx context.Context, options *GetConnectorStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetConnectorStatusResp, error)
+
+	ReconcileExternalRootByKey(ctx context.Context, options *ReconcileExternalRootByKeyRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReconcileExternalRootByKeyResponse, error)
+	ReconcileExternalRootByKeyWithResponse(ctx context.Context, options *ReconcileExternalRootByKeyRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReconcileExternalRootByKeyResp, error)
+
+	ListConnectorFields(ctx context.Context, options *ListConnectorFieldsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListConnectorFieldsResponse, error)
+	ListConnectorFieldsWithResponse(ctx context.Context, options *ListConnectorFieldsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListConnectorFieldsResp, error)
+
+	UnmapConnectorField(ctx context.Context, options *UnmapConnectorFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnmapConnectorFieldResponse, error)
+	UnmapConnectorFieldWithResponse(ctx context.Context, options *UnmapConnectorFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnmapConnectorFieldResp, error)
+
+	MapConnectorField(ctx context.Context, options *MapConnectorFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*MapConnectorFieldResponse, error)
+	MapConnectorFieldWithResponse(ctx context.Context, options *MapConnectorFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*MapConnectorFieldResp, error)
+
 	DigestGlobal(ctx context.Context, options *DigestGlobalRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DigestGlobalResponse, error)
 	DigestGlobalWithResponse(ctx context.Context, options *DigestGlobalRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DigestGlobalResp, error)
 
@@ -284,6 +302,30 @@ type ClientInterface interface {
 
 	UnassignIssue(ctx context.Context, options *UnassignIssueRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnassignIssueResponse, error)
 	UnassignIssueWithResponse(ctx context.Context, options *UnassignIssueRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnassignIssueResp, error)
+
+	UnbindExternalRoot(ctx context.Context, options *UnbindExternalRootRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnbindExternalRootResponse, error)
+	UnbindExternalRootWithResponse(ctx context.Context, options *UnbindExternalRootRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnbindExternalRootResp, error)
+
+	GetExternalRootBridge(ctx context.Context, options *GetExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetExternalRootBridgeResponse, error)
+	GetExternalRootBridgeWithResponse(ctx context.Context, options *GetExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetExternalRootBridgeResp, error)
+
+	BindExternalRoot(ctx context.Context, options *BindExternalRootRequestOptions, reqEditors ...runtime.RequestEditorFn) (*BindExternalRootResponse, error)
+	BindExternalRootWithResponse(ctx context.Context, options *BindExternalRootRequestOptions, reqEditors ...runtime.RequestEditorFn) (*BindExternalRootResp, error)
+
+	PauseExternalRootBridge(ctx context.Context, options *PauseExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PauseExternalRootBridgeResponse, error)
+	PauseExternalRootBridgeWithResponse(ctx context.Context, options *PauseExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PauseExternalRootBridgeResp, error)
+
+	ReconcileExternalRootBridge(ctx context.Context, options *ReconcileExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReconcileExternalRootBridgeResponse, error)
+	ReconcileExternalRootBridgeWithResponse(ctx context.Context, options *ReconcileExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReconcileExternalRootBridgeResp, error)
+
+	ResolveExternalComment(ctx context.Context, options *ResolveExternalCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveExternalCommentResponse, error)
+	ResolveExternalCommentWithResponse(ctx context.Context, options *ResolveExternalCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveExternalCommentResp, error)
+
+	ResolveExternalField(ctx context.Context, options *ResolveExternalFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveExternalFieldResponse, error)
+	ResolveExternalFieldWithResponse(ctx context.Context, options *ResolveExternalFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveExternalFieldResp, error)
+
+	ResumeExternalRootBridge(ctx context.Context, options *ResumeExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResumeExternalRootBridgeResponse, error)
+	ResumeExternalRootBridgeWithResponse(ctx context.Context, options *ResumeExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResumeExternalRootBridgeResp, error)
 
 	CreateComment(ctx context.Context, options *CreateCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateCommentResponse, error)
 	CreateCommentWithResponse(ctx context.Context, options *CreateCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateCommentResp, error)
@@ -453,6 +495,379 @@ func (c *Client) AuditCloses(ctx context.Context, options *AuditClosesRequestOpt
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/audit/closes")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) ListConnectors(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListConnectorsResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/connectors",
+		Method:     "GET",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ListConnectorsResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ListConnectorsErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ListConnectorsErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ListConnectorsResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListConnectorsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) GetConnectorStatus(ctx context.Context, options *GetConnectorStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetConnectorStatusResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*GetConnectorStatusResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(GetConnectorStatusErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetConnectorStatusErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(GetConnectorStatusResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetConnectorStatusResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) ReconcileExternalRootByKey(ctx context.Context, options *ReconcileExternalRootByKeyRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReconcileExternalRootByKeyResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}/actions/reconcile-root",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ReconcileExternalRootByKeyResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ReconcileExternalRootByKeyErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ReconcileExternalRootByKeyErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ReconcileExternalRootByKeyResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ReconcileExternalRootByKeyResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}/actions/reconcile-root")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) ListConnectorFields(ctx context.Context, options *ListConnectorFieldsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListConnectorFieldsResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}/fields",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ListConnectorFieldsResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ListConnectorFieldsErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ListConnectorFieldsErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ListConnectorFieldsResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListConnectorFieldsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}/fields")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) UnmapConnectorField(ctx context.Context, options *UnmapConnectorFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnmapConnectorFieldResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}/fields/{kata_field}",
+		Method:     "DELETE",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*UnmapConnectorFieldResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(UnmapConnectorFieldErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "UnmapConnectorFieldErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(UnmapConnectorFieldResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "UnmapConnectorFieldResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}/fields/{kata_field}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) MapConnectorField(ctx context.Context, options *MapConnectorFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*MapConnectorFieldResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}/fields/{kata_field}",
+		Method:      "PUT",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*MapConnectorFieldResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(MapConnectorFieldErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "MapConnectorFieldErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(MapConnectorFieldResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "MapConnectorFieldResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}/fields/{kata_field}")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}
@@ -3899,6 +4314,518 @@ func (c *Client) UnassignIssue(ctx context.Context, options *UnassignIssueReques
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/actions/unassign")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) UnbindExternalRoot(ctx context.Context, options *UnbindExternalRootRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnbindExternalRootResponse, error) {
+	var err error
+
+	queryEncoding := map[string]runtime.QueryEncoding{
+		"actor": {Style: "form", Explode: &[]bool{false}[0]},
+	}
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:    c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge",
+		Method:        "DELETE",
+		Options:       options,
+		QueryEncoding: queryEncoding,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*UnbindExternalRootResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(UnbindExternalRootErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "UnbindExternalRootErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(UnbindExternalRootResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "UnbindExternalRootResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) GetExternalRootBridge(ctx context.Context, options *GetExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetExternalRootBridgeResponse, error) {
+	var err error
+
+	queryEncoding := map[string]runtime.QueryEncoding{
+		"actor": {Style: "form", Explode: &[]bool{false}[0]},
+	}
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:    c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge",
+		Method:        "GET",
+		Options:       options,
+		QueryEncoding: queryEncoding,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*GetExternalRootBridgeResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(GetExternalRootBridgeErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetExternalRootBridgeErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(GetExternalRootBridgeResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetExternalRootBridgeResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) BindExternalRoot(ctx context.Context, options *BindExternalRootRequestOptions, reqEditors ...runtime.RequestEditorFn) (*BindExternalRootResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*BindExternalRootResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(BindExternalRootErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "BindExternalRootErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(BindExternalRootResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "BindExternalRootResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) PauseExternalRootBridge(ctx context.Context, options *PauseExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PauseExternalRootBridgeResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/pause",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*PauseExternalRootBridgeResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(PauseExternalRootBridgeErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "PauseExternalRootBridgeErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(PauseExternalRootBridgeResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "PauseExternalRootBridgeResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/pause")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) ReconcileExternalRootBridge(ctx context.Context, options *ReconcileExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReconcileExternalRootBridgeResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/reconcile",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ReconcileExternalRootBridgeResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ReconcileExternalRootBridgeErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ReconcileExternalRootBridgeErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ReconcileExternalRootBridgeResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ReconcileExternalRootBridgeResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/reconcile")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) ResolveExternalComment(ctx context.Context, options *ResolveExternalCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveExternalCommentResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-comment",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ResolveExternalCommentResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ResolveExternalCommentErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ResolveExternalCommentErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ResolveExternalCommentResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ResolveExternalCommentResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-comment")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) ResolveExternalField(ctx context.Context, options *ResolveExternalFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveExternalFieldResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-field",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ResolveExternalFieldResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ResolveExternalFieldErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ResolveExternalFieldErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ResolveExternalFieldResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ResolveExternalFieldResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-field")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+func (c *Client) ResumeExternalRootBridge(ctx context.Context, options *ResumeExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResumeExternalRootBridgeResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resume",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ResumeExternalRootBridgeResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ResumeExternalRootBridgeErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ResumeExternalRootBridgeErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ResumeExternalRootBridgeResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ResumeExternalRootBridgeResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resume")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -50,6 +50,244 @@ func (o *AuditClosesRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// GetConnectorStatusRequestOptions is the options needed to make a request to GetConnectorStatus.
+type GetConnectorStatusRequestOptions struct {
+	PathParams *GetConnectorStatusPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetConnectorStatusRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetConnectorStatusRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetConnectorStatusRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetConnectorStatusRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetConnectorStatusRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ReconcileExternalRootByKeyRequestOptions is the options needed to make a request to ReconcileExternalRootByKey.
+type ReconcileExternalRootByKeyRequestOptions struct {
+	PathParams *ReconcileExternalRootByKeyPath
+	Body       *ReconcileExternalRootByKeyBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ReconcileExternalRootByKeyRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ReconcileExternalRootByKeyRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ReconcileExternalRootByKeyRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ReconcileExternalRootByKeyRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *ReconcileExternalRootByKeyRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ListConnectorFieldsRequestOptions is the options needed to make a request to ListConnectorFields.
+type ListConnectorFieldsRequestOptions struct {
+	PathParams *ListConnectorFieldsPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ListConnectorFieldsRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ListConnectorFieldsRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ListConnectorFieldsRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ListConnectorFieldsRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *ListConnectorFieldsRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// UnmapConnectorFieldRequestOptions is the options needed to make a request to UnmapConnectorField.
+type UnmapConnectorFieldRequestOptions struct {
+	PathParams *UnmapConnectorFieldPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *UnmapConnectorFieldRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *UnmapConnectorFieldRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *UnmapConnectorFieldRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *UnmapConnectorFieldRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *UnmapConnectorFieldRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// MapConnectorFieldRequestOptions is the options needed to make a request to MapConnectorField.
+type MapConnectorFieldRequestOptions struct {
+	PathParams *MapConnectorFieldPath
+	Body       *MapConnectorFieldBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *MapConnectorFieldRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *MapConnectorFieldRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *MapConnectorFieldRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *MapConnectorFieldRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *MapConnectorFieldRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // DigestGlobalRequestOptions is the options needed to make a request to DigestGlobal.
 type DigestGlobalRequestOptions struct {
 	Query *DigestGlobalQuery
@@ -2652,6 +2890,430 @@ func (o *UnassignIssueRequestOptions) GetBody() any {
 
 // GetHeader returns the headers as a map.
 func (o *UnassignIssueRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// UnbindExternalRootRequestOptions is the options needed to make a request to UnbindExternalRoot.
+type UnbindExternalRootRequestOptions struct {
+	PathParams *UnbindExternalRootPath
+	Query      *UnbindExternalRootQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *UnbindExternalRootRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *UnbindExternalRootRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *UnbindExternalRootRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *UnbindExternalRootRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *UnbindExternalRootRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// GetExternalRootBridgeRequestOptions is the options needed to make a request to GetExternalRootBridge.
+type GetExternalRootBridgeRequestOptions struct {
+	PathParams *GetExternalRootBridgePath
+	Query      *GetExternalRootBridgeQuery
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetExternalRootBridgeRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Query != nil {
+		if v, ok := any(o.Query).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Query", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetExternalRootBridgeRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetExternalRootBridgeRequestOptions) GetQuery() (map[string]any, error) {
+	return runtime.AsMap[any](o.Query)
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetExternalRootBridgeRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetExternalRootBridgeRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// BindExternalRootRequestOptions is the options needed to make a request to BindExternalRoot.
+type BindExternalRootRequestOptions struct {
+	PathParams *BindExternalRootPath
+	Body       *BindExternalRootBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *BindExternalRootRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *BindExternalRootRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *BindExternalRootRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *BindExternalRootRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *BindExternalRootRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// PauseExternalRootBridgeRequestOptions is the options needed to make a request to PauseExternalRootBridge.
+type PauseExternalRootBridgeRequestOptions struct {
+	PathParams *PauseExternalRootBridgePath
+	Body       *PauseExternalRootBridgeBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *PauseExternalRootBridgeRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *PauseExternalRootBridgeRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *PauseExternalRootBridgeRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *PauseExternalRootBridgeRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *PauseExternalRootBridgeRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ReconcileExternalRootBridgeRequestOptions is the options needed to make a request to ReconcileExternalRootBridge.
+type ReconcileExternalRootBridgeRequestOptions struct {
+	PathParams *ReconcileExternalRootBridgePath
+	Body       *ReconcileExternalRootBridgeBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ReconcileExternalRootBridgeRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ReconcileExternalRootBridgeRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ReconcileExternalRootBridgeRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ReconcileExternalRootBridgeRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *ReconcileExternalRootBridgeRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ResolveExternalCommentRequestOptions is the options needed to make a request to ResolveExternalComment.
+type ResolveExternalCommentRequestOptions struct {
+	PathParams *ResolveExternalCommentPath
+	Body       *ResolveExternalCommentBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ResolveExternalCommentRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ResolveExternalCommentRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ResolveExternalCommentRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ResolveExternalCommentRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *ResolveExternalCommentRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ResolveExternalFieldRequestOptions is the options needed to make a request to ResolveExternalField.
+type ResolveExternalFieldRequestOptions struct {
+	PathParams *ResolveExternalFieldPath
+	Body       *ResolveExternalFieldBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ResolveExternalFieldRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ResolveExternalFieldRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ResolveExternalFieldRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ResolveExternalFieldRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *ResolveExternalFieldRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ResumeExternalRootBridgeRequestOptions is the options needed to make a request to ResumeExternalRootBridge.
+type ResumeExternalRootBridgeRequestOptions struct {
+	PathParams *ResumeExternalRootBridgePath
+	Body       *ResumeExternalRootBridgeBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ResumeExternalRootBridgeRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ResumeExternalRootBridgeRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ResumeExternalRootBridgeRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ResumeExternalRootBridgeRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *ResumeExternalRootBridgeRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -58,6 +58,295 @@ func (c *Client) AuditClosesWithResponse(ctx context.Context, options *AuditClos
 	}
 }
 
+func (c *Client) ListConnectorsWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListConnectorsResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/connectors",
+		Method:     "GET",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ListConnectorsResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ListConnectorsResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListConnectorsResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) GetConnectorStatusWithResponse(ctx context.Context, options *GetConnectorStatusRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetConnectorStatusResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &GetConnectorStatusResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(GetConnectorStatusResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetConnectorStatusResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) ReconcileExternalRootByKeyWithResponse(ctx context.Context, options *ReconcileExternalRootByKeyRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReconcileExternalRootByKeyResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}/actions/reconcile-root",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}/actions/reconcile-root")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ReconcileExternalRootByKeyResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ReconcileExternalRootByKeyResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ReconcileExternalRootByKeyResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) ListConnectorFieldsWithResponse(ctx context.Context, options *ListConnectorFieldsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListConnectorFieldsResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}/fields",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}/fields")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ListConnectorFieldsResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ListConnectorFieldsResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListConnectorFieldsResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) UnmapConnectorFieldWithResponse(ctx context.Context, options *UnmapConnectorFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnmapConnectorFieldResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}/fields/{kata_field}",
+		Method:     "DELETE",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}/fields/{kata_field}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &UnmapConnectorFieldResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(UnmapConnectorFieldResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnmapConnectorFieldResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) MapConnectorFieldWithResponse(ctx context.Context, options *MapConnectorFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*MapConnectorFieldResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/connectors/{instance}/fields/{kata_field}",
+		Method:      "PUT",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/connectors/{instance}/fields/{kata_field}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &MapConnectorFieldResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(MapConnectorFieldResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "MapConnectorFieldResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 func (c *Client) DigestGlobalWithResponse(ctx context.Context, options *DigestGlobalRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DigestGlobalResp, error) {
 	var err error
 	reqParams := runtime.RequestOptionsParameters{
@@ -2655,6 +2944,396 @@ func (c *Client) UnassignIssueWithResponse(ctx context.Context, options *Unassig
 					ContentType:   resp.Headers.Get("Content-Type"),
 					ContentLength: len(bodyBytes),
 					TargetType:    "UnassignIssueResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) UnbindExternalRootWithResponse(ctx context.Context, options *UnbindExternalRootRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnbindExternalRootResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge",
+		Method:     "DELETE",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &UnbindExternalRootResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(UnbindExternalRootResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnbindExternalRootResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) GetExternalRootBridgeWithResponse(ctx context.Context, options *GetExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetExternalRootBridgeResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &GetExternalRootBridgeResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(GetExternalRootBridgeResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetExternalRootBridgeResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) BindExternalRootWithResponse(ctx context.Context, options *BindExternalRootRequestOptions, reqEditors ...runtime.RequestEditorFn) (*BindExternalRootResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &BindExternalRootResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(BindExternalRootResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "BindExternalRootResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) PauseExternalRootBridgeWithResponse(ctx context.Context, options *PauseExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PauseExternalRootBridgeResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/pause",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/pause")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &PauseExternalRootBridgeResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(PauseExternalRootBridgeResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PauseExternalRootBridgeResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) ReconcileExternalRootBridgeWithResponse(ctx context.Context, options *ReconcileExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ReconcileExternalRootBridgeResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/reconcile",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/reconcile")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ReconcileExternalRootBridgeResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ReconcileExternalRootBridgeResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ReconcileExternalRootBridgeResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) ResolveExternalCommentWithResponse(ctx context.Context, options *ResolveExternalCommentRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveExternalCommentResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-comment",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-comment")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ResolveExternalCommentResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ResolveExternalCommentResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResolveExternalCommentResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) ResolveExternalFieldWithResponse(ctx context.Context, options *ResolveExternalFieldRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveExternalFieldResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-field",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-field")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ResolveExternalFieldResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ResolveExternalFieldResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResolveExternalFieldResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+func (c *Client) ResumeExternalRootBridgeWithResponse(ctx context.Context, options *ResumeExternalRootBridgeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResumeExternalRootBridgeResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resume",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resume")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ResumeExternalRootBridgeResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ResumeExternalRootBridgeResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResumeExternalRootBridgeResponse",
 					Body:          bodyBytes,
 					Err:           err,
 				}

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -6,6 +6,48 @@ import (
 	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
 )
 
+type GetConnectorStatusPath struct {
+	Instance string `json:"instance" validate:"required"`
+}
+
+func (g GetConnectorStatusPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+}
+
+type ReconcileExternalRootByKeyPath struct {
+	Instance string `json:"instance" validate:"required"`
+}
+
+func (r ReconcileExternalRootByKeyPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
+type ListConnectorFieldsPath struct {
+	Instance string `json:"instance" validate:"required"`
+}
+
+func (l ListConnectorFieldsPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(l))
+}
+
+type UnmapConnectorFieldPath struct {
+	Instance  string `json:"instance" validate:"required"`
+	KataField string `json:"kata_field" validate:"required"`
+}
+
+func (u UnmapConnectorFieldPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(u))
+}
+
+type MapConnectorFieldPath struct {
+	Instance  string `json:"instance" validate:"required"`
+	KataField string `json:"kata_field" validate:"required"`
+}
+
+func (m MapConnectorFieldPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(m))
+}
+
 type RevokeFederationEnrollmentPath struct {
 	EnrollmentID int64 `json:"enrollment_id"`
 }
@@ -247,6 +289,78 @@ type UnassignIssuePath struct {
 
 func (u UnassignIssuePath) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(u))
+}
+
+type UnbindExternalRootPath struct {
+	ProjectID int64  `json:"project_id"`
+	Ref       string `json:"ref" validate:"required"`
+}
+
+func (u UnbindExternalRootPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(u))
+}
+
+type GetExternalRootBridgePath struct {
+	ProjectID int64  `json:"project_id"`
+	Ref       string `json:"ref" validate:"required"`
+}
+
+func (g GetExternalRootBridgePath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+}
+
+type BindExternalRootPath struct {
+	ProjectID int64  `json:"project_id"`
+	Ref       string `json:"ref" validate:"required"`
+}
+
+func (b BindExternalRootPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(b))
+}
+
+type PauseExternalRootBridgePath struct {
+	ProjectID int64  `json:"project_id"`
+	Ref       string `json:"ref" validate:"required"`
+}
+
+func (p PauseExternalRootBridgePath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(p))
+}
+
+type ReconcileExternalRootBridgePath struct {
+	ProjectID int64  `json:"project_id"`
+	Ref       string `json:"ref" validate:"required"`
+}
+
+func (r ReconcileExternalRootBridgePath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
+type ResolveExternalCommentPath struct {
+	ProjectID int64  `json:"project_id"`
+	Ref       string `json:"ref" validate:"required"`
+}
+
+func (r ResolveExternalCommentPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
+type ResolveExternalFieldPath struct {
+	ProjectID int64  `json:"project_id"`
+	Ref       string `json:"ref" validate:"required"`
+}
+
+func (r ResolveExternalFieldPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
+type ResumeExternalRootBridgePath struct {
+	ProjectID int64  `json:"project_id"`
+	Ref       string `json:"ref" validate:"required"`
+}
+
+func (r ResumeExternalRootBridgePath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
 }
 
 type CreateCommentPath struct {

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -2,6 +2,10 @@
 
 package generated
 
+type ReconcileExternalRootByKeyBody = ReconcileExternalRootByKeyRequestBody
+
+type MapConnectorFieldBody = MapConnectorFieldRequestBody
+
 type CreateFederationEnrollmentBody = CreateFederationEnrollmentRequestBody
 
 type RotateFederationEnrollmentBody = RotateFederationEnrollmentRequestBody
@@ -59,6 +63,18 @@ type ReopenIssueBody = ActionRequestBody
 type RestoreIssueBody = RestoreRequestBody
 
 type UnassignIssueBody = UnassignRequestBody
+
+type BindExternalRootBody = BindExternalRootRequestBody
+
+type PauseExternalRootBridgeBody = ExternalRootActionRequestBody
+
+type ReconcileExternalRootBridgeBody = ExternalRootActionRequestBody
+
+type ResolveExternalCommentBody = ResolveExternalCommentRequestBody
+
+type ResolveExternalFieldBody = ResolveExternalFieldRequestBody
+
+type ResumeExternalRootBridgeBody = ExternalRootActionRequestBody
 
 type CreateCommentBody = CommentRequestBody
 

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -164,6 +164,14 @@ type ShowIssueQuery struct {
 	IncludeDeleted *bool `json:"include_deleted,omitempty"`
 }
 
+type UnbindExternalRootQuery struct {
+	Actor *string `json:"actor,omitempty"`
+}
+
+type GetExternalRootBridgeQuery struct {
+	Actor *string `json:"actor,omitempty"`
+}
+
 type ReachableIssueGraphQuery struct {
 	// Depth full or a bounded hop count such as 1, 2, or 3
 	Depth    *string `json:"depth,omitempty"`

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -8,6 +8,30 @@ type AuditClosesResponse = AuditClosesResponseBody
 
 type AuditClosesErrorResponse = ErrorEnvelope
 
+type ListConnectorsResponse = ConnectorListResponseBody
+
+type ListConnectorsErrorResponse = ErrorEnvelope
+
+type GetConnectorStatusResponse = ConnectorOut
+
+type GetConnectorStatusErrorResponse = ErrorEnvelope
+
+type ReconcileExternalRootByKeyResponse = ExternalRootRunOut
+
+type ReconcileExternalRootByKeyErrorResponse = ErrorEnvelope
+
+type ListConnectorFieldsResponse = ConnectorFieldsResponseBody
+
+type ListConnectorFieldsErrorResponse = ErrorEnvelope
+
+type UnmapConnectorFieldResponse = ExternalFieldMappingOut
+
+type UnmapConnectorFieldErrorResponse = ErrorEnvelope
+
+type MapConnectorFieldResponse = ExternalFieldMappingOut
+
+type MapConnectorFieldErrorResponse = ErrorEnvelope
+
 type DigestGlobalResponse = DigestResponseBody
 
 type DigestGlobalErrorResponse = ErrorEnvelope
@@ -225,6 +249,38 @@ type UnassignIssueResponse = MutationResponseBody
 
 type UnassignIssueErrorResponse = ErrorEnvelope
 
+type UnbindExternalRootResponse = ExternalRootBridgeOut
+
+type UnbindExternalRootErrorResponse = ErrorEnvelope
+
+type GetExternalRootBridgeResponse = ExternalRootBridgeOut
+
+type GetExternalRootBridgeErrorResponse = ErrorEnvelope
+
+type BindExternalRootResponse = ExternalRootBridgeOut
+
+type BindExternalRootErrorResponse = ErrorEnvelope
+
+type PauseExternalRootBridgeResponse = ExternalRootBridgeOut
+
+type PauseExternalRootBridgeErrorResponse = ErrorEnvelope
+
+type ReconcileExternalRootBridgeResponse = ExternalRootRunOut
+
+type ReconcileExternalRootBridgeErrorResponse = ErrorEnvelope
+
+type ResolveExternalCommentResponse = ExternalRootBridgeOut
+
+type ResolveExternalCommentErrorResponse = ErrorEnvelope
+
+type ResolveExternalFieldResponse = ExternalRootBridgeOut
+
+type ResolveExternalFieldErrorResponse = ErrorEnvelope
+
+type ResumeExternalRootBridgeResponse = ExternalRootBridgeOut
+
+type ResumeExternalRootBridgeErrorResponse = ErrorEnvelope
+
 type CreateCommentResponse = CommentResponseBody
 
 type CreateCommentErrorResponse = ErrorEnvelope
@@ -352,6 +408,48 @@ type AuditClosesResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *AuditClosesResponse
+}
+
+type ListConnectorsResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ListConnectorsResponse
+}
+
+type GetConnectorStatusResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *GetConnectorStatusResponse
+}
+
+type ReconcileExternalRootByKeyResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ReconcileExternalRootByKeyResponse
+}
+
+type ListConnectorFieldsResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ListConnectorFieldsResponse
+}
+
+type UnmapConnectorFieldResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *UnmapConnectorFieldResponse
+}
+
+type MapConnectorFieldResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *MapConnectorFieldResponse
 }
 
 type DigestGlobalResp struct {
@@ -734,6 +832,62 @@ type UnassignIssueResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *UnassignIssueResponse
+}
+
+type UnbindExternalRootResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *UnbindExternalRootResponse
+}
+
+type GetExternalRootBridgeResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *GetExternalRootBridgeResponse
+}
+
+type BindExternalRootResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *BindExternalRootResponse
+}
+
+type PauseExternalRootBridgeResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *PauseExternalRootBridgeResponse
+}
+
+type ReconcileExternalRootBridgeResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ReconcileExternalRootBridgeResponse
+}
+
+type ResolveExternalCommentResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ResolveExternalCommentResponse
+}
+
+type ResolveExternalFieldResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ResolveExternalFieldResponse
+}
+
+type ResumeExternalRootBridgeResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ResumeExternalRootBridgeResponse
 }
 
 type CreateCommentResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -153,6 +153,17 @@ func (a AuthInfoOut) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(a))
 }
 
+type BindExternalRootRequestBody struct {
+	Actor           *string `json:"actor,omitempty"`
+	Connector       string  `json:"connector" validate:"required"`
+	External        string  `json:"external" validate:"required"`
+	PublishComments *bool   `json:"publish_comments,omitempty"`
+}
+
+func (b BindExternalRootRequestBody) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(b))
+}
+
 type ChildCounts struct {
 	Open  int64 `json:"open"`
 	Total int64 `json:"total"`
@@ -499,6 +510,59 @@ func (c CommentResponseBody) Validate() error {
 		return nil
 	}
 	return errors
+}
+
+type ConnectorFieldsResponseBody struct {
+	Fields []FieldDescriptor `json:"fields,omitempty" validate:"required"`
+}
+
+func (c ConnectorFieldsResponseBody) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range c.Fields {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Fields[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ConnectorListResponseBody struct {
+	Connectors []ConnectorOut `json:"connectors,omitempty" validate:"required"`
+}
+
+func (c ConnectorListResponseBody) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range c.Connectors {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Connectors[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ConnectorOut struct {
+	AccountIdentity *string  `json:"account_identity,omitempty"`
+	Capabilities    []string `json:"capabilities,omitempty"`
+	ConnectorID     *string  `json:"connector_id,omitempty"`
+	DisplayName     *string  `json:"display_name,omitempty"`
+	HealthError     *string  `json:"health_error,omitempty"`
+	Healthy         bool     `json:"healthy"`
+	InstanceID      string   `json:"instance_id" validate:"required"`
+	Protocol        *string  `json:"protocol,omitempty"`
+}
+
+func (c ConnectorOut) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
 }
 
 type CreateFederationEnrollmentRequestBody struct {
@@ -1068,6 +1132,136 @@ func (e Evidence) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(e))
 }
 
+type ExternalFieldCandidateOut struct {
+	Kind     string  `json:"kind" validate:"required"`
+	Timezone *string `json:"timezone,omitempty"`
+	Value    *string `json:"value,omitempty"`
+}
+
+func (e ExternalFieldCandidateOut) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(e))
+}
+
+type ExternalFieldConflictOut struct {
+	ConflictAt        *time.Time                 `json:"conflict_at,omitempty"`
+	ExternalCandidate *ExternalFieldCandidateOut `json:"external_candidate,omitempty"`
+	KataCandidate     *ExternalFieldCandidateOut `json:"kata_candidate,omitempty"`
+	KataField         string                     `json:"kata_field" validate:"required"`
+}
+
+func (e ExternalFieldConflictOut) Validate() error {
+	var errors runtime.ValidationErrors
+	if e.ExternalCandidate != nil {
+		if v, ok := any(e.ExternalCandidate).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("ExternalCandidate", err)
+			}
+		}
+	}
+	if e.KataCandidate != nil {
+		if v, ok := any(e.KataCandidate).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("KataCandidate", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(e.KataField, "required"); err != nil {
+		errors = errors.Append("KataField", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ExternalFieldMappingOut struct {
+	AcceptedKinds     []string `json:"accepted_kinds,omitempty" validate:"required"`
+	Active            bool     `json:"active"`
+	ExternalFieldID   string   `json:"external_field_id" validate:"required"`
+	ExternalFieldName string   `json:"external_field_name" validate:"required"`
+	KataField         string   `json:"kata_field" validate:"required"`
+	Nullable          bool     `json:"nullable"`
+	SchemaRevision    string   `json:"schema_revision" validate:"required"`
+	Writable          bool     `json:"writable"`
+}
+
+func (e ExternalFieldMappingOut) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(e))
+}
+
+type ExternalRootActionRequestBody struct {
+	Actor  *string `json:"actor,omitempty"`
+	Reason *string `json:"reason,omitempty"`
+}
+
+type ExternalRootBridgeOut struct {
+	Active              bool                       `json:"active"`
+	CompleteExternal    bool                       `json:"complete_external"`
+	ConnectorInstance   string                     `json:"connector_instance" validate:"required"`
+	ConsecutiveFailures int64                      `json:"consecutive_failures"`
+	Enabled             bool                       `json:"enabled"`
+	FieldConflicts      []ExternalFieldConflictOut `json:"field_conflicts,omitempty"`
+	ID                  int64                      `json:"id"`
+	IssueID             int64                      `json:"issue_id"`
+	LastAttemptAt       *time.Time                 `json:"last_attempt_at,omitempty"`
+	LastError           *string                    `json:"last_error,omitempty"`
+	LastErrorAt         *time.Time                 `json:"last_error_at,omitempty"`
+	LastExternalState   *string                    `json:"last_external_state,omitempty"`
+	LastSuccessAt       *time.Time                 `json:"last_success_at,omitempty"`
+	NextAttemptAt       *time.Time                 `json:"next_attempt_at,omitempty"`
+	PausedReason        *string                    `json:"paused_reason,omitempty"`
+	PendingCommentUID   *string                    `json:"pending_comment_uid,omitempty"`
+	ProjectID           int64                      `json:"project_id"`
+	PublishComments     bool                       `json:"publish_comments"`
+	ReceiveComments     bool                       `json:"receive_comments"`
+	UID                 string                     `json:"uid" validate:"required"`
+}
+
+func (e ExternalRootBridgeOut) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(e.ConnectorInstance, "required"); err != nil {
+		errors = errors.Append("ConnectorInstance", err)
+	}
+	for i, item := range e.FieldConflicts {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("FieldConflicts[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(e.UID, "required"); err != nil {
+		errors = errors.Append("UID", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ExternalRootRunOut struct {
+	Bridge             ExternalRootBridgeOut `json:"bridge"`
+	CommentsCreated    int64                 `json:"comments_created"`
+	CommentsEdited     int64                 `json:"comments_edited"`
+	CompletionRequests int64                 `json:"completion_requests"`
+	FieldConflicts     int64                 `json:"field_conflicts"`
+	Paused             bool                  `json:"paused"`
+	ReopenRequests     int64                 `json:"reopen_requests"`
+	RootUpdated        bool                  `json:"root_updated"`
+}
+
+func (e ExternalRootRunOut) Validate() error {
+	var errors runtime.ValidationErrors
+	if v, ok := any(e.Bridge).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Bridge", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type FederationBindingOut struct {
 	Actor                *string    `json:"actor,omitempty"`
 	CreatedAt            time.Time  `json:"created_at" validate:"required"`
@@ -1291,6 +1485,19 @@ type FederationViolationSummary struct {
 }
 
 func (f FederationViolationSummary) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(f))
+}
+
+type FieldDescriptor struct {
+	AcceptedKinds  []string `json:"accepted_kinds,omitempty" validate:"required"`
+	DisplayName    string   `json:"display_name" validate:"required"`
+	ID             string   `json:"id" validate:"required"`
+	Nullable       bool     `json:"nullable"`
+	SchemaRevision string   `json:"schema_revision" validate:"required"`
+	Writable       bool     `json:"writable"`
+}
+
+func (f FieldDescriptor) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(f))
 }
 
@@ -2291,6 +2498,14 @@ func (l ListTokensResponseBody) Validate() error {
 	return errors
 }
 
+type MapConnectorFieldRequestBody struct {
+	ExternalField string `json:"external_field" validate:"required"`
+}
+
+func (m MapConnectorFieldRequestBody) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(m))
+}
+
 type MergeProjectRequestBody struct {
 	Actor           *string `json:"actor,omitempty"`
 	SourceProjectID int64   `json:"source_project_id"`
@@ -3104,6 +3319,14 @@ func (r RebindFederationReplicaResponseBody) Validate() error {
 	return errors
 }
 
+type ReconcileExternalRootByKeyRequestBody struct {
+	RootKey string `json:"root_key" validate:"required"`
+}
+
+func (r ReconcileExternalRootByKeyRequestBody) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
 type Recurrence struct {
 	Author              string         `json:"author" validate:"required"`
 	CreatedAt           time.Time      `json:"created_at" validate:"required"`
@@ -3183,6 +3406,26 @@ type RenameProjectRequestBody struct {
 }
 
 func (r RenameProjectRequestBody) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
+type ResolveExternalCommentRequestBody struct {
+	Action            string  `json:"action" validate:"required"`
+	Actor             *string `json:"actor,omitempty"`
+	ExternalCommentID *string `json:"external_comment_id,omitempty"`
+}
+
+func (r ResolveExternalCommentRequestBody) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
+type ResolveExternalFieldRequestBody struct {
+	Actor     *string `json:"actor,omitempty"`
+	KataField string  `json:"kata_field" validate:"required"`
+	Use       string  `json:"use" validate:"required"`
+}
+
+func (r ResolveExternalFieldRequestBody) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(r))
 }
 

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -133,6 +133,21 @@ components:
       required:
         - kind
       type: object
+    BindExternalRootRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        connector:
+          type: string
+        external:
+          type: string
+        publish_comments:
+          type: boolean
+      required:
+        - connector
+        - external
+      type: object
     ChildCounts:
       properties:
         open:
@@ -319,6 +334,51 @@ components:
         - comment
         - event
         - changed
+      type: object
+    ConnectorFieldsResponseBody:
+      properties:
+        fields:
+          items:
+            $ref: "#/components/schemas/FieldDescriptor"
+          nullable: true
+          type: array
+      required:
+        - fields
+      type: object
+    ConnectorListResponseBody:
+      properties:
+        connectors:
+          items:
+            $ref: "#/components/schemas/ConnectorOut"
+          nullable: true
+          type: array
+      required:
+        - connectors
+      type: object
+    ConnectorOut:
+      properties:
+        account_identity:
+          type: string
+        capabilities:
+          items:
+            type: string
+          nullable: true
+          type: array
+        connector_id:
+          type: string
+        display_name:
+          type: string
+        health_error:
+          type: string
+        healthy:
+          type: boolean
+        instance_id:
+          type: string
+        protocol:
+          type: string
+      required:
+        - instance_id
+        - healthy
       type: object
     CreateFederationEnrollmentRequestBody:
       additionalProperties: false
@@ -967,6 +1027,169 @@ components:
       required:
         - type
       type: object
+    ExternalFieldCandidateOut:
+      properties:
+        kind:
+          type: string
+        timezone:
+          type: string
+        value:
+          type: string
+      required:
+        - kind
+      type: object
+    ExternalFieldConflictOut:
+      properties:
+        conflict_at:
+          format: date-time
+          type: string
+        external_candidate:
+          $ref: "#/components/schemas/ExternalFieldCandidateOut"
+        kata_candidate:
+          $ref: "#/components/schemas/ExternalFieldCandidateOut"
+        kata_field:
+          type: string
+      required:
+        - kata_field
+      type: object
+    ExternalFieldMappingOut:
+      properties:
+        accepted_kinds:
+          items:
+            type: string
+          nullable: true
+          type: array
+        active:
+          type: boolean
+        external_field_id:
+          type: string
+        external_field_name:
+          type: string
+        kata_field:
+          type: string
+        nullable:
+          type: boolean
+        schema_revision:
+          type: string
+        writable:
+          type: boolean
+      required:
+        - kata_field
+        - external_field_id
+        - external_field_name
+        - accepted_kinds
+        - nullable
+        - writable
+        - schema_revision
+        - active
+      type: object
+    ExternalRootActionRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        reason:
+          type: string
+      type: object
+    ExternalRootBridgeOut:
+      properties:
+        active:
+          type: boolean
+        complete_external:
+          type: boolean
+        connector_instance:
+          type: string
+        consecutive_failures:
+          format: int64
+          type: integer
+        enabled:
+          type: boolean
+        field_conflicts:
+          items:
+            $ref: "#/components/schemas/ExternalFieldConflictOut"
+          nullable: true
+          type: array
+        id:
+          format: int64
+          type: integer
+        issue_id:
+          format: int64
+          type: integer
+        last_attempt_at:
+          format: date-time
+          type: string
+        last_error:
+          type: string
+        last_error_at:
+          format: date-time
+          type: string
+        last_external_state:
+          type: string
+        last_success_at:
+          format: date-time
+          type: string
+        next_attempt_at:
+          format: date-time
+          type: string
+        paused_reason:
+          type: string
+        pending_comment_uid:
+          type: string
+        project_id:
+          format: int64
+          type: integer
+        publish_comments:
+          type: boolean
+        receive_comments:
+          type: boolean
+        uid:
+          type: string
+      required:
+        - id
+        - uid
+        - project_id
+        - issue_id
+        - connector_instance
+        - active
+        - enabled
+        - receive_comments
+        - publish_comments
+        - complete_external
+        - consecutive_failures
+      type: object
+    ExternalRootRunOut:
+      properties:
+        bridge:
+          $ref: "#/components/schemas/ExternalRootBridgeOut"
+        comments_created:
+          format: int64
+          type: integer
+        comments_edited:
+          format: int64
+          type: integer
+        completion_requests:
+          format: int64
+          type: integer
+        field_conflicts:
+          format: int64
+          type: integer
+        paused:
+          type: boolean
+        reopen_requests:
+          format: int64
+          type: integer
+        root_updated:
+          type: boolean
+      required:
+        - bridge
+        - root_updated
+        - comments_created
+        - comments_edited
+        - field_conflicts
+        - completion_requests
+        - reopen_requests
+        - paused
+      type: object
     FederationBindingOut:
       properties:
         actor:
@@ -1370,6 +1593,31 @@ components:
         - event_uid
         - issue_uid
         - at
+      type: object
+    FieldDescriptor:
+      properties:
+        accepted_kinds:
+          items:
+            type: string
+          nullable: true
+          type: array
+        display_name:
+          type: string
+        id:
+          type: string
+        nullable:
+          type: boolean
+        schema_revision:
+          type: string
+        writable:
+          type: boolean
+      required:
+        - id
+        - display_name
+        - accepted_kinds
+        - nullable
+        - writable
+        - schema_revision
       type: object
     HealthResponseBody:
       properties:
@@ -2337,6 +2585,14 @@ components:
       required:
         - tokens
       type: object
+    MapConnectorFieldRequestBody:
+      additionalProperties: false
+      properties:
+        external_field:
+          type: string
+      required:
+        - external_field
+      type: object
     MergeProjectRequestBody:
       additionalProperties: false
       properties:
@@ -3206,6 +3462,14 @@ components:
         - new_origin
         - state
       type: object
+    ReconcileExternalRootByKeyRequestBody:
+      additionalProperties: false
+      properties:
+        root_key:
+          type: string
+      required:
+        - root_key
+      type: object
     Recurrence:
       properties:
         author:
@@ -3339,6 +3603,31 @@ components:
           type: string
       required:
         - name
+      type: object
+    ResolveExternalCommentRequestBody:
+      additionalProperties: false
+      properties:
+        action:
+          type: string
+        actor:
+          type: string
+        external_comment_id:
+          type: string
+      required:
+        - action
+      type: object
+    ResolveExternalFieldRequestBody:
+      additionalProperties: false
+      properties:
+        actor:
+          type: string
+        kata_field:
+          type: string
+        use:
+          type: string
+      required:
+        - kata_field
+        - use
       type: object
     ResolveProjectRequestBody:
       additionalProperties: false
@@ -4097,6 +4386,153 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuditClosesResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors:
+    get:
+      operationId: listConnectors
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorListResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors/{instance}:
+    get:
+      operationId: getConnectorStatus
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors/{instance}/actions/reconcile-root:
+    post:
+      operationId: reconcileExternalRootByKey
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReconcileExternalRootByKeyRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootRunOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors/{instance}/fields:
+    get:
+      operationId: listConnectorFields
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorFieldsResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/connectors/{instance}/fields/{kata_field}:
+    delete:
+      operationId: unmapConnectorField
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: kata_field
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalFieldMappingOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    put:
+      operationId: mapConnectorField
+      parameters:
+        - in: path
+          name: instance
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: kata_field
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MapConnectorFieldRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalFieldMappingOut"
           description: OK
         default:
           content:
@@ -5832,6 +6268,274 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge:
+    delete:
+      operationId: unbindExternalRoot
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: actor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    get:
+      operationId: getExternalRootBridge
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: actor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+    post:
+      operationId: bindExternalRoot
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BindExternalRootRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/pause:
+    post:
+      operationId: pauseExternalRootBridge
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExternalRootActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/reconcile:
+    post:
+      operationId: reconcileExternalRootBridge
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExternalRootActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootRunOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-comment:
+    post:
+      operationId: resolveExternalComment
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResolveExternalCommentRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-field:
+    post:
+      operationId: resolveExternalField
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResolveExternalFieldRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+  /api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resume:
+    post:
+      operationId: resumeExternalRootBridge
+      parameters:
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: ref
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExternalRootActionRequestBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalRootBridgeOut"
           description: OK
         default:
           content:

--- a/web/src/lib/api/schema.d.ts
+++ b/web/src/lib/api/schema.d.ts
@@ -20,6 +20,86 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/api/v1/connectors': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['listConnectors']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/connectors/{instance}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['getConnectorStatus']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/connectors/{instance}/actions/reconcile-root': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: operations['reconcileExternalRootByKey']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/connectors/{instance}/fields': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['listConnectorFields']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/connectors/{instance}/fields/{kata_field}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put: operations['mapConnectorField']
+    post?: never
+    delete: operations['unmapConnectorField']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/api/v1/digest': {
     parameters: {
       query?: never
@@ -800,6 +880,102 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/api/v1/projects/{project_id}/issues/{ref}/bridge': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['getExternalRootBridge']
+    put?: never
+    post: operations['bindExternalRoot']
+    delete: operations['unbindExternalRoot']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/pause': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: operations['pauseExternalRootBridge']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/reconcile': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: operations['reconcileExternalRootBridge']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-comment': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: operations['resolveExternalComment']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resolve-field': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: operations['resolveExternalField']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/api/v1/projects/{project_id}/issues/{ref}/bridge/actions/resume': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: operations['resumeExternalRootBridge']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/api/v1/projects/{project_id}/issues/{ref}/comments': {
     parameters: {
       query?: never
@@ -1317,6 +1493,12 @@ export interface components {
     } & {
       [key: string]: unknown
     }
+    BindExternalRootRequestBody: {
+      actor?: string
+      connector: string
+      external: string
+      publish_comments?: boolean
+    }
     ChildCounts: {
       /** Format: int64 */
       open: number
@@ -1415,6 +1597,28 @@ export interface components {
       comment: components['schemas']['Comment']
       event: components['schemas']['Event']
       issue: components['schemas']['Issue']
+    } & {
+      [key: string]: unknown
+    }
+    ConnectorFieldsResponseBody: {
+      fields: components['schemas']['FieldDescriptor'][] | null
+    } & {
+      [key: string]: unknown
+    }
+    ConnectorListResponseBody: {
+      connectors: components['schemas']['ConnectorOut'][] | null
+    } & {
+      [key: string]: unknown
+    }
+    ConnectorOut: {
+      account_identity?: string
+      capabilities?: string[] | null
+      connector_id?: string
+      display_name?: string
+      health_error?: string
+      healthy: boolean
+      instance_id: string
+      protocol?: string
     } & {
       [key: string]: unknown
     }
@@ -1735,6 +1939,87 @@ export interface components {
       type: string
       url?: string
     }
+    ExternalFieldCandidateOut: {
+      kind: string
+      timezone?: string
+      value?: string
+    } & {
+      [key: string]: unknown
+    }
+    ExternalFieldConflictOut: {
+      /** Format: date-time */
+      conflict_at?: string
+      external_candidate?: components['schemas']['ExternalFieldCandidateOut']
+      kata_candidate?: components['schemas']['ExternalFieldCandidateOut']
+      kata_field: string
+    } & {
+      [key: string]: unknown
+    }
+    ExternalFieldMappingOut: {
+      accepted_kinds: string[] | null
+      active: boolean
+      external_field_id: string
+      external_field_name: string
+      kata_field: string
+      nullable: boolean
+      schema_revision: string
+      writable: boolean
+    } & {
+      [key: string]: unknown
+    }
+    ExternalRootActionRequestBody: {
+      actor?: string
+      reason?: string
+    }
+    ExternalRootBridgeOut: {
+      active: boolean
+      complete_external: boolean
+      connector_instance: string
+      /** Format: int64 */
+      consecutive_failures: number
+      enabled: boolean
+      field_conflicts?: components['schemas']['ExternalFieldConflictOut'][] | null
+      /** Format: int64 */
+      id: number
+      /** Format: int64 */
+      issue_id: number
+      /** Format: date-time */
+      last_attempt_at?: string
+      last_error?: string
+      /** Format: date-time */
+      last_error_at?: string
+      last_external_state?: string
+      /** Format: date-time */
+      last_success_at?: string
+      /** Format: date-time */
+      next_attempt_at?: string
+      paused_reason?: string
+      pending_comment_uid?: string
+      /** Format: int64 */
+      project_id: number
+      publish_comments: boolean
+      receive_comments: boolean
+      uid: string
+    } & {
+      [key: string]: unknown
+    }
+    ExternalRootRunOut: {
+      bridge: components['schemas']['ExternalRootBridgeOut']
+      /** Format: int64 */
+      comments_created: number
+      /** Format: int64 */
+      comments_edited: number
+      /** Format: int64 */
+      completion_requests: number
+      /** Format: int64 */
+      field_conflicts: number
+      paused: boolean
+      /** Format: int64 */
+      reopen_requests: number
+      root_updated: boolean
+    } & {
+      [key: string]: unknown
+    }
     FederationBindingOut: {
       actor?: string
       /** Format: date-time */
@@ -1936,6 +2221,16 @@ export interface components {
       offending_origin_instance_uid?: string
       reason?: string
       short_id?: string
+    } & {
+      [key: string]: unknown
+    }
+    FieldDescriptor: {
+      accepted_kinds: string[] | null
+      display_name: string
+      id: string
+      nullable: boolean
+      schema_revision: string
+      writable: boolean
     } & {
       [key: string]: unknown
     }
@@ -2391,6 +2686,9 @@ export interface components {
     } & {
       [key: string]: unknown
     }
+    MapConnectorFieldRequestBody: {
+      external_field: string
+    }
     MergeProjectRequestBody: {
       actor?: string
       /** Format: int64 */
@@ -2834,6 +3132,9 @@ export interface components {
     } & {
       [key: string]: unknown
     }
+    ReconcileExternalRootByKeyRequestBody: {
+      root_key: string
+    }
     Recurrence: {
       author: string
       /** Format: date-time */
@@ -2899,6 +3200,16 @@ export interface components {
     RenameProjectRequestBody: {
       actor?: string
       name: string
+    }
+    ResolveExternalCommentRequestBody: {
+      action: string
+      actor?: string
+      external_comment_id?: string
+    }
+    ResolveExternalFieldRequestBody: {
+      actor?: string
+      kata_field: string
+      use: string
     }
     ResolveProjectRequestBody: {
       /** @description client-derived alias metadata; daemon resolves alias first, then falls back to name */
@@ -3245,6 +3556,200 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['AuditClosesResponseBody']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  listConnectors: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ConnectorListResponseBody']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  getConnectorStatus: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        instance: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ConnectorOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  reconcileExternalRootByKey: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        instance: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ReconcileExternalRootByKeyRequestBody']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalRootRunOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  listConnectorFields: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        instance: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ConnectorFieldsResponseBody']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  mapConnectorField: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        instance: string
+        kata_field: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MapConnectorFieldRequestBody']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalFieldMappingOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  unmapConnectorField: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        instance: string
+        kata_field: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalFieldMappingOut']
         }
       }
       /** @description Error */
@@ -5115,6 +5620,290 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['MutationResponseBody']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  getExternalRootBridge: {
+    parameters: {
+      query?: {
+        actor?: string
+      }
+      header?: never
+      path: {
+        project_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalRootBridgeOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  bindExternalRoot: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        project_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['BindExternalRootRequestBody']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalRootBridgeOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  unbindExternalRoot: {
+    parameters: {
+      query?: {
+        actor?: string
+      }
+      header?: never
+      path: {
+        project_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalRootBridgeOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  pauseExternalRootBridge: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        project_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ExternalRootActionRequestBody']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalRootBridgeOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  reconcileExternalRootBridge: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        project_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ExternalRootActionRequestBody']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalRootRunOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  resolveExternalComment: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        project_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResolveExternalCommentRequestBody']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalRootBridgeOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  resolveExternalField: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        project_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResolveExternalFieldRequestBody']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalRootBridgeOut']
+        }
+      }
+      /** @description Error */
+      default: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorEnvelope']
+        }
+      }
+    }
+  }
+  resumeExternalRootBridge: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        project_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ExternalRootActionRequestBody']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ExternalRootBridgeOut']
         }
       }
       /** @description Error */


### PR DESCRIPTION
## What changed

- add connector administration and external-root bridge endpoints to the daemon API and generated Go client
- add `kata connector` status/field-mapping commands and the full `kata bridge` bind/show/pause/resume/unbind/reconcile lifecycle
- add a progressive MCP loader with typed connector discovery, field mapping, and scoped bridge tools
- start reconciliation and event wake workers only when at least one connector is configured

## User-facing boundaries

The external root owns bound title and body. Inbound comments and lifecycle are enabled by default; outbound comments require `--publish-comments`. Planning mappings support `scheduled_on` and `deadline_on` only.

MCP bridge operations stay inside the startup project scope, connector mapping requires daemon-wide scope, and connector-process calls use the long-running client. No web UI binding indicator is included in this series.

## Scope and dependency

This is PR 4 of the delivery sequence tracked in #286 and depends on #287, #291, and #292. The branch is cumulative so it builds before those PRs merge; after they land, the review diff narrows to daemon/API/CLI/MCP integration.

Closes #286.