### PR TITLE
fix(ownership): add compare-and-swap guards

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -230,6 +230,8 @@ components:
           type: string
         force:
           type: boolean
+        if_unowned:
+          type: boolean
       required:
         - actor
       type: object
@@ -4587,6 +4589,8 @@ components:
       additionalProperties: false
       properties:
         actor:
+          type: string
+        expected_owner:
           type: string
       type: object
 info:

--- a/cmd/kata/assign.go
+++ b/cmd/kata/assign.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,7 @@ func newAssignCmd() *cobra.Command {
 		Short: "set the owner of an issue",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAssign(cmd, args[0], args[1], false)
+			return runAssign(cmd, args[0], args[1], false, nil)
 		},
 	}
 	addCommentFlag(cmd)
@@ -25,19 +26,31 @@ func newAssignCmd() *cobra.Command {
 }
 
 func newUnassignCmd() *cobra.Command {
+	var expectedOwner string
 	cmd := &cobra.Command{
 		Use:   "unassign <issue-ref>",
 		Short: "clear the owner of an issue",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAssign(cmd, args[0], "", true)
+			var expected *string
+			if cmd.Flags().Changed("expect-owner") {
+				trimmed := strings.TrimSpace(expectedOwner)
+				if trimmed == "" {
+					return &cliError{
+						Message: "--expect-owner must not be empty", Kind: kindValidation, ExitCode: ExitValidation,
+					}
+				}
+				expected = &trimmed
+			}
+			return runAssign(cmd, args[0], "", true, expected)
 		},
 	}
+	cmd.Flags().StringVar(&expectedOwner, "expect-owner", "", "clear ownership only if it matches this owner")
 	addCommentFlag(cmd)
 	return cmd
 }
 
