### PR TITLE
feat(mcp): expose running HTTP listeners through status

### DIFF
--- a/cmd/kata/mcp.go
+++ b/cmd/kata/mcp.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/kata/internal/client"
 	"go.kenn.io/kata/internal/config"
 	"go.kenn.io/kata/internal/daemon"
 	mcpserver "go.kenn.io/kata/internal/mcp"
@@ -25,11 +27,12 @@ func newMCPCmd() *cobra.Command {
 		Use:   "mcp",
 		Short: "serve Kata tools through Model Context Protocol",
 	}
-	command.AddCommand(newMCPServeCmd())
+	command.AddCommand(newMCPServeCmd(), newMCPStatusCmd())
 	return command
 }
 
 func newMCPServeCmd() *cobra.Command {
+	var runtimeDirectory string
 	var allProjects bool
 	var projects []string
 	var storageRoot string
@@ -82,13 +85,14 @@ func newMCPServeCmd() *cobra.Command {
 				}
 				defer func() { _ = storage.Close() }()
 			}
-			baseURL, err := ensureDaemon(ctx)
+			resolved, err := resolveMCPRuntime(ctx, runtimeDirectory)
 			if err != nil {
 				return err
 			}
+			baseURL := resolved.BaseURL
 			// Ordinary daemon calls retain the CLI request timeout so a
 			// stalled daemon cannot consume every MCP tool-call slot.
-			httpClient, err := httpClientFor(ctx, baseURL)
+			httpClient, err := httpClientForResolved(ctx, resolved)
 			if err != nil {
 				return err
 			}
@@ -108,7 +112,7 @@ func newMCPServeCmd() *cobra.Command {
 			// Sync passes, bounded waits, and SSE streams use their own
 			// request contexts and may legitimately outlive the ordinary
 			// request budget or delay response headers until completion.
-			longRunningHTTPClient, err := longRunningClientFor(ctx, baseURL)
+			longRunningHTTPClient, err := longRunningClientForResolved(ctx, resolved)
 			if err != nil {
 				return err
 			}
@@ -156,7 +160,15 @@ func newMCPServeCmd() *cobra.Command {
 				return err
 			}
 			if strings.TrimSpace(httpAddress) != "" {
-				return serveMCPHTTP(ctx, command.ErrOrStderr(), httpAddress, httpToken, server)
+				home, err := config.KataHome()
+				if err != nil {
+					return err
+				}
+				backendURL := baseURL
+				if resolved.Network == "unix" {
+					backendURL = "unix://" + resolved.UnixSocket
+				}
+				return serveMCPHTTP(ctx, command.ErrOrStderr(), httpAddress, httpToken, server, filepath.Join(home, "mcp"), backendURL)
 			}
 			transport := mcpserver.NewStdioTransport(
 				asReadCloser(command.InOrStdin()),
@@ -172,6 +184,7 @@ func newMCPServeCmd() *cobra.Command {
 			return err
 		},
 	}
+	command.Flags().StringVar(&runtimeDirectory, "runtime-dir", "", "use an existing daemon runtime directory without starting a daemon")
 	command.Flags().BoolVar(&allProjects, "all-projects", false, "serve every project visible to the selected daemon")
 	command.Flags().StringSliceVar(&projects, "projects", nil, "serve only these project names")
 	command.Flags().StringVar(&storageRoot, "storage-root", "", "enable host-local JSONL artifacts under this directory")
@@ -262,4 +275,20 @@ func asReadCloser(reader io.Reader) io.ReadCloser {
 		return readCloser
 	}
 	return io.NopCloser(reader)
+}
+
+// resolveMCPRuntime lets an embedding client pin the daemon it has already
+// discovered, including a Unix socket behind a separate browser listener.
+func resolveMCPRuntime(ctx context.Context, directory string) (client.ResolvedDaemon, error) {
+	if directory == "" {
+		return ensureDaemonResolved(ctx)
+	}
+	resolved, found, err := client.DiscoverResolved(ctx, directory)
+	if err != nil {
+		return client.ResolvedDaemon{}, err
+	}
+	if !found {
+		return client.ResolvedDaemon{}, fmt.Errorf("no running daemon in runtime directory %q", directory)
+	}
+	return resolved, nil
 }

