### PR TITLE
Consolidate federation replica leave state and enrollment cleanup

### DIFF
--- a/internal/daemon/federation_rebind_service.go
+++ b/internal/daemon/federation_rebind_service.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"go.kenn.io/kata/internal/api"
@@ -135,7 +134,10 @@ func RebindFederationReplica(
 		)
 	}
 	key := federationReplicaTransitionKey(store, project.Name)
-	if _, pending := federationReplicaLeaveIntents[key]; pending || federationReplicaIsSuppressed(key) {
+	// Rebind reports one message for both leave states; it does not use
+	// leaveBlockedError, whose wording distinguishes them for config-driven
+	// hub operations.
+	if federationReplicaTransitions.state(key) != federationReplicaIdle {
 		ensureFederationReplicaMu.Unlock()
 		return RebindFederationReplicaResult{}, federationReplicaError(
 			ErrFederationReplicaLeavePending,
@@ -195,7 +197,7 @@ func RebindFederationReplica(
 	targetCredential := credential
 	targetCredential.HubURL = targetURL
 	targetCredential.AllowInsecure = false
-	finishOperation := registerFederationReplicaHubOperationLocked(key)
+	finishOperation := federationReplicaTransitions.registerHubOperation(key)
 	ensureFederationReplicaMu.Unlock()
 	defer finishOperation()
 
@@ -231,7 +233,7 @@ func RebindFederationReplica(
 	defer finishSyncDrain()
 	ensureFederationReplicaMu.Lock()
 	defer ensureFederationReplicaMu.Unlock()
-	if _, pending := federationReplicaLeaveIntents[key]; pending || federationReplicaIsSuppressed(key) {
+	if federationReplicaTransitions.state(key) != federationReplicaIdle {
 		return RebindFederationReplicaResult{}, federationReplicaError(
 			ErrFederationReplicaLeavePending,
 			"explicit federation leave began during rebind validation",
@@ -486,31 +488,6 @@ func validateFederationRebindBindingState(
 
 func canonicalFederationRebindBaseURL(raw string) (string, error) {
 	return config.CanonicalHTTPBaseURL(raw)
-}
-
-func registerFederationReplicaHubOperationLocked(key string) func() {
-	state := federationReplicaHubOperations[key]
-	if state == nil {
-		state = &federationReplicaHubOperationState{done: make(chan struct{})}
-		federationReplicaHubOperations[key] = state
-	}
-	state.count++
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			ensureFederationReplicaMu.Lock()
-			defer ensureFederationReplicaMu.Unlock()
-			state := federationReplicaHubOperations[key]
-			if state == nil {
-				return
-			}
-			state.count--
-			if state.count == 0 {
-				delete(federationReplicaHubOperations, key)
-				close(state.done)
-			}
-		})
-	}
 }
 
 func fetchFederationRebindMetadata(

--- a/internal/daemon/federation_replica_service.go
+++ b/internal/daemon/federation_replica_service.go
@@ -231,10 +231,8 @@ func PrepareFederationReplicaLeave(
 	key := federationReplicaTransitionKey(store, project.Name)
 
 	ensureFederationReplicaMu.Lock()
-	federationReplicaTransitions.markLeavePending(key)
 	match, found, err := managed.FindManagedFederationCredential(ctx, project.Name)
 	if err != nil {
-		federationReplicaTransitions.clearLeave(key)
 		ensureFederationReplicaMu.Unlock()
 		if errors.Is(err, config.ErrFederationCredentialConflict) {
 			return PrepareFederationReplicaLeaveResult{}, err
@@ -248,7 +246,6 @@ func PrepareFederationReplicaLeave(
 		replacement.Credential.LeavePending = true
 		replacement.Credential.PendingEnrollmentID = 0
 		if err := managed.ReplaceManagedFederationCredential(ctx, match, replacement); err != nil {
-			federationReplicaTransitions.clearLeave(key)
 			ensureFederationReplicaMu.Unlock()
 			if errors.Is(err, config.ErrFederationCredentialConflict) {
 				return PrepareFederationReplicaLeaveResult{}, err
@@ -259,6 +256,12 @@ func PrepareFederationReplicaLeave(
 		}
 		match = replacement
 	}
+	// Publish the in-memory leave state only after the durable mark succeeded.
+	// Suppression reads are lock-free, so an earlier publish would let a
+	// concurrent reconciler record success for a leave that then fails to
+	// prepare, and rolling the publish back would erase a completed leave's
+	// suppression when a retried prepare fails.
+	federationReplicaTransitions.markLeavePending(key)
 	ensureFederationReplicaMu.Unlock()
 
 	for {

--- a/internal/daemon/federation_replica_service.go
+++ b/internal/daemon/federation_replica_service.go
@@ -51,18 +51,6 @@ var (
 // has no reverse edge.
 var ensureFederationReplicaMu sync.Mutex
 
-type federationReplicaHubOperationState struct {
-	count int
-	done  chan struct{}
-}
-
-var (
-	federationReplicaHubOperations = make(map[string]*federationReplicaHubOperationState)
-	federationReplicaLeaveIntents  = make(map[string]struct{})
-	federationReplicaSuppressionMu sync.RWMutex
-	federationReplicaSuppressed    = make(map[string]struct{})
-)
-
 // FederationReplicaError is a classified application error returned by
 // EnsureFederationReplica. HTTP handlers translate it into the public wire
 // status and error code at the transport boundary.
@@ -178,19 +166,8 @@ func beginFederationReplicaHubOperation(
 	defer ensureFederationReplicaMu.Unlock()
 
 	key := federationReplicaTransitionKey(store, projectName)
-	if _, pending := federationReplicaLeaveIntents[key]; pending {
-		return nil, federationReplicaError(
-			ErrFederationReplicaLeavePending,
-			"explicit federation leave is pending",
-			"",
-		)
-	}
-	if federationReplicaIsSuppressed(key) {
-		return nil, federationReplicaError(
-			ErrFederationReplicaLeavePending,
-			"federation mapping was explicitly left",
-			"",
-		)
+	if err := federationReplicaTransitions.leaveBlockedError(key); err != nil {
+		return nil, err
 	}
 	current, found, err := credentials.FederationCredential(ctx, baseline.ProjectUID)
 	if err != nil {
@@ -208,12 +185,7 @@ func beginFederationReplicaHubOperation(
 			"",
 		)
 	}
-	state := federationReplicaHubOperations[key]
-	if state == nil {
-		state = &federationReplicaHubOperationState{done: make(chan struct{})}
-		federationReplicaHubOperations[key] = state
-	}
-	state.count++
+	finishOperation := federationReplicaTransitions.registerHubOperationLocked(key)
 	var once sync.Once
 	var (
 		leavePending bool
@@ -223,38 +195,16 @@ func beginFederationReplicaHubOperation(
 		once.Do(func() {
 			ensureFederationReplicaMu.Lock()
 			defer ensureFederationReplicaMu.Unlock()
-			match, found, err := managed.FindManagedFederationCredential(
-				finishCtx, projectName,
+			pendingFound, recordErr := recordFederationReplicaPendingEnrollmentLocked(
+				finishCtx, managed, projectName, enrollmentID,
 			)
-			if err != nil {
-				finishErr = credentialIOError(
-					"read managed reservation after hub operation",
-				)
-			} else if found && match.Credential.LeavePending {
-				leavePending = true
-				if enrollmentID > 0 {
-					replacement := match
-					replacement.Credential.PendingEnrollmentID = enrollmentID
-					if err := managed.ReplaceManagedFederationCredential(
-						finishCtx, match, replacement,
-					); err != nil {
-						finishErr = credentialIOError(
-							"record pending enrollment after hub operation",
-						)
-					}
-				}
-			} else {
-				_, leavePending = federationReplicaLeaveIntents[key]
+			leavePending = pendingFound
+			finishErr = recordErr
+			if !pendingFound && recordErr == nil {
+				leavePending = federationReplicaTransitions.state(key) ==
+					federationReplicaLeavePending
 			}
-			state := federationReplicaHubOperations[key]
-			if state == nil {
-				return
-			}
-			state.count--
-			if state.count == 0 {
-				delete(federationReplicaHubOperations, key)
-				close(state.done)
-			}
+			finishOperation()
 		})
 		return leavePending, finishErr
 	}, nil
@@ -281,12 +231,10 @@ func PrepareFederationReplicaLeave(
 	key := federationReplicaTransitionKey(store, project.Name)
 
 	ensureFederationReplicaMu.Lock()
-	federationReplicaLeaveIntents[key] = struct{}{}
-	setFederationReplicaSuppressed(key, true)
+	federationReplicaTransitions.markLeavePending(key)
 	match, found, err := managed.FindManagedFederationCredential(ctx, project.Name)
 	if err != nil {
-		delete(federationReplicaLeaveIntents, key)
-		setFederationReplicaSuppressed(key, false)
+		federationReplicaTransitions.clearLeave(key)
 		ensureFederationReplicaMu.Unlock()
 		if errors.Is(err, config.ErrFederationCredentialConflict) {
 			return PrepareFederationReplicaLeaveResult{}, err
@@ -300,8 +248,7 @@ func PrepareFederationReplicaLeave(
 		replacement.Credential.LeavePending = true
 		replacement.Credential.PendingEnrollmentID = 0
 		if err := managed.ReplaceManagedFederationCredential(ctx, match, replacement); err != nil {
-			delete(federationReplicaLeaveIntents, key)
-			setFederationReplicaSuppressed(key, false)
+			federationReplicaTransitions.clearLeave(key)
 			ensureFederationReplicaMu.Unlock()
 			if errors.Is(err, config.ErrFederationCredentialConflict) {
 				return PrepareFederationReplicaLeaveResult{}, err
@@ -316,8 +263,8 @@ func PrepareFederationReplicaLeave(
 
 	for {
 		ensureFederationReplicaMu.Lock()
-		state := federationReplicaHubOperations[key]
-		if state == nil {
+		drained, waiting := federationReplicaTransitions.drainSignal(key)
+		if !waiting {
 			match, found, err = managed.FindManagedFederationCredential(ctx, project.Name)
 			ensureFederationReplicaMu.Unlock()
 			if err != nil {
@@ -333,41 +280,79 @@ func PrepareFederationReplicaLeave(
 				ManagedReservationFound: found,
 			}, nil
 		}
-		done := state.done
 		ensureFederationReplicaMu.Unlock()
 		select {
 		case <-ctx.Done():
 			return PrepareFederationReplicaLeaveResult{}, ctx.Err()
-		case <-done:
+		case <-drained:
 		}
 	}
+}
+
+// RecordFederationReplicaPendingEnrollment stamps a completed hub enrollment
+// onto a managed reservation that is already marked for leave, so durable
+// leave cleanup can revoke it after a crash. It reports whether a leave-pending
+// reservation was found, and serializes with EnsureFederationReplica and
+// PrepareFederationReplicaLeave.
+//
+// The config reconciler needs this after its hub operation has already
+// finished, so it cannot go through the finish closure, which fires once.
+func RecordFederationReplicaPendingEnrollment(
+	ctx context.Context,
+	credentials config.FederationCredentialStore,
+	projectName string,
+	enrollmentID int64,
+) (bool, error) {
+	managed, err := managedCredentialStore(credentials)
+	if err != nil {
+		return false, err
+	}
+	ensureFederationReplicaMu.Lock()
+	defer ensureFederationReplicaMu.Unlock()
+	return recordFederationReplicaPendingEnrollmentLocked(
+		ctx, managed, projectName, enrollmentID,
+	)
+}
+
+// recordFederationReplicaPendingEnrollmentLocked is the single implementation
+// of the stamp. The caller must hold ensureFederationReplicaMu, which is what
+// keeps this read-modify-write atomic against PrepareFederationReplicaLeave.
+// PendingEnrollmentID is only ever written on a credential that is already
+// LeavePending, which the credential store's write-path guard requires.
+func recordFederationReplicaPendingEnrollmentLocked(
+	ctx context.Context,
+	managed config.FederationManagedCredentialStore,
+	projectName string,
+	enrollmentID int64,
+) (bool, error) {
+	match, found, err := managed.FindManagedFederationCredential(ctx, projectName)
+	if err != nil {
+		return false, credentialIOError("read managed reservation after hub operation")
+	}
+	if !found || !match.Credential.LeavePending {
+		return false, nil
+	}
+	if enrollmentID <= 0 || match.Credential.PendingEnrollmentID == enrollmentID {
+		return true, nil
+	}
+	replacement := match
+	replacement.Credential.PendingEnrollmentID = enrollmentID
+	if err := managed.ReplaceManagedFederationCredential(ctx, match, replacement); err != nil {
+		return true, credentialIOError("record pending enrollment after hub operation")
+	}
+	return true, nil
 }
 
 func federationReplicaTransitionKey(store db.Storage, projectName string) string {
 	return store.InstanceUID() + "\x00" + strings.TrimSpace(projectName)
 }
 
-// FederationReplicaMappingSuppressed reports whether explicit leave completed
-// for this mapping in the current daemon process.
+// FederationReplicaMappingSuppressed reports whether explicit leave was
+// prepared or completed for this mapping in the current daemon process.
 func FederationReplicaMappingSuppressed(store db.Storage, projectName string) bool {
-	return federationReplicaIsSuppressed(federationReplicaTransitionKey(store, projectName))
-}
-
-func federationReplicaIsSuppressed(key string) bool {
-	federationReplicaSuppressionMu.RLock()
-	defer federationReplicaSuppressionMu.RUnlock()
-	_, suppressed := federationReplicaSuppressed[key]
-	return suppressed
-}
-
-func setFederationReplicaSuppressed(key string, suppressed bool) {
-	federationReplicaSuppressionMu.Lock()
-	defer federationReplicaSuppressionMu.Unlock()
-	if suppressed {
-		federationReplicaSuppressed[key] = struct{}{}
-		return
-	}
-	delete(federationReplicaSuppressed, key)
+	return federationReplicaTransitions.state(
+		federationReplicaTransitionKey(store, projectName),
+	) != federationReplicaIdle
 }
 
 // LeaveFederationReplica detaches a spoke replica and removes its local
@@ -458,9 +443,7 @@ func leaveFederationReplicaState(
 			)
 		}
 	}
-	key := federationReplicaTransitionKey(store, project.Name)
-	setFederationReplicaSuppressed(key, true)
-	delete(federationReplicaLeaveIntents, key)
+	federationReplicaTransitions.markLeft(federationReplicaTransitionKey(store, project.Name))
 	return result, nil
 }
 
@@ -667,9 +650,9 @@ func ensureFederationReplicaState(
 			return result, err
 		}
 	}
-	key := federationReplicaTransitionKey(store, p.ProjectName)
-	setFederationReplicaSuppressed(key, false)
-	delete(federationReplicaLeaveIntents, key)
+	federationReplicaTransitions.clearLeave(
+		federationReplicaTransitionKey(store, p.ProjectName),
+	)
 	return result, nil
 }
 

--- a/internal/daemon/federation_replica_service_test.go
+++ b/internal/daemon/federation_replica_service_test.go
@@ -661,6 +661,128 @@ func TestReserveFederationReplicaCredentialRejectsBindingThatAppearedAfterPrefli
 	assert.False(t, found)
 }
 
+// prepareLeaveFailureCredentialStore injects managed lookup and replacement
+// failures into leave preparation, with hooks that observe suppression while
+// each store call is in flight. FederationReplicaMappingSuppressed is a
+// lock-free read, so the hooks see exactly what a concurrent reconciler sees.
+type prepareLeaveFailureCredentialStore struct {
+	*replicaCredentialStore
+	findErr    error
+	managedErr error
+	onFind     func()
+	onReplace  func()
+}
+
+func (s *prepareLeaveFailureCredentialStore) FindManagedFederationCredential(
+	ctx context.Context, projectName string,
+) (config.FederationManagedCredentialReservation, bool, error) {
+	if s.onFind != nil {
+		s.onFind()
+	}
+	if s.findErr != nil {
+		return config.FederationManagedCredentialReservation{}, false, s.findErr
+	}
+	return s.replicaCredentialStore.FindManagedFederationCredential(ctx, projectName)
+}
+
+func (s *prepareLeaveFailureCredentialStore) ReplaceManagedFederationCredential(
+	ctx context.Context,
+	expected config.FederationManagedCredentialReservation,
+	replacement config.FederationManagedCredentialReservation,
+) error {
+	if s.onReplace != nil {
+		s.onReplace()
+	}
+	if s.managedErr != nil {
+		return s.managedErr
+	}
+	return s.replicaCredentialStore.ReplaceManagedFederationCredential(
+		ctx, expected, replacement,
+	)
+}
+
+func TestPrepareFederationReplicaLeaveFailurePublishesNoLeaveState(t *testing.T) {
+	newBoundStore := func(t *testing.T) (
+		*sqlitestore.Store, db.Project, *prepareLeaveFailureCredentialStore,
+	) {
+		t.Helper()
+		store := openReplicaServiceStore(t)
+		project, err := store.CreateProjectWithUID(
+			context.Background(), "spoke-project", replicaLocalProjectUID,
+		)
+		require.NoError(t, err)
+		credentials := &prepareLeaveFailureCredentialStore{
+			replicaCredentialStore: newReplicaCredentialStore(),
+		}
+		reservation := replicaServiceParams().Credential
+		reservation.ManagedByConfig = true
+		reservation.SpokeProjectName = project.Name
+		require.NoError(t, credentials.ReserveManagedFederationCredential(
+			context.Background(), config.FederationManagedCredentialReservation{
+				ProjectUID: replicaHubProjectUID,
+				Credential: reservation,
+			},
+		))
+		return store, project, credentials
+	}
+
+	t.Run("failed lookup never suppresses reconciliation", func(t *testing.T) {
+		ctx := context.Background()
+		store, project, credentials := newBoundStore(t)
+		suppressedDuringFind := false
+		credentials.onFind = func() {
+			suppressedDuringFind = suppressedDuringFind ||
+				daemon.FederationReplicaMappingSuppressed(store, project.Name)
+		}
+		credentials.findErr = errors.New("injected lookup failure")
+
+		_, err := daemon.PrepareFederationReplicaLeave(ctx, store, credentials, project.ID)
+
+		require.ErrorIs(t, err, daemon.ErrFederationReplicaCredentialIO)
+		assert.False(t, suppressedDuringFind,
+			"suppression must not be observable before the durable leave mark succeeds")
+		assert.False(t, daemon.FederationReplicaMappingSuppressed(store, project.Name))
+	})
+
+	t.Run("failed durable mark never suppresses reconciliation", func(t *testing.T) {
+		ctx := context.Background()
+		store, project, credentials := newBoundStore(t)
+		suppressedDuringReplace := false
+		credentials.onReplace = func() {
+			suppressedDuringReplace = suppressedDuringReplace ||
+				daemon.FederationReplicaMappingSuppressed(store, project.Name)
+		}
+		credentials.managedErr = errors.New("injected replacement failure")
+
+		_, err := daemon.PrepareFederationReplicaLeave(ctx, store, credentials, project.ID)
+
+		require.ErrorIs(t, err, daemon.ErrFederationReplicaCredentialIO)
+		assert.False(t, suppressedDuringReplace,
+			"suppression must not be observable before the durable leave mark succeeds")
+		assert.False(t, daemon.FederationReplicaMappingSuppressed(store, project.Name))
+		current, found, readErr := credentials.FederationCredential(ctx, replicaHubProjectUID)
+		require.NoError(t, readErr)
+		require.True(t, found)
+		assert.False(t, current.LeavePending,
+			"a failed replacement must leave the reservation unmarked")
+	})
+
+	t.Run("failed retry preserves a completed leave", func(t *testing.T) {
+		ctx := context.Background()
+		store, project, credentials := newBoundStore(t)
+		_, err := daemon.LeaveFederationReplica(ctx, store, credentials, nil, project.ID)
+		require.NoError(t, err)
+		require.True(t, daemon.FederationReplicaMappingSuppressed(store, project.Name))
+		credentials.findErr = errors.New("injected lookup failure")
+
+		_, err = daemon.PrepareFederationReplicaLeave(ctx, store, credentials, project.ID)
+
+		require.ErrorIs(t, err, daemon.ErrFederationReplicaCredentialIO)
+		assert.True(t, daemon.FederationReplicaMappingSuppressed(store, project.Name),
+			"a failed leave retry must not erase the completed leave's suppression")
+	})
+}
+
 func TestPrepareFederationReplicaLeaveDrainsAndBlocksHubOperations(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()

--- a/internal/daemon/federation_replica_service_test.go
+++ b/internal/daemon/federation_replica_service_test.go
@@ -25,18 +25,19 @@ const (
 )
 
 type replicaCredentialStore struct {
-	mu           sync.Mutex
-	credentials  map[string]config.FederationCredential
-	readErr      error
-	storeErr     error
-	deleteErr    error
-	rekeyErr     error
-	replaceErr   error
-	readCalls    int
-	storeCalls   int
-	deleteCalls  int
-	rekeyCalls   int
-	replaceCalls int
+	mu                  sync.Mutex
+	credentials         map[string]config.FederationCredential
+	readErr             error
+	storeErr            error
+	deleteErr           error
+	rekeyErr            error
+	replaceErr          error
+	readCalls           int
+	storeCalls          int
+	deleteCalls         int
+	rekeyCalls          int
+	replaceCalls        int
+	managedReplaceCalls int
 }
 
 // baseCredentialStore deliberately exposes only the public credential CRUD
@@ -191,6 +192,7 @@ func (s *replicaCredentialStore) ReplaceManagedFederationCredential(
 ) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.managedReplaceCalls++
 	current, found := s.credentials[expected.ProjectUID]
 	if !found || current != expected.Credential ||
 		replacement.ProjectUID != expected.ProjectUID {
@@ -231,6 +233,12 @@ func (s *replicaCredentialStore) storeCallCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.storeCalls
+}
+
+func (s *replicaCredentialStore) managedReplaces() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.managedReplaceCalls
 }
 
 func (s *replicaCredentialStore) setDeleteError(err error) {
@@ -275,6 +283,33 @@ func (s *replicaCredentialStoreBarrier) StoreFederationCredential(
 
 func (s *replicaCredentialStoreBarrier) releaseStore() {
 	s.releaseOnce.Do(func() { close(s.storeRelease) })
+}
+
+type leavePendingBarrierCredentialStore struct {
+	*replicaCredentialStore
+	leavePending chan struct{}
+	pendingOnce  sync.Once
+}
+
+func newLeavePendingBarrierCredentialStore() *leavePendingBarrierCredentialStore {
+	return &leavePendingBarrierCredentialStore{
+		replicaCredentialStore: newReplicaCredentialStore(),
+		leavePending:           make(chan struct{}),
+	}
+}
+
+func (s *leavePendingBarrierCredentialStore) ReplaceManagedFederationCredential(
+	ctx context.Context,
+	expected config.FederationManagedCredentialReservation,
+	replacement config.FederationManagedCredentialReservation,
+) error {
+	err := s.replicaCredentialStore.ReplaceManagedFederationCredential(
+		ctx, expected, replacement,
+	)
+	if err == nil && replacement.Credential.LeavePending {
+		s.pendingOnce.Do(func() { close(s.leavePending) })
+	}
+	return err
 }
 
 type managedCleanupConflictCredentialStore struct {
@@ -1941,6 +1976,285 @@ func TestEnsureFederationReplicaRejectsInvalidCanonicalOriginsBeforeMutation(t *
 		assert.ErrorIs(t, err, daemon.ErrFederationReplicaCredentialConflict)
 		assert.Equal(t, original, credentials.credentials[replicaHubProjectUID])
 		assert.Zero(t, credentials.storeCallCount())
+	})
+}
+
+func TestEnsureFederationReplicaClearsLeaveStateAndRepermitsHubOperations(t *testing.T) {
+	ctx := context.Background()
+	store := openReplicaServiceStore(t)
+	params := replicaServiceParams()
+	project, err := store.CreateProjectWithUID(ctx, params.ProjectName, replicaHubProjectUID)
+	require.NoError(t, err)
+	credentials := newReplicaCredentialStore()
+	reservation := params.Credential
+	reservation.ManagedByConfig = true
+	reservation.SpokeProjectName = project.Name
+	baseline := config.FederationManagedCredentialReservation{
+		ProjectUID: replicaHubProjectUID,
+		Credential: reservation,
+	}
+	require.NoError(t, credentials.ReserveManagedFederationCredential(ctx, baseline))
+
+	_, err = daemon.LeaveFederationReplica(ctx, store, credentials, nil, project.ID)
+	require.NoError(t, err)
+	require.True(t, daemon.FederationReplicaMappingSuppressed(store, project.Name),
+		"a completed leave suppresses config-driven reconciliation")
+	_, err = daemon.BeginFederationReplicaHubOperation(
+		ctx, store, credentials, project.Name, baseline,
+	)
+	require.ErrorIs(t, err, daemon.ErrFederationReplicaLeavePending)
+	assert.EqualError(t, err, "federation mapping was explicitly left")
+
+	rejoined := params.Credential
+	rejoined.ManagedByConfig = true
+	rejoined.SpokeProjectName = project.Name
+	rejoined.Capabilities = "pull,push"
+	params.Credential = rejoined
+	_, err = daemon.EnsureFederationReplica(ctx, store, credentials, nil, params)
+	require.NoError(t, err)
+
+	assert.False(t, daemon.FederationReplicaMappingSuppressed(store, project.Name),
+		"a successful ensure re-permits reconciliation for the mapping")
+	finish, err := daemon.BeginFederationReplicaHubOperation(
+		ctx, store, credentials, project.Name,
+		config.FederationManagedCredentialReservation{
+			ProjectUID: replicaHubProjectUID, Credential: rejoined,
+		},
+	)
+	require.NoError(t, err)
+	leavePending, finishErr := finish(ctx, 0)
+	require.NoError(t, finishErr)
+	assert.False(t, leavePending)
+}
+
+func TestFederationReplicaHubOperationsRaceWithLeavePreparation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	store := openReplicaServiceStore(t)
+	project, err := store.CreateProjectWithUID(ctx, "spoke-project", replicaLocalProjectUID)
+	require.NoError(t, err)
+	credentials := newLeavePendingBarrierCredentialStore()
+	reservation := replicaServiceParams().Credential
+	reservation.ManagedByConfig = true
+	reservation.SpokeProjectName = project.Name
+	baseline := config.FederationManagedCredentialReservation{
+		ProjectUID: replicaHubProjectUID,
+		Credential: reservation,
+	}
+	require.NoError(t, credentials.ReserveManagedFederationCredential(ctx, baseline))
+
+	// Hold one operation open so leave preparation is guaranteed to reach its
+	// drain wait while other operations are still registering and finishing.
+	held, err := daemon.BeginFederationReplicaHubOperation(
+		ctx, store, credentials, project.Name, baseline,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		_, cleanupErr := held(cleanupCtx, 0)
+		assert.NoError(t, cleanupErr)
+	})
+
+	const readerCount = 4
+	readersReady := make(chan struct{}, readerCount)
+	stopReader := make(chan struct{})
+	readerDone := make(chan struct{}, readerCount)
+	var stopReadersOnce sync.Once
+	stopReaders := func() {
+		stopReadersOnce.Do(func() { close(stopReader) })
+	}
+	t.Cleanup(func() {
+		stopReaders()
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		for range readerCount {
+			select {
+			case <-readerDone:
+			case <-cleanupCtx.Done():
+				t.Errorf("wait for suppression reader cleanup: %v", cleanupCtx.Err())
+				return
+			}
+		}
+	})
+	for range readerCount {
+		go func() {
+			defer func() { readerDone <- struct{}{} }()
+			// Complete one real read before declaring this worker ready.
+			_ = daemon.FederationReplicaMappingSuppressed(store, project.Name)
+			readersReady <- struct{}{}
+			for {
+				select {
+				case <-stopReader:
+					return
+				default:
+				}
+				// The reconciler calls this without ensureFederationReplicaMu.
+				_ = daemon.FederationReplicaMappingSuppressed(store, project.Name)
+			}
+		}()
+	}
+	for range readerCount {
+		select {
+		case <-readersReady:
+		case <-ctx.Done():
+			t.Fatalf("wait for suppression reader readiness: %v", ctx.Err())
+		}
+	}
+
+	type hubOperationResult struct {
+		beginErr  error
+		finishErr error
+	}
+	const churnCount = 8
+	churnResults := make(chan hubOperationResult, churnCount)
+	for range churnCount {
+		go func() {
+			finish, beginErr := daemon.BeginFederationReplicaHubOperation(
+				ctx, store, credentials, project.Name, baseline,
+			)
+			if beginErr != nil {
+				churnResults <- hubOperationResult{beginErr: beginErr}
+				return
+			}
+			_, finishErr := finish(ctx, 0)
+			churnResults <- hubOperationResult{finishErr: finishErr}
+		}()
+	}
+
+	type prepareResult struct {
+		result daemon.PrepareFederationReplicaLeaveResult
+		err    error
+	}
+	prepared := make(chan prepareResult, 1)
+	go func() {
+		result, prepareErr := daemon.PrepareFederationReplicaLeave(
+			ctx, store, credentials, project.ID,
+		)
+		prepared <- prepareResult{result: result, err: prepareErr}
+	}()
+
+	select {
+	case <-credentials.leavePending:
+	case <-ctx.Done():
+		t.Fatalf("wait for durable leave-pending marker: %v", ctx.Err())
+	}
+
+	// The held operation keeps preparation in its drain wait. Without that
+	// wait, the prepared result becomes observable before this timer fires.
+	select {
+	case call := <-prepared:
+		t.Fatalf("prepare returned before the held hub operation drained: %v", call.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	for range churnCount {
+		select {
+		case result := <-churnResults:
+			if result.beginErr != nil {
+				assert.ErrorIs(t, result.beginErr, daemon.ErrFederationReplicaLeavePending)
+			}
+			assert.NoError(t, result.finishErr)
+		case <-ctx.Done():
+			t.Fatalf("wait for hub-operation churn: %v", ctx.Err())
+		}
+	}
+
+	_, finishErr := held(ctx, 91)
+	require.NoError(t, finishErr)
+
+	var call prepareResult
+	select {
+	case call = <-prepared:
+	case <-ctx.Done():
+		t.Fatalf("leave preparation never drained: %v", ctx.Err())
+	}
+	require.NoError(t, call.err)
+	require.True(t, call.result.ManagedReservationFound)
+	assert.True(t, call.result.ManagedReservation.Credential.LeavePending)
+	assert.Equal(t, int64(91), call.result.ManagedReservation.Credential.PendingEnrollmentID)
+	stopReaders()
+
+	assert.True(t, daemon.FederationReplicaMappingSuppressed(store, project.Name))
+	_, err = daemon.BeginFederationReplicaHubOperation(
+		ctx, store, credentials, project.Name, baseline,
+	)
+	require.ErrorIs(t, err, daemon.ErrFederationReplicaLeavePending)
+}
+
+func TestRecordFederationReplicaPendingEnrollment(t *testing.T) {
+	ctx := context.Background()
+	newLeavePreparedStore := func(t *testing.T) (*sqlitestore.Store, *replicaCredentialStore, db.Project) {
+		t.Helper()
+		store := openReplicaServiceStore(t)
+		project, err := store.CreateProjectWithUID(
+			ctx, "spoke-project", replicaLocalProjectUID,
+		)
+		require.NoError(t, err)
+		credentials := newReplicaCredentialStore()
+		reservation := replicaServiceParams().Credential
+		reservation.ManagedByConfig = true
+		reservation.SpokeProjectName = project.Name
+		require.NoError(t, credentials.ReserveManagedFederationCredential(
+			ctx,
+			config.FederationManagedCredentialReservation{
+				ProjectUID: replicaHubProjectUID, Credential: reservation,
+			},
+		))
+		return store, credentials, project
+	}
+
+	t.Run("stamps a prepared leave", func(t *testing.T) {
+		store, credentials, project := newLeavePreparedStore(t)
+		_, err := daemon.PrepareFederationReplicaLeave(ctx, store, credentials, project.ID)
+		require.NoError(t, err)
+
+		pendingFound, err := daemon.RecordFederationReplicaPendingEnrollment(
+			ctx, credentials, project.Name, 71,
+		)
+		require.NoError(t, err)
+		assert.True(t, pendingFound)
+		stamped, found, err := credentials.FederationCredential(ctx, replicaHubProjectUID)
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.True(t, stamped.LeavePending)
+		assert.Equal(t, int64(71), stamped.PendingEnrollmentID)
+	})
+
+	t.Run("restamping the same enrollment does not rewrite", func(t *testing.T) {
+		store, credentials, project := newLeavePreparedStore(t)
+		_, err := daemon.PrepareFederationReplicaLeave(ctx, store, credentials, project.ID)
+		require.NoError(t, err)
+		_, err = daemon.RecordFederationReplicaPendingEnrollment(
+			ctx, credentials, project.Name, 71,
+		)
+		require.NoError(t, err)
+		writes := credentials.managedReplaces()
+
+		pendingFound, err := daemon.RecordFederationReplicaPendingEnrollment(
+			ctx, credentials, project.Name, 71,
+		)
+		require.NoError(t, err)
+		assert.True(t, pendingFound)
+		assert.Equal(t, writes, credentials.managedReplaces(),
+			"an unchanged stamp must not rewrite the credential store")
+	})
+
+	t.Run("never stamps a reservation that is not leaving", func(t *testing.T) {
+		_, credentials, project := newLeavePreparedStore(t)
+
+		pendingFound, err := daemon.RecordFederationReplicaPendingEnrollment(
+			ctx, credentials, project.Name, 71,
+		)
+		require.NoError(t, err)
+		assert.False(t, pendingFound)
+		assert.Zero(t, credentials.managedReplaces())
+		current, found, err := credentials.FederationCredential(ctx, replicaHubProjectUID)
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.False(t, current.LeavePending)
+		assert.Zero(t, current.PendingEnrollmentID,
+			"a pending enrollment without a pending leave is a rejected credential state")
 	})
 }
 

--- a/internal/daemon/federation_replica_transitions.go
+++ b/internal/daemon/federation_replica_transitions.go
@@ -1,0 +1,188 @@
+package daemon
+
+import "sync"
+
+// federationReplicaTransitionState is the leave lifecycle of one spoke
+// mapping. It replaces a (leaveIntent, suppressed) boolean pair whose four
+// combinations encoded only three legal states.
+type federationReplicaTransitionState int
+
+const (
+	// federationReplicaIdle means no explicit leave is prepared or completed.
+	federationReplicaIdle federationReplicaTransitionState = iota
+	// federationReplicaLeavePending means PrepareFederationReplicaLeave has
+	// durably marked the reservation and the leave has not completed yet.
+	federationReplicaLeavePending
+	// federationReplicaLeft means an explicit leave completed in this process.
+	federationReplicaLeft
+)
+
+// federationReplicaTransition holds one mapping's leave state together with
+// the drain accounting for hub operations already in flight for that mapping.
+type federationReplicaTransition struct {
+	state    federationReplicaTransitionState
+	inFlight int
+	drained  chan struct{}
+}
+
+// federationReplicaRegistry owns every per-mapping transition record.
+//
+// Lock discipline: every mutating method must be called by code that already
+// holds ensureFederationReplicaMu, so "check leave state, then register a hub
+// operation" stays atomic against PrepareFederationReplicaLeave. The
+// registry's own RWMutex exists solely so state can serve the config
+// reconciler's lock-free FederationReplicaMappingSuppressed read without
+// blocking on ensureFederationReplicaMu, which is held across database and
+// credential-store I/O.
+type federationReplicaRegistry struct {
+	mu          sync.RWMutex
+	transitions map[string]*federationReplicaTransition
+}
+
+var federationReplicaTransitions = &federationReplicaRegistry{
+	transitions: make(map[string]*federationReplicaTransition),
+}
+
+// state reports the current leave state for key. It is the only method safe to
+// call without holding ensureFederationReplicaMu.
+func (r *federationReplicaRegistry) state(key string) federationReplicaTransitionState {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	transition, ok := r.transitions[key]
+	if !ok {
+		return federationReplicaIdle
+	}
+	return transition.state
+}
+
+// leaveBlockedError returns the operator-facing error for a mapping whose
+// leave state forbids new config-driven hub operations, or nil when idle.
+func (r *federationReplicaRegistry) leaveBlockedError(key string) error {
+	switch r.state(key) {
+	case federationReplicaLeavePending:
+		return federationReplicaError(
+			ErrFederationReplicaLeavePending,
+			"explicit federation leave is pending",
+			"",
+		)
+	case federationReplicaLeft:
+		return federationReplicaError(
+			ErrFederationReplicaLeavePending,
+			"federation mapping was explicitly left",
+			"",
+		)
+	default:
+		return nil
+	}
+}
+
+// registerHubOperationLocked records one in-flight hub operation for key. The
+// caller must hold ensureFederationReplicaMu and must have already rejected a
+// blocking leave state with its own message. The returned finish function must
+// also be called with that mutex held, and is safe to call more than once.
+func (r *federationReplicaRegistry) registerHubOperationLocked(key string) func() {
+	r.mu.Lock()
+	transition, ok := r.transitions[key]
+	if !ok {
+		transition = &federationReplicaTransition{}
+		r.transitions[key] = transition
+	}
+	transition.inFlight++
+	if transition.drained == nil {
+		transition.drained = make(chan struct{})
+	}
+	r.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() { r.finishHubOperationLocked(key) })
+	}
+}
+
+// registerHubOperation is registerHubOperationLocked for callers that release
+// ensureFederationReplicaMu during hub I/O: the returned finish function takes
+// the mutex itself.
+func (r *federationReplicaRegistry) registerHubOperation(key string) func() {
+	finish := r.registerHubOperationLocked(key)
+	return func() {
+		ensureFederationReplicaMu.Lock()
+		defer ensureFederationReplicaMu.Unlock()
+		finish()
+	}
+}
+
+func (r *federationReplicaRegistry) finishHubOperationLocked(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	transition, ok := r.transitions[key]
+	if !ok || transition.inFlight == 0 {
+		return
+	}
+	transition.inFlight--
+	if transition.inFlight > 0 {
+		return
+	}
+	if transition.drained != nil {
+		close(transition.drained)
+		transition.drained = nil
+	}
+	r.pruneLocked(key, transition)
+}
+
+// drainSignal reports the channel closed when the last hub operation in flight
+// for key finishes; ok is false when nothing is in flight. The caller must hold
+// ensureFederationReplicaMu, and must re-check after each drain: a new
+// operation can register between the drain and the re-check.
+func (r *federationReplicaRegistry) drainSignal(key string) (<-chan struct{}, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	transition, ok := r.transitions[key]
+	if !ok || transition.inFlight == 0 || transition.drained == nil {
+		return nil, false
+	}
+	return transition.drained, true
+}
+
+// markLeavePending records that an explicit leave was durably prepared.
+func (r *federationReplicaRegistry) markLeavePending(key string) {
+	r.setState(key, federationReplicaLeavePending)
+}
+
+// markLeft records that an explicit leave completed in this process.
+func (r *federationReplicaRegistry) markLeft(key string) {
+	r.setState(key, federationReplicaLeft)
+}
+
+// clearLeave returns key to idle. It serves both the successful-ensure clear
+// and PrepareFederationReplicaLeave's rollback, so it clears the left and
+// leave-pending states alike.
+func (r *federationReplicaRegistry) clearLeave(key string) {
+	r.setState(key, federationReplicaIdle)
+}
+
+func (r *federationReplicaRegistry) setState(
+	key string, state federationReplicaTransitionState,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	transition, ok := r.transitions[key]
+	if !ok {
+		if state == federationReplicaIdle {
+			return
+		}
+		transition = &federationReplicaTransition{}
+		r.transitions[key] = transition
+	}
+	transition.state = state
+	r.pruneLocked(key, transition)
+}
+
+// pruneLocked drops records that carry no information: an idle mapping with
+// nothing in flight is indistinguishable from one never seen.
+func (r *federationReplicaRegistry) pruneLocked(
+	key string, transition *federationReplicaTransition,
+) {
+	if transition.state == federationReplicaIdle && transition.inFlight == 0 {
+		delete(r.transitions, key)
+	}
+}

--- a/internal/daemon/federation_replica_transitions_internal_test.go
+++ b/internal/daemon/federation_replica_transitions_internal_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestFederationReplicaRegistry() *federationReplicaRegistry {
+	return &federationReplicaRegistry{
+		transitions: make(map[string]*federationReplicaTransition),
+	}
+}
+
+func TestFederationReplicaRegistryStateTransitions(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		apply func(r *federationReplicaRegistry, key string)
+		want  federationReplicaTransitionState
+	}{
+		{
+			name:  "unseen key is idle",
+			apply: func(*federationReplicaRegistry, string) {},
+			want:  federationReplicaIdle,
+		},
+		{
+			name: "prepared leave is leave-pending",
+			apply: func(r *federationReplicaRegistry, key string) {
+				r.markLeavePending(key)
+			},
+			want: federationReplicaLeavePending,
+		},
+		{
+			name: "completed leave is left",
+			apply: func(r *federationReplicaRegistry, key string) {
+				r.markLeavePending(key)
+				r.markLeft(key)
+			},
+			want: federationReplicaLeft,
+		},
+		{
+			name: "leave completed without preparation is left",
+			apply: func(r *federationReplicaRegistry, key string) {
+				r.markLeft(key)
+			},
+			want: federationReplicaLeft,
+		},
+		{
+			name: "rolled back preparation is idle again",
+			apply: func(r *federationReplicaRegistry, key string) {
+				r.markLeavePending(key)
+				r.clearLeave(key)
+			},
+			want: federationReplicaIdle,
+		},
+		{
+			name: "successful ensure clears a completed leave",
+			apply: func(r *federationReplicaRegistry, key string) {
+				r.markLeft(key)
+				r.clearLeave(key)
+			},
+			want: federationReplicaIdle,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := newTestFederationReplicaRegistry()
+			tc.apply(registry, "key")
+			assert.Equal(t, tc.want, registry.state("key"))
+		})
+	}
+}
+
+func TestFederationReplicaRegistryForgetsIdleKeys(t *testing.T) {
+	registry := newTestFederationReplicaRegistry()
+	registry.markLeavePending("key")
+	registry.clearLeave("key")
+	assert.Empty(t, registry.transitions,
+		"an idle key with nothing in flight must not retain a record")
+
+	finish := registry.registerHubOperationLocked("key")
+	registry.markLeft("key")
+	finish()
+	assert.Equal(t, federationReplicaLeft, registry.state("key"),
+		"draining the last operation must not discard leave state")
+}
+
+func TestFederationReplicaRegistryBlocksEntryPerLeaveState(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		apply   func(r *federationReplicaRegistry, key string)
+		message string
+	}{
+		{
+			name:  "idle admits new hub operations",
+			apply: func(*federationReplicaRegistry, string) {},
+		},
+		{
+			name: "prepared leave blocks with the pending message",
+			apply: func(r *federationReplicaRegistry, key string) {
+				r.markLeavePending(key)
+			},
+			message: "explicit federation leave is pending",
+		},
+		{
+			name: "completed leave blocks with the left message",
+			apply: func(r *federationReplicaRegistry, key string) {
+				r.markLeft(key)
+			},
+			message: "federation mapping was explicitly left",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := newTestFederationReplicaRegistry()
+			tc.apply(registry, "key")
+			err := registry.leaveBlockedError("key")
+			if tc.message == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, ErrFederationReplicaLeavePending)
+			assert.EqualError(t, err, tc.message)
+		})
+	}
+}
+
+func TestFederationReplicaRegistryDrainSignalTracksInFlightOperations(t *testing.T) {
+	registry := newTestFederationReplicaRegistry()
+	_, waiting := registry.drainSignal("key")
+	assert.False(t, waiting, "nothing in flight must not require a wait")
+
+	first := registry.registerHubOperationLocked("key")
+	second := registry.registerHubOperationLocked("key")
+	drained, waiting := registry.drainSignal("key")
+	require.True(t, waiting)
+
+	first()
+	first()
+	select {
+	case <-drained:
+		require.FailNow(t, "drain closed while an operation was still in flight")
+	default:
+	}
+
+	second()
+	select {
+	case <-drained:
+	default:
+		require.FailNow(t, "drain did not close after the last operation finished")
+	}
+
+	_, waiting = registry.drainSignal("key")
+	assert.False(t, waiting, "a fully drained key must not require a wait")
+
+	registry.registerHubOperationLocked("key")
+	reopened, waiting := registry.drainSignal("key")
+	require.True(t, waiting)
+	select {
+	case <-reopened:
+		require.FailNow(t, "a newly registered operation reused the closed drain channel")
+	default:
+	}
+}

--- a/internal/federation/config_reconciler.go
+++ b/internal/federation/config_reconciler.go
@@ -482,11 +482,13 @@ func reconcileMapping(
 		return reconcileError(ErrCredentialIO, "finish federation hub operation")
 	}
 	if leavePending {
-		// enrollmentID is zero when the hub call failed, and compensation is
-		// then a no-op: the leave still wins over the enrollment error.
-		return compensateEnrollment(
+		// The finish closure already confirmed the leave, so its observation
+		// result is irrelevant here: the leave wins over an enrollment error,
+		// and enrollmentID is zero when the hub call failed.
+		_, compensateErr := compensateEnrollment(
 			ctx, store, credentials, managed, hub, mapping, enrollmentID,
 		)
+		return compensateErr
 	}
 	if err != nil {
 		return err
@@ -498,27 +500,29 @@ func reconcileMapping(
 	if !reservationChanged || err == nil {
 		return err
 	}
-	if enrollment.id <= 0 {
-		// With no enrollment to compensate, only a leave prepared or completed
-		// in this process justifies discarding the convergence conflict; an
-		// unrelated reservation change must keep failing so the controller
-		// retries.
-		if daemon.FederationReplicaMappingSuppressed(store, mapping.SpokeProject) {
-			return nil
-		}
-		return err
-	}
-	// The leave wins over the convergence failure, so err is discarded here.
-	return compensateEnrollment(
+	leaveObserved, compensateErr := compensateEnrollment(
 		ctx, store, credentials, managed, hub, mapping, enrollment.id,
 	)
+	if compensateErr != nil {
+		return compensateErr
+	}
+	if leaveObserved {
+		// The leave wins over the convergence failure, so err is discarded.
+		return nil
+	}
+	// No leave explains the reservation change, so the convergence conflict
+	// must keep failing: the controller stops retrying a mapping whose
+	// reconciliation reports success.
+	return err
 }
 
 // compensateEnrollment revokes a hub enrollment whose local reservation went
 // away. It serves both mid-flight leave windows: the daemon observed the leave
 // before the hub operation finished, or a leave landed while local convergence
-// ran. Both callers discard their own error before calling — an explicit leave
-// wins over a convergence or enrollment failure.
+// ran. The returned bool reports whether an explicit leave was observed — a
+// leave-pending reservation stamp or in-process leave state — so the
+// convergence caller can tell a leave, which wins over its conflict, from an
+// unrelated reservation change, which must keep failing.
 //
 // Suppression policy (design decision D3): a mapping whose leave was prepared
 // or completed in this process never fails reconciliation for hub cleanup it
@@ -532,40 +536,42 @@ func compensateEnrollment(
 	hub Hub,
 	mapping config.FederationProjectConfig,
 	enrollmentID int64,
-) error {
+) (bool, error) {
+	suppressed := func() bool {
+		return daemon.FederationReplicaMappingSuppressed(store, mapping.SpokeProject)
+	}
 	if enrollmentID <= 0 {
-		return nil
+		return suppressed(), nil
 	}
 	pendingFound, err := daemon.RecordFederationReplicaPendingEnrollment(
 		ctx, credentials, mapping.SpokeProject, enrollmentID,
 	)
 	if err != nil {
-		return reconcileError(ErrCredentialIO, "record pending enrollment after hub operation")
-	}
-	suppressed := func() bool {
-		return daemon.FederationReplicaMappingSuppressed(store, mapping.SpokeProject)
+		return false, reconcileError(ErrCredentialIO, "record pending enrollment after hub operation")
 	}
 	if !pendingFound && suppressed() {
 		// A prepared or completed local-only leave with no reservation
 		// deliberately skips hub cleanup. The process-local suppression still
 		// prevents this mapping from being recreated until restart.
-		return nil
+		return true, nil
 	}
 	if revokeErr := hub.RevokeEnrollment(ctx, enrollmentID); revokeErr != nil {
 		if suppressed() {
-			return nil
+			return true, nil
 		}
-		return safeHubError(revokeErr)
+		return pendingFound, safeHubError(revokeErr)
 	}
 	if !pendingFound {
-		return nil
+		// A leave can land while the revocation is in flight; re-check so it
+		// still wins over the caller's convergence conflict.
+		return suppressed(), nil
 	}
 	if confirmErr := confirmPendingEnrollmentCleanup(
 		ctx, managed, mapping.SpokeProject, enrollmentID,
 	); confirmErr != nil && !suppressed() {
-		return confirmErr
+		return true, confirmErr
 	}
-	return nil
+	return true, nil
 }
 
 func confirmPendingEnrollmentCleanup(

--- a/internal/federation/config_reconciler.go
+++ b/internal/federation/config_reconciler.go
@@ -498,6 +498,16 @@ func reconcileMapping(
 	if !reservationChanged || err == nil {
 		return err
 	}
+	if enrollment.id <= 0 {
+		// With no enrollment to compensate, only a leave prepared or completed
+		// in this process justifies discarding the convergence conflict; an
+		// unrelated reservation change must keep failing so the controller
+		// retries.
+		if daemon.FederationReplicaMappingSuppressed(store, mapping.SpokeProject) {
+			return nil
+		}
+		return err
+	}
 	// The leave wins over the convergence failure, so err is discarded here.
 	return compensateEnrollment(
 		ctx, store, credentials, managed, hub, mapping, enrollment.id,

--- a/internal/federation/config_reconciler.go
+++ b/internal/federation/config_reconciler.go
@@ -482,18 +482,11 @@ func reconcileMapping(
 		return reconcileError(ErrCredentialIO, "finish federation hub operation")
 	}
 	if leavePending {
-		if err != nil {
-			return nil
-		}
-		if revokeErr := hub.RevokeEnrollment(ctx, enrollment.id); revokeErr != nil {
-			return safeHubError(revokeErr)
-		}
-		if confirmErr := confirmPendingEnrollmentCleanup(
-			ctx, managed, mapping.SpokeProject, enrollment.id,
-		); confirmErr != nil {
-			return confirmErr
-		}
-		return nil
+		// enrollmentID is zero when the hub call failed, and compensation is
+		// then a no-op: the leave still wins over the enrollment error.
+		return compensateEnrollment(
+			ctx, store, credentials, managed, hub, mapping, enrollmentID,
+		)
 	}
 	if err != nil {
 		return err
@@ -502,45 +495,65 @@ func reconcileMapping(
 		ctx, store, credentials, wake, mapping, preflight, enrollment.credential,
 		projectEventSink,
 	)
-	if err == nil || enrollment.id == 0 || !reservationChanged {
+	if !reservationChanged || err == nil {
 		return err
 	}
-	pending, pendingFound, pendingErr := managed.FindManagedFederationCredential(
-		ctx, mapping.SpokeProject,
+	// The leave wins over the convergence failure, so err is discarded here.
+	return compensateEnrollment(
+		ctx, store, credentials, managed, hub, mapping, enrollment.id,
 	)
-	if pendingErr != nil {
-		return reconcileError(ErrCredentialIO, "read pending federation leave")
-	}
-	if pendingFound && pending.Credential.LeavePending {
-		replacement := pending
-		replacement.Credential.PendingEnrollmentID = enrollment.id
-		if replaceErr := managed.ReplaceManagedFederationCredential(
-			ctx, pending, replacement,
-		); replaceErr != nil {
-			return reconcileError(ErrCredentialIO, "record pending enrollment cleanup")
-		}
-		pending = replacement
-	}
-	if daemon.FederationReplicaMappingSuppressed(store, mapping.SpokeProject) &&
-		!pendingFound {
-		// A completed local-only leave deliberately skips hub cleanup. The
-		// process-local suppression still prevents this mapping from being
-		// recreated until restart.
+}
+
+// compensateEnrollment revokes a hub enrollment whose local reservation went
+// away. It serves both mid-flight leave windows: the daemon observed the leave
+// before the hub operation finished, or a leave landed while local convergence
+// ran. Both callers discard their own error before calling — an explicit leave
+// wins over a convergence or enrollment failure.
+//
+// Suppression policy (design decision D3): a mapping whose leave was prepared
+// or completed in this process never fails reconciliation for hub cleanup it
+// deliberately skips, so a missing reservation short-circuits and a failed
+// revoke or confirmation is tolerated. An unsuppressed mapping must retry.
+func compensateEnrollment(
+	ctx context.Context,
+	store db.Storage,
+	credentials config.FederationCredentialStore,
+	managed config.FederationManagedCredentialStore,
+	hub Hub,
+	mapping config.FederationProjectConfig,
+	enrollmentID int64,
+) error {
+	if enrollmentID <= 0 {
 		return nil
 	}
-	if revokeErr := hub.RevokeEnrollment(ctx, enrollment.id); revokeErr != nil {
-		if daemon.FederationReplicaMappingSuppressed(store, mapping.SpokeProject) {
+	pendingFound, err := daemon.RecordFederationReplicaPendingEnrollment(
+		ctx, credentials, mapping.SpokeProject, enrollmentID,
+	)
+	if err != nil {
+		return reconcileError(ErrCredentialIO, "record pending enrollment after hub operation")
+	}
+	suppressed := func() bool {
+		return daemon.FederationReplicaMappingSuppressed(store, mapping.SpokeProject)
+	}
+	if !pendingFound && suppressed() {
+		// A prepared or completed local-only leave with no reservation
+		// deliberately skips hub cleanup. The process-local suppression still
+		// prevents this mapping from being recreated until restart.
+		return nil
+	}
+	if revokeErr := hub.RevokeEnrollment(ctx, enrollmentID); revokeErr != nil {
+		if suppressed() {
 			return nil
 		}
 		return safeHubError(revokeErr)
 	}
-	if pendingFound && pending.Credential.LeavePending {
-		if confirmErr := confirmPendingEnrollmentCleanup(
-			ctx, managed, mapping.SpokeProject, enrollment.id,
-		); confirmErr != nil &&
-			!daemon.FederationReplicaMappingSuppressed(store, mapping.SpokeProject) {
-			return confirmErr
-		}
+	if !pendingFound {
+		return nil
+	}
+	if confirmErr := confirmPendingEnrollmentCleanup(
+		ctx, managed, mapping.SpokeProject, enrollmentID,
+	); confirmErr != nil && !suppressed() {
+		return confirmErr
 	}
 	return nil
 }

--- a/internal/federation/config_reconciler_test.go
+++ b/internal/federation/config_reconciler_test.go
@@ -875,6 +875,30 @@ func TestReconcileMappingUnsuppressedReservationChangeSurfacesConvergenceConflic
 		"no enrollment was created, so nothing may be revoked")
 }
 
+func TestReconcileMappingUnsuppressedReservationChangeAfterEnrollmentSurfacesConflict(
+	t *testing.T,
+) {
+	store := openReconcileStore(t)
+	credentials := newTokenRotatedDuringConvergenceStore()
+	hub := newFakeHub()
+	hub.onEnrollment = func(federation.EnrollmentRequest) {
+		// The next managed lookup is the daemon finish closure's; the one after
+		// it is EnsureFederationReplica's revalidation, where the rotation
+		// becomes visible.
+		credentials.armAfterFinds(1)
+	}
+
+	err := federation.ReconcileMapping(
+		context.Background(), store, credentials, hub,
+		testCatalog(), testMapping(), nil,
+	)
+
+	require.ErrorIs(t, err, federation.ErrConfigurationConflict,
+		"a reservation change with no observed leave must surface the convergence conflict")
+	assert.Equal(t, []int64{hub.enrollment.ID}, hub.revokeCalls,
+		"the enrollment whose reservation went away must still be revoked")
+}
+
 func TestReconcileMappingManagedCleanupLookupRequiresManagedStore(t *testing.T) {
 	ctx := t.Context()
 	store := openReconcileStore(t)

--- a/internal/federation/config_reconciler_test.go
+++ b/internal/federation/config_reconciler_test.go
@@ -537,6 +537,62 @@ func newLeaveAfterHubOperationStore() *leaveAfterHubOperationStore {
 	return &leaveAfterHubOperationStore{fakeCredentialStore: newFakeCredentialStore()}
 }
 
+// tokenRotatedDuringConvergenceStore replaces the managed reservation token in
+// the window between the daemon's finish closure and EnsureFederationReplica's
+// revalidation. Unlike leaveAfterHubOperationStore, the change is not an
+// explicit leave: nothing marks leave state in the daemon process, so the
+// reconciler must surface the convergence conflict instead of recording
+// success.
+type tokenRotatedDuringConvergenceStore struct {
+	*fakeCredentialStore
+	armMu     sync.Mutex
+	armed     bool
+	skipFinds int
+}
+
+func (s *tokenRotatedDuringConvergenceStore) armAfterFinds(skipFinds int) {
+	s.armMu.Lock()
+	defer s.armMu.Unlock()
+	s.armed = true
+	s.skipFinds = skipFinds
+}
+
+func (s *tokenRotatedDuringConvergenceStore) FindManagedFederationCredential(
+	ctx context.Context, projectName string,
+) (config.FederationManagedCredentialReservation, bool, error) {
+	s.armMu.Lock()
+	rotate := false
+	if s.armed {
+		if s.skipFinds > 0 {
+			s.skipFinds--
+		} else {
+			s.armed = false
+			rotate = true
+		}
+	}
+	s.armMu.Unlock()
+	if rotate {
+		s.rotateToken(projectName)
+	}
+	return s.fakeCredentialStore.FindManagedFederationCredential(ctx, projectName)
+}
+
+func (s *tokenRotatedDuringConvergenceStore) rotateToken(projectName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for projectUID, credential := range s.credentials {
+		if !credential.ManagedByConfig || credential.SpokeProjectName != projectName {
+			continue
+		}
+		credential.Token = "rotated-" + credential.Token
+		s.credentials[projectUID] = credential
+	}
+}
+
+func newTokenRotatedDuringConvergenceStore() *tokenRotatedDuringConvergenceStore {
+	return &tokenRotatedDuringConvergenceStore{fakeCredentialStore: newFakeCredentialStore()}
+}
+
 func TestReconcileMappingCreatesEnrollsAdoptsPushesAndWakes(t *testing.T) {
 	store := openReconcileStore(t)
 	credentials := newFakeCredentialStore()
@@ -783,6 +839,40 @@ func TestReconcileMappingUnsuppressedLeaveSurfacesFailedRevocation(t *testing.T)
 	stamped, found := credentials.get(hubProjectUID)
 	require.True(t, found)
 	assert.Equal(t, hub.enrollment.ID, stamped.PendingEnrollmentID)
+}
+
+func TestReconcileMappingUnsuppressedReservationChangeSurfacesConvergenceConflict(
+	t *testing.T,
+) {
+	store := openReconcileStore(t)
+	project := createMatchingBoundProject(t, store)
+	binding, err := store.FederationBindingByProject(context.Background(), project.ID)
+	require.NoError(t, err)
+	binding.PushEnabled = false
+	_, err = store.UpsertFederationBinding(context.Background(), binding)
+	require.NoError(t, err)
+
+	credentials := newTokenRotatedDuringConvergenceStore()
+	credentials.credentials[project.UID] = managedCredential()
+	// The reconciled binding reuses its enrollment, so no hub enrollment call
+	// exists to arm on. The managed lookups before EnsureFederationReplica's
+	// revalidation are the pending-leave probe, the preflight reservation
+	// read, and the daemon finish closure's stamp lookup; the rotation lands
+	// on the revalidation lookup that follows them.
+	credentials.armAfterFinds(3)
+	hub := newFakeHub()
+
+	err = federation.ReconcileMapping(
+		context.Background(), store, credentials, hub,
+		testCatalog(), testMapping(), nil,
+	)
+
+	require.ErrorIs(t, err, federation.ErrConfigurationConflict,
+		"a reservation change with no in-process leave must surface the convergence conflict")
+	assert.Empty(t, hub.enrollmentCalls,
+		"an operational credential with a bound project reuses its enrollment")
+	assert.Empty(t, hub.revokeCalls,
+		"no enrollment was created, so nothing may be revoked")
 }
 
 func TestReconcileMappingManagedCleanupLookupRequiresManagedStore(t *testing.T) {

--- a/internal/federation/config_reconciler_test.go
+++ b/internal/federation/config_reconciler_test.go
@@ -467,6 +467,76 @@ func (s *fakeCredentialStore) get(projectUID string) (config.FederationCredentia
 	return credential, ok
 }
 
+// leaveAfterHubOperationStore commits an explicit-leave stamp in the window
+// between the daemon's finish closure and EnsureFederationReplica's managed
+// reservation revalidation, which is the window-2 interleaving. It arms on the
+// hub enrollment call, skips the finish closure's lookup, and stamps on the
+// revalidation lookup that follows.
+type leaveAfterHubOperationStore struct {
+	*fakeCredentialStore
+	armMu      sync.Mutex
+	armed      bool
+	skipFinds  int
+	replaceErr error
+}
+
+func (s *leaveAfterHubOperationStore) armAfterFinds(skipFinds int) {
+	s.armMu.Lock()
+	defer s.armMu.Unlock()
+	s.armed = true
+	s.skipFinds = skipFinds
+}
+
+func (s *leaveAfterHubOperationStore) FindManagedFederationCredential(
+	ctx context.Context, projectName string,
+) (config.FederationManagedCredentialReservation, bool, error) {
+	s.armMu.Lock()
+	stamp := false
+	if s.armed {
+		if s.skipFinds > 0 {
+			s.skipFinds--
+		} else {
+			s.armed = false
+			stamp = true
+		}
+	}
+	s.armMu.Unlock()
+	if stamp {
+		s.stampLeavePending(projectName)
+	}
+	return s.fakeCredentialStore.FindManagedFederationCredential(ctx, projectName)
+}
+
+func (s *leaveAfterHubOperationStore) stampLeavePending(projectName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for projectUID, credential := range s.credentials {
+		if !credential.ManagedByConfig || credential.SpokeProjectName != projectName {
+			continue
+		}
+		credential.LeavePending = true
+		credential.PendingEnrollmentID = 0
+		s.credentials[projectUID] = credential
+	}
+}
+
+func (s *leaveAfterHubOperationStore) ReplaceManagedFederationCredential(
+	ctx context.Context,
+	expected config.FederationManagedCredentialReservation,
+	replacement config.FederationManagedCredentialReservation,
+) error {
+	if s.replaceErr != nil {
+		return s.replaceErr
+	}
+	return s.fakeCredentialStore.ReplaceManagedFederationCredential(
+		ctx, expected, replacement,
+	)
+}
+
+func newLeaveAfterHubOperationStore() *leaveAfterHubOperationStore {
+	return &leaveAfterHubOperationStore{fakeCredentialStore: newFakeCredentialStore()}
+}
+
 func TestReconcileMappingCreatesEnrollsAdoptsPushesAndWakes(t *testing.T) {
 	store := openReconcileStore(t)
 	credentials := newFakeCredentialStore()
@@ -590,6 +660,129 @@ func TestReconcileMappingGeneratedReservationRequiresManagedStore(t *testing.T) 
 	require.NoError(t, listErr)
 	assert.Empty(t, projects)
 	assert.Empty(t, delegate.credentials)
+}
+
+func TestReconcileMappingLeaveDuringConvergenceRevokesTheStampedEnrollment(t *testing.T) {
+	t.Run("stamps and revokes", func(t *testing.T) {
+		store := openReconcileStore(t)
+		credentials := newLeaveAfterHubOperationStore()
+		hub := newFakeHub()
+		hub.onEnrollment = func(federation.EnrollmentRequest) {
+			// The next managed lookup is the daemon finish closure's; the one after
+			// it is EnsureFederationReplica's revalidation, which is where a leave
+			// landing during convergence becomes visible.
+			credentials.armAfterFinds(1)
+		}
+
+		err := federation.ReconcileMapping(
+			context.Background(), store, credentials, hub,
+			testCatalog(), testMapping(), nil,
+		)
+
+		require.NoError(t, err, "an explicit leave wins over a convergence conflict")
+		assert.Equal(t, []int64{hub.enrollment.ID}, hub.revokeCalls)
+		stamped, found := credentials.get(hubProjectUID)
+		require.True(t, found)
+		assert.True(t, stamped.LeavePending)
+		assert.Equal(t, hub.enrollment.ID, stamped.PendingEnrollmentID,
+			"the revoked enrollment must be the one stamped for durable cleanup")
+		assert.Len(t, hub.enrollmentCalls, 1)
+	})
+
+	t.Run("uses the daemon stamp error", func(t *testing.T) {
+		store := openReconcileStore(t)
+		credentials := newLeaveAfterHubOperationStore()
+		credentials.replaceErr = errors.New("injected replacement failure")
+		hub := newFakeHub()
+		hub.onEnrollment = func(federation.EnrollmentRequest) {
+			credentials.armAfterFinds(1)
+		}
+
+		err := federation.ReconcileMapping(
+			context.Background(), store, credentials, hub,
+			testCatalog(), testMapping(), nil,
+		)
+
+		assert.EqualError(t, err, "record pending enrollment after hub operation")
+	})
+}
+
+func TestReconcileMappingSuppressedLeaveToleratesFailedRevocation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	store := openReconcileStore(t)
+	credentials := newFakeCredentialStore()
+	hub := newFakeHub()
+	hub.revokeErr = &federation.HubError{
+		Kind: federation.ErrHubUnavailable, Operation: "revoke enrollment",
+	}
+	hub.ensureEnrollmentStarted = make(chan struct{})
+	hub.releaseEnsureEnrollment = make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		result <- federation.ReconcileMapping(
+			ctx, store, credentials, hub, testCatalog(), testMapping(), nil,
+		)
+	}()
+
+	select {
+	case <-hub.ensureEnrollmentStarted:
+	case <-ctx.Done():
+		require.FailNow(t, "wait for paused enrollment", "error: %v", ctx.Err())
+	}
+	localProject, err := store.ProjectByName(ctx, "spoke-project")
+	require.NoError(t, err)
+	prepared := make(chan error, 1)
+	go func() {
+		_, prepareErr := daemon.PrepareFederationReplicaLeave(
+			ctx, store, credentials, localProject.ID,
+		)
+		prepared <- prepareErr
+	}()
+	require.Eventually(t, func() bool {
+		credential, found := credentials.get(hubProjectUID)
+		return found && credential.LeavePending
+	}, time.Second, time.Millisecond)
+	close(hub.releaseEnsureEnrollment)
+
+	select {
+	case err = <-result:
+	case <-ctx.Done():
+		require.FailNow(t, "wait for reconciliation after leave", "error: %v", ctx.Err())
+	}
+	require.NoError(t, err,
+		"a suppressed mapping must not fail reconciliation for an unreachable hub")
+	require.NoError(t, <-prepared)
+	assert.Equal(t, []int64{hub.enrollment.ID}, hub.revokeCalls)
+	retained, found := credentials.get(hubProjectUID)
+	require.True(t, found)
+	assert.True(t, retained.LeavePending)
+	assert.Equal(t, hub.enrollment.ID, retained.PendingEnrollmentID,
+		"the enrollment stays recorded so durable cleanup can retry the revocation")
+}
+
+func TestReconcileMappingUnsuppressedLeaveSurfacesFailedRevocation(t *testing.T) {
+	store := openReconcileStore(t)
+	credentials := newLeaveAfterHubOperationStore()
+	hub := newFakeHub()
+	hub.revokeErr = &federation.HubError{
+		Kind: federation.ErrHubUnavailable, Operation: "revoke enrollment",
+	}
+	hub.onEnrollment = func(federation.EnrollmentRequest) {
+		credentials.armAfterFinds(1)
+	}
+
+	err := federation.ReconcileMapping(
+		context.Background(), store, credentials, hub,
+		testCatalog(), testMapping(), nil,
+	)
+
+	require.ErrorIs(t, err, federation.ErrHubUnavailable,
+		"a mapping that was not locally left must retry the revocation")
+	assert.Equal(t, []int64{hub.enrollment.ID}, hub.revokeCalls)
+	stamped, found := credentials.get(hubProjectUID)
+	require.True(t, found)
+	assert.Equal(t, hub.enrollment.ID, stamped.PendingEnrollmentID)
 }
 
 func TestReconcileMappingManagedCleanupLookupRequiresManagedStore(t *testing.T) {


### PR DESCRIPTION
Federation replica leave tracking was spread across three process-global maps (leave intents, suppression, and in-flight hub operations) plus a second drain counter duplicated in the rebind path, and the mid-flight enrollment compensation logic existed twice: inline in the daemon's hub-operation finish closure and again in the config reconciler.

This change replaces the maps with one keyed registry (`internal/daemon/federation_replica_transitions.go`) that owns each mapping's leave state (idle, leave-pending, left) and the drain accounting for hub operations already in flight. The registry keeps its own lock only so the config reconciler can read suppression without blocking on `ensureFederationReplicaMu`, which is held across database and credential-store I/O; every state mutation still happens under that mutex, preserving the existing lock ordering, operator error messages, and rebind behavior. A leave becomes observable to those lock-free reads only after its durable credential mark succeeds, so a failed preparation never parks the reconciler as reconciled and never erases a completed leave's suppression.

Both windows where an explicit leave can land mid-enrollment — before the hub operation finishes, or while local convergence runs — now go through one durable pending-enrollment stamp (`daemon.RecordFederationReplicaPendingEnrollment`) and one `compensateEnrollment` policy. An observed leave (a leave-pending reservation stamp or in-process leave state) wins over an enrollment or convergence error, and hub cleanup failures are tolerated only while a leave is prepared or completed in this process, because the durable stamp lets the leave's own cleanup revoke the enrollment later. When no leave explains a reservation change during convergence, the conflict keeps failing — after revoking any enrollment the operation created — because the controller stops retrying a mapping whose reconciliation reports success. Previously a successful revocation reported the unconverged mapping as reconciled.

No route, wire-format, or persisted-schema changes. The only new exported symbol is `daemon.RecordFederationReplicaPendingEnrollment`, used by the config reconciler.

