### PR TITLE
Centralize daemon auth route rules into checked registries

### DIFF
--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -34,6 +34,13 @@ type authPolicy struct {
 	AllowUnauthenticatedPrivateNetworkWrites bool
 	InsecureReadonly                         bool
 	RequireTokenIdentity                     bool
+
+	// SelfAuthenticatedRoutes is the set of routes whose handler owns
+	// authentication; the middleware must not pre-empt them with a daemon-token
+	// check. NewServer generates it from the registered routes. The zero value
+	// matches nothing, so a caller that does not set it gets bearer enforcement
+	// on every route.
+	SelfAuthenticatedRoutes selfAuthenticatedRouteMatcher
 }
 
 // requireBearer returns an HTTP middleware that enforces bearer-token auth
@@ -67,8 +74,7 @@ func requireBearer(p authPolicy, tokenStores ...db.Storage) func(http.Handler) h
 				next.ServeHTTP(w, r)
 				return
 			}
-			if isFederationTransportRoute(r.Method, r.URL.Path) ||
-				isClaimActionRoute(r.Method, r.URL.Path) {
+			if p.SelfAuthenticatedRoutes.matches(r) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -148,72 +154,6 @@ func requireIdentityBearer(w http.ResponseWriter, r *http.Request, next http.Han
 
 func isTokenAdminPath(path string) bool {
 	return path == "/api/v1/tokens" || strings.HasPrefix(path, "/api/v1/tokens/")
-}
-
-func isClaimActionRoute(method, path string) bool {
-	rest, ok := strings.CutPrefix(path, "/api/v1/projects/")
-	if !ok {
-		return false
-	}
-	projectID, rest, ok := strings.Cut(rest, "/issues/")
-	if !ok || projectID == "" {
-		return false
-	}
-	for _, r := range projectID {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	_, suffix, ok := strings.Cut(rest, "/")
-	if !ok {
-		return false
-	}
-	if method == http.MethodGet {
-		return suffix == "lease"
-	}
-	if method != http.MethodPost {
-		return false
-	}
-	switch suffix {
-	case "lease/actions/acquire", "lease/actions/renew", "lease/actions/release", "lease/actions/force_release":
-		return true
-	default:
-		return false
-	}
-}
-
-func isFederationTransportRoute(method, path string) bool {
-	var suffix string
-	switch method {
-	case http.MethodGet:
-		if strings.HasSuffix(path, "/federation/events") {
-			suffix = "/federation/events"
-		} else {
-			suffix = "/federation/metadata"
-		}
-	case http.MethodPost:
-		suffix = "/federation/events:ingest"
-	default:
-		return false
-	}
-
-	rest, ok := strings.CutPrefix(path, "/api/v1/projects/")
-	if !ok {
-		return false
-	}
-	projectID, ok := strings.CutSuffix(rest, suffix)
-	if !ok {
-		return false
-	}
-	if projectID == "" {
-		return false
-	}
-	for _, r := range projectID {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
 }
 
 // checkAuthStartup refuses startup when the listen address would expose

--- a/internal/daemon/auth_routes.go
+++ b/internal/daemon/auth_routes.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// selfAuthenticatedRoutes returns the route templates of every registered
+// operation whose access rule says the handler owns authentication. Generating
+// the bypass set from the same literal the route is registered with is what
+// makes a path rename impossible to get wrong: rename the path in the handler
+// file and the matcher follows it.
+func selfAuthenticatedRoutes(doc *huma.OpenAPI) []routeTemplate {
+	var routes []routeTemplate
+	for operationID, template := range registeredOperations(doc) {
+		if hostAccessRuleFor(operationID).SelfAuthenticated {
+			routes = append(routes, template)
+		}
+	}
+	return routes
+}
+
+// selfAuthenticatedRouteMatcher answers "does this request address a route
+// whose handler authenticates itself?". It is an http.ServeMux built from the
+// registered route templates, so matching is the same method-and-wildcard
+// matching the real router performs. The zero value matches nothing, which is
+// the safe direction: the daemon bearer token is required.
+type selfAuthenticatedRouteMatcher struct {
+	mux *http.ServeMux
+}
+
+type selfAuthenticatedMatchKey struct{}
+
+func newSelfAuthenticatedRouteMatcher(routes []routeTemplate) selfAuthenticatedRouteMatcher {
+	mux := http.NewServeMux()
+	for _, route := range routes {
+		mux.Handle(route.Method+" "+route.Path, markSelfAuthenticatedMatch(route.Method))
+	}
+	return selfAuthenticatedRouteMatcher{mux: mux}
+}
+
+// markSelfAuthenticatedMatch records a match for the probe request. The
+// {project_id} guard is load-bearing: a handler can only authenticate a request
+// against a project it can identify, so a project id that is not a positive
+// integer keeps requiring the daemon's bearer token instead of reaching an
+// unauthenticated handler.
+func markSelfAuthenticatedMatch(method string) http.HandlerFunc {
+	return func(_ http.ResponseWriter, r *http.Request) {
+		if r.Method != method {
+			return
+		}
+		matched, ok := r.Context().Value(selfAuthenticatedMatchKey{}).(*bool)
+		if !ok {
+			return
+		}
+		if raw := r.PathValue("project_id"); raw != "" {
+			if _, valid := positiveProjectID(raw); !valid {
+				return
+			}
+		}
+		*matched = true
+	}
+}
+
+func (m selfAuthenticatedRouteMatcher) matches(r *http.Request) bool {
+	if m.mux == nil {
+		return false
+	}
+	matched := false
+	probe := r.WithContext(context.WithValue(
+		r.Context(), selfAuthenticatedMatchKey{}, &matched))
+	m.mux.ServeHTTP(discardResponseWriter{}, probe)
+	return matched
+}
+
+// discardResponseWriter absorbs whatever the probe mux writes for a request
+// that matches nothing (its own 404, or a redirect for a non-canonical path);
+// only the match flag is read back.
+type discardResponseWriter struct{}
+
+func (discardResponseWriter) Header() http.Header         { return http.Header{} }
+func (discardResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (discardResponseWriter) WriteHeader(int)             {}

--- a/internal/daemon/auth_routes_internal_test.go
+++ b/internal/daemon/auth_routes_internal_test.go
@@ -1,0 +1,224 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/db"
+)
+
+// TestSelfAuthenticatedRouteMatcherMatchesOnlyTransportRoutes uses literal
+// requests and expectations independent of the rule and route tables that
+// generate the matcher. Removing or misrouting any self-authenticating
+// operation, or broadening a route to the wrong method, makes this test fail.
+func TestSelfAuthenticatedRouteMatcherMatchesOnlyTransportRoutes(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { _ = srv.Close() })
+	matcher := srv.authPolicy.SelfAuthenticatedRoutes
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		want   bool
+	}{
+		{"federation metadata", http.MethodGet,
+			"/api/v1/projects/7/federation/metadata", true},
+		{"federation poll", http.MethodGet,
+			"/api/v1/projects/7/federation/events", true},
+		{"federation ingest", http.MethodPost,
+			"/api/v1/projects/7/federation/events:ingest", true},
+		{"lease acquire", http.MethodPost,
+			"/api/v1/projects/7/issues/abc4/lease/actions/acquire", true},
+		{"lease renew", http.MethodPost,
+			"/api/v1/projects/7/issues/abc4/lease/actions/renew", true},
+		{"lease release", http.MethodPost,
+			"/api/v1/projects/7/issues/abc4/lease/actions/release", true},
+		{"lease status", http.MethodGet,
+			"/api/v1/projects/7/issues/abc4/lease", true},
+		{"lease force release", http.MethodPost,
+			"/api/v1/projects/7/issues/abc4/lease/actions/force_release", true},
+		{"issue read requires daemon bearer", http.MethodGet,
+			"/api/v1/projects/7/issues/abc4", false},
+		{"federation setup requires daemon bearer", http.MethodPost,
+			"/api/v1/federation/enrollments", false},
+		{"project federation config requires daemon bearer", http.MethodGet,
+			"/api/v1/projects/7/federation", false},
+		{"poll rejects post", http.MethodPost,
+			"/api/v1/projects/7/federation/events", false},
+		{"ingest rejects get", http.MethodGet,
+			"/api/v1/projects/7/federation/events:ingest", false},
+		{"lease acquire rejects get", http.MethodGet,
+			"/api/v1/projects/7/issues/abc4/lease/actions/acquire", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := httptest.NewRequest(tc.method, tc.path, nil)
+			assert.Equal(t, tc.want, matcher.matches(request))
+		})
+	}
+}
+
+func TestSelfAuthenticatedRouteMatcherZeroValueMatchesNothing(t *testing.T) {
+	var matcher selfAuthenticatedRouteMatcher
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/federation/events", nil)
+	assert.False(t, matcher.matches(request))
+}
+
+// TestBearerMiddlewareRequiresExactMethodForSelfAuthenticatedGETRoutes catches
+// net/http's GET-pattern behavior broadening the bypass to HEAD. The deleted
+// parsers required exact GET, so HEAD must continue to require the daemon token.
+func TestBearerMiddlewareRequiresExactMethodForSelfAuthenticatedGETRoutes(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { _ = srv.Close() })
+	policy := authPolicy{
+		Token: "daemon-token",
+		SelfAuthenticatedRoutes: newSelfAuthenticatedRouteMatcher(
+			selfAuthenticatedRoutes(srv.API().OpenAPI())),
+	}
+	handler := requireBearer(policy)(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusAccepted) }))
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"lease status", "/api/v1/projects/7/issues/abc4/lease"},
+		{"federation poll", "/api/v1/projects/7/federation/events"},
+		{"federation metadata", "/api/v1/projects/7/federation/metadata"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodHead, tc.path, nil))
+			assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+		})
+	}
+}
+
+// TestBearerMiddlewareRequiresTokenForUnusableProjectID pins the guard the
+// deleted digit scans provided: a handler can only authenticate a request
+// against a project it can identify, so an unusable {project_id} keeps
+// requiring the daemon's bearer token.
+func TestBearerMiddlewareRequiresTokenForUnusableProjectID(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { _ = srv.Close() })
+	policy := authPolicy{
+		Token: "daemon-token",
+		SelfAuthenticatedRoutes: newSelfAuthenticatedRouteMatcher(
+			selfAuthenticatedRoutes(srv.API().OpenAPI())),
+	}
+	handler := requireBearer(policy)(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusAccepted) }))
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		want   int
+	}{
+		{"lease status", http.MethodGet,
+			"/api/v1/projects/7/issues/abc4/lease", http.StatusAccepted},
+		{"lease status non-numeric project", http.MethodGet,
+			"/api/v1/projects/spoke/issues/abc4/lease", http.StatusUnauthorized},
+		{"lease acquire", http.MethodPost,
+			"/api/v1/projects/7/issues/abc4/lease/actions/acquire", http.StatusAccepted},
+		{"lease acquire non-numeric project", http.MethodPost,
+			"/api/v1/projects/spoke/issues/abc4/lease/actions/acquire", http.StatusUnauthorized},
+		{"lease force release", http.MethodPost,
+			"/api/v1/projects/7/issues/abc4/lease/actions/force_release", http.StatusAccepted},
+		{"federation poll", http.MethodGet,
+			"/api/v1/projects/7/federation/events", http.StatusAccepted},
+		{"federation poll non-numeric project", http.MethodGet,
+			"/api/v1/projects/spoke/federation/events", http.StatusUnauthorized},
+		{"federation metadata non-numeric project", http.MethodGet,
+			"/api/v1/projects/spoke/federation/metadata", http.StatusUnauthorized},
+		{"federation ingest non-numeric project", http.MethodPost,
+			"/api/v1/projects/spoke/federation/events:ingest", http.StatusUnauthorized},
+		{"federation metadata zero project", http.MethodGet,
+			"/api/v1/projects/0/federation/metadata", http.StatusUnauthorized},
+		{"wrong method for poll", http.MethodPost,
+			"/api/v1/projects/7/federation/events", http.StatusUnauthorized},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(tc.method, tc.path, nil))
+			assert.Equal(t, tc.want, recorder.Code)
+		})
+	}
+}
+
+// TestHostAccessRejectsFederationBearerOnForceReleaseOnly is the HTTP-level
+// half of the force-release asymmetry: the bearer middleware defers to the
+// handler for both routes, but the host-access middleware only dispatches an
+// unattributed bearer for routes that accept an enrollment credential.
+func TestHostAccessRejectsFederationBearerOnForceReleaseOnly(t *testing.T) {
+	store := openAuthTestDB(t)
+	srv := NewServer(ServerConfig{DB: store, HostAccess: allowAllHostAccess{}})
+	t.Cleanup(func() { _ = srv.Close() })
+
+	for _, tc := range []struct {
+		name       string
+		path       string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "acquire reaches the handler's enrollment check",
+			path:       "/api/v1/projects/1/issues/abc4/lease/actions/acquire",
+			wantStatus: http.StatusForbidden,
+			wantCode:   "auth_invalid",
+		},
+		{
+			name:       "force release is refused before dispatch",
+			path:       "/api/v1/projects/1/issues/abc4/lease/actions/force_release",
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "authentication_required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, tc.path,
+				strings.NewReader(`{"holder":"spoke-holder"}`))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Authorization", "Bearer enrollment-token")
+			recorder := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(recorder, request)
+			assert.Equal(t, tc.wantStatus, recorder.Code, "body: %s", recorder.Body.String())
+			assert.Contains(t, recorder.Body.String(), tc.wantCode)
+		})
+	}
+}
+
+// TestFederationIngestPreauthParserMatchesRegisteredRoute pins the one route
+// parser that deliberately does not consume the matcher (see the comment on
+// federationIngestProjectID) against the template the route is registered with.
+func TestFederationIngestPreauthParserMatchesRegisteredRoute(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { _ = srv.Close() })
+	template, ok := registeredOperations(srv.API().OpenAPI())["ingestFederationProjectEvents"]
+	require.True(t, ok, "ingestFederationProjectEvents is not registered")
+
+	projectID, matched, valid := federationIngestProjectID(
+		template.Method, strings.ReplaceAll(template.Path, "{project_id}", "42"))
+
+	assert.Truef(t, matched, "preauth parser no longer matches the registered route %s %s",
+		template.Method, template.Path)
+	assert.True(t, valid)
+	assert.Equal(t, int64(42), projectID)
+}
+
+type allowAllHostAccess struct{}
+
+func (allowAllHostAccess) Authorize(
+	context.Context,
+	HostAccessRequest,
+) (HostAccessDecision, error) {
+	return HostAccessDecision{
+		Revalidate:       func(context.Context) error { return nil },
+		TransactionFence: func(context.Context, db.Transaction) error { return nil },
+	}, nil
+}

