### PR TITLE
docs: finalize 0.16.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Go applications can instead mount kata's listener-free HTTP service in-process;
 see [Embedding kata in Go](docs/development/embedding.md).
 MCP clients can start Kata's native server over stdio or Streamable HTTP with
 `kata mcp serve`. It binds the current workspace's project by default, and can
-serve a fixed allowlist or the complete daemon catalog on request. Thirteen
+serve a fixed allowlist or the complete daemon catalog on request. Fourteen
 section loaders progressively expose Kata's typed issue, administration,
 automation, and event workflows. See the [MCP reference](docs/reference/mcp.md).
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 ---
 title: Changelog
 description: Release history for kata
-last_edited: 2026-08-20
+last_edited: 2026-08-27
 ---
 
 All notable changes to kata, grouped by release. Versioned releases start with
@@ -9,8 +9,35 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 ## Unreleased
 
+## 0.16.0
+<small>2026-08-27</small>
+
+kata 0.16.0 connects issues to work that lives outside kata: external root
+bridges backed by a public connector protocol, close evidence for work
+finished outside any repository, and per-project merge imports. Auto-started
+daemons can now shut themselves down when idle.
+
 **New features**
 
+- Added external root bridges. A connector process configured through
+  `[[connector]]` in `<KATA_HOME>/config.toml` binds a kata issue to one root
+  object in an external system. The `kata connector` and `kata bridge`
+  commands and the MCP `kata.load_external_roots` tools cover discovery, field
+  mapping, and the bind, pause, resume, reconcile, and unbind lifecycle. The
+  external root owns the bound title and body; inbound comments and lifecycle
+  sync are on by default, and outbound comments are opt-in per binding.
+- Published the versioned `kata.connector.v1` connector protocol with a public
+  Go SDK and a language-neutral conformance kit, so provider credentials and
+  APIs stay inside the connector executable.
+- Added `external:<account>` close evidence for `done` work finished by email,
+  phone, or another channel that produces no repository artifact. The weaker
+  claim stays visible in `kata audit closes`, and a supplied-but-disallowed
+  evidence type is now reported instead of the missing-evidence error.
+- Added `kata import --merge`, which restores a one-project JSONL snapshot
+  into an existing SQLite or PostgreSQL database without touching other
+  projects. Merge imports preserve project and issue UIDs, refuse UID
+  collisions, skip cross-project links, and keep imported federation
+  authority disabled.
 - Added opt-in idle shutdown for implicitly started owner-local daemons. Active
   requests and finite background work drain safely, while running stdio or
   streamable-HTTP MCP server processes renew the advertised timeout
@@ -19,10 +46,47 @@ All notable changes to kata, grouped by release. Versioned releases start with
 
 **Improvements**
 
-- Daemon stop now drains accepted hook jobs instead of dropping them, and
-  cancels in-flight hooks early enough to exit cleanly inside the 25-second
+- Capped embedding provider requests by an aggregate token budget through the
+  optional `model_context_tokens` and `max_batch_tokens` settings. Deployments
+  that omit them keep count-only batching.
+- Validated plaintext daemon targets when the client is built: a non-loopback
+  plaintext target without the required private-network trust or
+  `allow_insecure` opt-in now fails before any request is sent.
+- Resolved `kata wait` target state and CLI output mode once per command, so
+  error reporting uses the same output mode as normal execution.
+- Let JSON storage and API types define their own OpenAPI shapes, and mirrored
+  deprecated federation `claim` fields from the canonical `lease` fields at
+  one response boundary. Committed schemas and generated clients are
+  unchanged.
+- Moved the remaining web actions onto shared Kit UI buttons and theme state
+  so disabled controls keep readable contrast in dark mode.
+- Made daemon stop drain accepted hook jobs instead of dropping them, and
+  cancel in-flight hooks early enough to exit cleanly inside the 25-second
   shutdown budget. `kata daemon restart` waits up to 30 seconds for the old
   process to exit.
