### PR TITLE
Document the qualified-id form in destructive confirm help

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
   },
   "overrides": {
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "nanoid": "3.3.18",
   },
   "packages": {
@@ -606,7 +606,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
+    "js-yaml": ["js-yaml@4.3.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 

--- a/cmd/kata/delete.go
+++ b/cmd/kata/delete.go
@@ -59,7 +59,7 @@ func newDeleteCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "required to perform the soft delete")
-	cmd.Flags().StringVar(&confirm, "confirm", "", `exact confirmation string ("DELETE <short_id>")`)
+	cmd.Flags().StringVar(&confirm, "confirm", "", `exact confirmation string ("DELETE <qualified-id>")`)
 	return cmd
 }
 

--- a/cmd/kata/purge.go
+++ b/cmd/kata/purge.go
@@ -52,7 +52,7 @@ func newPurgeCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "required to perform the purge")
-	cmd.Flags().StringVar(&confirm, "confirm", "", `exact confirmation string ("PURGE <short_id>")`)
+	cmd.Flags().StringVar(&confirm, "confirm", "", `exact confirmation string ("PURGE <qualified-id>")`)
 	cmd.Flags().StringVar(&reason, "reason", "", "free-text reason recorded in purge_log.reason")
 	return cmd
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": ["web", "packages/*"],
   "packageManager": "bun@1.3.14",
   "overrides": {
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "nanoid": "3.3.18"
   }
 }


### PR DESCRIPTION
`--confirm`'s help promises a bare short id, but `validateConfirm` builds `<verb> <project>#<short_id>`, so the documented value is always rejected:

```
$ kata purge v07w --force --confirm "PURGE v07w"
kata: X-Kata-Confirm header value does not match
```

`docs/reference/cli.md` already specifies `<qualified-id>`; this aligns the flag text with it.
