### PR TITLE
Handle reused PIDs during daemon discovery and upgrades

### DIFF
--- a/cmd/kata/daemon_cmd_test.go
+++ b/cmd/kata/daemon_cmd_test.go
@@ -283,14 +283,17 @@ func TestDaemonStatus_HumanReportsLifecycleDetails(t *testing.T) {
 	ns, err := daemon.NewNamespace()
 	require.NoError(t, err)
 	require.NoError(t, ns.EnsureDirs())
+	identity, ok := kitdaemon.ReadProcessIdentity(os.Getpid())
+	require.True(t, ok)
 	started := time.Now().Add(-52*time.Minute - 33*time.Second)
 	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
-		PID:       os.Getpid(),
-		Network:   "tcp",
-		Address:   "127.0.0.1:7777",
-		Version:   "v-test-status",
-		StartedAt: started,
-		Metadata:  map[string]string{"web_origin": "http://127.0.0.1:28888"},
+		ProcessIdentityV2: identity,
+		PID:               os.Getpid(),
+		Network:           "tcp",
+		Address:           "127.0.0.1:7777",
+		Version:           "v-test-status",
+		StartedAt:         started,
+		Metadata:          map[string]string{"web_origin": "http://127.0.0.1:28888"},
 	})
 	require.NoError(t, err)
 