--- a/internal/daemon/auth_test.go
+++ b/internal/daemon/auth_test.go
@@ -277,7 +277,10 @@ func TestAuthMiddleware_UnauthenticatedPathsAlwaysPass(t *testing.T) {
 }
 
 func TestAuthMiddleware_FederationTransportPathsBypassAdminBearer(t *testing.T) {
-	mw := requireBearer(authPolicy{Token: "expected-token"})
+	mw := requireBearer(authPolicy{
+		Token:                   "expected-token",
+		SelfAuthenticatedRoutes: selfAuthenticatedRoutesForTest(t),
+	})
 	h := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
@@ -297,7 +300,10 @@ func TestAuthMiddleware_FederationTransportPathsBypassAdminBearer(t *testing.T) 
 }
 
 func TestAuthMiddleware_FederationTransportBypassRequiresExactRouteAndMethod(t *testing.T) {
-	mw := requireBearer(authPolicy{Token: "expected-token"})
+	mw := requireBearer(authPolicy{
+		Token:                   "expected-token",
+		SelfAuthenticatedRoutes: selfAuthenticatedRoutesForTest(t),
+	})
 	h := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
@@ -351,4 +357,13 @@ func openAuthTestDB(t *testing.T) *sqlitestore.Store {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = d.Close() })
 	return d
