### PR TITLE
Allow identity tokens to administer connectors

### DIFF
--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-27
+last_edited: 2026-08-29
 ---
 
 # Remote daemon
@@ -223,6 +223,20 @@ In identity mode:
 - attributed writes require a DB-backed token;
 - the daemon derives the actor from the token and ignores body-provided actor
   strings for mutations.
+
+Connector administration is denied to database-backed tokens by default.
+Enable it only when every active identity token should administer connectors
+and external-root bridges across the daemon. Add this setting to the existing
+`[auth]` table:
+
+```toml
+allow_identity_connector_administration = true
+```
+
+The environment equivalent is
+`KATA_ALLOW_IDENTITY_CONNECTOR_ADMINISTRATION=1`. The identity-mode bootstrap
+token, browser sessions, and trusted-proxy principals still cannot administer
+connectors.
 
 The `kata federation enroll` CLI workflow also uses normal direct-client auth
 when it talks to the hub. Run it with a DB-backed personal token; the generated

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-27
+last_edited: 2026-08-29
 ---
 
 # CLI reference
@@ -519,8 +519,7 @@ kata connector field unmap <instance> <kata-field>
 `kata connector list` reports the configured instances, `status` shows one
 instance's safe status without credentials, and the `field` subcommands
 inspect and manage bidirectional field mappings. Kata planning-field mappings
-are limited to `scheduled_on` and `deadline_on`. Field mapping requires
-daemon-wide authority.
+are limited to `scheduled_on` and `deadline_on`.
 
 ```sh
 kata bridge bind <issue> --connector <instance> --external <locator> [--publish-comments]
@@ -532,6 +531,11 @@ kata bridge resolve-field <issue> <kata-field> --use kata|external
 kata bridge resolve-comment <issue> --adopt <external-comment-id> | --retry | --skip
 kata bridge unbind <issue>
 ```
