### PR TITLE
Simplify CLI wait and output state

### DIFF
--- a/cmd/kata/beads_import.go
+++ b/cmd/kata/beads_import.go
@@ -297,7 +297,7 @@ func isBeadsImportUnattended(cmd *cobra.Command) bool {
 }
 
 func printBeadsImportResult(cmd *cobra.Command, bs []byte, projectID int64) error {
-	if flags.JSON {
+	if currentOutputMode() == outputJSON {
 		_, err := cmd.OutOrStdout().Write(bs)
 		return err
 	}

--- a/cmd/kata/bridge_test.go
+++ b/cmd/kata/bridge_test.go
@@ -164,7 +164,7 @@ func TestBridgeOutputSortsConflictsAndRendersMissingValuesNeutrally(t *testing.T
 	assert.Contains(t, human, "External: kind=- value=- timezone=-")
 	assert.Less(t, strings.Index(human, "Field conflict: deadline_on"), strings.Index(human, "Field conflict: scheduled_on"))
 
-	flags.Agent = true
+	flags.Mode = outputAgent
 	out.Reset()
 	require.NoError(t, printBridgeResponse(cmd, nil, &bridge, "show", nil))
 	agent := out.String()

--- a/cmd/kata/export.go
+++ b/cmd/kata/export.go
@@ -64,7 +64,7 @@ func newExportCmd() *cobra.Command {
 			}); err != nil {
 				return err
 			}
-			if flags.Quiet || flags.JSON {
+			if flags.Quiet || currentOutputMode() == outputJSON {
 				return nil
 			}
 			switch currentOutputMode() {

--- a/cmd/kata/import.go
+++ b/cmd/kata/import.go
@@ -80,13 +80,19 @@ func resolveImportSourceFormat(cmd *cobra.Command, sourceFormat string) (string,
 }
 
 func legacyImportSourceFormat() string {
-	for _, format := range flags.FormatValues {
+	for _, format := range flags.Sel.formats {
 		format = strings.TrimSpace(format)
 		if isImportLegacySourceFormat(format) {
 			return format
 		}
 	}
-	return strings.TrimSpace(flags.Format)
+	// No legacy value: fall back to the last --format occurrence, which is what
+	// the removed singular format field held. The caller only acts on a legacy
+	// value, so a non-legacy string here is inert.
+	if n := len(flags.Sel.formats); n > 0 {
+		return strings.TrimSpace(flags.Sel.formats[n-1])
+	}
+	return ""
 }
 
 func validateBeadsImportFlags(cmd *cobra.Command) error {
@@ -322,7 +328,7 @@ func removeFreshPostgresTargetAfterFailure(
 }
 
 func writeImportSuccess(cmd *cobra.Command, target string) error {
-	if flags.Quiet || flags.JSON {
+	if flags.Quiet || currentOutputMode() == outputJSON {
 		return nil
 	}
 	var err error

--- a/cmd/kata/init_test.go
+++ b/cmd/kata/init_test.go
@@ -25,7 +25,7 @@ func TestInit_FreshGitRepoBindsViaRemote(t *testing.T) {
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
 	resetFlags(t)
-	flags.JSON = true
+	flags.Mode = outputJSON
 
 	ctx := context.Background()
 	out, err := callInit(ctx, env.URL, dir, callInitOpts{})
@@ -41,8 +41,8 @@ func TestInit_AddsLocalToGitignoreWhenAbsent(t *testing.T) {
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
 	require.NoError(t, err)
@@ -61,8 +61,8 @@ func TestInit_GitignoreIsIdempotent(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), //nolint:gosec // test fixture mirrors production .gitignore mode
 		[]byte("node_modules/\n.kata.local.toml\n"), 0o644))
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
 	require.NoError(t, err)
@@ -88,8 +88,8 @@ func TestInit_GitignoreLandsAtWorkspaceRoot(t *testing.T) {
 	sub := filepath.Join(root, "internal", "tui")
 	require.NoError(t, os.MkdirAll(sub, 0o755)) //nolint:gosec // test fixture under TempDir
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, sub, callInitOpts{})
 	require.NoError(t, err)
@@ -166,8 +166,8 @@ func TestInit_RemoteClient_SendsNameNotPath(t *testing.T) {
 
 	daemonStub := newFakeDaemon(t)
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), daemonStub.srv.URL, dir, callInitOpts{})
 	require.NoError(t, err)
@@ -192,8 +192,8 @@ func TestInit_RemoteClient_WritesGitignore(t *testing.T) {
 
 	daemonStub := newFakeDaemon(t)
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), daemonStub.srv.URL, dir, callInitOpts{})
 	require.NoError(t, err)
@@ -216,8 +216,8 @@ func TestInit_RemoteClient_FromSubdir(t *testing.T) {
 
 	daemonStub := newFakeDaemon(t)
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), daemonStub.srv.URL, sub, callInitOpts{})
 	require.NoError(t, err)
@@ -248,8 +248,8 @@ name     = "kata"
 
 	daemonStub := newFakeDaemon(t)
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), daemonStub.srv.URL, dir,
 		callInitOpts{Project: "other"})
@@ -275,8 +275,8 @@ func TestInit_RemoteClient_SendsAliasInfo(t *testing.T) {
 
 	daemonStub := newFakeDaemon(t)
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), daemonStub.srv.URL, dir, callInitOpts{})
 	require.NoError(t, err)
@@ -298,8 +298,8 @@ func TestInit_GitignoreAppendsToExisting(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), //nolint:gosec // test fixture mirrors production .gitignore mode
 		[]byte("dist/\n"), 0o644))
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
 	require.NoError(t, err)
@@ -312,7 +312,7 @@ func TestInit_GitignoreAppendsToExisting(t *testing.T) {
 
 func TestInit_AgentOutputReportsProjectWorkspaceAndChanged(t *testing.T) {
 	resetFlags(t)
-	flags.Agent = true
+	flags.Mode = outputAgent
 	dir := t.TempDir()
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
@@ -326,7 +326,7 @@ func TestInit_AgentOutputReportsProjectWorkspaceAndChanged(t *testing.T) {
 
 func TestInit_AgentOutputChangedWhenExistingProjectBindsFreshWorkspace(t *testing.T) {
 	resetFlags(t)
-	flags.Agent = true
+	flags.Mode = outputAgent
 	env := testenv.New(t)
 	_, err := env.DB.CreateProject(context.Background(), "kata")
 	require.NoError(t, err)
@@ -357,7 +357,7 @@ func TestInit_HumanOutputKeepsProjectCreatedSemanticsForFreshWorkspace(t *testin
 
 func TestInit_AgentOutputChangedWhenOnlyGitignoreUpdated(t *testing.T) {
 	resetFlags(t)
-	flags.Agent = true
+	flags.Mode = outputAgent
 	env := testenv.New(t)
 	_, err := env.DB.CreateProject(context.Background(), "kata")
 	require.NoError(t, err)
@@ -380,7 +380,7 @@ name     = "kata"
 
 func TestInit_AgentOutputQuotesProjectName(t *testing.T) {
 	resetFlags(t)
-	flags.Agent = true
+	flags.Mode = outputAgent
 	dir := t.TempDir()
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
@@ -401,14 +401,14 @@ func TestInit_MachineOutputSuppressesGitignoreWarning(t *testing.T) {
 		{
 			name: "agent",
 			configure: func() {
-				flags.Agent = true
+				flags.Mode = outputAgent
 			},
 			wantOut: "OK init project=kata workspace=",
 		},
 		{
 			name: "json",
 			configure: func() {
-				flags.JSON = true
+				flags.Mode = outputJSON
 			},
 			wantOut: `"kata_api_version":1`,
 		},
@@ -442,8 +442,8 @@ func TestInit_WithAgents_WritesAgentsFileWhenAbsent(t *testing.T) {
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
 	require.NoError(t, err)
@@ -461,8 +461,8 @@ func TestInit_WithoutFlag_DoesNotWriteAgents(t *testing.T) {
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{})
 	require.NoError(t, err)
@@ -476,8 +476,8 @@ func TestInit_WithAgents_Idempotent(t *testing.T) {
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
 	require.NoError(t, err)
@@ -499,8 +499,8 @@ func TestInit_WithAgents_AppendsToExistingFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), //nolint:gosec // test fixture under TempDir
 		[]byte("# House rules\n\nRun the linter before committing.\n"), 0o644))
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
 	require.NoError(t, err)
@@ -520,8 +520,8 @@ func TestInit_WithAgents_AppendsToExistingClaudeFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "CLAUDE.md"), //nolint:gosec // test fixture under TempDir
 		[]byte("# Claude rules\n\nUse the project test helper.\n"), 0o644))
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
 	require.NoError(t, err)
@@ -543,8 +543,8 @@ func TestInit_WithAgents_AppendsToBothAgentFilesWhenBothExist(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "CLAUDE.md"), //nolint:gosec // test fixture under TempDir
 		[]byte("# Claude rules\n\nUse the project test helper.\n"), 0o644))
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
 	require.NoError(t, err)
@@ -568,8 +568,8 @@ func TestInit_WithAgents_RefreshesStaleBlock(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), //nolint:gosec // test fixture under TempDir
 		[]byte("# House rules\n\n"+stale), 0o644))
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
 	require.NoError(t, err)
