### PR TITLE
Support mounting the browser application below a path

### DIFF
--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -148,6 +148,8 @@ sessions, and event streams below the mount. It returns `404` outside that
 path. The host still owns authentication exactly as described below;
 `HandlerAt` changes routing only. Mounts at `/api` or below it are rejected
 because that namespace belongs to the browser application's API routes.
+Standalone `/kata/` redirects to `/kata`, preserving view and filter queries
+so relative assets load from the origin root.
 
 ## Host-owned access
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -146,7 +146,8 @@ To serve the complete API and browser application below a path, use
 its trailing-slash form and keeps browser assets, deep links, API requests,
 sessions, and event streams below the mount. It returns `404` outside that
 path. The host still owns authentication exactly as described below;
-`HandlerAt` changes routing only.
+`HandlerAt` changes routing only. Mounts at `/api` or below it are rejected
+because that namespace belongs to the browser application's API routes.
 
 ## Host-owned access
 

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -140,6 +140,14 @@ use `server.ListenAndServeTLS(certFile, keyFile)` with a valid certificate or
 mount the handler behind a TLS-terminating reverse proxy. Never send the bearer
 token over plaintext non-loopback HTTP.
 
+To serve the complete API and browser application below a path, use
+`service.HandlerAt("/tools/tasks")` instead of wrapping `service.Handler()` with
+`http.StripPrefix` yourself. The returned handler redirects the exact path to
+its trailing-slash form and keeps browser assets, deep links, API requests,
+sessions, and event streams below the mount. It returns `404` outside that
+path. The host still owns authentication exactly as described below;
+`HandlerAt` changes routing only.
+
 ## Host-owned access
 
 `AccessController` is the fine-grained embedding seam. Kata calls it after a

--- a/e2e/port_env_test.go
+++ b/e2e/port_env_test.go
@@ -92,6 +92,9 @@ func TestPortEnvBind_ServesAndShutsDownCleanly(t *testing.T) {
 	// Graceful SIGTERM: the daemon's signal.NotifyContext wiring cancels
 	// the root context, which triggers httpSrv.Shutdown. A clean exit is
 	// code 0; we assert no error from cmd.Wait().
+	// Allow the documented 25-second drain budget plus five seconds for
+	// final cleanup and process exit, as daemon restart does.
+	const shutdownWait = 30 * time.Second
 	require.NoError(t, cmd.Process.Signal(syscall.SIGTERM))
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
@@ -99,10 +102,10 @@ func TestPortEnvBind_ServesAndShutsDownCleanly(t *testing.T) {
 	case waitErr := <-done:
 		assert.NoErrorf(t, waitErr,
 			"daemon should exit cleanly on SIGTERM (stderr: %s)", stderr.String())
-	case <-time.After(5 * time.Second):
+	case <-time.After(shutdownWait):
 		_ = cmd.Process.Kill()
 		<-done
-		t.Fatalf("daemon did not exit within 5s of SIGTERM (stderr: %s)", stderr.String())
+		t.Fatalf("daemon did not exit within %s of SIGTERM (stderr: %s)", shutdownWait, stderr.String())
 	}
 }
 

