### PR TITLE
Use golangci-lint 2.13.1 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
-          version: v2.12.2
+          version: v2.13.1
           args: --config .golangci.yml
 
   release-scripts:


### PR DESCRIPTION
Updates the reusable test workflow to install golangci-lint 2.13.1. The
previous 2.12.2 binary was built with Go 1.26 and rejects Go 1.27 targets, so
migration PR #294 cannot reach linting until `main` uses the newer release.

This is limited to the base workflow pin. `main` continues to target Go 1.26
until #294 lands.

<sup>generated by a clanker</sup>
