### PR TITLE
test: cover Firefox web UI snapshot startup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,10 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Install frozen web dependencies and Chromium
+      - name: Install frozen web dependencies and browsers
         run: |
           make web-install
-          cd web && bun x playwright install --with-deps chromium
+          cd web && bun x playwright install --with-deps chromium firefox
 
       - name: Run isolated browser tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           KATA_WORKSPACE: ${{ runner.temp }}/kata-web-browser/workspace
         run: |
           mkdir -p "$KATA_HOME" "$KATA_WORKSPACE"
-          make web-test-browser web-e2e
+          make web-test-browser web-e2e web-e2e-firefox
 
       - name: Upload browser failure artifacts
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ web-test-browser:
 web-e2e:
 	cd web && bun run test:e2e
 
+web-e2e-firefox:
+	cd web && bun run test:e2e:firefox
+
 web-build:
 	cd web && bun run build
 

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,8 @@
     "audit": "bun audit --audit-level high",
     "test": "vitest run",
     "test:browser": "vitest run --project browser",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test --grep-invert @firefox",
+    "test:e2e:firefox": "playwright test --grep @firefox",
     "build": "vite build",
     "dev": "vite"
   },

--- a/web/tests/firefox-startup.spec.ts
+++ b/web/tests/firefox-startup.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from './fixtures'
+
+test.use({ browserName: 'firefox', trace: 'off' })
+
+test('direct loopback tab loads the workspace snapshot in Firefox', async ({ page, kata }) => {
+  await page.goto(`${kata.origin}/kata?view=all-open`)
+  await expect(page.getByRole('button', { name: 'New task' })).toBeVisible()
+})

--- a/web/tests/firefox-startup.spec.ts
+++ b/web/tests/firefox-startup.spec.ts
@@ -2,7 +2,11 @@ import { expect, test } from './fixtures'
 
 test.use({ browserName: 'firefox', trace: 'off' })
 
-test('direct loopback tab loads the workspace snapshot in Firefox', async ({ page, kata }) => {
-  await page.goto(`${kata.origin}/kata?view=all-open`)
-  await expect(page.getByRole('button', { name: 'New task' })).toBeVisible()
-})
+test(
+  'direct loopback tab loads the workspace snapshot in Firefox',
+  { tag: '@firefox' },
+  async ({ page, kata }) => {
+    await page.goto(`${kata.origin}/kata?view=all-open`)
+    await expect(page.getByRole('button', { name: 'New task' })).toBeVisible()
+  },
+)


### PR DESCRIPTION
Firefox is now part of the browser regression surface for local Web UI startup. Without the existing GET and HEAD body guard, Firefox stops after daemon discovery and displays `Snapshot unavailable`; Chromium continues to load, so Chromium-only coverage cannot catch this regression.

Browser CI provisions Playwright's pinned Firefox build and runs the tagged startup scenario through a dedicated target. The default Chromium suite remains compatible with the deliberately main-pinned pull request dispatcher; after this workflow lands, main and later pull requests execute both browser targets.

Closes #285
