### PR TITLE
test: wait for federation pass before cleanup

### DIFF
--- a/service_federation_test.go
+++ b/service_federation_test.go
@@ -106,7 +106,10 @@ func TestServiceRunWakesFederationOnCommittedEvent(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		_, issueErr := hubService.store.IssueByUID(ctx, issue.UID, db.IncludeDeletedNo)
-		return issueErr == nil
+		status, statusErr := spokeService.store.FederationSyncStatusByProject(ctx, spokeProject.ID)
+		// The hub commit becomes visible before the spoke finishes pulling its echo.
+		// Keep Run alive until that successful pass clears the seeded offline error.
+		return issueErr == nil && statusErr == nil && status.LastError == nil
 	}, 2*time.Second, 10*time.Millisecond, "federation push should be event-driven, not wait for the 30-second poll")
 }
 


### PR DESCRIPTION
Prevents the recurring `TestServiceRunWakesFederationOnCommittedEvent` flake by keeping the mounted service alive until its event-driven federation pass finishes.

The test seeds an offline sync error, switches to the live test hub, creates an issue, and broadcasts a wake. It previously treated hub-side issue visibility as completion, but the hub commit becomes visible before the spoke pulls its echoed event. Cleanup could cancel that in-flight SQLite transaction, and `Service.Run` then surfaced the transaction failure as designed. The identical failure appeared in [Tests run 982](https://github.com/kenn-io/kata/actions/runs/33256462729) and the pg17 job in [Tests run 986](https://github.com/kenn-io/kata/actions/runs/33698019725).

The assertion now also waits for the successful pass to clear the deliberately seeded offline error. This preserves the existing two-second event-driven boundary and leaves production shutdown and worker-error handling unchanged.

Run 986's [Federation Docker failure](https://github.com/kenn-io/kata/actions/runs/33698019725/job/100471033803) is separate: `apt-get` timed out fetching every configured Debian index before the image could run Kata. This change leaves the image unchanged rather than adding a package-mirror workaround for a runner-network failure.