+
+**Bug fixes**
+
+- Restored owner-local loopback sessions for local `kata ui` tabs when the
+  daemon has a static API token, instead of falling into token login, and
+  omitted bodies from GET and HEAD responses so Firefox loads the initial
+  snapshot.
+- Kept the task list primary at narrow widths: the sidebar moves into a drawer
+  below 700px and filter controls wrap to the list pane width.
+
+**Acknowledgements**
+
+- Thanks to [Rusty Shackleford](https://github.com/salmonumbrella) for the
+  external root bridges and connector protocol, external close evidence,
+  per-project merge import, and the daemon credential and web action
+  improvements.
+- Thanks to [codyw912](https://github.com/codyw912) for idle shutdown of
+  auto-started daemons.
+- Thanks to [Wes McKinney](https://github.com/wesm) for the Firefox web UI
+  startup coverage.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the
+  local web UI access fix and narrow layouts, embedding token budgets, and the
+  Go 1.27 upgrade.
 
 ## 0.15.1
 <small>2026-08-20</small>

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -147,8 +147,9 @@ Close with:
 
 - a reason;
 - a substantive message;
-- typed evidence such as commit SHA, test command, PR URL, reviewed path, or
-  no-change audit note.
+- typed evidence such as commit SHA, test command, PR URL, reviewed path,
+  external account for work finished outside any repository, or no-change
+  audit note.
 
 If the work is not complete, keep the issue open and add a comment explaining
 what was attempted and what remains.

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -52,6 +52,10 @@ and label. Parent and child issues can be expanded inline, and the column
 picker controls the visible fields. Collection, scope, filter, and
 selected-issue state stays in the URL, making the current view bookmarkable.
 
+At narrow window widths the task list stays primary: below 700px the sidebar
+moves into a drawer, and filter controls wrap to fit the list pane, including
+side-by-side detail layouts.
+
 ![Kata Web UI showing a synthetic project and issue hierarchy](/assets/screenshots/web-ui/workspace.png)
 
 ## Manage an issue

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -110,7 +110,7 @@ by default. `--workspace` or `--project` selects one explicit project.
 `--projects` fixes an allowlist of project names, pinned by immutable project
 UID. `--all-projects` follows every project in the selected daemon catalog.
 The startup scope and actor apply to every tool call. The initial catalog
-contains 13 section loaders that progressively expose the detailed typed
+contains 14 section loaders that progressively expose the detailed typed
 tools. Optional `--storage-root` and repeatable `--storage-target
 alias=path-or-DSN` enable the otherwise absent host-local JSONL tools. See the
 [MCP reference](mcp.md) for transport configuration, the complete catalog,
@@ -499,6 +499,54 @@ immediate sync through the daemon and requires an enabled binding.
 V1 does not write back to GitHub, import timeline events, import pull requests,
 propagate deleted or transferred issues, or propagate edited or deleted GitHub
 comments.
+
+## External root bridges
+
+Bridges bind one kata issue to one root object in an external system through a
+configured connector process. The daemon reads connector instances from
+`[[connector]]` tables in `<KATA_HOME>/config.toml` (see the
+[configuration reference](configuration.md)); connector authors implement the
+[connector protocol](connector-protocol.md).
+
+```sh
+kata connector list
+kata connector status <instance>
+kata connector field list <instance>
+kata connector field map <instance> <kata-field> --external <selector>
+kata connector field unmap <instance> <kata-field>
+```
+
+`kata connector list` reports the configured instances, `status` shows one
+instance's safe status without credentials, and the `field` subcommands
+inspect and manage bidirectional field mappings. Kata planning-field mappings
+are limited to `scheduled_on` and `deadline_on`. Field mapping requires
+daemon-wide authority.
+
+```sh
+kata bridge bind <issue> --connector <instance> --external <locator> [--publish-comments]
+kata bridge show <issue>
+kata bridge reconcile <issue>
+kata bridge pause <issue> [--reason <text>]
+kata bridge resume <issue>
+kata bridge resolve-field <issue> <kata-field> --use kata|external
+kata bridge resolve-comment <issue> --adopt <external-comment-id> | --retry | --skip
+kata bridge unbind <issue>
+```
+
+`bind` attaches an issue to an existing external root that the connector
+resolves from `--external`. While a binding is active, the external root owns
+the bound title and body. Inbound comments and lifecycle sync are enabled by
+default; outbound comments require `--publish-comments` at bind time. `show`
+reports the binding's policy and reconciliation status, and `reconcile` runs a
+reconciliation pass now instead of waiting for the daemon's workers.
+
+`pause` stops reconciliation with an optional operator-visible reason and
+`resume` validates the binding before reconciliation restarts. When a mapped
+field changed on both sides, `resolve-field` picks the winning side explicitly.
+When outbound comment delivery is uncertain, `resolve-comment` either adopts
+the exact external comment ID that was published, retries publication, or
+skips the pending comment. `unbind` stops reconciliation permanently while
+preserving the binding's history.
 
 ## Events and audit
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-20
+last_edited: 2026-08-27
 ---
 
 # Configuration
@@ -21,7 +21,7 @@ bindings, local per-machine overrides, and daemon config.
 | `KATA_AUTHOR` | Default actor for mutations. |
 | `KATA_SERVER` | Remote daemon URL. Skips local discovery and auto-start. |
 | `KATA_AUTH_TOKEN` | Bearer token for daemon API auth. |
-| `KATA_TRUST_PRIVATE_NETWORK` | Set to `1` to permit trusted plaintext bearer use on private non-loopback HTTP. |
+| `KATA_TRUST_PRIVATE_NETWORK` | Set to `1` to permit trusted plaintext bearer use on private non-loopback HTTP. Without it (or `allow_insecure`), a plaintext non-loopback target fails when the client is built, before any request is sent. |
 | `KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES` | Set to `1` to permit tokenless writes and event streams on a literal private-IP daemon bind. |
 | `KATA_ALLOW_INSECURE` | Set to `1` or `true` to allow a configured remote daemon hostname over plain HTTP. Federation uses `kata federation enroll --allow-insecure` and `kata federation join --allow-insecure` instead because enrollment credentials are stored separately. |
 | `KATA_TELEMETRY_ENABLED` | Set to `0` to disable anonymous PostHog telemetry. |
@@ -342,6 +342,36 @@ Postgres DSNs may carry credentials. Runtime redaction strips userinfo and
 query parameters before a DSN appears in daemon metadata, health output, import
 output, errors, or per-database namespace hashing. Use environment variables or
 secret-managed configuration rather than committing a credential-bearing DSN.
+
+### Connector instances
+
+Each `[[connector]]` table configures one external-root connector process for
+[issue bridges](cli.md#external-root-bridges):
+
+```toml
+[[connector]]
+id = "notes"
+command = "/usr/local/bin/kata-connector-notes"
+args = ["--workspace-mode"]
+timeout_seconds = 30
+
+[connector.env]
+NOTES_TOKEN = "KATA_NOTES_TOKEN"
+
+[connector.settings]
+workspace = "example-workspace"
+```
+
+`id` is the lowercase instance name used by `kata connector` and
+`kata bridge --connector`; it must be unique. `command` is the absolute path of
+the connector executable and `args` its fixed arguments. `timeout_seconds`
+bounds each connector call (omit it for the default). `connector.env` maps
+child environment variable names to daemon environment variable names; only
+these variables reach the connector process, and their values are redacted from
+connector errors as secrets. `connector.settings` is non-secret JSON-compatible
+configuration passed to the connector on every call. The daemon validates all
+of this at startup and starts its reconciliation workers only when at least one
+connector is configured.
 
 ### Declarative federation mappings
 

--- a/docs/reference/connector-protocol.md
+++ b/docs/reference/connector-protocol.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-23
+last_edited: 2026-08-27
 ---
 
 # Connector author contract
@@ -8,12 +8,12 @@ Kata external-root connectors are executables that implement the versioned
 `kata.connector.v1` JSON protocol. Provider-specific credentials and APIs stay
 inside the connector.
 
-The current implementation provides the public protocol SDK and conformance kit
-plus internal process-client building blocks. Daemon configuration, durable
-bindings, synchronization, and API/CLI administration are not implemented yet.
-Do not add connector sections to `<KATA_HOME>/config.toml`; the daemon rejects
-unknown configuration keys. Those integration surfaces will be documented when
-they are available.
+This page is the contract for connector authors: the wire protocol, the public
+Go SDK, and the conformance kit. Operators configure connector instances with
+`[[connector]]` tables in `<KATA_HOME>/config.toml` (see the
+[configuration reference](configuration.md)) and manage bindings with the
+`kata connector` and `kata bridge` commands (see the
+[CLI reference](cli.md#external-root-bridges)).
 
 ## Process and framing
 
@@ -53,9 +53,8 @@ or `error`:
 Errors must be safe, bounded operator text: a lowercase structured code and a
 message without credentials, absolute paths, command lines, stack traces,
 standard-output/error dumps, or control characters. The process client redacts
-values supplied through its explicit environment mapping, but no daemon
-configuration exists for that mapping yet. The connector remains responsible
-for returning safe errors.
+values supplied through the instance's explicit `connector.env` mapping. The
+connector remains responsible for returning safe errors.
 
 ## Methods and capabilities
 
@@ -152,5 +151,4 @@ subsequent unchanged reads.
 - Kata planning-field mappings are limited to `scheduled_on` and `deadline_on`
   in protocol v1.
 - Kata uses one process per RPC for isolation and bounded cleanup.
-- The browser UI has no bridge indicator yet. Connector and bridge
-  administration through the daemon API and CLI is also deferred.
+- The browser UI has no bridge indicator yet.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-20
+last_edited: 2026-08-27
 ---
 
 # Model Context Protocol server
@@ -131,10 +131,10 @@ projects.
 
 ## Progressive tool catalog
 
-The initial catalog contains 13 read-only section loaders. Call the applicable
+The initial catalog contains 14 read-only section loaders. Call the applicable
 loader, then refresh the tool list when the server sends the standard
 `notifications/tools/list_changed` notification. This exposes only the detailed
-typed tools needed for the current task instead of placing all 55 tools in the
+typed tools needed for the current task instead of placing all 67 tools in the
 model context at startup.
 
 | Loader | Detailed tools |
@@ -151,7 +151,12 @@ model context at startup.
 | `kata.load_recurrence` | `kata.recurrences`, `kata.recurrence_update`, `kata.recurrence_delete` |
 | `kata.load_activity` | `kata.digest`, `kata.events` |
 | `kata.load_import` | `kata.import_issues` |
+| `kata.load_external_roots` | `kata.connectors`, `kata.connector_fields`, `kata.connector_field_map`, `kata.connector_field_unmap`, `kata.bridge_bind`, `kata.bridge_show`, `kata.bridge_reconcile`, `kata.bridge_pause`, `kata.bridge_resume`, `kata.bridge_resolve_field`, `kata.bridge_resolve_comment`, `kata.bridge_unbind` |
 | `kata.load_storage` | `kata.storage_export`, `kata.storage_import` when host storage is enabled |
+
+Bridge tools operate on issues inside the startup project scope;
+`kata.connector_field_map` and `kata.connector_field_unmap` require the
+`--all-projects` daemon-wide scope.
 
 Loaders are idempotent. A loader reports `available=false` when its optional
 startup dependency is absent. Loaded tools keep their individual input and

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-20
+last_edited: 2026-08-27
 ---
 
 # Agent workflows
@@ -109,7 +109,7 @@ kata mcp serve \
   --http-token-env KATA_MCP_HTTP_TOKEN
 ```
 
-The server starts with 13 section loaders. An agent loads only the detailed
+The server starts with 14 section loaders. An agent loads only the detailed
 issue, project, administration, automation, or event tools needed for its task.
 Pass `--workspace` or `--project` for an explicit project, `--projects` for a
 fixed allowlist, or `--all-projects` to use every project visible to the


### PR DESCRIPTION
Finalizes the public documentation for the 0.16.0 release using the tagged
changelog. The changelog records the shipped external root bridges, connector
protocol SDK, external close evidence, per-project merge imports, idle
shutdown for auto-started daemons, and the embedding, daemon-client, and web
improvements, and thanks the release contributors.

The connector author contract still said connector configuration, bindings,
and CLI administration were not implemented and told operators not to add
`[[connector]]` tables. 0.16.0 shipped all of that, so the page now points at
the configuration and CLI references instead. The CLI reference gains an
"External root bridges" section for `kata connector` and `kata bridge`, the
configuration reference documents `[[connector]]` instances, and the MCP
reference adds the `kata.load_external_roots` loader. The catalog counts move
from 13 loaders and 55 tools to 14 and 67 in the MCP reference, CLI
reference, agent workflow guide, and README, matching
`internal/mcp/sections.go`.

Smaller updates: `external` account evidence joins the typed-evidence list in
the concepts guide, and the web UI guide notes the narrow-width drawer
layout.

This PR is limited to behavior already shipped in v0.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)

<sup>generated by a clanker</sup>
