### PR TITLE
Finalize 0.17.0 release documentation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,20 +1,94 @@
 ---
 title: Changelog
 description: Release history for kata
-last_edited: 2026-08-27
+last_edited: 2026-09-07
 ---
 
 All notable changes to kata, grouped by release. Versioned releases start with
 0.5.0; earlier entries are a retroactive project history grouped by ISO week.
 
-## Unreleased
+## 0.17.0
+
+kata 0.17.0 helps agents coordinate ownership and retry closes after a lost
+response. CLI commands start faster, simple remote writes need fewer requests,
+and embedding hosts can serve the browser application below a URL path.
+
+**Before upgrading**
+
+- Upgrade remote daemons alongside the CLI. Older daemons reject the project
+  selectors used by the faster remote writes.
+- Update custom API clients for empty collections (`[]` and `{}`),
+  case-sensitive request field names, and rejection of `null` arrays. See the
+  [HTTP API contract](reference/http-api.md#version-history).
+- The SQLite history fix prevents loss during future upgrades. It does not
+  restore history lost during an earlier upgrade. Keep a
+  [backup](operations/backup-restore.md) before upgrading.
+
+**New features**
+
+- Check issue ownership with [`kata status <ref>`](reference/cli.md#issue-lifecycle).
+  It reports the issue's status and revision, your effective identity, the
+  owner, and whether a federation write lease is active, expired, or pending.
+  A lease reserves an issue for a holder while it is live.
+- Extend a timed federation lease without releasing it first with
+  [`kata federation lease renew <issue-ref> --ttl <duration>`](operations/federation.md#leases-and-write-gates).
+  Renewal accepts durations from 60 seconds to 24 hours.
+- Claim an issue only if nobody owns it with `kata claim --if-unowned`. Use
+  `kata unassign --expect-owner <owner>` to remove an assignment only if the
+  owner still matches. See [Claim work](workflows/agents.md#claim-work).
+- Retry an issue close after a lost response with `kata close --idempotency-key`.
+  Reusing the key for the same request returns the original result and avoids
+  duplicate follow-up comments. Add `--if-match` to reject the close if the
+  issue has changed. See [Close only when verified](workflows/agents.md#close-only-when-verified).
+- Mount the browser application below a URL path when
+  [embedding Kata](development/embedding.md#mount-below-a-url-path).
+  Navigation, API requests, sessions, live updates, and assets stay under the
+  selected path.
+- Grant database-backed identity tokens permission to administer connectors
+  and links to external issues with `allow_identity_connector_administration = true`
+  alongside `require_token_identity = true`. This setting defaults to off and
+  grants every active identity token that permission across the daemon. See
+  [Token identity mode](reference/configuration.md#token-identity-mode).
 
 **Improvements**
 
-- Made ordinary API arrays non-null. Empty and nil response slices serialize
-  as `[]`, requests reject `null` for ordinary array fields, and generated Go
-  and TypeScript clients match that contract. JSON object member names are now
-  case-sensitive.
+- Start CLI commands with less delay. In a 200-run cold-start comparison,
+  median time for a validation command fell from 19.8 ms to 8.9 ms.
+- Send simple remote `create`, `edit`, `comment`, and `label add` commands with
+  one HTTP request instead of three. Commands involving relationships still
+  require a separate project lookup. See [Remote daemon](operations/remote-daemon.md).
+- Read more context in `kata search --agent` results, including owner,
+  priority, revision, and a body excerpt. Agent output for `list` and `show`
+  also includes the revision needed for `--if-match` writes. See
+  [Agent output](reference/agent-output.md#reads).
+- Receive empty JSON arrays and objects instead of `null` collections in API
+  responses. Requests now require case-sensitive field names and reject
+  `null` for arrays.
+- Follow the new step-by-step [guide](https://katatracker.com/guide/) or browse
+  [reference documentation](https://katatracker.com/docs/). Existing
+  documentation URLs redirect to their new locations.
+
+**Bug fixes**
+
+- Keep audit history from before an issue move during SQLite upgrades and
+  project-filtered legacy exports. Unexplained missing events stop the upgrade
+  and leave the original database unchanged.
+- Preserve original issue, comment, and relationship authors when adding an
+  existing project to federation across multiple batches, including resumed
+  transfers.
+- Preserve relationship creation dates in new federation snapshots and
+  subsequent rebuilds on SQLite and PostgreSQL. Older snapshots without dates
+  retain their existing behavior.
+- Avoid delaying unrelated PostgreSQL writes by skipping unchanged comments
+  during federation rebuilds.
+- Recognize uncertain issue creation results after timeouts, cancellations,
+  dropped connections, or truncated responses as `create_outcome_unknown`.
+  Check whether the issue exists before retrying, and use `--force-new` only
+  after confirming that no issue was created.
+- Limit similar-issue checks to the first 500 Unicode code points of the title
+  and body, avoiding oversized queries for long issues.
+- Keep comment retries working after an issue moves between projects. Comment
+  idempotency keys now belong to individual issues.
 
 ## 0.16.0
 <small>2026-08-27</small>

--- a/docs/development/embedding.md
+++ b/docs/development/embedding.md
@@ -140,14 +140,23 @@ use `server.ListenAndServeTLS(certFile, keyFile)` with a valid certificate or
 mount the handler behind a TLS-terminating reverse proxy. Never send the bearer
 token over plaintext non-loopback HTTP.
 
-To serve the complete API and browser application below a path, use
-`service.HandlerAt("/tools/tasks")` instead of wrapping `service.Handler()` with
-`http.StripPrefix` yourself. The returned handler redirects the exact path to
-its trailing-slash form and keeps browser assets, deep links, API requests,
-sessions, and event streams below the mount. It returns `404` outside that
-path. The host still owns authentication exactly as described below;
-`HandlerAt` changes routing only. Mounts at `/api` or below it are rejected
-because that namespace belongs to the browser application's API routes.
+## Mount below a URL path
+
+Keep the browser application and API under one path with
+`service.HandlerAt("/tools/tasks")`. Handle its returned error, then mount the
+handler behind the host's authentication middleware. Open `/tools/tasks/` to
+use the application.
+
+The handler redirects `/tools/tasks` to `/tools/tasks/` and keeps navigation,
+assets, API requests, sessions, and live updates below that path. It returns
+`404` outside the mount. Use `HandlerAt` instead of applying `http.StripPrefix`
+to `service.Handler()` yourself.
+
+The mount must be an absolute path without a trailing slash or `.`/`..`
+segments. `/api` and paths below it are reserved for the browser application's
+API routes. `HandlerAt` changes routing only; the host still owns
+[authentication](#authentication-is-explicit).
+
 Standalone `/kata/` redirects to `/kata`, preserving view and filter queries
 so relative assets load from the origin root.
 

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -85,6 +85,20 @@ owning package manager. Packagers can read the complete
 remains supported, and building from a clone is still useful for development
 builds.
 
+## Upgrading to 0.17.0
+
+Upgrade the remote daemon alongside the CLI. Simple remote writes now select
+the project in the write request, and older daemons reject those selectors.
+See [remote command behavior](../operations/remote-daemon.md).
+
+Custom API clients must use case-sensitive request field names, send `[]`
+instead of `null` for arrays, and accept empty response collections as `[]` or
+`{}`. See the [HTTP API contract](../reference/http-api.md#version-history).
+
+Keep a [backup](../operations/backup-restore.md) before upgrading. The SQLite
+fix preserves moved-issue history during future upgrades; it cannot restore
+history lost during an earlier upgrade.
+
 ## Install with `go install`
 
 ```sh

--- a/docs/guide/web-ui.md
+++ b/docs/guide/web-ui.md
@@ -35,6 +35,12 @@ Release binaries contain the browser assets. A binary installed with
 `go install` does not, because that path does not run the browser build; use a
 [release or `make install`](../get-started/install.md) when you need `kata ui`.
 
+Embedding applications can serve the browser UI below a path such as
+`/tools/tasks/`. Navigation, assets, sessions, API requests, and live updates
+stay below that path. Hosts configure this through
+[`Service.HandlerAt`](../development/embedding.md#mount-below-a-url-path);
+the standalone `kata ui` command keeps its existing route.
+
 ## Navigate projects and collections
 
 The sidebar combines system collections with individual projects:

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,13 @@ powershell -ExecutionPolicy ByPass -c "irm https://katatracker.com/install.ps1 |
 ```
 </section>
 
+## New in 0.17.0
+
+Check ownership with `kata status`, claim only unowned work, and retry closes
+with an idempotency key. The [0.17.0 release notes](changelog.md#0170) cover
+these workflows, faster CLI commands, browser embedding below a path, and
+upgrade guidance for remote daemons and custom API clients.
+
 ## Quickstart
 
 ```sh

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -22,6 +22,8 @@ projects. Before replacing the database, it checks the imported event count
 against the source, allowing only orphan-event drops identified by preflight.
 An unexplained difference stops startup with `cutover event count mismatch`
 and leaves the source database unchanged. Preserve that database for diagnosis.
+The 0.17.0 fix protects future upgrades; it does not restore events lost during
+an earlier upgrade. Recovering those events requires a backup that contains them.
 
 ## Full backup
 
@@ -121,6 +123,11 @@ kata import --input backups/example-project.jsonl \
 
 This is useful for archiving one project, handing history to a collaborator who
 will set up a fresh kata install, or moving one project to another host.
+
+When exporting a legacy SQLite database, project filtering keeps audit events
+in their original project even if the issue later moved elsewhere. References
+to rows outside the export are removed, while issue UIDs retain the historical
+identity. Use a full backup when you need history from every project.
 
 Links may span projects, and a scoped export only contains the named project's
 issues. A fresh restore or project merge skips links whose peer is outside the

--- a/docs/operations/federation.md
+++ b/docs/operations/federation.md
@@ -512,7 +512,11 @@ projects that share links must use the same hub URL origin; different DNS names
 or IP aliases are intentionally separate federation groups. Adoption snapshot
 event actors are the bound federation actor. Snapshot payload authors and
 comment authors are preserved, so adopted issues keep their original displayed
-content authors.
+content authors. New snapshots also preserve relationship creation dates through
+rebuilds on SQLite and PostgreSQL. Older snapshots without those dates keep
+their existing insertion-time behavior; Kata does not invent missing dates.
+PostgreSQL rebuilds skip unchanged comments so they do not delay unrelated
+writes by rewriting the same rows.
 
 > **Preserving the pre-adoption timeline:** Adoption is a cutover, not an
 > in-place history merge. If you need the old local event timeline for audit or
@@ -722,6 +726,18 @@ issue, non-comment mutations are denied until the lease is released or expires.
 Comment creation and comment body edits bypass leases because they remain
 comment-level collaboration and maintenance actions rather than leased issue
 work.
+
+Check the owner and current lease with `kata status <issue-ref> --agent`.
+To keep a timed lease you already hold, renew it before it expires:
+
+```sh
+kata federation lease renew abc4 --ttl 30m
+```
+
+Renewal keeps the same lease and sets its expiry to 30 minutes from the hub's
+current time. It does not add 30 minutes to the old expiry. The duration must
+be a whole number followed by `s`, `m`, or `h`, from `60s` through `24h`
+inclusive. A lease without an expiry does not need timed renewal.
 
 Spokes refresh cached lease state before checking exclusivity when online.
 When offline, cached hard leases can still be used as a continuity hint, but

--- a/docs/reference/agent-output.md
+++ b/docs/reference/agent-output.md
@@ -194,10 +194,10 @@ Search rows append owner, priority, revision, and a body excerpt when present.
 The excerpt is at most 160 characters and centers the first query match when
 possible, folding case and diacritics like lexical search. `kata show <ref>
 --agent` remains the complete record and emits `Revision:` after `Priority:`.
-List rows append revision after title. Existing row fields keep their names, positions, and
-meanings, so these additions are purely additive and `agent_format` stays `1`.
-A daemon without `[search.embeddings]` always reports `mode=lexical` and never
-sets `degraded=`, so its output is unchanged apart from the appended `mode=`.
+List rows append revision after title. Existing fields keep their names,
+positions, and meanings, so `agent_format` stays `1`.
+A daemon without `[search.embeddings]` reports `mode=lexical` and omits
+`degraded=`. It includes the same added issue context.
 
 #### Single-result `next`
 
@@ -241,7 +241,7 @@ included when present. Their existing ordering and omission rules apply.
 lease state separate on one line:
 
 ```text
-OK status issue=abc4 project=kata issue_status=open revision=4 actor=agent-a actor_source=daemon auth=db_token instance=01HZNQ7VFPK1XGD8R5MABCD4AB owner=agent-a hold=active holder=agent-a holder_instance=01HZNQ7VFPK1XGD8R5MABCD4AB lease_kind=timed expires_at=2026-09-02T12:30:00Z
+OK status issue=abc4 project=example-project issue_status=open revision=4 actor=agent-a actor_source=daemon auth=db_token instance=01HZNQ7VFPK1XGD8R5MABCD4AB owner=agent-a hold=active holder=agent-a holder_instance=01HZNQ7VFPK1XGD8R5MABCD4AB lease_kind=timed expires_at=2026-09-02T12:30:00Z
 ```
 
 The fixed field order is `issue`, `project`, `issue_status`, `revision`,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-09-02
+last_edited: 2026-09-07
 ---
 
 # CLI reference
@@ -143,7 +143,7 @@ including closed ones, using the first 500 Unicode code points of the title
 and body. `--force-new` bypasses that check; idempotency still wins
 when an idempotency key matches. If create times out, the request is canceled
 or the connection drops before the response arrives, or the response is cut
-off before it completes, its outcome is unknown: check whether
+off before it completes, the CLI reports `create_outcome_unknown`: check whether
 the issue exists before retrying, and use `--force-new` only after confirming
 that no issue was created.
 
@@ -166,9 +166,9 @@ kata search <query> [--label LABEL] [--no-label LABEL]
 
 `kata show --render` renders Markdown only in issue descriptions and comment
 bodies. Headers, status, claims, labels, links, and metadata remain literal so
-the surrounding issue record stays predictable. The built-in renderer is
-Glamour. Set `KATA_COLOR_MODE=light` or `KATA_COLOR_MODE=dark` to give code
-blocks a background suited to the terminal theme. In the default `auto` mode,
+the surrounding issue record stays predictable. Set `KATA_COLOR_MODE=light`
+or `KATA_COLOR_MODE=dark` to give code blocks a background suited to the
+terminal theme. In the default `auto` mode,
 the one-shot CLI cannot safely determine background brightness, so it leaves
 the code-block background unset instead of guessing. `NO_COLOR` still removes
 rendered color through kata's normal output profile.
@@ -178,7 +178,7 @@ pipelines, including `kata show <issue-ref> --render | less -R`, intentionally
 remain plain text. This version has no force-render option for non-terminal
 output.
 
-`kata status` gives agents a compact view of the daemon identity, effective
+`kata status` reports the issue status and revision, daemon identity, effective
 actor, issue owner, and federation lease. Its `hold` value is `active`,
 `expired`, `pending`, `assigned`, `unassigned`, or `closed`. `assigned` means
 the open issue has an owner without a live or pending lease, which is the
@@ -309,7 +309,9 @@ kata close <ref> --done --message <text> \
 `--idempotency-key` makes a close safe to retry after a lost response. For
 seven days, an exact retry returns the original `issue.closed` event through
 `original_event` and does not close the issue again. Reusing the key with a
-different issue, actor, close payload, or revision returns a conflict.
+different issue, actor, close payload, or revision returns a conflict. The CLI
+also uses the key for its follow-up `--comment`, so an exact retry does not
+post the comment twice. Keep the comment text unchanged when retrying.
 
 `--if-match` accepts `7` or `rev-7`. The daemon checks that revision inside the
 close transaction and returns a revision conflict when it has changed. An
@@ -921,7 +923,8 @@ Issue edits on push-enabled federated spokes remain local-first; use
 issue. A live lease held by another actor blocks non-comment mutations until it
 is released or expires. Renew a timed lease before it expires with
 `kata federation lease renew <issue-ref> --ttl <duration>`. Renewal preserves
-the lease identity and sets a new expiry from the hub's current time.
+the lease identity and sets a new expiry from the hub's current time. Use a
+whole number followed by `s`, `m`, or `h`, from `60s` through `24h` inclusive.
 
 `kata federation quarantine list` reports every active quarantine with its
 project, direction, event range, creation time, and retained error. Use

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-29
+last_edited: 2026-09-07
 ---
 
 # Configuration
@@ -146,7 +146,7 @@ allow_insecure = true
 `[display]` belongs to the client reading `<KATA_HOME>/config.toml`. It is not
 sent to a remote daemon and does not change daemon rendering or API responses.
 
-`kata show --render` uses built-in Glamour rendering when no override is set.
+`kata show --render` uses the built-in terminal Markdown renderer by default.
 To use an external stdin/stdout renderer instead:
 
 ```toml

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -108,6 +108,12 @@ response of an older daemon that predates it. Treat an **absent or empty**
 Embedding hosts using `@kenn-io/kata-ui` must treat that state as incompatible
 and decline to render issue detail.
 
+Kata release 0.17.0 includes API contract changes `0.15.0` through `0.17.0`
+below. API contract versions advance independently of release versions. When
+upgrading a custom client, send array fields as `[]` (or omit optional fields),
+use the exact request field names, and accept empty response collections as
+`[]` or `{}`.
+
 ### Version history
 
 | Version | Change |
@@ -343,6 +349,13 @@ Comments can be appended with `POST
 `PATCH /api/v1/projects/{project_id}/issues/{ref}/comments/{comment_ref}`.
 Use the comment UID as `comment_ref`; numeric comment IDs are local storage
 artifacts.
+
+Send `Idempotency-Key` when creating a comment you may need to retry. For seven
+days, repeating the same issue, actor, body, and key returns the original
+comment. Keys belong to individual issues, so a retry can survive an issue
+move between projects. Reusing the key on that issue with a different actor or
+body returns a conflict. Use the full issue UID to identify the issue across
+moves.
 
 Editing a comment overwrites the current comment body while preserving the
 original author, UID, creation time, and thread position. This is the supported

--- a/docs/workflows/agents.md
+++ b/docs/workflows/agents.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-27
+last_edited: 2026-09-07
 ---
 
 # Agent workflows
@@ -131,6 +131,15 @@ kata create "fix login race" \
   --agent
 ```
 
+Search results include owner, priority, revision, and a short body excerpt when
+present. Use `kata show <ref> --agent` for the complete record. `list` and
+`show` also report the revision needed for guarded writes.
+
+If creation reports `create_outcome_unknown`, check whether the issue exists
+before retrying. A timeout or lost response does not tell you whether the daemon
+created it. Keep the original idempotency key; use `--force-new` only after
+confirming no issue was created.
+
 Prefer updating existing issues over opening duplicates:
 
 ```sh
@@ -146,12 +155,26 @@ In multi-agent environments, choose one unowned ready issue and claim it:
 
 ```sh
 kata next --unowned --agent
-kata claim abc4 --agent
+kata claim abc4 --if-unowned --agent
 ```
 
 `next` applies the shared priority rules and returns at most one candidate. The
-claim fails if another actor already claimed the issue; treat that as a
-coordination signal and run `next` again.
+`--if-unowned` claim fails if anyone owns the issue, including the same actor.
+This lets workers sharing an identity compete for unowned work. On a conflict,
+run `next` again. Without the flag, claiming an issue you already own succeeds
+as a no-op.
+
+Check the effective identity, issue status, revision, owner, and lease before
+continuing or handing off work:
+
+```sh
+kata status abc4 --agent
+```
+
+Ownership records who is responsible. A federation write lease reserves the
+issue for a holder while the lease is live. They are separate: a local claim
+normally reports `hold=assigned`, without a federation lease. For timed leases,
+see [renewal](../operations/federation.md#leases-and-write-gates).
 
 Use `ready` when you want to inspect a filtered queue instead of choosing one
 issue:
@@ -170,8 +193,13 @@ kata list --all --status open --label handoff --no-label parked --agent
 Release ownership only when you are intentionally giving the work back:
 
 ```sh
-kata unassign abc4 --comment "Releasing; blocked on missing test fixture." --agent
+kata unassign abc4 --expect-owner agent-a \
+  --comment "Releasing; blocked on missing test fixture." --agent
 ```
+
+Use the owner reported by `status` as `--expect-owner`. If ownership changes
+before the command arrives, the unassign fails instead of clearing the new
+owner's assignment.
 
 ## Keep durable notes
 
@@ -213,6 +241,25 @@ kata close abc4 --done \
   --test "make docs-check" \
   --agent
 ```
+
+For a close you may need to retry, add a unique key. To reject changes made
+since your last read, also pass the revision from `kata status` or `kata show`:
+
+```sh
+kata close abc4 --done \
+  --message "Updated the CLI reference and verified docs-check passes." \
+  --commit "$SHA" \
+  --idempotency-key close-abc4-docs \
+  --if-match <revision> \
+  --agent
+```
+
+After a lost response, retry the exact command with the same key and revision.
+For seven days, an exact retry returns the original close result. It also
+avoids duplicate follow-up comments when you use `--comment`. Keep the request
+and comment text unchanged. If the issue changed before the first close,
+`--if-match` returns a conflict; inspect it again before deciding to close.
+See the [CLI close reference](../reference/cli.md#issue-lifecycle).
 
 Close each issue as soon as its work is verified, not in a batch at the end of a
 run. By default the daemon allows sibling close bursts when each close carries


### PR DESCRIPTION
Finalizes the 0.17.0 documentation using the release changelog, with plain-language release notes and links to the affected guides.

Updates agent workflows for ownership checks, guarded claims and unassigns, lease renewal, and close retries. Clarifies browser mounting, comment retries after issue moves, and the limits of the history-preservation fixes.

Puts remote-daemon and custom API client upgrade requirements in the release notes and installation guide. Refreshes the documentation overview and removes stale renderer and agent-output descriptions.
