### PR TITLE
Preserve historical authors through chunked federation adoption

### DIFF
--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -214,7 +214,15 @@ On each spoke:
 
    Adoption preserves the current state of local issues, including closed and
    soft-deleted issues, comments, labels, metadata, priority, owner, and
-   links. It does not preserve the old local event history.
+   links. Historical issue, comment, and link authors survive every transport
+   chunk of the approved baseline, not only its first snapshot batch. The
+   enrollment's bound actor remains the event actor throughout. The hub records
+   the terminal source cursor when the baseline opens and consumes the
+   historical-author grant only when that terminal chunk commits. Exact
+   retries remain idempotent; completion does not permit fresh snapshot events
+   under the consumed grant.
+
+   Adoption does not preserve the old local event history.
    Instead it removes those pre-adoption local events and queues fresh snapshots
    for the hub with links embedded in the snapshot payloads. A cross-project
    edge materializes after both endpoint projects reach the same hub; until

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -302,7 +302,11 @@ printed command omits `--adopt-existing` and `join` creates a new spoke
 replica. If the spoke project name differs from the hub project name, replace
 the printed `--project <hub-project>` with `--project <spoke-project>`, and
 create the enrollment with `kata federation enroll --adopt-existing` so the
-token is marked for adoption snapshots.
+token is marked for adoption snapshots. That permission preserves historical
+issue, comment, and link authors across every chunk of the initial baseline,
+including resumed transfers. The event actor still identifies the enrolled
+installation's actor. Completing the baseline consumes the permission; later
+writes must use the bound actor.
 
 Before enrollment, clean current-state data that should not appear in baseline
 snapshots. Use `kata comment edit <ref> <comment-uid> --body ...` to replace

--- a/internal/db/dbtest/conformance_federation.go
+++ b/internal/db/dbtest/conformance_federation.go
@@ -2098,15 +2098,19 @@ func checkFederationAdoptionIngestLifecycle(t *testing.T, store db.Storage) erro
 		return err
 	}
 	assert.True(t, enrollment.AdoptionBaselineOpen)
-	assert.False(t, enrollment.AllowAdoptionSnapshotAuthors)
+	assert.True(t, enrollment.AllowAdoptionSnapshotAuthors)
 	assert.Equal(t, int64(12), enrollment.AdoptionBaselineNextSourceEventID)
 
 	secondIssueUID, err := uid.New()
 	if err != nil {
 		return err
 	}