--- a/cmd/kata/mcp_http.go
+++ b/cmd/kata/mcp_http.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/kata/internal/mcpdiscovery"
+
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -90,7 +92,8 @@ func serveMCPHTTP(
 	address string,
 	token string,
 	server *sdkmcp.Server,
-) error {
+	discoveryDirectory, backendURL string,
+) (result error) {
 	listener, err := net.Listen("tcp", strings.TrimSpace(address))
 	if err != nil {
 		return fmt.Errorf("listen for MCP HTTP: %w", err)
@@ -121,6 +124,12 @@ func serveMCPHTTP(
 		}
 		handler = requireMCPHTTPHost(reportedAuthority, handler)
 	}
+
+	cleanup, err := mcpdiscovery.Publish(discoveryDirectory, reportedAuthority, token, backendURL)
+	if err != nil {
+		return err
+	}
+	defer func() { result = errors.Join(result, cleanup()) }()
 
 	serveContext, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/cmd/kata/mcp_runtime_test.go
+++ b/cmd/kata/mcp_runtime_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kitdaemon "go.kenn.io/kit/daemon"
+)
+
+func TestMCPRuntimeDirectorySelectsAttachedDaemon(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	t.Setenv("KATA_SERVER", "http://127.0.0.1:1")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/ping" {
+			_, _ = w.Write([]byte(`{"ok":true,"service":"kata","version":"test"}`))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+	directory := t.TempDir()
+	record := kitdaemon.NewRuntimeRecord("kata", "test", kitdaemon.Endpoint{Network: "tcp", Address: strings.TrimPrefix(server.URL, "http://")})
+	_, err := (kitdaemon.RuntimeStore{Dir: directory}).Write(record)
+	require.NoError(t, err)
+	resolved, err := resolveMCPRuntime(t.Context(), directory)
+	require.NoError(t, err)
+	hc, err := httpClientForResolved(t.Context(), resolved)
+	require.NoError(t, err)
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, resolved.BaseURL+"/selected", nil)
+	require.NoError(t, err)
+	response, err := hc.Do(request)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = response.Body.Close() })
+	assert.Equal(t, http.StatusAccepted, response.StatusCode)
+}

