### PR TITLE
Cap embedding batches by token budget

### DIFF
--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -37,6 +37,7 @@ import (
 	"go.kenn.io/kata/internal/vector"
 	"go.kenn.io/kata/internal/version"
 	kitdaemon "go.kenn.io/kit/daemon"
+	kitvec "go.kenn.io/kit/vector"
 )
 
 func newDaemonCmd() *cobra.Command {
@@ -1518,11 +1519,26 @@ func preflightEmbeddingStartup(
 	if err != nil {
 		return nil, "", fmt.Errorf("embedding client: %w", err)
 	}
+	batchOptions := embeddingBatchOptions(ec, embedder.BatchSize())
+	if _, err := kitvec.EncodeBatched(
+		context.Background(), embedder.EncodeFunc(), nil, batchOptions...,
+	); err != nil {
+		return nil, "", fmt.Errorf("embedding batching: %w", err)
+	}
 	vectorsPath, err := vectorsPathForDSN(dbPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("embedding index: %w", err)
 	}
 	return embedder, vectorsPath, nil
+}
+
+func embeddingBatchOptions(ec config.EmbeddingsConfig, batchSize int) []kitvec.BatchOption {
+	options := []kitvec.BatchOption{kitvec.WithBatchSize(batchSize)}
+	if ec.MaxBatchTokens != 0 || ec.ModelContextTokens != 0 {
+		options = append(options,
+			kitvec.WithBatchTokenBudget(ec.MaxBatchTokens, ec.ModelContextTokens))
+	}
+	return options
 }
 
 // startEmbeddingReconciler opens the sidecar vector index for the embedding
@@ -1553,6 +1569,7 @@ func startEmbeddingReconciler(
 	}
 	reconciler := daemon.NewReconciler(store, idx, embedder, daemon.ReconcilerConfig{
 		BatchSize:      ec.BatchSize,
+		BatchOptions:   embeddingBatchOptions(ec, embedder.BatchSize()),
 		DrainAdmission: drainAdmission,
 	})
 	workers.Go(func() {

--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -2038,6 +2038,17 @@ func TestVectorsPathForDSN(t *testing.T) {
 	}
 }
 
+func TestPreflightEmbeddingStartupLetsKitRejectInvalidTokenBudget(t *testing.T) {
+	_, _, err := preflightEmbeddingStartup(config.EmbeddingsConfig{
+		BaseURL:            "http://127.0.0.1:11434/v1",
+		Model:              "example-model",
+		ModelContextTokens: 32_000,
+		MaxBatchTokens:     31_999,
+	}, filepath.Join(t.TempDir(), "kata.db"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "embedding batching")
+}
+
 func TestGitHubSyncRunnerInterval(t *testing.T) {
 	t.Setenv("KATA_GITHUB_SYNC_INTERVAL_MS", "")
 	assert.Equal(t, 5*time.Minute, githubSyncRunnerInterval())

--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -53,8 +53,11 @@ speaks the wire format and never bundles a model.
    provider also needs a key — set `api_key` or, better, `api_key_env` pointing
    at an environment variable. See
    [Configuration](../reference/configuration.md#semantic-search) for every
-   field (`dims`, `batch_size`, `timeout_seconds`, `fingerprint_salt`,
-   `trust_private_network`).
+   field (`dims`, `batch_size`, `model_context_tokens`, `max_batch_tokens`,
+   `timeout_seconds`, `fingerprint_salt`, `trust_private_network`). If the
+   provider limits total input tokens per request, set both token fields to
+   keep background embedding batches below that limit. Leave them unset for
+   the existing count-only batching behavior.
 
 3. Restart the daemon (or start it — `kata` will pick up the config). It begins
    embedding existing issues in the background immediately.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -523,6 +523,8 @@ model    = "nomic-embed-text"
 # fingerprint_salt = ""         # bump to force re-embed when model weights change
 # dims                          # expected vector dimensionality (default 768)
 # batch_size                    # inputs per request (default 64)
+# model_context_tokens          # model's maximum tokens for one input
+# max_batch_tokens              # provider's aggregate input-token cap per request
 # timeout_seconds               # per-request timeout (default 30)
 # trust_private_network = false # allow plaintext HTTP to literal non-public IPs
 ```
@@ -533,6 +535,19 @@ are mutually exclusive. The embedding API key is attached only to requests whose
 origin matches `base_url`, following the same bearer-token trust ladder as
 daemon catalog tokens: HTTPS is always allowed, HTTP to loopback is allowed, and
 HTTP to other private IPs needs `trust_private_network = true`.
+
+Some providers cap the total input tokens across one embedding request as well
+as the number of inputs. Set `model_context_tokens` to the model's per-input
+context limit and `max_batch_tokens` to the provider's aggregate request limit
+when that applies. Kata passes both limits to kit, which conservatively treats
+every input as capable of filling the model context and reduces `batch_size` as
+needed. This avoids repeatable oversized-request errors from providers that
+truncate each input before enforcing their aggregate limit.
+
+Both settings are optional and default to zero. Existing deployments therefore
+keep count-only batching. When either setting is used, both must be positive and
+`max_batch_tokens` must fit at least one `model_context_tokens` input; kit checks
+this during daemon startup before Kata processes documents.
 
 Privacy: configuring an endpoint sends issue titles and bodies to it on every
 embed. That is the consent boundary — the operator who writes this section

--- a/go.mod
+++ b/go.mod
@@ -25,12 +25,11 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/spf13/cobra v1.10.2
-	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/teambition/rrule-go v1.8.2
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
-	go.kenn.io/kit v0.21.3
+	go.kenn.io/kit v0.22.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
@@ -125,6 +124,7 @@ require (
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-go.kenn.io/kit v0.21.3 h1:7LejpspYJR2Lb2mCQnukXW5wc2cLQ9P6G2UInaoeowI=
-go.kenn.io/kit v0.21.3/go.mod h1:sUFJe7d25a3FYwjL3mlHx/qzHhF8//xNnR920jzoejw=
+go.kenn.io/kit v0.22.0 h1:F0tRgXL9Ni4B1EP999DuRlbL2yWiTFnxLRWNOqPosFM=
+go.kenn.io/kit v0.22.0/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/bridges/prometheus v0.69.0 h1:saQoWg5845Q8TojpqeVStS7zGwVZ6bc5W2PJavTPiBM=

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -122,6 +122,11 @@ type EmbeddingsConfig struct {
 	// BatchSize caps inputs per embedding request. 0 means the client
 	// default; negative values are rejected.
 	BatchSize int `toml:"batch_size"`
+	// ModelContextTokens is the maximum tokens accepted for one input.
+	// MaxBatchTokens is the provider's aggregate input-token cap per request.
+	// Leaving both at zero preserves count-only batching.
+	ModelContextTokens int `toml:"model_context_tokens"`
+	MaxBatchTokens     int `toml:"max_batch_tokens"`
 	// TimeoutSeconds is the per-request HTTP timeout. 0 means the client
 	// default; negative values are rejected.
 	TimeoutSeconds int `toml:"timeout_seconds"`

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -1337,6 +1337,8 @@ func TestReadDaemonConfig_SearchEmbeddingsValid(t *testing.T) {
 [search.embeddings]
 base_url = "http://localhost:11434/v1"
 model = "nomic-embed-text"
+model_context_tokens = 32000
+max_batch_tokens = 120000
 `), 0o600))
 
 	cfg, err := config.ReadDaemonConfig()
@@ -1345,6 +1347,8 @@ model = "nomic-embed-text"
 		"base_url + model present must enable embeddings")
 	assert.Equal(t, "http://localhost:11434/v1", cfg.Search.Embeddings.BaseURL)
 	assert.Equal(t, "nomic-embed-text", cfg.Search.Embeddings.Model)
+	assert.Equal(t, 32000, cfg.Search.Embeddings.ModelContextTokens)
+	assert.Equal(t, 120000, cfg.Search.Embeddings.MaxBatchTokens)
 }
 
 func TestReadDaemonConfig_SearchEmbeddingsDisabledWhenAbsent(t *testing.T) {

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -19,12 +19,12 @@ import (
 type embedder interface {
 	EncodeFunc() kitvec.EncodeFunc
 	Generation() kitvec.Generation
-	BatchSize() int
 }
 
 // ReconcilerConfig tunes the reconciler.
 type ReconcilerConfig struct {
 	BatchSize      int
+	BatchOptions   []kitvec.BatchOption
 	SweepEvery     time.Duration // periodic safety sweep; default 5m
 	MinBackoff     time.Duration // default 1s
 	MaxBackoff     time.Duration // default 5m
@@ -286,7 +286,7 @@ func (r *Reconciler) reconcileOnce(ctx context.Context) error {
 		return err
 	}
 	r.setCoverage(key, embedded, skipped, backlog)
-	if _, err := r.idx.Fill(ctx, key, r.emb.EncodeFunc(), r.cfg.BatchSize, r.emb.BatchSize(), r.markDocumentFilled); err != nil {
+	if _, err := r.idx.Fill(ctx, key, r.emb.EncodeFunc(), r.cfg.BatchSize, r.cfg.BatchOptions, r.markDocumentFilled); err != nil {
 		if embedded, skipped, backlog, coverageErr := r.idx.Coverage(ctx, key); coverageErr == nil {
 			r.setCoverage(key, embedded, skipped, backlog)
 		}

--- a/internal/vector/fill.go
+++ b/internal/vector/fill.go
@@ -20,7 +20,7 @@ const (
 )
 
 // Fill embeds every pending mirror document into the generation keyed by key.
-// scanBatch and encodeBatch <= 0 use kit defaults / single-batch respectively.
+// scanBatch <= 0 uses kit's default. batchOptions controls encode batching.
 //
 // Only a content-definitive HTTP 400 skips a document (poison-document
 // stamping). The embedding API reports request-level problems (bad model,
@@ -30,22 +30,21 @@ const (
 // aborts so the reconciler can back off instead of stamping the corpus as
 // skipped. Every non-400 error aborts unconditionally — an auth failure must
 // never stamp anything.
-func (ix *Index) Fill(ctx context.Context, key string, enc kitvec.EncodeFunc, scanBatch, encodeBatch int, onDocument func(bool)) (kitvec.FillStats, error) {
+func (ix *Index) Fill(ctx context.Context, key string, enc kitvec.EncodeFunc, scanBatch int, batchOptions []kitvec.BatchOption, onDocument func(bool)) (kitvec.FillStats, error) {
 	split := kitvec.SplitOptions{MaxRunes: splitMaxRunes, Overlap: splitOverlap}
-	batch := kitvec.BatchOptions{BatchSize: encodeBatch}
 	store := progressStore{Store: ix.flowStore, onDocument: onDocument}
-	return kitvec.Fill(ctx, store, key, enc, kitvec.FillOptions[string]{
-		ScanBatch: scanBatch,
-		Split:     split,
-		Batch:     batch,
-		OnEncodeError: func(doc string, err error) bool {
+	return kitvec.Fill(ctx, store, key, enc,
+		kitvec.WithFillScanBatch[string](scanBatch),
+		kitvec.WithFillSplit[string](split),
+		kitvec.WithFillBatch[string](batchOptions...),
+		kitvec.WithFillEncodeError[string](func(doc string, err error) bool {
 			var apiErr *embedding.APIError
 			if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusBadRequest {
 				return false
 			}
-			return ix.contentSpecific400(ctx, doc, enc, split, batch)
-		},
-	})
+			return ix.contentSpecific400(ctx, doc, enc, split, batchOptions)
+		}),
+	)
 }
 
 type progressStore struct {
@@ -70,7 +69,7 @@ func (s progressStore) SaveVectors(ctx context.Context, gen, doc string, revisio
 // rejection was the content itself and poison-skip is safe. Any replay
 // failure (shape-level 400, transient error, missing mirror row) keeps the
 // document pending by aborting the fill.
-func (ix *Index) contentSpecific400(ctx context.Context, doc string, enc kitvec.EncodeFunc, split kitvec.SplitOptions, batch kitvec.BatchOptions) bool {
+func (ix *Index) contentSpecific400(ctx context.Context, doc string, enc kitvec.EncodeFunc, split kitvec.SplitOptions, batchOptions []kitvec.BatchOption) bool {
 	content, err := ix.mirrorContent(ctx, doc)
 	if err != nil {
 		return false
@@ -79,6 +78,6 @@ func (ix *Index) contentSpecific400(ctx context.Context, doc string, enc kitvec.
 	for i := range chunks {
 		chunks[i].Text = strings.Repeat("a", utf8.RuneCountInString(chunks[i].Text))
 	}
-	_, err = kitvec.EncodeBatched(ctx, enc, chunks, batch)
+	_, err = kitvec.EncodeBatched(ctx, enc, chunks, batchOptions...)
 	return err == nil
 }

--- a/internal/vector/fill_test.go
+++ b/internal/vector/fill_test.go
@@ -3,6 +3,8 @@ package vector
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -51,7 +53,7 @@ func TestFillEmbedsChunksAndQueryFindsThem(t *testing.T) {
 		}
 		return out, nil
 	}
-	stats, err := ix.Fill(ctx, key, enc, 0, 0, nil)
+	stats, err := ix.Fill(ctx, key, enc, 0, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,6 +67,39 @@ func TestFillEmbedsChunksAndQueryFindsThem(t *testing.T) {
 	}
 	if len(hits) == 0 || hits[0].Doc != "u1" {
 		t.Fatalf("hits = %+v, want u1 first", hits)
+	}
+}
+
+func TestFillCapsConfiguredBatchesByTokenBudget(t *testing.T) {
+	ctx := context.Background()
+	ix := openTestIndex(t)
+	for i := range 4 {
+		seedMirror(t, ix, fmt.Sprintf("u%d", i), 1)
+	}
+	g := testGen("m1")
+	key := g.Fingerprint()
+	if err := ix.EnsureBuilding(ctx, key, g); err != nil {
+		t.Fatal(err)
+	}
+
+	var batchSizes []int
+	enc := func(_ context.Context, texts []string) ([][]float32, error) {
+		batchSizes = append(batchSizes, len(texts))
+		out := make([][]float32, len(texts))
+		for i := range texts {
+			out[i] = []float32{1, 0, 0, 0}
+		}
+		return out, nil
+	}
+	_, err := ix.Fill(ctx, key, enc, 0, []kitvec.BatchOption{
+		kitvec.WithBatchSize(4),
+		kitvec.WithBatchTokenBudget(120_000, 32_000),
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(batchSizes, []int{3, 1}) {
+		t.Fatalf("encode batch sizes = %v, want [3 1]", batchSizes)
 	}
 }
 
@@ -85,7 +120,7 @@ func TestFillAbortsOnRequestLevel400(t *testing.T) {
 	enc := func(_ context.Context, _ []string) ([][]float32, error) {
 		return nil, &embedding.APIError{StatusCode: 400, Body: "invalid model"}
 	}
-	stats, err := ix.Fill(ctx, key, enc, 0, 0, nil)
+	stats, err := ix.Fill(ctx, key, enc, 0, nil, nil)
 	var apiErr *embedding.APIError
 	if err == nil || !errors.As(err, &apiErr) || apiErr.StatusCode != 400 {
 		t.Fatalf("request-level 400 must abort the fill, got %v", err)
@@ -129,7 +164,7 @@ func TestFillAbortsOnBatchShape400(t *testing.T) {
 		}
 		return [][]float32{{1, 0, 0, 0}}, nil
 	}
-	stats, err := ix.Fill(ctx, key, enc, 0, 0, nil)
+	stats, err := ix.Fill(ctx, key, enc, 0, nil, nil)
 	var apiErr *embedding.APIError
 	if err == nil || !errors.As(err, &apiErr) || apiErr.StatusCode != 400 {
 		t.Fatalf("shape-level 400 must abort the fill, got %v", err)
@@ -162,7 +197,7 @@ func TestFillSkipsOnlyContentRejectedDocs(t *testing.T) {
 		}
 		return out, nil
 	}
-	stats, err := ix.Fill(ctx, key, enc, 0, 0, nil)
+	stats, err := ix.Fill(ctx, key, enc, 0, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +217,7 @@ func TestFillSkipsOnlyContentRejectedDocs(t *testing.T) {
 	authFail := func(_ context.Context, _ []string) ([][]float32, error) {
 		return nil, &embedding.APIError{StatusCode: 401, Body: "no"}
 	}
-	_, err = ix.Fill(ctx, key, authFail, 0, 0, nil)
+	_, err = ix.Fill(ctx, key, authFail, 0, nil, nil)
 	var apiErr *embedding.APIError
 	if err == nil || !errors.As(err, &apiErr) || apiErr.StatusCode != 401 {
 		t.Fatalf("401 must abort the fill, got %v", err)

--- a/internal/vector/generations_test.go
+++ b/internal/vector/generations_test.go
@@ -21,7 +21,7 @@ func fillAll(t *testing.T, ix *Index, key string) {
 		}
 		return out, nil
 	}
-	if _, err := ix.Fill(context.Background(), key, enc, 0, 0, nil); err != nil {
+	if _, err := ix.Fill(context.Background(), key, enc, 0, nil, nil); err != nil {
 		t.Fatalf("fill: %v", err)
 	}
 }


### PR DESCRIPTION
Kata embedding reconciliation can now cap provider requests by both input count and a conservative aggregate token budget. Operators set optional `model_context_tokens` and `max_batch_tokens` when their provider enforces a total request limit; deployments that omit them keep count-only batching.

The reconciler passes the limits to kit v0.22.0 through its functional Fill and Batch options, including the content-specific 400 replay. Startup also asks kit to validate the options before Kata processes documents, so Kata does not duplicate kit's budget arithmetic or validation rules.

<sup>generated by a clanker</sup>
