### PR TITLE
refactor(db): simplify import and export representations

### DIFF
--- a/internal/db/dbtest/conformance_external_roots.go
+++ b/internal/db/dbtest/conformance_external_roots.go
@@ -258,18 +258,18 @@ func checkExternalRootBindings(t *testing.T, store db.Storage, backend Backend) 
 	earlier := time.Date(2026, 8, 20, 11, 0, 0, 0, time.UTC)
 	later := earlier.Add(900 * time.Millisecond)
 	require.NoError(t, orderingStore.ImportReplay(ctx, []db.ImportRecord{
-		{Kind: db.ImportKindExternalFieldMapping, ExternalFieldMapping: &db.ExternalFieldMappingExport{
+		&db.ExternalFieldMappingExport{
 			ConnectorInstance: "timestamp-order", KataField: "scheduled_on",
 			ExternalFieldID: "start-earlier", ExternalFieldName: "Start earlier",
 			AcceptedKinds: []string{"date"}, Nullable: true, Writable: true,
 			SchemaRevision: "schema-earlier", CreatedAt: earlier, UpdatedAt: earlier,
-		}},
-		{Kind: db.ImportKindExternalFieldMapping, ExternalFieldMapping: &db.ExternalFieldMappingExport{
+		},
+		&db.ExternalFieldMappingExport{
 			ConnectorInstance: "timestamp-order", KataField: "scheduled_on",
 			ExternalFieldID: "start-later", ExternalFieldName: "Start later",
 			AcceptedKinds: []string{"date"}, Nullable: true, Writable: true,
 			SchemaRevision: "schema-later", CreatedAt: later, UpdatedAt: later,
-		}},
+		},
 	}, db.ImportOptions{}))
 	restoreOrderingClock := backend.InstallExternalRootClock(orderingStore, func() time.Time { return later })
 	orderedMapping, err := orderingStore.UpsertExternalFieldMapping(ctx, db.ExternalFieldMappingParams{

--- a/internal/db/dbtest/conformance_replay.go
+++ b/internal/db/dbtest/conformance_replay.go
@@ -216,9 +216,11 @@ func checkSnapshotReplayCore(t *testing.T, target db.Storage, backend Backend) e
 func replayEventUIDs(records []db.ImportRecord, projectID int64) []string {
 	uids := make([]string, 0)
 	for _, record := range records {
-		if record.Event != nil && record.Event.ProjectID == projectID {
-			uids = append(uids, record.Event.UID)
+		event, ok := record.(*db.EventExport)
+		if !ok || event.ProjectID != projectID {
+			continue
 		}
+		uids = append(uids, event.UID)
 	}
 	return uids
 }
@@ -241,145 +243,145 @@ func CollectImportRecords(
 	}
 	for value, err := range store.ExportMeta(ctx) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindMeta, Meta: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export meta for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportProjects(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindProject, Project: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export projects for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportProjectAliases(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindProjectAlias, Alias: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export project aliases for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportIssueSyncBindings(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindIssueSyncBinding, IssueSyncBinding: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export issue sync bindings for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportIssueSyncStatus(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindIssueSyncStatus, IssueSyncStatus: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export issue sync status for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportRecurrences(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindRecurrence, Recurrence: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export recurrences for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportIssues(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindIssue, Issue: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export issues for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportComments(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindComment, Comment: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export comments for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportIssueLabels(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindIssueLabel, Label: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export labels for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportLinks(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindLink, Link: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export links for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportImportMappings(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindImportMapping, ImportMapping: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export mappings for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportExternalFieldMappings(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindExternalFieldMapping, ExternalFieldMapping: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export external field mappings for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportExternalRootBindings(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindExternalRootBinding, ExternalRootBinding: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export external root bindings for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportExternalFieldStates(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindExternalFieldState, ExternalFieldState: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export external field states for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportFederationBindings(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindFederationBinding, FederationBinding: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export federation bindings for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportFederationSyncStatus(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindFederationSyncStatus, FederationSyncStatus: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export federation sync status for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportFederationQuarantine(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindFederationQuarantine, FederationQuarantine: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export federation quarantine for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportFederationEnrollments(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindFederationEnrollment, FederationEnrollment: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export federation enrollments for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportIssueClaims(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindIssueClaim, IssueClaim: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export issue claims for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportPendingClaimRequests(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindPendingClaimRequest, PendingClaimRequest: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export pending claims for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportEvents(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindEvent, Event: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export events for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportPurgeLog(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindPurgeLog, PurgeLog: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export purge log for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportProjectPurgeLog(ctx, filter) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindProjectPurgeLog, ProjectPurgeLog: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export project purge log for replay: %w", err)
 		}
 	}
 	for value, err := range store.ExportSequences(ctx) {
 		v := value
-		if err := appendRecord(db.ImportRecord{Kind: db.ImportKindSQLiteSequence, Sequence: &v}, err); err != nil {
+		if err := appendRecord(&v, err); err != nil {
 			return nil, fmt.Errorf("export sequences for replay: %w", err)
 		}
 	}

--- a/internal/db/dbtest/conformance_replay_extended.go
+++ b/internal/db/dbtest/conformance_replay_extended.go
@@ -297,8 +297,8 @@ func checkSnapshotReplayRejectsInvalidExternalRootFrontiers(t *testing.T, store 
 			name: "active binding belongs to a read-only federated spoke",
 			mutate: func(records []db.ImportRecord) {
 				for index := range records {
-					if records[index].FederationBinding != nil {
-						records[index].FederationBinding.PushEnabled = false
+					if binding, ok := records[index].(*db.FederationBindingExport); ok {
+						binding.PushEnabled = false
 						return
 					}
 				}
@@ -310,8 +310,8 @@ func checkSnapshotReplayRejectsInvalidExternalRootFrontiers(t *testing.T, store 
 			name: "active binding targets issue-sync-managed content",
 			mutate: func(records []db.ImportRecord) {
 				for index := range records {
-					if records[index].IssueSyncBinding != nil {
-						records[index].IssueSyncBinding.SourceKey = "connector:connector-one"
+					if binding, ok := records[index].(*db.IssueSyncBindingExport); ok {
+						binding.SourceKey = "connector:connector-one"
 						return
 					}
 				}
@@ -376,24 +376,24 @@ func checkSnapshotReplayRejectsInvalidExternalRootFrontiers(t *testing.T, store 
 			mutate: func(records []db.ImportRecord) {
 				projectID, issueID, otherIssueID, otherCommentID := int64(41), int64(61), int64(62), int64(122)
 				replacements := map[string]db.ImportRecord{
-					db.ImportKindProjectAlias: {Kind: db.ImportKindIssue, Issue: &db.IssueExport{
+					db.ImportKindProjectAlias: &db.IssueExport{
 						ID: otherIssueID, UID: "01HZZZZZZZZZZZZZZZZZZZZZ2A", ProjectID: projectID,
 						ShortID: "zz2a", Title: "Other replay issue", Status: "open",
 						Author: "fixture-author", CreatedAt: "2026-07-15T12:00:00.000Z",
 						UpdatedAt: "2026-07-15T12:00:00.000Z", Metadata: json.RawMessage(`{}`), Revision: 1,
-					}},
-					db.ImportKindIssueEmbedding: {Kind: db.ImportKindComment, Comment: &db.CommentExport{
+					},
+					db.ImportKindIssueEmbedding: &db.CommentExport{
 						ID: otherCommentID, UID: "01HZZZZZZZZZZZZZZZZZZZZZ2B", IssueID: otherIssueID,
 						Author: "fixture-author", Body: "Other replay comment", CreatedAt: "2026-07-15T12:00:00.000Z",
-					}},
-					db.ImportKindIssueSyncStatus: {Kind: db.ImportKindImportMapping, ImportMapping: &db.ImportMappingExport{
+					},
+					db.ImportKindIssueSyncStatus: &db.ImportMappingExport{
 						ID: 132, Source: "connector:connector-one:comments:external-42",
 						ExternalID: "cross-issue-comment", ObjectType: "comment", ProjectID: projectID,
 						IssueID: &issueID, CommentID: &otherCommentID, ImportedAt: "2026-07-15T12:00:00.000Z",
-					}},
+					},
 				}
 				for index := range records {
-					originalKind := records[index].Kind
+					originalKind := records[index].ImportKind()
 					if replacement, ok := replacements[originalKind]; ok {
 						records[index] = replacement
 						delete(replacements, originalKind)
@@ -407,24 +407,24 @@ func checkSnapshotReplayRejectsInvalidExternalRootFrontiers(t *testing.T, store 
 			mutate: func(records []db.ImportRecord) {
 				projectID, otherIssueID, otherCommentID := int64(41), int64(62), int64(122)
 				replacements := map[string]db.ImportRecord{
-					db.ImportKindProjectAlias: {Kind: db.ImportKindIssue, Issue: &db.IssueExport{
+					db.ImportKindProjectAlias: &db.IssueExport{
 						ID: otherIssueID, UID: "01HZZZZZZZZZZZZZZZZZZZZZ2A", ProjectID: projectID,
 						ShortID: "zz2a", Title: "Other replay issue", Status: "open",
 						Author: "fixture-author", CreatedAt: "2026-07-15T12:00:00.000Z",
 						UpdatedAt: "2026-07-15T12:00:00.000Z", Metadata: json.RawMessage(`{}`), Revision: 1,
-					}},
-					db.ImportKindIssueEmbedding: {Kind: db.ImportKindComment, Comment: &db.CommentExport{
+					},
+					db.ImportKindIssueEmbedding: &db.CommentExport{
 						ID: otherCommentID, UID: "01HZZZZZZZZZZZZZZZZZZZZZ2B", IssueID: otherIssueID,
 						Author: "fixture-author", Body: "Other replay comment", CreatedAt: "2026-07-15T12:00:00.000Z",
-					}},
-					db.ImportKindIssueSyncStatus: {Kind: db.ImportKindImportMapping, ImportMapping: &db.ImportMappingExport{
+					},
+					db.ImportKindIssueSyncStatus: &db.ImportMappingExport{
 						ID: 132, Source: "connector:connector-one:binding:" + replayBindingUID,
 						ExternalID: "cross-binding-comment", ObjectType: "comment", ProjectID: projectID,
 						IssueID: &otherIssueID, CommentID: &otherCommentID, ImportedAt: "2026-07-15T12:00:00.000Z",
-					}},
+					},
 				}
 				for index := range records {
-					originalKind := records[index].Kind
+					originalKind := records[index].ImportKind()
 					if replacement, ok := replacements[originalKind]; ok {
 						records[index] = replacement
 						delete(replacements, originalKind)
@@ -543,11 +543,8 @@ func checkSnapshotReplayRejectsDuplicateFieldMappingIdentities(t *testing.T, sto
 	duplicate.Active = false
 
 	for index := range records {
-		if records[index].Kind == db.ImportKindProjectAlias {
-			records[index] = db.ImportRecord{
-				Kind:                 db.ImportKindExternalFieldMapping,
-				ExternalFieldMapping: &duplicate,
-			}
+		if records[index].ImportKind() == db.ImportKindProjectAlias {
+			records[index] = &duplicate
 			break
 		}
 	}
@@ -572,11 +569,8 @@ func checkSnapshotReplayPreservesSubmicrosecondFieldMappingIdentities(
 	adjacent.CreatedAt = original.CreatedAt.Add(time.Nanosecond)
 
 	for index := range records {
-		if records[index].Kind == db.ImportKindProjectAlias {
-			records[index] = db.ImportRecord{
-				Kind:                 db.ImportKindExternalFieldMapping,
-				ExternalFieldMapping: &adjacent,
-			}
+		if records[index].ImportKind() == db.ImportKindProjectAlias {
+			records[index] = &adjacent
 			break
 		}
 	}
@@ -631,32 +625,32 @@ func installBindingMapping(
 	issueID := bindingIssue
 	commentID := bindingComment
 	replacements := map[string]db.ImportRecord{
-		db.ImportKindIssueSyncStatus: {Kind: db.ImportKindImportMapping, ImportMapping: &db.ImportMappingExport{
+		db.ImportKindIssueSyncStatus: &db.ImportMappingExport{
 			ID: 132, Source: source, ExternalID: "cross-binding-object", ObjectType: objectType,
 			ProjectID: projectID, IssueID: &issueID, ImportedAt: "2026-07-15T12:00:00.000Z",
-		}},
+		},
 	}
 	if crossIssue {
 		issueID = otherIssueID
 		commentID = otherComment
-		replacements[db.ImportKindProjectAlias] = db.ImportRecord{Kind: db.ImportKindIssue, Issue: &db.IssueExport{
+		replacements[db.ImportKindProjectAlias] = &db.IssueExport{
 			ID: otherIssueID, UID: "01HZZZZZZZZZZZZZZZZZZZZZ2A", ProjectID: projectID,
 			ShortID: "zz2a", Title: "Other replay issue", Status: "open",
 			Author: "fixture-author", CreatedAt: "2026-07-15T12:00:00.000Z",
 			UpdatedAt: "2026-07-15T12:00:00.000Z", Metadata: json.RawMessage(`{}`), Revision: 1,
-		}}
+		}
 	}
 	if withComment {
 		if crossIssue {
-			replacements[db.ImportKindIssueEmbedding] = db.ImportRecord{Kind: db.ImportKindComment, Comment: &db.CommentExport{
+			replacements[db.ImportKindIssueEmbedding] = &db.CommentExport{
 				ID: otherComment, UID: "01HZZZZZZZZZZZZZZZZZZZZZ2B", IssueID: otherIssueID,
 				Author: "fixture-author", Body: "Other replay comment", CreatedAt: "2026-07-15T12:00:00.000Z",
-			}}
+			}
 		}
-		replacements[db.ImportKindIssueSyncStatus].ImportMapping.CommentID = &commentID
+		replacements[db.ImportKindIssueSyncStatus].(*db.ImportMappingExport).CommentID = &commentID
 	}
 	for index := range records {
-		originalKind := records[index].Kind
+		originalKind := records[index].ImportKind()
 		if replacement, ok := replacements[originalKind]; ok {
 			records[index] = replacement
 			delete(replacements, originalKind)
@@ -666,8 +660,8 @@ func installBindingMapping(
 
 func externalRootReplayBinding(records []db.ImportRecord) *db.ExternalRootBindingExport {
 	for _, record := range records {
-		if record.Kind == db.ImportKindExternalRootBinding {
-			return record.ExternalRootBinding
+		if binding, ok := record.(*db.ExternalRootBindingExport); ok {
+			return binding
 		}
 	}
 	panic("external root replay fixture has no binding")
@@ -675,8 +669,8 @@ func externalRootReplayBinding(records []db.ImportRecord) *db.ExternalRootBindin
 
 func externalRootReplayMapping(records []db.ImportRecord) *db.ExternalFieldMappingExport {
 	for _, record := range records {
-		if record.Kind == db.ImportKindExternalFieldMapping {
-			return record.ExternalFieldMapping
+		if mapping, ok := record.(*db.ExternalFieldMappingExport); ok {
+			return mapping
 		}
 	}
 	panic("external root replay fixture has no field mapping")
@@ -684,8 +678,8 @@ func externalRootReplayMapping(records []db.ImportRecord) *db.ExternalFieldMappi
 
 func externalRootReplayState(records []db.ImportRecord) *db.ExternalFieldStateExport {
 	for _, record := range records {
-		if record.Kind == db.ImportKindExternalFieldState {
-			return record.ExternalFieldState
+		if state, ok := record.(*db.ExternalFieldStateExport); ok {
+			return state
 		}
 	}
 	panic("external root replay fixture has no field state")
@@ -717,60 +711,60 @@ func extendedReplayRecords() []db.ImportRecord {
 	projectPurgeUID := "01HZZZZZZZZZZZZZZZZZZZZZ1D"
 	projectPurgeID := int64(90)
 	records := []db.ImportRecord{
-		{Kind: db.ImportKindMeta, Meta: &db.MetaKV{Key: "instance_uid", Value: replayInstanceUID}},
-		{Kind: db.ImportKindProject, Project: &db.ProjectExport{
+		&db.MetaKV{Key: "instance_uid", Value: replayInstanceUID},
+		&db.ProjectExport{
 			ID: projectID, UID: projectUID, Name: "extended-replay", CreatedAt: created,
 			Metadata: json.RawMessage(`{"team":"example"}`), Revision: 3,
-		}},
-		{Kind: db.ImportKindProjectAlias, Alias: &db.AliasExport{
+		},
+		&db.AliasExport{
 			ID: 141, ProjectID: projectID, AliasIdentity: "example/extended", AliasKind: "git", CreatedAt: created,
-		}},
-		{Kind: db.ImportKindIssueSyncBinding, IssueSyncBinding: &db.IssueSyncBindingExport{
+		},
+		&db.IssueSyncBindingExport{
 			ID: 71, ProjectID: projectID, Provider: "example", SourceKey: "example:42",
 			RemoteID: "42", DisplayName: "Example tracker", Config: json.RawMessage(`{"mode":"mirror"}`),
 			Enabled: true, IntervalSeconds: 300, CreatedAt: created, UpdatedAt: created,
-		}},
-		{Kind: db.ImportKindIssueSyncStatus, IssueSyncStatus: &db.IssueSyncStatusExport{
+		},
+		&db.IssueSyncStatusExport{
 			BindingID: 71, ProjectID: projectID, LastErrorAt: &issueSyncLastErrorAt, LastError: &lastError,
 			LastCreated: 2, LastUpdated: 3, LastUnchanged: 4, LastComments: 5,
-		}},
-		{Kind: db.ImportKindRecurrence, Recurrence: &db.RecurrenceExport{
+		},
+		&db.RecurrenceExport{
 			ID: recurrenceID, UID: replayRecurrenceUID, ProjectID: projectID,
 			RRule: "FREQ=WEEKLY;BYDAY=MO", DTStart: "2026-07-20", Timezone: "UTC",
 			TemplateTitle: "Weekly review", TemplateBody: "Review progress",
 			TemplateLabels: json.RawMessage(`["weekly"]`), TemplateMetadata: json.RawMessage(`{"cadence":"weekly"}`),
 			Author: "scheduler", Revision: 1, CreatedAt: created, UpdatedAt: created,
-		}},
-		{Kind: db.ImportKindIssue, Issue: &db.IssueExport{
+		},
+		&db.IssueExport{
 			ID: issueID, UID: issueUID, ProjectID: projectID, ShortID: shortID,
 			Title: "Restored recurring issue", Body: "durable state", Status: "open",
 			Author: "fixture-author", CreatedAt: created, UpdatedAt: created,
 			Metadata: json.RawMessage(`{"source":"snapshot"}`), Revision: 2, ContentRevision: 1,
 			RecurrenceID: &recurrenceID, RecurrenceUID: new(replayRecurrenceUID),
-		}},
-		{Kind: db.ImportKindIssueEmbedding, IssueEmbedding: &db.IssueEmbeddingExport{
+		},
+		&db.IssueEmbeddingExport{
 			IssueUID: issueUID, EmbeddedContentRevision: 1, Fingerprint: "legacy-vector",
 			Dims: 2, VectorB64: "AAAAAAAAgD8=",
-		}},
-		{Kind: db.ImportKindComment, Comment: &db.CommentExport{
+		},
+		&db.CommentExport{
 			ID: commentID, UID: replayCommentUID, IssueID: issueID, Author: "reviewer",
 			Body: "restored comment", CreatedAt: created,
-		}},
-		{Kind: db.ImportKindIssueLabel, Label: &db.IssueLabelExport{
+		},
+		&db.IssueLabelExport{
 			IssueID: issueID, Label: "restored", Author: "fixture-author", CreatedAt: created,
-		}},
-		{Kind: db.ImportKindImportMapping, ImportMapping: &db.ImportMappingExport{
+		},
+		&db.ImportMappingExport{
 			ID: 131, Source: "connector:connector-one", ExternalID: "external-42", ObjectType: "issue",
 			ProjectID: projectID, IssueID: &issueID, ImportedAt: created,
-		}},
-		{Kind: db.ImportKindExternalFieldMapping, ExternalFieldMapping: &db.ExternalFieldMappingExport{
+		},
+		&db.ExternalFieldMappingExport{
 			ConnectorInstance: "connector-one", KataField: "scheduled_on",
 			ExternalFieldID: "schedule-one", ExternalFieldName: "Schedule",
 			AcceptedKinds: []string{"date"}, Nullable: true, Writable: true,
 			SchemaRevision: "schema-one", Active: true,
 			CreatedAt: mappingCreatedAt, UpdatedAt: mappingCreatedAt,
-		}},
-		{Kind: db.ImportKindExternalRootBinding, ExternalRootBinding: &db.ExternalRootBindingExport{
+		},
+		&db.ExternalRootBindingExport{
 			UID: replayBindingUID, ProjectUID: projectUID, IssueUID: issueUID,
 			RootMappingSource: "connector:connector-one", RootMappingExternalID: "external-42",
 			ConnectorInstance: "connector-one", ExternalRootKey: "external-42",
@@ -781,8 +775,8 @@ func extendedReplayRecords() []db.ImportRecord {
 			LastAttemptAt: &lastAttempt, LastSuccessAt: &lastSuccess, LastErrorAt: &externalLastErrorAt,
 			LastError: "temporary connector failure", ConsecutiveFailures: 1,
 			NextAttemptAt: &nextAttempt, CreatedAt: createdTime, UpdatedAt: externalLastErrorAt,
-		}},
-		{Kind: db.ImportKindExternalFieldState, ExternalFieldState: &db.ExternalFieldStateExport{
+		},
+		&db.ExternalFieldStateExport{
 			BindingUID: replayBindingUID, MappingConnectorInstance: "connector-one",
 			MappingKataField: "scheduled_on", MappingExternalFieldID: "schedule-one",
 			MappingSchemaRevision: "schema-one", MappingCreatedAt: mappingCreatedAt,
@@ -790,54 +784,54 @@ func extendedReplayRecords() []db.ImportRecord {
 			ConflictKata:     json.RawMessage(`"2026-08-21"`),
 			ConflictExternal: json.RawMessage(`"2026-08-22"`),
 			Conflicted:       true, ConflictAt: &conflictAt, UpdatedAt: conflictAt,
-		}},
-		{Kind: db.ImportKindFederationBinding, FederationBinding: &db.FederationBindingExport{
+		},
+		&db.FederationBindingExport{
 			ProjectID: projectID, Role: "spoke", HubURL: "https://hub.example",
 			HubProjectID: 7, HubProjectUID: replayHubProjectUID, ReplayHorizonEventID: 10,
 			PullCursorEventID: 11, PushEnabled: true, PushCursorEventID: 12,
 			Actor: "sync-agent", Enabled: true, CreatedAt: created, UpdatedAt: created,
-		}},
-		{Kind: db.ImportKindFederationSyncStatus, FederationSyncStatus: &db.FederationSyncStatusExport{
+		},
+		&db.FederationSyncStatusExport{
 			ProjectID: projectID, LastErrorAt: &issueSyncLastErrorAt, LastError: new("connection reset"),
-		}},
-		{Kind: db.ImportKindFederationQuarantine, FederationQuarantine: &db.FederationQuarantineExport{
+		},
+		&db.FederationQuarantineExport{
 			ID: 91, ProjectID: projectID, Direction: "pull", FirstEventID: 20, LastEventID: 21,
 			EventUIDs: json.RawMessage(`["event-one","event-two"]`), Error: "invalid remote event", CreatedAt: created,
-		}},
-		{Kind: db.ImportKindFederationEnrollment, FederationEnrollment: &db.FederationEnrollmentExport{
+		},
+		&db.FederationEnrollmentExport{
 			ID: 81, TokenHash: strings.Repeat("a", 64), SpokeInstanceUID: replaySpokeUID,
 			ProjectID: &projectID, Capabilities: "pull,push", Actor: "sync-agent",
 			CreatedAt: created, UpdatedAt: created,
-		}},
-		{Kind: db.ImportKindIssueClaim, IssueClaim: &db.IssueClaimExport{
+		},
+		&db.IssueClaimExport{
 			ID: 101, ClaimUID: replayClaimUID, ProjectID: projectID, IssueID: issueID,
 			IssueUID: issueUID, Holder: "worker", HolderInstanceUID: replaySpokeUID,
 			ClientKind: "agent", Purpose: "implementation", ClaimKind: "hard",
 			AcquiredAt: created, Revision: 1, UpdatedAt: created,
-		}},
-		{Kind: db.ImportKindPendingClaimRequest, PendingClaimRequest: &db.PendingClaimRequestExport{
+		},
+		&db.PendingClaimRequestExport{
 			ID: 111, RequestUID: replayPendingUID, ProjectID: projectID, IssueID: issueID,
 			IssueUID: issueUID, Holder: "reviewer", HolderInstanceUID: replayInstanceUID,
 			ClientKind: "cli", ClaimKind: "hard", Purpose: "review", RequestedAt: created,
-		}},
-		{Kind: db.ImportKindPurgeLog, PurgeLog: &db.PurgeLogExport{
+		},
+		&db.PurgeLogExport{
 			ID: 161, UID: replayPurgeUID, OriginInstanceUID: replayInstanceUID,
 			ProjectID: projectID, PurgedIssueID: 160, IssueUID: new("01HZZZZZZZZZZZZZZZZZZZZZ1E"),
 			ProjectUID: &projectUID, ProjectName: "extended-replay", ShortID: &purgeShortID,
 			IssueTitle: "Purged issue", IssueAuthor: "fixture-author", EventCount: 2,
 			PurgeResetAfterEventID: new(int64(100)), Actor: "operator", Reason: &reason, PurgedAt: created,
-		}},
-		{Kind: db.ImportKindProjectPurgeLog, ProjectPurgeLog: &db.ProjectPurgeLogExport{
+		},
+		&db.ProjectPurgeLogExport{
 			ID: 151, UID: replayProjectPurge, OriginInstanceUID: replayInstanceUID,
 			ProjectID: projectPurgeID, ProjectUID: &projectPurgeUID, ProjectName: "retired-project",
 			IssueCount: 2, EventCount: 3, AliasCount: 1, CommentCount: 1, LinkCount: 1,
 			LabelCount: 1, ClaimCount: 1, PendingClaimRequestCount: 1,
 			PurgeResetAfterEventID: new(int64(101)), Actor: "operator", Reason: &reason, PurgedAt: created,
-		}},
+		},
 	}
 	for name, floor := range replaySequenceFloors() {
 		sequence := db.SequenceExport{Name: name, Seq: floor}
-		records = append(records, db.ImportRecord{Kind: db.ImportKindSQLiteSequence, Sequence: &sequence})
+		records = append(records, &sequence)
 	}
 	return records
 }
@@ -875,30 +869,30 @@ func checkSnapshotReplayCompatibilityOptions(t *testing.T, store db.Storage) err
 	projectID := int64(5)
 	issueID := int64(6)
 	recurrenceRecords := []db.ImportRecord{
-		{Kind: db.ImportKindMeta, Meta: &db.MetaKV{Key: "instance_uid", Value: replayInstanceUID}},
-		{Kind: db.ImportKindProject, Project: &db.ProjectExport{
+		&db.MetaKV{Key: "instance_uid", Value: replayInstanceUID},
+		&db.ProjectExport{
 			ID: projectID, UID: replayProjectUID, Name: "compatibility-replay", CreatedAt: created,
 			Metadata: json.RawMessage(`{}`), Revision: 1,
-		}},
-		{Kind: db.ImportKindIssueSyncBinding, IssueSyncBinding: &db.IssueSyncBindingExport{
+		},
+		&db.IssueSyncBindingExport{
 			ID: 7, ProjectID: projectID, Provider: "example", SourceKey: "example:compat",
 			RemoteID: "compat", DisplayName: "Compatibility source", Config: json.RawMessage(`{}`),
 			Enabled: true, IntervalSeconds: 60, CreatedAt: created, UpdatedAt: created,
-		}},
-		{Kind: db.ImportKindIssue, Issue: &db.IssueExport{
+		},
+		&db.IssueExport{
 			ID: issueID, UID: replayIssueUID, ProjectID: projectID, ShortID: "zz12",
 			Title: "Legacy replay issue", Status: "open", Author: "fixture-author",
 			CreatedAt: created, UpdatedAt: created, Metadata: json.RawMessage(`{}`), Revision: 1,
-		}},
-		{Kind: db.ImportKindComment, Comment: &db.CommentExport{
+		},
+		&db.CommentExport{
 			ID: 10, UID: replayCommentUID, IssueID: issueID, Author: "fixture-author",
 			Body: "pending external comment", CreatedAt: created,
-		}},
-		{Kind: db.ImportKindImportMapping, ImportMapping: &db.ImportMappingExport{
+		},
+		&db.ImportMappingExport{
 			ID: 11, Source: "connector:connector-cutover", ExternalID: "root-cutover",
 			ObjectType: "issue", ProjectID: projectID, IssueID: &issueID, ImportedAt: created,
-		}},
-		{Kind: db.ImportKindExternalRootBinding, ExternalRootBinding: &db.ExternalRootBindingExport{
+		},
+		&db.ExternalRootBindingExport{
 			UID: replayBindingUID, ProjectUID: replayProjectUID, IssueUID: replayIssueUID,
 			RootMappingSource: "connector:connector-cutover", RootMappingExternalID: "root-cutover",
 			ConnectorInstance: "connector-cutover", ExternalRootKey: "root-cutover",
@@ -906,25 +900,25 @@ func checkSnapshotReplayCompatibilityOptions(t *testing.T, store db.Storage) err
 			ReceiveComments: true, CompleteExternal: true, ReceiveCommentsAfter: &receiveAfter,
 			PendingCommentUID: replayCommentUID, PendingCommentStartedAt: &pendingStarted,
 			CreatedAt: createdTime, UpdatedAt: pendingStarted,
-		}},
-		{Kind: db.ImportKindPendingClaimRequest, PendingClaimRequest: &db.PendingClaimRequestExport{
+		},
+		&db.PendingClaimRequestExport{
 			ID: 8, RequestUID: replayPendingUID, ProjectID: projectID, IssueID: issueID,
 			IssueUID: replayIssueUID, Holder: "worker", HolderInstanceUID: replaySpokeUID,
 			ClientKind: "agent", ClaimKind: "hard", RequestedAt: created,
-		}},
-		{Kind: db.ImportKindPendingClaimRequest, PendingClaimRequest: &db.PendingClaimRequestExport{
+		},
+		&db.PendingClaimRequestExport{
 			ID: 9, RequestUID: "01HZZZZZZZZZZZZZZZZZZZZZ1F", ProjectID: projectID, IssueID: issueID,
 			IssueUID: replayIssueUID, Holder: "worker", HolderInstanceUID: replaySpokeUID,
 			ClientKind: "agent", ClaimKind: "hard", RequestedAt: "2026-07-15T12:01:00.000Z",
-		}},
-		{Kind: db.ImportKindEvent, Event: &db.EventExport{
+		},
+		&db.EventExport{
 			ID: 10, UID: replayEventUID, OriginInstanceUID: replayInstanceUID,
 			ProjectID: projectID, ProjectUID: replayProjectUID, ProjectName: "compatibility-replay",
 			IssueID: &issueID, Type: "issue.created", Actor: "fixture-author",
 			Payload:       json.RawMessage(`{"title":"Imported replay event"}`),
 			HLCPhysicalMS: 1784102400000, HLCCounter: 0, ContentHash: "legacy-hash",
 			CreatedAt: created,
-		}},
+		},
 	}
 	if err := store.ImportReplay(ctx, recurrenceRecords, db.ImportOptions{
 		NewInstance:                         true,
@@ -991,16 +985,16 @@ func checkSnapshotReplayHistoricalProjectName(t *testing.T, store db.Storage) er
 		return err
 	}
 	err = store.ImportReplay(ctx, []db.ImportRecord{
-		{Kind: db.ImportKindProject, Project: &db.ProjectExport{
+		&db.ProjectExport{
 			ID: 5, UID: replayProjectUID, Name: currentName, CreatedAt: created,
 			Metadata: json.RawMessage(`{}`), Revision: 1,
-		}},
-		{Kind: db.ImportKindEvent, Event: &db.EventExport{
+		},
+		&db.EventExport{
 			ID: 10, UID: replayEventUID, OriginInstanceUID: replayInstanceUID,
 			ProjectID: 5, ProjectUID: replayProjectUID, ProjectName: historicalName,
 			Type: "project.created", Actor: "fixture-author", Payload: payload,
 			HLCPhysicalMS: 1784102400000, ContentHash: hash, CreatedAt: created,
-		}},
+		},
 	}, db.ImportOptions{})
 	if err != nil {
 		return err
@@ -1038,16 +1032,16 @@ func checkSnapshotReplayUnsafeHistoricalProjectName(t *testing.T, store db.Stora
 		return err
 	}
 	err = store.ImportReplay(ctx, []db.ImportRecord{
-		{Kind: db.ImportKindProject, Project: &db.ProjectExport{
+		&db.ProjectExport{
 			ID: 5, UID: replayProjectUID, Name: "safe-current-name", CreatedAt: created,
 			Metadata: json.RawMessage(`{}`), Revision: 1,
-		}},
-		{Kind: db.ImportKindEvent, Event: &db.EventExport{
+		},
+		&db.EventExport{
 			ID: 10, UID: replayEventUID, OriginInstanceUID: replayInstanceUID,
 			ProjectID: 5, ProjectUID: replayProjectUID, ProjectName: unsafeName,
 			Type: "project.created", Actor: "fixture-author", Payload: payload,
 			HLCPhysicalMS: 1784102400000, ContentHash: hash, CreatedAt: created,
-		}},
+		},
 	}, db.ImportOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "non-printable")
@@ -1065,15 +1059,15 @@ func checkSnapshotReplayAtomicRejection(t *testing.T, store db.Storage) error {
 	localInstanceUID := store.InstanceUID()
 	created := "2026-07-15T12:00:00.000Z"
 	records := []db.ImportRecord{
-		{Kind: db.ImportKindMeta, Meta: &db.MetaKV{Key: "instance_uid", Value: replayInstanceUID}},
-		{Kind: db.ImportKindProject, Project: &db.ProjectExport{
+		&db.MetaKV{Key: "instance_uid", Value: replayInstanceUID},
+		&db.ProjectExport{
 			ID: 2, UID: replayProjectUID, Name: "first-project", CreatedAt: created,
 			Metadata: json.RawMessage(`{}`), Revision: 1,
-		}},
-		{Kind: db.ImportKindProject, Project: &db.ProjectExport{
+		},
+		&db.ProjectExport{
 			ID: 3, UID: replayProjectUID, Name: "duplicate-project", CreatedAt: created,
 			Metadata: json.RawMessage(`{}`), Revision: 1,
-		}},
+		},
 	}
 	err := store.ImportReplay(ctx, records, db.ImportOptions{})
 	require.Error(t, err)
@@ -1088,25 +1082,45 @@ func checkSnapshotReplayAtomicRejection(t *testing.T, store db.Storage) error {
 	}
 
 	err = store.ImportReplay(ctx, []db.ImportRecord{
-		{Kind: db.ImportKindMeta, Meta: &db.MetaKV{Key: "instance_uid", Value: replayInstanceUID}},
-		{Kind: db.ImportKindProject},
+		&db.MetaKV{Key: "instance_uid", Value: replayInstanceUID},
+		(*db.ProjectExport)(nil),
 	}, db.ImportOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "import record 1")
-	assert.Contains(t, err.Error(), "no payload set")
+	assert.Contains(t, err.Error(), "nil payload")
 	projects, listErr = store.ListProjects(ctx)
 	if listErr != nil {
 		return listErr
 	}
 	assert.Empty(t, projects)
 
-	err = store.ImportReplay(ctx, []db.ImportRecord{{
-		Kind: db.ImportKindProject,
-		Project: &db.ProjectExport{
+	// The union check must refuse a malformed batch BEFORE any transaction
+	// opens, so a hostile or corrupt stream cannot partially mutate either
+	// backend. A canceled context makes the ordering observable: the
+	// pre-transaction check reports the malformed record, while a check moved
+	// inside the transaction would report the canceled BeginTx.
+	canceled, cancelReplay := context.WithCancel(ctx)
+	cancelReplay()
+	err = store.ImportReplay(canceled, []db.ImportRecord{
+		&db.MetaKV{Key: "instance_uid", Value: replayInstanceUID},
+		(*db.ProjectExport)(nil),
+	}, db.ImportOptions{})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, context.Canceled,
+		"a malformed batch must be refused before the replay transaction opens")
+	assert.Contains(t, err.Error(), "import record 1")
+	projects, listErr = store.ListProjects(ctx)
+	if listErr != nil {
+		return listErr
+	}
+	assert.Empty(t, projects, "refused batch must not write any row")
+
+	err = store.ImportReplay(ctx, []db.ImportRecord{
+		&db.ProjectExport{
 			ID: 4, UID: replayProjectUID, Name: "unsafe\nproject", CreatedAt: created,
 			Metadata: json.RawMessage(`{}`), Revision: 1,
 		},
-	}}, db.ImportOptions{})
+	}, db.ImportOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "non-printable")
 	projects, listErr = store.ListProjects(ctx)
@@ -1117,22 +1131,22 @@ func checkSnapshotReplayAtomicRejection(t *testing.T, store db.Storage) error {
 
 	issueID := int64(6)
 	err = store.ImportReplay(ctx, []db.ImportRecord{
-		{Kind: db.ImportKindProject, Project: &db.ProjectExport{
+		&db.ProjectExport{
 			ID: 5, UID: replayProjectUID, Name: "hash-rejection", CreatedAt: created,
 			Metadata: json.RawMessage(`{}`), Revision: 1,
-		}},
-		{Kind: db.ImportKindIssue, Issue: &db.IssueExport{
+		},
+		&db.IssueExport{
 			ID: issueID, UID: replayIssueUID, ProjectID: 5, ShortID: "zz12",
 			Title: "Hash rejection", Status: "open", Author: "fixture-author",
 			CreatedAt: created, UpdatedAt: created, Metadata: json.RawMessage(`{}`), Revision: 1,
-		}},
-		{Kind: db.ImportKindEvent, Event: &db.EventExport{
+		},
+		&db.EventExport{
 			ID: 10, UID: replayEventUID, OriginInstanceUID: replayInstanceUID,
 			ProjectID: 5, ProjectUID: replayProjectUID, ProjectName: "hash-rejection",
 			IssueID: &issueID, IssueUID: new(replayIssueUID), Type: "issue.created",
 			Actor: "fixture-author", Payload: json.RawMessage(`{"title":"Hash rejection"}`),
 			HLCPhysicalMS: 1784102400000, ContentHash: strings.Repeat("0", 64), CreatedAt: created,
-		}},
+		},
 	}, db.ImportOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "content_hash mismatch")
@@ -1146,13 +1160,12 @@ func checkSnapshotReplayAtomicRejection(t *testing.T, store db.Storage) error {
 	if createErr != nil {
 		return createErr
 	}
-	err = store.ImportReplay(ctx, []db.ImportRecord{{
-		Kind: db.ImportKindProject,
-		Project: &db.ProjectExport{
+	err = store.ImportReplay(ctx, []db.ImportRecord{
+		&db.ProjectExport{
 			ID: 8, UID: replayProjectUID, Name: "fresh-only", CreatedAt: created,
 			Metadata: json.RawMessage(`{}`), Revision: 1,
 		},
-	}}, db.ImportOptions{RequireFreshTarget: true})
+	}, db.ImportOptions{RequireFreshTarget: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fresh")
 	preserved, preserveErr := store.ProjectByUID(ctx, existing.UID)
@@ -1229,9 +1242,9 @@ func checkSnapshotReplayProjectEnvelopes(
 		return err
 	}
 	for _, record := range full {
-		if record.Link != nil && record.Link.ID == link.ID {
-			duplicate := *record.Link
-			full = append(full, db.ImportRecord{Kind: db.ImportKindLink, Link: &duplicate})
+		if replayLink, ok := record.(*db.LinkExport); ok && replayLink.ID == link.ID {
+			duplicate := *replayLink
+			full = append(full, &duplicate)
 			break
 		}
 	}
@@ -1309,12 +1322,12 @@ func checkSnapshotMergeExternalRoots(
 		return err
 	}
 	for i := range records {
-		if records[i].ExternalFieldMapping != nil {
-			records[i].ExternalFieldMapping.CreatedAt = targetMapping.CreatedAt
-			records[i].ExternalFieldMapping.UpdatedAt = targetMapping.UpdatedAt
+		if mapping, ok := records[i].(*db.ExternalFieldMappingExport); ok {
+			mapping.CreatedAt = targetMapping.CreatedAt
+			mapping.UpdatedAt = targetMapping.UpdatedAt
 		}
-		if records[i].ExternalFieldState != nil {
-			records[i].ExternalFieldState.MappingCreatedAt = targetMapping.CreatedAt
+		if state, ok := records[i].(*db.ExternalFieldStateExport); ok {
+			state.MappingCreatedAt = targetMapping.CreatedAt
 		}
 	}
 	existing, err := target.CreateProject(ctx, "existing-project")
@@ -1387,12 +1400,12 @@ func checkSnapshotMergeExternalRoots(
 	}
 	incomingCreatedAt := precisionMapping.CreatedAt.Add(time.Nanosecond)
 	for i := range precisionRecords {
-		if precisionRecords[i].ExternalFieldMapping != nil {
-			precisionRecords[i].ExternalFieldMapping.CreatedAt = incomingCreatedAt
-			precisionRecords[i].ExternalFieldMapping.UpdatedAt = incomingCreatedAt
+		if mapping, ok := precisionRecords[i].(*db.ExternalFieldMappingExport); ok {
+			mapping.CreatedAt = incomingCreatedAt
+			mapping.UpdatedAt = incomingCreatedAt
 		}
-		if precisionRecords[i].ExternalFieldState != nil {
-			precisionRecords[i].ExternalFieldState.MappingCreatedAt = incomingCreatedAt
+		if state, ok := precisionRecords[i].(*db.ExternalFieldStateExport); ok {
+			state.MappingCreatedAt = incomingCreatedAt
 		}
 	}
 	if err := precisionTarget.ImportReplay(ctx, precisionRecords, db.ImportOptions{MergeProject: true}); err != nil {
@@ -1443,12 +1456,12 @@ func checkSnapshotMergeExternalRoots(
 		return err
 	}
 	for i := range beforeDeactivation {
-		if beforeDeactivation[i].ExternalFieldMapping != nil {
-			beforeDeactivation[i].ExternalFieldMapping.CreatedAt = deactivatedMapping.CreatedAt
-			beforeDeactivation[i].ExternalFieldMapping.UpdatedAt = deactivatedMapping.UpdatedAt
+		if mapping, ok := beforeDeactivation[i].(*db.ExternalFieldMappingExport); ok {
+			mapping.CreatedAt = deactivatedMapping.CreatedAt
+			mapping.UpdatedAt = deactivatedMapping.UpdatedAt
 		}
-		if beforeDeactivation[i].ExternalFieldState != nil {
-			beforeDeactivation[i].ExternalFieldState.MappingCreatedAt = deactivatedMapping.CreatedAt
+		if state, ok := beforeDeactivation[i].(*db.ExternalFieldStateExport); ok {
+			state.MappingCreatedAt = deactivatedMapping.CreatedAt
 		}
 	}
 	time.Sleep(2 * time.Millisecond)
@@ -1489,13 +1502,13 @@ func checkSnapshotMergeExternalRoots(
 	}
 	incomingUpdatedAt := advancedMapping.UpdatedAt.Add(time.Minute)
 	for i := range afterDeactivation {
-		if afterDeactivation[i].ExternalFieldMapping != nil {
-			afterDeactivation[i].ExternalFieldMapping.CreatedAt = advancedMapping.CreatedAt
-			afterDeactivation[i].ExternalFieldMapping.UpdatedAt = incomingUpdatedAt
-			afterDeactivation[i].ExternalFieldMapping.Active = false
+		if mapping, ok := afterDeactivation[i].(*db.ExternalFieldMappingExport); ok {
+			mapping.CreatedAt = advancedMapping.CreatedAt
+			mapping.UpdatedAt = incomingUpdatedAt
+			mapping.Active = false
 		}
-		if afterDeactivation[i].ExternalFieldState != nil {
-			afterDeactivation[i].ExternalFieldState.MappingCreatedAt = advancedMapping.CreatedAt
+		if state, ok := afterDeactivation[i].(*db.ExternalFieldStateExport); ok {
+			state.MappingCreatedAt = advancedMapping.CreatedAt
 		}
 	}
 	if err := advancedTarget.ImportReplay(ctx, afterDeactivation, db.ImportOptions{MergeProject: true}); err != nil {
@@ -1540,12 +1553,12 @@ func checkSnapshotMergeExternalRoots(
 		return err
 	}
 	for i := range conflictingRecords {
-		if conflictingRecords[i].ExternalFieldMapping != nil {
-			conflictingRecords[i].ExternalFieldMapping.CreatedAt = conflictingMapping.CreatedAt
-			conflictingRecords[i].ExternalFieldMapping.UpdatedAt = conflictingMapping.UpdatedAt
+		if mapping, ok := conflictingRecords[i].(*db.ExternalFieldMappingExport); ok {
+			mapping.CreatedAt = conflictingMapping.CreatedAt
+			mapping.UpdatedAt = conflictingMapping.UpdatedAt
 		}
-		if conflictingRecords[i].ExternalFieldState != nil {
-			conflictingRecords[i].ExternalFieldState.MappingCreatedAt = conflictingMapping.CreatedAt
+		if state, ok := conflictingRecords[i].(*db.ExternalFieldStateExport); ok {
+			state.MappingCreatedAt = conflictingMapping.CreatedAt
 		}
 	}
 	err = conflictTarget.ImportReplay(ctx, conflictingRecords, db.ImportOptions{MergeProject: true})
@@ -1588,11 +1601,11 @@ func checkSnapshotMergeExternalRoots(
 		return err
 	}
 	for i := range uidCollisionRecords {
-		if uidCollisionRecords[i].ExternalRootBinding != nil {
-			uidCollisionRecords[i].ExternalRootBinding.UID = existingBinding.UID
+		if binding, ok := uidCollisionRecords[i].(*db.ExternalRootBindingExport); ok {
+			binding.UID = existingBinding.UID
 		}
-		if uidCollisionRecords[i].ExternalFieldState != nil {
-			uidCollisionRecords[i].ExternalFieldState.BindingUID = existingBinding.UID
+		if state, ok := uidCollisionRecords[i].(*db.ExternalFieldStateExport); ok {
+			state.BindingUID = existingBinding.UID
 		}
 	}
 	err = uidTarget.ImportReplay(ctx, uidCollisionRecords, db.ImportOptions{MergeProject: true})

--- a/internal/db/export_types.go
+++ b/internal/db/export_types.go
@@ -18,6 +18,9 @@ type MetaKV struct {
 	Value string `json:"value"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*MetaKV) ImportKind() string { return ImportKindMeta }
+
 // IssueExport is one issue row in export shape (recurrence_uid resolved via join).
 type IssueExport struct {
 	ID              int64           `json:"id"`
@@ -43,6 +46,9 @@ type IssueExport struct {
 	OccurrenceKey   *string         `json:"occurrence_key,omitempty"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*IssueExport) ImportKind() string { return ImportKindIssue }
+
 // IssueEmbeddingExport is one issue_embeddings row in export shape, keyed by
 // issue UID so import resolves identity independent of local numeric ids. The
 // vector is base64-encoded (dims x float32 little-endian, L2-normalized).
@@ -55,6 +61,9 @@ type IssueEmbeddingExport struct {
 	Dims                    int    `json:"dims"`
 	VectorB64               string `json:"vector_b64"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*IssueEmbeddingExport) ImportKind() string { return ImportKindIssueEmbedding }
 
 // RecurrenceExport is one recurrence row in export shape.
 type RecurrenceExport struct {
@@ -79,6 +88,9 @@ type RecurrenceExport struct {
 	DeletedAt           *string         `json:"deleted_at,omitempty"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*RecurrenceExport) ImportKind() string { return ImportKindRecurrence }
+
 // LinkExport is one link row in export shape, with both endpoint UIDs resolved
 // via the standard FROM links JOIN issues AS from_issues JOIN issues AS
 // to_issues query.
@@ -93,6 +105,9 @@ type LinkExport struct {
 	CreatedAt    string `json:"created_at"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*LinkExport) ImportKind() string { return ImportKindLink }
+
 // AliasExport is one project_aliases row in export shape.
 type AliasExport struct {
 	ID            int64  `json:"id"`
@@ -101,6 +116,9 @@ type AliasExport struct {
 	AliasKind     string `json:"alias_kind"`
 	CreatedAt     string `json:"created_at"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*AliasExport) ImportKind() string { return ImportKindProjectAlias }
 
 // IssueSyncBindingExport is one issue_sync_bindings row in export shape.
 type IssueSyncBindingExport struct {
@@ -118,6 +136,9 @@ type IssueSyncBindingExport struct {
 	UpdatedAt       string          `json:"updated_at"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*IssueSyncBindingExport) ImportKind() string { return ImportKindIssueSyncBinding }
+
 // IssueSyncStatusExport is one issue_sync_status row in export shape.
 type IssueSyncStatusExport struct {
 	BindingID     int64   `json:"binding_id"`
@@ -133,6 +154,9 @@ type IssueSyncStatusExport struct {
 	LastComments  int     `json:"last_comments"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*IssueSyncStatusExport) ImportKind() string { return ImportKindIssueSyncStatus }
+
 // CommentExport is one comment row in export shape.
 type CommentExport struct {
 	ID        int64  `json:"id"`
@@ -143,6 +167,9 @@ type CommentExport struct {
 	CreatedAt string `json:"created_at"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*CommentExport) ImportKind() string { return ImportKindComment }
+
 // IssueLabelExport is one issue_labels row in export shape.
 type IssueLabelExport struct {
 	IssueID   int64  `json:"issue_id"`
@@ -150,6 +177,9 @@ type IssueLabelExport struct {
 	Author    string `json:"author"`
 	CreatedAt string `json:"created_at"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*IssueLabelExport) ImportKind() string { return ImportKindIssueLabel }
 
 // ImportMappingExport is one import_mappings row in export shape.
 type ImportMappingExport struct {
@@ -165,6 +195,9 @@ type ImportMappingExport struct {
 	SourceUpdatedAt *string `json:"source_updated_at,omitempty"`
 	ImportedAt      string  `json:"imported_at"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*ImportMappingExport) ImportKind() string { return ImportKindImportMapping }
 
 // ExternalRootBindingExport is one portable external-root binding. All
 // references use durable identities; process settings, credentials, and live
@@ -235,6 +268,15 @@ type ExternalFieldStateExport struct {
 	UpdatedAt                time.Time       `json:"updated_at"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*ExternalRootBindingExport) ImportKind() string { return ImportKindExternalRootBinding }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*ExternalFieldMappingExport) ImportKind() string { return ImportKindExternalFieldMapping }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*ExternalFieldStateExport) ImportKind() string { return ImportKindExternalFieldState }
+
 // FederationBindingExport is one federation_bindings row in export shape.
 type FederationBindingExport struct {
 	ProjectID            int64   `json:"project_id"`
@@ -254,6 +296,9 @@ type FederationBindingExport struct {
 	LastSyncAt           *string `json:"last_sync_at,omitempty"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*FederationBindingExport) ImportKind() string { return ImportKindFederationBinding }
+
 // FederationSyncStatusExport is one federation_sync_status row in export shape.
 type FederationSyncStatusExport struct {
 	ProjectID         int64   `json:"project_id"`
@@ -265,6 +310,9 @@ type FederationSyncStatusExport struct {
 	LastError         *string `json:"last_error,omitempty"`
 	LastResetAt       *string `json:"last_reset_at,omitempty"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*FederationSyncStatusExport) ImportKind() string { return ImportKindFederationSyncStatus }
 
 // FederationQuarantineExport is one federation_quarantine row in export shape.
 type FederationQuarantineExport struct {
@@ -280,6 +328,9 @@ type FederationQuarantineExport struct {
 	SkippedBy    *string         `json:"skipped_by,omitempty"`
 	SkipReason   *string         `json:"skip_reason,omitempty"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*FederationQuarantineExport) ImportKind() string { return ImportKindFederationQuarantine }
 
 // FederationEnrollmentExport is one federation_enrollments row in export shape.
 type FederationEnrollmentExport struct {
@@ -297,6 +348,9 @@ type FederationEnrollmentExport struct {
 	UpdatedAt                         string  `json:"updated_at"`
 	RevokedAt                         *string `json:"revoked_at,omitempty"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*FederationEnrollmentExport) ImportKind() string { return ImportKindFederationEnrollment }
 
 // IssueClaimExport is one issue_claims row in export shape.
 type IssueClaimExport struct {
@@ -318,6 +372,9 @@ type IssueClaimExport struct {
 	UpdatedAt         string  `json:"updated_at"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*IssueClaimExport) ImportKind() string { return ImportKindIssueClaim }
+
 // PendingClaimRequestExport is one pending_claim_requests row in export shape.
 type PendingClaimRequestExport struct {
 	ID                int64   `json:"id"`
@@ -338,12 +395,18 @@ type PendingClaimRequestExport struct {
 	ResolvedAt        *string `json:"resolved_at,omitempty"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*PendingClaimRequestExport) ImportKind() string { return ImportKindPendingClaimRequest }
+
 // SequenceExport is one backend identity high-water mark using SQLite table
 // names as the portable wire vocabulary.
 type SequenceExport struct {
 	Name string `json:"name"`
 	Seq  int64  `json:"seq"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*SequenceExport) ImportKind() string { return ImportKindSQLiteSequence }
 
 // PurgeLogExport is one purge_log row in export shape. project_name is the
 // denormalized purge_log.project_name column at v10+ (no join).
@@ -371,6 +434,9 @@ type PurgeLogExport struct {
 	PurgedAt               string  `json:"purged_at"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*PurgeLogExport) ImportKind() string { return ImportKindPurgeLog }
+
 // ProjectPurgeLogExport is one project_purge_log row in export shape.
 type ProjectPurgeLogExport struct {
 	ID                       int64   `json:"id"`
@@ -394,6 +460,9 @@ type ProjectPurgeLogExport struct {
 	Reason                   *string `json:"reason"`
 	PurgedAt                 string  `json:"purged_at"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*ProjectPurgeLogExport) ImportKind() string { return ImportKindProjectPurgeLog }
 
 // EventExport is one event row in export shape. ProjectUID is marshaled as
 // `json:"-"` because it is used only to compute the content hash and is not
@@ -421,6 +490,9 @@ type EventExport struct {
 	CreatedAt         string          `json:"created_at"`
 }
 
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*EventExport) ImportKind() string { return ImportKindEvent }
+
 // ProjectExport is one project row in export shape.
 type ProjectExport struct {
 	ID        int64           `json:"id"`
@@ -431,3 +503,6 @@ type ProjectExport struct {
 	Metadata  json.RawMessage `json:"metadata"`
 	Revision  int64           `json:"revision"`
 }
+
+// ImportKind reports the NDJSON kind this payload replays as.
+func (*ProjectExport) ImportKind() string { return ImportKindProject }

--- a/internal/db/import_kind_test.go
+++ b/internal/db/import_kind_test.go
@@ -1,0 +1,58 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.kenn.io/kata/internal/db"
+)
+
+// TestImportKindMatchesWireConstant pins the type -> NDJSON kind mapping for
+// every replay payload. The kind strings are frozen wire vocabulary shared
+// with internal/jsonl, and after ImportRecord became an interface this table
+// is the only place the whole mapping is asserted at once.
+func TestImportKindMatchesWireConstant(t *testing.T) {
+	cases := []struct {
+		record db.ImportRecord
+		want   string
+	}{
+		{&db.MetaKV{}, db.ImportKindMeta},
+		{&db.ProjectExport{}, db.ImportKindProject},
+		{&db.AliasExport{}, db.ImportKindProjectAlias},
+		{&db.IssueSyncBindingExport{}, db.ImportKindIssueSyncBinding},
+		{&db.IssueSyncStatusExport{}, db.ImportKindIssueSyncStatus},
+		{&db.RecurrenceExport{}, db.ImportKindRecurrence},
+		{&db.IssueExport{}, db.ImportKindIssue},
+		{&db.IssueEmbeddingExport{}, db.ImportKindIssueEmbedding},
+		{&db.CommentExport{}, db.ImportKindComment},
+		{&db.IssueLabelExport{}, db.ImportKindIssueLabel},
+		{&db.LinkExport{}, db.ImportKindLink},
+		{&db.ImportMappingExport{}, db.ImportKindImportMapping},
+		{&db.ExternalFieldMappingExport{}, db.ImportKindExternalFieldMapping},
+		{&db.ExternalRootBindingExport{}, db.ImportKindExternalRootBinding},
+		{&db.ExternalFieldStateExport{}, db.ImportKindExternalFieldState},
+		{&db.FederationBindingExport{}, db.ImportKindFederationBinding},
+		{&db.FederationSyncStatusExport{}, db.ImportKindFederationSyncStatus},
+		{&db.FederationQuarantineExport{}, db.ImportKindFederationQuarantine},
+		{&db.FederationEnrollmentExport{}, db.ImportKindFederationEnrollment},
+		{&db.IssueClaimExport{}, db.ImportKindIssueClaim},
+		{&db.PendingClaimRequestExport{}, db.ImportKindPendingClaimRequest},
+		{&db.EventExport{}, db.ImportKindEvent},
+		{&db.PurgeLogExport{}, db.ImportKindPurgeLog},
+		{&db.ProjectPurgeLogExport{}, db.ImportKindProjectPurgeLog},
+		{&db.SequenceExport{}, db.ImportKindSQLiteSequence},
+	}
+
+	assert.Len(t, cases, 25, "every replay payload type must be listed")
+	seen := make(map[string]string, len(cases))
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.record.ImportKind())
+		})
+		if prior, dup := seen[tc.want]; dup {
+			t.Errorf("kind %q claimed by two types (%s)", tc.want, prior)
+		}
+		seen[tc.want] = tc.want
+	}
+	assert.Len(t, seen, 25, "the type -> kind mapping must be a bijection")
+}

--- a/internal/db/import_replay_policy.go
+++ b/internal/db/import_replay_policy.go
@@ -3,6 +3,7 @@ package db
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -27,10 +28,14 @@ func ReplayEventProjectName(event *EventExport, currentName string, recomputeHas
 
 // ValidateImportRecords checks the normalized replay union before a backend
 // opens a transaction. A malformed envelope therefore cannot partially mutate
-// either storage implementation.
+// either storage implementation. The interface makes kind/payload
+// disagreement unrepresentable, so only two failures remain: a missing
+// payload, and a type outside the replay union (the interface is exported, so
+// an out-of-tree type could implement it and reach a backend's default arm
+// inside the transaction).
 func ValidateImportRecords(records []ImportRecord) error {
 	for i, record := range records {
-		if err := record.Validate(); err != nil {
+		if err := validateImportRecord(record); err != nil {
 			return fmt.Errorf("import record %d: %w", i, err)
 		}
 	}
@@ -50,10 +55,11 @@ func validateReplayExternalFieldMappingIdentities(records []ImportRecord) error 
 	}
 	seen := make(map[portableIdentity]int)
 	for index, record := range records {
-		if record.ExternalFieldMapping == nil {
+		mapping, ok := record.(*ExternalFieldMappingExport)
+		if !ok {
 			continue
 		}
-		normalized, err := NormalizeExternalFieldMappingExport(*record.ExternalFieldMapping)
+		normalized, err := NormalizeExternalFieldMappingExport(*mapping)
 		if err != nil {
 			return fmt.Errorf("import record %d: %w", index, err)
 		}
@@ -87,20 +93,20 @@ func validateReplayBindingScopedMappings(records []ImportRecord) error {
 	issues := make(map[string]IssueExport)
 	commentIssueIDs := make(map[int64]int64)
 	for _, record := range records {
-		switch {
-		case record.Project != nil:
-			projectIDs[record.Project.UID] = record.Project.ID
-		case record.Issue != nil:
-			issues[record.Issue.UID] = *record.Issue
-		case record.Comment != nil:
-			commentIssueIDs[record.Comment.ID] = record.Comment.IssueID
+		switch record := record.(type) {
+		case *ProjectExport:
+			projectIDs[record.UID] = record.ID
+		case *IssueExport:
+			issues[record.UID] = *record
+		case *CommentExport:
+			commentIssueIDs[record.ID] = record.IssueID
 		}
 	}
 
 	shapes := make(map[string]replayBindingMappingShape)
 	for _, record := range records {
-		binding := record.ExternalRootBinding
-		if binding == nil {
+		binding, ok := record.(*ExternalRootBindingExport)
+		if !ok {
 			continue
 		}
 		projectID, projectFound := projectIDs[binding.ProjectUID]
@@ -125,8 +131,8 @@ func validateReplayBindingScopedMappings(records []ImportRecord) error {
 	}
 
 	for index, record := range records {
-		mapping := record.ImportMapping
-		if mapping == nil {
+		mapping, ok := record.(*ImportMappingExport)
+		if !ok {
 			continue
 		}
 		shape, bindingScoped := shapes[mapping.Source]
@@ -153,6 +159,74 @@ func validateReplayBindingScopedMappings(records []ImportRecord) error {
 	return nil
 }
 
+func validateImportRecord(record ImportRecord) error {
+	switch rec := record.(type) {
+	case nil:
+		return errors.New("nil record")
+	case *MetaKV:
+		return requireImportPayload(rec, ImportKindMeta)
+	case *ProjectExport:
+		return requireImportPayload(rec, ImportKindProject)
+	case *AliasExport:
+		return requireImportPayload(rec, ImportKindProjectAlias)
+	case *IssueSyncBindingExport:
+		return requireImportPayload(rec, ImportKindIssueSyncBinding)
+	case *IssueSyncStatusExport:
+		return requireImportPayload(rec, ImportKindIssueSyncStatus)
+	case *RecurrenceExport:
+		return requireImportPayload(rec, ImportKindRecurrence)
+	case *IssueExport:
+		return requireImportPayload(rec, ImportKindIssue)
+	case *IssueEmbeddingExport:
+		return requireImportPayload(rec, ImportKindIssueEmbedding)
+	case *CommentExport:
+		return requireImportPayload(rec, ImportKindComment)
+	case *IssueLabelExport:
+		return requireImportPayload(rec, ImportKindIssueLabel)
+	case *LinkExport:
+		return requireImportPayload(rec, ImportKindLink)
+	case *ImportMappingExport:
+		return requireImportPayload(rec, ImportKindImportMapping)
+	case *ExternalFieldMappingExport:
+		return requireImportPayload(rec, ImportKindExternalFieldMapping)
+	case *ExternalRootBindingExport:
+		return requireImportPayload(rec, ImportKindExternalRootBinding)
+	case *ExternalFieldStateExport:
+		return requireImportPayload(rec, ImportKindExternalFieldState)
+	case *FederationBindingExport:
+		return requireImportPayload(rec, ImportKindFederationBinding)
+	case *FederationSyncStatusExport:
+		return requireImportPayload(rec, ImportKindFederationSyncStatus)
+	case *FederationQuarantineExport:
+		return requireImportPayload(rec, ImportKindFederationQuarantine)
+	case *FederationEnrollmentExport:
+		return requireImportPayload(rec, ImportKindFederationEnrollment)
+	case *IssueClaimExport:
+		return requireImportPayload(rec, ImportKindIssueClaim)
+	case *PendingClaimRequestExport:
+		return requireImportPayload(rec, ImportKindPendingClaimRequest)
+	case *EventExport:
+		return requireImportPayload(rec, ImportKindEvent)
+	case *PurgeLogExport:
+		return requireImportPayload(rec, ImportKindPurgeLog)
+	case *ProjectPurgeLogExport:
+		return requireImportPayload(rec, ImportKindProjectPurgeLog)
+	case *SequenceExport:
+		return requireImportPayload(rec, ImportKindSQLiteSequence)
+	default:
+		return fmt.Errorf("unknown record type %T", record)
+	}
+}
+
+// requireImportPayload rejects a typed-nil payload pointer, which satisfies
+// the interface but would nil-deref inside a backend's replay arm.
+func requireImportPayload[T any](payload *T, kind string) error {
+	if payload == nil {
+		return fmt.Errorf("kind %q: nil payload", kind)
+	}
+	return nil
+}
+
 // OrderImportRecords returns a stable dependency order for replay. JSONL
 // exports already use this order, but accepting normalized records in any
 // order keeps the Storage contract backend-neutral without requiring every
@@ -160,7 +234,7 @@ func validateReplayBindingScopedMappings(records []ImportRecord) error {
 func OrderImportRecords(records []ImportRecord) []ImportRecord {
 	ordered := append([]ImportRecord(nil), records...)
 	sort.SliceStable(ordered, func(i, j int) bool {
-		return importReplayRank(ordered[i].Kind) < importReplayRank(ordered[j].Kind)
+		return importReplayRank(ordered[i].ImportKind()) < importReplayRank(ordered[j].ImportKind())
 	})
 	return ordered
 }

--- a/internal/db/import_replay_policy_test.go
+++ b/internal/db/import_replay_policy_test.go
@@ -1,0 +1,93 @@
+package db_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+)
+
+// unknownRecord implements db.ImportRecord but is not one of the 22 replay
+// payloads. ValidateImportRecords must refuse it: the backends' type switches
+// would otherwise reach their default arm inside an open transaction.
+type unknownRecord struct{}
+
+func (unknownRecord) ImportKind() string { return "totally-unknown" }
+
+func TestValidateImportRecordsRejectsMalformed(t *testing.T) {
+	valid := &db.MetaKV{Key: "instance_uid", Value: "01KATA00000000000000000001"}
+
+	cases := []struct {
+		name    string
+		records []db.ImportRecord
+		wantErr string
+	}{
+		{
+			name:    "nil interface",
+			records: []db.ImportRecord{valid, nil},
+			wantErr: "import record 1",
+		},
+		{
+			name:    "typed nil payload",
+			records: []db.ImportRecord{valid, (*db.ProjectExport)(nil)},
+			wantErr: "nil payload",
+		},
+		{
+			name:    "type outside the replay union",
+			records: []db.ImportRecord{valid, unknownRecord{}},
+			wantErr: "unknown record type",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := db.ValidateImportRecords(tc.records)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			assert.Contains(t, err.Error(), "import record 1",
+				"the error must name the slice ordinal")
+		})
+	}
+}
+
+func TestValidateImportRecordsAcceptsEveryPayloadType(t *testing.T) {
+	mappingTime := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
+	records := []db.ImportRecord{
+		&db.MetaKV{}, &db.ProjectExport{}, &db.AliasExport{},
+		&db.IssueSyncBindingExport{}, &db.IssueSyncStatusExport{},
+		&db.RecurrenceExport{}, &db.IssueExport{}, &db.IssueEmbeddingExport{},
+		&db.CommentExport{}, &db.IssueLabelExport{}, &db.LinkExport{},
+		&db.ImportMappingExport{}, &db.ExternalFieldMappingExport{
+			ConnectorInstance: "connector-one", KataField: "scheduled_on",
+			ExternalFieldID: "schedule-one", ExternalFieldName: "Schedule",
+			AcceptedKinds: []string{"date"}, Nullable: true, Writable: true,
+			SchemaRevision: "schema-one", CreatedAt: mappingTime, UpdatedAt: mappingTime,
+		},
+		&db.ExternalRootBindingExport{}, &db.ExternalFieldStateExport{},
+		&db.FederationBindingExport{},
+		&db.FederationSyncStatusExport{}, &db.FederationQuarantineExport{},
+		&db.FederationEnrollmentExport{}, &db.IssueClaimExport{},
+		&db.PendingClaimRequestExport{}, &db.EventExport{},
+		&db.PurgeLogExport{}, &db.ProjectPurgeLogExport{}, &db.SequenceExport{},
+	}
+	require.Len(t, records, 25)
+	assert.NoError(t, db.ValidateImportRecords(records))
+}
+
+// TestOrderImportRecordsPlacesDependenciesFirst pins the replay order the
+// backends rely on: meta and project rows must land before the issue rows
+// that reference them, and events after both.
+func TestOrderImportRecordsPlacesDependenciesFirst(t *testing.T) {
+	ordered := db.OrderImportRecords([]db.ImportRecord{
+		&db.EventExport{}, &db.IssueExport{}, &db.ProjectExport{}, &db.MetaKV{},
+	})
+	kinds := make([]string, 0, len(ordered))
+	for _, record := range ordered {
+		kinds = append(kinds, record.ImportKind())
+	}
+	assert.Equal(t, []string{
+		db.ImportKindMeta, db.ImportKindProject,
+		db.ImportKindIssue, db.ImportKindEvent,
+	}, kinds)
+}

--- a/internal/db/import_types.go
+++ b/internal/db/import_types.go
@@ -1,8 +1,6 @@
 package db
 
 import (
-	"fmt"
-	"strings"
 	"time"
 )
 
@@ -51,37 +49,16 @@ type ImportOptions struct {
 	PreserveExternalRootBindingsEnabled bool
 }
 
-// ImportRecord is one normalized, current-shape import row: a Kind discriminator
-// plus exactly one payload pointer reusing the 1c-export row structs. jsonl
-// normalizes every source version to the current shape before building these,
-// so ImportReplay never sees a source export_version.
-type ImportRecord struct {
-	Kind                 string
-	Meta                 *MetaKV
-	Project              *ProjectExport
-	Alias                *AliasExport
-	IssueSyncBinding     *IssueSyncBindingExport
-	IssueSyncStatus      *IssueSyncStatusExport
-	Recurrence           *RecurrenceExport
-	Issue                *IssueExport
-	IssueEmbedding       *IssueEmbeddingExport
-	Comment              *CommentExport
-	Label                *IssueLabelExport
-	Link                 *LinkExport
-	ImportMapping        *ImportMappingExport
-	ExternalFieldMapping *ExternalFieldMappingExport
-	ExternalRootBinding  *ExternalRootBindingExport
-	ExternalFieldState   *ExternalFieldStateExport
-	FederationBinding    *FederationBindingExport
-	FederationSyncStatus *FederationSyncStatusExport
-	FederationQuarantine *FederationQuarantineExport
-	FederationEnrollment *FederationEnrollmentExport
-	IssueClaim           *IssueClaimExport
-	PendingClaimRequest  *PendingClaimRequestExport
-	Event                *EventExport
-	PurgeLog             *PurgeLogExport
-	ProjectPurgeLog      *ProjectPurgeLogExport
-	Sequence             *SequenceExport
+// ImportRecord is one normalized, current-shape import row. Its
+// implementations are the export row structs on pointer receivers (see
+// export_types.go), so the discriminator is the record's dynamic type: a
+// record cannot disagree with its payload, carry two payloads, or carry
+// none. ImportKind returns the frozen NDJSON kind string that internal/jsonl
+// writes on the wire. jsonl normalizes every source version to the current
+// shape before building these, so ImportReplay never sees a source
+// export_version.
+type ImportRecord interface {
+	ImportKind() string
 }
 
 // Import kind discriminators. These mirror the wire Kind strings produced by
@@ -115,65 +92,6 @@ const (
 	ImportKindProjectPurgeLog      = "project_purge_log"
 	ImportKindSQLiteSequence       = "sqlite_sequence"
 )
-
-// Validate enforces the tagged-union invariant: Kind is recognized and exactly
-// the one matching payload pointer is set. It returns a clear error naming the
-// offending Kind; ImportReplay adds the slice ordinal.
-func (r ImportRecord) Validate() error {
-	payloads := []struct {
-		kind string
-		set  bool
-	}{
-		{ImportKindMeta, r.Meta != nil},
-		{ImportKindProject, r.Project != nil},
-		{ImportKindProjectAlias, r.Alias != nil},
-		{ImportKindIssueSyncBinding, r.IssueSyncBinding != nil},
-		{ImportKindIssueSyncStatus, r.IssueSyncStatus != nil},
-		{ImportKindRecurrence, r.Recurrence != nil},
-		{ImportKindIssue, r.Issue != nil},
-		{ImportKindIssueEmbedding, r.IssueEmbedding != nil},
-		{ImportKindComment, r.Comment != nil},
-		{ImportKindIssueLabel, r.Label != nil},
-		{ImportKindLink, r.Link != nil},
-		{ImportKindImportMapping, r.ImportMapping != nil},
-		{ImportKindExternalFieldMapping, r.ExternalFieldMapping != nil},
-		{ImportKindExternalRootBinding, r.ExternalRootBinding != nil},
-		{ImportKindExternalFieldState, r.ExternalFieldState != nil},
-		{ImportKindFederationBinding, r.FederationBinding != nil},
-		{ImportKindFederationSyncStatus, r.FederationSyncStatus != nil},
-		{ImportKindFederationQuarantine, r.FederationQuarantine != nil},
-		{ImportKindFederationEnrollment, r.FederationEnrollment != nil},
-		{ImportKindIssueClaim, r.IssueClaim != nil},
-		{ImportKindPendingClaimRequest, r.PendingClaimRequest != nil},
-		{ImportKindEvent, r.Event != nil},
-		{ImportKindPurgeLog, r.PurgeLog != nil},
-		{ImportKindProjectPurgeLog, r.ProjectPurgeLog != nil},
-		{ImportKindSQLiteSequence, r.Sequence != nil},
-	}
-	known := false
-	var set []string
-	for _, p := range payloads {
-		if p.kind == r.Kind {
-			known = true
-		}
-		if p.set {
-			set = append(set, p.kind)
-		}
-	}
-	if !known {
-		return fmt.Errorf("unknown kind %q", r.Kind)
-	}
-	if len(set) == 0 {
-		return fmt.Errorf("kind %q: no payload set", r.Kind)
-	}
-	if len(set) > 1 {
-		return fmt.Errorf("kind %q: multiple payloads set (%s)", r.Kind, strings.Join(set, ", "))
-	}
-	if set[0] != r.Kind {
-		return fmt.Errorf("kind %q: payload does not match (got %s)", r.Kind, set[0])
-	}
-	return nil
-}
 
 // ImportBatchParams is the input to ImportBatch: the project receiving the
 // import, the source identifier (e.g. "beads"), the actor recorded on emitted

--- a/internal/db/pgstore/import_replay.go
+++ b/internal/db/pgstore/import_replay.go
@@ -78,8 +78,8 @@ func (s *Store) importReplayTx(
 		switch skip {
 		case replayLinkMissingPeer:
 			missingPeers++
-			if record.Link != nil {
-				skippedLinkIDs[record.Link.ID] = struct{}{}
+			if link, ok := record.(*db.LinkExport); ok {
+				skippedLinkIDs[link.ID] = struct{}{}
 			}
 		case replayLinkDuplicate:
 			duplicates++
@@ -180,68 +180,69 @@ func (s *Store) importReplayRecord(
 	skippedLinkIDs map[int64]struct{},
 	sequenceFloors map[string]int64,
 ) (replayLinkSkip, error) {
-	switch record.Kind {
-	case db.ImportKindMeta:
-		return replayLinkInserted, pgReplayMeta(ctx, tx, record.Meta, opts)
-	case db.ImportKindProject:
-		return replayLinkInserted, pgReplayProject(ctx, tx, record.Project)
-	case db.ImportKindProjectAlias:
-		return replayLinkInserted, pgReplayAlias(ctx, tx, record.Alias)
-	case db.ImportKindIssueSyncBinding:
+	switch rec := record.(type) {
+	case *db.MetaKV:
+		return replayLinkInserted, pgReplayMeta(ctx, tx, rec, opts)
+	case *db.ProjectExport:
+		return replayLinkInserted, pgReplayProject(ctx, tx, rec)
+	case *db.AliasExport:
+		return replayLinkInserted, pgReplayAlias(ctx, tx, rec)
+	case *db.IssueSyncBindingExport:
 		return replayLinkInserted, pgReplayIssueSyncBinding(
-			ctx, tx, record.IssueSyncBinding, opts.PreserveIssueSyncBindingEnabled,
+			ctx, tx, rec, opts.PreserveIssueSyncBindingEnabled,
 		)
-	case db.ImportKindIssueSyncStatus:
-		return replayLinkInserted, pgReplayIssueSyncStatus(ctx, tx, record.IssueSyncStatus)
-	case db.ImportKindRecurrence:
-		return replayLinkInserted, pgReplayRecurrence(ctx, tx, record.Recurrence)
-	case db.ImportKindIssue:
-		return replayLinkInserted, pgReplayIssue(ctx, tx, record.Issue)
-	case db.ImportKindIssueEmbedding:
+	case *db.IssueSyncStatusExport:
+		return replayLinkInserted, pgReplayIssueSyncStatus(ctx, tx, rec)
+	case *db.RecurrenceExport:
+		return replayLinkInserted, pgReplayRecurrence(ctx, tx, rec)
+	case *db.IssueExport:
+		return replayLinkInserted, pgReplayIssue(ctx, tx, rec)
+	case *db.IssueEmbeddingExport:
 		return replayLinkInserted, nil
-	case db.ImportKindComment:
-		return replayLinkInserted, pgReplayComment(ctx, tx, record.Comment)
-	case db.ImportKindIssueLabel:
-		return replayLinkInserted, pgReplayLabel(ctx, tx, record.Label)
-	case db.ImportKindLink:
-		return pgReplayLink(ctx, tx, record.Link)
-	case db.ImportKindImportMapping:
-		return pgReplayImportMapping(ctx, tx, record.ImportMapping, skippedLinkIDs)
-	case db.ImportKindExternalFieldMapping:
-		return replayLinkInserted, pgReplayExternalFieldMapping(
-			ctx, tx, record.ExternalFieldMapping, opts.MergeProject,
-		)
-	case db.ImportKindExternalRootBinding:
+	case *db.CommentExport:
+		return replayLinkInserted, pgReplayComment(ctx, tx, rec)
+	case *db.IssueLabelExport:
+		return replayLinkInserted, pgReplayLabel(ctx, tx, rec)
+	case *db.LinkExport:
+		return pgReplayLink(ctx, tx, rec)
+	case *db.ImportMappingExport:
+		return pgReplayImportMapping(ctx, tx, rec, skippedLinkIDs)
+	case *db.ExternalFieldMappingExport:
+		return replayLinkInserted, pgReplayExternalFieldMapping(ctx, tx, rec, opts.MergeProject)
+	case *db.ExternalRootBindingExport:
 		return replayLinkInserted, pgReplayExternalRootBinding(
-			ctx, tx, record.ExternalRootBinding, opts.PreserveExternalRootBindingsEnabled,
+			ctx, tx, rec, opts.PreserveExternalRootBindingsEnabled,
 		)
-	case db.ImportKindExternalFieldState:
-		return replayLinkInserted, pgReplayExternalFieldState(ctx, tx, record.ExternalFieldState)
-	case db.ImportKindFederationBinding:
-		return replayLinkInserted, pgReplayFederationBinding(ctx, tx, record.FederationBinding)
-	case db.ImportKindFederationSyncStatus:
-		return replayLinkInserted, pgReplayFederationSyncStatus(ctx, tx, record.FederationSyncStatus)
-	case db.ImportKindFederationQuarantine:
-		return replayLinkInserted, pgReplayFederationQuarantine(ctx, tx, record.FederationQuarantine)
-	case db.ImportKindFederationEnrollment:
-		return replayLinkInserted, pgReplayFederationEnrollment(ctx, tx, record.FederationEnrollment)
-	case db.ImportKindIssueClaim:
-		return replayLinkInserted, pgReplayIssueClaim(ctx, tx, record.IssueClaim)
-	case db.ImportKindPendingClaimRequest:
-		return replayLinkInserted, pgReplayPendingClaim(ctx, tx, record.PendingClaimRequest, opts)
-	case db.ImportKindEvent:
-		return replayLinkInserted, pgReplayEvent(ctx, tx, record.Event, opts)
-	case db.ImportKindPurgeLog:
-		return replayLinkInserted, pgReplayPurgeLog(ctx, tx, record.PurgeLog)
-	case db.ImportKindProjectPurgeLog:
-		return replayLinkInserted, pgReplayProjectPurgeLog(ctx, tx, record.ProjectPurgeLog)
-	case db.ImportKindSQLiteSequence:
-		if record.Sequence.Seq > sequenceFloors[record.Sequence.Name] {
-			sequenceFloors[record.Sequence.Name] = record.Sequence.Seq
+	case *db.ExternalFieldStateExport:
+		return replayLinkInserted, pgReplayExternalFieldState(ctx, tx, rec)
+	case *db.FederationBindingExport:
+		return replayLinkInserted, pgReplayFederationBinding(ctx, tx, rec)
+	case *db.FederationSyncStatusExport:
+		return replayLinkInserted, pgReplayFederationSyncStatus(ctx, tx, rec)
+	case *db.FederationQuarantineExport:
+		return replayLinkInserted, pgReplayFederationQuarantine(ctx, tx, rec)
+	case *db.FederationEnrollmentExport:
+		return replayLinkInserted, pgReplayFederationEnrollment(ctx, tx, rec)
+	case *db.IssueClaimExport:
+		return replayLinkInserted, pgReplayIssueClaim(ctx, tx, rec)
+	case *db.PendingClaimRequestExport:
+		return replayLinkInserted, pgReplayPendingClaim(ctx, tx, rec, opts)
+	case *db.EventExport:
+		return replayLinkInserted, pgReplayEvent(ctx, tx, rec, opts)
+	case *db.PurgeLogExport:
+		return replayLinkInserted, pgReplayPurgeLog(ctx, tx, rec)
+	case *db.ProjectPurgeLogExport:
+		return replayLinkInserted, pgReplayProjectPurgeLog(ctx, tx, rec)
+	case *db.SequenceExport:
+		if rec.Seq > sequenceFloors[rec.Name] {
+			sequenceFloors[rec.Name] = rec.Seq
 		}
 		return replayLinkInserted, nil
 	default:
-		return replayLinkInserted, fmt.Errorf("import: unsupported kind %q", record.Kind)
+		// ValidateImportRecords rejects unknown types before the transaction
+		// opens; this arm exists so a future payload type cannot be replayed
+		// silently.
+		return replayLinkInserted, fmt.Errorf("import: unsupported record type %T", record)
 	}
 }
 

--- a/internal/db/pgstore/import_replay_merge.go
+++ b/internal/db/pgstore/import_replay_merge.go
@@ -127,26 +127,26 @@ func refusePGProjectMergeUIDCollisions(ctx context.Context, tx *sql.Tx, records 
 	type uidCheck struct{ table, column, kind, uid string }
 	checks := make([]uidCheck, 0, len(records))
 	for _, record := range records {
-		switch {
-		case record.Project != nil:
-			checks = append(checks, uidCheck{"projects", "uid", "project", record.Project.UID})
-		case record.Issue != nil:
-			checks = append(checks, uidCheck{"issues", "uid", "issue", record.Issue.UID})
-		case record.Comment != nil:
-			checks = append(checks, uidCheck{"comments", "uid", "comment", record.Comment.UID})
-		case record.Recurrence != nil:
-			checks = append(checks, uidCheck{"recurrences", "uid", "recurrence", record.Recurrence.UID})
-		case record.IssueClaim != nil:
-			checks = append(checks, uidCheck{"issue_claims", "claim_uid", "claim", record.IssueClaim.ClaimUID})
-		case record.PendingClaimRequest != nil:
-			checks = append(checks, uidCheck{"pending_claim_requests", "request_uid", "pending claim", record.PendingClaimRequest.RequestUID})
-		case record.Event != nil:
-			checks = append(checks, uidCheck{"events", "uid", "event", record.Event.UID})
-		case record.PurgeLog != nil:
-			checks = append(checks, uidCheck{"purge_log", "uid", "purge log", record.PurgeLog.UID})
-		case record.ExternalRootBinding != nil:
+		switch record := record.(type) {
+		case *db.ProjectExport:
+			checks = append(checks, uidCheck{"projects", "uid", "project", record.UID})
+		case *db.IssueExport:
+			checks = append(checks, uidCheck{"issues", "uid", "issue", record.UID})
+		case *db.CommentExport:
+			checks = append(checks, uidCheck{"comments", "uid", "comment", record.UID})
+		case *db.RecurrenceExport:
+			checks = append(checks, uidCheck{"recurrences", "uid", "recurrence", record.UID})
+		case *db.IssueClaimExport:
+			checks = append(checks, uidCheck{"issue_claims", "claim_uid", "claim", record.ClaimUID})
+		case *db.PendingClaimRequestExport:
+			checks = append(checks, uidCheck{"pending_claim_requests", "request_uid", "pending claim", record.RequestUID})
+		case *db.EventExport:
+			checks = append(checks, uidCheck{"events", "uid", "event", record.UID})
+		case *db.PurgeLogExport:
+			checks = append(checks, uidCheck{"purge_log", "uid", "purge log", record.UID})
+		case *db.ExternalRootBindingExport:
 			checks = append(checks, uidCheck{
-				"external_root_bindings", "uid", "external root binding", record.ExternalRootBinding.UID,
+				"external_root_bindings", "uid", "external root binding", record.UID,
 			})
 		}
 	}

--- a/internal/db/pgstore/import_replay_race_test.go
+++ b/internal/db/pgstore/import_replay_race_test.go
@@ -40,13 +40,12 @@ func TestImportReplayFreshTargetRejectsConcurrentWriter(t *testing.T) {
 
 	result := make(chan error, 1)
 	go func() {
-		result <- store.ImportReplay(ctx, []db.ImportRecord{{
-			Kind: db.ImportKindProject,
-			Project: &db.ProjectExport{
+		result <- store.ImportReplay(ctx, []db.ImportRecord{
+			&db.ProjectExport{
 				ID: 3, UID: "01KATA00000000000000000002", Name: "restored-project",
 				CreatedAt: "2026-07-15T12:00:00.000Z", Metadata: json.RawMessage(`{}`), Revision: 1,
 			},
-		}}, db.ImportOptions{RequireFreshTarget: true})
+		}, db.ImportOptions{RequireFreshTarget: true})
 	}()
 
 	require.Eventually(t, func() bool {
@@ -107,13 +106,12 @@ func TestImportReplayWaitsForConcurrentSchemaMigration(t *testing.T) {
 
 	result := make(chan error, 1)
 	go func() {
-		result <- store.ImportReplay(ctx, []db.ImportRecord{{
-			Kind: db.ImportKindProject,
-			Project: &db.ProjectExport{
+		result <- store.ImportReplay(ctx, []db.ImportRecord{
+			&db.ProjectExport{
 				ID: 2, UID: "01KATA00000000000000000003", Name: "restored-project",
 				CreatedAt: "2026-07-15T12:00:00.000Z", Metadata: json.RawMessage(`{}`), Revision: 1,
 			},
-		}}, db.ImportOptions{})
+		}, db.ImportOptions{})
 	}()
 
 	require.Eventually(t, func() bool {
@@ -155,10 +153,9 @@ func TestImportReplayWaitsForServingDaemonAcrossConnections(t *testing.T) {
 
 	result := make(chan error, 1)
 	go func() {
-		result <- restore.ImportReplay(ctx, []db.ImportRecord{{
-			Kind: db.ImportKindMeta,
-			Meta: &db.MetaKV{Key: "instance_uid", Value: "01KATA00000000000000000044"},
-		}}, db.ImportOptions{})
+		result <- restore.ImportReplay(ctx, []db.ImportRecord{
+			&db.MetaKV{Key: "instance_uid", Value: "01KATA00000000000000000044"},
+		}, db.ImportOptions{})
 	}()
 
 	require.Eventually(t, func() bool {
@@ -208,13 +205,12 @@ func TestImportReplayRefusesCrossSchemaCascade(t *testing.T) {
 		`INSERT INTO unrelated.project_refs(project_id,note) VALUES($1,'must survive')`, project.ID)
 	require.NoError(t, err)
 
-	err = store.ImportReplay(ctx, []db.ImportRecord{{
-		Kind: db.ImportKindProject,
-		Project: &db.ProjectExport{
+	err = store.ImportReplay(ctx, []db.ImportRecord{
+		&db.ProjectExport{
 			ID: 9, UID: "01KATA00000000000000000009", Name: "replacement",
 			CreatedAt: "2026-07-15T12:00:00.000Z", Metadata: json.RawMessage(`{}`), Revision: 1,
 		},
-	}}, db.ImportOptions{})
+	}, db.ImportOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "clear import target")
 
@@ -240,10 +236,9 @@ func TestImportReplayClearsTargetOnlyMetadata(t *testing.T) {
 		`INSERT INTO meta(key,value) VALUES('claim_status_refresh_error:old','stale')`)
 	require.NoError(t, err)
 
-	require.NoError(t, store.ImportReplay(ctx, []db.ImportRecord{{
-		Kind: db.ImportKindMeta,
-		Meta: &db.MetaKV{Key: "instance_uid", Value: "01KATA00000000000000000010"},
-	}}, db.ImportOptions{}))
+	require.NoError(t, store.ImportReplay(ctx, []db.ImportRecord{
+		&db.MetaKV{Key: "instance_uid", Value: "01KATA00000000000000000010"},
+	}, db.ImportOptions{}))
 	var stale string
 	err = store.QueryRowContext(ctx,
 		`SELECT value FROM meta WHERE key='claim_status_refresh_error:old'`).Scan(&stale)
@@ -251,10 +246,9 @@ func TestImportReplayClearsTargetOnlyMetadata(t *testing.T) {
 	assert.Equal(t, "01KATA00000000000000000010", store.InstanceUID())
 
 	localUID := store.InstanceUID()
-	require.NoError(t, store.ImportReplay(ctx, []db.ImportRecord{{
-		Kind: db.ImportKindMeta,
-		Meta: &db.MetaKV{Key: "instance_uid", Value: "01KATA00000000000000000011"},
-	}}, db.ImportOptions{NewInstance: true}))
+	require.NoError(t, store.ImportReplay(ctx, []db.ImportRecord{
+		&db.MetaKV{Key: "instance_uid", Value: "01KATA00000000000000000011"},
+	}, db.ImportOptions{NewInstance: true}))
 	assert.Equal(t, localUID, store.InstanceUID())
 }
 
@@ -282,17 +276,17 @@ func TestImportReplayPreservesHistoricalEventProjectName(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, store.ImportReplay(ctx, []db.ImportRecord{
-		{Kind: db.ImportKindMeta, Meta: &db.MetaKV{Key: "instance_uid", Value: instanceUID}},
-		{Kind: db.ImportKindProject, Project: &db.ProjectExport{
+		&db.MetaKV{Key: "instance_uid", Value: instanceUID},
+		&db.ProjectExport{
 			ID: 12, UID: projectUID, Name: "new-name", CreatedAt: createdAt,
 			Metadata: json.RawMessage(`{}`), Revision: 1,
-		}},
-		{Kind: db.ImportKindEvent, Event: &db.EventExport{
+		},
+		&db.EventExport{
 			ID: 13, UID: eventUID, OriginInstanceUID: instanceUID, ProjectID: 12,
 			ProjectUID: projectUID, ProjectName: "old-name", Type: "project.created",
 			Actor: "operator", Payload: payload, HLCPhysicalMS: 1784116800000,
 			ContentHash: hash, CreatedAt: createdAt,
-		}},
+		},
 	}, db.ImportOptions{}))
 	var storedName string
 	require.NoError(t, store.QueryRowContext(ctx,

--- a/internal/db/project_merge.go
+++ b/internal/db/project_merge.go
@@ -60,29 +60,26 @@ func PrepareProjectMergeRecords(
 	importedExternalBindings := make(map[string]struct{})
 	importedExternalMappings := make(map[externalFieldMappingIdentity]struct{})
 	for _, rec := range recs {
-		if rec.Project != nil {
-			if rec.Project.UID == SystemProjectUID || rec.Project.Name == SystemProjectName {
+		switch rec := rec.(type) {
+		case *ProjectExport:
+			if rec.UID == SystemProjectUID || rec.Name == SystemProjectName {
 				return nil, fmt.Errorf("project merge requires one non-system project")
 			}
 			if project != nil {
 				return nil, fmt.Errorf("project merge requires exactly one project record")
 			}
-			p := *rec.Project
+			p := *rec
 			project = &p
-		}
-		if rec.Issue != nil {
-			importedIssues[rec.Issue.ID] = rec.Issue.UID
-			importedIssueUIDs[rec.Issue.UID] = struct{}{}
-		}
-		if rec.Recurrence != nil {
-			importedRecurrencesByID[rec.Recurrence.ID] = rec.Recurrence.UID
-			importedRecurrencesByUID[rec.Recurrence.UID] = rec.Recurrence.ID
-		}
-		if rec.ExternalRootBinding != nil {
-			importedExternalBindings[rec.ExternalRootBinding.UID] = struct{}{}
-		}
-		if rec.ExternalFieldMapping != nil {
-			importedExternalMappings[externalFieldMappingExportIdentity(rec.ExternalFieldMapping)] = struct{}{}
+		case *IssueExport:
+			importedIssues[rec.ID] = rec.UID
+			importedIssueUIDs[rec.UID] = struct{}{}
+		case *RecurrenceExport:
+			importedRecurrencesByID[rec.ID] = rec.UID
+			importedRecurrencesByUID[rec.UID] = rec.ID
+		case *ExternalRootBindingExport:
+			importedExternalBindings[rec.UID] = struct{}{}
+		case *ExternalFieldMappingExport:
+			importedExternalMappings[externalFieldMappingExportIdentity(rec)] = struct{}{}
 		}
 	}
 	if project == nil {
@@ -132,193 +129,193 @@ func PrepareProjectMergeRecords(
 	out := make([]ImportRecord, 0, len(recs)-2)
 	var issueSequenceFloor, eventSequenceFloor int64
 	for _, rec := range recs {
-		if rec.Kind == ImportKindMeta {
+		if _, ok := rec.(*MetaKV); ok {
 			continue
 		}
 		cloned := cloneImportRecord(rec)
 		var err error
-		switch cloned.Kind {
-		case ImportKindProject:
-			cloned.Project.ID = offsets.TargetProjectID
-		case ImportKindProjectAlias:
-			if err = requireMergeProjectID(cloned.Alias.ProjectID, projectID, cloned.Kind); err == nil {
-				cloned.Alias.ID, err = addMergeOffset(cloned.Alias.ID, offsets.Alias, cloned.Kind)
-				cloned.Alias.ProjectID = offsets.TargetProjectID
+		switch payload := cloned.(type) {
+		case *ProjectExport:
+			payload.ID = offsets.TargetProjectID
+		case *AliasExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				payload.ID, err = addMergeOffset(payload.ID, offsets.Alias, payload.ImportKind())
+				payload.ProjectID = offsets.TargetProjectID
 			}
-		case ImportKindIssueSyncBinding:
-			if err = requireMergeProjectID(cloned.IssueSyncBinding.ProjectID, projectID, cloned.Kind); err == nil {
-				cloned.IssueSyncBinding.ID, err = addMergeOffset(cloned.IssueSyncBinding.ID, offsets.SyncBinding, cloned.Kind)
-				cloned.IssueSyncBinding.ProjectID = offsets.TargetProjectID
+		case *IssueSyncBindingExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				payload.ID, err = addMergeOffset(payload.ID, offsets.SyncBinding, payload.ImportKind())
+				payload.ProjectID = offsets.TargetProjectID
 			}
-		case ImportKindIssueSyncStatus:
-			if err = requireMergeProjectID(cloned.IssueSyncStatus.ProjectID, projectID, cloned.Kind); err == nil {
-				cloned.IssueSyncStatus.BindingID, err = addMergeOffset(cloned.IssueSyncStatus.BindingID, offsets.SyncBinding, cloned.Kind)
-				cloned.IssueSyncStatus.ProjectID = offsets.TargetProjectID
+		case *IssueSyncStatusExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				payload.BindingID, err = addMergeOffset(payload.BindingID, offsets.SyncBinding, payload.ImportKind())
+				payload.ProjectID = offsets.TargetProjectID
 			}
-		case ImportKindRecurrence:
-			if err = requireMergeProjectID(cloned.Recurrence.ProjectID, projectID, cloned.Kind); err == nil {
-				cloned.Recurrence.ID, err = addMergeOffset(cloned.Recurrence.ID, offsets.Recurrence, cloned.Kind)
-				cloned.Recurrence.ProjectID = offsets.TargetProjectID
+		case *RecurrenceExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				payload.ID, err = addMergeOffset(payload.ID, offsets.Recurrence, payload.ImportKind())
+				payload.ProjectID = offsets.TargetProjectID
 			}
-		case ImportKindIssue:
-			if err = requireMergeProjectID(cloned.Issue.ProjectID, projectID, cloned.Kind); err == nil {
-				cloned.Issue.ID, err = addMergeOffset(cloned.Issue.ID, offsets.Issue, cloned.Kind)
-				cloned.Issue.ProjectID = offsets.TargetProjectID
-				if err == nil && cloned.Issue.RecurrenceUID != nil {
-					sourceRecurrenceID, ok := importedRecurrencesByUID[*cloned.Issue.RecurrenceUID]
+		case *IssueExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				payload.ID, err = addMergeOffset(payload.ID, offsets.Issue, payload.ImportKind())
+				payload.ProjectID = offsets.TargetProjectID
+				if err == nil && payload.RecurrenceUID != nil {
+					sourceRecurrenceID, ok := importedRecurrencesByUID[*payload.RecurrenceUID]
 					if !ok {
 						err = fmt.Errorf("project merge issue recurrence UID %q is not part of the imported project",
-							*cloned.Issue.RecurrenceUID)
-					} else if cloned.Issue.RecurrenceID == nil {
-						cloned.Issue.RecurrenceID = &sourceRecurrenceID
-					} else if *cloned.Issue.RecurrenceID != sourceRecurrenceID {
+							*payload.RecurrenceUID)
+					} else if payload.RecurrenceID == nil {
+						payload.RecurrenceID = &sourceRecurrenceID
+					} else if *payload.RecurrenceID != sourceRecurrenceID {
 						err = fmt.Errorf("project merge issue recurrence ID %d does not match recurrence UID %q",
-							*cloned.Issue.RecurrenceID, *cloned.Issue.RecurrenceUID)
+							*payload.RecurrenceID, *payload.RecurrenceUID)
 					}
 				}
-				if err == nil && cloned.Issue.RecurrenceID != nil {
-					if _, ok := importedRecurrencesByID[*cloned.Issue.RecurrenceID]; !ok {
+				if err == nil && payload.RecurrenceID != nil {
+					if _, ok := importedRecurrencesByID[*payload.RecurrenceID]; !ok {
 						err = fmt.Errorf("project merge issue recurrence ID %d is not part of the imported project",
-							*cloned.Issue.RecurrenceID)
+							*payload.RecurrenceID)
 					}
 				}
-				if err == nil && cloned.Issue.RecurrenceID != nil {
-					*cloned.Issue.RecurrenceID, err = addMergeOffset(*cloned.Issue.RecurrenceID, offsets.Recurrence, cloned.Kind+" recurrence")
+				if err == nil && payload.RecurrenceID != nil {
+					*payload.RecurrenceID, err = addMergeOffset(*payload.RecurrenceID, offsets.Recurrence, payload.ImportKind()+" recurrence")
 				}
 			}
-		case ImportKindComment:
-			cloned.Comment.ID, err = addMergeOffset(cloned.Comment.ID, offsets.Comment, cloned.Kind)
+		case *CommentExport:
+			payload.ID, err = addMergeOffset(payload.ID, offsets.Comment, payload.ImportKind())
 			if err == nil {
-				cloned.Comment.IssueID, err = resolveImportedIssue(cloned.Comment.IssueID, "", "comment")
+				payload.IssueID, err = resolveImportedIssue(payload.IssueID, "", "comment")
 			}
-		case ImportKindIssueLabel:
-			cloned.Label.IssueID, err = resolveImportedIssue(cloned.Label.IssueID, "", "label")
-		case ImportKindLink:
-			_, fromImported := importedIssues[cloned.Link.FromIssueID]
-			_, toImported := importedIssues[cloned.Link.ToIssueID]
+		case *IssueLabelExport:
+			payload.IssueID, err = resolveImportedIssue(payload.IssueID, "", "label")
+		case *LinkExport:
+			_, fromImported := importedIssues[payload.FromIssueID]
+			_, toImported := importedIssues[payload.ToIssueID]
 			if !fromImported && !toImported {
 				err = fmt.Errorf("project merge link must include an issue from the imported project")
 			}
 			if err == nil {
-				cloned.Link.ID, err = addMergeOffset(cloned.Link.ID, offsets.Link, cloned.Kind)
+				payload.ID, err = addMergeOffset(payload.ID, offsets.Link, payload.ImportKind())
 			}
 			if err == nil {
-				cloned.Link.FromIssueID, err = resolveLinkIssue(cloned.Link.FromIssueID)
+				payload.FromIssueID, err = resolveLinkIssue(payload.FromIssueID)
 			}
 			if err == nil {
-				cloned.Link.ToIssueID, err = resolveLinkIssue(cloned.Link.ToIssueID)
+				payload.ToIssueID, err = resolveLinkIssue(payload.ToIssueID)
 			}
-		case ImportKindImportMapping:
-			if err = requireMergeProjectID(cloned.ImportMapping.ProjectID, projectID, cloned.Kind); err == nil {
-				cloned.ImportMapping.ID, err = addMergeOffset(cloned.ImportMapping.ID, offsets.ImportMapping, cloned.Kind)
-				cloned.ImportMapping.ProjectID = offsets.TargetProjectID
-				if err == nil && cloned.ImportMapping.IssueID != nil {
-					*cloned.ImportMapping.IssueID, err = addMergeOffset(*cloned.ImportMapping.IssueID, offsets.Issue, cloned.Kind+" issue")
+		case *ImportMappingExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				payload.ID, err = addMergeOffset(payload.ID, offsets.ImportMapping, payload.ImportKind())
+				payload.ProjectID = offsets.TargetProjectID
+				if err == nil && payload.IssueID != nil {
+					*payload.IssueID, err = addMergeOffset(*payload.IssueID, offsets.Issue, payload.ImportKind()+" issue")
 				}
-				if err == nil && cloned.ImportMapping.CommentID != nil {
-					*cloned.ImportMapping.CommentID, err = addMergeOffset(*cloned.ImportMapping.CommentID, offsets.Comment, cloned.Kind+" comment")
+				if err == nil && payload.CommentID != nil {
+					*payload.CommentID, err = addMergeOffset(*payload.CommentID, offsets.Comment, payload.ImportKind()+" comment")
 				}
-				if err == nil && cloned.ImportMapping.LinkID != nil {
-					*cloned.ImportMapping.LinkID, err = addMergeOffset(*cloned.ImportMapping.LinkID, offsets.Link, cloned.Kind+" link")
+				if err == nil && payload.LinkID != nil {
+					*payload.LinkID, err = addMergeOffset(*payload.LinkID, offsets.Link, payload.ImportKind()+" link")
 				}
 			}
-		case ImportKindExternalFieldMapping:
+		case *ExternalFieldMappingExport:
 			// Field mappings are global portable descriptor revisions. Preserve
 			// their identity; backend replay either reuses an exact existing
 			// revision or atomically rejects a conflicting target revision.
-		case ImportKindExternalRootBinding:
-			if cloned.ExternalRootBinding.ProjectUID != project.UID {
+		case *ExternalRootBindingExport:
+			if payload.ProjectUID != project.UID {
 				err = fmt.Errorf("project merge external root binding references project UID %q, want %q",
-					cloned.ExternalRootBinding.ProjectUID, project.UID)
-			} else if _, ok := importedIssueUIDs[cloned.ExternalRootBinding.IssueUID]; !ok {
+					payload.ProjectUID, project.UID)
+			} else if _, ok := importedIssueUIDs[payload.IssueUID]; !ok {
 				err = fmt.Errorf("project merge external root binding issue UID %q is not part of the imported project",
-					cloned.ExternalRootBinding.IssueUID)
+					payload.IssueUID)
 			}
-		case ImportKindExternalFieldState:
-			if _, ok := importedExternalBindings[cloned.ExternalFieldState.BindingUID]; !ok {
+		case *ExternalFieldStateExport:
+			if _, ok := importedExternalBindings[payload.BindingUID]; !ok {
 				err = fmt.Errorf("project merge external field state binding UID %q is not part of the imported project",
-					cloned.ExternalFieldState.BindingUID)
-			} else if _, ok := importedExternalMappings[externalFieldStateMappingIdentity(cloned.ExternalFieldState)]; !ok {
+					payload.BindingUID)
+			} else if _, ok := importedExternalMappings[externalFieldStateMappingIdentity(payload)]; !ok {
 				err = fmt.Errorf("project merge external field state mapping is not part of the imported project envelope")
 			}
-		case ImportKindFederationBinding, ImportKindFederationSyncStatus,
-			ImportKindFederationQuarantine, ImportKindFederationEnrollment:
+		case *FederationBindingExport, *FederationSyncStatusExport,
+			*FederationQuarantineExport, *FederationEnrollmentExport:
 			// Federation cursors are split between local and remote event ID
 			// spaces, while enrollment token hashes are live credentials. Drop
 			// all federation state so the imported project must rejoin cleanly.
 			continue
-		case ImportKindIssueClaim:
-			if err = requireMergeProjectID(cloned.IssueClaim.ProjectID, projectID, cloned.Kind); err == nil {
-				cloned.IssueClaim.ID, err = addMergeOffset(cloned.IssueClaim.ID, offsets.Claim, cloned.Kind)
-				cloned.IssueClaim.ProjectID = offsets.TargetProjectID
+		case *IssueClaimExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				payload.ID, err = addMergeOffset(payload.ID, offsets.Claim, payload.ImportKind())
+				payload.ProjectID = offsets.TargetProjectID
 				if err == nil {
-					cloned.IssueClaim.IssueID, err = resolveImportedIssue(
-						cloned.IssueClaim.IssueID, cloned.IssueClaim.IssueUID, "claim",
+					payload.IssueID, err = resolveImportedIssue(
+						payload.IssueID, payload.IssueUID, "claim",
 					)
 				}
 			}
-		case ImportKindPendingClaimRequest:
-			if err = requireMergeProjectID(cloned.PendingClaimRequest.ProjectID, projectID, cloned.Kind); err == nil {
-				cloned.PendingClaimRequest.ID, err = addMergeOffset(cloned.PendingClaimRequest.ID, offsets.PendingClaim, cloned.Kind)
-				cloned.PendingClaimRequest.ProjectID = offsets.TargetProjectID
+		case *PendingClaimRequestExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				payload.ID, err = addMergeOffset(payload.ID, offsets.PendingClaim, payload.ImportKind())
+				payload.ProjectID = offsets.TargetProjectID
 				if err == nil {
-					cloned.PendingClaimRequest.IssueID, err = resolveImportedIssue(
-						cloned.PendingClaimRequest.IssueID, cloned.PendingClaimRequest.IssueUID, "pending claim",
+					payload.IssueID, err = resolveImportedIssue(
+						payload.IssueID, payload.IssueUID, "pending claim",
 					)
 				}
 			}
-		case ImportKindEvent:
-			if err = requireMergeProjectID(cloned.Event.ProjectID, projectID, cloned.Kind); err == nil {
-				if cloned.Event.HLCPhysicalMS > maxProjectMergeHLCValue || cloned.Event.HLCCounter > maxProjectMergeHLCValue {
+		case *EventExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				if payload.HLCPhysicalMS > maxProjectMergeHLCValue || payload.HLCCounter > maxProjectMergeHLCValue {
 					err = fmt.Errorf("project merge event HLC exceeds safe range")
 				}
 				// UID, content hash, and payload form the event's portable
 				// identity. Only target-local numeric columns are remapped.
 				if err == nil {
-					cloned.Event.ID, err = addMergeOffset(cloned.Event.ID, offsets.Event, cloned.Kind)
+					payload.ID, err = addMergeOffset(payload.ID, offsets.Event, payload.ImportKind())
 				}
-				cloned.Event.ProjectID = offsets.TargetProjectID
-				if err == nil && cloned.Event.IssueID != nil {
-					*cloned.Event.IssueID, err = resolveImportedIssue(
-						*cloned.Event.IssueID, mergeStringValue(cloned.Event.IssueUID), "event",
+				payload.ProjectID = offsets.TargetProjectID
+				if err == nil && payload.IssueID != nil {
+					*payload.IssueID, err = resolveImportedIssue(
+						*payload.IssueID, mergeStringValue(payload.IssueUID), "event",
 					)
 				}
-				if err == nil && cloned.Event.RelatedIssueID != nil {
+				if err == nil && payload.RelatedIssueID != nil {
 					var resolvedID int64
-					resolvedID, err = resolveIssue(*cloned.Event.RelatedIssueID, mergeStringValue(cloned.Event.RelatedIssueUID))
+					resolvedID, err = resolveIssue(*payload.RelatedIssueID, mergeStringValue(payload.RelatedIssueUID))
 					if err == nil && resolvedID == 0 {
-						cloned.Event.RelatedIssueID = nil
+						payload.RelatedIssueID = nil
 					} else if err == nil {
-						*cloned.Event.RelatedIssueID = resolvedID
+						*payload.RelatedIssueID = resolvedID
 					}
 				}
 			}
-		case ImportKindPurgeLog:
-			if err = requireMergeProjectID(cloned.PurgeLog.ProjectID, projectID, cloned.Kind); err == nil {
-				cloned.PurgeLog.ID, err = addMergeOffset(cloned.PurgeLog.ID, offsets.PurgeLog, cloned.Kind)
-				cloned.PurgeLog.ProjectID = offsets.TargetProjectID
+		case *PurgeLogExport:
+			if err = requireMergeProjectID(payload.ProjectID, projectID, payload.ImportKind()); err == nil {
+				payload.ID, err = addMergeOffset(payload.ID, offsets.PurgeLog, payload.ImportKind())
+				payload.ProjectID = offsets.TargetProjectID
 				if err == nil {
-					cloned.PurgeLog.PurgedIssueID, err = addMergeOffset(cloned.PurgeLog.PurgedIssueID, offsets.Issue, cloned.Kind+" issue")
+					payload.PurgedIssueID, err = addMergeOffset(payload.PurgedIssueID, offsets.Issue, payload.ImportKind()+" issue")
 				}
-				if err == nil && cloned.PurgeLog.PurgedIssueID > issueSequenceFloor {
-					issueSequenceFloor = cloned.PurgeLog.PurgedIssueID
+				if err == nil && payload.PurgedIssueID > issueSequenceFloor {
+					issueSequenceFloor = payload.PurgedIssueID
 				}
 				if err == nil {
 					err = shiftEventPointers(
-						cloned.PurgeLog.EventsDeletedMinID,
-						cloned.PurgeLog.EventsDeletedMaxID,
-						cloned.PurgeLog.PurgeResetAfterEventID,
+						payload.EventsDeletedMinID,
+						payload.EventsDeletedMaxID,
+						payload.PurgeResetAfterEventID,
 						offsets.Event,
 					)
 				}
-				if err == nil && cloned.PurgeLog.PurgeResetAfterEventID != nil &&
-					*cloned.PurgeLog.PurgeResetAfterEventID > eventSequenceFloor {
-					eventSequenceFloor = *cloned.PurgeLog.PurgeResetAfterEventID
+				if err == nil && payload.PurgeResetAfterEventID != nil &&
+					*payload.PurgeResetAfterEventID > eventSequenceFloor {
+					eventSequenceFloor = *payload.PurgeResetAfterEventID
 				}
 			}
-		case ImportKindProjectPurgeLog:
+		case *ProjectPurgeLogExport:
 			return nil, fmt.Errorf("project merge does not accept project_purge_log records")
-		case ImportKindSQLiteSequence:
+		case *SequenceExport:
 			// Scoped exports carry whole-database sequence floors. They do not
 			// describe this project. Live imported IDs and the derived tombstone
 			// floors below advance target sequences during replay.
@@ -330,21 +327,15 @@ func PrepareProjectMergeRecords(
 		out = append(out, cloned)
 	}
 	if issueSequenceFloor > 0 {
-		out = append(out, ImportRecord{
-			Kind: ImportKindSQLiteSequence,
-			Sequence: &SequenceExport{
-				Name: "issues",
-				Seq:  issueSequenceFloor,
-			},
+		out = append(out, &SequenceExport{
+			Name: "issues",
+			Seq:  issueSequenceFloor,
 		})
 	}
 	if eventSequenceFloor > 0 {
-		out = append(out, ImportRecord{
-			Kind: ImportKindSQLiteSequence,
-			Sequence: &SequenceExport{
-				Name: "events",
-				Seq:  eventSequenceFloor,
-			},
+		out = append(out, &SequenceExport{
+			Name: "events",
+			Seq:  eventSequenceFloor,
 		})
 	}
 	return out, nil
@@ -382,131 +373,108 @@ func shiftEventPointers(first, last, reset *int64, offset int64) error {
 }
 
 func cloneImportRecord(rec ImportRecord) ImportRecord {
-	out := ImportRecord{Kind: rec.Kind}
-	if rec.Meta != nil {
-		v := *rec.Meta
-		out.Meta = &v
+	switch rec := rec.(type) {
+	case *MetaKV:
+		v := *rec
+		return &v
+	case *ProjectExport:
+		v := *rec
+		return &v
+	case *AliasExport:
+		v := *rec
+		return &v
+	case *IssueSyncBindingExport:
+		v := *rec
+		return &v
+	case *IssueSyncStatusExport:
+		v := *rec
+		return &v
+	case *RecurrenceExport:
+		v := *rec
+		return &v
+	case *IssueExport:
+		v := *rec
+		v.RecurrenceID = cloneInt64Ptr(rec.RecurrenceID)
+		return &v
+	case *IssueEmbeddingExport:
+		v := *rec
+		return &v
+	case *CommentExport:
+		v := *rec
+		return &v
+	case *IssueLabelExport:
+		v := *rec
+		return &v
+	case *LinkExport:
+		v := *rec
+		return &v
+	case *ImportMappingExport:
+		v := *rec
+		v.IssueID = cloneInt64Ptr(rec.IssueID)
+		v.CommentID = cloneInt64Ptr(rec.CommentID)
+		v.LinkID = cloneInt64Ptr(rec.LinkID)
+		return &v
+	case *ExternalFieldMappingExport:
+		v := *rec
+		v.AcceptedKinds = append([]string(nil), rec.AcceptedKinds...)
+		return &v
+	case *ExternalRootBindingExport:
+		v := *rec
+		v.ReceiveCommentsAfter = cloneTimePtr(rec.ReceiveCommentsAfter)
+		v.PublishCommentsAfter = cloneTimePtr(rec.PublishCommentsAfter)
+		v.PendingCommentStartedAt = cloneTimePtr(rec.PendingCommentStartedAt)
+		v.LastAttemptAt = cloneTimePtr(rec.LastAttemptAt)
+		v.LastSuccessAt = cloneTimePtr(rec.LastSuccessAt)
+		v.LastErrorAt = cloneTimePtr(rec.LastErrorAt)
+		v.NextAttemptAt = cloneTimePtr(rec.NextAttemptAt)
+		v.UnboundAt = cloneTimePtr(rec.UnboundAt)
+		return &v
+	case *ExternalFieldStateExport:
+		v := *rec
+		v.Baseline = append(json.RawMessage(nil), rec.Baseline...)
+		v.ConflictKata = append(json.RawMessage(nil), rec.ConflictKata...)
+		v.ConflictExternal = append(json.RawMessage(nil), rec.ConflictExternal...)
+		v.ConflictAt = cloneTimePtr(rec.ConflictAt)
+		return &v
+	case *FederationBindingExport:
+		v := *rec
+		return &v
+	case *FederationSyncStatusExport:
+		v := *rec
+		return &v
+	case *FederationQuarantineExport:
+		v := *rec
+		return &v
+	case *FederationEnrollmentExport:
+		v := *rec
+		v.ProjectID = cloneInt64Ptr(rec.ProjectID)
+		return &v
+	case *IssueClaimExport:
+		v := *rec
+		return &v
+	case *PendingClaimRequestExport:
+		v := *rec
+		return &v
+	case *EventExport:
+		v := *rec
+		v.IssueID = cloneInt64Ptr(rec.IssueID)
+		v.RelatedIssueID = cloneInt64Ptr(rec.RelatedIssueID)
+		return &v
+	case *PurgeLogExport:
+		v := *rec
+		v.EventsDeletedMinID = cloneInt64Ptr(rec.EventsDeletedMinID)
+		v.EventsDeletedMaxID = cloneInt64Ptr(rec.EventsDeletedMaxID)
+		v.PurgeResetAfterEventID = cloneInt64Ptr(rec.PurgeResetAfterEventID)
+		return &v
+	case *ProjectPurgeLogExport:
+		v := *rec
+		return &v
+	case *SequenceExport:
+		v := *rec
+		return &v
+	default:
+		return rec
 	}
-	if rec.Project != nil {
-		v := *rec.Project
-		out.Project = &v
-	}
-	if rec.Alias != nil {
-		v := *rec.Alias
-		out.Alias = &v
-	}
-	if rec.IssueSyncBinding != nil {
-		v := *rec.IssueSyncBinding
-		out.IssueSyncBinding = &v
-	}
-	if rec.IssueSyncStatus != nil {
-		v := *rec.IssueSyncStatus
-		out.IssueSyncStatus = &v
-	}
-	if rec.Recurrence != nil {
-		v := *rec.Recurrence
-		out.Recurrence = &v
-	}
-	if rec.Issue != nil {
-		v := *rec.Issue
-		out.Issue = &v
-		out.Issue.RecurrenceID = cloneInt64Ptr(v.RecurrenceID)
-	}
-	if rec.IssueEmbedding != nil {
-		v := *rec.IssueEmbedding
-		out.IssueEmbedding = &v
-	}
-	if rec.Comment != nil {
-		v := *rec.Comment
-		out.Comment = &v
-	}
-	if rec.Label != nil {
-		v := *rec.Label
-		out.Label = &v
-	}
-	if rec.Link != nil {
-		v := *rec.Link
-		out.Link = &v
-	}
-	if rec.ImportMapping != nil {
-		v := *rec.ImportMapping
-		out.ImportMapping = &v
-		out.ImportMapping.IssueID = cloneInt64Ptr(v.IssueID)
-		out.ImportMapping.CommentID = cloneInt64Ptr(v.CommentID)
-		out.ImportMapping.LinkID = cloneInt64Ptr(v.LinkID)
-	}
-	if rec.ExternalFieldMapping != nil {
-		v := *rec.ExternalFieldMapping
-		v.AcceptedKinds = append([]string(nil), v.AcceptedKinds...)
-		out.ExternalFieldMapping = &v
-	}
-	if rec.ExternalRootBinding != nil {
-		v := *rec.ExternalRootBinding
-		v.ReceiveCommentsAfter = cloneTimePtr(v.ReceiveCommentsAfter)
-		v.PublishCommentsAfter = cloneTimePtr(v.PublishCommentsAfter)
-		v.PendingCommentStartedAt = cloneTimePtr(v.PendingCommentStartedAt)
-		v.LastAttemptAt = cloneTimePtr(v.LastAttemptAt)
-		v.LastSuccessAt = cloneTimePtr(v.LastSuccessAt)
-		v.LastErrorAt = cloneTimePtr(v.LastErrorAt)
-		v.NextAttemptAt = cloneTimePtr(v.NextAttemptAt)
-		v.UnboundAt = cloneTimePtr(v.UnboundAt)
-		out.ExternalRootBinding = &v
-	}
-	if rec.ExternalFieldState != nil {
-		v := *rec.ExternalFieldState
-		v.Baseline = append(json.RawMessage(nil), v.Baseline...)
-		v.ConflictKata = append(json.RawMessage(nil), v.ConflictKata...)
-		v.ConflictExternal = append(json.RawMessage(nil), v.ConflictExternal...)
-		v.ConflictAt = cloneTimePtr(v.ConflictAt)
-		out.ExternalFieldState = &v
-	}
-	if rec.FederationBinding != nil {
-		v := *rec.FederationBinding
-		out.FederationBinding = &v
-	}
-	if rec.FederationSyncStatus != nil {
-		v := *rec.FederationSyncStatus
-		out.FederationSyncStatus = &v
-	}
-	if rec.FederationQuarantine != nil {
-		v := *rec.FederationQuarantine
-		out.FederationQuarantine = &v
-	}
-	if rec.FederationEnrollment != nil {
-		v := *rec.FederationEnrollment
-		out.FederationEnrollment = &v
-		out.FederationEnrollment.ProjectID = cloneInt64Ptr(v.ProjectID)
-	}
-	if rec.IssueClaim != nil {
-		v := *rec.IssueClaim
-		out.IssueClaim = &v
-	}
-	if rec.PendingClaimRequest != nil {
-		v := *rec.PendingClaimRequest
-		out.PendingClaimRequest = &v
-	}
-	if rec.Event != nil {
-		v := *rec.Event
-		out.Event = &v
-		out.Event.IssueID = cloneInt64Ptr(v.IssueID)
-		out.Event.RelatedIssueID = cloneInt64Ptr(v.RelatedIssueID)
-	}
-	if rec.PurgeLog != nil {
-		v := *rec.PurgeLog
-		out.PurgeLog = &v
-		out.PurgeLog.EventsDeletedMinID = cloneInt64Ptr(v.EventsDeletedMinID)
-		out.PurgeLog.EventsDeletedMaxID = cloneInt64Ptr(v.EventsDeletedMaxID)
-		out.PurgeLog.PurgeResetAfterEventID = cloneInt64Ptr(v.PurgeResetAfterEventID)
-	}
-	if rec.ProjectPurgeLog != nil {
-		v := *rec.ProjectPurgeLog
-		out.ProjectPurgeLog = &v
-	}
-	if rec.Sequence != nil {
-		v := *rec.Sequence
-		out.Sequence = &v
-	}
-	return out
 }
 
 type externalFieldMappingIdentity struct {

--- a/internal/db/project_merge_test.go
+++ b/internal/db/project_merge_test.go
@@ -18,8 +18,8 @@ func TestPrepareProjectMergeRecordsPreservesEventIdentityAndPayload(t *testing.T
 		Payload: payload, HLCPhysicalMS: 1, ContentHash: "source-hash", CreatedAt: "2026-08-19T00:00:00.000Z",
 	}
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindEvent, Event: event},
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		event,
 	}
 
 	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -28,20 +28,20 @@ func TestPrepareProjectMergeRecordsPreservesEventIdentityAndPayload(t *testing.T
 	require.NoError(t, err)
 	require.Len(t, prepared, 2)
 
-	assert.Equal(t, event.UID, prepared[1].Event.UID)
-	assert.Equal(t, event.ContentHash, prepared[1].Event.ContentHash)
-	assert.JSONEq(t, string(payload), string(prepared[1].Event.Payload))
+	assert.Equal(t, event.UID, recordPayloadAs[EventExport](t, prepared[1]).UID)
+	assert.Equal(t, event.ContentHash, recordPayloadAs[EventExport](t, prepared[1]).ContentHash)
+	assert.JSONEq(t, string(payload), string(recordPayloadAs[EventExport](t, prepared[1]).Payload))
 	assert.JSONEq(t, string(payload), string(event.Payload), "source event payload must not be mutated")
 	assert.Equal(t, "source-hash", event.ContentHash, "source event hash must not be mutated")
 }
 
 func TestPrepareProjectMergeRecordsDropsSequenceFloors(t *testing.T) {
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "projects", Seq: 9}},
-		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "issues", Seq: math.MaxInt64}},
-		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "events", Seq: 50}},
-		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "api_tokens", Seq: 99}},
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&SequenceExport{Name: "projects", Seq: 9},
+		&SequenceExport{Name: "issues", Seq: math.MaxInt64},
+		&SequenceExport{Name: "events", Seq: 50},
+		&SequenceExport{Name: "api_tokens", Seq: 99},
 	}
 
 	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -49,18 +49,18 @@ func TestPrepareProjectMergeRecordsDropsSequenceFloors(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	require.Len(t, prepared, 1)
-	assert.Equal(t, int64(4), prepared[0].Project.ID)
-	assert.Equal(t, int64(9), records[1].Sequence.Seq, "source sequence must not be mutated")
+	assert.Equal(t, int64(4), recordPayloadAs[ProjectExport](t, prepared[0]).ID)
+	assert.Equal(t, int64(9), recordPayloadAs[SequenceExport](t, records[1]).Seq, "source sequence must not be mutated")
 }
 
 func TestPrepareProjectMergeRecordsDerivesSequenceFloorsFromPurgeTombstone(t *testing.T) {
 	resetCursor := int64(50)
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindPurgeLog, PurgeLog: &PurgeLogExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&PurgeLogExport{
 			ID: 1, ProjectID: 2, PurgedIssueID: 3, PurgeResetAfterEventID: &resetCursor,
-		}},
-		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "events", Seq: math.MaxInt64}},
+		},
+		&SequenceExport{Name: "events", Seq: math.MaxInt64},
 	}
 
 	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -68,38 +68,38 @@ func TestPrepareProjectMergeRecordsDerivesSequenceFloorsFromPurgeTombstone(t *te
 	}, nil)
 	require.NoError(t, err)
 	require.Len(t, prepared, 4)
-	assert.Equal(t, int64(103), prepared[1].PurgeLog.PurgedIssueID)
-	require.NotNil(t, prepared[1].PurgeLog.PurgeResetAfterEventID)
-	assert.Equal(t, int64(250), *prepared[1].PurgeLog.PurgeResetAfterEventID)
-	require.NotNil(t, prepared[2].Sequence)
-	assert.Equal(t, "issues", prepared[2].Sequence.Name)
-	assert.Equal(t, int64(103), prepared[2].Sequence.Seq)
-	require.NotNil(t, prepared[3].Sequence)
-	assert.Equal(t, "events", prepared[3].Sequence.Name)
-	assert.Equal(t, int64(250), prepared[3].Sequence.Seq)
-	assert.Equal(t, int64(3), records[1].PurgeLog.PurgedIssueID, "source issue ID must not be mutated")
-	assert.Equal(t, int64(50), *records[1].PurgeLog.PurgeResetAfterEventID, "source cursor must not be mutated")
+	assert.Equal(t, int64(103), recordPayloadAs[PurgeLogExport](t, prepared[1]).PurgedIssueID)
+	require.NotNil(t, recordPayloadAs[PurgeLogExport](t, prepared[1]).PurgeResetAfterEventID)
+	assert.Equal(t, int64(250), *recordPayloadAs[PurgeLogExport](t, prepared[1]).PurgeResetAfterEventID)
+	require.NotNil(t, recordPayloadAs[SequenceExport](t, prepared[2]))
+	assert.Equal(t, "issues", recordPayloadAs[SequenceExport](t, prepared[2]).Name)
+	assert.Equal(t, int64(103), recordPayloadAs[SequenceExport](t, prepared[2]).Seq)
+	require.NotNil(t, recordPayloadAs[SequenceExport](t, prepared[3]))
+	assert.Equal(t, "events", recordPayloadAs[SequenceExport](t, prepared[3]).Name)
+	assert.Equal(t, int64(250), recordPayloadAs[SequenceExport](t, prepared[3]).Seq)
+	assert.Equal(t, int64(3), recordPayloadAs[PurgeLogExport](t, records[1]).PurgedIssueID, "source issue ID must not be mutated")
+	assert.Equal(t, int64(50), *recordPayloadAs[PurgeLogExport](t, records[1]).PurgeResetAfterEventID, "source cursor must not be mutated")
 }
 
 func TestPrepareProjectMergeRecordsRejectsIDsWithoutSequenceHeadroom(t *testing.T) {
-	project := ImportRecord{Kind: ImportKindProject, Project: &ProjectExport{
+	project := &ProjectExport{
 		ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project",
-	}}
+	}
 	tests := []struct {
 		name   string
 		record ImportRecord
 	}{
 		{
 			name: "issue",
-			record: ImportRecord{Kind: ImportKindIssue, Issue: &IssueExport{
+			record: &IssueExport{
 				ID: math.MaxInt64, UID: "01H00000000000000000000001", ProjectID: 2,
-			}},
+			},
 		},
 		{
 			name: "event",
-			record: ImportRecord{Kind: ImportKindEvent, Event: &EventExport{
+			record: &EventExport{
 				ID: math.MaxInt64, UID: "01H00000000000000000000002", ProjectID: 2,
-			}},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -116,11 +116,11 @@ func TestPrepareProjectMergeRecordsRejectsIDsWithoutSequenceHeadroom(t *testing.
 
 func TestPrepareProjectMergeRecordsRejectsHLCPhysicalValueWithoutHeadroom(t *testing.T) {
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindEvent, Event: &EventExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&EventExport{
 			ID: 7, UID: "01H00000000000000000000001", ProjectID: 2,
 			HLCPhysicalMS: maxProjectMergeHLCValue + 1,
-		}},
+		},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -132,11 +132,11 @@ func TestPrepareProjectMergeRecordsRejectsHLCPhysicalValueWithoutHeadroom(t *tes
 
 func TestPrepareProjectMergeRecordsRejectsHLCCounterWithoutHeadroom(t *testing.T) {
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindEvent, Event: &EventExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&EventExport{
 			ID: 7, UID: "01H00000000000000000000001", ProjectID: 2,
 			HLCPhysicalMS: 1, HLCCounter: maxProjectMergeHLCValue + 1,
-		}},
+		},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -150,15 +150,15 @@ func TestPrepareProjectMergeRecordsRemapsIDs(t *testing.T) {
 	issueID := int64(5)
 	peerID := int64(9)
 	records := []ImportRecord{
-		{Kind: ImportKindMeta, Meta: &MetaKV{Key: "instance_uid", Value: "source"}},
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{ID: issueID, UID: "01H00000000000000000000001", ProjectID: 2}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{ID: peerID, UID: "01H00000000000000000000002", ProjectID: 2}},
-		{Kind: ImportKindLink, Link: &LinkExport{
+		&MetaKV{Key: "instance_uid", Value: "source"},
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&IssueExport{ID: issueID, UID: "01H00000000000000000000001", ProjectID: 2},
+		&IssueExport{ID: peerID, UID: "01H00000000000000000000002", ProjectID: 2},
+		&LinkExport{
 			ID: 3, FromIssueID: issueID, FromIssueUID: "01H00000000000000000000001",
 			ToIssueID: peerID, ToIssueUID: "01H00000000000000000000002", Type: "blocks",
-		}},
-		{Kind: ImportKindSQLiteSequence, Sequence: &SequenceExport{Name: "issues", Seq: 99}},
+		},
+		&SequenceExport{Name: "issues", Seq: 99},
 	}
 
 	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -166,27 +166,27 @@ func TestPrepareProjectMergeRecordsRemapsIDs(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	require.Len(t, prepared, 4)
-	assert.Equal(t, int64(20), prepared[0].Project.ID)
-	assert.Equal(t, int64(105), prepared[1].Issue.ID)
-	assert.Equal(t, int64(20), prepared[1].Issue.ProjectID)
-	assert.Equal(t, int64(109), prepared[2].Issue.ID)
-	assert.Equal(t, int64(203), prepared[3].Link.ID)
-	assert.Equal(t, int64(105), prepared[3].Link.FromIssueID)
-	assert.Equal(t, int64(109), prepared[3].Link.ToIssueID)
+	assert.Equal(t, int64(20), recordPayloadAs[ProjectExport](t, prepared[0]).ID)
+	assert.Equal(t, int64(105), recordPayloadAs[IssueExport](t, prepared[1]).ID)
+	assert.Equal(t, int64(20), recordPayloadAs[IssueExport](t, prepared[1]).ProjectID)
+	assert.Equal(t, int64(109), recordPayloadAs[IssueExport](t, prepared[2]).ID)
+	assert.Equal(t, int64(203), recordPayloadAs[LinkExport](t, prepared[3]).ID)
+	assert.Equal(t, int64(105), recordPayloadAs[LinkExport](t, prepared[3]).FromIssueID)
+	assert.Equal(t, int64(109), recordPayloadAs[LinkExport](t, prepared[3]).ToIssueID)
 
-	assert.Equal(t, issueID, records[2].Issue.ID, "source records must not be mutated")
-	assert.Equal(t, peerID, records[4].Link.ToIssueID, "source link must not be mutated")
+	assert.Equal(t, issueID, recordPayloadAs[IssueExport](t, records[2]).ID, "source records must not be mutated")
+	assert.Equal(t, peerID, recordPayloadAs[LinkExport](t, records[4]).ToIssueID, "source link must not be mutated")
 }
 
 func TestPrepareProjectMergeRecordsRejectsRecurrenceUIDOutsideImport(t *testing.T) {
 	recurrenceUID := "01H00000000000000000000002"
 	occurrenceKey := "2026-08-20"
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&IssueExport{
 			ID: 5, UID: "01H00000000000000000000001", ProjectID: 2,
 			RecurrenceUID: &recurrenceUID, OccurrenceKey: &occurrenceKey,
-		}},
+		},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -200,13 +200,13 @@ func TestPrepareProjectMergeRecordsRejectsRecurrenceIdentityMismatch(t *testing.
 	recurrenceID := int64(3)
 	recurrenceUID := "01H00000000000000000000004"
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindRecurrence, Recurrence: &RecurrenceExport{ID: 3, UID: "01H00000000000000000000002", ProjectID: 2}},
-		{Kind: ImportKindRecurrence, Recurrence: &RecurrenceExport{ID: 4, UID: recurrenceUID, ProjectID: 2}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&RecurrenceExport{ID: 3, UID: "01H00000000000000000000002", ProjectID: 2},
+		&RecurrenceExport{ID: 4, UID: recurrenceUID, ProjectID: 2},
+		&IssueExport{
 			ID: 5, UID: "01H00000000000000000000001", ProjectID: 2,
 			RecurrenceID: &recurrenceID, RecurrenceUID: &recurrenceUID,
-		}},
+		},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -219,11 +219,11 @@ func TestPrepareProjectMergeRecordsRejectsRecurrenceIdentityMismatch(t *testing.
 func TestPrepareProjectMergeRecordsRejectsRecurrenceIDOutsideImport(t *testing.T) {
 	recurrenceID := int64(3)
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&IssueExport{
 			ID: 5, UID: "01H00000000000000000000001", ProjectID: 2,
 			RecurrenceID: &recurrenceID,
-		}},
+		},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -236,31 +236,31 @@ func TestPrepareProjectMergeRecordsRejectsRecurrenceIDOutsideImport(t *testing.T
 func TestPrepareProjectMergeRecordsRemapsRecurrenceUIDWithinImport(t *testing.T) {
 	recurrenceUID := "01H00000000000000000000002"
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindRecurrence, Recurrence: &RecurrenceExport{ID: 3, UID: recurrenceUID, ProjectID: 2}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&RecurrenceExport{ID: 3, UID: recurrenceUID, ProjectID: 2},
+		&IssueExport{
 			ID: 5, UID: "01H00000000000000000000001", ProjectID: 2,
 			RecurrenceUID: &recurrenceUID,
-		}},
+		},
 	}
 
 	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
 		TargetProjectID: 4, Issue: 10, Recurrence: 20,
 	}, nil)
 	require.NoError(t, err)
-	require.NotNil(t, prepared[2].Issue.RecurrenceID)
-	assert.Equal(t, int64(23), *prepared[2].Issue.RecurrenceID)
-	assert.Nil(t, records[2].Issue.RecurrenceID, "source issue must not be mutated")
+	require.NotNil(t, recordPayloadAs[IssueExport](t, prepared[2]).RecurrenceID)
+	assert.Equal(t, int64(23), *recordPayloadAs[IssueExport](t, prepared[2]).RecurrenceID)
+	assert.Nil(t, recordPayloadAs[IssueExport](t, records[2]).RecurrenceID, "source issue must not be mutated")
 }
 
 func TestPrepareProjectMergeRecordsDoesNotResolveExternalLinkPeer(t *testing.T) {
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2}},
-		{Kind: ImportKindLink, Link: &LinkExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2},
+		&LinkExport{
 			ID: 3, FromIssueID: 5, FromIssueUID: "01H00000000000000000000001",
 			ToIssueID: 9, ToIssueUID: "01H00000000000000000000002", Type: "blocks",
-		}},
+		},
 	}
 	lookupCalled := false
 
@@ -272,8 +272,8 @@ func TestPrepareProjectMergeRecordsDoesNotResolveExternalLinkPeer(t *testing.T) 
 	})
 	require.NoError(t, err)
 	require.Len(t, prepared, 3)
-	assert.Equal(t, int64(15), prepared[2].Link.FromIssueID)
-	assert.Zero(t, prepared[2].Link.ToIssueID)
+	assert.Equal(t, int64(15), recordPayloadAs[LinkExport](t, prepared[2]).FromIssueID)
+	assert.Zero(t, recordPayloadAs[LinkExport](t, prepared[2]).ToIssueID)
 	assert.False(t, lookupCalled)
 }
 
@@ -281,11 +281,11 @@ func TestPrepareProjectMergeRecordsClearsUnresolvedEventRelatedIssueID(t *testin
 	relatedIssueID := int64(9)
 	relatedIssueUID := "01H00000000000000000000002"
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindEvent, Event: &EventExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&EventExport{
 			ID: 7, UID: "01H00000000000000000000001", ProjectID: 2,
 			RelatedIssueID: &relatedIssueID, RelatedIssueUID: &relatedIssueUID,
-		}},
+		},
 	}
 
 	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -293,23 +293,23 @@ func TestPrepareProjectMergeRecordsClearsUnresolvedEventRelatedIssueID(t *testin
 	}, func(string) (int64, bool, error) { return 0, false, nil })
 	require.NoError(t, err)
 	require.Len(t, prepared, 2)
-	assert.Nil(t, prepared[1].Event.RelatedIssueID)
-	require.NotNil(t, prepared[1].Event.RelatedIssueUID)
-	assert.Equal(t, relatedIssueUID, *prepared[1].Event.RelatedIssueUID)
-	assert.Equal(t, int64(9), *records[1].Event.RelatedIssueID, "source event must not be mutated")
+	assert.Nil(t, recordPayloadAs[EventExport](t, prepared[1]).RelatedIssueID)
+	require.NotNil(t, recordPayloadAs[EventExport](t, prepared[1]).RelatedIssueUID)
+	assert.Equal(t, relatedIssueUID, *recordPayloadAs[EventExport](t, prepared[1]).RelatedIssueUID)
+	assert.Equal(t, int64(9), *recordPayloadAs[EventExport](t, records[1]).RelatedIssueID, "source event must not be mutated")
 }
 
 func TestPrepareProjectMergeRecordsRejectsEventRelatedIssueUIDMismatch(t *testing.T) {
 	relatedIssueID := int64(5)
 	relatedIssueUID := "01H00000000000000000000002"
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 6, UID: relatedIssueUID, ProjectID: 2}},
-		{Kind: ImportKindEvent, Event: &EventExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2},
+		&IssueExport{ID: 6, UID: relatedIssueUID, ProjectID: 2},
+		&EventExport{
 			ID: 7, UID: "01H00000000000000000000003", ProjectID: 2,
 			RelatedIssueID: &relatedIssueID, RelatedIssueUID: &relatedIssueUID,
-		}},
+		},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -323,18 +323,18 @@ func TestPrepareProjectMergeRecordsRejectsEventRelatedIssueUIDMismatch(t *testin
 func TestPrepareProjectMergeRecordsDropsFederationState(t *testing.T) {
 	projectID := int64(2)
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: projectID, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindFederationBinding, FederationBinding: &FederationBindingExport{
+		&ProjectExport{ID: projectID, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&FederationBindingExport{
 			ProjectID: projectID, Role: "spoke", Enabled: true, PushEnabled: true,
 			ReplayHorizonEventID: 40, PullCursorEventID: 50, PushCursorEventID: 60,
-		}},
-		{Kind: ImportKindFederationSyncStatus, FederationSyncStatus: &FederationSyncStatusExport{ProjectID: projectID}},
-		{Kind: ImportKindFederationQuarantine, FederationQuarantine: &FederationQuarantineExport{
+		},
+		&FederationSyncStatusExport{ProjectID: projectID},
+		&FederationQuarantineExport{
 			ID: 3, ProjectID: projectID, Direction: "pull", FirstEventID: 40, LastEventID: 50,
-		}},
-		{Kind: ImportKindFederationEnrollment, FederationEnrollment: &FederationEnrollmentExport{
+		},
+		&FederationEnrollmentExport{
 			ID: 4, ProjectID: &projectID, TokenHash: "attacker-controlled", Capabilities: "pull,push",
-		}},
+		},
 	}
 
 	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -342,20 +342,14 @@ func TestPrepareProjectMergeRecordsDropsFederationState(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	require.Len(t, prepared, 1)
-	assert.NotNil(t, prepared[0].Project)
-	for _, record := range prepared {
-		assert.Nil(t, record.FederationBinding)
-		assert.Nil(t, record.FederationSyncStatus)
-		assert.Nil(t, record.FederationQuarantine)
-		assert.Nil(t, record.FederationEnrollment)
-	}
-	assert.True(t, records[1].FederationBinding.Enabled, "source binding must not be mutated")
+	assert.NotNil(t, recordPayloadAs[ProjectExport](t, prepared[0]))
+	assert.True(t, recordPayloadAs[FederationBindingExport](t, records[1]).Enabled, "source binding must not be mutated")
 }
 
 func TestPrepareProjectMergeRecordsRejectsMultipleProjects(t *testing.T) {
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 3, UID: "01H00000000000000000000001", Name: "hub-project"}},
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&ProjectExport{ID: 3, UID: "01H00000000000000000000001", Name: "hub-project"},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{TargetProjectID: 4}, nil)
@@ -365,10 +359,10 @@ func TestPrepareProjectMergeRecordsRejectsMultipleProjects(t *testing.T) {
 
 func TestPrepareProjectMergeRecordsDropsWildcardFederationEnrollment(t *testing.T) {
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindFederationEnrollment, FederationEnrollment: &FederationEnrollmentExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&FederationEnrollmentExport{
 			ID: 4, ProjectID: nil,
-		}},
+		},
 	}
 
 	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -376,17 +370,17 @@ func TestPrepareProjectMergeRecordsDropsWildcardFederationEnrollment(t *testing.
 	}, nil)
 	require.NoError(t, err)
 	require.Len(t, prepared, 1)
-	assert.NotNil(t, prepared[0].Project)
+	assert.NotNil(t, recordPayloadAs[ProjectExport](t, prepared[0]))
 }
 
 func TestPrepareProjectMergeRecordsRejectsClaimOutsideImportedProject(t *testing.T) {
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2}},
-		{Kind: ImportKindIssueClaim, IssueClaim: &IssueClaimExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2},
+		&IssueClaimExport{
 			ID: 6, ClaimUID: "01H00000000000000000000002", ProjectID: 2,
 			IssueID: 99, IssueUID: "01H00000000000000000000003",
-		}},
+		},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -398,12 +392,12 @@ func TestPrepareProjectMergeRecordsRejectsClaimOutsideImportedProject(t *testing
 
 func TestPrepareProjectMergeRecordsRejectsClaimIssueUIDMismatch(t *testing.T) {
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2}},
-		{Kind: ImportKindIssueClaim, IssueClaim: &IssueClaimExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&IssueExport{ID: 5, UID: "01H00000000000000000000001", ProjectID: 2},
+		&IssueClaimExport{
 			ID: 6, ClaimUID: "01H00000000000000000000002", ProjectID: 2,
 			IssueID: 5, IssueUID: "01H00000000000000000000003",
-		}},
+		},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -416,11 +410,11 @@ func TestPrepareProjectMergeRecordsRejectsClaimIssueUIDMismatch(t *testing.T) {
 
 func TestPrepareProjectMergeRecordsRejectsLinkBetweenExistingProjects(t *testing.T) {
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"}},
-		{Kind: ImportKindLink, Link: &LinkExport{
+		&ProjectExport{ID: 2, UID: "01H00000000000000000000000", Name: "spoke-project"},
+		&LinkExport{
 			ID: 3, FromIssueID: 8, FromIssueUID: "01H00000000000000000000001",
 			ToIssueID: 9, ToIssueUID: "01H00000000000000000000002", Type: "blocks",
-		}},
+		},
 	}
 
 	_, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -429,36 +423,35 @@ func TestPrepareProjectMergeRecordsRejectsLinkBetweenExistingProjects(t *testing
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "link must include an issue from the imported project")
 }
-
 func TestPrepareProjectMergeRecordsPreservesExternalRootRecords(t *testing.T) {
 	createdAt := time.Date(2026, time.August, 20, 12, 0, 0, 0, time.UTC)
 	projectUID := "01H00000000000000000000000"
 	issueUID := "01H00000000000000000000001"
 	bindingUID := "01H00000000000000000000002"
 	records := []ImportRecord{
-		{Kind: ImportKindProject, Project: &ProjectExport{ID: 2, UID: projectUID, Name: "spoke-project"}},
-		{Kind: ImportKindIssue, Issue: &IssueExport{ID: 5, UID: issueUID, ProjectID: 2}},
-		{Kind: ImportKindExternalFieldMapping, ExternalFieldMapping: &ExternalFieldMappingExport{
+		&ProjectExport{ID: 2, UID: projectUID, Name: "spoke-project"},
+		&IssueExport{ID: 5, UID: issueUID, ProjectID: 2},
+		&ExternalFieldMappingExport{
 			ConnectorInstance: "connector-one", KataField: "scheduled_on",
 			ExternalFieldID: "schedule-one", ExternalFieldName: "Schedule",
 			AcceptedKinds: []string{"date"}, Nullable: true, Writable: true,
 			SchemaRevision: "schema-one", Active: true,
 			CreatedAt: createdAt, UpdatedAt: createdAt,
-		}},
-		{Kind: ImportKindExternalRootBinding, ExternalRootBinding: &ExternalRootBindingExport{
+		},
+		&ExternalRootBindingExport{
 			UID: bindingUID, ProjectUID: projectUID, IssueUID: issueUID,
 			RootMappingSource: "connector:connector-one", RootMappingExternalID: "root-one",
 			ConnectorInstance: "connector-one", ExternalRootKey: "root-one",
 			ExternalAccountKey: "account-one", Active: true, Enabled: true,
 			ReceiveComments: true, ReceiveCommentsAfter: &createdAt,
 			CreatedAt: createdAt, UpdatedAt: createdAt,
-		}},
-		{Kind: ImportKindExternalFieldState, ExternalFieldState: &ExternalFieldStateExport{
+		},
+		&ExternalFieldStateExport{
 			BindingUID: bindingUID, MappingConnectorInstance: "connector-one",
 			MappingKataField: "scheduled_on", MappingExternalFieldID: "schedule-one",
 			MappingSchemaRevision: "schema-one", MappingCreatedAt: createdAt,
 			Baseline: json.RawMessage(`"2026-08-20"`), UpdatedAt: createdAt,
-		}},
+		},
 	}
 
 	prepared, err := PrepareProjectMergeRecords(records, ProjectMergeOffsets{
@@ -466,11 +459,20 @@ func TestPrepareProjectMergeRecordsPreservesExternalRootRecords(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	require.Len(t, prepared, len(records))
-	require.NotNil(t, prepared[2].ExternalFieldMapping)
-	require.NotNil(t, prepared[3].ExternalRootBinding)
-	require.NotNil(t, prepared[4].ExternalFieldState)
-	assert.Equal(t, records[2].ExternalFieldMapping, prepared[2].ExternalFieldMapping)
-	assert.Equal(t, records[3].ExternalRootBinding, prepared[3].ExternalRootBinding)
-	assert.Equal(t, records[4].ExternalFieldState, prepared[4].ExternalFieldState)
-	assert.Equal(t, int64(2), records[1].Issue.ProjectID, "source records must not be mutated")
+	assert.Equal(t, recordPayloadAs[ExternalFieldMappingExport](t, records[2]),
+		recordPayloadAs[ExternalFieldMappingExport](t, prepared[2]))
+	assert.Equal(t, recordPayloadAs[ExternalRootBindingExport](t, records[3]),
+		recordPayloadAs[ExternalRootBindingExport](t, prepared[3]))
+	assert.Equal(t, recordPayloadAs[ExternalFieldStateExport](t, records[4]),
+		recordPayloadAs[ExternalFieldStateExport](t, prepared[4]))
+	assert.Equal(t, int64(2), recordPayloadAs[IssueExport](t, records[1]).ProjectID,
+		"source records must not be mutated")
+}
+
+func recordPayloadAs[T any](t *testing.T, record ImportRecord) *T {
+	t.Helper()
+	payload, ok := any(record).(*T)
+	require.True(t, ok, "record is %T, want *%T", record, *new(T))
+	require.NotNil(t, payload)
+	return payload
 }

--- a/internal/db/sqlitestore/import_replay.go
+++ b/internal/db/sqlitestore/import_replay.go
@@ -86,8 +86,8 @@ func (d *Store) importReplay(ctx context.Context, recs []db.ImportRecord, opts d
 		switch skip {
 		case linkSkipMissingPeer:
 			skippedMissingPeer++
-			if r.Link != nil {
-				skippedLinkIDs[r.Link.ID] = struct{}{}
+			if link, ok := r.(*db.LinkExport); ok {
+				skippedLinkIDs[link.ID] = struct{}{}
 			}
 		case linkSkipDuplicate:
 			skippedDup++
@@ -174,26 +174,26 @@ func refuseProjectMergeUIDCollisions(ctx context.Context, tx *sql.Tx, recs []db.
 	type uidCheck struct{ table, column, kind, uid string }
 	checks := make([]uidCheck, 0, len(recs))
 	for _, rec := range recs {
-		switch {
-		case rec.Project != nil:
-			checks = append(checks, uidCheck{"projects", "uid", "project", rec.Project.UID})
-		case rec.Issue != nil:
-			checks = append(checks, uidCheck{"issues", "uid", "issue", rec.Issue.UID})
-		case rec.Comment != nil:
-			checks = append(checks, uidCheck{"comments", "uid", "comment", rec.Comment.UID})
-		case rec.Recurrence != nil:
-			checks = append(checks, uidCheck{"recurrences", "uid", "recurrence", rec.Recurrence.UID})
-		case rec.IssueClaim != nil:
-			checks = append(checks, uidCheck{"issue_claims", "claim_uid", "claim", rec.IssueClaim.ClaimUID})
-		case rec.PendingClaimRequest != nil:
-			checks = append(checks, uidCheck{"pending_claim_requests", "request_uid", "pending claim", rec.PendingClaimRequest.RequestUID})
-		case rec.Event != nil:
-			checks = append(checks, uidCheck{"events", "uid", "event", rec.Event.UID})
-		case rec.PurgeLog != nil:
-			checks = append(checks, uidCheck{"purge_log", "uid", "purge log", rec.PurgeLog.UID})
-		case rec.ExternalRootBinding != nil:
+		switch rec := rec.(type) {
+		case *db.ProjectExport:
+			checks = append(checks, uidCheck{"projects", "uid", "project", rec.UID})
+		case *db.IssueExport:
+			checks = append(checks, uidCheck{"issues", "uid", "issue", rec.UID})
+		case *db.CommentExport:
+			checks = append(checks, uidCheck{"comments", "uid", "comment", rec.UID})
+		case *db.RecurrenceExport:
+			checks = append(checks, uidCheck{"recurrences", "uid", "recurrence", rec.UID})
+		case *db.IssueClaimExport:
+			checks = append(checks, uidCheck{"issue_claims", "claim_uid", "claim", rec.ClaimUID})
+		case *db.PendingClaimRequestExport:
+			checks = append(checks, uidCheck{"pending_claim_requests", "request_uid", "pending claim", rec.RequestUID})
+		case *db.EventExport:
+			checks = append(checks, uidCheck{"events", "uid", "event", rec.UID})
+		case *db.PurgeLogExport:
+			checks = append(checks, uidCheck{"purge_log", "uid", "purge log", rec.UID})
+		case *db.ExternalRootBindingExport:
 			checks = append(checks, uidCheck{
-				"external_root_bindings", "uid", "external root binding", rec.ExternalRootBinding.UID,
+				"external_root_bindings", "uid", "external root binding", rec.UID,
 			})
 		}
 	}
@@ -337,60 +337,64 @@ const (
 // linkSkipNone. The replay loop counts each reason separately and emits
 // per-reason aggregate notes.
 func importRecord(ctx context.Context, tx *sql.Tx, r db.ImportRecord, opts db.ImportOptions, skippedLinkIDs map[int64]struct{}) (linkSkip, error) {
-	switch r.Kind {
-	case db.ImportKindMeta:
-		return linkSkipNone, importMeta(ctx, tx, r.Meta, opts)
-	case db.ImportKindProject:
-		return linkSkipNone, importProject(ctx, tx, r.Project)
-	case db.ImportKindProjectAlias:
-		return linkSkipNone, importAlias(ctx, tx, r.Alias)
-	case db.ImportKindIssueSyncBinding:
-		return linkSkipNone, importIssueSyncBinding(ctx, tx, r.IssueSyncBinding, opts.PreserveIssueSyncBindingEnabled)
-	case db.ImportKindIssueSyncStatus:
-		return linkSkipNone, importIssueSyncStatus(ctx, tx, r.IssueSyncStatus)
-	case db.ImportKindRecurrence:
-		return linkSkipNone, importRecurrence(ctx, tx, r.Recurrence)
-	case db.ImportKindIssue:
-		return linkSkipNone, importIssue(ctx, tx, r.Issue)
-	case db.ImportKindIssueEmbedding:
-		return linkSkipNone, importIssueEmbedding(ctx, tx, r.IssueEmbedding)
-	case db.ImportKindComment:
-		return linkSkipNone, importComment(ctx, tx, r.Comment)
-	case db.ImportKindIssueLabel:
-		return linkSkipNone, importLabel(ctx, tx, r.Label)
-	case db.ImportKindLink:
-		return importLink(ctx, tx, r.Link)
-	case db.ImportKindImportMapping:
-		return importMapping(ctx, tx, r.ImportMapping, skippedLinkIDs)
-	case db.ImportKindExternalFieldMapping:
-		return linkSkipNone, importExternalFieldMapping(ctx, tx, r.ExternalFieldMapping, opts.MergeProject)
-	case db.ImportKindExternalRootBinding:
-		return linkSkipNone, importExternalRootBinding(ctx, tx, r.ExternalRootBinding, opts.PreserveExternalRootBindingsEnabled)
-	case db.ImportKindExternalFieldState:
-		return linkSkipNone, importExternalFieldState(ctx, tx, r.ExternalFieldState)
-	case db.ImportKindFederationBinding:
-		return linkSkipNone, importFederationBinding(ctx, tx, r.FederationBinding)
-	case db.ImportKindFederationSyncStatus:
-		return linkSkipNone, importFederationSyncStatus(ctx, tx, r.FederationSyncStatus)
-	case db.ImportKindFederationQuarantine:
-		return linkSkipNone, importFederationQuarantine(ctx, tx, r.FederationQuarantine)
-	case db.ImportKindFederationEnrollment:
-		return linkSkipNone, importFederationEnrollment(ctx, tx, r.FederationEnrollment)
-	case db.ImportKindIssueClaim:
-		return linkSkipNone, importIssueClaim(ctx, tx, r.IssueClaim)
-	case db.ImportKindPendingClaimRequest:
-		return linkSkipNone, importPendingClaimRequest(ctx, tx, r.PendingClaimRequest, opts)
-	case db.ImportKindEvent:
-		return linkSkipNone, importEvent(ctx, tx, r.Event, opts)
-	case db.ImportKindPurgeLog:
-		return linkSkipNone, importPurgeLog(ctx, tx, r.PurgeLog)
-	case db.ImportKindProjectPurgeLog:
-		return linkSkipNone, importProjectPurgeLog(ctx, tx, r.ProjectPurgeLog)
-	case db.ImportKindSQLiteSequence:
-		return linkSkipNone, upsertSequence(ctx, tx, r.Sequence.Name, r.Sequence.Seq)
+	switch rec := r.(type) {
+	case *db.MetaKV:
+		return linkSkipNone, importMeta(ctx, tx, rec, opts)
+	case *db.ProjectExport:
+		return linkSkipNone, importProject(ctx, tx, rec)
+	case *db.AliasExport:
+		return linkSkipNone, importAlias(ctx, tx, rec)
+	case *db.IssueSyncBindingExport:
+		return linkSkipNone, importIssueSyncBinding(ctx, tx, rec, opts.PreserveIssueSyncBindingEnabled)
+	case *db.IssueSyncStatusExport:
+		return linkSkipNone, importIssueSyncStatus(ctx, tx, rec)
+	case *db.RecurrenceExport:
+		return linkSkipNone, importRecurrence(ctx, tx, rec)
+	case *db.IssueExport:
+		return linkSkipNone, importIssue(ctx, tx, rec)
+	case *db.IssueEmbeddingExport:
+		return linkSkipNone, importIssueEmbedding(ctx, tx, rec)
+	case *db.CommentExport:
+		return linkSkipNone, importComment(ctx, tx, rec)
+	case *db.IssueLabelExport:
+		return linkSkipNone, importLabel(ctx, tx, rec)
+	case *db.LinkExport:
+		return importLink(ctx, tx, rec)
+	case *db.ImportMappingExport:
+		return importMapping(ctx, tx, rec, skippedLinkIDs)
+	case *db.ExternalFieldMappingExport:
+		return linkSkipNone, importExternalFieldMapping(ctx, tx, rec, opts.MergeProject)
+	case *db.ExternalRootBindingExport:
+		return linkSkipNone, importExternalRootBinding(
+			ctx, tx, rec, opts.PreserveExternalRootBindingsEnabled,
+		)
+	case *db.ExternalFieldStateExport:
+		return linkSkipNone, importExternalFieldState(ctx, tx, rec)
+	case *db.FederationBindingExport:
+		return linkSkipNone, importFederationBinding(ctx, tx, rec)
+	case *db.FederationSyncStatusExport:
+		return linkSkipNone, importFederationSyncStatus(ctx, tx, rec)
+	case *db.FederationQuarantineExport:
+		return linkSkipNone, importFederationQuarantine(ctx, tx, rec)
+	case *db.FederationEnrollmentExport:
+		return linkSkipNone, importFederationEnrollment(ctx, tx, rec)
+	case *db.IssueClaimExport:
+		return linkSkipNone, importIssueClaim(ctx, tx, rec)
+	case *db.PendingClaimRequestExport:
+		return linkSkipNone, importPendingClaimRequest(ctx, tx, rec, opts)
+	case *db.EventExport:
+		return linkSkipNone, importEvent(ctx, tx, rec, opts)
+	case *db.PurgeLogExport:
+		return linkSkipNone, importPurgeLog(ctx, tx, rec)
+	case *db.ProjectPurgeLogExport:
+		return linkSkipNone, importProjectPurgeLog(ctx, tx, rec)
+	case *db.SequenceExport:
+		return linkSkipNone, upsertSequence(ctx, tx, rec.Name, rec.Seq)
 	default:
-		// Unreachable: validate() already rejected unknown kinds.
-		return linkSkipNone, fmt.Errorf("import: unsupported kind %q", r.Kind)
+		// ValidateImportRecords rejects unknown types before the transaction
+		// opens; this arm exists so a future payload type cannot be replayed
+		// silently.
+		return linkSkipNone, fmt.Errorf("import: unsupported record type %T", r)
 	}
 }
 

--- a/internal/db/sqlitestore/import_replay_test.go
+++ b/internal/db/sqlitestore/import_replay_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 
@@ -16,142 +15,44 @@ import (
 	"go.kenn.io/kata/internal/db/sqlitestore"
 )
 
-// TestImportRecordValidate pins the tagged-union contract of ImportRecord
-// directly. The end-to-end path runs through ImportReplay in later tests, but
-// this table exercises Validate directly so unknown kinds, no-payload,
-// multi-payload, and kind/payload mismatches each surface a clear error.
-func TestImportRecordValidate(t *testing.T) {
-	id := int64(1)
-	cases := []struct {
-		name    string
-		rec     db.ImportRecord
-		wantErr string
-	}{
-		{
-			name:    "unknown kind",
-			rec:     db.ImportRecord{Kind: "bogus", Meta: &db.MetaKV{Key: "k", Value: "v"}},
-			wantErr: "unknown kind",
-		},
-		{
-			name:    "no payload",
-			rec:     db.ImportRecord{Kind: "meta"},
-			wantErr: "no payload set",
-		},
-		{
-			name: "multiple payloads",
-			rec: db.ImportRecord{
-				Kind:    "meta",
-				Meta:    &db.MetaKV{Key: "k", Value: "v"},
-				Project: &db.ProjectExport{ID: id},
-			},
-			wantErr: "multiple payloads set",
-		},
-		{
-			name:    "kind/payload mismatch",
-			rec:     db.ImportRecord{Kind: "project", Meta: &db.MetaKV{Key: "k", Value: "v"}},
-			wantErr: "does not match",
-		},
-		{
-			name:    "valid",
-			rec:     db.ImportRecord{Kind: "meta", Meta: &db.MetaKV{Key: "k", Value: "v"}},
-			wantErr: "",
-		},
-		{
-			name: "valid federation_binding",
-			rec: db.ImportRecord{
-				Kind:              "federation_binding",
-				FederationBinding: &db.FederationBindingExport{ProjectID: 1},
-			},
-			wantErr: "",
-		},
-		{
-			name: "valid issue_claim",
-			rec: db.ImportRecord{
-				Kind:       "issue_claim",
-				IssueClaim: &db.IssueClaimExport{ID: 1},
-			},
-			wantErr: "",
-		},
-		{
-			name: "valid issue_sync_binding",
-			rec: db.ImportRecord{
-				Kind:             db.ImportKindIssueSyncBinding,
-				IssueSyncBinding: &db.IssueSyncBindingExport{ID: 1},
-			},
-			wantErr: "",
-		},
-		{
-			name: "valid issue_sync_status",
-			rec: db.ImportRecord{
-				Kind:            db.ImportKindIssueSyncStatus,
-				IssueSyncStatus: &db.IssueSyncStatusExport{BindingID: 1},
-			},
-			wantErr: "",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.rec.Validate()
-			if tc.wantErr == "" {
-				if err != nil {
-					t.Fatalf("want nil, got %v", err)
-				}
-				return
-			}
-			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
-			}
-		})
-	}
-}
-
 func TestImportReplayInsertsGitHubSyncState(t *testing.T) {
 	ctx := context.Background()
 	target := openTestDB(t)
 	recs := []db.ImportRecord{
-		{
-			Kind: db.ImportKindProject,
-			Project: &db.ProjectExport{
-				ID:        1,
-				UID:       "01HZZZZZZZZZZZZZZZZZZZZZ11",
-				Name:      "example-project",
-				CreatedAt: "2026-06-01T09:00:00.000Z",
-				Metadata:  []byte(`{}`),
-				Revision:  1,
-			},
+		&db.ProjectExport{
+			ID:        1,
+			UID:       "01HZZZZZZZZZZZZZZZZZZZZZ11",
+			Name:      "example-project",
+			CreatedAt: "2026-06-01T09:00:00.000Z",
+			Metadata:  []byte(`{}`),
+			Revision:  1,
 		},
-		{
-			Kind: db.ImportKindIssueSyncBinding,
-			IssueSyncBinding: &db.IssueSyncBindingExport{
-				ID:              7,
-				ProjectID:       1,
-				Provider:        "github",
-				SourceKey:       "github:repo-node-example",
-				RemoteID:        "repo-node-example",
-				DisplayName:     "example-org/example-repo",
-				Config:          []byte(`{"host":"github.com","owner":"example-org","repo":"example-repo","repo_id":42}`),
-				Enabled:         true,
-				IntervalSeconds: 900,
-				LastCursorAt:    new("2026-06-01T10:00:00.000Z"),
-				CreatedAt:       "2026-06-01T09:00:00.000Z",
-				UpdatedAt:       "2026-06-01T10:01:00.000Z",
-			},
+		&db.IssueSyncBindingExport{
+			ID:              7,
+			ProjectID:       1,
+			Provider:        "github",
+			SourceKey:       "github:repo-node-example",
+			RemoteID:        "repo-node-example",
+			DisplayName:     "example-org/example-repo",
+			Config:          []byte(`{"host":"github.com","owner":"example-org","repo":"example-repo","repo_id":42}`),
+			Enabled:         true,
+			IntervalSeconds: 900,
+			LastCursorAt:    new("2026-06-01T10:00:00.000Z"),
+			CreatedAt:       "2026-06-01T09:00:00.000Z",
+			UpdatedAt:       "2026-06-01T10:01:00.000Z",
 		},
-		{
-			Kind: db.ImportKindIssueSyncStatus,
-			IssueSyncStatus: &db.IssueSyncStatusExport{
-				BindingID:     7,
-				ProjectID:     1,
-				SyncStartedAt: new("2026-06-01T09:58:00.000Z"),
-				LastAttemptAt: new("2026-06-01T09:58:00.000Z"),
-				LastSuccessAt: new("2026-06-01T10:00:00.000Z"),
-				LastErrorAt:   new("2026-06-01T10:02:00.000Z"),
-				LastError:     new("rate limited"),
-				LastCreated:   2,
-				LastUpdated:   3,
-				LastUnchanged: 4,
-				LastComments:  5,
-			},
+		&db.IssueSyncStatusExport{
+			BindingID:     7,
+			ProjectID:     1,
+			SyncStartedAt: new("2026-06-01T09:58:00.000Z"),
+			LastAttemptAt: new("2026-06-01T09:58:00.000Z"),
+			LastSuccessAt: new("2026-06-01T10:00:00.000Z"),
+			LastErrorAt:   new("2026-06-01T10:02:00.000Z"),
+			LastError:     new("rate limited"),
+			LastCreated:   2,
+			LastUpdated:   3,
+			LastUnchanged: 4,
+			LastComments:  5,
 		},
 	}
 	require.NoError(t, target.ImportReplay(ctx, recs, db.ImportOptions{}))
@@ -184,32 +85,26 @@ func TestImportReplayCanPreserveIssueSyncBindingEnabledForTrustedCutover(t *test
 	ctx := context.Background()
 	target := openTestDB(t)
 	recs := []db.ImportRecord{
-		{
-			Kind: db.ImportKindProject,
-			Project: &db.ProjectExport{
-				ID:        1,
-				UID:       "01HZZZZZZZZZZZZZZZZZZZZZ11",
-				Name:      "example-project",
-				CreatedAt: "2026-06-01T09:00:00.000Z",
-				Metadata:  []byte(`{}`),
-				Revision:  1,
-			},
+		&db.ProjectExport{
+			ID:        1,
+			UID:       "01HZZZZZZZZZZZZZZZZZZZZZ11",
+			Name:      "example-project",
+			CreatedAt: "2026-06-01T09:00:00.000Z",
+			Metadata:  []byte(`{}`),
+			Revision:  1,
 		},
-		{
-			Kind: db.ImportKindIssueSyncBinding,
-			IssueSyncBinding: &db.IssueSyncBindingExport{
-				ID:              7,
-				ProjectID:       1,
-				Provider:        "github",
-				SourceKey:       "github:repo-node-example",
-				RemoteID:        "repo-node-example",
-				DisplayName:     "example-org/example-repo",
-				Config:          []byte(`{"host":"github.com","owner":"example-org","repo":"example-repo","repo_id":42}`),
-				Enabled:         true,
-				IntervalSeconds: 900,
-				CreatedAt:       "2026-06-01T09:00:00.000Z",
-				UpdatedAt:       "2026-06-01T10:01:00.000Z",
-			},
+		&db.IssueSyncBindingExport{
+			ID:              7,
+			ProjectID:       1,
+			Provider:        "github",
+			SourceKey:       "github:repo-node-example",
+			RemoteID:        "repo-node-example",
+			DisplayName:     "example-org/example-repo",
+			Config:          []byte(`{"host":"github.com","owner":"example-org","repo":"example-repo","repo_id":42}`),
+			Enabled:         true,
+			IntervalSeconds: 900,
+			CreatedAt:       "2026-06-01T09:00:00.000Z",
+			UpdatedAt:       "2026-06-01T10:01:00.000Z",
 		},
 	}
 	require.NoError(t, target.ImportReplay(ctx, recs, db.ImportOptions{PreserveIssueSyncBindingEnabled: true}))
@@ -388,13 +283,13 @@ func TestImportReplay_DedupesRepeatedCrossProjectLink(t *testing.T) {
 	recs := collectImportRecords(t, ctx, src)
 	var dupLink db.LinkExport
 	for _, r := range recs {
-		if r.Kind == db.ImportKindLink {
-			dupLink = *r.Link
+		if link, ok := r.(*db.LinkExport); ok {
+			dupLink = *link
 			break
 		}
 	}
 	require.NotZero(t, dupLink.ID, "fixture must export a link record")
-	recs = append(recs, db.ImportRecord{Kind: db.ImportKindLink, Link: &dupLink})
+	recs = append(recs, &dupLink)
 
 	dst := openTestDB(t)
 	require.NoError(t, dst.ImportReplay(ctx, recs, db.ImportOptions{}),
@@ -461,10 +356,10 @@ func collectImportRecordsForProject(t *testing.T, ctx context.Context, d *sqlite
 func makeFirstIssueEventHashStale(t *testing.T, recs []db.ImportRecord) (eventID int64, finalHash string, issueUID string) {
 	t.Helper()
 	for _, r := range recs {
-		if r.Kind != db.ImportKindEvent || r.Event == nil || r.Event.IssueID == nil || r.Event.IssueUID == nil {
+		e, ok := r.(*db.EventExport)
+		if !ok || e.IssueID == nil || e.IssueUID == nil {
 			continue
 		}
-		e := r.Event
 		issueUID = *e.IssueUID
 		e.IssueUID = nil
 		staleHash, err := db.EventContentHash(db.EventHashInput{
@@ -565,8 +460,8 @@ func TestImportReplayReconcilesSequence(t *testing.T) {
 // in place, failing the test if no such record exists.
 func setSequenceRecord(recs []db.ImportRecord, name string, seq int64) {
 	for _, r := range recs {
-		if r.Kind == "sqlite_sequence" && r.Sequence != nil && r.Sequence.Name == name {
-			r.Sequence.Seq = seq
+		if sequence, ok := r.(*db.SequenceExport); ok && sequence.Name == name {
+			sequence.Seq = seq
 			return
 		}
 	}
@@ -603,15 +498,17 @@ func TestImportReplayIsAtomic(t *testing.T) {
 
 	var dup db.ProjectExport
 	for _, r := range recs {
-		if r.Kind == "project" && r.Project.UID != db.SystemProjectUID {
-			dup = *r.Project
-			break
+		project, ok := r.(*db.ProjectExport)
+		if !ok || project.UID == db.SystemProjectUID {
+			continue
 		}
+		dup = *project
+		break
 	}
 	require.NotEmpty(t, dup.UID, "fixture must contain a non-system project")
 	dup.ID += 1000
 	dup.Name += "-dup"
-	recs = append(recs, db.ImportRecord{Kind: "project", Project: &dup})
+	recs = append(recs, &dup)
 
 	dst := openTestDB(t)
 	err := dst.ImportReplay(ctx, recs, db.ImportOptions{})
@@ -632,13 +529,13 @@ func TestImportReplayRejectsMalformedRecord(t *testing.T) {
 	ctx := context.Background()
 	dst := openTestDB(t)
 	recs := []db.ImportRecord{
-		{Kind: "meta", Meta: &db.MetaKV{Key: "instance_uid", Value: "x"}},
-		{Kind: "project"}, // malformed: no payload
+		&db.MetaKV{Key: "instance_uid", Value: "x"},
+		(*db.ProjectExport)(nil), // malformed: nil payload
 	}
 	err := dst.ImportReplay(ctx, recs, db.ImportOptions{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "import record 1", "error names the slice ordinal")
-	require.Contains(t, err.Error(), "no payload set")
+	require.Contains(t, err.Error(), "nil payload")
 	var n int
 	require.NoError(t, dst.QueryRowContext(ctx, `SELECT COUNT(*) FROM meta WHERE value = 'x'`).Scan(&n))
 	require.Equal(t, 0, n, "no mutation on a malformed batch")
@@ -772,13 +669,13 @@ func TestImportReplay_StderrNotesDuplicateOnly(t *testing.T) {
 	recs := collectImportRecords(t, ctx, src)
 	var dupLink db.LinkExport
 	for _, r := range recs {
-		if r.Kind == db.ImportKindLink {
-			dupLink = *r.Link
+		if link, ok := r.(*db.LinkExport); ok {
+			dupLink = *link
 			break
 		}
 	}
 	require.NotZero(t, dupLink.ID, "fixture must export a link record")
-	recs = append(recs, db.ImportRecord{Kind: db.ImportKindLink, Link: &dupLink})
+	recs = append(recs, &dupLink)
 
 	dst := openTestDB(t)
 	stderr, restore := captureStderr(t)
@@ -814,8 +711,8 @@ func TestImportReplay_StderrNotesMixed(t *testing.T) {
 	wholeRecs := collectImportRecords(t, ctx, src)
 	var realLink db.LinkExport
 	for _, r := range wholeRecs {
-		if r.Kind == db.ImportKindLink {
-			realLink = *r.Link
+		if link, ok := r.(*db.LinkExport); ok {
+			realLink = *link
 			break
 		}
 	}
@@ -827,9 +724,9 @@ func TestImportReplay_StderrNotesMixed(t *testing.T) {
 	ghost2 := db.LinkExport{ID: 901, FromIssueID: aIssue.ID, FromIssueUID: aIssue.UID, ToIssueID: 9902, ToIssueUID: "ghost-2", Type: "related", Author: "a", CreatedAt: realLink.CreatedAt}
 
 	mixed := append(wholeRecs,
-		db.ImportRecord{Kind: db.ImportKindLink, Link: &realLink}, // duplicate
-		db.ImportRecord{Kind: db.ImportKindLink, Link: &ghost1},   // missing peer
-		db.ImportRecord{Kind: db.ImportKindLink, Link: &ghost2},   // missing peer
+		&realLink, // duplicate
+		&ghost1,   // missing peer
+		&ghost2,   // missing peer
 	)
 
 	dst := openTestDB(t)

--- a/internal/jsonl/cutover.go
+++ b/internal/jsonl/cutover.go
@@ -134,9 +134,8 @@ func importCutoverTarget(ctx context.Context, tmpJSONL, tmpDB string) error {
 // Returns "" when no orphans were dropped, so callers can skip
 // the println entirely on clean DBs. Only nonzero classes are
 // listed, in the fixed order events / comments / links /
-// issue_labels. ScrubbedRowsByTable is intentionally not
-// included — scrubs preserve the row, so reporting them as
-// "discarded" would mislead.
+// issue_labels. Scrubbed rows are intentionally not included — scrubs
+// preserve the row, so reporting them as "discarded" would mislead.
 func formatOrphanSummary(report OrphanReport) string {
 	// classes is sourced from preflight.go's knownOrphanClasses so the
 	// cutover summary stays in sync with the preflight classifier.
@@ -144,7 +143,7 @@ func formatOrphanSummary(report OrphanReport) string {
 	var parts []string
 	total := 0
 	for _, c := range classes {
-		n := len(report.DroppedRowsByTable[c])
+		n := report.DropCount(c)
 		if n == 0 {
 			continue
 		}

--- a/internal/jsonl/cutover_test.go
+++ b/internal/jsonl/cutover_test.go
@@ -529,6 +529,71 @@ func TestAutoCutover_DropsAllKnownOrphanClasses(t *testing.T) {
 	assertNoCutoverTemps(t, path)
 }
 
+// TestAutoCutover_V2ScrubsOrphanRelatedEvent mirrors
+// TestAutoCutover_DropsAllKnownOrphanClasses on a v2 source, whose events
+// projection is a separate copy of the kata#1 peer-scrub rule. A non-
+// aggregated event whose related_issue_id points at a missing issue must
+// survive with both related columns NULL, not be dropped and not dangle.
+func TestAutoCutover_V2ScrubsOrphanRelatedEvent(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "kata.db")
+	seedV2DBWithOrphanRelatedEvent(t, path)
+
+	_, restore := captureStderr(t)
+	defer restore()
+	require.NoError(t, jsonl.AutoCutover(ctx, path))
+
+	d, err := sqlitestore.Open(ctx, path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+	assertCurrentSchemaVersion(t, path)
+
+	var relatedID, relatedUID sql.NullString
+	require.NoError(t, d.QueryRowContext(ctx,
+		`SELECT related_issue_id, related_issue_uid FROM events WHERE type = 'issue.linked'`).
+		Scan(&relatedID, &relatedUID),
+		"the orphan-related event must survive the v2 export")
+	assert.False(t, relatedID.Valid, "related_issue_id must be NULL after scrub")
+	assert.False(t, relatedUID.Valid, "related_issue_uid must be NULL after scrub")
+
+	var issueCount int
+	require.NoError(t, d.QueryRowContext(ctx, `SELECT COUNT(*) FROM issues`).Scan(&issueCount))
+	assert.Equal(t, 1, issueCount, "the seeded valid issue must survive cutover")
+
+	assertNoCutoverTemps(t, path)
+}
+
+// TestAutoCutover_V1ScrubsOrphanRelatedEvent covers the one band whose
+// projection genuinely differs: the v1 events table has no
+// related_issue_uid column, so the scrub rule must NULL related_issue_id
+// alone without referencing a column that does not exist.
+func TestAutoCutover_V1ScrubsOrphanRelatedEvent(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "kata.db")
+	seedV1DBWithOrphanRelatedEvent(t, path)
+
+	_, restore := captureStderr(t)
+	defer restore()
+	require.NoError(t, jsonl.AutoCutover(ctx, path))
+
+	d, err := sqlitestore.Open(ctx, path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+	assertCurrentSchemaVersion(t, path)
+
+	var relatedID sql.NullString
+	require.NoError(t, d.QueryRowContext(ctx,
+		`SELECT related_issue_id FROM events WHERE type = 'issue.linked'`).Scan(&relatedID),
+		"the orphan-related event must survive the v1 export")
+	assert.False(t, relatedID.Valid, "related_issue_id must be NULL after scrub")
+
+	var issueCount int
+	require.NoError(t, d.QueryRowContext(ctx, `SELECT COUNT(*) FROM issues`).Scan(&issueCount))
+	assert.Equal(t, 1, issueCount, "the seeded valid issue must survive cutover")
+
+	assertNoCutoverTemps(t, path)
+}
+
 // --- v3 → v4 ---
 
 // TestV3ToV4CutoverPreservesProjects exercises the user-facing upgrade

--- a/internal/jsonl/export.go
+++ b/internal/jsonl/export.go
@@ -520,30 +520,7 @@ func exportIssueSyncStatus(ctx context.Context, d exportQuerier, enc *Encoder, o
 	if !hasBreakdown {
 		return exportIssueSyncStatusV17(ctx, d, enc, opts)
 	}
-	query := `SELECT binding_id, project_id,
-	                 CAST(sync_started_at AS TEXT), CAST(last_attempt_at AS TEXT),
-	                 CAST(last_success_at AS TEXT), CAST(last_error_at AS TEXT),
-	                 last_error, last_created, last_updated, last_unchanged,
-	                 last_comments
-	            FROM issue_sync_status`
-	args := []any{}
-	if opts.ProjectID > 0 {
-		query += ` WHERE project_id = ?`
-		args = append(args, opts.ProjectID)
-	}
-	query += ` ORDER BY binding_id ASC`
-	rows, err := d.QueryContext(ctx, query, args...)
-	if err != nil {
-		return fmt.Errorf("export issue_sync_status: %w", err)
-	}
-	return scanRecords(rows, KindIssueSyncStatus, enc, func(rows *sql.Rows) (db.IssueSyncStatusExport, error) {
-		var rec db.IssueSyncStatusExport
-		err := rows.Scan(&rec.BindingID, &rec.ProjectID, &rec.SyncStartedAt,
-			&rec.LastAttemptAt, &rec.LastSuccessAt, &rec.LastErrorAt,
-			&rec.LastError, &rec.LastCreated, &rec.LastUpdated,
-			&rec.LastUnchanged, &rec.LastComments)
-		return rec, err
-	})
+	return exportIssueSyncStatusFromTable(ctx, d, enc, opts, "issue_sync_status")
 }
 
 func exportLegacyGitHubSyncStatus(ctx context.Context, d exportQuerier, enc *Encoder, opts ExportOptions) error {
@@ -1598,30 +1575,9 @@ func exportEvents(ctx context.Context, d exportQuerier, enc *Encoder, opts Expor
 		ContentHash       string          `json:"content_hash"`
 		CreatedAt         string          `json:"created_at"`
 	}
-	// See exportEventsV2 for the kata#1 design call: live-only export
-	// keeps aggregated issue.links_changed events whose related_issue_id
-	// points at a now-soft-deleted peer, but the peer's row is omitted
-	// from the export — so the FK must be scrubbed at emit time so the
-	// JSONL round-trips. The payload's *_uids slices retain the orphan
-	// reference for historical context.
-	//
-	// Scrub related_issue_id when the peer is missing entirely
-	// (any event type) OR, on live-only export, when an
-	// issue.links_changed peer is soft-deleted (kata#1 history-
-	// preservation rule). Peer-missing must be checked first so
-	// `peer.deleted_at` doesn't dereference a NULL row.
-	scrubCondition := `(peer.id IS NULL AND events.related_issue_id IS NOT NULL)`
-	if !opts.IncludeDeleted {
-		scrubCondition += ` OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL)`
-	}
-	relatedIDExpr := `CASE WHEN ` + scrubCondition + ` THEN NULL ELSE events.related_issue_id END`
-	relatedUIDExpr := `CASE WHEN ` + scrubCondition + ` THEN NULL ELSE events.related_issue_uid END`
-	subjectLiveClause := `((events.issue_id IS NULL AND events.issue_uid IS NULL) OR subject_issue.id IS NOT NULL)`
-	if !opts.IncludeDeleted {
-		subjectLiveClause = `((events.issue_id IS NULL AND events.issue_uid IS NULL) OR (subject_issue.id IS NOT NULL AND subject_issue.deleted_at IS NULL))`
-	}
+	policy := newEventOrphanPolicy(opts)
 	query := fmt.Sprintf(`SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, export_project.uid, %s, events.issue_id, events.issue_uid,
-	                 `+relatedIDExpr+`, `+relatedUIDExpr+`,
+	                 `+policy.relatedIDExpr()+`, `+policy.relatedUIDExpr()+`,
 	                 events.type, events.actor, events.payload, events.hlc_physical_ms, events.hlc_counter, events.content_hash,
 	                 CAST(events.created_at AS TEXT)
 	          FROM events%s
@@ -1629,8 +1585,8 @@ func exportEvents(ctx context.Context, d exportQuerier, enc *Encoder, opts Expor
 	          LEFT JOIN issues subject_issue ON subject_issue.project_id = events.project_id
 	               AND (subject_issue.id = events.issue_id OR (events.issue_id IS NULL AND events.issue_uid IS NOT NULL AND subject_issue.uid = events.issue_uid))
 	          LEFT JOIN issues peer ON peer.id = events.related_issue_id`, projectNameExpr, joinProjects)
-	clauses, args := eventExportWhereClauses(opts)
-	clauses = append([]string{subjectLiveClause}, clauses...)
+	clauses, args := policy.whereClauses(opts)
+	clauses = append([]string{policy.subjectLiveClause(true)}, clauses...)
 	query += whereClause(clauses) + ` ORDER BY events.id ASC`
 	rows, err := d.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -1687,20 +1643,15 @@ func exportEventsV8(ctx context.Context, d exportQuerier, enc *Encoder, opts Exp
 		Payload           json.RawMessage `json:"payload"`
 		CreatedAt         string          `json:"created_at"`
 	}
-	scrubCondition := `(peer.id IS NULL AND events.related_issue_id IS NOT NULL)`
-	if !opts.IncludeDeleted {
-		scrubCondition += ` OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL)`
-	}
-	relatedIDExpr := `CASE WHEN ` + scrubCondition + ` THEN NULL ELSE events.related_issue_id END`
-	relatedUIDExpr := `CASE WHEN ` + scrubCondition + ` THEN NULL ELSE events.related_issue_uid END`
+	policy := newEventOrphanPolicy(opts)
 	query := fmt.Sprintf(`SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, %s, events.issue_id, events.issue_uid,
-	                 `+relatedIDExpr+`, `+relatedUIDExpr+`,
+	                 `+policy.relatedIDExpr()+`, `+policy.relatedUIDExpr()+`,
 	                 events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
 	          FROM events%s
 	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
 	          LEFT JOIN issues peer ON peer.id = events.related_issue_id`, projectNameExpr, joinProjects)
-	clauses, args := eventExportWhereClauses(opts)
-	clauses = append([]string{`(events.issue_id IS NULL OR subject_issue.id IS NOT NULL)`}, clauses...)
+	clauses, args := policy.whereClauses(opts)
+	clauses = append([]string{policy.subjectLiveClause(false)}, clauses...)
 	query += whereClause(clauses) + ` ORDER BY events.id ASC`
 	rows, err := d.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -1742,20 +1693,15 @@ func exportEventsV3(ctx context.Context, d exportQuerier, enc *Encoder, opts Exp
 		Payload           json.RawMessage `json:"payload"`
 		CreatedAt         string          `json:"created_at"`
 	}
-	scrubCondition := `(peer.id IS NULL AND events.related_issue_id IS NOT NULL)`
-	if !opts.IncludeDeleted {
-		scrubCondition += ` OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL)`
-	}
-	relatedIDExpr := `CASE WHEN ` + scrubCondition + ` THEN NULL ELSE events.related_issue_id END`
-	relatedUIDExpr := `CASE WHEN ` + scrubCondition + ` THEN NULL ELSE events.related_issue_uid END`
+	policy := newEventOrphanPolicy(opts)
 	query := fmt.Sprintf(`SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, %s, events.issue_id, events.issue_uid,
-	                 events.issue_number, `+relatedIDExpr+`, `+relatedUIDExpr+`,
+	                 events.issue_number, `+policy.relatedIDExpr()+`, `+policy.relatedUIDExpr()+`,
 	                 events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
 	          FROM events%s
 	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
 	          LEFT JOIN issues peer ON peer.id = events.related_issue_id`, projectNameExpr, joinProjects)
-	clauses, args := eventExportWhereClauses(opts)
-	clauses = append([]string{`(events.issue_id IS NULL OR subject_issue.id IS NOT NULL)`}, clauses...)
+	clauses, args := policy.whereClauses(opts)
+	clauses = append([]string{policy.subjectLiveClause(false)}, clauses...)
 	query += whereClause(clauses) + ` ORDER BY events.id ASC`
 	rows, err := d.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -1793,28 +1739,15 @@ func exportEventsV2(ctx context.Context, d exportQuerier, enc *Encoder, opts Exp
 		Payload         json.RawMessage `json:"payload"`
 		CreatedAt       string          `json:"created_at"`
 	}
-	// Live-only export keeps issue.links_changed events whose
-	// related_issue_id points at a soft-deleted peer (the iteration-21
-	// preservation rule) but the peer's `issues` row is intentionally
-	// omitted, so emitting the FK as-is would dangle on import. Scrub
-	// related_issue_id / related_issue_uid to NULL in that case so the
-	// JSONL round-trips. The payload's *_uids slices retain the orphan
-	// UID for historical context. include_deleted=true exports both
-	// sides, so the FK roundtrips fine — leave the columns alone there.
-	scrubCondition := `(peer.id IS NULL AND events.related_issue_id IS NOT NULL)`
-	if !opts.IncludeDeleted {
-		scrubCondition += ` OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL)`
-	}
-	relatedIDExpr := `CASE WHEN ` + scrubCondition + ` THEN NULL ELSE events.related_issue_id END`
-	relatedUIDExpr := `CASE WHEN ` + scrubCondition + ` THEN NULL ELSE events.related_issue_uid END`
+	policy := newEventOrphanPolicy(opts)
 	query := fmt.Sprintf(`SELECT events.id, events.project_id, %s, events.issue_id, events.issue_uid,
-	                 events.issue_number, `+relatedIDExpr+`, `+relatedUIDExpr+`,
+	                 events.issue_number, `+policy.relatedIDExpr()+`, `+policy.relatedUIDExpr()+`,
 	                 events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
 	          FROM events%s
 	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
 	          LEFT JOIN issues peer ON peer.id = events.related_issue_id`, projectNameExpr, joinProjects)
-	clauses, args := eventExportWhereClauses(opts)
-	clauses = append([]string{`(events.issue_id IS NULL OR subject_issue.id IS NOT NULL)`}, clauses...)
+	clauses, args := policy.whereClauses(opts)
+	clauses = append([]string{policy.subjectLiveClause(false)}, clauses...)
 	query += whereClause(clauses) + ` ORDER BY events.id ASC`
 	rows, err := d.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -1850,21 +1783,16 @@ func exportEventsV1(ctx context.Context, d exportQuerier, enc *Encoder, opts Exp
 		Payload        json.RawMessage `json:"payload"`
 		CreatedAt      string          `json:"created_at"`
 	}
-	// See exportEventsV2 above for why aggregated issue.links_changed
-	// events on a soft-deleted peer get their related_issue_id scrubbed
-	// in live-only exports. V1 has no related_issue_uid column.
-	scrubCondition := `(peer.id IS NULL AND events.related_issue_id IS NOT NULL)`
-	if !opts.IncludeDeleted {
-		scrubCondition += ` OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL)`
-	}
-	relatedIDExpr := `CASE WHEN ` + scrubCondition + ` THEN NULL ELSE events.related_issue_id END`
+	// V1 has no related_issue_uid column, so only related_issue_id is
+	// scrubbed; see eventOrphanPolicy for the rule itself.
+	policy := newEventOrphanPolicy(opts)
 	query := fmt.Sprintf(`SELECT events.id, events.project_id, %s, events.issue_id, events.issue_number,
-	                 `+relatedIDExpr+`, events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
+	                 `+policy.relatedIDExpr()+`, events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
 	          FROM events%s
 	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
 	          LEFT JOIN issues peer ON peer.id = events.related_issue_id`, projectNameExpr, joinProjects)
-	clauses, args := eventExportWhereClauses(opts)
-	clauses = append([]string{`(events.issue_id IS NULL OR subject_issue.id IS NOT NULL)`}, clauses...)
+	clauses, args := policy.whereClauses(opts)
+	clauses = append([]string{policy.subjectLiveClause(false)}, clauses...)
 	query += whereClause(clauses) + ` ORDER BY events.id ASC`
 	rows, err := d.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -2225,28 +2153,81 @@ func linkExportWhere(opts ExportOptions) (string, []any) {
 	return whereClause(clauses), args
 }
 
-// eventExportWhereClauses returns the individual WHERE clauses (not a joined
-// string like its issueExportWhere / linkExportWhere siblings) so callers can
-// prepend the JOIN-dependent subject_issue orphan filter before assembling
-// the final WHERE. The clauses below cover the soft-delete dimension; orphan
-// filtering rides on the subject_issue / peer LEFT JOINs in each variant.
-func eventExportWhereClauses(opts ExportOptions) ([]string, []any) {
+// eventOrphanPolicy is the kata#1 peer-reference disposition: which events
+// survive export, and which related_* columns are NULL-scrubbed on the way
+// out. Both halves live here because they must agree -- a fully-missing peer
+// must pass the WHERE filter so the SELECT-side CASE can scrub it, while a
+// soft-deleted non-aggregated peer must be dropped by the WHERE. The five
+// version-gated event projections differ only by column list and each apply
+// this same rule.
+//
+// Design call (kata#1): live-only export keeps aggregated
+// issue.links_changed events whose related_issue_id points at a
+// now-soft-deleted peer, but the peer's row is omitted from the export -- so
+// the FK is scrubbed at emit time and the JSONL round-trips. The payload's
+// *_uids slices retain the orphan reference for historical context.
+type eventOrphanPolicy struct{ includeDeleted bool }
+
+func newEventOrphanPolicy(opts ExportOptions) eventOrphanPolicy {
+	return eventOrphanPolicy{includeDeleted: opts.IncludeDeleted}
+}
+
+// scrubCondition is true for a peer reference that must not reach the wire:
+// a peer missing entirely (any event type) OR, on live-only export, an
+// issue.links_changed peer that is soft-deleted. Peer-missing is checked
+// first so `peer.deleted_at` never dereferences a NULL row.
+func (p eventOrphanPolicy) scrubCondition() string {
+	condition := `(peer.id IS NULL AND events.related_issue_id IS NOT NULL)`
+	if !p.includeDeleted {
+		condition += ` OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL)`
+	}
+	return condition
+}
+
+func (p eventOrphanPolicy) relatedIDExpr() string {
+	return `CASE WHEN ` + p.scrubCondition() + ` THEN NULL ELSE events.related_issue_id END`
+}
+
+// relatedUIDExpr is not called by the v1 projection: that schema has no
+// related_issue_uid column.
+func (p eventOrphanPolicy) relatedUIDExpr() string {
+	return `CASE WHEN ` + p.scrubCondition() + ` THEN NULL ELSE events.related_issue_uid END`
+}
+
+// subjectLiveClause keeps an event whose subject issue is absent from the
+// export out of the output. The two shapes are deliberately different, not an
+// accident of copying: uidAware is the current projection's project-scoped
+// join, which resolves the subject by id OR uid and is soft-delete sensitive
+// on live-only export; the legacy shape matches on issue_id alone and relies
+// on the WHERE half for the soft-delete dimension.
+func (p eventOrphanPolicy) subjectLiveClause(uidAware bool) string {
+	if !uidAware {
+		return `(events.issue_id IS NULL OR subject_issue.id IS NOT NULL)`
+	}
+	if p.includeDeleted {
+		return `((events.issue_id IS NULL AND events.issue_uid IS NULL) OR subject_issue.id IS NOT NULL)`
+	}
+	return `((events.issue_id IS NULL AND events.issue_uid IS NULL) OR (subject_issue.id IS NOT NULL AND subject_issue.deleted_at IS NULL))`
+}
+
+// whereClauses returns the individual WHERE clauses (not a joined string like
+// the issueExportWhere / linkExportWhere siblings) so callers can prepend the
+// JOIN-dependent subject_issue filter before assembling the final WHERE.
+func (p eventOrphanPolicy) whereClauses(opts ExportOptions) ([]string, []any) {
 	clauses := []string{}
 	args := []any{}
 	if opts.ProjectID > 0 {
 		clauses = append(clauses, `events.project_id = ?`)
 		args = append(args, opts.ProjectID)
 	}
-	if !opts.IncludeDeleted {
-		// See exportEventsV2 / exportEvents commentary for the
-		// kata#1 design call: aggregated issue.links_changed events
-		// retain related_issue_id pointing at a soft-deleted peer
-		// so historical context survives. Per-link issue.linked /
-		// issue.unlinked events still drop via related_issue_id when
-		// the peer is *soft-deleted* — but a fully-missing peer
-		// (orphan FK) must pass through to the SELECT-side CASE
-		// scrub so the event survives with NULL related fields,
-		// matching the issue_id-orphan behavior.
+	if !p.includeDeleted {
+		// Aggregated issue.links_changed events retain related_issue_id
+		// pointing at a soft-deleted peer so historical context survives.
+		// Per-link issue.linked / issue.unlinked events still drop via
+		// related_issue_id when the peer is *soft-deleted* -- but a
+		// fully-missing peer (orphan FK) must pass through to the
+		// SELECT-side CASE scrub so the event survives with NULL related
+		// fields, matching the issue_id-orphan behavior.
 		clauses = append(clauses,
 			`(events.issue_id IS NULL OR EXISTS (SELECT 1 FROM issues WHERE issues.id = events.issue_id AND issues.deleted_at IS NULL))`,
 			`(events.related_issue_id IS NULL OR events.type = 'issue.links_changed' OR NOT EXISTS (SELECT 1 FROM issues WHERE issues.id = events.related_issue_id AND issues.deleted_at IS NOT NULL))`,

--- a/internal/jsonl/export_events_sql_test.go
+++ b/internal/jsonl/export_events_sql_test.go
@@ -1,0 +1,104 @@
+package jsonl
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+)
+
+var updateEventSQLGolden = flag.Bool("update-golden", false,
+	"rewrite the event export SQL goldens from the current code")
+
+// errSQLCaptured stops each export function right after it has assembled its
+// query, so the golden test needs no database.
+var errSQLCaptured = errors.New("sql captured")
+
+type sqlCapture struct {
+	queries []string
+	args    [][]any
+}
+
+func (c *sqlCapture) QueryContext(_ context.Context, query string, args ...any) (*sql.Rows, error) {
+	c.queries = append(c.queries, query)
+	c.args = append(c.args, args)
+	return nil, errSQLCaptured
+}
+
+func (c *sqlCapture) QueryRowContext(_ context.Context, query string, _ ...any) *sql.Row {
+	panic("event export must not use QueryRowContext: " + query)
+}
+
+// TestEventExportSQLIsPinnedPerVersionBand locks the exact query each event
+// projection emits. The kata#1 peer-scrub rule and the subject-liveness
+// filter are pure string construction spread across five version bands, and
+// the emitted SQL must stay byte-identical per band: a changed projection
+// silently alters cutover output for one source-version band only, and event
+// ordering feeds federated short_id assignment.
+//
+// Regenerate with `-update-golden` ONLY when a query is deliberately changed,
+// and review the resulting diff as the specification of that change.
+func TestEventExportSQLIsPinnedPerVersionBand(t *testing.T) {
+	cases := []struct {
+		name     string
+		version  int
+		opts     ExportOptions
+		wantArgs []any
+	}{
+		{"v1_live_only", 1, ExportOptions{ProjectID: 7}, []any{int64(7)}},
+		{"v1_include_deleted", 1, ExportOptions{ProjectID: 7, IncludeDeleted: true}, []any{int64(7)}},
+		{"v2_live_only", 2, ExportOptions{ProjectID: 7}, []any{int64(7)}},
+		{"v2_include_deleted", 2, ExportOptions{ProjectID: 7, IncludeDeleted: true}, []any{int64(7)}},
+		{"v3_live_only", 3, ExportOptions{ProjectID: 7}, []any{int64(7)}},
+		{"v3_include_deleted", 3, ExportOptions{ProjectID: 7, IncludeDeleted: true}, []any{int64(7)}},
+		{"v8_live_only", 8, ExportOptions{ProjectID: 7}, []any{int64(7)}},
+		{"v8_include_deleted", 8, ExportOptions{ProjectID: 7, IncludeDeleted: true}, []any{int64(7)}},
+		{"current_live_only", db.CurrentSchemaVersion(), ExportOptions{ProjectID: 7}, []any{int64(7)}},
+		{"current_include_deleted", db.CurrentSchemaVersion(), ExportOptions{ProjectID: 7, IncludeDeleted: true}, []any{int64(7)}},
+		{"current_all_projects_live_only", db.CurrentSchemaVersion(), ExportOptions{}, []any{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := &sqlCapture{}
+			err := exportEvents(context.Background(), capture, NewEncoder(io.Discard), tc.opts, tc.version)
+			require.ErrorIs(t, err, errSQLCaptured)
+			require.Len(t, capture.queries, 1, "each band emits exactly one events query")
+			assert.Equal(t, tc.wantArgs, capture.args[0])
+			assertGoldenSQL(t, tc.name, capture.queries[0])
+		})
+	}
+}
+
+// TestEventExportV1OmitsRelatedIssueUID guards the one deliberate divergence
+// between the bands: the v1 events table has no related_issue_uid column, so
+// the shared scrub rule must not emit that expression there.
+func TestEventExportV1OmitsRelatedIssueUID(t *testing.T) {
+	for _, opts := range []ExportOptions{{}, {IncludeDeleted: true}} {
+		capture := &sqlCapture{}
+		err := exportEvents(context.Background(), capture, NewEncoder(io.Discard), opts, 1)
+		require.ErrorIs(t, err, errSQLCaptured)
+		assert.NotContains(t, capture.queries[0], "related_issue_uid")
+	}
+}
+
+func assertGoldenSQL(t *testing.T, name, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", "events_sql", name+".sql")
+	if *updateEventSQLGolden {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, os.WriteFile(path, []byte(got), 0o600))
+		return
+	}
+	want, err := os.ReadFile(path) //nolint:gosec // testdata path built from a fixed case name
+	require.NoError(t, err, "missing golden %s; regenerate with -update-golden and review the diff", path)
+	assert.Equal(t, string(want), got)
+}

--- a/internal/jsonl/fixtures_test.go
+++ b/internal/jsonl/fixtures_test.go
@@ -451,6 +451,52 @@ func seedV3DBWithOrphans(t *testing.T, path string, spec orphanSpec) {
 	require.NoError(t, err)
 }
 
+// seedV2DBWithOrphanRelatedEvent writes a v2-schema DB carrying the fixture's
+// project and issue #1 plus one non-aggregated issue.linked event whose
+// related_issue_id points at issue 999, which is never inserted. PRAGMA
+// foreign_keys=OFF lets the insert land; preflight then classifies it as a
+// scrub and the v2 events projection NULLs the peer columns on export.
+func seedV2DBWithOrphanRelatedEvent(t *testing.T, path string) {
+	t.Helper()
+	writeLegacyV2DB(t, path)
+	raw, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer func() { _ = raw.Close() }()
+
+	_, err = raw.Exec(`PRAGMA foreign_keys = OFF`)
+	require.NoError(t, err)
+	_, err = raw.Exec(
+		`INSERT INTO events (project_id, project_identity, issue_id, issue_uid, issue_number,
+		                     related_issue_id, related_issue_uid, type, actor, payload, created_at)
+		 VALUES (1, 'spoke-project', 1, '01HZZZZZZZZZZZZZZZZZZZZZZ1', 1,
+		         999, '01HZZZZZZZZZZZZZZZZZZZZA99', 'issue.linked', 'tester', '{}',
+		         '2026-05-03T00:00:03.000Z')`)
+	require.NoError(t, err)
+	_, err = raw.Exec(`PRAGMA foreign_keys = ON`)
+	require.NoError(t, err)
+}
+
+// seedV1DBWithOrphanRelatedEvent is seedV2DBWithOrphanRelatedEvent for the v1
+// schema, whose events table has neither issue_uid nor related_issue_uid.
+func seedV1DBWithOrphanRelatedEvent(t *testing.T, path string) {
+	t.Helper()
+	writeLegacyV1DB(t, path)
+	raw, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer func() { _ = raw.Close() }()
+
+	_, err = raw.Exec(`PRAGMA foreign_keys = OFF`)
+	require.NoError(t, err)
+	_, err = raw.Exec(
+		`INSERT INTO events (project_id, project_identity, issue_id, issue_number,
+		                     related_issue_id, type, actor, payload, created_at)
+		 VALUES (1, 'spoke-project', 1, 1, 999, 'issue.linked', 'tester', '{}',
+		         '2026-05-03T00:00:03.000Z')`)
+	require.NoError(t, err)
+	_, err = raw.Exec(`PRAGMA foreign_keys = ON`)
+	require.NoError(t, err)
+}
+
 // dropV10Additions trims a freshly-bootstrapped current-schema DB back to
 // the v8/v9 column shape: removes the recurrences table, the issues
 // recurrence linkage, and metadata + revision on both issues and projects.

--- a/internal/jsonl/import.go
+++ b/internal/jsonl/import.go
@@ -197,211 +197,211 @@ func toImportRecord(env Envelope, exportVersion int, localInstanceUID string, pr
 	case KindMeta:
 		var rec metaRecord
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		m := db.MetaKV{Key: rec.Key, Value: rec.Value}
-		return db.ImportRecord{Kind: string(KindMeta), Meta: &m}, nil
+		return &m, nil
 	case KindProject:
 		var rec projectImport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeProjectTimes(&rec.ProjectExport); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := fillProjectUID(&rec, exportVersion); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		p := rec.ProjectExport
-		return db.ImportRecord{Kind: string(KindProject), Project: &p}, nil
+		return &p, nil
 	case KindProjectAlias:
 		var rec db.AliasExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeAliasTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindProjectAlias), Alias: &rec}, nil
+		return &rec, nil
 	case KindIssueSyncBinding:
 		var rec db.IssueSyncBindingExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeIssueSyncBindingTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindIssueSyncBinding), IssueSyncBinding: &rec}, nil
+		return &rec, nil
 	case KindGitHubSyncBinding:
 		rec, err := decodeLegacyGitHubSyncBinding(env)
 		if err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeIssueSyncBindingTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindIssueSyncBinding), IssueSyncBinding: &rec}, nil
+		return &rec, nil
 	case KindIssueSyncStatus:
 		var rec db.IssueSyncStatusExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeIssueSyncStatusTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindIssueSyncStatus), IssueSyncStatus: &rec}, nil
+		return &rec, nil
 	case KindGitHubSyncStatus:
 		var rec db.IssueSyncStatusExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeIssueSyncStatusTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindIssueSyncStatus), IssueSyncStatus: &rec}, nil
+		return &rec, nil
 	case KindRecurrence:
 		var rec db.RecurrenceExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeRecurrenceTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindRecurrence), Recurrence: &rec}, nil
+		return &rec, nil
 	case KindIssue:
 		var rec issueImport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeIssueTimes(&rec.IssueExport); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := fillIssueUID(&rec, exportVersion); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		i := rec.IssueExport
-		return db.ImportRecord{Kind: string(KindIssue), Issue: &i}, nil
+		return &i, nil
 	case KindIssueEmbedding:
 		var rec db.IssueEmbeddingExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindIssueEmbedding), IssueEmbedding: &rec}, nil
+		return &rec, nil
 	case KindComment:
 		var rec db.CommentExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeCommentTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := fillCommentUID(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindComment), Comment: &rec}, nil
+		return &rec, nil
 	case KindIssueLabel:
 		var rec db.IssueLabelExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeIssueLabelTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindIssueLabel), Label: &rec}, nil
+		return &rec, nil
 	case KindLink:
 		var rec db.LinkExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeLinkTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindLink), Link: &rec}, nil
+		return &rec, nil
 	case KindImportMapping:
 		var rec db.ImportMappingExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeImportMappingTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindImportMapping), ImportMapping: &rec}, nil
+		return &rec, nil
 	case KindExternalFieldMapping:
 		var rec db.ExternalFieldMappingExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindExternalFieldMapping), ExternalFieldMapping: &rec}, nil
+		return &rec, nil
 	case KindExternalRootBinding:
 		var rec db.ExternalRootBindingExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindExternalRootBinding), ExternalRootBinding: &rec}, nil
+		return &rec, nil
 	case KindExternalFieldState:
 		var rec db.ExternalFieldStateExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindExternalFieldState), ExternalFieldState: &rec}, nil
+		return &rec, nil
 	case KindFederationBinding:
 		var rec db.FederationBindingExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeFederationBindingTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindFederationBinding), FederationBinding: &rec}, nil
+		return &rec, nil
 	case KindFederationSyncStatus:
 		var rec db.FederationSyncStatusExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeFederationSyncStatusTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindFederationSyncStatus), FederationSyncStatus: &rec}, nil
+		return &rec, nil
 	case KindFederationQuarantine:
 		var rec db.FederationQuarantineExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeFederationQuarantineTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindFederationQuarantine), FederationQuarantine: &rec}, nil
+		return &rec, nil
 	case KindFederationEnrollment:
 		var rec db.FederationEnrollmentExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeFederationEnrollmentTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindFederationEnrollment), FederationEnrollment: &rec}, nil
+		return &rec, nil
 	case KindIssueClaim:
 		var rec db.IssueClaimExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeIssueClaimTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindIssueClaim), IssueClaim: &rec}, nil
+		return &rec, nil
 	case KindPendingClaimRequest:
 		var rec db.PendingClaimRequestExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizePendingClaimRequestTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindPendingClaimRequest), PendingClaimRequest: &rec}, nil
+		return &rec, nil
 	case KindEvent:
 		var rec eventImport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if rec.ProjectName == "" && rec.LegacyProjectName != "" {
 			rec.ProjectName = rec.LegacyProjectName
@@ -413,52 +413,52 @@ func toImportRecord(env Envelope, exportVersion int, localInstanceUID string, pr
 		// will mismatch the recomputed one and be rejected with a
 		// content_hash error.
 		if err := normalizeEventTimes(&rec.EventExport); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := fillEventV3Identity(&rec.EventExport, exportVersion, localInstanceUID); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := fillEventV11ReplayFields(&rec.EventExport, exportVersion, projectUIDByID); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if rec.ProjectUID == "" {
 			rec.ProjectUID = projectUIDByID[rec.ProjectID]
 		}
 		e := rec.EventExport
-		return db.ImportRecord{Kind: string(KindEvent), Event: &e}, nil
+		return &e, nil
 	case KindPurgeLog:
 		var rec purgeLogImport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if rec.ProjectName == "" && rec.LegacyProjectName != "" {
 			rec.ProjectName = rec.LegacyProjectName
 		}
 		if err := normalizePurgeLogTimes(&rec.PurgeLogExport); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := fillPurgeLogV3Identity(&rec.PurgeLogExport, exportVersion, localInstanceUID); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		pl := rec.PurgeLogExport
-		return db.ImportRecord{Kind: string(KindPurgeLog), PurgeLog: &pl}, nil
+		return &pl, nil
 	case KindProjectPurgeLog:
 		var rec db.ProjectPurgeLogExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
 		if err := normalizeProjectPurgeLogTimes(&rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindProjectPurgeLog), ProjectPurgeLog: &rec}, nil
+		return &rec, nil
 	case KindSQLiteSequence:
 		var rec db.SequenceExport
 		if err := decodeData(env, &rec); err != nil {
-			return db.ImportRecord{}, err
+			return nil, err
 		}
-		return db.ImportRecord{Kind: string(KindSQLiteSequence), Sequence: &rec}, nil
+		return &rec, nil
 	default:
-		return db.ImportRecord{}, fmt.Errorf("import %s: unsupported kind", env.Kind)
+		return nil, fmt.Errorf("import %s: unsupported kind", env.Kind)
 	}
 }
 

--- a/internal/jsonl/import_internal_test.go
+++ b/internal/jsonl/import_internal_test.go
@@ -30,9 +30,9 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindProject,
 			data: `{"id":1,"uid":"` + projectUID + `","name":"kata","created_at":"` + legacy + `","deleted_at":"` + legacy + `","metadata":{},"revision":1}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Project)
-				assert.Equal(t, canonical, rec.Project.CreatedAt)
-				assert.Equal(t, canonical, *rec.Project.DeletedAt)
+				project := recordAs[db.ProjectExport](t, rec)
+				assert.Equal(t, canonical, project.CreatedAt)
+				assert.Equal(t, canonical, *project.DeletedAt)
 			},
 		},
 		{
@@ -40,8 +40,8 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindProjectAlias,
 			data: `{"id":1,"project_id":1,"alias_identity":"repo","alias_kind":"git","root_path":"/tmp/repo","created_at":"` + legacy + `","last_seen_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Alias)
-				assert.Equal(t, canonical, rec.Alias.CreatedAt)
+				alias := recordAs[db.AliasExport](t, rec)
+				assert.Equal(t, canonical, alias.CreatedAt)
 			},
 		},
 		{
@@ -49,10 +49,10 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindRecurrence,
 			data: `{"id":1,"uid":"` + otherUID + `","project_id":1,"rrule":"FREQ=DAILY","dtstart":"2026-05-04T00:00:00.000Z","timezone":"UTC","template_title":"todo","template_body":"","template_labels":[],"template_metadata":{},"author":"tester","revision":1,"created_at":"` + legacy + `","updated_at":"` + legacy + `","deleted_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Recurrence)
-				assert.Equal(t, canonical, rec.Recurrence.CreatedAt)
-				assert.Equal(t, canonical, rec.Recurrence.UpdatedAt)
-				assert.Equal(t, canonical, *rec.Recurrence.DeletedAt)
+				recurrence := recordAs[db.RecurrenceExport](t, rec)
+				assert.Equal(t, canonical, recurrence.CreatedAt)
+				assert.Equal(t, canonical, recurrence.UpdatedAt)
+				assert.Equal(t, canonical, *recurrence.DeletedAt)
 			},
 		},
 		{
@@ -60,8 +60,8 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindIssueLabel,
 			data: `{"issue_id":1,"label":"bug","author":"tester","created_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Label)
-				assert.Equal(t, canonical, rec.Label.CreatedAt)
+				label := recordAs[db.IssueLabelExport](t, rec)
+				assert.Equal(t, canonical, label.CreatedAt)
 			},
 		},
 		{
@@ -69,8 +69,8 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindComment,
 			data: `{"id":1,"uid":"` + otherUID + `","issue_id":1,"author":"tester","body":"note","created_at":"2026-05-04T00:21:07.000500Z"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Comment)
-				assert.Equal(t, "2026-05-04T00:21:07.000500Z", rec.Comment.CreatedAt)
+				comment := recordAs[db.CommentExport](t, rec)
+				assert.Equal(t, "2026-05-04T00:21:07.000500Z", comment.CreatedAt)
 			},
 		},
 		{
@@ -78,8 +78,8 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindComment,
 			data: `{"id":2,"uid":"` + projectUID + `","issue_id":1,"author":"tester","body":"note","created_at":"2026-05-04T00:21:07.000500900Z"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Comment)
-				assert.Equal(t, "2026-05-04T00:21:07.000500900Z", rec.Comment.CreatedAt)
+				comment := recordAs[db.CommentExport](t, rec)
+				assert.Equal(t, "2026-05-04T00:21:07.000500900Z", comment.CreatedAt)
 			},
 		},
 		{
@@ -87,8 +87,8 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindComment,
 			data: `{"id":3,"uid":"` + issueUID + `","issue_id":1,"author":"tester","body":"note","created_at":"2026-05-04T02:21:07.000500+02:00"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Comment)
-				assert.Equal(t, "2026-05-04T00:21:07.000500Z", rec.Comment.CreatedAt)
+				comment := recordAs[db.CommentExport](t, rec)
+				assert.Equal(t, "2026-05-04T00:21:07.000500Z", comment.CreatedAt)
 			},
 		},
 		{
@@ -96,8 +96,8 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindComment,
 			data: `{"id":4,"uid":"` + otherUID + `","issue_id":1,"author":"tester","body":"note","created_at":"2026-05-04T00:21:07.0005Z"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Comment)
-				assert.Equal(t, "2026-05-04T00:21:07.000500Z", rec.Comment.CreatedAt)
+				comment := recordAs[db.CommentExport](t, rec)
+				assert.Equal(t, "2026-05-04T00:21:07.000500Z", comment.CreatedAt)
 			},
 		},
 		{
@@ -105,8 +105,8 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindComment,
 			data: `{"id":5,"uid":"` + projectUID + `","issue_id":1,"author":"tester","body":"note","created_at":"2026-05-04 00:21:07.0005009 +0000 UTC"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Comment)
-				assert.Equal(t, "2026-05-04T00:21:07.000500900Z", rec.Comment.CreatedAt)
+				comment := recordAs[db.CommentExport](t, rec)
+				assert.Equal(t, "2026-05-04T00:21:07.000500900Z", comment.CreatedAt)
 			},
 		},
 		{
@@ -114,8 +114,8 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindLink,
 			data: `{"id":1,"project_id":1,"from_issue_id":1,"from_issue_uid":"` + issueUID + `","to_issue_id":2,"to_issue_uid":"` + otherUID + `","type":"blocks","author":"tester","created_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.Link)
-				assert.Equal(t, canonical, rec.Link.CreatedAt)
+				link := recordAs[db.LinkExport](t, rec)
+				assert.Equal(t, canonical, link.CreatedAt)
 			},
 		},
 		{
@@ -123,9 +123,9 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindImportMapping,
 			data: `{"id":1,"source":"gh","external_id":"1","object_type":"issue","project_id":1,"issue_id":1,"source_updated_at":"` + legacy + `","imported_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.ImportMapping)
-				assert.Equal(t, canonical, *rec.ImportMapping.SourceUpdatedAt)
-				assert.Equal(t, canonical, rec.ImportMapping.ImportedAt)
+				mapping := recordAs[db.ImportMappingExport](t, rec)
+				assert.Equal(t, canonical, *mapping.SourceUpdatedAt)
+				assert.Equal(t, canonical, mapping.ImportedAt)
 			},
 		},
 		{
@@ -133,10 +133,10 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindFederationBinding,
 			data: `{"project_id":1,"role":"hub","hub_url":"","hub_project_id":0,"hub_project_uid":"` + projectUID + `","replay_horizon_event_id":0,"pull_cursor_event_id":0,"push_enabled":false,"push_cursor_event_id":0,"enabled":true,"created_at":"` + legacy + `","updated_at":"` + legacy + `","last_sync_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.FederationBinding)
-				assert.Equal(t, canonical, rec.FederationBinding.CreatedAt)
-				assert.Equal(t, canonical, rec.FederationBinding.UpdatedAt)
-				assert.Equal(t, canonical, *rec.FederationBinding.LastSyncAt)
+				binding := recordAs[db.FederationBindingExport](t, rec)
+				assert.Equal(t, canonical, binding.CreatedAt)
+				assert.Equal(t, canonical, binding.UpdatedAt)
+				assert.Equal(t, canonical, *binding.LastSyncAt)
 			},
 		},
 		{
@@ -144,13 +144,13 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindFederationSyncStatus,
 			data: `{"project_id":1,"last_pull_started_at":"` + legacy + `","last_pull_success_at":"` + legacy + `","last_push_started_at":"` + legacy + `","last_push_success_at":"` + legacy + `","last_error_at":"` + legacy + `","last_reset_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.FederationSyncStatus)
-				assert.Equal(t, canonical, *rec.FederationSyncStatus.LastPullStartedAt)
-				assert.Equal(t, canonical, *rec.FederationSyncStatus.LastPullSuccessAt)
-				assert.Equal(t, canonical, *rec.FederationSyncStatus.LastPushStartedAt)
-				assert.Equal(t, canonical, *rec.FederationSyncStatus.LastPushSuccessAt)
-				assert.Equal(t, canonical, *rec.FederationSyncStatus.LastErrorAt)
-				assert.Equal(t, canonical, *rec.FederationSyncStatus.LastResetAt)
+				status := recordAs[db.FederationSyncStatusExport](t, rec)
+				assert.Equal(t, canonical, *status.LastPullStartedAt)
+				assert.Equal(t, canonical, *status.LastPullSuccessAt)
+				assert.Equal(t, canonical, *status.LastPushStartedAt)
+				assert.Equal(t, canonical, *status.LastPushSuccessAt)
+				assert.Equal(t, canonical, *status.LastErrorAt)
+				assert.Equal(t, canonical, *status.LastResetAt)
 			},
 		},
 		{
@@ -158,10 +158,10 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindIssueSyncBinding,
 			data: `{"id":1,"project_id":1,"source_key":"github:repo-node-example","host":"github.com","owner":"example-org","repo":"example-repo","repo_node_id":"repo-node-example","repo_id":42,"enabled":false,"interval_seconds":900,"last_cursor_at":"` + legacy + `","created_at":"` + legacy + `","updated_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.IssueSyncBinding)
-				assert.Equal(t, canonical, *rec.IssueSyncBinding.LastCursorAt)
-				assert.Equal(t, canonical, rec.IssueSyncBinding.CreatedAt)
-				assert.Equal(t, canonical, rec.IssueSyncBinding.UpdatedAt)
+				binding := recordAs[db.IssueSyncBindingExport](t, rec)
+				assert.Equal(t, canonical, *binding.LastCursorAt)
+				assert.Equal(t, canonical, binding.CreatedAt)
+				assert.Equal(t, canonical, binding.UpdatedAt)
 			},
 		},
 		{
@@ -169,17 +169,17 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindIssueSyncStatus,
 			data: `{"binding_id":1,"project_id":1,"sync_started_at":"` + legacy + `","last_attempt_at":"` + legacy + `","last_success_at":"` + legacy + `","last_error_at":"` + legacy + `","last_error":"rate limited","last_created":2,"last_updated":3,"last_unchanged":4,"last_comments":5}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.IssueSyncStatus)
-				assert.Equal(t, canonical, *rec.IssueSyncStatus.SyncStartedAt)
-				assert.Equal(t, canonical, *rec.IssueSyncStatus.LastAttemptAt)
-				assert.Equal(t, canonical, *rec.IssueSyncStatus.LastSuccessAt)
-				assert.Equal(t, canonical, *rec.IssueSyncStatus.LastErrorAt)
-				require.NotNil(t, rec.IssueSyncStatus.LastError)
-				assert.Equal(t, "rate limited", *rec.IssueSyncStatus.LastError)
-				assert.Equal(t, 2, rec.IssueSyncStatus.LastCreated)
-				assert.Equal(t, 3, rec.IssueSyncStatus.LastUpdated)
-				assert.Equal(t, 4, rec.IssueSyncStatus.LastUnchanged)
-				assert.Equal(t, 5, rec.IssueSyncStatus.LastComments)
+				status := recordAs[db.IssueSyncStatusExport](t, rec)
+				assert.Equal(t, canonical, *status.SyncStartedAt)
+				assert.Equal(t, canonical, *status.LastAttemptAt)
+				assert.Equal(t, canonical, *status.LastSuccessAt)
+				assert.Equal(t, canonical, *status.LastErrorAt)
+				require.NotNil(t, status.LastError)
+				assert.Equal(t, "rate limited", *status.LastError)
+				assert.Equal(t, 2, status.LastCreated)
+				assert.Equal(t, 3, status.LastUpdated)
+				assert.Equal(t, 4, status.LastUnchanged)
+				assert.Equal(t, 5, status.LastComments)
 			},
 		},
 		{
@@ -187,9 +187,9 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindFederationQuarantine,
 			data: `{"id":1,"project_id":1,"direction":"pull","first_event_id":1,"last_event_id":1,"event_uids":[],"error":"bad","created_at":"` + legacy + `","skipped_at":"` + legacy + `","skipped_by":"tester","skip_reason":"done"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.FederationQuarantine)
-				assert.Equal(t, canonical, rec.FederationQuarantine.CreatedAt)
-				assert.Equal(t, canonical, *rec.FederationQuarantine.SkippedAt)
+				quarantine := recordAs[db.FederationQuarantineExport](t, rec)
+				assert.Equal(t, canonical, quarantine.CreatedAt)
+				assert.Equal(t, canonical, *quarantine.SkippedAt)
 			},
 		},
 		{
@@ -197,10 +197,10 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindFederationEnrollment,
 			data: `{"id":1,"token_hash":"` + stringOf("a", 64) + `","spoke_instance_uid":"` + otherUID + `","project_id":1,"capabilities":"pull","created_at":"` + legacy + `","updated_at":"` + legacy + `","revoked_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.FederationEnrollment)
-				assert.Equal(t, canonical, rec.FederationEnrollment.CreatedAt)
-				assert.Equal(t, canonical, rec.FederationEnrollment.UpdatedAt)
-				assert.Equal(t, canonical, *rec.FederationEnrollment.RevokedAt)
+				enrollment := recordAs[db.FederationEnrollmentExport](t, rec)
+				assert.Equal(t, canonical, enrollment.CreatedAt)
+				assert.Equal(t, canonical, enrollment.UpdatedAt)
+				assert.Equal(t, canonical, *enrollment.RevokedAt)
 			},
 		},
 		{
@@ -208,11 +208,11 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindIssueClaim,
 			data: `{"id":1,"claim_uid":"` + otherUID + `","project_id":1,"issue_id":1,"issue_uid":"` + issueUID + `","holder":"tester","holder_instance_uid":"` + projectUID + `","client_kind":"cli","purpose":"edit","claim_kind":"timed","acquired_at":"` + legacy + `","expires_at":"` + legacy + `","released_at":"` + legacy + `","release_reason":"done","revision":1,"updated_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.IssueClaim)
-				assert.Equal(t, canonical, rec.IssueClaim.AcquiredAt)
-				assert.Equal(t, canonical, *rec.IssueClaim.ExpiresAt)
-				assert.Equal(t, canonical, *rec.IssueClaim.ReleasedAt)
-				assert.Equal(t, canonical, rec.IssueClaim.UpdatedAt)
+				claim := recordAs[db.IssueClaimExport](t, rec)
+				assert.Equal(t, canonical, claim.AcquiredAt)
+				assert.Equal(t, canonical, *claim.ExpiresAt)
+				assert.Equal(t, canonical, *claim.ReleasedAt)
+				assert.Equal(t, canonical, claim.UpdatedAt)
 			},
 		},
 		{
@@ -220,11 +220,11 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindPendingClaimRequest,
 			data: `{"id":1,"request_uid":"` + otherUID + `","project_id":1,"issue_id":1,"issue_uid":"` + issueUID + `","holder":"tester","holder_instance_uid":"` + projectUID + `","client_kind":"cli","claim_kind":"timed","ttl_seconds":60,"purpose":"edit","requested_at":"` + legacy + `","last_attempt_at":"` + legacy + `","last_error":"bad","rejected_at":"` + legacy + `","resolved_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.PendingClaimRequest)
-				assert.Equal(t, canonical, rec.PendingClaimRequest.RequestedAt)
-				assert.Equal(t, canonical, *rec.PendingClaimRequest.LastAttemptAt)
-				assert.Equal(t, canonical, *rec.PendingClaimRequest.RejectedAt)
-				assert.Equal(t, canonical, *rec.PendingClaimRequest.ResolvedAt)
+				request := recordAs[db.PendingClaimRequestExport](t, rec)
+				assert.Equal(t, canonical, request.RequestedAt)
+				assert.Equal(t, canonical, *request.LastAttemptAt)
+				assert.Equal(t, canonical, *request.RejectedAt)
+				assert.Equal(t, canonical, *request.ResolvedAt)
 			},
 		},
 		{
@@ -232,8 +232,8 @@ func TestToImportRecordNormalizesTimestampFields(t *testing.T) {
 			kind: KindPurgeLog,
 			data: `{"id":1,"uid":"` + otherUID + `","origin_instance_uid":"` + projectUID + `","project_id":1,"purged_issue_id":1,"issue_uid":"` + issueUID + `","project_uid":"` + projectUID + `","project_name":"kata","short_id":"abc1","issue_title":"done","issue_author":"tester","comment_count":0,"link_count":0,"label_count":0,"event_count":0,"actor":"tester","reason":"done","purged_at":"` + legacy + `"}`,
 			assert: func(t *testing.T, rec db.ImportRecord) {
-				require.NotNil(t, rec.PurgeLog)
-				assert.Equal(t, canonical, rec.PurgeLog.PurgedAt)
+				purgeLog := recordAs[db.PurgeLogExport](t, rec)
+				assert.Equal(t, canonical, purgeLog.PurgedAt)
 			},
 		},
 	}
@@ -265,4 +265,15 @@ func stringOf(s string, n int) string {
 		out += s
 	}
 	return out
+}
+
+// recordAs asserts the mapped record's payload type and returns it, replacing
+// the old `require.NotNil(t, rec.Field)` guard now that the discriminator is
+// the type itself.
+func recordAs[T any](t *testing.T, rec db.ImportRecord) *T {
+	t.Helper()
+	got, ok := any(rec).(*T)
+	require.True(t, ok, "record is %T, want *%T", rec, *new(T))
+	require.NotNil(t, got)
+	return got
 }

--- a/internal/jsonl/preflight.go
+++ b/internal/jsonl/preflight.go
@@ -17,15 +17,56 @@ import (
 // here. The order is the order classes are listed in the summary line.
 var knownOrphanClasses = []string{"events", "comments", "links", "issue_labels"}
 
-// OrphanReport is the result of preflighting a source DB before
-// cutover. DroppedRowsByTable and ScrubbedRowsByTable are keyed by
-// child-table name; values are the set of rowids in each
-// disposition. UnknownViolations is everything that doesn't match
-// a known orphan class — a non-empty list halts the cutover.
+// OrphanReport is the result of preflighting a source DB before cutover.
+// Rows holds exactly one disposition per (child table, rowid): a row that is
+// classified twice — an events row with both issue_id and related_issue_id
+// orphaned produces two PRAGMA foreign_key_check rows — keeps the
+// higher-precedence disposition, so it can never be both dropped and
+// scrubbed. UnknownViolations is everything that doesn't match a known
+// orphan class; a non-empty list halts the cutover.
 type OrphanReport struct {
-	DroppedRowsByTable  map[string]map[int64]struct{}
-	ScrubbedRowsByTable map[string]map[int64]struct{}
-	UnknownViolations   []FKViolation
+	Rows              map[orphanRow]orphanDisposition
+	UnknownViolations []FKViolation
+}
+
+// orphanRow identifies one source row by child table and rowid.
+type orphanRow struct {
+	Table string
+	RowID int64
+}
+
+func newOrphanReport() OrphanReport {
+	return OrphanReport{Rows: map[orphanRow]orphanDisposition{}}
+}
+
+// record files disp against key, keeping the higher-precedence disposition
+// when the same row is classified more than once.
+func (r OrphanReport) record(key orphanRow, disp orphanDisposition) {
+	if existing, ok := r.Rows[key]; ok && existing.rank() >= disp.rank() {
+		return
+	}
+	r.Rows[key] = disp
+}
+
+// DropCount reports how many rows of table the export discards.
+func (r OrphanReport) DropCount(table string) int {
+	return r.countByDisposition(table, dispositionDrop)
+}
+
+// ScrubCount reports how many rows of table survive the export with their
+// orphan peer columns NULLed.
+func (r OrphanReport) ScrubCount(table string) int {
+	return r.countByDisposition(table, dispositionScrub)
+}
+
+func (r OrphanReport) countByDisposition(table string, want orphanDisposition) int {
+	n := 0
+	for row, disp := range r.Rows {
+		if row.Table == table && disp == want {
+			n++
+		}
+	}
+	return n
 }
 
 // FKViolation is a single PRAGMA foreign_key_check row with the
@@ -48,6 +89,22 @@ const (
 	dispositionDrop
 	dispositionScrub
 )
+
+// rank orders dispositions by precedence: when one row is classified twice,
+// the higher rank wins. Dropping the row makes scrubbing it moot, so drop
+// outranks scrub. This is deliberately independent of the iota order above,
+// which lists drop before scrub — comparing the constants directly would
+// invert the rule.
+func (d orphanDisposition) rank() int {
+	switch d {
+	case dispositionDrop:
+		return 2
+	case dispositionScrub:
+		return 1
+	default:
+		return 0
+	}
+}
 
 // classifyKnownOrphan returns dispositionDrop or dispositionScrub
 // for known issue-child orphan classes, or dispositionUnknown
@@ -85,10 +142,9 @@ func classifyKnownOrphan(table, parent, column string) orphanDisposition {
 // PreflightSourceFKs opens path read-only, runs PRAGMA
 // foreign_key_check, classifies each violation against the
 // known-orphan-class table, and returns a structured report.
-// Drop precedence: when the same rowid appears in both buckets
-// during the scan, drop wins (the scrub entry is removed and any
-// later scrub entry for that rowid is skipped). The source DB is
-// not modified.
+// Drop precedence: when the same rowid is classified twice during the
+// scan, the drop disposition wins regardless of arrival order. The source
+// DB is not modified.
 func PreflightSourceFKs(ctx context.Context, path string) (OrphanReport, error) {
 	source, err := sqlitestore.Open(ctx, path, db.ReadOnly())
 	if err != nil {
@@ -121,10 +177,7 @@ func PreflightSourceFKs(ctx context.Context, path string) (OrphanReport, error) 
 	}
 	_ = rows.Close()
 
-	report := OrphanReport{
-		DroppedRowsByTable:  map[string]map[int64]struct{}{},
-		ScrubbedRowsByTable: map[string]map[int64]struct{}{},
-	}
+	report := newOrphanReport()
 	resolver := sqlitestore.NewFKColumnResolver(source)
 	for _, r := range raws {
 		// Classification depends on the column name -- if we can't resolve
@@ -139,60 +192,21 @@ func PreflightSourceFKs(ctx context.Context, path string) (OrphanReport, error) 
 			return OrphanReport{}, fmt.Errorf("preflight resolve %s: %w", r.Table, err)
 		}
 		disp := classifyKnownOrphan(r.Table, r.ParentTable, col)
-		// A NULL rowid (WITHOUT ROWID source table) leaves us with no
-		// stable identifier to dedupe drop/scrub buckets by, so we
-		// can't safely include it in either. The four known orphan
-		// classes are all rowid tables, so this should never fire on
-		// real data, but if it ever does we surface the violation
-		// rather than silently coalesce or skip it.
-		if !r.RowID.Valid {
-			disp = dispositionUnknown
-		}
-		switch disp {
-		case dispositionDrop:
-			ensureRowSet(report.DroppedRowsByTable, r.Table)[r.RowID.Int64] = struct{}{}
-			// Drop precedence: remove any earlier scrub entry for
-			// this rowid in the same table.
-			if scrubs, ok := report.ScrubbedRowsByTable[r.Table]; ok {
-				delete(scrubs, r.RowID.Int64)
-			}
-		case dispositionScrub:
-			// Drop precedence: skip if this rowid is already in
-			// the drop bucket for the same table.
-			if drops, ok := report.DroppedRowsByTable[r.Table]; ok {
-				if _, present := drops[r.RowID.Int64]; present {
-					continue
-				}
-			}
-			ensureRowSet(report.ScrubbedRowsByTable, r.Table)[r.RowID.Int64] = struct{}{}
-		default:
+		// A NULL rowid (WITHOUT ROWID source table) gives us no stable row
+		// identity, so the row cannot be filed under a disposition without
+		// risking coalescing two distinct rows. The four known orphan
+		// classes are all rowid tables, so this should never fire on real
+		// data; when it does, surface the violation rather than guess.
+		if disp == dispositionUnknown || !r.RowID.Valid {
 			report.UnknownViolations = append(report.UnknownViolations, FKViolation{
 				Table:       r.Table,
 				RowID:       r.RowID,
 				ParentTable: r.ParentTable,
 				Column:      col,
 			})
+			continue
 		}
-	}
-	// Trim empty per-table maps so callers can use len() to gate.
-	for tbl, set := range report.DroppedRowsByTable {
-		if len(set) == 0 {
-			delete(report.DroppedRowsByTable, tbl)
-		}
-	}
-	for tbl, set := range report.ScrubbedRowsByTable {
-		if len(set) == 0 {
-			delete(report.ScrubbedRowsByTable, tbl)
-		}
+		report.record(orphanRow{Table: r.Table, RowID: r.RowID.Int64}, disp)
 	}
 	return report, nil
-}
-
-func ensureRowSet(m map[string]map[int64]struct{}, key string) map[int64]struct{} {
-	if existing, ok := m[key]; ok {
-		return existing
-	}
-	fresh := map[int64]struct{}{}
-	m[key] = fresh
-	return fresh
 }

--- a/internal/jsonl/preflight_internal_test.go
+++ b/internal/jsonl/preflight_internal_test.go
@@ -1,0 +1,49 @@
+package jsonl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOrphanReportDropOutranksScrub pins drop precedence in BOTH arrival
+// orders. PRAGMA foreign_key_check emits one row per violated FK, so an
+// events row with both issue_id and related_issue_id orphaned is classified
+// twice; which classification arrives first is an implementation detail of
+// SQLite's scan order, and the report must not depend on it.
+func TestOrphanReportDropOutranksScrub(t *testing.T) {
+	row := orphanRow{Table: "events", RowID: 7}
+
+	t.Run("drop then scrub", func(t *testing.T) {
+		report := newOrphanReport()
+		report.record(row, dispositionDrop)
+		report.record(row, dispositionScrub)
+		assert.Equal(t, 1, report.DropCount("events"))
+		assert.Equal(t, 0, report.ScrubCount("events"))
+	})
+
+	t.Run("scrub then drop", func(t *testing.T) {
+		report := newOrphanReport()
+		report.record(row, dispositionScrub)
+		report.record(row, dispositionDrop)
+		assert.Equal(t, 1, report.DropCount("events"),
+			"drop must win no matter which violation is observed first")
+		assert.Equal(t, 0, report.ScrubCount("events"))
+	})
+
+	t.Run("same disposition twice counts once", func(t *testing.T) {
+		report := newOrphanReport()
+		report.record(row, dispositionScrub)
+		report.record(row, dispositionScrub)
+		assert.Equal(t, 1, report.ScrubCount("events"))
+	})
+
+	t.Run("counts are per table", func(t *testing.T) {
+		report := newOrphanReport()
+		report.record(orphanRow{Table: "events", RowID: 1}, dispositionDrop)
+		report.record(orphanRow{Table: "comments", RowID: 1}, dispositionDrop)
+		assert.Equal(t, 1, report.DropCount("events"))
+		assert.Equal(t, 1, report.DropCount("comments"))
+		assert.Equal(t, 0, report.DropCount("links"))
+	})
+}

--- a/internal/jsonl/preflight_test.go
+++ b/internal/jsonl/preflight_test.go
@@ -27,11 +27,11 @@ func TestPreflightSourceFKs_DeduplicatesPerRow(t *testing.T) {
 
 		report, err := jsonl.PreflightSourceFKs(ctx, path)
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(report.DroppedRowsByTable["links"]),
+		assert.Equal(t, 1, report.DropCount("links"),
 			"links row with two violated FKs should count once")
-		assert.Equal(t, 1, len(report.DroppedRowsByTable["events"]),
+		assert.Equal(t, 1, report.DropCount("events"),
 			"events row with both columns orphaned should count as one drop")
-		assert.Equal(t, 0, len(report.ScrubbedRowsByTable["events"]),
+		assert.Equal(t, 0, report.ScrubCount("events"),
 			"drop precedence: same events rowid must NOT also appear in scrub bucket")
 		assert.Empty(t, report.UnknownViolations)
 	})
@@ -44,9 +44,9 @@ func TestPreflightSourceFKs_DeduplicatesPerRow(t *testing.T) {
 
 		report, err := jsonl.PreflightSourceFKs(ctx, path)
 		require.NoError(t, err)
-		assert.Equal(t, 0, len(report.DroppedRowsByTable["events"]),
+		assert.Equal(t, 0, report.DropCount("events"),
 			"events with valid issue_id but orphan related must NOT be dropped")
-		assert.Equal(t, 1, len(report.ScrubbedRowsByTable["events"]),
+		assert.Equal(t, 1, report.ScrubCount("events"),
 			"events with orphan related_issue_id should be scrubbed (preserved with NULL related)")
 		assert.Empty(t, report.UnknownViolations)
 	})
@@ -71,8 +71,7 @@ func TestPreflightSourceFKs_DeduplicatesPerRow(t *testing.T) {
 
 		report, err := jsonl.PreflightSourceFKs(ctx, path)
 		require.NoError(t, err)
-		assert.Empty(t, report.DroppedRowsByTable)
-		assert.Empty(t, report.ScrubbedRowsByTable)
+		assert.Empty(t, report.Rows, "a clean DB files no row under any disposition")
 		assert.Empty(t, report.UnknownViolations)
 	})
 

--- a/internal/jsonl/testdata/events_sql/current_all_projects_live_only.sql
+++ b/internal/jsonl/testdata/events_sql/current_all_projects_live_only.sql
@@ -1,0 +1,9 @@
+SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, export_project.uid, events.project_name, events.issue_id, events.issue_uid,
+	                 CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_id END, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_uid END,
+	                 events.type, events.actor, events.payload, events.hlc_physical_ms, events.hlc_counter, events.content_hash,
+	                 CAST(events.created_at AS TEXT)
+	          FROM events
+	          JOIN projects export_project ON export_project.id = events.project_id
+	          LEFT JOIN issues subject_issue ON subject_issue.project_id = events.project_id
+	               AND (subject_issue.id = events.issue_id OR (events.issue_id IS NULL AND events.issue_uid IS NOT NULL AND subject_issue.uid = events.issue_uid))
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE ((events.issue_id IS NULL AND events.issue_uid IS NULL) OR (subject_issue.id IS NOT NULL AND subject_issue.deleted_at IS NULL)) AND (events.issue_id IS NULL OR EXISTS (SELECT 1 FROM issues WHERE issues.id = events.issue_id AND issues.deleted_at IS NULL)) AND (events.related_issue_id IS NULL OR events.type = 'issue.links_changed' OR NOT EXISTS (SELECT 1 FROM issues WHERE issues.id = events.related_issue_id AND issues.deleted_at IS NOT NULL)) ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/current_include_deleted.sql
+++ b/internal/jsonl/testdata/events_sql/current_include_deleted.sql
@@ -1,0 +1,9 @@
+SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, export_project.uid, events.project_name, events.issue_id, events.issue_uid,
+	                 CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) THEN NULL ELSE events.related_issue_id END, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) THEN NULL ELSE events.related_issue_uid END,
+	                 events.type, events.actor, events.payload, events.hlc_physical_ms, events.hlc_counter, events.content_hash,
+	                 CAST(events.created_at AS TEXT)
+	          FROM events
+	          JOIN projects export_project ON export_project.id = events.project_id
+	          LEFT JOIN issues subject_issue ON subject_issue.project_id = events.project_id
+	               AND (subject_issue.id = events.issue_id OR (events.issue_id IS NULL AND events.issue_uid IS NOT NULL AND subject_issue.uid = events.issue_uid))
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE ((events.issue_id IS NULL AND events.issue_uid IS NULL) OR subject_issue.id IS NOT NULL) AND events.project_id = ? ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/current_live_only.sql
+++ b/internal/jsonl/testdata/events_sql/current_live_only.sql
@@ -1,0 +1,9 @@
+SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, export_project.uid, events.project_name, events.issue_id, events.issue_uid,
+	                 CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_id END, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_uid END,
+	                 events.type, events.actor, events.payload, events.hlc_physical_ms, events.hlc_counter, events.content_hash,
+	                 CAST(events.created_at AS TEXT)
+	          FROM events
+	          JOIN projects export_project ON export_project.id = events.project_id
+	          LEFT JOIN issues subject_issue ON subject_issue.project_id = events.project_id
+	               AND (subject_issue.id = events.issue_id OR (events.issue_id IS NULL AND events.issue_uid IS NOT NULL AND subject_issue.uid = events.issue_uid))
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE ((events.issue_id IS NULL AND events.issue_uid IS NULL) OR (subject_issue.id IS NOT NULL AND subject_issue.deleted_at IS NULL)) AND events.project_id = ? AND (events.issue_id IS NULL OR EXISTS (SELECT 1 FROM issues WHERE issues.id = events.issue_id AND issues.deleted_at IS NULL)) AND (events.related_issue_id IS NULL OR events.type = 'issue.links_changed' OR NOT EXISTS (SELECT 1 FROM issues WHERE issues.id = events.related_issue_id AND issues.deleted_at IS NOT NULL)) ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/v1_include_deleted.sql
+++ b/internal/jsonl/testdata/events_sql/v1_include_deleted.sql
@@ -1,0 +1,5 @@
+SELECT events.id, events.project_id, projects.name, events.issue_id, events.issue_number,
+	                 CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) THEN NULL ELSE events.related_issue_id END, events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
+	          FROM events JOIN projects ON projects.id = events.project_id
+	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE (events.issue_id IS NULL OR subject_issue.id IS NOT NULL) AND events.project_id = ? ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/v1_live_only.sql
+++ b/internal/jsonl/testdata/events_sql/v1_live_only.sql
@@ -1,0 +1,5 @@
+SELECT events.id, events.project_id, projects.name, events.issue_id, events.issue_number,
+	                 CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_id END, events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
+	          FROM events JOIN projects ON projects.id = events.project_id
+	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE (events.issue_id IS NULL OR subject_issue.id IS NOT NULL) AND events.project_id = ? AND (events.issue_id IS NULL OR EXISTS (SELECT 1 FROM issues WHERE issues.id = events.issue_id AND issues.deleted_at IS NULL)) AND (events.related_issue_id IS NULL OR events.type = 'issue.links_changed' OR NOT EXISTS (SELECT 1 FROM issues WHERE issues.id = events.related_issue_id AND issues.deleted_at IS NOT NULL)) ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/v2_include_deleted.sql
+++ b/internal/jsonl/testdata/events_sql/v2_include_deleted.sql
@@ -1,0 +1,6 @@
+SELECT events.id, events.project_id, projects.name, events.issue_id, events.issue_uid,
+	                 events.issue_number, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) THEN NULL ELSE events.related_issue_id END, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) THEN NULL ELSE events.related_issue_uid END,
+	                 events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
+	          FROM events JOIN projects ON projects.id = events.project_id
+	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE (events.issue_id IS NULL OR subject_issue.id IS NOT NULL) AND events.project_id = ? ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/v2_live_only.sql
+++ b/internal/jsonl/testdata/events_sql/v2_live_only.sql
@@ -1,0 +1,6 @@
+SELECT events.id, events.project_id, projects.name, events.issue_id, events.issue_uid,
+	                 events.issue_number, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_id END, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_uid END,
+	                 events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
+	          FROM events JOIN projects ON projects.id = events.project_id
+	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE (events.issue_id IS NULL OR subject_issue.id IS NOT NULL) AND events.project_id = ? AND (events.issue_id IS NULL OR EXISTS (SELECT 1 FROM issues WHERE issues.id = events.issue_id AND issues.deleted_at IS NULL)) AND (events.related_issue_id IS NULL OR events.type = 'issue.links_changed' OR NOT EXISTS (SELECT 1 FROM issues WHERE issues.id = events.related_issue_id AND issues.deleted_at IS NOT NULL)) ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/v3_include_deleted.sql
+++ b/internal/jsonl/testdata/events_sql/v3_include_deleted.sql
@@ -1,0 +1,6 @@
+SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, projects.name, events.issue_id, events.issue_uid,
+	                 events.issue_number, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) THEN NULL ELSE events.related_issue_id END, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) THEN NULL ELSE events.related_issue_uid END,
+	                 events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
+	          FROM events JOIN projects ON projects.id = events.project_id
+	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE (events.issue_id IS NULL OR subject_issue.id IS NOT NULL) AND events.project_id = ? ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/v3_live_only.sql
+++ b/internal/jsonl/testdata/events_sql/v3_live_only.sql
@@ -1,0 +1,6 @@
+SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, projects.name, events.issue_id, events.issue_uid,
+	                 events.issue_number, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_id END, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_uid END,
+	                 events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
+	          FROM events JOIN projects ON projects.id = events.project_id
+	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE (events.issue_id IS NULL OR subject_issue.id IS NOT NULL) AND events.project_id = ? AND (events.issue_id IS NULL OR EXISTS (SELECT 1 FROM issues WHERE issues.id = events.issue_id AND issues.deleted_at IS NULL)) AND (events.related_issue_id IS NULL OR events.type = 'issue.links_changed' OR NOT EXISTS (SELECT 1 FROM issues WHERE issues.id = events.related_issue_id AND issues.deleted_at IS NOT NULL)) ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/v8_include_deleted.sql
+++ b/internal/jsonl/testdata/events_sql/v8_include_deleted.sql
@@ -1,0 +1,6 @@
+SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, events.project_name, events.issue_id, events.issue_uid,
+	                 CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) THEN NULL ELSE events.related_issue_id END, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) THEN NULL ELSE events.related_issue_uid END,
+	                 events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
+	          FROM events
+	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE (events.issue_id IS NULL OR subject_issue.id IS NOT NULL) AND events.project_id = ? ORDER BY events.id ASC

--- a/internal/jsonl/testdata/events_sql/v8_live_only.sql
+++ b/internal/jsonl/testdata/events_sql/v8_live_only.sql
@@ -1,0 +1,6 @@
+SELECT events.id, events.uid, events.origin_instance_uid, events.project_id, events.project_name, events.issue_id, events.issue_uid,
+	                 CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_id END, CASE WHEN (peer.id IS NULL AND events.related_issue_id IS NOT NULL) OR (events.type = 'issue.links_changed' AND peer.deleted_at IS NOT NULL) THEN NULL ELSE events.related_issue_uid END,
+	                 events.type, events.actor, events.payload, CAST(events.created_at AS TEXT)
+	          FROM events
+	          LEFT JOIN issues subject_issue ON subject_issue.id = events.issue_id
+	          LEFT JOIN issues peer ON peer.id = events.related_issue_id WHERE (events.issue_id IS NULL OR subject_issue.id IS NOT NULL) AND events.project_id = ? AND (events.issue_id IS NULL OR EXISTS (SELECT 1 FROM issues WHERE issues.id = events.issue_id AND issues.deleted_at IS NULL)) AND (events.related_issue_id IS NULL OR events.type = 'issue.links_changed' OR NOT EXISTS (SELECT 1 FROM issues WHERE issues.id = events.related_issue_id AND issues.deleted_at IS NOT NULL)) ORDER BY events.id ASC


### PR DESCRIPTION
## Summary

- Replace the 22-pointer import union with typed payload records while keeping malformed replay rejection before either backend opens a transaction.
- Give each orphan row one explicit drop-or-scrub disposition with arrival-order-independent precedence.
- Centralize event orphan handling across all five export version bands and delegate issue-sync status export to the existing shared path.

## Compatibility

- Preserve NDJSON kind strings and persisted schemas.
- Preserve the per-version event export SQL, including the legacy V1 shape.