--- a/cmd/kata/mcp_status.go
+++ b/cmd/kata/mcp_status.go
@@ -11,12 +11,10 @@ import (
 )
 
 func newMCPStatusCmd() *cobra.Command {
-	var jsonOutput bool
 	command := &cobra.Command{
-		Use:               "status",
-		Short:             "List running HTTP MCP listeners",
-		Args:              cobra.NoArgs,
-		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
+		Use:   "status",
+		Short: "List running HTTP MCP listeners",
+		Args:  cobra.NoArgs,
 		RunE: func(command *cobra.Command, _ []string) error {
 			home, err := config.KataHome()
 			if err != nil {
@@ -27,7 +25,7 @@ func newMCPStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if jsonOutput {
+			if currentOutputMode() == outputJSON {
 				return json.MarshalWrite(command.OutOrStdout(), endpoints)
 			}
 			if len(endpoints) == 0 {
@@ -42,6 +40,5 @@ func newMCPStatusCmd() *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().BoolVar(&jsonOutput, "json", false, "Print listener discovery as JSON")
 	return command
 }

--- a/cmd/kata/mcp_status.go
+++ b/cmd/kata/mcp_status.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json/v2"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/kata/internal/config"
+	"go.kenn.io/kata/internal/mcpdiscovery"
+)
+
+func newMCPStatusCmd() *cobra.Command {
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:               "status",
+		Short:             "List running HTTP MCP listeners",
+		Args:              cobra.NoArgs,
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
+		RunE: func(command *cobra.Command, _ []string) error {
+			home, err := config.KataHome()
+			if err != nil {
+				return err
+			}
+			directory := filepath.Join(home, "mcp")
+			endpoints, err := mcpdiscovery.List(directory)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return json.MarshalWrite(command.OutOrStdout(), endpoints)
+			}
+			if len(endpoints) == 0 {
+				_, err := fmt.Fprintln(command.OutOrStdout(), "No HTTP MCP listeners are running.")
+				return err
+			}
+			for _, endpoint := range endpoints {
+				if _, err := fmt.Fprintf(command.OutOrStdout(), "MCP %s (pid %d)\n", endpoint.URL, endpoint.PID); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	command.Flags().BoolVar(&jsonOutput, "json", false, "Print listener discovery as JSON")
+	return command
+}

--- a/cmd/kata/mcp_status_test.go
+++ b/cmd/kata/mcp_status_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kata/internal/mcpdiscovery"
+)
+
+func TestMCPStatusJSONReportsPublishedListener(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	cleanup, err := mcpdiscovery.Publish(filepath.Join(home, "mcp"), "127.0.0.1:9876", "", "http://127.0.0.1:4321")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup()) })
+	command := newMCPStatusCmd()
+	command.SetArgs([]string{"--json"})
+	var output bytes.Buffer
+	command.SetOut(&output)
+	require.NoError(t, command.Execute())
+	var rows []mcpdiscovery.Endpoint
+	require.NoError(t, json.Unmarshal(output.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "http://127.0.0.1:9876/mcp", rows[0].URL)
+	assert.Equal(t, "http://127.0.0.1:4321", rows[0].BackendURL)
+}

--- a/cmd/kata/mcp_status_test.go
+++ b/cmd/kata/mcp_status_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json/v2"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,14 +17,27 @@ func TestMCPStatusJSONReportsPublishedListener(t *testing.T) {
 	cleanup, err := mcpdiscovery.Publish(filepath.Join(home, "mcp"), "127.0.0.1:9876", "", "http://127.0.0.1:4321")
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, cleanup()) })
-	command := newMCPStatusCmd()
-	command.SetArgs([]string{"--json"})
-	var output bytes.Buffer
-	command.SetOut(&output)
-	require.NoError(t, command.Execute())
-	var rows []mcpdiscovery.Endpoint
-	require.NoError(t, json.Unmarshal(output.Bytes(), &rows))
-	require.Len(t, rows, 1)
-	assert.Equal(t, "http://127.0.0.1:9876/mcp", rows[0].URL)
-	assert.Equal(t, "http://127.0.0.1:4321", rows[0].BackendURL)
+	for _, args := range [][]string{
+		{"--json", "mcp", "status"},
+		{"mcp", "status", "--json"},
+		{"--format=json", "mcp", "status"},
+		{"mcp", "status", "--format=json"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			output := executeRoot(t, newRootCmd(), args...)
+			var rows []mcpdiscovery.Endpoint
+			require.NoError(t, json.Unmarshal(output, &rows))
+			require.Len(t, rows, 1)
+			assert.Equal(t, "http://127.0.0.1:9876/mcp", rows[0].URL)
+			assert.Equal(t, "http://127.0.0.1:4321", rows[0].BackendURL)
+		})
+	}
+}
+
+func TestMCPStatusRejectsConflictingOutputModes(t *testing.T) {
+	t.Setenv("KATA_HOME", t.TempDir())
+	_, _, err := executeRootCapture(t, t.Context(), "mcp", "status", "--json", "--format=human")
+	var cli *cliError
+	require.ErrorAs(t, err, &cli)
+	assert.Equal(t, ExitUsage, cli.ExitCode)
 }

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -35,16 +35,18 @@ then `anonymous`.
 ### Discover running HTTP listeners
 
 Run `kata mcp status --json` to list HTTP MCP listeners started by this
