### PR TITLE
Simplify GitHub sync scans and fetcher sessions

### DIFF
--- a/internal/githubsync/gh_fetcher.go
+++ b/internal/githubsync/gh_fetcher.go
@@ -12,13 +12,34 @@ import (
 	"time"
 )
 
+// ParentScan states which of three outcomes produced a ParentData value.
+type ParentScan uint8
+
+const (
+	// ParentScanAbsent means no parent information was supplied. Items built
+	// from such a fetch leave LinkTypesAuthoritative unset, and
+	// db.ImportItemLinkTypeAuthoritative reads an unset entry as
+	// authoritative. This state is therefore the opposite of
+	// ParentScanUnsupported, not a cautious "unknown".
+	ParentScanAbsent ParentScan = iota
+	// ParentScanUnsupported means the provider does not expose the parent
+	// field, so parent links from this source are not authoritative.
+	ParentScanUnsupported
+	// ParentScanComplete means a full repository parent scan succeeded and
+	// ScannedChildIDs is its coverage.
+	ParentScanComplete
+)
+
 // ParentData carries GitHub parent relationship data plus scan coverage.
 type ParentData struct {
-	ParentByChild   map[int]int64
-	ScannedChildren map[int]struct{}
-	ChildIDByNumber map[int]int64
-	Authoritative   bool
-	Unsupported     bool
+	// Scan states which fetch outcome produced this value.
+	Scan ParentScan
+	// ScannedChildIDs maps every child issue number the scan covered to its
+	// REST database id. Coverage and identity are the same map, so they
+	// cannot disagree, and every id is non-zero.
+	ScannedChildIDs map[int]int64
+	// ParentByChild maps a child issue number to its parent's REST id.
+	ParentByChild map[int]int64
 }
 
 // ParentID returns the parent REST ID for childNumber when GitHub reported one.
