### PR TITLE
Remove the graceful hook drain test deadline

### DIFF
--- a/internal/hooks/dispatcher_test.go
+++ b/internal/hooks/dispatcher_test.go
@@ -302,10 +302,9 @@ func TestDispatcher_Shutdown_DrainsQueued(t *testing.T) {
 		return activity.NewLease(func() { released.Add(1) }, nil), true
 	}
 	enqueueEvents(d, "issue.created", 400, 5)
-	time.Sleep(50 * time.Millisecond) // worker has popped one
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := d.Shutdown(ctx); err != nil {
+	// Exercise graceful draining without a deadline that can force queued jobs
+	// to be dropped on slow runners. Deadline cancellation is tested separately.
+	if err := d.Shutdown(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	lines := countJSONLLines(runsPath)


### PR DESCRIPTION
Fixes the Windows flake in `TestDispatcher_Shutdown_DrainsQueued`, where only four of five accepted hooks were recorded. Its two-second shutdown deadline starts cancelling work after 1.5 seconds, allowing queued hooks to be dropped on a slow runner.

Uses the test context without a shutdown deadline and removes the startup sleep, while retaining the run-count and lease-release assertions. The separate deadline-cancellation test still covers forced shutdown. Slowing the helper hooks reproduced the four-of-five failure before this change and drained all five afterward.
