### PR TITLE
docs: correct connector scope and startup claims

### DIFF
--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -60,9 +60,12 @@ side-by-side detail layouts.
 
 ## Manage an issue
 
-Select an issue to open its detail panel. The browser renders Markdown in the
-description and comments and can update the title, description, schedule, due
-date, owner, priority, labels, and project. It also supports:
+Select an issue to open its detail panel. The panel opens as a read-only view
+of the description, properties, checklist, links, comments, recurrence, and
+events, with Markdown rendered in the description and comments. **Edit issue**
+switches the panel to the editor, which can update the title, description,
+schedule, due date, owner, priority, labels, and project, and **Done editing**
+returns to the read-only view. The editor also supports:
 
 - adding, completing, and removing checklist items;
 - adding comments with issue-reference completion;

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -369,9 +369,13 @@ bounds each connector call (omit it for the default). `connector.env` maps
 child environment variable names to daemon environment variable names; only
 these variables reach the connector process, and their values are redacted from
 connector errors as secrets. `connector.settings` is non-secret JSON-compatible
-configuration passed to the connector on every call. The daemon validates all
-of this at startup and starts its reconciliation workers only when at least one
-connector is configured.
+configuration passed to the connector on every call. The daemon validates this
+structure at startup and refuses to start on an invalid `[[connector]]` table,
+but it does not run the executable or read the mapped environment sources
+until a connector call needs them; connector health is observed through
+`kata connector status`. The bridge reconciliation workers always run, so
+durable bindings are still handled when their connector is removed from
+configuration.
 
 ### Declarative federation mappings
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -154,9 +154,10 @@ model context at startup.
 | `kata.load_external_roots` | `kata.connectors`, `kata.connector_fields`, `kata.connector_field_map`, `kata.connector_field_unmap`, `kata.bridge_bind`, `kata.bridge_show`, `kata.bridge_reconcile`, `kata.bridge_pause`, `kata.bridge_resume`, `kata.bridge_resolve_field`, `kata.bridge_resolve_comment`, `kata.bridge_unbind` |
 | `kata.load_storage` | `kata.storage_export`, `kata.storage_import` when host storage is enabled |
 
-Bridge tools operate on issues inside the startup project scope;
-`kata.connector_field_map` and `kata.connector_field_unmap` require the
-`--all-projects` daemon-wide scope.
+`kata.connectors`, `kata.connector_fields`, `kata.connector_field_map`,
+`kata.connector_field_unmap`, and `kata.bridge_bind` require the
+`--all-projects` daemon-wide scope. The remaining bridge tools operate on
+already-bound issues inside the startup project scope.
 
 Loaders are idempotent. A loader reports `available=false` when its optional
 startup dependency is absent. Loaded tools keep their individual input and


### PR DESCRIPTION
Corrects two claims a code review flagged in the 0.16.0 external-root
docs (#320).

The MCP reference said only `kata.connector_field_map` and
`kata.connector_field_unmap` need daemon-wide scope. The tool
registrations in `internal/mcp/external_roots.go` also gate
`kata.connectors`, `kata.connector_fields`, and `kata.bridge_bind` on
`--all-projects`; the reference now lists all five and notes the
remaining bridge tools work on already-bound issues inside the startup
scope.

The configuration reference said the daemon "validates all of this at
startup and starts its reconciliation workers only when at least one
connector is configured". In the shipped daemon the runner and event
wake always start (`cmd/kata/daemon_cmd.go`), so durable bindings are
still handled when their connector is removed, and startup validation
is structural: the executable and mapped environment are not touched
until a connector call needs them. The text now says that, and points
at `kata connector status` for health.

While comparing the regenerated screenshots against the live site, a
third stale claim surfaced: the web UI guide still described the issue
detail panel as directly editable. Since #247 the panel opens
read-only and editing happens behind "Edit issue"; the guide now
describes that flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)

<sup>generated by a clanker</sup>

