### PR TITLE
Reduce remote CLI mutation round trips

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4438,7 +4438,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.16.0
+  version: 0.17.0
 openapi: 3.1.0
 paths:
   /api/v1/audit/closes:
@@ -5924,12 +5924,25 @@ paths:
     post:
       operationId: createIssue
       parameters:
-        - in: path
+        - description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+          in: path
           name: project_id
           required: true
           schema:
-            format: int64
-            type: integer
+            description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+            type: string
+        - description: "Workspace alias identity; requires a name: selector"
+          in: header
+          name: X-Kata-Project-Alias
+          schema:
+            description: "Workspace alias identity; requires a name: selector"
+            type: string
+        - description: Workspace alias kind; required with X-Kata-Project-Alias
+          in: header
+          name: X-Kata-Project-Alias-Kind
+          schema:
+            description: Workspace alias kind; required with X-Kata-Project-Alias
+            type: string
         - in: header
           name: Idempotency-Key
           schema:
@@ -5947,6 +5960,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -5989,12 +6007,25 @@ paths:
     patch:
       operationId: editIssue
       parameters:
-        - in: path
+        - description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+          in: path
           name: project_id
           required: true
           schema:
-            format: int64
-            type: integer
+            description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+            type: string
+        - description: "Workspace alias identity; requires a name: selector"
+          in: header
+          name: X-Kata-Project-Alias
+          schema:
+            description: "Workspace alias identity; requires a name: selector"
+            type: string
+        - description: Workspace alias kind; required with X-Kata-Project-Alias
+          in: header
+          name: X-Kata-Project-Alias-Kind
+          schema:
+            description: Workspace alias kind; required with X-Kata-Project-Alias
+            type: string
         - in: path
           name: ref
           required: true
@@ -6013,6 +6044,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/EditIssueResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6047,6 +6083,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6123,6 +6164,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6161,6 +6207,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6237,6 +6288,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6309,6 +6365,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6343,6 +6404,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6377,6 +6443,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6655,12 +6726,25 @@ paths:
     post:
       operationId: createComment
       parameters:
-        - in: path
+        - description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+          in: path
           name: project_id
           required: true
           schema:
-            format: int64
-            type: integer
+            description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+            type: string
+        - description: "Workspace alias identity; requires a name: selector"
+          in: header
+          name: X-Kata-Project-Alias
+          schema:
+            description: "Workspace alias identity; requires a name: selector"
+            type: string
+        - description: Workspace alias kind; required with X-Kata-Project-Alias
+          in: header
+          name: X-Kata-Project-Alias-Kind
+          schema:
+            description: Workspace alias kind; required with X-Kata-Project-Alias
+            type: string
         - in: path
           name: ref
           required: true
@@ -6683,6 +6767,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/CommentResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6722,6 +6811,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/CommentResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6772,12 +6866,25 @@ paths:
     post:
       operationId: addLabel
       parameters:
-        - in: path
+        - description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+          in: path
           name: project_id
           required: true
           schema:
-            format: int64
-            type: integer
+            description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+            type: string
+        - description: "Workspace alias identity; requires a name: selector"
+          in: header
+          name: X-Kata-Project-Alias
+          schema:
+            description: "Workspace alias identity; requires a name: selector"
+            type: string
+        - description: Workspace alias kind; required with X-Kata-Project-Alias
+          in: header
+          name: X-Kata-Project-Alias-Kind
+          schema:
+            description: Workspace alias kind; required with X-Kata-Project-Alias
+            type: string
         - in: path
           name: ref
           required: true
@@ -6796,6 +6903,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/AddLabelResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6834,6 +6946,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -7092,6 +7209,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:

--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -187,18 +189,20 @@ func cliDaemonTargetError(err error) error {
 // CLI command site is already named for it.
 func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 	workspaceStart := workspaceStartForRemote()
-	return client.NewHTTPClient(ctx, baseURL, client.Opts{
+	hc, err := client.NewHTTPClient(ctx, baseURL, client.Opts{
 		Timeout:        envHTTPTimeout(defaultHTTPTimeout),
 		AllowInsecure:  client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart), //nolint:staticcheck // URL-only compatibility caller awaits resolved-target migration.
 		WorkspaceStart: workspaceStart,
 		DaemonName:     flags.Daemon,
 	})
+	return markDaemonHTTPClient(baseURL, hc, err)
 }
 
 func httpClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) (*http.Client, error) {
-	return client.NewHTTPClientForResolved(ctx, resolved, client.Opts{
+	hc, err := client.NewHTTPClientForResolved(ctx, resolved, client.Opts{
 		Timeout: envHTTPTimeout(defaultHTTPTimeout),
 	})
+	return markDaemonHTTPClient(resolved.BaseURL, hc, err)
 }
 
 // longRunningClientFor builds a variant with no overall Client.Timeout for
@@ -206,22 +210,24 @@ func httpClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) 
 // legitimately take longer than the default CLI request budget.
 func longRunningClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 	workspaceStart := workspaceStartForRemote()
-	return client.NewHTTPClient(ctx, baseURL, client.Opts{
+	hc, err := client.NewHTTPClient(ctx, baseURL, client.Opts{
 		AllowInsecure:  client.RemoteAllowInsecureForBaseURL(baseURL, workspaceStart), //nolint:staticcheck // URL-only compatibility caller awaits resolved-target migration.
 		WorkspaceStart: workspaceStart,
 		DaemonName:     flags.Daemon,
 	})
+	return markDaemonHTTPClient(baseURL, hc, err)
 }
 
 func longRunningClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) (*http.Client, error) {
-	return client.NewHTTPClientForResolved(ctx, resolved, client.Opts{})
+	hc, err := client.NewHTTPClientForResolved(ctx, resolved, client.Opts{})
+	return markDaemonHTTPClient(resolved.BaseURL, hc, err)
 }
 
 // streamingClientFor builds the SSE-friendly variant. Body cancellation comes
 // from the request context.
 func streamingClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 	workspaceStart := workspaceStartForRemote()
-	return client.NewHTTPClient(ctx, baseURL, client.Opts{
+	hc, err := client.NewHTTPClient(ctx, baseURL, client.Opts{
 		ResponseHeaderTimeout: client.SSEHandshakeTimeout,
 		AllowInsecure: client.RemoteAllowInsecureForBaseURL( //nolint:staticcheck // URL-only compatibility caller awaits resolved-target migration.
 			baseURL, workspaceStart,
@@ -229,12 +235,57 @@ func streamingClientFor(ctx context.Context, baseURL string) (*http.Client, erro
 		WorkspaceStart: workspaceStart,
 		DaemonName:     flags.Daemon,
 	})
+	return markDaemonHTTPClient(baseURL, hc, err)
 }
 
 func streamingClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) (*http.Client, error) {
-	return client.NewHTTPClientForResolved(ctx, resolved, client.Opts{
+	hc, err := client.NewHTTPClientForResolved(ctx, resolved, client.Opts{
 		ResponseHeaderTimeout: client.SSEHandshakeTimeout,
 	})
+	return markDaemonHTTPClient(resolved.BaseURL, hc, err)
+}
+
+// Embed the operation error to preserve net.Error timeout behavior through
+// net/http's url.Error. Retain the full cause for diagnostics and unwrapping.
+type daemonDialError struct {
+	*net.OpError
+	cause error
+}
+
+func (e *daemonDialError) Error() string { return e.cause.Error() }
+func (e *daemonDialError) Unwrap() error { return e.cause }
+
+// Only clients built for the selected daemon mark its dial failures. Hub
+// clients and requests redirected to other origins retain their own errors.
+func markDaemonHTTPClient(baseURL string, hc *http.Client, err error) (*http.Client, error) {
+	if err != nil {
+		return nil, err
+	}
+	origin, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	transport := hc.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	hc.Transport = daemonErrorTransport{RoundTripper: transport, origin: origin}
+	return hc, nil
+}
+
+type daemonErrorTransport struct {
+	http.RoundTripper
+	origin *url.URL
+}
+
+func (t daemonErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.RoundTripper.RoundTrip(req)
+	if req.URL.Scheme == t.origin.Scheme && req.URL.Host == t.origin.Host {
+		if op, ok := errors.AsType[*net.OpError](err); ok && op.Op == "dial" {
+			return resp, &daemonDialError{OpError: op, cause: err}
+		}
+	}
+	return resp, err
 }
 
 // daemonAPI is a resolved connection to one daemon: the base URL, the

--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -38,7 +38,7 @@ func envHTTPTimeout(def time.Duration) time.Duration {
 	return d
 }
 
-// ensureDaemonResolved discovers a live daemon, auto-starting one if none is
+// ensureDaemonResolved selects a daemon, auto-starting a local one if none is
 // found, and carries the source, credentials, and transport policy selected by
 // that resolution. Client construction consumes this value without deriving
 // policy again from its base URL.
@@ -47,19 +47,18 @@ func envHTTPTimeout(def time.Duration) time.Duration {
 // the .kata.local.toml walk so a workspace-local [server] override is
 // honored even when the user is invoking kata from outside the repo.
 //
-// If a daemon is explicitly configured (via --daemon, KATA_SERVER,
-// .kata.local.toml, or active_daemon) but does not respond, the CLI surfaces
-// this as a daemon-unavailable error so callers see a stable exit code and shape.
+// Configured remotes are not pinged before ordinary API requests. Discovery
+// and health commands use discoverDaemonResolved when liveness is the result.
 func ensureDaemonResolved(ctx context.Context) (client.ResolvedDaemon, error) {
 	if flags.Daemon != "" {
-		resolved, err := client.EnsureResolvedNamed(ctx, flags.Daemon)
+		resolved, err := client.PrepareResolvedNamed(ctx, flags.Daemon)
 		if err != nil {
 			return client.ResolvedDaemon{}, cliDaemonTargetError(err)
 		}
 		return resolved, nil
 	}
 	workspaceStart := workspaceStartForRemote()
-	resolved, err := client.EnsureResolvedInWorkspace(ctx, workspaceStart)
+	resolved, err := client.PrepareResolvedInWorkspace(ctx, workspaceStart)
 	if err != nil {
 		return client.ResolvedDaemon{}, cliDaemonTargetError(err)
 	}

--- a/cmd/kata/client.go
+++ b/cmd/kata/client.go
@@ -195,14 +195,20 @@ func httpClientFor(ctx context.Context, baseURL string) (*http.Client, error) {
 		WorkspaceStart: workspaceStart,
 		DaemonName:     flags.Daemon,
 	})
-	return markDaemonHTTPClient(baseURL, hc, err)
+	if err != nil {
+		return nil, err
+	}
+	return markDaemonHTTPClient(baseURL, hc)
 }
 
 func httpClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) (*http.Client, error) {
 	hc, err := client.NewHTTPClientForResolved(ctx, resolved, client.Opts{
 		Timeout: envHTTPTimeout(defaultHTTPTimeout),
 	})
-	return markDaemonHTTPClient(resolved.BaseURL, hc, err)
+	if err != nil {
+		return nil, err
+	}
+	return markDaemonHTTPClient(resolved.BaseURL, hc)
 }
 
 // longRunningClientFor builds a variant with no overall Client.Timeout for
@@ -215,12 +221,18 @@ func longRunningClientFor(ctx context.Context, baseURL string) (*http.Client, er
 		WorkspaceStart: workspaceStart,
 		DaemonName:     flags.Daemon,
 	})
-	return markDaemonHTTPClient(baseURL, hc, err)
+	if err != nil {
+		return nil, err
+	}
+	return markDaemonHTTPClient(baseURL, hc)
 }
 
 func longRunningClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) (*http.Client, error) {
 	hc, err := client.NewHTTPClientForResolved(ctx, resolved, client.Opts{})
-	return markDaemonHTTPClient(resolved.BaseURL, hc, err)
+	if err != nil {
+		return nil, err
+	}
+	return markDaemonHTTPClient(resolved.BaseURL, hc)
 }
 
 // streamingClientFor builds the SSE-friendly variant. Body cancellation comes
@@ -235,14 +247,20 @@ func streamingClientFor(ctx context.Context, baseURL string) (*http.Client, erro
 		WorkspaceStart: workspaceStart,
 		DaemonName:     flags.Daemon,
 	})
-	return markDaemonHTTPClient(baseURL, hc, err)
+	if err != nil {
+		return nil, err
+	}
+	return markDaemonHTTPClient(baseURL, hc)
 }
 
 func streamingClientForResolved(ctx context.Context, resolved client.ResolvedDaemon) (*http.Client, error) {
 	hc, err := client.NewHTTPClientForResolved(ctx, resolved, client.Opts{
 		ResponseHeaderTimeout: client.SSEHandshakeTimeout,
 	})
-	return markDaemonHTTPClient(resolved.BaseURL, hc, err)
+	if err != nil {
+		return nil, err
+	}
+	return markDaemonHTTPClient(resolved.BaseURL, hc)
 }
 
 // Embed the operation error to preserve net.Error timeout behavior through
@@ -257,10 +275,7 @@ func (e *daemonDialError) Unwrap() error { return e.cause }
 
 // Only clients built for the selected daemon mark its dial failures. Hub
 // clients and requests redirected to other origins retain their own errors.
