### PR TITLE
Restart the local daemon after self-updating Kata

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
   },
   "overrides": {
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "nanoid": "3.3.18",
   },
   "packages": {
@@ -606,7 +606,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
+    "js-yaml": ["js-yaml@4.3.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -910,10 +910,7 @@ func announceIdleShutdown(w io.Writer, timeout time.Duration) {
 // re-executes itself only after every listener and the runtime record have
 // been released.
 func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bool) error {
-	restart, err := newDaemonRestart()
-	if err != nil {
-		return err
-	}
+	restart := newDaemonRestart(os.Stderr)
 	if err := runDaemonProcess(ctx, listen, insecureReadonly, restart); err != nil {
 		return err
 	}

--- a/cmd/kata/daemon_cmd.go
+++ b/cmd/kata/daemon_cmd.go
@@ -905,7 +905,24 @@ func announceIdleShutdown(w io.Writer, timeout time.Duration) {
 // <KATA_HOME>/config.toml has a `listen = "..."` entry, in which case the
 // config value is used. CLI flag always wins over config.
 // insecureReadonly is the dev escape hatch from --insecure-readonly.
-func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bool) (returnErr error) {
+//
+// When the daemon shuts down because it received the restart signal, it
+// re-executes itself only after every listener and the runtime record have
+// been released.
+func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bool) error {
+	restart, err := newDaemonRestart()
+	if err != nil {
+		return err
+	}
+	if err := runDaemonProcess(ctx, listen, insecureReadonly, restart); err != nil {
+		return err
+	}
+	return restart.exec(ctx)
+}
+
+func runDaemonProcess(
+	ctx context.Context, listen string, insecureReadonly bool, restart *daemonRestart,
+) (returnErr error) {
 	startup, err := preflightDaemonStartup(ctx, listen, insecureReadonly)
 	if err != nil {
 		return err
@@ -1054,6 +1071,9 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	rec.Address = runtimeEndpoint.ConfigAddress()
 	rec.Metadata = map[string]string{"db_path": redactRuntimeDSN(dbPath)}
 	maps.Copy(rec.Metadata, webRuntime.Metadata())
+	if restart != nil {
+		rec.Metadata[daemon.RuntimeRestartMetadataKey] = "1"
+	}
 
 	broadcaster := daemon.NewEventBroadcaster()
 	publisher := daemon.NewEventPublisher(broadcaster, disp)
@@ -1079,6 +1099,14 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 	workers.Go(func() {
 		runReloadLoop(ctx, sigs, hookCfgPath, disp, daemonLog)
 	})
+	restartCleanup := daemonPlatformCleanup(func(context.Context) bool { return true })
+	if restart != nil {
+		var restartSignals <-chan os.Signal
+		restartSignals, restartCleanup = installRestartSource(ctx, ns.DBHash)
+		workers.Go(func() {
+			restart.watch(ctx, restartSignals, shutdownTrigger.Call)
+		})
+	}
 	federationWake := startFederationRunner(
 		ctx, workers, waitableDrainAdmission, store, publisher, daemonLog,
 	)
@@ -1184,6 +1212,7 @@ func runDaemonWithListen(ctx context.Context, listen string, insecureReadonly bo
 		daemonShutdownDrainTimeout,
 		stopCleanup,
 		reloadCleanup,
+		restartCleanup,
 	)
 	shutdownTrigger.Set(shutdown.Trigger)
 	httpHandlersJoined := true

--- a/cmd/kata/daemon_restart.go
+++ b/cmd/kata/daemon_restart.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -20,22 +21,27 @@ type daemonRestart struct {
 	requested  atomic.Bool
 }
 
+// resolveDaemonExecutable is swapped in tests that exercise unsupported hosts.
+var resolveDaemonExecutable = os.Executable
+
 // newDaemonRestart resolves the executable to re-execute before any update
-// can replace it: Linux reports a replaced binary as deleted. Ephemeral test
-// and go-build binaries return nil, which disables the restart signal.
-func newDaemonRestart() (*daemonRestart, error) {
-	executable, err := os.Executable()
-	if err != nil {
-		return nil, fmt.Errorf("resolve daemon executable: %w", err)
+// can replace it: Linux reports a replaced binary as deleted. A host that
+// cannot resolve the running binary still starts the daemon; it only loses
+// automatic restart, and stderr says so. Ephemeral test and go-build binaries
+// are silently excluded.
+func newDaemonRestart(stderr io.Writer) *daemonRestart {
+	executable, err := resolveDaemonExecutable()
+	if err == nil {
+		executable, err = filepath.EvalSymlinks(executable)
 	}
-	executable, err = filepath.EvalSymlinks(executable)
 	if err != nil {
-		return nil, fmt.Errorf("resolve daemon executable: %w", err)
+		_, _ = fmt.Fprintf(stderr, "kata daemon: automatic restart after updates disabled: %v\n", err)
+		return nil
 	}
 	if kitdaemon.IsEphemeralExecutable(executable) {
-		return nil, nil
+		return nil
 	}
-	return &daemonRestart{executable: executable}, nil
+	return &daemonRestart{executable: executable}
 }
 
 // watch records the first restart signal and triggers daemon shutdown.

--- a/cmd/kata/daemon_restart.go
+++ b/cmd/kata/daemon_restart.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	kitdaemon "go.kenn.io/kit/daemon"
+)
+
+// daemonRestart carries a restart request from the platform signal source to
+// the point where the daemon has released its listeners and runtime record.
+// The daemon re-executes itself with its own arguments and environment, so
+// the replacement keeps the listener, read-only mode, credentials, auto-start
+// marker, and idle timeout of the process it replaces.
+type daemonRestart struct {
+	executable string
+	requested  atomic.Bool
+}
+
+// newDaemonRestart resolves the executable to re-execute before any update
+// can replace it: Linux reports a replaced binary as deleted. Ephemeral test
+// and go-build binaries return nil, which disables the restart signal.
+func newDaemonRestart() (*daemonRestart, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve daemon executable: %w", err)
+	}
+	executable, err = filepath.EvalSymlinks(executable)
+	if err != nil {
+		return nil, fmt.Errorf("resolve daemon executable: %w", err)
+	}
+	if kitdaemon.IsEphemeralExecutable(executable) {
+		return nil, nil
+	}
+	return &daemonRestart{executable: executable}, nil
+}
+
+// watch records the first restart signal and triggers daemon shutdown.
+func (r *daemonRestart) watch(ctx context.Context, sigs <-chan os.Signal, trigger func()) {
+	select {
+	case <-ctx.Done():
+	case <-sigs:
+		r.requested.Store(true)
+		trigger()
+	}
+}
+
+// exec replaces the daemon once the current process has shut down. On Unix
+// the process image is replaced in place so supervisors keep the same PID; on
+// Windows a detached replacement starts and this process exits.
+func (r *daemonRestart) exec(ctx context.Context) error {
+	if r == nil || !r.requested.Load() {
+		return nil
+	}
+	if err := reexecDaemon(ctx, r.executable); err != nil {
+		return fmt.Errorf("restart daemon: %w", err)
+	}
+	return nil
+}

--- a/cmd/kata/daemon_restart_test.go
+++ b/cmd/kata/daemon_restart_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stubDaemonExecutable(t *testing.T, resolve func() (string, error)) {
+	t.Helper()
+	original := resolveDaemonExecutable
+	resolveDaemonExecutable = resolve
+	t.Cleanup(func() { resolveDaemonExecutable = original })
+}
+
+func TestNewDaemonRestart_UnresolvableExecutableDisablesRestart(t *testing.T) {
+	stubDaemonExecutable(t, func() (string, error) { return "", errors.New("procfs unavailable") })
+	var stderr bytes.Buffer
+	restart := newDaemonRestart(&stderr)
+	assert.Nil(t, restart, "startup must continue without automatic restart")
+	assert.Contains(t, stderr.String(), "procfs unavailable")
+	assert.Contains(t, stderr.String(), "automatic restart")
+}
+
+func TestNewDaemonRestart_MissingExecutableDisablesRestart(t *testing.T) {
+	stubDaemonExecutable(t, func() (string, error) { return filepath.Join(t.TempDir(), "kata"), nil })
+	var stderr bytes.Buffer
+	assert.Nil(t, newDaemonRestart(&stderr))
+	assert.Contains(t, stderr.String(), "automatic restart")
+}
+
+func TestNewDaemonRestart_EphemeralExecutableIsSilent(t *testing.T) {
+	stubDaemonExecutable(t, os.Executable)
+	var stderr bytes.Buffer
+	assert.Nil(t, newDaemonRestart(&stderr), "test binaries never re-execute")
+	assert.Empty(t, stderr.String())
+}
+
+func TestNewDaemonRestart_ResolvesSymlinkedExecutable(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "kata")
+	require.NoError(t, os.WriteFile(target, []byte("#!/bin/sh\n"), 0o600))
+	link := filepath.Join(dir, "kata-link")
+	require.NoError(t, os.Symlink(target, link))
+	stubDaemonExecutable(t, func() (string, error) { return link, nil })
+	var stderr bytes.Buffer
+	restart := newDaemonRestart(&stderr)
+	require.NotNil(t, restart)
+	assert.Equal(t, target, restart.executable)
+	assert.Empty(t, stderr.String())
+}

--- a/cmd/kata/daemon_restart_test.go
+++ b/cmd/kata/daemon_restart_test.go
@@ -51,6 +51,9 @@ func TestNewDaemonRestart_ResolvesSymlinkedExecutable(t *testing.T) {
 	var stderr bytes.Buffer
 	restart := newDaemonRestart(&stderr)
 	require.NotNil(t, restart)
-	assert.Equal(t, target, restart.executable)
+	// Windows temp dirs may carry 8.3 short names; resolve the expected path the same way.
+	expected, err := filepath.EvalSymlinks(target)
+	require.NoError(t, err)
+	assert.Equal(t, expected, restart.executable)
 	assert.Empty(t, stderr.String())
 }

--- a/cmd/kata/daemon_restart_unix.go
+++ b/cmd/kata/daemon_restart_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+)
+
+// reexecDaemon replaces the current process image. It only returns on failure.
+func reexecDaemon(_ context.Context, executable string) error {
+	return syscall.Exec(executable, os.Args, os.Environ()) //nolint:gosec // the daemon re-executes its own resolved binary with its own arguments
+}

--- a/cmd/kata/daemon_restart_windows.go
+++ b/cmd/kata/daemon_restart_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"os"
+
+	kitdaemon "go.kenn.io/kit/daemon"
+)
+
+// reexecDaemon starts a detached replacement with this process's arguments,
+// environment, and standard streams. Windows cannot replace a process image.
+func reexecDaemon(ctx context.Context, executable string) error {
+	return kitdaemon.StartDetached(ctx, kitdaemon.StartDetachedOptions{
+		Executable: executable,
+		Args:       os.Args[1:],
+		Env:        os.Environ(),
+		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
+	})
+}

--- a/cmd/kata/daemon_signal_endpoints_windows_test.go
+++ b/cmd/kata/daemon_signal_endpoints_windows_test.go
@@ -11,13 +11,14 @@ import (
 )
 
 // registerDaemonSignalEndpoints creates the manual-reset named events that a
-// real daemon stands up at startup (installStopWatcher / installReloadSource),
+// real daemon stands up at startup (installStopWatcher / installReloadSource /
+// installRestartSource),
 // so `kata daemon stop`/`reload` can OpenEvent them against a faked daemon PID
 // in tests. The handles are held open until test cleanup, keeping the events
 // alive for the in-process command's OpenEvent call. On Unix this is a no-op.
 func registerDaemonSignalEndpoints(t *testing.T, dbhash string, pid int) {
 	t.Helper()
-	for _, name := range []string{daemon.StopEventName(dbhash, pid), daemon.ReloadEventName(dbhash, pid)} {
+	for _, name := range []string{daemon.StopEventName(dbhash, pid), daemon.ReloadEventName(dbhash, pid), daemon.RestartEventName(dbhash, pid)} {
 		namePtr, err := windows.UTF16PtrFromString(name)
 		if err != nil {
 			t.Fatalf("event name %q: %v", name, err)

--- a/cmd/kata/daemon_signaling_unix.go
+++ b/cmd/kata/daemon_signaling_unix.go
@@ -27,3 +27,14 @@ func installReloadSource(_ context.Context, _ string) (<-chan os.Signal, daemonP
 		return true
 	}
 }
+
+// installRestartSource hooks SIGUSR1 onto a channel the restart watcher reads
+// from. Cleanup detaches the signal handler.
+func installRestartSource(_ context.Context, _ string) (<-chan os.Signal, daemonPlatformCleanup) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGUSR1)
+	return sigs, func(context.Context) bool {
+		signal.Stop(sigs)
+		return true
+	}
+}

--- a/cmd/kata/daemon_signaling_windows.go
+++ b/cmd/kata/daemon_signaling_windows.go
@@ -17,10 +17,11 @@ import (
 //
 //	Local\kata-stop-<dbhash>-<pid>     — set by `kata daemon stop`
 //	Local\kata-reload-<dbhash>-<pid>   — set by `kata daemon reload`
+//	Local\kata-restart-<dbhash>-<pid>  — set by `kata update`
 //
 // The daemon creates the events at startup, waits on them in goroutines,
-// and translates a fire into ctx cancel (stop) or a synthetic reload fed
-// to the existing reload loop.
+// and translates a fire into ctx cancel (stop) or a synthetic signal fed
+// to the reload loop or restart watcher.
 
 // installStopWatcher creates the stop event for this daemon process and
 // spawns a goroutine that waits on it. When the event fires (and we are
@@ -59,17 +60,28 @@ func installStopWatcher(dbhash string, cancel context.CancelFunc) daemonPlatform
 	}
 }
 
-type syntheticReloadSignal struct{}
+type syntheticSignal string
 
-func (syntheticReloadSignal) String() string { return "reload" }
-func (syntheticReloadSignal) Signal()        {}
+func (s syntheticSignal) String() string { return string(s) }
+func (syntheticSignal) Signal()          {}
 
 // installReloadSource creates the reload event and pumps a private synthetic
 // signal onto the returned channel each time it fires, so the existing
 // runReloadLoop machinery works unchanged.
 func installReloadSource(ctx context.Context, dbhash string) (<-chan os.Signal, daemonPlatformCleanup) {
+	return installNamedEventSource(ctx, daemon.ReloadEventName(dbhash, os.Getpid()), syntheticSignal("reload"))
+}
+
+// installRestartSource creates the restart event set by `kata update`.
+func installRestartSource(ctx context.Context, dbhash string) (<-chan os.Signal, daemonPlatformCleanup) {
+	return installNamedEventSource(ctx, daemon.RestartEventName(dbhash, os.Getpid()), syntheticSignal("restart"))
+}
+
+// installNamedEventSource creates a manual-reset named event and pumps sig
+// onto the returned channel each time the event fires.
+func installNamedEventSource(ctx context.Context, name string, sig os.Signal) (<-chan os.Signal, daemonPlatformCleanup) {
 	sigs := make(chan os.Signal, 1)
-	namePtr, err := windows.UTF16PtrFromString(daemon.ReloadEventName(dbhash, os.Getpid()))
+	namePtr, err := windows.UTF16PtrFromString(name)
 	if err != nil {
 		return sigs, func(context.Context) bool { return true }
 	}
@@ -95,7 +107,7 @@ func installReloadSource(ctx context.Context, dbhash string) (<-chan os.Signal, 
 			}
 			_ = windows.ResetEvent(h)
 			select {
-			case sigs <- syntheticReloadSignal{}:
+			case sigs <- sig:
 			default:
 			}
 		}

--- a/cmd/kata/update.go
+++ b/cmd/kata/update.go
@@ -6,12 +6,18 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/version"
+	kitdaemon "go.kenn.io/kit/daemon"
 	"go.kenn.io/kit/selfupdate"
 )
 
