### PR TITLE
Show existing issue refs in create conflict errors

### DIFF
--- a/cmd/kata/create_test.go
+++ b/cmd/kata/create_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -361,6 +362,77 @@ func TestCreate_AgentOutputIdempotencyReuse(t *testing.T) {
 	second := runCLI(t, env, dir, "--agent", "create", "first issue", "--idempotency-key", "K")
 
 	assert.Contains(t, second, "reused=true changed=false")
+}
+
+func TestCreate_ConflictReportsExistingIssues(t *testing.T) {
+	for _, conflict := range []string{"idempotency_mismatch", "duplicate_candidates", "multiple_candidates"} {
+		t.Run(conflict, func(t *testing.T) {
+			env := testenv.New(t)
+			dir, _ := initLocalBoundWorkspace(t, env, "example-project")
+			ctx := contextWithBaseURL(t.Context(), env.URL)
+			first := runCLI(t, env, dir, "--json", "--as", "test-agent", "create",
+				"fix login crash", "--body", "login crashes on startup", "--idempotency-key", "request-1")
+			var created struct {
+				Issue struct {
+					UID     string `json:"uid"`
+					ShortID string `json:"short_id"`
+				} `json:"issue"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(first), &created))
+			refs := []string{"example-project#" + created.Issue.ShortID}
+			args := []string{"--workspace", dir, "--as", "test-agent", "create", "fix login crash", "--body", "login crashes on startup"}
+			code := "duplicate_candidates"
+			if conflict == "idempotency_mismatch" {
+				code = conflict
+				args = append(args, "--idempotency-key", "request-1", "--owner", "another-agent")
+			}
+			if conflict == "multiple_candidates" {
+				second := runCLI(t, env, dir, "--quiet", "--as", "test-agent", "create",
+					"fix login crash", "--body", "login crashes on startup", "--force-new")
+				refs = append(refs, "example-project#"+strings.TrimSpace(second))
+			}
+			for _, mode := range []string{"agent", "json"} {
+				t.Run(mode, func(t *testing.T) {
+					stdout, stderr, err := executeRootCapture(t, ctx, append(args, "--"+mode)...)
+					cli := requireCLIError(t, err, ExitConflict)
+					assert.Equal(t, code, cli.Code)
+					assert.Empty(t, stdout)
+					if mode == "agent" {
+						assert.True(t, strings.HasPrefix(stderr, "ERR create conflict: "), stderr)
+						for _, ref := range refs {
+							assert.Contains(t, stderr, ref)
+						}
+						assert.Equal(t, 1, strings.Count(stderr, "\n"))
+						return
+					}
+					var envelope struct {
+						Error struct {
+							Data map[string]any `json:"data"`
+						} `json:"error"`
+					}
+					require.NoError(t, json.Unmarshal([]byte(stderr), &envelope))
+					require.NotEmpty(t, envelope.Error.Data, stderr)
+					if code == "idempotency_mismatch" {
+						assert.Equal(t, created.Issue.UID, envelope.Error.Data["uid"])
+						assert.Equal(t, created.Issue.ShortID, envelope.Error.Data["short_id"])
+						assert.Equal(t, refs[0], envelope.Error.Data["qualified_id"])
+						return
+					}
+					candidates := envelope.Error.Data["candidates"].([]any)
+					var gotRefs []string
+					for _, candidate := range candidates {
+						data := candidate.(map[string]any)
+						assert.NotEmpty(t, data["uid"])
+						assert.NotEmpty(t, data["short_id"])
+						assert.Equal(t, "fix login crash", data["title"])
+						assert.GreaterOrEqual(t, data["score"].(float64), 0.7)
+						gotRefs = append(gotRefs, data["qualified_id"].(string))
+					}
+					assert.ElementsMatch(t, refs, gotRefs)
+				})
+			}
+		})
+	}
 }
 
 // TestCreate_IdempotentReuseHumanModeOmitsLinksSummary pins that a

--- a/cmd/kata/init.go
+++ b/cmd/kata/init.go
@@ -52,6 +52,7 @@ type cliError struct {
 	Kind     errKind
 	Code     string
 	ExitCode int
+	Data     json.RawMessage
 }
 
 func (e *cliError) Error() string { return e.Message }
@@ -564,8 +565,9 @@ func resolveStartPath(workspace string) (string, error) {
 func apiErrFromBody(status int, bs []byte) *cliError {
 	var env struct {
 		Error struct {
-			Code    string `json:"code"`
-			Message string `json:"message"`
+			Code    string          `json:"code"`
+			Message string          `json:"message"`
+			Data    json.RawMessage `json:"data,omitempty"`
 		} `json:"error"`
 	}
 	if err := json.Unmarshal(bs, &env); err != nil {
@@ -581,6 +583,7 @@ func apiErrFromBody(status int, bs []byte) *cliError {
 		Code:     env.Error.Code,
 		Kind:     kindForStatus(status),
 		ExitCode: mapStatusToExit(status, env.Error.Code),
+		Data:     env.Error.Data,
 	}
 }
 

--- a/cmd/kata/main.go
+++ b/cmd/kata/main.go
@@ -253,16 +253,18 @@ func emitJSONError(w io.Writer, err error, runEReached bool) {
 	cli := cliErrorForErr(err, runEReached)
 	env := struct {
 		Error struct {
-			Kind     errKind `json:"kind"`
-			Code     string  `json:"code,omitempty"`
-			Message  string  `json:"message"`
-			ExitCode int     `json:"exit_code"`
+			Kind     errKind         `json:"kind"`
+			Code     string          `json:"code,omitempty"`
+			Message  string          `json:"message"`
+			ExitCode int             `json:"exit_code"`
+			Data     json.RawMessage `json:"data,omitempty"`
 		} `json:"error"`
 	}{}
 	env.Error.Kind = cli.Kind
 	env.Error.Code = cli.Code
 	env.Error.Message = cli.Message
 	env.Error.ExitCode = cli.ExitCode
+	env.Error.Data = cli.Data
 	bs, mErr := json.Marshal(env)
 	if mErr == nil {
 		_, _ = fmt.Fprintln(w, string(bs))

--- a/cmd/kata/output_mode.go
+++ b/cmd/kata/output_mode.go
@@ -367,7 +367,31 @@ func emitAgentError(w io.Writer, command string, err error) {
 	if command == "" {
 		command = "kata"
 	}
-	_, _ = fmt.Fprintf(w, "ERR %s %s: %s\n", command, cli.Kind, firstLine(cli.Message)) //nolint:gosec // G705: CLI stderr error text, not HTML.
+	message := firstLine(cli.Message)
+	switch cli.Code {
+	case "idempotency_mismatch", "idempotency_deleted", "duplicate_candidates":
+		var data struct {
+			QualifiedID string `json:"qualified_id"`
+			Candidates  []struct {
+				QualifiedID string `json:"qualified_id"`
+			} `json:"candidates"`
+		}
+		if json.Unmarshal(cli.Data, &data) == nil {
+			var refs []string
+			if data.QualifiedID != "" {
+				refs = append(refs, agentValue(data.QualifiedID))
+			}
+			for _, candidate := range data.Candidates {
+				if candidate.QualifiedID != "" {
+					refs = append(refs, agentValue(candidate.QualifiedID))
+				}
+			}
+			if len(refs) > 0 {
+				message += " (" + strings.Join(refs, ", ") + ")"
+			}
+		}
+	}
+	_, _ = fmt.Fprintf(w, "ERR %s %s: %s\n", command, cli.Kind, message) //nolint:gosec // G705: CLI stderr error text, not HTML.
 }
 
 func agentValue(s string) string {

--- a/cmd/kata/wait_test.go
+++ b/cmd/kata/wait_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -594,6 +595,7 @@ func TestWaitParentDeadlineDuringResolutionIsNotWaitTimeout(t *testing.T) {
 // fetch (with no --timeout to bound it) hangs even though the wait is already
 // met.
 func TestWaitAnyInitialPassStopsAfterJoinMet(t *testing.T) {
+	var laterFetches atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/api/v1/projects/resolve":
@@ -601,12 +603,7 @@ func TestWaitAnyInitialPassStopsAfterJoinMet(t *testing.T) {
 		case strings.HasSuffix(r.URL.Path, "/issues/aaaa"):
 			_, _ = w.Write([]byte(`{"issue":{"short_id":"aaaa","status":"closed","metadata":{},"revision":1}}`))
 		case strings.HasSuffix(r.URL.Path, "/issues/bbbb"):
-			// A stalled later ref: it must never be fetched once aaaa has
-			// already satisfied the --any join.
-			select {
-			case <-r.Context().Done():
-			case <-time.After(5 * time.Second):
-			}
+			laterFetches.Add(1)
 			_, _ = w.Write([]byte(`{"issue":{"short_id":"bbbb","status":"open","metadata":{},"revision":1}}`))
 		default:
 			http.NotFound(w, r)
@@ -615,15 +612,13 @@ func TestWaitAnyInitialPassStopsAfterJoinMet(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	resetFlags(t)
-	start := time.Now()
 	stdout, _, err := executeRootCapture(t, contextWithBaseURL(context.Background(), srv.URL),
 		"wait", "kata#aaaa", "kata#bbbb", "--any", "--poll-interval", "50ms")
-	elapsed := time.Since(start)
 
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "aaaa")
-	assert.Less(t, elapsed, 2*time.Second,
-		"--any must stop the initial pass once the join is met, not block on a stalled later ref")
+	assert.Zero(t, laterFetches.Load(),
+		"--any must stop fetching once the initial pass satisfies the join")
 }
 
 func TestWaitBadRefFailsFast(t *testing.T) {

--- a/docs/reference/agent-output.md
+++ b/docs/reference/agent-output.md
@@ -73,13 +73,17 @@ Hint: pass --body, --body-file, or --body-stdin
 ```
 
 - The first line is `ERR <command> <kind>: <message>`.
+- Create idempotency and look-alike conflicts append the existing issues'
+  qualified refs, for example
+  `ERR create conflict: 1 existing issue matches this title (example-project#abc4)`.
 - `<kind>` reuses the CLI error taxonomy: `usage`, `validation`, `not_found`,
   `conflict`, `confirm`, `daemon_unavailable`, `internal`.
 - Optional follow-up lines use fixed field names such as `Hint:`, `Code:`, and
   `Exit-Code:`.
 - A top-level parse error, before any subcommand runs, uses `kata` as the
   command token: `ERR kata usage: unknown command "cretae"`.
-- In `--format json` errors remain the JSON error envelope; in `--format human`
+- In `--format json` errors include daemon-provided details in `error.data`
+  when present; in `--format human`
   they remain the existing human text.
 
 ## Success shapes

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -147,6 +147,18 @@ off before it completes, the CLI reports `create_outcome_unknown`: check whether
 the issue exists before retrying, and use `--force-new` only after confirming
 that no issue was created.
 
+Create conflicts identify existing issues. With `--json`, `error.data` carries
+the prior issue's `uid`, `short_id`, and `qualified_id` for an idempotency
+conflict, or a `candidates` list with those fields, titles, and similarity
+scores for a look-alike conflict. With `--agent`, the error line includes the
+qualified refs.
+
+These conflicts come from duplicate prevention. Reusing an idempotency key
+within seven days with the same request fields returns the original issue;
+changing those fields returns `idempotency_mismatch`. The look-alike check
+compares title and body text. Neither conflict means that generated issue
+ULIDs collided.
+
 List and inspect:
 
 ```sh

--- a/internal/daemon/federation_replica_service_test.go
+++ b/internal/daemon/federation_replica_service_test.go
@@ -2406,7 +2406,8 @@ func openReplicaServiceStore(t *testing.T) *sqlitestore.Store {
 	ctx := context.Background()
 	store, err := sqlitestore.Open(ctx, filepath.Join(t.TempDir(), "kata.db"))
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	// This fixture is discarded after the test; it needs no WAL checkpoint.
+	t.Cleanup(func() { require.NoError(t, store.DB.Close()) })
 	return store
 }
 

--- a/internal/daemon/handlers_issues.go
+++ b/internal/daemon/handlers_issues.go
@@ -80,7 +80,8 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 		if err != nil {
 			return nil, err
 		}
-		if _, err := activeProjectByID(ctx, cfg.DB, in.ProjectID); err != nil {
+		project, err := activeProjectByID(ctx, cfg.DB, in.ProjectID)
+		if err != nil {
 			return nil, err
 		}
 
@@ -148,7 +149,7 @@ func registerIssuesHandlers(humaAPI huma.API, cfg ServerConfig) {
 			return nil, err
 		}
 		if !in.Body.ForceNew {
-			if err := runLookalikeCheck(ctx, cfg, in); err != nil {
+			if err := runLookalikeCheck(ctx, cfg, in, project.Name); err != nil {
 				return nil, err
 			}
 		}
@@ -1327,7 +1328,7 @@ func tryIdempotencyMatch(ctx context.Context, cfg ServerConfig, in *api.CreateIs
 // above the 0.7 threshold. nil means proceed. The OR variant is required
 // because near-duplicates that differ by even one token would be filtered
 // out by SearchFTS's implicit-AND before similarity scoring runs.
-func runLookalikeCheck(ctx context.Context, cfg ServerConfig, in *api.CreateIssueRequest) error {
+func runLookalikeCheck(ctx context.Context, cfg ServerConfig, in *api.CreateIssueRequest, projectName string) error {
 	q := similarity.LookalikeQuery(in.Body.Title, in.Body.Body)
 	candidates, err := cfg.DB.SearchFTSAny(ctx, db.SearchFTSParams{
 		ProjectID: in.ProjectID, Query: q, Limit: 20,
@@ -1340,10 +1341,11 @@ func runLookalikeCheck(ctx context.Context, cfg ServerConfig, in *api.CreateIssu
 		score := similarity.Score(in.Body.Title, in.Body.Body, c.Issue.Title, c.Issue.Body)
 		if score >= similarityThreshold {
 			matched = append(matched, map[string]any{
-				"uid":      c.Issue.UID,
-				"short_id": c.Issue.ShortID,
-				"title":    c.Issue.Title,
-				"score":    score,
+				"uid":          c.Issue.UID,
+				"short_id":     c.Issue.ShortID,
+				"qualified_id": qualifiedID(projectName, c.Issue.ShortID),
+				"title":        c.Issue.Title,
+				"score":        score,
 			})
 		}
 	}

--- a/internal/daemon/handlers_issues_internal_test.go
+++ b/internal/daemon/handlers_issues_internal_test.go
@@ -28,7 +28,7 @@ func TestRunLookalikeCheckBoundsSearchQuery(t *testing.T) {
 	in.Body.Title = "full issue title"
 	in.Body.Body = strings.Repeat("界", 499) + "留 discard-this-suffix"
 
-	err := runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in)
+	err := runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in, "example-project")
 
 	require.NoError(t, err)
 	assert.Contains(t, store.query, in.Body.Title)
@@ -40,7 +40,7 @@ func TestRunLookalikeCheckBoundsSearchQuery(t *testing.T) {
 	in.Body.Title = strings.Repeat("界", 499) + "留 discarded-title-suffix"
 	in.Body.Body = "plain body"
 
-	err = runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in)
+	err = runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in, "example-project")
 
 	require.NoError(t, err)
 	assert.Contains(t, store.query, "plain body")
@@ -84,7 +84,7 @@ func TestRunLookalikeCheckConflictMessageCountsClosedCandidates(t *testing.T) {
 			closedLookalike(title, body, "01J5EXAMPLE000000000000EXA"),
 		}}
 
-		err := runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in)
+		err := runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in, "example-project")
 
 		require.Error(t, err)
 		var apiErr *api.APIError
@@ -101,7 +101,7 @@ func TestRunLookalikeCheckConflictMessageCountsClosedCandidates(t *testing.T) {
 			closedLookalike(title, body, "01J5EXAMPLE000000000000EXB"),
 		}}
 
-		err := runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in)
+		err := runLookalikeCheck(context.Background(), ServerConfig{DB: store}, in, "example-project")
 
 		require.Error(t, err)
 		var apiErr *api.APIError


### PR DESCRIPTION
Create conflicts now identify the existing issues, so agents can report their refs without another search. The CLI preserves daemon error details in JSON `error.data` and appends qualified refs to agent error lines, including all look-alike candidates.

Also addresses the two CI failures: the wait test now checks that later issues are not fetched after `--any` is satisfied, instead of timing the whole command. Replica service fixtures close their disposable database pools without requiring a WAL checkpoint during cleanup.

The affected tests and lint pass. A delayed first response reproduces the old wait-test failure while the revised test passes; deliberately fetching the later issue still fails the revised assertion. The full local short suite encountered Unix socket setup, inherited network-trust configuration, and mise trust failures.

Fixes #357.