-func markDaemonHTTPClient(baseURL string, hc *http.Client, err error) (*http.Client, error) {
-	if err != nil {
-		return nil, err
-	}
+func markDaemonHTTPClient(baseURL string, hc *http.Client) (*http.Client, error) {
 	origin, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err

--- a/cmd/kata/client_test.go
+++ b/cmd/kata/client_test.go
@@ -146,7 +146,7 @@ func TestDaemonDialTimeoutPreservesCreateOutcomeUnknown(t *testing.T) {
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			return nil, &net.OpError{Op: "dial", Net: "tcp", Err: &net.DNSError{IsTimeout: true}}
 		}),
-	}, nil)
+	})
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://daemon.example/issues", nil)
 	require.NoError(t, err)

--- a/cmd/kata/client_test.go
+++ b/cmd/kata/client_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -71,6 +73,88 @@ func TestRemoteCommand_UnavailableMapsToCLIError(t *testing.T) {
 	}
 	assert.Equal(t, ExitDaemonUnavail, exitCodeForErr(err, true))
 	assert.Contains(t, stderr, `"kind":"daemon_unavailable"`)
+}
+
+func TestFederationEnroll_UnavailableHubKeepsOperationalError(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_SERVER", "http://127.0.0.1:1")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Chdir(t.TempDir())
+
+	_, stderr, err := executeRootCapture(t, t.Context(), "federation", "enroll", "hub-project",
+		"--hub-url", "http://127.0.0.1:1", "--spoke-instance", "example-spoke",
+		"--capabilities", "pull", "--actor", "user-a", "--json")
+	require.Error(t, err)
+	assert.Equal(t, ExitInternal, exitCodeForErr(err, true))
+	assert.Contains(t, stderr, `"kind":"internal"`)
+	assert.NotContains(t, stderr, `"kind":"daemon_unavailable"`)
+}
+
+func TestDaemonClients_ClassifyOnlyTheirOwnDialFailures(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_SERVER", "")
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	t.Chdir(t.TempDir())
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://127.0.0.1:1/external", http.StatusFound)
+	}))
+	t.Cleanup(redirect.Close)
+
+	for _, constructor := range []struct {
+		name     string
+		url      func(context.Context, string) (*http.Client, error)
+		resolved func(context.Context, client.ResolvedDaemon) (*http.Client, error)
+	}{
+		{name: "default", url: httpClientFor, resolved: httpClientForResolved},
+		{name: "long-running", url: longRunningClientFor, resolved: longRunningClientForResolved},
+		{name: "streaming", url: streamingClientFor, resolved: streamingClientForResolved},
+	} {
+		for _, resolved := range []bool{false, true} {
+			for _, target := range []struct {
+				name, url string
+				exit      int
+			}{
+				{name: "daemon", url: "http://127.0.0.1:1", exit: ExitDaemonUnavail},
+				{name: "redirect", url: redirect.URL, exit: ExitInternal},
+			} {
+				t.Run(fmt.Sprintf("%s/resolved=%t/%s", constructor.name, resolved, target.name), func(t *testing.T) {
+					var hc *http.Client
+					var err error
+					if resolved {
+						hc, err = constructor.resolved(t.Context(), client.ResolvedDaemon{BaseURL: target.url})
+					} else {
+						hc, err = constructor.url(t.Context(), target.url)
+					}
+					require.NoError(t, err)
+					req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, target.url, nil)
+					require.NoError(t, err)
+					resp, err := hc.Do(req) //nolint:gosec // loopback fixtures only
+					if resp != nil {
+						require.NoError(t, resp.Body.Close())
+					}
+					require.Error(t, err)
+					assert.Equal(t, target.exit, exitCodeForErr(fmt.Errorf("request failed: %w", err), true))
+				})
+			}
+		}
+	}
+}
+
+func TestDaemonDialTimeoutPreservesCreateOutcomeUnknown(t *testing.T) {
+	hc, err := markDaemonHTTPClient("https://daemon.example", &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, &net.OpError{Op: "dial", Net: "tcp", Err: &net.DNSError{IsTimeout: true}}
+		}),
+	}, nil)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://daemon.example/issues", nil)
+	require.NoError(t, err)
+	_, err = hc.Do(req) //nolint:gosec // fixture transport does not make network requests
+	require.Error(t, err)
+	classified := cliErrorForErr(createRequestError(err, false), true)
+	assert.Equal(t, "create_outcome_unknown", classified.Code)
+	assert.Equal(t, ExitInternal, classified.ExitCode)
 }
 
 func TestEnsureDaemonResolvedPreservesInjectedResolution(t *testing.T) {

--- a/cmd/kata/client_test.go
+++ b/cmd/kata/client_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -54,25 +53,24 @@ func TestLongRunningClientForLeavesResponseHeadersUnbounded(t *testing.T) {
 	}
 }
 
-func TestEnsureDaemon_RemoteUnavailableMapsToCLIError(t *testing.T) {
+func TestRemoteCommand_UnavailableMapsToCLIError(t *testing.T) {
 	t.Setenv("KATA_HOME", t.TempDir())
 	t.Setenv("KATA_SERVER", "http://127.0.0.1:1") // closed port
+	t.Chdir(t.TempDir())
 
-	_, err := ensureDaemon(context.Background())
+	_, stderr, err := executeRootCapture(t, t.Context(), "projects", "list", "--json")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-
-	var ce *cliError
-	if !errors.As(err, &ce) {
-		t.Fatalf("expected *cliError, got %T (%v)", err, err)
-	}
+	ce := cliErrorForErr(err, true)
 	if ce.Kind != kindDaemonUnavail {
 		t.Errorf("expected Kind=%v, got %v", kindDaemonUnavail, ce.Kind)
 	}
 	if ce.ExitCode != ExitDaemonUnavail {
 		t.Errorf("expected ExitCode=%d, got %d", ExitDaemonUnavail, ce.ExitCode)
 	}
+	assert.Equal(t, ExitDaemonUnavail, exitCodeForErr(err, true))
+	assert.Contains(t, stderr, `"kind":"daemon_unavailable"`)
 }
 
 func TestEnsureDaemonResolvedPreservesInjectedResolution(t *testing.T) {

--- a/cmd/kata/comment.go
+++ b/cmd/kata/comment.go
@@ -44,23 +44,16 @@ func newCommentCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, args[0])
+		project, issue, err := prepareIssueMutation(cmd, args[0], false)
 		if err != nil {
 			return err
 		}
-		actor, _ := resolveActor(ctx, flags.As, nil)
-		client, err := httpClientFor(ctx, baseURL)
+		actor, _ := resolveActor(project.api.ctx, flags.As, nil)
+		bs, err := project.mutate(http.MethodPost,
+			"/issues/"+url.PathEscape(issue.RefForAPI)+"/comments",
+			map[string]any{"actor": actor, "body": body}, nil)
 		if err != nil {
 			return err
-		}
-		status, bs, err := httpDoJSON(ctx, client, http.MethodPost,
-			fmt.Sprintf("%s/api/v1/projects/%d/issues/%s/comments", baseURL, pid, url.PathEscape(issue.RefForAPI)),
-			map[string]any{"actor": actor, "body": body})
-		if err != nil {
-			return err
-		}
-		if status >= 400 {
-			return apiErrFromBody(status, bs)
 		}
 		switch currentOutputMode() {
 		case outputJSON:

--- a/cmd/kata/create.go
+++ b/cmd/kata/create.go
@@ -88,14 +88,16 @@ func newCreateCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		baseURL, err := ensureDaemon(ctx)
+		a, err := dialDaemon(ctx)
 		if err != nil {
 			return err
 		}
-		projectID, projectName, err := resolveProjectIDAndName(ctx, baseURL, start)
+		withLinks := len(parentRefSlice)+len(blocks)+len(blockedBy)+len(related) > 0
+		project, err := prepareProjectMutation(a, start, withLinks)
 		if err != nil {
 			return err
 		}
+		projectName := project.name
 		body, err := resolveBody(src, cmd.InOrStdin())
 		if err != nil {
 			code := ExitValidation
@@ -105,10 +107,6 @@ func newCreateCmd() *cobra.Command {
 			return &cliError{Message: err.Error(), Kind: kindForExit(code), ExitCode: code}
 		}
 		actor, _ := resolveActor(ctx, flags.As, nil)
-		client, err := httpClientFor(ctx, baseURL)
-		if err != nil {
-			return err
-		}
 
 		req := map[string]any{"actor": actor, "title": title, "body": body}
 		if cmd.Flags().Changed("owner") {
@@ -169,14 +167,9 @@ func newCreateCmd() *cobra.Command {
 			headers["Idempotency-Key"] = idempotencyKey
 		}
 
-		status, bs, err := httpDoJSONWithHeader(ctx, client, http.MethodPost,
-			fmt.Sprintf("%s/api/v1/projects/%d/issues", baseURL, projectID),
-			headers, req)
+		bs, err := project.mutate(http.MethodPost, "/issues", req, headers)
 		if err != nil {
 			return createRequestError(err, forceNew)
-		}
-		if status >= 400 {
-			return apiErrFromBody(status, bs)
 		}
 		// The /issues create response doesn't carry a `changes` block (it
 		// lives on the PATCH path). Synthesize one from the resolved
@@ -186,7 +179,7 @@ func newCreateCmd() *cobra.Command {
 		// direction (`--blocked-by` adding to `blocked_by_added` rather
 		// than `blocks_added`) preserves the user's POV.
 		applied := initialLinksAsChanges(parentRef, blocksRefs, blockedByRefs, relatedRefs)
-		return printMutationWithApplied(cmd, bs, applied, projectName)
+		return printMutationWithApplied(cmd, bs, applied, project.name)
 	}
 	return cmd
 }

--- a/cmd/kata/edit.go
+++ b/cmd/kata/edit.go
@@ -96,12 +96,14 @@ func newEditCmd() *cobra.Command {
 			}
 		}
 
-		// Resolve the URL issue early so we have ctx/baseURL/pid available
-		// to resolve link-target refs (short_id, qualified short_id, or ULID).
-		ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, args[0])
+		// Relationship checks need canonical identity before submission.
+		// Ordinary edits resolve the project inside the mutation instead.
+		withLinks := len(parentRefSlice)+len(removeParentRefSlice)+len(blocks)+len(blockedBy)+len(related)+len(removeBlocks)+len(removeBlockedBy)+len(removeRelated) > 0
+		project, issue, err := prepareIssueMutation(cmd, args[0], withLinks)
 		if err != nil {
 			return err
 		}
+		ctx, baseURL, pid := project.api.ctx, project.api.baseURL, project.id
 
 		// --parent and --remove-parent are at-most-one but accept any of
 		// short_id, qualified ("other#abc4"), or ULID. singletonRefToWire
@@ -148,23 +150,14 @@ func newEditCmd() *cobra.Command {
 		}
 		actor, _ := resolveActor(ctx, flags.As, nil)
 		payload["actor"] = actor
-		client, err := httpClientFor(ctx, baseURL)
+		bs, err := project.mutate(http.MethodPatch, "/issues/"+url.PathEscape(issue.RefForAPI), payload, nil)
 		if err != nil {
 			return err
 		}
-		status, bs, err := httpDoJSON(ctx, client, http.MethodPatch,
-			fmt.Sprintf("%s/api/v1/projects/%d/issues/%s", baseURL, pid, url.PathEscape(issue.RefForAPI)),
-			payload)
-		if err != nil {
+		if err := project.comment(bs, issue.RefForAPI, actor, comment); err != nil {
 			return err
 		}
-		if status >= 400 {
-			return apiErrFromBody(status, bs)
-		}
-		if err := postFollowupComment(ctx, client, baseURL, pid, issue.RefForAPI, actor, comment); err != nil {
-			return err
-		}
-		return printMutationWithApplied(cmd, bs, nil, issue.ProjectName)
+		return printMutationWithApplied(cmd, bs, nil, project.name)
 	}
 	return cmd
 }

--- a/cmd/kata/label.go
+++ b/cmd/kata/label.go
@@ -36,25 +36,17 @@ func labelAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ctx, baseURL, pid, issue, err := resolveIssueRefForCommand(cmd, args[0])
+			project, issue, err := prepareIssueMutation(cmd, args[0], false)
 			if err != nil {
 				return err
 			}
-			actor, _ := resolveActor(ctx, flags.As, nil)
-			client, err := httpClientFor(ctx, baseURL)
-			if err != nil {
-				return err
-			}
+			actor, _ := resolveActor(project.api.ctx, flags.As, nil)
 			payload := map[string]string{"actor": actor, "label": label}
-			postURL := fmt.Sprintf("%s/api/v1/projects/%d/issues/%s/labels", baseURL, pid, url.PathEscape(issue.RefForAPI))
-			status, bs, err := httpDoJSON(ctx, client, http.MethodPost, postURL, payload)
+			bs, err := project.mutate(http.MethodPost, "/issues/"+url.PathEscape(issue.RefForAPI)+"/labels", payload, nil)
 			if err != nil {
 				return err
 			}