-func runAssign(cmd *cobra.Command, raw, owner string, unassign bool) error {
+func runAssign(cmd *cobra.Command, raw, owner string, unassign bool, expectedOwner *string) error {
 	comment, err := commentFromFlag(cmd)
 	if err != nil {
 		return err
@@ -56,6 +69,9 @@ func runAssign(cmd *cobra.Command, raw, owner string, unassign bool) error {
 	if unassign {
 		action = "unassign"
 		body = map[string]any{"actor": actor}
+		if expectedOwner != nil {
+			body["expected_owner"] = *expectedOwner
+		}
 	}
 	postURL := fmt.Sprintf("%s/api/v1/projects/%d/issues/%s/actions/%s", baseURL, pid, url.PathEscape(issue.RefForAPI), action)
 	status, bs, err := httpDoJSON(ctx, client, http.MethodPost, postURL, body)

--- a/cmd/kata/assign_test.go
+++ b/cmd/kata/assign_test.go
@@ -59,3 +59,38 @@ func TestUnassign_WithComment_AppendsComment(t *testing.T) {
 	require.Len(t, got.Comments, 1)
 	assert.Equal(t, "rolling off", got.Comments[0].Body)
 }
+
+func TestUnassign_ExpectOwnerMatches(t *testing.T) {
+	env, dir, _, ref := setupWorkspaceWithIssue(t, "x")
+	runCLI(t, env, dir, "assign", ref, "agent-a")
+
+	out := runCLI(t, env, dir, "unassign", ref, "--expect-owner", "agent-a")
+
+	assert.Contains(t, out, "unassigned")
+}
+
+func TestUnassign_ExpectOwnerMismatchDoesNotAppendComment(t *testing.T) {
+	env, dir, pid, ref := setupWorkspaceWithIssue(t, "x")
+	runCLI(t, env, dir, "assign", ref, "agent-b")
+
+	_, err := runCLICapture(t, env, dir, "unassign", ref,
+		"--expect-owner", "agent-a", "--comment", "release if unchanged")
+
+	cliErr := requireCLIError(t, err, ExitConflict)
+	assert.Equal(t, "owner_mismatch", cliErr.Code)
+	got := fetchIssueViaHTTPWithComments(t, env, pid, ref)
+	assert.Empty(t, got.Comments)
+}
+
+func TestUnassign_BlankExpectOwnerIsValidationError(t *testing.T) {
+	for _, expected := range []string{"", "   "} {
+		t.Run("value="+expected, func(t *testing.T) {
+			env, dir, _, ref := setupWorkspaceWithIssue(t, "x")
+
+			_, err := runCLICapture(t, env, dir, "unassign", ref, "--expect-owner", expected)
+
+			cliErr := requireCLIError(t, err, ExitValidation)
+			assert.Contains(t, cliErr.Message, "--expect-owner")
+		})
+	}
+}

--- a/cmd/kata/claim.go
+++ b/cmd/kata/claim.go
@@ -12,21 +12,23 @@ import (
 )
 
 func newClaimCmd() *cobra.Command {
-	var force bool
+	var force, ifUnowned bool
 	cmd := &cobra.Command{
 		Use:   "claim <issue-ref>",
 		Short: "claim ownership of an issue",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runClaim(cmd, args[0], force)
+			return runClaim(cmd, args[0], force, ifUnowned)
 		},
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "force claim even if already owned by another actor")
+	cmd.Flags().BoolVar(&ifUnowned, "if-unowned", false, "claim only if the issue has no owner")
+	cmd.MarkFlagsMutuallyExclusive("force", "if-unowned")
 	addCommentFlag(cmd)
 	return cmd
 }
 
-func runClaim(cmd *cobra.Command, raw string, force bool) error {
+func runClaim(cmd *cobra.Command, raw string, force, ifUnowned bool) error {
 	comment, err := commentFromFlag(cmd)
 	if err != nil {
 		return err
@@ -41,6 +43,9 @@ func runClaim(cmd *cobra.Command, raw string, force bool) error {
 		return err
 	}
 	body := map[string]any{"actor": actor, "force": force}
+	if ifUnowned {
+		body["if_unowned"] = true
+	}
 	postURL := fmt.Sprintf("%s/api/v1/projects/%d/issues/%s/actions/claim", baseURL, pid, url.PathEscape(issue.RefForAPI))
 	status, bs, err := httpDoJSON(ctx, client, http.MethodPost, postURL, body)
 	if err != nil {

--- a/cmd/kata/claim_test.go
+++ b/cmd/kata/claim_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -52,6 +53,27 @@ func TestClaim_AlreadyClaimedBySameActor(t *testing.T) {
 	iss := mustGetIssueViaHTTP(t, env.URL, pid, issue.ShortID)
 	require.NotNil(t, iss.Owner)
 	assert.Equal(t, "agent1", *iss.Owner)
+}
+
+func TestClaim_IfUnownedRejectsSameActor(t *testing.T) {
+	env, dir := setupCLIEnv(t)
+	issue := createIssueViaHTTPFull(t, env, dir, "guarded claim")
+	runCLIAs(t, env, dir, "agent1", "claim", issue.ShortID)
+
+	_, err := runCLICapture(t, env, dir, "--as", "agent1", "claim", issue.ShortID, "--if-unowned")
+
+	cliErr := requireCLIError(t, err, ExitConflict)
+	assert.Contains(t, strings.ToLower(cliErr.Message), "already claimed")
+	assert.NotContains(t, cliErr.Message, "--force")
+}
+
+func TestClaim_ForceAndIfUnownedAreMutuallyExclusive(t *testing.T) {
+	_, _, err := executeRootCapture(t, context.Background(),
+		"claim", "abcd", "--force", "--if-unowned")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "if-unowned")
+	assert.Contains(t, err.Error(), "force")
 }
 
 func TestClaim_Conflict(t *testing.T) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -347,12 +347,20 @@ kata label rm <ref> <label> [--comment TEXT]
 kata labels
 
 kata assign <ref> <owner> [--comment TEXT]
-kata unassign <ref> [--comment TEXT]
-kata claim <ref> [--force] [--comment TEXT]
+kata unassign <ref> [--expect-owner <owner>] [--comment TEXT]
+kata claim <ref> [--force | --if-unowned] [--comment TEXT]
 ```
 
 `kata claim` atomically sets ownership to the current actor and fails if the
-issue is already owned by someone else unless `--force` is used.
+issue is already owned by someone else unless `--force` is used. A repeated
+claim by the current actor remains a no-op. Use `--if-unowned` when competing
+workers must claim only a truly ownerless issue; it conflicts even when the
+current actor already owns the issue.
+
+`kata unassign --expect-owner <owner>` clears ownership only when the current
+owner matches the expected value. A mismatch returns a conflict without
+changing the issue. Omitting `--expect-owner` preserves unconditional
+unassignment.
 
 ## Issue metadata
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1038,7 +1038,8 @@ type UnassignRequest struct {
 	ProjectID int64  `path:"project_id" required:"true"`
 	Ref       string `path:"ref" required:"true"`
 	Body      struct {
-		Actor string `json:"actor,omitempty"`
+		Actor         string  `json:"actor,omitempty"`
+		ExpectedOwner *string `json:"expected_owner,omitempty"`
 	}
 }
 
@@ -1047,8 +1048,9 @@ type ClaimRequest struct {
 	ProjectID int64  `path:"project_id" required:"true"`
 	Ref       string `path:"ref" required:"true"`
 	Body      struct {
-		Actor string `json:"actor" required:"true"`
-		Force bool   `json:"force,omitempty"`
+		Actor     string `json:"actor" required:"true"`
+		Force     bool   `json:"force,omitempty"`
+		IfUnowned bool   `json:"if_unowned,omitempty"`
 	}
 }
 

--- a/internal/daemon/handlers_ownership.go
+++ b/internal/daemon/handlers_ownership.go
@@ -59,6 +59,15 @@ func registerOwnershipHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
+		var expectedOwner *string
+		if in.Body.ExpectedOwner != nil {
+			expected := strings.TrimSpace(*in.Body.ExpectedOwner)
+			if expected == "" {
+				return nil, api.NewError(400, "validation",
+					"expected_owner must be non-empty when provided", "omit expected_owner for an unconditional unassign", nil)
+			}
+			expectedOwner = &expected
+		}
 		issue, err := activeIssueByRef(ctx, cfg.DB, in.ProjectID, in.Ref, db.IncludeDeletedNo)
 		if err != nil {
 			return nil, err
@@ -66,8 +75,18 @@ func registerOwnershipHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err := requireFederatedIssueClaim(ctx, cfg, in.ProjectID, issue, actor); err != nil {
 			return nil, err
 		}
-		updated, evt, changed, err := cfg.DB.UpdateOwner(ctx, issue.ID, nil, actor)
+		updated, evt, changed, err := cfg.DB.UnassignOwner(ctx, issue.ID, actor, expectedOwner)
 		if err != nil {
+			if errors.Is(err, db.ErrOwnerMismatch) {
+				var currentOwner any
+				if updated.Owner != nil {
+					currentOwner = *updated.Owner
+				}
+				return nil, api.NewError(409, "owner_mismatch",
+					"issue owner does not match expected owner",
+					"refresh issue state before retrying",
+					map[string]any{"expected_owner": *expectedOwner, "current_owner": currentOwner})
+			}
 			if apiErr := federationReadOnlyError(err); apiErr != nil {
 				return nil, apiErr
 			}
@@ -92,6 +111,10 @@ func registerOwnershipHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
+		if in.Body.Force && in.Body.IfUnowned {
+			return nil, api.NewError(400, "validation",
+				"force and if_unowned are mutually exclusive", "choose one claim mode", nil)
+		}
 		issue, err := activeIssueByRef(ctx, cfg.DB, in.ProjectID, in.Ref, db.IncludeDeletedNo)
 		if err != nil {
 			return nil, err
@@ -103,7 +126,11 @@ func registerOwnershipHandlers(humaAPI huma.API, cfg ServerConfig) {
 		var result db.ClaimResult
 		err = cfg.DB.RetryTransient(ctx, func() error {
 			var err error
-			result, err = cfg.DB.ClaimOwner(ctx, issue.ID, actor, in.Body.Force)
+			if in.Body.IfUnowned {
+				result, err = cfg.DB.ClaimOwnerIfUnowned(ctx, issue.ID, actor)
+			} else {
+				result, err = cfg.DB.ClaimOwner(ctx, issue.ID, actor, in.Body.Force)
+			}
 			return err
 		})
 		if errors.Is(err, db.ErrAlreadyClaimed) {
@@ -111,9 +138,13 @@ func registerOwnershipHandlers(humaAPI huma.API, cfg ServerConfig) {
 			if result.CurrentOwner != nil {
 				currentOwner = *result.CurrentOwner
 			}
+			hint := "use --force to reassign"
+			if in.Body.IfUnowned {
+				hint = "choose another issue, or omit if_unowned only for a deliberate retry"
+			}
 			return nil, api.NewError(409, "already_claimed",
 				fmt.Sprintf("issue is already claimed by %s", currentOwner),
-				"use --force to reassign",
+				hint,
 				map[string]any{"current_owner": currentOwner})
 		}
 		if err != nil {

--- a/internal/daemon/handlers_ownership_test.go
+++ b/internal/daemon/handlers_ownership_test.go
@@ -107,6 +107,61 @@ func TestUnassign_HappyPath(t *testing.T) {
 	assert.True(t, out.Changed)
 }
 
+func TestUnassign_ExpectedOwnerMatches(t *testing.T) {
+	env := testenv.New(t)
+	pid, n := setupOneIssue(t, env)
+	resp, _ := postAssign(t, env, pid, n, "tester", "agent-a")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, issuePath(pid, n, "actions/unassign"),
+		map[string]any{"actor": "tester", "expected_owner": "agent-a"}, nil)
+
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "body: %s", string(raw))
+	var out ownerResp
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.True(t, out.Changed)
+	assert.Nil(t, out.Issue.Owner)
+}
+
+func TestUnassign_ExpectedOwnerMismatch(t *testing.T) {
+	env := testenv.New(t)
+	pid, n := setupOneIssue(t, env)
+	resp, _ := postAssign(t, env, pid, n, "tester", "agent-b")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, issuePath(pid, n, "actions/unassign"),
+		map[string]any{"actor": "tester", "expected_owner": "agent-a"}, nil)
+
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	assert.Contains(t, string(raw), `"code":"owner_mismatch"`)
+	assert.Contains(t, string(raw), `"expected_owner":"agent-a"`)
+	assert.Contains(t, string(raw), `"current_owner":"agent-b"`)
+}
+
+func TestUnassign_ExpectedOwnerMismatchWhenUnowned(t *testing.T) {
+	env := testenv.New(t)
+	pid, n := setupOneIssue(t, env)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, issuePath(pid, n, "actions/unassign"),
+		map[string]any{"actor": "tester", "expected_owner": "agent-a"}, nil)
+
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	assert.Contains(t, string(raw), `"code":"owner_mismatch"`)
+	assert.Contains(t, string(raw), `"current_owner":null`)
+}
+
+func TestUnassign_BlankExpectedOwnerIs400(t *testing.T) {
+	for _, expected := range []string{"", "   "} {
+		t.Run("value="+expected, func(t *testing.T) {
+			env := testenv.New(t)
+			pid, n := setupOneIssue(t, env)
+			resp, _ := envDoRaw(t, env, http.MethodPost, issuePath(pid, n, "actions/unassign"),
+				map[string]any{"actor": "tester", "expected_owner": expected}, nil)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	}
+}
+
 func TestClaim_UnownedIssue(t *testing.T) {
 	env := testenv.New(t)
 	pid, n := setupOneIssue(t, env)
@@ -130,6 +185,55 @@ func TestClaim_AlreadyOwnedBySameActor(t *testing.T) {
 	assert.False(t, out.Changed)
 	assert.Nil(t, out.Event)
 	assert.Nil(t, out.PreviousOwner)
+}
+
+func TestClaim_IfUnownedClaimsUnownedIssue(t *testing.T) {
+	env := testenv.New(t)
+	pid, n := setupOneIssue(t, env)
+	resp, raw := envDoRaw(t, env, http.MethodPost, issuePath(pid, n, "actions/claim"),
+		map[string]any{"actor": "alice", "if_unowned": true}, nil)
+
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "body: %s", string(raw))
+	var out claimResp
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.True(t, out.Changed)
+	require.NotNil(t, out.Event)
+}
+
+func TestClaim_IfUnownedRejectsSameActorWithoutForceHint(t *testing.T) {
+	env := testenv.New(t)
+	pid, n := setupOneIssue(t, env)
+	resp, _ := postClaim(t, env, pid, n, "alice", false)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp, raw := envDoRaw(t, env, http.MethodPost, issuePath(pid, n, "actions/claim"),
+		map[string]any{"actor": "alice", "if_unowned": true}, nil)
+
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	assert.Contains(t, string(raw), `"code":"already_claimed"`)
+	assert.Contains(t, string(raw), `"current_owner":"alice"`)
+	assert.NotContains(t, string(raw), "--force")
+}
+
+func TestClaim_IfUnownedRejectsDifferentActor(t *testing.T) {
+	env := testenv.New(t)
+	pid, n := setupOneIssue(t, env)
+	resp, _ := postClaim(t, env, pid, n, "alice", false)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp, _ = envDoRaw(t, env, http.MethodPost, issuePath(pid, n, "actions/claim"),
+		map[string]any{"actor": "bob", "if_unowned": true}, nil)
+
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+}
+
+func TestClaim_ForceAndIfUnownedIs400(t *testing.T) {
+	env := testenv.New(t)
+	pid, n := setupOneIssue(t, env)
+	resp, _ := envDoRaw(t, env, http.MethodPost, issuePath(pid, n, "actions/claim"),
+		map[string]any{"actor": "alice", "force": true, "if_unowned": true}, nil)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestClaim_AlreadyOwnedByDifferentActor(t *testing.T) {

--- a/internal/db/dbtest/conformance.go
+++ b/internal/db/dbtest/conformance.go
@@ -131,6 +131,21 @@ var storageScenarios = []scenario{
 		run:     checkConcurrentOwnerClaim,
 	},
 	{
+		name:    "concurrent guarded owner claim",
+		methods: []string{"ClaimOwnerIfUnowned", "CreateIssue", "CreateProject", "IssueByID"},
+		run:     checkConcurrentGuardedOwnerClaim,
+	},
+	{
+		name:    "expected owner unassign",
+		methods: []string{"CreateIssue", "CreateProject", "UnassignOwner"},
+		run:     checkExpectedOwnerUnassign,
+	},
+	{
+		name:    "concurrent expected owner unassign",
+		methods: []string{"CreateIssue", "CreateProject", "IssueByID", "UnassignOwner", "UpdateOwner"},
+		run:     checkConcurrentExpectedOwnerUnassign,
+	},
+	{
 		name: "comments",
 		methods: []string{
 			"CommentBodyByID", "CommentsByIssue", "CreateComment", "CreateIssue", "CreateProject",

--- a/internal/db/dbtest/conformance_core.go
+++ b/internal/db/dbtest/conformance_core.go
@@ -1026,3 +1026,136 @@ func checkConcurrentOwnerClaim(t *testing.T, store db.Storage) error {
 	assert.Equal(t, 1, conflicts)
 	return nil
 }
+
+func checkConcurrentGuardedOwnerClaim(t *testing.T, store db.Storage) error {
+	t.Helper()
+	ctx := context.Background()
+	project, err := store.CreateProject(ctx, "concurrent-guarded-owner-project")
+	if err != nil {
+		return fmt.Errorf("create project: %w", err)
+	}
+	issue, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "guarded claim once", Author: "conformance-agent",
+	})
+	if err != nil {
+		return fmt.Errorf("create issue: %w", err)
+	}
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, err := store.ClaimOwnerIfUnowned(ctx, issue.ID, "shared-agent")
+			results <- err
+		}()
+	}
+	close(start)
+	var success, conflicts int
+	for range 2 {
+		err := <-results
+		switch {
+		case err == nil:
+			success++
+		case errors.Is(err, db.ErrAlreadyClaimed):
+			conflicts++
+		default:
+			return fmt.Errorf("concurrent guarded owner claim: %w", err)
+		}
+	}
+	assert.Equal(t, 1, success)
+	assert.Equal(t, 1, conflicts)
+	claimed, err := store.IssueByID(ctx, issue.ID)
+	if err != nil {
+		return fmt.Errorf("load claimed issue: %w", err)
+	}
+	require.NotNil(t, claimed.Owner)
+	assert.Equal(t, "shared-agent", *claimed.Owner)
+	return nil
+}
+
+func checkExpectedOwnerUnassign(t *testing.T, store db.Storage) error {
+	t.Helper()
+	ctx := context.Background()
+	project, err := store.CreateProject(ctx, "expected-owner-project")
+	if err != nil {
+		return fmt.Errorf("create project: %w", err)
+	}
+	owner := "agent-a"
+	issue, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "release expected owner", Author: "conformance-agent", Owner: &owner,
+	})
+	if err != nil {
+		return fmt.Errorf("create issue: %w", err)
+	}
+
+	updated, event, changed, err := store.UnassignOwner(ctx, issue.ID, "conformance-agent", &owner)
+	if err != nil {
+		return fmt.Errorf("matching expected owner: %w", err)
+	}
+	assert.Nil(t, updated.Owner)
+	assert.True(t, changed)
+	require.NotNil(t, event)
+
+	owner = "agent-b"
+	issue, _, err = store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "preserve replacement owner", Author: "conformance-agent", Owner: &owner,
+	})
+	if err != nil {
+		return fmt.Errorf("create replacement issue: %w", err)
+	}
+	expected := "agent-a"
+	current, event, changed, err := store.UnassignOwner(ctx, issue.ID, "conformance-agent", &expected)
+	if !errors.Is(err, db.ErrOwnerMismatch) {
+		return fmt.Errorf("mismatched expected owner: %w", err)
+	}
+	require.NotNil(t, current.Owner)
+	assert.Equal(t, "agent-b", *current.Owner)
+	assert.False(t, changed)
+	assert.Nil(t, event)
+	return nil
+}
+
+func checkConcurrentExpectedOwnerUnassign(t *testing.T, store db.Storage) error {
+	t.Helper()
+	ctx := context.Background()
+	project, err := store.CreateProject(ctx, "concurrent-expected-owner-project")
+	if err != nil {
+		return fmt.Errorf("create project: %w", err)
+	}
+	ownerA := "agent-a"
+	issue, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "preserve concurrent replacement", Author: "conformance-agent", Owner: &ownerA,
+	})
+	if err != nil {
+		return fmt.Errorf("create issue: %w", err)
+	}
+	ownerB := "agent-b"
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	go func() {
+		<-start
+		_, _, _, err := store.UnassignOwner(ctx, issue.ID, "conformance-agent", &ownerA)
+		if errors.Is(err, db.ErrOwnerMismatch) {
+			err = nil
+		}
+		results <- err
+	}()
+	go func() {
+		<-start
+		_, _, _, err := store.UpdateOwner(ctx, issue.ID, &ownerB, "conformance-agent")
+		results <- err
+	}()
+	close(start)
+	for range 2 {
+		if err := <-results; err != nil {
+			return fmt.Errorf("concurrent expected-owner unassign: %w", err)
+		}
+	}
+	current, err := store.IssueByID(ctx, issue.ID)
+	if err != nil {
+		return fmt.Errorf("load concurrently assigned issue: %w", err)
+	}
+	require.NotNil(t, current.Owner)
+	assert.Equal(t, ownerB, *current.Owner)
+	return nil
+}

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -35,6 +35,10 @@ var (
 	// ErrAlreadyClaimed is returned by ClaimOwner when another actor already
 	// owns the issue and Force=false.
 	ErrAlreadyClaimed = errors.New("already claimed")
+
+	// ErrOwnerMismatch is returned by guarded unassign when the current owner
+	// does not match the caller's expected owner.
+	ErrOwnerMismatch = errors.New("owner mismatch")
 )
 
 // EditIssueAtomic sentinels.

--- a/internal/db/pgstore/issue_lifecycle.go
+++ b/internal/db/pgstore/issue_lifecycle.go
@@ -91,7 +91,20 @@ func (s *Store) EditIssue(ctx context.Context, params db.EditIssueParams) (db.Is
 
 // UpdateOwner changes assignment state, treating an equal value as a no-op.
 func (s *Store) UpdateOwner(ctx context.Context, issueID int64, owner *string, actor string) (db.Issue, *db.Event, bool, error) {
+	return s.updateOwner(ctx, issueID, owner, actor, nil)
+}
+
+// UnassignOwner clears ownership only when expectedOwner is nil or matches the
+// current owner. A mismatch returns the current issue without an event.
+func (s *Store) UnassignOwner(ctx context.Context, issueID int64, actor string, expectedOwner *string) (db.Issue, *db.Event, bool, error) {
+	return s.updateOwner(ctx, issueID, nil, actor, expectedOwner)
+}
+
+func (s *Store) updateOwner(ctx context.Context, issueID int64, owner *string, actor string, expectedOwner *string) (db.Issue, *db.Event, bool, error) {
 	return s.updateIssueAttribute(ctx, issueID, actor, func(current db.Issue, updatedAt string) (string, any, string, string, bool, error) {
+		if expectedOwner != nil && !equalStringPointers(current.Owner, expectedOwner) {
+			return "", nil, "", "", false, db.ErrOwnerMismatch
+		}
 		if equalStringPointers(current.Owner, owner) {
 			return "", nil, "", "", false, nil
 		}
@@ -149,6 +162,7 @@ func (s *Store) updateIssueAttribute(
 		if err != nil {
 			return err
 		}
+		issue = current
 		updatedAt := mutationTimestamp()
 		column, value, eventType, payload, shouldChange, err := plan(current, updatedAt)
 		if err != nil {
@@ -183,6 +197,16 @@ func (s *Store) updateIssueAttribute(
 
 // ClaimOwner atomically assigns an unowned issue or force-replaces its owner.
 func (s *Store) ClaimOwner(ctx context.Context, issueID int64, actor string, force bool) (db.ClaimResult, error) {
+	return s.claimOwner(ctx, issueID, actor, force, false)
+}
+
+// ClaimOwnerIfUnowned claims only when no owner is set, including when the
+// current owner has the same actor identity.
+func (s *Store) ClaimOwnerIfUnowned(ctx context.Context, issueID int64, actor string) (db.ClaimResult, error) {
+	return s.claimOwner(ctx, issueID, actor, false, true)
+}
+
+func (s *Store) claimOwner(ctx context.Context, issueID int64, actor string, force, ifUnowned bool) (db.ClaimResult, error) {
 	actor = strings.TrimSpace(actor)
 	var result db.ClaimResult
 	err := s.withSerializableTx(ctx, func(tx *sql.Tx) error {
@@ -190,6 +214,10 @@ func (s *Store) ClaimOwner(ctx context.Context, issueID int64, actor string, for
 		current, project, err := lockedIssueTx(ctx, tx, issueID, false)
 		if err != nil {
 			return err
+		}
+		if ifUnowned && current.Owner != nil {
+			result.CurrentOwner = current.Owner
+			return db.ErrAlreadyClaimed
 		}
 		if current.Owner != nil && *current.Owner == actor {
 			result.Issue = current

--- a/internal/db/pgstore/stubgen/main.go
+++ b/internal/db/pgstore/stubgen/main.go
@@ -97,6 +97,7 @@ var alreadyImplemented = map[string]bool{
 	"ClaimIssueSyncBinding":                true, // issue_sync.go
 	"ClaimExternalRootBinding":             true, // external_roots.go
 	"ClaimOwner":                           true, // issue_lifecycle.go
+	"ClaimOwnerIfUnowned":                  true, // issue_lifecycle.go
 	"ClaimStatus":                          true, // claims_core.go
 	"ClaimStatusReadOnly":                  true, // claims_core.go
 	"ClaimStatusRefreshError":              true, // claims_pending.go
@@ -282,6 +283,7 @@ var alreadyImplemented = map[string]bool{
 	"UnresolvedClaimViolationsForIssue":    true, // claim_violations.go
 	"UnresolvedClaimViolationsForProject":  true, // claim_violations.go
 	"UpdateOwner":                          true, // issue_lifecycle.go
+	"UnassignOwner":                        true, // issue_lifecycle.go
 	"UpdatePriority":                       true, // issue_lifecycle.go
 	"UpsertClaimCache":                     true, // claims_pending.go
 	"UpsertImportMapping":                  true, // import_mappings.go

--- a/internal/db/pgstore/stubgen/main_test.go
+++ b/internal/db/pgstore/stubgen/main_test.go
@@ -38,7 +38,7 @@ type Storage interface { Only(context.Context) error }
 func TestStorageMethodInventoryClassifiesEveryMethod(t *testing.T) {
 	methods, err := CollectStorageMethodInventory("../../storage.go")
 	require.NoError(t, err)
-	require.Len(t, methods, 247)
+	require.Len(t, methods, 249)
 
 	var implemented []string
 	var stubbed []string
@@ -79,6 +79,7 @@ func TestStorageMethodInventoryClassifiesEveryMethod(t *testing.T) {
 		"ClaimExternalRootBindingForManualReconcile",
 		"ClaimIssueSyncBinding",
 		"ClaimOwner",
+		"ClaimOwnerIfUnowned",
 		"ClaimStatus",
 		"ClaimStatusReadOnly",
 		"ClaimStatusRefreshError",
@@ -289,6 +290,7 @@ func TestStorageMethodInventoryClassifiesEveryMethod(t *testing.T) {
 		"SoftDeleteIssue",
 		"SoftDeleteRecurrence",
 		"SystemProject",
+		"UnassignOwner",
 		"UnbindExternalRootBinding",
 		"UnmapExternalField",
 		"UnresolvedClaimViolationsForIssue",

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -1912,11 +1912,19 @@ type eventInsert struct {
 // new value matches the current value (returns nil event, changed=false).
 func (d *Store) UpdateOwner(ctx context.Context, issueID int64, newOwner *string, actor string) (db.Issue, *db.Event, bool, error) {
 	return retryWrite3(ctx, d, func() (db.Issue, *db.Event, bool, error) {
-		return d.updateOwner(ctx, issueID, newOwner, actor)
+		return d.updateOwner(ctx, issueID, newOwner, actor, nil)
 	})
 }
 
-func (d *Store) updateOwner(ctx context.Context, issueID int64, newOwner *string, actor string) (db.Issue, *db.Event, bool, error) {
+// UnassignOwner clears ownership only when expectedOwner is nil or matches the
+// current owner. A mismatch returns the current issue without an event.
+func (d *Store) UnassignOwner(ctx context.Context, issueID int64, actor string, expectedOwner *string) (db.Issue, *db.Event, bool, error) {
+	return retryWrite3(ctx, d, func() (db.Issue, *db.Event, bool, error) {
+		return d.updateOwner(ctx, issueID, nil, actor, expectedOwner)
+	})
+}
+
+func (d *Store) updateOwner(ctx context.Context, issueID int64, newOwner *string, actor string, expectedOwner *string) (db.Issue, *db.Event, bool, error) {
 	tx, err := d.BeginTx(ctx, nil)
 	if err != nil {
 		return db.Issue{}, nil, false, err
@@ -1926,6 +1934,9 @@ func (d *Store) updateOwner(ctx context.Context, issueID int64, newOwner *string
 	issue, projectName, err := lookupIssueForEvent(ctx, tx, issueID)
 	if err != nil {
 		return db.Issue{}, nil, false, err
+	}
+	if expectedOwner != nil && !ownerEqual(issue.Owner, expectedOwner) {
+		return issue, nil, false, db.ErrOwnerMismatch
 	}
 	// No-op: same owner.
 	if ownerEqual(issue.Owner, newOwner) {
@@ -1998,11 +2009,19 @@ func ownerEqual(a, b *string) bool {
 // and force is false. The ClaimResult.CurrentOwner field is set in this case.
 func (d *Store) ClaimOwner(ctx context.Context, issueID int64, actor string, force bool) (db.ClaimResult, error) {
 	return retryWrite1(ctx, d, func() (db.ClaimResult, error) {
-		return d.claimOwner(ctx, issueID, actor, force)
+		return d.claimOwner(ctx, issueID, actor, force, false)
 	})
 }
 
-func (d *Store) claimOwner(ctx context.Context, issueID int64, actor string, force bool) (db.ClaimResult, error) {
+// ClaimOwnerIfUnowned claims only when no owner is set, including when the
+// current owner has the same actor identity.
+func (d *Store) ClaimOwnerIfUnowned(ctx context.Context, issueID int64, actor string) (db.ClaimResult, error) {
+	return retryWrite1(ctx, d, func() (db.ClaimResult, error) {
+		return d.claimOwner(ctx, issueID, actor, false, true)
+	})
+}
+
+func (d *Store) claimOwner(ctx context.Context, issueID int64, actor string, force, ifUnowned bool) (db.ClaimResult, error) {
 	actor = strings.TrimSpace(actor)
 	tx, err := d.BeginTx(ctx, nil)
 	if err != nil {
@@ -2014,6 +2033,10 @@ func (d *Store) claimOwner(ctx context.Context, issueID int64, actor string, for
 	issue, projectName, err := lookupIssueForEvent(ctx, tx, issueID)
 	if err != nil {
 		return db.ClaimResult{}, err
+	}
+
+	if ifUnowned && issue.Owner != nil {
+		return db.ClaimResult{CurrentOwner: issue.Owner}, db.ErrAlreadyClaimed
 	}
 
 	// Already owned by same actor: no-op
@@ -2047,6 +2070,12 @@ func (d *Store) claimOwner(ctx context.Context, issueID int64, actor string, for
 			 SET owner      = ?,
 			     updated_at = ?
 			 WHERE id = ? AND deleted_at IS NULL`, actor, ts, issueID)
+	} else if ifUnowned {
+		res, err = tx.ExecContext(ctx,
+			`UPDATE issues
+			 SET owner      = ?,
+			     updated_at = ?
+			 WHERE id = ? AND deleted_at IS NULL AND owner IS NULL`, actor, ts, issueID)
 	} else {
 		res, err = tx.ExecContext(ctx,
 			`UPDATE issues

--- a/internal/db/sqlitestore/queries_owner_test.go
+++ b/internal/db/sqlitestore/queries_owner_test.go
@@ -63,6 +63,44 @@ func TestUpdateOwner_NoOpAlreadyUnassigned(t *testing.T) {
 	assert.Nil(t, evt)
 }
 
+func TestUnassignOwner_ExpectedOwnerMatches(t *testing.T) {
+	d, ctx, _, i := setupAssignedIssue(t, "agent-a")
+	expected := "agent-a"
+
+	updated, evt, changed, err := d.UnassignOwner(ctx, i.ID, "tester", &expected)
+
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Nil(t, updated.Owner)
+	require.NotNil(t, evt)
+	assert.Equal(t, "issue.unassigned", evt.Type)
+}
+
+func TestUnassignOwner_ExpectedOwnerMismatch(t *testing.T) {
+	d, ctx, _, i := setupAssignedIssue(t, "agent-b")
+	expected := "agent-a"
+
+	current, evt, changed, err := d.UnassignOwner(ctx, i.ID, "tester", &expected)
+
+	require.ErrorIs(t, err, db.ErrOwnerMismatch)
+	require.NotNil(t, current.Owner)
+	assert.Equal(t, "agent-b", *current.Owner)
+	assert.False(t, changed)
+	assert.Nil(t, evt)
+}
+
+func TestUnassignOwner_ExpectedOwnerMismatchWhenUnowned(t *testing.T) {
+	d, ctx, _, i := setupTestIssue(t)
+	expected := "agent-a"
+
+	current, evt, changed, err := d.UnassignOwner(ctx, i.ID, "tester", &expected)
+
+	require.ErrorIs(t, err, db.ErrOwnerMismatch)
+	assert.Nil(t, current.Owner)
+	assert.False(t, changed)
+	assert.Nil(t, evt)
+}
+
 // Regression: %q-encoded payloads produced invalid JSON for owner strings
 // containing control bytes (e.g. NUL), tripping the events.payload
 // json_valid CHECK and rolling back the assignment. Now built via
@@ -109,6 +147,18 @@ func TestClaimOwner_AlreadyOwnedBySameActor(t *testing.T) {
 	assert.Nil(t, result.Event)
 	require.NotNil(t, result.Issue.Owner)
 	assert.Equal(t, "agent1", *result.Issue.Owner)
+}
+
+func TestClaimOwnerIfUnowned_AlreadyOwnedBySameActor(t *testing.T) {
+	d, ctx, _, i := setupAssignedIssue(t, "agent1")
+
+	result, err := d.ClaimOwnerIfUnowned(ctx, i.ID, "agent1")
+
+	require.ErrorIs(t, err, db.ErrAlreadyClaimed)
+	require.NotNil(t, result.CurrentOwner)
+	assert.Equal(t, "agent1", *result.CurrentOwner)
+	assert.False(t, result.Changed)
+	assert.Nil(t, result.Event)
 }
 
 func TestClaimOwner_AlreadyOwnedByDifferentActor(t *testing.T) {

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -86,7 +86,9 @@ type Storage interface {
 	// projects; ErrNotFound if the project does not exist.
 	PurgeProject(ctx context.Context, p PurgeProjectParams) (ProjectPurgeLog, error)
 	ClaimOwner(ctx context.Context, issueID int64, actor string, force bool) (ClaimResult, error)
+	ClaimOwnerIfUnowned(ctx context.Context, issueID int64, actor string) (ClaimResult, error)
 	UpdateOwner(ctx context.Context, issueID int64, newOwner *string, actor string) (Issue, *Event, bool, error)
+	UnassignOwner(ctx context.Context, issueID int64, actor string, expectedOwner *string) (Issue, *Event, bool, error)
 	UpdatePriority(ctx context.Context, issueID int64, newPriority *int64, actor string) (Issue, *Event, bool, error)
 	PatchIssueMetadata(ctx context.Context, in PatchIssueMetadataIn) (PatchIssueMetadataOut, error)
 	IssueQualifiersByUIDs(ctx context.Context, uids []string) (map[string]IssueQualifier, error)

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -370,8 +370,9 @@ func (c ClaimPrincipalOut) Validate() error {
 }
 
 type ClaimRequestBody struct {
-	Actor string `json:"actor" validate:"required"`
-	Force *bool  `json:"force,omitempty"`
+	Actor     string `json:"actor" validate:"required"`
+	Force     *bool  `json:"force,omitempty"`
+	IfUnowned *bool  `json:"if_unowned,omitempty"`
 }
 
 func (c ClaimRequestBody) Validate() error {
@@ -4268,5 +4269,6 @@ func (u UISnapshotResponseBody) Validate() error {
 }
 
 type UnassignRequestBody struct {
-	Actor *string `json:"actor,omitempty"`
+	Actor         *string `json:"actor,omitempty"`
+	ExpectedOwner *string `json:"expected_owner,omitempty"`
 }

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -219,6 +219,8 @@ components:
           type: string
         force:
           type: boolean
+        if_unowned:
+          type: boolean
       required:
         - actor
       type: object
@@ -4355,6 +4357,8 @@ components:
       additionalProperties: false
       properties:
         actor:
+          type: string
+        expected_owner:
           type: string
       type: object
 info:

--- a/web/src/lib/api/schema.d.ts
+++ b/web/src/lib/api/schema.d.ts
@@ -1540,6 +1540,7 @@ export interface components {
     ClaimRequestBody: {
       actor: string
       force?: boolean
+      if_unowned?: boolean
     }
     ClaimResponseBody: {
       changed: boolean
@@ -3532,6 +3533,7 @@ export interface components {
     }
     UnassignRequestBody: {
       actor?: string
+      expected_owner?: string
     }
   }
   responses: never


### PR DESCRIPTION
## What changed

- Added `kata claim --if-unowned` for an atomic claim that conflicts whenever an issue already has an owner, including the same actor.
- Added `kata unassign --expect-owner <owner>` for an atomic compare-and-swap release.
- Implemented both guards in SQLite and PostgreSQL, exposed them through the API and generated clients, and kept the existing unguarded behavior compatible.

## Why

Separate sessions can share one actor name. A same-actor re-claim therefore cannot tell a retry from a sibling session taking the same work, and a read followed by an unconditional unassign leaves a race with reassignment. These guards let clients close both windows in one storage transaction.

## Usage

```sh
kata claim spoke-project#abc4 --if-unowned
kata unassign spoke-project#abc4 --expect-owner worker-a
```

`--if-unowned` is mutually exclusive with `--force`. An expected-owner mismatch returns a conflict without changing ownership.

Closes #328
