### PR TITLE
Stack the issue editor heading when the pane is narrow

### DIFF
--- a/web/src/components/IssueEditor.svelte
+++ b/web/src/components/IssueEditor.svelte
@@ -558,6 +558,8 @@
     overflow: auto;
     background: var(--bg-primary);
     padding: 18px 22px;
+    container-type: inline-size;
+    container-name: kata-detail;
   }
 
   .mutation-controls {
@@ -832,5 +834,16 @@
   .accent-button:disabled {
     cursor: default;
     opacity: 0.62;
+  }
+
+  /* Stack the title above the action row once the pane is narrow. The actions
+     never shrink, so in a row the title absorbs the whole squeeze and wraps a
+     word at a time. Keyed to the pane rather than the viewport because the
+     detail pane is a resizable SplitLayout secondary and can be dragged narrow
+     while the window is still wide. */
+  @container kata-detail (max-width: 640px) {
+    .detail-heading {
+      display: grid;
+    }
   }
 </style>


### PR DESCRIPTION
Editing an issue on a narrow pane squashes the title: `.detail-heading` is a row, `.detail-actions` is `flex: 0 0 auto` with a `nowrap` timestamp, so `.detail-heading-main` absorbs the whole squeeze and the title wraps a word at a time.

Stacking the title above the actions below 640px fixes it. Keyed to the pane, not the viewport, because the detail pane is a resizable `SplitLayout` secondary (`minSecondary: 220`) and can be dragged narrow while the window is still wide — a `@media` query never fires there. Same reasoning as the `@container list` rules in `IssueCollection.svelte`.

The read-only view already handles this (`packages/kata-ui/src/IssueDetail.svelte` stacks `.detail-header` at 640px); the editor had no width handling at all.

No change above 640px.

### Current

<img width="355" height="875" alt="before" src="https://github.com/user-attachments/assets/e9a90ddf-fbf4-41b5-bea7-31e5bad3e76e" />

### With change

<img width="355" height="875" alt="after" src="https://github.com/user-attachments/assets/f10f6386-9ea2-43ce-a91f-8f96b1f0eeff" />

