### PR TITLE
Fence vector reconciliation and simplify federation stress nodes

### DIFF
--- a/e2e/federation_failpoints_test.go
+++ b/e2e/federation_failpoints_test.go
@@ -24,8 +24,8 @@ func TestFederationFailpointHubRestartMidIngestBatch(t *testing.T) {
 	fx := newFederationStressFixture(t, 1)
 	fx.enableProject(t, "failpoint-mid-ingest")
 
-	spokeIssue := fx.createIssueOnNode(t, &fx.spokes[0], fx.spokes[0].replica.Project.ID, "precommit-crash")
-	fx.waitForHubUnavailable(t)
+	spokeIssue := fx.createIssueOnNode(t, fx.spokes[0], "precommit-crash")
+	fx.waitForNodeUnavailable(t, fx.hub)
 	_, err := fx.hub.db.IssueByUID(context.Background(), spokeIssue.UID, db.IncludeDeletedYes)
 	require.Error(t, err, "pre-commit crash must not leave a partially-ingested issue")
 
@@ -42,8 +42,8 @@ func TestFederationFailpointHubCommitBeforeBroadcastStillConverges(t *testing.T)
 	fx := newFederationStressFixture(t, 2)
 	fx.enableProject(t, "failpoint-post-commit")
 
-	spokeIssue := fx.createIssueOnNode(t, &fx.spokes[0], fx.spokes[0].replica.Project.ID, "postcommit-crash")
-	fx.waitForHubUnavailable(t)
+	spokeIssue := fx.createIssueOnNode(t, fx.spokes[0], "postcommit-crash")
+	fx.waitForNodeUnavailable(t, fx.hub)
 	got, err := fx.hub.db.IssueByUID(context.Background(), spokeIssue.UID, db.IncludeDeletedNo)
 	require.NoError(t, err, "post-commit crash must retain the accepted issue")
 	assert.Equal(t, spokeIssue.ShortID, got.ShortID)
@@ -60,15 +60,15 @@ func TestFederationFailpointBeforeSpokePushCursorAdvanceRetriesDuplicateBatch(t 
 	fx := newFederationStressFixture(t, 1)
 	fx.enableProject(t, "failpoint-push-cursor")
 
-	spokeIssue := fx.createIssueOnNode(t, &fx.spokes[0], fx.spokes[0].replica.Project.ID, "cursor-crash")
-	fx.waitForSpokeUnavailable(t, 0)
+	spokeIssue := fx.createIssueOnNode(t, fx.spokes[0], "cursor-crash")
+	fx.waitForNodeUnavailable(t, fx.spokes[0])
 	fx.assertHubEventCountForIssue(t, spokeIssue.UID, 1)
 
 	t.Setenv("KATA_TEST_FEDERATION_FAILPOINTS", "")
-	fx.restartSpoke(t, 0)
+	fx.restartSpoke(t, fx.spokes[0])
 	fx.waitForConvergence(t)
 	fx.assertHubEventCountForIssue(t, spokeIssue.UID, 1)
-	binding, err := fx.spokes[0].db.FederationBindingByProject(context.Background(), fx.spokes[0].replica.Project.ID)
+	binding, err := fx.spokes[0].db.FederationBindingByProject(context.Background(), fx.spokes[0].projectID)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, binding.PushCursorEventID, int64(1))
 }
@@ -84,14 +84,14 @@ func TestFederationFailpointConcurrentLocalWriteDuringPullApply(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	hubIssue := fx.createIssueOnNode(t, &fx.hub, fx.hubProject.ID, "hub-pull-sleep")
+	hubIssue := fx.createIssueOnNode(t, fx.hub, "hub-pull-sleep")
 	fx.waitForFailpointMarker(t, marker)
-	localIssue := fx.createIssueOnNode(t, &fx.spokes[0], fx.spokes[0].replica.Project.ID, "local-during-pull")
+	localIssue := fx.createIssueOnNode(t, fx.spokes[0], "local-during-pull")
 	fx.waitForConvergence(t)
 
 	waitForFederatedIssue(t, fx.spokes[0].db, hubIssue.UID, fx.spokes[0].stderr)
 	waitForFederatedIssue(t, fx.hub.db, localIssue.UID, fx.hub.stderr)
-	fx.assertEventOrderValid(t, fx.spokes[0].db, fx.spokes[0].replica.Project.ID)
+	fx.assertEventOrderValid(t, fx.spokes[0].db, fx.spokes[0].projectID)
 	fx.assertDaemonStderrClean(t)
 }
 