@@ -46,6 +52,8 @@ var newSelfUpdateClient = func(current string) (updateClient, error) {
 var updateInfoNeedsRefetch = func(info *selfupdate.Info) bool {
 	return info.NeedsRefetch()
 }
+
+var updateExecutable = os.Executable
 
 func newUpdateCmd() *cobra.Command {
 	var checkOnly bool
@@ -98,11 +106,23 @@ func newUpdateCmd() *cobra.Command {
 					return err
 				}
 			}
+			restart, err := prepareUpdateDaemonRestart(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("prepare daemon restart before update: %w", err)
+			}
 			if err := client.Install(cmd.Context(), info, selfupdate.InstallOptions{}); err != nil {
 				return &cliError{
 					Message:  "install update: " + err.Error(),
 					Kind:     kindInternal,
 					ExitCode: ExitInternal,
+				}
+			}
+			if restart != nil {
+				// Keep the update's JSON/agent result as a single stdout record.
+				restart.Stdout = cmd.ErrOrStderr()
+				restart.Stderr = cmd.ErrOrStderr()
+				if err := restart.Run(); err != nil {
+					return fmt.Errorf("installed kata %s, but daemon restart failed: %w; run 'kata daemon restart' after resolving the error", latestUpdateVersion(info), err)
 				}
 			}
 			return printUpdateInstallResult(cmd, info)
@@ -112,6 +132,50 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "force a fresh update check")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "install without prompting")
 	return cmd
+}
+
+// Capture the installed executable's destination before Install replaces it.
+// On Linux, os.Executable may refer to a deleted inode after replacement. Run
+// restart through the new binary so validation and startup use the new code.
+func prepareUpdateDaemonRestart(ctx context.Context) (*exec.Cmd, error) {
+	ns, err := daemon.NewNamespace()
+	if err != nil {
+		return nil, err
+	}
+	records, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).List()
+	if err != nil {
+		return nil, err
+	}
+	for _, record := range records {
+		if !daemon.RuntimeProcessAlive(record) {
+			continue
+		}
+		executable, err := updateExecutable()
+		if err != nil {
+			return nil, err
+		}
+		executable, err = filepath.EvalSymlinks(executable)
+		if err != nil {
+			return nil, err
+		}
+		// Match selfupdate.Client's default destination, including installations
+		// invoked through a symlink or a differently named executable.
+		name := "kata"
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		destination := filepath.Join(filepath.Dir(executable), name)
+		args := []string{"daemon", "restart"}
+		if endpoint := record.Endpoint(); !endpoint.IsUnix() {
+			args = append(args, "--listen", endpoint.Address)
+		}
+		// Local runtime records advertise polling only for --insecure-readonly.
+		if slices.Contains(strings.Split(record.Metadata["web_capabilities"], ","), "poll") {
+			args = append(args, "--insecure-readonly")
+		}
+		return exec.CommandContext(ctx, destination, args...), nil //nolint:gosec // resolved self-update destination and locally discovered listener, passed without a shell
+	}
+	return nil, nil
 }
 
 func printUpdateSummary(cmd *cobra.Command, info *selfupdate.Info) error {

--- a/cmd/kata/update.go
+++ b/cmd/kata/update.go
@@ -106,10 +106,7 @@ func newUpdateCmd() *cobra.Command {
 					return err
 				}
 			}
