### PR TITLE
Add `kata federation lease renew` to extend a timed lease before it expires

### DIFF
--- a/cmd/kata/federation_lease.go
+++ b/cmd/kata/federation_lease.go
@@ -55,12 +55,12 @@ func newFederationLeaseRenewCmd() *cobra.Command {
 		Short: "renew a timed federation write lease",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if strings.TrimSpace(ttlRaw) == "" {
-				return &cliError{Message: "--ttl is required", Kind: kindUsage, ExitCode: ExitUsage}
-			}
-			ttl, _, err := parseClaimTTL(ttlRaw)
+			ttl, timed, err := parseClaimTTL(ttlRaw)
 			if err != nil {
 				return err
+			}
+			if !timed {
+				return &cliError{Message: "--ttl is required", Kind: kindUsage, ExitCode: ExitUsage}
 			}
 			return runClaimAction(cmd, args[0], "renew", ttl, true)
 		},

--- a/cmd/kata/federation_lease.go
+++ b/cmd/kata/federation_lease.go
@@ -25,7 +25,7 @@ func newFederationLeaseCmd() *cobra.Command {
 		Use:   "lease",
 		Short: "manage federation write leases",
 	}
-	cmd.AddCommand(newFederationLeaseAcquireCmd(), newFederationLeaseReleaseCmd(),
+	cmd.AddCommand(newFederationLeaseAcquireCmd(), newFederationLeaseRenewCmd(), newFederationLeaseReleaseCmd(),
 		newFederationLeaseForceReleaseCmd(), newFederationLeaseStealCmd())
 	return cmd
 }
@@ -45,6 +45,27 @@ func newFederationLeaseAcquireCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&ttlRaw, "ttl", "", "timed lease duration (for example 30m or 2h)")
+	return cmd
+}
+
+func newFederationLeaseRenewCmd() *cobra.Command {
+	var ttlRaw string
+	cmd := &cobra.Command{
+		Use:   "renew <issue-ref>",
+		Short: "renew a timed federation write lease",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(ttlRaw) == "" {
+				return &cliError{Message: "--ttl is required", Kind: kindUsage, ExitCode: ExitUsage}
+			}
+			ttl, _, err := parseClaimTTL(ttlRaw)
+			if err != nil {
+				return err
+			}
+			return runClaimAction(cmd, args[0], "renew", ttl, true)
+		},
+	}
+	cmd.Flags().StringVar(&ttlRaw, "ttl", "", "new timed lease duration (for example 30m or 2h)")
 	return cmd
 }
 
@@ -180,13 +201,16 @@ func runClaimAction(cmd *cobra.Command, rawRef, action string, ttl time.Duration
 		"holder":      actor,
 		"client_kind": "cli",
 	}
-	if action == "claim" || action == "acquire" {
+	switch action {
+	case "claim", "acquire":
 		if timed {
 			body["claim_kind"] = "timed"
 			body["ttl_seconds"] = int64(ttl / time.Second)
 		} else {
 			body["claim_kind"] = "hard"
 		}
+	case "renew":
+		body["ttl_seconds"] = int64(ttl / time.Second)
 	}
 	bs, ref, err := postClaimAction(cmd, rawRef, action, body)
 	if err != nil {
@@ -383,6 +407,10 @@ func printLeaseMutation(cmd *cobra.Command, bs []byte, action, ref, actor string
 		_, err := fmt.Fprintf(cmd.OutOrStdout(), "lease pending for %s as %s\n", ref, holder)
 		return err
 	}
+	if action == "renew" {
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "renewed lease on %s as %s\n", ref, holder)
+		return err
+	}
 	_, err = fmt.Fprintf(cmd.OutOrStdout(), "acquired lease on %s as %s\n", ref, holder)
 	return err
 }
@@ -410,6 +438,9 @@ func printLeaseMutationAgent(cmd *cobra.Command, action, ref, actor string, b cl
 		return err
 	}
 	state := "acquired"
+	if action == "renew" {
+		state = "renewed"
+	}
 	if b.Pending {
 		state = "pending"
 	}

--- a/cmd/kata/federation_lease_test.go
+++ b/cmd/kata/federation_lease_test.go
@@ -83,6 +83,32 @@ func TestClaim_TTLPostsTimedClaim(t *testing.T) {
 	assert.LessOrEqual(t, left, 31*time.Minute)
 }
 