--- a/e2e/web_assets_test.go
+++ b/e2e/web_assets_test.go
@@ -111,9 +111,9 @@ func TestReleaseBinaryContainsValidatedWebUI(t *testing.T) {
 	index := releaseGET(t, client, origin+"/")
 	require.Contains(t, index, productionWebMarker)
 	require.NotContains(t, index, "Kata UI assets are not built")
-	assetPath := regexp.MustCompile(`(?:src|href)="(/assets/[^"]+)"`).FindStringSubmatch(index)
+	assetPath := regexp.MustCompile(`(?:src|href)="(\./assets/[^"]+)"`).FindStringSubmatch(index)
 	require.Len(t, assetPath, 2, "production index must reference a built asset")
-	releaseGET(t, client, origin+assetPath[1])
+	releaseGET(t, client, origin+"/"+strings.TrimPrefix(assetPath[1], "./"))
 	require.Contains(t, releaseGET(t, client, origin+"/kata?view=all-open"), productionWebMarker)
 
 	waitForWebRuntime(t, home, origin, stderr)

--- a/e2e/web_assets_test.go
+++ b/e2e/web_assets_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,6 +116,23 @@ func TestReleaseBinaryContainsValidatedWebUI(t *testing.T) {
 	require.Len(t, assetPath, 2, "production index must reference a built asset")
 	releaseGET(t, client, origin+"/"+strings.TrimPrefix(assetPath[1], "./"))
 	require.Contains(t, releaseGET(t, client, origin+"/kata?view=all-open"), productionWebMarker)
+
+	request, err := http.NewRequest(http.MethodGet, origin+"/kata/?view=today&label=ready", nil)
+	require.NoError(t, err)
+	request.Header.Set("Accept", "text/html")
+	page, err := client.Do(request) //nolint:gosec // loopback origin selected by this test.
+	require.NoError(t, err)
+	pageBody, err := io.ReadAll(page.Body)
+	require.NoError(t, page.Body.Close())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, page.StatusCode)
+	require.Equal(t, origin+"/kata?view=today&label=ready", page.Request.URL.String())
+	require.Contains(t, string(pageBody), productionWebMarker)
+	pageAsset := regexp.MustCompile(`(?:src|href)="(\./assets/[^"]+)"`).FindSubmatch(pageBody)
+	require.Len(t, pageAsset, 2)
+	reference, err := url.Parse(string(pageAsset[1]))
+	require.NoError(t, err)
+	releaseGET(t, client, page.Request.URL.ResolveReference(reference).String())
 
 	waitForWebRuntime(t, home, origin, stderr)
 	sessionResponse := releaseJSON(t, client, http.MethodPost, origin+"/api/v1/ui/session/local",

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"mime"
 	"net/http"
+	"net/url"
 	"path"
 	"strconv"
 	"strings"
@@ -81,6 +82,14 @@ func (h *handler) serve(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/" {
 		w.Header().Set("Cache-Control", "no-store")
 		http.Redirect(w, r, defaultRoute, http.StatusFound)
+		return
+	}
+	if r.URL.Path == defaultRoute+"/" {
+		// Relative assets must resolve from the origin root on standalone pages.
+		location := (&url.URL{Path: "../kata", RawQuery: r.URL.RawQuery}).String()
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Location", location)
+		w.WriteHeader(http.StatusPermanentRedirect)
 		return
 	}
 	if daemonOwnedPath(r.URL.Path) || !safeRequestPath(r.URL.Path) {

--- a/service.go
+++ b/service.go
@@ -342,7 +342,11 @@ func (s *Service) HandlerAt(mountPath string) (http.Handler, error) {
 	}))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == mountPath {
-			http.Redirect(w, r, path.Base(mountPath)+"/", http.StatusPermanentRedirect)
+			target := path.Base(mountPath) + "/"
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, target, http.StatusPermanentRedirect)
 			return
 		}
 		mounted.ServeHTTP(w, r)