+}
+
+// selfAuthenticatedRoutesForTest builds the bypass matcher the daemon
+// generates at startup, so middleware-level tests exercise the real route set.
+func selfAuthenticatedRoutesForTest(t *testing.T) selfAuthenticatedRouteMatcher {
+	t.Helper()
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { _ = srv.Close() })
+	return newSelfAuthenticatedRouteMatcher(selfAuthenticatedRoutes(srv.API().OpenAPI()))
 }

--- a/internal/daemon/claims_auth.go
+++ b/internal/daemon/claims_auth.go
@@ -15,7 +15,6 @@ import (
 
 type claimPrincipal struct {
 	db.ClaimPrincipal
-	Local         bool
 	IdentityToken bool
 }
 
@@ -29,7 +28,6 @@ func resolveClaimPrincipal(
 	body api.ClaimActionBody,
 	operation HostFederationOperation,
 	allowEnrollment bool,
-	requireMutationLocal bool,
 ) (context.Context, claimPrincipal, error) {
 	if cfg.HostAccess != nil {
 		if requestPrincipal, ok := PrincipalFromContext(ctx); ok {
@@ -67,7 +65,7 @@ func resolveClaimPrincipal(
 		}
 	}
 
-	if requireMutationLocal && cfg.InsecureReadonly {
+	if cfg.InsecureReadonly {
 		return ctx, claimPrincipal{}, localAuthError(cfg, authz)
 	}
 	return ctx, localClaimPrincipal(cfg, body), nil
@@ -120,7 +118,7 @@ func authorizeClaimStatusRead(
 		}
 		if hasBearerHeader(authz) {
 			authorizedCtx, _, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
-				HostFederationOperation{ID: "getIssueLeaseStatus", Mutation: true})
+				federationTransportOperation("getIssueLeaseStatus"))
 			return authorizedCtx, err
 		}
 		return ctx, api.NewError(http.StatusUnauthorized, "auth_required",
@@ -129,7 +127,7 @@ func authorizeClaimStatusRead(
 	if cfg.Auth.Token == "" {
 		if hasBearerHeader(authz) {
 			authorizedCtx, _, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
-				HostFederationOperation{ID: "getIssueLeaseStatus", Mutation: true})
+				federationTransportOperation("getIssueLeaseStatus"))
 			return authorizedCtx, err
 		}
 		if cfg.InsecureReadonly {
@@ -141,7 +139,7 @@ func authorizeClaimStatusRead(
 		return ctx, err
 	}
 	authorizedCtx, _, err := authorizeFederationRequest(ctx, cfg, authz, projectID, "claim",
-		HostFederationOperation{ID: "getIssueLeaseStatus", Mutation: true})
+		federationTransportOperation("getIssueLeaseStatus"))
 	return authorizedCtx, err
 }
 
@@ -191,10 +189,11 @@ func localClaimPrincipal(cfg ServerConfig, body api.ClaimActionBody) claimPrinci
 }
 
 func localClaimPrincipalWithHolder(cfg ServerConfig, body api.ClaimActionBody, holder string) claimPrincipal {
-	return claimPrincipal{Local: true,
+	return claimPrincipal{
 		HolderInstanceUID: cfg.DB.InstanceUID(),
 		Holder:            strings.TrimSpace(holder),
-		ClientKind:        strings.TrimSpace(body.ClientKind)}
+		ClientKind:        strings.TrimSpace(body.ClientKind),
+	}
 }
 
 func hasBearerHeader(authz string) bool {

--- a/internal/daemon/federation_access.go
+++ b/internal/daemon/federation_access.go
@@ -19,6 +19,43 @@ type HostFederationOperation struct {
 	Mutation bool
 }
 
+// federationTransportOperations is the source of truth for the transport-auth
+// facts of every route a project-scoped federation enrollment can
+// authenticate. Mutation here answers "may this request write, so compute and
+// require a transaction fence?" — a narrower question than the capability class
+// hostOperationPolicies declares for the same route, which is why this table is
+// its own source of truth and not derived from that registry.
+var federationTransportOperations = map[string]HostFederationOperation{
+	"acquireIssueLease": {ID: "acquireIssueLease", Mutation: true},
+	"renewIssueLease":   {ID: "renewIssueLease", Mutation: true},
+	"releaseIssueLease": {ID: "releaseIssueLease", Mutation: true},
+	// forceReleaseIssueLease never authenticates an enrollment credential
+	// (resolveClaimPrincipal receives allowEnrollment=false); the entry exists
+	// so its call site names one table like every other lease route.
+	"forceReleaseIssueLease": {ID: "forceReleaseIssueLease", Mutation: true},
+	// Fenced despite its read policy: handleClaimStatus expires timed claims
+	// and emits events, so this GET writes.
+	"getIssueLeaseStatus": {ID: "getIssueLeaseStatus", Mutation: true},
+	// Fenced despite its read policy: projectFederationBody can call
+	// RefreshProjectFederationBaseline, so this GET writes.
+	"getFederationProjectMetadata":  {ID: "getFederationProjectMetadata", Mutation: true},
+	"pollFederationProjectEvents":   {ID: "pollFederationProjectEvents"},
+	"ingestFederationProjectEvents": {ID: "ingestFederationProjectEvents", Mutation: true},
+}
+
+// federationTransportOperation returns the transport-auth facts for
+// operationID. An unknown ID is a programming error: returning a zero value
+// would authorize the request as a non-mutating operation and silently drop its
+// transaction fence, so this panics instead, mirroring registerHostOperations'
+// duplicate-registration discipline.
+func federationTransportOperation(operationID string) HostFederationOperation {
+	operation, ok := federationTransportOperations[operationID]
+	if !ok {
+		panic("unknown federation transport operation: " + operationID)
+	}
+	return operation
+}
+
 // HostFederationAccessRequest carries native credential and project facts to
 // the public service adapter.
 type HostFederationAccessRequest struct {

--- a/internal/daemon/federation_access_internal_test.go
+++ b/internal/daemon/federation_access_internal_test.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFederationTransportOperationsMatchTheSelfAuthenticatedRoutes ties the two
+// registries together: a route a federation enrollment can authenticate must
+// have transport facts, and every route with transport facts must be one the
+// bearer middleware defers on. Either half going missing is the drift the
+// eleven hand-written literals allowed.
+func TestFederationTransportOperationsMatchTheSelfAuthenticatedRoutes(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { _ = srv.Close() })
+
+	selfAuthenticated := make(map[string]struct{})
+	for operationID := range registeredOperations(srv.API().OpenAPI()) {
+		if hostAccessRuleFor(operationID).SelfAuthenticated {
+			selfAuthenticated[operationID] = struct{}{}
+		}
+	}
+	require.NotEmpty(t, selfAuthenticated)
+
+	for operationID, operation := range federationTransportOperations {
+		assert.Equalf(t, operationID, operation.ID,
+			"transport table key %q carries ID %q", operationID, operation.ID)
+		_, hasPolicy := hostOperationPolicy(operationID)
+		assert.Truef(t, hasPolicy,
+			"federation transport operation %q has no host operation policy", operationID)
+		_, isSelfAuthenticated := selfAuthenticated[operationID]
+		assert.Truef(t, isSelfAuthenticated,
+			"federation transport operation %q is not a self-authenticated route", operationID)
+		delete(selfAuthenticated, operationID)
+	}
+
+	for operationID := range selfAuthenticated {
+		t.Errorf("self-authenticated route %q has no federation transport facts", operationID)
+	}
+}
+
+func TestFederationTransportOperationRejectsUnknownID(t *testing.T) {
+	require.PanicsWithValue(t, "unknown federation transport operation: listIssues", func() {
+		federationTransportOperation("listIssues")
+	})
+}
+
+// TestFederationTransportFencesGETsThatWrite pins the two deliberate
+// divergences from hostOperationPolicies. Both routes are declared reads but
+// write while serving: handleClaimStatus expires timed claims and emits events,
+// and projectFederationBody can refresh the federation baseline. Deriving the
+// transport table from the policy registry would drop their transaction fence.
+func TestFederationTransportFencesGETsThatWrite(t *testing.T) {
+	for _, operationID := range []string{"getIssueLeaseStatus", "getFederationProjectMetadata"} {
+		policy, ok := hostOperationPolicy(operationID)
+		require.Truef(t, ok, "%s has no host operation policy", operationID)
+		assert.Falsef(t, policy.Mutation,
+			"%s is declared a read by the policy registry", operationID)
+		assert.Truef(t, federationTransportOperation(operationID).Mutation,
+			"%s must stay transaction-fenced on the federation path", operationID)
+	}
+}
+
+func TestFederationTransportPollIsNotFenced(t *testing.T) {
+	assert.False(t, federationTransportOperation("pollFederationProjectEvents").Mutation,
+		"a pure read must not demand a transaction fence")
+}

--- a/internal/daemon/federation_auth.go
+++ b/internal/daemon/federation_auth.go
@@ -80,6 +80,9 @@ func federationAuthorizationFromContext(
 	operation HostFederationOperation,
 ) (federationAuthorization, bool) {
 	cached, ok := ctx.Value(federationAuthorizationContextKey{}).(cachedFederationAuthorization)
+	// The whole operation is compared, not just its ID: a cached authorization
+	// for a non-mutating call carries no transaction fence, so it must never be
+	// reused by a mutating call for the same route.
 	if !ok || cached.authHeader != authHeader || cached.projectID != projectID ||
 		cached.capability != capability || cached.operation != operation {
 		return federationAuthorization{}, false

--- a/internal/daemon/federation_preauth.go
+++ b/internal/daemon/federation_preauth.go
@@ -25,7 +25,7 @@ func withFederationIngestPreauthorization(cfg ServerConfig, next http.Handler) h
 			api.WriteEnvelope(w, http.StatusBadRequest, "validation", "project_id must be a positive integer")
 			return
 		}
-		operation := HostFederationOperation{ID: "ingestFederationProjectEvents", Mutation: true}
+		operation := federationTransportOperation("ingestFederationProjectEvents")
 		ctx, err := preauthorizeHostFederationIngest(r.Context(), cfg.HostAccess, projectID)
 		if err != nil {
 			writeFederationPreauthorizationError(w, err)
@@ -92,6 +92,13 @@ func preauthorizeHostFederationIngest(
 	return context.WithValue(ctx, hostAccessStateContextKey{}, state), nil
 }
 
+// federationIngestProjectID is a deliberate exception to the route matcher in
+// auth_routes.go, not drift. It runs ahead of the huma mux so credential and
+// path validation happen before Huma may read a 64 MiB body, and it needs two
+// things the matcher collapses: the parsed project id, and the "matched the
+// route but the id is unusable" case that answers 400 rather than falling
+// through. TestFederationIngestPreauthParserMatchesRegisteredRoute pins it
+// against the registered ingest route so a path rename fails a test.
 func federationIngestProjectID(method, path string) (projectID int64, matched, valid bool) {
 	if method != http.MethodPost {
 		return 0, false, false

--- a/internal/daemon/federation_transport_auth_test.go
+++ b/internal/daemon/federation_transport_auth_test.go
@@ -1,0 +1,103 @@
+package daemon_test
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+// countingFederationAccess records every host federation authorization the
+// daemon asks for, so a test can assert how many times one request was
+// evaluated.
+type countingFederationAccess struct {
+	mu         sync.Mutex
+	operations []daemon.HostFederationOperation
+}
+
+func (c *countingFederationAccess) AuthorizeFederation(
+	_ context.Context,
+	request daemon.HostFederationAccessRequest,
+) (daemon.HostFederationAccessDecision, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.operations = append(c.operations, request.Operation)
+	return daemon.HostFederationAccessDecision{
+		TransactionFence: func(context.Context, db.Transaction) error { return nil },
+	}, nil
+}
+
+func (c *countingFederationAccess) snapshot() []daemon.HostFederationOperation {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]daemon.HostFederationOperation(nil), c.operations...)
+}
+
+// TestFederationIngestAuthorizesOncePerRequest pins the preauthorization cache
+// hit on the ingest path. The body-bearing route is authorized by middleware
+// before Huma reads the body; the handler must reuse that decision instead of
+// re-running it. A second evaluation is invisible in the response, so only a
+// call count catches it.
+func TestFederationIngestAuthorizesOncePerRequest(t *testing.T) {
+	access := &countingFederationAccess{}
+	env := testenv.New(t, func(cfg *daemon.ServerConfig) {
+		cfg.HostFederationAccess = access
+	})
+	project := createFederatedHubProject(t, env, "hub-project")
+	created, err := env.DB.CreateFederationEnrollment(t.Context(), db.CreateFederationEnrollmentParams{ //nolint:gosec // test-only bearer token
+		Token:            "ingest-once-token",
+		SpokeInstanceUID: federationTestSpokeUID,
+		ProjectID:        &project.ID,
+		Capabilities:     "pull,push",
+		Actor:            "tester",
+	})
+	require.NoError(t, err)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		projectPath(project.ID)+"/federation/events:ingest",
+		federationIngestBody(), bearer(created.Token))
+	require.Equal(t, http.StatusOK, resp.StatusCode, "ingest response: %s", raw)
+
+	evaluated := access.snapshot()
+	require.Lenf(t, evaluated, 1,
+		"ingest must evaluate federation authorization once; got %d evaluations", len(evaluated))
+	assert.Equal(t,
+		daemon.HostFederationOperation{ID: "ingestFederationProjectEvents", Mutation: true},
+		evaluated[0])
+}
+
+// TestFederationPollAuthorizesOncePerRequest is the control: the pull route has
+// no preauthorization middleware, so its single evaluation happens in the
+// handler and must not be fenced.
+func TestFederationPollAuthorizesOncePerRequest(t *testing.T) {
+	access := &countingFederationAccess{}
+	env := testenv.New(t, func(cfg *daemon.ServerConfig) {
+		cfg.HostFederationAccess = access
+	})
+	project := createFederatedHubProject(t, env, "hub-project")
+	created, err := env.DB.CreateFederationEnrollment(t.Context(), db.CreateFederationEnrollmentParams{ //nolint:gosec // test-only bearer token
+		Token:            "poll-once-token",
+		SpokeInstanceUID: federationTestSpokeUID,
+		ProjectID:        &project.ID,
+		Capabilities:     "pull",
+		Actor:            "tester",
+	})
+	require.NoError(t, err)
+
+	resp, raw := envDoRaw(t, env, http.MethodGet,
+		projectPath(project.ID)+"/federation/events?after_id=0", nil, bearer(created.Token))
+	require.Equal(t, http.StatusOK, resp.StatusCode, "poll response: %s", raw)
+
+	evaluated := access.snapshot()
+	require.Len(t, evaluated, 1)
+	assert.Equal(t,
+		daemon.HostFederationOperation{ID: "pollFederationProjectEvents"},
+		evaluated[0])
+}

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -31,7 +31,7 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/lease/actions/acquire",
 	}, func(ctx context.Context, in *api.ClaimActionRequest) (*api.ClaimActionResponse, error) {
 		ctx, principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body,
-			HostFederationOperation{ID: "acquireIssueLease", Mutation: true}, true, true)
+			federationTransportOperation("acquireIssueLease"), true)
 		if err != nil {
 			return nil, err
 		}
@@ -48,7 +48,7 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/lease/actions/renew",
 	}, func(ctx context.Context, in *api.ClaimActionRequest) (*api.ClaimActionResponse, error) {
 		ctx, principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body,
-			HostFederationOperation{ID: "renewIssueLease", Mutation: true}, true, true)
+			federationTransportOperation("renewIssueLease"), true)
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +65,7 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/lease/actions/release",
 	}, func(ctx context.Context, in *api.ClaimActionRequest) (*api.ClaimActionResponse, error) {
 		ctx, principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body,
-			HostFederationOperation{ID: "releaseIssueLease", Mutation: true}, true, true)
+			federationTransportOperation("releaseIssueLease"), true)
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +82,7 @@ func registerClaimHandlers(humaAPI huma.API, cfg ServerConfig) {
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/lease/actions/force_release",
 	}, func(ctx context.Context, in *api.ClaimActionRequest) (*api.ClaimActionResponse, error) {
 		ctx, principal, err := resolveClaimPrincipal(ctx, cfg, in.ProjectID, in.Authorization, in.Body,
-			HostFederationOperation{ID: "forceReleaseIssueLease", Mutation: true}, false, true)
+			federationTransportOperation("forceReleaseIssueLease"), false)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/daemon/handlers_claims_test.go
+++ b/internal/daemon/handlers_claims_test.go
@@ -51,6 +51,22 @@ func TestClaimAuthLocalDaemonMissingBearerRedactsPlaceholder(t *testing.T) {
 	assert.NotContains(t, string(raw), "Bearer <token>")
 }
 
