### PR TITLE
Clarify remote daemon browser access

### DIFF
--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-25
+last_edited: 2026-08-27
 ---
 
 # Remote daemon
@@ -99,11 +99,18 @@ socket address form.
 
 ## Browser access
 
-`kata ui` follows the same daemon selection order. A configured remote opens
-the daemon's canonical browser route and shows an in-document token login; the
-token is exchanged for a browser session in memory and is never put in the URL
-or browser storage. Identity-token mode keeps the token actor authoritative.
-Static-token deployments use the daemon's normal request-actor policy.
+Plain `kata ui` always starts or discovers the local browser gateway; it does
+not use `KATA_SERVER`. The gateway initially selects `active_daemon` when one
+is configured.
+
+To open a remote daemon directly, add it as a named `[[daemon]]` entry and run
+`kata ui --daemon <name>`. If the remote is configured only through
+`KATA_SERVER`, open its canonical `/kata` route in a browser instead, for
+example `https://daemon.example/kata`. A remote browser route shows an
+in-document token login; the token is exchanged for a browser session in
+memory and is never put in the URL or browser storage. Identity-token mode
+keeps the token actor authoritative. Static-token deployments use the daemon's
+normal request-actor policy.
 
 For an HTTPS reverse proxy, set `[web].public_origin` to the exact browser
 origin and route the UI, assets, `/api/v1/ui/*`, ordinary `/api/v1/*`, and the


### PR DESCRIPTION
## What changed

- clarify that plain `kata ui` stays on the local browser gateway even when `KATA_SERVER` is set
- document direct remote browser access through a named `[[daemon]]` entry or the daemon's canonical `/kata` route
- keep the existing in-browser token exchange and actor behavior unchanged

## Why

The remote-daemon guide applied the CLI daemon-selection order to `kata ui`, so a reader following its `KATA_SERVER` setup could open an unrelated local gateway and see different data. The corrected instructions match the existing browser behavior and configuration reference.

## Usage

Configure a named remote and open it directly:

```toml
[[daemon]]
name = "example-remote"
url = "https://daemon.example"
```

```sh
kata ui --daemon example-remote
```

With only `KATA_SERVER` configured, open `https://daemon.example/kata` directly in a browser.

Closes #312