+func TestLeaseRenew_ExtendsTimedLease(t *testing.T) {
+	env, dir, pid, ref := setupFederatedHubIssue(t, "renew target")
+	runCLIAs(t, env, dir, "alice", "federation", "lease", "acquire", ref, "--ttl", "5m")
+	before := fetchClaimStatus(t, env, pid, ref)
+	require.NotNil(t, before.Claim)
+	require.NotNil(t, before.Claim.ExpiresAt)
+
+	out := runCLIAs(t, env, dir, "alice", "federation", "lease", "renew", ref, "--ttl", "30m")
+	assert.Equal(t, "renewed lease on "+ref+" as alice", out)
+
+	after := fetchClaimStatus(t, env, pid, ref)
+	require.NotNil(t, after.Claim)
+	require.NotNil(t, after.Claim.ExpiresAt)
+	assert.Equal(t, before.Claim.ClaimUID, after.Claim.ClaimUID)
+	assert.Greater(t, after.Claim.Revision, before.Claim.Revision)
+	assert.Greater(t, after.Claim.ExpiresAt.Sub(*before.Claim.ExpiresAt), 20*time.Minute)
+}
+
+func TestLeaseRenew_RequiresTTL(t *testing.T) {
+	env, dir, _, ref := setupFederatedHubIssue(t, "renew without ttl")
+
+	_, err := runCLICapture(t, env, dir, "federation", "lease", "renew", ref)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--ttl is required")
+}
+
 func TestClaim_RejectsBareNumericTTL(t *testing.T) {
 	env, dir, _, ref := setupFederatedHubIssue(t, "bad ttl")
 

--- a/cmd/kata/federation_lease_test.go
+++ b/cmd/kata/federation_lease_test.go
@@ -101,6 +101,15 @@ func TestLeaseRenew_ExtendsTimedLease(t *testing.T) {
 	assert.Greater(t, after.Claim.ExpiresAt.Sub(*before.Claim.ExpiresAt), 20*time.Minute)
 }
 
+func TestLeaseRenew_RejectsHardLease(t *testing.T) {
+	env, dir, _, ref := setupFederatedHubIssue(t, "renew hard lease")
+	runCLIAs(t, env, dir, "alice", "federation", "lease", "acquire", ref)
+
+	_, err := runCLICapture(t, env, dir, "--as", "alice", "federation", "lease", "renew", ref, "--ttl", "30m")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hard claims cannot be renewed")
+}
+
 func TestLeaseRenew_RequiresTTL(t *testing.T) {
 	env, dir, _, ref := setupFederatedHubIssue(t, "renew without ttl")
 

--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -397,6 +397,7 @@ kata federation leave <project> [--delete [--force]] [--local-only] [--hub <name
 kata federation status
 kata federation status --json
 kata federation lease acquire <issue-ref> [--ttl 30m]
+kata federation lease renew <issue-ref> --ttl 30m
 kata federation lease release <issue-ref>
 ```
 

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -754,6 +754,7 @@ kata federation rebind --all --hub <name>
 kata federation status
 kata federation status --json
 kata federation lease acquire <issue-ref> [--ttl 30m]
+kata federation lease renew <issue-ref> --ttl 30m
 kata federation lease release <issue-ref>
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -839,6 +839,7 @@ kata federation status
 kata federation enrollments list
 kata federation revoke <enrollment-id>
 kata federation lease acquire <issue-ref> [--ttl 30m]
+kata federation lease renew <issue-ref> --ttl 30m
 kata federation lease release <issue-ref>
 kata federation quarantine list
 kata federation quarantine show <id>
@@ -879,7 +880,9 @@ Federation is an operator workflow. Most users never need these commands.
 Issue edits on push-enabled federated spokes remain local-first; use
 `kata federation lease acquire` only when you want exclusive coordination on an
 issue. A live lease held by another actor blocks non-comment mutations until it
-is released or expires.
+is released or expires. Renew a timed lease before it expires with
+`kata federation lease renew <issue-ref> --ttl <duration>`. Renewal preserves
+the lease identity and sets a new expiry from the hub's current time.
 
 `kata federation quarantine list` reports every active quarantine with its
 project, direction, event range, creation time, and retained error. Use


### PR DESCRIPTION
Timed federation write leases could be acquired from the CLI with `kata federation lease acquire --ttl`, but there was no CLI way to extend one. A holder whose lease was about to expire had to release and re-acquire, which drops the lease identity and opens a window for another actor to take the issue. The daemon and the MCP lease tool already supported renewal; only the CLI lacked it.

`kata federation lease renew <issue-ref> --ttl <duration>` now posts to the daemon's existing renew action. The lease keeps its claim UID, its revision advances, and the new expiry is computed from the hub's clock, so the holder keeps exclusive coordination without a gap. `--ttl` is required and accepts the same whole-unit 60s–24h durations as acquire.

Renewal applies only to timed leases. Renewing a hard lease (one acquired without `--ttl`) fails with the daemon's `hard claims cannot be renewed` validation error, and renewing a lease held by someone else or no lease at all fails with `claim not held`. Both surface as ordinary CLI errors with non-zero exit; there is no path that reports success without the hub extending the lease.

Human output prints `renewed lease on <ref> as <holder>`, agent output reports `State: renewed`, and JSON output is the daemon's lease response unchanged. The command is documented in the CLI reference and the federation design doc.