+// TestInsecureReadonlyRejectsLeaseMutation pins the rule the
+// requireMutationLocal parameter encodes. The lease routes bypass the bearer
+// middleware, so this 401 can only come from the claim principal resolver's own
+// insecure-readonly guard.
+func TestInsecureReadonlyRejectsLeaseMutation(t *testing.T) {
+	env := testenv.New(t, testenv.WithInsecureReadonly())
+	project, issue := createClaimHubIssue(t, env)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost,
+		issuePath(project.ID, issue.ID, "lease/actions/acquire"),
+		map[string]any{"holder": "tester"}, nil)
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "acquire response: %s", raw)
+	assert.Contains(t, string(raw), "insecure-readonly")
+}
+
 func TestClaimRoutesRejectArchivedFederatedProject(t *testing.T) {
 	env := testenv.New(t, testenv.WithAuthToken("admin-token"))
 	project, issue := createClaimHubIssue(t, env)

--- a/internal/daemon/handlers_federation.go
+++ b/internal/daemon/handlers_federation.go
@@ -143,7 +143,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 	}, func(ctx context.Context, in *api.FederationProjectMetadataRequest) (*api.ProjectFederationResponse, error) {
 		var err error
 		ctx, _, err = authorizeFederationRequest(ctx, cfg, in.Authorization, in.ProjectID, "pull",
-			HostFederationOperation{ID: "getFederationProjectMetadata", Mutation: true})
+			federationTransportOperation("getFederationProjectMetadata"))
 		if err != nil {
 			return nil, err
 		}
