### PR TITLE
Preserve daemon credential provenance

### DIFF
--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
 	"go.kenn.io/kata/internal/client"
 	"go.kenn.io/kata/internal/daemon"
 )
@@ -34,10 +38,10 @@ func envHTTPTimeout(def time.Duration) time.Duration {
 	return d
 }
 
-// ensureDaemon discovers a live daemon's HTTP base URL, auto-starting one
-// if none is found. Thin wrapper over client.EnsureRunning so the CLI
-// and TUI share one resolution path; tests still inject a base URL via
-// client.BaseURLKey{} on the context.
+// ensureDaemonResolved discovers a live daemon, auto-starting one if none is
+// found, and carries the source, credentials, and transport policy selected by
+// that resolution. Client construction consumes this value without deriving
+// policy again from its base URL.
 //
 // When --workspace points at a specific directory, that path anchors
 // the .kata.local.toml walk so a workspace-local [server] override is
@@ -46,20 +50,27 @@ func envHTTPTimeout(def time.Duration) time.Duration {
 // If a daemon is explicitly configured (via --daemon, KATA_SERVER,
 // .kata.local.toml, or active_daemon) but does not respond, the CLI surfaces
 // this as a daemon-unavailable error so callers see a stable exit code and shape.
-func ensureDaemon(ctx context.Context) (string, error) {
+func ensureDaemonResolved(ctx context.Context) (client.ResolvedDaemon, error) {
 	if flags.Daemon != "" {
-		baseURL, err := client.EnsureNamedRunning(ctx, flags.Daemon)
-		if err == nil {
-			return baseURL, nil
+		resolved, err := client.EnsureResolvedNamed(ctx, flags.Daemon)
+		if err != nil {
+			return client.ResolvedDaemon{}, cliDaemonTargetError(err)
 		}
-		return "", cliDaemonTargetError(err)
+		return resolved, nil
 	}
 	workspaceStart := workspaceStartForRemote()
-	baseURL, err := client.EnsureRunningInWorkspace(ctx, workspaceStart)
+	resolved, err := client.EnsureResolvedInWorkspace(ctx, workspaceStart)
 	if err != nil {
-		return "", cliDaemonTargetError(err)
+		return client.ResolvedDaemon{}, cliDaemonTargetError(err)
 	}
-	return baseURL, nil
+	return resolved, nil
+}
+
+// ensureDaemon is the URL-only compatibility view used by command paths that
+// have not moved to the resolved client constructors yet.
+func ensureDaemon(ctx context.Context) (string, error) {
+	resolved, err := ensureDaemonResolved(ctx)
+	return resolved.BaseURL, err
 }
 
 // workspaceStartForRemote returns the absolute --workspace path when
@@ -97,42 +108,51 @@ func workspaceStartForRemote() string {
 // Returns a kindDaemonUnavail cliError when no live daemon is found,
 // matching hammer-test finding #1's expectation that `kata health`
 // doesn't lie about the daemon's actual state.
-func discoverDaemon(ctx context.Context) (string, error) {
+func discoverDaemonResolved(ctx context.Context) (client.ResolvedDaemon, error) {
 	if v, ok := ctx.Value(client.BaseURLKey{}).(string); ok && v != "" {
-		return v, nil
+		// The injected branch returns before remote resolution or local startup,
+		// while retaining the same global auth policy as ensured injection.
+		return client.EnsureResolvedInWorkspace(ctx, "")
 	}
 	if flags.Daemon != "" {
-		baseURL, ok, err := client.DiscoverNamed(ctx, flags.Daemon)
-		if err == nil && ok {
-			return baseURL, nil
+		resolved, err := client.DiscoverResolvedNamed(ctx, flags.Daemon)
+		if err != nil {
+			return client.ResolvedDaemon{}, cliDaemonTargetError(err)
 		}
-		if err == nil {
-			return "", noDaemonRunningError()
+		if resolved.BaseURL == "" {
+			return client.ResolvedDaemon{}, noDaemonRunningError()
 		}
-		return "", cliDaemonTargetError(err)
+		return resolved, nil
 	}
-	if url, ok, err := client.ResolveRemote(ctx, workspaceStartForRemote()); err != nil {
+	if resolved, ok, err := client.ResolveRemoteDaemon(ctx, workspaceStartForRemote()); err != nil {
 		if errors.Is(err, client.ErrRemoteUnavailable) {
-			return "", &cliError{
+			return client.ResolvedDaemon{}, &cliError{
 				Message:  err.Error(),
 				Kind:     kindDaemonUnavail,
 				ExitCode: ExitDaemonUnavail,
 			}
 		}
-		return "", err
+		return client.ResolvedDaemon{}, err
 	} else if ok {
-		return url, nil
+		return resolved, nil
 	}
 	ns, err := daemon.NewNamespace()
 	if err != nil {
-		return "", err
+		return client.ResolvedDaemon{}, err
 	}
-	if url, ok, err := client.Discover(ctx, ns.DataDir); err != nil {
-		return "", cliDaemonTargetError(err)
+	if resolved, ok, err := client.DiscoverResolved(ctx, ns.DataDir); err != nil {
+		return client.ResolvedDaemon{}, cliDaemonTargetError(err)
 	} else if ok {
-		return url, nil
+		return resolved, nil
 	}
-	return "", noDaemonRunningError()
+	return client.ResolvedDaemon{}, noDaemonRunningError()
+}
+
+// discoverDaemon is the URL-only compatibility view used by command paths
+// that have not moved to the resolved client constructors yet.
+func discoverDaemon(ctx context.Context) (string, error) {
+	resolved, err := discoverDaemonResolved(ctx)
+	return resolved.BaseURL, err
 }
 
 func noDaemonRunningError() error {
@@ -168,13 +188,18 @@ func cliDaemonTargetError(err error) error {
 // CLI command site is already named for it.
 func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 	workspaceStart := workspaceStartForRemote()
-	return client.NewHTTPClient(ctx, baseURL,
-		client.Opts{
-			Timeout:        envHTTPTimeout(defaultHTTPTimeout),
-			AllowInsecure:  client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart),
-			WorkspaceStart: workspaceStart,
-			DaemonName:     flags.Daemon,
-		})
+	return client.NewHTTPClient(ctx, baseURL, client.Opts{
+		Timeout:        envHTTPTimeout(defaultHTTPTimeout),
+		AllowInsecure:  client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart), //nolint:staticcheck // URL-only compatibility caller awaits resolved-target migration.
+		WorkspaceStart: workspaceStart,
+		DaemonName:     flags.Daemon,
+	})
+}
+
+func httpClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) (*http.Client, error) {
+	return client.NewHTTPClientForResolved(ctx, resolved, client.Opts{
+		Timeout: envHTTPTimeout(defaultHTTPTimeout),
+	})
 }
 
 // longRunningClientFor builds a variant with no overall Client.Timeout for
@@ -183,10 +208,14 @@ func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 func longRunningClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 	workspaceStart := workspaceStartForRemote()
 	return client.NewHTTPClient(ctx, baseURL, client.Opts{
-		AllowInsecure:  client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart),
+		AllowInsecure:  client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart), //nolint:staticcheck // URL-only compatibility caller awaits resolved-target migration.
 		WorkspaceStart: workspaceStart,
 		DaemonName:     flags.Daemon,
 	})
+}
+
+func longRunningClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) (*http.Client, error) {
+	return client.NewHTTPClientForResolved(ctx, resolved, client.Opts{})
 }
 
 // streamingClientFor builds the SSE-friendly variant. Body cancellation comes
@@ -195,10 +224,144 @@ func streamingClientFor(ctx context.Context, baseURL string) (*http.Client, erro
 	workspaceStart := workspaceStartForRemote()
 	return client.NewHTTPClient(ctx, baseURL, client.Opts{
 		ResponseHeaderTimeout: client.SSEHandshakeTimeout,
-		AllowInsecure:         client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart),
-		WorkspaceStart:        workspaceStart,
-		DaemonName:            flags.Daemon,
+		AllowInsecure: client.RemoteAllowInsecureForBaseURL( //nolint:staticcheck // URL-only compatibility caller awaits resolved-target migration.
+			baseURL, workspaceStart,
+		),
+		WorkspaceStart: workspaceStart,
+		DaemonName:     flags.Daemon,
 	})
+}
+
+func streamingClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) (*http.Client, error) {
+	return client.NewHTTPClientForResolved(ctx, resolved, client.Opts{
+		ResponseHeaderTimeout: client.SSEHandshakeTimeout,
+	})
+}
+
+// daemonAPI is a resolved connection to one daemon: the base URL, the
+// *http.Client configured for it, and the resolution provenance behind both.
+// Paths passed to its methods are API-relative ("/api/v1/…").
+//
+// The ctx field is deliberate: a daemonAPI is built inside a command's RunE
+// and discarded when it returns, so it carries that invocation's context
+// rather than making every call site thread it. Do not store one in a
+// longer-lived struct or share it across goroutines.
+//
+// dialDaemon is LOCAL-DAEMON-ONLY. A federation hub is reached through hubAPI
+// with a client built by the hub-specific constructors; the local daemon's
+// token must never travel to a hub.
+type daemonAPI struct {
+	ctx      context.Context
+	baseURL  string
+	client   *http.Client
+	resolved client.ResolvedDaemon
+}
+
+// dialDaemon resolves the local daemon (auto-starting one if needed) and
+// builds the standard request-budget client for it.
+func dialDaemon(ctx context.Context) (daemonAPI, error) {
+	return dialResolved(ctx, httpClientForResolved)
+}
+
+func dialResolved(
+	ctx context.Context,
+	build func(context.Context, client.ResolvedDaemon) (*http.Client, error),
+) (daemonAPI, error) {
+	resolved, err := ensureDaemonResolved(ctx)
+	if err != nil {
+		return daemonAPI{}, err
+	}
+	hc, err := build(ctx, resolved)
+	if err != nil {
+		return daemonAPI{}, err
+	}
+	return daemonAPI{ctx: ctx, baseURL: resolved.BaseURL, client: hc, resolved: resolved}, nil
+}
+
+// discoverDaemonAPI is dialDaemon without auto-start, for probes where "no
+// daemon running" is a meaningful answer.
+func discoverDaemonAPI(ctx context.Context) (daemonAPI, error) {
+	resolved, err := discoverDaemonResolved(ctx)
+	if err != nil {
+		return daemonAPI{}, err
+	}
+	hc, err := httpClientForResolved(ctx, resolved)
+	if err != nil {
+		return daemonAPI{}, err
+	}
+	return daemonAPI{ctx: ctx, baseURL: resolved.BaseURL, client: hc, resolved: resolved}, nil
+}
+
+// hubAPI wraps an already-constructed federation hub client. It is a separate
+// constructor on purpose: hub credentials are resolved by the hub-specific
+// paths (resolveHubAdminAuth / federationEnrollHTTPClient) and must never come
+// from local daemon resolution.
+func hubAPI(ctx context.Context, hubBaseURL string, hc *http.Client) daemonAPI {
+	return daemonAPI{ctx: ctx, baseURL: strings.TrimRight(hubBaseURL, "/"), client: hc}
+}
+
+func (a daemonAPI) url(path string) string {
+	return strings.TrimRight(a.baseURL, "/") + path
+}
+
+// status is the raw form: the HTTP status and body with no error mapping. Use
+// it only where a call site deliberately diverges from the >= 400 rule.
+func (a daemonAPI) status(method, path string, body any) (int, []byte, error) {
+	return httpDoJSON(a.ctx, a.client, method, a.url(path), body)
+}
+
+// do performs the request and maps any status >= 400 to a cliError.
+func (a daemonAPI) do(method, path string, body any) ([]byte, error) {
+	status, bs, err := a.status(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	if status >= 400 {
+		return nil, apiErrFromBody(status, bs)
+	}
+	return bs, nil
+}
+
+func (a daemonAPI) doWithHeaders(method, path string, headers map[string]string, body any) ([]byte, error) {
+	status, bs, err := httpDoJSONWithHeader(a.ctx, a.client, method, a.url(path), headers, body)
+	if err != nil {
+		return nil, err
+	}
+	if status >= 400 {
+		return nil, apiErrFromBody(status, bs)
+	}
+	return bs, nil
+}
+
+// decode performs the request and unmarshals a successful body into out.
+func (a daemonAPI) decode(method, path string, body, out any) error {
+	bs, err := a.do(method, path, body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bs, out)
+}
+
+// passthrough performs the request and, in JSON output mode, writes the
+// daemon's response body straight through. The bool reports whether output was
+// written, so callers can return immediately in JSON mode and fall through to
+// their human/agent rendering otherwise.
+func (a daemonAPI) passthrough(cmd *cobra.Command, method, path string, body any) ([]byte, bool, error) {
+	bs, err := a.do(method, path, body)
+	if err != nil {
+		return nil, false, err
+	}
+	if currentOutputMode() != outputJSON {
+		return bs, false, nil
+	}
+	var buf bytes.Buffer
+	if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
+		return nil, false, err
+	}
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), buf.String()); err != nil {
+		return nil, false, err
+	}
+	return bs, true, nil
 }
 
 // resolvedIssueRef captures everything a CLI command needs after parsing a

--- a/cmd/kata/client_test.go
+++ b/cmd/kata/client_test.go
@@ -4,8 +4,15 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/client"
 )
 
 func TestEnvHTTPTimeout(t *testing.T) {
@@ -68,6 +75,225 @@ func TestEnsureDaemon_RemoteUnavailableMapsToCLIError(t *testing.T) {
 	}
 }
 
+func TestEnsureDaemonResolvedPreservesInjectedResolution(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_AUTH_TOKEN", "injected-token")
+	ctx := context.WithValue(t.Context(), client.BaseURLKey{}, "https://daemon.example")
+
+	resolved, err := ensureDaemonResolved(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, client.DaemonSourceInjected, resolved.Source)
+	assert.Equal(t, "https://daemon.example", resolved.BaseURL)
+	assert.Equal(t, "injected-token", resolved.Token)
+}
+
+func TestDiscoverDaemonResolvedPreservesInjectedResolution(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_AUTH_TOKEN", "discover-injected-token")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+	ctx := context.WithValue(t.Context(), client.BaseURLKey{}, "https://daemon.example")
+
+	resolved, err := discoverDaemonResolved(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, client.DaemonSourceInjected, resolved.Source)
+	assert.Equal(t, "https://daemon.example", resolved.BaseURL)
+	assert.Equal(t, "discover-injected-token", resolved.Token)
+	assert.True(t, resolved.TrustPrivateNetwork)
+}
+
+func TestHTTPClientForResolvedUsesResolvedPolicy(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_ALLOW_INSECURE", "")
+
+	resolved := client.ResolvedDaemon{
+		Source:        client.DaemonSourceNamedCatalog,
+		Name:          "example-daemon",
+		BaseURL:       "http://daemon.example:7777",
+		Token:         "catalog-token",
+		AllowInsecure: true,
+	}
+	constructors := []struct {
+		name string
+		new  func(context.Context, client.ResolvedDaemon) (*http.Client, error)
+	}{
+		{name: "default", new: httpClientForResolved},
+		{name: "long running", new: longRunningClientForResolved},
+		{name: "streaming", new: streamingClientForResolved},
+	}
+	for _, tt := range constructors {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.new(t.Context(), resolved)
+			require.NoError(t, err)
+			assert.NotNil(t, got)
+		})
+	}
+}
+
+func TestHTTPClientForResolvedRefusesUnsafeTargetWithoutPolicy(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_ALLOW_INSECURE", "")
+
+	_, err := httpClientForResolved(t.Context(), client.ResolvedDaemon{
+		Source:  client.DaemonSourceNamedCatalog,
+		BaseURL: "http://daemon.example:7777",
+		Token:   "catalog-token",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plaintext")
+}
+
+func TestHTTPClientForCompatibilityCarriesMatchedAllowInsecure(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_ALLOW_INSECURE", "")
+	const baseURL = "http://daemon.example:7777"
+
+	for _, tt := range []struct {
+		name          string
+		allowInsecure bool
+		wantErr       bool
+	}{
+		{name: "rejects without opt-in", wantErr: true},
+		{name: "accepts matched opt-in", allowInsecure: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFlags(t)
+			workspace := t.TempDir()
+			flags.Workspace = workspace
+			t.Setenv("KATA_HOME", t.TempDir())
+			require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.toml"), []byte(
+				"version = 1\n\n[project]\nidentity = \"example.test/spoke-project\"\nname = \"spoke-project\"\n",
+			), 0o600))
+			localConfig := "version = 1\n\n[server]\nurl = \"" + baseURL + "\"\n"
+			if tt.allowInsecure {
+				localConfig += "allow_insecure = true\n"
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
+				[]byte(localConfig), 0o600))
+
+			got, err := httpClientFor(t.Context(), baseURL)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, got)
+		})
+	}
+}
+
+func TestEnsureDaemonHTTPClientForUsesNamedCatalogCredential(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		catalogAuth  string
+		authOverride string
+		tokenEnv     string
+		want         string
+	}{
+		{name: "catalog token", catalogAuth: `token = "catalog-token"`, want: "Bearer catalog-token"},
+		{ //nolint:gosec // Fake credential literals exercise catalog precedence.
+			name: "catalog token env", catalogAuth: `token_env = "KATA_SHARED_TOKEN"`,
+			tokenEnv: "catalog-env-token", want: "Bearer catalog-env-token",
+		},
+		{ //nolint:gosec // Fake credential literals exercise catalog precedence.
+			name: "auth token env override", catalogAuth: `token_env = "KATA_SHARED_TOKEN"`,
+			authOverride: "override-token", tokenEnv: "catalog-env-token", want: "Bearer override-token",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFlags(t)
+			flags.Daemon = "shared"
+			t.Setenv("KATA_AUTH_TOKEN", tt.authOverride)
+			t.Setenv("KATA_SHARED_TOKEN", tt.tokenEnv)
+
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v1/ping" {
+					_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+					return
+				}
+				got = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			t.Cleanup(srv.Close)
+
+			home := t.TempDir()
+			t.Setenv("KATA_HOME", home)
+			require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+`+tt.catalogAuth+`
+`), 0o600))
+
+			baseURL, err := ensureDaemon(t.Context())
+			require.NoError(t, err)
+			hc, err := httpClientFor(t.Context(), baseURL)
+			require.NoError(t, err)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, baseURL+"/protected", nil)
+			require.NoError(t, err)
+			resp, err := hc.Do(req) //nolint:gosec // baseURL is the test's own httptest.Server
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = resp.Body.Close() })
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEnsureDaemonHTTPClientForUsesActiveCatalogToken(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_SERVER", "")
+
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+			return
+		}
+		got = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+active_daemon = "shared"
+
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token = "catalog-token"
+`), 0o600))
+
+	baseURL, err := ensureDaemon(t.Context())
+	require.NoError(t, err)
+	hc, err := httpClientFor(t.Context(), baseURL)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, baseURL+"/protected", nil)
+	require.NoError(t, err)
+	resp, err := hc.Do(req) //nolint:gosec // baseURL is the test's own httptest.Server
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, "Bearer catalog-token", got)
+}
+
 func assertEnvDurationOverride(t *testing.T, envKey, envVal string, fallback, want time.Duration, parseFn func(time.Duration) time.Duration) {
 	t.Helper()
 	t.Setenv(envKey, envVal)
@@ -75,4 +301,87 @@ func assertEnvDurationOverride(t *testing.T, envKey, envVal string, fallback, wa
 	if got != want {
 		t.Fatalf("%s=%q override failed: got %v, want %v", envKey, envVal, got, want)
 	}
+}
+
+// TestDaemonAPIStatusMapsToCLIError pins the status→cliError contract in the
+// one place it now lives. Before daemonAPI this rule was re-typed at ~31 call
+// sites, which is how the >= 300 outlier at ensureFederationProjectByName
+// survived unnoticed.
+func TestDaemonAPIStatusMapsToCLIError(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		wantErr  bool
+		wantKind errKind
+		wantExit int
+		wantCode string
+	}{
+		{name: "200 ok", status: http.StatusOK, body: `{"ok":true}`},
+		{name: "201 created", status: http.StatusCreated, body: `{"ok":true}`},
+		{name: "204 no content", status: http.StatusNoContent, body: ``},
+		{
+			name: "400 validation", status: http.StatusBadRequest,
+			body:    `{"error":{"code":"validation","message":"bad input"}}`,
+			wantErr: true, wantKind: kindValidation, wantExit: ExitValidation, wantCode: "validation",
+		},
+		{
+			name: "404 not found", status: http.StatusNotFound,
+			body:    `{"error":{"code":"not_found","message":"missing"}}`,
+			wantErr: true, wantKind: kindNotFound, wantExit: ExitNotFound, wantCode: "not_found",
+		},
+		{
+			name: "409 conflict", status: http.StatusConflict,
+			body:    `{"error":{"code":"conflict","message":"already exists"}}`,
+			wantErr: true, wantKind: kindConflict, wantExit: ExitConflict, wantCode: "conflict",
+		},
+		{
+			name: "500 internal", status: http.StatusInternalServerError,
+			body:    `{"error":{"code":"internal","message":"boom"}}`,
+			wantErr: true, wantKind: kindInternal, wantExit: ExitInternal, wantCode: "internal",
+		},
+		{
+			name: "non-json error body", status: http.StatusBadGateway,
+			body:    `upstream exploded`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(srv.Close)
+
+			api := daemonAPI{ctx: context.Background(), baseURL: srv.URL, client: srv.Client()}
+			bs, err := api.do(http.MethodGet, "/api/v1/health", nil)
+
+			if !tt.wantErr {
+				require.NoError(t, err)
+				assert.Equal(t, tt.body, string(bs))
+				return
+			}
+			require.Error(t, err)
+			var cerr *cliError
+			require.ErrorAs(t, err, &cerr)
+			if tt.wantKind != "" {
+				assert.Equal(t, tt.wantKind, cerr.Kind)
+				assert.Equal(t, tt.wantExit, cerr.ExitCode)
+				assert.Equal(t, tt.wantCode, cerr.Code)
+			}
+		})
+	}
+}
+
+// TestDaemonAPIURLJoinsAPIRelativePaths pins that paths are API-relative and
+// joined in one place, so the API surface the CLI depends on is greppable.
+func TestDaemonAPIURLJoinsAPIRelativePaths(t *testing.T) {
+	api := daemonAPI{baseURL: "http://127.0.0.1:7777"}
+	assert.Equal(t, "http://127.0.0.1:7777/api/v1/federation/status",
+		api.url("/api/v1/federation/status"))
+
+	trailing := daemonAPI{baseURL: "http://127.0.0.1:7777/"}
+	assert.Equal(t, "http://127.0.0.1:7777/api/v1/federation/status",
+		trailing.url("/api/v1/federation/status"))
 }