+
+Every command in this section requires daemon-wide connector administration.
+In token identity mode, DB-backed tokens have this authority only when
+`allow_identity_connector_administration` is enabled; see the
+[configuration reference](configuration.md#token-identity-mode).
 
 `bind` attaches an issue to an existing external root that the connector
 resolves from `--external`. While a binding is active, the external root owns

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-27
+last_edited: 2026-08-29
 ---
 
 # Configuration
@@ -23,6 +23,7 @@ bindings, local per-machine overrides, and daemon config.
 | `KATA_AUTH_TOKEN` | Bearer token for daemon API auth. |
 | `KATA_TRUST_PRIVATE_NETWORK` | Set to `1` to permit trusted plaintext bearer use on private non-loopback HTTP. Without it (or `allow_insecure`), a plaintext non-loopback target fails when the client is built, before any request is sent. |
 | `KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES` | Set to `1` to permit tokenless writes and event streams on a literal private-IP daemon bind. |
+| `KATA_ALLOW_IDENTITY_CONNECTOR_ADMINISTRATION` | Set to `1` to let database-backed identity tokens administer connectors and external-root bridges. Off by default. |
 | `KATA_ALLOW_INSECURE` | Set to `1` or `true` to allow a configured remote daemon hostname over plain HTTP. Federation uses `kata federation enroll --allow-insecure` and `kata federation join --allow-insecure` instead because enrollment credentials are stored separately. |
 | `KATA_TELEMETRY_ENABLED` | Set to `0` to disable anonymous PostHog telemetry. |
 | `KATA_HTTP_TIMEOUT` | Timeout for configured-remote connectivity probes and non-streaming CLI requests, such as `30s` or `2m`. Defaults to `5s`; raise it for bulk imports. It also overrides the federation sync client's separate 60-second request budget. Larger values increase how long an unreachable remote can delay a command or sync attempt. |
@@ -502,6 +503,22 @@ Lost tokens must be revoked and recreated.
 In identity mode, the bootstrap/admin token can manage tokens and perform
 reads, but attributed writes require a DB-backed token. The daemon derives the
 actor from that token.
+
+Connector administration is off for DB-backed tokens by default. To grant it,
+add this setting to the same `[auth]` table:
+
+```toml
+allow_identity_connector_administration = true
+```
+
+Every active DB-backed token can then use all connector and external-root
+bridge routes across the daemon. For attributed mutations, the token actor
+overrides any `actor` in the request body.
+
+This setting changes only DB-backed token authority. The identity-mode
+bootstrap token, browser sessions, trusted-proxy principals, insecure read-only
+requests, and unauthenticated private-network requests still cannot administer
+connectors.
 
 ## Close throttle
 

--- a/internal/config/daemon_config.go
+++ b/internal/config/daemon_config.go
@@ -236,11 +236,14 @@ func NormalizeGitHubSyncConfig(cfg GitHubSyncConfig) (GitHubSyncConfig, error) {
 // KATA_TRUST_PRIVATE_NETWORK=1 is equivalent to trust_private_network = true.
 // KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES=1 is equivalent to
 // allow_unauthenticated_private_network_writes = true.
+// KATA_ALLOW_IDENTITY_CONNECTOR_ADMINISTRATION=1 is equivalent to
+// allow_identity_connector_administration = true.
 type AuthConfig struct {
 	Token                                    string      `toml:"token"`
 	TrustPrivateNetwork                      bool        `toml:"trust_private_network"`
 	AllowUnauthenticatedPrivateNetworkWrites bool        `toml:"allow_unauthenticated_private_network_writes"`
 	RequireTokenIdentity                     bool        `toml:"require_token_identity"`
+	AllowIdentityConnectorAdministration     bool        `toml:"allow_identity_connector_administration"`
 	Proxy                                    ProxyConfig `toml:"proxy"`
 }
 
@@ -707,6 +710,9 @@ func applyDaemonConfigEnv(cfg *DaemonConfig) {
 	}
 	if EnvTruthy("KATA_ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK_WRITES") {
 		cfg.Auth.AllowUnauthenticatedPrivateNetworkWrites = true
+	}
+	if EnvTruthy("KATA_ALLOW_IDENTITY_CONNECTOR_ADMINISTRATION") {
+		cfg.Auth.AllowIdentityConnectorAdministration = true
 	}
 	if v := strings.TrimSpace(os.Getenv("KATA_TRUSTED_ACTOR_HEADER")); v != "" {
 		cfg.Auth.Proxy.TrustedActorHeader = v

--- a/internal/config/daemon_config_test.go
+++ b/internal/config/daemon_config_test.go
@@ -1055,6 +1055,42 @@ func TestReadDaemonConfig_ReadsRequireTokenIdentity(t *testing.T) {
 	assert.True(t, cfg.Auth.RequireTokenIdentity)
 }
 
+func TestReadDaemonConfig_ReadsAllowIdentityConnectorAdministration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[auth]\nallow_identity_connector_administration = true\n"), 0o600))
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.True(t, cfg.Auth.AllowIdentityConnectorAdministration)
+}
+
+func TestReadDaemonConfig_AllowIdentityConnectorAdministrationDefaultsDisabled(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_ALLOW_IDENTITY_CONNECTOR_ADMINISTRATION", "")
+
+	cfg, err := config.ReadDaemonConfig()
+	require.NoError(t, err)
+	assert.False(t, cfg.Auth.AllowIdentityConnectorAdministration)
+}
+
+func TestReadDaemonConfig_AllowIdentityConnectorAdministrationEnvOverridesTOML(t *testing.T) {
+	for _, value := range []string{"1", "true"} {
+		t.Run(value, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("KATA_HOME", home)
+			t.Setenv("KATA_ALLOW_IDENTITY_CONNECTOR_ADMINISTRATION", value)
+			require.NoError(t, os.WriteFile(filepath.Join(home, "config.toml"),
+				[]byte("[auth]\nallow_identity_connector_administration = false\n"), 0o600))
+
+			cfg, err := config.ReadDaemonConfig()
+			require.NoError(t, err)
+			assert.True(t, cfg.Auth.AllowIdentityConnectorAdministration)
+		})
+	}
+}
+
 func TestReadDaemonConfig_AuthTrustPrivateNetworkEnvOverridesTOML(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)

--- a/internal/daemon/handlers_external_roots.go
+++ b/internal/daemon/handlers_external_roots.go
@@ -26,14 +26,14 @@ var externalRootOperationIDs = map[string]bool{
 	"resolveExternalComment": true, "unbindExternalRoot": true,
 }
 
-func withExternalRootAdministration(humaAPI huma.API) {
+func withExternalRootAdministration(humaAPI huma.API, allowIdentityConnectorAdministration bool) {
 	humaAPI.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
 		operation := ctx.Operation()
 		if operation == nil || !externalRootOperationIDs[operation.OperationID] {
 			next(ctx)
 			return
 		}
-		if err := ensureExternalRootAdministrationAllowed(ctx.Context()); err != nil {
+		if err := ensureExternalRootAdministrationAllowed(ctx.Context(), allowIdentityConnectorAdministration); err != nil {
 			writeHostAccessError(ctx, http.StatusForbidden, "integration_administration_forbidden", "connector administration is unavailable to this principal")
 			return
 		}
@@ -41,11 +41,14 @@ func withExternalRootAdministration(humaAPI huma.API) {
 	})
 }
 
-func ensureExternalRootAdministrationAllowed(ctx context.Context) error {
+func ensureExternalRootAdministrationAllowed(ctx context.Context, allowIdentityConnectorAdministration bool) error {
 	if webSessionAuthenticated(ctx) || insecureReadonlyRequest(ctx) || unauthenticatedPrivateNetworkRequest(ctx) {
 		return api.NewError(http.StatusForbidden, "integration_administration_forbidden", "connector administration is unavailable to this principal", "", nil)
 	}
 	if principal, ok := PrincipalFromContext(ctx); ok {
+		if principal.Kind == PrincipalDBToken && allowIdentityConnectorAdministration {
+			return nil
+		}
 		switch principal.Kind {
 		case PrincipalDBToken, PrincipalBootstrap, PrincipalTrustedProxy,
 			PrincipalTrustedProxyAbsent, PrincipalWebLocal:

--- a/internal/daemon/handlers_external_roots_functional_test.go
+++ b/internal/daemon/handlers_external_roots_functional_test.go
@@ -31,6 +31,99 @@ func testExternalRootCommand(t *testing.T) string {
 	return filepath.Join(t.TempDir(), "example-connector")
 }
 
+func TestExternalRootIdentityAdministrationRequiresOptIn(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		enabled bool
+		want    int
+	}{
+		{name: "default denied", want: http.StatusForbidden},
+		{name: "opted in", enabled: true, want: http.StatusOK},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			database := openTestDB(t)
+			_, _, err := database.db.CreateAPIToken(t.Context(), db.CreateAPITokenParams{
+				PlaintextToken: "identity-token", Actor: "operator", AdminActor: db.BootstrapActor,
+			})
+			require.NoError(t, err)
+			ts := startTestServer(t, daemon.ServerConfig{
+				DB: database.db,
+				Auth: config.AuthConfig{
+					Token: "bootstrap-token", RequireTokenIdentity: true,
+					AllowIdentityConnectorAdministration: test.enabled,
+				},
+			})
+
+			status, body := requestExternalRootJSONWithBearer(
+				t, ts.URL, http.MethodGet, "/api/v1/connectors", nil, "identity-token",
+			)
+			assert.Equal(t, test.want, status, string(body))
+			if !test.enabled {
+				assert.Contains(t, string(body), `"integration_administration_forbidden"`)
+			}
+		})
+	}
+}
+
+func TestExternalRootIdentityAdministrationUsesTokenActor(t *testing.T) {
+	database := openTestDB(t)
+	project, err := database.db.CreateProject(t.Context(), "example-project")
+	require.NoError(t, err)
+	issue, _, err := database.db.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: project.ID, Title: "Local title", Author: "tester",
+	})
+	require.NoError(t, err)
+	_, _, err = database.db.CreateAPIToken(t.Context(), db.CreateAPITokenParams{
+		PlaintextToken: "identity-token", Actor: "operator", AdminActor: db.BootstrapActor,
+	})
+	require.NoError(t, err)
+
+	now := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	client := &daemonExternalRootClient{
+		description: connector.Description{
+			ConnectorID: "example.connector", DisplayName: "Example connector",
+			Protocol: connector.ProtocolVersion, AccountIdentity: "account-1",
+		},
+		root: connector.Root{
+			Key: "root-1", IdentityKey: "account-1", Title: "External title",
+			State: "open", Revision: "revision-1", UpdatedAt: now, ObservedAt: now,
+		},
+	}
+	registry, err := rootbridge.NewRegistry(t.Context(), []config.ConnectorConfig{{
+		ID: "example-connector", Command: testExternalRootCommand(t),
+	}}, func(config.ConnectorConfig) connectorclient.Client { return client })
+	require.NoError(t, err)
+	reconciler := rootbridge.NewReconciler(database.db, registry, rootbridge.ReconcilerConfig{Now: func() time.Time { return now }})
+	service := rootbridge.NewService(database.db, registry,
+		func(ctx context.Context, bindingID int64, claimToken string) ([]db.Event, error) {
+			result, reconcileErr := reconciler.Run(ctx, bindingID, rootbridge.RunOptions{ClaimToken: claimToken})
+			return result.Events, reconcileErr
+		})
+	ts := startTestServer(t, daemon.ServerConfig{
+		DB: database.db, StartedAt: now, ExternalRootRegistry: registry,
+		ExternalRootService: service, ExternalRootReconciler: reconciler,
+		Auth: config.AuthConfig{
+			Token: "bootstrap-token", RequireTokenIdentity: true,
+			AllowIdentityConnectorAdministration: true,
+		},
+	})
+
+	bridgePath := fmt.Sprintf("/api/v1/projects/%d/issues/%s/bridge", project.ID, issue.ShortID)
+	status, body := requestExternalRootJSONWithBearer(t, ts.URL, http.MethodPost, bridgePath, map[string]any{
+		"connector": "example-connector", "external": "opaque-locator", "actor": "mallory",
+	}, "identity-token")
+	require.Equal(t, http.StatusOK, status, string(body))
+	events, err := database.db.EventsAfter(t.Context(), db.EventsAfterParams{ProjectID: project.ID, Limit: 100})
+	require.NoError(t, err)
+	for _, event := range events {
+		if event.Type == "issue.external_root_bound" {
+			assert.Equal(t, "operator", event.Actor)
+			return
+		}
+	}
+	t.Fatal("issue.external_root_bound event not found")
+}
+
 func TestExternalRootHandlersFullLifecycleAndDelivery(t *testing.T) {
 	database := openTestDB(t)
 	project, err := database.db.CreateProject(t.Context(), "example-project")
@@ -522,6 +615,10 @@ func TestExternalRootHandlersClassifyConnectorAndInternalFailures(t *testing.T) 
 }
 
 func requestExternalRootJSON(t *testing.T, baseURL, method, path string, body any) (int, []byte) {
+	return requestExternalRootJSONWithBearer(t, baseURL, method, path, body, "")
+}
+
+func requestExternalRootJSONWithBearer(t *testing.T, baseURL, method, path string, body any, bearer string) (int, []byte) {
 	t.Helper()
 	var reader io.Reader
 	if body != nil {
@@ -533,6 +630,9 @@ func requestExternalRootJSON(t *testing.T, baseURL, method, path string, body an
 	require.NoError(t, err)
 	if body != nil {
 		request.Header.Set("Content-Type", "application/json")
+	}
+	if bearer != "" {
+		request.Header.Set("Authorization", "Bearer "+bearer)
 	}
 	response, err := http.DefaultClient.Do(request)
 	require.NoError(t, err)

--- a/internal/daemon/handlers_external_roots_test.go
+++ b/internal/daemon/handlers_external_roots_test.go
@@ -95,33 +95,41 @@ func TestListConnectorsResponseDoesNotExposeExecutableConfiguration(t *testing.T
 	assert.NotContains(t, rr.Body.String(), "environment")
 }
 
-func TestExternalRootAdministrationRejectsBrowserAndReadonlyPrincipals(t *testing.T) {
-	for _, ctx := range []context.Context{
-		withWebSession(context.Background(), Principal{Kind: PrincipalWebLocal, Actor: "operator"}),
-		withWebSession(context.Background(), Principal{Kind: PrincipalDBToken, Actor: "operator", TokenID: 7}),
-		WithPrincipal(context.Background(), Principal{Kind: PrincipalWebLocal, Actor: "operator"}),
-		WithPrincipal(context.Background(), Principal{Kind: PrincipalDBToken, Actor: "operator", TokenID: 7}),
-		WithPrincipal(context.Background(), Principal{Kind: PrincipalBootstrap}),
-		WithPrincipal(context.Background(), Principal{Kind: PrincipalTrustedProxy, Actor: "operator"}),
-		WithPrincipal(context.Background(), Principal{Kind: PrincipalTrustedProxyAbsent}),
-		withInsecureReadonlyRequest(context.Background()),
-	} {
-		err := ensureExternalRootAdministrationAllowed(ctx)
-		require.Error(t, err)
-		var apiErr interface{ GetStatus() int }
-		if errors.As(err, &apiErr) {
-			assert.Equal(t, http.StatusForbidden, apiErr.GetStatus())
-		}
+func TestExternalRootAdministrationPolicy(t *testing.T) {
+	dbPrincipal := Principal{Kind: PrincipalDBToken, Actor: "operator", TokenID: 7}
+	tests := []struct {
+		name          string
+		ctx           context.Context
+		allowIdentity bool
+		wantAllowed   bool
+	}{
+		{name: "owner local", ctx: context.Background(), wantAllowed: true},
+		{name: "static token", ctx: WithPrincipal(context.Background(), Principal{Kind: PrincipalStaticToken}), wantAllowed: true},
+		{name: "host", ctx: WithPrincipal(context.Background(), Principal{Kind: PrincipalHost, Actor: "operator", Subject: "example-service"}), wantAllowed: true},
+		{name: "DB token default", ctx: WithPrincipal(context.Background(), dbPrincipal)},
+		{name: "DB token opted in", ctx: WithPrincipal(context.Background(), dbPrincipal), allowIdentity: true, wantAllowed: true},
+		{name: "bootstrap opted in", ctx: WithPrincipal(context.Background(), Principal{Kind: PrincipalBootstrap}), allowIdentity: true},
+		{name: "browser local opted in", ctx: withWebSession(context.Background(), Principal{Kind: PrincipalWebLocal, Actor: "operator"}), allowIdentity: true},
+		{name: "browser DB token opted in", ctx: withWebSession(context.Background(), dbPrincipal), allowIdentity: true},
+		{name: "web local principal opted in", ctx: WithPrincipal(context.Background(), Principal{Kind: PrincipalWebLocal, Actor: "operator"}), allowIdentity: true},
+		{name: "trusted proxy opted in", ctx: WithPrincipal(context.Background(), Principal{Kind: PrincipalTrustedProxy, Actor: "operator"}), allowIdentity: true},
+		{name: "missing proxy actor opted in", ctx: WithPrincipal(context.Background(), Principal{Kind: PrincipalTrustedProxyAbsent}), allowIdentity: true},
+		{name: "insecure readonly opted in", ctx: withInsecureReadonlyRequest(context.Background()), allowIdentity: true},
+		{name: "unauthenticated private network opted in", ctx: withUnauthenticatedPrivateNetworkRequest(context.Background()), allowIdentity: true},
 	}
-}
 
-func TestExternalRootAdministrationAllowsOwnerAndIntegrationPrincipals(t *testing.T) {
-	for _, ctx := range []context.Context{
-		context.Background(),
-		WithPrincipal(context.Background(), Principal{Kind: PrincipalStaticToken}),
-		WithPrincipal(context.Background(), Principal{Kind: PrincipalHost, Subject: "example-service"}),
-	} {
-		require.NoError(t, ensureExternalRootAdministrationAllowed(ctx))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ensureExternalRootAdministrationAllowed(test.ctx, test.allowIdentity)
+			if test.wantAllowed {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var apiErr interface{ GetStatus() int }
+			require.ErrorAs(t, err, &apiErr)
+			assert.Equal(t, http.StatusForbidden, apiErr.GetStatus())
+		})
 	}
 }
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -244,7 +244,7 @@ func NewServer(cfg ServerConfig) *Server {
 	humaAPI := huma.NewAPI(humaConfig, api.WrapErrorAdapter(humago.NewAdapter(mux, "")))
 	withEmbeddingProfile(humaAPI, cfg.EmbeddingProfile)
 	withHostAccess(humaAPI, cfg.HostAccess)
-	withExternalRootAdministration(humaAPI)
+	withExternalRootAdministration(humaAPI, cfg.Auth.AllowIdentityConnectorAdministration)
 
 	s := &Server{cfg: cfg, api: humaAPI}
 	registerRoutes(humaAPI, mux, cfg)


### PR DESCRIPTION
## What changed

- Added a default-off auth setting for database-backed identity tokens to administer connector and external bridge routes.
- Kept owner, static-token, browser, proxy, bootstrap, insecure read-only, and unauthenticated-private-network boundaries unchanged.
- Made the authenticated token actor authoritative when a request body also supplies an actor.

## Why

Hosted identity deployments can authenticate database-backed tokens for ordinary API operations, but they had no explicit way to grant those tokens connector administration. This adds that capability without widening the default trust boundary.

## Usage

Enable the setting alongside identity-backed token authentication:

```toml
[auth]
require_token_identity = true
allow_identity_connector_administration = true
```

The equivalent environment override is `KATA_ALLOW_IDENTITY_CONNECTOR_ADMINISTRATION=1`.

When enabled, every active database-backed identity token gains daemon-wide connector and external bridge administration. Browser-derived and unauthenticated principals remain denied.

Closes #324
