### PR TITLE
Simplify contained audit fixes

### DIFF
--- a/cmd/kata/attention_hook.go
+++ b/cmd/kata/attention_hook.go
@@ -64,10 +64,7 @@ func parseAttentionHookArgs(args []string) (string, bool) {
 }
 
 func runAttentionHook(cmd *cobra.Command, mode string) {
-	if mode != "start" && mode != "end" {
-		return
-	}
-
+	// parseAttentionHookArgs is the sole caller, so mode is already validated.
 	// Claude Code exposes the workspace it launched from even when hook cwd
 	// differs. Prefer it as the normal project-resolution anchor when present.
 	if projectDir := strings.TrimSpace(os.Getenv("CLAUDE_PROJECT_DIR")); projectDir != "" {
@@ -93,10 +90,10 @@ const (
 	lookupOpen
 )
 
+// attnLookup uses empty attention for absent, null, and non-string metadata.
 type attnLookup struct {
 	kind      attnLookupKind
 	attention string
-	hasAttn   bool
 	revision  int64
 }
 
@@ -146,7 +143,7 @@ func attnEnd(d attnDaemon, kataRef string) {
 	}
 	for range attnWriteAttempts {
 		lookup := d.lookup(ref)
-		if lookup.kind != lookupOpen || !lookup.hasAttn || lookup.attention != attnValueOK {
+		if lookup.kind != lookupOpen || lookup.attention != attnValueOK {
 			return
 		}
 		if d.setMetaIfRevision(ref, map[string]string{
@@ -184,13 +181,7 @@ func (l *liveAttnDaemon) lookup(ref string) attnLookup {
 	if status >= http.StatusBadRequest {
 		return attnLookup{kind: lookupTransient}
 	}
-	var response struct {
-		Issue struct {
-			Status   string                     `json:"status"`
-			Metadata map[string]json.RawMessage `json:"metadata"`
-			Revision int64                      `json:"revision"`
-		} `json:"issue"`
-	}
+	var response metaShowResponse
 	if err := json.Unmarshal(body, &response); err != nil {
 		return attnLookup{kind: lookupTransient}
 	}
@@ -200,12 +191,11 @@ func (l *liveAttnDaemon) lookup(ref string) attnLookup {
 	if response.Issue.Revision <= 0 {
 		return attnLookup{kind: lookupTransient}
 	}
-	lookup := attnLookup{kind: lookupOpen, revision: response.Issue.Revision}
-	if raw, ok := response.Issue.Metadata[attentionKey]; ok {
-		lookup.hasAttn = true
-		_ = json.Unmarshal(raw, &lookup.attention)
+	return attnLookup{
+		kind:      lookupOpen,
+		attention: decodeJSONString(response.Issue.Metadata[attentionKey]),
+		revision:  response.Issue.Revision,
 	}
-	return lookup
 }
 
 func (l *liveAttnDaemon) setMetaIfRevision(ref string, patch map[string]string, revision int64) attnWriteResult {

--- a/cmd/kata/attention_hook_unit_test.go
+++ b/cmd/kata/attention_hook_unit_test.go
@@ -52,7 +52,7 @@ func (f *fakeAttnDaemon) setMetaIfRevision(ref string, patch map[string]string, 
 
 func TestAttnStart_ConditionallySetsOnlyAttentionOKForOpenIssue(t *testing.T) {
 	d := &fakeAttnDaemon{lookups: map[string]attnLookup{
-		"abc4": {kind: lookupOpen, hasAttn: true, attention: attnValueNeedsHuman, revision: 13},
+		"abc4": {kind: lookupOpen, attention: attnValueNeedsHuman, revision: 13},
 	}}
 
 	attnStart(d, "  abc4  ")
@@ -102,7 +102,7 @@ func TestAttnStart_RetriesOnceAfterRevisionConflict(t *testing.T) {
 
 func TestAttnEnd_AtomicallySetsHandoffForOpenOKIssue(t *testing.T) {
 	d := &fakeAttnDaemon{lookups: map[string]attnLookup{
-		"abc4": {kind: lookupOpen, hasAttn: true, attention: attnValueOK, revision: 17},
+		"abc4": {kind: lookupOpen, attention: attnValueOK, revision: 17},
 	}}
 
 	attnEnd(d, " abc4 ")
@@ -126,8 +126,8 @@ func TestAttnEnd_SkipsNonActionableIssues(t *testing.T) {
 		{name: "missing", lookup: attnLookup{kind: lookupGone}},
 		{name: "transient", lookup: attnLookup{kind: lookupTransient}},
 		{name: "attention absent", lookup: attnLookup{kind: lookupOpen}},
-		{name: "attention non-ok", lookup: attnLookup{kind: lookupOpen, hasAttn: true, attention: attnValueNeedsHuman}},
-		{name: "attention empty", lookup: attnLookup{kind: lookupOpen, hasAttn: true}},
+		{name: "attention non-ok", lookup: attnLookup{kind: lookupOpen, attention: attnValueNeedsHuman}},
+		{name: "attention empty", lookup: attnLookup{kind: lookupOpen}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			d := &fakeAttnDaemon{lookups: map[string]attnLookup{"abc4": tc.lookup}}
@@ -143,8 +143,8 @@ func TestAttnEnd_SkipsNonActionableIssues(t *testing.T) {
 func TestAttnEnd_RechecksAttentionAfterRevisionConflict(t *testing.T) {
 	d := &fakeAttnDaemon{
 		lookupSequence: []attnLookup{
-			{kind: lookupOpen, hasAttn: true, attention: attnValueOK, revision: 17},
-			{kind: lookupOpen, hasAttn: true, attention: attnValueNeedsHuman, revision: 18},
+			{kind: lookupOpen, attention: attnValueOK, revision: 17},
+			{kind: lookupOpen, attention: attnValueNeedsHuman, revision: 18},
 		},
 		conditionalResults: []attnWriteResult{attnWriteConflict},
 	}
@@ -224,7 +224,7 @@ func TestAttentionHookCommand_InvalidInvocationsExitZeroWithoutDaemonActivity(t 
 func TestAttnEnd_WriteFailureDoesNotRetry(t *testing.T) {
 	d := &fakeAttnDaemon{
 		lookups: map[string]attnLookup{
-			"abc4": {kind: lookupOpen, hasAttn: true, attention: attnValueOK, revision: 23},
+			"abc4": {kind: lookupOpen, attention: attnValueOK, revision: 23},
 		},
 		conditionalResults: []attnWriteResult{attnWriteFailed},
 	}
@@ -233,6 +233,55 @@ func TestAttnEnd_WriteFailureDoesNotRetry(t *testing.T) {
 
 	assert.Equal(t, []string{"abc4"}, d.lookupRefs)
 	assert.Len(t, d.conditionalWrites, 1)
+}
+
+func TestLiveAttnDaemon_LookupTreatsNonStringAttentionAsAbsent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{name: "number", raw: json.RawMessage(`7`)},
+		{name: "null", raw: json.RawMessage(`null`)},
+		{name: "object", raw: json.RawMessage(`{"state":"ok"}`)},
+		{name: "array", raw: json.RawMessage(`["ok"]`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetFlags(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/v1/projects/resolve":
+					require.Equal(t, http.MethodPost, r.Method)
+					require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+						"project": map[string]any{"id": 42, "name": "example-project"},
+					}))
+				case "/api/v1/projects/42/issues/abc4":
+					require.Equal(t, http.MethodGet, r.Method)
+					require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+						"issue": map[string]any{
+							"short_id": "abc4",
+							"status":   "open",
+							"metadata": map[string]json.RawMessage{attentionKey: tc.raw},
+							"revision": int64(17),
+						},
+					}))
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			cmd := newRootCmd()
+			cmd.SetContext(contextWithBaseURL(context.Background(), server.URL))
+			flags.Project = "example-project"
+
+			lookup := (&liveAttnDaemon{cmd: cmd}).lookup("abc4")
+
+			assert.Equal(t, lookupOpen, lookup.kind)
+			assert.Equal(t, int64(17), lookup.revision)
+			assert.Empty(t, lookup.attention)
+		})
+	}
 }
 
 func TestLiveAttnDaemon_ConditionalSetSendsOnlyActorPatchAndIfMatch(t *testing.T) {

--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -129,28 +129,28 @@ func newCreateCmd() *cobra.Command {
 		var links []map[string]any
 		var parentRef string
 		if cmd.Flags().Changed("parent") {
-			r, err := resolveSingletonRefToWire(ctx, baseURL, projectName, projectID, parentRefSlice, "--parent", false)
+			r, err := singletonRefToWire(parentRefSlice, "--parent", projectName)
 			if err != nil {
 				return err
 			}
 			parentRef = r
 			links = append(links, map[string]any{"type": "parent", "to_ref": r})
 		}
-		blocksRefs, err := resolveRefSliceToWire(ctx, baseURL, projectName, projectID, blocks, "--blocks")
+		blocksRefs, err := refsToWire(blocks, "--blocks", projectName)
 		if err != nil {
 			return err
 		}
 		for _, r := range blocksRefs {
 			links = append(links, map[string]any{"type": "blocks", "to_ref": r})
 		}
-		blockedByRefs, err := resolveRefSliceToWire(ctx, baseURL, projectName, projectID, blockedBy, "--blocked-by")
+		blockedByRefs, err := refsToWire(blockedBy, "--blocked-by", projectName)
 		if err != nil {
 			return err
 		}
 		for _, r := range blockedByRefs {
 			links = append(links, map[string]any{"type": "blocks", "to_ref": r, "incoming": true})
 		}
-		relatedRefs, err := resolveRefSliceToWire(ctx, baseURL, projectName, projectID, related, "--related")
+		relatedRefs, err := refsToWire(related, "--related", projectName)
 		if err != nil {
 			return err
 		}

--- a/cmd/kata/delete.go
+++ b/cmd/kata/delete.go
@@ -50,7 +50,7 @@ func newDeleteCmd() *cobra.Command {
 			}
 			expected := fmt.Sprintf("DELETE %s", issue.QualifiedID)
 			confirm, err = resolveConfirm(cmd, confirm, expected,
-				fmt.Sprintf("Type %q to confirm: ", expected), confirmPromptFull)
+				fmt.Sprintf("Type %q to confirm: ", expected))
 			if err != nil {
 				return err
 			}
@@ -62,25 +62,12 @@ func newDeleteCmd() *cobra.Command {
 	return cmd
 }
 
-// confirmMatcher decides whether the user's TTY input satisfies the prompt.
-// Both delete and purge now use confirmPromptFull (the full
-// "VERB <project>#<short_id>" string) so the X-Kata-Confirm header — which
-// must match that exact form — works whether the user typed in interactively
-// or passed it noninteractively via --confirm.
-type confirmMatcher func(line, expected string) bool
-
-// confirmPromptFull accepts only the exact expected string.
-func confirmPromptFull(line, expected string) bool {
-	return line == expected
-}
-
 // resolveConfirm returns the X-Kata-Confirm value the daemon expects:
 //   - if --confirm was passed, use it as-is (the daemon validates exact match);
-//   - otherwise, if stdin is a TTY, prompt with `prompt` and accept input that
-//     `match` says satisfies the verb's friction rule;
+//   - otherwise, if stdin is a TTY, prompt with `prompt` and require the exact
+//     expected confirmation string;
 //   - otherwise, exit 6 confirm_required.
-func resolveConfirm(cmd *cobra.Command, flagVal, expected, prompt string,
-	match confirmMatcher) (string, error) {
+func resolveConfirm(cmd *cobra.Command, flagVal, expected, prompt string) (string, error) {
 	if flagVal != "" {
 		return flagVal, nil
 	}
@@ -99,7 +86,7 @@ func resolveConfirm(cmd *cobra.Command, flagVal, expected, prompt string,
 	// just means the user closed stdin, which we treat as an empty mismatch.
 	line, _ := r.ReadString('\n')
 	line = strings.TrimSpace(line)
-	if !match(line, expected) {
+	if line != expected {
 		return "", &cliError{
 			Message: "confirmation input did not match",
 			Code:    "confirm_mismatch",

--- a/cmd/kata/edit.go
+++ b/cmd/kata/edit.go
@@ -104,7 +104,7 @@ func newEditCmd() *cobra.Command {
 		}
 
 		// --parent and --remove-parent are at-most-one but accept any of
-		// short_id, qualified ("other#abc4"), or ULID. resolveSingletonRefToWire
+		// short_id, qualified ("other#abc4"), or ULID. singletonRefToWire
 		// rejects only when distinct refs resolve to *different* issues, so
 		// equivalent forms (e.g. `--parent abc4 --parent kata#abc4`) succeed.
 		// issue.ProjectName is the URL issue's canonical project. Bare refs resolve
@@ -112,13 +112,13 @@ func newEditCmd() *cobra.Command {
 		// resolve globally. The daemon enforces archived/existence rules.
 		var parentRef, removeParentRef string
 		if cmd.Flags().Changed("parent") {
-			parentRef, err = resolveSingletonRefToWire(ctx, baseURL, issue.ProjectName, pid, parentRefSlice, "--parent", false)
+			parentRef, err = singletonRefToWire(parentRefSlice, "--parent", issue.ProjectName)
 			if err != nil {
 				return err
 			}
 		}
 		if cmd.Flags().Changed("remove-parent") {
-			removeParentRef, err = resolveSingletonRefToWire(ctx, baseURL, issue.ProjectName, pid, removeParentRefSlice, "--remove-parent", true)
+			removeParentRef, err = singletonRefToWire(removeParentRefSlice, "--remove-parent", issue.ProjectName)
 			if err != nil {
 				return err
 			}
@@ -131,42 +131,6 @@ func newEditCmd() *cobra.Command {
 		}
 		if linksDelta != nil {
 			payload["links_delta"] = linksDelta
-		}
-
-		// Pure idempotent-remove of refs that resolved to "no such issue"
-		// would arrive here with payload == {} (no field flags, no link
-		// delta). Treat that as a successful no-op locally rather than
-		// sending an empty PATCH the daemon would reject. Examples:
-		//   kata edit 1 --remove-blocks <missing-uid-prefix>
-		//   kata edit 1 --remove-related 99
-		// Both are documented as idempotent; producing a synthetic
-		// no-op response keeps that contract for non-numeric refs too.
-		// Numeric refs that resolved to nothing also benefit (they
-		// previously short-circuited at the daemon).
-		anyLinkFlagSet := cmd.Flags().Changed("parent") || cmd.Flags().Changed("blocks") ||
-			cmd.Flags().Changed("blocked-by") || cmd.Flags().Changed("related") ||
-			cmd.Flags().Changed("remove-parent") || cmd.Flags().Changed("remove-blocks") ||
-			cmd.Flags().Changed("remove-blocked-by") || cmd.Flags().Changed("remove-related")
-		if len(payload) == 0 && anyLinkFlagSet {
-			// Fetch the issue so the "no changes applied" line can echo
-			// the issue's title/status — printMutation reads those off
-			// the response body. One extra GET avoids a wasted PATCH the
-			// daemon would 400 on as an empty mutation.
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
-				return err
-			}
-			_, bs, err := httpDoJSON(ctx, client, http.MethodGet,
-				fmt.Sprintf("%s/api/v1/projects/%d/issues/%s", baseURL, pid, url.PathEscape(issue.RefForAPI)),
-				nil)
-			if err != nil {
-				return err
-			}
-			actor, _ := resolveActor(ctx, flags.As, nil)
-			if err := postFollowupComment(ctx, client, baseURL, pid, issue.RefForAPI, actor, comment); err != nil {
-				return err
-			}
-			return printMutationWithApplied(cmd, syntheticNoopFromShow(bs), nil, issue.ProjectName)
 		}
 
 		// At least one mutation must be present, mirroring the daemon's check
@@ -250,26 +214,24 @@ func buildLinksDelta(
 		removeBlocksRefs, removeBlockedByRefs, removeRelatedRefs []string
 		err                                                      error
 	)
-	if blocksRefs, err = resolveRefSliceToWire(ctx, baseURL, currentProject, projectID, blocks, "--blocks"); err != nil {
+	if blocksRefs, err = refsToWire(blocks, "--blocks", currentProject); err != nil {
 		return nil, err
 	}
-	if blockedByRefs, err = resolveRefSliceToWire(ctx, baseURL, currentProject, projectID, blockedBy, "--blocked-by"); err != nil {
+	if blockedByRefs, err = refsToWire(blockedBy, "--blocked-by", currentProject); err != nil {
 		return nil, err
 	}
-	if relatedRefs, err = resolveRefSliceToWire(ctx, baseURL, currentProject, projectID, related, "--related"); err != nil {
+	if relatedRefs, err = refsToWire(related, "--related", currentProject); err != nil {
 		return nil, err
 	}
-	// Remove flags are idempotent at the contract level: removing a link
-	// that doesn't exist is a no-op. The daemon's resolver tolerates
-	// soft-deleted peers (the link row is real); idempotent remove of a
-	// completely-missing peer is handled daemon-side too.
-	if removeBlocksRefs, err = resolveRefSliceToWireIdempotentRemove(ctx, baseURL, currentProject, projectID, removeBlocks, "--remove-blocks"); err != nil {
+	// Add and remove flags share pure ref parsing. The daemon owns existence,
+	// soft-delete tolerance, and the idempotent-remove contract.
+	if removeBlocksRefs, err = refsToWire(removeBlocks, "--remove-blocks", currentProject); err != nil {
 		return nil, err
 	}
-	if removeBlockedByRefs, err = resolveRefSliceToWireIdempotentRemove(ctx, baseURL, currentProject, projectID, removeBlockedBy, "--remove-blocked-by"); err != nil {
+	if removeBlockedByRefs, err = refsToWire(removeBlockedBy, "--remove-blocked-by", currentProject); err != nil {
 		return nil, err
 	}
-	if removeRelatedRefs, err = resolveRefSliceToWireIdempotentRemove(ctx, baseURL, currentProject, projectID, removeRelated, "--remove-related"); err != nil {
+	if removeRelatedRefs, err = refsToWire(removeRelated, "--remove-related", currentProject); err != nil {
 		return nil, err
 	}
 
@@ -338,30 +300,6 @@ func buildLinksDelta(
 		return nil, nil
 	}
 	return delta, nil
-}
-
-// syntheticNoopFromShow extracts the issue subobject from a show
-// response body and wraps it in a MutationResponse-shaped envelope
-// with changed=false plus an empty `changes` block. summarizeChanges
-// requires the changes key to be present-but-empty AND changed=false
-// to render the "(no changes applied)" tail; absent changes prints
-// no tail at all, which would look identical to a normal field edit.
-// Used when every requested link mutation resolved to a no-op locally
-// (idempotent --remove-* against missing peers) so we honor the
-// idempotent contract without sending an empty PATCH the daemon
-// would reject.
-func syntheticNoopFromShow(showBody []byte) []byte {
-	var src struct {
-		Issue json.RawMessage `json:"issue"`
-	}
-	_ = json.Unmarshal(showBody, &src)
-	resp := map[string]any{
-		"issue":   src.Issue,
-		"changed": false,
-		"changes": map[string]any{},
-	}
-	bs, _ := json.Marshal(resp)
-	return bs
 }
 
 // firstResolvedOverlap canonicalizes every ref in adds and removes to its

--- a/cmd/kata/edit_links_test.go
+++ b/cmd/kata/edit_links_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func linkDeltaTestCommand(t *testing.T, changedFlag string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var parentRefs, removeParentRefs []string
+	cmd.Flags().Var(newRefSliceValue(&parentRefs), "parent", "")
+	cmd.Flags().Var(newRefSliceValue(&removeParentRefs), "remove-parent", "")
+	if changedFlag == "parent" || changedFlag == "remove-parent" {
+		if err := cmd.Flags().Set(changedFlag, "abc4"); err != nil {
+			t.Fatalf("set --%s: %v", changedFlag, err)
+		}
+	}
+	return cmd
+}
+
+func TestBuildLinksDeltaAlwaysYieldsADeltaForEverySetLinkFlag(t *testing.T) {
+	tests := []struct {
+		name                                         string
+		changedFlag                                  string
+		parentRef                                    string
+		blocks, blockedBy, related                   []string
+		removeParentRef                              string
+		removeBlocks, removeBlockedBy, removeRelated []string
+		want                                         map[string]any
+	}{
+		{name: "parent", changedFlag: "parent", parentRef: "abc4", want: map[string]any{"set_parent": "abc4"}},
+		{name: "remove parent", changedFlag: "remove-parent", removeParentRef: "abc4", want: map[string]any{"remove_parent": "abc4"}},
+		{name: "blocks", blocks: []string{"abc4"}, want: map[string]any{"add_blocks": []string{"abc4"}}},
+		{name: "blocked by", blockedBy: []string{"abc4"}, want: map[string]any{"add_blocked_by": []string{"abc4"}}},
+		{name: "related", related: []string{"abc4"}, want: map[string]any{"add_related": []string{"abc4"}}},
+		{name: "remove blocks", removeBlocks: []string{"abc4"}, want: map[string]any{"remove_blocks": []string{"abc4"}}},
+		{name: "remove blocked by", removeBlockedBy: []string{"abc4"}, want: map[string]any{"remove_blocked_by": []string{"abc4"}}},
+		{name: "remove related", removeRelated: []string{"abc4"}, want: map[string]any{"remove_related": []string{"abc4"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delta, err := buildLinksDelta(
+				context.Background(), linkDeltaTestCommand(t, tt.changedFlag), "", "example-project", 1,
+				tt.parentRef, tt.blocks, tt.blockedBy, tt.related,
+				tt.removeParentRef, tt.removeBlocks, tt.removeBlockedBy, tt.removeRelated,
+			)
+			if err != nil {
+				t.Fatalf("buildLinksDelta: %v", err)
+			}
+			if delta == nil {
+				t.Fatal("buildLinksDelta returned a nil delta for a set link flag")
+			}
+			if !reflect.DeepEqual(delta, tt.want) {
+				t.Fatalf("buildLinksDelta delta = %#v, want %#v", delta, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitRefListNeverYieldsAnEmptySlice(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "empty literal", in: "", want: []string{""}},
+		{name: "two empty entries", in: ",", want: []string{"", ""}},
+		{name: "one ref", in: "abc4", want: []string{"abc4"}},
+		{name: "spaced refs", in: " abc4, def5 ", want: []string{"abc4", "def5"}},
+		{name: "three empty entries", in: ",,", want: []string{"", "", ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitRefList(tt.in)
+			if len(got) == 0 {
+				t.Fatal("splitRefList returned an empty slice")
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("splitRefList(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -1795,11 +1795,11 @@ func federationQuarantineSkipCmd() *cobra.Command {
 			}
 			expected := fmt.Sprintf("SKIP FEDERATION BATCH %d", id)
 			confirm, err := resolveConfirm(cmd, confirm, expected,
-				fmt.Sprintf("Type %q to skip this federation batch: ", expected), confirmPromptFull)
+				fmt.Sprintf("Type %q to skip this federation batch: ", expected))
 			if err != nil {
 				return err
 			}
-			return runFederationQuarantineSkip(cmd.Context(), cmd, id, confirm, reason)
+			return runFederationQuarantineAction(cmd.Context(), cmd, id, "skip", confirm, reason)
 		},
 	}
 	cmd.Flags().StringVar(&confirm, "confirm", "", "exact confirmation string")
@@ -1825,11 +1825,11 @@ func federationQuarantineRetryCmd() *cobra.Command {
 			}
 			expected := fmt.Sprintf("RETRY FEDERATION BATCH %d", id)
 			confirm, err := resolveConfirm(cmd, confirm, expected,
-				fmt.Sprintf("Type %q to retry this federation batch: ", expected), confirmPromptFull)
+				fmt.Sprintf("Type %q to retry this federation batch: ", expected))
 			if err != nil {
 				return err
 			}
-			return runFederationQuarantineRetry(cmd.Context(), cmd, id, confirm, reason)
+			return runFederationQuarantineAction(cmd.Context(), cmd, id, "retry", confirm, reason)
 		},
 	}
 	cmd.Flags().StringVar(&confirm, "confirm", "", "exact confirmation string")
@@ -1837,7 +1837,11 @@ func federationQuarantineRetryCmd() *cobra.Command {
 	return cmd
 }
 
-func runFederationQuarantineSkip(ctx context.Context, cmd *cobra.Command, id int64, confirm, reason string) error {
+// runFederationQuarantineAction applies one of the two operator decisions for
+// an active push quarantine. Skip advances past the rejected batch; retry
+// releases the batch without advancing the cursor so the events can be sent
+// again on the next sync.
+func runFederationQuarantineAction(ctx context.Context, cmd *cobra.Command, id int64, action, confirm, reason string) error {
 	baseURL, err := ensureDaemon(ctx)
 	if err != nil {
 		return err
@@ -1863,7 +1867,7 @@ func runFederationQuarantineSkip(ctx context.Context, cmd *cobra.Command, id int
 	}
 	actor, _ := resolveActor(ctx, flags.As, nil)
 	status, bs, err = httpDoJSONWithHeader(ctx, client, http.MethodPost,
-		fmt.Sprintf("%s/api/v1/projects/%d/federation/quarantine/%d/skip", baseURL, projectID, id),
+		fmt.Sprintf("%s/api/v1/projects/%d/federation/quarantine/%d/%s", baseURL, projectID, id, action),
 		map[string]string{"X-Kata-Confirm": confirm},
 		map[string]any{"actor": actor, "reason": reason})
 	if err != nil {
@@ -1885,66 +1889,18 @@ func runFederationQuarantineSkip(ctx context.Context, cmd *cobra.Command, id int
 		return nil
 	}
 	if mode == outputAgent {
-		_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK federation-quarantine-skip id=%d\n", id)
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK federation-quarantine-%s id=%d\n", action, id)
 		return err
 	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "quarantine #%d skipped\n", id)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "quarantine #%d %s\n", id, federationQuarantineActionResult(action))
 	return err
 }
 
-func runFederationQuarantineRetry(ctx context.Context, cmd *cobra.Command, id int64, confirm, reason string) error {
-	baseURL, err := ensureDaemon(ctx)
-	if err != nil {
-		return err
+func federationQuarantineActionResult(action string) string {
+	if action == "retry" {
+		return "released for retry"
 	}
-	client, err := httpClientFor(ctx, baseURL)
-	if err != nil {
-		return err
-	}
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status", nil)
-	if err != nil {
-		return err
-	}
-	if status >= 400 {
-		return apiErrFromBody(status, bs)
-	}
-	var body api.FederationStatusBody
-	if err := json.Unmarshal(bs, &body); err != nil {
-		return err
-	}
-	projectID, err := federationProjectForQuarantine(body, id)
-	if err != nil {
-		return err
-	}
-	actor, _ := resolveActor(ctx, flags.As, nil)
-	status, bs, err = httpDoJSONWithHeader(ctx, client, http.MethodPost,
-		fmt.Sprintf("%s/api/v1/projects/%d/federation/quarantine/%d/retry", baseURL, projectID, id),
-		map[string]string{"X-Kata-Confirm": confirm},
-		map[string]any{"actor": actor, "reason": reason})
-	if err != nil {
-		return err
-	}
-	if status >= 400 {
-		return apiErrFromBody(status, bs)
-	}
-	mode := currentOutputMode()
-	if mode == outputJSON {
-		var buf bytes.Buffer
-		if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
-			return err
-		}
-		_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
-		return err
-	}
-	if flags.Quiet {
-		return nil
-	}
-	if mode == outputAgent {
-		_, err = fmt.Fprintf(cmd.OutOrStdout(), "OK federation-quarantine-retry id=%d\n", id)
-		return err
-	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "quarantine #%d released for retry\n", id)
-	return err
+	return "skipped"
 }
 
 func federationProjectForQuarantine(body api.FederationStatusBody, id int64) (int64, error) {

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -247,6 +247,19 @@ func TestFederationQuarantineSkipCLI(t *testing.T) {
 	assert.Equal(t, q.LastEventID, binding.PushCursorEventID)
 }
 
+func TestFederationQuarantineSkipCLIAgentMode(t *testing.T) {
+	env, project := setupFederationStatusCLIState(t)
+	ctx := context.Background()
+	q, err := env.DB.ActiveFederationQuarantine(ctx, project.ID, db.FederationQuarantineDirectionPush)
+	require.NoError(t, err)
+
+	out := requireCmdOutput(t, env, "--agent", "federation", "quarantine", "skip", strconv.FormatInt(q.ID, 10),
+		"--confirm", "SKIP FEDERATION BATCH "+strconv.FormatInt(q.ID, 10),
+		"--reason", "operator accepted skip")
+
+	assert.Equal(t, fmt.Sprintf("OK federation-quarantine-skip id=%d\n", q.ID), out)
+}
+
 func TestFederationQuarantineRetryCLI(t *testing.T) {
 	env, project := setupFederationStatusCLIState(t)
 	ctx := context.Background()
@@ -270,6 +283,19 @@ func TestFederationQuarantineRetryCLI(t *testing.T) {
 		 WHERE id = ?`,
 		q.ID).Scan(&skipReason))
 	assert.Equal(t, "retry: hub upgraded", skipReason)
+}
+
+func TestFederationQuarantineRetryCLIAgentMode(t *testing.T) {
+	env, project := setupFederationStatusCLIState(t)
+	ctx := context.Background()
+	q, err := env.DB.ActiveFederationQuarantine(ctx, project.ID, db.FederationQuarantineDirectionPush)
+	require.NoError(t, err)
+
+	out := requireCmdOutput(t, env, "--agent", "federation", "quarantine", "retry", strconv.FormatInt(q.ID, 10),
+		"--confirm", "RETRY FEDERATION BATCH "+strconv.FormatInt(q.ID, 10),
+		"--reason", "hub upgraded")
+
+	assert.Equal(t, fmt.Sprintf("OK federation-quarantine-retry id=%d\n", q.ID), out)
 }
 
 func TestFederationHelpIsVisible(t *testing.T) {

--- a/cmd/kata/issue_ref_cli.go
+++ b/cmd/kata/issue_ref_cli.go
@@ -23,11 +23,11 @@ import (
 // inherits the workspace's bound project. When neither source supplies a
 // project name, the daemon is asked to resolve from the workspace's
 // .kata.toml binding via start_path.
+//
+// Destructive verbs that operate on soft-deleted issues get that tolerance
+// from their subsequent hydrateRefWithQualified call with includeDeleted=true;
+// resolving the positional ref itself needs no destructive-command option.
 func resolveIssueRefForCommand(cmd *cobra.Command, ref string) (context.Context, string, int64, resolvedIssueRef, error) {
-	return resolveIssueRefForCommandWithOptions(cmd, ref, false)
-}
-
-func resolveIssueRefForCommandWithOptions(cmd *cobra.Command, ref string, _ bool) (context.Context, string, int64, resolvedIssueRef, error) {
 	ctx := cmd.Context()
 	start, err := resolveStartPath(flags.Workspace)
 	if err != nil {
@@ -128,29 +128,12 @@ func workspaceProjectName(startPath string) string {
 	return cfg.Project.Name
 }
 
-// resolveRefToWireOpts resolves one link-flag ref string to the wire value the
-// daemon expects. Used by relationship flags on `kata edit` and `kata create`
-// so they accept the same shapes as positional issue-ref args.
+// refToWire purely parses one link-flag ref into the wire value the daemon
+// expects. The daemon owns existence, soft-delete, and idempotent-remove checks.
 //
-// flagName is folded into validation errors so the user knows which flag failed.
-//
-// currentProject is the canonical name of the project the surrounding command
-// targets (i.e. the URL issue's project for `kata edit`, the create-time project
-// for `kata create`). A qualified ref whose project segment differs from
-// currentProject is forwarded verbatim as "project#short_id" — the daemon
-// resolves link targets in the named project (storage v16, cross-project links).
-// Bare refs and same-project qualified refs are forwarded as plain short_ids or
-// ULIDs so the daemon resolves them against the URL issue's project. Pass "" to
-// skip the qualified-forward path (intended for callers that can't yet plumb the
-// canonical name).
-//
-// includeDeleted=true matches the soft-delete-tolerant lookup the daemon's
-// remove paths use. The remove flags pass true; the add flags pass false.
-func resolveRefToWireOpts(ctx context.Context, baseURL, currentProject string, projectID int64, ref, flagName string, includeDeleted bool) (string, error) {
-	_ = ctx
-	_ = baseURL
-	_ = projectID
-	_ = includeDeleted
+// When currentProject is known, a qualified ref for another project stays
+// qualified; otherwise refs use the bare wire shape.
+func refToWire(ref, flagName, currentProject string) (string, error) {
 	if strings.TrimSpace(ref) == "" {
 		return "", &cliError{
 			Message:  fmt.Sprintf("%s must not be empty", flagName),
@@ -158,64 +141,33 @@ func resolveRefToWireOpts(ctx context.Context, baseURL, currentProject string, p
 			ExitCode: ExitValidation,
 		}
 	}
-	// Pre-flight: surface a legacy numeric ref with the documented error so
-	// users see "use a short_id" instead of a daemon-side "issue not found".
-	// Pass currentProject (when known) as the workspace fallback so bare
-	// refs validate without requiring callers to plumb their own.
 	fallbackProject := currentProject
 	if fallbackProject == "" {
-		// ResolveRef rejects numerics before consulting workspaceProject,
-		// so a placeholder is safe when the caller doesn't yet plumb
-		// the canonical name.
 		fallbackProject = "anything"
 	}
 	parsed, err := ResolveRef(ref, fallbackProject)
 	if err != nil {
-		// Surface validation errors from ResolveRef (legacy numbers, bad
-		// shortid syntax) with a flag-name prefix so the user can tell
-		// which flag was malformed.
 		return "", &cliError{
 			Message:  fmt.Sprintf("%s: %s", flagName, err.Error()),
 			Kind:     kindValidation,
 			ExitCode: ExitValidation,
 		}
 	}
-	// A qualified ref ("other#abc4") names a project explicitly. Links may
-	// span projects (storage v16), and the daemon resolves link-target refs
-	// in the named project — forward the qualified form verbatim so the
-	// daemon can. Bare refs and same-project qualified refs keep the bare
-	// wire shape the daemon resolves against the URL issue's project.
-	// For ULID refs, ResolveRef sets ProjectName to the workspace fallback
-	// (same as currentProject), so parsed.ProjectName == currentProject and
-	// the condition below is false; ULID refs are forwarded bare in RefForAPI.
 	if currentProject != "" && parsed.ProjectName != "" && parsed.ProjectName != currentProject {
 		return parsed.ProjectName + "#" + parsed.RefForAPI, nil
 	}
 	return parsed.RefForAPI, nil
 }
 
-// resolveRefSliceToWire maps every entry of refs through resolveRefToWireOpts.
-// Returns the slice in the original order. Empty refs is OK (nil out, nil err).
-func resolveRefSliceToWire(ctx context.Context, baseURL, currentProject string, projectID int64, refs []string, flagName string) ([]string, error) {
-	return resolveRefSliceToWireOpts(ctx, baseURL, currentProject, projectID, refs, flagName, false, false)
-}
-
-// resolveRefSliceToWireIdempotentRemove is the variant the
-// idempotent --remove-blocks / --remove-blocked-by / --remove-related
-// flags use. In addition to soft-delete tolerance, it drops refs that
-// resolve to "issue not found" entirely.
-func resolveRefSliceToWireIdempotentRemove(ctx context.Context, baseURL, currentProject string, projectID int64, refs []string, flagName string) ([]string, error) {
-	return resolveRefSliceToWireOpts(ctx, baseURL, currentProject, projectID, refs, flagName, true, true)
-}
-
-func resolveRefSliceToWireOpts(ctx context.Context, baseURL, currentProject string, projectID int64, refs []string, flagName string, includeDeleted, tolerateNotFound bool) ([]string, error) {
-	_ = tolerateNotFound // refs are validated locally; daemon does the existence check
+// refsToWire preserves the input order and rejects the whole slice when any
+// entry is invalid.
+func refsToWire(refs []string, flagName, currentProject string) ([]string, error) {
 	if len(refs) == 0 {
 		return nil, nil
 	}
 	out := make([]string, 0, len(refs))
 	for _, r := range refs {
-		s, err := resolveRefToWireOpts(ctx, baseURL, currentProject, projectID, r, flagName, includeDeleted)
+		s, err := refToWire(r, flagName, currentProject)
 		if err != nil {
 			return nil, err
 		}
@@ -224,17 +176,14 @@ func resolveRefSliceToWireOpts(ctx context.Context, baseURL, currentProject stri
 	return out, nil
 }
 
-// resolveSingletonRefToWire resolves the StringSliceVar storage for an
-// at-most-one flag (--parent, --remove-parent) and returns the ref string
-// every entry resolves to. Rejects only when entries resolve to *different*
-// refs (after normalization), so equivalent forms — `abc4` and `kata#abc4`,
-// the same string twice — succeed.
-func resolveSingletonRefToWire(ctx context.Context, baseURL, currentProject string, projectID int64, values []string, flagName string, includeDeleted bool) (string, error) {
+// singletonRefToWire normalizes an at-most-one flag's StringSliceVar storage.
+// Equivalent repeated forms are accepted; distinct refs are rejected.
+func singletonRefToWire(values []string, flagName, currentProject string) (string, error) {
 	if len(values) == 0 {
 		return "", nil
 	}
 	first := strings.TrimSpace(values[0])
-	firstResolved, err := resolveRefToWireOpts(ctx, baseURL, currentProject, projectID, first, flagName, includeDeleted)
+	firstResolved, err := refToWire(first, flagName, currentProject)
 	if err != nil {
 		return "", err
 	}
@@ -243,7 +192,7 @@ func resolveSingletonRefToWire(ctx context.Context, baseURL, currentProject stri
 		if trimmed == first {
 			continue
 		}
-		resolved, err := resolveRefToWireOpts(ctx, baseURL, currentProject, projectID, trimmed, flagName, includeDeleted)
+		resolved, err := refToWire(trimmed, flagName, currentProject)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/kata/issue_ref_cli_test.go
+++ b/cmd/kata/issue_ref_cli_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefToWireForwardsQualifiedRefsOnlyForOtherProjects(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "bare short ID stays bare", ref: "abc4", want: "abc4"},
+		{name: "same-project qualified ref collapses", ref: "kata#abc4", want: "abc4"},
+		{name: "cross-project qualified ref stays qualified", ref: "other#abc4", want: "other#abc4"},
+		{name: "ULID stays bare", ref: "01HZNQ7VFPK1XGD8R5MABCD4EX", want: "01HZNQ7VFPK1XGD8R5MABCD4EX"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := refToWire(tt.ref, "--related", "kata")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRefToWireWithoutCurrentProjectKeepsRefsBare(t *testing.T) {
+	for _, ref := range []string{"abc4", "other#abc4"} {
+		t.Run(ref, func(t *testing.T) {
+			got, err := refToWire(ref, "--related", "")
+			require.NoError(t, err)
+			assert.Equal(t, "abc4", got)
+		})
+	}
+}
+
+func TestRefToWireRejectsEmptyAndLegacyNumericRefsWithTheFlagName(t *testing.T) {
+	for _, ref := range []string{"", "  ", "12"} {
+		t.Run(ref, func(t *testing.T) {
+			_, err := refToWire(ref, "--blocked-by", "kata")
+			var cliErr *cliError
+			require.ErrorAs(t, err, &cliErr)
+			assert.Equal(t, kindValidation, cliErr.Kind)
+			assert.Equal(t, ExitValidation, cliErr.ExitCode)
+			assert.Contains(t, cliErr.Message, "--blocked-by")
+		})
+	}
+}
+
+func TestRefsToWireKeepsOrderAndFailsTheWholeList(t *testing.T) {
+	got, err := refsToWire([]string{"other#abc4", "def5", "kata#jkm6"}, "--blocks", "kata")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"other#abc4", "def5", "jkm6"}, got)
+
+	got, err = refsToWire(nil, "--blocks", "kata")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	got, err = refsToWire([]string{"abc4", "12", "def5"}, "--blocks", "kata")
+	require.Error(t, err)
+	assert.Nil(t, got)
+}
+
+func TestSingletonRefToWireAcceptsEquivalentFormsAndRejectsDistinctOnes(t *testing.T) {
+	got, err := singletonRefToWire([]string{"abc4", "kata#abc4", "abc4"}, "--parent", "kata")
+	require.NoError(t, err)
+	assert.Equal(t, "abc4", got)
+
+	got, err = singletonRefToWire(nil, "--parent", "kata")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	_, err = singletonRefToWire([]string{"abc4", "other#abc4"}, "--parent", "kata")
+	var cliErr *cliError
+	require.ErrorAs(t, err, &cliErr)
+	assert.Equal(t, kindValidation, cliErr.Kind)
+	assert.Equal(t, ExitValidation, cliErr.ExitCode)
+	assert.Contains(t, cliErr.Message, "--parent")
+	assert.Contains(t, cliErr.Message, `"abc4"`)
+	assert.Contains(t, cliErr.Message, `"other#abc4"`)
+}
+
+func TestAddAndRemoveRefsResolveIdentically(t *testing.T) {
+	refs := []string{"abc4", "kata#def5", "other#jkm6"}
+
+	add, err := refsToWire(refs, "--related", "kata")
+	require.NoError(t, err)
+	remove, err := refsToWire(refs, "--remove-related", "kata")
+	require.NoError(t, err)
+
+	assert.Equal(t, add, remove)
+}

--- a/cmd/kata/meta.go
+++ b/cmd/kata/meta.go
@@ -93,11 +93,11 @@ func newMetaGetCmd() *cobra.Command {
 }
 
 // metaIssueWire is the minimal shared decode of the show-issue response body
-// (`{"issue": {...}}`) used by both meta and wait: short_id, status, metadata,
-// and revision are the only fields either command reads. show.go keeps its own
-// richer struct for the full `kata show` surface. Status is unused by meta but
-// carried here so waitFetchState can decode the lifecycle status through the
-// same struct instead of a second anonymous one.
+// (`{"issue": {...}}`) used by meta, wait, and the attention hook: short_id,
+// status, metadata, and revision are the only fields those consumers read.
+// show.go keeps its own richer struct for the full `kata show` surface. Status
+// is unused by meta but lets waitFetchState and liveAttnDaemon.lookup decode the
+// lifecycle status through the same struct instead of anonymous copies.
 type metaIssueWire struct {
 	ShortID  string                     `json:"short_id"`
 	Status   string                     `json:"status"`

--- a/cmd/kata/projects_purge.go
+++ b/cmd/kata/projects_purge.go
@@ -45,7 +45,7 @@ func projectsPurgeCmd() *cobra.Command {
 			}
 			expected := fmt.Sprintf("PURGE %s", project.Name)
 			confirm, err = resolveConfirm(cmd, confirm, expected,
-				fmt.Sprintf("Type %q to confirm: ", expected), confirmPromptFull)
+				fmt.Sprintf("Type %q to confirm: ", expected))
 			if err != nil {
 				return err
 			}

--- a/cmd/kata/purge.go
+++ b/cmd/kata/purge.go
@@ -28,7 +28,7 @@ func newPurgeCmd() *cobra.Command {
 					Kind:    kindValidation, ExitCode: ExitValidation,
 				}
 			}
-			ctx, baseURL, pid, issue, err := resolveIssueRefForCommandWithOptions(cmd, args[0], true)
+			ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, args[0])
 			if err != nil {
 				return err
 			}
@@ -40,7 +40,7 @@ func newPurgeCmd() *cobra.Command {
 			}
 			expected := fmt.Sprintf("PURGE %s", issue.QualifiedID)
 			confirm, err = resolveConfirm(cmd, confirm, expected,
-				fmt.Sprintf("Type %q to confirm: ", expected), confirmPromptFull)
+				fmt.Sprintf("Type %q to confirm: ", expected))
 			if err != nil {
 				return err
 			}

--- a/cmd/kata/restore.go
+++ b/cmd/kata/restore.go
@@ -22,7 +22,7 @@ func newRestoreCmd() *cobra.Command {
 		Short: "restore a soft-deleted issue",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, baseURL, pid, issue, err := resolveIssueRefForCommandWithOptions(cmd, args[0], true)
+			ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, args[0])
 			if err != nil {
 				return err
 			}

--- a/internal/config/federation_credentials.go
+++ b/internal/config/federation_credentials.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -489,6 +490,7 @@ func ReplaceFederationCredential(replacement FederationCredentialReplacement) er
 	if err != nil {
 		return err
 	}
+	before := maps.Clone(creds.Projects)
 	current, found := creds.Projects[projectUID]
 	if found && current == replacement.Replacement {
 		return nil
@@ -500,6 +502,9 @@ func ReplaceFederationCredential(replacement FederationCredentialReplacement) er
 		)
 	}
 	creds.Projects[projectUID] = replacement.Replacement
+	if err := federationCredentialLeaveConflict(before, creds); err != nil {
+		return err
+	}
 	return writeFederationCredentials(creds)
 }
 
@@ -552,6 +557,29 @@ func RekeyFederationCredential(rekey FederationCredentialRekey) error {
 	})
 }
 
+// federationCredentialLeaveConflict rejects persisting a credential that names
+// a hub enrollment to revoke while recording no leave in progress. Entries this
+// update did not change are left alone so a contradictory pair from an older
+// build cannot block an unrelated write.
+func federationCredentialLeaveConflict(
+	before map[string]FederationCredential,
+	after *FederationCredentials,
+) error {
+	for projectUID, credential := range after.Projects {
+		if credential.PendingEnrollmentID == 0 || credential.LeavePending {
+			continue
+		}
+		if previous, found := before[projectUID]; found && previous == credential {
+			continue
+		}
+		return fmt.Errorf(
+			"%w: %s records pending enrollment %d without a pending leave",
+			ErrFederationCredentialConflict, projectUID, credential.PendingEnrollmentID,
+		)
+	}
+	return nil
+}
+
 func updateFederationCredentials(update func(*FederationCredentials) error) error {
 	federationCredentialsMu.Lock()
 	defer federationCredentialsMu.Unlock()
@@ -560,7 +588,11 @@ func updateFederationCredentials(update func(*FederationCredentials) error) erro
 	if err != nil {
 		return err
 	}
+	before := maps.Clone(creds.Projects)
 	if err := update(creds); err != nil {
+		return err
+	}
+	if err := federationCredentialLeaveConflict(before, creds); err != nil {
 		return err
 	}
 	return writeFederationCredentials(creds)

--- a/internal/config/federation_credentials_test.go
+++ b/internal/config/federation_credentials_test.go
@@ -90,6 +90,106 @@ func TestWriteFederationCredentialRoundTrips(t *testing.T) {
 	assert.True(t, got.AllowInsecure)
 }
 
+func TestWriteFederationCredentialRejectsPendingEnrollmentWithoutPendingLeave(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	const projectUID = "01EXAMPLEPROJECT0000000000"
+	settled := config.FederationCredential{
+		HubURL: "https://daemon.example", HubProjectID: 42, Token: "settled-token",
+	}
+	require.NoError(t, config.WriteFederationCredential(projectUID, settled))
+
+	contradictory := settled
+	contradictory.PendingEnrollmentID = 7
+	err := config.WriteFederationCredential(projectUID, contradictory)
+
+	require.ErrorIs(t, err, config.ErrFederationCredentialConflict)
+	assert.ErrorContains(t, err, projectUID)
+	assert.ErrorContains(t, err, "7")
+	credentials, readErr := config.ReadFederationCredentials()
+	require.NoError(t, readErr)
+	assert.Equal(t, settled, credentials.Projects[projectUID])
+}
+
+func TestWriteFederationCredentialAcceptsPendingEnrollmentWithPendingLeave(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	const projectUID = "01EXAMPLEPROJECT0000000000"
+	want := config.FederationCredential{
+		HubURL: "https://daemon.example", HubProjectID: 42, Token: "pending-token",
+		LeavePending: true, PendingEnrollmentID: 7,
+	}
+
+	require.NoError(t, config.WriteFederationCredential(projectUID, want))
+
+	credentials, err := config.ReadFederationCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, want, credentials.Projects[projectUID])
+}
+
+func TestWriteFederationCredentialAllowsUnchangedLegacyConflictDuringUnrelatedWrite(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	const (
+		legacyUID = "01LEGACYPROJECT00000000000"
+		otherUID  = "01OTHERPROJECT000000000000"
+	)
+	path := filepath.Join(home, "credentials.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[projects."01LEGACYPROJECT00000000000"]
+hub_url = "https://legacy-daemon.example"
+hub_project_id = 41
+token = "legacy-token"
+pending_enrollment_id = 7
+`), 0o600))
+	legacy := config.FederationCredential{
+		HubURL: "https://legacy-daemon.example", HubProjectID: 41,
+		Token: "legacy-token", PendingEnrollmentID: 7,
+	}
+	other := config.FederationCredential{
+		HubURL: "https://daemon.example", HubProjectID: 42, Token: "other-token",
+	}
+
+	require.NoError(t, config.WriteFederationCredential(otherUID, other))
+
+	credentials, err := config.ReadFederationCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, legacy, credentials.Projects[legacyUID])
+	assert.Equal(t, other, credentials.Projects[otherUID])
+}
+
+func TestReplaceFederationCredentialRejectsChangedLegacyLeaveConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	const projectUID = "01LEGACYPROJECT00000000000"
+	path := filepath.Join(home, "credentials.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[projects."01LEGACYPROJECT00000000000"]
+hub_url = "https://old-daemon.example"
+hub_project_id = 42
+token = "legacy-token"
+pending_enrollment_id = 7
+`), 0o600))
+	current := config.FederationCredential{
+		HubURL: "https://old-daemon.example", HubProjectID: 42,
+		Token: "legacy-token", PendingEnrollmentID: 7,
+	}
+	replacement := current
+	replacement.HubURL = "http://new-daemon.example"
+	replacement.AllowInsecure = true
+
+	err := config.ReplaceFederationCredential(config.FederationCredentialReplacement{
+		ProjectUID:  projectUID,
+		Expected:    current,
+		Replacement: replacement,
+	})
+
+	require.ErrorIs(t, err, config.ErrFederationCredentialConflict)
+	assert.ErrorContains(t, err, projectUID)
+	assert.ErrorContains(t, err, "7")
+	credentials, readErr := config.ReadFederationCredentials()
+	require.NoError(t, readErr)
+	assert.Equal(t, current, credentials.Projects[projectUID])
+}
+
 func TestReadFederationCredentialWithoutCapabilitiesDefaultsEmpty(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)

--- a/internal/db/sqlitestore/claims.go
+++ b/internal/db/sqlitestore/claims.go
@@ -39,32 +39,33 @@ func (d *Store) AcquireClaim(ctx context.Context, p db.AcquireClaimParams) (db.L
 		expiresAt = &expires
 	}
 
-	var out db.LeaseResult
-	err := d.withImmediateClaimTx(ctx, func(conn *sql.Conn) error {
+	return d.withLeaseTx(ctx, func(conn *sql.Conn) (leaseOutcome, error) {
+		var out leaseOutcome
 		issue, projectName, err := resolveClaimIssueTx(ctx, conn, p.ProjectID, p.IssueRef)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
 		expiredEvents, err := d.expireTimedClaimsTx(ctx, conn, now, 0)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out.Events = append(out.Events, expiredEvents...)
+		out.Result.Events = append(out.Result.Events, expiredEvents...)
 		live, err := liveClaimForIssueTx(ctx, conn, issue.UID)
 		if err == nil {
-			out = resultForClaimWithEvents(live, sameClaimPrincipal(live, p.Principal), out.Events)
-			if sameClaimPrincipal(live, p.Principal) {
-				return nil
+			same := sameClaimPrincipal(live, p.Principal)
+			out.Result = resultForClaimWithEvents(live, same, out.Result.Events)
+			if same {
+				return out, nil
 			}
-			return db.ErrClaimDenied
+			return out, db.ErrClaimDenied
 		}
 		if !errors.Is(err, db.ErrNotFound) {
-			return err
+			return leaseOutcome{}, err
 		}
 
 		claimUID, err := katauid.New()
 		if err != nil {
-			return fmt.Errorf("generate claim uid: %w", err)
+			return leaseOutcome{}, fmt.Errorf("generate claim uid: %w", err)
 		}
 		acquiredAt := now.UTC().Format(sqliteTimeFormat)
 		var expiresValue any
@@ -81,28 +82,27 @@ func (d *Store) AcquireClaim(ctx context.Context, p db.AcquireClaimParams) (db.L
 			p.Principal.HolderInstanceUID, p.Principal.ClientKind, p.Purpose,
 			p.ClaimKind, acquiredAt, expiresValue, acquiredAt)
 		if err != nil {
-			return fmt.Errorf("insert issue claim: %w", err)
+			return leaseOutcome{}, fmt.Errorf("insert issue claim: %w", err)
 		}
 		id, err := res.LastInsertId()
 		if err != nil {
-			return fmt.Errorf("issue claim last id: %w", err)
+			return leaseOutcome{}, fmt.Errorf("issue claim last id: %w", err)
 		}
 		claim, err := claimByIDTx(ctx, conn, id)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
 		evt, err := d.insertClaimEventTx(ctx, conn, claimEventInput{
 			ProjectID: issue.ProjectID, ProjectName: projectName, IssueID: issue.ID,
 			Type: "claim.acquired", Actor: p.Principal.Holder, Claim: claim,
 		})
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out = resultForClaimWithEvents(claim, true, out.Events)
-		out.Event = &evt
-		return nil
+		out.Result = resultForClaimWithEvents(claim, true, out.Result.Events)
+		out.Result.Event = &evt
+		return out, nil
 	})
-	return out, err
 }
 
 // RenewClaim extends a live timed claim held by the same principal.
@@ -115,44 +115,43 @@ func (d *Store) RenewClaim(ctx context.Context, p db.RenewClaimParams) (db.Lease
 		return db.LeaseResult{}, err
 	}
 
-	var out db.LeaseResult
-	expiredOutcome := false
-	err := d.withImmediateClaimTx(ctx, func(conn *sql.Conn) error {
+	return d.withLeaseTx(ctx, func(conn *sql.Conn) (leaseOutcome, error) {
+		var out leaseOutcome
 		issue, _, err := resolveClaimIssueTx(ctx, conn, p.ProjectID, p.IssueRef)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
 		liveBefore, err := liveClaimForIssueTx(ctx, conn, issue.UID)
 		if err != nil && !errors.Is(err, db.ErrNotFound) {
-			return err
+			return leaseOutcome{}, err
 		}
 		expiredEvents, err := d.expireTimedClaimsTx(ctx, conn, now, 0)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out.Events = append(out.Events, expiredEvents...)
+		out.Result.Events = append(out.Result.Events, expiredEvents...)
 		live, err := liveClaimForIssueTx(ctx, conn, issue.UID)
 		if errors.Is(err, db.ErrNotFound) {
 			if claimExpiredThisPass(liveBefore, p.Principal, now) {
 				expired, expiredErr := claimByIDTx(ctx, conn, liveBefore.ID)
 				if expiredErr != nil {
-					return expiredErr
+					return leaseOutcome{}, expiredErr
 				}
-				out = resultForClaimWithEvents(expired, false, out.Events)
-				expiredOutcome = true
-				return nil
+				out.Result = resultForClaimWithEvents(expired, false, out.Result.Events)
+				out.CommitErr = db.ErrClaimExpired
+				return out, nil
 			}
-			return db.ErrClaimNotHeld
+			return out, db.ErrClaimNotHeld
 		}
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out = resultForClaimWithEvents(live, sameClaimPrincipal(live, p.Principal), out.Events)
+		out.Result = resultForClaimWithEvents(live, sameClaimPrincipal(live, p.Principal), out.Result.Events)
 		if !sameClaimPrincipal(live, p.Principal) {
-			return db.ErrClaimNotHeld
+			return out, db.ErrClaimNotHeld
 		}
 		if live.ClaimKind != "timed" {
-			return fmt.Errorf("%w: hard claims cannot be renewed", db.ErrClaimValidation)
+			return out, fmt.Errorf("%w: hard claims cannot be renewed", db.ErrClaimValidation)
 		}
 		expiresAt := now.Add(p.TTL).UTC().Format(sqliteTimeFormat)
 		if _, err := conn.ExecContext(ctx, `
@@ -160,19 +159,15 @@ func (d *Store) RenewClaim(ctx context.Context, p db.RenewClaimParams) (db.Lease
 			   SET expires_at = ?, revision = revision + 1, updated_at = ?
 			 WHERE id = ?`,
 			expiresAt, now.UTC().Format(sqliteTimeFormat), live.ID); err != nil {
-			return fmt.Errorf("renew issue claim: %w", err)
+			return leaseOutcome{}, fmt.Errorf("renew issue claim: %w", err)
 		}
 		renewed, err := claimByIDTx(ctx, conn, live.ID)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out = resultForClaimWithEvents(renewed, true, out.Events)
-		return nil
+		out.Result = resultForClaimWithEvents(renewed, true, out.Result.Events)
+		return out, nil
 	})
-	if err == nil && expiredOutcome {
-		err = db.ErrClaimExpired
-	}
-	return out, err
 }
 
 // ReleaseClaim releases a live claim only when the requester is the holder.
@@ -182,55 +177,50 @@ func (d *Store) ReleaseClaim(ctx context.Context, p db.ReleaseClaimParams) (db.L
 		return db.LeaseResult{}, err
 	}
 
-	var out db.LeaseResult
-	expiredOutcome := false
-	err := d.withImmediateClaimTx(ctx, func(conn *sql.Conn) error {
+	return d.withLeaseTx(ctx, func(conn *sql.Conn) (leaseOutcome, error) {
+		var out leaseOutcome
 		issue, projectName, err := resolveClaimIssueTx(ctx, conn, p.ProjectID, p.IssueRef)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
 		liveBefore, err := liveClaimForIssueTx(ctx, conn, issue.UID)
 		if err != nil && !errors.Is(err, db.ErrNotFound) {
-			return err
+			return leaseOutcome{}, err
 		}
 		expiredEvents, err := d.expireTimedClaimsTx(ctx, conn, now, 0)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out.Events = append(out.Events, expiredEvents...)
+		out.Result.Events = append(out.Result.Events, expiredEvents...)
 		live, err := liveClaimForIssueTx(ctx, conn, issue.UID)
 		if errors.Is(err, db.ErrNotFound) {
 			if claimExpiredThisPass(liveBefore, p.Principal, now) {
 				expired, expiredErr := claimByIDTx(ctx, conn, liveBefore.ID)
 				if expiredErr != nil {
-					return expiredErr
+					return leaseOutcome{}, expiredErr
 				}
-				out = resultForClaimWithEvents(expired, false, out.Events)
-				expiredOutcome = true
-				return nil
+				out.Result = resultForClaimWithEvents(expired, false, out.Result.Events)
+				out.CommitErr = db.ErrClaimExpired
+				return out, nil
 			}
-			return db.ErrClaimNotHeld
+			return out, db.ErrClaimNotHeld
 		}
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out = resultForClaimWithEvents(live, sameClaimPrincipal(live, p.Principal), out.Events)
+		out.Result = resultForClaimWithEvents(live, sameClaimPrincipal(live, p.Principal), out.Result.Events)
 		if !sameClaimPrincipal(live, p.Principal) {
-			return db.ErrClaimNotHeld
+			return out, db.ErrClaimNotHeld
 		}
 		released, evt, err := d.releaseClaimTx(ctx, conn, live, issue.ID, projectName,
 			"claim.released", p.Principal.Holder, p.Reason, now)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out = resultForClaimWithEvents(released, true, out.Events)
-		out.Event = &evt
-		return nil
+		out.Result = resultForClaimWithEvents(released, true, out.Result.Events)
+		out.Result.Event = &evt
+		return out, nil
 	})
-	if err == nil && expiredOutcome {
-		err = db.ErrClaimExpired
-	}
-	return out, err
 }
 
 // ForceReleaseClaim releases any live claim for the issue. Authorization is
@@ -241,51 +231,46 @@ func (d *Store) ForceReleaseClaim(ctx context.Context, p db.ForceReleaseClaimPar
 		return db.LeaseResult{}, fmt.Errorf("%w: actor is required", db.ErrClaimValidation)
 	}
 
-	var out db.LeaseResult
-	expiredOutcome := false
-	err := d.withImmediateClaimTx(ctx, func(conn *sql.Conn) error {
+	return d.withLeaseTx(ctx, func(conn *sql.Conn) (leaseOutcome, error) {
+		var out leaseOutcome
 		issue, projectName, err := resolveClaimIssueTx(ctx, conn, p.ProjectID, p.IssueRef)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
 		liveBefore, err := liveClaimForIssueTx(ctx, conn, issue.UID)
 		if err != nil && !errors.Is(err, db.ErrNotFound) {
-			return err
+			return leaseOutcome{}, err
 		}
 		expiredEvents, err := d.expireTimedClaimsTx(ctx, conn, now, 0)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out.Events = append(out.Events, expiredEvents...)
+		out.Result.Events = append(out.Result.Events, expiredEvents...)
 		live, err := liveClaimForIssueTx(ctx, conn, issue.UID)
 		if errors.Is(err, db.ErrNotFound) {
 			if claimTimedExpiredThisPass(liveBefore, now) {
 				expired, expiredErr := claimByIDTx(ctx, conn, liveBefore.ID)
 				if expiredErr != nil {
-					return expiredErr
+					return leaseOutcome{}, expiredErr
 				}
-				out = resultForClaimWithEvents(expired, false, out.Events)
-				expiredOutcome = true
-				return nil
+				out.Result = resultForClaimWithEvents(expired, false, out.Result.Events)
+				out.CommitErr = db.ErrClaimExpired
+				return out, nil
 			}
-			return db.ErrClaimNotHeld
+			return out, db.ErrClaimNotHeld
 		}
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
 		released, evt, err := d.releaseClaimTx(ctx, conn, live, issue.ID, projectName,
 			"claim.force_released", p.Actor, p.Reason, now)
 		if err != nil {
-			return err
+			return leaseOutcome{}, err
 		}
-		out = resultForClaimWithEvents(released, true, out.Events)
-		out.Event = &evt
-		return nil
+		out.Result = resultForClaimWithEvents(released, true, out.Result.Events)
+		out.Result.Event = &evt
+		return out, nil
 	})
-	if err == nil && expiredOutcome {
-		err = db.ErrClaimExpired
-	}
-	return out, err
 }
 
 // ClaimStatus returns the live claim after expiring stale timed claims.
@@ -993,33 +978,80 @@ func assertSingleLiveClaimTx(ctx context.Context, tx claimStore, issueUID string
 	return nil
 }
 
-func (d *Store) withImmediateClaimTx(ctx context.Context, fn func(*sql.Conn) error) error {
-	return d.RetryTransient(ctx, func() error {
-		conn, err := d.Conn(ctx)
-		if err != nil {
-			return fmt.Errorf("acquire conn: %w", err)
-		}
-		defer func() { _ = conn.Close() }()
+// commitClaimTx is a package-local test seam for forcing a transient failure
+// at the claim transaction's commit point; production commits directly.
+var commitClaimTx = func(ctx context.Context, conn *sql.Conn) error {
+	_, err := conn.ExecContext(ctx, "COMMIT")
+	return err
+}
 
-		if err := d.beginImmediateTransaction(ctx, conn); err != nil {
-			return fmt.Errorf("begin immediate: %w", err)
-		}
-		committed := false
-		defer func() {
-			if !committed {
-				_, _ = conn.ExecContext(context.WithoutCancel(ctx), "ROLLBACK")
-			}
-		}()
+// leaseOutcome is one lease attempt's result. A non-nil CommitErr is returned
+// to the caller after the transaction commits: the expired-during-this-pass
+// paths must persist their expiry writes while still failing the request.
+// Because each attempt produces a fresh value, a rolled-back attempt can
+// neither contribute events to nor stick an error onto the attempt that wins.
+type leaseOutcome struct {
+	Result    db.LeaseResult
+	CommitErr error
+}
 
-		if err := fn(conn); err != nil {
-			return err
-		}
-		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
-			return fmt.Errorf("commit: %w", err)
-		}
-		committed = true
-		return nil
+// withLeaseTx runs fn under the same RetryTransient + BEGIN IMMEDIATE
+// discipline as withImmediateClaimTx, taking the whole outcome as fn's return
+// value instead of letting fn write to captured state. fn's outcome is kept
+// even when fn returns an error, so the denied/not-held paths can report the
+// current holder alongside their sentinel error.
+func (d *Store) withLeaseTx(
+	ctx context.Context,
+	fn func(*sql.Conn) (leaseOutcome, error),
+) (db.LeaseResult, error) {
+	var out leaseOutcome
+	err := d.RetryTransient(ctx, func() error {
+		attempt, attemptErr := d.leaseAttempt(ctx, fn)
+		out = attempt
+		return attemptErr
 	})
+	if err != nil {
+		return out.Result, err
+	}
+	return out.Result, out.CommitErr
+}
+
+func (d *Store) leaseAttempt(
+	ctx context.Context,
+	fn func(*sql.Conn) (leaseOutcome, error),
+) (leaseOutcome, error) {
+	conn, err := d.Conn(ctx)
+	if err != nil {
+		return leaseOutcome{}, fmt.Errorf("acquire conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := d.beginImmediateTransaction(ctx, conn); err != nil {
+		return leaseOutcome{}, fmt.Errorf("begin immediate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.WithoutCancel(ctx), "ROLLBACK")
+		}
+	}()
+
+	out, err := fn(conn)
+	if err != nil {
+		return out, err
+	}
+	if err := commitClaimTx(ctx, conn); err != nil {
+		return out, fmt.Errorf("commit: %w", err)
+	}
+	committed = true
+	return out, nil
+}
+
+func (d *Store) withImmediateClaimTx(ctx context.Context, fn func(*sql.Conn) error) error {
+	_, err := d.withLeaseTx(ctx, func(conn *sql.Conn) (leaseOutcome, error) {
+		return leaseOutcome{}, fn(conn)
+	})
+	return err
 }
 
 func (d *Store) releaseClaimTx(

--- a/internal/db/sqlitestore/claims_retry_test.go
+++ b/internal/db/sqlitestore/claims_retry_test.go
@@ -1,0 +1,147 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	katauid "go.kenn.io/kata/internal/uid"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+func newLeaseRetryStore(t *testing.T) (*Store, db.Project, db.Issue) {
+	t.Helper()
+	ctx := context.Background()
+	t.Setenv("KATA_HOME", t.TempDir())
+	d, err := Open(ctx, filepath.Join(t.TempDir(), "kata.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = d.Close() })
+
+	project, err := d.CreateProject(ctx, "spoke-project")
+	require.NoError(t, err)
+	issue, _, err := d.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "lease retry subject", Author: "tester",
+	})
+	require.NoError(t, err)
+	return d, project, issue
+}
+
+func newLeasePrincipal(t *testing.T, holder string) db.ClaimPrincipal {
+	t.Helper()
+	instanceUID, err := katauid.New()
+	require.NoError(t, err)
+	return db.ClaimPrincipal{
+		HolderInstanceUID: instanceUID, Holder: holder, ClientKind: "agent",
+	}
+}
+
+func countClaimExpired(events []db.Event) int {
+	n := 0
+	for _, evt := range events {
+		if evt.Type == "claim.expired" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestAcquireClaimRetryDoesNotDuplicateExpiryEvents pins that a lease attempt
+// rolled back by a transient failure contributes none of its events to the
+// result. The expiry events of a rolled-back attempt were never committed, so
+// broadcasting them would emit phantom SSE frames and phantom hook deliveries.
+func TestAcquireClaimRetryDoesNotDuplicateExpiryEvents(t *testing.T) {
+	ctx := context.Background()
+	d, project, issue := newLeaseRetryStore(t)
+	start := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+
+	_, err := d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: project.ID, IssueRef: issue.ShortID,
+		Principal: newLeasePrincipal(t, "holder-a"),
+		ClaimKind: "timed", TTL: time.Minute, Now: start,
+	})
+	require.NoError(t, err)
+
+	original := commitClaimTx
+	commits := 0
+	commitClaimTx = func(ctx context.Context, conn *sql.Conn) error {
+		commits++
+		if commits == 1 {
+			return codedSQLiteErr(sqlite3.SQLITE_BUSY)
+		}
+		return original(ctx, conn)
+	}
+	t.Cleanup(func() { commitClaimTx = original })
+
+	result, err := d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: project.ID, IssueRef: issue.ShortID,
+		Principal: newLeasePrincipal(t, "holder-b"),
+		ClaimKind: "hard", Now: start.Add(2 * time.Minute),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, commits, "the busy commit must have forced exactly one retry")
+	assert.Equal(t, 1, countClaimExpired(result.Events),
+		"the rolled-back attempt's claim.expired event must not survive into the result")
+
+	var expiredRows int
+	require.NoError(t, d.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM events WHERE project_id = ? AND type = 'claim.expired'`,
+		project.ID).Scan(&expiredRows))
+	assert.Equal(t, 1, expiredRows, "only the committed attempt's expiry may persist")
+}
+
+// TestRenewClaimRetriedIntoSuccessDoesNotReturnExpired pins that the
+// "committed but failed" signal is per-attempt. An attempt that saw the claim
+// expire, then lost its commit to a busy lock and retried into a clean renew,
+// must report success.
+func TestRenewClaimRetriedIntoSuccessDoesNotReturnExpired(t *testing.T) {
+	ctx := context.Background()
+	d, project, issue := newLeaseRetryStore(t)
+	start := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	holder := newLeasePrincipal(t, "holder-a")
+
+	_, err := d.AcquireClaim(ctx, db.AcquireClaimParams{
+		ProjectID: project.ID, IssueRef: issue.ShortID,
+		Principal: holder, ClaimKind: "timed", TTL: time.Minute, Now: start,
+	})
+	require.NoError(t, err)
+
+	original := commitClaimTx
+	commits := 0
+	commitClaimTx = func(ctx context.Context, conn *sql.Conn) error {
+		commits++
+		if commits > 1 {
+			return original(ctx, conn)
+		}
+		// End the failing attempt here so the follow-up write lands outside
+		// it, push the expiry out of reach, then report a busy condition so
+		// RetryTransient re-runs the closure against the refreshed row.
+		if _, err := conn.ExecContext(ctx, "ROLLBACK"); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx,
+			`UPDATE issue_claims SET expires_at = ? WHERE issue_id = ? AND released_at IS NULL`,
+			start.Add(time.Hour).UTC().Format(sqliteTimeFormat), issue.ID); err != nil {
+			return err
+		}
+		return codedSQLiteErr(sqlite3.SQLITE_BUSY)
+	}
+	t.Cleanup(func() { commitClaimTx = original })
+
+	result, err := d.RenewClaim(ctx, db.RenewClaimParams{
+		ProjectID: project.ID, IssueRef: issue.ShortID,
+		Principal: holder, TTL: time.Minute, Now: start.Add(2 * time.Minute),
+	})
+
+	require.NoError(t, err,
+		"a renew retried into a clean success must not return the rolled-back attempt's ErrClaimExpired")
+	require.Equal(t, 2, commits, "the busy commit must have forced exactly one retry")
+	assert.True(t, result.Granted)
+	assert.Zero(t, countClaimExpired(result.Events),
+		"the rolled-back attempt's expiry event must not survive into the result")
+}

--- a/internal/hooks/dispatcher.go
+++ b/internal/hooks/dispatcher.go
@@ -474,7 +474,7 @@ func (d *Dispatcher) runDeps() runDeps {
 			// paths that bypass AppendRun.
 			d.active.Delete(groupKey{eventID: r.EventID, hookIndex: r.HookIndex})
 			d.appender.Append(r)
-			d.pruner.AddRun(r.EventID, r.HookIndex, r.StdoutBytes, r.StderrBytes)
+			d.pruner.AddRun(r.StdoutBytes, r.StderrBytes)
 		},
 		LogWorkingDirMissing: d.maybeLogWorkingDirMissing,
 	}

--- a/internal/hooks/prune.go
+++ b/internal/hooks/prune.go
@@ -78,7 +78,7 @@ func (p *pruner) Total() int64 {
 
 // AddRun adds the byte counts produced by one finished run to the
 // running total and, if over cap, triggers MaybeSweep.
-func (p *pruner) AddRun(_ int64, _ int, outBytes, errBytes int64) {
+func (p *pruner) AddRun(outBytes, errBytes int64) {
 	p.mu.Lock()
 	p.total += outBytes + errBytes
 	over := p.total > p.capBytes
@@ -97,8 +97,6 @@ type groupInfo struct {
 	key     groupKey
 	outPath string
 	errPath string
-	outSize int64
-	errSize int64
 }
 
 // MaybeSweep is a no-op if total <= cap. Otherwise it rescans the dir,
@@ -143,8 +141,8 @@ func (p *pruner) MaybeSweep() {
 // holds p.mu so total accounting stays consistent. Missing files are
 // silent (already gone is fine); other errors are logged.
 func (p *pruner) deleteGroupLocked(g groupInfo) {
-	p.removeStreamLocked(g.outPath, g.outSize)
-	p.removeStreamLocked(g.errPath, g.errSize)
+	p.removeStreamLocked(g.outPath)
+	p.removeStreamLocked(g.errPath)
 }
 
 // removeStreamLocked removes one captured stream file and decrements
@@ -153,7 +151,7 @@ func (p *pruner) deleteGroupLocked(g groupInfo) {
 // double-subtract bytes already removed by a concurrent sweep:
 // ErrNotExist short-circuits with no decrement, and a successful
 // remove subtracts whatever the file weighed at the moment we owned it.
-func (p *pruner) removeStreamLocked(path string, _ int64) {
+func (p *pruner) removeStreamLocked(path string) {
 	if path == "" {
 		return
 	}
@@ -230,11 +228,7 @@ func scanGroups(dir string) ([]groupInfo, error) {
 		if !ok {
 			continue
 		}
-		info, err := e.Info()
-		if err != nil {
-			continue
-		}
-		recordEntry(byKey, dir, e.Name(), key, stream, info.Size())
+		recordEntry(byKey, dir, e.Name(), key, stream)
 	}
 	out := make([]groupInfo, 0, len(byKey))
 	for _, g := range byKey {
@@ -243,7 +237,7 @@ func scanGroups(dir string) ([]groupInfo, error) {
 	return out, nil
 }
 
-func recordEntry(byKey map[groupKey]*groupInfo, dir, name string, k groupKey, stream string, size int64) {
+func recordEntry(byKey map[groupKey]*groupInfo, dir, name string, k groupKey, stream string) {
 	g := byKey[k]
 	if g == nil {
 		g = &groupInfo{key: k}
@@ -252,9 +246,7 @@ func recordEntry(byKey map[groupKey]*groupInfo, dir, name string, k groupKey, st
 	full := filepath.Join(dir, name)
 	if stream == "out" {
 		g.outPath = full
-		g.outSize = size
 	} else {
 		g.errPath = full
-		g.errSize = size
 	}
 }

--- a/internal/hooks/prune_test.go
+++ b/internal/hooks/prune_test.go
@@ -56,9 +56,9 @@ func TestPrune_AddAfterRun_TriggersSweep(t *testing.T) {
 	dir := t.TempDir()
 	p := setupSeededPruner(t, dir, 100)
 	writeHookLogs(t, dir, 1, 0, 80, 0)
-	p.AddRun(1, 0, 80, 0)
+	p.AddRun(80, 0)
 	writeHookLogs(t, dir, 2, 0, 80, 0)
-	p.AddRun(2, 0, 80, 0)
+	p.AddRun(80, 0)
 	// Total now 160 over cap 100 -> after second AddRun, sweep should run
 	// and delete oldest (1.0) leaving 80.
 	assertPruned(t, filepath.Join(dir, "1.0.out"))
@@ -95,13 +95,41 @@ func TestPrune_StaleScan_NoDoubleDecrement(t *testing.T) {
 	stale := groupInfo{
 		key:     groupKey{eventID: 999, hookIndex: 0},
 		outPath: filepath.Join(dir, "999.0.out"),
-		outSize: 1234,
 	}
 	p.mu.Lock()
-	p.removeStreamLocked(stale.outPath, stale.outSize)
+	p.removeStreamLocked(stale.outPath)
 	p.mu.Unlock()
 	if got := p.Total(); got != startTotal {
 		t.Fatalf("stale missing-file delete decremented total: %d -> %d", startTotal, got)
+	}
+}
+
+// TestPrune_GrownStream_DecrementsFinalOnDiskSize pins that the size a
+// deletion subtracts is the one read under p.mu, not the one observed during
+// the scan. A worker that is still writing when scanGroups runs must not
+// leave p.total permanently above the bytes actually on disk.
+func TestPrune_GrownStream_DecrementsFinalOnDiskSize(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "1.0.out"), 100)
+	p := setupSeededPruner(t, dir, 1024)
+
+	groups, err := scanGroups(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("scanGroups returned %d groups, want 1", len(groups))
+	}
+	mustWrite(t, filepath.Join(dir, "1.0.out"), 250)
+
+	p.mu.Lock()
+	p.total = 250
+	p.deleteGroupLocked(groups[0])
+	total := p.total
+	p.mu.Unlock()
+
+	if total != 0 {
+		t.Fatalf("total after deleting a grown stream = %d, want 0", total)
 	}
 }
 

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -203,10 +203,10 @@ func waitForCompletion(tree *processtree.Tree, timeout time.Duration, shutdown <
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
-	result, exitCode, action := selectCompletion(doneCh, timer.C, shutdown)
+	action, waitErr := selectCompletion(doneCh, timer.C, shutdown)
 	switch action {
 	case completionDone:
-		return result, exitCode
+		return "ok", exitCodeOf(waitErr)
 	case completionTimeout:
 		killTreeWithGrace(tree, deps.GraceWindow, deps.DaemonLog)
 		w := <-doneCh
@@ -224,32 +224,29 @@ func selectCompletion(
 	doneCh <-chan error,
 	timeout <-chan time.Time,
 	shutdown <-chan struct{},
-) (result string, exitCode int, action completionAction) {
-	if result, exitCode, ok := pollCompletion(doneCh); ok {
-		return result, exitCode, completionDone
-	}
+) (completionAction, error) {
 	select {
 	case e := <-doneCh:
-		return "ok", exitCodeOf(e), completionDone
+		return completionDone, e
 	case <-timeout:
-		if result, exitCode, ok := pollCompletion(doneCh); ok {
-			return result, exitCode, completionDone
+		if done, waitErr := pollCompletion(doneCh); done {
+			return completionDone, waitErr
 		}
-		return "timed_out", -1, completionTimeout
+		return completionTimeout, nil
 	case <-shutdown:
-		if result, exitCode, ok := pollCompletion(doneCh); ok {
-			return result, exitCode, completionDone
+		if done, waitErr := pollCompletion(doneCh); done {
+			return completionDone, waitErr
 		}
-		return "daemon_shutdown", -1, completionShutdown
+		return completionShutdown, nil
 	}
 }
 
-func pollCompletion(doneCh <-chan error) (result string, exitCode int, ok bool) {
+func pollCompletion(doneCh <-chan error) (done bool, waitErr error) {
 	select {
 	case e := <-doneCh:
-		return "ok", exitCodeOf(e), true
+		return true, e
 	default:
-		return "", 0, false
+		return false, nil
 	}
 }
 

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -260,10 +260,23 @@ func TestCompletionSelectPrefersDoneOverExpiredTimeout(t *testing.T) {
 	expired := make(chan time.Time, 1)
 	expired <- time.Now()
 
-	result, exitCode, action := selectCompletion(done, expired, make(chan struct{}))
+	action, waitErr := selectCompletion(done, expired, make(chan struct{}))
 
-	if result != "ok" || exitCode != 0 || action != completionDone {
-		t.Fatalf("got result=%q exit=%d action=%v, want ok/0/done", result, exitCode, action)
+	if action != completionDone || waitErr != nil {
+		t.Fatalf("got action=%v waitErr=%v, want done/nil", action, waitErr)
+	}
+}
+
+func TestCompletionSelectPrefersDoneOverClosedShutdown(t *testing.T) {
+	done := make(chan error, 1)
+	done <- nil
+	shutdown := make(chan struct{})
+	close(shutdown)
+
+	action, waitErr := selectCompletion(done, make(chan time.Time), shutdown)
+
+	if action != completionDone || waitErr != nil {
+		t.Fatalf("got action=%v waitErr=%v, want done/nil", action, waitErr)
 	}
 }
 

--- a/internal/vector/fill.go
+++ b/internal/vector/fill.go
@@ -71,18 +71,14 @@ func (s progressStore) SaveVectors(ctx context.Context, gen, doc string, revisio
 // failure (shape-level 400, transient error, missing mirror row) keeps the
 // document pending by aborting the fill.
 func (ix *Index) contentSpecific400(ctx context.Context, doc string, enc kitvec.EncodeFunc, split kitvec.SplitOptions, batch kitvec.BatchOptions) bool {
-	var content string
-	query := `SELECT content FROM issue_mirror WHERE issue_uid = ?`
-	if ix.pg != nil {
-		query = `SELECT content FROM issue_vector_mirror WHERE issue_uid = $1`
-	}
-	if err := ix.db.QueryRowContext(ctx, query, doc).Scan(&content); err != nil {
+	content, err := ix.mirrorContent(ctx, doc)
+	if err != nil {
 		return false
 	}
 	chunks := kitvec.Split(content, split)
 	for i := range chunks {
 		chunks[i].Text = strings.Repeat("a", utf8.RuneCountInString(chunks[i].Text))
 	}
-	_, err := kitvec.EncodeBatched(ctx, enc, chunks, batch)
+	_, err = kitvec.EncodeBatched(ctx, enc, chunks, batch)
 	return err == nil
 }

--- a/internal/vector/index.go
+++ b/internal/vector/index.go
@@ -35,8 +35,6 @@ type Index struct {
 	store     *sqlitevec.Store[string, string]
 	flowStore kitvec.Store[string, string]
 	pg        *postgresIndex
-	path      string
-	ownsDB    bool
 }
 
 // Open opens (or creates) the sidecar at path. A mirror schema version
@@ -77,7 +75,7 @@ func Open(ctx context.Context, path string) (*Index, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("vector: init kit store: %w", err)
 	}
-	return &Index{db: db, store: store, flowStore: store, path: path, ownsDB: true}, nil
+	return &Index{db: db, store: store, flowStore: store}, nil
 }
 
 // OpenPostgres binds the semantic index to canonical pgvector tables on an
@@ -90,9 +88,10 @@ func OpenPostgres(ctx context.Context, db *sql.DB) (*Index, error) {
 	return &Index{db: db, flowStore: pg, pg: pg}, nil
 }
 
-// Close releases the sidecar handle.
+// Close releases the sidecar handle. A Postgres-backed index runs on the
+// caller's pool and must not close it.
 func (ix *Index) Close() error {
-	if !ix.ownsDB {
+	if ix.pg != nil {
 		return nil
 	}
 	return ix.db.Close()

--- a/internal/vector/mirror.go
+++ b/internal/vector/mirror.go
@@ -10,6 +10,25 @@ import (
 
 const mirrorPageSize = 500
 
+// mirrorContent reads one mirrored document's text. Each backend owns its own
+// table name and placeholder style, so the caller never has to know which is
+// in play.
+func (ix *Index) mirrorContent(ctx context.Context, doc string) (string, error) {
+	if ix.pg != nil {
+		return ix.pg.mirrorContent(ctx, doc)
+	}
+	return ix.sqliteMirrorContent(ctx, doc)
+}
+
+func (ix *Index) sqliteMirrorContent(ctx context.Context, doc string) (string, error) {
+	var content string
+	if err := ix.db.QueryRowContext(ctx,
+		`SELECT content FROM issue_mirror WHERE issue_uid = ?`, doc).Scan(&content); err != nil {
+		return "", err
+	}
+	return content, nil
+}
+
 // RefreshMirror synchronizes issue_mirror with the canonical store: it
 // upserts new/edited issues (rendering the embed recipe) and removes rows —
 // plus their vectors in every generation — for issues that left the feed

--- a/internal/vector/mirror_test.go
+++ b/internal/vector/mirror_test.go
@@ -36,6 +36,46 @@ func openTestIndex(t *testing.T) *Index {
 	return ix
 }
 
+func TestMirrorContentReadsTheSeededDocument(t *testing.T) {
+	ctx := context.Background()
+	ix := openTestIndex(t)
+	seedMirror(t, ix, "u1", 1)
+
+	got, err := ix.mirrorContent(ctx, "u1")
+	if err != nil {
+		t.Fatalf("mirrorContent: %v", err)
+	}
+	if got != "text" {
+		t.Fatalf("mirrorContent = %q, want %q", got, "text")
+	}
+}
+
+func TestMirrorContentErrorsForAnUnknownDocument(t *testing.T) {
+	ctx := context.Background()
+	ix := openTestIndex(t)
+
+	if _, err := ix.mirrorContent(ctx, "missing"); err == nil {
+		t.Fatal("mirrorContent for an unmirrored document must error so the fill aborts " +
+			"instead of stamping the document as skipped")
+	}
+}
+
+// TestClosePostgresIndexLeavesTheCallersPoolOpen pins that a Postgres-backed
+// Index does not close a handle it does not own. The sidecar handle stands in
+// for the caller's pool here so the test needs no database container.
+func TestClosePostgresIndexLeavesTheCallersPoolOpen(t *testing.T) {
+	ctx := context.Background()
+	owner := openTestIndex(t)
+	borrowed := &Index{db: owner.db, pg: &postgresIndex{db: owner.db}}
+
+	if err := borrowed.Close(); err != nil {
+		t.Fatalf("Close on a Postgres-backed index: %v", err)
+	}
+	if err := owner.db.PingContext(ctx); err != nil {
+		t.Fatalf("caller's pool was closed by Index.Close: %v", err)
+	}
+}
+
 func TestRefreshMirrorUpdatesProjectMoveWithoutRevisionBump(t *testing.T) {
 	ctx := context.Background()
 	ix := openTestIndex(t)

--- a/internal/vector/postgres.go
+++ b/internal/vector/postgres.go
@@ -70,6 +70,17 @@ func (p *postgresIndex) validate(ctx context.Context) error {
 	return nil
 }
 
+// mirrorContent reads one mirrored document's text from the canonical
+// pgvector mirror table.
+func (p *postgresIndex) mirrorContent(ctx context.Context, doc string) (string, error) {
+	var content string
+	if err := p.db.QueryRowContext(ctx,
+		`SELECT content FROM issue_vector_mirror WHERE issue_uid = $1`, doc).Scan(&content); err != nil {
+		return "", err
+	}
+	return content, nil
+}
+
 func (p *postgresIndex) PendingForGeneration(ctx context.Context, gen string, limit int) ([]kitvec.Pending[string], error) {
 	if limit <= 0 {
 		limit = 1

--- a/service.go
+++ b/service.go
@@ -530,6 +530,7 @@ func (s *Service) Run(ctx context.Context) error {
 				s.broadcaster.Broadcast(daemon.StreamMsg{
 					Kind: "event", Event: &event, ProjectID: projectID,
 				})
+				s.hookSink.Enqueue(event)
 			}
 		},
 	}

--- a/service_federation_test.go
+++ b/service_federation_test.go
@@ -240,3 +240,112 @@ func (s *serviceFederationCredentialStore) DeleteFederationCredential(
 	delete(s.entries, projectUID)
 	return nil
 }
+
+// recordingHookSink is a hooks.Sink that keeps every enqueued event so a test
+// can assert which events reached webhook delivery.
+type recordingHookSink struct {
+	mu     sync.Mutex
+	events []db.Event
+}
+
+func (s *recordingHookSink) Enqueue(evt db.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, evt)
+}
+
+func (s *recordingHookSink) snapshot() []db.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]db.Event(nil), s.events...)
+}
+
+// TestServiceRunEnqueuesHooksForFederationPulledEvents pins that a mounted
+// service delivers hooks for events it pulled from a hub, matching the
+// standalone daemon's federation callback. Before the fix the mounted service
+// only broadcast pulled events over SSE, so webhooks never fired for them.
+func TestServiceRunEnqueuesHooksForFederationPulledEvents(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	ctx := context.Background()
+	hubService, err := New(ctx, Config{
+		DSN:  filepath.Join(t.TempDir(), "hub.db"),
+		Auth: AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, hubService.Close()) })
+	hubServer := httptest.NewServer(hubService.Handler())
+	t.Cleanup(hubServer.Close)
+
+	hubProject, err := hubService.store.CreateProject(ctx, "hub-project")
+	require.NoError(t, err)
+	hubBinding, err := hubService.store.EnableProjectFederation(ctx, hubProject.ID, "example-user")
+	require.NoError(t, err)
+
+	credentials := newServiceFederationCredentialStore()
+	spokeService, err := New(ctx, Config{
+		DSN:                   filepath.Join(t.TempDir(), "spoke.db"),
+		Auth:                  AuthConfig{TrustCallerAuthentication: true},
+		FederationCredentials: credentials,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, spokeService.Close()) })
+	sink := &recordingHookSink{}
+	spokeService.hookSink = sink
+
+	spokeProject, err := spokeService.store.CreateProjectWithUID(ctx, "spoke-project", hubProject.UID)
+	require.NoError(t, err)
+	enrollment, err := hubService.store.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{
+		SpokeInstanceUID: spokeService.store.InstanceUID(),
+		ProjectID:        &hubProject.ID,
+		Capabilities:     "pull,push",
+		Actor:            "example-user",
+	})
+	require.NoError(t, err)
+	_, err = spokeService.store.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID:            spokeProject.ID,
+		Role:                 db.FederationRoleSpoke,
+		HubURL:               hubServer.URL,
+		HubProjectID:         hubProject.ID,
+		HubProjectUID:        hubProject.UID,
+		ReplayHorizonEventID: hubBinding.ReplayHorizonEventID,
+		PushEnabled:          true,
+		Actor:                "example-user",
+		AllowInsecure:        true,
+		Enabled:              true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, credentials.StoreFederationCredential(ctx, spokeProject.UID, FederationCredential{
+		HubURL: hubServer.URL, HubProjectID: hubProject.ID,
+		Token: enrollment.Token, AllowInsecure: true,
+	}))
+
+	// Create the hub-side issue before Run starts: the runner syncs once
+	// immediately, so the first pull carries this issue's events.
+	hubIssue, _, err := hubService.store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: hubProject.ID, Title: "pulled to spoke", Author: "example-user",
+	})
+	require.NoError(t, err)
+
+	runCtx, cancelRun := context.WithCancel(ctx)
+	runDone := make(chan error, 1)
+	go func() { runDone <- spokeService.Run(runCtx) }()
+	t.Cleanup(func() {
+		cancelRun()
+		require.NoError(t, <-runDone)
+	})
+
+	require.Eventually(t, func() bool {
+		_, issueErr := spokeService.store.IssueByUID(ctx, hubIssue.UID, db.IncludeDeletedNo)
+		return issueErr == nil
+	}, 5*time.Second, 20*time.Millisecond, "spoke should pull the hub issue")
+
+	require.Eventually(t, func() bool {
+		for _, evt := range sink.snapshot() {
+			if evt.Type == "issue.created" && evt.IssueUID != nil && *evt.IssueUID == hubIssue.UID {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 20*time.Millisecond,
+		"federation-pulled events must reach the hook sink, not only the SSE broadcaster")
+}

--- a/tools/migrationhistorycheck/main.go
+++ b/tools/migrationhistorycheck/main.go
@@ -91,12 +91,12 @@ func writef(w io.Writer, format string, args ...any) {
 
 func invalidMigrationNameViolations(diff, migrationDir string) []string {
 	var violations []string
-	for _, path := range stagedPaths(diff, migrationDir) {
-		if filepath.Ext(path) != ".sql" {
+	for _, change := range parseNameStatus(diff, migrationDir) {
+		if change.dst == "" {
 			continue
 		}
-		if _, _, ok := migrationIdentityFromPath(path); !ok {
-			violations = append(violations, path)
+		if _, _, ok := migrationIdentityFromPath(change.dst); !ok {
+			violations = append(violations, change.dst)
 		}
 	}
 	slices.Sort(violations)
@@ -104,28 +104,25 @@ func invalidMigrationNameViolations(diff, migrationDir string) []string {
 }
 
 func changedMainBranchMigrations(ctx context.Context, baseRef, migrationDir, diff string) []string {
-	var violations []string
-	for line := range strings.SplitSeq(diff, "\n") {
-		if line == "" {
-			continue
+	violations := map[string]struct{}{}
+	for _, change := range parseNameStatus(diff, migrationDir) {
+		paths := []string{change.baseRefPath()}
+		if change.status == 'R' && change.dst != "" && change.dst != change.src {
+			paths = append(paths, change.dst)
 		}
-		fields := strings.Split(line, "\t")
-		if len(fields) < 2 {
-			continue
-		}
-		for _, path := range changedPaths(fields) {
-			if !strings.HasPrefix(path, migrationDir+"/") || filepath.Ext(path) != ".sql" {
+		for _, path := range paths {
+			if path == "" {
 				continue
 			}
 			if _, err := git(ctx, "cat-file", "-e", baseRef+":"+path); err == nil {
 				if stagedPathMatchesBase(ctx, baseRef, path) {
 					continue
 				}
-				violations = append(violations, path)
+				violations[path] = struct{}{}
 			}
 		}
 	}
-	return violations
+	return slices.Sorted(maps.Keys(violations))
 }
 
 func stagedPathMatchesBase(ctx context.Context, baseRef, path string) bool {
@@ -138,21 +135,6 @@ func stagedPathMatchesBase(ctx context.Context, baseRef, path string) bool {
 		return false
 	}
 	return stagedContent == baseContent
-}
-
-func changedPaths(fields []string) []string {
-	status := fields[0]
-	paths := fields[1:]
-	if strings.HasPrefix(status, "R") {
-		return paths
-	}
-	if len(paths) == 0 {
-		return nil
-	}
-	if strings.HasPrefix(status, "C") && len(paths) > 1 {
-		return paths[1:]
-	}
-	return paths[:1]
 }
 
 type duplicateVersionViolation struct {
@@ -225,35 +207,59 @@ func migrationNamesByVersion(output string) map[string]map[string]struct{} {
 	return byVersion
 }
 
-func stagedPaths(diff, migrationDir string) []string {
-	var paths []string
+type stagedChange struct {
+	status byte
+	src    string
+	dst    string
+}
+
+// baseRefPath chooses the path that can exist on the base revision. Copies
+// deliberately use the destination: checking the untouched source would make
+// copying a released migration look like a history edit.
+func (change stagedChange) baseRefPath() string {
+	if change.status == 'C' {
+		return change.dst
+	}
+	if change.src != "" {
+		return change.src
+	}
+	return change.dst
+}
+
+func parseNameStatus(diff, migrationDir string) []stagedChange {
+	var changes []stagedChange
+	prefix := migrationDir + "/"
 	for line := range strings.SplitSeq(diff, "\n") {
 		if line == "" {
 			continue
 		}
 		fields := strings.Split(line, "\t")
-		if len(fields) < 2 {
+		if len(fields) < 2 || fields[0] == "" {
 			continue
 		}
-		path, ok := stagedPath(fields)
-		if !ok || !strings.HasPrefix(path, migrationDir+"/") {
-			continue
+		status := fields[0][0]
+		filtered := make([]string, len(fields)-1)
+		for i, path := range fields[1:] {
+			if strings.HasPrefix(path, prefix) && filepath.Ext(path) == ".sql" {
+				filtered[i] = path
+			}
 		}
-		paths = append(paths, path)
+		change := stagedChange{status: status}
+		switch status {
+		case 'R', 'C':
+			if len(filtered) >= 2 {
+				change.src, change.dst = filtered[0], filtered[1]
+			}
+		case 'D':
+			change.src = filtered[0]
+		default:
+			change.dst = filtered[0]
+		}
+		if change.src != "" || change.dst != "" {
+			changes = append(changes, change)
+		}
 	}
-	return paths
-}
-
-func stagedPath(fields []string) (string, bool) {
-	status := fields[0]
-	paths := fields[1:]
-	if len(paths) == 0 || strings.HasPrefix(status, "D") {
-		return "", false
-	}
-	if strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C") {
-		return paths[len(paths)-1], true
-	}
-	return paths[0], true
+	return changes
 }
 
 func migrationIdentityFromPath(path string) (string, string, bool) {

--- a/tools/migrationhistorycheck/main_test.go
+++ b/tools/migrationhistorycheck/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -129,6 +130,34 @@ func TestBlocksReleasedPostgresMigrationRename(t *testing.T) {
 	var stderr bytes.Buffer
 	assert.Equal(t, 1, run(t.Context(), &stderr))
 	assert.Contains(t, stderr.String(), "internal/db/pgstore/migrations/000001_init.up.sql")
+}
+
+func TestBlocksRenameOntoMigrationReleasedAfterFeatureFork(t *testing.T) {
+	isolateGitEnvironment(t)
+	repo := initRepoWithMainMigration(t)
+	t.Chdir(repo)
+	t.Setenv("KATA_MIGRATION_BASE_REF", "main")
+
+	source := "internal/db/pgstore/migrations/000002_draft.up.sql"
+	destination := "internal/db/pgstore/migrations/000002_released.up.sql"
+	content := strings.Repeat("SELECT 1;\n", 20)
+	writeFile(t, repo, source, content)
+	gitCommand(t, "add", source)
+	gitCommand(t, "commit", "-qm", "draft migration")
+
+	gitCommand(t, "checkout", "main")
+	writeFile(t, repo, destination, content)
+	gitCommand(t, "add", destination)
+	gitCommand(t, "commit", "-qm", "release migration")
+	gitCommand(t, "checkout", "feature")
+
+	gitCommand(t, "mv", source, destination)
+	writeFile(t, repo, destination, "SELECT 2;\n"+strings.Repeat("SELECT 1;\n", 19))
+	gitCommand(t, "add", destination)
+
+	var stderr bytes.Buffer
+	assert.Equal(t, 1, run(t.Context(), &stderr))
+	assert.Contains(t, stderr.String(), "internal/db/pgstore/migrations/000002_released.up.sql")
 }
 
 func TestUsesHookGitIndexFile(t *testing.T) {

--- a/tools/migrationhistorycheck/parse_test.go
+++ b/tools/migrationhistorycheck/parse_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNameStatusAssignsPathRolesPerStatus(t *testing.T) {
+	tests := map[string]struct {
+		diff string
+		want []stagedChange
+	}{
+		"add and modify use destination": {
+			diff: "A\tinternal/db/pgstore/migrations/000007_add_thing.up.sql\nM\tinternal/db/pgstore/migrations/000008_edit_thing.up.sql",
+			want: []stagedChange{
+				{status: 'A', dst: "internal/db/pgstore/migrations/000007_add_thing.up.sql"},
+				{status: 'M', dst: "internal/db/pgstore/migrations/000008_edit_thing.up.sql"},
+			},
+		},
+		"delete uses source": {
+			diff: "D\tinternal/db/pgstore/migrations/000007_remove_thing.up.sql",
+			want: []stagedChange{{status: 'D', src: "internal/db/pgstore/migrations/000007_remove_thing.up.sql"}},
+		},
+		"rename and copy preserve both filtered paths": {
+			diff: "R100\tinternal/db/pgstore/migrations/000007_old.up.sql\tinternal/db/pgstore/migrations/000008_new.up.sql\nC100\tinternal/db/pgstore/migrations/000009_source.up.sql\tinternal/db/pgstore/migrations/000010_copy.up.sql",
+			want: []stagedChange{
+				{status: 'R', src: "internal/db/pgstore/migrations/000007_old.up.sql", dst: "internal/db/pgstore/migrations/000008_new.up.sql"},
+				{status: 'C', src: "internal/db/pgstore/migrations/000009_source.up.sql", dst: "internal/db/pgstore/migrations/000010_copy.up.sql"},
+			},
+		},
+		"filters paths and malformed records": {
+			diff: "\nM\tinternal/db/pgstore/migrations/readme.txt\nM\tother/000007_outside.up.sql\nR100\tinternal/db/pgstore/migrations/000007_old.txt\tinternal/db/pgstore/migrations/000008_new.up.sql\nC100\tinternal/db/pgstore/migrations/000009_source.up.sql\tother/000010_copy.up.sql\nM\tinternal/db/pgstore/migrations/000011_valid.up.sql\nmalformed",
+			want: []stagedChange{
+				{status: 'R', dst: "internal/db/pgstore/migrations/000008_new.up.sql"},
+				{status: 'C', src: "internal/db/pgstore/migrations/000009_source.up.sql"},
+				{status: 'M', dst: "internal/db/pgstore/migrations/000011_valid.up.sql"},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseNameStatus(tt.diff, "internal/db/pgstore/migrations"))
+		})
+	}
+}
+
+func TestStagedChangeBaseRefPathPicksThePathThatCanExistOnBase(t *testing.T) {
+	tests := []struct {
+		name   string
+		change stagedChange
+		want   string
+	}{
+		{name: "add", change: stagedChange{status: 'A', dst: "new.sql"}, want: "new.sql"},
+		{name: "modify", change: stagedChange{status: 'M', dst: "changed.sql"}, want: "changed.sql"},
+		{name: "delete", change: stagedChange{status: 'D', src: "deleted.sql"}, want: "deleted.sql"},
+		{name: "rename", change: stagedChange{status: 'R', src: "old.sql", dst: "new.sql"}, want: "old.sql"},
+		{name: "copy", change: stagedChange{status: 'C', src: "source.sql", dst: "copy.sql"}, want: "copy.sql"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.change.baseRefPath())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes federation-pull hook fan-out and per-attempt SQLite lease outcomes.
- Simplifies hook, CLI, vector, attention, and migration-history representations while preserving behavior.
- Guards contradictory federation leave credentials without changing persisted schema.

## Notes

- Mounted hook provisioning remains separate scope; this restores callback parity for the existing injected/internal sink.