@@ -591,8 +591,8 @@ func TestInit_WithAgents_BlockIncludesWorkflowConventions(t *testing.T) {
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wesm/kata.git")
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
 	require.NoError(t, err)
@@ -612,8 +612,8 @@ func TestInit_WithAgents_BlockIncludesScheduleDueAndSomedayConventions(t *testin
 	runGit(t, dir, "init", "--quiet")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/example/example-project.git")
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
 	require.NoError(t, err)
@@ -658,8 +658,8 @@ func TestInit_WithAgents_RefreshesPreWorkConventionsBlock(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), //nolint:gosec // test fixture under TempDir
 		[]byte(fixture), 0o644))
 
-	flags.JSON = true
-	t.Cleanup(func() { flags.JSON = false })
+	flags.Mode = outputJSON
+	t.Cleanup(func() { flags.Mode = "" })
 
 	_, err := callInit(context.Background(), env.URL, dir, callInitOpts{WithAgents: true})
 	require.NoError(t, err)

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -16,19 +16,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// globalFlags carries the universal flags applied on every command.
+// globalFlags carries the universal flags applied on every command. Sel is the
+// output selection as typed; Mode is the single resolved answer, written once
+// by PersistentPreRunE and read everywhere through currentOutputMode().
 type globalFlags struct {
-	Format       string
-	FormatValues []string
-	JSON         bool
-	Agent        bool
-	Mode         outputMode
-	Quiet        bool
-	As           string
-	Workspace    string
-	Project      string
-	Daemon       string
-	Version      bool
+	Sel       outputSelection
+	Mode      outputMode
+	Quiet     bool
+	As        string
+	Workspace string
+	Project   string
+	Daemon    string
+	Version   bool
 }
 
 var flags globalFlags
@@ -75,16 +74,13 @@ func newRootCmd() *cobra.Command {
 				return err
 			}
 			flags.Mode = mode
-			if mode == outputJSON {
-				flags.JSON = true
-			}
 			return nil
 		},
 	}
-	cmd.PersistentFlags().Var(outputFormatFlag{value: &flags.Format, values: &flags.FormatValues},
+	cmd.PersistentFlags().Var(outputFormatFlag{values: &flags.Sel.formats},
 		"format", "output format: human|json|agent; contract for quickstart")
-	cmd.PersistentFlags().BoolVar(&flags.JSON, "json", false, "emit machine-readable JSON")
-	cmd.PersistentFlags().BoolVar(&flags.Agent, "agent", false, "emit concise agent-readable text")
+	cmd.PersistentFlags().BoolVar(&flags.Sel.json, "json", false, "emit machine-readable JSON")
+	cmd.PersistentFlags().BoolVar(&flags.Sel.agent, "agent", false, "emit concise agent-readable text")
 	cmd.PersistentFlags().BoolVarP(&flags.Quiet, "quiet", "q", false, "suppress non-essential output")
 	cmd.PersistentFlags().StringVar(&flags.As, "as", "", "override actor (default: $KATA_AUTHOR > $USER > git > anonymous)")
 	cmd.PersistentFlags().StringVar(&flags.Workspace, "workspace", "", "path used for project resolution (default: cwd)")
@@ -178,16 +174,6 @@ func main() {
 	}
 }
 
-// emitError preserves the legacy bool-shaped test/helper API while main uses
-// the resolved output mode.
-func emitError(w io.Writer, err error, jsonMode bool, runEReached bool) {
-	if jsonMode {
-		emitErrorForMode(w, err, outputJSON, runEReached)
-		return
-	}
-	emitErrorForMode(w, err, outputHuman, runEReached)
-}
-
 func emitErrorForMode(w io.Writer, err error, mode outputMode, runEReached bool) {
 	switch mode {
 	case outputJSON:
@@ -216,45 +202,8 @@ func resolvedOutputModeForError(root *cobra.Command, args []string) (outputMode,
 	if flags.Mode != "" {
 		return flags.Mode, nil
 	}
-	importLegacy := false
-	if cmd := commandFromArgs(root, args); isImportCommand(cmd) {
-		importLegacy = true
-	}
-	mode, err := resolveOutputModeArgsForCommand(args, flags.Format, flags.JSON, flags.Agent, importLegacy, root)
-	if err != nil {
-		return outputModeHintForResolutionError(importLegacy), err
-	}
-	return mode, nil
-}
-
-func outputModeHintForResolutionError(importLegacy bool) outputMode {
-	formats := flags.FormatValues
-	if len(formats) == 0 && flags.Format != "" {
-		formats = []string{flags.Format}
-	}
-	selected := make([]outputMode, 0, len(formats)+2)
-	for _, format := range formats {
-		switch mode := outputMode(outputFormatValue(format, importLegacy)); mode {
-		case outputHuman, outputJSON, outputAgent:
-			selected = append(selected, mode)
-		}
-	}
-	if flags.JSON {
-		selected = append(selected, outputJSON)
-	}
-	if flags.Agent {
-		selected = append(selected, outputAgent)
-	}
-	if len(selected) == 0 {
-		return outputHuman
-	}
-	first := selected[0]
-	for _, mode := range selected[1:] {
-		if mode != first {
-			return outputHuman
-		}
-	}
-	return first
+	cmd, sel := preParse(root, args)
+	return sel.resolve(isImportCommand(cmd), supportsContractOutput(cmd))
 }
 
 func commandNameForError(root *cobra.Command, args []string, runEReached bool) string {
@@ -262,36 +211,11 @@ func commandNameForError(root *cobra.Command, args []string, runEReached bool) s
 		return errorCommandName
 	}
 	if !runEReached {
-		if cmd := commandFromArgs(root, args); cmd != nil && cmd != root {
+		if cmd, _ := preParse(root, args); cmd != nil && cmd != root {
 			return commandLeaf(cmd)
 		}
 	}
 	return "kata"
-}
-
-func commandFromArgs(root *cobra.Command, args []string) *cobra.Command {
-	if root == nil {
-		return nil
-	}
-	cmd := root
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--" {
-			break
-		}
-		if strings.HasPrefix(arg, "-") {
-			if flagArgConsumesValue(cmd, arg) && i+1 < len(args) {
-				i++
-			}
-			continue
-		}
-		next := childCommandByName(cmd, arg)
-		if next == nil {
-			break
-		}
-		cmd = next
-	}
-	return cmd
 }
 
 func childCommandByName(cmd *cobra.Command, name string) *cobra.Command {
@@ -307,24 +231,6 @@ func childCommandByName(cmd *cobra.Command, name string) *cobra.Command {
 		}
 	}
 	return nil
