### PR TITLE
Preserve federation link dates and skip unchanged PostgreSQL comments

### DIFF
--- a/docs/design/federation.md
+++ b/docs/design/federation.md
@@ -616,6 +616,14 @@ history is not replay-complete, enabling federation emits a baseline of
 single-writer view; replicas fold forward from that horizon and keep older events
 as audit-only.
 
+New baseline snapshots include each relationship's stored `created_at` date.
+Both storage backends preserve that date when rebuilding links, including links
+whose other endpoint arrives in a later batch. Older persisted snapshots omit
+the date and remain readable: a newly materialized link gets its insertion time,
+and later rebuilds retain it. Those events cannot recover the original date.
+This does not rewrite old events or attempt historical repair; generating a new
+baseline on the original hub carries the dates that hub still stores.
+
 ### Metadata Merge Semantics
 
 Issue and project metadata is a per-key map, and unreserved keys may hold

--- a/internal/db/dbtest/conformance.go
+++ b/internal/db/dbtest/conformance.go
@@ -440,6 +440,14 @@ var storageScenarios = []scenario{
 		run: checkFederationAdoptionIngestLifecycle,
 	},
 	{
+		name: "federation snapshot link dates",
+		methods: []string{
+			"CreateProject", "CreateIssue", "CreateLink", "EnableProjectFederation",
+			"EventsAfter", "DeleteLinkByID", "MaterializeFederatedProject", "LinkByEndpoints",
+		},
+		run: checkFederationSnapshotLinkDates,
+	},
+	{
 		name: "federation project adoption",
 		methods: []string{
 			"AcquireClaim", "AdoptProjectIntoFederation", "CountLiveClaims", "CountPendingClaims",

--- a/internal/db/dbtest/conformance_federation.go
+++ b/internal/db/dbtest/conformance_federation.go
@@ -2028,6 +2028,62 @@ func checkFederationIngestLifecycle(t *testing.T, store db.Storage) error {
 	return nil
 }
 
+func checkFederationSnapshotLinkDates(t *testing.T, store db.Storage) error {
+	ctx := t.Context()
+	project, err := store.CreateProject(ctx, "snapshot-links")
+	require.NoError(t, err)
+	first, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "first", Author: "author",
+	})
+	require.NoError(t, err)
+	second, _, err := store.CreateIssue(ctx, db.CreateIssueParams{
+		ProjectID: project.ID, Title: "second", Author: "author",
+	})
+	require.NoError(t, err)
+	var originals []db.Link
+	for _, typ := range []string{"blocks", "related", "parent"} {
+		link, err := store.CreateLink(ctx, db.CreateLinkParams{
+			FromIssueID: first.ID, ToIssueID: second.ID, Type: typ, Author: "link-author",
+		})
+		require.NoError(t, err)
+		originals = append(originals, link)
+	}
+	binding, err := store.EnableProjectFederation(ctx, project.ID, "operator")
+	require.NoError(t, err)
+	events, err := store.EventsAfter(ctx, db.EventsAfterParams{ProjectID: project.ID, AfterID: binding.ReplayHorizonEventID, Limit: 100})
+	require.NoError(t, err)
+	var snapshotLinks []struct {
+		Type      string    `json:"type"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+	for _, event := range events {
+		if event.Type == "issue.snapshot" && event.IssueUID != nil && *event.IssueUID == first.UID {
+			payload := db.PayloadMap(json.RawMessage(event.Payload))
+			require.NoError(t, json.Unmarshal(payload["links"], &snapshotLinks))
+		}
+	}
+	require.Len(t, snapshotLinks, 3)
+	for _, original := range originals {
+		for _, link := range snapshotLinks {
+			if link.Type == original.Type {
+				assert.True(t, original.CreatedAt.Equal(link.CreatedAt), "snapshot %s date: got %s, want %s", link.Type, link.CreatedAt, original.CreatedAt)
+			}
+		}
+		// Recreate from events, not from an already populated link row.
+		require.NoError(t, store.DeleteLinkByID(ctx, original.ID))
+	}
+	for range 2 {
+		err := store.MaterializeFederatedProject(ctx, project.ID)
+		require.NoError(t, err)
+		for _, original := range originals {
+			link, err := store.LinkByEndpoints(ctx, original.FromIssueID, original.ToIssueID, original.Type)
+			require.NoError(t, err)
+			assert.True(t, original.CreatedAt.Equal(link.CreatedAt), "rebuilt %s date: got %s, want %s", link.Type, link.CreatedAt, original.CreatedAt)
+		}
+	}
+	return nil
+}
+
 func checkFederationAdoptionIngestLifecycle(t *testing.T, store db.Storage) error {
 	t.Helper()
 	ctx := context.Background()
@@ -2110,7 +2166,7 @@ func checkFederationAdoptionIngestLifecycle(t *testing.T, store db.Storage) erro
 		return err
 	}
 	secondSnapshot := newRemoteEvent(t, project, &secondIssueUID, "issue.snapshot", "adoption-agent",
-		spokeUID, 400, json.RawMessage(`{"uid":"`+secondIssueUID+`","title":"historical second","body":"","author":"another-historical-author","status":"open","metadata":{},"comments":[{"comment_uid":"`+commentUID+`","author":"historical-reviewer","body":"original comment","created_at":"2026-05-23T12:00:00.000Z"}],"links":[{"type":"related","to_issue_uid":"`+firstIssueUID+`","author":"historical-linker"}],"created_at":"2026-05-23T12:00:00.000Z"}`))
+		spokeUID, 400, json.RawMessage(`{"uid":"`+secondIssueUID+`","title":"historical second","body":"","author":"another-historical-author","status":"open","metadata":{},"comments":[{"comment_uid":"`+commentUID+`","author":"historical-reviewer","body":"original comment","created_at":"2026-05-23T12:00:00.000Z"}],"links":[{"type":"related","to_issue_uid":"`+firstIssueUID+`","author":"historical-linker","created_at":"2026-04-01T09:10:11.123456789Z"},{"type":"blocks","to_issue_uid":"`+firstIssueUID+`","author":"historical-linker"}],"created_at":"2026-05-23T12:00:00.000Z"}`))
 	terminalParams := db.FederationIngestParams{
 		ProjectID: project.ID, FederationEnrollmentID: created.Enrollment.ID,
 		SpokeInstanceUID: spokeUID, BoundActor: "adoption-agent",
@@ -2139,8 +2195,21 @@ func checkFederationAdoptionIngestLifecycle(t *testing.T, store db.Storage) erro
 	if err != nil {
 		return err
 	}
-	require.Len(t, links, 1)
-	assert.Equal(t, "historical-linker", links[0].Author)
+	require.Len(t, links, 2)
+	for _, link := range links {
+		assert.Equal(t, "historical-linker", link.Author)
+		if link.Type == "related" {
+			assert.Equal(t, "2026-04-01T09:10:11.123456789Z", link.CreatedAt.UTC().Format(time.RFC3339Nano))
+		} else {
+			// Old snapshots have no link date. Keep their insertion-time behavior,
+			// and do not replace that date on a subsequent rebuild.
+			assert.False(t, link.CreatedAt.IsZero())
+			require.NoError(t, store.MaterializeFederatedProject(ctx, project.ID))
+			rebuilt, err := store.LinkByID(ctx, link.ID)
+			require.NoError(t, err)
+			assert.True(t, link.CreatedAt.Equal(rebuilt.CreatedAt))
+		}
+	}
 	enrollment, err = federationEnrollmentByID(ctx, store, created.Enrollment.ID)
 	if err != nil {
 		return err

--- a/internal/db/fold.go
+++ b/internal/db/fold.go
@@ -111,6 +111,7 @@ func (p *FoldProjection) applyIssueCreated(e FoldEvent) {
 			ToIssueUID string `json:"to_issue_uid"`
 			Incoming   bool   `json:"incoming"`
 			Author     string `json:"author"`
+			CreatedAt  string `json:"created_at"`
 		} `json:"links"`
 		Comments []struct {
 			CommentUID string `json:"comment_uid"`
@@ -178,7 +179,7 @@ func (p *FoldProjection) applyIssueCreated(e FoldEvent) {
 		if author == "" {
 			author = e.Actor
 		}
-		p.setLink(from, to, link.Type, true, clockOf(e), author)
+		p.setLink(from, to, link.Type, true, clockOf(e), author, link.CreatedAt)
 	}
 	for _, comment := range in.Comments {
 		p.setComment(comment.CommentUID, uid, comment.Author, comment.Body, comment.CreatedAt, clockOf(e))
@@ -412,7 +413,7 @@ func (p *FoldProjection) applyLinkEvent(e FoldEvent, payload map[string]json.Raw
 			from, to = linkFrom, linkTo
 		}
 	}
-	p.setLink(from, to, typ, present, clockOf(e), e.Actor)
+	p.setLink(from, to, typ, present, clockOf(e), e.Actor, "")
 	p.touchIssue(issueUID(e, payload), issueUpdatedAt(e, payload))
 }
 
@@ -425,22 +426,22 @@ func (p *FoldProjection) applyLinksChanged(e FoldEvent, payload map[string]json.
 	p.applyUIDList(base, payload["parent_set_uid"], "parent", true, false, clockOf(e), e.Actor)
 	p.applyUIDList(base, payload["parent_removed_uid"], "parent", false, false, clockOf(e), e.Actor)
 	for _, uid := range stringSlice(payload["blocks_added_uids"]) {
-		p.setLink(base, uid, "blocks", true, clockOf(e), e.Actor)
+		p.setLink(base, uid, "blocks", true, clockOf(e), e.Actor, "")
 	}
 	for _, uid := range stringSlice(payload["blocks_removed_uids"]) {
-		p.setLink(base, uid, "blocks", false, clockOf(e), e.Actor)
+		p.setLink(base, uid, "blocks", false, clockOf(e), e.Actor, "")
 	}
 	for _, uid := range stringSlice(payload["blocked_by_added_uids"]) {
-		p.setLink(uid, base, "blocks", true, clockOf(e), e.Actor)
+		p.setLink(uid, base, "blocks", true, clockOf(e), e.Actor, "")
 	}
 	for _, uid := range stringSlice(payload["blocked_by_removed_uids"]) {
-		p.setLink(uid, base, "blocks", false, clockOf(e), e.Actor)
+		p.setLink(uid, base, "blocks", false, clockOf(e), e.Actor, "")
 	}
 	for _, uid := range stringSlice(payload["related_added_uids"]) {
-		p.setLink(base, uid, "related", true, clockOf(e), e.Actor)
+		p.setLink(base, uid, "related", true, clockOf(e), e.Actor, "")
 	}
 	for _, uid := range stringSlice(payload["related_removed_uids"]) {
-		p.setLink(base, uid, "related", false, clockOf(e), e.Actor)
+		p.setLink(base, uid, "related", false, clockOf(e), e.Actor, "")
 	}
 }
 
@@ -522,17 +523,17 @@ func (p *FoldProjection) applyUIDList(base string, raw json.RawMessage, typ stri
 	if incoming {
 		from, to = to, from
 	}
-	p.setLink(from, to, typ, present, clock, author)
+	p.setLink(from, to, typ, present, clock, author, "")
 }
 
-func (p *FoldProjection) setLink(from, to, typ string, present bool, clock FoldClock, author string) {
+func (p *FoldProjection) setLink(from, to, typ string, present bool, clock FoldClock, author, createdAt string) {
 	if typ == "related" && from > to {
 		from, to = to, from
 	}
 	if typ == "parent" && present {
 		p.clearOlderParents(from, to, clock)
 	}
-	p.Links[FoldLinkKey{FromUID: from, ToUID: to, Type: typ}] = FoldElementState{Present: present, Clock: clock, Author: author}
+	p.Links[FoldLinkKey{FromUID: from, ToUID: to, Type: typ}] = FoldElementState{Present: present, Clock: clock, Author: author, CreatedAt: createdAt}
 }
 
 func (p *FoldProjection) clearOlderParents(childUID, keepParentUID string, clock FoldClock) {

--- a/internal/db/fold_types.go
+++ b/internal/db/fold_types.go
@@ -83,6 +83,9 @@ type FoldElementState struct {
 	Present bool
 	Clock   FoldClock
 	Author  string
+	// CreatedAt is the original link date when supplied by a snapshot.
+	// Empty means the event did not record it; labels do not use this field.
+	CreatedAt string
 }
 
 // FoldLinkEdge pairs one link key with its tombstone state. It is the element

--- a/internal/db/pgstore/federation_links.go
+++ b/internal/db/pgstore/federation_links.go
@@ -16,13 +16,14 @@ import (
 )
 
 type federatedLinkRow struct {
-	id      int64
-	fromID  int64
-	toID    int64
-	fromUID string
-	toUID   string
-	typ     string
-	author  string
+	id        int64
+	fromID    int64
+	toID      int64
+	fromUID   string
+	toUID     string
+	typ       string
+	author    string
+	createdAt string
 }
 
 func (row federatedLinkRow) key() db.FoldLinkKey {
@@ -187,7 +188,7 @@ func reconcileFederatedLinkGroup(
 		}
 		row := federatedLinkRow{
 			fromID: fromID, toID: toID, fromUID: fromUID, toUID: toUID,
-			typ: key.Type, author: state.Author,
+			typ: key.Type, author: state.Author, createdAt: state.CreatedAt,
 		}
 		desired[row.key()] = row
 	}
@@ -205,20 +206,21 @@ func reconcileFederatedLinkGroup(
 	for key, row := range desired {
 		author := nonEmptyFederationAuthor(row.author)
 		if existingRow, ok := existing[key]; ok {
-			if existingRow.fromID == row.fromID && existingRow.toID == row.toID && existingRow.author == author {
+			if existingRow.fromID == row.fromID && existingRow.toID == row.toID && existingRow.author == author && (row.createdAt == "" || existingRow.createdAt == row.createdAt) {
 				continue
 			}
 			_, err := tx.ExecContext(ctx, `UPDATE links SET from_issue_id=$1,to_issue_id=$2,
-from_issue_uid=$3,to_issue_uid=$4,type=$5,author=$6 WHERE id=$7`,
-				row.fromID, row.toID, row.fromUID, row.toUID, row.typ, author, existingRow.id)
+from_issue_uid=$3,to_issue_uid=$4,type=$5,author=$6,created_at=COALESCE(NULLIF($7,''),created_at) WHERE id=$8`,
+				row.fromID, row.toID, row.fromUID, row.toUID, row.typ, author, row.createdAt, existingRow.id)
 			if err != nil {
 				return mapSQLError(err, linkConstraintErrors)
 			}
 			continue
 		}
 		_, err := tx.ExecContext(ctx, `INSERT INTO links(
-from_issue_id,to_issue_id,from_issue_uid,to_issue_uid,type,author
-) VALUES($1,$2,$3,$4,$5,$6)`, row.fromID, row.toID, row.fromUID, row.toUID, row.typ, author)
+from_issue_id,to_issue_id,from_issue_uid,to_issue_uid,type,author,created_at
+) VALUES($1,$2,$3,$4,$5,$6,COALESCE(NULLIF($7,''),to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')))`,
+			row.fromID, row.toID, row.fromUID, row.toUID, row.typ, author, row.createdAt)
 		if err != nil {
 			return mapSQLError(err, linkConstraintErrors)
 		}
@@ -390,7 +392,7 @@ func federatedLinkRows(
 	args := append(fromArgs, toArgs...)
 	//nolint:gosec // IN values use generated placeholders with separately bound integer IDs.
 	rows, err := tx.QueryContext(ctx, `SELECT l.id,l.from_issue_id,l.to_issue_id,
-l.from_issue_uid,l.to_issue_uid,l.type,l.author FROM links l
+l.from_issue_uid,l.to_issue_uid,l.type,l.author,l.created_at FROM links l
 JOIN issues f ON f.id=l.from_issue_id JOIN issues t ON t.id=l.to_issue_id
 WHERE f.project_id IN (`+fromPlaceholders+`) AND t.project_id IN (`+toPlaceholders+`)`, args...)
 	if err != nil {
@@ -401,7 +403,7 @@ WHERE f.project_id IN (`+fromPlaceholders+`) AND t.project_id IN (`+toPlaceholde
 	for rows.Next() {
 		var row federatedLinkRow
 		if err := rows.Scan(&row.id, &row.fromID, &row.toID, &row.fromUID, &row.toUID,
-			&row.typ, &row.author); err != nil {
+			&row.typ, &row.author, &row.createdAt); err != nil {
 			return nil, mapSQLError(err, nil)
 		}
 		output[row.key()] = row

--- a/internal/db/pgstore/federation_projection.go
+++ b/internal/db/pgstore/federation_projection.go
@@ -651,6 +651,13 @@ func reconcileFederatedComments(
 			return fmt.Errorf("federated comment %s references unknown issue %s", commentUID, comment.IssueUID)
 		}
 		if row, ok := existing[commentUID]; ok {
+			// A fold visits all existing comments, even when the incoming batch
+			// changed none of them. Avoid per-comment queries and writes while
+			// the ingest transaction holds the event-ordering fence.
+			if row.issueID == issueID && row.author == nonEmptyFederationAuthor(comment.Author) &&
+				row.body == comment.Body && row.createdAt == nonEmptyFederationTime(comment.CreatedAt) {
+				continue
+			}
 			owned, err := federatedExternalCommentOwnedTx(ctx, tx, row.id)
 			if err != nil {
 				return err
@@ -681,8 +688,11 @@ WHERE id=$5`, issueID, nonEmptyFederationAuthor(comment.Author), comment.Body,
 }
 
 type federatedCommentRow struct {
-	id   int64
-	body string
+	id        int64
+	issueID   int64
+	author    string
+	body      string
+	createdAt string
 }
 
 func federatedExternalCommentOwnedTx(ctx context.Context, tx *sql.Tx, commentID int64) (bool, error) {
@@ -707,7 +717,7 @@ func federatedCommentRowsByUID(
 	tx *sql.Tx,
 	projectID int64,
 ) (map[string]federatedCommentRow, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT c.uid,c.id,c.body FROM comments c
+	rows, err := tx.QueryContext(ctx, `SELECT c.uid,c.id,c.issue_id,c.author,c.body,c.created_at FROM comments c
 JOIN issues i ON i.id=c.issue_id WHERE i.project_id=$1`, projectID)
 	if err != nil {
 		return nil, mapSQLError(err, nil)
@@ -717,7 +727,7 @@ JOIN issues i ON i.id=c.issue_id WHERE i.project_id=$1`, projectID)
 	for rows.Next() {
 		var commentUID string
 		var row federatedCommentRow
-		if err := rows.Scan(&commentUID, &row.id, &row.body); err != nil {
+		if err := rows.Scan(&commentUID, &row.id, &row.issueID, &row.author, &row.body, &row.createdAt); err != nil {
 			return nil, mapSQLError(err, nil)
 		}
 		output[commentUID] = row

--- a/internal/db/pgstore/federation_projection.go
+++ b/internal/db/pgstore/federation_projection.go
@@ -301,10 +301,10 @@ func federationIssueLabels(ctx context.Context, tx *sql.Tx, issueID int64) ([]st
 }
 
 func federationIssueLinks(ctx context.Context, tx *sql.Tx, issueID int64) ([]createdLink, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT l.type,peer.short_id,peer.uid,FALSE,l.author
+	rows, err := tx.QueryContext(ctx, `SELECT l.type,peer.short_id,peer.uid,FALSE,l.author,l.created_at
 FROM links l JOIN issues peer ON peer.id=l.to_issue_id WHERE l.from_issue_id=$1
 UNION ALL
-SELECT l.type,peer.short_id,peer.uid,CASE WHEN l.type='related' THEN FALSE ELSE TRUE END,l.author
+SELECT l.type,peer.short_id,peer.uid,CASE WHEN l.type='related' THEN FALSE ELSE TRUE END,l.author,l.created_at
 FROM links l JOIN issues peer ON peer.id=l.from_issue_id WHERE l.to_issue_id=$1
 AND peer.project_id<>(SELECT project_id FROM issues WHERE id=$1)
 ORDER BY 1 ASC,3 ASC,4 ASC`, issueID)
@@ -315,7 +315,7 @@ ORDER BY 1 ASC,3 ASC,4 ASC`, issueID)
 	var output []createdLink
 	for rows.Next() {
 		var link createdLink
-		if err := rows.Scan(&link.Type, &link.ToShortID, &link.ToIssueUID, &link.Incoming, &link.Author); err != nil {
+		if err := rows.Scan(&link.Type, &link.ToShortID, &link.ToIssueUID, &link.Incoming, &link.Author, &link.CreatedAt); err != nil {
 			return nil, mapSQLError(err, nil)
 		}
 		output = append(output, link)

--- a/internal/db/pgstore/federation_projection_regression_test.go
+++ b/internal/db/pgstore/federation_projection_regression_test.go
@@ -67,6 +67,67 @@ func TestMaterializeFederatedProjectPrunesLinkedIssueMissingFromProjection(t *te
 	assert.ErrorIs(t, err, db.ErrNotFound)
 }
 
+func TestMaterializeFederatedProjectLeavesUnchangedCommentsUnwritten(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires postgres testcontainer")
+	}
+	ctx := t.Context()
+	dsn, cleanup := testenv.NewPostgresContainer(t, ctx)
+	t.Cleanup(cleanup)
+	store, err := OpenWithConfig(ctx, dsn, Config{
+		Schema: "comment_rebuild", SchemaMode: SchemaModeBootstrap,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	project, err := store.CreateProject(ctx, "comment-rebuild")
+	require.NoError(t, err)
+	_, err = store.UpsertFederationBinding(ctx, db.FederationBinding{
+		ProjectID: project.ID, Role: db.FederationRoleSpoke,
+		HubURL: "https://hub.example", HubProjectID: 1,
+		HubProjectUID: project.UID, Enabled: true,
+	})
+	require.NoError(t, err)
+	origin, err := uid.New()
+	require.NoError(t, err)
+	issueUID, err := uid.New()
+	require.NoError(t, err)
+	commentUID, err := uid.New()
+	require.NoError(t, err)
+	snapshot := projectionSnapshotEvent(t, project, issueUID, origin, 1,
+		json.RawMessage(`{"uid":"`+issueUID+`","title":"original issue","author":"remote","status":"open","comments":[{"comment_uid":"`+commentUID+`","author":"reviewer","body":"original comment","created_at":"2026-05-20T10:00:00.000Z"}],"created_at":"2026-05-20T09:00:00.000Z"}`))
+	_, err = store.InsertRemoteEvent(ctx, project.ID, snapshot)
+	require.NoError(t, err)
+	require.NoError(t, store.MaterializeFederatedProject(ctx, project.ID))
+	var before, after string
+	require.NoError(t, store.QueryRowContext(ctx,
+		`SELECT xmin::text FROM comments WHERE uid=$1`, commentUID).Scan(&before))
+	require.NoError(t, store.MaterializeFederatedProject(ctx, project.ID))
+	require.NoError(t, store.QueryRowContext(ctx,
+		`SELECT xmin::text FROM comments WHERE uid=$1`, commentUID).Scan(&after))
+	assert.Equal(t, before, after, "rebuilding unchanged state must not rewrite the comment row")
+
+	edit := snapshot
+	edit.EventUID, err = uid.New()
+	require.NoError(t, err)
+	edit.Type, edit.HLCCounter = "issue.comment_edited", 2
+	edit.Payload = json.RawMessage(`{"comment_uid":"` + commentUID + `","body":"revised comment"}`)
+	edit.ContentHash, err = db.EventContentHash(db.EventHashInput{
+		UID: edit.EventUID, OriginInstanceUID: edit.OriginInstanceUID,
+		ProjectUID: edit.ProjectUID, ProjectName: edit.ProjectName,
+		IssueUID: edit.IssueUID, Type: edit.Type, Actor: edit.Actor,
+		HLCPhysicalMS: edit.HLCPhysicalMS, HLCCounter: edit.HLCCounter,
+		CreatedAt: "2026-05-23T12:00:00.000Z", Payload: edit.Payload,
+	})
+	require.NoError(t, err)
+	_, err = store.InsertRemoteEvent(ctx, project.ID, edit)
+	require.NoError(t, err)
+	require.NoError(t, store.MaterializeFederatedProject(ctx, project.ID))
+	var body string
+	require.NoError(t, store.QueryRowContext(ctx,
+		`SELECT body FROM comments WHERE uid=$1`, commentUID).Scan(&body))
+	assert.Equal(t, "revised comment", body, "a real remote edit must still update the comment")
+}
+
 func projectionSnapshotEvent(
 	t *testing.T,
 	project db.Project,

--- a/internal/db/pgstore/issues.go
+++ b/internal/db/pgstore/issues.go
@@ -60,6 +60,7 @@ type createdLink struct {
 	ToIssueUID string `json:"to_issue_uid,omitempty"`
 	Incoming   bool   `json:"incoming,omitempty"`
 	Author     string `json:"author,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
 }
 
 type issueSnapshotComment struct {

--- a/internal/db/sqlitestore/federation.go
+++ b/internal/db/sqlitestore/federation.go
@@ -1448,14 +1448,14 @@ func federationIssueLabels(ctx context.Context, tx *sql.Tx, issueID int64) ([]st
 
 func federationIssueLinks(ctx context.Context, tx *sql.Tx, issueID int64) ([]createdLinkOut, error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT l.type, peer.short_id, peer.uid, 0 AS incoming, l.author
+		SELECT l.type, peer.short_id, peer.uid, 0 AS incoming, l.author, l.created_at
 		  FROM links l
 		  JOIN issues peer ON peer.id = l.to_issue_id
 		 WHERE l.from_issue_id = ?
 		UNION ALL
 		SELECT l.type, peer.short_id, peer.uid,
 		       CASE WHEN l.type = 'related' THEN 0 ELSE 1 END AS incoming,
-		       l.author
+		       l.author, l.created_at
 		  FROM links l
 		  JOIN issues peer ON peer.id = l.from_issue_id
 		 WHERE l.to_issue_id = ?
@@ -1468,9 +1468,11 @@ func federationIssueLinks(ctx context.Context, tx *sql.Tx, issueID int64) ([]cre
 	var out []createdLinkOut
 	for rows.Next() {
 		var link createdLinkOut
-		if err := rows.Scan(&link.Type, &link.ToShortID, &link.ToIssueUID, &link.Incoming, &link.Author); err != nil {
+		var createdAt time.Time
+		if err := rows.Scan(&link.Type, &link.ToShortID, &link.ToIssueUID, &link.Incoming, &link.Author, &createdAt); err != nil {
 			return nil, fmt.Errorf("scan federation snapshot link: %w", err)
 		}
+		link.CreatedAt = createdAt.UTC().Format(time.RFC3339Nano)
 		out = append(out, link)
 	}
 	return out, rows.Err()
@@ -1968,13 +1970,14 @@ func federatedLabelKeys(ctx context.Context, tx *sql.Tx, projectID int64) (map[f
 }
 
 type federatedLinkRow struct {
-	id      int64
-	fromID  int64
-	toID    int64
-	fromUID string
-	toUID   string
-	typ     string
-	author  string
+	id        int64
+	fromID    int64
+	toID      int64
+	fromUID   string
+	toUID     string
+	typ       string
+	author    string
+	createdAt string
 }
 
 func (r federatedLinkRow) key() db.FoldLinkKey {
@@ -2032,12 +2035,13 @@ func reconcileFederatedLinkGroup(
 			fromUID, toUID = toUID, fromUID
 		}
 		row := federatedLinkRow{
-			fromID:  fromID,
-			toID:    toID,
-			fromUID: fromUID,
-			toUID:   toUID,
-			typ:     key.Type,
-			author:  state.Author,
+			fromID:    fromID,
+			toID:      toID,
+			fromUID:   fromUID,
+			toUID:     toUID,
+			typ:       key.Type,
+			author:    state.Author,
+			createdAt: state.CreatedAt,
 		}
 		desired[row.key()] = row
 	}
@@ -2054,23 +2058,24 @@ func reconcileFederatedLinkGroup(
 	}
 	for key, row := range desired {
 		if existingRow, ok := existing[key]; ok {
-			if existingRow.fromID == row.fromID && existingRow.toID == row.toID && existingRow.author == nonEmptyAuthor(row.author) {
+			if existingRow.fromID == row.fromID && existingRow.toID == row.toID && existingRow.author == nonEmptyAuthor(row.author) && (row.createdAt == "" || existingRow.createdAt == row.createdAt) {
 				continue
 			}
 			if _, err := tx.ExecContext(ctx, `
 				UPDATE links
 				   SET from_issue_id = ?, to_issue_id = ?,
-				       from_issue_uid = ?, to_issue_uid = ?, type = ?, author = ?
+				       from_issue_uid = ?, to_issue_uid = ?, type = ?, author = ?,
+				       created_at = COALESCE(NULLIF(?, ''), created_at)
 				 WHERE id = ?`,
-				row.fromID, row.toID, row.fromUID, row.toUID, row.typ, nonEmptyAuthor(row.author), existingRow.id); err != nil {
+				row.fromID, row.toID, row.fromUID, row.toUID, row.typ, nonEmptyAuthor(row.author), row.createdAt, existingRow.id); err != nil {
 				return fmt.Errorf("update federated link %s %s->%s: %w", key.Type, key.FromUID, key.ToUID, err)
 			}
 			continue
 		}
 		if _, err := tx.ExecContext(ctx, `
-			INSERT INTO links(from_issue_id, to_issue_id, from_issue_uid, to_issue_uid, type, author)
-			VALUES(?, ?, ?, ?, ?, ?)`,
-			row.fromID, row.toID, row.fromUID, row.toUID, row.typ, nonEmptyAuthor(row.author)); err != nil {
+			INSERT INTO links(from_issue_id, to_issue_id, from_issue_uid, to_issue_uid, type, author, created_at)
+			VALUES(?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?, ''), strftime('%Y-%m-%dT%H:%M:%fZ','now')))`,
+			row.fromID, row.toID, row.fromUID, row.toUID, row.typ, nonEmptyAuthor(row.author), row.createdAt); err != nil {
 			return fmt.Errorf("insert federated link %s %s->%s: %w", key.Type, key.FromUID, key.ToUID, err)
 		}
 	}
@@ -2405,7 +2410,7 @@ func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectIDs []int64) (map
 	queryArgs = append(queryArgs, args...)
 	//nolint:gosec // IN values use generated ? placeholders with separately bound integer IDs.
 	rows, err := tx.QueryContext(ctx, `
-		SELECT l.id, l.from_issue_id, l.to_issue_id, l.from_issue_uid, l.to_issue_uid, l.type, l.author
+		SELECT l.id, l.from_issue_id, l.to_issue_id, l.from_issue_uid, l.to_issue_uid, l.type, l.author, CAST(l.created_at AS TEXT)
 		  FROM links l
 		  JOIN issues f ON f.id = l.from_issue_id
 		  JOIN issues t ON t.id = l.to_issue_id
@@ -2418,7 +2423,7 @@ func federatedLinkRows(ctx context.Context, tx *sql.Tx, projectIDs []int64) (map
 	out := map[db.FoldLinkKey]federatedLinkRow{}
 	for rows.Next() {
 		var row federatedLinkRow
-		if err := rows.Scan(&row.id, &row.fromID, &row.toID, &row.fromUID, &row.toUID, &row.typ, &row.author); err != nil {
+		if err := rows.Scan(&row.id, &row.fromID, &row.toID, &row.fromUID, &row.toUID, &row.typ, &row.author, &row.createdAt); err != nil {
 			return nil, fmt.Errorf("scan federated link: %w", err)
 		}
 		out[row.key()] = row

--- a/internal/db/sqlitestore/queries.go
+++ b/internal/db/sqlitestore/queries.go
@@ -763,6 +763,7 @@ type createdLinkOut struct {
 	ToIssueUID string `json:"to_issue_uid,omitempty"`
 	Incoming   bool   `json:"incoming,omitempty"`
 	Author     string `json:"author,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
 }
 
 type issueSnapshotComment struct {


### PR DESCRIPTION
Fix two problems during federation adoption and projection rebuilds:

- Preserve relationship creation dates in new snapshots on both SQLite and PostgreSQL. Previously, snapshots omitted the date and rebuilt links received the time of insertion instead.
- Skip PostgreSQL comment queries and writes when the stored issue, author, body, and creation date already match the folded state. Rewriting every comment held the event-ordering lock longer and delayed unrelated writers. Real edits still follow the existing ownership checks and write path.

No database schema changes are required, and event ordering is unchanged. Older snapshots without relationship dates remain readable with their existing insertion-time behavior; this does not invent missing dates or rewrite historical events.

Regression coverage checks relationship dates through snapshot generation and repeated rebuilds on both backends, and verifies that unchanged PostgreSQL comments retain their row version while remote edits still apply.
