### PR TITLE
test: drive docs screenshots through the issue editor

### DIFF
--- a/web/tests/docs-screenshots.spec.ts
+++ b/web/tests/docs-screenshots.spec.ts
@@ -98,6 +98,7 @@ test('captures stable Web UI documentation states from synthetic issues', async 
   await page.evaluate(() => {
     document.documentElement.style.zoom = '0.875'
   })
+  await page.getByRole('button', { name: 'Edit issue' }).click()
   await page
     .getByRole('textbox', { name: 'Comment' })
     .fill('The synthetic release is ready for documentation review.')
@@ -110,6 +111,7 @@ test('captures stable Web UI documentation states from synthetic issues', async 
   await page.getByRole('textbox', { name: 'New checklist item' }).fill('Verify example build')
   await page.getByRole('textbox', { name: 'New checklist item' }).press('Enter')
   await expect(page.getByRole('checkbox', { name: 'Verify example build' })).toBeVisible()
+  await page.getByRole('button', { name: 'Done editing' }).click()
   await expect(page.getByRole('region', { name: 'Description' })).toContainText('Release checklist')
   await expect(page.getByRole('region', { name: 'Links' })).toContainText(
     /Document browser workflows|Verify example packages|Coordinate example announcement/,


### PR DESCRIPTION
Unblocks the 0.16.0 docs deployment. The docs screenshot spec still
filled the comment box directly on the issue detail pane, but since the
shared read-only issue detail landed (#247) the comment composer and
checklist actions only exist behind "Edit issue". The spec timed out
waiting for a Comment textbox that never renders. Nothing caught this
earlier because the spec is skipped unless the screenshot generator
sets `KATA_DOCS_SCREENSHOT_DIR`, so it runs only during docs deploys.

The spec now clicks "Edit issue" for the comment and checklist steps
and clicks "Done editing" before capturing `issue-detail.png`, so the
published screenshot shows the default read-only detail presentation
with the seeded comment and checklist visible. Verified by running
`docs/screenshots/generate-web-ui.sh` against a temporary output
directory; all four captures generate and the spec passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5)

<sup>generated by a clanker</sup>