-version. The command reads local runtime records without starting a server.
+version. `--format=json` selects the same output. The command reads local
+runtime records without starting a server.
 Each entry includes `transport`, `url`, `pid`, `backend_url` when known,
 and `token_path` when the listener requires a bearer token. Read the token
 from that private file; the status output does not print it.
 
 The listener publishes its actual bound port after startup, including when
 started with port zero, and removes its record on orderly shutdown. Status
-omits records whose process has exited. Stdio sessions are not listening
-endpoints and do not appear. An empty JSON list means no HTTP listeners were
-found in this application's configured data directory.
+omits records whose process has exited or whose PID belongs to a different
+process, using the recorded process identity or start time. Stdio sessions are
+not listening endpoints and do not appear. An empty JSON list means no HTTP
+listeners were found in this application's configured data directory.
 
 For Unix-socket daemons, `backend_url` is the actual `unix:///path` address,
 not the synthetic HTTP request URL. An embedding client that has already

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -32,6 +32,26 @@ no status text or logs to stdout. The actor is fixed when the process starts
 and uses the normal precedence: `--as`, `KATA_AUTHOR`, `USER`, Git `user.name`,
 then `anonymous`.
 
+### Discover running HTTP listeners
+
+Run `kata mcp status --json` to list HTTP MCP listeners started by this
+version. The command reads local runtime records without starting a server.
+Each entry includes `transport`, `url`, `pid`, `backend_url` when known,
+and `token_path` when the listener requires a bearer token. Read the token
+from that private file; the status output does not print it.
+
+The listener publishes its actual bound port after startup, including when
+started with port zero, and removes its record on orderly shutdown. Status
+omits records whose process has exited. Stdio sessions are not listening
+endpoints and do not appear. An empty JSON list means no HTTP listeners were
+found in this application's configured data directory.
+
+For Unix-socket daemons, `backend_url` is the actual `unix:///path` address,
+not the synthetic HTTP request URL. An embedding client that has already
+selected a local runtime can use `kata mcp serve --all-projects --runtime-dir
+/path/to/runtime` to reach that daemon over stdio. This option ignores the
+working directory's server selection and never starts a missing daemon.
+
 ## Transport
 
 The default transport is stdio. Use `--http` to run a Streamable HTTP listener

--- a/internal/mcpdiscovery/discovery.go
+++ b/internal/mcpdiscovery/discovery.go
@@ -7,7 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"go.kenn.io/kit/daemon"
+	"go.kenn.io/kata/internal/daemon"
+	kitdaemon "go.kenn.io/kit/daemon"
 	"go.kenn.io/kit/safefileio"
 )
 
@@ -29,8 +30,8 @@ func Publish(directory, address, token, backendURL string) (func() error, error)
 	if err := os.MkdirAll(directory, 0o700); err != nil {
 		return nil, err
 	}
-	store := daemon.RuntimeStore{Dir: directory, Prefix: "mcp"}
-	rec := daemon.NewRuntimeRecord(service, "", daemon.Endpoint{Network: "tcp", Address: address})
+	store := kitdaemon.RuntimeStore{Dir: directory, Prefix: "mcp"}
+	rec := kitdaemon.NewRuntimeRecord(service, "", kitdaemon.Endpoint{Network: "tcp", Address: address})
 	rec.Metadata = map[string]string{"url": "http://" + address + "/mcp", "backend_url": backendURL}
 	tokenPath := ""
 	if token != "" {
@@ -64,7 +65,7 @@ func Publish(directory, address, token, backendURL string) (func() error, error)
 }
 
 // List is observational: it never starts a daemon or prunes another process's