-			if status >= 400 {
-				return apiErrFromBody(status, bs)
-			}
-			if err := postFollowupComment(ctx, client, baseURL, pid, issue.RefForAPI, actor, comment); err != nil {
+			if err := project.comment(bs, issue.RefForAPI, actor, comment); err != nil {
 				return err
 			}
 			return printLabelMutation(cmd, bs)

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/signal"
 	"slices"
@@ -299,11 +298,10 @@ func exitCodeForErr(err error, runEReached bool) int {
 	if cli, ok := errors.AsType[*cliError](err); ok {
 		return cli.ExitCode
 	}
-	// Ordinary remote requests establish reachability themselves. A failed
-	// dial still means daemon unavailable, even without a preliminary ping.
-	// Do not classify post-connect failures this way: a mutation may already
-	// have committed, and command-specific outcome-unknown errors take priority.
-	if op, ok := errors.AsType[*net.OpError](err); ok && op.Op == "dial" {
+	// Only the selected daemon's transport marks unavailable errors. Hub and
+	// other external dial failures retain their command's error classification.
+	// Command-specific outcome-unknown errors above still take priority.
+	if _, ok := errors.AsType[*daemonDialError](err); ok {
 		return ExitDaemonUnavail
 	}
 	return exitCodeFor(err, runEReached)

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/signal"
 	"slices"
@@ -297,6 +298,13 @@ func cliErrorForErr(err error, runEReached bool) *cliError {
 func exitCodeForErr(err error, runEReached bool) int {
 	if cli, ok := errors.AsType[*cliError](err); ok {
 		return cli.ExitCode
+	}
+	// Ordinary remote requests establish reachability themselves. A failed
+	// dial still means daemon unavailable, even without a preliminary ping.
+	// Do not classify post-connect failures this way: a mutation may already
+	// have committed, and command-specific outcome-unknown errors take priority.
+	if op, ok := errors.AsType[*net.OpError](err); ok && op.Op == "dial" {
+		return ExitDaemonUnavail
 	}
 	return exitCodeFor(err, runEReached)
 }

--- a/cmd/kata/project_mutation.go
+++ b/cmd/kata/project_mutation.go
@@ -65,6 +65,10 @@ func prepareIssueMutation(cmd *cobra.Command, ref string, resolveNow bool) (*pro
 		return nil, resolvedIssueRef{}, err
 	}
 	project := strings.TrimSpace(flags.Project)
+	// ResolveRef fills ProjectName for both explicit and inherited names.
+	// Preserve the source so workspace-bound refs retain alias resolution
+	// and binding repair after a project rename or merge.
+	workspaceBound := project == "" && !strings.Contains(ref, "#")
 	if project == "" {
 		project = workspaceProjectName(start)
 	}
@@ -72,7 +76,7 @@ func prepareIssueMutation(cmd *cobra.Command, ref string, resolveNow bool) (*pro
 	if err != nil {
 		return nil, resolvedIssueRef{}, &cliError{Message: err.Error(), Kind: kindValidation, ExitCode: ExitValidation}
 	}
-	if parsed.ProjectName == "" {
+	if workspaceBound {
 		p, err := prepareProjectMutation(a, start, resolveNow)
 		if err != nil {
 			return nil, resolvedIssueRef{}, err

--- a/cmd/kata/project_mutation.go
+++ b/cmd/kata/project_mutation.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// projectMutation carries the locally known project selector to the daemon.
+// Only operations which need canonical identity before submitting their body
+// (relationship validation and path-only workspaces) resolve it separately.
+type projectMutation struct {
+	api      daemonAPI
+	selector string
+	name     string
+	id       int64
+	headers  map[string]string
+	repair   func(string) error
+}
+
+func prepareProjectMutation(a daemonAPI, start string, resolveNow bool) (*projectMutation, error) {
+	p := &projectMutation{api: a}
+	if !resolveNow {
+		body, repair, err := buildResolveRequest(a.ctx, start)
+		if err != nil {
+			return nil, err
+		}
+		if _, pathOnly := body["start_path"]; !pathOnly {
+			p.name, _ = body["name"].(string)
+			p.selector = "name:" + p.name
+			p.repair = repair
+			if alias, ok := body["alias"].(map[string]any); ok {
+				identity, _ := alias["identity"].(string)
+				kind, _ := alias["kind"].(string)
+				p.headers = map[string]string{
+					"X-Kata-Project-Alias":      identity,
+					"X-Kata-Project-Alias-Kind": kind,
+				}
+			}
+			return p, nil
+		}
+	}
+	id, name, err := resolveProjectIDAndNameWithClient(a, start)
+	if err != nil {
+		return nil, err
+	}
+	p.id, p.name, p.selector = id, name, strconv.FormatInt(id, 10)
+	return p, nil
+}
+
+func prepareIssueMutation(cmd *cobra.Command, ref string, resolveNow bool) (*projectMutation, resolvedIssueRef, error) {
+	start, err := resolveStartPath(flags.Workspace)
+	if err != nil {
+		return nil, resolvedIssueRef{}, err
+	}
+	a, err := dialDaemon(cmd.Context())
+	if err != nil {
+		return nil, resolvedIssueRef{}, err
+	}
+	project := strings.TrimSpace(flags.Project)
+	if project == "" {
+		project = workspaceProjectName(start)
+	}
+	parsed, err := ResolveRef(ref, project)
+	if err != nil {
+		return nil, resolvedIssueRef{}, &cliError{Message: err.Error(), Kind: kindValidation, ExitCode: ExitValidation}
+	}
+	if parsed.ProjectName == "" {
+		p, err := prepareProjectMutation(a, start, resolveNow)
+		if err != nil {
+			return nil, resolvedIssueRef{}, err
+		}
+		return p, resolvedIssueRef{RefForAPI: parsed.RefForAPI, ProjectName: p.name}, nil
+	}
+	p := &projectMutation{api: a, name: parsed.ProjectName, selector: "name:" + parsed.ProjectName}
+	if resolveNow {
+		p.id, p.name, err = resolveProjectIDAndNameForRef(a, start, parsed.ProjectName, false)
+		if err != nil {
+			return nil, resolvedIssueRef{}, err
+		}
+		p.selector = strconv.FormatInt(p.id, 10)
+	}
+	return p, resolvedIssueRef{RefForAPI: parsed.RefForAPI, ProjectName: p.name}, nil
+}
+
+func (p *projectMutation) mutate(method, suffix string, body any, headers map[string]string) ([]byte, error) {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := p.api.url("/api/v1/projects/" + url.PathEscape(p.selector) + suffix)
+	req, err := http.NewRequestWithContext(p.api.ctx, method, endpoint, bytes.NewReader(encoded))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range p.headers {
+		req.Header.Set(key, value)
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	resp, err := p.api.client.Do(req) //nolint:gosec // selected daemon, with escaped project selector and issue refs
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &responseBodyReadError{err: err}
+	}
+	if resp.StatusCode >= 400 {
+		return nil, apiErrFromBody(resp.StatusCode, data)
+	}
+	if canonical := resp.Header.Get("X-Kata-Project-Name"); canonical != "" {
+		p.name = canonical
+	}
+	if p.repair != nil {
+		if err := p.repair(p.name); err != nil {
+			return nil, &cliError{
+				Message: fmt.Sprintf("issue mutation succeeded but workspace binding repair failed: %v; do not repeat the mutation", err),
+				Kind:    kindInternal, Code: "workspace_repair_failed", ExitCode: ExitInternal,
+			}
+		}
+	}
+	return data, nil
+}
+
+// Follow-up comments use the project ID returned by the successful mutation,
+// not another lookup of the name which might have changed in the meantime.
+func (p *projectMutation) comment(data []byte, ref, actor, body string) error {
+	if body == "" {
+		return nil
+	}
+	var response struct {
+		Issue struct {
+			ProjectID int64 `json:"project_id"`
+		} `json:"issue"`
+	}
+	if err := json.Unmarshal(data, &response); err != nil {
+		return fmt.Errorf("issue mutation succeeded but reading its project for --comment failed: %w", err)
+	}
+	return postFollowupComment(p.api.ctx, p.api.client, p.api.baseURL, response.Issue.ProjectID, ref, actor, body)
+}

--- a/cmd/kata/project_mutation_test.go
+++ b/cmd/kata/project_mutation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/db"
 	"go.kenn.io/kata/internal/testenv"
 )
 
@@ -21,6 +22,109 @@ func TestCreateRepairsRenamedWorkspaceAfterInlineResolution(t *testing.T) {
 	cfg, err := config.ReadProjectConfig(dir)
 	require.NoError(t, err)
 	assert.Equal(t, "renamed-project", cfg.Project.Name)
+}
+
+func TestBareIssueMutationsFollowWorkspaceAlias(t *testing.T) {
+	for _, change := range []string{"rename", "merge"} {
+		for _, operation := range []string{"edit", "comment", "label"} {
+			t.Run(change+"/"+operation, func(t *testing.T) {
+				env := testenv.New(t)
+				dir, pid := initLocalBoundWorkspace(t, env, "old-project")
+				issue, _, err := env.DB.CreateIssue(t.Context(), db.CreateIssueParams{
+					ProjectID: pid, Title: "Example task", Author: "user-a",
+				})
+				require.NoError(t, err)
+				if change == "rename" {
+					_, err = env.DB.RenameProject(t.Context(), pid, "current-project")
+					require.NoError(t, err)
+					// An unrelated project can reuse the old name. The alias
+					// must still select the workspace's original project.
+					_, err = env.DB.CreateProject(t.Context(), "old-project")
+					require.NoError(t, err)
+				} else {
+					target, err := env.DB.CreateProject(t.Context(), "current-project")
+					require.NoError(t, err)
+					_, err = env.DB.MergeProjects(t.Context(), db.MergeProjectsParams{
+						SourceProjectID: pid, TargetProjectID: target.ID,
+					})
+					require.NoError(t, err)
+				}
+				switch operation {
+				case "edit":
+					runCLI(t, env, dir, "edit", issue.ShortID, "--body", "Updated description")
+					updated, err := env.DB.IssueByID(t.Context(), issue.ID)
+					require.NoError(t, err)
+					assert.Equal(t, "Updated description", updated.Body)
+				case "comment":
+					runCLI(t, env, dir, "comment", issue.ShortID, "--body", "Example comment")
+					comments, err := env.DB.CommentsByIssue(t.Context(), issue.ID)
+					require.NoError(t, err)
+					require.Len(t, comments, 1)
+					assert.Equal(t, "Example comment", comments[0].Body)
+				case "label":
+					runCLI(t, env, dir, "label", "add", issue.ShortID, "example-label")
+					labels, err := env.DB.LabelsByIssue(t.Context(), issue.ID)
+					require.NoError(t, err)
+					require.Len(t, labels, 1)
+					assert.Equal(t, "example-label", labels[0].Label)
+				}
+				cfg, err := config.ReadProjectConfig(dir)
+				require.NoError(t, err)
+				assert.Equal(t, "current-project", cfg.Project.Name)
+			})
+		}
+	}
+}
+
+func TestIssueMutationExplicitProjectDoesNotFollowWorkspaceAlias(t *testing.T) {
+	for _, selector := range []string{"flag", "qualified"} {
+		t.Run(selector, func(t *testing.T) {
+			env := testenv.New(t)
+			dir, pid := initLocalBoundWorkspace(t, env, "old-project")
+			_, err := env.DB.RenameProject(t.Context(), pid, "current-project")
+			require.NoError(t, err)
+			reused, err := env.DB.CreateProject(t.Context(), "old-project")
+			require.NoError(t, err)
+			issue, _, err := env.DB.CreateIssue(t.Context(), db.CreateIssueParams{
+				ProjectID: reused.ID, Title: "Explicit target", Author: "user-a",
+			})
+			require.NoError(t, err)
+			args := []string{"edit", issue.ShortID, "--body", "Updated description"}
+			if selector == "flag" {
+				args = append(args, "--project", "old-project")
+			} else {
+				args[1] = "old-project#" + issue.ShortID
+				args = append(args, "--project", "current-project")
+			}
+			runCLI(t, env, dir, args...)
+			updated, err := env.DB.IssueByID(t.Context(), issue.ID)
+			require.NoError(t, err)
+			assert.Equal(t, "Updated description", updated.Body)
+			cfg, err := config.ReadProjectConfig(dir)
+			require.NoError(t, err)
+			assert.Equal(t, "old-project", cfg.Project.Name)
+		})
+	}
+}
+
+func TestRelationshipEditFollowsRenamedWorkspaceAlias(t *testing.T) {
+	env := testenv.New(t)
+	dir, pid := initLocalBoundWorkspace(t, env, "old-project")
+	issue, _, err := env.DB.CreateIssue(t.Context(), db.CreateIssueParams{
+		ProjectID: pid, Title: "Child task", Author: "user-a",
+	})
+	require.NoError(t, err)
+	parent := createIssue(t, env, pid, "Parent task")
+	_, err = env.DB.RenameProject(t.Context(), pid, "current-project")
+	require.NoError(t, err)
+	runCLI(t, env, dir, "edit", issue.UID, "--parent", parent)
+	updated := fetchIssueViaHTTP(t, env, pid, issue.ShortID)
+	require.Len(t, updated.Links, 1)
+	assert.Equal(t, "parent", updated.Links[0].Type)
+	assert.Equal(t, parent, updated.Links[0].To.ShortID)
+	cfg, err := config.ReadProjectConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "current-project", cfg.Project.Name)
 }
 
 // Local repair is now after the write. A failure must not suggest that

--- a/cmd/kata/project_mutation_test.go
+++ b/cmd/kata/project_mutation_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+func TestCreateRepairsRenamedWorkspaceAfterInlineResolution(t *testing.T) {
+	env := testenv.New(t)
+	dir, pid := initLocalBoundWorkspace(t, env, "old-project")
+	_, err := env.DB.RenameProject(t.Context(), pid, "renamed-project")
+	require.NoError(t, err)
+	runCLI(t, env, dir, "create", "Example task", "--body", "Example description")
+	cfg, err := config.ReadProjectConfig(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed-project", cfg.Project.Name)
+}
+
+// Local repair is now after the write. A failure must not suggest that
+// creation failed and encourage the caller to create a duplicate issue.
+func TestInlineMutationRepairFailureReportsCommittedWrite(t *testing.T) {
+	env := testenv.New(t)
+	dir, pid := initLocalBoundWorkspace(t, env, "example-project")
+	t.Setenv("KATA_SERVER", env.URL)
+	t.Chdir(dir)
+	resetFlags(t)
+	a, err := dialDaemon(t.Context())
+	require.NoError(t, err)
+	p := &projectMutation{
+		api: a, selector: itoa(pid), name: "example-project",
+		repair: func(string) error { return os.ErrPermission },
+	}
+	_, err = p.mutate(http.MethodPost, "/issues", map[string]string{"title": "Example task", "actor": "tester"}, nil)
+	require.Error(t, err)
+	var cli *cliError
+	require.True(t, errors.As(err, &cli), "expected explicit post-commit error, got %v", err)
+	assert.Equal(t, "workspace_repair_failed", cli.Code)
+	assert.Contains(t, cli.Message, "mutation succeeded")
+	assert.Contains(t, cli.Message, "do not repeat")
+	// Creation did actually commit; this is not only an error-message test.
+	output := runCLI(t, env, dir, "list", "--json")
+	assert.Contains(t, output, "Example task")
+}

--- a/cmd/kata/remote_requests_test.go
+++ b/cmd/kata/remote_requests_test.go
@@ -19,8 +19,8 @@ import (
 	"go.kenn.io/kata/internal/testfix"
 )
 
-// A remote command should spend its requests on project resolution and the
-// operation itself, not a preliminary liveness check. Exercise every remote
+// A simple remote mutation resolves its project in the mutation request.
+// Exercise every remote
 // selection source against a real, authenticated daemon and persisted writes.
 func TestRemoteMutationsWithoutPreflight(t *testing.T) {
 	for _, source := range []string{"environment", "workspace", "active", "named"} {
@@ -67,7 +67,7 @@ func TestRemoteMutationsWithoutPreflight(t *testing.T) {
 			for _, operation := range []string{"create", "edit", "comment", "label"} {
 				var command []string
 				var wantMutation string
-				issuePath := fmt.Sprintf("/api/v1/projects/%d/issues", project.ID)
+				issuePath := "/api/v1/projects/name:example-project/issues"
 				switch operation {
 				case "create":
 					command = []string{"create", "Example task", "--body", "Original description"}
@@ -88,7 +88,7 @@ func TestRemoteMutationsWithoutPreflight(t *testing.T) {
 				stdout, stderr, err := executeRootCapture(t, t.Context(), append(command, args...)...)
 				require.NoError(t, err, "%s: %s", operation, stderr)
 				mu.Lock()
-				assert.Equal(t, []string{"POST /api/v1/projects/resolve", wantMutation}, paths, operation)
+				assert.Equal(t, []string{wantMutation}, paths, operation)
 				mu.Unlock()
 				if operation == "create" {
 					var response struct {

--- a/cmd/kata/remote_requests_test.go
+++ b/cmd/kata/remote_requests_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json/v2"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/testenv"
+	"go.kenn.io/kata/internal/testfix"
+)
+
+// A remote command should spend its requests on project resolution and the
+// operation itself, not a preliminary liveness check. Exercise every remote
+// selection source against a real, authenticated daemon and persisted writes.
+func TestRemoteMutationsWithoutPreflight(t *testing.T) {
+	for _, source := range []string{"environment", "workspace", "active", "named"} {
+		t.Run(source, func(t *testing.T) {
+			env := testenv.New(t, testenv.WithAuthToken("fixture-token"))
+			workspace := t.TempDir()
+			testfix.WriteKataToml(t, workspace, "example-project")
+			t.Chdir(workspace)
+			t.Setenv("KATA_SERVER", "")
+			project, err := env.DB.CreateProject(t.Context(), "example-project")
+			require.NoError(t, err)
+			target, err := url.Parse(env.URL)
+			require.NoError(t, err)
+			proxy := httputil.NewSingleHostReverseProxy(target)
+			var mu sync.Mutex
+			var paths []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				paths = append(paths, r.Method+" "+r.URL.Path)
+				mu.Unlock()
+				r.Host = target.Host
+				proxy.ServeHTTP(w, r)
+			}))
+			t.Cleanup(server.Close)
+			args := []string{"--project", project.Name, "--json"}
+			switch source {
+			case "environment":
+				t.Setenv("KATA_SERVER", server.URL)
+			case "workspace":
+				require.NoError(t, os.WriteFile(filepath.Join(workspace, ".kata.local.toml"),
+					[]byte(fmt.Sprintf("version = 1\n[server]\nurl = %q\n", server.URL)), 0o600))
+			case "active", "named":
+				t.Setenv("KATA_AUTH_TOKEN", "")
+				config := fmt.Sprintf("[[daemon]]\nname = \"example-remote\"\nurl = %q\ntoken = \"fixture-token\"\n", server.URL)
+				if source == "active" {
+					config = "active_daemon = \"example-remote\"\n" + config
+				} else {
+					args = append(args, "--daemon", "example-remote")
+				}
+				require.NoError(t, os.WriteFile(filepath.Join(env.Home, "config.toml"), []byte(config), 0o600))
+			}
+			var ref string
+			var issueID int64
+			for _, operation := range []string{"create", "edit", "comment", "label"} {
+				var command []string
+				var wantMutation string
+				issuePath := fmt.Sprintf("/api/v1/projects/%d/issues", project.ID)
+				switch operation {
+				case "create":
+					command = []string{"create", "Example task", "--body", "Original description"}
+					wantMutation = "POST " + issuePath
+				case "edit":
+					command = []string{"edit", ref, "--body", "Updated description"}
+					wantMutation = "PATCH " + issuePath + "/" + ref
+				case "comment":
+					command = []string{"comment", ref, "--body", "Example comment"}
+					wantMutation = "POST " + issuePath + "/" + ref + "/comments"
+				case "label":
+					command = []string{"label", "add", ref, "example-label"}
+					wantMutation = "POST " + issuePath + "/" + ref + "/labels"
+				}
+				mu.Lock()
+				paths = nil
+				mu.Unlock()
+				stdout, stderr, err := executeRootCapture(t, t.Context(), append(command, args...)...)
+				require.NoError(t, err, "%s: %s", operation, stderr)
+				mu.Lock()
+				assert.Equal(t, []string{"POST /api/v1/projects/resolve", wantMutation}, paths, operation)
+				mu.Unlock()
+				if operation == "create" {
+					var response struct {
+						Issue db.Issue `json:"issue"`
+					}
+					require.NoError(t, json.Unmarshal([]byte(stdout), &response))
+					ref, issueID = response.Issue.ShortID, response.Issue.ID
+					require.NotEmpty(t, ref)
+				}
+			}
+			issue, err := env.DB.IssueByID(t.Context(), issueID)
+			require.NoError(t, err)
+			assert.Equal(t, "Updated description", issue.Body)
+			// Read through the CLI as well so the daemon's actual comment and
+			// label projections, not just successful status codes, are checked.
+			stdout, stderr, err := executeRootCapture(t, t.Context(), append([]string{"show", ref}, args...)...)
+			require.NoError(t, err, stderr)
+			assert.Contains(t, stdout, "Example comment")
+			assert.Contains(t, stdout, "example-label")
+		})
+	}
+}

--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -96,10 +96,16 @@ resolve endpoint; `--comment` adds its own comment request after the mutation.
 Upgrade the remote daemon with the CLI: older daemons reject named project
 selectors rather than silently performing a different operation.
 
-When create resolves a renamed workspace through its alias, the CLI repairs
+When a mutation resolves a renamed workspace through its alias, the CLI repairs
 `.kata.toml` from the successful response. If that local repair fails, the CLI
 reports `workspace_repair_failed` and states that the mutation succeeded. Fix
 the binding without repeating the mutation.
+
+Bare issue references and ULIDs use the workspace alias, including after a
+project rename or merge. An explicit `--project` or qualified issue reference
+selects that project name instead and does not repair the workspace binding.
+Relationship-bearing edits resolve the alias and repair the binding before
+submitting the mutation, because their link checks need canonical identity.
 
 To inspect the endpoint selected by those rules, including its transport and
 canonical request URL, run:

--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -84,6 +84,10 @@ If none of those are set, clients next honor `active_daemon` in
 `<KATA_HOME>/config.toml`; otherwise they use local daemon discovery or
 auto-start.
 
+Ordinary remote CLI commands send their API requests without a preliminary
+ping. Refused connections still report `daemon_unavailable` (exit code 7).
+Explicit health and discovery commands continue to probe the selected daemon.
+
 To inspect the endpoint selected by those rules, including its transport and
 canonical request URL, run:
 

--- a/docs/operations/remote-daemon.md
+++ b/docs/operations/remote-daemon.md
@@ -88,6 +88,19 @@ Ordinary remote CLI commands send their API requests without a preliminary
 ping. Refused connections still report `daemon_unavailable` (exit code 7).
 Explicit health and discovery commands continue to probe the selected daemon.
 
+With API `0.17.0` or later, simple `create`, `edit`, `comment`, and `label add`
+commands also resolve the project within the mutation, so each needs only one
+HTTP request. Relationship flags retain their separate project resolution and
+any necessary target checks. Path-only workspaces still use the explicit
+resolve endpoint; `--comment` adds its own comment request after the mutation.
+Upgrade the remote daemon with the CLI: older daemons reject named project
+selectors rather than silently performing a different operation.
+
+When create resolves a renamed workspace through its alias, the CLI repairs
+`.kata.toml` from the successful response. If that local repair fails, the CLI
+reports `workspace_repair_failed` and states that the mutation succeeded. Fix
+the binding without repeating the mutation.
+
 To inspect the endpoint selected by those rules, including its transport and
 canonical request URL, run:
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-27
+last_edited: 2026-09-07
 ---
 
 # HTTP API schema
@@ -45,7 +45,7 @@ The schema carries a version in its `info.version` field
 {
   "ok": true,
   "schema_version": 7,
-  "api_schema_version": "0.16.0",
+  "api_schema_version": "0.17.0",
   "version": "1.4.2",
   "uptime": "5m0s",
   "db_path": "/path/to/kata.db",
@@ -112,6 +112,7 @@ and decline to render issue detail.
 
 | Version | Change |
 | --- | --- |
+| `0.17.0` | Create issue, edit issue, create comment, and add label accept a numeric project ID or `name:<project>` in the project path. Optional alias headers use alias-first resolution. Successful responses include `X-Kata-Project-Name`. Generated clients represent these four path parameters as strings. |
 | `0.16.0` | Ordinary API array fields are non-null. Empty and nil Go slices serialize as `[]`, generated clients omit `null` from ordinary array types, and requests reject `null` for those arrays. JSON object member names are case-sensitive. |
 | `0.15.0` | Added close idempotency and revision headers, the `close-v1` request marker, and retry receipt fields. |
 | `0.14.0` | Added `external` close evidence with its required `account` field. |
@@ -134,6 +135,35 @@ this means nil maps encode as `{}`, duplicate object member names and invalid
 UTF-8 are rejected, and struct field names match case-sensitively. JSON object
 member order is unspecified. Unknown request members remain governed by the
 request schema and are rejected for strict request objects.
+
+## Resolving projects inside mutations
+
+These operations accept either a numeric project ID or a `name:` selector:
+
+| Method | Path |
+| --- | --- |
+| `POST` | `/api/v1/projects/name:example-project/issues` |
+| `PATCH` | `/api/v1/projects/name:example-project/issues/{ref}` |
+| `POST` | `/api/v1/projects/name:example-project/issues/{ref}/comments` |
+| `POST` | `/api/v1/projects/name:example-project/issues/{ref}/labels` |
+
+URL-encode the project selector as one path segment. Numeric paths such as
+`/api/v1/projects/42/issues` remain valid. The issue ref and mutation body
+keep their existing meanings. A successful response includes the canonical
+project name in `X-Kata-Project-Name`.
+
+A `name:` request can also carry `X-Kata-Project-Alias` (the workspace alias
+identity) and `X-Kata-Project-Alias-Kind` (`git` or `local`). The alias takes
+precedence over the name, preserving rename and merge resolution. If the
+alias is unknown, the existing named project is used and the alias is
+attached. `name:` with no name requires a registered alias. Resolution does
+not create projects, and numeric selectors do not accept alias headers.
+
+Alias attachment requires attributed write authority and is unavailable to
+local browser sessions. When a host access controller is installed, named
+resolution requires all-project authority before resolution or attachment,
+matching the standalone project-resolve endpoint. Project-scoped clients
+can continue using numeric IDs.
 
 ## Compatibility expectations
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -381,13 +381,33 @@ type MergeProjectResponse struct {
 	Body MergeProjectResultOut
 }
 
+// ProjectTarget selects a mutation's project by local numeric ID or name.
+// Alias headers use the same alias-first resolution as the resolve endpoint.
+type ProjectTarget struct {
+	ProjectSelector  string `path:"project_id" required:"true" doc:"Numeric project ID or name:<project name>; name: alone requires an alias"`
+	ProjectAlias     string `header:"X-Kata-Project-Alias" doc:"Workspace alias identity; requires a name: selector"`
+	ProjectAliasKind string `header:"X-Kata-Project-Alias-Kind" doc:"Workspace alias kind; required with X-Kata-Project-Alias"`
+	ProjectID        int64  `json:"-" hidden:"true"`
+}
+
+// Target provides the mutable target shared by issue mutation requests.
+func (p *ProjectTarget) Target() *ProjectTarget { return p }
+
+// ProjectNameHeader carries the canonical name selected for a mutation.
+type ProjectNameHeader struct {
+	ProjectName string `header:"X-Kata-Project-Name" doc:"Canonical project name"`
+}
+
+// SetProjectName records the canonical project selected by the daemon.
+func (p *ProjectNameHeader) SetProjectName(name string) { p.ProjectName = name }
+
 // CreateIssueRequest is POST /api/v1/projects/{id}/issues.
 //
 // IdempotencyKey is read from the Idempotency-Key HTTP header (spec §4.4).
 // Body.ForceNew bypasses look-alike soft-block but is overridden by an
 // idempotent match (idempotency wins per spec §3.7).
 type CreateIssueRequest struct {
-	ProjectID      int64  `path:"project_id" required:"true"`
+	ProjectTarget
 	IdempotencyKey string `header:"Idempotency-Key"`
 	Body           struct {
 		Actor    string                  `json:"actor,omitempty"`
@@ -430,6 +450,7 @@ type CreateInitialLinkBody struct {
 // non-nil only on idempotent reuse — the issue.created event row of the prior
 // creation, so clients can correlate the reuse to the original mutation.
 type MutationResponse struct {
+	ProjectNameHeader
 	Body struct {
 		Issue         db.Issue  `json:"issue"`
 		Event         *db.Event `json:"event"`
@@ -720,9 +741,9 @@ type ClaimViolationOut struct {
 
 // EditIssueRequest is PATCH /api/v1/projects/{id}/issues/{ref}.
 type EditIssueRequest struct {
-	ProjectID int64  `path:"project_id" required:"true"`
-	Ref       string `path:"ref" required:"true"`
-	Body      struct {
+	ProjectTarget
+	Ref  string `path:"ref" required:"true"`
+	Body struct {
 		Actor         string      `json:"actor,omitempty"`
 		Title         *string     `json:"title,omitempty"`
 		Body          *string     `json:"body,omitempty"`
@@ -785,6 +806,7 @@ type LinkChanges struct {
 // new clients can walk the full slice to observe every transition (e.g.
 // distinguishing a priority change from a link change).
 type EditIssueResponse struct {
+	ProjectNameHeader
 	Body struct {
 		Issue   db.Issue     `json:"issue"`
 		Event   *db.Event    `json:"event"`
@@ -796,7 +818,7 @@ type EditIssueResponse struct {
 
 // CommentRequest is POST /api/v1/projects/{id}/issues/{ref}/comments.
 type CommentRequest struct {
-	ProjectID      int64  `path:"project_id" required:"true"`
+	ProjectTarget
 	Ref            string `path:"ref" required:"true"`
 	IdempotencyKey string `header:"Idempotency-Key"`
 	Body           struct {
@@ -818,6 +840,7 @@ type EditCommentRequest struct {
 
 // CommentResponse mirrors MutationResponse but adds the new comment row.
 type CommentResponse struct {
+	ProjectNameHeader
 	Body struct {
 		Issue   db.Issue   `json:"issue"`
 		Comment db.Comment `json:"comment"`
@@ -1007,9 +1030,9 @@ type DetachProjectAliasResponse struct {
 
 // AddLabelRequest is POST /api/v1/projects/{id}/issues/{ref}/labels.
 type AddLabelRequest struct {
-	ProjectID int64  `path:"project_id" required:"true"`
-	Ref       string `path:"ref" required:"true"`
-	Body      struct {
+	ProjectTarget
+	Ref  string `path:"ref" required:"true"`
+	Body struct {
 		Actor string `json:"actor,omitempty"`
 		Label string `json:"label" required:"true"`
 	}
@@ -1017,6 +1040,7 @@ type AddLabelRequest struct {
 
 // AddLabelResponse extends the standard envelope with the new label row.
 type AddLabelResponse struct {
+	ProjectNameHeader
 	Body struct {
 		Issue   db.Issue      `json:"issue"`
 		Label   db.IssueLabel `json:"label"`

--- a/internal/client/remote.go
+++ b/internal/client/remote.go
@@ -187,6 +187,7 @@ type remoteResolutionMode int
 const (
 	remoteEndpointOnly remoteResolutionMode = iota
 	remoteWithCredentials
+	remoteRequestTarget
 )
 
 func resolveRemoteSelection(
@@ -199,7 +200,7 @@ func resolveRemoteSelection(
 			return ResolvedDaemon{}, false,
 				fmt.Errorf("KATA_SERVER %q: %w", remoteURLForError(value), err)
 		}
-		if !probeRemote(ctx, baseURL) {
+		if mode != remoteRequestTarget && !probeRemote(ctx, baseURL) {
 			return ResolvedDaemon{}, false,
 				fmt.Errorf("%w: %s (KATA_SERVER)", ErrRemoteUnavailable, baseURL)
 		}
@@ -207,7 +208,7 @@ func resolveRemoteSelection(
 			DaemonSourceServerEnv, "", remoteRunningDaemon(baseURL, true),
 		)
 		resolved.AllowInsecure = allowInsecure
-		if mode == remoteWithCredentials {
+		if mode != remoteEndpointOnly {
 			resolved = resolved.withGlobalAuth()
 		}
 		return resolved, true, nil
@@ -235,7 +236,7 @@ func resolveRemoteSelection(
 		return ResolvedDaemon{}, false,
 			fmt.Errorf("%s server.url %q: %w", path, remoteURLForError(cfg.Server.URL), err)
 	}
-	if !probeRemote(ctx, baseURL) {
+	if mode != remoteRequestTarget && !probeRemote(ctx, baseURL) {
 		return ResolvedDaemon{}, false,
 			fmt.Errorf("%w: %s (%s)", ErrRemoteUnavailable, baseURL, path)
 	}
@@ -243,7 +244,7 @@ func resolveRemoteSelection(
 		DaemonSourceLocalConfig, "", remoteRunningDaemon(baseURL, true),
 	)
 	resolved.AllowInsecure = cfg.Server.AllowInsecure
-	if mode == remoteWithCredentials {
+	if mode != remoteEndpointOnly {
 		resolved = resolved.withGlobalAuth()
 	}
 	return resolved, true, nil
@@ -257,13 +258,13 @@ func resolveActiveRemoteSelection(
 		return ResolvedDaemon{}, false, err
 	}
 	token := target.Token
-	if mode == remoteWithCredentials && !globalAuthTokenOverrideSet() {
+	if mode != remoteEndpointOnly && !globalAuthTokenOverrideSet() {
 		token, err = resolveActiveRemoteTargetToken(target)
 		if err != nil {
 			return ResolvedDaemon{}, false, err
 		}
 	}
-	if !probeRemote(ctx, target.BaseURL) {
+	if mode != remoteRequestTarget && !probeRemote(ctx, target.BaseURL) {
 		return ResolvedDaemon{}, false, fmt.Errorf("%w: %s (%s active_daemon %q)",
 			ErrRemoteUnavailable, target.BaseURL, daemonConfigSource(), target.Name)
 	}
@@ -271,7 +272,7 @@ func resolveActiveRemoteSelection(
 		DaemonSourceActiveDaemon, target.Name, remoteRunningDaemon(target.BaseURL, true),
 	)
 	resolved.AllowInsecure = target.AllowInsecure
-	if mode == remoteWithCredentials {
+	if mode != remoteEndpointOnly {
 		resolved = resolved.withRemoteTargetAuth(token, target.AllowInsecure)
 	}
 	return resolved, true, nil
@@ -291,6 +292,7 @@ type namedResolutionMode int
 const (
 	namedDiscoverOnly namedResolutionMode = iota
 	namedEnsureRunning
+	namedRequestTarget
 )
 
 func buildNamedDaemonTarget(
@@ -310,7 +312,7 @@ func buildNamedDaemonTarget(
 		}
 		if d.Local {
 			var running RunningDaemon
-			if mode == namedEnsureRunning {
+			if mode != namedDiscoverOnly {
 				running, err = EnsureLocalRunningTarget(ctx)
 			} else {
 				var ns *daemon.Namespace
@@ -339,7 +341,7 @@ func buildNamedDaemonTarget(
 		if err != nil {
 			return namedDaemonTarget{}, false, err
 		}
-		if !probeRemote(ctx, target.BaseURL) {
+		if mode != namedRequestTarget && !probeRemote(ctx, target.BaseURL) {
 			return namedDaemonTarget{}, false, fmt.Errorf("%w: %s (%s daemon %q)",
 				ErrRemoteUnavailable, target.BaseURL, daemonConfigSource(), d.Name)
 		}
@@ -349,7 +351,11 @@ func buildNamedDaemonTarget(
 }
 
 func resolveNamedDaemon(ctx context.Context, name string) (ResolvedDaemon, error) {
-	target, ok, err := buildNamedDaemonTarget(ctx, name, namedEnsureRunning)
+	return resolveNamedDaemonMode(ctx, name, namedEnsureRunning)
+}
+
+func resolveNamedDaemonMode(ctx context.Context, name string, mode namedResolutionMode) (ResolvedDaemon, error) {
+	target, ok, err := buildNamedDaemonTarget(ctx, name, mode)
 	if err != nil {
 		return ResolvedDaemon{}, err
 	}

--- a/internal/client/resolved.go
+++ b/internal/client/resolved.go
@@ -155,12 +155,23 @@ func (d ResolvedDaemon) withLocalTargetAuth(token string) ResolvedDaemon {
 // EnsureResolvedInWorkspace selects a daemon and retains the policy selected
 // by that same source. Configured remotes precede local discovery and start.
 func EnsureResolvedInWorkspace(ctx context.Context, workspaceStart string) (ResolvedDaemon, error) {
+	return resolveForClient(ctx, workspaceStart, remoteWithCredentials)
+}
+
+// PrepareResolvedInWorkspace selects the target and credentials for an API
+// request. Configured remotes are not pinged: the request itself establishes
+// reachability. Local discovery, version checks, and auto-start are unchanged.
+func PrepareResolvedInWorkspace(ctx context.Context, workspaceStart string) (ResolvedDaemon, error) {
+	return resolveForClient(ctx, workspaceStart, remoteRequestTarget)
+}
+
+func resolveForClient(ctx context.Context, workspaceStart string, mode remoteResolutionMode) (ResolvedDaemon, error) {
 	if value, ok := ctx.Value(BaseURLKey{}).(string); ok && value != "" {
 		return resolvedForRunning(
 			DaemonSourceInjected, "", remoteRunningDaemon(value, false),
 		).withGlobalAuth(), nil
 	}
-	if resolved, ok, err := resolveRemoteDaemon(ctx, workspaceStart); err != nil {
+	if resolved, ok, err := resolveRemoteSelection(ctx, workspaceStart, mode); err != nil {
 		return ResolvedDaemon{}, err
 	} else if ok {
 		return resolved, nil
@@ -178,6 +189,12 @@ func ResolveRemoteDaemon(ctx context.Context, workspaceStart string) (ResolvedDa
 // entries may start the local daemon; named remotes are probed.
 func EnsureResolvedNamed(ctx context.Context, name string) (ResolvedDaemon, error) {
 	return resolveNamedDaemon(ctx, name)
+}
+
+// PrepareResolvedNamed selects a catalog target for an API request without
+// probing a remote. Named local daemons retain discovery and auto-start.
+func PrepareResolvedNamed(ctx context.Context, name string) (ResolvedDaemon, error) {
+	return resolveNamedDaemonMode(ctx, name, namedRequestTarget)
 }
 
 // DiscoverResolved returns the first live local runtime with its exact

--- a/internal/daemon/handlers_comments.go
+++ b/internal/daemon/handlers_comments.go
@@ -25,7 +25,7 @@ func registerCommentsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		OperationID: "createComment",
 		Method:      "POST",
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/comments",
-	}, func(ctx context.Context, in *api.CommentRequest) (*api.CommentResponse, error) {
+	}, withResolvedProject(cfg, func(ctx context.Context, in *api.CommentRequest) (*api.CommentResponse, error) {
 		actor, err := attributedActor(ctx, in.Body.Actor)
 		if err != nil {
 			return nil, err
@@ -107,7 +107,7 @@ func registerCommentsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		out.Body.Event = &evt
 		out.Body.Changed = true
 		return out, nil
-	})
+	}))
 
 	huma.Register(humaAPI, huma.Operation{
 		OperationID: "editComment",

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -75,7 +75,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		OperationID: "createIssue",
 		Method:      "POST",
 		Path:        "/api/v1/projects/{project_id}/issues",
-	}, func(ctx context.Context, in *api.CreateIssueRequest) (*api.MutationResponse, error) {
+	}, withResolvedProject(cfg, func(ctx context.Context, in *api.CreateIssueRequest) (*api.MutationResponse, error) {
 		actor, err := attributedActor(ctx, in.Body.Actor)
 		if err != nil {
 			return nil, err
@@ -202,7 +202,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		out.Body.Event = &evt
 		out.Body.Changed = true
 		return out, nil
-	})
+	}))
 
 	huma.Register(humaAPI, huma.Operation{
 		OperationID: "listIssues",
@@ -395,7 +395,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		OperationID: "editIssue",
 		Method:      "PATCH",
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}",
-	}, editIssueHandler(cfg))
+	}, withResolvedProject(cfg, editIssueHandler(cfg)))
 }
 
 // editIssueHandler dispatches a PATCH /issues/{ref} call. It applies any

--- a/internal/daemon/handlers_labels.go
+++ b/internal/daemon/handlers_labels.go
@@ -19,7 +19,7 @@ func registerLabelsHandlers(humaAPI huma.API, cfg ServerConfig) {
 		OperationID: "addLabel",
 		Method:      "POST",
 		Path:        "/api/v1/projects/{project_id}/issues/{ref}/labels",
-	}, addLabelHandler(cfg))
+	}, withResolvedProject(cfg, addLabelHandler(cfg)))
 
 	huma.Register(humaAPI, huma.Operation{
 		OperationID: "removeLabel",

--- a/internal/daemon/handlers_project_target.go
+++ b/internal/daemon/handlers_project_target.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/kata/internal/api"
+)
+
+type projectTargetRequest interface {
+	Target() *api.ProjectTarget
+}
+
+type projectNameResponse interface {
+	SetProjectName(string)
+}
+
+// withResolvedProject keeps project selection inside the mutation request.
+// HostAccess authorizes name selectors as all-project operations before this
+// handler runs, matching the standalone resolve endpoint's authority.
+func withResolvedProject[I any, O any, PI interface {
+	*I
+	projectTargetRequest
+}, PO interface {
+	*O
+	projectNameResponse
+}](cfg ServerConfig, handler func(context.Context, *I) (*O, error)) func(context.Context, *I) (*O, error) {
+	return func(ctx context.Context, in *I) (*O, error) {
+		target := PI(in).Target()
+		name, named := strings.CutPrefix(target.ProjectSelector, "name:")
+		var canonicalName string
+		if named {
+			var alias *api.AliasInput
+			if target.ProjectAlias != "" || target.ProjectAliasKind != "" {
+				if err := ensureAttributedWriteAllowed(ctx); err != nil {
+					return nil, err
+				}
+				if principal, ok := PrincipalFromContext(ctx); ok && principal.Kind == PrincipalWebLocal {
+					return nil, api.NewError(http.StatusForbidden, "web_local_operation_forbidden",
+						"local web sessions cannot resolve projects through daemon aliases", "", nil)
+				}
+				alias = &api.AliasInput{Identity: target.ProjectAlias, Kind: target.ProjectAliasKind}
+			}
+			resolved, err := resolveProject(ctx, cfg.DB, alias, name, "")
+			if err != nil {
+				return nil, err
+			}
+			target.ProjectID = resolved.Project.ID
+			canonicalName = resolved.Project.Name
+		} else {
+			if target.ProjectAlias != "" || target.ProjectAliasKind != "" {
+				return nil, api.NewError(http.StatusBadRequest, "validation",
+					"project alias headers require a name: project selector", "", nil)
+			}
+			id, err := strconv.ParseInt(target.ProjectSelector, 10, 64)
+			if err != nil {
+				return nil, api.NewError(http.StatusBadRequest, "validation",
+					"project selector must be a numeric ID or name:<project name>", "", nil)
+			}
+			project, err := activeProjectByID(ctx, cfg.DB, id)
+			if err != nil {
+				return nil, err
+			}
+			target.ProjectID = project.ID
+			canonicalName = project.Name
+		}
+		out, err := handler(ctx, in)
+		if err != nil {
+			return nil, err
+		}
+		PO(out).SetProjectName(canonicalName)
+		return out, nil
+	}
+}

--- a/internal/daemon/handlers_project_target_test.go
+++ b/internal/daemon/handlers_project_target_test.go
@@ -1,0 +1,179 @@
+package daemon_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/daemon"
+	"go.kenn.io/kata/internal/db"
+	"go.kenn.io/kata/internal/testenv"
+)
+
+func TestIssueMutationsResolveProjectName(t *testing.T) {
+	for _, selector := range []string{"name:example-project", "numeric"} {
+		t.Run(selector, func(t *testing.T) {
+			env := testenv.New(t)
+			project, err := env.DB.CreateProject(t.Context(), "example-project")
+			require.NoError(t, err)
+			base := "/api/v1/projects/" + selector
+			if selector == "numeric" {
+				base = projectPath(project.ID)
+			}
+			t.Run("create", func(t *testing.T) {
+				resp, raw := envDoRaw(t, env, http.MethodPost, base+"/issues", map[string]any{
+					"actor": "user-a", "title": "created title",
+				}, nil)
+				require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+				require.Equal(t, "example-project", resp.Header.Get("X-Kata-Project-Name"))
+				var created struct{ Issue db.Issue }
+				require.NoError(t, json.Unmarshal(raw, &created))
+				require.Equal(t, project.ID, created.Issue.ProjectID)
+			})
+			issueID := createIssueViaHTTP(t, env, project.ID, "fixture issue")
+			fixture, err := env.DB.IssueByID(t.Context(), issueID)
+			require.NoError(t, err)
+			path := base + "/issues/" + fixture.ShortID
+			for _, mutation := range []struct {
+				method, suffix string
+				body           map[string]string
+			}{
+				{http.MethodPatch, "", map[string]string{"actor": "user-a", "title": "updated title"}},
+				{http.MethodPost, "/comments", map[string]string{"actor": "user-a", "body": "comment text"}},
+				{http.MethodPost, "/labels", map[string]string{"actor": "user-a", "label": "urgent"}},
+			} {
+				t.Run(mutation.method+mutation.suffix, func(t *testing.T) {
+					resp, raw := envDoRaw(t, env, mutation.method, path+mutation.suffix, mutation.body, nil)
+					require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+					require.Equal(t, "example-project", resp.Header.Get("X-Kata-Project-Name"))
+				})
+			}
+			issue, err := env.DB.IssueByID(t.Context(), fixture.ID)
+			require.NoError(t, err)
+			require.Equal(t, "updated title", issue.Title)
+			comments, err := env.DB.CommentsByIssue(t.Context(), issue.ID)
+			require.NoError(t, err)
+			require.Len(t, comments, 1)
+			require.Equal(t, "comment text", comments[0].Body)
+			labels, err := env.DB.LabelsByIssue(t.Context(), issue.ID)
+			require.NoError(t, err)
+			require.Len(t, labels, 1)
+			require.Equal(t, "urgent", labels[0].Label)
+		})
+	}
+}
+
+func TestIssueMutationAliasResolution(t *testing.T) {
+	env := testenv.New(t)
+	project, err := env.DB.CreateProject(t.Context(), "original-project")
+	require.NoError(t, err)
+	headers := map[string]string{
+		"X-Kata-Project-Alias": "example.com/team/example-project", "X-Kata-Project-Alias-Kind": "git",
+	}
+	resp, raw := envDoRaw(t, env, http.MethodPost, "/api/v1/projects/name:original-project/issues",
+		map[string]string{"actor": "user-a", "title": "first issue"}, headers)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+	alias, err := env.DB.AliasByIdentity(t.Context(), headers["X-Kata-Project-Alias"])
+	require.NoError(t, err)
+	require.Equal(t, project.ID, alias.ProjectID)
+	_, _, _, err = env.DB.RenameProjectAndEvent(t.Context(), project.ID, "renamed-project", "user-a")
+	require.NoError(t, err)
+	resp, raw = envDoRaw(t, env, http.MethodPost, "/api/v1/projects/name:original-project/issues",
+		map[string]any{"actor": "user-a", "title": "after rename", "force_new": true}, headers)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+	require.Equal(t, "renamed-project", resp.Header.Get("X-Kata-Project-Name"))
+	target, err := env.DB.CreateProject(t.Context(), "surviving-project")
+	require.NoError(t, err)
+	_, err = env.DB.MergeProjects(t.Context(), db.MergeProjectsParams{SourceProjectID: project.ID, TargetProjectID: target.ID})
+	require.NoError(t, err)
+	resp, raw = envDoRaw(t, env, http.MethodPost, "/api/v1/projects/name:/issues",
+		map[string]any{"actor": "user-a", "title": "after merge", "force_new": true}, headers)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+	require.Equal(t, "surviving-project", resp.Header.Get("X-Kata-Project-Name"))
+	var created struct{ Issue db.Issue }
+	require.NoError(t, json.Unmarshal(raw, &created))
+	require.Equal(t, target.ID, created.Issue.ProjectID)
+}
+
+func TestIssueMutationRejectsUnresolvedProject(t *testing.T) {
+	for _, tc := range []struct {
+		selector string
+		status   int
+	}{
+		{"name:", http.StatusBadRequest},
+		{"unknown", http.StatusBadRequest},
+		{"name:missing-project", http.StatusNotFound},
+		{"0", http.StatusNotFound},
+	} {
+		t.Run(tc.selector, func(t *testing.T) {
+			env := testenv.New(t)
+			resp, raw := envDoRaw(t, env, http.MethodPost, "/api/v1/projects/"+tc.selector+"/issues",
+				map[string]string{"actor": "user-a", "title": "not created"}, nil)
+			require.Equal(t, tc.status, resp.StatusCode, string(raw))
+			require.Empty(t, resp.Header.Get("X-Kata-Project-Name"))
+		})
+	}
+}
+
+func TestIssueMutationRejectsInvalidAliasTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name, selector, identity, kind string
+	}{
+		{"numeric selector", "numeric", "example.com/team/example-project", "git"},
+		{"missing identity", "name:example-project", "", "git"},
+		{"missing kind", "name:example-project", "example.com/team/example-project", ""},
+		{"invalid kind", "name:example-project", "example.com/team/example-project", "invalid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := testenv.New(t)
+			project, err := env.DB.CreateProject(t.Context(), "example-project")
+			require.NoError(t, err)
+			path := "/api/v1/projects/" + tc.selector + "/issues"
+			if tc.selector == "numeric" {
+				path = projectPath(project.ID) + "/issues"
+			}
+			resp, raw := envDoRaw(t, env, http.MethodPost, path,
+				map[string]string{"actor": "user-a", "title": "not created"}, map[string]string{
+					"X-Kata-Project-Alias": tc.identity, "X-Kata-Project-Alias-Kind": tc.kind,
+				})
+			assertAPIError(t, resp.StatusCode, raw, http.StatusBadRequest, "validation")
+			aliases, err := env.DB.ProjectAliases(t.Context(), project.ID)
+			require.NoError(t, err)
+			require.Empty(t, aliases)
+		})
+	}
+}
+
+func TestIssueMutationAliasAttachmentRespectsAuthority(t *testing.T) {
+	for _, principal := range []daemon.PrincipalKind{daemon.PrincipalHost, daemon.PrincipalBootstrap, daemon.PrincipalWebLocal} {
+		t.Run(string(principal), func(t *testing.T) {
+			env := testenv.New(t)
+			project, err := env.DB.CreateProject(t.Context(), "example-project")
+			require.NoError(t, err)
+			cfg := daemon.ServerConfig{DB: env.DB}
+			if principal == daemon.PrincipalHost {
+				cfg.HostAccess = denyingUILaunchHostAccess{}
+			}
+			server := daemon.NewServer(cfg)
+			t.Cleanup(func() { require.NoError(t, server.Close()) })
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ctx := daemon.WithPrincipal(r.Context(), daemon.Principal{Kind: principal, Subject: "user-a", Actor: "user-a"})
+				server.Handler().ServeHTTP(w, r.WithContext(ctx))
+			}))
+			t.Cleanup(ts.Close)
+			resp := postWithHeader(t, ts, "/api/v1/projects/name:example-project/issues", map[string]string{
+				"X-Kata-Project-Alias": "example.com/team/example-project", "X-Kata-Project-Alias-Kind": "git",
+			}, map[string]string{"actor": "user-a", "title": "not created"})
+			want := http.StatusForbidden
+			if principal == daemon.PrincipalHost {
+				want = http.StatusNotFound
+			}
+			require.Equal(t, want, resp.status, string(resp.body))
+			aliases, err := env.DB.ProjectAliases(t.Context(), project.ID)
+			require.NoError(t, err)
+			require.Empty(t, aliases)
+		})
+	}
+}

--- a/internal/daemon/openapi.go
+++ b/internal/daemon/openapi.go
@@ -16,7 +16,7 @@ import (
 // (info.version). It tracks the HTTP API contract, not the build version, so
 // the committed schema artifact stays stable across builds and is bumped
 // deliberately when the wire contract changes.
-const APISchemaVersion = "0.16.0"
+const APISchemaVersion = "0.17.0"
 
 // OpenAPIDocument builds the daemon's complete OpenAPI model by wiring every
 // route through NewServer with a zero ServerConfig. It binds no listener and

--- a/internal/daemon/openapi_test.go
+++ b/internal/daemon/openapi_test.go
@@ -287,12 +287,6 @@ func TestOpenAPIDocumentIncludesUIReadContract(t *testing.T) {
 	}
 }
 
-func TestOpenAPISchemaVersionReflectsNonNullArrays(t *testing.T) {
-	if APISchemaVersion != "0.16.0" {
-		t.Fatalf("APISchemaVersion = %q, want 0.16.0 for non-null API arrays", APISchemaVersion)
-	}
-}
-
 func TestOpenAPIDocumentOrdinarySlicesAreNonNullable(t *testing.T) {
 	doc := OpenAPIDocument()
 	for schemaName, propertyName := range map[string]string{

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -485,7 +485,7 @@ func (h toolHandlers) create(ctx context.Context, _ *sdkmcp.CallToolRequest, inp
 		body.Owner = &input.Owner
 	}
 	response, err := h.options.Client.CreateIssue(ctx, &generated.CreateIssueRequestOptions{
-		PathParams: &generated.CreateIssuePath{ProjectID: project.ID},
+		PathParams: &generated.CreateIssuePath{ProjectID: strconv.FormatInt(project.ID, 10)},
 		Body:       &body,
 		Header:     &generated.CreateIssueHeaders{IdempotencyKey: &key},
 	})
@@ -559,7 +559,7 @@ func (h toolHandlers) edit(ctx context.Context, _ *sdkmcp.CallToolRequest, input
 	}
 	if hasIssueEdit {
 		response, editErr := h.options.Client.EditIssue(ctx, &generated.EditIssueRequestOptions{
-			PathParams: &generated.EditIssuePath{ProjectID: project.ID, Ref: ref},
+			PathParams: &generated.EditIssuePath{ProjectID: strconv.FormatInt(project.ID, 10), Ref: ref},
 			Body:       &body,
 		})
 		if editErr != nil {
@@ -617,7 +617,7 @@ func (h toolHandlers) comment(ctx context.Context, _ *sdkmcp.CallToolRequest, in
 		return nil, CommentOutput{}, errors.New("idempotency_key must not be empty")
 	}
 	response, err := h.options.Client.CreateComment(ctx, &generated.CreateCommentRequestOptions{
-		PathParams: &generated.CreateCommentPath{ProjectID: project.ID, Ref: ref},
+		PathParams: &generated.CreateCommentPath{ProjectID: strconv.FormatInt(project.ID, 10), Ref: ref},
 		Body:       &generated.CreateCommentBody{Actor: &h.options.Actor, Body: input.Body},
 		Header:     &generated.CreateCommentHeaders{IdempotencyKey: &key},
 	})
@@ -662,7 +662,7 @@ func (h toolHandlers) setLabel(ctx context.Context, _ *sdkmcp.CallToolRequest, i
 	}
 	if input.Present {
 		response, err := h.options.Client.AddLabel(ctx, &generated.AddLabelRequestOptions{
-			PathParams: &generated.AddLabelPath{ProjectID: project.ID, Ref: ref},
+			PathParams: &generated.AddLabelPath{ProjectID: strconv.FormatInt(project.ID, 10), Ref: ref},
 			Body:       &generated.AddLabelBody{Actor: &h.options.Actor, Label: label},
 		})
 		if err != nil {

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -2287,6 +2287,7 @@ func (o *ShowIssueRequestOptions) GetHeader() (map[string]string, error) {
 type EditIssueRequestOptions struct {
 	PathParams *EditIssuePath
 	Body       *EditIssueBody
+	Header     *EditIssueHeaders
 }
 
 // Validate validates all the fields in the options.
@@ -2306,6 +2307,14 @@ func (o *EditIssueRequestOptions) Validate() error {
 		if v, ok := any(o.Body).(runtime.Validator); ok {
 			if err := v.Validate(); err != nil {
 				errors = errors.Append("Body", err)
+			}
+		}
+	}
+
+	if o.Header != nil {
+		if v, ok := any(o.Header).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Header", err)
 			}
 		}
 	}
@@ -2333,7 +2342,7 @@ func (o *EditIssueRequestOptions) GetBody() any {
 
 // GetHeader returns the headers as a map.
 func (o *EditIssueRequestOptions) GetHeader() (map[string]string, error) {
-	return nil, nil
+	return runtime.AsMap[string](o.Header)
 }
 
 // AssignIssueRequestOptions is the options needed to make a request to AssignIssue.
@@ -3498,6 +3507,7 @@ func (o *ReachableIssueGraphRequestOptions) GetHeader() (map[string]string, erro
 type AddLabelRequestOptions struct {
 	PathParams *AddLabelPath
 	Body       *AddLabelBody
+	Header     *AddLabelHeaders
 }
 
 // Validate validates all the fields in the options.
@@ -3517,6 +3527,14 @@ func (o *AddLabelRequestOptions) Validate() error {
 		if v, ok := any(o.Body).(runtime.Validator); ok {
 			if err := v.Validate(); err != nil {
 				errors = errors.Append("Body", err)
+			}
+		}
+	}
+
+	if o.Header != nil {
+		if v, ok := any(o.Header).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Header", err)
 			}
 		}
 	}
@@ -3544,7 +3562,7 @@ func (o *AddLabelRequestOptions) GetBody() any {
 
 // GetHeader returns the headers as a map.
 func (o *AddLabelRequestOptions) GetHeader() (map[string]string, error) {
-	return nil, nil
+	return runtime.AsMap[string](o.Header)
 }
 
 // RemoveLabelRequestOptions is the options needed to make a request to RemoveLabel.

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -2359,6 +2359,9 @@ func (c *Client) CreateIssueWithResponse(ctx context.Context, options *CreateIss
 				}
 			}
 		}
+		out.Headers200 = &CreateIssueResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
+		}
 		return out, nil
 	case 500:
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
@@ -2456,6 +2459,9 @@ func (c *Client) EditIssueWithResponse(ctx context.Context, options *EditIssueRe
 				}
 			}
 		}
+		out.Headers200 = &EditIssueResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
+		}
 		return out, nil
 	case 500:
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
@@ -2504,6 +2510,9 @@ func (c *Client) AssignIssueWithResponse(ctx context.Context, options *AssignIss
 					Err:           err,
 				}
 			}
+		}
+		out.Headers200 = &AssignIssueResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
 		}
 		return out, nil
 	case 500:
@@ -2603,6 +2612,9 @@ func (c *Client) CloseIssueWithResponse(ctx context.Context, options *CloseIssue
 				}
 			}
 		}
+		out.Headers200 = &CloseIssueResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
+		}
 		return out, nil
 	case 500:
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
@@ -2651,6 +2663,9 @@ func (c *Client) DeleteIssueWithResponse(ctx context.Context, options *DeleteIss
 					Err:           err,
 				}
 			}
+		}
+		out.Headers200 = &DeleteIssueResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
 		}
 		return out, nil
 	case 500:
@@ -2753,6 +2768,9 @@ func (c *Client) SetIssuePriorityWithResponse(ctx context.Context, options *SetI
 				}
 			}
 		}
+		out.Headers200 = &SetIssuePriorityResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
+		}
 		return out, nil
 	case 500:
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
@@ -2851,6 +2869,9 @@ func (c *Client) ReopenIssueWithResponse(ctx context.Context, options *ReopenIss
 				}
 			}
 		}
+		out.Headers200 = &ReopenIssueResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
+		}
 		return out, nil
 	case 500:
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
@@ -2900,6 +2921,9 @@ func (c *Client) RestoreIssueWithResponse(ctx context.Context, options *RestoreI
 				}
 			}
 		}
+		out.Headers200 = &RestoreIssueResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
+		}
 		return out, nil
 	case 500:
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
@@ -2948,6 +2972,9 @@ func (c *Client) UnassignIssueWithResponse(ctx context.Context, options *Unassig
 					Err:           err,
 				}
 			}
+		}
+		out.Headers200 = &UnassignIssueResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
 		}
 		return out, nil
 	case 500:
@@ -3388,6 +3415,9 @@ func (c *Client) CreateCommentWithResponse(ctx context.Context, options *CreateC
 				}
 			}
 		}
+		out.Headers200 = &CreateCommentResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
+		}
 		return out, nil
 	case 500:
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
@@ -3436,6 +3466,9 @@ func (c *Client) EditCommentWithResponse(ctx context.Context, options *EditComme
 					Err:           err,
 				}
 			}
+		}
+		out.Headers200 = &EditCommentResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
 		}
 		return out, nil
 	case 500:
@@ -3534,6 +3567,9 @@ func (c *Client) AddLabelWithResponse(ctx context.Context, options *AddLabelRequ
 				}
 			}
 		}
+		out.Headers200 = &AddLabelResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
+		}
 		return out, nil
 	case 500:
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
@@ -3581,6 +3617,9 @@ func (c *Client) RemoveLabelWithResponse(ctx context.Context, options *RemoveLab
 					Err:           err,
 				}
 			}
+		}
+		out.Headers200 = &RemoveLabelResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
 		}
 		return out, nil
 	case 500:
@@ -3922,6 +3961,9 @@ func (c *Client) DeleteLinkWithResponse(ctx context.Context, options *DeleteLink
 					Err:           err,
 				}
 			}
+		}
+		out.Headers200 = &DeleteLinkResp200Headers{
+			XKataProjectName: resp.Headers.Get("X-Kata-Project-Name"),
 		}
 		return out, nil
 	case 500:

--- a/pkg/client/generated/headers.go
+++ b/pkg/client/generated/headers.go
@@ -40,7 +40,20 @@ type SkipFederationQuarantineHeaders struct {
 }
 
 type CreateIssueHeaders struct {
-	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
+	// XKataProjectAlias Workspace alias identity; requires a name: selector
+	XKataProjectAlias *string `json:"X-Kata-Project-Alias,omitempty"`
+
+	// XKataProjectAliasKind Workspace alias kind; required with X-Kata-Project-Alias
+	XKataProjectAliasKind *string `json:"X-Kata-Project-Alias-Kind,omitempty"`
+	IdempotencyKey        *string `json:"Idempotency-Key,omitempty"`
+}
+
+type EditIssueHeaders struct {
+	// XKataProjectAlias Workspace alias identity; requires a name: selector
+	XKataProjectAlias *string `json:"X-Kata-Project-Alias,omitempty"`
+
+	// XKataProjectAliasKind Workspace alias kind; required with X-Kata-Project-Alias
+	XKataProjectAliasKind *string `json:"X-Kata-Project-Alias-Kind,omitempty"`
 }
 
 type CloseIssueHeaders struct {
@@ -61,7 +74,20 @@ type PurgeIssueHeaders struct {
 }
 
 type CreateCommentHeaders struct {
-	IdempotencyKey *string `json:"Idempotency-Key,omitempty"`
+	// XKataProjectAlias Workspace alias identity; requires a name: selector
+	XKataProjectAlias *string `json:"X-Kata-Project-Alias,omitempty"`
+
+	// XKataProjectAliasKind Workspace alias kind; required with X-Kata-Project-Alias
+	XKataProjectAliasKind *string `json:"X-Kata-Project-Alias-Kind,omitempty"`
+	IdempotencyKey        *string `json:"Idempotency-Key,omitempty"`
+}
+
+type AddLabelHeaders struct {
+	// XKataProjectAlias Workspace alias identity; requires a name: selector
+	XKataProjectAlias *string `json:"X-Kata-Project-Alias,omitempty"`
+
+	// XKataProjectAliasKind Workspace alias kind; required with X-Kata-Project-Alias
+	XKataProjectAliasKind *string `json:"X-Kata-Project-Alias-Kind,omitempty"`
 }
 
 type GetIssueLeaseStatusHeaders struct {

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -180,7 +180,12 @@ type ListIssuesPath struct {
 }
 
 type CreateIssuePath struct {
-	ProjectID int64 `json:"project_id"`
+	// ProjectID Numeric project ID or name:<project name>; name: alone requires an alias
+	ProjectID string `json:"project_id" validate:"required"`
+}
+
+func (c CreateIssuePath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
 }
 
 type ShowIssuePath struct {
@@ -193,7 +198,8 @@ func (s ShowIssuePath) Validate() error {
 }
 
 type EditIssuePath struct {
-	ProjectID int64  `json:"project_id"`
+	// ProjectID Numeric project ID or name:<project name>; name: alone requires an alias
+	ProjectID string `json:"project_id" validate:"required"`
 	Ref       string `json:"ref" validate:"required"`
 }
 
@@ -364,7 +370,8 @@ func (r ResumeExternalRootBridgePath) Validate() error {
 }
 
 type CreateCommentPath struct {
-	ProjectID int64  `json:"project_id"`
+	// ProjectID Numeric project ID or name:<project name>; name: alone requires an alias
+	ProjectID string `json:"project_id" validate:"required"`
 	Ref       string `json:"ref" validate:"required"`
 }
 
@@ -392,7 +399,8 @@ func (r ReachableIssueGraphPath) Validate() error {
 }
 
 type AddLabelPath struct {
-	ProjectID int64  `json:"project_id"`
+	// ProjectID Numeric project ID or name:<project name>; name: alone requires an alias
+	ProjectID string `json:"project_id" validate:"required"`
 	Ref       string `json:"ref" validate:"required"`
 }
 

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -738,11 +738,16 @@ type ListIssuesResp struct {
 	JSON200      *ListIssuesResponse
 }
 
+type CreateIssueResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
+}
+
 type CreateIssueResp struct {
 	HTTPResponse *http.Response
 	Body         []byte
 	StatusCode   int
 	JSON200      *CreateIssueResponse
+	Headers200   *CreateIssueResp200Headers
 }
 
 type ShowIssueResp struct {
@@ -752,11 +757,20 @@ type ShowIssueResp struct {
 	JSON200      *ShowIssueResponse
 }
 
+type EditIssueResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
+}
+
 type EditIssueResp struct {
 	HTTPResponse *http.Response
 	Body         []byte
 	StatusCode   int
 	JSON200      *EditIssueResponse
+	Headers200   *EditIssueResp200Headers
+}
+
+type AssignIssueResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
 }
 
 type AssignIssueResp struct {
@@ -764,6 +778,7 @@ type AssignIssueResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *AssignIssueResponse
+	Headers200   *AssignIssueResp200Headers
 }
 
 type ClaimIssueResp struct {
@@ -773,11 +788,20 @@ type ClaimIssueResp struct {
 	JSON200      *ClaimIssueResponse
 }
 
+type CloseIssueResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
+}
+
 type CloseIssueResp struct {
 	HTTPResponse *http.Response
 	Body         []byte
 	StatusCode   int
 	JSON200      *CloseIssueResponse
+	Headers200   *CloseIssueResp200Headers
+}
+
+type DeleteIssueResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
 }
 
 type DeleteIssueResp struct {
@@ -785,6 +809,7 @@ type DeleteIssueResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *DeleteIssueResponse
+	Headers200   *DeleteIssueResp200Headers
 }
 
 type MoveIssueResp200Headers struct {
@@ -799,11 +824,16 @@ type MoveIssueResp struct {
 	Headers200   *MoveIssueResp200Headers
 }
 
+type SetIssuePriorityResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
+}
+
 type SetIssuePriorityResp struct {
 	HTTPResponse *http.Response
 	Body         []byte
 	StatusCode   int
 	JSON200      *SetIssuePriorityResponse
+	Headers200   *SetIssuePriorityResp200Headers
 }
 
 type PurgeIssueResp struct {
@@ -813,11 +843,20 @@ type PurgeIssueResp struct {
 	JSON200      *PurgeIssueResponse
 }
 
+type ReopenIssueResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
+}
+
 type ReopenIssueResp struct {
 	HTTPResponse *http.Response
 	Body         []byte
 	StatusCode   int
 	JSON200      *ReopenIssueResponse
+	Headers200   *ReopenIssueResp200Headers
+}
+
+type RestoreIssueResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
 }
 
 type RestoreIssueResp struct {
@@ -825,6 +864,11 @@ type RestoreIssueResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *RestoreIssueResponse
+	Headers200   *RestoreIssueResp200Headers
+}
+
+type UnassignIssueResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
 }
 
 type UnassignIssueResp struct {
@@ -832,6 +876,7 @@ type UnassignIssueResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *UnassignIssueResponse
+	Headers200   *UnassignIssueResp200Headers
 }
 
 type UnbindExternalRootResp struct {
@@ -890,11 +935,20 @@ type ResumeExternalRootBridgeResp struct {
 	JSON200      *ResumeExternalRootBridgeResponse
 }
 
+type CreateCommentResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
+}
+
 type CreateCommentResp struct {
 	HTTPResponse *http.Response
 	Body         []byte
 	StatusCode   int
 	JSON200      *CreateCommentResponse
+	Headers200   *CreateCommentResp200Headers
+}
+
+type EditCommentResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
 }
 
 type EditCommentResp struct {
@@ -902,6 +956,7 @@ type EditCommentResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *EditCommentResponse
+	Headers200   *EditCommentResp200Headers
 }
 
 type ReachableIssueGraphResp struct {
@@ -911,11 +966,20 @@ type ReachableIssueGraphResp struct {
 	JSON200      *ReachableIssueGraphResponse
 }
 
+type AddLabelResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
+}
+
 type AddLabelResp struct {
 	HTTPResponse *http.Response
 	Body         []byte
 	StatusCode   int
 	JSON200      *AddLabelResponse
+	Headers200   *AddLabelResp200Headers
+}
+
+type RemoveLabelResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
 }
 
 type RemoveLabelResp struct {
@@ -923,6 +987,7 @@ type RemoveLabelResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *RemoveLabelResponse
+	Headers200   *RemoveLabelResp200Headers
 }
 
 type GetIssueLeaseStatusResp struct {
@@ -967,11 +1032,16 @@ type CreateLinkResp struct {
 	JSON200      *CreateLinkResponse
 }
 
+type DeleteLinkResp200Headers struct {
+	XKataProjectName string `header:"X-Kata-Project-Name"`
+}
+
 type DeleteLinkResp struct {
 	HTTPResponse *http.Response
 	Body         []byte
 	StatusCode   int
 	JSON200      *DeleteLinkResponse
+	Headers200   *DeleteLinkResp200Headers
 }
 
 type PatchIssueMetadataResp200Headers struct {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -4301,7 +4301,7 @@ components:
       type: object
 info:
   title: kata
-  version: 0.16.0
+  version: 0.17.0
 openapi: 3.0.3
 paths:
   /api/v1/audit/closes:
@@ -5787,12 +5787,25 @@ paths:
     post:
       operationId: createIssue
       parameters:
-        - in: path
+        - description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+          in: path
           name: project_id
           required: true
           schema:
-            format: int64
-            type: integer
+            description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+            type: string
+        - description: "Workspace alias identity; requires a name: selector"
+          in: header
+          name: X-Kata-Project-Alias
+          schema:
+            description: "Workspace alias identity; requires a name: selector"
+            type: string
+        - description: Workspace alias kind; required with X-Kata-Project-Alias
+          in: header
+          name: X-Kata-Project-Alias-Kind
+          schema:
+            description: Workspace alias kind; required with X-Kata-Project-Alias
+            type: string
         - in: header
           name: Idempotency-Key
           schema:
@@ -5810,6 +5823,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -5852,12 +5870,25 @@ paths:
     patch:
       operationId: editIssue
       parameters:
-        - in: path
+        - description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+          in: path
           name: project_id
           required: true
           schema:
-            format: int64
-            type: integer
+            description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+            type: string
+        - description: "Workspace alias identity; requires a name: selector"
+          in: header
+          name: X-Kata-Project-Alias
+          schema:
+            description: "Workspace alias identity; requires a name: selector"
+            type: string
+        - description: Workspace alias kind; required with X-Kata-Project-Alias
+          in: header
+          name: X-Kata-Project-Alias-Kind
+          schema:
+            description: Workspace alias kind; required with X-Kata-Project-Alias
+            type: string
         - in: path
           name: ref
           required: true
@@ -5876,6 +5907,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/EditIssueResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -5910,6 +5946,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -5986,6 +6027,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6024,6 +6070,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6100,6 +6151,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6172,6 +6228,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6206,6 +6267,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6240,6 +6306,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6518,12 +6589,25 @@ paths:
     post:
       operationId: createComment
       parameters:
-        - in: path
+        - description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+          in: path
           name: project_id
           required: true
           schema:
-            format: int64
-            type: integer
+            description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+            type: string
+        - description: "Workspace alias identity; requires a name: selector"
+          in: header
+          name: X-Kata-Project-Alias
+          schema:
+            description: "Workspace alias identity; requires a name: selector"
+            type: string
+        - description: Workspace alias kind; required with X-Kata-Project-Alias
+          in: header
+          name: X-Kata-Project-Alias-Kind
+          schema:
+            description: Workspace alias kind; required with X-Kata-Project-Alias
+            type: string
         - in: path
           name: ref
           required: true
@@ -6546,6 +6630,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/CommentResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6585,6 +6674,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/CommentResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6635,12 +6729,25 @@ paths:
     post:
       operationId: addLabel
       parameters:
-        - in: path
+        - description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+          in: path
           name: project_id
           required: true
           schema:
-            format: int64
-            type: integer
+            description: "Numeric project ID or name:<project name>; name: alone requires an alias"
+            type: string
+        - description: "Workspace alias identity; requires a name: selector"
+          in: header
+          name: X-Kata-Project-Alias
+          schema:
+            description: "Workspace alias identity; requires a name: selector"
+            type: string
+        - description: Workspace alias kind; required with X-Kata-Project-Alias
+          in: header
+          name: X-Kata-Project-Alias-Kind
+          schema:
+            description: Workspace alias kind; required with X-Kata-Project-Alias
+            type: string
         - in: path
           name: ref
           required: true
@@ -6659,6 +6766,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/AddLabelResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6697,6 +6809,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:
@@ -6955,6 +7072,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/MutationResponseBody"
           description: OK
+          headers:
+            X-Kata-Project-Name:
+              schema:
+                description: Canonical project name
+                type: string
         default:
           content:
             application/json:

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -321,7 +321,7 @@
         : { title, key: globalThis.crypto.randomUUID() }
     pendingCreate = create
     const accepted = await runMutation({ draft: title, createKey: create.key }, (context) =>
-      createIssueRequest({ projectId: inbox.id }, context.body({ title }, requestActor), {
+      createIssueRequest({ projectId: String(inbox.id) }, context.body({ title }, requestActor), {
         headers: { 'Idempotency-Key': create.key },
       }),
     )
@@ -380,7 +380,7 @@
     if (patch.body !== undefined) body.body = patch.body
     return runMutation({ draft: patch }, (context) =>
       editIssueRequest(
-        { projectId: target.project_id, ref: target.ref },
+        { projectId: String(target.project_id), ref: target.ref },
         context.body(body, requestActor),
       ),
     )
@@ -409,7 +409,7 @@
     pendingComment = comment
     const accepted = await runMutation({ draft: body }, (context) =>
       createComment(
-        { projectId: target.project_id, ref: target.ref },
+        { projectId: String(target.project_id), ref: target.ref },
         context.body({ body }, requestActor),
         { headers: { 'Idempotency-Key': comment.key } },
       ),
@@ -570,7 +570,7 @@
     if (!target) return false
     return runMutation({ draft: label }, (context) =>
       addLabelRequest(
-        { projectId: target.project_id, ref: target.ref },
+        { projectId: String(target.project_id), ref: target.ref },
         context.body({ label }, requestActor),
       ),
     )

--- a/web/src/lib/api/generated/models/addLabelPathParameters.ts
+++ b/web/src/lib/api/generated/models/addLabelPathParameters.ts
@@ -3,6 +3,6 @@
  */
 
 export type AddLabelPathParameters = {
-  projectId: number
+  projectId: string
   ref: string
 }

--- a/web/src/lib/api/generated/models/createCommentPathParameters.ts
+++ b/web/src/lib/api/generated/models/createCommentPathParameters.ts
@@ -3,6 +3,6 @@
  */
 
 export type CreateCommentPathParameters = {
-  projectId: number
+  projectId: string
   ref: string
 }

--- a/web/src/lib/api/generated/models/createIssuePathParameters.ts
+++ b/web/src/lib/api/generated/models/createIssuePathParameters.ts
@@ -3,5 +3,5 @@
  */
 
 export type CreateIssuePathParameters = {
-  projectId: number
+  projectId: string
 }

--- a/web/src/lib/api/generated/models/editIssuePathParameters.ts
+++ b/web/src/lib/api/generated/models/editIssuePathParameters.ts
@@ -3,6 +3,6 @@
  */
 
 export type EditIssuePathParameters = {
-  projectId: number
+  projectId: string
   ref: string
 }


### PR DESCRIPTION
Simple remote `create`, `edit`, `comment`, and `label add` commands now use one HTTP request instead of a ping, a project lookup, and a write. Explicit health and discovery commands still probe the daemon, and local startup checks remain in place.

The four mutation routes accept numeric project IDs or `name:<project>` selectors. The daemon uses existing name/alias resolution and returns the canonical project name. Host authorization precedes named resolution and alias attachment; numeric requests keep their project scope. The CLI repairs renamed workspace bindings after a successful response and clearly reports when the write succeeded but local repair failed.

API `0.17.0` publishes the selector and response-header contract, with regenerated Go and browser clients. Upgrade the remote daemon with the CLI; older daemons reject named selectors. No database schema changes are required.

Relationship-bearing create/edit commands and path-only workspaces retain their separate project lookup. Follow-up `--comment` requests remain separate and use the project ID returned by the mutation.