-}
-
-func flagArgConsumesValue(cmd *cobra.Command, arg string) bool {
-	name := strings.TrimLeft(arg, "-")
-	if found := strings.Contains(name, "="); found {
-		return false
-	}
-	if name == "" {
-		return false
-	}
-	flag := cmd.Flags().Lookup(name)
-	if flag == nil {
-		flag = cmd.PersistentFlags().Lookup(name)
-	}
-	if flag == nil {
-		flag = cmd.InheritedFlags().Lookup(name)
-	}
-	return flag != nil && flag.Value.Type() != "bool"
 }
 
 func commandLeaf(cmd *cobra.Command) string {

--- a/cmd/kata/main_test.go
+++ b/cmd/kata/main_test.go
@@ -91,10 +91,8 @@ func assertNoFederationStorageInternals(t *testing.T, out string, msgAndArgs ...
 
 func TestNewRootCmdResetsGlobalFlagState(t *testing.T) {
 	resetFlags(t)
-	flags.Format = "json"
-	flags.FormatValues = []string{"json"}
-	flags.JSON = true
-	flags.Agent = true
+	flags.Sel = outputSelection{formats: []string{"json"}, json: true, agent: true}
+	flags.Mode = outputJSON
 	flags.Workspace = "/tmp/leaked"
 	flags.Daemon = "shared"
 
@@ -105,9 +103,9 @@ func TestNewRootCmdResetsGlobalFlagState(t *testing.T) {
 	cmd.SetArgs([]string{"version"})
 
 	require.NoError(t, cmd.Execute())
-	assert.False(t, flags.JSON)
-	assert.False(t, flags.Agent)
-	assert.Empty(t, flags.FormatValues)
+	assert.Equal(t, outputSelection{}, flags.Sel)
+	assert.Equal(t, outputHuman, flags.Mode,
+		"a run with no output flags resolves to human, not the leaked mode")
 	assert.Empty(t, flags.Workspace)
 	assert.Empty(t, flags.Daemon)
 }
@@ -259,7 +257,7 @@ func TestEmitError_JSONMode_ProducesParseableEnvelope(t *testing.T) {
 		ExitCode: ExitNotFound,
 	}
 	var buf bytes.Buffer
-	emitError(&buf, cli, true, true)
+	emitErrorForMode(&buf, cli, outputJSON, true)
 	got := parseErrorEnvelope(t, buf.Bytes())
 	assert.Equal(t, "not_found", got.Error.Kind)
 	assert.Equal(t, "issue_not_found", got.Error.Code)
@@ -276,7 +274,7 @@ func TestEmitError_HumanMode_StillPrintsKataPrefix(t *testing.T) {
 		ExitCode: ExitValidation,
 	}
 	var buf bytes.Buffer
-	emitError(&buf, cli, false, true)
+	emitErrorForMode(&buf, cli, outputHuman, true)
 	assert.Contains(t, buf.String(), "kata: title must not be empty")
 }
 
@@ -403,6 +401,31 @@ func TestOutputMode_ContractConflictsWithAgentAndJSON(t *testing.T) {
 	}
 }
 
+func TestEmitError_QuickstartContractConflictUsesAgentFallback(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	stdout, stderr, err := executeRootCapture(t, context.Background(),
+		"quickstart", "--agent", "--format", "contract")
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Truef(t, strings.HasPrefix(stderr, "ERR quickstart usage:"),
+		"contract conflict should retain agent error output, got %q", stderr)
+	assert.Contains(t, stderr, "conflicting output modes")
+}
+
+func TestEmitError_QuickstartContractConflictUsesJSONFallback(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	stdout, stderr, err := executeRootCapture(t, context.Background(),
+		"quickstart", "--format", "contract", "--format", "json")
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	got := parseErrorEnvelope(t, []byte(stderr))
+	assert.Equal(t, "usage", got.Error.Kind)
+	assert.Equal(t, "conflicting output modes", got.Error.Message)
+	assert.Equal(t, ExitUsage, got.Error.ExitCode)
+}
+
 func TestEmitError_RawModeScanParsesJSONTrueValue(t *testing.T) {
 	resetRunEEntered(t)
 	resetFlags(t)
@@ -493,6 +516,20 @@ func TestEmitError_AgentMode_CommandArgErrorUsesLeafCommand(t *testing.T) {
 		"stderr should start with agent usage error for show, got %q", stderr)
 }
 
+// TestEmitError_AgentMode_FlagParseErrorUsesLeafCommand covers the only
+// consumer of the error path's fallback mode: cobra rejects the flags before
+// PersistentPreRunE resolves an output mode, so the ERR line's mode has to be
+// recovered from argv. Without that, an --agent caller gets a human-shaped
+// error it cannot parse.
+func TestEmitError_AgentMode_FlagParseErrorUsesLeafCommand(t *testing.T) {
+	resetRunEEntered(t)
+	resetFlags(t)
+	_, stderr, err := executeRootCapture(t, context.Background(), "--agent", "show", "--nonexistent-flag")
+	require.Error(t, err)
+	assert.Truef(t, strings.HasPrefix(stderr, "ERR show usage:"),
+		"a flag-parse failure under --agent must still emit the agent ERR shape, got %q", stderr)
+}
+
 // TestEmitError_NonCliError_SynthesizesEnvelope confirms a plain
 // error (e.g. a network failure that escaped the cliError wrap)
 // still gets a uniform JSON envelope when --json is set, with the
@@ -500,7 +537,7 @@ func TestEmitError_AgentMode_CommandArgErrorUsesLeafCommand(t *testing.T) {
 func TestEmitError_NonCliError_SynthesizesEnvelope(t *testing.T) {
 	plain := errors.New("connection refused")
 	var buf bytes.Buffer
-	emitError(&buf, plain, true, true) // runEReached=true → ExitInternal/internal
+	emitErrorForMode(&buf, plain, outputJSON, true) // runEReached=true → ExitInternal/internal
 	got := parseErrorEnvelope(t, buf.Bytes())
 	assert.Equal(t, "internal", got.Error.Kind)
 	assert.Equal(t, "connection refused", got.Error.Message)

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -10,7 +10,6 @@ import (
 	"unicode"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"go.kenn.io/kata/internal/textsafe"
 )
 
@@ -46,22 +45,22 @@ type agentIssueMutation struct {
 	PreviousOwner *string `json:"previous_owner,omitempty"`
 }
 
+// outputFormatFlag records every --format occurrence in order. pflag calls Set
+// once per occurrence; the last value is what String() reports for help text.
 type outputFormatFlag struct {
-	value  *string
 	values *[]string
 }
 
 func (f outputFormatFlag) Set(s string) error {
-	*f.value = s
 	*f.values = append(*f.values, s)
 	return nil
 }
 
 func (f outputFormatFlag) String() string {
-	if f.value == nil {
+	if f.values == nil || len(*f.values) == 0 {
 		return ""
 	}
-	return *f.value
+	return (*f.values)[len(*f.values)-1]
 }
 
 func (f outputFormatFlag) Type() string { return "string" }
@@ -115,29 +114,41 @@ func printAgentMutationDecoded(
 	return nil
 }
 
-func resolveOutputModeFormats(
-	formats []string,
-	fallback string,
-	importLegacy bool,
-	contractAllowed bool,
-	jsonFlag, agentFlag bool,
-) (outputMode, error) {
-	if len(formats) == 0 && fallback != "" {
-		formats = []string{fallback}
-	}
+// outputSelection is the output-mode flags exactly as the user typed them. It
+// is written only by flag parsing (and by preParse on the error path) and
+// never by resolution, so it can never be contradicted by its own result.
+type outputSelection struct {
+	formats []string // every --format occurrence, in order
+	json    bool     // --json as typed
+	agent   bool     // --agent as typed
+}
+
+// resolve reduces the selection to one output mode. On failure it returns the
+// error together with a best-effort fallback mode to render that error in:
+// the agreed-upon human, JSON, or agent mode, else human. Contract participates
+// in validation but is not an error-rendering mode.
+//
+// importLegacy marks `kata import`, whose --format also carries the legacy
+// kata|beads source-format overload; those values select no output mode and
+// are skipped rather than rejected. contractAllowed marks commands such as
+// quickstart whose output contract is a supported format.
+func (s outputSelection) resolve(importLegacy, contractAllowed bool) (outputMode, error) {
 	wanted := "human, json, or agent"
 	if contractAllowed {
 		wanted = "human, json, agent, or contract"
 	}
-	var selected []outputMode
-	for _, format := range formats {
+	selected := make([]outputMode, 0, len(s.formats)+2)
+	fallbackSelected := make([]outputMode, 0, len(s.formats)+2)
+	badFormat := ""
+	for _, format := range s.formats {
 		format = outputFormatValue(format, importLegacy)
 		if format == "" {
 			continue
 		}
-		switch outputMode(format) {
+		switch mode := outputMode(format); mode {
 		case outputHuman, outputJSON, outputAgent:
-			selected = append(selected, outputMode(format))
+			selected = append(selected, mode)
+			fallbackSelected = append(fallbackSelected, mode)
 		case outputContract:
 			if contractAllowed {
 				selected = append(selected, outputContract)
@@ -145,139 +156,165 @@ func resolveOutputModeFormats(
 			}
 			fallthrough
 		default:
-			return "", &cliError{
-				Message:  "unsupported output format " + strconv.Quote(format) + " (want " + wanted + ")",
-				Kind:     kindUsage,
-				ExitCode: ExitUsage,
+			if badFormat == "" {
+				badFormat = format
 			}
 		}
 	}
-	if jsonFlag {
+	if s.json {
 		selected = append(selected, outputJSON)
+		fallbackSelected = append(fallbackSelected, outputJSON)
 	}
-	if agentFlag {
+	if s.agent {
 		selected = append(selected, outputAgent)
+		fallbackSelected = append(fallbackSelected, outputAgent)
 	}
-	if len(selected) == 0 {
-		return outputHuman, nil
-	}
-	first := selected[0]
-	for _, mode := range selected[1:] {
-		if mode != first {
-			return "", &cliError{Message: "conflicting output modes", Kind: kindUsage, ExitCode: ExitUsage}
+
+	agreed := outputHuman
+	consistent := true
+	if len(selected) > 0 {
+		agreed = selected[0]
+		for _, mode := range selected[1:] {
+			if mode != agreed {
+				consistent = false
+				break
+			}
 		}
 	}
-	return first, nil
+	fallback := outputHuman
+	if len(fallbackSelected) > 0 {
+		fallback = fallbackSelected[0]
+		for _, mode := range fallbackSelected[1:] {
+			if mode != fallback {
+				fallback = outputHuman
+				break
+			}
+		}
+	}
+
+	// An unsupported format outranks a conflict, matching the order the
+	// selection is read in: a value that names no mode at all is reported
+	// before modes that merely disagree.
+	if badFormat != "" {
+		return fallback, &cliError{
+			Message:  "unsupported output format " + strconv.Quote(badFormat) + " (want " + wanted + ")",
+			Kind:     kindUsage,
+			ExitCode: ExitUsage,
+		}
+	}
+	if !consistent {
+		return fallback, &cliError{Message: "conflicting output modes", Kind: kindUsage, ExitCode: ExitUsage}
+	}
+	return agreed, nil
 }
 
-func resolveOutputModeValues(format string, jsonFlag, agentFlag bool) (outputMode, error) {
-	return resolveOutputModeFormats(nil, format, false, false, jsonFlag, agentFlag)
-}
-
+// currentOutputMode returns the resolved output mode. PersistentPreRunE
+// resolves it exactly once before any RunE runs; an empty Mode means
+// resolution has not happened (the error path, where cobra failed first), and
+// human is the safe answer there.
 func currentOutputMode() outputMode {
 	if flags.Mode != "" {
 		return flags.Mode
-	}
-	if flags.Agent {
-		return outputAgent
-	}
-	if flags.JSON {
-		return outputJSON
 	}
 	return outputHuman
 }
 
 func resolveOutputModeForCommand(cmd *cobra.Command) (outputMode, error) {
-	format := flags.Format
-	if isImportCommand(cmd) && isImportLegacySourceFormat(format) {
-		format = ""
+	return flags.Sel.resolve(isImportCommand(cmd), supportsContractOutput(cmd))
+}
+
+// preParse walks argv once, returning the command those args select and the
+// output flags they carry. It is used only on the error path, where cobra
+// failed before PersistentPreRunE could resolve a mode, so it is total: it
+// never returns an error and never panics, and an argv it cannot interpret
+// simply yields the root command and an empty selection.
+//
+// A `-`-prefixed token is always a flag, never a command name — that is the
+// point where the two walkers this replaces used to disagree, one of them
+// abandoning command resolution at a shorthand like -q. An unrecognized
+// *positional* stops command resolution (the command path cannot continue past
+// it) but flag scanning continues to the end of argv. Everything after `--` is
+// positional by definition and is not scanned.
+//
+// --format, --json, and --agent are root-persistent, so they are valid on every
+// command and are recorded wherever they appear.
+func preParse(root *cobra.Command, args []string) (*cobra.Command, outputSelection) {
+	var sel outputSelection
+	if root == nil {
+		return nil, sel
 	}
-	return resolveOutputModeFormats(
-		flags.FormatValues,
-		format,
-		isImportCommand(cmd),
-		supportsContractOutput(cmd),
-		flags.JSON,
-		flags.Agent,
-	)
-}
-
-func resolveOutputModeArgs(args []string, format string, jsonFlag, agentFlag bool) (outputMode, error) {
-	return resolveOutputModeArgsForCommand(args, format, jsonFlag, agentFlag, false, nil)
-}
-
-func resolveOutputModeArgsForCommand(
-	args []string,
-	format string,
-	jsonFlag, agentFlag bool,
-	importLegacy bool,
-	root *cobra.Command,
-) (outputMode, error) {
 	cmd := root
-	formats := append([]string(nil), flags.FormatValues...)
 	commandPathStopped := false
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
-			return resolveOutputModeFormats(
-				formats, format, importLegacy, supportsContractOutput(cmd), jsonFlag, agentFlag,
-			)
+			break
 		}
-		name, value, hasValue, ok := splitLongFlag(arg)
-		if !ok {
+		if !strings.HasPrefix(arg, "-") {
 			if !commandPathStopped {
 				if next := childCommandByName(cmd, arg); next != nil {
 					cmd = next
-				} else {
-					commandPathStopped = true
+					continue
 				}
+				commandPathStopped = true
 			}
+			continue
+		}
+		name, value, hasValue, ok := splitLongFlag(arg)
+		if !ok {
+			// A shorthand cluster (-q, -1). None of the output flags has a
+			// shorthand, so there is nothing to record; a shorthand's value
+			// token, if any, is handled by the positional branch above.
 			continue
 		}
 		switch name {
 		case "json":
-			if !rawFlagKnown(cmd, name) {
-				continue
-			}
 			if hasValue {
 				if parsed, err := strconv.ParseBool(value); err == nil {
-					jsonFlag = parsed
+					sel.json = parsed
 				}
 			} else {
-				jsonFlag = true
+				sel.json = true
 			}
 		case "agent":
-			if !rawFlagKnown(cmd, name) {
-				continue
-			}
 			if hasValue {
 				if parsed, err := strconv.ParseBool(value); err == nil {
-					agentFlag = parsed
+					sel.agent = parsed
 				}
 			} else {
-				agentFlag = true
+				sel.agent = true
 			}
 		case "format":
-			if !rawFlagKnown(cmd, name) {
-				continue
-			}
 			if hasValue {
-				format = value
-				formats = append(formats, value)
+				sel.formats = append(sel.formats, value)
 			} else if i+1 < len(args) {
-				format = args[i+1]
-				formats = append(formats, args[i+1])
+				sel.formats = append(sel.formats, args[i+1])
 				i++
 			}
 		default:
-			if rawFlagConsumesValue(cmd, name) && !hasValue && i+1 < len(args) {
+			if flagConsumesValue(cmd, name) && !hasValue && i+1 < len(args) {
 				i++
 			}
 		}
 	}
-	return resolveOutputModeFormats(
-		formats, format, importLegacy, supportsContractOutput(cmd), jsonFlag, agentFlag,
-	)
+	return cmd, sel
+}
+
+// flagConsumesValue reports whether cmd's long flag `name` takes a following
+// argument, so preParse can skip that argument instead of mistaking it for a
+// command name (`--workspace /path list`).
+func flagConsumesValue(cmd *cobra.Command, name string) bool {
+	if cmd == nil || name == "" {
+		return false
+	}
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
+		flag = cmd.PersistentFlags().Lookup(name)
+	}
+	if flag == nil {
+		flag = cmd.InheritedFlags().Lookup(name)
+	}
+	return flag != nil && flag.Value.Type() != "bool"
 }
 
 func splitLongFlag(arg string) (name, value string, hasValue bool, ok bool) {
@@ -292,58 +329,6 @@ func splitLongFlag(arg string) (name, value string, hasValue bool, ok bool) {
 		return before, after, true, true
 	}
 	return trimmed, "", false, true
-}
-
-func rawFlagKnown(cmd *cobra.Command, name string) bool {
-	if cmd == nil {
-		return isRootPersistentFlag(name)
-	}
-	return lookupRawFlag(cmd, name) != nil
-}
-
-func rawFlagConsumesValue(cmd *cobra.Command, name string) bool {
-	if cmd == nil {
-		return isRootStringFlag(name)
-	}
-	flag := lookupRawFlag(cmd, name)
-	return flag != nil && flag.Value.Type() != "bool"
-}
-
-func lookupRawFlag(cmd *cobra.Command, name string) *pflag.Flag {
-	if cmd == nil {
-		return nil
-	}
-	if flag := cmd.Flags().Lookup(name); flag != nil {
-		return flag
-	}
-	if flag := cmd.PersistentFlags().Lookup(name); flag != nil {
-		return flag
-	}
-	if flag := cmd.InheritedFlags().Lookup(name); flag != nil {
-		return flag
-	}
-	if root := cmd.Root(); root != nil {
-		return root.PersistentFlags().Lookup(name)
-	}
-	return nil
-}
-
-func isRootPersistentFlag(name string) bool {
-	switch name {
-	case "format", "json", "agent", "quiet", "as", "workspace", "project":
-		return true
-	default:
-		return false
-	}
-}
-
-func isRootStringFlag(name string) bool {
-	switch name {
-	case "format", "as", "workspace", "project":
-		return true
-	default:
-		return false
-	}
 }
 
 func outputFormatValue(format string, importLegacy bool) string {

--- a/cmd/kata/output_mode_test.go
+++ b/cmd/kata/output_mode_test.go
@@ -9,29 +9,69 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolveOutputMode(t *testing.T) {
+// TestOutputModePrecedenceTable pins the user-visible --format/--json/--agent
+// contract: how repeated and mixed selections resolve, when they conflict,
+// which commands allow contract output, and how the import command's legacy
+// --format kata|beads overload is skipped rather than rejected.
+func TestOutputModePrecedenceTable(t *testing.T) {
 	cases := []struct {
-		name    string
-		format  string
-		json    bool
-		agent   bool
-		want    outputMode
-		wantErr string
+		name            string
+		formats         []string
+		json            bool
+		agent           bool
+		importLegacy    bool
+		contractAllowed bool
+		want            outputMode
+		wantErr         string
 	}{
-		{name: "default human", want: outputHuman},
-		{name: "format json", format: "json", want: outputJSON},
-		{name: "json alias", json: true, want: outputJSON},
-		{name: "agent alias", agent: true, want: outputAgent},
-		{name: "matching agent flags", format: "agent", agent: true, want: outputAgent},
-		{name: "conflicting modes", format: "human", json: true, wantErr: "conflicting output modes"},
-		{name: "bad format", format: "xml", wantErr: "unsupported output format"},
+		{name: "no selection is human", want: outputHuman},
+		{name: "--json", json: true, want: outputJSON},
+		{name: "--agent", agent: true, want: outputAgent},
+		{name: "--format human", formats: []string{"human"}, want: outputHuman},
+		{name: "--format json", formats: []string{"json"}, want: outputJSON},
+		{name: "--format agent", formats: []string{"agent"}, want: outputAgent},
+		{name: "repeated --format agreeing", formats: []string{"json", "json"}, want: outputJSON},
+		{name: "repeated --format disagreeing", formats: []string{"human", "json"},
+			wantErr: "conflicting output modes"},
+		{name: "--format json with --agent", formats: []string{"json"}, agent: true,
+			wantErr: "conflicting output modes"},
+		{name: "--format human with --json", formats: []string{"human"}, json: true,
+			wantErr: "conflicting output modes"},
+		{name: "--format agent with --agent agrees", formats: []string{"agent"}, agent: true,
+			want: outputAgent},
+		{name: "--json with --agent", json: true, agent: true,
+			wantErr: "conflicting output modes"},
+		{name: "empty format value is skipped", formats: []string{""}, want: outputHuman},
+		{name: "empty format value does not conflict", formats: []string{"", "json"}, want: outputJSON},
+		{name: "unsupported format", formats: []string{"xml"},
+			wantErr: `unsupported output format "xml"`},
+		{name: "contract allowed", formats: []string{"contract"}, contractAllowed: true,
+			want: outputContract},
+		{name: "contract disallowed", formats: []string{"contract"},
+			wantErr: `unsupported output format "contract"`},
+		{name: "contract allowed with --json", formats: []string{"contract"}, contractAllowed: true,
+			json: true, wantErr: "conflicting output modes"},
+		{name: "contract allowed with --agent", formats: []string{"contract"}, contractAllowed: true,
+			agent: true, wantErr: "conflicting output modes"},
+		{name: "import legacy beads is skipped", formats: []string{"beads"}, importLegacy: true,
+			want: outputHuman},
+		{name: "import legacy kata is skipped", formats: []string{"kata"}, importLegacy: true,
+			want: outputHuman},
+		{name: "import legacy beads with --json still json", formats: []string{"beads"},
+			importLegacy: true, json: true, want: outputJSON},
+		{name: "beads outside import is unsupported", formats: []string{"beads"},
+			wantErr: `unsupported output format "beads"`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := resolveOutputModeValues(tc.format, tc.json, tc.agent)
+			sel := outputSelection{formats: tc.formats, json: tc.json, agent: tc.agent}
+			got, err := sel.resolve(tc.importLegacy, tc.contractAllowed)
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
+				var cli *cliError
+				require.ErrorAs(t, err, &cli)
+				assert.Equal(t, ExitUsage, cli.ExitCode, "a bad output selection is a usage error")
 				return
 			}
 			require.NoError(t, err)
@@ -40,10 +80,171 @@ func TestResolveOutputMode(t *testing.T) {
 	}
 }
 
-func TestResolveOutputModeArgs_BadFormatOutsideImport(t *testing.T) {
-	_, err := resolveOutputModeArgs([]string{"--format", "xml"}, "", false, false)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unsupported output format")
+// TestOutputSelectionResolveFallbackMode pins the mode resolve returns
+// alongside an error. That mode is what emitRootError renders the failure in,
+// so an --agent caller whose other flag was bad still gets a parseable ERR
+// line rather than human prose.
+func TestOutputSelectionResolveFallbackMode(t *testing.T) {
+	cases := []struct {
+		name            string
+		sel             outputSelection
+		contractAllowed bool
+		want            outputMode
+	}{
+		{
+			name: "unsupported format alongside --agent falls back to agent",
+			sel:  outputSelection{formats: []string{"xml"}, agent: true},
+			want: outputAgent,
+		},
+		{
+			name: "unsupported format alongside --json falls back to json",
+			sel:  outputSelection{formats: []string{"xml"}, json: true},
+			want: outputJSON,
+		},
+		{
+			name: "unsupported format alone falls back to human",
+			sel:  outputSelection{formats: []string{"xml"}},
+			want: outputHuman,
+		},
+		{
+			name: "conflicting selection falls back to human",
+			sel:  outputSelection{formats: []string{"json"}, agent: true},
+			want: outputHuman,
+		},
+		{
+			name:            "contract conflict with --agent falls back to agent",
+			sel:             outputSelection{formats: []string{"contract"}, agent: true},
+			contractAllowed: true,
+			want:            outputAgent,
+		},
+		{
+			name:            "contract conflict with json format falls back to json",
+			sel:             outputSelection{formats: []string{"contract", "json"}},
+			contractAllowed: true,
+			want:            outputJSON,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.sel.resolve(false, tc.contractAllowed)
+			require.Error(t, err)
+			assert.Equal(t, tc.want, got, "resolve must return a usable mode with its error")
+		})
+	}
+}
+
+// errorPathArgvCases are the argv shapes whose command selection and resolved
+// output mode the error path must reproduce. -q is the shorthand case where
+// the former argv walkers disagreed: one resolved `import` while the other
+// abandoned command resolution at the shorthand and stayed on root.
+var errorPathArgvCases = []struct {
+	name        string
+	args        []string
+	wantCommand string
+	wantSel     outputSelection
+	wantMode    outputMode
+}{
+	{
+		name: "shorthand before import with legacy format",
+		args: []string{"-q", "import", "--format", "beads"},
+		// beads is the legacy import-source value, skipped for mode selection.
+		wantCommand: "import",
+		wantSel:     outputSelection{formats: []string{"beads"}},
+		wantMode:    outputHuman,
+	},
+	{
+		name:        "root string flag with value then subcommand flag",
+		args:        []string{"--workspace", "/tmp/example-workspace", "list", "--json"},
+		wantCommand: "list",
+		wantSel:     outputSelection{json: true},
+		wantMode:    outputJSON,
+	},
+	{
+		name: "flags after the -- separator are positional",
+		args: []string{"list", "--", "--json"},
+		// --json after -- is a positional, so it must not select JSON.
+		wantCommand: "list",
+		wantSel:     outputSelection{},
+		wantMode:    outputHuman,
+	},
+	{
+		name:        "attached long-flag value before the command",
+		args:        []string{"--format=agent", "show", "abc4"},
+		wantCommand: "show",
+		wantSel:     outputSelection{formats: []string{"agent"}},
+		wantMode:    outputAgent,
+	},
+	{
+		name:        "quickstart contract format",
+		args:        []string{"quickstart", "--format", "contract"},
+		wantCommand: "quickstart",
+		wantSel:     outputSelection{formats: []string{"contract"}},
+		wantMode:    outputContract,
+	},
+}
+
+// TestErrorPathArgvSelectsCommand pins which command each argv shape selects
+// and which output flags it carries. The command decides importLegacy and
+// contractAllowed, which decide whether overloaded --format values are valid.
+func TestErrorPathArgvSelectsCommand(t *testing.T) {
+	for _, tc := range errorPathArgvCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := newRootCmd()
+			cmd, sel := preParse(root, tc.args)
+			require.NotNil(t, cmd)
+			assert.Equal(t, tc.wantCommand, commandLeaf(cmd))
+			assert.Equal(t, tc.wantSel, sel)
+		})
+	}
+}
+
+// TestPreParseIsTotal covers the degenerate inputs the error path can hand
+// preParse: it must answer without panicking, since it runs after cobra has
+// already failed.
+func TestPreParseIsTotal(t *testing.T) {
+	root := newRootCmd()
+	for _, args := range [][]string{
+		nil,
+		{},
+		{"--"},
+		{"--format"},                       // trailing flag with no value
+		{"--json=notabool"},                // unparseable bool value
+		{"-1"},                             // negative-number positional
+		{"nonexistent", "--agent"},         // unknown command, flag still counts
+		{"show", "abc4", "def5", "--json"}, // extra positionals do not stop flags
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			cmd, sel := preParse(root, args)
+			assert.NotNil(t, cmd)
+			mode, _ := sel.resolve(isImportCommand(cmd), supportsContractOutput(cmd))
+			assert.Contains(t, []outputMode{outputHuman, outputJSON, outputAgent, outputContract}, mode)
+		})
+	}
+	cmd, sel := preParse(root, []string{"nonexistent", "--agent"})
+	assert.Same(t, root, cmd, "an unknown command leaves the root selected")
+	assert.True(t, sel.agent, "flags after an unknown positional still count")
+
+	cmd, sel = preParse(root, []string{"show", "abc4", "def5", "--json"})
+	assert.Equal(t, "show", commandLeaf(cmd))
+	assert.True(t, sel.json, "extra positionals stop command resolution, not flag scanning")
+
+	_, sel = preParse(root, []string{"--json=notabool"})
+	assert.False(t, sel.json, "an unparseable --json value leaves the selection untouched")
+}
+
+// TestErrorPathArgvResolvesMode pins the end-to-end error-path answer: the mode
+// emitRootError renders in when cobra failed before PersistentPreRunE could
+// resolve one.
+func TestErrorPathArgvResolvesMode(t *testing.T) {
+	for _, tc := range errorPathArgvCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetFlags(t)
+			root := newRootCmd()
+			got, err := resolvedOutputModeForError(root, tc.args)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMode, got)
+		})
+	}
 }
 
 func TestAgentValue_Quoting(t *testing.T) {

--- a/cmd/kata/projects.go
+++ b/cmd/kata/projects.go
@@ -72,7 +72,7 @@ func projectsCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if flags.JSON {
+			if currentOutputMode() == outputJSON {
 				var buf bytes.Buffer
 				if err := emitJSON(&buf, json.RawMessage(bs)); err != nil {
 					return err

--- a/cmd/kata/testhelpers_test.go
+++ b/cmd/kata/testhelpers_test.go
@@ -398,7 +398,7 @@ func runCLIWithErr(t *testing.T, env *testenv.Env, dir string, args ...string) (
 	cmd.SetContext(contextWithBaseURL(context.Background(), env.URL))
 	err = cmd.Execute()
 	if err != nil {
-		emitError(&se, err, false, true)
+		emitErrorForMode(&se, err, outputHuman, true)
 	}
 	return so.String(), se.String(), err
 }

--- a/cmd/kata/wait.go
+++ b/cmd/kata/wait.go
@@ -133,15 +133,35 @@ type waitJSONOutput struct {
 	Abandoned []waitAbandoned `json:"abandoned,omitempty"`
 }
 
+// waitTargetState is a ref's position in the per-run lifecycle: pending →
+// satisfied, or pending → abandoned. One field rather than a done/abandoned
+// bool pair, which admitted the meaningless "done and abandoned" combination
+// and forced every reader to re-derive pending as !done && !abandoned.
+type waitTargetState int
+
+const (
+	targetPending waitTargetState = iota
+	targetSatisfied
+	targetAbandoned
+)
+
+// waitJoin is the multi-ref join rule. The zero value is joinAll because --all
+// is the documented default when neither --any nor --all is passed.
+type waitJoin int
+
+const (
+	joinAll waitJoin = iota
+	joinAny
+)
+
 // waitTarget is a ref's mutable per-run state.
 type waitTarget struct {
 	arg        string // user-supplied ref, used verbatim for display
 	pid        int64
 	refForAPI  string
 	fails      int
-	done       bool
-	abandoned  bool  // dropped from the join after a permanent fetch error (--any)
-	abandonErr error // the permanent error that caused abandonment
+	state      waitTargetState
+	abandonErr error // the permanent error that moved this ref to targetAbandoned
 	result     waitResult
 }
 
@@ -151,6 +171,28 @@ type waitOptions struct {
 	pollInterval time.Duration
 	anyMode      bool
 	allMode      bool
+}
+
+// waitRun is the immutable per-invocation plan: what each ref is waiting for,
+// how the refs join, and the single deadline every elapsed check reads.
+type waitRun struct {
+	mode     waitMode
+	join     waitJoin
+	start    time.Time
+	deadline time.Time // zero = wait forever (--timeout 0)
+	poll     time.Duration
+}
+
+// expired reports whether the wait's own --timeout deadline has passed.
+//
+// This is deliberately a wall-clock comparison and must never be conflated
+// with ctx.Err(): the wait's context is derived from the caller's, so a parent
+// context deadline also surfaces as context.DeadlineExceeded here. Attributing
+// that to --timeout would report a caller's budget exhaustion as a wait
+// timeout (exit 8, timed_out=true) instead of the real error. Callers that
+// need both conditions test ctx.Err() and expired() together.
+func (r waitRun) expired() bool {
+	return !r.deadline.IsZero() && !time.Now().Before(r.deadline)
 }
 
 func newWaitCmd() *cobra.Command {
@@ -240,18 +282,29 @@ func runWait(cmd *cobra.Command, args []string, opts waitOptions) error {
 			ExitCode: ExitValidation,
 		}
 	}
-	anyMode := opts.anyMode // --all is the default when neither is set
+	// --all is the default when neither flag is set, and joinAll is the zero
+	// value, so only --any needs an explicit assignment.
+	join := joinAll
+	if opts.anyMode {
+		join = joinAny
+	}
 
 	originalCtx := cmd.Context()
-	start := time.Now()
+	run := waitRun{
+		mode:  mode,
+		join:  join,
+		start: time.Now(),
+		poll:  opts.pollInterval,
+	}
 	ctx := originalCtx
 	var cancel context.CancelFunc
 	if opts.timeout > 0 {
-		ctx, cancel = context.WithDeadline(originalCtx, start.Add(opts.timeout))
+		run.deadline = run.start.Add(opts.timeout)
+		ctx, cancel = context.WithDeadline(originalCtx, run.deadline)
 		defer cancel()
 		// Ref/project resolution reads cmd.Context(), so temporarily install the
 		// wait deadline before resolving refs. Restore the original context before
-		// returning so tests and future callers do not observe a mutated command.
+		// returning so tests and future callers do not observe a mutated context.
 		cmd.SetContext(ctx)
 		defer cmd.SetContext(originalCtx)
 	}
@@ -268,8 +321,7 @@ func runWait(cmd *cobra.Command, args []string, opts waitOptions) error {
 			// (e.g. a caller's ExecuteContext budget) also surfaces as
 			// DeadlineExceeded on the derived context, and that failure must
 			// return the resolution error, not timed_out=true.
-			if opts.timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) &&
-				!time.Now().Before(start.Add(opts.timeout)) {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) && run.expired() {
 				if err := emitWaitJSON(cmd, waitJSONOutput{
 					Results:  []waitResult{},
 					TimedOut: true,
@@ -290,11 +342,10 @@ func runWait(cmd *cobra.Command, args []string, opts waitOptions) error {
 		return err
 	}
 
-	// Bound every state fetch by the wait deadline so a hung daemon request
-	// cannot block past --timeout. The same deadline also covered ref/project
-	// resolution above, making --timeout a wall-clock cap for the whole command.
-	// Cancellation (Ctrl-C) still flows through the parent context.
-	fetchCtx := ctx
+	// ctx carries both the wait deadline (installed above when --timeout > 0)
+	// and the parent's cancellation (Ctrl-C), so every state GET below is
+	// bounded by --timeout as a wall-clock cap for the whole command. The old
+	// fetchCtx alias was always this same value and is merged away.
 
 	// Initial pass: fail fast only on a permanent (4xx) unresolvable ref
 	// (listing which), and complete refs whose condition already holds at
@@ -305,7 +356,7 @@ func runWait(cmd *cobra.Command, args []string, opts waitOptions) error {
 	var firstFetchErr error
 	var badRefs []string
 	for _, t := range targets {
-		st, msg, ferr := waitFetchState(fetchCtx, client, baseURL, t)
+		st, msg, ferr := waitFetchState(ctx, client, baseURL, t)
 		if ferr != nil {
 			if classifyFetchErr(ferr) {
 				if firstFetchErr == nil {
@@ -317,11 +368,11 @@ func runWait(cmd *cobra.Command, args []string, opts waitOptions) error {
 			}
 			continue
 		}
-		if evalTarget(mode, t, st, msg, start) {
+		if evalTarget(run, t, st, msg) {
 			if rerr := reporter.report(t); rerr != nil {
 				return rerr
 			}
-			if anyMode {
+			if join == joinAny {
 				// --any is satisfied; stop probing the remaining refs. A later
 				// ref whose fetch stalls (no --timeout to bound it) would
 				// otherwise hang the whole command despite the join being met.
@@ -334,7 +385,7 @@ func runWait(cmd *cobra.Command, args []string, opts waitOptions) error {
 	// rather than failing on them. --all is unaffected (any bad ref still
 	// fails fast); in --any, bad refs still fail fast when the join is not
 	// yet satisfied.
-	if len(badRefs) > 0 && (!anyMode || !waitComplete(targets, anyMode)) {
+	if len(badRefs) > 0 && (run.join == joinAll || !waitComplete(targets, run.join)) {
 		if len(badRefs) == 1 {
 			return firstFetchErr // preserve the daemon-derived exit code (e.g. 404)
 		}
@@ -345,11 +396,11 @@ func runWait(cmd *cobra.Command, args []string, opts waitOptions) error {
 		}
 	}
 
-	if err := waitPollLoop(ctx, fetchCtx, client, baseURL, mode, opts, anyMode, start, targets, reporter); err != nil {
+	if err := waitPollLoop(ctx, client, baseURL, run, targets, reporter); err != nil {
 		return err
 	}
 
-	timedOut := !waitComplete(targets, anyMode)
+	timedOut := !waitComplete(targets, run.join)
 
 	if reporter.mode == outputJSON {
 		// pending is documented as timeout-only: on a successful join (notably
@@ -399,43 +450,37 @@ func waitTimeoutError(timeout time.Duration, pending []string) *cliError {
 	}
 }
 
-// waitPollLoop polls the still-pending targets on the configured cadence until
-// the join condition is met, the timeout deadline passes, or the context is
-// cancelled. It returns an error only for a hard failure (context cancellation
-// or a ref that has failed too many consecutive fetches); timeout is signalled
-// to the caller via the targets' completion state, not an error here.
-// ctx carries cancellation (Ctrl-C) for the inter-poll sleep; fetchCtx bounds
-// each state GET by the wait deadline so a hung request cannot outlast --timeout.
+// waitPollLoop polls the still-pending targets on run.poll cadence until the
+// join condition is met, run's deadline passes, or the context is cancelled.
+// It returns an error only for a hard failure (context cancellation or a ref
+// that has failed too many consecutive fetches); timeout is signalled to the
+// caller via the targets' completion state, not an error here.
+//
+// ctx carries both cancellation (Ctrl-C) for the inter-poll sleep and the wait
+// deadline that bounds each state GET, so a hung request cannot outlast
+// --timeout.
 func waitPollLoop(
 	ctx context.Context,
-	fetchCtx context.Context,
 	client *http.Client,
 	baseURL string,
-	mode waitMode,
-	opts waitOptions,
-	anyMode bool,
-	start time.Time,
+	run waitRun,
 	targets []*waitTarget,
 	reporter *waitReporter,
 ) error {
-	var deadline time.Time
-	if opts.timeout > 0 {
-		deadline = start.Add(opts.timeout)
-	}
-	for !waitComplete(targets, anyMode) {
-		if !deadline.IsZero() && !time.Now().Before(deadline) {
+	for !waitComplete(targets, run.join) {
+		if run.expired() {
 			return nil // timed out; caller detects via waitComplete
 		}
-		sleep := opts.pollInterval
-		if !deadline.IsZero() {
-			if rem := time.Until(deadline); rem < sleep {
+		sleep := run.poll
+		if !run.deadline.IsZero() {
+			if rem := time.Until(run.deadline); rem < sleep {
 				sleep = rem
 			}
 		}
 		if sleep > 0 {
 			select {
 			case <-ctx.Done():
-				if !deadline.IsZero() && !time.Now().Before(deadline) {
+				if run.expired() {
 					return nil // timed out during the sleep
 				}
 				return ctx.Err()
@@ -445,32 +490,32 @@ func waitPollLoop(
 		// Re-check the deadline before fetching: the sleep above is clamped to
 		// land on the deadline, so without this a whole extra poll pass would
 		// fire after --timeout had already elapsed.
-		if !deadline.IsZero() && !time.Now().Before(deadline) {
+		if run.expired() {
 			return nil // timed out during the sleep
 		}
 		for _, t := range targets {
-			if t.done || t.abandoned {
+			if t.state != targetPending {
 				continue
 			}
-			st, msg, err := waitFetchState(fetchCtx, client, baseURL, t)
+			st, msg, err := waitFetchState(ctx, client, baseURL, t)
 			if err != nil {
 				// A fetch cut short by the wait deadline is a timeout, not a
 				// fetch failure: bail to the clean timeout result rather than
 				// counting it toward the consecutive-failure budget (which would
 				// otherwise surface ExitInternal after prior transient errors).
-				if !deadline.IsZero() && !time.Now().Before(deadline) {
+				if run.expired() {
 					return nil
 				}
 				if classifyFetchErr(err) {
 					// Permanent daemon error (e.g. a deleted issue's 404).
-					if !anyMode {
+					if run.join == joinAll {
 						// --all: one dead ref can never satisfy the join, so
 						// abort now preserving the daemon's kind/exit code
 						// (a deleted ref surfaces as not-found exit 4).
 						return err
 					}
 					// --any: drop this ref and keep waiting on the rest.
-					t.abandoned = true
+					t.state = targetAbandoned
 					t.abandonErr = err
 					if rerr := reporter.reportAbandoned(t); rerr != nil {
 						return rerr
@@ -492,11 +537,11 @@ func waitPollLoop(
 				continue
 			}
 			t.fails = 0
-			if evalTarget(mode, t, st, msg, start) {
+			if evalTarget(run, t, st, msg) {
 				if rerr := reporter.report(t); rerr != nil {
 					return rerr
 				}
-				if anyMode {
+				if run.join == joinAny {
 					return nil
 				}
 			}
@@ -505,22 +550,22 @@ func waitPollLoop(
 	return nil
 }
 
-// evalTarget evaluates st against mode for a not-yet-done target. When the
+// evalTarget evaluates st against run.mode for a still-pending target. When the
 // condition is newly satisfied it records the result (sanitizing user-visible
 // attention text) and returns true.
-func evalTarget(mode waitMode, t *waitTarget, st issueState, msg string, start time.Time) bool {
-	if t.done {
+func evalTarget(run waitRun, t *waitTarget, st issueState, msg string) bool {
+	if t.state != targetPending {
 		return false
 	}
-	satisfied, reason := evalWait(mode, st)
+	satisfied, reason := evalWait(run.mode, st)
 	if !satisfied {
 		return false
 	}
-	t.done = true
+	t.state = targetSatisfied
 	t.result = waitResult{
 		Ref:      t.arg,
 		Reason:   reason,
-		WaitedMs: time.Since(start).Milliseconds(),
+		WaitedMs: time.Since(run.start).Milliseconds(),
 	}
 	if reason == "attention" {
 		t.result.Attention = textsafe.Line(st.attention)
@@ -587,23 +632,23 @@ func decodeJSONString(raw json.RawMessage) string {
 
 // waitComplete reports whether the join condition is met: every target for
 // --all, at least one for --any.
-func waitComplete(targets []*waitTarget, anyMode bool) bool {
-	done := 0
+func waitComplete(targets []*waitTarget, join waitJoin) bool {
+	satisfied := 0
 	for _, t := range targets {
-		if t.done {
-			done++
+		if t.state == targetSatisfied {
+			satisfied++
 		}
 	}
-	if anyMode {
-		return done > 0
+	if join == joinAny {
+		return satisfied > 0
 	}
-	return done == len(targets)
+	return satisfied == len(targets)
 }
 
 func collectResults(targets []*waitTarget) []waitResult {
 	out := make([]waitResult, 0, len(targets))
 	for _, t := range targets {
-		if t.done {
+		if t.state == targetSatisfied {
 			out = append(out, t.result)
 		}
 	}
@@ -613,7 +658,7 @@ func collectResults(targets []*waitTarget) []waitResult {
 func pendingRefs(targets []*waitTarget) []string {
 	out := make([]string, 0)
 	for _, t := range targets {
-		if !t.done && !t.abandoned {
+		if t.state == targetPending {
 			out = append(out, t.arg)
 		}
 	}
@@ -624,7 +669,7 @@ func pendingRefs(targets []*waitTarget) []string {
 func collectAbandoned(targets []*waitTarget) []waitAbandoned {
 	var out []waitAbandoned
 	for _, t := range targets {
-		if !t.abandoned {
+		if t.state != targetAbandoned {
 			continue
 		}
 		msg := ""
@@ -640,12 +685,12 @@ func collectAbandoned(targets []*waitTarget) []waitAbandoned {
 	return out
 }
 
-// allAbandoned reports whether every target was abandoned (none completed the
+// allAbandoned reports whether every target was abandoned (none satisfied the
 // join, none still pending). In --any this means the wait can never fire, so
 // the caller surfaces the first permanent error rather than spinning.
 func allAbandoned(targets []*waitTarget) bool {
 	for _, t := range targets {
-		if !t.abandoned {
+		if t.state != targetAbandoned {
 			return false
 		}
 	}
@@ -656,7 +701,7 @@ func allAbandoned(targets []*waitTarget) bool {
 // preserving its daemon-derived kind/exit code.
 func firstAbandonErr(targets []*waitTarget) error {
 	for _, t := range targets {
-		if t.abandoned && t.abandonErr != nil {
+		if t.state == targetAbandoned && t.abandonErr != nil {
 			return t.abandonErr
 		}
 	}

--- a/cmd/kata/wait_test.go
+++ b/cmd/kata/wait_test.go
@@ -89,6 +89,135 @@ func TestWaitClassifyFetchErr(t *testing.T) {
 	}
 }
 
+// --- target-state / join-mode table --------------------------------------
+
+// waitStateTargets builds one target per state, named "a", "b", … Satisfied
+// targets carry a result; abandoned targets carry their permanent error, so
+// the accessors' outputs are distinguishable per state.
+func waitStateTargets(states ...waitTargetState) []*waitTarget {
+	names := []string{"a", "b", "c"}
+	targets := make([]*waitTarget, 0, len(states))
+	for i, state := range states {
+		name := names[i]
+		t := &waitTarget{arg: name, state: state}
+		switch state {
+		case targetSatisfied:
+			t.result = waitResult{Ref: name, Reason: "closed"}
+		case targetAbandoned:
+			t.abandonErr = errors.New(name + " is gone")
+		case targetPending:
+		}
+		targets = append(targets, t)
+	}
+	return targets
+}
+
+func waitResultRefs(results []waitResult) []string {
+	out := []string{}
+	for _, r := range results {
+		out = append(out, r.Ref)
+	}
+	return out
+}
+
+func waitAbandonedRefs(abandoned []waitAbandoned) []string {
+	out := []string{}
+	for _, a := range abandoned {
+		out = append(out, a.Ref)
+	}
+	return out
+}
+
+// TestWaitTargetStateAccessors pins every combination of the three-state
+// target lifecycle against both join modes. The old done/abandoned bool pair
+// could not express this table without constructing the invalid
+// "done and abandoned" target.
+func TestWaitTargetStateAccessors(t *testing.T) {
+	cases := []struct {
+		name          string
+		states        []waitTargetState
+		join          waitJoin
+		wantComplete  bool
+		wantPending   []string
+		wantResults   []string
+		wantAbandoned []string
+		wantAllAband  bool
+		wantFirstErr  string
+	}{
+		{
+			name:   "all pending under all",
+			states: []waitTargetState{targetPending, targetPending},
+			join:   joinAll, wantComplete: false,
+			wantPending: []string{"a", "b"}, wantResults: []string{}, wantAbandoned: []string{},
+		},
+		{
+			name:   "one satisfied under all is incomplete",
+			states: []waitTargetState{targetSatisfied, targetPending},
+			join:   joinAll, wantComplete: false,
+			wantPending: []string{"b"}, wantResults: []string{"a"}, wantAbandoned: []string{},
+		},
+		{
+			name:   "one satisfied under any is complete",
+			states: []waitTargetState{targetSatisfied, targetPending},
+			join:   joinAny, wantComplete: true,
+			wantPending: []string{"b"}, wantResults: []string{"a"}, wantAbandoned: []string{},
+		},
+		{
+			name:   "every target satisfied under all is complete",
+			states: []waitTargetState{targetSatisfied, targetSatisfied},
+			join:   joinAll, wantComplete: true,
+			wantPending: []string{}, wantResults: []string{"a", "b"}, wantAbandoned: []string{},
+		},
+		{
+			name:   "abandoned is neither pending nor satisfied",
+			states: []waitTargetState{targetAbandoned, targetPending},
+			join:   joinAny, wantComplete: false,
+			wantPending: []string{"b"}, wantResults: []string{}, wantAbandoned: []string{"a"},
+			wantFirstErr: "a is gone",
+		},
+		{
+			name:   "abandoned plus satisfied leaves nothing pending",
+			states: []waitTargetState{targetAbandoned, targetSatisfied},
+			join:   joinAll, wantComplete: false,
+			wantPending: []string{}, wantResults: []string{"b"}, wantAbandoned: []string{"a"},
+			wantFirstErr: "a is gone",
+		},
+		{
+			name:   "all abandoned can never complete",
+			states: []waitTargetState{targetAbandoned, targetAbandoned},
+			join:   joinAny, wantComplete: false,
+			wantPending: []string{}, wantResults: []string{}, wantAbandoned: []string{"a", "b"},
+			wantAllAband: true, wantFirstErr: "a is gone",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			targets := waitStateTargets(tc.states...)
+			assert.Equal(t, tc.wantComplete, waitComplete(targets, tc.join))
+			assert.Equal(t, tc.wantPending, pendingRefs(targets))
+			assert.Equal(t, tc.wantResults, waitResultRefs(collectResults(targets)))
+			assert.Equal(t, tc.wantAbandoned, waitAbandonedRefs(collectAbandoned(targets)))
+			assert.Equal(t, tc.wantAllAband, allAbandoned(targets))
+			if tc.wantFirstErr == "" {
+				assert.NoError(t, firstAbandonErr(targets))
+			} else {
+				require.Error(t, firstAbandonErr(targets))
+				assert.Equal(t, tc.wantFirstErr, firstAbandonErr(targets).Error())
+			}
+		})
+	}
+}
+
+// TestWaitJoinZeroValueIsAll pins --all as the documented default join: the
+// zero value of waitJoin must be joinAll, because runWait only ever sets
+// joinAny explicitly.
+func TestWaitJoinZeroValueIsAll(t *testing.T) {
+	var zero waitJoin
+	targets := waitStateTargets(targetSatisfied, targetPending)
+	assert.False(t, waitComplete(targets, zero),
+		"the zero join must be --all, which is not satisfied by one of two refs")
+}
+
 func TestWaitParseModeRejectsUnknown(t *testing.T) {
 	_, err := parseWaitMode("banana")
 	require.Error(t, err)


### PR DESCRIPTION
## What changed

- represent `kata wait` target state, join mode, and deadlines as single typed values
- resolve CLI output mode once while preserving legacy import and contract-conflict behavior
- replace overlapping error-path argument walkers with one total pre-parser

## Why

Wait state and output selection were spread across overlapping booleans and parsers that could disagree on the same command line. The CLI should make each decision once and carry that answer through normal execution and error reporting.

## Usage

No usage change.