@@ -310,11 +313,14 @@ func TestDaemonStatus_JSONReportsDaemonsWithVersion(t *testing.T) {
 	ns, err := daemon.NewNamespace()
 	require.NoError(t, err)
 	require.NoError(t, ns.EnsureDirs())
+	identity, ok := kitdaemon.ReadProcessIdentity(os.Getpid())
+	require.True(t, ok)
 	started := time.Date(2026, 5, 4, 1, 2, 3, 0, time.UTC)
 	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
-		PID:     os.Getpid(),
-		Network: "unix",
-		Address: "/tmp/kata-test.sock",
+		ProcessIdentityV2: identity,
+		PID:               os.Getpid(),
+		Network:           "unix",
+		Address:           "/tmp/kata-test.sock",
 		Metadata: map[string]string{
 			"db_path":    filepath.Join(tmp, "kata.db"),
 			"web_origin": "http://127.0.0.1:28888",
@@ -355,14 +361,17 @@ func TestDaemonStatus_JSONReportsDBPathFromKitRuntimeMetadata(t *testing.T) {
 	ns, err := daemon.NewNamespace()
 	require.NoError(t, err)
 	require.NoError(t, ns.EnsureDirs())
+	identity, ok := kitdaemon.ReadProcessIdentity(os.Getpid())
+	require.True(t, ok)
 	started := time.Date(2026, 5, 4, 1, 2, 3, 0, time.UTC)
 	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
-		PID:       os.Getpid(),
-		Network:   "unix",
-		Address:   "/tmp/kata-test.sock",
-		Service:   "kata",
-		Version:   "v-test-status",
-		StartedAt: started,
+		ProcessIdentityV2: identity,
+		PID:               os.Getpid(),
+		Network:           "unix",
+		Address:           "/tmp/kata-test.sock",
+		Service:           "kata",
+		Version:           "v-test-status",
+		StartedAt:         started,
 		Metadata: map[string]string{
 			"db_path": filepath.Join(tmp, "kata.db"),
 		},

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.47
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/oklog/ulid/v2 v2.1.1
+	github.com/shirou/gopsutil/v4 v4.26.6
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/teambition/rrule-go v1.8.2
@@ -134,7 +135,6 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
-	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -13,7 +13,6 @@ import (
 	"iter"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -131,17 +130,9 @@ func liveDaemons(ctx context.Context, dataDir string) iter.Seq2[liveDaemon, erro
 			}
 			// A reused PID can keep an old record alive after another daemon
 			// takes over its endpoint. The responding daemon is not this record's
-			// process. Remove the stale record so it cannot appear unreachable
-			// after the responding daemon shuts down during a version restart.
+			// process; keep scanning for its matching record. Do not delete the
+			// PID-named file: startup may have replaced it during the probe.
 			if info.PID != 0 && info.PID != r.PID {
-				recordPath, err := (kitdaemon.RuntimeStore{Dir: dataDir}).Path(r.PID)
-				if err == nil {
-					err = os.Remove(recordPath)
-				}
-				if err != nil && !errors.Is(err, os.ErrNotExist) {
-					yield(liveDaemon{}, fmt.Errorf("remove stale daemon record for pid %d: %w", r.PID, err))
-					return
-				}
 				continue
 			}
 			candidate := liveDaemon{Record: r, BaseURL: url, Info: info}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -13,6 +13,7 @@ import (
 	"iter"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -124,6 +125,21 @@ func liveDaemons(ctx context.Context, dataDir string) iter.Seq2[liveDaemon, erro
 					address: address,
 					cause:   probeErr,
 				}) {
+					return
+				}
+				continue
+			}
+			// A reused PID can keep an old record alive after another daemon
+			// takes over its endpoint. The responding daemon is not this record's
+			// process. Remove the stale record so it cannot appear unreachable
+			// after the responding daemon shuts down during a version restart.
+			if info.PID != 0 && info.PID != r.PID {
+				recordPath, err := (kitdaemon.RuntimeStore{Dir: dataDir}).Path(r.PID)
+				if err == nil {
+					err = os.Remove(recordPath)
+				}
+				if err != nil && !errors.Is(err, os.ErrNotExist) {
+					yield(liveDaemon{}, fmt.Errorf("remove stale daemon record for pid %d: %w", r.PID, err))
 					return
 				}
 				continue

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -278,7 +278,7 @@ func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
 		targets = append(targets, candidate.Record)
 	}
 	if len(targets) == 0 {
-		return nil
+		return unreachable
 	}
 	// Finish discovery before signaling: a stale record may share a target's
 	// endpoint, and its mismatch is only observable while that endpoint is up.

--- a/internal/client/ensure.go
+++ b/internal/client/ensure.go
@@ -258,10 +258,12 @@ func daemonVersionCompatible(info PingInfo) bool {
 }
 
 func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
-	signaled := false
+	var targets []kitdaemon.RuntimeRecord
+	var unreachable error
 	for candidate, err := range liveDaemons(ctx, dataDir) {
 		if err != nil {
 			if errors.Is(err, ErrLocalDaemonUnreachable) {
+				unreachable = err
 				continue
 			}
 			return err
@@ -273,22 +275,40 @@ func stopRunningDaemons(ctx context.Context, dataDir, dbhash string) error {
 		if candidate.Info.PID == 0 || candidate.Info.PID != candidate.Record.PID {
 			return fmt.Errorf("daemon at %s is running but its PID could not be verified; stop it manually", address)
 		}
-		if err := signalDaemonStopForEnsure(candidate.Record, dbhash); err != nil {
-			return fmt.Errorf("stop old daemon pid %d: %w", candidate.Record.PID, err)
-		}
-		signaled = true
+		targets = append(targets, candidate.Record)
 	}
-	if !signaled {
+	if len(targets) == 0 {
 		return nil
+	}
+	// Finish discovery before signaling: a stale record may share a target's
+	// endpoint, and its mismatch is only observable while that endpoint is up.
+	for _, record := range targets {
+		if err := signalDaemonStopForEnsure(record, dbhash); err != nil {
+			return fmt.Errorf("stop old daemon pid %d: %w", record.PID, err)
+		}
+	}
+	if unreachable != nil {
+		return unreachable
 	}
 
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		found, err := discoverForEnsure(ctx, dataDir)
-		if err != nil {
-			return err
+		// Wait only for verified targets. Reprobing every runtime file here
+		// would turn ignored stale records into unreachable-daemon errors as
+		// soon as the real daemon closes its listener.
+		running := false
+		for _, record := range targets {
+			if !daemon.RuntimeProcessAlive(record) {
+				continue
+			}
+			if _, err := os.Stat(record.SourcePath); errors.Is(err, os.ErrNotExist) {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("check stopping daemon pid %d: %w", record.PID, err)
+			}
+			running = true
 		}
-		if found.Outcome == daemonScanNone {
+		if !running {
 			return nil
 		}
 		select {

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -553,6 +553,38 @@ func TestStopRunningDaemonsSignalsVerifiedIncompatibleRuntime(t *testing.T) {
 	assert.Equal(t, ns.DBHash, signaledDBHash)
 }
 
+func TestDaemonDiscoveryPreservesRecordPublishedDuringProbe(t *testing.T) {
+	tmp := setupKataEnv(t)
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	store := kitdaemon.RuntimeStore{Dir: ns.DataDir}
+	other, _ := startLongLivedTestProcess(t)
+	replacementURL, replacementAddress := startMockDaemonPing(t, map[string]any{
+		"ok": true, "service": "kata", "version": currentVersionForEnsure(), "pid": os.Getpid(),
+	})
+	published := make(chan error, 1)
+	oldServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Startup publishes a fresh record at the reused PID path while
+		// discovery is waiting for the old endpoint's response.
+		_, writeErr := store.Write(kitdaemon.NewRuntimeRecord("kata", currentVersionForEnsure(),
+			kitdaemon.Endpoint{Network: "tcp", Address: replacementAddress}))
+		published <- writeErr
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true, "service": "kata", "version": "old-version", "pid": other.Process.Pid,
+		})
+	}))
+	t.Cleanup(oldServer.Close)
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), strings.TrimPrefix(oldServer.URL, "http://")))
+
+	_, _, err = Discover(context.Background(), ns.DataDir)
+	require.NoError(t, err)
+	require.NoError(t, <-published)
+	url, found, err := Discover(context.Background(), ns.DataDir)
+	require.NoError(t, err)
+	require.True(t, found, "the newly published daemon must remain discoverable")
+	assert.Equal(t, replacementURL, url)
+}
+
 func TestDaemonDiscoverySkipsReusedPIDAtSameEndpoint(t *testing.T) {
 	for _, staleFirst := range []bool{true, false} {
 		t.Run(fmt.Sprintf("staleFirst=%t", staleFirst), func(t *testing.T) {

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -585,6 +585,40 @@ func TestDaemonDiscoveryPreservesRecordPublishedDuringProbe(t *testing.T) {
 	assert.Equal(t, replacementURL, url)
 }
 
+func TestEnsureRunningStartsAfterLegacyDaemonExits(t *testing.T) {
+	tmp := setupKataEnv(t)
+	ns, err := daemon.NewNamespace()
+	require.NoError(t, err)
+	unrelated, _ := startLongLivedTestProcess(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true, "service": "kata", "version": currentVersionForEnsure(), "pid": os.Getpid(),
+		})
+	}))
+	t.Cleanup(server.Close)
+	address := strings.TrimPrefix(server.URL, "http://")
+	// This legacy record predates the unrelated process now holding its PID.
+	_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
+		PID: unrelated.Process.Pid, Address: address, StartedAt: time.Unix(1, 0),
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), address))
+	_, found, err := Discover(context.Background(), ns.DataDir)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// The real daemon exits normally; the stale legacy record remains.
+	server.Close()
+	path, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Path(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(path))
+	state := patchEnsureHooks(t, currentVersionForEnsure(), "http://new-daemon")
+	url, err := EnsureLocalRunning(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "http://new-daemon", url)
+	assert.Equal(t, 1, state.startCalls)
+}
+
 func TestDaemonDiscoverySkipsReusedPIDAtSameEndpoint(t *testing.T) {
 	for _, staleFirst := range []bool{true, false} {
 		t.Run(fmt.Sprintf("staleFirst=%t", staleFirst), func(t *testing.T) {

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -553,6 +553,52 @@ func TestStopRunningDaemonsSignalsVerifiedIncompatibleRuntime(t *testing.T) {
 	assert.Equal(t, ns.DBHash, signaledDBHash)
 }
 
+func TestDaemonDiscoverySkipsReusedPIDAtSameEndpoint(t *testing.T) {
+	for _, staleFirst := range []bool{true, false} {
+		t.Run(fmt.Sprintf("staleFirst=%t", staleFirst), func(t *testing.T) {
+			t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
+			tmp := setupKataEnv(t)
+			unrelated, _ := startLongLivedTestProcess(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"ok": true, "service": "kata", "version": "old-version", "pid": os.Getpid(),
+				})
+			}))
+			t.Cleanup(server.Close)
+			addr := strings.TrimPrefix(server.URL, "http://")
+			require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), addr))
+			ns, err := daemon.NewNamespace()
+			require.NoError(t, err)
+			startedAt := time.Now().Add(time.Hour)
+			if staleFirst {
+				startedAt = time.Now().Add(-time.Hour)
+			}
+			// An old record has no process identity, and its PID now belongs
+			// to another live process. Both records point at the current daemon.
+			_, err = (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(kitdaemon.RuntimeRecord{
+				PID: unrelated.Process.Pid, Address: addr, StartedAt: startedAt,
+			})
+			require.NoError(t, err)
+
+			found, err := discoverForEnsure(context.Background(), ns.DataDir)
+			require.NoError(t, err)
+			require.Equal(t, os.Getpid(), found.Daemon.Record.PID)
+
+			origSignal := signalDaemonStopForEnsure
+			var signaled []int
+			signalDaemonStopForEnsure = func(rec kitdaemon.RuntimeRecord, _ string) error {
+				signaled = append(signaled, rec.PID)
+				server.Close()
+				return os.Remove(filepath.Join(ns.DataDir, fmt.Sprintf("daemon.%d.json", rec.PID)))
+			}
+			t.Cleanup(func() { signalDaemonStopForEnsure = origSignal })
+
+			require.NoError(t, stopRunningDaemons(context.Background(), ns.DataDir, ns.DBHash))
+			assert.Equal(t, []int{os.Getpid()}, signaled)
+		})
+	}
+}
+
 func TestStopRunningDaemonsReportsUnreachableDaemonRemainingAfterSignal(t *testing.T) {
 	t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
 	tmp := setupKataEnv(t)

--- a/internal/client/ensure_test.go
+++ b/internal/client/ensure_test.go
@@ -386,13 +386,41 @@ func TestStopRunningDaemonsDoesNotSignalUnverifiedRuntimePID(t *testing.T) {
 	require.NoError(t, writeRuntimeRecordForPID(t, tmp, cmd.Process.Pid, "127.0.0.1:1"))
 	ns, err := daemon.NewNamespace()
 	require.NoError(t, err)
-	require.NoError(t, stopRunningDaemons(context.Background(), ns.DataDir, ns.DBHash))
+	require.ErrorIs(t, stopRunningDaemons(context.Background(), ns.DataDir, ns.DBHash), ErrLocalDaemonUnreachable)
 
 	select {
 	case err := <-waitCh:
 		t.Fatalf("unverified runtime PID was signaled; process exited with %v", err)
 	case <-time.After(200 * time.Millisecond):
 	}
+}
+
+func TestEnsureLocalRunningDoesNotStartWhenRestartProbeFails(t *testing.T) {
+	t.Setenv("KATA_SKIP_DAEMON_VERSION_CHECK", "")
+	tmp := setupKataEnv(t)
+	var probes atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if probes.Add(1) > 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true, "service": "kata", "version": "old-version", "pid": os.Getpid(),
+		})
+	}))
+	t.Cleanup(server.Close)
+	require.NoError(t, writeRuntimeRecordForPID(t, tmp, os.Getpid(), strings.TrimPrefix(server.URL, "http://")))
+	origStart := startDaemonForEnsure
+	startCalls := 0
+	startDaemonForEnsure = func(context.Context, string) (RunningDaemon, error) {
+		startCalls++
+		return RunningDaemon{}, nil
+	}
+	t.Cleanup(func() { startDaemonForEnsure = origStart })
+
+	_, err := EnsureLocalRunning(context.Background())
+	assert.ErrorIs(t, err, ErrLocalDaemonUnreachable)
+	assert.Zero(t, startCalls)
 }
 
 func TestNewHTTPClientWithoutAuthSkipsDeadRuntimeRecords(t *testing.T) {

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1,13 +1,36 @@
 package daemon
 
-import kitdaemon "go.kenn.io/kit/daemon"
+import (
+	"math"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/process"
+	kitdaemon "go.kenn.io/kit/daemon"
+)
 
 // RuntimeProcessAlive reports whether a runtime record still identifies the
-// process that created it. Records without a verifiable identity retain the
-// legacy PID-only behavior; a definite identity mismatch is stale.
+// process that created it. For legacy records without an identity, a process
+// created after the record was published proves that the PID has been reused.
 func RuntimeProcessAlive(record kitdaemon.RuntimeRecord) bool {
-	if !kitdaemon.ProcessAlive(record.PID) {
+	if record.PID <= 0 || record.PID > math.MaxInt32 || !kitdaemon.ProcessAlive(record.PID) {
 		return false
 	}
-	return kitdaemon.CompareRuntimeProcessIdentity(record) != kitdaemon.ProcessIdentityMismatch
+	switch kitdaemon.CompareRuntimeProcessIdentity(record) {
+	case kitdaemon.ProcessIdentityMatch:
+		return true
+	case kitdaemon.ProcessIdentityMismatch:
+		return false
+	}
+	if record.StartedAt.IsZero() {
+		return true
+	}
+	proc, err := process.NewProcess(int32(record.PID))
+	if err != nil {
+		return true
+	}
+	created, err := proc.CreateTime()
+	if err != nil || created <= 0 {
+		return true
+	}
+	return !time.UnixMilli(created).After(record.StartedAt)
 }


### PR DESCRIPTION
Fixes commands such as `kata tui` failing during daemon upgrades or later startup when an old runtime record’s PID has been reused by another process.

Legacy records without a verifiable process identity are rejected when the OS process creation time is later than the record timestamp. Discovery also skips records whose PID disagrees with the responding daemon. Restart collects verified targets before signaling them and waits only for those targets, so stale records pointing at the closed endpoint do not block shutdown.

Discovery leaves runtime files untouched, preserving replacements published during a probe. Regressions cover concurrent publication, both record orders through shutdown, and a later startup after the real daemon exits. Missing creation-time information retains the existing liveness behavior; daemons that report no PID still require manual intervention for upgrades.

Intended for 0.17.2.