-// records. Dead-process records are omitted, including after an unclean exit.
+// records. Stale process records are omitted, including after PID reuse.
 func List(directory string) ([]Endpoint, error) {
 	endpoints := []Endpoint{}
 	if _, err := os.Stat(directory); errors.Is(err, os.ErrNotExist) {
@@ -75,12 +76,12 @@ func List(directory string) ([]Endpoint, error) {
 	if err := safefileio.ValidatePrivateDir(directory); err != nil {
 		return nil, err
 	}
-	records, err := (daemon.RuntimeStore{Dir: filepath.Clean(directory), Prefix: "mcp"}).List()
+	records, err := (kitdaemon.RuntimeStore{Dir: filepath.Clean(directory), Prefix: "mcp"}).List()
 	if err != nil {
 		return nil, fmt.Errorf("read MCP listener status: %w", err)
 	}
 	for _, rec := range records {
-		if rec.Service != service || !daemon.ProcessAlive(rec.PID) {
+		if rec.Service != service || !daemon.RuntimeProcessAlive(rec) {
 			continue
 		}
 		endpoints = append(endpoints, Endpoint{PID: rec.PID, Transport: "http", URL: rec.Metadata["url"], BackendURL: rec.Metadata["backend_url"], TokenPath: rec.Metadata["token_path"]})

--- a/internal/mcpdiscovery/discovery.go
+++ b/internal/mcpdiscovery/discovery.go
@@ -1,0 +1,89 @@
+// Package mcpdiscovery publishes the local HTTP MCP listener for CLI clients.
+package mcpdiscovery
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.kenn.io/kit/daemon"
+	"go.kenn.io/kit/safefileio"
+)
+
+const service = "kata-mcp"
+
+// Endpoint describes an existing listener. TokenPath locates a private file;
+// status output never includes the bearer token itself.
+type Endpoint struct {
+	PID        int    `json:"pid"`
+	Transport  string `json:"transport"`
+	URL        string `json:"url"`
+	BackendURL string `json:"backend_url,omitempty"`
+	TokenPath  string `json:"token_path,omitempty"`
+}
+
+// Publish runs only after bind succeeds. The caller removes discovery state
+// after the listener closes, including shutdown caused by a serving error.
+func Publish(directory, address, token, backendURL string) (func() error, error) {
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return nil, err
+	}
+	store := daemon.RuntimeStore{Dir: directory, Prefix: "mcp"}
+	rec := daemon.NewRuntimeRecord(service, "", daemon.Endpoint{Network: "tcp", Address: address})
+	rec.Metadata = map[string]string{"url": "http://" + address + "/mcp", "backend_url": backendURL}
+	tokenPath := ""
+	if token != "" {
+		file, err := os.CreateTemp(directory, "mcp-token-*")
+		if err != nil {
+			return nil, err
+		}
+		tokenPath = file.Name()
+		_, writeErr := file.WriteString(token)
+		if err := errors.Join(writeErr, file.Close()); err != nil {
+			_ = os.Remove(tokenPath)
+			return nil, err
+		}
+		rec.Metadata["token_path"] = tokenPath
+	}
+	recordPath, err := store.Write(rec)
+	if err != nil {
+		if tokenPath != "" {
+			_ = os.Remove(tokenPath)
+		}
+		return nil, err
+	}
+	return func() error {
+		recordErr := os.Remove(recordPath)
+		var tokenErr error
+		if tokenPath != "" {
+			tokenErr = os.Remove(tokenPath)
+		}
+		return errors.Join(recordErr, tokenErr)
+	}, nil
+}
+
+// List is observational: it never starts a daemon or prunes another process's
+// records. Dead-process records are omitted, including after an unclean exit.
+func List(directory string) ([]Endpoint, error) {
+	endpoints := []Endpoint{}
+	if _, err := os.Stat(directory); errors.Is(err, os.ErrNotExist) {
+		return endpoints, nil
+	} else if err != nil {
+		return nil, err
+	}
+	if err := safefileio.ValidatePrivateDir(directory); err != nil {
+		return nil, err
+	}
+	records, err := (daemon.RuntimeStore{Dir: filepath.Clean(directory), Prefix: "mcp"}).List()
+	if err != nil {
+		return nil, fmt.Errorf("read MCP listener status: %w", err)
+	}
+	for _, rec := range records {
+		if rec.Service != service || !daemon.ProcessAlive(rec.PID) {
+			continue
+		}
+		endpoints = append(endpoints, Endpoint{PID: rec.PID, Transport: "http", URL: rec.Metadata["url"], BackendURL: rec.Metadata["backend_url"], TokenPath: rec.Metadata["token_path"]})
+	}
+	return endpoints, nil
+}

--- a/internal/mcpdiscovery/discovery_test.go
+++ b/internal/mcpdiscovery/discovery_test.go
@@ -1,0 +1,34 @@
+package mcpdiscovery
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Listener publication, status, and cleanup are the client discovery contract.
+func TestPublishedListenerStatusAndCleanup(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "mcp")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+	cleanup, err := Publish(dir, listener.Addr().String(), "test-listener-token", "http://127.0.0.1:4321")
+	require.NoError(t, err)
+	rows, err := List(dir)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "http://"+listener.Addr().String()+"/mcp", rows[0].URL)
+	assert.Equal(t, "http://127.0.0.1:4321", rows[0].BackendURL)
+	token, err := os.ReadFile(rows[0].TokenPath)
+	require.NoError(t, err)
+	assert.Equal(t, "test-listener-token", string(token))
+	require.NoError(t, cleanup())
+	rows, err = List(dir)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}

--- a/internal/mcpdiscovery/discovery_test.go
+++ b/internal/mcpdiscovery/discovery_test.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	kitdaemon "go.kenn.io/kit/daemon"
 )
 
 // Listener publication, status, and cleanup are the client discovery contract.