--- a/service.go
+++ b/service.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -311,6 +312,42 @@ func resolveGitHubSyncConfig(cfg GitHubSyncConfig) (config.GitHubSyncConfig, err
 
 // Handler returns the HTTP application for mounting in a caller-owned server.
 func (s *Service) Handler() http.Handler { return http.HandlerFunc(s.serveHTTP) }
+
+// HandlerAt mounts the complete Kata HTTP application below one clean,
+// absolute path. The returned handler owns only that path. Requests for the
+// path without its trailing slash are redirected so relative browser assets
+// and API requests stay beneath the mount.
+func (s *Service) HandlerAt(mountPath string) (http.Handler, error) {
+	if mountPath == "" || mountPath == "/" || !strings.HasPrefix(mountPath, "/") ||
+		strings.HasSuffix(mountPath, "/") || path.Clean(mountPath) != mountPath ||
+		strings.Contains(mountPath, `\`) {
+		return nil, errors.New("kata: mount path must be a clean absolute path without a trailing slash")
+	}
+	for _, r := range mountPath {
+		if r < 0x20 || r == 0x7f {
+			return nil, errors.New("kata: mount path must not contain control characters")
+		}
+	}
+
+	application := s.Handler()
+	mounted := http.StripPrefix(mountPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			request := r.Clone(r.Context())
+			request.URL.Path = "/kata"
+			request.URL.RawPath = ""
+			application.ServeHTTP(w, request)
+			return
+		}
+		application.ServeHTTP(w, r)
+	}))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == mountPath {
+			http.Redirect(w, r, path.Base(mountPath)+"/", http.StatusPermanentRedirect)
+			return
+		}
+		mounted.ServeHTTP(w, r)
+	}), nil
+}
 
 func (s *Service) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()

--- a/service.go
+++ b/service.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 	"sync"
@@ -323,6 +324,9 @@ func (s *Service) HandlerAt(mountPath string) (http.Handler, error) {
 		strings.Contains(mountPath, `\`) {
 		return nil, errors.New("kata: mount path must be a clean absolute path without a trailing slash")
 	}
+	if mountPath == "/api" || strings.HasPrefix(mountPath, "/api/") {
+		return nil, errors.New("kata: mount path must not overlap the API namespace")
+	}
 	for _, r := range mountPath {
 		if r < 0x20 || r == 0x7f {
 			return nil, errors.New("kata: mount path must not contain control characters")
@@ -342,11 +346,11 @@ func (s *Service) HandlerAt(mountPath string) (http.Handler, error) {
 	}))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == mountPath {
-			target := path.Base(mountPath) + "/"
-			if r.URL.RawQuery != "" {
-				target += "?" + r.URL.RawQuery
-			}
-			http.Redirect(w, r, target, http.StatusPermanentRedirect)
+			location := (&url.URL{
+				Path: path.Base(mountPath) + "/", RawQuery: r.URL.RawQuery,
+			}).String()
+			w.Header().Set("Location", location)
+			w.WriteHeader(http.StatusPermanentRedirect)
 			return
 		}
 		mounted.ServeHTTP(w, r)

--- a/service.go
+++ b/service.go
@@ -353,6 +353,10 @@ func (s *Service) HandlerAt(mountPath string) (http.Handler, error) {
 			w.WriteHeader(http.StatusPermanentRedirect)
 			return
 		}
+		if !strings.HasPrefix(r.URL.Path, mountPath+"/") {
+			http.NotFound(w, r)
+			return
+		}
 		mounted.ServeHTTP(w, r)
 	}), nil
 }

--- a/service_test.go
+++ b/service_test.go
@@ -113,7 +113,9 @@ func TestServiceHandlerAtRejectsInvalidMountPaths(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, service.Close()) })
 
-	for _, mountPath := range []string{"", "/", "relative", "/trailing/", "/not/../clean"} {
+	for _, mountPath := range []string{
+		"", "/", "relative", "/trailing/", "/not/../clean", "/api", "/api/v1",
+	} {
 		t.Run(strings.ReplaceAll(mountPath, "/", "_"), func(t *testing.T) {
 			handler, err := service.HandlerAt(mountPath)
 			assert.Nil(t, handler)

--- a/service_test.go
+++ b/service_test.go
@@ -124,6 +124,23 @@ func TestServiceHandlerAtRejectsInvalidMountPaths(t *testing.T) {
 	}
 }
 
+func TestServiceHandlerAtRejectsSiblingPathBeforeCallingService(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	handler, err := service.HandlerAt("/tools/tasks")
+	require.NoError(t, err)
+	require.NoError(t, service.Close())
+
+	request := httptest.NewRequest(http.MethodGet, "/tools/tasks-other", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusNotFound, response.Code)
+}
+
 func TestNewRejectsMissingDSN(t *testing.T) {
 	service, err := kata.New(context.Background(), kata.Config{})
 

--- a/service_test.go
+++ b/service_test.go
@@ -77,13 +77,18 @@ func TestServiceHandlerAtMountsAPIAndBrowserApplication(t *testing.T) {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	request, err := http.NewRequest(http.MethodGet, server.URL+"/tools/tasks", nil)
+	request, err := http.NewRequest(
+		http.MethodGet, server.URL+"/tools/tasks?view=today&label=ready", nil,
+	)
 	require.NoError(t, err)
 	request.Header.Set("Accept", "text/html")
 	redirect, err := http.DefaultClient.Do(request)
 	require.NoError(t, err)
 	defer func() { _ = redirect.Body.Close() }()
-	assert.Equal(t, server.URL+"/tools/tasks/", redirect.Request.URL.String())
+	assert.Equal(t,
+		server.URL+"/tools/tasks/?view=today&label=ready",
+		redirect.Request.URL.String(),
+	)
 	assert.Equal(t, http.StatusOK, redirect.StatusCode)
 	body, err := io.ReadAll(redirect.Body)
 	require.NoError(t, err)

--- a/service_test.go
+++ b/service_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,6 +62,59 @@ func TestServiceMountRunAndClose(t *testing.T) {
 	projects := listProjects(t, reopenedServer.URL)
 	require.Len(t, projects.Projects, 1)
 	assert.Equal(t, "example-project", projects.Projects[0].Name)
+}
+
+func TestServiceHandlerAtMountsAPIAndBrowserApplication(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	handler, err := service.HandlerAt("/tools/tasks")
+	require.NoError(t, err)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/tools/tasks", nil)
+	require.NoError(t, err)
+	request.Header.Set("Accept", "text/html")
+	redirect, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer func() { _ = redirect.Body.Close() }()
+	assert.Equal(t, server.URL+"/tools/tasks/", redirect.Request.URL.String())
+	assert.Equal(t, http.StatusOK, redirect.StatusCode)
+	body, err := io.ReadAll(redirect.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Kata UI assets are not built")
+
+	health, err := http.Get(server.URL + "/tools/tasks/api/v1/health")
+	require.NoError(t, err)
+	defer func() { _ = health.Body.Close() }()
+	assert.Equal(t, http.StatusOK, health.StatusCode)
+
+	outside, err := http.Get(server.URL + "/api/v1/health")
+	require.NoError(t, err)
+	defer func() { _ = outside.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, outside.StatusCode)
+}
+
+func TestServiceHandlerAtRejectsInvalidMountPaths(t *testing.T) {
+	service, err := kata.New(context.Background(), kata.Config{
+		DSN:  filepath.Join(t.TempDir(), "service.db"),
+		Auth: kata.AuthConfig{TrustCallerAuthentication: true},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, service.Close()) })
+
+	for _, mountPath := range []string{"", "/", "relative", "/trailing/", "/not/../clean"} {
+		t.Run(strings.ReplaceAll(mountPath, "/", "_"), func(t *testing.T) {
+			handler, err := service.HandlerAt(mountPath)
+			assert.Nil(t, handler)
+			assert.ErrorContains(t, err, "mount path")
+		})
+	}
 }
 
 func TestNewRejectsMissingDSN(t *testing.T) {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -81,10 +81,13 @@
     type UISnapshotIntent,
   } from './lib/state/snapshot'
   import { loadPreferences, savePreferences, type Preferences } from './lib/state/preferences'
+  import { applicationRoutePath, currentApplicationBaseURL } from './lib/applicationBase'
 
   type ShellMode = 'loading' | 'launch' | 'login' | 'route-error' | 'ready'
   type AppRoute = Exclude<KataRoute, { kind: 'route-error' }>
   const requestActor = 'kata-web'
+  const routePath = applicationRoutePath()
+  const mountedApplication = currentApplicationBaseURL().pathname !== '/'
 
   initTheme({ storageKey: 'kata.kit-ui.theme.v1' })
 
@@ -93,7 +96,7 @@
   }
   const launch = consumeLaunchFragment(window.location, history.replaceState.bind(history))
   const launchDaemonID = launch.daemonID
-  const directDaemonTarget = launch.directTarget === true
+  const directDaemonTarget = launch.directTarget === true || mountedApplication
   const selectedAuthentication = selectAuthenticationMode(launch)
   const initialRoute = parseRoute(new URL(window.location.href))
   let route = $state(initialRoute)
@@ -249,7 +252,9 @@
   async function navigateAfterAuthentication(target: string): Promise<boolean> {
     const parsed = new URL(target, window.location.origin)
     const canonicalTarget =
-      parsed.pathname === '/' ? `/kata${parsed.search}` : `${parsed.pathname}${parsed.search}`
+      parsed.pathname === '/'
+        ? `${routePath}${parsed.search}`
+        : `${parsed.pathname}${parsed.search}`
     history.replaceState(null, '', canonicalTarget)
     route = parseRoute(new URL(window.location.href))
     mode = route.kind === 'route-error' ? 'route-error' : authority?.snapshot ? 'ready' : 'loading'
@@ -793,7 +798,7 @@
         return false
       }
       daemonError = undefined
-      if (activeDaemonID && window.location.pathname === '/kata' && !window.location.search) {
+      if (activeDaemonID && window.location.pathname === routePath && !window.location.search) {
         const persisted = loadDaemonRoute(activeDaemonID)
         if (persisted) {
           history.replaceState(null, '', persisted)
@@ -828,7 +833,7 @@
     const sourceDaemon = activeDaemonID
     const sourceRoute = route.kind === 'route-error' ? acceptedRoute : route
     if (sourceDaemon && sourceRoute) saveDaemonRoute(sourceDaemon, serializeRoute(sourceRoute))
-    const restoredPath = loadDaemonRoute(id) ?? '/kata?view=all-open'
+    const restoredPath = loadDaemonRoute(id) ?? `${routePath}?view=all-open`
     const restored = parseRoute(new URL(restoredPath, window.location.origin))
     if (restored.kind === 'route-error') return
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1,5 +1,6 @@
 import type { SessionCredentials } from '../auth/session'
 import { loadSessionCredentials } from '../auth/session'
+import { applicationRequest, applicationURL } from '../applicationBase'
 
 type CredentialReader = () => SessionCredentials | undefined
 type AuthenticationRequiredHandler = () => boolean
@@ -29,7 +30,7 @@ export function createCredentialedFetch(
         headers.set('X-Kata-CSRF', credentials.csrf)
       }
     }
-    const response = await upstream(input, {
+    const response = await upstream(applicationRequest(input), {
       ...init,
       credentials: 'same-origin',
       redirect: 'error',
@@ -53,7 +54,7 @@ export async function orvalFetch<T>(
   options: RequestInit,
   fetcher: typeof fetch = generatedFetch,
 ): Promise<T> {
-  const response = await fetcher(new URL(url, window.location.origin), options)
+  const response = await fetcher(applicationURL(url), options)
   const text = await response.text()
   const data = response.headers.get('Content-Type')?.includes('json') ? JSON.parse(text) : text
   return {

--- a/web/src/lib/applicationBase.test.ts
+++ b/web/src/lib/applicationBase.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { applicationBaseURL, applicationURL } from './applicationBase'
+
+describe('browser application base', () => {
+  it('keeps top-level release assets on the origin root', () => {
+    const base = applicationBaseURL(
+      new URL('https://daemon.example/assets/app-a1b2c3d4.js'),
+      'https://daemon.example',
+    )
+
+    expect(base.href).toBe('https://daemon.example/')
+    expect(applicationURL('/api/v1/ui/snapshot', base).href).toBe(
+      'https://daemon.example/api/v1/ui/snapshot',
+    )
+  })
+
+  it('keeps API requests beside assets mounted below a path', () => {
+    const base = applicationBaseURL(
+      new URL('https://daemon.example/tools/tasks/assets/app-a1b2c3d4.js'),
+      'https://daemon.example',
+    )
+
+    expect(base.href).toBe('https://daemon.example/tools/tasks/')
+    expect(applicationURL('/api/v1/ui/snapshot?view=today', base).href).toBe(
+      'https://daemon.example/tools/tasks/api/v1/ui/snapshot?view=today',
+    )
+  })
+
+  it('does not move an already mounted or cross-origin URL', () => {
+    const base = new URL('https://daemon.example/tools/tasks/')
+
+    expect(applicationURL('/tools/tasks/api/v1/health', base).href).toBe(
+      'https://daemon.example/tools/tasks/api/v1/health',
+    )
+    expect(applicationURL('https://other.example/api/v1/health', base).href).toBe(
+      'https://other.example/api/v1/health',
+    )
+  })
+})

--- a/web/src/lib/applicationBase.ts
+++ b/web/src/lib/applicationBase.ts
@@ -1,0 +1,42 @@
+const assetsSegment = '/assets/'
+
+export function applicationBaseURL(entrypoint: URL, origin: string): URL {
+  const marker = entrypoint.pathname.lastIndexOf(assetsSegment)
+  if (marker < 0) return new URL('/', origin)
+  const prefix = entrypoint.pathname.slice(0, marker)
+  return new URL(prefix ? `${prefix}/` : '/', origin)
+}
+
+const runtimeBaseURL = applicationBaseURL(new URL(import.meta.url), window.location.origin)
+
+export function currentApplicationBaseURL(): URL {
+  return new URL(runtimeBaseURL)
+}
+
+export function applicationRoutePath(base = runtimeBaseURL): string {
+  return base.pathname === '/' ? '/kata' : base.pathname
+}
+
+export function applicationURL(input: string | URL, base = runtimeBaseURL): URL {
+  const target = new URL(String(input), base.origin)
+  if (target.origin !== base.origin || base.pathname === '/') return target
+  if (target.pathname === base.pathname.slice(0, -1) || target.pathname.startsWith(base.pathname)) {
+    return target
+  }
+  if (target.pathname === '/api' || target.pathname.startsWith('/api/')) {
+    target.pathname = `${base.pathname}${target.pathname.slice(1)}`
+  }
+  return target
+}
+
+export function applicationRequest(
+  input: RequestInfo | URL,
+  base = runtimeBaseURL,
+): RequestInfo | URL {
+  if (base.pathname === '/') return input
+  if (input instanceof Request) {
+    const target = applicationURL(new URL(input.url), base)
+    return target.href === input.url ? input : new Request(target, input)
+  }
+  return applicationURL(input instanceof URL ? input : String(input), base)
+}

--- a/web/src/lib/auth/session.ts
+++ b/web/src/lib/auth/session.ts
@@ -1,3 +1,5 @@
+import { applicationRequest, applicationRoutePath } from '../applicationBase'
+
 export const sessionStorageKey = 'kata.web.session.v1'
 export const authenticationModeStorageKey = 'kata.web.authentication-mode.v1'
 const directTargetStorageKey = 'kata.web.direct-target.v1'
@@ -106,12 +108,12 @@ export async function openLocalSession(
   fetcher: typeof fetch = fetch,
   storage: Storage = sessionStorage,
 ): Promise<AuthenticatedSession | undefined> {
-  const response = await fetcher('/api/v1/ui/session/local', {
+  const response = await fetcher(applicationRequest('/api/v1/ui/session/local'), {
     method: 'POST',
     credentials: 'same-origin',
     redirect: 'error',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ return_path: normalizeReturnPath(returnPath, '/kata') }),
+    body: JSON.stringify({ return_path: normalizeReturnPath(returnPath, applicationRoutePath()) }),
   })
   if ([401, 403, 404].includes(response.status)) return undefined
   return acceptSessionResponse(response, storage, 'Local authorization failed')
@@ -122,12 +124,12 @@ export async function openTrustedProxySession(
   fetcher: typeof fetch = fetch,
   storage: Storage = sessionStorage,
 ): Promise<AuthenticatedSession> {
-  const response = await fetcher('/api/v1/ui/session/proxy', {
+  const response = await fetcher(applicationRequest('/api/v1/ui/session/proxy'), {
     method: 'POST',
     credentials: 'same-origin',
     redirect: 'error',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ return_path: normalizeReturnPath(returnPath, '/kata') }),
+    body: JSON.stringify({ return_path: normalizeReturnPath(returnPath, applicationRoutePath()) }),
   })
   return acceptSessionResponse(response, storage, 'Trusted proxy authorization failed')
 }
@@ -138,12 +140,15 @@ export async function exchangeLoginToken(
   fetcher: typeof fetch = fetch,
   storage: Storage = sessionStorage,
 ): Promise<AuthenticatedSession> {
-  const response = await fetcher('/api/v1/ui/session/login', {
+  const response = await fetcher(applicationRequest('/api/v1/ui/session/login'), {
     method: 'POST',
     credentials: 'same-origin',
     redirect: 'error',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ token, return_path: normalizeReturnPath(returnPath, '/kata') }),
+    body: JSON.stringify({
+      token,
+      return_path: normalizeReturnPath(returnPath, applicationRoutePath()),
+    }),
   })
   return acceptSessionResponse(response, storage, 'Login failed')
 }
@@ -205,7 +210,7 @@ async function acceptSessionResponse(
       updates: body.updates,
       actorPolicy: body.actor_policy,
     },
-    returnPath: normalizeReturnPath(body.return_path, '/kata'),
+    returnPath: normalizeReturnPath(body.return_path, applicationRoutePath()),
   }
 }
 

--- a/web/src/lib/router.test.ts
+++ b/web/src/lib/router.test.ts
@@ -71,4 +71,15 @@ describe('canonical Kata routes', () => {
       `/kata?scope=${issueUID}&label=backend&label=urgent&owner=user-a&status=open`,
     )
   })
+
+  it('parses and serializes a browser application mounted below a path', () => {
+    const routePath = '/tools/tasks/'
+    const route = parseRoute(
+      new URL(`https://daemon.example${routePath}?view=today&label=ready`),
+      routePath,
+    )
+
+    expect(route).toMatchObject({ kind: 'kata', view: 'today' })
+    expect(serializeRoute(route, routePath)).toBe('/tools/tasks/?view=today&label=ready')
+  })
 })