--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -331,16 +331,15 @@ func resolveProjectIDAndName(ctx context.Context, baseURL, startPath string) (in
 	if err != nil {
 		return 0, "", err
 	}
-	return resolveProjectIDAndNameWithClient(ctx, client, baseURL, startPath)
+	return resolveProjectIDAndNameWithClient(
+		daemonAPI{ctx: ctx, client: client, baseURL: baseURL}, startPath)
 }
 
 func resolveProjectIDAndNameWithClient(
-	ctx context.Context,
-	client *http.Client,
-	baseURL string,
+	a daemonAPI,
 	startPath string,
 ) (int64, string, error) {
-	return resolveProjectIDAndNameWithClientHeaders(ctx, client, baseURL, startPath, nil)
+	return resolveProjectIDAndNameWithDaemonHeaders(a, startPath, nil)
 }
 
 func resolveProjectIDAndNameWithClientHeaders(
@@ -350,17 +349,22 @@ func resolveProjectIDAndNameWithClientHeaders(
 	startPath string,
 	headers map[string]string,
 ) (int64, string, error) {
-	body, repair, err := buildResolveRequest(ctx, startPath)
+	return resolveProjectIDAndNameWithDaemonHeaders(
+		daemonAPI{ctx: ctx, client: client, baseURL: baseURL}, startPath, headers)
+}
+
+func resolveProjectIDAndNameWithDaemonHeaders(
+	a daemonAPI,
+	startPath string,
+	headers map[string]string,
+) (int64, string, error) {
+	body, repair, err := buildResolveRequest(a.ctx, startPath)
 	if err != nil {
 		return 0, "", err
 	}
-	status, bs, err := httpDoJSONHeaders(ctx, client, http.MethodPost,
-		baseURL+"/api/v1/projects/resolve", body, headers)
+	bs, err := a.doWithHeaders(http.MethodPost, "/api/v1/projects/resolve", headers, body)
 	if err != nil {
 		return 0, "", err
-	}
-	if status >= 400 {
-		return 0, "", apiErrFromBody(status, bs)
 	}
 	var b struct {
 		Project struct {

--- a/cmd/kata/federation.go
+++ b/cmd/kata/federation.go
@@ -51,30 +51,15 @@ func federationIdentityCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
+			bs, emitted, err := a.passthrough(cmd, http.MethodGet, "/api/v1/instance", nil)
+			if err != nil || emitted {
 				return err
-			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/instance", nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			mode := currentOutputMode()
-			if mode == outputJSON {
-				var buf bytes.Buffer
-				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
-					return err
-				}
-				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
-				return err
-			}
 			var body struct {
 				InstanceUID   string `json:"instance_uid"`
 				Version       string `json:"version"`
@@ -103,20 +88,16 @@ func federationEnableCmd() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
-				return err
-			}
-			project, err := resolveFederationProject(ctx, client, baseURL, args, false, "")
+			project, err := resolveFederationProject(a, args, false, "")
 			if err != nil {
 				return err
 			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
-			metadata, err := enableAndReadFederationMetadata(ctx, client, baseURL, project.ID, actor)
+			metadata, err := enableAndReadFederationMetadata(a, project.ID, actor)
 			if err != nil {
 				return err
 			}
@@ -167,15 +148,16 @@ func federationEnrollCmd() *cobra.Command {
 			if err != nil {
 				return federationEnrollHTTPClientError(err)
 			}
+			hub := hubAPI(ctx, hubBaseURL, hubClient)
 			requestActor := strings.TrimSpace(actor)
 			if requestActor == "" {
 				requestActor, _ = resolveActor(ctx, flags.As, nil)
 			}
-			project, err := resolveFederationProject(ctx, hubClient, hubBaseURL, args, true, requestActor)
+			project, err := resolveFederationProject(hub, args, true, requestActor)
 			if err != nil {
 				return err
 			}
-			metadata, err := enableAndReadFederationMetadata(ctx, hubClient, hubBaseURL, project.ID, requestActor)
+			metadata, err := enableAndReadFederationMetadata(hub, project.ID, requestActor)
 			if err != nil {
 				return err
 			}
@@ -193,8 +175,7 @@ func federationEnrollCmd() *cobra.Command {
 					adoptExisting = spokeUID == "" || spokeUID != metadata.ProjectUID
 				}
 			}
-			status, bs, err := httpDoJSON(ctx, hubClient, http.MethodPost,
-				hubBaseURL+"/api/v1/federation/enrollments",
+			bs, err := hub.do(http.MethodPost, "/api/v1/federation/enrollments",
 				map[string]any{
 					"spoke_instance_uid":              spokeInstance,
 					"project_id":                      project.ID,
@@ -205,9 +186,6 @@ func federationEnrollCmd() *cobra.Command {
 				})
 			if err != nil {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			var enrollment api.FederationEnrollmentOut
 			if err := json.Unmarshal(bs, &enrollment); err != nil {
@@ -273,7 +251,10 @@ func federationSpokeProjectExists(ctx context.Context, projectName, spokeInstanc
 // federationSpokeProjectUID reports whether the default/spoke daemon (when its
 // instance matches spokeInstance) has a project named projectName, returning
 // that project's UID. The UID is "" when the daemon's list payload predates
-// uid, in which case callers should fall back to the adoption default.
+// uid, in which case callers should fall back to the adoption default. This
+// probe deliberately keeps its spoke-specific client instead of dialDaemon:
+// during federation enroll, KATA_AUTH_TOKEN belongs to the hub and must not be
+// attached to the spoke. Requests still use daemonAPI once that client is built.
 func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance string) (string, bool, error) {
 	explicitDaemon := federationSpokeProbeExplicit(ctx)
 	spokeURL, err := ensureDaemon(ctx)
@@ -290,8 +271,9 @@ func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance s
 		}
 		return "", false, nil
 	}
+	a := daemonAPI{ctx: ctx, baseURL: spokeURL, client: spokeClient}
 	if strings.TrimSpace(spokeInstance) != "" {
-		uid, err := federationSpokeInstanceUID(ctx, spokeClient, spokeURL)
+		uid, err := federationSpokeInstanceUID(a)
 		if err != nil || uid != strings.TrimSpace(spokeInstance) {
 			if err != nil && explicitDaemon {
 				return "", false, err
@@ -299,7 +281,7 @@ func federationSpokeProjectUID(ctx context.Context, projectName, spokeInstance s
 			return "", false, nil
 		}
 	}
-	uid, ok, err := federationSpokeProjectNameExists(ctx, spokeClient, spokeURL, projectName)
+	uid, ok, err := federationSpokeProjectNameExists(a, projectName)
 	if err != nil && explicitDaemon {
 		return "", false, err
 	}
@@ -332,7 +314,8 @@ func federationSpokeProbePreflight(ctx context.Context, spokeInstance string) er
 	if strings.TrimSpace(spokeInstance) == "" {
 		return nil
 	}
-	_, err = federationSpokeInstanceUID(ctx, spokeClient, spokeURL)
+	a := daemonAPI{ctx: ctx, baseURL: spokeURL, client: spokeClient}
+	_, err = federationSpokeInstanceUID(a)
 	return err
 }
 
@@ -366,93 +349,71 @@ func federationSpokeHTTPClient(ctx context.Context, spokeURL string) (*http.Clie
 	if err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(token) == "" {
-		return clientpkg.NewHTTPClientForTarget(ctx, spokeURL,
-			clientpkg.TargetAuth{AllowInsecure: entry.AllowInsecure}, opts)
-	}
-	auth, err := config.ReadAuthConfig()
-	if err != nil {
-		auth.TrustPrivateNetwork = config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
-	}
 	return clientpkg.NewHTTPClientForTarget(ctx, spokeURL,
 		clientpkg.TargetAuth{
 			Token:               token,
 			AllowInsecure:       entry.AllowInsecure,
-			TrustPrivateNetwork: auth.TrustPrivateNetwork,
+			TrustPrivateNetwork: config.ResolvedBearerTrustPrivateNetwork(),
 		}, opts)
 }
 
 func federationImplicitSpokeTargetAuth(ctx context.Context, spokeURL string) (clientpkg.TargetAuth, error) {
 	workspaceStart := workspaceStartForRemote()
-	if remoteURL, ok, err := clientpkg.ResolveRemote(ctx, workspaceStart); err != nil {
-		return clientpkg.TargetAuth{}, err
-	} else if !ok || strings.TrimRight(remoteURL, "/") != strings.TrimRight(spokeURL, "/") {
-		return clientpkg.TargetAuth{}, nil
+	targetAuth := clientpkg.TargetAuth{
+		TrustPrivateNetwork: config.ResolvedBearerTrustPrivateNetwork(),
 	}
+	remoteURL, ok, err := clientpkg.ResolveRemote(ctx, workspaceStart)
+	if err != nil {
+		return clientpkg.TargetAuth{}, err
+	}
+	if !ok || strings.TrimRight(remoteURL, "/") != strings.TrimRight(spokeURL, "/") {
+		return targetAuth, nil
+	}
+	targetAuth.AllowInsecure = clientpkg.RemoteAllowInsecureForBaseURL(spokeURL, workspaceStart) //nolint:staticcheck // URL-only compatibility caller awaits resolved-target migration.
 	if os.Getenv("KATA_SERVER") != "" {
-		return clientpkg.TargetAuth{}, nil
+		return targetAuth, nil
 	}
 	cfg, err := config.ReadDaemonConfig()
 	if err != nil {
 		return clientpkg.TargetAuth{}, err
 	}
 	if strings.TrimSpace(cfg.ActiveDaemon) == "" {
-		return clientpkg.TargetAuth{}, nil
+		return targetAuth, nil
 	}
 	entry := catalogByName(cfg, cfg.ActiveDaemon)
 	if entry == nil || entry.Local {
-		return clientpkg.TargetAuth{}, nil
+		return targetAuth, nil
 	}
 	entryURL, err := clientpkg.NormalizeRemoteURL(entry.URL, entry.AllowInsecure)
 	if err != nil {
 		return clientpkg.TargetAuth{}, err
 	}
 	if strings.TrimRight(entryURL, "/") != strings.TrimRight(spokeURL, "/") {
-		return clientpkg.TargetAuth{}, nil
+		return targetAuth, nil
 	}
+	targetAuth.AllowInsecure = entry.AllowInsecure
 	token, err := selectedCatalogToken(entry)
 	if err != nil {
 		return clientpkg.TargetAuth{}, err
 	}
-	auth, err := config.ReadAuthConfig()
-	if err != nil {
-		auth.TrustPrivateNetwork = config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
-	}
-	return clientpkg.TargetAuth{
-		Token:               token,
-		AllowInsecure:       entry.AllowInsecure,
-		TrustPrivateNetwork: auth.TrustPrivateNetwork,
-	}, nil
+	targetAuth.Token = token
+	return targetAuth, nil
 }
 
-func federationSpokeInstanceUID(ctx context.Context, client *http.Client, baseURL string) (string, error) {
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/instance", nil)
-	if err != nil {
-		return "", err
-	}
-	if status >= 400 {
-		return "", apiErrFromBody(status, bs)
-	}
+func federationSpokeInstanceUID(a daemonAPI) (string, error) {
 	var body struct {
 		InstanceUID string `json:"instance_uid"`
 	}
-	if err := json.Unmarshal(bs, &body); err != nil {
+	if err := a.decode(http.MethodGet, "/api/v1/instance", nil, &body); err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(body.InstanceUID), nil
 }
 
-func federationSpokeProjectNameExists(ctx context.Context, client *http.Client, baseURL, projectName string) (string, bool, error) {
+func federationSpokeProjectNameExists(a daemonAPI, projectName string) (string, bool, error) {
 	projectName = strings.TrimSpace(projectName)
 	if projectName == "" {
 		return "", false, nil
-	}
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/projects", nil)
-	if err != nil {
-		return "", false, err
-	}
-	if status >= 400 {
-		return "", false, apiErrFromBody(status, bs)
 	}
 	var body struct {
 		Projects []struct {
@@ -460,7 +421,7 @@ func federationSpokeProjectNameExists(ctx context.Context, client *http.Client, 
 			UID  string `json:"uid"`
 		} `json:"projects"`
 	}
-	if err := json.Unmarshal(bs, &body); err != nil {
+	if err := a.decode(http.MethodGet, "/api/v1/projects", nil, &body); err != nil {
 		return "", false, err
 	}
 	for _, project := range body.Projects {
@@ -481,21 +442,14 @@ func federationEnrollmentsCmd() *cobra.Command {
 		Short: "list hub federation enrollments",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(cmd.Context())
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
+			bs, emitted, err := a.passthrough(
+				cmd, http.MethodGet, "/api/v1/federation/enrollments", nil)
+			if err != nil || emitted {
 				return err
-			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/enrollments", nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			return printFederationEnrollments(cmd, bs)
 		},
@@ -513,22 +467,14 @@ func federationRevokeCmd() *cobra.Command {
 			if err != nil || id <= 0 {
 				return &cliError{Message: "enrollment-id must be a positive integer", Kind: kindValidation, ExitCode: ExitValidation}
 			}
-			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(cmd.Context())
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
+			bs, emitted, err := a.passthrough(cmd, http.MethodPost,
+				fmt.Sprintf("/api/v1/federation/enrollments/%d/revoke", id), map[string]any{})
+			if err != nil || emitted {
 				return err
-			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-				fmt.Sprintf("%s/api/v1/federation/enrollments/%d/revoke", baseURL, id), map[string]any{})
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			return printFederationRevoke(cmd, bs)
 		},
@@ -582,19 +528,15 @@ func federationJoinCmd() *cobra.Command {
 					ExitCode: ExitValidation,
 				}
 			}
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
+			if err := clientpkg.ConfigureOriginPinnedRedirects(a.client, a.baseURL); err != nil {
 				return err
 			}
-			if err := clientpkg.ConfigureOriginPinnedRedirects(client, baseURL); err != nil {
-				return err
-			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-				baseURL+"/api/v1/federation/replicas",
+			bs, emitted, err := a.passthrough(cmd, http.MethodPost,
+				"/api/v1/federation/replicas",
 				map[string]any{
 					"hub_url":                   strings.TrimRight(bundle.HubURL, "/"),
 					"hub_project_id":            bundle.HubProjectID,
@@ -609,11 +551,8 @@ func federationJoinCmd() *cobra.Command {
 					"push_enabled":              bundle.PushEnabled,
 					"adopt_existing":            bundle.AdoptExisting,
 				})
-			if err != nil {
+			if err != nil || emitted {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			if currentOutputMode() == outputHuman && federationCapabilitiesContain(internalCaps, "push") && !bundle.PushEnabled {
 				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: push capability is present but local push is disabled; rerun join with --push to send spoke edits to the hub")
@@ -645,14 +584,14 @@ func federationJoinCmd() *cobra.Command {
 // runs the normal bound path (idempotent hub revoke + teardown). The cwd
 // workspace form keeps active-only resolution: its alias surface treats
 // archived projects as gone.
-func resolveLeaveProject(ctx context.Context, client *http.Client, baseURL string, args []string) (projectRef, error) {
+func resolveLeaveProject(a daemonAPI, args []string) (projectRef, error) {
 	if len(args) > 0 {
-		return resolveProjectSelectorIncludingArchived(ctx, client, baseURL, args[0])
+		return resolveProjectSelectorIncludingArchived(a, args[0])
 	}
 	if projectName := strings.TrimSpace(flags.Project); projectName != "" {
-		return resolveProjectSelectorIncludingArchived(ctx, client, baseURL, projectName)
+		return resolveProjectSelectorIncludingArchived(a, projectName)
 	}
-	return resolveFederationProject(ctx, client, baseURL, args, false, "")
+	return resolveFederationProject(a, args, false, "")
 }
 
 // spokeLeaveTarget captures the resolved local spoke a leave will tear down.
@@ -692,15 +631,11 @@ func federationLeaveCmd() *cobra.Command {
 				return &cliError{Message: "--force requires --delete", Kind: kindValidation, ExitCode: ExitValidation}
 			}
 			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
-				return err
-			}
-			target, err := resolveSpokeForLeave(ctx, client, baseURL, args)
+			target, err := resolveSpokeForLeave(a, args)
 			if err != nil {
 				return err
 			}
@@ -717,24 +652,18 @@ func federationLeaveCmd() *cobra.Command {
 			// checks stay inside the daemon's transactions.
 			if !localOnly {
 				actor, _ := resolveActor(ctx, flags.As, nil)
-				status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-					fmt.Sprintf("%s/api/v1/federation/replicas/%d/actions/leave", baseURL, target.projectID),
-					map[string]any{"disposition": disposition, "force": force, "actor": actor, "preflight": true})
-				if err != nil {
-					return err
-				}
-				if status >= 400 {
-					return apiErrFromBody(status, bs)
-				}
 				var preflight api.LeaveFederationReplicaResultBody
-				if err := json.Unmarshal(bs, &preflight); err != nil {
+				if err := a.decode(http.MethodPost,
+					fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", target.projectID),
+					map[string]any{"disposition": disposition, "force": force, "actor": actor, "preflight": true},
+					&preflight); err != nil {
 					return err
 				}
 				if target.standalone && preflight.PendingEnrollment != nil {
 					target.hubURL = strings.TrimRight(preflight.PendingEnrollment.HubURL, "/")
 					target.hubProjectID = preflight.PendingEnrollment.HubProjectID
 					target.allowInsecure = preflight.PendingEnrollment.AllowInsecure
-					target.instanceUID, err = federationSpokeInstanceUID(ctx, client, baseURL)
+					target.instanceUID, err = federationSpokeInstanceUID(a)
 					if err != nil {
 						return err
 					}
@@ -758,17 +687,11 @@ func federationLeaveCmd() *cobra.Command {
 			}
 			if !localOnly {
 				actor, _ := resolveActor(ctx, flags.As, nil)
-				status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-					fmt.Sprintf("%s/api/v1/federation/replicas/%d/actions/leave", baseURL, target.projectID),
-					map[string]any{"disposition": disposition, "force": force, "actor": actor, "prepare": true})
-				if err != nil {
-					return err
-				}
-				if status >= 400 {
-					return apiErrFromBody(status, bs)
-				}
 				var prepared api.LeaveFederationReplicaResultBody
-				if err := json.Unmarshal(bs, &prepared); err != nil {
+				if err := a.decode(http.MethodPost,
+					fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", target.projectID),
+					map[string]any{"disposition": disposition, "force": force, "actor": actor, "prepare": true},
+					&prepared); err != nil {
 					return err
 				}
 				if prepared.PendingEnrollment != nil {
@@ -776,7 +699,7 @@ func federationLeaveCmd() *cobra.Command {
 					target.hubProjectID = prepared.PendingEnrollment.HubProjectID
 					target.allowInsecure = prepared.PendingEnrollment.AllowInsecure
 					if target.instanceUID == "" {
-						target.instanceUID, err = federationSpokeInstanceUID(ctx, client, baseURL)
+						target.instanceUID, err = federationSpokeInstanceUID(a)
 						if err != nil {
 							return err
 						}
@@ -811,14 +734,11 @@ func federationLeaveCmd() *cobra.Command {
 				}
 			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-				fmt.Sprintf("%s/api/v1/federation/replicas/%d/actions/leave", baseURL, target.projectID),
+			bs, emitted, err := a.passthrough(cmd, http.MethodPost,
+				fmt.Sprintf("/api/v1/federation/replicas/%d/actions/leave", target.projectID),
 				map[string]any{"disposition": disposition, "force": force, "actor": actor})
-			if err != nil {
+			if err != nil || emitted {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			return printFederationLeave(cmd, bs)
 		},
@@ -839,8 +759,8 @@ func federationLeaveCmd() *cobra.Command {
 //     resume for plain leave; archive-only path for --delete).
 //   - hub binding    → hard error "not_a_spoke" (this command does not disband
 //     hubs).
-func resolveSpokeForLeave(ctx context.Context, client *http.Client, baseURL string, args []string) (spokeLeaveTarget, error) {
-	project, err := resolveLeaveProject(ctx, client, baseURL, args)
+func resolveSpokeForLeave(a daemonAPI, args []string) (spokeLeaveTarget, error) {
+	project, err := resolveLeaveProject(a, args)
 	if err != nil {
 		return spokeLeaveTarget{}, err
 	}
@@ -851,15 +771,8 @@ func resolveSpokeForLeave(ctx context.Context, client *http.Client, baseURL stri
 	// idempotent, so the already-revoked retry is a no-op while the
 	// never-revoked remove case gets its enrollment revoked instead of
 	// silently stranded.
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status?include=archived", nil)
-	if err != nil {
-		return spokeLeaveTarget{}, err
-	}
-	if status >= 400 {
-		return spokeLeaveTarget{}, apiErrFromBody(status, bs)
-	}
 	var body api.FederationStatusBody
-	if err := json.Unmarshal(bs, &body); err != nil {
+	if err := a.decode(http.MethodGet, "/api/v1/federation/status?include=archived", nil, &body); err != nil {
 		return spokeLeaveTarget{}, err
 	}
 	var match *api.FederationProjectStatus
@@ -889,7 +802,7 @@ func resolveSpokeForLeave(ctx context.Context, client *http.Client, baseURL stri
 			ExitCode: ExitValidation,
 		}
 	}
-	instanceUID, err := federationSpokeInstanceUID(ctx, client, baseURL)
+	instanceUID, err := federationSpokeInstanceUID(a)
 	if err != nil {
 		return spokeLeaveTarget{}, err
 	}
@@ -926,20 +839,14 @@ func revokeSpokeEnrollmentsOnHub(ctx context.Context, target spokeLeaveTarget, i
 	if err != nil {
 		return nil, err
 	}
-	hub, err := hubAdminClient(ctx, auth)
+	hubClient, err := hubAdminClient(ctx, auth)
 	if err != nil {
 		return nil, federationLeaveHubError(err)
 	}
-	status, bs, err := httpDoJSON(ctx, hub, http.MethodGet, auth.url+"/api/v1/federation/enrollments", nil)
-	if err != nil {
-		return nil, federationLeaveHubError(err)
-	}
-	if status >= 400 {
-		return nil, federationLeaveHubError(apiErrFromBody(status, bs))
-	}
+	hub := hubAPI(ctx, auth.url, hubClient)
 	var list api.ListFederationEnrollmentsBody
-	if err := json.Unmarshal(bs, &list); err != nil {
-		return nil, err
+	if err := hub.decode(http.MethodGet, "/api/v1/federation/enrollments", nil, &list); err != nil {
+		return nil, federationLeaveHubError(err)
 	}
 	var globals, matched, foreignScoped []int64
 	for _, enrollment := range list.Enrollments {
@@ -972,13 +879,9 @@ func revokeSpokeEnrollmentsOnHub(ctx context.Context, target spokeLeaveTarget, i
 		}
 	}
 	for _, id := range matched {
-		status, bs, err := httpDoJSON(ctx, hub, http.MethodPost,
-			fmt.Sprintf("%s/api/v1/federation/enrollments/%d/revoke", auth.url, id), map[string]any{})
-		if err != nil {
+		if _, err := hub.do(http.MethodPost,
+			fmt.Sprintf("/api/v1/federation/enrollments/%d/revoke", id), map[string]any{}); err != nil {
 			return nil, federationLeaveHubError(err)
-		}
-		if status >= 400 {
-			return nil, federationLeaveHubError(apiErrFromBody(status, bs))
 		}
 	}
 	return globals, nil
@@ -1098,31 +1001,16 @@ func federationStatusCmd() *cobra.Command {
 		Short: "show federation status",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(cmd.Context())
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
+			bs, emitted, err := a.passthrough(
+				cmd, http.MethodGet, "/api/v1/federation/status", nil)
+			if err != nil || emitted {
 				return err
-			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status", nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			mode := currentOutputMode()
-			if mode == outputJSON {
-				var buf bytes.Buffer
-				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
-					return err
-				}
-				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
-				return err
-			}
 			var body api.FederationStatusBody
 			if err := json.Unmarshal(bs, &body); err != nil {
 				return err
@@ -1181,57 +1069,49 @@ func hydrateFederationJoinMetadata(ctx context.Context, bundle *federationJoinBu
 }
 
 func resolveFederationProject(
-	ctx context.Context,
-	client *http.Client,
-	baseURL string,
+	a daemonAPI,
 	args []string,
 	createMissing bool,
 	actor string,
 ) (projectRef, error) {
 	if len(args) > 0 {
-		return resolveProjectSelector(ctx, client, baseURL, args[0])
+		return resolveProjectSelector(a, args[0])
 	}
 	if projectName := strings.TrimSpace(flags.Project); projectName != "" {
 		if !createMissing {
-			return resolveFederationProjectByName(ctx, client, baseURL, projectName)
+			return resolveFederationProjectByName(a, projectName)
 		}
-		return ensureFederationProjectByName(ctx, client, baseURL, projectName, actor)
+		return ensureFederationProjectByName(a, projectName, actor)
 	}
 	start, err := resolveStartPath(flags.Workspace)
 	if err != nil {
 		return projectRef{}, err
 	}
-	id, name, err := resolveProjectIDAndNameWithClient(ctx, client, baseURL, start)
+	id, name, err := resolveProjectIDAndNameWithClient(a, start)
 	if err != nil {
 		return projectRef{}, err
 	}
 	return projectRef{ID: id, Name: name}, nil
 }
 
-func resolveFederationProjectByName(ctx context.Context, client *http.Client, baseURL, name string) (projectRef, error) {
-	status, bs, err := httpDoJSON(ctx, client, http.MethodPost, baseURL+"/api/v1/projects/resolve", map[string]any{"name": name})
-	if err != nil {
-		return projectRef{}, err
-	}
-	if status >= 400 {
-		return projectRef{}, apiErrFromBody(status, bs)
-	}
+func resolveFederationProjectByName(a daemonAPI, name string) (projectRef, error) {
 	var resp struct {
 		Project struct {
 			ID   int64  `json:"id"`
 			Name string `json:"name"`
 		} `json:"project"`
 	}
-	if err := json.Unmarshal(bs, &resp); err != nil {
+	if err := a.decode(http.MethodPost, "/api/v1/projects/resolve",
+		map[string]any{"name": name}, &resp); err != nil {
 		return projectRef{}, err
 	}
 	return projectRef{ID: resp.Project.ID, Name: resp.Project.Name}, nil
 }
 
 func ensureFederationProjectByName(
-	ctx context.Context, client *http.Client, baseURL, name, actor string,
+	a daemonAPI, name, actor string,
 ) (projectRef, error) {
-	status, bs, err := httpDoJSON(ctx, client, http.MethodPost, baseURL+"/api/v1/projects",
+	status, bs, err := a.status(http.MethodPost, "/api/v1/projects",
 		map[string]any{"name": name, "actor": actor})
 	if err != nil {
 		return projectRef{}, fmt.Errorf("POST /api/v1/projects: %w", err)
@@ -1251,18 +1131,11 @@ func ensureFederationProjectByName(
 	return projectRef{ID: resp.Project.ID, Name: resp.Project.Name}, nil
 }
 
-func enableAndReadFederationMetadata(ctx context.Context, client *http.Client, baseURL string, projectID int64, actor string) (api.ProjectFederationBody, error) {
-	status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-		fmt.Sprintf("%s/api/v1/projects/%d/federation/enable", baseURL, projectID),
-		map[string]string{"actor": actor})
-	if err != nil {
-		return api.ProjectFederationBody{}, err
-	}
-	if status >= 400 {
-		return api.ProjectFederationBody{}, apiErrFromBody(status, bs)
-	}
+func enableAndReadFederationMetadata(a daemonAPI, projectID int64, actor string) (api.ProjectFederationBody, error) {
 	var metadata api.ProjectFederationBody
-	if err := json.Unmarshal(bs, &metadata); err != nil {
+	if err := a.decode(http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%d/federation/enable", projectID),
+		map[string]string{"actor": actor}, &metadata); err != nil {
 		return api.ProjectFederationBody{}, err
 	}
 	return metadata, nil
@@ -1630,23 +1503,12 @@ func parseFederationQuarantineID(raw string) (int64, error) {
 }
 
 func loadFederationStatus(ctx context.Context) (api.FederationStatusBody, error) {
-	baseURL, err := ensureDaemon(ctx)
+	a, err := dialDaemon(ctx)
 	if err != nil {
 		return api.FederationStatusBody{}, err
-	}
-	client, err := httpClientFor(ctx, baseURL)
-	if err != nil {
-		return api.FederationStatusBody{}, err
-	}
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status", nil)
-	if err != nil {
-		return api.FederationStatusBody{}, err
-	}
-	if status >= 400 {
-		return api.FederationStatusBody{}, apiErrFromBody(status, bs)
 	}
 	var body api.FederationStatusBody
-	if err := json.Unmarshal(bs, &body); err != nil {
+	if err := a.decode(http.MethodGet, "/api/v1/federation/status", nil, &body); err != nil {
 		return api.FederationStatusBody{}, err
 	}
 	return body, nil
@@ -1842,23 +1704,12 @@ func federationQuarantineRetryCmd() *cobra.Command {
 // releases the batch without advancing the cursor so the events can be sent
 // again on the next sync.
 func runFederationQuarantineAction(ctx context.Context, cmd *cobra.Command, id int64, action, confirm, reason string) error {
-	baseURL, err := ensureDaemon(ctx)
+	a, err := dialDaemon(ctx)
 	if err != nil {
 		return err
-	}
-	client, err := httpClientFor(ctx, baseURL)
-	if err != nil {
-		return err
-	}
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status", nil)
-	if err != nil {
-		return err
-	}
-	if status >= 400 {
-		return apiErrFromBody(status, bs)
 	}
 	var body api.FederationStatusBody
-	if err := json.Unmarshal(bs, &body); err != nil {
+	if err := a.decode(http.MethodGet, "/api/v1/federation/status", nil, &body); err != nil {
 		return err
 	}
 	projectID, err := federationProjectForQuarantine(body, id)
@@ -1866,15 +1717,12 @@ func runFederationQuarantineAction(ctx context.Context, cmd *cobra.Command, id i
 		return err
 	}
 	actor, _ := resolveActor(ctx, flags.As, nil)
-	status, bs, err = httpDoJSONWithHeader(ctx, client, http.MethodPost,
-		fmt.Sprintf("%s/api/v1/projects/%d/federation/quarantine/%d/%s", baseURL, projectID, id, action),
+	bs, err := a.doWithHeaders(http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%d/federation/quarantine/%d/%s", projectID, id, action),
 		map[string]string{"X-Kata-Confirm": confirm},
 		map[string]any{"actor": actor, "reason": reason})
 	if err != nil {
 		return err
-	}
-	if status >= 400 {
-		return apiErrFromBody(status, bs)
 	}
 	mode := currentOutputMode()
 	if mode == outputJSON {

--- a/cmd/kata/federation_rebind.go
+++ b/cmd/kata/federation_rebind.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -44,22 +42,18 @@ func federationRebindCmd() *cobra.Command {
 				return federationRebindSelectorError("--all and a single project selector are mutually exclusive")
 			}
 			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
-				return err
-			}
-			targets, err := federationRebindTargets(ctx, client, baseURL, args, all)
+			targets, err := federationRebindTargets(a, args, all)
 			if err != nil {
 				return err
 			}
 			results := make([]federationRebindCLIResult, 0, len(targets))
 			failed := 0
 			for _, target := range targets {
-				result, rebindErr := executeFederationRebind(ctx, client, baseURL, target, hubCatalog)
+				result, rebindErr := executeFederationRebind(a, target, hubCatalog)
 				if rebindErr != nil {
 					if !all {
 						return rebindErr
@@ -97,23 +91,14 @@ func federationRebindSelectorError(message string) error {
 }
 
 func federationRebindTargets(
-	ctx context.Context,
-	client *http.Client,
-	baseURL string,
+	a daemonAPI,
 	args []string,
 	all bool,
 ) ([]api.FederationProjectStatus, error) {
 	// Archived projects can retain live spoke bindings, so endpoint migrations
 	// must discover them for both explicit selectors and --all.
-	status, body, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/federation/status?include=archived", nil)
-	if err != nil {
-		return nil, err
-	}
-	if status >= 400 {
-		return nil, apiErrFromBody(status, body)
-	}
 	var federationStatus api.FederationStatusBody
-	if err := json.Unmarshal(body, &federationStatus); err != nil {
+	if err := a.decode(http.MethodGet, "/api/v1/federation/status?include=archived", nil, &federationStatus); err != nil {
 		return nil, err
 	}
 	if all {
@@ -144,7 +129,7 @@ func federationRebindTargets(
 		return nil, federationRebindNotSpoke(name)
 	}
 
-	project, err := resolveFederationProject(ctx, client, baseURL, nil, false, "")
+	project, err := resolveFederationProject(a, nil, false, "")
 	if err != nil {
 		return nil, err
 	}
@@ -168,27 +153,14 @@ func federationRebindNotSpoke(project string) error {
 }
 
 func executeFederationRebind(
-	ctx context.Context,
-	client *http.Client,
-	baseURL string,
+	a daemonAPI,
 	target api.FederationProjectStatus,
 	hubCatalog string,
 ) (federationRebindCLIResult, error) {
-	status, body, err := httpDoJSON(
-		ctx,
-		client,
-		http.MethodPost,
-		fmt.Sprintf("%s/api/v1/federation/replicas/%d/actions/rebind", baseURL, target.ProjectID),
-		map[string]any{"hub_catalog": strings.TrimSpace(hubCatalog)},
-	)
-	if err != nil {
-		return federationRebindCLIResult{}, err
-	}
-	if status >= 400 {
-		return federationRebindCLIResult{}, apiErrFromBody(status, body)
-	}
 	var response api.RebindFederationReplicaResponseBody
-	if err := json.Unmarshal(body, &response); err != nil {
+	if err := a.decode(http.MethodPost,
+		fmt.Sprintf("/api/v1/federation/replicas/%d/actions/rebind", target.ProjectID),
+		map[string]any{"hub_catalog": strings.TrimSpace(hubCatalog)}, &response); err != nil {
 		return federationRebindCLIResult{}, err
 	}
 	return federationRebindCLIResult{

--- a/cmd/kata/federation_test.go
+++ b/cmd/kata/federation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/api"
+	clientpkg "go.kenn.io/kata/internal/client"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/testenv"
@@ -968,7 +969,8 @@ func TestResolveFederationProjectUsesProvidedClientForWorkspaceResolution(t *tes
 		}, nil
 	})}
 
-	project, err := resolveFederationProject(context.Background(), client, baseURL, nil, false, "")
+	project, err := resolveFederationProject(
+		daemonAPI{ctx: context.Background(), baseURL: baseURL, client: client}, nil, false, "")
 
 	require.NoError(t, err)
 	assert.True(t, called)
@@ -1062,6 +1064,127 @@ url = "`+spoke.URL+`"
 
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 	assert.Empty(t, gotAuth)
+}
+
+func TestFederationSpokeHTTPClientNamedTokenlessHonorsTrustPrivateNetwork(t *testing.T) {
+	resetFlags(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	flags.Daemon = "spoke"
+	baseURL := "http://100.64.0.5:7373"
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[auth]
+trust_private_network = true
+
+[[daemon]]
+name = "spoke"
+url = "`+baseURL+`"
+`), 0o600))
+
+	hc, err := federationSpokeHTTPClient(t.Context(), baseURL)
+
+	require.NoError(t, err)
+	assert.NotNil(t, hc)
+}
+
+func TestFederationImplicitSpokeTargetAuthMatchingServerPreservesTrust(t *testing.T) {
+	resetFlags(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ping" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+	}))
+	t.Cleanup(spoke.Close)
+	t.Setenv("KATA_SERVER", spoke.URL)
+
+	auth, err := federationImplicitSpokeTargetAuth(t.Context(), spoke.URL)
+	require.NoError(t, err)
+	assert.Empty(t, auth.Token)
+	assert.True(t, auth.TrustPrivateNetwork)
+	assert.False(t, auth.AllowInsecure)
+
+	// Exercise the actual D2 construction boundary: the preserved global trust
+	// must make a tokenless plaintext private-IP target legal.
+	hc, err := clientpkg.NewHTTPClientForTarget(t.Context(), "http://100.64.0.5:7373", auth, clientpkg.Opts{})
+	require.NoError(t, err)
+	assert.NotNil(t, hc)
+}
+
+func TestFederationImplicitSpokeTargetAuthMatchingLocalConfigPreservesPolicy(t *testing.T) {
+	resetFlags(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[auth]
+trust_private_network = true
+`), 0o600))
+	workspace := t.TempDir()
+	flags.Workspace = workspace
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.toml"), []byte(
+		"version = 1\n\n[project]\nidentity = \"example.test/spoke-project\"\nname = \"spoke-project\"\n",
+	), 0o600))
+	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ping" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+	}))
+	t.Cleanup(spoke.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(
+		"version = 1\n\n[server]\nurl = \""+spoke.URL+"\"\nallow_insecure = true\n",
+	), 0o600))
+
+	auth, err := federationImplicitSpokeTargetAuth(t.Context(), spoke.URL)
+
+	require.NoError(t, err)
+	assert.Empty(t, auth.Token)
+	assert.True(t, auth.TrustPrivateNetwork)
+	assert.True(t, auth.AllowInsecure)
+}
+
+func TestFederationImplicitSpokeTargetAuthMismatchDoesNotResolveActiveTokenEnv(t *testing.T) {
+	resetFlags(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_UNRELATED_TOKEN", "")
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ping" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+	}))
+	t.Cleanup(active.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+active_daemon = "unrelated"
+
+[auth]
+trust_private_network = true
+
+[[daemon]]
+name = "unrelated"
+url = "`+active.URL+`"
+token_env = "KATA_UNRELATED_TOKEN"
+`), 0o600))
+
+	auth, err := federationImplicitSpokeTargetAuth(t.Context(), "http://127.0.0.1:27123")
+
+	require.NoError(t, err)
+	assert.Empty(t, auth.Token)
+	assert.True(t, auth.TrustPrivateNetwork)
+	assert.False(t, auth.AllowInsecure)
 }
 
 func TestFederationSpokeHTTPClientNamedDaemonTokenEnvHonorsTrustPrivateNetwork(t *testing.T) {
@@ -1796,6 +1919,28 @@ func TestFederationLeaveHubUnreachableAbortsWithoutLocalOnly(t *testing.T) {
 	assert.ErrorIs(t, bindErr, db.ErrNotFound)
 }
 
+func TestFederationLeaveHubDecodeFailureIncludesLocalOnlyRecovery(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("KATA_HOME", t.TempDir())
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/federation/enrollments" {
+			_, _ = w.Write([]byte(`not-json`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(hub.Close)
+
+	_, err := revokeSpokeEnrollmentsOnHub(t.Context(), spokeLeaveTarget{
+		instanceUID:  "spoke-instance",
+		hubProjectID: 42,
+	}, hubAuthInputs{hubURL: hub.URL, hubToken: "hub-admin-token"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hub revoke failed")
+	assert.Contains(t, err.Error(), "--local-only")
+}
+
 // TestFederationLeaveResolvesArchivedProject: an archive-leave retry must be
 // able to reach the daemon's idempotent resume by name even though the
 // project is archived — active-only resolution would report "not found"
@@ -2386,4 +2531,44 @@ func TestFederationLeaveWarnsAboutActiveGlobalEnrollment(t *testing.T) {
 	assert.Contains(t, stdout, "standalone")
 	assert.Contains(t, stderr, "global enrollment(s) #11")
 	assert.Contains(t, stderr, "remain active")
+}
+
+// TestEnsureFederationProjectByNameRejects3xx pins the deliberate divergence:
+// this one call site errors on any status >= 300, not >= 400. A redirect here
+// means the project was not created as asked, and the generic helper's >= 400
+// rule would let it fall through to an opaque decode failure.
+func TestEnsureFederationProjectByNameRejects3xx(t *testing.T) {
+	const actor = "cli-operator"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects" {
+			var body struct {
+				Name  string `json:"name"`
+				Actor string `json:"actor"`
+			}
+			if assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+				assert.Equal(t, "spoke-project", body.Name)
+				assert.Equal(t, actor, body.Actor)
+			}
+			w.Header().Set("Location", "/api/v1/projects/1")
+			w.WriteHeader(http.StatusMovedPermanently)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	api := daemonAPI{ctx: context.Background(), baseURL: srv.URL, client: noRedirectClient(srv)}
+	_, err := ensureFederationProjectByName(api, "spoke-project", actor)
+
+	require.Error(t, err)
+	var cerr *cliError
+	require.ErrorAs(t, err, &cerr)
+}
+
+// noRedirectClient stops the client from following the redirect, so the 3xx
+// reaches the status check rather than being resolved transparently.
+func noRedirectClient(srv *httptest.Server) *http.Client {
+	c := srv.Client()
+	c.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	return c
 }

--- a/cmd/kata/github_sync.go
+++ b/cmd/kata/github_sync.go
@@ -95,11 +95,11 @@ func newGitHubSyncEnableCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			client, baseURL, projectID, err := githubSyncProjectClient(ctx)
+			a, projectID, err := githubSyncProjectAPI(ctx)
 			if err != nil {
 				return err
 			}
-			binding, err := githubSyncResolveBinding(ctx, client, baseURL, projectID, opts)
+			binding, err := githubSyncResolveBinding(a, projectID, opts)
 			if err != nil {
 				return err
 			}
@@ -114,13 +114,10 @@ func newGitHubSyncEnableCmd() *cobra.Command {
 			if strings.TrimSpace(opts.interval) != "" {
 				body["interval"] = strings.TrimSpace(opts.interval)
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-				issueSyncEndpointURL(baseURL, projectID, "github", "enable"), body)
+			bs, err := a.do(http.MethodPost,
+				issueSyncEndpointPath(projectID, "github", "enable"), body)
 			if err != nil {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			return githubSyncPrintBindingBody(cmd.OutOrStdout(), bs, "enabled")
 		},
@@ -150,17 +147,14 @@ func newIssueSyncStatusCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			client, baseURL, projectID, err := githubSyncProjectClient(ctx)
+			a, projectID, err := githubSyncProjectAPI(ctx)
 			if err != nil {
 				return err
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodGet,
-				issueSyncEndpointURL(baseURL, projectID, "github", "status"), nil)
+			bs, err := a.do(http.MethodGet,
+				issueSyncEndpointPath(projectID, "github", "status"), nil)
 			if err != nil {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			return githubSyncPrintBindingBody(cmd.OutOrStdout(), bs, "status")
 		},
@@ -174,21 +168,18 @@ func newGitHubSyncOnceCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			_, baseURL, projectID, err := githubSyncProjectClient(ctx)
+			a, projectID, err := githubSyncProjectAPI(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := longRunningClientFor(ctx, baseURL)
+			a.client, err = longRunningClientForResolved(ctx, a.resolved)
 			if err != nil {
 				return err
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-				issueSyncEndpointURL(baseURL, projectID, "github", "once"), map[string]any{})
+			bs, err := a.do(http.MethodPost,
+				issueSyncEndpointPath(projectID, "github", "once"), map[string]any{})
 			if err != nil {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			return githubSyncPrintOnceBody(cmd.OutOrStdout(), bs)
 		},
@@ -197,49 +188,43 @@ func newGitHubSyncOnceCmd() *cobra.Command {
 
 func githubSyncPostEmpty(cmd *cobra.Command, endpoint, action string) error {
 	ctx := cmd.Context()
-	client, baseURL, projectID, err := githubSyncProjectClient(ctx)
+	a, projectID, err := githubSyncProjectAPI(ctx)
 	if err != nil {
 		return err
 	}
-	status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-		issueSyncEndpointURL(baseURL, projectID, "github", endpoint), map[string]any{})
+	bs, err := a.do(http.MethodPost,
+		issueSyncEndpointPath(projectID, "github", endpoint), map[string]any{})
 	if err != nil {
 		return err
-	}
-	if status >= 400 {
-		return apiErrFromBody(status, bs)
 	}
 	return githubSyncPrintBindingBody(cmd.OutOrStdout(), bs, action)
 }
 
-func issueSyncEndpointURL(baseURL string, projectID int64, provider, action string) string {
-	return fmt.Sprintf("%s/api/v1/projects/%d/issue-sync/%s/%s", baseURL, projectID, provider, action)
+func issueSyncEndpointPath(projectID int64, provider, action string) string {
+	return fmt.Sprintf("/api/v1/projects/%d/issue-sync/%s/%s", projectID, provider, action)
 }
 
-func githubSyncProjectClient(ctx context.Context) (*http.Client, string, int64, error) {
-	baseURL, err := ensureDaemon(ctx)
+// githubSyncProjectAPI is the connected daemon plus the workspace's project
+// ID — the pairing githubSyncProjectClient used to return as a four-value
+// tuple.
+func githubSyncProjectAPI(ctx context.Context) (daemonAPI, int64, error) {
+	a, err := dialDaemon(ctx)
 	if err != nil {
-		return nil, "", 0, err
-	}
-	client, err := httpClientFor(ctx, baseURL)
-	if err != nil {
-		return nil, "", 0, err
+		return daemonAPI{}, 0, err
 	}
 	start, err := resolveStartPath(flags.Workspace)
 	if err != nil {
-		return nil, "", 0, err
+		return daemonAPI{}, 0, err
 	}
-	projectID, _, err := resolveProjectIDAndNameWithClient(ctx, client, baseURL, start)
+	projectID, _, err := resolveProjectIDAndNameWithClient(a, start)
 	if err != nil {
-		return nil, "", 0, err
+		return daemonAPI{}, 0, err
 	}
-	return client, baseURL, projectID, nil
+	return a, projectID, nil
 }
 
 func githubSyncResolveBinding(
-	ctx context.Context,
-	client *http.Client,
-	baseURL string,
+	a daemonAPI,
 	projectID int64,
 	opts githubSyncOptions,
 ) (githubsync.Binding, error) {
@@ -254,7 +239,7 @@ func githubSyncResolveBinding(
 		}
 		return githubsync.Binding{Host: host, Owner: owner, Repo: repo}, nil
 	}
-	return inferIssueSyncBinding(ctx, client, baseURL, projectID, opts.host)
+	return inferIssueSyncBinding(a, projectID, opts.host)
 }
 
 func parseGitHubSyncRepo(repo string) (string, string, error) {
@@ -269,15 +254,11 @@ func parseGitHubSyncRepo(repo string) (string, string, error) {
 	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
 }
 
-func inferIssueSyncBinding(ctx context.Context, client *http.Client, baseURL string, projectID int64, requestedHost string) (githubsync.Binding, error) {
+func inferIssueSyncBinding(a daemonAPI, projectID int64, requestedHost string) (githubsync.Binding, error) {
 	requestedHost = strings.ToLower(strings.TrimSpace(requestedHost))
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet,
-		fmt.Sprintf("%s/api/v1/projects/%d", baseURL, projectID), nil)
+	bs, err := a.do(http.MethodGet, fmt.Sprintf("/api/v1/projects/%d", projectID), nil)
 	if err != nil {
 		return githubsync.Binding{}, err
-	}
-	if status >= 400 {
-		return githubsync.Binding{}, apiErrFromBody(status, bs)
 	}
 	var out struct {
 		Aliases []projectAliasRef `json:"aliases"`

--- a/cmd/kata/github_sync_test.go
+++ b/cmd/kata/github_sync_test.go
@@ -184,6 +184,13 @@ func TestGitHubSyncOnceAllowsLongRunningRequest(t *testing.T) {
 	assert.Equal(t, int64(1), f.runner.runs)
 }
 
+func TestIssueSyncEndpointPathIsAPIRelative(t *testing.T) {
+	assert.Equal(t,
+		"/api/v1/projects/42/issue-sync/github/once",
+		issueSyncEndpointPath(42, "github", "once"),
+	)
+}
+
 func TestRootRegistersSyncGitHub(t *testing.T) {
 	syncCmd, ok := rootSubcommands()["sync"]
 	require.True(t, ok, "root command should register sync")

--- a/cmd/kata/health.go
+++ b/cmd/kata/health.go
@@ -15,24 +15,16 @@ func newHealthCmd() *cobra.Command {
 		Short: "report daemon health",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
 			// health is a probe — it must report the daemon's actual
 			// state, not auto-start one and report on the spawned
 			// child. Hammer-test finding #1.
-			baseURL, err := discoverDaemon(ctx)
+			a, err := discoverDaemonAPI(cmd.Context())
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
+			bs, err := a.do(http.MethodGet, "/api/v1/health", nil)
 			if err != nil {
 				return err
-			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/health", nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			var b struct {
 				OK            bool   `json:"ok"`

--- a/cmd/kata/issue_ref_cli.go
+++ b/cmd/kata/issue_ref_cli.go
@@ -42,7 +42,7 @@ func resolveIssueRefForCommandWithOptions(
 	if err != nil {
 		return nil, "", 0, resolvedIssueRef{}, err
 	}
-	baseURL, err := ensureDaemon(ctx)
+	a, err := dialDaemon(ctx)
 	if err != nil {
 		return nil, "", 0, resolvedIssueRef{}, err
 	}
@@ -64,12 +64,12 @@ func resolveIssueRefForCommandWithOptions(
 		}
 	}
 	pid, projectName, err := resolveProjectIDAndNameForRef(
-		ctx, baseURL, start, parsed.ProjectName, includeArchivedProject,
+		a, start, parsed.ProjectName, includeArchivedProject,
 	)
 	if err != nil {
 		return nil, "", 0, resolvedIssueRef{}, err
 	}
-	return ctx, baseURL, pid, resolvedIssueRef{
+	return ctx, a.baseURL, pid, resolvedIssueRef{
 		RefForAPI:   parsed.RefForAPI,
 		ProjectName: projectName,
 	}, nil
@@ -81,17 +81,17 @@ func resolveIssueRefForCommandWithOptions(
 // The canonical name is used by destructive verbs to format the
 // X-Kata-Confirm header value ("DELETE <project>#<short_id>").
 func resolveProjectIDAndNameForRef(
-	ctx context.Context,
-	baseURL, startPath, refProjectName string,
+	a daemonAPI,
+	startPath, refProjectName string,
 	includeArchived bool,
 ) (int64, string, error) {
 	if strings.TrimSpace(refProjectName) == "" {
-		return resolveProjectIDAndName(ctx, baseURL, startPath)
+		return resolveProjectIDAndNameWithClient(a, startPath)
 	}
 	saved := flags.Project
 	flags.Project = refProjectName
 	defer func() { flags.Project = saved }()
-	projectID, projectName, err := resolveProjectIDAndName(ctx, baseURL, startPath)
+	projectID, projectName, err := resolveProjectIDAndNameWithClient(a, startPath)
 	if err == nil || !includeArchived {
 		return projectID, projectName, err
 	}
@@ -99,11 +99,7 @@ func resolveProjectIDAndNameForRef(
 	if !errors.As(err, &cliErr) || cliErr.Kind != kindNotFound {
 		return 0, "", err
 	}
-	client, err := httpClientFor(ctx, baseURL)
-	if err != nil {
-		return 0, "", err
-	}
-	project, err := resolveProjectSelectorIncludingArchived(ctx, client, baseURL, refProjectName)
+	project, err := resolveProjectSelectorIncludingArchived(a, refProjectName)
 	if err != nil {
 		return 0, "", err
 	}

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -563,6 +563,21 @@ func TestHealth_DoesNotAutoStartDaemon(t *testing.T) {
 		"hint must point the user at the right action")
 }
 
+func TestHealthCommandDoesNotAutoStartDaemon(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_SERVER", "")
+
+	cmd := newHealthCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.ExecuteContext(context.Background())
+
+	ce := requireCLIError(t, err, ExitDaemonUnavail)
+	assert.Equal(t, kindDaemonUnavail, ce.Kind)
+	assert.Contains(t, ce.Message, "no daemon running")
+}
+
 func TestHealthReportsLiveUnreachableDaemon(t *testing.T) {
 	resetFlags(t)
 	home := setupKataEnv(t)

--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -129,7 +129,8 @@ func newMCPServeCmd() *cobra.Command {
 				if startErr != nil {
 					return startErr
 				}
-				projectID, projectName, err = resolveProjectIDAndNameWithClient(ctx, httpClient, baseURL, start)
+				projectID, projectName, err = resolveProjectIDAndNameWithClient(
+					daemonAPI{ctx: ctx, client: httpClient, baseURL: baseURL}, start)
 				if err != nil && strings.TrimSpace(flags.Workspace) == "" && strings.TrimSpace(flags.Project) == "" {
 					err = fmt.Errorf("%w (run inside a kata workspace, or pass --project, --workspace, --projects, or --all-projects)", err)
 				}

--- a/cmd/kata/move.go
+++ b/cmd/kata/move.go
@@ -62,7 +62,8 @@ func runMove(cmd *cobra.Command, rawRef, targetProject string, dryRun bool) erro
 	if err != nil {
 		return err
 	}
-	target, err := resolveProjectSelector(ctx, client, baseURL, targetProject)
+	target, err := resolveProjectSelector(
+		daemonAPI{ctx: ctx, client: client, baseURL: baseURL}, targetProject)
 	if err != nil {
 		return err
 	}

--- a/cmd/kata/projects.go
+++ b/cmd/kata/projects.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -113,33 +112,17 @@ func projectsListCmd() *cobra.Command {
 		Short: "list known projects",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
-			if err != nil {
-				return err
-			}
-			client, err := httpClientFor(ctx, baseURL)
+			a, err := dialDaemon(cmd.Context())
 			if err != nil {
 				return err
 			}
 			mode := currentOutputMode()
-			path := baseURL + "/api/v1/projects"
+			path := "/api/v1/projects"
 			if mode == outputAgent {
 				path += "?include=stats"
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, path, nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if mode == outputJSON {
-				var buf bytes.Buffer
-				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
-					return err
-				}
-				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+			bs, emitted, err := a.passthrough(cmd, http.MethodGet, path, nil)
+			if err != nil || emitted {
 				return err
 			}
 			var b struct {
@@ -201,33 +184,18 @@ func projectsRenameCmd() *cobra.Command {
 
 			ctx := cmd.Context()
 			actor, _ := resolveActor(ctx, flags.As, nil)
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
+			project, err := resolveProjectSelector(a, args[0])
 			if err != nil {
 				return err
 			}
-			project, err := resolveProjectSelector(ctx, client, baseURL, args[0])
-			if err != nil {
-				return err
-			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPatch,
-				fmt.Sprintf("%s/api/v1/projects/%d", baseURL, project.ID),
+			bs, emitted, err := a.passthrough(cmd, http.MethodPatch,
+				fmt.Sprintf("/api/v1/projects/%d", project.ID),
 				map[string]string{"name": name, "actor": actor})
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if flags.JSON {
-				var buf bytes.Buffer
-				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
-					return err
-				}
-				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+			if err != nil || emitted {
 				return err
 			}
 			var b struct {
@@ -267,21 +235,17 @@ func projectsRewriteAuthorCmd() *cobra.Command {
 				return &cliError{Message: "--to is required", Kind: kindValidation, ExitCode: ExitValidation}
 			}
 			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
-				return err
-			}
-			project, err := resolveProjectArgFlagOrWorkspace(ctx, client, baseURL, args)
+			project, err := resolveProjectArgFlagOrWorkspace(a, args)
 			if err != nil {
 				return err
 			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-				fmt.Sprintf("%s/api/v1/projects/%d/actions/rewrite-author", baseURL, project.ID),
+			bs, err := a.do(http.MethodPost,
+				fmt.Sprintf("/api/v1/projects/%d/actions/rewrite-author", project.ID),
 				map[string]any{
 					"actor": actor,
 					"from":  from,
@@ -289,9 +253,6 @@ func projectsRewriteAuthorCmd() *cobra.Command {
 				})
 			if err != nil {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			var result db.RewriteAuthorIdentityResult
 			if err := json.Unmarshal(bs, &result); err != nil {
@@ -338,19 +299,15 @@ func projectsMergeCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			actor, _ := resolveActor(ctx, flags.As, nil)
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
+			source, err := resolveProjectSelector(a, args[0])
 			if err != nil {
 				return err
 			}
-			source, err := resolveProjectSelector(ctx, client, baseURL, args[0])
-			if err != nil {
-				return err
-			}
-			target, err := resolveProjectSelector(ctx, client, baseURL, args[1])
+			target, err := resolveProjectSelector(a, args[1])
 			if err != nil {
 				return err
 			}
@@ -365,13 +322,10 @@ func projectsMergeCmd() *cobra.Command {
 			if strings.TrimSpace(targetName) != "" {
 				body["target_name"] = strings.TrimSpace(targetName)
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-				fmt.Sprintf("%s/api/v1/projects/%d/merge", baseURL, target.ID), body)
+			bs, err := a.do(http.MethodPost,
+				fmt.Sprintf("/api/v1/projects/%d/merge", target.ID), body)
 			if err != nil {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			var b struct {
 				Source            projectRef             `json:"source"`
@@ -387,7 +341,7 @@ func projectsMergeCmd() *cobra.Command {
 			if err := repairMergedWorkspaceBinding(source, b.Target); err != nil {
 				return err
 			}
-			if flags.JSON {
+			if currentOutputMode() == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err
@@ -487,12 +441,7 @@ func projectsShowCmd() *cobra.Command {
 		Short: "show project details",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
-			if err != nil {
-				return err
-			}
-			client, err := httpClientFor(ctx, baseURL)
+			a, err := dialDaemon(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -501,25 +450,14 @@ func projectsShowCmd() *cobra.Command {
 				project.ID = id
 			} else {
 				var err error
-				project, err = resolveProjectSelector(ctx, client, baseURL, args[0])
+				project, err = resolveProjectSelector(a, args[0])
 				if err != nil {
 					return err
 				}
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodGet,
-				fmt.Sprintf("%s/api/v1/projects/%d", baseURL, project.ID), nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if flags.JSON {
-				var buf bytes.Buffer
-				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
-					return err
-				}
-				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+			bs, emitted, err := a.passthrough(cmd, http.MethodGet,
+				fmt.Sprintf("/api/v1/projects/%d", project.ID), nil)
+			if err != nil || emitted {
 				return err
 			}
 			var b struct {
@@ -548,12 +486,12 @@ func projectsShowCmd() *cobra.Command {
 	}
 }
 
-func resolveProjectSelector(ctx context.Context, client *http.Client, baseURL, selector string) (projectRef, error) {
+func resolveProjectSelector(a daemonAPI, selector string) (projectRef, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
 		return projectRef{}, &cliError{Message: "project selector must be non-empty", Kind: kindValidation, ExitCode: ExitValidation}
 	}
-	projects, err := loadProjectRefs(ctx, client, baseURL)
+	projects, err := loadProjectRefs(a)
 	if err != nil {
 		return projectRef{}, err
 	}
@@ -561,34 +499,32 @@ func resolveProjectSelector(ctx context.Context, client *http.Client, baseURL, s
 }
 
 func resolveProjectArgFlagOrWorkspace(
-	ctx context.Context,
-	client *http.Client,
-	baseURL string,
+	a daemonAPI,
 	args []string,
 ) (projectRef, error) {
 	if len(args) > 0 {
-		return resolveProjectSelector(ctx, client, baseURL, args[0])
+		return resolveProjectSelector(a, args[0])
 	}
 	if projectName := strings.TrimSpace(flags.Project); projectName != "" {
-		return resolveProjectSelector(ctx, client, baseURL, projectName)
+		return resolveProjectSelector(a, projectName)
 	}
 	start, err := resolveStartPath(flags.Workspace)
 	if err != nil {
 		return projectRef{}, err
 	}
-	id, name, err := resolveProjectIDAndNameWithClient(ctx, client, baseURL, start)
+	id, name, err := resolveProjectIDAndNameWithClient(a, start)
 	if err != nil {
 		return projectRef{}, err
 	}
 	return projectRef{ID: id, Name: name}, nil
 }
 
-func resolveProjectSelectorIncludingArchived(ctx context.Context, client *http.Client, baseURL, selector string) (projectRef, error) {
+func resolveProjectSelectorIncludingArchived(a daemonAPI, selector string) (projectRef, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
 		return projectRef{}, &cliError{Message: "project selector must be non-empty", Kind: kindValidation, ExitCode: ExitValidation}
 	}
-	projects, err := loadProjectRefsIncludingArchived(ctx, client, baseURL)
+	projects, err := loadProjectRefsIncludingArchived(a)
 	if err != nil {
 		return projectRef{}, err
 	}
@@ -618,25 +554,22 @@ func resolveProjectSelectorFromRefs(selector string, projects []projectRef) (pro
 	}
 }
 
-func loadProjectRefs(ctx context.Context, client *http.Client, baseURL string) ([]projectRef, error) {
-	return loadProjectRefsWithArchived(ctx, client, baseURL, false)
+func loadProjectRefs(a daemonAPI) ([]projectRef, error) {
+	return loadProjectRefsWithArchived(a, false)
 }
 
-func loadProjectRefsIncludingArchived(ctx context.Context, client *http.Client, baseURL string) ([]projectRef, error) {
-	return loadProjectRefsWithArchived(ctx, client, baseURL, true)
+func loadProjectRefsIncludingArchived(a daemonAPI) ([]projectRef, error) {
+	return loadProjectRefsWithArchived(a, true)
 }
 
-func loadProjectRefsWithArchived(ctx context.Context, client *http.Client, baseURL string, includeArchived bool) ([]projectRef, error) {
-	path := baseURL + "/api/v1/projects"
+func loadProjectRefsWithArchived(a daemonAPI, includeArchived bool) ([]projectRef, error) {
+	path := "/api/v1/projects"
 	if includeArchived {
 		path += "?include=archived"
 	}
-	status, bs, err := httpDoJSON(ctx, client, http.MethodGet, path, nil)
+	bs, err := a.do(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
-	}
-	if status >= 400 {
-		return nil, apiErrFromBody(status, bs)
 	}
 	var list struct {
 		Projects []projectRef `json:"projects"`
@@ -648,13 +581,10 @@ func loadProjectRefsWithArchived(ctx context.Context, client *http.Client, baseU
 		if list.Projects[i].DeletedAt != nil {
 			continue
 		}
-		status, detail, err := httpDoJSON(ctx, client, http.MethodGet,
-			fmt.Sprintf("%s/api/v1/projects/%d", baseURL, list.Projects[i].ID), nil)
+		detail, err := a.do(http.MethodGet,
+			fmt.Sprintf("/api/v1/projects/%d", list.Projects[i].ID), nil)
 		if err != nil {
 			return nil, err
-		}
-		if status >= 400 {
-			return nil, apiErrFromBody(status, detail)
 		}
 		var show struct {
 			Aliases []projectAliasRef `json:"aliases"`
@@ -761,37 +691,22 @@ func projectsRemoveCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
-				return err
-			}
-			project, err := resolveProjectSelector(ctx, client, baseURL, args[0])
+			project, err := resolveProjectSelector(a, args[0])
 			if err != nil {
 				return err
 			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
-			path := fmt.Sprintf("%s/api/v1/projects/%d?actor=%s",
-				baseURL, project.ID, url.QueryEscape(actor))
+			path := fmt.Sprintf("/api/v1/projects/%d?actor=%s",
+				project.ID, url.QueryEscape(actor))
 			if force {
 				path += "&force=true"
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodDelete, path, nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if flags.JSON {
-				var buf bytes.Buffer
-				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
-					return err
-				}
-				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+			_, emitted, err := a.passthrough(cmd, http.MethodDelete, path, nil)
+			if err != nil || emitted {
 				return err
 			}
 			if currentOutputMode() == outputAgent {
@@ -817,34 +732,19 @@ func projectsRestoreCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
-				return err
-			}
-			project, err := resolveProjectSelectorIncludingArchived(ctx, client, baseURL, args[0])
+			project, err := resolveProjectSelectorIncludingArchived(a, args[0])
 			if err != nil {
 				return err
 			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
-			path := fmt.Sprintf("%s/api/v1/projects/%d/restore?actor=%s",
-				baseURL, project.ID, url.QueryEscape(actor))
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost, path, nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if flags.JSON {
-				var buf bytes.Buffer
-				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
-					return err
-				}
-				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+			path := fmt.Sprintf("/api/v1/projects/%d/restore?actor=%s",
+				project.ID, url.QueryEscape(actor))
+			bs, emitted, err := a.passthrough(cmd, http.MethodPost, path, nil)
+			if err != nil || emitted {
 				return err
 			}
 			var b struct {
@@ -890,16 +790,12 @@ func projectsDetachCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
-			if err != nil {
-				return err
-			}
-			client, err := httpClientFor(ctx, baseURL)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
 			selector := strings.TrimSpace(args[0])
-			projects, err := loadProjectRefs(ctx, client, baseURL)
+			projects, err := loadProjectRefs(a)
 			if err != nil {
 				return err
 			}
@@ -912,24 +808,13 @@ func projectsDetachCmd() *cobra.Command {
 				}
 			}
 			actor, _ := resolveActor(ctx, flags.As, nil)
-			path := fmt.Sprintf("%s/api/v1/projects/%d/aliases/%d?actor=%s",
-				baseURL, projectID, aliasID, url.QueryEscape(actor))
+			path := fmt.Sprintf("/api/v1/projects/%d/aliases/%d?actor=%s",
+				projectID, aliasID, url.QueryEscape(actor))
 			if force {
 				path += "&force=true"
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodDelete, path, nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if flags.JSON {
-				var buf bytes.Buffer
-				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
-					return err
-				}
-				_, err := fmt.Fprint(cmd.OutOrStdout(), buf.String())
+			_, emitted, err := a.passthrough(cmd, http.MethodDelete, path, nil)
+			if err != nil || emitted {
 				return err
 			}
 			if currentOutputMode() == outputAgent {

--- a/cmd/kata/projects_purge.go
+++ b/cmd/kata/projects_purge.go
@@ -31,15 +31,11 @@ func projectsPurgeCmd() *cobra.Command {
 				}
 			}
 			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(ctx)
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
-				return err
-			}
-			project, err := resolveProjectSelectorIncludingArchived(ctx, client, baseURL, args[0])
+			project, err := resolveProjectSelectorIncludingArchived(a, args[0])
 			if err != nil {
 				return err
 			}
@@ -54,14 +50,11 @@ func projectsPurgeCmd() *cobra.Command {
 			if reason != "" {
 				body["reason"] = reason
 			}
-			postURL := fmt.Sprintf("%s/api/v1/projects/%d/actions/purge", baseURL, project.ID)
-			status, bs, err := httpDoJSONWithHeader(ctx, client, http.MethodPost, postURL,
+			bs, err := a.doWithHeaders(http.MethodPost,
+				fmt.Sprintf("/api/v1/projects/%d/actions/purge", project.ID),
 				map[string]string{"X-Kata-Confirm": confirm}, body)
 			if err != nil {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
 			}
 			return printProjectPurge(cmd, project.Name, bs)
 		},

--- a/cmd/kata/projects_test.go
+++ b/cmd/kata/projects_test.go
@@ -35,6 +35,46 @@ func TestProjects_ListJSONHasNoNextIssueNumber(t *testing.T) {
 	}
 }
 
+// TestProjectResolutionHelpersUseDaemonAPI pins the shared resolver seam to
+// one already-resolved daemon connection. A regression back to independently
+// supplied context/client/baseURL values could route the lookup through a
+// different credential or endpoint than the command that consumes it.
+func TestProjectResolutionHelpersUseDaemonAPI(t *testing.T) {
+	resetFlags(t)
+	flags.Project = "spoke-project"
+
+	deletedAt := "2026-08-25T00:00:00Z"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects" && r.URL.Query().Get("include") == "archived":
+			_, _ = w.Write([]byte(`{"projects":[{"id":17,"name":"archived-project","deleted_at":"` + deletedAt + `"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"projects":[{"id":7,"name":"spoke-project"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/7":
+			_, _ = w.Write([]byte(`{"aliases":[]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/resolve":
+			_, _ = w.Write([]byte(`{"project":{"id":7,"name":"spoke-project"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	a := daemonAPI{ctx: t.Context(), baseURL: srv.URL, client: srv.Client()}
+
+	active, err := resolveProjectSelector(a, "spoke-project")
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), active.ID)
+
+	archived, err := resolveProjectSelectorIncludingArchived(a, "archived-project")
+	require.NoError(t, err)
+	assert.Equal(t, int64(17), archived.ID)
+
+	id, name, err := resolveProjectIDAndNameWithClient(a, t.TempDir())
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), id)
+	assert.Equal(t, "spoke-project", name)
+}
+
 func TestProjects_ListAgentIncludesStats(t *testing.T) {
 	env := testenv.New(t)
 	ctx := context.Background()

--- a/cmd/kata/tokens.go
+++ b/cmd/kata/tokens.go
@@ -54,12 +54,7 @@ func tokensCreateCmd() *cobra.Command {
 			if actor == "" {
 				return &cliError{Message: "actor is required", Kind: kindUsage, ExitCode: ExitUsage}
 			}
-			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
-			if err != nil {
-				return err
-			}
-			client, err := httpClientFor(ctx, baseURL)
+			a, err := dialDaemon(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -67,15 +62,9 @@ func tokensCreateCmd() *cobra.Command {
 			if trimmed := strings.TrimSpace(name); trimmed != "" {
 				payload["name"] = trimmed
 			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost, baseURL+"/api/v1/tokens", payload)
-			if err != nil {
+			bs, emitted, err := a.passthrough(cmd, http.MethodPost, "/api/v1/tokens", payload)
+			if err != nil || emitted {
 				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if currentOutputMode() == outputJSON {
-				return emitJSON(cmd.OutOrStdout(), json.RawMessage(bs))
 			}
 			var out createTokenCLIResponse
 			if err := json.Unmarshal(bs, &out); err != nil {
@@ -95,24 +84,13 @@ func tokensListCmd() *cobra.Command {
 		Short: "list identity tokens",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(cmd.Context())
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
+			bs, emitted, err := a.passthrough(cmd, http.MethodGet, "/api/v1/tokens", nil)
+			if err != nil || emitted {
 				return err
-			}
-			status, bs, err := httpDoJSON(ctx, client, http.MethodGet, baseURL+"/api/v1/tokens", nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if currentOutputMode() == outputJSON {
-				return emitJSON(cmd.OutOrStdout(), json.RawMessage(bs))
 			}
 			var out listTokensCLIResponse
 			if err := json.Unmarshal(bs, &out); err != nil {
@@ -133,25 +111,14 @@ func tokensRevokeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ctx := cmd.Context()
-			baseURL, err := ensureDaemon(ctx)
+			a, err := dialDaemon(cmd.Context())
 			if err != nil {
 				return err
 			}
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
+			path := fmt.Sprintf("/api/v1/tokens/%d/actions/revoke", id)
+			bs, emitted, err := a.passthrough(cmd, http.MethodPost, path, nil)
+			if err != nil || emitted {
 				return err
-			}
-			url := fmt.Sprintf("%s/api/v1/tokens/%d/actions/revoke", baseURL, id)
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost, url, nil)
-			if err != nil {
-				return err
-			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if currentOutputMode() == outputJSON {
-				return emitJSON(cmd.OutOrStdout(), json.RawMessage(bs))
 			}
 			var out revokeTokenCLIResponse
 			if err := json.Unmarshal(bs, &out); err != nil {

--- a/docs/design/semantic-search.md
+++ b/docs/design/semantic-search.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-25
+---
+
 # Semantic search technical notes
 
 Status: implemented. This note captures the semantic search design
@@ -56,7 +60,7 @@ Credential handling follows the existing bearer-token trust model:
 - The embedding API key is attached only to requests whose origin exactly
   matches the configured `base_url` origin. The client reuses the
   origin-pinned transport machinery from `internal/config/bearer.go`
-  (`bearerTransport`, `CheckBearerTargetSafeURLWithTrust`): cross-origin
+  (`bearerTransport`, `BearerPolicy.CheckTargetURL`): cross-origin
   redirects are refused rather than followed, so a key configured for one
   origin can never leak to another.
 - Plaintext HTTP targets follow the same safety ladder as other bearer

--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-25
+---
+
 # Remote daemon
 
 A daemon can serve clients on other hosts over a private network. This is an
@@ -319,6 +323,19 @@ kata daemon start --foreground --listen 100.64.0.5:7777 --insecure-readonly
 This permits GET requests only. Mutations and the event stream still require
 authentication. Network ACLs, VPNs, or tailnet policy are the access boundary in
 this development mode.
+
+Clients of a plaintext private-network daemon must opt into the same trust the
+server does, even when no token is configured:
+
+```sh
+export KATA_SERVER=http://100.64.0.5:7777
+export KATA_TRUST_PRIVATE_NETWORK=1
+```
+
+kata validates the bearer target whenever it builds a client, so a plaintext
+non-loopback endpoint is refused up front rather than failing later as an opaque
+error. The opt-in states that the private network is the access boundary;
+without it, use HTTPS, a loopback address, or an SSH tunnel.
 
 `require_token_identity = true` cannot be combined with
 `--insecure-readonly`.

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -39,54 +39,30 @@ func authTokenEnvOverride() string {
 	return strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
 }
 
-// withBearer wraps base with bearer-token injection when token is
-// non-empty. When token is empty the base transport is returned
-// unchanged so the no-auth daemon deployments incur zero extra cost.
-// A nil base falls back to http.DefaultTransport — matching net/http's
-// own zero-value behavior when *http.Client.Transport is nil. origin
-// is the scheme://host the bearer is pinned to (see bearerTransport).
-func withBearer(base http.RoundTripper, token, origin string, trustPrivateNetwork bool) http.RoundTripper {
-	return config.BearerTransportWithTrust(base, token, origin, trustPrivateNetwork)
+// bearerPolicyFor builds the target-validation policy for a client.
+// allow_insecure is an explicit per-target operator opt-out and subsumes the
+// private-network trust axis, so the two are never both set.
+func bearerPolicyFor(trustPrivateNetwork, allowInsecure bool) config.BearerPolicy {
+	if allowInsecure {
+		return config.BearerPolicy{AllowInsecurePlaintext: true}
+	}
+	return config.BearerPolicy{TrustPrivateNetwork: trustPrivateNetwork}
 }
 
-// checkBearerTargetSafe refuses to attach a bearer token to a baseURL that
-// would put the token on the wire in cleartext, and returns the scheme://host
-// origin the bearer should be pinned to for subsequent requests. Thin wrapper
-// over checkBearerTargetSafeURL that accepts a string base URL — used at
-// client construction time to fail fast before any request is built.
-func checkBearerTargetSafe(baseURL string, trustPrivateNetwork bool) (string, error) {
-	return config.BearerOriginForBaseURLWithTrust(baseURL, trustPrivateNetwork)
-}
-
+// authBearerTransport wraps base with an origin-pinned bearer transport for
+// baseURL. The target is validated whether or not token is empty (decision
+// D2): an empty token against a safe target installs nothing, while an unsafe
+// target is an error either way.
 func authBearerTransport(
 	base http.RoundTripper,
 	token, baseURL string,
 	trustPrivateNetwork bool,
 	allowInsecure bool,
 ) (http.RoundTripper, error) {
-	if token == "" {
-		return base, nil
-	}
-	if allowInsecure {
-		origin, err := config.BearerOriginForBaseURLAllowInsecure(baseURL)
-		if err != nil {
-			return nil, err
-		}
-		return config.BearerTransportWithPolicy(base, token, origin,
-			config.BearerPolicy{AllowInsecurePlaintext: true}), nil
-	}
-	origin, err := checkBearerTargetSafe(baseURL, trustPrivateNetwork)
+	policy := bearerPolicyFor(trustPrivateNetwork, allowInsecure)
+	origin, err := policy.OriginForBaseURL(baseURL)
 	if err != nil {
 		return nil, err
 	}
-	return withBearer(base, token, origin, trustPrivateNetwork), nil
-}
-
-func explicitBearerTransport(
-	base http.RoundTripper,
-	token, baseURL string,
-	trustPrivateNetwork bool,
-	allowInsecure bool,
-) (http.RoundTripper, error) {
-	return authBearerTransport(base, token, baseURL, trustPrivateNetwork, allowInsecure)
+	return policy.Transport(base, token, origin), nil
 }

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/kata/internal/config"
 )
 
 func TestResolveAuthTokenEnvWins(t *testing.T) {
@@ -74,7 +76,7 @@ func TestBearerTransportInjectsHeader(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c := &http.Client{Transport: withBearer(http.DefaultTransport, "secret", srv.URL, false)}
+	c := &http.Client{Transport: (config.BearerPolicy{}).Transport(http.DefaultTransport, "secret", srv.URL)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
@@ -92,7 +94,7 @@ func TestBearerTransportNoTokenPassthrough(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	rt := withBearer(http.DefaultTransport, "", srv.URL, false)
+	rt := (config.BearerPolicy{}).Transport(http.DefaultTransport, "", srv.URL)
 	assert.Equal(t, http.DefaultTransport, rt,
 		"empty token must return the base transport unchanged")
 
@@ -114,7 +116,7 @@ func TestBearerTransportPreservesCallerHeader(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c := &http.Client{Transport: withBearer(http.DefaultTransport, "from-transport", srv.URL, false)}
+	c := &http.Client{Transport: (config.BearerPolicy{}).Transport(http.DefaultTransport, "from-transport", srv.URL)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer caller-supplied")
@@ -132,7 +134,7 @@ func TestBearerTransportDoesNotMutateRequest(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c := &http.Client{Transport: withBearer(http.DefaultTransport, "secret", srv.URL, false)}
+	c := &http.Client{Transport: (config.BearerPolicy{}).Transport(http.DefaultTransport, "secret", srv.URL)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
@@ -374,11 +376,11 @@ url = "::not-a-url::"
 url = "`+srv.URL+`"
 `), 0o600))
 
-	baseURL, ok, err := resolveRemote(context.Background(), workspace)
+	resolved, ok, err := ResolveRemoteDaemon(context.Background(), workspace)
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, srv.URL, baseURL)
-	c, err := NewHTTPClient(context.Background(), baseURL, Opts{WorkspaceStart: workspace})
+	require.Equal(t, srv.URL, resolved.BaseURL)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{})
 	require.NoError(t, err)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
@@ -416,7 +418,7 @@ url = "`+active.URL+`"
 token = "active-token"
 `))
 
-	c, err := NewHTTPClient(context.Background(), active.URL, Opts{})
+	c, err := NewHTTPClient(context.Background(), active.URL, Opts{DaemonName: "shared"})
 	require.NoError(t, err)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
@@ -543,6 +545,10 @@ func TestNewHTTPClientWithBearerAttachesExplicitToken(t *testing.T) {
 func TestNewHTTPClientUsesActiveDaemonTargetToken(t *testing.T) {
 	var got string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+			return
+		}
 		got = r.Header.Get("Authorization")
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -563,7 +569,9 @@ url = "`+srv.URL+`"
 token = "target-token"
 `))
 
-	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{})
+	resolved, err := EnsureResolvedInWorkspace(context.Background(), "")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{})
 	require.NoError(t, err)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
@@ -626,13 +634,54 @@ func TestNewHTTPClientForTargetRefusesPlaintextHostnameWithoutAllowInsecure(t *t
 	assert.Contains(t, err.Error(), "plaintext")
 }
 
+func TestNewHTTPClientForTargetEmptyTokenPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		auth    TargetAuth
+		wantErr bool
+	}{
+		{
+			name: "strict rejects plaintext hostname", baseURL: "http://daemon.internal:7373",
+			wantErr: true,
+		},
+		{
+			name: "strict rejects plaintext private IP", baseURL: "http://100.64.0.5:7373",
+			wantErr: true,
+		},
+		{name: "strict accepts loopback", baseURL: "http://127.0.0.1:7373"},
+		{name: "strict accepts https", baseURL: "https://daemon.example"},
+		{
+			name: "trust private network accepts private IP", baseURL: "http://100.64.0.5:7373",
+			auth: TargetAuth{TrustPrivateNetwork: true},
+		},
+		{
+			name: "allow insecure accepts plaintext hostname", baseURL: "http://daemon.internal:7373",
+			auth: TargetAuth{AllowInsecure: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewHTTPClientForTarget(context.Background(), tt.baseURL, tt.auth, Opts{})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, client)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, client)
+		})
+	}
+}
+
 func TestNewHTTPClientForTargetAllowInsecureStillRefusesCrossOrigin(t *testing.T) {
 	called := false
 	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		called = true
 		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
 	})
-	rt, err := explicitBearerTransport(base, "target-token", "http://100.64.0.5:7373", false, true)
+	rt, err := authBearerTransport(base, "target-token", "http://100.64.0.5:7373", false, true)
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		"http://100.64.0.6:7373/api/v1/ping", nil)
@@ -647,8 +696,19 @@ func TestNewHTTPClientForTargetAllowInsecureStillRefusesCrossOrigin(t *testing.T
 	assert.False(t, called, "cross-origin request must not reach the base transport")
 }
 
-func TestNewHTTPClientWithBearerEmptyTokenSkipsSafetyCheck(t *testing.T) {
-	c, err := NewHTTPClientWithBearer(context.Background(), "http://example.invalid:7373", "", Opts{})
+// TestNewHTTPClientWithBearerEmptyTokenChecksTarget pins decision D2: the
+// target is validated whether or not a token is present, so a plaintext
+// non-loopback endpoint is reported at construction rather than silently
+// producing a client that will fail later as an opaque 401.
+func TestNewHTTPClientWithBearerEmptyTokenChecksTarget(t *testing.T) {
+	_, err := NewHTTPClientWithBearer(context.Background(), "http://example.invalid:7373", "", Opts{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plaintext")
+}
+
+func TestNewHTTPClientWithBearerEmptyTokenAllowsSafeTarget(t *testing.T) {
+	c, err := NewHTTPClientWithBearer(context.Background(), "http://127.0.0.1:7373", "", Opts{})
 
 	require.NoError(t, err)
 	assert.NotNil(t, c)
@@ -659,6 +719,18 @@ func TestNewHTTPClientWithBearerRefusesPlaintextNonLoopback(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "plaintext")
+}
+
+func TestNewHTTPClientWithBearerHonorsConfiguredRemoteAllowInsecure(t *testing.T) {
+	const baseURL = "http://daemon.example:7373"
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_SERVER", baseURL)
+	t.Setenv("KATA_ALLOW_INSECURE", "1")
+
+	c, err := NewHTTPClientWithBearer(context.Background(), baseURL, "secret", Opts{})
+
+	require.NoError(t, err)
+	assert.NotNil(t, c)
 }
 
 func TestNewHTTPClientStreamingAttachesAuthHeader(t *testing.T) {
@@ -740,6 +812,7 @@ func TestNewHTTPClient_TrustPrivateNetworkRejectsPlaintextHostname(t *testing.T)
 }
 
 func TestNewHTTPClient_EnvRemoteAllowInsecureAllowsBearerOnPlaintextHostname(t *testing.T) {
+	stubProbe(t, true)
 	tmp := t.TempDir()
 	t.Setenv("KATA_HOME", tmp)
 	t.Setenv("KATA_AUTH_TOKEN", "secret")
@@ -747,11 +820,15 @@ func TestNewHTTPClient_EnvRemoteAllowInsecureAllowsBearerOnPlaintextHostname(t *
 	t.Setenv("KATA_SERVER", "http://tailscale-host:7777")
 	t.Setenv("KATA_ALLOW_INSECURE", "1")
 
-	_, err := NewHTTPClient(context.Background(), "http://tailscale-host:7777", Opts{})
+	resolved, ok, err := ResolveRemoteDaemon(context.Background(), "")
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, err = NewHTTPClientForResolved(context.Background(), resolved, Opts{})
 	require.NoError(t, err)
 }
 
 func TestNewHTTPClient_FileRemoteAllowInsecureAllowsBearerOnPlaintextHostname(t *testing.T) {
+	stubProbe(t, true)
 	tmp := t.TempDir()
 	t.Setenv("KATA_HOME", tmp)
 	t.Setenv("KATA_AUTH_TOKEN", "secret")
@@ -768,12 +845,15 @@ url = "http://tailscale-host:7777"
 allow_insecure = true
 `), 0o600))
 
-	_, err := NewHTTPClient(context.Background(), "http://tailscale-host:7777", Opts{})
+	resolved, ok, err := ResolveRemoteDaemon(context.Background(), dir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	_, err = NewHTTPClientForResolved(context.Background(), resolved, Opts{})
 	require.NoError(t, err)
 }
 
 // TestNewHTTPClient_AllowsBearerOnLoopback covers the safe-target arm of
-// checkBearerTargetSafe: 127.0.0.1 and [::1] keep the token in-host even
+// BearerPolicy: 127.0.0.1 and [::1] keep the token in-host even
 // over plaintext HTTP.
 func TestNewHTTPClient_AllowsBearerOnLoopback(t *testing.T) {
 	tmp := t.TempDir()
@@ -803,36 +883,66 @@ func TestNewHTTPClient_AllowsBearerOverHTTPS(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestCheckBearerTargetSafe_UnixBase verifies the UnixBase sentinel URL
+// TestBearerPolicyOriginForUnixBase verifies the UnixBase sentinel URL
 // passes the safety check directly. The previous test went through
-// NewHTTPClient, which can fail in unixClientFromRuntime before reaching
+// NewHTTPClient, which can fail while locating a Unix runtime before reaching
 // the bearer-attachment code path — so a regression in the UnixBase
-// branch of checkBearerTargetSafe would have been masked. Hitting the
-// helper directly makes the coverage unambiguous.
+// branch of BearerPolicy would have been masked. Hitting the policy directly
+// makes the coverage unambiguous.
 //
 // The returned origin is the scheme+host stripped of any path component —
 // path-bearing baseURLs must normalize to the same origin so the per-request
 // pin matches regardless of which API path triggered the check.
-func TestCheckBearerTargetSafe_UnixBase(t *testing.T) {
-	origin, err := checkBearerTargetSafe(UnixBase, false)
+func TestBearerPolicyOriginForUnixBase(t *testing.T) {
+	origin, err := (config.BearerPolicy{}).OriginForBaseURL(UnixBase)
 	require.NoError(t, err)
 	assert.Equal(t, UnixBase, origin)
 
-	origin, err = checkBearerTargetSafe(UnixBase+"/api/v1/ping", false)
+	origin, err = (config.BearerPolicy{}).OriginForBaseURL(UnixBase + "/api/v1/ping")
 	require.NoError(t, err)
 	assert.Equal(t, UnixBase, origin)
 }
 
-// TestNewHTTPClient_NoTokenSkipsSafetyCheck verifies the gate is
-// token-conditional: when KATA_AUTH_TOKEN is unset, even non-loopback
-// plaintext URLs are fine because no token will be attached.
-func TestNewHTTPClient_NoTokenSkipsSafetyCheck(t *testing.T) {
+// TestNewHTTPClient_NoTokenChecksTarget is the D2 counterpart for the global
+// auth path: an unset KATA_AUTH_TOKEN no longer waives the target check.
+func TestNewHTTPClient_NoTokenChecksTarget(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("KATA_HOME", tmp)
 	t.Setenv("KATA_AUTH_TOKEN", "")
 
 	_, err := NewHTTPClient(context.Background(), "http://example.invalid:7373", Opts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "plaintext")
+}
+
+// TestNewHTTPClient_NoTokenPrivateTargetNeedsTrustOptIn is the documented
+// unauthenticated private-network client flow. Without the opt-in the target
+// is refused; with it the client builds.
+func TestNewHTTPClient_NoTokenPrivateTargetNeedsTrustOptIn(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+
+	_, err := NewHTTPClient(context.Background(), "http://100.64.0.5:7777", Opts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KATA_TRUST_PRIVATE_NETWORK")
+
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+	c, err := NewHTTPClient(context.Background(), "http://100.64.0.5:7777", Opts{})
 	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
+// TestNewHTTPClient_NoTokenLoopbackAlwaysSafe pins that the local loopback
+// path — by far the most common no-token configuration — is unaffected by D2.
+func TestNewHTTPClient_NoTokenLoopbackAlwaysSafe(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("KATA_HOME", tmp)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+
+	c, err := NewHTTPClient(context.Background(), "http://127.0.0.1:7373", Opts{})
+	require.NoError(t, err)
+	assert.NotNil(t, c)
 }
 
 // TestBearerTransport_RefusesPlaintextNonLoopbackPerRequest pins the
@@ -841,7 +951,7 @@ func TestNewHTTPClient_NoTokenSkipsSafetyCheck(t *testing.T) {
 // pointed at a plaintext non-loopback URL must be refused before the
 // token reaches the wire.
 func TestBearerTransport_RefusesPlaintextNonLoopbackPerRequest(t *testing.T) {
-	rt := withBearer(http.DefaultTransport, "secret", "http://127.0.0.1:7373", false)
+	rt := (config.BearerPolicy{}).Transport(http.DefaultTransport, "secret", "http://127.0.0.1:7373")
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		"http://example.invalid:7373/api/v1/ping", nil)
 	require.NoError(t, err)
@@ -864,7 +974,9 @@ func TestBearerTransport_AllowsPlaintextNonLoopbackWhenTrustPrivateNetworkSet(t 
 			Request:    req,
 		}, nil
 	})
-	rt := withBearer(base, "secret", "http://100.64.0.5:7373", true)
+	rt := (config.BearerPolicy{TrustPrivateNetwork: true}).Transport(
+		base, "secret", "http://100.64.0.5:7373",
+	)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		"http://100.64.0.5:7373/api/v1/ping", nil)
 	require.NoError(t, err)
@@ -881,7 +993,9 @@ func TestBearerTransport_TrustPrivateNetworkStillRefusesCrossOrigin(t *testing.T
 		called = true
 		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
 	})
-	rt := withBearer(base, "secret", "http://100.64.0.5:7373", true)
+	rt := (config.BearerPolicy{TrustPrivateNetwork: true}).Transport(
+		base, "secret", "http://100.64.0.5:7373",
+	)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		"http://100.64.0.6:7373/api/v1/ping", nil)
 	require.NoError(t, err)
@@ -906,7 +1020,7 @@ func TestBearerTransport_BlocksTokenOnRedirectToPlaintextNonLoopback(t *testing.
 	}))
 	t.Cleanup(srv.Close)
 
-	c := &http.Client{Transport: withBearer(http.DefaultTransport, "secret", srv.URL, false)}
+	c := &http.Client{Transport: (config.BearerPolicy{}).Transport(http.DefaultTransport, "secret", srv.URL)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
@@ -923,7 +1037,7 @@ func TestBearerTransport_BlocksTokenOnRedirectToPlaintextNonLoopback(t *testing.
 // passes the HTTPS / loopback safety check on its own) must be refused
 // before the token reaches the wire.
 func TestBearerTransport_RefusesCrossOriginPerRequest(t *testing.T) {
-	rt := withBearer(http.DefaultTransport, "secret", "https://daemon.example", false)
+	rt := (config.BearerPolicy{}).Transport(http.DefaultTransport, "secret", "https://daemon.example")
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		"https://attacker.example/api/v1/ping", nil)
 	require.NoError(t, err)
@@ -940,7 +1054,7 @@ func TestBearerTransport_RefusesCrossOriginPerRequest(t *testing.T) {
 // TestBearerTransport_BlocksTokenOnCrossOriginHTTPSRedirect is the
 // regression test for the finding the HTTPS-only safety check missed:
 // the trusted daemon (or an attacker-influenced base URL) 302-redirects
-// to https://attacker.example. checkBearerTargetSafeURL accepts both
+// to https://attacker.example. BearerPolicy accepts both
 // hosts as "safe transport," so without origin pinning the redirected
 // request would carry Authorization: Bearer <token> to the attacker.
 // With origin pinning, the redirected RoundTrip refuses and never
@@ -952,7 +1066,7 @@ func TestBearerTransport_BlocksTokenOnCrossOriginHTTPSRedirect(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	base := srv.Client().Transport
-	c := &http.Client{Transport: withBearer(base, "secret", srv.URL, false)}
+	c := &http.Client{Transport: (config.BearerPolicy{}).Transport(base, "secret", srv.URL)}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"net"
 	"net/http"
 	"strings"
@@ -83,36 +84,79 @@ func (e *localDaemonUnreachableError) Is(target error) bool {
 	return target == ErrLocalDaemonUnreachable
 }
 
+// liveDaemon is one runtime record that answered /api/v1/ping: the record
+// itself, the URL callers should dial, the socket path for unix endpoints,
+// and the identity the daemon reported. It is the single definition of "a
+// daemon worth talking to" so discovery call sites can filter one scan.
+type liveDaemon struct {
+	Record     kitdaemon.RuntimeRecord
+	BaseURL    string
+	UnixSocket string
+	Info       PingInfo
+}
+
+// liveDaemons scans the namespace's runtime records lazily. A successful
+// result contains a live daemon; an error result preserves store, context, or
+// unreachable-endpoint failures for callers that must distinguish them from
+// an empty store. Laziness is load bearing: Discover runs on every CLI
+// invocation and must stop after the first live record.
+func liveDaemons(ctx context.Context, dataDir string) iter.Seq2[liveDaemon, error] {
+	return func(yield func(liveDaemon, error) bool) {
+		recs, err := (kitdaemon.RuntimeStore{Dir: dataDir}).List()
+		if err != nil {
+			yield(liveDaemon{}, err)
+			return
+		}
+		for _, r := range recs {
+			if !daemon.RuntimeProcessAlive(r) {
+				continue
+			}
+			ep := r.Endpoint()
+			address := ep.ConfigAddress()
+			url, info, probeErr := probeAddressWithError(ctx, address)
+			if probeErr != nil {
+				if err := ctx.Err(); err != nil {
+					yield(liveDaemon{}, err)
+					return
+				}
+				if !yield(liveDaemon{}, &localDaemonUnreachableError{
+					pid:     r.PID,
+					address: address,
+					cause:   probeErr,
+				}) {
+					return
+				}
+				continue
+			}
+			candidate := liveDaemon{Record: r, BaseURL: url, Info: info}
+			if ep.IsUnix() {
+				candidate.UnixSocket = ep.Address
+			}
+			if !yield(candidate, nil) {
+				return
+			}
+		}
+	}
+}
+
 // Discover scans the namespace's runtime files and returns the base URL of
 // the first daemon that passes /api/v1/ping. The bool is false when no live
 // runtime record exists. A live process whose endpoint cannot be reached
 // returns ErrLocalDaemonUnreachable so callers do not mistake a permission or
 // transport failure for an absent daemon.
 func Discover(ctx context.Context, dataDir string) (string, bool, error) {
-	recs, err := (kitdaemon.RuntimeStore{Dir: dataDir}).List()
-	if err != nil {
-		return "", false, err
-	}
 	var unreachable error
-	for _, r := range recs {
-		if !daemon.RuntimeProcessAlive(r) {
+	for candidate, err := range liveDaemons(ctx, dataDir) {
+		if err == nil {
+			return candidate.BaseURL, true, nil
+		}
+		if errors.Is(err, ErrLocalDaemonUnreachable) {
+			if unreachable == nil {
+				unreachable = err
+			}
 			continue
 		}
-		address := r.Endpoint().ConfigAddress()
-		url, _, probeErr := probeAddressWithError(ctx, address)
-		if probeErr == nil {
-			return url, true, nil
-		}
-		if err := ctx.Err(); err != nil {
-			return "", false, err
-		}
-		if unreachable == nil {
-			unreachable = &localDaemonUnreachableError{
-				pid:     r.PID,
-				address: address,
-				cause:   probeErr,
-			}
-		}
+		return "", false, err
 	}
 	return "", false, unreachable
 }
@@ -191,8 +235,15 @@ type Opts struct {
 	Timeout               time.Duration
 	ResponseHeaderTimeout time.Duration
 	AllowInsecure         bool
-	WorkspaceStart        string
-	DaemonName            string
+	// WorkspaceStart is retained for URL-only compatibility callers that have
+	// not yet migrated to ResolvedDaemon. It scopes the temporary active-daemon
+	// credential lookup and must not be used by resolved construction.
+	// Deprecated: resolve the daemon and call NewHTTPClientForResolved.
+	WorkspaceStart string
+	// DaemonName is retained for URL-only compatibility callers that discard a
+	// named daemon's provenance before client construction.
+	// Deprecated: resolve the daemon and call NewHTTPClientForResolved.
+	DaemonName string
 }
 
 // TargetAuth is explicit per-target bearer configuration. It is used by
@@ -205,18 +256,11 @@ type TargetAuth struct {
 	TrustPrivateNetwork bool
 }
 
-// NewHTTPClient returns an *http.Client whose transport matches baseURL —
-// unix-socket dialing when baseURL == UnixBase, plain TCP otherwise. Pair
-// with the URL returned by Discover/EnsureRunning. We re-scan and re-probe
-// runtime files for unix endpoints so a stale record listed before a live
-// one cannot redirect us to a dead socket.
-//
-// When KATA_AUTH_TOKEN or [auth].token in <KATA_HOME>/config.toml is set,
-// the returned client transparently attaches Authorization: Bearer <token>
-// to every outgoing request via a wrapping RoundTripper. This matches the
-// daemon's bearer-auth middleware so token-protected daemons stay usable
-// from the first-party CLI/TUI without callers having to plumb the header
-// through every request site.
+// NewHTTPClient returns an *http.Client for a URL-only compatibility caller.
+// DaemonName and WorkspaceStart temporarily recover catalog credentials for
+// callers that still discard source provenance. Callers that resolved their
+// daemon through this package should use NewHTTPClientForResolved, which
+// consumes the selected token and transport policy without re-reading config.
 func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client, error) {
 	if opts.DaemonName != "" {
 		target, err := namedDaemonTargetForBaseURL(opts.DaemonName, baseURL)
@@ -260,7 +304,8 @@ func NewHTTPClient(ctx context.Context, baseURL string, opts Opts) (*http.Client
 }
 
 // NewHTTPClientWithBearer returns an HTTP client bound to baseURL with an
-// explicit bearer token. Empty token preserves the plain no-auth client path.
+// explicit bearer token. Empty token preserves the plain no-auth transport,
+// but the target is still validated before the client is returned.
 // TrustPrivateNetwork is still resolved from config so private-network
 // federation callers honour the operator opt-in even when supplying their
 // own token.
@@ -279,7 +324,7 @@ func NewHTTPClientForTarget(ctx context.Context, baseURL string, auth TargetAuth
 	if err != nil {
 		return nil, err
 	}
-	rt, err := explicitBearerTransport(c.Transport, auth.Token, baseURL,
+	rt, err := authBearerTransport(c.Transport, auth.Token, baseURL,
 		auth.TrustPrivateNetwork, auth.AllowInsecure)
 	if err != nil {
 		return nil, err
@@ -288,13 +333,39 @@ func NewHTTPClientForTarget(ctx context.Context, baseURL string, auth TargetAuth
 	return c, nil
 }
 
+// NewHTTPClientForResolved constructs a client from an already-resolved
+// daemon. The endpoint, token, and target policy are consumed as supplied;
+// construction does not re-read remote configuration, catalog credentials,
+// or global authentication policy.
+func NewHTTPClientForResolved(ctx context.Context, d ResolvedDaemon, opts Opts) (*http.Client, error) {
+	if d.BaseURL == "" {
+		return nil, errors.New("resolved daemon has no base URL")
+	}
+	if d.UnixSocket != "" {
+		c := unixClient(d.UnixSocket, opts)
+		rt, err := authBearerTransport(c.Transport, d.Token, d.BaseURL,
+			d.TrustPrivateNetwork, d.AllowInsecure)
+		if err != nil {
+			return nil, err
+		}
+		c.Transport = rt
+		return c, nil
+	}
+	return NewHTTPClientForTarget(ctx, d.BaseURL, TargetAuth{
+		Token:               d.Token,
+		AllowInsecure:       d.AllowInsecure,
+		TrustPrivateNetwork: d.TrustPrivateNetwork,
+	}, opts)
+}
+
 func newHTTPClientWithAuth(ctx context.Context, baseURL string, auth config.AuthConfig, opts Opts) (*http.Client, error) {
 	c, err := newHTTPClientWithoutAuth(ctx, baseURL, opts)
 	if err != nil {
 		return nil, err
 	}
 	allowInsecure := opts.AllowInsecure || remoteAllowInsecureForBaseURL(baseURL, opts.WorkspaceStart)
-	rt, err := authBearerTransport(c.Transport, auth.Token, baseURL, auth.TrustPrivateNetwork, allowInsecure)
+	rt, err := authBearerTransport(c.Transport, auth.Token, baseURL,
+		auth.TrustPrivateNetwork, allowInsecure)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +377,23 @@ func newHTTPClientWithoutAuth(ctx context.Context, baseURL string, opts Opts) (*
 	if !strings.HasPrefix(baseURL, UnixBase) {
 		return tcpClient(opts)
 	}
-	return unixClientFromRuntime(ctx, opts)
+	ns, err := daemon.NewNamespace()
+	if err != nil {
+		return nil, err
+	}
+	for candidate, err := range liveDaemons(ctx, ns.DataDir) {
+		if err != nil {
+			if errors.Is(err, ErrLocalDaemonUnreachable) {
+				continue
+			}
+			return nil, err
+		}
+		if candidate.UnixSocket == "" {
+			continue
+		}
+		return unixClient(candidate.UnixSocket, opts), nil
+	}
+	return nil, errors.New("no unix-socket daemon found")
 }
 
 func tcpClient(opts Opts) (*http.Client, error) {
@@ -329,33 +416,11 @@ func tcpClient(opts Opts) (*http.Client, error) {
 	return c, nil
 }
 
-func unixClientFromRuntime(ctx context.Context, opts Opts) (*http.Client, error) {
-	ns, err := daemon.NewNamespace()
-	if err != nil {
-		return nil, err
+// unixClient builds a client whose transport dials the named socket.
+func unixClient(socket string, opts Opts) *http.Client {
+	t := UnixTransport(socket)
+	if opts.ResponseHeaderTimeout > 0 {
+		t.ResponseHeaderTimeout = opts.ResponseHeaderTimeout
 	}
-	recs, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).List()
-	if err != nil {
-		return nil, err
-	}
-	for _, r := range recs {
-		if !daemon.RuntimeProcessAlive(r) {
-			continue
-		}
-		ep := r.Endpoint()
-		if !ep.IsUnix() {
-			continue
-		}
-		path := ep.Address
-		probe := &http.Client{Transport: UnixTransport(path), Timeout: 1 * time.Second}
-		if !Ping(ctx, probe, UnixBase) {
-			continue
-		}
-		t := UnixTransport(path)
-		if opts.ResponseHeaderTimeout > 0 {
-			t.ResponseHeaderTimeout = opts.ResponseHeaderTimeout
-		}
-		return &http.Client{Transport: t, Timeout: opts.Timeout}, nil
-	}
-	return nil, errors.New("no unix-socket daemon found")
+	return &http.Client{Transport: t, Timeout: opts.Timeout}
 }

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -84,7 +84,7 @@ var (
 	startDetachedDaemonForEnsure = kitdaemon.StartDetached
 	stopRunningDaemonsForEnsure  = stopRunningDaemons
 	signalDaemonStopForEnsure    = daemon.SignalDaemonStop
-	discoverDaemonForAutoStart   = discoverTargetForEnsureWithError
+	discoverDaemonForAutoStart   = discoverForEnsure
 	checkDaemonStateForEnsure    = func(dataDir string) error {
 		return (kitdaemon.RuntimeStore{Dir: dataDir}).CheckWritable()
 	}
@@ -130,26 +130,23 @@ func EnsureRunningTargetInWorkspace(
 // outside the repo still picks up /repo/.kata.local.toml's [server]
 // override instead of falling through to local auto-start.
 func EnsureRunningInWorkspace(ctx context.Context, workspaceStart string) (string, error) {
-	target, err := ensureRunningTargetInWorkspace(ctx, workspaceStart)
-	return target.BaseURL, err
+	resolved, err := EnsureResolvedInWorkspace(ctx, workspaceStart)
+	return resolved.BaseURL, err
 }
 
 func ensureRunningTargetInWorkspace(ctx context.Context, workspaceStart string) (RunningDaemon, error) {
-	return runningTargetInWorkspace(ctx, workspaceStart, true)
+	resolved, err := EnsureResolvedInWorkspace(ctx, workspaceStart)
+	return resolved.Running(), err
 }
 
 // LocateRunningTargetInWorkspace selects and probes the same endpoint as
 // EnsureRunningTargetInWorkspace without resolving bearer credentials. Local
 // selections are still started when necessary.
 func LocateRunningTargetInWorkspace(ctx context.Context, workspaceStart string) (RunningDaemon, error) {
-	return runningTargetInWorkspace(ctx, workspaceStart, false)
-}
-
-func runningTargetInWorkspace(ctx context.Context, workspaceStart string, resolveCredentials bool) (RunningDaemon, error) {
 	if v, ok := ctx.Value(BaseURLKey{}).(string); ok && v != "" {
 		return remoteRunningDaemon(v, false), nil
 	}
-	if url, ok, err := resolveRemoteEndpoint(ctx, workspaceStart, resolveCredentials); err != nil {
+	if url, ok, err := resolveRemoteEndpoint(ctx, workspaceStart); err != nil {
 		return RunningDaemon{}, err
 	} else if ok {
 		return remoteRunningDaemon(url, true), nil
@@ -187,68 +184,69 @@ func ensureLocalRunningTarget(ctx context.Context) (RunningDaemon, error) {
 	if err != nil {
 		return RunningDaemon{}, err
 	}
-	target, compatible, ok, err := discoverTargetForEnsureWithError(ctx, ns.DataDir)
+	found, err := discoverForEnsure(ctx, ns.DataDir)
 	if err != nil {
 		return RunningDaemon{}, err
 	}
-	if ok {
-		if compatible {
-			return target, nil
-		}
+	switch found.Outcome {
+	case daemonScanCompatible:
+		return runningDaemonForLive(found.Daemon), nil
+	case daemonScanStale:
 		if err := stopRunningDaemonsForEnsure(ctx, ns.DataDir, ns.DBHash); err != nil {
 			return RunningDaemon{}, err
 		}
-		return startDaemonForEnsure(ctx, ns.DataDir)
 	}
 	return startDaemonForEnsure(ctx, ns.DataDir)
 }
 
-func discoverForEnsureWithError(ctx context.Context, dataDir string) (string, bool, bool, error) {
-	target, compatible, ok, err := discoverTargetForEnsureWithError(ctx, dataDir)
-	return target.BaseURL, compatible, ok, err
+// daemonScanOutcome is the three-case answer to whether a local daemon is
+// usable: none answered, one is version-compatible, or one is live but stale.
+// The previous (compatible, found) booleans also admitted the meaningless
+// compatible-but-not-found combination.
+type daemonScanOutcome int
+
+const (
+	daemonScanNone daemonScanOutcome = iota
+	daemonScanCompatible
+	daemonScanStale
+)
+
+// ensureDiscovery retains the exact runtime record behind a scan result so
+// callers can construct a RunningDaemon without re-deriving its endpoint.
+// Daemon is the zero value when Outcome is daemonScanNone.
+type ensureDiscovery struct {
+	Outcome daemonScanOutcome
+	Daemon  liveDaemon
 }
 
-func discoverTargetForEnsureWithError(ctx context.Context, dataDir string) (RunningDaemon, bool, bool, error) {
-	recs, err := (kitdaemon.RuntimeStore{Dir: dataDir}).List()
-	if err != nil {
-		return RunningDaemon{}, false, false, err
-	}
-	var staleTarget RunningDaemon
+func discoverForEnsure(ctx context.Context, dataDir string) (ensureDiscovery, error) {
+	var stale ensureDiscovery
 	var unreachable error
-	for _, r := range recs {
-		if !daemon.RuntimeProcessAlive(r) {
-			continue
-		}
-		address := r.Endpoint().ConfigAddress()
-		url, info, probeErr := probeAddressWithError(ctx, address)
-		if probeErr != nil {
-			if err := ctx.Err(); err != nil {
-				return RunningDaemon{}, false, false, err
-			}
-			if unreachable == nil {
-				unreachable = &localDaemonUnreachableError{
-					pid:     r.PID,
-					address: address,
-					cause:   probeErr,
+	for candidate, err := range liveDaemons(ctx, dataDir) {
+		if err != nil {
+			if errors.Is(err, ErrLocalDaemonUnreachable) {
+				if unreachable == nil {
+					unreachable = err
 				}
+				continue
 			}
-			continue
+			return ensureDiscovery{}, err
 		}
-		target := localRunningDaemon(url, address)
-		if daemonVersionCheckSkipped() || daemonVersionCompatible(info) {
-			return target, true, true, nil
+		if daemonVersionCheckSkipped() || daemonVersionCompatible(candidate.Info) {
+			return ensureDiscovery{Outcome: daemonScanCompatible, Daemon: candidate}, nil
 		}
-		if staleTarget.BaseURL == "" {
-			staleTarget = target
+		if stale.Outcome == daemonScanNone {
+			stale = ensureDiscovery{Outcome: daemonScanStale, Daemon: candidate}
 		}
 	}
 	if unreachable != nil {
-		return RunningDaemon{}, false, false, unreachable
+		return ensureDiscovery{}, unreachable
 	}
-	if staleTarget.BaseURL != "" {
-		return staleTarget, false, true, nil
-	}
-	return RunningDaemon{}, false, false, nil
+	return stale, nil
+}
+
+func runningDaemonForLive(candidate liveDaemon) RunningDaemon {
+	return localRunningDaemon(candidate.BaseURL, candidate.Record.Endpoint().ConfigAddress())
 }
 
 func daemonVersionCheckSkipped() bool {
@@ -260,25 +258,23 @@ func daemonVersionCompatible(info PingInfo) bool {
 }
 
 func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
-	recs, err := (kitdaemon.RuntimeStore{Dir: dataDir}).List()
-	if err != nil {
-		return err
-	}
 	signaled := false
-	for _, r := range recs {
-		if !daemon.RuntimeProcessAlive(r) {
+	for candidate, err := range liveDaemons(ctx, dataDir) {
+		if err != nil {
+			if errors.Is(err, ErrLocalDaemonUnreachable) {
+				continue
+			}
+			return err
+		}
+		if candidate.Info.Service != daemonServiceName || daemonVersionCompatible(candidate.Info) {
 			continue
 		}
-		address := r.Endpoint().ConfigAddress()
-		_, info, ok := probeAddress(ctx, address)
-		if !ok || info.Service != daemonServiceName || daemonVersionCompatible(info) {
-			continue
-		}
-		if info.PID == 0 || info.PID != r.PID {
+		address := candidate.Record.Endpoint().ConfigAddress()
+		if candidate.Info.PID == 0 || candidate.Info.PID != candidate.Record.PID {
 			return fmt.Errorf("daemon at %s is running but its PID could not be verified; stop it manually", address)
 		}
-		if err := signalDaemonStopForEnsure(r, dbhash); err != nil {
-			return fmt.Errorf("stop old daemon pid %d: %w", r.PID, err)
+		if err := signalDaemonStopForEnsure(candidate.Record, dbhash); err != nil {
+			return fmt.Errorf("stop old daemon pid %d: %w", candidate.Record.PID, err)
 		}
 		signaled = true
 	}
@@ -288,11 +284,11 @@ func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
 
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		_, _, ok, err := discoverForEnsureWithError(ctx, dataDir)
+		found, err := discoverForEnsure(ctx, dataDir)
 		if err != nil {
 			return err
 		}
-		if !ok {
+		if found.Outcome == daemonScanNone {
 			return nil
 		}
 		select {
@@ -338,15 +334,15 @@ func autoStart(ctx context.Context, dataDir string) (RunningDaemon, error) {
 	deadline := time.Now().Add(daemonStartupWait)
 	var unreachable error
 	for time.Now().Before(deadline) {
-		target, compatible, ok, err := discoverDaemonForAutoStart(ctx, dataDir)
+		found, err := discoverDaemonForAutoStart(ctx, dataDir)
 		if err != nil && !errors.Is(err, ErrLocalDaemonUnreachable) {
 			return RunningDaemon{}, err
 		}
 		if errors.Is(err, ErrLocalDaemonUnreachable) {
 			unreachable = err
 		}
-		if ok && compatible {
-			return target, nil
+		if found.Outcome == daemonScanCompatible {
+			return runningDaemonForLive(found.Daemon), nil
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -131,6 +134,82 @@ func TestEnsureRunningTargetRetainsSelectedLocalEndpoint(t *testing.T) {
 	assert.Equal(t, "http://"+addr, target.BaseURL)
 }
 
+func TestDiscoverForEnsureThreeOutcomes(t *testing.T) {
+	tests := []struct {
+		name        string
+		pingPayload map[string]any
+		want        daemonScanOutcome
+	}{
+		{name: "no live record", want: daemonScanNone},
+		{
+			name: "live and compatible",
+			pingPayload: map[string]any{
+				"ok": true, "service": "kata", "version": "test-version", "pid": os.Getpid(),
+			},
+			want: daemonScanCompatible,
+		},
+		{
+			name: "live but stale build",
+			pingPayload: map[string]any{
+				"ok": true, "service": "kata", "version": "old-version", "pid": os.Getpid(),
+			},
+			want: daemonScanStale,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
+			tmp := setupKataEnv(t)
+			origVersion := currentVersionForEnsure
+			currentVersionForEnsure = func() string { return "test-version" }
+			t.Cleanup(func() { currentVersionForEnsure = origVersion })
+
+			wantURL := ""
+			wantAddress := ""
+			if tt.pingPayload != nil {
+				wantURL, wantAddress = startMockDaemonPing(t, tt.pingPayload)
+				require.NoError(t, writeRuntimeRecord(t, tmp, wantAddress))
+			}
+			ns, err := daemon.NewNamespace()
+			require.NoError(t, err)
+
+			got, err := discoverForEnsure(context.Background(), ns.DataDir)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.Outcome)
+			if tt.want == daemonScanNone {
+				assert.Empty(t, got.Daemon.BaseURL)
+				return
+			}
+			assert.Equal(t, wantURL, got.Daemon.BaseURL)
+			assert.Equal(t, wantAddress, got.Daemon.Record.Endpoint().ConfigAddress())
+			assert.Equal(t, os.Getpid(), got.Daemon.Record.PID)
+		})
+	}
+}
+
+func TestDiscoverForEnsurePreservesScanErrors(t *testing.T) {
+	t.Run("runtime store", func(t *testing.T) {
+		_, err := discoverForEnsure(t.Context(), "relative-data-dir")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be absolute")
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		tmp := setupKataEnv(t)
+		require.NoError(t, writeRuntimeRecord(t, tmp, "unix://"+filepath.Join(tmp, "missing.sock")))
+		ns, err := daemon.NewNamespace()
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_, err = discoverForEnsure(ctx, ns.DataDir)
+
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
 func TestDiscoverWebRuntime(t *testing.T) {
 	record := kitdaemon.RuntimeRecord{
 		PID: 4242,
@@ -231,11 +310,11 @@ func TestAutoStartAllowsDaemonStartupBeyondFiveSeconds(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		startedAt := time.Now()
-		discoverDaemonForAutoStart = func(context.Context, string) (RunningDaemon, bool, bool, error) {
+		discoverDaemonForAutoStart = func(context.Context, string) (ensureDiscovery, error) {
 			if time.Since(startedAt) < 6*time.Second {
-				return RunningDaemon{}, false, false, nil
+				return ensureDiscovery{}, nil
 			}
-			return remoteRunningDaemon("http://127.0.0.1:27123", false), true, true, nil
+			return compatibleEnsureDiscovery("127.0.0.1:27123"), nil
 		}
 
 		target, err := autoStart(t.Context(), dataDir)
@@ -259,11 +338,11 @@ func TestAutoStartWaitsForUnreachableSpawnedDaemonToBecomeReady(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		startedAt := time.Now()
-		discoverDaemonForAutoStart = func(context.Context, string) (RunningDaemon, bool, bool, error) {
+		discoverDaemonForAutoStart = func(context.Context, string) (ensureDiscovery, error) {
 			if time.Since(startedAt) < 6*time.Second {
-				return RunningDaemon{}, false, false, fmt.Errorf("%w: listener not ready", ErrLocalDaemonUnreachable)
+				return ensureDiscovery{}, fmt.Errorf("%w: listener not ready", ErrLocalDaemonUnreachable)
 			}
-			return remoteRunningDaemon("http://127.0.0.1:27123", false), true, true, nil
+			return compatibleEnsureDiscovery("127.0.0.1:27123"), nil
 		}
 
 		target, err := autoStart(t.Context(), dataDir)
@@ -287,8 +366,8 @@ func TestAutoStartReportsPersistentUnreachableDaemonAfterReadinessDeadline(t *te
 
 	synctest.Test(t, func(t *testing.T) {
 		probeErr := fmt.Errorf("%w: daemon pid 123 at unix:///tmp/kata.sock", ErrLocalDaemonUnreachable)
-		discoverDaemonForAutoStart = func(context.Context, string) (RunningDaemon, bool, bool, error) {
-			return RunningDaemon{}, false, false, probeErr
+		discoverDaemonForAutoStart = func(context.Context, string) (ensureDiscovery, error) {
+			return ensureDiscovery{}, probeErr
 		}
 
 		_, err := autoStart(t.Context(), dataDir)
@@ -314,6 +393,103 @@ func TestStopRunningDaemonsDoesNotSignalUnverifiedRuntimePID(t *testing.T) {
 		t.Fatalf("unverified runtime PID was signaled; process exited with %v", err)
 	case <-time.After(200 * time.Millisecond):
 	}
+}
+
+func TestNewHTTPClientWithoutAuthSkipsDeadRuntimeRecords(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are unsupported on Windows")
+	}
+	tmp := setupKataEnv(t)
+	socket := filepath.Join(t.TempDir(), "kata.sock")
+	ln, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v1/ping" {
+				http.NotFound(w, r)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "service": "kata"})
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// A dead PID pointing at a socket path that does not exist, plus the
+	// live record. Construction must reach the live one.
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, deadPID(t), "unix:///nonexistent/kata.sock"))
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), "unix://"+socket))
+
+	c, err := newHTTPClientWithoutAuth(context.Background(), UnixBase, Opts{Timeout: 2 * time.Second})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, UnixBase+"/api/v1/ping", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestNewHTTPClientWithoutAuthSkipsLiveTCPRuntimeBeforeUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are unsupported on Windows")
+	}
+	tmp := setupKataEnv(t)
+	_, tcpAddress := startMockDaemonPing(t, map[string]any{
+		"ok": true, "service": "kata", "version": currentVersionForEnsure(),
+	})
+	tcpProcess, _ := startLongLivedTestProcess(t)
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, tcpProcess.Process.Pid, tcpAddress))
+
+	socket := filepath.Join(t.TempDir(), "kata.sock")
+	ln, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v1/ping":
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"ok": true, "service": "kata", "version": currentVersionForEnsure(),
+				})
+			case "/ready":
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.NotFound(w, r)
+			}
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), "unix://"+socket))
+
+	c, err := newHTTPClientWithoutAuth(t.Context(), UnixBase, Opts{Timeout: 2 * time.Second})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, UnixBase+"/ready", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// deadPID returns a PID that is not alive: a child process that has already
+// been reaped.
+func deadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestEnsureSleepHelperProcess", "--") //nolint:gosec // test helper starts this test binary
+	cmd.Env = append(os.Environ(), "KATA_ENSURE_SLEEP_HELPER=1")
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	require.NoError(t, stdin.Close())
+	_ = cmd.Wait()
+	return pid
 }
 
 func startLongLivedTestProcess(t *testing.T) (*exec.Cmd, <-chan error) {
@@ -512,6 +688,49 @@ func TestDiscoverIgnoresRuntimeRecordWhosePIDWasReused(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestDiscoverStopsProbingAfterFirstLiveDaemon(t *testing.T) {
+	tmp := setupKataEnv(t)
+
+	var firstHits, secondHits atomic.Int32
+	_, addr1 := startCountingPing(t, &firstHits)
+	_, addr2 := startCountingPing(t, &secondHits)
+
+	// Two distinct alive PIDs: this process and a long-lived helper.
+	helper, _ := startLongLivedTestProcess(t)
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), addr1))
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, helper.Process.Pid, addr2))
+
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+
+	url, ok, err := Discover(context.Background(), ns.DataDir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Contains(t, []string{"http://" + addr1, "http://" + addr2}, url)
+
+	total := firstHits.Load() + secondHits.Load()
+	assert.Equal(t, int32(1), total,
+		"Discover must stop probing after the first live record; an eager scan probes both")
+}
+
+// startCountingPing is startMockDaemonPing with a hit counter, for asserting
+// that a scan short-circuits rather than probing every record.
+func startCountingPing(t *testing.T, hits *atomic.Int32) (url, addr string) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ping" {
+			http.NotFound(w, r)
+			return
+		}
+		hits.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true, "service": "kata", "version": "test-version", "pid": os.Getpid(),
+		})
+	}))
+	t.Cleanup(server.Close)
+	return server.URL, strings.TrimPrefix(server.URL, "http://")
+}
+
 func mismatchedProcessIdentity(t *testing.T, identity kitdaemon.ProcessIdentity) kitdaemon.ProcessIdentity {
 	t.Helper()
 	encoded := string(identity)
@@ -584,6 +803,16 @@ func startMockDaemonPing(t *testing.T, payload map[string]any) (url, addr string
 	}))
 	t.Cleanup(server.Close)
 	return server.URL, strings.TrimPrefix(server.URL, "http://")
+}
+
+func compatibleEnsureDiscovery(address string) ensureDiscovery {
+	return ensureDiscovery{
+		Outcome: daemonScanCompatible,
+		Daemon: liveDaemon{
+			BaseURL: "http://" + address,
+			Record:  kitdaemon.RuntimeRecord{Address: address},
+		},
+	}
 }
 
 func writeRuntimeRecord(t *testing.T, home, addr string) error {

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -50,14 +50,14 @@ type namedDaemonTarget struct {
 	BaseURL       string
 	Token         string
 	AllowInsecure bool
+	Running       RunningDaemon
 }
 
-// ResolveRemote is the exported view of resolveRemote so callers
-// outside client (e.g. cmd/kata health) can honor the same
-// KATA_SERVER / .kata.local.toml / active_daemon resolution rules without
-// auto-starting a local daemon.
+// ResolveRemote selects and probes configured remote sources without
+// resolving their credentials or auto-starting a local daemon. Callers that
+// need credentials and provenance use ResolveRemoteDaemon.
 func ResolveRemote(ctx context.Context, workspaceStart string) (string, bool, error) {
-	return resolveRemote(ctx, workspaceStart)
+	return resolveRemoteEndpoint(ctx, workspaceStart)
 }
 
 // DiscoverNamed returns the base URL for a named daemon catalog entry without
@@ -76,11 +76,11 @@ func DiscoverNamed(ctx context.Context, name string) (string, bool, error) {
 // per-invocation selection and therefore ignores KATA_SERVER, .kata.local.toml,
 // and active_daemon.
 func EnsureNamedRunning(ctx context.Context, name string) (string, error) {
-	target, err := resolveNamedDaemonTarget(ctx, name)
+	resolved, err := EnsureResolvedNamed(ctx, name)
 	if err != nil {
 		return "", err
 	}
-	return target.BaseURL, nil
+	return resolved.BaseURL, nil
 }
 
 // LocateNamedRunningTarget ensures a named local daemon is running or probes a
@@ -146,6 +146,12 @@ func NormalizeRemoteBaseURL(v string, allowInsecure bool) (string, error) {
 
 // RemoteAllowInsecureForBaseURL reports whether the configured remote source
 // for workspaceStart explicitly opted baseURL into plaintext HTTP.
+//
+// Deprecated: string-matching a base URL cannot distinguish two sources that
+// normalize to the same origin. Resolve through EnsureResolvedInWorkspace and
+// read ResolvedDaemon.AllowInsecure instead. Retained while compatibility CLI
+// lifecycle and federation callers still construct clients from base URLs
+// alone.
 func RemoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 	return remoteAllowInsecureForBaseURL(baseURL, workspaceStart)
 }
@@ -169,66 +175,127 @@ func RemoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 // CWD; otherwise running from outside the repo with `--workspace`
 // would silently miss the workspace's local override.
 func resolveRemote(ctx context.Context, workspaceStart string) (string, bool, error) {
-	return resolveRemoteEndpoint(ctx, workspaceStart, true)
+	return resolveRemoteEndpoint(ctx, workspaceStart)
 }
 
-func resolveRemoteEndpoint(ctx context.Context, workspaceStart string, resolveCredentials bool) (string, bool, error) {
-	if v := os.Getenv(remoteServerEnvVar); v != "" {
-		u, err := normalizeRemoteURL(v, envAllowInsecure())
+func resolveRemoteDaemon(ctx context.Context, workspaceStart string) (ResolvedDaemon, bool, error) {
+	return resolveRemoteSelection(ctx, workspaceStart, remoteWithCredentials)
+}
+
+type remoteResolutionMode int
+
+const (
+	remoteEndpointOnly remoteResolutionMode = iota
+	remoteWithCredentials
+)
+
+func resolveRemoteSelection(
+	ctx context.Context, workspaceStart string, mode remoteResolutionMode,
+) (ResolvedDaemon, bool, error) {
+	if value := os.Getenv(remoteServerEnvVar); value != "" {
+		allowInsecure := envAllowInsecure()
+		baseURL, err := normalizeRemoteURL(value, allowInsecure)
 		if err != nil {
-			return "", false, fmt.Errorf("KATA_SERVER %q: %w", remoteURLForError(v), err)
+			return ResolvedDaemon{}, false,
+				fmt.Errorf("KATA_SERVER %q: %w", remoteURLForError(value), err)
 		}
-		if !probeRemote(ctx, u) {
-			return "", false, fmt.Errorf("%w: %s (KATA_SERVER)", ErrRemoteUnavailable, u)
+		if !probeRemote(ctx, baseURL) {
+			return ResolvedDaemon{}, false,
+				fmt.Errorf("%w: %s (KATA_SERVER)", ErrRemoteUnavailable, baseURL)
 		}
-		return u, true, nil
+		resolved := resolvedForRunning(
+			DaemonSourceServerEnv, "", remoteRunningDaemon(baseURL, true),
+		)
+		resolved.AllowInsecure = allowInsecure
+		if mode == remoteWithCredentials {
+			resolved = resolved.withGlobalAuth()
+		}
+		return resolved, true, nil
 	}
+
 	root, path, ok, err := findLocalConfig(workspaceStart)
 	if err != nil {
-		return "", false, err
+		return ResolvedDaemon{}, false, err
 	}
 	if !ok {
-		return resolveActiveRemote(ctx, resolveCredentials)
+		return resolveActiveRemoteSelection(ctx, mode)
 	}
 	cfg, err := config.ReadLocalConfig(root)
 	if err != nil {
 		if errors.Is(err, config.ErrLocalConfigMissing) {
-			return "", false, nil
+			return ResolvedDaemon{}, false, nil
 		}
-		return "", false, fmt.Errorf("read %s: %w", path, err)
+		return ResolvedDaemon{}, false, fmt.Errorf("read %s: %w", path, err)
 	}
 	if cfg.Server.URL == "" {
-		return resolveActiveRemote(ctx, resolveCredentials)
+		return resolveActiveRemoteSelection(ctx, mode)
 	}
-	u, err := normalizeRemoteURL(cfg.Server.URL, cfg.Server.AllowInsecure)
+	baseURL, err := normalizeRemoteURL(cfg.Server.URL, cfg.Server.AllowInsecure)
 	if err != nil {
-		return "", false, fmt.Errorf("%s server.url %q: %w", path, remoteURLForError(cfg.Server.URL), err)
+		return ResolvedDaemon{}, false,
+			fmt.Errorf("%s server.url %q: %w", path, remoteURLForError(cfg.Server.URL), err)
 	}
-	if !probeRemote(ctx, u) {
-		return "", false, fmt.Errorf("%w: %s (%s)", ErrRemoteUnavailable, u, path)
+	if !probeRemote(ctx, baseURL) {
+		return ResolvedDaemon{}, false,
+			fmt.Errorf("%w: %s (%s)", ErrRemoteUnavailable, baseURL, path)
 	}
-	return u, true, nil
+	resolved := resolvedForRunning(
+		DaemonSourceLocalConfig, "", remoteRunningDaemon(baseURL, true),
+	)
+	resolved.AllowInsecure = cfg.Server.AllowInsecure
+	if mode == remoteWithCredentials {
+		resolved = resolved.withGlobalAuth()
+	}
+	return resolved, true, nil
 }
 
-func resolveActiveRemote(ctx context.Context, resolveCredentials bool) (string, bool, error) {
+func resolveActiveRemoteSelection(
+	ctx context.Context, mode remoteResolutionMode,
+) (ResolvedDaemon, bool, error) {
 	target, ok, err := activeRemoteFromConfig()
 	if err != nil || !ok {
-		return "", false, err
+		return ResolvedDaemon{}, false, err
 	}
-	if resolveCredentials && !globalAuthTokenOverrideSet() {
-		_, err = resolveActiveRemoteTargetToken(target)
-	}
-	if err != nil {
-		return "", false, err
+	token := target.Token
+	if mode == remoteWithCredentials && !globalAuthTokenOverrideSet() {
+		token, err = resolveActiveRemoteTargetToken(target)
+		if err != nil {
+			return ResolvedDaemon{}, false, err
+		}
 	}
 	if !probeRemote(ctx, target.BaseURL) {
-		return "", false, fmt.Errorf("%w: %s (%s active_daemon %q)",
+		return ResolvedDaemon{}, false, fmt.Errorf("%w: %s (%s active_daemon %q)",
 			ErrRemoteUnavailable, target.BaseURL, daemonConfigSource(), target.Name)
 	}
-	return target.BaseURL, true, nil
+	resolved := resolvedForRunning(
+		DaemonSourceActiveDaemon, target.Name, remoteRunningDaemon(target.BaseURL, true),
+	)
+	resolved.AllowInsecure = target.AllowInsecure
+	if mode == remoteWithCredentials {
+		resolved = resolved.withRemoteTargetAuth(token, target.AllowInsecure)
+	}
+	return resolved, true, nil
+}
+
+func resolveRemoteEndpoint(ctx context.Context, workspaceStart string) (string, bool, error) {
+	resolved, ok, err := resolveRemoteSelection(ctx, workspaceStart, remoteEndpointOnly)
+	return resolved.BaseURL, ok, err
 }
 
 func discoverNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTarget, bool, error) {
+	return buildNamedDaemonTarget(ctx, name, namedDiscoverOnly)
+}
+
+type namedResolutionMode int
+
+const (
+	namedDiscoverOnly namedResolutionMode = iota
+	namedEnsureRunning
+)
+
+func buildNamedDaemonTarget(
+	ctx context.Context, name string, mode namedResolutionMode,
+) (namedDaemonTarget, bool, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return namedDaemonTarget{}, false, fmt.Errorf("%w: empty name", ErrNamedDaemonNotFound)
@@ -242,21 +309,30 @@ func discoverNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTar
 			continue
 		}
 		if d.Local {
-			ns, err := daemon.NewNamespace()
+			var running RunningDaemon
+			if mode == namedEnsureRunning {
+				running, err = EnsureLocalRunningTarget(ctx)
+			} else {
+				var ns *daemon.Namespace
+				ns, err = daemon.NewNamespace()
+				if err == nil {
+					var ok bool
+					var resolved ResolvedDaemon
+					resolved, ok, err = DiscoverResolved(ctx, ns.DataDir)
+					if err == nil && !ok {
+						return namedDaemonTarget{}, false, nil
+					}
+					running = resolved.Running()
+				}
+			}
 			if err != nil {
 				return namedDaemonTarget{}, false, err
 			}
-			baseURL, ok, err := Discover(ctx, ns.DataDir)
+			target, err := namedDaemonTargetFromCatalog(d, running.BaseURL, true)
 			if err != nil {
 				return namedDaemonTarget{}, false, err
 			}
-			if !ok {
-				return namedDaemonTarget{}, false, nil
-			}
-			target, err := namedDaemonTargetFromCatalog(d, baseURL, true)
-			if err != nil {
-				return namedDaemonTarget{}, false, err
-			}
+			target.Running = running
 			return target, true, nil
 		}
 		target, err := namedDaemonTargetFromCatalog(d, "", false)
@@ -272,39 +348,22 @@ func discoverNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTar
 	return namedDaemonTarget{}, false, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, name)
 }
 
-func resolveNamedDaemonTarget(ctx context.Context, name string) (namedDaemonTarget, error) {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return namedDaemonTarget{}, fmt.Errorf("%w: empty name", ErrNamedDaemonNotFound)
-	}
-	cfg, err := config.ReadDaemonConfig()
+func resolveNamedDaemon(ctx context.Context, name string) (ResolvedDaemon, error) {
+	target, ok, err := buildNamedDaemonTarget(ctx, name, namedEnsureRunning)
 	if err != nil {
-		return namedDaemonTarget{}, err
+		return ResolvedDaemon{}, err
 	}
-	for _, d := range cfg.Daemons {
-		if d.Name != name {
-			continue
-		}
-		if d.Local {
-			baseURL, err := EnsureLocalRunning(ctx)
-			if err != nil {
-				return namedDaemonTarget{}, err
-			}
-			return namedDaemonTargetFromCatalog(d, baseURL, true)
-		}
-		target, err := namedDaemonTargetFromCatalog(d, "", false)
-		if err != nil {
-			return namedDaemonTarget{}, err
-		}
-		if !probeRemote(ctx, target.BaseURL) {
-			return namedDaemonTarget{}, fmt.Errorf("%w: %s (%s daemon %q)",
-				ErrRemoteUnavailable, target.BaseURL, daemonConfigSource(), d.Name)
-		}
-		return target, nil
+	if !ok {
+		return ResolvedDaemon{}, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, strings.TrimSpace(name))
 	}
-	return namedDaemonTarget{}, fmt.Errorf("%w: %q", ErrNamedDaemonNotFound, name)
+	return namedResolved(target), nil
 }
 
+// namedDaemonTargetForBaseURL is the compatibility bridge for callers that
+// resolved a named daemon but retained only its URL. It does not probe or
+// start a daemon; the mismatch check in NewHTTPClient rejects changed catalog
+// provenance.
+// Deprecated: use EnsureResolvedNamed and NewHTTPClientForResolved.
 func namedDaemonTargetForBaseURL(name, baseURL string) (namedDaemonTarget, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -340,7 +399,7 @@ func namedDaemonTargetFromCatalog(
 				daemonConfigSource(), daemon.Name, remoteURLForError(daemon.URL), err)
 		}
 	}
-	target := activeRemoteTarget{
+	activeTarget := activeRemoteTarget{
 		Name:          daemon.Name,
 		BaseURL:       baseURL,
 		Token:         daemon.Token,
@@ -350,18 +409,22 @@ func namedDaemonTargetFromCatalog(
 	token := daemon.Token
 	if local || !globalAuthTokenOverrideSet() {
 		var err error
-		token, err = resolveActiveRemoteTargetToken(target)
+		token, err = resolveActiveRemoteTargetToken(activeTarget)
 		if err != nil {
 			return namedDaemonTarget{}, err
 		}
 	}
-	return namedDaemonTarget{
+	target := namedDaemonTarget{
 		Name:          daemon.Name,
 		Local:         local,
 		BaseURL:       baseURL,
 		Token:         token,
 		AllowInsecure: daemon.AllowInsecure,
-	}, nil
+	}
+	if !local {
+		target.Running = remoteRunningDaemon(baseURL, true)
+	}
+	return target, nil
 }
 
 func activeRemoteFromConfig() (activeRemoteTarget, bool, error) {
@@ -408,6 +471,10 @@ func resolveActiveRemoteTargetToken(target activeRemoteTarget) (string, error) {
 	return token, nil
 }
 
+// activeRemoteTargetAuthForBaseURL is the compatibility bridge for callers
+// that retained only the selected active daemon's URL. It reads configuration
+// but never re-probes the endpoint.
+// Deprecated: use EnsureResolvedInWorkspace and NewHTTPClientForResolved.
 func activeRemoteTargetAuthForBaseURL(baseURL, workspaceStart string) (TargetAuth, bool, error) {
 	if globalAuthTokenOverrideSet() || higherPriorityRemoteSourceMatchesBaseURL(baseURL, workspaceStart) {
 		return TargetAuth{}, false, nil
@@ -441,9 +508,8 @@ func higherPriorityRemoteSourceMatchesBaseURL(baseURL, workspaceStart string) bo
 		u, err := normalizeRemoteURL(v, envAllowInsecure())
 		return err == nil && u == baseURL
 	}
-	// An unverifiable local config (findErr != nil) aborts resolution in
-	// resolveRemote, so no client reaches this point through it; report
-	// no match rather than guessing at its contents.
+	// An unverifiable local config aborts resolution before a compatibility
+	// client is built, so no match is safer than guessing at its contents.
 	root, _, ok, findErr := findLocalConfig(workspaceStart)
 	if findErr != nil || !ok {
 		return false
@@ -454,11 +520,6 @@ func higherPriorityRemoteSourceMatchesBaseURL(baseURL, workspaceStart string) bo
 	}
 	u, err := normalizeRemoteURL(cfg.Server.URL, cfg.Server.AllowInsecure)
 	return err == nil && u == baseURL
-}
-
-func activeRemoteAllowInsecureForBaseURL(baseURL string) bool {
-	target, ok, err := activeRemoteFromConfig()
-	return err == nil && ok && target.BaseURL == baseURL && target.AllowInsecure
 }
 
 func daemonConfigSource() string {
@@ -478,6 +539,10 @@ func envAllowInsecure() bool {
 }
 
 func remoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
+	activeAllows := func() bool {
+		target, ok, err := activeRemoteFromConfig()
+		return err == nil && ok && target.BaseURL == baseURL && target.AllowInsecure
+	}
 	if v := os.Getenv(remoteServerEnvVar); v != "" {
 		allow := envAllowInsecure()
 		u, err := normalizeRemoteURL(v, allow)
@@ -489,7 +554,7 @@ func remoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 		return false
 	}
 	if !ok {
-		return activeRemoteAllowInsecureForBaseURL(baseURL)
+		return activeAllows()
 	}
 	cfg, err := config.ReadLocalConfig(root)
 	if err != nil {
@@ -502,7 +567,7 @@ func remoteAllowInsecureForBaseURL(baseURL, workspaceStart string) bool {
 		u, err := normalizeRemoteURL(cfg.Server.URL, true)
 		return err == nil && u == baseURL
 	}
-	return activeRemoteAllowInsecureForBaseURL(baseURL)
+	return activeAllows()
 }
 
 // findLocalConfig walks upward from start looking for .kata.local.toml,

--- a/internal/client/remote_test.go
+++ b/internal/client/remote_test.go
@@ -272,10 +272,9 @@ url = "`+srv.URL+`"
 token = "catalog-token"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
-		Timeout:    time.Second,
-		DaemonName: "shared",
-	})
+	resolved, err := EnsureResolvedNamed(context.Background(), "shared")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
 	require.NoError(t, err)
@@ -316,10 +315,9 @@ url = "`+srv.URL+`"
 token_env = "KATA_SHARED_TOKEN"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
-		Timeout:    time.Second,
-		DaemonName: "shared",
-	})
+	resolved, err := EnsureResolvedNamed(context.Background(), "shared")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
 	require.NoError(t, err)
@@ -358,10 +356,9 @@ name = "shared"
 url = "`+srv.URL+`"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
-		Timeout:    time.Second,
-		DaemonName: "shared",
-	})
+	resolved, err := EnsureResolvedNamed(context.Background(), "shared")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
 	require.NoError(t, err)
@@ -405,10 +402,9 @@ name = "shared"
 url = "`+srv.URL+`"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
-		Timeout:    time.Second,
-		DaemonName: "shared",
-	})
+	resolved, err := EnsureResolvedNamed(context.Background(), "shared")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
 	require.NoError(t, err)
@@ -421,6 +417,7 @@ url = "`+srv.URL+`"
 }
 
 func TestNewHTTPClient_NamedRemoteAuthTokenEnvHonorsTrustPrivateNetwork(t *testing.T) {
+	stubProbe(t, true)
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
 	t.Setenv("KATA_AUTH_TOKEN", "env-token")
@@ -432,16 +429,16 @@ name = "shared"
 url = "`+baseURL+`"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), baseURL, Opts{
-		Timeout:    time.Second,
-		DaemonName: "shared",
-	})
+	resolved, err := EnsureResolvedNamed(context.Background(), "shared")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }
 
 func TestNewHTTPClient_NamedRemoteCatalogTokenHonorsTrustPrivateNetwork(t *testing.T) {
+	stubProbe(t, true)
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
 	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
@@ -453,16 +450,16 @@ url = "`+baseURL+`"
 token = "catalog-token"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), baseURL, Opts{
-		Timeout:    time.Second,
-		DaemonName: "shared",
-	})
+	resolved, err := EnsureResolvedNamed(context.Background(), "shared")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }
 
 func TestNewHTTPClient_ActiveRemoteTokenEnvHonorsTrustPrivateNetwork(t *testing.T) {
+	stubProbe(t, true)
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
 	t.Setenv("KATA_SERVER", "")
@@ -480,7 +477,9 @@ url = "`+baseURL+`"
 token_env = "KATA_SHARED_TOKEN"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), baseURL, Opts{Timeout: time.Second})
+	resolved, err := EnsureResolvedInWorkspace(context.Background(), "")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 
 	require.NoError(t, err)
 	assert.NotNil(t, c)
@@ -514,10 +513,9 @@ local = true
 token = "local-token"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
-		Timeout:    time.Second,
-		DaemonName: "local-auth",
-	})
+	resolved, err := EnsureResolvedNamed(context.Background(), "local-auth")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/protected", nil)
 	require.NoError(t, err)
@@ -533,10 +531,17 @@ func TestNewHTTPClient_NamedLocalUsesProvidedBaseURLWithoutStarting(t *testing.T
 	home := setupKataEnv(t)
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true, "service": "kata", "version": currentVersionForEnsure(), "pid": os.Getpid(),
+			})
+			return
+		}
 		gotAuth = r.Header.Get("Authorization")
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(srv.Close)
+	require.NoError(t, writeRuntimeRecord(t, home, strings.TrimPrefix(srv.URL, "http://")))
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
 [[daemon]]
 name = "local-auth"
@@ -544,10 +549,9 @@ local = true
 token = "local-token"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
-		Timeout:    time.Second,
-		DaemonName: "local-auth",
-	})
+	resolved, err := EnsureResolvedNamed(context.Background(), "local-auth")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
@@ -563,10 +567,17 @@ func TestNewHTTPClient_NamedLocalBypassesActiveDaemonAuth(t *testing.T) {
 	home := setupKataEnv(t)
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true, "service": "kata", "version": currentVersionForEnsure(), "pid": os.Getpid(),
+			})
+			return
+		}
 		gotAuth = r.Header.Get("Authorization")
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(srv.Close)
+	require.NoError(t, writeRuntimeRecord(t, home, strings.TrimPrefix(srv.URL, "http://")))
 	t.Setenv("KATA_REMOTE_TOKEN", "")
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
 active_daemon = "remote"
@@ -584,10 +595,9 @@ url = "`+srv.URL+`"
 token_env = "KATA_REMOTE_TOKEN"
 `), 0o600))
 
-	c, err := NewHTTPClient(context.Background(), srv.URL, Opts{
-		Timeout:    time.Second,
-		DaemonName: "local",
-	})
+	resolved, err := EnsureResolvedNamed(context.Background(), "local")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(context.Background(), resolved, Opts{Timeout: time.Second})
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)

--- a/internal/client/resolved.go
+++ b/internal/client/resolved.go
@@ -1,0 +1,243 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"go.kenn.io/kata/internal/config"
+)
+
+// DaemonSource names the input that selected a daemon. The source is carried
+// with the endpoint because two inputs can normalize to the same origin while
+// supplying different credentials.
+type DaemonSource int
+
+// DaemonSource constants identify each supported daemon-selection input.
+const (
+	DaemonSourceUnknown DaemonSource = iota
+	DaemonSourceInjected
+	DaemonSourceServerEnv
+	DaemonSourceLocalConfig
+	DaemonSourceActiveDaemon
+	DaemonSourceNamedCatalog
+	DaemonSourceLocalRuntime
+)
+
+func (s DaemonSource) String() string {
+	switch s {
+	case DaemonSourceInjected:
+		return "injected"
+	case DaemonSourceServerEnv:
+		return remoteServerEnvVar
+	case DaemonSourceLocalConfig:
+		return config.LocalConfigFilename
+	case DaemonSourceActiveDaemon:
+		return "active_daemon"
+	case DaemonSourceNamedCatalog:
+		return "daemon catalog"
+	case DaemonSourceLocalRuntime:
+		return "local runtime"
+	default:
+		return "unknown"
+	}
+}
+
+// ResolvedDaemon is the complete result of daemon resolution: endpoint
+// provenance, exact transport metadata, and the credentials and policy chosen
+// for that source. Client construction consumes this value without resolving
+// those inputs again.
+type ResolvedDaemon struct {
+	Source              DaemonSource
+	Name                string
+	BaseURL             string
+	Address             string
+	Network             string
+	Scheme              string
+	UnixSocket          string
+	Token               string
+	AllowInsecure       bool
+	TrustPrivateNetwork bool
+
+	// Named catalog entries can be local or remote while sharing one public
+	// source enum. Retain that distinction so Running reproduces the exact
+	// RunningDaemon returned by the credential-free named locator.
+	namedRemote bool
+}
+
+// ConfiguredRemote reports whether resolution selected configured remote
+// endpoint metadata rather than local discovery or an injected test target.
+func (d ResolvedDaemon) ConfiguredRemote() bool {
+	switch d.Source {
+	case DaemonSourceServerEnv, DaemonSourceLocalConfig, DaemonSourceActiveDaemon:
+		return true
+	case DaemonSourceNamedCatalog:
+		return d.namedRemote
+	default:
+		return false
+	}
+}
+
+// Running returns the credential-free view without dropping exact endpoint
+// address, network, or scheme metadata.
+func (d ResolvedDaemon) Running() RunningDaemon {
+	return RunningDaemon{
+		BaseURL:          d.BaseURL,
+		Address:          d.Address,
+		Network:          d.Network,
+		Scheme:           d.Scheme,
+		ConfiguredRemote: d.ConfiguredRemote(),
+	}
+}
+
+// WithRunning replaces only the selected runtime endpoint metadata. It keeps
+// the source identity and bearer policy already resolved for the daemon, so a
+// local restart can refresh its socket without re-reading credentials.
+func (d ResolvedDaemon) WithRunning(running RunningDaemon) ResolvedDaemon {
+	refreshed := resolvedForRunning(d.Source, d.Name, running)
+	refreshed.Token = d.Token
+	refreshed.AllowInsecure = d.AllowInsecure
+	refreshed.TrustPrivateNetwork = d.TrustPrivateNetwork
+	refreshed.namedRemote = d.namedRemote
+	return refreshed
+}
+
+func resolvedForRunning(source DaemonSource, name string, running RunningDaemon) ResolvedDaemon {
+	resolved := ResolvedDaemon{
+		Source:      source,
+		Name:        name,
+		BaseURL:     running.BaseURL,
+		Address:     running.Address,
+		Network:     running.Network,
+		Scheme:      running.Scheme,
+		namedRemote: source == DaemonSourceNamedCatalog && running.ConfiguredRemote,
+	}
+	if running.Network == "unix" {
+		resolved.UnixSocket = running.Address
+		if socket, ok := strings.CutPrefix(running.Address, "unix://"); ok {
+			resolved.UnixSocket = socket
+		}
+	}
+	return resolved
+}
+
+func (d ResolvedDaemon) withGlobalAuth() ResolvedDaemon {
+	auth := resolveAuthConfig()
+	d.Token = auth.Token
+	if override := authTokenEnvOverride(); override != "" {
+		d.Token = override
+	}
+	d.TrustPrivateNetwork = auth.TrustPrivateNetwork
+	return d
+}
+
+func (d ResolvedDaemon) withRemoteTargetAuth(token string, allowInsecure bool) ResolvedDaemon {
+	auth := resolveAuthConfig()
+	d.Token = token
+	if override := authTokenEnvOverride(); override != "" {
+		d.Token = override
+	}
+	d.AllowInsecure = allowInsecure
+	d.TrustPrivateNetwork = auth.TrustPrivateNetwork
+	return d
+}
+
+func (d ResolvedDaemon) withLocalTargetAuth(token string) ResolvedDaemon {
+	auth := resolveAuthConfig()
+	d.Token = token
+	if d.Token == "" {
+		d.Token = auth.Token
+	}
+	d.TrustPrivateNetwork = auth.TrustPrivateNetwork
+	return d
+}
+
+// EnsureResolvedInWorkspace selects a daemon and retains the policy selected
+// by that same source. Configured remotes precede local discovery and start.
+func EnsureResolvedInWorkspace(ctx context.Context, workspaceStart string) (ResolvedDaemon, error) {
+	if value, ok := ctx.Value(BaseURLKey{}).(string); ok && value != "" {
+		return resolvedForRunning(
+			DaemonSourceInjected, "", remoteRunningDaemon(value, false),
+		).withGlobalAuth(), nil
+	}
+	if resolved, ok, err := resolveRemoteDaemon(ctx, workspaceStart); err != nil {
+		return ResolvedDaemon{}, err
+	} else if ok {
+		return resolved, nil
+	}
+	return ensureLocalResolved(ctx)
+}
+
+// ResolveRemoteDaemon resolves only configured remote sources and returns
+// their provenance and credentials without falling through to local startup.
+func ResolveRemoteDaemon(ctx context.Context, workspaceStart string) (ResolvedDaemon, bool, error) {
+	return resolveRemoteDaemon(ctx, workspaceStart)
+}
+
+// EnsureResolvedNamed resolves an explicit catalog selection. Named local
+// entries may start the local daemon; named remotes are probed.
+func EnsureResolvedNamed(ctx context.Context, name string) (ResolvedDaemon, error) {
+	return resolveNamedDaemon(ctx, name)
+}
+
+// DiscoverResolved returns the first live local runtime with its exact
+// endpoint and preserves store, cancellation, and unreachable-daemon errors.
+func DiscoverResolved(ctx context.Context, dataDir string) (ResolvedDaemon, bool, error) {
+	var unreachable error
+	for candidate, err := range liveDaemons(ctx, dataDir) {
+		if err == nil {
+			return localRuntimeResolved(candidate), true, nil
+		}
+		if errors.Is(err, ErrLocalDaemonUnreachable) {
+			if unreachable == nil {
+				unreachable = err
+			}
+			continue
+		}
+		return ResolvedDaemon{}, false, err
+	}
+	return ResolvedDaemon{}, false, unreachable
+}
+
+// DiscoverResolvedNamed resolves an explicit catalog selection without
+// starting a local daemon. A configured local entry with no live runtime
+// returns the zero value and no error, matching DiscoverNamed's not-found
+// result while preserving all resolver errors.
+func DiscoverResolvedNamed(ctx context.Context, name string) (ResolvedDaemon, error) {
+	target, ok, err := discoverNamedDaemonTarget(ctx, name)
+	if err != nil {
+		return ResolvedDaemon{}, err
+	}
+	if !ok {
+		return ResolvedDaemon{}, nil
+	}
+	return namedResolved(target), nil
+}
+
+func namedResolved(target namedDaemonTarget) ResolvedDaemon {
+	running := target.Running
+	if running.BaseURL == "" {
+		running = remoteRunningDaemon(target.BaseURL, !target.Local)
+	}
+	resolved := resolvedForRunning(DaemonSourceNamedCatalog, target.Name, running)
+	if target.Local {
+		return resolved.withLocalTargetAuth(target.Token)
+	}
+	return resolved.withRemoteTargetAuth(target.Token, target.AllowInsecure)
+}
+
+func ensureLocalResolved(ctx context.Context) (ResolvedDaemon, error) {
+	running, err := ensureLocalRunningTarget(ctx)
+	if err != nil {
+		return ResolvedDaemon{}, err
+	}
+	return resolvedForRunning(DaemonSourceLocalRuntime, "", running).withGlobalAuth(), nil
+}
+
+func localRuntimeResolved(candidate liveDaemon) ResolvedDaemon {
+	resolved := resolvedForRunning(
+		DaemonSourceLocalRuntime, "", runningDaemonForLive(candidate),
+	).withGlobalAuth()
+	resolved.UnixSocket = candidate.UnixSocket
+	return resolved
+}

--- a/internal/client/resolved_test.go
+++ b/internal/client/resolved_test.go
@@ -1,0 +1,637 @@
+package client
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/daemon"
+	kitdaemon "go.kenn.io/kit/daemon"
+)
+
+// TestNewHTTPClientForResolvedUsesCarriedUnixSocket pins that client
+// construction consumes the socket selected during resolution. Requiring a
+// runtime record here would reintroduce a time-of-check/time-of-use re-scan.
+func TestNewHTTPClientForResolvedUsesCarriedUnixSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are unsupported on Windows")
+	}
+	setupKataEnv(t)
+	socket := filepath.Join(t.TempDir(), "kata.sock")
+	ln, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// The namespace deliberately has no runtime record. The resolved value is
+	// complete and must remain sufficient after runtime discovery state changes.
+	resolved := ResolvedDaemon{
+		Source:     DaemonSourceLocalRuntime,
+		BaseURL:    UnixBase,
+		UnixSocket: socket,
+	}
+	c, err := NewHTTPClientForResolved(t.Context(), resolved, Opts{Timeout: time.Second})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, UnixBase+"/ready", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// TestNewHTTPClientForResolvedNamedNeedsNoURLCrossCheck pins that a named
+// catalog daemon builds from its resolved provenance. The old construction
+// path re-resolved the catalog entry and compared base URLs, a guard that only
+// existed because the name-to-URL binding was discarded before construction.
+func TestNewHTTPClientForResolvedNamedNeedsNoURLCrossCheck(t *testing.T) {
+	var gotAuthorization string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+			return
+		}
+		gotAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `
+[[daemon]]
+name = "hub-project-daemon"
+url = "`+srv.URL+`"
+token = "catalog-token"
+`))
+
+	resolved, err := EnsureResolvedNamed(t.Context(), "hub-project-daemon")
+	require.NoError(t, err)
+	c, err := NewHTTPClientForResolved(t.Context(), resolved, Opts{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/projects", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, "Bearer catalog-token", gotAuthorization)
+}
+
+func TestResolvedDaemonSameOriginTwoSourcesPicksHigherPriority(t *testing.T) {
+	srv := startResolvableDaemon(t)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", srv.URL)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeRawConfig(home, `
+active_daemon = "shared"
+
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token = "catalog-token"
+`))
+
+	resolved, err := EnsureResolvedInWorkspace(t.Context(), "")
+	require.NoError(t, err)
+
+	assert.Equal(t, DaemonSourceServerEnv, resolved.Source)
+	assert.Equal(t, "global-token", resolved.Token)
+	assert.True(t, resolved.ConfiguredRemote())
+}
+
+func TestNewHTTPClientForResolvedDoesNotRereadConfiguration(t *testing.T) {
+	var gotAuthorization string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+			return
+		}
+		gotAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	require.NoError(t, writeAuthConfig(home, "resolved-token"))
+
+	workspace := t.TempDir()
+	writeNeutralWorkspaceMarker(t, workspace)
+	localPath := filepath.Join(workspace, ".kata.local.toml")
+	require.NoError(t, os.WriteFile(localPath,
+		[]byte("version = 1\n\n[server]\nurl = \""+srv.URL+"\"\n"), 0o600))
+
+	resolved, err := EnsureResolvedInWorkspace(t.Context(), workspace)
+	require.NoError(t, err)
+	require.Equal(t, DaemonSourceLocalConfig, resolved.Source)
+
+	// Construction must consume the value above, not any state changed after it.
+	t.Setenv("KATA_AUTH_TOKEN", "replacement-token")
+	require.NoError(t, writeRawConfig(home, "not = valid = toml"))
+	require.NoError(t, os.WriteFile(localPath,
+		[]byte("[server]\nurl = \"http://elsewhere.invalid\"\nallow_insecure = true\n"), 0o600))
+
+	c, err := NewHTTPClientForResolved(t.Context(), resolved, Opts{Timeout: time.Second})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/protected", nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req) //nolint:gosec // G704: srv.URL is the test's own httptest.Server
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer resolved-token", gotAuthorization)
+	assert.False(t, resolved.AllowInsecure)
+}
+
+func TestResolvedDaemonSourcesTable(t *testing.T) {
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+
+	t.Run("server env", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_SERVER", srv.URL)
+		t.Setenv("KATA_ALLOW_INSECURE", "1")
+		t.Setenv("KATA_AUTH_TOKEN", "")
+		require.NoError(t, writeAuthConfig(home, "global-token"))
+
+		resolved, err := EnsureResolvedInWorkspace(t.Context(), "")
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceServerEnv, "global-token", true)
+	})
+
+	t.Run("workspace local config", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_SERVER", "")
+		t.Setenv("KATA_AUTH_TOKEN", "")
+		require.NoError(t, writeAuthConfig(home, "global-token"))
+		workspace := t.TempDir()
+		writeNeutralWorkspaceMarker(t, workspace)
+		require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`
+version = 1
+
+[server]
+url = "`+srv.URL+`"
+token = "ignored-local-token"
+allow_insecure = true
+`), 0o600))
+
+		resolved, err := EnsureResolvedInWorkspace(t.Context(), workspace)
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceLocalConfig, "global-token", true)
+	})
+
+	t.Run("active daemon entry token env", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_SERVER", "")
+		t.Setenv("KATA_AUTH_TOKEN", "")
+		t.Setenv("KATA_SHARED_TOKEN", "catalog-env-token")
+		require.NoError(t, writeRawConfig(home, `
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_SHARED_TOKEN"
+allow_insecure = true
+`))
+
+		resolved, err := EnsureResolvedInWorkspace(t.Context(), "")
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceActiveDaemon, "catalog-env-token", true)
+		assert.Equal(t, "shared", resolved.Name)
+	})
+
+	t.Run("active daemon explicit env override", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_SERVER", "")
+		t.Setenv("KATA_AUTH_TOKEN", "override-token")
+		t.Setenv("KATA_SHARED_TOKEN", "")
+		require.NoError(t, writeRawConfig(home, `
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_SHARED_TOKEN"
+`))
+
+		resolved, err := EnsureResolvedInWorkspace(t.Context(), "")
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceActiveDaemon, "override-token", false)
+	})
+
+	t.Run("named catalog remote token env", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_AUTH_TOKEN", "")
+		t.Setenv("KATA_NAMED_TOKEN", "catalog-env-token")
+		require.NoError(t, writeRawConfig(home, `
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_NAMED_TOKEN"
+allow_insecure = true
+`))
+
+		resolved, err := EnsureResolvedNamed(t.Context(), "shared")
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceNamedCatalog, "catalog-env-token", true)
+		assert.Equal(t, remoteRunningDaemon(srv.URL, true), resolved.Running())
+	})
+
+	t.Run("named catalog remote explicit env override", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_AUTH_TOKEN", "override-token")
+		t.Setenv("KATA_NAMED_TOKEN", "")
+		require.NoError(t, writeRawConfig(home, `
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_NAMED_TOKEN"
+`))
+
+		resolved, err := EnsureResolvedNamed(t.Context(), "shared")
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceNamedCatalog, "override-token", false)
+	})
+
+	t.Run("named catalog local token env", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_AUTH_TOKEN", "global-token")
+		t.Setenv("KATA_LOCAL_TOKEN", "local-entry-token")
+		require.NoError(t, writeRawConfig(home, `
+[[daemon]]
+name = "local"
+local = true
+token_env = "KATA_LOCAL_TOKEN"
+`))
+		patchEnsureHooks(t, currentVersionForEnsure(), "http://127.0.0.1:27123")
+
+		resolved, err := EnsureResolvedNamed(t.Context(), "local")
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceNamedCatalog, "local-entry-token", false)
+		assert.False(t, resolved.ConfiguredRemote())
+	})
+
+	t.Run("named catalog local global fallback", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_AUTH_TOKEN", "")
+		require.NoError(t, writeRawConfig(home, `
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "local"
+local = true
+`))
+		patchEnsureHooks(t, currentVersionForEnsure(), "http://127.0.0.1:27123")
+
+		resolved, err := EnsureResolvedNamed(t.Context(), "local")
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceNamedCatalog, "global-token", false)
+	})
+
+	t.Run("local runtime", func(t *testing.T) {
+		home := setupKataEnv(t)
+		t.Setenv("KATA_SERVER", "")
+		t.Setenv("KATA_AUTH_TOKEN", "")
+		require.NoError(t, writeAuthConfig(home, "global-token"))
+		_, address := startMockDaemonPing(t, map[string]any{
+			"ok": true, "service": "kata", "version": currentVersionForEnsure(),
+		})
+		require.NoError(t, writeRuntimeRecord(t, home, address))
+
+		resolved, err := EnsureResolvedInWorkspace(t.Context(), "")
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceLocalRuntime, "global-token", false)
+		assert.Equal(t, address, resolved.Address)
+		assert.Empty(t, resolved.UnixSocket)
+	})
+
+	t.Run("injected", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_AUTH_TOKEN", "injected-token")
+		ctx := context.WithValue(t.Context(), BaseURLKey{}, "https://daemon.example")
+
+		resolved, err := EnsureResolvedInWorkspace(ctx, "")
+		require.NoError(t, err)
+		assertResolvedCredential(t, resolved, DaemonSourceInjected, "injected-token", false)
+	})
+}
+
+func TestResolvedDaemonRunningPreservesEndpointMetadata(t *testing.T) {
+	tests := []struct {
+		name           string
+		in             ResolvedDaemon
+		want           RunningDaemon
+		wantUnixSocket string
+	}{
+		{
+			name: "local tcp",
+			in: localRuntimeResolved(liveDaemon{
+				BaseURL: "http://127.0.0.1:27123",
+				Record:  kitdaemon.RuntimeRecord{Address: "127.0.0.1:27123"},
+			}),
+			want: RunningDaemon{BaseURL: "http://127.0.0.1:27123", Address: "127.0.0.1:27123", Network: "tcp", Scheme: "http"},
+		},
+		{
+			name: "local unix",
+			in: resolvedForRunning(DaemonSourceLocalRuntime, "",
+				localRunningDaemon(UnixBase, "unix:///tmp/kata-test.sock")),
+			want:           RunningDaemon{BaseURL: UnixBase, Address: "unix:///tmp/kata-test.sock", Network: "unix", Scheme: "http"},
+			wantUnixSocket: "/tmp/kata-test.sock",
+		},
+		{
+			name: "configured remote",
+			in:   ResolvedDaemon{Source: DaemonSourceServerEnv, BaseURL: "https://daemon.example", Address: "https://daemon.example", Network: "tcp", Scheme: "https"},
+			want: RunningDaemon{BaseURL: "https://daemon.example", Address: "https://daemon.example", Network: "tcp", Scheme: "https", ConfiguredRemote: true},
+		},
+		{
+			name: "injected",
+			in:   ResolvedDaemon{Source: DaemonSourceInjected, BaseURL: "http://127.0.0.1:27123", Address: "http://127.0.0.1:27123", Network: "tcp", Scheme: "http"},
+			want: RunningDaemon{BaseURL: "http://127.0.0.1:27123", Address: "http://127.0.0.1:27123", Network: "tcp", Scheme: "http"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.in.Running())
+			assert.Equal(t, tt.wantUnixSocket, tt.in.UnixSocket)
+		})
+	}
+}
+
+func TestResolvedDaemonWithRunningReplacesOnlyRuntimeMetadata(t *testing.T) {
+	original := ResolvedDaemon{
+		Source: DaemonSourceNamedCatalog, Name: "local-daemon",
+		BaseURL: "http://127.0.0.1:27123", Address: "127.0.0.1:27123",
+		Network: "tcp", Scheme: "http",
+		Token: "target-token", AllowInsecure: true, TrustPrivateNetwork: true,
+	}
+	running := RunningDaemon{
+		BaseURL: UnixBase, Address: "unix:///tmp/fresh-kata.sock",
+		Network: "unix", Scheme: "http",
+	}
+
+	refreshed := original.WithRunning(running)
+
+	assert.Equal(t, DaemonSourceNamedCatalog, refreshed.Source)
+	assert.Equal(t, "local-daemon", refreshed.Name)
+	assert.Equal(t, "target-token", refreshed.Token)
+	assert.True(t, refreshed.AllowInsecure)
+	assert.True(t, refreshed.TrustPrivateNetwork)
+	assert.Equal(t, UnixBase, refreshed.BaseURL)
+	assert.Equal(t, "unix:///tmp/fresh-kata.sock", refreshed.Address)
+	assert.Equal(t, "unix", refreshed.Network)
+	assert.Equal(t, "http", refreshed.Scheme)
+	assert.Equal(t, "/tmp/fresh-kata.sock", refreshed.UnixSocket)
+}
+
+func TestDiscoverResolvedPreservesScanErrors(t *testing.T) {
+	t.Run("runtime store", func(t *testing.T) {
+		_, ok, err := DiscoverResolved(t.Context(), "relative-data-dir")
+		require.Error(t, err)
+		assert.False(t, ok)
+		assert.Contains(t, err.Error(), "must be absolute")
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		home := setupKataEnv(t)
+		require.NoError(t, writeRuntimeRecord(t, home, "unix://"+filepath.Join(home, "missing.sock")))
+		namespace, err := daemon.NewNamespace()
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_, ok, err := DiscoverResolved(ctx, namespace.DataDir)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, ok)
+	})
+
+	t.Run("unreachable local daemon", func(t *testing.T) {
+		home := setupKataEnv(t)
+		address := "unix://" + filepath.Join(home, "missing.sock")
+		require.NoError(t, writeRuntimeRecord(t, home, address))
+		namespace, err := daemon.NewNamespace()
+		require.NoError(t, err)
+
+		_, ok, err := DiscoverResolved(t.Context(), namespace.DataDir)
+		require.ErrorIs(t, err, ErrLocalDaemonUnreachable)
+		assert.False(t, ok)
+		assert.Contains(t, err.Error(), address)
+	})
+}
+
+func TestDiscoverResolvedNamedLocalWithoutLiveDaemon(t *testing.T) {
+	home := setupKataEnv(t)
+	require.NoError(t, writeRawConfig(home, `
+[[daemon]]
+name = "local"
+local = true
+`))
+
+	resolved, err := DiscoverResolvedNamed(t.Context(), "local")
+	require.NoError(t, err)
+	assert.Empty(t, resolved.BaseURL)
+}
+
+func TestDiscoverResolvedNamedPreservesLocalRuntimeMetadata(t *testing.T) {
+	home := setupKataEnv(t)
+	require.NoError(t, writeRawConfig(home, `
+[[daemon]]
+name = "local"
+local = true
+`))
+	baseURL, address := startMockDaemonPing(t, map[string]any{
+		"ok": true, "service": "kata", "version": currentVersionForEnsure(),
+	})
+	require.NoError(t, writeRuntimeRecord(t, home, address))
+
+	resolved, err := DiscoverResolvedNamed(t.Context(), "local")
+	require.NoError(t, err)
+	assert.Equal(t, localRunningDaemon(baseURL, address), resolved.Running())
+}
+
+func TestDiscoverResolvedNamedPreservesResolutionErrors(t *testing.T) {
+	home := setupKataEnv(t)
+	require.NoError(t, writeRawConfig(home, `
+[[daemon]]
+name = "remote"
+url = "http://127.0.0.1:1"
+`))
+
+	_, err := DiscoverResolvedNamed(t.Context(), "remote")
+	require.ErrorIs(t, err, ErrRemoteUnavailable)
+}
+
+func TestCredentialFreeLocatorsDoNotResolveCatalogTokenEnv(t *testing.T) {
+	t.Run("active remote", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_SERVER", "")
+		t.Setenv("KATA_AUTH_TOKEN", "")
+		t.Setenv("KATA_MISSING_TOKEN", "")
+		require.NoError(t, writeRawConfig(home, `
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_MISSING_TOKEN"
+`))
+
+		target, err := LocateRunningTargetInWorkspace(t.Context(), "")
+		require.NoError(t, err)
+		assert.Equal(t, remoteRunningDaemon(srv.URL, true), target)
+	})
+
+	t.Run("named remote", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_AUTH_TOKEN", "")
+		t.Setenv("KATA_MISSING_TOKEN", "")
+		require.NoError(t, writeRawConfig(home, `
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_MISSING_TOKEN"
+`))
+
+		target, err := LocateNamedRunningTarget(t.Context(), "shared")
+		require.NoError(t, err)
+		assert.Equal(t, remoteRunningDaemon(srv.URL, true), target)
+	})
+}
+
+func TestRemoteResolutionModesShareSelectionWithoutCredentialLeak(t *testing.T) {
+	t.Run("server environment wins for both modes", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_SERVER", srv.URL)
+		t.Setenv("KATA_AUTH_TOKEN", "global-token")
+		workspace := t.TempDir()
+		writeNeutralWorkspaceMarker(t, workspace)
+		require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(`
+version = 1
+
+[server]
+url = "http://127.0.0.1:1"
+`), 0o600))
+
+		baseURL, ok, err := ResolveRemote(t.Context(), workspace)
+		require.NoError(t, err)
+		require.True(t, ok)
+		resolved, resolvedOK, err := ResolveRemoteDaemon(t.Context(), workspace)
+		require.NoError(t, err)
+		require.True(t, resolvedOK)
+
+		assert.Equal(t, srv.URL, baseURL)
+		assert.Equal(t, baseURL, resolved.BaseURL)
+		assert.Equal(t, DaemonSourceServerEnv, resolved.Source)
+		assert.Equal(t, "global-token", resolved.Token)
+	})
+
+	t.Run("credential-free active selection ignores unset token env", func(t *testing.T) {
+		srv := startResolvableDaemon(t)
+		home := t.TempDir()
+		t.Setenv("KATA_HOME", home)
+		t.Setenv("KATA_SERVER", "")
+		t.Setenv("KATA_AUTH_TOKEN", "")
+		t.Setenv("KATA_MISSING_TOKEN", "")
+		require.NoError(t, writeRawConfig(home, `
+active_daemon = "shared"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_MISSING_TOKEN"
+`))
+
+		baseURL, ok, err := ResolveRemote(t.Context(), "")
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, srv.URL, baseURL)
+
+		_, _, err = ResolveRemoteDaemon(t.Context(), "")
+		require.EqualError(t, err, `daemon "shared": token_env "KATA_MISSING_TOKEN" is unset or empty`)
+	})
+}
+
+func assertResolvedCredential(
+	t *testing.T,
+	resolved ResolvedDaemon,
+	wantSource DaemonSource,
+	wantToken string,
+	wantAllowInsecure bool,
+) {
+	t.Helper()
+	assert.Equal(t, wantSource, resolved.Source)
+	assert.Equal(t, wantToken, resolved.Token)
+	assert.Equal(t, wantAllowInsecure, resolved.AllowInsecure)
+	assert.True(t, resolved.TrustPrivateNetwork)
+}
+
+func startResolvableDaemon(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ping" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func writeNeutralWorkspaceMarker(t *testing.T, workspace string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.toml"), []byte(
+		"version = 1\n\n[project]\nidentity = \"example.test/spoke-project\"\nname = \"spoke-project\"\n",
+	), 0o600))
+}

--- a/internal/client/webui.go
+++ b/internal/client/webui.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"go.kenn.io/kata/internal/api"
-	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	kitdaemon "go.kenn.io/kit/daemon"
 )
@@ -53,17 +52,14 @@ type WebUIOpener func(context.Context, WebUILaunch) error
 // PrepareWebUI resolves and probes the selected daemon and validates local
 // browser runtime metadata.
 func PrepareWebUI(ctx context.Context, opts PrepareWebUIOptions) (PreparedWebUI, error) {
-	baseURL, configuredRemote, allowInsecure, err := resolveWebUIHostTarget(ctx, opts)
+	resolved, err := resolveWebUIHostTarget(ctx, opts)
 	if err != nil {
 		return PreparedWebUI{}, err
 	}
-
-	httpClient, err := NewHTTPClient(ctx, baseURL, Opts{
-		Timeout:        DefaultHTTPTimeout,
-		AllowInsecure:  allowInsecure,
-		WorkspaceStart: opts.WorkspaceStart,
-		DaemonName:     opts.DaemonName,
-	})
+	baseURL := resolved.BaseURL
+	configuredRemote := resolved.ConfiguredRemote()
+	allowInsecure := resolved.AllowInsecure
+	httpClient, err := NewHTTPClientForResolved(ctx, resolved, Opts{Timeout: DefaultHTTPTimeout})
 	if err != nil {
 		return PreparedWebUI{}, err
 	}
@@ -79,7 +75,10 @@ func PrepareWebUI(ctx context.Context, opts PrepareWebUIOptions) (PreparedWebUI,
 		if _, err := validatedWebBaseURL(baseURL, true); err != nil {
 			return PreparedWebUI{}, err
 		}
-		anonymousClient, err := NewHTTPClientForTarget(ctx, baseURL, TargetAuth{}, Opts{
+		anonymousClient, err := NewHTTPClientForTarget(ctx, baseURL, TargetAuth{
+			TrustPrivateNetwork: prepared.TrustPrivateNetwork,
+			AllowInsecure:       allowInsecure,
+		}, Opts{
 			Timeout: DefaultHTTPTimeout,
 		})
 		if err != nil {
@@ -103,17 +102,19 @@ func PrepareWebUI(ctx context.Context, opts PrepareWebUIOptions) (PreparedWebUI,
 
 func resolveWebUIHostTarget(
 	ctx context.Context, opts PrepareWebUIOptions,
-) (baseURL string, configuredRemote, allowInsecure bool, err error) {
+) (ResolvedDaemon, error) {
 	if opts.DaemonName != "" {
-		target, err := resolveNamedDaemonTarget(ctx, opts.DaemonName)
-		if err != nil {
-			return "", false, false, err
-		}
-		return target.BaseURL, !target.Local, target.AllowInsecure, nil
+		return EnsureResolvedNamed(ctx, opts.DaemonName)
 	}
-
-	baseURL, err = EnsureLocalRunning(ctx)
-	return baseURL, false, false, err
+	running, err := EnsureLocalRunningTarget(ctx)
+	if err != nil {
+		return ResolvedDaemon{}, err
+	}
+	source := DaemonSourceLocalRuntime
+	if value, ok := ctx.Value(BaseURLKey{}).(string); ok && value != "" {
+		source = DaemonSourceInjected
+	}
+	return resolvedForRunning(source, "", running).withGlobalAuth(), nil
 }
 
 func discoverWebRuntimeForBaseURL(ctx context.Context, dataDir, baseURL string) (DiscoveredWebRuntime, error) {
@@ -297,11 +298,7 @@ func probeAnonymousReadonlyWebUI(
 }
 
 func validateWebLoginTarget(baseURL string, trustPrivateNetwork, allowInsecure bool) error {
-	if allowInsecure {
-		_, err := config.BearerOriginForBaseURLAllowInsecure(baseURL)
-		return err
-	}
-	_, err := checkBearerTargetSafe(baseURL, trustPrivateNetwork)
+	_, err := bearerPolicyFor(trustPrivateNetwork, allowInsecure).OriginForBaseURL(baseURL)
 	return err
 }
 

--- a/internal/client/webui_test.go
+++ b/internal/client/webui_test.go
@@ -49,12 +49,69 @@ func TestResolveWebUIHostTargetUsesLocalGatewayDespiteRemoteOverride(t *testing.
 	t.Setenv("KATA_SERVER", "https://daemon.example")
 	ctx := context.WithValue(t.Context(), BaseURLKey{}, "http://127.0.0.1:27123")
 
-	baseURL, configuredRemote, allowInsecure, err := resolveWebUIHostTarget(ctx, PrepareWebUIOptions{})
+	resolved, err := resolveWebUIHostTarget(ctx, PrepareWebUIOptions{})
 
 	require.NoError(t, err)
-	assert.Equal(t, "http://127.0.0.1:27123", baseURL)
-	assert.False(t, configuredRemote)
-	assert.False(t, allowInsecure)
+	assert.Equal(t, "http://127.0.0.1:27123", resolved.BaseURL)
+	assert.False(t, resolved.ConfiguredRemote())
+	assert.False(t, resolved.AllowInsecure)
+}
+
+// TestPrepareWebUIBuildsAnonymousClientWithResolvedPolicy covers the actual
+// configured-remote construction path. The anonymous client carries no token,
+// but D2 still requires the target policy that made the selected daemon legal.
+func TestPrepareWebUIBuildsAnonymousClientWithResolvedPolicy(t *testing.T) {
+	stubProbe(t, true)
+	tests := []struct {
+		name              string
+		daemonName        string
+		configBody        string
+		wantTrustPrivate  bool
+		wantAllowInsecure bool
+	}{
+		{
+			name:       "trusted private network literal",
+			daemonName: "trusted-private",
+			configBody: `
+[auth]
+trust_private_network = true
+
+[[daemon]]
+name = "trusted-private"
+url = "http://100.64.0.5:7777"
+`,
+			wantTrustPrivate: true,
+		},
+		{
+			name:       "explicit insecure hostname",
+			daemonName: "insecure-hostname",
+			configBody: `
+[[daemon]]
+name = "insecure-hostname"
+url = "http://daemon.example:7777"
+allow_insecure = true
+`,
+			wantAllowInsecure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("KATA_HOME", home)
+			t.Setenv("KATA_AUTH_TOKEN", "")
+			t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+			require.NoError(t, writeRawConfig(home, tt.configBody))
+
+			prepared, err := PrepareWebUI(t.Context(), PrepareWebUIOptions{DaemonName: tt.daemonName})
+
+			require.NoError(t, err)
+			assert.True(t, prepared.ConfiguredRemote)
+			assert.Equal(t, tt.wantTrustPrivate, prepared.TrustPrivateNetwork)
+			assert.Equal(t, tt.wantAllowInsecure, prepared.AllowInsecure)
+			assert.NotNil(t, prepared.AnonymousClient)
+		})
+	}
 }
 
 func TestOpenWebUILocalTrustedProxyOpensDirectly(t *testing.T) {
@@ -176,6 +233,39 @@ func TestOpenWebUIRemoteLoginRejectsUntrustedPlaintext(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "plaintext non-loopback")
 	assert.False(t, opened)
+}
+
+func TestValidateWebLoginTargetPolicy(t *testing.T) {
+	tests := []struct {
+		name                string
+		baseURL             string
+		trustPrivateNetwork bool
+		allowInsecure       bool
+		wantErr             bool
+	}{
+		{name: "strict rejects plaintext hostname", baseURL: "http://daemon.example", wantErr: true},
+		{name: "strict accepts loopback", baseURL: "http://127.0.0.1:7777"},
+		{name: "strict accepts https", baseURL: "https://daemon.example"},
+		{
+			name: "trust private network accepts private literal", baseURL: "http://100.64.0.5:7777",
+			trustPrivateNetwork: true,
+		},
+		{
+			name: "allow insecure accepts plaintext hostname", baseURL: "http://daemon.example",
+			allowInsecure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWebLoginTarget(tt.baseURL, tt.trustPrivateNetwork, tt.allowInsecure)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestOpenWebUIRemoteAuthenticationOpensCanonicalLoginOrigin(t *testing.T) {

--- a/internal/config/bearer.go
+++ b/internal/config/bearer.go
@@ -7,49 +7,37 @@ import (
 	"net/url"
 )
 
-// ConfigureBearerClient attaches an origin-pinned bearer transport to c. Empty
-// token preserves the no-auth client path and skips target safety checks.
-func ConfigureBearerClient(c *http.Client, baseURL, token string) error {
-	return ConfigureBearerClientWithTrust(c, baseURL, token, resolvedBearerTrustPrivateNetwork())
-}
-
-// ConfigureBearerClientWithTrust is ConfigureBearerClient with an explicit
-// plaintext-private-network trust decision. Empty token preserves the no-auth
-// client path and skips target safety checks.
-func ConfigureBearerClientWithTrust(c *http.Client, baseURL, token string, trustPrivateNetwork bool) error {
+// ConfigureClient attaches an origin-pinned bearer transport to c under this
+// policy.
+//
+// The target is validated whether or not a token is present (decision D2,
+// daemon-strict). An empty token against a safe target installs nothing and
+// returns nil; an unsafe target is an error regardless of token presence, so a
+// misrouted or plaintext-exposed endpoint is reported at construction instead
+// of silently producing a client that will fail later as an opaque 401. Legal
+// deployments stay legal through TrustPrivateNetwork and
+// AllowInsecurePlaintext.
+func (p BearerPolicy) ConfigureClient(c *http.Client, baseURL, token string) error {
 	if c == nil {
 		return fmt.Errorf("nil HTTP client for bearer configuration")
 	}
-	origin := ""
-	var err error
-	if token != "" {
-		origin, err = BearerOriginForBaseURLWithTrust(baseURL, trustPrivateNetwork)
-		if err != nil {
-			return err
-		}
+	origin, err := p.OriginForBaseURL(baseURL)
+	if err != nil {
+		return err
 	}
-	c.Transport = BearerTransportWithTrust(c.Transport, token, origin, trustPrivateNetwork)
+	c.Transport = p.Transport(c.Transport, token, origin)
 	return nil
 }
 
-func resolvedBearerTrustPrivateNetwork() bool {
+// ResolvedBearerTrustPrivateNetwork reports the operator's configured
+// private-network trust decision ([auth].trust_private_network, or
+// KATA_TRUST_PRIVATE_NETWORK when the config cannot be read).
+func ResolvedBearerTrustPrivateNetwork() bool {
 	auth, err := ReadAuthConfig()
 	if err != nil {
 		return EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
 	}
 	return auth.TrustPrivateNetwork
-}
-
-// BearerTransport wraps base with bearer-token injection when token is
-// non-empty. The token is attached only to requests that still target origin.
-func BearerTransport(base http.RoundTripper, token, origin string) http.RoundTripper {
-	return BearerTransportWithTrust(base, token, origin, false)
-}
-
-// BearerTransportWithTrust wraps base with bearer-token injection when token is
-// non-empty, allowing plaintext private-IP targets only when trust is explicit.
-func BearerTransportWithTrust(base http.RoundTripper, token, origin string, trustPrivateNetwork bool) http.RoundTripper {
-	return BearerTransportWithPolicy(base, token, origin, BearerPolicy{TrustPrivateNetwork: trustPrivateNetwork})
 }
 
 // BearerPolicy controls bearer-token target validation.
@@ -62,56 +50,81 @@ type BearerPolicy struct {
 	AllowInsecurePlaintext bool
 }
 
-// BearerTransportWithPolicy wraps base with bearer-token injection when token
-// is non-empty, applying the supplied target-validation policy.
-func BearerTransportWithPolicy(base http.RoundTripper, token, origin string, policy BearerPolicy) http.RoundTripper {
+// CheckTargetURL reports whether u is a safe target for a bearer token under
+// this policy. It is the single definition of that rule: the per-request guard
+// in bearerTransport.RoundTrip, construction-time validation in
+// ConfigureClient, and OriginForBaseURL all go through here.
+//
+// AllowInsecurePlaintext skips the plaintext-exposure judgement but NOT the
+// shape rules — an unparseable scheme or a missing host is still refused, and
+// origin pinning (applied by the transport) still prevents a token following a
+// cross-origin redirect. That combination is what makes an explicit
+// allow_insecure target safe to pin a token to.
+func (p BearerPolicy) CheckTargetURL(u *url.URL) error {
+	if u == nil {
+		return fmt.Errorf("nil URL for bearer-token safety check")
+	}
+	if u.Host == "kata.invalid" {
+		return nil
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme %q for bearer-token client", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("bearer-token target %q must include host", u.Redacted())
+	}
+	if p.AllowInsecurePlaintext || u.Scheme == "https" {
+		return nil
+	}
+	host := u.Hostname()
+	if host == "" || host == "localhost" {
+		return nil
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	if p.TrustPrivateNetwork {
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return fmt.Errorf("plaintext trusted-private-network bearer target %q rejected: address %q is not a literal IP", u.Redacted(), host)
+		}
+		if ip.IsUnspecified() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || cgnatBlock.Contains(ip) {
+			return nil
+		}
+		return fmt.Errorf("plaintext trusted-private-network bearer target %q rejected: address %q is not non-public", u.Redacted(), host)
+	}
+	return fmt.Errorf("refusing to attach bearer token to plaintext non-loopback URL %q - "+
+		"the daemon does not terminate TLS, so the token would travel in cleartext; "+
+		"use a Unix socket or loopback address, tunnel via SSH, terminate TLS "+
+		"in a reverse proxy, or opt into the private network with "+
+		"KATA_TRUST_PRIVATE_NETWORK=1 ([auth].trust_private_network)", u.Redacted())
+}
+
+// OriginForBaseURL validates baseURL under this policy and returns the
+// canonical scheme://host origin the bearer is pinned to.
+func (p BearerPolicy) OriginForBaseURL(baseURL string) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse base URL %q for bearer-token safety check: %w", baseURL, err)
+	}
+	if err := p.CheckTargetURL(u); err != nil {
+		return "", err
+	}
+	return CanonicalHTTPOrigin(baseURL)
+}
+
+// Transport wraps base with bearer-token injection when token is non-empty,
+// applying this policy per request. An empty token returns base unchanged so
+// no-auth deployments incur zero cost; target validation for the empty-token
+// case belongs to ConfigureClient, not here.
+func (p BearerPolicy) Transport(base http.RoundTripper, token, origin string) http.RoundTripper {
 	if token == "" {
 		return base
 	}
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	return &bearerTransport{base: base, token: token, origin: origin, policy: policy}
-}
-
-// BearerOriginForBaseURL validates baseURL as a safe bearer target and returns
-// the scheme://host origin used for redirect pinning.
-func BearerOriginForBaseURL(baseURL string) (string, error) {
-	return BearerOriginForBaseURLWithTrust(baseURL, false)
-}
-
-// BearerOriginForBaseURLWithTrust validates baseURL as a safe bearer target
-// and returns the scheme://host origin used for redirect pinning.
-func BearerOriginForBaseURLWithTrust(baseURL string, trustPrivateNetwork bool) (string, error) {
-	u, err := url.Parse(baseURL)
-	if err != nil {
-		return "", fmt.Errorf("parse base URL %q for bearer-token safety check: %w", baseURL, err)
-	}
-	if err := CheckBearerTargetSafeURLWithTrust(u, trustPrivateNetwork); err != nil {
-		return "", err
-	}
-	return CanonicalHTTPOrigin(baseURL)
-}
-
-// BearerOriginForBaseURLAllowInsecure validates only the URL shape and returns
-// the scheme://host origin used for redirect pinning. It is for explicit
-// per-target allow_insecure configuration where the operator has opted out of
-// plaintext target safety checks.
-func BearerOriginForBaseURLAllowInsecure(baseURL string) (string, error) {
-	u, err := url.Parse(baseURL)
-	if err != nil {
-		return "", fmt.Errorf("parse base URL %q for bearer-token safety check: %w", baseURL, err)
-	}
-	if u.Host == "kata.invalid" {
-		return CanonicalHTTPOrigin(baseURL)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return "", fmt.Errorf("unsupported URL scheme %q for bearer-token client", u.Scheme)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("bearer-token target %q must include host", u.Redacted())
-	}
-	return CanonicalHTTPOrigin(baseURL)
+	return &bearerTransport{base: base, token: token, origin: origin, policy: p}
 }
 
 type bearerTransport struct {
@@ -125,10 +138,8 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.token == "" || req.Header.Get("Authorization") != "" {
 		return t.base.RoundTrip(req)
 	}
-	if !t.policy.AllowInsecurePlaintext {
-		if err := CheckBearerTargetSafeURLWithTrust(req.URL, t.policy.TrustPrivateNetwork); err != nil {
-			return nil, err
-		}
+	if err := t.policy.CheckTargetURL(req.URL); err != nil {
+		return nil, err
 	}
 	reqOrigin, err := CanonicalHTTPOrigin(req.URL.String())
 	if err != nil {
@@ -146,52 +157,6 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	clone := req.Clone(req.Context())
 	clone.Header.Set("Authorization", "Bearer "+t.token)
 	return t.base.RoundTrip(clone)
-}
-
-// CheckBearerTargetSafeURL is the per-request bearer-safety check. Safe
-// targets are the Unix-socket sentinel host, HTTPS, and HTTP loopback.
-func CheckBearerTargetSafeURL(u *url.URL) error {
-	return CheckBearerTargetSafeURLWithTrust(u, false)
-}
-
-// CheckBearerTargetSafeURLWithTrust is the per-request bearer-safety check.
-// Safe targets are the Unix-socket sentinel host, HTTPS, HTTP loopback, and
-// plaintext non-public IP literals only when the operator opted into trusting
-// the private network.
-func CheckBearerTargetSafeURLWithTrust(u *url.URL, trustPrivateNetwork bool) error {
-	if u == nil {
-		return fmt.Errorf("nil URL for bearer-token safety check")
-	}
-	if u.Host == "kata.invalid" {
-		return nil
-	}
-	if u.Scheme == "https" {
-		return nil
-	}
-	if u.Scheme != "http" {
-		return fmt.Errorf("unsupported URL scheme %q for bearer-token client", u.Scheme)
-	}
-	host := u.Hostname()
-	if host == "" || host == "localhost" {
-		return nil
-	}
-	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
-		return nil
-	}
-	if trustPrivateNetwork {
-		ip := net.ParseIP(host)
-		if ip == nil {
-			return fmt.Errorf("plaintext trusted-private-network bearer target %q rejected: address %q is not a literal IP", u.Redacted(), host)
-		}
-		if ip.IsUnspecified() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || cgnatBlock.Contains(ip) {
-			return nil
-		}
-		return fmt.Errorf("plaintext trusted-private-network bearer target %q rejected: address %q is not non-public", u.Redacted(), host)
-	}
-	return fmt.Errorf("refusing to attach bearer token to plaintext non-loopback URL %q - "+
-		"the daemon does not terminate TLS, so the token would travel in cleartext; "+
-		"use a Unix socket or loopback address, tunnel via SSH, or terminate TLS "+
-		"in a reverse proxy", u.Redacted())
 }
 
 // cgnatBlock is RFC6598 100.64.0.0/10. Go's net.IP.IsPrivate() intentionally

--- a/internal/config/bearer_test.go
+++ b/internal/config/bearer_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,7 +52,7 @@ func TestBearerTransportCanonicalOrigin(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			base := &recordingRoundTripper{}
-			transport := BearerTransport(base, "test-token", "https://Daemon.Example:443")
+			transport := (BearerPolicy{}).Transport(base, "test-token", "https://Daemon.Example:443")
 			req, err := http.NewRequest(http.MethodGet, tt.target, nil)
 			require.NoError(t, err)
 
@@ -72,7 +73,7 @@ func TestBearerTransportCanonicalOrigin(t *testing.T) {
 
 func TestBearerTransportCanonicalIPv6ZoneOrigin(t *testing.T) {
 	base := &recordingRoundTripper{}
-	transport := BearerTransport(
+	transport := (BearerPolicy{}).Transport(
 		base,
 		"test-token",
 		"https://[FE80::ABCD%25EnABC]:00443/configured/path",
@@ -90,4 +91,306 @@ func TestBearerTransportCanonicalIPv6ZoneOrigin(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 	assert.Equal(t, 1, base.calls)
 	assert.Equal(t, "Bearer test-token", base.authorization)
+}
+
+// TestBearerTargetPolicyMatrix is the accept/reject contract for bearer
+// targets: every policy combination crossed with every target shape kata can
+// be pointed at. It is the gate for folding the telescoping bearer helpers
+// onto BearerPolicy — the refactor is only safe if this table's answers do
+// not move.
+func TestBearerTargetPolicyMatrix(t *testing.T) {
+	targets := []struct {
+		name string
+		url  string
+	}{
+		{"https public host", "https://daemon.example/api/v1/ping"},
+		{"http loopback literal", "http://127.0.0.1:7777/api/v1/ping"},
+		{"http localhost", "http://localhost:7777/api/v1/ping"},
+		{"http rfc1918 literal", "http://192.168.10.5:7777/api/v1/ping"},
+		{"http cgnat literal", "http://100.64.0.5:7777/api/v1/ping"},
+		{"http public host", "http://daemon.example/api/v1/ping"},
+		{"http private hostname", "http://daemon-host:7777/api/v1/ping"},
+		{"unix sentinel", "http://kata.invalid/api/v1/ping"},
+	}
+	// want[policyName][targetName] = accepted
+	want := map[string]map[string]bool{
+		"strict": {
+			"https public host":     true,
+			"http loopback literal": true,
+			"http localhost":        true,
+			"http rfc1918 literal":  false,
+			"http cgnat literal":    false,
+			"http public host":      false,
+			"http private hostname": false,
+			"unix sentinel":         true,
+		},
+		"trust private network": {
+			"https public host":     true,
+			"http loopback literal": true,
+			"http localhost":        true,
+			"http rfc1918 literal":  true,
+			"http cgnat literal":    true,
+			"http public host":      false,
+			"http private hostname": false,
+			"unix sentinel":         true,
+		},
+		"allow insecure plaintext": {
+			"https public host":     true,
+			"http loopback literal": true,
+			"http localhost":        true,
+			"http rfc1918 literal":  true,
+			"http cgnat literal":    true,
+			"http public host":      true,
+			"http private hostname": true,
+			"unix sentinel":         true,
+		},
+		"allow insecure plaintext and trust": {
+			"https public host":     true,
+			"http loopback literal": true,
+			"http localhost":        true,
+			"http rfc1918 literal":  true,
+			"http cgnat literal":    true,
+			"http public host":      true,
+			"http private hostname": true,
+			"unix sentinel":         true,
+		},
+	}
+	policies := []struct {
+		name   string
+		policy BearerPolicy
+	}{
+		{"strict", BearerPolicy{}},
+		{"trust private network", BearerPolicy{TrustPrivateNetwork: true}},
+		{"allow insecure plaintext", BearerPolicy{AllowInsecurePlaintext: true}},
+		{"allow insecure plaintext and trust", BearerPolicy{AllowInsecurePlaintext: true, TrustPrivateNetwork: true}},
+	}
+
+	for _, p := range policies {
+		for _, target := range targets {
+			t.Run(p.name+"/"+target.name, func(t *testing.T) {
+				u, err := url.Parse(target.url)
+				require.NoError(t, err)
+
+				err = checkTargetUnderPolicy(p.policy, u)
+
+				if want[p.name][target.name] {
+					require.NoError(t, err, "target must be accepted under this policy")
+					return
+				}
+				require.Error(t, err, "target must be rejected under this policy")
+			})
+		}
+	}
+}
+
+// TestBearerTargetAllowInsecureShapeValidation pins that opting into plaintext
+// does not opt out of the URL-shape checks needed to bind a bearer origin.
+func TestBearerTargetAllowInsecureShapeValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy BearerPolicy
+		target string
+	}{
+		{
+			name:   "allow insecure rejects unsupported scheme",
+			policy: BearerPolicy{AllowInsecurePlaintext: true},
+			target: "ftp://daemon.example/api/v1/ping",
+		},
+		{
+			name:   "allow insecure rejects missing host",
+			policy: BearerPolicy{AllowInsecurePlaintext: true},
+			target: "http:///api/v1/ping",
+		},
+		{
+			name:   "allow insecure and trust rejects unsupported scheme",
+			policy: BearerPolicy{AllowInsecurePlaintext: true, TrustPrivateNetwork: true},
+			target: "ftp://daemon.example/api/v1/ping",
+		},
+		{
+			name:   "allow insecure and trust rejects missing host",
+			policy: BearerPolicy{AllowInsecurePlaintext: true, TrustPrivateNetwork: true},
+			target: "http:///api/v1/ping",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.target)
+			require.NoError(t, err)
+
+			require.Error(t, checkTargetUnderPolicy(tt.policy, u), "invalid target shape must be rejected")
+		})
+	}
+}
+
+// checkTargetUnderPolicy is the seam the matrix runs through. It now calls the
+// unified method; the table's answers must be unchanged from Task 4.
+func checkTargetUnderPolicy(p BearerPolicy, u *url.URL) error {
+	return p.CheckTargetURL(u)
+}
+
+// TestBearerTransportPerRequestPolicyMatrix pins that the per-request guard
+// applies the same target rules as construction. The transport is always
+// bound to a safe origin; only the request target varies, which is the
+// redirect-exfiltration shape.
+func TestBearerTransportPerRequestPolicyMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		policy      BearerPolicy
+		target      string
+		wantErr     bool
+		wantReached bool
+	}{
+		{
+			name:        "strict same-origin loopback accepted",
+			policy:      BearerPolicy{},
+			target:      "http://127.0.0.1:7777/api/v1/ping",
+			wantReached: true,
+		},
+		{
+			name:    "strict rejects plaintext private redirect",
+			policy:  BearerPolicy{},
+			target:  "http://192.168.10.5:7777/api/v1/ping",
+			wantErr: true,
+		},
+		{
+			name:    "trust private network still refuses cross-origin",
+			policy:  BearerPolicy{TrustPrivateNetwork: true},
+			target:  "http://192.168.10.5:7777/api/v1/ping",
+			wantErr: true,
+		},
+		{
+			name:    "allow insecure still refuses cross-origin",
+			policy:  BearerPolicy{AllowInsecurePlaintext: true},
+			target:  "http://daemon.example/api/v1/ping",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := &recordingRoundTripper{}
+			rt := tt.policy.Transport(base, "test-token", "http://127.0.0.1:7777")
+			req, err := http.NewRequest(http.MethodGet, tt.target, nil)
+			require.NoError(t, err)
+
+			resp, err := rt.RoundTrip(req)
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.wantReached {
+				assert.Equal(t, 1, base.calls)
+				assert.Equal(t, "Bearer test-token", base.authorization)
+			} else {
+				assert.Zero(t, base.calls, "a rejected target must not reach the base transport")
+			}
+		})
+	}
+}
+
+// TestBearerPolicyConfigureClientEmptyToken pins decision D2: the target is
+// validated whether or not a token is present. An empty token against a safe
+// target configures nothing and succeeds; an unsafe target is an error even
+// with no token, so a misconfigured endpoint is diagnosable instead of a
+// silent no-op that fails later as an opaque 401.
+func TestBearerPolicyConfigureClientEmptyToken(t *testing.T) {
+	tests := []struct {
+		name              string
+		policy            BearerPolicy
+		baseURL           string
+		token             string
+		wantErr           bool
+		wantSameTransport bool
+		wantAuthHeader    string
+	}{
+		{
+			name:              "empty token safe target configures nothing",
+			baseURL:           "http://127.0.0.1:7777",
+			wantSameTransport: true,
+		},
+		{
+			name:              "empty token unsafe target errors",
+			baseURL:           "http://daemon.example",
+			wantErr:           true,
+			wantSameTransport: true,
+		},
+		{
+			name:              "empty token private target errors without trust",
+			baseURL:           "http://192.168.10.5:7777",
+			wantErr:           true,
+			wantSameTransport: true,
+		},
+		{
+			name:              "empty token private target accepted under trust",
+			policy:            BearerPolicy{TrustPrivateNetwork: true},
+			baseURL:           "http://192.168.10.5:7777",
+			wantSameTransport: true,
+		},
+		{
+			name:              "empty token plaintext hostname accepted under allow insecure",
+			policy:            BearerPolicy{AllowInsecurePlaintext: true},
+			baseURL:           "http://daemon-host:7777",
+			wantSameTransport: true,
+		},
+		{
+			name:           "token safe target attaches header",
+			baseURL:        "http://127.0.0.1:7777",
+			token:          "secret",
+			wantAuthHeader: "Bearer secret",
+		},
+		{
+			name:              "token unsafe target errors",
+			baseURL:           "http://daemon.example",
+			token:             "secret",
+			wantErr:           true,
+			wantSameTransport: true,
+		},
+		{
+			name:              "unix sentinel accepted without token",
+			baseURL:           "http://kata.invalid",
+			wantSameTransport: true,
+		},
+		{
+			name:           "unix sentinel accepted with token",
+			baseURL:        "http://kata.invalid",
+			token:          "secret",
+			wantAuthHeader: "Bearer secret",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := &recordingRoundTripper{}
+			c := &http.Client{Transport: base}
+
+			err := tt.policy.ConfigureClient(c, tt.baseURL, tt.token)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Same(t, base, c.Transport,
+					"a rejected target must leave the client's transport untouched")
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantSameTransport {
+				assert.Same(t, base, c.Transport,
+					"an empty token must preserve the client's transport")
+			}
+
+			req, err := http.NewRequest(http.MethodGet, tt.baseURL+"/api/v1/ping", nil)
+			require.NoError(t, err)
+			resp, err := c.Transport.RoundTrip(req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			assert.Equal(t, tt.wantAuthHeader, base.authorization)
+		})
+	}
+}
+
+func TestBearerPolicyConfigureClientRejectsNilClient(t *testing.T) {
+	err := BearerPolicy{}.ConfigureClient(nil, "http://127.0.0.1:7777", "secret")
+	require.Error(t, err)
 }

--- a/internal/daemon/federation_rebind_client_internal_test.go
+++ b/internal/daemon/federation_rebind_client_internal_test.go
@@ -158,6 +158,6 @@ func federationRebindTestBearerClient(
 	t.Helper()
 	origin, err := config.CanonicalHTTPOrigin(baseURL)
 	require.NoError(t, err)
-	httpClient.Transport = config.BearerTransport(httpClient.Transport, token, origin)
+	httpClient.Transport = (config.BearerPolicy{}).Transport(httpClient.Transport, token, origin)
 	return httpClient
 }

--- a/internal/daemon/federation_rebind_service.go
+++ b/internal/daemon/federation_rebind_service.go
@@ -38,7 +38,7 @@ var (
 			Transport: transport.Clone(),
 			Timeout:   federationRebindRequestTimeout,
 		}
-		if err := config.ConfigureBearerClientWithTrust(httpClient, baseURL, token, false); err != nil {
+		if err := (config.BearerPolicy{}).ConfigureClient(httpClient, baseURL, token); err != nil {
 			return nil, err
 		}
 		return httpClient, nil

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -576,17 +576,15 @@ func newClaimHubClient(ctx context.Context, baseURL, token string, allowInsecure
 	}, nil
 }
 
+// configureClaimHubBearerClient pins the hub's own token to the hub origin.
+// This is a hub client, never the local daemon: the local daemon's global
+// token must never reach it.
 func configureClaimHubBearerClient(c *http.Client, baseURL, token string, allowInsecure bool) error {
+	policy := config.BearerPolicy{AllowInsecurePlaintext: allowInsecure}
 	if !allowInsecure {
-		return config.ConfigureBearerClient(c, baseURL, token)
+		policy.TrustPrivateNetwork = config.ResolvedBearerTrustPrivateNetwork()
 	}
-	origin, err := config.BearerOriginForBaseURLAllowInsecure(baseURL)
-	if err != nil {
-		return err
-	}
-	c.Transport = config.BearerTransportWithPolicy(c.Transport, token, origin,
-		config.BearerPolicy{AllowInsecurePlaintext: true})
-	return nil
+	return policy.ConfigureClient(c, baseURL, token)
 }
 
 func newClaimHubHTTPClient(ctx context.Context, baseURL string) (*http.Client, error) {

--- a/internal/daemon/handlers_ui_daemons.go
+++ b/internal/daemon/handlers_ui_daemons.go
@@ -633,23 +633,14 @@ func (g *webDaemonGateway) proxy(d resolvedWebDaemon) (http.Handler, error) {
 }
 
 func webDaemonBearerTransport(d resolvedWebDaemon, trustPrivateNetwork bool) (http.RoundTripper, error) {
-	if d.token == "" {
-		return http.DefaultTransport, nil
-	}
 	policy := config.BearerPolicy{
 		TrustPrivateNetwork: trustPrivateNetwork, AllowInsecurePlaintext: d.allowInsecure,
 	}
-	var origin string
-	var err error
-	if d.allowInsecure {
-		origin, err = config.BearerOriginForBaseURLAllowInsecure(d.baseURL)
-	} else {
-		origin, err = config.BearerOriginForBaseURLWithTrust(d.baseURL, trustPrivateNetwork)
-	}
-	if err != nil {
+	client := &http.Client{Transport: http.DefaultTransport}
+	if err := policy.ConfigureClient(client, d.baseURL, d.token); err != nil {
 		return nil, err
 	}
-	return config.BearerTransportWithPolicy(http.DefaultTransport, d.token, origin, policy), nil
+	return client.Transport, nil
 }
 
 func webDaemonCapabilityPath(path string) bool {

--- a/internal/daemon/handlers_ui_daemons_authorization_test.go
+++ b/internal/daemon/handlers_ui_daemons_authorization_test.go
@@ -468,6 +468,58 @@ func TestWebDaemonBearerTransportRequiresExplicitPlaintextTrust(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestWebDaemonBearerTransportValidatesEmptyTokenTarget(t *testing.T) {
+	tests := []struct {
+		name              string
+		daemon            resolvedWebDaemon
+		trustPrivate      bool
+		wantErr           bool
+		wantBaseTransport bool
+	}{
+		{
+			name:    "strict unsafe target rejected",
+			daemon:  resolvedWebDaemon{baseURL: "http://daemon.example"},
+			wantErr: true,
+		},
+		{
+			name:              "loopback target accepted",
+			daemon:            resolvedWebDaemon{baseURL: "http://127.0.0.1:7777"},
+			wantBaseTransport: true,
+		},
+		{
+			name: "plaintext private target accepted with trust",
+			daemon: resolvedWebDaemon{
+				baseURL: "http://192.168.10.5:7777",
+			},
+			trustPrivate:      true,
+			wantBaseTransport: true,
+		},
+		{
+			name: "plaintext hostname accepted with allow insecure",
+			daemon: resolvedWebDaemon{
+				baseURL: "http://daemon.example", allowInsecure: true,
+			},
+			wantBaseTransport: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport, err := webDaemonBearerTransport(tt.daemon, tt.trustPrivate)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, transport)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantBaseTransport {
+				assert.Same(t, http.DefaultTransport, transport,
+					"an empty token must preserve the base transport")
+			}
+		})
+	}
+}
+
 func TestWebDaemonGatewayRejectsNullSnapshotEnvelope(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/embedding/client.go
+++ b/internal/embedding/client.go
@@ -64,16 +64,17 @@ func New(cfg Config) (*Client, error) {
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	origin, err := config.BearerOriginForBaseURLWithTrust(cfg.BaseURL, cfg.TrustPrivateNetwork)
+	policy := config.BearerPolicy{TrustPrivateNetwork: cfg.TrustPrivateNetwork}
+	origin, err := policy.OriginForBaseURL(cfg.BaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("embedding: configure client: %w", err)
 	}
 	hc := &http.Client{
 		Timeout: timeout,
 		Transport: &embeddingTransport{
-			origin:              origin,
-			apiKey:              cfg.APIKey,
-			trustPrivateNetwork: cfg.TrustPrivateNetwork,
+			origin: origin,
+			apiKey: cfg.APIKey,
+			policy: policy,
 		},
 	}
 	return &Client{
@@ -87,10 +88,10 @@ func New(cfg Config) (*Client, error) {
 }
 
 type embeddingTransport struct {
-	base                http.RoundTripper
-	origin              string
-	apiKey              string
-	trustPrivateNetwork bool
+	base   http.RoundTripper
+	origin string
+	apiKey string
+	policy config.BearerPolicy
 }
 
 func (t *embeddingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -98,7 +99,7 @@ func (t *embeddingTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	if err := config.CheckBearerTargetSafeURLWithTrust(req.URL, t.trustPrivateNetwork); err != nil {
+	if err := t.policy.CheckTargetURL(req.URL); err != nil {
 		return nil, err
 	}
 	if reqOrigin := req.URL.Scheme + "://" + req.URL.Host; reqOrigin != t.origin {

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -138,9 +138,11 @@ func TestTUIFederationClientsKeepAuthRolesSeparate(t *testing.T) {
 	require.NoError(t, err)
 	spoke := NewClient(spokeSrv.URL, spokeHTTP)
 	hubAdmin, _, err := newHubAdminClient(ctx, daemonTarget{
-		Name:  "hub",
-		URL:   hubSrv.URL,
-		Token: "hub-admin-token",
+		Name: "hub",
+		URL:  hubSrv.URL,
+		resolved: clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceInjected, BaseURL: hubSrv.URL, Token: "hub-admin-token",
+		},
 	})
 	require.NoError(t, err)
 
@@ -223,12 +225,175 @@ func TestClientGetInstanceDecodesAuthPrincipal(t *testing.T) {
 
 func TestTUIHubAdminClientRejectsPlainHTTPHostnameWithoutAllowInsecure(t *testing.T) {
 	_, _, err := newHubAdminClient(context.Background(), daemonTarget{
-		Name:  "hub",
-		URL:   "http://hub.internal:7777",
-		Token: "hub-admin-token",
+		Name: "hub",
+		URL:  "http://hub.internal:7777",
+		resolved: clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceInjected, BaseURL: "http://hub.internal:7777", Token: "hub-admin-token",
+		},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "allow_insecure")
+}
+
+func TestTUIHubAdminClientResolvesMatchedLeaveTargetTokenEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("HUB_ADMIN_TOKEN", "catalog-env-token")
+	srv := startTUIPingServer(t)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "hub"
+url = "`+srv.URL+`"
+token_env = "HUB_ADMIN_TOKEN"
+`), 0o600))
+	m := newTestModel()
+	m.daemonTargets = daemonTargetsFromConfig([]config.CatalogDaemonConfig{{ //nolint:gosec // Fake credential environment name verifies catalog lookup.
+		Name: "hub", URL: srv.URL, TokenEnv: "HUB_ADMIN_TOKEN",
+	}})
+	target := m.federationLeaveHubTarget(srv.URL, false)
+
+	_, resolved, err := newHubAdminClient(t.Context(), target)
+
+	require.NoError(t, err)
+	assert.Equal(t, "catalog-env-token", resolved.resolved.Token)
+	assert.Equal(t, srv.URL, resolved.resolved.BaseURL)
+}
+
+func TestTUIHubAdminClientDoesNotSendGlobalDaemonTokenToCatalogHub(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		credential string
+		token      string
+		tokenEnv   string
+	}{
+		{ //nolint:gosec // Fake credential literals exercise the catalog-token boundary.
+			name:       "literal token",
+			credential: "token = \"hub-token\"",
+			token:      "hub-token",
+		},
+		{ //nolint:gosec // Fake credential literals exercise the catalog-token boundary.
+			name:       "token env",
+			credential: "token_env = \"HUB_CATALOG_TOKEN\"",
+			tokenEnv:   "HUB_CATALOG_TOKEN",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("KATA_HOME", home)
+			t.Setenv("KATA_AUTH_TOKEN", "local-daemon-token")
+			if tt.tokenEnv != "" {
+				t.Setenv(tt.tokenEnv, "hub-token")
+			}
+			var gotAuth string
+			var allAuth []string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if auth := r.Header.Get("Authorization"); auth != "" {
+					allAuth = append(allAuth, auth)
+				}
+				switch r.URL.Path {
+				case "/api/v1/ping":
+					respondJSON(t, w, map[string]any{"ok": true, "service": "kata", "version": "test"})
+				case "/api/v1/instance":
+					gotAuth = r.Header.Get("Authorization")
+					respondJSON(t, w, map[string]any{"instance_uid": "01HZNQ7VFPK1XGD8R5MABCD4EA"})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "hub"
+url = "`+srv.URL+`"
+`+tt.credential+`
+`), 0o600))
+			targets := daemonTargetsFromConfig([]config.CatalogDaemonConfig{{
+				Name: "hub", URL: srv.URL, Token: tt.token, TokenEnv: tt.tokenEnv,
+			}})
+
+			hub, _, err := newHubAdminClient(t.Context(), targets[0])
+			require.NoError(t, err)
+			_, err = hub.GetInstance(t.Context())
+			require.NoError(t, err)
+
+			assert.Equal(t, "Bearer hub-token", gotAuth)
+			assert.NotContains(t, allAuth, "Bearer local-daemon-token")
+		})
+	}
+}
+
+func TestTUIHubAdminClientInjectedRemoteRetainsPrivateNetworkTrustWithoutGlobalToken(t *testing.T) {
+	endpoint := "http://100.64.0.5:7777"
+	for _, tt := range []struct {
+		name   string
+		target func() daemonTarget
+	}{
+		{
+			name: "leave fallback",
+			target: func() daemonTarget {
+				m := newTestModel()
+				m.daemonTargets = []daemonTarget{{Name: "local", Local: true}}
+				return m.federationLeaveHubTarget(endpoint, false)
+			},
+		},
+		{
+			name: "empty resolved base URL",
+			target: func() daemonTarget {
+				return daemonTarget{
+					URL: endpoint,
+					resolved: clientpkg.ResolvedDaemon{
+						Source: clientpkg.DaemonSourceInjected,
+					},
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("KATA_HOME", home)
+			t.Setenv("KATA_AUTH_TOKEN", "local-daemon-token")
+			t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
+			require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte("[auth\n"), 0o600))
+
+			hub, resolved, err := newHubAdminClient(t.Context(), tt.target())
+
+			require.NoError(t, err)
+			require.NotNil(t, hub)
+			assert.Equal(t, endpoint, resolved.resolved.BaseURL)
+			assert.True(t, resolved.resolved.TrustPrivateNetwork)
+			assert.Empty(t, resolved.resolved.Token,
+				"the local daemon token must never be sent to an injected hub")
+		})
+	}
+}
+
+func TestTUIHubAdminClientLocalNamedTargetRetainsLocalDaemonGlobalAuth(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "local-daemon-token")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "local"
+local = true
+`), 0o600))
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		respondJSON(t, w, map[string]any{"instance_uid": "01HZNQ7VFPK1XGD8R5MABCD4EA"})
+	}))
+	t.Cleanup(srv.Close)
+	ctx := context.WithValue(t.Context(), clientpkg.BaseURLKey{}, srv.URL)
+	target := daemonTargetsFromConfig([]config.CatalogDaemonConfig{{
+		Name: "local", Local: true,
+	}})[0]
+
+	hub, resolved, err := newHubAdminClient(ctx, target)
+	require.NoError(t, err)
+	_, err = hub.GetInstance(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer local-daemon-token", gotAuth)
+	assert.Equal(t, "local-daemon-token", resolved.resolved.Token)
 }
 
 func TestTUIHubEnrollmentClientCarriesAllowInsecureForPlainHTTPHostname(t *testing.T) {

--- a/internal/tui/daemon_target.go
+++ b/internal/tui/daemon_target.go
@@ -14,17 +14,14 @@ import (
 )
 
 type daemonTarget struct {
-	Name                 string
-	Local                bool
-	URL                  string
-	Token                string
-	TokenEnv             string
-	AllowInsecure        bool
-	Implicit             bool
-	ConfiguredRemote     bool
-	UseAuthTokenOverride bool
-	workspaceStart       string
-	skipInitialScope     bool
+	Name             string
+	Local            bool
+	URL              string
+	TokenEnv         string
+	Implicit         bool
+	resolved         client.ResolvedDaemon
+	workspaceStart   string
+	skipInitialScope bool
 }
 
 type daemonConnection struct {
@@ -44,50 +41,22 @@ const (
 )
 
 var (
-	readDaemonConfigForTUI   = config.ReadDaemonConfig
-	ensureRunningForTUI      = client.EnsureRunningTargetInWorkspace
-	ensureLocalRunningForTUI = client.EnsureLocalRunning
-	normalizeRemoteURLForTUI = func(v string, allowInsecure bool) (string, error) {
+	readDaemonConfigForTUI         = config.ReadDaemonConfig
+	ensureResolvedForTUI           = client.EnsureResolvedInWorkspace
+	ensureLocalRunningTargetForTUI = client.EnsureLocalRunningTarget
+	ensureResolvedNamedForTUI      = client.EnsureResolvedNamed
+	normalizeRemoteURLForTUI       = func(v string, allowInsecure bool) (string, error) {
 		return client.NormalizeRemoteURL(v, allowInsecure)
-	}
-	probeRemoteForTUI = func(ctx context.Context, base string) bool {
-		return client.Ping(ctx, &http.Client{Timeout: remoteProbeTimeout}, base)
 	}
 	newHTTPClientForTUI = func(
 		ctx context.Context,
-		endpoint string,
+		_ string,
 		target daemonTarget,
 		kind clientOptsKind,
 	) (*http.Client, error) {
 		opts := optsForKind(kind)
 		opts.WorkspaceStart = target.workspaceStart
-		if target.Local || target.Implicit {
-			if target.Implicit {
-				opts.AllowInsecure = target.AllowInsecure ||
-					client.RemoteAllowInsecureForBaseURL(endpoint, target.workspaceStart)
-			}
-			if target.Token != "" {
-				return client.NewHTTPClientWithBearer(ctx, endpoint, target.Token, opts)
-			}
-			if target.Local && target.Name != "" {
-				opts.DaemonName = target.Name
-			}
-			return client.NewHTTPClient(ctx, endpoint, opts)
-		}
-		auth := effectiveGlobalAuthForTUI()
-		token := target.Token
-		if target.UseAuthTokenOverride {
-			if envToken := authTokenEnvOverrideForTUI(); envToken != "" {
-				token = envToken
-			}
-		}
-		return client.NewHTTPClientForTarget(ctx, endpoint,
-			client.TargetAuth{
-				Token:               token,
-				AllowInsecure:       target.AllowInsecure,
-				TrustPrivateNetwork: auth.TrustPrivateNetwork,
-			},
-			opts)
+		return client.NewHTTPClientForResolved(ctx, target.resolved, opts)
 	}
 	bootResolveScopeForTUI         = bootResolveScope
 	bootResolveScopePathFreeForTUI = bootResolveScopePathFree
@@ -98,12 +67,13 @@ func daemonTargetsFromConfig(daemons []config.CatalogDaemonConfig) []daemonTarge
 	out := make([]daemonTarget, 0, len(daemons))
 	for _, d := range daemons {
 		out = append(out, daemonTarget{
-			Name:          d.Name,
-			Local:         d.Local,
-			URL:           d.URL,
-			Token:         d.Token,
-			TokenEnv:      d.TokenEnv,
-			AllowInsecure: d.AllowInsecure,
+			Name:     d.Name,
+			Local:    d.Local,
+			URL:      d.URL,
+			TokenEnv: d.TokenEnv,
+			resolved: client.ResolvedDaemon{
+				Token: d.Token, AllowInsecure: d.AllowInsecure,
+			},
 		})
 	}
 	return out
@@ -178,15 +148,15 @@ func daemonTargetWithLaunchSelectors(target daemonTarget, opts Options) daemonTa
 func connectImplicitDaemonTarget(
 	ctx context.Context, workspaceStart string, skipInitialScope bool,
 ) (daemonConnection, error) {
-	running, err := ensureRunningForTUI(ctx, workspaceStart)
+	resolved, err := ensureResolvedForTUI(ctx, workspaceStart)
 	if err != nil {
 		return daemonConnection{}, err
 	}
-	target := implicitDaemonTarget(running.BaseURL)
-	target.ConfiguredRemote = running.ConfiguredRemote
+	target := implicitDaemonTarget(resolved.BaseURL)
+	target.resolved = resolved
 	target.workspaceStart = workspaceStart
 	target.skipInitialScope = skipInitialScope
-	return connectResolvedDaemonTarget(ctx, target, running.BaseURL)
+	return connectResolvedDaemonTarget(ctx, target, resolved.BaseURL)
 }
 
 func initialScopeDirective(opts Options) (string, bool, error) {
@@ -199,41 +169,20 @@ func initialScopeDirective(opts Options) (string, bool, error) {
 }
 
 func connectDaemonTarget(ctx context.Context, target daemonTarget) (daemonConnection, error) {
-	var err error
-	target.UseAuthTokenOverride = true
-	target, err = resolveDaemonTargetToken(target)
+	resolved, err := ensureResolvedNamedForTUI(ctx, target.Name)
 	if err != nil {
 		return daemonConnection{}, err
 	}
-	endpoint, err := resolveDaemonEndpoint(ctx, target)
-	if err != nil {
-		return daemonConnection{}, err
+	target.resolved = resolved
+	if target.Local {
+		target.URL = ""
+	} else {
+		target.URL = resolved.BaseURL
 	}
-	return connectResolvedDaemonTarget(ctx, target, endpoint)
-}
-
-func resolveDaemonTargetToken(target daemonTarget) (daemonTarget, error) {
-	if target.UseAuthTokenOverride && !target.Local {
-		if token := authTokenEnvOverrideForTUI(); token != "" {
-			target.Token = token
-			target.TokenEnv = ""
-			return target, nil
-		}
-	}
-	if target.TokenEnv == "" {
-		return target, nil
-	}
-	token := strings.TrimSpace(os.Getenv(target.TokenEnv))
-	if token == "" {
-		return target, fmt.Errorf("daemon %q: token_env %q is unset or empty",
-			daemonTargetDisplay(target), target.TokenEnv)
-	}
-	target.Token = token
-	return target, nil
+	return connectResolvedDaemonTarget(ctx, target, resolved.BaseURL)
 }
 
 func connectResolvedDaemonTarget(ctx context.Context, target daemonTarget, endpoint string) (daemonConnection, error) {
-	target = resolvedDaemonTarget(target, endpoint)
 	hc, err := newHTTPClientForTUI(ctx, endpoint, target, clientOptsNormal)
 	if err != nil {
 		return daemonConnection{}, err
@@ -274,7 +223,7 @@ func daemonTargetUsesRemoteFilesystem(target daemonTarget, endpoint string) bool
 	if target.Local || endpoint == client.UnixBase {
 		return false
 	}
-	if target.ConfiguredRemote {
+	if target.resolved.ConfiguredRemote() {
 		return true
 	}
 	if !target.Implicit {
@@ -292,66 +241,16 @@ func localHTTPClientRefreshForTarget(
 	endpoint string, target daemonTarget,
 ) func(context.Context) (*http.Client, error) {
 	return func(ctx context.Context) (*http.Client, error) {
-		refreshedEndpoint := endpoint
+		refreshedTarget := target
 		if target.Local || endpoint == client.UnixBase {
-			var err error
-			refreshedEndpoint, err = ensureLocalRunningForTUI(ctx)
+			running, err := ensureLocalRunningTargetForTUI(ctx)
 			if err != nil {
 				return nil, err
 			}
+			refreshedTarget.resolved = target.resolved.WithRunning(running)
 		}
-		refreshedTarget := resolvedDaemonTarget(target, refreshedEndpoint)
-		return newHTTPClientForTUI(ctx, refreshedEndpoint, refreshedTarget, clientOptsNormal)
+		return newHTTPClientForTUI(ctx, refreshedTarget.resolved.BaseURL, refreshedTarget, clientOptsNormal)
 	}
-}
-
-func resolveDaemonEndpoint(ctx context.Context, target daemonTarget) (string, error) {
-	if target.Local {
-		return ensureLocalRunningForTUI(ctx)
-	}
-	endpoint, err := normalizeRemoteURLForTUI(target.URL, target.AllowInsecure)
-	if err != nil {
-		return "", err
-	}
-	if !probeRemoteForTUI(ctx, endpoint) {
-		return "", fmt.Errorf("%w: %s", client.ErrRemoteUnavailable, endpoint)
-	}
-	return endpoint, nil
-}
-
-func resolvedDaemonTarget(target daemonTarget, endpoint string) daemonTarget {
-	target.URL = endpoint
-	if target.Local {
-		target.URL = ""
-	} else if target.Implicit {
-		target.AllowInsecure = client.RemoteAllowInsecureForBaseURL(
-			endpoint, target.workspaceStart,
-		)
-	}
-	if (target.Local || target.Implicit) && target.Token == "" {
-		target.Token = effectiveGlobalAuthTokenForTUI()
-	}
-	return target
-}
-
-func effectiveGlobalAuthTokenForTUI() string {
-	return strings.TrimSpace(effectiveGlobalAuthForTUI().Token)
-}
-
-func effectiveGlobalAuthForTUI() config.AuthConfig {
-	auth, err := config.ReadAuthConfig()
-	if err != nil {
-		auth.TrustPrivateNetwork = config.EnvTruthy("KATA_TRUST_PRIVATE_NETWORK")
-	}
-	if token := authTokenEnvOverrideForTUI(); token != "" {
-		auth.Token = token
-	}
-	return auth
-}
-
-func authTokenEnvOverrideForTUI() string {
-	envToken := strings.TrimSpace(os.Getenv("KATA_AUTH_TOKEN"))
-	return envToken
 }
 
 func implicitDaemonTarget(endpoint string) daemonTarget {

--- a/internal/tui/daemon_target_test.go
+++ b/internal/tui/daemon_target_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -28,10 +30,10 @@ func TestDaemonTargetsFromConfigIncludesConfiguredEntries(t *testing.T) {
 	require.Len(t, targets, 2)
 	assert.Equal(t, daemonTarget{Name: "local", Local: true}, targets[0])
 	assert.Equal(t, daemonTarget{ //nolint:gosec // env var name, not a credential
-		Name:          "shared",
-		URL:           "http://100.64.0.5:7777",
-		TokenEnv:      "KATA_SHARED_TOKEN",
-		AllowInsecure: true,
+		Name:     "shared",
+		URL:      "http://100.64.0.5:7777",
+		TokenEnv: "KATA_SHARED_TOKEN",
+		resolved: clientpkg.ResolvedDaemon{AllowInsecure: true},
 	}, targets[1])
 }
 
@@ -66,25 +68,28 @@ func TestDaemonTargetDisplayLocalFallback(t *testing.T) {
 }
 
 func TestConnectDaemonTargetLocalUsesLocalOnlyEnsurePath(t *testing.T) {
-	oldEnsure := ensureRunningForTUI
-	oldEnsureLocal := ensureLocalRunningForTUI
+	oldEnsure := ensureResolvedForTUI
+	oldEnsureNamed := ensureResolvedNamedForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
 	t.Cleanup(func() {
-		ensureRunningForTUI = oldEnsure
-		ensureLocalRunningForTUI = oldEnsureLocal
+		ensureResolvedForTUI = oldEnsure
+		ensureResolvedNamedForTUI = oldEnsureNamed
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
 	})
 
 	var ensured bool
-	ensureRunningForTUI = func(context.Context, string) (clientpkg.RunningDaemon, error) {
+	ensureResolvedForTUI = func(context.Context, string) (clientpkg.ResolvedDaemon, error) {
 		t.Fatal("explicit local target must not honor remote-aware EnsureRunning")
-		return clientpkg.RunningDaemon{}, nil
+		return clientpkg.ResolvedDaemon{}, nil
 	}
-	ensureLocalRunningForTUI = func(context.Context) (string, error) {
+	ensureResolvedNamedForTUI = func(_ context.Context, name string) (clientpkg.ResolvedDaemon, error) {
 		ensured = true
-		return "http://kata.invalid", nil
+		require.Equal(t, "local", name)
+		return clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceNamedCatalog, Name: name, BaseURL: "http://kata.invalid",
+		}, nil
 	}
 	newHTTPClientForTUI = func(_ context.Context, _ string, _ daemonTarget, _ clientOptsKind) (*http.Client, error) {
 		return &http.Client{}, nil
@@ -206,18 +211,18 @@ func TestConnectImplicitConfiguredLoopbackUsesPathFreeBoot(t *testing.T) {
 					0o600))
 			}
 
-			oldEnsure := ensureRunningForTUI
+			oldEnsure := ensureResolvedForTUI
 			oldNewClient := newHTTPClientForTUI
 			oldBootScope := bootResolveScopeForTUI
 			oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 			t.Cleanup(func() {
-				ensureRunningForTUI = oldEnsure
+				ensureResolvedForTUI = oldEnsure
 				newHTTPClientForTUI = oldNewClient
 				bootResolveScopeForTUI = oldBootScope
 				bootResolveScopePathFreeForTUI = oldPathFreeBootScope
 			})
 
-			ensureRunningForTUI = clientpkg.EnsureRunningTargetInWorkspace
+			ensureResolvedForTUI = clientpkg.EnsureResolvedInWorkspace
 			newHTTPClientForTUI = func(
 				context.Context,
 				string,
@@ -262,19 +267,19 @@ url = "http://daemon.internal:7777"
 allow_insecure = true
 `), 0o600))
 
-	oldEnsure := ensureRunningForTUI
+	oldEnsure := ensureResolvedForTUI
 	oldBootScope := bootResolveScopeForTUI
 	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 	t.Cleanup(func() {
-		ensureRunningForTUI = oldEnsure
+		ensureResolvedForTUI = oldEnsure
 		bootResolveScopeForTUI = oldBootScope
 		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
 	})
-	ensureRunningForTUI = func(_ context.Context, gotWorkspace string) (clientpkg.RunningDaemon, error) {
+	ensureResolvedForTUI = func(_ context.Context, gotWorkspace string) (clientpkg.ResolvedDaemon, error) {
 		assert.Equal(t, workspace, gotWorkspace)
-		return clientpkg.RunningDaemon{
-			BaseURL:          "http://daemon.internal:7777",
-			ConfiguredRemote: true,
+		return clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceLocalConfig, BaseURL: "http://daemon.internal:7777",
+			Token: "workspace-token", AllowInsecure: true,
 		}, nil
 	}
 	bootResolveScopeForTUI = func(context.Context, *Client, string) (bootInit, error) {
@@ -288,21 +293,21 @@ allow_insecure = true
 	conn, err := connectImplicitDaemonTarget(t.Context(), workspace, false)
 
 	require.NoError(t, err)
-	assert.True(t, conn.target.AllowInsecure)
+	assert.True(t, conn.target.resolved.AllowInsecure)
 	require.NotNil(t, conn.api)
 	require.NotNil(t, conn.sseHC)
 }
 
 func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *testing.T) {
 	oldRead := readDaemonConfigForTUI
-	oldEnsure := ensureRunningForTUI
-	oldEnsureLocal := ensureLocalRunningForTUI
+	oldEnsure := ensureResolvedForTUI
+	oldEnsureLocal := ensureLocalRunningTargetForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
 	t.Cleanup(func() {
 		readDaemonConfigForTUI = oldRead
-		ensureRunningForTUI = oldEnsure
-		ensureLocalRunningForTUI = oldEnsureLocal
+		ensureResolvedForTUI = oldEnsure
+		ensureLocalRunningTargetForTUI = oldEnsureLocal
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
 	})
@@ -313,13 +318,15 @@ func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *t
 	t.Chdir(t.TempDir())
 	workspace := t.TempDir()
 	var ensuredWorkspace string
-	ensureRunningForTUI = func(_ context.Context, workspace string) (clientpkg.RunningDaemon, error) {
+	ensureResolvedForTUI = func(_ context.Context, workspace string) (clientpkg.ResolvedDaemon, error) {
 		ensuredWorkspace = workspace
-		return clientpkg.RunningDaemon{BaseURL: "http://kata.invalid"}, nil
+		return clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceLocalRuntime, BaseURL: "http://kata.invalid",
+		}, nil
 	}
-	ensureLocalRunningForTUI = func(context.Context) (string, error) {
+	ensureLocalRunningTargetForTUI = func(context.Context) (clientpkg.RunningDaemon, error) {
 		t.Fatal("implicit default boot must keep existing remote-aware EnsureRunning behavior")
-		return "", nil
+		return clientpkg.RunningDaemon{}, nil
 	}
 	newHTTPClientForTUI = func(_ context.Context, _ string, _ daemonTarget, _ clientOptsKind) (*http.Client, error) {
 		return &http.Client{}, nil
@@ -344,20 +351,20 @@ func TestBootDaemonConnectionWithoutActiveKeepsRemoteAwareEnsureRunningPath(t *t
 
 func TestBootDaemonConnectionDefinitiveTargetSkipsCWDResolution(t *testing.T) {
 	oldRead := readDaemonConfigForTUI
-	oldEnsure := ensureRunningForTUI
+	oldEnsure := ensureResolvedForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
 	t.Cleanup(func() {
 		readDaemonConfigForTUI = oldRead
-		ensureRunningForTUI = oldEnsure
+		ensureResolvedForTUI = oldEnsure
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
 	})
 	readDaemonConfigForTUI = func() (*config.DaemonConfig, error) {
 		return &config.DaemonConfig{}, nil
 	}
-	ensureRunningForTUI = func(context.Context, string) (clientpkg.RunningDaemon, error) {
-		return clientpkg.RunningDaemon{BaseURL: clientpkg.UnixBase}, nil
+	ensureResolvedForTUI = func(context.Context, string) (clientpkg.ResolvedDaemon, error) {
+		return clientpkg.ResolvedDaemon{Source: clientpkg.DaemonSourceLocalRuntime, BaseURL: clientpkg.UnixBase}, nil
 	}
 	newHTTPClientForTUI = func(_ context.Context, _ string, _ daemonTarget, _ clientOptsKind) (*http.Client, error) {
 		return &http.Client{}, nil
@@ -421,13 +428,13 @@ func TestBootDaemonConnectionOptionsDaemonNameOverridesActiveDaemon(t *testing.T
 
 func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testing.T) {
 	oldRead := readDaemonConfigForTUI
-	oldEnsure := ensureRunningForTUI
+	oldEnsure := ensureResolvedForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
 	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 	t.Cleanup(func() {
 		readDaemonConfigForTUI = oldRead
-		ensureRunningForTUI = oldEnsure
+		ensureResolvedForTUI = oldEnsure
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
 		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
@@ -436,10 +443,9 @@ func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testin
 	readDaemonConfigForTUI = func() (*config.DaemonConfig, error) {
 		return &config.DaemonConfig{}, nil
 	}
-	ensureRunningForTUI = func(context.Context, string) (clientpkg.RunningDaemon, error) {
-		return clientpkg.RunningDaemon{
-			BaseURL:          "https://daemon.example:7777",
-			ConfiguredRemote: true,
+	ensureResolvedForTUI = func(context.Context, string) (clientpkg.ResolvedDaemon, error) {
+		return clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceServerEnv, BaseURL: "https://daemon.example:7777",
 		}, nil
 	}
 	newHTTPClientForTUI = func(_ context.Context, _ string, _ daemonTarget, _ clientOptsKind) (*http.Client, error) {
@@ -459,24 +465,30 @@ func TestBootDaemonConnectionWithoutActiveLabelsImplicitRemoteEndpoint(t *testin
 }
 
 func TestResolvedImplicitRemoteTargetCarriesEnvAllowInsecure(t *testing.T) {
-	endpoint := "http://spoke.internal:7777"
-	t.Setenv("KATA_SERVER", endpoint)
+	srv := startTUIPingServer(t)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_SERVER", srv.URL)
 	t.Setenv("KATA_ALLOW_INSECURE", "1")
 
-	target := resolvedDaemonTarget(implicitDaemonTarget(endpoint), endpoint)
+	resolved, ok, err := clientpkg.ResolveRemoteDaemon(t.Context(), "")
 
-	assert.True(t, target.AllowInsecure)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.True(t, resolved.AllowInsecure)
 }
 
 func TestResolvedImplicitRemoteTargetCarriesGlobalAuthToken(t *testing.T) {
-	endpoint := "http://spoke.internal:7777"
-	t.Setenv("KATA_SERVER", endpoint)
+	srv := startTUIPingServer(t)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_SERVER", srv.URL)
 	t.Setenv("KATA_ALLOW_INSECURE", "1")
 	t.Setenv("KATA_AUTH_TOKEN", "global-token")
 
-	target := resolvedDaemonTarget(implicitDaemonTarget(endpoint), endpoint)
+	resolved, ok, err := clientpkg.ResolveRemoteDaemon(t.Context(), "")
 
-	assert.Equal(t, "global-token", target.Token)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "global-token", resolved.Token)
 }
 
 func TestResolvedImplicitRemoteTargetEnvTokenOverridesAuthConfig(t *testing.T) {
@@ -487,10 +499,13 @@ func TestResolvedImplicitRemoteTargetEnvTokenOverridesAuthConfig(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
 		[]byte("[auth]\ntoken = \"bootstrap-token\"\nrequire_token_identity = true\n"), 0o600))
 
-	endpoint := "http://spoke.internal:7777"
-	target := resolvedDaemonTarget(implicitDaemonTarget(endpoint), endpoint)
+	srv := startTUIPingServer(t)
+	t.Setenv("KATA_SERVER", srv.URL)
+	resolved, ok, err := clientpkg.ResolveRemoteDaemon(t.Context(), "")
 
-	assert.Equal(t, "client-db-token", target.Token)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "client-db-token", resolved.Token)
 }
 
 func TestConnectResolvedImplicitRemoteUsesEnvTokenForHTTPClient(t *testing.T) {
@@ -522,11 +537,15 @@ func TestConnectResolvedImplicitRemoteUsesEnvTokenForHTTPClient(t *testing.T) {
 		return bootInit{view: viewEmpty, scope: scope{empty: true}}, nil
 	}
 
-	conn, err := connectResolvedDaemonTarget(t.Context(), implicitDaemonTarget(srv.URL), srv.URL)
+	target := implicitDaemonTarget(srv.URL)
+	target.resolved = clientpkg.ResolvedDaemon{
+		Source: clientpkg.DaemonSourceServerEnv, BaseURL: srv.URL, Token: "client-db-token",
+	}
+	conn, err := connectResolvedDaemonTarget(t.Context(), target, srv.URL)
 
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer client-db-token", gotAuth)
-	assert.Equal(t, "client-db-token", conn.target.Token)
+	assert.Equal(t, "client-db-token", conn.target.resolved.Token)
 }
 
 func TestNewHTTPClientForTUIResolvedImplicitRemoteHonorsTrustPrivateNetwork(t *testing.T) {
@@ -534,9 +553,13 @@ func TestNewHTTPClientForTUIResolvedImplicitRemoteHonorsTrustPrivateNetwork(t *t
 	t.Setenv("KATA_AUTH_TOKEN", "global-token")
 	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "1")
 	endpoint := "http://100.64.0.5:7777"
-	target := resolvedDaemonTarget(implicitDaemonTarget(endpoint), endpoint)
-	require.Equal(t, "global-token", target.Token)
-	require.False(t, target.AllowInsecure)
+	target := implicitDaemonTarget(endpoint)
+	target.resolved = clientpkg.ResolvedDaemon{
+		Source: clientpkg.DaemonSourceServerEnv, BaseURL: endpoint,
+		Token: "global-token", TrustPrivateNetwork: true,
+	}
+	require.Equal(t, "global-token", target.resolved.Token)
+	require.False(t, target.resolved.AllowInsecure)
 
 	_, err := newHTTPClientForTUI(t.Context(), endpoint, target, clientOptsNormal)
 
@@ -552,7 +575,12 @@ func TestNewHTTPClientForTUILocalFallsBackToGlobalAuth(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	hc, err := newHTTPClientForTUI(t.Context(), srv.URL, daemonTarget{Local: true}, clientOptsNormal)
+	hc, err := newHTTPClientForTUI(t.Context(), srv.URL, daemonTarget{
+		Local: true,
+		resolved: clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceLocalRuntime, BaseURL: srv.URL, Token: "global-token",
+		},
+	}, clientOptsNormal)
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
@@ -564,6 +592,8 @@ func TestNewHTTPClientForTUILocalFallsBackToGlobalAuth(t *testing.T) {
 }
 
 func TestNewHTTPClientForTUIExplicitLocalBypassesActiveDaemonAuth(t *testing.T) {
+	originalEnsureResolvedNamed := ensureResolvedNamedForTUI
+	t.Cleanup(func() { ensureResolvedNamedForTUI = originalEnsureResolvedNamed })
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
 	t.Setenv("KATA_REMOTE_TOKEN", "")
@@ -573,6 +603,12 @@ func TestNewHTTPClientForTUIExplicitLocalBypassesActiveDaemonAuth(t *testing.T) 
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(srv.Close)
+	ensureResolvedNamedForTUI = func(context.Context, string) (clientpkg.ResolvedDaemon, error) {
+		return clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceNamedCatalog, Name: "local",
+			BaseURL: srv.URL, Token: "global-token",
+		}, nil
+	}
 	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
 active_daemon = "remote"
 
@@ -590,7 +626,10 @@ token_env = "KATA_REMOTE_TOKEN"
 `), 0o600))
 
 	hc, err := newHTTPClientForTUI(t.Context(), srv.URL,
-		daemonTarget{Name: "local", Local: true}, clientOptsNormal)
+		daemonTarget{Name: "local", Local: true, resolved: clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceNamedCatalog, Name: "local",
+			BaseURL: srv.URL, Token: "global-token",
+		}}, clientOptsNormal)
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
@@ -612,12 +651,10 @@ func TestNewHTTPClientForTUIExplicitRemoteAuthTokenEnvOverridesCatalogToken(t *t
 	t.Cleanup(srv.Close)
 
 	hc, err := newHTTPClientForTUI(t.Context(), srv.URL,
-		daemonTarget{
-			Name:                 "shared",
-			URL:                  srv.URL,
-			Token:                "catalog-token",
-			UseAuthTokenOverride: true,
-		}, clientOptsNormal)
+		daemonTarget{Name: "shared", URL: srv.URL, resolved: clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceNamedCatalog, Name: "shared",
+			BaseURL: srv.URL, Token: "env-token",
+		}}, clientOptsNormal)
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
@@ -637,7 +674,11 @@ func TestNewHTTPClientForTUIImplicitRemoteFallsBackToGlobalAuth(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	hc, err := newHTTPClientForTUI(t.Context(), srv.URL, implicitDaemonTarget(srv.URL), clientOptsNormal)
+	target := implicitDaemonTarget(srv.URL)
+	target.resolved = clientpkg.ResolvedDaemon{
+		Source: clientpkg.DaemonSourceServerEnv, BaseURL: srv.URL, Token: "global-token",
+	}
+	hc, err := newHTTPClientForTUI(t.Context(), srv.URL, target, clientOptsNormal)
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
@@ -648,28 +689,78 @@ func TestNewHTTPClientForTUIImplicitRemoteFallsBackToGlobalAuth(t *testing.T) {
 	assert.Equal(t, "Bearer global-token", gotAuth)
 }
 
+func TestNewHTTPClientForTUIImplicitRemoteAnchorsCompatibilityToWorkspace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_MISSING_TOKEN", "")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+active_daemon = "shared"
+
+[auth]
+token = "global-token"
+
+[[daemon]]
+name = "shared"
+url = "`+srv.URL+`"
+token_env = "KATA_MISSING_TOKEN"
+`), 0o600))
+
+	workspace := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.toml"), []byte(
+		"version = 1\n\n[project]\nidentity = \"example.test/spoke-project\"\nname = \"spoke-project\"\n",
+	), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"), []byte(
+		"version = 1\n\n[server]\nurl = \""+srv.URL+"\"\n",
+	), 0o600))
+	unrelatedCWD := t.TempDir()
+	t.Chdir(unrelatedCWD)
+
+	target := implicitDaemonTarget(srv.URL)
+	target.workspaceStart = workspace
+	target.resolved = clientpkg.ResolvedDaemon{
+		Source: clientpkg.DaemonSourceLocalConfig, BaseURL: srv.URL, Token: "global-token",
+	}
+	hc, err := newHTTPClientForTUI(t.Context(), srv.URL, target, clientOptsNormal)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/protected", nil)
+	require.NoError(t, err)
+	resp, err := hc.Do(req) //nolint:gosec // request targets the test's own server
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, "Bearer global-token", gotAuth)
+}
+
 func TestConnectDaemonTargetRemoteUsesPerDaemonAuth(t *testing.T) {
-	oldNormalize := normalizeRemoteURLForTUI
-	oldProbe := probeRemoteForTUI
+	oldEnsureResolvedNamed := ensureResolvedNamedForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
 	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 	t.Cleanup(func() {
-		normalizeRemoteURLForTUI = oldNormalize
-		probeRemoteForTUI = oldProbe
+		ensureResolvedNamedForTUI = oldEnsureResolvedNamed
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
 		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
 	})
 
-	target := daemonTarget{Name: "shared", URL: "http://daemon.internal:7777", Token: "tok", AllowInsecure: true}
+	target := daemonTarget{Name: "shared", URL: "http://daemon.internal:7777"}
 	var gotNormal, gotSSE daemonTarget
-	normalizeRemoteURLForTUI = func(v string, allowInsecure bool) (string, error) {
-		require.Equal(t, target.URL, v)
-		require.True(t, allowInsecure)
-		return "http://daemon.internal:7777", nil
+	ensureResolvedNamedForTUI = func(_ context.Context, name string) (clientpkg.ResolvedDaemon, error) {
+		require.Equal(t, target.Name, name)
+		return clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceNamedCatalog, Name: name,
+			BaseURL: target.URL, Token: "tok", AllowInsecure: true,
+		}, nil
 	}
-	probeRemoteForTUI = func(context.Context, string) bool { return true }
 	newHTTPClientForTUI = func(_ context.Context, _ string, target daemonTarget, kind clientOptsKind) (*http.Client, error) {
 		if kind == clientOptsNormal {
 			gotNormal = target
@@ -688,21 +779,70 @@ func TestConnectDaemonTargetRemoteUsesPerDaemonAuth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "http://daemon.internal:7777", conn.endpoint)
 	expected := target
-	expected.UseAuthTokenOverride = true
+	expected.resolved = clientpkg.ResolvedDaemon{
+		Source: clientpkg.DaemonSourceNamedCatalog, Name: "shared",
+		BaseURL: target.URL, Token: "tok", AllowInsecure: true,
+	}
 	assert.Equal(t, expected, gotNormal)
 	assert.Equal(t, expected, gotSSE)
 	assert.Equal(t, "shared", conn.target.Name)
 }
 
+func TestConnectDaemonTargetCarriesResolvedProvenance(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("HUB_TOKEN_ENV", "catalog-token")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ping" {
+			http.NotFound(w, r)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"ok": true, "service": "kata", "version": "test",
+		}))
+	}))
+	t.Cleanup(srv.Close)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "hub-project-daemon"
+url = "`+srv.URL+`"
+token_env = "HUB_TOKEN_ENV"
+`), 0o600))
+
+	oldNewClient := newHTTPClientForTUI
+	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
+	t.Cleanup(func() {
+		newHTTPClientForTUI = oldNewClient
+		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
+	})
+	newHTTPClientForTUI = func(
+		context.Context, string, daemonTarget, clientOptsKind,
+	) (*http.Client, error) {
+		return &http.Client{}, nil
+	}
+	bootResolveScopePathFreeForTUI = func(context.Context, *Client, string) (bootInit, error) {
+		return bootInit{view: viewProjects}, nil
+	}
+
+	conn, err := connectDaemonTarget(t.Context(), daemonTarget{ //nolint:gosec // Fake credential environment name verifies token snapshotting.
+		Name: "hub-project-daemon", URL: srv.URL, TokenEnv: "HUB_TOKEN_ENV",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "catalog-token", conn.target.resolved.Token)
+	assert.Equal(t, clientpkg.DaemonSourceNamedCatalog, conn.target.resolved.Source)
+	t.Setenv("HUB_TOKEN_ENV", "rotated-token")
+	assert.Equal(t, "catalog-token", conn.target.resolved.Token)
+}
+
 func TestConnectDaemonTargetRemoteResolvesTokenEnvOnUse(t *testing.T) {
-	oldNormalize := normalizeRemoteURLForTUI
-	oldProbe := probeRemoteForTUI
+	oldEnsureResolvedNamed := ensureResolvedNamedForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
 	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 	t.Cleanup(func() {
-		normalizeRemoteURLForTUI = oldNormalize
-		probeRemoteForTUI = oldProbe
+		ensureResolvedNamedForTUI = oldEnsureResolvedNamed
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
 		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
@@ -711,10 +851,12 @@ func TestConnectDaemonTargetRemoteResolvesTokenEnvOnUse(t *testing.T) {
 
 	target := daemonTarget{Name: "shared", URL: "https://daemon.example", TokenEnv: "KATA_WORK_TOKEN"} //nolint:gosec // env var name, not a credential
 	var gotNormal, gotSSE daemonTarget
-	normalizeRemoteURLForTUI = func(v string, _ bool) (string, error) {
-		return v, nil
+	ensureResolvedNamedForTUI = func(context.Context, string) (clientpkg.ResolvedDaemon, error) {
+		return clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceNamedCatalog, Name: "shared",
+			BaseURL: target.URL, Token: "secret-from-env",
+		}, nil
 	}
-	probeRemoteForTUI = func(context.Context, string) bool { return true }
 	newHTTPClientForTUI = func(_ context.Context, _ string, target daemonTarget, kind clientOptsKind) (*http.Client, error) {
 		if kind == clientOptsNormal {
 			gotNormal = target
@@ -731,20 +873,18 @@ func TestConnectDaemonTargetRemoteResolvesTokenEnvOnUse(t *testing.T) {
 	conn, err := connectDaemonTarget(context.Background(), target)
 
 	require.NoError(t, err)
-	assert.Equal(t, "secret-from-env", gotNormal.Token)
-	assert.Equal(t, "secret-from-env", gotSSE.Token)
-	assert.Equal(t, "secret-from-env", conn.target.Token)
+	assert.Equal(t, "secret-from-env", gotNormal.resolved.Token)
+	assert.Equal(t, "secret-from-env", gotSSE.resolved.Token)
+	assert.Equal(t, "secret-from-env", conn.target.resolved.Token)
 }
 
 func TestConnectDaemonTargetRemoteAuthTokenEnvOverridesUnsetTokenEnv(t *testing.T) {
-	oldNormalize := normalizeRemoteURLForTUI
-	oldProbe := probeRemoteForTUI
+	oldEnsureResolvedNamed := ensureResolvedNamedForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
 	oldPathFreeBootScope := bootResolveScopePathFreeForTUI
 	t.Cleanup(func() {
-		normalizeRemoteURLForTUI = oldNormalize
-		probeRemoteForTUI = oldProbe
+		ensureResolvedNamedForTUI = oldEnsureResolvedNamed
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
 		bootResolveScopePathFreeForTUI = oldPathFreeBootScope
@@ -755,10 +895,12 @@ func TestConnectDaemonTargetRemoteAuthTokenEnvOverridesUnsetTokenEnv(t *testing.
 
 	target := daemonTarget{Name: "shared", URL: "https://daemon.example", TokenEnv: "KATA_WORK_TOKEN"} //nolint:gosec // env var name, not a credential
 	var gotNormal, gotSSE daemonTarget
-	normalizeRemoteURLForTUI = func(v string, _ bool) (string, error) {
-		return v, nil
+	ensureResolvedNamedForTUI = func(context.Context, string) (clientpkg.ResolvedDaemon, error) {
+		return clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceNamedCatalog, Name: "shared",
+			BaseURL: target.URL, Token: "env-token",
+		}, nil
 	}
-	probeRemoteForTUI = func(context.Context, string) bool { return true }
 	newHTTPClientForTUI = func(_ context.Context, _ string, target daemonTarget, kind clientOptsKind) (*http.Client, error) {
 		if kind == clientOptsNormal {
 			gotNormal = target
@@ -775,25 +917,47 @@ func TestConnectDaemonTargetRemoteAuthTokenEnvOverridesUnsetTokenEnv(t *testing.
 	conn, err := connectDaemonTarget(context.Background(), target)
 
 	require.NoError(t, err)
-	assert.Equal(t, "env-token", gotNormal.Token)
-	assert.Equal(t, "env-token", gotSSE.Token)
-	assert.Equal(t, "env-token", conn.target.Token)
+	assert.Equal(t, "env-token", gotNormal.resolved.Token)
+	assert.Equal(t, "env-token", gotSSE.resolved.Token)
+	assert.Equal(t, "env-token", conn.target.resolved.Token)
 }
 
 func TestConnectResolvedLocalTargetRetryRefreshPreservesTargetToken(t *testing.T) {
-	oldEnsureLocal := ensureLocalRunningForTUI
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are unsupported on Windows")
+	}
+	oldEnsureLocal := ensureLocalRunningTargetForTUI
 	oldNewClient := newHTTPClientForTUI
 	oldBootScope := bootResolveScopeForTUI
 	oldRefresh := refreshLocalHTTPClientForTUI
 	t.Cleanup(func() {
-		ensureLocalRunningForTUI = oldEnsureLocal
+		ensureLocalRunningTargetForTUI = oldEnsureLocal
 		newHTTPClientForTUI = oldNewClient
 		bootResolveScopeForTUI = oldBootScope
 		refreshLocalHTTPClientForTUI = oldRefresh
 	})
 
-	ensureLocalRunningForTUI = func(context.Context) (string, error) {
-		return clientpkg.UnixBase, nil
+	t.Setenv("KATA_HOME", t.TempDir())
+	socket := filepath.Join(t.TempDir(), "fresh-kata.sock")
+	ln, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	var gotAuth string
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			_ = json.NewEncoder(w).Encode(map[string]any{"issues": []map[string]any{}})
+		}),
+		ReadHeaderTimeout: time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	ensureLocalRunningTargetForTUI = func(context.Context) (clientpkg.RunningDaemon, error) {
+		return clientpkg.RunningDaemon{
+			BaseURL: clientpkg.UnixBase, Address: "unix://" + socket,
+			Network: "unix", Scheme: "http",
+		}, nil
 	}
 	refreshLocalHTTPClientForTUI = func(context.Context) (*http.Client, error) {
 		t.Fatal("local retry should refresh through the resolved daemon target")
@@ -805,7 +969,7 @@ func TestConnectResolvedLocalTargetRetryRefreshPreservesTargetToken(t *testing.T
 	var normalCalls int
 	var retryTarget daemonTarget
 	newHTTPClientForTUI = func(
-		_ context.Context, _ string, target daemonTarget, kind clientOptsKind,
+		ctx context.Context, _ string, target daemonTarget, kind clientOptsKind,
 	) (*http.Client, error) {
 		if kind == clientOptsSSE {
 			return &http.Client{}, nil
@@ -817,23 +981,45 @@ func TestConnectResolvedLocalTargetRetryRefreshPreservesTargetToken(t *testing.T
 			})}, nil
 		}
 		retryTarget = target
-		return &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-			return jsonResponse(t, map[string]any{"issues": []map[string]any{}}), nil
-		})}, nil
+		return clientpkg.NewHTTPClientForResolved(ctx, target.resolved,
+			clientpkg.Opts{Timeout: time.Second})
 	}
 
 	conn, err := connectResolvedDaemonTarget(t.Context(),
-		daemonTarget{Name: "local-secure", Local: true, Token: "target-token"},
+		daemonTarget{Name: "local-secure", Local: true, resolved: clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceNamedCatalog, Name: "local-secure",
+			BaseURL: clientpkg.UnixBase, Address: "unix:///tmp/stale.sock",
+			Network: "unix", Scheme: "http", UnixSocket: "/tmp/stale.sock",
+			Token: "target-token", AllowInsecure: true, TrustPrivateNetwork: true,
+		}},
 		clientpkg.UnixBase)
 	require.NoError(t, err)
 
 	_, err = conn.api.ListIssues(t.Context(), 7, ListFilter{Limit: 2001})
 	require.NoError(t, err)
-	assert.Equal(t, "target-token", retryTarget.Token)
+	assert.Equal(t, "target-token", retryTarget.resolved.Token)
+	assert.Equal(t, clientpkg.DaemonSourceNamedCatalog, retryTarget.resolved.Source)
+	assert.Equal(t, "local-secure", retryTarget.resolved.Name)
+	assert.Equal(t, clientpkg.UnixBase, retryTarget.resolved.BaseURL)
+	assert.Equal(t, "unix://"+socket, retryTarget.resolved.Address)
+	assert.Equal(t, "unix", retryTarget.resolved.Network)
+	assert.Equal(t, "http", retryTarget.resolved.Scheme)
+	assert.Equal(t, socket, retryTarget.resolved.UnixSocket)
+	assert.True(t, retryTarget.resolved.AllowInsecure)
+	assert.True(t, retryTarget.resolved.TrustPrivateNetwork)
+	assert.Equal(t, "Bearer target-token", gotAuth)
 }
 
 func TestConnectDaemonTargetRemoteRejectsUnsetTokenEnvOnUse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
 	t.Setenv("KATA_WORK_TOKEN", "")
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"), []byte(`
+[[daemon]]
+name = "shared"
+url = "https://daemon.example"
+token_env = "KATA_WORK_TOKEN"
+`), 0o600))
 
 	_, err := connectDaemonTarget(context.Background(),
 		daemonTarget{Name: "shared", URL: "https://daemon.example", TokenEnv: "KATA_WORK_TOKEN"}) //nolint:gosec // env var name, not a credential
@@ -865,4 +1051,19 @@ func TestDaemonConnectionUsesSSEHeaderTimeout(t *testing.T) {
 
 func clientSSEHandshakeTimeout() time.Duration {
 	return 10 * time.Second
+}
+
+func startTUIPingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ping" {
+			http.NotFound(w, r)
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"ok": true, "service": "kata", "version": "test",
+		}))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
 }

--- a/internal/tui/daemon_view_render.go
+++ b/internal/tui/daemon_view_render.go
@@ -122,7 +122,7 @@ func daemonEndpoint(target daemonTarget) string {
 }
 
 func daemonAuth(target daemonTarget) string {
-	if target.Token != "" || target.TokenEnv != "" {
+	if target.resolved.Token != "" || target.TokenEnv != "" {
 		return "token"
 	}
 	return "no token"
@@ -130,7 +130,7 @@ func daemonAuth(target daemonTarget) string {
 
 func daemonFooter(row daemonRow, width int) string {
 	text := sanitizeForLine(daemonName(row.target)) + " · " + sanitizeForLine(daemonEndpoint(row.target))
-	if row.target.AllowInsecure {
+	if row.target.resolved.AllowInsecure {
 		text += " · allow_insecure"
 	}
 	return truncate(text, width)

--- a/internal/tui/daemon_view_test.go
+++ b/internal/tui/daemon_view_test.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	clientpkg "go.kenn.io/kata/internal/client"
 )
 
 func TestDaemonView_DKeyTransitionsFromList(t *testing.T) {
@@ -463,7 +464,9 @@ func setupDaemonViewSource() Model {
 	m.activeDaemon = daemonTarget{Name: "shared", URL: "http://daemon.internal:7777"}
 	m.daemonTargets = []daemonTarget{
 		{Name: "local", Local: true},
-		{Name: "shared", URL: "http://daemon.internal:7777", Token: "tok", AllowInsecure: true},
+		{Name: "shared", URL: "http://daemon.internal:7777", resolved: clientpkg.ResolvedDaemon{
+			Token: "tok", AllowInsecure: true,
+		}},
 		{Name: "prod", URL: "https://kata.example.test"},
 	}
 	return m

--- a/internal/tui/federation_client.go
+++ b/internal/tui/federation_client.go
@@ -2,30 +2,89 @@ package tui
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 
 	clientpkg "go.kenn.io/kata/internal/client"
+	"go.kenn.io/kata/internal/config"
 	hubfederation "go.kenn.io/kata/internal/federation"
 )
 
 func newHubAdminClient(ctx context.Context, target daemonTarget) (*Client, daemonTarget, error) {
-	resolved, err := resolveDaemonTargetToken(target)
+	hubToken, err := federationHubTargetToken(target)
 	if err != nil {
 		return nil, daemonTarget{}, err
 	}
-	var endpoint string
-	if resolved.Local {
-		endpoint, err = ensureLocalRunningForTUI(ctx)
+	resolved := target.resolved
+	if resolved.Source == clientpkg.DaemonSourceUnknown && target.Name != "" {
+		resolved, err = ensureResolvedNamedForTUI(ctx, target.Name)
+		if err == nil && !target.Local {
+			var selectedBaseURL string
+			selectedBaseURL, err = normalizeRemoteURLForTUI(
+				target.URL, target.resolved.AllowInsecure,
+			)
+			if err == nil && selectedBaseURL != resolved.BaseURL {
+				err = fmt.Errorf("daemon %q url changed from %q to %q",
+					target.Name, selectedBaseURL, resolved.BaseURL)
+			}
+			resolved.AllowInsecure = resolved.AllowInsecure || target.resolved.AllowInsecure
+		}
+	} else if resolved.BaseURL == "" {
+		resolved.BaseURL, err = normalizeRemoteURLForTUI(target.URL, resolved.AllowInsecure)
+		resolved.Source = clientpkg.DaemonSourceInjected
+	}
+	if err != nil {
+		return nil, daemonTarget{}, err
+	}
+	if !target.Local {
+		// Federation hub credentials are an origin-specific trust boundary.
+		// Named resolution supplies exact endpoint metadata, but its ordinary
+		// global auth override belongs to daemon switching and must never replace
+		// the catalog credential sent to a hub. Injected credential-free targets
+		// retain only the global transport trust decision, never its token.
+		resolved.Token = hubToken
+		if resolved.Source == clientpkg.DaemonSourceInjected {
+			resolved.TrustPrivateNetwork = resolved.TrustPrivateNetwork ||
+				config.ResolvedBearerTrustPrivateNetwork()
+		}
+		resolved.BaseURL, err = normalizeRemoteURLForTUI(resolved.BaseURL, resolved.AllowInsecure)
+		if err != nil {
+			return nil, daemonTarget{}, err
+		}
+	}
+	target.resolved = resolved
+	endpoint := resolved.BaseURL
+	if target.Local {
+		target.URL = ""
 	} else {
-		endpoint, err = normalizeRemoteURLForTUI(resolved.URL, resolved.AllowInsecure)
+		target.URL = endpoint
 	}
+	hc, err := newHTTPClientForTUI(ctx, endpoint, target, clientOptsNormal)
 	if err != nil {
 		return nil, daemonTarget{}, err
 	}
-	hc, err := newHTTPClientForTUI(ctx, endpoint, resolved, clientOptsNormal)
-	if err != nil {
-		return nil, daemonTarget{}, err
+	return NewClient(endpoint, hc), target, nil
+}
+
+// federationHubTargetToken resolves only the credential attached to the
+// selected hub target. In particular, KATA_AUTH_TOKEN authenticates the local
+// daemon and is never a fallback or override for a catalog hub.
+func federationHubTargetToken(target daemonTarget) (string, error) {
+	if target.TokenEnv == "" {
+		return target.resolved.Token, nil
 	}
-	return NewClient(endpoint, hc), resolvedDaemonTarget(resolved, endpoint), nil
+	token := strings.TrimSpace(os.Getenv(target.TokenEnv))
+	if token == "" {
+		return "", fmt.Errorf("daemon %q: token_env %q is unset or empty",
+			daemonTargetDisplay(target), target.TokenEnv)
+	}
+	return token, nil
+}
+
+func validateFederationHubTargetCredential(target daemonTarget) error {
+	_, err := federationHubTargetToken(target)
+	return err
 }
 
 func newHubEnrollmentClient(

--- a/internal/tui/federation_view.go
+++ b/internal/tui/federation_view.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	clientpkg "go.kenn.io/kata/internal/client"
 	hubfederation "go.kenn.io/kata/internal/federation"
 )
 
@@ -593,12 +594,11 @@ func (m Model) executeFederationLeave(attempt uint64) tea.Cmd {
 
 // federationLeaveHubTarget resolves the hub admin daemonTarget for a leave by
 // matching the binding's hub URL against the catalog (so its token/token_env
-// is used), falling back to an implicit target that picks up global auth.
-// This mirrors the CLI's hub-admin auth precedence: the catalog entry whose URL
-// matches the binding's hub_url supplies only the admin token, else the global
-// KATA_AUTH_TOKEN fallback. The target URL is ALWAYS the binding's hub URL —
-// the catalog entry never redirects the admin token to a different origin — and
-// the URL comparison normalizes trailing slashes so a catalog/binding slash
+// is used), falling back to an unauthenticated target. The catalog entry whose
+// URL matches the binding's hub_url supplies only the admin token; global daemon
+// auth is never sent to a hub. The target URL is ALWAYS the binding's hub URL —
+// the catalog entry never redirects the admin token to a different origin —
+// and the URL comparison normalizes trailing slashes so a catalog/binding slash
 // mismatch still matches (#273).
 func (m Model) federationLeaveHubTarget(hubURL string, allowInsecure bool) daemonTarget {
 	want := strings.TrimRight(hubURL, "/")
@@ -615,14 +615,20 @@ func (m Model) federationLeaveHubTarget(hubURL string, allowInsecure bool) daemo
 			// partial-leave recovery, but can never remove the binding's.
 			matched := target
 			matched.URL = want
-			matched.AllowInsecure = allowInsecure || target.AllowInsecure
+			matched.resolved.BaseURL = want
+			matched.resolved.AllowInsecure = allowInsecure || target.resolved.AllowInsecure
 			return matched
 		}
 	}
 	// No catalog match: an unauthenticated, non-implicit target. Implicit
-	// targets pick up the global KATA_AUTH_TOKEN/[auth].token in
-	// resolvedDaemonTarget, which must never be sent to the hub origin.
-	return daemonTarget{URL: want, AllowInsecure: allowInsecure}
+	// targets could pick up the global KATA_AUTH_TOKEN/[auth].token during
+	// implicit resolution, which must never be sent to the hub origin.
+	return daemonTarget{
+		URL: want,
+		resolved: clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceInjected, BaseURL: want, AllowInsecure: allowInsecure,
+		},
+	}
 }
 
 // runFederationLeave mirrors runFederationEnrollment: revoke-first on the hub
@@ -990,25 +996,24 @@ func (m Model) selectFederationHub(target daemonTarget) (Model, tea.Cmd) {
 		m.federationEnrollErr = errors.New("local hub targets cannot be used for federation enrollment; select a hub daemon with a spoke-reachable URL")
 		return m, nil
 	}
-	resolved, err := resolveDaemonTargetToken(target)
-	if err != nil {
+	if err := validateFederationHubTargetCredential(target); err != nil {
 		m.federationEnrollErr = err
 		return m, nil
 	}
-	if !resolved.Local {
-		if _, err := normalizeRemoteURLForTUI(resolved.URL, resolved.AllowInsecure); err != nil {
+	if !target.Local {
+		if _, err := normalizeRemoteURLForTUI(target.URL, target.resolved.AllowInsecure); err != nil {
 			m.federationEnrollErr = err
 			return m, nil
 		}
 	}
-	m.federationDraft.HubTarget = resolved
-	m.federationDraft.AllowInsecure = resolved.AllowInsecure
+	m.federationDraft.HubTarget = target
+	m.federationDraft.AllowInsecure = target.resolved.AllowInsecure
 	m.federationMode = federationModeSelectHubProject
 	m.federationHubProjectsLoading = true
 	m.federationHubProjects = nil
 	m.federationHubProjectCursor = 0
 	m.federationEnrollGen++
-	return m, m.fetchFederationHubProjects(resolved)
+	return m, m.fetchFederationHubProjects(target)
 }
 
 func (m Model) fetchFederationHubProjects(target daemonTarget) tea.Cmd {
@@ -1197,8 +1202,8 @@ func baseFederationRecovery(
 			AdoptExisting:      draft.AdoptExisting,
 			SpokeName:          daemonName(active),
 			SpokeEndpoint:      federationDaemonEndpoint(active),
-			SpokeAllowInsecure: active.AllowInsecure,
-			SpokeToken:         active.Token,
+			SpokeAllowInsecure: active.resolved.AllowInsecure,
+			SpokeToken:         active.resolved.Token,
 		},
 	}
 }
@@ -1296,7 +1301,7 @@ func (m Model) previewFederationEnrollment() (Model, tea.Cmd) {
 			}
 		}
 	}
-	draft.AllowInsecure = draft.HubTarget.AllowInsecure
+	draft.AllowInsecure = draft.HubTarget.resolved.AllowInsecure
 	m.federationDraft = draft
 	m.federationMode = federationModePreview
 	return m, nil

--- a/internal/tui/federation_view_render.go
+++ b/internal/tui/federation_view_render.go
@@ -107,7 +107,7 @@ func renderFederationSelectHub(m Model) string {
 	for i, row := range rows {
 		label := daemonName(row.target) + " " + federationDaemonEndpoint(row.target) +
 			" auth " + daemonAuth(row.target)
-		if row.target.AllowInsecure {
+		if row.target.resolved.AllowInsecure {
 			label += " allow_insecure"
 		}
 		if daemonTargetsMatch(row.target, m.activeDaemon) {
@@ -129,7 +129,7 @@ func renderFederationSelectHubProject(m Model) string {
 			m.federationDraft.HubTarget,
 			m.federationDraft.HubInstance.Auth,
 		)),
-		fmt.Sprintf("allow_insecure: %t", m.federationDraft.HubTarget.AllowInsecure),
+		fmt.Sprintf("allow_insecure: %t", m.federationDraft.HubTarget.resolved.AllowInsecure),
 		"",
 	)
 	if m.federationHubProjectsLoading {
@@ -153,7 +153,7 @@ func renderFederationBrowseHubs(m Model) string {
 		"catalog hub: "+sanitizeForLine(daemonName(target))+
 			" "+sanitizeForLine(federationDaemonEndpoint(target)),
 		"hub auth: "+sanitizeForLine(federationAuthDisplay(target, m.federationDraft.HubInstance.Auth)),
-		fmt.Sprintf("allow_insecure: %t", target.AllowInsecure),
+		fmt.Sprintf("allow_insecure: %t", target.resolved.AllowInsecure),
 		"mode: read-only",
 		"",
 	)

--- a/internal/tui/federation_view_test.go
+++ b/internal/tui/federation_view_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/api"
+	clientpkg "go.kenn.io/kata/internal/client"
 )
 
 func TestFederationView_FKeyTransitionsFromList(t *testing.T) {
@@ -149,8 +150,8 @@ func TestFederationView_HelpAndFooterIncludeFederationBinding(t *testing.T) {
 
 func TestFederationBrowse_BKeyListsCatalogHubProjectsWithoutSwitchingActiveDaemon(t *testing.T) {
 	spokeAPI := &Client{}
-	spokeTarget := daemonTarget{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"}
-	hubTarget := daemonTarget{Name: "catalog-hub", URL: "https://hub.example", Token: "hub-auth"}
+	spokeTarget := daemonTargetWithResolvedAuth("spoke", "https://spoke.example", "spoke-auth", false)
+	hubTarget := daemonTargetWithResolvedAuth("catalog-hub", "https://hub.example", "hub-auth", false)
 	hub := &recordingFederationHubAdmin{
 		projects: []ProjectSummary{
 			{ID: 42, Name: "hub-project"},
@@ -200,7 +201,7 @@ func TestFederationBrowse_BKeyListsCatalogHubProjectsWithoutSwitchingActiveDaemo
 }
 
 func TestFederationBrowse_ReadOnlyDoesNotCreateEnrollment(t *testing.T) {
-	hubTarget := daemonTarget{Name: "catalog-hub", URL: "https://hub.example", Token: "hub-auth"}
+	hubTarget := daemonTargetWithResolvedAuth("catalog-hub", "https://hub.example", "hub-auth", false)
 	hub := &recordingFederationHubAdmin{
 		projects: []ProjectSummary{{ID: 42, Name: "hub-project"}},
 	}
@@ -212,7 +213,7 @@ func TestFederationBrowse_ReadOnlyDoesNotCreateEnrollment(t *testing.T) {
 	})
 	m := setupFederationView()
 	m.api = &Client{}
-	m.activeDaemon = daemonTarget{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"}
+	m.activeDaemon = daemonTargetWithResolvedAuth("spoke", "https://spoke.example", "spoke-auth", false)
 	m.daemonTargets = []daemonTarget{m.activeDaemon, hubTarget}
 	m.federationHubCursor = 1
 
@@ -250,8 +251,8 @@ func TestFederationEnroll_NWithCurrentProjectStartsLocalSelectionCursored(t *tes
 		mockProject{ID: 9, Name: "other-project"},
 	)
 	m.daemonTargets = []daemonTarget{
-		{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"},
-		{Name: "hub", URL: "https://hub.example", Token: "hub-auth"},
+		daemonTargetWithResolvedAuth("spoke", "https://spoke.example", "spoke-auth", false),
+		daemonTargetWithResolvedAuth("hub", "https://hub.example", "hub-auth", false),
 	}
 	m.activeDaemon = m.daemonTargets[0]
 
@@ -386,8 +387,8 @@ func TestFederationEnroll_SelectHubLoadsHubAuthPrincipal(t *testing.T) {
 	m.scope = homedScope(7, "spoke-project")
 	injectProjects(&m, mockProject{ID: 7, Name: "spoke-project"})
 	m.daemonTargets = []daemonTarget{
-		{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"},
-		{Name: "hub", URL: "https://hub.example", Token: "hub-auth"},
+		daemonTargetWithResolvedAuth("spoke", "https://spoke.example", "spoke-auth", false),
+		daemonTargetWithResolvedAuth("hub", "https://hub.example", "hub-auth", false),
 	}
 	m.activeDaemon = m.daemonTargets[0]
 
@@ -449,8 +450,8 @@ func TestFederationEnroll_CreateReplicaBranchDefaultsLocalNameFromHubProject(t *
 	m := setupFederationView()
 	m.scope = scope{allProjects: true}
 	m.daemonTargets = []daemonTarget{
-		{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"},
-		{Name: "hub", URL: "https://hub.example", Token: "hub-auth"},
+		daemonTargetWithResolvedAuth("spoke", "https://spoke.example", "spoke-auth", false),
+		daemonTargetWithResolvedAuth("hub", "https://hub.example", "hub-auth", false),
 	}
 	m.activeDaemon = m.daemonTargets[0]
 
@@ -531,12 +532,13 @@ func TestFederationEnroll_ExistingLocalFederationBindingBlocksBeforeMutation(t *
 }
 
 func TestFederationEnroll_MissingTokenEnvBlocksBeforeMutation(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv(missingHubAuthEnvName(), "")
 	m := setupFederationView()
 	m.scope = homedScope(7, "spoke-project")
 	injectProjects(&m, mockProject{ID: 7, Name: "spoke-project"})
 	m.daemonTargets = []daemonTarget{
-		{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"},
+		daemonTargetWithResolvedAuth("spoke", "https://spoke.example", "spoke-auth", false),
 		{Name: "hub", URL: "https://hub.example", TokenEnv: missingHubAuthEnvName()},
 	}
 	m.activeDaemon = m.daemonTargets[0]
@@ -548,14 +550,38 @@ func TestFederationEnroll_MissingTokenEnvBlocksBeforeMutation(t *testing.T) {
 
 	require.Nil(t, cmd)
 	assert.Equal(t, federationModeSelectHub, out.federationMode)
-	assert.Contains(t, stripANSI(renderFederation(out)), "token_env")
+	require.EqualError(t, out.federationEnrollErr,
+		`daemon "hub": token_env "`+missingHubAuthEnvName()+`" is unset or empty`)
+}
+
+func TestFederationEnroll_GlobalAuthTokenDoesNotOverrideMissingTargetTokenEnv(t *testing.T) {
+	t.Setenv("KATA_AUTH_TOKEN", "local-daemon-token")
+	t.Setenv(missingHubAuthEnvName(), "")
+	m := setupFederationView()
+	m.scope = homedScope(7, "spoke-project")
+	injectProjects(&m, mockProject{ID: 7, Name: "spoke-project"})
+	m.daemonTargets = []daemonTarget{
+		daemonTargetWithResolvedAuth("spoke", "https://spoke.example", "spoke-auth", false),
+		{Name: "hub", URL: "https://hub.example", TokenEnv: missingHubAuthEnvName()},
+	}
+	m.activeDaemon = m.daemonTargets[0]
+
+	out, _ := m.routeFederationViewKey(keyRune('n'))
+	out, _ = out.routeFederationViewKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	out.federationHubCursor = 1
+	out, cmd := out.routeFederationViewKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	require.Nil(t, cmd)
+	assert.Equal(t, federationModeSelectHub, out.federationMode)
+	require.EqualError(t, out.federationEnrollErr,
+		`daemon "hub": token_env "`+missingHubAuthEnvName()+`" is unset or empty`)
 }
 
 func TestFederationEnroll_ActiveDaemonAsHubBlocked(t *testing.T) {
 	m := setupFederationView()
 	m.scope = homedScope(7, "spoke-project")
 	injectProjects(&m, mockProject{ID: 7, Name: "spoke-project"})
-	m.daemonTargets = []daemonTarget{{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"}}
+	m.daemonTargets = []daemonTarget{daemonTargetWithResolvedAuth("spoke", "https://spoke.example", "spoke-auth", false)}
 	m.activeDaemon = m.daemonTargets[0]
 
 	out, _ := m.routeFederationViewKey(keyRune('n'))
@@ -594,8 +620,8 @@ func TestFederationEnroll_PlainHTTPHostnameRequiresCatalogAllowInsecure(t *testi
 	m.scope = homedScope(7, "spoke-project")
 	injectProjects(&m, mockProject{ID: 7, Name: "spoke-project"})
 	m.daemonTargets = []daemonTarget{
-		{Name: "spoke", URL: "https://spoke.example", Token: "spoke-auth"},
-		{Name: "hub", URL: "http://hub.internal:7777", Token: "hub-auth"},
+		daemonTargetWithResolvedAuth("spoke", "https://spoke.example", "spoke-auth", false),
+		daemonTargetWithResolvedAuth("hub", "http://hub.internal:7777", "hub-auth", false),
 	}
 	m.activeDaemon = m.daemonTargets[0]
 
@@ -813,7 +839,7 @@ func TestFederationEnroll_JoinFailureRecoveryRevealIsExplicitAndSecretBearing(t 
 
 func TestFederationEnroll_RecoveryCommandPreservesSpokeAllowInsecure(t *testing.T) {
 	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{joinStatus: 500})
-	m.activeDaemon.AllowInsecure = true
+	m.activeDaemon.resolved.AllowInsecure = true
 	out, cmd := enterThroughAdoptConfirm(t, m)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
@@ -829,7 +855,7 @@ func TestFederationEnroll_RecoveryCommandPreservesSpokeAllowInsecure(t *testing.
 func TestFederationEnroll_RecoveryCommandPreservesSpokeAuthOnlyAfterReveal(t *testing.T) {
 	spokeToken := spokeAuthSecret()
 	m, _ := setupFederationExecutionPreview(t, federationExecutionServerOptions{joinStatus: 500})
-	m.activeDaemon.Token = spokeToken
+	m.activeDaemon.resolved.Token = spokeToken
 	out, cmd := enterThroughAdoptConfirm(t, m)
 	msg := cmd().(federationEnrollResultMsg)
 	out, _ = updateModel(out, msg)
@@ -1276,17 +1302,17 @@ func TestFederationLeaveHubTargetUsesBindingURLAndToleratesTrailingSlash(t *test
 		{Name: "local", Local: true},
 		// Catalog entry's URL carries a trailing slash and a foreign-looking
 		// path; only its token must be reused.
-		{Name: "hub", URL: "https://bound.example/", Token: "catalog-token"},
+		daemonTargetWithResolvedAuth("hub", "https://bound.example/", "catalog-token", false),
 	}
 
 	got := m.federationLeaveHubTarget("https://bound.example", true)
 
 	// Token comes from the matched catalog entry (slash-tolerant match)...
-	assert.Equal(t, "catalog-token", got.Token)
+	assert.Equal(t, "catalog-token", got.resolved.Token)
 	// ...but the target URL is pinned to the binding's hub URL, normalized,
 	// and allow_insecure comes from the binding, not the catalog entry.
 	assert.Equal(t, "https://bound.example", got.URL)
-	assert.True(t, got.AllowInsecure, "binding allow_insecure must carry through")
+	assert.True(t, got.resolved.AllowInsecure, "binding allow_insecure must carry through")
 	assert.False(t, got.Implicit, "a matched catalog entry is not an implicit target")
 }
 
@@ -1298,13 +1324,13 @@ func TestFederationLeaveHubTargetUsesBindingURLAndToleratesTrailingSlash(t *test
 func TestFederationLeaveHubTargetUnionsCatalogAllowInsecure(t *testing.T) {
 	m := newTestModel()
 	m.daemonTargets = []daemonTarget{
-		{Name: "hub", URL: "http://hub.internal:7373", Token: "catalog-token", AllowInsecure: true},
+		daemonTargetWithResolvedAuth("hub", "http://hub.internal:7373", "catalog-token", true),
 	}
 
 	got := m.federationLeaveHubTarget("http://hub.internal:7373", false)
 
-	assert.Equal(t, "catalog-token", got.Token)
-	assert.True(t, got.AllowInsecure,
+	assert.Equal(t, "catalog-token", got.resolved.Token)
+	assert.True(t, got.resolved.AllowInsecure,
 		"same-origin catalog allow_insecure must union into the leave hub target")
 }
 
@@ -1318,8 +1344,8 @@ func TestFederationLeaveHubTargetNoMatchFallsBackToBindingURL(t *testing.T) {
 	// pick up the global daemon token, which must never go to the hub origin.
 	assert.False(t, got.Implicit, "fallback must not be implicit (global-auth pickup)")
 	assert.Equal(t, "https://bound.example", got.URL)
-	assert.Empty(t, got.Token)
-	assert.True(t, got.AllowInsecure, "binding allow_insecure must carry through")
+	assert.Empty(t, got.resolved.Token)
+	assert.True(t, got.resolved.AllowInsecure, "binding allow_insecure must carry through")
 }
 
 func setupFederationSourceModel() Model {
@@ -1413,12 +1439,9 @@ func setupFederationHubProjectSelection() Model {
 	m.federationDraft = newFederationDraft("operator")
 	m.federationDraft.SpokeProjectID = 7
 	m.federationDraft.SpokeProjectName = "spoke-project"
-	m.federationDraft.HubTarget = daemonTarget{
-		Name:          "hub",
-		URL:           "https://hub.example",
-		Token:         "hub-auth",
-		AllowInsecure: true,
-	}
+	m.federationDraft.HubTarget = daemonTargetWithResolvedAuth(
+		"hub", "https://hub.example", "hub-auth", true,
+	)
 	m.federationDraft.AllowInsecure = true
 	m.federationDraft.AdoptExisting = true
 	return m
@@ -1493,7 +1516,7 @@ func setupFederationExecutionPreview(
 	m.federationDraft.Operation = federationOperationAdoptSameName
 	m.federationDraft.HubProjectID = 42
 	m.federationDraft.HubProjectName = hubProjectName
-	m.federationDraft.HubTarget = daemonTarget{Name: "hub", URL: hub.URL, AllowInsecure: true}
+	m.federationDraft.HubTarget = daemonTargetWithResolvedAuth("hub", hub.URL, "", true)
 	m.federationDraft.AllowInsecure = true
 	return m, &joinBody
 }
@@ -1896,4 +1919,15 @@ func TestFetchProjectsCarriesUIDs(t *testing.T) {
 	// And the loaded handler must apply them to projectUIDByID.
 	out, _ := updateModel(m, msg)
 	assert.Equal(t, "01HZNQ7VFPK1XGD8R5MABCD4EX", out.projectUIDByID[7])
+}
+
+func daemonTargetWithResolvedAuth(name, baseURL, token string, allowInsecure bool) daemonTarget {
+	return daemonTarget{
+		Name: name,
+		URL:  baseURL,
+		resolved: clientpkg.ResolvedDaemon{
+			Source: clientpkg.DaemonSourceInjected, Name: name, BaseURL: baseURL,
+			Token: token, AllowInsecure: allowInsecure,
+		},
+	}
 }

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -18,7 +18,6 @@ import (
 )
 
 const defaultHTTPTimeout = 5 * time.Second
-const remoteProbeTimeout = time.Second
 
 type sseStarter func(context.Context, sseClient, string, *int64, chan tea.Msg, uint64)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -32,6 +32,9 @@ type RequestEditorFn = runtime.RequestEditorFn
 type TargetAuth struct {
 	Token         string
 	AllowInsecure bool
+	// TrustPrivateNetwork permits a plaintext bearer target that is a literal
+	// non-public IP, matching the daemon-side private-network opt-in.
+	TrustPrivateNetwork bool
 }
 
 // TransportOptions controls the HTTP transport built by auth-aware
@@ -135,7 +138,11 @@ func NewWithBearer(ctx context.Context, baseURL, token string, opts ...Option) (
 func NewForTarget(ctx context.Context, baseURL string, auth TargetAuth, opts ...Option) (*Client, error) {
 	merged := collectOptions(opts...)
 	httpClient, err := internalclient.NewHTTPClientForTarget(ctx, baseURL,
-		internalclient.TargetAuth{Token: auth.Token, AllowInsecure: auth.AllowInsecure},
+		internalclient.TargetAuth{
+			Token:               auth.Token,
+			AllowInsecure:       auth.AllowInsecure,
+			TrustPrivateNetwork: auth.TrustPrivateNetwork,
+		},
 		internalOpts(merged.transport))
 	if err != nil {
 		return nil, err

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -83,6 +83,25 @@ func TestNewForTargetAllowsPlaintextPrivateNetworkOptOut(t *testing.T) {
 	require.NotNil(t, api)
 }
 
+// TestNewForTargetHonorsTrustPrivateNetwork pins that the public SDK can
+// express the same private-network trust the CLI does. Without the field the
+// conversion dropped it, so an SDK caller got a stricter policy than kata
+// itself for the same endpoint.
+func TestNewForTargetHonorsTrustPrivateNetwork(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Setenv("KATA_TRUST_PRIVATE_NETWORK", "")
+
+	_, err := NewForTarget(context.Background(), "http://100.64.0.5:7777",
+		TargetAuth{Token: "target-token"})
+	require.Error(t, err, "a plaintext CGNAT target must be refused without the opt-in")
+
+	c, err := NewForTarget(context.Background(), "http://100.64.0.5:7777",
+		TargetAuth{Token: "target-token", TrustPrivateNetwork: true})
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
 func TestNewWithTrustedActorHeader(t *testing.T) {
 	var gotActor string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What changed

- carry daemon source, credentials, transport policy, and Unix endpoint metadata through resolution instead of reconstructing them from URLs
- centralize bearer-target validation and origin-pinned client construction
- route CLI and TUI callers through resolved daemon clients while keeping hub credentials isolated from local daemon credentials
- preserve non-starting health probes, long-running GitHub sync requests, and the existing federation redirect boundary

## Why

Reconstructing a daemon client from its URL throws away where the endpoint came from and which credential and transport policy belong to it. That makes unsafe plaintext failures late and opaque, and it creates too many places where a local daemon token could be paired with the wrong origin.

## Usage

Configuration syntax is unchanged. Plaintext targets without the required private-network trust or `allow_insecure` opt-in now fail when the client is built.