+	commentUID, err := uid.New()
+	if err != nil {
+		return err
+	}
 	secondSnapshot := newRemoteEvent(t, project, &secondIssueUID, "issue.snapshot", "adoption-agent",
-		spokeUID, 400, json.RawMessage(`{"uid":"`+secondIssueUID+`","title":"historical second","body":"","author":"another-historical-author","status":"open","metadata":{},"created_at":"2026-05-23T12:00:00.000Z"}`))
+		spokeUID, 400, json.RawMessage(`{"uid":"`+secondIssueUID+`","title":"historical second","body":"","author":"another-historical-author","status":"open","metadata":{},"comments":[{"comment_uid":"`+commentUID+`","author":"historical-reviewer","body":"original comment","created_at":"2026-05-23T12:00:00.000Z"}],"links":[{"type":"related","to_issue_uid":"`+firstIssueUID+`","author":"historical-linker"}],"created_at":"2026-05-23T12:00:00.000Z"}`))
 	terminalParams := db.FederationIngestParams{
 		ProjectID: project.ID, FederationEnrollmentID: created.Enrollment.ID,
 		SpokeInstanceUID: spokeUID, BoundActor: "adoption-agent",
@@ -2123,7 +2127,20 @@ func checkFederationAdoptionIngestLifecycle(t *testing.T, store db.Storage) erro
 	if err != nil {
 		return err
 	}
-	assert.Equal(t, "adoption-agent", secondIssue.Author)
+	assert.Equal(t, "another-historical-author", secondIssue.Author)
+	comments, err := store.CommentsByIssue(ctx, secondIssue.ID)
+	if err != nil {
+		return err
+	}
+	require.Len(t, comments, 1)
+	assert.Equal(t, commentUID, comments[0].UID)
+	assert.Equal(t, "historical-reviewer", comments[0].Author)
+	links, err := store.LinksByIssue(ctx, secondIssue.ID)
+	if err != nil {
+		return err
+	}
+	require.Len(t, links, 1)
+	assert.Equal(t, "historical-linker", links[0].Author)
 	enrollment, err = federationEnrollmentByID(ctx, store, created.Enrollment.ID)
 	if err != nil {
 		return err

--- a/internal/db/federation_events.go
+++ b/internal/db/federation_events.go
@@ -59,6 +59,30 @@ func ValidateRemoteEventContentHash(event RemoteEvent) (json.RawMessage, string,
 	return payload, createdAt, nil
 }
 
+// ValidateFederationSnapshotEntries checks embedded entries without changing
+// historical authors. Author preservation must not bypass payload validation.
+func ValidateFederationSnapshotEntries(event RemoteEvent) error {
+	var payload struct {
+		Comments []map[string]json.RawMessage `json:"comments"`
+		Links    []map[string]json.RawMessage `json:"links"`
+	}
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return fmt.Errorf("%w: event %s issue.snapshot entries are invalid JSON",
+			ErrFederationIngestValidation, event.EventUID)
+	}
+	for field, entries := range map[string][]map[string]json.RawMessage{
+		"comments": payload.Comments, "links": payload.Links,
+	} {
+		for _, entry := range entries {
+			if entry == nil {
+				return fmt.Errorf("%w: event %s issue.snapshot %s payload entry must be a JSON object",
+					ErrFederationIngestValidation, event.EventUID, field)
+			}
+		}
+	}
+	return nil
+}
+
 // CanonicalizeFederationSnapshotAuthors rewrites an adoption snapshot's
 // embedded authors to its bound actor and recomputes the portable hash.
 func CanonicalizeFederationSnapshotAuthors(event RemoteEvent, boundActor string) (RemoteEvent, error) {

--- a/internal/db/pgstore/federation_ingest.go
+++ b/internal/db/pgstore/federation_ingest.go
@@ -263,7 +263,7 @@ func validateFederationBoundActorPayload(
 	switch event.Type {
 	case "issue.snapshot":
 		if allowSnapshotAuthorPreservation {
-			return nil
+			return db.ValidateFederationSnapshotEntries(event)
 		}
 		if err := validateFederationPayloadAuthor(event, boundActor); err != nil {
 			return err

--- a/internal/db/pgstore/federation_ingest_adoption.go
+++ b/internal/db/pgstore/federation_ingest_adoption.go
@@ -123,10 +123,12 @@ func computeFederationIngestOpenAdoptionBaselineState(
 	shape federationIngestBaselineShape,
 	endSourceEventID int64,
 ) (federationIngestAdoptionSnapshotAuthorState, error) {
+	// A transport chunk is not the whole adoption. Preserve the grant until
+	// the recorded terminal cursor commits, including across retries.
 	state := federationIngestAdoptionSnapshotAuthorState{
 		allowAuthorPreservation:      shape.hasSnapshot && marker.allowSnapshotAuthors,
 		shouldDeferMarker:            true,
-		deferAuthorPreservationGrant: marker.allowSnapshotAuthors && !shape.hasSnapshot,
+		deferAuthorPreservationGrant: marker.allowSnapshotAuthors,
 		overrideSnapshotAuthors:      shape.hasSnapshot && marker.baselineOpen && !marker.allowSnapshotAuthors,
 		nextSourceEventID:            shape.maxSourceEventID + 1,
 		endSourceEventID:             endSourceEventID,

--- a/internal/db/sqlitestore/federation_ingest.go
+++ b/internal/db/sqlitestore/federation_ingest.go
@@ -228,7 +228,7 @@ func validateFederationBoundActorPayload(
 	switch ev.Type {
 	case "issue.snapshot":
 		if allowSnapshotAuthorPreservation {
-			return nil
+			return db.ValidateFederationSnapshotEntries(ev)
 		}
 		if err := validateFederationPayloadAuthor(ev, boundActor); err != nil {
 			return err
@@ -371,10 +371,12 @@ func computeFederationIngestOpenAdoptionBaselineState(
 	baselineShape federationIngestBaselineShape,
 	adoptionBaselineEndSourceEventID int64,
 ) (federationIngestAdoptionSnapshotAuthorState, error) {
+	// A transport chunk is not the whole adoption. Preserve the grant until
+	// the recorded terminal cursor commits, including across retries.
 	state := federationIngestAdoptionSnapshotAuthorState{
 		allowAuthorPreservation:      baselineShape.hasSnapshot && marker.allowSnapshotAuthors,
 		shouldDeferMarker:            true,
-		deferAuthorPreservationGrant: marker.allowSnapshotAuthors && !baselineShape.hasSnapshot,
+		deferAuthorPreservationGrant: marker.allowSnapshotAuthors,
 		overrideSnapshotAuthors:      baselineShape.hasSnapshot && marker.baselineOpen && !marker.allowSnapshotAuthors,
 		nextSourceEventID:            baselineShape.maxSourceEventID + 1,
 		endSourceEventID:             adoptionBaselineEndSourceEventID,

--- a/internal/db/sqlitestore/federation_test.go
+++ b/internal/db/sqlitestore/federation_test.go
@@ -3028,7 +3028,7 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		assert.Equal(t, 1, firstRes.Accepted)
 		authorized, err := d.AuthorizeFederationToken(ctx, markerValue, p.ID, "push")
 		require.NoError(t, err)
-		assert.False(t, authorized.AllowAdoptionSnapshotAuthors)
+		assert.True(t, authorized.AllowAdoptionSnapshotAuthors)
 		firstIssue, err := d.IssueByUID(ctx, firstUID, db.IncludeDeletedYes)
 		require.NoError(t, err)
 		assert.Equal(t, "historical-agent", firstIssue.Author)
@@ -3053,14 +3053,14 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		assert.False(t, authorized.AllowAdoptionSnapshotAuthors)
 		secondIssue, err := d.IssueByUID(ctx, secondUID, db.IncludeDeletedYes)
 		require.NoError(t, err)
-		assert.Equal(t, "bound-agent", secondIssue.Author)
+		assert.Equal(t, "second-historical-agent", secondIssue.Author)
 		links, err = d.LinksByIssue(ctx, firstIssue.ID)
 		require.NoError(t, err)
 		require.Len(t, links, 1)
 		assert.Equal(t, "historical-linker", links[0].Author)
 	})
 
-	t.Run("projects continuation adoption snapshot historical author as bound actor", func(t *testing.T) {
+	t.Run("preserves continuation snapshot payload and bound event actor", func(t *testing.T) {
 		d, ctx, p, spokeUID := setupFederationIngestHub(t)
 		markerValue := strings.Join([]string{"snapshot", "adoption", "continuation", "author"}, "-")
 		created, err := d.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{
@@ -3114,11 +3114,12 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		assert.Equal(t, "historical-agent", firstIssue.Author)
 		secondIssue, err := d.IssueByUID(ctx, secondUID, db.IncludeDeletedYes)
 		require.NoError(t, err)
-		assert.Equal(t, "bound-agent", secondIssue.Author)
-		var storedPayload string
+		assert.Equal(t, "spoofed-agent", secondIssue.Author)
+		var storedPayload, storedActor string
 		require.NoError(t, d.QueryRowContext(ctx,
-			`SELECT payload FROM events WHERE uid = ?`, second.EventUID).Scan(&storedPayload))
-		assert.Contains(t, storedPayload, `"author":"bound-agent"`)
+			`SELECT payload, actor FROM events WHERE uid = ?`, second.EventUID).Scan(&storedPayload, &storedActor))
+		assert.JSONEq(t, string(second.Payload), storedPayload)
+		assert.Equal(t, "bound-agent", storedActor)
 	})
 
 	t.Run("rejects null continuation adoption snapshot entries", func(t *testing.T) {
@@ -3247,7 +3248,7 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 		assert.Equal(t, 1, res.Accepted)
 		secondIssue, err := d.IssueByUID(ctx, secondUID, db.IncludeDeletedYes)
 		require.NoError(t, err)
-		assert.Equal(t, "bound-agent", secondIssue.Author)
+		assert.Equal(t, "second-historical-agent", secondIssue.Author)
 
 		retryParams := completeParams
 		retryParams.AllowSnapshotAuthorPreservation = false
@@ -3580,7 +3581,7 @@ func TestIngestFederationEvents_Validation(t *testing.T) {
 
 		authorized, err := d.AuthorizeFederationToken(ctx, markerValue, p.ID, "push")
 		require.NoError(t, err)
-		assert.False(t, authorized.AllowAdoptionSnapshotAuthors)
+		assert.True(t, authorized.AllowAdoptionSnapshotAuthors)
 		var baselineOpen, nextSourceEventID, endSourceEventID int64
 		require.NoError(t, d.QueryRowContext(ctx, `
 				SELECT adoption_baseline_open, adoption_baseline_next_source_event_id,

--- a/internal/federation/federation_sync_test.go
+++ b/internal/federation/federation_sync_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2387,19 +2386,14 @@ func TestSyncFederationOncePushesSplitAdoptionSnapshotsWithHistoricalAuthors(t *
 	var baselineStages []string
 	var baselineEndEventIDs []int64
 	var baselineLastEventIDs []int64
-	snapshotAuthorsByUID := map[string]string{}
-	var sawContinuationBoundActor bool
-	var snapshotRequestAccepted bool
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		requestHadSnapshot := false
 		if r.URL.Path == fmt.Sprintf("/api/v1/projects/%d/federation/events:ingest", hubProject.ID) {
 			requestSizes = append(requestSizes, len(raw))
 			var body api.FederationIngestEventsRequestBody
 			require.NoError(t, json.Unmarshal(raw, &body))
 			require.NotEmpty(t, body.Events)
-			isSnapshotContinuation := snapshotRequestAccepted
 			baselineStages = append(baselineStages, body.AdoptionBaseline)
 			baselineEndEventIDs = append(baselineEndEventIDs, body.AdoptionBaselineEndEventID)
 			baselineLastEventIDs = append(baselineLastEventIDs, body.Events[len(body.Events)-1].EventID)
@@ -2413,13 +2407,6 @@ func TestSyncFederationOncePushesSplitAdoptionSnapshotsWithHistoricalAuthors(t *
 				}
 				require.NoError(t, json.Unmarshal(ev.Payload, &payload))
 				assert.Equal(t, "historical-author", payload.Author)
-				projectedAuthor := "historical-author"
-				if isSnapshotContinuation {
-					projectedAuthor = "agent"
-					sawContinuationBoundActor = true
-				}
-				snapshotAuthorsByUID[payload.UID] = projectedAuthor
-				requestHadSnapshot = true
 			}
 		}
 		req, err := http.NewRequestWithContext(r.Context(), r.Method, hub.URL+r.URL.RequestURI(), bytes.NewReader(raw)) //nolint:gosec // test proxy forwards only to the local httptest hub.
@@ -2436,9 +2423,6 @@ func TestSyncFederationOncePushesSplitAdoptionSnapshotsWithHistoricalAuthors(t *
 		w.WriteHeader(resp.StatusCode)
 		_, err = io.Copy(w, resp.Body)
 		require.NoError(t, err)
-		if requestHadSnapshot && resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusBadRequest {
-			snapshotRequestAccepted = true
-		}
 	}))
 	t.Cleanup(proxy.Close)
 
@@ -2516,14 +2500,11 @@ func TestSyncFederationOncePushesSplitAdoptionSnapshotsWithHistoricalAuthors(t *
 	for _, endEventID := range baselineEndEventIDs {
 		assert.Equal(t, terminalEndEventID, endEventID)
 	}
-	require.True(t, sawContinuationBoundActor)
 
 	for _, issueUID := range issueUIDs {
-		expectedAuthor, ok := snapshotAuthorsByUID[issueUID]
-		require.True(t, ok)
 		pushed, err := hub.DB.IssueByUID(ctx, issueUID, db.IncludeDeletedYes)
 		require.NoError(t, err)
-		assert.Equal(t, expectedAuthor, pushed.Author)
+		assert.Equal(t, "historical-author", pushed.Author)
 	}
 	pullReplica := testenv.New(t)
 	pullEnrollment, err := hub.DB.CreateFederationEnrollment(ctx, db.CreateFederationEnrollmentParams{ //nolint:gosec // test-only bearer token
@@ -2555,11 +2536,9 @@ func TestSyncFederationOncePushesSplitAdoptionSnapshotsWithHistoricalAuthors(t *
 		Capabilities: "pull",
 	}))
 	for _, issueUID := range issueUIDs {
-		expectedAuthor, ok := snapshotAuthorsByUID[issueUID]
-		require.True(t, ok)
 		pulled, err := pullReplica.DB.IssueByUID(ctx, issueUID, db.IncludeDeletedYes)
 		require.NoError(t, err)
-		assert.Equal(t, expectedAuthor, pulled.Author)
+		assert.Equal(t, "historical-author", pulled.Author)
 	}
 	var linkCount int
 	require.NoError(t, hub.DB.QueryRowContext(ctx, `
@@ -2601,21 +2580,15 @@ func TestSyncFederationOnceResumesSplitAdoptionBaselineAfterFailure(t *testing.T
 	var ingestCount int
 	var firstAcceptedCursor int64
 	failSecondIngest := true
-	snapshotAuthorsByUID := map[string]string{}
-	var sawContinuationBoundActor bool
-	var snapshotRequestAccepted bool
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		requestSnapshotAuthors := map[string]string{}
-		requestHadSnapshot := false
 		forwardedIngest := r.URL.Path == fmt.Sprintf("/api/v1/projects/%d/federation/events:ingest", hubProject.ID)
 		if forwardedIngest {
 			ingestCount++
 			var body api.FederationIngestEventsRequestBody
 			require.NoError(t, json.Unmarshal(raw, &body))
 			require.NotEmpty(t, body.Events)
-			isSnapshotContinuation := snapshotRequestAccepted
 			for _, ev := range body.Events {
 				if ev.Type != "issue.snapshot" {
 					continue
@@ -2626,13 +2599,6 @@ func TestSyncFederationOnceResumesSplitAdoptionBaselineAfterFailure(t *testing.T
 				}
 				require.NoError(t, json.Unmarshal(ev.Payload, &payload))
 				assert.Equal(t, "historical-author", payload.Author)
-				projectedAuthor := "historical-author"
-				if isSnapshotContinuation {
-					projectedAuthor = "agent"
-					sawContinuationBoundActor = true
-				}
-				requestSnapshotAuthors[payload.UID] = projectedAuthor
-				requestHadSnapshot = true
 			}
 			if ingestCount == 1 {
 				firstAcceptedCursor = body.Events[len(body.Events)-1].EventID
@@ -2650,12 +2616,6 @@ func TestSyncFederationOnceResumesSplitAdoptionBaselineAfterFailure(t *testing.T
 		resp, err := http.DefaultClient.Do(req) //nolint:gosec // test proxy forwards only to the local httptest hub.
 		require.NoError(t, err)
 		defer func() { _ = resp.Body.Close() }()
-		if forwardedIngest && resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusBadRequest {
-			maps.Copy(snapshotAuthorsByUID, requestSnapshotAuthors)
-			if requestHadSnapshot {
-				snapshotRequestAccepted = true
-			}
-		}
 		for key, values := range resp.Header {
 			for _, value := range values {
 				w.Header().Add(key, value)
@@ -2713,18 +2673,15 @@ func TestSyncFederationOnceResumesSplitAdoptionBaselineAfterFailure(t *testing.T
 	assert.Equal(t, firstAcceptedCursor, binding.PushCursorEventID)
 	authorized, err := hub.DB.AuthorizeFederationToken(ctx, created.Token, hubProject.ID, "push")
 	require.NoError(t, err)
-	assert.False(t, authorized.AllowAdoptionSnapshotAuthors)
+	assert.True(t, authorized.AllowAdoptionSnapshotAuthors)
 
 	failSecondIngest = false
 	err = SyncFederationOnce(ctx, spoke.DB, binding, creds)
 	require.NoError(t, err)
-	require.True(t, sawContinuationBoundActor)
 	for _, issueUID := range issueUIDs {
-		expectedAuthor, ok := snapshotAuthorsByUID[issueUID]
-		require.True(t, ok)
 		pushed, err := hub.DB.IssueByUID(ctx, issueUID, db.IncludeDeletedYes)
 		require.NoError(t, err)
-		assert.Equal(t, expectedAuthor, pushed.Author)
+		assert.Equal(t, "historical-author", pushed.Author)
 	}
 	authorized, err = hub.DB.AuthorizeFederationToken(ctx, created.Token, hubProject.ID, "push")
 	require.NoError(t, err)


### PR DESCRIPTION
Preserve historical issue, comment, and link authors when adopting an existing project across multiple federation batches. Previously, the hub consumed the author-preservation permission after the first snapshot batch. Later batches silently replaced historical authors with the enrolling actor, including after a resumed transfer.

Both SQLite and PostgreSQL now retain that permission until the recorded adoption baseline completes. Import events still carry the enrolled actor, payload validation remains in place, and completing adoption does not authorize new snapshot events.

The regression coverage checks stored authors across batches and resumed transfers on both backends. No database schema or CLI changes are required.