@@ -31,4 +33,50 @@ func TestPublishedListenerStatusAndCleanup(t *testing.T) {
 	rows, err = List(dir)
 	require.NoError(t, err)
 	assert.Empty(t, rows)
+}
+
+func TestListOmitsReusedPID(t *testing.T) {
+	for _, identityAvailable := range []bool{true, false} {
+		name := "start time"
+		if identityAvailable {
+			name = "process identity"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "mcp")
+			cleanup, err := Publish(dir, "127.0.0.1:9876", "test-listener-token", "")
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, cleanup()) })
+			rows, err := List(dir)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+
+			store := kitdaemon.RuntimeStore{Dir: dir, Prefix: "mcp"}
+			records, err := store.List()
+			require.NoError(t, err)
+			require.Len(t, records, 1)
+			record := records[0]
+			if identityAvailable {
+				identity, ok := kitdaemon.ReadProcessIdentity(record.PID)
+				require.True(t, ok)
+				encoded := string(identity)
+				replacement := byte('0')
+				if encoded[len(encoded)-1] == replacement {
+					replacement = '1'
+				}
+				record.ProcessIdentityV2 = kitdaemon.ProcessIdentity(encoded[:len(encoded)-1] + string(replacement))
+			} else {
+				record.ProcessIdentity = ""
+				record.ProcessIdentityV2 = ""
+				record.StartedAt = time.Unix(1, 0)
+			}
+			recordPath, err := store.Write(record)
+			require.NoError(t, err)
+
+			rows, err = List(dir)
+			require.NoError(t, err)
+			assert.Empty(t, rows, "a reused PID must not advertise the endpoint or retained token path")
+			assert.FileExists(t, recordPath, "status must remain observational")
+			assert.FileExists(t, record.Metadata["token_path"], "status must not prune retained credentials")
+		})
+	}
 }


### PR DESCRIPTION
`kata mcp status --json` reports running HTTP MCP listeners, including their actual bound ports, backend targets, and private token-file paths. Clients can discover an existing listener instead of guessing its port. Status does not start a daemon or print bearer tokens.

Listeners publish after binding and remove their records on orderly shutdown. Status omits dead processes; stdio sessions do not appear in the list.

For local embedding clients, `mcp serve --runtime-dir` selects an already running daemon from its runtime directory. This preserves the CLI Unix socket behind a separate browser listener and ignores unrelated working-directory or environment server selections. It never starts a missing daemon.
