### PR TITLE
fix(create): bound look-alike checks and clarify outcomes

### DIFF
--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -172,7 +173,7 @@ func newCreateCmd() *cobra.Command {
 			fmt.Sprintf("%s/api/v1/projects/%d/issues", baseURL, projectID),
 			headers, req)
 		if err != nil {
-			return err
+			return createRequestError(err, forceNew)
 		}
 		if status >= 400 {
 			return apiErrFromBody(status, bs)
@@ -188,6 +189,40 @@ func newCreateCmd() *cobra.Command {
 		return printMutationWithApplied(cmd, bs, applied, projectName)
 	}
 	return cmd
+}
+
+func createRequestError(err error, forceNew bool) error {
+	if err == nil {
+		return err
+	}
+	reason := ""
+	switch {
+	case requestTimedOut(err):
+		reason = "request timed out"
+	case errors.Is(err, context.Canceled):
+		reason = "request canceled before the response arrived"
+	default:
+		return err
+	}
+	message := "create outcome unknown: " + reason +
+		"; check whether the issue was created before retrying"
+	if !forceNew {
+		message += "; use --force-new only after confirming no issue exists"
+	}
+	return &cliError{
+		Message:  message,
+		Kind:     kindInternal,
+		Code:     "create_outcome_unknown",
+		ExitCode: ExitInternal,
+	}
+}
+
+func requestTimedOut(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 // initialLinksAsChanges builds a synthetic mutationChanges from the

--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -222,7 +222,10 @@ func requestTimedOut(err error) bool {
 		return true
 	}
 	var netErr net.Error
-	return errors.As(err, &netErr) && netErr.Timeout()
+	if !errors.As(err, &netErr) || netErr == nil {
+		return false
+	}
+	return netErr.Timeout()
 }
 
 // initialLinksAsChanges builds a synthetic mutationChanges from the

--- a/cmd/kata/create_test.go
+++ b/cmd/kata/create_test.go
@@ -3,13 +3,17 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +21,156 @@ import (
 	"go.kenn.io/kata/internal/testenv"
 	"go.kenn.io/kata/internal/testfix"
 )