-			restart, err := prepareUpdateDaemonRestart(cmd.Context())
-			if err != nil {
-				return fmt.Errorf("prepare daemon restart before update: %w", err)
-			}
+			restart, restartErr := prepareUpdateDaemonRestart(cmd.Context())
 			if err := client.Install(cmd.Context(), info, selfupdate.InstallOptions{}); err != nil {
 				return &cliError{
 					Message:  "install update: " + err.Error(),
@@ -117,12 +114,15 @@ func newUpdateCmd() *cobra.Command {
 					ExitCode: ExitInternal,
 				}
 			}
+			if restartErr != nil {
+				return fmt.Errorf("installed kata %s, but daemon restart was skipped: %w", latestUpdateVersion(info), restartErr)
+			}
 			if restart != nil {
 				// Keep the update's JSON/agent result as a single stdout record.
 				restart.Stdout = cmd.ErrOrStderr()
 				restart.Stderr = cmd.ErrOrStderr()
 				if err := restart.Run(); err != nil {
-					return fmt.Errorf("installed kata %s, but daemon restart failed: %w; run 'kata daemon restart' after resolving the error", latestUpdateVersion(info), err)
+					return fmt.Errorf("installed kata %s, but daemon restart failed: %w; run 'kata daemon restart' with its original startup options after resolving the error", latestUpdateVersion(info), err)
 				}
 			}
 			return printUpdateInstallResult(cmd, info)
@@ -169,9 +169,13 @@ func prepareUpdateDaemonRestart(ctx context.Context) (*exec.Cmd, error) {
 		if endpoint := record.Endpoint(); !endpoint.IsUnix() {
 			args = append(args, "--listen", endpoint.Address)
 		}
-		// Local runtime records advertise polling only for --insecure-readonly.
-		if slices.Contains(strings.Split(record.Metadata["web_capabilities"], ","), "poll") {
+		// Polling identifies --insecure-readonly; SSE identifies its absence.
+		// Missing metadata is not evidence that restarting writable is correct.
+		capabilities := strings.Split(record.Metadata["web_capabilities"], ",")
+		if slices.Contains(capabilities, "poll") {
 			args = append(args, "--insecure-readonly")
+		} else if !slices.Contains(capabilities, "sse") {
+			return nil, fmt.Errorf("running daemon does not report its read-only mode; run 'kata daemon restart' with its original startup options, including --listen and --insecure-readonly if used")
 		}
 		return exec.CommandContext(ctx, destination, args...), nil //nolint:gosec // resolved self-update destination and locally discovered listener, passed without a shell
 	}

--- a/cmd/kata/update.go
+++ b/cmd/kata/update.go
@@ -4,19 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"slices"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
-	"go.kenn.io/kata/internal/client"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/version"
@@ -55,8 +49,6 @@ var newSelfUpdateClient = func(current string) (updateClient, error) {
 var updateInfoNeedsRefetch = func(info *selfupdate.Info) bool {
 	return info.NeedsRefetch()
 }
-
-var updateExecutable = os.Executable
 
 func newUpdateCmd() *cobra.Command {
 	var checkOnly bool
@@ -109,7 +101,6 @@ func newUpdateCmd() *cobra.Command {
 					return err
 				}
 			}
-			restart, restartErr := prepareUpdateDaemonRestart(cmd.Context())
 			if err := client.Install(cmd.Context(), info, selfupdate.InstallOptions{}); err != nil {
 				return &cliError{
 					Message:  "install update: " + err.Error(),
@@ -117,16 +108,10 @@ func newUpdateCmd() *cobra.Command {
 					ExitCode: ExitInternal,
 				}
 			}
-			if restartErr != nil {
-				return fmt.Errorf("installed kata %s, but daemon restart was skipped: %w", latestUpdateVersion(info), restartErr)
-			}
-			if restart != nil {
-				// Keep the update's JSON/agent result as a single stdout record.
-				restart.Stdout = cmd.ErrOrStderr()
-				restart.Stderr = cmd.ErrOrStderr()
-				if err := restart.Run(); err != nil {
-					return fmt.Errorf("installed kata %s, but daemon restart failed: %w; run 'kata daemon restart' with its original startup options after resolving the error", latestUpdateVersion(info), err)
-				}
+			// Restart output goes to stderr so JSON and agent stdout stay a
+			// single update record.
+			if err := restartDaemonAfterUpdate(cmd.Context(), cmd.ErrOrStderr()); err != nil {
+				return fmt.Errorf("installed kata %s, but the daemon was not restarted: %w", latestUpdateVersion(info), err)
 			}
 			return printUpdateInstallResult(cmd, info)
 		},
@@ -137,90 +122,83 @@ func newUpdateCmd() *cobra.Command {
 	return cmd
 }
 
-// Capture the installed executable's destination before Install replaces it.
-// On Linux, os.Executable may refer to a deleted inode after replacement. Run
-// restart through the new binary so validation and startup use the new code.
-func prepareUpdateDaemonRestart(ctx context.Context) (*exec.Cmd, error) {
+// restartDaemonAfterUpdate asks a running daemon in the local namespace to
+// re-execute itself through the newly installed binary. The daemon restarts
+// with its own arguments and environment, so the updater needs neither its
+// startup options nor its credentials. A stopped daemon stays stopped.
+func restartDaemonAfterUpdate(ctx context.Context, stderr io.Writer) error {
 	ns, err := daemon.NewNamespace()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	records, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).List()
+	store := kitdaemon.RuntimeStore{Dir: ns.DataDir}
+	records, err := store.List()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	for _, record := range records {
 		if !daemon.RuntimeProcessAlive(record) {
 			continue
 		}
-		executable, err := updateExecutable()
+		if !daemon.RuntimeRecordRestartable(record) {
+			return fmt.Errorf("daemon pid %d predates automatic restart; run 'kata daemon restart' with its original startup options", record.PID)
+		}
+		if err := daemon.SignalDaemonRestart(record, ns.DBHash); err != nil {
+			return fmt.Errorf("signal daemon pid %d: %w", record.PID, err)
+		}
+		replacement, err := waitForDaemonReplacement(ctx, store, record)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		executable, err = filepath.EvalSymlinks(executable)
-		if err != nil {
-			return nil, err
+		if _, err := fmt.Fprintf(stderr, "restarted daemon pid=%d address=%s\n",
+			replacement.PID, replacement.Endpoint().ConfigAddress()); err != nil {
+			return err
 		}
-		// Match selfupdate.Client's default destination, including installations
-		// invoked through a symlink or a differently named executable.
-		name := "kata"
-		if runtime.GOOS == "windows" {
-			name += ".exe"
+		if err := writeDaemonWebURL(stderr, replacement.Metadata["web_origin"]); err != nil {
+			return err
 		}
-		destination := filepath.Join(filepath.Dir(executable), name)
-		args := []string{"daemon", "restart"}
-		if endpoint := record.Endpoint(); !endpoint.IsUnix() {
-			args = append(args, "--listen", endpoint.Address)
-		}
-		// Polling identifies --insecure-readonly; SSE identifies its absence.
-		// Missing metadata is not evidence that restarting writable is correct.
-		capabilities := strings.Split(record.Metadata["web_capabilities"], ",")
-		if slices.Contains(capabilities, "poll") {
-			args = append(args, "--insecure-readonly")
-		} else if !slices.Contains(capabilities, "sse") {
-			return nil, fmt.Errorf("running daemon does not report its read-only mode; run 'kata daemon restart' with its original startup options, including --listen and --insecure-readonly if used")
-		}
-		cfg, err := config.ReadDaemonConfig()
-		if err != nil {
-			return nil, err
-		}
-		httpClient, baseURL := client.LocalHTTPClient(record.Endpoint().ConfigAddress())
-		httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-		defer httpClient.CloseIdleConnections()
-		// Health is public, so use the protected instance endpoint to check that
-		// the updater has the credential needed by the running daemon. Never
-		// copy credentials out of another process's environment or runtime file.
-		headers := make(map[string]string)
-		if cfg.Auth.Token != "" {
-			headers["Authorization"] = "Bearer " + cfg.Auth.Token
-		}
-		status, _, err := httpDoJSONHeaders(ctx, httpClient, http.MethodGet, baseURL+"/api/v1/instance", nil, headers)
-		if err != nil {
-			return nil, fmt.Errorf("check daemon authentication: %w", err)
-		}
-		if status != http.StatusOK {
-			return nil, fmt.Errorf("cannot verify daemon authentication with the update environment (HTTP %d); restart manually from the original daemon environment", status)
-		}
-		status, body, err := httpDoJSON(ctx, httpClient, http.MethodGet, baseURL+"/api/v1/health", nil)
-		if err != nil {
-			return nil, fmt.Errorf("check daemon idle shutdown: %w", err)
-		}
-		if status != http.StatusOK {
-			return nil, fmt.Errorf("check daemon idle shutdown: HTTP %d", status)
-		}
-		var health daemonAPIHealth
-		if err := json.Unmarshal(body, &health); err != nil {
-			return nil, fmt.Errorf("decode daemon idle shutdown: %w", err)
-		}
-		restart := exec.CommandContext(ctx, destination, args...) //nolint:gosec // resolved self-update destination and locally discovered listener, passed without a shell
-		restart.Env = withoutEnvironmentKey(os.Environ(), daemon.AutoStartMarkerEnv)
-		if health.IdleShutdown != nil {
-			restart.Env = append(withoutEnvironmentKey(restart.Env, "KATA_AUTOSTART_IDLE_TIMEOUT"),
-				daemon.AutoStartMarkerEnv+"=1", "KATA_AUTOSTART_IDLE_TIMEOUT="+health.IdleShutdown.Timeout)
-		}
-		return restart, nil
 	}
-	return nil, nil
+	return nil
+}
+
+// updateDaemonReplacementGrace bounds how long a replacement may take to
+// publish its runtime record once the previous daemon process has exited.
+const updateDaemonReplacementGrace = 5 * time.Second
+
+// waitForDaemonReplacement returns the first live runtime record started
+// after previous. On Unix the daemon keeps its PID across re-execution, so a
+// newer record rather than a new PID identifies the replacement.
+func waitForDaemonReplacement(
+	ctx context.Context, store kitdaemon.RuntimeStore, previous kitdaemon.RuntimeRecord,
+) (kitdaemon.RuntimeRecord, error) {
+	deadline := time.Now().Add(daemonRestartProcessWaitTimeout)
+	var exitedAt time.Time
+	for {
+		records, err := store.List()
+		if err != nil {
+			return kitdaemon.RuntimeRecord{}, err
+		}
+		for _, record := range records {
+			if record.StartedAt.After(previous.StartedAt) && daemon.RuntimeProcessAlive(record) {
+				return record, nil
+			}
+		}
+		now := time.Now()
+		if exitedAt.IsZero() && !kitdaemon.ProcessAlive(previous.PID) {
+			exitedAt = now
+		}
+		switch {
+		case !exitedAt.IsZero() && now.Sub(exitedAt) > updateDaemonReplacementGrace:
+			return kitdaemon.RuntimeRecord{}, fmt.Errorf("daemon pid %d exited without starting a replacement; check the daemon log, then run 'kata daemon start' with its original startup options", previous.PID)
+		case now.After(deadline):
+			return kitdaemon.RuntimeRecord{}, fmt.Errorf("daemon pid %d did not restart within %s", previous.PID, daemonRestartProcessWaitTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return kitdaemon.RuntimeRecord{}, ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
 }
 
 func printUpdateSummary(cmd *cobra.Command, info *selfupdate.Info) error {

--- a/cmd/kata/update.go
+++ b/cmd/kata/update.go
@@ -141,7 +141,7 @@ func restartDaemonAfterUpdate(ctx context.Context, stderr io.Writer) error {
 			continue
 		}
 		if !daemon.RuntimeRecordRestartable(record) {
-			return fmt.Errorf("daemon pid %d predates automatic restart; run 'kata daemon restart' with its original startup options", record.PID)
+			return fmt.Errorf("daemon pid %d does not support automatic restart; run 'kata daemon restart' with its original startup options", record.PID)
 		}
 		if err := daemon.SignalDaemonRestart(record, ns.DBHash); err != nil {
 			return fmt.Errorf("signal daemon pid %d: %w", record.PID, err)

--- a/cmd/kata/update.go
+++ b/cmd/kata/update.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/kata/internal/client"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	"go.kenn.io/kata/internal/version"
@@ -177,7 +180,45 @@ func prepareUpdateDaemonRestart(ctx context.Context) (*exec.Cmd, error) {
 		} else if !slices.Contains(capabilities, "sse") {
 			return nil, fmt.Errorf("running daemon does not report its read-only mode; run 'kata daemon restart' with its original startup options, including --listen and --insecure-readonly if used")
 		}
-		return exec.CommandContext(ctx, destination, args...), nil //nolint:gosec // resolved self-update destination and locally discovered listener, passed without a shell
+		cfg, err := config.ReadDaemonConfig()
+		if err != nil {
+			return nil, err
+		}
+		httpClient, baseURL := client.LocalHTTPClient(record.Endpoint().ConfigAddress())
+		httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+		defer httpClient.CloseIdleConnections()
+		// Health is public, so use the protected instance endpoint to check that
+		// the updater has the credential needed by the running daemon. Never
+		// copy credentials out of another process's environment or runtime file.
+		headers := make(map[string]string)
+		if cfg.Auth.Token != "" {
+			headers["Authorization"] = "Bearer " + cfg.Auth.Token
+		}
+		status, _, err := httpDoJSONHeaders(ctx, httpClient, http.MethodGet, baseURL+"/api/v1/instance", nil, headers)
+		if err != nil {
+			return nil, fmt.Errorf("check daemon authentication: %w", err)
+		}
+		if status != http.StatusOK {
+			return nil, fmt.Errorf("cannot verify daemon authentication with the update environment (HTTP %d); restart manually from the original daemon environment", status)
+		}
+		status, body, err := httpDoJSON(ctx, httpClient, http.MethodGet, baseURL+"/api/v1/health", nil)
+		if err != nil {
+			return nil, fmt.Errorf("check daemon idle shutdown: %w", err)
+		}
+		if status != http.StatusOK {
+			return nil, fmt.Errorf("check daemon idle shutdown: HTTP %d", status)
+		}
+		var health daemonAPIHealth
+		if err := json.Unmarshal(body, &health); err != nil {
+			return nil, fmt.Errorf("decode daemon idle shutdown: %w", err)
+		}
+		restart := exec.CommandContext(ctx, destination, args...) //nolint:gosec // resolved self-update destination and locally discovered listener, passed without a shell
+		restart.Env = withoutEnvironmentKey(os.Environ(), daemon.AutoStartMarkerEnv)
+		if health.IdleShutdown != nil {
+			restart.Env = append(withoutEnvironmentKey(restart.Env, "KATA_AUTOSTART_IDLE_TIMEOUT"),
+				daemon.AutoStartMarkerEnv+"=1", "KATA_AUTOSTART_IDLE_TIMEOUT="+health.IdleShutdown.Timeout)
+		}
+		return restart, nil
 	}
 	return nil, nil
 }

--- a/cmd/kata/update_daemon_test.go
+++ b/cmd/kata/update_daemon_test.go
@@ -28,15 +28,16 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 	}
 	// Child daemons get only toolchain/OS variables and the test's Kata paths.
 	var childEnv []string
-	allowed := []string{"PATH", "HOME", "USERPROFILE", "SystemRoot", "SYSTEMROOT", "WINDIR", "TMPDIR", "TMP", "TEMP", "GOCACHE", "GOMODCACHE", "GOPATH", "GOROOT", "GOTOOLCHAIN"}
-	for _, key := range allowed {
-		if value, ok := os.LookupEnv(key); ok {
-			childEnv = append(childEnv, key+"="+value)
-		}
-	}
+	allowed := []string{"PATH", "HOME", "USERPROFILE", "LOCALAPPDATA", "SYSTEMROOT", "WINDIR", "TMPDIR", "TMP", "TEMP", "GOCACHE", "GOMODCACHE", "GOPATH", "GOROOT", "GOTOOLCHAIN"}
 	for _, entry := range os.Environ() {
 		key, _, _ := strings.Cut(entry, "=")
-		if !slices.Contains(allowed, key) {
+		lookupKey := key
+		if runtime.GOOS == "windows" {
+			lookupKey = strings.ToUpper(key)
+		}
+		if slices.Contains(allowed, lookupKey) {
+			childEnv = append(childEnv, entry)
+		} else {
 			t.Setenv(key, "")
 		}
 	}
@@ -58,7 +59,7 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 		require.NoError(t, err, "%s", output)
 		binaries[version] = binary
 	}
-	for _, scenario := range []string{"running", "stopped", "check only", "cancelled", "install failure", "restart failure", "read-only TCP"} {
+	for _, scenario := range []string{"running", "stopped", "check only", "cancelled", "install failure", "restart failure", "read-only TCP", "unknown daemon mode"} {
 		t.Run(scenario, func(t *testing.T) {
 			resetFlags(t)
 			fake := &fakeUpdateClient{checkResults: []*selfupdate.Info{{CurrentVersion: "v0.1.0", LatestVersion: "v0.2.0"}}}
@@ -92,7 +93,7 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 			})
 			if scenario != "stopped" {
 				args := []string{"daemon", "start", "--foreground"}
-				if scenario == "read-only TCP" {
+				if scenario == "read-only TCP" || scenario == "unknown daemon mode" {
 					args = append(args, "--listen", "127.0.0.1:0", "--insecure-readonly")
 				}
 				process := exec.Command(binary, args...) //nolint:gosec // test-owned binary and fixed arguments
@@ -112,6 +113,12 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 				require.Eventually(t, func() bool { return record().PID != 0 }, 10*time.Second, 20*time.Millisecond)
 			}
 			before := record()
+			if scenario == "unknown daemon mode" {
+				// v0.13.0 records contain only db_path, even in read-only mode.
+				before.Metadata = map[string]string{"db_path": before.Metadata["db_path"]}
+				_, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(before)
+				require.NoError(t, err)
+			}
 			fake.install = func() error {
 				if scenario == "install failure" {
 					return errors.New("download failed")
@@ -137,6 +144,21 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 				return
 			}
 			stdout, stderr, updateErr := executeRootCapture(t, t.Context(), "update", "--yes", "--json")
+			if scenario == "unknown daemon mode" {
+				require.Error(t, updateErr)
+				assert.Contains(t, updateErr.Error(), "installed")
+				assert.Contains(t, updateErr.Error(), "read-only mode")
+				assert.NotEmpty(t, fake.installed)
+				assert.Equal(t, before.PID, record().PID)
+				httpClient, baseURL := client.LocalHTTPClient(before.Endpoint().ConfigAddress())
+				status, _, err := httpDoJSON(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/ping", nil)
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusOK, status)
+				status, _, err = httpDoJSON(t.Context(), httpClient, http.MethodPost, baseURL+"/api/v1/projects", map[string]string{"name": "example-project", "actor": "user-a"})
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusUnauthorized, status)
+				return
+			}
 			if scenario == "restart failure" {
 				require.Error(t, updateErr)
 				assert.Contains(t, updateErr.Error(), "installed")

--- a/cmd/kata/update_daemon_test.go
+++ b/cmd/kata/update_daemon_test.go
@@ -59,7 +59,7 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 		require.NoError(t, err, "%s", output)
 		binaries[version] = binary
 	}
-	for _, scenario := range []string{"running", "stopped", "check only", "cancelled", "install failure", "restart failure", "read-only TCP", "unknown daemon mode", "missing daemon token", "shared daemon token", "idle shutdown"} {
+	for _, scenario := range []string{"running", "stopped", "check only", "cancelled", "install failure", "restart failure", "read-only TCP", "older daemon", "daemon token", "idle shutdown"} {
 		t.Run(scenario, func(t *testing.T) {
 			resetFlags(t)
 			fake := &fakeUpdateClient{checkResults: []*selfupdate.Info{{CurrentVersion: "v0.1.0", LatestVersion: "v0.2.0"}}}
@@ -68,18 +68,15 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 			require.NoError(t, err)
 			binary := filepath.Join(t.TempDir(), filepath.Base(binaries["v0.1.0"]))
 			require.NoError(t, selfupdate.InstallBinary(binaries["v0.1.0"], binary))
-			originalExecutable := updateExecutable
-			updateExecutable = func() (string, error) { return binary, nil }
-			t.Cleanup(func() { updateExecutable = originalExecutable })
 			env := append(append([]string(nil), childEnv...), "KATA_HOME="+home, "KATA_DB="+filepath.Join(home, "kata.db"), "KATA_WORKSPACE="+workspace, "KATA_AUTHOR=user-a")
-			if scenario == "missing daemon token" || scenario == "shared daemon token" {
+			// The daemon restarts from its own environment. A hosted PORT in the
+			// updater's shell must not move a Unix-socket daemon onto wildcard TCP.
+			t.Setenv("PORT", "4321")
+			if scenario == "daemon token" {
+				// Only the daemon holds the token; the updater never needs it.
 				env = append(env, "KATA_AUTH_TOKEN=fixture-token")
-				if scenario == "shared daemon token" {
-					t.Setenv("KATA_AUTH_TOKEN", "fixture-token")
-				}
 			}
 			if scenario == "idle shutdown" {
-				// Neither the auto-start marker nor the timeout is in the updater's environment.
 				env = append(env, "KATA_AUTOSTART=1", "KATA_AUTOSTART_IDLE_TIMEOUT=10s")
 			}
 			ns, err := daemon.NewNamespace()
@@ -104,9 +101,9 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 			if scenario != "stopped" {
 				args := []string{"daemon", "start", "--foreground"}
 				switch scenario {
-				case "read-only TCP", "unknown daemon mode":
+				case "read-only TCP":
 					args = append(args, "--listen", "127.0.0.1:0", "--insecure-readonly")
-				case "missing daemon token", "shared daemon token":
+				case "daemon token":
 					args = append(args, "--listen", "127.0.0.1:0")
 				}
 				process := exec.Command(binary, args...) //nolint:gosec // test-owned binary and fixed arguments
@@ -126,9 +123,9 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 				require.Eventually(t, func() bool { return record().PID != 0 }, 10*time.Second, 20*time.Millisecond)
 			}
 			before := record()
-			if scenario == "unknown daemon mode" {
-				// v0.13.0 records contain only db_path, even in read-only mode.
-				before.Metadata = map[string]string{"db_path": before.Metadata["db_path"]}
+			if scenario == "older daemon" {
+				// Earlier daemons do not advertise the restart signal.
+				delete(before.Metadata, daemon.RuntimeRestartMetadataKey)
 				_, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).Write(before)
 				require.NoError(t, err)
 			}
@@ -153,52 +150,35 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 					assert.Equal(t, kindConfirm, requireCLIError(t, err, ExitConfirm).Kind)
 				}
 				assert.Empty(t, fake.installed)
-				assert.Equal(t, before.PID, record().PID)
+				assert.Equal(t, before.StartedAt, record().StartedAt)
 				return
 			}
 			stdout, stderr, updateErr := executeRootCapture(t, t.Context(), "update", "--yes", "--json")
-			if scenario == "missing daemon token" {
+			if scenario == "older daemon" {
 				require.Error(t, updateErr)
 				assert.Contains(t, updateErr.Error(), "installed")
-				assert.Contains(t, updateErr.Error(), "authentication")
+				assert.Contains(t, updateErr.Error(), "kata daemon restart")
 				assert.NotEmpty(t, fake.installed)
-				assert.Equal(t, before.PID, record().PID)
-				httpClient, baseURL := client.LocalHTTPClient(before.Endpoint().ConfigAddress())
-				status, _, err := httpDoJSON(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/projects", nil)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusUnauthorized, status)
-				status, _, err = httpDoJSONHeaders(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/projects", nil, map[string]string{"Authorization": "Bearer fixture-token"})
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusOK, status)
-				return
-			}
-			if scenario == "unknown daemon mode" {
-				require.Error(t, updateErr)
-				assert.Contains(t, updateErr.Error(), "installed")
-				assert.Contains(t, updateErr.Error(), "read-only mode")
-				assert.NotEmpty(t, fake.installed)
-				assert.Equal(t, before.PID, record().PID)
+				assert.Equal(t, before.StartedAt, record().StartedAt)
 				httpClient, baseURL := client.LocalHTTPClient(before.Endpoint().ConfigAddress())
 				status, _, err := httpDoJSON(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/ping", nil)
 				require.NoError(t, err)
 				assert.Equal(t, http.StatusOK, status)
-				status, _, err = httpDoJSON(t.Context(), httpClient, http.MethodPost, baseURL+"/api/v1/projects", map[string]string{"name": "example-project", "actor": "user-a"})
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusUnauthorized, status)
 				return
 			}
 			if scenario == "restart failure" {
+				// The replacement refuses the broken config after the original has
+				// already released its listeners, so the daemon is down.
 				require.Error(t, updateErr)
 				assert.Contains(t, updateErr.Error(), "installed")
 				assert.Contains(t, updateErr.Error(), "restart")
-				// Restore the fixture config so cleanup can discover and stop the daemon.
 				require.NoError(t, os.Remove(filepath.Join(home, "config.toml")))
-				assert.Equal(t, before.PID, record().PID)
+				assert.Zero(t, record().PID)
 				return
 			}
 			if scenario == "install failure" {
 				require.Error(t, updateErr)
-				assert.Equal(t, before.PID, record().PID)
+				assert.Equal(t, before.StartedAt, record().StartedAt)
 				return
 			}
 			require.NoError(t, updateErr, "%s", stderr)
@@ -210,28 +190,31 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 			after := record()
 			if scenario == "stopped" {
 				assert.Zero(t, after.PID)
+				assert.NotContains(t, stderr, "restarted")
 				return
 			}
-			require.NotEqual(t, before.PID, after.PID, "update must replace the running daemon")
+			require.True(t, after.StartedAt.After(before.StartedAt), "update must replace the running daemon")
 			assert.Equal(t, "v0.2.0", after.Version)
+			assert.Contains(t, stderr, "restarted daemon")
 			httpClient, baseURL := client.LocalHTTPClient(after.Endpoint().ConfigAddress())
 			status, _, err := httpDoJSON(t.Context(), httpClient, "GET", baseURL+"/api/v1/ping", nil)
 			require.NoError(t, err)
 			assert.Equal(t, 200, status)
-			if scenario == "shared daemon token" {
+			switch scenario {
+			case "running":
+				assert.Equal(t, before.Endpoint().IsUnix(), after.Endpoint().IsUnix())
+			case "daemon token":
 				status, _, err := httpDoJSON(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/projects", nil)
 				require.NoError(t, err)
 				assert.Equal(t, http.StatusUnauthorized, status)
 				status, _, err = httpDoJSONHeaders(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/projects", nil, map[string]string{"Authorization": "Bearer fixture-token"})
 				require.NoError(t, err)
 				assert.Equal(t, http.StatusOK, status)
-			}
-			if scenario == "idle shutdown" {
+			case "idle shutdown":
 				// Observe the actual exit without sending requests that reset the idle timer.
 				require.Eventually(t, func() bool { return record().PID == 0 }, 20*time.Second, 50*time.Millisecond)
-			}
-			if scenario == "read-only TCP" {
-				assert.Equal(t, before.Address, after.Address)
+			case "read-only TCP":
+				assert.False(t, after.Endpoint().IsUnix())
 				// Anonymous read-only mode must survive the automatic restart.
 				status, _, err = httpDoJSON(t.Context(), httpClient, http.MethodPost, baseURL+"/api/v1/projects", map[string]string{"name": "example-project", "actor": "user-a"})
 				require.NoError(t, err)

--- a/cmd/kata/update_daemon_test.go
+++ b/cmd/kata/update_daemon_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/client"
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/daemon"
+	kitdaemon "go.kenn.io/kit/daemon"
+	"go.kenn.io/kit/selfupdate"
+)
+
+func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and runs isolated daemon binaries")
+	}
+	// Child daemons get only toolchain/OS variables and the test's Kata paths.
+	var childEnv []string
+	allowed := []string{"PATH", "HOME", "USERPROFILE", "SystemRoot", "SYSTEMROOT", "WINDIR", "TMPDIR", "TMP", "TEMP", "GOCACHE", "GOMODCACHE", "GOPATH", "GOROOT", "GOTOOLCHAIN"}
+	for _, key := range allowed {
+		if value, ok := os.LookupEnv(key); ok {
+			childEnv = append(childEnv, key+"="+value)
+		}
+	}
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if !slices.Contains(allowed, key) {
+			t.Setenv(key, "")
+		}
+	}
+	moduleDir, err := os.Getwd()
+	require.NoError(t, err)
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	binaries := make(map[string]string)
+	for _, version := range []string{"v0.1.0", "v0.2.0"} {
+		binary := filepath.Join(t.TempDir(), "kata")
+		if runtime.GOOS == "windows" {
+			binary += ".exe"
+		}
+		build := exec.CommandContext(t.Context(), "go", "build", "-tags", "kit_posthog_disabled", "-buildvcs=false", "-ldflags", "-X go.kenn.io/kata/internal/version.Version="+version, "-o", binary, "go.kenn.io/kata/cmd/kata") //nolint:gosec // test-owned executable and fixed build arguments
+		// Build inside the module, while runtime commands use a scratch workspace.
+		build.Dir = moduleDir
+		build.Env = childEnv
+		output, err := build.CombinedOutput()
+		require.NoError(t, err, "%s", output)
+		binaries[version] = binary
+	}
+	for _, scenario := range []string{"running", "stopped", "check only", "cancelled", "install failure", "restart failure", "read-only TCP"} {
+		t.Run(scenario, func(t *testing.T) {
+			resetFlags(t)
+			fake := &fakeUpdateClient{checkResults: []*selfupdate.Info{{CurrentVersion: "v0.1.0", LatestVersion: "v0.2.0"}}}
+			stubUpdateClient(t, fake)
+			home, err := config.KataHome()
+			require.NoError(t, err)
+			binary := filepath.Join(t.TempDir(), filepath.Base(binaries["v0.1.0"]))
+			require.NoError(t, selfupdate.InstallBinary(binaries["v0.1.0"], binary))
+			originalExecutable := updateExecutable
+			updateExecutable = func() (string, error) { return binary, nil }
+			t.Cleanup(func() { updateExecutable = originalExecutable })
+			env := append(append([]string(nil), childEnv...), "KATA_HOME="+home, "KATA_DB="+filepath.Join(home, "kata.db"), "KATA_WORKSPACE="+workspace, "KATA_AUTHOR=user-a")
+			ns, err := daemon.NewNamespace()
+			require.NoError(t, err)
+			record := func() kitdaemon.RuntimeRecord {
+				records, err := (kitdaemon.RuntimeStore{Dir: ns.DataDir}).List()
+				require.NoError(t, err)
+				for _, rec := range records {
+					if daemon.RuntimeProcessAlive(rec) {
+						return rec
+					}
+				}
+				return kitdaemon.RuntimeRecord{}
+			}
+			t.Cleanup(func() {
+				stop := exec.Command(binary, "daemon", "stop") //nolint:gosec // test-owned binary
+				stop.Env = env
+				output, err := stop.CombinedOutput()
+				assert.NoError(t, err, "%s", output)
+				require.Eventually(t, func() bool { return record().PID == 0 }, 10*time.Second, 20*time.Millisecond)
+			})
+			if scenario != "stopped" {
+				args := []string{"daemon", "start", "--foreground"}
+				if scenario == "read-only TCP" {
+					args = append(args, "--listen", "127.0.0.1:0", "--insecure-readonly")
+				}
+				process := exec.Command(binary, args...) //nolint:gosec // test-owned binary and fixed arguments
+				process.Env = env
+				process.Stderr = os.Stderr
+				require.NoError(t, process.Start())
+				exited := make(chan error, 1)
+				go func() { exited <- process.Wait() }()
+				t.Cleanup(func() {
+					_ = process.Process.Kill()
+					select {
+					case <-exited:
+					case <-time.After(10 * time.Second):
+						t.Error("original daemon did not exit")
+					}
+				})
+				require.Eventually(t, func() bool { return record().PID != 0 }, 10*time.Second, 20*time.Millisecond)
+			}
+			before := record()
+			fake.install = func() error {
+				if scenario == "install failure" {
+					return errors.New("download failed")
+				}
+				if err := selfupdate.InstallBinary(binaries["v0.2.0"], binary); err != nil {
+					return err
+				}
+				if scenario == "restart failure" {
+					return os.WriteFile(filepath.Join(home, "config.toml"), []byte("invalid = ["), 0600)
+				}
+				return nil
+			}
+			if scenario == "check only" || scenario == "cancelled" {
+				if scenario == "check only" {
+					_, _, err := executeRootCapture(t, t.Context(), "update", "--check")
+					require.NoError(t, err)
+				} else {
+					_, _, err := executeRootCaptureWithInput(t.Context(), t, "n\n", "update")
+					assert.Equal(t, kindConfirm, requireCLIError(t, err, ExitConfirm).Kind)
+				}
+				assert.Empty(t, fake.installed)
+				assert.Equal(t, before.PID, record().PID)
+				return
+			}
+			stdout, stderr, updateErr := executeRootCapture(t, t.Context(), "update", "--yes", "--json")
+			if scenario == "restart failure" {
+				require.Error(t, updateErr)
+				assert.Contains(t, updateErr.Error(), "installed")
+				assert.Contains(t, updateErr.Error(), "restart")
+				// Restore the fixture config so cleanup can discover and stop the daemon.
+				require.NoError(t, os.Remove(filepath.Join(home, "config.toml")))
+				assert.Equal(t, before.PID, record().PID)
+				return
+			}
+			if scenario == "install failure" {
+				require.Error(t, updateErr)
+				assert.Equal(t, before.PID, record().PID)
+				return
+			}
+			require.NoError(t, updateErr, "%s", stderr)
+			var result struct {
+				Installed bool `json:"installed"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+			assert.True(t, result.Installed)
+			after := record()
+			if scenario == "stopped" {
+				assert.Zero(t, after.PID)
+				return
+			}
+			require.NotEqual(t, before.PID, after.PID, "update must replace the running daemon")
+			assert.Equal(t, "v0.2.0", after.Version)
+			httpClient, baseURL := client.LocalHTTPClient(after.Endpoint().ConfigAddress())
+			status, _, err := httpDoJSON(t.Context(), httpClient, "GET", baseURL+"/api/v1/ping", nil)
+			require.NoError(t, err)
+			assert.Equal(t, 200, status)
+			if scenario == "read-only TCP" {
+				assert.Equal(t, before.Address, after.Address)
+				// Anonymous read-only mode must survive the automatic restart.
+				status, _, err = httpDoJSON(t.Context(), httpClient, http.MethodPost, baseURL+"/api/v1/projects", map[string]string{"name": "example-project", "actor": "user-a"})
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusUnauthorized, status)
+			}
+		})
+	}
+}

--- a/cmd/kata/update_daemon_test.go
+++ b/cmd/kata/update_daemon_test.go
@@ -59,7 +59,7 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 		require.NoError(t, err, "%s", output)
 		binaries[version] = binary
 	}
-	for _, scenario := range []string{"running", "stopped", "check only", "cancelled", "install failure", "restart failure", "read-only TCP", "unknown daemon mode"} {
+	for _, scenario := range []string{"running", "stopped", "check only", "cancelled", "install failure", "restart failure", "read-only TCP", "unknown daemon mode", "missing daemon token", "shared daemon token", "idle shutdown"} {
 		t.Run(scenario, func(t *testing.T) {
 			resetFlags(t)
 			fake := &fakeUpdateClient{checkResults: []*selfupdate.Info{{CurrentVersion: "v0.1.0", LatestVersion: "v0.2.0"}}}
@@ -72,6 +72,16 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 			updateExecutable = func() (string, error) { return binary, nil }
 			t.Cleanup(func() { updateExecutable = originalExecutable })
 			env := append(append([]string(nil), childEnv...), "KATA_HOME="+home, "KATA_DB="+filepath.Join(home, "kata.db"), "KATA_WORKSPACE="+workspace, "KATA_AUTHOR=user-a")
+			if scenario == "missing daemon token" || scenario == "shared daemon token" {
+				env = append(env, "KATA_AUTH_TOKEN=fixture-token")
+				if scenario == "shared daemon token" {
+					t.Setenv("KATA_AUTH_TOKEN", "fixture-token")
+				}
+			}
+			if scenario == "idle shutdown" {
+				// Neither the auto-start marker nor the timeout is in the updater's environment.
+				env = append(env, "KATA_AUTOSTART=1", "KATA_AUTOSTART_IDLE_TIMEOUT=10s")
+			}
 			ns, err := daemon.NewNamespace()
 			require.NoError(t, err)
 			record := func() kitdaemon.RuntimeRecord {
@@ -93,8 +103,11 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 			})
 			if scenario != "stopped" {
 				args := []string{"daemon", "start", "--foreground"}
-				if scenario == "read-only TCP" || scenario == "unknown daemon mode" {
+				switch scenario {
+				case "read-only TCP", "unknown daemon mode":
 					args = append(args, "--listen", "127.0.0.1:0", "--insecure-readonly")
+				case "missing daemon token", "shared daemon token":
+					args = append(args, "--listen", "127.0.0.1:0")
 				}
 				process := exec.Command(binary, args...) //nolint:gosec // test-owned binary and fixed arguments
 				process.Env = env
@@ -144,6 +157,21 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 				return
 			}
 			stdout, stderr, updateErr := executeRootCapture(t, t.Context(), "update", "--yes", "--json")
+			if scenario == "missing daemon token" {
+				require.Error(t, updateErr)
+				assert.Contains(t, updateErr.Error(), "installed")
+				assert.Contains(t, updateErr.Error(), "authentication")
+				assert.NotEmpty(t, fake.installed)
+				assert.Equal(t, before.PID, record().PID)
+				httpClient, baseURL := client.LocalHTTPClient(before.Endpoint().ConfigAddress())
+				status, _, err := httpDoJSON(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/projects", nil)
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusUnauthorized, status)
+				status, _, err = httpDoJSONHeaders(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/projects", nil, map[string]string{"Authorization": "Bearer fixture-token"})
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusOK, status)
+				return
+			}
 			if scenario == "unknown daemon mode" {
 				require.Error(t, updateErr)
 				assert.Contains(t, updateErr.Error(), "installed")
@@ -190,6 +218,18 @@ func TestUpdateInstall_DaemonLifecycle(t *testing.T) {
 			status, _, err := httpDoJSON(t.Context(), httpClient, "GET", baseURL+"/api/v1/ping", nil)
 			require.NoError(t, err)
 			assert.Equal(t, 200, status)
+			if scenario == "shared daemon token" {
+				status, _, err := httpDoJSON(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/projects", nil)
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusUnauthorized, status)
+				status, _, err = httpDoJSONHeaders(t.Context(), httpClient, http.MethodGet, baseURL+"/api/v1/projects", nil, map[string]string{"Authorization": "Bearer fixture-token"})
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusOK, status)
+			}
+			if scenario == "idle shutdown" {
+				// Observe the actual exit without sending requests that reset the idle timer.
+				require.Eventually(t, func() bool { return record().PID == 0 }, 20*time.Second, 50*time.Millisecond)
+			}
 			if scenario == "read-only TCP" {
 				assert.Equal(t, before.Address, after.Address)
 				// Anonymous read-only mode must survive the automatic restart.

--- a/cmd/kata/update_test.go
+++ b/cmd/kata/update_test.go
@@ -20,6 +20,7 @@ type fakeUpdateClient struct {
 	checkErr     error
 	installed    []*selfupdate.Info
 	installErr   error
+	install      func() error
 }
 
 func (f *fakeUpdateClient) Check(_ context.Context, opts selfupdate.CheckOptions) (*selfupdate.Info, error) {
@@ -37,11 +38,15 @@ func (f *fakeUpdateClient) Check(_ context.Context, opts selfupdate.CheckOptions
 
 func (f *fakeUpdateClient) Install(_ context.Context, info *selfupdate.Info, _ selfupdate.InstallOptions) error {
 	f.installed = append(f.installed, info)
+	if f.install != nil {
+		return f.install()
+	}
 	return f.installErr
 }
 
 func stubUpdateClient(t *testing.T, client updateClient) {
 	t.Helper()
+	setupKataEnv(t)
 	orig := newSelfUpdateClient
 	newSelfUpdateClient = func(string) (updateClient, error) {
 		return client, nil

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -86,6 +86,11 @@ with the daemon's original startup options. If an older daemon does not report
 its read-only mode, the update installs the binary but skips the restart and
 returns an error. Restart it manually, repeating `--listen` and
 `--insecure-readonly` if originally used.
+
+Automatic restart also requires the updater to have the daemon's authentication
+credentials, if needed. Run the update from the same environment or restart the
+daemon manually from its original environment. Auto-started daemons retain
+their effective idle-shutdown timeout.
 Reopen `kata ui` to use the replacement daemon's browser address.
 
 Package-managed installations keep

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -78,20 +78,18 @@ kata update
 ```
 
 `kata update` verifies the downloaded archive against `SHA256SUMS` before
-replacing the installed binary. After a successful install, it restarts a
-running local daemon with the new binary; a stopped daemon stays stopped.
-If restart fails, the command reports that the binary was installed and returns
-an error. Resolve the reported startup problem, then run `kata daemon restart`
-with the daemon's original startup options. If an older daemon does not report
-its read-only mode, the update installs the binary but skips the restart and
-returns an error. Restart it manually, repeating `--listen` and
-`--insecure-readonly` if originally used.
+replacing the installed binary. After a successful install, it asks a running
+local daemon to restart itself through the new binary. The daemon restarts
+with its own startup options and environment, so `--listen`,
+`--insecure-readonly`, authentication tokens, and the auto-start idle timeout
+carry over without the updater knowing them. A stopped daemon stays stopped.
+Reopen `kata ui` if the daemon used an ephemeral port, because the replacement
+binds a new one.
 
-Automatic restart also requires the updater to have the daemon's authentication
-credentials, if needed. Run the update from the same environment or restart the
-daemon manually from its original environment. Auto-started daemons retain
-their effective idle-shutdown timeout.
-Reopen `kata ui` to use the replacement daemon's browser address.
+If the daemon does not come back, or it predates automatic restart, the
+command reports that the binary was installed and returns an error. Resolve
+any reported startup problem, then run `kata daemon restart` with the daemon's
+original startup options.
 
 Package-managed installations keep
 `kata update --check`, but install-capable update forms direct you back to the

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -78,7 +78,13 @@ kata update
 ```
 
 `kata update` verifies the downloaded archive against `SHA256SUMS` before
-replacing the installed binary. Package-managed installations keep
+replacing the installed binary. After a successful install, it restarts a
+running local daemon with the new binary; a stopped daemon stays stopped.
+If restart fails, the command reports that the binary was installed and returns
+an error. Resolve the reported startup problem, then run `kata daemon restart`.
+Reopen `kata ui` to use the replacement daemon's browser address.
+
+Package-managed installations keep
 `kata update --check`, but install-capable update forms direct you back to the
 owning package manager. Packagers can read the complete
 [packaging contract](../development/packaging.md). Installing with `go install`

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -81,7 +81,11 @@ kata update
 replacing the installed binary. After a successful install, it restarts a
 running local daemon with the new binary; a stopped daemon stays stopped.
 If restart fails, the command reports that the binary was installed and returns
-an error. Resolve the reported startup problem, then run `kata daemon restart`.
+an error. Resolve the reported startup problem, then run `kata daemon restart`
+with the daemon's original startup options. If an older daemon does not report
+its read-only mode, the update installs the binary but skips the restart and
+returns an error. Restart it manually, repeating `--listen` and
+`--insecure-readonly` if originally used.
 Reopen `kata ui` to use the replacement daemon's browser address.
 
 Package-managed installations keep

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -86,7 +86,7 @@ carry over without the updater knowing them. A stopped daemon stays stopped.
 Reopen `kata ui` if the daemon used an ephemeral port, because the replacement
 binds a new one.
 
-If the daemon does not come back, or it predates automatic restart, the
+If the daemon does not come back, or it does not support automatic restart, the
 command reports that the binary was installed and returns an error. Resolve
 any reported startup problem, then run `kata daemon restart` with the daemon's
 original startup options.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -760,8 +760,13 @@ manager instead. Ordinary archives retain the self-installing update behavior.
 
 After installing an update, `kata update` restarts a running daemon in the
 current local Kata home and database namespace through the newly installed
-binary. It retains the running TCP listener and read-only mode. A stopped daemon
-stays stopped; update checks and failed installs do not restart it. Restart
+binary. It retains the running TCP listener, read-only mode, and effective
+auto-start idle timeout. Before restarting, it checks the running daemon's
+protected instance endpoint using the replacement's configured token. If that
+check fails, the binary is installed but the daemon stays running; the command
+returns an error so you can restart from the original daemon environment.
+
+A stopped daemon stays stopped; update checks and failed installs do not restart it. Restart
 output, including the new web UI address, goes to stderr so JSON and agent
 stdout remain a single update result. If restart fails, the command returns an
 error identifying the installed version and directs you to `kata daemon restart`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -758,6 +758,15 @@ and install-capable flag combinations fail with exit code 2 before constructing
 the update client; upgrade through Homebrew or the owning system package
 manager instead. Ordinary archives retain the self-installing update behavior.
 
+After installing an update, `kata update` restarts a running daemon in the
+current local Kata home and database namespace through the newly installed
+binary. It retains the running TCP listener and read-only mode. A stopped daemon
+stays stopped; update checks and failed installs do not restart it. Restart
+output, including the new web UI address, goes to stderr so JSON and agent
+stdout remain a single update result. If restart fails, the command returns an
+error identifying the installed version and directs you to `kata daemon restart`.
+Remote daemons must be updated on their own hosts.
+
 Local commands auto-start the daemon when appropriate. `daemon start` starts a
 background daemon and returns after startup is confirmed. If the running local
 daemon was auto-started with `autostart_idle_timeout` in effect, `daemon start`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -770,7 +770,7 @@ ephemeral `--listen` port binds a new port.
 A stopped daemon stays stopped; update checks and failed installs do not
 restart it. Restart output, including the new web UI address, goes to stderr
 so JSON and agent stdout remain a single update result. If the replacement
-fails to start, or the running daemon predates automatic restart, the command
+fails to start, or the running daemon does not support automatic restart, the command
 returns an error identifying the installed version and directs you to
 `kata daemon restart` with the daemon's original startup options. Remote
 daemons must be updated on their own hosts.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -758,23 +758,22 @@ and install-capable flag combinations fail with exit code 2 before constructing
 the update client; upgrade through Homebrew or the owning system package
 manager instead. Ordinary archives retain the self-installing update behavior.
 
-After installing an update, `kata update` restarts a running daemon in the
-current local Kata home and database namespace through the newly installed
-binary. It retains the running TCP listener, read-only mode, and effective
-auto-start idle timeout. Before restarting, it checks the running daemon's
-protected instance endpoint using the replacement's configured token. If that
-check fails, the binary is installed but the daemon stays running; the command
-returns an error so you can restart from the original daemon environment.
+After installing an update, `kata update` signals a running daemon in the
+current local Kata home and database namespace to restart itself through the
+newly installed binary. The daemon re-executes with its own arguments and
+environment, so its listener, read-only mode, credentials, and effective
+auto-start idle timeout carry over, and the updater needs no daemon token. On
+Unix the daemon keeps its PID, so service managers see the same process; on
+Windows it starts a detached replacement and exits. A daemon started with an
+ephemeral `--listen` port binds a new port.
 
-A stopped daemon stays stopped; update checks and failed installs do not restart it. Restart
-output, including the new web UI address, goes to stderr so JSON and agent
-stdout remain a single update result. If restart fails, the command returns an
-error identifying the installed version and directs you to `kata daemon restart`.
-If the running daemon does not report its read-only mode, installation still
-proceeds, but the daemon stays running and the command returns an error explaining
-that automatic restart was skipped. Restart it manually with its original
-startup options, including `--listen` and `--insecure-readonly` if used.
-Remote daemons must be updated on their own hosts.
+A stopped daemon stays stopped; update checks and failed installs do not
+restart it. Restart output, including the new web UI address, goes to stderr
+so JSON and agent stdout remain a single update result. If the replacement
+fails to start, or the running daemon predates automatic restart, the command
+returns an error identifying the installed version and directs you to
+`kata daemon restart` with the daemon's original startup options. Remote
+daemons must be updated on their own hosts.
 
 Local commands auto-start the daemon when appropriate. `daemon start` starts a
 background daemon and returns after startup is confirmed. If the running local

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -765,6 +765,10 @@ stays stopped; update checks and failed installs do not restart it. Restart
 output, including the new web UI address, goes to stderr so JSON and agent
 stdout remain a single update result. If restart fails, the command returns an
 error identifying the installed version and directs you to `kata daemon restart`.
+If the running daemon does not report its read-only mode, installation still
+proceeds, but the daemon stays running and the command returns an error explaining
+that automatic restart was skipped. Restart it manually with its original
+startup options, including `--listen` and `--insecure-readonly` if used.
 Remote daemons must be updated on their own hosts.
 
 Local commands auto-start the daemon when appropriate. `daemon start` starts a

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -2,6 +2,12 @@ package daemon
 
 import kitdaemon "go.kenn.io/kit/daemon"
 
+// RuntimeRestartMetadataKey marks a runtime record whose daemon re-executes
+// itself, with its own arguments and environment, when it receives the
+// restart signal. Records without it belong to daemons that need a manual
+// restart after an update.
+const RuntimeRestartMetadataKey = "restart_signal"
+
 // RuntimeProcessAlive reports whether a runtime record still identifies the
 // process that created it. Records without a verifiable identity retain the
 // legacy PID-only behavior; a definite identity mismatch is stale.
@@ -10,4 +16,10 @@ func RuntimeProcessAlive(record kitdaemon.RuntimeRecord) bool {
 		return false
 	}
 	return kitdaemon.CompareRuntimeProcessIdentity(record) != kitdaemon.ProcessIdentityMismatch
+}
+
+// RuntimeRecordRestartable reports whether the record's daemon handles the
+// restart signal sent by SignalDaemonRestart.
+func RuntimeRecordRestartable(record kitdaemon.RuntimeRecord) bool {
+	return record.Metadata[RuntimeRestartMetadataKey] == "1"
 }

--- a/internal/daemon/signal_unix.go
+++ b/internal/daemon/signal_unix.go
@@ -27,3 +27,14 @@ func SignalDaemonReload(rec kitdaemon.RuntimeRecord, _ string) error {
 	}
 	return p.Signal(syscall.SIGHUP)
 }
+
+// SignalDaemonRestart asks a running daemon to re-execute itself with its own
+// arguments and environment. Only send it to records that advertise
+// RuntimeRestartMetadataKey: SIGUSR1 terminates older daemons.
+func SignalDaemonRestart(rec kitdaemon.RuntimeRecord, _ string) error {
+	p, err := os.FindProcess(rec.PID)
+	if err != nil {
+		return fmt.Errorf("find pid %d: %w", rec.PID, err)
+	}
+	return p.Signal(syscall.SIGUSR1)
+}

--- a/internal/daemon/signal_windows.go
+++ b/internal/daemon/signal_windows.go
@@ -21,6 +21,12 @@ func ReloadEventName(dbhash string, pid int) string {
 	return fmt.Sprintf(`Local\kata-reload-%s-%d`, dbhash, pid)
 }
 
+// RestartEventName is the named-event endpoint a Windows daemon creates so
+// another kata process can request that it re-execute itself.
+func RestartEventName(dbhash string, pid int) string {
+	return fmt.Sprintf(`Local\kata-restart-%s-%d`, dbhash, pid)
+}
+
 // SignalDaemonStop asks a running daemon to shut down gracefully.
 func SignalDaemonStop(rec kitdaemon.RuntimeRecord, dbhash string) error {
 	return setNamedEvent(StopEventName(dbhash, rec.PID))
@@ -29,6 +35,12 @@ func SignalDaemonStop(rec kitdaemon.RuntimeRecord, dbhash string) error {
 // SignalDaemonReload asks a running daemon to reload hook configuration.
 func SignalDaemonReload(rec kitdaemon.RuntimeRecord, dbhash string) error {
 	return setNamedEvent(ReloadEventName(dbhash, rec.PID))
+}
+
+// SignalDaemonRestart asks a running daemon to start a replacement with its
+// own arguments and environment, then exit.
+func SignalDaemonRestart(rec kitdaemon.RuntimeRecord, dbhash string) error {
+	return setNamedEvent(RestartEventName(dbhash, rec.PID))
 }
 
 func setNamedEvent(name string) error {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": ["web", "packages/*"],
   "packageManager": "bun@1.3.14",
   "overrides": {
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "nanoid": "3.3.18"
   }
 }


### PR DESCRIPTION
`kata update` replaced the CLI binary but left a running daemon serving the old code and web UI, even after reporting success. It now asks that daemon to restart itself through the newly installed binary.

The updater does not know how the daemon was started. Its listener, read-only mode, token, auto-start marker, and idle timeout live in the daemon's own arguments and environment, and rebuilding them from runtime records and health responses gets one of them wrong in some configuration: a Unix-socket daemon can come back on a hosted `PORT`, or an auto-started daemon can lose its marker. So the updater only sends a restart signal (SIGUSR1 on Unix, a named event on Windows), and the daemon re-executes itself once it has released its listeners and runtime record. Transport, mode, credentials, and idle shutdown carry over because nothing is reconstructed. On Unix the process image is replaced in place, so the PID and any service-manager attachment stay the same. Windows cannot replace a process image, so the daemon starts a detached replacement and exits. The updater waits for a live runtime record newer than the one it observed, then prints the replacement's address and web UI URL to stderr so JSON and agent stdout remain a single update record.

Daemons advertise the signal in their runtime record. The updater refuses to signal a record without it, because SIGUSR1 would kill an older daemon; it installs the binary and reports a manual `kata daemon restart` instead. A stopped daemon stays stopped. If the replacement fails to start, for example because the new binary rejects the config, the daemon is down and the command returns an error naming the installed version. An auto-started daemon comes back on the next CLI call. A daemon started with an ephemeral `--listen` port binds a new port.

Risk concentrates in two places: the re-exec after shutdown in `cmd/kata/daemon_restart.go` and its platform files, and the replacement wait in `cmd/kata/update.go`, which keys on the record's start time because the Unix PID does not change.

Related to #345; this fixes the confirmed updater bug, while the reporter's running daemon version remains unconfirmed.
