### PR TITLE
Make JSON schemas and lease aliases self-describing

### DIFF
--- a/cmd/kata/federation_lease.go
+++ b/cmd/kata/federation_lease.go
@@ -301,15 +301,31 @@ func explicitClaimAdminReason(cmd *cobra.Command, reason string) (string, error)
 	return strings.TrimSpace(reason), nil
 }
 
+// claimHolderForCLI is the single field the CLI needs from a lease payload.
+type claimHolderForCLI struct {
+	Holder string `json:"holder"`
+}
+
 type claimMutationBody struct {
 	Granted bool `json:"granted"`
 	Pending bool `json:"pending"`
 	Holder  struct {
 		Holder string `json:"holder"`
 	} `json:"holder"`
-	Claim *struct {
-		Holder string `json:"holder"`
-	} `json:"claim"`
+	// Lease is canonical. Claim is the deprecated alias the daemon still
+	// publishes; it is decoded only as a fallback for a hub older than the
+	// release that started setting lease on every arbitration response.
+	Lease *claimHolderForCLI `json:"lease"`
+	Claim *claimHolderForCLI `json:"claim"`
+}
+
+// canonicalLease returns the lease payload, falling back to the deprecated
+// claim alias.
+func (b claimMutationBody) canonicalLease() *claimHolderForCLI {
+	if b.Lease != nil {
+		return b.Lease
+	}
+	return b.Claim
 }
 
 func decodeClaimMutation(bs []byte) (claimMutationBody, error) {
@@ -325,7 +341,7 @@ func printLeaseMutation(cmd *cobra.Command, bs []byte, action, ref, actor string
 	if err != nil {
 		return err
 	}
-	deniedErr := claimDeniedErr(action, ref, b.Granted, b.Pending, b.Claim)
+	deniedErr := claimDeniedErr(action, ref, b.Granted, b.Pending, b.canonicalLease())
 	mode := currentOutputMode()
 	if mode == outputJSON {
 		var buf bytes.Buffer
@@ -526,25 +542,23 @@ func claimStealSecondClaimErr(ref string, claimed claimMutationBody) error {
 			ExitCode: ExitConflict,
 		}
 	}
-	return claimDeniedErr("claim", ref, claimed.Granted, claimed.Pending, claimed.Claim)
+	return claimDeniedErr("claim", ref, claimed.Granted, claimed.Pending, claimed.canonicalLease())
 }
 
 func holderFromClaimMutation(b claimMutationBody) string {
-	if b.Claim != nil && strings.TrimSpace(b.Claim.Holder) != "" {
-		return strings.TrimSpace(b.Claim.Holder)
+	if lease := b.canonicalLease(); lease != nil && strings.TrimSpace(lease.Holder) != "" {
+		return strings.TrimSpace(lease.Holder)
 	}
 	return strings.TrimSpace(b.Holder.Holder)
 }
 
-func claimDeniedErr(action, ref string, granted, pending bool, claim *struct {
-	Holder string `json:"holder"`
-}) error {
+func claimDeniedErr(action, ref string, granted, pending bool, lease *claimHolderForCLI) error {
 	if (action != "claim" && action != "acquire") || pending || granted {
 		return nil
 	}
 	deniedBy := ""
-	if claim != nil {
-		deniedBy = strings.TrimSpace(claim.Holder)
+	if lease != nil {
+		deniedBy = strings.TrimSpace(lease.Holder)
 	}
 	msg := "lease denied"
 	if deniedBy != "" {

--- a/cmd/kata/federation_lease_test.go
+++ b/cmd/kata/federation_lease_test.go
@@ -18,6 +18,41 @@ import (
 	"go.kenn.io/kata/internal/testenv"
 )
 
+// TestClaimMutationBodyPrefersLeaseOverDeprecatedClaim pins that the CLI reads
+// the canonical lease field. It used to decode only "claim", so it and
+// kata show — same binary, same daemon — disagreed about which spelling was
+// authoritative, and the CLI would have broken on the day the deprecated
+// alias is retired.
+func TestClaimMutationBodyPrefersLeaseOverDeprecatedClaim(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		payload    string
+		wantHolder string
+	}{
+		{
+			name:       "both spellings present",
+			payload:    `{"granted":true,"holder":{"holder":"principal"},"lease":{"holder":"alice"},"claim":{"holder":"deprecated"}}`,
+			wantHolder: "alice",
+		},
+		{
+			name:       "only the deprecated alias",
+			payload:    `{"granted":true,"holder":{"holder":"principal"},"claim":{"holder":"bob"}}`,
+			wantHolder: "bob",
+		},
+		{
+			name:       "no lease at all falls back to the principal",
+			payload:    `{"granted":false,"holder":{"holder":"carol"}}`,
+			wantHolder: "carol",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := decodeClaimMutation([]byte(tc.payload))
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantHolder, holderFromClaimMutation(body))
+		})
+	}
+}
+
 func TestClaim_DefaultsToHardClaimPostsActor(t *testing.T) {
 	env, dir, pid, ref := setupFederatedHubIssue(t, "claim target")
 

--- a/internal/api/claim_mirror_test.go
+++ b/internal/api/claim_mirror_test.go
@@ -1,0 +1,135 @@
+package api_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/api"
+)
+
+// TestMirrorDeprecatedClaimFieldsCopiesEveryPair is the enforcement point that
+// replaces eight scattered mirroring assignments in the daemon handlers. The
+// representation permits lease != claim in all seven pairs; nothing in the
+// type system prevents it, so this test is what does. The zero and
+// empty-slice cases matter because a nil slice and an empty slice are
+// different JSON values and a mirror that reconstructed rather than copied
+// would silently normalize one into the other.
+func TestMirrorDeprecatedClaimFieldsCopiesEveryPair(t *testing.T) {
+	lease := &api.IssueClaimOut{Holder: "alice", ClaimKind: "hard"}
+	pending := []api.PendingClaimOut{{RequestUID: "req-1", Holder: "bob", ClaimKind: "timed"}}
+	hubNow := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	violations := []api.ClaimViolationOut{{EventID: 7, EventUID: "evt-7", IssueUID: "iss-7"}}
+	count := int64(1)
+
+	showCases := []struct {
+		name string
+		body api.ShowIssueResponseBody
+	}{
+		{
+			name: "populated",
+			body: api.ShowIssueResponseBody{
+				Lease:               lease,
+				PendingLeases:       pending,
+				LeaseHubNow:         &hubNow,
+				LeaseViolations:     violations,
+				LeaseViolationCount: &count,
+			},
+		},
+		{name: "zero value", body: api.ShowIssueResponseBody{}},
+		{
+			name: "empty slices",
+			body: api.ShowIssueResponseBody{
+				PendingLeases:   []api.PendingClaimOut{},
+				LeaseViolations: []api.ClaimViolationOut{},
+			},
+		},
+	}
+	for _, tc := range showCases {
+		t.Run("ShowIssueResponseBody/"+tc.name, func(t *testing.T) {
+			body := tc.body
+			body.MirrorDeprecatedClaimFields()
+
+			assert.Equal(t, body.Lease, body.Claim)
+			assert.Equal(t, body.PendingLeases, body.PendingClaims)
+			assert.Equal(t, body.LeaseHubNow, body.ClaimHubNow)
+			assert.Equal(t, body.LeaseViolations, body.ClaimViolations)
+			assert.Equal(t, body.LeaseViolationCount, body.ClaimViolationCount)
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		body api.ClaimActionResponseBody
+	}{
+		{name: "granted", body: api.ClaimActionResponseBody{Granted: true, Lease: lease}},
+		{name: "denied", body: api.ClaimActionResponseBody{}},
+	} {
+		t.Run("ClaimActionResponseBody/"+tc.name, func(t *testing.T) {
+			body := tc.body
+			body.MirrorDeprecatedClaimFields()
+			assert.Equal(t, body.Lease, body.Claim)
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		body api.ClaimStatusBody
+	}{
+		{name: "held", body: api.ClaimStatusBody{Held: true, Lease: lease, HubNow: hubNow}},
+		{name: "free", body: api.ClaimStatusBody{HubNow: hubNow}},
+	} {
+		t.Run("ClaimStatusBody/"+tc.name, func(t *testing.T) {
+			body := tc.body
+			body.MirrorDeprecatedClaimFields()
+			assert.Equal(t, body.Lease, body.Claim)
+		})
+	}
+}
+
+// TestMirroredBodiesPublishBothLeaseAndClaimKeys pins that claim* stays a
+// deprecation and does not become an accidental removal. Both spellings are
+// published in api/openapi.yaml and cannot be dropped without an
+// APISchemaVersion bump.
+func TestMirroredBodiesPublishBothLeaseAndClaimKeys(t *testing.T) {
+	lease := &api.IssueClaimOut{Holder: "alice", ClaimKind: "hard"}
+	hubNow := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	count := int64(1)
+
+	show := api.ShowIssueResponseBody{
+		Lease:               lease,
+		PendingLeases:       []api.PendingClaimOut{{RequestUID: "req-1", Holder: "bob"}},
+		LeaseHubNow:         &hubNow,
+		LeaseViolations:     []api.ClaimViolationOut{{EventID: 7, EventUID: "evt-7"}},
+		LeaseViolationCount: &count,
+	}
+	show.MirrorDeprecatedClaimFields()
+	assertJSONHasKeys(t, show,
+		"lease", "claim",
+		"pending_leases", "pending_claims",
+		"lease_hub_now", "claim_hub_now",
+		"lease_violations", "claim_violations",
+		"lease_violation_count", "claim_violation_count",
+	)
+
+	action := api.ClaimActionResponseBody{Granted: true, Lease: lease}
+	action.MirrorDeprecatedClaimFields()
+	assertJSONHasKeys(t, action, "lease", "claim")
+
+	status := api.ClaimStatusBody{Held: true, Lease: lease, HubNow: hubNow}
+	status.MirrorDeprecatedClaimFields()
+	assertJSONHasKeys(t, status, "lease", "claim")
+}
+
+func assertJSONHasKeys(t *testing.T, value any, keys ...string) {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	require.NoError(t, err)
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	for _, key := range keys {
+		require.Contains(t, decoded, key, "response must still carry %q", key)
+	}
+}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -14,10 +14,10 @@ import (
 
 // ErrorBody is the inner payload of an error envelope.
 type ErrorBody struct {
-	Code    string         `json:"code"`
-	Message string         `json:"message"`
-	Hint    string         `json:"hint,omitempty"`
-	Data    map[string]any `json:"data,omitempty"`
+	Code    string  `json:"code"`
+	Message string  `json:"message"`
+	Hint    string  `json:"hint,omitempty"`
+	Data    JSONMap `json:"data,omitempty"`
 }
 
 // ErrorEnvelope is the stable wire shape for non-2xx responses.

--- a/internal/api/federation.go
+++ b/internal/api/federation.go
@@ -438,8 +438,11 @@ type ClaimActionResponse struct {
 }
 
 // ClaimActionResponseBody summarizes the arbitration result. Lease is the
-// public federation name; Claim is kept as a compatibility alias for the
-// internal storage term until this pre-merge branch finishes the storage rename.
+// canonical federation name. Claim is a deprecated alias that has shipped in
+// every public release since 0.5.0 and is published in api/openapi.yaml, so
+// it cannot be removed without bumping APISchemaVersion (see
+// internal/daemon/openapi.go). Producers set Lease and call
+// MirrorDeprecatedClaimFields; consumers read Lease.
 type ClaimActionResponseBody struct {
 	Granted    bool              `json:"granted"`
 	Pending    bool              `json:"pending,omitempty"`
@@ -448,6 +451,12 @@ type ClaimActionResponseBody struct {
 	Lease      *IssueClaimOut    `json:"lease,omitempty"`
 	Claim      *IssueClaimOut    `json:"claim,omitempty"`
 	Event      *db.Event         `json:"event,omitempty"`
+}
+
+// MirrorDeprecatedClaimFields copies the canonical Lease field onto its
+// deprecated Claim alias.
+func (b *ClaimActionResponseBody) MirrorDeprecatedClaimFields() {
+	b.Claim = b.Lease
 }
 
 // ClaimStatusResponse wraps ClaimStatusBody.
@@ -462,6 +471,12 @@ type ClaimStatusBody struct {
 	Lease  *IssueClaimOut    `json:"lease,omitempty"`
 	Claim  *IssueClaimOut    `json:"claim,omitempty"`
 	HubNow time.Time         `json:"hub_now"`
+}
+
+// MirrorDeprecatedClaimFields copies the canonical Lease field onto its
+// deprecated Claim alias. See ClaimActionResponseBody.
+func (b *ClaimStatusBody) MirrorDeprecatedClaimFields() {
+	b.Claim = b.Lease
 }
 
 // FederationBindingOut is the API-owned representation of a local federation

--- a/internal/api/github_sync.go
+++ b/internal/api/github_sync.go
@@ -18,9 +18,9 @@ type EnableIssueSyncRequest struct {
 // scheduling options. Config must not contain raw credentials; providers that
 // need credentials should store references or use their own CLI auth.
 type EnableIssueSyncRequestBody struct {
-	Config          map[string]any `json:"config,omitempty"`
-	IntervalSeconds int            `json:"interval_seconds,omitempty"`
-	Interval        string         `json:"interval,omitempty"`
+	Config          JSONMap `json:"config,omitempty"`
+	IntervalSeconds int     `json:"interval_seconds,omitempty"`
+	Interval        string  `json:"interval,omitempty"`
 }
 
 // DisableIssueSyncRequest disables durable external issue sync for one project.
@@ -66,10 +66,6 @@ type IssueSyncBindingOut struct {
 	CreatedAt       time.Time  `json:"created_at"`
 	UpdatedAt       time.Time  `json:"updated_at"`
 }
-
-// JSONMap is an opaque JSON object used for provider-specific issue-sync
-// configuration in API responses.
-type JSONMap map[string]any
 
 // IssueSyncStatusOut summarizes current sync state.
 type IssueSyncStatusOut struct {

--- a/internal/api/jsonwire.go
+++ b/internal/api/jsonwire.go
@@ -1,0 +1,95 @@
+package api //nolint:revive // package name "api" is fixed by Plan 1 §4 wire-types layout.
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// This file holds the wire types for fields whose contract is "an arbitrary
+// JSON object". Each one implements huma.SchemaProvider so its declaration
+// and its published OpenAPI schema are the same fact in one place. Before
+// this existed, internal/daemon rebuilt these schemas by string-matching JSON
+// property names on the finished document, so adding an opaque-JSON field
+// here published the wrong schema unless someone remembered to edit a table
+// in another package.
+//
+// additionalProperties is explicitly true rather than left unset: the
+// code-generator document flavor clears it where oapi-codegen needs it
+// cleared (see openAPIClientDocument in internal/daemon/openapi.go).
+
+// jsonObjectSchema is the shared "arbitrary JSON object" schema. Each call
+// returns a fresh value: huma stores the returned pointer in the document,
+// and later document passes may mutate it in place.
+func jsonObjectSchema() *huma.Schema {
+	return &huma.Schema{
+		Type:                 huma.TypeObject,
+		AdditionalProperties: true,
+	}
+}
+
+// JSONMap is an opaque JSON object decoded into Go values — used for
+// provider-specific issue-sync configuration and for the error envelope's
+// structured data.
+type JSONMap map[string]any
+
+// Schema implements huma.SchemaProvider.
+func (JSONMap) Schema(huma.Registry) *huma.Schema { return jsonObjectSchema() }
+
+// JSONRawMap is an opaque JSON object whose values stay undecoded, so each
+// key can be validated (or passed through) on its own terms. Used by the
+// create-issue metadata body and by both metadata patch bodies.
+type JSONRawMap map[string]json.RawMessage
+
+// Schema implements huma.SchemaProvider.
+func (JSONRawMap) Schema(huma.Registry) *huma.Schema { return jsonObjectSchema() }
+
+// JSONRawObject is an opaque JSON object carried as undecoded bytes.
+// MarshalJSON/UnmarshalJSON reproduce json.RawMessage's behavior exactly — a
+// defined type over []byte inherits no methods, so without these the value
+// would be base64-encoded on the wire.
+type JSONRawObject json.RawMessage
+
+// MarshalJSON emits the stored bytes verbatim; the empty value emits null.
+func (m JSONRawObject) MarshalJSON() ([]byte, error) {
+	if len(m) == 0 {
+		return []byte("null"), nil
+	}
+	return m, nil
+}
+
+// UnmarshalJSON copies the raw input bytes verbatim.
+func (m *JSONRawObject) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("api.JSONRawObject: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}
+
+// Schema implements huma.SchemaProvider.
+func (JSONRawObject) Schema(huma.Registry) *huma.Schema { return jsonObjectSchema() }
+
+// JSONNullableRawObject is JSONRawObject for fields that additionally accept
+// an explicit JSON null. It is a distinct type because huma resolves a
+// SchemaProvider on the dereferenced type, so pointer-ness alone cannot make
+// a self-describing schema nullable.
+type JSONNullableRawObject json.RawMessage
+
+// MarshalJSON emits the stored bytes verbatim; the empty value emits null.
+func (m JSONNullableRawObject) MarshalJSON() ([]byte, error) {
+	return JSONRawObject(m).MarshalJSON()
+}
+
+// UnmarshalJSON copies the raw input bytes verbatim.
+func (m *JSONNullableRawObject) UnmarshalJSON(data []byte) error {
+	return (*JSONRawObject)(m).UnmarshalJSON(data)
+}
+
+// Schema implements huma.SchemaProvider.
+func (JSONNullableRawObject) Schema(huma.Registry) *huma.Schema {
+	schema := jsonObjectSchema()
+	schema.Nullable = true
+	return schema
+}

--- a/internal/api/jsonwire_test.go
+++ b/internal/api/jsonwire_test.go
@@ -1,0 +1,79 @@
+package api_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/api"
+)
+
+// TestJSONRawObjectRoundTripsVerbatim pins that the opaque raw-object wire
+// type keeps json.RawMessage's exact behavior: bytes in, same bytes out, no
+// base64 and no re-encoding. A defined type over []byte that forgot its own
+// MarshalJSON would silently base64-encode every recurrence template
+// metadata blob.
+func TestJSONRawObjectRoundTripsVerbatim(t *testing.T) {
+	const stored = `{"area":"example-workspace","depth":2}`
+
+	raw, err := json.Marshal(api.JSONRawObject(stored))
+	require.NoError(t, err)
+	assert.JSONEq(t, stored, string(raw))
+
+	var back api.JSONRawObject
+	require.NoError(t, json.Unmarshal(raw, &back))
+	assert.JSONEq(t, stored, string(back))
+
+	empty, err := json.Marshal(api.JSONRawObject(nil))
+	require.NoError(t, err)
+	assert.Equal(t, "null", string(empty))
+}
+
+// TestJSONNullableRawObjectRoundTripsVerbatim pins the same behavior for the
+// nullable sibling used by the recurrence template patch body.
+func TestJSONNullableRawObjectRoundTripsVerbatim(t *testing.T) {
+	const stored = `{"area":"example-workspace"}`
+
+	raw, err := json.Marshal(api.JSONNullableRawObject(stored))
+	require.NoError(t, err)
+	assert.JSONEq(t, stored, string(raw))
+
+	var back api.JSONNullableRawObject
+	require.NoError(t, json.Unmarshal(raw, &back))
+	assert.JSONEq(t, stored, string(back))
+}
+
+// TestRecurrenceTemplateUpdateInputPreservesNullAsAbsent pins the patch
+// handler's compatibility contract: both an absent metadata key and an
+// explicit null mean "no change", while an object remains available as raw
+// bytes. encoding/json intentionally clears pointer fields for null without
+// calling the pointed-to type's UnmarshalJSON method.
+func TestRecurrenceTemplateUpdateInputPreservesNullAsAbsent(t *testing.T) {
+	var absent api.RecurrenceTemplateUpdateInput
+	require.NoError(t, json.Unmarshal([]byte(`{"title":"weekly triage"}`), &absent))
+	assert.Nil(t, absent.Metadata)
+
+	var cleared api.RecurrenceTemplateUpdateInput
+	require.NoError(t, json.Unmarshal([]byte(`{"metadata":null}`), &cleared))
+	assert.Nil(t, cleared.Metadata)
+
+	var set api.RecurrenceTemplateUpdateInput
+	require.NoError(t, json.Unmarshal([]byte(`{"metadata":{"area":"example-workspace"}}`), &set))
+	require.NotNil(t, set.Metadata)
+	assert.JSONEq(t, `{"area":"example-workspace"}`, string(*set.Metadata))
+}
+
+// TestJSONRawMapDecodesPerKeyRawValues pins that the patch/metadata map form
+// still hands each key's value to the caller as undecoded bytes — the daemon
+// validates reserved keys through their own type validators and passes
+// unknown keys through opaquely.
+func TestJSONRawMapDecodesPerKeyRawValues(t *testing.T) {
+	var m api.JSONRawMap
+	require.NoError(t, json.Unmarshal([]byte(`{"someday":true,"checklist":[{"text":"a"}]}`), &m))
+
+	require.Contains(t, m, "someday")
+	assert.Equal(t, "true", string(m["someday"]))
+	require.Contains(t, m, "checklist")
+	assert.JSONEq(t, `[{"text":"a"}]`, string(m["checklist"]))
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -3,7 +3,6 @@ package api //nolint:revive // package name "api" is fixed by Plan 1 §4 wire-ty
 
 import (
 	"cmp"
-	"encoding/json"
 	"time"
 
 	"go.kenn.io/kata/internal/db"
@@ -400,7 +399,7 @@ type CreateIssueRequest struct {
 		// validator; unknown keys pass opaquely). JSON null values are
 		// rejected — there is nothing to clear at creation. On idempotent
 		// replay this field is ignored (the stored issue is returned as-is).
-		Metadata map[string]json.RawMessage `json:"metadata,omitempty"`
+		Metadata JSONRawMap `json:"metadata,omitempty"`
 	}
 }
 
@@ -660,24 +659,45 @@ type ReachableGraphResponse struct {
 
 // ShowIssueResponse is the per-issue read payload (Plan 2: + links, + labels).
 type ShowIssueResponse struct {
-	Body struct {
-		Issue               db.Issue            `json:"issue"`
-		Comments            []db.Comment        `json:"comments"`
-		Links               []LinkOut           `json:"links"`
-		Labels              []db.IssueLabel     `json:"labels"`
-		Parent              *IssueRef           `json:"parent,omitempty"`
-		Children            []IssueOut          `json:"children,omitempty"`
-		Claim               *IssueClaimOut      `json:"claim,omitempty"`
-		Lease               *IssueClaimOut      `json:"lease,omitempty"`
-		PendingClaims       []PendingClaimOut   `json:"pending_claims,omitempty"`
-		PendingLeases       []PendingClaimOut   `json:"pending_leases,omitempty"`
-		ClaimHubNow         *time.Time          `json:"claim_hub_now,omitempty"`
-		LeaseHubNow         *time.Time          `json:"lease_hub_now,omitempty"`
-		ClaimViolations     []ClaimViolationOut `json:"claim_violations,omitempty"`
-		LeaseViolations     []ClaimViolationOut `json:"lease_violations,omitempty"`
-		ClaimViolationCount *int64              `json:"claim_violation_count,omitempty"`
-		LeaseViolationCount *int64              `json:"lease_violation_count,omitempty"`
-	}
+	Body ShowIssueResponseBody
+}
+
+// ShowIssueResponseBody is the show-issue payload. The Claim* fields are
+// deprecated aliases of the canonical Lease* fields; see
+// MirrorDeprecatedClaimFields. The type name is load-bearing: Huma publishes
+// this component as "ShowIssueResponseBody", so renaming the Go type renames
+// the published component and breaks every generated client.
+type ShowIssueResponseBody struct {
+	Issue               db.Issue            `json:"issue"`
+	Comments            []db.Comment        `json:"comments"`
+	Links               []LinkOut           `json:"links"`
+	Labels              []db.IssueLabel     `json:"labels"`
+	Parent              *IssueRef           `json:"parent,omitempty"`
+	Children            []IssueOut          `json:"children,omitempty"`
+	Claim               *IssueClaimOut      `json:"claim,omitempty"`
+	Lease               *IssueClaimOut      `json:"lease,omitempty"`
+	PendingClaims       []PendingClaimOut   `json:"pending_claims,omitempty"`
+	PendingLeases       []PendingClaimOut   `json:"pending_leases,omitempty"`
+	ClaimHubNow         *time.Time          `json:"claim_hub_now,omitempty"`
+	LeaseHubNow         *time.Time          `json:"lease_hub_now,omitempty"`
+	ClaimViolations     []ClaimViolationOut `json:"claim_violations,omitempty"`
+	LeaseViolations     []ClaimViolationOut `json:"lease_violations,omitempty"`
+	ClaimViolationCount *int64              `json:"claim_violation_count,omitempty"`
+	LeaseViolationCount *int64              `json:"lease_violation_count,omitempty"`
+}
+
+// MirrorDeprecatedClaimFields copies the canonical Lease* fields onto their
+// deprecated Claim* aliases. Producers set only the Lease* fields and call
+// this once; that is the whole enforcement of an invariant the struct itself
+// cannot express — five independent pairs that must never disagree. See the
+// deprecation note on ClaimActionResponseBody for why both spellings stay on
+// the wire.
+func (b *ShowIssueResponseBody) MirrorDeprecatedClaimFields() {
+	b.Claim = b.Lease
+	b.PendingClaims = b.PendingLeases
+	b.ClaimHubNow = b.LeaseHubNow
+	b.ClaimViolations = b.LeaseViolations
+	b.ClaimViolationCount = b.LeaseViolationCount
 }
 
 // ClaimViolationOut is the canonical Phase 4 claim violation display shape.
@@ -1352,12 +1372,12 @@ type AuditClosesResponse struct {
 // types into request bodies. Labels are accepted as a JSON array of strings;
 // metadata is an opaque JSON object.
 type RecurrenceTemplateInput struct {
-	Title    string          `json:"title" required:"true"`
-	Body     string          `json:"body,omitempty"`
-	Owner    *string         `json:"owner,omitempty"`
-	Priority *int64          `json:"priority,omitempty"`
-	Labels   []string        `json:"labels,omitempty"`
-	Metadata json.RawMessage `json:"metadata,omitempty"`
+	Title    string        `json:"title" required:"true"`
+	Body     string        `json:"body,omitempty"`
+	Owner    *string       `json:"owner,omitempty"`
+	Priority *int64        `json:"priority,omitempty"`
+	Labels   []string      `json:"labels,omitempty"`
+	Metadata JSONRawObject `json:"metadata,omitempty"`
 }
 
 // CreateRecurrenceRequest is POST /api/v1/projects/{project_id}/recurrences.
@@ -1409,14 +1429,14 @@ type ShowRecurrenceResponse struct {
 // recurrence template. Pointer fields use nil for "no change"; nullable scalar
 // fields have explicit clear operations because JSON null also decodes to nil.
 type RecurrenceTemplateUpdateInput struct {
-	Title         *string          `json:"title,omitempty"`
-	Body          *string          `json:"body,omitempty"`
-	Owner         *string          `json:"owner,omitempty"`
-	ClearOwner    bool             `json:"clear_owner,omitempty"`
-	Priority      *int64           `json:"priority,omitempty"`
-	ClearPriority bool             `json:"clear_priority,omitempty"`
-	Labels        *[]string        `json:"labels,omitempty"`
-	Metadata      *json.RawMessage `json:"metadata,omitempty"`
+	Title         *string                `json:"title,omitempty"`
+	Body          *string                `json:"body,omitempty"`
+	Owner         *string                `json:"owner,omitempty"`
+	ClearOwner    bool                   `json:"clear_owner,omitempty"`
+	Priority      *int64                 `json:"priority,omitempty"`
+	ClearPriority bool                   `json:"clear_priority,omitempty"`
+	Labels        *[]string              `json:"labels,omitempty"`
+	Metadata      *JSONNullableRawObject `json:"metadata,omitempty" nullable:"true"`
 }
 
 // PatchRecurrenceRequest is PATCH /api/v1/projects/{project_id}/recurrences/{recurrence_uid}.
@@ -1473,9 +1493,9 @@ type PatchIssueMetadataRequest struct {
 	Ref       string `path:"ref" required:"true"`
 	IfMatch   string `header:"If-Match"`
 	Body      struct {
-		Actor string                     `json:"actor,omitempty"`
-		Patch map[string]json.RawMessage `json:"patch"`
-		Guard *MetadataPatchGuard        `json:"guard,omitempty"`
+		Actor string              `json:"actor,omitempty"`
+		Patch JSONRawMap          `json:"patch"`
+		Guard *MetadataPatchGuard `json:"guard,omitempty"`
 	}
 }
 
@@ -1495,8 +1515,8 @@ type PatchProjectMetadataRequest struct {
 	ProjectID int64  `path:"project_id" required:"true"`
 	IfMatch   string `header:"If-Match"`
 	Body      struct {
-		Actor string                     `json:"actor" required:"true"`
-		Patch map[string]json.RawMessage `json:"patch"`
+		Actor string     `json:"actor" required:"true"`
+		Patch JSONRawMap `json:"patch"`
 	}
 }
 

--- a/internal/daemon/handlers_claims.go
+++ b/internal/daemon/handlers_claims.go
@@ -667,6 +667,9 @@ func (c *claimHubClient) ReleaseClaim(
 func (c *claimHubClient) ClaimStatus(ctx context.Context, hubProjectID int64, ref string) (api.ClaimStatusBody, error) {
 	var body api.ClaimStatusBody
 	err := c.getJSON(ctx, claimHubPath(hubProjectID, ref, "lease"), &body)
+	if err == nil {
+		normalizeForwardedClaimStatus(&body)
+	}
 	return body, err
 }
 
@@ -679,7 +682,24 @@ func (c *claimHubClient) claimAction(
 ) (api.ClaimActionResponseBody, error) {
 	var body api.ClaimActionResponseBody
 	err := c.postJSON(ctx, claimHubPath(hubProjectID, ref, "lease/actions/"+action), req, &body)
+	if err == nil {
+		normalizeForwardedClaimActionResponse(&body)
+	}
 	return body, err
+}
+
+func normalizeForwardedClaimActionResponse(body *api.ClaimActionResponseBody) {
+	if body.Lease == nil {
+		body.Lease = body.Claim
+	}
+	body.MirrorDeprecatedClaimFields()
+}
+
+func normalizeForwardedClaimStatus(body *api.ClaimStatusBody) {
+	if body.Lease == nil {
+		body.Lease = body.Claim
+	}
+	body.MirrorDeprecatedClaimFields()
 }
 
 func (c *claimHubClient) getJSON(ctx context.Context, path string, out any) error {
@@ -785,25 +805,25 @@ func claimAPIError(err error) error {
 }
 
 func claimResultBody(result db.LeaseResult) api.ClaimActionResponseBody {
-	lease := issueClaimOut(result.Claim)
-	return api.ClaimActionResponseBody{
+	body := api.ClaimActionResponseBody{
 		Granted: result.Granted,
 		Holder:  claimPrincipalOut(result.Holder),
-		Lease:   lease,
-		Claim:   lease,
+		Lease:   issueClaimOut(result.Claim),
 		Event:   result.Event,
 	}
+	body.MirrorDeprecatedClaimFields()
+	return body
 }
 
 func claimStatusBody(status db.ClaimStatus) api.ClaimStatusBody {
-	lease := issueClaimOut(status.Claim)
-	return api.ClaimStatusBody{
+	body := api.ClaimStatusBody{
 		Held:   status.Held,
 		Holder: claimPrincipalOut(status.Holder),
-		Lease:  lease,
-		Claim:  lease,
+		Lease:  issueClaimOut(status.Claim),
 		HubNow: status.HubNow,
 	}
+	body.MirrorDeprecatedClaimFields()
+	return body
 }
 
 const showClaimStatusRetryAfter = time.Minute
@@ -950,18 +970,15 @@ func hydrateClaimOutForIssue(ctx context.Context, cfg ServerConfig, issue db.Iss
 	if err != nil {
 		return internalAPIError(err)
 	}
-	out.Body.Claim = issueClaimOut(status.Claim)
-	out.Body.Lease = out.Body.Claim
+	out.Body.Lease = issueClaimOut(status.Claim)
 	if len(pending) > 0 {
-		out.Body.PendingClaims = pendingClaimOuts(pending)
-		out.Body.PendingLeases = out.Body.PendingClaims
+		out.Body.PendingLeases = pendingClaimOuts(pending)
 	}
 	if out.Body.Lease != nil || len(pending) > 0 {
 		hubNow := status.HubNow
 		if hubNow.IsZero() {
 			hubNow = now
 		}
-		out.Body.ClaimHubNow = &hubNow
 		out.Body.LeaseHubNow = &hubNow
 	}
 	return nil

--- a/internal/daemon/handlers_claims_internal_test.go
+++ b/internal/daemon/handlers_claims_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -60,6 +61,55 @@ func TestNewClaimHubClientHonorsAllowInsecureHostnameOptIn(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 	assert.Equal(t, "http://tailnet-hub.internal:7787", client.baseURL)
+}
+
+func TestClaimHubClientNormalizesDeprecatedClaimFields(t *testing.T) {
+	legacyClaim := &api.IssueClaimOut{
+		ClaimUID: "01HZNQ7VFPK1XGD8R5MABCD4EF",
+		IssueUID: "01HZNQ7VFPK1XGD8R5MABCD4EG",
+	}
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(api.ClaimStatusBody{Held: true, Claim: legacyClaim})
+		case http.MethodPost:
+			_ = json.NewEncoder(w).Encode(api.ClaimActionResponseBody{Granted: true, Claim: legacyClaim})
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(hub.Close)
+
+	client, err := newClaimHubClient(context.Background(), hub.URL, "enrollment-token", false)
+	require.NoError(t, err)
+
+	actions := []struct {
+		name string
+		call func() (api.ClaimActionResponseBody, error)
+	}{
+		{"acquire", func() (api.ClaimActionResponseBody, error) {
+			return client.AcquireClaim(context.Background(), 42, "ABC", api.ClaimActionBody{})
+		}},
+		{"renew", func() (api.ClaimActionResponseBody, error) {
+			return client.RenewClaim(context.Background(), 42, "ABC", api.ClaimActionBody{})
+		}},
+		{"release", func() (api.ClaimActionResponseBody, error) {
+			return client.ReleaseClaim(context.Background(), 42, "ABC", api.ClaimActionBody{})
+		}},
+	}
+	for _, action := range actions {
+		t.Run(action.name, func(t *testing.T) {
+			body, err := action.call()
+			require.NoError(t, err)
+			assert.Equal(t, legacyClaim, body.Lease)
+			assert.Equal(t, legacyClaim, body.Claim)
+		})
+	}
+
+	status, err := client.ClaimStatus(context.Background(), 42, "ABC")
+	require.NoError(t, err)
+	assert.Equal(t, legacyClaim, status.Lease)
+	assert.Equal(t, legacyClaim, status.Claim)
 }
 
 func TestClaimHubClientUsesUnixRuntimeForKataInvalid(t *testing.T) {

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -813,7 +813,20 @@ func resolveIssueByUIDOrPrefix(ctx context.Context, store db.Storage, ref string
 	}
 }
 
+// buildShowIssueResponse assembles the show-issue payload and mirrors the
+// canonical Lease* fields onto their deprecated Claim* aliases. Hydration has
+// several early returns; funneling every success through here is what keeps
+// the two spellings from ever disagreeing.
 func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issue, includeDeleted bool) (*api.ShowIssueResponse, error) {
+	out, err := hydrateShowIssueResponse(ctx, cfg, issue, includeDeleted)
+	if err != nil {
+		return nil, err
+	}
+	out.Body.MirrorDeprecatedClaimFields()
+	return out, nil
+}
+
+func hydrateShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issue, includeDeleted bool) (*api.ShowIssueResponse, error) {
 	if issue.DeletedAt != nil && !includeDeleted {
 		return nil, api.NewError(404, "issue_not_found",
 			"issue not found",
@@ -879,7 +892,6 @@ func buildShowIssueResponse(ctx context.Context, cfg ServerConfig, issue db.Issu
 		return nil, err
 	}
 	if refreshedHubNow != nil && (out.Body.Lease != nil || len(out.Body.PendingLeases) > 0) {
-		out.Body.ClaimHubNow = refreshedHubNow
 		out.Body.LeaseHubNow = refreshedHubNow
 	}
 	return out, nil
@@ -893,9 +905,7 @@ func hydrateClaimViolationsForIssue(ctx context.Context, store db.Storage, issue
 	if count == 0 {
 		return nil
 	}
-	out.Body.ClaimViolations = claimViolationOuts(violations)
-	out.Body.LeaseViolations = out.Body.ClaimViolations
-	out.Body.ClaimViolationCount = &count
+	out.Body.LeaseViolations = claimViolationOuts(violations)
 	out.Body.LeaseViolationCount = &count
 	return nil
 }

--- a/internal/daemon/handlers_recurrences.go
+++ b/internal/daemon/handlers_recurrences.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -123,7 +124,7 @@ func createRecurrenceHandler(cfg ServerConfig) func(context.Context, *api.Create
 				Owner:    in.Body.Template.Owner,
 				Priority: in.Body.Template.Priority,
 				Labels:   in.Body.Template.Labels,
-				Metadata: in.Body.Template.Metadata,
+				Metadata: json.RawMessage(in.Body.Template.Metadata),
 			},
 		}
 		var rec db.Recurrence
@@ -221,7 +222,7 @@ func patchRecurrenceHandler(cfg ServerConfig) func(context.Context, *api.PatchRe
 			update.TemplatePriority = in.Body.Template.Priority
 			update.ClearTemplatePriority = in.Body.Template.ClearPriority
 			update.TemplateLabels = in.Body.Template.Labels
-			update.TemplateMetadata = in.Body.Template.Metadata
+			update.TemplateMetadata = (*json.RawMessage)(in.Body.Template.Metadata)
 		}
 		res, err := cfg.DB.PatchRecurrence(ctx, db.PatchRecurrenceIn{
 			RecurrenceID: rec.ID,

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -46,9 +46,7 @@ func openAPIClientDocument() *huma.OpenAPI {
 
 func baseOpenAPIDocument() *huma.OpenAPI {
 	doc := NewServer(ServerConfig{}).API().OpenAPI()
-	applyMetadataPatchGuardSchema(doc)
-	applyJSONBlobSchemaOverrides(doc)
-	applyArrayQueryParamEncoding(doc)
+	applyDocumentPostProcessing(doc)
 	return doc
 }
 
@@ -81,6 +79,16 @@ func applyMetadataPatchGuardSchema(doc *huma.OpenAPI) {
 	guard.OneOf[0].PrecomputeMessages()
 	guard.OneOf[1].PrecomputeMessages()
 	guard.PrecomputeMessages()
+}
+
+// applyDocumentPostProcessing runs the document-level passes that shape the
+// daemon's OpenAPI output. Opaque JSON wire shapes come from the types
+// themselves (huma.SchemaProvider — see internal/api/jsonwire.go and
+// internal/db/types.go), so adding one cannot silently publish the wrong
+// schema and a typed property named "metadata" keeps its reflected shape.
+func applyDocumentPostProcessing(doc *huma.OpenAPI) {
+	applyMetadataPatchGuardSchema(doc)
+	applyArrayQueryParamEncoding(doc)
 }
 
 // OpenAPIYAML renders the OpenAPI document (OpenAPI 3.1) as YAML.
@@ -292,71 +300,6 @@ func schemaChildren(schema *huma.Schema) []*huma.Schema {
 	return children
 }
 
-func applyJSONBlobSchemaOverrides(doc *huma.OpenAPI) {
-	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
-		return
-	}
-	for name, schema := range doc.Components.Schemas.Map() {
-		applyJSONBlobSchemaOverridesTo(name, schema, map[*huma.Schema]struct{}{})
-	}
-}
-
-func applyJSONBlobSchemaOverridesTo(componentName string, schema *huma.Schema, seen map[*huma.Schema]struct{}) {
-	if schema == nil {
-		return
-	}
-	if _, ok := seen[schema]; ok {
-		return
-	}
-	seen[schema] = struct{}{}
-
-	for name, prop := range schema.Properties {
-		switch name {
-		case "data":
-			if componentName == "ErrorBody" {
-				schema.Properties[name] = jsonObjectSchema()
-				continue
-			}
-			applyJSONBlobSchemaOverridesTo("", prop, seen)
-		case "patch":
-			if componentName == "PatchIssueMetadataRequestBody" || componentName == "PatchProjectMetadataRequestBody" {
-				schema.Properties[name] = jsonObjectSchema()
-				continue
-			}
-			applyJSONBlobSchemaOverridesTo("", prop, seen)
-		case "metadata":
-			if componentName == "RecurrenceTemplateUpdateInput" {
-				schema.Properties[name] = jsonNullableObjectSchema()
-				continue
-			}
-			schema.Properties[name] = jsonObjectSchema()
-		case "template_metadata":
-			schema.Properties[name] = jsonObjectSchema()
-		case "template_labels":
-			schema.Properties[name] = jsonStringArraySchema()
-		case "config":
-			if componentName == "EnableIssueSyncRequestBody" || componentName == "IssueSyncBindingOut" {
-				schema.Properties[name] = jsonObjectSchema()
-				continue
-			}
-			applyJSONBlobSchemaOverridesTo("", prop, seen)
-		default:
-			applyJSONBlobSchemaOverridesTo("", prop, seen)
-		}
-	}
-	applyJSONBlobSchemaOverridesTo("", schema.Items, seen)
-	for _, child := range schema.OneOf {
-		applyJSONBlobSchemaOverridesTo("", child, seen)
-	}
-	for _, child := range schema.AnyOf {
-		applyJSONBlobSchemaOverridesTo("", child, seen)
-	}
-	for _, child := range schema.AllOf {
-		applyJSONBlobSchemaOverridesTo("", child, seen)
-	}
-	applyJSONBlobSchemaOverridesTo("", schema.Not, seen)
-}
-
 func applyArrayQueryParamEncoding(doc *huma.OpenAPI) {
 	if doc == nil {
 		return
@@ -390,25 +333,5 @@ func applyArrayQueryParamEncodingTo(params []*huma.Param) {
 		}
 		explode := true
 		param.Explode = &explode
-	}
-}
-
-func jsonObjectSchema() *huma.Schema {
-	return &huma.Schema{
-		Type:                 huma.TypeObject,
-		AdditionalProperties: true,
-	}
-}
-
-func jsonNullableObjectSchema() *huma.Schema {
-	schema := jsonObjectSchema()
-	schema.Nullable = true
-	return schema
-}
-
-func jsonStringArraySchema() *huma.Schema {
-	return &huma.Schema{
-		Type:  huma.TypeArray,
-		Items: &huma.Schema{Type: huma.TypeString},
 	}
 }

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -2,8 +2,10 @@ package daemon
 
 import (
 	"bytes"
+	"context"
 	"io/fs"
 	"maps"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
+	humago "github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/stretchr/testify/require"
 )
 
@@ -189,6 +192,47 @@ func TestOpenAPIDocumentShape(t *testing.T) {
 	}
 }
 
+// TestOpenAPITypedMetadataPropertyKeepsReflectedSchema pins that the document
+// pipeline no longer rewrites schemas by JSON property name. A component whose
+// `metadata` property is a typed struct must keep its reflected shape — a $ref
+// to the struct's own component — rather than being flattened into an open
+// object. The old override applied its `metadata` rule unconditionally to every
+// component in the document, so there was no way to publish a typed metadata
+// field at all.
+func TestOpenAPITypedMetadataPropertyKeepsReflectedSchema(t *testing.T) {
+	type probeMetadata struct {
+		Area string `json:"area"`
+	}
+	type probeBody struct {
+		Metadata probeMetadata `json:"metadata"`
+	}
+	type probeOutput struct {
+		Body probeBody
+	}
+
+	humaConfig := huma.DefaultConfig("probe", "1.0.0")
+	humaConfig.CreateHooks = nil
+	probeAPI := huma.NewAPI(humaConfig, humago.NewAdapter(http.NewServeMux(), ""))
+	huma.Register(probeAPI, huma.Operation{
+		OperationID: "probe",
+		Method:      http.MethodGet,
+		Path:        "/probe",
+	}, func(_ context.Context, _ *struct{}) (*probeOutput, error) {
+		return &probeOutput{}, nil
+	})
+
+	doc := probeAPI.OpenAPI()
+	applyDocumentPostProcessing(doc)
+	relaxResponseAdditionalProperties(doc)
+
+	body := doc.Components.Schemas.Map()["ProbeBody"]
+	require.NotNil(t, body, "missing ProbeBody schema")
+	metadata := body.Properties["metadata"]
+	require.NotNil(t, metadata, "missing ProbeBody.metadata schema")
+	require.Equal(t, "#/components/schemas/ProbeMetadata", metadata.Ref,
+		"typed metadata property must keep its reflected component reference")
+}
+
 func TestOpenAPIDocumentIncludesUIReadContract(t *testing.T) {
 	doc := OpenAPIDocument()
 
@@ -328,38 +372,48 @@ func TestOpenAPIDocumentIncludesEventsStream(t *testing.T) {
 	}
 }
 
+// TestOpenAPIDocumentJSONBlobShapes checks one representative component per
+// opaque-JSON shape family. It is no longer an enumeration: the schemas come
+// from the wire types themselves (huma.SchemaProvider), so there is no rule
+// table here to keep in sync with one in another package.
 func TestOpenAPIDocumentJSONBlobShapes(t *testing.T) {
 	doc := OpenAPIDocument()
-	assertSchemaPropertyType(t, doc, "Issue", "metadata", huma.TypeObject)
-	// The create body's optional metadata is an open object (the generic
-	// `metadata` override), so callers can supply arbitrary keys.
-	assertSchemaPropertyType(t, doc, "CreateIssueRequestBody", "metadata", huma.TypeObject)
-	createMeta := doc.Components.Schemas.Map()["CreateIssueRequestBody"].Properties["metadata"]
-	if createMeta.AdditionalProperties != true {
-		t.Fatalf("CreateIssueRequestBody.metadata additionalProperties = %#v, want true", createMeta.AdditionalProperties)
-	}
-	assertSchemaPropertyType(t, doc, "ProjectOut", "metadata", huma.TypeObject)
-	assertSchemaPropertyType(t, doc, "ReadyGlobalIssueOut", "metadata", huma.TypeObject)
-	assertSchemaPropertyType(t, doc, "Recurrence", "template_labels", huma.TypeArray)
-	assertSchemaPropertyType(t, doc, "Recurrence", "template_metadata", huma.TypeObject)
-	assertSchemaPropertyType(t, doc, "RecurrenceTemplateUpdateInput", "metadata", huma.TypeObject)
-	assertSchemaPropertyType(t, doc, "EnableIssueSyncRequestBody", "config", huma.TypeObject)
-	assertSchemaPropertyType(t, doc, "IssueSyncBindingOut", "config", huma.TypeObject)
 
+	// db.JSONBlob — the storage object form, on a response component.
+	assertOpenObjectProperty(t, doc, "Issue", "metadata")
+	// api.JSONRawMap — undecoded per-key values, on a request body.
+	assertOpenObjectProperty(t, doc, "CreateIssueRequestBody", "metadata")
+	assertOpenObjectProperty(t, doc, "PatchIssueMetadataRequestBody", "patch")
+	// api.JSONMap — decoded Go values, on a request body and a response body.
+	assertOpenObjectProperty(t, doc, "EnableIssueSyncRequestBody", "config")
+	assertOpenObjectProperty(t, doc, "ErrorBody", "data")
+	// api.JSONRawObject — raw bytes, on a request body.
+	assertOpenObjectProperty(t, doc, "RecurrenceTemplateInput", "metadata")
+
+	// db.JSONStringArray publishes an array of strings, not an object.
 	labels := doc.Components.Schemas.Map()["Recurrence"].Properties["template_labels"]
-	if labels.Items == nil || labels.Items.Type != huma.TypeString {
-		t.Fatalf("Recurrence.template_labels items = %+v, want string items", labels.Items)
-	}
+	require.NotNil(t, labels, "missing Recurrence.template_labels schema")
+	require.Equal(t, huma.TypeArray, labels.Type)
+	require.NotNil(t, labels.Items, "template_labels must declare item schema")
+	require.Equal(t, huma.TypeString, labels.Items.Type)
+
+	// api.JSONNullableRawObject additionally admits an explicit null, which is
+	// how a recurrence template patch clears metadata.
 	updateMetadata := doc.Components.Schemas.Map()["RecurrenceTemplateUpdateInput"].Properties["metadata"]
-	if !updateMetadata.Nullable {
-		t.Fatal("RecurrenceTemplateUpdateInput.metadata must allow null")
-	}
-	for _, schemaName := range []string{"EnableIssueSyncRequestBody", "IssueSyncBindingOut"} {
-		config := doc.Components.Schemas.Map()[schemaName].Properties["config"]
-		if config.AdditionalProperties != true {
-			t.Fatalf("%s.config additionalProperties = %#v, want true", schemaName, config.AdditionalProperties)
-		}
-	}
+	require.NotNil(t, updateMetadata, "missing RecurrenceTemplateUpdateInput.metadata schema")
+	require.Equal(t, huma.TypeObject, updateMetadata.Type)
+	require.True(t, updateMetadata.Nullable, "template patch metadata must allow null")
+}
+
+// assertOpenObjectProperty asserts that a component property publishes the
+// arbitrary-JSON-object shape: type object with additionalProperties
+// explicitly true.
+func assertOpenObjectProperty(t *testing.T, doc *huma.OpenAPI, schemaName, propertyName string) {
+	t.Helper()
+	assertSchemaPropertyType(t, doc, schemaName, propertyName, huma.TypeObject)
+	prop := doc.Components.Schemas.Map()[schemaName].Properties[propertyName]
+	require.Equal(t, true, prop.AdditionalProperties,
+		"%s.%s additionalProperties", schemaName, propertyName)
 }
 
 func TestOpenAPIDocumentArrayQueryParamsExplode(t *testing.T) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -260,7 +260,6 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 	mux.Handle("/", webHandler)
 	applyErrorEnvelopeResponses(humaAPI.OpenAPI())
-	applyJSONBlobSchemaOverrides(humaAPI.OpenAPI())
 	policy := cfg.authPolicy()
 	policy.SelfAuthenticatedRoutes = newSelfAuthenticatedRouteMatcher(
 		selfAuthenticatedRoutes(humaAPI.OpenAPI()))

--- a/internal/db/pgstore/recurrences.go
+++ b/internal/db/pgstore/recurrences.go
@@ -377,7 +377,7 @@ func (s *Store) PatchRecurrence(ctx context.Context, input db.PatchRecurrenceIn)
 			}
 			if string(labelsJSON) != string(current.TemplateLabels) {
 				addDiff("template_labels", json.RawMessage(current.TemplateLabels), json.RawMessage(labelsJSON))
-				next.TemplateLabels = db.JSONBlob(labelsJSON)
+				next.TemplateLabels = db.JSONStringArray(labelsJSON)
 			}
 		}
 		if value := input.Update.TemplateMetadata; value != nil && string(*value) != string(current.TemplateMetadata) {

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -3,10 +3,12 @@ package db
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/danielgtaylor/huma/v2"
 )
 
-// JSONBlob is the storage type for TEXT columns that hold a JSON value
-// (objects for metadata, arrays for labels). Underlying string lets the
+// JSONBlob is the storage type for TEXT columns that hold a JSON object,
+// such as metadata fields. Underlying string lets the
 // database/sql driver scan TEXT into it directly with no `(*[]byte)(&…)`
 // cast and lets handlers pass it back into INSERT/UPDATE as a regular
 // string parameter. Custom MarshalJSON / UnmarshalJSON make it round-trip
@@ -20,8 +22,8 @@ import (
 // does no shape validation on marshal.
 type JSONBlob string
 
-// MarshalJSON emits the stored bytes verbatim (a JSON object or array,
-// per schema). Empty JSONBlob marshals as JSON null.
+// MarshalJSON emits the stored JSON object bytes verbatim, per schema.
+// Empty JSONBlob marshals as JSON null.
 func (j JSONBlob) MarshalJSON() ([]byte, error) {
 	if j == "" {
 		return []byte("null"), nil
@@ -39,6 +41,57 @@ func (j *JSONBlob) UnmarshalJSON(b []byte) error {
 	}
 	*j = JSONBlob(b)
 	return nil
+}
+
+// Schema implements huma.SchemaProvider so the published OpenAPI document
+// describes this field with its true wire shape. Reflection would otherwise
+// publish `type: string` — JSONBlob's underlying type — which lies about
+// every metadata field on the wire. additionalProperties stays explicitly
+// true rather than unset: the code-generator document flavor clears it where
+// it must (see openAPIClientDocument in internal/daemon/openapi.go).
+func (JSONBlob) Schema(huma.Registry) *huma.Schema {
+	return &huma.Schema{
+		Type:                 huma.TypeObject,
+		AdditionalProperties: true,
+	}
+}
+
+// JSONStringArray is the storage type for TEXT columns that hold a JSON array
+// of strings — today only recurrences.template_labels. It is byte-for-byte the
+// same storage and wire behavior as JSONBlob; the two types exist separately so
+// each can publish its own OpenAPI shape instead of the shape being guessed
+// from a JSON property name in another package. As with JSONBlob, the schema's
+// json_type CHECK constraint is the authority on the persisted shape and this
+// type does no shape validation on marshal.
+type JSONStringArray string
+
+// MarshalJSON emits the stored bytes verbatim (a JSON array of strings, per
+// schema). The empty JSONStringArray marshals as JSON null.
+func (j JSONStringArray) MarshalJSON() ([]byte, error) {
+	if j == "" {
+		return []byte("null"), nil
+	}
+	return []byte(j), nil
+}
+
+// UnmarshalJSON copies the raw input bytes verbatim. JSON null is stored as
+// the empty string so a round-trip through unmarshal/marshal is idempotent.
+func (j *JSONStringArray) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		*j = ""
+		return nil
+	}
+	*j = JSONStringArray(b)
+	return nil
+}
+
+// Schema implements huma.SchemaProvider. See JSONBlob.Schema: reflection would
+// publish `type: string` for this string-backed storage type.
+func (JSONStringArray) Schema(huma.Registry) *huma.Schema {
+	return &huma.Schema{
+		Type:  huma.TypeArray,
+		Items: &huma.Schema{Type: huma.TypeString},
+	}
 }
 
 // Project mirrors a row in projects. DeletedAt is set when the project has
@@ -444,25 +497,25 @@ type IssueLabel struct {
 // link is closed by issues.recurrence_id + issues.occurrence_key, whose
 // partial unique index guarantees one materialized issue per occurrence.
 type Recurrence struct {
-	ID                  int64      `json:"id"`
-	UID                 string     `json:"uid"`
-	ProjectID           int64      `json:"project_id"`
-	RRule               string     `json:"rrule"`
-	DTStart             string     `json:"dtstart"`
-	Timezone            string     `json:"timezone"`
-	TemplateTitle       string     `json:"template_title"`
-	TemplateBody        string     `json:"template_body"`
-	TemplateOwner       *string    `json:"template_owner,omitempty"`
-	TemplatePriority    *int64     `json:"template_priority,omitempty"`
-	TemplateLabels      JSONBlob   `json:"template_labels"`
-	TemplateMetadata    JSONBlob   `json:"template_metadata"`
-	NextOccurrenceKey   *string    `json:"next_occurrence_key,omitempty"`
-	LastMaterializedUID *string    `json:"last_materialized_uid,omitempty"`
-	Author              string     `json:"author"`
-	Revision            int64      `json:"revision"`
-	CreatedAt           time.Time  `json:"created_at"`
-	UpdatedAt           time.Time  `json:"updated_at"`
-	DeletedAt           *time.Time `json:"deleted_at,omitempty"`
+	ID                  int64           `json:"id"`
+	UID                 string          `json:"uid"`
+	ProjectID           int64           `json:"project_id"`
+	RRule               string          `json:"rrule"`
+	DTStart             string          `json:"dtstart"`
+	Timezone            string          `json:"timezone"`
+	TemplateTitle       string          `json:"template_title"`
+	TemplateBody        string          `json:"template_body"`
+	TemplateOwner       *string         `json:"template_owner,omitempty"`
+	TemplatePriority    *int64          `json:"template_priority,omitempty"`
+	TemplateLabels      JSONStringArray `json:"template_labels"`
+	TemplateMetadata    JSONBlob        `json:"template_metadata"`
+	NextOccurrenceKey   *string         `json:"next_occurrence_key,omitempty"`
+	LastMaterializedUID *string         `json:"last_materialized_uid,omitempty"`
+	Author              string          `json:"author"`
+	Revision            int64           `json:"revision"`
+	CreatedAt           time.Time       `json:"created_at"`
+	UpdatedAt           time.Time       `json:"updated_at"`
+	DeletedAt           *time.Time      `json:"deleted_at,omitempty"`
 }
 
 // LabelCount is the per-label aggregate returned by LabelCounts.

--- a/internal/db/types_test.go
+++ b/internal/db/types_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -14,4 +15,50 @@ func TestIssue_HasShortIDFieldAndNoNumber(t *testing.T) {
 	_, hasNumber := typ.FieldByName("Number")
 	assert.True(t, hasShortID, "Issue.ShortID should exist")
 	assert.False(t, hasNumber, "Issue.Number should be removed")
+}
+
+// TestJSONStringArrayRoundTripsVerbatim pins that the array-shaped storage
+// blob behaves exactly like JSONBlob on the wire: the stored bytes go out
+// verbatim (not as a JSON-encoded string), and JSON null comes back as the
+// empty value so unmarshal/marshal is idempotent.
+func TestJSONStringArrayRoundTripsVerbatim(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		stored  db.JSONStringArray
+		want    string
+		wantVal db.JSONStringArray
+	}{
+		{name: "labels", stored: `["p2","recurring"]`, want: `["p2","recurring"]`, wantVal: `["p2","recurring"]`},
+		{name: "empty array", stored: `[]`, want: `[]`, wantVal: `[]`},
+		{name: "zero value", stored: "", want: `null`, wantVal: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.stored)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, string(raw))
+
+			var back db.JSONStringArray
+			assert.NoError(t, json.Unmarshal(raw, &back))
+			assert.Equal(t, tc.wantVal, back)
+		})
+	}
+}
+
+// TestRecurrenceTemplateLabelsMarshalAsArray pins that the recurrence row
+// publishes template_labels as a JSON array and template_metadata as a JSON
+// object — the two shapes the daemon used to reconstruct by property name.
+func TestRecurrenceTemplateLabelsMarshalAsArray(t *testing.T) {
+	raw, err := json.Marshal(db.Recurrence{
+		TemplateLabels:   `["p2","recurring"]`,
+		TemplateMetadata: `{"area":"example-workspace"}`,
+	})
+	assert.NoError(t, err)
+
+	var decoded struct {
+		TemplateLabels   []string       `json:"template_labels"`
+		TemplateMetadata map[string]any `json:"template_metadata"`
+	}
+	assert.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, []string{"p2", "recurring"}, decoded.TemplateLabels)
+	assert.Equal(t, map[string]any{"area": "example-workspace"}, decoded.TemplateMetadata)
 }

--- a/internal/federation/federation_claims.go
+++ b/internal/federation/federation_claims.go
@@ -12,7 +12,16 @@ import (
 type ClaimRequest = api.ClaimActionBody
 
 // ClaimResponse is the wire body returned by federation claim actions.
-type ClaimResponse = api.ClaimActionResponseBody
+type ClaimResponse api.ClaimActionResponseBody
+
+// canonicalLease returns the canonical lease, falling back to the deprecated
+// claim alias for responses from older hubs.
+func (r ClaimResponse) canonicalLease() *api.IssueClaimOut {
+	if r.Lease != nil {
+		return r.Lease
+	}
+	return r.Claim
+}
 
 // ClaimStatusResponse is the wire body returned by federation lease status reads.
 type ClaimStatusResponse = api.ClaimStatusBody

--- a/internal/federation/federation_claims_test.go
+++ b/internal/federation/federation_claims_test.go
@@ -16,6 +16,36 @@ import (
 	"go.kenn.io/kata/internal/testenv"
 )
 
+// TestAcquireClaimResponseCarriesCanonicalLease pins that the hub sets the
+// canonical lease field on every granted arbitration, which is the precondition
+// for the sync runner reading resp.Lease directly instead of coalescing it with
+// the deprecated claim alias.
+func TestAcquireClaimResponseCarriesCanonicalLease(t *testing.T) {
+	body := api.ClaimActionResponseBody{
+		Granted: true,
+		Lease:   &api.IssueClaimOut{Holder: "alice", ClaimKind: "hard"},
+	}
+	body.MirrorDeprecatedClaimFields()
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var decoded ClaimResponse
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.NotNil(t, decoded.Lease)
+	assert.Equal(t, "alice", decoded.Lease.Holder)
+	assert.Equal(t, decoded.Lease, decoded.Claim)
+}
+
+func TestClaimResponseCanonicalLeasePrefersCanonicalField(t *testing.T) {
+	lease := &api.IssueClaimOut{Holder: "canonical"}
+	deprecated := &api.IssueClaimOut{Holder: "deprecated"}
+
+	got := (ClaimResponse{Lease: lease, Claim: deprecated}).canonicalLease()
+
+	assert.Same(t, lease, got)
+}
+
 func TestFederationClientAcquireClaimPostsRequestAndParsesTimedHubFields(t *testing.T) {
 	expiresAt := time.Date(2026, 5, 23, 15, 4, 5, 0, time.UTC)
 	hubNow := time.Date(2026, 5, 23, 15, 0, 0, 0, time.UTC)

--- a/internal/federation/federation_sync.go
+++ b/internal/federation/federation_sync.go
@@ -1081,10 +1081,7 @@ func retryPendingClaim(
 		}
 		return err
 	}
-	lease := resp.Lease
-	if lease == nil {
-		lease = resp.Claim
-	}
+	lease := resp.canonicalLease()
 	if resp.Granted && lease != nil {
 		return store.ResolvePendingClaim(ctx, pending.RequestUID, issueClaimFromAPI(lease))
 	}

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -3605,6 +3605,55 @@ func TestPendingClaimRetryResolvesAfterHubReconnectWithFreshTimedTTL(t *testing.
 		status.Claim.ExpiresAt, retryStart)
 }
 
+func TestPendingClaimRetryResolvesClaimOnlyResponseFromOlderHub(t *testing.T) {
+	ctx := context.Background()
+	spoke := testenv.New(t)
+	project, issue, _ := createPendingClaimRetrySpoke(t, spoke.DB, "legacy-claim-response")
+	pending, err := spoke.DB.EnqueuePendingClaim(
+		ctx, pendingClaimParams(spoke.DB, project.ID, issue.ShortID, "legacy-client"),
+	)
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	legacyClaim := &api.IssueClaimOut{
+		ClaimUID:          mustTestUID(t),
+		ProjectID:         42,
+		IssueUID:          issue.UID,
+		Holder:            pending.Holder,
+		HolderInstanceUID: pending.HolderInstanceUID,
+		ClientKind:        pending.ClientKind,
+		ClaimKind:         pending.ClaimKind,
+		AcquiredAt:        now,
+		Revision:          1,
+		UpdatedAt:         now,
+	}
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/projects/42/issues/"+issue.UID+"/lease/actions/acquire", r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(api.ClaimActionResponseBody{
+			Granted: true,
+			Claim:   legacyClaim,
+		}))
+	}))
+	t.Cleanup(hub.Close)
+	client, err := NewClient(ctx, hub.URL, "token", clientOptsWithDefault(clientpkg.Opts{}))
+	require.NoError(t, err)
+
+	require.NoError(t, retryPendingClaim(ctx, spoke.DB, client, 42, pending, nil))
+
+	var resolved, rejected int
+	require.NoError(t, spoke.DB.QueryRowContext(ctx, `
+		SELECT resolved_at IS NOT NULL, rejected_at IS NOT NULL
+		  FROM pending_claim_requests
+		 WHERE request_uid = ?`, pending.RequestUID).Scan(&resolved, &rejected))
+	assert.Equal(t, 1, resolved)
+	assert.Equal(t, 0, rejected)
+	status, err := spoke.DB.ClaimStatusReadOnly(ctx, project.ID, issue.ShortID, now)
+	require.NoError(t, err)
+	require.True(t, status.Held)
+	require.NotNil(t, status.Claim)
+	assert.Equal(t, "legacy-client", status.Claim.Holder)
+}
+
 func TestPendingClaimRetryUnknownCapabilitiesTransportFailureRetriesAfterReconnect(t *testing.T) {
 	ctx := context.Background()
 	hub := testenv.New(t)


### PR DESCRIPTION
## What changed

- let opaque JSON storage and API types define their own OpenAPI shapes
- remove the daemon's property-name schema rewrite while keeping committed OpenAPI documents and generated clients byte-identical
- mirror canonical `lease` fields to deprecated `claim` aliases once at response boundaries
- keep explicit `claim` fallbacks where first-party clients still talk to older hubs
- leave persisted schemas, migrations, and wire spellings unchanged

## Why

Schema meaning and lease compatibility were encoded in property names and repeated producer logic. That is fragile: an unrelated typed field named `metadata` could be rewritten, and lease aliases could drift between response paths.

## Usage

No usage change.