+
+func TestCreateRequestError(t *testing.T) {
+	timeoutErr := &url.Error{
+		Op:  http.MethodPost,
+		URL: "https://daemon.example/api/v1/projects/7/issues",
+		Err: context.DeadlineExceeded,
+	}
+
+	got := createRequestError(timeoutErr, false)
+	var cliErr *cliError
+	require.ErrorAs(t, got, &cliErr)
+	assert.Equal(t, kindInternal, cliErr.Kind)
+	assert.Equal(t, "create_outcome_unknown", cliErr.Code)
+	assert.Equal(t, ExitInternal, cliErr.ExitCode)
+	assert.Contains(t, cliErr.Message, "timed out")
+	assert.Contains(t, cliErr.Message, "check whether the issue was created")
+	assert.Contains(t, cliErr.Message, "--force-new")
+	assert.NotContains(t, cliErr.Message, "daemon.example")
+
+	forceGot := createRequestError(timeoutErr, true)
+	var forceErr *cliError
+	require.ErrorAs(t, forceGot, &forceErr)
+	assert.Equal(t, "create_outcome_unknown", forceErr.Code)
+	assert.Contains(t, forceErr.Message, "check whether the issue was created")
+	assert.NotContains(t, forceErr.Message, "--force-new")
+	assert.NotContains(t, forceErr.Message, "daemon.example")
+
+	clientTimeoutErr := &url.Error{
+		Op:  http.MethodPost,
+		URL: "https://daemon.example/api/v1/projects/7/issues",
+		Err: &net.DNSError{IsTimeout: true},
+	}
+	clientTimeoutGot := createRequestError(clientTimeoutErr, false)
+	var clientTimeoutCLIError *cliError
+	require.ErrorAs(t, clientTimeoutGot, &clientTimeoutCLIError)
+	assert.Equal(t, "create_outcome_unknown", clientTimeoutCLIError.Code)
+	assert.Contains(t, clientTimeoutCLIError.Message, "check whether the issue was created")
+	assert.NotContains(t, clientTimeoutCLIError.Message, "daemon.example")
+
+	otherErr := errors.New("connection refused")
+	assert.Same(t, otherErr, createRequestError(otherErr, false))
+}
+
+func TestCreateRequestErrorCanceled(t *testing.T) {
+	canceledErr := &url.Error{
+		Op:  http.MethodPost,
+		URL: "https://daemon.example/api/v1/projects/7/issues",
+		Err: context.Canceled,
+	}
+
+	got := createRequestError(canceledErr, false)
+	var cliErr *cliError
+	require.ErrorAs(t, got, &cliErr)
+	assert.Equal(t, kindInternal, cliErr.Kind)
+	assert.Equal(t, "create_outcome_unknown", cliErr.Code)
+	assert.Equal(t, ExitInternal, cliErr.ExitCode)
+	assert.Contains(t, cliErr.Message, "canceled")
+	assert.Contains(t, cliErr.Message, "check whether the issue was created")
+	assert.Contains(t, cliErr.Message, "--force-new")
+	assert.NotContains(t, cliErr.Message, "timed out")
+	assert.NotContains(t, cliErr.Message, "daemon.example")
+
+	forceGot := createRequestError(canceledErr, true)
+	var forceErr *cliError
+	require.ErrorAs(t, forceGot, &forceErr)
+	assert.Equal(t, "create_outcome_unknown", forceErr.Code)
+	assert.Contains(t, forceErr.Message, "canceled")
+	assert.Contains(t, forceErr.Message, "check whether the issue was created")
+	assert.NotContains(t, forceErr.Message, "--force-new")
+	assert.NotContains(t, forceErr.Message, "timed out")
+	assert.NotContains(t, forceErr.Message, "daemon.example")
+}
+
+func TestCreateCanceledClassificationAtCommandBoundary(t *testing.T) {
+	createHit := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects/resolve":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"project":{"id":7,"name":"example-project"}}`)
+		case "/api/v1/projects/7/issues":
+			select {
+			case createHit <- struct{}{}:
+			default:
+			}
+			select {
+			case <-r.Context().Done():
+			case <-time.After(500 * time.Millisecond):
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(contextWithBaseURL(context.Background(), server.URL))
+	t.Cleanup(cancel)
+	go func() {
+		<-createHit
+		cancel()
+	}()
+
+	_, _, err := executeRootCapture(t, ctx, "--workspace", t.TempDir(),
+		"create", "example issue")
+	cliErr := requireCLIError(t, err, ExitInternal)
+	assert.Equal(t, "create_outcome_unknown", cliErr.Code)
+	assert.Contains(t, cliErr.Message, "canceled")
+	assert.Contains(t, cliErr.Message, "check whether the issue was created")
+	assert.NotContains(t, cliErr.Message, "timed out")
+}
+
+func TestCreateTimeoutClassificationAtCommandBoundary(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects/resolve":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"project":{"id":7,"name":"example-project"}}`)
+		case "/api/v1/projects/7/issues":
+			select {
+			case <-r.Context().Done():
+			case <-time.After(500 * time.Millisecond):
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	run := func(t *testing.T, extra ...string) error {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(
+			contextWithBaseURL(context.Background(), server.URL), 150*time.Millisecond)
+		defer cancel()
+		args := []string{"--workspace", t.TempDir(), "create", "example issue"}
+		args = append(args, extra...)
+		_, _, err := executeRootCapture(t, ctx, args...)
+		return err
+	}
+
+	t.Run("normal create reports unknown outcome", func(t *testing.T) {
+		cliErr := requireCLIError(t, run(t), ExitInternal)
+		assert.Equal(t, "create_outcome_unknown", cliErr.Code)
+	})
+
+	t.Run("force new reports unknown outcome without retry advice", func(t *testing.T) {
+		cliErr := requireCLIError(t, run(t, "--force-new"), ExitInternal)
+		assert.Equal(t, "create_outcome_unknown", cliErr.Code)
+		assert.NotContains(t, cliErr.Message, "--force-new")
+	})
+}
 
 func TestCreate_PrintsIssueShortIDInQuietMode(t *testing.T) {
 	env, dir := setupCLIEnv(t)

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -43,8 +43,9 @@ type callInitOpts struct {
 //
 // Kind is the coarse classification used by the --json error envelope so
 // scripts can branch on a stable taxonomy instead of grepping the
-// human-readable message. Code is the daemon-supplied per-error tag
-// (e.g. "issue_not_found"); empty when the error originated client-side.
+// human-readable message. Code is the stable per-error tag, usually supplied
+// by the daemon (e.g. "issue_not_found") but occasionally added by a client
+// path with command-specific recovery semantics.
 // Message is the human-readable text. ExitCode is what main() exits with.
 type cliError struct {
 	Message  string

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-29
+last_edited: 2026-09-02
 ---
 
 # CLI reference
@@ -137,6 +137,14 @@ kata create <title> \
 ```
 
 `--meta` binds string-valued metadata at creation and is repeatable.
+
+Before creating an issue, the daemon checks existing non-deleted look-alikes,
+including closed ones, using the full title and the first 500 Unicode code
+points of the body. `--force-new` bypasses that check; idempotency still wins
+when an idempotency key matches. If create times out, or the request is
+canceled before the response arrives, its outcome is unknown: check whether
+the issue exists before retrying, and use `--force-new` only after confirming
+that no issue was created.
 
 List and inspect:
 

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -1320,14 +1320,15 @@ func tryIdempotencyMatch(ctx context.Context, cfg ServerConfig, in *api.CreateIs
 	return fp, out, nil
 }
 
-// runLookalikeCheck runs the §3.7 soft-block: SearchFTSAny over title+body
+// runLookalikeCheck runs the §3.7 soft-block: SearchFTSAny over the title and
+// the body prefix used by the scorer
 // (OR-of-tokens for high recall), scores each candidate via similarity.Score,
 // and returns a 409 duplicate_candidates error if any candidate is at or
 // above the 0.7 threshold. nil means proceed. The OR variant is required
 // because near-duplicates that differ by even one token would be filtered
 // out by SearchFTS's implicit-AND before similarity scoring runs.
 func runLookalikeCheck(ctx context.Context, cfg ServerConfig, in *api.CreateIssueRequest) error {
-	q := strings.TrimSpace(in.Body.Title + " " + in.Body.Body)
+	q := similarity.LookalikeQuery(in.Body.Title, in.Body.Body)
 	candidates, err := cfg.DB.SearchFTSAny(ctx, db.SearchFTSParams{
 		ProjectID: in.ProjectID, Query: q, Limit: 20,
 	})
@@ -1360,7 +1361,7 @@ func runLookalikeCheck(ctx context.Context, cfg ServerConfig, in *api.CreateIssu
 func formatDuplicateMessage(matched []map[string]any) string {
 	n := len(matched)
 	if n == 1 {
-		return "1 open issue matches this title"
+		return "1 existing issue matches this title"
 	}
-	return strconv.Itoa(n) + " open issues match this title"
+	return strconv.Itoa(n) + " existing issues match this title"
 }

--- a/internal/daemon/handlers_issues_internal_test.go
+++ b/internal/daemon/handlers_issues_internal_test.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/api"
+	"go.kenn.io/kata/internal/db"
+)
+
+type lookalikeQueryRecordingStore struct {
+	db.Storage
+	query string
+}
+
+func (s *lookalikeQueryRecordingStore) SearchFTSAny(_ context.Context, params db.SearchFTSParams) ([]db.SearchCandidate, error) {
+	s.query = params.Query
+	return nil, nil
+}
+
+func TestRunLookalikeCheckBoundsSearchQuery(t *testing.T) {
+	store := &lookalikeQueryRecordingStore{}
+	in := &api.CreateIssueRequest{ProjectID: 7}
+	in.Body.Title = "full issue title"
+	in.Body.Body = strings.Repeat("界", 499) + "留 discard-this-suffix"
+
+	err := runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in)
+
+	require.NoError(t, err)
+	assert.Contains(t, store.query, in.Body.Title)
+	assert.Contains(t, store.query, "留")
+	assert.NotContains(t, store.query, "discard-this-suffix")
+	assert.True(t, utf8.ValidString(store.query))
+}
+
+type lookalikeCandidateStore struct {
+	db.Storage
+	candidates []db.SearchCandidate
+}
+
+func (s *lookalikeCandidateStore) SearchFTSAny(_ context.Context, _ db.SearchFTSParams) ([]db.SearchCandidate, error) {
+	return s.candidates, nil
+}
+
+func closedLookalike(title, body, uid string) db.SearchCandidate {
+	done := "done"
+	return db.SearchCandidate{
+		Issue: db.Issue{
+			UID:          uid,
+			ShortID:      uid[:4],
+			Title:        title,
+			Body:         body,
+			Status:       "closed",
+			ClosedReason: &done,
+		},
+	}
+}
+
+func TestRunLookalikeCheckConflictMessageCountsClosedCandidates(t *testing.T) {
+	title := "printer jams on tray two"
+	body := "paper path sensor reports a jam after pickup"
+	in := &api.CreateIssueRequest{ProjectID: 3}
+	in.Body.Title = title
+	in.Body.Body = body
+
+	t.Run("single closed candidate", func(t *testing.T) {
+		store := &lookalikeCandidateStore{candidates: []db.SearchCandidate{
+			closedLookalike(title, body, "01J5EXAMPLE000000000000EXA"),
+		}}
+
+		err := runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in)
+
+		require.Error(t, err)
+		var apiErr *api.APIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, 409, apiErr.Status)
+		assert.Equal(t, "duplicate_candidates", apiErr.Code)
+		assert.Equal(t, "1 existing issue matches this title", apiErr.Message)
+		assert.NotContains(t, apiErr.Message, "open")
+	})
+
+	t.Run("multiple closed candidates", func(t *testing.T) {
+		store := &lookalikeCandidateStore{candidates: []db.SearchCandidate{
+			closedLookalike(title, body, "01J5EXAMPLE000000000000EXA"),
+			closedLookalike(title, body, "01J5EXAMPLE000000000000EXB"),
+		}}
+
+		err := runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in)
+
+		require.Error(t, err)
+		var apiErr *api.APIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, 409, apiErr.Status)
+		assert.Equal(t, "2 existing issues match this title", apiErr.Message)
+		assert.NotContains(t, apiErr.Message, "open")
+	})
+}

--- a/internal/similarity/similarity.go
+++ b/internal/similarity/similarity.go
@@ -132,19 +132,25 @@ func Jaccard(a, b []string) float64 {
 // are tokenized. Spec §3.7.
 func Score(titleA, bodyA, titleB, bodyB string) float64 {
 	titleScore := Jaccard(Tokenize(titleA), Tokenize(titleB))
-	bodyScore := Jaccard(Tokenize(firstRunes(bodyA, 500)), Tokenize(firstRunes(bodyB, 500)))
+	bodyScore := Jaccard(Tokenize(BodyPrefix(bodyA)), Tokenize(BodyPrefix(bodyB)))
 	return 0.6*titleScore + 0.4*bodyScore
 }
 
-// firstRunes returns the first n runes of s. If s has fewer than n runes,
-// it's returned unchanged.
-func firstRunes(s string, n int) string {
+// BodyPrefix returns the first 500 runes of body. If body has fewer than 500
+// runes, it is returned unchanged.
+func BodyPrefix(body string) string {
 	count := 0
-	for i := range s {
-		if count == n {
-			return s[:i]
+	for i := range body {
+		if count == 500 {
+			return body[:i]
 		}
 		count++
 	}
-	return s
+	return body
+}
+
+// LookalikeQuery returns the issue text used to retrieve look-alike
+// candidates. Its body portion matches the prefix used by Score.
+func LookalikeQuery(title, body string) string {
+	return strings.TrimSpace(title + " " + BodyPrefix(body))
 }

--- a/internal/similarity/similarity_test.go
+++ b/internal/similarity/similarity_test.go
@@ -3,10 +3,43 @@ package similarity_test
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"go.kenn.io/kata/internal/similarity"
 )
+
+func TestBodyPrefix(t *testing.T) {
+	t.Run("short body is unchanged", func(t *testing.T) {
+		assert.Equal(t, "short body", similarity.BodyPrefix("short body"))
+	})
+
+	t.Run("ASCII is limited to 500 runes", func(t *testing.T) {
+		got := similarity.BodyPrefix(strings.Repeat("a", 501))
+		assert.Equal(t, 500, utf8.RuneCountInString(got))
+		assert.Equal(t, strings.Repeat("a", 500), got)
+	})
+
+	t.Run("multibyte text stays valid at the boundary", func(t *testing.T) {
+		got := similarity.BodyPrefix(strings.Repeat("界", 501))
+		assert.Equal(t, 500, utf8.RuneCountInString(got))
+		assert.True(t, utf8.ValidString(got))
+		assert.Equal(t, strings.Repeat("界", 500), got)
+	})
+}
+
+func TestLookalikeQuery(t *testing.T) {
+	prefix := strings.Repeat("界", 499) + "留"
+	body := prefix + " discard-this-suffix"
+
+	got := similarity.LookalikeQuery("  full issue title  ", body)
+
+	assert.Contains(t, got, "full issue title")
+	assert.Contains(t, got, "留")
+	assert.NotContains(t, got, "discard-this-suffix")
+	assert.True(t, utf8.ValidString(got))
+	assert.Equal(t, "full issue title   "+prefix, got)
+}
 
 const epsilon = 1e-9
 


### PR DESCRIPTION
## What changed

- Bounded look-alike retrieval and scoring to the first 500 Unicode code points of both the title and body.
- Classified ambiguous create transport failures, including timeouts, cancellations, and dropped responses, as `create_outcome_unknown`.
- Added recovery guidance for normal and `--force-new` creates without exposing the daemon URL.

## Why

Large issue text could expand into expensive look-alike queries even though text after the scorer's 500-code-point boundary could not affect the result. If the connection failed after sending a create, the raw error also left users without a safe way to decide whether retrying would create a duplicate.

## Usage

No command changes are required. If `kata create` reports `create_outcome_unknown`, check whether the issue exists before retrying. Use `--force-new` only after confirming that no issue was created.

Closes #329