--- a/web/src/lib/router.ts
+++ b/web/src/lib/router.ts
@@ -1,3 +1,5 @@
+import { applicationRoutePath } from './applicationBase'
+
 export const systemViews = [
   'inbox',
   'today',
@@ -36,10 +38,9 @@ export type KataRoute =
       searchRef?: string
     }
 
-export function parseRoute(url: URL): KataRoute {
-  const segments = url.pathname.split('/').filter(Boolean)
+export function parseRoute(url: URL, routePath = applicationRoutePath()): KataRoute {
   const filters = parseFilters(url.searchParams)
-  if (segments.length !== 1 || segments[0] !== 'kata') {
+  if (normalizeRoutePath(url.pathname) !== normalizeRoutePath(routePath)) {
     return { kind: 'route-error', path: url.pathname, reason: 'path' }
   }
   const view = url.searchParams.get('view')?.trim()
@@ -71,7 +72,7 @@ export function parseRoute(url: URL): KataRoute {
   }
 }
 
-export function serializeRoute(route: KataRoute): string {
+export function serializeRoute(route: KataRoute, routePath = applicationRoutePath()): string {
   if (route.kind === 'route-error') return route.path
   const query = new URLSearchParams()
   if (route.view) query.set('view', route.view)
@@ -88,7 +89,11 @@ export function serializeRoute(route: KataRoute): string {
   }
   if (route.filters.text) query.set('text', route.filters.text)
   const encoded = query.toString()
-  return encoded ? `/kata?${encoded}` : '/kata'
+  return encoded ? `${routePath}?${encoded}` : routePath
+}
+
+function normalizeRoutePath(value: string): string {
+  return value.length > 1 ? value.replace(/\/+$/, '') : value
 }
 
 function parseFilters(query: URLSearchParams): ShareableFilters {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,6 +5,7 @@ const developmentBackend = process.env.KATA_WEB_DEV_BACKEND
 const developmentPort = Number.parseInt(process.env.KATA_WEB_DEV_PORT ?? '5173', 10)
 
 export default defineConfig({
+  base: './',
   plugins: [svelte({ preprocess: vitePreprocess({ script: true }) })],
   build: {
     manifest: true,


### PR DESCRIPTION
Embedding hosts can mount Kata's HTTP service below a path, but the browser
application assumed the origin root. Its navigation, API calls, sessions,
event stream, and production assets could therefore escape the selected mount.

This adds `Service.HandlerAt`, makes release asset references relative, and
derives the browser route and API base from the loaded entrypoint. Root
deployments keep the existing `/kata` route; mounted applications stay below
the host-selected path. The browser's `/api` namespace remains reserved.
Authentication remains the host's responsibility and is unchanged.