@@ -587,7 +587,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 	}, func(ctx context.Context, in *api.FederationPollEventsRequest) (*api.PollEventsResponse, error) {
 		var err error
 		ctx, _, err = authorizeFederationRequest(ctx, cfg, in.Authorization, in.ProjectID, "pull",
-			HostFederationOperation{ID: "pollFederationProjectEvents"})
+			federationTransportOperation("pollFederationProjectEvents"))
 		if err != nil {
 			return nil, err
 		}
@@ -607,7 +607,7 @@ func registerFederationHandlers(humaAPI huma.API, cfg ServerConfig) {
 		MaxBodyBytes: 64 << 20,
 	}, func(ctx context.Context, in *api.FederationIngestEventsRequest) (*api.FederationIngestEventsResponse, error) {
 		ctx, principal, err := authorizeFederationRequest(ctx, cfg, in.Authorization, in.ProjectID, "push",
-			HostFederationOperation{ID: "ingestFederationProjectEvents", Mutation: true})
+			federationTransportOperation("ingestFederationProjectEvents"))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/daemon/host_access.go
+++ b/internal/daemon/host_access.go
@@ -103,6 +103,7 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 				"access_unavailable", "access decision unavailable")
 			return
 		}
+		rule := hostAccessRuleFor(operation.OperationID)
 		principal, ok := PrincipalFromContext(ctx.Context())
 		if ok && !validHostPrincipal(principal) {
 			writeHostAccessError(ctx, http.StatusUnauthorized,
@@ -110,8 +111,7 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 			return
 		}
 		if !ok {
-			if hostSelfAuthenticatedOperation(operation.OperationID) &&
-				hasBearerHeader(ctx.Header(authHeader)) {
+			if rule.AcceptsFederationBearer && hasBearerHeader(ctx.Header(authHeader)) {
 				next(ctx)
 				return
 			}
@@ -144,15 +144,15 @@ func withHostAccess(humaAPI huma.API, controller HostAccessController) {
 		if projectID, ok := positiveProjectID(pathParams["project_id"]); ok {
 			request.Operation.ProjectIDs = []int64{projectID}
 		}
-		if hostAccessRequiresAllProjects(operation.OperationID) {
+		if rule.RequiresAllProjects {
 			request.Operation.AllProjects = true
 		}
 		state := &hostAccessState{controller: controller, request: request}
-		if hostAccessResolvedByHandler(operation.OperationID) {
+		if rule.ResolvedByHandler {
 			next(withHostAccessState(ctx, state))
 			return
 		}
-		if len(request.Operation.ProjectIDs) == 0 && !hostAccessOperationWithoutProjectData(operation.OperationID) {
+		if len(request.Operation.ProjectIDs) == 0 && !rule.NoProjectData {
 			request.Operation.AllProjects = true
 			state.request.Operation.AllProjects = true
 		}
@@ -192,61 +192,6 @@ func withHostAccessState(ctx huma.Context, state *hostAccessState) huma.Context 
 		return nil
 	})
 	return huma.WithContext(ctx, fenced)
-}
-
-func hostSelfAuthenticatedOperation(operationID string) bool {
-	switch operationID {
-	case "getFederationProjectMetadata",
-		"pollFederationProjectEvents",
-		"ingestFederationProjectEvents",
-		"acquireIssueLease",
-		"renewIssueLease",
-		"releaseIssueLease",
-		"getIssueLeaseStatus":
-		return true
-	default:
-		return false
-	}
-}
-
-func hostAccessResolvedByHandler(operationID string) bool {
-	switch operationID {
-	case "mergeProject",
-		"moveIssue",
-		"listAllIssues",
-		"readUIReferences",
-		"readUILaunchTarget",
-		"patchProjectMetadata",
-		"createFederationEnrollment",
-		"rotateFederationEnrollment":
-		return true
-	default:
-		return false
-	}
-}
-
-// hostAccessRequiresAllProjects identifies operations whose result or side
-// effects can depend on relationships outside the project named in the URL.
-// Requiring complete authority before dispatch keeps denials from becoming
-// project-existence or relationship-state oracles.
-func hostAccessRequiresAllProjects(operationID string) bool {
-	switch operationID {
-	case "purgeIssue", "purgeProject", "closeIssue", "readyIssues", "showIssueByUID",
-		"importIssues", "pollProjectEvents", "streamEvents", "auditCloses", "digestProject",
-		"deleteLink", "rewriteAuthorIdentity":
-		return true
-	default:
-		return false
-	}
-}
-
-func hostAccessOperationWithoutProjectData(operationID string) bool {
-	switch operationID {
-	case "ping", "health", "instance":
-		return true
-	default:
-		return false
-	}
 }
 
 func positiveProjectID(raw string) (int64, bool) {

--- a/internal/daemon/host_access_rules.go
+++ b/internal/daemon/host_access_rules.go
@@ -1,0 +1,134 @@
+package daemon
+
+import "github.com/danielgtaylor/huma/v2"
+
+// hostAccessRule is the single source of truth for one route's access facts:
+// who is allowed to authenticate it, and how much project authority a decision
+// needs before dispatch. Operations with no entry take the conservative
+// default (every field false): the daemon bearer token is required, the scope
+// comes from {project_id} in the URL, and a route with no URL scope is
+// authorized against every project.
+type hostAccessRule struct {
+	// SelfAuthenticated marks a route whose handler owns authentication: the
+	// credential it carries is not the daemon token, so the bearer middleware
+	// must not pre-empt it. The middleware's bypass set is generated from this
+	// field (see selfAuthenticatedRoutes).
+	SelfAuthenticated bool
+
+	// AcceptsFederationBearer additionally lets the host-access middleware
+	// dispatch an unattributed bearer request, because the handler will
+	// authenticate it as a project-scoped federation enrollment. It is
+	// deliberately narrower than SelfAuthenticated: forceReleaseIssueLease
+	// bypasses the bearer middleware but passes allowEnrollment=false to
+	// resolveClaimPrincipal, so an enrollment credential must not reach it.
+	AcceptsFederationBearer bool
+
+	// ResolvedByHandler marks a route whose project scope is discovered during
+	// dispatch, so pre-dispatch authorization is deferred to the handler's
+	// authorizeHostProjectScope call.
+	ResolvedByHandler bool
+
+	// RequiresAllProjects marks a route whose result or side effects can depend
+	// on relationships outside the project named in the URL. Requiring complete
+	// authority before dispatch keeps denials from becoming project-existence
+	// or relationship-state oracles.
+	RequiresAllProjects bool
+
+	// NoProjectData marks a route that reads no project data at all, so a
+	// missing URL scope must not be widened to every project.
+	NoProjectData bool
+}
+
+var hostAccessRules = buildHostAccessRules()
+
+func buildHostAccessRules() map[string]hostAccessRule {
+	rules := make(map[string]hostAccessRule)
+	registerHostAccessRules(rules, hostAccessRule{
+		SelfAuthenticated: true, AcceptsFederationBearer: true,
+	}, "getFederationProjectMetadata", "pollFederationProjectEvents",
+		"ingestFederationProjectEvents", "acquireIssueLease", "renewIssueLease",
+		"releaseIssueLease", "getIssueLeaseStatus")
+	registerHostAccessRules(rules, hostAccessRule{SelfAuthenticated: true},
+		"forceReleaseIssueLease")
+	registerHostAccessRules(rules, hostAccessRule{ResolvedByHandler: true},
+		"mergeProject", "moveIssue", "listAllIssues", "readUIReferences",
+		"readUILaunchTarget", "patchProjectMetadata", "createFederationEnrollment",
+		"rotateFederationEnrollment")
+	registerHostAccessRules(rules, hostAccessRule{RequiresAllProjects: true},
+		"purgeIssue", "purgeProject", "closeIssue", "readyIssues", "showIssueByUID",
+		"importIssues", "pollProjectEvents", "streamEvents", "auditCloses",
+		"digestProject", "deleteLink", "rewriteAuthorIdentity")
+	registerHostAccessRules(rules, hostAccessRule{NoProjectData: true},
+		"ping", "health", "instance")
+	return rules
+}
+
+// registerHostAccessRules mirrors registerHostOperations' discipline: a
+// contradictory rule or a duplicate registration is a programming error that
+// fails at process start rather than becoming a silent access decision.
+func registerHostAccessRules(
+	rules map[string]hostAccessRule,
+	rule hostAccessRule,
+	operationIDs ...string,
+) {
+	for _, operationID := range operationIDs {
+		if conflict := hostAccessRuleConflict(rule); conflict != "" {
+			panic("contradictory host access rule for " + operationID + ": " + conflict)
+		}
+		if _, exists := rules[operationID]; exists {
+			panic("duplicate host access rule: " + operationID)
+		}
+		rules[operationID] = rule
+	}
+}
+
+// hostAccessRuleConflict reports why a rule asserts two facts that cannot both
+// hold, or "" when the rule is internally consistent.
+func hostAccessRuleConflict(rule hostAccessRule) string {
+	switch {
+	case rule.NoProjectData && rule.RequiresAllProjects:
+		return "an operation cannot both touch no project data and require " +
+			"authority over every project"
+	case rule.AcceptsFederationBearer && !rule.SelfAuthenticated:
+		return "a federation bearer cannot reach a route the bearer middleware pre-empts"
+	default:
+		return ""
+	}
+}
+
+func hostAccessRuleFor(operationID string) hostAccessRule {
+	return hostAccessRules[operationID]
+}
+
+// routeTemplate is one registered route in http.ServeMux pattern form.
+type routeTemplate struct {
+	Method string
+	Path   string
+}
+
+// registeredOperations returns every operation huma registered on doc, keyed by
+// operation ID. It is the bridge between the operation-ID key space the access
+// rules use and the URL templates the routes are registered with.
+func registeredOperations(doc *huma.OpenAPI) map[string]routeTemplate {
+	operations := make(map[string]routeTemplate)
+	if doc == nil {
+		return operations
+	}
+	for _, pathItem := range doc.Paths {
+		if pathItem == nil {
+			continue
+		}
+		for _, operation := range []*huma.Operation{
+			pathItem.Get, pathItem.Put, pathItem.Post, pathItem.Delete,
+			pathItem.Options, pathItem.Head, pathItem.Patch, pathItem.Trace,
+		} {
+			if operation == nil {
+				continue
+			}
+			operations[operation.OperationID] = routeTemplate{
+				Method: operation.Method, Path: operation.Path,
+			}
+		}
+	}
+	return operations
+}

--- a/internal/daemon/host_access_rules_internal_test.go
+++ b/internal/daemon/host_access_rules_internal_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHostAccessRulesReferenceRegisteredOperations catches a rule keyed by a
+// misspelled or removed operation ID, which would otherwise silently apply to
+// nothing.
+func TestHostAccessRulesReferenceRegisteredOperations(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	t.Cleanup(func() { _ = srv.Close() })
+	registered := registeredOperations(srv.API().OpenAPI())
+
+	for operationID := range hostAccessRules {
+		_, ok := registered[operationID]
+		assert.Truef(t, ok, "host access rule references unregistered operation %q", operationID)
+	}
+}
+
+func TestRegisterHostAccessRulesRejectsContradictoryRules(t *testing.T) {
+	require.PanicsWithValue(t,
+		"contradictory host access rule for purgeProject: an operation cannot both "+
+			"touch no project data and require authority over every project",
+		func() {
+			registerHostAccessRules(map[string]hostAccessRule{},
+				hostAccessRule{NoProjectData: true, RequiresAllProjects: true}, "purgeProject")
+		})
+
+	require.PanicsWithValue(t,
+		"contradictory host access rule for acquireIssueLease: a federation bearer "+
+			"cannot reach a route the bearer middleware pre-empts",
+		func() {
+			registerHostAccessRules(map[string]hostAccessRule{},
+				hostAccessRule{AcceptsFederationBearer: true}, "acquireIssueLease")
+		})
+}
+
+func TestRegisterHostAccessRulesRejectsDuplicateRegistration(t *testing.T) {
+	rules := map[string]hostAccessRule{}
+	registerHostAccessRules(rules, hostAccessRule{NoProjectData: true}, "ping")
+
+	require.PanicsWithValue(t, "duplicate host access rule: ping", func() {
+		registerHostAccessRules(rules, hostAccessRule{RequiresAllProjects: true}, "ping")
+	})
+}
+
+// TestHostAccessRulesPreserveTheForceReleaseAsymmetry pins the one deliberate
+// difference between the bearer-middleware bypass set and the set of routes a
+// federation enrollment credential may authenticate. forceReleaseIssueLease
+// passes allowEnrollment=false to resolveClaimPrincipal, so an enrollment
+// token must not reach it even though the middleware defers to the handler.
+func TestHostAccessRulesPreserveTheForceReleaseAsymmetry(t *testing.T) {
+	forceRelease := hostAccessRuleFor("forceReleaseIssueLease")
+	assert.True(t, forceRelease.SelfAuthenticated,
+		"force release must stay out of the bearer middleware's pre-emption")
+	assert.False(t, forceRelease.AcceptsFederationBearer,
+		"force release must not accept a federation enrollment credential")
+
+	acquire := hostAccessRuleFor("acquireIssueLease")
+	assert.True(t, acquire.SelfAuthenticated)
+	assert.True(t, acquire.AcceptsFederationBearer)
+}
+
+// TestHostAccessRulesPreserveHandlerResolvedScopes catches route-table drift
+// that would authorize one of these operations against every project before
+// its handler has resolved the projects it actually touches.
+func TestHostAccessRulesPreserveHandlerResolvedScopes(t *testing.T) {
+	for _, operationID := range []string{
+		"readUIReferences",
+		"readUILaunchTarget",
+		"patchProjectMetadata",
+	} {
+		assert.Truef(t, hostAccessRuleFor(operationID).ResolvedByHandler,
+			"%s must defer project-scope authorization to its handler", operationID)
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -186,6 +186,7 @@ type Server struct {
 	baseHandler http.Handler
 	handler     http.Handler
 	api         huma.API
+	authPolicy  authPolicy
 
 	shutdownTimeout time.Duration
 }
@@ -247,6 +248,10 @@ func NewServer(cfg ServerConfig) *Server {
 	mux.Handle("/", webHandler)
 	applyErrorEnvelopeResponses(humaAPI.OpenAPI())
 	applyJSONBlobSchemaOverrides(humaAPI.OpenAPI())
+	policy := cfg.authPolicy()
+	policy.SelfAuthenticatedRoutes = newSelfAuthenticatedRouteMatcher(
+		selfAuthenticatedRoutes(humaAPI.OpenAPI()))
+	s.authPolicy = policy
 
 	s.baseHandler = mux
 	s.handler, _ = s.HandlerFor(ListenerPolicy{Kind: ListenerSocket})
@@ -285,7 +290,7 @@ func (s *Server) HandlerFor(policy ListenerPolicy) (http.Handler, error) {
 		base = withIdleAdmission(s.cfg.IdleAdmission, base)
 		base = withFederationIngestPreauthorization(s.cfg, base)
 		base = withTrustedProxyActor(s.cfg)(base)
-		base = requireBearer(s.cfg.authPolicy(), s.cfg.DB)(base)
+		base = requireBearer(s.authPolicy, s.cfg.DB)(base)
 		base = withGzip(base)
 		base = withOwnerLocalTransport(base)
 	}


### PR DESCRIPTION
Before this change, the daemon's per-route authentication facts lived in five places that had to agree by hand: four switch statements listing operation IDs, two URL parsers in the bearer middleware that re-implemented route matching character by character, and eleven repeated `HostFederationOperation{...}` literals at call sites. Adding or renaming a route meant updating each list separately, and nothing failed when one was missed — a forgotten entry silently became an access decision.

Now each fact lives in one checked table, and the tables cross-check each other:

- `hostAccessRules` (`internal/daemon/host_access_rules.go`) holds every operation's access facts, keyed by Huma operation ID. Registration panics on duplicate or contradictory rules, and a test fails if a rule names an operation that is no longer registered.
- The bearer middleware's bypass set is generated from the routes Huma actually registered, so renaming a path in a handler moves the bypass with it. Matching runs on an `http.ServeMux` built from those route templates, which makes it behave the same way the real router does. Exact-method checks keep net/http from widening GET patterns to HEAD, and the old parsers' numeric `{project_id}` guard is preserved; both are pinned by tests.
- `federationTransportOperations` (`internal/daemon/federation_access.go`) replaces the eleven literals. Two GETs that write while serving keep their transaction fences — `getIssueLeaseStatus` expires timed claims and `getFederationProjectMetadata` can refresh the federation baseline — and a test pins that deliberate divergence from the read policy those routes declare.

The one intentional asymmetry is kept and now has an HTTP-level test: `forceReleaseIssueLease` bypasses the bearer middleware but never accepts a federation enrollment credential. The federation ingest pre-authorization keeps its own URL parser because it runs before Huma may read a 64 MiB body; a test pins that parser to the registered route template so a rename cannot strand it.

Two pieces of dead state are removed: the claim principal's `Local` field (written, never read) and `resolveClaimPrincipal`'s `requireMutationLocal` parameter (true at every call site).

No route, wire-format, API-contract, or persisted-schema changes. Addresses findings S06-1 and S07-2.