@@ -35,10 +56,10 @@ func (d ParentData) ParentID(childNumber int) (int64, bool) {
 
 // ChildScanned reports whether the parent scan included childNumber.
 func (d ParentData) ChildScanned(childNumber int) bool {
-	if d.ScannedChildren == nil {
+	if d.ScannedChildIDs == nil {
 		return false
 	}
-	_, ok := d.ScannedChildren[childNumber]
+	_, ok := d.ScannedChildIDs[childNumber]
 	return ok
 }
 

--- a/internal/githubsync/http_fetcher.go
+++ b/internal/githubsync/http_fetcher.go
@@ -70,17 +70,14 @@ func NewHTTPFetcher(cfg HTTPFetcherConfig) *HTTPFetcher {
 	return fetcher
 }
 
-// Repository validates and reads a GitHub repository over REST.
+// Repository validates and reads a GitHub repository over REST through a
+// single-use binding session.
 func (f *HTTPFetcher) Repository(ctx context.Context, host, owner, repo string) (Repository, error) {
-	binding, err := normalizeBinding(Binding{Host: host, Owner: owner, Repo: repo})
+	session, err := f.ForBinding(ctx, Binding{Host: host, Owner: owner, Repo: repo})
 	if err != nil {
 		return Repository{}, err
 	}
-	client, err := f.clientForBinding(ctx, binding)
-	if err != nil {
-		return Repository{}, err
-	}
-	return f.repositoryWithClient(ctx, client, binding)
+	return session.Repository(ctx, host, owner, repo)
 }
 
 func (f *HTTPFetcher) repositoryWithClient(ctx context.Context, client *http.Client, binding Binding) (Repository, error) {
@@ -100,41 +97,28 @@ func (f *HTTPFetcher) repositoryWithClient(ctx context.Context, client *http.Cli
 	return out, nil
 }
 
-// Issues reads repository issues over REST, following Link rel="next" pages.
+// Issues reads repository issues over REST through a single-use binding
+// session, following Link rel="next" pages.
 func (f *HTTPFetcher) Issues(ctx context.Context, binding Binding, since *time.Time) ([]Issue, error) {
-	binding, err := normalizeBinding(binding)
+	session, err := f.ForBinding(ctx, binding)
 	if err != nil {
 		return nil, err
 	}
-	requestURL, err := f.restEndpointURL(binding, issuesEndpoint(binding, since))
-	if err != nil {
-		return nil, err
-	}
-	client, err := f.clientForBinding(ctx, binding)
-	if err != nil {
-		return nil, err
-	}
-	return fetchRESTPagesWithClient[Issue](ctx, f, client, binding, requestURL, "GitHub issues")
+	return session.Issues(ctx, binding, since)
 }
 
-// Comments reads issue comments over REST, following Link rel="next" pages.
+// Comments reads issue comments over REST through a single-use binding
+// session, following Link rel="next" pages. The issue number is validated
+// here so an invalid argument is rejected before credentials are resolved.
 func (f *HTTPFetcher) Comments(ctx context.Context, binding Binding, issueNumber int) ([]Comment, error) {
 	if issueNumber <= 0 {
 		return nil, fmt.Errorf("GitHub issue number must be positive")
 	}
-	binding, err := normalizeBinding(binding)
+	session, err := f.ForBinding(ctx, binding)
 	if err != nil {
 		return nil, err
 	}
-	requestURL, err := f.restEndpointURL(binding, commentsEndpoint(binding, issueNumber))
-	if err != nil {
-		return nil, err
-	}
-	client, err := f.clientForBinding(ctx, binding)
-	if err != nil {
-		return nil, err
-	}
-	return fetchRESTPagesWithClient[Comment](ctx, f, client, binding, requestURL, "GitHub comments for issue "+strconv.Itoa(issueNumber))
+	return session.Comments(ctx, binding, issueNumber)
 }
 
 func fetchRESTPagesWithClient[T any](ctx context.Context, f *HTTPFetcher, client *http.Client, binding Binding, firstURL, resource string) ([]T, error) {

--- a/internal/githubsync/http_fetcher_test.go
+++ b/internal/githubsync/http_fetcher_test.go
@@ -523,6 +523,77 @@ func TestHTTPFetcherBindingSessionReusesCredentialTransport(t *testing.T) {
 	assert.Equal(t, 1, resolver.calls)
 }
 
+func TestHTTPFetcherUnboundReadsResolveCredentialsOncePerCall(t *testing.T) {
+	resolver := &countingHTTPFetcherTestResolver{token: "test-token"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertHTTPFetcherHeaders(t, r)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		switch r.URL.Path {
+		case "/repos/example-owner/example-repo":
+			writeHTTPFetcherTestResponse(t, w, `{"node_id":"R_example","id":123456789012,"full_name":"example-owner/example-repo"}`)
+		case "/repos/example-owner/example-repo/issues":
+			writeHTTPFetcherTestResponse(t, w, `[{"id":101,"node_id":"I_first","number":1,"title":"first"}]`)
+		case "/repos/example-owner/example-repo/issues/1/comments":
+			writeHTTPFetcherTestResponse(t, w, `[{"id":201,"node_id":"C_first","body":"first"}]`)
+		case "/graphql":
+			writeHTTPFetcherTestResponse(t, w, `{
+				"data": {
+					"repository": {
+						"issues": {
+							"pageInfo": {"hasNextPage": false, "endCursor": null},
+							"nodes": [
+								{"number": 1, "fullDatabaseId": "101", "parent": null}
+							]
+						}
+					}
+				}
+			}`)
+		default:
+			t.Fatalf("unexpected unbound request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	fetcher := NewHTTPFetcher(HTTPFetcherConfig{
+		Client:              server.Client(),
+		CredentialResolver:  resolver,
+		RESTBaseURLOverride: server.URL,
+		GraphQLURLOverride:  server.URL + "/graphql",
+	})
+	binding := Binding{Host: "github.com", Owner: "example-owner", Repo: "example-repo"}
+
+	_, err := fetcher.Repository(context.Background(), "github.com", "example-owner", "example-repo")
+	require.NoError(t, err)
+	_, err = fetcher.Issues(context.Background(), binding, nil)
+	require.NoError(t, err)
+	_, err = fetcher.Comments(context.Background(), binding, 1)
+	require.NoError(t, err)
+	data, err := fetcher.ParentData(context.Background(), binding)
+	require.NoError(t, err)
+
+	assert.Equal(t, ParentScanComplete, data.Scan)
+	assert.Equal(t, 4, resolver.calls)
+}
+
+func TestHTTPFetcherCommentsRejectsNonPositiveIssueNumberWithoutResolvingCredentials(t *testing.T) {
+	resolver := &countingHTTPFetcherTestResolver{token: "test-token"}
+	fetcher := NewHTTPFetcher(HTTPFetcherConfig{
+		Client:              http.DefaultClient,
+		CredentialResolver:  resolver,
+		RESTBaseURLOverride: "https://api.github.example",
+	})
+
+	_, err := fetcher.Comments(context.Background(), Binding{
+		Host:  "github.com",
+		Owner: "example-owner",
+		Repo:  "example-repo",
+	}, 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GitHub issue number must be positive")
+	assert.Equal(t, 0, resolver.calls)
+}
+
 func assertHTTPFetcherHeaders(t testing.TB, r *http.Request) {
 	t.Helper()
 	assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))

--- a/internal/githubsync/live_test.go
+++ b/internal/githubsync/live_test.go
@@ -26,7 +26,7 @@ func TestLiveGitHubParentGraphQLMatchesREST(t *testing.T) {
 
 	data, err := fetcher.ParentData(ctx, binding)
 	require.NoError(t, err)
-	require.False(t, data.Unsupported, "live repository does not expose parent GraphQL fields")
+	require.NotEqual(t, ParentScanUnsupported, data.Scan, "live repository does not expose parent GraphQL fields")
 	assert.True(t, data.ChildScanned(childNumber))
 
 	parentID, ok := data.ParentID(childNumber)

--- a/internal/githubsync/mapping.go
+++ b/internal/githubsync/mapping.go
@@ -61,10 +61,14 @@ func BuildImportBatchWithConfig(sourceKey string, config Config, issues []Issue,
 				TargetExternalID: fmt.Sprintf("issue-id:%d", parentID),
 			})
 		}
-		if parentData.Unsupported {
+		switch parentData.Scan {
+		case ParentScanUnsupported:
 			item.LinkTypesAuthoritative = map[string]bool{"parent": false}
-		} else if parentData.Authoritative {
+		case ParentScanComplete:
 			item.LinkTypesAuthoritative = map[string]bool{"parent": parentData.ChildScanned(issue.Number)}
+		case ParentScanAbsent:
+			// Leave LinkTypesAuthoritative nil: the import layer defaults an
+			// absent entry to authoritative.
 		}
 		batch.Items = append(batch.Items, item)
 	}

--- a/internal/githubsync/mapping_test.go
+++ b/internal/githubsync/mapping_test.go
@@ -230,12 +230,9 @@ func TestBuildImportBatchUsesParentDataAuthority(t *testing.T) {
 		},
 	}
 	parentData := ParentData{
-		ParentByChild: map[int]int64{1: 102},
-		ScannedChildren: map[int]struct{}{
-			1: {},
-			2: {},
-		},
-		Authoritative: true,
+		Scan:            ParentScanComplete,
+		ParentByChild:   map[int]int64{1: 102},
+		ScannedChildIDs: map[int]int64{1: 101, 2: 102},
 	}
 
 	batch := BuildImportBatchWithConfig("github:repo-node", Config{}, issues, nil, parentData, syncStartedAt)
@@ -270,7 +267,7 @@ func TestBuildImportBatchUnsupportedParentDataIsNotAuthoritative(t *testing.T) {
 		},
 	}
 
-	batch := BuildImportBatchWithConfig("github:repo-node", Config{}, issues, nil, ParentData{Unsupported: true}, syncStartedAt)
+	batch := BuildImportBatchWithConfig("github:repo-node", Config{}, issues, nil, ParentData{Scan: ParentScanUnsupported}, syncStartedAt)
 
 	item := itemByExternalID(t, batch.Items, "issue-id:101")
 	assert.Empty(t, item.Links)

--- a/internal/githubsync/parent_graphql.go
+++ b/internal/githubsync/parent_graphql.go
@@ -40,33 +40,29 @@ query($owner: String!, $repo: String!, $after: String) {
 
 var errParentFeatureUnsupported = errors.New("GitHub parent GraphQL feature unsupported")
 
-// ParentData fetches child->parent REST database IDs through GitHub GraphQL.
+// ParentData fetches child->parent REST database IDs through GitHub GraphQL
+// using a single-use binding session.
 func (f *HTTPFetcher) ParentData(ctx context.Context, binding Binding) (ParentData, error) {
-	binding, err := normalizeBinding(binding)
+	session, err := f.ForBinding(ctx, binding)
 	if err != nil {
 		return ParentData{}, err
 	}
-	client, err := f.clientForBinding(ctx, binding)
-	if err != nil {
-		return ParentData{}, err
-	}
-	return f.parentDataWithClient(ctx, client, binding)
+	return session.ParentData(ctx, binding)
 }
 
 func (f *HTTPFetcher) parentDataWithClient(ctx context.Context, client *http.Client, binding Binding) (ParentData, error) {
 	cache := f.parentCapabilityCache()
 	if cache.featureUnsupported(binding.Host) {
-		return ParentData{Unsupported: true}, nil
+		return ParentData{Scan: ParentScanUnsupported}, nil
 	}
 	requestURL, err := f.graphQLEndpointURL(binding)
 	if err != nil {
 		return ParentData{}, err
 	}
 	data := ParentData{
+		Scan:            ParentScanComplete,
+		ScannedChildIDs: map[int]int64{},
 		ParentByChild:   map[int]int64{},
-		ScannedChildren: map[int]struct{}{},
-		ChildIDByNumber: map[int]int64{},
-		Authoritative:   true,
 	}
 	var after *string
 	retryBudget := &gitHubRetryBudget{}
@@ -75,7 +71,7 @@ func (f *HTTPFetcher) parentDataWithClient(ctx context.Context, client *http.Cli
 		if err != nil {
 			if errors.Is(err, errParentFeatureUnsupported) {
 				cache.markUnsupported(binding.Host)
-				return ParentData{Unsupported: true}, nil
+				return ParentData{Scan: ParentScanUnsupported}, nil
 			}
 			return ParentData{}, err
 		}
@@ -83,12 +79,11 @@ func (f *HTTPFetcher) parentDataWithClient(ctx context.Context, client *http.Cli
 			if node.Number <= 0 {
 				continue
 			}
-			data.ScannedChildren[node.Number] = struct{}{}
 			if node.FullDatabaseID <= 0 {
 				return ParentData{}, fmt.Errorf("%s child issue %d missing fullDatabaseId",
 					parentGraphQLResource, node.Number)
 			}
-			data.ChildIDByNumber[node.Number] = int64(node.FullDatabaseID)
+			data.ScannedChildIDs[node.Number] = int64(node.FullDatabaseID)
 			if node.Parent != nil {
 				if node.Parent.FullDatabaseID <= 0 {
 					return ParentData{}, fmt.Errorf("%s parent issue %d for child issue %d missing fullDatabaseId",

--- a/internal/githubsync/parent_graphql_test.go
+++ b/internal/githubsync/parent_graphql_test.go
@@ -77,13 +77,9 @@ func TestHTTPFetcherParentDataPaginatesAndIncludesRESTDatabaseIDs(t *testing.T) 
 	})
 	require.NoError(t, err)
 
-	assert.True(t, data.Authoritative)
-	assert.False(t, data.Unsupported)
+	assert.Equal(t, ParentScanComplete, data.Scan)
 	assert.Equal(t, map[int]int64{1: 102}, data.ParentByChild)
-	assert.Equal(t, map[int]int64{1: 101, 2: 102, 3: 103}, data.ChildIDByNumber)
-	assert.Contains(t, data.ScannedChildren, 1)
-	assert.Contains(t, data.ScannedChildren, 2)
-	assert.Contains(t, data.ScannedChildren, 3)
+	assert.Equal(t, map[int]int64{1: 101, 2: 102, 3: 103}, data.ScannedChildIDs)
 	assert.Len(t, requests, 2)
 }
 
@@ -115,11 +111,77 @@ func TestHTTPFetcherParentDataReturnsAuthoritativeEmptyForScannedChildrenWithout
 	})
 	require.NoError(t, err)
 
-	assert.True(t, data.Authoritative)
-	assert.False(t, data.Unsupported)
+	assert.Equal(t, ParentScanComplete, data.Scan)
 	assert.Empty(t, data.ParentByChild)
-	assert.Contains(t, data.ScannedChildren, 5)
-	assert.Contains(t, data.ScannedChildren, 7)
+	assert.Equal(t, map[int]int64{5: 105, 7: 107}, data.ScannedChildIDs)
+}
+
+func TestHTTPFetcherParentDataScanCoverageCarriesRESTIDsForEveryChild(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		decodeParentGraphQLTestRequest(t, r)
+		writeParentGraphQLTestResponse(t, w, `{
+			"data": {
+				"repository": {
+					"issues": {
+						"pageInfo": {"hasNextPage": false, "endCursor": null},
+						"nodes": [
+							{"number": 11, "fullDatabaseId": "111", "parent": {"number": 12, "fullDatabaseId": "112"}},
+							{"number": 12, "fullDatabaseId": "112", "parent": null}
+						]
+					}
+				}
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	fetcher := newParentGraphQLTestFetcher(server.URL + "/graphql")
+
+	data, err := fetcher.ParentData(context.Background(), Binding{
+		Host:  "github.com",
+		Owner: "example-owner",
+		Repo:  "example-repo",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, ParentScanComplete, data.Scan)
+	assert.Equal(t, map[int]int64{11: 111, 12: 112}, data.ScannedChildIDs)
+	for number, id := range data.ScannedChildIDs {
+		assert.NotZero(t, id, "scanned child %d must carry a REST id", number)
+	}
+}
+
+func TestHTTPFetcherParentDataMissingChildIDIsFatalAndYieldsNoScanCoverage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		decodeParentGraphQLTestRequest(t, r)
+		writeParentGraphQLTestResponse(t, w, `{
+			"data": {
+				"repository": {
+					"issues": {
+						"pageInfo": {"hasNextPage": false, "endCursor": null},
+						"nodes": [
+							{"number": 11, "fullDatabaseId": "111", "parent": null},
+							{"number": 12, "parent": null}
+						]
+					}
+				}
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	fetcher := newParentGraphQLTestFetcher(server.URL + "/graphql")
+
+	data, err := fetcher.ParentData(context.Background(), Binding{
+		Host:  "github.com",
+		Owner: "example-owner",
+		Repo:  "example-repo",
+	})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "child issue 12 missing fullDatabaseId")
+	assert.Equal(t, ParentScanAbsent, data.Scan)
+	assert.Empty(t, data.ScannedChildIDs)
 }
 
 func TestHTTPFetcherParentDataFeatureUnsupportedIsNonFatal(t *testing.T) {
@@ -146,10 +208,9 @@ func TestHTTPFetcherParentDataFeatureUnsupportedIsNonFatal(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.True(t, data.Unsupported)
-	assert.False(t, data.Authoritative)
+	assert.Equal(t, ParentScanUnsupported, data.Scan)
 	assert.Empty(t, data.ParentByChild)
-	assert.Empty(t, data.ScannedChildren)
+	assert.Empty(t, data.ScannedChildIDs)
 }
 
 func TestHTTPFetcherParentDataFeatureUnsupportedFromSchemaFieldNameWithoutPath(t *testing.T) {
@@ -178,10 +239,9 @@ func TestHTTPFetcherParentDataFeatureUnsupportedFromSchemaFieldNameWithoutPath(t
 	})
 	require.NoError(t, err)
 
-	assert.True(t, data.Unsupported)
-	assert.False(t, data.Authoritative)
+	assert.Equal(t, ParentScanUnsupported, data.Scan)
 	assert.Empty(t, data.ParentByChild)
-	assert.Empty(t, data.ScannedChildren)
+	assert.Empty(t, data.ScannedChildIDs)
 }
 
 func TestHTTPFetcherParentDataFeatureUnsupportedFromStructuredClassOnly(t *testing.T) {
@@ -207,8 +267,7 @@ func TestHTTPFetcherParentDataFeatureUnsupportedFromStructuredClassOnly(t *testi
 	})
 	require.NoError(t, err)
 
-	assert.True(t, data.Unsupported)
-	assert.False(t, data.Authoritative)
+	assert.Equal(t, ParentScanUnsupported, data.Scan)
 }
 
 func TestHTTPFetcherParentDataFeatureUnsupportedFromStructuredFieldAndValidationClass(t *testing.T) {
@@ -237,8 +296,7 @@ func TestHTTPFetcherParentDataFeatureUnsupportedFromStructuredFieldAndValidation
 	})
 	require.NoError(t, err)
 
-	assert.True(t, data.Unsupported)
-	assert.False(t, data.Authoritative)
+	assert.Equal(t, ParentScanUnsupported, data.Scan)
 }
 
 func TestHTTPFetcherParentDataFeatureUnsupportedFromMessageOnlySchemaError(t *testing.T) {
@@ -263,10 +321,9 @@ func TestHTTPFetcherParentDataFeatureUnsupportedFromMessageOnlySchemaError(t *te
 	})
 	require.NoError(t, err)
 
-	assert.True(t, data.Unsupported)
-	assert.False(t, data.Authoritative)
+	assert.Equal(t, ParentScanUnsupported, data.Scan)
 	assert.Empty(t, data.ParentByChild)
-	assert.Empty(t, data.ScannedChildren)
+	assert.Empty(t, data.ScannedChildIDs)
 }
 
 func TestHTTPFetcherParentDataAmbiguousMessageOnlyFieldErrorIsFatalAndUncached(t *testing.T) {
@@ -312,8 +369,8 @@ func TestHTTPFetcherParentDataAmbiguousMessageOnlyFieldErrorIsFatalAndUncached(t
 
 	data, err := fetcher.ParentData(context.Background(), binding)
 	require.NoError(t, err)
-	assert.True(t, data.Authoritative)
-	assert.Contains(t, data.ScannedChildren, 10)
+	assert.Equal(t, ParentScanComplete, data.Scan)
+	assert.Contains(t, data.ScannedChildIDs, 10)
 	assert.Equal(t, 2, requests)
 }
 
@@ -369,8 +426,8 @@ func TestHTTPFetcherParentDataGraphQLRateLimitRetriesHTTP200Errors(t *testing.T)
 
 	assert.Equal(t, 2, attempts)
 	assert.Equal(t, []time.Duration{2 * time.Second}, sleeps)
-	assert.True(t, data.Authoritative)
-	assert.Contains(t, data.ScannedChildren, 4)
+	assert.Equal(t, ParentScanComplete, data.Scan)
+	assert.Contains(t, data.ScannedChildIDs, 4)
 }
 
 func TestHTTPFetcherParentDataRetryAfterCapReturnsFatal(t *testing.T) {
@@ -742,20 +799,19 @@ func TestParentCapabilityCacheReusesUnsupportedAndExpires(t *testing.T) {
 
 	first, err := fetcher.ParentData(context.Background(), binding)
 	require.NoError(t, err)
-	assert.True(t, first.Unsupported)
+	assert.Equal(t, ParentScanUnsupported, first.Scan)
 	assert.Equal(t, 1, requests)
 
 	second, err := fetcher.ParentData(context.Background(), binding)
 	require.NoError(t, err)
-	assert.True(t, second.Unsupported)
+	assert.Equal(t, ParentScanUnsupported, second.Scan)
 	assert.Equal(t, 1, requests)
 
 	now = now.Add(time.Hour + time.Nanosecond)
 	third, err := fetcher.ParentData(context.Background(), binding)
 	require.NoError(t, err)
-	assert.True(t, third.Authoritative)
-	assert.False(t, third.Unsupported)
-	assert.Contains(t, third.ScannedChildren, 8)
+	assert.Equal(t, ParentScanComplete, third.Scan)
+	assert.Contains(t, third.ScannedChildIDs, 8)
 	assert.Equal(t, 2, requests)
 }
 
@@ -803,8 +859,8 @@ func TestParentCapabilityCacheDoesNotCacheTransientErrors(t *testing.T) {
 
 	data, err := fetcher.ParentData(context.Background(), binding)
 	require.NoError(t, err)
-	assert.True(t, data.Authoritative)
-	assert.Contains(t, data.ScannedChildren, 9)
+	assert.Equal(t, ParentScanComplete, data.Scan)
+	assert.Contains(t, data.ScannedChildIDs, 9)
 	assert.Equal(t, 2, requests)
 }
 

--- a/internal/githubsync/runner.go
+++ b/internal/githubsync/runner.go
@@ -253,7 +253,7 @@ func (r *Runner) runClaimed(
 	if err != nil {
 		return r.recordError(ctx, binding, syncStartedAt, err, db.ImportBatchResult{})
 	}
-	parentLinkBackfill := ghConfig.NeedsParentLinkBackfill() && parentData.Authoritative
+	parentLinkBackfill := ghConfig.NeedsParentLinkBackfill() && parentData.Scan == ParentScanComplete
 
 	since := syncSince(binding.LastCursorAt)
 	if reconcileLegacyTitles || parentLinkBackfill {
@@ -271,7 +271,7 @@ func (r *Runner) runClaimed(
 	batch := BuildImportBatchWithConfig(binding.SourceKey, ghConfig, issues, comments, parentData, syncStartedAt)
 	batch.ProjectID = binding.ProjectID
 	batch.PreserveLocalParentConflicts = true
-	if parentData.Authoritative {
+	if parentData.Scan == ParentScanComplete {
 		batch.ReconcileLinkTypesForUnchanged = map[string]bool{"parent": true}
 		batch.Items, err = r.appendScannedParentReconcileItems(ctx, batch, parentData)
 		if err != nil {
@@ -386,25 +386,21 @@ func (r *Runner) fetchComments(ctx context.Context, fetcher Fetcher, ghConfig Co
 }
 
 func (r *Runner) appendScannedParentReconcileItems(ctx context.Context, batch db.ImportBatchParams, parentData ParentData) ([]db.ImportItem, error) {
-	if !parentData.Authoritative || len(parentData.ChildIDByNumber) == 0 {
+	if parentData.Scan != ParentScanComplete || len(parentData.ScannedChildIDs) == 0 {
 		return batch.Items, nil
 	}
 	present := make(map[string]struct{}, len(batch.Items))
 	for _, item := range batch.Items {
 		present[item.ExternalID] = struct{}{}
 	}
-	numbers := make([]int, 0, len(parentData.ChildIDByNumber))
-	for number := range parentData.ChildIDByNumber {
+	numbers := make([]int, 0, len(parentData.ScannedChildIDs))
+	for number := range parentData.ScannedChildIDs {
 		numbers = append(numbers, number)
 	}
 	sort.Ints(numbers)
 	items := append([]db.ImportItem(nil), batch.Items...)
 	for _, number := range numbers {
-		childID := parentData.ChildIDByNumber[number]
-		if childID == 0 {
-			continue
-		}
-		childExternalID := fmt.Sprintf("issue-id:%d", childID)
+		childExternalID := fmt.Sprintf("issue-id:%d", parentData.ScannedChildIDs[number])
 		if _, ok := present[childExternalID]; ok {
 			continue
 		}

--- a/internal/githubsync/runner_test.go
+++ b/internal/githubsync/runner_test.go
@@ -1,6 +1,7 @@
 package githubsync
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -175,7 +176,7 @@ func TestRunnerFeatureUnsupportedParentDataPreservesChangedIssueParent(t *testin
 	lastCursor := h.now.Add(-10 * time.Minute)
 	recordSuccessfulCursor(h.ctx, t, h.db, h.binding.ID, lastCursor)
 	h.fetcher.issues = []Issue{testIssue(101, 1, "changed child", h.now.Add(-time.Hour))}
-	h.fetcher.parentData = ParentData{Unsupported: true}
+	h.fetcher.parentData = ParentData{Scan: ParentScanUnsupported}
 	h.fetcher.parentDataSet = true
 
 	_, err := h.runner.RunOnce(h.ctx, h.binding.ID)
@@ -196,9 +197,9 @@ func TestRunnerBackfillsParentLinksWithOneFullImport(t *testing.T) {
 		testIssue(102, 2, "parent", h.now.Add(-time.Hour)),
 	}
 	h.fetcher.parentData = ParentData{
+		Scan:            ParentScanComplete,
 		ParentByChild:   map[int]int64{1: 102},
-		ScannedChildren: map[int]struct{}{1: {}, 2: {}},
-		Authoritative:   true,
+		ScannedChildIDs: map[int]int64{1: 101, 2: 102},
 	}
 	h.fetcher.parentDataSet = true
 
@@ -254,9 +255,9 @@ func TestRunnerBackfillReconcilesParentLinksForUnchangedExistingIssues(t *testin
 		testIssue(102, 2, "unchanged parent", initialTime),
 	}
 	h.fetcher.parentData = ParentData{
+		Scan:            ParentScanComplete,
 		ParentByChild:   map[int]int64{1: 102},
-		ScannedChildren: map[int]struct{}{1: {}, 2: {}},
-		Authoritative:   true,
+		ScannedChildIDs: map[int]int64{1: 101, 2: 102},
 	}
 	h.fetcher.parentDataSet = true
 
@@ -285,10 +286,9 @@ func TestRunnerReconcilesScannedParentForIssueAbsentFromIncrementalFetch(t *test
 		testIssue(102, 2, "old parent", initialTime),
 		testIssue(103, 3, "new parent", initialTime),
 	}, nil, ParentData{
+		Scan:            ParentScanComplete,
 		ParentByChild:   map[int]int64{1: 102},
-		ScannedChildren: map[int]struct{}{1: {}, 2: {}, 3: {}},
-		ChildIDByNumber: map[int]int64{1: 101, 2: 102, 3: 103},
-		Authoritative:   true,
+		ScannedChildIDs: map[int]int64{1: 101, 2: 102, 3: 103},
 	}, h.now)
 	seedBatch.ProjectID = h.project.ID
 	_, _, err := h.db.ImportBatch(h.ctx, seedBatch)
@@ -298,10 +298,9 @@ func TestRunnerReconcilesScannedParentForIssueAbsentFromIncrementalFetch(t *test
 	recordSuccessfulCursor(h.ctx, t, h.db, h.binding.ID, lastCursor)
 	h.fetcher.issues = nil
 	h.fetcher.parentData = ParentData{
+		Scan:            ParentScanComplete,
 		ParentByChild:   map[int]int64{1: 103},
-		ScannedChildren: map[int]struct{}{1: {}, 2: {}, 3: {}},
-		ChildIDByNumber: map[int]int64{1: 101, 2: 102, 3: 103},
-		Authoritative:   true,
+		ScannedChildIDs: map[int]int64{1: 101, 2: 102, 3: 103},
 	}
 	h.fetcher.parentDataSet = true
 
@@ -322,9 +321,8 @@ func TestRunnerRemovesScannedParentForIssueAbsentFromIncrementalFetch(t *testing
 	recordSuccessfulCursor(h.ctx, t, h.db, h.binding.ID, lastCursor)
 	h.fetcher.issues = nil
 	h.fetcher.parentData = ParentData{
-		ScannedChildren: map[int]struct{}{1: {}, 2: {}},
-		ChildIDByNumber: map[int]int64{1: 101, 2: 102},
-		Authoritative:   true,
+		Scan:            ParentScanComplete,
+		ScannedChildIDs: map[int]int64{1: 101, 2: 102},
 	}
 	h.fetcher.parentDataSet = true
 
@@ -346,9 +344,9 @@ func TestRunnerBackfillConfigPersistFailureRecordsErrorAndClearsInFlight(t *test
 		testIssue(102, 2, "parent", h.now.Add(-time.Hour)),
 	}
 	h.fetcher.parentData = ParentData{
+		Scan:            ParentScanComplete,
 		ParentByChild:   map[int]int64{1: 102},
-		ScannedChildren: map[int]struct{}{1: {}, 2: {}},
-		Authoritative:   true,
+		ScannedChildIDs: map[int]int64{1: 101, 2: 102},
 	}
 	h.fetcher.parentDataSet = true
 	h.store.refreshErr = errors.New("config persist unavailable")
@@ -373,9 +371,9 @@ func TestRunnerMissingParentTargetSkipsLinkAndPreservesExistingParent(t *testing
 	recordSuccessfulCursor(h.ctx, t, h.db, h.binding.ID, lastCursor)
 	h.fetcher.issues = []Issue{testIssue(101, 1, "changed child", h.now.Add(-time.Hour))}
 	h.fetcher.parentData = ParentData{
+		Scan:            ParentScanComplete,
 		ParentByChild:   map[int]int64{1: 999},
-		ScannedChildren: map[int]struct{}{1: {}},
-		Authoritative:   true,
+		ScannedChildIDs: map[int]int64{1: 101},
 	}
 	h.fetcher.parentDataSet = true
 
@@ -392,9 +390,9 @@ func TestRunnerParentTargetLookupErrorRecordsFailureAndSkipsImport(t *testing.T)
 	recordSuccessfulCursor(h.ctx, t, h.db, h.binding.ID, lastCursor)
 	h.fetcher.issues = []Issue{testIssue(101, 1, "changed child", h.now.Add(-time.Hour))}
 	h.fetcher.parentData = ParentData{
+		Scan:            ParentScanComplete,
 		ParentByChild:   map[int]int64{1: 999},
-		ScannedChildren: map[int]struct{}{1: {}},
-		Authoritative:   true,
+		ScannedChildIDs: map[int]int64{1: 101},
 	}
 	h.fetcher.parentDataSet = true
 	h.store.importMappingErr = errors.New("mapping lookup unavailable")
@@ -419,14 +417,41 @@ func TestRunnerChildAbsentFromParentScanPreservesChangedIssueParent(t *testing.T
 	recordSuccessfulCursor(h.ctx, t, h.db, h.binding.ID, lastCursor)
 	h.fetcher.issues = []Issue{testIssue(101, 1, "changed child", h.now.Add(-time.Hour))}
 	h.fetcher.parentData = ParentData{
-		ScannedChildren: map[int]struct{}{2: {}},
-		Authoritative:   true,
+		Scan:            ParentScanComplete,
+		ScannedChildIDs: map[int]int64{2: 102},
 	}
 	h.fetcher.parentDataSet = true
 
 	_, err := h.runner.RunOnce(h.ctx, h.binding.ID)
 	require.NoError(t, err)
 
+	assertSourceParent(t, h, "issue-id:101", "issue-id:102")
+	assertCursorAt(h.ctx, t, h.db, h.binding.ID, h.now)
+}
+
+func TestRunnerScannedChildWithoutImportMappingIsSkippedAndWarned(t *testing.T) {
+	var logs bytes.Buffer
+	h := newRunnerHarness(t, withLogger(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))))
+	initialTime := h.now.Add(-2 * time.Hour)
+	seedSourceParentLink(t, h, initialTime)
+	lastCursor := h.now.Add(-10 * time.Minute)
+	recordSuccessfulCursor(h.ctx, t, h.db, h.binding.ID, lastCursor)
+	h.fetcher.issues = []Issue{testIssue(101, 1, "changed child", h.now.Add(-time.Hour))}
+	h.fetcher.parentData = ParentData{
+		Scan:            ParentScanComplete,
+		ParentByChild:   map[int]int64{1: 102},
+		ScannedChildIDs: map[int]int64{1: 101, 5: 105},
+	}
+	h.fetcher.parentDataSet = true
+
+	_, err := h.runner.RunOnce(h.ctx, h.binding.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, []int{1}, h.store.importItemCounts)
+	_, err = h.db.ImportMappingBySource(h.ctx, h.project.ID, h.binding.SourceKey, "issue", "issue-id:105")
+	assert.ErrorIs(t, err, db.ErrNotFound)
+	assert.Contains(t, logs.String(), "github sync skipped parent reconciliation for unmapped scanned child")
+	assert.Contains(t, logs.String(), "issue-id:105")
 	assertSourceParent(t, h, "issue-id:101", "issue-id:102")
 	assertCursorAt(h.ctx, t, h.db, h.binding.ID, h.now)
 }
@@ -526,7 +551,7 @@ func TestRunnerBackfillRefreshRetainsTransactionFenceAfterCancellation(t *testin
 		cancel()
 		return nil
 	}
-	h.fetcher.parentData = ParentData{Authoritative: true}
+	h.fetcher.parentData = ParentData{Scan: ParentScanComplete}
 	h.fetcher.parentDataSet = true
 	h.fetcher.issues = []Issue{testIssue(101, 1, "first issue", h.now.Add(-time.Hour))}
 
@@ -1127,6 +1152,12 @@ func withWake(wake <-chan struct{}) runnerOption {
 	}
 }
 
+func withLogger(logger *slog.Logger) runnerOption {
+	return func(config *RunnerConfig) {
+		config.Logger = logger
+	}
+}
+
 func withDrainAdmission(admission activity.Admission) runnerOption {
 	return func(config *RunnerConfig) {
 		config.DrainAdmission = func() (*activity.Lease, bool, <-chan struct{}) {
@@ -1383,12 +1414,12 @@ func (f *fakeRunnerFetcher) ParentData(_ context.Context, _ Binding) (ParentData
 		return ParentData{}, nil
 	}
 	out := make(map[int]int64, len(f.parentMap))
-	scanned := make(map[int]struct{}, len(f.parentMap))
-	for k, v := range f.parentMap {
-		out[k] = v
-		scanned[k] = struct{}{}
+	maps.Copy(out, f.parentMap)
+	scanned := make(map[int]int64, len(f.issues))
+	for _, issue := range f.issues {
+		scanned[issue.Number] = issue.ID
 	}
-	return ParentData{ParentByChild: out, ScannedChildren: scanned, Authoritative: true}, nil
+	return ParentData{Scan: ParentScanComplete, ParentByChild: out, ScannedChildIDs: scanned}, nil
 }
 
 func cloneParentData(in ParentData) ParentData {
@@ -1397,13 +1428,9 @@ func cloneParentData(in ParentData) ParentData {
 		out.ParentByChild = make(map[int]int64, len(in.ParentByChild))
 		maps.Copy(out.ParentByChild, in.ParentByChild)
 	}
-	if in.ScannedChildren != nil {
-		out.ScannedChildren = make(map[int]struct{}, len(in.ScannedChildren))
-		maps.Copy(out.ScannedChildren, in.ScannedChildren)
-	}
-	if in.ChildIDByNumber != nil {
-		out.ChildIDByNumber = make(map[int]int64, len(in.ChildIDByNumber))
-		maps.Copy(out.ChildIDByNumber, in.ChildIDByNumber)
+	if in.ScannedChildIDs != nil {
+		out.ScannedChildIDs = make(map[int]int64, len(in.ScannedChildIDs))
+		maps.Copy(out.ScannedChildIDs, in.ScannedChildIDs)
 	}
 	return out
 }

--- a/service_github_sync_test.go
+++ b/service_github_sync_test.go
@@ -163,5 +163,5 @@ func (*serviceGitHubFetcher) Comments(context.Context, githubsync.Binding, int) 
 }
 
 func (*serviceGitHubFetcher) ParentData(context.Context, githubsync.Binding) (githubsync.ParentData, error) {
-	return githubsync.ParentData{Unsupported: true}, nil
+	return githubsync.ParentData{Scan: githubsync.ParentScanUnsupported}, nil
 }

--- a/service_worker_events_test.go
+++ b/service_worker_events_test.go
@@ -55,7 +55,7 @@ func (*workerEventFetcher) Comments(context.Context, githubsync.Binding, int) ([
 }
 
 func (*workerEventFetcher) ParentData(context.Context, githubsync.Binding) (githubsync.ParentData, error) {
-	return githubsync.ParentData{Unsupported: true}, nil
+	return githubsync.ParentData{Scan: githubsync.ParentScanUnsupported}, nil
 }
 
 // TestServiceWorkerEventsReachBroadcasterAndHooks pins the invariant the


### PR DESCRIPTION
## What changed

- represent GitHub parent-scan state with one three-valued enum and one child-ID map
- preserve producer and reconciliation behavior while removing overlapping scan sentinels
- route unbound `HTTPFetcher` reads through single-use binding sessions
- keep fetcher interfaces, credential scoping, normalization, and redirect behavior unchanged

## Why

Parent reconciliation carried the same state through several maps and booleans, while unbound fetcher calls repeated binding setup around each request. Both paths had more states than the behavior needs and made it harder to see which repository and credentials a read belongs to.

## Usage

No usage change.
