### PR TITLE
Retire the legacy release-script CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -225,19 +225,6 @@ jobs:
       - name: Run golangci-lint
         run: make lint
 
-  release-scripts:
-    name: Release script tests
-    runs-on: ${{ github.repository == 'kenn-io/kata' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
-        with:
-          persist-credentials: false
-
-      - name: Run release script tests
-        run: env -u KATA_AUTH_TOKEN make release-scripts-test
-
   nilaway:
     name: nilaway
     runs-on: ${{ github.repository == 'kenn-io/kata' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}


### PR DESCRIPTION
Remove the legacy release-script test job before deleting the scripts in #340.

PRs use the test workflow from `main`, so #340 still runs the old job against its checkout and fails on the deleted Makefile target. Merge this prerequisite first, then update #340 from `main` and start a fresh CI run.

This changes only the test job. The scripts and release publishers remain until #340 lands.