@@ -100,11 +100,11 @@ func TestFederationFailpointSpokeRestartDuringPendingPush(t *testing.T) {
 	fx := newFederationStressFixture(t, 1)
 	fx.enableProject(t, "failpoint-restart-pending-push")
 
-	spokeIssue := fx.createIssueOnNode(t, &fx.spokes[0], fx.spokes[0].replica.Project.ID, "restart-pending-push")
-	fx.waitForSpokeUnavailable(t, 0)
+	spokeIssue := fx.createIssueOnNode(t, fx.spokes[0], "restart-pending-push")
+	fx.waitForNodeUnavailable(t, fx.spokes[0])
 
 	t.Setenv("KATA_TEST_FEDERATION_FAILPOINTS", "")
-	fx.restartSpoke(t, 0)
+	fx.restartSpoke(t, fx.spokes[0])
 	fx.waitForConvergence(t)
 	waitForFederatedIssue(t, fx.hub.db, spokeIssue.UID, fx.hub.stderr)
 	fx.assertHubEventCountForIssue(t, spokeIssue.UID, 1)
@@ -118,7 +118,7 @@ func TestFederationFailpointHubUnavailableClaimStatusFallsBackToCache(t *testing
 	now := time.Now().UTC()
 	cached := db.IssueClaim{
 		ClaimUID:          "01KSD7P0000000000000000001",
-		ProjectID:         fx.spokes[0].replica.Project.ID,
+		ProjectID:         fx.spokes[0].projectID,
 		IssueID:           statusIssue.ID,
 		IssueUID:          statusIssue.UID,
 		Holder:            "cached-holder",
@@ -131,7 +131,7 @@ func TestFederationFailpointHubUnavailableClaimStatusFallsBackToCache(t *testing
 		UpdatedAt:         now,
 	}
 	require.NoError(t, fx.spokes[0].db.ApplyClaimStatus(context.Background(),
-		fx.spokes[0].replica.Project.ID, statusIssue.UID, db.ClaimStatus{
+		fx.spokes[0].projectID, statusIssue.UID, db.ClaimStatus{
 			Held: true,
 			Holder: db.ClaimPrincipal{
 				Holder:            cached.Holder,
@@ -141,15 +141,71 @@ func TestFederationFailpointHubUnavailableClaimStatusFallsBackToCache(t *testing
 			Claim:  &cached,
 			HubNow: now,
 		}))
-	fx.stopHub(t)
+	fx.stopNode(t, fx.hub)
 
 	for i := 0; i < 2; i++ {
 		status, raw := stressDoJSON(t, fx.spokes[0].http, http.MethodGet,
-			fx.spokes[0].url+"/api/v1/projects/"+strconv.FormatInt(fx.spokes[0].replica.Project.ID, 10)+
+			fx.spokes[0].url+"/api/v1/projects/"+strconv.FormatInt(fx.spokes[0].projectID, 10)+
 				"/issues/"+statusIssue.ShortID,
 			nil, nil, nil)
 		require.Equalf(t, http.StatusOK, status, "show body: %s", raw)
 		require.Contains(t, string(raw), "cached-holder")
+	}
+}
+
+// Stopping a daemon does not take its stderr buffer or its SQLite file with
+// it, so the checks that read those must keep running for a stopped node.
+// This pins that decision for the hub: gating the unified node loops on
+// `running` would silently skip it, which is how `online` became a
+// write-only field for the hub in the first place.
+func TestFederationFailpointStoppedHubKeepsProcessIndependentAssertions(t *testing.T) {
+	fx := newFederationStressFixture(t, 1)
+	fx.enableProject(t, "failpoint-stopped-hub-assertions")
+	fx.waitForConvergence(t)
+
+	fx.stopNode(t, fx.hub)
+	require.False(t, fx.hub.running)
+
+	_, err := fx.hub.stderr.Write([]byte("panic: injected by the stopped-hub assertion test\n"))
+	require.NoError(t, err)
+	stderrRun := &stressTBRecorder{federationStressTB: t}
+	fx.assertDaemonStderrClean(stderrRun)
+	require.Len(t, stderrRun.failures, 1,
+		"the stopped hub's stderr must still be inspected, and the running spoke's must stay clean")
+	assert.Contains(t, stderrRun.failures[0], "hub daemon stderr")
+
+	fx.injectDuplicateLiveClaims(t, fx.hub)
+	claimRun := &stressTBRecorder{federationStressTB: t}
+	fx.assertNoDuplicateLiveClaims(claimRun)
+	require.NotEmpty(t, claimRun.failures,
+		"the stopped hub's database must still be checked for duplicate live claims")
+	assert.Contains(t, claimRun.failures[0], "hub has duplicate live claims")
+}
+
+// injectDuplicateLiveClaims writes two unreleased claims for the fixture's
+// baseline issue on node. The live-claim uniqueness index has to go first;
+// this is ephemeral DDL on the node's throwaway e2e SQLite file and defines
+// no product persisted state.
+func (fx *federationStressFixture) injectDuplicateLiveClaims(t *testing.T, node *federationStressNode) {
+	t.Helper()
+	ctx := context.Background()
+	issue, err := node.db.IssueByUID(ctx, fx.hubIssue.UID, db.IncludeDeletedNo)
+	require.NoError(t, err)
+	_, err = node.db.ExecContext(ctx, `DROP INDEX IF EXISTS uniq_issue_claims_live_issue`)
+	require.NoError(t, err)
+	for _, claimUID := range []string{
+		"01KSD7P0000000000000000011",
+		"01KSD7P0000000000000000012",
+	} {
+		_, err = node.db.ExecContext(ctx, `
+			INSERT INTO issue_claims(
+			  claim_uid, project_id, issue_id, issue_uid, holder,
+			  holder_instance_uid, client_kind, purpose, claim_kind,
+			  acquired_at, revision, updated_at)
+			VALUES(?, ?, ?, ?, 'duplicate-holder', ?, 'stress', 'edit', 'hard',
+			       '2026-01-01T00:00:00.000Z', 1, '2026-01-01T00:00:00.000Z')`,
+			claimUID, node.projectID, issue.ID, issue.UID, node.db.InstanceUID())
+		require.NoError(t, err)
 	}
 }
 
@@ -170,27 +226,20 @@ func (fx *federationStressFixture) assertHubEventCountForIssue(t *testing.T, iss
 	var got int
 	require.NoError(t, fx.hub.db.QueryRowContext(context.Background(),
 		`SELECT COUNT(*) FROM events WHERE project_id = ? AND issue_uid = ?`,
-		fx.hubProject.ID, issueUID).Scan(&got))
+		fx.hub.projectID, issueUID).Scan(&got))
 	assert.Equal(t, want, got, fmt.Sprintf("hub event count for issue %s", issueUID))
 }
 
-func (fx *federationStressFixture) waitForHubUnavailable(t *testing.T) {
+func (fx *federationStressFixture) waitForNodeUnavailable(t *testing.T, node *federationStressNode) {
 	t.Helper()
-	fx.waitForHTTPUnavailable(t, fx.hub.http, fx.hub.url)
-	fx.hub.online = false
+	fx.waitForHTTPUnavailable(t, node.http, node.url)
+	node.running = false
 }
 
-func (fx *federationStressFixture) stopHub(t *testing.T) {
+func (fx *federationStressFixture) stopNode(t *testing.T, node *federationStressNode) {
 	t.Helper()
-	stopDaemon(fx.hub.cmd)
-	fx.waitForHTTPUnavailable(t, fx.hub.http, fx.hub.url)
-	fx.hub.online = false
-}
-
-func (fx *federationStressFixture) waitForSpokeUnavailable(t *testing.T, i int) {
-	t.Helper()
-	fx.waitForHTTPUnavailable(t, fx.spokes[i].http, fx.spokes[i].url)
-	fx.spokes[i].online = false
+	stopDaemon(node.cmd)
+	fx.waitForNodeUnavailable(t, node)
 }
 
 func (fx *federationStressFixture) waitForHTTPUnavailable(t *testing.T, client *http.Client, base string) {
@@ -213,15 +262,15 @@ func (fx *federationStressFixture) restartHub(t *testing.T) {
 	addr := strings.TrimPrefix(fx.hub.url, "http://")
 	fx.hub.cmd = startFederationStressTCPDaemon(t, fx.bin, fx.hub.dirs, fx.hub.stderr, addr)
 	stressWaitForPing(t, fx.hub.url, 5*time.Second)
-	fx.hub.online = true
+	fx.hub.running = true
 }
 
-func (fx *federationStressFixture) restartSpoke(t *testing.T, i int) {
+func (fx *federationStressFixture) restartSpoke(t *testing.T, spoke *federationStressNode) {
 	t.Helper()
-	stopDaemon(fx.spokes[i].cmd)
-	fx.spokes[i].cmd = startFederationStressUnixDaemon(t, fx.bin, fx.spokes[i].dirs, fx.spokes[i].stderr)
-	fx.spokes[i].url, fx.spokes[i].http = stressConnectDaemon(t, fx.spokes[i].dirs, fx.spokes[i].stderr)
-	fx.spokes[i].online = true
+	stopDaemon(spoke.cmd)
+	spoke.cmd = startFederationStressUnixDaemon(t, fx.bin, spoke.dirs, spoke.stderr)
+	spoke.url, spoke.http = stressConnectDaemon(t, spoke.dirs, spoke.stderr)
+	spoke.running = true
 }
 
 func (fx *federationStressFixture) assertEventOrderValid(t *testing.T, store *sqlitestore.Store, projectID int64) {

--- a/e2e/federation_stress_harness_test.go
+++ b/e2e/federation_stress_harness_test.go
@@ -45,27 +45,53 @@ type federationStressTB interface {
 	Cleanup(func())
 }
 
+// stressTBRecorder records assertion failures instead of aborting, so a test
+// can assert that a fixture-level check actually ran against a given node.
+// FailNow is deliberately inert: the caller controls the scenario and wants
+// every check in the loop to execute.
+type stressTBRecorder struct {
+	federationStressTB
+	failures []string
+}
+
+func (r *stressTBRecorder) Errorf(format string, args ...any) {
+	r.failures = append(r.failures, fmt.Sprintf(format, args...))
+}
+
+func (r *stressTBRecorder) Fatalf(format string, args ...any) {
+	r.failures = append(r.failures, fmt.Sprintf(format, args...))
+}
+
+func (r *stressTBRecorder) FailNow() {}
+
+func (r *stressTBRecorder) Failed() bool { return len(r.failures) > 0 }
+
 type federationStressFixture struct {
 	bin           string
-	hub           federationStressNode
-	spokes        []federationStressNode
-	hubProject    api.ProjectOut
+	hub           *federationStressNode
+	spokes        []*federationStressNode
 	hubIssue      createdIssue
 	meta          api.ProjectFederationBody
 	replayAfterID int64
 	opSeq         int
 }
 
+// federationStressNode is one daemon in the fixture. Hub and spoke are the
+// same shape: a node knows its own name, the project id it serves, and
+// whether its process is up, so no caller has to know a node's role to
+// address it. replica is zero for the hub.
 type federationStressNode struct {
-	dirs    e2eDirs
-	url     string
-	http    *http.Client
-	db      *sqlitestore.Store
-	stderr  *safeBuffer
-	cmd     *exec.Cmd
-	online  bool
-	cred    config.FederationCredential
-	replica api.CreateFederationReplicaBody
+	name      string
+	dirs      e2eDirs
+	url       string
+	http      *http.Client
+	db        *sqlitestore.Store
+	stderr    *safeBuffer
+	cmd       *exec.Cmd
+	projectID int64
+	running   bool
+	cred      config.FederationCredential
+	replica   api.CreateFederationReplicaBody
 }
 
 type federationStressIssue struct {
@@ -83,12 +109,19 @@ func newFederationStressFixture(t federationStressTB, spokeCount int) *federatio
 	fx := &federationStressFixture{
 		bin:    bin,
 		hub:    startFederationStressHub(t, bin),
-		spokes: make([]federationStressNode, 0, spokeCount),
+		spokes: make([]*federationStressNode, 0, spokeCount),
 	}
 	for i := 0; i < spokeCount; i++ {
-		fx.spokes = append(fx.spokes, startFederationStressSpoke(t, bin))
+		fx.spokes = append(fx.spokes, startFederationStressSpoke(t, bin, i))
 	}
 	return fx
+}
+
+// nodes returns every node in the fixture, hub first. Assertions that hold
+// for hub and spokes alike iterate this instead of writing a hub arm and a
+// spoke arm that can drift apart.
+func (fx *federationStressFixture) nodes() []*federationStressNode {
+	return append([]*federationStressNode{fx.hub}, fx.spokes...)
 }
 
 func (fx *federationStressFixture) enableProject(t federationStressTB, name string) {
@@ -99,10 +132,10 @@ func (fx *federationStressFixture) enableProject(t federationStressTB, name stri
 	}
 	stressDecodePOST(t, fx.hub.http, fx.hub.url+"/api/v1/projects",
 		map[string]any{"name": name, "actor": "user-a"}, &initBody)
-	fx.hubProject = initBody.Project
+	fx.hub.projectID = initBody.Project.ID
 
 	fx.hubIssue = stressCreateIssue(t, fx.hub.http,
-		fx.hub.url+"/api/v1/projects/"+strconv.FormatInt(fx.hubProject.ID, 10)+"/issues",
+		fx.hub.url+"/api/v1/projects/"+strconv.FormatInt(fx.hub.projectID, 10)+"/issues",
 		map[string]any{
 			"actor": "agent",
 			"title": "stress baseline",
@@ -110,12 +143,12 @@ func (fx *federationStressFixture) enableProject(t federationStressTB, name stri
 		})
 
 	stressDecodePOST(t, fx.hub.http,
-		fx.hub.url+"/api/v1/projects/"+strconv.FormatInt(fx.hubProject.ID, 10)+"/federation/enable",
+		fx.hub.url+"/api/v1/projects/"+strconv.FormatInt(fx.hub.projectID, 10)+"/federation/enable",
 		map[string]any{"actor": "agent"}, &fx.meta)
 	fx.replayAfterID = fx.meta.ReplayHorizonEventID - 1
 
-	for i := range fx.spokes {
-		fx.spokes[i].replica = fx.enrollSpoke(t, i)
+	for _, spoke := range fx.spokes {
+		fx.enrollSpoke(t, spoke)
 	}
 }
 
@@ -123,29 +156,27 @@ func (fx *federationStressFixture) waitForAllSpokes(t *testing.T) {
 	t.Helper()
 	require.NotEmpty(t, fx.hubIssue.UID, "enableProject must create the baseline issue before waiting")
 	fx.waitForConvergence(t)
-	for i := range fx.spokes {
-		waitForFederatedIssue(t, fx.spokes[i].db, fx.hubIssue.UID, fx.spokes[i].stderr)
+	for _, spoke := range fx.spokes {
+		waitForFederatedIssue(t, spoke.db, fx.hubIssue.UID, spoke.stderr)
 	}
 }
 
 func (fx *federationStressFixture) assertAllFoldedProjectionsMatch(t federationStressTB) {
 	t.Helper()
-	for i := range fx.spokes {
-		if !fx.spokes[i].online {
+	for _, spoke := range fx.spokes {
+		if !spoke.running {
 			continue
 		}
-		fx.waitForFoldedProjectionMatch(t, i)
+		fx.waitForFoldedProjectionMatch(t, spoke)
 	}
 }
 
+// A node's SQLite file is readable while its daemon is down, so the
+// duplicate-claim invariant is checked for every node unconditionally.
 func (fx *federationStressFixture) assertNoDuplicateLiveClaims(t federationStressTB) {
 	t.Helper()
-	assertNoDuplicateLiveClaimsOnNode(t, "hub", fx.hub.db)
-	for i := range fx.spokes {
-		if !fx.spokes[i].online {
-			continue
-		}
-		assertNoDuplicateLiveClaimsOnNode(t, fmt.Sprintf("spoke-%d", i), fx.spokes[i].db)
+	for _, node := range fx.nodes() {
+		assertNoDuplicateLiveClaimsOnNode(t, node)
 	}
 }
 
@@ -174,10 +205,9 @@ func (fx *federationStressFixture) assertNoPendingPushBacklogEventually(t federa
 	require.Empty(t, last, "pending federation push backlog did not drain")
 }
 
-func (fx *federationStressFixture) enrollSpoke(t federationStressTB, i int) api.CreateFederationReplicaBody {
+func (fx *federationStressFixture) enrollSpoke(t federationStressTB, spoke *federationStressNode) {
 	t.Helper()
-	spoke := fx.spokes[i]
-	token := fmt.Sprintf("stress-spoke-%d-token", i)
+	token := "stress-" + spoke.name + "-token"
 	var inst struct {
 		InstanceUID string `json:"instance_uid"`
 	}
@@ -186,7 +216,7 @@ func (fx *federationStressFixture) enrollSpoke(t federationStressTB, i int) api.
 	stressDecodePOST(t, fx.hub.http, fx.hub.url+"/api/v1/federation/enrollments", map[string]any{
 		"token":              token,
 		"spoke_instance_uid": inst.InstanceUID,
-		"project_id":         fx.hubProject.ID,
+		"project_id":         fx.hub.projectID,
 		"capabilities":       "pull,push,claim",
 		"actor":              "stress",
 	}, &created)
@@ -194,7 +224,7 @@ func (fx *federationStressFixture) enrollSpoke(t federationStressTB, i int) api.
 	var replica api.CreateFederationReplicaBody
 	stressDecodePOST(t, spoke.http, spoke.url+"/api/v1/federation/replicas", map[string]any{
 		"hub_url":                   fx.hub.url,
-		"hub_project_id":            fx.hubProject.ID,
+		"hub_project_id":            fx.hub.projectID,
 		"hub_project_uid":           fx.meta.ProjectUID,
 		"project_name":              fx.meta.ProjectName,
 		"replay_horizon_event_id":   fx.meta.ReplayHorizonEventID,
@@ -205,36 +235,36 @@ func (fx *federationStressFixture) enrollSpoke(t federationStressTB, i int) api.
 		"push_enabled":              true,
 	}, &replica)
 	require.True(t, replica.Binding.PushEnabled)
-	fx.spokes[i].cred = config.FederationCredential{
+	spoke.replica = replica
+	spoke.projectID = replica.Project.ID
+	spoke.cred = config.FederationCredential{
 		HubURL:       fx.hub.url,
-		HubProjectID: fx.hubProject.ID,
+		HubProjectID: fx.hub.projectID,
 		Token:        created.Token,
 		Capabilities: "claim,pull,push",
 		Actor:        "stress",
 	}
-	return replica
 }
 
 func (fx *federationStressFixture) pendingPushBacklogs(t federationStressTB) []string {
 	t.Helper()
 	ctx := context.Background()
 	var pending []string
-	for i := range fx.spokes {
-		if !fx.spokes[i].online {
+	for _, spoke := range fx.spokes {
+		if !spoke.running {
 			continue
 		}
-		spoke := fx.spokes[i]
-		binding, err := spoke.db.FederationBindingByProject(ctx, spoke.replica.Project.ID)
+		binding, err := spoke.db.FederationBindingByProject(ctx, spoke.projectID)
 		require.NoError(t, err)
 		events, err := spoke.db.PendingFederationPushEvents(ctx,
-			spoke.replica.Project.ID,
+			spoke.projectID,
 			spoke.db.InstanceUID(),
 			binding.PushCursorEventID,
 			1000,
 		)
 		require.NoError(t, err)
 		if len(events) > 0 {
-			pending = append(pending, fmt.Sprintf("spoke-%d:%d", i, len(events)))
+			pending = append(pending, fmt.Sprintf("%s:%d", spoke.name, len(events)))
 		}
 	}
 	return pending
@@ -245,9 +275,11 @@ func (fx *federationStressFixture) applyRandomOperation(t *rapid.T) {
 	fx.opSeq++
 	switch rapid.IntRange(0, 5).Draw(t, "operation") {
 	case 0:
-		fx.createHubIssue(t)
+		fx.createIssueOnNode(t, fx.hub, "hub-create")
 	case 1:
-		fx.createSpokeIssue(t)
+		if spoke, ok := fx.drawRunningSpoke(t, "create-spoke"); ok {
+			fx.createIssueOnNode(t, spoke, "spoke-create")
+		}
 	case 2:
 		fx.acquireSpokeHardClaim(t)
 	case 3:
@@ -259,41 +291,27 @@ func (fx *federationStressFixture) applyRandomOperation(t *rapid.T) {
 	}
 }
 
-func (fx *federationStressFixture) createHubIssue(t *rapid.T) {
-	t.Helper()
-	fx.createIssueOnNode(t, &fx.hub, fx.hubProject.ID, "hub-create")
-}
-
-func (fx *federationStressFixture) createSpokeIssue(t *rapid.T) {
-	t.Helper()
-	i, ok := fx.drawOnlineSpoke(t, "create-spoke")
-	if !ok {
-		return
-	}
-	fx.createIssueOnNode(t, &fx.spokes[i], fx.spokes[i].replica.Project.ID, "spoke-create")
-}
-
 func (fx *federationStressFixture) acquireSpokeHardClaim(t *rapid.T) {
 	t.Helper()
-	spokeIdx, issue, ok := fx.drawSpokeLiveIssue(t, "claim")
+	spoke, issue, ok := fx.drawSpokeLiveIssue(t, "claim")
 	if !ok {
 		return
 	}
 	actor := fx.drawActor(t, "claim-actor")
-	_ = fx.acquireClaim(t, spokeIdx, issue.ShortID, actor)
+	_ = fx.acquireClaim(t, spoke, issue.ShortID, actor)
 }
 
 func (fx *federationStressFixture) releaseSpokeClaim(t *rapid.T) {
 	t.Helper()
-	spokeIdx, ok := fx.drawOnlineSpoke(t, "release-spoke")
+	spoke, ok := fx.drawRunningSpoke(t, "release-spoke")
 	if !ok {
 		return
 	}
-	claim, ok := fx.drawLiveClaim(t, fx.spokes[spokeIdx], fx.spokes[spokeIdx].replica.Project.ID, "release-claim")
+	claim, ok := fx.drawLiveClaim(t, spoke, "release-claim")
 	if !ok {
 		return
 	}
-	fx.postClaimAction(t, spokeIdx, claim.IssueRef, "release", map[string]any{
+	fx.postClaimAction(t, spoke, claim.IssueRef, "release", map[string]any{
 		"holder": claim.Holder,
 		"reason": "stress release",
 	})
@@ -301,35 +319,34 @@ func (fx *federationStressFixture) releaseSpokeClaim(t *rapid.T) {
 
 func (fx *federationStressFixture) editClaimedIssue(t *rapid.T) {
 	t.Helper()
-	spokeIdx, issue, ok := fx.drawSpokeLiveIssue(t, "edit")
+	spoke, issue, ok := fx.drawSpokeLiveIssue(t, "edit")
 	if !ok {
 		return
 	}
 	actor := fx.drawActor(t, "edit-actor")
-	if !fx.acquireClaim(t, spokeIdx, issue.ShortID, actor) {
+	if !fx.acquireClaim(t, spoke, issue.ShortID, actor) {
 		return
 	}
-	spoke := fx.spokes[spokeIdx]
 	switch rapid.IntRange(0, 3).Draw(t, "edit-kind") {
 	case 0:
-		fx.patchIssue(t, spoke, spoke.replica.Project.ID, issue.ShortID, map[string]any{
+		fx.patchIssue(t, spoke, issue.ShortID, map[string]any{
 			"actor": actor,
 			"title": fmt.Sprintf("stress title %03d", fx.opSeq),
 			"body":  fmt.Sprintf("stress body %03d", fx.opSeq),
 		})
 	case 1:
 		priority := int64(rapid.IntRange(0, 3).Draw(t, "priority"))
-		fx.patchIssue(t, spoke, spoke.replica.Project.ID, issue.ShortID, map[string]any{
+		fx.patchIssue(t, spoke, issue.ShortID, map[string]any{
 			"actor":        actor,
 			"set_priority": priority,
 		})
 	case 2:
-		fx.patchIssue(t, spoke, spoke.replica.Project.ID, issue.ShortID, map[string]any{
+		fx.patchIssue(t, spoke, issue.ShortID, map[string]any{
 			"actor":          actor,
 			"clear_priority": true,
 		})
 	case 3:
-		fx.addLabel(t, spoke, spoke.replica.Project.ID, issue.ShortID, actor,
+		fx.addLabel(t, spoke, issue.ShortID, actor,
 			fmt.Sprintf("stress:%d", rapid.IntRange(0, 5).Draw(t, "label")))
 	}
 }
@@ -338,30 +355,30 @@ func (fx *federationStressFixture) commentClaimedIssue(t *rapid.T) {
 	t.Helper()
 	actor := fx.drawActor(t, "comment-actor")
 	if rapid.Bool().Draw(t, "comment-on-hub") {
-		issue, ok := fx.drawIssue(t, fx.hub, fx.hubProject.ID, false, "hub-comment")
+		issue, ok := fx.drawIssue(t, fx.hub, false, "hub-comment")
 		if !ok {
 			return
 		}
-		if !fx.acquireHubClaim(t, issue.ShortID, actor) {
+		if !fx.acquireClaim(t, fx.hub, issue.ShortID, actor) {
 			return
 		}
-		fx.commentOnNode(t, fx.hub, fx.hubProject.ID, issue.ShortID, actor)
+		fx.commentOnNode(t, fx.hub, issue.ShortID, actor)
 		return
 	}
-	spokeIdx, issue, ok := fx.drawSpokeLiveIssue(t, "spoke-comment")
+	spoke, issue, ok := fx.drawSpokeLiveIssue(t, "spoke-comment")
 	if !ok {
 		return
 	}
-	if !fx.acquireClaim(t, spokeIdx, issue.ShortID, actor) {
+	if !fx.acquireClaim(t, spoke, issue.ShortID, actor) {
 		return
 	}
-	fx.commentOnNode(t, fx.spokes[spokeIdx], fx.spokes[spokeIdx].replica.Project.ID, issue.ShortID, actor)
+	fx.commentOnNode(t, spoke, issue.ShortID, actor)
 }
 
-func (fx *federationStressFixture) createIssueOnNode(t federationStressTB, node *federationStressNode, projectID int64, prefix string) createdIssue {
+func (fx *federationStressFixture) createIssueOnNode(t federationStressTB, node *federationStressNode, prefix string) createdIssue {
 	t.Helper()
 	return stressCreateIssue(t, node.http,
-		node.url+"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues",
+		node.url+"/api/v1/projects/"+strconv.FormatInt(node.projectID, 10)+"/issues",
 		map[string]any{
 			"actor":     "stress",
 			"title":     fmt.Sprintf("%s %03d", prefix, fx.opSeq),
@@ -371,22 +388,10 @@ func (fx *federationStressFixture) createIssueOnNode(t federationStressTB, node 
 		})
 }
 
-func (fx *federationStressFixture) acquireClaim(t federationStressTB, spokeIdx int, ref, actor string) bool {
+func (fx *federationStressFixture) acquireClaim(t federationStressTB, node *federationStressNode, ref, actor string) bool {
 	t.Helper()
 	var out api.ClaimActionResponseBody
-	ok := fx.postClaimAction(t, spokeIdx, ref, "acquire", map[string]any{
-		"holder":      actor,
-		"client_kind": "stress",
-		"claim_kind":  "hard",
-		"purpose":     "edit",
-	}, &out)
-	return ok && out.Granted && !out.Pending
-}
-
-func (fx *federationStressFixture) acquireHubClaim(t federationStressTB, ref, actor string) bool {
-	t.Helper()
-	var out api.ClaimActionResponseBody
-	ok := fx.postClaimActionOnNode(t, fx.hub, fx.hubProject.ID, ref, "acquire", map[string]any{
+	ok := fx.postClaimAction(t, node, ref, "acquire", map[string]any{
 		"holder":      actor,
 		"client_kind": "stress",
 		"claim_kind":  "hard",
@@ -397,21 +402,7 @@ func (fx *federationStressFixture) acquireHubClaim(t federationStressTB, ref, ac
 
 func (fx *federationStressFixture) postClaimAction(
 	t federationStressTB,
-	spokeIdx int,
-	ref string,
-	action string,
-	body map[string]any,
-	out ...*api.ClaimActionResponseBody,
-) bool {
-	t.Helper()
-	spoke := fx.spokes[spokeIdx]
-	return fx.postClaimActionOnNode(t, spoke, spoke.replica.Project.ID, ref, action, body, out...)
-}
-
-func (fx *federationStressFixture) postClaimActionOnNode(
-	t federationStressTB,
-	node federationStressNode,
-	projectID int64,
+	node *federationStressNode,
 	ref string,
 	action string,
 	body map[string]any,
@@ -420,7 +411,7 @@ func (fx *federationStressFixture) postClaimActionOnNode(
 	t.Helper()
 	var parsed api.ClaimActionResponseBody
 	status, raw := stressDoJSON(t, node.http, http.MethodPost,
-		node.url+"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+
+		node.url+"/api/v1/projects/"+strconv.FormatInt(node.projectID, 10)+
 			"/issues/"+url.PathEscape(ref)+"/lease/actions/"+action,
 		nil, body, &parsed)
 	if status == http.StatusConflict {
@@ -435,43 +426,40 @@ func (fx *federationStressFixture) postClaimActionOnNode(
 
 func (fx *federationStressFixture) patchIssue(
 	t federationStressTB,
-	node federationStressNode,
-	projectID int64,
+	node *federationStressNode,
 	ref string,
 	body map[string]any,
 ) {
 	t.Helper()
 	status, raw := stressDoJSON(t, node.http, http.MethodPatch,
-		node.url+"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+url.PathEscape(ref),
+		node.url+"/api/v1/projects/"+strconv.FormatInt(node.projectID, 10)+"/issues/"+url.PathEscape(ref),
 		nil, body, nil)
 	require.Equalf(t, http.StatusOK, status, "patch issue body: %s", raw)
 }
 
 func (fx *federationStressFixture) addLabel(
 	t federationStressTB,
-	node federationStressNode,
-	projectID int64,
+	node *federationStressNode,
 	ref string,
 	actor string,
 	label string,
 ) {
 	t.Helper()
 	status, raw := stressDoJSON(t, node.http, http.MethodPost,
-		node.url+"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+url.PathEscape(ref)+"/labels",
+		node.url+"/api/v1/projects/"+strconv.FormatInt(node.projectID, 10)+"/issues/"+url.PathEscape(ref)+"/labels",
 		nil, map[string]any{"actor": actor, "label": label}, nil)
 	require.Equalf(t, http.StatusOK, status, "add label body: %s", raw)
 }
 
 func (fx *federationStressFixture) commentOnNode(
 	t federationStressTB,
-	node federationStressNode,
-	projectID int64,
+	node *federationStressNode,
 	ref string,
 	actor string,
 ) {
 	t.Helper()
 	status, raw := stressDoJSON(t, node.http, http.MethodPost,
-		node.url+"/api/v1/projects/"+strconv.FormatInt(projectID, 10)+"/issues/"+url.PathEscape(ref)+"/comments",
+		node.url+"/api/v1/projects/"+strconv.FormatInt(node.projectID, 10)+"/issues/"+url.PathEscape(ref)+"/comments",
 		nil, map[string]any{
 			"actor": actor,
 			"body":  fmt.Sprintf("claimed stress comment %03d", fx.opSeq),
@@ -485,27 +473,27 @@ func (fx *federationStressFixture) drawActor(t *rapid.T, label string) string {
 	return actors[rapid.IntRange(0, len(actors)-1).Draw(t, label)]
 }
 
-func (fx *federationStressFixture) drawOnlineSpoke(t *rapid.T, label string) (int, bool) {
+func (fx *federationStressFixture) drawRunningSpoke(t *rapid.T, label string) (*federationStressNode, bool) {
 	t.Helper()
-	var online []int
-	for i := range fx.spokes {
-		if fx.spokes[i].online {
-			online = append(online, i)
+	var running []*federationStressNode
+	for _, spoke := range fx.spokes {
+		if spoke.running {
+			running = append(running, spoke)
 		}
 	}
-	if len(online) == 0 {
-		return 0, false
+	if len(running) == 0 {
+		return nil, false
 	}
-	return online[rapid.IntRange(0, len(online)-1).Draw(t, label)], true
+	return running[rapid.IntRange(0, len(running)-1).Draw(t, label)], true
 }
 
-func (fx *federationStressFixture) drawSpokeLiveIssue(t *rapid.T, label string) (int, federationStressIssue, bool) {
+func (fx *federationStressFixture) drawSpokeLiveIssue(t *rapid.T, label string) (*federationStressNode, federationStressIssue, bool) {
 	t.Helper()
-	spokeIdx, ok := fx.drawOnlineSpoke(t, label+"-spoke")
+	spoke, ok := fx.drawRunningSpoke(t, label+"-spoke")
 	if !ok {
-		return 0, federationStressIssue{}, false
+		return nil, federationStressIssue{}, false
 	}
-	issues := fx.issuesOnNode(t, fx.spokes[spokeIdx], fx.spokes[spokeIdx].replica.Project.ID, false)
+	issues := fx.issuesOnNode(t, spoke, false)
 	hubKnown := issues[:0]
 	for _, issue := range issues {
 		if fx.issueLiveOnHub(t, issue.UID) {
@@ -513,21 +501,20 @@ func (fx *federationStressFixture) drawSpokeLiveIssue(t *rapid.T, label string) 
 		}
 	}
 	if len(hubKnown) == 0 {
-		return 0, federationStressIssue{}, false
+		return nil, federationStressIssue{}, false
 	}
 	issue := hubKnown[rapid.IntRange(0, len(hubKnown)-1).Draw(t, label+"-issue")]
-	return spokeIdx, issue, ok
+	return spoke, issue, true
 }
 
 func (fx *federationStressFixture) drawIssue(
 	t *rapid.T,
-	node federationStressNode,
-	projectID int64,
+	node *federationStressNode,
 	includeDeleted bool,
 	label string,
 ) (federationStressIssue, bool) {
 	t.Helper()
-	issues := fx.issuesOnNode(t, node, projectID, includeDeleted)
+	issues := fx.issuesOnNode(t, node, includeDeleted)
 	if len(issues) == 0 {
 		return federationStressIssue{}, false
 	}
@@ -541,8 +528,7 @@ type federationStressLiveClaim struct {
 
 func (fx *federationStressFixture) drawLiveClaim(
 	t *rapid.T,
-	node federationStressNode,
-	projectID int64,
+	node *federationStressNode,
 	label string,
 ) (federationStressLiveClaim, bool) {
 	t.Helper()
@@ -553,7 +539,7 @@ func (fx *federationStressFixture) drawLiveClaim(
 		 WHERE c.project_id = ?
 		   AND c.released_at IS NULL
 		   AND i.deleted_at IS NULL
-		 ORDER BY c.id`, projectID)
+		 ORDER BY c.id`, node.projectID)
 	require.NoError(t, err)
 	defer func() { _ = rows.Close() }()
 	var claims []federationStressLiveClaim
@@ -571,8 +557,7 @@ func (fx *federationStressFixture) drawLiveClaim(
 
 func (fx *federationStressFixture) issuesOnNode(
 	t federationStressTB,
-	node federationStressNode,
-	projectID int64,
+	node *federationStressNode,
 	includeDeleted bool,
 ) []federationStressIssue {
 	t.Helper()
@@ -581,7 +566,7 @@ func (fx *federationStressFixture) issuesOnNode(
 		q += ` AND deleted_at IS NULL`
 	}
 	q += ` ORDER BY id`
-	rows, err := node.db.QueryContext(context.Background(), q, projectID)
+	rows, err := node.db.QueryContext(context.Background(), q, node.projectID)
 	require.NoError(t, err)
 	defer func() { _ = rows.Close() }()
 	var issues []federationStressIssue
@@ -600,15 +585,14 @@ func (fx *federationStressFixture) issueLiveOnHub(t federationStressTB, issueUID
 	return err == nil
 }
 
-func (fx *federationStressFixture) waitForFoldedProjectionMatch(t federationStressTB, spokeIdx int) {
+func (fx *federationStressFixture) waitForFoldedProjectionMatch(t federationStressTB, spoke *federationStressNode) {
 	t.Helper()
-	spoke := fx.spokes[spokeIdx]
 	deadline := time.Now().Add(10 * time.Second)
 	var lastHub, lastSpoke db.FoldProjection
 	for time.Now().Before(deadline) {
 		var err error
 		lastHub, lastSpoke, err = stressFoldedProjections(t, fx.hub.db, spoke.db,
-			fx.hubProject.ID, spoke.replica.Project.ID, fx.replayAfterID)
+			fx.hub.projectID, spoke.projectID, fx.replayAfterID)
 		require.NoError(t, err)
 		if assert.ObjectsAreEqual(lastHub.Issues, lastSpoke.Issues) &&
 			assert.ObjectsAreEqual(lastHub.Comments, lastSpoke.Comments) &&
@@ -620,7 +604,7 @@ func (fx *federationStressFixture) waitForFoldedProjectionMatch(t federationStre
 	assert.Equal(t, lastHub.Issues, lastSpoke.Issues)
 	assert.Equal(t, lastHub.Comments, lastSpoke.Comments)
 	assert.Equal(t, lastHub.Labels, lastSpoke.Labels)
-	t.Fatalf("folded projections did not converge for spoke-%d\ndaemon stderr: %s", spokeIdx, spoke.stderr.String())
+	t.Fatalf("folded projections did not converge for %s\ndaemon stderr: %s", spoke.name, spoke.stderr.String())
 }
 
 func stressFoldedProjections(
@@ -651,17 +635,18 @@ func stressFoldedProjections(
 	return db.FoldEvents(foldEvents(hubEvents)), db.FoldEvents(foldEvents(spokeEvents)), nil
 }
 
+// A daemon's stderr buffer outlives its process, so every node is inspected
+// whether or not it is running. `running` gates only the loops that need a
+// live daemon to make progress (assertAllFoldedProjectionsMatch,
+// pendingPushBacklogs).
 func (fx *federationStressFixture) assertDaemonStderrClean(t federationStressTB) {
 	t.Helper()
-	fx.assertNodeStderrClean(t, "hub", fx.hub)
-	for i := range fx.spokes {
-		if fx.spokes[i].online {
-			fx.assertNodeStderrClean(t, fmt.Sprintf("spoke-%d", i), fx.spokes[i])
-		}
+	for _, node := range fx.nodes() {
+		fx.assertNodeStderrClean(t, node)
 	}
 }
 
-func (fx *federationStressFixture) assertNodeStderrClean(t federationStressTB, name string, node federationStressNode) {
+func (fx *federationStressFixture) assertNodeStderrClean(t federationStressTB, node *federationStressNode) {
 	t.Helper()
 	log := strings.ToLower(node.stderr.String())
 	for _, bad := range []string{
@@ -674,12 +659,12 @@ func (fx *federationStressFixture) assertNodeStderrClean(t federationStressTB, n
 		"invalid token",
 	} {
 		if strings.Contains(log, bad) {
-			t.Fatalf("%s daemon stderr contains %q:\n%s", name, bad, node.stderr.String())
+			t.Fatalf("%s daemon stderr contains %q:\n%s", node.name, bad, node.stderr.String())
 		}
 	}
 }
 
-func startFederationStressHub(t federationStressTB, bin string) federationStressNode {
+func startFederationStressHub(t federationStressTB, bin string) *federationStressNode {
 	t.Helper()
 	dirs := newFederationStressDirs(t)
 	port := federationStressFreeTCPPort(t)
@@ -691,14 +676,15 @@ func startFederationStressHub(t federationStressTB, bin string) federationStress
 	store, err := sqlitestore.Open(context.Background(), dirs.dbPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	return federationStressNode{
-		dirs:   dirs,
-		url:    url,
-		http:   &http.Client{Timeout: 5 * time.Second},
-		db:     store,
-		stderr: stderr,
-		cmd:    cmd,
-		online: true,
+	return &federationStressNode{
+		name:    "hub",
+		dirs:    dirs,
+		url:     url,
+		http:    &http.Client{Timeout: 5 * time.Second},
+		db:      store,
+		stderr:  stderr,
+		cmd:     cmd,
+		running: true,
 	}
 }
 
@@ -726,7 +712,7 @@ func startFederationStressTCPDaemon(
 	return cmd
 }
 
-func startFederationStressSpoke(t federationStressTB, bin string) federationStressNode {
+func startFederationStressSpoke(t federationStressTB, bin string, index int) *federationStressNode {
 	t.Helper()
 	dirs := newFederationStressDirs(t)
 	stderr := &safeBuffer{}
@@ -735,7 +721,16 @@ func startFederationStressSpoke(t federationStressTB, bin string) federationStre
 	store, err := sqlitestore.Open(context.Background(), dirs.dbPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
-	return federationStressNode{dirs: dirs, url: url, http: client, db: store, stderr: stderr, cmd: cmd, online: true}
+	return &federationStressNode{
+		name:    fmt.Sprintf("spoke-%d", index),
+		dirs:    dirs,
+		url:     url,
+		http:    client,
+		db:      store,
+		stderr:  stderr,
+		cmd:     cmd,
+		running: true,
+	}
 }
 
 func startFederationStressUnixDaemon(t federationStressTB, bin string, dirs e2eDirs, stderr *safeBuffer) *exec.Cmd {
@@ -756,9 +751,9 @@ func startFederationStressUnixDaemon(t federationStressTB, bin string, dirs e2eD
 	return cmd
 }
 
-func assertNoDuplicateLiveClaimsOnNode(t federationStressTB, node string, store *sqlitestore.Store) {
+func assertNoDuplicateLiveClaimsOnNode(t federationStressTB, node *federationStressNode) {
 	t.Helper()
-	rows, err := store.QueryContext(context.Background(), `
+	rows, err := node.db.QueryContext(context.Background(), `
 		SELECT issue_uid, COUNT(*)
 		  FROM issue_claims
 		 WHERE released_at IS NULL
@@ -770,7 +765,7 @@ func assertNoDuplicateLiveClaimsOnNode(t federationStressTB, node string, store 
 		var issueUID string
 		var count int
 		require.NoError(t, rows.Scan(&issueUID, &count))
-		assert.LessOrEqualf(t, count, 1, "%s has duplicate live claims for issue %s", node, issueUID)
+		assert.LessOrEqualf(t, count, 1, "%s has duplicate live claims for issue %s", node.name, issueUID)
 	}
 	require.NoError(t, rows.Err())
 }

--- a/internal/daemon/reconciler_postgres_test.go
+++ b/internal/daemon/reconciler_postgres_test.go
@@ -80,9 +80,7 @@ func TestPostgresReconcilerReacquiresLeaseAfterSessionLoss(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return store.QueryRowContext(ctx, `
 			SELECT pid FROM pg_catalog.pg_locks
-			WHERE locktype = 'advisory' AND granted
-			  AND classid = (hashtext(current_database())::bigint & 4294967295)
-			  AND objid = (hashtext('kata:vector:reconciler:' || current_schema())::bigint & 4294967295)
+			WHERE `+vector.ReconcilerLockPredicateSQL+`
 			LIMIT 1`).Scan(&currentPID) == nil
 	}, 5*time.Second, 10*time.Millisecond, "reconciler did not acquire its initial lease")
 	require.Eventually(t, func() bool {
@@ -108,9 +106,7 @@ func TestPostgresReconcilerReacquiresLeaseAfterSessionLoss(t *testing.T) {
 		require.Eventually(t, func() bool {
 			err := store.QueryRowContext(ctx, `
 				SELECT pid FROM pg_catalog.pg_locks
-				WHERE locktype = 'advisory' AND granted
-				  AND classid = (hashtext(current_database())::bigint & 4294967295)
-				  AND objid = (hashtext('kata:vector:reconciler:' || current_schema())::bigint & 4294967295)
+				WHERE `+vector.ReconcilerLockPredicateSQL+`
 				LIMIT 1`).Scan(&currentPID)
 			return err == nil && currentPID != previousPID
 		}, 5*time.Second, 10*time.Millisecond, "cycle %d did not reacquire leadership", cycle)

--- a/internal/vector/export_test.go
+++ b/internal/vector/export_test.go
@@ -1,0 +1,39 @@
+package vector
+
+import (
+	"context"
+
+	kitvec "go.kenn.io/kit/vector"
+)
+
+// This file is compiled only into the test binary. It gives the external
+// vector_test package access to package internals. It must not import
+// internal/testenv or internal/daemon: those import internal/vector, and an
+// in-package test file may not close that cycle.
+
+// ErrReconcilerLeaseNotHeldForTest exposes the sentinel every derived-state
+// mutator returns when this index holds no reconciler lease.
+var ErrReconcilerLeaseNotHeldForTest = errReconcilerLeaseNotHeld
+
+// SaveVectorsForTest reaches the one derived-state mutator that has no
+// exported Index method: kit's fill drives it through the flow store.
+func (ix *Index) SaveVectorsForTest(
+	ctx context.Context,
+	gen, doc string,
+	revision any,
+	vectors []kitvec.ChunkVector,
+) error {
+	return ix.flowStore.SaveVectors(ctx, gen, doc, revision, vectors)
+}
+
+// ClearReconcilerLeaseForTest forgets the recorded lease session without
+// releasing its advisory lock or closing its connection, so a test can assert
+// that fencing comes from the representation rather than from a terminated
+// connection erroring.
+func (ix *Index) ClearReconcilerLeaseForTest() {
+	conn, err := ix.pg.leaseSession()
+	if err != nil {
+		return
+	}
+	ix.pg.releaseLease(conn)
+}

--- a/internal/vector/lease.go
+++ b/internal/vector/lease.go
@@ -21,14 +21,9 @@ func (ix *Index) AcquireReconcilerLease(ctx context.Context) (func() error, erro
 	if err != nil {
 		return nil, fmt.Errorf("vector: reserve reconciler lease connection: %w", err)
 	}
-	const lockQuery = `
-		SELECT pg_try_advisory_lock(
-			hashtext(current_database()),
-			hashtext('kata:vector:reconciler:' || current_schema())
-		)`
 	for {
 		var acquired bool
-		if err := conn.QueryRowContext(ctx, lockQuery).Scan(&acquired); err != nil {
+		if err := conn.QueryRowContext(ctx, reconcilerLockSQL).Scan(&acquired); err != nil {
 			_ = conn.Close()
 			return nil, fmt.Errorf("vector: acquire postgres reconciler lease: %w", err)
 		}
@@ -44,55 +39,34 @@ func (ix *Index) AcquireReconcilerLease(ctx context.Context) (func() error, erro
 		case <-timer.C:
 		}
 	}
-	ix.pg.leaseMu.Lock()
-	if ix.pg.leaseConn != nil {
-		ix.pg.leaseMu.Unlock()
+	if err := ix.pg.adoptLease(conn); err != nil {
 		_ = conn.Close()
-		return nil, errors.New("vector: postgres reconciler lease already held by this index")
+		return nil, err
 	}
-	ix.pg.leaseConn = conn
-	ix.pg.leaseMu.Unlock()
 	return func() error {
-		ix.pg.leaseMu.Lock()
-		if ix.pg.leaseConn == conn {
-			ix.pg.leaseConn = nil
-		}
-		ix.pg.leaseMu.Unlock()
+		ix.pg.releaseLease(conn)
 		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_, unlockErr := conn.ExecContext(releaseCtx, `
-			SELECT pg_advisory_unlock(
-				hashtext(current_database()),
-				hashtext('kata:vector:reconciler:' || current_schema())
-			)`)
+		_, unlockErr := conn.ExecContext(releaseCtx, reconcilerUnlockSQL)
 		return errors.Join(unlockErr, conn.Close())
 	}, nil
 }
 
 // ValidateReconcilerLease checks that the exact PostgreSQL session used for
-// derived-state mutations still owns the schema's reconciler lease. SQLite
+// derived-state mutations still owns the schema's reconciler lease. It asks
+// reconcilerExecutor for that session precisely so it can never validate a
+// different connection than the one a mutation would run on. SQLite
 // reconciliation has no cross-process lease and always succeeds.
 func (ix *Index) ValidateReconcilerLease(ctx context.Context) error {
 	if ix.pg == nil {
 		return nil
 	}
-	ix.pg.leaseMu.RLock()
-	conn := ix.pg.leaseConn
-	ix.pg.leaseMu.RUnlock()
-	if conn == nil {
-		return errors.New("vector: postgres reconciler lease is not held")
+	executor, err := ix.pg.reconcilerExecutor()
+	if err != nil {
+		return err
 	}
 	var held bool
-	err := conn.QueryRowContext(ctx, `
-		SELECT EXISTS (
-			SELECT 1 FROM pg_catalog.pg_locks
-			WHERE pid = pg_backend_pid()
-			  AND locktype = 'advisory'
-			  AND granted
-			  AND classid = (hashtext(current_database())::bigint & 4294967295)
-			  AND objid = (hashtext('kata:vector:reconciler:' || current_schema())::bigint & 4294967295)
-		)`).Scan(&held)
-	if err != nil {
+	if err := executor.QueryRowContext(ctx, reconcilerLeaseHeldSQL).Scan(&held); err != nil {
 		return fmt.Errorf("vector: validate postgres reconciler lease: %w", err)
 	}
 	if !held {

--- a/internal/vector/lease_fencing_postgres_test.go
+++ b/internal/vector/lease_fencing_postgres_test.go
@@ -1,0 +1,58 @@
+package vector_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db/pgstore"
+	"go.kenn.io/kata/internal/testenv"
+	"go.kenn.io/kata/internal/vector"
+	kitvec "go.kenn.io/kit/vector"
+)
+
+// TestPostgresReconcilerLeaseFencesWorkAfterSessionLoss covers fencing when
+// the lease session dies, where the driver itself errors. This covers the
+// case that has no driver error to lean on: the recorded lease is gone while
+// its connection is still healthy and its advisory lock still held. Fencing
+// must come from the representation.
+func TestPostgresMutatorsFenceAfterTheLeaseSessionIsForgotten(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires pgvector testcontainer")
+	}
+	ctx := context.Background()
+	dsn, cleanup := testenv.NewPostgresWithPgvectorContainer(t, ctx)
+	t.Cleanup(cleanup)
+	store, err := pgstore.Open(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	idx, err := vector.OpenPostgres(ctx, store.DB)
+	require.NoError(t, err)
+
+	release, err := idx.AcquireReconcilerLease(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = release() })
+	require.NoError(t, idx.EnsureBuilding(ctx, "leased",
+		kitvec.Generation{Model: "example", Dimensions: 2}))
+
+	idx.ClearReconcilerLeaseForTest()
+
+	var stillLocked int
+	require.NoError(t, store.QueryRowContext(ctx,
+		`SELECT count(*) FROM pg_catalog.pg_locks WHERE `+
+			vector.ReconcilerLockPredicateSQL).Scan(&stillLocked))
+	require.Equal(t, 1, stillLocked,
+		"the advisory lock must still be held, so a driver error cannot be what fences the write")
+
+	require.ErrorIs(t,
+		idx.EnsureBuilding(ctx, "unfenced", kitvec.Generation{Model: "example", Dimensions: 2}),
+		vector.ErrReconcilerLeaseNotHeldForTest)
+	require.ErrorIs(t, idx.ValidateReconcilerLease(ctx),
+		vector.ErrReconcilerLeaseNotHeldForTest)
+
+	var rows int
+	require.NoError(t, store.QueryRowContext(ctx,
+		`SELECT count(*) FROM issue_vector_generations WHERE gen_key = 'unfenced'`).Scan(&rows))
+	assert.Zero(t, rows, "a forgotten lease must not have written a generation")
+}

--- a/internal/vector/lease_postgres_test.go
+++ b/internal/vector/lease_postgres_test.go
@@ -34,9 +34,7 @@ func TestPostgresReconcilerLeaseFencesWorkAfterSessionLoss(t *testing.T) {
 	var leaderPID int
 	require.NoError(t, store.QueryRowContext(ctx, `
 		SELECT pid FROM pg_catalog.pg_locks
-		WHERE locktype = 'advisory' AND granted
-		  AND classid = (hashtext(current_database())::bigint & 4294967295)
-		  AND objid = (hashtext('kata:vector:reconciler:' || current_schema())::bigint & 4294967295)
+		WHERE `+vector.ReconcilerLockPredicateSQL+`
 		LIMIT 1`).Scan(&leaderPID))
 
 	secondAcquired := make(chan struct{})

--- a/internal/vector/lease_required_postgres_test.go
+++ b/internal/vector/lease_required_postgres_test.go
@@ -1,0 +1,65 @@
+package vector_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db/pgstore"
+	"go.kenn.io/kata/internal/testenv"
+	"go.kenn.io/kata/internal/vector"
+	kitvec "go.kenn.io/kit/vector"
+)
+
+// One elected reconciler per database/schema mutates derived state. An index
+// that never acquired the lease must not be able to write at all: without
+// this, two daemons in the unleased state would both write to the same
+// pgvector tables.
+func TestPostgresMutatorsRequireTheReconcilerLease(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires pgvector testcontainer")
+	}
+	ctx := context.Background()
+	dsn, cleanup := testenv.NewPostgresWithPgvectorContainer(t, ctx)
+	t.Cleanup(cleanup)
+	store, err := pgstore.Open(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	idx, err := vector.OpenPostgres(ctx, store.DB)
+	require.NoError(t, err)
+
+	mutators := []struct {
+		name string
+		call func() error
+	}{
+		{"EnsureBuilding", func() error {
+			return idx.EnsureBuilding(ctx, "unleased",
+				kitvec.Generation{Model: "example", Dimensions: 2})
+		}},
+		{"CutOver", func() error {
+			return idx.CutOver(ctx, "unleased")
+		}},
+		{"RefreshMirror", func() error {
+			_, err := idx.RefreshMirror(ctx, store)
+			return err
+		}},
+		{"SaveVectors", func() error {
+			return idx.SaveVectorsForTest(ctx, "unleased", "01KSD7P0000000000000000001", int64(1),
+				[]kitvec.ChunkVector{{ChunkIndex: 0, Vector: kitvec.Vector{1, 0}}})
+		}},
+	}
+	for _, mutator := range mutators {
+		t.Run(mutator.name, func(t *testing.T) {
+			require.ErrorIs(t, mutator.call(), vector.ErrReconcilerLeaseNotHeldForTest)
+		})
+	}
+
+	var generations, mirrorRows int
+	require.NoError(t, store.QueryRowContext(ctx,
+		`SELECT count(*) FROM issue_vector_generations`).Scan(&generations))
+	assert.Zero(t, generations, "an unleased index must not have registered a generation")
+	require.NoError(t, store.QueryRowContext(ctx,
+		`SELECT count(*) FROM issue_vector_mirror`).Scan(&mirrorRows))
+	assert.Zero(t, mirrorRows, "an unleased index must not have written mirror rows")
+}

--- a/internal/vector/postgres.go
+++ b/internal/vector/postgres.go
@@ -28,23 +28,62 @@ type postgresExecutor interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
-func (p *postgresIndex) reconcilerExecutor() postgresExecutor {
+// errReconcilerLeaseNotHeld is returned by every derived-state mutator when
+// this index does not hold the schema's reconciler lease. Falling back to an
+// unfenced pool connection would let two daemons in the unleased state write
+// to the same derived tables, so "no lease" is an error, not a default.
+var errReconcilerLeaseNotHeld = errors.New("vector: postgres reconciler lease is not held")
+
+// leaseSession returns the connection this index holds the reconciler lease
+// on. It is the only read of leaseConn.
+func (p *postgresIndex) leaseSession() (*sql.Conn, error) {
 	p.leaseMu.RLock()
 	defer p.leaseMu.RUnlock()
-	if p.leaseConn != nil {
-		return p.leaseConn
+	if p.leaseConn == nil {
+		return nil, errReconcilerLeaseNotHeld
 	}
-	return p.db
+	return p.leaseConn, nil
+}
+
+// adoptLease records conn as the session holding this index's reconciler
+// lease. Taking the advisory lock on conn, and releasing it, stay with the
+// caller; adoptLease only owns the bookkeeping.
+func (p *postgresIndex) adoptLease(conn *sql.Conn) error {
+	p.leaseMu.Lock()
+	defer p.leaseMu.Unlock()
+	if p.leaseConn != nil {
+		return errors.New("vector: postgres reconciler lease already held by this index")
+	}
+	p.leaseConn = conn
+	return nil
+}
+
+// releaseLease forgets conn if it is still the recorded lease session. It is
+// a no-op for any other connection, so a stale release closure cannot evict a
+// lease a later acquisition adopted.
+func (p *postgresIndex) releaseLease(conn *sql.Conn) {
+	p.leaseMu.Lock()
+	defer p.leaseMu.Unlock()
+	if p.leaseConn == conn {
+		p.leaseConn = nil
+	}
+}
+
+// reconcilerExecutor is the executor every derived-state mutation runs on.
+func (p *postgresIndex) reconcilerExecutor() (postgresExecutor, error) {
+	conn, err := p.leaseSession()
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
 }
 
 func (p *postgresIndex) beginReconcilerTx(ctx context.Context) (*sql.Tx, error) {
-	p.leaseMu.RLock()
-	conn := p.leaseConn
-	p.leaseMu.RUnlock()
-	if conn != nil {
-		return conn.BeginTx(ctx, nil)
+	conn, err := p.leaseSession()
+	if err != nil {
+		return nil, err
 	}
-	return p.db.BeginTx(ctx, nil)
+	return conn.BeginTx(ctx, nil)
 }
 
 func (p *postgresIndex) validate(ctx context.Context) error {
@@ -260,15 +299,17 @@ func (p *postgresIndex) ensureBuilding(ctx context.Context, key string, gen kitv
 	if gen.Dimensions > 4000 {
 		return fmt.Errorf("vector: postgres halfvec dimensions must not exceed 4,000 (got %d)", gen.Dimensions)
 	}
-	executor := p.reconcilerExecutor()
-	_, err := executor.ExecContext(ctx, `
+	executor, err := p.reconcilerExecutor()
+	if err != nil {
+		return fmt.Errorf("vector: ensure postgres generation %s: %w", key, err)
+	}
+	if _, err := executor.ExecContext(ctx, `
 		INSERT INTO issue_vector_generations(gen_key, model, dimensions, state)
 		VALUES($1, $2, $3, 'building')
 		ON CONFLICT(gen_key) DO UPDATE SET state = 'building'
 		WHERE issue_vector_generations.state <> 'active'
 		  AND issue_vector_generations.model = EXCLUDED.model
-		  AND issue_vector_generations.dimensions = EXCLUDED.dimensions`, key, gen.Model, gen.Dimensions)
-	if err != nil {
+		  AND issue_vector_generations.dimensions = EXCLUDED.dimensions`, key, gen.Model, gen.Dimensions); err != nil {
 		return fmt.Errorf("vector: ensure postgres generation %s: %w", key, err)
 	}
 	var model string
@@ -365,7 +406,10 @@ func (p *postgresIndex) coverage(ctx context.Context, key string) (embedded, ski
 }
 
 func (p *postgresIndex) refreshMirror(ctx context.Context, store db.Storage) (int, error) {
-	executor := p.reconcilerExecutor()
+	executor, err := p.reconcilerExecutor()
+	if err != nil {
+		return 0, fmt.Errorf("vector: refresh postgres mirror: %w", err)
+	}
 	changed := 0
 	seen := make(map[string]struct{})
 	var afterID int64

--- a/internal/vector/reconciler_lock.go
+++ b/internal/vector/reconciler_lock.go
@@ -1,0 +1,35 @@
+package vector
+
+// The semantic-search reconciler is elected with a PostgreSQL advisory lock.
+// The key has to be spelled twice: pg_try_advisory_lock takes two int4
+// arguments, while pg_catalog.pg_locks reports the same pair as classid/objid
+// bigints holding the unsigned 32-bit truncation of those values. Both
+// spellings are built from reconcilerLockName here, so a change to the key
+// cannot land in one encoding and not the other.
+
+// reconcilerLockName is the advisory-lock key prefix. current_schema() is
+// appended so two kata schemas in one database elect independent reconcilers.
+const reconcilerLockName = "kata:vector:reconciler:"
+
+// reconcilerLockArgs is the (classid, objid) argument pair passed to
+// pg_try_advisory_lock and pg_advisory_unlock.
+const reconcilerLockArgs = `hashtext(current_database()), ` +
+	`hashtext('` + reconcilerLockName + `' || current_schema())`
+
+// ReconcilerLockPredicateSQL matches the reconciler's advisory lock in
+// pg_catalog.pg_locks. It is exported so tests outside this package that
+// observe the lock (internal/daemon's reconciler recovery tests) share this
+// one definition of the key instead of re-deriving the truncation.
+const ReconcilerLockPredicateSQL = `locktype = 'advisory'
+	  AND granted
+	  AND classid = (hashtext(current_database())::bigint & 4294967295)
+	  AND objid = (hashtext('` + reconcilerLockName + `' || current_schema())::bigint & 4294967295)`
+
+const reconcilerLockSQL = `SELECT pg_try_advisory_lock(` + reconcilerLockArgs + `)`
+
+const reconcilerUnlockSQL = `SELECT pg_advisory_unlock(` + reconcilerLockArgs + `)`
+
+const reconcilerLeaseHeldSQL = `SELECT EXISTS (
+		SELECT 1 FROM pg_catalog.pg_locks
+		WHERE pid = pg_backend_pid()
+		  AND ` + ReconcilerLockPredicateSQL + `)`

--- a/internal/vector/reconciler_lock_postgres_test.go
+++ b/internal/vector/reconciler_lock_postgres_test.go
@@ -1,0 +1,48 @@
+package vector_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db/pgstore"
+	"go.kenn.io/kata/internal/testenv"
+	"go.kenn.io/kata/internal/vector"
+)
+
+// The reconciler lock key is written two ways against PostgreSQL: as the two
+// int4 arguments pg_try_advisory_lock takes, and as the truncated bigint
+// classid/objid pg_locks reports. This asserts both spellings designate the
+// same lock, which is the invariant the duplicated literals threatened.
+func TestReconcilerLockPredicateMatchesTheAcquiredLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires pgvector testcontainer")
+	}
+	ctx := context.Background()
+	dsn, cleanup := testenv.NewPostgresWithPgvectorContainer(t, ctx)
+	t.Cleanup(cleanup)
+	store, err := pgstore.Open(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	idx, err := vector.OpenPostgres(ctx, store.DB)
+	require.NoError(t, err)
+
+	countLocks := func() int {
+		var n int
+		require.NoError(t, store.QueryRowContext(ctx,
+			`SELECT count(*) FROM pg_catalog.pg_locks WHERE `+
+				vector.ReconcilerLockPredicateSQL).Scan(&n))
+		return n
+	}
+
+	assert.Zero(t, countLocks(), "no lock may match the predicate before one is acquired")
+
+	release, err := idx.AcquireReconcilerLease(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, countLocks(),
+		"the pg_locks spelling must match the lock pg_try_advisory_lock took")
+
+	require.NoError(t, release())
+	assert.Zero(t, countLocks(), "releasing the lease must drop the matched lock")
+}


### PR DESCRIPTION
## What changed

- require PostgreSQL vector mutations to run on the elected reconciler session
- centralize the advisory-lock key and give the vector index ownership of lease adoption, validation, and release
- make unleased derived-state writes fail instead of falling back to the connection pool
- give federation stress nodes ownership of their identity and process state while preserving stopped-node stderr and SQLite assertions
- leave persisted schemas and migrations unchanged

## Why

A PostgreSQL vector index without its recorded lease could fall back to a pool connection and mutate derived state without being the elected reconciler. The stress harness also repeated parallel arrays for node state, which made lifecycle assertions harder to keep attached to the right process.

## Usage

No usage change.
